### PR TITLE
fix(claude-usage): price Claude Opus 5, Fable 5, and Sonnet 5 usage

### DIFF
--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -317,6 +317,95 @@ describe('ClaudeUsageStore', () => {
     ).toBeCloseTo(14.7)
   })
 
+  it('prices Claude Sonnet 5 usage before 2026-09-01 at introductory rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-08-31',
+          model: 'claude-sonnet-5',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        }
+      ]
+    })
+
+    const breakdown = await store.getBreakdown('orca', 'all', 'model')
+
+    expect(breakdown[0]?.estimatedCostUsd).toBeCloseTo(14.7)
+  })
+
+  it('prices Claude Sonnet 5 usage from 2026-09-01 at standard rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-09-01',
+          model: 'claude-sonnet-5',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        }
+      ]
+    })
+
+    const breakdown = await store.getBreakdown('orca', 'all', 'model')
+
+    expect(breakdown[0]?.estimatedCostUsd).toBeCloseTo(22.05)
+  })
+
+  it('sums Claude Sonnet 5 usage across introductory and standard pricing days', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-08-31',
+          model: 'claude-sonnet-5',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        },
+        {
+          day: '2026-09-01',
+          model: 'claude-sonnet-5',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        }
+      ]
+    })
+
+    const breakdown = await store.getBreakdown('orca', 'all', 'model')
+
+    expect(breakdown[0]?.estimatedCostUsd).toBeCloseTo(36.75)
+  })
+
   it('prices unknown newer Opus 4 point releases with current Opus rates', async () => {
     const store = createStoreWithState({
       dailyAggregates: [

--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -254,6 +254,69 @@ describe('ClaudeUsageStore', () => {
     ).toBeCloseTo(36.75)
   })
 
+  it('prices Claude 5-series models with current Anthropic rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-07-25',
+          model: 'claude-opus-5-20260724',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        },
+        {
+          day: '2026-07-25',
+          model: 'anthropic/claude-fable-5',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        },
+        {
+          day: '2026-07-25',
+          model: 'claude-sonnet-5-thinking',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(124.95)
+    expect(
+      breakdown.find((row) => row.key === 'claude-opus-5-20260724')?.estimatedCostUsd
+    ).toBeCloseTo(36.75)
+    expect(
+      breakdown.find((row) => row.key === 'anthropic/claude-fable-5')?.estimatedCostUsd
+    ).toBeCloseTo(73.5)
+    expect(
+      breakdown.find((row) => row.key === 'claude-sonnet-5-thinking')?.estimatedCostUsd
+    ).toBeCloseTo(14.7)
+  })
+
   it('prices unknown newer Opus 4 point releases with current Opus rates', async () => {
     const store = createStoreWithState({
       dailyAggregates: [

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -50,6 +50,13 @@ type AutomationUsageLookupInput = {
 }
 
 const LONG_CONTEXT_THRESHOLD_TOKENS = 200_000
+const SONNET_5_STANDARD_PRICING_START_DAY = '2026-09-01'
+const SONNET_5_STANDARD_PRICING = {
+  input: 3,
+  output: 15,
+  cacheRead: 0.3,
+  cacheWrite: 3.75
+} satisfies ClaudeModelPricing
 const SONNET_LONG_CONTEXT_PRICING = {
   thresholdTokens: LONG_CONTEXT_THRESHOLD_TOKENS,
   inputAboveThreshold: 6,
@@ -255,13 +262,14 @@ function estimateCostUsd(
   inputTokens: number,
   outputTokens: number,
   cacheReadTokens: number,
-  cacheWriteTokens: number
+  cacheWriteTokens: number,
+  day?: string | null
 ): number | null {
   const normalized = normalizeModelForPricing(model)
   if (!normalized) {
     return null
   }
-  const pricing = MODEL_PRICING[normalized]
+  const pricing = resolvePricingForDay(normalized, day)
   return (
     (calculateTieredCost(
       inputTokens,
@@ -291,6 +299,24 @@ function estimateCostUsd(
   )
 }
 
+function resolvePricingForDay(normalizedModel: string, day?: string | null): ClaudeModelPricing {
+  const effectiveDay = day ?? formatLocalDay(new Date())
+  if (
+    normalizedModel === 'claude-sonnet-5' &&
+    effectiveDay >= SONNET_5_STANDARD_PRICING_START_DAY
+  ) {
+    return SONNET_5_STANDARD_PRICING
+  }
+  return MODEL_PRICING[normalizedModel]
+}
+
+function formatLocalDay(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 function getRangeCutoff(range: ClaudeUsageRange): string | null {
   if (range === 'all') {
     return null
@@ -299,10 +325,7 @@ function getRangeCutoff(range: ClaudeUsageRange): string | null {
   const now = new Date()
   now.setHours(0, 0, 0, 0)
   now.setDate(now.getDate() - (days - 1))
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
+  return formatLocalDay(now)
 }
 
 function getLocalDay(timestamp: string): string | null {
@@ -310,10 +333,7 @@ function getLocalDay(timestamp: string): string | null {
   if (Number.isNaN(parsed.getTime())) {
     return null
   }
-  const year = parsed.getFullYear()
-  const month = String(parsed.getMonth() + 1).padStart(2, '0')
-  const day = String(parsed.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
+  return formatLocalDay(parsed)
 }
 
 function getWorktreeFingerprint(worktreesByRepo: Map<string, UsageWorktreeRef[]>): string {
@@ -513,7 +533,8 @@ export class ClaudeUsageStore {
         row.inputTokens,
         row.outputTokens,
         row.cacheReadTokens,
-        row.cacheWriteTokens
+        row.cacheWriteTokens,
+        row.day
       )
       if (cost !== null) {
         hasAnyBillableCost = true
@@ -614,6 +635,19 @@ export class ClaudeUsageStore {
       existing.outputTokens += daily.outputTokens
       existing.cacheReadTokens += daily.cacheReadTokens
       existing.cacheWriteTokens += daily.cacheWriteTokens
+      if (kind === 'model') {
+        const cost = estimateCostUsd(
+          daily.model,
+          daily.inputTokens,
+          daily.outputTokens,
+          daily.cacheReadTokens,
+          daily.cacheWriteTokens,
+          daily.day
+        )
+        if (cost !== null) {
+          existing.estimatedCostUsd = (existing.estimatedCostUsd ?? 0) + cost
+        }
+      }
       rows.set(key, existing)
     }
 
@@ -639,18 +673,6 @@ export class ClaudeUsageStore {
         if (row) {
           row.sessions++
         }
-      }
-    }
-
-    for (const row of rows.values()) {
-      if (kind === 'model') {
-        row.estimatedCostUsd = estimateCostUsd(
-          row.key,
-          row.inputTokens,
-          row.outputTokens,
-          row.cacheReadTokens,
-          row.cacheWriteTokens
-        )
       }
     }
 
@@ -814,7 +836,8 @@ export class ClaudeUsageStore {
       totals.inputTokens,
       totals.outputTokens,
       totals.cacheReadTokens,
-      totals.cacheWriteTokens
+      totals.cacheWriteTokens,
+      getLocalDay(session.lastTimestamp)
     )
 
     return {

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -59,12 +59,19 @@ const SONNET_LONG_CONTEXT_PRICING = {
 } satisfies Partial<ClaudeModelPricing>
 
 const MODEL_PRICING: Record<string, ClaudeModelPricing> = {
+  'claude-fable-5': { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  'claude-opus-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-6': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-1': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
   'claude-opus-4': { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+  // Why: Sonnet 5 introductory pricing ($2/$10, cache 0.2/2.5) is in effect
+  // through 2026-08-31; standard pricing $3/$15 (cache 0.3/3.75) starts
+  // 2026-09-01. No long-context surcharge: 4.6+ models include the full 1M
+  // context window at standard rates.
+  'claude-sonnet-5': { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
   'claude-sonnet-4-6': {
     input: 3,
     output: 15,
@@ -102,6 +109,9 @@ const MODEL_ALIASES: Record<string, string> = {
   'claude-opus-4.8-thinking': 'claude-opus-4-8',
   'claude-opus-4.6-thinking': 'claude-opus-4-6',
   'claude-sonnet-4.6-thinking': 'claude-sonnet-4-6',
+  'claude-opus-5-thinking': 'claude-opus-5',
+  'claude-sonnet-5-thinking': 'claude-sonnet-5',
+  'claude-fable-5-thinking': 'claude-fable-5',
   'claude-opus-4-8-thinking': 'claude-opus-4-8',
   'claude-opus-4-6-thinking': 'claude-opus-4-6',
   'claude-sonnet-4-6-thinking': 'claude-sonnet-4-6'
@@ -155,6 +165,15 @@ function normalizeModelForPricing(model: string | null): string | null {
   const alias = MODEL_ALIASES[lower]
   if (alias) {
     return alias
+  }
+  if (hasClaudeModelVersion(lower, 'fable', '5')) {
+    return 'claude-fable-5'
+  }
+  if (hasClaudeModelVersion(lower, 'opus', '5')) {
+    return 'claude-opus-5'
+  }
+  if (hasClaudeModelVersion(lower, 'sonnet', '5')) {
+    return 'claude-sonnet-5'
   }
   if (hasClaudeModelVersion(lower, 'opus', '4-8')) {
     return 'claude-opus-4-8'

--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -56,6 +56,10 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
     expect(COMMIT_MESSAGE_AGENT_SPECS.copilot?.defaultModelId).toBe('gpt-5.4')
     expect(COMMIT_MESSAGE_AGENT_SPECS.copilot?.models.map((m) => m.id)).toEqual([
       'auto',
+      'claude-opus-5',
+      'claude-opus-5-fast',
+      'claude-sonnet-5',
+      'claude-fable-5',
       'claude-haiku-4.5',
       'claude-sonnet-4.5',
       'claude-sonnet-4.6',

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -581,6 +581,22 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     models: [
       { id: 'auto', label: 'Auto' },
       {
+        id: 'claude-opus-5',
+        label: 'Claude Opus 5'
+      },
+      {
+        id: 'claude-opus-5-fast',
+        label: 'Claude Opus 5 Fast'
+      },
+      {
+        id: 'claude-sonnet-5',
+        label: 'Claude Sonnet 5'
+      },
+      {
+        id: 'claude-fable-5',
+        label: 'Claude Fable 5'
+      },
+      {
         id: 'claude-haiku-4.5',
         label: 'Claude Haiku 4.5'
       },


### PR DESCRIPTION
## Summary

Claude usage on the 5-series models was silently dropped from the cost breakdown.

`MODEL_PRICING` and `normalizeModelForPricing` had no entry or branch for `claude-opus-5`, `claude-fable-5`, or `claude-sonnet-5`, so `estimateCostUsd` returned `null` for any usage on those models. Opus 5 shipped 2026-07-24 and is now the default model on Claude Max, so this affects current usage, not a hypothetical future model.

The existing future-proofing did not catch it. `store.ts` already has a fallback that maps unknown `opus-4` point releases onto current Opus pricing, with a comment explaining that the goal is to avoid silently mis-costing unknown Claude Code model IDs. That guard is keyed on the literal `opus-4` family string, so it stopped applying the moment the family name became `opus-5`.

Changes:

- `store.ts`: add `claude-opus-5`, `claude-fable-5`, `claude-sonnet-5` to `MODEL_PRICING`, plus their `-thinking` aliases and `hasClaudeModelVersion` branches in `normalizeModelForPricing`.
- `commit-message-agent-spec.ts`: extend the static Copilot catalog with the 5-series entries so users can select the models their org has enabled. The catalog is intentionally static (per the existing comment, Copilot's picker is policy-filtered per account/org), so new hosted models have to be added by hand.

All rates verified against https://platform.claude.com/docs/en/about-claude/pricing on 2026-07-26:

| Model | Input | Output | Cache read | Cache write (5m) |
| --- | --- | --- | --- | --- |
| Claude Opus 5 | $5 | $25 | $0.50 | $6.25 |
| Claude Fable 5 | $10 | $50 | $1 | $12.50 |
| Claude Sonnet 5 | $2 | $10 | $0.20 | $2.50 |

## Screenshots

No visual change. This only affects the cost figures already rendered in the usage breakdown.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`pnpm typecheck` passes clean.

`pnpm lint` and `pnpm test` fail on this branch, but both failures reproduce identically on a pristine `origin/main` checkout with this branch's commit absent, and neither touches the files in this PR:

- `pnpm lint` fails at `verify:localization-coverage` on unlocalized `Ghostty` keyword strings in `terminal-advanced-platform-search.ts` and `terminal-pane-appearance-search.ts`. Confirmed `node config/scripts/audit-localization-coverage.mjs --check` exits 1 on pristine `origin/main`.
- `pnpm test` reports 20 failing files out of 3437 (3410 passing), concentrated in socket, PTY, and git-integration suites that appear environment-sensitive. Spot-checking four of them on pristine `origin/main` reproduced two of the same failures.

The four test files this PR touches or covers all pass: 95 tests green.

`pnpm build` passes clean, exit 0, roughly 93 seconds, including the native and computer-use-macos steps.

New test coverage in `store.test.ts` asserts the pricing rows and the normalization branches, including a `claude-opus-5-20260724`-style dated model ID, so a future family rename regression would be caught.

## AI Review Report

Reviewed with Claude. Risks checked:

- **Rate accuracy.** Every added rate was cross-checked line by line against the official Anthropic pricing table rather than copied from memory or a secondary source. Cache-write values use the 5-minute multiplier, consistent with the surrounding rows.
- **Normalization ordering.** The new `fable`/`opus`/`sonnet` version-5 branches are placed ahead of the `opus-4` and `sonnet-4` branches, and the review confirmed no earlier substring branch shadows them. `claude-fable-5` is matched before the opus branches so it cannot be absorbed by a looser match.
- **Cross-platform.** No platform-specific behavior. This is a pure data table plus string normalization in main-process code, with no path handling, shell invocation, shortcut, or label surface. Nothing here differs on macOS, Linux, or Windows.
- **Provider neutrality.** The Copilot catalog addition stays inside the existing Copilot-specific block and does not change behavior for other agents.

Flagged and deliberately not changed in this PR, listed under Notes below.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change adds constant numeric rates to an existing in-memory table and adds string-comparison branches to an existing pure function that already receives the same untrusted model string. No new external calls and no new dependencies.

## Notes

One follow-up left out to keep this PR scoped to the reported bug. Happy to open a separate PR if you want it.

1. ~~**Sonnet 5 introductory pricing expires.**~~ Resolved in 02b657c after review feedback. Pricing now resolves per usage day, and `buildBreakdown` accumulates cost per daily aggregate so a model row spanning 2026-08-31 to 2026-09-01 is priced correctly on both sides rather than approximated with one representative date.

2. **The family fallback is still version-specific.** `lower.includes('opus-4')` mapping to current Opus pricing is exactly the guard that failed here once the family became `opus-5`. A version-agnostic form would prevent the next occurrence, but it involves assuming pricing for unreleased models, so it seemed like a maintainer call rather than something to fold into a data fix.

Also worth noting: pricing is not machine-readable from any Anthropic API. The Models API returns `max_input_tokens`, `max_tokens`, and `capabilities` but no rates, so this table cannot be automated and will need manual updates on each model launch.

## ELI5

Usage for Claude Opus 5, Fable 5, and Sonnet 5 was ignored in cost estimates because pricing tables had no entries. Those models are priced correctly so usage breakdowns include real spend.
