### PR TITLE
fix(ui): ignore the IME-composition Enter in name and notes inputs

### DIFF
--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.ime-enter.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import { EditorPanelHeaderPath } from './EditorPanelHeaderPath'
+
+const { commitRename, cancelRename } = vi.hoisted(() => ({
+  commitRename: vi.fn(),
+  cancelRename: vi.fn()
+}))
+
+// Why: the rename field only mounts while the hook reports isRenaming, so the
+// hook is stubbed into that state instead of driving the whole rename flow.
+vi.mock('./editor-header-file-rename', () => ({
+  useEditorHeaderFileRename: () => ({
+    canRename: true,
+    currentFileName: '議事録.md',
+    isRenaming: true,
+    renameInputRef: { current: null },
+    openRenameInput: vi.fn(),
+    commitRename,
+    cancelRename
+  })
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutLabel: () => '⌘⇧M'
+}))
+
+const activeFile: OpenFile = {
+  id: 'edit:/repo/議事録.md',
+  filePath: '/repo/議事録.md',
+  relativePath: '議事録.md',
+  worktreeId: 'repo::/repo',
+  language: 'markdown',
+  isDirty: false,
+  mode: 'edit'
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  commitRename.mockClear()
+  cancelRename.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderHeaderPath(): HTMLInputElement {
+  act(() => {
+    root.render(
+      <EditorPanelHeaderPath
+        activeFile={activeFile}
+        copiedPathVisible={false}
+        canShowMarkdownPreview={false}
+        onCopyPath={vi.fn()}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+  })
+  const input = document.body.querySelector<HTMLInputElement>(
+    '[data-editor-header-rename-input="true"]'
+  )
+  if (!input) {
+    throw new Error('rename input not rendered')
+  }
+  return input
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('EditorPanelHeaderPath IME Enter guard', () => {
+  it('does not commit the rename on an IME-composition Enter', () => {
+    const input = renderHeaderPath()
+
+    pressEnter(input, { isComposing: true })
+
+    expect(commitRename).not.toHaveBeenCalled()
+  })
+
+  it('does not commit it for IMEs that report keyCode 229 without isComposing', () => {
+    const input = renderHeaderPath()
+
+    pressEnter(input, { keyCode: 229 })
+
+    expect(commitRename).not.toHaveBeenCalled()
+  })
+
+  it('still commits the rename on a plain Enter', () => {
+    const input = renderHeaderPath()
+
+    pressEnter(input)
+
+    expect(commitRename).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { translate } from '@/i18n/i18n'
 import type { OpenFile } from '@/store/slices/editor'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from '../tab-bar/SortableTab'
@@ -96,6 +97,9 @@ export function EditorPanelHeaderPath({
             onClick={(event) => event.stopPropagation()}
             onDoubleClick={(event) => event.stopPropagation()}
             onKeyDown={(event) => {
+              if (isImeCompositionKeyDown(event)) {
+                return
+              }
               if (event.key === 'Enter') {
                 event.preventDefault()
                 event.stopPropagation()

--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.ime-enter.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UntitledFileRenameDialog } from './UntitledFileRenameDialog'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderDialog(onConfirm: (relativePath: string) => void): {
+  nameInput: HTMLInputElement
+  folderInput: HTMLInputElement
+} {
+  act(() => {
+    root.render(
+      <UntitledFileRenameDialog
+        open={true}
+        currentName="議事録"
+        worktreePath="/repo"
+        disableBrowse
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+  })
+  const inputs = Array.from(document.body.querySelectorAll('input'))
+  if (inputs.length < 2) {
+    throw new Error('rename dialog inputs not rendered')
+  }
+  return { nameInput: inputs[0], folderInput: inputs[1] }
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('UntitledFileRenameDialog IME Enter guard', () => {
+  it('does not save the file on an IME-composition Enter in the name field', () => {
+    const onConfirm = vi.fn()
+    const { nameInput } = renderDialog(onConfirm)
+
+    pressEnter(nameInput, { isComposing: true })
+
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('does not save it for IMEs that report keyCode 229 without isComposing', () => {
+    const onConfirm = vi.fn()
+    const { nameInput } = renderDialog(onConfirm)
+
+    pressEnter(nameInput, { keyCode: 229 })
+
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('does not save the file on an IME-composition Enter in the folder field', () => {
+    const onConfirm = vi.fn()
+    const { folderInput } = renderDialog(onConfirm)
+
+    pressEnter(folderInput, { isComposing: true })
+
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('still saves on a plain Enter', () => {
+    const onConfirm = vi.fn()
+    const { nameInput } = renderDialog(onConfirm)
+
+    pressEnter(nameInput)
+
+    expect(onConfirm).toHaveBeenCalledWith('議事録.md')
+  })
+})

--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { getRelativePathInsideRoot } from '@/lib/path'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 
@@ -157,6 +158,9 @@ export function UntitledFileRenameDialog({
                   setError(null)
                 }}
                 onKeyDown={(e) => {
+                  if (isImeCompositionKeyDown(e)) {
+                    return
+                  }
                   if (e.key === 'Enter') {
                     e.preventDefault()
                     handleSubmit()
@@ -186,6 +190,9 @@ export function UntitledFileRenameDialog({
                   setError(null)
                 }}
                 onKeyDown={(e) => {
+                  if (isImeCompositionKeyDown(e)) {
+                    return
+                  }
                   if (e.key === 'Enter') {
                     e.preventDefault()
                     handleSubmit()

--- a/src/renderer/src/components/sidebar/HostRenameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/HostRenameDialog.ime-enter.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HostRenameDialog } from './HostRenameDialog'
+
+const { updateSettings } = vi.hoisted(() => ({ updateSettings: vi.fn() }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ settings: {}, updateSettings })
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  updateSettings.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderDialog(onOpenChange: (open: boolean) => void): HTMLInputElement {
+  act(() => {
+    root.render(
+      <HostRenameDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        hostId="local"
+        derivedLabel="This Mac"
+      />
+    )
+  })
+  const input = document.body.querySelector<HTMLInputElement>('#host-rename-input')
+  if (!input) {
+    throw new Error('host rename input not rendered')
+  }
+  return input
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('HostRenameDialog IME Enter guard', () => {
+  it('does not commit the rename on an IME-composition Enter', () => {
+    const onOpenChange = vi.fn()
+    const input = renderDialog(onOpenChange)
+
+    pressEnter(input, { isComposing: true })
+
+    expect(updateSettings).not.toHaveBeenCalled()
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('does not commit it for IMEs that report keyCode 229 without isComposing', () => {
+    const onOpenChange = vi.fn()
+    const input = renderDialog(onOpenChange)
+
+    pressEnter(input, { keyCode: 229 })
+
+    expect(updateSettings).not.toHaveBeenCalled()
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('still commits the rename on a plain Enter', () => {
+    const onOpenChange = vi.fn()
+    const input = renderDialog(onOpenChange)
+
+    pressEnter(input)
+
+    expect(updateSettings).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/HostRenameDialog.tsx
+++ b/src/renderer/src/components/sidebar/HostRenameDialog.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useAppStore } from '@/store'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { translate } from '@/i18n/i18n'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { applyHostRename, getHostDisplayLabelOverride } from './host-rename-remove'
@@ -78,6 +79,9 @@ export function HostRenameDialog({
             placeholder={derivedLabel}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
+              if (isImeCompositionKeyDown(e)) {
+                return
+              }
               if (e.key === 'Enter') {
                 e.preventDefault()
                 submit()

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.ime-enter.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderDialog(onSubmit: () => void): HTMLInputElement {
+  act(() => {
+    root.render(
+      <ProjectGroupNameDialog
+        open={true}
+        title="Rename Project Group"
+        description="Name this group."
+        initialName="グループ"
+        confirmLabel="Save"
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+  })
+  const input = document.body.querySelector('input')
+  if (!input) {
+    throw new Error('group name input not rendered')
+  }
+  return input
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+  return event
+}
+
+describe('ProjectGroupNameDialog IME Enter guard', () => {
+  it('cancels the implicit form submit on an IME-composition Enter (isComposing)', () => {
+    const onSubmit = vi.fn()
+    const input = renderDialog(onSubmit)
+
+    const event = pressEnter(input, { isComposing: true })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('cancels it for IMEs that report keyCode 229 without isComposing', () => {
+    const onSubmit = vi.fn()
+    const input = renderDialog(onSubmit)
+
+    const event = pressEnter(input, { keyCode: 229 })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('leaves a plain Enter alone so the form still submits', () => {
+    const onSubmit = vi.fn()
+    const input = renderDialog(onSubmit)
+
+    const event = pressEnter(input)
+
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('still saves the trimmed name when the form submits', () => {
+    const onSubmit = vi.fn()
+    renderDialog(onSubmit)
+    const form = document.body.querySelector('form')
+    if (!form) {
+      throw new Error('form not rendered')
+    }
+
+    act(() => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith('グループ')
+  })
+})

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { translate } from '@/i18n/i18n'
 
 type ProjectGroupNameDialogProps = {
@@ -102,6 +103,13 @@ export function ProjectGroupNameDialog({
               ref={inputRef}
               value={name}
               onChange={(event) => setName(event.target.value)}
+              onKeyDown={(event) => {
+                // Why: the form submits implicitly on Enter, and a CJK IME fires one
+                // for the conversion candidate — that must not save a half-typed name.
+                if (event.key === 'Enter' && isImeCompositionKeyDown(event)) {
+                  event.preventDefault()
+                }
+              }}
               className="h-8 text-xs"
             />
           </div>

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.ime-enter.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import WorktreeMetaDialog from './WorktreeMetaDialog'
+
+const { closeModal, updateWorktreeMeta } = vi.hoisted(() => ({
+  closeModal: vi.fn(),
+  updateWorktreeMeta: vi.fn(async () => undefined)
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      activeModal: 'edit-meta',
+      modalData: { worktreeId: 'repo::/repo', currentDisplayName: '', focus: 'comment' },
+      closeModal,
+      updateWorktreeMeta,
+      fetchIssue: vi.fn(),
+      worktreesByRepo: {}
+    })
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  updateWorktreeMeta.mockClear()
+  closeModal.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderDialog(): { displayNameInput: HTMLInputElement; comment: HTMLTextAreaElement } {
+  act(() => {
+    root.render(<WorktreeMetaDialog />)
+  })
+  const displayNameInput = document.body.querySelector('input')
+  const comment = document.body.querySelector('textarea')
+  if (!displayNameInput || !comment) {
+    throw new Error('worktree meta fields not rendered')
+  }
+  return { displayNameInput, comment }
+}
+
+function pressEnter(element: HTMLElement, init?: KeyboardEventInit & { keyCode?: number }): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    element.dispatchEvent(event)
+  })
+}
+
+describe('WorktreeMetaDialog IME Enter guard', () => {
+  it('does not save the note on the Enter that commits an IME composition', () => {
+    const { comment } = renderDialog()
+
+    pressEnter(comment, { isComposing: true })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('does not save it for IMEs that report keyCode 229 without isComposing', () => {
+    const { comment } = renderDialog()
+
+    pressEnter(comment, { keyCode: 229 })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('does not save the display name on an IME-composition Enter', () => {
+    const { displayNameInput } = renderDialog()
+
+    pressEnter(displayNameInput, { isComposing: true })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('still saves on a plain Enter', () => {
+    const { comment } = renderDialog()
+
+    pressEnter(comment)
+
+    expect(updateWorktreeMeta).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -18,6 +18,7 @@ import {
 } from './worktree-meta-updates'
 import { useWorktreeIssueLink } from './use-worktree-issue-link'
 import { getScreenSubmitShortcutLabel, isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { ExternalLink, LoaderCircle } from 'lucide-react'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
@@ -158,6 +159,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
 
   const handleCommentKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (isImeCompositionKeyDown(e)) {
+        return
+      }
       const isPlainEnter = e.key === 'Enter' && !e.shiftKey && !e.altKey && !e.metaKey && !e.ctrlKey
       if (isPlainEnter || isScreenSubmitShortcut(e)) {
         e.preventDefault()
@@ -170,6 +174,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
 
   const handleIssueKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (isImeCompositionKeyDown(e)) {
+        return
+      }
       if (e.key === 'Enter') {
         e.preventDefault()
         handleSave()


### PR DESCRIPTION
## Summary

CJK IMEs (Japanese/Chinese/Korean) fire a `keydown` for the Enter that only confirms a conversion candidate. Five inputs committed on that keydown, so they saved a half-typed value while the user was still composing:

- **Project group name dialog** (New/Rename Project Group) — the field sits in a `<form>`, so the composition Enter submitted it implicitly.
- **Host rename dialog**
- **Worktree details dialog** — display name, GH issue, GH PR, and the notes textarea. The textarea saves on a plain Enter and closes the dialog, so a Japanese note could not get past its first conversion.
- **Untitled file rename dialog** — file name and folder fields.
- **Editor header inline file rename**

All five now use the existing `isImeCompositionKeyDown()` helper — the same guard already applied to worktree titles (#7081), tabs, and the workspace name field (#9526). It reads `nativeEvent.isComposing` with a `keyCode === 229` fallback for IMEs that do not set the flag on keydown.

`ProjectGroupNameDialog` differs slightly: it cancels the composition Enter with `preventDefault()` so the form's implicit submission never fires, rather than returning early from a submit handler.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added 5 `*.ime-enter.test.tsx` files (18 cases). Each covers both IME signals (`isComposing` and `keyCode === 229`) and keeps a plain-Enter control case, so a regression that drops the guard — or one that swallows a real Enter — fails the suite.

Pre-existing failure unrelated to this PR: `verify:localization-coverage` flags unlocalized "Ghostty" keywords already on `main`.

## AI Review Report

Reviewed with Claude Code. Checks and findings:

- **Cross-platform (macOS/Linux/Windows):** IME composition state is reported by Chromium on all three platforms; the guard adds no platform branch and touches no shortcut, label, path, or shell behavior. `WorktreeMetaDialog` keeps its existing `isScreenSubmitShortcut()` call, which already resolves ⌘/Ctrl per platform — the guard runs before it and does not alter that resolution.
- **SSH / remote / folder workspaces:** all five inputs are renderer-local; no IPC, git, or host-dependent path is involved.
- **Agent / integration / git provider neutrality:** no provider-specific code touched.
- **Performance:** one boolean check at the top of existing keydown handlers.
- **UI quality:** no rendered output changes; Escape during composition now cancels the conversion instead of the dialog, which matches the guards already shipped for worktree titles.
- **Risk considered:** guarding on `keyCode === 229` could in theory suppress a legitimate Enter. It cannot here — 229 is only reported while an IME owns the key event, and the plain-Enter control tests confirm the normal path still commits.

## Security Audit

No new input parsing, command execution, path handling, auth, secret, dependency, or IPC surface. The change only decides whether an existing save handler runs for a given keydown. Saved values continue through the same validation as before.

## Notes

Reproducing needs a CJK IME: type a Japanese word, press Enter to confirm the conversion, and observe that the value is no longer committed mid-composition.

## ELI5

With Japanese/Chinese/Korean keyboards, pressing Enter only to confirm a conversion candidate also submitted name/notes fields. Orca ignores that composition Enter so you finish typing before save.
