### PR TITLE
fix(agent-status): prevent ghost sidebar row on completed split-pane detach

### DIFF
--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1303,50 +1303,75 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       const to = transfer.ownerPaneKey
       const targetTabId = getTabIdFromPaneKey(to) ?? undefined
       const targetLeafId = getLeafIdFromPaneKey(to) ?? undefined
-      set((s) => ({
-        agentStatusByPaneKey: movePaneKeyedRecord(s.agentStatusByPaneKey, from, to, (entry) => ({
-          ...entry,
-          paneKey: to,
-          tabId: targetTabId
-        })),
-        runtimeAgentOrchestrationByPaneKey: movePaneKeyedRecord(
-          s.runtimeAgentOrchestrationByPaneKey,
-          from,
-          to
-        ),
-        retainedAgentsByPaneKey: movePaneKeyedRecord(
-          s.retainedAgentsByPaneKey,
-          from,
-          to,
-          (retained) => ({
-            ...retained,
-            entry: { ...retained.entry, paneKey: to, tabId: targetTabId },
-            tab: targetTabId ? { ...retained.tab, id: targetTabId } : retained.tab
-          })
-        ),
-        sleepingAgentSessionsByPaneKey: movePaneKeyedRecord(
-          s.sleepingAgentSessionsByPaneKey,
-          from,
-          to,
-          (record) => ({ ...record, paneKey: to, tabId: targetTabId })
-        ),
-        agentLaunchConfigByPaneKey: movePaneKeyedRecord(
-          s.agentLaunchConfigByPaneKey,
-          from,
-          to,
-          (entry) => ({
+      set((s) => {
+        // Why: useRetainedAgentsSync tracks live pane keys in its own ref and only
+        // sees `from` vanish on the next epoch — it never learns the pane migrated.
+        // A live/done agent has no suppressor on `from`, so moving suppressors is a
+        // no-op and leaves `from` unguarded; the hook then misreads the disappear as
+        // a finished-and-gone `done` agent and resurrects an unclickable ghost row
+        // (also double-counting). Plant a one-shot suppressor on `from` so the
+        // disappear is consumed, not retained. Only when `from` was actually live:
+        // a suppressor is consumed on a live→gone transition, so planting it for a
+        // pane that never had a live agent would leak forever (mirrors dropAgentStatus).
+        const movedSuppressors = movePaneKeyedRecord(s.retentionSuppressedPaneKeys, from, to)
+        const fromWasLive = from in s.agentStatusByPaneKey
+        const retentionSuppressedPaneKeys =
+          fromWasLive && !(from in movedSuppressors)
+            ? { ...movedSuppressors, [from]: true }
+            : movedSuppressors
+        return {
+          agentStatusByPaneKey: movePaneKeyedRecord(s.agentStatusByPaneKey, from, to, (entry) => ({
             ...entry,
-            identity: { ...entry.identity, tabId: targetTabId, leafId: targetLeafId }
-          })
-        ),
-        acknowledgedAgentsByPaneKey: movePaneKeyedRecord(s.acknowledgedAgentsByPaneKey, from, to),
-        paneForegroundAgentByPaneKey: movePaneKeyedRecord(s.paneForegroundAgentByPaneKey, from, to),
-        unreadTerminalPanes: movePaneKeyedRecord(s.unreadTerminalPanes, from, to),
-        unreadAgentCompletionPanes: movePaneKeyedRecord(s.unreadAgentCompletionPanes, from, to),
-        lastTerminalInputAtByPaneKey: movePaneKeyedRecord(s.lastTerminalInputAtByPaneKey, from, to),
-        cacheTimerByKey: movePaneKeyedRecord(s.cacheTimerByKey, from, to),
-        retentionSuppressedPaneKeys: movePaneKeyedRecord(s.retentionSuppressedPaneKeys, from, to)
-      }))
+            paneKey: to,
+            tabId: targetTabId
+          })),
+          runtimeAgentOrchestrationByPaneKey: movePaneKeyedRecord(
+            s.runtimeAgentOrchestrationByPaneKey,
+            from,
+            to
+          ),
+          retainedAgentsByPaneKey: movePaneKeyedRecord(
+            s.retainedAgentsByPaneKey,
+            from,
+            to,
+            (retained) => ({
+              ...retained,
+              entry: { ...retained.entry, paneKey: to, tabId: targetTabId },
+              tab: targetTabId ? { ...retained.tab, id: targetTabId } : retained.tab
+            })
+          ),
+          sleepingAgentSessionsByPaneKey: movePaneKeyedRecord(
+            s.sleepingAgentSessionsByPaneKey,
+            from,
+            to,
+            (record) => ({ ...record, paneKey: to, tabId: targetTabId })
+          ),
+          agentLaunchConfigByPaneKey: movePaneKeyedRecord(
+            s.agentLaunchConfigByPaneKey,
+            from,
+            to,
+            (entry) => ({
+              ...entry,
+              identity: { ...entry.identity, tabId: targetTabId, leafId: targetLeafId }
+            })
+          ),
+          acknowledgedAgentsByPaneKey: movePaneKeyedRecord(s.acknowledgedAgentsByPaneKey, from, to),
+          paneForegroundAgentByPaneKey: movePaneKeyedRecord(
+            s.paneForegroundAgentByPaneKey,
+            from,
+            to
+          ),
+          unreadTerminalPanes: movePaneKeyedRecord(s.unreadTerminalPanes, from, to),
+          unreadAgentCompletionPanes: movePaneKeyedRecord(s.unreadAgentCompletionPanes, from, to),
+          lastTerminalInputAtByPaneKey: movePaneKeyedRecord(
+            s.lastTerminalInputAtByPaneKey,
+            from,
+            to
+          ),
+          cacheTimerByKey: movePaneKeyedRecord(s.cacheTimerByKey, from, to),
+          retentionSuppressedPaneKeys
+        }
+      })
       if (typeof window !== 'undefined') {
         window.api?.agentStatus?.transferPaneAuthority?.({
           fromPaneKey: from,

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1304,18 +1304,12 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
       const targetTabId = getTabIdFromPaneKey(to) ?? undefined
       const targetLeafId = getLeafIdFromPaneKey(to) ?? undefined
       set((s) => {
-        // Why: useRetainedAgentsSync tracks live pane keys in its own ref and only
-        // sees `from` vanish on the next epoch — it never learns the pane migrated.
-        // A live/done agent has no suppressor on `from`, so moving suppressors is a
-        // no-op and leaves `from` unguarded; the hook then misreads the disappear as
-        // a finished-and-gone `done` agent and resurrects an unclickable ghost row
-        // (also double-counting). Plant a one-shot suppressor on `from` so the
-        // disappear is consumed, not retained. Only when `from` was actually live:
-        // a suppressor is consumed on a live→gone transition, so planting it for a
-        // pane that never had a live agent would leak forever (mirrors dropAgentStatus).
+        // Plant a one-shot suppressor on the source key so useRetainedAgentsSync —
+        // which only sees `from` vanish, not the migration — can't resurrect a ghost row.
         const movedSuppressors = movePaneKeyedRecord(s.retentionSuppressedPaneKeys, from, to)
+        // Guard on fromWasLive: a suppressor is consumed only on a live→gone transition, else it leaks.
         const fromWasLive = from in s.agentStatusByPaneKey
-        const retentionSuppressedPaneKeys =
+        const retentionSuppressedPaneKeys: Record<string, true> =
           fromWasLive && !(from in movedSuppressors)
             ? { ...movedSuppressors, [from]: true }
             : movedSuppressors

--- a/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
+++ b/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
@@ -103,7 +103,9 @@ describe('syncPaneDetachPtyOwnership agent identity', () => {
       tabId: targetTabId,
       providerSession: { key: 'session_id', id: 'session-1' }
     })
-    expect(state.retentionSuppressedPaneKeys[sourcePaneKey]).toBeUndefined()
+    // Why: detach plants a one-shot suppressor on the source key so the sidebar
+    // retention hook can't resurrect the migrated pane as an unclickable ghost row.
+    expect(state.retentionSuppressedPaneKeys[sourcePaneKey]).toBe(true)
     expect(state.paneForegroundAgentByPaneKey[siblingPaneKey]).toEqual({
       agent: 'antigravity',
       shellForeground: false

--- a/src/renderer/src/store/slices/terminal-pane-detach-agent-retention.test.ts
+++ b/src/renderer/src/store/slices/terminal-pane-detach-agent-retention.test.ts
@@ -5,13 +5,8 @@ import { createTestStore, makeTab, makeWorktree, seedStore } from './store-test-
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 
-// Why: detaching a completed split pane into its own tab keeps the leafId but
-// changes the tabId, so the paneKey migrates from `sourceTab:leaf` to
-// `targetTab:leaf`. The sidebar retention hook (useRetainedAgentsSync) tracks
-// live pane keys in its own ref and only observes the source key disappearing.
-// Without a suppressor on the source key it misreads that disappear as a
-// finished `done` agent and resurrects an unclickable ghost row. These tests
-// pin the store→hook contract that prevents the ghost.
+// Detaching a completed split pane migrates the paneKey `sourceTab:leaf → targetTab:leaf`;
+// these tests pin the store→hook contract that stops the sidebar resurrecting a ghost row.
 
 const WORKTREE_ID = 'repo::/repo/worktree'
 const SOURCE_TAB = 'tab-source'

--- a/src/renderer/src/store/slices/terminal-pane-detach-agent-retention.test.ts
+++ b/src/renderer/src/store/slices/terminal-pane-detach-agent-retention.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { collectRetainedAgentsOnDisappear } from '@/components/dashboard/useRetainedAgents'
+import { createTestStore, makeTab, makeWorktree, seedStore } from './store-test-helpers'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+
+// Why: detaching a completed split pane into its own tab keeps the leafId but
+// changes the tabId, so the paneKey migrates from `sourceTab:leaf` to
+// `targetTab:leaf`. The sidebar retention hook (useRetainedAgentsSync) tracks
+// live pane keys in its own ref and only observes the source key disappearing.
+// Without a suppressor on the source key it misreads that disappear as a
+// finished `done` agent and resurrects an unclickable ghost row. These tests
+// pin the store→hook contract that prevents the ghost.
+
+const WORKTREE_ID = 'repo::/repo/worktree'
+const SOURCE_TAB = 'tab-source'
+const TARGET_TAB = 'tab-target'
+const LEAF = '11111111-1111-4111-8111-111111111111'
+const SIBLING_LEAF = '22222222-2222-4222-8222-222222222222'
+const SOURCE_PANE_KEY = makePaneKey(SOURCE_TAB, LEAF)
+const TARGET_PANE_KEY = makePaneKey(TARGET_TAB, LEAF)
+
+function makeDoneEntry(paneKey: string, tabId: string): AgentStatusEntry {
+  return {
+    state: 'done',
+    prompt: 'Fix it',
+    updatedAt: 100,
+    stateStartedAt: 100,
+    paneKey,
+    tabId,
+    terminalTitle: 'Claude',
+    stateHistory: [],
+    agentType: 'claude',
+    interrupted: false
+  }
+}
+
+function makeRow(paneKey: string, tabId: string): DashboardAgentRow {
+  return {
+    paneKey,
+    entry: makeDoneEntry(paneKey, tabId),
+    tab: makeTab({ id: tabId, worktreeId: WORKTREE_ID }),
+    agentType: 'claude',
+    state: 'done',
+    startedAt: 100
+  }
+}
+
+function detachDoneAgentAndReadStore() {
+  const store = createTestStore()
+  seedStore(store, {
+    worktreesByRepo: {
+      repo: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo', path: '/repo/worktree' })]
+    },
+    tabsByWorktree: {
+      [WORKTREE_ID]: [
+        makeTab({ id: SOURCE_TAB, worktreeId: WORKTREE_ID, ptyId: 'pty-a' }),
+        makeTab({ id: TARGET_TAB, worktreeId: WORKTREE_ID, ptyId: null })
+      ]
+    },
+    ptyIdsByTabId: { [SOURCE_TAB]: ['pty-a', 'pty-sibling'], [TARGET_TAB]: [] }
+  })
+  store.getState().setAgentStatus(SOURCE_PANE_KEY, {
+    state: 'done',
+    prompt: 'Fix it',
+    agentType: 'claude'
+  })
+  store.getState().syncPaneDetachPtyOwnership({
+    detachedLeafId: LEAF,
+    detachedPtyId: 'pty-a',
+    sourceLayout: {
+      root: { type: 'leaf', leafId: SIBLING_LEAF },
+      activeLeafId: SIBLING_LEAF,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [SIBLING_LEAF]: 'pty-sibling' }
+    },
+    sourceTabId: SOURCE_TAB,
+    targetTabId: TARGET_TAB
+  })
+  return store.getState()
+}
+
+describe('detach completed split pane → sidebar retention', () => {
+  it('plants a source-key suppressor so the retention hook drops the migrated pane', () => {
+    const state = detachDoneAgentAndReadStore()
+
+    // Status migrated to the new tab's pane key.
+    expect(state.agentStatusByPaneKey[SOURCE_PANE_KEY]).toBeUndefined()
+    expect(state.agentStatusByPaneKey[TARGET_PANE_KEY]?.state).toBe('done')
+
+    // The retention hook sees the old key vanish (prevRef held source, current
+    // holds target). Feed it the REAL post-detach suppressor state.
+    const result = collectRetainedAgentsOnDisappear({
+      previousAgents: new Map([
+        [SOURCE_PANE_KEY, { row: makeRow(SOURCE_PANE_KEY, SOURCE_TAB), worktreeId: WORKTREE_ID }]
+      ]),
+      currentAgents: new Map([
+        [TARGET_PANE_KEY, { row: makeRow(TARGET_PANE_KEY, TARGET_TAB), worktreeId: WORKTREE_ID }]
+      ]),
+      retainedAgentsByPaneKey: {},
+      retentionSuppressedPaneKeys: state.retentionSuppressedPaneKeys,
+      recentlyClosedAgentStatusTabIds: {}
+    })
+
+    // No ghost row; the one-shot suppressor is consumed instead of retained.
+    expect(result.toRetain).toEqual([])
+    expect(result.consumedSuppressedPaneKeys).toEqual([SOURCE_PANE_KEY])
+  })
+
+  it('does not plant a suppressor when the detached pane never had a live agent', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: {
+        repo: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo', path: '/repo/worktree' })]
+      },
+      tabsByWorktree: {
+        [WORKTREE_ID]: [
+          makeTab({ id: SOURCE_TAB, worktreeId: WORKTREE_ID, ptyId: 'pty-a' }),
+          makeTab({ id: TARGET_TAB, worktreeId: WORKTREE_ID, ptyId: null })
+        ]
+      },
+      ptyIdsByTabId: { [SOURCE_TAB]: ['pty-a', 'pty-sibling'], [TARGET_TAB]: [] }
+    })
+
+    // No setAgentStatus here: a plain terminal pane with no agent.
+    store.getState().syncPaneDetachPtyOwnership({
+      detachedLeafId: LEAF,
+      detachedPtyId: 'pty-a',
+      sourceLayout: {
+        root: { type: 'leaf', leafId: SIBLING_LEAF },
+        activeLeafId: SIBLING_LEAF,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [SIBLING_LEAF]: 'pty-sibling' }
+      },
+      sourceTabId: SOURCE_TAB,
+      targetTabId: TARGET_TAB
+    })
+
+    // Why: a suppressor is only consumed on a live→gone transition. The source
+    // key was never live, so planting one here would leak it forever.
+    expect(store.getState().retentionSuppressedPaneKeys[SOURCE_PANE_KEY]).toBeUndefined()
+    expect(store.getState().retentionSuppressedPaneKeys[TARGET_PANE_KEY]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #10675 — detaching a **completed (done-state)** split-pane agent into its own tab split the same agent session into two sidebar rows: one working, one a stale unclickable duplicate, plus an inflated worktree agent count.

Root cause: detaching a pane onto the tab strip keeps the `leafId` but changes the `tabId`, so the agent's `paneKey` migrates `oldTab:leaf → newTab:leaf`. `transferAgentPaneAuthority` moves the live status to the new key, but the sidebar's `useRetainedAgentsSync` hook tracks live pane keys in its own `prevAgentsRef` and only observes the **old** key disappearing. A live/done agent has no retention suppressor on the source key (suppressors are only planted on explicit teardown), so moving suppressors is a no-op and the source key is left unguarded — the hook misreads the migration as a "done agent that vanished" and resurrects it as a retained snapshot. The retained row's activation callback is a no-op, so the duplicate can't be opened.

## Fix

Plant a one-shot retention suppressor on the **source** key during `transferAgentPaneAuthority`, so the disappear the hook later observes is consumed instead of retained. Guarded on `from in s.agentStatusByPaneKey` (the source actually held a live agent) — mirroring the existing `hasLive` guards elsewhere in the slice — so a suppressor is never leaked for a pane that never had an agent (e.g. detaching a plain terminal pane).

## Changes

- `agent-status.ts` — `transferAgentPaneAuthority` now plants a guarded one-shot suppressor on the source paneKey.
- `terminal-pane-detach-agent-identity.test.ts` — flipped the stale assertion (source key now carries the suppressor).
- `terminal-pane-detach-agent-retention.test.ts` *(new)* — regression coverage for the store→retention-hook contract: a detached done agent produces no ghost row, and an agent-less pane detach plants no (leaking) suppressor.

## Test plan

- [x] `vitest` on affected suites — 56 passed (agent-status, detach-identity, detach-retention, useRetainedAgents, useRetainedAgentsSync)
- [x] Renderer typecheck (`tsc -p config/tsconfig.tc.web.json`) — clean
- [x] Independent `codex exec review` — no correctness issues found
- [x] Live app inspection via CDP after a done-agent detach — `retainedAgentsByPaneKey` empty (no ghost row), suppressor consumed

## Notes

- Desktop + web client share this renderer store, so both are fixed. `orca-mobile` is a separate app that doesn't use this slice and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Detaching a finished split-pane agent into its own tab left a ghost duplicate sidebar row and wrong agent counts. Detach now moves identity cleanly so only one real row remains.
