### PR TITLE
docs(relay): trim the pending-output drain comment

### DIFF
--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -723,11 +723,8 @@ export class PtyHandler {
 
   private flushPendingOutput(): void {
     this.outputFlushTimer = null
-    // Why: the send loop has no skip path and stops at PTY_OUTPUT_FLUSH_MAX_WRITES, so it can never
-    // reach a third entry — `Array.from(entries())` allocated one tuple per session every tick to
-    // consume at most two. Capture only that prefix, and capture it *before* the first send so a
-    // re-entrant sink still reads the values a whole-map snapshot would have frozen.
-    // Why the explicit iterator: `for...of` would advance one tuple past the limit and discard it.
+    // Why batch before the first send: a re-entrant sink must read the values a whole-map snapshot
+    // would have frozen. Why the raw iterator: `for...of` would consume one entry past the limit.
     const pendingEntries = this.pendingOutputByPty[Symbol.iterator]()
     const batch: [string, PendingPtyOutput][] = []
     while (batch.length < PTY_OUTPUT_FLUSH_MAX_WRITES) {


### PR DESCRIPTION
Follow-up to #10670. Comment-only — no behavior change.

## Description

The comment added in #10670 ran 5 lines and restated the allocation backstory the PR description already covered. Trimmed to the two facts a reader genuinely can't infer from the code:

- why the batch is captured **before** the first send (re-entrant sink must read the values a whole-map snapshot would have frozen)
- why the raw iterator instead of `for...of` (`for...of` consumes one entry past the limit)

## ELI5

The code had a paragraph explaining itself. Most of it was history you can read in the PR. Kept the two sentences that stop someone from "simplifying" it back into a bug.

## Proof of no regression

Comment-only; the diff touches no executable line.

- `src/relay/pty-handler-output-drain-differential.test.ts` — **6/6 pass**
- oxlint clean, oxfmt clean

Both retained notes are load-bearing: dropping either invites a refactor that reintroduces a real defect.

Made with [Orca](https://github.com/stablyai/orca) 🐋
