### PR TITLE
fix(remote): keep reachable hosts selectable and isolate folder-workspace PTYs

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3278,6 +3278,53 @@ describe('OrcaRuntimeService', () => {
     expect(terminals.terminals[0]?.worktreePath).toBe(TEST_FOLDER_WORKSPACE_PATH)
   })
 
+  it('keeps controller PTYs scoped to their exact folder workspace instance', async () => {
+    const firstWorkspaceId = `${TEST_REPO_ID}::${TEST_FOLDER_WORKSPACE_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}11111111-1111-4111-8111-111111111111`
+    const secondWorkspaceId = `${TEST_REPO_ID}::${TEST_FOLDER_WORKSPACE_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}22222222-2222-4222-8222-222222222222`
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [
+        {
+          id: TEST_REPO_ID,
+          path: TEST_FOLDER_WORKSPACE_PATH,
+          displayName: 'folder',
+          badgeColor: 'blue',
+          addedAt: 1,
+          kind: 'folder' as const
+        }
+      ],
+      getRepo: (id: string) => (id === TEST_REPO_ID ? runtimeStore.getRepos()[0] : undefined),
+      getAllWorktreeMeta: () => ({
+        [firstWorkspaceId]: makeWorktreeMeta({ instanceId: 'first' }),
+        [secondWorkspaceId]: makeWorktreeMeta({ instanceId: 'second' })
+      }),
+      getWorktreeMeta: (worktreeId: string) => runtimeStore.getAllWorktreeMeta()[worktreeId]
+    }
+    const ptyId = `${firstWorkspaceId}@@daemon-controller-pty`
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: ptyId,
+          cwd: TEST_FOLDER_WORKSPACE_PATH,
+          title: 'Codex',
+          worktreeId: firstWorkspaceId
+        }
+      ]
+    })
+
+    const all = await runtime.listTerminals()
+    const second = await runtime.listTerminals(`id:${secondWorkspaceId}`)
+
+    expect(all.terminals).toEqual([
+      expect.objectContaining({ ptyId, worktreeId: firstWorkspaceId })
+    ])
+    expect(second.terminals).toEqual([])
+  })
+
   it('routes PTY output through the PTY leaf index in large terminal graphs', () => {
     const runtime = new OrcaRuntimeService(store)
     const liveLeafCount = 2773
@@ -29158,6 +29205,17 @@ describe('OrcaRuntimeService', () => {
         .filter((event) => event.type === 'worktreeTerminalSleepState')
         .map((event) => event.phase)
     ).toEqual(['started', 'committed', 'woken'])
+  })
+
+  it('does not serialize terminal mutations across folder workspace instances', async () => {
+    const firstWorkspaceId = `${TEST_REPO_ID}::${TEST_FOLDER_WORKSPACE_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}11111111-1111-4111-8111-111111111111`
+    const secondWorkspaceId = `${TEST_REPO_ID}::${TEST_FOLDER_WORKSPACE_PATH}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}22222222-2222-4222-8222-222222222222`
+    const runtime = new OrcaRuntimeService(store)
+    const releaseFirst = await runtime.acquireWorktreeTerminalSpawn(firstWorkspaceId)
+    const releaseSecond = await runtime.acquireWorktreeTerminalSpawn(secondWorkspaceId)
+
+    releaseFirst()
+    releaseSecond()
   })
 
   it('waits for an in-flight spawn before inventorying worktree sleep', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -32171,14 +32171,24 @@ function runtimeWorktreeIdsEqual(left: string, right: string): boolean {
   const parsedRight = splitWorktreeIdForFilesystem(right)
   return parsedLeft && parsedRight
     ? parsedLeft.repoId === parsedRight.repoId &&
-        runtimePathsEqual(parsedLeft.worktreePath, parsedRight.worktreePath)
+        runtimePathsEqual(parsedLeft.worktreePath, parsedRight.worktreePath) &&
+        getRuntimeFolderWorkspaceInstanceIdSuffix(left) ===
+          getRuntimeFolderWorkspaceInstanceIdSuffix(right)
     : left === right
+}
+
+function getRuntimeFolderWorkspaceInstanceIdSuffix(worktreeId: string): string | null {
+  const separatorIndex = worktreeId.lastIndexOf(FOLDER_WORKSPACE_INSTANCE_SEPARATOR)
+  return separatorIndex === -1
+    ? null
+    : worktreeId.slice(separatorIndex + FOLDER_WORKSPACE_INSTANCE_SEPARATOR.length)
 }
 
 function runtimeWorktreeIdentityKey(worktreeId: string): string {
   const parsed = splitWorktreeIdForFilesystem(worktreeId)
+  const folderWorkspaceInstanceId = getRuntimeFolderWorkspaceInstanceIdSuffix(worktreeId)
   return parsed
-    ? `${parsed.repoId}\0${normalizeRuntimePathForComparison(parsed.worktreePath)}`
+    ? `${parsed.repoId}\0${normalizeRuntimePathForComparison(parsed.worktreePath)}\0${folderWorkspaceInstanceId ?? ''}`
     : worktreeId
 }
 

--- a/src/renderer/src/components/sidebar/AddRepoHostSelector.test.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoHostSelector.test.tsx
@@ -167,4 +167,46 @@ describe('AddRepoHostSelector', () => {
     expect(html).not.toContain('cursor-not-allowed')
     expect(html).not.toContain('opacity-55')
   })
+
+  it('keeps a version-blocked runtime host disabled while shared control is connecting', () => {
+    const html = renderToStaticMarkup(
+      <AddRepoHostSelector
+        hosts={[
+          {
+            id: 'local',
+            label: 'Local Mac',
+            detail: 'This computer',
+            kind: 'local',
+            health: 'local',
+            presence: 'local'
+          },
+          {
+            id: 'runtime:old-server',
+            label: 'Old server',
+            detail: 'Orca server',
+            kind: 'runtime',
+            // Why: shared-control diagnostics win over the compat verdict in the
+            // registry, so a too-old server can report 'connecting' health.
+            health: 'connecting',
+            presence: 'active',
+            compatibility: {
+              kind: 'blocked',
+              reason: 'server-too-old',
+              clientProtocolVersion: 3,
+              serverProtocolVersion: 1,
+              requiredServerProtocolVersion: 2
+            }
+          }
+        ]}
+        selectedHostId="local"
+        open
+        onOpenChange={vi.fn()}
+        onSelectHost={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('The selected Orca server is too old for this client.')
+    expect(html).toContain('aria-disabled="true"')
+    expect(html).toContain('cursor-not-allowed')
+  })
 })

--- a/src/renderer/src/components/sidebar/AddRepoHostSelector.test.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoHostSelector.test.tsx
@@ -134,4 +134,37 @@ describe('AddRepoHostSelector', () => {
     expect(html).toContain('Update Orca on the server.')
     expect(html).toContain('aria-disabled="true"')
   })
+
+  it('keeps a reachable runtime host selectable while shared control finishes connecting', () => {
+    const html = renderToStaticMarkup(
+      <AddRepoHostSelector
+        hosts={[
+          {
+            id: 'local',
+            label: 'Local Mac',
+            detail: 'This computer',
+            kind: 'local',
+            health: 'local',
+            presence: 'local'
+          },
+          {
+            id: 'runtime:server',
+            label: 'OCI',
+            detail: 'Orca server',
+            kind: 'runtime',
+            health: 'connecting',
+            presence: 'active'
+          }
+        ]}
+        selectedHostId="local"
+        open
+        onOpenChange={vi.fn()}
+        onSelectHost={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('OCI')
+    expect(html).not.toContain('cursor-not-allowed')
+    expect(html).not.toContain('opacity-55')
+  })
 })

--- a/src/renderer/src/components/sidebar/add-repo-host-availability.ts
+++ b/src/renderer/src/components/sidebar/add-repo-host-availability.ts
@@ -1,7 +1,11 @@
 import type { SidebarHostOption } from './sidebar-host-options'
 
 export function canSelectAddRepoHost(host: Pick<SidebarHostOption, 'health' | 'kind'>): boolean {
-  return host.health === 'local' || host.health === 'available'
+  return (
+    host.health === 'local' ||
+    host.health === 'available' ||
+    (host.kind === 'runtime' && host.health === 'connecting')
+  )
 }
 
 export function canConnectAddRepoHost(host: Pick<SidebarHostOption, 'health' | 'kind'>): boolean {

--- a/src/renderer/src/components/sidebar/add-repo-host-availability.ts
+++ b/src/renderer/src/components/sidebar/add-repo-host-availability.ts
@@ -1,11 +1,26 @@
 import type { SidebarHostOption } from './sidebar-host-options'
 
-export function canSelectAddRepoHost(host: Pick<SidebarHostOption, 'health' | 'kind'>): boolean {
-  return (
-    host.health === 'local' ||
-    host.health === 'available' ||
-    (host.kind === 'runtime' && host.health === 'connecting')
-  )
+export function canSelectAddRepoHost(
+  host: Pick<SidebarHostOption, 'health' | 'kind' | 'compatibility'>
+): boolean {
+  // Why: shared-control health overrides the compat verdict in the registry, so a
+  // version-blocked server can read 'connecting'. Keep it unselectable regardless.
+  if (host.compatibility?.kind === 'blocked') {
+    return false
+  }
+  switch (host.health) {
+    case 'local':
+    case 'available':
+      return true
+    // Why: a runtime's 'connecting' describes only its persistent shared-control
+    // channel — the status probe behind it already proved the host reachable.
+    case 'connecting':
+      return host.kind === 'runtime'
+    case 'blocked':
+    case 'disconnected':
+    case 'error':
+      return false
+  }
 }
 
 export function canConnectAddRepoHost(host: Pick<SidebarHostOption, 'health' | 'kind'>): boolean {

--- a/src/renderer/src/components/sidebar/use-add-repo-host-selection.test.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-host-selection.test.ts
@@ -244,6 +244,46 @@ describe('useAddRepoHostSelection', () => {
     expect(setStep).toHaveBeenCalledWith('add')
   })
 
+  it('keeps an already-picked runtime host selected when it drops to connecting mid-flow', async () => {
+    // Why: the dialog is already open, so the open-reset effect must not run and
+    // silently move the user's pick back to Local while the channel reconnects.
+    mocks.refValues = [true]
+    mocks.stateValues = ['runtime:env-1', false]
+    mocks.hostOptions[2] = {
+      ...mocks.hostOptions[2],
+      health: 'connecting'
+    }
+    const { useAddRepoHostSelection } = await import('./use-add-repo-host-selection')
+
+    const result = useAddRepoHostSelection({ isOpen: true, setStep: vi.fn() })
+
+    expect(result.selectedHostId).toBe('runtime:env-1')
+    expect(result.selectedParsedHost).toMatchObject({ kind: 'runtime', environmentId: 'env-1' })
+  })
+
+  it('does not select a version-blocked runtime host that reports connecting', async () => {
+    mocks.stateValues = ['local', false]
+    mocks.hostOptions[2] = {
+      ...mocks.hostOptions[2],
+      health: 'connecting',
+      compatibility: {
+        kind: 'blocked',
+        reason: 'server-too-old',
+        clientProtocolVersion: 3,
+        serverProtocolVersion: 1,
+        requiredServerProtocolVersion: 2
+      }
+    }
+    const setStep = vi.fn()
+    const { useAddRepoHostSelection } = await import('./use-add-repo-host-selection')
+
+    const result = useAddRepoHostSelection({ isOpen: true, setStep })
+    await result.handleSelectAddProjectHost('runtime:env-1')
+
+    expect(mocks.stateSetters[0]).not.toHaveBeenCalledWith('runtime:env-1')
+    expect(setStep).not.toHaveBeenCalled()
+  })
+
   it('hides ephemeral VM runtime hosts from Add Project selection', async () => {
     mocks.stateValues = ['runtime:env-vm', false]
     mocks.hostOptions.push({

--- a/src/renderer/src/components/sidebar/use-add-repo-host-selection.test.ts
+++ b/src/renderer/src/components/sidebar/use-add-repo-host-selection.test.ts
@@ -228,6 +228,22 @@ describe('useAddRepoHostSelection', () => {
     expect(mocks.stateSetters[0]).toHaveBeenCalledWith('local')
   })
 
+  it('selects a runtime host while shared control finishes connecting', async () => {
+    mocks.stateValues = ['local', false]
+    mocks.hostOptions[2] = {
+      ...mocks.hostOptions[2],
+      health: 'connecting'
+    }
+    const setStep = vi.fn()
+    const { useAddRepoHostSelection } = await import('./use-add-repo-host-selection')
+
+    const result = useAddRepoHostSelection({ isOpen: true, setStep })
+    await result.handleSelectAddProjectHost('runtime:env-1')
+
+    expect(mocks.stateSetters[0]).toHaveBeenCalledWith('runtime:env-1')
+    expect(setStep).toHaveBeenCalledWith('add')
+  })
+
   it('hides ephemeral VM runtime hosts from Add Project selection', async () => {
     mocks.stateValues = ['runtime:env-vm', false]
     mocks.hostOptions.push({


### PR DESCRIPTION
## Summary

This PR fixes both failures observed with a paired macOS client and Cloudflare-hosted web UI against a headless OCI runtime:

1. **Add Project host selection:** a reachable runtime remains selectable while shared control reports `connecting`.
2. **Folder-workspace terminal identity:** sibling folder workspaces sharing one directory no longer collapse onto the same runtime PTY identity.

The second bug caused a selected workspace to open another instance's terminal—typically a plain shell—instead of its live/resumed Codex TUI. `runtimeWorktreeIdsEqual()` and `runtimeWorktreeIdentityKey()` used `splitWorktreeIdForFilesystem()`, which intentionally strips `::workspace:<uuid>`. The fix keeps normalized filesystem comparison while requiring the folder instance suffix to match.

Closes #10704.
Closes #10750.

Related:

- #10252 — the same folder-instance suffix loss previously caused sibling session teardown.
- #9047 / #9147 — separate web-client `host:local` routing issue behind `Local PTYs are unavailable`.
- #9760 — reverse-proxy web-client report with the same visible PTY error.
- #7400 — stale remote session-tab projection hiding live tabs.
- #5132 — stale active-tab persistence in headless serve.
- #8878 — remote clients resuming sessions before live host ownership was visible.

## ELI5

Several folder workspaces can point at the same directory. Orca labels them with different IDs, but the terminal runtime erased those labels before deciding which workspace owned a terminal. Opening one could therefore show another workspace's shell instead of its Codex session. Orca now retains the workspace label for terminal ownership while still using the real path for filesystem operations.

## Proof of fix

Regression coverage proves:

- a controller PTY owned by folder-workspace instance A is absent when listing instance B;
- terminal mutations for A and B acquire independently instead of sharing one lock.

```text
Test Files  1 passed (1)
Tests       2 passed | 879 skipped (881)
```

End-to-end text/RPC validation against the deployed Linux ARM64 runtime also confirmed:

- the paired macOS client and both persisted remote-client selections projected the target ready terminal;
- `terminal read` reported `running` and contained the Codex header plus historical resumed-session prompt;
- `terminal wait --for tui-idle` succeeded;
- the live process was `codex resume <session-id>`, not a plain shell;
- OCI serve, web proxy, and Cloudflare services were active.

No screenshot or image inspection was used.

## User-visible behavior

- A reachable runtime remains selectable in Add Project while shared control connects.
- Opening a folder-workspace instance shows only terminals owned by that exact instance.
- The base folder workspace and each `::workspace:<uuid>` instance remain distinct.
- Filesystem cwd/path behavior is unchanged.
- SSH worktrees, Git worktrees, and unique-path folder workspaces retain existing behavior.

## Compatibility

- **macOS / Linux / Windows:** existing normalized path comparison remains; no platform-specific shell, shortcut, label, or Electron behavior was added.
- **SSH / remote:** exact identity is preserved across daemon/controller PTY projection. Routing is unchanged.
- **Folder/Git workspaces:** only folder instance suffix identity changes. Ordinary Git IDs compare as before.
- **Performance:** constant-time suffix extraction on existing comparisons and key creation; no new polling or I/O.

## Screenshots

No visual change. This corrects host availability and terminal ownership; validation was text/RPC based.

## Testing

- [ ] `pnpm lint` — not run in full. Staged-file hooks and targeted runtime `oxlint` passed; the existing host-selection change passed the renderer switch-exhaustiveness gate.
- [x] `pnpm typecheck` — targeted node typecheck passed; the existing host-selection change passed web typecheck.
- [ ] `pnpm test` — not run in full. Targeted runtime tests passed; the existing PR ran the full touched sidebar directory successfully.
- [x] `pnpm build` — the patched Linux ARM64 app was built and deployed for end-to-end OCI verification.
- [x] Added regression tests that distinguish sibling folder instances and fail on the old behavior.

## AI Review Report

Reviewed the identity boundary, base-vs-instance behavior, sibling isolation, cross-platform path normalization, SSH/folder/Git compatibility, remote selected-TUI evidence, and performance. Filesystem callers may remove the suffix, but PTY ownership, projection, mutation locks, sleep/wake state, and session selection must retain it. No further code changes were required.

## Security Audit

- No new external input, parser, command execution, dependency, or IPC surface.
- Filesystem normalization is unchanged; the UUID suffix is identity metadata only.
- No credentials, pairing codes, tokens, or transcript contents are included.
- Ownership is narrowed, reducing cross-instance impact and aligning with #10252.

## Notes

- Web-client `host:local` routing remains tracked separately in #9047 / #9147.
- Reverse-proxy-specific `unavailableReason` handling remains tracked in #9760.
- X/Twitter: [@dongwook_chan](https://x.com/dongwook_chan)
