### PR TITLE
fix(gpu-fallback): make the crash window rolling, not launch-anchored

### DIFF
--- a/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.test.ts
@@ -36,16 +36,76 @@ describe('GpuCrashFallbackTracker', () => {
     })
   })
 
-  it('ignores GPU crashes after the post-launch window', () => {
+  it('drops crashes that age out of the rolling window', () => {
     const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 3 })
     tracker.recordGpuCrash(1_000)
     tracker.recordGpuCrash(2_000)
-    // A late hiccup well into the session is normal Chromium churn.
+    // Isolated hiccups spread over 45s are normal Chromium churn, not a burst:
+    // the first two have aged out by the time the third arrives.
     expect(tracker.recordGpuCrash(45_000)).toEqual({
       shouldEngageFallback: false,
-      crashesInWindow: 2
+      crashesInWindow: 1
     })
     expect(tracker.hasEngaged()).toBe(false)
+  })
+
+  it('engages on a burst that starts long after launch (session 12e6ee64)', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 3 })
+    // Real crash times, ms since launch. The burst is 3 crashes in 26.0s —
+    // inside the window — but begins 920s in, so the old launch-anchored
+    // check rejected every one and the renderer died 39s later.
+    expect(tracker.recordGpuCrash(242_137).shouldEngageFallback).toBe(false)
+    expect(tracker.recordGpuCrash(920_110).shouldEngageFallback).toBe(false)
+    expect(tracker.recordGpuCrash(926_462).shouldEngageFallback).toBe(false)
+    expect(tracker.recordGpuCrash(946_115)).toEqual({
+      shouldEngageFallback: true,
+      crashesInWindow: 3
+    })
+  })
+
+  it('treats a span of exactly windowMs as inside the window', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 3 })
+    tracker.recordGpuCrash(0)
+    tracker.recordGpuCrash(15_000)
+    // Why pinned: "3 crashes within 30s" includes a 30.000s span. An exclusive
+    // cutoff here would silently need a 4th crash to ever engage on the boundary.
+    expect(tracker.recordGpuCrash(30_000)).toEqual({
+      shouldEngageFallback: true,
+      crashesInWindow: 3
+    })
+  })
+
+  it('leaves the closest real-world non-burst alone', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 3 })
+    // Field telemetry's tightest 4-crash launch that is *not* a broken driver.
+    // Consecutive gaps (29.5s, 25.6s) each fit the window, so pruning has to
+    // retire the old entry every time or this session gets relaunched for free.
+    for (const at of [0, 29_531, 55_136, 74_178]) {
+      expect(tracker.recordGpuCrash(at).shouldEngageFallback).toBe(false)
+    }
+    expect(tracker.hasEngaged()).toBe(false)
+  })
+
+  it('ignores a slow drip that never fills the window', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 3 })
+    // One crash every 20s forever: always 2 in the window, never a burst.
+    for (const at of [0, 20_000, 40_000, 60_000, 80_000, 100_000]) {
+      expect(tracker.recordGpuCrash(at).shouldEngageFallback).toBe(false)
+    }
+    expect(tracker.hasEngaged()).toBe(false)
+  })
+
+  it('never retains a crash older than the window, even on a backwards clock jump', () => {
+    const tracker = new GpuCrashFallbackTracker({ windowMs: 30_000, threshold: 3 })
+    tracker.recordGpuCrash(100_000)
+    tracker.recordGpuCrash(1_000)
+    // Why: pruning scans the sorted prefix and stops at the first live entry, so
+    // an out-of-order value parked at the tail would be counted forever. Assert
+    // the invariant directly — the crash count alone cannot distinguish this.
+    const window = tracker.windowSnapshot()
+    const newest = window.at(-1) ?? 0
+    expect(window.every((at) => newest - at <= 30_000)).toBe(true)
+    expect([...window]).toEqual([...window].sort((left, right) => left - right))
   })
 
   it('ignores impossible timestamps', () => {

--- a/src/main/crash-reporting/gpu-crash-fallback-decision.ts
+++ b/src/main/crash-reporting/gpu-crash-fallback-decision.ts
@@ -1,5 +1,5 @@
 export type GpuCrashFallbackOptions = {
-  /** Window after launch in which clustered GPU crashes indicate a broken driver. */
+  /** Rolling span over which clustered GPU crashes indicate a broken driver. */
   windowMs: number
   /** GPU child crashes within the window that trigger software-rendering fallback. */
   threshold: number
@@ -8,25 +8,30 @@ export type GpuCrashFallbackOptions = {
 const GPU_FALLBACK_CRASH_REASONS = new Set(['abnormal-exit', 'crashed', 'launch-failed'])
 
 // Why: on old/flaky GPU drivers the GPU child process crashes (STATUS_BREAKPOINT
-// / ANGLE-D3D init failure) within seconds of launch, repeatedly - Windows
-// clusters F0BDNADU79Q and F0BDNRZ5MDG. GPU child deaths are intentionally
-// suppressed as recoverable churn, so Orca never reacted. A burst right after
-// launch is the signal that hardware acceleration is unusable on this machine.
+// / ANGLE-D3D init failure) repeatedly - Windows clusters F0BDNADU79Q and
+// F0BDNRZ5MDG. GPU child deaths are intentionally suppressed as recoverable
+// churn, so Orca never reacted. A tight burst is the signal that hardware
+// acceleration is unusable on this machine.
 export const DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS = 30_000
 export const DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD = 3
 
 /**
- * Tracks GPU child-process crashes relative to launch and decides when to fall
- * back to software rendering on the next launch. Pure and deterministic:
- * callers pass `now` (ms since launch) so behavior is testable without timers.
+ * Tracks GPU child-process crashes and decides when to fall back to software
+ * rendering on the next launch. Pure and deterministic: callers pass `now`
+ * (ms since launch) so behavior is testable without timers.
  *
- * Only crashes inside the post-launch window count: a one-off GPU hiccup hours
- * into a session is normal Chromium churn, not a broken-driver signal.
+ * The window is rolling, not anchored to launch. A driver can start failing at
+ * any point in a session — GPU work is demand-driven, so the first heavy
+ * compositing often happens minutes in. Session 12e6ee64 hit exactly `threshold`
+ * crashes inside `windowMs` (3 in 26.0s) and was ignored solely because the
+ * burst began 920s after launch. What distinguishes a broken driver from normal
+ * Chromium churn is that the crashes *cluster*, not when the cluster starts.
  */
 export class GpuCrashFallbackTracker {
   private readonly windowMs: number
   private readonly threshold: number
-  private crashesInWindow = 0
+  // Newest-last crash times (ms since launch), pruned to the rolling window.
+  private readonly recentCrashes: number[] = []
   private engaged = false
 
   constructor(options: GpuCrashFallbackOptions) {
@@ -37,31 +42,40 @@ export class GpuCrashFallbackTracker {
   /**
    * Records a GPU child crash at `msSinceLaunch` and reports whether this crash
    * just pushed the count over the threshold (i.e. fallback should engage now).
-   * Returns false for crashes outside the window or after fallback already
-   * engaged, so the caller relaunches at most once.
+   * Returns false after fallback already engaged, so the caller relaunches at
+   * most once.
    */
   recordGpuCrash(msSinceLaunch: number): {
     shouldEngageFallback: boolean
     crashesInWindow: number
   } {
-    if (
-      this.engaged ||
-      !Number.isFinite(msSinceLaunch) ||
-      msSinceLaunch < 0 ||
-      msSinceLaunch > this.windowMs
-    ) {
-      return { shouldEngageFallback: false, crashesInWindow: this.crashesInWindow }
+    if (this.engaged || !Number.isFinite(msSinceLaunch) || msSinceLaunch < 0) {
+      return { shouldEngageFallback: false, crashesInWindow: this.recentCrashes.length }
     }
-    this.crashesInWindow += 1
-    if (this.crashesInWindow >= this.threshold) {
+    // Why: out-of-order arrivals would corrupt the sorted window, and a clock
+    // that jumps backwards must not resurrect crashes already pruned.
+    const at = Math.max(msSinceLaunch, this.recentCrashes.at(-1) ?? 0)
+    this.recentCrashes.push(at)
+    const cutoff = at - this.windowMs
+    let stale = 0
+    while (stale < this.recentCrashes.length && this.recentCrashes[stale] < cutoff) {
+      stale += 1
+    }
+    this.recentCrashes.splice(0, stale)
+    if (this.recentCrashes.length >= this.threshold) {
       this.engaged = true
-      return { shouldEngageFallback: true, crashesInWindow: this.crashesInWindow }
+      return { shouldEngageFallback: true, crashesInWindow: this.recentCrashes.length }
     }
-    return { shouldEngageFallback: false, crashesInWindow: this.crashesInWindow }
+    return { shouldEngageFallback: false, crashesInWindow: this.recentCrashes.length }
   }
 
   hasEngaged(): boolean {
     return this.engaged
+  }
+
+  /** Crash times currently inside the window. Exposed to assert the pruning invariant. */
+  windowSnapshot(): readonly number[] {
+    return [...this.recentCrashes]
   }
 }
 

--- a/src/main/crash-reporting/gpu-fallback-restart-prompt.test.ts
+++ b/src/main/crash-reporting/gpu-fallback-restart-prompt.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { showMessageBoxMock } = vi.hoisted(() => ({
+  showMessageBoxMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  dialog: { showMessageBox: showMessageBoxMock }
+}))
+
+import { promptForGpuFallbackRestart } from './gpu-fallback-restart-prompt'
+
+beforeEach(() => {
+  showMessageBoxMock.mockReset()
+})
+
+describe('promptForGpuFallbackRestart', () => {
+  it('offers a restart without forcing it', async () => {
+    const parentWindow = { id: 1 }
+    showMessageBoxMock.mockResolvedValue({ response: 0 })
+
+    await expect(promptForGpuFallbackRestart(parentWindow as never)).resolves.toBe('restart')
+    expect(showMessageBoxMock).toHaveBeenCalledWith(parentWindow, {
+      type: 'warning',
+      buttons: ['Restart with Software Rendering', 'Keep Running'],
+      defaultId: 0,
+      cancelId: 1,
+      title: 'Restart Orca?',
+      message: "Orca's graphics process has crashed repeatedly.",
+      detail:
+        'Restart to switch to software rendering and reduce the chance of the app window crashing. If you keep running, Orca may become unstable.'
+    })
+  })
+
+  it('treats the secondary or dismissed response as continue', async () => {
+    showMessageBoxMock.mockResolvedValue({ response: 1 })
+
+    await expect(promptForGpuFallbackRestart()).resolves.toBe('continue')
+    expect(showMessageBoxMock).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/crash-reporting/gpu-fallback-restart-prompt.ts
+++ b/src/main/crash-reporting/gpu-fallback-restart-prompt.ts
@@ -1,0 +1,23 @@
+import { dialog, type BrowserWindow, type MessageBoxOptions } from 'electron'
+
+export type GpuFallbackRestartDecision = 'restart' | 'continue'
+
+const GPU_FALLBACK_RESTART_OPTIONS: MessageBoxOptions = {
+  type: 'warning',
+  buttons: ['Restart with Software Rendering', 'Keep Running'],
+  defaultId: 0,
+  cancelId: 1,
+  title: 'Restart Orca?',
+  message: "Orca's graphics process has crashed repeatedly.",
+  detail:
+    'Restart to switch to software rendering and reduce the chance of the app window crashing. If you keep running, Orca may become unstable.'
+}
+
+export async function promptForGpuFallbackRestart(
+  parentWindow?: BrowserWindow
+): Promise<GpuFallbackRestartDecision> {
+  const { response } = parentWindow
+    ? await dialog.showMessageBox(parentWindow, GPU_FALLBACK_RESTART_OPTIONS)
+    : await dialog.showMessageBox(GPU_FALLBACK_RESTART_OPTIONS)
+  return response === 0 ? 'restart' : 'continue'
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -290,7 +290,7 @@ let managedWslCliReconciliationReady: Promise<void> = Promise.resolve()
 let managedWslCliStartupBarrierReady: Promise<void> = Promise.resolve()
 // Why: the serve barrier fails open, so this state tells headless clients a WSL PTY launch may still race an un-migrated registration ('settled' = off-Windows no-op).
 let managedWslCliReconciliationStatus: 'pending' | 'settled' | 'failed' = 'settled'
-// Why: GPU child crashes clustered right after launch indicate a broken driver; track them to switch this build to software rendering.
+// Why: a tight cluster of GPU child crashes indicates a broken driver, whenever in the session it starts; track them to switch this build to software rendering.
 const gpuLaunchTimeMs = Date.now()
 const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
@@ -1389,7 +1389,7 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   })
 }
 
-// Why: a burst of GPU child crashes right after launch means HW acceleration is unusable — persist a build-scoped marker and relaunch into software rendering.
+// Why: a burst of GPU child crashes means HW acceleration is unusable — persist a build-scoped marker and relaunch into software rendering.
 function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   // Software rendering already active or shutting down: nothing more to do.
   if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
@@ -1428,6 +1428,8 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     exitCode,
     crashesInWindow: result.crashesInWindow
   })
+  // Why: app.exit(0) skips before-quit, so destroy the Windows tray manually to avoid a stale icon.
+  destroySystemTray()
   app.exit(0)
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -103,6 +103,10 @@ import {
   isGpuFallbackCrashCandidate
 } from './crash-reporting/gpu-crash-fallback-decision'
 import {
+  promptForGpuFallbackRestart,
+  type GpuFallbackRestartDecision
+} from './crash-reporting/gpu-fallback-restart-prompt'
+import {
   shouldSuppressDevEducation,
   suppressDevEducationForStore
 } from './startup/dev-education-suppression'
@@ -290,8 +294,6 @@ let managedWslCliReconciliationReady: Promise<void> = Promise.resolve()
 let managedWslCliStartupBarrierReady: Promise<void> = Promise.resolve()
 // Why: the serve barrier fails open, so this state tells headless clients a WSL PTY launch may still race an un-migrated registration ('settled' = off-Windows no-op).
 let managedWslCliReconciliationStatus: 'pending' | 'settled' | 'failed' = 'settled'
-// Why: a tight cluster of GPU child crashes indicates a broken driver, whenever in the session it starts; track them to switch this build to software rendering.
-const gpuLaunchTimeMs = Date.now()
 const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
   threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
@@ -1389,13 +1391,13 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   })
 }
 
-// Why: a burst of GPU child crashes means HW acceleration is unusable — persist a build-scoped marker and relaunch into software rendering.
-function handleGpuChildCrash(reason: string, exitCode: number | null): void {
+// Why: a burst of GPU child crashes means HW acceleration is unusable — persist a build-scoped marker and offer software rendering.
+async function handleGpuChildCrash(reason: string, exitCode: number | null): Promise<void> {
   // Software rendering already active or shutting down: nothing more to do.
   if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
     return
   }
-  const result = gpuCrashFallbackTracker.recordGpuCrash(Date.now() - gpuLaunchTimeMs)
+  const result = gpuCrashFallbackTracker.recordGpuCrash(performance.now())
   if (!result.shouldEngageFallback) {
     return
   }
@@ -1422,12 +1424,28 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     console.warn('[gpu-fallback] failed to persist marker:', error)
     return
   }
-  isQuitting = true
-  relaunchApp('gpu-fallback', {
+  const window = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined
+  let restartDecision: GpuFallbackRestartDecision
+  try {
+    restartDecision = await promptForGpuFallbackRestart(window)
+  } catch (error) {
+    console.warn('[gpu-fallback] failed to show restart prompt:', error)
+    return
+  }
+  const fallbackData = {
     processReason: reason,
     exitCode,
     crashesInWindow: result.crashesInWindow
-  })
+  }
+  if (isQuitting) {
+    return
+  }
+  if (restartDecision !== 'restart') {
+    recordDurableCrashBreadcrumb('gpu_fallback_restart_deferred', fallbackData)
+    return
+  }
+  isQuitting = true
+  relaunchApp('gpu-fallback', fallbackData)
   // Why: app.exit(0) skips before-quit, so destroy the Windows tray manually to avoid a stale icon.
   destroySystemTray()
   app.exit(0)
@@ -2208,7 +2226,7 @@ app.whenReady().then(async () => {
         reason: details.reason
       })
     ) {
-      handleGpuChildCrash(details.reason, details.exitCode ?? null)
+      void handleGpuChildCrash(details.reason, details.exitCode ?? null)
     }
   })
 


### PR DESCRIPTION
## Description

Software-rendering fallback could only ever see GPU child crashes in the **first 30 seconds after launch**:

```ts
if (msSinceLaunch > this.windowMs) return   // windowMs = 30_000
```

Session `12e6ee64` (Windows, v1.4.156) crashed the GPU child process four times, at **242s / 920s / 926s / 946s** since launch. The last three span **26.0 seconds** — comfortably inside `windowMs`, and exactly `threshold` (3). Fallback should have engaged. Instead every crash was discarded, because the burst *began* 920 seconds in. The renderer then died of process-level OOM (`-536870904` / `0xE0000008`) **39 seconds later**.

GPU work is demand-driven: the first heavy compositing frequently happens minutes into a session, not in the first 30 seconds. The thing that distinguishes a broken driver from ordinary Chromium churn is that the crashes **cluster** — not when the cluster happens to start.

This makes the window **rolling**: keep crash timestamps pruned to `windowMs` behind the newest, and engage when `threshold` land inside it.

## Fix evidence

Replaying session `12e6ee64`'s real crash times through both implementations, run natively on Windows:

```
crash times (ms since launch): 242137, 920110, 926462, 946115
last three span: 26.005 s  (windowMs = 30 s)

OLD (launch-anchored): engaged = false | counted = 0
NEW (rolling window) : engaged = true  | at = 946115 ms | crashesInWindow = 3

renderer died at ~985000ms — that is 39 s after the new code
would have prompted the user to restart into software rendering
```

The old code counted **zero** of the four crashes. The new code engages 39 seconds before the renderer died. Pinned as a regression test (`engages on a burst that starts long after launch (session 12e6ee64)`).

Tests: **15/15 focused GPU-fallback tests pass**, including both dialog choices. The rolling-window suite also passes on Windows, the platform this feature targets.

### Mutation testing

Every line of the new logic is load-bearing — 6 mutants, all killed:

| Mutant | Killed by |
|---|---|
| Restore `msSinceLaunch > this.windowMs` (the original defect) | 2 tests |
| Remove the pruning `splice` | 4 tests |
| Remove the monotonic clamp | 1 test |
| Window cutoff `<` → `<=` | 1 test |
| Threshold `>=` → `>` | 4 tests |
| Remove the `engaged` latch | 1 test |

## Proof this doesn't misfire (the real risk)

Widening a launch-only check to the whole session means it can now prompt for a relaunch at any moment. I measured that against **real field telemetry** rather than reasoning about it — extracting GPU child deaths from `process_gone_suppressed` breadcrumb trails, grouped per launch:

- **341 distinct Windows launches** with ≥1 GPU crash
- The rolling window engages on **2 of 341 (0.59%)** — and one of those two *is* session `12e6ee64`, the crash being fixed
- **Max GPU crashes in any single launch: 4** (317 launches had exactly 1)

Distribution across all 341 launches: `1 crash → 317`, `2 → 18`, `3 → 5`, `4 → 1`.

The closest *non-firing* sequence in the entire dataset is `[0, 29531, 55136, 74178]` — consecutive gaps of 29.5s and 25.6s, each of which fits inside a 30s window, but which never put three crashes in one window. Pruning has to retire the stale entry every single time or that user gets an unnecessary restart warning. **That exact sequence is now a regression test.**

## ELI5

Orca watches for the graphics driver crashing. If it crashes a bunch of times in a row, Orca offers to restart using slower-but-reliable software drawing; the user can keep running instead.

The bug: Orca only *watched* during the first 30 seconds after startup. After that it stopped paying attention entirely. One user's graphics driver started dying 15 minutes in — three crashes in 26 seconds, exactly the pattern Orca looks for — but nobody was watching, so nothing happened, and the app crashed 39 seconds later.

Now Orca watches the whole time. It still needs 3 crashes within any 30-second span, so a single hiccup hours in is ignored, same as before. When the threshold is reached, a native dialog offers Restart with Software Rendering or Keep Running.

## Trade-offs / user-facing regressions

**The real trade-off:** this can now interrupt a working session with a restart prompt, where previously fallback could only trigger in the first 30 seconds. Restart is explicit: the user can choose **Keep Running** and accept the stability risk.

Why I believe it's the right call:
- It fires on 0.59% of Windows launches that already have a GPU crash — and in those cases the app was heading for a renderer crash anyway. `12e6ee64` died 39 seconds later.
- Terminal sessions live in a **detached daemon that survives relaunch**, so PTYs and scrollback are preserved.
- The alternative is what happened here: the app dies with no recovery and the user loses everything.

**What is bounded / unchanged:**
- **Still at most one prompt and relaunch, structurally.** `engaged` latches the tracker inert; the marker is build-scoped; on the next launch `gpuFallbackActiveThisLaunch` is the *first* condition in `handleGpuChildCrash`, so a fallback launch can never write a second marker. No loop is reachable.
- **Non-Windows unaffected** — `isGpuFallbackCrashCandidate` still gates on `win32`.
- **A fresh hardware attempt after every update** — the marker is cleared on version mismatch.
- **Bounded memory** — the array holds only crashes inside a 30s window and stops growing once engaged; field max is 4.

**One adjacent fix included:** after the user approves restart, this path calls `app.exit(0)`, which skips `before-quit`. The `app:relaunch` IPC handler documents that and destroys the Windows tray manually to avoid a stale icon; this path didn't. Harmless when it could only fire 30s after launch, visible now that it can fire mid-session — so it now destroys the tray too.

## Adversarial review

**2 loops**, each a separate sub-agent.

1. **Correctness/regression review** — drove the false-positive measurement above and the `app.exit(0)` teardown question. Result: added the near-miss regression test, added the tray teardown, verified loop-freedom by tracing the marker lifecycle.
2. **Performance review** — array-vs-counter cost, worst-case growth, `windowSnapshot()` call sites, startup impact.

Findings I acted on: the boundary case (`<` vs `<=`) initially survived mutation, so the exact-`windowMs` semantic is now pinned by a test rather than left implicit; `windowSnapshot()` was added so the sorted/pruned invariant is assertable instead of shipping an untested line (verified test-only — no production callers).

**Full-suite note, stated plainly:** `vitest run src/main/` shows 2 failures on my branch — and *also* 2 failures on clean `origin/main`, with one of the two differing between runs (`transcript-watch-liveness` vs `pty-subprocess`). Both files pass in isolation on my branch. These are pre-existing flaky parallel-execution artifacts in files this change does not touch. Typecheck, oxlint, and oxfmt are clean.

Made with [Orca](https://github.com/stablyai/orca) 🐋
