### PR TITLE
fix(persistence): unbreak main by expecting the new 'cli' card property in fresh defaults

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -7072,6 +7072,7 @@ describe('Store', () => {
       'linear-issue',
       'pr',
       'automation',
+      'cli',
       'comment',
       'ports',
       'inline-agents'


### PR DESCRIPTION
## What

One line in a test. `main` is currently red on every commit, and this makes it green again.

`#10712` ("distinguish and filter CLI-created workspaces") added `'cli'` to `DEFAULT_WORKTREE_CARD_PROPERTIES`, but the `derives fresh default profiles without branch` assertion in `persistence.test.ts` still lists the pre-`'cli'` array. Production is right; the expectation is stale.

## ELI5

The app has a checklist of badges to show on each workspace card. Someone added a new badge, "cli", to the real checklist — but forgot to add it to the copy the test compares against. So the test says "you gave me 10 badges, I only wanted 9" and fails. This adds the badge to the test's copy.

## Why this matters now

`verify` fails on **every** PR branched off current `main`, so nobody can get a clean run. I hit it while validating an unrelated sidebar PR (#10693) and traced it back rather than merging around it.

## Fix proof

On pristine `origin/main` (`54e22402bc`), before any change:

```
FAIL  src/main/persistence.test.ts > Store > derives fresh default profiles without branch
AssertionError: expected [ 'status', 'unread', 'issue', …(7) ] to deeply equal [ 'status', 'unread', 'issue', …(6) ]

    "automation",
+   "cli",
    "comment",
```

Note the `+` — the *received* value has `'cli'`, the expectation doesn't. The production default is correct.

After this change: **417/417** in `persistence.test.ts`.

*Mutation-tested* — I removed `'cli'` from `DEFAULT_WORKTREE_CARD_PROPERTIES` in the production module and re-ran: exactly **1 failed | 416 passed**, this test. So the restored assertion genuinely pins the default rather than being a tautology I bent to fit.

## Proof of no regressions

- Full suite: `persistence.test.ts` green; **36,586 passed**.
- `tsc -p config/tsconfig.tc.web.json` → exit 0. `oxlint` → exit 0.
- Scope: one added string in one test file. No production code touched, so no runtime behavior changes on any platform.
- Cross-platform: a test-only string literal — nothing OS-dependent.

**Honest note on my local runs:** two other files (`relay/agent-exec-handler.test.ts`, `main/pty/omp-shell-wrapper.node-pty.test.ts`) fail on my macOS machine — but they fail *identically on pristine `main` with my change stashed*, and CI's run showed `1 failed | 3429 passed` with `persistence` as the only failure. They're pre-existing and local to my environment, not caused here and not fixed here.

## Trade-offs

None. The alternative — dropping `'cli'` from the production default — would revert a deliberate feature from #10712.

## Review loop

1 loop, clean. Verdict: correct fix, minimal, right direction (expectation follows production, not the reverse). The mutation test was added specifically to answer "did you just make the test agree with whatever the code does?" — no; removing the property re-breaks it.

Made with [Orca](https://github.com/stablyai/orca) 🐋
