### PR TITLE
fix(test): expect default worktree card properties to include cli

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -7072,6 +7072,7 @@ describe('Store', () => {
       'linear-issue',
       'pr',
       'automation',
+      'cli',
       'comment',
       'ports',
       'inline-agents'

--- a/src/shared/worktree-card-properties.test.ts
+++ b/src/shared/worktree-card-properties.test.ts
@@ -17,6 +17,7 @@ describe('worktree card properties', () => {
     expect(props).not.toContain('branch')
     expect(props).toContain('pr')
     expect(props).toContain('automation')
+    expect(props).toContain('cli')
     expect(props).toEqual(DEFAULT_WORKTREE_CARD_PROPERTIES)
   })
 


### PR DESCRIPTION
## Summary
CI verify is failing on `main` (and thus on PRs based on it) because `#10712` added `cli` to `DEFAULT_WORKTREE_CARD_PROPERTIES`, but `src/main/persistence.test.ts` still expected the pre-`cli` default list.

## Changes
- Update the fresh default-profile expectation in `persistence.test.ts` to include `cli`.
- Tighten `worktree-card-properties.test.ts` to assert `cli` is present in Default mode.

## Relation
Unrelated to terminal bold-flash work (#10692). Separate PR so that PR can merge without carrying this fixture fix, and so `main`/other PRs stop failing verify for this reason.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence.test.ts -t "derives fresh default profiles without branch"`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/worktree-card-properties.test.ts`
- [ ] CI verify green

Made with [Orca](https://github.com/stablyai/orca) 🐋
