### PR TITLE
test(settings): correct stale coverage note on the remote-scope test

### DIFF
--- a/src/renderer/src/components/settings/AccountsPane.test.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.test.tsx
@@ -103,8 +103,8 @@ describe('AccountsPane', () => {
 
   it('scopes account copy to the active remote server and disables local sign-in actions', () => {
     // Note: static SSR markup reads the store's initial state (zustand v5), so
-    // this exercises the fallback server label; the named-server path is
-    // covered by live validation against a paired server.
+    // this exercises the pre-hydration path where no server name is known yet.
+    // The named-server label is covered in provider-account-scope.test.ts.
     const markup = renderPane(
       {
         ...getDefaultSettings('/tmp'),


### PR DESCRIPTION
Follow-up to #8188.

That PR moved the account-scope label into `getRemoteAccountsPaneScope()` and unit-tested both branches in `provider-account-scope.test.ts`, but the note above the `AccountsPane` remote-scope test still said the named-server path was "covered by live validation against a paired server." That was true of the original PR and is no longer true, so the note now points a future reader away from the coverage that exists.

Comment-only; no behavior change. It just missed the merge window on #8188.

## Testing

`vitest run src/renderer/src/components/settings/AccountsPane.test.tsx src/renderer/src/components/settings/provider-account-scope.test.ts` — 13 passed.

Made with [Orca](https://github.com/stablyai/orca) 🐋
