### PR TITLE
fix(crash-reporting): stop fit-retry bursts from erasing the pre-crash trail

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -249,5 +249,104 @@ describe('crash breadcrumb store', () => {
 
       expect(hit()).toEqual({ suppressedSinceLast: 29 })
     })
+
+    // Panes mount progressively, so the first crumb of a burst sees a census of
+    // 1. Freezing it would report `livePanes: 1` for a 34-pane wave — the exact
+    // "one pane looping" misread that coalescing by name was built to prevent.
+    it('reports the newest census of a growing burst, not the first', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      for (let pane = 1; pane <= burstSize; pane += 1) {
+        vi.advanceTimersByTime(2)
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: {
+            paneId: 1,
+            leafId: `3333333${pane}-3333-4333-8333-333333333333`,
+            livePanes: pane,
+            livePaneManagers: pane
+          },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+      }
+
+      const bursts = getCrashBreadcrumbSnapshot().filter(
+        (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
+      )
+
+      expect(bursts).toHaveLength(1)
+      expect(bursts[0].data).toEqual(
+        expect.objectContaining({
+          livePanes: burstSize,
+          livePaneManagers: burstSize,
+          leafId: `3333333${burstSize}-3333-4333-8333-333333333333`,
+          suppressedSinceLast: burstSize - 1
+        })
+      )
+    })
+
+    // The re-emitted crumb already carries `suppressedSinceLast`, so folding the
+    // same events into the expiring slot too would report one burst twice.
+    it('counts a burst once when the window expires and the key re-emits', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      const hit = (livePanes: number): void => {
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: { livePanes },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+      }
+
+      hit(1)
+      vi.advanceTimersByTime(10)
+      hit(2)
+      vi.advanceTimersByTime(31_000)
+      hit(3)
+
+      const bursts = getCrashBreadcrumbSnapshot().filter(
+        (entry) => entry.name === 'terminal_safe_fit_retry_exhausted'
+      )
+
+      expect(bursts).toHaveLength(2)
+      expect(bursts[0].data).toEqual({ livePanes: 1 })
+      expect(bursts[1].data).toEqual({ livePanes: 3, suppressedSinceLast: 1 })
+    })
+
+    // A key that ages out loses its only handle on the ring entry it owns, so
+    // the newest suppressed payload must be folded in before the entry is
+    // dropped from the map.
+    it('resolves a suppressed payload when an unrelated key ages the map', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      recordCoalescedCrashBreadcrumb({
+        name: 'terminal_park_verdict_churn',
+        data: { livePanes: 1 },
+        coalesceKey: 'terminal_park_verdict_churn',
+        minIntervalMs: 30_000
+      })
+      vi.advanceTimersByTime(10)
+      recordCoalescedCrashBreadcrumb({
+        name: 'terminal_park_verdict_churn',
+        data: { livePanes: 9 },
+        coalesceKey: 'terminal_park_verdict_churn',
+        minIntervalMs: 30_000
+      })
+      vi.advanceTimersByTime(31_000)
+      recordCoalescedCrashBreadcrumb({
+        name: 'terminal_safe_fit_retry_exhausted',
+        data: { livePanes: 2 },
+        coalesceKey: 'terminal_safe_fit_retry_exhausted',
+        minIntervalMs: 30_000
+      })
+
+      const churn = getCrashBreadcrumbSnapshot().find(
+        (entry) => entry.name === 'terminal_park_verdict_churn'
+      )
+
+      expect(churn?.data).toEqual({ livePanes: 9, suppressedSinceLast: 1 })
+    })
   })
 })

--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -124,4 +124,68 @@ describe('crash breadcrumb store', () => {
 
     vi.useRealTimers()
   })
+
+  // Windows crash F0BKR84AHEH: two `terminal_safe_fit_retry_exhausted` bursts
+  // (34 crumbs in 76ms, 34 in 56ms) flushed the pre-crash trail out of a
+  // 30-entry ring. Every hidden pane is display:none, so it measures 0x0, fails
+  // the fit thresholds, and burns its whole retry budget — one reattach wave
+  // fires once per mounted pane, near-simultaneously. These two cases pin the
+  // before/after so the coalescing in crash-reporting.ts cannot silently regress.
+  describe('a per-pane burst against the fixed-size ring', () => {
+    const recordPreCrashTrail = (): void => {
+      for (let index = 0; index < 10; index += 1) {
+        recordCrashBreadcrumb(`pre_crash_evidence_${index}`, { index })
+      }
+    }
+    const burstSize = 34
+
+    it('erases the entire pre-crash trail when uncoalesced', () => {
+      recordPreCrashTrail()
+      for (let pane = 0; pane < burstSize; pane += 1) {
+        recordCrashBreadcrumb('terminal_safe_fit_retry_exhausted', { paneId: 1 })
+      }
+
+      const snapshot = getCrashBreadcrumbSnapshot()
+
+      expect(snapshot.filter((entry) => entry.name.startsWith('pre_crash_evidence_'))).toHaveLength(
+        0
+      )
+      expect(
+        snapshot.filter((entry) => entry.name === 'terminal_safe_fit_retry_exhausted')
+      ).toHaveLength(30)
+    })
+
+    it('costs one slot when coalesced, and keeps the pane count on the payload', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      recordPreCrashTrail()
+      for (let pane = 0; pane < burstSize; pane += 1) {
+        vi.advanceTimersByTime(2)
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: {
+            paneId: 1,
+            leafId: `2222222${pane}-2222-4222-8222-222222222222`,
+            livePanes: burstSize,
+            livePaneManagers: burstSize
+          },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+      }
+
+      const snapshot = getCrashBreadcrumbSnapshot()
+      const bursts = snapshot.filter((entry) => entry.name === 'terminal_safe_fit_retry_exhausted')
+
+      expect(snapshot.filter((entry) => entry.name.startsWith('pre_crash_evidence_'))).toHaveLength(
+        10
+      )
+      expect(bursts).toHaveLength(1)
+      // The population survives even though 33 crumbs did not — that count was
+      // the only signal the multiplicity ever carried.
+      expect(bursts[0].data).toEqual(
+        expect.objectContaining({ livePanes: burstSize, livePaneManagers: burstSize })
+      )
+    })
+  })
 })

--- a/src/main/crash-reporting/crash-breadcrumb-store.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.test.ts
@@ -187,5 +187,67 @@ describe('crash breadcrumb store', () => {
         expect.objectContaining({ livePanes: burstSize, livePaneManagers: burstSize })
       )
     })
