### PR TITLE
fix(pty): bound stats salvage and Resource Manager session seeding

### DIFF
--- a/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
+++ b/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
@@ -3,7 +3,7 @@ import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 
 describe('foreground-confirmation daemon protocol', () => {
   it('rejects daemons from before the fresh-confirmation RPC', () => {
-    expect(PROTOCOL_VERSION).toBe(28)
+    expect(PROTOCOL_VERSION).toBe(29)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(19)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(22)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(23)

--- a/src/main/daemon/daemon-protocol-version.test.ts
+++ b/src/main/daemon/daemon-protocol-version.test.ts
@@ -5,18 +5,20 @@ import {
   COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION,
   GET_FOREGROUND_PROCESS_PROTOCOL_VERSION,
   PREVIOUS_DAEMON_PROTOCOL_VERSIONS,
-  PROTOCOL_VERSION
+  PROTOCOL_VERSION,
+  SESSION_ID_LIST_PROTOCOL_VERSION
 } from './daemon-protocol-version'
 
 describe('daemon protocol version', () => {
-  it('ships preflight-cache replacement after completion inspection', () => {
-    expect(PROTOCOL_VERSION).toBe(28)
+  it('ships session-ID listing after preflight-cache replacement', () => {
+    expect(PROTOCOL_VERSION).toBe(29)
+    expect(SESSION_ID_LIST_PROTOCOL_VERSION).toBe(29)
     expect(COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION).toBe(27)
     expect(GET_FOREGROUND_PROCESS_PROTOCOL_VERSION).toBe(11)
     expect(AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toEqual(
-      Array.from({ length: 27 }, (_, index) => index + 1)
+      Array.from({ length: 28 }, (_, index) => index + 1)
     )
   })
 })

--- a/src/main/daemon/daemon-protocol-version.ts
+++ b/src/main/daemon/daemon-protocol-version.ts
@@ -1,6 +1,7 @@
 // Why: daemons survive app updates, so wire behavior must be version-gated.
-// v28 replaces v26/v27 daemons that can retain permanent macOS preflight rejections (#9756).
-export const PROTOCOL_VERSION = 28
+// v29 gives the closed Resource Manager badge a cheap session-ID inventory.
+export const PROTOCOL_VERSION = 29
+export const SESSION_ID_LIST_PROTOCOL_VERSION = 29
 export const COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION = 27
 export const GET_FOREGROUND_PROCESS_PROTOCOL_VERSION = 11
 export const PTY_STARTUP_INGRESS_PROTOCOL_VERSION = 25
@@ -9,7 +10,8 @@ export const AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION = 26
 export const GIT_CREDENTIAL_GUARD_HOST_PROTOCOL_VERSION = 22
 export const CLEAN_DISCONNECT_PROTOCOL_VERSION = 24
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+  28
 ] as const
 
 export function supportsPtyStartupIngress(protocolVersion: number): boolean {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -912,6 +912,26 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     })
   })
 
+  describe('listSessionIds', () => {
+    it('uses the ID-only RPC on the current protocol', async () => {
+      const first = await adapter.spawn({ cols: 80, rows: 24 })
+      const second = await adapter.spawn({ cols: 80, rows: 24 })
+
+      await expect(adapter.listSessionIds()).resolves.toEqual([first.id, second.id])
+    })
+
+    it('uses the full process fallback for preserved protocols', async () => {
+      const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 28 })
+      const listProcesses = vi
+        .spyOn(legacy, 'listProcesses')
+        .mockResolvedValue([{ id: 'legacy-id', cwd: '', title: 'shell' }])
+
+      await expect(legacy.listSessionIds()).resolves.toEqual(['legacy-id'])
+      expect(listProcesses).toHaveBeenCalledTimes(1)
+      legacy.dispose()
+    })
+  })
+
   describe('hasChildProcesses / getForegroundProcess', () => {
     it('returns false for shell foreground processes', async () => {
       const { id } = await adapter.spawn({ cols: 80, rows: 24 })

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -16,6 +16,7 @@ import {
   AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION,
   GIT_CREDENTIAL_GUARD_HOST_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
+  SESSION_ID_LIST_PROTOCOL_VERSION,
   supportsPtyStartupIngress,
   type CreateOrAttachResult,
   type DaemonEvent,
@@ -967,6 +968,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
       )
     }
     return processes
+  }
+
+  async listSessionIds(): Promise<string[]> {
+    if (this.protocolVersion < SESSION_ID_LIST_PROTOCOL_VERSION) {
+      return (await this.listProcesses()).map(({ id }) => id)
+    }
+    await this.ensureConnected()
+    const result = await this.client.request<{ sessionIds: string[] }>('listSessionIds', undefined)
+    return result.sessionIds
   }
 
   private validatedAgentSessionOwners(

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -59,6 +59,7 @@ function createAdapter(
         title: label
       }))
     ),
+    listSessionIds: vi.fn(async () => [...sessions]),
     hasPty: vi.fn((id: string) => sessions.includes(id)),
     write: vi.fn((id: string, data: string) => {
       writes.push({ id, data })
@@ -171,6 +172,16 @@ it('preserves unavailable inspection from the owning legacy daemon', async () =>
 })
 
 describe('DaemonPtyRouter', () => {
+  it('deduplicates ID-only listings across current and preserved daemons', async () => {
+    const current = createAdapter('current', ['shared', 'current'])
+    const legacy = createAdapter('legacy', ['shared', 'legacy'])
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+    await expect(router.listSessionIds()).resolves.toEqual(['shared', 'current', 'legacy'])
+    expect(current.listProcesses).not.toHaveBeenCalled()
+    expect(legacy.listProcesses).not.toHaveBeenCalled()
+  })
+
   it('reports separate conservative resume and fresh-create boundaries', () => {
     const current = createAdapter(
       'current',

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -215,6 +215,13 @@ export class DaemonPtyRouter implements IPtyProvider {
     return results.flat()
   }
 
+  async listSessionIds(): Promise<string[]> {
+    const listings = await Promise.all(
+      this.allAdapters().map((adapter) => adapter.listSessionIds())
+    )
+    return Array.from(new Set(listings.flat()))
+  }
+
   async getDefaultShell(): Promise<string> {
     return this.current.getDefaultShell()
   }

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -408,6 +408,9 @@ describe('DaemonServer', () => {
 
       const result = await c.request<{ sessions: unknown[] }>('listSessions', undefined)
       expect(result.sessions).toHaveLength(1)
+
+      const ids = await c.request<{ sessionIds: string[] }>('listSessionIds', undefined)
+      expect(ids.sessionIds).toEqual(['test-session'])
     })
 
     it('handles ping health checks', async () => {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -928,6 +928,9 @@ export class DaemonServer {
         this.host.clearScrollback(request.payload.sessionId)
         return {}
 
+      case 'listSessionIds':
+        return { sessionIds: this.host.listSessionIds() }
+
       case 'listSessions':
         return { sessions: this.host.listSessions() }
 

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -48,6 +48,7 @@ function createProvider(
     confirmForegroundProcess: vi.fn(async () => `${label}-confirmed`),
     serialize: vi.fn(async () => '{}'),
     revive: vi.fn(async () => {}),
+    listSessionIds: vi.fn(async () => [...sessions]),
     listProcesses: vi.fn(async () => sessions.map((id) => ({ id, cwd: '', title: label }))),
     getDefaultShell: vi.fn(async () => '/bin/zsh'),
     getProfiles: vi.fn(async () => []),
@@ -148,6 +149,17 @@ it('preserves unavailable inspection from an owning daemon', async () => {
 })
 
 describe('DegradedDaemonPtyProvider', () => {
+  it('deduplicates cheap IDs and falls back only for providers without the method', async () => {
+    const current = createDaemonAdapter('daemon', ['shared', 'daemon'])
+    const fallback = createProvider('fallback', ['shared', 'fallback'])
+    fallback.listSessionIds = undefined
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+
+    await expect(provider.listSessionIds()).resolves.toEqual(['shared', 'fallback', 'daemon'])
+    expect(current.listProcesses).not.toHaveBeenCalled()
+    expect(fallback.listProcesses).toHaveBeenCalledTimes(1)
+  })
+
   it('only delegates owner-listing authority to the provider that owns the id', async () => {
     const current = createDaemonAdapter('daemon', ['daemon-session'])
     const fallback = createProvider('fallback', [], true)

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -4,6 +4,7 @@ import { inspectPtyProviderProcess } from '../providers/pty-process-inspection'
 import type { IPtyProvider, PtyBackgroundStreamEvent } from '../providers/types'
 import type { PtyDataEvent, PtyProviderBufferSnapshot } from '../providers/types'
 import type { PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import { listUniquePtyProviderSessionIds } from '../providers/pty-session-id-list-admission'
 
 export class DegradedDaemonPtyProvider implements IPtyProvider {
   readonly routesFreshSpawnsToLocalProvider = true
@@ -176,6 +177,8 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     )
     return results.flat()
   }
+
+  listSessionIds = (): Promise<string[]> => listUniquePtyProviderSessionIds(this.allProviders())
 
   async getDefaultShell(): Promise<string> {
     return this.fallback.getDefaultShell()

--- a/src/main/daemon/terminal-host-session-listing.ts
+++ b/src/main/daemon/terminal-host-session-listing.ts
@@ -2,6 +2,16 @@ import type { ClaimedAgentPtyOwnerRegistry } from '../../shared/claimed-agent-pt
 import type { Session } from './session'
 import type { SessionInfo } from './types'
 
+export function listLiveTerminalHostSessionIds(sessions: ReadonlyMap<string, Session>): string[] {
+  const ids: string[] = []
+  for (const session of sessions.values()) {
+    if (session.isAlive) {
+      ids.push(session.sessionId)
+    }
+  }
+  return ids
+}
+
 export function listLiveTerminalHostSessions(
   sessions: ReadonlyMap<string, Session>,
   agentSessionOwners: ClaimedAgentPtyOwnerRegistry

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -728,6 +728,7 @@ describe('TerminalHost', () => {
       const sessions = host.listSessions()
       expect(sessions).toHaveLength(2)
       expect(sessions.map((s) => s.sessionId).sort()).toEqual(['session-1', 'session-2'])
+      expect(host.listSessionIds().sort()).toEqual(['session-1', 'session-2'])
     })
 
     it('uses applied size without serializing terminal snapshots', async () => {

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -14,7 +14,10 @@ import { createOrAttachClaimedAgentSession } from './terminal-host-agent-session
 import { TerminalHostAgentSessionGenerations } from './terminal-host-agent-session-generations'
 import { resolveTerminalHostSessionCwd } from './terminal-host-session-cwd'
 import { TerminalHostTombstones } from './terminal-host-tombstones'
-import { listLiveTerminalHostSessions } from './terminal-host-session-listing'
+import {
+  listLiveTerminalHostSessionIds,
+  listLiveTerminalHostSessions
+} from './terminal-host-session-listing'
 import { createOrAttachTerminalSession } from './terminal-host-session-create'
 import { isShellProcess } from '../../shared/agent-detection'
 
@@ -216,6 +219,10 @@ export class TerminalHost {
 
   listSessions(): SessionInfo[] {
     return listLiveTerminalHostSessions(this.sessions, this.agentSessionOwners)
+  }
+
+  listSessionIds(): string[] {
+    return listLiveTerminalHostSessionIds(this.sessions)
   }
 
   dispose(): Promise<void> {

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -32,6 +32,7 @@ export {
   PREVIOUS_DAEMON_PROTOCOL_VERSIONS,
   PROTOCOL_VERSION,
   PTY_STARTUP_INGRESS_PROTOCOL_VERSION,
+  SESSION_ID_LIST_PROTOCOL_VERSION,
   supportsPtyStartupIngress
 } from './daemon-protocol-version'
 
@@ -301,6 +302,7 @@ export type DaemonRequest =
   | SetSessionBackgroundRequest
   | KillRequest
   | SignalRequest
+  | { id: string; type: 'listSessionIds' }
   | ListSessionsRequest
   | ShutdownIfIdleRequest
   | DetachRequest

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -5451,6 +5451,52 @@ describe('registerPtyHandlers', () => {
     })
   })
 
+  it('lists bounded unique IDs without loading supported provider details', async () => {
+    const local = getLocalPtyProvider()
+    const localListSessionIds = vi
+      .spyOn(local, 'listSessionIds')
+      .mockResolvedValue(['shared-pty', 'local-pty'])
+    const localListProcesses = vi.spyOn(local, 'listProcesses')
+    const sshListSessionIds = vi.fn(async () => ['shared-pty', 'remote-pty'])
+    const sshListProcesses = vi.fn(async () => {
+      throw new Error('full listing should not run')
+    })
+    registerPtyHandlers(mainWindow as never)
+    registerSshPtyProvider('ssh-1', {
+      listSessionIds: sshListSessionIds,
+      listProcesses: sshListProcesses,
+      onData: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {})
+    } as never)
+
+    await expect(handlers.get('pty:listSessionIds')!(null, undefined)).resolves.toEqual([
+      'shared-pty',
+      'local-pty',
+      'remote-pty'
+    ])
+    expect(localListSessionIds).toHaveBeenCalledTimes(1)
+    expect(sshListSessionIds).toHaveBeenCalledTimes(1)
+    expect(localListProcesses).not.toHaveBeenCalled()
+    expect(sshListProcesses).not.toHaveBeenCalled()
+  })
+
+  it('ignores unavailable SSH ID inventories without hiding local IDs', async () => {
+    vi.spyOn(getLocalPtyProvider(), 'listSessionIds').mockResolvedValue(['local-pty'])
+    registerPtyHandlers(mainWindow as never)
+    registerSshPtyProvider('ssh-1', {
+      listSessionIds: vi.fn(async () => {
+        throw new Error('relay unavailable')
+      }),
+      listProcesses: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {})
+    } as never)
+
+    await expect(handlers.get('pty:listSessionIds')!(null, undefined)).resolves.toEqual([
+      'local-pty'
+    ])
+  })
+
   it('starts local and SSH session inventories concurrently', async () => {
     let resolveLocal!: (sessions: { id: string; cwd: string; title: string }[]) => void
     const localSessions = new Promise<{ id: string; cwd: string; title: string }[]>((resolve) => {
@@ -10774,6 +10820,87 @@ describe('registerPtyHandlers', () => {
       expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
         id: spawn.id,
         data: '\x1b[6n\x1b[0c',
+        droppedOutput: true
+      })
+    } finally {
+      errorSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps a final dropped-output query chunk to the remaining salvage allowance', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const ackData = getPtyAckDataListener()
+      const query = '\x1b[6n'
+      mainWindow.webContents.send.mockClear()
+
+      mockProc.emitData('x'.repeat(600 * 1024))
+      vi.advanceTimersByTime(2)
+      for (let index = 0; index < 32; index++) {
+        vi.advanceTimersByTime(1)
+      }
+
+      mockProc.emitData(`${'y'.repeat(3 * 1024 * 1024)}${query.repeat(1_023)}`)
+      mockProc.emitData(query.repeat(2))
+
+      mainWindow.webContents.send.mockClear()
+      ackData(null, { id: spawn.id, charCount: 512 * 1024 })
+      vi.advanceTimersByTime(2)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawn.id,
+        data: query.repeat(1_024),
+        droppedOutput: true
+      })
+    } finally {
+      errorSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not split a terminal query at the dropped-output salvage boundary', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const ackData = getPtyAckDataListener()
+      const almostFull = `${'\x1b[6n'.repeat(1_021)}${'\x1b[14t'.repeat(2)}`
+      const extractedAlmostFull = `${'\x1b[14t'.repeat(2)}${'\x1b[6n'.repeat(1_021)}`
+
+      mockProc.emitData('x'.repeat(600 * 1024))
+      vi.advanceTimersByTime(2)
+      for (let index = 0; index < 32; index++) {
+        vi.advanceTimersByTime(1)
+      }
+      mockProc.emitData(`${'y'.repeat(3 * 1024 * 1024)}${almostFull}`)
+      mockProc.emitData('\x1b[6n')
+
+      mainWindow.webContents.send.mockClear()
+      ackData(null, { id: spawn.id, charCount: 512 * 1024 })
+      vi.advanceTimersByTime(2)
+
+      expect(almostFull).toHaveLength(4_094)
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+        id: spawn.id,
+        data: extractedAlmostFull,
         droppedOutput: true
       })
     } finally {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -63,6 +63,7 @@ import {
   PtyProcessListAdmission,
   visitPtyProcessListingsInBatches
 } from '../providers/pty-process-list-admission'
+import { collectPtySessionIdListings } from '../providers/pty-session-id-list-admission'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import {
   SSH_SESSION_EXPIRED_ERROR,
@@ -1628,6 +1629,7 @@ export function registerPtyHandlers(
   // Remove prior handlers so re-registration (e.g. macOS re-activate creating a new window) doesn't double-register.
   ipcMain.removeHandler('pty:spawn')
   ipcMain.removeHandler('pty:kill')
+  ipcMain.removeHandler('pty:listSessionIds')
   ipcMain.removeHandler('pty:listSessions')
   ipcMain.removeHandler('pty:hasPty')
   ipcMain.removeHandler('pty:hasChildProcesses')
@@ -2396,6 +2398,10 @@ export function registerPtyHandlers(
     return extracted.statelessQueryData + extracted.statefulQueryData + extracted.oscColorQueryData
   }
 
+  function fitDroppedPtyQueryBytes(data: string, maxChars: number): string {
+    return extractDroppedPtyQueryBytes(extractDroppedPtyQueryBytes(data).slice(0, maxChars))
+  }
+
   function dropOversizedPendingPtyData(id: string, pending: PendingPtyData): PendingPtyData {
     const capChars = pendingDataCapChars()
     if (pending.droppedOutput === true || pending.data.length <= capChars) {
@@ -2418,7 +2424,7 @@ export function registerPtyHandlers(
     pendingDroppedChars += pending.data.length
     // Why no trimmed content tail: a mid-stream gap would corrupt the pane; the droppedOutput sentinel repaints from the snapshot and realigns by sequence (only query bytes ride along).
     return {
-      data: extractDroppedPtyQueryBytes(pending.data).slice(0, DROPPED_QUERY_SALVAGE_MAX_CHARS),
+      data: fitDroppedPtyQueryBytes(pending.data, DROPPED_QUERY_SALVAGE_MAX_CHARS),
       droppedOutput: true
     }
   }
@@ -2438,7 +2444,8 @@ export function registerPtyHandlers(
       if (existing.data.length >= DROPPED_QUERY_SALVAGE_MAX_CHARS) {
         return existing
       }
-      const salvaged = extractDroppedPtyQueryBytes(data)
+      const remaining = DROPPED_QUERY_SALVAGE_MAX_CHARS - existing.data.length
+      const salvaged = fitDroppedPtyQueryBytes(data, remaining)
       return salvaged ? { ...existing, data: existing.data + salvaged } : existing
     }
     const nextContainsBackgroundOutput =
@@ -5463,6 +5470,21 @@ export function registerPtyHandlers(
       sendPtyExitToRenderer({ id: args.id, code: -1 })
     }
   })
+
+  ipcMain.handle(
+    'pty:listSessionIds',
+    async (): Promise<string[]> =>
+      await collectPtySessionIdListings(
+        registeredPtyProviders(),
+        async ({ provider, connectionId }) => {
+          const load = async (): Promise<string[]> =>
+            provider.listSessionIds
+              ? await provider.listSessionIds()
+              : (await provider.listProcesses()).map(({ id }) => id)
+          return connectionId === null ? await load() : await load().catch(() => [])
+        }
+      )
+  )
 
   ipcMain.handle(
     'pty:listSessions',

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -1331,6 +1331,10 @@ export class LocalPtyProvider implements IPtyProvider {
     /* re-spawning handles local revival */
   }
 
+  async listSessionIds(): Promise<string[]> {
+    return Array.from(ptyProcesses.keys())
+  }
+
   async listProcesses(): Promise<PtyProcessInfo[]> {
     return Array.from(ptyProcesses.entries()).map(([id, proc]) => ({
       id,

--- a/src/main/providers/pty-session-id-list-admission.test.ts
+++ b/src/main/providers/pty-session-id-list-admission.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MAX_AGGREGATED_PTY_PROCESS_LIST_BYTES,
+  MAX_AGGREGATED_PTY_PROCESS_LIST_ENTRIES,
+  PTY_PROCESS_LIST_PROVIDER_BATCH_SIZE
+} from './pty-process-list-admission'
+import {
+  collectPtySessionIdListings,
+  PtySessionIdListAdmission
+} from './pty-session-id-list-admission'
+
+describe('PtySessionIdListAdmission', () => {
+  it('validates, bounds, and deduplicates session IDs', () => {
+    const admission = new PtySessionIdListAdmission()
+    expect(admission.admit('pty-1')).toBe(true)
+    expect(admission.admit('pty-1')).toBe(false)
+    expect(() => admission.admit('')).toThrow('invalid_pty_session_id_list')
+    expect(() => admission.admit(42)).toThrow('invalid_pty_session_id_list')
+
+    const entryAdmission = new PtySessionIdListAdmission()
+    for (let index = 0; index < MAX_AGGREGATED_PTY_PROCESS_LIST_ENTRIES; index += 1) {
+      entryAdmission.admit(`pty-${index}`)
+    }
+    expect(() => entryAdmission.admit('one-more')).toThrow('pty_session_id_list_capacity')
+
+    expect(() =>
+      new PtySessionIdListAdmission().admit('x'.repeat(MAX_AGGREGATED_PTY_PROCESS_LIST_BYTES + 1))
+    ).toThrow('pty_session_id_list_capacity')
+  })
+})
+
+describe('collectPtySessionIdListings', () => {
+  it('deduplicates listings and bounds provider concurrency', async () => {
+    let active = 0
+    let peak = 0
+    const finishes: (() => void)[] = []
+    const load = vi.fn(
+      async (source: number) =>
+        await new Promise<string[]>((resolve) => {
+          active += 1
+          peak = Math.max(peak, active)
+          finishes.push(() => {
+            active -= 1
+            resolve(['shared', `pty-${source}`])
+          })
+        })
+    )
+    const collecting = collectPtySessionIdListings(
+      Array.from({ length: PTY_PROCESS_LIST_PROVIDER_BATCH_SIZE + 1 }, (_, index) => index),
+      load
+    )
+
+    await vi.waitFor(() => expect(finishes).toHaveLength(PTY_PROCESS_LIST_PROVIDER_BATCH_SIZE))
+    finishes.splice(0).forEach((finish) => finish())
+    await vi.waitFor(() => expect(finishes).toHaveLength(1))
+    finishes.splice(0).forEach((finish) => finish())
+
+    await expect(collecting).resolves.toEqual([
+      'shared',
+      'pty-0',
+      'pty-1',
+      'pty-2',
+      'pty-3',
+      'pty-4'
+    ])
+    expect(peak).toBe(PTY_PROCESS_LIST_PROVIDER_BATCH_SIZE)
+  })
+})

--- a/src/main/providers/pty-session-id-list-admission.ts
+++ b/src/main/providers/pty-session-id-list-admission.ts
@@ -1,0 +1,77 @@
+import {
+  MAX_AGGREGATED_PTY_PROCESS_LIST_BYTES,
+  MAX_AGGREGATED_PTY_PROCESS_LIST_ENTRIES,
+  PTY_PROCESS_LIST_PROVIDER_BATCH_SIZE
+} from './pty-process-list-admission'
+import type { IPtyProvider } from './types'
+
+export async function listPtyProviderSessionIds(provider: IPtyProvider): Promise<string[]> {
+  if (provider.listSessionIds) {
+    return await provider.listSessionIds()
+  }
+  return (await provider.listProcesses()).map(({ id }) => id)
+}
+
+export async function listUniquePtyProviderSessionIds(
+  providers: readonly IPtyProvider[]
+): Promise<string[]> {
+  const listings = await Promise.all(providers.map(listPtyProviderSessionIds))
+  return Array.from(new Set(listings.flat()))
+}
+
+export class PtySessionIdListAdmission {
+  private entries = 0
+  private retainedBytes = 0
+  private readonly seen = new Set<string>()
+
+  admit(value: unknown): boolean {
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error('invalid_pty_session_id_list')
+    }
+    const nextEntries = this.entries + 1
+    const nextBytes = this.retainedBytes + Buffer.byteLength(value, 'utf8')
+    if (
+      nextEntries > MAX_AGGREGATED_PTY_PROCESS_LIST_ENTRIES ||
+      nextBytes > MAX_AGGREGATED_PTY_PROCESS_LIST_BYTES
+    ) {
+      throw new Error('pty_session_id_list_capacity')
+    }
+    this.entries = nextEntries
+    this.retainedBytes = nextBytes
+    if (this.seen.has(value)) {
+      return false
+    }
+    this.seen.add(value)
+    return true
+  }
+}
+
+export async function collectPtySessionIdListings<T>(
+  sources: Iterable<T>,
+  load: (source: T) => Promise<readonly unknown[]>
+): Promise<string[]> {
+  const admission = new PtySessionIdListAdmission()
+  const sessionIds: string[] = []
+  let batch: T[] = []
+  const loadBatch = async (): Promise<void> => {
+    const listings = await Promise.all(batch.map(load))
+    for (const listing of listings) {
+      for (const value of listing) {
+        if (admission.admit(value)) {
+          sessionIds.push(value as string)
+        }
+      }
+    }
+    batch = []
+  }
+  for (const source of sources) {
+    batch.push(source)
+    if (batch.length === PTY_PROCESS_LIST_PROVIDER_BATCH_SIZE) {
+      await loadBatch()
+    }
+  }
+  if (batch.length > 0) {
+    await loadBatch()
+  }
+  return sessionIds
+}

--- a/src/main/providers/ssh-pty-provider.test.ts
+++ b/src/main/providers/ssh-pty-provider.test.ts
@@ -36,6 +36,57 @@ describe('SshPtyProvider', () => {
     expect(provider.getConnectionId()).toBe('conn-1')
   })
 
+  describe('listSessionIds', () => {
+    it('uses and validates the cheap relay method', async () => {
+      mux.request.mockResolvedValue(['pty-1', 'pty-2'])
+
+      await expect(provider.listSessionIds()).resolves.toEqual([
+        'ssh:conn-1@@pty-1',
+        'ssh:conn-1@@pty-2'
+      ])
+      expect(mux.request).toHaveBeenCalledWith('pty.listSessionIds')
+      expect(mux.request).not.toHaveBeenCalledWith('pty.listProcesses', expect.anything())
+    })
+
+    it('coalesces and caches only a method-not-found fallback', async () => {
+      const methodNotFound = Object.assign(new Error('Method not found'), { code: -32601 })
+      let rejectProbe!: (error: Error) => void
+      const probe = new Promise<unknown>((_resolve, reject) => {
+        rejectProbe = reject
+      })
+      mux.request.mockImplementation((method: string) => {
+        if (method === 'pty.listSessionIds') {
+          return probe
+        }
+        return Promise.resolve([{ id: 'pty-legacy', cwd: '/remote', title: 'shell' }])
+      })
+
+      const requests = [provider.listSessionIds(), provider.listSessionIds()]
+      rejectProbe(methodNotFound)
+
+      await expect(Promise.all(requests)).resolves.toEqual([
+        ['ssh:conn-1@@pty-legacy'],
+        ['ssh:conn-1@@pty-legacy']
+      ])
+      await expect(provider.listSessionIds()).resolves.toEqual(['ssh:conn-1@@pty-legacy'])
+      const methods = mux.request.mock.calls.map(([method]) => method)
+      expect(methods.filter((method) => method === 'pty.listSessionIds')).toHaveLength(1)
+      expect(methods.filter((method) => method === 'pty.listProcesses')).toHaveLength(2)
+    })
+
+    it('does not cache transport or payload failures', async () => {
+      mux.request
+        .mockRejectedValueOnce(new Error('connection lost'))
+        .mockResolvedValueOnce([''])
+        .mockResolvedValueOnce(['pty-recovered'])
+
+      await expect(provider.listSessionIds()).rejects.toThrow('connection lost')
+      await expect(provider.listSessionIds()).rejects.toThrow('invalid_pty_session_id_list')
+      await expect(provider.listSessionIds()).resolves.toEqual(['ssh:conn-1@@pty-recovered'])
+      expect(mux.request).toHaveBeenCalledTimes(3)
+    })
+  })
+
   it('keeps a shared claim probe alive when one waiter disconnects', async () => {
     let finishProbe!: (result: { agentSessionClaimVersion: number }) => void
     mux.request.mockReturnValueOnce(

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -24,6 +24,7 @@ import { buildSshPtySpawnRequest } from './ssh-pty-spawn-request'
 import { SshPtySpawnExitRaceTracker } from './ssh-pty-spawn-exit-race'
 import { SshAgentSessionCapabilities } from './ssh-agent-session-capabilities'
 import type { PtyProcessInspection } from './pty-process-inspection'
+import { SshPtySessionIdLister } from './ssh-pty-session-id-listing'
 
 // Why: sequential relay teardown calls share one absolute budget; convert to the mux-relative timeout only at dispatch.
 function relayTimeoutOptions(deadlineMs: number | undefined): { timeoutMs: number } | undefined {
@@ -32,7 +33,6 @@ function relayTimeoutOptions(deadlineMs: number | undefined): { timeoutMs: numbe
 
 /** Remote PTY provider that proxies IPtyProvider operations through the relay. */
 export class SshPtyProvider implements IPtyProvider {
-  private mux: SshChannelMultiplexer
   private connectionId: string
   private dataListeners = new Set<SshPtyDataCallback>()
   private replayListeners = new Set<SshPtyReplayCallback>()
@@ -42,17 +42,18 @@ export class SshPtyProvider implements IPtyProvider {
   private unsubscribeNotifications: (() => void) | null = null
   readonly getAppliedSize: NonNullable<IPtyProvider['getAppliedSize']>
   private readonly agentSessionCapabilities: SshAgentSessionCapabilities
+  private readonly sessionIdLister: SshPtySessionIdLister
   private spawnExitRaces = new SshPtySpawnExitRaceTracker()
 
   constructor(
     connectionId: string,
-    mux: SshChannelMultiplexer,
+    private mux: SshChannelMultiplexer,
     private readonly remoteCliBridgeEnv?: RemoteCliBridgeEnv
   ) {
     this.connectionId = connectionId
-    this.mux = mux
     this.agentSessionCapabilities = new SshAgentSessionCapabilities(mux)
     this.getAppliedSize = createSshPtyAppliedSizeReader(mux, connectionId)
+    this.sessionIdLister = new SshPtySessionIdLister(connectionId, mux)
 
     this.unsubscribeNotifications = subscribeSshPtyNotifications({
       mux,
@@ -311,6 +312,8 @@ export class SshPtyProvider implements IPtyProvider {
     }
     return processes
   }
+
+  listSessionIds = (): Promise<string[]> => this.sessionIdLister.list()
 
   hasPty(id: string): boolean {
     return this.livePtyIds.has(id)

--- a/src/main/providers/ssh-pty-session-id-listing.ts
+++ b/src/main/providers/ssh-pty-session-id-listing.ts
@@ -1,0 +1,59 @@
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import { JsonRpcErrorCode } from '../ssh/relay-protocol'
+import { mapSshPtyProcessList } from './ssh-agent-session-process-list'
+import { toAppSshPtyId } from './ssh-pty-id'
+import type { PtyProcessInfo } from './types'
+
+export class SshPtySessionIdLister {
+  private support: boolean | null = null
+  private probe: Promise<string[]> | null = null
+
+  constructor(
+    private readonly connectionId: string,
+    private readonly mux: SshChannelMultiplexer
+  ) {}
+
+  async list(): Promise<string[]> {
+    if (this.support === false) {
+      return await this.fallback()
+    }
+    if (this.support === true) {
+      return await this.request()
+    }
+    if (!this.probe) {
+      this.probe = this.probeSupport().finally(() => {
+        this.probe = null
+      })
+    }
+    return await this.probe
+  }
+
+  private async request(): Promise<string[]> {
+    const result = await this.mux.request('pty.listSessionIds')
+    if (!Array.isArray(result) || !result.every((id) => typeof id === 'string' && id.length > 0)) {
+      throw new Error('invalid_pty_session_id_list')
+    }
+    return result.map((id) => toAppSshPtyId(this.connectionId, id))
+  }
+
+  private async probeSupport(): Promise<string[]> {
+    try {
+      const ids = await this.request()
+      this.support = true
+      return ids
+    } catch (error) {
+      if ((error as { code?: unknown })?.code !== JsonRpcErrorCode.MethodNotFound) {
+        throw error
+      }
+      this.support = false
+      return await this.fallback()
+    }
+  }
+
+  private async fallback(): Promise<string[]> {
+    const result = await this.mux.request('pty.listProcesses')
+    return mapSshPtyProcessList(result as PtyProcessInfo[], (id) =>
+      toAppSshPtyId(this.connectionId, id)
+    ).map(({ id }) => id)
+  }
+}

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -197,6 +197,8 @@ export type IPtyProvider = {
   confirmForegroundProcess?: (id: string) => Promise<string | null>
   serialize(ids: string[]): Promise<string>
   revive(state: string): Promise<void>
+  /** Cheap live-session inventory for badge/count paths. */
+  listSessionIds?: () => Promise<string[]>
   // Why: deadlineMs bounds the underlying RPC exactly like shutdown's deadlineMs.
   listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]>
   getDefaultShell(): Promise<string>

--- a/src/main/stats/collector-async-save.test.ts
+++ b/src/main/stats/collector-async-save.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import type * as Fs from 'node:fs'
 import type * as FsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -21,17 +22,43 @@ vi.mock('electron', () => ({
 const gate = vi.hoisted(() => ({
   blocked: false,
   waiters: [] as (() => void)[],
-  writeFileCalls: 0
+  writeFileCalls: 0,
+  activeWriteFileCalls: 0,
+  maxActiveWriteFileCalls: 0,
+  failAfterWriteOnce: false,
+  failRenameOnce: false
 }))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof Fs>('node:fs')
+  const renameSync = ((...args: Parameters<typeof actual.renameSync>) => {
+    if (gate.failRenameOnce) {
+      gate.failRenameOnce = false
+      throw new Error('injected rename failure')
+    }
+    return actual.renameSync(...args)
+  }) as typeof actual.renameSync
+  return { ...actual, renameSync }
+})
 
 vi.mock('node:fs/promises', async () => {
   const actual = await vi.importActual<typeof FsPromises>('node:fs/promises')
   const writeFile = (async (...args: Parameters<typeof actual.writeFile>) => {
     gate.writeFileCalls += 1
-    if (gate.blocked) {
-      await new Promise<void>((resolve) => gate.waiters.push(resolve))
+    gate.activeWriteFileCalls += 1
+    gate.maxActiveWriteFileCalls = Math.max(gate.maxActiveWriteFileCalls, gate.activeWriteFileCalls)
+    try {
+      if (gate.blocked) {
+        await new Promise<void>((resolve) => gate.waiters.push(resolve))
+      }
+      await actual.writeFile(...args)
+      if (gate.failAfterWriteOnce) {
+        gate.failAfterWriteOnce = false
+        throw new Error('injected partial write failure')
+      }
+    } finally {
+      gate.activeWriteFileCalls -= 1
     }
-    return actual.writeFile(...args)
   }) as typeof actual.writeFile
   return { ...actual, writeFile }
 })
@@ -46,6 +73,10 @@ describe('StatsCollector async debounced save', () => {
     gate.blocked = false
     gate.waiters = []
     gate.writeFileCalls = 0
+    gate.activeWriteFileCalls = 0
+    gate.maxActiveWriteFileCalls = 0
+    gate.failAfterWriteOnce = false
+    gate.failRenameOnce = false
     vi.resetModules()
   })
 
@@ -89,6 +120,94 @@ describe('StatsCollector async debounced save', () => {
     // Synchronous: the file exists immediately with no awaiting.
     const parsed = JSON.parse(readFileSync(statsPath(), 'utf-8'))
     expect(parsed.aggregates.totalAgentsSpawned).toBe(1)
+  })
+
+  it('serializes debounced writes while a prior temp write is in flight', async () => {
+    vi.useFakeTimers()
+    const { StatsCollector, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+
+    gate.blocked = true
+    collector.onAgentStart('pty-first', 1_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.waitFor(() => expect(gate.writeFileCalls).toBe(1))
+
+    collector.onAgentStart('pty-second', 2_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(gate.writeFileCalls).toBe(1)
+    expect(gate.maxActiveWriteFileCalls).toBe(1)
+
+    gate.blocked = false
+    gate.waiters.splice(0).forEach((resolve) => resolve())
+    await vi.waitFor(() => expect(gate.writeFileCalls).toBe(2))
+    await vi.waitFor(() =>
+      expect(JSON.parse(readFileSync(statsPath(), 'utf-8')).aggregates.totalAgentsSpawned).toBe(2)
+    )
+    expect(gate.maxActiveWriteFileCalls).toBe(1)
+  })
+
+  it('cleans a partial temp write and allows the next debounced save', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { StatsCollector, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+
+    gate.failAfterWriteOnce = true
+    collector.onAgentStart('pty-failed', 1_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled())
+    expect(readdirSync(userDataDir).filter((file) => file.endsWith('.tmp'))).toHaveLength(0)
+
+    collector.onAgentStart('pty-retry', 2_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.waitFor(() =>
+      expect(JSON.parse(readFileSync(statsPath(), 'utf-8')).aggregates.totalAgentsSpawned).toBe(2)
+    )
+    expect(readdirSync(userDataDir).filter((file) => file.endsWith('.tmp'))).toHaveLength(0)
+    errorSpy.mockRestore()
+  })
+
+  it('flush cancels a debounced attempt queued behind an in-flight write', async () => {
+    vi.useFakeTimers()
+    const { StatsCollector, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+
+    gate.blocked = true
+    collector.onAgentStart('pty-a', 1_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.waitFor(() => expect(gate.writeFileCalls).toBe(1))
+
+    collector.onAgentStart('pty-b', 1_000)
+    await vi.advanceTimersByTimeAsync(5_000)
+    collector.onAgentStop('pty-a', 5_000)
+    collector.onAgentStop('pty-b', 5_000)
+    collector.flush()
+
+    gate.blocked = false
+    gate.waiters.splice(0).forEach((resolve) => resolve())
+    await vi.waitFor(() => expect(gate.activeWriteFileCalls).toBe(0))
+    await vi.waitFor(() =>
+      expect(readdirSync(userDataDir).filter((file) => file.endsWith('.tmp'))).toHaveLength(0)
+    )
+
+    expect(gate.writeFileCalls).toBe(1)
+    expect(JSON.parse(readFileSync(statsPath(), 'utf-8')).aggregates.totalAgentTimeMs).toBe(8_000)
+  })
+
+  it('cleans the temp file when the async rename fails', async () => {
+    const { StatsCollector, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+    const internals = collector as unknown as { writeToDiskAsync: () => Promise<void> }
+
+    collector.onAgentStart('pty-rename', 1_000)
+    gate.failRenameOnce = true
+
+    await expect(internals.writeToDiskAsync()).rejects.toThrow('injected rename failure')
+    expect(readdirSync(userDataDir).filter((file) => file.endsWith('.tmp'))).toHaveLength(0)
   })
 
   it('an in-flight async write is vetoed by a shutdown flush (no data-loss clobber)', async () => {

--- a/src/main/stats/collector.ts
+++ b/src/main/stats/collector.ts
@@ -56,6 +56,8 @@ export class StatsCollector {
   private aggregates: StatsAggregates
   private liveAgents = new Map<string, number>() // ptyId → startTimestamp
   private writeTimer: ReturnType<typeof setTimeout> | null = null
+  private asyncWriteTail: Promise<void> = Promise.resolve()
+  private asyncWriteEpoch = 0
   // Monotonic id stamped on each prepared payload; the highest committed one
   // wins so a slow in-flight async write can't clobber a newer sync flush.
   private writeGeneration = 0
@@ -154,6 +156,7 @@ export class StatsCollector {
       this.onAgentStop(ptyId, now)
     }
     this.cancelPendingSave()
+    this.asyncWriteEpoch += 1
     this.writeToDiskSync()
   }
 
@@ -237,10 +240,18 @@ export class StatsCollector {
       // A chatty multi-agent session re-arms this every 5s; a fully-sync write
       // is a recurring main-thread stall. Shutdown flush() stays synchronous;
       // the generation guard keeps the two paths race-safe.
-      void this.writeToDiskAsync().catch((err) => {
-        console.error('[stats] Failed to write stats:', err)
-      })
+      this.enqueueAsyncWrite()
     }, DEBOUNCE_MS)
+  }
+
+  private enqueueAsyncWrite(): void {
+    const epoch = this.asyncWriteEpoch
+    const attempt = this.asyncWriteTail.then(() =>
+      epoch === this.asyncWriteEpoch ? this.writeToDiskAsync() : undefined
+    )
+    this.asyncWriteTail = attempt.catch((err) => {
+      console.error('[stats] Failed to write stats:', err)
+    })
   }
 
   private cancelPendingSave(): void {
@@ -294,9 +305,6 @@ export class StatsCollector {
 
   private async writeToDiskAsync(): Promise<void> {
     const dir = dirname(getStatsFile())
-    if (!existsSync(dir)) {
-      await mkdir(dir, { recursive: true })
-    }
     const { statsFile, tmpFile, json, generation } = this.prepareWritePayload()
     // Only the ~900KB tmp write moves off the main thread; stringify stayed sync
     // above (torn-snapshot constraint). The rename is a trivial metadata op done
@@ -306,12 +314,18 @@ export class StatsCollector {
     // later debounce OR the shutdown flush) already committed while we were
     // writing; the check + rename run with no await between them, so the sync
     // flush cannot interleave.
-    await writeFile(tmpFile, json, 'utf-8')
-    if (this.lastCommittedGeneration >= generation) {
+    try {
+      if (!existsSync(dir)) {
+        await mkdir(dir, { recursive: true })
+      }
+      await writeFile(tmpFile, json, 'utf-8')
+      if (this.lastCommittedGeneration >= generation) {
+        return
+      }
+      renameSync(tmpFile, statsFile)
+      this.lastCommittedGeneration = generation
+    } finally {
       await rm(tmpFile, { force: true }).catch(() => {})
-      return
     }
-    renameSync(tmpFile, statsFile)
-    this.lastCommittedGeneration = generation
   }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1383,6 +1383,7 @@ export type PreloadApi = {
     confirmForegroundProcess: (id: string) => Promise<string | null>
     getCwd: (id: string) => Promise<string>
     getSize: (id: string) => Promise<{ cols: number; rows: number } | null>
+    listSessionIds: () => Promise<string[]>
     listSessions: () => Promise<{ id: string; cwd: string; title: string }[]>
     getAuthoritativeBufferSnapshotCapabilities?: (
       ids: string[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -922,6 +922,7 @@ const api = {
     kill: (id: string, opts?: { keepHistory?: boolean }): Promise<void> =>
       ipcRenderer.invoke('pty:kill', { id, keepHistory: opts?.keepHistory ?? false }),
 
+    listSessionIds: (): Promise<string[]> => ipcRenderer.invoke('pty:listSessionIds'),
     listSessions: (): Promise<{ id: string; cwd: string; title: string }[]> =>
       ipcRenderer.invoke('pty:listSessions'),
     getAuthoritativeBufferSnapshotCapabilities: (

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -152,6 +152,7 @@ describe('PtyHandler', () => {
     expect(methods).toContain('pty.hasChildProcesses')
     expect(methods).toContain('pty.getForegroundProcess')
     expect(methods).toContain('pty.inspectProcess')
+    expect(methods).toContain('pty.listSessionIds')
     expect(methods).toContain('pty.listProcesses')
     expect(methods).toContain('pty.getDefaultShell')
 
@@ -207,6 +208,21 @@ describe('PtyHandler', () => {
     expect(result).toEqual({ id: 'pty-1', incarnationId: expect.any(String) })
     expect(mockPtySpawn).toHaveBeenCalled()
     expect(handler.activePtyCount).toBe(1)
+  })
+
+  it('lists live PTY IDs without foreground-process inspection', async () => {
+    const foregroundSpy = vi
+      .spyOn(ptyShellUtils, 'getForegroundProcessName')
+      .mockResolvedValue('shell')
+    await spawnPty({ cols: 80, rows: 24 })
+    await spawnPty({ cols: 80, rows: 24 })
+
+    await expect(dispatcher.callRequest('pty.listSessionIds', {})).resolves.toEqual([
+      'pty-1',
+      'pty-2'
+    ])
+    expect(foregroundSpy).not.toHaveBeenCalled()
+    foregroundSpy.mockRestore()
   })
 
   it("does not forward Orca's own NODE_ENV into the spawned shell", async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -627,6 +627,7 @@ export class PtyHandler {
       agentSessionClaimVersion: AGENT_SESSION_EXECUTION_OWNER_PROTOCOL_VERSION,
       agentSessionCreateOperationVersion: AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION
     }))
+    this.dispatcher.onRequest('pty.listSessionIds', async () => this.listSessionIds())
     this.dispatcher.onRequest('pty.listProcesses', () => this.listProcesses())
     this.dispatcher.onRequest('pty.getDefaultShell', async () => resolveDefaultShell())
     this.dispatcher.onRequest('pty.serialize', (p) => this.serialize(p))
@@ -1424,6 +1425,16 @@ export class PtyHandler {
       })
     }
     return results
+  }
+
+  private listSessionIds(): string[] {
+    const ids: string[] = []
+    for (const [id, managed] of this.ptys) {
+      if (!managed.disposed) {
+        ids.push(id)
+      }
+    }
+    return ids
   }
 
   private async serialize(params: Record<string, unknown>): Promise<string> {

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.session-polling.test.ts
@@ -13,8 +13,9 @@ describe('ResourceUsageStatusSegment session inventory', () => {
     expect(source).not.toContain('installWindowVisibilityInterval')
     expect(source).not.toContain('SESSIONS_POLL_MS')
     expect(inventoryHookSource).not.toContain('setInterval')
-    // Why: every seed/action/lifecycle refresh shares one guarded inventory
-    // read, and the closed path never installs a polling interval.
+    // Why: the closed seed uses the cheap ID path while open/action refreshes
+    // retain one guarded detail read.
+    expect(inventoryHookSource.match(/window\.api\.pty\.listSessionIds\(\)/g) ?? []).toHaveLength(1)
     expect(inventoryHookSource.match(/window\.api\.pty\.listSessions\(\)/g) ?? []).toHaveLength(1)
 
     const openEffectIndex = source.indexOf('if (!open)')
@@ -34,6 +35,7 @@ describe('ResourceUsageStatusSegment session inventory', () => {
     expect(source).toContain('sessionInventory.count')
     expect(inventoryHookSource).toContain('window.api.pty.onSpawned')
     expect(inventoryHookSource).toContain('window.api.pty.onExit')
+    expect(inventoryHookSource).toContain('window.api.pty.listSessionIds')
     expect(source).not.toContain('createClosedResourceSessionCountSelector')
     expect(source).not.toContain('boundPtyIds.size')
     expect(source).not.toContain('closedSessionCount')

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -752,7 +752,7 @@ export function ResourceUsageStatusSegment({
     clearSessionsError,
     removeSession,
     removeSessions
-  } = useResourceSessionInventory(workspaceSessionReady)
+  } = useResourceSessionInventory(workspaceSessionReady, open)
   const sessions = sessionInventory.sessions
   const [killConfirm, setKillConfirm] = useState<UnifiedSessionRow | null>(null)
   const [killing, setKilling] = useState(false)

--- a/src/renderer/src/components/status-bar/resource-session-inventory.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-inventory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   EMPTY_DAEMON_SESSION_INVENTORY,
+  inventoryFromSessionIds,
   inventoryFromSessions,
   removeSessionFromInventory,
   removeSessionsFromInventory
@@ -13,9 +14,18 @@ function session(id: string): DaemonSession {
 
 describe('resource session inventory', () => {
   it('builds count from daemon listSessions payloads', () => {
-    const inventory = inventoryFromSessions([session('a'), session('b')])
+    const inventory = inventoryFromSessions([session('a'), session('b'), session('a')])
     expect(inventory.count).toBe(2)
+    expect(inventory.sessionIds).toEqual(['a', 'b'])
     expect(inventory.sessions.map((entry) => entry.id)).toEqual(['a', 'b'])
+  })
+
+  it('builds a detail-free count from unique session IDs', () => {
+    expect(inventoryFromSessionIds(['a', 'b', 'a'])).toEqual({
+      sessionIds: ['a', 'b'],
+      sessions: [],
+      count: 2
+    })
   })
 
   it('returns a detached sessions array so callers can mutate safely', () => {
@@ -30,10 +40,16 @@ describe('resource session inventory', () => {
     const start = inventoryFromSessions([session('live'), session('orphan'), session('other')])
     const afterOne = removeSessionFromInventory(start, 'orphan')
     expect(afterOne.count).toBe(2)
+    expect(afterOne.sessionIds).toEqual(['live', 'other'])
     expect(afterOne.sessions.map((entry) => entry.id)).toEqual(['live', 'other'])
 
     const afterMany = removeSessionsFromInventory(start, new Set(['live', 'missing', 'other']))
     expect(afterMany).toEqual(inventoryFromSessions([session('orphan')]))
+  })
+
+  it('removes sessions from a detail-free ID inventory', () => {
+    const start = inventoryFromSessionIds(['live', 'exited'])
+    expect(removeSessionFromInventory(start, 'exited')).toEqual(inventoryFromSessionIds(['live']))
   })
 
   it('is a no-op when removed ids are absent', () => {

--- a/src/renderer/src/components/status-bar/resource-session-inventory.ts
+++ b/src/renderer/src/components/status-bar/resource-session-inventory.ts
@@ -2,19 +2,32 @@ import type { DaemonSession } from './resource-usage-merge-types'
 
 /** Last-known daemon terminal inventory for the Resource Manager badge. */
 export type DaemonSessionInventory = {
+  sessionIds: string[]
   sessions: DaemonSession[]
   count: number
 }
 
 export const EMPTY_DAEMON_SESSION_INVENTORY: DaemonSessionInventory = {
+  sessionIds: [],
   sessions: [],
   count: 0
 }
 
 export function inventoryFromSessions(sessions: readonly DaemonSession[]): DaemonSessionInventory {
+  const deduped = new Map(sessions.map((session) => [session.id, session]))
   return {
-    sessions: sessions.slice(),
-    count: sessions.length
+    sessionIds: Array.from(deduped.keys()),
+    sessions: Array.from(deduped.values()),
+    count: deduped.size
+  }
+}
+
+export function inventoryFromSessionIds(sessionIds: readonly string[]): DaemonSessionInventory {
+  const uniqueIds = Array.from(new Set(sessionIds))
+  return {
+    sessionIds: uniqueIds,
+    sessions: [],
+    count: uniqueIds.length
   }
 }
 
@@ -22,16 +35,18 @@ export function removeSessionsFromInventory(
   inventory: DaemonSessionInventory,
   sessionIds: ReadonlySet<string>
 ): DaemonSessionInventory {
-  if (sessionIds.size === 0 || inventory.sessions.length === 0) {
+  if (sessionIds.size === 0 || inventory.sessionIds.length === 0) {
     return inventory
   }
+  const retainedIds = inventory.sessionIds.filter((id) => !sessionIds.has(id))
   const sessions = inventory.sessions.filter((session) => !sessionIds.has(session.id))
-  if (sessions.length === inventory.sessions.length) {
+  if (retainedIds.length === inventory.sessionIds.length) {
     return inventory
   }
   return {
+    sessionIds: retainedIds,
     sessions,
-    count: sessions.length
+    count: retainedIds.length
   }
 }
 

--- a/src/renderer/src/components/status-bar/use-resource-session-inventory.test.tsx
+++ b/src/renderer/src/components/status-bar/use-resource-session-inventory.test.tsx
@@ -17,6 +17,7 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 }
 
 describe('useResourceSessionInventory', () => {
+  const listSessionIds = vi.fn<() => Promise<string[]>>()
   const listSessions = vi.fn<() => Promise<DaemonSession[]>>()
   const unsubscribeSpawned = vi.fn()
   const unsubscribeExit = vi.fn()
@@ -26,11 +27,13 @@ describe('useResourceSessionInventory', () => {
   beforeEach(() => {
     spawnedCallback = null
     exitCallback = null
+    listSessionIds.mockReset()
     listSessions.mockReset()
     unsubscribeSpawned.mockReset()
     unsubscribeExit.mockReset()
     ;(window as unknown as { api: unknown }).api = {
       pty: {
+        listSessionIds,
         listSessions,
         onSpawned: (callback: (data: { id: string }) => void) => {
           spawnedCallback = callback
@@ -48,29 +51,30 @@ describe('useResourceSessionInventory', () => {
     delete (window as unknown as { api?: unknown }).api
   })
 
-  it('seeds from the daemon inventory and resets when session restore is not ready', async () => {
-    listSessions.mockResolvedValue([session('one'), session('two')])
-    const { result, rerender } = renderHook(({ ready }) => useResourceSessionInventory(ready), {
-      initialProps: { ready: false }
-    })
+  it('seeds the closed badge from IDs without listing details and resets with readiness', async () => {
+    listSessionIds.mockResolvedValue(['one', 'two'])
+    const { result, rerender } = renderHook(
+      ({ ready }) => useResourceSessionInventory(ready, false),
+      { initialProps: { ready: false } }
+    )
 
-    expect(result.current.sessionInventory.count).toBe(0)
-    expect(listSessions).not.toHaveBeenCalled()
-
+    expect(listSessionIds).not.toHaveBeenCalled()
     rerender({ ready: true })
     await waitFor(() => expect(result.current.sessionInventory.count).toBe(2))
-    expect(listSessions).toHaveBeenCalledTimes(1)
+
+    expect(result.current.sessionInventory.sessions).toEqual([])
+    expect(listSessionIds).toHaveBeenCalledTimes(1)
+    expect(listSessions).not.toHaveBeenCalled()
 
     rerender({ ready: false })
     expect(result.current.sessionInventory.count).toBe(0)
     expect(result.current.sessionsError).toBe(false)
   })
 
-  it('recovers inventory and clears the error after a failed readiness seed', async () => {
-    listSessions
-      .mockRejectedValueOnce(new Error('daemon unavailable'))
-      .mockResolvedValueOnce([session('recovered')])
-    const { result } = renderHook(() => useResourceSessionInventory(true))
+  it('recovers a failed ID seed through an explicit detail refresh', async () => {
+    listSessionIds.mockRejectedValue(new Error('daemon unavailable'))
+    listSessions.mockResolvedValue([session('recovered')])
+    const { result } = renderHook(() => useResourceSessionInventory(true, true))
 
     await waitFor(() => expect(result.current.sessionsError).toBe(true))
     await act(async () => {
@@ -81,182 +85,159 @@ describe('useResourceSessionInventory', () => {
     expect(result.current.sessionsError).toBe(false)
   })
 
-  it('refreshes for background spawns without depending on mounted pane state', async () => {
-    listSessions
-      .mockResolvedValueOnce([session('one')])
-      .mockResolvedValue([session('one'), session('background')])
-    const { result } = renderHook(() => useResourceSessionInventory(true))
+  it('uses only ID inventory for closed lifecycle signals and ignores known reattaches', async () => {
+    listSessionIds
+      .mockResolvedValueOnce(['one'])
+      .mockResolvedValueOnce(['one', 'background', 'background-2'])
+    const { result } = renderHook(() => useResourceSessionInventory(true, false))
     await waitFor(() => expect(result.current.sessionInventory.count).toBe(1))
 
-    await act(async () => {
+    act(() => {
       spawnedCallback?.({ id: 'one' })
+    })
+    expect(listSessionIds).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
       spawnedCallback?.({ id: 'background' })
       spawnedCallback?.({ id: 'background-2' })
       await new Promise((resolve) => window.setTimeout(resolve, 0))
     })
-
-    await waitFor(() => expect(result.current.sessionInventory.count).toBe(2))
-    expect(listSessions).toHaveBeenCalledTimes(2)
-  })
-
-  it('does not inventory again when an existing session reattaches', async () => {
-    listSessions.mockResolvedValue([session('one')])
-    const { result } = renderHook(() => useResourceSessionInventory(true))
-    await waitFor(() => expect(result.current.sessionInventory.count).toBe(1))
-
-    act(() => {
-      spawnedCallback?.({ id: 'one' })
-    })
-
-    expect(listSessions).toHaveBeenCalledTimes(1)
-  })
-
-  it('does not overlap provider-wide inventory reads for spawns during a slow refresh', async () => {
-    listSessions.mockResolvedValueOnce([session('one')])
-    const { result } = renderHook(() => useResourceSessionInventory(true))
-    await waitFor(() => expect(result.current.sessionInventory.count).toBe(1))
-
-    const inFlight = deferred<DaemonSession[]>()
-    listSessions.mockReturnValueOnce(inFlight.promise)
-    await act(async () => {
-      spawnedCallback?.({ id: 'background-one' })
-      await new Promise((resolve) => window.setTimeout(resolve, 0))
-    })
-    expect(listSessions).toHaveBeenCalledTimes(2)
-
-    await act(async () => {
-      spawnedCallback?.({ id: 'background-two' })
-      await new Promise((resolve) => window.setTimeout(resolve, 0))
-    })
-    expect(listSessions).toHaveBeenCalledTimes(2)
-
-    await act(async () => {
-      inFlight.resolve([session('one'), session('background-one'), session('background-two')])
-      await inFlight.promise
-    })
     await waitFor(() => expect(result.current.sessionInventory.count).toBe(3))
-    expect(listSessions).toHaveBeenCalledTimes(2)
+
+    expect(listSessionIds).toHaveBeenCalledTimes(2)
+    expect(listSessions).not.toHaveBeenCalled()
   })
 
-  it('reconciles once when an in-flight inventory misses a later spawn', async () => {
-    listSessions.mockResolvedValueOnce([session('one')])
-    const { result } = renderHook(() => useResourceSessionInventory(true))
-    await waitFor(() => expect(result.current.sessionInventory.count).toBe(1))
+  it('coalesces an ID seed and runs one cheap follow-up when it misses a later spawn', async () => {
+    const seed = deferred<string[]>()
+    listSessionIds
+      .mockReturnValueOnce(seed.promise)
+      .mockResolvedValueOnce(['one', 'background-one', 'background-two'])
+    const { result } = renderHook(() => useResourceSessionInventory(true, false))
 
-    const inFlight = deferred<DaemonSession[]>()
-    listSessions
-      .mockReturnValueOnce(inFlight.promise)
-      .mockResolvedValueOnce([session('one'), session('background-one'), session('background-two')])
     await act(async () => {
       spawnedCallback?.({ id: 'background-one' })
       await new Promise((resolve) => window.setTimeout(resolve, 0))
     })
+    expect(listSessionIds).toHaveBeenCalledTimes(1)
+
     act(() => {
       spawnedCallback?.({ id: 'background-two' })
     })
-
     await act(async () => {
-      inFlight.resolve([session('one'), session('background-one')])
-      await inFlight.promise
+      seed.resolve(['one', 'background-one'])
+      await seed.promise
     })
+
     await waitFor(() => expect(result.current.sessionInventory.count).toBe(3))
-    expect(listSessions).toHaveBeenCalledTimes(3)
+    expect(listSessionIds).toHaveBeenCalledTimes(2)
+    expect(listSessions).not.toHaveBeenCalled()
   })
 
-  it('cancels a queued inventory read when the unknown session exits first', async () => {
-    listSessions.mockResolvedValueOnce([session('one')])
-    const { result } = renderHook(() => useResourceSessionInventory(true))
-    await waitFor(() => expect(result.current.sessionInventory.count).toBe(1))
+  it('does not resurrect an exit that races the ID seed', async () => {
+    const seed = deferred<string[]>()
+    listSessionIds.mockReturnValue(seed.promise)
+    const { result } = renderHook(() => useResourceSessionInventory(true, false))
 
-    act(() => {
-      spawnedCallback?.({ id: 'short-lived' })
-      exitCallback?.({ id: 'short-lived', code: 0 })
-    })
-    await new Promise((resolve) => window.setTimeout(resolve, 0))
-
-    expect(listSessions).toHaveBeenCalledTimes(1)
-    expect(result.current.sessionInventory.count).toBe(1)
-  })
-
-  it('does not schedule follow-up inventory after unmount', async () => {
-    listSessions.mockResolvedValueOnce([session('one')])
-    const { result, unmount } = renderHook(() => useResourceSessionInventory(true))
-    await waitFor(() => expect(result.current.sessionInventory.count).toBe(1))
-
-    const inFlight = deferred<DaemonSession[]>()
-    listSessions.mockReturnValueOnce(inFlight.promise)
-    await act(async () => {
-      spawnedCallback?.({ id: 'background-one' })
-      await new Promise((resolve) => window.setTimeout(resolve, 0))
-    })
-    act(() => {
-      spawnedCallback?.({ id: 'background-two' })
-    })
-    unmount()
-
-    inFlight.resolve([session('one'), session('background-one')])
-    await inFlight.promise
-    await new Promise((resolve) => window.setTimeout(resolve, 0))
-
-    expect(listSessions).toHaveBeenCalledTimes(2)
-  })
-
-  it('filters an exit from an in-flight list without losing other new sessions', async () => {
-    listSessions.mockResolvedValueOnce([session('one'), session('exited')])
-    const { result } = renderHook(() => useResourceSessionInventory(true))
-    await waitFor(() => expect(result.current.sessionInventory.count).toBe(2))
-
-    const stale = deferred<DaemonSession[]>()
-    listSessions.mockReturnValueOnce(stale.promise)
-    let refresh!: Promise<void>
-    act(() => {
-      refresh = result.current.refreshSessions()
-    })
     act(() => {
       exitCallback?.({ id: 'exited', code: 0 })
     })
-    expect(result.current.sessionInventory.sessions.map(({ id }) => id)).toEqual(['one'])
-
     await act(async () => {
-      stale.resolve([session('one'), session('exited'), session('background')])
-      await refresh
+      seed.resolve(['live', 'exited'])
+      await seed.promise
     })
-    expect(result.current.sessionInventory.sessions.map(({ id }) => id)).toEqual([
-      'one',
-      'background'
-    ])
+
+    expect(result.current.sessionInventory.sessionIds).toEqual(['live'])
+    expect(result.current.sessionInventory.count).toBe(1)
   })
 
-  it('keeps the newest result when refreshes resolve out of order', async () => {
-    listSessions.mockResolvedValueOnce([session('one')])
-    const { result } = renderHook(() => useResourceSessionInventory(true))
+  it('uses full details for lifecycle refreshes while open', async () => {
+    listSessionIds.mockResolvedValue(['one'])
+    listSessions.mockResolvedValue([session('one'), session('background')])
+    const { result } = renderHook(() => useResourceSessionInventory(true, true))
     await waitFor(() => expect(result.current.sessionInventory.count).toBe(1))
 
-    const older = deferred<DaemonSession[]>()
-    const newer = deferred<DaemonSession[]>()
-    listSessions.mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise)
-    let olderRefresh!: Promise<void>
-    let newerRefresh!: Promise<void>
+    await act(async () => {
+      spawnedCallback?.({ id: 'background' })
+      await new Promise((resolve) => window.setTimeout(resolve, 0))
+    })
+    await waitFor(() => expect(result.current.sessionInventory.sessions).toHaveLength(2))
+
+    expect(listSessionIds).toHaveBeenCalledTimes(1)
+    expect(listSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-seeds IDs when closing cancels a queued detail refresh', async () => {
+    listSessionIds
+      .mockResolvedValueOnce(['one'])
+      .mockResolvedValueOnce(['one', 'queued-before-close'])
+    const { result, rerender } = renderHook(
+      ({ detailsEnabled }) => useResourceSessionInventory(true, detailsEnabled),
+      { initialProps: { detailsEnabled: true } }
+    )
+    await waitFor(() => expect(result.current.sessionInventory.count).toBe(1))
+
     act(() => {
-      olderRefresh = result.current.refreshSessions()
-      newerRefresh = result.current.refreshSessions()
+      spawnedCallback?.({ id: 'queued-before-close' })
+      rerender({ detailsEnabled: false })
     })
+    await waitFor(() => expect(result.current.sessionInventory.count).toBe(2))
+
+    expect(listSessionIds).toHaveBeenCalledTimes(2)
+    expect(listSessions).not.toHaveBeenCalled()
+  })
+
+  it('starts a fresh close seed when a detail refresh superseded the first ID seed', async () => {
+    const staleSeed = deferred<string[]>()
+    const detailRefresh = deferred<DaemonSession[]>()
+    listSessionIds
+      .mockReturnValueOnce(staleSeed.promise)
+      .mockResolvedValueOnce(['one', 'queued-before-close'])
+    listSessions.mockReturnValue(detailRefresh.promise)
+    const { result, rerender } = renderHook(
+      ({ detailsEnabled }) => useResourceSessionInventory(true, detailsEnabled),
+      { initialProps: { detailsEnabled: true } }
+    )
+    await waitFor(() => expect(listSessionIds).toHaveBeenCalledTimes(1))
+
+    let details!: Promise<void>
+    act(() => {
+      details = result.current.refreshSessions()
+      spawnedCallback?.({ id: 'queued-before-close' })
+      rerender({ detailsEnabled: false })
+    })
+    await waitFor(() => expect(result.current.sessionInventory.count).toBe(2))
 
     await act(async () => {
-      newer.resolve([session('one'), session('two')])
-      await newerRefresh
+      detailRefresh.resolve([session('one')])
+      staleSeed.resolve(['one'])
+      await Promise.all([details, staleSeed.promise])
+    })
+    expect(result.current.sessionInventory.sessionIds).toEqual(['one', 'queued-before-close'])
+    expect(listSessionIds).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the newer detail result when an older ID seed resolves later', async () => {
+    const seed = deferred<string[]>()
+    listSessionIds.mockReturnValue(seed.promise)
+    listSessions.mockResolvedValue([session('one'), session('newer')])
+    const { result } = renderHook(() => useResourceSessionInventory(true, true))
+
+    await act(async () => {
+      await result.current.refreshSessions()
     })
     await act(async () => {
-      older.resolve([session('one')])
-      await olderRefresh
+      seed.resolve(['one'])
+      await seed.promise
     })
 
+    expect(result.current.sessionInventory.sessions).toEqual([session('one'), session('newer')])
     expect(result.current.sessionInventory.count).toBe(2)
   })
 
   it('unsubscribes from lifecycle events on unmount', () => {
-    listSessions.mockResolvedValue([])
-    const { unmount } = renderHook(() => useResourceSessionInventory(true))
+    listSessionIds.mockResolvedValue([])
+    const { unmount } = renderHook(() => useResourceSessionInventory(true, false))
 
     unmount()
 

--- a/src/renderer/src/components/status-bar/use-resource-session-inventory.ts
+++ b/src/renderer/src/components/status-bar/use-resource-session-inventory.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   EMPTY_DAEMON_SESSION_INVENTORY,
+  inventoryFromSessionIds,
   inventoryFromSessions,
   removeSessionFromInventory,
   removeSessionsFromInventory,
@@ -23,9 +24,14 @@ type ResourceSessionInventoryState = {
   sessionsError: boolean
 }
 
-export function useResourceSessionInventory(ready: boolean): ResourceSessionInventory {
+export function useResourceSessionInventory(
+  ready: boolean,
+  detailsEnabled: boolean
+): ResourceSessionInventory {
   const mountedRef = useMountedRef()
   const refreshGenerationRef = useRef(0)
+  const sessionIdRefreshRef = useRef<{ generation: number; promise: Promise<void> } | null>(null)
+  const previousDetailsEnabledRef = useRef(detailsEnabled)
   const lifecycleRevisionRef = useRef(0)
   const removedAtRevisionRef = useRef(new Map<string, number>())
   const knownSessionIdsRef = useRef(new Set<string>())
@@ -48,6 +54,66 @@ export function useResourceSessionInventory(ready: boolean): ResourceSessionInve
     setStoredState(state)
   }
 
+  const commitInventory = useCallback(
+    (
+      generation: number,
+      lifecycleRevision: number,
+      sessionIds: readonly string[],
+      sessions?: readonly DaemonSessionInventory['sessions'][number][]
+    ): void => {
+      if (!mountedRef.current || generation !== refreshGenerationRef.current) {
+        return
+      }
+      const currentRemovedAtRevision = removedAtRevisionRef.current
+      const liveIds = sessionIds.filter(
+        (id) => (currentRemovedAtRevision.get(id) ?? 0) <= lifecycleRevision
+      )
+      const liveIdSet = new Set(liveIds)
+      for (const [id, removedAtRevision] of currentRemovedAtRevision) {
+        if (removedAtRevision <= lifecycleRevision) {
+          currentRemovedAtRevision.delete(id)
+        }
+      }
+      knownSessionIdsRef.current = liveIdSet
+      setStoredState({
+        ready: true,
+        sessionInventory: sessions
+          ? inventoryFromSessions(sessions.filter(({ id }) => liveIdSet.has(id)))
+          : inventoryFromSessionIds(liveIds),
+        sessionsError: false
+      })
+    },
+    [mountedRef]
+  )
+
+  const refreshSessionIds = useCallback((): Promise<void> => {
+    if (!ready) {
+      return Promise.resolve()
+    }
+    const currentRefresh = sessionIdRefreshRef.current
+    if (currentRefresh?.generation === refreshGenerationRef.current) {
+      return currentRefresh.promise
+    }
+    const generation = ++refreshGenerationRef.current
+    const lifecycleRevision = lifecycleRevisionRef.current
+    const refresh = (async (): Promise<void> => {
+      try {
+        const sessionIds = await window.api.pty.listSessionIds()
+        commitInventory(generation, lifecycleRevision, sessionIds)
+      } catch {
+        if (mountedRef.current && generation === refreshGenerationRef.current) {
+          setStoredState((current) => ({ ...current, sessionsError: true }))
+        }
+      }
+    })().finally(() => {
+      if (sessionIdRefreshRef.current?.promise === refresh) {
+        sessionIdRefreshRef.current = null
+      }
+    })
+    sessionIdRefreshRef.current = { generation, promise: refresh }
+    return refresh
+  }, [commitInventory, mountedRef, ready])
+
   const refreshSessions = useCallback(async (): Promise<void> => {
     if (!ready) {
       return
@@ -56,34 +122,18 @@ export function useResourceSessionInventory(ready: boolean): ResourceSessionInve
     const lifecycleRevision = lifecycleRevisionRef.current
     try {
       const sessions = await window.api.pty.listSessions()
-      // Why: an exit or newer refresh can land while the global provider list
-      // is in flight; stale results must not resurrect dead sessions.
-      if (!mountedRef.current || generation !== refreshGenerationRef.current) {
-        return
-      }
-      const currentRemovedAtRevision = removedAtRevisionRef.current
-      const liveSessions = sessions.filter(
-        ({ id }) => (currentRemovedAtRevision.get(id) ?? 0) <= lifecycleRevision
+      commitInventory(
+        generation,
+        lifecycleRevision,
+        sessions.map(({ id }) => id),
+        sessions
       )
-      // Tombstones at or before this request cannot suppress later ID reuse;
-      // only exits that raced this request must survive to the next refresh.
-      for (const [id, removedAtRevision] of currentRemovedAtRevision) {
-        if (removedAtRevision <= lifecycleRevision) {
-          currentRemovedAtRevision.delete(id)
-        }
-      }
-      knownSessionIdsRef.current = new Set(liveSessions.map(({ id }) => id))
-      setStoredState({
-        ready: true,
-        sessionInventory: inventoryFromSessions(liveSessions),
-        sessionsError: false
-      })
     } catch {
       if (mountedRef.current && generation === refreshGenerationRef.current) {
         setStoredState((current) => ({ ...current, sessionsError: true }))
       }
     }
-  }, [mountedRef, ready])
+  }, [commitInventory, mountedRef, ready])
 
   const clearSessionsError = useCallback((): void => {
     setStoredState((current) => ({ ...current, sessionsError: false }))
@@ -115,13 +165,22 @@ export function useResourceSessionInventory(ready: boolean): ResourceSessionInve
 
   useEffect(() => {
     refreshGenerationRef.current += 1
+    sessionIdRefreshRef.current = null
     if (!ready) {
       removedAtRevisionRef.current.clear()
       knownSessionIdsRef.current.clear()
       return
     }
-    void refreshSessions()
-  }, [ready, refreshSessions])
+    void refreshSessionIds()
+  }, [ready, refreshSessionIds])
+
+  useEffect(() => {
+    const wasEnabled = previousDetailsEnabledRef.current
+    previousDetailsEnabledRef.current = detailsEnabled
+    if (ready && wasEnabled && !detailsEnabled) {
+      void refreshSessionIds()
+    }
+  }, [detailsEnabled, ready, refreshSessionIds])
 
   useEffect(() => {
     if (!ready) {
@@ -141,7 +200,7 @@ export function useResourceSessionInventory(ready: boolean): ResourceSessionInve
           return
         }
         pendingSpawnIds.clear()
-        const refresh = refreshSessions()
+        const refresh = detailsEnabled ? refreshSessions() : refreshSessionIds()
         lifecycleRefresh = refresh
         void refresh.finally(() => {
           if (disposed || lifecycleRefresh !== refresh) {
@@ -183,7 +242,7 @@ export function useResourceSessionInventory(ready: boolean): ResourceSessionInve
       unsubscribeSpawned()
       unsubscribeExit()
     }
-  }, [ready, refreshSessions, removeSession])
+  }, [detailsEnabled, ready, refreshSessionIds, refreshSessions, removeSession])
 
   return {
     sessionInventory: state.sessionInventory,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2954,6 +2954,7 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     confirmForegroundProcess: () => Promise.resolve(null),
     getCwd: () => Promise.resolve('~'),
     getSize: () => Promise.resolve(null),
+    listSessionIds: () => Promise.resolve([]),
     listSessions: () => Promise.resolve([]),
     getAuthoritativeBufferSnapshotCapabilities: (ids) =>
       ids.map((id) => ({ id, authoritative: false })),


### PR DESCRIPTION
## Summary

- Add a protocol-29 `listSessionIds` path through daemon, local, SSH, relay, IPC, preload, and the Resource Manager inventory. Current daemons use the cheap ID-only RPC; preserved daemons and older SSH relays use bounded compatibility fallbacks, with deduplication and admission limits.
- Keep the closed Resource Manager badge on the ID-only seed path while retaining full session details for open/action refreshes, including lifecycle and stale-result race coverage.
- Serialize debounced async stats writes, clean temporary files on write/rename failure, and prevent queued stale writes from running after a synchronous flush.
- Bound each final dropped-output query salvage chunk to the remaining 4KB allowance and add regression coverage for both overshoot and query-boundary behavior.

## Release-scan references

- [#9697](https://github.com/stablyai/orca/pull/9697) — moved debounced stats persistence off the main thread; this PR closes the reported overlap and temporary-file cleanup residuals.
- [#9387](https://github.com/stablyai/orca/pull/9387) — introduced the Resource Manager closed-badge `listSessions` seed; this PR changes that closed seed to a bounded ID-only inventory.
- Pre-existing 4KB dropped-output query salvage finding: the release scan documented that the unchanged append path could let one extracted chunk exceed `DROPPED_QUERY_SALVAGE_MAX_CHARS`; this finding predates the audited release span, and this PR bounds the final chunk.

## Validation

- 799 focused tests passed.
- `pnpm typecheck` passed.
- Touched-file oxlint passed.
- Max-lines ratchet passed.
- `git diff --check` passed.
- Wider suite reached 36,526 passing; three unrelated unchanged macOS PTY-device tests failed with `posix_openpt errno 6`.

## Test plan

- Verify daemon protocol versioning, current and preserved daemon ID listing, relay ID listing, SSH method-not-found fallback and non-cacheable transport/payload failures.
- Verify bounded, deduplicated provider aggregation and that closed Resource Manager seeding does not load process details while open lifecycle refreshes still do.
- Verify async stats writes serialize, stale queued saves are vetoed after flush, and partial-write/rename failures leave no `.tmp` files.
- Verify dropped-output salvage never exceeds the remaining 4KB allowance and preserves complete terminal query sequences at the boundary.
- Do not merge as part of this PR-author step.