### PR TITLE
fix: preserve selected composer text on Delete

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -377,7 +377,7 @@ function NativeChatResolvedView({
       onKeyDownCapture={(event) => {
         // Backspace/Delete outside an input focuses the composer (like typing)
         // but inserts nothing — let the now-focused field handle the keystroke.
-        if (shouldFocusNativeChatComposerFromEditingKey(event)) {
+        if (shouldFocusNativeChatComposerFromEditingKey(event, document.activeElement)) {
           composerRef.current?.focus()
           return
         }

--- a/src/renderer/src/components/native-chat/native-chat-typing-redirect.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-redirect.test.ts
@@ -85,6 +85,15 @@ describe('shouldFocusNativeChatComposerFromEditingKey', () => {
       )
     ).toBe(false)
   })
+
+  it('does not refocus a selected textarea when Electron retargets Delete to the pane', () => {
+    expect(
+      shouldFocusNativeChatComposerFromEditingKey(
+        keyEvent({ key: 'Delete', target: inertTarget() }),
+        interactiveTarget()
+      )
+    ).toBe(false)
+  })
 })
 
 describe('shouldFocusNativeChatPaneFromPointerTarget', () => {

--- a/src/renderer/src/components/native-chat/native-chat-typing-redirect.ts
+++ b/src/renderer/src/components/native-chat/native-chat-typing-redirect.ts
@@ -50,7 +50,10 @@ export function shouldFocusNativeChatPaneFromPointerTarget(target: EventTarget |
  *  are not inserted (their character has no literal form), so the caller only
  *  focuses. Modified chords (Shift/Alt/Ctrl/Cmd+Delete = cut, delete-word, …)
  *  are left to the focused target. */
-export function shouldFocusNativeChatComposerFromEditingKey(event: KeyboardRedirectEvent): boolean {
+export function shouldFocusNativeChatComposerFromEditingKey(
+  event: KeyboardRedirectEvent,
+  activeTarget: EventTarget | null = null
+): boolean {
   if (
     event.defaultPrevented ||
     event.isComposing ||
@@ -62,7 +65,7 @@ export function shouldFocusNativeChatComposerFromEditingKey(event: KeyboardRedir
   ) {
     return false
   }
-  return !isNativeChatInteractiveTarget(event.target)
+  return !isNativeChatInteractiveTarget(event.target) && !isNativeChatInteractiveTarget(activeTarget)
 }
 
 function isNativeChatInteractiveTarget(target: EventTarget | null): boolean {


### PR DESCRIPTION
## Summary

Исправлено удаление выделенного фрагмента черновика в чате. Если Electron передаёт Delete или Backspace от панели вместо textarea, Orca больше не повторно фокусирует поле и не сбрасывает выделение в конец.

## Screenshots

Нет визуального изменения: исправлена обработка клавиши.

## Testing

- [ ] `pnpm lint` — не запускался: несвязанная полная проверка.
- [ ] `pnpm typecheck` — блокируется существующими TS6307 в `src/main/ipc/worktree-logic.ts` и связанных файлах.
- [x] Целевой Vitest: `native-chat-typing-redirect.test.ts` — 10 проверок прошли.
- [x] `pnpm run build:electron-vite` — успешно.
- [x] Добавлен регрессионный тест Electron-ретаргетинга Delete.

## AI Review Report

Проверены: путь события клавиатуры от панели к textarea, сохранение прежнего поведения для неинтерактивной панели, Ctrl/Cmd/Shift/Alt-сочетаний, IME и интерактивных элементов. Исправление дополнительно учитывает `document.activeElement`; оно не изменяет отправку сообщений, ввод текста, пути или команды.

Проверена кроссплатформенность macOS, Linux и Windows: используются стандартные `Delete`/`Backspace`, DOM `activeElement` и Electron без платформенно-зависимых ярлыков, путей или оболочки.

CodeRabbit не выявил замечаний к коду.

## Security Audit

Изменение не обрабатывает внешние данные, команды, пути, учётные данные, IPC или зависимости. Оно только предотвращает изменение фокуса для уже активного интерактивного DOM-элемента.

## Notes

Нужна ручная проверка в Electron на Windows после доступности нативной сборки. Локальный запуск dev-версии сейчас блокирован отсутствием Visual Studio Build Tools для `windows-native-registry`.

## ELI5

Selecting text in the composer and pressing Delete/Backspace could jump the cursor to the end and fail to delete the selection when the key came from a panel. Delete now removes the selected text as expected.
