### PR TITLE
perf: bound SSH startup reconnects and idle git polling

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -942,6 +942,52 @@ describe('SSH IPC handlers', () => {
     }
   })
 
+  // Why: the pull-side probe has to mirror the push-channel hold. A renderer whose ssh:connect
+  // timed out falls back to ssh:getState; the raw transport is already 'connected' there, so
+  // without this hold it would publish connected and clear the deferred SSH pane gate before any
+  // provider exists — the exact premature-connected the push channel guards against.
+  it('ssh:getState holds a live connect at deploying-relay until the relay is ready', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    const conn = {}
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue(conn)
+    mockConnectionManager.getConnection.mockReturnValue(conn)
+    mockConnectionManager.getState.mockReturnValue({
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    let releaseDeploy!: () => void
+    mockDeployAndLaunchRelay.mockReset().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseDeploy = () => resolve(createRelayLaunchResult())
+        })
+    )
+
+    const connectPromise = handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+    await vi.waitFor(() => expect(mockDeployAndLaunchRelay).toHaveBeenCalled())
+
+    const midConnect = handlers.get('ssh:getState')!(null, {
+      targetId: 'ssh-1'
+    }) as SshConnectionState
+    expect(midConnect.status).toBe('deploying-relay')
+
+    releaseDeploy()
+    await connectPromise
+    const afterReady = handlers.get('ssh:getState')!(null, {
+      targetId: 'ssh-1'
+    }) as SshConnectionState
+    expect(afterReady.status).toBe('connected')
+  })
+
   it('rebuilds instead of reusing a ready session while relay loss is pending', async () => {
     vi.useFakeTimers()
     const target: SshTarget = {

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -360,8 +360,34 @@ function connectionSupportsFolderDownload(targetId: string): boolean {
 }
 
 function getPublicSshState(targetId: string): SshConnectionState | undefined {
-  const state = relayStateOverrides.get(targetId) ?? connectionManager!.getState(targetId)
-  return state ? withSshRemotePlatform(targetId, state) : undefined
+  const override = relayStateOverrides.get(targetId)
+  if (override) {
+    return withSshRemotePlatform(targetId, override)
+  }
+  const state = connectionManager!.getState(targetId)
+  if (!state) {
+    return undefined
+  }
+  const sessionState = activeSessions.get(targetId)?.getState()
+  if (
+    state.status === 'connected' &&
+    sessionState !== undefined &&
+    sessionState !== 'ready' &&
+    connectInFlight.has(targetId)
+  ) {
+    // Why: mirrors the push-channel hold in onStateChange. The raw transport reaches 'connected'
+    // before the relay session establishes, so a pull-side probe (ssh:getState, RPC projections)
+    // would otherwise report the host fully up while no provider exists — callers then remount SSH
+    // panes and clear deferred gates too early. Same connectInFlight gate, so a stray raw
+    // 'connected' outside a live connect is never wedged at 'deploying-relay'.
+    return withSshRemotePlatform(targetId, {
+      targetId,
+      status: 'deploying-relay',
+      error: state.error,
+      reconnectAttempt: state.reconnectAttempt
+    })
+  }
+  return withSshRemotePlatform(targetId, state)
 }
 
 function broadcastPortForwards(getMainWindow: () => BrowserWindow | null, targetId: string): void {

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -57,6 +57,8 @@ export function createWorktreePollerWindowVisibility(
 
 export type WorktreeBasePollerOptions = {
   pollIntervalMs?: number
+  gitCommonIdlePollIntervalMs?: number
+  gitCommonBackstopIntervalMs?: number
   platform?: NodeJS.Platform
   visibility?: WorktreePollerWindowVisibility
   /** Test hook: called whenever a full snapshot scan runs (vs. a gated skip). */
@@ -72,6 +74,8 @@ export type WorktreeBasePollerOptions = {
 // calls per tick. 2s is fast enough for external `git worktree add/remove`;
 // Orca's own worktree operations notify the renderer directly.
 export const WORKTREE_BASE_POLL_INTERVAL_MS = 2_000
+export const WORKTREE_GIT_COMMON_IDLE_POLL_INTERVAL_MS = 10_000
+export const WORKTREE_GIT_COMMON_BACKSTOP_INTERVAL_MS = 30_000
 
 // Why: the mtime gate is an optimization, not a correctness boundary — some
 // filesystems have coarse dir timestamps, and pending `.git` markers expire.
@@ -343,13 +347,18 @@ export async function startWorktreeBaseDirectoryPoller(
   const platform = options.platform ?? process.platform
   const visibility = options.visibility ?? alwaysVisible
   if (target.kind === 'git-common') {
+    const intervalScale = pollIntervalMs / WORKTREE_BASE_POLL_INTERVAL_MS
     return startGitCommonWatch(
       target,
       onEvents,
       pollIntervalMs,
       platform,
       visibility,
-      options.onFullScan
+      options.onFullScan,
+      options.gitCommonIdlePollIntervalMs ??
+        WORKTREE_GIT_COMMON_IDLE_POLL_INTERVAL_MS * intervalScale,
+      options.gitCommonBackstopIntervalMs ??
+        WORKTREE_GIT_COMMON_BACKSTOP_INTERVAL_MS * intervalScale
     )
   }
   return startBasePoller(target, getRepos, onEvents, pollIntervalMs, visibility, options.onFullScan)

--- a/src/main/ipc/worktree-git-common-poll-cadence.ts
+++ b/src/main/ipc/worktree-git-common-poll-cadence.ts
@@ -1,0 +1,159 @@
+import type {
+  WorktreeBaseSubscription,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+
+const UNCHANGED_POLLS_BEFORE_IDLE = 3
+
+export type GitCommonPollingCadence = {
+  activeIntervalMs: number
+  idleIntervalMs: number
+  indexBackstopIntervalMs?: number
+}
+
+export type AdaptiveGitCommonPollSubscription = WorktreeBaseSubscription & {
+  resetCadence: () => void
+}
+
+export async function tryTakeGitCommonPollBaseline<T>(
+  takeSnapshot: () => Promise<T>
+): Promise<T | null> {
+  try {
+    return await takeSnapshot()
+  } catch {
+    return null
+  }
+}
+
+export function startAdaptiveGitCommonPoller(args: {
+  cadence: GitCommonPollingCadence
+  visibility: WorktreePollerWindowVisibility
+  poll: (forceFullScan: boolean) => Promise<{ changed: boolean }>
+}): AdaptiveGitCommonPollSubscription {
+  const { cadence, visibility, poll } = args
+  let disposed = false
+  let ticking = false
+  let unchangedPolls = 0
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let pendingForceFullScan = false
+  let forceRetryNeeded = false
+  let activityGeneration = 0
+  let lastActivityAt: number | null = null
+  let indexBackstopAt =
+    cadence.indexBackstopIntervalMs === undefined
+      ? Number.POSITIVE_INFINITY
+      : performance.now() + cadence.indexBackstopIntervalMs
+
+  const clearTimer = (): void => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  const armTimer = (delayMs: number): void => {
+    clearTimer()
+    timer = setTimeout(() => {
+      timer = null
+      void tick()
+    }, delayMs)
+    timer.unref?.()
+  }
+
+  const resetCadence = (): void => {
+    if (disposed) {
+      return
+    }
+    unchangedPolls = 0
+    activityGeneration++
+    lastActivityAt = performance.now()
+    clearTimer()
+    if (!ticking && visibility.isWindowVisible()) {
+      armTimer(cadence.activeIntervalMs)
+    }
+  }
+
+  const tick = async (): Promise<void> => {
+    clearTimer()
+    if (disposed || !visibility.isWindowVisible() || ticking) {
+      return
+    }
+    ticking = true
+    const startedAt = performance.now()
+    const startingActivityGeneration = activityGeneration
+    const requestedForceFullScan = pendingForceFullScan
+    pendingForceFullScan = false
+    const backstopDue = startedAt >= indexBackstopAt
+    const shouldForceFullScan = requestedForceFullScan || forceRetryNeeded || backstopDue
+    let succeeded = false
+    let changed = false
+    try {
+      const result = await poll(shouldForceFullScan)
+      succeeded = true
+      changed = result.changed
+      if (shouldForceFullScan && cadence.indexBackstopIntervalMs !== undefined) {
+        indexBackstopAt = performance.now() + cadence.indexBackstopIntervalMs
+      }
+      forceRetryNeeded = false
+    } catch {
+      forceRetryNeeded ||= shouldForceFullScan
+    } finally {
+      ticking = false
+    }
+    if (disposed) {
+      return
+    }
+
+    const activityDuringPoll = activityGeneration !== startingActivityGeneration
+    if (!activityDuringPoll) {
+      unchangedPolls = !succeeded || changed ? 0 : unchangedPolls + 1
+    }
+    if (pendingForceFullScan) {
+      void tick()
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      return
+    }
+    if (forceRetryNeeded) {
+      armTimer(cadence.activeIntervalMs)
+      return
+    }
+    const now = performance.now()
+    if (activityDuringPoll && lastActivityAt !== null) {
+      armTimer(Math.max(0, cadence.activeIntervalMs - (now - lastActivityAt)))
+      return
+    }
+    const intervalMs =
+      unchangedPolls >= UNCHANGED_POLLS_BEFORE_IDLE
+        ? cadence.idleIntervalMs
+        : cadence.activeIntervalMs
+    const cadenceDelay = Math.max(0, intervalMs - (now - startedAt))
+    const backstopDelay = Math.max(0, indexBackstopAt - now)
+    armTimer(Math.min(cadenceDelay, backstopDelay))
+  }
+
+  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
+    if (disposed) {
+      return
+    }
+    unchangedPolls = 0
+    activityGeneration++
+    lastActivityAt = performance.now()
+    pendingForceFullScan = true
+    clearTimer()
+    if (!ticking) {
+      void tick()
+    }
+  })
+
+  armTimer(cadence.activeIntervalMs)
+  return {
+    resetCadence,
+    unsubscribe: async () => {
+      disposed = true
+      clearTimer()
+      unsubscribeVisibility()
+    }
+  }
+}

--- a/src/main/ipc/worktree-git-common-poll-cadence.ts
+++ b/src/main/ipc/worktree-git-common-poll-cadence.ts
@@ -4,6 +4,13 @@ import type {
 } from './worktree-base-directory-poller'
 
 const UNCHANGED_POLLS_BEFORE_IDLE = 3
+/**
+ * Consecutive forced retries that never resolved before the retry itself backs off to the idle
+ * interval. A tree that stays unreadable (dead NFS/SMB mount, root-owned dir, Windows ACL/AV lock)
+ * would otherwise hold the active cadence for the process lifetime, since a degraded scan can
+ * never refresh the index backstop that keeps forcing it.
+ */
+const UNRESOLVED_FORCED_SCANS_BEFORE_IDLE = 3
 
 export type GitCommonPollingCadence = {
   activeIntervalMs: number
@@ -11,34 +18,77 @@ export type GitCommonPollingCadence = {
   indexBackstopIntervalMs?: number
 }
 
+export type GitCommonPollResult = {
+  changed: boolean
+  /**
+   * A leaf read failed and its previous value was retained, so this tick saw only part of the
+   * tree. The observed half is still authoritative (no fabricated events); the unseen half is not.
+   */
+  degraded?: boolean
+}
+
 export type AdaptiveGitCommonPollSubscription = WorktreeBaseSubscription & {
   resetCadence: () => void
 }
 
 export async function tryTakeGitCommonPollBaseline<T>(
-  takeSnapshot: () => Promise<T>
+  takeSnapshot: () => Promise<T>,
+  label: string
 ): Promise<T | null> {
   try {
     return await takeSnapshot()
-  } catch {
+  } catch (error) {
+    // The first successful poll re-baselines, so this is recoverable — but a non-transient cause
+    // (EACCES, corrupt git dir) would otherwise leave no trace of why startup re-emitted everything.
+    console.warn(`[worktree-base-watcher] git-common poll baseline failed for ${label}:`, error)
     return null
+  }
+}
+
+/**
+ * Degraded scans a poller waits out before accepting a partial view as its baseline. Holding out
+ * for a whole scan keeps a transient failure from seeding holes the next clean tick reports as
+ * creates, but a chronically unreadable leaf (dead mount, TCC-protected path) would otherwise keep
+ * the poller silent for the process lifetime — far worse than the one redundant create a partial
+ * baseline costs when the leaf heals.
+ */
+const DEGRADED_BASELINE_SCANS_BEFORE_ACCEPT = 3
+
+/** Returns true while the caller should keep waiting for a clean scan before baselining. */
+export function createDegradedBaselineGate(): (degraded: boolean) => boolean {
+  let degradedScans = 0
+  return (degraded) => {
+    if (!degraded) {
+      return false
+    }
+    degradedScans++
+    return degradedScans <= DEGRADED_BASELINE_SCANS_BEFORE_ACCEPT
   }
 }
 
 export function startAdaptiveGitCommonPoller(args: {
   cadence: GitCommonPollingCadence
   visibility: WorktreePollerWindowVisibility
-  poll: (forceFullScan: boolean) => Promise<{ changed: boolean }>
+  poll: (forceFullScan: boolean) => Promise<GitCommonPollResult>
 }): AdaptiveGitCommonPollSubscription {
   const { cadence, visibility, poll } = args
   let disposed = false
   let ticking = false
   let unchangedPolls = 0
   let timer: ReturnType<typeof setTimeout> | null = null
+  let nextPollAt = Number.POSITIVE_INFINITY
   let pendingForceFullScan = false
   let forceRetryNeeded = false
-  let activityGeneration = 0
+  let unresolvedForcedScans = 0
   let lastActivityAt: number | null = null
+  // Why: one accelerated wake, refunded only when a poll observes a change or the window is
+  // re-shown — there is no time-based refill. A chatty linked-worktree tree (index locks,
+  // agent/status writers) fires native events many times a second while the polled files never
+  // move; re-arming on every event both pins the active cadence forever and, since each arm
+  // restarts the interval from now, can postpone the poll indefinitely. Activity that actually
+  // predicts a change earns the next wake back.
+  let activityWakeSpent = false
+  let pendingActivityWake = false
   let indexBackstopAt =
     cadence.indexBackstopIntervalMs === undefined
       ? Number.POSITIVE_INFINITY
@@ -49,12 +99,15 @@ export function startAdaptiveGitCommonPoller(args: {
       clearTimeout(timer)
       timer = null
     }
+    nextPollAt = Number.POSITIVE_INFINITY
   }
 
   const armTimer = (delayMs: number): void => {
     clearTimer()
+    nextPollAt = performance.now() + delayMs
     timer = setTimeout(() => {
       timer = null
+      nextPollAt = Number.POSITIVE_INFINITY
       void tick()
     }, delayMs)
     timer.unref?.()
@@ -64,13 +117,20 @@ export function startAdaptiveGitCommonPoller(args: {
     if (disposed) {
       return
     }
-    unchangedPolls = 0
-    activityGeneration++
     lastActivityAt = performance.now()
-    clearTimer()
-    if (!ticking && visibility.isWindowVisible()) {
-      armTimer(cadence.activeIntervalMs)
+    if (activityWakeSpent) {
+      return
     }
+    activityWakeSpent = true
+    if (ticking) {
+      pendingActivityWake = true
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      return
+    }
+    // Only ever pulls the next poll in, never pushes it out.
+    armTimer(Math.min(cadence.activeIntervalMs, Math.max(0, nextPollAt - lastActivityAt)))
   }
 
   const tick = async (): Promise<void> => {
@@ -79,24 +139,30 @@ export function startAdaptiveGitCommonPoller(args: {
       return
     }
     ticking = true
+    pendingActivityWake = false
     const startedAt = performance.now()
-    const startingActivityGeneration = activityGeneration
     const requestedForceFullScan = pendingForceFullScan
     pendingForceFullScan = false
     const backstopDue = startedAt >= indexBackstopAt
     const shouldForceFullScan = requestedForceFullScan || forceRetryNeeded || backstopDue
     let succeeded = false
     let changed = false
+    let degraded = false
     try {
       const result = await poll(shouldForceFullScan)
       succeeded = true
       changed = result.changed
-      if (shouldForceFullScan && cadence.indexBackstopIntervalMs !== undefined) {
+      degraded = result.degraded === true
+      // A degraded scan never read the whole tree, so it cannot satisfy the backstop.
+      if (shouldForceFullScan && !degraded && cadence.indexBackstopIntervalMs !== undefined) {
         indexBackstopAt = performance.now() + cadence.indexBackstopIntervalMs
       }
-      forceRetryNeeded = false
+      forceRetryNeeded = degraded && shouldForceFullScan
     } catch {
-      forceRetryNeeded ||= shouldForceFullScan
+      // A thrown poll read nothing it can vouch for, so force the retry regardless of what this
+      // tick was: a plain retry would re-gate the per-entry `index` read on an unchanged dir
+      // signature and push detection out to the index backstop instead of the active interval.
+      forceRetryNeeded = true
     } finally {
       ticking = false
     }
@@ -104,9 +170,9 @@ export function startAdaptiveGitCommonPoller(args: {
       return
     }
 
-    const activityDuringPoll = activityGeneration !== startingActivityGeneration
-    if (!activityDuringPoll) {
-      unchangedPolls = !succeeded || changed ? 0 : unchangedPolls + 1
+    unchangedPolls = !succeeded || changed ? 0 : unchangedPolls + 1
+    if (changed) {
+      activityWakeSpent = false
     }
     if (pendingForceFullScan) {
       void tick()
@@ -116,21 +182,33 @@ export function startAdaptiveGitCommonPoller(args: {
       return
     }
     if (forceRetryNeeded) {
-      armTimer(cadence.activeIntervalMs)
+      // A tick that still observed changes resolved something, so it does not count toward the
+      // bound: one unreadable leaf must not drag a repo the user is actively moving to the idle
+      // interval.
+      unresolvedForcedScans = changed ? 0 : unresolvedForcedScans + 1
+      // The early return is load-bearing: a degraded scan never advances indexBackstopAt, so the
+      // tail clamp below would compute a 0ms delay and busy-loop. Keep forcing the scan — the
+      // retry is what heals a transient failure — but stop paying the active cadence for a tree
+      // that has stayed unreadable across several of them.
+      armTimer(
+        unresolvedForcedScans >= UNRESOLVED_FORCED_SCANS_BEFORE_IDLE
+          ? cadence.idleIntervalMs
+          : cadence.activeIntervalMs
+      )
       return
     }
+    unresolvedForcedScans = 0
     const now = performance.now()
-    if (activityDuringPoll && lastActivityAt !== null) {
-      armTimer(Math.max(0, cadence.activeIntervalMs - (now - lastActivityAt)))
-      return
-    }
     const intervalMs =
       unchangedPolls >= UNCHANGED_POLLS_BEFORE_IDLE
         ? cadence.idleIntervalMs
         : cadence.activeIntervalMs
-    const cadenceDelay = Math.max(0, intervalMs - (now - startedAt))
-    const backstopDelay = Math.max(0, indexBackstopAt - now)
-    armTimer(Math.min(cadenceDelay, backstopDelay))
+    let delayMs = Math.max(0, intervalMs - (now - startedAt))
+    if (pendingActivityWake && lastActivityAt !== null) {
+      delayMs = Math.min(delayMs, Math.max(0, cadence.activeIntervalMs - (now - lastActivityAt)))
+    }
+    pendingActivityWake = false
+    armTimer(Math.min(delayMs, Math.max(0, indexBackstopAt - now)))
   }
 
   const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
@@ -138,7 +216,7 @@ export function startAdaptiveGitCommonPoller(args: {
       return
     }
     unchangedPolls = 0
-    activityGeneration++
+    activityWakeSpent = false
     lastActivityAt = performance.now()
     pendingForceFullScan = true
     clearTimer()

--- a/src/main/ipc/worktree-git-common-polling-cadence.test.ts
+++ b/src/main/ipc/worktree-git-common-polling-cadence.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WorktreePollerWindowVisibility } from './worktree-base-directory-poller'
+import { startAdaptiveGitCommonPoller } from './worktree-git-common-poll-cadence'
+
+function createVisibilityHarness(): {
+  source: WorktreePollerWindowVisibility
+  hide: () => void
+  show: () => void
+} {
+  let visible = true
+  let listener: (() => void) | null = null
+  return {
+    source: {
+      isWindowVisible: () => visible,
+      onWindowBecameVisible: (nextListener) => {
+        listener = nextListener
+        return () => {
+          if (listener === nextListener) {
+            listener = null
+          }
+        }
+      }
+    },
+    hide: () => {
+      visible = false
+    },
+    show: () => {
+      visible = true
+      listener?.()
+    }
+  }
+}
+
+function controlledPromise<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('adaptive git-common poll cadence', () => {
+  it('backs off after three unchanged polls and returns fast after a change', async () => {
+    vi.useFakeTimers()
+    const changes = [false, false, false, true, false]
+    const poll = vi.fn(async () => ({ changed: changes.shift() ?? false }))
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: { activeIntervalMs: 100, idleIntervalMs: 500 },
+      visibility: createVisibilityHarness().source,
+      poll
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(poll).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(499)
+    expect(poll).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(poll).toHaveBeenCalledTimes(4)
+    await vi.advanceTimersByTimeAsync(99)
+    expect(poll).toHaveBeenCalledTimes(4)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(poll).toHaveBeenCalledTimes(5)
+
+    await subscription.unsubscribe()
+  })
+
+  it('caps an idle delay at the monotonic index backstop deadline', async () => {
+    vi.useFakeTimers()
+    const forced: boolean[] = []
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: {
+        activeIntervalMs: 100,
+        idleIntervalMs: 500,
+        indexBackstopIntervalMs: 700
+      },
+      visibility: createVisibilityHarness().source,
+      poll: async (forceFullScan) => {
+        forced.push(forceFullScan)
+        return { changed: false }
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(699)
+    expect(forced).toEqual([false, false, false])
+    await vi.advanceTimersByTimeAsync(1)
+    expect(forced).toEqual([false, false, false, true])
+
+    await subscription.unsubscribe()
+  })
+
+  it('retries a failed overdue scan at the nonzero active cadence', async () => {
+    vi.useFakeTimers()
+    const forced: boolean[] = []
+    let failFirstForcedScan = true
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: {
+        activeIntervalMs: 100,
+        idleIntervalMs: 500,
+        indexBackstopIntervalMs: 300
+      },
+      visibility: createVisibilityHarness().source,
+      poll: async (forceFullScan) => {
+        forced.push(forceFullScan)
+        if (forceFullScan && failFirstForcedScan) {
+          failFirstForcedScan = false
+          throw new Error('transient stat failure')
+        }
+        return { changed: false }
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(forced).toEqual([false, false, true])
+    await vi.advanceTimersByTimeAsync(99)
+    expect(forced).toEqual([false, false, true])
+    await vi.advanceTimersByTimeAsync(1)
+    expect(forced).toEqual([false, false, true, true])
+
+    await subscription.unsubscribe()
+  })
+
+  it('forces every visibility resume and coalesces one behind an in-flight poll', async () => {
+    vi.useFakeTimers()
+    const visibility = createVisibilityHarness()
+    const first = controlledPromise<{ changed: boolean }>()
+    const forced: boolean[] = []
+    const poll = vi.fn((forceFullScan: boolean) => {
+      forced.push(forceFullScan)
+      return forced.length === 1 ? first.promise : Promise.resolve({ changed: false })
+    })
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: { activeIntervalMs: 100, idleIntervalMs: 500 },
+      visibility: visibility.source,
+      poll
+    })
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(forced).toEqual([false])
+    visibility.show()
+    expect(forced).toEqual([false])
+
+    first.resolve({ changed: false })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(forced).toEqual([false, true])
+
+    await subscription.unsubscribe()
+  })
+
+  it('replaces an outstanding idle timer when native activity resets cadence', async () => {
+    vi.useFakeTimers()
+    const poll = vi.fn(async () => ({ changed: false }))
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: { activeIntervalMs: 100, idleIntervalMs: 500 },
+      visibility: createVisibilityHarness().source,
+      poll
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(poll).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(50)
+    subscription.resetCadence()
+    await vi.advanceTimersByTimeAsync(99)
+    expect(poll).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(poll).toHaveBeenCalledTimes(4)
+
+    await subscription.unsubscribe()
+  })
+})

--- a/src/main/ipc/worktree-git-common-polling-cadence.test.ts
+++ b/src/main/ipc/worktree-git-common-polling-cadence.test.ts
@@ -126,6 +126,37 @@ describe('adaptive git-common poll cadence', () => {
     await subscription.unsubscribe()
   })
 
+  it('forces the retry after a failed regular poll', async () => {
+    vi.useFakeTimers()
+    const forced: boolean[] = []
+    let failSecondPoll = true
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: {
+        activeIntervalMs: 100,
+        idleIntervalMs: 500,
+        indexBackstopIntervalMs: 3000
+      },
+      visibility: createVisibilityHarness().source,
+      poll: async (forceFullScan) => {
+        forced.push(forceFullScan)
+        if (forced.length === 2 && failSecondPoll) {
+          failSecondPoll = false
+          throw new Error('transient stat failure')
+        }
+        return { changed: false }
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+    // The retry runs forced so the dir-signature-gated `index` read cannot be skipped, then the
+    // next tick drops back to a regular poll.
+    expect(forced).toEqual([false, false, true])
+    await vi.advanceTimersByTimeAsync(100)
+    expect(forced).toEqual([false, false, true, false])
+
+    await subscription.unsubscribe()
+  })
+
   it('forces every visibility resume and coalesces one behind an in-flight poll', async () => {
     vi.useFakeTimers()
     const visibility = createVisibilityHarness()
@@ -199,6 +230,198 @@ describe('adaptive git-common poll cadence', () => {
     expect(poll).toHaveBeenCalledTimes(3)
     await vi.advanceTimersByTimeAsync(1)
     expect(poll).toHaveBeenCalledTimes(4)
+
+    await subscription.unsubscribe()
+  })
+
+  it('neither pins the active cadence nor postpones the poll under an event storm', async () => {
+    vi.useFakeTimers()
+    const poll = vi.fn(async () => ({ changed: false }))
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: { activeIntervalMs: 100, idleIntervalMs: 500 },
+      visibility: createVisibilityHarness().source,
+      poll
+    })
+
+    // A chatty worktrees tree: an event every 50ms while nothing the poller reads ever moves.
+    const storm = async (durationMs: number): Promise<void> => {
+      for (let elapsed = 0; elapsed < durationMs; elapsed += 50) {
+        await vi.advanceTimersByTimeAsync(50)
+        subscription.resetCadence()
+      }
+    }
+
+    // Resets land faster than the interval, yet the poll still runs on schedule.
+    await storm(300)
+    expect(poll).toHaveBeenCalledTimes(3)
+
+    await storm(450)
+    // Still idle-paced: the storm bought one accelerated wake, not a permanent 100ms cadence.
+    expect(poll).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(50)
+    expect(poll).toHaveBeenCalledTimes(4)
+
+    await subscription.unsubscribe()
+  })
+
+  it('re-arms the activity accelerator once a poll confirms a real change', async () => {
+    vi.useFakeTimers()
+    const changes = [false, false, false, true]
+    const poll = vi.fn(async () => ({ changed: changes.shift() ?? false }))
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: { activeIntervalMs: 100, idleIntervalMs: 500 },
+      visibility: createVisibilityHarness().source,
+      poll
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(poll).toHaveBeenCalledTimes(3)
+    subscription.resetCadence()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(poll).toHaveBeenCalledTimes(4)
+
+    // Back to idle after three more unchanged polls, with the accelerator restored by the change.
+    await vi.advanceTimersByTimeAsync(300)
+    expect(poll).toHaveBeenCalledTimes(7)
+    subscription.resetCadence()
+    await vi.advanceTimersByTimeAsync(99)
+    expect(poll).toHaveBeenCalledTimes(7)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(poll).toHaveBeenCalledTimes(8)
+
+    await subscription.unsubscribe()
+  })
+
+  // Why: a degraded scan can never advance the backstop, so the forced retry re-latches forever.
+  // Without a bound, a permanently unreadable tree (dead mount, root-owned dir, Windows ACL lock)
+  // holds the 2s active cadence for the process lifetime.
+  it('backs a chronically degraded forced scan off to the idle interval', async () => {
+    vi.useFakeTimers()
+    const forced: boolean[] = []
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: {
+        activeIntervalMs: 100,
+        idleIntervalMs: 500,
+        indexBackstopIntervalMs: 300
+      },
+      visibility: createVisibilityHarness().source,
+      poll: async (forceFullScan) => {
+        forced.push(forceFullScan)
+        return { changed: false, degraded: forceFullScan }
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(forced).toEqual([false, false, true])
+    // Two more retries at the active interval before the bound trips.
+    await vi.advanceTimersByTimeAsync(200)
+    expect(forced).toEqual([false, false, true, true, true])
+    // Still forced — the retry is what heals it — but no longer at the active cadence.
+    await vi.advanceTimersByTimeAsync(499)
+    expect(forced).toHaveLength(5)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(forced).toEqual([false, false, true, true, true, true])
+
+    await subscription.unsubscribe()
+  })
+
+  it('keeps the active cadence while a degraded forced scan still reports changes', async () => {
+    vi.useFakeTimers()
+    const forced: boolean[] = []
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: {
+        activeIntervalMs: 100,
+        idleIntervalMs: 500,
+        indexBackstopIntervalMs: 300
+      },
+      visibility: createVisibilityHarness().source,
+      poll: async (forceFullScan) => {
+        forced.push(forceFullScan)
+        return { changed: forceFullScan, degraded: forceFullScan }
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(forced).toEqual([false, false, true])
+    // One unreadable leaf must not slow a repo the user is visibly moving: the bound only counts
+    // retries that resolved nothing.
+    await vi.advanceTimersByTimeAsync(500)
+    expect(forced).toHaveLength(8)
+
+    await subscription.unsubscribe()
+  })
+
+  // Why: native activity landing mid-poll is the common case on a chatty tree — the poll that is
+  // already running cannot have seen it, so the wake has to survive to the tail.
+  it('coalesces native activity that lands while a poll is in flight', async () => {
+    vi.useFakeTimers()
+    const inFlight = controlledPromise<{ changed: boolean }>()
+    const poll = vi.fn(
+      (): Promise<{ changed: boolean }> =>
+        poll.mock.calls.length === 4 ? inFlight.promise : Promise.resolve({ changed: false })
+    )
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: { activeIntervalMs: 100, idleIntervalMs: 500 },
+      visibility: createVisibilityHarness().source,
+      poll
+    })
+
+    // Three unchanged polls settle the cadence into the 500ms idle interval.
+    await vi.advanceTimersByTimeAsync(300)
+    expect(poll).toHaveBeenCalledTimes(3)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(poll).toHaveBeenCalledTimes(4)
+
+    // Activity arrives 20ms into the fourth poll, which is therefore blind to it.
+    await vi.advanceTimersByTimeAsync(20)
+    subscription.resetCadence()
+    inFlight.resolve({ changed: false })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The next poll is pulled in to activeIntervalMs after the activity, not a full idle interval
+    // after the poll that missed it.
+    await vi.advanceTimersByTimeAsync(99)
+    expect(poll).toHaveBeenCalledTimes(4)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(poll).toHaveBeenCalledTimes(5)
+
+    await subscription.unsubscribe()
+  })
+
+  it('does not let a degraded forced scan satisfy the index backstop', async () => {
+    vi.useFakeTimers()
+    const forced: boolean[] = []
+    let degradeFirstForcedScan = true
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: {
+        activeIntervalMs: 100,
+        idleIntervalMs: 500,
+        indexBackstopIntervalMs: 300
+      },
+      visibility: createVisibilityHarness().source,
+      poll: async (forceFullScan) => {
+        forced.push(forceFullScan)
+        if (forceFullScan && degradeFirstForcedScan) {
+          degradeFirstForcedScan = false
+          return { changed: false, degraded: true }
+        }
+        return { changed: false }
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(forced).toEqual([false, false, true])
+    await vi.advanceTimersByTimeAsync(99)
+    expect(forced).toHaveLength(3)
+    // Retried like a thrown scan: a partial read never observed the gated index.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(forced).toEqual([false, false, true, true])
+
+    await vi.advanceTimersByTimeAsync(299)
+    expect(forced).toHaveLength(4)
+    // The backstop clock restarted at the complete scan, not at the degraded one.
+    await vi.advanceTimersByTimeAsync(1)
+    expect(forced).toEqual([false, false, true, true, true])
 
     await subscription.unsubscribe()
   })

--- a/src/main/ipc/worktree-git-common-polling-cadence.test.ts
+++ b/src/main/ipc/worktree-git-common-polling-cadence.test.ts
@@ -153,6 +153,35 @@ describe('adaptive git-common poll cadence', () => {
     await subscription.unsubscribe()
   })
 
+  it('stops polling while the window is hidden and forces a scan on resume', async () => {
+    vi.useFakeTimers()
+    const visibility = createVisibilityHarness()
+    const forced: boolean[] = []
+    const subscription = startAdaptiveGitCommonPoller({
+      cadence: { activeIntervalMs: 100, idleIntervalMs: 500 },
+      visibility: visibility.source,
+      poll: async (forceFullScan) => {
+        forced.push(forceFullScan)
+        return { changed: false }
+      }
+    })
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(forced).toEqual([false])
+    visibility.hide()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(forced).toEqual([false])
+
+    visibility.show()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(forced).toEqual([false, true])
+    // Resume restarts the active cadence rather than the idle one it parked on.
+    await vi.advanceTimersByTimeAsync(100)
+    expect(forced).toEqual([false, true, false])
+
+    await subscription.unsubscribe()
+  })
+
   it('replaces an outstanding idle timer when native activity resets cadence', async () => {
     vi.useFakeTimers()
     const poll = vi.fn(async () => ({ changed: false }))

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -28,7 +28,7 @@ function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): st
   return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
 }
 
-function isMissingPathError(error: unknown): boolean {
+export function isMissingPathError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException).code
   return code === 'ENOENT' || code === 'ENOTDIR'
 }

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -5,6 +5,11 @@ import type {
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
+import {
+  startAdaptiveGitCommonPoller,
+  tryTakeGitCommonPollBaseline,
+  type GitCommonPollingCadence
+} from './worktree-git-common-poll-cadence'
 
 // Shared with the darwin primary-metadata poll so platforms cannot drift.
 // `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag.
@@ -18,13 +23,14 @@ export const PRIMARY_CHECKOUT_METADATA_FILES = [
 const LINKED_WORKTREE_STRUCTURAL_METADATA_FILES = ['HEAD', 'gitdir', 'locked', 'config.worktree']
 const LINKED_WORKTREE_INDEX_FILE = 'index'
 const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
-// Why: the entry-dir signature gate can miss same-granule index rewrites on
-// coarse-mtime filesystems; a periodic ungated re-stat bounds that miss the
-// same way the base poller's backstop rescan does.
-const INDEX_BACKSTOP_TICKS = 15
 
 function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
   return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code
+  return code === 'ENOENT' || code === 'ENOTDIR'
 }
 
 async function dirSignature(path: string): Promise<string> {
@@ -33,8 +39,11 @@ async function dirSignature(path: string): Promise<string> {
     // allocation change would otherwise slip the readdir gate to the backstop.
     const s = await stat(path)
     return `${statSignature(s)}:${s.size}`
-  } catch {
-    return 'missing'
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return 'missing'
+    }
+    throw error
   }
 }
 
@@ -42,8 +51,11 @@ async function fileSignature(path: string): Promise<string | null> {
   try {
     const s = await stat(path)
     return s.isFile() ? `${statSignature(s)}:${s.size}` : null
-  } catch {
-    return null
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return null
+    }
+    throw error
   }
 }
 
@@ -144,15 +156,11 @@ async function snapshotGitCommon(
       .filter((entry) => entry.isDirectory())
       .map((entry) => join(worktreesDir, entry.name))
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+    if (isMissingPathError(error)) {
       // Dir genuinely absent (no linked worktrees, or all removed) → authoritative empty listing.
       entryPaths = []
     } else {
-      // Why: a TRANSIENT readdir failure (EIO/ESTALE/EMFILE, network/SSH hiccup) must not masquerade as
-      // "every worktree removed" — that would emit false delete events (and false creates next tick).
-      // Reuse the known entries so per-entry stats still run; a real removal surfaces as that entry's own
-      // stat miss (handled in snapshotGitCommonEntry), and the next successful readdir catches any add.
-      entryPaths = previous ? [...previous.entries.keys()] : []
+      throw error
     }
   }
 
@@ -256,45 +264,40 @@ function diffGitCommon(
 export async function startGitCommonPolling(
   commonDirPath: string,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
-  pollIntervalMs: number,
+  cadence: GitCommonPollingCadence,
   visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void,
   includePrimary = true
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
-  let ticking = false
-  let tickCount = 0
-  let snapshot = await snapshotGitCommon(commonDirPath, undefined, includePrimary)
-  let timer: ReturnType<typeof setTimeout> | null = null
-  let parkedWhileHidden = false
-
-  const tick = async (forceFullScan = false): Promise<void> => {
-    timer = null
-    if (disposed) {
-      return
-    }
-    if (!visibility.isWindowVisible()) {
-      parkedWhileHidden = true
-      return
-    }
-    if (ticking) {
-      return
-    }
-    ticking = true
-    // Why: measure from tick start so cadence is start-to-start, not gap-after-completion (which would
-    // land each visible refresh a full scan-duration late every tick).
-    const startedAt = Date.now()
-    tickCount++
-    const shouldForceFullScan = forceFullScan || tickCount % INDEX_BACKSTOP_TICKS === 0
-    try {
+  let snapshot = await tryTakeGitCommonPollBaseline(() =>
+    snapshotGitCommon(commonDirPath, undefined, includePrimary)
+  )
+  const polling = startAdaptiveGitCommonPoller({
+    cadence,
+    visibility,
+    poll: async (forceFullScan) => {
       const next = await snapshotGitCommon(
         commonDirPath,
-        snapshot,
+        snapshot ?? undefined,
         includePrimary,
-        shouldForceFullScan
+        forceFullScan
       )
       if (disposed) {
-        return
+        return { changed: false }
+      }
+      if (!snapshot) {
+        snapshot = next
+        onEvents([
+          { type: 'update', path: join(commonDirPath, 'worktrees') },
+          ...(includePrimary
+            ? PRIMARY_CHECKOUT_METADATA_FILES.map((name) => ({
+                type: 'update' as const,
+                path: join(commonDirPath, name)
+              }))
+            : [])
+        ])
+        return { changed: true }
       }
       if (next.didFullScan) {
         onFullScan?.()
@@ -304,44 +307,14 @@ export async function startGitCommonPolling(
       if (events.length > 0) {
         onEvents(events)
       }
-    } catch {
-      // Transient fs error: keep the previous snapshot and retry next tick.
-    } finally {
-      ticking = false
+      return { changed: events.length > 0 }
     }
-    if (!disposed) {
-      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
-      // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
-      // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
-      const nextDelay = Math.max(
-        0,
-        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
-      )
-      timer = setTimeout(() => void tick(), nextDelay)
-      timer.unref?.()
-    }
-  }
-
-  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
-    if (disposed || !parkedWhileHidden) {
-      return
-    }
-    parkedWhileHidden = false
-    // Why: a linked index can change without its parent dir signature moving;
-    // force the leaf read when diffing the retained pre-hide snapshot.
-    void tick(true)
   })
-
-  timer = setTimeout(() => void tick(), pollIntervalMs)
-  timer.unref?.()
 
   return {
     unsubscribe: async () => {
       disposed = true
-      if (timer) {
-        clearTimeout(timer)
-      }
-      unsubscribeVisibility()
+      await polling.unsubscribe()
     }
   }
 }

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -1,4 +1,3 @@
-import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import type {
   WorktreeBasePollEvent,
@@ -6,181 +5,18 @@ import type {
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 import {
+  createDegradedBaselineGate,
   startAdaptiveGitCommonPoller,
   tryTakeGitCommonPollBaseline,
   type GitCommonPollingCadence
 } from './worktree-git-common-poll-cadence'
-
-// Shared with the darwin primary-metadata poll so platforms cannot drift.
-// `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag.
-export const PRIMARY_CHECKOUT_METADATA_FILES = [
-  'HEAD',
-  'packed-refs',
-  'index',
-  'config.worktree',
-  'logs/HEAD'
-]
-const LINKED_WORKTREE_STRUCTURAL_METADATA_FILES = ['HEAD', 'gitdir', 'locked', 'config.worktree']
-const LINKED_WORKTREE_INDEX_FILE = 'index'
-const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
-
-function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
-  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
-}
-
-export function isMissingPathError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException).code
-  return code === 'ENOENT' || code === 'ENOTDIR'
-}
-
-async function dirSignature(path: string): Promise<string> {
-  try {
-    // Why: keep `size` — on a coarse-timestamp filesystem a same-granule directory
-    // allocation change would otherwise slip the readdir gate to the backstop.
-    const s = await stat(path)
-    return `${statSignature(s)}:${s.size}`
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      return 'missing'
-    }
-    throw error
-  }
-}
-
-async function fileSignature(path: string): Promise<string | null> {
-  try {
-    const s = await stat(path)
-    return s.isFile() ? `${statSignature(s)}:${s.size}` : null
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      return null
-    }
-    throw error
-  }
-}
-
-type GitCommonEntrySnapshot = {
-  dirSignature: string
-  structuralSignatures: Map<string, string>
-  indexSignature: string | null
-  headLogSignature: string | null
-}
-
-type GitCommonSnapshot = {
-  worktreesDirSignature: string
-  entries: Map<string, GitCommonEntrySnapshot>
-  primarySignatures: Map<string, string>
-  didFullScan: boolean
-}
-
-async function snapshotGitCommonEntry(
-  entryPath: string,
-  previous: GitCommonEntrySnapshot | undefined,
-  forceFullScan: boolean
-): Promise<GitCommonEntrySnapshot> {
-  // Why: HEAD, gitdir, locked, config.worktree and logs/HEAD are rewritten in place without bumping
-  // the entry-dir mtime, so — like the pre-idle-gate poller — they are re-stat'd EVERY tick, never
-  // gated behind the dir signature (else a raw HEAD/structural rewrite would slip to the ~30s
-  // backstop). Only `index` rides the entry-dir signature (its same-dir rewrites are index-backstop-bounded).
-  const structuralSignatures = new Map<string, string>()
-  const [nextDirSignature, headLogSignature] = await Promise.all([
-    dirSignature(entryPath),
-    fileSignature(join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE)),
-    Promise.all(
-      LINKED_WORKTREE_STRUCTURAL_METADATA_FILES.map(async (name) => {
-        const signature = await fileSignature(join(entryPath, name))
-        if (signature !== null) {
-          structuralSignatures.set(name, signature)
-        }
-      })
-    )
-  ])
-  if (nextDirSignature === 'missing') {
-    // A transient stat failure must not masquerade as a removal; the parent listing is authoritative.
-    return (
-      previous ?? {
-        dirSignature: nextDirSignature,
-        structuralSignatures,
-        indexSignature: null,
-        headLogSignature
-      }
-    )
-  }
-  const shouldReadIndex = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
-  const indexSignature = shouldReadIndex
-    ? await fileSignature(join(entryPath, LINKED_WORKTREE_INDEX_FILE))
-    : previous.indexSignature
-  return {
-    dirSignature: nextDirSignature,
-    structuralSignatures,
-    indexSignature,
-    headLogSignature
-  }
-}
-
-async function snapshotPrimaryCheckoutSignatures(
-  commonDirPath: string
-): Promise<Map<string, string>> {
-  const signatures = new Map<string, string>()
-  await Promise.all(
-    PRIMARY_CHECKOUT_METADATA_FILES.map(async (name) => {
-      const signature = await fileSignature(join(commonDirPath, name))
-      if (signature !== null) {
-        signatures.set(name, signature)
-      }
-    })
-  )
-  return signatures
-}
-
-async function snapshotGitCommon(
-  commonDirPath: string,
-  previous?: GitCommonSnapshot,
-  includePrimary = true,
-  forceFullScan = false
-): Promise<GitCommonSnapshot> {
-  const worktreesDir = join(commonDirPath, 'worktrees')
-  const [worktreesDirSignature, primarySignatures] = await Promise.all([
-    dirSignature(worktreesDir),
-    includePrimary ? snapshotPrimaryCheckoutSignatures(commonDirPath) : new Map<string, string>()
-  ])
-  // Why: enumerate the worktrees dir EVERY tick rather than gating the readdir on its stat signature.
-  // A single readdir of a small dir is negligible next to the per-entry structural stats that already
-  // run each tick, and the signature gate could miss a same-granule add+remove on a coarse-mtime/FAT
-  // filesystem (its size/mtime/ino/ctime all collide), leaving a linked worktree add/remove undetected
-  // until the ~30s index backstop (#9882 review). The listing is the authoritative add/remove signal.
-  let entryPaths: string[]
-  try {
-    const entries = await readdir(worktreesDir, { withFileTypes: true })
-    entryPaths = entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => join(worktreesDir, entry.name))
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      // Dir genuinely absent (no linked worktrees, or all removed) → authoritative empty listing.
-      entryPaths = []
-    } else {
-      throw error
-    }
-  }
-
-  const entries = new Map<string, GitCommonEntrySnapshot>()
-  await Promise.all(
-    entryPaths.map(async (entryPath) => {
-      const previousEntry = previous?.entries.get(entryPath)
-      entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
-    })
-  )
-  // Why: the expensive per-entry `index` read stays gated on each entry's own dir signature; onFullScan
-  // now reflects an ungated index-metadata backstop fan-out (forceFullScan) — the real periodic cost —
-  // rather than the always-run worktrees-dir readdir.
-  return {
-    worktreesDirSignature,
-    entries,
-    primarySignatures,
-    didFullScan: forceFullScan
-  }
-}
+import {
+  LINKED_WORKTREE_HEAD_LOG_FILE,
+  LINKED_WORKTREE_INDEX_FILE,
+  PRIMARY_CHECKOUT_METADATA_FILES,
+  snapshotGitCommon,
+  type GitCommonSnapshot
+} from './worktree-git-common-snapshot'
 
 function classifySignatureDiff(
   prevSignature: string | null | undefined,
@@ -270,9 +106,15 @@ export async function startGitCommonPolling(
   includePrimary = true
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
-  let snapshot = await tryTakeGitCommonPollBaseline(() =>
-    snapshotGitCommon(commonDirPath, undefined, includePrimary)
+  // Why: with no previous view to retain, a degraded scan *omits* whatever leaf failed rather than
+  // holding it. Committing that as the baseline makes the next clean tick diff the missing entry as
+  // a create, fanning out a redundant worktree re-list; wait out a bounded number of whole scans.
+  const deferDegradedBaseline = createDegradedBaselineGate()
+  const baseline = await tryTakeGitCommonPollBaseline(
+    () => snapshotGitCommon(commonDirPath, undefined, includePrimary),
+    commonDirPath
   )
+  let snapshot = baseline && !deferDegradedBaseline(baseline.degraded) ? baseline : null
   const polling = startAdaptiveGitCommonPoller({
     cadence,
     visibility,
@@ -287,6 +129,11 @@ export async function startGitCommonPolling(
         return { changed: false }
       }
       if (!snapshot) {
+        if (deferDegradedBaseline(next.degraded)) {
+          // Same reasoning as the baseline above: an incomplete recovery scan would seed holes the
+          // next clean tick reports as creates.
+          return { changed: false, degraded: true }
+        }
         snapshot = next
         onEvents([
           { type: 'update', path: join(commonDirPath, 'worktrees') },
@@ -307,7 +154,7 @@ export async function startGitCommonPolling(
       if (events.length > 0) {
         onEvents(events)
       }
-      return { changed: events.length > 0 }
+      return { changed: events.length > 0, degraded: next.degraded }
     }
   })
 

--- a/src/main/ipc/worktree-git-common-snapshot.ts
+++ b/src/main/ipc/worktree-git-common-snapshot.ts
@@ -1,0 +1,267 @@
+import { readdir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+// Shared with the darwin primary-metadata poll so platforms cannot drift.
+// `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag.
+export const PRIMARY_CHECKOUT_METADATA_FILES = [
+  'HEAD',
+  'packed-refs',
+  'index',
+  'config.worktree',
+  'logs/HEAD'
+]
+const LINKED_WORKTREE_STRUCTURAL_METADATA_FILES = ['HEAD', 'gitdir', 'locked', 'config.worktree']
+export const LINKED_WORKTREE_INDEX_FILE = 'index'
+export const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
+
+function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
+  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
+}
+
+export function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+async function dirSignature(path: string): Promise<string> {
+  try {
+    // Why: keep `size` — on a coarse-timestamp filesystem a same-granule directory
+    // allocation change would otherwise slip the readdir gate to the backstop.
+    const s = await stat(path)
+    return `${statSignature(s)}:${s.size}`
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return 'missing'
+    }
+    throw error
+  }
+}
+
+async function fileSignature(path: string): Promise<string | null> {
+  try {
+    const s = await stat(path)
+    return s.isFile() ? `${statSignature(s)}:${s.size}` : null
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+export type GitCommonEntrySnapshot = {
+  dirSignature: string
+  structuralSignatures: Map<string, string>
+  indexSignature: string | null
+  headLogSignature: string | null
+}
+
+export type GitCommonSnapshot = {
+  worktreesDirSignature: string
+  entries: Map<string, GitCommonEntrySnapshot>
+  primarySignatures: Map<string, string>
+  didFullScan: boolean
+  /** A leaf read failed and its previous value was retained, so this scan is not authoritative. */
+  degraded: boolean
+}
+
+// Why: a transient fs error (EIO/ESTALE/EMFILE/EACCES, network/SSH hiccup) must degrade to
+// "nothing observable changed at this leaf" — never to a fabricated create/delete, and never to
+// throwing away the whole tick's per-entry progress. The flag tells the cadence the scan is
+// partial so it cannot satisfy the index backstop.
+type PollDegradation = { degraded: boolean }
+
+async function snapshotGitCommonEntry(
+  entryPath: string,
+  previous: GitCommonEntrySnapshot | undefined,
+  forceFullScan: boolean,
+  degradation: PollDegradation
+): Promise<GitCommonEntrySnapshot | null> {
+  // Why: HEAD, gitdir, locked, config.worktree and logs/HEAD are rewritten in place without bumping
+  // the entry-dir mtime, so — like the pre-idle-gate poller — they are re-stat'd EVERY tick, never
+  // gated behind the dir signature (else a raw HEAD/structural rewrite would slip to the ~30s
+  // backstop). Only `index` rides the entry-dir signature (its same-dir rewrites are index-backstop-bounded).
+  const structuralSignatures = new Map<string, string>()
+  try {
+    const [nextDirSignature, headLogSignature] = await Promise.all([
+      dirSignature(entryPath),
+      fileSignature(join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE)),
+      Promise.all(
+        LINKED_WORKTREE_STRUCTURAL_METADATA_FILES.map(async (name) => {
+          const signature = await fileSignature(join(entryPath, name))
+          if (signature !== null) {
+            structuralSignatures.set(name, signature)
+          }
+        })
+      )
+    ])
+    if (nextDirSignature === 'missing') {
+      // A transient stat failure must not masquerade as a removal; the parent listing is
+      // authoritative. The entry's `index` went unread either way, so this scan is not a full one —
+      // otherwise a forced scan taking this path would refresh the index backstop on a partial read.
+      degradation.degraded = true
+      return (
+        previous ?? {
+          dirSignature: nextDirSignature,
+          structuralSignatures,
+          indexSignature: null,
+          headLogSignature
+        }
+      )
+    }
+    const shouldReadIndex = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
+    const indexSignature = shouldReadIndex
+      ? await fileSignature(join(entryPath, LINKED_WORKTREE_INDEX_FILE))
+      : previous.indexSignature
+    return {
+      dirSignature: nextDirSignature,
+      structuralSignatures,
+      indexSignature,
+      headLogSignature
+    }
+  } catch {
+    degradation.degraded = true
+    // No previous view to retain: omit the entry rather than half-report it. It is absent from the
+    // previous snapshot too, so the diff stays silent and the next successful tick emits its create.
+    return previous ?? null
+  }
+}
+
+async function snapshotPrimaryCheckoutSignatures(
+  commonDirPath: string,
+  previous: Map<string, string> | undefined,
+  degradation: PollDegradation
+): Promise<Map<string, string>> {
+  const signatures = new Map<string, string>()
+  await Promise.all(
+    PRIMARY_CHECKOUT_METADATA_FILES.map(async (name) => {
+      let signature: string | null
+      try {
+        signature = await fileSignature(join(commonDirPath, name))
+      } catch {
+        degradation.degraded = true
+        signature = previous?.get(name) ?? null
+      }
+      if (signature !== null) {
+        signatures.set(name, signature)
+      }
+    })
+  )
+  return signatures
+}
+
+export type PrimaryCheckoutMetadataSnapshot = {
+  mtimes: Map<string, number>
+  /** A stat failed for a non-missing reason, so this scan saw only part of the file set. */
+  degraded: boolean
+}
+
+// Why: the mtime-only twin of snapshotPrimaryCheckoutSignatures, for the darwin narrow watch — the
+// same files, but the linked worktrees they exclude are covered by FSEvents rather than by polling.
+export async function snapshotPrimaryCheckoutMetadata(
+  commonDirPath: string,
+  previous?: Map<string, number>
+): Promise<PrimaryCheckoutMetadataSnapshot> {
+  const mtimes = new Map<string, number>()
+  let degraded = false
+  for (const name of PRIMARY_CHECKOUT_METADATA_FILES) {
+    const filePath = join(commonDirPath, name)
+    try {
+      mtimes.set(filePath, (await stat(filePath)).mtimeMs)
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        continue
+      }
+      // Why: a transient failure (EIO/EMFILE, dead mount) must degrade to "nothing observable
+      // changed here", never to a fabricated delete, and must not cost the tick the files it did
+      // read. Throwing instead reset the cadence's unchanged run, pinning a flaky mount at the
+      // active interval.
+      degraded = true
+      const previousMtime = previous?.get(filePath)
+      if (previousMtime !== undefined) {
+        mtimes.set(filePath, previousMtime)
+      }
+    }
+  }
+  return { mtimes, degraded }
+}
+
+export async function snapshotGitCommon(
+  commonDirPath: string,
+  previous?: GitCommonSnapshot,
+  includePrimary = true,
+  forceFullScan = false
+): Promise<GitCommonSnapshot> {
+  const worktreesDir = join(commonDirPath, 'worktrees')
+  const degradation: PollDegradation = { degraded: false }
+  const [worktreesDirSignature, primarySignatures] = await Promise.all([
+    (async () => {
+      try {
+        return await dirSignature(worktreesDir)
+      } catch (error) {
+        if (!previous) {
+          throw error
+        }
+        degradation.degraded = true
+        return previous.worktreesDirSignature
+      }
+    })(),
+    includePrimary
+      ? snapshotPrimaryCheckoutSignatures(commonDirPath, previous?.primarySignatures, degradation)
+      : new Map<string, string>()
+  ])
+  // Why: enumerate the worktrees dir EVERY tick rather than gating the readdir on its stat signature.
+  // A single readdir of a small dir is negligible next to the per-entry structural stats that already
+  // run each tick, and the signature gate could miss a same-granule add+remove on a coarse-mtime/FAT
+  // filesystem (its size/mtime/ino/ctime all collide), leaving a linked worktree add/remove undetected
+  // until the ~30s index backstop (#9882 review). The listing is the authoritative add/remove signal.
+  let entryPaths: string[]
+  try {
+    const entries = await readdir(worktreesDir, { withFileTypes: true })
+    entryPaths = entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(worktreesDir, entry.name))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      // Dir genuinely absent (no linked worktrees, or all removed) → authoritative empty listing.
+      // ENOTDIR is deliberately excluded: here it means the path exists as a FILE (a stray temp
+      // file from a git operation), not that the worktrees are gone. Treating it as an empty
+      // listing would diff every linked worktree as a delete.
+      entryPaths = []
+    } else if (previous) {
+      // Why: a TRANSIENT readdir failure must neither masquerade as "every worktree removed" nor cost
+      // the tick its per-entry freshness. Re-stat the known entries; a real removal surfaces on the
+      // next successful listing, and an add is invisible only until then.
+      degradation.degraded = true
+      entryPaths = [...previous.entries.keys()]
+    } else {
+      throw error
+    }
+  }
+
+  const entries = new Map<string, GitCommonEntrySnapshot>()
+  await Promise.all(
+    entryPaths.map(async (entryPath) => {
+      const previousEntry = previous?.entries.get(entryPath)
+      const entry = await snapshotGitCommonEntry(
+        entryPath,
+        previousEntry,
+        forceFullScan,
+        degradation
+      )
+      if (entry) {
+        entries.set(entryPath, entry)
+      }
+    })
+  )
+  // Why: the expensive per-entry `index` read stays gated on each entry's own dir signature; onFullScan
+  // now reflects an ungated index-metadata backstop fan-out (forceFullScan) — the real periodic cost —
+  // rather than the always-run worktrees-dir readdir.
+  return {
+    worktreesDirSignature,
+    entries,
+    primarySignatures,
+    didFullScan: forceFullScan && !degradation.degraded,
+    degraded: degradation.degraded
+  }
+}

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -44,6 +44,9 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 })
 
 const POLL_MS = 25
+// Mirrors the production ratio in worktree-base-directory-poller.
+const IDLE_POLL_MS = POLL_MS * 5
+const BACKSTOP_MS = POLL_MS * 15
 
 const alwaysVisible: WorktreePollerWindowVisibility = {
   isWindowVisible: () => true,
@@ -135,7 +138,10 @@ describe('worktree git-common narrow watch (darwin)', () => {
       (events) => received.push(events),
       POLL_MS,
       'darwin',
-      alwaysVisible
+      alwaysVisible,
+      undefined,
+      IDLE_POLL_MS,
+      BACKSTOP_MS
     )
     cleanups.push(() => watch.unsubscribe())
   }
@@ -286,7 +292,10 @@ describe('worktree git-common narrow watch (darwin)', () => {
       (events) => received.push(events),
       POLL_MS,
       'darwin',
-      visibility.source
+      visibility.source,
+      undefined,
+      IDLE_POLL_MS,
+      BACKSTOP_MS
     )
     cleanups.push(() => watch.unsubscribe())
     visibility.hide()
@@ -350,7 +359,10 @@ describe('worktree git-common narrow watch (darwin)', () => {
       (events) => received.push(events),
       POLL_MS,
       'darwin',
-      visibility.source
+      visibility.source,
+      undefined,
+      IDLE_POLL_MS,
+      BACKSTOP_MS
     )
     cleanups.push(() => watch.unsubscribe())
 
@@ -370,7 +382,10 @@ describe('worktree git-common narrow watch (darwin)', () => {
       () => {},
       POLL_MS,
       'darwin',
-      visibility.source
+      visibility.source,
+      undefined,
+      IDLE_POLL_MS,
+      BACKSTOP_MS
     )
 
     // Narrow watch + primary-metadata poll each park on window visibility.
@@ -393,7 +408,9 @@ describe('worktree git-common narrow watch (darwin)', () => {
       POLL_MS,
       'darwin',
       visibility.source,
-      () => fullScans.push(Date.now())
+      () => fullScans.push(Date.now()),
+      IDLE_POLL_MS,
+      BACKSTOP_MS
     )
     cleanups.push(() => watch.unsubscribe())
 
@@ -424,7 +441,10 @@ describe('worktree git-common narrow watch (darwin)', () => {
       (events) => received.push(events),
       POLL_MS,
       'darwin',
-      alwaysVisible
+      alwaysVisible,
+      undefined,
+      IDLE_POLL_MS,
+      BACKSTOP_MS
     )
     await watch.unsubscribe()
     expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledTimes(1)
@@ -474,7 +494,9 @@ describe('worktree git-common polling gate (non-darwin)', () => {
       POLL_MS,
       'linux',
       visibility,
-      onFullScan
+      onFullScan,
+      IDLE_POLL_MS,
+      BACKSTOP_MS
     )
     cleanups.push(() => watch.unsubscribe())
   }

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { appendFile, mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdtemp, mkdir, readdir, realpath, rm, writeFile } from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import { chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -21,9 +21,10 @@ vi.mock('./parcel-watcher-process', () => ({
 }))
 
 // Records every stat target so a test can assert which paths a parked poll stopped touching.
-const { statCalls, transientStatFailures } = vi.hoisted(() => ({
+const { statCalls, transientStatFailures, readdirFailureCodes } = vi.hoisted(() => ({
   statCalls: [] as string[],
-  transientStatFailures: new Map<string, number>()
+  transientStatFailures: new Map<string, number>(),
+  readdirFailureCodes: new Map<string, string>()
 }))
 
 vi.mock('node:fs/promises', async (importOriginal) => {
@@ -39,6 +40,17 @@ vi.mock('node:fs/promises', async (importOriginal) => {
         throw Object.assign(new Error('transient stat failure'), { code: 'EIO' })
       }
       return actual.stat(...args)
+    },
+    // Injected rather than staged on the real fs: swapping the dir for a file is two syscalls, so an
+    // in-flight tick could observe the ENOENT window and legitimately emit the delete under test.
+    readdir: async (path: string, options?: { withFileTypes?: boolean }) => {
+      const failureCode = readdirFailureCodes.get(String(path))
+      if (failureCode) {
+        throw Object.assign(new Error(`injected ${failureCode}`), { code: failureCode })
+      }
+      return options?.withFileTypes === true
+        ? actual.readdir(path, { withFileTypes: true })
+        : actual.readdir(path)
     }
   }
 })
@@ -174,6 +186,92 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'update', path: headPath })
     })
+  })
+
+  it('keeps reporting other primary files while one keeps failing to stat', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const headPath = join(commonDir, 'HEAD')
+    const packedRefsPath = join(commonDir, 'packed-refs')
+    await writeFile(headPath, 'ref: refs/heads/main\n')
+    await writeFile(packedRefsPath, '')
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    transientStatFailures.set(headPath, 1_000)
+    // Only append once the failure is provably in effect, so the tick that sees it also lost HEAD.
+    await vi.waitFor(() => expect(transientStatFailures.get(headPath)).toBeLessThan(1_000))
+    await appendFile(packedRefsPath, 'deadbeef refs/heads/feature\n')
+
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: packedRefsPath })
+    })
+
+    transientStatFailures.delete(headPath)
+    await appendFile(packedRefsPath, 'deadbeef refs/heads/other\n')
+    await vi.waitFor(() => {
+      expect(
+        received.flat().filter((event) => event.path === packedRefsPath).length
+      ).toBeGreaterThan(1)
+    })
+    // The unreadable file is held at its last known mtime: never a fabricated delete, and recovery
+    // is silent because the retained value still matches.
+    expect(received.flat().filter((event) => event.path === headPath)).toEqual([])
+  })
+
+  it('accepts a partial baseline when one primary file is unreadable from the start', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const headPath = join(commonDir, 'HEAD')
+    const headLogPath = join(commonDir, 'logs', 'HEAD')
+    await writeFile(headPath, 'ref: refs/heads/main\n')
+    await mkdir(join(commonDir, 'logs'))
+    await writeFile(headLogPath, '')
+    // Unreadable before the watch even starts, so no clean scan is ever available to baseline from.
+    transientStatFailures.set(headLogPath, 1_000)
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: headPath })
+    })
+    const updatesBeforeWrite = received.flat().filter((event) => event.path === headPath).length
+    await appendFile(headPath, 'ref: refs/heads/other\n')
+
+    // The readable files stay watched for the whole outage instead of going silent behind a
+    // baseline that can never be taken.
+    await vi.waitFor(() => {
+      expect(received.flat().filter((event) => event.path === headPath).length).toBeGreaterThan(
+        updatesBeforeWrite
+      )
+    })
+  })
+
+  it('settles to the idle cadence while a primary file stays unreadable', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const headPath = join(commonDir, 'HEAD')
+    await writeFile(headPath, 'ref: refs/heads/main\n')
+    const activeMs = 20
+    const idleMs = 500
+    const polledAt: number[] = []
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      () => {},
+      activeMs,
+      'darwin',
+      alwaysVisible,
+      () => polledAt.push(performance.now()),
+      idleMs,
+      idleMs * 3
+    )
+    cleanups.push(() => watch.unsubscribe())
+    transientStatFailures.set(headPath, 1_000)
+
+    // A degraded tick observed nothing new, so it must count toward the unchanged run rather than
+    // resetting it — a flaky mount would otherwise hold the active interval forever.
+    await vi.waitFor(() => expect(polledAt.length).toBeGreaterThanOrEqual(5), { timeout: 5_000 })
+    expect(polledAt.at(-1)! - polledAt.at(-2)!).toBeGreaterThan(idleMs / 2)
   })
 
   it('resets the idle primary poll when the native stream reports activity', async () => {
@@ -461,6 +559,7 @@ describe('worktree git-common polling gate (non-darwin)', () => {
   const cleanups: (() => Promise<void>)[] = []
 
   afterEach(async () => {
+    readdirFailureCodes.clear()
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
     transientStatFailures.clear()
   })
@@ -588,6 +687,82 @@ describe('worktree git-common polling gate (non-darwin)', () => {
       expect(received.flat()).not.toContainEqual({ type: 'delete', path: entry })
     }
   )
+
+  it('does not fabricate worktree deletions when the listing fails ENOTDIR', async () => {
+    // Why: only ENOENT is an authoritative empty listing. ENOTDIR means the path exists as a FILE —
+    // a stray temp file from a git operation — so the linked worktrees are still there.
+    const commonDir = await makePollingCommonDir()
+    const entry = join(commonDir, 'worktrees', 'keep')
+    await mkdir(entry)
+    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
+    const received: WorktreeBasePollEvent[][] = []
+    await startPollingWatch(commonDir, received)
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    readdirFailureCodes.set(join(commonDir, 'worktrees'), 'ENOTDIR')
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
+
+    expect(received.flat()).not.toContainEqual({ type: 'delete', path: entry })
+  })
+
+  // Why runIf: same chmod-based EACCES injection constraint as the test above.
+  it.runIf(process.platform !== 'win32' && process.getuid?.() !== 0)(
+    "keeps re-stat'ing known entries while the readdir keeps failing",
+    async () => {
+      // Why: a failing listing must cost the tick only what it could not observe. Mode 0o111 revokes
+      // read (readdir → EACCES) while keeping traverse, so the known entry's leaves are still
+      // readable — an in-place HEAD rewrite must still surface instead of waiting out the outage.
+      const commonDir = await makePollingCommonDir()
+      const entry = join(commonDir, 'worktrees', 'live')
+      await mkdir(entry)
+      const headPath = join(entry, 'HEAD')
+      await writeFile(headPath, 'ref: refs/heads/main')
+      const received: WorktreeBasePollEvent[][] = []
+      await startPollingWatch(commonDir, received)
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+      const worktreesDir = join(commonDir, 'worktrees')
+      chmodSync(worktreesDir, 0o111)
+      try {
+        // Guard against a vacuous pass: the listing must really be denied on this filesystem.
+        await expect(readdir(worktreesDir)).rejects.toThrow()
+        await writeFile(headPath, 'ref: refs/heads/feature-branch')
+        await vi.waitFor(() => {
+          expect(received.flat()).toContainEqual({ type: 'update', path: headPath })
+        })
+      } finally {
+        chmodSync(worktreesDir, 0o755)
+      }
+      expect(received.flat()).not.toContainEqual({ type: 'delete', path: entry })
+    }
+  )
+
+  it('reports the other entries when one entry keeps failing to stat', async () => {
+    // Why: a per-leaf fs error must not throw away the whole tick. The stuck entry keeps its previous
+    // view (no fabricated delete) while its sibling's change is still reported on the same tick.
+    const commonDir = await makePollingCommonDir()
+    const stuck = join(commonDir, 'worktrees', 'stuck')
+    const healthy = join(commonDir, 'worktrees', 'healthy')
+    await mkdir(stuck)
+    await mkdir(healthy)
+    await writeFile(join(stuck, 'HEAD'), 'ref: refs/heads/main')
+    const healthyHead = join(healthy, 'HEAD')
+    await writeFile(healthyHead, 'ref: refs/heads/main')
+    const received: WorktreeBasePollEvent[][] = []
+    await startPollingWatch(commonDir, received)
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    transientStatFailures.set(join(stuck, 'HEAD'), 1_000)
+    await writeFile(healthyHead, 'ref: refs/heads/feature-branch')
+
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: healthyHead })
+    })
+    expect(received.flat()).not.toContainEqual({ type: 'delete', path: stuck })
+    expect(received.flat().filter((event) => event.path.startsWith(stuck))).toEqual([])
+    // Guard against a vacuous pass: the injected leaf failure really fired.
+    expect(transientStatFailures.get(join(stuck, 'HEAD'))).toBeLessThan(1_000)
+  })
 
   it('detects an in-place structural (HEAD) write on a known entry every tick, without the index backstop', async () => {
     // Why: a raw HEAD/gitdir/config.worktree rewrite does not bump the entry-dir mtime, so the

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -21,14 +21,23 @@ vi.mock('./parcel-watcher-process', () => ({
 }))
 
 // Records every stat target so a test can assert which paths a parked poll stopped touching.
-const { statCalls } = vi.hoisted(() => ({ statCalls: [] as string[] }))
+const { statCalls, transientStatFailures } = vi.hoisted(() => ({
+  statCalls: [] as string[],
+  transientStatFailures: new Map<string, number>()
+}))
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof NodeFsPromises>()
   return {
     ...actual,
-    stat: (...args: Parameters<typeof actual.stat>) => {
-      statCalls.push(String(args[0]))
+    stat: async (...args: Parameters<typeof actual.stat>) => {
+      const path = String(args[0])
+      statCalls.push(path)
+      const remainingFailures = transientStatFailures.get(path) ?? 0
+      if (remainingFailures > 0) {
+        transientStatFailures.set(path, remainingFailures - 1)
+        throw Object.assign(new Error('transient stat failure'), { code: 'EIO' })
+      }
       return actual.stat(...args)
     }
   }
@@ -89,6 +98,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
     childSubscriptions = []
     statCalls.length = 0
+    transientStatFailures.clear()
     subscribeMock.mockReset()
   })
 
@@ -144,6 +154,46 @@ describe('worktree git-common narrow watch (darwin)', () => {
     const entryPath = join(commonDir, 'worktrees', 'wt-a')
     childSubscriptions[0].callback(null, [{ type: 'create', path: entryPath }])
     expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
+  })
+
+  it('installs the narrow stream and retries a transient primary baseline failure', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const headPath = join(commonDir, 'HEAD')
+    transientStatFailures.set(headPath, 1)
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: headPath })
+    })
+  })
+
+  it('resets the idle primary poll when the native stream reports activity', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const fullScans: number[] = []
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      () => {},
+      POLL_MS,
+      'darwin',
+      alwaysVisible,
+      () => fullScans.push(performance.now()),
+      1_000,
+      3_000
+    )
+    cleanups.push(() => watch.unsubscribe())
+
+    await vi.waitFor(() => expect(fullScans.length).toBeGreaterThanOrEqual(3))
+    const scansBeforeNativeEvent = fullScans.length
+    childSubscriptions[0].callback(null, [
+      { type: 'update', path: join(commonDir, 'worktrees', 'native-change', 'HEAD') }
+    ])
+    await vi.waitFor(() => expect(fullScans.length).toBeGreaterThan(scansBeforeNativeEvent), {
+      timeout: 250
+    })
   })
 
   it('tears down and re-arms when the watched root is deleted', async () => {
@@ -392,6 +442,7 @@ describe('worktree git-common polling gate (non-darwin)', () => {
 
   afterEach(async () => {
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+    transientStatFailures.clear()
   })
 
   async function makePollingCommonDir(): Promise<string> {
@@ -445,6 +496,19 @@ describe('worktree git-common polling gate (non-darwin)', () => {
 
     expect(fullScans).not.toHaveBeenCalled()
     expect(received.flat()).toHaveLength(0)
+  })
+
+  it('installs the poller and resyncs after a transient initial baseline failure', async () => {
+    const commonDir = await makePollingCommonDir()
+    const worktreesDir = join(commonDir, 'worktrees')
+    transientStatFailures.set(worktreesDir, 1)
+    const received: WorktreeBasePollEvent[][] = []
+
+    await startPollingWatch(commonDir, received)
+
+    await vi.waitFor(() => {
+      expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
+    })
   })
 
   it('detects linked worktree add and remove from the every-tick readdir', async () => {

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -8,6 +8,12 @@ import type {
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 import {
+  startAdaptiveGitCommonPoller,
+  tryTakeGitCommonPollBaseline,
+  type AdaptiveGitCommonPollSubscription,
+  type GitCommonPollingCadence
+} from './worktree-git-common-poll-cadence'
+import {
   PRIMARY_CHECKOUT_METADATA_FILES,
   startGitCommonPolling
 } from './worktree-git-common-polling'
@@ -30,6 +36,11 @@ import {
 // Why: branch switches and commits made in the primary checkout rewrite these
 // top-level files (linked-worktree equivalents live under `worktrees/`).
 // Deliberately excludes FETCH_HEAD-style churn that carries no status change.
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
 async function snapshotPrimaryCheckoutMetadata(
   commonDirPath: string
 ): Promise<Map<string, number>> {
@@ -38,8 +49,10 @@ async function snapshotPrimaryCheckoutMetadata(
     const filePath = join(commonDirPath, name)
     try {
       mtimes.set(filePath, (await stat(filePath)).mtimeMs)
-    } catch {
-      // Missing file (e.g. no packed-refs yet) diffs into a create later.
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error
+      }
     }
   }
   return mtimes
@@ -69,79 +82,41 @@ function diffMtimeMap(
 async function startSnapshotDiffPoller(
   takeSnapshot: () => Promise<Map<string, number>>,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
-  pollIntervalMs: number,
+  cadence: GitCommonPollingCadence,
   visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void
-): Promise<WorktreeBaseSubscription> {
+  onFullScan: (() => void) | undefined,
+  onBaselineRecovered: () => void
+): Promise<AdaptiveGitCommonPollSubscription> {
   let disposed = false
-  let ticking = false
-  let snapshot = await takeSnapshot()
-  let timer: ReturnType<typeof setTimeout> | null = null
-  let parkedWhileHidden = false
-
-  const tick = async (): Promise<void> => {
-    timer = null
-    if (disposed) {
-      return
-    }
-    if (!visibility.isWindowVisible()) {
-      parkedWhileHidden = true
-      return
-    }
-    if (ticking) {
-      return
-    }
-    ticking = true
-    // Why: measure from tick start so cadence is start-to-start, not gap-after-completion (which would
-    // land each visible refresh a full scan-duration late every tick).
-    const startedAt = Date.now()
-    onFullScan?.()
-    try {
+  let snapshot = await tryTakeGitCommonPollBaseline(takeSnapshot)
+  const polling = startAdaptiveGitCommonPoller({
+    cadence: { activeIntervalMs: cadence.activeIntervalMs, idleIntervalMs: cadence.idleIntervalMs },
+    visibility,
+    poll: async () => {
+      onFullScan?.()
       const next = await takeSnapshot()
       if (disposed) {
-        return
+        return { changed: false }
+      }
+      if (!snapshot) {
+        snapshot = next
+        onBaselineRecovered()
+        return { changed: true }
       }
       const events = diffMtimeMap(snapshot, next)
       snapshot = next
       if (events.length > 0) {
         onEvents(events)
       }
-    } catch {
-      // Transient fs error: keep the previous snapshot and retry next tick.
-    } finally {
-      ticking = false
+      return { changed: events.length > 0 }
     }
-    if (!disposed) {
-      // Why: clamp to [0, pollIntervalMs]. Date.now() is not monotonic — a backward wall-clock jump (NTP) would
-      // otherwise make elapsed negative and push the next tick out by the adjustment (suppressing refreshes for
-      // minutes); the upper clamp caps the wait at one interval, the lower clamp keeps a long scan from going negative.
-      const nextDelay = Math.max(
-        0,
-        Math.min(pollIntervalMs, pollIntervalMs - (Date.now() - startedAt))
-      )
-      timer = setTimeout(() => void tick(), nextDelay)
-      timer.unref?.()
-    }
-  }
-
-  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
-    if (disposed || !parkedWhileHidden) {
-      return
-    }
-    parkedWhileHidden = false
-    void tick()
   })
 
-  timer = setTimeout(() => void tick(), pollIntervalMs)
-  timer.unref?.()
-
   return {
+    resetCadence: polling.resetCadence,
     unsubscribe: async () => {
       disposed = true
-      if (timer) {
-        clearTimeout(timer)
-      }
-      unsubscribeVisibility()
+      await polling.unsubscribe()
     }
   }
 }
@@ -150,7 +125,8 @@ async function startGitCommonNarrowWatch(
   target: WorktreeBaseWatchTarget,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
-  visibility: WorktreePollerWindowVisibility
+  visibility: WorktreePollerWindowVisibility,
+  onActivity: () => void
 ): Promise<WorktreeBaseSubscription> {
   const worktreesDir = join(target.path, 'worktrees')
   let disposed = false
@@ -175,6 +151,7 @@ async function startGitCommonNarrowWatch(
       const installed = await trySubscribe()
       if (installed && !disposed) {
         stopExistencePoll()
+        onActivity()
         // The dir appearing means a first linked worktree was just
         // registered; surface it so the repo's worktree list refreshes.
         onEvents([{ type: 'create', path: worktreesDir }])
@@ -254,11 +231,13 @@ async function startGitCommonNarrowWatch(
             return
           }
           if (error) {
+            onActivity()
             onEvents([{ type: 'update', path: worktreesDir }])
             teardownAndRearm()
             return
           }
           if (events.length > 0) {
+            onActivity()
             const rootGone = events.some(
               (event) => event.type === 'delete' && event.path === worktreesDir
             )
@@ -274,6 +253,7 @@ async function startGitCommonNarrowWatch(
           // resubscribe gap; report a structural change so worktrees re-sync.
           onInterruption: () => {
             if (!disposed && active) {
+              onActivity()
               onEvents([{ type: 'update', path: worktreesDir }])
             }
           }
@@ -316,24 +296,42 @@ export async function startGitCommonWatch(
   pollIntervalMs: number,
   platform: NodeJS.Platform,
   visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void
+  onFullScan?: () => void,
+  idlePollIntervalMs = pollIntervalMs * 5,
+  indexBackstopIntervalMs = pollIntervalMs * 15
 ): Promise<WorktreeBaseSubscription> {
+  const cadence: GitCommonPollingCadence = {
+    activeIntervalMs: pollIntervalMs,
+    idleIntervalMs: idlePollIntervalMs,
+    indexBackstopIntervalMs
+  }
   if (platform === 'darwin') {
-    const [narrowWatch, primaryMetadataPoll] = await Promise.all([
-      startGitCommonNarrowWatch(target, onEvents, pollIntervalMs, visibility),
-      startSnapshotDiffPoller(
-        () => snapshotPrimaryCheckoutMetadata(target.path),
-        onEvents,
-        pollIntervalMs,
-        visibility,
-        onFullScan
-      )
-    ])
+    const primaryMetadataPoll = await startSnapshotDiffPoller(
+      () => snapshotPrimaryCheckoutMetadata(target.path),
+      onEvents,
+      cadence,
+      visibility,
+      onFullScan,
+      () =>
+        onEvents(
+          PRIMARY_CHECKOUT_METADATA_FILES.map((name) => ({
+            type: 'update',
+            path: join(target.path, name)
+          }))
+        )
+    )
+    const narrowWatch = await startGitCommonNarrowWatch(
+      target,
+      onEvents,
+      pollIntervalMs,
+      visibility,
+      primaryMetadataPoll.resetCadence
+    )
     return {
       unsubscribe: async () => {
         await Promise.all([narrowWatch.unsubscribe(), primaryMetadataPoll.unsubscribe()])
       }
     }
   }
-  return startGitCommonPolling(target.path, onEvents, pollIntervalMs, visibility, onFullScan)
+  return startGitCommonPolling(target.path, onEvents, cadence, visibility, onFullScan)
 }

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -14,6 +14,7 @@ import {
   type GitCommonPollingCadence
 } from './worktree-git-common-poll-cadence'
 import {
+  isMissingPathError,
   PRIMARY_CHECKOUT_METADATA_FILES,
   startGitCommonPolling
 } from './worktree-git-common-polling'
@@ -36,11 +37,6 @@ import {
 // Why: branch switches and commits made in the primary checkout rewrite these
 // top-level files (linked-worktree equivalents live under `worktrees/`).
 // Deliberately excludes FETCH_HEAD-style churn that carries no status change.
-function isMissingPathError(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException).code
-  return code === 'ENOENT' || code === 'ENOTDIR'
-}
-
 async function snapshotPrimaryCheckoutMetadata(
   commonDirPath: string
 ): Promise<Map<string, number>> {
@@ -82,7 +78,9 @@ function diffMtimeMap(
 async function startSnapshotDiffPoller(
   takeSnapshot: () => Promise<Map<string, number>>,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
-  cadence: GitCommonPollingCadence,
+  // No index backstop: this poller re-stats every file each tick, so there is no gated
+  // read for a forced full scan to unblock.
+  cadence: Pick<GitCommonPollingCadence, 'activeIntervalMs' | 'idleIntervalMs'>,
   visibility: WorktreePollerWindowVisibility,
   onFullScan: (() => void) | undefined,
   onBaselineRecovered: () => void
@@ -296,9 +294,11 @@ export async function startGitCommonWatch(
   pollIntervalMs: number,
   platform: NodeJS.Platform,
   visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void,
-  idlePollIntervalMs = pollIntervalMs * 5,
-  indexBackstopIntervalMs = pollIntervalMs * 15
+  onFullScan: (() => void) | undefined,
+  // Why: required, not defaulted — the interval policy lives with the base-poller constants;
+  // a local multiplier default here would silently desync when either constant changes.
+  idlePollIntervalMs: number,
+  indexBackstopIntervalMs: number
 ): Promise<WorktreeBaseSubscription> {
   const cadence: GitCommonPollingCadence = {
     activeIntervalMs: pollIntervalMs,

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -8,16 +8,18 @@ import type {
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 import {
+  createDegradedBaselineGate,
   startAdaptiveGitCommonPoller,
   tryTakeGitCommonPollBaseline,
   type AdaptiveGitCommonPollSubscription,
   type GitCommonPollingCadence
 } from './worktree-git-common-poll-cadence'
+import { startGitCommonPolling } from './worktree-git-common-polling'
 import {
-  isMissingPathError,
   PRIMARY_CHECKOUT_METADATA_FILES,
-  startGitCommonPolling
-} from './worktree-git-common-polling'
+  snapshotPrimaryCheckoutMetadata,
+  type PrimaryCheckoutMetadataSnapshot
+} from './worktree-git-common-snapshot'
 
 // Watches a repo's `<common>/.git/worktrees` metadata plus the primary
 // checkout's shallow branch/index files — the only paths the git-common event
@@ -33,26 +35,6 @@ import {
 // Electron main process: watcher.node teardown races heap-corrupt the hosting
 // process when unsubscribe overlaps in-flight callbacks (issue #8732), and
 // root deletion via `git worktree prune` makes that overlap routine here.
-
-// Why: branch switches and commits made in the primary checkout rewrite these
-// top-level files (linked-worktree equivalents live under `worktrees/`).
-// Deliberately excludes FETCH_HEAD-style churn that carries no status change.
-async function snapshotPrimaryCheckoutMetadata(
-  commonDirPath: string
-): Promise<Map<string, number>> {
-  const mtimes = new Map<string, number>()
-  for (const name of PRIMARY_CHECKOUT_METADATA_FILES) {
-    const filePath = join(commonDirPath, name)
-    try {
-      mtimes.set(filePath, (await stat(filePath)).mtimeMs)
-    } catch (error) {
-      if (!isMissingPathError(error)) {
-        throw error
-      }
-    }
-  }
-  return mtimes
-}
 
 function diffMtimeMap(
   prev: Map<string, number>,
@@ -76,7 +58,7 @@ function diffMtimeMap(
 }
 
 async function startSnapshotDiffPoller(
-  takeSnapshot: () => Promise<Map<string, number>>,
+  takeSnapshot: (previous?: Map<string, number>) => Promise<PrimaryCheckoutMetadataSnapshot>,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   // No index backstop: this poller re-stats every file each tick, so there is no gated
   // read for a forced full scan to unblock.
@@ -86,27 +68,38 @@ async function startSnapshotDiffPoller(
   onBaselineRecovered: () => void
 ): Promise<AdaptiveGitCommonPollSubscription> {
   let disposed = false
-  let snapshot = await tryTakeGitCommonPollBaseline(takeSnapshot)
+  // Why: a degraded scan has no previous view to retain at baseline time, so it simply omits the
+  // files it could not read. Committing that as authoritative makes the next clean tick diff them
+  // as creates; wait out a bounded number of whole ones instead.
+  const deferDegradedBaseline = createDegradedBaselineGate()
+  const baseline = await tryTakeGitCommonPollBaseline(
+    () => takeSnapshot(),
+    'primary-checkout metadata'
+  )
+  let snapshot = baseline && !deferDegradedBaseline(baseline.degraded) ? baseline.mtimes : null
   const polling = startAdaptiveGitCommonPoller({
     cadence: { activeIntervalMs: cadence.activeIntervalMs, idleIntervalMs: cadence.idleIntervalMs },
     visibility,
     poll: async () => {
       onFullScan?.()
-      const next = await takeSnapshot()
+      const next = await takeSnapshot(snapshot ?? undefined)
       if (disposed) {
         return { changed: false }
       }
       if (!snapshot) {
-        snapshot = next
+        if (deferDegradedBaseline(next.degraded)) {
+          return { changed: false, degraded: true }
+        }
+        snapshot = next.mtimes
         onBaselineRecovered()
         return { changed: true }
       }
-      const events = diffMtimeMap(snapshot, next)
-      snapshot = next
+      const events = diffMtimeMap(snapshot, next.mtimes)
+      snapshot = next.mtimes
       if (events.length > 0) {
         onEvents(events)
       }
-      return { changed: events.length > 0 }
+      return { changed: events.length > 0, degraded: next.degraded }
     }
   })
 
@@ -306,27 +299,31 @@ export async function startGitCommonWatch(
     indexBackstopIntervalMs
   }
   if (platform === 'darwin') {
-    const primaryMetadataPoll = await startSnapshotDiffPoller(
-      () => snapshotPrimaryCheckoutMetadata(target.path),
-      onEvents,
-      cadence,
-      visibility,
-      onFullScan,
-      () =>
-        onEvents(
-          PRIMARY_CHECKOUT_METADATA_FILES.map((name) => ({
-            type: 'update',
-            path: join(target.path, name)
-          }))
-        )
-    )
-    const narrowWatch = await startGitCommonNarrowWatch(
-      target,
-      onEvents,
-      pollIntervalMs,
-      visibility,
-      primaryMetadataPoll.resetCadence
-    )
+    // Why: install both in parallel — a slow/blocked stat on a primary file must not delay the
+    // FSEvents subscription (and with it, first linked-worktree create detection). The narrow watch
+    // reaches the poller through a late-bound holder; events that land before the poller exists are
+    // covered by the baseline it takes at that moment.
+    let resetPrimaryPollCadence: () => void = () => {}
+    const [primaryMetadataPoll, narrowWatch] = await Promise.all([
+      startSnapshotDiffPoller(
+        (previous) => snapshotPrimaryCheckoutMetadata(target.path, previous),
+        onEvents,
+        cadence,
+        visibility,
+        onFullScan,
+        () =>
+          onEvents(
+            PRIMARY_CHECKOUT_METADATA_FILES.map((name) => ({
+              type: 'update',
+              path: join(target.path, name)
+            }))
+          )
+      ),
+      startGitCommonNarrowWatch(target, onEvents, pollIntervalMs, visibility, () =>
+        resetPrimaryPollCadence()
+      )
+    ])
+    resetPrimaryPollCadence = primaryMetadataPoll.resetCadence
     return {
       unsubscribe: async () => {
         await Promise.all([narrowWatch.unsubscribe(), primaryMetadataPoll.unsubscribe()])

--- a/src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts
+++ b/src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts
@@ -61,14 +61,18 @@ async function waitForRequest(
   transport: ReturnType<typeof createTransport>,
   method: string
 ): Promise<Record<string, unknown>> {
-  for (let turn = 0; turn < 10; turn += 1) {
-    const request = requestPayloads(transport).find((payload) => payload.method === method)
-    if (request) {
+  // Why: post-shutdown cancelDelivery is scheduled through async catch/rollback chains.
+  // A fixed microtask budget flakes under CI load (esp. Node 26 shards); yield real turns.
+  return await vi.waitFor(
+    () => {
+      const request = requestPayloads(transport).find((payload) => payload.method === method)
+      if (!request) {
+        throw new Error(`request not dispatched: ${method}`)
+      }
       return request
-    }
-    await Promise.resolve()
-  }
-  throw new Error(`request not dispatched: ${method}`)
+    },
+    { timeout: 1000, interval: 1 }
+  )
 }
 
 describe('SSH fresh agent-session create operations', () => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -146,7 +146,12 @@ import {
   timeRendererStartupStep,
   timeRendererStartupSyncStep
 } from './startup/startup-diagnostics'
-import { reconnectSshTargetForRendererStartup } from './startup/ssh-startup-reconnect'
+import {
+  partitionSshStartupReconnectTargets,
+  reconnectSshTargetsForRendererStartup,
+  resolveSshStartupActiveWorkspaceId,
+  type SshStartupReconnectBatchResult
+} from './startup/ssh-startup-reconnect'
 import { shouldRenderPetOverlay } from './components/pet/pet-overlay-visibility'
 import { applyDocumentTheme } from './lib/document-theme'
 import { getSystemPrefersDark } from './lib/terminal-theme'
@@ -196,6 +201,7 @@ import {
   type ExecutionHostId
 } from '../../shared/execution-host'
 import { mapWithConcurrency } from '../../shared/map-with-concurrency'
+import { getConnectionIdFromState } from './lib/connection-owner-resolution'
 import {
   ModifierDoubleTapDetector,
   toModifierDoubleTapEvent
@@ -465,6 +471,7 @@ function App(): React.JSX.Element {
       fetchBrowserSessionProfiles: s.fetchBrowserSessionProfiles,
       reconnectPersistedTerminals: s.reconnectPersistedTerminals,
       setDeferredSshReconnectTargets: s.setDeferredSshReconnectTargets,
+      removeDeferredSshReconnectTarget: s.removeDeferredSshReconnectTarget,
       setSshConnectionState: s.setSshConnectionState,
       hydratePersistedUI: s.hydratePersistedUI,
       setHydrationSucceeded: s.setHydrationSucceeded,
@@ -998,59 +1005,77 @@ function App(): React.JSX.Element {
               const eagerTargets = targets.filter((t) => !t.needsPassphrase)
               const deferredTargets = targets.filter((t) => t.needsPassphrase)
 
-              if (deferredTargets.length > 0) {
-                actions.setDeferredSshReconnectTargets(deferredTargets.map((t) => t.targetId))
+              const startupState = useAppStore.getState()
+              const activeWorkspaceId = resolveSshStartupActiveWorkspaceId({
+                activeWorkspaceKey: startupState.activeWorkspaceKey,
+                activeWorktreeId: startupState.activeWorktreeId
+              })
+              const activeConnectionId = getConnectionIdFromState(startupState, activeWorkspaceId)
+              const { criticalTargetIds, backgroundTargetIds } =
+                partitionSshStartupReconnectTargets({
+                  targetIds: eagerTargets.map(({ targetId }) => targetId),
+                  activeTargetIds:
+                    typeof activeConnectionId === 'string' ? [activeConnectionId] : [],
+                  activeTabId: sessionRead.session.activeTabId,
+                  remoteSessionIdsByTabId: sessionRead.session.remoteSessionIdsByTabId
+                })
+              actions.setDeferredSshReconnectTargets([
+                ...new Set(targets.map(({ targetId }) => targetId))
+              ])
+
+              const reconnectTargets = (targetIds: readonly string[]) =>
+                reconnectSshTargetsForRendererStartup({
+                  targetIds,
+                  budgetMs: SSH_RECONNECT_TIMEOUT_MS,
+                  signal: abortController.signal,
+                  connect: (targetId) => window.api.ssh.connect({ targetId }),
+                  publishState: actions.setSshConnectionState,
+                  onFailure: (targetId, error) => {
+                    console.warn(`SSH auto-reconnect failed for ${targetId}:`, error)
+                  }
+                })
+              const finalizeCompletedTargets = async (
+                results: readonly SshStartupReconnectBatchResult[]
+              ): Promise<void> => {
+                for (const { targetId, outcome } of results) {
+                  if (outcome !== 'completed' || abortController.signal.aborted) {
+                    continue
+                  }
+                  // Why: older/wrapped providers may return no connect state; poll once before releasing the deferred pane gate.
+                  try {
+                    const state = await window.api.ssh.getState({ targetId })
+                    if (state?.status === 'connected') {
+                      actions.setSshConnectionState(targetId, state)
+                    }
+                  } catch {
+                    /* best-effort */
+                  }
+                  if (!abortController.signal.aborted) {
+                    actions.removeDeferredSshReconnectTarget(targetId)
+                  }
+                }
               }
 
-              // Why: treat timed-out eager targets as deferred so their PTYs reattach on tab focus (ssh.connect keeps running in main and likely finishes by then).
-              const timedOutTargets: string[] = []
-              await timeRendererStartupStep(
+              const criticalResults = await timeRendererStartupStep(
                 'ssh-reconnect',
-                () =>
-                  Promise.all(
-                    eagerTargets.map(async ({ targetId }) => {
-                      const result = await reconnectSshTargetForRendererStartup({
-                        targetId,
-                        timeoutMs: SSH_RECONNECT_TIMEOUT_MS,
-                        connect: (id) => window.api.ssh.connect({ targetId: id }),
-                        publishState: actions.setSshConnectionState,
-                        onFailure: (id, error) => {
-                          console.warn(`SSH auto-reconnect failed for ${id}:`, error)
-                        }
-                      })
-                      if (result.timedOut) {
-                        timedOutTargets.push(targetId)
-                      }
-                    })
-                  ),
+                () => reconnectTargets(criticalTargetIds),
                 {
-                  eagerTargets: eagerTargets.length,
+                  criticalTargets: criticalTargetIds.length,
+                  backgroundTargets: backgroundTargetIds.length,
                   deferredTargets: deferredTargets.length
                 }
               )
-              if (timedOutTargets.length > 0) {
-                actions.setDeferredSshReconnectTargets([
-                  ...deferredTargets.map((t) => t.targetId),
-                  ...timedOutTargets
-                ])
-              }
-
-              // Why: older/wrapped providers may return no state from connect; poll main once as a compatibility fallback before terminal restoration.
-              for (const { targetId } of eagerTargets) {
-                if (timedOutTargets.includes(targetId)) {
-                  continue
-                }
-                try {
-                  const state = await window.api.ssh.getState({ targetId })
-                  console.warn(
-                    `[ssh-restore] Polled state for ${targetId}: status=${state?.status}`
-                  )
-                  if (state?.status === 'connected') {
-                    actions.setSshConnectionState(targetId, state)
-                  }
-                } catch {
-                  /* best-effort */
-                }
+              await finalizeCompletedTargets(criticalResults)
+              if (
+                criticalResults.every(({ outcome }) => outcome === 'completed') &&
+                backgroundTargetIds.length > 0 &&
+                !abortController.signal.aborted
+              ) {
+                void timeRendererStartupStep('ssh-reconnect-background', () =>
+                  reconnectTargets(backgroundTargetIds)
+                )
+                  .then(finalizeCompletedTargets)
+                  .catch((error) => console.warn('SSH background reconnect failed:', error))
               }
             } catch (err) {
               console.warn('SSH startup reconnect failed:', err)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -148,11 +148,9 @@ import {
 } from './startup/startup-diagnostics'
 import {
   partitionSshStartupReconnectTargets,
-  reconnectSshTargetsForRendererStartup,
-  resolveSshStartupActiveWorkspaceId,
-  shouldStartBackgroundSshReconnect,
-  type SshStartupReconnectBatchResult
+  resolveSshStartupActiveWorkspaceId
 } from './startup/ssh-startup-reconnect'
+import { startSshStartupReconnect } from './startup/ssh-startup-reconnect-orchestration'
 import { connectSshTargetDeduplicated } from './lib/ssh-target-connect-deduplication'
 import { shouldRenderPetOverlay } from './components/pet/pet-overlay-visibility'
 import { applyDocumentTheme } from './lib/document-theme'
@@ -1019,76 +1017,49 @@ function App(): React.JSX.Element {
                   activeTargetIds:
                     typeof activeConnectionId === 'string' ? [activeConnectionId] : [],
                   activeTabId: sessionRead.session.activeTabId,
+                  activeWorkspaceSessionIds: activeWorkspaceId
+                    ? (sessionRead.session.tabsByWorktree[activeWorkspaceId] ?? []).flatMap(
+                        (tab) => {
+                          // Folder workspaces never key remoteSessionIdsByTabId, so fall back to the
+                          // tab's own pty id — the only place their SSH host is recorded.
+                          const sessionId =
+                            sessionRead.session.remoteSessionIdsByTabId?.[tab.id] ?? tab.ptyId
+                          return sessionId ? [sessionId] : []
+                        }
+                      )
+                    : [],
                   remoteSessionIdsByTabId: sessionRead.session.remoteSessionIdsByTabId
                 })
-              actions.setDeferredSshReconnectTargets([
-                ...new Set(targets.map(({ targetId }) => targetId))
-              ])
 
-              const reconnectTargets = (targetIds: readonly string[]) =>
-                reconnectSshTargetsForRendererStartup({
-                  targetIds,
-                  budgetMs: SSH_RECONNECT_TIMEOUT_MS,
-                  signal: abortController.signal,
-                  connect: (targetId) =>
-                    connectSshTargetDeduplicated(targetId, () =>
-                      window.api.ssh.connect({ targetId })
-                    ),
-                  publishState: actions.setSshConnectionState,
-                  onFailure: (targetId, error) => {
-                    console.warn(`SSH auto-reconnect failed for ${targetId}:`, error)
-                  }
-                })
-              const finalizeCompletedTargets = async (
-                results: readonly SshStartupReconnectBatchResult[]
-              ): Promise<void> => {
-                // Why: the critical batch awaits this on the startup path, so probe every target
-                // at once instead of paying one IPC round-trip per target serially.
-                await Promise.all(
-                  results
-                    .filter(({ outcome }) => outcome === 'completed')
-                    .map(async ({ targetId }) => {
-                      if (abortController.signal.aborted) {
-                        return
-                      }
-                      // Why: older/wrapped providers may return no connect state; poll once before releasing the deferred pane gate.
-                      try {
-                        const state = await window.api.ssh.getState({ targetId })
-                        if (state?.status === 'connected') {
-                          actions.setSshConnectionState(targetId, state)
-                        }
-                      } catch {
-                        /* best-effort */
-                      }
-                      if (!abortController.signal.aborted) {
-                        actions.removeDeferredSshReconnectTarget(targetId)
-                      }
-                    })
-                )
-              }
-
-              const criticalResults = await timeRendererStartupStep(
-                'ssh-reconnect',
-                () => reconnectTargets(criticalTargetIds),
-                {
-                  criticalTargets: criticalTargetIds.length,
-                  backgroundTargets: backgroundTargetIds.length,
-                  deferredTargets: deferredTargets.length
-                }
+              const { backgroundSettled } = await startSshStartupReconnect({
+                targetIds: targets.map(({ targetId }) => targetId),
+                criticalTargetIds,
+                backgroundTargetIds,
+                attemptTimeoutMs: SSH_RECONNECT_TIMEOUT_MS,
+                criticalBudgetMs: SSH_RECONNECT_TIMEOUT_MS,
+                signal: abortController.signal,
+                connect: (targetId) =>
+                  connectSshTargetDeduplicated(targetId, () =>
+                    window.api.ssh.connect({ targetId })
+                  ),
+                getState: (targetId) => window.api.ssh.getState({ targetId }),
+                publishState: actions.setSshConnectionState,
+                setDeferredTargets: actions.setDeferredSshReconnectTargets,
+                removeDeferredTarget: actions.removeDeferredSshReconnectTarget,
+                onFailure: (targetId, error) => {
+                  console.warn(`SSH auto-reconnect failed for ${targetId}:`, error)
+                },
+                runCriticalStep: (run) =>
+                  timeRendererStartupStep('ssh-reconnect', run, {
+                    criticalTargets: criticalTargetIds.length,
+                    backgroundTargets: backgroundTargetIds.length,
+                    deferredTargets: deferredTargets.length
+                  }),
+                runBackgroundStep: (run) => timeRendererStartupStep('ssh-reconnect-background', run)
+              })
+              void backgroundSettled?.catch((error) =>
+                console.warn('SSH background reconnect failed:', error)
               )
-              await finalizeCompletedTargets(criticalResults)
-              if (
-                shouldStartBackgroundSshReconnect({
-                  backgroundTargetCount: backgroundTargetIds.length,
-                  aborted: abortController.signal.aborted
-                })
-              ) {
-                void timeRendererStartupStep('ssh-reconnect-background', () =>
-                  reconnectTargets(backgroundTargetIds)
-                )
-                  .then(finalizeCompletedTargets)
-                  .catch((error) => console.warn('SSH background reconnect failed:', error))
-              }
             } catch (err) {
               console.warn('SSH startup reconnect failed:', err)
             }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -150,8 +150,10 @@ import {
   partitionSshStartupReconnectTargets,
   reconnectSshTargetsForRendererStartup,
   resolveSshStartupActiveWorkspaceId,
+  shouldStartBackgroundSshReconnect,
   type SshStartupReconnectBatchResult
 } from './startup/ssh-startup-reconnect'
+import { connectSshTargetDeduplicated } from './lib/ssh-target-connect-deduplication'
 import { shouldRenderPetOverlay } from './components/pet/pet-overlay-visibility'
 import { applyDocumentTheme } from './lib/document-theme'
 import { getSystemPrefersDark } from './lib/terminal-theme'
@@ -1028,7 +1030,10 @@ function App(): React.JSX.Element {
                   targetIds,
                   budgetMs: SSH_RECONNECT_TIMEOUT_MS,
                   signal: abortController.signal,
-                  connect: (targetId) => window.api.ssh.connect({ targetId }),
+                  connect: (targetId) =>
+                    connectSshTargetDeduplicated(targetId, () =>
+                      window.api.ssh.connect({ targetId })
+                    ),
                   publishState: actions.setSshConnectionState,
                   onFailure: (targetId, error) => {
                     console.warn(`SSH auto-reconnect failed for ${targetId}:`, error)
@@ -1037,23 +1042,29 @@ function App(): React.JSX.Element {
               const finalizeCompletedTargets = async (
                 results: readonly SshStartupReconnectBatchResult[]
               ): Promise<void> => {
-                for (const { targetId, outcome } of results) {
-                  if (outcome !== 'completed' || abortController.signal.aborted) {
-                    continue
-                  }
-                  // Why: older/wrapped providers may return no connect state; poll once before releasing the deferred pane gate.
-                  try {
-                    const state = await window.api.ssh.getState({ targetId })
-                    if (state?.status === 'connected') {
-                      actions.setSshConnectionState(targetId, state)
-                    }
-                  } catch {
-                    /* best-effort */
-                  }
-                  if (!abortController.signal.aborted) {
-                    actions.removeDeferredSshReconnectTarget(targetId)
-                  }
-                }
+                // Why: the critical batch awaits this on the startup path, so probe every target
+                // at once instead of paying one IPC round-trip per target serially.
+                await Promise.all(
+                  results
+                    .filter(({ outcome }) => outcome === 'completed')
+                    .map(async ({ targetId }) => {
+                      if (abortController.signal.aborted) {
+                        return
+                      }
+                      // Why: older/wrapped providers may return no connect state; poll once before releasing the deferred pane gate.
+                      try {
+                        const state = await window.api.ssh.getState({ targetId })
+                        if (state?.status === 'connected') {
+                          actions.setSshConnectionState(targetId, state)
+                        }
+                      } catch {
+                        /* best-effort */
+                      }
+                      if (!abortController.signal.aborted) {
+                        actions.removeDeferredSshReconnectTarget(targetId)
+                      }
+                    })
+                )
               }
 
               const criticalResults = await timeRendererStartupStep(
@@ -1067,9 +1078,10 @@ function App(): React.JSX.Element {
               )
               await finalizeCompletedTargets(criticalResults)
               if (
-                criticalResults.every(({ outcome }) => outcome === 'completed') &&
-                backgroundTargetIds.length > 0 &&
-                !abortController.signal.aborted
+                shouldStartBackgroundSshReconnect({
+                  backgroundTargetCount: backgroundTargetIds.length,
+                  aborted: abortController.signal.aborted
+                })
               ) {
                 void timeRendererStartupStep('ssh-reconnect-background', () =>
                   reconnectTargets(backgroundTargetIds)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -176,6 +176,7 @@ import { createTerminalCommandLifecycle } from './terminal-command-lifecycle'
 import { createPaneForegroundAgentTracker } from './pane-foreground-agent-tracker'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import { resolveSshPaneConnectGate } from './ssh-pane-connect-gate'
+import { connectSshTargetDeduplicated } from '@/lib/ssh-target-connect-deduplication'
 import { dispatchTerminalCommandFinishedEvent } from '@/hooks/terminal-command-finished-event'
 import { e2eConfig } from '@/lib/e2e-config'
 import {
@@ -752,14 +753,8 @@ function recordPtyConnectDiagnostic(message: string): void {
   }
 }
 
-// Why: when multiple panes/tabs need the same deferred SSH connection,
-// the first one calls ssh.connect() and subsequent ones must wait for it
-// rather than returning early (which would leave them disconnected). This
-// helper either connects or waits for an in-flight connect to finish.
 type SshConnectResult = { connected: true } | { connected: false; error: string }
 type UserInitiatedSshConnectOutcome = 'connected' | 'cancelled' | 'failed'
-
-const sshConnectPromises = new Map<string, Promise<SshConnectResult>>()
 
 function isSshSessionExpiredError(err: unknown): boolean {
   return (err instanceof Error ? err.message : String(err)).includes(SSH_SESSION_EXPIRED_ERROR)
@@ -819,28 +814,18 @@ async function waitForSshConnection(connectionId: string): Promise<SshConnectRes
     return { connected: true }
   }
 
-  const existing = sshConnectPromises.get(connectionId)
-  if (existing) {
-    return existing
-  }
-
-  const promise: Promise<SshConnectResult> = (async (): Promise<SshConnectResult> => {
-    try {
-      await window.api.ssh.connect({ targetId: connectionId })
-      return { connected: true }
-    } catch (err) {
-      console.warn(`Deferred SSH reconnect failed for ${connectionId}:`, err)
-      return {
-        connected: false,
-        error: err instanceof Error ? err.message : String(err)
-      }
-    } finally {
-      sshConnectPromises.delete(connectionId)
+  try {
+    await connectSshTargetDeduplicated(connectionId, () =>
+      window.api.ssh.connect({ targetId: connectionId })
+    )
+    return { connected: true }
+  } catch (err) {
+    console.warn(`Deferred SSH reconnect failed for ${connectionId}:`, err)
+    return {
+      connected: false,
+      error: err instanceof Error ? err.message : String(err)
     }
-  })()
-
-  sshConnectPromises.set(connectionId, promise)
-  return promise
+  }
 }
 
 function isCodexPaneStale(args: {

--- a/src/renderer/src/lib/ssh-target-connect-deduplication.test.ts
+++ b/src/renderer/src/lib/ssh-target-connect-deduplication.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { SshConnectionState } from '../../../shared/ssh-types'
+import { connectSshTargetDeduplicated } from './ssh-target-connect-deduplication'
+
+const connectedState: SshConnectionState = {
+  targetId: 'ssh-1',
+  status: 'connected',
+  error: null,
+  reconnectAttempt: 0,
+  remotePlatform: 'linux'
+}
+
+function controlledConnect(): {
+  promise: Promise<SshConnectionState | null>
+  resolve: (state: SshConnectionState | null) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (state: SshConnectionState | null) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<SshConnectionState | null>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('connectSshTargetDeduplicated', () => {
+  it('lets a pane reuse a pending startup connection', async () => {
+    const pending = controlledConnect()
+    const startupConnect = vi.fn(() => pending.promise)
+    const paneConnect = vi.fn().mockRejectedValue(new Error('already in progress'))
+
+    const startupAttempt = connectSshTargetDeduplicated('ssh-1', startupConnect)
+    expect(startupConnect).toHaveBeenCalledOnce()
+    const paneAttempt = connectSshTargetDeduplicated('ssh-1', paneConnect)
+
+    expect(paneConnect).not.toHaveBeenCalled()
+    expect(paneAttempt).toBe(startupAttempt)
+
+    pending.resolve(connectedState)
+    await expect(Promise.all([startupAttempt, paneAttempt])).resolves.toEqual([
+      connectedState,
+      connectedState
+    ])
+
+    const laterConnect = vi.fn().mockResolvedValue(connectedState)
+    await expect(connectSshTargetDeduplicated('ssh-1', laterConnect)).resolves.toBe(connectedState)
+    expect(laterConnect).toHaveBeenCalledOnce()
+  })
+
+  it('returns synchronous failures as rejected promises and cleans up for retry', async () => {
+    const failure = new Error('Authentication failed')
+    const failedConnect = vi.fn(() => {
+      throw failure
+    })
+
+    const failedAttempt = connectSshTargetDeduplicated('ssh-failed', failedConnect)
+    await expect(failedAttempt).rejects.toBe(failure)
+
+    const retryConnect = vi.fn().mockResolvedValue({
+      ...connectedState,
+      targetId: 'ssh-failed'
+    })
+    await expect(connectSshTargetDeduplicated('ssh-failed', retryConnect)).resolves.toMatchObject({
+      targetId: 'ssh-failed',
+      status: 'connected'
+    })
+    expect(failedConnect).toHaveBeenCalledOnce()
+    expect(retryConnect).toHaveBeenCalledOnce()
+  })
+
+  it('does not deduplicate different targets', async () => {
+    const firstConnect = vi.fn().mockResolvedValue(connectedState)
+    const secondConnect = vi.fn().mockResolvedValue({
+      ...connectedState,
+      targetId: 'ssh-2'
+    })
+
+    await Promise.all([
+      connectSshTargetDeduplicated('ssh-1', firstConnect),
+      connectSshTargetDeduplicated('ssh-2', secondConnect)
+    ])
+
+    expect(firstConnect).toHaveBeenCalledOnce()
+    expect(secondConnect).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/lib/ssh-target-connect-deduplication.ts
+++ b/src/renderer/src/lib/ssh-target-connect-deduplication.ts
@@ -1,0 +1,27 @@
+import type { SshConnectionState } from '../../../shared/ssh-types'
+
+const pendingConnects = new Map<string, Promise<SshConnectionState | null>>()
+
+export function connectSshTargetDeduplicated(
+  targetId: string,
+  connect: () => Promise<SshConnectionState | null>
+): Promise<SshConnectionState | null> {
+  const pending = pendingConnects.get(targetId)
+  if (pending) {
+    return pending
+  }
+
+  let next: Promise<SshConnectionState | null>
+  try {
+    next = connect()
+  } catch (error) {
+    next = Promise.reject(error)
+  }
+  const tracked = next.finally(() => {
+    if (pendingConnects.get(targetId) === tracked) {
+      pendingConnects.delete(targetId)
+    }
+  })
+  pendingConnects.set(targetId, tracked)
+  return tracked
+}

--- a/src/renderer/src/startup/ssh-startup-reconnect-orchestration.test.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect-orchestration.test.ts
@@ -1,0 +1,286 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SshConnectionState, SshProviderEpoch } from '../../../shared/ssh-types'
+import {
+  SshStartupReconnectScheduler,
+  type SshStartupReconnectBatchResult
+} from './ssh-startup-reconnect'
+import {
+  startSshStartupReconnect,
+  type SshStartupReconnectOrchestrationArgs
+} from './ssh-startup-reconnect-orchestration'
+
+function connectedState(targetId: string): SshConnectionState {
+  return {
+    targetId,
+    status: 'connected',
+    error: null,
+    reconnectAttempt: 0,
+    providerEpoch: 'startup-provider-epoch' as SshProviderEpoch,
+    connectionGeneration: 1,
+    remotePlatform: 'linux'
+  }
+}
+
+function disconnectedState(targetId: string): SshConnectionState {
+  return {
+    targetId,
+    status: 'disconnected',
+    error: 'Authentication failed',
+    reconnectAttempt: 1,
+    providerEpoch: 'startup-provider-epoch' as SshProviderEpoch
+  }
+}
+
+function deployingRelayState(targetId: string): SshConnectionState {
+  return {
+    targetId,
+    status: 'deploying-relay',
+    error: null,
+    reconnectAttempt: 0,
+    providerEpoch: 'startup-provider-epoch' as SshProviderEpoch
+  }
+}
+
+function controlledPromise<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
+}
+
+type Harness = {
+  /** Mirrors the store slice: seeded wholesale, then cleared per target. */
+  deferred: string[]
+  published: [string, SshConnectionState][]
+  starts: string[]
+  args: SshStartupReconnectOrchestrationArgs
+}
+
+function createHarness(
+  overrides: Partial<SshStartupReconnectOrchestrationArgs> & {
+    connect: SshStartupReconnectOrchestrationArgs['connect']
+    getState: SshStartupReconnectOrchestrationArgs['getState']
+    targetIds: readonly string[]
+  },
+  concurrency = 3
+): Harness {
+  const harness = {
+    deferred: [] as string[],
+    published: [] as [string, SshConnectionState][],
+    starts: [] as string[]
+  }
+  const args: SshStartupReconnectOrchestrationArgs = {
+    criticalTargetIds: [],
+    backgroundTargetIds: [],
+    attemptTimeoutMs: 1_000,
+    criticalBudgetMs: 1_000,
+    signal: new AbortController().signal,
+    publishState: (targetId, state) => harness.published.push([targetId, state]),
+    setDeferredTargets: (targetIds) => {
+      harness.deferred = [...targetIds]
+    },
+    removeDeferredTarget: (targetId) => {
+      harness.deferred = harness.deferred.filter((id) => id !== targetId)
+    },
+    onFailure: () => {},
+    runCriticalStep: (run) => run(),
+    runBackgroundStep: (run) => run(),
+    scheduler: new SshStartupReconnectScheduler(concurrency),
+    ...overrides,
+    connect: (targetId) => {
+      harness.starts.push(targetId)
+      return overrides.connect(targetId)
+    }
+  }
+  // Same object the closures above mutate — a spread copy would freeze `deferred` at seed time.
+  return Object.assign(harness, { args })
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('startSshStartupReconnect', () => {
+  it('returns after the critical batch while background hosts are still dialing', async () => {
+    const background = controlledPromise<SshConnectionState>()
+    const state = new Map<string, SshConnectionState>()
+    const harness = createHarness({
+      targetIds: ['ssh-active', 'ssh-bg', 'ssh-passphrase'],
+      criticalTargetIds: ['ssh-active'],
+      backgroundTargetIds: ['ssh-bg'],
+      connect: (targetId) => {
+        if (targetId === 'ssh-bg') {
+          return background.promise
+        }
+        state.set(targetId, connectedState(targetId))
+        return Promise.resolve(connectedState(targetId))
+      },
+      getState: (targetId) => Promise.resolve(state.get(targetId) ?? null)
+    })
+
+    const { criticalResults, backgroundSettled } = await startSshStartupReconnect(harness.args)
+
+    expect(criticalResults).toEqual([{ targetId: 'ssh-active', outcome: 'completed' }])
+    expect(harness.starts).toEqual(['ssh-active', 'ssh-bg'])
+    // The gate is already open for the active host and still closed for everyone else.
+    expect(harness.deferred).toEqual(['ssh-bg', 'ssh-passphrase'])
+
+    state.set('ssh-bg', connectedState('ssh-bg'))
+    background.resolve(connectedState('ssh-bg'))
+    await expect(backgroundSettled).resolves.toEqual([{ targetId: 'ssh-bg', outcome: 'completed' }])
+    // A passphrase target belongs to neither batch, so its gate survives until tab focus.
+    expect(harness.deferred).toEqual(['ssh-passphrase'])
+  })
+
+  it('keeps a still-disconnected target gated after a failed attempt', async () => {
+    const harness = createHarness({
+      targetIds: ['ssh-down'],
+      criticalTargetIds: ['ssh-down'],
+      connect: () => Promise.reject(new Error('Authentication failed')),
+      getState: (targetId) => Promise.resolve(disconnectedState(targetId))
+    })
+
+    const { criticalResults } = await startSshStartupReconnect(harness.args)
+
+    expect(criticalResults).toEqual([{ targetId: 'ssh-down', outcome: 'failed' }])
+    expect(harness.deferred).toEqual(['ssh-down'])
+    expect(harness.published).toEqual([])
+  })
+
+  it('opens the gate for targets main finished after our own attempt gave up', async () => {
+    vi.useFakeTimers()
+    // Concurrency 1 + a 1s budget: only the first host is dialed, the rest expire queued. Main
+    // still owns those connects, so a probe must release them instead of gating them forever.
+    const harness = createHarness(
+      {
+        targetIds: ['ssh-hung', 'ssh-queued-up', 'ssh-queued-down'],
+        criticalTargetIds: ['ssh-hung', 'ssh-queued-up', 'ssh-queued-down'],
+        connect: () => new Promise<SshConnectionState>(() => {}),
+        getState: (targetId) =>
+          Promise.resolve(
+            targetId === 'ssh-queued-down' ? disconnectedState(targetId) : connectedState(targetId)
+          )
+      },
+      1
+    )
+
+    const started = startSshStartupReconnect(harness.args)
+    await vi.advanceTimersByTimeAsync(1_000)
+    const { criticalResults } = await started
+
+    expect(criticalResults).toEqual([
+      { targetId: 'ssh-hung', outcome: 'timed-out' },
+      { targetId: 'ssh-queued-up', outcome: 'not-started-budget' },
+      { targetId: 'ssh-queued-down', outcome: 'not-started-budget' }
+    ])
+    expect(harness.starts).toEqual(['ssh-hung'])
+    expect(harness.deferred).toEqual(['ssh-queued-down'])
+    expect(harness.published.map(([targetId]) => targetId).sort()).toEqual([
+      'ssh-hung',
+      'ssh-queued-up'
+    ])
+  })
+
+  // Why: main holds a live connect at 'deploying-relay' until the relay session is ready, so a
+  // half-up host reads as not-yet-connected here. Clearing the gate on it would remount SSH panes
+  // before any PTY provider exists — the whole reason the gate is there.
+  it('keeps a half-up target gated when the probe reports deploying-relay', async () => {
+    vi.useFakeTimers()
+    const harness = createHarness({
+      targetIds: ['ssh-half-up'],
+      criticalTargetIds: ['ssh-half-up'],
+      connect: () => new Promise<SshConnectionState>(() => {}),
+      getState: (targetId) => Promise.resolve(deployingRelayState(targetId))
+    })
+
+    const started = startSshStartupReconnect(harness.args)
+    await vi.advanceTimersByTimeAsync(1_000)
+    const { criticalResults } = await started
+
+    expect(criticalResults).toEqual([{ targetId: 'ssh-half-up', outcome: 'timed-out' }])
+    expect(harness.published).toEqual([])
+    expect(harness.deferred).toEqual(['ssh-half-up'])
+  })
+
+  it('leaves the gate alone for a background batch cancelled by startup teardown', async () => {
+    const abortController = new AbortController()
+    const background = controlledPromise<SshConnectionState>()
+    const getState = vi.fn(async (targetId: string) => connectedState(targetId))
+    const harness = createHarness({
+      targetIds: ['ssh-active', 'ssh-bg'],
+      criticalTargetIds: ['ssh-active'],
+      backgroundTargetIds: ['ssh-bg'],
+      signal: abortController.signal,
+      connect: (targetId) =>
+        targetId === 'ssh-bg' ? background.promise : Promise.resolve(connectedState(targetId)),
+      getState
+    })
+
+    const { backgroundSettled } = await startSshStartupReconnect(harness.args)
+    getState.mockClear()
+    abortController.abort()
+
+    await expect(backgroundSettled).resolves.toEqual([{ targetId: 'ssh-bg', outcome: 'cancelled' }])
+    expect(getState).not.toHaveBeenCalled()
+    expect(harness.deferred).toEqual(['ssh-bg'])
+    background.resolve(connectedState('ssh-bg'))
+  })
+
+  it('skips the background batch entirely when there is nothing left to dial', async () => {
+    const harness = createHarness({
+      targetIds: ['ssh-active'],
+      criticalTargetIds: ['ssh-active'],
+      backgroundTargetIds: [],
+      connect: (targetId) => Promise.resolve(connectedState(targetId)),
+      getState: (targetId) => Promise.resolve(connectedState(targetId))
+    })
+    const runBackgroundStep = vi.fn<SshStartupReconnectOrchestrationArgs['runBackgroundStep']>(
+      (run) => run()
+    )
+
+    const { backgroundSettled } = await startSshStartupReconnect({
+      ...harness.args,
+      runBackgroundStep
+    })
+
+    expect(backgroundSettled).toBeNull()
+    expect(runBackgroundStep).not.toHaveBeenCalled()
+    expect(harness.deferred).toEqual([])
+  })
+
+  it('reports both batches to the startup timer under their own step names', async () => {
+    const steps: string[] = []
+    const harness = createHarness({
+      targetIds: ['ssh-active', 'ssh-bg'],
+      criticalTargetIds: ['ssh-active'],
+      backgroundTargetIds: ['ssh-bg'],
+      connect: (targetId) => Promise.resolve(connectedState(targetId)),
+      getState: (targetId) => Promise.resolve(connectedState(targetId))
+    })
+    const track =
+      (name: string) =>
+      (
+        run: () => Promise<SshStartupReconnectBatchResult[]>
+      ): Promise<SshStartupReconnectBatchResult[]> => {
+        steps.push(name)
+        return run()
+      }
+
+    const { backgroundSettled } = await startSshStartupReconnect({
+      ...harness.args,
+      runCriticalStep: track('ssh-reconnect'),
+      runBackgroundStep: track('ssh-reconnect-background')
+    })
+    await backgroundSettled
+
+    expect(steps).toEqual(['ssh-reconnect', 'ssh-reconnect-background'])
+    expect(harness.deferred).toEqual([])
+  })
+})

--- a/src/renderer/src/startup/ssh-startup-reconnect-orchestration.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect-orchestration.ts
@@ -1,0 +1,118 @@
+import type { SshConnectionState } from '../../../shared/ssh-types'
+import {
+  reconnectSshTargetsForRendererStartup,
+  shouldStartBackgroundSshReconnect,
+  type SshStartupReconnectBatchResult,
+  type SshStartupReconnectScheduler
+} from './ssh-startup-reconnect'
+
+export type SshStartupReconnectOrchestration = {
+  criticalResults: SshStartupReconnectBatchResult[]
+  /** Resolves when the fire-and-forget background batch settles; null when there is none. */
+  backgroundSettled: Promise<SshStartupReconnectBatchResult[]> | null
+}
+
+export type SshStartupReconnectOrchestrationArgs = {
+  /** Every eager target, in the order they should be gated behind the deferred pane flow. */
+  targetIds: readonly string[]
+  criticalTargetIds: readonly string[]
+  backgroundTargetIds: readonly string[]
+  attemptTimeoutMs: number
+  criticalBudgetMs: number
+  signal: AbortSignal
+  connect: (targetId: string) => Promise<SshConnectionState | null>
+  getState: (targetId: string) => Promise<SshConnectionState | null>
+  publishState: (targetId: string, state: SshConnectionState) => void
+  setDeferredTargets: (targetIds: string[]) => void
+  removeDeferredTarget: (targetId: string) => void
+  onFailure: (targetId: string, error: unknown) => void
+  /** Wraps each batch so the caller can time it as a startup step. */
+  runCriticalStep: (
+    run: () => Promise<SshStartupReconnectBatchResult[]>
+  ) => Promise<SshStartupReconnectBatchResult[]>
+  runBackgroundStep: (
+    run: () => Promise<SshStartupReconnectBatchResult[]>
+  ) => Promise<SshStartupReconnectBatchResult[]>
+  scheduler?: SshStartupReconnectScheduler
+}
+
+// Awaits only the critical batch, then hands the caller a background batch that keeps running while
+// terminal restore and the catalog refresh proceed. Deferred-target bookkeeping lives here so the
+// gate a pane reads can never outlive the connection it was waiting for.
+export async function startSshStartupReconnect(
+  args: SshStartupReconnectOrchestrationArgs
+): Promise<SshStartupReconnectOrchestration> {
+  const reconnect = (
+    targetIds: readonly string[],
+    batchBudgetMs?: number
+  ): Promise<SshStartupReconnectBatchResult[]> =>
+    reconnectSshTargetsForRendererStartup({
+      targetIds,
+      attemptTimeoutMs: args.attemptTimeoutMs,
+      batchBudgetMs,
+      signal: args.signal,
+      scheduler: args.scheduler,
+      connect: args.connect,
+      publishState: args.publishState,
+      onFailure: args.onFailure
+    })
+
+  const finalizeSettledTargets = async (
+    results: readonly SshStartupReconnectBatchResult[]
+  ): Promise<void> => {
+    // Why: the critical batch awaits this on the startup path, so probe every target at once
+    // instead of paying one IPC round-trip per target serially.
+    await Promise.all(
+      results.map(async ({ targetId, outcome }) => {
+        if (outcome === 'cancelled' || args.signal.aborted) {
+          return
+        }
+        // Why: probe every settled outcome, not just `completed`. Main coalesces duplicate connects
+        // and keeps running past our timeout, so `in-progress`/`timed-out`/`failed` targets are
+        // routinely up by now — leaving them gated would strand them deferred for the process
+        // lifetime, since nothing else reconciles the gate against the live connection.
+        let state: SshConnectionState | null = null
+        try {
+          state = await args.getState(targetId)
+        } catch {
+          /* best-effort */
+        }
+        if (args.signal.aborted) {
+          return
+        }
+        if (state?.status === 'connected') {
+          args.publishState(targetId, state)
+        }
+        // A resolved connect is authority on its own: clear the gate even if the probe could not run.
+        if (outcome === 'completed' || state?.status === 'connected') {
+          args.removeDeferredTarget(targetId)
+        }
+      })
+    )
+  }
+
+  args.setDeferredTargets([...new Set(args.targetIds)])
+
+  const criticalResults = await args.runCriticalStep(() =>
+    reconnect(args.criticalTargetIds, args.criticalBudgetMs)
+  )
+  await finalizeSettledTargets(criticalResults)
+
+  if (
+    !shouldStartBackgroundSshReconnect({
+      backgroundTargetCount: args.backgroundTargetIds.length,
+      aborted: args.signal.aborted
+    })
+  ) {
+    return { criticalResults, backgroundSettled: null }
+  }
+  // No batch budget: the queue drains at the bounded concurrency until every host has had its own
+  // attempt, or the startup abort signal cancels what is left.
+  const backgroundSettled = args
+    .runBackgroundStep(() => reconnect(args.backgroundTargetIds))
+    .then(async (results) => {
+      await finalizeSettledTargets(results)
+      return results
+    })
+  return { criticalResults, backgroundSettled }
+}

--- a/src/renderer/src/startup/ssh-startup-reconnect.test.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SshConnectionState, SshProviderEpoch } from '../../../shared/ssh-types'
 import {
   partitionSshStartupReconnectTargets,
-  reconnectSshTargetForRendererStartup,
   reconnectSshTargetsForRendererStartup,
   resolveSshStartupActiveWorkspaceId,
   shouldStartBackgroundSshReconnect,
@@ -41,67 +40,6 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-describe('reconnectSshTargetForRendererStartup', () => {
-  it('publishes the connect result before startup terminal restoration continues', async () => {
-    const publishState = vi.fn()
-    const result = await reconnectSshTargetForRendererStartup({
-      targetId: 'ssh-1',
-      timeoutMs: 1_000,
-      connect: vi.fn().mockResolvedValue(connectedState),
-      publishState,
-      onFailure: vi.fn()
-    })
-
-    expect(result).toEqual({ timedOut: false })
-    expect(publishState).toHaveBeenCalledWith('ssh-1', connectedState)
-    expect(publishState.mock.calls[0]?.[1]).toMatchObject({
-      providerEpoch: 'startup-provider-epoch',
-      connectionGeneration: 41
-    })
-  })
-
-  it('does not synthesize the missing half of a partial startup authority', async () => {
-    const publishState = vi.fn()
-    const partialState = {
-      targetId: 'ssh-1',
-      status: 'connected',
-      error: null,
-      reconnectAttempt: 0,
-      providerEpoch: 'partial-provider-epoch' as SshProviderEpoch
-    } satisfies SshConnectionState
-
-    await reconnectSshTargetForRendererStartup({
-      targetId: 'ssh-1',
-      timeoutMs: 1_000,
-      connect: vi.fn().mockResolvedValue(partialState),
-      publishState,
-      onFailure: vi.fn()
-    })
-
-    expect(publishState).toHaveBeenCalledWith('ssh-1', partialState)
-    expect(publishState.mock.calls[0]?.[1]).not.toHaveProperty('connectionGeneration')
-  })
-
-  it('marks a stalled connect as deferred without publishing stale state', async () => {
-    vi.useFakeTimers()
-    const publishState = vi.fn()
-    const onFailure = vi.fn()
-    const resultPromise = reconnectSshTargetForRendererStartup({
-      targetId: 'ssh-1',
-      timeoutMs: 1_000,
-      connect: () => new Promise(() => {}),
-      publishState,
-      onFailure
-    })
-
-    await vi.advanceTimersByTimeAsync(1_000)
-
-    await expect(resultPromise).resolves.toEqual({ timedOut: true })
-    expect(publishState).not.toHaveBeenCalled()
-    expect(onFailure).toHaveBeenCalledWith('ssh-1', expect.any(Error))
-  })
-})
-
 describe('partitionSshStartupReconnectTargets', () => {
   it('unwraps an active worktree key before connection-owner resolution', () => {
     expect(
@@ -136,6 +74,44 @@ describe('partitionSshStartupReconnectTargets', () => {
       backgroundTargetIds: ['session-b', 'idle-a']
     })
   })
+
+  it("elevates the active workspace's own tabs when owner resolution found no connection", () => {
+    // Owner resolution returns undefined for a repo missing from the local catalog, so
+    // activeTargetIds is empty; the workspace's non-focused tabs must still be critical.
+    expect(
+      partitionSshStartupReconnectTargets({
+        targetIds: ['idle-a', 'workspace-b'],
+        activeTargetIds: [],
+        activeTabId: 'tab-editor',
+        activeWorkspaceSessionIds: ['ssh:workspace-b@@pty-1'],
+        remoteSessionIdsByTabId: {
+          'tab-terminal': 'ssh:workspace-b@@pty-1',
+          'tab-elsewhere': 'ssh:idle-a@@pty-2'
+        }
+      })
+    ).toEqual({
+      criticalTargetIds: ['workspace-b'],
+      backgroundTargetIds: ['idle-a']
+    })
+  })
+
+  // Why: remoteSessionIdsByTabId is built from repo → connectionId, which folder workspaces have
+  // no path to. Their tabs' own pty ids are the only record of the host, so elevation has to run
+  // off those or every folder-workspace SSH host lands in the background batch.
+  it('elevates a folder workspace host that no repo mapping can name', () => {
+    expect(
+      partitionSshStartupReconnectTargets({
+        targetIds: ['idle-a', 'folder-host'],
+        activeTargetIds: [],
+        activeTabId: null,
+        activeWorkspaceSessionIds: ['ssh:folder-host@@pty-9', 'local-pty-no-target'],
+        remoteSessionIdsByTabId: { 'tab-elsewhere': 'ssh:idle-a@@pty-2' }
+      })
+    ).toEqual({
+      criticalTargetIds: ['folder-host'],
+      backgroundTargetIds: ['idle-a']
+    })
+  })
 })
 
 describe('reconnectSshTargetsForRendererStartup', () => {
@@ -152,7 +128,8 @@ describe('reconnectSshTargetsForRendererStartup', () => {
     const reconnect = (targetIds: readonly string[]) =>
       reconnectSshTargetsForRendererStartup({
         targetIds,
-        budgetMs: 1_000,
+        attemptTimeoutMs: 1_000,
+        batchBudgetMs: 1_000,
         signal: new AbortController().signal,
         scheduler,
         connect,
@@ -182,7 +159,7 @@ describe('reconnectSshTargetsForRendererStartup', () => {
     const starts: string[] = []
     const resultPromise = reconnectSshTargetsForRendererStartup({
       targetIds: ['ssh-1', 'ssh-2', 'ssh-3', 'ssh-4'],
-      budgetMs: 1_000,
+      attemptTimeoutMs: 5_000,
       signal: new AbortController().signal,
       scheduler,
       connect: (targetId) => {
@@ -216,12 +193,13 @@ describe('reconnectSshTargetsForRendererStartup', () => {
     expect(peak).toBe(2)
   })
 
-  it('uses one batch budget and never starts targets still queued at expiry', async () => {
+  it('bounds a budgeted batch end to end, dropping targets still queued at expiry', async () => {
     vi.useFakeTimers()
     const starts: string[] = []
     const resultPromise = reconnectSshTargetsForRendererStartup({
       targetIds: ['ssh-stalled', 'ssh-queued'],
-      budgetMs: 1_000,
+      attemptTimeoutMs: 1_000,
+      batchBudgetMs: 1_000,
       signal: new AbortController().signal,
       scheduler: new SshStartupReconnectScheduler(1),
       connect: (targetId) => {
@@ -241,13 +219,105 @@ describe('reconnectSshTargetsForRendererStartup', () => {
     expect(starts).toEqual(['ssh-stalled'])
   })
 
+  it('gives every unbudgeted target its own attempt behind slow front-of-queue hosts', async () => {
+    vi.useFakeTimers()
+    const scheduler = new SshStartupReconnectScheduler(1)
+    const starts: string[] = []
+    const resultPromise = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-slow-1', 'ssh-slow-2', 'ssh-tail'],
+      attemptTimeoutMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler,
+      connect: (targetId) => {
+        starts.push(targetId)
+        return targetId === 'ssh-tail'
+          ? Promise.resolve(stateFor(targetId))
+          : new Promise<SshConnectionState>(() => {})
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    // Two full attempt timeouts elapse before the tail host ever reaches a slot.
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    await expect(resultPromise).resolves.toEqual([
+      { targetId: 'ssh-slow-1', outcome: 'timed-out' },
+      { targetId: 'ssh-slow-2', outcome: 'timed-out' },
+      { targetId: 'ssh-tail', outcome: 'completed' }
+    ])
+    expect(starts).toEqual(['ssh-slow-1', 'ssh-slow-2', 'ssh-tail'])
+  })
+
+  it('clamps a late-started attempt to what is left of the batch budget', async () => {
+    vi.useFakeTimers()
+    const scheduler = new SshStartupReconnectScheduler(1)
+    const starts: string[] = []
+    const resultPromise = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-slow', 'ssh-late'],
+      attemptTimeoutMs: 600,
+      batchBudgetMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler,
+      connect: (targetId) => {
+        starts.push(targetId)
+        return new Promise<SshConnectionState>(() => {})
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    // ssh-slow burns 600ms, so ssh-late gets the remaining 400ms — not a fresh 600ms, which
+    // would push the awaited critical batch out to 1_200ms.
+    await vi.advanceTimersByTimeAsync(999)
+    expect(starts).toEqual(['ssh-slow', 'ssh-late'])
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(resultPromise).resolves.toEqual([
+      { targetId: 'ssh-slow', outcome: 'timed-out' },
+      { targetId: 'ssh-late', outcome: 'timed-out' }
+    ])
+  })
+
+  // Why: without a floor, a target reaching a slot with a sliver of budget left dials main, is
+  // killed milliseconds later, and reports 'timed-out' with an onFailure warning — a connect that
+  // never had a chance, indistinguishable from a real host failure.
+  it('skips an attempt whose remaining batch budget is below the useful floor', async () => {
+    vi.useFakeTimers()
+    const starts: string[] = []
+    const onFailure = vi.fn()
+    const resultPromise = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-slow', 'ssh-sliver'],
+      attemptTimeoutMs: 900,
+      batchBudgetMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler: new SshStartupReconnectScheduler(1),
+      connect: (targetId) => {
+        starts.push(targetId)
+        return new Promise<SshConnectionState>(() => {})
+      },
+      publishState: vi.fn(),
+      onFailure
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await expect(resultPromise).resolves.toEqual([
+      { targetId: 'ssh-slow', outcome: 'timed-out' },
+      { targetId: 'ssh-sliver', outcome: 'not-started-budget' }
+    ])
+    // ssh-sliver gives up waiting once the batch has less than the floor left, so it never dials.
+    expect(starts).toEqual(['ssh-slow'])
+    expect(onFailure).toHaveBeenCalledTimes(1)
+    expect(onFailure).toHaveBeenCalledWith('ssh-slow', expect.any(Error))
+  })
+
   it("frees a hung target's slot at its deadline so later batches still run", async () => {
     vi.useFakeTimers()
     const scheduler = new SshStartupReconnectScheduler(1)
     const starts: string[] = []
     const hungResult = reconnectSshTargetsForRendererStartup({
       targetIds: ['ssh-hung'],
-      budgetMs: 1_000,
+      attemptTimeoutMs: 1_000,
       signal: new AbortController().signal,
       scheduler,
       connect: (targetId) => {
@@ -263,7 +333,7 @@ describe('reconnectSshTargetsForRendererStartup', () => {
 
     const nextResult = reconnectSshTargetsForRendererStartup({
       targetIds: ['ssh-next'],
-      budgetMs: 1_000,
+      attemptTimeoutMs: 1_000,
       signal: new AbortController().signal,
       scheduler,
       connect: async (targetId) => {
@@ -288,7 +358,7 @@ describe('reconnectSshTargetsForRendererStartup', () => {
     const onFailure = vi.fn()
     const resultPromise = reconnectSshTargetsForRendererStartup({
       targetIds: ['ssh-started', 'ssh-queued'],
-      budgetMs: 1_000,
+      attemptTimeoutMs: 1_000,
       signal: abortController.signal,
       scheduler,
       connect: (targetId) => {
@@ -314,44 +384,32 @@ describe('reconnectSshTargetsForRendererStartup', () => {
     expect(onFailure).not.toHaveBeenCalled()
   })
 
-  it('retains capacity for duplicate in-progress rejections until the first budget ends', async () => {
+  it('frees the slot immediately when main already owns the connect', async () => {
     vi.useFakeTimers()
     const scheduler = new SshStartupReconnectScheduler(1)
     const starts: string[] = []
-    const firstResult = reconnectSshTargetsForRendererStartup({
-      targetIds: ['ssh-duplicate'],
-      budgetMs: 1_000,
+    const results = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-duplicate', 'ssh-behind'],
+      attemptTimeoutMs: 1_000,
       signal: new AbortController().signal,
       scheduler,
       connect: async (targetId) => {
         starts.push(targetId)
-        throw new Error('Connection to duplicate host is already in progress')
-      },
-      publishState: vi.fn(),
-      onFailure: vi.fn()
-    })
-
-    await expect(firstResult).resolves.toEqual([
-      { targetId: 'ssh-duplicate', outcome: 'in-progress' }
-    ])
-    const secondResult = reconnectSshTargetsForRendererStartup({
-      targetIds: ['ssh-next'],
-      budgetMs: 2_000,
-      signal: new AbortController().signal,
-      scheduler,
-      connect: async (targetId) => {
-        starts.push(targetId)
+        if (targetId === 'ssh-duplicate') {
+          throw new Error('Connection to duplicate host is already in progress')
+        }
         return stateFor(targetId)
       },
       publishState: vi.fn(),
       onFailure: vi.fn()
     })
 
-    await vi.advanceTimersByTimeAsync(999)
-    expect(starts).toEqual(['ssh-duplicate'])
-    await vi.advanceTimersByTimeAsync(1)
-    await expect(secondResult).resolves.toEqual([{ targetId: 'ssh-next', outcome: 'completed' }])
-    expect(starts).toEqual(['ssh-duplicate', 'ssh-next'])
+    // No timer advance: main owns the duplicate's attempt, so the queue must not wait out a timeout.
+    await expect(results).resolves.toEqual([
+      { targetId: 'ssh-duplicate', outcome: 'in-progress' },
+      { targetId: 'ssh-behind', outcome: 'completed' }
+    ])
+    expect(starts).toEqual(['ssh-duplicate', 'ssh-behind'])
   })
 
   it('keeps an aborted raw attempt in the pool until its connect promise settles', async () => {
@@ -361,7 +419,7 @@ describe('reconnectSshTargetsForRendererStartup', () => {
     const starts: string[] = []
     const firstResult = reconnectSshTargetsForRendererStartup({
       targetIds: ['ssh-old'],
-      budgetMs: 1_000,
+      attemptTimeoutMs: 1_000,
       signal: firstAbort.signal,
       scheduler,
       connect: (targetId) => {
@@ -378,7 +436,7 @@ describe('reconnectSshTargetsForRendererStartup', () => {
 
     const nextResult = reconnectSshTargetsForRendererStartup({
       targetIds: ['ssh-new'],
-      budgetMs: 1_000,
+      attemptTimeoutMs: 1_000,
       signal: new AbortController().signal,
       scheduler,
       connect: async (targetId) => {

--- a/src/renderer/src/startup/ssh-startup-reconnect.test.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect.test.ts
@@ -5,6 +5,7 @@ import {
   reconnectSshTargetForRendererStartup,
   reconnectSshTargetsForRendererStartup,
   resolveSshStartupActiveWorkspaceId,
+  shouldStartBackgroundSshReconnect,
   SshStartupReconnectScheduler
 } from './ssh-startup-reconnect'
 
@@ -138,6 +139,41 @@ describe('partitionSshStartupReconnectTargets', () => {
 })
 
 describe('reconnectSshTargetsForRendererStartup', () => {
+  it('reconnects a healthy background target after a critical target fails', async () => {
+    const scheduler = new SshStartupReconnectScheduler(1)
+    const starts: string[] = []
+    const connect = async (targetId: string): Promise<SshConnectionState> => {
+      starts.push(targetId)
+      if (targetId === 'ssh-critical') {
+        throw new Error('Authentication failed')
+      }
+      return stateFor(targetId)
+    }
+    const reconnect = (targetIds: readonly string[]) =>
+      reconnectSshTargetsForRendererStartup({
+        targetIds,
+        budgetMs: 1_000,
+        signal: new AbortController().signal,
+        scheduler,
+        connect,
+        publishState: vi.fn(),
+        onFailure: vi.fn()
+      })
+
+    const criticalResults = await reconnect(['ssh-critical'])
+    expect(criticalResults).toEqual([{ targetId: 'ssh-critical', outcome: 'failed' }])
+    expect(
+      shouldStartBackgroundSshReconnect({
+        backgroundTargetCount: 1,
+        aborted: false
+      })
+    ).toBe(true)
+    await expect(reconnect(['ssh-background'])).resolves.toEqual([
+      { targetId: 'ssh-background', outcome: 'completed' }
+    ])
+    expect(starts).toEqual(['ssh-critical', 'ssh-background'])
+  })
+
   it('bounds raw concurrent attempts and starts queued targets as slots settle', async () => {
     const scheduler = new SshStartupReconnectScheduler(2)
     const controls = new Map<string, ReturnType<typeof controlledPromise<SshConnectionState>>>()
@@ -203,6 +239,44 @@ describe('reconnectSshTargetsForRendererStartup', () => {
       { targetId: 'ssh-queued', outcome: 'not-started-budget' }
     ])
     expect(starts).toEqual(['ssh-stalled'])
+  })
+
+  it("frees a hung target's slot at its deadline so later batches still run", async () => {
+    vi.useFakeTimers()
+    const scheduler = new SshStartupReconnectScheduler(1)
+    const starts: string[] = []
+    const hungResult = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-hung'],
+      budgetMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler,
+      connect: (targetId) => {
+        starts.push(targetId)
+        return new Promise<SshConnectionState>(() => {})
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await expect(hungResult).resolves.toEqual([{ targetId: 'ssh-hung', outcome: 'timed-out' }])
+
+    const nextResult = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-next'],
+      budgetMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler,
+      connect: async (targetId) => {
+        starts.push(targetId)
+        return stateFor(targetId)
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(nextResult).resolves.toEqual([{ targetId: 'ssh-next', outcome: 'completed' }])
+    expect(starts).toEqual(['ssh-hung', 'ssh-next'])
   })
 
   it('cancels queued results and suppresses late state publication', async () => {
@@ -320,5 +394,28 @@ describe('reconnectSshTargetsForRendererStartup', () => {
     first.resolve(stateFor('ssh-old'))
     await expect(nextResult).resolves.toEqual([{ targetId: 'ssh-new', outcome: 'completed' }])
     expect(starts).toEqual(['ssh-old', 'ssh-new'])
+  })
+})
+
+describe('shouldStartBackgroundSshReconnect', () => {
+  it('requires a background target and a live startup signal', () => {
+    expect(
+      shouldStartBackgroundSshReconnect({
+        backgroundTargetCount: 0,
+        aborted: false
+      })
+    ).toBe(false)
+    expect(
+      shouldStartBackgroundSshReconnect({
+        backgroundTargetCount: 1,
+        aborted: true
+      })
+    ).toBe(false)
+    expect(
+      shouldStartBackgroundSshReconnect({
+        backgroundTargetCount: 1,
+        aborted: false
+      })
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/startup/ssh-startup-reconnect.test.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { SshConnectionState, SshProviderEpoch } from '../../../shared/ssh-types'
-import { reconnectSshTargetForRendererStartup } from './ssh-startup-reconnect'
+import {
+  partitionSshStartupReconnectTargets,
+  reconnectSshTargetForRendererStartup,
+  reconnectSshTargetsForRendererStartup,
+  resolveSshStartupActiveWorkspaceId,
+  SshStartupReconnectScheduler
+} from './ssh-startup-reconnect'
 
 const connectedState: SshConnectionState = {
   targetId: 'ssh-1',
@@ -10,6 +16,24 @@ const connectedState: SshConnectionState = {
   providerEpoch: 'startup-provider-epoch' as SshProviderEpoch,
   connectionGeneration: 41,
   remotePlatform: 'linux'
+}
+
+function stateFor(targetId: string): SshConnectionState {
+  return { ...connectedState, targetId }
+}
+
+function controlledPromise<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
 }
 
 afterEach(() => {
@@ -74,5 +98,227 @@ describe('reconnectSshTargetForRendererStartup', () => {
     await expect(resultPromise).resolves.toEqual({ timedOut: true })
     expect(publishState).not.toHaveBeenCalled()
     expect(onFailure).toHaveBeenCalledWith('ssh-1', expect.any(Error))
+  })
+})
+
+describe('partitionSshStartupReconnectTargets', () => {
+  it('unwraps an active worktree key before connection-owner resolution', () => {
+    expect(
+      resolveSshStartupActiveWorkspaceId({
+        activeWorkspaceKey: 'worktree:repo-1::/remote/project',
+        activeWorktreeId: 'stale-worktree'
+      })
+    ).toBe('repo-1::/remote/project')
+    expect(
+      resolveSshStartupActiveWorkspaceId({
+        activeWorkspaceKey: 'folder:folder-1',
+        activeWorktreeId: null
+      })
+    ).toBe('folder:folder-1')
+  })
+
+  it('prioritizes active targets, then persisted sessions, in stable target order', () => {
+    expect(
+      partitionSshStartupReconnectTargets({
+        targetIds: ['idle-a', 'session-b', 'active-c', 'session-d', 'active-c'],
+        activeTargetIds: ['active-c', 'missing'],
+        activeTabId: 'tab-active',
+        remoteSessionIdsByTabId: {
+          'tab-other': 'ssh:session-b@@pty-1',
+          'tab-active': 'ssh:session-d@@pty-2',
+          malformed: 'relay-pty-without-target',
+          stale: 'ssh:missing@@pty-3'
+        }
+      })
+    ).toEqual({
+      criticalTargetIds: ['active-c', 'session-d'],
+      backgroundTargetIds: ['session-b', 'idle-a']
+    })
+  })
+})
+
+describe('reconnectSshTargetsForRendererStartup', () => {
+  it('bounds raw concurrent attempts and starts queued targets as slots settle', async () => {
+    const scheduler = new SshStartupReconnectScheduler(2)
+    const controls = new Map<string, ReturnType<typeof controlledPromise<SshConnectionState>>>()
+    let active = 0
+    let peak = 0
+    const starts: string[] = []
+    const resultPromise = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-1', 'ssh-2', 'ssh-3', 'ssh-4'],
+      budgetMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler,
+      connect: (targetId) => {
+        starts.push(targetId)
+        active++
+        peak = Math.max(peak, active)
+        const control = controlledPromise<SshConnectionState>()
+        controls.set(targetId, control)
+        return control.promise.finally(() => {
+          active--
+        })
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    await vi.waitFor(() => expect(starts).toEqual(['ssh-1', 'ssh-2']))
+    controls.get('ssh-1')!.resolve(stateFor('ssh-1'))
+    await vi.waitFor(() => expect(starts).toEqual(['ssh-1', 'ssh-2', 'ssh-3']))
+    controls.get('ssh-2')!.resolve(stateFor('ssh-2'))
+    await vi.waitFor(() => expect(starts).toEqual(['ssh-1', 'ssh-2', 'ssh-3', 'ssh-4']))
+    controls.get('ssh-3')!.resolve(stateFor('ssh-3'))
+    controls.get('ssh-4')!.resolve(stateFor('ssh-4'))
+
+    await expect(resultPromise).resolves.toEqual(
+      ['ssh-1', 'ssh-2', 'ssh-3', 'ssh-4'].map((targetId) => ({
+        targetId,
+        outcome: 'completed'
+      }))
+    )
+    expect(peak).toBe(2)
+  })
+
+  it('uses one batch budget and never starts targets still queued at expiry', async () => {
+    vi.useFakeTimers()
+    const starts: string[] = []
+    const resultPromise = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-stalled', 'ssh-queued'],
+      budgetMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler: new SshStartupReconnectScheduler(1),
+      connect: (targetId) => {
+        starts.push(targetId)
+        return new Promise(() => {})
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await expect(resultPromise).resolves.toEqual([
+      { targetId: 'ssh-stalled', outcome: 'timed-out' },
+      { targetId: 'ssh-queued', outcome: 'not-started-budget' }
+    ])
+    expect(starts).toEqual(['ssh-stalled'])
+  })
+
+  it('cancels queued results and suppresses late state publication', async () => {
+    const scheduler = new SshStartupReconnectScheduler(1)
+    const abortController = new AbortController()
+    const first = controlledPromise<SshConnectionState>()
+    const starts: string[] = []
+    const publishState = vi.fn()
+    const onFailure = vi.fn()
+    const resultPromise = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-started', 'ssh-queued'],
+      budgetMs: 1_000,
+      signal: abortController.signal,
+      scheduler,
+      connect: (targetId) => {
+        starts.push(targetId)
+        return first.promise
+      },
+      publishState,
+      onFailure
+    })
+
+    await vi.waitFor(() => expect(starts).toEqual(['ssh-started']))
+    abortController.abort()
+    await expect(resultPromise).resolves.toEqual([
+      { targetId: 'ssh-started', outcome: 'cancelled' },
+      { targetId: 'ssh-queued', outcome: 'cancelled' }
+    ])
+
+    first.resolve(stateFor('ssh-started'))
+    await first.promise
+    await Promise.resolve()
+    expect(starts).toEqual(['ssh-started'])
+    expect(publishState).not.toHaveBeenCalled()
+    expect(onFailure).not.toHaveBeenCalled()
+  })
+
+  it('retains capacity for duplicate in-progress rejections until the first budget ends', async () => {
+    vi.useFakeTimers()
+    const scheduler = new SshStartupReconnectScheduler(1)
+    const starts: string[] = []
+    const firstResult = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-duplicate'],
+      budgetMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler,
+      connect: async (targetId) => {
+        starts.push(targetId)
+        throw new Error('Connection to duplicate host is already in progress')
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    await expect(firstResult).resolves.toEqual([
+      { targetId: 'ssh-duplicate', outcome: 'in-progress' }
+    ])
+    const secondResult = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-next'],
+      budgetMs: 2_000,
+      signal: new AbortController().signal,
+      scheduler,
+      connect: async (targetId) => {
+        starts.push(targetId)
+        return stateFor(targetId)
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(starts).toEqual(['ssh-duplicate'])
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(secondResult).resolves.toEqual([{ targetId: 'ssh-next', outcome: 'completed' }])
+    expect(starts).toEqual(['ssh-duplicate', 'ssh-next'])
+  })
+
+  it('keeps an aborted raw attempt in the pool until its connect promise settles', async () => {
+    const scheduler = new SshStartupReconnectScheduler(1)
+    const firstAbort = new AbortController()
+    const first = controlledPromise<SshConnectionState>()
+    const starts: string[] = []
+    const firstResult = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-old'],
+      budgetMs: 1_000,
+      signal: firstAbort.signal,
+      scheduler,
+      connect: (targetId) => {
+        starts.push(targetId)
+        return first.promise
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+
+    await vi.waitFor(() => expect(starts).toEqual(['ssh-old']))
+    firstAbort.abort()
+    await expect(firstResult).resolves.toEqual([{ targetId: 'ssh-old', outcome: 'cancelled' }])
+
+    const nextResult = reconnectSshTargetsForRendererStartup({
+      targetIds: ['ssh-new'],
+      budgetMs: 1_000,
+      signal: new AbortController().signal,
+      scheduler,
+      connect: async (targetId) => {
+        starts.push(targetId)
+        return stateFor(targetId)
+      },
+      publishState: vi.fn(),
+      onFailure: vi.fn()
+    })
+    await Promise.resolve()
+    expect(starts).toEqual(['ssh-old'])
+
+    first.resolve(stateFor('ssh-old'))
+    await expect(nextResult).resolves.toEqual([{ targetId: 'ssh-new', outcome: 'completed' }])
+    expect(starts).toEqual(['ssh-old', 'ssh-new'])
   })
 })

--- a/src/renderer/src/startup/ssh-startup-reconnect.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect.ts
@@ -1,7 +1,276 @@
 import type { SshConnectionState } from '../../../shared/ssh-types'
+import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
+import { getActiveSidebarWorkspaceId } from '../../../shared/workspace-scope'
+
+export const SSH_STARTUP_RECONNECT_CONCURRENCY = 3
 
 export type SshStartupReconnectResult = {
   timedOut: boolean
+}
+
+export type SshStartupReconnectOutcome =
+  | 'completed'
+  | 'failed'
+  | 'timed-out'
+  | 'in-progress'
+  | 'not-started-budget'
+  | 'cancelled'
+
+export type SshStartupReconnectBatchResult = {
+  targetId: string
+  outcome: SshStartupReconnectOutcome
+}
+
+type ScheduledReconnect = {
+  targetId: string
+  deadline: number
+  signal: AbortSignal
+  connect: () => Promise<SshConnectionState | null>
+  publishState: (state: SshConnectionState) => void
+  onFailure: (error: unknown) => void
+  resolve: (result: SshStartupReconnectBatchResult) => void
+  started: boolean
+  resultSettled: boolean
+  released: boolean
+  holdUntilBudget: boolean
+  budgetTimer: ReturnType<typeof setTimeout> | null
+  removeAbortListener: () => void
+}
+
+function remainingBudgetMs(deadline: number): number {
+  return Math.max(0, deadline - performance.now())
+}
+
+function isConnectAlreadyInProgress(error: unknown): boolean {
+  return error instanceof Error && /Connection to .+ is already in progress/.test(error.message)
+}
+
+export class SshStartupReconnectScheduler {
+  private activeCount = 0
+  private readonly queue: ScheduledReconnect[] = []
+
+  constructor(private readonly concurrency = SSH_STARTUP_RECONNECT_CONCURRENCY) {}
+
+  schedule(args: {
+    targetId: string
+    deadline: number
+    signal: AbortSignal
+    connect: () => Promise<SshConnectionState | null>
+    publishState: (state: SshConnectionState) => void
+    onFailure: (error: unknown) => void
+  }): Promise<SshStartupReconnectBatchResult> {
+    return new Promise((resolve) => {
+      const task: ScheduledReconnect = {
+        ...args,
+        resolve,
+        started: false,
+        resultSettled: false,
+        released: false,
+        holdUntilBudget: false,
+        budgetTimer: null,
+        removeAbortListener: () => {}
+      }
+      const finish = (outcome: SshStartupReconnectOutcome): void => {
+        if (task.resultSettled) {
+          return
+        }
+        task.resultSettled = true
+        task.resolve({ targetId: task.targetId, outcome })
+      }
+      const onAbort = (): void => {
+        if (!task.started) {
+          this.removeQueuedTask(task)
+          this.clearTaskTimer(task)
+          task.removeAbortListener()
+          finish('cancelled')
+          this.drain()
+          return
+        }
+        finish('cancelled')
+      }
+      args.signal.addEventListener('abort', onAbort, { once: true })
+      task.removeAbortListener = () => args.signal.removeEventListener('abort', onAbort)
+
+      if (args.signal.aborted) {
+        onAbort()
+        return
+      }
+      const budgetMs = remainingBudgetMs(args.deadline)
+      if (budgetMs <= 0) {
+        task.removeAbortListener()
+        finish('not-started-budget')
+        return
+      }
+      task.budgetTimer = setTimeout(() => {
+        task.budgetTimer = null
+        if (!task.started) {
+          this.removeQueuedTask(task)
+          task.removeAbortListener()
+          finish('not-started-budget')
+          this.drain()
+          return
+        }
+        if (task.holdUntilBudget) {
+          this.release(task)
+          return
+        }
+        if (!task.resultSettled && !task.signal.aborted) {
+          const error = new Error('SSH reconnect timeout')
+          task.onFailure(error)
+          finish('timed-out')
+        }
+      }, budgetMs)
+      this.queue.push(task)
+      this.drain()
+    })
+  }
+
+  private drain(): void {
+    while (this.activeCount < this.concurrency && this.queue.length > 0) {
+      const task = this.queue.shift()!
+      if (task.signal.aborted || remainingBudgetMs(task.deadline) <= 0) {
+        this.clearTaskTimer(task)
+        task.removeAbortListener()
+        if (!task.resultSettled) {
+          task.resolve({
+            targetId: task.targetId,
+            outcome: task.signal.aborted ? 'cancelled' : 'not-started-budget'
+          })
+          task.resultSettled = true
+        }
+        continue
+      }
+      this.start(task)
+    }
+  }
+
+  private start(task: ScheduledReconnect): void {
+    task.started = true
+    this.activeCount++
+    void Promise.resolve()
+      .then(task.connect)
+      .then(
+        (state) => {
+          if (!task.resultSettled && !task.signal.aborted) {
+            if (state) {
+              task.publishState(state)
+            }
+            task.resultSettled = true
+            task.resolve({ targetId: task.targetId, outcome: 'completed' })
+          }
+          this.release(task)
+        },
+        (error: unknown) => {
+          if (isConnectAlreadyInProgress(error) && remainingBudgetMs(task.deadline) > 0) {
+            task.holdUntilBudget = true
+            if (!task.resultSettled) {
+              task.resultSettled = true
+              task.resolve({ targetId: task.targetId, outcome: 'in-progress' })
+            }
+            return
+          }
+          if (!task.resultSettled && !task.signal.aborted) {
+            task.onFailure(error)
+            task.resultSettled = true
+            task.resolve({ targetId: task.targetId, outcome: 'failed' })
+          }
+          this.release(task)
+        }
+      )
+  }
+
+  private release(task: ScheduledReconnect): void {
+    if (task.released) {
+      return
+    }
+    task.released = true
+    this.clearTaskTimer(task)
+    task.removeAbortListener()
+    this.activeCount--
+    this.drain()
+  }
+
+  private removeQueuedTask(task: ScheduledReconnect): void {
+    const index = this.queue.indexOf(task)
+    if (index >= 0) {
+      this.queue.splice(index, 1)
+    }
+  }
+
+  private clearTaskTimer(task: ScheduledReconnect): void {
+    if (task.budgetTimer) {
+      clearTimeout(task.budgetTimer)
+      task.budgetTimer = null
+    }
+  }
+}
+
+const startupReconnectScheduler = new SshStartupReconnectScheduler()
+
+export function resolveSshStartupActiveWorkspaceId(args: {
+  activeWorkspaceKey: string | null
+  activeWorktreeId: string | null
+}): string | null {
+  return getActiveSidebarWorkspaceId(args.activeWorkspaceKey, args.activeWorktreeId)
+}
+
+export function partitionSshStartupReconnectTargets(args: {
+  targetIds: readonly string[]
+  activeTargetIds: readonly string[]
+  activeTabId: string | null
+  remoteSessionIdsByTabId?: Readonly<Record<string, string>>
+}): { criticalTargetIds: string[]; backgroundTargetIds: string[] } {
+  const targetIds = [...new Set(args.targetIds)]
+  const eligible = new Set(targetIds)
+  const activeTargets = new Set(args.activeTargetIds.filter((id) => eligible.has(id)))
+  const sessionTargets = new Set<string>()
+  for (const [tabId, sessionId] of Object.entries(args.remoteSessionIdsByTabId ?? {})) {
+    const targetId = parseAppSshPtyId(sessionId)?.connectionId
+    if (!targetId || !eligible.has(targetId)) {
+      continue
+    }
+    sessionTargets.add(targetId)
+    if (tabId === args.activeTabId) {
+      activeTargets.add(targetId)
+    }
+  }
+  const criticalTargetIds = targetIds.filter((targetId) => activeTargets.has(targetId))
+  return {
+    criticalTargetIds,
+    backgroundTargetIds: [
+      ...targetIds.filter(
+        (targetId) => !activeTargets.has(targetId) && sessionTargets.has(targetId)
+      ),
+      ...targetIds.filter(
+        (targetId) => !activeTargets.has(targetId) && !sessionTargets.has(targetId)
+      )
+    ]
+  }
+}
+
+export function reconnectSshTargetsForRendererStartup(args: {
+  targetIds: readonly string[]
+  budgetMs: number
+  signal: AbortSignal
+  connect: (targetId: string) => Promise<SshConnectionState | null>
+  publishState: (targetId: string, state: SshConnectionState) => void
+  onFailure: (targetId: string, error: unknown) => void
+  scheduler?: SshStartupReconnectScheduler
+}): Promise<SshStartupReconnectBatchResult[]> {
+  const deadline = performance.now() + args.budgetMs
+  const scheduler = args.scheduler ?? startupReconnectScheduler
+  return Promise.all(
+    args.targetIds.map((targetId) =>
+      scheduler.schedule({
+        targetId,
+        deadline,
+        signal: args.signal,
+        connect: () => args.connect(targetId),
+        publishState: (state) => args.publishState(targetId, state),
+        onFailure: (error) => args.onFailure(targetId, error)
+      })
+    )
+  )
 }
 
 export async function reconnectSshTargetForRendererStartup(args: {
@@ -18,8 +287,6 @@ export async function reconnectSshTargetForRendererStartup(args: {
       timeoutId = setTimeout(() => reject(new Error('SSH reconnect timeout')), timeoutMs)
     })
     const state = await Promise.race([connect(targetId), timeout])
-    // Why: the state-change IPC can trail connect's resolution. Publish the
-    // authoritative result before restored terminals inspect renderer state.
     if (state) {
       publishState(targetId, state)
     }

--- a/src/renderer/src/startup/ssh-startup-reconnect.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect.ts
@@ -4,9 +4,12 @@ import { getActiveSidebarWorkspaceId } from '../../../shared/workspace-scope'
 
 export const SSH_STARTUP_RECONNECT_CONCURRENCY = 3
 
-export type SshStartupReconnectResult = {
-  timedOut: boolean
-}
+/**
+ * Floor on the batch budget a task must still have when it takes a slot. Below this the attempt
+ * would be killed before a connect could plausibly land, so it is skipped as `not-started-budget`
+ * instead of burning a slot and reporting a misleading `timed-out` with a spurious onFailure.
+ */
+const MIN_ATTEMPT_BUDGET_MS = 250
 
 export type SshStartupReconnectOutcome =
   | 'completed'
@@ -30,7 +33,9 @@ export function shouldStartBackgroundSshReconnect(args: {
 
 type ScheduledReconnect = {
   targetId: string
-  deadline: number
+  attemptTimeoutMs: number
+  /** Wall-clock cap on the whole batch, or null to let the queue drain unbounded. */
+  batchDeadline: number | null
   signal: AbortSignal
   connect: () => Promise<SshConnectionState | null>
   publishState: (state: SshConnectionState) => void
@@ -39,8 +44,7 @@ type ScheduledReconnect = {
   started: boolean
   resultSettled: boolean
   released: boolean
-  holdUntilBudget: boolean
-  budgetTimer: ReturnType<typeof setTimeout> | null
+  timer: ReturnType<typeof setTimeout> | null
   removeAbortListener: () => void
 }
 
@@ -60,7 +64,13 @@ export class SshStartupReconnectScheduler {
 
   schedule(args: {
     targetId: string
-    deadline: number
+    /**
+     * Per-attempt cap, counted from the moment the task takes a slot — never from batch start.
+     * With a `batchDeadline` the effective cap is the smaller of the two, so a task that reaches a
+     * slot late gets only the budget the batch has left.
+     */
+    attemptTimeoutMs: number
+    batchDeadline: number | null
     signal: AbortSignal
     connect: () => Promise<SshConnectionState | null>
     publishState: (state: SshConnectionState) => void
@@ -73,27 +83,19 @@ export class SshStartupReconnectScheduler {
         started: false,
         resultSettled: false,
         released: false,
-        holdUntilBudget: false,
-        budgetTimer: null,
+        timer: null,
         removeAbortListener: () => {}
-      }
-      const finish = (outcome: SshStartupReconnectOutcome): void => {
-        if (task.resultSettled) {
-          return
-        }
-        task.resultSettled = true
-        task.resolve({ targetId: task.targetId, outcome })
       }
       const onAbort = (): void => {
         if (!task.started) {
           this.removeQueuedTask(task)
           this.clearTaskTimer(task)
           task.removeAbortListener()
-          finish('cancelled')
+          this.finish(task, 'cancelled')
           this.drain()
           return
         }
-        finish('cancelled')
+        this.finish(task, 'cancelled')
       }
       args.signal.addEventListener('abort', onAbort, { once: true })
       task.removeAbortListener = () => args.signal.removeEventListener('abort', onAbort)
@@ -102,34 +104,24 @@ export class SshStartupReconnectScheduler {
         onAbort()
         return
       }
-      const budgetMs = remainingBudgetMs(args.deadline)
-      if (budgetMs <= 0) {
-        task.removeAbortListener()
-        finish('not-started-budget')
-        return
-      }
-      task.budgetTimer = setTimeout(() => {
-        task.budgetTimer = null
-        if (!task.started) {
+      if (task.batchDeadline !== null) {
+        const queueBudgetMs = remainingBudgetMs(task.batchDeadline)
+        if (queueBudgetMs < MIN_ATTEMPT_BUDGET_MS) {
+          task.removeAbortListener()
+          this.finish(task, 'not-started-budget')
+          return
+        }
+        // Why: only the wait for a slot is batch-bounded. Once started, the task owns its own
+        // timeout — otherwise a few slow front-of-queue connects would expire every target behind
+        // them without ever calling connect, silently skipping those hosts for the session.
+        task.timer = setTimeout(() => {
+          task.timer = null
           this.removeQueuedTask(task)
           task.removeAbortListener()
-          finish('not-started-budget')
+          this.finish(task, 'not-started-budget')
           this.drain()
-          return
-        }
-        if (task.holdUntilBudget) {
-          this.release(task)
-          return
-        }
-        if (!task.resultSettled && !task.signal.aborted) {
-          const error = new Error('SSH reconnect timeout')
-          task.onFailure(error)
-          finish('timed-out')
-        }
-        // Why: connect gets no abort signal, so a hung IPC would hold its slot forever and
-        // three of them would starve every later batch. The deadline caps the hold instead.
-        this.release(task)
-      }, budgetMs)
+        }, queueBudgetMs - MIN_ATTEMPT_BUDGET_MS)
+      }
       this.queue.push(task)
       this.drain()
     })
@@ -138,16 +130,12 @@ export class SshStartupReconnectScheduler {
   private drain(): void {
     while (this.activeCount < this.concurrency && this.queue.length > 0) {
       const task = this.queue.shift()!
-      if (task.signal.aborted || remainingBudgetMs(task.deadline) <= 0) {
+      const expired =
+        task.batchDeadline !== null && remainingBudgetMs(task.batchDeadline) < MIN_ATTEMPT_BUDGET_MS
+      if (task.signal.aborted || expired) {
         this.clearTaskTimer(task)
         task.removeAbortListener()
-        if (!task.resultSettled) {
-          task.resolve({
-            targetId: task.targetId,
-            outcome: task.signal.aborted ? 'cancelled' : 'not-started-budget'
-          })
-          task.resultSettled = true
-        }
+        this.finish(task, task.signal.aborted ? 'cancelled' : 'not-started-budget')
         continue
       }
       this.start(task)
@@ -157,6 +145,24 @@ export class SshStartupReconnectScheduler {
   private start(task: ScheduledReconnect): void {
     task.started = true
     this.activeCount++
+    this.clearTaskTimer(task)
+    // A batch deadline still caps a started attempt: the critical batch is awaited on the startup
+    // path, so it must return within its budget no matter when the task reached a slot.
+    const timeoutMs =
+      task.batchDeadline === null
+        ? task.attemptTimeoutMs
+        : Math.min(task.attemptTimeoutMs, remainingBudgetMs(task.batchDeadline))
+    task.timer = setTimeout(() => {
+      task.timer = null
+      if (!task.resultSettled && !task.signal.aborted) {
+        const error = new Error('SSH reconnect timeout')
+        task.onFailure(error)
+        this.finish(task, 'timed-out')
+      }
+      // Why: connect gets no abort signal, so a hung IPC would hold its slot forever and
+      // three of them would starve every later batch. The timeout caps the hold instead.
+      this.release(task)
+    }, timeoutMs)
     void Promise.resolve()
       .then(task.connect)
       .then(
@@ -165,28 +171,34 @@ export class SshStartupReconnectScheduler {
             if (state) {
               task.publishState(state)
             }
-            task.resultSettled = true
-            task.resolve({ targetId: task.targetId, outcome: 'completed' })
+            this.finish(task, 'completed')
           }
           this.release(task)
         },
         (error: unknown) => {
-          if (isConnectAlreadyInProgress(error) && remainingBudgetMs(task.deadline) > 0) {
-            task.holdUntilBudget = true
-            if (!task.resultSettled) {
-              task.resultSettled = true
-              task.resolve({ targetId: task.targetId, outcome: 'in-progress' })
-            }
+          if (isConnectAlreadyInProgress(error)) {
+            // Why: main already owns an attempt for this target and will publish its result via
+            // the state-change push, so this task has no work left. Holding the slot until the
+            // timeout would idle up to `concurrency` slots and starve the rest of the queue.
+            this.finish(task, 'in-progress')
+            this.release(task)
             return
           }
           if (!task.resultSettled && !task.signal.aborted) {
             task.onFailure(error)
-            task.resultSettled = true
-            task.resolve({ targetId: task.targetId, outcome: 'failed' })
+            this.finish(task, 'failed')
           }
           this.release(task)
         }
       )
+  }
+
+  private finish(task: ScheduledReconnect, outcome: SshStartupReconnectOutcome): void {
+    if (task.resultSettled) {
+      return
+    }
+    task.resultSettled = true
+    task.resolve({ targetId: task.targetId, outcome })
   }
 
   private release(task: ScheduledReconnect): void {
@@ -208,9 +220,9 @@ export class SshStartupReconnectScheduler {
   }
 
   private clearTaskTimer(task: ScheduledReconnect): void {
-    if (task.budgetTimer) {
-      clearTimeout(task.budgetTimer)
-      task.budgetTimer = null
+    if (task.timer) {
+      clearTimeout(task.timer)
+      task.timer = null
     }
   }
 }
@@ -228,21 +240,34 @@ export function partitionSshStartupReconnectTargets(args: {
   targetIds: readonly string[]
   activeTargetIds: readonly string[]
   activeTabId: string | null
+  /**
+   * SSH pty ids owned by the active workspace's tabs. Why: connection-owner resolution returns
+   * `undefined` when the workspace's repo is missing from the local catalog, and folder workspaces
+   * never key `remoteSessionIdsByTabId` at all (it is built from repo → connection), so the active
+   * host would fall through to background. A tab's own pty id names the target either way.
+   */
+  activeWorkspaceSessionIds?: readonly string[]
   remoteSessionIdsByTabId?: Readonly<Record<string, string>>
 }): { criticalTargetIds: string[]; backgroundTargetIds: string[] } {
   const targetIds = [...new Set(args.targetIds)]
   const eligible = new Set(targetIds)
   const activeTargets = new Set(args.activeTargetIds.filter((id) => eligible.has(id)))
   const sessionTargets = new Set<string>()
-  for (const [tabId, sessionId] of Object.entries(args.remoteSessionIdsByTabId ?? {})) {
+  const addSessionTarget = (sessionId: string, elevate: boolean): void => {
     const targetId = parseAppSshPtyId(sessionId)?.connectionId
     if (!targetId || !eligible.has(targetId)) {
-      continue
+      return
     }
     sessionTargets.add(targetId)
-    if (tabId === args.activeTabId) {
+    if (elevate) {
       activeTargets.add(targetId)
     }
+  }
+  for (const [tabId, sessionId] of Object.entries(args.remoteSessionIdsByTabId ?? {})) {
+    addSessionTarget(sessionId, tabId === args.activeTabId)
+  }
+  for (const sessionId of args.activeWorkspaceSessionIds ?? []) {
+    addSessionTarget(sessionId, true)
   }
   const criticalTargetIds = targetIds.filter((targetId) => activeTargets.has(targetId))
   return {
@@ -260,20 +285,33 @@ export function partitionSshStartupReconnectTargets(args: {
 
 export function reconnectSshTargetsForRendererStartup(args: {
   targetIds: readonly string[]
-  budgetMs: number
+  /**
+   * Cap on a single connect once it holds a slot. When `batchBudgetMs` is set, the attempt is
+   * capped at whichever of the two expires first, so a full per-host window is only guaranteed for
+   * batches whose budget exceeds it — today, just the unbudgeted background batch.
+   */
+  attemptTimeoutMs: number
+  /**
+   * Cap on the whole batch, for the critical batch that startup awaits. Omit for fire-and-forget
+   * batches: a shared batch cap plus bounded concurrency expires queued hosts without ever dialing
+   * them, so a background host would silently lose its startup attempt entirely.
+   */
+  batchBudgetMs?: number
   signal: AbortSignal
   connect: (targetId: string) => Promise<SshConnectionState | null>
   publishState: (targetId: string, state: SshConnectionState) => void
   onFailure: (targetId: string, error: unknown) => void
   scheduler?: SshStartupReconnectScheduler
 }): Promise<SshStartupReconnectBatchResult[]> {
-  const deadline = performance.now() + args.budgetMs
+  const batchDeadline =
+    args.batchBudgetMs === undefined ? null : performance.now() + args.batchBudgetMs
   const scheduler = args.scheduler ?? startupReconnectScheduler
   return Promise.all(
     args.targetIds.map((targetId) =>
       scheduler.schedule({
         targetId,
-        deadline,
+        attemptTimeoutMs: args.attemptTimeoutMs,
+        batchDeadline,
         signal: args.signal,
         connect: () => args.connect(targetId),
         publishState: (state) => args.publishState(targetId, state),
@@ -281,34 +319,4 @@ export function reconnectSshTargetsForRendererStartup(args: {
       })
     )
   )
-}
-
-export async function reconnectSshTargetForRendererStartup(args: {
-  targetId: string
-  timeoutMs: number
-  connect: (targetId: string) => Promise<SshConnectionState | null>
-  publishState: (targetId: string, state: SshConnectionState) => void
-  onFailure: (targetId: string, error: unknown) => void
-}): Promise<SshStartupReconnectResult> {
-  const { targetId, timeoutMs, connect, publishState, onFailure } = args
-  let timeoutId: ReturnType<typeof setTimeout> | null = null
-  try {
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timeoutId = setTimeout(() => reject(new Error('SSH reconnect timeout')), timeoutMs)
-    })
-    const state = await Promise.race([connect(targetId), timeout])
-    if (state) {
-      publishState(targetId, state)
-    }
-    return { timedOut: false }
-  } catch (error) {
-    onFailure(targetId, error)
-    return {
-      timedOut: error instanceof Error && error.message === 'SSH reconnect timeout'
-    }
-  } finally {
-    if (timeoutId !== null) {
-      clearTimeout(timeoutId)
-    }
-  }
 }

--- a/src/renderer/src/startup/ssh-startup-reconnect.ts
+++ b/src/renderer/src/startup/ssh-startup-reconnect.ts
@@ -21,6 +21,13 @@ export type SshStartupReconnectBatchResult = {
   outcome: SshStartupReconnectOutcome
 }
 
+export function shouldStartBackgroundSshReconnect(args: {
+  backgroundTargetCount: number
+  aborted: boolean
+}): boolean {
+  return !args.aborted && args.backgroundTargetCount > 0
+}
+
 type ScheduledReconnect = {
   targetId: string
   deadline: number
@@ -119,6 +126,9 @@ export class SshStartupReconnectScheduler {
           task.onFailure(error)
           finish('timed-out')
         }
+        // Why: connect gets no abort signal, so a hung IPC would hold its slot forever and
+        // three of them would starve every later batch. The deadline caps the hold instead.
+        this.release(task)
       }, budgetMs)
       this.queue.push(task)
       this.drain()

--- a/src/renderer/src/store/slices/ssh.test.ts
+++ b/src/renderer/src/store/slices/ssh.test.ts
@@ -499,4 +499,53 @@ describe('createSshSlice', () => {
     expect(state.sshCredentialQueue).toBe(sshCredentialQueue)
     expect(state.deferredSshSessionIdsByTabId).toBe(deferredSshSessionIdsByTabId)
   })
+
+  it('releases the startup deferred gate once a target reports connected', () => {
+    const store = createTestStore()
+    store.setState({ deferredSshReconnectTargets: ['ssh-1', 'ssh-2'] })
+
+    store.getState().setSshConnectionState('ssh-1', {
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+
+    expect(store.getState().deferredSshReconnectTargets).toEqual(['ssh-2'])
+  })
+
+  it('releases the gate on a duplicate connected report from main', () => {
+    // Why: the startup batch can lose its own attempt (timeout, in-progress rejection) while main's
+    // connect still lands. That push carries state the store already holds, so the equality
+    // short-circuit must not skip the gate reconciliation.
+    const store = createTestStore()
+    const connected = {
+      targetId: 'ssh-1',
+      status: 'connected' as const,
+      error: null,
+      reconnectAttempt: 0
+    }
+    store.setState({
+      sshConnectionStates: new Map([['ssh-1', connected]]),
+      deferredSshReconnectTargets: ['ssh-1']
+    })
+
+    store.getState().setSshConnectionState('ssh-1', { ...connected })
+
+    expect(store.getState().deferredSshReconnectTargets).toEqual([])
+  })
+
+  it('keeps the gate closed while a target is still down', () => {
+    const store = createTestStore()
+    store.setState({ deferredSshReconnectTargets: ['ssh-1'] })
+
+    store.getState().setSshConnectionState('ssh-1', {
+      targetId: 'ssh-1',
+      status: 'connecting',
+      error: null,
+      reconnectAttempt: 1
+    })
+
+    expect(store.getState().deferredSshReconnectTargets).toEqual(['ssh-1'])
+  })
 })

--- a/src/renderer/src/store/slices/ssh.ts
+++ b/src/renderer/src/store/slices/ssh.ts
@@ -96,10 +96,21 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
 
   setSshConnectionState: (targetId, state) =>
     set((s) => {
+      // Why: the startup deferred gate must not outlive the connection it waits for. Reconcile on
+      // every connected report, including a duplicate one — the batch that seeded the gate can lose
+      // its own attempt (timeout, in-progress rejection) while main's connect still lands here.
+      const deferredPatch =
+        state.status === 'connected' && s.deferredSshReconnectTargets.includes(targetId)
+          ? {
+              deferredSshReconnectTargets: s.deferredSshReconnectTargets.filter(
+                (id) => id !== targetId
+              )
+            }
+          : null
       const next = new Map(s.sshConnectionStates)
       const previous = next.get(targetId)
       if (sshConnectionStatesEqual(previous, state)) {
-        return s
+        return deferredPatch ?? s
       }
       advanceLocalSshTargetConnectionGeneration(targetId)
       next.set(targetId, state)
@@ -110,6 +121,7 @@ export const createSshSlice: StateCreator<AppState, [], [], SshSlice> = (set) =>
         delete blockedConnections[targetId]
       }
       return {
+        ...deferredPatch,
         sshConnectionStates: next,
         sshConnectedGeneration: didReconnect
           ? s.sshConnectedGeneration + 1


### PR DESCRIPTION
## Summary

- Bound renderer startup SSH reconnects at concurrency=3, prioritizing the active tab and hydrated active workspace connection, then persisted remote-session targets; unrelated targets are deferred and background reconnects start only after tier 1 completes.
- Added visible git-common polling cadence of 2s, backing off to 10s after 3 unchanged polls. A monotonic 30s backstop, visibility-resume forced scan/reset, and native macOS linked-worktree activity reset keep detection bounded and responsive.
- Added transient baseline recovery and narrow missing-path handling, while preserving fast retries for transient filesystem failures. The implementation is scoped for macOS, Linux, Windows, WSL, SSH hosts, and folder workspaces.

## Validation

- `pnpm run typecheck`
- `pnpm exec vitest run src/renderer/src/startup/ssh-startup-reconnect.test.ts src/main/ipc/worktree-base-directory-poller.test.ts src/main/ipc/worktree-git-common-polling-cadence.test.ts src/main/ipc/worktree-git-common-watch.test.ts`

Result: 4 files passed, 57 tests passed.

## Release scan

- `/private/tmp/prod-release-worker-reports/FINAL.md` — release summary and tracked local/SSH and visible-idle polling risks.
- `/private/tmp/prod-release-worker-reports/perf-codex-original-seven.md` — startup SSH finding: eager reconnects launched together without aggregate concurrency; the reviewed fix adds bounded shared scheduling and active-session priority.
- `/private/tmp/prod-release-worker-reports/perf-grok2.md` — visible-idle polling finding: git-common structural stats ran every 2s while visible; the reviewed fix adds idle backoff with a monotonic backstop.

Permanent evidence:

- https://github.com/stablyai/orca/blob/c06bf64b4873a3040045aa0482be3ba85bf92559/src/renderer/src/App.tsx
- https://github.com/stablyai/orca/blob/c06bf64b4873a3040045aa0482be3ba85bf92559/src/main/ipc/worktree-git-common-polling.ts