### PR TITLE
perf(renderer): give owner-routed settings a stable identity

### DIFF
--- a/config/scripts/repo-owner-settings-selector-benchmark.mjs
+++ b/config/scripts/repo-owner-settings-selector-benchmark.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+// Benchmark: cost of the owner-routed settings selector per store write.
+//
+// getSettingsForRepoRuntimeOwner() is called from useShallow selectors at ~43
+// sites across PullRequestPage and TaskPage. Zustand re-runs every subscribed
+// selector on every store write, so before the fix each unrelated write
+// allocated one settings-sized object per row and then shallow-compared every
+// field to conclude nothing had changed.
+//
+// The fix caches by repo id and reuses the reference while the settings object,
+// repo list, and resolved owner are unchanged, so useShallow's equality check
+// short-circuits on Object.is.
+//
+// The selector body is mirrored here (node cannot import the .ts source, matching
+// the sibling benchmarks). The settings field count is read from the real
+// GlobalSettings type so a drifted shape fails loudly instead of flattering the
+// result with a stale, smaller object.
+import { readFileSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
+import { fileURLToPath } from 'node:url'
+
+const TYPES_SOURCE = readFileSync(
+  fileURLToPath(new URL('../../src/shared/types.ts', import.meta.url)),
+  'utf8'
+)
+
+function countGlobalSettingsFields(source) {
+  const block = source.match(/export type GlobalSettings = \{([\s\S]*?)\n\}/)
+  if (!block) {
+    throw new Error('types.ts no longer declares GlobalSettings in the expected shape')
+  }
+  const fields = block[1].match(/^\s{2}\w+\??:/gm) ?? []
+  if (fields.length < 50) {
+    throw new Error(`GlobalSettings parsed as only ${fields.length} fields; re-sync this benchmark`)
+  }
+  return fields.length
+}
+
+const SETTINGS_FIELDS = countGlobalSettingsFields(TYPES_SOURCE)
+const ROWS = Number.parseInt(process.env.ORCA_OWNER_SETTINGS_BENCH_ROWS ?? '43', 10)
+const WRITES = Number.parseInt(process.env.ORCA_OWNER_SETTINGS_BENCH_WRITES ?? '2000', 10)
+const WARMUP = Number.parseInt(process.env.ORCA_OWNER_SETTINGS_BENCH_WARMUP ?? '200', 10)
+
+for (const [name, value] of [
+  ['ORCA_OWNER_SETTINGS_BENCH_ROWS', ROWS],
+  ['ORCA_OWNER_SETTINGS_BENCH_WRITES', WRITES],
+  ['ORCA_OWNER_SETTINGS_BENCH_WARMUP', WARMUP]
+]) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, received ${value}`)
+  }
+}
+
+function makeSettings() {
+  const settings = { activeRuntimeEnvironmentId: 'focused-runtime' }
+  for (let index = 0; index < SETTINGS_FIELDS - 1; index += 1) {
+    settings[`field${index}`] = index % 3 === 0 ? `value-${index}` : index % 3 === 1 ? index : true
+  }
+  return settings
+}
+
+function makeRepos(rows) {
+  return Array.from({ length: rows }, (_value, index) => ({
+    id: `repo-${index}`,
+    connectionId: null,
+    executionHostId: `runtime:env-${index % 4}`
+  }))
+}
+
+function resolveEnvironmentId(state, repoId) {
+  if (!repoId) {
+    return null
+  }
+  const matching = state.repos.filter((entry) => entry.id === repoId)
+  const repo = matching.length === 1 ? matching[0] : null
+  const hasOwner = Boolean(repo?.executionHostId?.trim() || repo?.connectionId?.trim())
+  if (repo && hasOwner) {
+    const hostId = repo.executionHostId ?? ''
+    return hostId.startsWith('runtime:') ? hostId.slice('runtime:'.length) : null
+  }
+  return state.settings?.activeRuntimeEnvironmentId?.trim() || null
+}
+
+// Pre-fix: a fresh object every call.
+function selectorBefore(state, repoId) {
+  return { ...state.settings, activeRuntimeEnvironmentId: resolveEnvironmentId(state, repoId) }
+}
+
+// Post-fix: reuse the reference while nothing it derives from changed.
+function makeCachedSelector() {
+  const cache = new Map()
+  return (state, repoId) => {
+    const environmentId = resolveEnvironmentId(state, repoId)
+    const cacheKey = repoId ?? ''
+    const cached = cache.get(cacheKey)
+    if (
+      cached &&
+      cached.settingsSource === state.settings &&
+      cached.reposSource === state.repos &&
+      cached.environmentId === environmentId
+    ) {
+      return cached.value
+    }
+    const value = { ...state.settings, activeRuntimeEnvironmentId: environmentId }
+    cache.set(cacheKey, {
+      settingsSource: state.settings,
+      reposSource: state.repos,
+      environmentId,
+      value
+    })
+    if (cache.size > 256) {
+      const oldest = cache.keys().next()
+      if (!oldest.done) {
+        cache.delete(oldest.value)
+      }
+    }
+    return value
+  }
+}
+
+// Mirror of zustand's useShallow comparison.
+function shallowEqual(a, b) {
+  if (Object.is(a, b)) {
+    return true
+  }
+  if (a === null || b === null || a === undefined || b === undefined) {
+    return false
+  }
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+  if (keysA.length !== keysB.length) {
+    return false
+  }
+  for (const key of keysA) {
+    if (!Object.is(a[key], b[key])) {
+      return false
+    }
+  }
+  return true
+}
+
+// One unrelated store write: every subscribed row re-runs its selector and the
+// result is compared against the previous one to decide whether to re-render.
+function simulateWrite(selector, state, rows, previous) {
+  let changed = 0
+  for (let row = 0; row < rows; row += 1) {
+    const next = selector(state, `repo-${row}`)
+    if (!shallowEqual(previous[row], next)) {
+      changed += 1
+    }
+    previous[row] = next
+  }
+  return changed
+}
+
+function measure(selector, state, rows) {
+  const previous = Array.from({ length: rows }, () => null)
+  for (let index = 0; index < WARMUP; index += 1) {
+    simulateWrite(selector, state, rows, previous)
+  }
+  const samples = []
+  for (let round = 0; round < 5; round += 1) {
+    const start = performance.now()
+    for (let index = 0; index < WRITES; index += 1) {
+      simulateWrite(selector, state, rows, previous)
+    }
+    samples.push((performance.now() - start) / WRITES)
+  }
+  samples.sort((a, b) => a - b)
+  return samples[2]
+}
+
+const settings = makeSettings()
+const rowCounts = [1, 10, ROWS, 100]
+const rows = []
+for (const rowCount of rowCounts) {
+  const state = { repos: makeRepos(Math.max(rowCount, ROWS)), settings }
+  const cached = makeCachedSelector()
+  // Equivalence: both selectors must produce the same value for every row.
+  for (let row = 0; row < rowCount; row += 1) {
+    const before = selectorBefore(state, `repo-${row}`)
+    const after = cached(state, `repo-${row}`)
+    if (!shallowEqual(before, after)) {
+      throw new Error(`selector mismatch at repo-${row}`)
+    }
+  }
+  rows.push({
+    rowCount,
+    beforeMs: measure(selectorBefore, state, rowCount),
+    afterMs: measure(makeCachedSelector(), state, rowCount)
+  })
+}
+
+const pad = (value, width) => String(value).padStart(width)
+console.log(`Owner-routed settings selector, per unrelated store write`)
+console.log(
+  `GlobalSettings fields=${SETTINGS_FIELDS} writes=${WRITES} warmup=${WARMUP} (median of 5 rounds)`
+)
+console.log(`${pad('rows', 6)} ${pad('before ms', 11)} ${pad('after ms', 10)} ${pad('speedup', 9)}`)
+for (const row of rows) {
+  console.log(
+    `${pad(row.rowCount, 6)} ${pad(row.beforeMs.toFixed(4), 11)} ${pad(row.afterMs.toFixed(4), 10)} ${pad(`${(row.beforeMs / row.afterMs).toFixed(0)}x`, 9)}`
+  )
+}
+console.log(
+  `\nrows = subscribed selector call sites on screen (~${ROWS} across PullRequestPage/TaskPage).\nThe cost is paid on EVERY store write, including writes that touch nothing\nthese selectors read.`
+)

--- a/src/renderer/src/lib/repo-runtime-owner.test.ts
+++ b/src/renderer/src/lib/repo-runtime-owner.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { GlobalSettings } from '../../../shared/types'
+import type { RepoRuntimeOwnerState } from './repo-runtime-owner'
 import {
   getExplicitRuntimeOwnerEnvironmentId,
   getRepoOwnerRoutedSettings,
@@ -241,7 +242,10 @@ describe('getSettingsForRepoRuntimeOwner identity', () => {
     releaseRepoRuntimeOwnerSettingsCache()
   })
 
-  const repos = [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-a' }]
+  type OwnerRepo = NonNullable<RepoRuntimeOwnerState['repos']>[number]
+  const repos: OwnerRepo[] = [
+    { id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-a' }
+  ]
   const settings = {
     activeRuntimeEnvironmentId: 'focused',
     sourceControlViewMode: 'list'
@@ -278,10 +282,42 @@ describe('getSettingsForRepoRuntimeOwner identity', () => {
 
   it('returns a new value when the repo owner changes', () => {
     const first = getSettingsForRepoRuntimeOwner({ repos, settings }, 'repo-1')
-    const movedRepos = [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-b' }]
+    const movedRepos: OwnerRepo[] = [
+      { id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-b' }
+    ]
     const second = getSettingsForRepoRuntimeOwner({ repos: movedRepos, settings }, 'repo-1')
     expect(second).not.toBe(first)
     expect(second.activeRuntimeEnvironmentId).toBe('env-b')
+  })
+
+  // Why isolate each source: a fixture that changes the repo list AND the
+  // resolved owner together still passes when only one of the two checks
+  // survives, so each gets a case that holds the other constant.
+  it('returns a new value when the repo list changes but the owner does not', () => {
+    const first = getSettingsForRepoRuntimeOwner({ repos, settings }, 'repo-1')
+    // Same owner for repo-1; only the array identity and an unrelated row differ.
+    const grownRepos: OwnerRepo[] = [
+      ...repos,
+      { id: 'repo-9', connectionId: null, executionHostId: 'local' }
+    ]
+    const second = getSettingsForRepoRuntimeOwner({ repos: grownRepos, settings }, 'repo-1')
+    expect(second.activeRuntimeEnvironmentId).toBe('env-a')
+    expect(second).not.toBe(first)
+  })
+
+  it('returns a new value when the owner changes under a stable repo list identity', () => {
+    // Mutate in place so the array reference and settings both stay identical
+    // and only the resolved environment id differs.
+    const mutableRepos: OwnerRepo[] = [
+      { id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-a' }
+    ]
+    const state = { repos: mutableRepos, settings }
+    const first = getSettingsForRepoRuntimeOwner(state, 'repo-1')
+    expect(first.activeRuntimeEnvironmentId).toBe('env-a')
+    mutableRepos[0]!.executionHostId = 'runtime:env-c'
+    const second = getSettingsForRepoRuntimeOwner(state, 'repo-1')
+    expect(second.activeRuntimeEnvironmentId).toBe('env-c')
+    expect(second).not.toBe(first)
   })
 
   it('bounds the cache so unbounded repo ids cannot leak', () => {

--- a/src/renderer/src/lib/repo-runtime-owner.test.ts
+++ b/src/renderer/src/lib/repo-runtime-owner.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import type { GlobalSettings } from '../../../shared/types'
 import {
   getExplicitRuntimeOwnerEnvironmentId,
   getRepoOwnerRoutedSettings,
   getRuntimeEnvironmentIdForRepo,
-  getSettingsForRepoRuntimeOwner
+  getSettingsForRepoRuntimeOwner,
+  releaseRepoRuntimeOwnerSettingsCache
 } from './repo-runtime-owner'
 
 describe('getRuntimeEnvironmentIdForRepo', () => {
@@ -232,5 +233,63 @@ describe('getRepoOwnerRoutedSettings', () => {
         executionHostId: null
       })
     ).toBeNull()
+  })
+})
+
+describe('getSettingsForRepoRuntimeOwner identity', () => {
+  beforeEach(() => {
+    releaseRepoRuntimeOwnerSettingsCache()
+  })
+
+  const repos = [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-a' }]
+  const settings = {
+    activeRuntimeEnvironmentId: 'focused',
+    sourceControlViewMode: 'list'
+  } as unknown as GlobalSettings
+
+  // Why identity matters: these run inside useShallow selectors, so a fresh
+  // object per store write costs a full settings-wide compare on every row.
+  it('returns the same reference while settings and repos are unchanged', () => {
+    const state = { repos, settings }
+    expect(getSettingsForRepoRuntimeOwner(state, 'repo-1')).toBe(
+      getSettingsForRepoRuntimeOwner(state, 'repo-1')
+    )
+  })
+
+  it('keeps separate identities per repo id', () => {
+    const state = { repos, settings }
+    const first = getSettingsForRepoRuntimeOwner(state, 'repo-1')
+    const second = getSettingsForRepoRuntimeOwner(state, 'repo-2')
+    expect(first).not.toBe(second)
+    expect(first.activeRuntimeEnvironmentId).toBe('env-a')
+    expect(second.activeRuntimeEnvironmentId).toBe('focused')
+    // Interleaving must not evict either entry.
+    expect(getSettingsForRepoRuntimeOwner(state, 'repo-1')).toBe(first)
+    expect(getSettingsForRepoRuntimeOwner(state, 'repo-2')).toBe(second)
+  })
+
+  it('returns a new value when the settings object changes', () => {
+    const first = getSettingsForRepoRuntimeOwner({ repos, settings }, 'repo-1')
+    const nextSettings = { ...settings, sourceControlViewMode: 'tree' } as unknown as GlobalSettings
+    const second = getSettingsForRepoRuntimeOwner({ repos, settings: nextSettings }, 'repo-1')
+    expect(second).not.toBe(first)
+    expect((second as { sourceControlViewMode?: string }).sourceControlViewMode).toBe('tree')
+  })
+
+  it('returns a new value when the repo owner changes', () => {
+    const first = getSettingsForRepoRuntimeOwner({ repos, settings }, 'repo-1')
+    const movedRepos = [{ id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-b' }]
+    const second = getSettingsForRepoRuntimeOwner({ repos: movedRepos, settings }, 'repo-1')
+    expect(second).not.toBe(first)
+    expect(second.activeRuntimeEnvironmentId).toBe('env-b')
+  })
+
+  it('bounds the cache so unbounded repo ids cannot leak', () => {
+    const state = { repos, settings }
+    const first = getSettingsForRepoRuntimeOwner(state, 'repo-evictable')
+    for (let index = 0; index < 300; index += 1) {
+      getSettingsForRepoRuntimeOwner(state, `repo-filler-${index}`)
+    }
+    expect(getSettingsForRepoRuntimeOwner(state, 'repo-evictable')).not.toBe(first)
   })
 })

--- a/src/renderer/src/lib/repo-runtime-owner.ts
+++ b/src/renderer/src/lib/repo-runtime-owner.ts
@@ -65,14 +65,59 @@ export function getExplicitRuntimeOwnerEnvironmentId(
   return parsed?.kind === 'runtime' ? parsed.environmentId : null
 }
 
+type OwnerRoutedSettingsCacheEntry = {
+  settingsSource: RepoRuntimeOwnerState['settings']
+  reposSource: RepoRuntimeOwnerState['repos']
+  environmentId: string | null
+  value: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'>
+}
+
+// Why keyed by repo id: every PR/task row calls this with its own repo while
+// sharing one settings object, so a single-entry cache would thrash.
+const ownerRoutedSettingsCache = new Map<string, OwnerRoutedSettingsCacheEntry>()
+// Why bounded: repo ids come from remote listings, so the key space is not closed.
+const MAX_OWNER_ROUTED_SETTINGS_CACHE_KEYS = 256
+
+export function releaseRepoRuntimeOwnerSettingsCache(): void {
+  ownerRoutedSettingsCache.clear()
+}
+
 export function getSettingsForRepoRuntimeOwner(
   state: RepoRuntimeOwnerState,
   repoId: string | null | undefined
 ): Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> {
-  return {
-    ...state.settings,
-    activeRuntimeEnvironmentId: getRuntimeEnvironmentIdForRepo(state, repoId)
+  const environmentId = getRuntimeEnvironmentIdForRepo(state, repoId)
+  // Why a stable identity: this runs inside useShallow selectors on every store
+  // write, and spreading the whole settings object per row made unrelated writes
+  // allocate and re-compare every field. Reusing the reference when nothing it
+  // derives from changed lets useShallow settle on the Object.is fast path.
+  const cacheKey = repoId ?? ''
+  const cached = ownerRoutedSettingsCache.get(cacheKey)
+  if (
+    cached &&
+    cached.settingsSource === state.settings &&
+    cached.reposSource === state.repos &&
+    cached.environmentId === environmentId
+  ) {
+    return cached.value
   }
+  const value = {
+    ...state.settings,
+    activeRuntimeEnvironmentId: environmentId
+  }
+  ownerRoutedSettingsCache.set(cacheKey, {
+    settingsSource: state.settings,
+    reposSource: state.repos,
+    environmentId,
+    value
+  })
+  if (ownerRoutedSettingsCache.size > MAX_OWNER_ROUTED_SETTINGS_CACHE_KEYS) {
+    const oldest = ownerRoutedSettingsCache.keys().next()
+    if (!oldest.done) {
+      ownerRoutedSettingsCache.delete(oldest.value)
+    }
+  }
+  return value
 }
 
 // Why: git/file/terminal mutations must route by the OWNER host of the repo,


### PR DESCRIPTION
## Summary

`getSettingsForRepoRuntimeOwner()` spread the whole `GlobalSettings` object (**185 fields**) on every call. It runs inside `useShallow` selectors at **~43 call sites** across `PullRequestPage` and `TaskPage`.

Zustand re-runs every subscribed selector on every store write, so each *unrelated* write allocated one settings-sized object per row and then shallow-compared all 185 fields to conclude nothing had changed.

This caches by repo id and reuses the reference while the settings object, repo list, and resolved owner are unchanged, so `useShallow` settles on the `Object.is` fast path.

## ELI5

Each row on the PR and task pages needs the app's settings, but with one field swapped to point at the machine that owns that row's repo.

The old code rebuilt a fresh 185-field copy for every row, every time *anything* in the app changed — even something unrelated like a terminal printing a character. Then React compared all 185 fields, field by field, to discover nothing had changed and nothing needed redrawing.

Now, if the settings and the repo's owner haven't changed, each row gets back the *exact same object* it had before. React sees it's literally the same thing and skips the comparison entirely.

## Screenshots

No visual change — this only affects object identity, never the values a component reads.

## Proof of performance improvement

`node config/scripts/repo-owner-settings-selector-benchmark.mjs` (new):

```
GlobalSettings fields=185 writes=2000 warmup=200 (median of 5 rounds)
  rows   before ms   after ms   speedup
     1      0.0251     0.0003       79x
    10      0.2411     0.0014      178x
    43      1.0206     0.0069      149x
   100      2.4084     0.0309       78x
```

At the realistic ~43 on-screen call sites this saves **~1 ms of main-thread work per store write** — and that cost was paid on writes that touch nothing these selectors read, which is exactly what happens while an agent streams terminal output.

The benchmark simulates the real loop (selector + `useShallow` compare per row), verifies both versions produce equal values before timing, and reads the field count from the real `GlobalSettings` type so a drifted shape fails loudly rather than flattering the result with a stale, smaller object. I confirmed the equivalence guard is non-vacuous by breaking the cached selector and watching it throw.

## Proof of zero regression

The returned **value** is unchanged in every case; only its **identity** is now reused when nothing it derives from has changed. That makes cache invalidation the entire risk surface, so each invalidation source is tested in isolation.

5 new tests: stable identity across repeated calls; per-repo-id identities that survive interleaving; new value when the settings object changes; new value when the repo list changes *with the owner held constant*; new value when the owner changes *with the repo list identity held constant*; and cache bounding.

**Mutation testing — 6/6 killed** (`--no-cache`):

| mutant | result |
|---|---|
| ignore settings-source change | 1 fails |
| ignore repos-source change | 1 fails |
| ignore resolved-owner change | 1 fails |
| collapse to a single cache key | 2 fail |
| remove the size bound | 1 fails |
| break identity (`return { ...cached.value }`) | 2 fail |

The repos-source and resolved-owner mutants **initially survived**: my first fixture changed the repo array *and* the resolved owner together, so dropping either check alone was still caught by the other. The two isolating tests above were written specifically to close that.

The cache is bounded at 256 keys with insertion-order eviction, matching the existing idiom in `local-preflight-context-cache.ts`, because repo ids come from remote listings and the key space is not closed. `releaseRepoRuntimeOwnerSettingsCache()` is exported for test isolation.

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 24/24 in the touched file; full-suite failures are a subset of the pre-existing set
- [x] Added tests that would catch regressions

### Pre-existing test failures

`pnpm test` is already red on `main`; baseline captured on a tree identical to `origin/main`. Deterministic: `persistence.test.ts` ×1, `agent-exec-handler.test.ts` ×2 (assert against `process.env`). Load-flaky, all passing in isolation: `remote-runtime-shared-control-connection`, `terminal-history-incremental-restore` ×2, `cli/runtime-client` timeout. Two consecutive runs on unmodified `main` gave different failure sets (4, then 3).

## Review loop count + verdict

**2 review loops: adversarial review plus mutation-driven revision. Final verdict: ship.**

**1 round**, plus the mutation-testing loop above which drove 2 test revisions. Methodology carried over from the sibling PRs in this series, where 2 review rounds established the vacuous-guard and unpinned-branch failure classes that I then checked for here proactively.

## AI Review Report

Main risks reviewed:

- **Stale settings after a mutation.** The guard compares source *identities* (`state.settings`, `state.repos`) plus the resolved owner. Zustand state is immutable-by-convention, so any real settings change produces a new object and misses the cache. The in-place-mutation test covers the case where a caller mutates a repo row without replacing the array — the resolved-owner check catches it.
- **Cross-tenant leakage between repos.** Keyed per repo id, with an interleaving test proving one repo's entry cannot be served for another.
- **Unbounded growth.** Bounded at 256 with a test that proves eviction actually happens.
- **Module-level state in the renderer.** Matches the existing house pattern (`worktree-agent-orchestration-index.ts`, `local-preflight-context-cache.ts`), including an exported release function.

Cross-platform: no path, shell, keyboard, or platform-dependent behavior touched. Runtime-owner routing (local / SSH / runtime hosts) is resolved by the unchanged `getRuntimeEnvironmentIdForRepo`; this PR only affects the identity of the object wrapping it, so SSH and folder-workspace routing are unaffected.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or IPC surface. One consideration reviewed explicitly: the cache holds references to settings objects, which include AI/provider configuration. It lives in renderer memory that already holds the same objects via the store, adds no persistence and no new exposure, and is bounded so it cannot grow without limit. Cache keys are repo ids, never secrets. No dependency changes.

## Notes

`getRepoOwnerRoutedSettings()` — the sibling that rebinds settings for a single repo — is deliberately left uncached: it takes a settings object rather than store state, so it has no stable identity to key on, and its callers are event handlers rather than per-render selectors.

Made with [Orca](https://github.com/stablyai/orca) 🐋
