### PR TITLE
fix(mobile): open previewed files in editor tabs

### DIFF
--- a/mobile/src/files/MobileFilePreviewScreen.test.ts
+++ b/mobile/src/files/MobileFilePreviewScreen.test.ts
@@ -3,6 +3,7 @@ import { sourceKeyForPreview } from './mobile-file-preview-source'
 import {
   hasUnsavedMobileTerminalArtifactDraft,
   isEditableMobileTerminalArtifactPreview,
+  isOpenableMobileWorktreeFilePreview,
   shouldKeepDirtyDraftOnPreviewLoadResult
 } from './mobile-file-preview-editability'
 
@@ -35,6 +36,61 @@ describe('MobileFilePreviewScreen', () => {
         content: 'partial',
         truncated: true,
         byteLength: 1024
+      })
+    ).toBe(false)
+  })
+
+  it('offers Open for worktree text, code, HTML, and Markdown previews', () => {
+    expect(
+      isOpenableMobileWorktreeFilePreview('worktree', {
+        status: 'ready',
+        kind: 'markdown',
+        content: '# Notes',
+        truncated: false,
+        byteLength: 7
+      })
+    ).toBe(true)
+    expect(
+      isOpenableMobileWorktreeFilePreview('worktree', {
+        status: 'empty',
+        kind: 'markdown'
+      })
+    ).toBe(true)
+    expect(
+      isOpenableMobileWorktreeFilePreview('worktree', {
+        status: 'ready',
+        kind: 'text',
+        content: 'export const value = 1',
+        truncated: true,
+        byteLength: 500_000
+      })
+    ).toBe(true)
+    expect(
+      isOpenableMobileWorktreeFilePreview('worktree', {
+        status: 'ready',
+        kind: 'html',
+        content: '<main>Hello</main>',
+        truncated: false,
+        byteLength: 18
+      })
+    ).toBe(true)
+  })
+
+  it('does not offer Open for images or non-worktree artifacts', () => {
+    expect(
+      isOpenableMobileWorktreeFilePreview('worktree', {
+        status: 'ready',
+        kind: 'image',
+        dataUri: 'data:image/png;base64,aW1n'
+      })
+    ).toBe(false)
+    expect(
+      isOpenableMobileWorktreeFilePreview('terminalArtifact', {
+        status: 'ready',
+        kind: 'markdown',
+        content: '# Artifact',
+        truncated: false,
+        byteLength: 10
       })
     ).toBe(false)
   })

--- a/mobile/src/files/MobileFilePreviewScreen.tsx
+++ b/mobile/src/files/MobileFilePreviewScreen.tsx
@@ -1,9 +1,18 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Alert, BackHandler, Pressable, Text, View, useWindowDimensions } from 'react-native'
+import {
+  ActivityIndicator,
+  Alert,
+  BackHandler,
+  Pressable,
+  Text,
+  View,
+  useWindowDimensions
+} from 'react-native'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
-import { ChevronLeft, Save } from 'lucide-react-native'
+import { ChevronLeft, FileText, Save } from 'lucide-react-native'
 import { getWorktreeLabel } from '../session/worktree-label'
