### PR TITLE
feat(accounts): show per-account Claude usage in the Accounts pane

### DIFF
--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -71,10 +71,8 @@ import {
   DialogHeader,
   DialogTitle
 } from '../ui/dialog'
-import {
-  codexRateLimitTargetMatchesAccountRuntime,
-  getCodexAccountAuthWarning
-} from './codex-account-auth-warning'
+import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
+import { rateLimitTargetMatchesAccountRuntime } from './rate-limit-target-match'
 import { getCodexConfigSyncWarning } from './codex-config-sync-warning'
 import type { CodexConfigSyncStatus } from '../../../../shared/codex-config-sync-types'
 import {
@@ -427,7 +425,7 @@ export function AccountsPane({
   // rate-limit poll says nothing about accounts owned by a remote runtime.
   const claudeUsageVisible = !isRemoteAccountScope
   const activeClaudeAccountId = getProviderAccountActiveIdForView(claudeAccounts, accountRuntime)
-  const claudeUsageTargetMatches = codexRateLimitTargetMatchesAccountRuntime(
+  const claudeUsageTargetMatches = rateLimitTargetMatchesAccountRuntime(
     claudeRateLimitTarget,
     accountRuntime
   )

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -33,6 +33,8 @@ import {
   X
 } from 'lucide-react'
 import { useAppStore } from '../../store'
+import { InlineUsageBars, InlineUsageSkeleton } from '../status-bar/inline-usage-bars'
+import { resolveClaudeRowUsage } from './claude-account-usage'
 import {
   ClaudeIcon,
   GeminiIcon,
@@ -69,7 +71,10 @@ import {
   DialogHeader,
   DialogTitle
 } from '../ui/dialog'
-import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
+import {
+  codexRateLimitTargetMatchesAccountRuntime,
+  getCodexAccountAuthWarning
+} from './codex-account-auth-warning'
 import { getCodexConfigSyncWarning } from './codex-config-sync-warning'
 import type { CodexConfigSyncStatus } from '../../../../shared/codex-config-sync-types'
 import {
@@ -327,6 +332,10 @@ export function AccountsPane({
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const codexRateLimits = useAppStore((s) => s.rateLimits.codex)
   const codexRateLimitTarget = useAppStore((s) => s.rateLimits.codexTarget)
+  const claudeRateLimits = useAppStore((s) => s.rateLimits.claude)
+  const claudeRateLimitTarget = useAppStore((s) => s.rateLimits.claudeTarget)
+  const inactiveClaudeAccounts = useAppStore((s) => s.rateLimits.inactiveClaudeAccounts)
+  const fetchInactiveClaudeAccountUsage = useAppStore((s) => s.fetchInactiveClaudeAccountUsage)
   const miniMaxRateLimits = useAppStore((s) => s.rateLimits.minimax)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const fetchSettings = useAppStore((s) => s.fetchSettings)
@@ -414,6 +423,19 @@ export function AccountsPane({
   const visibleClaudeAccounts = claudeAccounts.accounts.filter((account) =>
     providerAccountMatchesView(account, accountRuntime, accountVisibilityOptions)
   )
+  // Why: same remote gate the Codex auth warning uses below. The desktop's
+  // rate-limit poll says nothing about accounts owned by a remote runtime.
+  const claudeUsageVisible = !isRemoteAccountScope
+  const activeClaudeAccountId = getProviderAccountActiveIdForView(claudeAccounts, accountRuntime)
+  const claudeUsageTargetMatches = codexRateLimitTargetMatchesAccountRuntime(
+    claudeRateLimitTarget,
+    accountRuntime
+  )
+  // Why: re-run the inactive fetch when the roster or the active account moves;
+  // selecting an account leaves the outgoing one with no cache entry.
+  const claudeUsageRosterKey = `${activeClaudeAccountId ?? 'system'}|${visibleClaudeAccounts
+    .map((account) => account.id)
+    .join(',')}`
   const visibleCodexAccounts = codexAccounts.accounts.filter((account) =>
     providerAccountMatchesView(account, accountRuntime, accountVisibilityOptions)
   )
@@ -451,6 +473,27 @@ export function AccountsPane({
   // Why: the mirror keeps serving the last synced settings when ~/.codex is
   // unusable, so without this the user only sees their edits being ignored.
   const [codexConfigSync, setCodexConfigSync] = useState<CodexConfigSyncStatus | null>(null)
+  // Why: without a settled flag a row whose account never gets a cache entry
+  // would show the loading skeleton for the life of the pane.
+  const [claudeUsageFetchSettled, setClaudeUsageFetchSettled] = useState(false)
+  useEffect(() => {
+    // Why: mirrors the switcher's fetch-on-open (StatusBar) so opening this pane
+    // fills inactive-account usage. The service debounces, so a revisit is cheap.
+    if (!claudeUsageVisible) {
+      return
+    }
+    let cancelled = false
+    setClaudeUsageFetchSettled(false)
+    void fetchInactiveClaudeAccountUsage().finally(() => {
+      if (!cancelled) {
+        setClaudeUsageFetchSettled(true)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [claudeUsageVisible, claudeUsageRosterKey, fetchInactiveClaudeAccountUsage])
+
   useEffect(() => {
     // Why: the status resolves the host's own ~/.codex and shared runtime home.
     // A WSL or remote scope mirrors different homes entirely, so showing it there
@@ -1003,6 +1046,15 @@ export function AccountsPane({
                 )
                 const isReauthing = claudeAction === `reauth:${account.id}`
                 const isBusy = claudeAction !== 'idle' || accountRuntimeUnavailable
+                const usage = resolveClaudeRowUsage({
+                  accountId: account.id,
+                  isActive,
+                  visible: claudeUsageVisible,
+                  targetMatchesRuntime: claudeUsageTargetMatches,
+                  activeLimits: claudeRateLimits,
+                  inactiveAccounts: inactiveClaudeAccounts,
+                  inactiveFetchSettled: claudeUsageFetchSettled
+                })
 
                 return (
                   <div
@@ -1014,49 +1066,70 @@ export function AccountsPane({
                     }`}
                   >
                     <div className="flex w-full items-center justify-between gap-3 max-md:flex-col max-md:items-start">
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const accountRuntimeView = getProviderAccountRuntime(account)
-                          void runClaudeAccountAction(
-                            `select:${account.id}`,
-                            () =>
-                              selectClaudeProviderAccount(settings, {
-                                accountId: account.id,
-                                ...accountRuntimeView
-                              }),
-                            accountRuntimeView
-                          )
-                        }}
-                        disabled={isBusy}
-                        className="flex min-w-0 flex-1 flex-col gap-0.5 text-left disabled:cursor-default"
-                      >
-                        <div className="flex min-w-0 items-center gap-2">
-                          <span className="truncate text-sm font-medium">{account.email}</span>
-                          <Badge
-                            variant="outline"
-                            className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/70"
-                          >
-                            {getClaudeAccountRuntimeLabel(account, accountRuntime.label)}
-                          </Badge>
-                          {isActive ? (
+                      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const accountRuntimeView = getProviderAccountRuntime(account)
+                            void runClaudeAccountAction(
+                              `select:${account.id}`,
+                              () =>
+                                selectClaudeProviderAccount(settings, {
+                                  accountId: account.id,
+                                  ...accountRuntimeView
+                                }),
+                              accountRuntimeView
+                            )
+                          }}
+                          disabled={isBusy}
+                          className="flex min-w-0 flex-col gap-0.5 text-left disabled:cursor-default"
+                        >
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className="truncate text-sm font-medium">{account.email}</span>
                             <Badge
                               variant="outline"
-                              className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/80"
+                              className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/70"
                             >
-                              {translate(
-                                'auto.components.settings.AccountsPane.e74831fb6b',
-                                'Active'
-                              )}
+                              {getClaudeAccountRuntimeLabel(account, accountRuntime.label)}
                             </Badge>
-                          ) : null}
-                        </div>
-                        <span className="truncate text-[11px] text-muted-foreground">
-                          {account.organizationName
-                            ? `${account.organizationName} · ${formatAccountTimestamp(account.lastAuthenticatedAt)}`
-                            : formatAccountTimestamp(account.lastAuthenticatedAt)}
-                        </span>
-                      </button>
+                            {isActive ? (
+                              <Badge
+                                variant="outline"
+                                className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/80"
+                              >
+                                {translate(
+                                  'auto.components.settings.AccountsPane.e74831fb6b',
+                                  'Active'
+                                )}
+                              </Badge>
+                            ) : null}
+                          </div>
+                          <span className="truncate text-[11px] text-muted-foreground">
+                            {account.organizationName
+                              ? `${account.organizationName} · ${formatAccountTimestamp(account.lastAuthenticatedAt)}`
+                              : formatAccountTimestamp(account.lastAuthenticatedAt)}
+                          </span>
+                        </button>
+                        {usage.kind === 'hidden' ? null : (
+                          <div className="mt-1 w-full max-w-xs">
+                            {usage.kind === 'ready' ? (
+                              <InlineUsageBars
+                                limits={usage.limits}
+                                isFetching={usage.isFetching}
+                              />
+                            ) : usage.kind === 'loading' ? (
+                              <InlineUsageSkeleton />
+                            ) : (
+                              <span className="text-[10px] text-muted-foreground">
+                                {translate(
+                                  'auto.components.settings.AccountsPane.3f6c8d220e',
+                                  'Usage unavailable'
+                                )}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </div>
                       <div className="flex shrink-0 items-center justify-end gap-1 max-md:w-full max-md:flex-wrap">
                         <Button
                           variant="ghost"

--- a/src/renderer/src/components/settings/claude-account-usage.test.ts
+++ b/src/renderer/src/components/settings/claude-account-usage.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+import type { InactiveAccountUsage, ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import { resolveClaudeRowUsage } from './claude-account-usage'
+
+function limits(usedPercent: number): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: { usedPercent, windowMinutes: 300, resetsAt: null, resetDescription: null },
+    weekly: null,
+    updatedAt: 0,
+    error: null,
+    status: 'ok'
+  }
+}
+
+/** What a failed credential read actually looks like coming out of the fetcher. */
+function failedLimits(): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: 'No credentials',
+    status: 'error'
+  }
+}
+
+function entry(overrides: Partial<InactiveAccountUsage>): InactiveAccountUsage {
+  return { accountId: 'b', rateLimits: null, updatedAt: 0, isFetching: false, ...overrides }
+}
+
+const base = {
+  accountId: 'b',
+  isActive: false,
+  visible: true,
+  targetMatchesRuntime: true,
+  activeLimits: null,
+  inactiveAccounts: [] as InactiveAccountUsage[],
+  inactiveFetchSettled: false
+}
+
+describe('resolveClaudeRowUsage', () => {
+  it('hides usage for remote-owned accounts', () => {
+    expect(resolveClaudeRowUsage({ ...base, visible: false })).toEqual({ kind: 'hidden' })
+  })
+
+  // Why: the status bar can retarget the Claude poll to another runtime without
+  // changing this pane's view, and a host percentage on a WSL row is a lie.
+  it('hides the active row when the poll describes a different runtime', () => {
+    expect(
+      resolveClaudeRowUsage({
+        ...base,
+        isActive: true,
+        targetMatchesRuntime: false,
+        activeLimits: limits(12)
+      })
+    ).toEqual({ kind: 'hidden' })
+  })
+
+  it('reads the live poll for the active account', () => {
+    expect(resolveClaudeRowUsage({ ...base, isActive: true, activeLimits: limits(12) })).toEqual({
+      kind: 'ready',
+      limits: limits(12),
+      isFetching: false
+    })
+  })
+
+  it('pulses the active row while its poll is refreshing', () => {
+    const refreshing = { ...limits(12), status: 'fetching' as const }
+    expect(resolveClaudeRowUsage({ ...base, isActive: true, activeLimits: refreshing })).toEqual({
+      kind: 'ready',
+      limits: refreshing,
+      isFetching: true
+    })
+  })
+
+  it('treats a missing active snapshot as loading, not unavailable', () => {
+    expect(resolveClaudeRowUsage({ ...base, isActive: true })).toEqual({ kind: 'loading' })
+  })
+
+  // Why: the regression this guards. A failed read returns a snapshot with every
+  // window null, so without the check it renders as usable data.
+  it('reports unavailable when the active poll failed', () => {
+    expect(
+      resolveClaudeRowUsage({ ...base, isActive: true, activeLimits: failedLimits() })
+    ).toEqual({ kind: 'unavailable' })
+  })
+
+  it('reports unavailable when an inactive account failed to authenticate', () => {
+    expect(
+      resolveClaudeRowUsage({ ...base, inactiveAccounts: [entry({ rateLimits: failedLimits() })] })
+    ).toEqual({ kind: 'unavailable' })
+  })
+
+  it('shows a missing inactive entry as loading until the fetch settles', () => {
+    expect(resolveClaudeRowUsage(base)).toEqual({ kind: 'loading' })
+  })
+
+  // Why: nothing re-runs the inactive fetch on its own, so a still-missing entry
+  // after ours settled would otherwise skeleton for the life of the pane.
+  it('stops loading a missing inactive entry once the fetch settled', () => {
+    expect(resolveClaudeRowUsage({ ...base, inactiveFetchSettled: true })).toEqual({
+      kind: 'unavailable'
+    })
+  })
+
+  it('keeps loading while an inactive account is still fetching', () => {
+    expect(
+      resolveClaudeRowUsage({ ...base, inactiveAccounts: [entry({ isFetching: true })] })
+    ).toEqual({ kind: 'loading' })
+  })
+
+  it('shows cached bars for an inactive account that is refreshing', () => {
+    expect(
+      resolveClaudeRowUsage({
+        ...base,
+        inactiveAccounts: [entry({ rateLimits: limits(44), isFetching: true })]
+      })
+    ).toEqual({ kind: 'ready', limits: limits(44), isFetching: true })
+  })
+
+  it('ignores entries belonging to a different account', () => {
+    expect(
+      resolveClaudeRowUsage({
+        ...base,
+        inactiveAccounts: [entry({ accountId: 'other', rateLimits: limits(90) })]
+      })
+    ).toEqual({ kind: 'loading' })
+  })
+})

--- a/src/renderer/src/components/settings/claude-account-usage.test.ts
+++ b/src/renderer/src/components/settings/claude-account-usage.test.ts
@@ -104,6 +104,12 @@ describe('resolveClaudeRowUsage', () => {
     })
   })
 
+  it('reports unavailable for a settled inactive entry carrying no snapshot', () => {
+    expect(resolveClaudeRowUsage({ ...base, inactiveAccounts: [entry({})] })).toEqual({
+      kind: 'unavailable'
+    })
+  })
+
   it('keeps loading while an inactive account is still fetching', () => {
     expect(
       resolveClaudeRowUsage({ ...base, inactiveAccounts: [entry({ isFetching: true })] })

--- a/src/renderer/src/components/settings/claude-account-usage.ts
+++ b/src/renderer/src/components/settings/claude-account-usage.ts
@@ -1,0 +1,69 @@
+import type { InactiveAccountUsage, ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import { isUnavailableInactiveUsage } from '../status-bar/usage-availability'
+
+export type ClaudeRowUsage =
+  | { kind: 'hidden' }
+  | { kind: 'loading' }
+  | { kind: 'ready'; limits: ProviderRateLimits; isFetching: boolean }
+  | { kind: 'unavailable' }
+
+/**
+ * Picks what an Accounts-pane Claude row should show for usage.
+ *
+ * The active account reads the live poll; every other account reads the
+ * per-account inactive cache the switcher already fills.
+ */
+export function resolveClaudeRowUsage({
+  accountId,
+  isActive,
+  visible,
+  targetMatchesRuntime,
+  activeLimits,
+  inactiveAccounts,
+  inactiveFetchSettled
+}: {
+  accountId: string
+  isActive: boolean
+  visible: boolean
+  targetMatchesRuntime: boolean
+  activeLimits: ProviderRateLimits | null
+  inactiveAccounts: readonly InactiveAccountUsage[]
+  inactiveFetchSettled: boolean
+}): ClaudeRowUsage {
+  if (!visible) {
+    return { kind: 'hidden' }
+  }
+  if (isActive) {
+    // Why: the Claude poll can be retargeted to another runtime from the status
+    // bar without changing this pane's account view, and a host percentage
+    // shown on a WSL row is worse than showing nothing.
+    if (!targetMatchesRuntime) {
+      return { kind: 'hidden' }
+    }
+    if (!activeLimits) {
+      return { kind: 'loading' }
+    }
+    if (isUnavailableInactiveUsage(activeLimits)) {
+      return { kind: 'unavailable' }
+    }
+    return {
+      kind: 'ready',
+      limits: activeLimits,
+      isFetching: activeLimits.status === 'fetching'
+    }
+  }
+  const entry = inactiveAccounts.find((usage) => usage.accountId === accountId)
+  if (!entry) {
+    // Why: nothing re-runs the inactive fetch on its own, so once ours settles a
+    // still-missing entry is the final answer rather than a pending one.
+    return inactiveFetchSettled ? { kind: 'unavailable' } : { kind: 'loading' }
+  }
+  if (entry.rateLimits) {
+    // Why: a failed credential read comes back as a snapshot with every window
+    // null, not as a null snapshot. Without this it renders as usable data.
+    return isUnavailableInactiveUsage(entry.rateLimits)
+      ? { kind: 'unavailable' }
+      : { kind: 'ready', limits: entry.rateLimits, isFetching: entry.isFetching }
+  }
+  return entry.isFetching ? { kind: 'loading' } : { kind: 'unavailable' }
+}

--- a/src/renderer/src/components/settings/codex-account-auth-warning.test.ts
+++ b/src/renderer/src/components/settings/codex-account-auth-warning.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { isCodexAuthError } from '../../../../shared/codex-auth-errors'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
-import {
-  codexRateLimitTargetMatchesAccountRuntime,
-  getCodexAccountAuthWarning
-} from './codex-account-auth-warning'
+import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
+import { rateLimitTargetMatchesAccountRuntime } from './rate-limit-target-match'
 
 function codexLimits(error: string | null, status: ProviderRateLimits['status'] = 'error') {
   return {
@@ -134,7 +132,7 @@ describe('codex account auth warning', () => {
 
   it('allows a WSL default account location to receive the active WSL target warning', () => {
     expect(
-      codexRateLimitTargetMatchesAccountRuntime(
+      rateLimitTargetMatchesAccountRuntime(
         { runtime: 'wsl', wslDistro: 'Ubuntu' },
         { runtime: 'wsl', wslDistro: null }
       )

--- a/src/renderer/src/components/settings/codex-account-auth-warning.ts
+++ b/src/renderer/src/components/settings/codex-account-auth-warning.ts
@@ -4,26 +4,12 @@ import type {
 } from '../../../../shared/rate-limit-types'
 import type { CodexSystemDefaultIdentity } from '../../../../shared/types'
 import { isCodexAuthError } from '../../../../shared/codex-auth-errors'
-
-type AccountRuntime = {
-  runtime: 'host' | 'wsl'
-  wslDistro?: string | null
-}
+import {
+  type AccountRuntime,
+  rateLimitTargetMatchesAccountRuntime
+} from './rate-limit-target-match'
 
 type CodexAccountAuthWarning = 'missing-sign-in' | 'stale-sign-in'
-
-export function codexRateLimitTargetMatchesAccountRuntime(
-  target: RateLimitRuntimeTarget,
-  runtime: AccountRuntime
-): boolean {
-  if (target.runtime !== runtime.runtime) {
-    return false
-  }
-  if (runtime.runtime === 'host') {
-    return true
-  }
-  return !runtime.wslDistro || target.wslDistro === runtime.wslDistro
-}
 
 export function getCodexAccountAuthWarning(args: {
   limits: ProviderRateLimits | null
@@ -44,7 +30,7 @@ export function getCodexAccountAuthWarning(args: {
   if (args.accountId === null && args.authKind === 'none') {
     return 'missing-sign-in'
   }
-  if (!codexRateLimitTargetMatchesAccountRuntime(args.target, args.runtime)) {
+  if (!rateLimitTargetMatchesAccountRuntime(args.target, args.runtime)) {
     return null
   }
   if (args.limits?.status !== 'error' || !isCodexAuthError(args.limits.error)) {

--- a/src/renderer/src/components/settings/rate-limit-target-match.ts
+++ b/src/renderer/src/components/settings/rate-limit-target-match.ts
@@ -1,0 +1,25 @@
+import type { RateLimitRuntimeTarget } from '../../../../shared/rate-limit-types'
+
+export type AccountRuntime = {
+  runtime: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
+/**
+ * True when a rate-limit poll describes the runtime an account row belongs to.
+ *
+ * The poll can be retargeted independently of the account view, so a row must
+ * check this before it renders a percentage as its own.
+ */
+export function rateLimitTargetMatchesAccountRuntime(
+  target: RateLimitRuntimeTarget,
+  runtime: AccountRuntime
+): boolean {
+  if (target.runtime !== runtime.runtime) {
+    return false
+  }
+  if (runtime.runtime === 'host') {
+    return true
+  }
+  return !runtime.wslDistro || target.wslDistro === runtime.wslDistro
+}

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -53,7 +53,6 @@ import { getRendererAppPlatform } from '../../lib/renderer-app-platform'
 import {
   ProviderIcon,
   ProviderPanel,
-  barColor,
   clampUsedPercent,
   formatResetCreditExpiry,
   getProviderDisplayName,
@@ -64,7 +63,6 @@ import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
-import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import {
   markLiveCodexSessionsForRestart,
   resolveCodexRestartPromptAccountLabel
@@ -101,6 +99,11 @@ import {
   type UsagePercentageDisplay
 } from '../../../../shared/usage-percentage-display'
 import { formatUsagePercentageLabel } from './usage-percentage-label'
+import {
+  InlineUsageBars,
+  InlineUsageSkeleton,
+  isUnavailableInactiveUsage
+} from './inline-usage-bars'
 import {
   normalizeStatusBarUsageMode,
   type StatusBarUsageMode
@@ -980,78 +983,6 @@ function MiniBar({
   )
 }
 
-// Compact usage bars for inactive accounts in the switcher.
-export function InlineUsageBars({
-  limits,
-  isFetching
-}: {
-  limits: ProviderRateLimits
-  isFetching: boolean
-}): React.JSX.Element {
-  const display = normalizeUsagePercentageDisplay(
-    useAppStore((state) => state.usagePercentageDisplay)
-  )
-  // Why: tick the session countdown live via one boundary-scheduled clock, not just the usage poll (#5399).
-  const now = useResetCountdownClock([limits.session?.resetsAt])
-  const usageWindows = [
-    limits.session
-      ? {
-          key: 'session',
-          used: clampUsedPercent(limits.session.usedPercent),
-          // Why: live reset countdown (matches popover); '5h' window length only when resetsAt is unknown (#5399).
-          label: formatRateLimitWindowChipLabel(limits.session, now)
-        }
-      : null,
-    limits.weekly
-      ? {
-          key: 'weekly',
-          used: clampUsedPercent(limits.weekly.usedPercent),
-          label: translate('auto.components.status.bar.StatusBar.5c938d39ac', 'wk')
-        }
-      : null,
-    limits.fableWeekly
-      ? {
-          key: 'fableWeekly',
-          used: clampUsedPercent(limits.fableWeekly.usedPercent),
-          label: translate('auto.components.status.bar.StatusBar.54e8d6bb2d', 'Fable')
-        }
-      : null
-  ].filter((window): window is { key: string; used: number; label: string } => window !== null)
-
-  return (
-    <div
-      className={`grid w-full items-center gap-1.5 ${isFetching ? 'animate-pulse' : ''}`}
-      style={{
-        gridTemplateColumns: `repeat(${Math.max(1, usageWindows.length)}, minmax(0, 1fr))`
-      }}
-    >
-      {usageWindows.map((window) => (
-        <div key={window.key} className="flex min-w-0 items-center gap-1">
-          <div className="h-[4px] min-w-0 flex-1 overflow-hidden rounded-full bg-muted">
-            {/* Why: fill follows the selected percentage; color still signals consumption urgency. */}
-            <div
-              className={`h-full rounded-full ${barColor(window.used)}`}
-              style={{ width: `${getDisplayedUsagePercentage(window.used, display)}%` }}
-            />
-          </div>
-          <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
-            {formatUsagePercentageLabel(window.used, display)} {window.label}
-          </span>
-        </div>
-      ))}
-      {usageWindows.length === 0 && limits.status === 'error' ? (
-        <span className="text-[10px] text-muted-foreground">
-          {translate('auto.components.status.bar.StatusBar.f19a63e7cd', 'Sign in to see usage')}
-        </span>
-      ) : null}
-    </div>
-  )
-}
-
-function isUnavailableInactiveUsage(limits: ProviderRateLimits | null | undefined): boolean {
-  return limits?.status === 'error' && !limits.session && !limits.weekly && !limits.fableWeekly
-}
-
 function InlineUsageSignInAction({
   isFetching,
   isSigningIn,
@@ -1094,15 +1025,6 @@ function InlineUsageSignInAction({
         )}
         {translate('auto.components.status.bar.StatusBar.c35af53b73', 'Sign in')}
       </Button>
-    </div>
-  )
-}
-
-function InlineUsageSkeleton(): React.JSX.Element {
-  return (
-    <div className="flex w-full animate-pulse items-center gap-2">
-      <div className="h-[4px] flex-1 rounded-full bg-muted" />
-      <div className="h-[4px] flex-1 rounded-full bg-muted" />
     </div>
   )
 }

--- a/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
+++ b/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
@@ -59,7 +59,7 @@ describe('InlineUsageBars', () => {
   })
 
   it('renders Claude Fable usage in inactive account preview rows', async () => {
-    const { InlineUsageBars } = await import('./StatusBar')
+    const { InlineUsageBars } = await import('./inline-usage-bars')
 
     const markup = renderToStaticMarkup(
       <InlineUsageBars limits={claudeLimits()} isFetching={false} />
@@ -72,7 +72,7 @@ describe('InlineUsageBars', () => {
   })
 
   it('derives the collapsed session label from resetsAt (#5399)', async () => {
-    const { InlineUsageBars } = await import('./StatusBar')
+    const { InlineUsageBars } = await import('./inline-usage-bars')
 
     const limits = claudeLimits()
     // ~1h 20m away; +5s buffer keeps the floor-based formatter at '1h 20m'
@@ -89,7 +89,7 @@ describe('InlineUsageBars', () => {
   })
 
   it('shows "now" for an already-expired session reset', async () => {
-    const { InlineUsageBars } = await import('./StatusBar')
+    const { InlineUsageBars } = await import('./inline-usage-bars')
 
     const limits = claudeLimits()
     limits.session!.resetsAt = Date.now() - 1000
@@ -126,7 +126,7 @@ describe('InlineUsageBars', () => {
 
   it('shows remaining copy and remaining meter fill', async () => {
     mocks.usagePercentageDisplay = 'remaining'
-    const { InlineUsageBars } = await import('./StatusBar')
+    const { InlineUsageBars } = await import('./inline-usage-bars')
 
     const markup = renderToStaticMarkup(
       <InlineUsageBars limits={claudeLimits()} isFetching={false} />

--- a/src/renderer/src/components/status-bar/inline-usage-bars.tsx
+++ b/src/renderer/src/components/status-bar/inline-usage-bars.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { translate } from '@/i18n/i18n'
+import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
+import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
+import { useAppStore } from '../../store'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import {
+  getDisplayedUsagePercentage,
+  normalizeUsagePercentageDisplay
+} from '../../../../shared/usage-percentage-display'
+import { formatUsagePercentageLabel } from './usage-percentage-label'
+import { barColor, clampUsedPercent } from './tooltip'
+
+export { isUnavailableInactiveUsage } from './usage-availability'
+
+// Compact usage bars for accounts the user is not currently signed in as.
+export function InlineUsageBars({
+  limits,
+  isFetching
+}: {
+  limits: ProviderRateLimits
+  isFetching: boolean
+}): React.JSX.Element {
+  const display = normalizeUsagePercentageDisplay(
+    useAppStore((state) => state.usagePercentageDisplay)
+  )
+  // Why: tick the session countdown live via one boundary-scheduled clock, not just the usage poll (#5399).
+  const now = useResetCountdownClock([limits.session?.resetsAt])
+  const usageWindows = [
+    limits.session
+      ? {
+          key: 'session',
+          used: clampUsedPercent(limits.session.usedPercent),
+          // Why: live reset countdown (matches popover); '5h' window length only when resetsAt is unknown (#5399).
+          label: formatRateLimitWindowChipLabel(limits.session, now)
+        }
+      : null,
+    limits.weekly
+      ? {
+          key: 'weekly',
+          used: clampUsedPercent(limits.weekly.usedPercent),
+          label: translate('auto.components.status.bar.StatusBar.5c938d39ac', 'wk')
+        }
+      : null,
+    limits.fableWeekly
+      ? {
+          key: 'fableWeekly',
+          used: clampUsedPercent(limits.fableWeekly.usedPercent),
+          label: translate('auto.components.status.bar.StatusBar.54e8d6bb2d', 'Fable')
+        }
+      : null
+  ].filter((window): window is { key: string; used: number; label: string } => window !== null)
+
+  return (
+    <div
+      className={`grid w-full items-center gap-1.5 ${isFetching ? 'animate-pulse' : ''}`}
+      style={{
+        gridTemplateColumns: `repeat(${Math.max(1, usageWindows.length)}, minmax(0, 1fr))`
+      }}
+    >
+      {usageWindows.map((window) => (
+        <div key={window.key} className="flex min-w-0 items-center gap-1">
+          <div className="h-[4px] min-w-0 flex-1 overflow-hidden rounded-full bg-muted">
+            {/* Why: fill follows the selected percentage; color still signals consumption urgency. */}
+            <div
+              className={`h-full rounded-full ${barColor(window.used)}`}
+              style={{ width: `${getDisplayedUsagePercentage(window.used, display)}%` }}
+            />
+          </div>
+          <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
+            {formatUsagePercentageLabel(window.used, display)} {window.label}
+          </span>
+        </div>
+      ))}
+      {usageWindows.length === 0 && limits.status === 'error' ? (
+        <span className="text-[10px] text-muted-foreground">
+          {translate('auto.components.status.bar.StatusBar.f19a63e7cd', 'Sign in to see usage')}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+export function InlineUsageSkeleton(): React.JSX.Element {
+  return (
+    <div className="flex w-full animate-pulse items-center gap-2">
+      <div className="h-[4px] flex-1 rounded-full bg-muted" />
+      <div className="h-[4px] flex-1 rounded-full bg-muted" />
+    </div>
+  )
+}

--- a/src/renderer/src/components/status-bar/usage-availability.ts
+++ b/src/renderer/src/components/status-bar/usage-availability.ts
@@ -1,0 +1,9 @@
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+
+/**
+ * True when a snapshot exists but carries no usable window, which is what a
+ * failed credential read looks like: `status: 'error'` with every window null.
+ */
+export function isUnavailableInactiveUsage(limits: ProviderRateLimits | null | undefined): boolean {
+  return limits?.status === 'error' && !limits.session && !limits.weekly && !limits.fableWeekly
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5286,7 +5286,8 @@
           "codexSystemDefaultNeedsSignIn": "No Codex sign-in was found for {{value0}}.",
           "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
           "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
-          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+          "3f6c8d220e": "Usage unavailable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5241,7 +5241,8 @@
           "codexSystemDefaultNeedsSignIn": "No se encontró ningún inicio de sesión de Codex para {{value0}}.",
           "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
           "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
-          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+          "3f6c8d220e": "Usage unavailable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reiniciar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5226,7 +5226,8 @@
           "codexSystemDefaultNeedsSignIn": "{{value0}} の Codex サインインが見つかりません。",
           "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
           "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
-          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+          "3f6c8d220e": "Usage unavailable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5226,7 +5226,8 @@
           "codexSystemDefaultNeedsSignIn": "{{value0}}에 대한 Codex 로그인을 찾을 수 없습니다.",
           "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
           "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
-          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+          "3f6c8d220e": "Usage unavailable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5226,7 +5226,8 @@
           "codexSystemDefaultNeedsSignIn": "未找到 {{value0}} 的 Codex 登录信息。",
           "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
           "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
-          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+          "3f6c8d220e": "Usage unavailable"
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",


### PR DESCRIPTION
Closes #10688.

## Summary

Each managed Claude row now shows session, weekly and Fable usage, or an explicit unavailable state.

## Screenshots

None attached. The pane shows four account emails and an org name, and I'd rather not publish those. The element is the same `InlineUsageBars` that #1259 shipped in the switcher, sitting under the org/date line and capped at `max-w-xs`.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Add two or more Claude accounts, then open Settings > AI Provider Accounts. Every Claude row shows usage under the org line, including the accounts you are not signed in as.

Switch accounts from that same pane. The rows repopulate.

## AI Review Report

The review covered correctness, cross-platform behavior, UI quality against `docs/STYLEGUIDE.md`, performance, and security. It confirmed the moved code is byte-faithful against `git show HEAD:...StatusBar.tsx`, that no import cycle appears, that `InlineUsageSignInAction` is still wired into the Codex branch, and that the dropped `barColor` and `useResetCountdownClock` imports have no remaining references.

The unavailable state turned out to be unreachable, and the case it was meant to cover rendered the wrong copy. A failed credential read doesn't produce a null snapshot; `fetchManagedAccountUsage` returns `{session: null, weekly: null, status: 'error'}`, which caches fine and falls through to `InlineUsageBars`, which renders "Sign in to see usage" for that shape. That copy is wrong sitting next to a Re-authenticate button. `resolveClaudeRowUsage` now runs `isUnavailableInactiveUsage` on both branches. The active branch was inverted too, since a null snapshot there means the first poll hasn't landed, which is a loading state.

Separately, the active row could show another runtime's numbers. `refreshClaudeRateLimitsForTarget` retargets the Claude poll from the status bar without touching `localAccountRuntime`, so a host-scoped pane could render WSL percentages. The row is now gated on `codexRateLimitTargetMatchesAccountRuntime(claudeTarget, accountRuntime)`, which is provider-neutral despite the name, and hides on a mismatch.

The loading skeleton also had no exit. Nothing re-runs the inactive fetch on a timer, so an account that never got a cache entry would spin for the life of the pane, reachable by switching accounts inside the pane and by a multi-distro WSL view where no row resolves as active. The effect now re-runs on roster and active-account changes and tracks whether its own fetch settled.

On platform behavior: this is renderer-only, with no paths, no shell, no `process.platform`, no shortcut labels or accelerators. Colors are theme tokens plus the existing `barColor` scale, so light and dark are unchanged. The runtime-target mismatch above was the one platform-sensitive item, Windows-primary with a macOS/Linux variant when a WSL setting travels between machines.

Also applied from the review: the usage block moved out of the switch-account `<button>`, so clicking a bar no longer switches accounts and the numbers stop landing in the button's accessible name. `isFetching` on the active row derives from `status === 'fetching'`, `max-w-[320px]` became the documented `max-w-xs`, and `oxfmt` ran over the changed files.

## Security Audit

No new IPC channel, no new preload surface, no new dependency, no `package.json` change. No path handling, command execution, or `dangerouslySetInnerHTML`. Bar widths come from `clampUsedPercent` into `getDisplayedUsagePercentage`, both bounded, so a percentage can't inject style. `ProviderRateLimits` already flowed to this renderer and the status bar already renders it. No credential, token, or `usageMetadata` field is surfaced, and the account emails on these rows were already on screen.

## Notes

The pane reads `rateLimits.claude` for the active account and `rateLimits.inactiveClaudeAccounts` for the rest, and calls the existing `fetchInactiveClaudeAccountUsage()` on open, the same trigger the switcher uses when it expands. No new fetching or storage. `InlineUsageBars` and `InlineUsageSkeleton` move to `status-bar/inline-usage-bars.tsx` and `isUnavailableInactiveUsage` to `status-bar/usage-availability.ts`, unchanged, so the pane can reuse them instead of importing all of `StatusBar.tsx`. Row state resolves in a pure helper covered by unit tests.

Before this the rows showed only email, runtime badge and org, so an exhausted account looked the same as a fresh one until you switched into it.

Update after rebasing onto current main: `verify:localization-coverage` is green now, the Ghostty keyword strings got allowlisted upstream. The `src/main/attribution/terminal-attribution.test.ts` failures still repro on clean main, a git-hook temp-file issue unrelated to the renderer, so that one still predates this branch.

I did not change these, and each is worth its own PR:

- The "System default" Claude row still shows nothing. It sits outside the mapped list, and when it's the active row `rateLimits.claude` is its usage.
- Codex accounts in this pane still show no usage. `inactiveCodexAccounts` is already in the store and `InlineUsageBars` is provider-neutral now, so it's mostly a repeat of this diff.
- The JSX branches have no test. Account rows arrive from an effect, so they don't render under the `renderToStaticMarkup` harness `AccountsPane.test.tsx` uses, and covering them needs a happy-dom test with the provider-accounts client mocked. The state machine underneath is covered.

No X handle for the contributor shoutout.

## ELI5

Each Claude account in the Accounts pane now shows session, weekly, and Fable usage bars (or an unavailable state) so you can see quota at a glance without digging elsewhere.

