### PR TITLE
fix(ai-vault): bound OpenCode SQLite and parse-cache scans

### DIFF
--- a/src/main/ai-vault/fake-opencode-sqlite-worker.ts
+++ b/src/main/ai-vault/fake-opencode-sqlite-worker.ts
@@ -1,0 +1,75 @@
+import type { Worker } from 'node:worker_threads'
+import type { OpenCodeSqliteWorkerRequest } from './session-scanner-opencode-sqlite-worker-protocol'
+
+export class FakeOpenCodeSqliteWorker {
+  postedRequests: OpenCodeSqliteWorkerRequest[] = []
+  postMessageError: Error | null = null
+  terminated = false
+  unrefed = false
+  private listeners = new Map<string, Set<(arg?: unknown) => void>>()
+
+  on(event: string, listener: (arg?: unknown) => void): this {
+    const set = this.listeners.get(event) ?? new Set()
+    set.add(listener)
+    this.listeners.set(event, set)
+    return this
+  }
+
+  off(event: string, listener: (arg?: unknown) => void): this {
+    this.listeners.get(event)?.delete(listener)
+    return this
+  }
+
+  removeAllListeners(): void {
+    this.listeners.clear()
+  }
+
+  unref(): void {
+    this.unrefed = true
+  }
+
+  async terminate(): Promise<number> {
+    this.terminated = true
+    return 1
+  }
+
+  postMessage(request: OpenCodeSqliteWorkerRequest): void {
+    if (this.postMessageError) {
+      const error = this.postMessageError
+      this.postMessageError = null
+      throw error
+    }
+    this.postedRequests.push(request)
+  }
+
+  emit(event: string, arg?: unknown): void {
+    for (const listener of Array.from(this.listeners.get(event) ?? [])) {
+      listener(arg)
+    }
+  }
+
+  lastId(): number {
+    const last = this.postedRequests.at(-1)
+    if (!last) {
+      throw new Error('no request posted to fake worker')
+    }
+    return last.id
+  }
+
+  listenerCount(): number {
+    return Array.from(this.listeners.values()).reduce(
+      (total, listeners) => total + listeners.size,
+      0
+    )
+  }
+}
+
+export function makeFakeOpenCodeSqliteWorkerFactory(
+  workers: FakeOpenCodeSqliteWorker[]
+): () => Worker {
+  return () => {
+    const worker = new FakeOpenCodeSqliteWorker()
+    workers.push(worker)
+    return worker as unknown as Worker
+  }
+}

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -49,6 +49,7 @@ const APP_VERSION = '1.2.3-test'
 
 let tempRoots: string[] = []
 let activeDebugSpy: MockInstance | null = null
+let activeFileHandleSyncSpy: MockInstance | null = null
 
 // Restored from a hook, not inline: a failed assertion must not leave
 // console.debug stubbed for every later test in the file.
@@ -65,6 +66,8 @@ beforeEach(() => {
 afterEach(async () => {
   activeDebugSpy?.mockRestore()
   activeDebugSpy = null
+  activeFileHandleSyncSpy?.mockRestore()
+  activeFileHandleSyncSpy = null
   resetSessionParseCachePersistenceForTests()
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
@@ -187,11 +190,14 @@ describe('session parse cache persistence', () => {
     const cacheFile = join(root, 'session-parse-cache.json')
     await writeFile(cacheFile, 'not json {{{')
     initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    const debugSpy = silenceDebugLogs()
 
     const transcript = await writeTranscript(root)
     const stats = await coldParseStats(transcript)
     expect(stats.fullParses).toBe(1)
     expect(stats.reused).toBe(0)
+    expect(existsSync(cacheFile)).toBe(false)
+    expect(debugSpy).toHaveBeenCalled()
   })
 
   it('rejects an oversized sparse cache before reading its contents', async () => {
@@ -200,11 +206,14 @@ describe('session parse cache persistence', () => {
     await writeFile(cacheFile, '')
     await truncate(cacheFile, SESSION_PARSE_CACHE_MAX_BYTES + 1)
     initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    const debugSpy = silenceDebugLogs()
 
     const transcript = await writeTranscript(root)
     const stats = await coldParseStats(transcript)
     expect(stats.fullParses).toBe(1)
     expect(stats.reused).toBe(0)
+    expect(existsSync(cacheFile)).toBe(false)
+    expect(debugSpy).toHaveBeenCalled()
   })
 
   it('accepts an exact-byte-cap cache file', async () => {
@@ -265,10 +274,13 @@ describe('session parse cache persistence', () => {
       })
     )
     initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    const debugSpy = silenceDebugLogs()
 
     const stats = await coldParseStats(transcript)
     expect(stats.fullParses).toBe(1)
     expect(stats.reused).toBe(0)
+    expect(existsSync(cacheFile)).toBe(false)
+    expect(debugSpy).toHaveBeenCalled()
   })
 
   it('accepts nesting depth 32 and rejects depth 33 through the real loader', async () => {
@@ -424,6 +436,27 @@ describe('session parse cache persistence', () => {
     expect(existsSync(cacheFile)).toBe(true)
   })
 
+  it('syncs a complete temp snapshot before its atomic rename', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    const transcript = await writeTranscript(root)
+    const stats = await coldParseStats(transcript)
+    const probe = await fsPromises.open(join(root, 'file-handle-probe'), 'w')
+    activeFileHandleSyncSpy = vi.spyOn(Object.getPrototypeOf(probe), 'sync')
+    await probe.close()
+    vi.clearAllMocks()
+
+    scheduleSessionParseCachePersist(stats)
+    await flushSessionParseCachePersistForTests()
+
+    expect(activeFileHandleSyncSpy).toHaveBeenCalledTimes(1)
+    expect(fsPromises.rename).toHaveBeenCalledTimes(1)
+    expect(activeFileHandleSyncSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(fsPromises.rename).mock.invocationCallOrder[0]!
+    )
+  })
+
   it('sweeps orphaned temp files from a prior crashed save on load', async () => {
     const root = await makeTempDir()
     const cacheFile = join(root, 'session-parse-cache.json')
@@ -504,13 +537,13 @@ describe('session parse cache persistence', () => {
     expect(stats.fullParses).toBe(0)
   })
 
-  it('round-trips a full 4,096-entry writer snapshot', async () => {
+  it('trims a large writer snapshot to the synchronous parse budget and keeps its newest entry', async () => {
     const root = await makeTempDir()
     const cacheFile = join(root, 'session-parse-cache.json')
     const transcript = await writeTranscript(root)
     const candidate = await claudeCandidate(transcript)
     const largeSession = {
-      padding: 'x'.repeat(14_000)
+      padding: 'x'.repeat(4_000)
     } as unknown as PersistedSessionParseCacheEntry['session']
     const entry: PersistedSessionParseCacheEntry = {
       mtimeMs: candidate.file.mtimeMs,
@@ -540,8 +573,10 @@ describe('session parse cache persistence', () => {
     await parseAgentSessionFileCached(candidate, process.platform, stats)
     expect(stats.reused).toBe(1)
     const persistedText = await readFile(cacheFile, 'utf8')
-    expect(Buffer.byteLength(persistedText)).toBeGreaterThan(54 * 1024 * 1024)
-    expect(JSON.parse(persistedText).entries).toHaveLength(4096)
+    expect(Buffer.byteLength(persistedText)).toBeLessThanOrEqual(SESSION_PARSE_CACHE_MAX_BYTES)
+    const persisted = JSON.parse(persistedText) as { entries: unknown[] }
+    expect(persisted.entries.length).toBeGreaterThan(0)
+    expect(persisted.entries.length).toBeLessThan(4096)
   })
 
   it('rejects malformed entries even when they fall outside the retained tail', async () => {

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -21,6 +21,7 @@ import {
   initSessionParseCachePersistence,
   resetSessionParseCachePersistenceForTests,
   scheduleSessionParseCachePersist,
+  serializeSessionParseCacheSnapshot,
   SESSION_PARSE_CACHE_MAX_BYTES
 } from './session-parse-cache-persistence'
 import { scanAiVaultSessions } from './session-scanner'
@@ -615,6 +616,49 @@ describe('session parse cache persistence', () => {
     await flushSessionParseCachePersistForTests()
 
     expect(await readFile(cacheFile, 'utf8')).toBe(previousSnapshot)
+    expect(debugSpy).toHaveBeenCalled()
+    debugSpy.mockRestore()
+  })
+
+  // Why: hitting the cap must degrade, not disable. Giving up outright would
+  // leave the stale file in place and every later save failing identically,
+  // silently turning the #9210 cache off for the rest of the install's life.
+  it('trims the oldest entries rather than abandoning an oversized snapshot', () => {
+    const entries: [string, PersistedSessionParseCacheEntry][] = Array.from(
+      { length: 16 },
+      (_, index) => [
+        `/foreign/entry-${index}.jsonl`,
+        { mtimeMs: index, sizeBytes: 1, platform: process.platform, session: null }
+      ]
+    )
+
+    // A cap that only a subset can fit under.
+    const serialized = serializeSessionParseCacheSnapshot(entries, APP_VERSION, 512)
+    expect(serialized).not.toBeNull()
+
+    const saved = JSON.parse(serialized!) as {
+      entries: [string, PersistedSessionParseCacheEntry][]
+    }
+    expect(saved.entries.length).toBeGreaterThan(0)
+    expect(saved.entries.length).toBeLessThan(entries.length)
+    // Snapshot order is oldest→newest, and a restart only reuses the newest.
+    expect(saved.entries.at(-1)?.[0]).toBe('/foreign/entry-15.jsonl')
+  })
+
+  it('reports rather than writes when no subset of entries can fit', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    // One poison entry, so trimming can never produce a fitting snapshot.
+    const serialized = serializeSessionParseCacheSnapshot(
+      [
+        [
+          '/foreign/huge.jsonl',
+          { mtimeMs: 1, sizeBytes: 1, platform: process.platform, session: null }
+        ]
+      ],
+      APP_VERSION,
+      8
+    )
+    expect(serialized).toBeNull()
     expect(debugSpy).toHaveBeenCalled()
     debugSpy.mockRestore()
   })

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -26,6 +26,7 @@ import {
   SESSION_PARSE_CACHE_MAX_BYTES
 } from './session-parse-cache-persistence'
 import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
+import { serializeSessionParseCacheSnapshotCooperatively } from './session-parse-cache-snapshot-serialization'
 import { scanAiVaultSessions } from './session-scanner'
 import {
   createSessionParseStats,
@@ -648,10 +649,49 @@ describe('session parse cache persistence', () => {
     expect(saved.entries.at(-1)?.[0]).toBe('/foreign/entry-15.jsonl')
   })
 
-  // Why: the save path no longer re-scans its own output for structural tokens,
-  // so nothing at runtime stops a snapshot the loader would then reject and
-  // delete — silently disabling the #9210 cache. This is that guard: a maximal
-  // snapshot of the widest realistic session must load back within both limits.
+  it('retains the maximum fitting suffix instead of dropping half for a tiny overflow', () => {
+    const entries: [string, PersistedSessionParseCacheEntry][] = Array.from(
+      { length: 16 },
+      (_, index) => [
+        `/foreign/entry-${index}.jsonl`,
+        { mtimeMs: index, sizeBytes: 1, platform: process.platform, session: null }
+      ]
+    )
+    const full = serializeSessionParseCacheSnapshot(entries, APP_VERSION)
+    expect(full).not.toBeNull()
+
+    const serialized = serializeSessionParseCacheSnapshot(
+      entries,
+      APP_VERSION,
+      Buffer.byteLength(full!) - 1
+    )
+    const saved = JSON.parse(serialized!) as {
+      entries: [string, PersistedSessionParseCacheEntry][]
+    }
+    expect(saved.entries).toHaveLength(15)
+    expect(saved.entries[0]?.[0]).toBe('/foreign/entry-1.jsonl')
+    expect(saved.entries.at(-1)?.[0]).toBe('/foreign/entry-15.jsonl')
+  })
+
+  it('cooperatively matches synchronous admission and precise trimming', async () => {
+    const entries: [string, PersistedSessionParseCacheEntry][] = Array.from(
+      { length: 64 },
+      (_, index) => [
+        `/foreign/entry-${index}.jsonl`,
+        { mtimeMs: index, sizeBytes: 1, platform: process.platform, session: null }
+      ]
+    )
+
+    const full = serializeSessionParseCacheSnapshot(entries, APP_VERSION)
+    expect(full).not.toBeNull()
+    const maxBytes = Buffer.byteLength(full!) - 1
+    await expect(
+      serializeSessionParseCacheSnapshotCooperatively(entries, APP_VERSION, maxBytes)
+    ).resolves.toBe(serializeSessionParseCacheSnapshot(entries, APP_VERSION, maxBytes))
+  })
+
+  // Writer and loader enforce the same limits; pin enough headroom for the
+  // widest realistic full cache so capacity trimming stays exceptional.
   it('keeps a full snapshot loadable within the load-path limits', () => {
     const entries: [string, PersistedSessionParseCacheEntry][] = Array.from(
       { length: MAX_CACHE_ENTRIES },

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -490,11 +490,14 @@ describe('session parse cache persistence', () => {
     const cacheFile = join(root, 'session-parse-cache.json')
     const transcript = await writeTranscript(root)
     const candidate = await claudeCandidate(transcript)
+    const largeSession = {
+      padding: 'x'.repeat(14_000)
+    } as unknown as PersistedSessionParseCacheEntry['session']
     const entry: PersistedSessionParseCacheEntry = {
       mtimeMs: candidate.file.mtimeMs,
       sizeBytes: candidate.file.sizeBytes ?? null,
       platform: process.platform,
-      session: null
+      session: largeSession
     }
     seedSessionParseCache([
       ...Array.from({ length: 4095 }, (_, index): [string, PersistedSessionParseCacheEntry] => [
@@ -517,7 +520,9 @@ describe('session parse cache persistence', () => {
     const stats = createSessionParseStats()
     await parseAgentSessionFileCached(candidate, process.platform, stats)
     expect(stats.reused).toBe(1)
-    expect(JSON.parse(await readFile(cacheFile, 'utf8')).entries).toHaveLength(4096)
+    const persistedText = await readFile(cacheFile, 'utf8')
+    expect(Buffer.byteLength(persistedText)).toBeGreaterThan(54 * 1024 * 1024)
+    expect(JSON.parse(persistedText).entries).toHaveLength(4096)
   })
 
   it('rejects malformed entries even when they fall outside the retained tail', async () => {

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -22,11 +22,14 @@ import {
   resetSessionParseCachePersistenceForTests,
   scheduleSessionParseCachePersist,
   serializeSessionParseCacheSnapshot,
+  SESSION_PARSE_CACHE_JSON_LIMITS,
   SESSION_PARSE_CACHE_MAX_BYTES
 } from './session-parse-cache-persistence'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
 import { scanAiVaultSessions } from './session-scanner'
 import {
   createSessionParseStats,
+  MAX_CACHE_ENTRIES,
   parseAgentSessionFileCached,
   resetSessionParseCacheForTests,
   seedSessionParseCache,
@@ -643,6 +646,59 @@ describe('session parse cache persistence', () => {
     expect(saved.entries.length).toBeLessThan(entries.length)
     // Snapshot order is oldest→newest, and a restart only reuses the newest.
     expect(saved.entries.at(-1)?.[0]).toBe('/foreign/entry-15.jsonl')
+  })
+
+  // Why: the save path no longer re-scans its own output for structural tokens,
+  // so nothing at runtime stops a snapshot the loader would then reject and
+  // delete — silently disabling the #9210 cache. This is that guard: a maximal
+  // snapshot of the widest realistic session must load back within both limits.
+  it('keeps a full snapshot loadable within the load-path limits', () => {
+    const entries: [string, PersistedSessionParseCacheEntry][] = Array.from(
+      { length: MAX_CACHE_ENTRIES },
+      (_, index) => [
+        `/Users/someone/.claude/projects/a-fairly-long-project-dir/session-${index}.jsonl`,
+        {
+          mtimeMs: 1_700_000_000_000 + index,
+          sizeBytes: 4096,
+          platform: process.platform,
+          session: {
+            id: `local:claude:session-${index}:/path/session-${index}.jsonl`,
+            executionHostId: 'local',
+            agent: 'claude',
+            sessionId: `session-${index}`,
+            title: 't'.repeat(96),
+            cwd: '/Users/someone/Documents/projects/orca/a-worktree',
+            branch: 'some-fairly-long-branch-name',
+            model: 'claude-opus-5',
+            filePath: `/path/session-${index}.jsonl`,
+            codexHome: null,
+            createdAt: '2026-07-20T00:00:00.000Z',
+            updatedAt: '2026-07-26T00:00:00.000Z',
+            modifiedAt: '2026-07-26T00:00:00.000Z',
+            messageCount: 500,
+            totalTokens: 1_000_000,
+            // The accumulator's ring buffer caps previews at 5 × 220 chars.
+            previewMessages: Array.from({ length: 5 }, () => ({
+              role: 'user' as const,
+              text: 'p'.repeat(220),
+              timestamp: '2026-07-26T00:00:00.000Z'
+            })),
+            lastUserPrompt: 'q'.repeat(500),
+            queuedMessageCount: 0,
+            subagentTranscriptCount: 4,
+            resumeCommand: `claude --resume session-${index}`,
+            subagent: null
+          }
+        }
+      ]
+    )
+
+    const serialized = serializeSessionParseCacheSnapshot(entries, APP_VERSION)
+    expect(serialized).not.toBeNull()
+    expect(Buffer.byteLength(serialized!, 'utf8')).toBeLessThan(SESSION_PARSE_CACHE_MAX_BYTES)
+    expect(() =>
+      assertJsonTextStructureWithinLimits(serialized!, SESSION_PARSE_CACHE_JSON_LIMITS)
+    ).not.toThrow()
   })
 
   it('reports rather than writes when no subset of entries can fit', () => {

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -7,6 +7,7 @@ import {
   readdir,
   rm,
   stat,
+  truncate,
   utimes,
   writeFile
 } from 'node:fs/promises'
@@ -19,7 +20,8 @@ import {
   flushSessionParseCachePersistForTests,
   initSessionParseCachePersistence,
   resetSessionParseCachePersistenceForTests,
-  scheduleSessionParseCachePersist
+  scheduleSessionParseCachePersist,
+  SESSION_PARSE_CACHE_MAX_BYTES
 } from './session-parse-cache-persistence'
 import { scanAiVaultSessions } from './session-scanner'
 import {
@@ -164,6 +166,50 @@ describe('session parse cache persistence', () => {
     initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
 
     const transcript = await writeTranscript(root)
+    const stats = await coldParseStats(transcript)
+    expect(stats.fullParses).toBe(1)
+    expect(stats.reused).toBe(0)
+  })
+
+  it('rejects an oversized sparse cache before reading its contents', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    await writeFile(cacheFile, '')
+    await truncate(cacheFile, SESSION_PARSE_CACHE_MAX_BYTES + 1)
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+
+    const transcript = await writeTranscript(root)
+    const stats = await coldParseStats(transcript)
+    expect(stats.fullParses).toBe(1)
+    expect(stats.reused).toBe(0)
+  })
+
+  it('rejects structurally excessive JSON before parsing the cache graph', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    const transcript = await writeTranscript(root)
+    const candidate = await claudeCandidate(transcript)
+    const structuralNoise = Array.from({ length: 1_000_000 }, () => null)
+    await writeFile(
+      cacheFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        appVersion: APP_VERSION,
+        entries: [
+          [
+            transcript,
+            {
+              mtimeMs: candidate.file.mtimeMs,
+              sizeBytes: candidate.file.sizeBytes,
+              platform: process.platform,
+              session: { structuralNoise }
+            }
+          ]
+        ]
+      })
+    )
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+
     const stats = await coldParseStats(transcript)
     expect(stats.fullParses).toBe(1)
     expect(stats.reused).toBe(0)
@@ -359,6 +405,100 @@ describe('session parse cache persistence', () => {
     await parseAgentSessionFileCached(candidate, process.platform, stats)
     expect(stats.reused).toBe(1)
     expect(stats.fullParses).toBe(0)
+  })
+
+  it('rejects malformed entries even when they fall outside the retained tail', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    const transcript = await writeTranscript(root)
+    const candidate = await claudeCandidate(transcript)
+    const validEntry: PersistedSessionParseCacheEntry = {
+      mtimeMs: candidate.file.mtimeMs,
+      sizeBytes: candidate.file.sizeBytes ?? null,
+      platform: process.platform,
+      session: null
+    }
+    const entries: unknown[] = [
+      ['discarded-malformed'],
+      ...Array.from({ length: 4097 }, (_, index) => [`/fake-${index}`, validEntry]),
+      [transcript, validEntry],
+      [transcript, { ...validEntry, mtimeMs: candidate.file.mtimeMs + 1 }]
+    ]
+    await writeFile(
+      cacheFile,
+      JSON.stringify({ schemaVersion: 1, appVersion: APP_VERSION, entries })
+    )
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+
+    const stats = await coldParseStats(transcript)
+    expect(stats.fullParses).toBe(1)
+    expect(stats.reused).toBe(0)
+  })
+
+  it('keeps the newest persisted entry when a path is duplicated', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    const transcript = await writeTranscript(root)
+    const candidate = await claudeCandidate(transcript)
+    const entry: PersistedSessionParseCacheEntry = {
+      mtimeMs: candidate.file.mtimeMs,
+      sizeBytes: candidate.file.sizeBytes ?? null,
+      platform: process.platform,
+      session: null
+    }
+    await writeFile(
+      cacheFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        appVersion: APP_VERSION,
+        entries: [
+          [transcript, { ...entry, mtimeMs: entry.mtimeMs - 1 }],
+          [transcript, entry]
+        ]
+      })
+    )
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+
+    const stats = await coldParseStats(transcript)
+    expect(stats.reused).toBe(1)
+    expect(stats.fullParses).toBe(0)
+  })
+
+  it('leaves the previous snapshot intact when writer structure admission fails', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    const transcript = await writeTranscript(root)
+    await parseAndPersist(transcript)
+    const previousSnapshot = await readFile(cacheFile, 'utf8')
+
+    let deeplyNested: unknown = null
+    for (let depth = 0; depth < 40; depth += 1) {
+      deeplyNested = { next: deeplyNested }
+    }
+    seedSessionParseCache([
+      [
+        '/foreign/deep-session.jsonl',
+        {
+          mtimeMs: 1,
+          sizeBytes: 1,
+          platform: process.platform,
+          session: deeplyNested as PersistedSessionParseCacheEntry['session']
+        }
+      ]
+    ])
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    scheduleSessionParseCachePersist({
+      reused: 0,
+      incremental: 0,
+      fullParses: 1,
+      bytesRead: 1
+    })
+    await flushSessionParseCachePersistForTests()
+
+    expect(await readFile(cacheFile, 'utf8')).toBe(previousSnapshot)
+    expect(debugSpy).toHaveBeenCalled()
+    debugSpy.mockRestore()
   })
 
   it('a failing rename cleans up its temp file and keeps the previous snapshot usable', async () => {

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -97,6 +97,14 @@ function assistantRecord(index: number, text: string): string {
   })
 }
 
+function nestedUnknownSession(depth: number): PersistedSessionParseCacheEntry['session'] {
+  let value: unknown = null
+  for (let index = 0; index < depth; index += 1) {
+    value = { next: value }
+  }
+  return value as PersistedSessionParseCacheEntry['session']
+}
+
 async function writeTranscript(root: string): Promise<string> {
   const path = join(root, 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee.jsonl')
   await writeFile(path, `${userRecord(0, 'first question')}\n${assistantRecord(1, 'answer')}\n`)
@@ -184,6 +192,39 @@ describe('session parse cache persistence', () => {
     expect(stats.reused).toBe(0)
   })
 
+  it('accepts an exact-byte-cap cache file', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    const transcript = await writeTranscript(root)
+    const candidate = await claudeCandidate(transcript)
+    const file = {
+      schemaVersion: 1,
+      appVersion: APP_VERSION,
+      entries: [
+        [
+          transcript,
+          {
+            mtimeMs: candidate.file.mtimeMs,
+            sizeBytes: candidate.file.sizeBytes,
+            platform: process.platform,
+            session: null
+          }
+        ]
+      ],
+      padding: ''
+    }
+    const base = JSON.stringify(file)
+    file.padding = 'x'.repeat(SESSION_PARSE_CACHE_MAX_BYTES - Buffer.byteLength(base))
+    const payload = JSON.stringify(file)
+    expect(Buffer.byteLength(payload)).toBe(SESSION_PARSE_CACHE_MAX_BYTES)
+    await writeFile(cacheFile, payload)
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+
+    const stats = await coldParseStats(transcript)
+    expect(stats.reused).toBe(1)
+    expect(stats.fullParses).toBe(0)
+  })
+
   it('rejects structurally excessive JSON before parsing the cache graph', async () => {
     const root = await makeTempDir()
     const cacheFile = join(root, 'session-parse-cache.json')
@@ -213,6 +254,43 @@ describe('session parse cache persistence', () => {
     const stats = await coldParseStats(transcript)
     expect(stats.fullParses).toBe(1)
     expect(stats.reused).toBe(0)
+  })
+
+  it('accepts nesting depth 32 and rejects depth 33 through the real loader', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    const transcript = await writeTranscript(root)
+    const candidate = await claudeCandidate(transcript)
+    const writeNestedCache = async (sessionDepth: number): Promise<void> => {
+      await writeFile(
+        cacheFile,
+        JSON.stringify({
+          schemaVersion: 1,
+          appVersion: APP_VERSION,
+          entries: [
+            [
+              transcript,
+              {
+                mtimeMs: candidate.file.mtimeMs,
+                sizeBytes: candidate.file.sizeBytes,
+                platform: process.platform,
+                session: nestedUnknownSession(sessionDepth)
+              }
+            ]
+          ]
+        })
+      )
+    }
+
+    await writeNestedCache(28)
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    expect((await coldParseStats(transcript)).reused).toBe(1)
+
+    simulateRestart(cacheFile)
+    await writeNestedCache(29)
+    const rejectedStats = await coldParseStats(transcript)
+    expect(rejectedStats.reused).toBe(0)
+    expect(rejectedStats.fullParses).toBe(1)
   })
 
   it('ignores a cache file with a mismatched schemaVersion', async () => {
@@ -407,6 +485,41 @@ describe('session parse cache persistence', () => {
     expect(stats.fullParses).toBe(0)
   })
 
+  it('round-trips a full 4,096-entry writer snapshot', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    const transcript = await writeTranscript(root)
+    const candidate = await claudeCandidate(transcript)
+    const entry: PersistedSessionParseCacheEntry = {
+      mtimeMs: candidate.file.mtimeMs,
+      sizeBytes: candidate.file.sizeBytes ?? null,
+      platform: process.platform,
+      session: null
+    }
+    seedSessionParseCache([
+      ...Array.from({ length: 4095 }, (_, index): [string, PersistedSessionParseCacheEntry] => [
+        `/fake-${index}`,
+        entry
+      ]),
+      [transcript, entry]
+    ])
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    scheduleSessionParseCachePersist({
+      reused: 0,
+      incremental: 0,
+      fullParses: 1,
+      bytesRead: 1
+    })
+    await flushSessionParseCachePersistForTests()
+
+    simulateRestart(cacheFile)
+    await ensureSessionParseCacheLoaded()
+    const stats = createSessionParseStats()
+    await parseAgentSessionFileCached(candidate, process.platform, stats)
+    expect(stats.reused).toBe(1)
+    expect(JSON.parse(await readFile(cacheFile, 'utf8')).entries).toHaveLength(4096)
+  })
+
   it('rejects malformed entries even when they fall outside the retained tail', async () => {
     const root = await makeTempDir()
     const cacheFile = join(root, 'session-parse-cache.json')
@@ -484,6 +597,39 @@ describe('session parse cache persistence', () => {
           sizeBytes: 1,
           platform: process.platform,
           session: deeplyNested as PersistedSessionParseCacheEntry['session']
+        }
+      ]
+    ])
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    scheduleSessionParseCachePersist({
+      reused: 0,
+      incremental: 0,
+      fullParses: 1,
+      bytesRead: 1
+    })
+    await flushSessionParseCachePersistForTests()
+
+    expect(await readFile(cacheFile, 'utf8')).toBe(previousSnapshot)
+    expect(debugSpy).toHaveBeenCalled()
+    debugSpy.mockRestore()
+  })
+
+  it('leaves the previous snapshot intact when writer byte admission fails', async () => {
+    const root = await makeTempDir()
+    const cacheFile = join(root, 'session-parse-cache.json')
+    initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
+    const transcript = await writeTranscript(root)
+    await parseAndPersist(transcript)
+    const previousSnapshot = await readFile(cacheFile, 'utf8')
+
+    seedSessionParseCache([
+      [
+        'x'.repeat(SESSION_PARSE_CACHE_MAX_BYTES),
+        {
+          mtimeMs: 1,
+          sizeBytes: 1,
+          platform: process.platform,
+          session: null
         }
       ]
     ])

--- a/src/main/ai-vault/session-parse-cache-persistence.test.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.test.ts
@@ -14,7 +14,7 @@ import {
 import * as fsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
 import {
   ensureSessionParseCacheLoaded,
   flushSessionParseCachePersistForTests,
@@ -48,6 +48,14 @@ vi.mock('node:fs/promises', { spy: true })
 const APP_VERSION = '1.2.3-test'
 
 let tempRoots: string[] = []
+let activeDebugSpy: MockInstance | null = null
+
+// Restored from a hook, not inline: a failed assertion must not leave
+// console.debug stubbed for every later test in the file.
+function silenceDebugLogs(): MockInstance {
+  activeDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+  return activeDebugSpy
+}
 
 beforeEach(() => {
   resetSessionParseCacheForTests()
@@ -55,6 +63,8 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
+  activeDebugSpy?.mockRestore()
+  activeDebugSpy = null
   resetSessionParseCachePersistenceForTests()
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
@@ -287,12 +297,16 @@ describe('session parse cache persistence', () => {
       )
     }
 
-    await writeNestedCache(28)
+    // The persisted wrapper (file object → entries → entry pair → entry
+    // object) already spends 4 of the budget before the session value starts.
+    const maxSessionDepth = SESSION_PARSE_CACHE_JSON_LIMITS.nestingDepth - 4
+
+    await writeNestedCache(maxSessionDepth)
     initSessionParseCachePersistence({ filePath: cacheFile, appVersion: APP_VERSION })
     expect((await coldParseStats(transcript)).reused).toBe(1)
 
     simulateRestart(cacheFile)
-    await writeNestedCache(29)
+    await writeNestedCache(maxSessionDepth + 1)
     const rejectedStats = await coldParseStats(transcript)
     expect(rejectedStats.reused).toBe(0)
     expect(rejectedStats.fullParses).toBe(1)
@@ -610,7 +624,7 @@ describe('session parse cache persistence', () => {
         }
       ]
     ])
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const debugSpy = silenceDebugLogs()
     scheduleSessionParseCachePersist({
       reused: 0,
       incremental: 0,
@@ -621,7 +635,6 @@ describe('session parse cache persistence', () => {
 
     expect(await readFile(cacheFile, 'utf8')).toBe(previousSnapshot)
     expect(debugSpy).toHaveBeenCalled()
-    debugSpy.mockRestore()
   })
 
   // Why: hitting the cap must degrade, not disable. Giving up outright would
@@ -742,7 +755,7 @@ describe('session parse cache persistence', () => {
   })
 
   it('reports rather than writes when no subset of entries can fit', () => {
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const debugSpy = silenceDebugLogs()
     // One poison entry, so trimming can never produce a fitting snapshot.
     const serialized = serializeSessionParseCacheSnapshot(
       [
@@ -756,7 +769,6 @@ describe('session parse cache persistence', () => {
     )
     expect(serialized).toBeNull()
     expect(debugSpy).toHaveBeenCalled()
-    debugSpy.mockRestore()
   })
 
   it('leaves the previous snapshot intact when writer byte admission fails', async () => {
@@ -778,7 +790,7 @@ describe('session parse cache persistence', () => {
         }
       ]
     ])
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const debugSpy = silenceDebugLogs()
     scheduleSessionParseCachePersist({
       reused: 0,
       incremental: 0,
@@ -789,7 +801,6 @@ describe('session parse cache persistence', () => {
 
     expect(await readFile(cacheFile, 'utf8')).toBe(previousSnapshot)
     expect(debugSpy).toHaveBeenCalled()
-    debugSpy.mockRestore()
   })
 
   it('a failing rename cleans up its temp file and keeps the previous snapshot usable', async () => {
@@ -806,7 +817,7 @@ describe('session parse cache persistence', () => {
     await writeFile(other, `${userRecord(2, 'second session')}\n${assistantRecord(3, 'reply')}\n`)
     const stats = createSessionParseStats()
     await parseAgentSessionFileCached(await claudeCandidate(other), process.platform, stats)
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const debugSpy = silenceDebugLogs()
     vi.mocked(fsPromises.rename).mockRejectedValueOnce(
       Object.assign(new Error('EPERM: rename blocked'), { code: 'EPERM' })
     )
@@ -829,7 +840,6 @@ describe('session parse cache persistence', () => {
       reusedStats
     )
     expect(reusedStats.reused).toBe(1)
-    debugSpy.mockRestore()
   })
 
   it('swallows save failures and leaves scan results unaffected', async () => {
@@ -842,7 +852,7 @@ describe('session parse cache persistence', () => {
       filePath: join(blocker, 'session-parse-cache.json'),
       appVersion: APP_VERSION
     })
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const debugSpy = silenceDebugLogs()
 
     const transcript = await writeTranscript(root)
     const candidate = await claudeCandidate(transcript)
@@ -863,6 +873,5 @@ describe('session parse cache persistence', () => {
     expect(reusedStats.reused).toBe(1)
     expect(await readdir(root)).toEqual(expect.arrayContaining(['blocker']))
     expect((await readdir(root)).filter((name) => name.endsWith('.tmp'))).toEqual([])
-    debugSpy.mockRestore()
   })
 })

--- a/src/main/ai-vault/session-parse-cache-persistence.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.ts
@@ -5,9 +5,16 @@
 // degrades to today's cold-scan behavior.
 import { mkdir, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
-import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
+import {
+  assertJsonTextStructureWithinLimits,
+  JsonTextStructureCapacityError,
+  type JsonTextStructureLimits
+} from '../../shared/json-text-structure-limit'
 import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
-import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../../shared/node-bounded-json-stringify'
 import {
   MAX_CACHE_ENTRIES,
   seedSessionParseCache,
@@ -116,7 +123,11 @@ async function loadPersistedEntries(current: SessionParseCachePersistenceOptions
     const entries = parsePersistedFile(JSON.parse(raw), current.appVersion)
     if (entries) {
       seedSessionParseCache(entries)
+      return
     }
+    // Unreadable content, not a missing file: drop it so it can't be re-read
+    // every launch while the next save replaces it.
+    await rm(current.filePath, { force: true }).catch(() => {})
   } catch {
     // Why: a missing/corrupt/foreign cache file must never fail the scan;
     // worst case is exactly today's cold scan.
@@ -204,19 +215,61 @@ function parsePersistedEntry(item: unknown): [string, PersistedSessionParseCache
   ]
 }
 
+// Why: hitting a capacity limit must degrade, not disable. Serializing the whole
+// snapshot and giving up would leave the old file in place and every later save
+// failing the same way, silently turning the #9210 cache back off for good. The
+// newest entries are the ones a restart actually reuses, so drop the oldest half
+// and retry until it fits.
+export function serializeSessionParseCacheSnapshot(
+  entries: [string, PersistedSessionParseCacheEntry][],
+  appVersion: string,
+  maxBytes: number = SESSION_PARSE_CACHE_MAX_BYTES,
+  jsonLimits: JsonTextStructureLimits = SESSION_PARSE_CACHE_JSON_LIMITS
+): string | null {
+  let retained = entries
+  while (retained.length > 0) {
+    try {
+      const { serialized } = stringifyJsonWithinByteLimit(
+        { schemaVersion: SCHEMA_VERSION, appVersion, entries: retained },
+        maxBytes
+      )
+      assertJsonTextStructureWithinLimits(serialized, jsonLimits)
+      if (retained.length !== entries.length) {
+        console.debug(
+          `[ai-vault] session parse cache trimmed to ${retained.length}/${entries.length} entries to fit its size limits`
+        )
+      }
+      return serialized
+    } catch (err) {
+      if (!isCapacityError(err)) {
+        throw err
+      }
+      // Snapshot order is oldest→newest; keep the newest half. At most
+      // log2(MAX_CACHE_ENTRIES) attempts, and only ever on the failure path.
+      retained = retained.slice(Math.ceil(retained.length / 2))
+    }
+  }
+  // Nothing fit, so a single entry — not aggregate pressure — is the problem.
+  // Trimming cannot help; keep the previous snapshot and say so.
+  console.debug('[ai-vault] session parse cache save skipped: no entry subset fits its size limits')
+  return null
+}
+
+function isCapacityError(err: unknown): boolean {
+  return err instanceof JsonStringifyByteLimitError || err instanceof JsonTextStructureCapacityError
+}
+
 async function persistSnapshot(current: SessionParseCachePersistenceOptions): Promise<void> {
   const directory = dirname(current.filePath)
   const tempPath = join(directory, `session-parse-cache-${process.pid}-${Date.now()}.tmp`)
   try {
-    const { serialized: payload } = stringifyJsonWithinByteLimit(
-      {
-        schemaVersion: SCHEMA_VERSION,
-        appVersion: current.appVersion,
-        entries: snapshotSessionParseCacheForPersistence()
-      },
-      SESSION_PARSE_CACHE_MAX_BYTES
+    const payload = serializeSessionParseCacheSnapshot(
+      snapshotSessionParseCacheForPersistence(),
+      current.appVersion
     )
-    assertJsonTextStructureWithinLimits(payload, SESSION_PARSE_CACHE_JSON_LIMITS)
+    if (payload === null) {
+      return
+    }
     await mkdir(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE })
     await writeFile(tempPath, payload, { mode: PRIVATE_FILE_MODE })
     // Atomic on POSIX; on Windows a rename racing an open handle fails and is

--- a/src/main/ai-vault/session-parse-cache-persistence.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.ts
@@ -3,9 +3,13 @@
 // of re-reading the whole transcript corpus (issue #9210: 6.7 GB / 109 s cold
 // scans). Disabled unless the composition root calls init; every failure mode
 // degrades to today's cold-scan behavior.
-import { mkdir, readdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
 import {
+  MAX_CACHE_ENTRIES,
   seedSessionParseCache,
   snapshotSessionParseCacheForPersistence,
   type PersistedSessionParseCacheEntry,
@@ -20,6 +24,11 @@ const SAVE_DEBOUNCE_MS = 1_500
 // (mode bits are inert on Windows — the userData ACL grant is the boundary there).
 const PRIVATE_DIRECTORY_MODE = 0o700
 const PRIVATE_FILE_MODE = 0o600
+export const SESSION_PARSE_CACHE_MAX_BYTES = 64 * 1024 * 1024
+export const SESSION_PARSE_CACHE_JSON_LIMITS = {
+  structuralTokens: 1_000_000,
+  nestingDepth: 32
+} as const
 
 type SessionParseCachePersistenceOptions = {
   filePath: string
@@ -98,7 +107,12 @@ export async function flushSessionParseCachePersistForTests(): Promise<void> {
 async function loadPersistedEntries(current: SessionParseCachePersistenceOptions): Promise<void> {
   await sweepOrphanedTempFiles(current.filePath)
   try {
-    const raw = await readFile(current.filePath, 'utf-8')
+    const { buffer } = await readNodeFileWithinLimit(
+      current.filePath,
+      SESSION_PARSE_CACHE_MAX_BYTES
+    )
+    const raw = buffer.toString('utf8')
+    assertJsonTextStructureWithinLimits(raw, SESSION_PARSE_CACHE_JSON_LIMITS)
     const entries = parsePersistedFile(JSON.parse(raw), current.appVersion)
     if (entries) {
       seedSessionParseCache(entries)
@@ -143,15 +157,19 @@ function parsePersistedFile(
     return null
   }
   const entries: [string, PersistedSessionParseCacheEntry][] = []
-  for (const item of file.entries) {
-    const entry = parsePersistedEntry(item)
+  const retainedPaths = new Set<string>()
+  for (let index = file.entries.length - 1; index >= 0; index -= 1) {
+    const entry = parsePersistedEntry(file.entries[index])
     if (entry === null) {
       // One malformed entry means the file can't be trusted; discard it whole.
       return null
     }
-    entries.push(entry)
+    if (entries.length < MAX_CACHE_ENTRIES && !retainedPaths.has(entry[0])) {
+      retainedPaths.add(entry[0])
+      entries.push(entry)
+    }
   }
-  return entries
+  return entries.toReversed()
 }
 
 function parsePersistedEntry(item: unknown): [string, PersistedSessionParseCacheEntry] | null {
@@ -190,11 +208,15 @@ async function persistSnapshot(current: SessionParseCachePersistenceOptions): Pr
   const directory = dirname(current.filePath)
   const tempPath = join(directory, `session-parse-cache-${process.pid}-${Date.now()}.tmp`)
   try {
-    const payload = JSON.stringify({
-      schemaVersion: SCHEMA_VERSION,
-      appVersion: current.appVersion,
-      entries: snapshotSessionParseCacheForPersistence()
-    })
+    const { serialized: payload } = stringifyJsonWithinByteLimit(
+      {
+        schemaVersion: SCHEMA_VERSION,
+        appVersion: current.appVersion,
+        entries: snapshotSessionParseCacheForPersistence()
+      },
+      SESSION_PARSE_CACHE_MAX_BYTES
+    )
+    assertJsonTextStructureWithinLimits(payload, SESSION_PARSE_CACHE_JSON_LIMITS)
     await mkdir(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE })
     await writeFile(tempPath, payload, { mode: PRIVATE_FILE_MODE })
     // Atomic on POSIX; on Windows a rename racing an open handle fails and is

--- a/src/main/ai-vault/session-parse-cache-persistence.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.ts
@@ -3,18 +3,16 @@
 // of re-reading the whole transcript corpus (issue #9210: 6.7 GB / 109 s cold
 // scans). Disabled unless the composition root calls init; every failure mode
 // degrades to today's cold-scan behavior.
-import { mkdir, readdir, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdir, open, readdir, rename, rm } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import {
-  assertJsonTextStructureWithinLimits,
-  JsonTextStructureCapacityError,
-  type JsonTextStructureLimits
-} from '../../shared/json-text-structure-limit'
+  assertSessionParseCacheJsonWithinLimitsCooperatively,
+  serializeSessionParseCacheSnapshotPiecesCooperatively,
+  SESSION_PARSE_CACHE_JSON_LIMITS,
+  SESSION_PARSE_CACHE_MAX_BYTES,
+  SESSION_PARSE_CACHE_SCHEMA_VERSION
+} from './session-parse-cache-snapshot-serialization'
 import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
-import {
-  JsonStringifyByteLimitError,
-  stringifyJsonWithinByteLimit
-} from '../../shared/node-bounded-json-stringify'
 import {
   MAX_CACHE_ENTRIES,
   seedSessionParseCache,
@@ -23,20 +21,18 @@ import {
   type SessionParseStats
 } from './session-scanner-parse-cache'
 
-// Bump when the persisted entry layout changes; a mismatched file is discarded whole.
-const SCHEMA_VERSION = 1
+export {
+  serializeSessionParseCacheSnapshot,
+  SESSION_PARSE_CACHE_JSON_LIMITS,
+  SESSION_PARSE_CACHE_MAX_BYTES
+} from './session-parse-cache-snapshot-serialization'
+
 // Debounce so back-to-back scans (desktop IPC + runtime RPC) collapse into one write.
 const SAVE_DEBOUNCE_MS = 1_500
 // The payload contains transcript-derived preview text; keep it user-only
 // (mode bits are inert on Windows — the userData ACL grant is the boundary there).
 const PRIVATE_DIRECTORY_MODE = 0o700
 const PRIVATE_FILE_MODE = 0o600
-export const SESSION_PARSE_CACHE_MAX_BYTES = 64 * 1024 * 1024
-export const SESSION_PARSE_CACHE_JSON_LIMITS = {
-  structuralTokens: 1_000_000,
-  nestingDepth: 32
-} as const
-
 type SessionParseCachePersistenceOptions = {
   filePath: string
   appVersion: string
@@ -119,7 +115,7 @@ async function loadPersistedEntries(current: SessionParseCachePersistenceOptions
       SESSION_PARSE_CACHE_MAX_BYTES
     )
     const raw = buffer.toString('utf8')
-    assertJsonTextStructureWithinLimits(raw, SESSION_PARSE_CACHE_JSON_LIMITS)
+    await assertSessionParseCacheJsonWithinLimitsCooperatively(raw, SESSION_PARSE_CACHE_JSON_LIMITS)
     const entries = parsePersistedFile(JSON.parse(raw), current.appVersion)
     if (entries) {
       seedSessionParseCache(entries)
@@ -161,7 +157,7 @@ function parsePersistedFile(
   const file = parsed as Record<string, unknown>
   // Why: parser output shape/semantics may change between app versions, so a
   // cross-version file is discarded — one cold scan per update is the price.
-  if (file.schemaVersion !== SCHEMA_VERSION || file.appVersion !== appVersion) {
+  if (file.schemaVersion !== SESSION_PARSE_CACHE_SCHEMA_VERSION || file.appVersion !== appVersion) {
     return null
   }
   if (!Array.isArray(file.entries)) {
@@ -215,69 +211,19 @@ function parsePersistedEntry(item: unknown): [string, PersistedSessionParseCache
   ]
 }
 
-// Why: hitting a capacity limit must degrade, not disable. Serializing the whole
-// snapshot and giving up would leave the old file in place and every later save
-// failing the same way, silently turning the #9210 cache back off for good. The
-// newest entries are the ones a restart actually reuses, so drop the oldest half
-// and retry until it fits.
-//
-// Both limits are checked against the same limits the load path applies: a
-// snapshot we cannot read back would delete itself on next launch and silently
-// disable the cache. The structure pass is not free (it scans the serialized
-// text), so `keeps a full snapshot loadable` pins the headroom a normal
-// full-size snapshot has, and this stays a guard rather than a routine trimmer.
-export function serializeSessionParseCacheSnapshot(
-  entries: [string, PersistedSessionParseCacheEntry][],
-  appVersion: string,
-  maxBytes: number = SESSION_PARSE_CACHE_MAX_BYTES,
-  jsonLimits: JsonTextStructureLimits = SESSION_PARSE_CACHE_JSON_LIMITS
-): string | null {
-  let retained = entries
-  while (retained.length > 0) {
-    try {
-      const { serialized } = stringifyJsonWithinByteLimit(
-        { schemaVersion: SCHEMA_VERSION, appVersion, entries: retained },
-        maxBytes
-      )
-      assertJsonTextStructureWithinLimits(serialized, jsonLimits)
-      if (retained.length !== entries.length) {
-        console.debug(
-          `[ai-vault] session parse cache trimmed to ${retained.length}/${entries.length} entries to fit its size limits`
-        )
-      }
-      return serialized
-    } catch (err) {
-      if (!isCapacityError(err)) {
-        throw err
-      }
-      // Snapshot order is oldest→newest; keep the newest half. At most
-      // log2(MAX_CACHE_ENTRIES) attempts, and only ever on the failure path.
-      retained = retained.slice(Math.ceil(retained.length / 2))
-    }
-  }
-  // Nothing fit, so a single entry — not aggregate pressure — is the problem.
-  // Trimming cannot help; keep the previous snapshot and say so.
-  console.debug('[ai-vault] session parse cache save skipped: no entry subset fits its size limits')
-  return null
-}
-
-function isCapacityError(err: unknown): boolean {
-  return err instanceof JsonStringifyByteLimitError || err instanceof JsonTextStructureCapacityError
-}
-
 async function persistSnapshot(current: SessionParseCachePersistenceOptions): Promise<void> {
   const directory = dirname(current.filePath)
   const tempPath = join(directory, `session-parse-cache-${process.pid}-${Date.now()}.tmp`)
   try {
-    const payload = serializeSessionParseCacheSnapshot(
+    const snapshot = await serializeSessionParseCacheSnapshotPiecesCooperatively(
       snapshotSessionParseCacheForPersistence(),
       current.appVersion
     )
-    if (payload === null) {
+    if (snapshot === null) {
       return
     }
     await mkdir(directory, { recursive: true, mode: PRIVATE_DIRECTORY_MODE })
-    await writeFile(tempPath, payload, { mode: PRIVATE_FILE_MODE })
+    await writeSessionParseCacheSnapshot(tempPath, snapshot.pieces)
     // Atomic on POSIX; on Windows a rename racing an open handle fails and is
     // caught below (save lost, never a torn file).
     await rename(tempPath, current.filePath)
@@ -286,5 +232,19 @@ async function persistSnapshot(current: SessionParseCachePersistenceOptions): Pr
     // it becomes an unhandled rejection. Worst case is the no-file case.
     await rm(tempPath, { force: true }).catch(() => {})
     console.debug('[ai-vault] session parse cache save failed', err)
+  }
+}
+
+async function writeSessionParseCacheSnapshot(
+  tempPath: string,
+  pieces: readonly string[]
+): Promise<void> {
+  const handle = await open(tempPath, 'w', PRIVATE_FILE_MODE)
+  try {
+    for (const piece of pieces) {
+      await handle.writeFile(piece)
+    }
+  } finally {
+    await handle.close()
   }
 }

--- a/src/main/ai-vault/session-parse-cache-persistence.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.ts
@@ -220,6 +220,12 @@ function parsePersistedEntry(item: unknown): [string, PersistedSessionParseCache
 // failing the same way, silently turning the #9210 cache back off for good. The
 // newest entries are the ones a restart actually reuses, so drop the oldest half
 // and retry until it fits.
+//
+// Both limits are checked against the same limits the load path applies: a
+// snapshot we cannot read back would delete itself on next launch and silently
+// disable the cache. The structure pass is not free (it scans the serialized
+// text), so `keeps a full snapshot loadable` pins the headroom a normal
+// full-size snapshot has, and this stays a guard rather than a routine trimmer.
 export function serializeSessionParseCacheSnapshot(
   entries: [string, PersistedSessionParseCacheEntry][],
   appVersion: string,

--- a/src/main/ai-vault/session-parse-cache-persistence.ts
+++ b/src/main/ai-vault/session-parse-cache-persistence.ts
@@ -9,7 +9,6 @@ import {
   assertSessionParseCacheJsonWithinLimitsCooperatively,
   serializeSessionParseCacheSnapshotPiecesCooperatively,
   SESSION_PARSE_CACHE_JSON_LIMITS,
-  SESSION_PARSE_CACHE_MAX_BYTES,
   SESSION_PARSE_CACHE_SCHEMA_VERSION
 } from './session-parse-cache-snapshot-serialization'
 import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
@@ -23,9 +22,11 @@ import {
 
 export {
   serializeSessionParseCacheSnapshot,
-  SESSION_PARSE_CACHE_JSON_LIMITS,
-  SESSION_PARSE_CACHE_MAX_BYTES
+  SESSION_PARSE_CACHE_JSON_LIMITS
 } from './session-parse-cache-snapshot-serialization'
+
+// JSON.parse is synchronous; 16 MiB retains a realistic full cache while bounding launch stalls.
+export const SESSION_PARSE_CACHE_MAX_BYTES = 16 * 1024 * 1024
 
 // Debounce so back-to-back scans (desktop IPC + runtime RPC) collapse into one write.
 const SAVE_DEBOUNCE_MS = 1_500
@@ -121,12 +122,31 @@ async function loadPersistedEntries(current: SessionParseCachePersistenceOptions
       seedSessionParseCache(entries)
       return
     }
-    // Unreadable content, not a missing file: drop it so it can't be re-read
-    // every launch while the next save replaces it.
-    await rm(current.filePath, { force: true }).catch(() => {})
-  } catch {
-    // Why: a missing/corrupt/foreign cache file must never fail the scan;
-    // worst case is exactly today's cold scan.
+    await discardUnreadableCache(current.filePath, 'invalid schema or content')
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return
+    }
+    // Why: an unreadable cache must degrade to a cold scan.
+    await discardUnreadableCache(current.filePath, error)
+  }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  )
+}
+
+async function discardUnreadableCache(filePath: string, cause: unknown): Promise<void> {
+  try {
+    await rm(filePath, { force: true })
+    console.debug('[ai-vault] discarded unreadable session parse cache', cause)
+  } catch (cleanupError) {
+    console.debug('[ai-vault] session parse cache load and cleanup failed', cause, cleanupError)
   }
 }
 
@@ -217,7 +237,8 @@ async function persistSnapshot(current: SessionParseCachePersistenceOptions): Pr
   try {
     const snapshot = await serializeSessionParseCacheSnapshotPiecesCooperatively(
       snapshotSessionParseCacheForPersistence(),
-      current.appVersion
+      current.appVersion,
+      SESSION_PARSE_CACHE_MAX_BYTES
     )
     if (snapshot === null) {
       return
@@ -244,6 +265,7 @@ async function writeSessionParseCacheSnapshot(
     for (const piece of pieces) {
       await handle.writeFile(piece)
     }
+    await handle.sync()
   } finally {
     await handle.close()
   }

--- a/src/main/ai-vault/session-parse-cache-snapshot-serialization.ts
+++ b/src/main/ai-vault/session-parse-cache-snapshot-serialization.ts
@@ -1,0 +1,248 @@
+import { setImmediate as yieldToEventLoop } from 'node:timers/promises'
+import {
+  JsonTextStructureCapacityError,
+  JsonTextStructureValidator,
+  type JsonTextStructureLimits
+} from '../../shared/json-text-structure-limit'
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../../shared/node-bounded-json-stringify'
+import type { PersistedSessionParseCacheEntry } from './session-scanner-parse-cache'
+
+export const SESSION_PARSE_CACHE_SCHEMA_VERSION = 1
+export const SESSION_PARSE_CACHE_MAX_BYTES = 64 * 1024 * 1024
+export const SESSION_PARSE_CACHE_JSON_LIMITS = {
+  structuralTokens: 1_000_000,
+  nestingDepth: 32
+} as const
+
+const SNAPSHOT_OUTER_STRUCTURAL_TOKENS = 9
+const SNAPSHOT_ENTRY_DEPTH_OFFSET = 2
+const SERIALIZE_YIELD_EVERY_ENTRIES = 16
+const VALIDATE_YIELD_EVERY_CHARACTERS = 256 * 1024
+
+type CacheEntry = [string, PersistedSessionParseCacheEntry]
+export type SerializedSessionParseCacheSnapshot = Readonly<{
+  pieces: readonly string[]
+  byteLength: number
+}>
+
+export function serializeSessionParseCacheSnapshot(
+  entries: CacheEntry[],
+  appVersion: string,
+  maxBytes: number = SESSION_PARSE_CACHE_MAX_BYTES,
+  jsonLimits: JsonTextStructureLimits = SESSION_PARSE_CACHE_JSON_LIMITS
+): string | null {
+  return retainMaximumFittingSuffix(
+    entries,
+    (retained) => serializeSnapshotAttempt(retained, appVersion, maxBytes, jsonLimits),
+    logRetainedEntries
+  )
+}
+
+export async function serializeSessionParseCacheSnapshotCooperatively(
+  entries: CacheEntry[],
+  appVersion: string,
+  maxBytes: number = SESSION_PARSE_CACHE_MAX_BYTES,
+  jsonLimits: JsonTextStructureLimits = SESSION_PARSE_CACHE_JSON_LIMITS
+): Promise<string | null> {
+  const snapshot = await serializeSessionParseCacheSnapshotPiecesCooperatively(
+    entries,
+    appVersion,
+    maxBytes,
+    jsonLimits
+  )
+  return snapshot ? snapshot.pieces.join('') : null
+}
+
+export function serializeSessionParseCacheSnapshotPiecesCooperatively(
+  entries: CacheEntry[],
+  appVersion: string,
+  maxBytes: number = SESSION_PARSE_CACHE_MAX_BYTES,
+  jsonLimits: JsonTextStructureLimits = SESSION_PARSE_CACHE_JSON_LIMITS
+): Promise<SerializedSessionParseCacheSnapshot | null> {
+  return retainMaximumFittingSuffixAsync(
+    entries,
+    (retained) => serializeSnapshotAttemptCooperatively(retained, appVersion, maxBytes, jsonLimits),
+    logRetainedEntries
+  )
+}
+
+export async function assertSessionParseCacheJsonWithinLimitsCooperatively(
+  content: string,
+  limits: JsonTextStructureLimits
+): Promise<void> {
+  const validator = new JsonTextStructureValidator(limits)
+  for (let start = 0; start < content.length; start += VALIDATE_YIELD_EVERY_CHARACTERS) {
+    const end = Math.min(content.length, start + VALIDATE_YIELD_EVERY_CHARACTERS)
+    validator.consume(content, start, end)
+    if (end < content.length) {
+      await yieldToEventLoop()
+    }
+  }
+}
+
+function serializeSnapshotAttempt(
+  entries: CacheEntry[],
+  appVersion: string,
+  maxBytes: number,
+  jsonLimits: JsonTextStructureLimits
+): string {
+  const { serialized } = stringifyJsonWithinByteLimit(
+    {
+      schemaVersion: SESSION_PARSE_CACHE_SCHEMA_VERSION,
+      appVersion,
+      entries
+    },
+    maxBytes
+  )
+  new JsonTextStructureValidator(jsonLimits).consume(serialized)
+  return serialized
+}
+
+async function serializeSnapshotAttemptCooperatively(
+  entries: CacheEntry[],
+  appVersion: string,
+  maxBytes: number,
+  jsonLimits: JsonTextStructureLimits
+): Promise<SerializedSessionParseCacheSnapshot> {
+  assertOuterStructureFits(entries.length, jsonLimits)
+  const prefix = `{"schemaVersion":${SESSION_PARSE_CACHE_SCHEMA_VERSION},"appVersion":${JSON.stringify(appVersion)},"entries":[`
+  const suffix = ']}'
+  const commaBytes = Math.max(0, entries.length - 1)
+  let byteLength = Buffer.byteLength(prefix) + Buffer.byteLength(suffix) + commaBytes
+  if (byteLength > maxBytes) {
+    throw new JsonStringifyByteLimitError(byteLength, maxBytes)
+  }
+  let structuralTokens = SNAPSHOT_OUTER_STRUCTURAL_TOKENS + commaBytes
+  const pieces = [prefix]
+
+  for (let index = 0; index < entries.length; index += 1) {
+    const { serialized, byteLength: entryBytes } = stringifyJsonWithinByteLimit(
+      entries[index],
+      maxBytes - byteLength
+    )
+    const remainingStructuralTokens = jsonLimits.structuralTokens - structuralTokens
+    const validator = new JsonTextStructureValidator({
+      structuralTokens: remainingStructuralTokens,
+      nestingDepth: jsonLimits.nestingDepth - SNAPSHOT_ENTRY_DEPTH_OFFSET
+    })
+    validator.consume(serialized)
+    structuralTokens += validator.usage().structuralTokens
+    byteLength += entryBytes
+    if (index > 0) {
+      pieces.push(',')
+    }
+    pieces.push(serialized)
+    if ((index + 1) % SERIALIZE_YIELD_EVERY_ENTRIES === 0 && index + 1 < entries.length) {
+      await yieldToEventLoop()
+    }
+  }
+  pieces.push(suffix)
+  return { pieces, byteLength }
+}
+
+function assertOuterStructureFits(entryCount: number, limits: JsonTextStructureLimits): void {
+  if (limits.nestingDepth < SNAPSHOT_ENTRY_DEPTH_OFFSET) {
+    throw new JsonTextStructureCapacityError('nestingDepth', limits.nestingDepth)
+  }
+  const structuralTokens = SNAPSHOT_OUTER_STRUCTURAL_TOKENS + Math.max(0, entryCount - 1)
+  if (structuralTokens > limits.structuralTokens) {
+    throw new JsonTextStructureCapacityError('structuralTokens', limits.structuralTokens)
+  }
+}
+
+function retainMaximumFittingSuffix(
+  entries: CacheEntry[],
+  serialize: (retained: CacheEntry[]) => string,
+  onRetained: (retained: number, total: number) => void
+): string | null {
+  if (entries.length === 0) {
+    return null
+  }
+  try {
+    return serialize(entries)
+  } catch (error) {
+    if (!isCapacityError(error)) {
+      throw error
+    }
+  }
+
+  let low = 1
+  let high = entries.length - 1
+  let best: { serialized: string; start: number } | null = null
+  while (low <= high) {
+    const start = Math.floor((low + high) / 2)
+    try {
+      best = { serialized: serialize(entries.slice(start)), start }
+      high = start - 1
+    } catch (error) {
+      if (!isCapacityError(error)) {
+        throw error
+      }
+      low = start + 1
+    }
+  }
+  if (!best) {
+    logNoFittingEntries()
+    return null
+  }
+  onRetained(entries.length - best.start, entries.length)
+  return best.serialized
+}
+
+async function retainMaximumFittingSuffixAsync<Value>(
+  entries: CacheEntry[],
+  serialize: (retained: CacheEntry[]) => Promise<Value>,
+  onRetained: (retained: number, total: number) => void
+): Promise<Value | null> {
+  if (entries.length === 0) {
+    return null
+  }
+  try {
+    return await serialize(entries)
+  } catch (error) {
+    if (!isCapacityError(error)) {
+      throw error
+    }
+  }
+
+  let low = 1
+  let high = entries.length - 1
+  let best: { serialized: Value; start: number } | null = null
+  while (low <= high) {
+    const start = Math.floor((low + high) / 2)
+    try {
+      best = { serialized: await serialize(entries.slice(start)), start }
+      high = start - 1
+    } catch (error) {
+      if (!isCapacityError(error)) {
+        throw error
+      }
+      low = start + 1
+    }
+  }
+  if (!best) {
+    logNoFittingEntries()
+    return null
+  }
+  onRetained(entries.length - best.start, entries.length)
+  return best.serialized
+}
+
+function isCapacityError(error: unknown): boolean {
+  return (
+    error instanceof JsonStringifyByteLimitError || error instanceof JsonTextStructureCapacityError
+  )
+}
+
+function logRetainedEntries(retained: number, total: number): void {
+  console.debug(
+    `[ai-vault] session parse cache trimmed to ${retained}/${total} entries to fit its size limits`
+  )
+}
+
+function logNoFittingEntries(): void {
+  console.debug('[ai-vault] session parse cache save skipped: no entry subset fits its size limits')
+}

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -19,6 +19,13 @@ import {
 import type { SessionFileCandidate } from './session-scanner-types'
 import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
+export class MissingOpenCodeSqliteScanContextError extends Error {
+  constructor(filePath: string) {
+    super(`OpenCode SQLite parsing requires a scan context (${filePath})`)
+    this.name = 'MissingOpenCodeSqliteScanContextError'
+  }
+}
+
 /**
  * Parse a single agent session file into an `AiVaultSession`. Routes to the
  * appropriate agent-specific parser based on `candidate.agent`. For OpenCode
@@ -52,8 +59,10 @@ export async function parseAgentSessionFile(
       // real filesystem paths and fall through to the JSON parser.
       const sqliteCandidate = splitOpenCodeSqliteCandidate(candidate.file.path)
       if (sqliteCandidate) {
+        // Every production caller reaches this through parseSessionCandidates,
+        // which requires a context; only narrow-agent unit tests may omit it.
         if (!opencodeSqliteScanContext) {
-          throw new Error('OpenCode SQLite parsing requires a scan context')
+          throw new MissingOpenCodeSqliteScanContextError(candidate.file.path)
         }
         return parseOpenCodeSqliteSessionViaWorker({
           context: opencodeSqliteScanContext,

--- a/src/main/ai-vault/session-scanner-agent-parser.ts
+++ b/src/main/ai-vault/session-scanner-agent-parser.ts
@@ -17,6 +17,7 @@ import {
   parseOpenCodeSessionFile
 } from './session-scanner-secondary-parsers'
 import type { SessionFileCandidate } from './session-scanner-types'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 /**
  * Parse a single agent session file into an `AiVaultSession`. Routes to the
@@ -29,7 +30,8 @@ import type { SessionFileCandidate } from './session-scanner-types'
  */
 export async function parseAgentSessionFile(
   candidate: SessionFileCandidate,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  opencodeSqliteScanContext?: OpenCodeSqliteScanContext
 ): Promise<AiVaultSession | null> {
   switch (candidate.agent) {
     case 'claude':
@@ -50,7 +52,11 @@ export async function parseAgentSessionFile(
       // real filesystem paths and fall through to the JSON parser.
       const sqliteCandidate = splitOpenCodeSqliteCandidate(candidate.file.path)
       if (sqliteCandidate) {
+        if (!opencodeSqliteScanContext) {
+          throw new Error('OpenCode SQLite parsing requires a scan context')
+        }
         return parseOpenCodeSqliteSessionViaWorker({
+          context: opencodeSqliteScanContext,
           dbPath: sqliteCandidate.dbPath,
           sessionId: sqliteCandidate.sessionId,
           platform

--- a/src/main/ai-vault/session-scanner-antigravity-history.ts
+++ b/src/main/ai-vault/session-scanner-antigravity-history.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import { normalizeTitleText, parseJsonObject, timestampMs } from './session-scanner-values'
 
@@ -32,6 +33,14 @@ export function createAntigravityWorkspaceResolver(
       const workspace = findAntigravityWorkspace(session, await index)
       return workspace ? { ...session, cwd: workspace } : session
     }
+  }
+}
+
+export async function readOptionalAntigravityHistoryFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return null
   }
 }
 

--- a/src/main/ai-vault/session-scanner-candidate-parsing.ts
+++ b/src/main/ai-vault/session-scanner-candidate-parsing.ts
@@ -1,0 +1,136 @@
+import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { sessionSortTime } from './session-scanner-accumulator'
+import { dedupeCodexSessionsBySessionId } from './codex-session-root-dedup'
+import type { AntigravityWorkspaceResolver } from './session-scanner-antigravity-history'
+import { withSessionExecutionHost } from './session-scanner-execution-host'
+import { OpenCodeSqliteCandidatePhase } from './session-scanner-opencode-sqlite-candidate-phase'
+import {
+  isOpenCodeSqliteScanTerminatedError,
+  type OpenCodeSqliteScanContext
+} from './session-scanner-opencode-sqlite-scan-context'
+import { parseAgentSessionFileCached, type SessionParseStats } from './session-scanner-parse-cache'
+import type { SessionFileCandidate, SessionParseResult } from './session-scanner-types'
+import { errorMessage } from './session-scanner-values'
+
+// Bounded fan-out: transcripts are parsed in batches so a large corpus cannot
+// open every file at once, and so the recency cap can stop the walk early.
+const SESSION_PARSE_CONCURRENCY = 8
+
+export async function parseSessionCandidates(args: {
+  candidates: SessionFileCandidate[]
+  limit: number
+  platform: NodeJS.Platform
+  executionHostId: ExecutionHostId
+  issues: AiVaultScanIssue[]
+  parseStats: SessionParseStats
+  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
+  opencodeSqliteScanContext: OpenCodeSqliteScanContext
+}): Promise<AiVaultSession[]> {
+  const sessions: AiVaultSession[] = []
+  let index = 0
+  const opencodePhase = new OpenCodeSqliteCandidatePhase({
+    candidates: args.candidates,
+    platform: args.platform,
+    context: args.opencodeSqliteScanContext
+  })
+
+  while (index < args.candidates.length) {
+    if (canStopParsingSessions(sessions, args.limit, args.candidates[index]?.file.mtimeMs)) {
+      break
+    }
+
+    const remaining = args.candidates.length - index
+    const needed = Math.max(args.limit - sessions.length, 1)
+    const batchSize = Math.min(SESSION_PARSE_CONCURRENCY, needed, remaining)
+    const batch = args.candidates.slice(index, index + batchSize)
+    const parseableBatch = opencodePhase.prepareBatch(batch)
+    const parsePromises = parseableBatch.map((candidate) =>
+      parseSessionCandidate(
+        candidate,
+        args.platform,
+        args.executionHostId,
+        args.parseStats,
+        args.antigravityWorkspaceResolver,
+        args.opencodeSqliteScanContext
+      )
+    )
+    opencodePhase.trackBatch(parseableBatch, parsePromises)
+    const results = await Promise.all(parsePromises)
+
+    for (const result of results) {
+      if (result.issue) {
+        args.issues.push(result.issue)
+      }
+      if (result.session) {
+        sessions.push(result.session)
+      }
+    }
+
+    // Why: cross-volume backfill copies have no shared inode, so collapse
+    // parsed aliases before they can crowd the unique-session parse budget.
+    const uniqueSessions = dedupeCodexSessionsBySessionId(sessions)
+    sessions.splice(0, sessions.length, ...uniqueSessions)
+
+    index += batchSize
+  }
+
+  opencodePhase.finish()
+  return sessions
+}
+
+async function parseSessionCandidate(
+  candidate: SessionFileCandidate,
+  platform: NodeJS.Platform,
+  executionHostId: ExecutionHostId,
+  parseStats: SessionParseStats,
+  antigravityWorkspaceResolver: AntigravityWorkspaceResolver | undefined,
+  opencodeSqliteScanContext: OpenCodeSqliteScanContext
+): Promise<SessionParseResult> {
+  try {
+    let session = await parseAgentSessionFileCached(
+      candidate,
+      platform,
+      parseStats,
+      opencodeSqliteScanContext
+    )
+    if (session && candidate.antigravityHistoryPath && antigravityWorkspaceResolver) {
+      session = await antigravityWorkspaceResolver.enrich(session, candidate.antigravityHistoryPath)
+    }
+    return {
+      session: session ? withSessionExecutionHost(session, executionHostId) : null,
+      issue: null
+    }
+  } catch (err) {
+    if (isOpenCodeSqliteScanTerminatedError(err)) {
+      return { session: null, issue: null }
+    }
+    return {
+      session: null,
+      issue: {
+        executionHostId,
+        agent: candidate.agent,
+        path: candidate.file.path,
+        message: errorMessage(err)
+      }
+    }
+  }
+}
+
+function canStopParsingSessions(
+  sessions: AiVaultSession[],
+  limit: number,
+  nextCandidateMtimeMs: number | undefined
+): boolean {
+  if (sessions.length < limit || typeof nextCandidateMtimeMs !== 'number') {
+    return false
+  }
+  const visibleCutoff = sessions
+    .map(sessionSortTime)
+    .sort((left, right) => right - left)
+    .at(limit - 1)
+
+  // Transcript mtime is already our discovery bound and fallback sort key; older
+  // files cannot displace the current visible set once the cutoff is newer.
+  return typeof visibleCutoff === 'number' && nextCandidateMtimeMs < visibleCutoff
+}

--- a/src/main/ai-vault/session-scanner-execution-host.ts
+++ b/src/main/ai-vault/session-scanner-execution-host.ts
@@ -1,0 +1,16 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
+
+export function withSessionExecutionHost(
+  session: AiVaultSession,
+  executionHostId: ExecutionHostId
+): AiVaultSession {
+  if (session.executionHostId === executionHostId) {
+    return session
+  }
+  return {
+    ...session,
+    executionHostId,
+    id: `${executionHostId}:${session.agent}:${session.sessionId}:${session.filePath}`
+  }
+}

--- a/src/main/ai-vault/session-scanner-opencode-sources.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sources.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { opencodeDiscoveries } from './session-scanner-opencode-sources'
+import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 const { discoverOpenCodeSessionsMock, listOpenCodeDatabasesMock } = vi.hoisted(() => ({
   discoverOpenCodeSessionsMock: vi.fn(),
@@ -31,13 +32,16 @@ describe('opencodeDiscoveries', () => {
       files: []
     })
     const issues = []
+    const context = new OpenCodeSqliteScanContext()
 
-    await Promise.all(opencodeDiscoveries({}, [], 25, issues))
+    await Promise.all(opencodeDiscoveries({ platform: 'linux' }, [], 25, issues, context))
 
     expect(discoverOpenCodeSessionsMock).toHaveBeenCalledWith({
+      context,
       storageDir: join('/xdg/data', 'opencode', 'storage'),
       dbPaths: [],
       limitPerAgent: 25,
+      platform: 'linux',
       issues
     })
   })

--- a/src/main/ai-vault/session-scanner-opencode-sources.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sources.ts
@@ -21,6 +21,7 @@ export function opencodeDiscoveries(
       storageDir,
       dbPaths: await opencodeDbPathsForSource(options, wslHomeDirs, storageDir, index),
       limitPerAgent: limit,
+      platform: options.platform ?? process.platform,
       issues
     })
   )

--- a/src/main/ai-vault/session-scanner-opencode-sources.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sources.ts
@@ -5,16 +5,19 @@ import { resolveOpenCodeStorageDirectory } from '../opencode/opencode-data-direc
 import { listOpenCodeDatabases } from '../opencode-usage/scanner'
 import { discoverOpenCodeSessions } from './session-scanner-opencode-sqlite-discovery'
 import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner-types'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 export function opencodeDiscoveries(
   options: AiVaultScanOptions,
   wslHomeDirs: readonly string[],
   limit: number,
-  issues: AiVaultScanIssue[]
+  issues: AiVaultScanIssue[],
+  context: OpenCodeSqliteScanContext
 ): Promise<SessionFileDiscovery>[] {
   const storageDirs = opencodeStorageDirs(options, wslHomeDirs)
   return storageDirs.map(async (storageDir, index) =>
     discoverOpenCodeSessions({
+      context,
       storageDir,
       dbPaths: await opencodeDbPathsForSource(options, wslHomeDirs, storageDir, index),
       limitPerAgent: limit,

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-cached-candidates.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-cached-candidates.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import {
+  resetSessionParseCacheForTests,
+  seedSessionParseCache,
+  type PersistedSessionParseCacheEntry
+} from './session-scanner-parse-cache'
+import { cachedOpenCodeSqliteCandidates } from './session-scanner-opencode-sqlite-cached-candidates'
+
+function cacheEntry(
+  path: string,
+  sessionId: string,
+  mtimeMs: number
+): PersistedSessionParseCacheEntry {
+  const session: AiVaultSession = {
+    id: `local:opencode:${sessionId}:${path}`,
+    executionHostId: 'local',
+    agent: 'opencode',
+    sessionId,
+    title: sessionId,
+    cwd: null,
+    branch: null,
+    model: null,
+    filePath: path,
+    codexHome: null,
+    createdAt: null,
+    updatedAt: null,
+    modifiedAt: new Date(mtimeMs).toISOString(),
+    messageCount: 1,
+    totalTokens: 0,
+    previewMessages: [],
+    queuedMessageCount: 0,
+    subagentTranscriptCount: 0,
+    resumeCommand: `opencode --session ${sessionId}`,
+    subagent: null
+  }
+  return { mtimeMs, sizeBytes: null, platform: 'darwin', session }
+}
+
+describe('cachedOpenCodeSqliteCandidates', () => {
+  beforeEach(() => resetSessionParseCacheForTests())
+
+  it('deduplicates DB aliases by session id before applying the limit', () => {
+    const canonicalDb = '/data/opencode.db'
+    const backupDb = '/data/opencode-backup.db'
+    seedSessionParseCache([
+      [`${backupDb}#same`, cacheEntry(`${backupDb}#same`, 'same', 10)],
+      [`${canonicalDb}#same`, cacheEntry(`${canonicalDb}#same`, 'same', 20)],
+      [`${canonicalDb}#unique`, cacheEntry(`${canonicalDb}#unique`, 'unique', 15)]
+    ])
+
+    expect(
+      cachedOpenCodeSqliteCandidates({
+        dbPaths: [canonicalDb, backupDb],
+        platform: 'darwin',
+        limit: 2
+      }).map((candidate) => candidate.file.path)
+    ).toEqual([`${canonicalDb}#same`, `${canonicalDb}#unique`])
+  })
+
+  it('uses DB path order to break equal-mtime alias ties', () => {
+    const canonicalDb = '/data/opencode.db'
+    const backupDb = '/data/opencode-backup.db'
+    seedSessionParseCache([
+      [`${backupDb}#same`, cacheEntry(`${backupDb}#same`, 'same', 20)],
+      [`${canonicalDb}#same`, cacheEntry(`${canonicalDb}#same`, 'same', 20)]
+    ])
+
+    expect(
+      cachedOpenCodeSqliteCandidates({
+        dbPaths: [canonicalDb, backupDb],
+        platform: 'darwin',
+        limit: 10
+      }).map((candidate) => candidate.file.path)
+    ).toEqual([`${canonicalDb}#same`])
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-cached-candidates.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-cached-candidates.ts
@@ -1,0 +1,49 @@
+import { sessionParseCacheEntries } from './session-scanner-parse-cache'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+/**
+ * Rebuild OpenCode SQLite candidates for `dbPaths` from entries already in the
+ * parse cache. Used when the SQLite listing leg is skipped (cooldown, spent
+ * budget): the listing is the only producer of `<dbPath>#<sessionId>`
+ * candidates, so without this a paused scanner blanks every SQLite-backed
+ * session even though this scan could still serve them for free. Replayed rows
+ * carry their cached mtime, so `hasFreshSessionParseCacheEntry` keeps them off
+ * the worker.
+ * @param args.dbPaths - Databases this source would have listed.
+ * @param args.platform - Only entries parsed on this platform are reusable.
+ * @param args.limit - Maximum candidates to return.
+ * @returns Candidates newest-first, capped at `limit`.
+ */
+export function cachedOpenCodeSqliteCandidates(args: {
+  dbPaths: readonly string[]
+  platform: NodeJS.Platform
+  limit: number
+}): SessionFileCandidate[] {
+  if (args.dbPaths.length === 0 || args.limit <= 0) {
+    return []
+  }
+  const prefixes = args.dbPaths.map((dbPath) => `${dbPath}#`)
+  const candidates: SessionFileCandidate[] = []
+  for (const [path, entry] of sessionParseCacheEntries()) {
+    if (
+      entry.platform !== args.platform ||
+      entry.session === null ||
+      !prefixes.some((prefix) => path.startsWith(prefix))
+    ) {
+      continue
+    }
+    candidates.push({
+      agent: 'opencode',
+      codexHome: null,
+      file: {
+        path,
+        mtimeMs: entry.mtimeMs,
+        modifiedAt: new Date(entry.mtimeMs).toISOString(),
+        ...(entry.sizeBytes === null ? {} : { sizeBytes: entry.sizeBytes })
+      }
+    })
+  }
+  return candidates
+    .sort((left, right) => right.file.mtimeMs - left.file.mtimeMs)
+    .slice(0, args.limit)
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-cached-candidates.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-cached-candidates.ts
@@ -1,4 +1,5 @@
 import { sessionParseCacheEntries } from './session-scanner-parse-cache'
+import { splitOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
 import type { SessionFileCandidate } from './session-scanner-types'
 
 /**
@@ -22,17 +23,23 @@ export function cachedOpenCodeSqliteCandidates(args: {
   if (args.dbPaths.length === 0 || args.limit <= 0) {
     return []
   }
-  const prefixes = args.dbPaths.map((dbPath) => `${dbPath}#`)
-  const candidates: SessionFileCandidate[] = []
+  const dbPathRanks = new Map(args.dbPaths.map((dbPath, index) => [dbPath, index]))
+  const candidatesBySessionId = new Map<
+    string,
+    { candidate: SessionFileCandidate; dbPathRank: number }
+  >()
   for (const [path, entry] of sessionParseCacheEntries()) {
+    const parsed = splitOpenCodeSqliteCandidate(path)
+    const dbPathRank = parsed ? dbPathRanks.get(parsed.dbPath) : undefined
     if (
       entry.platform !== args.platform ||
       entry.session === null ||
-      !prefixes.some((prefix) => path.startsWith(prefix))
+      !parsed ||
+      dbPathRank === undefined
     ) {
       continue
     }
-    candidates.push({
+    const candidate: SessionFileCandidate = {
       agent: 'opencode',
       codexHome: null,
       file: {
@@ -41,9 +48,19 @@ export function cachedOpenCodeSqliteCandidates(args: {
         modifiedAt: new Date(entry.mtimeMs).toISOString(),
         ...(entry.sizeBytes === null ? {} : { sizeBytes: entry.sizeBytes })
       }
-    })
+    }
+    const previous = candidatesBySessionId.get(parsed.sessionId)
+    if (
+      !previous ||
+      candidate.file.mtimeMs > previous.candidate.file.mtimeMs ||
+      (candidate.file.mtimeMs === previous.candidate.file.mtimeMs &&
+        dbPathRank < previous.dbPathRank)
+    ) {
+      candidatesBySessionId.set(parsed.sessionId, { candidate, dbPathRank })
+    }
   }
-  return candidates
+  return [...candidatesBySessionId.values()]
+    .map(({ candidate }) => candidate)
     .sort((left, right) => right.file.mtimeMs - left.file.mtimeMs)
     .slice(0, args.limit)
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.test.ts
@@ -55,7 +55,7 @@ describe('OpenCodeSqliteCandidatePhase', () => {
 
       // Cache reuse needs no worker, so only the uncached row is omitted.
       expect(phase.prepareBatch([cached, uncached])).toEqual([cached])
-      expect(context.metrics().workOmitted).toBe(true)
+      expect(context.metrics()).toMatchObject({ sqliteParseCacheHits: 1, workOmitted: true })
     } finally {
       context.dispose()
     }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.test.ts
@@ -40,15 +40,18 @@ describe('OpenCodeSqliteCandidatePhase', () => {
     }
   })
 
-  it('disarms after the last SQLite batch or an early parser stop', async () => {
+  it('disarms after the last SQLite promise without awaiting an unrelated parser', async () => {
     vi.useFakeTimers()
     const sqlite = candidate('/data/opencode.db#session')
+    const legacy = candidate('/legacy/session.json')
     const completedContext = new OpenCodeSqliteScanContext(1)
     const stoppedContext = new OpenCodeSqliteScanContext(1)
     try {
-      const completed = new OpenCodeSqliteCandidatePhase([sqlite], completedContext)
-      expect(completed.prepareBatch([sqlite])).toEqual([sqlite])
-      completed.completeBatch()
+      const completed = new OpenCodeSqliteCandidatePhase([sqlite, legacy], completedContext)
+      const batch = completed.prepareBatch([sqlite, legacy])
+      const neverSettles = new Promise<void>(() => {})
+      completed.trackBatch(batch, [Promise.resolve(), neverSettles])
+      await Promise.resolve()
 
       const stopped = new OpenCodeSqliteCandidatePhase([sqlite], stoppedContext)
       stopped.finish()

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OpenCodeSqliteCandidatePhase } from './session-scanner-opencode-sqlite-candidate-phase'
 import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import {
+  resetSessionParseCacheForTests,
+  seedSessionParseCache
+} from './session-scanner-parse-cache'
 import type { SessionFileCandidate } from './session-scanner-types'
 
 function candidate(path: string): SessionFileCandidate {
@@ -11,6 +15,17 @@ function candidate(path: string): SessionFileCandidate {
   }
 }
 
+function phaseFor(
+  candidates: readonly SessionFileCandidate[],
+  context: OpenCodeSqliteScanContext
+): OpenCodeSqliteCandidatePhase {
+  return new OpenCodeSqliteCandidatePhase({ candidates, platform: 'darwin', context })
+}
+
+afterEach(() => {
+  resetSessionParseCacheForTests()
+})
+
 describe('OpenCodeSqliteCandidatePhase', () => {
   it('filters terminated SQLite candidates before parsing but keeps legacy files', () => {
     const context = new OpenCodeSqliteScanContext()
@@ -18,7 +33,7 @@ describe('OpenCodeSqliteCandidatePhase', () => {
     const legacy = candidate('/data/storage/session/session.json')
     try {
       context.tripCircuit(new Error('test circuit'))
-      const phase = new OpenCodeSqliteCandidatePhase([sqlite, legacy], context)
+      const phase = phaseFor([sqlite, legacy], context)
 
       expect(phase.prepareBatch([sqlite, legacy])).toEqual([legacy])
       expect(context.metrics().workOmitted).toBe(true)
@@ -27,11 +42,86 @@ describe('OpenCodeSqliteCandidatePhase', () => {
     }
   })
 
+  it('keeps terminated SQLite candidates that the parse cache can still serve', () => {
+    const context = new OpenCodeSqliteScanContext()
+    const cached = candidate('/data/opencode.db#cached')
+    const uncached = candidate('/data/opencode.db#uncached')
+    seedSessionParseCache([
+      [cached.file.path, { mtimeMs: 1, sizeBytes: null, platform: 'darwin', session: null }]
+    ])
+    try {
+      context.tripCircuit(new Error('test circuit'))
+      const phase = phaseFor([cached, uncached], context)
+
+      // Cache reuse needs no worker, so only the uncached row is omitted.
+      expect(phase.prepareBatch([cached, uncached])).toEqual([cached])
+      expect(context.metrics().workOmitted).toBe(true)
+    } finally {
+      context.dispose()
+    }
+  })
+
+  it('spends the budget on SQLite batches only', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1_000)
+    const sqlite = candidate('/data/opencode.db#session')
+    const legacy = candidate('/data/storage/session/session.json')
+    try {
+      const phase = phaseFor([sqlite, legacy], context)
+
+      // A batch of other-agent work runs long; the SQLite budget must not tick.
+      phase.prepareBatch([legacy])
+      phase.trackBatch([legacy], [Promise.resolve()])
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(context.metrics().deadlineExpired).toBe(false)
+
+      phase.prepareBatch([sqlite])
+      phase.trackBatch([sqlite], [new Promise<void>(() => {})])
+      await vi.advanceTimersByTimeAsync(999)
+      expect(context.metrics().deadlineExpired).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(context.metrics().deadlineExpired).toBe(true)
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('banks the unspent budget between SQLite batches', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1_000)
+    const first = candidate('/data/opencode.db#first')
+    const second = candidate('/data/opencode.db#second')
+    try {
+      const phase = phaseFor([first, second], context)
+
+      let finishFirst: () => void = () => {}
+      phase.prepareBatch([first])
+      phase.trackBatch([first], [new Promise<void>((resolve) => (finishFirst = resolve))])
+      await vi.advanceTimersByTimeAsync(400)
+      finishFirst()
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(context.metrics().deadlineExpired).toBe(false)
+
+      // Only the 400ms actually spent on SQLite work is gone from the budget.
+      phase.prepareBatch([second])
+      phase.trackBatch([second], [new Promise<void>(() => {})])
+      await vi.advanceTimersByTimeAsync(599)
+      expect(context.metrics().deadlineExpired).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(context.metrics().deadlineExpired).toBe(true)
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
+    }
+  })
+
   it('disarms immediately when discovery has no SQLite candidates', async () => {
     vi.useFakeTimers()
     const context = new OpenCodeSqliteScanContext(1)
     try {
-      new OpenCodeSqliteCandidatePhase([candidate('/legacy/session.json')], context)
+      phaseFor([candidate('/legacy/session.json')], context)
+      context.armDeadline()
       await vi.advanceTimersByTimeAsync(10)
       expect(context.metrics().deadlineExpired).toBe(false)
     } finally {
@@ -47,14 +137,15 @@ describe('OpenCodeSqliteCandidatePhase', () => {
     const completedContext = new OpenCodeSqliteScanContext(1)
     const stoppedContext = new OpenCodeSqliteScanContext(1)
     try {
-      const completed = new OpenCodeSqliteCandidatePhase([sqlite, legacy], completedContext)
+      const completed = phaseFor([sqlite, legacy], completedContext)
       const batch = completed.prepareBatch([sqlite, legacy])
       const neverSettles = new Promise<void>(() => {})
       completed.trackBatch(batch, [Promise.resolve(), neverSettles])
       await Promise.resolve()
 
-      const stopped = new OpenCodeSqliteCandidatePhase([sqlite], stoppedContext)
+      const stopped = phaseFor([sqlite], stoppedContext)
       stopped.finish()
+      stoppedContext.armDeadline()
       await vi.advanceTimersByTimeAsync(10)
       expect(completedContext.metrics().deadlineExpired).toBe(false)
       expect(stoppedContext.metrics().deadlineExpired).toBe(false)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OpenCodeSqliteCandidatePhase } from './session-scanner-opencode-sqlite-candidate-phase'
+import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+function candidate(path: string): SessionFileCandidate {
+  return {
+    agent: 'opencode',
+    codexHome: null,
+    file: { path, mtimeMs: 1, modifiedAt: new Date(1).toISOString() }
+  }
+}
+
+describe('OpenCodeSqliteCandidatePhase', () => {
+  it('filters terminated SQLite candidates before parsing but keeps legacy files', () => {
+    const context = new OpenCodeSqliteScanContext()
+    const sqlite = candidate('/data/opencode.db#session')
+    const legacy = candidate('/data/storage/session/session.json')
+    try {
+      context.tripCircuit(new Error('test circuit'))
+      const phase = new OpenCodeSqliteCandidatePhase([sqlite, legacy], context)
+
+      expect(phase.prepareBatch([sqlite, legacy])).toEqual([legacy])
+      expect(context.metrics().workOmitted).toBe(true)
+    } finally {
+      context.dispose()
+    }
+  })
+
+  it('disarms immediately when discovery has no SQLite candidates', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1)
+    try {
+      new OpenCodeSqliteCandidatePhase([candidate('/legacy/session.json')], context)
+      await vi.advanceTimersByTimeAsync(10)
+      expect(context.metrics().deadlineExpired).toBe(false)
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('disarms after the last SQLite batch or an early parser stop', async () => {
+    vi.useFakeTimers()
+    const sqlite = candidate('/data/opencode.db#session')
+    const completedContext = new OpenCodeSqliteScanContext(1)
+    const stoppedContext = new OpenCodeSqliteScanContext(1)
+    try {
+      const completed = new OpenCodeSqliteCandidatePhase([sqlite], completedContext)
+      expect(completed.prepareBatch([sqlite])).toEqual([sqlite])
+      completed.completeBatch()
+
+      const stopped = new OpenCodeSqliteCandidatePhase([sqlite], stoppedContext)
+      stopped.finish()
+      await vi.advanceTimersByTimeAsync(10)
+      expect(completedContext.metrics().deadlineExpired).toBe(false)
+      expect(stoppedContext.metrics().deadlineExpired).toBe(false)
+    } finally {
+      completedContext.dispose()
+      stoppedContext.dispose()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.ts
@@ -32,10 +32,20 @@ export class OpenCodeSqliteCandidatePhase {
     })
   }
 
-  completeBatch(): void {
-    if (this.remainingCandidates === 0) {
-      this.context?.disarmDeadline()
+  trackBatch(
+    candidates: readonly SessionFileCandidate[],
+    promises: readonly Promise<unknown>[]
+  ): void {
+    if (this.remainingCandidates !== 0 || !this.context) {
+      return
     }
+    const sqlitePromises = promises.filter((_, index) =>
+      looksLikeOpenCodeSqliteCandidate(candidates[index]?.file.path ?? '')
+    )
+    if (sqlitePromises.length === 0) {
+      return
+    }
+    void Promise.allSettled(sqlitePromises).then(() => this.context?.disarmDeadline())
   }
 
   finish(): void {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.ts
@@ -1,54 +1,85 @@
 import { looksLikeOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
 import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import { hasFreshSessionParseCacheEntry } from './session-scanner-parse-cache'
 import type { SessionFileCandidate } from './session-scanner-types'
 
 export class OpenCodeSqliteCandidatePhase {
   private remainingCandidates: number
+  private workerBoundBatch = new Set<SessionFileCandidate>()
+  private readonly platform: NodeJS.Platform
+  private readonly context: OpenCodeSqliteScanContext
 
-  constructor(
-    candidates: readonly SessionFileCandidate[],
-    private readonly context?: OpenCodeSqliteScanContext
-  ) {
-    this.remainingCandidates = context
-      ? candidates.filter((candidate) => looksLikeOpenCodeSqliteCandidate(candidate.file.path))
-          .length
-      : 0
+  constructor(args: {
+    candidates: readonly SessionFileCandidate[]
+    platform: NodeJS.Platform
+    context: OpenCodeSqliteScanContext
+  }) {
+    this.platform = args.platform
+    this.context = args.context
+    this.remainingCandidates = args.candidates.filter((candidate) =>
+      looksLikeOpenCodeSqliteCandidate(candidate.file.path)
+    ).length
     if (this.remainingCandidates === 0) {
-      context?.disarmDeadline()
+      args.context.disarmDeadline()
     }
   }
 
   prepareBatch(batch: readonly SessionFileCandidate[]): SessionFileCandidate[] {
-    return batch.filter((candidate) => {
+    this.workerBoundBatch = new Set()
+    const prepared = batch.filter((candidate) => {
       if (!looksLikeOpenCodeSqliteCandidate(candidate.file.path)) {
         return true
       }
       this.remainingCandidates -= 1
-      if (!this.context?.isTerminated) {
+      // Cache reuse is path+mtime based and never reaches the worker, so a spent
+      // budget must not drop rows this scan can still serve for free — and a
+      // cache-served row must not spend the budget either, since the budget
+      // measures outstanding SQLite work.
+      const servedFromCache = hasFreshSessionParseCacheEntry(candidate, this.platform)
+      if (servedFromCache) {
         return true
       }
-      this.context.markWorkOmitted()
-      return false
+      if (this.context.isTerminated) {
+        this.context.markWorkOmitted()
+        return false
+      }
+      this.workerBoundBatch.add(candidate)
+      return true
     })
+    if (this.workerBoundBatch.size > 0) {
+      this.context.armDeadline()
+    }
+    return prepared
   }
 
   trackBatch(
     candidates: readonly SessionFileCandidate[],
     promises: readonly Promise<unknown>[]
   ): void {
-    if (this.remainingCandidates !== 0 || !this.context) {
+    // Pairs 1:1 with the arm in prepareBatch: only a batch that armed the clock
+    // may pause it, or the reference count drifts.
+    if (this.workerBoundBatch.size === 0) {
       return
     }
-    const sqlitePromises = promises.filter((_, index) =>
-      looksLikeOpenCodeSqliteCandidate(candidates[index]?.file.path ?? '')
-    )
+    const workerBound = this.workerBoundBatch
+    this.workerBoundBatch = new Set()
+    const sqlitePromises = promises.filter((_, index) => {
+      const candidate = candidates[index]
+      return candidate !== undefined && workerBound.has(candidate)
+    })
     if (sqlitePromises.length === 0) {
+      this.context.pauseDeadline()
       return
     }
-    void Promise.allSettled(sqlitePromises).then(() => this.context?.disarmDeadline())
+    // Stop the budget clock as soon as this batch's SQLite work settles, even if
+    // a co-scheduled parser for another agent is still running.
+    const lastBatch = this.remainingCandidates === 0
+    void Promise.allSettled(sqlitePromises).then(() =>
+      lastBatch ? this.context.disarmDeadline() : this.context.pauseDeadline()
+    )
   }
 
   finish(): void {
-    this.context?.disarmDeadline()
+    this.context.disarmDeadline()
   }
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.ts
@@ -1,0 +1,44 @@
+import { looksLikeOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import type { SessionFileCandidate } from './session-scanner-types'
+
+export class OpenCodeSqliteCandidatePhase {
+  private remainingCandidates: number
+
+  constructor(
+    candidates: readonly SessionFileCandidate[],
+    private readonly context?: OpenCodeSqliteScanContext
+  ) {
+    this.remainingCandidates = context
+      ? candidates.filter((candidate) => looksLikeOpenCodeSqliteCandidate(candidate.file.path))
+          .length
+      : 0
+    if (this.remainingCandidates === 0) {
+      context?.disarmDeadline()
+    }
+  }
+
+  prepareBatch(batch: readonly SessionFileCandidate[]): SessionFileCandidate[] {
+    return batch.filter((candidate) => {
+      if (!looksLikeOpenCodeSqliteCandidate(candidate.file.path)) {
+        return true
+      }
+      this.remainingCandidates -= 1
+      if (!this.context?.isTerminated) {
+        return true
+      }
+      this.context.markWorkOmitted()
+      return false
+    })
+  }
+
+  completeBatch(): void {
+    if (this.remainingCandidates === 0) {
+      this.context?.disarmDeadline()
+    }
+  }
+
+  finish(): void {
+    this.context?.disarmDeadline()
+  }
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-candidate-phase.ts
@@ -37,6 +37,7 @@ export class OpenCodeSqliteCandidatePhase {
       // measures outstanding SQLite work.
       const servedFromCache = hasFreshSessionParseCacheEntry(candidate, this.platform)
       if (servedFromCache) {
+        this.context.noteSqliteParseCacheHit()
         return true
       }
       if (this.context.isTerminated) {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -233,7 +233,7 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
       expect(persistenceMock.lastStats?.fullParses).toBe(8)
       expect(result.sessions).toEqual([])
       expect(
-        result.issues.filter((issue) => /OpenCode history was skipped/.test(issue.message))
+        result.issues.filter((issue) => issue.message.includes('OpenCode history was skipped'))
       ).toHaveLength(1)
     } finally {
       vi.useRealTimers()

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -11,7 +11,10 @@ import {
 import Database from '../sqlite/sync-database'
 import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
 import type { SessionFileCandidate } from './session-scanner-types'
-import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import {
+  OPENCODE_SQLITE_SCAN_DEADLINE_MS,
+  type OpenCodeSqliteScanContext
+} from './session-scanner-opencode-sqlite-scan-context'
 import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
 import type { SessionParseStats } from './session-scanner-parse-cache'
 import type * as GrokParserModule from './session-scanner-grok-parser'
@@ -465,7 +468,7 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
         limit: 500
       })
       await vi.waitFor(() => expect(workerMock.parseCalls).toBe(8))
-      await vi.advanceTimersByTimeAsync(45_000)
+      await vi.advanceTimersByTimeAsync(OPENCODE_SQLITE_SCAN_DEADLINE_MS + 1)
       const result = await scan
 
       expect(workerMock.listCalls).toBe(2)
@@ -522,7 +525,7 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
         expect(workerMock.parseCalls).toBe(1)
         expect(grokMock.calls).toBe(1)
       })
-      await vi.advanceTimersByTimeAsync(45_000)
+      await vi.advanceTimersByTimeAsync(OPENCODE_SQLITE_SCAN_DEADLINE_MS + 1)
       expect(context).not.toBeNull()
       expect(context!.metrics().deadlineExpired).toBe(false)
 
@@ -555,7 +558,7 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
 
       const scan = scanAiVaultSessions({ ...roots, limit: 10 })
       await vi.waitFor(() => expect(grokMock.calls).toBe(1))
-      await vi.advanceTimersByTimeAsync(45_000)
+      await vi.advanceTimersByTimeAsync(OPENCODE_SQLITE_SCAN_DEADLINE_MS + 1)
       expect(context).not.toBeNull()
       expect(context!.metrics().deadlineExpired).toBe(false)
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -13,9 +13,10 @@ import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-typ
 import type { SessionFileCandidate } from './session-scanner-types'
 import {
   OPENCODE_SQLITE_SCAN_DEADLINE_MS,
-  type OpenCodeSqliteScanContext
+  OpenCodeSqliteScanContext
 } from './session-scanner-opencode-sqlite-scan-context'
 import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
+import { discoverOpenCodeSessions } from './session-scanner-opencode-sqlite-discovery'
 import type { SessionParseStats } from './session-scanner-parse-cache'
 import type * as GrokParserModule from './session-scanner-grok-parser'
 import type * as ParseCachePersistenceModule from './session-parse-cache-persistence'
@@ -227,6 +228,55 @@ function sqliteSession(dbPath: string, sessionId: string, mtimeMs: number): AiVa
 }
 
 describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', () => {
+  it('retains a completed live list when a sibling source terminates the shared context', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-list-race-'))
+    tempRoots.push(root)
+    const firstStorage = join(root, 'first-storage')
+    const secondStorage = join(root, 'second-storage')
+    await Promise.all([
+      mkdir(join(firstStorage, 'session'), { recursive: true }),
+      mkdir(join(secondStorage, 'session'), { recursive: true })
+    ])
+    const firstDbPath = join(root, 'first.db')
+    const secondDbPath = join(root, 'second.db')
+    const live = sqliteCandidate(firstDbPath, 'live-first', 2_000)
+    const context = new OpenCodeSqliteScanContext()
+    workerMock.listOverride = async (args) => {
+      if (args.dbPaths[0] === secondDbPath) {
+        args.context.tripCircuit(new Error('sibling worker fault'))
+        return []
+      }
+      return [live]
+    }
+
+    try {
+      const [first, second] = await Promise.all([
+        discoverOpenCodeSessions({
+          context,
+          storageDir: firstStorage,
+          dbPaths: [firstDbPath],
+          limitPerAgent: 50,
+          platform: 'darwin',
+          issues: []
+        }),
+        discoverOpenCodeSessions({
+          context,
+          storageDir: secondStorage,
+          dbPaths: [secondDbPath],
+          limitPerAgent: 50,
+          platform: 'darwin',
+          issues: []
+        })
+      ])
+
+      expect(first.files).toContainEqual(live.file)
+      expect(second.files).toEqual([])
+      expect(context.metrics().terminationReason).toBe('workerCrashLoop')
+    } finally {
+      context.dispose()
+    }
+  })
+
   it('keeps the SQLite budget for SQLite work when other agents parse for longer', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -5,6 +5,31 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { scanAiVaultSessions } from './session-scanner'
 import Database from '../sqlite/sync-database'
+import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
+import type { SessionFileCandidate } from './session-scanner-types'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
+
+type WorkerListArgs = {
+  context: OpenCodeSqliteScanContext
+  dbPaths: readonly string[]
+  limit: number
+  issues: AiVaultScanIssue[]
+}
+
+type WorkerParseArgs = {
+  context: OpenCodeSqliteScanContext
+  dbPath: string
+  sessionId: string
+  platform: NodeJS.Platform
+}
+
+const workerMock = vi.hoisted(() => ({
+  listCalls: 0,
+  parseCalls: 0,
+  listOverride: null as null | ((args: WorkerListArgs) => Promise<SessionFileCandidate[]>),
+  parseOverride: null as null | ((args: WorkerParseArgs) => Promise<AiVaultSession | null>)
+}))
 
 // Why: this source-level integration suite has no built worker entry. Keep its
 // SQLite fixtures inline explicitly; production fails closed if the bundle is absent.
@@ -14,8 +39,14 @@ vi.mock('./session-scanner-opencode-sqlite-worker-spawn', async () => {
     import('./session-scanner-opencode-sqlite')
   ])
   return {
-    listOpenCodeSqliteSessionsViaWorker: listOpenCodeSqliteSessions,
-    parseOpenCodeSqliteSessionViaWorker: parseOpenCodeSqliteSession
+    listOpenCodeSqliteSessionsViaWorker: (args: WorkerListArgs) => {
+      workerMock.listCalls += 1
+      return workerMock.listOverride?.(args) ?? listOpenCodeSqliteSessions(args)
+    },
+    parseOpenCodeSqliteSessionViaWorker: (args: WorkerParseArgs) => {
+      workerMock.parseCalls += 1
+      return workerMock.parseOverride?.(args) ?? parseOpenCodeSqliteSession(args)
+    }
   }
 })
 
@@ -23,6 +54,10 @@ let tempRoots: string[] = []
 let tempDbDirs: string[] = []
 
 afterEach(async () => {
+  workerMock.listCalls = 0
+  workerMock.parseCalls = 0
+  workerMock.listOverride = null
+  workerMock.parseOverride = null
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   for (const dir of tempDbDirs) {
     rmSync(dir, { recursive: true, force: true })
@@ -104,6 +139,69 @@ function applyOpenCodeSchema(db: Database.Database): void {
 }
 
 describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', () => {
+  it('stops native and WSL SQLite parsing at one scan deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-deadline-'))
+      tempRoots.push(root)
+      const roots = isolatedScanRoots(root)
+      const nativeDataDir = join(root, 'native-opencode')
+      const wslHome = join(root, 'wsl-home')
+      await mkdir(join(nativeDataDir, 'storage'), { recursive: true })
+      await mkdir(join(wslHome, '.local', 'share', 'opencode'), { recursive: true })
+      await writeFile(join(nativeDataDir, 'opencode.db'), '')
+      await writeFile(join(wslHome, '.local', 'share', 'opencode', 'opencode.db'), '')
+
+      workerMock.listOverride = async (args) =>
+        args.dbPaths.flatMap((dbPath, sourceIndex) =>
+          Array.from({ length: 120 }, (_, candidateIndex) => ({
+            agent: 'opencode' as const,
+            codexHome: null,
+            file: {
+              path: buildOpenCodeSqliteCandidatePath(
+                dbPath,
+                `session-${sourceIndex}-${candidateIndex}`
+              ),
+              mtimeMs: 10_000 - candidateIndex,
+              modifiedAt: new Date(10_000 - candidateIndex).toISOString()
+            }
+          }))
+        )
+      workerMock.parseOverride = (args) =>
+        new Promise((_, reject) => {
+          const rejectTerminated = (): void => {
+            args.context.markWorkOmitted()
+            reject(args.context.terminationError())
+          }
+          if (args.context.isTerminated) {
+            rejectTerminated()
+          } else {
+            args.context.signal.addEventListener('abort', rejectTerminated, { once: true })
+          }
+        })
+
+      const scan = scanAiVaultSessions({
+        ...roots,
+        opencodeStorageDir: join(nativeDataDir, 'storage'),
+        opencodeDbPaths: undefined,
+        wslHomeDirs: [wslHome],
+        limit: 500
+      })
+      await vi.waitFor(() => expect(workerMock.parseCalls).toBe(8))
+      await vi.advanceTimersByTimeAsync(45_000)
+      const result = await scan
+
+      expect(workerMock.listCalls).toBe(2)
+      expect(workerMock.parseCalls).toBe(8)
+      expect(result.sessions).toEqual([])
+      expect(
+        result.issues.filter((issue) => /OpenCode history was skipped/.test(issue.message))
+      ).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('discovers SQLite sessions next to a custom OpenCode storage directory', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-custom-opencode-'))
     tempRoots.push(root)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { scanAiVaultSessions } from './session-scanner'
-import { resetOpenCodeSqliteScanCooldownForTests } from './session-scanner-opencode-sqlite-scan-cooldown'
+import {
+  noteOpenCodeSqliteScanHardFailure,
+  resetOpenCodeSqliteScanCooldownForTests
+} from './session-scanner-opencode-sqlite-scan-cooldown'
 import Database from '../sqlite/sync-database'
 import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
 import type { SessionFileCandidate } from './session-scanner-types'
@@ -298,6 +301,44 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
       'cached-b'
     ])
     expect(rescan.issues).toEqual([])
+  })
+
+  // Why: the SQLite listing is the only producer of synthetic candidates, so a
+  // paused scanner used to blank every SQLite-backed session for the whole
+  // backoff — including ones this scan already had parsed and could serve free.
+  it('still lists cached SQLite sessions while the backoff pauses the scanner', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-cooldown-cache-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const dbPath = join(root, 'opencode.db')
+    const scanArgs = {
+      ...roots,
+      opencodeDbPaths: [dbPath],
+      platform: 'darwin' as const,
+      limit: 50
+    }
+
+    workerMock.listOverride = async () => [
+      sqliteCandidate(dbPath, 'warm-a', 2_000),
+      sqliteCandidate(dbPath, 'warm-b', 1_000)
+    ]
+    workerMock.parseOverride = async (args) => sqliteSession(dbPath, args.sessionId, 2_000)
+    const warm = await scanAiVaultSessions(scanArgs)
+    expect(warm.sessions.map((session) => session.sessionId).sort()).toEqual(['warm-a', 'warm-b'])
+
+    // The backoff now holds, so the scan terminates before discovery.
+    noteOpenCodeSqliteScanHardFailure()
+    workerMock.listCalls = 0
+    workerMock.parseCalls = 0
+    const paused = await scanAiVaultSessions(scanArgs)
+
+    expect(workerMock.listCalls).toBe(0)
+    expect(workerMock.parseCalls).toBe(0)
+    expect(paused.sessions.map((session) => session.sessionId).sort()).toEqual(['warm-a', 'warm-b'])
+    // The listing was not reconciled against the DB, and the user is told so.
+    expect(paused.issues.map((issue) => issue.message)).toEqual([
+      'OpenCode history was not scanned this time; its background scanner is paused after repeated failures and will be retried automatically. Its SQLite database was never checked, so some sessions may also be missing or out of date.'
+    ])
   })
 
   it('flags legacy OpenCode files as unreconciled when the SQLite listing is cancelled', async () => {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -2,8 +2,9 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { scanAiVaultSessions } from './session-scanner'
+import { resetOpenCodeSqliteScanCooldownForTests } from './session-scanner-opencode-sqlite-scan-cooldown'
 import Database from '../sqlite/sync-database'
 import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
 import type { SessionFileCandidate } from './session-scanner-types'
@@ -87,7 +88,14 @@ vi.mock('./session-parse-cache-persistence', async (importOriginal) => {
 let tempRoots: string[] = []
 let tempDbDirs: string[] = []
 
+beforeEach(() => {
+  // The SQLite backoff is process-wide by design; a crash-loop case must not
+  // leave the next scan paused.
+  resetOpenCodeSqliteScanCooldownForTests()
+})
+
 afterEach(async () => {
+  resetOpenCodeSqliteScanCooldownForTests()
   workerMock.listCalls = 0
   workerMock.parseCalls = 0
   workerMock.listOverride = null
@@ -175,7 +183,196 @@ function applyOpenCodeSchema(db: Database.Database): void {
   `)
 }
 
+function sqliteCandidate(dbPath: string, sessionId: string, mtimeMs: number): SessionFileCandidate {
+  return {
+    agent: 'opencode',
+    codexHome: null,
+    file: {
+      path: buildOpenCodeSqliteCandidatePath(dbPath, sessionId),
+      mtimeMs,
+      modifiedAt: new Date(mtimeMs).toISOString()
+    }
+  }
+}
+
+function sqliteSession(dbPath: string, sessionId: string, mtimeMs: number): AiVaultSession {
+  return {
+    id: `opencode:${sessionId}`,
+    executionHostId: 'local',
+    agent: 'opencode',
+    sessionId,
+    title: sessionId,
+    cwd: '/tmp/opencode',
+    branch: null,
+    model: null,
+    filePath: dbPath,
+    codexHome: null,
+    createdAt: new Date(mtimeMs).toISOString(),
+    updatedAt: new Date(mtimeMs).toISOString(),
+    modifiedAt: new Date(mtimeMs).toISOString(),
+    messageCount: 1,
+    totalTokens: 0,
+    previewMessages: [],
+    queuedMessageCount: 0,
+    subagentTranscriptCount: 0,
+    resumeCommand: `opencode --session '${sessionId}'`,
+    subagent: null
+  }
+}
+
 describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', () => {
+  it('keeps the SQLite budget for SQLite work when other agents parse for longer', async () => {
+    vi.useFakeTimers()
+    try {
+      const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-slow-others-'))
+      tempRoots.push(root)
+      const roots = isolatedScanRoots(root)
+      // A full batch of newer non-SQLite candidates sorts ahead of the DB rows.
+      for (let index = 0; index < 8; index += 1) {
+        await mkdir(join(roots.grokSessionsDir, `session-${index}`), { recursive: true })
+        await writeFile(join(roots.grokSessionsDir, `session-${index}`, 'summary.json'), '{}')
+      }
+
+      const dbPath = join(root, 'opencode.db')
+      const pendingGrok: (() => void)[] = []
+      grokMock.override = () =>
+        new Promise((resolve) => {
+          pendingGrok.push(() => resolve(null))
+        })
+      workerMock.listOverride = async () => [sqliteCandidate(dbPath, 'budget-session', 1_000)]
+      workerMock.parseOverride = async () => sqliteSession(dbPath, 'budget-session', 1_000)
+
+      const scan = scanAiVaultSessions({ ...roots, opencodeDbPaths: [dbPath], limit: 50 })
+      await vi.waitFor(() => expect(grokMock.calls).toBe(8))
+      // Far past the 45s budget, but none of it was OpenCode's to spend.
+      await vi.advanceTimersByTimeAsync(120_000)
+      for (const finish of pendingGrok) {
+        finish()
+      }
+      const result = await scan
+
+      expect(workerMock.parseCalls).toBe(1)
+      expect(result.sessions.map((session) => session.sessionId)).toEqual(['budget-session'])
+      expect(result.issues).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('serves warm parse-cache rows for SQLite candidates after termination', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-terminated-cache-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    const dbPath = join(root, 'opencode.db')
+    const candidates = [
+      sqliteCandidate(dbPath, 'cached-a', 2_000),
+      sqliteCandidate(dbPath, 'cached-b', 1_000)
+    ]
+
+    workerMock.listOverride = async () => candidates
+    workerMock.parseOverride = async (args) => sqliteSession(dbPath, args.sessionId, 2_000)
+    const warm = await scanAiVaultSessions({
+      ...roots,
+      opencodeDbPaths: [dbPath],
+      platform: 'darwin',
+      limit: 50
+    })
+    expect(warm.sessions).toHaveLength(2)
+
+    // Second scan: the budget is gone before any candidate is prepared.
+    workerMock.parseCalls = 0
+    workerMock.listOverride = async (args) => {
+      args.context.tripCircuit(new Error('worker died'))
+      return candidates
+    }
+    const rescan = await scanAiVaultSessions({
+      ...roots,
+      opencodeDbPaths: [dbPath],
+      platform: 'darwin',
+      limit: 50
+    })
+
+    expect(workerMock.parseCalls).toBe(0)
+    expect(rescan.sessions.map((session) => session.sessionId).sort()).toEqual([
+      'cached-a',
+      'cached-b'
+    ])
+    expect(rescan.issues).toEqual([])
+  })
+
+  it('flags legacy OpenCode files as unreconciled when the SQLite listing is cancelled', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-list-cancelled-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    await mkdir(join(roots.opencodeStorageDir, 'session', 'project'), { recursive: true })
+    await writeFile(
+      join(roots.opencodeStorageDir, 'session', 'project', 'legacy-only.json'),
+      JSON.stringify({
+        id: 'legacy-only',
+        directory: '/tmp/legacy',
+        title: 'Legacy file session',
+        time: { created: 1_777_634_000_000, updated: 1_777_634_001_000 }
+      })
+    )
+
+    workerMock.listOverride = async (args) => {
+      args.context.tripCircuit(new Error('worker died'))
+      return []
+    }
+    const result = await scanAiVaultSessions({
+      ...roots,
+      opencodeDbPaths: [join(root, 'opencode.db')],
+      platform: 'darwin',
+      limit: 50
+    })
+
+    expect(result.sessions.map((session) => session.sessionId)).toContain('legacy-only')
+    expect(result.issues.map((issue) => issue.message)).toEqual([
+      'OpenCode history could not be checked against its SQLite database, so some sessions may be missing or out of date.'
+    ])
+  })
+
+  // Why: this scan re-runs every cache TTL. A crash loop that can't be retried
+  // into success must not re-burn a core on the same doomed work each time.
+  it('skips SQLite work entirely while the process-wide backoff holds', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-cooldown-'))
+    tempRoots.push(root)
+    const roots = isolatedScanRoots(root)
+    await mkdir(join(roots.opencodeStorageDir, 'session', 'project'), { recursive: true })
+    await writeFile(
+      join(roots.opencodeStorageDir, 'session', 'project', 'legacy-only.json'),
+      JSON.stringify({
+        id: 'legacy-only',
+        directory: '/tmp/legacy',
+        title: 'Legacy file session',
+        time: { created: 1_777_634_000_000, updated: 1_777_634_001_000 }
+      })
+    )
+    const scanArgs = {
+      ...roots,
+      opencodeDbPaths: [join(root, 'opencode.db')],
+      platform: 'darwin' as const,
+      limit: 50
+    }
+
+    // First scan dies to a crash loop, arming the backoff.
+    workerMock.listOverride = async (args) => {
+      args.context.tripCircuit(new Error('worker died'))
+      return []
+    }
+    await scanAiVaultSessions(scanArgs)
+    expect(workerMock.listCalls).toBe(1)
+
+    // Second scan must not reach the worker at all, and must say why.
+    const second = await scanAiVaultSessions(scanArgs)
+    expect(workerMock.listCalls).toBe(1)
+    // Legacy file history still lists; only the SQLite half is paused.
+    expect(second.sessions.map((session) => session.sessionId)).toContain('legacy-only')
+    expect(
+      second.issues.some((issue) => /paused after repeated failures/.test(issue.message))
+    ).toBe(true)
+  })
+
   it('stops native and WSL SQLite parsing at one scan deadline', async () => {
     vi.useFakeTimers()
     try {
@@ -230,7 +427,10 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
 
       expect(workerMock.listCalls).toBe(2)
       expect(workerMock.parseCalls).toBe(8)
-      expect(persistenceMock.lastStats?.fullParses).toBe(8)
+      // All 8 were cancelled, so none read a byte: parse stats count completed
+      // work, never work the deadline threw away.
+      expect(persistenceMock.lastStats?.fullParses).toBe(0)
+      expect(persistenceMock.lastStats?.bytesRead).toBe(0)
       expect(result.sessions).toEqual([])
       expect(
         result.issues.filter((issue) => issue.message.includes('OpenCode history was skipped'))

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -286,7 +286,7 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
     workerMock.parseCalls = 0
     workerMock.listOverride = async (args) => {
       args.context.tripCircuit(new Error('worker died'))
-      return candidates
+      return []
     }
     const rescan = await scanAiVaultSessions({
       ...roots,
@@ -300,7 +300,9 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
       'cached-a',
       'cached-b'
     ])
-    expect(rescan.issues).toEqual([])
+    expect(rescan.issues.map((issue) => issue.message)).toEqual([
+      'OpenCode history could not be checked against its SQLite database, so some sessions may be missing or out of date.'
+    ])
   })
 
   // Why: the SQLite listing is the only producer of synthetic candidates, so a

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-coexistence.test.ts
@@ -9,6 +9,9 @@ import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-typ
 import type { SessionFileCandidate } from './session-scanner-types'
 import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 import { buildOpenCodeSqliteCandidatePath } from './session-scanner-opencode-sqlite-paths'
+import type { SessionParseStats } from './session-scanner-parse-cache'
+import type * as GrokParserModule from './session-scanner-grok-parser'
+import type * as ParseCachePersistenceModule from './session-parse-cache-persistence'
 
 type WorkerListArgs = {
   context: OpenCodeSqliteScanContext
@@ -31,6 +34,15 @@ const workerMock = vi.hoisted(() => ({
   parseOverride: null as null | ((args: WorkerParseArgs) => Promise<AiVaultSession | null>)
 }))
 
+const grokMock = vi.hoisted(() => ({
+  calls: 0,
+  override: null as null | (() => Promise<AiVaultSession | null>)
+}))
+
+const persistenceMock = vi.hoisted(() => ({
+  lastStats: null as SessionParseStats | null
+}))
+
 // Why: this source-level integration suite has no built worker entry. Keep its
 // SQLite fixtures inline explicitly; production fails closed if the bundle is absent.
 vi.mock('./session-scanner-opencode-sqlite-worker-spawn', async () => {
@@ -50,6 +62,28 @@ vi.mock('./session-scanner-opencode-sqlite-worker-spawn', async () => {
   }
 })
 
+vi.mock('./session-scanner-grok-parser', async (importOriginal) => {
+  const actual = await importOriginal<typeof GrokParserModule>()
+  return {
+    ...actual,
+    parseGrokSessionFile: (...args: Parameters<typeof actual.parseGrokSessionFile>) => {
+      grokMock.calls += 1
+      return grokMock.override?.() ?? actual.parseGrokSessionFile(...args)
+    }
+  }
+})
+
+vi.mock('./session-parse-cache-persistence', async (importOriginal) => {
+  const actual = await importOriginal<typeof ParseCachePersistenceModule>()
+  return {
+    ...actual,
+    scheduleSessionParseCachePersist(stats: SessionParseStats) {
+      persistenceMock.lastStats = { ...stats }
+      actual.scheduleSessionParseCachePersist(stats)
+    }
+  }
+})
+
 let tempRoots: string[] = []
 let tempDbDirs: string[] = []
 
@@ -58,6 +92,9 @@ afterEach(async () => {
   workerMock.parseCalls = 0
   workerMock.listOverride = null
   workerMock.parseOverride = null
+  grokMock.calls = 0
+  grokMock.override = null
+  persistenceMock.lastStats = null
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   for (const dir of tempDbDirs) {
     rmSync(dir, { recursive: true, force: true })
@@ -193,10 +230,94 @@ describe('scanAiVaultSessions — OpenCode SQLite + legacy file coexistence', ()
 
       expect(workerMock.listCalls).toBe(2)
       expect(workerMock.parseCalls).toBe(8)
+      expect(persistenceMock.lastStats?.fullParses).toBe(8)
       expect(result.sessions).toEqual([])
       expect(
         result.issues.filter((issue) => /OpenCode history was skipped/.test(issue.message))
       ).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('disarms after the last SQLite promise while a mixed-batch parser remains active', async () => {
+    vi.useFakeTimers()
+    try {
+      const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-mixed-disarm-'))
+      tempRoots.push(root)
+      const roots = isolatedScanRoots(root)
+      await mkdir(roots.grokSessionsDir, { recursive: true })
+      await writeFile(join(roots.grokSessionsDir, 'summary.json'), '{}')
+
+      let context: OpenCodeSqliteScanContext | null = null
+      let finishGrok: (() => void) | null = null
+      workerMock.listOverride = async (args) => {
+        context = args.context
+        return [
+          {
+            agent: 'opencode',
+            codexHome: null,
+            file: {
+              path: buildOpenCodeSqliteCandidatePath('/data/opencode.db', 'mixed-session'),
+              mtimeMs: Date.now(),
+              modifiedAt: new Date().toISOString()
+            }
+          }
+        ]
+      }
+      workerMock.parseOverride = async (args) => {
+        context = args.context
+        return null
+      }
+      grokMock.override = () =>
+        new Promise((resolve) => {
+          finishGrok = () => resolve(null)
+        })
+
+      const scan = scanAiVaultSessions({ ...roots, limit: 10 })
+      await vi.waitFor(() => {
+        expect(workerMock.parseCalls).toBe(1)
+        expect(grokMock.calls).toBe(1)
+      })
+      await vi.advanceTimersByTimeAsync(45_000)
+      expect(context).not.toBeNull()
+      expect(context!.metrics().deadlineExpired).toBe(false)
+
+      finishGrok!()
+      await expect(scan).resolves.toBeDefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('disarms a no-database scan before unrelated parsing completes', async () => {
+    vi.useFakeTimers()
+    try {
+      const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-no-db-disarm-'))
+      tempRoots.push(root)
+      const roots = isolatedScanRoots(root)
+      await mkdir(roots.grokSessionsDir, { recursive: true })
+      await writeFile(join(roots.grokSessionsDir, 'summary.json'), '{}')
+
+      let context: OpenCodeSqliteScanContext | null = null
+      let finishGrok: (() => void) | null = null
+      workerMock.listOverride = async (args) => {
+        context = args.context
+        return []
+      }
+      grokMock.override = () =>
+        new Promise((resolve) => {
+          finishGrok = () => resolve(null)
+        })
+
+      const scan = scanAiVaultSessions({ ...roots, limit: 10 })
+      await vi.waitFor(() => expect(grokMock.calls).toBe(1))
+      await vi.advanceTimersByTimeAsync(45_000)
+      expect(context).not.toBeNull()
+      expect(context!.metrics().deadlineExpired).toBe(false)
+
+      finishGrok!()
+      await expect(scan).resolves.toBeDefined()
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
@@ -4,6 +4,7 @@ import { discoverFiles } from './session-scanner-discovery'
 import { splitOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
 import { listOpenCodeSqliteSessionsViaWorker } from './session-scanner-opencode-sqlite-worker-spawn'
 import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 // Why: keep the SQLite discovery + dedup layer separate from the parser so
 // each file stays under the max-lines lint rule and the discovery layer can
@@ -36,6 +37,7 @@ function sessionIdFromLegacyFilePath(filePath: string): string {
  * @returns A `SessionFileDiscovery` with deduplicated file entries.
  */
 export async function discoverOpenCodeSessions(args: {
+  context: OpenCodeSqliteScanContext
   storageDir: string
   dbPaths: readonly string[]
   limitPerAgent: number
@@ -52,6 +54,7 @@ export async function discoverOpenCodeSessions(args: {
     // Why (#8864): the SQLite list leg runs on a worker thread; only this leg
     // moves off the main thread, the filesystem scan stays inline.
     listOpenCodeSqliteSessionsViaWorker({
+      context: args.context,
       dbPaths: args.dbPaths,
       limit: args.limitPerAgent,
       issues: args.issues

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
@@ -3,7 +3,11 @@ import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import { discoverFiles } from './session-scanner-discovery'
 import { splitOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
 import { listOpenCodeSqliteSessionsViaWorker } from './session-scanner-opencode-sqlite-worker-spawn'
-import type { FileWithMtime, SessionFileDiscovery } from './session-scanner-types'
+import type {
+  FileWithMtime,
+  SessionFileCandidate,
+  SessionFileDiscovery
+} from './session-scanner-types'
 import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 // Why: keep the SQLite discovery + dedup layer separate from the parser so
@@ -15,6 +19,33 @@ import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlit
 // Re-exported: the pure list reader moved to its own electron-free module so the
 // worker entry can import it without the worker client's Electron dependency.
 export { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
+
+// Why: the scan budget covers SQLite work only, so it runs while this leg is in
+// flight and is banked again the moment it settles.
+async function listWithinScanBudget(args: {
+  context: OpenCodeSqliteScanContext
+  dbPaths: readonly string[]
+  limitPerAgent: number
+  issues: AiVaultScanIssue[]
+}): Promise<SessionFileCandidate[]> {
+  // An already-terminated scan (cooldown, or a sibling source that crashed the
+  // shared context) has no budget to spend; don't round-trip the worker to be
+  // told so.
+  if (args.context.isTerminated) {
+    return []
+  }
+  args.context.armDeadline()
+  try {
+    return await listOpenCodeSqliteSessionsViaWorker({
+      context: args.context,
+      dbPaths: args.dbPaths,
+      limit: args.limitPerAgent,
+      issues: args.issues
+    })
+  } finally {
+    args.context.pauseDeadline()
+  }
+}
 
 // Why: extract the sessionId from a legacy file path like
 // storage/session/<projectId>/<sessionId>.json. Falls back to the filename
@@ -53,12 +84,7 @@ export async function discoverOpenCodeSessions(args: {
     }),
     // Why (#8864): the SQLite list leg runs on a worker thread; only this leg
     // moves off the main thread, the filesystem scan stays inline.
-    listOpenCodeSqliteSessionsViaWorker({
-      context: args.context,
-      dbPaths: args.dbPaths,
-      limit: args.limitPerAgent,
-      issues: args.issues
-    })
+    listWithinScanBudget(args)
   ])
 
   const sqliteFiles = sqliteCandidates.map((c) => c.file)
@@ -68,6 +94,14 @@ export async function discoverOpenCodeSessions(args: {
   // the same sessionId already exists. Deduping at the file level also avoids
   // parsing the same session twice.
   if (sqliteFiles.length === 0) {
+    // An empty list from a terminated scan is not "no SQLite sessions": the
+    // legacy files below were never reconciled against the DB, so say so rather
+    // than presenting possibly-stale JSON rows as the whole truth. A source with
+    // no DB at all had nothing to reconcile, so it stays quiet even when another
+    // source terminated the shared context.
+    if (args.dbPaths.length > 0 && args.context.isTerminated) {
+      args.context.markSqliteListCancelled()
+    }
     return {
       agent: 'opencode' as const,
       rootDir: fileDiscovery.rootDir,

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
@@ -54,15 +54,20 @@ async function listWithinScanBudget(args: {
       limit: args.limitPerAgent,
       issues: args.issues
     })
-    if (!args.context.isTerminated) {
+    // A sibling source can terminate the shared context after this list already
+    // answered; completed live work remains authoritative.
+    if (candidates.length > 0) {
       return candidates
     }
-    args.context.markSqliteListCancelled()
-    return cachedOpenCodeSqliteCandidates({
-      dbPaths: args.dbPaths,
-      platform: args.platform,
-      limit: args.limitPerAgent
-    })
+    if (args.context.isTerminated || args.context.metrics().sqliteListCancelled) {
+      args.context.markSqliteListCancelled()
+      return cachedOpenCodeSqliteCandidates({
+        dbPaths: args.dbPaths,
+        platform: args.platform,
+        limit: args.limitPerAgent
+      })
+    }
+    return []
   } finally {
     args.context.pauseDeadline()
   }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
@@ -3,6 +3,7 @@ import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import { discoverFiles } from './session-scanner-discovery'
 import { splitOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
 import { listOpenCodeSqliteSessionsViaWorker } from './session-scanner-opencode-sqlite-worker-spawn'
+import { cachedOpenCodeSqliteCandidates } from './session-scanner-opencode-sqlite-cached-candidates'
 import type {
   FileWithMtime,
   SessionFileCandidate,
@@ -26,13 +27,24 @@ async function listWithinScanBudget(args: {
   context: OpenCodeSqliteScanContext
   dbPaths: readonly string[]
   limitPerAgent: number
+  platform: NodeJS.Platform
   issues: AiVaultScanIssue[]
 }): Promise<SessionFileCandidate[]> {
   // An already-terminated scan (cooldown, or a sibling source that crashed the
   // shared context) has no budget to spend; don't round-trip the worker to be
-  // told so.
+  // told so. Replay what the parse cache already knows instead of dropping every
+  // SQLite-backed session for the duration of the backoff — the listing is still
+  // unreconciled, which is what markSqliteListCancelled tells the user.
   if (args.context.isTerminated) {
-    return []
+    if (args.dbPaths.length === 0) {
+      return []
+    }
+    args.context.markSqliteListCancelled()
+    return cachedOpenCodeSqliteCandidates({
+      dbPaths: args.dbPaths,
+      platform: args.platform,
+      limit: args.limitPerAgent
+    })
   }
   args.context.armDeadline()
   try {
@@ -64,6 +76,7 @@ function sessionIdFromLegacyFilePath(filePath: string): string {
  * @param args.storageDir - Root of the OpenCode storage directory (contains `session/` and `message/`).
  * @param args.dbPaths - Absolute paths to opencode.db files to scan.
  * @param args.limitPerAgent - Maximum number of candidates per source.
+ * @param args.platform - Platform the parse cache entries were produced on.
  * @param args.issues - Collected scan issues to append errors to.
  * @returns A `SessionFileDiscovery` with deduplicated file entries.
  */
@@ -72,8 +85,12 @@ export async function discoverOpenCodeSessions(args: {
   storageDir: string
   dbPaths: readonly string[]
   limitPerAgent: number
+  platform: NodeJS.Platform
   issues: AiVaultScanIssue[]
 }): Promise<SessionFileDiscovery> {
+  if (args.dbPaths.length > 0) {
+    args.context.markSqliteSourcePresent()
+  }
   const [fileDiscovery, sqliteCandidates] = await Promise.all([
     discoverFiles({
       rootDir: join(args.storageDir, 'session'),

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-discovery.ts
@@ -48,11 +48,20 @@ async function listWithinScanBudget(args: {
   }
   args.context.armDeadline()
   try {
-    return await listOpenCodeSqliteSessionsViaWorker({
+    const candidates = await listOpenCodeSqliteSessionsViaWorker({
       context: args.context,
       dbPaths: args.dbPaths,
       limit: args.limitPerAgent,
       issues: args.issues
+    })
+    if (!args.context.isTerminated) {
+      return candidates
+    }
+    args.context.markSqliteListCancelled()
+    return cachedOpenCodeSqliteCandidates({
+      dbPaths: args.dbPaths,
+      platform: args.platform,
+      limit: args.limitPerAgent
     })
   } finally {
     args.context.pauseDeadline()

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
@@ -1,5 +1,12 @@
+import { noteOpenCodeSqliteScanHardFailure } from './session-scanner-opencode-sqlite-scan-cooldown'
+
 export const OPENCODE_SQLITE_SCAN_DEADLINE_MS = 45_000
 export const MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS = 3
+// Why: a worker that answers slowly is not a worker that died. A large DB can
+// exceed the per-call timeout without anything being wrong, so timeouts get
+// their own budget and their own termination reason rather than being reported
+// to the user as a crash.
+export const MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS = 3
 
 export class OpenCodeSqliteScanTerminatedError extends Error {
   constructor(message: string) {
@@ -14,34 +21,46 @@ export function isOpenCodeSqliteScanTerminatedError(
   return error instanceof OpenCodeSqliteScanTerminatedError
 }
 
+export type OpenCodeSqliteScanTerminationReason =
+  | 'cooldown'
+  | 'deadline'
+  | 'workerCrashLoop'
+  | 'workerTimeoutLoop'
+  | 'scanEnded'
+
 export type OpenCodeSqliteScanMetrics = {
   activeWorkerMs: number
   deadlineExpired: boolean
   queueWaitMs: number
+  sqliteListCancelled: boolean
+  terminationReason: OpenCodeSqliteScanTerminationReason | null
   workOmitted: boolean
 }
 
 export class OpenCodeSqliteScanContext {
   readonly signal: AbortSignal
-  readonly startedAtMs = Date.now()
   private readonly controller = new AbortController()
-  private deadlineTimer: NodeJS.Timeout | null
+  private deadlineTimer: NodeJS.Timeout | null = null
+  // Budget left to spend; only decremented while the deadline is armed.
+  private remainingDeadlineMs: number
+  private armedAtMs: number | null = null
+  private armCount = 0
+  private deadlineRetired = false
   private consecutiveWorkerDeaths = 0
+  private consecutiveWorkerTimeouts = 0
   private activeWorkerMs = 0
   private queueWaitMs = 0
   private deadlineExpired = false
+  private listCancelled = false
   private omitted = false
+  private terminationReason: OpenCodeSqliteScanTerminationReason | null = null
 
   constructor(deadlineMs = OPENCODE_SQLITE_SCAN_DEADLINE_MS) {
     if (!Number.isSafeInteger(deadlineMs) || deadlineMs < 0) {
       throw new RangeError('OpenCode SQLite scan deadline must be a non-negative integer')
     }
+    this.remainingDeadlineMs = deadlineMs
     this.signal = this.controller.signal
-    this.deadlineTimer = setTimeout(() => {
-      this.deadlineExpired = true
-      this.abort('OpenCode SQLite scan deadline elapsed')
-    }, deadlineMs)
-    this.deadlineTimer.unref?.()
   }
 
   get isTerminated(): boolean {
@@ -52,6 +71,11 @@ export class OpenCodeSqliteScanContext {
     this.omitted = true
   }
 
+  // A cancelled list leaves legacy OpenCode files unreconciled against SQLite.
+  markSqliteListCancelled(): void {
+    this.listCancelled = true
+  }
+
   terminationError(): OpenCodeSqliteScanTerminatedError {
     return isOpenCodeSqliteScanTerminatedError(this.signal.reason)
       ? this.signal.reason
@@ -60,6 +84,7 @@ export class OpenCodeSqliteScanContext {
 
   noteWorkerResponse(): void {
     this.consecutiveWorkerDeaths = 0
+    this.consecutiveWorkerTimeouts = 0
   }
 
   noteWorkerDeath(): boolean {
@@ -67,9 +92,32 @@ export class OpenCodeSqliteScanContext {
     return this.consecutiveWorkerDeaths >= MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS
   }
 
+  noteWorkerTimeout(): boolean {
+    this.consecutiveWorkerTimeouts += 1
+    return this.consecutiveWorkerTimeouts >= MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS
+  }
+
   tripCircuit(error: Error): void {
+    noteOpenCodeSqliteScanHardFailure()
     this.abort(
-      `OpenCode SQLite worker crashed repeatedly; remaining work was skipped (${error.message})`
+      `OpenCode SQLite worker crashed repeatedly; remaining work was skipped (${error.message})`,
+      'workerCrashLoop'
+    )
+  }
+
+  tripTimeoutCircuit(error: Error): void {
+    noteOpenCodeSqliteScanHardFailure()
+    this.abort(
+      `OpenCode SQLite worker kept timing out; remaining work was skipped (${error.message})`,
+      'workerTimeoutLoop'
+    )
+  }
+
+  /** Skip this scan's SQLite work entirely while the process-wide backoff holds. */
+  enterCooldown(remainingMs: number): void {
+    this.abort(
+      `OpenCode SQLite scanning is paused for another ${Math.ceil(remainingMs / 1000)}s after repeated failures`,
+      'cooldown'
     )
   }
 
@@ -86,24 +134,71 @@ export class OpenCodeSqliteScanContext {
       activeWorkerMs: this.activeWorkerMs,
       deadlineExpired: this.deadlineExpired,
       queueWaitMs: this.queueWaitMs,
+      sqliteListCancelled: this.listCancelled,
+      terminationReason: this.terminationReason,
       workOmitted: this.omitted
     }
   }
 
+  /**
+   * Start (or re-start) the budget clock for one leg of SQLite work. Arming is
+   * reference counted so overlapping list/parse legs share one clock, and the
+   * budget only elapses while SQLite work is actually outstanding — a slow cache
+   * load or another agent's transcripts must never spend OpenCode's budget.
+   */
+  armDeadline(): void {
+    this.armCount += 1
+    if (this.armCount > 1 || this.deadlineRetired || this.signal.aborted || this.deadlineTimer) {
+      return
+    }
+    this.armedAtMs = Date.now()
+    this.deadlineTimer = setTimeout(() => {
+      this.deadlineExpired = true
+      this.abort('OpenCode SQLite scan deadline elapsed', 'deadline')
+    }, this.remainingDeadlineMs)
+    this.deadlineTimer.unref?.()
+  }
+
+  /** Stop the clock once the last outstanding SQLite leg settles, banking what is left. */
+  pauseDeadline(): void {
+    if (this.armCount === 0) {
+      return
+    }
+    this.armCount -= 1
+    if (this.armCount === 0) {
+      this.stopDeadlineTimer()
+    }
+  }
+
+  /** Retire the budget for the rest of the scan; no later leg can re-arm it. */
   disarmDeadline(): void {
+    this.armCount = 0
+    this.deadlineRetired = true
+    this.stopDeadlineTimer()
+  }
+
+  dispose(): void {
+    this.abort('OpenCode SQLite scan ended', 'scanEnded')
+  }
+
+  private stopDeadlineTimer(): void {
     if (this.deadlineTimer) {
       clearTimeout(this.deadlineTimer)
       this.deadlineTimer = null
     }
+    if (this.armedAtMs !== null) {
+      this.remainingDeadlineMs = Math.max(
+        0,
+        this.remainingDeadlineMs - (Date.now() - this.armedAtMs)
+      )
+      this.armedAtMs = null
+    }
   }
 
-  dispose(): void {
-    this.abort('OpenCode SQLite scan ended')
-  }
-
-  private abort(message: string): void {
+  private abort(message: string, reason: OpenCodeSqliteScanTerminationReason): void {
     this.disarmDeadline()
     if (!this.signal.aborted) {
+      this.terminationReason = reason
       this.controller.abort(new OpenCodeSqliteScanTerminatedError(message))
     }
   }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
@@ -6,7 +6,16 @@ export const MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS = 3
 // exceed the per-call timeout without anything being wrong, so timeouts get
 // their own budget and their own termination reason rather than being reported
 // to the user as a crash.
-export const MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS = 3
+//
+// Two, not three: a timed-out call also costs TERMINATE_GRACE_MS before the next
+// one can dispatch, so three parse timeouts (3 × 15s + 2 × 5s) outlast the scan
+// deadline and this circuit could never trip. Keep
+// MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS × (PARSE_TIMEOUT_MS + TERMINATE_GRACE_MS)
+// under OPENCODE_SQLITE_SCAN_DEADLINE_MS or the timeout reason becomes dead code.
+export const MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS = 2
+// A worker that cannot be spawned fails instantly, so retrying it for every one
+// of a thousand candidates is pure waste; give up on the scan after a few.
+export const MAX_CONSECUTIVE_OPENCODE_WORKER_UNAVAILABLE = 3
 
 export class OpenCodeSqliteScanTerminatedError extends Error {
   constructor(message: string) {
@@ -26,14 +35,21 @@ export type OpenCodeSqliteScanTerminationReason =
   | 'deadline'
   | 'workerCrashLoop'
   | 'workerTimeoutLoop'
+  | 'workerUnavailable'
   | 'scanEnded'
 
 export type OpenCodeSqliteScanMetrics = {
   activeWorkerMs: number
   deadlineExpired: boolean
   queueWaitMs: number
+  // True once any SQLite source was found to have a database at all; gates
+  // user-facing OpenCode messages on OpenCode actually being installed.
+  sqliteSourcePresent: boolean
   sqliteListCancelled: boolean
   terminationReason: OpenCodeSqliteScanTerminationReason | null
+  // Whether any worker call answered this scan. A scan that answered nothing
+  // made no cacheable progress, whichever limiter ended it.
+  workerAnswered: boolean
   workOmitted: boolean
 }
 
@@ -48,10 +64,13 @@ export class OpenCodeSqliteScanContext {
   private deadlineRetired = false
   private consecutiveWorkerDeaths = 0
   private consecutiveWorkerTimeouts = 0
+  private consecutiveWorkerUnavailable = 0
   private activeWorkerMs = 0
   private queueWaitMs = 0
   private deadlineExpired = false
   private listCancelled = false
+  private sourcePresent = false
+  private answered = false
   private omitted = false
   private terminationReason: OpenCodeSqliteScanTerminationReason | null = null
 
@@ -76,6 +95,10 @@ export class OpenCodeSqliteScanContext {
     this.listCancelled = true
   }
 
+  markSqliteSourcePresent(): void {
+    this.sourcePresent = true
+  }
+
   terminationError(): OpenCodeSqliteScanTerminatedError {
     return isOpenCodeSqliteScanTerminatedError(this.signal.reason)
       ? this.signal.reason
@@ -83,8 +106,10 @@ export class OpenCodeSqliteScanContext {
   }
 
   noteWorkerResponse(): void {
+    this.answered = true
     this.consecutiveWorkerDeaths = 0
     this.consecutiveWorkerTimeouts = 0
+    this.consecutiveWorkerUnavailable = 0
   }
 
   noteWorkerDeath(): boolean {
@@ -95,6 +120,11 @@ export class OpenCodeSqliteScanContext {
   noteWorkerTimeout(): boolean {
     this.consecutiveWorkerTimeouts += 1
     return this.consecutiveWorkerTimeouts >= MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS
+  }
+
+  noteWorkerUnavailable(): boolean {
+    this.consecutiveWorkerUnavailable += 1
+    return this.consecutiveWorkerUnavailable >= MAX_CONSECUTIVE_OPENCODE_WORKER_UNAVAILABLE
   }
 
   tripCircuit(error: Error): void {
@@ -110,6 +140,14 @@ export class OpenCodeSqliteScanContext {
     this.abort(
       `OpenCode SQLite worker kept timing out; remaining work was skipped (${error.message})`,
       'workerTimeoutLoop'
+    )
+  }
+
+  tripUnavailableCircuit(error: Error): void {
+    noteOpenCodeSqliteScanHardFailure()
+    this.abort(
+      `OpenCode SQLite worker could not be started; remaining work was skipped (${error.message})`,
+      'workerUnavailable'
     )
   }
 
@@ -134,8 +172,10 @@ export class OpenCodeSqliteScanContext {
       activeWorkerMs: this.activeWorkerMs,
       deadlineExpired: this.deadlineExpired,
       queueWaitMs: this.queueWaitMs,
+      sqliteSourcePresent: this.sourcePresent,
       sqliteListCancelled: this.listCancelled,
       terminationReason: this.terminationReason,
+      workerAnswered: this.answered,
       workOmitted: this.omitted
     }
   }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
@@ -36,6 +36,7 @@ export type OpenCodeSqliteScanTerminationReason =
   | 'workerCrashLoop'
   | 'workerTimeoutLoop'
   | 'workerUnavailable'
+  | 'listFailed'
   | 'scanEnded'
 
 export type OpenCodeSqliteScanMetrics = {
@@ -47,9 +48,10 @@ export type OpenCodeSqliteScanMetrics = {
   sqliteSourcePresent: boolean
   sqliteListCancelled: boolean
   terminationReason: OpenCodeSqliteScanTerminationReason | null
-  // Whether any worker call answered this scan. A scan that answered nothing
-  // made no cacheable progress, whichever limiter ended it.
+  // Whether any worker call answered this scan; diagnostic only.
   workerAnswered: boolean
+  // A successful parse response is cacheable; a list response is not.
+  parseAnswered: boolean
   workOmitted: boolean
 }
 
@@ -71,6 +73,7 @@ export class OpenCodeSqliteScanContext {
   private listCancelled = false
   private sourcePresent = false
   private answered = false
+  private parseAnswered = false
   private omitted = false
   private terminationReason: OpenCodeSqliteScanTerminationReason | null = null
 
@@ -112,6 +115,10 @@ export class OpenCodeSqliteScanContext {
     this.consecutiveWorkerUnavailable = 0
   }
 
+  noteParseResponse(): void {
+    this.parseAnswered = true
+  }
+
   noteWorkerDeath(): boolean {
     this.consecutiveWorkerDeaths += 1
     return this.consecutiveWorkerDeaths >= MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS
@@ -151,6 +158,14 @@ export class OpenCodeSqliteScanContext {
     )
   }
 
+  tripListFailure(error: Error): void {
+    noteOpenCodeSqliteScanHardFailure()
+    this.abort(
+      `OpenCode SQLite listing failed; remaining work was skipped (${error.message})`,
+      'listFailed'
+    )
+  }
+
   /** Skip this scan's SQLite work entirely while the process-wide backoff holds. */
   enterCooldown(remainingMs: number): void {
     this.abort(
@@ -176,6 +191,7 @@ export class OpenCodeSqliteScanContext {
       sqliteListCancelled: this.listCancelled,
       terminationReason: this.terminationReason,
       workerAnswered: this.answered,
+      parseAnswered: this.parseAnswered,
       workOmitted: this.omitted
     }
   }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
@@ -52,6 +52,7 @@ export type OpenCodeSqliteScanMetrics = {
   workerAnswered: boolean
   // A successful parse response is cacheable; a list response is not.
   parseAnswered: boolean
+  sqliteParseCacheHits: number
   workOmitted: boolean
 }
 
@@ -74,6 +75,7 @@ export class OpenCodeSqliteScanContext {
   private sourcePresent = false
   private answered = false
   private parseAnswered = false
+  private parseCacheHits = 0
   private omitted = false
   private terminationReason: OpenCodeSqliteScanTerminationReason | null = null
 
@@ -117,6 +119,10 @@ export class OpenCodeSqliteScanContext {
 
   noteParseResponse(): void {
     this.parseAnswered = true
+  }
+
+  noteSqliteParseCacheHit(): void {
+    this.parseCacheHits += 1
   }
 
   noteWorkerDeath(): boolean {
@@ -192,6 +198,7 @@ export class OpenCodeSqliteScanContext {
       terminationReason: this.terminationReason,
       workerAnswered: this.answered,
       parseAnswered: this.parseAnswered,
+      sqliteParseCacheHits: this.parseCacheHits,
       workOmitted: this.omitted
     }
   }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-context.ts
@@ -1,0 +1,110 @@
+export const OPENCODE_SQLITE_SCAN_DEADLINE_MS = 45_000
+export const MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS = 3
+
+export class OpenCodeSqliteScanTerminatedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'OpenCodeSqliteScanTerminatedError'
+  }
+}
+
+export function isOpenCodeSqliteScanTerminatedError(
+  error: unknown
+): error is OpenCodeSqliteScanTerminatedError {
+  return error instanceof OpenCodeSqliteScanTerminatedError
+}
+
+export type OpenCodeSqliteScanMetrics = {
+  activeWorkerMs: number
+  deadlineExpired: boolean
+  queueWaitMs: number
+  workOmitted: boolean
+}
+
+export class OpenCodeSqliteScanContext {
+  readonly signal: AbortSignal
+  readonly startedAtMs = Date.now()
+  private readonly controller = new AbortController()
+  private deadlineTimer: NodeJS.Timeout | null
+  private consecutiveWorkerDeaths = 0
+  private activeWorkerMs = 0
+  private queueWaitMs = 0
+  private deadlineExpired = false
+  private omitted = false
+
+  constructor(deadlineMs = OPENCODE_SQLITE_SCAN_DEADLINE_MS) {
+    if (!Number.isSafeInteger(deadlineMs) || deadlineMs < 0) {
+      throw new RangeError('OpenCode SQLite scan deadline must be a non-negative integer')
+    }
+    this.signal = this.controller.signal
+    this.deadlineTimer = setTimeout(() => {
+      this.deadlineExpired = true
+      this.abort('OpenCode SQLite scan deadline elapsed')
+    }, deadlineMs)
+    this.deadlineTimer.unref?.()
+  }
+
+  get isTerminated(): boolean {
+    return this.signal.aborted
+  }
+
+  markWorkOmitted(): void {
+    this.omitted = true
+  }
+
+  terminationError(): OpenCodeSqliteScanTerminatedError {
+    return isOpenCodeSqliteScanTerminatedError(this.signal.reason)
+      ? this.signal.reason
+      : new OpenCodeSqliteScanTerminatedError('OpenCode SQLite scan was cancelled')
+  }
+
+  noteWorkerResponse(): void {
+    this.consecutiveWorkerDeaths = 0
+  }
+
+  noteWorkerDeath(): boolean {
+    this.consecutiveWorkerDeaths += 1
+    return this.consecutiveWorkerDeaths >= MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS
+  }
+
+  tripCircuit(error: Error): void {
+    this.abort(
+      `OpenCode SQLite worker crashed repeatedly; remaining work was skipped (${error.message})`
+    )
+  }
+
+  noteQueueWait(durationMs: number): void {
+    this.queueWaitMs += Math.max(0, durationMs)
+  }
+
+  noteActiveWorker(durationMs: number): void {
+    this.activeWorkerMs += Math.max(0, durationMs)
+  }
+
+  metrics(): OpenCodeSqliteScanMetrics {
+    return {
+      activeWorkerMs: this.activeWorkerMs,
+      deadlineExpired: this.deadlineExpired,
+      queueWaitMs: this.queueWaitMs,
+      workOmitted: this.omitted
+    }
+  }
+
+  disarmDeadline(): void {
+    if (this.deadlineTimer) {
+      clearTimeout(this.deadlineTimer)
+      this.deadlineTimer = null
+    }
+  }
+
+  dispose(): void {
+    this.abort('OpenCode SQLite scan ended')
+  }
+
+  private abort(message: string): void {
+    this.disarmDeadline()
+    if (!this.signal.aborted) {
+      this.controller.abort(new OpenCodeSqliteScanTerminatedError(message))
+    }
+  }
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-cooldown.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-cooldown.ts
@@ -1,0 +1,31 @@
+// Why: a scan that expired its budget still made progress — the parse cache
+// retains what it finished, so the next scan resumes further down the list. A
+// scan killed by a crash loop, a timeout loop, or a worker that will not spawn
+// made none, and retrying it every cache-TTL just re-burns a core on work that
+// cannot succeed. Only those hard failures back off, and only process-wide.
+const COOLDOWN_BASE_MS = 60_000
+const COOLDOWN_MAX_MS = 10 * 60_000
+
+let cooldownUntilMs = 0
+let consecutiveHardFailures = 0
+
+export function noteOpenCodeSqliteScanHardFailure(nowMs = Date.now()): void {
+  consecutiveHardFailures += 1
+  const backoffMs = Math.min(COOLDOWN_MAX_MS, COOLDOWN_BASE_MS * 2 ** (consecutiveHardFailures - 1))
+  cooldownUntilMs = Math.max(cooldownUntilMs, nowMs + backoffMs)
+}
+
+/** A scan that finished its SQLite work clears the backoff. */
+export function noteOpenCodeSqliteScanProgress(): void {
+  consecutiveHardFailures = 0
+  cooldownUntilMs = 0
+}
+
+export function openCodeSqliteScanCooldownRemainingMs(nowMs = Date.now()): number {
+  return Math.max(0, cooldownUntilMs - nowMs)
+}
+
+export function resetOpenCodeSqliteScanCooldownForTests(): void {
+  cooldownUntilMs = 0
+  consecutiveHardFailures = 0
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
@@ -154,6 +154,7 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
     const context = new OpenCodeSqliteScanContext()
     const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
     try {
+      context.markSqliteSourcePresent()
       context.enterCooldown(120_000)
 
       recordOpenCodeSqliteScanOutcome({
@@ -169,6 +170,73 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
       expect(issues[0]?.message).toMatch(/paused after repeated failures/)
     } finally {
       context.dispose()
+    }
+  })
+
+  // Why: the backoff is process-wide and outlives the install that armed it.
+  it('stays quiet about the pause when no OpenCode database exists', () => {
+    const context = new OpenCodeSqliteScanContext()
+    const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
+    try {
+      context.enterCooldown(120_000)
+
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues,
+        span: recordingSpan(new Map())
+      })
+
+      expect(issues).toEqual([])
+    } finally {
+      context.dispose()
+    }
+  })
+
+  // Why: a budget that expired without a single worker answer cached nothing, so
+  // the next scan would burn the same 45s again. That is a hard failure.
+  it('backs off when the whole budget elapsed with no worker answer', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1)
+    try {
+      context.armDeadline()
+      await vi.advanceTimersByTimeAsync(1)
+      context.markWorkOmitted()
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues: [],
+        span: recordingSpan(new Map())
+      })
+      expect(context.metrics().workerAnswered).toBe(false)
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBeGreaterThan(0)
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not back off when the budget expired after real progress', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1)
+    try {
+      context.noteWorkerResponse()
+      context.armDeadline()
+      await vi.advanceTimersByTimeAsync(1)
+      context.markWorkOmitted()
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues: [],
+        span: recordingSpan(new Map())
+      })
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBe(0)
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
     }
   })
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ActiveSpan } from '../observability/tracer'
+import { recordOpenCodeSqliteScanOutcome } from './session-scanner-opencode-sqlite-scan-outcome'
+import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+
+function recordingSpan(attributes: Map<string, unknown>): ActiveSpan {
+  return {
+    traceId: 'trace',
+    spanId: 'span',
+    setAttribute(key, value) {
+      attributes.set(key, value)
+    },
+    addEvent() {},
+    fail() {},
+    interrupt() {},
+    end() {}
+  }
+}
+
+describe('recordOpenCodeSqliteScanOutcome', () => {
+  it('reports omitted work once with tuning metrics', () => {
+    const context = new OpenCodeSqliteScanContext()
+    const attributes = new Map<string, unknown>()
+    const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
+    try {
+      context.markWorkOmitted()
+      context.markWorkOmitted()
+      context.noteQueueWait(12)
+      context.noteActiveWorker(34)
+
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues,
+        span: recordingSpan(attributes)
+      })
+
+      expect(issues).toHaveLength(1)
+      expect(issues[0]?.message).toMatch(/Some OpenCode history was skipped/)
+      expect(attributes.get('opencodeSqliteQueueWaitMs')).toBe(12)
+      expect(attributes.get('opencodeSqliteActiveWorkerMs')).toBe(34)
+    } finally {
+      context.dispose()
+    }
+  })
+
+  it('does not report deadline expiry when no work was omitted', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1)
+    try {
+      await vi.advanceTimersByTimeAsync(1)
+      const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues,
+        span: recordingSpan(new Map())
+      })
+      expect(context.metrics().deadlineExpired).toBe(true)
+      expect(issues).toEqual([])
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('disarms the deadline before later non-SQLite scan work', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1)
+    try {
+      context.disarmDeadline()
+      await vi.advanceTimersByTimeAsync(10)
+      expect(context.isTerminated).toBe(false)
+      expect(context.metrics().deadlineExpired).toBe(false)
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ActiveSpan } from '../observability/tracer'
 import { recordOpenCodeSqliteScanOutcome } from './session-scanner-opencode-sqlite-scan-outcome'
 import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import {
+  openCodeSqliteScanCooldownRemainingMs,
+  resetOpenCodeSqliteScanCooldownForTests
+} from './session-scanner-opencode-sqlite-scan-cooldown'
 
 function recordingSpan(attributes: Map<string, unknown>): ActiveSpan {
   return {
@@ -18,6 +22,39 @@ function recordingSpan(attributes: Map<string, unknown>): ActiveSpan {
 }
 
 describe('recordOpenCodeSqliteScanOutcome', () => {
+  beforeEach(() => {
+    resetOpenCodeSqliteScanCooldownForTests()
+  })
+
+  afterEach(() => {
+    resetOpenCodeSqliteScanCooldownForTests()
+  })
+
+  it('arms the process-wide backoff on a crash loop and clears it on a clean scan', () => {
+    const crashed = new OpenCodeSqliteScanContext()
+    try {
+      crashed.tripCircuit(new Error('worker died'))
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBeGreaterThan(0)
+    } finally {
+      crashed.dispose()
+    }
+
+    // A budget expiry is not a hard failure: it still made cacheable progress.
+    const clean = new OpenCodeSqliteScanContext()
+    try {
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context: clean,
+        discoveries: [],
+        issues: [],
+        span: recordingSpan(new Map())
+      })
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBe(0)
+    } finally {
+      clean.dispose()
+    }
+  })
+
   it('reports omitted work once with tuning metrics', () => {
     const context = new OpenCodeSqliteScanContext()
     const attributes = new Map<string, unknown>()
@@ -45,10 +82,101 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
     }
   })
 
+  it('names the cause when a worker crash loop, not the budget, omitted work', () => {
+    const context = new OpenCodeSqliteScanContext()
+    const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
+    try {
+      context.tripCircuit(new Error('worker died'))
+      context.markWorkOmitted()
+
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues,
+        span: recordingSpan(new Map())
+      })
+
+      expect(issues[0]?.message).toMatch(/kept crashing/)
+    } finally {
+      context.dispose()
+    }
+  })
+
+  it('reports unreconciled legacy files when the SQLite listing was cancelled', () => {
+    const context = new OpenCodeSqliteScanContext()
+    const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
+    try {
+      context.markSqliteListCancelled()
+
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues,
+        span: recordingSpan(new Map())
+      })
+
+      expect(issues).toHaveLength(1)
+      expect(issues[0]?.message).toMatch(/could not be checked against its SQLite database/)
+    } finally {
+      context.dispose()
+    }
+  })
+
+  // Why: the cause is the actionable half. A cancelled listing is a consequence
+  // of it, so it must not displace it in a single-issue report.
+  it('leads with the termination cause when the listing was also cancelled', () => {
+    const context = new OpenCodeSqliteScanContext()
+    const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
+    try {
+      context.tripTimeoutCircuit(new Error('too slow'))
+      context.markSqliteListCancelled()
+      context.markWorkOmitted()
+
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues,
+        span: recordingSpan(new Map())
+      })
+
+      expect(issues).toHaveLength(1)
+      expect(issues[0]?.message).toMatch(/^Some OpenCode history was skipped because its SQLite/)
+      expect(issues[0]?.message).toMatch(/never checked/)
+    } finally {
+      context.dispose()
+    }
+  })
+
+  it('explains the pause while the process-wide backoff holds', () => {
+    const context = new OpenCodeSqliteScanContext()
+    const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
+    try {
+      context.enterCooldown(120_000)
+
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues,
+        span: recordingSpan(new Map())
+      })
+
+      // Reported even with nothing omitted: it explains the absent SQLite half.
+      expect(issues).toHaveLength(1)
+      expect(issues[0]?.message).toMatch(/paused after repeated failures/)
+    } finally {
+      context.dispose()
+    }
+  })
+
   it('does not report deadline expiry when no work was omitted', async () => {
     vi.useFakeTimers()
     const context = new OpenCodeSqliteScanContext(1)
     try {
+      context.armDeadline()
       await vi.advanceTimersByTimeAsync(1)
       const issues: Parameters<typeof recordOpenCodeSqliteScanOutcome>[0]['issues'] = []
       recordOpenCodeSqliteScanOutcome({
@@ -71,6 +199,8 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
     const context = new OpenCodeSqliteScanContext(1)
     try {
       context.disarmDeadline()
+      // A retired budget stays retired even if a later leg tries to re-arm it.
+      context.armDeadline()
       await vi.advanceTimersByTimeAsync(10)
       expect(context.isTerminated).toBe(false)
       expect(context.metrics().deadlineExpired).toBe(false)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
@@ -284,6 +284,32 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
     }
   })
 
+  it('does not back off when the deadline scan served SQLite rows from parse cache', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1)
+    try {
+      context.noteSqliteParseCacheHit()
+      context.armDeadline()
+      await vi.advanceTimersByTimeAsync(1)
+      context.markWorkOmitted()
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues: [],
+        span: recordingSpan(new Map())
+      })
+      expect(context.metrics()).toMatchObject({
+        parseAnswered: false,
+        sqliteParseCacheHits: 1
+      })
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBe(0)
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
+    }
+  })
+
   it('does not report deadline expiry when no work was omitted', async () => {
     vi.useFakeTimers()
     const context = new OpenCodeSqliteScanContext(1)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.test.ts
@@ -42,6 +42,7 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
     // A budget expiry is not a hard failure: it still made cacheable progress.
     const clean = new OpenCodeSqliteScanContext()
     try {
+      clean.markSqliteSourcePresent()
       recordOpenCodeSqliteScanOutcome({
         candidates: [],
         context: clean,
@@ -52,6 +53,27 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
       expect(openCodeSqliteScanCooldownRemainingMs()).toBe(0)
     } finally {
       clean.dispose()
+    }
+  })
+
+  it('does not clear a prior failure when the scan had no SQLite source', () => {
+    const failed = new OpenCodeSqliteScanContext()
+    failed.tripCircuit(new Error('worker died'))
+    failed.dispose()
+    expect(openCodeSqliteScanCooldownRemainingMs()).toBeGreaterThan(0)
+
+    const noSource = new OpenCodeSqliteScanContext()
+    try {
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context: noSource,
+        discoveries: [],
+        issues: [],
+        span: recordingSpan(new Map())
+      })
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBeGreaterThan(0)
+    } finally {
+      noSource.dispose()
     }
   })
 
@@ -194,9 +216,7 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
     }
   })
 
-  // Why: a budget that expired without a single worker answer cached nothing, so
-  // the next scan would burn the same 45s again. That is a hard failure.
-  it('backs off when the whole budget elapsed with no worker answer', async () => {
+  it('backs off when the whole budget elapsed with no parse response', async () => {
     vi.useFakeTimers()
     const context = new OpenCodeSqliteScanContext(1)
     try {
@@ -218,11 +238,35 @@ describe('recordOpenCodeSqliteScanOutcome', () => {
     }
   })
 
+  it('does not mistake a list response for cacheable progress', async () => {
+    vi.useFakeTimers()
+    const context = new OpenCodeSqliteScanContext(1)
+    try {
+      context.noteWorkerResponse()
+      context.armDeadline()
+      await vi.advanceTimersByTimeAsync(1)
+      context.markWorkOmitted()
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context,
+        discoveries: [],
+        issues: [],
+        span: recordingSpan(new Map())
+      })
+      expect(context.metrics()).toMatchObject({ workerAnswered: true, parseAnswered: false })
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBeGreaterThan(0)
+    } finally {
+      context.dispose()
+      vi.useRealTimers()
+    }
+  })
+
   it('does not back off when the budget expired after real progress', async () => {
     vi.useFakeTimers()
     const context = new OpenCodeSqliteScanContext(1)
     try {
       context.noteWorkerResponse()
+      context.noteParseResponse()
       context.armDeadline()
       await vi.advanceTimersByTimeAsync(1)
       context.markWorkOmitted()

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
@@ -37,17 +37,15 @@ export function recordOpenCodeSqliteScanOutcome(args: {
   if (message) {
     args.issues.push({ agent: 'opencode', path: 'opencode.db', message })
   }
-  // Why: a deadline expiry normally means partial progress worth resuming, so it
-  // does not back off. But a scan that ran its whole budget without a single
-  // worker answer cached nothing, and the next scan would burn the same budget
-  // again — that is a hard failure whichever limiter happened to fire first.
-  if (metrics.terminationReason === 'deadline' && !metrics.workerAnswered) {
+  // A list response caches nothing. Only a completed parse proves the next scan
+  // can advance instead of replaying the same list-and-deadline cycle.
+  if (metrics.terminationReason === 'deadline' && !metrics.parseAnswered) {
     noteOpenCodeSqliteScanHardFailure()
     return
   }
   // Only a scan that got through its SQLite work clears the process-wide
   // backoff; a scan that never had any to do says nothing either way.
-  if (metrics.terminationReason === null && !metrics.workOmitted) {
+  if (metrics.sqliteSourcePresent && metrics.terminationReason === null && !metrics.workOmitted) {
     noteOpenCodeSqliteScanProgress()
   }
 }
@@ -92,6 +90,8 @@ function terminationCauseMessage(metrics: OpenCodeSqliteScanMetrics): string | n
       return 'Some OpenCode history was skipped because its SQLite database was too slow to read.'
     case 'workerUnavailable':
       return 'Some OpenCode history was skipped because its background scanner could not start.'
+    case 'listFailed':
+      return 'Some OpenCode history was skipped because its SQLite session listing failed.'
     // 'cooldown' returned above, so it is already narrowed out here.
     case 'scanEnded':
     case null:

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
@@ -1,0 +1,34 @@
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import type { ActiveSpan } from '../observability/tracer'
+import { looksLikeOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import type { SessionFileCandidate, SessionFileDiscovery } from './session-scanner-types'
+
+export function recordOpenCodeSqliteScanOutcome(args: {
+  candidates: readonly SessionFileCandidate[]
+  context: OpenCodeSqliteScanContext
+  discoveries: readonly SessionFileDiscovery[]
+  issues: AiVaultScanIssue[]
+  span: ActiveSpan
+}): void {
+  const metrics = args.context.metrics()
+  args.span.setAttribute('opencodeSqliteDeadlineExpired', metrics.deadlineExpired)
+  args.span.setAttribute('opencodeSqliteQueueWaitMs', metrics.queueWaitMs)
+  args.span.setAttribute('opencodeSqliteActiveWorkerMs', metrics.activeWorkerMs)
+  args.span.setAttribute(
+    'opencodeSqliteSources',
+    args.discoveries.filter((discovery) => discovery.agent === 'opencode').length
+  )
+  args.span.setAttribute(
+    'opencodeSqliteCandidates',
+    args.candidates.filter((candidate) => looksLikeOpenCodeSqliteCandidate(candidate.file.path))
+      .length
+  )
+  if (metrics.workOmitted) {
+    args.issues.push({
+      agent: 'opencode',
+      path: 'opencode.db',
+      message: 'Some OpenCode history was skipped after its SQLite scan budget ended.'
+    })
+  }
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
@@ -5,7 +5,10 @@ import type {
   OpenCodeSqliteScanContext,
   OpenCodeSqliteScanMetrics
 } from './session-scanner-opencode-sqlite-scan-context'
-import { noteOpenCodeSqliteScanProgress } from './session-scanner-opencode-sqlite-scan-cooldown'
+import {
+  noteOpenCodeSqliteScanHardFailure,
+  noteOpenCodeSqliteScanProgress
+} from './session-scanner-opencode-sqlite-scan-cooldown'
 import type { SessionFileCandidate, SessionFileDiscovery } from './session-scanner-types'
 
 export function recordOpenCodeSqliteScanOutcome(args: {
@@ -34,6 +37,14 @@ export function recordOpenCodeSqliteScanOutcome(args: {
   if (message) {
     args.issues.push({ agent: 'opencode', path: 'opencode.db', message })
   }
+  // Why: a deadline expiry normally means partial progress worth resuming, so it
+  // does not back off. But a scan that ran its whole budget without a single
+  // worker answer cached nothing, and the next scan would burn the same budget
+  // again — that is a hard failure whichever limiter happened to fire first.
+  if (metrics.terminationReason === 'deadline' && !metrics.workerAnswered) {
+    noteOpenCodeSqliteScanHardFailure()
+    return
+  }
   // Only a scan that got through its SQLite work clears the process-wide
   // backoff; a scan that never had any to do says nothing either way.
   if (metrics.terminationReason === null && !metrics.workOmitted) {
@@ -61,9 +72,13 @@ function scanOutcomeMessage(metrics: OpenCodeSqliteScanMetrics): string | null {
 
 function terminationCauseMessage(metrics: OpenCodeSqliteScanMetrics): string | null {
   // Cooldown is worth reporting even with nothing omitted: it explains why the
-  // SQLite half of the listing is absent this time round.
+  // SQLite half of the listing is absent this time round. But only to someone
+  // who has an OpenCode database — a backoff outliving the install it came from
+  // must not surface an OpenCode error on a machine with no OpenCode.
   if (metrics.terminationReason === 'cooldown') {
-    return 'OpenCode history was not scanned this time; its background scanner is paused after repeated failures and will be retried automatically.'
+    return metrics.sqliteSourcePresent
+      ? 'OpenCode history was not scanned this time; its background scanner is paused after repeated failures and will be retried automatically.'
+      : null
   }
   if (!metrics.workOmitted) {
     return null
@@ -75,6 +90,8 @@ function terminationCauseMessage(metrics: OpenCodeSqliteScanMetrics): string | n
       return 'Some OpenCode history was skipped because its background scanner kept crashing.'
     case 'workerTimeoutLoop':
       return 'Some OpenCode history was skipped because its SQLite database was too slow to read.'
+    case 'workerUnavailable':
+      return 'Some OpenCode history was skipped because its background scanner could not start.'
     // 'cooldown' returned above, so it is already narrowed out here.
     case 'scanEnded':
     case null:

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
@@ -1,7 +1,11 @@
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import type { ActiveSpan } from '../observability/tracer'
 import { looksLikeOpenCodeSqliteCandidate } from './session-scanner-opencode-sqlite-paths'
-import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import type {
+  OpenCodeSqliteScanContext,
+  OpenCodeSqliteScanMetrics
+} from './session-scanner-opencode-sqlite-scan-context'
+import { noteOpenCodeSqliteScanProgress } from './session-scanner-opencode-sqlite-scan-cooldown'
 import type { SessionFileCandidate, SessionFileDiscovery } from './session-scanner-types'
 
 export function recordOpenCodeSqliteScanOutcome(args: {
@@ -24,11 +28,56 @@ export function recordOpenCodeSqliteScanOutcome(args: {
     args.candidates.filter((candidate) => looksLikeOpenCodeSqliteCandidate(candidate.file.path))
       .length
   )
-  if (metrics.workOmitted) {
-    args.issues.push({
-      agent: 'opencode',
-      path: 'opencode.db',
-      message: 'Some OpenCode history was skipped after its SQLite scan budget ended.'
-    })
+  args.span.setAttribute('opencodeSqliteListCancelled', metrics.sqliteListCancelled)
+  args.span.setAttribute('opencodeSqliteTerminationReason', metrics.terminationReason ?? 'none')
+  const message = scanOutcomeMessage(metrics)
+  if (message) {
+    args.issues.push({ agent: 'opencode', path: 'opencode.db', message })
+  }
+  // Only a scan that got through its SQLite work clears the process-wide
+  // backoff; a scan that never had any to do says nothing either way.
+  if (metrics.terminationReason === null && !metrics.workOmitted) {
+    noteOpenCodeSqliteScanProgress()
+  }
+}
+
+// Why: crash loops, timeout loops, and cooldown are not budget exhaustion;
+// reporting them all as "budget ended" sends operators after the wrong cause.
+// The termination reason leads because it is the actionable half — an
+// unreconciled listing is a consequence of it, not a competing explanation.
+function scanOutcomeMessage(metrics: OpenCodeSqliteScanMetrics): string | null {
+  const cause = terminationCauseMessage(metrics)
+  if (cause && metrics.sqliteListCancelled) {
+    return `${cause} Its SQLite database was never checked, so some sessions may also be missing or out of date.`
+  }
+  if (cause) {
+    return cause
+  }
+  if (metrics.sqliteListCancelled) {
+    return 'OpenCode history could not be checked against its SQLite database, so some sessions may be missing or out of date.'
+  }
+  return null
+}
+
+function terminationCauseMessage(metrics: OpenCodeSqliteScanMetrics): string | null {
+  // Cooldown is worth reporting even with nothing omitted: it explains why the
+  // SQLite half of the listing is absent this time round.
+  if (metrics.terminationReason === 'cooldown') {
+    return 'OpenCode history was not scanned this time; its background scanner is paused after repeated failures and will be retried automatically.'
+  }
+  if (!metrics.workOmitted) {
+    return null
+  }
+  switch (metrics.terminationReason) {
+    case 'deadline':
+      return 'Some OpenCode history was skipped after its SQLite scan budget ended.'
+    case 'workerCrashLoop':
+      return 'Some OpenCode history was skipped because its background scanner kept crashing.'
+    case 'workerTimeoutLoop':
+      return 'Some OpenCode history was skipped because its SQLite database was too slow to read.'
+    // 'cooldown' returned above, so it is already narrowed out here.
+    case 'scanEnded':
+    case null:
+      return 'Some OpenCode history was skipped because the scan ended before it finished.'
   }
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-scan-outcome.ts
@@ -32,14 +32,19 @@ export function recordOpenCodeSqliteScanOutcome(args: {
       .length
   )
   args.span.setAttribute('opencodeSqliteListCancelled', metrics.sqliteListCancelled)
+  args.span.setAttribute('opencodeSqliteParseCacheHits', metrics.sqliteParseCacheHits)
   args.span.setAttribute('opencodeSqliteTerminationReason', metrics.terminationReason ?? 'none')
   const message = scanOutcomeMessage(metrics)
   if (message) {
     args.issues.push({ agent: 'opencode', path: 'opencode.db', message })
   }
-  // A list response caches nothing. Only a completed parse proves the next scan
-  // can advance instead of replaying the same list-and-deadline cycle.
-  if (metrics.terminationReason === 'deadline' && !metrics.parseAnswered) {
+  // A list response caches nothing. A completed parse or a cache-served row
+  // proves the user-visible scan still made progress.
+  if (
+    metrics.terminationReason === 'deadline' &&
+    !metrics.parseAnswered &&
+    metrics.sqliteParseCacheHits === 0
+  ) {
     noteOpenCodeSqliteScanHardFailure()
     return
   }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-backoff.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-backoff.test.ts
@@ -1,0 +1,178 @@
+import type { Worker } from 'node:worker_threads'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  OpenCodeSqliteWorkerClient,
+  PARSE_TIMEOUT_MS
+} from './session-scanner-opencode-sqlite-worker-client'
+import {
+  MAX_CONSECUTIVE_TIMEOUTS,
+  MAX_CONSECUTIVE_UNAVAILABLE,
+  TERMINATE_GRACE_MS
+} from './session-scanner-opencode-sqlite-worker-transport'
+import type { OpenCodeSqliteWorkerRequest } from './session-scanner-opencode-sqlite-worker-protocol'
+import type { ActiveSpan } from '../observability/tracer'
+import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
+import {
+  openCodeSqliteScanCooldownRemainingMs,
+  resetOpenCodeSqliteScanCooldownForTests
+} from './session-scanner-opencode-sqlite-scan-cooldown'
+import { recordOpenCodeSqliteScanOutcome } from './session-scanner-opencode-sqlite-scan-outcome'
+
+// A worker_threads stand-in that records posted requests and never answers.
+// Enough to drive the transport without a built worker bundle.
+class SilentWorker {
+  postedRequests: OpenCodeSqliteWorkerRequest[] = []
+  private listeners = new Map<string, Set<(arg?: unknown) => void>>()
+
+  on(event: string, listener: (arg?: unknown) => void): this {
+    const set = this.listeners.get(event) ?? new Set()
+    set.add(listener)
+    this.listeners.set(event, set)
+    return this
+  }
+
+  off(event: string, listener: (arg?: unknown) => void): this {
+    this.listeners.get(event)?.delete(listener)
+    return this
+  }
+
+  removeAllListeners(): void {
+    this.listeners.clear()
+  }
+
+  unref(): void {}
+
+  async terminate(): Promise<number> {
+    return 1
+  }
+
+  postMessage(request: OpenCodeSqliteWorkerRequest): void {
+    this.postedRequests.push(request)
+  }
+}
+
+function makeFactory(workers: SilentWorker[]): () => Worker {
+  return () => {
+    const worker = new SilentWorker()
+    workers.push(worker)
+    return worker as unknown as Worker
+  }
+}
+
+function noopSpan(): ActiveSpan {
+  return {
+    traceId: 'trace',
+    spanId: 'span',
+    setAttribute() {},
+    addEvent() {},
+    fail() {},
+    interrupt() {},
+    end() {}
+  }
+}
+
+// The budget clock is armed by the scan phases, not by construction.
+function armedScanContext(): OpenCodeSqliteScanContext {
+  const scanContext = new OpenCodeSqliteScanContext()
+  scanContext.armDeadline()
+  return scanContext
+}
+
+beforeEach(() => {
+  resetOpenCodeSqliteScanCooldownForTests()
+})
+
+afterEach(() => {
+  resetOpenCodeSqliteScanCooldownForTests()
+})
+
+// Why: this scan re-runs every cache TTL, so work that cannot succeed must stop
+// being retried. Both circuits below arm the process-wide backoff, and both must
+// terminate the scan — a scan that reads as clean clears the backoff it armed.
+describe('OpenCode SQLite worker backoff circuits', () => {
+  // Why: a worker that cannot spawn fails instantly, so retrying it once per
+  // candidate re-burns the same doomed work for a whole 1000-row scan. It must
+  // give up, and the give-up must survive end-of-scan bookkeeping — otherwise
+  // the scan reads as clean and clears the backoff it just armed.
+  it('gives up on a scan whose worker never spawns and keeps the backoff armed', async () => {
+    resetOpenCodeSqliteScanCooldownForTests()
+    let spawnAttempts = 0
+    const client = new OpenCodeSqliteWorkerClient({
+      workerFactory: () => {
+        spawnAttempts += 1
+        throw new Error('no worker bundle')
+      },
+      log() {}
+    })
+    const scanContext = armedScanContext()
+
+    try {
+      for (let call = 0; call < MAX_CONSECUTIVE_UNAVAILABLE + 5; call += 1) {
+        await expect(
+          client.parse({
+            context: scanContext,
+            dbPath: '/db',
+            sessionId: `s${call}`,
+            platform: 'darwin'
+          })
+        ).rejects.toThrow()
+      }
+
+      expect(spawnAttempts).toBe(MAX_CONSECUTIVE_UNAVAILABLE)
+      expect(scanContext.metrics().terminationReason).toBe('workerUnavailable')
+
+      // End-of-scan bookkeeping must not read this as a clean run.
+      recordOpenCodeSqliteScanOutcome({
+        candidates: [],
+        context: scanContext,
+        discoveries: [],
+        issues: [],
+        span: noopSpan()
+      })
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBeGreaterThan(0)
+    } finally {
+      scanContext.dispose()
+      resetOpenCodeSqliteScanCooldownForTests()
+    }
+  })
+
+  // Why: each timeout also costs a terminate grace period before the next call
+  // can dispatch. If that total outlasts the scan deadline the timeout circuit
+  // can never trip, and a permanently-slow database is misreported as a budget
+  // expiry — which by design does not back off, so it re-burns every scan.
+  it('trips the timeout circuit before the scan deadline can preempt it', async () => {
+    vi.useFakeTimers()
+    resetOpenCodeSqliteScanCooldownForTests()
+    const workers: SilentWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+    const scanContext = armedScanContext()
+
+    try {
+      const calls = Array.from({ length: MAX_CONSECUTIVE_TIMEOUTS + 2 }, (_, index) =>
+        client
+          .parse({
+            context: scanContext,
+            dbPath: '/db',
+            sessionId: `s${index}`,
+            platform: 'darwin'
+          })
+          .catch(() => 'rejected')
+      )
+
+      // Never answer: every dispatched call times out, each followed by the
+      // terminate grace period before the next one can start.
+      await vi.advanceTimersByTimeAsync(
+        MAX_CONSECUTIVE_TIMEOUTS * (PARSE_TIMEOUT_MS + TERMINATE_GRACE_MS) + 1
+      )
+      await Promise.all(calls)
+
+      expect(scanContext.metrics().terminationReason).toBe('workerTimeoutLoop')
+      expect(scanContext.metrics().deadlineExpired).toBe(false)
+      expect(openCodeSqliteScanCooldownRemainingMs()).toBeGreaterThan(0)
+    } finally {
+      scanContext.dispose()
+      resetOpenCodeSqliteScanCooldownForTests()
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -10,86 +10,13 @@ import {
   MAX_CONSECUTIVE_DEATHS,
   MAX_CONSECUTIVE_TIMEOUTS
 } from './session-scanner-opencode-sqlite-worker-transport'
-import type {
-  OpenCodeSqliteWorkerRequest,
-  OpenCodeSqliteWorkerResponse
-} from './session-scanner-opencode-sqlite-worker-protocol'
+import type { OpenCodeSqliteWorkerResponse } from './session-scanner-opencode-sqlite-worker-protocol'
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
-
-// A worker_threads stand-in the tests drive directly: it records posted requests
-// and lets a test emit message/error/exit without a built worker bundle.
-class FakeWorker {
-  postedRequests: OpenCodeSqliteWorkerRequest[] = []
-  postMessageError: Error | null = null
-  terminated = false
-  unrefed = false
-  private listeners = new Map<string, Set<(arg?: unknown) => void>>()
-
-  on(event: string, listener: (arg?: unknown) => void): this {
-    const set = this.listeners.get(event) ?? new Set()
-    set.add(listener)
-    this.listeners.set(event, set)
-    return this
-  }
-
-  off(event: string, listener: (arg?: unknown) => void): this {
-    this.listeners.get(event)?.delete(listener)
-    return this
-  }
-
-  removeAllListeners(): void {
-    this.listeners.clear()
-  }
-
-  unref(): void {
-    this.unrefed = true
-  }
-
-  async terminate(): Promise<number> {
-    this.terminated = true
-    return 1
-  }
-
-  postMessage(request: OpenCodeSqliteWorkerRequest): void {
-    if (this.postMessageError) {
-      const error = this.postMessageError
-      this.postMessageError = null
-      throw error
-    }
-    this.postedRequests.push(request)
-  }
-
-  emit(event: string, arg?: unknown): void {
-    // Copy first: the client removes its listeners synchronously during a fault.
-    for (const listener of Array.from(this.listeners.get(event) ?? [])) {
-      listener(arg)
-    }
-  }
-
-  lastId(): number {
-    const last = this.postedRequests.at(-1)
-    if (!last) {
-      throw new Error('no request posted to fake worker')
-    }
-    return last.id
-  }
-
-  listenerCount(): number {
-    return Array.from(this.listeners.values()).reduce(
-      (total, listeners) => total + listeners.size,
-      0
-    )
-  }
-}
-
-function makeFactory(workers: FakeWorker[]): () => Worker {
-  return () => {
-    const worker = new FakeWorker()
-    workers.push(worker)
-    return worker as unknown as Worker
-  }
-}
+import {
+  FakeOpenCodeSqliteWorker as FakeWorker,
+  makeFakeOpenCodeSqliteWorkerFactory as makeFactory
+} from './fake-opencode-sqlite-worker'
 
 function emitSettlementRaceEvent(worker: FakeWorker, event: 'message' | 'error' | 'exit'): void {
   if (event === 'message') {
@@ -553,6 +480,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     expect(
       listIssues.some((issue) => issue.message.includes('background scanner could not start'))
     ).toBe(true)
+    expect(context.metrics().terminationReason).toBe('workerUnavailable')
     await expect(
       client.parse({
         context,
@@ -560,7 +488,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
         sessionId: 'ses_skipped',
         platform: 'darwin'
       })
-    ).rejects.toThrow(/background scanner could not start/)
+    ).rejects.toThrow(/could not be started/)
   })
 
   // Why: the transport is a process-wide singleton shared by every concurrent
@@ -717,9 +645,34 @@ describe('OpenCodeSqliteWorkerClient', () => {
       expect(issues).toHaveLength(1)
       expect(issues[0]!.agent).toBe('opencode')
       expect(issues[0]!.message).toMatch(/did not complete/)
+      expect(context.metrics().terminationReason).toBe('workerTimeoutLoop')
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('terminates the scan when the worker rejects the list request', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({
+      workerFactory: makeFactory(workers),
+      log() {}
+    })
+    const issues: AiVaultScanIssue[] = []
+    const listPromise = client.list({
+      context,
+      dbPaths: ['/tmp/opencode.db'],
+      limit: 10,
+      issues
+    })
+    workers[0]!.emit('message', {
+      id: workers[0]!.lastId(),
+      ok: false,
+      error: 'list handler failed'
+    } satisfies OpenCodeSqliteWorkerResponse)
+
+    await expect(listPromise).resolves.toEqual([])
+    expect(context.metrics().terminationReason).toBe('listFailed')
+    expect(issues[0]?.message).toMatch(/list handler failed/)
   })
 
   it('self-heals after repeated spawn failures instead of latching unavailable', async () => {
@@ -736,37 +689,39 @@ describe('OpenCodeSqliteWorkerClient', () => {
       },
       log() {}
     })
-    // Scan 1: both calls fail closed, keeping synchronous SQLite off the main
-    // thread. The failure is not latched, so a later scan can still recover.
+    // Scan 1 fails closed and terminates only its own context.
     const firstIssues: AiVaultScanIssue[] = []
     const first = await client.list({ context, dbPaths: ['/db'], limit: 10, issues: firstIssues })
     expect(first).toEqual([])
     expect(
       firstIssues.some((issue) => issue.message.includes('background scanner could not start'))
     ).toBe(true)
-    await expect(
-      client.parse({ context, dbPath: '/db', sessionId: 'ses_heal', platform: 'darwin' })
-    ).rejects.toThrow(/background scanner could not start/)
+    expect(context.metrics().terminationReason).toBe('workerUnavailable')
     expect(workers).toHaveLength(0)
 
     // Spawns recover; the next scan must re-probe and use the worker.
     failSpawns = false
+    const recoveredContext = armedScanContext()
     const secondIssues: AiVaultScanIssue[] = []
-    const secondPromise = client.list({
-      context,
-      dbPaths: ['/db'],
-      limit: 10,
-      issues: secondIssues
-    })
-    const worker = workers[0]
-    expect(worker).toBeDefined()
-    worker!.emit('message', {
-      id: worker!.lastId(),
-      ok: true,
-      value: { candidates: [], issues: [] }
-    } satisfies OpenCodeSqliteWorkerResponse)
-    await expect(secondPromise).resolves.toEqual([])
-    expect(secondIssues).toHaveLength(0)
+    try {
+      const secondPromise = client.list({
+        context: recoveredContext,
+        dbPaths: ['/db'],
+        limit: 10,
+        issues: secondIssues
+      })
+      const worker = workers[0]
+      expect(worker).toBeDefined()
+      worker!.emit('message', {
+        id: worker!.lastId(),
+        ok: true,
+        value: { candidates: [], issues: [] }
+      } satisfies OpenCodeSqliteWorkerResponse)
+      await expect(secondPromise).resolves.toEqual([])
+      expect(secondIssues).toHaveLength(0)
+    } finally {
+      recoveredContext.dispose()
+    }
   })
 
   it('drops a cleanly exited idle worker and respawns on the next request', async () => {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -477,9 +477,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     await expect(
       client.list({ context, dbPaths: ['/tmp/opencode.db'], limit: 10, issues: listIssues })
     ).resolves.toEqual([])
-    expect(
-      listIssues.some((issue) => issue.message.includes('background scanner could not start'))
-    ).toBe(true)
+    expect(listIssues).toEqual([])
     expect(context.metrics().terminationReason).toBe('workerUnavailable')
     await expect(
       client.parse({
@@ -623,7 +621,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     expect(workers).toHaveLength(MAX_CONSECUTIVE_DEATHS)
   })
 
-  it('surfaces a list-leg timeout as a scan issue and returns no candidates', async () => {
+  it('leaves a single list timeout below the consecutive-failure circuit threshold', async () => {
     vi.useFakeTimers()
     try {
       const workers: FakeWorker[] = []
@@ -638,14 +636,16 @@ describe('OpenCodeSqliteWorkerClient', () => {
         limit: 10,
         issues
       })
-      // The list request is dispatched but never answered → it must time out into
-      // a scan issue (not an unbounded stall) and contribute no sessions.
+      // The list request is dispatched but never answered. Outcome reporting,
+      // not this transport client, owns the single user-facing diagnostic.
       await vi.advanceTimersByTimeAsync(LIST_TIMEOUT_MS)
       await expect(listPromise).resolves.toEqual([])
-      expect(issues).toHaveLength(1)
-      expect(issues[0]!.agent).toBe('opencode')
-      expect(issues[0]!.message).toMatch(/did not complete/)
-      expect(context.metrics().terminationReason).toBe('workerTimeoutLoop')
+      expect(issues).toEqual([])
+      expect(context.metrics()).toMatchObject({
+        sqliteListCancelled: true,
+        terminationReason: null,
+        workOmitted: true
+      })
     } finally {
       vi.useRealTimers()
     }
@@ -672,7 +672,32 @@ describe('OpenCodeSqliteWorkerClient', () => {
 
     await expect(listPromise).resolves.toEqual([])
     expect(context.metrics().terminationReason).toBe('listFailed')
-    expect(issues[0]?.message).toMatch(/list handler failed/)
+    expect(issues).toEqual([])
+  })
+
+  it('leaves a single list worker fault below the consecutive-death threshold', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({
+      workerFactory: makeFactory(workers),
+      log() {}
+    })
+    const issues: AiVaultScanIssue[] = []
+    const listPromise = client.list({
+      context,
+      dbPaths: ['/tmp/opencode.db'],
+      limit: 10,
+      issues
+    })
+
+    workers[0]!.emit('error', new Error('single list fault'))
+
+    await expect(listPromise).resolves.toEqual([])
+    expect(issues).toEqual([])
+    expect(context.metrics()).toMatchObject({
+      sqliteListCancelled: true,
+      terminationReason: null,
+      workOmitted: true
+    })
   })
 
   it('self-heals after repeated spawn failures instead of latching unavailable', async () => {
@@ -693,9 +718,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     const firstIssues: AiVaultScanIssue[] = []
     const first = await client.list({ context, dbPaths: ['/db'], limit: 10, issues: firstIssues })
     expect(first).toEqual([])
-    expect(
-      firstIssues.some((issue) => issue.message.includes('background scanner could not start'))
-    ).toBe(true)
+    expect(firstIssues).toEqual([])
     expect(context.metrics().terminationReason).toBe('workerUnavailable')
     expect(workers).toHaveLength(0)
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -189,6 +189,9 @@ describe('OpenCodeSqliteWorkerClient', () => {
     // Exactly one respawn; the queued call drains on the new worker.
     expect(workers).toHaveLength(2)
     const respawned = workers[1]!
+    workers[0]!.emit('error', new Error('late old-worker fault'))
+    workers[0]!.emit('message', { id: respawned.lastId(), ok: true, value: 'stale' })
+    expect(workers).toHaveLength(2)
     respawned.emit('message', { id: respawned.lastId(), ok: true, value: 'B' })
     await expect(queued).resolves.toBe('B')
   })
@@ -351,6 +354,24 @@ describe('OpenCodeSqliteWorkerClient', () => {
     ).rejects.toThrow(/background scanner could not start/)
   })
 
+  it('rejects already-aborted work without spawning a worker', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+    const abortedContext = new OpenCodeSqliteScanContext()
+    abortedContext.dispose()
+
+    await expect(
+      client.parse({
+        context: abortedContext,
+        dbPath: '/db#a',
+        sessionId: 'a',
+        platform: 'darwin'
+      })
+    ).rejects.toThrow(/scan ended/)
+    expect(workers).toEqual([])
+    expect(abortedContext.metrics().workOmitted).toBe(true)
+  })
+
   it('stops respawning after the consecutive-death cap and fails the rest to issues', async () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
@@ -505,6 +526,19 @@ describe('OpenCodeSqliteWorkerClient', () => {
         await rejection
         expect(addListener).toHaveBeenCalledTimes(index + 1)
         expect(removeListener).toHaveBeenCalledTimes(index + 1)
+
+        const interleaved = client.parse({
+          context: otherContext,
+          dbPath: `/db#b${index}`,
+          sessionId: `b${index}`,
+          platform: 'darwin'
+        })
+        workers.at(-1)!.emit('message', {
+          id: workers.at(-1)!.lastId(),
+          ok: true,
+          value: `B${index}`
+        })
+        await expect(interleaved).resolves.toBe(`B${index}`)
       }
 
       const third = client.parse({

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -451,7 +451,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
       client.list({ context, dbPaths: ['/tmp/opencode.db'], limit: 10, issues: listIssues })
     ).resolves.toEqual([])
     expect(
-      listIssues.some((issue) => /background scanner could not start/.test(issue.message))
+      listIssues.some((issue) => issue.message.includes('background scanner could not start'))
     ).toBe(true)
     await expect(
       client.parse({
@@ -549,7 +549,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     const first = await client.list({ context, dbPaths: ['/db'], limit: 10, issues: firstIssues })
     expect(first).toEqual([])
     expect(
-      firstIssues.some((issue) => /background scanner could not start/.test(issue.message))
+      firstIssues.some((issue) => issue.message.includes('background scanner could not start'))
     ).toBe(true)
     await expect(
       client.parse({ context, dbPath: '/db', sessionId: 'ses_heal', platform: 'darwin' })

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -71,6 +71,13 @@ class FakeWorker {
     }
     return last.id
   }
+
+  listenerCount(): number {
+    return Array.from(this.listeners.values()).reduce(
+      (total, listeners) => total + listeners.size,
+      0
+    )
+  }
 }
 
 function makeFactory(workers: FakeWorker[]): () => Worker {
@@ -88,6 +95,26 @@ function emitSettlementRaceEvent(worker: FakeWorker, event: 'message' | 'error' 
     worker.emit('error', new Error('worker race error'))
   } else {
     worker.emit('exit', 1)
+  }
+}
+
+function watchInternalSettlement(client: OpenCodeSqliteWorkerClient): {
+  callbackCount: () => number
+  settleCount: () => number
+} {
+  type Settle = (call: unknown, run: () => void) => void
+  const transport = (client as unknown as { transport: { settle: Settle } }).transport
+  const originalSettle = transport.settle.bind(transport)
+  let callbacks = 0
+  const settle = vi.spyOn(transport, 'settle').mockImplementation((call, run) => {
+    originalSettle(call, () => {
+      callbacks += 1
+      run()
+    })
+  })
+  return {
+    callbackCount: () => callbacks,
+    settleCount: () => settle.mock.calls.length
   }
 }
 
@@ -243,17 +270,12 @@ describe('OpenCodeSqliteWorkerClient', () => {
         workerFactory: makeFactory(workers),
         log() {}
       })
-      let activeSettlements = 0
-      const active = client
-        .parse({
-          context: expiringContext,
-          dbPath: '/db#a',
-          sessionId: 'a',
-          platform: 'darwin'
-        })
-        .finally(() => {
-          activeSettlements += 1
-        })
+      const active = client.parse({
+        context: expiringContext,
+        dbPath: '/db#a',
+        sessionId: 'a',
+        platform: 'darwin'
+      })
       const retained = client.parse({
         context: retainedContext,
         dbPath: '/db#b',
@@ -271,7 +293,6 @@ describe('OpenCodeSqliteWorkerClient', () => {
 
       await vi.advanceTimersByTimeAsync(10)
       await Promise.all([activeRejection, queuedRejection])
-      expect(activeSettlements).toBe(1)
       expect(workers[0]!.terminated).toBe(true)
       expect(workers).toHaveLength(2)
       workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'B' })
@@ -288,7 +309,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     }
   })
 
-  it('settles once when the per-call timeout wins a later context abort', async () => {
+  it('cleans up once when the per-call timeout wins a later context abort', async () => {
     vi.useFakeTimers()
     const timeoutContext = new OpenCodeSqliteScanContext(PARSE_TIMEOUT_MS * 2)
     try {
@@ -297,7 +318,9 @@ describe('OpenCodeSqliteWorkerClient', () => {
         workerFactory: makeFactory(workers),
         log() {}
       })
-      let settlements = 0
+      const settlement = watchInternalSettlement(client)
+      const addListener = vi.spyOn(timeoutContext.signal, 'addEventListener')
+      const removeListener = vi.spyOn(timeoutContext.signal, 'removeEventListener')
       const outcome = client
         .parse({
           context: timeoutContext,
@@ -306,15 +329,25 @@ describe('OpenCodeSqliteWorkerClient', () => {
           platform: 'darwin'
         })
         .catch((error: unknown) => (error instanceof Error ? error.message : String(error)))
-        .finally(() => {
-          settlements += 1
-        })
 
+      expect(vi.getTimerCount()).toBe(2)
       await vi.advanceTimersByTimeAsync(PARSE_TIMEOUT_MS)
       await expect(outcome).resolves.toMatch(/timed out/)
+      expect(settlement.settleCount()).toBe(1)
+      expect(settlement.callbackCount()).toBe(1)
+      expect(addListener).toHaveBeenCalledTimes(1)
+      expect(removeListener).toHaveBeenCalledTimes(1)
+      expect(workers[0]!.listenerCount()).toBe(0)
+      expect(vi.getTimerCount()).toBe(1)
+
       timeoutContext.dispose()
+      emitSettlementRaceEvent(workers[0]!, 'message')
+      emitSettlementRaceEvent(workers[0]!, 'error')
+      emitSettlementRaceEvent(workers[0]!, 'exit')
       await vi.advanceTimersByTimeAsync(PARSE_TIMEOUT_MS)
-      expect(settlements).toBe(1)
+      expect(settlement.settleCount()).toBe(1)
+      expect(settlement.callbackCount()).toBe(1)
+      expect(vi.getTimerCount()).toBe(0)
     } finally {
       timeoutContext.dispose()
       vi.useRealTimers()
@@ -379,61 +412,105 @@ describe('OpenCodeSqliteWorkerClient', () => {
   })
 
   it.each(['message', 'error', 'exit'] as const)(
-    'settles once when context abort wins the %s race',
+    'cleans up once when context abort wins the %s and timeout races',
     async (event) => {
-      const workers: FakeWorker[] = []
-      const client = new OpenCodeSqliteWorkerClient({
-        workerFactory: makeFactory(workers),
-        log() {}
-      })
-      let settlements = 0
-      const parse = client
-        .parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
-        .finally(() => {
-          settlements += 1
+      vi.useFakeTimers()
+      const raceContext = new OpenCodeSqliteScanContext(PARSE_TIMEOUT_MS * 2)
+      try {
+        const workers: FakeWorker[] = []
+        const client = new OpenCodeSqliteWorkerClient({
+          workerFactory: makeFactory(workers),
+          log() {}
         })
-      const rejection = expect(parse).rejects.toThrow(/scan ended/)
+        const settlement = watchInternalSettlement(client)
+        const addListener = vi.spyOn(raceContext.signal, 'addEventListener')
+        const removeListener = vi.spyOn(raceContext.signal, 'removeEventListener')
+        const parse = client.parse({
+          context: raceContext,
+          dbPath: '/db#a',
+          sessionId: 'a',
+          platform: 'darwin'
+        })
+        const rejection = expect(parse).rejects.toThrow(/scan ended/)
 
-      context.dispose()
-      await rejection
-      emitSettlementRaceEvent(workers[0]!, event)
-      await Promise.resolve()
-      expect(settlements).toBe(1)
-      expect(workers[0]!.terminated).toBe(true)
+        expect(vi.getTimerCount()).toBe(2)
+        raceContext.dispose()
+        await rejection
+        expect(settlement.settleCount()).toBe(1)
+        expect(settlement.callbackCount()).toBe(1)
+        expect(addListener).toHaveBeenCalledTimes(1)
+        expect(removeListener).toHaveBeenCalledTimes(1)
+        expect(workers[0]!.listenerCount()).toBe(0)
+        expect(vi.getTimerCount()).toBe(0)
+
+        emitSettlementRaceEvent(workers[0]!, event)
+        await vi.advanceTimersByTimeAsync(PARSE_TIMEOUT_MS)
+        expect(settlement.settleCount()).toBe(1)
+        expect(settlement.callbackCount()).toBe(1)
+        expect(vi.getTimerCount()).toBe(0)
+      } finally {
+        raceContext.dispose()
+        vi.useRealTimers()
+      }
     }
   )
 
   it.each(['message', 'error', 'exit'] as const)(
-    'settles once when the worker %s wins the context-abort race',
+    'cleans up once when worker %s wins the context-abort race',
     async (event) => {
-      const workers: FakeWorker[] = []
-      const client = new OpenCodeSqliteWorkerClient({
-        workerFactory: makeFactory(workers),
-        log() {}
-      })
-      let settlements = 0
-      const outcome = client
-        .parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
-        .then(
-          (value) => ({ error: null, value }),
-          (error: unknown) => ({
-            error: error instanceof Error ? error.message : String(error),
-            value: null
-          })
-        )
-        .finally(() => {
-          settlements += 1
+      vi.useFakeTimers()
+      const raceContext = new OpenCodeSqliteScanContext(PARSE_TIMEOUT_MS * 2)
+      try {
+        const workers: FakeWorker[] = []
+        const client = new OpenCodeSqliteWorkerClient({
+          workerFactory: makeFactory(workers),
+          log() {}
         })
+        const settlement = watchInternalSettlement(client)
+        const addListener = vi.spyOn(raceContext.signal, 'addEventListener')
+        const removeListener = vi.spyOn(raceContext.signal, 'removeEventListener')
+        const outcome = client
+          .parse({
+            context: raceContext,
+            dbPath: '/db#a',
+            sessionId: 'a',
+            platform: 'darwin'
+          })
+          .then(
+            (value) => ({ error: null, value }),
+            (error: unknown) => ({
+              error: error instanceof Error ? error.message : String(error),
+              value: null
+            })
+          )
 
-      emitSettlementRaceEvent(workers[0]!, event)
-      const settled = await outcome
-      context.dispose()
-      await Promise.resolve()
-      expect(settlements).toBe(1)
-      if (event === 'message') {
-        expect(settled.error).toBeNull()
-      } else {
-        expect(settled.error).toEqual(expect.any(String))
+        expect(vi.getTimerCount()).toBe(2)
+        emitSettlementRaceEvent(workers[0]!, event)
+        const settled = await outcome
+        expect(settlement.settleCount()).toBe(1)
+        expect(settlement.callbackCount()).toBe(1)
+        expect(addListener).toHaveBeenCalledTimes(1)
+        expect(removeListener).toHaveBeenCalledTimes(1)
+        if (event === 'message') {
+          expect(settled.error).toBeNull()
+        } else {
+          expect(settled.error).toEqual(expect.any(String))
+        }
+
+        raceContext.dispose()
+        emitSettlementRaceEvent(workers[0]!, event)
+        if (event === 'message') {
+          expect(workers[0]!.listenerCount()).toBe(3)
+          expect(vi.getTimerCount()).toBe(1)
+          await vi.advanceTimersByTimeAsync(IDLE_TEARDOWN_MS)
+        }
+        expect(workers[0]!.listenerCount()).toBe(0)
+        expect(vi.getTimerCount()).toBe(0)
+        expect(settlement.settleCount()).toBe(1)
+        expect(settlement.callbackCount()).toBe(1)
+      } finally {
+        raceContext.dispose()
+        vi.useRealTimers()
       }
     }
   )

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -1,5 +1,5 @@
 import type { Worker } from 'node:worker_threads'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   IDLE_TEARDOWN_MS,
   LIST_TIMEOUT_MS,
@@ -12,11 +12,13 @@ import type {
   OpenCodeSqliteWorkerResponse
 } from './session-scanner-opencode-sqlite-worker-protocol'
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 // A worker_threads stand-in the tests drive directly: it records posted requests
 // and lets a test emit message/error/exit without a built worker bundle.
 class FakeWorker {
   postedRequests: OpenCodeSqliteWorkerRequest[] = []
+  postMessageError: Error | null = null
   terminated = false
   unrefed = false
   private listeners = new Map<string, Set<(arg?: unknown) => void>>()
@@ -47,6 +49,11 @@ class FakeWorker {
   }
 
   postMessage(request: OpenCodeSqliteWorkerRequest): void {
+    if (this.postMessageError) {
+      const error = this.postMessageError
+      this.postMessageError = null
+      throw error
+    }
     this.postedRequests.push(request)
   }
 
@@ -74,12 +81,27 @@ function makeFactory(workers: FakeWorker[]): () => Worker {
   }
 }
 
+let context: OpenCodeSqliteScanContext
+
+beforeEach(() => {
+  context = new OpenCodeSqliteScanContext()
+})
+
+afterEach(() => {
+  context.dispose()
+})
+
 describe('OpenCodeSqliteWorkerClient', () => {
   it('correlates responses by id and ignores stale ids', async () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
 
-    const parsePromise = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    const parsePromise = client.parse({
+      context,
+      dbPath: '/db#a',
+      sessionId: 'a',
+      platform: 'darwin'
+    })
     const worker = workers[0]
     expect(worker).toBeDefined()
     expect(worker!.unrefed).toBe(true)
@@ -103,8 +125,8 @@ describe('OpenCodeSqliteWorkerClient', () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
 
-    const first = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
-    const second = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+    const first = client.parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    const second = client.parse({ context, dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
     const worker = workers[0]!
 
     // Only the first is dispatched; the second waits for the active slot.
@@ -131,8 +153,8 @@ describe('OpenCodeSqliteWorkerClient', () => {
         log() {}
       })
 
-      const active = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
-      const queued = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+      const active = client.parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+      const queued = client.parse({ context, dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
       const activeAssertion = expect(active).rejects.toThrow(/timed out/)
 
       // The queued call's timer must not have started while it waited, so only
@@ -156,8 +178,8 @@ describe('OpenCodeSqliteWorkerClient', () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
 
-    const active = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
-    const queued = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+    const active = client.parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    const queued = client.parse({ context, dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
     const activeAssertion = expect(active).rejects.toThrow(/exited with code/)
 
     workers[0]!.emit('exit', 1)
@@ -171,6 +193,139 @@ describe('OpenCodeSqliteWorkerClient', () => {
     await expect(queued).resolves.toBe('B')
   })
 
+  it('treats a synchronous postMessage throw as a worker fault', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({
+      workerFactory() {
+        const worker = new FakeWorker()
+        if (workers.length === 0) {
+          worker.postMessageError = new Error('post failed')
+        }
+        workers.push(worker)
+        return worker as unknown as Worker
+      },
+      log() {}
+    })
+
+    await expect(
+      client.parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    ).rejects.toThrow(/post failed/)
+    const recovered = client.parse({
+      context,
+      dbPath: '/db#b',
+      sessionId: 'b',
+      platform: 'darwin'
+    })
+    workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'B' })
+    await expect(recovered).resolves.toBe('B')
+  })
+
+  it('uses one queue-inclusive deadline and preserves unrelated FIFO work', async () => {
+    vi.useFakeTimers()
+    const expiringContext = new OpenCodeSqliteScanContext(10)
+    const retainedContext = new OpenCodeSqliteScanContext(1_000)
+    try {
+      const workers: FakeWorker[] = []
+      const client = new OpenCodeSqliteWorkerClient({
+        workerFactory: makeFactory(workers),
+        log() {}
+      })
+      const active = client.parse({
+        context: expiringContext,
+        dbPath: '/db#a',
+        sessionId: 'a',
+        platform: 'darwin'
+      })
+      const retained = client.parse({
+        context: retainedContext,
+        dbPath: '/db#b',
+        sessionId: 'b',
+        platform: 'darwin'
+      })
+      const queued = client.parse({
+        context: expiringContext,
+        dbPath: '/db#a2',
+        sessionId: 'a2',
+        platform: 'darwin'
+      })
+      const activeRejection = expect(active).rejects.toThrow(/deadline elapsed/)
+      const queuedRejection = expect(queued).rejects.toThrow(/deadline elapsed/)
+
+      await vi.advanceTimersByTimeAsync(10)
+      await Promise.all([activeRejection, queuedRejection])
+      expect(workers[0]!.terminated).toBe(true)
+      expect(workers).toHaveLength(2)
+      workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'B' })
+      await expect(retained).resolves.toBe('B')
+      expect(expiringContext.metrics()).toMatchObject({
+        deadlineExpired: true,
+        queueWaitMs: 10,
+        workOmitted: true
+      })
+    } finally {
+      expiringContext.dispose()
+      retainedContext.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels queued work without terminating another context active on the worker', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+    const activeContext = new OpenCodeSqliteScanContext()
+    const queuedContext = new OpenCodeSqliteScanContext()
+    try {
+      const active = client.parse({
+        context: activeContext,
+        dbPath: '/db#b',
+        sessionId: 'b',
+        platform: 'darwin'
+      })
+      const queued = client.parse({
+        context: queuedContext,
+        dbPath: '/db#a',
+        sessionId: 'a',
+        platform: 'darwin'
+      })
+      const queuedRejection = expect(queued).rejects.toThrow(/scan ended/)
+
+      queuedContext.dispose()
+      await queuedRejection
+      expect(workers[0]!.terminated).toBe(false)
+      workers[0]!.emit('message', { id: workers[0]!.lastId(), ok: true, value: 'B' })
+      await expect(active).resolves.toBe('B')
+      expect(queuedContext.metrics().workOmitted).toBe(true)
+    } finally {
+      activeContext.dispose()
+      queuedContext.dispose()
+    }
+  })
+
+  it('dispose cancels active and queued work owned by an exceptional scan exit', async () => {
+    const workers: FakeWorker[] = []
+    const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+    const exceptionalContext = new OpenCodeSqliteScanContext()
+    const active = client.parse({
+      context: exceptionalContext,
+      dbPath: '/db#a',
+      sessionId: 'a',
+      platform: 'darwin'
+    })
+    const queued = client.parse({
+      context: exceptionalContext,
+      dbPath: '/db#a2',
+      sessionId: 'a2',
+      platform: 'darwin'
+    })
+    const activeRejection = expect(active).rejects.toThrow(/scan ended/)
+    const queuedRejection = expect(queued).rejects.toThrow(/scan ended/)
+
+    exceptionalContext.dispose()
+    await Promise.all([activeRejection, queuedRejection])
+    expect(workers[0]!.terminated).toBe(true)
+    expect(exceptionalContext.metrics().workOmitted).toBe(true)
+  })
+
   it('fails closed instead of running SQLite on the main thread when spawn fails', async () => {
     const client = new OpenCodeSqliteWorkerClient({
       workerFactory() {
@@ -181,13 +336,18 @@ describe('OpenCodeSqliteWorkerClient', () => {
 
     const listIssues: AiVaultScanIssue[] = []
     await expect(
-      client.list({ dbPaths: ['/tmp/opencode.db'], limit: 10, issues: listIssues })
+      client.list({ context, dbPaths: ['/tmp/opencode.db'], limit: 10, issues: listIssues })
     ).resolves.toEqual([])
     expect(
       listIssues.some((issue) => /background scanner could not start/.test(issue.message))
     ).toBe(true)
     await expect(
-      client.parse({ dbPath: '/tmp/opencode.db', sessionId: 'ses_skipped', platform: 'darwin' })
+      client.parse({
+        context,
+        dbPath: '/tmp/opencode.db',
+        sessionId: 'ses_skipped',
+        platform: 'darwin'
+      })
     ).rejects.toThrow(/background scanner could not start/)
   })
 
@@ -196,7 +356,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
 
     const pending = Array.from({ length: MAX_CONSECUTIVE_DEATHS + 2 }, (_, i) =>
-      client.parse({ dbPath: `/db#${i}`, sessionId: `s${i}`, platform: 'darwin' })
+      client.parse({ context, dbPath: `/db#${i}`, sessionId: `s${i}`, platform: 'darwin' })
     )
     const settled = pending.map((promise) => expect(promise).rejects.toThrow())
 
@@ -222,6 +382,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
       })
       const issues: AiVaultScanIssue[] = []
       const listPromise = client.list({
+        context,
         dbPaths: ['/tmp/opencode.db'],
         limit: 10,
         issues
@@ -255,20 +416,25 @@ describe('OpenCodeSqliteWorkerClient', () => {
     // Scan 1: both calls fail closed, keeping synchronous SQLite off the main
     // thread. The failure is not latched, so a later scan can still recover.
     const firstIssues: AiVaultScanIssue[] = []
-    const first = await client.list({ dbPaths: ['/db'], limit: 10, issues: firstIssues })
+    const first = await client.list({ context, dbPaths: ['/db'], limit: 10, issues: firstIssues })
     expect(first).toEqual([])
     expect(
       firstIssues.some((issue) => /background scanner could not start/.test(issue.message))
     ).toBe(true)
     await expect(
-      client.parse({ dbPath: '/db', sessionId: 'ses_heal', platform: 'darwin' })
+      client.parse({ context, dbPath: '/db', sessionId: 'ses_heal', platform: 'darwin' })
     ).rejects.toThrow(/background scanner could not start/)
     expect(workers).toHaveLength(0)
 
     // Spawns recover; the next scan must re-probe and use the worker.
     failSpawns = false
     const secondIssues: AiVaultScanIssue[] = []
-    const secondPromise = client.list({ dbPaths: ['/db'], limit: 10, issues: secondIssues })
+    const secondPromise = client.list({
+      context,
+      dbPaths: ['/db'],
+      limit: 10,
+      issues: secondIssues
+    })
     const worker = workers[0]
     expect(worker).toBeDefined()
     worker!.emit('message', {
@@ -284,12 +450,12 @@ describe('OpenCodeSqliteWorkerClient', () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
 
-    const first = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+    const first = client.parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
     workers[0]!.emit('message', { id: workers[0]!.lastId(), ok: true, value: 'A' })
     await expect(first).resolves.toBe('A')
     workers[0]!.emit('exit', 0)
 
-    const second = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+    const second = client.parse({ context, dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
     expect(workers).toHaveLength(2)
     workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'B' })
     await expect(second).resolves.toBe('B')
@@ -304,13 +470,13 @@ describe('OpenCodeSqliteWorkerClient', () => {
         log() {}
       })
 
-      const first = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+      const first = client.parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
       workers[0]!.emit('message', { id: workers[0]!.lastId(), ok: true, value: 'A' })
       await expect(first).resolves.toBe('A')
       await vi.advanceTimersByTimeAsync(IDLE_TEARDOWN_MS)
       expect(workers[0]!.terminated).toBe(true)
 
-      const second = client.parse({ dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+      const second = client.parse({ context, dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
       expect(workers).toHaveLength(2)
       workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'B' })
       await expect(second).resolves.toBe('B')
@@ -319,30 +485,64 @@ describe('OpenCodeSqliteWorkerClient', () => {
     }
   })
 
-  it('does not carry a worker death from a prior burst into the next scan cap', async () => {
+  it('retains scan fault state across queue-empty parser batches', async () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
+    const otherContext = new OpenCodeSqliteScanContext()
+    const addListener = vi.spyOn(context.signal, 'addEventListener')
+    const removeListener = vi.spyOn(context.signal, 'removeEventListener')
 
-    // Burst 1: one parse whose worker dies, then the burst ends (queue empties)
-    // with no success to reset the death counter.
-    const first = client.parse({ dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
-    const firstAssertion = expect(first).rejects.toThrow(/exited with code/)
-    workers[0]!.emit('exit', 1)
-    await firstAssertion
+    try {
+      for (let index = 0; index < MAX_CONSECUTIVE_DEATHS - 1; index += 1) {
+        const batch = client.parse({
+          context,
+          dbPath: `/db#a${index}`,
+          sessionId: `a${index}`,
+          platform: 'darwin'
+        })
+        const rejection = expect(batch).rejects.toThrow(/batch crash/)
+        workers.at(-1)!.emit('error', new Error(`batch crash ${index}`))
+        await rejection
+        expect(addListener).toHaveBeenCalledTimes(index + 1)
+        expect(removeListener).toHaveBeenCalledTimes(index + 1)
+      }
 
-    // Burst 2 from idle: the fresh scan resets the cap, so MAX_CONSECUTIVE_DEATHS
-    // brand-new workers must be spawned before the remainder drains — the carried
-    // death from burst 1 does not count against burst 2.
-    const pending = Array.from({ length: MAX_CONSECUTIVE_DEATHS }, (_, i) =>
-      client.parse({ dbPath: `/db#b${i}`, sessionId: `b${i}`, platform: 'darwin' })
-    )
-    const settled = pending.map((promise) => expect(promise).rejects.toThrow())
-    for (let i = 0; i < MAX_CONSECUTIVE_DEATHS; i++) {
-      workers.at(-1)!.emit('error', new Error(`b-crash ${i}`))
+      const third = client.parse({
+        context,
+        dbPath: '/db#a2',
+        sessionId: 'a2',
+        platform: 'darwin'
+      })
+      const retained = client.parse({
+        context: otherContext,
+        dbPath: '/db#b',
+        sessionId: 'b',
+        platform: 'darwin'
+      })
+      const skipped = client.parse({
+        context,
+        dbPath: '/db#a3',
+        sessionId: 'a3',
+        platform: 'darwin'
+      })
+      const thirdRejection = expect(third).rejects.toThrow(/third crash/)
+      const skippedRejection = expect(skipped).rejects.toThrow(/crashed repeatedly/)
+      workers.at(-1)!.emit('error', new Error('third crash'))
+      await Promise.all([thirdRejection, skippedRejection])
+
+      const retainedWorker = workers.at(-1)!
+      retainedWorker.emit('message', {
+        id: retainedWorker.lastId(),
+        ok: true,
+        value: 'B'
+      })
+      await expect(retained).resolves.toBe('B')
+      expect(workers).toHaveLength(MAX_CONSECUTIVE_DEATHS + 1)
+      expect(addListener).toHaveBeenCalledTimes(MAX_CONSECUTIVE_DEATHS)
+      expect(removeListener).toHaveBeenCalledTimes(MAX_CONSECUTIVE_DEATHS)
+    } finally {
+      otherContext.dispose()
     }
-    await Promise.all(settled)
-    // One worker from burst 1 plus a fresh worker per allowed death in burst 2.
-    expect(workers).toHaveLength(1 + MAX_CONSECUTIVE_DEATHS)
   })
 
   it('reuses the warm worker across a burst without respawning', async () => {
@@ -350,7 +550,12 @@ describe('OpenCodeSqliteWorkerClient', () => {
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
 
     for (let i = 0; i < 3; i++) {
-      const promise = client.parse({ dbPath: `/db#${i}`, sessionId: `s${i}`, platform: 'darwin' })
+      const promise = client.parse({
+        context,
+        dbPath: `/db#${i}`,
+        sessionId: `s${i}`,
+        platform: 'darwin'
+      })
       const worker = workers[0]!
       worker.emit('message', { id: worker.lastId(), ok: true, value: `v${i}` })
       await expect(promise).resolves.toBe(`v${i}`)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -81,6 +81,16 @@ function makeFactory(workers: FakeWorker[]): () => Worker {
   }
 }
 
+function emitSettlementRaceEvent(worker: FakeWorker, event: 'message' | 'error' | 'exit'): void {
+  if (event === 'message') {
+    worker.emit('message', { id: worker.lastId(), ok: true, value: 'response' })
+  } else if (event === 'error') {
+    worker.emit('error', new Error('worker race error'))
+  } else {
+    worker.emit('exit', 1)
+  }
+}
+
 let context: OpenCodeSqliteScanContext
 
 beforeEach(() => {
@@ -233,12 +243,17 @@ describe('OpenCodeSqliteWorkerClient', () => {
         workerFactory: makeFactory(workers),
         log() {}
       })
-      const active = client.parse({
-        context: expiringContext,
-        dbPath: '/db#a',
-        sessionId: 'a',
-        platform: 'darwin'
-      })
+      let activeSettlements = 0
+      const active = client
+        .parse({
+          context: expiringContext,
+          dbPath: '/db#a',
+          sessionId: 'a',
+          platform: 'darwin'
+        })
+        .finally(() => {
+          activeSettlements += 1
+        })
       const retained = client.parse({
         context: retainedContext,
         dbPath: '/db#b',
@@ -256,6 +271,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
 
       await vi.advanceTimersByTimeAsync(10)
       await Promise.all([activeRejection, queuedRejection])
+      expect(activeSettlements).toBe(1)
       expect(workers[0]!.terminated).toBe(true)
       expect(workers).toHaveLength(2)
       workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'B' })
@@ -268,6 +284,39 @@ describe('OpenCodeSqliteWorkerClient', () => {
     } finally {
       expiringContext.dispose()
       retainedContext.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('settles once when the per-call timeout wins a later context abort', async () => {
+    vi.useFakeTimers()
+    const timeoutContext = new OpenCodeSqliteScanContext(PARSE_TIMEOUT_MS * 2)
+    try {
+      const workers: FakeWorker[] = []
+      const client = new OpenCodeSqliteWorkerClient({
+        workerFactory: makeFactory(workers),
+        log() {}
+      })
+      let settlements = 0
+      const outcome = client
+        .parse({
+          context: timeoutContext,
+          dbPath: '/db#a',
+          sessionId: 'a',
+          platform: 'darwin'
+        })
+        .catch((error: unknown) => (error instanceof Error ? error.message : String(error)))
+        .finally(() => {
+          settlements += 1
+        })
+
+      await vi.advanceTimersByTimeAsync(PARSE_TIMEOUT_MS)
+      await expect(outcome).resolves.toMatch(/timed out/)
+      timeoutContext.dispose()
+      await vi.advanceTimersByTimeAsync(PARSE_TIMEOUT_MS)
+      expect(settlements).toBe(1)
+    } finally {
+      timeoutContext.dispose()
       vi.useRealTimers()
     }
   })
@@ -328,6 +377,66 @@ describe('OpenCodeSqliteWorkerClient', () => {
     expect(workers[0]!.terminated).toBe(true)
     expect(exceptionalContext.metrics().workOmitted).toBe(true)
   })
+
+  it.each(['message', 'error', 'exit'] as const)(
+    'settles once when context abort wins the %s race',
+    async (event) => {
+      const workers: FakeWorker[] = []
+      const client = new OpenCodeSqliteWorkerClient({
+        workerFactory: makeFactory(workers),
+        log() {}
+      })
+      let settlements = 0
+      const parse = client
+        .parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+        .finally(() => {
+          settlements += 1
+        })
+      const rejection = expect(parse).rejects.toThrow(/scan ended/)
+
+      context.dispose()
+      await rejection
+      emitSettlementRaceEvent(workers[0]!, event)
+      await Promise.resolve()
+      expect(settlements).toBe(1)
+      expect(workers[0]!.terminated).toBe(true)
+    }
+  )
+
+  it.each(['message', 'error', 'exit'] as const)(
+    'settles once when the worker %s wins the context-abort race',
+    async (event) => {
+      const workers: FakeWorker[] = []
+      const client = new OpenCodeSqliteWorkerClient({
+        workerFactory: makeFactory(workers),
+        log() {}
+      })
+      let settlements = 0
+      const outcome = client
+        .parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+        .then(
+          (value) => ({ error: null, value }),
+          (error: unknown) => ({
+            error: error instanceof Error ? error.message : String(error),
+            value: null
+          })
+        )
+        .finally(() => {
+          settlements += 1
+        })
+
+      emitSettlementRaceEvent(workers[0]!, event)
+      const settled = await outcome
+      context.dispose()
+      await Promise.resolve()
+      expect(settlements).toBe(1)
+      if (event === 'message') {
+        expect(settled.error).toBeNull()
+      } else {
+        expect(settled.error).toEqual(expect.any(String))
+      }
+    }
+  )
 
   it('fails closed instead of running SQLite on the main thread when spawn fails', async () => {
     const client = new OpenCodeSqliteWorkerClient({

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.test.ts
@@ -1,12 +1,15 @@
 import type { Worker } from 'node:worker_threads'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  IDLE_TEARDOWN_MS,
   LIST_TIMEOUT_MS,
-  MAX_CONSECUTIVE_DEATHS,
   OpenCodeSqliteWorkerClient,
   PARSE_TIMEOUT_MS
 } from './session-scanner-opencode-sqlite-worker-client'
+import {
+  IDLE_TEARDOWN_MS,
+  MAX_CONSECUTIVE_DEATHS,
+  MAX_CONSECUTIVE_TIMEOUTS
+} from './session-scanner-opencode-sqlite-worker-transport'
 import type {
   OpenCodeSqliteWorkerRequest,
   OpenCodeSqliteWorkerResponse
@@ -118,10 +121,30 @@ function watchInternalSettlement(client: OpenCodeSqliteWorkerClient): {
   }
 }
 
+// The transport waits for a destroyed worker to actually die before spawning a
+// replacement — OpenCode's SQLite reads are synchronous, so `terminate()` is not
+// instant and a second thread started early would double the CPU cost. That puts
+// every respawn a few microtasks after the fault that caused it.
+// Microtasks only, never a macrotask: fake timers mock setImmediate, so a
+// timer-based flush would deadlock the tests that use them.
+async function flushWorkerTeardown(): Promise<void> {
+  for (let tick = 0; tick < 8; tick += 1) {
+    await Promise.resolve()
+  }
+}
+
+// The budget clock is armed by the scan phases, not by construction; transport
+// tests drive contexts whose SQLite leg is already running.
+function armedScanContext(deadlineMs?: number): OpenCodeSqliteScanContext {
+  const scanContext = new OpenCodeSqliteScanContext(deadlineMs)
+  scanContext.armDeadline()
+  return scanContext
+}
+
 let context: OpenCodeSqliteScanContext
 
 beforeEach(() => {
-  context = new OpenCodeSqliteScanContext()
+  context = armedScanContext()
 })
 
 afterEach(() => {
@@ -262,8 +285,8 @@ describe('OpenCodeSqliteWorkerClient', () => {
 
   it('uses one queue-inclusive deadline and preserves unrelated FIFO work', async () => {
     vi.useFakeTimers()
-    const expiringContext = new OpenCodeSqliteScanContext(10)
-    const retainedContext = new OpenCodeSqliteScanContext(1_000)
+    const expiringContext = armedScanContext(10)
+    const retainedContext = armedScanContext(1_000)
     try {
       const workers: FakeWorker[] = []
       const client = new OpenCodeSqliteWorkerClient({
@@ -311,7 +334,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
 
   it('cleans up once when the per-call timeout wins a later context abort', async () => {
     vi.useFakeTimers()
-    const timeoutContext = new OpenCodeSqliteScanContext(PARSE_TIMEOUT_MS * 2)
+    const timeoutContext = armedScanContext(PARSE_TIMEOUT_MS * 2)
     try {
       const workers: FakeWorker[] = []
       const client = new OpenCodeSqliteWorkerClient({
@@ -357,8 +380,8 @@ describe('OpenCodeSqliteWorkerClient', () => {
   it('cancels queued work without terminating another context active on the worker', async () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
-    const activeContext = new OpenCodeSqliteScanContext()
-    const queuedContext = new OpenCodeSqliteScanContext()
+    const activeContext = armedScanContext()
+    const queuedContext = armedScanContext()
     try {
       const active = client.parse({
         context: activeContext,
@@ -389,7 +412,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
   it('dispose cancels active and queued work owned by an exceptional scan exit', async () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
-    const exceptionalContext = new OpenCodeSqliteScanContext()
+    const exceptionalContext = armedScanContext()
     const active = client.parse({
       context: exceptionalContext,
       dbPath: '/db#a',
@@ -415,7 +438,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     'cleans up once when context abort wins the %s and timeout races',
     async (event) => {
       vi.useFakeTimers()
-      const raceContext = new OpenCodeSqliteScanContext(PARSE_TIMEOUT_MS * 2)
+      const raceContext = armedScanContext(PARSE_TIMEOUT_MS * 2)
       try {
         const workers: FakeWorker[] = []
         const client = new OpenCodeSqliteWorkerClient({
@@ -459,7 +482,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     'cleans up once when worker %s wins the context-abort race',
     async (event) => {
       vi.useFakeTimers()
-      const raceContext = new OpenCodeSqliteScanContext(PARSE_TIMEOUT_MS * 2)
+      const raceContext = armedScanContext(PARSE_TIMEOUT_MS * 2)
       try {
         const workers: FakeWorker[] = []
         const client = new OpenCodeSqliteWorkerClient({
@@ -540,10 +563,101 @@ describe('OpenCodeSqliteWorkerClient', () => {
     ).rejects.toThrow(/background scanner could not start/)
   })
 
+  // Why: the transport is a process-wide singleton shared by every concurrent
+  // scan. A transient spawn failure that drained the whole queue would erase
+  // OpenCode history for scans that had nothing to do with it.
+  it('fails only the call that hit a spawn failure, not another scan behind it', async () => {
+    const workers: FakeWorker[] = []
+    let spawnAttempts = 0
+    const client = new OpenCodeSqliteWorkerClient({
+      workerFactory: () => {
+        spawnAttempts += 1
+        // The very first spawn succeeds so a call can occupy the worker; the
+        // next one fails; the one after that recovers.
+        if (spawnAttempts === 2) {
+          throw new Error('transient spawn failure')
+        }
+        const worker = new FakeWorker()
+        workers.push(worker)
+        return worker as unknown as Worker
+      },
+      log() {}
+    })
+    const otherContext = armedScanContext()
+
+    try {
+      const active = client.parse({ context, dbPath: '/db#a', sessionId: 'a', platform: 'darwin' })
+      // Queued behind the active call, so both are pending when the worker dies.
+      const queuedOwn = client
+        .parse({ context, dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
+        .catch((error: unknown) => (error instanceof Error ? error.message : String(error)))
+      const queuedOther = client.parse({
+        context: otherContext,
+        dbPath: '/db#c',
+        sessionId: 'c',
+        platform: 'darwin'
+      })
+
+      workers[0]!.emit('error', new Error('worker died'))
+      await expect(active).rejects.toThrow(/worker died/)
+      await flushWorkerTeardown()
+
+      // The respawn threw for the head call only; the call behind it got the
+      // retry and a live worker.
+      await expect(queuedOwn).resolves.toMatch(/background scanner could not start/)
+      expect(workers).toHaveLength(2)
+      workers[1]!.emit('message', { id: workers[1]!.lastId(), ok: true, value: 'C' })
+      await expect(queuedOther).resolves.toBe('C')
+    } finally {
+      otherContext.dispose()
+    }
+  })
+
+  // Why: a worker answering slowly is not a worker that died. Reporting a large
+  // database as a crash sends people looking for the wrong problem.
+  it('trips a timeout circuit, not the crash circuit, when calls keep timing out', async () => {
+    vi.useFakeTimers()
+    const timeoutContext = armedScanContext(PARSE_TIMEOUT_MS * (MAX_CONSECUTIVE_TIMEOUTS + 4))
+    try {
+      const workers: FakeWorker[] = []
+      const client = new OpenCodeSqliteWorkerClient({
+        workerFactory: makeFactory(workers),
+        log() {}
+      })
+
+      const pending = Array.from({ length: MAX_CONSECUTIVE_TIMEOUTS }, (_, index) =>
+        client
+          .parse({
+            context: timeoutContext,
+            dbPath: `/db#${index}`,
+            sessionId: `s${index}`,
+            platform: 'darwin'
+          })
+          .catch((error: unknown) => (error instanceof Error ? error.message : String(error)))
+      )
+
+      for (let index = 0; index < MAX_CONSECUTIVE_TIMEOUTS; index += 1) {
+        await vi.advanceTimersByTimeAsync(PARSE_TIMEOUT_MS)
+        await flushWorkerTeardown()
+      }
+      for (const outcome of pending) {
+        await expect(outcome).resolves.toMatch(/timed out|kept timing out|cancelled/)
+      }
+
+      expect(timeoutContext.isTerminated).toBe(true)
+      expect(timeoutContext.metrics().terminationReason).toBe('workerTimeoutLoop')
+      // Never spawned more workers than the timeout budget allows.
+      expect(workers.length).toBeLessThanOrEqual(MAX_CONSECUTIVE_TIMEOUTS)
+    } finally {
+      timeoutContext.dispose()
+      vi.useRealTimers()
+    }
+  })
+
   it('rejects already-aborted work without spawning a worker', async () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
-    const abortedContext = new OpenCodeSqliteScanContext()
+    const abortedContext = armedScanContext()
     abortedContext.dispose()
 
     await expect(
@@ -569,9 +683,11 @@ describe('OpenCodeSqliteWorkerClient', () => {
 
     // Crash every worker as it is spawned; the client respawns up to the cap.
     for (let i = 0; i < MAX_CONSECUTIVE_DEATHS; i++) {
+      await flushWorkerTeardown()
       expect(workers[i]).toBeDefined()
       workers[i]!.emit('error', new Error(`crash ${i}`))
     }
+    await flushWorkerTeardown()
 
     await Promise.all(settled)
     // No respawn past the cap: only MAX_CONSECUTIVE_DEATHS workers were created,
@@ -661,6 +777,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
     workers[0]!.emit('message', { id: workers[0]!.lastId(), ok: true, value: 'A' })
     await expect(first).resolves.toBe('A')
     workers[0]!.emit('exit', 0)
+    await flushWorkerTeardown()
 
     const second = client.parse({ context, dbPath: '/db#b', sessionId: 'b', platform: 'darwin' })
     expect(workers).toHaveLength(2)
@@ -695,7 +812,7 @@ describe('OpenCodeSqliteWorkerClient', () => {
   it('retains scan fault state across queue-empty parser batches', async () => {
     const workers: FakeWorker[] = []
     const client = new OpenCodeSqliteWorkerClient({ workerFactory: makeFactory(workers), log() {} })
-    const otherContext = new OpenCodeSqliteScanContext()
+    const otherContext = armedScanContext()
     const addListener = vi.spyOn(context.signal, 'addEventListener')
     const removeListener = vi.spyOn(context.signal, 'removeEventListener')
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -1,83 +1,35 @@
-import type { Worker } from 'node:worker_threads'
 import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
-import type {
-  OpenCodeSqliteListRequest,
-  OpenCodeSqliteListValue,
-  OpenCodeSqliteParseRequest,
-  OpenCodeSqliteWorkerRequest,
-  OpenCodeSqliteWorkerResponse
-} from './session-scanner-opencode-sqlite-worker-protocol'
 import type { SessionFileCandidate } from './session-scanner-types'
 import { errorMessage } from './session-scanner-values'
+import {
+  isOpenCodeSqliteScanTerminatedError,
+  type OpenCodeSqliteScanContext
+} from './session-scanner-opencode-sqlite-scan-context'
+import type { OpenCodeSqliteListValue } from './session-scanner-opencode-sqlite-worker-protocol'
+import {
+  OpenCodeSqliteWorkerTransport,
+  OpenCodeSqliteWorkerUnavailableError,
+  type WorkerFactory
+} from './session-scanner-opencode-sqlite-worker-transport'
 
-// Why (#8864): a lazily-spawned, unref'd worker runs OpenCode SQLite reads off
-// the main-process event loop. Lifecycle (idle teardown, FIFO one-at-a-time
-// dispatch, per-call timeouts, respawn-on-fault) mirrors src/main/speech/
-// stt-service.ts. The default spawn + shared singleton live in
-// session-scanner-opencode-sqlite-worker-spawn.ts.
+export {
+  IDLE_TEARDOWN_MS,
+  MAX_CONSECUTIVE_DEATHS
+} from './session-scanner-opencode-sqlite-worker-transport'
+export type { WorkerFactory } from './session-scanner-opencode-sqlite-worker-transport'
 
 export const LIST_TIMEOUT_MS = 30_000
 export const PARSE_TIMEOUT_MS = 15_000
-export const IDLE_TEARDOWN_MS = 30_000
-// After this many consecutive worker deaths, fail the remaining queued calls to
-// scan issues instead of respawning so a DB that reliably kills the worker can't
-// spin a crash loop. Reset on any successful response, after draining, and when a
-// fresh scan burst starts from idle (so the cap is per-scan, not process-wide).
-export const MAX_CONSECUTIVE_DEATHS = 3
 
-export type WorkerFactory = () => Worker
-
-// Omit<union, 'id'> collapses to the shared keys, so omit each member and let
-// the client stamp the correlation id.
-type OpenCodeSqliteRequestBody =
-  | Omit<OpenCodeSqliteListRequest, 'id'>
-  | Omit<OpenCodeSqliteParseRequest, 'id'>
-
-type PendingCall = {
-  request: OpenCodeSqliteWorkerRequest
-  timeoutMs: number
-  resolve: (value: unknown) => void
-  reject: (error: Error) => void
-  timer: NodeJS.Timeout | null
-}
-
-// Distinguishes "no worker available at all" from a timeout or crash so callers
-// can surface a precise issue while keeping synchronous SQLite off the main thread.
-class OpenCodeSqliteWorkerUnavailableError extends Error {}
-
-/**
- * Main-thread bridge that runs OpenCode SQLite reads on a persistent worker
- * thread. Dispatches one request at a time (FIFO), times each request out from
- * dispatch, respawns after faults (capped by `MAX_CONSECUTIVE_DEATHS`), tears
- * the worker down after `IDLE_TEARDOWN_MS` of inactivity, and fails closed when
- * no worker can be spawned rather than moving SQLite work onto the main thread.
- */
 export class OpenCodeSqliteWorkerClient {
-  private worker: Worker | null = null
-  private active: PendingCall | null = null
-  private queue: PendingCall[] = []
-  private idleTimer: NodeJS.Timeout | null = null
-  private consecutiveDeaths = 0
-  private nextId = 1
-  private loggedWorkerUnavailable = false
-  private cleanupWorkerListeners: (() => void) | null = null
-  private readonly workerFactory: WorkerFactory
-  private readonly log: (message: string) => void
+  private readonly transport: OpenCodeSqliteWorkerTransport
 
   constructor(options: { workerFactory: WorkerFactory; log?: (message: string) => void }) {
-    this.workerFactory = options.workerFactory
-    this.log = options.log ?? ((message) => console.warn(message))
+    this.transport = new OpenCodeSqliteWorkerTransport(options)
   }
 
-  /**
-   * List session candidates from the given OpenCode databases on the worker.
-   * @param args.dbPaths - Absolute paths to opencode.db files to scan.
-   * @param args.limit - Maximum number of sessions to return per database.
-   * @param args.issues - Collected scan issues (worker issues are merged in).
-   * @returns Synthetic candidates sorted by effective recency; empty (with a
-   *   scan issue) when the worker is unavailable, times out, or crashes.
-   */
   async list(args: {
+    context: OpenCodeSqliteScanContext
     dbPaths: readonly string[]
     limit: number
     issues: AiVaultScanIssue[]
@@ -86,13 +38,17 @@ export class OpenCodeSqliteWorkerClient {
       return []
     }
     try {
-      const value = (await this.dispatch(
+      const value = (await this.transport.dispatch(
         { kind: 'list', dbPaths: args.dbPaths, limit: args.limit },
-        LIST_TIMEOUT_MS
+        LIST_TIMEOUT_MS,
+        args.context
       )) as OpenCodeSqliteListValue
       args.issues.push(...value.issues)
       return value.candidates
     } catch (err) {
+      if (isOpenCodeSqliteScanTerminatedError(err)) {
+        return []
+      }
       if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
         args.issues.push({
           agent: 'opencode',
@@ -102,8 +58,6 @@ export class OpenCodeSqliteWorkerClient {
         })
         return []
       }
-      // Timeout/crash: this storage dir's SQLite DBs contribute no sessions this
-      // scan, surfaced as one scan issue rather than an unbounded stall.
       args.issues.push({
         agent: 'opencode',
         path: args.dbPaths[0] ?? 'opencode.db',
@@ -113,232 +67,27 @@ export class OpenCodeSqliteWorkerClient {
     }
   }
 
-  /**
-   * Parse a single OpenCode session on the worker.
-   * @param args.dbPath - Absolute path to the opencode.db file.
-   * @param args.sessionId - Primary key in the `session` table.
-   * @param args.platform - Platform used for resume-command generation.
-   * @returns The parsed session, or `null` when it does not exist; rejects on
-   *   worker timeout/crash so the scanner records a per-session scan issue.
-   */
   async parse(args: {
+    context: OpenCodeSqliteScanContext
     dbPath: string
     sessionId: string
     platform: NodeJS.Platform
   }): Promise<AiVaultSession | null> {
     try {
-      const value = await this.dispatch(
+      const value = await this.transport.dispatch(
         { kind: 'parse', dbPath: args.dbPath, sessionId: args.sessionId, platform: args.platform },
-        PARSE_TIMEOUT_MS
+        PARSE_TIMEOUT_MS,
+        args.context
       )
       return value as AiVaultSession | null
     } catch (err) {
+      if (isOpenCodeSqliteScanTerminatedError(err)) {
+        throw err
+      }
       if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
         throw new Error('OpenCode SQLite background scanner could not start.')
       }
-      // Reject only this session; the scanner turns the throw into a scan issue.
       throw err instanceof Error ? err : new Error(String(err))
     }
-  }
-
-  private dispatch(request: OpenCodeSqliteRequestBody, timeoutMs: number): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      const id = this.nextId++
-      // A fresh burst from full idle starts a new scan: clear any death count
-      // carried from a prior scan so the respawn cap can't drain this scan early.
-      if (!this.active && this.queue.length === 0) {
-        this.consecutiveDeaths = 0
-      }
-      this.queue.push({
-        request: { ...request, id } as OpenCodeSqliteWorkerRequest,
-        timeoutMs,
-        resolve,
-        reject,
-        timer: null
-      })
-      this.pump()
-    })
-  }
-
-  private pump(): void {
-    if (this.active || this.queue.length === 0) {
-      return
-    }
-    const worker = this.ensureWorker()
-    if (!worker) {
-      this.failQueuedAsUnavailable()
-      return
-    }
-    const call = this.queue.shift()
-    if (!call) {
-      return
-    }
-    this.active = call
-    this.clearIdleTimer()
-    // Timeout clock starts at dispatch (not enqueue): a batch may enqueue up to
-    // 8 parses at once, and a queue-inclusive timeout would fire falsely.
-    call.timer = setTimeout(() => this.onTimeout(call), call.timeoutMs)
-    call.timer.unref?.()
-    worker.postMessage(call.request)
-  }
-
-  private ensureWorker(): Worker | null {
-    if (this.worker) {
-      return this.worker
-    }
-    try {
-      const worker = this.workerFactory()
-      const onMessage = (response: OpenCodeSqliteWorkerResponse): void => this.onMessage(response)
-      const onError = (error: Error): void => this.onWorkerFault(error)
-      const onExit = (code: number): void => this.onWorkerExit(code)
-      worker.on('message', onMessage)
-      worker.on('error', onError)
-      worker.on('exit', onExit)
-      this.cleanupWorkerListeners = () => {
-        worker.off('message', onMessage)
-        worker.off('error', onError)
-        worker.off('exit', onExit)
-      }
-      // Never keep the app alive for a scan worker.
-      worker.unref?.()
-      this.worker = worker
-      return worker
-    } catch (err) {
-      // Why (#8864): never fall back to synchronous SQLite reads here; a missing
-      // bundle or resource-exhausted spawn must omit OpenCode history rather than
-      // reintroduce the main-process hang this worker boundary prevents.
-      if (!this.loggedWorkerUnavailable) {
-        this.loggedWorkerUnavailable = true
-        this.log(`OpenCode SQLite worker unavailable; skipping its history. ${errorMessage(err)}`)
-      }
-      return null
-    }
-  }
-
-  private onMessage(response: OpenCodeSqliteWorkerResponse): void {
-    const call = this.active
-    if (!call || call.request.id !== response.id) {
-      return
-    }
-    this.consecutiveDeaths = 0
-    if (response.ok) {
-      this.settle(call, () => call.resolve(response.value))
-    } else {
-      this.settle(call, () => call.reject(new Error(response.error)))
-    }
-    this.afterSettle()
-  }
-
-  private onTimeout(call: PendingCall): void {
-    if (this.active !== call) {
-      return
-    }
-    this.onWorkerFault(new Error(`OpenCode SQLite worker timed out after ${call.timeoutMs}ms`))
-  }
-
-  private onWorkerExit(code: number): void {
-    // A clean self-exit is not a death, but the stale handle must be dropped
-    // or the next dispatch would post into the dead worker and stall to timeout.
-    if (code === 0 && !this.active && this.queue.length === 0) {
-      this.destroyWorker()
-      return
-    }
-    this.onWorkerFault(new Error(`OpenCode SQLite worker exited with code ${code}`))
-  }
-
-  private onWorkerFault(error: Error): void {
-    const failed = this.active
-    this.destroyWorker()
-    this.consecutiveDeaths++
-    if (failed) {
-      this.settle(failed, () => failed.reject(error))
-    }
-    if (this.consecutiveDeaths >= MAX_CONSECUTIVE_DEATHS) {
-      this.drainQueueAfterCrashLoop(error)
-      return
-    }
-    if (this.queue.length > 0) {
-      this.pump()
-    }
-  }
-
-  private drainQueueAfterCrashLoop(error: Error): void {
-    const pending = this.queue
-    this.queue = []
-    this.consecutiveDeaths = 0
-    const drainError = new Error(
-      `OpenCode SQLite worker crashed repeatedly; skipping remaining sessions (${error.message})`
-    )
-    for (const call of pending) {
-      this.settle(call, () => call.reject(drainError))
-    }
-  }
-
-  private failQueuedAsUnavailable(): void {
-    const pending = this.queue
-    this.queue = []
-    for (const call of pending) {
-      this.settle(call, () =>
-        call.reject(new OpenCodeSqliteWorkerUnavailableError('worker spawn failed'))
-      )
-    }
-  }
-
-  private settle(call: PendingCall, run: () => void): void {
-    if (call.timer) {
-      clearTimeout(call.timer)
-      call.timer = null
-    }
-    if (this.active === call) {
-      this.active = null
-    }
-    run()
-  }
-
-  private afterSettle(): void {
-    if (this.queue.length > 0) {
-      this.pump()
-    } else {
-      this.scheduleIdleTeardown()
-    }
-  }
-
-  private scheduleIdleTeardown(): void {
-    this.clearIdleTimer()
-    if (!this.worker) {
-      return
-    }
-    this.idleTimer = setTimeout(() => this.teardownIfIdle(), IDLE_TEARDOWN_MS)
-    this.idleTimer.unref?.()
-  }
-
-  private teardownIfIdle(): void {
-    this.idleTimer = null
-    // Only tear down with nothing active AND nothing queued: a request arriving
-    // as the timer fires must never be lost to a self-exiting worker.
-    if (this.active || this.queue.length > 0) {
-      return
-    }
-    this.destroyWorker()
-  }
-
-  private clearIdleTimer(): void {
-    if (this.idleTimer) {
-      clearTimeout(this.idleTimer)
-      this.idleTimer = null
-    }
-  }
-
-  private destroyWorker(): void {
-    this.clearIdleTimer()
-    const worker = this.worker
-    this.worker = null
-    if (!worker) {
-      return
-    }
-    this.cleanupWorkerListeners?.()
-    this.cleanupWorkerListeners = null
-    worker.removeAllListeners()
-    void worker.terminate().catch(() => undefined)
   }
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -12,12 +12,6 @@ import {
   type WorkerFactory
 } from './session-scanner-opencode-sqlite-worker-transport'
 
-export {
-  IDLE_TEARDOWN_MS,
-  MAX_CONSECUTIVE_DEATHS
-} from './session-scanner-opencode-sqlite-worker-transport'
-export type { WorkerFactory } from './session-scanner-opencode-sqlite-worker-transport'
-
 export const LIST_TIMEOUT_MS = 30_000
 export const PARSE_TIMEOUT_MS = 15_000
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -1,6 +1,5 @@
 import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
 import type { SessionFileCandidate } from './session-scanner-types'
-import { errorMessage } from './session-scanner-values'
 import {
   isOpenCodeSqliteScanTerminatedError,
   type OpenCodeSqliteScanContext
@@ -45,30 +44,23 @@ export class OpenCodeSqliteWorkerClient {
       if (isOpenCodeSqliteScanTerminatedError(err)) {
         return []
       }
+      args.context.markSqliteListCancelled()
+      args.context.markWorkOmitted()
       if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
         if (!args.context.isTerminated) {
           args.context.tripUnavailableCircuit(err)
         }
-        args.issues.push({
-          agent: 'opencode',
-          path: args.dbPaths[0] ?? 'opencode.db',
-          message:
-            'OpenCode history was skipped because its background scanner could not start; the app remains responsive.'
-        })
         return []
       }
-      if (err instanceof OpenCodeSqliteWorkerTimeoutError && !args.context.isTerminated) {
-        args.context.tripTimeoutCircuit(err)
-      } else if (err instanceof OpenCodeSqliteWorkerFaultError && !args.context.isTerminated) {
-        args.context.tripCircuit(err)
-      } else if (!args.context.isTerminated) {
+      // The transport owns consecutive timeout/crash counting. A single failed
+      // list must not abort sibling sources or claim a repeated worker loop.
+      if (
+        !(err instanceof OpenCodeSqliteWorkerTimeoutError) &&
+        !(err instanceof OpenCodeSqliteWorkerFaultError) &&
+        !args.context.isTerminated
+      ) {
         args.context.tripListFailure(err instanceof Error ? err : new Error(String(err)))
       }
-      args.issues.push({
-        agent: 'opencode',
-        path: args.dbPaths[0] ?? 'opencode.db',
-        message: `OpenCode history scan did not complete: ${errorMessage(err)}`
-      })
       return []
     }
   }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -7,6 +7,8 @@ import {
 } from './session-scanner-opencode-sqlite-scan-context'
 import type { OpenCodeSqliteListValue } from './session-scanner-opencode-sqlite-worker-protocol'
 import {
+  OpenCodeSqliteWorkerFaultError,
+  OpenCodeSqliteWorkerTimeoutError,
   OpenCodeSqliteWorkerTransport,
   OpenCodeSqliteWorkerUnavailableError,
   type WorkerFactory
@@ -44,6 +46,9 @@ export class OpenCodeSqliteWorkerClient {
         return []
       }
       if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
+        if (!args.context.isTerminated) {
+          args.context.tripUnavailableCircuit(err)
+        }
         args.issues.push({
           agent: 'opencode',
           path: args.dbPaths[0] ?? 'opencode.db',
@@ -51,6 +56,13 @@ export class OpenCodeSqliteWorkerClient {
             'OpenCode history was skipped because its background scanner could not start; the app remains responsive.'
         })
         return []
+      }
+      if (err instanceof OpenCodeSqliteWorkerTimeoutError && !args.context.isTerminated) {
+        args.context.tripTimeoutCircuit(err)
+      } else if (err instanceof OpenCodeSqliteWorkerFaultError && !args.context.isTerminated) {
+        args.context.tripCircuit(err)
+      } else if (!args.context.isTerminated) {
+        args.context.tripListFailure(err instanceof Error ? err : new Error(String(err)))
       }
       args.issues.push({
         agent: 'opencode',

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-handle.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-handle.test.ts
@@ -1,0 +1,42 @@
+import type { Worker } from 'node:worker_threads'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FakeOpenCodeSqliteWorker } from './fake-opencode-sqlite-worker'
+import {
+  OpenCodeSqliteWorkerHandle,
+  TERMINATE_GRACE_MS
+} from './session-scanner-opencode-sqlite-worker-handle'
+
+class WedgedTerminateWorker extends FakeOpenCodeSqliteWorker {
+  override terminate(): Promise<number> {
+    this.terminated = true
+    return new Promise(() => undefined)
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('OpenCodeSqliteWorkerHandle', () => {
+  it('logs when worker termination exceeds the grace period', async () => {
+    vi.useFakeTimers()
+    const log = vi.fn()
+    const handle = new OpenCodeSqliteWorkerHandle({
+      workerFactory: () => new WedgedTerminateWorker() as unknown as Worker,
+      log,
+      onMessage() {},
+      onFault() {},
+      onExit() {},
+      onTeardownSettled() {}
+    })
+
+    expect(handle.ensure()).not.toBeNull()
+    handle.destroy()
+    await vi.advanceTimersByTimeAsync(TERMINATE_GRACE_MS)
+
+    expect(log).toHaveBeenCalledWith(
+      `OpenCode SQLite worker terminate grace expired after ${TERMINATE_GRACE_MS}ms; replacement may overlap a wedged worker.`
+    )
+    expect(handle.isTearingDown).toBe(false)
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-handle.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-handle.ts
@@ -1,0 +1,144 @@
+import type { Worker } from 'node:worker_threads'
+import type { OpenCodeSqliteWorkerResponse } from './session-scanner-opencode-sqlite-worker-protocol'
+import { errorMessage } from './session-scanner-values'
+
+export const IDLE_TEARDOWN_MS = 30_000
+// Why: OpenCode reads use synchronous node:sqlite, so `terminate()` cannot
+// preempt a thread parked inside a long query — it resolves only once that query
+// returns. Spawning a replacement before then stacks a second thread onto the
+// same core, which is exactly the CPU burn this worker boundary exists to bound.
+// So the next spawn waits for the old thread to actually die, and this grace
+// period keeps a never-returning query from wedging the transport forever.
+export const TERMINATE_GRACE_MS = 5_000
+
+export type WorkerFactory = () => Worker
+
+/**
+ * Owns the single lazily-spawned scan worker: its listeners, its idle teardown,
+ * and the guarantee that a replacement thread never starts before the previous
+ * one is confirmed dead. Knows nothing about queueing or scan budgets.
+ */
+export class OpenCodeSqliteWorkerHandle {
+  private worker: Worker | null = null
+  private idleTimer: NodeJS.Timeout | null = null
+  private teardownInFlight: Promise<void> | null = null
+  private cleanupListeners: (() => void) | null = null
+  private loggedUnavailable = false
+  private readonly options: {
+    workerFactory: WorkerFactory
+    log: (message: string) => void
+    onMessage: (response: OpenCodeSqliteWorkerResponse) => void
+    onFault: (error: Error) => void
+    onExit: (code: number) => void
+    onTeardownSettled: () => void
+  }
+
+  constructor(options: OpenCodeSqliteWorkerHandle['options']) {
+    this.options = options
+  }
+
+  /** True while a previous thread is still dying; no spawn may happen yet. */
+  get isTearingDown(): boolean {
+    return this.teardownInFlight !== null
+  }
+
+  get isSpawned(): boolean {
+    return this.worker !== null
+  }
+
+  ensure(): Worker | null {
+    if (this.worker) {
+      return this.worker
+    }
+    try {
+      const worker = this.options.workerFactory()
+      const onMessage = (response: OpenCodeSqliteWorkerResponse): void =>
+        this.options.onMessage(response)
+      const onError = (error: Error): void => this.options.onFault(error)
+      const onExit = (code: number): void => this.options.onExit(code)
+      worker.on('message', onMessage)
+      worker.on('error', onError)
+      worker.on('exit', onExit)
+      this.cleanupListeners = () => {
+        worker.off('message', onMessage)
+        worker.off('error', onError)
+        worker.off('exit', onExit)
+      }
+      // Never keep the app alive for a scan worker.
+      worker.unref?.()
+      this.worker = worker
+      // A later spawn failure is news again once one has succeeded.
+      this.loggedUnavailable = false
+      return worker
+    } catch (err) {
+      // Why (#8864): never fall back to synchronous SQLite reads here; a missing
+      // bundle or resource-exhausted spawn must omit OpenCode history rather than
+      // reintroduce the main-process hang this worker boundary prevents.
+      if (!this.loggedUnavailable) {
+        this.loggedUnavailable = true
+        this.options.log(
+          `OpenCode SQLite worker unavailable; skipping its history. ${errorMessage(err)}`
+        )
+      }
+      return null
+    }
+  }
+
+  destroy(): void {
+    this.clearIdleTimer()
+    const worker = this.worker
+    this.worker = null
+    if (!worker) {
+      return
+    }
+    this.cleanupListeners?.()
+    this.cleanupListeners = null
+    worker.removeAllListeners()
+    let graceTimer: NodeJS.Timeout | null = null
+    const teardown = Promise.race([
+      worker.terminate().then(
+        () => undefined,
+        () => undefined
+      ),
+      new Promise<void>((resolve) => {
+        graceTimer = setTimeout(resolve, TERMINATE_GRACE_MS)
+        graceTimer.unref?.()
+      })
+    ]).finally(() => {
+      // The loser of the race must not leave a live timer behind.
+      if (graceTimer) {
+        clearTimeout(graceTimer)
+      }
+    })
+    this.teardownInFlight = teardown
+    void teardown.then(() => {
+      if (this.teardownInFlight !== teardown) {
+        return
+      }
+      this.teardownInFlight = null
+      this.options.onTeardownSettled()
+    })
+  }
+
+  /** @param isIdle - re-checked when the timer fires; a late arrival cancels teardown. */
+  scheduleIdleTeardown(isIdle: () => boolean): void {
+    this.clearIdleTimer()
+    if (!this.worker) {
+      return
+    }
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null
+      if (isIdle()) {
+        this.destroy()
+      }
+    }, IDLE_TEARDOWN_MS)
+    this.idleTimer.unref?.()
+  }
+
+  clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer)
+      this.idleTimer = null
+    }
+  }
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-handle.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-handle.ts
@@ -7,16 +7,16 @@ export const IDLE_TEARDOWN_MS = 30_000
 // preempt a thread parked inside a long query — it resolves only once that query
 // returns. Spawning a replacement before then stacks a second thread onto the
 // same core, which is exactly the CPU burn this worker boundary exists to bound.
-// So the next spawn waits for the old thread to actually die, and this grace
-// period keeps a never-returning query from wedging the transport forever.
+// So the next spawn waits during a bounded grace period; expiry is logged
+// because a replacement may overlap a never-returning query.
 export const TERMINATE_GRACE_MS = 5_000
 
 export type WorkerFactory = () => Worker
 
 /**
  * Owns the single lazily-spawned scan worker: its listeners, its idle teardown,
- * and the guarantee that a replacement thread never starts before the previous
- * one is confirmed dead. Knows nothing about queueing or scan budgets.
+ * and the bounded teardown before a replacement may start. Knows nothing about
+ * queueing or scan budgets.
  */
 export class OpenCodeSqliteWorkerHandle {
   private worker: Worker | null = null
@@ -37,7 +37,7 @@ export class OpenCodeSqliteWorkerHandle {
     this.options = options
   }
 
-  /** True while a previous thread is still dying; no spawn may happen yet. */
+  /** True while a previous thread is within its teardown grace period. */
   get isTearingDown(): boolean {
     return this.teardownInFlight !== null
   }
@@ -101,7 +101,12 @@ export class OpenCodeSqliteWorkerHandle {
         () => undefined
       ),
       new Promise<void>((resolve) => {
-        graceTimer = setTimeout(resolve, TERMINATE_GRACE_MS)
+        graceTimer = setTimeout(() => {
+          this.options.log(
+            `OpenCode SQLite worker terminate grace expired after ${TERMINATE_GRACE_MS}ms; replacement may overlap a wedged worker.`
+          )
+          resolve()
+        }, TERMINATE_GRACE_MS)
         graceTimer.unref?.()
       })
     ]).finally(() => {

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-spawn.ts
@@ -4,6 +4,7 @@ import { Worker } from 'node:worker_threads'
 import type { AiVaultScanIssue, AiVaultSession } from '../../shared/ai-vault-types'
 import type { SessionFileCandidate } from './session-scanner-types'
 import { OpenCodeSqliteWorkerClient } from './session-scanner-opencode-sqlite-worker-client'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 // Why: resolve the built worker entry + own the process-wide shared client so
 // the client class stays free of Electron (require'd lazily here) and the
@@ -53,6 +54,7 @@ function getSharedClient(): OpenCodeSqliteWorkerClient {
  * @returns Synthetic candidates sorted by effective recency.
  */
 export function listOpenCodeSqliteSessionsViaWorker(args: {
+  context: OpenCodeSqliteScanContext
   dbPaths: readonly string[]
   limit: number
   issues: AiVaultScanIssue[]
@@ -68,6 +70,7 @@ export function listOpenCodeSqliteSessionsViaWorker(args: {
  * @returns The parsed session, or `null` when it does not exist.
  */
 export function parseOpenCodeSqliteSessionViaWorker(args: {
+  context: OpenCodeSqliteScanContext
   dbPath: string
   sessionId: string
   platform: NodeJS.Platform

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-transport.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-transport.ts
@@ -1,15 +1,25 @@
-import type { Worker } from 'node:worker_threads'
 import type {
   OpenCodeSqliteListRequest,
   OpenCodeSqliteParseRequest,
   OpenCodeSqliteWorkerRequest,
   OpenCodeSqliteWorkerResponse
 } from './session-scanner-opencode-sqlite-worker-protocol'
-import { errorMessage } from './session-scanner-values'
 import {
   MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS,
+  MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS,
   type OpenCodeSqliteScanContext
 } from './session-scanner-opencode-sqlite-scan-context'
+import { noteOpenCodeSqliteScanHardFailure } from './session-scanner-opencode-sqlite-scan-cooldown'
+import {
+  OpenCodeSqliteWorkerHandle,
+  type WorkerFactory
+} from './session-scanner-opencode-sqlite-worker-handle'
+
+export {
+  IDLE_TEARDOWN_MS,
+  TERMINATE_GRACE_MS,
+  type WorkerFactory
+} from './session-scanner-opencode-sqlite-worker-handle'
 
 // Why (#8864): a lazily-spawned, unref'd worker runs OpenCode SQLite reads off
 // the main-process event loop. Lifecycle (idle teardown, FIFO one-at-a-time
@@ -17,12 +27,10 @@ import {
 // stt-service.ts. The default spawn + shared singleton live in
 // session-scanner-opencode-sqlite-worker-spawn.ts.
 
-export const IDLE_TEARDOWN_MS = 30_000
 // Why: scan-owned fault state survives queue-empty batch gaps without affecting
 // overlapping scans.
 export const MAX_CONSECUTIVE_DEATHS = MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS
-
-export type WorkerFactory = () => Worker
+export const MAX_CONSECUTIVE_TIMEOUTS = MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS
 
 // Omit<union, 'id'> collapses to the shared keys, so omit each member and let
 // the client stamp the correlation id.
@@ -49,25 +57,29 @@ export class OpenCodeSqliteWorkerUnavailableError extends Error {}
 /**
  * Worker transport that runs OpenCode SQLite reads on a persistent worker
  * thread. Dispatches one request at a time (FIFO), times each request out from
- * dispatch, respawns after faults (capped by `MAX_CONSECUTIVE_DEATHS`), tears
- * the worker down after `IDLE_TEARDOWN_MS` of inactivity, and fails closed when
- * no worker can be spawned rather than moving SQLite work onto the main thread.
+ * dispatch, respawns after faults (capped separately by `MAX_CONSECUTIVE_DEATHS`
+ * and `MAX_CONSECUTIVE_TIMEOUTS`) once the previous thread is confirmed dead,
+ * tears the worker down after `IDLE_TEARDOWN_MS` of inactivity, and fails closed
+ * when no worker can be spawned rather than moving SQLite work onto the main
+ * thread. The instance is shared across concurrent scans, so every failure path
+ * is scoped to the calls it actually owns.
  */
 export class OpenCodeSqliteWorkerTransport {
-  private worker: Worker | null = null
   private active: PendingCall | null = null
   private queue: PendingCall[] = []
-  private idleTimer: NodeJS.Timeout | null = null
   private nextId = 1
-  private loggedWorkerUnavailable = false
-  private cleanupWorkerListeners: (() => void) | null = null
   private readonly contextAbortListeners = new Map<OpenCodeSqliteScanContext, () => void>()
-  private readonly workerFactory: WorkerFactory
-  private readonly log: (message: string) => void
+  private readonly handle: OpenCodeSqliteWorkerHandle
 
   constructor(options: { workerFactory: WorkerFactory; log?: (message: string) => void }) {
-    this.workerFactory = options.workerFactory
-    this.log = options.log ?? ((message) => console.warn(message))
+    this.handle = new OpenCodeSqliteWorkerHandle({
+      workerFactory: options.workerFactory,
+      log: options.log ?? ((message) => console.warn(message)),
+      onMessage: (response) => this.onMessage(response),
+      onFault: (error) => this.onWorkerFault(error),
+      onExit: (code) => this.onWorkerExit(code),
+      onTeardownSettled: () => this.pump()
+    })
   }
 
   dispatch(
@@ -102,9 +114,14 @@ export class OpenCodeSqliteWorkerTransport {
     if (this.active || this.queue.length === 0) {
       return
     }
-    const worker = this.ensureWorker()
+    // A replacement thread must not start until the previous one is confirmed
+    // dead; the teardown re-pumps once it settles.
+    if (this.handle.isTearingDown) {
+      return
+    }
+    const worker = this.handle.ensure()
     if (!worker) {
-      this.failQueuedAsUnavailable()
+      this.failHeadAsUnavailable()
       return
     }
     const call = this.queue.shift()
@@ -112,7 +129,7 @@ export class OpenCodeSqliteWorkerTransport {
       return
     }
     this.active = call
-    this.clearIdleTimer()
+    this.handle.clearIdleTimer()
     call.activeAtMs = Date.now()
     this.recordQueueWait(call, call.activeAtMs)
     // Timeout clock starts at dispatch (not enqueue): a batch may enqueue up to
@@ -123,39 +140,6 @@ export class OpenCodeSqliteWorkerTransport {
       worker.postMessage(call.request)
     } catch (err) {
       this.onWorkerFault(err instanceof Error ? err : new Error(String(err)))
-    }
-  }
-
-  private ensureWorker(): Worker | null {
-    if (this.worker) {
-      return this.worker
-    }
-    try {
-      const worker = this.workerFactory()
-      const onMessage = (response: OpenCodeSqliteWorkerResponse): void => this.onMessage(response)
-      const onError = (error: Error): void => this.onWorkerFault(error)
-      const onExit = (code: number): void => this.onWorkerExit(code)
-      worker.on('message', onMessage)
-      worker.on('error', onError)
-      worker.on('exit', onExit)
-      this.cleanupWorkerListeners = () => {
-        worker.off('message', onMessage)
-        worker.off('error', onError)
-        worker.off('exit', onExit)
-      }
-      // Never keep the app alive for a scan worker.
-      worker.unref?.()
-      this.worker = worker
-      return worker
-    } catch (err) {
-      // Why (#8864): never fall back to synchronous SQLite reads here; a missing
-      // bundle or resource-exhausted spawn must omit OpenCode history rather than
-      // reintroduce the main-process hang this worker boundary prevents.
-      if (!this.loggedWorkerUnavailable) {
-        this.loggedWorkerUnavailable = true
-        this.log(`OpenCode SQLite worker unavailable; skipping its history. ${errorMessage(err)}`)
-      }
-      return null
     }
   }
 
@@ -174,18 +158,34 @@ export class OpenCodeSqliteWorkerTransport {
     this.afterSettle()
   }
 
+  // A timeout is not a death: the thread is very likely still alive and grinding
+  // through a slow query. It still costs us the worker (we cannot cancel the
+  // query, so the thread is unusable), but it is counted and reported separately
+  // so a merely-slow database is never described to the user as a crash.
   private onTimeout(call: PendingCall): void {
     if (this.active !== call) {
       return
     }
-    this.onWorkerFault(new Error(`OpenCode SQLite worker timed out after ${call.timeoutMs}ms`))
+    const error = new Error(`OpenCode SQLite worker timed out after ${call.timeoutMs}ms`)
+    const failed = call
+    this.handle.destroy()
+    const shouldTrip = failed.context.noteWorkerTimeout()
+    this.settle(failed, () => failed.reject(error))
+    if (shouldTrip) {
+      failed.context.tripTimeoutCircuit(error)
+      return
+    }
+    this.releaseContextAbortListenerIfUnused(failed.context)
+    if (this.queue.length > 0) {
+      this.pump()
+    }
   }
 
   private onWorkerExit(code: number): void {
     // A clean self-exit is not a death, but the stale handle must be dropped
     // or the next dispatch would post into the dead worker and stall to timeout.
     if (code === 0 && !this.active && this.queue.length === 0) {
-      this.destroyWorker()
+      this.handle.destroy()
       return
     }
     this.onWorkerFault(new Error(`OpenCode SQLite worker exited with code ${code}`))
@@ -193,7 +193,7 @@ export class OpenCodeSqliteWorkerTransport {
 
   private onWorkerFault(error: Error): void {
     const failed = this.active
-    this.destroyWorker()
+    this.handle.destroy()
     const shouldTrip = failed?.context.noteWorkerDeath() ?? false
     if (failed) {
       this.settle(failed, () => failed.reject(error))
@@ -210,16 +210,22 @@ export class OpenCodeSqliteWorkerTransport {
     }
   }
 
-  private failQueuedAsUnavailable(): void {
-    const pending = this.queue
-    this.queue = []
-    for (const call of pending) {
-      this.settle(call, () =>
-        call.reject(new OpenCodeSqliteWorkerUnavailableError('worker spawn failed'))
-      )
+  // Why: the transport is shared by every concurrent scan. Draining the whole
+  // queue on one spawn failure would let a single transient failure erase every
+  // in-flight scan's OpenCode history, so only the head call is failed and the
+  // next pump re-tries the factory for whoever is behind it.
+  private failHeadAsUnavailable(): void {
+    const call = this.queue.shift()
+    if (!call) {
+      return
     }
-    for (const call of pending) {
-      this.releaseContextAbortListenerIfUnused(call.context)
+    noteOpenCodeSqliteScanHardFailure()
+    this.settle(call, () =>
+      call.reject(new OpenCodeSqliteWorkerUnavailableError('worker spawn failed'))
+    )
+    this.releaseContextAbortListenerIfUnused(call.context)
+    if (this.queue.length > 0) {
+      this.pump()
     }
   }
 
@@ -242,19 +248,18 @@ export class OpenCodeSqliteWorkerTransport {
     if (this.contextAbortListeners.has(context)) {
       return
     }
+    // `dispatch` rejects an already-terminated context before enqueueing, so the
+    // signal is always live here.
     const onAbort = (): void => this.onContextAbort(context)
     this.contextAbortListeners.set(context, onAbort)
     context.signal.addEventListener('abort', onAbort, { once: true })
-    if (context.signal.aborted) {
-      this.onContextAbort(context)
-    }
   }
 
   private onContextAbort(context: OpenCodeSqliteScanContext): void {
     const error = context.terminationError()
     if (this.active?.context === context) {
       const active = this.active
-      this.destroyWorker()
+      this.handle.destroy()
       context.markWorkOmitted()
       this.settle(active, () => active.reject(error))
     }
@@ -301,47 +306,10 @@ export class OpenCodeSqliteWorkerTransport {
   private afterSettle(): void {
     if (this.queue.length > 0) {
       this.pump()
-    } else {
-      this.scheduleIdleTeardown()
-    }
-  }
-
-  private scheduleIdleTeardown(): void {
-    this.clearIdleTimer()
-    if (!this.worker) {
       return
     }
-    this.idleTimer = setTimeout(() => this.teardownIfIdle(), IDLE_TEARDOWN_MS)
-    this.idleTimer.unref?.()
-  }
-
-  private teardownIfIdle(): void {
-    this.idleTimer = null
     // Only tear down with nothing active AND nothing queued: a request arriving
     // as the timer fires must never be lost to a self-exiting worker.
-    if (this.active || this.queue.length > 0) {
-      return
-    }
-    this.destroyWorker()
-  }
-
-  private clearIdleTimer(): void {
-    if (this.idleTimer) {
-      clearTimeout(this.idleTimer)
-      this.idleTimer = null
-    }
-  }
-
-  private destroyWorker(): void {
-    this.clearIdleTimer()
-    const worker = this.worker
-    this.worker = null
-    if (!worker) {
-      return
-    }
-    this.cleanupWorkerListeners?.()
-    this.cleanupWorkerListeners = null
-    worker.removeAllListeners()
-    void worker.terminate().catch(() => undefined)
+    this.handle.scheduleIdleTeardown(() => !this.active && this.queue.length === 0)
   }
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-transport.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-transport.ts
@@ -54,6 +54,16 @@ type PendingCall = {
 // Distinguishes "no worker available at all" from a timeout or crash so callers
 // can surface a precise issue while keeping synchronous SQLite off the main thread.
 export class OpenCodeSqliteWorkerUnavailableError extends Error {}
+export class OpenCodeSqliteWorkerTimeoutError extends Error {}
+export class OpenCodeSqliteWorkerFaultError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: Error
+  ) {
+    super(message)
+    this.name = 'OpenCodeSqliteWorkerFaultError'
+  }
+}
 
 /**
  * Worker transport that runs OpenCode SQLite reads on a persistent worker
@@ -150,6 +160,9 @@ export class OpenCodeSqliteWorkerTransport {
       return
     }
     call.context.noteWorkerResponse()
+    if (call.request.kind === 'parse' && response.ok) {
+      call.context.noteParseResponse()
+    }
     if (response.ok) {
       this.settle(call, () => call.resolve(response.value))
     } else {
@@ -167,7 +180,9 @@ export class OpenCodeSqliteWorkerTransport {
     if (this.active !== call) {
       return
     }
-    const error = new Error(`OpenCode SQLite worker timed out after ${call.timeoutMs}ms`)
+    const error = new OpenCodeSqliteWorkerTimeoutError(
+      `OpenCode SQLite worker timed out after ${call.timeoutMs}ms`
+    )
     const failed = call
     this.handle.destroy()
     const shouldTrip = failed.context.noteWorkerTimeout()
@@ -197,7 +212,9 @@ export class OpenCodeSqliteWorkerTransport {
     this.handle.destroy()
     const shouldTrip = failed?.context.noteWorkerDeath() ?? false
     if (failed) {
-      this.settle(failed, () => failed.reject(error))
+      this.settle(failed, () =>
+        failed.reject(new OpenCodeSqliteWorkerFaultError(error.message, error))
+      )
     }
     if (failed && shouldTrip) {
       failed.context.tripCircuit(error)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-transport.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-transport.ts
@@ -1,0 +1,347 @@
+import type { Worker } from 'node:worker_threads'
+import type {
+  OpenCodeSqliteListRequest,
+  OpenCodeSqliteParseRequest,
+  OpenCodeSqliteWorkerRequest,
+  OpenCodeSqliteWorkerResponse
+} from './session-scanner-opencode-sqlite-worker-protocol'
+import { errorMessage } from './session-scanner-values'
+import {
+  MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS,
+  type OpenCodeSqliteScanContext
+} from './session-scanner-opencode-sqlite-scan-context'
+
+// Why (#8864): a lazily-spawned, unref'd worker runs OpenCode SQLite reads off
+// the main-process event loop. Lifecycle (idle teardown, FIFO one-at-a-time
+// dispatch, per-call timeouts, respawn-on-fault) mirrors src/main/speech/
+// stt-service.ts. The default spawn + shared singleton live in
+// session-scanner-opencode-sqlite-worker-spawn.ts.
+
+export const IDLE_TEARDOWN_MS = 30_000
+// Why: scan-owned fault state survives queue-empty batch gaps without affecting
+// overlapping scans.
+export const MAX_CONSECUTIVE_DEATHS = MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS
+
+export type WorkerFactory = () => Worker
+
+// Omit<union, 'id'> collapses to the shared keys, so omit each member and let
+// the client stamp the correlation id.
+type OpenCodeSqliteRequestBody =
+  | Omit<OpenCodeSqliteListRequest, 'id'>
+  | Omit<OpenCodeSqliteParseRequest, 'id'>
+
+type PendingCall = {
+  request: OpenCodeSqliteWorkerRequest
+  context: OpenCodeSqliteScanContext
+  enqueuedAtMs: number
+  queueWaitRecorded: boolean
+  activeAtMs: number | null
+  timeoutMs: number
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  timer: NodeJS.Timeout | null
+}
+
+// Distinguishes "no worker available at all" from a timeout or crash so callers
+// can surface a precise issue while keeping synchronous SQLite off the main thread.
+export class OpenCodeSqliteWorkerUnavailableError extends Error {}
+
+/**
+ * Worker transport that runs OpenCode SQLite reads on a persistent worker
+ * thread. Dispatches one request at a time (FIFO), times each request out from
+ * dispatch, respawns after faults (capped by `MAX_CONSECUTIVE_DEATHS`), tears
+ * the worker down after `IDLE_TEARDOWN_MS` of inactivity, and fails closed when
+ * no worker can be spawned rather than moving SQLite work onto the main thread.
+ */
+export class OpenCodeSqliteWorkerTransport {
+  private worker: Worker | null = null
+  private active: PendingCall | null = null
+  private queue: PendingCall[] = []
+  private idleTimer: NodeJS.Timeout | null = null
+  private nextId = 1
+  private loggedWorkerUnavailable = false
+  private cleanupWorkerListeners: (() => void) | null = null
+  private readonly contextAbortListeners = new Map<OpenCodeSqliteScanContext, () => void>()
+  private readonly workerFactory: WorkerFactory
+  private readonly log: (message: string) => void
+
+  constructor(options: { workerFactory: WorkerFactory; log?: (message: string) => void }) {
+    this.workerFactory = options.workerFactory
+    this.log = options.log ?? ((message) => console.warn(message))
+  }
+
+  dispatch(
+    request: OpenCodeSqliteRequestBody,
+    timeoutMs: number,
+    context: OpenCodeSqliteScanContext
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      if (context.isTerminated) {
+        context.markWorkOmitted()
+        reject(context.terminationError())
+        return
+      }
+      const id = this.nextId++
+      this.queue.push({
+        request: { ...request, id } as OpenCodeSqliteWorkerRequest,
+        context,
+        enqueuedAtMs: Date.now(),
+        queueWaitRecorded: false,
+        activeAtMs: null,
+        timeoutMs,
+        resolve,
+        reject,
+        timer: null
+      })
+      this.ensureContextAbortListener(context)
+      this.pump()
+    })
+  }
+
+  private pump(): void {
+    if (this.active || this.queue.length === 0) {
+      return
+    }
+    const worker = this.ensureWorker()
+    if (!worker) {
+      this.failQueuedAsUnavailable()
+      return
+    }
+    const call = this.queue.shift()
+    if (!call) {
+      return
+    }
+    this.active = call
+    this.clearIdleTimer()
+    call.activeAtMs = Date.now()
+    this.recordQueueWait(call, call.activeAtMs)
+    // Timeout clock starts at dispatch (not enqueue): a batch may enqueue up to
+    // 8 parses at once, and a queue-inclusive timeout would fire falsely.
+    call.timer = setTimeout(() => this.onTimeout(call), call.timeoutMs)
+    call.timer.unref?.()
+    try {
+      worker.postMessage(call.request)
+    } catch (err) {
+      this.onWorkerFault(err instanceof Error ? err : new Error(String(err)))
+    }
+  }
+
+  private ensureWorker(): Worker | null {
+    if (this.worker) {
+      return this.worker
+    }
+    try {
+      const worker = this.workerFactory()
+      const onMessage = (response: OpenCodeSqliteWorkerResponse): void => this.onMessage(response)
+      const onError = (error: Error): void => this.onWorkerFault(error)
+      const onExit = (code: number): void => this.onWorkerExit(code)
+      worker.on('message', onMessage)
+      worker.on('error', onError)
+      worker.on('exit', onExit)
+      this.cleanupWorkerListeners = () => {
+        worker.off('message', onMessage)
+        worker.off('error', onError)
+        worker.off('exit', onExit)
+      }
+      // Never keep the app alive for a scan worker.
+      worker.unref?.()
+      this.worker = worker
+      return worker
+    } catch (err) {
+      // Why (#8864): never fall back to synchronous SQLite reads here; a missing
+      // bundle or resource-exhausted spawn must omit OpenCode history rather than
+      // reintroduce the main-process hang this worker boundary prevents.
+      if (!this.loggedWorkerUnavailable) {
+        this.loggedWorkerUnavailable = true
+        this.log(`OpenCode SQLite worker unavailable; skipping its history. ${errorMessage(err)}`)
+      }
+      return null
+    }
+  }
+
+  private onMessage(response: OpenCodeSqliteWorkerResponse): void {
+    const call = this.active
+    if (!call || call.request.id !== response.id) {
+      return
+    }
+    call.context.noteWorkerResponse()
+    if (response.ok) {
+      this.settle(call, () => call.resolve(response.value))
+    } else {
+      this.settle(call, () => call.reject(new Error(response.error)))
+    }
+    this.releaseContextAbortListenerIfUnused(call.context)
+    this.afterSettle()
+  }
+
+  private onTimeout(call: PendingCall): void {
+    if (this.active !== call) {
+      return
+    }
+    this.onWorkerFault(new Error(`OpenCode SQLite worker timed out after ${call.timeoutMs}ms`))
+  }
+
+  private onWorkerExit(code: number): void {
+    // A clean self-exit is not a death, but the stale handle must be dropped
+    // or the next dispatch would post into the dead worker and stall to timeout.
+    if (code === 0 && !this.active && this.queue.length === 0) {
+      this.destroyWorker()
+      return
+    }
+    this.onWorkerFault(new Error(`OpenCode SQLite worker exited with code ${code}`))
+  }
+
+  private onWorkerFault(error: Error): void {
+    const failed = this.active
+    this.destroyWorker()
+    const shouldTrip = failed?.context.noteWorkerDeath() ?? false
+    if (failed) {
+      this.settle(failed, () => failed.reject(error))
+    }
+    if (failed && shouldTrip) {
+      failed.context.tripCircuit(error)
+      return
+    }
+    if (failed) {
+      this.releaseContextAbortListenerIfUnused(failed.context)
+    }
+    if (this.queue.length > 0) {
+      this.pump()
+    }
+  }
+
+  private failQueuedAsUnavailable(): void {
+    const pending = this.queue
+    this.queue = []
+    for (const call of pending) {
+      this.settle(call, () =>
+        call.reject(new OpenCodeSqliteWorkerUnavailableError('worker spawn failed'))
+      )
+    }
+    for (const call of pending) {
+      this.releaseContextAbortListenerIfUnused(call.context)
+    }
+  }
+
+  private settle(call: PendingCall, run: () => void): void {
+    if (call.timer) {
+      clearTimeout(call.timer)
+      call.timer = null
+    }
+    if (call.activeAtMs !== null) {
+      call.context.noteActiveWorker(Date.now() - call.activeAtMs)
+      call.activeAtMs = null
+    }
+    if (this.active === call) {
+      this.active = null
+    }
+    run()
+  }
+
+  private ensureContextAbortListener(context: OpenCodeSqliteScanContext): void {
+    if (this.contextAbortListeners.has(context)) {
+      return
+    }
+    const onAbort = (): void => this.onContextAbort(context)
+    this.contextAbortListeners.set(context, onAbort)
+    context.signal.addEventListener('abort', onAbort, { once: true })
+    if (context.signal.aborted) {
+      this.onContextAbort(context)
+    }
+  }
+
+  private onContextAbort(context: OpenCodeSqliteScanContext): void {
+    const error = context.terminationError()
+    if (this.active?.context === context) {
+      const active = this.active
+      this.destroyWorker()
+      context.markWorkOmitted()
+      this.settle(active, () => active.reject(error))
+    }
+    const retained: PendingCall[] = []
+    for (const call of this.queue) {
+      if (call.context === context) {
+        context.markWorkOmitted()
+        this.recordQueueWait(call, Date.now())
+        this.settle(call, () => call.reject(error))
+      } else {
+        retained.push(call)
+      }
+    }
+    this.queue = retained
+    this.releaseContextAbortListener(context)
+    if (!this.active && this.queue.length > 0) {
+      this.pump()
+    }
+  }
+
+  private releaseContextAbortListenerIfUnused(context: OpenCodeSqliteScanContext): void {
+    if (this.active?.context !== context && !this.queue.some((call) => call.context === context)) {
+      this.releaseContextAbortListener(context)
+    }
+  }
+
+  private recordQueueWait(call: PendingCall, settledAtMs: number): void {
+    if (call.queueWaitRecorded) {
+      return
+    }
+    call.queueWaitRecorded = true
+    call.context.noteQueueWait(settledAtMs - call.enqueuedAtMs)
+  }
+
+  private releaseContextAbortListener(context: OpenCodeSqliteScanContext): void {
+    const listener = this.contextAbortListeners.get(context)
+    if (!listener) {
+      return
+    }
+    context.signal.removeEventListener('abort', listener)
+    this.contextAbortListeners.delete(context)
+  }
+
+  private afterSettle(): void {
+    if (this.queue.length > 0) {
+      this.pump()
+    } else {
+      this.scheduleIdleTeardown()
+    }
+  }
+
+  private scheduleIdleTeardown(): void {
+    this.clearIdleTimer()
+    if (!this.worker) {
+      return
+    }
+    this.idleTimer = setTimeout(() => this.teardownIfIdle(), IDLE_TEARDOWN_MS)
+    this.idleTimer.unref?.()
+  }
+
+  private teardownIfIdle(): void {
+    this.idleTimer = null
+    // Only tear down with nothing active AND nothing queued: a request arriving
+    // as the timer fires must never be lost to a self-exiting worker.
+    if (this.active || this.queue.length > 0) {
+      return
+    }
+    this.destroyWorker()
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer)
+      this.idleTimer = null
+    }
+  }
+
+  private destroyWorker(): void {
+    this.clearIdleTimer()
+    const worker = this.worker
+    this.worker = null
+    if (!worker) {
+      return
+    }
+    this.cleanupWorkerListeners?.()
+    this.cleanupWorkerListeners = null
+    worker.removeAllListeners()
+    void worker.terminate().catch(() => undefined)
+  }
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-transport.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-transport.ts
@@ -7,9 +7,9 @@ import type {
 import {
   MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS,
   MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS,
+  MAX_CONSECUTIVE_OPENCODE_WORKER_UNAVAILABLE,
   type OpenCodeSqliteScanContext
 } from './session-scanner-opencode-sqlite-scan-context'
-import { noteOpenCodeSqliteScanHardFailure } from './session-scanner-opencode-sqlite-scan-cooldown'
 import {
   OpenCodeSqliteWorkerHandle,
   type WorkerFactory
@@ -31,6 +31,7 @@ export {
 // overlapping scans.
 export const MAX_CONSECUTIVE_DEATHS = MAX_CONSECUTIVE_OPENCODE_WORKER_DEATHS
 export const MAX_CONSECUTIVE_TIMEOUTS = MAX_CONSECUTIVE_OPENCODE_WORKER_TIMEOUTS
+export const MAX_CONSECUTIVE_UNAVAILABLE = MAX_CONSECUTIVE_OPENCODE_WORKER_UNAVAILABLE
 
 // Omit<union, 'id'> collapses to the shared keys, so omit each member and let
 // the client stamp the correlation id.
@@ -213,16 +214,23 @@ export class OpenCodeSqliteWorkerTransport {
   // Why: the transport is shared by every concurrent scan. Draining the whole
   // queue on one spawn failure would let a single transient failure erase every
   // in-flight scan's OpenCode history, so only the head call is failed and the
-  // next pump re-tries the factory for whoever is behind it.
+  // next pump re-tries the factory for whoever is behind it. The owning scan
+  // still counts the failure, so a worker that never spawns gives up after
+  // MAX_CONSECUTIVE_UNAVAILABLE instead of being retried once per candidate.
   private failHeadAsUnavailable(): void {
     const call = this.queue.shift()
     if (!call) {
       return
     }
-    noteOpenCodeSqliteScanHardFailure()
-    this.settle(call, () =>
-      call.reject(new OpenCodeSqliteWorkerUnavailableError('worker spawn failed'))
-    )
+    const error = new OpenCodeSqliteWorkerUnavailableError('worker spawn failed')
+    const shouldTrip = call.context.noteWorkerUnavailable()
+    this.settle(call, () => call.reject(error))
+    if (shouldTrip) {
+      // Arms the process-wide backoff and terminates the scan, so end-of-scan
+      // bookkeeping cannot mistake it for a clean run and clear the backoff.
+      call.context.tripUnavailableCircuit(error)
+      return
+    }
     this.releaseContextAbortListenerIfUnused(call.context)
     if (this.queue.length > 0) {
       this.pump()

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -144,6 +144,31 @@ export function seedSessionParseCache(
   }
 }
 
+function isEntryUnchanged(
+  entry: SessionParseCacheEntry | undefined,
+  candidate: SessionFileCandidate,
+  platform: NodeJS.Platform
+): boolean {
+  const { file } = candidate
+  return (
+    entry?.platform === platform &&
+    entry.mtimeMs === file.mtimeMs &&
+    (entry.sizeBytes === null || file.sizeBytes === undefined || entry.sizeBytes === file.sizeBytes)
+  )
+}
+
+/**
+ * Whether this candidate would be served straight from the in-memory cache, i.e.
+ * without touching its store. Callers that gate expensive parses (the OpenCode
+ * SQLite budget) use this so a spent budget never hides an already-parsed row.
+ */
+export function hasFreshSessionParseCacheEntry(
+  candidate: SessionFileCandidate,
+  platform: NodeJS.Platform
+): boolean {
+  return isEntryUnchanged(cache.get(candidate.file.path), candidate, platform)
+}
+
 function storeEntry(path: string, entry: SessionParseCacheEntry): void {
   cache.delete(path)
   cache.set(path, entry)
@@ -173,11 +198,7 @@ export async function parseAgentSessionFileCached(
   const { file } = candidate
   const entry = cache.get(file.path)
 
-  const unchanged =
-    entry?.platform === platform &&
-    entry.mtimeMs === file.mtimeMs &&
-    (entry.sizeBytes === null || file.sizeBytes === undefined || entry.sizeBytes === file.sizeBytes)
-  if (unchanged) {
+  if (entry !== undefined && isEntryUnchanged(entry, candidate, platform)) {
     if (stats) {
       stats.reused++
     }
@@ -208,11 +229,13 @@ export async function parseAgentSessionFileCached(
     return parsed.session
   }
 
+  // Counted after the parse: a cancelled OpenCode SQLite parse throws, and work
+  // that never happened must not show up as bytes this scan read.
+  const session = await parseAgentSessionFile(candidate, platform, opencodeSqliteScanContext)
   if (stats) {
     stats.fullParses++
     stats.bytesRead += file.sizeBytes ?? 0
   }
-  const session = await parseAgentSessionFile(candidate, platform, opencodeSqliteScanContext)
   storeEntry(file.path, {
     mtimeMs: file.mtimeMs,
     sizeBytes: file.sizeBytes ?? null,

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -174,8 +174,7 @@ export async function parseAgentSessionFileCached(
   const entry = cache.get(file.path)
 
   const unchanged =
-    entry !== undefined &&
-    entry.platform === platform &&
+    entry?.platform === platform &&
     entry.mtimeMs === file.mtimeMs &&
     (entry.sizeBytes === null || file.sizeBytes === undefined || entry.sizeBytes === file.sizeBytes)
   if (unchanged) {

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -169,6 +169,11 @@ export function hasFreshSessionParseCacheEntry(
   return isEntryUnchanged(cache.get(candidate.file.path), candidate, platform)
 }
 
+/** Live read-only view of cached entries, in LRU order (oldest first). */
+export function sessionParseCacheEntries(): Iterable<[string, PersistedSessionParseCacheEntry]> {
+  return cache.entries()
+}
+
 function storeEntry(path: string, entry: SessionParseCacheEntry): void {
   cache.delete(path)
   cache.set(path, entry)

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -14,10 +14,11 @@ import {
 } from './session-scanner-secondary-parsers'
 import { countSubagentTranscripts } from './session-scanner-subagent-transcripts'
 import type { ResumableSessionParseState, SessionFileCandidate } from './session-scanner-types'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 // Sized past the default recency cap (1000) plus the in-scope cap (2000) so a
 // full steady-state result set stays resident between forced rescans.
-const MAX_CACHE_ENTRIES = 4096
+export const MAX_CACHE_ENTRIES = 4096
 
 const NEWLINE_BYTE = 0x0a
 const CARRIAGE_RETURN_BYTE = 0x0d
@@ -166,7 +167,8 @@ function storeEntry(path: string, entry: SessionParseCacheEntry): void {
 export async function parseAgentSessionFileCached(
   candidate: SessionFileCandidate,
   platform: NodeJS.Platform,
-  stats?: SessionParseStats
+  stats?: SessionParseStats,
+  opencodeSqliteScanContext?: OpenCodeSqliteScanContext
 ): Promise<AiVaultSession | null> {
   const { file } = candidate
   const entry = cache.get(file.path)
@@ -211,7 +213,7 @@ export async function parseAgentSessionFileCached(
     stats.fullParses++
     stats.bytesRead += file.sizeBytes ?? 0
   }
-  const session = await parseAgentSessionFile(candidate, platform)
+  const session = await parseAgentSessionFile(candidate, platform, opencodeSqliteScanContext)
   storeEntry(file.path, {
     mtimeMs: file.mtimeMs,
     sizeBytes: file.sizeBytes ?? null,

--- a/src/main/ai-vault/session-scanner-session-merge.ts
+++ b/src/main/ai-vault/session-scanner-session-merge.ts
@@ -1,0 +1,19 @@
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { sessionSortTime } from './session-scanner-accumulator'
+
+export function mergeSessions(
+  cappedSessions: AiVaultSession[],
+  scopeSessions: AiVaultSession[]
+): AiVaultSession[] {
+  if (scopeSessions.length === 0) {
+    return cappedSessions
+  }
+  const byId = new Map<string, AiVaultSession>()
+  for (const session of cappedSessions) {
+    byId.set(session.id, session)
+  }
+  for (const session of scopeSessions) {
+    byId.set(session.id, session)
+  }
+  return [...byId.values()].sort((left, right) => sessionSortTime(right) - sessionSortTime(left))
+}

--- a/src/main/ai-vault/session-scanner-source-discovery.ts
+++ b/src/main/ai-vault/session-scanner-source-discovery.ts
@@ -10,6 +10,7 @@ import type { AiVaultScanOptions, SessionFileDiscovery } from './session-scanner
 import { normalizeAgentSessionsDir } from './session-scanner-values'
 import { resolveGrokSessionsDir } from '../../shared/grok-session-paths'
 import { antigravityDiscoveries } from './session-scanner-antigravity-sources'
+import type { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), '.claude', 'projects')
 export const DEFAULT_CODEX_HOME_DIR = join(homedir(), '.codex')
@@ -54,6 +55,7 @@ export async function discoverAiVaultSessionSources(args: {
   options: AiVaultScanOptions
   limitPerAgent: number
   issues: AiVaultScanIssue[]
+  opencodeSqliteScanContext: OpenCodeSqliteScanContext
 }): Promise<SessionFileDiscovery[]> {
   const { options, limitPerAgent, issues } = args
   const wslHomeDirs = normalizedWslHomeDirs(options.wslHomeDirs)
@@ -72,7 +74,13 @@ export async function discoverAiVaultSessionSources(args: {
     // Why: OpenCode 1.17.x migrated sessions from per-session JSON files to a
     // SQLite DB. discoverOpenCodeSessions runs both the file scanner (legacy)
     // and the SQLite scanner (1.17.x); dedup by sessionId happens inside.
-    ...opencodeDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
+    ...opencodeDiscoveries(
+      options,
+      wslHomeDirs,
+      limitPerAgent,
+      issues,
+      args.opencodeSqliteScanContext
+    ),
     ...claudeDiscoveries(options, wslHomeDirs, limitPerAgent, issues),
     ...codexDiscoveries(codexSessionsDirs, limitPerAgent, issues),
     ...standardDiscoveries(options, wslHomeDirs, limitPerAgent, issues),

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises'
 import type {
   AiVaultListResult,
   AiVaultScanIssue,
@@ -14,6 +13,7 @@ import {
 } from './codex-session-root-dedup'
 import {
   createAntigravityWorkspaceResolver,
+  readOptionalAntigravityHistoryFile,
   type AntigravityWorkspaceResolver
 } from './session-scanner-antigravity-history'
 import { antigravityHistoryPathForBrainDir } from './session-scanner-antigravity-paths'
@@ -39,6 +39,14 @@ import type {
   SessionParseResult
 } from './session-scanner-types'
 import { clampPositiveInteger, errorMessage } from './session-scanner-values'
+import {
+  isOpenCodeSqliteScanTerminatedError,
+  OpenCodeSqliteScanContext
+} from './session-scanner-opencode-sqlite-scan-context'
+import { recordOpenCodeSqliteScanOutcome } from './session-scanner-opencode-sqlite-scan-outcome'
+import { OpenCodeSqliteCandidatePhase } from './session-scanner-opencode-sqlite-candidate-phase'
+import { withSessionExecutionHost } from './session-scanner-execution-host'
+import { mergeSessions } from './session-scanner-session-merge'
 
 const DEFAULT_LIMIT = 1000
 const DEFAULT_SCAN_LIMIT_PER_AGENT = 1000
@@ -63,107 +71,111 @@ export async function scanAiVaultSessions(
   // "one core pegged" reports need to show whether transcript scanning is the
   // subsystem burning CPU, and how much of each scan the cache absorbed.
   return withSpan('aiVault.scan', async (span) => {
-    const limit = clampPositiveInteger(options.limit, DEFAULT_LIMIT)
-    const limitPerAgent = clampPositiveInteger(options.limitPerAgent, DEFAULT_SCAN_LIMIT_PER_AGENT)
-    const platform = options.platform ?? process.platform
-    const executionHostId = options.executionHostId ?? LOCAL_EXECUTION_HOST_ID
-    const issues: AiVaultScanIssue[] = []
-    const parseStats = createSessionParseStats()
-    const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(readOptionalTextFile)
-    // Why: persisted entries must be seeded before any candidate is parsed, or
-    // the cold scan gains nothing from the cache file (#9210).
-    await ensureSessionParseCacheLoaded()
-    const discoveries = await discoverAiVaultSessionSources({ options, limitPerAgent, issues })
+    const opencodeSqliteScanContext = new OpenCodeSqliteScanContext()
+    try {
+      const limit = clampPositiveInteger(options.limit, DEFAULT_LIMIT)
+      const limitPerAgent = clampPositiveInteger(
+        options.limitPerAgent,
+        DEFAULT_SCAN_LIMIT_PER_AGENT
+      )
+      const platform = options.platform ?? process.platform
+      const executionHostId = options.executionHostId ?? LOCAL_EXECUTION_HOST_ID
+      const issues: AiVaultScanIssue[] = []
+      const parseStats = createSessionParseStats()
+      const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(
+        readOptionalAntigravityHistoryFile
+      )
+      // Why: persisted entries must be seeded before any candidate is parsed, or
+      // the cold scan gains nothing from the cache file (#9210).
+      await ensureSessionParseCacheLoaded()
+      const discoveries = await discoverAiVaultSessionSources({
+        options,
+        limitPerAgent,
+        issues,
+        opencodeSqliteScanContext
+      })
 
-    const candidates = dedupeCodexRolloutFileAliases(
-      discoveries
-        .flatMap((discovery) =>
-          discovery.files.map(
-            (file): SessionFileCandidate => ({
-              agent: discovery.agent,
-              file,
-              codexHome:
-                discovery.agent === 'codex'
-                  ? codexHomeForSessionsDir(
-                      discovery.rootDir,
-                      options.defaultCodexHomeDir ?? DEFAULT_CODEX_HOME_DIR
-                    )
-                  : null,
-              antigravityHistoryPath:
-                discovery.agent === 'antigravity'
-                  ? antigravityHistoryPathForBrainDir(discovery.rootDir)
-                  : undefined
-            })
+      const candidates = dedupeCodexRolloutFileAliases(
+        discoveries
+          .flatMap((discovery) =>
+            discovery.files.map(
+              (file): SessionFileCandidate => ({
+                agent: discovery.agent,
+                file,
+                codexHome:
+                  discovery.agent === 'codex'
+                    ? codexHomeForSessionsDir(
+                        discovery.rootDir,
+                        options.defaultCodexHomeDir ?? DEFAULT_CODEX_HOME_DIR
+                      )
+                    : null,
+                antigravityHistoryPath:
+                  discovery.agent === 'antigravity'
+                    ? antigravityHistoryPathForBrainDir(discovery.rootDir)
+                    : undefined
+              })
+            )
           )
-        )
-        .sort((left, right) => right.file.mtimeMs - left.file.mtimeMs),
-      {
-        isCodex: (candidate) => candidate.agent === 'codex',
-        getFilePath: (candidate) => candidate.file.path,
-        getCodexHome: (candidate) => candidate.codexHome,
-        getHardlinkIdentity: (candidate) => codexRolloutHardlinkIdentity(candidate.file)
+          .sort((left, right) => right.file.mtimeMs - left.file.mtimeMs),
+        {
+          isCodex: (candidate) => candidate.agent === 'codex',
+          getFilePath: (candidate) => candidate.file.path,
+          getCodexHome: (candidate) => candidate.codexHome,
+          getHardlinkIdentity: (candidate) => codexRolloutHardlinkIdentity(candidate.file)
+        }
+      )
+
+      const parsedSessions = await parseSessionCandidates({
+        candidates,
+        limit,
+        platform,
+        executionHostId,
+        issues,
+        parseStats,
+        antigravityWorkspaceResolver,
+        opencodeSqliteScanContext
+      })
+      opencodeSqliteScanContext.disarmDeadline()
+
+      const cappedSessions = dedupeCodexSessionsBySessionId(parsedSessions)
+        .sort((left, right) => sessionSortTime(right) - sessionSortTime(left))
+        .slice(0, limit)
+
+      const scopeSessions = await scanInScopeSessions({
+        discoveries,
+        scopePaths: options.scopePaths ?? [],
+        alreadyParsedFilePaths: new Set(cappedSessions.map((session) => session.filePath)),
+        platform,
+        executionHostId,
+        issues,
+        parseStats
+      })
+
+      span.setAttribute('candidates', candidates.length)
+      span.setAttribute('reused', parseStats.reused)
+      span.setAttribute('incremental', parseStats.incremental)
+      span.setAttribute('fullParses', parseStats.fullParses)
+      span.setAttribute('bytesRead', parseStats.bytesRead)
+      recordOpenCodeSqliteScanOutcome({
+        candidates,
+        context: opencodeSqliteScanContext,
+        discoveries,
+        issues,
+        span
+      })
+      span.setAttribute('issues', issues.length)
+
+      scheduleSessionParseCachePersist(parseStats)
+
+      return {
+        sessions: mergeSessions(cappedSessions, scopeSessions),
+        issues: issues.map((issue) => ({ executionHostId, ...issue })),
+        scannedAt: new Date().toISOString()
       }
-    )
-
-    const parsedSessions = await parseSessionCandidates({
-      candidates,
-      limit,
-      platform,
-      executionHostId,
-      issues,
-      parseStats,
-      antigravityWorkspaceResolver
-    })
-
-    const cappedSessions = dedupeCodexSessionsBySessionId(parsedSessions)
-      .sort((left, right) => sessionSortTime(right) - sessionSortTime(left))
-      .slice(0, limit)
-
-    const scopeSessions = await scanInScopeSessions({
-      discoveries,
-      scopePaths: options.scopePaths ?? [],
-      alreadyParsedFilePaths: new Set(cappedSessions.map((session) => session.filePath)),
-      platform,
-      executionHostId,
-      issues,
-      parseStats
-    })
-
-    span.setAttribute('candidates', candidates.length)
-    span.setAttribute('reused', parseStats.reused)
-    span.setAttribute('incremental', parseStats.incremental)
-    span.setAttribute('fullParses', parseStats.fullParses)
-    span.setAttribute('bytesRead', parseStats.bytesRead)
-    span.setAttribute('issues', issues.length)
-
-    scheduleSessionParseCachePersist(parseStats)
-
-    return {
-      sessions: mergeSessions(cappedSessions, scopeSessions),
-      issues: issues.map((issue) => ({ executionHostId, ...issue })),
-      scannedAt: new Date().toISOString()
+    } finally {
+      opencodeSqliteScanContext.dispose()
     }
   })
-}
-
-// In-scope sessions are guaranteed regardless of the recency cap, so the global
-// (already capped) result and the scope result are unioned and de-duplicated by
-// session id, then re-sorted DESC.
-function mergeSessions(
-  cappedSessions: AiVaultSession[],
-  scopeSessions: AiVaultSession[]
-): AiVaultSession[] {
-  if (scopeSessions.length === 0) {
-    return cappedSessions
-  }
-  const byId = new Map<string, AiVaultSession>()
-  for (const session of cappedSessions) {
-    byId.set(session.id, session)
-  }
-  for (const session of scopeSessions) {
-    byId.set(session.id, session)
-  }
-  return [...byId.values()].sort((left, right) => sessionSortTime(right) - sessionSortTime(left))
 }
 
 async function scanInScopeSessions(args: {
@@ -213,9 +225,14 @@ async function parseSessionCandidates(args: {
   issues: AiVaultScanIssue[]
   parseStats: SessionParseStats
   antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
+  opencodeSqliteScanContext?: OpenCodeSqliteScanContext
 }): Promise<AiVaultSession[]> {
   const sessions: AiVaultSession[] = []
   let index = 0
+  const opencodePhase = new OpenCodeSqliteCandidatePhase(
+    args.candidates,
+    args.opencodeSqliteScanContext
+  )
 
   while (index < args.candidates.length) {
     if (canStopParsingSessions(sessions, args.limit, args.candidates[index]?.file.mtimeMs)) {
@@ -226,17 +243,20 @@ async function parseSessionCandidates(args: {
     const needed = Math.max(args.limit - sessions.length, 1)
     const batchSize = Math.min(SESSION_PARSE_CONCURRENCY, needed, remaining)
     const batch = args.candidates.slice(index, index + batchSize)
+    const parseableBatch = opencodePhase.prepareBatch(batch)
     const results = await Promise.all(
-      batch.map((candidate) =>
+      parseableBatch.map((candidate) =>
         parseSessionCandidate(
           candidate,
           args.platform,
           args.executionHostId,
           args.parseStats,
-          args.antigravityWorkspaceResolver
+          args.antigravityWorkspaceResolver,
+          args.opencodeSqliteScanContext
         )
       )
     )
+    opencodePhase.completeBatch()
 
     for (const result of results) {
       if (result.issue) {
@@ -255,6 +275,7 @@ async function parseSessionCandidates(args: {
     index += batchSize
   }
 
+  opencodePhase.finish()
   return sessions
 }
 
@@ -263,10 +284,16 @@ async function parseSessionCandidate(
   platform: NodeJS.Platform,
   executionHostId: ExecutionHostId,
   parseStats: SessionParseStats,
-  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
+  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver,
+  opencodeSqliteScanContext?: OpenCodeSqliteScanContext
 ): Promise<SessionParseResult> {
   try {
-    let session = await parseAgentSessionFileCached(candidate, platform, parseStats)
+    let session = await parseAgentSessionFileCached(
+      candidate,
+      platform,
+      parseStats,
+      opencodeSqliteScanContext
+    )
     if (session && candidate.antigravityHistoryPath && antigravityWorkspaceResolver) {
       session = await antigravityWorkspaceResolver.enrich(session, candidate.antigravityHistoryPath)
     }
@@ -275,6 +302,9 @@ async function parseSessionCandidate(
       issue: null
     }
   } catch (err) {
+    if (isOpenCodeSqliteScanTerminatedError(err)) {
+      return { session: null, issue: null }
+    }
     return {
       session: null,
       issue: {
@@ -284,28 +314,6 @@ async function parseSessionCandidate(
         message: errorMessage(err)
       }
     }
-  }
-}
-
-async function readOptionalTextFile(path: string): Promise<string | null> {
-  try {
-    return await readFile(path, 'utf-8')
-  } catch {
-    return null
-  }
-}
-
-function withSessionExecutionHost(
-  session: AiVaultSession,
-  executionHostId: ExecutionHostId
-): AiVaultSession {
-  if (session.executionHostId === executionHostId) {
-    return session
-  }
-  return {
-    ...session,
-    executionHostId,
-    id: `${executionHostId}:${session.agent}:${session.sessionId}:${session.filePath}`
   }
 }
 

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -244,19 +244,18 @@ async function parseSessionCandidates(args: {
     const batchSize = Math.min(SESSION_PARSE_CONCURRENCY, needed, remaining)
     const batch = args.candidates.slice(index, index + batchSize)
     const parseableBatch = opencodePhase.prepareBatch(batch)
-    const results = await Promise.all(
-      parseableBatch.map((candidate) =>
-        parseSessionCandidate(
-          candidate,
-          args.platform,
-          args.executionHostId,
-          args.parseStats,
-          args.antigravityWorkspaceResolver,
-          args.opencodeSqliteScanContext
-        )
+    const parsePromises = parseableBatch.map((candidate) =>
+      parseSessionCandidate(
+        candidate,
+        args.platform,
+        args.executionHostId,
+        args.parseStats,
+        args.antigravityWorkspaceResolver,
+        args.opencodeSqliteScanContext
       )
     )
-    opencodePhase.completeBatch()
+    opencodePhase.trackBatch(parseableBatch, parsePromises)
+    const results = await Promise.all(parsePromises)
 
     for (const result of results) {
       if (result.issue) {

--- a/src/main/ai-vault/session-scanner.ts
+++ b/src/main/ai-vault/session-scanner.ts
@@ -13,8 +13,7 @@ import {
 } from './codex-session-root-dedup'
 import {
   createAntigravityWorkspaceResolver,
-  readOptionalAntigravityHistoryFile,
-  type AntigravityWorkspaceResolver
+  readOptionalAntigravityHistoryFile
 } from './session-scanner-antigravity-history'
 import { antigravityHistoryPathForBrainDir } from './session-scanner-antigravity-paths'
 import { codexHomeForSessionsDir } from './session-scanner-codex-paths'
@@ -22,11 +21,8 @@ import {
   ensureSessionParseCacheLoaded,
   scheduleSessionParseCachePersist
 } from './session-parse-cache-persistence'
-import {
-  createSessionParseStats,
-  parseAgentSessionFileCached,
-  type SessionParseStats
-} from './session-scanner-parse-cache'
+import { createSessionParseStats, type SessionParseStats } from './session-scanner-parse-cache'
+import { parseSessionCandidates } from './session-scanner-candidate-parsing'
 import { discoverInScopeClaudeFiles } from './session-scanner-scope-discovery'
 import {
   DEFAULT_CODEX_HOME_DIR,
@@ -35,22 +31,16 @@ import {
 import type {
   AiVaultScanOptions,
   SessionFileCandidate,
-  SessionFileDiscovery,
-  SessionParseResult
+  SessionFileDiscovery
 } from './session-scanner-types'
-import { clampPositiveInteger, errorMessage } from './session-scanner-values'
-import {
-  isOpenCodeSqliteScanTerminatedError,
-  OpenCodeSqliteScanContext
-} from './session-scanner-opencode-sqlite-scan-context'
+import { clampPositiveInteger } from './session-scanner-values'
+import { OpenCodeSqliteScanContext } from './session-scanner-opencode-sqlite-scan-context'
 import { recordOpenCodeSqliteScanOutcome } from './session-scanner-opencode-sqlite-scan-outcome'
-import { OpenCodeSqliteCandidatePhase } from './session-scanner-opencode-sqlite-candidate-phase'
-import { withSessionExecutionHost } from './session-scanner-execution-host'
+import { openCodeSqliteScanCooldownRemainingMs } from './session-scanner-opencode-sqlite-scan-cooldown'
 import { mergeSessions } from './session-scanner-session-merge'
 
 const DEFAULT_LIMIT = 1000
 const DEFAULT_SCAN_LIMIT_PER_AGENT = 1000
-const SESSION_PARSE_CONCURRENCY = 8
 // Upper bound on extra in-scope transcripts discovered and parsed past the
 // recency cap; guards against a pathological scoped history directory.
 const SCOPE_PARSE_LIMIT = 2000
@@ -71,23 +61,31 @@ export async function scanAiVaultSessions(
   // "one core pegged" reports need to show whether transcript scanning is the
   // subsystem burning CPU, and how much of each scan the cache absorbed.
   return withSpan('aiVault.scan', async (span) => {
+    const limit = clampPositiveInteger(options.limit, DEFAULT_LIMIT)
+    const limitPerAgent = clampPositiveInteger(options.limitPerAgent, DEFAULT_SCAN_LIMIT_PER_AGENT)
+    const platform = options.platform ?? process.platform
+    const executionHostId = options.executionHostId ?? LOCAL_EXECUTION_HOST_ID
+    const issues: AiVaultScanIssue[] = []
+    const parseStats = createSessionParseStats()
+    const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(
+      readOptionalAntigravityHistoryFile
+    )
+    // Why: persisted entries must be seeded before any candidate is parsed, or
+    // the cold scan gains nothing from the cache file (#9210). Seeding happens
+    // before the OpenCode context exists so a large cache cannot spend its budget.
+    const cacheLoadStartedAtMs = Date.now()
+    await ensureSessionParseCacheLoaded()
+    span.setAttribute('parseCacheLoadMs', Date.now() - cacheLoadStartedAtMs)
     const opencodeSqliteScanContext = new OpenCodeSqliteScanContext()
+    // Why: a crash loop, a timeout loop, or a worker that will not spawn cannot
+    // be retried into success, and this scan re-runs every cache TTL. Back off
+    // process-wide instead of re-burning a core on the same doomed work.
+    const cooldownRemainingMs = openCodeSqliteScanCooldownRemainingMs()
+    if (cooldownRemainingMs > 0) {
+      opencodeSqliteScanContext.enterCooldown(cooldownRemainingMs)
+    }
+    span.setAttribute('opencodeSqliteCooldownMs', cooldownRemainingMs)
     try {
-      const limit = clampPositiveInteger(options.limit, DEFAULT_LIMIT)
-      const limitPerAgent = clampPositiveInteger(
-        options.limitPerAgent,
-        DEFAULT_SCAN_LIMIT_PER_AGENT
-      )
-      const platform = options.platform ?? process.platform
-      const executionHostId = options.executionHostId ?? LOCAL_EXECUTION_HOST_ID
-      const issues: AiVaultScanIssue[] = []
-      const parseStats = createSessionParseStats()
-      const antigravityWorkspaceResolver = createAntigravityWorkspaceResolver(
-        readOptionalAntigravityHistoryFile
-      )
-      // Why: persisted entries must be seeded before any candidate is parsed, or
-      // the cold scan gains nothing from the cache file (#9210).
-      await ensureSessionParseCacheLoaded()
       const discoveries = await discoverAiVaultSessionSources({
         options,
         limitPerAgent,
@@ -148,7 +146,8 @@ export async function scanAiVaultSessions(
         platform,
         executionHostId,
         issues,
-        parseStats
+        parseStats,
+        opencodeSqliteScanContext
       })
 
       span.setAttribute('candidates', candidates.length)
@@ -186,6 +185,7 @@ async function scanInScopeSessions(args: {
   executionHostId: ExecutionHostId
   issues: AiVaultScanIssue[]
   parseStats: SessionParseStats
+  opencodeSqliteScanContext: OpenCodeSqliteScanContext
 }): Promise<AiVaultSession[]> {
   if (args.scopePaths.length === 0) {
     return []
@@ -213,123 +213,7 @@ async function scanInScopeSessions(args: {
     platform: args.platform,
     executionHostId: args.executionHostId,
     issues: args.issues,
-    parseStats: args.parseStats
+    parseStats: args.parseStats,
+    opencodeSqliteScanContext: args.opencodeSqliteScanContext
   })
-}
-
-async function parseSessionCandidates(args: {
-  candidates: SessionFileCandidate[]
-  limit: number
-  platform: NodeJS.Platform
-  executionHostId: ExecutionHostId
-  issues: AiVaultScanIssue[]
-  parseStats: SessionParseStats
-  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver
-  opencodeSqliteScanContext?: OpenCodeSqliteScanContext
-}): Promise<AiVaultSession[]> {
-  const sessions: AiVaultSession[] = []
-  let index = 0
-  const opencodePhase = new OpenCodeSqliteCandidatePhase(
-    args.candidates,
-    args.opencodeSqliteScanContext
-  )
-
-  while (index < args.candidates.length) {
-    if (canStopParsingSessions(sessions, args.limit, args.candidates[index]?.file.mtimeMs)) {
-      break
-    }
-
-    const remaining = args.candidates.length - index
-    const needed = Math.max(args.limit - sessions.length, 1)
-    const batchSize = Math.min(SESSION_PARSE_CONCURRENCY, needed, remaining)
-    const batch = args.candidates.slice(index, index + batchSize)
-    const parseableBatch = opencodePhase.prepareBatch(batch)
-    const parsePromises = parseableBatch.map((candidate) =>
-      parseSessionCandidate(
-        candidate,
-        args.platform,
-        args.executionHostId,
-        args.parseStats,
-        args.antigravityWorkspaceResolver,
-        args.opencodeSqliteScanContext
-      )
-    )
-    opencodePhase.trackBatch(parseableBatch, parsePromises)
-    const results = await Promise.all(parsePromises)
-
-    for (const result of results) {
-      if (result.issue) {
-        args.issues.push(result.issue)
-      }
-      if (result.session) {
-        sessions.push(result.session)
-      }
-    }
-
-    // Why: cross-volume backfill copies have no shared inode, so collapse
-    // parsed aliases before they can crowd the unique-session parse budget.
-    const uniqueSessions = dedupeCodexSessionsBySessionId(sessions)
-    sessions.splice(0, sessions.length, ...uniqueSessions)
-
-    index += batchSize
-  }
-
-  opencodePhase.finish()
-  return sessions
-}
-
-async function parseSessionCandidate(
-  candidate: SessionFileCandidate,
-  platform: NodeJS.Platform,
-  executionHostId: ExecutionHostId,
-  parseStats: SessionParseStats,
-  antigravityWorkspaceResolver?: AntigravityWorkspaceResolver,
-  opencodeSqliteScanContext?: OpenCodeSqliteScanContext
-): Promise<SessionParseResult> {
-  try {
-    let session = await parseAgentSessionFileCached(
-      candidate,
-      platform,
-      parseStats,
-      opencodeSqliteScanContext
-    )
-    if (session && candidate.antigravityHistoryPath && antigravityWorkspaceResolver) {
-      session = await antigravityWorkspaceResolver.enrich(session, candidate.antigravityHistoryPath)
-    }
-    return {
-      session: session ? withSessionExecutionHost(session, executionHostId) : null,
-      issue: null
-    }
-  } catch (err) {
-    if (isOpenCodeSqliteScanTerminatedError(err)) {
-      return { session: null, issue: null }
-    }
-    return {
-      session: null,
-      issue: {
-        executionHostId,
-        agent: candidate.agent,
-        path: candidate.file.path,
-        message: errorMessage(err)
-      }
-    }
-  }
-}
-
-function canStopParsingSessions(
-  sessions: AiVaultSession[],
-  limit: number,
-  nextCandidateMtimeMs: number | undefined
-): boolean {
-  if (sessions.length < limit || typeof nextCandidateMtimeMs !== 'number') {
-    return false
-  }
-  const visibleCutoff = sessions
-    .map(sessionSortTime)
-    .sort((left, right) => right - left)
-    .at(limit - 1)
-
-  // Transcript mtime is already our discovery bound and fallback sort key; older
-  // files cannot displace the current visible set once the cutoff is newer.
-  return typeof visibleCutoff === 'number' && nextCandidateMtimeMs < visibleCutoff
 }

--- a/src/main/opencode-usage/scanner-windows-data-directory.test.ts
+++ b/src/main/opencode-usage/scanner-windows-data-directory.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { opencodeDiscoveries } from '../ai-vault/session-scanner-opencode-sources'
+import { OpenCodeSqliteScanContext } from '../ai-vault/session-scanner-opencode-sqlite-scan-context'
 import Database from '../sqlite/sync-database'
 import { scanOpenCodeUsageDatabases } from './scanner'
 
@@ -80,7 +81,10 @@ describe('OpenCode usage discovery on Windows', () => {
 
     const result = await scanOpenCodeUsageDatabases([], [])
     const issues = []
-    const [discovery] = await Promise.all(opencodeDiscoveries({}, [], 25, issues))
+    const context = new OpenCodeSqliteScanContext()
+    const [discovery] = await Promise.all(
+      opencodeDiscoveries({ platform: 'win32' }, [], 25, issues, context)
+    )
 
     expect(discovery?.files.map(({ path }) => path)).toEqual([`${databasePath}#windows-session`])
     expect(issues).toEqual([])

--- a/src/shared/json-text-structure-limit.test.ts
+++ b/src/shared/json-text-structure-limit.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   assertJsonTextStructureWithinLimits,
-  JsonTextStructureCapacityError
+  JsonTextStructureCapacityError,
+  JsonTextStructureValidator
 } from './json-text-structure-limit'
 
 describe('JSON text structure admission', () => {
@@ -36,5 +37,21 @@ describe('JSON text structure admission', () => {
         nestingDepth: 1
       })
     ).not.toThrow()
+  })
+
+  it('preserves string and escape state across chunks', () => {
+    const content = '{"value":"before\\\\\\\"[{:,}]after","rows":[{}]}'
+    const validator = new JsonTextStructureValidator({
+      structuralTokens: 9,
+      nestingDepth: 3
+    })
+    for (let index = 0; index < content.length; index += 1) {
+      validator.consume(content, index, index + 1)
+    }
+
+    expect(validator.usage()).toEqual({
+      structuralTokens: 9,
+      nestingDepth: 3
+    })
   })
 })

--- a/src/shared/json-text-structure-limit.ts
+++ b/src/shared/json-text-structure-limit.ts
@@ -28,35 +28,39 @@ export function assertJsonTextStructureWithinLimits(
   let inString = false
   let escaped = false
 
-  for (let index = 0; index < content.length; index += 1) {
-    const character = content[index]
+  // Why: this scans whole cache snapshots (tens of MB) on the main thread, so it
+  // reads char codes rather than one-character substrings — same grammar, but
+  // without a per-character string comparison chain.
+  const length = content.length
+  for (let index = 0; index < length; index += 1) {
+    const code = content.charCodeAt(index)
     if (inString) {
       if (escaped) {
         escaped = false
-      } else if (character === '\\') {
+      } else if (code === BACKSLASH) {
         escaped = true
-      } else if (character === '"') {
+      } else if (code === QUOTE) {
         inString = false
       }
       continue
     }
-    if (character === '"') {
+    if (code === QUOTE) {
       inString = true
       continue
     }
-    if (!isStructuralToken(character)) {
+    if (!isStructuralToken(code)) {
       continue
     }
     structuralTokens += 1
     if (structuralTokens > limits.structuralTokens) {
       throw new JsonTextStructureCapacityError('structuralTokens', limits.structuralTokens)
     }
-    if (character === '{' || character === '[') {
+    if (code === OPEN_BRACE || code === OPEN_BRACKET) {
       depth += 1
       if (depth > limits.nestingDepth) {
         throw new JsonTextStructureCapacityError('nestingDepth', limits.nestingDepth)
       }
-    } else if (character === '}' || character === ']') {
+    } else if (code === CLOSE_BRACE || code === CLOSE_BRACKET) {
       depth = Math.max(0, depth - 1)
     }
   }
@@ -68,13 +72,22 @@ function assertLimit(value: number): void {
   }
 }
 
-function isStructuralToken(character: string | undefined): boolean {
+const QUOTE = 0x22
+const COMMA = 0x2c
+const COLON = 0x3a
+const OPEN_BRACKET = 0x5b
+const BACKSLASH = 0x5c
+const CLOSE_BRACKET = 0x5d
+const OPEN_BRACE = 0x7b
+const CLOSE_BRACE = 0x7d
+
+function isStructuralToken(code: number): boolean {
   return (
-    character === '{' ||
-    character === '}' ||
-    character === '[' ||
-    character === ']' ||
-    character === ',' ||
-    character === ':'
+    code === OPEN_BRACE ||
+    code === CLOSE_BRACE ||
+    code === OPEN_BRACKET ||
+    code === CLOSE_BRACKET ||
+    code === COMMA ||
+    code === COLON
   )
 }

--- a/src/shared/json-text-structure-limit.ts
+++ b/src/shared/json-text-structure-limit.ts
@@ -17,58 +17,90 @@ export class JsonTextStructureCapacityError extends Error {
   }
 }
 
+export type JsonTextStructureUsage = Readonly<{
+  structuralTokens: number
+  nestingDepth: number
+}>
+
+export class JsonTextStructureValidator {
+  private structuralTokens = 0
+  private depth = 0
+  private maximumDepth = 0
+  private inString = false
+  private escaped = false
+
+  constructor(private readonly limits: JsonTextStructureLimits) {
+    assertLimit(limits.structuralTokens)
+    assertLimit(limits.nestingDepth)
+  }
+
+  consume(content: string, start = 0, end = content.length): void {
+    assertTextRange(content, start, end)
+    for (let index = start; index < end; index += 1) {
+      const code = content.charCodeAt(index)
+      if (this.inString) {
+        if (this.escaped) {
+          this.escaped = false
+        } else if (code === BACKSLASH) {
+          this.escaped = true
+        } else if (code === QUOTE) {
+          this.inString = false
+        }
+        continue
+      }
+      if (code === QUOTE) {
+        this.inString = true
+        continue
+      }
+      if (!isStructuralToken(code)) {
+        continue
+      }
+      this.structuralTokens += 1
+      if (this.structuralTokens > this.limits.structuralTokens) {
+        throw new JsonTextStructureCapacityError('structuralTokens', this.limits.structuralTokens)
+      }
+      if (code === OPEN_BRACE || code === OPEN_BRACKET) {
+        this.depth += 1
+        this.maximumDepth = Math.max(this.maximumDepth, this.depth)
+        if (this.depth > this.limits.nestingDepth) {
+          throw new JsonTextStructureCapacityError('nestingDepth', this.limits.nestingDepth)
+        }
+      } else if (code === CLOSE_BRACE || code === CLOSE_BRACKET) {
+        this.depth = Math.max(0, this.depth - 1)
+      }
+    }
+  }
+
+  usage(): JsonTextStructureUsage {
+    return {
+      structuralTokens: this.structuralTokens,
+      nestingDepth: this.maximumDepth
+    }
+  }
+}
+
 export function assertJsonTextStructureWithinLimits(
   content: string,
   limits: JsonTextStructureLimits
 ): void {
-  assertLimit(limits.structuralTokens)
-  assertLimit(limits.nestingDepth)
-  let structuralTokens = 0
-  let depth = 0
-  let inString = false
-  let escaped = false
-
-  // Why: this scans whole cache snapshots (tens of MB) on the main thread, so it
-  // reads char codes rather than one-character substrings — same grammar, but
-  // without a per-character string comparison chain.
-  const length = content.length
-  for (let index = 0; index < length; index += 1) {
-    const code = content.charCodeAt(index)
-    if (inString) {
-      if (escaped) {
-        escaped = false
-      } else if (code === BACKSLASH) {
-        escaped = true
-      } else if (code === QUOTE) {
-        inString = false
-      }
-      continue
-    }
-    if (code === QUOTE) {
-      inString = true
-      continue
-    }
-    if (!isStructuralToken(code)) {
-      continue
-    }
-    structuralTokens += 1
-    if (structuralTokens > limits.structuralTokens) {
-      throw new JsonTextStructureCapacityError('structuralTokens', limits.structuralTokens)
-    }
-    if (code === OPEN_BRACE || code === OPEN_BRACKET) {
-      depth += 1
-      if (depth > limits.nestingDepth) {
-        throw new JsonTextStructureCapacityError('nestingDepth', limits.nestingDepth)
-      }
-    } else if (code === CLOSE_BRACE || code === CLOSE_BRACKET) {
-      depth = Math.max(0, depth - 1)
-    }
-  }
+  new JsonTextStructureValidator(limits).consume(content)
 }
 
 function assertLimit(value: number): void {
   if (!Number.isSafeInteger(value) || value < 0) {
     throw new RangeError('JSON structure limits must be non-negative safe integers')
+  }
+}
+
+function assertTextRange(content: string, start: number, end: number): void {
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(end) ||
+    start < 0 ||
+    end < start ||
+    end > content.length
+  ) {
+    throw new RangeError('JSON text range is out of bounds')
   }
 }
 


### PR DESCRIPTION
## Summary

This PR addresses both release-scan findings for p2-ai-vault-perf:

- #8924 — OpenCode SQLite scan-owned deadline/cancel. Each Vault scan owns one 45-second context spanning cache load, discovery, FIFO queue wait, native/WSL sources, and active SQLite work. Context-local cancellation and worker-death circuit breaking drain only that scan's work, suppress cancelled candidates, and emit one aggregate issue when history is omitted; no new SQLite dispatch starts after expiry.
- #9474 — bounded persisted parse-cache load/write. Cache ingress uses a 64 MiB bounded reader before UTF-8 decoding or JSON.parse, plus 1,000,000 structural-token and depth-32 admission limits. Loading retains only the newest 4,096 unique paths with newest-duplicate precedence, while serialization uses the same byte/structure contract and preserves the prior snapshot when rejected.

Release-scan reference: /private/tmp/prod-release-worker-reports/FINAL.md (findings #8924 and #9474).

## Test plan and results

- Focused OpenCode worker-client suite: 1 file, 24 tests passed.
- Full affected AI Vault and shared-bound suites: 37 files, 257 tests passed.
- pnpm run typecheck:node: passed.
- Configured scoped oxlint, type-aware oxlint, and oxfmt --check: passed.
- pnpm run check:max-lines-ratchet: passed.
- git diff --check origin/main...HEAD: passed.
- Merge-tree check against current origin/main: no conflict.
- Full pnpm lint is blocked only by the pre-existing unrelated Ghostty localization keyword audit.

Design: docs/p2-ai-vault-perf-design.md
Round-five review: docs/p2-ai-vault-perf-code-review-round-5.md (SHIP; no P0/P1/P2 findings).