+
+    // The suppression path returns before the delete-then-set that re-anchors
+    // recency, so a continuously-suppressed key kept its original insertion slot
+    // and became the FIRST eviction candidate — the exact inverse of the LRU's
+    // intent. `renderer_error` keys carry message+stack identity, so one noisy
+    // loop mints unbounded distinct keys and evicts the burst key mid-storm,
+    // re-arming the ring flush this suppression exists to prevent.
+    it('keeps suppressing a hot key while high-cardinality churn fills the LRU', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      const hitBurstKey = (): { suppressedSinceLast: number } | undefined =>
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: { livePanes: burstSize },
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+
+      hitBurstKey()
+      let reEmissions = 0
+      for (let index = 0; index < 200; index += 1) {
+        vi.advanceTimersByTime(10)
+        recordCoalescedCrashBreadcrumb({
+          name: 'renderer_error',
+          data: { message: `error-${index}` },
+          coalesceKey: `renderer_error:error-${index}`,
+          minIntervalMs: 30_000
+        })
+        if (hitBurstKey() !== undefined) {
+          reEmissions += 1
+        }
+      }
+
+      // Assert on suppression, not on ring occupancy: 200 genuinely-distinct
+      // errors legitimately flush the 30-entry ring, which masks an eviction as
+      // "one entry" either way.
+      expect(reEmissions).toBe(0)
+      expect(hitBurstKey()).toBeUndefined()
+    })
+
+    // Re-anchoring must move position only. Renewing recordedAt on every hit
+    // would let a sustained emitter suppress itself forever and never re-emit.
+    it('still expires the suppression window while a hot key is re-anchored', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-22T12:00:00.000Z'))
+      const hit = (): { suppressedSinceLast: number } | undefined =>
+        recordCoalescedCrashBreadcrumb({
+          name: 'terminal_safe_fit_retry_exhausted',
+          data: {},
+          coalesceKey: 'terminal_safe_fit_retry_exhausted',
+          minIntervalMs: 30_000
+        })
+
+      hit()
+      for (let index = 0; index < 29; index += 1) {
+        vi.advanceTimersByTime(1_000)
+        expect(hit()).toBeUndefined()
+      }
+      vi.advanceTimersByTime(1_000)
+
+      expect(hit()).toEqual({ suppressedSinceLast: 29 })
+    })
   })
 })

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -71,6 +71,13 @@ export function recordCoalescedCrashBreadcrumb({
   const previous = coalescedBreadcrumbs.get(coalesceKey)
   if (previous && now - previous.recordedAt < minIntervalMs) {
     previous.suppressed += 1
+    // Re-anchor recency without touching recordedAt: a suppressed key is the
+    // hottest key in the map, but only the emit path below moves position, so
+    // a continuously-suppressed key would keep its original slot and be first
+    // out under high-cardinality churn. recordedAt stays put so the suppression
+    // window still expires on schedule instead of renewing on every hit.
+    coalescedBreadcrumbs.delete(coalesceKey)
+    coalescedBreadcrumbs.set(coalesceKey, previous)
     return undefined
   }
 

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -1,5 +1,6 @@
 import {
   sanitizeCrashReportBreadcrumbs,
+  sanitizeCrashReportDetails,
   type CrashReportBreadcrumbData,
   type CrashReportBreadcrumb
 } from '../../shared/crash-reporting'
@@ -12,9 +13,18 @@ const MAX_RETAINED_BREADCRUMBS = 4
 // Bound the coalesce map the same way ProcessGoneDedupe bounds its key map.
 const MAX_COALESCE_KEYS = 128
 
+type CoalescedBreadcrumbState = {
+  recordedAt: number
+  suppressed: number
+  /** Ring entry this key owns, refreshed in place while suppressing. */
+  emitted?: CrashReportBreadcrumb
+  /** Newest suppressed payload, sanitized only if a snapshot actually asks for it. */
+  pending?: CrashReportBreadcrumbData
+}
+
 let breadcrumbs: CrashReportBreadcrumb[] = []
 let retainedBreadcrumbs = new Map<string, CrashReportBreadcrumb>()
-let coalescedBreadcrumbs = new Map<string, { recordedAt: number; suppressed: number }>()
+let coalescedBreadcrumbs = new Map<string, CoalescedBreadcrumbState>()
 
 function retainedBreadcrumbKey(breadcrumb: CrashReportBreadcrumb): string | null {
   if (breadcrumb.name !== 'renderer_memory_highwater') {
@@ -25,7 +35,11 @@ function retainedBreadcrumbKey(breadcrumb: CrashReportBreadcrumb): string | null
   return `${breadcrumb.name}:${String(surface)}:${String(threshold)}`
 }
 
-export function recordCrashBreadcrumb(name: string, data?: CrashReportBreadcrumbData): void {
+/** Returns the stored breadcrumb so coalescing can refresh the entry it owns. */
+export function recordCrashBreadcrumb(
+  name: string,
+  data?: CrashReportBreadcrumbData
+): CrashReportBreadcrumb | undefined {
   const sanitized = sanitizeCrashReportBreadcrumbs([
     {
       createdAt: new Date().toISOString(),
@@ -48,12 +62,13 @@ export function recordCrashBreadcrumb(name: string, data?: CrashReportBreadcrumb
       }
       retainedBreadcrumbs.delete(oldestKey.value)
     }
-    return
+    return breadcrumb
   }
   breadcrumbs.push(breadcrumb)
   if (breadcrumbs.length > MAX_BREADCRUMBS) {
     breadcrumbs.shift()
   }
+  return breadcrumb
 }
 
 export function recordCoalescedCrashBreadcrumb({
@@ -71,6 +86,17 @@ export function recordCoalescedCrashBreadcrumb({
   const previous = coalescedBreadcrumbs.get(coalesceKey)
   if (previous && now - previous.recordedAt < minIntervalMs) {
     previous.suppressed += 1
+    // Stash the newest payload for the entry this key already owns: the burst
+    // still costs exactly one ring slot, but the retained crumb ends up
+    // describing the latest event plus a running count instead of freezing the
+    // first. Without this, a burst that grows (pane 1 exhausts, then 33 more)
+    // leaves a census reading `livePanes: 1` — the "one pane looping" misread
+    // this coalescing was built to prevent. Sanitizing here would put that cost
+    // on every suppressed hit of a 1459/min crash loop; the snapshot resolves it
+    // once instead, on the rare path that actually reads breadcrumbs.
+    if (previous.emitted) {
+      previous.pending = data
+    }
     // Re-anchor recency without touching recordedAt: a suppressed key is the
     // hottest key in the map, but only the emit path below moves position, so
     // a continuously-suppressed key would keep its original slot and be first
@@ -83,27 +109,58 @@ export function recordCoalescedCrashBreadcrumb({
 
   // Drop entries past their suppression window (they can no longer coalesce
   // anything) and LRU-cap the rest. delete-then-set keeps insertion order =
-  // recency so only genuinely idle keys are evicted.
+  // recency so only genuinely idle keys are evicted. Resolve first: an expiring
+  // key is about to lose its only handle on the ring entry it owns.
   for (const [key, entry] of coalescedBreadcrumbs) {
     if (now - entry.recordedAt >= minIntervalMs) {
+      // Why the key check: this key is about to emit a fresh crumb carrying
+      // `suppressedSinceLast`, so folding the same events into its old slot
+      // too would report one burst twice.
+      if (key !== coalesceKey) {
+        resolvePendingCoalescedBreadcrumb(entry)
+      }
       coalescedBreadcrumbs.delete(key)
     }
   }
   coalescedBreadcrumbs.delete(coalesceKey)
-  coalescedBreadcrumbs.set(coalesceKey, { recordedAt: now, suppressed: 0 })
+  const state: CoalescedBreadcrumbState = { recordedAt: now, suppressed: 0 }
+  coalescedBreadcrumbs.set(coalesceKey, state)
   while (coalescedBreadcrumbs.size > MAX_COALESCE_KEYS) {
-    const oldest = coalescedBreadcrumbs.keys().next()
+    const oldest = coalescedBreadcrumbs.entries().next()
     if (oldest.done) {
       break
     }
-    coalescedBreadcrumbs.delete(oldest.value)
+    resolvePendingCoalescedBreadcrumb(oldest.value[1])
+    coalescedBreadcrumbs.delete(oldest.value[0])
   }
   const suppressedSinceLast = previous?.suppressed ?? 0
-  recordCrashBreadcrumb(name, suppressedSinceLast > 0 ? { ...data, suppressedSinceLast } : data)
+  state.emitted = recordCrashBreadcrumb(
+    name,
+    suppressedSinceLast > 0 ? { ...data, suppressedSinceLast } : data
+  )
   return { suppressedSinceLast }
 }
 
+/** Fold a key's newest suppressed payload into the ring entry it owns. */
+function resolvePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): void {
+  if (!state.pending || !state.emitted) {
+    return
+  }
+  state.emitted.data = sanitizeCrashReportDetails({
+    ...state.pending,
+    suppressedSinceLast: state.suppressed
+  })
+  state.pending = undefined
+}
+
+function resolveAllPendingCoalescedBreadcrumbs(): void {
+  for (const state of coalescedBreadcrumbs.values()) {
+    resolvePendingCoalescedBreadcrumb(state)
+  }
+}
+
 export function getCrashBreadcrumbSnapshot(): CrashReportBreadcrumb[] {
+  resolveAllPendingCoalescedBreadcrumbs()
   // Why: long sessions must retain threshold profiles without growing the 30-entry budget.
   const retained = [...retainedBreadcrumbs.values()]
   const recent = breadcrumbs.slice(-(MAX_BREADCRUMBS - retained.length))

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -255,6 +255,49 @@ describe('renderer breadcrumb IPC routing', () => {
     }
   })
 
+  // Why: every hidden pane is 0x0, so one post-reload reattach wave exhausts
+  // the fit budget once per mounted pane inside ~60ms. Windows crash
+  // F0BKR84AHEH lost 26-90% of its 30-entry ring to two such bursts.
+  it('coalesces fit-retry exhaustion by name, not by pane', () => {
+    emitRendererBreadcrumb({
+      name: 'terminal_safe_fit_retry_exhausted',
+      data: { paneId: 1, leafId: 'leaf-a' }
+    })
+    emitRendererBreadcrumb({
+      name: 'terminal_safe_fit_retry_exhausted',
+      data: { paneId: 1, leafId: 'leaf-b' }
+    })
+
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledTimes(2)
+    for (const call of recordCoalescedCrashBreadcrumbMock.mock.calls) {
+      expect(call[0]).toMatchObject({ coalesceKey: 'terminal_safe_fit_retry_exhausted' })
+    }
+  })
+
+  // Why kind-scoped: a routine post-wake atlas reset must never suppress the
+  // context-loss crumb that says the driver gave up on this renderer.
+  it('coalesces WebGL diagnostics per kind so one kind cannot mask another', () => {
+    emitRendererBreadcrumb({
+      name: 'terminal_webgl_diagnostic',
+      data: { kind: 'webgl-context-loss', paneId: 1 }
+    })
+    emitRendererBreadcrumb({
+      name: 'terminal_webgl_diagnostic',
+      data: { kind: 'webgl-atlas-reset', managers: 3 }
+    })
+
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(
+      recordCoalescedCrashBreadcrumbMock.mock.calls.map(
+        (call) => (call[0] as { coalesceKey: string }).coalesceKey
+      )
+    ).toEqual([
+      'terminal_webgl_diagnostic:webgl-context-loss',
+      'terminal_webgl_diagnostic:webgl-atlas-reset'
+    ])
+  })
+
   it('records non-error renderer breadcrumbs without coalescing', () => {
     emitRendererBreadcrumb({ name: 'renderer_bootstrap_started', data: { dev: true } })
 

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -33,6 +33,7 @@ import {
   isClipboardTextWriteTooLargeError
 } from '../../shared/clipboard-text'
 import { formatCrashReportCopyText } from '../crash-reporting/crash-report-copy-text'
+import { TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB } from '../../shared/terminal-webgl-diagnostics'
 
 const inFlightSubmissions = new Set<string>()
 const submittedReportIds = new Set<string>()
@@ -328,13 +329,24 @@ function buildUncapturedCrashReportText(
 const COALESCED_RENDERER_BREADCRUMB_NAMES = new Set([
   'renderer_error',
   'renderer_unhandled_rejection',
-  'terminal_park_verdict_churn'
+  'terminal_park_verdict_churn',
+  'terminal_safe_fit_retry_exhausted',
+  TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB
 ])
 const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
 // Why: these carry no message identity — they are per-tab telemetry whose rate,
 // not whose text, is the signal. Coalescing by name alone bounds a many-tab
 // storm to one ring entry plus a suppressed count.
-const NAME_ONLY_COALESCED_BREADCRUMB_NAMES = new Set(['terminal_park_verdict_churn'])
+//
+// terminal_safe_fit_retry_exhausted: every hidden (display:none) pane is 0x0 and
+// burns its whole retry budget, so one post-reload reattach wave fires once per
+// mounted pane within ~60ms. Windows crash F0BKR84AHEH lost 26-90% of its
+// 30-entry ring to two such bursts. `suppressedSinceLast` keeps the pane count
+// — the only signal these carry — in one slot.
+const NAME_ONLY_COALESCED_BREADCRUMB_NAMES = new Set([
+  'terminal_park_verdict_churn',
+  'terminal_safe_fit_retry_exhausted'
+])
 
 function rendererBreadcrumbCoalesceKey(
   name: string,
@@ -342,6 +354,13 @@ function rendererBreadcrumbCoalesceKey(
 ): string | undefined {
   if (NAME_ONLY_COALESCED_BREADCRUMB_NAMES.has(name)) {
     return name
+  }
+  // Why kind and not name alone: a context loss (GPU/driver gave up on this
+  // renderer) and an atlas reset (routine post-wake repaint) must never
+  // suppress each other. Within one kind the count is the whole signal — every
+  // live pane emits on a GPU death.
+  if (name === TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB) {
+    return `${name}:${String(data?.kind ?? '')}`
   }
   const primaryMessage = name === 'renderer_error' ? data?.message : data?.reasonMessage
   const fallbackMessage = name === 'renderer_error' ? data?.errorMessage : undefined

--- a/src/renderer/src/components/terminal-pane/terminal-freeze-breadcrumbs.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-freeze-breadcrumbs.ts
@@ -2,11 +2,15 @@
 // delivery-affecting transitions (gate marks, visibility trust changes,
 // watchdog heals, restore markers) so a field report carries the history
 // that led to the frozen state, not just a point-in-time counter snapshot.
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import {
   type PtyDeliveryBreadcrumb,
   createPtyDeliveryBreadcrumbRing
 } from '../../../../shared/pty-delivery-diagnostics'
-import { setTerminalWebglDiagnosticRecorder } from '../../../../shared/terminal-webgl-diagnostics'
+import {
+  TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB,
+  setTerminalWebglDiagnosticRecorder
+} from '../../../../shared/terminal-webgl-diagnostics'
 import { maybeStartTerminalRenderDesyncSentinel } from './terminal-render-desync-sentinel'
 
 const rendererDeliveryBreadcrumbs = createPtyDeliveryBreadcrumbRing()
@@ -22,9 +26,18 @@ export function recordTerminalFreezeBreadcrumb(
 // import this components-layer ring directly, so it records through a shared
 // sink. Point that sink at the same ring here so context-loss and atlas-reset
 // crumbs land in the one-paste report alongside delivery/visibility history.
-setTerminalWebglDiagnosticRecorder((kind, detail) =>
+//
+// Also mirror into the crash-report ring: this ring is DevTools-only (readable
+// solely via window.n()), so a renderer that dies takes the WebGL history with
+// it. Windows crash F0BKR84AHEH had three GPU-process deaths in the 65s before
+// its renderer OOM and zero WebGL evidence in the bundle — absence of
+// instrumentation, not absence of the event.
+setTerminalWebglDiagnosticRecorder((kind, detail) => {
   rendererDeliveryBreadcrumbs.record(kind, detail)
-)
+  // `kind` last: it is the coalescing discriminator, so a detail field of the
+  // same name must not be able to shadow it.
+  recordRendererCrashBreadcrumb(TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB, { ...detail, kind })
+})
 
 // Why: the sentinel is a field-diagnostic that must be armable on production
 // builds; starting it from this diagnostics bootstrap keeps arming independent

--- a/src/renderer/src/components/terminal-pane/terminal-webgl-diagnostics-breadcrumbs.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-webgl-diagnostics-breadcrumbs.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { recordTerminalWebglDiagnostic } from '../../../../shared/terminal-webgl-diagnostics'
 import {
   getTerminalFreezeBreadcrumbs,
   resetTerminalFreezeBreadcrumbsForTesting
 } from './terminal-freeze-breadcrumbs'
+
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: vi.fn()
+}))
 
 // Why: lib-layer WebGL code records through the shared sink because it may not
 // import the components-layer ring. Importing terminal-freeze-breadcrumbs wires
@@ -12,6 +17,7 @@ import {
 describe('WebGL diagnostics → freeze breadcrumb ring', () => {
   beforeEach(() => {
     resetTerminalFreezeBreadcrumbsForTesting()
+    vi.mocked(recordRendererCrashBreadcrumb).mockClear()
   })
 
   afterEach(() => {
@@ -26,5 +32,25 @@ describe('WebGL diagnostics → freeze breadcrumb ring', () => {
     expect(crumbs.map((crumb) => crumb.kind)).toEqual(['webgl-context-loss', 'webgl-atlas-reset'])
     expect(crumbs[0]?.detail).toEqual({ paneId: 3 })
     expect(crumbs[1]?.detail).toEqual({ managers: 1 })
+  })
+
+  // Why: the freeze ring is DevTools-only (window.n()), so a renderer that dies
+  // takes its WebGL history with it. Windows crash F0BKR84AHEH had three GPU
+  // deaths in the 65s before its renderer OOM and zero WebGL evidence.
+  it('mirrors WebGL crumbs into the crash report so a dead renderer still reports them', () => {
+    recordTerminalWebglDiagnostic('webgl-context-loss', { paneId: 3 })
+
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledWith('terminal_webgl_diagnostic', {
+      kind: 'webgl-context-loss',
+      paneId: 3
+    })
+  })
+
+  it('mirrors detail-less crumbs without inventing fields', () => {
+    recordTerminalWebglDiagnostic('webgl-context-restore')
+
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledWith('terminal_webgl_diagnostic', {
+      kind: 'webgl-context-restore'
+    })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-fit-continuation-retry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-continuation-retry.ts
@@ -1,4 +1,5 @@
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+import { getLivePaneCensus } from './pane-manager-registry'
 import type { ManagedPane } from './pane-manager-types'
 
 const MAX_RETRY_FRAMES = 40
@@ -75,8 +76,17 @@ export function armPaneFitContinuationRetry(
     }
     state.attempts += 1
     if (state.attempts >= MAX_RETRY_FRAMES) {
+      // Why leafId + census: `pane.id` restarts at 1 per PaneManager and there
+      // is one manager per tab, so a burst of identical `paneId: 1` crumbs
+      // cannot distinguish one pane looping from N panes exhausting in
+      // lockstep. Both facts now travel on every crumb, so main can coalesce
+      // the burst without destroying its meaning.
+      const census = getLivePaneCensus()
       recordRendererCrashBreadcrumb('terminal_safe_fit_retry_exhausted', {
-        paneId: pane.id
+        paneId: pane.id,
+        leafId: pane.leafId,
+        livePanes: census.panes,
+        livePaneManagers: census.managers
       })
       clearPaneFitContinuationRetry(pane)
       state.onExhausted()

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -168,9 +168,16 @@ describe('safeFitAndThen unmeasurable-pane retry', () => {
     }
 
     expect(continuation).not.toHaveBeenCalled()
+    // Why census fields: main coalesces this crumb by name, so the pane count
+    // must ride on the payload — the burst multiplicity no longer carries it.
     expect(recordRendererCrashBreadcrumb).toHaveBeenCalledWith(
       'terminal_safe_fit_retry_exhausted',
-      { paneId: 7 }
+      {
+        paneId: 7,
+        leafId: '22222222-2222-4222-8222-222222222222',
+        livePanes: 0,
+        livePaneManagers: 0
+      }
     )
     await expect(handle.completion).resolves.toBe(false)
 

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -205,6 +205,19 @@ describe('pane manager registry', () => {
     expect(getLivePaneCensus()).toEqual({ managers: 1, panes: 1 })
   })
 
+  it('prefers the allocation-free pane count when a manager exposes one', () => {
+    const counted = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      getPaneCount: () => 4,
+      getPanes: vi.fn(() => [{ id: 1, terminal: {} }])
+    }
+    registerLivePaneManager(counted)
+    registeredManagers.push(counted)
+
+    expect(getLivePaneCensus()).toEqual({ managers: 1, panes: 4 })
+    expect(counted.getPanes).not.toHaveBeenCalled()
+  })
+
   it('counts surviving managers when one throws mid-teardown', () => {
     const broken = {
       resetWebglTextureAtlases: vi.fn<() => void>(),

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 import {
   forEachLivePaneForDesyncSentinel,
+  getLivePaneCensus,
   refitAndRefreshAllTerminalPanes,
   registerLivePaneManager,
   resetAndRefreshAllTerminalWebglAtlases,
@@ -177,5 +178,49 @@ describe('pane manager registry', () => {
 
     expect(before).toHaveLength(2)
     expect(after).toEqual([before[1]])
+  })
+
+  // Why: this is the number crash reports could never recover from breadcrumb
+  // multiplicity, since every manager's first pane is id 1.
+  it('counts panes across managers and drops them on unregister', () => {
+    const twoPanes = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      getPanes: () => [
+        { id: 1, terminal: {} },
+        { id: 2, terminal: {} }
+      ]
+    }
+    const onePane = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      getPanes: () => [{ id: 1, terminal: {} }]
+    }
+    registerLivePaneManager(twoPanes)
+    registeredManagers.push(twoPanes)
+    registerLivePaneManager(onePane)
+    registeredManagers.push(onePane)
+
+    expect(getLivePaneCensus()).toEqual({ managers: 2, panes: 3 })
+
+    unregisterLivePaneManager(twoPanes)
+    expect(getLivePaneCensus()).toEqual({ managers: 1, panes: 1 })
+  })
+
+  it('counts surviving managers when one throws mid-teardown', () => {
+    const broken = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      getPanes: () => {
+        throw new Error('disposed')
+      }
+    }
+    const healthy = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      getPanes: () => [{ id: 1, terminal: {} }]
+    }
+    registerLivePaneManager(broken)
+    registeredManagers.push(broken)
+    registerLivePaneManager(healthy)
+    registeredManagers.push(healthy)
+
+    expect(getLivePaneCensus()).toEqual({ managers: 2, panes: 1 })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -7,6 +7,7 @@ type RegisteredPaneManager = {
   refreshAllPanes?: () => void
   getRenderingDiagnostics?: () => PaneRenderingDiagnostics[]
   getPanes?: () => { id: number; terminal: unknown }[]
+  getPaneCount?: () => number
 }
 
 const liveManagers = new Set<RegisteredPaneManager>()
@@ -101,7 +102,7 @@ export function getLivePaneCensus(): { managers: number; panes: number } {
   let panes = 0
   for (const manager of liveManagers) {
     try {
-      panes += manager.getPanes?.().length ?? 0
+      panes += manager.getPaneCount?.() ?? manager.getPanes?.().length ?? 0
     } catch {
       // Why: a manager mid-teardown must not sink the count for the rest.
     }

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -90,6 +90,26 @@ export function getAllPaneRenderingDiagnostics(): PaneRenderingDiagnostics[] {
 }
 
 /**
+ * Live pane census: managers (≈ terminal tabs) and the panes they hold.
+ *
+ * Why: this is the population number crash reports have been inferring from
+ * breadcrumb multiplicity, which never worked — `pane.id` restarts at 1 per
+ * manager, so N panes and one looping pane are indistinguishable in the ring.
+ * Measure it instead.
+ */
+export function getLivePaneCensus(): { managers: number; panes: number } {
+  let panes = 0
+  for (const manager of liveManagers) {
+    try {
+      panes += manager.getPanes?.().length ?? 0
+    } catch {
+      // Why: a manager mid-teardown must not sink the count for the rest.
+    }
+  }
+  return { managers: liveManagers.size, panes }
+}
+
+/**
  * Iterates every live pane for the render-desync sentinel. Weakly-held manager
  * ids stay stable when an earlier manager unregisters without retaining it.
  */

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -194,6 +194,12 @@ export class PaneManager {
     return Array.from(this.panes.values()).map(toPublicPane)
   }
 
+  /** Why separate from getPanes: the census runs on the crash path, where
+   *  materializing every public pane view just to read `.length` is waste. */
+  getPaneCount(): number {
+    return this.panes.size
+  }
+
   fitAllPanes(): void {
     fitAllPanesInternal(this.panes)
   }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setTerminalWebglDiagnosticRecorder } from '../../../../shared/terminal-webgl-diagnostics'
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { resumePaneRendering } from './pane-rendering-control'
 import { attachWebgl, resetTerminalWebglSuggestion } from './pane-webgl-renderer'
@@ -122,5 +123,28 @@ describe('terminal WebGL context recovery', () => {
     fireContextLoss(pane)
     expect(pane.webglDisabledAfterContextLoss).toBe(true)
     expect(pane.webglAddon).toBeNull()
+  })
+
+  // Why exact keys: a GPU death loses every pane's context at once and the
+  // crash ring coalesces the repeats, so the population has to survive on the
+  // payload. It must use the same names the fit-retry crumb uses, or one ring
+  // ends up describing one measurement two ways.
+  it('carries the pane census under the same field names the fit-retry crumb uses', () => {
+    const recorded: { kind: string; detail?: Record<string, unknown> }[] = []
+    setTerminalWebglDiagnosticRecorder((kind, detail) => recorded.push({ kind, detail }))
+    try {
+      const pane = createPane()
+      attachWebgl(pane)
+      fireContextLoss(pane)
+    } finally {
+      setTerminalWebglDiagnosticRecorder(null)
+    }
+
+    expect(recorded).toEqual([
+      {
+        kind: 'webgl-context-loss',
+        detail: { paneId: 1, livePanes: expect.any(Number), livePaneManagers: expect.any(Number) }
+      }
+    ])
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -182,9 +182,11 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       // Census rides along: a GPU-process death loses every pane's context at
       // once, and the crash-report ring coalesces repeats, so the count has to
       // be in the payload rather than in the number of crumbs.
+      const census = getLivePaneCensus()
       recordTerminalWebglDiagnostic('webgl-context-loss', {
         paneId: pane.id,
-        ...getLivePaneCensus()
+        livePanes: census.panes,
+        livePaneManagers: census.managers
       })
       // Why: Chromium starts reclaiming terminal contexts under pressure.
       // Recreating WebGL for this pane can loop context loss and leave xterm

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -1,6 +1,7 @@
 import { WebglAddon } from '@xterm/addon-webgl'
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { recordTerminalWebglDiagnostic } from '../../../../shared/terminal-webgl-diagnostics'
+import { getLivePaneCensus } from './pane-manager-registry'
 import { forceRepaintThroughRenderPause } from './terminal-render-pause-release'
 import {
   getTerminalWebglAutoDecision,
@@ -178,7 +179,13 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       // Why: a lost context is the decisive signal for a post-wake garble
       // report — it means the glyph atlas was wiped (needs a full reset), not
       // just a missed repaint. Silent breadcrumb; the console.warn stays.
-      recordTerminalWebglDiagnostic('webgl-context-loss', { paneId: pane.id })
+      // Census rides along: a GPU-process death loses every pane's context at
+      // once, and the crash-report ring coalesces repeats, so the count has to
+      // be in the payload rather than in the number of crumbs.
+      recordTerminalWebglDiagnostic('webgl-context-loss', {
+        paneId: pane.id,
+        ...getLivePaneCensus()
+      })
       // Why: Chromium starts reclaiming terminal contexts under pressure.
       // Recreating WebGL for this pane can loop context loss and leave xterm
       // visually blank, so keep the pane on the DOM renderer until the next

--- a/src/shared/terminal-webgl-diagnostics.ts
+++ b/src/shared/terminal-webgl-diagnostics.ts
@@ -7,6 +7,9 @@
  * until then (and in non-renderer contexts) recording is a silent no-op.
  */
 
+/** Crash-report breadcrumb name these crumbs are mirrored under. */
+export const TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB = 'terminal_webgl_diagnostic'
+
 export type WebglDiagnosticRecorder = (
   kind: string,
   detail?: Record<string, string | number | boolean | null>


### PR DESCRIPTION
## Description

Windows crash bundle **F0BKR84AHEH** (renderer OOM, exit `-536870904` / `0xE0000008`) arrived with an unusable breadcrumb trail. Two independent instrumentation defects, both fixed here:

**1. The crash-breadcrumb ring was flushed by its own noise.**
Two bursts of `terminal_safe_fit_retry_exhausted` — **34 crumbs in 76 ms**, then **34 in 56 ms** — consumed 26–90% of a fixed 30-entry ring, erasing everything that led up to the crash.

Why the burst exists: a hidden pane is `display:none`, so it measures 0×0 and fails `canMeasurePaneForFit` (thresholds 48×24, `pane-fit.ts:24-25`). It then burns its entire `MAX_RETRY_FRAMES = 40` budget and gives up. One post-reload reattach wave therefore fires this crumb **once per mounted pane**, and because every pane shares one document's rAF clock, they land near-simultaneously.

**2. WebGL evidence never left the renderer.**
`recordTerminalWebglDiagnostic` fed *only* the DevTools-only freeze ring (readable solely via `window.n()`). A renderer that dies takes that ring with it. That bundle had **three GPU-process deaths (`exitCode 34`) in the 65 s before the final renderer OOM and zero WebGL evidence** — absence of instrumentation, not absence of event, which left the leading hypothesis unfalsifiable in *both* directions.

### What changed

- `terminal_safe_fit_retry_exhausted` is now coalesced **by name alone** in main's renderer-breadcrumb IPC, so a whole burst costs one ring slot plus a `suppressedSinceLast` count.
- Because that collapse would otherwise destroy the only signal the burst carried, the crumb now carries the facts directly: `leafId` (a UUID discriminator) and a live pane census (`livePanes`, `livePaneManagers`).
- WebGL diagnostics are mirrored into the crash-report ring, coalesced **per `kind`**, so a routine post-wake `webgl-atlas-reset` can never suppress the `webgl-context-loss` crumb that says the driver gave up.

### The ambiguity this removes

`pane.id` is **not unique across the app**. `nextPaneId` starts at `FIRST_PANE_ID = 1` and is a per-`PaneManager` instance field (`pane-manager.ts:69`), and there is one `PaneManager` per tab (`use-terminal-pane-lifecycle.ts:782`). **Every tab's first pane is `id: 1`.** So 34 identical `paneId: 1` crumbs could not distinguish *one pane looping* from *34 panes exhausting in lockstep* — the two readings imply completely different root causes. Both `leafId` and a measured census now travel on every crumb.

---

## Fix evidence

A regression test drives the **real** breadcrumb store (not a mock) with the exact shape of the field failure: 10 pre-crash crumbs, then a 34-crumb per-pane burst against the 30-entry ring.

`src/main/crash-reporting/crash-breadcrumb-store.test.ts`:

| | pre-crash crumbs surviving | ring slots consumed by the burst | pane count recoverable |
|---|---|---|---|
| **Before** (uncoalesced) | **0 of 10** | **30 of 30** | no — multiplicity only |
| **After** (coalesced) | **10 of 10** | **1 of 30** | **yes — `livePanes: 34` + `suppressedSinceLast: 33` on the payload** |

```
✓ erases the entire pre-crash trail when uncoalesced
✓ costs one slot when coalesced, and keeps the pane count on the payload
✓ reports the newest census of a growing burst, not the first
✓ counts a burst once when the window expires and the key re-emits
✓ resolves a suppressed payload when an unrelated key ages the map
```

The first case is a live demonstration of the bug: it fails the moment the burst stops being coalesced, so the regression cannot come back silently.

**Test totals — stated precisely:** the *targeted* run over every area this diff touches (`src/main/crash-reporting/`, the renderer-breadcrumb IPC test, `src/renderer/src/lib/pane-manager/`, `src/renderer/src/components/terminal-pane/`) is **254 files / 3139 tests, all passing** (1 skipped). That is not the whole repo suite — it is the blast radius. `pnpm run typecheck` is clean across all three tsconfigs; `npx oxlint src/` exits 0.

Pre-existing full-suite flakes (`agent-exec-handler`, `persistence`, `pty-connection`, `project-view-wrapper-source-context-boundary`, `remote-runtime-shared-control-connection`) were verified against a `git stash`ed clean tree — they reproduce identically without this diff and each passes in isolation. Not caused by this change.

---

## ELI5

The app keeps a **flight recorder** with room for exactly 30 notes. When it crashes, we read those 30 notes to find out what happened.

The problem: one particular note got written **once per terminal pane**, all within a few hundredths of a second. With 34 panes open, that's 34 notes — more than the recorder holds. It shoved out everything else. We opened the flight recorder after a crash and found 30 copies of the same boring note and nothing about the crash.

Worse, those 34 notes were all labeled "pane 1", because pane numbering restarts inside every tab. So we couldn't even tell whether *one* pane wrote the note 34 times or *34* panes wrote it once.

Now: the note gets written **once**, and it says "and this happened 34 times, across 34 live panes." Same information, one line instead of thirty-four. The other 29 slots keep the notes that actually explain the crash.

Separately, the terminal's graphics diagnostics were being written to a notepad that only exists inside the window that's dying — so it burned up with the evidence. Those now go to the flight recorder too.

---

## Trade-offs / user-facing regressions

**User-facing regressions: none.** This diff touches no rendering, lifecycle, layout, or behavior path. It changes what gets *recorded*, never what gets *done*.

Honest costs:

1. **A second, genuinely distinct fit-retry exhaustion within 30 s is suppressed** into a count rather than kept as its own entry. Accepted deliberately: these crumbs have no message identity — their *rate* is the signal, not their text — and the alternative (what shipped) is losing the entire pre-crash trail. `suppressedSinceLast` preserves the rate.
2. **Two new coalesce keys** in a 128-entry LRU (`MAX_COALESCE_KEYS`). An earlier revision of this description claimed the window-pruning made it impossible for these to evict live keys. That was wrong, and probing it turned up a real pre-existing bug — see *Defect 5* below, now fixed in this PR.
3. **A `getLivePaneCensus()` walk on two crash paths.** It's a `Set` iteration reading `this.panes.size` per manager — no allocation per pane. A commit in this PR (`perf(pane-manager): count panes without materializing public views`) exists specifically to avoid `getPanes()`, which allocates a 9-field object per pane; that would have been real waste on a crash path.
4. **WebGL crumbs now cross IPC.** `ipcRenderer.send` (fire-and-forget, `preload/index.ts:1155`) — no synchronous renderer block. Coalescing happens in main, i.e. *after* the hop, so a GPU death with N panes does send N messages; each is a small primitive-only object and the ring cost is still one slot.

**Privacy:** `leafId` is constrained to a strict UUID pattern (`stable-pane-id.ts:4`), so no path or user string can occupy that field. All census values are integers. Everything still passes through `sanitizeCrashReportDetails`, which drops non-primitives and redacts paths/secrets.

---

## Verification performed

**Mutation testing — 6 mutants, all killed.** Every new test was verified load-bearing by reverting the thing it protects and confirming the test fails:

| mutation | test that caught it |
|---|---|
| drop `terminal_safe_fit_retry_exhausted` from name-only coalescing | `coalesces fit-retry exhaustion by name, not by pane` |
| WebGL coalesce key → name only (drop `:kind` scoping) | `coalesces WebGL diagnostics per kind so one kind cannot mask another` |
| drop `leafId` + census from the fit crumb | `resolves failure after the bounded frame budget instead of hanging reattach` |
| context-loss crumb → raw `...getLivePaneCensus()` spread | `carries the pane census under the same field names the fit-retry crumb uses` |
| remove the suppression-path re-anchor (restores the original bug) | `keeps suppressing a hot key while high-cardinality churn fills the LRU` |
| re-anchor by renewing `recordedAt` instead of position only | `still expires the suppression window while a hot key is re-anchored` |

**Self-caught defects, fixed before review:**
1. *Name-only coalescing would have destroyed the pane-count signal.* The 34-crumb multiplicity **was** the population census; collapsing it to one entry would have discarded the only usable datum. Hence `getLivePaneCensus()` and the payload fields — coalescing now costs nothing in information.
2. *`{kind, ...detail}` let a `detail` field named `kind` shadow the coalescing discriminator.* Reordered to `{...detail, kind}`.
3. *The census originally called `getPanes().length`*, which allocates a 9-field object per pane — on the crash path. Split out `getPaneCount()` (`this.panes.size`); a dedicated test asserts `getPanes` is never called when a count method exists.
4. *A hot coalesce key was the **first** thing the LRU evicted — the inverse of its stated intent.* See *Defect 5*.
5. *One ring, two names for one measurement.* The context-loss crumb spread the census raw (`managers`/`panes`) while the fit crumb used `livePanes`/`livePaneManagers`. Fixed and pinned — in a change whose entire purpose is crash-report legibility, that inconsistency was self-defeating.

**Edge cases verified:** a manager exposing neither count method contributes 0 (not `NaN`); `getPaneCount()` returning a legitimate `0` does **not** fall through to `getPanes()` (nullish coalescing, not falsy); a manager throwing mid-teardown doesn't sink the count for its siblings; `pane-manager-registry.ts` does not import `pane-manager.ts`, so the census introduces no import cycle.

**Privacy verified by tracing, not assumption:** `leafId` is UUID-constrained at `stable-pane-id.ts:4`; the desync sentinel's `paneKey` is synthetic (`m1:p2`, `pane-manager-registry.ts:133`), not the tab-embedding UUID paneKey; all census values are integers; everything still passes `sanitizeCrashReportDetails`, which drops non-primitives and redacts paths/secrets.

---

## Defect 5 — a pre-existing LRU bug this PR's own review turned up

An earlier revision of this description asserted that the two new coalesce keys "cannot evict live keys," reasoning that the map prunes expired entries before applying the 128-key cap. I set out to prove that claim and it failed.

`recordCoalescedCrashBreadcrumb` returned early on the suppression path, **before** the `delete`-then-`set` that re-anchors recency. Map iteration order is insertion order, so a key being hit continuously never moved from its original slot — making the hottest key in the map the *first* eviction candidate. The code comment claimed the exact opposite ("only genuinely idle keys are evicted").

Why it matters here specifically: `renderer_error` coalesce keys embed message + stack identity, so one noisy render loop mints unbounded distinct keys. Inside a single 30 s window that churn evicted `terminal_safe_fit_retry_exhausted` mid-burst, un-suppressing it and re-arming the exact ring flush this PR exists to prevent.

**Measured, before → after** (hot key hit once per iteration, interleaved with 200 distinct `renderer_error` keys):

| | hot-key re-emissions during churn |
|---|---|
| before | **1** (evicted at the 127th cold key) |
| after | **0** |

The fix re-anchors position only. `recordedAt` is deliberately left alone — renewing it would let a sustained emitter suppress itself forever and never re-emit. Both halves of that are pinned by their own test; each dies to its own mutant.

This is pre-existing (`8a7cd84bda`, #8800) and affects every coalesced breadcrumb, not just the ones added here. The fix is in the shared store, so all callers get it.

Worth noting where else it bites, since one caller makes it more than an evidence problem. `process_gone_suppressed` routes through `recordCoalescedDurableCrashBreadcrumb`, whose emit path calls `flushActiveSink()` — a forced disk flush, deliberately un-batched so the crumb survives the crash. Its coalesce key is a JSON tuple of 8 fields including `exitCode` and `serviceName`, and this is exactly the path guarding a Chromium child crash-loop that the code itself documents at **1459/min** (`process-gone-recorder.ts:97-98`). A crash-loop varying any tuple field mints keys fast; under the old behavior the hot key it was suppressing would be evicted first, restoring both the ring flood *and* the per-event forced flush that the suppression was added to stop.

---

## Defect 6 — this PR's own fix reintroduced the bug it was fixing

Having argued above that the census *is* the reason name-only coalescing is safe, I tested whether the census actually survives a burst. It did not.

The suppression path wrote **nothing** to the ring — it incremented a counter and returned. So the retained crumb froze the **first** event of a burst. Panes mount progressively, so pane 1 exhausting alone legitimately measures `livePanes: 1`; the 33 later crumbs, each carrying a truer census, were discarded.

| | what a crash bundle actually retained |
|---|---|
| before | **`livePanes: 1`, no count** — for a 34-pane wave |
| after | **`livePanes: 34`, `suppressedSinceLast: 33`** — still one ring slot |

That "before" row is the exact *one pane looping vs. 34 panes in lockstep* ambiguity this PR exists to remove, reintroduced by this PR's own mechanism.

**Why the existing test didn't catch it:** the burst test fed a *constant* census (`livePanes: burstSize` on every crumb), which makes frozen-first and newest-wins indistinguishable. The new test mounts panes progressively, so it can tell them apart — and fails against the old code.

The fix stashes the newest payload and folds it into the ring entry the key already owns. Resolution is deferred to snapshot time rather than performed per hit, because this path guards a 1459/min crash loop:

| suppression path | ns/op |
|---|---|
| sanitize on every suppressed hit (naive) | 2194.5 |
| deferred to snapshot (shipped) | **184.8** |

At 1459/min that is **0.0004% of one core**, and the sanitize cost lands only on the rare path that actually reads breadcrumbs.

**Two follow-on defects surfaced while building it**, both caught by tests rather than review:
1. A key aging out of the map silently dropped its pending payload — expiry is its last handle on the ring entry it owns. Now resolved before the entry is deleted.
2. Resolving the *re-emitting* key's own old slot double-counted a burst: the fresh crumb already carries `suppressedSinceLast`. Caught by an existing assertion; fixed by folding only foreign keys.

Stale-handle safety was verified directly: once a ring entry is shifted out by the 30-slot bound, later writes through the retained reference are inert — the entry is not resurrected and the ring bound holds.

**This fix is broader than the fit-retry crumb.** For `process_gone_suppressed` the payload is *fully subsumed* by its coalesce key — two events sharing a key produce byte-identical payloads no matter what else differs — so freezing the first lost nothing there. But two other callers carry **monotonic counters** the key does not subsume: `pr_refresh_queue` (`enqueued`/`coalesced`/`skipped`) and `pr_refresh_validation_skip` (`recorded`/`skipped`/`expired`). Those were reporting the counter values from the *start* of a storm. Because the fix lives in the shared store, they now report current values too — verified: 50 coalesced hits report `enqueued: 50`, not `enqueued: 1`.

**Coupling check:** `crash-breadcrumb-store` has zero importers in `src/renderer/`, `src/preload/`, or `src/shared/` — it is main-process only, so the renderer areas in the blast radius below are conservative coverage, not actual coupling.

---

## Perf of the LRU fix

The fix adds a `delete`+`set` to the *suppression* path — by definition the hottest one — so it was measured, not assumed. 128-key map, keys rotating as in real traffic:

| | ns/op |
|---|---|
| suppression, before | 27.4 |
| suppression, after | **58.3** (+31 ns) |
| emit path (already shipped, same function) | 579.0 |

In absolute terms: the worst burst actually observed in the field (34 crumbs / 76 ms) costs **16.8 µs** total, and the worst rate the codebase documents anywhere — the 1459/min network-service crash loop — costs **0.0005% of one core**. Heap after 5M `delete`+`set` on one key: no growth, map stays at 128 entries.

The direction matters more than the delta: an eviction forces a full *emit*, which is ~10x the cost of the suppression it replaces — and on the durable path, an additional forced `flushActiveSink()` disk write. So the fix is net-*negative* on work in exactly the scenario it targets.

(First measurement of this hammered a single key and reported 22x. That was a benchmark artifact — repeatedly re-appending one Map slot triggers compaction that rotating keys don't. Recorded here because the artifact is easy to reproduce and mistake for a regression.)

## Scope note

This is **evidence-only**. It does not fix the renderer OOM — it makes the next OOM bundle diagnosable. The underlying root cause is still blocked on exact-heap telemetry: the crashing build v1.4.156 predates `804d4dd110` / `c67aadbc18`, so its heap numbers are Blink-quantized (~100 log buckets, ~20-minute cache) and every renderer in that session died inside one cache period. Heap-vs-non-heap cannot be settled until `heapSource: 'v8'` bundles arrive.

Keeping this diff strictly evidence-only is what lets it ship now, at high confidence, rather than waiting on that analysis.

