### PR TITLE
fix(terminal): render country flag emoji as one glyph

### DIFF
--- a/src/main/daemon/headless-emulator-unicode-width.test.ts
+++ b/src/main/daemon/headless-emulator-unicode-width.test.ts
@@ -28,8 +28,7 @@ describe('headless emulator unicode widths', () => {
 
   it('joins a regional indicator pair into one wide flag like the renderer provider', async () => {
     const emulator = new HeadlessEmulator({ cols: 40, rows: 4 })
-    // 🇺🇸 is two regional indicators with no ZWJ; it occupies columns 1-2, so a
-    // write to column 3 replaces "A" rather than landing inside the flag.
+    // Column 3 must replace "A" after the two-cell flag.
     await emulator.write('\x1b[H\u{1F1FA}\u{1F1F8}AB')
     await emulator.write('\x1b[1;3HZ')
     expect(emulator.getVisibleLines()[0]).toBe('\u{1F1FA}\u{1F1F8}ZB')
@@ -38,7 +37,7 @@ describe('headless emulator unicode widths', () => {
 
   it('pairs consecutive flags instead of chaining every indicator', async () => {
     const emulator = new HeadlessEmulator({ cols: 40, rows: 4 })
-    // 🇺🇸🇩🇪 is four indicators forming two flags across columns 1-4.
+    // Column 5 must follow two paired flags.
     await emulator.write('\x1b[H\u{1F1FA}\u{1F1F8}\u{1F1E9}\u{1F1EA}A')
     await emulator.write('\x1b[1;5HZ')
     expect(emulator.getVisibleLines()[0]).toBe('\u{1F1FA}\u{1F1F8}\u{1F1E9}\u{1F1EA}Z')

--- a/src/main/daemon/headless-emulator-unicode-width.test.ts
+++ b/src/main/daemon/headless-emulator-unicode-width.test.ts
@@ -25,4 +25,23 @@ describe('headless emulator unicode widths', () => {
     expect(emulator.getVisibleLines()[0]).toBe('\u{1F469}\u{200D}\u{1F4BB}Y')
     emulator.dispose()
   })
+
+  it('joins a regional indicator pair into one wide flag like the renderer provider', async () => {
+    const emulator = new HeadlessEmulator({ cols: 40, rows: 4 })
+    // 🇺🇸 is two regional indicators with no ZWJ; it occupies columns 1-2, so a
+    // write to column 3 replaces "A" rather than landing inside the flag.
+    await emulator.write('\x1b[H\u{1F1FA}\u{1F1F8}AB')
+    await emulator.write('\x1b[1;3HZ')
+    expect(emulator.getVisibleLines()[0]).toBe('\u{1F1FA}\u{1F1F8}ZB')
+    emulator.dispose()
+  })
+
+  it('pairs consecutive flags instead of chaining every indicator', async () => {
+    const emulator = new HeadlessEmulator({ cols: 40, rows: 4 })
+    // 🇺🇸🇩🇪 is four indicators forming two flags across columns 1-4.
+    await emulator.write('\x1b[H\u{1F1FA}\u{1F1F8}\u{1F1E9}\u{1F1EA}A')
+    await emulator.write('\x1b[1;5HZ')
+    expect(emulator.getVisibleLines()[0]).toBe('\u{1F1FA}\u{1F1F8}\u{1F1E9}\u{1F1EA}Z')
+    emulator.dispose()
+  })
 })

--- a/src/shared/terminal-unicode-provider.test.ts
+++ b/src/shared/terminal-unicode-provider.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import type { Terminal } from '@xterm/headless'
+import { createRendererParityTerminal, writeToTerminal } from './terminal-restore-parity-fixture'
+
+// Why these oracles: a country flag is two regional indicators with no ZWJ, so the
+// ZWJ-only join rule left each indicator in its own cell. Chromium then shapes each
+// one alone and paints a lettered tile instead of the flag. Cell contents (not just
+// row text) are asserted because the row string looks identical either way.
+type Cell = { chars: string; width: number }
+
+function readCells(terminal: Terminal, count: number): Cell[] {
+  const line = terminal.buffer.active.getLine(0)
+  const cells: Cell[] = []
+  for (let x = 0; x < count; x++) {
+    const cell = line?.getCell(x)
+    cells.push({ chars: cell?.getChars() ?? '', width: cell?.getWidth() ?? 0 })
+  }
+  return cells
+}
+
+const US = '\u{1F1FA}\u{1F1F8}'
+const DE = '\u{1F1E9}\u{1F1EA}'
+
+describe('orca terminal unicode provider', () => {
+  it('folds a regional indicator pair into one wide flag cluster', async () => {
+    const { terminal } = createRendererParityTerminal({ cols: 40, rows: 4 })
+
+    await writeToTerminal(terminal, US)
+
+    expect(readCells(terminal, 2)).toEqual([
+      { chars: US, width: 2 },
+      { chars: '', width: 0 }
+    ])
+    terminal.dispose()
+  })
+
+  it('starts a new flag on the next pair instead of chaining indicators', async () => {
+    const { terminal } = createRendererParityTerminal({ cols: 40, rows: 4 })
+
+    await writeToTerminal(terminal, US + DE)
+
+    expect(readCells(terminal, 4)).toEqual([
+      { chars: US, width: 2 },
+      { chars: '', width: 0 },
+      { chars: DE, width: 2 },
+      { chars: '', width: 0 }
+    ])
+    terminal.dispose()
+  })
+
+  it('leaves a trailing unpaired indicator on its own', async () => {
+    const { terminal } = createRendererParityTerminal({ cols: 40, rows: 4 })
+
+    await writeToTerminal(terminal, `${US}\u{1F1E9}`)
+
+    expect(readCells(terminal, 3)).toEqual([
+      { chars: US, width: 2 },
+      { chars: '', width: 0 },
+      { chars: '\u{1F1E9}', width: 1 }
+    ])
+    terminal.dispose()
+  })
+
+  it('budgets a flag as two cells so positioned writes land past it', async () => {
+    const { terminal } = createRendererParityTerminal({ cols: 40, rows: 4 })
+
+    // A flag totals two cells in wcwidth (each indicator is East_Asian_Width
+    // Neutral), so an agent TUI addressing column 3 must clear the flag.
+    await writeToTerminal(terminal, `\x1b[H${US}AB`)
+    await writeToTerminal(terminal, '\x1b[1;3HZ')
+
+    expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe(`${US}ZB`)
+    terminal.dispose()
+  })
+
+  it('keeps ZWJ joining and plain wide glyphs unchanged', async () => {
+    const { terminal } = createRendererParityTerminal({ cols: 40, rows: 4 })
+
+    const family = '\u{1F469}\u{200D}\u{1F4BB}'
+    await writeToTerminal(terminal, `${family}\u{1F600}你`)
+
+    expect(readCells(terminal, 6)).toEqual([
+      { chars: family, width: 2 },
+      { chars: '', width: 0 },
+      { chars: '\u{1F600}', width: 2 },
+      { chars: '', width: 0 },
+      { chars: '你', width: 2 },
+      { chars: '', width: 0 }
+    ])
+    terminal.dispose()
+  })
+})

--- a/src/shared/terminal-unicode-provider.test.ts
+++ b/src/shared/terminal-unicode-provider.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { Terminal } from '@xterm/headless'
 import { createRendererParityTerminal, writeToTerminal } from './terminal-restore-parity-fixture'
 
-// Why these oracles: a country flag is two regional indicators with no ZWJ, so the
-// ZWJ-only join rule left each indicator in its own cell. Chromium then shapes each
-// one alone and paints a lettered tile instead of the flag. Cell contents (not just
-// row text) are asserted because the row string looks identical either way.
+// Cell contents expose shaping clusters that row text cannot distinguish.
 type Cell = { chars: string; width: number }
 
 function readCells(terminal: Terminal, count: number): Cell[] {
@@ -22,10 +19,11 @@ const US = '\u{1F1FA}\u{1F1F8}'
 const DE = '\u{1F1E9}\u{1F1EA}'
 
 describe('orca terminal unicode provider', () => {
-  it('folds a regional indicator pair into one wide flag cluster', async () => {
+  it('folds a regional indicator pair split across writes into one flag cluster', async () => {
     const { terminal } = createRendererParityTerminal({ cols: 40, rows: 4 })
 
-    await writeToTerminal(terminal, US)
+    await writeToTerminal(terminal, '\u{1F1FA}')
+    await writeToTerminal(terminal, '\u{1F1F8}')
 
     expect(readCells(terminal, 2)).toEqual([
       { chars: US, width: 2 },
@@ -64,8 +62,7 @@ describe('orca terminal unicode provider', () => {
   it('budgets a flag as two cells so positioned writes land past it', async () => {
     const { terminal } = createRendererParityTerminal({ cols: 40, rows: 4 })
 
-    // A flag totals two cells in wcwidth (each indicator is East_Asian_Width
-    // Neutral), so an agent TUI addressing column 3 must clear the flag.
+    // Agent TUIs address the flag's two-column CLI width.
     await writeToTerminal(terminal, `\x1b[H${US}AB`)
     await writeToTerminal(terminal, '\x1b[1;3HZ')
 

--- a/src/shared/terminal-unicode-provider.ts
+++ b/src/shared/terminal-unicode-provider.ts
@@ -55,11 +55,9 @@ class OrcaUnicodeProvider implements IUnicodeVersionProvider {
     }
 
     if (isRegionalIndicator(codepoint)) {
-      // Why: a country flag is two adjacent regional indicators with no ZWJ. CLIs
-      // budget the pair as one wide cell pair; xterm Unicode11 otherwise gives each
-      // indicator its own cell and the font paints two lone letter tiles.
+      // Flags join two indicators while retaining their two-cell CLI width.
       if (isRegionalIndicator(precedingKind) && precedingWidth > 0) {
-        // charKind 0 closes the pair so a third indicator opens the next flag.
+        // Reset the kind so a third indicator starts the next pair.
         return createProperties(0, 2, true)
       }
       return createProperties(codepoint, this.wcwidth(codepoint), false)

--- a/src/shared/terminal-unicode-provider.ts
+++ b/src/shared/terminal-unicode-provider.ts
@@ -12,6 +12,12 @@ type XtermTerminalWithUnicodeCore = {
 const ORCA_UNICODE_VERSION = 'orca-11-zwj'
 const UNICODE11_VERSION = '11'
 const ZERO_WIDTH_JOINER = 0x200d
+const REGIONAL_INDICATOR_FIRST = 0x1f1e6
+const REGIONAL_INDICATOR_LAST = 0x1f1ff
+
+function isRegionalIndicator(codepoint: number): boolean {
+  return codepoint >= REGIONAL_INDICATOR_FIRST && codepoint <= REGIONAL_INDICATOR_LAST
+}
 
 function extractWidth(properties: number): 0 | 1 | 2 {
   return ((properties >> 1) & 3) as 0 | 1 | 2
@@ -46,6 +52,17 @@ class OrcaUnicodeProvider implements IUnicodeVersionProvider {
       // Why: CLIs render ZWJ emoji as one visible glyph and budget them as one
       // wide cell pair; xterm Unicode11 otherwise advances for both emoji parts.
       return createProperties(codepoint, precedingWidth, true)
+    }
+
+    if (isRegionalIndicator(codepoint)) {
+      // Why: a country flag is two adjacent regional indicators with no ZWJ. CLIs
+      // budget the pair as one wide cell pair; xterm Unicode11 otherwise gives each
+      // indicator its own cell and the font paints two lone letter tiles.
+      if (isRegionalIndicator(precedingKind) && precedingWidth > 0) {
+        // charKind 0 closes the pair so a third indicator opens the next flag.
+        return createProperties(0, 2, true)
+      }
+      return createProperties(codepoint, this.wcwidth(codepoint), false)
     }
 
     return this.baseProvider.charProperties(codepoint, preceding)


### PR DESCRIPTION
Fixes #10731.

## User-visible change

Country flag emoji (🇺🇸 🇩🇪 🇯🇵) rendered as two lettered tiles in the terminal instead of the flag. They now render as a single flag glyph.

**Visual change:** yes, terminal glyph rendering only — no UI/layout/component change. Before: `printf '🇺🇸 🇩🇪 🇯🇵'` paints boxed letter pairs (🇺 🇸). After: it paints the flags. No screenshot attached because the difference is font shaping in the terminal grid; the cell-level assertions in `terminal-unicode-provider.test.ts` capture it precisely (the row *string* is identical either way — only the cell clustering differs, which is exactly why this went unnoticed).

## Root cause

A country flag is two adjacent Regional Indicator Symbols (U+1F1E6–U+1F1FF) with **no ZWJ** — e.g. 🇺🇸 = U+1F1FA U+1F1F8. `OrcaUnicodeProvider.charProperties` only joins across ZWJ, so each indicator stayed in its own cell. Chromium then shaped each one in isolation and drew a lone letter tile rather than shaping the pair into a flag.

Note the indicators are *not* in xterm's Unicode 11 wide table (`wcwidth` = 1 each), so total column budgeting was already 2 — the bug is purely missing cluster joining, not width.

## Fix

Pair regional indicators into one two-cell cluster, mirroring the existing ZWJ branch:

- `charKind` resets to `0` on the completed pair, so a third indicator opens a **new** flag instead of chaining into a three-glyph cluster (`RI RI RI` → flag + lone indicator, per UAX #29).
- Joined width is **2**, matching the pair's total `wcwidth` (each indicator is `East_Asian_Width=Neutral` → 1 + 1). This keeps cursor budgeting in step with what CLIs compute, so positioned writes don't drift.

Considered and rejected: swapping to `@xterm/addon-unicode-graphemes` (full UAX #29 segmentation). It would compute widths by spec rather than by the CLI convention this provider deliberately encodes for ZWJ sequences, regressing that tuned behavior and the terminal rendering goldens. The targeted change fits the existing architecture.

## Tests

- `src/shared/terminal-unicode-provider.test.ts` (new) — asserts cell contents + widths via `createRendererParityTerminal`: pair folding, consecutive flags, trailing unpaired indicator, column budgeting, and a ZWJ/CJK/plain-emoji regression guard.
- `src/main/daemon/headless-emulator-unicode-width.test.ts` — flag cases in the existing style, covering the daemon mirror used by mobile/remote.

Verified the three cluster-level tests **fail without the provider change** and pass with it. The width-budget assertions pass either way by design — they lock the two-cell contract against a future "fix" that returns `precedingWidth`.

`pnpm lint` (oxlint on changed files) and `pnpm typecheck` (`tsconfig.node.json`) are clean. Ran the `src/main/daemon`, `src/renderer/src/lib/pane-manager`, and `src/renderer/src/components/terminal-pane` suites: 4123 passed. The only failures are `node-pty-fd-leak.test.ts` / `shell-ready.test.ts` with `posix_spawnp failed` — reproduced identically on a clean tree with these changes stashed (unbuilt native `node-pty` in my sandbox), unrelated to this change.

## Code review summary

- **Cross-platform:** pure Unicode arithmetic in `src/shared`, no platform branches, no paths, no keybindings. Identical on macOS/Linux/Windows.
- **SSH / remote / local:** the provider is shared by the renderer pane, the daemon headless emulator, and the web bundle, so local, SSH, remote-server and mobile viewers all pick it up from one place; no host assumptions added. Daemon path covered by tests.
- **Agents / integrations / git providers:** none touched — this is below the agent layer. Agent TUIs benefit because flag budgeting is unchanged (still 2 columns) while clustering is now correct.
- **Performance:** two integer range comparisons on a path that already ran per codepoint, and only for codepoints that reach the fallback. No allocation, no new indirection in the write hot path.
- **UI quality:** no component, token, or layout change; STYLEGUIDE.md not implicated.
- **Security:** no I/O, no parsing of untrusted structure beyond codepoint values already flowing through the emulator; no new surface.

## Notes for reviewers

Skin-tone modifiers, variation selectors and keycap sequences are deliberately out of scope here — they're separate cluster classes and would each need their own width decision. Happy to follow up if you'd like them covered.

## Maintainer validation (2026-07-26)

- Confirmed in an isolated Electron dev instance with the real WebGL terminal: the US, Germany, and Japan flags each render as one combined two-column glyph. An adjacent ZWJ emoji, plain wide emoji, and CJK glyph remained correct.
- The follow-up commit splits the first flag across two terminal writes, covering arbitrary PTY chunk boundaries while retaining the cell-level clustering assertion.
- `pnpm typecheck` passed. Targeted oxlint passed. The provider, daemon width, renderer/daemon parity, and hidden/reveal fuzz suites passed: 17 tests passed and 2 were skipped by their existing gates.
- Performance audit: no allocation, polling, IPC, or renderer lifecycle work was added. Synthetic headless runs processed 2 million mixed characters in about 30-37 ms of CPU versus 27-31 ms for the prior provider; the measured absolute delta was about 3-6 ms per 2 million characters. The live renderer finished with zero pending or in-flight characters.
- Full `pnpm lint` reached pre-existing localization-coverage findings in untouched settings-search files; all changed files passed oxlint, formatting hooks, and typecheck.
