### PR TITLE
feat(linear): persist the issue list filter and view options across sessions

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -13,6 +13,7 @@ import { isTaskProvider } from '../../../../shared/task-providers'
 import { normalizeDisabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import { normalizePRBotAuthorOverrides } from '../../../../shared/pr-bot-author-overrides'
 import { normalizeWorktreeCardProperties } from '../../../../shared/worktree-card-properties'
+import { LinearIssueAttributeFilterSchema } from './linear-issue-attribute-filter-schema'
 import type { TaskProvider } from '../../../../shared/types'
 
 const NullableString = z.string().nullable()
@@ -66,7 +67,18 @@ const TaskResumeState = z
     githubItemsQuery: z.string().optional(),
     githubProjectHiddenFieldIdsByView: z.record(z.string(), z.array(z.string())).optional(),
     linearPreset: z.enum(['assigned', 'created', 'all', 'completed']).optional(),
-    linearQuery: z.string().optional()
+    linearQuery: z.string().optional(),
+    // Why: this schema is strict — a TaskResumeState field the renderer persists but
+    // that is missing here fails the whole ui.set call for paired web/mobile clients.
+    linearViewMode: z.enum(['list', 'board']).optional(),
+    linearGroupBy: z.enum(['none', 'status', 'assignee', 'priority', 'team']).optional(),
+    linearOrderBy: z.enum(['priority', 'updated', 'identifier']).optional(),
+    linearDisplayProperties: z
+      .array(z.enum(['state', 'priority', 'assignee', 'team', 'labels', 'updated']))
+      .optional(),
+    linearTeamPropertyTouched: z.boolean().optional(),
+    linearIssueFilter: LinearIssueAttributeFilterSchema.optional(),
+    linearIssueFilterWorkspaceId: z.string().optional()
   })
   .strict()
 const WorkspaceCleanupDismissal = z

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -437,7 +437,19 @@ describe('client UI RPC methods', () => {
         githubItemsQuery: 'is:open',
         githubProjectHiddenFieldIdsByView: {
           'project-1:view-1': ['field-1']
-        }
+        },
+        linearViewMode: 'board',
+        linearGroupBy: 'assignee',
+        linearOrderBy: 'updated',
+        linearDisplayProperties: ['state', 'labels'],
+        linearTeamPropertyTouched: true,
+        linearIssueFilter: {
+          stateIds: ['state-1'],
+          priorities: [2],
+          assignee: { kind: 'user', id: 'user-1' },
+          labelIds: ['label-1']
+        },
+        linearIssueFilterWorkspaceId: 'workspace-1'
       },
       workspaceCleanup: {
         dismissals: {
@@ -479,7 +491,19 @@ describe('client UI RPC methods', () => {
         githubItemsQuery: 'is:open',
         githubProjectHiddenFieldIdsByView: {
           'project-1:view-1': ['field-1']
-        }
+        },
+        linearViewMode: 'board',
+        linearGroupBy: 'assignee',
+        linearOrderBy: 'updated',
+        linearDisplayProperties: ['state', 'labels'],
+        linearTeamPropertyTouched: true,
+        linearIssueFilter: {
+          stateIds: ['state-1'],
+          priorities: [2],
+          assignee: { kind: 'user', id: 'user-1' },
+          labelIds: ['label-1']
+        },
+        linearIssueFilterWorkspaceId: 'workspace-1'
       },
       workspaceCleanup: {
         dismissals: {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -212,6 +212,12 @@ import { sortWorkItemsByNumber } from '../../../shared/work-items'
 import LinearIssueAttributeFilterDropdowns from '@/components/linear-issue-attribute-filter-dropdowns'
 import { resolveLinearIssueAttributeFilterPrimaryTeam } from '@/components/linear-issue-attribute-filter-primary-team'
 import {
+  DEFAULT_LINEAR_DISPLAY_PROPERTIES,
+  linearIssueViewPreferencesResumeUpdate,
+  resolveLinearIssueViewPreferences,
+  shouldResetLinearFilterForWorkspaceChange
+} from '@/components/linear-issue-view-preferences'
+import {
   buildLinearIssueListReadArgs,
   buildLinearIssueListRequestSignature,
   isLinearIssueSearchActive,
@@ -620,15 +626,6 @@ function mergeLinearCollectionResults<T>(
     ...(results.some((result) => result.hasMore) ? { hasMore: true } : {})
   }
 }
-
-const DEFAULT_LINEAR_DISPLAY_PROPERTIES: LinearDisplayProperty[] = [
-  'state',
-  'priority',
-  'assignee',
-  'team',
-  'labels',
-  'updated'
-]
 
 function getLinearStatusSectionState(section: LinearGroupSection): LinearIssue['state'] | null {
   if (!section.key.startsWith('status:')) {
@@ -3668,6 +3665,7 @@ export default function TaskPage(): React.JSX.Element {
   const taskResumeAppliedRef = useRef(false)
   const githubSearchPersistReadyRef = useRef(false)
   const linearSearchPersistReadyRef = useRef(false)
+  const linearViewPersistReadyRef = useRef(false)
   const jiraSearchPersistReadyRef = useRef(false)
   const [taskResumeApplied, setTaskResumeApplied] = useState(false)
 
@@ -4344,7 +4342,7 @@ export default function TaskPage(): React.JSX.Element {
     linearIssueAttributeFilterSignature(emptyLinearIssueAttributeFilter())
   )
   const linearPrimaryTeamIdRef = useRef<string | null>(null)
-  const previousLinearWorkspaceIdForFiltersRef = useRef<string | null | undefined>(undefined)
+  const previousLinearWorkspaceIdForFiltersRef = useRef<string | undefined>(undefined)
   const [linearViewMode, setLinearViewMode] = useState<LinearViewMode>('list')
   const [linearGroupBy, setLinearGroupBy] = useState<LinearGroupBy>('none')
   const [linearOrderBy, setLinearOrderBy] = useState<LinearOrderBy>('priority')
@@ -4627,6 +4625,16 @@ export default function TaskPage(): React.JSX.Element {
     setLinearMode(taskResumeState?.linearMode ?? 'issues')
     setLinearSearchInput(linearQuery)
     setAppliedLinearSearch(linearQuery)
+
+    const linearView = resolveLinearIssueViewPreferences(taskResumeState)
+    setLinearViewMode(linearView.viewMode)
+    setLinearGroupBy(linearView.groupBy)
+    setLinearOrderBy(linearView.orderBy)
+    setLinearDisplayProperties(linearView.displayProperties)
+    setLinearTeamPropertyTouched(linearView.teamPropertyTouched)
+    setLinearAttributeFilter(linearView.attributeFilter)
+    // Why: seed the workspace the saved facets belong to, so resolving a different one drops them as a switch.
+    previousLinearWorkspaceIdForFiltersRef.current = taskResumeState?.linearIssueFilterWorkspaceId
 
     const jiraPreset = taskResumeState?.jiraPreset ?? 'assigned'
     const jiraQuery = taskResumeState?.jiraQuery ?? ''
@@ -5152,13 +5160,17 @@ export default function TaskPage(): React.JSX.Element {
   }, [])
 
   useEffect(() => {
-    const workspaceId = selectedLinearWorkspaceId ?? null
-    const previous = previousLinearWorkspaceIdForFiltersRef.current
-    previousLinearWorkspaceIdForFiltersRef.current = workspaceId
-    if (previous === undefined || previous === workspaceId) {
-      return
+    const reset = shouldResetLinearFilterForWorkspaceChange(
+      previousLinearWorkspaceIdForFiltersRef.current,
+      selectedLinearWorkspaceId
+    )
+    // Why: only remember resolved ids, so a not-yet-loaded null can't later read as a workspace switch.
+    if (selectedLinearWorkspaceId !== null) {
+      previousLinearWorkspaceIdForFiltersRef.current = selectedLinearWorkspaceId
     }
-    applyLinearAttributeFilter(emptyLinearIssueAttributeFilter())
+    if (reset) {
+      applyLinearAttributeFilter(emptyLinearIssueAttributeFilter())
+    }
   }, [applyLinearAttributeFilter, selectedLinearWorkspaceId])
 
   useEffect(() => {
@@ -7204,6 +7216,42 @@ export default function TaskPage(): React.JSX.Element {
     }
     setTaskResumeState({ linearQuery: appliedLinearSearch.trim() })
   }, [appliedLinearSearch, setTaskResumeState, taskResumeApplied])
+
+  // Why: watch the values rather than each setter, so the workspace/team filter resets persist too.
+  useEffect(() => {
+    if (!taskResumeApplied) {
+      return
+    }
+    if (!linearViewPersistReadyRef.current) {
+      linearViewPersistReadyRef.current = true
+      return
+    }
+    setTaskResumeState(
+      linearIssueViewPreferencesResumeUpdate(
+        {
+          viewMode: linearViewMode,
+          groupBy: linearGroupBy,
+          orderBy: linearOrderBy,
+          displayProperties: linearDisplayProperties,
+          teamPropertyTouched: linearTeamPropertyTouched,
+          attributeFilter: linearAttributeFilter
+        },
+        // Why: the ref tracks the workspace the current facets belong to, so an unresolved
+        // (null) status keeps the existing tag instead of dropping the filter's scope.
+        previousLinearWorkspaceIdForFiltersRef.current ?? null
+      )
+    )
+  }, [
+    linearAttributeFilter,
+    linearDisplayProperties,
+    linearGroupBy,
+    linearOrderBy,
+    linearTeamPropertyTouched,
+    linearViewMode,
+    selectedLinearWorkspaceId,
+    setTaskResumeState,
+    taskResumeApplied
+  ])
 
   useEffect(() => {
     setLinearIssueLimit(LINEAR_ITEM_LIMIT)

--- a/src/renderer/src/components/linear-issue-view-preferences.test.ts
+++ b/src/renderer/src/components/linear-issue-view-preferences.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { emptyLinearIssueAttributeFilter } from '../../../shared/linear-issue-attribute-filter'
+import type { LinearIssueAttributeFilter } from '../../../shared/linear-issue-attribute-filter'
+import type { TaskResumeState } from '../../../shared/types'
+import {
+  DEFAULT_LINEAR_DISPLAY_PROPERTIES,
+  linearIssueViewPreferencesResumeUpdate,
+  resolveLinearIssueViewPreferences,
+  shouldResetLinearFilterForWorkspaceChange,
+  type LinearIssueViewPreferences
+} from './linear-issue-view-preferences'
+
+function filter(overrides: Partial<LinearIssueAttributeFilter> = {}): LinearIssueAttributeFilter {
+  return { ...emptyLinearIssueAttributeFilter(), ...overrides }
+}
+
+function preferences(
+  overrides: Partial<LinearIssueViewPreferences> = {}
+): LinearIssueViewPreferences {
+  return {
+    viewMode: 'list',
+    groupBy: 'none',
+    orderBy: 'priority',
+    displayProperties: new Set(DEFAULT_LINEAR_DISPLAY_PROPERTIES),
+    teamPropertyTouched: false,
+    attributeFilter: emptyLinearIssueAttributeFilter(),
+    ...overrides
+  }
+}
+
+describe('resolveLinearIssueViewPreferences', () => {
+  it('falls back to list/none/priority and every display property without saved state', () => {
+    const resolved = resolveLinearIssueViewPreferences(undefined)
+
+    expect(resolved.viewMode).toBe('list')
+    expect(resolved.groupBy).toBe('none')
+    expect(resolved.orderBy).toBe('priority')
+    expect(Array.from(resolved.displayProperties)).toEqual(DEFAULT_LINEAR_DISPLAY_PROPERTIES)
+    expect(resolved.teamPropertyTouched).toBe(false)
+    expect(resolved.attributeFilter).toEqual(emptyLinearIssueAttributeFilter())
+  })
+
+  it('restores saved view options and the saved attribute filter', () => {
+    const resume: TaskResumeState = {
+      linearViewMode: 'board',
+      linearGroupBy: 'assignee',
+      linearOrderBy: 'updated',
+      linearDisplayProperties: ['state', 'labels'],
+      linearTeamPropertyTouched: true,
+      linearIssueFilter: filter({ priorities: [1, 2] })
+    }
+
+    const resolved = resolveLinearIssueViewPreferences(resume)
+
+    expect(resolved.viewMode).toBe('board')
+    expect(resolved.groupBy).toBe('assignee')
+    expect(resolved.orderBy).toBe('updated')
+    expect(Array.from(resolved.displayProperties)).toEqual(['state', 'labels'])
+    expect(resolved.teamPropertyTouched).toBe(true)
+    expect(resolved.attributeFilter).toEqual(filter({ priorities: [1, 2] }))
+  })
+
+  it('treats an empty saved display-property list as "hide everything", not as missing', () => {
+    const resolved = resolveLinearIssueViewPreferences({ linearDisplayProperties: [] })
+
+    expect(Array.from(resolved.displayProperties)).toEqual([])
+  })
+})
+
+describe('linearIssueViewPreferencesResumeUpdate', () => {
+  it('omits an empty filter and its workspace tag so the payload stays "unfiltered"', () => {
+    const update = linearIssueViewPreferencesResumeUpdate(preferences(), 'workspace-1')
+
+    expect(update.linearIssueFilter).toBeUndefined()
+    expect(update.linearIssueFilterWorkspaceId).toBeUndefined()
+  })
+
+  it('canonicalizes a non-empty filter and tags the workspace it was captured under', () => {
+    const update = linearIssueViewPreferencesResumeUpdate(
+      preferences({ attributeFilter: filter({ labelIds: ['b', 'a', 'a'] }) }),
+      'workspace-1'
+    )
+
+    expect(update.linearIssueFilter).toEqual(filter({ labelIds: ['a', 'b'] }))
+    expect(update.linearIssueFilterWorkspaceId).toBe('workspace-1')
+  })
+
+  it('emits display properties in catalog order regardless of toggle order', () => {
+    const update = linearIssueViewPreferencesResumeUpdate(
+      preferences({ displayProperties: new Set(['updated', 'state']) }),
+      'workspace-1'
+    )
+
+    expect(update.linearDisplayProperties).toEqual(['state', 'updated'])
+  })
+
+  it('drops the workspace tag when no workspace is resolved', () => {
+    const update = linearIssueViewPreferencesResumeUpdate(
+      preferences({ attributeFilter: filter({ priorities: [0] }) }),
+      null
+    )
+
+    expect(update.linearIssueFilter).toEqual(filter({ priorities: [0] }))
+    expect(update.linearIssueFilterWorkspaceId).toBeUndefined()
+  })
+})
+
+describe('shouldResetLinearFilterForWorkspaceChange', () => {
+  it('resets when the workspace actually changes', () => {
+    expect(shouldResetLinearFilterForWorkspaceChange('workspace-1', 'workspace-2')).toBe(true)
+  })
+
+  it('keeps the filter when the workspace is unchanged', () => {
+    expect(shouldResetLinearFilterForWorkspaceChange('workspace-1', 'workspace-1')).toBe(false)
+  })
+
+  it('keeps the restored filter when Linear status first resolves', () => {
+    expect(shouldResetLinearFilterForWorkspaceChange(undefined, 'workspace-1')).toBe(false)
+  })
+
+  it('keeps the filter while Linear status is unresolved or disconnected', () => {
+    expect(shouldResetLinearFilterForWorkspaceChange('workspace-1', null)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/linear-issue-view-preferences.ts
+++ b/src/renderer/src/components/linear-issue-view-preferences.ts
@@ -1,0 +1,88 @@
+// Why: shared coercion between TaskResumeState (persisted, plain JSON) and the
+// Linear issue list's in-memory view state, so restore defaults and the persisted
+// payload can be tested without rendering TaskPage.
+
+import {
+  canonicalizeLinearIssueAttributeFilter,
+  emptyLinearIssueAttributeFilter,
+  isEmptyLinearIssueAttributeFilter,
+  type LinearIssueAttributeFilter
+} from '../../../shared/linear-issue-attribute-filter'
+import type { TaskResumeState } from '../../../shared/types'
+import type {
+  LinearDisplayProperty,
+  LinearGroupBy,
+  LinearOrderBy,
+  LinearViewMode
+} from '@/components/task-page-localized-options'
+
+export const DEFAULT_LINEAR_DISPLAY_PROPERTIES: LinearDisplayProperty[] = [
+  'state',
+  'priority',
+  'assignee',
+  'team',
+  'labels',
+  'updated'
+]
+
+export type LinearIssueViewPreferences = {
+  viewMode: LinearViewMode
+  groupBy: LinearGroupBy
+  orderBy: LinearOrderBy
+  displayProperties: ReadonlySet<LinearDisplayProperty>
+  /** True once the user overrides the single-team auto-hide of the Team column. */
+  teamPropertyTouched: boolean
+  attributeFilter: LinearIssueAttributeFilter
+}
+
+export function resolveLinearIssueViewPreferences(
+  resume: TaskResumeState | undefined
+): LinearIssueViewPreferences {
+  return {
+    viewMode: resume?.linearViewMode ?? 'list',
+    groupBy: resume?.linearGroupBy ?? 'none',
+    orderBy: resume?.linearOrderBy ?? 'priority',
+    displayProperties: new Set(
+      resume?.linearDisplayProperties ?? DEFAULT_LINEAR_DISPLAY_PROPERTIES
+    ),
+    teamPropertyTouched: resume?.linearTeamPropertyTouched ?? false,
+    attributeFilter: resume?.linearIssueFilter ?? emptyLinearIssueAttributeFilter()
+  }
+}
+
+export function linearIssueViewPreferencesResumeUpdate(
+  preferences: LinearIssueViewPreferences,
+  workspaceId: string | null
+): Partial<TaskResumeState> {
+  const filtered = !isEmptyLinearIssueAttributeFilter(preferences.attributeFilter)
+  return {
+    linearViewMode: preferences.viewMode,
+    linearGroupBy: preferences.groupBy,
+    linearOrderBy: preferences.orderBy,
+    // Why: emit in catalog order so toggling a property off and on doesn't rewrite the payload.
+    linearDisplayProperties: DEFAULT_LINEAR_DISPLAY_PROPERTIES.filter((property) =>
+      preferences.displayProperties.has(property)
+    ),
+    linearTeamPropertyTouched: preferences.teamPropertyTouched,
+    linearIssueFilter: filtered
+      ? canonicalizeLinearIssueAttributeFilter(preferences.attributeFilter)
+      : undefined,
+    linearIssueFilterWorkspaceId: filtered && workspaceId !== null ? workspaceId : undefined
+  }
+}
+
+/**
+ * Filter facets are workspace-scoped ids, so a real workspace switch has to drop them.
+ * A null id means Linear status has not resolved yet (or disconnected), which is not a switch —
+ * treating it as one would clear the filter restored from the previous session on every launch.
+ */
+export function shouldResetLinearFilterForWorkspaceChange(
+  previousWorkspaceId: string | undefined,
+  nextWorkspaceId: string | null
+): boolean {
+  return (
+    nextWorkspaceId !== null &&
+    previousWorkspaceId !== undefined &&
+    previousWorkspaceId !== nextWorkspaceId
+  )
+}

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1616,6 +1616,18 @@ describe('createUISlice hydratePersistedUI', () => {
           githubItemsQuery: 42,
           linearPreset: 'completed',
           linearQuery: 'label:bug',
+          linearViewMode: 'board',
+          linearGroupBy: 'nonsense',
+          linearOrderBy: 'updated',
+          linearDisplayProperties: ['state', 'bogus', 'labels'],
+          linearTeamPropertyTouched: 'yes',
+          linearIssueFilter: {
+            stateIds: ['state-b', 'state-a'],
+            priorities: [2],
+            assignee: null,
+            labelIds: []
+          },
+          linearIssueFilterWorkspaceId: 'workspace-1',
           jiraPreset: 'reported',
           jiraQuery: 99
         } as unknown as PersistedUIState['taskResumeState']
@@ -1626,8 +1638,33 @@ describe('createUISlice hydratePersistedUI', () => {
       githubMode: 'project',
       linearPreset: 'completed',
       linearQuery: 'label:bug',
+      linearViewMode: 'board',
+      linearOrderBy: 'updated',
+      linearDisplayProperties: ['state', 'labels'],
+      linearIssueFilter: {
+        stateIds: ['state-a', 'state-b'],
+        priorities: [2],
+        assignee: null,
+        labelIds: []
+      },
+      linearIssueFilterWorkspaceId: 'workspace-1',
       jiraPreset: 'reported'
     })
+  })
+
+  it('drops a corrupt persisted Linear filter without losing the rest of the resume state', () => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        taskResumeState: {
+          linearViewMode: 'board',
+          linearIssueFilter: { stateIds: 'not-an-array' }
+        } as unknown as PersistedUIState['taskResumeState']
+      })
+    )
+
+    expect(store.getState().taskResumeState).toEqual({ linearViewMode: 'board' })
   })
 
   it('restores acknowledgedAgentsByPaneKey from persisted UI state', () => {

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -36,6 +36,7 @@ import {
   normalizeManualRepoOrder
 } from '../../../../shared/manual-repo-order'
 import { isTopLevelView } from '../../../../shared/top-level-view'
+import { optionalParsedLinearIssueAttributeFilter } from '../../../../shared/linear-issue-attribute-filter'
 import type { UsagePercentageDisplay } from '../../../../shared/usage-percentage-display'
 import {
   DEFAULT_USAGE_PERCENTAGE_DISPLAY,
@@ -321,6 +322,31 @@ const VALID_JIRA_PRESETS = new Set<NonNullable<TaskResumeState['jiraPreset']>>([
   'all',
   'done'
 ])
+const VALID_LINEAR_VIEW_MODES = new Set<NonNullable<TaskResumeState['linearViewMode']>>([
+  'list',
+  'board'
+])
+const VALID_LINEAR_GROUP_BY = new Set<NonNullable<TaskResumeState['linearGroupBy']>>([
+  'none',
+  'status',
+  'assignee',
+  'priority',
+  'team'
+])
+const VALID_LINEAR_ORDER_BY = new Set<NonNullable<TaskResumeState['linearOrderBy']>>([
+  'priority',
+  'updated',
+  'identifier'
+])
+type LinearDisplayPropertyId = NonNullable<TaskResumeState['linearDisplayProperties']>[number]
+const VALID_LINEAR_DISPLAY_PROPERTIES = new Set<LinearDisplayPropertyId>([
+  'state',
+  'priority',
+  'assignee',
+  'team',
+  'labels',
+  'updated'
+])
 
 function resolvePaneKeyWorktreeIdFromTabs(state: AppState, paneKey: string): string | null {
   const parsed = parsePaneKey(paneKey)
@@ -551,6 +577,51 @@ function sanitizeTaskResumeState(value: unknown): TaskResumeState | undefined {
   }
   if (typeof input.linearQuery === 'string') {
     next.linearQuery = input.linearQuery
+  }
+  if (
+    typeof input.linearViewMode === 'string' &&
+    VALID_LINEAR_VIEW_MODES.has(
+      input.linearViewMode as NonNullable<TaskResumeState['linearViewMode']>
+    )
+  ) {
+    next.linearViewMode = input.linearViewMode as NonNullable<TaskResumeState['linearViewMode']>
+  }
+  if (
+    typeof input.linearGroupBy === 'string' &&
+    VALID_LINEAR_GROUP_BY.has(input.linearGroupBy as NonNullable<TaskResumeState['linearGroupBy']>)
+  ) {
+    next.linearGroupBy = input.linearGroupBy as NonNullable<TaskResumeState['linearGroupBy']>
+  }
+  if (
+    typeof input.linearOrderBy === 'string' &&
+    VALID_LINEAR_ORDER_BY.has(input.linearOrderBy as NonNullable<TaskResumeState['linearOrderBy']>)
+  ) {
+    next.linearOrderBy = input.linearOrderBy as NonNullable<TaskResumeState['linearOrderBy']>
+  }
+  // Why: an empty array is meaningful here (every property hidden), so keep it rather than dropping the key.
+  if (Array.isArray(input.linearDisplayProperties)) {
+    next.linearDisplayProperties = input.linearDisplayProperties.filter(
+      (property): property is LinearDisplayPropertyId =>
+        typeof property === 'string' &&
+        VALID_LINEAR_DISPLAY_PROPERTIES.has(property as LinearDisplayPropertyId)
+    )
+  }
+  if (typeof input.linearTeamPropertyTouched === 'boolean') {
+    next.linearTeamPropertyTouched = input.linearTeamPropertyTouched
+  }
+  try {
+    const parsedFilter = optionalParsedLinearIssueAttributeFilter(input.linearIssueFilter)
+    if (parsedFilter) {
+      next.linearIssueFilter = parsedFilter
+    }
+  } catch {
+    // Why: a corrupt persisted filter must not take the rest of the resume state down with it.
+  }
+  if (
+    typeof input.linearIssueFilterWorkspaceId === 'string' &&
+    input.linearIssueFilterWorkspaceId
+  ) {
+    next.linearIssueFilterWorkspaceId = input.linearIssueFilterWorkspaceId
   }
   if (input.linearContext && typeof input.linearContext === 'object') {
     const context = input.linearContext as Record<string, unknown>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import type { ExecutionHostId } from './execution-host'
+import type { LinearIssueAttributeFilter } from './linear-issue-attribute-filter'
 import type { RemovedSshTargetTombstone, SshRemotePtyLease, SshTarget } from './ssh-types'
 import type { Automation, AutomationExecutionTargetType, AutomationRun } from './automations-types'
 import type { WorkspaceSource } from './workspace-source'
@@ -3168,6 +3169,16 @@ export type TaskResumeState = {
   linearMode?: 'issues' | 'projects' | 'views'
   linearPreset?: 'assigned' | 'created' | 'all' | 'completed'
   linearQuery?: string
+  // Mirrors the renderer's LinearViewMode/LinearGroupBy/LinearOrderBy/LinearDisplayProperty unions.
+  linearViewMode?: 'list' | 'board'
+  linearGroupBy?: 'none' | 'status' | 'assignee' | 'priority' | 'team'
+  linearOrderBy?: 'priority' | 'updated' | 'identifier'
+  linearDisplayProperties?: ('state' | 'priority' | 'assignee' | 'team' | 'labels' | 'updated')[]
+  linearTeamPropertyTouched?: boolean
+  /** Omitted when empty, mirroring how an unfiltered list is sent over the wire. */
+  linearIssueFilter?: LinearIssueAttributeFilter
+  /** Facet ids above are workspace-scoped; this tags the workspace they were captured under. */
+  linearIssueFilterWorkspaceId?: string
   linearContext?: {
     kind: 'project' | 'view'
     id: string


### PR DESCRIPTION
## Summary

Linear's filter bar and View menu reset to defaults every time you leave the Tasks page, and again on every launch.

Filter a board down to a few statuses and labels, switch to another tab, come back — it is gone. Set the layout to board, group by assignee, order by updated, hide a couple of columns; same thing. Every visit starts from scratch, which makes the Linear tab painful to actually work out of.

This was never a deliberate decision. The founding resume commit (`5ce9c3b48`) scoped itself to preset and query; the attribute filter did not exist yet when it landed (#8021, two months later) and the View menu was simply never wired in.

**What now persists** — layout (list/board), grouping, ordering, display properties, and the attribute filter (statuses, priorities, assignee, labels).

**How** — these ride the existing `TaskResumeState` channel alongside `linearPreset` and `linearQuery`. No new store slice, no new persistence layer, no new IPC.

**Workspace scoping** — filter facets are workspace-scoped ids, so a filter saved under one workspace must not be applied to another. The persisted filter carries the workspace it was captured under and is dropped when a different one resolves. The previous reset effect keyed off any change including `null → id`, which on a cold start (Linear status not yet resolved) would have wiped the restored filter before the user ever saw it; an unresolved workspace is now correctly not treated as a switch.

## Screenshots

No new UI surface is introduced — no new controls, no layout or styling change. The visible difference is that the existing filter bar and View menu keep their values instead of resetting, which is hard to convey in a still.

Manually verified in a dev build against a live Linear workspace:

1. Applied a filter with both a status and a label (covers both facet kinds).
2. Changed layout list → board, changed grouping, changed ordering, toggled a display property off.
3. Navigated away to another tab and back — all retained.
4. Quit and relaunched — all retained.

Happy to attach a short screen recording if that is preferred over the description.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

11 new tests in `linear-issue-view-preferences.test.ts` plus extensions to `ui.test.ts` and `client-ui.test.ts`. They cover the parts that actually break: restore defaults, the empty-array-means-hide-everything case, omission of an empty filter, canonicalization and workspace tagging, catalog ordering of the emitted properties, dropping the tag when no workspace is resolved, all four branches of the workspace-reset rule, and recovery from a corrupt persisted filter without losing the rest of the resume state.

Following the convention already used by ~24 sibling modules, the coercion logic lives in a small pure module next to `TaskPage.tsx` rather than in it, so it is testable without rendering a 12k-line component.

`pnpm test` reports 8 pre-existing failing files on my machine (`window.localStorage` undefined under this environment). I confirmed they are unrelated by stashing this change and re-running them on a clean tree — they fail identically.

## AI Review Report

Reviewed with Claude Code, then a second adversarial pass specifically looking for over-engineering. Risks checked:

- **Cold-start race** — the original reset effect treated `null → resolved` as a workspace switch. Restoring a filter would have tripped it on every launch and cleared the filter before the user saw it. `shouldResetLinearFilterForWorkspaceChange` now returns false for an unresolved (`null`) workspace, and the effect only records non-null ids. Directly covered by tests.
- **Stale cross-workspace facets** — the inverse risk. A filter restored from workspace A must not silently apply to workspace B. Handled by the persisted workspace tag; verified the reset still fires on a genuine switch.
- **Dropping the workspace tag** — found during review: the persist effect originally passed `selectedLinearWorkspaceId` directly, so editing any view option while Linear was disconnected or unresolved would have written `linearIssueFilterWorkspaceId: undefined` and silently unscoped the saved filter. Changed to read the ref that tracks the workspace the current facets belong to.
- **Duplicated validation** — found during review: I had hand-written a Zod object for the filter in `client-ui-schemas.ts`. `LinearIssueAttributeFilterSchema` already existed and is *stricter* (id length and array bounds from the shared limits). Mine was unbounded. Replaced with the existing schema.
- **Coverage of all mutation paths** — the persist effect watches state values rather than hooking each setter, so the workspace-switch reset and the primary-team reset persist too, instead of only the paths a call-site patch would have caught.
- **Corrupt persisted state** — `parseLinearIssueAttributeFilter` throws on five distinct malformed shapes. Hydration catches it so one bad filter cannot take down the rest of the UI state. Covered by a test.
- **Cross-platform (macOS/Linux/Windows)** — no platform-dependent code touched: no keyboard shortcuts or `metaKey` checks, no shortcut labels, no filesystem paths, no shell invocation, no Electron platform APIs. State flows through the existing persistence channel, which is already platform-independent.
- **SSH / remote and folder workspaces** — nothing assumes a local or Git-worktree workspace. Both desktop (`ui:set` IPC) and paired web/mobile/relay (`ui.set` RPC) paths were updated; the RPC schema addition is what keeps remote clients from having the update rejected wholesale.
- **Git provider compatibility** — not applicable, no Git or provider code touched.
- **Performance** — one effect writing a small object on view-state change; the emitted display-property array is ordered by the canonical catalog so toggling a property off and back on produces an identical payload rather than a rewrite.
- **`max-lines`** — no new suppression added, per `AGENTS.md`. Net effect on `TaskPage.tsx` is small because the extracted module also removes a constant from it.
- **Boundary tests** — `feature-interaction-writer-boundaries.test.ts` anchors on the literal `const toggleLinearDisplayProperty` in `TaskPage.tsx`; that symbol is untouched.

## Security Audit

- **Input handling** — persisted state is untrusted on read. Hydration validates every field individually (closed-set membership for the four enums, `boolean` typeof, per-element filtering for the array) and drops anything invalid rather than trusting the blob. The filter is validated by the existing `parseLinearIssueAttributeFilter`, which enforces the shared bounds on array lengths and id lengths; a throw is caught and only that field is discarded.
- **RPC surface** — the strict Zod schema for `ui.set` was extended in lockstep so paired clients are neither rejected nor able to submit unbounded input. The filter reuses `LinearIssueAttributeFilterSchema` with its existing `.max()` bounds rather than a laxer hand-rolled copy, so this does not weaken the RPC boundary. Parent object remains `.strict()`.
- **Command execution / path handling** — none. No value here reaches a shell or a filesystem path.
- **Auth / secrets** — none. Workspace and facet ids are opaque identifiers, not credentials. The Linear token is stored separately under `~/.orca` and is untouched.
- **IPC** — no new IPC surface; existing `ui:set` / `ui.set` carry additional validated fields.
- **Dependencies** — none added.

No follow-up needed.

## Notes

No platform-specific behavior.

`linearTeamPropertyTouched` is persisted alongside the display properties on purpose. It gates the single-team auto-hide of the Team column (`TaskPage.tsx`); without it a restored session would re-apply the auto-hide and stomp an explicit user choice.

This touches the same Zod block as the `ui.set` schema fix I am opening alongside it (#10715). The two are independent in substance — that one is a pre-existing bug affecting `linearMode`/`linearContext`/`jira*` on paired clients — but whichever merges second will need a trivial rebase. This branch is cut from `main`, not from that one, so it can also merge first.

I do not use X, so no handle for the shoutout.

## ELI5

Linear filters and view options (status, layout, grouping) reset every time you left Tasks or relaunched the app. Those choices now persist across sessions so you don't rebuild your board setup every visit.
