### PR TITLE
fix(cmd-j): focus the destination workspace's own terminal after a jump

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -38,6 +38,7 @@ import StatusIndicator from '@/components/sidebar/StatusIndicator'
 import { cn } from '@/lib/utils'
 import { getWorktreeStatus, getWorktreeStatusLabel } from '@/lib/worktree-status'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { queueWorkspaceActivationTerminalFocus } from '@/lib/workspace-activation-terminal-focus'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import {
   getWorktreePaletteSearchScope,
@@ -1249,12 +1250,16 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         )
         return
       }
-      activateAndRevealWorktree(worktreeId)
+      const activation = activateAndRevealWorktree(worktreeId)
       recordFeatureInteraction('cmd-j-workspace-open')
       skipRestoreFocusRef.current = true
       closeModal()
       setSelectedItemId('')
-      focusFallbackSurface()
+      // Why: #9939 — the unscoped fallback grabs the first terminal in the document, which is
+      // often the worktree we just left, now hidden. Focus the destination's own tab instead.
+      if (!queueWorkspaceActivationTerminalFocus(worktreeId, activation)) {
+        focusFallbackSurface()
+      }
     },
     [closeModal, focusFallbackSurface, recordFeatureInteraction]
   )
@@ -1410,7 +1415,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         return
       }
       if (previousWorktreeIdRef.current) {
-        focusFallbackSurface()
+        // Why: #9939 — sidebar reveal keeps the same worktree, so restore the exact element the
+        // user came from rather than the first terminal in the document.
+        focusFallbackSurface(previousFocusElementRef.current)
       }
     },
     [
@@ -1481,7 +1488,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       const activeMatch = matches.find((w) => w.repoId === state.activeRepoId) ?? matches[0]
       if (activeMatch) {
         closeModal()
-        activateAndRevealWorktree(activeMatch.id)
+        // Why: #9939 — jumping to an already-open workspace must focus its own terminal.
+        const activation = activateAndRevealWorktree(activeMatch.id)
+        queueWorkspaceActivationTerminalFocus(activeMatch.id, activation)
         recordFeatureInteraction('cmd-j-workspace-open')
         return
       }
@@ -1508,7 +1517,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       const activeMatch = matches.find((w) => w.repoId === state.activeRepoId) ?? matches[0]
       if (activeMatch) {
         closeModal()
-        activateAndRevealWorktree(activeMatch.id)
+        // Why: #9939 — jumping to an already-open workspace must focus its own terminal.
+        const activation = activateAndRevealWorktree(activeMatch.id)
+        queueWorkspaceActivationTerminalFocus(activeMatch.id, activation)
         recordFeatureInteraction('cmd-j-workspace-open')
         return
       }

--- a/src/renderer/src/components/cmd-j/palette-activation-focus-routing.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-activation-focus-routing.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Why: happy-dom does not reproduce Chromium's display:none focus no-op, so the #9939 regression
+// is invisible to behavioral tests. Pin the routing decision at the source level instead.
+function paletteSource(): string {
+  return readFileSync(join(__dirname, '..', 'WorktreeJumpPalette.tsx'), 'utf8')
+}
+
+function sourceBetween(source: string, startPattern: string, endPattern: string): string {
+  const start = source.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('Cmd+J activation focus routing (#9939)', () => {
+  it('routes worktree selection through the scoped helper before any unscoped fallback', () => {
+    const handler = sourceBetween(
+      paletteSource(),
+      'const handleSelectWorktree = useCallback',
+      'const handleSelectBrowserPage'
+    )
+
+    expect(handler).toContain('queueWorkspaceActivationTerminalFocus(worktreeId, activation)')
+    // The fallback must be reachable only when the helper declines the destination.
+    expect(handler).toMatch(
+      /if \(!queueWorkspaceActivationTerminalFocus\(worktreeId, activation\)\) \{\s*focusFallbackSurface\(\)\s*\}/
+    )
+    // An unconditional fallback is the exact shape of the original bug, so the only bare call
+    // allowed is the guarded one inside the if-block above.
+    expect(handler.match(/focusFallbackSurface\(\)/g)?.length).toBe(1)
+  })
+
+  it('restores the pre-palette element for project targets instead of the first terminal found', () => {
+    const handler = sourceBetween(
+      paletteSource(),
+      'const handleSelectProjectTarget = useCallback',
+      'const handleSelectItem = useCallback'
+    )
+
+    expect(handler).toContain('focusFallbackSurface(previousFocusElementRef.current)')
+    expect(handler).not.toMatch(/focusFallbackSurface\(\)/)
+  })
+
+  it('focuses the destination workspace when jumping to an already-open issue match', () => {
+    const source = paletteSource()
+    const activationCalls =
+      source.match(/const activation = activateAndRevealWorktree\(activeMatch\.id\)/g)?.length ?? 0
+    // Both issue-number match paths (PR and issue lookup) must focus the destination.
+    expect(activationCalls).toBe(2)
+    expect(
+      source.match(/queueWorkspaceActivationTerminalFocus\(activeMatch\.id, activation\)/g)?.length
+    ).toBe(activationCalls)
+  })
+})

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -144,7 +144,7 @@ import {
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
-import { queueNewWorkspaceTerminalFocus } from '@/lib/new-workspace-terminal-focus'
+import { queueWorkspaceActivationTerminalFocus } from '@/lib/workspace-activation-terminal-focus'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 import { getSuggestedCreatureName } from '@/components/sidebar/worktree-name-suggestions'
 import type { SmartWorkspaceNameSelection } from '@/components/new-workspace/SmartWorkspaceNameField'
@@ -3611,7 +3611,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         clearNewWorkspaceDraft()
       }
       onCreated?.()
-      queueNewWorkspaceTerminalFocus(worktree.id, activation)
+      queueWorkspaceActivationTerminalFocus(worktree.id, activation)
     } catch (error) {
       const formattedError = formatWorkspaceCreateError(error)
       setCreateError(formattedError)

--- a/src/renderer/src/lib/workspace-activation-terminal-focus.test.ts
+++ b/src/renderer/src/lib/workspace-activation-terminal-focus.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/store', () => ({
   }
 }))
 