+import { useMobileWorktreeFileOpener } from '../session/use-mobile-worktree-file-opener'
 import { colors, spacing } from '../theme/mobile-theme'
 import { useForceReconnect, useHostClient } from '../transport/client-context'
 import {
@@ -15,6 +24,7 @@ import {
 } from './mobile-file-preview-request'
 import { MobileFilePreviewBody } from './MobileFilePreviewBody'
 import {
+  createMobileFilePreviewSessionHref,
   displayNameFromPreviewPath,
   type MobileFilePreviewRouteState
 } from './mobile-file-preview-route'
@@ -23,6 +33,7 @@ import { normalizeMobileFilePreviewLineColumn } from './mobile-file-preview-line
 import {
   hasUnsavedMobileTerminalArtifactDraft,
   isEditableMobileTerminalArtifactPreview,
+  isOpenableMobileWorktreeFilePreview,
   shouldKeepDirtyDraftOnPreviewLoadResult
 } from './mobile-file-preview-editability'
 import { filePreviewStyles as styles } from './mobile-file-preview-styles'
@@ -43,6 +54,10 @@ export function MobileFilePreviewScreen({ route }: Props) {
   const [savedContent, setSavedContent] = useState('')
   const [saveError, setSaveError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [openFailure, setOpenFailure] = useState<{
+    scopeKey: string | null
+    message: string
+  } | null>(null)
   const draftContentRef = useRef(draftContent)
   const savedContentRef = useRef(savedContent)
   const draftSourceKeyRef = useRef<string | null>(null)
@@ -67,6 +82,31 @@ export function MobileFilePreviewScreen({ route }: Props) {
         : null,
     [previewParams]
   )
+
+  const returnToSession = useCallback(() => {
+    if (!previewParams) {
+      return
+    }
+    router.dismissTo(
+      createMobileFilePreviewSessionHref(previewParams) as Parameters<typeof router.dismissTo>[0]
+    )
+  }, [previewParams, router])
+  const setScopedOpenError = useCallback(
+    (message: string | null) => {
+      setOpenFailure(message ? { scopeKey: previewSourceKey, message } : null)
+    },
+    [previewSourceKey]
+  )
+  const { opening, openWorktreeFile } = useMobileWorktreeFileOpener({
+    client,
+    connectionState: connState,
+    worktreeId: previewParams?.worktreeId ?? '',
+    scopeKey: previewSourceKey,
+    onActivated: returnToSession,
+    onErrorChange: setScopedOpenError
+  })
+  const openError =
+    openFailure?.scopeKey === previewSourceKey ? (openFailure?.message ?? null) : null
 
   useEffect(() => {
     setPreviewSource(routePreviewSource)
@@ -182,6 +222,10 @@ export function MobileFilePreviewScreen({ route }: Props) {
   const meta = previewParams ? `${worktreeLabel} - ${displayPath}` : 'Preview'
   const isEditableTerminalArtifact =
     previewSource?.source === 'terminalArtifact' && isEditableMobileTerminalArtifactPreview(preview)
+  const previewMatchesRoute = previewSourceKey === routePreviewSourceKey
+  const canOpenWorktreeFile =
+    previewMatchesRoute && isOpenableMobileWorktreeFilePreview(previewSource?.source, preview)
+  const openDisabled = opening || !client || connState !== 'connected'
   const canSaveArtifact =
     isEditableTerminalArtifact &&
     draftSourceKeyRef.current === previewSourceKey &&
@@ -217,6 +261,12 @@ export function MobileFilePreviewScreen({ route }: Props) {
       setSaving(false)
     }
   }, [canSaveArtifact, client, draftContent, previewSource, savedContent, saving])
+
+  const openWorktreeFileInPane = useCallback(() => {
+    if (previewSource?.source === 'worktree') {
+      openWorktreeFile(previewSource.relativePath)
+    }
+  }, [openWorktreeFile, previewSource])
 
   const requestBack = useCallback(() => {
     if (!hasUnsavedTerminalArtifactDraft) {
@@ -264,9 +314,36 @@ export function MobileFilePreviewScreen({ route }: Props) {
             >
               <Save size={18} color={colors.textPrimary} strokeWidth={2.2} />
             </Pressable>
+          ) : canOpenWorktreeFile ? (
+            <Pressable
+              style={({ pressed }) => [
+                styles.openButton,
+                pressed && !openDisabled && styles.openButtonPressed,
+                openDisabled && styles.openButtonDisabled
+              ]}
+              onPress={openWorktreeFileInPane}
+              disabled={openDisabled}
+              accessibilityRole="button"
+              accessibilityLabel="Open file in editor"
+              accessibilityState={{ disabled: openDisabled, busy: opening }}
+            >
+              {opening ? (
+                <ActivityIndicator size="small" color={colors.textPrimary} />
+              ) : (
+                <>
+                  <FileText size={15} color={colors.textPrimary} strokeWidth={2.2} />
+                  <Text style={styles.openButtonText}>Open</Text>
+                </>
+              )}
+            </Pressable>
           ) : null}
         </View>
       </SafeAreaView>
+      {openError ? (
+        <Text style={styles.openErrorText} accessibilityLiveRegion="polite">
+          {openError}
+        </Text>
+      ) : null}
       <MobileFilePreviewBody
         preview={preview}
         relativePath={displayPath}

--- a/mobile/src/files/mobile-file-preview-editability.ts
+++ b/mobile/src/files/mobile-file-preview-editability.ts
@@ -10,6 +10,16 @@ export function isEditableMobileTerminalArtifactPreview(preview: MobileFilePrevi
   )
 }
 
+export function isOpenableMobileWorktreeFilePreview(
+  source: MobileFilePreviewSource['source'] | undefined,
+  preview: MobileFilePreviewResult
+): boolean {
+  return (
+    source === 'worktree' &&
+    ((preview.status === 'ready' && preview.kind !== 'image') || preview.status === 'empty')
+  )
+}
+
 export function hasUnsavedMobileTerminalArtifactDraft({
   source,
   draftSourceKey,

--- a/mobile/src/files/mobile-file-preview-route.test.ts
+++ b/mobile/src/files/mobile-file-preview-route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   createMobileFilePreviewHref,
+  createMobileFilePreviewSessionHref,
   displayNameFromPreviewPath,
   normalizeMobileFilePreviewRouteParams
 } from './mobile-file-preview-route'
@@ -126,6 +127,20 @@ describe('mobile-file-preview-route', () => {
         name: 'file.ts'
       }
     })
+  })
+
+  it('builds the existing session destination with encoded path and name values', () => {
+    expect(
+      createMobileFilePreviewSessionHref({
+        hostId: 'host/one',
+        worktreeId: 'repo::feature notes',
+        worktreeName: 'Feature & notes'
+      })
+    ).toBe('/h/host%2Fone/session/repo%3A%3Afeature%20notes?name=Feature%20%26%20notes')
+
+    expect(createMobileFilePreviewSessionHref({ hostId: 'host-1', worktreeId: 'wt-1' })).toBe(
+      '/h/host-1/session/wt-1'
+    )
   })
 
   it('derives display names from slash or backslash paths only for display', () => {

--- a/mobile/src/files/mobile-file-preview-route.ts
+++ b/mobile/src/files/mobile-file-preview-route.ts
@@ -110,6 +110,13 @@ export function createMobileFilePreviewHref(
   }
 }
 
+export function createMobileFilePreviewSessionHref(
+  params: Pick<MobileFilePreviewRouteParams, 'hostId' | 'worktreeId' | 'worktreeName'>
+): string {
+  const path = `/h/${encodeURIComponent(params.hostId)}/session/${encodeURIComponent(params.worktreeId)}`
+  return params.worktreeName ? `${path}?name=${encodeURIComponent(params.worktreeName)}` : path
+}
+
 export function displayNameFromPreviewPath(relativePath: string): string {
   return relativePath.split(/[\\/]/).findLast(Boolean) ?? relativePath
 }

--- a/mobile/src/files/mobile-file-preview-styles.ts
+++ b/mobile/src/files/mobile-file-preview-styles.ts
@@ -84,6 +84,35 @@ export const filePreviewStyles = StyleSheet.create({
   saveButtonDisabled: {
     opacity: 0.42
   },
+  openButton: {
+    minWidth: 72,
+    height: 36,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgRaised,
+    paddingHorizontal: spacing.md
+  },
+  openButtonPressed: {
+    opacity: 0.78
+  },
+  openButtonDisabled: {
+    opacity: 0.42
+  },
+  openButtonText: {
+    color: colors.textPrimary,
+    fontSize: typography.bodySize,
+    fontWeight: '600'
+  },
+  openErrorText: {
+    color: colors.statusRed,
+    fontSize: typography.metaSize,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    backgroundColor: colors.bgPanel
+  },
   scroll: {
     flex: 1,
     backgroundColor: colors.editorSurface

--- a/mobile/src/session/mobile-worktree-file-tab-open.test.ts
+++ b/mobile/src/session/mobile-worktree-file-tab-open.test.ts
@@ -1,0 +1,315 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcResponse } from '../transport/types'
+import { openMobileWorktreeFileTab } from './mobile-worktree-file-tab-open'
+
+function success(result: unknown): RpcResponse {
+  return { id: 'rpc-1', ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+}
+
+function failure(code: string, message: string): RpcResponse {
+  return {
+    id: 'rpc-1',
+    ok: false,
+    error: { code, message },
+    _meta: { runtimeId: 'runtime-1' }
+  }
+}
+
+function openResult(opened = true, kind: 'markdown' | 'text' | 'binary' | 'image' = 'markdown') {
+  return {
+    worktree: 'worktree-1',
+    relativePath: 'docs/readme.md',
+    kind,
+    opened
+  }
+}
+
+function clientWith(sendRequest: RpcClient['sendRequest']): Pick<RpcClient, 'sendRequest'> {
+  return { sendRequest }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('openMobileWorktreeFileTab', () => {
+  it('opens, finds the exact non-diff tab, and activates it for only the caller', async () => {
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValueOnce(success(openResult()))
+      .mockResolvedValueOnce(
+        success({
+          tabs: [
+            {
+              type: 'file',
+              id: 'other',
+              relativePath: 'docs/readme.md.bak',
+              mode: 'edit'
+            },
+            { type: 'file', id: 'diff', relativePath: 'docs/readme.md', mode: 'diff' },
+            { type: 'markdown', id: 'edit', relativePath: 'docs/readme.md' }
+          ]
+        })
+      )
+      .mockResolvedValueOnce(success({ activeTabId: 'edit' }))
+
+    await expect(
+      openMobileWorktreeFileTab({
+        client: clientWith(sendRequest),
+        worktreeId: 'worktree-1',
+        relativePath: 'docs/readme.md'
+      })
+    ).resolves.toEqual({ status: 'activated', tabId: 'edit', kind: 'markdown' })
+
+    expect(sendRequest).toHaveBeenNthCalledWith(
+      1,
+      'files.open',
+      { worktree: 'id:worktree-1', relativePath: 'docs/readme.md' },
+      { timeoutMs: 15_000 }
+    )
+    expect(sendRequest).toHaveBeenNthCalledWith(
+      2,
+      'session.tabs.list',
+      { worktree: 'id:worktree-1' },
+      { timeoutMs: 10_000 }
+    )
+    expect(sendRequest).toHaveBeenNthCalledWith(3, 'session.tabs.activate', {
+      worktree: 'id:worktree-1',
+      tabId: 'edit',
+      notifyClients: false,
+      navigation: 'caller'
+    })
+  })
+
+  it('waits for delayed SSH tab publication before activation', async () => {
+    vi.useFakeTimers()
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValueOnce(success(openResult()))
+      .mockResolvedValueOnce(success({ tabs: [] }))
+      .mockResolvedValueOnce(success({ tabs: [] }))
+      .mockResolvedValueOnce(
+        success({ tabs: [{ type: 'markdown', id: 'remote-tab', relativePath: 'docs/readme.md' }] })
+      )
+      .mockResolvedValueOnce(success({ activeTabId: 'remote-tab' }))
+
+    const opening = openMobileWorktreeFileTab({
+      client: clientWith(sendRequest),
+      worktreeId: 'worktree-1',
+      relativePath: 'docs/readme.md'
+    })
+    await vi.advanceTimersByTimeAsync(900)
+
+    await expect(opening).resolves.toEqual({
+      status: 'activated',
+      tabId: 'remote-tab',
+      kind: 'markdown'
+    })
+    expect(sendRequest).toHaveBeenCalledTimes(5)
+  })
+
+  it.each([
+    { staleMode: 'diff', staleId: 'existing-diff' },
+    { staleMode: 'markdown-preview', staleId: 'existing-preview' }
+  ])('waits for an edit tab instead of activating a same-path $staleMode tab', async (entry) => {
+    vi.useFakeTimers()
+    const staleTab = {
+      type: entry.staleMode === 'diff' ? 'file' : 'markdown',
+      id: entry.staleId,
+      relativePath: 'docs/readme.md',
+      mode: entry.staleMode
+    }
+    const editTab = {
+      type: 'markdown',
+      id: 'new-edit',
+      relativePath: 'docs/readme.md',
+      mode: 'edit'
+    }
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValueOnce(success(openResult()))
+      .mockResolvedValueOnce(success({ tabs: [staleTab] }))
+      .mockResolvedValueOnce(success({ tabs: [staleTab, editTab] }))
+      .mockResolvedValueOnce(success({ activeTabId: 'new-edit' }))
+
+    const opening = openMobileWorktreeFileTab({
+      client: clientWith(sendRequest),
+      worktreeId: 'worktree-1',
+      relativePath: 'docs/readme.md'
+    })
+    await vi.advanceTimersByTimeAsync(300)
+
+    await expect(opening).resolves.toEqual({
+      status: 'activated',
+      tabId: 'new-edit',
+      kind: 'markdown'
+    })
+    expect(sendRequest).toHaveBeenLastCalledWith('session.tabs.activate', {
+      worktree: 'id:worktree-1',
+      tabId: 'new-edit',
+      notifyClients: false,
+      navigation: 'caller'
+    })
+  })
+
+  it('returns an explicit open failure without listing tabs', async () => {
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValue(failure('renderer_unavailable', 'Renderer unavailable'))
+
+    await expect(
+      openMobileWorktreeFileTab({
+        client: clientWith(sendRequest),
+        worktreeId: 'worktree-1',
+        relativePath: 'docs/readme.md'
+      })
+    ).resolves.toEqual({
+      status: 'failed',
+      stage: 'open',
+      code: 'renderer_unavailable',
+      message: 'Renderer unavailable'
+    })
+    expect(sendRequest).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    { worktree: 'other-worktree', relativePath: 'docs/readme.md' },
+    { worktree: 'worktree-1', relativePath: 'docs/other.md' }
+  ])('rejects a files.open response for a different target', async (target) => {
+    const sendRequest = vi.fn<RpcClient['sendRequest']>().mockResolvedValue(
+      success({
+        ...openResult(),
+        ...target
+      })
+    )
+
+    await expect(
+      openMobileWorktreeFileTab({
+        client: clientWith(sendRequest),
+        worktreeId: 'worktree-1',
+        relativePath: 'docs/readme.md'
+      })
+    ).resolves.toEqual({
+      status: 'failed',
+      stage: 'open',
+      code: 'invalid_response',
+      message: 'Invalid files.open response'
+    })
+    expect(sendRequest).toHaveBeenCalledOnce()
+  })
+
+  it('reports unsupported binary files when the host declines to open them', async () => {
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValue(success(openResult(false, 'binary')))
+
+    await expect(
+      openMobileWorktreeFileTab({
+        client: clientWith(sendRequest),
+        worktreeId: 'worktree-1',
+        relativePath: 'docs/readme.md'
+      })
+    ).resolves.toEqual({ status: 'not-opened', kind: 'binary' })
+    expect(sendRequest).toHaveBeenCalledOnce()
+  })
+
+  it('returns timeout after a finite number of successful empty snapshots', async () => {
+    vi.useFakeTimers()
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValueOnce(success(openResult()))
+      .mockResolvedValue(success({ tabs: [] }))
+
+    const opening = openMobileWorktreeFileTab({
+      client: clientWith(sendRequest),
+      worktreeId: 'worktree-1',
+      relativePath: 'docs/readme.md'
+    })
+    await vi.advanceTimersByTimeAsync(1_800)
+
+    await expect(opening).resolves.toEqual({ status: 'timeout', attempts: 4 })
+    expect(sendRequest).toHaveBeenCalledTimes(5)
+  })
+
+  it('returns a list failure instead of treating a missing snapshot as success', async () => {
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValueOnce(success(openResult()))
+      .mockResolvedValueOnce(failure('disconnected', 'Desktop disconnected'))
+
+    await expect(
+      openMobileWorktreeFileTab({
+        client: clientWith(sendRequest),
+        worktreeId: 'worktree-1',
+        relativePath: 'docs/readme.md'
+      })
+    ).resolves.toEqual({
+      status: 'failed',
+      stage: 'list',
+      code: 'disconnected',
+      message: 'Desktop disconnected'
+    })
+  })
+
+  it('requires activation confirmation before reporting success', async () => {
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValueOnce(success(openResult()))
+      .mockResolvedValueOnce(
+        success({ tabs: [{ type: 'markdown', id: 'edit', relativePath: 'docs/readme.md' }] })
+      )
+      .mockResolvedValueOnce(success({ activeTabId: 'other-tab' }))
+
+    await expect(
+      openMobileWorktreeFileTab({
+        client: clientWith(sendRequest),
+        worktreeId: 'worktree-1',
+        relativePath: 'docs/readme.md'
+      })
+    ).resolves.toEqual({
+      status: 'failed',
+      stage: 'activate',
+      code: 'activation_unconfirmed',
+      message: 'Host did not confirm session tab activation'
+    })
+  })
+
+  it('cancels before issuing any RPC when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const sendRequest = vi.fn<RpcClient['sendRequest']>()
+
+    await expect(
+      openMobileWorktreeFileTab({
+        client: clientWith(sendRequest),
+        worktreeId: 'worktree-1',
+        relativePath: 'docs/readme.md',
+        signal: controller.signal
+      })
+    ).resolves.toEqual({ status: 'cancelled' })
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('stops polling when a newer caller action supersedes the request', async () => {
+    vi.useFakeTimers()
+    let current = true
+    const sendRequest = vi
+      .fn<RpcClient['sendRequest']>()
+      .mockResolvedValueOnce(success(openResult()))
+      .mockResolvedValueOnce(success({ tabs: [] }))
+
+    const opening = openMobileWorktreeFileTab({
+      client: clientWith(sendRequest),
+      worktreeId: 'worktree-1',
+      relativePath: 'docs/readme.md',
+      isCurrent: () => current
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    current = false
+    await vi.advanceTimersByTimeAsync(300)
+
+    await expect(opening).resolves.toEqual({ status: 'cancelled' })
+    expect(sendRequest).toHaveBeenCalledTimes(2)
+  })
+})

--- a/mobile/src/session/mobile-worktree-file-tab-open.ts
+++ b/mobile/src/session/mobile-worktree-file-tab-open.ts
@@ -1,0 +1,251 @@
+import type { RuntimeFileOpenResult } from '../../../src/shared/runtime-types'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcFailure, RpcResponse } from '../transport/types'
+import { activateMobileSessionTab } from './mobile-session-tab-activation'
+import {
+  findEditableOpenedMobileSessionTab,
+  type OpenedMobileSessionTabCandidate
+} from './opened-mobile-session-tab'
+
+type WorktreeFileTabOpenClient = Pick<RpcClient, 'sendRequest'>
+
+export type MobileWorktreeFileTabOpenOptions = {
+  client: WorktreeFileTabOpenClient
+  worktreeId: string
+  relativePath: string
+  signal?: AbortSignal
+  isCurrent?: () => boolean
+}
+
+type MobileWorktreeFileTabOpenFailureStage = 'open' | 'list' | 'activate'
+
+export type MobileWorktreeFileTabOpenResult =
+  | {
+      status: 'activated'
+      tabId: string
+      kind: RuntimeFileOpenResult['kind']
+    }
+  | { status: 'cancelled' }
+  | {
+      status: 'not-opened'
+      kind: RuntimeFileOpenResult['kind']
+    }
+  | {
+      status: 'timeout'
+      attempts: number
+    }
+  | {
+      status: 'failed'
+      stage: MobileWorktreeFileTabOpenFailureStage
+      message: string
+      code?: string
+    }
+
+const OPEN_REQUEST_TIMEOUT_MS = 15_000
+const TAB_LIST_REQUEST_TIMEOUT_MS = 10_000
+const TAB_POLL_DELAYS_MS = [0, 300, 600, 900] as const
+
+export async function openMobileWorktreeFileTab(
+  options: MobileWorktreeFileTabOpenOptions
+): Promise<MobileWorktreeFileTabOpenResult> {
+  if (isCancelled(options)) {
+    return { status: 'cancelled' }
+  }
+  const worktree = `id:${options.worktreeId}`
+  const openResponse = await sendRequest(
+    options.client,
+    'files.open',
+    {
+      worktree,
+      relativePath: options.relativePath
+    },
+    OPEN_REQUEST_TIMEOUT_MS
+  )
+  if (isCancelled(options)) {
+    return { status: 'cancelled' }
+  }
+  if (openResponse instanceof Error) {
+    return failedResult('open', openResponse.message)
+  }
+  if (!openResponse.ok) {
+    return rpcFailureResult('open', openResponse)
+  }
+  const opened = readFileOpenResult(openResponse.result, options.worktreeId, options.relativePath)
+  if (!opened) {
+    return failedResult('open', 'Invalid files.open response', 'invalid_response')
+  }
+  if (!opened.opened) {
+    return { status: 'not-opened', kind: opened.kind }
+  }
+
+  for (let attempt = 0; attempt < TAB_POLL_DELAYS_MS.length; attempt += 1) {
+    await waitForDelay(TAB_POLL_DELAYS_MS[attempt] ?? 0, options.signal)
+    if (isCancelled(options)) {
+      return { status: 'cancelled' }
+    }
+    const listResponse = await sendRequest(
+      options.client,
+      'session.tabs.list',
+      { worktree },
+      TAB_LIST_REQUEST_TIMEOUT_MS
+    )
+    if (isCancelled(options)) {
+      return { status: 'cancelled' }
+    }
+    if (listResponse instanceof Error) {
+      return failedResult('list', listResponse.message)
+    }
+    if (!listResponse.ok) {
+      return rpcFailureResult('list', listResponse)
+    }
+    const tabs = readSessionTabs(listResponse.result)
+    if (!tabs) {
+      return failedResult('list', 'Invalid session.tabs.list response', 'invalid_response')
+    }
+    const tab = findEditableOpenedMobileSessionTab(tabs, opened.relativePath)
+    if (!tab) {
+      continue
+    }
+    if (isCancelled(options)) {
+      return { status: 'cancelled' }
+    }
+    const activationResponse = await sendActivationRequest(options.client, worktree, tab.id)
+    if (isCancelled(options)) {
+      return { status: 'cancelled' }
+    }
+    if (activationResponse instanceof Error) {
+      return failedResult('activate', activationResponse.message)
+    }
+    if (!activationResponse.ok) {
+      return rpcFailureResult('activate', activationResponse)
+    }
+    if (!activationConfirmsTab(activationResponse.result, tab.id)) {
+      return failedResult(
+        'activate',
+        'Host did not confirm session tab activation',
+        'activation_unconfirmed'
+      )
+    }
+    return { status: 'activated', tabId: tab.id, kind: opened.kind }
+  }
+
+  return { status: 'timeout', attempts: TAB_POLL_DELAYS_MS.length }
+}
+
+async function sendRequest(
+  client: WorktreeFileTabOpenClient,
+  method: string,
+  params: unknown,
+  timeoutMs: number
+): Promise<RpcResponse | Error> {
+  try {
+    return await client.sendRequest(method, params, { timeoutMs })
+  } catch (error) {
+    return error instanceof Error ? error : new Error('Request failed')
+  }
+}
+
+async function sendActivationRequest(
+  client: WorktreeFileTabOpenClient,
+  worktree: string,
+  tabId: string
+): Promise<RpcResponse | Error> {
+  try {
+    return await activateMobileSessionTab(client, {
+      worktree,
+      tabId,
+      notifyClients: false,
+      navigation: 'caller'
+    })
+  } catch (error) {
+    return error instanceof Error ? error : new Error('Tab activation failed')
+  }
+}
+
+function readFileOpenResult(
+  value: unknown,
+  worktreeId: string,
+  relativePath: string
+): RuntimeFileOpenResult | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  if (
+    value.worktree !== worktreeId ||
+    value.relativePath !== relativePath ||
+    typeof value.opened !== 'boolean' ||
+    !isFileKind(value.kind)
+  ) {
+    return null
+  }
+  return value as RuntimeFileOpenResult
+}
+
+function readSessionTabs(value: unknown): OpenedMobileSessionTabCandidate[] | null {
+  if (!isRecord(value) || !Array.isArray(value.tabs)) {
+    return null
+  }
+  if (!value.tabs.every(isSessionTabCandidate)) {
+    return null
+  }
+  return value.tabs as OpenedMobileSessionTabCandidate[]
+}
+
+function isSessionTabCandidate(value: unknown): value is OpenedMobileSessionTabCandidate {
+  return isRecord(value) && typeof value.id === 'string' && typeof value.type === 'string'
+}
+
+function activationConfirmsTab(value: unknown, tabId: string): boolean {
+  return isRecord(value) && value.activeTabId === tabId
+}
+
+function isFileKind(value: unknown): value is RuntimeFileOpenResult['kind'] {
+  return value === 'markdown' || value === 'text' || value === 'binary' || value === 'image'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isCancelled(options: MobileWorktreeFileTabOpenOptions): boolean {
+  return options.signal?.aborted === true || options.isCurrent?.() === false
+}
+
+function rpcFailureResult(
+  stage: MobileWorktreeFileTabOpenFailureStage,
+  response: RpcFailure
+): MobileWorktreeFileTabOpenResult {
+  return failedResult(stage, response.error.message, response.error.code)
+}
+
+function failedResult(
+  stage: MobileWorktreeFileTabOpenFailureStage,
+  message: string,
+  code?: string
+): MobileWorktreeFileTabOpenResult {
+  return {
+    status: 'failed',
+    stage,
+    message,
+    ...(code ? { code } : {})
+  }
+}
+
+async function waitForDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (delayMs <= 0 || signal?.aborted) {
+    return
+  }
+  await new Promise<void>((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const finish = () => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      signal?.removeEventListener('abort', finish)
+      resolve()
+    }
+    timer = setTimeout(finish, delayMs)
+    signal?.addEventListener('abort', finish, { once: true })
+  })
+}

--- a/mobile/src/session/opened-mobile-session-tab.test.ts
+++ b/mobile/src/session/opened-mobile-session-tab.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   activateOpenedMobileSessionTab,
   activateOpenedSourceControlDiffTab,
+  findEditableOpenedMobileSessionTab,
   findOpenedMobileSessionTab,
   refreshOpenedMobileSessionTabs,
   shouldActivateOpenedMobileSessionTab,
@@ -69,6 +70,32 @@ describe('findOpenedMobileSessionTab', () => {
     ]
 
     expect(findOpenedMobileSessionTab(tabs, 'README.md', { preferMode: 'diff' })?.id).toBe('diff-1')
+  })
+})
+
+describe('findEditableOpenedMobileSessionTab', () => {
+  it('selects an edit tab without falling back to same-path diff or preview tabs', () => {
+    const tabs: OpenedMobileSessionTabCandidate[] = [
+      { type: 'file', id: 'diff-1', mode: 'diff', relativePath: 'README.md' },
+      {
+        type: 'markdown',
+        id: 'preview-1',
+        mode: 'markdown-preview',
+        relativePath: 'README.md'
+      },
+      { type: 'markdown', id: 'edit-1', mode: 'edit', relativePath: 'README.md' }
+    ]
+
+    expect(findEditableOpenedMobileSessionTab(tabs, 'README.md')?.id).toBe('edit-1')
+    expect(findEditableOpenedMobileSessionTab(tabs.slice(0, 2), 'README.md')).toBeNull()
+  })
+
+  it('accepts legacy file-like tabs that do not publish a mode', () => {
+    const tabs: OpenedMobileSessionTabCandidate[] = [
+      { type: 'markdown', id: 'legacy-1', relativePath: 'README.md' }
+    ]
+
+    expect(findEditableOpenedMobileSessionTab(tabs, 'README.md')?.id).toBe('legacy-1')
   })
 })
 

--- a/mobile/src/session/opened-mobile-session-tab.ts
+++ b/mobile/src/session/opened-mobile-session-tab.ts
@@ -55,6 +55,23 @@ export function findOpenedMobileSessionTab<T extends OpenedMobileSessionTabCandi
   return matches.find((tab) => tab.mode !== 'diff') ?? matches[0] ?? null
 }
 
+export function findEditableOpenedMobileSessionTab<T extends OpenedMobileSessionTabCandidate>(
+  tabs: readonly T[],
+  relativePath: string
+): T | null {
+  const matches = tabs.filter(
+    (tab) =>
+      tab.type !== 'browser' &&
+      tab.type !== 'terminal' &&
+      tab.relativePath === relativePath &&
+      tab.mode !== 'diff' &&
+      tab.mode !== 'markdown-preview'
+  )
+  return (
+    matches.find((tab) => tab.mode === 'edit') ?? matches.find((tab) => tab.mode == null) ?? null
+  )
+}
+
 export type OpenedSourceControlDiffActivationState = {
   activated: boolean
   activationSeq: number

--- a/mobile/src/session/use-mobile-worktree-file-opener.test.ts
+++ b/mobile/src/session/use-mobile-worktree-file-opener.test.ts
@@ -1,0 +1,175 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { ConnectionState } from '../transport/types'
+import {
+  mobileWorktreeFileOpenError,
+  useMobileWorktreeFileOpener
+} from './use-mobile-worktree-file-opener'
+
+const mockOpenWorktreeFileTab = vi.hoisted(() => vi.fn())
+vi.mock('./mobile-worktree-file-tab-open', () => ({
+  openMobileWorktreeFileTab: mockOpenWorktreeFileTab
+}))
+
+type HookValue = ReturnType<typeof useMobileWorktreeFileOpener>
+
+type HarnessProps = {
+  client: Pick<RpcClient, 'sendRequest'> | null
+  connectionState: ConnectionState
+  worktreeId: string
+  scopeKey?: string | null
+  onActivated: (result: {
+    status: 'activated'
+    tabId: string
+    kind: 'markdown' | 'text' | 'binary' | 'image'
+  }) => void
+  onErrorChange: (message: string | null) => void
+}
+
+let hookValue: HookValue | null = null
+let renderer: ReactTestRenderer | null = null
+
+function HookHarness(props: HarnessProps) {
+  hookValue = useMobileWorktreeFileOpener(props)
+  return null
+}
+
+function currentHook(): HookValue {
+  if (!hookValue) {
+    throw new Error('Hook harness did not render')
+  }
+  return hookValue
+}
+
+async function renderHook(props: HarnessProps): Promise<void> {
+  const originalConsoleError = console.error
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+      return
+    }
+    originalConsoleError(...args)
+  })
+  try {
+    await act(async () => {
+      renderer = create(createElement(HookHarness, props))
+    })
+  } finally {
+    consoleErrorSpy.mockRestore()
+  }
+}
+
+async function flushAsyncOperation(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function connectedProps(overrides: Partial<HarnessProps> = {}): HarnessProps {
+  return {
+    client: { sendRequest: vi.fn() },
+    connectionState: 'connected',
+    worktreeId: 'worktree-1',
+    scopeKey: 'markdown-tab-1',
+    onActivated: vi.fn(),
+    onErrorChange: vi.fn(),
+    ...overrides
+  }
+}
+
+afterEach(() => {
+  if (renderer) {
+    act(() => renderer?.unmount())
+  }
+  renderer = null
+  hookValue = null
+  mockOpenWorktreeFileTab.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe('mobileWorktreeFileOpenError', () => {
+  it('keeps RPC details out of user-facing failures', () => {
+    expect(
+      mobileWorktreeFileOpenError({
+        status: 'failed',
+        stage: 'open',
+        message: '/private/worktree/path was rejected',
+        code: 'EACCES'
+      })
+    ).toBe('Unable to open file.')
+  })
+
+  it('distinguishes unsupported files and delayed tab publication', () => {
+    expect(mobileWorktreeFileOpenError({ status: 'not-opened', kind: 'binary' })).toBe(
+      "This file can't be opened in an editor."
+    )
+    expect(mobileWorktreeFileOpenError({ status: 'timeout', attempts: 4 })).toBe(
+      "The file opened, but its tab isn't ready yet. Try again."
+    )
+  })
+})
+
+describe('useMobileWorktreeFileOpener', () => {
+  it('opens and activates a text file in the worktree session', async () => {
+    const props = connectedProps()
+    mockOpenWorktreeFileTab.mockResolvedValue({
+      status: 'activated',
+      tabId: 'file-tab-2',
+      kind: 'text'
+    })
+    await renderHook(props)
+
+    act(() => currentHook().openWorktreeFile('src/app.ts'))
+    await flushAsyncOperation()
+
+    expect(mockOpenWorktreeFileTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: props.client,
+        worktreeId: 'worktree-1',
+        relativePath: 'src/app.ts'
+      })
+    )
+    expect(props.onActivated).toHaveBeenCalledWith({
+      status: 'activated',
+      tabId: 'file-tab-2',
+      kind: 'text'
+    })
+    expect(props.onErrorChange).toHaveBeenCalledWith(null)
+  })
+
+  it('cancels a pending open when the preview scope changes', async () => {
+    let resolveOpen: ((value: unknown) => void) | null = null
+    mockOpenWorktreeFileTab.mockReturnValue(
+      new Promise((resolve) => {
+        resolveOpen = resolve
+      })
+    )
+    const props = connectedProps()
+    await renderHook(props)
+
+    act(() => currentHook().openWorktreeFile('docs/next.md'))
+    const openOptions = mockOpenWorktreeFileTab.mock.calls[0]?.[0]
+    await act(async () => {
+      renderer?.update(createElement(HookHarness, { ...props, scopeKey: 'markdown-tab-3' }))
+    })
+    expect(openOptions.signal.aborted).toBe(true)
+
+    resolveOpen?.({ status: 'activated', tabId: 'markdown-tab-2', kind: 'markdown' })
+    await flushAsyncOperation()
+
+    expect(props.onActivated).not.toHaveBeenCalled()
+    expect(currentHook().opening).toBe(false)
+  })
+
+  it('reports a reconnect requirement without issuing an RPC', async () => {
+    const props = connectedProps({ client: null, connectionState: 'disconnected' })
+    await renderHook(props)
+
+    act(() => currentHook().openWorktreeFile('docs/next.md'))
+
+    expect(mockOpenWorktreeFileTab).not.toHaveBeenCalled()
+    expect(props.onErrorChange).toHaveBeenLastCalledWith('Reconnect to open this file.')
+  })
+})

--- a/mobile/src/session/use-mobile-worktree-file-opener.ts
+++ b/mobile/src/session/use-mobile-worktree-file-opener.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { RpcClient } from '../transport/rpc-client'
+import type { ConnectionState } from '../transport/types'
+import {
+  openMobileWorktreeFileTab,
+  type MobileWorktreeFileTabOpenResult
+} from './mobile-worktree-file-tab-open'
+
+type Options = {
+  client: Pick<RpcClient, 'sendRequest'> | null
+  connectionState: ConnectionState
+  worktreeId: string
+  scopeKey?: string | null
+  onActivated: (result: Extract<MobileWorktreeFileTabOpenResult, { status: 'activated' }>) => void
+  onErrorChange: (message: string | null) => void
+}
+
+type OpenScope = Pick<Options, 'client' | 'connectionState' | 'scopeKey' | 'worktreeId'>
+
+type OpenOperation = {
+  revision: number
+  controller: AbortController
+  scope: OpenScope
+}
+
+export function useMobileWorktreeFileOpener({
+  client,
+  connectionState,
+  worktreeId,
+  scopeKey,
+  onActivated,
+  onErrorChange
+}: Options): {
+  opening: boolean
+  openWorktreeFile: (relativePath: string) => void
+} {
+  const scope = { client, connectionState, scopeKey, worktreeId }
+  const scopeRef = useRef(scope)
+  scopeRef.current = scope
+  const [openingOperation, setOpeningOperation] = useState<OpenOperation | null>(null)
+  const operationRef = useRef<OpenOperation | null>(null)
+  const nextRevisionRef = useRef(0)
+
+  const beginOperation = useCallback((operationScope: OpenScope) => {
+    operationRef.current?.controller.abort()
+    const operation = {
+      revision: nextRevisionRef.current + 1,
+      controller: new AbortController(),
+      scope: operationScope
+    }
+    nextRevisionRef.current = operation.revision
+    operationRef.current = operation
+    return operation
+  }, [])
+
+  const isCurrent = useCallback(
+    (operation: OpenOperation) =>
+      operationRef.current?.revision === operation.revision &&
+      !operation.controller.signal.aborted &&
+      scopesMatch(operation.scope, scopeRef.current),
+    []
+  )
+
+  useEffect(
+    () => () => {
+      operationRef.current?.controller.abort()
+      operationRef.current = null
+    },
+    []
+  )
+
+  useEffect(() => {
+    operationRef.current?.controller.abort()
+    operationRef.current = null
+  }, [client, connectionState, scopeKey, worktreeId])
+
+  const openWorktreeFile = useCallback(
+    (relativePath: string) => {
+      const operation = beginOperation({ client, connectionState, scopeKey, worktreeId })
+      onErrorChange(null)
+      if (!client || connectionState !== 'connected') {
+        setOpeningOperation(null)
+        onErrorChange('Reconnect to open this file.')
+        return
+      }
+
+      setOpeningOperation(operation)
+      void openMobileWorktreeFileTab({
+        client,
+        worktreeId,
+        relativePath,
+        signal: operation.controller.signal,
+        isCurrent: () => isCurrent(operation)
+      }).then((result) => {
+        if (!isCurrent(operation)) {
+          return
+        }
+        setOpeningOperation(null)
+        if (result.status === 'activated') {
+          onActivated(result)
+          return
+        }
+        if (result.status !== 'cancelled') {
+          onErrorChange(mobileWorktreeFileOpenError(result))
+        }
+      })
+    },
+    [
+      beginOperation,
+      client,
+      connectionState,
+      isCurrent,
+      onActivated,
+      onErrorChange,
+      scopeKey,
+      worktreeId
+    ]
+  )
+
+  const opening = openingOperation !== null && scopesMatch(openingOperation.scope, scope)
+  return { opening, openWorktreeFile }
+}
+
+function scopesMatch(left: OpenScope, right: OpenScope): boolean {
+  return (
+    left.client === right.client &&
+    left.connectionState === right.connectionState &&
+    left.scopeKey === right.scopeKey &&
+    left.worktreeId === right.worktreeId
+  )
+}
+
+export function mobileWorktreeFileOpenError(
+  result: Exclude<MobileWorktreeFileTabOpenResult, { status: 'activated' | 'cancelled' }>
+): string {
+  if (result.status === 'timeout') {
+    return "The file opened, but its tab isn't ready yet. Try again."
+  }
+  if (result.status === 'not-opened') {
+    return "This file can't be opened in an editor."
+  }
+  return 'Unable to open file.'
+}

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -358,6 +358,43 @@ describe('RuntimeFileCommands', () => {
     expect(openFile).not.toHaveBeenCalled()
   })
 
+  it('rejects local directories without creating an editor tab', async () => {
+    const openFile = vi.fn()
+    const { commands } = createRuntimeFileCommands({ openFile })
+    resolveAuthorizedPathMock.mockResolvedValue('/repo/docs')
+    statMock.mockResolvedValue({ isDirectory: () => true })
+
+    await expect(commands.openMobileFile('id:wt-1', 'docs')).rejects.toThrow(
+      "EISDIR: illegal operation on a directory, open '/repo/docs'"
+    )
+    expect(openFile).not.toHaveBeenCalled()
+  })
+
+  it('rejects remote directories without creating an editor tab', async () => {
+    const openFile = vi.fn()
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: {
+        id: 'wt-1',
+        repoId: 'repo-1',
+        path: '/remote/repo'
+      },
+      connectionId: 'ssh-1'
+    }))
+    const { commands } = createRuntimeFileCommands({
+      openFile,
+      path: '/remote/repo',
+      resolveRuntimeFileTarget
+    })
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({
+      stat: vi.fn().mockResolvedValue({ type: 'directory' })
+    } as never)
+
+    await expect(commands.openMobileFile('id:wt-1', 'docs')).rejects.toThrow(
+      "EISDIR: illegal operation on a directory, open '/remote/repo/docs'"
+    )
+    expect(openFile).not.toHaveBeenCalled()
+  })
+
   it('does not follow symlinks when reading runtime-local file explorer dirs', async () => {
     const { commands } = createRuntimeFileCommands()
     resolveAuthorizedPathMock.mockResolvedValue('/repo')
@@ -2038,7 +2075,7 @@ describe('RuntimeFileCommands', () => {
       const target = absoluteFileTarget(result)
 
       await rm(artifactPath)
-      await writeFile(artifactPath, 'changed!')
+      await writeFile(artifactPath, 'changed-content')
 
       await expect(
         commands.readTerminalArtifactPreview(

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -651,9 +651,12 @@ export class RuntimeFileCommands {
     connectionId?: string
   ): Promise<void> {
     try {
-      await (connectionId
+      const stats = await (connectionId
         ? this.statRemoteTerminalPath(filePath, connectionId)
         : stat(await resolveAuthorizedPath(filePath, this.host.requireStore())))
+      if (stats.isDirectory()) {
+        throw new Error(`EISDIR: illegal operation on a directory, open '${filePath}'`)
+      }
     } catch (error) {
       if (
         isENOENT(error) ||


### PR DESCRIPTION
## Summary

- add an explicit **Open** action to worktree-backed mobile file previews
- open editable Markdown/text/code files in Orca's existing editor session
- preserve preview-first behavior for images, terminal artifacts, directories, and unsupported files
- wait for the exact published editor tab and activate it only for the requesting mobile client

## Implementation

- use the existing mobile-allowlisted `files.open` RPC
- match exact worktree/path ownership while excluding diff and Markdown-preview tabs
- cancel stale work on route/source changes
- bound publication polling to four requests over at most 1.8 seconds
- reject directories before host opening on local and SSH runtimes

## Screenshots

No new screenshot is attached. The equivalent feature build was manually accepted on a paired Samsung S24 Ultra; the final rebased head was not redeployed to that physical device.

## Testing

Exact published head: `8adf4a2b1ad7dd761ef4964bdb36abc405964af2` on base `f71373953baa1d384b75bbdf4845fda17a847da5`.

- focused mobile/runtime coverage passed in the rebased integration
- the stale terminal-artifact fixture now changes file size as well as content, avoiding inode/timestamp reuse false positives
- combined stable integration passed lint, all three TypeScript projects, 3,563 focused desktop tests, and 55 mobile tests before the final #10046-only delta
- the final delta passed 8/8 plus web typecheck, and package compatibility/daemon/plugin gates passed at `e13fa51f38102e1c3bf972e206e68fd323927406`
- the equivalent pre-rebase feature build passed the complete mobile suite, focused runtime file suite, desktop/web/native build, and physical-device acceptance

## AI Review Report

The review covered exact tab matching, local/SSH/folder-workspace ownership, cancellation and bounded polling, accessibility state, and client-local activation. The flow uses existing design-system primitives and adds no agent- or git-provider-specific behavior.

## Security Audit

The action stays on existing allowlisted `files.open` and session-tab APIs. Responses are structurally validated, activation requires an exact worktree/path match, and directories/binaries retain safe preview behavior. No dependency, command construction, authentication, secret handling, or new permission surface is added.

## Notes

- This completes the preview-to-editor transition without replacing safe preview.
- Direct editing inside preview, binary editor tabs, and cross-client focus changes remain out of scope.
- X handle: not provided.

## ELI5

After previewing a file on mobile, **Open** now takes that exact file into Orca's real editor.