-import { queueNewWorkspaceTerminalFocus } from './new-workspace-terminal-focus'
+import { queueWorkspaceActivationTerminalFocus } from './workspace-activation-terminal-focus'
 
 type FocusState = {
   activeWorktreeId: string | null
@@ -39,7 +39,7 @@ function flushFrame(): void {
   frame?.()
 }
 
-describe('queueNewWorkspaceTerminalFocus', () => {
+describe('queueWorkspaceActivationTerminalFocus', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     pendingFrame = null
@@ -58,7 +58,7 @@ describe('queueNewWorkspaceTerminalFocus', () => {
       activeTabId: 'tab-1'
     })
 
-    queueNewWorkspaceTerminalFocus('wt-1', { primaryTabId: 'tab-1' })
+    queueWorkspaceActivationTerminalFocus('wt-1', { primaryTabId: 'tab-1' })
 
     expect(focusRuntimeTerminalSurfaceMock).not.toHaveBeenCalled()
     flushFrame()
@@ -75,7 +75,7 @@ describe('queueNewWorkspaceTerminalFocus', () => {
       activeTabId: 'tab-adopted'
     })
 
-    queueNewWorkspaceTerminalFocus('wt-1', { primaryTabId: null })
+    queueWorkspaceActivationTerminalFocus('wt-1', { primaryTabId: null })
     flushFrame()
 
     expect(focusRuntimeTerminalSurfaceMock).toHaveBeenCalledWith('tab-adopted')
@@ -91,11 +91,49 @@ describe('queueNewWorkspaceTerminalFocus', () => {
       activeTabId: 'tab-1'
     })
 
-    queueNewWorkspaceTerminalFocus('wt-1', { primaryTabId: 'tab-1' })
+    queueWorkspaceActivationTerminalFocus('wt-1', { primaryTabId: 'tab-1' })
     flushFrame()
 
     expect(focusRuntimeTerminalSurfaceMock).toHaveBeenCalledWith('tab-1')
     expect(focusTerminalTabSurfaceMock).not.toHaveBeenCalled()
+  })
+
+  // Why: #9939 — the return value is what stops the palette from running its whole-document
+  // fallback, which would grab the worktree the user just left, now mounted but hidden.
+  it('reports that it claimed focus for a terminal destination', () => {
+    setFocusState({
+      activeWorktreeId: 'wt-1',
+      activeView: 'terminal',
+      activeTabType: 'terminal',
+      activeTabId: 'tab-adopted'
+    })
+
+    expect(queueWorkspaceActivationTerminalFocus('wt-1', { primaryTabId: null })).toBe(true)
+  })
+
+  it('declines a destination whose restored surface is not a terminal', () => {
+    setFocusState({
+      activeWorktreeId: 'wt-1',
+      activeView: 'terminal',
+      activeTabType: 'browser',
+      activeTabId: 'tab-adopted'
+    })
+
+    expect(queueWorkspaceActivationTerminalFocus('wt-1', { primaryTabId: null })).toBe(false)
+    flushFrame()
+    expect(focusRuntimeTerminalSurfaceMock).not.toHaveBeenCalled()
+    expect(focusTerminalTabSurfaceMock).not.toHaveBeenCalled()
+  })
+
+  it('declines a destination that has no terminal tab yet', () => {
+    setFocusState({
+      activeWorktreeId: 'wt-1',
+      activeView: 'terminal',
+      activeTabType: 'terminal',
+      activeTabId: null
+    })
+
+    expect(queueWorkspaceActivationTerminalFocus('wt-1', { primaryTabId: null })).toBe(false)
   })
 
   it('does not steal focus if the user leaves the created workspace first', () => {
@@ -107,7 +145,7 @@ describe('queueNewWorkspaceTerminalFocus', () => {
     }
     setFocusState(state)
 
-    queueNewWorkspaceTerminalFocus('wt-1', { primaryTabId: 'tab-1' })
+    queueWorkspaceActivationTerminalFocus('wt-1', { primaryTabId: 'tab-1' })
     state.activeWorktreeId = 'wt-2'
     flushFrame()
 

--- a/src/renderer/src/lib/workspace-activation-terminal-focus.ts
+++ b/src/renderer/src/lib/workspace-activation-terminal-focus.ts
@@ -3,7 +3,7 @@ import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { focusRuntimeTerminalSurface } from '@/runtime/sync-runtime-graph'
 import type { ActivateAndRevealResult } from '@/lib/worktree-activation'
 
-function resolveCreatedWorkspaceTerminalTabId(
+function resolveActivatedWorkspaceTerminalTabId(
   worktreeId: string,
   activation: ActivateAndRevealResult | false
 ): string | null {
@@ -21,13 +21,15 @@ function resolveCreatedWorkspaceTerminalTabId(
   return state.activeTabId
 }
 
-export function queueNewWorkspaceTerminalFocus(
+// Why: returns false when the destination's restored surface is not a terminal, so callers can
+// fall back instead of focusing an unrelated worktree's mounted-but-hidden terminal (#9939).
+export function queueWorkspaceActivationTerminalFocus(
   worktreeId: string,
   activation: ActivateAndRevealResult | false
-): void {
-  const tabId = resolveCreatedWorkspaceTerminalTabId(worktreeId, activation)
+): boolean {
+  const tabId = resolveActivatedWorkspaceTerminalTabId(worktreeId, activation)
   if (!tabId) {
-    return
+    return false
   }
 
   requestAnimationFrame(() => {
@@ -48,4 +50,5 @@ export function queueNewWorkspaceTerminalFocus(
       focusTerminalTabSurface(tabId)
     }
   })
+  return true
 }

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -57,8 +57,8 @@ vi.mock('@/lib/worktree-activation', () => ({
   ensureWorktreeHasInitialTerminal: vi.fn()
 }))
 
-vi.mock('@/lib/new-workspace-terminal-focus', () => ({
-  queueNewWorkspaceTerminalFocus: vi.fn()
+vi.mock('@/lib/workspace-activation-terminal-focus', () => ({
+  queueWorkspaceActivationTerminalFocus: vi.fn()
 }))
 
 vi.mock('@/lib/new-workspace', () => ({
@@ -80,7 +80,7 @@ import {
   activateAndRevealWorktree,
   ensureWorktreeHasInitialTerminal
 } from '@/lib/worktree-activation'
-import { queueNewWorkspaceTerminalFocus } from '@/lib/new-workspace-terminal-focus'
+import { queueWorkspaceActivationTerminalFocus } from '@/lib/workspace-activation-terminal-focus'
 import {
   beginBackgroundWorktreePreparation,
   continueBackgroundWorktreeCreation,
@@ -498,7 +498,7 @@ describe('staged background worktree creation', () => {
       undefined,
       { activateCreatedTabs: false }
     )
-    expect(queueNewWorkspaceTerminalFocus).not.toHaveBeenCalled()
+    expect(queueWorkspaceActivationTerminalFocus).not.toHaveBeenCalled()
     expect(store.removePendingWorktreeCreation).toHaveBeenCalledWith('creation-1', {
       cleanupVm: false
     })

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -8,7 +8,7 @@ import {
   type WorktreeStartupPayload
 } from '@/lib/worktree-activation'
 import { ensureAgentStartupInTerminal } from '@/lib/new-workspace'
-import { queueNewWorkspaceTerminalFocus } from '@/lib/new-workspace-terminal-focus'
+import { queueWorkspaceActivationTerminalFocus } from '@/lib/workspace-activation-terminal-focus'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   attachEphemeralVmRuntimeToWorkspace,
@@ -273,7 +273,7 @@ async function executeWorktreeCreation(
     })
   }
   if (shouldActivateOnCompletion && !preparedRequest.suppressTerminalFocusOnCompletion) {
-    queueNewWorkspaceTerminalFocus(worktree.id, activation)
+    queueWorkspaceActivationTerminalFocus(worktree.id, activation)
   }
 
   // Why: awaiting the note IPC before the swap would add a visible round-trip to


### PR DESCRIPTION
Fixes #9939

## What's broken

Switch workspace with `Cmd+J` and the keyboard goes nowhere. You have to click the terminal before you can type. @yanghoonkim: *"really need it!!!!!!"*

## ELI5

Orca keeps every workspace you've visited alive in the background and just *hides* the ones you're not looking at. When you jumped to a new workspace, the code said "focus the first terminal you can find on the page" — and the first one it found was usually the workspace you just **left**, which is now hidden.

Focusing a hidden element in Chromium doesn't throw an error. It doesn't do anything at all. So the keyboard was left attached to nothing, silently.

The fix: ask the store which tab the destination workspace actually restored, and focus *that specific tab*, instead of grabbing whatever terminal happens to come first in the document.

## Root cause

`Terminal.tsx:2136-2145` gives inactive worktrees the `hidden` class while keeping them mounted. `handleSelectWorktree` called `focusFallbackSurface()`, which resolves through `palette-focus-restore-target.ts:13` — a bare `document.querySelector('.xterm-helper-textarea')` with **no worktree or tab-type scoping at all**.

`.focus()` on a `display:none` element is a silent no-op in Chromium: no error, no focus, `activeElement` stays `document.body`.

The sibling handlers in the same file already did this correctly — `handleSelectBrowserPage` dispatches a scoped `requestBrowserFocus({ pageId })`. Only the plain worktree-row path fell through to the unscoped query.

## Fix proof

Measured in **real Chromium** (Playwright, Chromium 147) — not happy-dom, which does *not* replicate the `display:none` no-op and would have shown a false pass:

```json
{ "before": { "picked": "background",  "activeElementIsBody": true,  "focusReachedATerminal": false },
  "after":  { "picked": "destination", "activeElementIsBody": false, "focusReachedATerminal": true  } }
```

![#9939 before/after](https://raw.githubusercontent.com/stablyai/orca/evidence/9939-cmdj-terminal-focus/evidence/9939-cmdj-focus.png)

## Proof of no regressions

- **3,045 tests / 334 files** pass across `src/renderer/src/lib/` and `src/renderer/src/components/cmd-j/`
- `pnpm typecheck` clean, `oxlint` clean
- **Verified the riskiest assumption independently**: read `worktrees.ts:4509-4745` and confirmed `setActiveWorktree` commits via a *synchronous* Zustand `set()`, so reading the store immediately after activation is not observing stale state. Both reviewers confirmed this separately.
- **Creation flows are byte-identical.** The helper rename (`new-workspace-terminal-focus` → `workspace-activation-terminal-focus`) adds only a `return` statement; both existing callers ignore it.

### Mutation testing

Two independent reviewers (GPT-5.6-sol + Fable) found the helper well-pinned but the **call-site wiring completely unpinned** — reverting to the original bug passed all **10,140** component tests. happy-dom can't see this class of bug, so the added tests use the repo's existing source-boundary pattern (`feature-interaction-writer-boundaries.test.ts`), pinning *which API the handler selects* rather than who ended up focused.

| Mutation | Before | After |
|---|---|---|
| Full revert to bare `focusFallbackSurface()` | SURVIVED | **KILLED** |
| Ignore helper return, always fall back | SURVIVED | **KILLED** |
| Project-target reverts to unscoped query | SURVIVED | **KILLED** |
| Helper `return false` → `return true` | KILLED | KILLED |
| Drop `activeTabType !== 'terminal'` guard | KILLED | KILLED |
| Drop `activeWorktreeId` race guard | KILLED | KILLED |

**Review loop: 2 rounds to clean** (round 1 GPT + Fable → both NON-BLOCKING with a shared coverage finding; round 2 closed it).

## Trade-offs / known limits

Stated plainly rather than claimed away:

1. **~1 frame focus-steal window.** The rAF callback validates store state but not whether another element claimed focus in the meantime. Deliberately clicking a rename input within one frame of the jump could lose focus to the terminal. Both reviewers rated this non-blocking — the user's explicit intent was to jump to that terminal.
2. **Non-terminal destinations still use the old fallback.** If the destination restored a browser/editor tab, the helper declines and the caller keeps prior behavior. Not a regression (previously broken for *all* destinations), but not fixed either.
3. **`Cmd+1..9` and nav back/forward have the same bug** (`useIpcEvents.ts:1416`, `worktree-activation.ts:729`). Out of scope here; worth a follow-up.

## Cross-platform

No platform-specific code paths. DOM selectors and Zustand state only — no `metaKey` handling, no filesystem assumptions. SSH and native remote tabs follow the same renderer mount path; web-runtime workspaces with no mirrored tab decline focus rather than claiming it.

## Perf

No new subscriptions, no polling, no added renders. One `requestAnimationFrame` replacing a path that already used two. Strictly one frame earlier.

**0 regressions / risk.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
