### PR TITLE
fix(terminal): durable lost-worker archive with atomic retire and mixed-version SSH revive

### DIFF
--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -169,7 +169,7 @@ export function formatTerminalFocus(result: { focus: RuntimeTerminalFocus }): st
 
 export function formatTerminalClose(result: { close: RuntimeTerminalClose }): string {
   if (result.close.closeMode === 'tab') {
-    return `Closed terminal tab ${result.close.tabId} (${result.close.handle}).`
+    return `Closed terminal tab ${result.close.tabId} (${result.close.handle}).${result.close.archiveId ? ` Archive ${result.close.archiveId}.` : ''}`
   }
   const ptyNote = result.close.ptyKilled ? ' PTY killed.' : ''
   return `Closed terminal ${result.close.handle}.${ptyNote}`

--- a/src/main/daemon/daemon-admission-limits.ts
+++ b/src/main/daemon/daemon-admission-limits.ts
@@ -197,6 +197,10 @@ function createOrAttachPayloadError(payload: unknown): string | null {
         DAEMON_PTY_HISTORY_SEED_MAX_BYTES
       ),
     () =>
+      payload.attachOnly === undefined || typeof payload.attachOnly === 'boolean'
+        ? null
+        : 'createOrAttach payload.attachOnly must be a boolean',
+    () =>
       optionalBoundedStringError(
         payload.shellOverride,
         'createOrAttach payload.shellOverride',

--- a/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
+++ b/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
@@ -3,12 +3,13 @@ import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 
 describe('foreground-confirmation daemon protocol', () => {
   it('rejects daemons from before the fresh-confirmation RPC', () => {
-    expect(PROTOCOL_VERSION).toBe(27)
+    expect(PROTOCOL_VERSION).toBe(28)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(19)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(22)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(23)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(24)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(25)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(26)
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(27)
   })
 })

--- a/src/main/daemon/daemon-protocol-version.test.ts
+++ b/src/main/daemon/daemon-protocol-version.test.ts
@@ -2,19 +2,21 @@ import { describe, expect, it } from 'vitest'
 import {
   AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION,
   AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION,
+  ATTACH_ONLY_PROTOCOL_VERSION,
   COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION,
   PREVIOUS_DAEMON_PROTOCOL_VERSIONS,
   PROTOCOL_VERSION
 } from './daemon-protocol-version'
 
 describe('daemon protocol version', () => {
-  it('ships strict completion inspection after claim authority', () => {
-    expect(PROTOCOL_VERSION).toBe(27)
+  it('ships attach-only admission after strict completion inspection', () => {
+    expect(PROTOCOL_VERSION).toBe(28)
     expect(COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION).toBe(27)
+    expect(ATTACH_ONLY_PROTOCOL_VERSION).toBe(28)
     expect(AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toEqual(
-      Array.from({ length: 26 }, (_, index) => index + 1)
+      Array.from({ length: 27 }, (_, index) => index + 1)
     )
   })
 })

--- a/src/main/daemon/daemon-protocol-version.ts
+++ b/src/main/daemon/daemon-protocol-version.ts
@@ -1,13 +1,14 @@
 // Why: daemons survive app updates, so wire behavior must be version-gated.
-export const PROTOCOL_VERSION = 27
+export const PROTOCOL_VERSION = 28
 export const COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION = 27
+export const ATTACH_ONLY_PROTOCOL_VERSION = 28
 export const PTY_STARTUP_INGRESS_PROTOCOL_VERSION = 25
 export const AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION = 26
 export const AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION = 26
 export const GIT_CREDENTIAL_GUARD_HOST_PROTOCOL_VERSION = 22
 export const CLEAN_DISCONNECT_PROTOCOL_VERSION = 24
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27
 ] as const
 
 export function supportsPtyStartupIngress(protocolVersion: number): boolean {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1633,6 +1633,85 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       })
     })
 
+    it('uses one cold-restore fixture for both ordinary creation and hibernation resume', async () => {
+      const sessionId = 'cold-restore-ordinary-and-hibernation'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/projects/recovered-shell',
+          cols: 132,
+          rows: 44,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      writeFileSync(join(sessionDir, 'scrollback.bin'), 'recovered fixture output\r\n')
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const client = (historyAdapter as unknown as { client: DaemonClient }).client
+      const request = vi.spyOn(client, 'request')
+
+      const ordinary = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+      const ordinaryCreates = request.mock.calls.filter(([type]) => type === 'createOrAttach')
+
+      expect(ordinaryCreates).toHaveLength(1)
+      expect(ordinaryCreates[0]?.[1]).toMatchObject({
+        sessionId,
+        cwd: '/projects/recovered-shell',
+        cols: 132,
+        rows: 44,
+        historySeed: expect.stringContaining('recovered fixture output')
+      })
+      expect(ordinaryCreates[0]?.[1]).not.toHaveProperty('attachOnly')
+      expect(ordinary).toMatchObject({
+        coldRestore: {
+          cwd: '/projects/recovered-shell',
+          cols: 132,
+          rows: 44
+        },
+        providerSequence: { value: 0, generation: 'reset' }
+      })
+      expect(lastSpawnOpts).toMatchObject({
+        sessionId,
+        cwd: '/projects/recovered-shell',
+        cols: 132,
+        rows: 44
+      })
+
+      await historyAdapter.shutdown(sessionId, { immediate: true, keepHistory: true })
+      request.mockClear()
+      lastSpawnOpts = null
+
+      const hibernationResume = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+      const hibernationCreates = request.mock.calls.filter(([type]) => type === 'createOrAttach')
+
+      expect(hibernationCreates).toHaveLength(1)
+      expect(hibernationCreates[0]?.[1]).toMatchObject({
+        sessionId,
+        cwd: '/projects/recovered-shell',
+        cols: 132,
+        rows: 44,
+        historySeed: expect.stringContaining('recovered fixture output')
+      })
+      // Why: hibernation resumes the ordinary cold-restore path; only lost-worker recovery may make an attach-only probe.
+      expect(hibernationCreates[0]?.[1]).not.toHaveProperty('attachOnly')
+      expect(hibernationResume).toMatchObject({
+        coldRestore: {
+          cwd: '/projects/recovered-shell',
+          cols: 132,
+          rows: 44
+        }
+      })
+      expect(lastSpawnOpts).toMatchObject({
+        sessionId,
+        cwd: '/projects/recovered-shell',
+        cols: 132,
+        rows: 44
+      })
+    })
+
     it('returns the main archive decision before creating a lost worker cold restore', async () => {
       const sessionId = 'lost-worker-cold-restore'
       const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1672,6 +1672,51 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(lastSpawnOpts).toBeNull()
     })
 
+    it('uses attach-only before the lost-worker gate when a live probe races session exit', async () => {
+      const sessionId = 'lost-worker-probe-race'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/projects/worker',
+          cols: 120,
+          rows: 40,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      writeFileSync(join(sessionDir, 'scrollback.bin'), 'worker output\r\n')
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+      lastSpawnOpts = null
+      const probe = vi.spyOn(historyAdapter, 'getAppliedSize').mockImplementation(async () => {
+        lastSubprocess._simulateExit(1)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+        return { cols: 80, rows: 24 }
+      })
+      const preSpawnLostWorker = vi.fn(async () => ({
+        kind: 'archived' as const,
+        archiveId: 'archive-worker-race'
+      }))
+
+      const result = await historyAdapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId,
+        preSpawnLostWorker
+      })
+
+      expect(probe).toHaveBeenCalledOnce()
+      expect(preSpawnLostWorker).toHaveBeenCalledOnce()
+      expect(result.lostWorkerRecovery).toEqual({
+        kind: 'archived',
+        archiveId: 'archive-worker-race'
+      })
+      expect(lastSpawnOpts).toBeNull()
+    })
+
     it('repairs legacy hostname UNC cwd for WSL spawn and cold-restore metadata', async () => {
       const platform = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1633,6 +1633,45 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       })
     })
 
+    it('returns the main archive decision before creating a lost worker cold restore', async () => {
+      const sessionId = 'lost-worker-cold-restore'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/projects/worker',
+          cols: 120,
+          rows: 40,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      writeFileSync(join(sessionDir, 'scrollback.bin'), 'worker output\r\n')
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const preSpawnLostWorker = vi.fn(async () => ({
+        kind: 'archived' as const,
+        archiveId: 'archive-worker'
+      }))
+
+      const result = await historyAdapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId,
+        preSpawnLostWorker
+      })
+
+      expect(preSpawnLostWorker).toHaveBeenCalledWith(
+        expect.objectContaining({ scrollback: 'worker output\r\n', cwd: '/projects/worker' })
+      )
+      expect(result).toMatchObject({
+        id: sessionId,
+        lostWorkerRecovery: { kind: 'archived', archiveId: 'archive-worker' }
+      })
+      expect(lastSpawnOpts).toBeNull()
+    })
+
     it('repairs legacy hostname UNC cwd for WSL spawn and cold-restore metadata', async () => {
       const platform = Object.getOwnPropertyDescriptor(process, 'platform')
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -2027,7 +2027,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(result.coldRestore).toBeUndefined()
     })
 
-    it('returns capture-unavailable for an empty lost-worker payload without creating a replacement', async () => {
+    it('passes a proven empty lost-worker payload to the archive gate', async () => {
       const sessionId = 'lost-worker-empty-payload'
       const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
       mkdirSync(sessionDir, { recursive: true })
@@ -2066,7 +2066,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
       const preSpawnLostWorker = vi.fn(async () => ({
         kind: 'archived' as const,
-        archiveId: 'unexpected-archive'
+        archiveId: 'archive-empty-worker'
       }))
 
       const result = await historyAdapter.spawn({
@@ -2077,10 +2077,12 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       })
 
       expect(result.lostWorkerRecovery).toEqual({
-        kind: 'retryable-error',
-        code: 'capture-unavailable'
+        kind: 'archived',
+        archiveId: 'archive-empty-worker'
       })
-      expect(preSpawnLostWorker).not.toHaveBeenCalled()
+      expect(preSpawnLostWorker).toHaveBeenCalledWith(
+        expect.objectContaining({ scrollback: '', probeSibling: expect.any(Function) })
+      )
       expect(lastSpawnOpts).toBeNull()
     })
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -988,8 +988,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(() => JSON.parse(state)).not.toThrow()
     })
 
-    it('revive does not throw', async () => {
-      await expect(adapter.revive('{}')).resolves.toBeUndefined()
+    it('reports that daemon revival is not applicable', async () => {
+      await expect(adapter.revive('{}')).resolves.toEqual({ mode: 'not-applicable' })
     })
   })
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1691,10 +1691,15 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
       await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
       lastSpawnOpts = null
-      const probe = vi.spyOn(historyAdapter, 'getAppliedSize').mockImplementation(async () => {
-        lastSubprocess._simulateExit(1)
-        await new Promise((resolve) => setTimeout(resolve, 0))
-        return { cols: 80, rows: 24 }
+      const client = (historyAdapter as unknown as { client: DaemonClient }).client
+      const originalRequest = client.request.bind(client)
+      const request = vi.spyOn(client, 'request')
+      request.mockImplementation(async (type, payload) => {
+        if (type === 'createOrAttach' && (payload as { attachOnly?: boolean }).attachOnly) {
+          lastSubprocess._simulateExit(1)
+          await new Promise((resolve) => setTimeout(resolve, 0))
+        }
+        return await originalRequest(type, payload)
       })
       const preSpawnLostWorker = vi.fn(async () => ({
         kind: 'archived' as const,
@@ -1708,12 +1713,64 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         preSpawnLostWorker
       })
 
-      expect(probe).toHaveBeenCalledOnce()
+      expect(request).toHaveBeenCalledWith(
+        'createOrAttach',
+        expect.objectContaining({ attachOnly: true })
+      )
       expect(preSpawnLostWorker).toHaveBeenCalledOnce()
       expect(result.lostWorkerRecovery).toEqual({
         kind: 'archived',
         archiveId: 'archive-worker-race'
       })
+      expect(lastSpawnOpts).toBeNull()
+    })
+
+    it('adopts a live lost worker with missing history without creating a replacement', async () => {
+      const sessionId = 'lost-worker-missing-history-live'
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
+      rmSync(join(historyDir, getHistorySessionDirName(sessionId)), {
+        recursive: true,
+        force: true
+      })
+      lastSpawnOpts = null
+      const preSpawnLostWorker = vi.fn(async () => ({
+        kind: 'archived' as const,
+        archiveId: 'unexpected-archive'
+      }))
+
+      const result = await historyAdapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId,
+        preSpawnLostWorker
+      })
+
+      expect(result).toMatchObject({ id: sessionId, isReattach: true })
+      expect(preSpawnLostWorker).not.toHaveBeenCalled()
+      expect(lastSpawnOpts).toBeNull()
+    })
+
+    it('returns capture-unavailable for a lost worker with missing history instead of creating one', async () => {
+      const sessionId = 'lost-worker-missing-history'
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const preSpawnLostWorker = vi.fn(async () => ({
+        kind: 'archived' as const,
+        archiveId: 'unexpected-archive'
+      }))
+
+      const result = await historyAdapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId,
+        preSpawnLostWorker
+      })
+
+      expect(result.lostWorkerRecovery).toEqual({
+        kind: 'retryable-error',
+        code: 'capture-unavailable'
+      })
+      expect(preSpawnLostWorker).not.toHaveBeenCalled()
       expect(lastSpawnOpts).toBeNull()
     })
 
@@ -1889,6 +1946,63 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       const result = await historyAdapter.spawn({ cols: 80, rows: 24, sessionId })
       expect(result.coldRestore).toBeUndefined()
+    })
+
+    it('returns capture-unavailable for an empty lost-worker payload without creating a replacement', async () => {
+      const sessionId = 'lost-worker-empty-payload'
+      const sessionDir = join(historyDir, getHistorySessionDirName(sessionId))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, 'meta.json'),
+        JSON.stringify({
+          cwd: '/projects/myapp',
+          cols: 80,
+          rows: 24,
+          startedAt: '2026-04-15T10:00:00Z',
+          endedAt: null,
+          exitCode: null
+        })
+      )
+      writeFileSync(
+        join(sessionDir, 'checkpoint.json'),
+        JSON.stringify({
+          snapshotAnsi: '',
+          scrollbackAnsi: '',
+          oscLinks: [],
+          rehydrateSequences: '\x1b[?1049h',
+          cwd: '/projects/myapp',
+          cols: 80,
+          rows: 24,
+          modes: {
+            bracketedPaste: false,
+            mouseTracking: false,
+            applicationCursor: false,
+            alternateScreen: true
+          },
+          scrollbackLines: 0,
+          generation: 0,
+          checkpointedAt: '2026-04-15T11:00:00Z'
+        })
+      )
+      historyAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, historyPath: historyDir })
+      const preSpawnLostWorker = vi.fn(async () => ({
+        kind: 'archived' as const,
+        archiveId: 'unexpected-archive'
+      }))
+
+      const result = await historyAdapter.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId,
+        preSpawnLostWorker
+      })
+
+      expect(result.lostWorkerRecovery).toEqual({
+        kind: 'retryable-error',
+        code: 'capture-unavailable'
+      })
+      expect(preSpawnLostWorker).not.toHaveBeenCalled()
+      expect(lastSpawnOpts).toBeNull()
     })
 
     it('re-anchors a cold-restored session with a full checkpoint on the first tick', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -9,6 +9,7 @@ import { mintPtySessionId, parsePtySessionId } from './pty-session-id'
 import { supportsPtyStartupBarrier } from './shell-ready'
 import { CODEX_SHELL_READY_TIMEOUT_MS } from './session'
 import {
+  ATTACH_ONLY_PROTOCOL_VERSION,
   CLEAN_DISCONNECT_PROTOCOL_VERSION,
   COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION,
   AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION,
@@ -106,6 +107,13 @@ export class TerminalKilledError extends Error {
     super(`Session "${sessionId}" was explicitly killed`)
     this.name = 'TerminalKilledError'
   }
+}
+
+function isDaemonSessionNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'SessionNotFoundError' || error.message.startsWith('Session not found:'))
+  )
 }
 
 export class DaemonPtyAdapter implements IPtyProvider {
@@ -330,7 +338,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         ? CODEX_SHELL_READY_TIMEOUT_MS
         : undefined
 
-    const createOrAttach = (historySeed: string | null) => {
+    const createOrAttach = (historySeed: string | null, options?: { attachOnly?: boolean }) => {
       if (opts.signal?.aborted) {
         throw new Error('client_disconnected')
       }
@@ -351,6 +359,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         shellReadySupported,
         ...(shellReadyTimeoutMs !== undefined ? { shellReadyTimeoutMs } : {}),
         ...(historySeed ? { historySeed } : {}),
+        ...(options?.attachOnly ? { attachOnly: true } : {}),
         ...(this.supportsStartupIngress && opts.startupIngress
           ? { startupIngress: opts.startupIngress }
           : {}),
@@ -359,7 +368,40 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     let scrollback = restoreInfo ? getRecoveredHistorySeed(restoreInfo) : null
-    let result = await createOrAttach(scrollback)
+    let result: CreateOrAttachResult
+    if (restoreSkippedForLiveSession && opts.preSpawnLostWorker) {
+      if (this.protocolVersion < ATTACH_ONLY_PROTOCOL_VERSION) {
+        return {
+          id: sessionId,
+          lostWorkerRecovery: { kind: 'retryable-error', code: 'durability-failed' },
+          ...(wslDistro ? { wslDistro } : {})
+        }
+      }
+      try {
+        // Why: a probe can go stale between RPCs; attach-only makes that gap unable to create a replacement shell.
+        result = await createOrAttach(null, { attachOnly: true })
+      } catch (error) {
+        if (!isDaemonSessionNotFoundError(error)) {
+          throw error
+        }
+        restoreInfo = detectColdRestore({ ignoreCleanEnd: true })
+        const coldRestore = restoreInfo ? this.buildColdRestorePayload(restoreInfo) : null
+        if (!coldRestore) {
+          return {
+            id: sessionId,
+            lostWorkerRecovery: { kind: 'retryable-error', code: 'capture-unavailable' },
+            ...(wslDistro ? { wslDistro } : {})
+          }
+        }
+        return {
+          id: sessionId,
+          lostWorkerRecovery: await opts.preSpawnLostWorker(coldRestore),
+          ...(wslDistro ? { wslDistro } : {})
+        }
+      }
+    } else {
+      result = await createOrAttach(scrollback)
+    }
     if (opts.agentSessionEnsure && !isAgentSessionClaimedSpawnResult(result.agentSessionEnsure)) {
       // Why: a claim-incapable owner may already have spawned before returning
       // a malformed response; retire only this requested session before failing closed.
@@ -416,14 +458,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
     }
 
-    // Why: the probe→createOrAttach gap is racy — the session can exit in between, so re-detect to match the unprobed restore path.
-    // Why ignoreCleanEnd: the raced exit event can write endedAt before the reply; nulling the restore here would delete the checkpoint instead of restoring it.
-    if (result.isNew && restoreSkippedForLiveSession) {
+    if (result.isNew && restoreSkippedForLiveSession && !opts.preSpawnLostWorker) {
       restoreInfo = detectColdRestore({ ignoreCleanEnd: true })
       scrollback = restoreInfo ? getRecoveredHistorySeed(restoreInfo) : null
       if (restoreInfo && scrollback) {
-        // Why: the aliveness probe raced with session death, so the first
-        // create lacked recovery bytes. Replace it before exposing the PTY.
+        // Why: ordinary shells retain the legacy restart path; workers use attach-only above so they never create this provisional replacement.
         if (result.incarnationId) {
           operation.ignoredExitIncarnationIds.add(result.incarnationId)
         }

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -36,9 +36,9 @@ import type {
   PtyPersistenceProtocolOptions,
   PtyProviderBufferSnapshot,
   PtyProcessInfo,
-  PtySpawnOptions,
   PtySpawnResult
 } from '../providers/types'
+import type { PtySpawnOptionsWithLostWorker } from '../providers/pty-lost-worker-recovery'
 import { isShellProcess } from '../../shared/agent-detection'
 import { resolveWslSessionContext } from './wsl-session-context'
 import { normalizeWslColdRestoreCwd } from './wsl-cold-restore-cwd'
@@ -218,7 +218,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return this.protocolVersion >= AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION
   }
 
-  async spawn(opts: PtySpawnOptions): Promise<PtySpawnResult> {
+  async spawn(opts: PtySpawnOptionsWithLostWorker): Promise<PtySpawnResult> {
     const sessionId = opts.sessionId ?? mintPtySessionId(opts.worktreeId)
     const operation = {
       exitsBySessionId: new Map<string, { incarnationId?: string }[]>(),
@@ -243,7 +243,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   private async doSpawn(
-    opts: PtySpawnOptions,
+    opts: PtySpawnOptionsWithLostWorker,
     operation: PendingDaemonSpawnOperation
   ): Promise<PtySpawnResult> {
     if (
@@ -304,6 +304,17 @@ export class DaemonPtyAdapter implements IPtyProvider {
     let effectiveCwd = restoreInfo?.cwd ?? opts.cwd
     let effectiveCols = restoreInfo?.cols ?? opts.cols
     let effectiveRows = restoreInfo?.rows ?? opts.rows
+
+    if (restoreInfo && opts.preSpawnLostWorker) {
+      const coldRestore = this.buildColdRestorePayload(restoreInfo)
+      if (coldRestore) {
+        return {
+          id: sessionId,
+          lostWorkerRecovery: await opts.preSpawnLostWorker(coldRestore),
+          ...(wslDistro ? { wslDistro } : {})
+        }
+      }
+    }
 
     const shellReadySupported = opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
     const isCodexStartupCommand =

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -39,7 +39,10 @@ import type {
   PtyProcessInfo,
   PtySpawnResult
 } from '../providers/types'
-import type { PtySpawnOptionsWithLostWorker } from '../providers/pty-lost-worker-recovery'
+import type {
+  PtyColdRestoreProbe,
+  PtySpawnOptionsWithLostWorker
+} from '../providers/pty-lost-worker-recovery'
 import { isShellProcess } from '../../shared/agent-detection'
 import { resolveWslSessionContext } from './wsl-session-context'
 import { normalizeWslColdRestoreCwd } from './wsl-cold-restore-cwd'
@@ -365,7 +368,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
           throw error
         }
         restoreInfo = detectColdRestore({ ignoreCleanEnd: true })
-        const coldRestore = restoreInfo ? this.buildColdRestorePayload(restoreInfo) : null
+        const coldRestore = restoreInfo
+          ? this.buildColdRestorePayloadForLostWorker(restoreInfo)
+          : null
         if (!coldRestore) {
           return {
             id: sessionId,
@@ -375,7 +380,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
         }
         return {
           id: sessionId,
-          lostWorkerRecovery: await opts.preSpawnLostWorker(coldRestore),
+          lostWorkerRecovery: await opts.preSpawnLostWorker({
+            ...coldRestore,
+            probeSibling: (candidateSessionId) =>
+              this.probeColdRestoreForLostWorker(candidateSessionId)
+          }),
           ...(wslDistro ? { wslDistro } : {})
         }
       }
@@ -784,6 +793,27 @@ export class DaemonPtyAdapter implements IPtyProvider {
       rows: restoreInfo.rows,
       oscLinks: restoreInfo.oscLinks
     }
+  }
+
+  private buildColdRestorePayloadForLostWorker(restoreInfo: ColdRestoreInfo): ColdRestorePayload {
+    return {
+      scrollback: getRecoveredHistorySeed(restoreInfo) ?? '',
+      cwd: restoreInfo.cwd,
+      cols: restoreInfo.cols,
+      rows: restoreInfo.rows,
+      oscLinks: restoreInfo.oscLinks
+    }
+  }
+
+  private probeColdRestoreForLostWorker(sessionId: string): PtyColdRestoreProbe {
+    const probe = this.historyReader?.probeColdRestore(sessionId, {
+      wslDistro: this.wslDistrosBySessionId.get(sessionId)
+    }) ?? { kind: 'io-error' as const }
+    if (probe.kind !== 'valid-snapshot') {
+      return probe
+    }
+    const payload = this.buildColdRestorePayloadForLostWorker(probe.restore)
+    return { kind: 'valid-snapshot', ...payload, truncated: probe.truncated }
   }
 
   async sendSignal(id: string, signal: string): Promise<void> {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -298,31 +298,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
       this.setPtyBackgrounded(sessionId, false)
     }
 
-    // Why detect crash-recovery history before spawning: the revived shell should inherit the recovered cwd/dims, not the renderer's mount-time request.
-    // Why probe aliveness first: detectColdRestore replays up to ~5MB on the main process, but a live session's snapshot supersedes disk, so the replay would be wasted.
     let restoreInfo: ColdRestoreInfo | null = null
     let restoreSkippedForLiveSession = false
-    if (this.historyReader?.hasRestorableHistory(sessionId)) {
-      if ((await this.getAppliedSize(sessionId)) !== null) {
-        restoreSkippedForLiveSession = true
-      } else {
-        restoreInfo = detectColdRestore()
-      }
-    }
-    let effectiveCwd = restoreInfo?.cwd ?? opts.cwd
-    let effectiveCols = restoreInfo?.cols ?? opts.cols
-    let effectiveRows = restoreInfo?.rows ?? opts.rows
-
-    if (restoreInfo && opts.preSpawnLostWorker) {
-      const coldRestore = this.buildColdRestorePayload(restoreInfo)
-      if (coldRestore) {
-        return {
-          id: sessionId,
-          lostWorkerRecovery: await opts.preSpawnLostWorker(coldRestore),
-          ...(wslDistro ? { wslDistro } : {})
-        }
-      }
-    }
+    let effectiveCwd = opts.cwd
+    let effectiveCols = opts.cols
+    let effectiveRows = opts.rows
 
     const shellReadySupported = opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
     const isCodexStartupCommand =
@@ -367,9 +347,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
       })
     }
 
-    let scrollback = restoreInfo ? getRecoveredHistorySeed(restoreInfo) : null
+    let scrollback: string | null = null
     let result: CreateOrAttachResult
-    if (restoreSkippedForLiveSession && opts.preSpawnLostWorker) {
+    if (opts.preSpawnLostWorker) {
       if (this.protocolVersion < ATTACH_ONLY_PROTOCOL_VERSION) {
         return {
           id: sessionId,
@@ -378,7 +358,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         }
       }
       try {
-        // Why: a probe can go stale between RPCs; attach-only makes that gap unable to create a replacement shell.
+        // Why: recognized workers must adopt a live session before any recovery payload can choose an archive path.
         result = await createOrAttach(null, { attachOnly: true })
       } catch (error) {
         if (!isDaemonSessionNotFoundError(error)) {
@@ -400,6 +380,19 @@ export class DaemonPtyAdapter implements IPtyProvider {
         }
       }
     } else {
+      // Why detect crash-recovery history before spawning: the revived shell should inherit the recovered cwd/dims, not the renderer's mount-time request.
+      // Why probe aliveness first: detectColdRestore replays up to ~5MB on the main process, but a live session's snapshot supersedes disk, so the replay would be wasted.
+      if (this.historyReader?.hasRestorableHistory(sessionId)) {
+        if ((await this.getAppliedSize(sessionId)) !== null) {
+          restoreSkippedForLiveSession = true
+        } else {
+          restoreInfo = detectColdRestore()
+        }
+      }
+      effectiveCwd = restoreInfo?.cwd ?? opts.cwd
+      effectiveCols = restoreInfo?.cols ?? opts.cols
+      effectiveRows = restoreInfo?.rows ?? opts.rows
+      scrollback = restoreInfo ? getRecoveredHistorySeed(restoreInfo) : null
       result = await createOrAttach(scrollback)
     }
     if (opts.agentSessionEnsure && !isAgentSessionClaimedSpawnResult(result.agentSessionEnsure)) {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -33,6 +33,7 @@ import { cloneAgentSessionOwnerBinding } from '../../shared/claimed-agent-pty-ow
 import type {
   IPtyProvider,
   PtyBackgroundStreamEvent,
+  PtyPersistenceProtocolOptions,
   PtyProviderBufferSnapshot,
   PtyProcessInfo,
   PtySpawnOptions,
@@ -862,7 +863,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
   }
 
-  async serialize(ids: string[]): Promise<string> {
+  async serialize(ids: string[], _options?: PtyPersistenceProtocolOptions): Promise<string> {
     const sessions: Record<string, { initialCwd?: string }> = {}
     for (const id of ids) {
       sessions[id] = { initialCwd: this.initialCwds.get(id) }
@@ -870,8 +871,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return JSON.stringify(sessions)
   }
 
-  async revive(_state: string): Promise<void> {
-    // Sessions already live in the daemon — no revival needed
+  async revive(_state: string, _options?: PtyPersistenceProtocolOptions) {
+    // Sessions already live in the daemon — no revival needed.
+    return { mode: 'not-applicable' as const }
   }
 
   /** Called on app launch. Lists daemon sessions, kills orphans whose workspaceId

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -84,7 +84,7 @@ function createAdapter(
     inspectProcess: vi.fn(async () => ({ foregroundProcess: null, hasChildProcesses: false })),
     confirmForegroundProcess: vi.fn(async () => `${label}-confirmed`),
     serialize: vi.fn(async () => '{}'),
-    revive: vi.fn(async () => {}),
+    revive: vi.fn(async () => ({ mode: 'not-applicable' as const })),
     getDefaultShell: vi.fn(async () => '/bin/zsh'),
     getProfiles: vi.fn(async () => []),
     onData: vi.fn(
@@ -582,5 +582,13 @@ describe('DaemonPtyRouter', () => {
       expect(current.dispose).not.toHaveBeenCalled()
       expect(legacy.dispose).not.toHaveBeenCalled()
     })
+  })
+
+  it('forwards the current adapter revival result', async () => {
+    const current = createAdapter('current')
+    const router = new DaemonPtyRouter({ current, legacy: [] })
+
+    await expect(router.revive('{}')).resolves.toEqual({ mode: 'not-applicable' })
+    expect(current.revive).toHaveBeenCalledWith('{}')
   })
 })

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -2,6 +2,7 @@ import type { DaemonPtyAdapter } from './daemon-pty-adapter'
 import type {
   IPtyProvider,
   PtyBackgroundStreamEvent,
+  PtyPersistenceProtocolOptions,
   PtyProviderBufferSnapshot,
   PtyProcessInfo,
   PtySpawnOptions,
@@ -205,12 +206,12 @@ export class DaemonPtyRouter implements IPtyProvider {
     return this.adapterFor(id).confirmForegroundProcess(id)
   }
 
-  async serialize(ids: string[]): Promise<string> {
-    return this.current.serialize(ids)
+  async serialize(ids: string[], options?: PtyPersistenceProtocolOptions): Promise<string> {
+    return options ? this.current.serialize(ids, options) : this.current.serialize(ids)
   }
 
-  async revive(state: string): Promise<void> {
-    await this.current.revive(state)
+  async revive(state: string, options?: PtyPersistenceProtocolOptions) {
+    return options ? await this.current.revive(state, options) : await this.current.revive(state)
   }
 
   async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -880,6 +880,7 @@ export class DaemonServer {
             terminalWindowsPowerShellImplementation: p.terminalWindowsPowerShellImplementation,
             shellReadySupported: p.shellReadySupported,
             historySeed: p.historySeed,
+            attachOnly: p.attachOnly === true,
             startupIngress: parsePtyStartupIngressIntent(p.startupIngress),
             ...(p.shellReadyTimeoutMs !== undefined
               ? { shellReadyTimeoutMs: p.shellReadyTimeoutMs }

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -44,7 +44,7 @@ function createProvider(
     getForegroundProcess: vi.fn(async () => null),
     confirmForegroundProcess: vi.fn(async () => `${label}-confirmed`),
     serialize: vi.fn(async () => '{}'),
-    revive: vi.fn(async () => {}),
+    revive: vi.fn(async () => ({ mode: 'not-applicable' as const })),
     listProcesses: vi.fn(async () => sessions.map((id) => ({ id, cwd: '', title: label }))),
     getDefaultShell: vi.fn(async () => '/bin/zsh'),
     getProfiles: vi.fn(async () => []),
@@ -327,5 +327,14 @@ describe('DegradedDaemonPtyProvider', () => {
     expect(exitSpy).toHaveBeenCalledWith({ id: 'current-session', code: -1 })
     expect(provider.getCurrentDaemonSessionIds()).toEqual([])
     expect(provider.hasPty('legacy-session')).toBe(true)
+  })
+
+  it('forwards the fallback revival result without claiming typed inspection', async () => {
+    const current = createDaemonAdapter('daemon')
+    const fallback = createProvider('fallback')
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [], fallback })
+
+    await expect(provider.revive('{}')).resolves.toEqual({ mode: 'not-applicable' })
+    expect(fallback.revive).toHaveBeenCalledWith('{}')
   })
 })

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -1,7 +1,11 @@
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { shutdownDegradedFallbackSessions } from './degraded-daemon-fallback-shutdown'
 import { inspectPtyProviderProcess } from '../providers/pty-process-inspection'
-import type { IPtyProvider, PtyBackgroundStreamEvent } from '../providers/types'
+import type {
+  IPtyProvider,
+  PtyBackgroundStreamEvent,
+  PtyPersistenceProtocolOptions
+} from '../providers/types'
 import type { PtyDataEvent, PtyProviderBufferSnapshot } from '../providers/types'
 import type { PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from '../providers/types'
 import {
@@ -167,12 +171,12 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     return this.providerFor(id).confirmForegroundProcess?.(id) ?? null
   }
 
-  async serialize(ids: string[]): Promise<string> {
-    return this.fallback.serialize(ids)
+  async serialize(ids: string[], options?: PtyPersistenceProtocolOptions): Promise<string> {
+    return options ? this.fallback.serialize(ids, options) : this.fallback.serialize(ids)
   }
 
-  async revive(state: string): Promise<void> {
-    await this.fallback.revive(state)
+  async revive(state: string, options?: PtyPersistenceProtocolOptions) {
+    return options ? await this.fallback.revive(state, options) : await this.fallback.revive(state)
   }
 
   listProcesses = (opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> =>
@@ -283,7 +287,9 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
   }
 
   getCurrentDaemonSessionIds(): string[] {
-    return this.sessionIdsForProvider(this.current)
+    return [...this.sessionProviders]
+      .filter(([, provider]) => provider === this.current)
+      .map(([id]) => id)
   }
 
   fanoutCurrentDaemonSyntheticExits(code: number): void {
@@ -330,12 +336,6 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
       }
     }
     return null
-  }
-
-  private sessionIdsForProvider(provider: IPtyProvider): string[] {
-    return [...this.sessionProviders]
-      .filter(([, mappedProvider]) => mappedProvider === provider)
-      .map(([id]) => id)
   }
 
   private daemonAdapterFor(sessionId: string): DaemonPtyAdapter | null {

--- a/src/main/daemon/history-reader.test.ts
+++ b/src/main/daemon/history-reader.test.ts
@@ -200,6 +200,30 @@ describe('HistoryReader', () => {
 
       expect(reader.probeColdRestore('no-payload')).toEqual({ kind: 'payload-absent' })
     })
+
+    it('marks log read, decode, and replay completeness failures unavailable', () => {
+      writeSessionWithCheckpoint(dir, 'log-read-failure', makeMeta(), makeCheckpoint())
+      mkdirSync(join(dir, getHistorySessionDirName('log-read-failure'), 'output.log'))
+      writeSessionWithCheckpoint(dir, 'log-decode-failure', makeMeta(), makeCheckpoint())
+      writeFileSync(
+        join(dir, getHistorySessionDirName('log-decode-failure'), 'output.log'),
+        'not a terminal history log'
+      )
+      writeSessionWithCheckpoint(
+        dir,
+        'log-replay-failure',
+        makeMeta(),
+        makeCheckpoint({ generation: 1 })
+      )
+      writeFileSync(
+        join(dir, getHistorySessionDirName('log-replay-failure'), 'output.log'),
+        Buffer.concat([encodeLogHeader(2), encodeLogBatch(1, [{ kind: 'output', data: 'newer' }])])
+      )
+
+      expect(reader.probeColdRestore('log-read-failure')).toEqual({ kind: 'completeness-lost' })
+      expect(reader.probeColdRestore('log-decode-failure')).toEqual({ kind: 'completeness-lost' })
+      expect(reader.probeColdRestore('log-replay-failure')).toEqual({ kind: 'completeness-lost' })
+    })
   })
 
   it('replays incremental hostname OSC-7 with the same WSL context', () => {

--- a/src/main/daemon/history-reader.test.ts
+++ b/src/main/daemon/history-reader.test.ts
@@ -165,6 +165,43 @@ describe('HistoryReader', () => {
     })
   })
 
+  describe('probeColdRestore', () => {
+    it('distinguishes a proven empty snapshot from missing or closed history', () => {
+      writeSessionWithCheckpoint(
+        dir,
+        'empty',
+        makeMeta(),
+        makeCheckpoint({ snapshotAnsi: '', scrollbackAnsi: '', rehydrateSequences: '' })
+      )
+      writeSessionWithCheckpoint(
+        dir,
+        'closed',
+        makeMeta({ endedAt: '2026-04-15T12:00:00Z' }),
+        makeCheckpoint()
+      )
+      const corruptDir = join(dir, getHistorySessionDirName('corrupt-meta'))
+      mkdirSync(corruptDir, { recursive: true })
+      writeFileSync(join(corruptDir, 'meta.json'), 'not json')
+
+      expect(reader.probeColdRestore('empty')).toMatchObject({
+        kind: 'valid-snapshot',
+        truncated: false,
+        restore: { snapshotAnsi: '' }
+      })
+      expect(reader.probeColdRestore('missing')).toEqual({ kind: 'meta-absent' })
+      expect(reader.probeColdRestore('closed')).toEqual({ kind: 'meta-closed' })
+      expect(reader.probeColdRestore('corrupt-meta')).toEqual({ kind: 'meta-corrupt' })
+    })
+
+    it('fails closed when metadata is valid but no recovery payload exists', () => {
+      const sessionDir = join(dir, getHistorySessionDirName('no-payload'))
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(join(sessionDir, 'meta.json'), JSON.stringify(makeMeta()))
+
+      expect(reader.probeColdRestore('no-payload')).toEqual({ kind: 'payload-absent' })
+    })
+  })
+
   it('replays incremental hostname OSC-7 with the same WSL context', () => {
     writeSessionWithCheckpoint(dir, 'wsl-log', makeMeta(), makeCheckpoint({ generation: 7 }))
     const sessionDir = join(dir, getHistorySessionDirName('wsl-log'))

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -6,6 +6,8 @@ import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges
 import { getHistorySessionDirName } from './history-paths'
 import { decodeTerminalHistoryLog } from './terminal-history-log'
 import { HeadlessEmulator } from './headless-emulator'
+import { truncateUnclosedAlternateScreen } from './terminal-alt-screen-truncation'
+import { probeTerminalHistoryMetadata } from './terminal-history-metadata-probe'
 import {
   readTerminalHistoryBuffer,
   readTerminalHistoryJson,
@@ -14,8 +16,7 @@ import {
 import {
   TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES,
   TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES,
-  TERMINAL_HISTORY_LOG_MAX_BYTES,
-  TERMINAL_HISTORY_META_MAX_BYTES
+  TERMINAL_HISTORY_LOG_MAX_BYTES
 } from './terminal-history-file-limits'
 import {
   retainNewestRestorableTerminalHistorySessions,
@@ -33,8 +34,17 @@ export type ColdRestoreInfo = {
   modes: TerminalModes
 }
 
-const ALT_SCREEN_ON = '\x1b[?1049h'
-const ALT_SCREEN_OFF = '\x1b[?1049l'
+export type ColdRestoreProbe =
+  | {
+      kind:
+        | 'meta-absent'
+        | 'meta-corrupt'
+        | 'meta-closed'
+        | 'payload-absent'
+        | 'payload-corrupt'
+        | 'io-error'
+    }
+  | { kind: 'valid-snapshot'; restore: ColdRestoreInfo; truncated: false }
 
 export class HistoryReader {
   private basePath: string
@@ -43,13 +53,36 @@ export class HistoryReader {
     this.basePath = basePath
   }
 
-  // Why: spawn needs a cheap "could this cold-restore?" predicate before
-  // deciding to pay detectColdRestore's full checkpoint+log replay. Reads only
-  // the small meta.json, using the same unclean-shutdown test detectColdRestore
-  // starts with.
+  // Why: spawn avoids replaying history until metadata proves an unclean shutdown is possible.
   hasRestorableHistory(sessionId: string): boolean {
     const meta = this.readMeta(sessionId)
     return meta !== null && meta.endedAt === null
+  }
+
+  probeColdRestore(
+    sessionId: string,
+    opts?: { ignoreCleanEnd?: boolean; wslDistro?: string }
+  ): ColdRestoreProbe {
+    const meta = probeTerminalHistoryMetadata(this.basePath, sessionId)
+    if (meta.kind !== 'valid') {
+      return meta
+    }
+    if (meta.meta.endedAt !== null && !opts?.ignoreCleanEnd) {
+      return { kind: 'meta-closed' }
+    }
+    try {
+      const restore = this.detectColdRestore(sessionId, opts)
+      if (restore) {
+        return { kind: 'valid-snapshot', restore, truncated: false }
+      }
+      const sessionDir = join(this.basePath, getHistorySessionDirName(sessionId))
+      const hasPayload = ['checkpoint.json', 'output.log', 'scrollback.bin'].some((name) =>
+        existsSync(join(sessionDir, name))
+      )
+      return { kind: hasPayload ? 'payload-corrupt' : 'payload-absent' }
+    } catch {
+      return { kind: 'io-error' }
+    }
   }
 
   detectColdRestore(
@@ -83,10 +116,7 @@ export class HistoryReader {
       }
     }
 
-    // Why log replay is preferred over the checkpoint alone: the log carries
-    // byte-exact output up to ~5s before the crash (up to the full-snapshot
-    // cooldown, ~45s, for a streaming session mid-deferral), while the
-    // checkpoint can be a full log-cap (~5MB of output) stale.
+    // Why: the incremental log is newer than a checkpoint while remaining byte-exact.
     const logRestore = this.restoreFromIncrementalLog(sessionDir, meta, checkpoint, opts?.wslDistro)
     if (logRestore) {
       return logRestore
@@ -268,15 +298,8 @@ export class HistoryReader {
   }
 
   private readMeta(sessionId: string): SessionMeta | null {
-    const metaPath = join(this.basePath, getHistorySessionDirName(sessionId), 'meta.json')
-    if (!existsSync(metaPath)) {
-      return null
-    }
-    try {
-      return readTerminalHistoryJson<SessionMeta>(metaPath, TERMINAL_HISTORY_META_MAX_BYTES)
-    } catch {
-      return null
-    }
+    const result = probeTerminalHistoryMetadata(this.basePath, sessionId)
+    return result.kind === 'valid' ? result.meta : null
   }
 
   // Why: handles the upgrade transition where sessions created before the
@@ -298,7 +321,7 @@ export class HistoryReader {
         scrollbackPath,
         TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES
       )
-      const truncated = this.truncateAltScreen(scrollback)
+      const truncated = truncateUnclosedAlternateScreen(scrollback)
       return {
         snapshotAnsi: truncated,
         scrollbackAnsi: truncated,
@@ -316,43 +339,5 @@ export class HistoryReader {
     } catch {
       return null
     }
-  }
-
-  // Why: raw scrollback from TUI sessions (vim, less, htop) contains
-  // alternate-screen switches that produce garbled output when replayed.
-  // Truncate before the outermost unmatched alt-screen-on so only normal
-  // terminal output is restored.
-  private truncateAltScreen(data: string): string {
-    let depth = 0
-    let outermostUnmatchedOnIdx = -1
-
-    let searchFrom = 0
-    while (searchFrom < data.length) {
-      const onIdx = data.indexOf(ALT_SCREEN_ON, searchFrom)
-      const offIdx = data.indexOf(ALT_SCREEN_OFF, searchFrom)
-
-      if (onIdx === -1 && offIdx === -1) {
-        break
-      }
-
-      if (onIdx !== -1 && (offIdx === -1 || onIdx < offIdx)) {
-        if (depth === 0) {
-          outermostUnmatchedOnIdx = onIdx
-        }
-        depth++
-        searchFrom = onIdx + ALT_SCREEN_ON.length
-      } else {
-        if (depth > 0) {
-          depth--
-        }
-        searchFrom = offIdx + ALT_SCREEN_OFF.length
-      }
-    }
-
-    if (depth > 0 && outermostUnmatchedOnIdx !== -1) {
-      return data.slice(0, outermostUnmatchedOnIdx)
-    }
-
-    return data
   }
 }

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -6,22 +6,17 @@ import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges
 import { getHistorySessionDirName } from './history-paths'
 import { decodeTerminalHistoryLog } from './terminal-history-log'
 import { HeadlessEmulator } from './headless-emulator'
-import { truncateUnclosedAlternateScreen } from './terminal-alt-screen-truncation'
 import { probeTerminalHistoryMetadata } from './terminal-history-metadata-probe'
-import {
-  readTerminalHistoryBuffer,
-  readTerminalHistoryJson,
-  readTerminalHistoryText
-} from './terminal-history-file-reader'
+import { readTerminalHistoryBuffer, readTerminalHistoryJson } from './terminal-history-file-reader'
 import {
   TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES,
-  TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES,
   TERMINAL_HISTORY_LOG_MAX_BYTES
 } from './terminal-history-file-limits'
 import {
   retainNewestRestorableTerminalHistorySessions,
   type RestorableTerminalHistorySession
 } from './terminal-history-restorable-retention'
+import { restoreTerminalHistoryScrollback } from './terminal-history-scrollback-restore'
 
 export type ColdRestoreInfo = {
   snapshotAnsi: string
@@ -44,7 +39,7 @@ export type ColdRestoreProbe =
         | 'payload-corrupt'
         | 'io-error'
     }
-  | { kind: 'valid-snapshot'; restore: ColdRestoreInfo; truncated: false }
+  | { kind: 'valid-snapshot'; restore: ColdRestoreInfo; truncated: boolean }
 
 export class HistoryReader {
   private basePath: string
@@ -71,9 +66,13 @@ export class HistoryReader {
       return { kind: 'meta-closed' }
     }
     try {
-      const restore = this.detectColdRestore(sessionId, opts)
-      if (restore) {
-        return { kind: 'valid-snapshot', restore, truncated: false }
+      const detected = this.detectColdRestoreWithCompleteness(sessionId, opts)
+      if (detected) {
+        return {
+          kind: 'valid-snapshot',
+          restore: detected.restore,
+          truncated: detected.truncated
+        }
       }
       const sessionDir = join(this.basePath, getHistorySessionDirName(sessionId))
       const hasPayload = ['checkpoint.json', 'output.log', 'scrollback.bin'].some((name) =>
@@ -89,6 +88,13 @@ export class HistoryReader {
     sessionId: string,
     opts?: { ignoreCleanEnd?: boolean; wslDistro?: string }
   ): ColdRestoreInfo | null {
+    return this.detectColdRestoreWithCompleteness(sessionId, opts)?.restore ?? null
+  }
+
+  private detectColdRestoreWithCompleteness(
+    sessionId: string,
+    opts?: { ignoreCleanEnd?: boolean; wslDistro?: string }
+  ): { restore: ColdRestoreInfo; truncated: boolean } | null {
     const meta = this.readMeta(sessionId)
     if (!meta) {
       return null
@@ -118,17 +124,21 @@ export class HistoryReader {
 
     // Why: the incremental log is newer than a checkpoint while remaining byte-exact.
     const logRestore = this.restoreFromIncrementalLog(sessionDir, meta, checkpoint, opts?.wslDistro)
-    if (logRestore) {
-      return logRestore
+    if (logRestore?.restore) {
+      return { restore: logRestore.restore, truncated: logRestore.truncated }
     }
 
     if (!checkpoint) {
       // Why: backward compatibility with pre-checkpoint sessions, and corrupt
       // checkpoints — the old scrollback.bin is the best remaining data.
-      return this.detectColdRestoreFromScrollback(sessionId, meta)
+      const restore = restoreTerminalHistoryScrollback(this.basePath, sessionId, meta)
+      return restore ? { restore, truncated: logRestore?.truncated ?? false } : null
     }
 
-    return this.coldRestoreInfoFromSnapshot(checkpoint, checkpoint.cwd, meta)
+    return {
+      restore: this.coldRestoreInfoFromSnapshot(checkpoint, checkpoint.cwd, meta),
+      truncated: logRestore?.truncated ?? false
+    }
   }
 
   listRestorable(): string[] {
@@ -196,7 +206,7 @@ export class HistoryReader {
     meta: SessionMeta,
     checkpoint: TerminalCheckpointFile | null,
     wslDistro?: string
-  ): ColdRestoreInfo | null {
+  ): { restore: ColdRestoreInfo | null; truncated: boolean } | null {
     let logBuffer: Buffer
     try {
       logBuffer = readTerminalHistoryBuffer(
@@ -207,8 +217,11 @@ export class HistoryReader {
       return null
     }
     const log = decodeTerminalHistoryLog(logBuffer)
-    if (!log || log.batches.length === 0) {
-      return null
+    if (!log) {
+      return { restore: null, truncated: false }
+    }
+    if (log.batches.length === 0) {
+      return { restore: null, truncated: log.truncatedTail }
     }
     // Generation mismatch means the log does not continue this checkpoint
     // (e.g. crash between checkpoint rename and log reset, or a pre-log
@@ -216,10 +229,10 @@ export class HistoryReader {
     // garble content; the checkpoint alone is consistent.
     if (checkpoint) {
       if (typeof checkpoint.generation !== 'number' || log.generation !== checkpoint.generation) {
-        return null
+        return { restore: null, truncated: log.truncatedTail }
       }
     } else if (log.generation !== 0) {
-      return null
+      return { restore: null, truncated: log.truncatedTail }
     }
 
     const emulator = new HeadlessEmulator({
@@ -236,7 +249,7 @@ export class HistoryReader {
               checkpoint.snapshotAnsi
           )
         ) {
-          return null
+          return { restore: null, truncated: log.truncatedTail }
         }
         emulator.setRestoredOscLinks(checkpoint.oscLinks)
       }
@@ -244,7 +257,7 @@ export class HistoryReader {
         for (const record of batch.records) {
           if (record.kind === 'output') {
             if (!emulator.writeSync(record.data)) {
-              return null
+              return { restore: null, truncated: log.truncatedTail }
             }
           } else if (record.kind === 'resize') {
             emulator.resize(record.cols, record.rows)
@@ -254,15 +267,18 @@ export class HistoryReader {
         }
       }
       const snapshot = emulator.getSnapshot()
-      return this.coldRestoreInfoFromSnapshot(
-        snapshot,
-        snapshot.cwd ?? checkpoint?.cwd ?? meta.cwd,
-        meta
-      )
+      return {
+        restore: this.coldRestoreInfoFromSnapshot(
+          snapshot,
+          snapshot.cwd ?? checkpoint?.cwd ?? meta.cwd,
+          meta
+        ),
+        truncated: log.truncatedTail
+      }
     } catch {
       // Why: a replay failure must degrade to checkpoint-only restore, never
       // surface as a failed spawn.
-      return null
+      return { restore: null, truncated: log.truncatedTail }
     } finally {
       emulator.dispose()
     }
@@ -300,44 +316,5 @@ export class HistoryReader {
   private readMeta(sessionId: string): SessionMeta | null {
     const result = probeTerminalHistoryMetadata(this.basePath, sessionId)
     return result.kind === 'valid' ? result.meta : null
-  }
-
-  // Why: handles the upgrade transition where sessions created before the
-  // checkpoint migration still have scrollback.bin but no checkpoint.json.
-  private detectColdRestoreFromScrollback(
-    sessionId: string,
-    meta: SessionMeta
-  ): ColdRestoreInfo | null {
-    const scrollbackPath = join(
-      this.basePath,
-      getHistorySessionDirName(sessionId),
-      'scrollback.bin'
-    )
-    if (!existsSync(scrollbackPath)) {
-      return null
-    }
-    try {
-      const scrollback = readTerminalHistoryText(
-        scrollbackPath,
-        TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES
-      )
-      const truncated = truncateUnclosedAlternateScreen(scrollback)
-      return {
-        snapshotAnsi: truncated,
-        scrollbackAnsi: truncated,
-        rehydrateSequences: '',
-        cwd: meta.cwd,
-        cols: meta.cols,
-        rows: meta.rows,
-        modes: {
-          bracketedPaste: false,
-          mouseTracking: false,
-          applicationCursor: false,
-          alternateScreen: false
-        }
-      }
-    } catch {
-      return null
-    }
   }
 }

--- a/src/main/daemon/history-reader.ts
+++ b/src/main/daemon/history-reader.ts
@@ -38,6 +38,7 @@ export type ColdRestoreProbe =
         | 'payload-absent'
         | 'payload-corrupt'
         | 'io-error'
+        | 'completeness-lost'
     }
   | { kind: 'valid-snapshot'; restore: ColdRestoreInfo; truncated: boolean }
 
@@ -67,7 +68,10 @@ export class HistoryReader {
     }
     try {
       const detected = this.detectColdRestoreWithCompleteness(sessionId, opts)
-      if (detected) {
+      if (detected?.completenessLost) {
+        return { kind: 'completeness-lost' }
+      }
+      if (detected?.restore) {
         return {
           kind: 'valid-snapshot',
           restore: detected.restore,
@@ -94,7 +98,7 @@ export class HistoryReader {
   private detectColdRestoreWithCompleteness(
     sessionId: string,
     opts?: { ignoreCleanEnd?: boolean; wslDistro?: string }
-  ): { restore: ColdRestoreInfo; truncated: boolean } | null {
+  ): { restore: ColdRestoreInfo | null; truncated: boolean; completenessLost: boolean } | null {
     const meta = this.readMeta(sessionId)
     if (!meta) {
       return null
@@ -125,19 +129,28 @@ export class HistoryReader {
     // Why: the incremental log is newer than a checkpoint while remaining byte-exact.
     const logRestore = this.restoreFromIncrementalLog(sessionDir, meta, checkpoint, opts?.wslDistro)
     if (logRestore?.restore) {
-      return { restore: logRestore.restore, truncated: logRestore.truncated }
+      return {
+        restore: logRestore.restore,
+        truncated: logRestore.truncated,
+        completenessLost: logRestore.completenessLost
+      }
     }
 
     if (!checkpoint) {
       // Why: backward compatibility with pre-checkpoint sessions, and corrupt
       // checkpoints — the old scrollback.bin is the best remaining data.
       const restore = restoreTerminalHistoryScrollback(this.basePath, sessionId, meta)
-      return restore ? { restore, truncated: logRestore?.truncated ?? false } : null
+      return {
+        restore,
+        truncated: logRestore?.truncated ?? false,
+        completenessLost: logRestore?.completenessLost ?? false
+      }
     }
 
     return {
       restore: this.coldRestoreInfoFromSnapshot(checkpoint, checkpoint.cwd, meta),
-      truncated: logRestore?.truncated ?? false
+      truncated: logRestore?.truncated ?? false,
+      completenessLost: logRestore?.completenessLost ?? false
     }
   }
 
@@ -206,22 +219,23 @@ export class HistoryReader {
     meta: SessionMeta,
     checkpoint: TerminalCheckpointFile | null,
     wslDistro?: string
-  ): { restore: ColdRestoreInfo | null; truncated: boolean } | null {
+  ): { restore: ColdRestoreInfo | null; truncated: boolean; completenessLost: boolean } | null {
+    const logPath = join(sessionDir, 'output.log')
+    if (!existsSync(logPath)) {
+      return null
+    }
     let logBuffer: Buffer
     try {
-      logBuffer = readTerminalHistoryBuffer(
-        join(sessionDir, 'output.log'),
-        TERMINAL_HISTORY_LOG_MAX_BYTES
-      )
+      logBuffer = readTerminalHistoryBuffer(logPath, TERMINAL_HISTORY_LOG_MAX_BYTES)
     } catch {
-      return null
+      return { restore: null, truncated: false, completenessLost: true }
     }
     const log = decodeTerminalHistoryLog(logBuffer)
     if (!log) {
-      return { restore: null, truncated: false }
+      return { restore: null, truncated: false, completenessLost: true }
     }
     if (log.batches.length === 0) {
-      return { restore: null, truncated: log.truncatedTail }
+      return { restore: null, truncated: log.truncatedTail, completenessLost: false }
     }
     // Generation mismatch means the log does not continue this checkpoint
     // (e.g. crash between checkpoint rename and log reset, or a pre-log
@@ -229,10 +243,10 @@ export class HistoryReader {
     // garble content; the checkpoint alone is consistent.
     if (checkpoint) {
       if (typeof checkpoint.generation !== 'number' || log.generation !== checkpoint.generation) {
-        return { restore: null, truncated: log.truncatedTail }
+        return { restore: null, truncated: log.truncatedTail, completenessLost: true }
       }
     } else if (log.generation !== 0) {
-      return { restore: null, truncated: log.truncatedTail }
+      return { restore: null, truncated: log.truncatedTail, completenessLost: true }
     }
 
     const emulator = new HeadlessEmulator({
@@ -249,7 +263,7 @@ export class HistoryReader {
               checkpoint.snapshotAnsi
           )
         ) {
-          return { restore: null, truncated: log.truncatedTail }
+          return { restore: null, truncated: log.truncatedTail, completenessLost: true }
         }
         emulator.setRestoredOscLinks(checkpoint.oscLinks)
       }
@@ -257,7 +271,7 @@ export class HistoryReader {
         for (const record of batch.records) {
           if (record.kind === 'output') {
             if (!emulator.writeSync(record.data)) {
-              return { restore: null, truncated: log.truncatedTail }
+              return { restore: null, truncated: log.truncatedTail, completenessLost: true }
             }
           } else if (record.kind === 'resize') {
             emulator.resize(record.cols, record.rows)
@@ -273,12 +287,12 @@ export class HistoryReader {
           snapshot.cwd ?? checkpoint?.cwd ?? meta.cwd,
           meta
         ),
-        truncated: log.truncatedTail
+        truncated: log.truncatedTail,
+        completenessLost: false
       }
     } catch {
-      // Why: a replay failure must degrade to checkpoint-only restore, never
-      // surface as a failed spawn.
-      return { restore: null, truncated: log.truncatedTail }
+      // Why: normal cold restore may use the checkpoint, but archive capture cannot claim it is complete after replay fails.
+      return { restore: null, truncated: log.truncatedTail, completenessLost: true }
     } finally {
       emulator.dispose()
     }

--- a/src/main/daemon/terminal-alt-screen-truncation.ts
+++ b/src/main/daemon/terminal-alt-screen-truncation.ts
@@ -1,7 +1,6 @@
 const ALT_SCREEN_ON = '\x1b[?1049h'
 const ALT_SCREEN_OFF = '\x1b[?1049l'
 
-/** Keeps only normal-screen history when a legacy scrollback ends inside a TUI. */
 export function truncateUnclosedAlternateScreen(data: string): string {
   let depth = 0
   let outermostUnmatchedOnIdx = -1

--- a/src/main/daemon/terminal-alt-screen-truncation.ts
+++ b/src/main/daemon/terminal-alt-screen-truncation.ts
@@ -1,0 +1,29 @@
+const ALT_SCREEN_ON = '\x1b[?1049h'
+const ALT_SCREEN_OFF = '\x1b[?1049l'
+
+/** Keeps only normal-screen history when a legacy scrollback ends inside a TUI. */
+export function truncateUnclosedAlternateScreen(data: string): string {
+  let depth = 0
+  let outermostUnmatchedOnIdx = -1
+  let searchFrom = 0
+  while (searchFrom < data.length) {
+    const onIdx = data.indexOf(ALT_SCREEN_ON, searchFrom)
+    const offIdx = data.indexOf(ALT_SCREEN_OFF, searchFrom)
+    if (onIdx === -1 && offIdx === -1) {
+      break
+    }
+    if (onIdx !== -1 && (offIdx === -1 || onIdx < offIdx)) {
+      if (depth === 0) {
+        outermostUnmatchedOnIdx = onIdx
+      }
+      depth++
+      searchFrom = onIdx + ALT_SCREEN_ON.length
+    } else {
+      if (depth > 0) {
+        depth--
+      }
+      searchFrom = offIdx + ALT_SCREEN_OFF.length
+    }
+  }
+  return depth > 0 && outermostUnmatchedOnIdx !== -1 ? data.slice(0, outermostUnmatchedOnIdx) : data
+}

--- a/src/main/daemon/terminal-history-incremental-restore.test.ts
+++ b/src/main/daemon/terminal-history-incremental-restore.test.ts
@@ -156,6 +156,18 @@ describe('incremental terminal history restore', () => {
     expect(restore!.scrollbackAnsi).not.toContain('torn batch')
   })
 
+  it('marks a torn log tail truncated so lost-worker capture cannot claim it is empty', async () => {
+    await manager.appendIncrements(SESSION_ID, 1, [{ kind: 'output', data: 'complete batch\r\n' }])
+    await manager.appendIncrements(SESSION_ID, 2, [{ kind: 'output', data: 'torn batch\r\n' }])
+    const logPath = sessionFile('output.log')
+    truncateSync(logPath, readFileSync(logPath).length - 5)
+
+    expect(reader.probeColdRestore(SESSION_ID)).toMatchObject({
+      kind: 'valid-snapshot',
+      truncated: true
+    })
+  })
+
   it('applies resize records during replay', async () => {
     await manager.appendIncrements(SESSION_ID, 1, [
       { kind: 'output', data: 'before resize\r\n' },

--- a/src/main/daemon/terminal-history-metadata-probe.ts
+++ b/src/main/daemon/terminal-history-metadata-probe.ts
@@ -1,0 +1,28 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { SessionMeta } from './history-manager'
+import { getHistorySessionDirName } from './history-paths'
+import { readTerminalHistoryJson } from './terminal-history-file-reader'
+import { TERMINAL_HISTORY_META_MAX_BYTES } from './terminal-history-file-limits'
+
+export type TerminalHistoryMetadataProbe =
+  | { kind: 'meta-absent' | 'meta-corrupt' }
+  | { kind: 'valid'; meta: SessionMeta }
+
+export function probeTerminalHistoryMetadata(
+  basePath: string,
+  sessionId: string
+): TerminalHistoryMetadataProbe {
+  const metaPath = join(basePath, getHistorySessionDirName(sessionId), 'meta.json')
+  if (!existsSync(metaPath)) {
+    return { kind: 'meta-absent' }
+  }
+  try {
+    return {
+      kind: 'valid',
+      meta: readTerminalHistoryJson<SessionMeta>(metaPath, TERMINAL_HISTORY_META_MAX_BYTES)
+    }
+  } catch {
+    return { kind: 'meta-corrupt' }
+  }
+}

--- a/src/main/daemon/terminal-history-scrollback-restore.ts
+++ b/src/main/daemon/terminal-history-scrollback-restore.ts
@@ -1,0 +1,42 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { SessionMeta } from './history-manager'
+import { getHistorySessionDirName } from './history-paths'
+import { truncateUnclosedAlternateScreen } from './terminal-alt-screen-truncation'
+import { readTerminalHistoryText } from './terminal-history-file-reader'
+import { TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES } from './terminal-history-file-limits'
+import type { ColdRestoreInfo } from './history-reader'
+
+export function restoreTerminalHistoryScrollback(
+  basePath: string,
+  sessionId: string,
+  meta: SessionMeta
+): ColdRestoreInfo | null {
+  const scrollbackPath = join(basePath, getHistorySessionDirName(sessionId), 'scrollback.bin')
+  if (!existsSync(scrollbackPath)) {
+    return null
+  }
+  try {
+    const scrollback = readTerminalHistoryText(
+      scrollbackPath,
+      TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES
+    )
+    const truncated = truncateUnclosedAlternateScreen(scrollback)
+    return {
+      snapshotAnsi: truncated,
+      scrollbackAnsi: truncated,
+      rehydrateSequences: '',
+      cwd: meta.cwd,
+      cols: meta.cols,
+      rows: meta.rows,
+      modes: {
+        bracketedPaste: false,
+        mouseTracking: false,
+        applicationCursor: false,
+        alternateScreen: false
+      }
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/main/daemon/terminal-host-create-contract.ts
+++ b/src/main/daemon/terminal-host-create-contract.ts
@@ -26,6 +26,8 @@ export type CreateOrAttachOptions = {
   shellReadySupported?: boolean
   shellReadyTimeoutMs?: number
   historySeed?: string
+  /** Refuse to turn a missing session into a replacement process. */
+  attachOnly?: boolean
   startupIngress?: PtyStartupIngressIntent
   agentSessionEnsure?: {
     claim: AgentSessionExecutionClaim

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -23,6 +23,7 @@ export type { TerminalModes } from './terminal-modes'
 import type { TerminalSnapshot } from './terminal-snapshot'
 export type { TerminalSnapshot } from './terminal-snapshot'
 export {
+  ATTACH_ONLY_PROTOCOL_VERSION,
   AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION,
   AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION,
   CLEAN_DISCONNECT_PROTOCOL_VERSION,
@@ -81,6 +82,8 @@ export type CreateOrAttachRequest = {
     shellReadyTimeoutMs?: number
     /** Recovered ANSI applied before the new subprocess can emit startup output. */
     historySeed?: string
+    /** Refuse to create when a formerly-live session vanished before attach. */
+    attachOnly?: boolean
     startupIngress?: PtyStartupIngressIntent
     agentSessionEnsure?: {
       claim: AgentSessionExecutionClaim

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -169,6 +169,7 @@ import { findTrustedCodexSessionResume } from './codex/codex-session-resume-home
 import { getSystemCodexHomePath } from './codex/codex-home-paths'
 import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
 import type { AgentProviderSessionMetadata } from '../shared/agent-session-resume'
+import { isTuiAgent } from '../shared/tui-agent-config'
 import { getDefaultWslDistro } from './wsl'
 import { ClaudeAccountService } from './claude-accounts/service'
 import { ClaudeRuntimeAuthService } from './claude-accounts/runtime-auth-service'
@@ -1223,6 +1224,22 @@ function openMainWindow(): BrowserWindow {
       promptInteractionKey,
       isReplay
     }) => {
+      const orchestration = runtime?.getAgentStatusOrchestrationContextForPaneKey(paneKey)
+      const hint = {
+        ...(providerSession ? { providerSession } : {}),
+        ...(isTuiAgent(payload.agentType) ? { launchAgent: payload.agentType } : {}),
+        ...(orchestration?.taskId ? { orchestrationTaskId: orchestration.taskId } : {})
+      }
+      if (store && worktreeId && Object.keys(hint).length > 0) {
+        try {
+          store.persistTerminalArchiveHint(
+            { paneKey, hint, source: 'hook' },
+            store.getWorkspaceSessionHostIdForWorktree(worktreeId)
+          )
+        } catch (error) {
+          console.warn('[agent-hooks] failed to persist terminal archive evidence:', error)
+        }
+      }
       if (mainWindow?.isDestroyed()) {
         return
       }
@@ -1243,7 +1260,6 @@ function openMainWindow(): BrowserWindow {
         return
       }
       maybeAutoRenameBranchOnFirstWorkFromHook({ paneKey, tabId, worktreeId, payload, isReplay })
-      const orchestration = runtime?.getAgentStatusOrchestrationContextForPaneKey(paneKey)
       const terminalHandle = runtime?.getAgentStatusTerminalHandleForPaneKey(paneKey)
       mainWindow?.webContents.send('agentStatus:set', {
         ...payload,

--- a/src/main/ipc/agent-hooks.test.ts
+++ b/src/main/ipc/agent-hooks.test.ts
@@ -401,6 +401,10 @@ describe('agent pane authority IPC', () => {
   })
 
   it('transfers validated pane authority with its provider PTY', async () => {
+    const { configureAgentPaneAuthorityPersistence } = await import('./agent-pane-authority-ipc')
+    configureAgentPaneAuthorityPersistence({
+      transferPaneDurableState: vi.fn(() => ({ kind: 'transferred' as const }))
+    })
     const { registerAgentHookHandlers } = await import('./agent-hooks')
     registerAgentHookHandlers()
 
@@ -414,6 +418,60 @@ describe('agent pane authority IPC', () => {
     )
 
     expect(transferPaneAuthority).toHaveBeenCalledWith(PANE_KEY, CHILD_PANE_KEY, 'pty-1')
+  })
+
+  it('moves durable pane state before transferring the hook alias', async () => {
+    const { configureAgentPaneAuthorityPersistence } = await import('./agent-pane-authority-ipc')
+    const transferPaneDurableState = vi.fn(() => ({ kind: 'transferred' as const }))
+    configureAgentPaneAuthorityPersistence({ transferPaneDurableState })
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    onHandlers.get('agentStatus:transferPaneAuthority')!(
+      {},
+      { fromPaneKey: PANE_KEY, toPaneKey: CHILD_PANE_KEY, ptyId: 'pty-1' }
+    )
+
+    expect(transferPaneDurableState).toHaveBeenCalledWith({
+      fromPaneKey: PANE_KEY,
+      toPaneKey: CHILD_PANE_KEY,
+      ptyId: 'pty-1'
+    })
+    expect(transferPaneDurableState.mock.invocationCallOrder[0]).toBeLessThan(
+      transferPaneAuthority.mock.invocationCallOrder[0]!
+    )
+  })
+
+  it('acknowledges a durable transfer for renderer reconciliation', async () => {
+    const { configureAgentPaneAuthorityPersistence } = await import('./agent-pane-authority-ipc')
+    configureAgentPaneAuthorityPersistence({
+      transferPaneDurableState: vi.fn(() => ({ kind: 'transferred' as const }))
+    })
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    expect(
+      handleHandlers.get('agentStatus:transferPaneAuthority')!(
+        {},
+        { fromPaneKey: PANE_KEY, toPaneKey: CHILD_PANE_KEY, ptyId: 'pty-1' }
+      )
+    ).toEqual({ kind: 'transferred' })
+  })
+
+  it('keeps the hook alias at its source when durable transfer is not acknowledged', async () => {
+    const { configureAgentPaneAuthorityPersistence } = await import('./agent-pane-authority-ipc')
+    configureAgentPaneAuthorityPersistence({
+      transferPaneDurableState: vi.fn(() => ({ kind: 'durability-failed' as const }))
+    })
+    const { registerAgentHookHandlers } = await import('./agent-hooks')
+    registerAgentHookHandlers()
+
+    onHandlers.get('agentStatus:transferPaneAuthority')!(
+      {},
+      { fromPaneKey: PANE_KEY, toPaneKey: CHILD_PANE_KEY, ptyId: 'pty-1' }
+    )
+
+    expect(transferPaneAuthority).not.toHaveBeenCalled()
   })
 
   it('rejects malformed pane authority messages and replaces prior listeners', async () => {

--- a/src/main/ipc/agent-pane-authority-ipc.ts
+++ b/src/main/ipc/agent-pane-authority-ipc.ts
@@ -8,11 +8,33 @@ export type AgentPaneAuthorityOwnership = {
   ownsPty: (paneKey: string, ptyId: string) => boolean
 }
 
+export type AgentPaneAuthorityTransferResult =
+  | { kind: 'transferred' }
+  | { kind: 'not-owned' }
+  | { kind: 'durability-failed' }
+
+type AgentPaneAuthorityPersistence = {
+  transferPaneDurableState: (args: {
+    fromPaneKey: string
+    toPaneKey: string
+    ptyId: string
+  }) => AgentPaneAuthorityTransferResult
+}
+
+let paneAuthorityPersistence: AgentPaneAuthorityPersistence | null = null
+
+export function configureAgentPaneAuthorityPersistence(
+  persistence: AgentPaneAuthorityPersistence | null
+): void {
+  paneAuthorityPersistence = persistence
+}
+
 export function registerAgentPaneAuthorityIpcHandlers(
   ownership: AgentPaneAuthorityOwnership
 ): void {
   ipcMain.removeAllListeners('agentStatus:retirePaneAuthority')
   ipcMain.removeAllListeners('agentStatus:transferPaneAuthority')
+  ipcMain.removeHandler('agentStatus:transferPaneAuthority')
   ipcMain.on('agentStatus:retirePaneAuthority', (_event, paneKey: unknown) => {
     if (typeof paneKey !== 'string' || !isValidPaneKey(paneKey)) {
       return
@@ -24,9 +46,9 @@ export function registerAgentPaneAuthorityIpcHandlers(
       console.warn('[agent-hooks] retirePaneAuthority failed:', err)
     }
   })
-  ipcMain.on('agentStatus:transferPaneAuthority', (_event, value: unknown) => {
+  const transferPaneAuthority = (value: unknown): AgentPaneAuthorityTransferResult => {
     if (!value || typeof value !== 'object') {
-      return
+      return { kind: 'not-owned' }
     }
     const args = value as Record<string, unknown>
     const ptyId = typeof args.ptyId === 'string' ? args.ptyId : undefined
@@ -43,12 +65,28 @@ export function registerAgentPaneAuthorityIpcHandlers(
           args.ptyId.length === 0)) ||
       !agentHookServer.canTransferPaneAuthority(args.fromPaneKey, ptyId, ownership.ownsPty)
     ) {
-      return
+      return { kind: 'not-owned' }
     }
     try {
+      const durableTransfer = paneAuthorityPersistence?.transferPaneDurableState({
+        fromPaneKey: args.fromPaneKey,
+        toPaneKey: args.toPaneKey,
+        ptyId: ptyId ?? ''
+      })
+      if (!durableTransfer || durableTransfer.kind !== 'transferred') {
+        return durableTransfer ?? { kind: 'not-owned' }
+      }
       agentHookServer.transferPaneAuthority(args.fromPaneKey, args.toPaneKey, ptyId)
+      return { kind: 'transferred' }
     } catch (err) {
       console.warn('[agent-hooks] transferPaneAuthority failed:', err)
+      return { kind: 'durability-failed' }
     }
+  }
+  ipcMain.on('agentStatus:transferPaneAuthority', (_event, value: unknown) => {
+    transferPaneAuthority(value)
   })
+  ipcMain.handle('agentStatus:transferPaneAuthority', (_event, value: unknown) =>
+    transferPaneAuthority(value)
+  )
 }

--- a/src/main/ipc/pty-renderer-delivery-router.ts
+++ b/src/main/ipc/pty-renderer-delivery-router.ts
@@ -1,9 +1,14 @@
 import type { PtyDataEvent } from '../providers/pty-provider-events'
+import type { TerminalLostWorkerRendererReceipt } from '../../shared/terminal-archive-types'
 
 export type ExternalPtyRendererDeliveryRouter = {
   data(payload: PtyDataEvent): void
   replay(payload: { id: string; data: string }): void
-  exit(payload: { id: string; code: number }): void
+  exit(payload: {
+    id: string
+    code: number
+    lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+  }): void
 }
 
 function returnUnroutedCredit(payload: PtyDataEvent): void {
@@ -30,6 +35,10 @@ export function routeExternalPtyReplay(payload: { id: string; data: string }): v
   router.replay(payload)
 }
 
-export function routeExternalPtyExit(payload: { id: string; code: number }): void {
+export function routeExternalPtyExit(payload: {
+  id: string
+  code: number
+  lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+}): void {
   router.exit(payload)
 }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -3747,7 +3747,11 @@ describe('registerPtyHandlers', () => {
             worktreeId: 'wt-1',
             tabId: 'tab-1',
             leafId,
-            ptyId: 'ssh-pty'
+            ptyId: 'ssh-pty',
+            archiveHint: {
+              source: 'spawn',
+              hint: { startedAt: expect.any(Number) }
+            }
           },
           'ssh:ssh-1'
         )
@@ -6592,7 +6596,11 @@ describe('registerPtyHandlers', () => {
       tabId: 'tab-headless',
       leafId,
       ptyId: expect.any(String),
-      incarnationId: expect.any(String)
+      incarnationId: expect.any(String),
+      archiveHint: {
+        source: 'spawn',
+        hint: { startedAt: expect.any(Number) }
+      }
     })
   })
 
@@ -6869,7 +6877,11 @@ describe('registerPtyHandlers', () => {
       tabId: 'tab-race',
       leafId,
       ptyId: 'pty-shared',
-      startupCwd: '/tmp'
+      startupCwd: '/tmp',
+      archiveHint: {
+        source: 'spawn',
+        hint: { cwd: '/tmp', startedAt: expect.any(Number) }
+      }
     })
   })
 
@@ -6983,7 +6995,11 @@ describe('registerPtyHandlers', () => {
       tabId: 'tab-race',
       leafId,
       ptyId: 'pty-renderer',
-      startupCwd: '/tmp'
+      startupCwd: '/tmp',
+      archiveHint: {
+        source: 'spawn',
+        hint: { cwd: '/tmp', startedAt: expect.any(Number) }
+      }
     })
   })
 
@@ -7206,7 +7222,11 @@ describe('registerPtyHandlers', () => {
         worktreeId: 'wt-remote',
         tabId: 'tab-remote',
         leafId,
-        ptyId: 'ssh:ssh-1@@relay-pty'
+        ptyId: 'ssh:ssh-1@@relay-pty',
+        archiveHint: {
+          source: 'spawn',
+          hint: { startedAt: expect.any(Number) }
+        }
       },
       'ssh:ssh-1'
     )
@@ -7358,7 +7378,8 @@ describe('registerPtyHandlers', () => {
           worktreeId: 'wt-remote',
           tabId: 'tab-remote',
           leafId,
-          ptyId: 'ssh:ssh-reattach-ok@@relay-pty'
+          ptyId: 'ssh:ssh-reattach-ok@@relay-pty',
+          archiveHint: { source: 'spawn', hint: {} }
         },
         'ssh:ssh-reattach-ok'
       )

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -600,6 +600,9 @@ describe('registerPtyHandlers', () => {
     const worktreeId = 'repo-1::/worktree'
     const shutdownStarted = makeDeferred()
     const releaseShutdown = makeDeferred()
+    const exitListeners = new Set<
+      (payload: { id: string; code: number; incarnationId?: string }) => void
+    >()
     setLocalPtyProvider({
       spawn: vi.fn(),
       write: vi.fn(),
@@ -608,6 +611,9 @@ describe('registerPtyHandlers', () => {
       shutdown: vi.fn(async () => {
         shutdownStarted.resolve()
         await releaseShutdown.promise
+        for (const listener of exitListeners) {
+          listener({ id: ptyId, code: 0, incarnationId: oldIncarnationId })
+        }
         throw new Error('daemon unavailable')
       }),
       sendSignal: vi.fn(),
@@ -622,7 +628,10 @@ describe('registerPtyHandlers', () => {
       revive: vi.fn(),
       onData: vi.fn(() => () => {}),
       onReplay: vi.fn(() => () => {}),
-      onExit: vi.fn(() => () => {}),
+      onExit: vi.fn((listener) => {
+        exitListeners.add(listener)
+        return () => exitListeners.delete(listener)
+      }),
       listProcesses: vi.fn(async () => []),
       attach: vi.fn(),
       getDefaultShell: vi.fn(),
@@ -718,6 +727,11 @@ describe('registerPtyHandlers', () => {
 
     await expect(pending).resolves.toMatchObject({ kind: 'archived' })
     expect(runtime.onPtyExit).toHaveBeenCalledWith(ptyId, -1, oldIncarnationId)
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
+      id: ptyId,
+      code: -1,
+      lostWorkerRecovery: { kind: 'archived', archiveId: expect.any(String) }
+    })
     clearProviderPtyState(ptyId)
   })
 
@@ -856,6 +870,149 @@ describe('registerPtyHandlers', () => {
       id: ptyId,
       code: 0,
       incarnationId,
+      lostWorkerRecovery: { kind: 'archived', archiveId: expect.any(String) }
+    })
+    clearProviderPtyState(ptyId)
+  })
+
+  it('does not attach an old archive receipt to a replacement non-SSH exit', async () => {
+    const ptyId = 'daemon-archive-replacement-exit'
+    const oldIncarnationId = 'incarnation-old'
+    const replacementIncarnationId = 'incarnation-replacement'
+    const leafId = '44444444-4444-4444-8444-444444444444'
+    const tabId = 'tab-archive-replacement-exit'
+    const worktreeId = 'repo-1::/worktree'
+    const exitListeners = new Set<
+      (payload: { id: string; code: number; incarnationId?: string }) => void
+    >()
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(async () => {
+        restorePtyIncarnation(ptyId, replacementIncarnationId)
+        for (const listener of exitListeners) {
+          listener({ id: ptyId, code: 0, incarnationId: replacementIncarnationId })
+        }
+      }),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      confirmForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn((listener) => {
+        exitListeners.add(listener)
+        return () => exitListeners.delete(listener)
+      }),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    const session = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        [worktreeId]: [
+          {
+            id: tabId,
+            worktreeId,
+            title: 'Worker',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: { type: 'leaf' as const, leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: ptyId }
+        }
+      },
+      terminalPtyIncarnationsByPaneKey: { [makePaneKey(tabId, leafId)]: oldIncarnationId },
+      terminalArchiveHintsByPaneKey: {
+        [makePaneKey(tabId, leafId)]: { launchAgent: 'codex' as const, startedAt: 1 }
+      }
+    }
+    let archives = {}
+    const store = {
+      getWorkspaceSession: vi.fn(() => session),
+      createTerminalArchiveStore: vi.fn(
+        (snapshotSource) =>
+          new TerminalArchiveStore(
+            {
+              getTerminalArchives: () => archives,
+              replaceTerminalArchivesAndFlush: (next) => {
+                archives = next
+              },
+              getTerminalArchiveRetentionDays: () => 7,
+              isExecutionHostReachable: () => true,
+              worktreeExists: () => true,
+              isTerminalArchiveRequestOwned: () => true,
+              isTerminalScrollbackSnapshotLive: () => false,
+              commitLostTerminalArchiveAndRetire: (nextArchives) => {
+                archives = nextArchives
+                return { closed: true, ptyIdsToKill: [ptyId], session }
+              }
+            } as never,
+            snapshotSource,
+            () => 100
+          )
+      )
+    }
+    const runtime = {
+      setPtyController: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+
+    restorePtyIncarnation(ptyId, oldIncarnationId)
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      undefined,
+      undefined,
+      undefined,
+      store as never
+    )
+    const archive = handlers.get('pty:handleLostTerminalCandidate')
+    if (!archive) {
+      throw new Error('missing lost-worker archive handler')
+    }
+
+    await expect(
+      archive(mainWindowIpcEvent, {
+        worktreeId,
+        tabId,
+        leafId,
+        reason: 'daemon-worker-lost',
+        executionHostId: 'local',
+        snapshotsByLeafId: {
+          [leafId]: { buffer: '', source: 'renderer', truncated: false, byteLength: 0 }
+        }
+      })
+    ).resolves.toMatchObject({ kind: 'archived' })
+
+    expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(1, 'pty:exit', {
+      id: ptyId,
+      code: 0,
+      incarnationId: replacementIncarnationId
+    })
+    expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(2, 'pty:exit', {
+      id: ptyId,
+      code: -1,
       lostWorkerRecovery: { kind: 'archived', archiveId: expect.any(String) }
     })
     clearProviderPtyState(ptyId)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -721,6 +721,146 @@ describe('registerPtyHandlers', () => {
     clearProviderPtyState(ptyId)
   })
 
+  it('delivers the archive receipt with a synchronous non-SSH provider exit', async () => {
+    const ptyId = 'daemon-archive-sync-exit'
+    const incarnationId = 'incarnation-current'
+    const leafId = '33333333-3333-4333-8333-333333333333'
+    const tabId = 'tab-archive-sync-exit'
+    const worktreeId = 'repo-1::/worktree'
+    const exitListeners = new Set<
+      (payload: { id: string; code: number; incarnationId?: string }) => void
+    >()
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(async () => {
+        for (const listener of exitListeners) {
+          listener({ id: ptyId, code: 0, incarnationId })
+        }
+      }),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      confirmForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn((listener) => {
+        exitListeners.add(listener)
+        return () => exitListeners.delete(listener)
+      }),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    const session = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        [worktreeId]: [
+          {
+            id: tabId,
+            worktreeId,
+            title: 'Worker',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: { type: 'leaf' as const, leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: ptyId }
+        }
+      },
+      terminalPtyIncarnationsByPaneKey: { [makePaneKey(tabId, leafId)]: incarnationId },
+      terminalArchiveHintsByPaneKey: {
+        [makePaneKey(tabId, leafId)]: { launchAgent: 'codex' as const, startedAt: 1 }
+      }
+    }
+    let archives = {}
+    const store = {
+      getWorkspaceSession: vi.fn(() => session),
+      createTerminalArchiveStore: vi.fn(
+        (snapshotSource) =>
+          new TerminalArchiveStore(
+            {
+              getTerminalArchives: () => archives,
+              replaceTerminalArchivesAndFlush: (next) => {
+                archives = next
+              },
+              getTerminalArchiveRetentionDays: () => 7,
+              isExecutionHostReachable: () => true,
+              worktreeExists: () => true,
+              isTerminalArchiveRequestOwned: () => true,
+              isTerminalScrollbackSnapshotLive: () => false,
+              commitLostTerminalArchiveAndRetire: (nextArchives) => {
+                archives = nextArchives
+                return { closed: true, ptyIdsToKill: [ptyId], session }
+              }
+            } as never,
+            snapshotSource,
+            () => 100
+          )
+      )
+    }
+    const runtime = {
+      setPtyController: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+
+    restorePtyIncarnation(ptyId, incarnationId)
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      undefined,
+      undefined,
+      undefined,
+      store as never
+    )
+    const archive = handlers.get('pty:handleLostTerminalCandidate')
+    if (!archive) {
+      throw new Error('missing lost-worker archive handler')
+    }
+
+    await expect(
+      archive(mainWindowIpcEvent, {
+        worktreeId,
+        tabId,
+        leafId,
+        reason: 'daemon-worker-lost',
+        executionHostId: 'local',
+        snapshotsByLeafId: {
+          [leafId]: { buffer: '', source: 'renderer', truncated: false, byteLength: 0 }
+        }
+      })
+    ).resolves.toMatchObject({ kind: 'archived' })
+
+    expect(runtime.onPtyExit).toHaveBeenCalledOnce()
+    expect(runtime.onPtyExit).toHaveBeenCalledWith(ptyId, 0, incarnationId)
+    expect(mainWindow.webContents.send).toHaveBeenCalledTimes(1)
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
+      id: ptyId,
+      code: 0,
+      incarnationId,
+      lostWorkerRecovery: { kind: 'archived', archiveId: expect.any(String) }
+    })
+    clearProviderPtyState(ptyId)
+  })
+
   it('guards recognized daemon workers with agent-resume payloads unless the wake is explicitly controlled', async () => {
     const daemonSpawn = installDaemonTestProvider()
     daemonSpawn.mockImplementation(async (options: { sessionId?: string }) => ({

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -590,6 +590,65 @@ describe('registerPtyHandlers', () => {
     return spawn
   }
 
+  it('guards recognized daemon workers with agent-resume payloads unless the wake is explicitly controlled', async () => {
+    const daemonSpawn = installDaemonTestProvider()
+    daemonSpawn.mockImplementation(async (options: { sessionId?: string }) => ({
+      id: options.sessionId ?? 'daemon-worker',
+      lostWorkerRecovery: { kind: 'retryable-error' as const, code: 'capture-unavailable' as const }
+    }))
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const paneKey = makePaneKey('tab-1', leafId)
+    const store = {
+      getWorkspaceSession: vi.fn(() => ({
+        terminalArchiveHintsByPaneKey: {
+          [paneKey]: { providerSession: { key: 'session_id', id: 'worker-session' } }
+        }
+      }))
+    }
+    registerPtyHandlers(
+      mainWindow as never,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      store as never
+    )
+    const agentResume = {
+      launchConfig: { agentCommand: 'codex', agentArgs: '', agentEnv: {} },
+      resumeProviderSession: { key: 'session_id' as const, id: 'worker-session' }
+    }
+    const spawn = handlers.get('pty:spawn')!
+
+    await spawn(null, {
+      cols: 80,
+      rows: 24,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId,
+      sessionId: 'daemon-worker',
+      ...agentResume
+    })
+
+    expect(daemonSpawn.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        preSpawnLostWorker: expect.any(Function)
+      })
+    )
+
+    await spawn(null, {
+      cols: 80,
+      rows: 24,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId,
+      sessionId: 'daemon-worker',
+      controlledHibernationWake: true,
+      ...agentResume
+    })
+
+    expect(daemonSpawn.mock.calls[1]?.[0]).not.toHaveProperty('preSpawnLostWorker')
+  })
+
   function installObservableDaemonTestProvider() {
     const spawn = vi.fn(async (options: { sessionId?: string }) => ({
       id: options.sessionId ?? 'daemon-pty'

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -649,6 +649,94 @@ describe('registerPtyHandlers', () => {
     expect(daemonSpawn.mock.calls[1]?.[0]).not.toHaveProperty('preSpawnLostWorker')
   })
 
+  it.each([
+    {
+      name: 'an archived receipt',
+      receipt: { kind: 'archived' as const, archiveId: 'archive-existing-worker' }
+    },
+    {
+      name: 'a retryable receipt',
+      receipt: { kind: 'retryable-error' as const, code: 'capture-unavailable' as const }
+    }
+  ])('returns $name before registering or retaining a hidden daemon PTY', async ({ receipt }) => {
+    const sessionId = 'stable-existing-daemon-pty'
+    const spawn = vi.fn(async () => ({ id: sessionId, lostWorkerRecovery: receipt }))
+    const shutdown = vi.fn()
+    const kill = vi.fn()
+    setLocalPtyProvider({
+      spawn,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill,
+      shutdown,
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      confirmForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    const runtime = {
+      setPtyController: vi.fn(),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'term-existing-daemon-pty'),
+      registerPreAllocatedHandleForPty: vi.fn(),
+      beginPtyRegistration: vi.fn(),
+      cancelPendingPtyRegistration: vi.fn(),
+      registerPty: vi.fn(),
+      onPtySpawned: vi.fn()
+    }
+    const store = { persistPtyBinding: vi.fn() }
+    const startupCommand = 'echo do-not-log-this-startup-command'
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      registerPtyHandlers(
+        mainWindow as never,
+        runtime as never,
+        undefined,
+        undefined,
+        undefined,
+        store as never
+      )
+      const result = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        sessionId,
+        command: startupCommand,
+        initiallyHidden: true
+      })) as { id: string; lostWorkerRecovery?: unknown }
+
+      expect(result).toEqual({ id: sessionId, lostWorkerRecovery: receipt })
+      expect(runtime.beginPtyRegistration).toHaveBeenCalledWith(sessionId)
+      expect(runtime.cancelPendingPtyRegistration).toHaveBeenCalledWith(sessionId)
+      expect(runtime.registerPty).not.toHaveBeenCalled()
+      expect(runtime.onPtySpawned).not.toHaveBeenCalled()
+      expect(registerPtyMock).not.toHaveBeenCalled()
+      expect(store.persistPtyBinding).not.toHaveBeenCalled()
+      expect(shutdown).not.toHaveBeenCalled()
+      expect(kill).not.toHaveBeenCalled()
+      expect(isHiddenRendererPty(sessionId)).toBe(false)
+      expect([...errorSpy.mock.calls, ...warnSpy.mock.calls].flat().join(' ')).not.toContain(
+        startupCommand
+      )
+    } finally {
+      errorSpy.mockRestore()
+      warnSpy.mockRestore()
+    }
+  })
+
   function installObservableDaemonTestProvider() {
     const spawn = vi.fn(async (options: { sessionId?: string }) => ({
       id: options.sessionId ?? 'daemon-pty'

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../../shared/terminal-input'
 import { CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS } from '../../shared/clipboard-text'
 import { redactPtyIdForDiagnostics } from '../../shared/pty-delivery-diagnostics'
-import { FLOATING_TERMINAL_WORKTREE_ID } from '../../shared/constants'
+import { FLOATING_TERMINAL_WORKTREE_ID, getDefaultWorkspaceSession } from '../../shared/constants'
 import type { TuiAgent } from '../../shared/types'
 import type { AgentSessionOwnerBinding } from '../../shared/agent-session-host-authority'
 import { MAX_CLAIMED_AGENT_PTY_OWNER_ENTRIES } from '../../shared/claimed-agent-pty-owner'
@@ -251,6 +251,7 @@ import {
 } from '../providers/ssh-pty-errors'
 import { _resetWslCachesForTests, _setWslCachesForTests } from '../wsl'
 import { acquireWatcherRemovalGate } from './watcher-removal-gate'
+import { TerminalArchiveStore } from '../terminal-archive-store'
 
 const POWERSHELL_OSC133_ARGS = [
   '-NoLogo',
@@ -589,6 +590,136 @@ describe('registerPtyHandlers', () => {
     } as never)
     return spawn
   }
+
+  it('keeps a failed archive shutdown fenced to the incarnation captured before cleanup', async () => {
+    const ptyId = 'daemon-archive-reused'
+    const oldIncarnationId = 'incarnation-old'
+    const replacementIncarnationId = 'incarnation-replacement'
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const tabId = 'tab-archive-reused'
+    const worktreeId = 'repo-1::/worktree'
+    const shutdownStarted = makeDeferred()
+    const releaseShutdown = makeDeferred()
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(async () => {
+        shutdownStarted.resolve()
+        await releaseShutdown.promise
+        throw new Error('daemon unavailable')
+      }),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      confirmForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => []),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+    const session = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        [worktreeId]: [
+          {
+            id: tabId,
+            worktreeId,
+            title: 'Worker',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: { type: 'leaf' as const, leafId },
+          activeLeafId: leafId,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [leafId]: ptyId }
+        }
+      },
+      terminalPtyIncarnationsByPaneKey: { [makePaneKey(tabId, leafId)]: oldIncarnationId },
+      terminalArchiveHintsByPaneKey: {
+        [makePaneKey(tabId, leafId)]: { launchAgent: 'codex' as const, startedAt: 1 }
+      }
+    }
+    let archives = {}
+    const store = {
+      getWorkspaceSession: vi.fn(() => session),
+      createTerminalArchiveStore: vi.fn(
+        (snapshotSource) =>
+          new TerminalArchiveStore(
+            {
+              getTerminalArchives: () => archives,
+              replaceTerminalArchivesAndFlush: (next) => {
+                archives = next
+              },
+              getTerminalArchiveRetentionDays: () => 7,
+              isExecutionHostReachable: () => true,
+              worktreeExists: () => true,
+              isTerminalArchiveRequestOwned: () => true,
+              isTerminalScrollbackSnapshotLive: () => false,
+              commitLostTerminalArchiveAndRetire: (nextArchives) => {
+                archives = nextArchives
+                return { closed: true, ptyIdsToKill: [ptyId], session }
+              }
+            } as never,
+            snapshotSource,
+            () => 100
+          )
+      )
+    }
+    const runtime = {
+      setPtyController: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+
+    restorePtyIncarnation(ptyId, oldIncarnationId)
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      undefined,
+      undefined,
+      undefined,
+      store as never
+    )
+    const archive = handlers.get('pty:handleLostTerminalCandidate')
+    if (!archive) {
+      throw new Error('missing lost-worker archive handler')
+    }
+    const pending = archive(mainWindowIpcEvent, {
+      worktreeId,
+      tabId,
+      leafId,
+      reason: 'daemon-worker-lost',
+      executionHostId: 'local',
+      snapshotsByLeafId: {
+        [leafId]: { buffer: '', source: 'renderer', truncated: false, byteLength: 0 }
+      }
+    })
+    await shutdownStarted.promise
+    restorePtyIncarnation(ptyId, replacementIncarnationId)
+    releaseShutdown.resolve()
+
+    await expect(pending).resolves.toMatchObject({ kind: 'archived' })
+    expect(runtime.onPtyExit).toHaveBeenCalledWith(ptyId, -1, oldIncarnationId)
+    clearProviderPtyState(ptyId)
+  })
 
   it('guards recognized daemon workers with agent-resume payloads unless the wake is explicitly controlled', async () => {
     const daemonSpawn = installDaemonTestProvider()

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -4698,6 +4698,91 @@ describe('registerPtyHandlers', () => {
         ).toEqual([['pty:exit', { id: 'local-pty', code: 0 }]])
       })
 
+      it.each([
+        ['controller kill', 'controllerKill'],
+        ['controller stopAndWait', 'controllerStopAndWait'],
+        ['IPC kill', 'ipcKill']
+      ] as const)(
+        'keeps a replacement PTY open when %s races its predecessor shutdown',
+        async (_label, operation) => {
+          const ptyId = `local-shutdown-replaced-${operation}`
+          const oldIncarnationId = 'incarnation-old'
+          const replacementIncarnationId = 'incarnation-replacement'
+          const shutdownStarted = makeDeferred()
+          const releaseShutdown = makeDeferred()
+          const exitListeners = new Set<
+            (payload: { id: string; code: number; incarnationId?: string }) => void
+          >()
+          const runtime = {
+            setPtyController: vi.fn(),
+            onPtyExit: vi.fn()
+          }
+          setLocalPtyProvider({
+            spawn: vi.fn(),
+            write: vi.fn(),
+            resize: vi.fn(),
+            shutdown: vi.fn(async () => {
+              shutdownStarted.resolve()
+              await releaseShutdown.promise
+              for (const listener of exitListeners) {
+                listener({ id: ptyId, code: 0, incarnationId: oldIncarnationId })
+              }
+            }),
+            sendSignal: vi.fn(),
+            getCwd: vi.fn(),
+            getInitialCwd: vi.fn(),
+            clearBuffer: vi.fn(),
+            acknowledgeDataEvent: vi.fn(),
+            hasChildProcesses: vi.fn(),
+            getForegroundProcess: vi.fn(),
+            confirmForegroundProcess: vi.fn(),
+            serialize: vi.fn(),
+            revive: vi.fn(),
+            onData: vi.fn(() => () => {}),
+            onReplay: vi.fn(() => () => {}),
+            onExit: vi.fn((listener) => {
+              exitListeners.add(listener)
+              return () => exitListeners.delete(listener)
+            }),
+            listProcesses: vi.fn(async () => []),
+            attach: vi.fn(),
+            getDefaultShell: vi.fn(),
+            getProfiles: vi.fn()
+          } as never)
+          restorePtyIncarnation(ptyId, oldIncarnationId)
+          handlers.clear()
+          registerPtyHandlers(mainWindow as never, runtime as never)
+          const controller = runtime.setPtyController.mock.calls[0]?.[0] as {
+            kill: (id: string) => boolean
+            stopAndWait: (id: string) => Promise<boolean>
+          }
+          let completed: Promise<unknown>
+          if (operation === 'controllerKill') {
+            expect(controller.kill(ptyId)).toBe(true)
+            completed = new Promise((resolve) => setImmediate(resolve))
+          } else if (operation === 'controllerStopAndWait') {
+            completed = controller.stopAndWait(ptyId)
+          } else {
+            completed = Promise.resolve(handlers.get('pty:kill')!(null, { id: ptyId }))
+          }
+
+          await shutdownStarted.promise
+          restorePtyIncarnation(ptyId, replacementIncarnationId)
+          releaseShutdown.resolve()
+          await completed
+
+          expect(runtime.onPtyExit).toHaveBeenCalledWith(ptyId, -1, oldIncarnationId)
+          expect(runtime.onPtyExit).not.toHaveBeenCalledWith(ptyId, -1, replacementIncarnationId)
+          expect(isCurrentPtyExit({ id: ptyId, incarnationId: replacementIncarnationId })).toBe(
+            true
+          )
+          expect(
+            mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')
+          ).toEqual([])
+          clearProviderPtyState(ptyId)
+        }
+      )
+
       it('controller stopAndWait skips the synthetic exit when the provider emitted one', async () => {
         vi.useFakeTimers()
         const exitListeners = new Set<(payload: { id: string; code: number }) => void>()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3033,17 +3033,30 @@ export function registerPtyHandlers(
   }
 
   const syntheticKillExitPtyIds = new Map<string, NodeJS.Timeout>()
-  const archivedNonSshExitRecoveryByPtyId = new Map<string, string>()
+  const archivedNonSshExitRecoveryByPtyId = new Map<
+    string,
+    { archiveId: string; expectedIncarnationId: string | undefined }
+  >()
   const reversibleStopOwnersByPtyId = new Map<string, number>()
 
-  function beginArchivedNonSshPtyExitRecovery(ptyId: string, archiveId: string): void {
-    archivedNonSshExitRecoveryByPtyId.set(ptyId, archiveId)
+  function beginArchivedNonSshPtyExitRecovery(
+    ptyId: string,
+    archiveId: string,
+    expectedIncarnationId: string | undefined
+  ): void {
+    archivedNonSshExitRecoveryByPtyId.set(ptyId, { archiveId, expectedIncarnationId })
   }
 
-  function takeArchivedNonSshPtyExitRecovery(ptyId: string): string | undefined {
-    const archiveId = archivedNonSshExitRecoveryByPtyId.get(ptyId)
+  function takeArchivedNonSshPtyExitRecovery(
+    ptyId: string,
+    incarnationId: string | undefined
+  ): string | undefined {
+    const receipt = archivedNonSshExitRecoveryByPtyId.get(ptyId)
+    if (!receipt || receipt.expectedIncarnationId !== incarnationId) {
+      return undefined
+    }
     archivedNonSshExitRecoveryByPtyId.delete(ptyId)
-    return archiveId
+    return receipt.archiveId
   }
 
   function rememberSyntheticKillExit(id: string): void {
@@ -3169,7 +3182,8 @@ export function registerPtyHandlers(
     const unsubscribe = provider.onExit((payload) => {
       if (
         payload.id === id &&
-        (!expectedIncarnationId || payload.incarnationId === expectedIncarnationId)
+        (!expectedIncarnationId || payload.incarnationId === expectedIncarnationId) &&
+        isCurrentPtyExit(payload)
       ) {
         providerExitObserved = true
       }
@@ -3198,7 +3212,7 @@ export function registerPtyHandlers(
         if (isSsh) {
           beginArchivedSshPtyExitRecovery(ptyId, args.archiveId)
         } else {
-          beginArchivedNonSshPtyExitRecovery(ptyId, args.archiveId)
+          beginArchivedNonSshPtyExitRecovery(ptyId, args.archiveId, expectedIncarnationId)
         }
         let succeeded = false
         let providerExitObserved = false
@@ -3248,7 +3262,7 @@ export function registerPtyHandlers(
         }
         const recoveryArchiveId = isSsh
           ? takeArchivedSshPtyExitRecovery(ptyId)
-          : takeArchivedNonSshPtyExitRecovery(ptyId)
+          : takeArchivedNonSshPtyExitRecovery(ptyId, expectedIncarnationId)
         if (recoveryArchiveId && !providerExitObserved) {
           rememberSyntheticKillExit(ptyId)
           sendPtyExitToRenderer({
@@ -3440,7 +3454,7 @@ export function registerPtyHandlers(
       if (consumeSyntheticKillExit(payload.id)) {
         return
       }
-      const archiveId = takeArchivedNonSshPtyExitRecovery(payload.id)
+      const archiveId = takeArchivedNonSshPtyExitRecovery(payload.id, payload.incarnationId)
       if (!isLocalProvider) {
         clearProviderPtyState(payload.id)
         ptyOwnership.delete(payload.id)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3183,6 +3183,7 @@ export function registerPtyHandlers(
         const provider = tryGetProviderForPty(ptyId)
         const sshTargetId = parseExecutionHostId(args.executionHostId)
         const isSsh = sshTargetId?.kind === 'ssh'
+        const expectedIncarnationId = ptyIncarnationById.get(ptyId)
         if (isSsh) {
           beginArchivedSshPtyExitRecovery(ptyId, args.archiveId)
         }
@@ -3225,7 +3226,7 @@ export function registerPtyHandlers(
           clearProviderPtyState(ptyId)
           ptyOwnership.delete(ptyId)
           markClaudePtyExited(ptyId)
-          runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
+          runtime?.onPtyExit(ptyId, -1, expectedIncarnationId)
         }
         const recoveryArchiveId = isSsh ? takeArchivedSshPtyExitRecovery(ptyId) : args.archiveId
         if (recoveryArchiveId) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3087,7 +3087,11 @@ export function registerPtyHandlers(
     return true
   }
 
-  function sendPtyExitToRenderer(payload: { id: string; code: number }): void {
+  function sendPtyExitToRenderer(payload: {
+    id: string
+    code: number
+    lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+  }): void {
     if (mainWindow.isDestroyed()) {
       const pending = pendingData.get(payload.id)
       if (pending) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -28,10 +28,18 @@ import type {
 import { captureTerminalArchiveBuffer } from '../../shared/terminal-archive-snapshot-capture'
 import { classifyLostTerminal } from '../../shared/terminal-lost-worker-policy'
 import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
+import {
+  beginArchivedSshPtyExitRecovery,
+  takeArchivedSshPtyExitRecovery
+} from '../ssh/ssh-archived-exit-recovery'
 import { createDaemonLostWorkerSnapshotSource } from '../terminal-lost-worker-snapshot-source'
 import { workspaceSessionStateSchema } from '../../shared/workspace-session-schema'
 import { makeTerminalArchiveSourcePaneSignature } from '../terminal-archive-source-pane-signature'
-import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../shared/execution-host'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  toSshExecutionHostId
+} from '../../shared/execution-host'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { terminalOutputBacklogCapChars } from '../../shared/terminal-scrollback-policy'
 import type {
@@ -1864,6 +1872,9 @@ export function registerPtyHandlers(
       if (!worktreeId || !tabId || !leafId || !reason || !executionHostId) {
         return { kind: 'retryable-error', code: 'contract-invalid' }
       }
+      const parsedExecutionHost = parseExecutionHostId(executionHostId)
+      const sshTerminationTargetId =
+        parsedExecutionHost?.kind === 'ssh' ? parsedExecutionHost.targetId : undefined
       const persistedSession = store.getWorkspaceSession(executionHostId)
       const paneKey = makePaneKey(tabId, leafId)
       if (
@@ -1940,23 +1951,22 @@ export function registerPtyHandlers(
             ...(typeof request.runtimeEnvironmentId === 'string' && request.runtimeEnvironmentId
               ? { runtimeEnvironmentId: request.runtimeEnvironmentId }
               : {}),
+            ...(sshTerminationTargetId ? { sshTerminationTargetId } : {}),
             expectedSourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId
           },
           frozenSession: session,
-          snapshotSource
+          snapshotSource,
+          completeArchive: ({ archive, ptyIdsToKill }) =>
+            shutdownLostWorkerArchivePtys({
+              archiveId: archive.id,
+              ptyIds: ptyIdsToKill,
+              reason,
+              executionHostId,
+              tabId
+            })
         })
         if (result.kind !== 'archived') {
           return { kind: 'retryable-error', code: result.code }
-        }
-        if (result.archiveCompletionOwner) {
-          for (const ptyId of result.ptyIdsToKill) {
-            const provider = tryGetProviderForPty(ptyId)
-            if (provider) {
-              void shutdownProviderAndDetectExit(provider, ptyId, { immediate: true }).catch(
-                () => {}
-              )
-            }
-          }
         }
         return { kind: 'archived', archiveId: result.archive.id }
       })()
@@ -2032,18 +2042,18 @@ export function registerPtyHandlers(
           expectedSourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId
         },
         frozenSession: persistedSession,
-        snapshotSource
+        snapshotSource,
+        completeArchive: ({ archive, ptyIdsToKill }) =>
+          shutdownLostWorkerArchivePtys({
+            archiveId: archive.id,
+            ptyIds: ptyIdsToKill,
+            reason: 'daemon-worker-lost',
+            executionHostId,
+            tabId: args.tabId
+          })
       })
       if (result.kind !== 'archived') {
         return { kind: 'retryable-error', code: result.code }
-      }
-      if (result.archiveCompletionOwner) {
-        for (const ptyId of result.ptyIdsToKill) {
-          const provider = tryGetProviderForPty(ptyId)
-          if (provider) {
-            void shutdownProviderAndDetectExit(provider, ptyId, { immediate: true }).catch(() => {})
-          }
-        }
       }
       return { kind: 'archived', archiveId: result.archive.id }
     })()
@@ -3159,6 +3169,75 @@ export function registerPtyHandlers(
       unsubscribe()
     }
     return providerExitObserved
+  }
+
+  async function shutdownLostWorkerArchivePtys(args: {
+    archiveId: string
+    ptyIds: readonly string[]
+    reason: 'relay-worker-lost' | 'daemon-worker-lost'
+    executionHostId: string
+    tabId: string
+  }): Promise<void> {
+    await Promise.all(
+      args.ptyIds.map(async (ptyId) => {
+        const provider = tryGetProviderForPty(ptyId)
+        const sshTargetId = parseExecutionHostId(args.executionHostId)
+        const isSsh = sshTargetId?.kind === 'ssh'
+        if (isSsh) {
+          beginArchivedSshPtyExitRecovery(ptyId, args.archiveId)
+        }
+        let succeeded = false
+        if (!provider) {
+          console.warn('[pty] lost-worker archive shutdown diagnostic', {
+            reason: args.reason,
+            executionHostId: args.executionHostId,
+            tabId: args.tabId,
+            ptyId,
+            stage: 'shutdown',
+            attempt: 'archive-completion',
+            error: 'provider unavailable'
+          })
+        } else {
+          try {
+            await shutdownProviderAndDetectExit(provider, ptyId, { immediate: true })
+            succeeded = true
+          } catch (error) {
+            succeeded = isSshPtyNotFoundError(error)
+            console.warn('[pty] lost-worker archive shutdown diagnostic', {
+              reason: args.reason,
+              executionHostId: args.executionHostId,
+              tabId: args.tabId,
+              ptyId,
+              stage: 'shutdown',
+              attempt: 'archive-completion',
+              error: error instanceof Error ? error.message : String(error)
+            })
+          }
+        }
+        if (succeeded) {
+          const incarnationId = finishPtyShutdown(
+            ptyId,
+            isSsh ? sshTargetId.targetId : undefined,
+            store
+          )
+          runtime?.onPtyExit(ptyId, -1, incarnationId)
+        } else {
+          clearProviderPtyState(ptyId)
+          ptyOwnership.delete(ptyId)
+          markClaudePtyExited(ptyId)
+          runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
+        }
+        const recoveryArchiveId = isSsh ? takeArchivedSshPtyExitRecovery(ptyId) : args.archiveId
+        if (recoveryArchiveId) {
+          rememberSyntheticKillExit(ptyId)
+          sendPtyExitToRenderer({
+            id: ptyId,
+            code: -1,
+            lostWorkerRecovery: { kind: 'archived', archiveId: recoveryArchiveId }
+          })
+        }
+      })
+    )
   }
 
   function routeProviderData(payload: PtyDataEvent, runtimeAlreadyIngested: boolean): void {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -25,7 +25,7 @@ import type {
   TerminalLostWorkerRendererReceipt,
   TerminalLostWorkerRendererRequest
 } from '../../shared/terminal-archive-types'
-import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import { captureTerminalArchiveBuffer } from '../../shared/terminal-archive-snapshot-capture'
 import { classifyLostTerminal } from '../../shared/terminal-lost-worker-policy'
 import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
 import { workspaceSessionStateSchema } from '../../shared/workspace-session-schema'
@@ -1695,8 +1695,6 @@ export function registerPtyHandlers(
           capture: async (pane) => archiveSnapshotsByPane.get(pane) ?? { kind: 'unavailable' }
         })
       : null
-  const lostWorkerArchiveInFlight = new Map<string, Promise<TerminalLostWorkerRendererReceipt>>()
-
   ipcMain.handle(
     'pty:archiveTerminalTab',
     async (_event, raw: unknown): Promise<{ archiveId: string }> => {
@@ -1745,21 +1743,6 @@ export function registerPtyHandlers(
         const archivedPane = cwd ? { ...pane, cwd } : pane
         captured.panesByLeafId[leafId] = archivedPane
 
-        const fromBuffer = (
-          buffer: string,
-          source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar',
-          truncated = false
-        ): TerminalArchivePaneSnapshotCapture =>
-          buffer.length === 0
-            ? { kind: 'captured-empty' }
-            : {
-                kind: 'captured-bytes',
-                buffer,
-                source,
-                truncated,
-                byteLength: getUtf8ByteLength(buffer)
-              }
-
         // Provider snapshots are authoritative for daemon-backed panes and win over all client material.
         const providerSnapshot =
           ptyId && provider?.canProvideAuthoritativeBufferSnapshot?.(ptyId)
@@ -1770,7 +1753,10 @@ export function registerPtyHandlers(
         if (providerSnapshot?.data !== undefined) {
           archiveSnapshotsByPane.set(
             archivedPane,
-            fromBuffer(providerSnapshot.data, 'daemon-headless')
+            captureTerminalArchiveBuffer({
+              buffer: providerSnapshot.data,
+              source: 'daemon-headless'
+            })
           )
           continue
         }
@@ -1785,7 +1771,11 @@ export function registerPtyHandlers(
         ) {
           archiveSnapshotsByPane.set(
             archivedPane,
-            fromBuffer(snapshot.buffer, 'renderer', snapshot.truncated)
+            captureTerminalArchiveBuffer({
+              buffer: snapshot.buffer,
+              source: 'renderer',
+              truncated: snapshot.truncated
+            })
           )
           continue
         }
@@ -1796,7 +1786,10 @@ export function registerPtyHandlers(
             ? store.readTerminalScrollbackSnapshot(persistedLayout.scrollbackRefsByLeafId[leafId])
             : null)
         if (typeof sidecarBuffer === 'string') {
-          archiveSnapshotsByPane.set(archivedPane, fromBuffer(sidecarBuffer, 'session-sidecar'))
+          archiveSnapshotsByPane.set(
+            archivedPane,
+            captureTerminalArchiveBuffer({ buffer: sidecarBuffer, source: 'session-sidecar' })
+          )
           continue
         }
         const relaySnapshot = ptyId
@@ -1805,7 +1798,11 @@ export function registerPtyHandlers(
         if (relaySnapshot?.data !== undefined) {
           archiveSnapshotsByPane.set(
             archivedPane,
-            fromBuffer(relaySnapshot.data, 'relay-tail', true)
+            captureTerminalArchiveBuffer({
+              buffer: relaySnapshot.data,
+              source: 'relay-tail',
+              truncated: true
+            })
           )
           continue
         }
@@ -1883,15 +1880,7 @@ export function registerPtyHandlers(
       if (!captured) {
         return { kind: 'retryable-error', code: 'capture-unavailable' }
       }
-      const operationKey = `${reason}:${executionHostId}:${tabId}:${makeTerminalArchiveSourcePaneSignature(
-        captured.panesByLeafId,
-        captured.sourcePaneIdentityByLeafId
-      )}`
-      const existing = lostWorkerArchiveInFlight.get(operationKey)
-      if (existing) {
-        return await existing
-      }
-      const operation = (async (): Promise<TerminalLostWorkerRendererReceipt> => {
+      return await (async (): Promise<TerminalLostWorkerRendererReceipt> => {
         const snapshotSource = {
           capture: async (
             pane: ArchivedTerminalPane
@@ -1905,22 +1894,11 @@ export function registerPtyHandlers(
                     .getBufferSnapshot?.(ptyId, { scrollbackRows: 50_000 })
                     .catch(() => null)
                 : null
-            const fromBuffer = (
-              buffer: string,
-              source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar',
-              truncated = false
-            ): TerminalArchivePaneSnapshotCapture =>
-              buffer.length === 0
-                ? { kind: 'captured-empty' }
-                : {
-                    kind: 'captured-bytes',
-                    buffer,
-                    source,
-                    truncated,
-                    byteLength: getUtf8ByteLength(buffer)
-                  }
             if (providerSnapshot?.data !== undefined) {
-              return fromBuffer(providerSnapshot.data, 'daemon-headless')
+              return captureTerminalArchiveBuffer({
+                buffer: providerSnapshot.data,
+                source: 'daemon-headless'
+              })
             }
             const rendererSnapshot = request.snapshotsByLeafId?.[leafId]
             if (
@@ -1932,7 +1910,11 @@ export function registerPtyHandlers(
               Number.isFinite(rendererSnapshot.byteLength) &&
               rendererSnapshot.byteLength >= 0
             ) {
-              return fromBuffer(rendererSnapshot.buffer, 'renderer', rendererSnapshot.truncated)
+              return captureTerminalArchiveBuffer({
+                buffer: rendererSnapshot.buffer,
+                source: 'renderer',
+                truncated: rendererSnapshot.truncated
+              })
             }
             const persistedLayout = persistedSession.terminalLayoutsByTabId[tabId]
             const sidecar =
@@ -1943,7 +1925,7 @@ export function registerPtyHandlers(
                   )
                 : null)
             return typeof sidecar === 'string'
-              ? fromBuffer(sidecar, 'session-sidecar')
+              ? captureTerminalArchiveBuffer({ buffer: sidecar, source: 'session-sidecar' })
               : { kind: 'unavailable' }
           }
         }
@@ -1973,14 +1955,6 @@ export function registerPtyHandlers(
         }
         return { kind: 'archived', archiveId: result.archive.id }
       })()
-      lostWorkerArchiveInFlight.set(operationKey, operation)
-      try {
-        return await operation
-      } finally {
-        if (lostWorkerArchiveInFlight.get(operationKey) === operation) {
-          lostWorkerArchiveInFlight.delete(operationKey)
-        }
-      }
     }
   )
 
@@ -2016,42 +1990,17 @@ export function registerPtyHandlers(
     if (!captured) {
       return { kind: 'retryable-error', code: 'capture-unavailable' }
     }
-    const operationKey = `daemon-worker-lost:${executionHostId}:${args.tabId}:${makeTerminalArchiveSourcePaneSignature(
-      captured.panesByLeafId,
-      captured.sourcePaneIdentityByLeafId
-    )}`
-    const existing = lostWorkerArchiveInFlight.get(operationKey)
-    if (existing) {
-      const receipt = await existing
-      return receipt.kind === 'archived'
-        ? receipt
-        : {
-            kind: 'retryable-error',
-            code: receipt.kind === 'ordinary-shell' ? 'not-owned' : receipt.code
-          }
-    }
-    const operation = (async (): Promise<TerminalLostWorkerRendererReceipt> => {
+    const receipt = await (async (): Promise<TerminalLostWorkerRendererReceipt> => {
       const snapshotSource = {
         capture: async (
           pane: ArchivedTerminalPane
         ): Promise<TerminalArchivePaneSnapshotCapture> => {
           const leafId = pane.archivedLeafId
-          const fromBuffer = (
-            buffer: string,
-            source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar',
-            truncated = false
-          ): TerminalArchivePaneSnapshotCapture =>
-            buffer.length === 0
-              ? { kind: 'captured-empty' }
-              : {
-                  kind: 'captured-bytes',
-                  buffer,
-                  source,
-                  truncated,
-                  byteLength: getUtf8ByteLength(buffer)
-                }
           if (leafId === args.leafId) {
-            return fromBuffer(args.coldRestore.scrollback, 'daemon-headless')
+            return captureTerminalArchiveBuffer({
+              buffer: args.coldRestore.scrollback,
+              source: 'daemon-headless'
+            })
           }
           const layout = persistedSession.terminalLayoutsByTabId[args.tabId]
           const sidecar =
@@ -2060,14 +2009,17 @@ export function registerPtyHandlers(
               ? store.readTerminalScrollbackSnapshot(layout.scrollbackRefsByLeafId[leafId])
               : null)
           if (typeof sidecar === 'string') {
-            return fromBuffer(sidecar, 'session-sidecar')
+            return captureTerminalArchiveBuffer({ buffer: sidecar, source: 'session-sidecar' })
           }
           const ptyId = layout?.ptyIdsByLeafId?.[leafId]
           const probe = ptyId ? args.coldRestore.probeSibling(ptyId) : null
           if (probe?.kind !== 'valid-snapshot' || probe.truncated) {
             return { kind: 'unavailable' }
           }
-          return fromBuffer(probe.scrollback, 'daemon-headless')
+          return captureTerminalArchiveBuffer({
+            buffer: probe.scrollback,
+            source: 'daemon-headless'
+          })
         }
       }
       const result = await archiveLostTerminalWorker({
@@ -2093,20 +2045,12 @@ export function registerPtyHandlers(
       }
       return { kind: 'archived', archiveId: result.archive.id }
     })()
-    lostWorkerArchiveInFlight.set(operationKey, operation)
-    try {
-      const receipt = await operation
-      return receipt.kind === 'archived'
-        ? receipt
-        : {
-            kind: 'retryable-error',
-            code: receipt.kind === 'ordinary-shell' ? 'not-owned' : receipt.code
-          }
-    } finally {
-      if (lostWorkerArchiveInFlight.get(operationKey) === operation) {
-        lostWorkerArchiveInFlight.delete(operationKey)
-      }
-    }
+    return receipt.kind === 'archived'
+      ? receipt
+      : {
+          kind: 'retryable-error',
+          code: receipt.kind === 'ordinary-shell' ? 'not-owned' : receipt.code
+        }
   }
 
   // Why: only LocalPtyProvider needs main-process hook injection; daemon-backed providers spawn subprocesses internally.

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3033,7 +3033,18 @@ export function registerPtyHandlers(
   }
 
   const syntheticKillExitPtyIds = new Map<string, NodeJS.Timeout>()
+  const archivedNonSshExitRecoveryByPtyId = new Map<string, string>()
   const reversibleStopOwnersByPtyId = new Map<string, number>()
+
+  function beginArchivedNonSshPtyExitRecovery(ptyId: string, archiveId: string): void {
+    archivedNonSshExitRecoveryByPtyId.set(ptyId, archiveId)
+  }
+
+  function takeArchivedNonSshPtyExitRecovery(ptyId: string): string | undefined {
+    const archiveId = archivedNonSshExitRecoveryByPtyId.get(ptyId)
+    archivedNonSshExitRecoveryByPtyId.delete(ptyId)
+    return archiveId
+  }
 
   function rememberSyntheticKillExit(id: string): void {
     const existing = syntheticKillExitPtyIds.get(id)
@@ -3186,8 +3197,11 @@ export function registerPtyHandlers(
         const expectedIncarnationId = ptyIncarnationById.get(ptyId)
         if (isSsh) {
           beginArchivedSshPtyExitRecovery(ptyId, args.archiveId)
+        } else {
+          beginArchivedNonSshPtyExitRecovery(ptyId, args.archiveId)
         }
         let succeeded = false
+        let providerExitObserved = false
         if (!provider) {
           console.warn('[pty] lost-worker archive shutdown diagnostic', {
             reason: args.reason,
@@ -3200,7 +3214,9 @@ export function registerPtyHandlers(
           })
         } else {
           try {
-            await shutdownProviderAndDetectExit(provider, ptyId, { immediate: true })
+            providerExitObserved = await shutdownProviderAndDetectExit(provider, ptyId, {
+              immediate: true
+            })
             succeeded = true
           } catch (error) {
             succeeded = isSshPtyNotFoundError(error)
@@ -3221,15 +3237,19 @@ export function registerPtyHandlers(
             isSsh ? sshTargetId.targetId : undefined,
             store
           )
-          runtime?.onPtyExit(ptyId, -1, incarnationId)
+          if (!providerExitObserved) {
+            runtime?.onPtyExit(ptyId, -1, incarnationId)
+          }
         } else {
           clearProviderPtyState(ptyId)
           ptyOwnership.delete(ptyId)
           markClaudePtyExited(ptyId)
           runtime?.onPtyExit(ptyId, -1, expectedIncarnationId)
         }
-        const recoveryArchiveId = isSsh ? takeArchivedSshPtyExitRecovery(ptyId) : args.archiveId
-        if (recoveryArchiveId) {
+        const recoveryArchiveId = isSsh
+          ? takeArchivedSshPtyExitRecovery(ptyId)
+          : takeArchivedNonSshPtyExitRecovery(ptyId)
+        if (recoveryArchiveId && !providerExitObserved) {
           rememberSyntheticKillExit(ptyId)
           sendPtyExitToRenderer({
             id: ptyId,
@@ -3420,13 +3440,21 @@ export function registerPtyHandlers(
       if (consumeSyntheticKillExit(payload.id)) {
         return
       }
+      const archiveId = takeArchivedNonSshPtyExitRecovery(payload.id)
       if (!isLocalProvider) {
         clearProviderPtyState(payload.id)
         ptyOwnership.delete(payload.id)
         markClaudePtyExited(payload.id)
         runtime?.onPtyExit(payload.id, payload.code, payload.incarnationId)
       }
-      sendPtyExitToRenderer(payload)
+      sendPtyExitToRenderer(
+        archiveId
+          ? {
+              ...payload,
+              lostWorkerRecovery: { kind: 'archived', archiveId }
+            }
+          : payload
+      )
     })
   }
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1948,10 +1948,14 @@ export function registerPtyHandlers(
         if (result.kind !== 'archived') {
           return { kind: 'retryable-error', code: result.code }
         }
-        for (const ptyId of result.ptyIdsToKill) {
-          const provider = tryGetProviderForPty(ptyId)
-          if (provider) {
-            void shutdownProviderAndDetectExit(provider, ptyId, { immediate: true }).catch(() => {})
+        if (result.archiveCompletionOwner) {
+          for (const ptyId of result.ptyIdsToKill) {
+            const provider = tryGetProviderForPty(ptyId)
+            if (provider) {
+              void shutdownProviderAndDetectExit(provider, ptyId, { immediate: true }).catch(
+                () => {}
+              )
+            }
           }
         }
         return { kind: 'archived', archiveId: result.archive.id }
@@ -2033,10 +2037,12 @@ export function registerPtyHandlers(
       if (result.kind !== 'archived') {
         return { kind: 'retryable-error', code: result.code }
       }
-      for (const ptyId of result.ptyIdsToKill) {
-        const provider = tryGetProviderForPty(ptyId)
-        if (provider) {
-          void shutdownProviderAndDetectExit(provider, ptyId, { immediate: true }).catch(() => {})
+      if (result.archiveCompletionOwner) {
+        for (const ptyId of result.ptyIdsToKill) {
+          const provider = tryGetProviderForPty(ptyId)
+          if (provider) {
+            void shutdownProviderAndDetectExit(provider, ptyId, { immediate: true }).catch(() => {})
+          }
         }
       }
       return { kind: 'archived', archiveId: result.archive.id }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -15,6 +15,17 @@ export { getBashShellReadyRcfileContent } from '../providers/local-pty-shell-rea
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import type { Store } from '../persistence'
 import type { GlobalSettings, TuiAgent } from '../../shared/types'
+import {
+  captureTerminalArchiveTab,
+  type TerminalArchivePaneSnapshotCapture
+} from '../../shared/workspace-session-terminal-archive'
+import type {
+  ArchivedTerminalPane,
+  TerminalArchiveRendererCloseRequest
+} from '../../shared/terminal-archive-types'
+import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import { workspaceSessionStateSchema } from '../../shared/workspace-session-schema'
+import { makeTerminalArchiveSourcePaneSignature } from '../terminal-archive-source-pane-signature'
 import { toSshExecutionHostId } from '../../shared/execution-host'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { terminalOutputBacklogCapChars } from '../../shared/terminal-scrollback-policy'
@@ -1619,6 +1630,7 @@ export function registerPtyHandlers(
   // Remove prior handlers so re-registration (e.g. macOS re-activate creating a new window) doesn't double-register.
   ipcMain.removeHandler('pty:spawn')
   ipcMain.removeHandler('pty:kill')
+  ipcMain.removeHandler('pty:archiveTerminalTab')
   ipcMain.removeHandler('pty:listSessions')
   ipcMain.removeHandler('pty:hasPty')
   ipcMain.removeHandler('pty:hasChildProcesses')
@@ -1643,6 +1655,160 @@ export function registerPtyHandlers(
   ipcMain.removeAllListeners('pty:ackData')
   ipcMain.removeAllListeners('pty:deliveryResyncResponse')
   ipcMain.removeAllListeners('pty:serializeBuffer:response')
+
+  // One store serializes all close intents registered by this IPC owner. The
+  // pane object itself is request-local, so a WeakMap keeps concurrent captures isolated.
+  const archiveSnapshotsByPane = new WeakMap<
+    ArchivedTerminalPane,
+    TerminalArchivePaneSnapshotCapture
+  >()
+  const archiveStore =
+    typeof store?.createTerminalArchiveStore === 'function'
+      ? store.createTerminalArchiveStore({
+          capture: async (pane) => archiveSnapshotsByPane.get(pane) ?? { kind: 'unavailable' }
+        })
+      : null
+
+  ipcMain.handle(
+    'pty:archiveTerminalTab',
+    async (_event, raw: unknown): Promise<{ archiveId: string }> => {
+      if (!store || !archiveStore || !raw || typeof raw !== 'object') {
+        throw new Error('terminal_archive_unavailable')
+      }
+      const request = raw as Partial<TerminalArchiveRendererCloseRequest>
+      if (
+        typeof request.worktreeId !== 'string' ||
+        !request.worktreeId ||
+        typeof request.tabId !== 'string' ||
+        !request.tabId ||
+        typeof request.executionHostId !== 'string' ||
+        !request.executionHostId
+      ) {
+        throw new Error('terminal_archive_invalid_request')
+      }
+      const parsedRendererSession = workspaceSessionStateSchema.safeParse(request.session)
+      if (!parsedRendererSession.success) {
+        throw new Error('terminal_archive_invalid_session')
+      }
+
+      const persistedSession = store.getWorkspaceSession(request.executionHostId)
+      // The renderer owns the frozen layout and xterm bytes; process identity and
+      // host-observed hints stay main-owned so stale clients cannot archive a replacement PTY.
+      const session = {
+        ...parsedRendererSession.data,
+        terminalPtyIncarnationsByPaneKey: persistedSession.terminalPtyIncarnationsByPaneKey,
+        terminalArchiveHintsByPaneKey: persistedSession.terminalArchiveHintsByPaneKey
+      }
+      const captured = captureTerminalArchiveTab({
+        session,
+        worktreeId: request.worktreeId,
+        tabId: request.tabId
+      })
+      if (!captured) {
+        throw new Error('terminal_archive_capture_unavailable')
+      }
+
+      const rendererSnapshots = request.snapshotsByLeafId ?? {}
+      for (const [leafId, pane] of Object.entries(captured.panesByLeafId)) {
+        const snapshot = rendererSnapshots[leafId]
+        const ptyId = session.terminalLayoutsByTabId[request.tabId]?.ptyIdsByLeafId?.[leafId]
+        const provider = ptyId ? tryGetProviderForPty(ptyId) : undefined
+        const cwd = ptyId ? await provider?.getCwd(ptyId).catch(() => '') : ''
+        const archivedPane = cwd ? { ...pane, cwd } : pane
+        captured.panesByLeafId[leafId] = archivedPane
+
+        const fromBuffer = (
+          buffer: string,
+          source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar',
+          truncated = false
+        ): TerminalArchivePaneSnapshotCapture =>
+          buffer.length === 0
+            ? { kind: 'captured-empty' }
+            : {
+                kind: 'captured-bytes',
+                buffer,
+                source,
+                truncated,
+                byteLength: getUtf8ByteLength(buffer)
+              }
+
+        // Provider snapshots are authoritative for daemon-backed panes and win over all client material.
+        const providerSnapshot =
+          ptyId && provider?.canProvideAuthoritativeBufferSnapshot?.(ptyId)
+            ? await provider
+                ?.getBufferSnapshot?.(ptyId, { scrollbackRows: 50_000 })
+                .catch(() => null)
+            : null
+        if (providerSnapshot?.data !== undefined) {
+          archiveSnapshotsByPane.set(
+            archivedPane,
+            fromBuffer(providerSnapshot.data, 'daemon-headless')
+          )
+          continue
+        }
+        if (
+          snapshot &&
+          typeof snapshot.buffer === 'string' &&
+          snapshot.source === 'renderer' &&
+          typeof snapshot.truncated === 'boolean' &&
+          typeof snapshot.byteLength === 'number' &&
+          Number.isFinite(snapshot.byteLength) &&
+          snapshot.byteLength >= 0
+        ) {
+          archiveSnapshotsByPane.set(
+            archivedPane,
+            fromBuffer(snapshot.buffer, 'renderer', snapshot.truncated)
+          )
+          continue
+        }
+        const persistedLayout = persistedSession.terminalLayoutsByTabId[request.tabId]
+        const sidecarBuffer =
+          persistedLayout?.buffersByLeafId?.[leafId] ??
+          (persistedLayout?.scrollbackRefsByLeafId?.[leafId]
+            ? store.readTerminalScrollbackSnapshot(persistedLayout.scrollbackRefsByLeafId[leafId])
+            : null)
+        if (typeof sidecarBuffer === 'string') {
+          archiveSnapshotsByPane.set(archivedPane, fromBuffer(sidecarBuffer, 'session-sidecar'))
+          continue
+        }
+        const relaySnapshot = ptyId
+          ? await runtime?.serializeHiddenOutputRecoveryBuffer(ptyId, { scrollbackRows: 50_000 })
+          : null
+        if (relaySnapshot?.data !== undefined) {
+          archiveSnapshotsByPane.set(
+            archivedPane,
+            fromBuffer(relaySnapshot.data, 'relay-tail', true)
+          )
+          continue
+        }
+        // Missing capture is not an empty terminal: Store must reject before the caller can retire it.
+        archiveSnapshotsByPane.set(archivedPane, { kind: 'unavailable' })
+      }
+      const operationId = `user-close:${request.tabId}:${makeTerminalArchiveSourcePaneSignature(
+        captured.panesByLeafId,
+        captured.sourcePaneIdentityByLeafId
+      )}`
+      const archive = await archiveStore.archiveTerminalTab({
+        operationId,
+        sourceTabId: request.tabId,
+        executionHostId: request.executionHostId,
+        ...(typeof request.runtimeEnvironmentId === 'string' && request.runtimeEnvironmentId
+          ? { runtimeEnvironmentId: request.runtimeEnvironmentId }
+          : {}),
+        worktreeId: request.worktreeId,
+        title: captured.tab.customTitle || captured.tab.title,
+        ...(captured.tab.defaultTitle ? { defaultTitle: captured.tab.defaultTitle } : {}),
+        ...(captured.tab.color !== undefined ? { color: captured.tab.color } : {}),
+        layout: captured.layout,
+        panesByLeafId: captured.panesByLeafId,
+        sourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId,
+        reason: 'user-close',
+        createdAt: captured.tab.createdAt,
+        capturedAt: Date.now()
+      })
+      return { archiveId: archive.id }
+    }
+  )
 
   // Why: only LocalPtyProvider needs main-process hook injection; daemon-backed providers spawn subprocesses internally.
   if (localProvider instanceof LocalPtyProvider) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -5132,11 +5132,7 @@ export function registerPtyHandlers(
             if (effectiveSessionAppId !== undefined) {
               ptySizes.delete(effectiveSessionAppId)
             }
-            throw new Error(
-              result.lostWorkerRecovery.kind === 'archived'
-                ? 'terminal_lost_worker_archived'
-                : 'terminal_lost_worker_archive_pending'
-            )
+            return resolvePaneSpawnReservation(reservationPaneKey, paneSpawnReservation, result)
           }
           rejectedRegistrationCandidate = result
           if (pendingRegistrationPtyId !== result.id) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -21,12 +21,16 @@ import {
 } from '../../shared/workspace-session-terminal-archive'
 import type {
   ArchivedTerminalPane,
-  TerminalArchiveRendererCloseRequest
+  TerminalArchiveRendererCloseRequest,
+  TerminalLostWorkerRendererReceipt,
+  TerminalLostWorkerRendererRequest
 } from '../../shared/terminal-archive-types'
 import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import { classifyLostTerminal } from '../../shared/terminal-lost-worker-policy'
+import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
 import { workspaceSessionStateSchema } from '../../shared/workspace-session-schema'
 import { makeTerminalArchiveSourcePaneSignature } from '../terminal-archive-source-pane-signature'
-import { toSshExecutionHostId } from '../../shared/execution-host'
+import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../shared/execution-host'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { terminalOutputBacklogCapChars } from '../../shared/terminal-scrollback-policy'
 import type {
@@ -75,6 +79,8 @@ import type {
   PtySpawnOptions,
   PtySpawnResult
 } from '../providers/types'
+import type { PtyLostWorkerRecovery } from '../providers/pty-spawn-result'
+import type { PtySpawnOptionsWithLostWorker } from '../providers/pty-lost-worker-recovery'
 import { inspectPtyProviderProcess } from '../providers/pty-process-inspection'
 import {
   PtyProcessListAdmission,
@@ -1648,6 +1654,7 @@ export function registerPtyHandlers(
   ipcMain.removeHandler('pty:spawn')
   ipcMain.removeHandler('pty:kill')
   ipcMain.removeHandler('pty:archiveTerminalTab')
+  ipcMain.removeHandler('pty:handleLostTerminalCandidate')
   ipcMain.removeHandler('pty:listSessions')
   ipcMain.removeHandler('pty:hasPty')
   ipcMain.removeHandler('pty:hasChildProcesses')
@@ -1685,6 +1692,7 @@ export function registerPtyHandlers(
           capture: async (pane) => archiveSnapshotsByPane.get(pane) ?? { kind: 'unavailable' }
         })
       : null
+  const lostWorkerArchiveInFlight = new Map<string, Promise<TerminalLostWorkerRendererReceipt>>()
 
   ipcMain.handle(
     'pty:archiveTerminalTab',
@@ -1826,6 +1834,265 @@ export function registerPtyHandlers(
       return { archiveId: archive.id }
     }
   )
+
+  ipcMain.handle(
+    'pty:handleLostTerminalCandidate',
+    async (_event, raw: unknown): Promise<TerminalLostWorkerRendererReceipt> => {
+      if (!store || !raw || typeof raw !== 'object') {
+        return { kind: 'retryable-error', code: 'contract-invalid' }
+      }
+      const request = raw as Partial<TerminalLostWorkerRendererRequest>
+      if (
+        typeof request.worktreeId !== 'string' ||
+        !request.worktreeId ||
+        typeof request.tabId !== 'string' ||
+        !isValidTerminalTabId(request.tabId) ||
+        typeof request.leafId !== 'string' ||
+        !isTerminalLeafId(request.leafId) ||
+        (request.reason !== 'relay-worker-lost' && request.reason !== 'daemon-worker-lost') ||
+        typeof request.executionHostId !== 'string' ||
+        !request.executionHostId
+      ) {
+        return { kind: 'retryable-error', code: 'contract-invalid' }
+      }
+      const worktreeId = request.worktreeId
+      const tabId = request.tabId
+      const leafId = request.leafId
+      const reason = request.reason
+      const executionHostId = request.executionHostId
+      if (!worktreeId || !tabId || !leafId || !reason || !executionHostId) {
+        return { kind: 'retryable-error', code: 'contract-invalid' }
+      }
+      const persistedSession = store.getWorkspaceSession(executionHostId)
+      const paneKey = makePaneKey(tabId, leafId)
+      if (
+        classifyLostTerminal(persistedSession.terminalArchiveHintsByPaneKey?.[paneKey]).kind !==
+        'worker'
+      ) {
+        return { kind: 'ordinary-shell' }
+      }
+      const session = persistedSession
+      const captured = captureTerminalArchiveTab({
+        session,
+        worktreeId,
+        tabId
+      })
+      if (!captured) {
+        return { kind: 'retryable-error', code: 'capture-unavailable' }
+      }
+      const operationKey = `${reason}:${executionHostId}:${tabId}:${makeTerminalArchiveSourcePaneSignature(
+        captured.panesByLeafId,
+        captured.sourcePaneIdentityByLeafId
+      )}`
+      const existing = lostWorkerArchiveInFlight.get(operationKey)
+      if (existing) {
+        return await existing
+      }
+      const operation = (async (): Promise<TerminalLostWorkerRendererReceipt> => {
+        const snapshotSource = {
+          capture: async (
+            pane: ArchivedTerminalPane
+          ): Promise<TerminalArchivePaneSnapshotCapture> => {
+            const leafId = pane.archivedLeafId
+            const ptyId = session.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId]
+            const provider = ptyId ? tryGetProviderForPty(ptyId) : undefined
+            const providerSnapshot =
+              ptyId && provider?.canProvideAuthoritativeBufferSnapshot?.(ptyId)
+                ? await provider
+                    .getBufferSnapshot?.(ptyId, { scrollbackRows: 50_000 })
+                    .catch(() => null)
+                : null
+            const fromBuffer = (
+              buffer: string,
+              source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar',
+              truncated = false
+            ): TerminalArchivePaneSnapshotCapture =>
+              buffer.length === 0
+                ? { kind: 'captured-empty' }
+                : {
+                    kind: 'captured-bytes',
+                    buffer,
+                    source,
+                    truncated,
+                    byteLength: getUtf8ByteLength(buffer)
+                  }
+            if (providerSnapshot?.data !== undefined) {
+              return fromBuffer(providerSnapshot.data, 'daemon-headless')
+            }
+            const rendererSnapshot = request.snapshotsByLeafId?.[leafId]
+            if (
+              rendererSnapshot &&
+              typeof rendererSnapshot.buffer === 'string' &&
+              rendererSnapshot.source === 'renderer' &&
+              typeof rendererSnapshot.truncated === 'boolean' &&
+              typeof rendererSnapshot.byteLength === 'number' &&
+              Number.isFinite(rendererSnapshot.byteLength) &&
+              rendererSnapshot.byteLength >= 0
+            ) {
+              return fromBuffer(rendererSnapshot.buffer, 'renderer', rendererSnapshot.truncated)
+            }
+            const persistedLayout = persistedSession.terminalLayoutsByTabId[tabId]
+            const sidecar =
+              persistedLayout?.buffersByLeafId?.[leafId] ??
+              (persistedLayout?.scrollbackRefsByLeafId?.[leafId]
+                ? store.readTerminalScrollbackSnapshot(
+                    persistedLayout.scrollbackRefsByLeafId[leafId]
+                  )
+                : null)
+            return typeof sidecar === 'string'
+              ? fromBuffer(sidecar, 'session-sidecar')
+              : { kind: 'unavailable' }
+          }
+        }
+        const result = await archiveLostTerminalWorker({
+          owner: store,
+          candidate: {
+            reason,
+            executionHostId,
+            worktreeId,
+            tabId,
+            ...(typeof request.runtimeEnvironmentId === 'string' && request.runtimeEnvironmentId
+              ? { runtimeEnvironmentId: request.runtimeEnvironmentId }
+              : {}),
+            expectedSourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId
+          },
+          frozenSession: session,
+          snapshotSource
+        })
+        if (result.kind !== 'archived') {
+          return { kind: 'retryable-error', code: result.code }
+        }
+        for (const ptyId of result.ptyIdsToKill) {
+          const provider = tryGetProviderForPty(ptyId)
+          if (provider) {
+            void shutdownProviderAndDetectExit(provider, ptyId, { immediate: true }).catch(() => {})
+          }
+        }
+        return { kind: 'archived', archiveId: result.archive.id }
+      })()
+      lostWorkerArchiveInFlight.set(operationKey, operation)
+      try {
+        return await operation
+      } finally {
+        if (lostWorkerArchiveInFlight.get(operationKey) === operation) {
+          lostWorkerArchiveInFlight.delete(operationKey)
+        }
+      }
+    }
+  )
+
+  const archiveDaemonColdRestoreBeforeSpawn = async (args: {
+    worktreeId: string
+    tabId: string
+    leafId: string
+    coldRestore: { scrollback: string; cwd: string; cols?: number; rows?: number }
+  }): Promise<PtyLostWorkerRecovery> => {
+    if (!store) {
+      return { kind: 'retryable-error', code: 'durability-failed' }
+    }
+    const executionHostId = LOCAL_EXECUTION_HOST_ID
+    const persistedSession = store.getWorkspaceSession(executionHostId)
+    const paneKey = makePaneKey(args.tabId, args.leafId)
+    if (
+      classifyLostTerminal(persistedSession.terminalArchiveHintsByPaneKey?.[paneKey]).kind !==
+      'worker'
+    ) {
+      return { kind: 'retryable-error', code: 'not-owned' }
+    }
+    const captured = captureTerminalArchiveTab({
+      session: persistedSession,
+      worktreeId: args.worktreeId,
+      tabId: args.tabId
+    })
+    if (!captured) {
+      return { kind: 'retryable-error', code: 'capture-unavailable' }
+    }
+    const operationKey = `daemon-worker-lost:${executionHostId}:${args.tabId}:${makeTerminalArchiveSourcePaneSignature(
+      captured.panesByLeafId,
+      captured.sourcePaneIdentityByLeafId
+    )}`
+    const existing = lostWorkerArchiveInFlight.get(operationKey)
+    if (existing) {
+      const receipt = await existing
+      return receipt.kind === 'archived'
+        ? receipt
+        : {
+            kind: 'retryable-error',
+            code: receipt.kind === 'ordinary-shell' ? 'not-owned' : receipt.code
+          }
+    }
+    const operation = (async (): Promise<TerminalLostWorkerRendererReceipt> => {
+      const snapshotSource = {
+        capture: async (
+          pane: ArchivedTerminalPane
+        ): Promise<TerminalArchivePaneSnapshotCapture> => {
+          const leafId = pane.archivedLeafId
+          const fromBuffer = (
+            buffer: string,
+            source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar',
+            truncated = false
+          ): TerminalArchivePaneSnapshotCapture =>
+            buffer.length === 0
+              ? { kind: 'captured-empty' }
+              : {
+                  kind: 'captured-bytes',
+                  buffer,
+                  source,
+                  truncated,
+                  byteLength: getUtf8ByteLength(buffer)
+                }
+          if (leafId === args.leafId) {
+            return fromBuffer(args.coldRestore.scrollback, 'daemon-headless')
+          }
+          const layout = persistedSession.terminalLayoutsByTabId[args.tabId]
+          const sidecar =
+            layout?.buffersByLeafId?.[leafId] ??
+            (layout?.scrollbackRefsByLeafId?.[leafId]
+              ? store.readTerminalScrollbackSnapshot(layout.scrollbackRefsByLeafId[leafId])
+              : null)
+          return typeof sidecar === 'string'
+            ? fromBuffer(sidecar, 'session-sidecar')
+            : { kind: 'unavailable' }
+        }
+      }
+      const result = await archiveLostTerminalWorker({
+        owner: store,
+        candidate: {
+          reason: 'daemon-worker-lost',
+          executionHostId,
+          worktreeId: args.worktreeId,
+          tabId: args.tabId,
+          expectedSourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId
+        },
+        frozenSession: persistedSession,
+        snapshotSource
+      })
+      if (result.kind !== 'archived') {
+        return { kind: 'retryable-error', code: result.code }
+      }
+      for (const ptyId of result.ptyIdsToKill) {
+        const provider = tryGetProviderForPty(ptyId)
+        if (provider) {
+          void shutdownProviderAndDetectExit(provider, ptyId, { immediate: true }).catch(() => {})
+        }
+      }
+      return { kind: 'archived', archiveId: result.archive.id }
+    })()
+    lostWorkerArchiveInFlight.set(operationKey, operation)
+    try {
+      const receipt = await operation
+      return receipt.kind === 'archived'
+        ? receipt
+        : {
+            kind: 'retryable-error',
+            code: receipt.kind === 'ordinary-shell' ? 'not-owned' : receipt.code
+          }
+    } finally {
+      if (lostWorkerArchiveInFlight.get(operationKey) === operation) {
+        lostWorkerArchiveInFlight.delete(operationKey)
+      }
+    }
+  }
 
   // Why: only LocalPtyProvider needs main-process hook injection; daemon-backed providers spawn subprocesses internally.
   if (localProvider instanceof LocalPtyProvider) {
@@ -4704,7 +4971,7 @@ export function registerPtyHandlers(
       }
       deleteRequestedEnvKeys(spawnEnv, combinedEnvToDelete)
       promoteAgentTeamsShimPath(spawnEnv, requestedAgentTeamsPath)
-      const spawnOptions: PtySpawnOptions = {
+      const spawnOptions: PtySpawnOptionsWithLostWorker = {
         cols: args.cols,
         rows: args.rows,
         cwd,
@@ -4740,6 +5007,33 @@ export function registerPtyHandlers(
       }
       if (effectiveSessionId !== undefined) {
         spawnOptions.sessionId = effectiveSessionId
+      }
+      const daemonColdRestorePaneKey =
+        typeof args.tabId === 'string' && validatedLeafId
+          ? makePaneKey(args.tabId, validatedLeafId)
+          : null
+      const daemonColdRestoreIsRecognizedWorker =
+        isDaemonHostSpawn &&
+        !isMintedSessionId &&
+        !args.launchConfig &&
+        !args.resumeProviderSession &&
+        typeof args.worktreeId === 'string' &&
+        args.worktreeId.length > 0 &&
+        typeof args.tabId === 'string' &&
+        daemonColdRestorePaneKey !== null &&
+        classifyLostTerminal(
+          store?.getWorkspaceSession(LOCAL_EXECUTION_HOST_ID).terminalArchiveHintsByPaneKey?.[
+            daemonColdRestorePaneKey
+          ]
+        ).kind === 'worker'
+      if (daemonColdRestoreIsRecognizedWorker && validatedLeafId) {
+        spawnOptions.preSpawnLostWorker = async (coldRestore) =>
+          await archiveDaemonColdRestoreBeforeSpawn({
+            worktreeId: args.worktreeId!,
+            tabId: args.tabId!,
+            leafId: validatedLeafId,
+            coldRestore
+          })
       }
       // Why: without this, the Windows daemon path ignores the user's Default Shell preference (LocalPtyProvider already honors it via getWindowsShell()).
       if (effectiveShellOverride !== undefined) {
@@ -4819,6 +5113,31 @@ export function registerPtyHandlers(
             ? (runtime?.getPtyOutputSequence?.(expectedPtyId) ?? 0)
             : 0
           result = await provider.spawn(spawnOptions)
+          if (result.lostWorkerRecovery) {
+            if (
+              (isMintedSessionId || preparedProvisionalExecutionContext) &&
+              effectiveSessionAppId
+            ) {
+              runtime?.preparePtyExecutionContext?.(effectiveSessionAppId, null, {
+                resetIncarnation: true
+              })
+            }
+            if (preSpawnHiddenMarkId !== null) {
+              unmarkHiddenRendererPty(preSpawnHiddenMarkId)
+            }
+            if (pendingRegistrationPtyId) {
+              runtime?.cancelPendingPtyRegistration?.(pendingRegistrationPtyId)
+              pendingRegistrationPtyId = null
+            }
+            if (effectiveSessionAppId !== undefined) {
+              ptySizes.delete(effectiveSessionAppId)
+            }
+            throw new Error(
+              result.lostWorkerRecovery.kind === 'archived'
+                ? 'terminal_lost_worker_archived'
+                : 'terminal_lost_worker_archive_pending'
+            )
+          }
           rejectedRegistrationCandidate = result
           if (pendingRegistrationPtyId !== result.id) {
             if (pendingRegistrationPtyId) {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4665,6 +4665,8 @@ export function registerPtyHandlers(
         }
         // Why: hidden-at-spawn declaration (terminal-query-authority.md §races) — main marks hidden before byte zero so the gate owns spawn-time queries.
         initiallyHidden?: boolean
+        // Why: only the renderer-controlled sleeping-record wake may bypass the lost-worker gate; agent-resume payloads alone are not wake evidence.
+        controlledHibernationWake?: boolean
         // Why: closes the SIGKILL race (INVESTIGATION.md) by letting main sync-flush the binding before pty:spawn returns; only the Ctrl+T daemon-host path threads these.
         tabId?: string
         leafId?: string
@@ -5015,8 +5017,7 @@ export function registerPtyHandlers(
       const daemonColdRestoreIsRecognizedWorker =
         isDaemonHostSpawn &&
         !isMintedSessionId &&
-        !args.launchConfig &&
-        !args.resumeProviderSession &&
+        args.controlledHibernationWake !== true &&
         typeof args.worktreeId === 'string' &&
         args.worktreeId.length > 0 &&
         typeof args.tabId === 'string' &&

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -80,7 +80,10 @@ import type {
   PtySpawnResult
 } from '../providers/types'
 import type { PtyLostWorkerRecovery } from '../providers/pty-spawn-result'
-import type { PtySpawnOptionsWithLostWorker } from '../providers/pty-lost-worker-recovery'
+import type {
+  PtyColdRestoreProbe,
+  PtySpawnOptionsWithLostWorker
+} from '../providers/pty-lost-worker-recovery'
 import { inspectPtyProviderProcess } from '../providers/pty-process-inspection'
 import {
   PtyProcessListAdmission,
@@ -1985,7 +1988,13 @@ export function registerPtyHandlers(
     worktreeId: string
     tabId: string
     leafId: string
-    coldRestore: { scrollback: string; cwd: string; cols?: number; rows?: number }
+    coldRestore: {
+      scrollback: string
+      cwd: string
+      cols?: number
+      rows?: number
+      probeSibling: (sessionId: string) => PtyColdRestoreProbe
+    }
   }): Promise<PtyLostWorkerRecovery> => {
     if (!store) {
       return { kind: 'retryable-error', code: 'durability-failed' }
@@ -2050,9 +2059,15 @@ export function registerPtyHandlers(
             (layout?.scrollbackRefsByLeafId?.[leafId]
               ? store.readTerminalScrollbackSnapshot(layout.scrollbackRefsByLeafId[leafId])
               : null)
-          return typeof sidecar === 'string'
-            ? fromBuffer(sidecar, 'session-sidecar')
-            : { kind: 'unavailable' }
+          if (typeof sidecar === 'string') {
+            return fromBuffer(sidecar, 'session-sidecar')
+          }
+          const ptyId = layout?.ptyIdsByLeafId?.[leafId]
+          const probe = ptyId ? args.coldRestore.probeSibling(ptyId) : null
+          if (probe?.kind !== 'valid-snapshot' || probe.truncated) {
+            return { kind: 'unavailable' }
+          }
+          return fromBuffer(probe.scrollback, 'daemon-headless')
         }
       }
       const result = await archiveLostTerminalWorker({

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -3176,7 +3176,7 @@ export function registerPtyHandlers(
     provider: IPtyProvider,
     id: string,
     opts: { immediate?: boolean; keepHistory?: boolean; deadlineMs?: number }
-  ): Promise<boolean> {
+  ): Promise<{ providerExitObserved: boolean; expectedIncarnationId: string | undefined }> {
     let providerExitObserved = false
     const expectedIncarnationId = ptyIncarnationById.get(id)
     const unsubscribe = provider.onExit((payload) => {
@@ -3193,7 +3193,7 @@ export function registerPtyHandlers(
     } finally {
       unsubscribe()
     }
-    return providerExitObserved
+    return { providerExitObserved, expectedIncarnationId }
   }
 
   async function shutdownLostWorkerArchivePtys(args: {
@@ -3208,7 +3208,7 @@ export function registerPtyHandlers(
         const provider = tryGetProviderForPty(ptyId)
         const sshTargetId = parseExecutionHostId(args.executionHostId)
         const isSsh = sshTargetId?.kind === 'ssh'
-        const expectedIncarnationId = ptyIncarnationById.get(ptyId)
+        let expectedIncarnationId = ptyIncarnationById.get(ptyId)
         if (isSsh) {
           beginArchivedSshPtyExitRecovery(ptyId, args.archiveId)
         } else {
@@ -3228,9 +3228,11 @@ export function registerPtyHandlers(
           })
         } else {
           try {
-            providerExitObserved = await shutdownProviderAndDetectExit(provider, ptyId, {
+            const shutdown = await shutdownProviderAndDetectExit(provider, ptyId, {
               immediate: true
             })
+            providerExitObserved = shutdown.providerExitObserved
+            expectedIncarnationId = shutdown.expectedIncarnationId
             succeeded = true
           } catch (error) {
             succeeded = isSshPtyNotFoundError(error)
@@ -3246,18 +3248,20 @@ export function registerPtyHandlers(
           }
         }
         if (succeeded) {
-          const incarnationId = finishPtyShutdown(
-            ptyId,
-            isSsh ? sshTargetId.targetId : undefined,
-            store
-          )
+          const isExpectedIncarnationCurrent =
+            ptyIncarnationById.get(ptyId) === expectedIncarnationId
+          const incarnationId = isExpectedIncarnationCurrent
+            ? finishPtyShutdown(ptyId, isSsh ? sshTargetId.targetId : undefined, store)
+            : expectedIncarnationId
           if (!providerExitObserved) {
             runtime?.onPtyExit(ptyId, -1, incarnationId)
           }
         } else {
-          clearProviderPtyState(ptyId)
-          ptyOwnership.delete(ptyId)
-          markClaudePtyExited(ptyId)
+          if (ptyIncarnationById.get(ptyId) === expectedIncarnationId) {
+            clearProviderPtyState(ptyId)
+            ptyOwnership.delete(ptyId)
+            markClaudePtyExited(ptyId)
+          }
           runtime?.onPtyExit(ptyId, -1, expectedIncarnationId)
         }
         const recoveryArchiveId = isSsh
@@ -4384,6 +4388,7 @@ export function registerPtyHandlers(
       const parsedSshId = connectionId === undefined ? parseAppSshPtyId(ptyId) : null
       connectionId ??= parsedSshId?.connectionId
       const killWithCurrentProvider = (): boolean => {
+        const expectedIncarnationId = ptyIncarnationById.get(ptyId)
         let provider: IPtyProvider
         try {
           provider = connectionId ? getProvider(connectionId) : getProviderForPty(ptyId)
@@ -4402,16 +4407,28 @@ export function registerPtyHandlers(
         }
         // Why: controller is synchronous, but keep ownership until async shutdown proves whether the provider emitted an exit.
         void shutdownProviderAndDetectExit(provider, ptyId, { immediate: false })
-          .then((providerExitObserved) => {
-            const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
-            if (!providerExitObserved) {
-              runtime?.onPtyExit(ptyId, -1, incarnationId)
-              rememberSyntheticKillExit(ptyId)
-              sendPtyExitToRenderer({ id: ptyId, code: -1 })
+          .then(
+            ({ providerExitObserved, expectedIncarnationId: shutdownExpectedIncarnationId }) => {
+              if (ptyIncarnationById.get(ptyId) !== shutdownExpectedIncarnationId) {
+                if (!providerExitObserved) {
+                  runtime?.onPtyExit(ptyId, -1, shutdownExpectedIncarnationId)
+                }
+                return
+              }
+              const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
+              if (!providerExitObserved) {
+                runtime?.onPtyExit(ptyId, -1, incarnationId)
+                rememberSyntheticKillExit(ptyId)
+                sendPtyExitToRenderer({ id: ptyId, code: -1 })
+              }
             }
-          })
+          )
           .catch((err) => {
             if (isPtyAlreadyGoneError(err)) {
+              if (ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+                runtime?.onPtyExit(ptyId, -1, expectedIncarnationId)
+                return
+              }
               const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
               runtime?.onPtyExit(ptyId, -1, incarnationId)
               rememberSyntheticKillExit(ptyId)
@@ -4423,7 +4440,7 @@ export function registerPtyHandlers(
             )
             // Why: close runtime tails without clearing provider ownership, so
             // a retry can still target a PTY that survived the failed shutdown.
-            runtime?.onPtyExit(ptyId, -1, ptyIncarnationById.get(ptyId))
+            runtime?.onPtyExit(ptyId, -1, expectedIncarnationId)
           })
         return true
       }
@@ -4506,13 +4523,16 @@ export function registerPtyHandlers(
         }
         return false
       }
+      let expectedIncarnationId = ptyIncarnationById.get(ptyId)
       let providerExitObserved = false
       try {
-        providerExitObserved = await shutdownProviderAndDetectExit(provider, ptyId, {
+        const shutdown = await shutdownProviderAndDetectExit(provider, ptyId, {
           immediate: true,
           keepHistory: opts?.keepHistory ?? false,
           deadlineMs
         })
+        providerExitObserved = shutdown.providerExitObserved
+        expectedIncarnationId = shutdown.expectedIncarnationId
       } catch (err) {
         if (!isPtyAlreadyGoneError(err)) {
           console.warn(
@@ -4520,6 +4540,12 @@ export function registerPtyHandlers(
           )
           return false
         }
+      }
+      if (ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+        if (!providerExitObserved) {
+          runtime?.onPtyExit(ptyId, -1, expectedIncarnationId)
+        }
+        return true
       }
       try {
         if (!(await verifyPtyStopped(provider, ptyId, opts))) {
@@ -4532,6 +4558,12 @@ export function registerPtyHandlers(
           }`
         )
         return false
+      }
+      if (ptyIncarnationById.get(ptyId) !== expectedIncarnationId) {
+        if (!providerExitObserved) {
+          runtime?.onPtyExit(ptyId, -1, expectedIncarnationId)
+        }
+        return true
       }
       const incarnationId = finishPtyShutdown(ptyId, connectionId, store)
       if (!providerExitObserved) {
@@ -6079,12 +6111,15 @@ export function registerPtyHandlers(
       return
     }
     const shutdownProvider = provider ?? getProviderForPty(args.id)
+    let expectedIncarnationId = ptyIncarnationById.get(args.id)
     let providerExitObserved = false
     try {
-      providerExitObserved = await shutdownProviderAndDetectExit(shutdownProvider, args.id, {
+      const shutdown = await shutdownProviderAndDetectExit(shutdownProvider, args.id, {
         immediate: true,
         keepHistory: args.keepHistory ?? false
       })
+      providerExitObserved = shutdown.providerExitObserved
+      expectedIncarnationId = shutdown.expectedIncarnationId
     } catch (err) {
       if (!isPtyAlreadyGoneError(err)) {
         // Why: a failed shutdown can leave the process alive (SSH relay grace window / local daemon); keep ownership/lease state so the user can retry.
@@ -6094,6 +6129,12 @@ export function registerPtyHandlers(
     }
     // Why: some shutdown paths do not emit onExit through the provider listener.
     // Explicit cleanup is idempotent and covers already-dead PTYs.
+    if (ptyIncarnationById.get(args.id) !== expectedIncarnationId) {
+      if (!providerExitObserved) {
+        runtime?.onPtyExit(args.id, -1, expectedIncarnationId)
+      }
+      return
+    }
     const incarnationId = finishPtyShutdown(args.id, connectionId, store)
     if (!providerExitObserved) {
       runtime?.onPtyExit(args.id, -1, incarnationId)

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -28,6 +28,7 @@ import type {
 import { captureTerminalArchiveBuffer } from '../../shared/terminal-archive-snapshot-capture'
 import { classifyLostTerminal } from '../../shared/terminal-lost-worker-policy'
 import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
+import { createDaemonLostWorkerSnapshotSource } from '../terminal-lost-worker-snapshot-source'
 import { workspaceSessionStateSchema } from '../../shared/workspace-session-schema'
 import { makeTerminalArchiveSourcePaneSignature } from '../terminal-archive-source-pane-signature'
 import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../shared/execution-host'
@@ -1991,37 +1992,32 @@ export function registerPtyHandlers(
       return { kind: 'retryable-error', code: 'capture-unavailable' }
     }
     const receipt = await (async (): Promise<TerminalLostWorkerRendererReceipt> => {
-      const snapshotSource = {
-        capture: async (
-          pane: ArchivedTerminalPane
-        ): Promise<TerminalArchivePaneSnapshotCapture> => {
-          const leafId = pane.archivedLeafId
-          if (leafId === args.leafId) {
-            return captureTerminalArchiveBuffer({
-              buffer: args.coldRestore.scrollback,
-              source: 'daemon-headless'
-            })
-          }
-          const layout = persistedSession.terminalLayoutsByTabId[args.tabId]
+      const layout = persistedSession.terminalLayoutsByTabId[args.tabId]
+      const snapshotSource = createDaemonLostWorkerSnapshotSource({
+        lostLeafId: args.leafId,
+        captureLostLeaf: () =>
+          captureTerminalArchiveBuffer({
+            buffer: args.coldRestore.scrollback,
+            source: 'daemon-headless'
+          }),
+        captureSessionSidecar: (leafId) => {
           const sidecar =
             layout?.buffersByLeafId?.[leafId] ??
             (layout?.scrollbackRefsByLeafId?.[leafId]
               ? store.readTerminalScrollbackSnapshot(layout.scrollbackRefsByLeafId[leafId])
               : null)
-          if (typeof sidecar === 'string') {
-            return captureTerminalArchiveBuffer({ buffer: sidecar, source: 'session-sidecar' })
-          }
+          return typeof sidecar === 'string'
+            ? captureTerminalArchiveBuffer({ buffer: sidecar, source: 'session-sidecar' })
+            : undefined
+        },
+        captureSiblingColdRestore: (leafId) => {
           const ptyId = layout?.ptyIdsByLeafId?.[leafId]
           const probe = ptyId ? args.coldRestore.probeSibling(ptyId) : null
-          if (probe?.kind !== 'valid-snapshot' || probe.truncated) {
-            return { kind: 'unavailable' }
-          }
-          return captureTerminalArchiveBuffer({
-            buffer: probe.scrollback,
-            source: 'daemon-headless'
-          })
+          return probe?.kind === 'valid-snapshot' && !probe.truncated
+            ? captureTerminalArchiveBuffer({ buffer: probe.scrollback, source: 'daemon-headless' })
+            : { kind: 'unavailable' }
         }
-      }
+      })
       const result = await archiveLostTerminalWorker({
         owner: store,
         candidate: {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -62,6 +62,7 @@ import {
   getFirstCommandToken
 } from '../../shared/command-token-scanner'
 import { agentHookServer } from '../agent-hooks/server'
+import { configureAgentPaneAuthorityPersistence } from './agent-pane-authority-ipc'
 import { wslHookRelayManager } from '../agent-hooks/wsl-hook-relay-manager'
 import { isAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
 import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
@@ -1605,6 +1606,22 @@ export function registerPtyHandlers(
     isRecoveryReloadInFlight?: (webContentsId: number) => boolean
   }
 ): void {
+  configureAgentPaneAuthorityPersistence(
+    store
+      ? {
+          transferPaneDurableState: ({ fromPaneKey, toPaneKey, ptyId }) => {
+            if (!ptyId) {
+              return { kind: 'not-owned' }
+            }
+            return store.transferTerminalArchivePaneDurableStateForOwnedPty({
+              fromPaneKey,
+              toPaneKey,
+              ptyId
+            })
+          }
+        }
+      : null
+  )
   // Why: a re-registration means a new window owns delivery — cancel the prior closure's watchdog and neutralize its bridged reset so mark-hidden below can't arm a timer against the dead closure.
   clearRendererDispatcherReadyWatchdog()
   resetRendererDeliveryAccountingForLifecycleReset = () => {}
@@ -3297,6 +3314,36 @@ export function registerPtyHandlers(
     })
   }
 
+  const archiveHintForSpawn = (
+    args: {
+      command?: string
+      launchAgent?: TuiAgent
+      resumeProviderSession?: AgentProviderSessionMetadata
+    },
+    cwd: string | undefined,
+    shellOverride: string | undefined,
+    isReattach = false
+  ) => {
+    if (isReattach) {
+      return { source: 'spawn' as const, hint: {} }
+    }
+    const launchAgent = isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+    const providerSession = normalizeAgentProviderSession(args.resumeProviderSession)
+    return {
+      source: launchAgent ? ('launch' as const) : ('spawn' as const),
+      hint: {
+        ...(cwd ? { cwd } : {}),
+        ...(typeof args.command === 'string' && args.command
+          ? { startupCommand: args.command }
+          : {}),
+        ...(shellOverride ? { shellOverride } : {}),
+        ...(launchAgent ? { launchAgent } : {}),
+        ...(providerSession ? { providerSession } : {}),
+        startedAt: Date.now()
+      }
+    }
+  }
+
   // Why: route through getProviderForPty() so CLI commands work for remote PTYs too; localProvider would silently fail for them.
   runtime?.setPtyController({
     spawn: async (args) => {
@@ -3842,7 +3889,13 @@ export function registerPtyHandlers(
               leafId: hostSessionBinding.leafId,
               ptyId: result.id,
               ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
-              ...(cwd ? { startupCwd: cwd } : {})
+              ...(cwd ? { startupCwd: cwd } : {}),
+              archiveHint: archiveHintForSpawn(
+                args,
+                cwd,
+                daemonShellOverride,
+                result.isReattach === true
+              )
             }
             if (args.connectionId) {
               hostSessionBinding.store.persistPtyBinding(
@@ -4923,7 +4976,13 @@ export function registerPtyHandlers(
               leafId: validatedLeafId,
               ptyId: result.id,
               ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
-              ...(cwd ? { startupCwd: cwd } : {})
+              ...(cwd ? { startupCwd: cwd } : {}),
+              archiveHint: archiveHintForSpawn(
+                args,
+                cwd,
+                effectiveShellOverride,
+                result.isReattach === true
+              )
             }
             if (args.connectionId) {
               store.persistPtyBinding(binding, toSshExecutionHostId(args.connectionId))

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -1009,7 +1009,12 @@ export function registerSshHandlers(
     const provider = getSshPtyProvider(args.targetId)
     const leasedIds = persistedStore!
       .getSshRemotePtyLeases(args.targetId)
-      .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+      .filter(
+        (lease) =>
+          lease.state !== 'termination-pending' &&
+          lease.state !== 'terminated' &&
+          lease.state !== 'expired'
+      )
       .map((lease) => lease.ptyId)
     const ptyIdsByRelayId = new Map<string, string>()
     for (const ptyId of getPtyIdsForConnection(args.targetId)) {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -7114,6 +7114,27 @@ describe('Store', () => {
     const store = await createStore()
     const worktreeId = 'repo-1::/worktree'
     store.addRepo(makeRepo({ id: 'repo-1', connectionId: 'ssh-target-1' }))
+    store.setWorktreeMeta(worktreeId, { displayName: 'worktree' })
+    store.setWorkspaceSession(
+      {
+        ...getDefaultWorkspaceSession(),
+        tabsByWorktree: {
+          [worktreeId]: [makeTerminalTab({ id: 'tab-archive', ptyId: 'archive-pty', worktreeId })]
+        },
+        terminalLayoutsByTabId: {
+          'tab-archive': {
+            root: { type: 'leaf', leafId: TEST_LEAF_1 },
+            activeLeafId: TEST_LEAF_1,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [TEST_LEAF_1]: 'archive-pty' }
+          }
+        },
+        terminalPtyIncarnationsByPaneKey: {
+          [`tab-archive:${TEST_LEAF_1}`]: 'archive-incarnation'
+        }
+      },
+      'ssh:ssh-target-1'
+    )
     const archiveStore = store.createTerminalArchiveStore({
       capture: async () => ({
         kind: 'captured-bytes' as const,
@@ -7126,7 +7147,7 @@ describe('Store', () => {
     const archive = await archiveStore.archiveTerminalTab({
       operationId: 'close-intent-archive-ref',
       sourceTabId: 'tab-archive',
-      executionHostId: 'local',
+      executionHostId: 'ssh:ssh-target-1',
       worktreeId,
       title: 'Archived terminal',
       layout: {
@@ -10665,6 +10686,31 @@ describe('Store host-partitioned workspace sessions', () => {
     }
   })
 
+  async function archiveBoundTerminal(
+    store: Awaited<ReturnType<typeof createStore>>,
+    executionHostId: 'local' | `ssh:${string}` | `runtime:${string}`,
+    incarnationId = 'incarnation-1',
+    capture = vi.fn(async () => ({ kind: 'captured-empty' as const }))
+  ): Promise<void> {
+    await store.createTerminalArchiveStore({ capture }).archiveTerminalTab({
+      operationId: 'ownership-check',
+      sourceTabId: 'tab-1',
+      executionHostId,
+      worktreeId: 'repo-1::/worktree',
+      title: 'Terminal',
+      layout: {
+        root: { type: 'leaf', leafId: TEST_LEAF_1 },
+        activeLeafId: TEST_LEAF_1,
+        expandedLeafId: null
+      },
+      panesByLeafId: { [TEST_LEAF_1]: { archivedLeafId: TEST_LEAF_1, cwd: '/worktree' } },
+      sourcePaneIdentityByLeafId: {
+        [TEST_LEAF_1]: { paneKey: `tab-1:${TEST_LEAF_1}`, incarnationId }
+      },
+      reason: 'user-close'
+    })
+  }
+
   it('migrates a legacy workspaceSession blob into the local partition', async () => {
     writeDataFile({
       schemaVersion: 1,
@@ -10680,6 +10726,102 @@ describe('Store host-partitioned workspace sessions', () => {
     store.flush()
     const persisted = readDataFile() as { workspaceSession?: { activeRepoId?: string } }
     expect(persisted.workspaceSession?.activeRepoId).toBe('legacy-repo')
+  })
+
+  it.each([
+    ['local worktree from an SSH request', { id: 'repo-1' }, 'local', 'ssh:ssh-a'],
+    [
+      'SSH A worktree from SSH B',
+      { id: 'repo-1', connectionId: 'ssh-a' },
+      'ssh:ssh-a',
+      'ssh:ssh-b'
+    ],
+    [
+      'runtime A worktree from a stale runtime B',
+      { id: 'repo-1', executionHostId: 'runtime:env-a' },
+      'runtime:env-a',
+      'runtime:env-b'
+    ]
+  ])('rejects %s before writing archive sidecars', async (_label, repo, ownerHost, requestHost) => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    const paneKey = `tab-1:${TEST_LEAF_1}`
+    const capture = vi.fn(async () => ({ kind: 'captured-empty' as const }))
+    store.addRepo(makeRepo(repo as Partial<Repo>))
+    store.setWorktreeMeta(worktreeId, { displayName: 'worktree' })
+    store.setWorkspaceSession(
+      {
+        ...makeBoundHostSession('pty-1'),
+        terminalPtyIncarnationsByPaneKey: { [paneKey]: 'incarnation-1' }
+      },
+      ownerHost
+    )
+
+    await expect(
+      archiveBoundTerminal(
+        store,
+        requestHost as 'local' | `ssh:${string}` | `runtime:${string}`,
+        'incarnation-1',
+        capture
+      )
+    ).rejects.toMatchObject({ code: 'not-owned' })
+    expect(capture).not.toHaveBeenCalled()
+    expect(store.getTerminalArchives()).toEqual({})
+  })
+
+  it('rejects a stale PTY incarnation before writing archive sidecars', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    const capture = vi.fn(async () => ({ kind: 'captured-empty' as const }))
+    store.addRepo(makeRepo({ id: 'repo-1' }))
+    store.setWorktreeMeta(worktreeId, { displayName: 'worktree' })
+    store.setWorkspaceSession({
+      ...makeBoundHostSession('pty-1'),
+      terminalPtyIncarnationsByPaneKey: { [`tab-1:${TEST_LEAF_1}`]: 'current-incarnation' }
+    })
+
+    await expect(
+      archiveBoundTerminal(store, 'local', 'stale-incarnation', capture)
+    ).rejects.toMatchObject({ code: 'not-owned' })
+    expect(capture).not.toHaveBeenCalled()
+    expect(store.getTerminalArchives()).toEqual({})
+  })
+
+  it('rejects a partial frozen split before capture even when every requested leaf is current', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    const secondPaneKey = `tab-1:${TEST_LEAF_2}`
+    const capture = vi.fn(async () => ({ kind: 'captured-empty' as const }))
+    store.addRepo(makeRepo({ id: 'repo-1' }))
+    store.setWorktreeMeta(worktreeId, { displayName: 'worktree' })
+    store.setWorkspaceSession({
+      ...makeBoundHostSession('pty-1'),
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'vertical',
+            first: { type: 'leaf', leafId: TEST_LEAF_1 },
+            second: { type: 'leaf', leafId: TEST_LEAF_2 }
+          },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_1]: 'pty-1', [TEST_LEAF_2]: 'pty-2' }
+        }
+      },
+      terminalPtyIncarnationsByPaneKey: {
+        [`tab-1:${TEST_LEAF_1}`]: 'incarnation-1',
+        [secondPaneKey]: 'incarnation-2'
+      }
+    })
+
+    await expect(
+      archiveBoundTerminal(store, 'local', 'incarnation-1', capture)
+    ).rejects.toMatchObject({
+      code: 'not-owned'
+    })
+    expect(capture).not.toHaveBeenCalled()
+    expect(store.getTerminalArchives()).toEqual({})
   })
 
   it('is idempotent: re-loading already-partitioned state preserves all hosts', async () => {
@@ -10829,6 +10971,178 @@ describe('Store host-partitioned workspace sessions', () => {
     ).toBeNull()
   })
 
+  it('flushes spawn evidence with its PTY incarnation only in the execution host session', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(makeBoundHostSession(null), 'local')
+    store.setWorkspaceSession(makeBoundHostSession(null), 'ssh:ssh-1')
+
+    store.persistPtyBinding(
+      {
+        worktreeId: 'repo-1::/worktree',
+        tabId: 'tab-1',
+        leafId: TEST_LEAF_1,
+        ptyId: 'ssh:ssh-1@@remote-pty',
+        incarnationId: 'remote-incarnation',
+        archiveHint: {
+          source: 'launch',
+          hint: {
+            cwd: '/worktree',
+            launchAgent: 'codex',
+            providerSession: { key: 'session_id', id: 'session-1' },
+            startedAt: 10
+          }
+        }
+      },
+      'ssh:ssh-1'
+    )
+
+    const remote = store.getWorkspaceSession('ssh:ssh-1')
+    expect(remote.terminalPtyIncarnationsByPaneKey?.[`tab-1:${TEST_LEAF_1}`]).toBe(
+      'remote-incarnation'
+    )
+    expect(remote.terminalArchiveHintsByPaneKey?.[`tab-1:${TEST_LEAF_1}`]).toMatchObject({
+      launchAgent: 'codex',
+      providerSession: { id: 'session-1' }
+    })
+    expect(store.getWorkspaceSession('local').terminalArchiveHintsByPaneKey).toEqual({})
+  })
+
+  it('keeps an SSH reconnect incarnation and its hint out of the local partition', async () => {
+    const store = await createStore()
+    const paneKey = `tab-1:${TEST_LEAF_1}`
+    const remote = {
+      ...makeBoundHostSession('ssh:ssh-1@@remote-pty'),
+      terminalPtyIncarnationsByPaneKey: { [paneKey]: 'old-incarnation' },
+      terminalArchiveHintsByPaneKey: {
+        [paneKey]: { launchAgent: 'codex' as const, startedAt: 10 }
+      }
+    }
+    store.setWorkspaceSession(makeBoundHostSession(null), 'local')
+    store.setWorkspaceSession(remote, 'ssh:ssh-1')
+
+    store.persistPtyBinding(
+      {
+        worktreeId: 'repo-1::/worktree',
+        tabId: 'tab-1',
+        leafId: TEST_LEAF_1,
+        ptyId: 'ssh:ssh-1@@remote-pty',
+        incarnationId: 'reconnected-incarnation'
+      },
+      'ssh:ssh-1'
+    )
+
+    expect(store.getWorkspaceSession('ssh:ssh-1').terminalPtyIncarnationsByPaneKey?.[paneKey]).toBe(
+      'reconnected-incarnation'
+    )
+    expect(
+      store.getWorkspaceSession('ssh:ssh-1').terminalArchiveHintsByPaneKey?.[paneKey]
+    ).toMatchObject({
+      launchAgent: 'codex'
+    })
+    expect(
+      store.getWorkspaceSession('local').terminalPtyIncarnationsByPaneKey?.[paneKey]
+    ).toBeUndefined()
+    expect(store.getWorkspaceSession('local').terminalArchiveHintsByPaneKey).toEqual({})
+  })
+
+  it.each([
+    ['local', {}, 'local'],
+    ['SSH', { connectionId: 'ssh-1' }, 'ssh:ssh-1'],
+    ['runtime', { executionHostId: 'runtime:env-a' }, 'runtime:env-a']
+  ] as const)(
+    'writes hook and dispatch evidence only to the authoritative %s partition',
+    async (_label, repoOverrides, hostId) => {
+      const store = await createStore()
+      const worktreeId = 'repo-1::/worktree'
+      const paneKey = `tab-1:${TEST_LEAF_1}`
+      store.addRepo(makeRepo({ id: 'repo-1', ...repoOverrides }))
+      store.setWorktreeMeta(worktreeId, { displayName: 'worktree' })
+      store.setWorkspaceSession(makeBoundHostSession('pty-1'), hostId)
+
+      const resolvedHostId = store.getWorkspaceSessionHostIdForWorktree(worktreeId)
+      store.persistTerminalArchiveHint(
+        { paneKey, hint: { orchestrationTaskId: `task-${hostId}` }, source: 'hook' },
+        resolvedHostId
+      )
+
+      expect(resolvedHostId).toBe(hostId)
+      expect(
+        store.getWorkspaceSession(hostId).terminalArchiveHintsByPaneKey?.[paneKey]
+          ?.orchestrationTaskId
+      ).toBe(`task-${hostId}`)
+      for (const otherHostId of ['local', 'ssh:ssh-1', 'runtime:env-a']) {
+        if (otherHostId !== hostId) {
+          expect(
+            store.getWorkspaceSession(otherHostId).terminalArchiveHintsByPaneKey?.[paneKey]
+          ).toBeUndefined()
+        }
+      }
+    }
+  )
+
+  it('moves runtime pane durable state only after the persisted runtime owner proves the PTY', async () => {
+    const store = await createStore()
+    const sourcePaneKey = `tab-1:${TEST_LEAF_1}`
+    const targetPaneKey = `tab-2:${TEST_LEAF_2}`
+    store.addRepo(makeRepo({ id: 'repo-1', executionHostId: 'runtime:env-a' }))
+    store.setWorkspaceSession(
+      {
+        ...makeBoundHostSession('runtime-pty'),
+        terminalPtyIncarnationsByPaneKey: { [sourcePaneKey]: 'runtime-incarnation' },
+        terminalArchiveHintsByPaneKey: {
+          [sourcePaneKey]: { launchAgent: 'codex' as const, startedAt: 10 }
+        }
+      },
+      'runtime:env-a'
+    )
+
+    expect(
+      store.transferTerminalArchivePaneDurableStateForOwnedPty({
+        fromPaneKey: sourcePaneKey,
+        toPaneKey: targetPaneKey,
+        ptyId: 'runtime-pty'
+      })
+    ).toEqual({ kind: 'transferred' })
+    expect(
+      store.getWorkspaceSession('runtime:env-a').terminalPtyIncarnationsByPaneKey?.[targetPaneKey]
+    ).toBe('runtime-incarnation')
+    expect(
+      store.getWorkspaceSession('runtime:env-a').terminalArchiveHintsByPaneKey?.[targetPaneKey]
+    ).toMatchObject({ launchAgent: 'codex' })
+    expect(
+      store.getWorkspaceSession('runtime:env-a').terminalArchiveHintsByPaneKey?.[sourcePaneKey]
+    ).toBeUndefined()
+    expect(
+      store.getWorkspaceSession('local').terminalArchiveHintsByPaneKey?.[targetPaneKey]
+    ).toBeUndefined()
+  })
+
+  it('sync-flushes archive retirement behind a topology fence that stale session replays cannot rebase', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    const initial = {
+      ...makeBoundHostSession('pty-1'),
+      terminalTopologyRevisionByRepoId: { 'repo-1': 3 }
+    }
+    store.setWorkspaceSession(initial)
+    const stale = structuredClone(store.getWorkspaceSession())
+    const flush = vi.spyOn(store, 'flushOrThrow')
+
+    const retired = store.retireArchivedTerminalTabAndFlush({
+      worktreeId,
+      tabId: 'tab-1',
+      executionHostId: 'local'
+    })
+
+    expect(retired.closed).toBe(true)
+    expect(flush).toHaveBeenCalledTimes(1)
+    expect(store.getWorkspaceSession().tabsByWorktree[worktreeId]).toEqual([])
+    expect(store.getWorkspaceSession().terminalTopologyRevisionByRepoId?.['repo-1']).toBe(4)
+    store.setWorkspaceSession(stale)
+    expect(store.getWorkspaceSession().tabsByWorktree[worktreeId]).toEqual([])
+    flush.mockRestore()
+  })
+
   it('rolls back a failed SSH PTY binding flush in the SSH host partition', async () => {
     const store = await createStore()
     store.setWorkspaceSession(makeBoundHostSession(null), 'local')
@@ -10843,7 +11157,12 @@ describe('Store host-partitioned workspace sessions', () => {
           worktreeId: 'repo-1::/worktree',
           tabId: 'tab-1',
           leafId: TEST_LEAF_1,
-          ptyId: 'ssh:ssh-1@@remote-pty'
+          ptyId: 'ssh:ssh-1@@remote-pty',
+          incarnationId: 'remote-incarnation',
+          archiveHint: {
+            source: 'launch',
+            hint: { launchAgent: 'codex', startedAt: 10 }
+          }
         },
         'ssh:ssh-1'
       )
@@ -10856,6 +11175,8 @@ describe('Store host-partitioned workspace sessions', () => {
     expect(
       store.getWorkspaceSession('local').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
     ).toBeNull()
+    expect(store.getWorkspaceSession('ssh:ssh-1').terminalPtyIncarnationsByPaneKey).toBeUndefined()
+    expect(store.getWorkspaceSession('ssh:ssh-1').terminalArchiveHintsByPaneKey).toEqual({})
   })
 
   it('clears expired SSH PTY bindings from the SSH partition and legacy local copy', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -7110,6 +7110,119 @@ describe('Store', () => {
     expect(existsSync(join(testState.dir, 'terminal-scrollback', `${ref}.bin`))).toBe(false)
   })
 
+  it('keeps an archive sidecar live when its active session reference is removed', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    store.addRepo(makeRepo({ id: 'repo-1', connectionId: 'ssh-target-1' }))
+    const archiveStore = store.createTerminalArchiveStore({
+      capture: async () => ({
+        kind: 'captured-bytes' as const,
+        buffer: 'archived scrollback',
+        source: 'renderer' as const,
+        truncated: false,
+        byteLength: Buffer.byteLength('archived scrollback')
+      })
+    })
+    const archive = await archiveStore.archiveTerminalTab({
+      operationId: 'close-intent-archive-ref',
+      sourceTabId: 'tab-archive',
+      executionHostId: 'local',
+      worktreeId,
+      title: 'Archived terminal',
+      layout: {
+        root: { type: 'leaf', leafId: TEST_LEAF_1 },
+        activeLeafId: TEST_LEAF_1,
+        expandedLeafId: null
+      },
+      panesByLeafId: { [TEST_LEAF_1]: { archivedLeafId: TEST_LEAF_1, cwd: '/worktree' } },
+      sourcePaneIdentityByLeafId: {
+        [TEST_LEAF_1]: {
+          paneKey: `tab-archive:${TEST_LEAF_1}`,
+          incarnationId: 'archive-incarnation'
+        }
+      },
+      reason: 'user-close'
+    })
+    const ref = archive.panesByLeafId[TEST_LEAF_1]?.snapshot?.ref
+    if (!ref) {
+      throw new Error('expected archive snapshot')
+    }
+    const sessionWithArchiveRef: WorkspaceSessionState = {
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        [worktreeId]: [makeTerminalTab({ id: 'tab-archive', ptyId: 'remote-pty', worktreeId })]
+      },
+      terminalLayoutsByTabId: {
+        'tab-archive': {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          scrollbackRefsByLeafId: { [TEST_LEAF_1]: ref }
+        }
+      }
+    }
+    store.setWorkspaceSession(sessionWithArchiveRef)
+    store.setWorkspaceSession(getDefaultWorkspaceSession())
+
+    expect(existsSync(join(testState.dir, 'terminal-scrollback', `${ref}.bin`))).toBe(true)
+
+    store.replaceTerminalArchivesAndFlush({})
+    store.setWorkspaceSession(sessionWithArchiveRef)
+    store.setWorkspaceSession(getDefaultWorkspaceSession())
+
+    expect(existsSync(join(testState.dir, 'terminal-scrollback', `${ref}.bin`))).toBe(false)
+  })
+
+  it.each([
+    [0, 1],
+    [1, 1],
+    [365, 365],
+    [366, 365],
+    [1.6, 2],
+    [Number.NaN, 7]
+  ])('normalizes terminal archive retention %s to %s', async (input, expected) => {
+    const store = await createStore()
+    store.updateSettings({ terminalArchiveRetentionDays: input } as never)
+
+    expect(store.getSettings().terminalArchiveRetentionDays).toBe(expected)
+  })
+
+  it('drops terminal archive records with unknown fields during migration', async () => {
+    const archiveId = '11111111-1111-4111-8111-111111111111'
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalArchiveRetentionDays: 366 },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      terminalArchivesById: {
+        [archiveId]: {
+          schemaVersion: 1,
+          id: archiveId,
+          operationId: 'close-1',
+          sourceTabId: 'tab-1',
+          executionHostId: 'local',
+          worktreeId: 'repo-1::/worktree',
+          title: 'Terminal',
+          layout: { root: null, activeLeafId: null, expandedLeafId: null },
+          panesByLeafId: {},
+          reason: 'user-close',
+          archivedAt: 1,
+          expiresAt: 2,
+          restoreCount: 0,
+          terminalHandle: 'must-not-persist'
+        }
+      },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+
+    expect(store.getTerminalArchives()).toEqual({})
+    expect(store.getSettings().terminalArchiveRetentionDays).toBe(365)
+  })
+
   it('reads only the replay tail from oversized terminal scrollback snapshots', async () => {
     const store = await createStore()
     const ref = 'v1-00000000000000000000000000000000'

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -11045,6 +11045,80 @@ describe('Store host-partitioned workspace sessions', () => {
     expect(store.getWorkspaceSession('local').terminalArchiveHintsByPaneKey).toEqual({})
   })
 
+  it.each(['local', 'ssh:ssh-1'] as const)(
+    'preserves the full main-owned hint set when an %s renderer replay omits it',
+    async (hostId) => {
+      const store = await createStore()
+      const paneKey = `tab-1:${TEST_LEAF_1}`
+      const hints = {
+        [paneKey]: { launchAgent: 'codex' as const, startedAt: 10 }
+      }
+      store.setWorkspaceSession(
+        {
+          ...makeBoundHostSession(hostId === 'local' ? 'local-pty' : 'ssh:ssh-1@@remote-pty'),
+          terminalArchiveHintsByPaneKey: hints
+        },
+        hostId
+      )
+      const rendererReplay = structuredClone(store.getWorkspaceSession(hostId))
+      delete rendererReplay.terminalArchiveHintsByPaneKey
+
+      store.setWorkspaceSession(rendererReplay, hostId)
+
+      expect(store.getWorkspaceSession(hostId).terminalArchiveHintsByPaneKey).toEqual(hints)
+    }
+  )
+
+  it('does not revive a retired hint when an old renderer snapshot replays', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    const retiredPaneKey = `tab-1:${TEST_LEAF_1}`
+    const retainedPaneKey = `tab-2:${TEST_LEAF_2}`
+    const initial = makeBoundHostSession('pty-1')
+    initial.tabsByWorktree[worktreeId] = [
+      initial.tabsByWorktree[worktreeId][0]!,
+      {
+        ...initial.tabsByWorktree[worktreeId][0]!,
+        id: 'tab-2',
+        ptyId: 'pty-2',
+        sortOrder: 1
+      }
+    ]
+    initial.terminalLayoutsByTabId['tab-2'] = {
+      root: { type: 'leaf', leafId: TEST_LEAF_2 },
+      activeLeafId: TEST_LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [TEST_LEAF_2]: 'pty-2' }
+    }
+    initial.terminalArchiveHintsByPaneKey = {
+      [retiredPaneKey]: { launchAgent: 'codex', startedAt: 10 },
+      [retainedPaneKey]: { cwd: '/worktree' }
+    }
+    store.setWorkspaceSession(initial)
+    const oldRendererSnapshot = structuredClone(store.getWorkspaceSession())
+    delete oldRendererSnapshot.terminalArchiveHintsByPaneKey
+
+    expect(
+      store.retireArchivedTerminalTabAndFlush({
+        worktreeId,
+        tabId: 'tab-1',
+        executionHostId: 'local'
+      }).closed
+    ).toBe(true)
+    expect(store.getWorkspaceSession().terminalArchiveHintsByPaneKey).toEqual({
+      [retainedPaneKey]: { cwd: '/worktree' }
+    })
+
+    store.setWorkspaceSession(oldRendererSnapshot)
+
+    expect(store.getWorkspaceSession().terminalArchiveHintsByPaneKey).toEqual({
+      [retainedPaneKey]: { cwd: '/worktree' }
+    })
+    expect(
+      store.getWorkspaceSession().terminalArchiveHintsByPaneKey?.[retiredPaneKey]
+    ).toBeUndefined()
+  })
+
   it.each([
     ['local', {}, 'local'],
     ['SSH', { connectionId: 'ssh-1' }, 'ssh:ssh-1'],

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -11117,6 +11117,73 @@ describe('Store host-partitioned workspace sessions', () => {
     ).toBeUndefined()
   })
 
+  it('transfers durable pane state after the renderer topology has already moved the owned PTY', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    const sourcePaneKey = `tab-1:${TEST_LEAF_1}`
+    const targetPaneKey = `tab-2:${TEST_LEAF_1}`
+    store.addRepo(makeRepo({ id: 'repo-1', executionHostId: 'runtime:env-a' }))
+    store.setWorkspaceSession(
+      {
+        ...makeBoundHostSession('runtime-pty'),
+        tabsByWorktree: {
+          [worktreeId]: [
+            {
+              ...makeBoundHostSession('runtime-pty').tabsByWorktree[worktreeId]![0]!,
+              ptyId: 'sibling-pty'
+            },
+            {
+              id: 'tab-2',
+              worktreeId,
+              title: 'Detached terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 1,
+              createdAt: 2,
+              ptyId: 'runtime-pty'
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: { type: 'leaf', leafId: TEST_LEAF_2 },
+            activeLeafId: TEST_LEAF_2,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [TEST_LEAF_2]: 'sibling-pty' }
+          },
+          'tab-2': {
+            root: { type: 'leaf', leafId: TEST_LEAF_1 },
+            activeLeafId: TEST_LEAF_1,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [TEST_LEAF_1]: 'runtime-pty' }
+          }
+        },
+        terminalPtyIncarnationsByPaneKey: { [sourcePaneKey]: 'runtime-incarnation' },
+        terminalArchiveHintsByPaneKey: {
+          [sourcePaneKey]: { launchAgent: 'codex' as const, startedAt: 10 }
+        }
+      },
+      'runtime:env-a'
+    )
+
+    expect(
+      store.transferTerminalArchivePaneDurableStateForOwnedPty({
+        fromPaneKey: sourcePaneKey,
+        toPaneKey: targetPaneKey,
+        ptyId: 'runtime-pty'
+      })
+    ).toEqual({ kind: 'transferred' })
+    expect(
+      store.getWorkspaceSession('runtime:env-a').terminalPtyIncarnationsByPaneKey?.[targetPaneKey]
+    ).toBe('runtime-incarnation')
+    expect(
+      store.getWorkspaceSession('runtime:env-a').terminalArchiveHintsByPaneKey?.[targetPaneKey]
+    ).toMatchObject({ launchAgent: 'codex' })
+    expect(
+      store.getWorkspaceSession('runtime:env-a').terminalArchiveHintsByPaneKey?.[sourcePaneKey]
+    ).toBeUndefined()
+  })
+
   it('sync-flushes archive retirement behind a topology fence that stale session replays cannot rebase', async () => {
     const store = await createStore()
     const worktreeId = 'repo-1::/worktree'

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -11390,6 +11390,51 @@ describe('Store host-partitioned workspace sessions', () => {
     flush.mockRestore()
   })
 
+  it('persists only archived SSH leases as termination-pending in the retirement flush', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    const archivedPtyId = 'ssh:ssh-1@@remote-pty'
+    store.setWorkspaceSession(makeBoundHostSession(archivedPtyId), 'ssh:ssh-1')
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId,
+      tabId: 'tab-1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'unrelated-pty',
+      worktreeId,
+      tabId: 'other-tab',
+      leafId: TEST_LEAF_2,
+      state: 'attached'
+    })
+    const flushOrThrow = store.flushOrThrow.bind(store)
+    const flush = vi.spyOn(store, 'flushOrThrow').mockImplementation(() => {
+      expect(store.getWorkspaceSession('ssh:ssh-1').tabsByWorktree[worktreeId]).toEqual([])
+      expect(store.getSshRemotePtyLeases('ssh-1')).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ ptyId: 'remote-pty', state: 'termination-pending' }),
+          expect.objectContaining({ ptyId: 'unrelated-pty', state: 'attached' })
+        ])
+      )
+      flushOrThrow()
+    })
+
+    const retired = store.retireArchivedTerminalTabAndFlush({
+      worktreeId,
+      tabId: 'tab-1',
+      executionHostId: 'ssh:ssh-1',
+      sshTerminationTargetId: 'ssh-1'
+    })
+
+    expect(retired).toMatchObject({ closed: true, ptyIdsToKill: [archivedPtyId] })
+    expect(flush).toHaveBeenCalledOnce()
+    flush.mockRestore()
+  })
+
   it('rolls back a failed SSH PTY binding flush in the SSH host partition', async () => {
     const store = await createStore()
     store.setWorkspaceSession(makeBoundHostSession(null), 'local')

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -11435,6 +11435,88 @@ describe('Store host-partitioned workspace sessions', () => {
     flush.mockRestore()
   })
 
+  it('rolls back archive metadata, host session, and SSH leases when the retirement flush fails', async () => {
+    const store = await createStore()
+    const worktreeId = 'repo-1::/worktree'
+    const hostId = 'ssh:ssh-1'
+    const archivedPtyId = 'ssh:ssh-1@@remote-pty'
+    const session = {
+      ...makeBoundHostSession(archivedPtyId),
+      terminalPtyIncarnationsByPaneKey: {
+        [makePaneKey('tab-1', TEST_LEAF_1)]: 'incarnation-1'
+      }
+    }
+    store.setWorkspaceSession(session, hostId)
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId,
+      tabId: 'tab-1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+    const archiveId = '11111111-1111-4111-8111-111111111111'
+    const nextArchives = {
+      [archiveId]: {
+        schemaVersion: 1,
+        id: archiveId,
+        operationId: 'relay-worker-lost:tab-1:test',
+        sourceTabId: 'tab-1',
+        sourcePaneSignature: 'a'.repeat(64),
+        executionHostId: hostId,
+        worktreeId,
+        title: 'Terminal',
+        layout: {
+          root: { type: 'leaf' as const, leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null
+        },
+        panesByLeafId: { [TEST_LEAF_1]: { archivedLeafId: TEST_LEAF_1, cwd: '/worktree' } },
+        reason: 'relay-worker-lost' as const,
+        archivedAt: 1,
+        expiresAt: 2,
+        restoreCount: 0
+      }
+    }
+    const flush = vi.spyOn(store, 'flushOrThrow').mockImplementationOnce(() => {
+      expect(store.getTerminalArchives()).toEqual(nextArchives)
+      expect(store.getWorkspaceSession(hostId).tabsByWorktree[worktreeId]).toEqual([])
+      expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+        expect.objectContaining({ ptyId: 'remote-pty', state: 'termination-pending' })
+      ])
+      throw new Error('disk unavailable')
+    })
+    const commitLostTerminalArchiveAndRetire = store as unknown as {
+      commitLostTerminalArchiveAndRetire: (
+        archives: typeof nextArchives,
+        args: {
+          worktreeId: string
+          tabId: string
+          executionHostId: typeof hostId
+          sshTerminationTargetId: string
+        }
+      ) => void
+    }
+
+    expect(() =>
+      commitLostTerminalArchiveAndRetire.commitLostTerminalArchiveAndRetire(nextArchives, {
+        worktreeId,
+        tabId: 'tab-1',
+        executionHostId: hostId,
+        sshTerminationTargetId: 'ssh-1'
+      })
+    ).toThrow('disk unavailable')
+    flush.mockRestore()
+
+    expect(store.getTerminalArchives()).toEqual({})
+    expect(store.getWorkspaceSession(hostId).tabsByWorktree[worktreeId]).toEqual([
+      expect.objectContaining({ id: 'tab-1', ptyId: archivedPtyId })
+    ])
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({ ptyId: 'remote-pty', state: 'attached' })
+    ])
+  })
+
   it('rolls back a failed SSH PTY binding flush in the SSH host partition', async () => {
     const store = await createStore()
     store.setWorkspaceSession(makeBoundHostSession(null), 'local')

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -43,6 +43,7 @@ import { ORCA_PERSISTED_STATE_MAX_BYTES } from '../shared/persisted-state-file-b
 import { setSourceControlActionDefault } from '../shared/source-control-ai-actions'
 import { LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { closeTerminalTabInWorkspaceSession } from '../shared/workspace-session-terminal-tab-close'
+import { retireTerminalSurfaceFromPersistence } from './runtime/mobile-session-terminal-persistence-retirement'
 
 // Shared mutable state so the electron mock can reference a per-test directory
 const testState = { dir: '' }
@@ -11117,6 +11118,111 @@ describe('Store host-partitioned workspace sessions', () => {
     expect(
       store.getWorkspaceSession().terminalArchiveHintsByPaneKey?.[retiredPaneKey]
     ).toBeUndefined()
+  })
+
+  it.each(['local', 'ssh:ssh-1'] as const)(
+    'preserves main-owned pty incarnations when an %s renderer replay omits them',
+    async (hostId) => {
+      const store = await createStore()
+      const paneKey = `tab-1:${TEST_LEAF_1}`
+      const incarnations = { [paneKey]: 'incarnation-1' }
+      store.setWorkspaceSession(
+        {
+          ...makeBoundHostSession(hostId === 'local' ? 'local-pty' : 'ssh:ssh-1@@remote-pty'),
+          terminalPtyIncarnationsByPaneKey: incarnations
+        },
+        hostId
+      )
+      const rendererReplay = structuredClone(store.getWorkspaceSession(hostId))
+      // Why: buildWorkspaceSessionPayload emits neither field, so a replay drops both together.
+      delete rendererReplay.terminalPtyIncarnationsByPaneKey
+      delete rendererReplay.terminalTopologyRevisionByRepoId
+
+      store.setWorkspaceSession(rendererReplay, hostId)
+
+      expect(store.getWorkspaceSession(hostId).terminalPtyIncarnationsByPaneKey).toEqual(
+        incarnations
+      )
+    }
+  )
+
+  it('lets a legacy tombstone retire the seeded incarnation on a renderer replay', async () => {
+    const paneKey = `tab-1:${TEST_LEAF_1}`
+    // Why: tombstones only survive on disk from older builds; every setter write clears them.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      workspaceSession: {
+        ...makeBoundHostSession('pty-1'),
+        terminalPtyIncarnationsByPaneKey: { [paneKey]: 'incarnation-1' },
+        terminalSurfaceTombstonesByPaneKey: {
+          [paneKey]: {
+            worktreeId: 'repo-1::/worktree',
+            parentTabId: 'tab-1',
+            leafId: TEST_LEAF_1,
+            ptyId: 'pty-1',
+            incarnationId: 'incarnation-1',
+            retiredAt: 1
+          }
+        }
+      }
+    })
+    const store = await createStore()
+    const rendererReplay = structuredClone(store.getWorkspaceSession())
+    delete rendererReplay.terminalPtyIncarnationsByPaneKey
+    delete rendererReplay.terminalTopologyRevisionByRepoId
+    delete rendererReplay.terminalSurfaceTombstonesByPaneKey
+
+    store.setWorkspaceSession(rendererReplay)
+
+    // Why: seeding runs before sanitize, so tombstone retirement still gets the final say.
+    expect(store.getWorkspaceSession().terminalPtyIncarnationsByPaneKey?.[paneKey]).toBeUndefined()
+  })
+
+  it('does not resurrect an orphaned incarnation the sanitizer just filtered out', async () => {
+    const store = await createStore()
+    const orphanPaneKey = `ghost-tab:${TEST_LEAF_2}`
+    store.setWorkspaceSession({
+      ...makeBoundHostSession('pty-1'),
+      terminalTopologyRevisionByRepoId: { 'repo-1': 1 },
+      terminalPtyIncarnationsByPaneKey: { [orphanPaneKey]: 'orphan-incarnation' }
+    })
+    const rendererReplay = structuredClone(store.getWorkspaceSession())
+    delete rendererReplay.terminalPtyIncarnationsByPaneKey
+    delete rendererReplay.terminalTopologyRevisionByRepoId
+
+    store.setWorkspaceSession(rendererReplay)
+
+    // Why: membership rebase already dropped this pane; a wholesale restore would undo the sanitizer.
+    expect(
+      store.getWorkspaceSession().terminalPtyIncarnationsByPaneKey?.[orphanPaneKey]
+    ).toBeUndefined()
+  })
+
+  it('lets main retire the last pty incarnation without the replay guard reviving it', async () => {
+    const store = await createStore()
+    const paneKey = `tab-1:${TEST_LEAF_1}`
+    store.setWorkspaceSession({
+      ...makeBoundHostSession('pty-1'),
+      terminalPtyIncarnationsByPaneKey: { [paneKey]: 'incarnation-1' }
+    })
+
+    // Why: this is the runtime's retirement path — it carries the topology fence, so it is not a replay.
+    const retired = retireTerminalSurfaceFromPersistence(store.getWorkspaceSession(), {
+      worktreeId: 'repo-1::/worktree',
+      parentTabId: 'tab-1',
+      leafId: TEST_LEAF_1,
+      ptyId: 'pty-1',
+      incarnationId: 'incarnation-1'
+    })
+    expect(retired.terminalPtyIncarnationsByPaneKey?.[paneKey]).toBeUndefined()
+
+    store.setWorkspaceSession(retired)
+
+    expect(store.getWorkspaceSession().terminalPtyIncarnationsByPaneKey?.[paneKey]).toBeUndefined()
   })
 
   it.each([

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -79,6 +79,7 @@ import type { MigrationUnsupportedPtyEntry } from '../shared/agent-status-types'
 import { MOBILE_PAIRING_USERDATA_FILES } from './runtime/mobile-pairing-files'
 import { normalizePersistedMobileClientTabSelections } from './runtime/client-session-tab-selection-persistence'
 import { sanitizeWorkspaceSessionTerminalRetirements } from './runtime/mobile-session-terminal-persistence-retirement'
+import { advanceTerminalTopologyRevision } from './runtime/workspace-session-terminal-membership-authority'
 import {
   removeRepoFromHostWorkspaceSessions,
   removeRepoFromWorkspaceSession
@@ -245,10 +246,17 @@ import {
 import {
   normalizeTerminalArchiveRetentionDays,
   terminalArchivesByIdSchema,
-  type ArchivedTerminalTab
+  type ArchivedTerminalTab,
+  type TerminalArchiveHint,
+  type TerminalArchiveHintSource
 } from '../shared/terminal-archive-types'
 import { TerminalArchiveStore } from './terminal-archive-store'
-import type { TerminalArchiveSnapshotSource } from '../shared/workspace-session-terminal-archive'
+import {
+  mergeTerminalArchiveHintIntoSession,
+  moveTerminalArchivePaneDurableState,
+  retireArchivedTerminalTab,
+  type TerminalArchiveSnapshotSource
+} from '../shared/workspace-session-terminal-archive'
 import { track } from './telemetry/client'
 import { getCohortAtEmit } from './telemetry/cohort-classifier'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from './startup/startup-diagnostics'
@@ -2601,6 +2609,11 @@ function deleteRemovedTerminalScrollbackSnapshots(
 export type StoreOptions = {
   dataFile?: string
 }
+
+export type TerminalArchivePaneDurableTransferResult =
+  | { kind: 'transferred' }
+  | { kind: 'not-owned' }
+  | { kind: 'durability-failed' }
 
 export class Store {
   private state: PersistedState
@@ -5730,6 +5743,7 @@ export class Store {
         getTerminalArchiveRetentionDays: () => this.getTerminalArchiveRetentionDays(),
         isExecutionHostReachable: (hostId) => this.isArchiveExecutionHostReachable(hostId),
         worktreeExists: (worktreeId, hostId) => this.archiveWorktreeExists(worktreeId, hostId),
+        isTerminalArchiveRequestOwned: (request) => this.isTerminalArchiveRequestOwned(request),
         isTerminalScrollbackSnapshotLive: (ref) => this.isTerminalScrollbackSnapshotLive(ref),
         terminalScrollbackSnapshotStorage: this.terminalScrollbackSnapshotStorage
       },
@@ -5750,6 +5764,53 @@ export class Store {
     return Boolean(
       repo && getRepoExecutionHostId(repo) === hostId && this.state.worktreeMeta[worktreeId]
     )
+  }
+
+  private isTerminalArchiveRequestOwned(request: {
+    executionHostId: ExecutionHostId
+    worktreeId: string
+    sourceTabId: string
+    sourcePaneIdentityByLeafId: Record<string, { paneKey: string; incarnationId: string }>
+  }): boolean {
+    if (!this.archiveWorktreeExists(request.worktreeId, request.executionHostId)) {
+      return false
+    }
+    const session = this.getWorkspaceSession(request.executionHostId)
+    if (
+      !session.tabsByWorktree[request.worktreeId]?.some((tab) => tab.id === request.sourceTabId)
+    ) {
+      return false
+    }
+    const layout = session.terminalLayoutsByTabId[request.sourceTabId]
+    if (!layout) {
+      return false
+    }
+    const requestLeafIds = Object.keys(request.sourcePaneIdentityByLeafId)
+    const persistedLeafIds = this.getTerminalLayoutLeafIds(layout.root)
+    if (
+      requestLeafIds.length !== persistedLeafIds.size ||
+      requestLeafIds.some((leafId) => !persistedLeafIds.has(leafId))
+    ) {
+      return false
+    }
+    return requestLeafIds.every((leafId) => {
+      const identity = request.sourcePaneIdentityByLeafId[leafId]
+      if (!identity) {
+        return false
+      }
+      const paneKey = makePaneKey(request.sourceTabId, leafId)
+      return (
+        identity.paneKey === paneKey &&
+        session.terminalPtyIncarnationsByPaneKey?.[paneKey] === identity.incarnationId &&
+        layout.ptyIdsByLeafId?.[leafId] !== undefined
+      )
+    })
+  }
+
+  /** The repo's execution-host ownership is the only host-selection authority for durable facts. */
+  getWorkspaceSessionHostIdForWorktree(worktreeId: string): ExecutionHostId {
+    const repo = this.getRepo(getRepoIdFromWorktreeId(worktreeId))
+    return repo ? getRepoExecutionHostId(repo) : LOCAL_EXECUTION_HOST_ID
   }
 
   private isTerminalScrollbackSnapshotLive(ref: string): boolean {
@@ -5789,6 +5850,58 @@ export class Store {
       return
     }
     this.setHostWorkspaceSession(resolved, session)
+  }
+
+  /** Retires an already archived tab under the host topology fence, then sync-flushes before kill authority escapes. */
+  retireArchivedTerminalTabAndFlush(args: {
+    worktreeId: string
+    tabId: string
+    executionHostId: ExecutionHostId
+  }): ReturnType<typeof retireArchivedTerminalTab> {
+    const hostId = this.resolveHostId(args.executionHostId)
+    const session = this.getWorkspaceSession(hostId)
+    const retired = retireArchivedTerminalTab(session, args.worktreeId, args.tabId)
+    if (!retired.closed) {
+      return retired
+    }
+    const next = advanceTerminalTopologyRevision(retired.session, args.worktreeId)
+    const tabStillPresent =
+      next.tabsByWorktree[args.worktreeId]?.some((tab) => tab.id === args.tabId) ||
+      next.unifiedTabs?.[args.worktreeId]?.some(
+        (tab) => tab.id === args.tabId || tab.entityId === args.tabId
+      )
+    if (tabStillPresent) {
+      return { ...retired, closed: false, ptyIdsToKill: [] }
+    }
+    const previous = cloneWorkspaceSessionState(session)
+    if (hostId === LOCAL_EXECUTION_HOST_ID) {
+      this.state.workspaceSession = next
+    } else {
+      this.state.workspaceSessionsByHostId = {
+        ...this.state.workspaceSessionsByHostId,
+        [hostId]: next
+      }
+    }
+    try {
+      this.flushOrThrow()
+    } catch (error) {
+      if (hostId === LOCAL_EXECUTION_HOST_ID) {
+        this.state.workspaceSession = previous
+      } else {
+        this.state.workspaceSessionsByHostId = {
+          ...this.state.workspaceSessionsByHostId,
+          [hostId]: previous
+        }
+      }
+      throw error
+    }
+    const persisted = this.getWorkspaceSession(hostId)
+    const persistedTabStillPresent =
+      persisted.tabsByWorktree[args.worktreeId]?.some((tab) => tab.id === args.tabId) ||
+      persisted.unifiedTabs?.[args.worktreeId]?.some(
+        (tab) => tab.id === args.tabId || tab.entityId === args.tabId
+      )
+    return persistedTabStillPresent ? { ...retired, closed: false, ptyIdsToKill: [] } : retired
   }
 
   /** Persist a non-'local' host partition; remote hosts skip setLocalWorkspaceSession's local-daemon PTY-binding race guards. */
@@ -6103,6 +6216,10 @@ export class Store {
       ptyId: string
       incarnationId?: string
       startupCwd?: string
+      archiveHint?: {
+        hint: Partial<TerminalArchiveHint>
+        source: TerminalArchiveHintSource
+      }
     },
     hostId?: string | null
   ): void {
@@ -6226,6 +6343,15 @@ export class Store {
         }
       }
     }
+    if (args.archiveHint) {
+      const merged = mergeTerminalArchiveHintIntoSession({
+        session,
+        paneKey,
+        hint: args.archiveHint.hint,
+        source: args.archiveHint.source
+      })
+      session.terminalArchiveHintsByPaneKey = merged.terminalArchiveHintsByPaneKey
+    }
     advanceTopologyAfterMembershipChange()
     try {
       this.flushOrThrow()
@@ -6233,6 +6359,122 @@ export class Store {
       restoreSession()
       throw err
     }
+  }
+
+  /** Persists main-observed worker evidence without admitting renderer-provided state. */
+  persistTerminalArchiveHint(
+    args: {
+      paneKey: string
+      hint: Partial<TerminalArchiveHint>
+      source: TerminalArchiveHintSource
+    },
+    hostId?: string | null
+  ): void {
+    const resolvedHostId = this.resolveHostId(hostId)
+    const session = this.getWorkspaceSession(resolvedHostId)
+    const previous = cloneWorkspaceSessionState(session)
+    const merged = mergeTerminalArchiveHintIntoSession({
+      session,
+      paneKey: args.paneKey,
+      hint: args.hint,
+      source: args.source
+    })
+    if (resolvedHostId === LOCAL_EXECUTION_HOST_ID) {
+      this.state.workspaceSession = merged
+    } else {
+      this.state.workspaceSessionsByHostId = {
+        ...this.state.workspaceSessionsByHostId,
+        [resolvedHostId]: merged
+      }
+    }
+    try {
+      this.flushOrThrow()
+    } catch (error) {
+      if (resolvedHostId === LOCAL_EXECUTION_HOST_ID) {
+        this.state.workspaceSession = previous
+      } else {
+        this.state.workspaceSessionsByHostId = {
+          ...this.state.workspaceSessionsByHostId,
+          [resolvedHostId]: previous
+        }
+      }
+      throw error
+    }
+  }
+
+  /** Transfers both durable pane facts in one host-scoped, synchronous mutation. */
+  transferTerminalArchivePaneDurableState(
+    args: { fromPaneKey: string; toPaneKey: string },
+    hostId?: string | null
+  ): void {
+    const resolvedHostId = this.resolveHostId(hostId)
+    const session = this.getWorkspaceSession(resolvedHostId)
+    const moved = moveTerminalArchivePaneDurableState({ session, ...args })
+    if (moved === session) {
+      return
+    }
+    const previous = cloneWorkspaceSessionState(session)
+    if (resolvedHostId === LOCAL_EXECUTION_HOST_ID) {
+      this.state.workspaceSession = moved
+    } else {
+      this.state.workspaceSessionsByHostId = {
+        ...this.state.workspaceSessionsByHostId,
+        [resolvedHostId]: moved
+      }
+    }
+    try {
+      this.flushOrThrow()
+    } catch (error) {
+      if (resolvedHostId === LOCAL_EXECUTION_HOST_ID) {
+        this.state.workspaceSession = previous
+      } else {
+        this.state.workspaceSessionsByHostId = {
+          ...this.state.workspaceSessionsByHostId,
+          [resolvedHostId]: previous
+        }
+      }
+      throw error
+    }
+  }
+
+  /** Moves durable pane state only after the persisted layout proves the PTY and execution host. */
+  transferTerminalArchivePaneDurableStateForOwnedPty(args: {
+    fromPaneKey: string
+    toPaneKey: string
+    ptyId: string
+  }): TerminalArchivePaneDurableTransferResult {
+    const parsed = parsePaneKey(args.fromPaneKey)
+    if (!parsed) {
+      return { kind: 'not-owned' }
+    }
+    for (const repo of this.state.repos) {
+      const hostId = getRepoExecutionHostId(repo)
+      const session = this.getWorkspaceSession(hostId)
+      for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree)) {
+        if (getRepoIdFromWorktreeId(worktreeId) !== repo.id) {
+          continue
+        }
+        if (!tabs.some((tab) => tab.id === parsed.tabId)) {
+          continue
+        }
+        if (
+          session.terminalLayoutsByTabId[parsed.tabId]?.ptyIdsByLeafId?.[parsed.leafId] !==
+          args.ptyId
+        ) {
+          continue
+        }
+        try {
+          this.transferTerminalArchivePaneDurableState(
+            { fromPaneKey: args.fromPaneKey, toPaneKey: args.toPaneKey },
+            hostId
+          )
+          return { kind: 'transferred' }
+        } catch {
+          return { kind: 'durability-failed' }
+        }
+      }
+    }
+    return { kind: 'not-owned' }
   }
 
   // ── SSH Targets ────────────────────────────────────────────────────

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1547,7 +1547,7 @@ function normalizeSshRemotePtyLease(value: unknown): SshRemotePtyLease | null {
     return null
   }
   const state = raw.state ?? 'detached'
-  if (!['attached', 'detached', 'terminated', 'expired'].includes(state)) {
+  if (!['attached', 'detached', 'termination-pending', 'terminated', 'expired'].includes(state)) {
     return null
   }
   const now = Date.now()
@@ -5874,11 +5874,12 @@ export class Store {
     this.setHostWorkspaceSession(resolved, session)
   }
 
-  /** Retires an already archived tab under the host topology fence, then sync-flushes before kill authority escapes. */
+  /** Retires a tab and records SSH termination intent in one durable mutation before kill authority escapes. */
   retireArchivedTerminalTabAndFlush(args: {
     worktreeId: string
     tabId: string
     executionHostId: ExecutionHostId
+    sshTerminationTargetId?: string
   }): ReturnType<typeof retireArchivedTerminalTab> {
     const hostId = this.resolveHostId(args.executionHostId)
     const session = this.getWorkspaceSession(hostId)
@@ -5896,12 +5897,32 @@ export class Store {
       return { ...retired, closed: false, ptyIdsToKill: [] }
     }
     const previous = cloneWorkspaceSessionState(session)
+    const previousLeases = this.state.sshRemotePtyLeases?.map((lease) => ({ ...lease }))
     if (hostId === LOCAL_EXECUTION_HOST_ID) {
       this.state.workspaceSession = next
     } else {
       this.state.workspaceSessionsByHostId = {
         ...this.state.workspaceSessionsByHostId,
         [hostId]: next
+      }
+    }
+    if (args.sshTerminationTargetId) {
+      const relayPtyIds = new Set(
+        retired.ptyIdsToKill.map((ptyId) =>
+          this.getRelayPtyIdForSshLeaseStorage(args.sshTerminationTargetId!, ptyId)
+        )
+      )
+      const now = Date.now()
+      for (const lease of this.state.sshRemotePtyLeases ?? []) {
+        if (
+          lease.targetId === args.sshTerminationTargetId &&
+          relayPtyIds.has(lease.ptyId) &&
+          lease.state !== 'terminated' &&
+          lease.state !== 'expired'
+        ) {
+          lease.state = 'termination-pending'
+          lease.updatedAt = now
+        }
       }
     }
     try {
@@ -5915,6 +5936,7 @@ export class Store {
           [hostId]: previous
         }
       }
+      this.state.sshRemotePtyLeases = previousLeases
       throw error
     }
     const persisted = this.getWorkspaceSession(hostId)
@@ -6153,7 +6175,12 @@ export class Store {
     const leases = this.state.sshRemotePtyLeases?.filter((entry) =>
       this.sshRemotePtyLeaseMatchesBinding(entry, binding)
     )
-    return !leases?.some((lease) => lease.state === 'terminated' || lease.state === 'expired')
+    return !leases?.some(
+      (lease) =>
+        lease.state === 'termination-pending' ||
+        lease.state === 'terminated' ||
+        lease.state === 'expired'
+    )
   }
 
   private getRelayPtyIdForSshLeaseComparison(targetId: string, ptyId: string): string {
@@ -6204,6 +6231,7 @@ export class Store {
       this.state.sshRemotePtyLeases?.some(
         (lease) =>
           this.sshRemotePtyLeaseMatchesBinding(lease, binding) &&
+          lease.state !== 'termination-pending' &&
           lease.state !== 'terminated' &&
           lease.state !== 'expired'
       ) ?? false

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2403,6 +2403,28 @@ function cloneWorkspaceSessionState(session: WorkspaceSessionState): WorkspaceSe
   return structuredClone(session)
 }
 
+/**
+ * Re-seed main-owned PTY incarnations that a renderer session replay dropped.
+ *
+ * An absent topology fence marks the replay: renderer payloads omit every main-owned field, while
+ * main retires through this same setter and always carries a fresh fence. Seeding before sanitize
+ * leaves tombstone retirement and membership rebase the final say over what they legitimately drop.
+ */
+function reseedMainOwnedPtyIncarnations(
+  session: WorkspaceSessionState,
+  prior: WorkspaceSessionState | undefined
+): WorkspaceSessionState {
+  const priorIncarnations = prior?.terminalPtyIncarnationsByPaneKey
+  if (
+    !priorIncarnations ||
+    session.terminalTopologyRevisionByRepoId ||
+    Object.keys(session.terminalPtyIncarnationsByPaneKey ?? {}).length > 0
+  ) {
+    return session
+  }
+  return { ...session, terminalPtyIncarnationsByPaneKey: priorIncarnations }
+}
+
 function removeWorkspaceSessionOwner(
   session: WorkspaceSessionState | undefined,
   ownerKey: string,
@@ -5907,6 +5929,7 @@ export class Store {
   /** Persist a non-'local' host partition; remote hosts skip setLocalWorkspaceSession's local-daemon PTY-binding race guards. */
   private setHostWorkspaceSession(hostId: ExecutionHostId, session: WorkspaceSessionState): void {
     const prior = this.state.workspaceSessionsByHostId?.[hostId]
+    session = reseedMainOwnedPtyIncarnations(session, prior)
     // Why: each partition owns its topology fence; renderer writes omit it and must rebase locally.
     session = sanitizeWorkspaceSessionTerminalRetirements(session, prior)
     const incoming = session.terminalArchiveHintsByPaneKey ?? {}
@@ -5927,6 +5950,7 @@ export class Store {
 
   private setLocalWorkspaceSession(session: PersistedState['workspaceSession']): void {
     const prior = this.state.workspaceSession
+    session = reseedMainOwnedPtyIncarnations(session, prior)
     session = sanitizeWorkspaceSessionTerminalRetirements(session, prior)
     session = pruneWorkspaceSessionBrowserHistory(
       pruneLocalTerminalScrollbackBuffers(session, this.state.repos)

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -6443,8 +6443,9 @@ export class Store {
     toPaneKey: string
     ptyId: string
   }): TerminalArchivePaneDurableTransferResult {
-    const parsed = parsePaneKey(args.fromPaneKey)
-    if (!parsed) {
+    const source = parsePaneKey(args.fromPaneKey)
+    const target = parsePaneKey(args.toPaneKey)
+    if (!source || !target) {
       return { kind: 'not-owned' }
     }
     for (const repo of this.state.repos) {
@@ -6454,13 +6455,12 @@ export class Store {
         if (getRepoIdFromWorktreeId(worktreeId) !== repo.id) {
           continue
         }
-        if (!tabs.some((tab) => tab.id === parsed.tabId)) {
-          continue
-        }
-        if (
-          session.terminalLayoutsByTabId[parsed.tabId]?.ptyIdsByLeafId?.[parsed.leafId] !==
-          args.ptyId
-        ) {
+        const ownershipProven = [source, target].some(
+          (pane) =>
+            tabs.some((tab) => tab.id === pane.tabId) &&
+            session.terminalLayoutsByTabId[pane.tabId]?.ptyIdsByLeafId?.[pane.leafId] === args.ptyId
+        )
+        if (!ownershipProven) {
           continue
         }
         try {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -5906,11 +5906,15 @@ export class Store {
 
   /** Persist a non-'local' host partition; remote hosts skip setLocalWorkspaceSession's local-daemon PTY-binding race guards. */
   private setHostWorkspaceSession(hostId: ExecutionHostId, session: WorkspaceSessionState): void {
+    const prior = this.state.workspaceSessionsByHostId?.[hostId]
     // Why: each partition owns its topology fence; renderer writes omit it and must rebase locally.
-    session = sanitizeWorkspaceSessionTerminalRetirements(
-      session,
-      this.state.workspaceSessionsByHostId?.[hostId]
-    )
+    session = sanitizeWorkspaceSessionTerminalRetirements(session, prior)
+    const incoming = session.terminalArchiveHintsByPaneKey ?? {}
+    const incomingHasAnyHint = Object.keys(incoming).length > 0
+    if (!incomingHasAnyHint && prior?.terminalArchiveHintsByPaneKey) {
+      // Why: host-observed hints stay main-owned when a renderer session replay omits them.
+      session.terminalArchiveHintsByPaneKey = prior.terminalArchiveHintsByPaneKey
+    }
     const pruned = pruneWorkspaceSessionBrowserHistory(
       pruneLocalTerminalScrollbackBuffers(session, this.state.repos)
     )
@@ -6061,6 +6065,12 @@ export class Store {
       this.terminalScrollbackSnapshotStorage,
       this.getTerminalScrollbackRefsOutsideLocalSession()
     )
+    const incoming = session.terminalArchiveHintsByPaneKey ?? {}
+    const incomingHasAnyHint = Object.keys(incoming).length > 0
+    if (!incomingHasAnyHint && prior?.terminalArchiveHintsByPaneKey) {
+      // Why: host-observed hints stay main-owned when a renderer session replay omits them.
+      session.terminalArchiveHintsByPaneKey = prior.terminalArchiveHintsByPaneKey
+    }
     this.state.workspaceSession = session
     this.scheduleSave()
   }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -251,6 +251,10 @@ import {
   type TerminalArchiveHintSource
 } from '../shared/terminal-archive-types'
 import { TerminalArchiveStore } from './terminal-archive-store'
+import type {
+  LostTerminalArchiveRetirement,
+  LostTerminalArchiveRetirementResult
+} from './terminal-archive-contracts'
 import {
   mergeTerminalArchiveHintIntoSession,
   moveTerminalArchivePaneDurableState,
@@ -5767,6 +5771,8 @@ export class Store {
         worktreeExists: (worktreeId, hostId) => this.archiveWorktreeExists(worktreeId, hostId),
         isTerminalArchiveRequestOwned: (request) => this.isTerminalArchiveRequestOwned(request),
         isTerminalScrollbackSnapshotLive: (ref) => this.isTerminalScrollbackSnapshotLive(ref),
+        commitLostTerminalArchiveAndRetire: (archives, retirement) =>
+          this.commitLostTerminalArchiveAndRetire(archives, retirement),
         terminalScrollbackSnapshotStorage: this.terminalScrollbackSnapshotStorage
       },
       snapshotSource
@@ -5881,6 +5887,13 @@ export class Store {
     executionHostId: ExecutionHostId
     sshTerminationTargetId?: string
   }): ReturnType<typeof retireArchivedTerminalTab> {
+    return this.commitLostTerminalArchiveAndRetire(this.state.terminalArchivesById, args)
+  }
+
+  private commitLostTerminalArchiveAndRetire(
+    archives: Record<string, ArchivedTerminalTab>,
+    args: LostTerminalArchiveRetirement
+  ): LostTerminalArchiveRetirementResult {
     const hostId = this.resolveHostId(args.executionHostId)
     const session = this.getWorkspaceSession(hostId)
     const retired = retireArchivedTerminalTab(session, args.worktreeId, args.tabId)
@@ -5896,8 +5909,10 @@ export class Store {
     if (tabStillPresent) {
       return { ...retired, closed: false, ptyIdsToKill: [] }
     }
+    const previousArchives = this.state.terminalArchivesById
     const previous = cloneWorkspaceSessionState(session)
     const previousLeases = this.state.sshRemotePtyLeases?.map((lease) => ({ ...lease }))
+    this.state.terminalArchivesById = archives
     if (hostId === LOCAL_EXECUTION_HOST_ID) {
       this.state.workspaceSession = next
     } else {
@@ -5928,6 +5943,7 @@ export class Store {
     try {
       this.flushOrThrow()
     } catch (error) {
+      this.state.terminalArchivesById = previousArchives
       if (hostId === LOCAL_EXECUTION_HOST_ID) {
         this.state.workspaceSession = previous
       } else {
@@ -5939,13 +5955,7 @@ export class Store {
       this.state.sshRemotePtyLeases = previousLeases
       throw error
     }
-    const persisted = this.getWorkspaceSession(hostId)
-    const persistedTabStillPresent =
-      persisted.tabsByWorktree[args.worktreeId]?.some((tab) => tab.id === args.tabId) ||
-      persisted.unifiedTabs?.[args.worktreeId]?.some(
-        (tab) => tab.id === args.tabId || tab.entityId === args.tabId
-      )
-    return persistedTabStillPresent ? { ...retired, closed: false, ptyIdsToKill: [] } : retired
+    return retired
   }
 
   /** Persist a non-'local' host partition; remote hosts skip setLocalWorkspaceSession's local-daemon PTY-binding race guards. */

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -235,12 +235,20 @@ import {
 } from '../shared/workspace-scope'
 import {
   collectTerminalScrollbackSnapshotRefs,
+  collectTerminalArchiveScrollbackSnapshotRefs,
   deleteTerminalScrollbackSnapshotSync,
   getProfileTerminalScrollbackSnapshotRoot,
   migrateWorkspaceSessionTerminalScrollbackSnapshots,
   readTerminalScrollbackSnapshotSync,
   type TerminalScrollbackSnapshotStorage
 } from './terminal-scrollback-snapshots'
+import {
+  normalizeTerminalArchiveRetentionDays,
+  terminalArchivesByIdSchema,
+  type ArchivedTerminalTab
+} from '../shared/terminal-archive-types'
+import { TerminalArchiveStore } from './terminal-archive-store'
+import type { TerminalArchiveSnapshotSource } from '../shared/workspace-session-terminal-archive'
 import { track } from './telemetry/client'
 import { getCohortAtEmit } from './telemetry/cohort-classifier'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from './startup/startup-diagnostics'
@@ -603,6 +611,33 @@ function migrateTerminalScrollbackRows(settings: unknown): {
     rows,
     needsSave: !hasRows || hasLegacyBytes || legacySettings.terminalScrollbackRows !== rows
   }
+}
+
+function migrateTerminalArchiveRetentionDays(settings: unknown): {
+  days: number
+  needsSave: boolean
+} {
+  const raw =
+    settings && typeof settings === 'object'
+      ? (settings as { terminalArchiveRetentionDays?: unknown }).terminalArchiveRetentionDays
+      : undefined
+  const days = normalizeTerminalArchiveRetentionDays(raw)
+  return { days, needsSave: raw !== days }
+}
+
+function parseTerminalArchives(raw: unknown): {
+  archives: Record<string, ArchivedTerminalTab>
+  needsSave: boolean
+} {
+  if (raw === undefined) {
+    return { archives: {}, needsSave: false }
+  }
+  const parsed = terminalArchivesByIdSchema.safeParse(raw)
+  if (!parsed.success) {
+    console.warn('[persistence] Ignoring invalid terminal archive metadata')
+    return { archives: {}, needsSave: true }
+  }
+  return { archives: parsed.data as Record<string, ArchivedTerminalTab>, needsSave: false }
 }
 
 function migrateTerminalTuiScrollSensitivityDefault(settings: GlobalSettings | undefined): {
@@ -2549,14 +2584,15 @@ function backfillFolderScopeConnectionIds(state: PersistedState): {
 function deleteRemovedTerminalScrollbackSnapshots(
   prior: WorkspaceSessionState | undefined,
   next: WorkspaceSessionState,
-  storage?: TerminalScrollbackSnapshotStorage
+  storage?: TerminalScrollbackSnapshotStorage,
+  protectedRefs: ReadonlySet<string> = new Set()
 ): void {
   if (!prior) {
     return
   }
   const nextRefs = collectTerminalScrollbackSnapshotRefs(next)
   for (const ref of collectTerminalScrollbackSnapshotRefs(prior)) {
-    if (!nextRefs.has(ref)) {
+    if (!nextRefs.has(ref) && !protectedRefs.has(ref)) {
       deleteTerminalScrollbackSnapshotSync(ref, storage)
     }
   }
@@ -2830,6 +2866,16 @@ export class Store {
         if (migratedTerminalScrollback.needsSave) {
           this.loadNeedsSave = true
         }
+        const migratedTerminalArchiveRetention = migrateTerminalArchiveRetentionDays(
+          parsed.settings
+        )
+        if (migratedTerminalArchiveRetention.needsSave) {
+          this.loadNeedsSave = true
+        }
+        const parsedTerminalArchives = parseTerminalArchives(parsed.terminalArchivesById)
+        if (parsedTerminalArchives.needsSave) {
+          this.loadNeedsSave = true
+        }
         const migratedTerminalTuiScrollSensitivity = migrateTerminalTuiScrollSensitivityDefault(
           parsed.settings
         )
@@ -3056,6 +3102,7 @@ export class Store {
           workspaceLineageByChildKey: normalizeWorkspaceLineageByChildKey(
             parsed.workspaceLineageByChildKey
           ),
+          terminalArchivesById: parsedTerminalArchives.archives,
           settings: {
             ...defaults.settings,
             // Why (#7977): keep persisted experimentalNewWorktreeCardStyle:true — v1.4.130's onboarding auto-wrote it as a plain boolean, so it's indistinguishable from a real opt-in; only the default changed.
@@ -3104,6 +3151,7 @@ export class Store {
             floatingTerminalTrustedCwds: migratedFloatingTerminalTrustedCwds,
             floatingTerminalCwdMigratedToAppWorkspace: true,
             terminalScrollbackRows: migratedTerminalScrollback.rows,
+            terminalArchiveRetentionDays: migratedTerminalArchiveRetention.days,
             terminalQuickCommands: normalizeTerminalQuickCommands(
               parsed.settings?.terminalQuickCommands
             ),
@@ -5249,6 +5297,11 @@ export class Store {
         updates.terminalScrollbackRows
       )
     }
+    if ('terminalArchiveRetentionDays' in updates) {
+      sanitizedUpdates.terminalArchiveRetentionDays = normalizeTerminalArchiveRetentionDays(
+        updates.terminalArchiveRetentionDays
+      )
+    }
     if (
       'terminalTuiScrollSensitivity' in updates ||
       'terminalTuiScrollSensitivityDefaultedToOne' in updates
@@ -5648,6 +5701,82 @@ export class Store {
     return readTerminalScrollbackSnapshotSync(ref, this.terminalScrollbackSnapshotStorage)
   }
 
+  getTerminalArchives(): Record<string, ArchivedTerminalTab> {
+    return { ...this.state.terminalArchivesById }
+  }
+
+  getTerminalArchiveRetentionDays(): number {
+    return normalizeTerminalArchiveRetentionDays(this.state.settings.terminalArchiveRetentionDays)
+  }
+
+  /** Archive metadata is the durability boundary: callers must not retire a PTY until this succeeds. */
+  replaceTerminalArchivesAndFlush(archives: Record<string, ArchivedTerminalTab>): void {
+    const previous = this.state.terminalArchivesById
+    this.state.terminalArchivesById = archives
+    try {
+      this.flushOrThrow()
+    } catch (error) {
+      this.state.terminalArchivesById = previous
+      throw error
+    }
+  }
+
+  createTerminalArchiveStore(snapshotSource: TerminalArchiveSnapshotSource): TerminalArchiveStore {
+    return new TerminalArchiveStore(
+      {
+        getTerminalArchives: () => this.getTerminalArchives(),
+        replaceTerminalArchivesAndFlush: (archives) =>
+          this.replaceTerminalArchivesAndFlush(archives),
+        getTerminalArchiveRetentionDays: () => this.getTerminalArchiveRetentionDays(),
+        isExecutionHostReachable: (hostId) => this.isArchiveExecutionHostReachable(hostId),
+        worktreeExists: (worktreeId, hostId) => this.archiveWorktreeExists(worktreeId, hostId),
+        isTerminalScrollbackSnapshotLive: (ref) => this.isTerminalScrollbackSnapshotLive(ref),
+        terminalScrollbackSnapshotStorage: this.terminalScrollbackSnapshotStorage
+      },
+      snapshotSource
+    )
+  }
+
+  private isArchiveExecutionHostReachable(hostId: ExecutionHostId): boolean {
+    if (hostId === LOCAL_EXECUTION_HOST_ID) {
+      return true
+    }
+    return this.state.repos.some((repo) => getRepoExecutionHostId(repo) === hostId)
+  }
+
+  private archiveWorktreeExists(worktreeId: string, hostId: ExecutionHostId): boolean {
+    const repoId = getRepoIdFromWorktreeId(worktreeId)
+    const repo = this.state.repos.find((entry) => entry.id === repoId)
+    return Boolean(
+      repo && getRepoExecutionHostId(repo) === hostId && this.state.worktreeMeta[worktreeId]
+    )
+  }
+
+  private isTerminalScrollbackSnapshotLive(ref: string): boolean {
+    if (collectTerminalArchiveScrollbackSnapshotRefs(this.state.terminalArchivesById).has(ref)) {
+      return true
+    }
+    if (collectTerminalScrollbackSnapshotRefs(this.state.workspaceSession).has(ref)) {
+      return true
+    }
+    return Object.values(this.state.workspaceSessionsByHostId ?? {}).some((session) =>
+      session ? collectTerminalScrollbackSnapshotRefs(session).has(ref) : false
+    )
+  }
+
+  private getTerminalScrollbackRefsOutsideLocalSession(): Set<string> {
+    const refs = collectTerminalArchiveScrollbackSnapshotRefs(this.state.terminalArchivesById)
+    for (const session of Object.values(this.state.workspaceSessionsByHostId ?? {})) {
+      if (!session) {
+        continue
+      }
+      for (const ref of collectTerminalScrollbackSnapshotRefs(session)) {
+        refs.add(ref)
+      }
+    }
+    return refs
+  }
+
   /** Resolve the worktree a terminal tab belongs to; more reliable than agent-echoed hook fields. */
   getWorktreeIdForTab(tabId: string): string | undefined {
     return findWorktreeIdForTab(this.getWorkspaceSession(), tabId)
@@ -5813,7 +5942,12 @@ export class Store {
       this.terminalScrollbackSnapshotStorage
     )
     session = migratedScrollback.session
-    deleteRemovedTerminalScrollbackSnapshots(prior, session, this.terminalScrollbackSnapshotStorage)
+    deleteRemovedTerminalScrollbackSnapshots(
+      prior,
+      session,
+      this.terminalScrollbackSnapshotStorage,
+      this.getTerminalScrollbackRefsOutsideLocalSession()
+    )
     this.state.workspaceSession = session
     this.scheduleSave()
   }

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1902,4 +1902,8 @@ describe('LocalPtyProvider', () => {
       await expect(shutdown).resolves.toBeUndefined()
     })
   })
+
+  it('reports local revival as not applicable instead of a fake empty outcome', async () => {
+    await expect(provider.revive('{}')).resolves.toEqual({ mode: 'not-applicable' })
+  })
 })

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -1316,8 +1316,8 @@ export class LocalPtyProvider implements IPtyProvider {
   async serialize(_ids: string[]): Promise<string> {
     return '{}'
   }
-  async revive(_state: string): Promise<void> {
-    /* re-spawning handles local revival */
+  async revive(_state: string) {
+    return { mode: 'not-applicable' as const }
   }
 
   async listProcesses(): Promise<PtyProcessInfo[]> {

--- a/src/main/providers/pty-lost-worker-recovery.ts
+++ b/src/main/providers/pty-lost-worker-recovery.ts
@@ -20,6 +20,7 @@ export type PtyColdRestoreProbe =
         | 'payload-absent'
         | 'payload-corrupt'
         | 'io-error'
+        | 'completeness-lost'
     }
 
 export type PtyPreSpawnLostWorkerHandler = (coldRestore: {

--- a/src/main/providers/pty-lost-worker-recovery.ts
+++ b/src/main/providers/pty-lost-worker-recovery.ts
@@ -1,0 +1,17 @@
+import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
+import type { PtyLostWorkerRecovery } from './pty-spawn-result'
+import type { PtySpawnOptions } from './types'
+
+export type PtyPreSpawnLostWorkerHandler = (coldRestore: {
+  scrollback: string
+  cwd: string
+  cols?: number
+  rows?: number
+  oscLinks?: TerminalOscLinkRange[]
+}) => Promise<PtyLostWorkerRecovery>
+
+export type PtyPreSpawnLostWorkerOption = {
+  preSpawnLostWorker?: PtyPreSpawnLostWorkerHandler
+}
+
+export type PtySpawnOptionsWithLostWorker = PtySpawnOptions & PtyPreSpawnLostWorkerOption

--- a/src/main/providers/pty-lost-worker-recovery.ts
+++ b/src/main/providers/pty-lost-worker-recovery.ts
@@ -2,12 +2,33 @@ import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges
 import type { PtyLostWorkerRecovery } from './pty-spawn-result'
 import type { PtySpawnOptions } from './types'
 
+export type PtyColdRestoreProbe =
+  | {
+      kind: 'valid-snapshot'
+      scrollback: string
+      cwd: string
+      cols?: number
+      rows?: number
+      oscLinks?: TerminalOscLinkRange[]
+      truncated: false
+    }
+  | {
+      kind:
+        | 'meta-absent'
+        | 'meta-corrupt'
+        | 'meta-closed'
+        | 'payload-absent'
+        | 'payload-corrupt'
+        | 'io-error'
+    }
+
 export type PtyPreSpawnLostWorkerHandler = (coldRestore: {
   scrollback: string
   cwd: string
   cols?: number
   rows?: number
   oscLinks?: TerminalOscLinkRange[]
+  probeSibling: (sessionId: string) => PtyColdRestoreProbe
 }) => Promise<PtyLostWorkerRecovery>
 
 export type PtyPreSpawnLostWorkerOption = {

--- a/src/main/providers/pty-lost-worker-recovery.ts
+++ b/src/main/providers/pty-lost-worker-recovery.ts
@@ -10,7 +10,7 @@ export type PtyColdRestoreProbe =
       cols?: number
       rows?: number
       oscLinks?: TerminalOscLinkRange[]
-      truncated: false
+      truncated: boolean
     }
   | {
       kind:

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -3,6 +3,18 @@ import type { TuiAgent } from '../../shared/types'
 import type { AgentSessionClaimedSpawnResult } from '../../shared/agent-session-host-authority'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
 
+export type PtyLostWorkerRecovery =
+  | { kind: 'archived'; archiveId: string }
+  | {
+      kind: 'retryable-error'
+      code:
+        | 'not-owned'
+        | 'stale-source'
+        | 'capture-unavailable'
+        | 'contract-invalid'
+        | 'durability-failed'
+    }
+
 export type PtySpawnResult = {
   agentSessionEnsure?: AgentSessionClaimedSpawnResult
   /** App-facing PTY id. Remote providers must return globally routable ids,
@@ -63,4 +75,7 @@ export type PtySpawnResult = {
     rows?: number
     oscLinks?: TerminalOscLinkRange[]
   }
+  /** A daemon found crash history before createOrAttach, so main decided the
+   * archive outcome without creating a replacement PTY. */
+  lostWorkerRecovery?: PtyLostWorkerRecovery
 }

--- a/src/main/providers/ssh-pty-persistence-revive.test.ts
+++ b/src/main/providers/ssh-pty-persistence-revive.test.ts
@@ -42,7 +42,7 @@ describe('SshPtyPersistenceRevive', () => {
               cwd: '/repo'
             }
           ],
-          diagnostics: []
+          diagnostics: [{ code: 'entry-invalid', id: 'pty-2' }]
         }
       }
       return undefined
@@ -51,7 +51,11 @@ describe('SshPtyPersistenceRevive', () => {
     await expect(subject.serialize(['pty-1'], { formatVersion: 2 })).resolves.toBe('v2-state')
     await expect(subject.revive('v2-state', { formatVersion: 2 })).resolves.toMatchObject({
       mode: 'typed',
-      outcome: { revived: [{ id: 'app:pty-1' }], lost: [{ id: 'app:pty-2' }] }
+      outcome: {
+        revived: [{ id: 'app:pty-1' }],
+        lost: [{ id: 'app:pty-2' }],
+        diagnostics: [{ code: 'entry-invalid', id: 'app:pty-2' }]
+      }
     })
     expect(mux.request).toHaveBeenCalledWith('pty.serialize', {
       ids: ['relay:pty-1'],
@@ -95,6 +99,28 @@ describe('SshPtyPersistenceRevive', () => {
       'pty.getCapabilities',
       'pty.revive'
     ])
+  })
+
+  it('fails closed when a typed diagnostic references a non-admitted relay PTY id', async () => {
+    const { mux, subject } = createSubject()
+    mux.request.mockImplementation(async (method: string) => {
+      if (method === 'pty.getCapabilities') {
+        return { ptyPersistenceEnvelopeVersion: 2, ptyReviveOutcomeVersion: 1 }
+      }
+      if (method === 'pty.revive') {
+        return {
+          outcomeVersion: 1,
+          revived: [],
+          lost: [],
+          diagnostics: [{ code: 'entry-invalid', id: 'invalid\nid' }]
+        }
+      }
+      return undefined
+    })
+
+    await expect(subject.revive('v2-state', { formatVersion: 2 })).rejects.toThrow(
+      'invalid relay PTY id'
+    )
   })
 
   it('keeps the existing legacy wire until a caller explicitly requests v2', async () => {

--- a/src/main/providers/ssh-pty-persistence-revive.test.ts
+++ b/src/main/providers/ssh-pty-persistence-revive.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest'
+import { SshPtyPersistenceRevive } from './ssh-pty-persistence-revive'
+
+type MockMultiplexer = { request: ReturnType<typeof vi.fn> }
+
+function createSubject(): { mux: MockMultiplexer; subject: SshPtyPersistenceRevive } {
+  const mux = { request: vi.fn().mockResolvedValue(undefined) }
+  return {
+    mux,
+    subject: new SshPtyPersistenceRevive(
+      mux as never,
+      (id) => `relay:${id}`,
+      (id) => `app:${id}`
+    )
+  }
+}
+
+describe('SshPtyPersistenceRevive', () => {
+  it('uses the v2 protocol and maps relay ids back to application ids', async () => {
+    const { mux, subject } = createSubject()
+    mux.request.mockImplementation(async (method: string) => {
+      if (method === 'pty.getCapabilities') {
+        return { ptyPersistenceEnvelopeVersion: 2, ptyReviveOutcomeVersion: 1 }
+      }
+      if (method === 'pty.serialize') {
+        return 'v2-state'
+      }
+      if (method === 'pty.revive') {
+        return {
+          outcomeVersion: 1,
+          revived: [
+            { id: 'pty-1', disposition: 'replacement-spawned', incarnationId: 'incarnation-1' }
+          ],
+          lost: [
+            {
+              id: 'pty-2',
+              kind: 'ordinary-shell',
+              reason: 'process-not-running',
+              pid: 42,
+              cols: 80,
+              rows: 24,
+              cwd: '/repo'
+            }
+          ],
+          diagnostics: []
+        }
+      }
+      return undefined
+    })
+
+    await expect(subject.serialize(['pty-1'], { formatVersion: 2 })).resolves.toBe('v2-state')
+    await expect(subject.revive('v2-state', { formatVersion: 2 })).resolves.toMatchObject({
+      mode: 'typed',
+      outcome: { revived: [{ id: 'app:pty-1' }], lost: [{ id: 'app:pty-2' }] }
+    })
+    expect(mux.request).toHaveBeenCalledWith('pty.serialize', {
+      ids: ['relay:pty-1'],
+      formatVersion: 2
+    })
+    expect(mux.request).toHaveBeenCalledWith('pty.revive', { state: 'v2-state', formatVersion: 2 })
+  })
+
+  it('uses legacy revive only when capability discovery is unavailable', async () => {
+    const { mux, subject } = createSubject()
+    mux.request.mockImplementation(async (method: string) => {
+      if (method === 'pty.getCapabilities') {
+        throw Object.assign(new Error('method not found'), { code: -32601 })
+      }
+      return undefined
+    })
+
+    await expect(subject.revive('legacy-state', { formatVersion: 2 })).resolves.toEqual({
+      mode: 'legacy',
+      diagnosticCode: 'pty-revive-outcome-unavailable'
+    })
+    expect(mux.request).toHaveBeenCalledWith('pty.revive', { state: 'legacy-state' })
+  })
+
+  it('fails closed when a relay claiming v2 returns a malformed outcome', async () => {
+    const { mux, subject } = createSubject()
+    mux.request.mockImplementation(async (method: string) => {
+      if (method === 'pty.getCapabilities') {
+        return { ptyPersistenceEnvelopeVersion: 2, ptyReviveOutcomeVersion: 1 }
+      }
+      if (method === 'pty.revive') {
+        return { outcomeVersion: 1, revived: [], lost: [] }
+      }
+      return undefined
+    })
+
+    await expect(subject.revive('v2-state', { formatVersion: 2 })).rejects.toThrow(
+      'PTY revive outcome'
+    )
+    expect(mux.request.mock.calls.map((call) => call[0])).toEqual([
+      'pty.getCapabilities',
+      'pty.revive'
+    ])
+  })
+
+  it('keeps the existing legacy wire until a caller explicitly requests v2', async () => {
+    const { mux, subject } = createSubject()
+
+    await expect(subject.serialize(['pty-1'])).resolves.toBeUndefined()
+    await expect(subject.revive('legacy-state')).resolves.toEqual({
+      mode: 'legacy',
+      diagnosticCode: 'pty-revive-outcome-unavailable'
+    })
+    expect(mux.request).toHaveBeenCalledWith('pty.serialize', { ids: ['relay:pty-1'] })
+    expect(mux.request).toHaveBeenCalledWith('pty.revive', { state: 'legacy-state' })
+    expect(mux.request).not.toHaveBeenCalledWith('pty.getCapabilities')
+  })
+})

--- a/src/main/providers/ssh-pty-persistence-revive.ts
+++ b/src/main/providers/ssh-pty-persistence-revive.ts
@@ -49,6 +49,18 @@ export class SshPtyPersistenceRevive {
         throw new Error('PTY revive outcome contains an invalid relay PTY id')
       }
     }
+    for (const entry of outcome.lost) {
+      for (const owner of entry.agentOwners ?? []) {
+        if (!isAdmittedSshRelayPtyId(owner.ptyId) || owner.ptyId !== entry.id) {
+          throw new Error('PTY revive outcome contains an invalid agent owner PTY id')
+        }
+      }
+    }
+    for (const diagnostic of outcome.diagnostics) {
+      if (diagnostic.id !== undefined && !isAdmittedSshRelayPtyId(diagnostic.id)) {
+        throw new Error('PTY revive outcome contains an invalid relay PTY id')
+      }
+    }
     return {
       ...outcome,
       revived: outcome.revived.map((entry) => ({ ...entry, id: this.toAppPtyId(entry.id) })),
@@ -63,6 +75,10 @@ export class SshPtyPersistenceRevive {
               }))
             }
           : {})
+      })),
+      diagnostics: outcome.diagnostics.map((diagnostic) => ({
+        ...diagnostic,
+        ...(diagnostic.id === undefined ? {} : { id: this.toAppPtyId(diagnostic.id) })
       }))
     }
   }

--- a/src/main/providers/ssh-pty-persistence-revive.ts
+++ b/src/main/providers/ssh-pty-persistence-revive.ts
@@ -1,0 +1,69 @@
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import {
+  normalizeRelayPtyReviveOutcome,
+  type PtyReviveResult,
+  type RelayPtyReviveOutcomeV1
+} from '../../shared/pty-revive-protocol'
+import { SshPtyReviveCapabilities } from './ssh-pty-revive-capabilities'
+import { isAdmittedSshRelayPtyId } from './ssh-pty-wire-admission'
+import type { PtyPersistenceProtocolOptions } from './types'
+
+export class SshPtyPersistenceRevive {
+  private readonly capabilities: SshPtyReviveCapabilities
+
+  constructor(
+    private readonly mux: SshChannelMultiplexer,
+    private readonly toRelayPtyId: (id: string) => string,
+    private readonly toAppPtyId: (id: string) => string
+  ) {
+    this.capabilities = new SshPtyReviveCapabilities(mux)
+  }
+
+  async serialize(ids: string[], options?: PtyPersistenceProtocolOptions): Promise<string> {
+    const supportsTypedRevive =
+      options?.formatVersion === 2 && (await this.capabilities.supportsTypedRevive())
+    const result = await this.mux.request('pty.serialize', {
+      ids: ids.map((id) => this.toRelayPtyId(id)),
+      ...(supportsTypedRevive ? { formatVersion: 2 } : {})
+    })
+    return result as string
+  }
+
+  async revive(state: string, options?: PtyPersistenceProtocolOptions): Promise<PtyReviveResult> {
+    const supportsTypedRevive =
+      options?.formatVersion === 2 && (await this.capabilities.supportsTypedRevive())
+    if (!supportsTypedRevive) {
+      await this.mux.request('pty.revive', { state })
+      return { mode: 'legacy', diagnosticCode: 'pty-revive-outcome-unavailable' }
+    }
+    const result = await this.mux.request('pty.revive', { state, formatVersion: 2 })
+    return {
+      mode: 'typed',
+      outcome: this.mapTypedReviveOutcome(normalizeRelayPtyReviveOutcome(result))
+    }
+  }
+
+  private mapTypedReviveOutcome(outcome: RelayPtyReviveOutcomeV1): RelayPtyReviveOutcomeV1 {
+    for (const entry of [...outcome.revived, ...outcome.lost]) {
+      if (!isAdmittedSshRelayPtyId(entry.id)) {
+        throw new Error('PTY revive outcome contains an invalid relay PTY id')
+      }
+    }
+    return {
+      ...outcome,
+      revived: outcome.revived.map((entry) => ({ ...entry, id: this.toAppPtyId(entry.id) })),
+      lost: outcome.lost.map((entry) => ({
+        ...entry,
+        id: this.toAppPtyId(entry.id),
+        ...(entry.agentOwners
+          ? {
+              agentOwners: entry.agentOwners.map((owner) => ({
+                ...owner,
+                ptyId: this.toAppPtyId(owner.ptyId)
+              }))
+            }
+          : {})
+      }))
+    }
+  }
+}

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -1,5 +1,12 @@
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
-import type { IPtyProvider, PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from './types'
+import type {
+  IPtyProvider,
+  PtyPersistenceProtocolOptions,
+  PtyProcessInfo,
+  PtySpawnOptions,
+  PtySpawnResult
+} from './types'
+import type { PtyReviveResult } from '../../shared/pty-revive-protocol'
 import { toAppSshPtyId, toRelaySshPtyId } from './ssh-pty-id'
 import { createSshPtyAppliedSizeReader } from './ssh-pty-applied-size'
 import type {
@@ -22,14 +29,12 @@ import {
 import { buildSshPtySpawnRequest } from './ssh-pty-spawn-request'
 import { SshPtySpawnExitRaceTracker } from './ssh-pty-spawn-exit-race'
 import { SshAgentSessionCapabilities } from './ssh-agent-session-capabilities'
+import { SshPtyPersistenceRevive } from './ssh-pty-persistence-revive'
 import { SshPtyProviderNotifications } from './ssh-pty-provider-notifications'
 import { SshPtyLiveRoster } from './ssh-pty-live-roster'
 import { isAdmittedSshRelayPtyId } from './ssh-pty-wire-admission'
-
-// Why: sequential relay teardown calls share one absolute budget; convert to the mux-relative timeout only at dispatch.
-function relayTimeoutOptions(deadlineMs: number | undefined): { timeoutMs: number } | undefined {
-  return deadlineMs === undefined ? undefined : { timeoutMs: Math.max(1, deadlineMs - Date.now()) }
-}
+import { relayPtyRequestTimeout } from './ssh-pty-request-timeout'
+import { getSshPtyDefaultShell, getSshPtyProfiles } from './ssh-pty-shell-info'
 
 /** Remote PTY provider that proxies IPtyProvider operations through the relay. */
 export class SshPtyProvider implements IPtyProvider {
@@ -38,6 +43,7 @@ export class SshPtyProvider implements IPtyProvider {
   private readonly livePtys = new SshPtyLiveRoster()
   readonly getAppliedSize: NonNullable<IPtyProvider['getAppliedSize']>
   private readonly agentSessionCapabilities: SshAgentSessionCapabilities
+  private readonly persistenceRevive: SshPtyPersistenceRevive
   private spawnExitRaces = new SshPtySpawnExitRaceTracker()
   private readonly notifications: SshPtyProviderNotifications
 
@@ -49,6 +55,11 @@ export class SshPtyProvider implements IPtyProvider {
     this.connectionId = connectionId
     this.mux = mux
     this.agentSessionCapabilities = new SshAgentSessionCapabilities(mux)
+    this.persistenceRevive = new SshPtyPersistenceRevive(
+      mux,
+      (id) => this.toRelayPtyId(id),
+      (id) => this.toAppPtyId(id)
+    )
     this.getAppliedSize = createSshPtyAppliedSizeReader(mux, connectionId)
     this.notifications = new SshPtyProviderNotifications(
       mux,
@@ -230,7 +241,7 @@ export class SshPtyProvider implements IPtyProvider {
         immediate: opts.immediate ?? false,
         keepHistory: opts.keepHistory ?? false
       },
-      relayTimeoutOptions(opts.deadlineMs)
+      relayPtyRequestTimeout(opts.deadlineMs)
     )
     this.livePtys.recordExit(id)
   }
@@ -283,15 +294,12 @@ export class SshPtyProvider implements IPtyProvider {
     })) as { foregroundProcess: string | null; hasChildProcesses: boolean }
   }
 
-  async serialize(ids: string[]): Promise<string> {
-    const result = await this.mux.request('pty.serialize', {
-      ids: ids.map((id) => this.toRelayPtyId(id))
-    })
-    return result as string
+  async serialize(ids: string[], options?: PtyPersistenceProtocolOptions): Promise<string> {
+    return this.persistenceRevive.serialize(ids, options)
   }
 
-  async revive(state: string): Promise<void> {
-    await this.mux.request('pty.revive', { state })
+  async revive(state: string, options?: PtyPersistenceProtocolOptions): Promise<PtyReviveResult> {
+    return this.persistenceRevive.revive(state, options)
   }
 
   async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
@@ -299,7 +307,7 @@ export class SshPtyProvider implements IPtyProvider {
     const result = await this.mux.request(
       'pty.listProcesses',
       undefined,
-      relayTimeoutOptions(opts?.deadlineMs)
+      relayPtyRequestTimeout(opts?.deadlineMs)
     )
     const processes = mapSshPtyProcessList(result, (id) => this.toAppPtyId(id))
     this.livePtys.reconcileListing(
@@ -314,13 +322,11 @@ export class SshPtyProvider implements IPtyProvider {
   }
 
   async getDefaultShell(): Promise<string> {
-    const result = await this.mux.request('pty.getDefaultShell')
-    return result as string
+    return getSshPtyDefaultShell(this.mux)
   }
 
   async getProfiles(): Promise<{ name: string; path: string }[]> {
-    const result = await this.mux.request('pty.getProfiles')
-    return result as { name: string; path: string }[]
+    return getSshPtyProfiles(this.mux)
   }
 
   onData(callback: SshPtyDataCallback): () => void {

--- a/src/main/providers/ssh-pty-request-timeout.ts
+++ b/src/main/providers/ssh-pty-request-timeout.ts
@@ -1,0 +1,5 @@
+export function relayPtyRequestTimeout(
+  deadlineMs: number | undefined
+): { timeoutMs: number } | undefined {
+  return deadlineMs === undefined ? undefined : { timeoutMs: Math.max(1, deadlineMs - Date.now()) }
+}

--- a/src/main/providers/ssh-pty-revive-capabilities.ts
+++ b/src/main/providers/ssh-pty-revive-capabilities.ts
@@ -1,0 +1,45 @@
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import { waitForSshCapabilityProbe } from './ssh-capability-probe-waiter'
+
+export class SshPtyReviveCapabilities {
+  private probe: Promise<boolean> | null = null
+
+  constructor(private readonly mux: SshChannelMultiplexer) {}
+
+  async supportsTypedRevive(options: { signal?: AbortSignal } = {}): Promise<boolean> {
+    const probe = this.probe ?? this.probeTypedRevive()
+    this.probe = probe
+    try {
+      const supported = await waitForSshCapabilityProbe(probe, options.signal)
+      if (!supported && this.probe === probe) {
+        // Why: a relay can be upgraded without replacing the current SSH mux.
+        this.probe = null
+      }
+      return supported
+    } catch (error) {
+      if (!options.signal?.aborted && this.probe === probe) {
+        this.probe = null
+      }
+      if (isPtyCapabilityMethodUnavailable(error)) {
+        return false
+      }
+      throw error
+    }
+  }
+
+  private async probeTypedRevive(): Promise<boolean> {
+    const capabilities = await this.mux.request('pty.getCapabilities')
+    if (!capabilities || typeof capabilities !== 'object' || Array.isArray(capabilities)) {
+      return false
+    }
+    const value = capabilities as Record<string, unknown>
+    return value.ptyPersistenceEnvelopeVersion === 2 && value.ptyReviveOutcomeVersion === 1
+  }
+}
+
+function isPtyCapabilityMethodUnavailable(error: unknown): boolean {
+  if (typeof error === 'object' && error !== null && 'code' in error && error.code === -32601) {
+    return true
+  }
+  return false
+}

--- a/src/main/providers/ssh-pty-shell-info.ts
+++ b/src/main/providers/ssh-pty-shell-info.ts
@@ -1,0 +1,11 @@
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+
+export async function getSshPtyDefaultShell(mux: SshChannelMultiplexer): Promise<string> {
+  return (await mux.request('pty.getDefaultShell')) as string
+}
+
+export async function getSshPtyProfiles(
+  mux: SshChannelMultiplexer
+): Promise<{ name: string; path: string }[]> {
+  return (await mux.request('pty.getProfiles')) as { name: string; path: string }[]
+}

--- a/src/main/providers/ssh-pty-spawn-request.ts
+++ b/src/main/providers/ssh-pty-spawn-request.ts
@@ -22,6 +22,18 @@ export function buildSshPtySpawnRequest(args: {
     // Why: the relay needs launch identity for plugin env overlays and provider-side delivery.
     ...(options.command ? { command: options.command } : {}),
     ...(options.launchAgent ? { launchAgent: options.launchAgent } : {}),
+    ...(options.archiveContext
+      ? {
+          archiveContext: {
+            ...(options.archiveContext.providerSession
+              ? { providerSession: options.archiveContext.providerSession }
+              : {}),
+            ...(options.archiveContext.orchestrationTaskId
+              ? { orchestrationTaskId: options.archiveContext.orchestrationTaskId }
+              : {})
+          }
+        }
+      : {}),
     ...(options.shellOverride !== undefined ? { shellOverride: options.shellOverride } : {}),
     ...(options.terminalWindowsWslDistro !== undefined
       ? { terminalWindowsWslDistro: options.terminalWindowsWslDistro }

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -28,6 +28,8 @@ import type { GitProviderStatusOptions } from './git-provider-status-options'
 import type { PtyBackgroundStreamEvent, PtyDataEvent } from './pty-provider-events'
 import type { PtySpawnResult } from './pty-spawn-result'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { AgentProviderSessionMetadata } from '../../shared/agent-session-resume'
+import type { PtyReviveResult } from '../../shared/pty-revive-protocol'
 import type {
   AgentSessionExecutionClaim,
   AgentSessionSurfaceBinding
@@ -57,6 +59,10 @@ export type PtyProviderBufferSnapshot = {
   pendingEscapeTailAnsi?: string
 }
 
+export type PtyPersistenceProtocolOptions = {
+  formatVersion?: 2
+}
+
 export type PtySpawnOptions = {
   cols: number
   rows: number
@@ -70,6 +76,11 @@ export type PtySpawnOptions = {
   startupCommandDelivery?: StartupCommandDelivery
   /** Minimal allowlisted launch ownership preserved by daemon reattach. */
   launchAgent?: TuiAgent
+  /** Main-sanitized recovery facts for a versioned trusted-relay handoff. */
+  archiveContext?: {
+    providerSession?: AgentProviderSessionMetadata
+    orchestrationTaskId?: string
+  }
   /** Orca worktree identity. When present, the local provider scopes shell
    *  history to this worktree so ArrowUp only surfaces local commands. */
   worktreeId?: string
@@ -196,8 +207,8 @@ export type IPtyProvider = {
   getForegroundProcess(id: string): Promise<string | null>
   /** Strong process evidence captured after the caller's command boundary. */
   confirmForegroundProcess?: (id: string) => Promise<string | null>
-  serialize(ids: string[]): Promise<string>
-  revive(state: string): Promise<void>
+  serialize(ids: string[], options?: PtyPersistenceProtocolOptions): Promise<string>
+  revive(state: string, options?: PtyPersistenceProtocolOptions): Promise<PtyReviveResult>
   // Why: deadlineMs bounds the underlying RPC exactly like shutdown's deadlineMs.
   listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]>
   getDefaultShell(): Promise<string>

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1435,6 +1435,8 @@ function createRuntimeTestTerminalArchiveStore() {
         getTerminalArchiveRetentionDays: () => 7,
         isExecutionHostReachable: () => true,
         worktreeExists: () => true,
+        // This fixture models an already-authorized Runtime owner; F8 rejection is covered by Store tests.
+        isTerminalArchiveRequestOwned: () => true,
         isTerminalScrollbackSnapshotLive: () => false
       },
       snapshotSource

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8,6 +8,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdirSync } from 'node:fs'
 import { lstat, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
+import type * as Os from 'node:os'
 import { basename, join, win32 } from 'node:path'
 import { ipcMain } from 'electron'
 import type {
@@ -96,6 +97,7 @@ import {
   getDefaultWorkspaceSession
 } from '../../shared/constants'
 import { advertisedUrlWatcher } from '../ports/advertised-url-watcher'
+import { TerminalArchiveStore } from '../terminal-archive-store'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import { SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV } from '../../shared/setup-agent-sequencing'
 import type {
@@ -111,6 +113,15 @@ import {
   _resetTerminalViewAttributesForTest,
   setTerminalViewAttributes
 } from './terminal-view-attribute-store'
+
+const runtimeTestHome = vi.hoisted(() => `/private/tmp/orca-runtime-test-home-${process.pid}`)
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof Os>()
+  return { ...actual, homedir: () => runtimeTestHome }
+})
+
+mkdirSync(runtimeTestHome, { recursive: true })
 
 const ORIGINAL_PLATFORM = process.platform
 const ORIGINAL_PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -1372,18 +1383,78 @@ function makeHeadlessTerminalLayout(
   }
 }
 
+function makeArchiveReadyWorkspaceSession(session: WorkspaceSessionState): WorkspaceSessionState {
+  const terminalPtyIncarnationsByPaneKey = { ...session.terminalPtyIncarnationsByPaneKey }
+  const terminalLayoutsByTabId = { ...session.terminalLayoutsByTabId }
+  for (const tabs of Object.values(session.tabsByWorktree)) {
+    for (const tab of tabs) {
+      const layout = terminalLayoutsByTabId[tab.id]
+      if (!layout) {
+        continue
+      }
+      const leafIds = new Set(Object.keys(layout.ptyIdsByLeafId ?? {}))
+      const collectLeafIds = (node: TerminalLayoutSnapshot['root']): void => {
+        if (!node) {
+          return
+        }
+        if (node.type === 'leaf') {
+          leafIds.add(node.leafId)
+          return
+        }
+        collectLeafIds(node.first)
+        collectLeafIds(node.second)
+      }
+      collectLeafIds(layout.root)
+      for (const leafId of leafIds) {
+        const paneKey = makePaneKey(tab.id, leafId)
+        terminalPtyIncarnationsByPaneKey[paneKey] ??= `test-incarnation:${paneKey}`
+      }
+      terminalLayoutsByTabId[tab.id] = {
+        ...layout,
+        buffersByLeafId: Object.fromEntries(
+          [...leafIds].map((leafId) => [
+            leafId,
+            layout.buffersByLeafId?.[leafId] ?? `test scrollback for ${tab.id}:${leafId}`
+          ])
+        )
+      }
+    }
+  }
+  return { ...session, terminalLayoutsByTabId, terminalPtyIncarnationsByPaneKey }
+}
+
+function createRuntimeTestTerminalArchiveStore() {
+  let archives = {}
+  return (snapshotSource: ConstructorParameters<typeof TerminalArchiveStore>[1]) =>
+    new TerminalArchiveStore(
+      {
+        getTerminalArchives: () => archives,
+        replaceTerminalArchivesAndFlush: (next) => {
+          archives = next
+        },
+        getTerminalArchiveRetentionDays: () => 7,
+        isExecutionHostReachable: () => true,
+        worktreeExists: () => true,
+        isTerminalScrollbackSnapshotLive: () => false
+      },
+      snapshotSource
+    )
+}
+
 function makeRuntimeStoreWithWorkspaceSession(initialSession: WorkspaceSessionState): {
   runtimeStore: typeof store & {
     getWorkspaceSession: () => WorkspaceSessionState
-    setWorkspaceSession: ReturnType<typeof vi.fn>
+    setWorkspaceSession: (next: WorkspaceSessionState) => void
     persistPtyBinding: ReturnType<typeof vi.fn>
   }
   getSession: () => WorkspaceSessionState
 } {
-  let session = initialSession
+  let session = makeArchiveReadyWorkspaceSession(initialSession)
+  const createTerminalArchiveStore = createRuntimeTestTerminalArchiveStore()
   const runtimeStore = {
     ...store,
     getWorkspaceSession: () => session,
+    createTerminalArchiveStore,
     setWorkspaceSession: vi.fn((next: WorkspaceSessionState) => {
       session = next
     }),
@@ -20981,26 +21052,30 @@ describe('OrcaRuntimeService', () => {
 
   it('closes a headless SSH tab only in its SSH workspace-session partition', async () => {
     const sshPtyId = 'ssh:ssh-1@@remote-pty'
-    const localSession = makeWorkspaceSessionWithHeadlessTerminal()
-    let sshSession = makeWorkspaceSessionWithHeadlessTerminal({
-      tabsByWorktree: {
-        [TEST_WORKTREE_ID]: [
-          {
-            id: 'ssh-host-tab',
-            ptyId: sshPtyId,
-            worktreeId: TEST_WORKTREE_ID,
-            title: 'SSH host terminal',
-            customTitle: null,
-            color: null,
-            sortOrder: 0,
-            createdAt: 1
-          }
-        ]
-      },
-      terminalLayoutsByTabId: {
-        'ssh-host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: sshPtyId })
-      }
-    })
+    const localSession = makeArchiveReadyWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal()
+    )
+    let sshSession = makeArchiveReadyWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'ssh-host-tab',
+              ptyId: sshPtyId,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'SSH host terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'ssh-host-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: sshPtyId })
+        }
+      })
+    )
     const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
     const setWorkspaceSession = vi.fn((session: WorkspaceSessionState, hostId?: string | null) => {
       expect(hostId).toBe('ssh:ssh-1')
@@ -21013,6 +21088,7 @@ describe('OrcaRuntimeService', () => {
       getRepo: (id: string) => (id === TEST_REPO_ID ? remoteRepo : undefined),
       getWorkspaceSession: (hostId?: string | null) =>
         hostId === 'ssh:ssh-1' ? sshSession : localSession,
+      createTerminalArchiveStore: createRuntimeTestTerminalArchiveStore(),
       setWorkspaceSession
     } as never)
     runtime.setPtyController({
@@ -21516,7 +21592,28 @@ describe('OrcaRuntimeService', () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'laptop-created-pty' })
     const kill = vi.fn(() => true)
     const closeTerminal = vi.fn()
-    const runtime = new OrcaRuntimeService(store)
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        tabsByWorktree: {
+          [TEST_WORKTREE_ID]: [
+            {
+              id: 'laptop-tab',
+              ptyId: null,
+              worktreeId: TEST_WORKTREE_ID,
+              title: 'Laptop terminal',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        terminalLayoutsByTabId: {
+          'laptop-tab': makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: undefined })
+        }
+      })
+    )
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
     runtime.setNotifier({ closeTerminal } as never)
     runtime.setPtyController({
       spawn,
@@ -21546,15 +21643,18 @@ describe('OrcaRuntimeService', () => {
       ptyKilled: true
     })
     expect(kill).toHaveBeenCalledWith('laptop-created-pty')
-    expect(closeTerminal).toHaveBeenCalledWith('laptop-tab')
+    expect(closeTerminal).not.toHaveBeenCalled()
   })
 
-  it('waits for renderer acknowledgement before returning a whole-tab close receipt', async () => {
+  it('waits for renderer acknowledgement before returning a whole-tab archive receipt', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal()
     )
-    const acknowledged = makeDeferred()
-    const closeTerminalTab = vi.fn(() => acknowledged.promise)
+    let resolveAcknowledged!: (result: { archiveId: string }) => void
+    const acknowledged = new Promise<{ archiveId: string }>((resolve) => {
+      resolveAcknowledged = resolve
+    })
+    const closeTerminalTab = vi.fn(() => acknowledged)
     const runtime = new OrcaRuntimeService(runtimeStore as never)
     runtime.setNotifier({ closeTerminal: vi.fn(), closeTerminalTab } as never)
     runtime.setPtyController({
@@ -21593,11 +21693,12 @@ describe('OrcaRuntimeService', () => {
     await vi.waitFor(() => expect(closeTerminalTab).toHaveBeenCalledWith('host-tab'))
     expect(settled).toBe(false)
 
-    acknowledged.resolve()
+    resolveAcknowledged({ archiveId: '11111111-1111-4111-8111-111111111111' })
     await expect(pending).resolves.toEqual({
       handle: terminal.handle,
       tabId: 'host-tab',
       closeMode: 'tab',
+      archiveId: '11111111-1111-4111-8111-111111111111',
       ptyKilled: false
     })
   })
@@ -21643,6 +21744,18 @@ describe('OrcaRuntimeService', () => {
       leafId: HEADLESS_LEAF_ID
     })
     await runtime.splitTerminal(terminal.handle, { direction: 'vertical' })
+    runtimeStore.setWorkspaceSession(
+      makeArchiveReadyWorkspaceSession({
+        ...getSession(),
+        terminalLayoutsByTabId: {
+          ...getSession().terminalLayoutsByTabId,
+          'durable-tab': makeHeadlessTerminalLayout({
+            [HEADLESS_LEAF_ID]: 'headless-left',
+            [HEADLESS_SECOND_LEAF_ID]: 'headless-right'
+          })
+        }
+      })
+    )
 
     await runtime.closeTerminalTab(terminal.handle)
 
@@ -23332,7 +23445,7 @@ describe('OrcaRuntimeService', () => {
     expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
   })
 
-  it('retires an SSH-owned surface when a stale renderer acknowledges close after relay recovery', async () => {
+  it('keeps renderer-owned SSH tab retirement on the pane-only exit path after relay recovery', async () => {
     const ptyId = 'ssh:ssh-1@@relay-recovered-pty'
     const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({
@@ -23413,11 +23526,11 @@ describe('OrcaRuntimeService', () => {
       ptyKilled: true
     })
 
-    expect(closeTerminalTab).toHaveBeenCalledWith('host-tab')
-    expect(closeTerminal).toHaveBeenCalledWith('host-tab')
-    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
-    expect(getSession().terminalLayoutsByTabId['host-tab']).toBeUndefined()
-    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([])
+    expect(closeTerminalTab).not.toHaveBeenCalled()
+    expect(closeTerminal).not.toHaveBeenCalled()
+    // Why: a renderer-owned pane exit removes its own last-pane mirror; the runtime must not turn it into a user whole-tab archive.
+    expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toHaveLength(1)
+    expect(getSession().terminalLayoutsByTabId['host-tab']).toBeDefined()
   })
 
   it('keeps the renderer close transaction for an adopted runtime-owned tab', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -951,6 +951,7 @@ export type AccountsSnapshot = {
 type RuntimeStore = {
   getRepos: Store['getRepos']
   getRepo: Store['getRepo']
+  getWorkspaceSessionHostIdForWorktree?: Store['getWorkspaceSessionHostIdForWorktree']
   addRepo: Store['addRepo']
   updateRepo: Store['updateRepo']
   getProjects?: Store['getProjects']
@@ -988,6 +989,7 @@ type RuntimeStore = {
   readTerminalScrollbackSnapshot?: Store['readTerminalScrollbackSnapshot']
   flushOrThrow?: Store['flushOrThrow']
   persistPtyBinding?: Store['persistPtyBinding']
+  persistTerminalArchiveHint?: Store['persistTerminalArchiveHint']
   getSshRemotePtyLeases?: Store['getSshRemotePtyLeases']
   getUI?: Store['getUI']
   updateUI?: Store['updateUI']
@@ -3401,6 +3403,10 @@ export class OrcaRuntimeService {
   }
 
   private getWorkspaceSessionHostIdForWorktree(worktreeId: string): ExecutionHostId {
+    const authoritativeHostId = this.store?.getWorkspaceSessionHostIdForWorktree?.(worktreeId)
+    if (authoritativeHostId) {
+      return authoritativeHostId
+    }
     const repo = this.store?.getRepo?.(getRepoIdFromWorktreeId(worktreeId))
     return repo ? getRepoExecutionHostId(repo) : 'local'
   }
@@ -13502,6 +13508,30 @@ export class OrcaRuntimeService {
   // dispatch still works for handles without a resolvable pane.
   getTerminalPaneKey(handle: string): string | null {
     return this.getPaneKeyForTerminalHandle(handle)
+  }
+
+  persistTerminalOrchestrationTask(handle: string, taskId: string): void {
+    if (
+      !this.store?.persistTerminalArchiveHint ||
+      !taskId ||
+      taskId.length > 512 ||
+      taskId.trim() !== taskId
+    ) {
+      return
+    }
+    const paneKey = this.getTerminalPaneKey(handle)
+    const pty = paneKey ? this.getPtyRecordForPaneKey(paneKey) : null
+    if (!paneKey || !pty) {
+      return
+    }
+    this.store.persistTerminalArchiveHint(
+      {
+        paneKey,
+        hint: { orchestrationTaskId: taskId },
+        source: 'hook'
+      },
+      this.getWorkspaceSessionHostIdForWorktree(pty.worktreeId)
+    )
   }
 
   resolveTerminalPane(paneKey: string, expectedWorktreeId?: string): RuntimeTerminalResolvePane {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -202,7 +202,7 @@ import {
 } from '../../shared/workspace-session-terminal-archive'
 import type { ArchivedTerminalPane } from '../../shared/terminal-archive-types'
 import { makeTerminalArchiveSourcePaneSignature } from '../terminal-archive-source-pane-signature'
-import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import { captureTerminalArchiveBuffer } from '../../shared/terminal-archive-snapshot-capture'
 import type {
   LinearCurrentIssueContextHints,
   LinearAttachResult,
@@ -6235,20 +6235,6 @@ export class OrcaRuntimeService {
     const snapshots = new WeakMap<ArchivedTerminalPane, TerminalArchivePaneSnapshotCapture>()
     for (const [leafId, pane] of Object.entries(captured.panesByLeafId)) {
       const ptyId = session.terminalLayoutsByTabId[tab.parentTabId]?.ptyIdsByLeafId?.[leafId]
-      const fromBuffer = (
-        buffer: string,
-        source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar',
-        truncated = false
-      ): TerminalArchivePaneSnapshotCapture =>
-        buffer.length === 0
-          ? { kind: 'captured-empty' }
-          : {
-              kind: 'captured-bytes',
-              buffer,
-              source,
-              truncated,
-              byteLength: getUtf8ByteLength(buffer)
-            }
       const providerSnapshot = ptyId
         ? await this.serializeProviderTerminalBuffer(ptyId, { scrollbackRows: 50_000 })
         : null
@@ -6257,7 +6243,10 @@ export class OrcaRuntimeService {
       if (providerSnapshot) {
         snapshots.set(
           archivedPane,
-          fromBuffer(providerSnapshot.scrollbackAnsi ?? providerSnapshot.data, 'daemon-headless')
+          captureTerminalArchiveBuffer({
+            buffer: providerSnapshot.scrollbackAnsi ?? providerSnapshot.data,
+            source: 'daemon-headless'
+          })
         )
         continue
       }
@@ -6265,7 +6254,10 @@ export class OrcaRuntimeService {
         ? await this.serializeRendererTerminalBuffer(ptyId, { scrollbackRows: 50_000 })
         : null
       if (rendererSnapshot) {
-        snapshots.set(archivedPane, fromBuffer(rendererSnapshot.data, 'renderer'))
+        snapshots.set(
+          archivedPane,
+          captureTerminalArchiveBuffer({ buffer: rendererSnapshot.data, source: 'renderer' })
+        )
         continue
       }
       const layout = session.terminalLayoutsByTabId[tab.parentTabId]
@@ -6275,7 +6267,10 @@ export class OrcaRuntimeService {
           ? this.store.readTerminalScrollbackSnapshot?.(layout.scrollbackRefsByLeafId[leafId])
           : null)
       if (typeof persisted === 'string') {
-        snapshots.set(archivedPane, fromBuffer(persisted, 'session-sidecar'))
+        snapshots.set(
+          archivedPane,
+          captureTerminalArchiveBuffer({ buffer: persisted, source: 'session-sidecar' })
+        )
         continue
       }
       const relayTail = ptyId
@@ -6283,7 +6278,13 @@ export class OrcaRuntimeService {
         : null
       snapshots.set(
         archivedPane,
-        relayTail ? fromBuffer(relayTail.data, 'relay-tail', true) : { kind: 'unavailable' }
+        relayTail
+          ? captureTerminalArchiveBuffer({
+              buffer: relayTail.data,
+              source: 'relay-tail',
+              truncated: true
+            })
+          : { kind: 'unavailable' }
       )
     }
     const operationId = `user-close:${tab.parentTabId}:${makeTerminalArchiveSourcePaneSignature(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -196,6 +196,13 @@ import {
 } from './runtime-ssh-relay-recovery-generations'
 import { RuntimeOperationGenerations } from './runtime-operation-generations'
 import { closeTerminalTabInWorkspaceSession } from '../../shared/workspace-session-terminal-tab-close'
+import {
+  captureTerminalArchiveTab,
+  type TerminalArchivePaneSnapshotCapture
+} from '../../shared/workspace-session-terminal-archive'
+import type { ArchivedTerminalPane } from '../../shared/terminal-archive-types'
+import { makeTerminalArchiveSourcePaneSignature } from '../terminal-archive-source-pane-signature'
+import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
 import type {
   LinearCurrentIssueContextHints,
   LinearAttachResult,
@@ -977,6 +984,8 @@ type RuntimeStore = {
   getGitHubCache: Store['getGitHubCache']
   getWorkspaceSession?: Store['getWorkspaceSession']
   setWorkspaceSession?: Store['setWorkspaceSession']
+  createTerminalArchiveStore?: Store['createTerminalArchiveStore']
+  readTerminalScrollbackSnapshot?: Store['readTerminalScrollbackSnapshot']
   flushOrThrow?: Store['flushOrThrow']
   persistPtyBinding?: Store['persistPtyBinding']
   getSshRemotePtyLeases?: Store['getSshRemotePtyLeases']
@@ -1631,7 +1640,7 @@ type RuntimeNotifier = {
     content: string
   ): Promise<RuntimeMarkdownSaveTabResult>
   closeTerminal(tabId: string, paneRuntimeId?: number): void
-  closeTerminalTab?(tabId: string): Promise<void>
+  closeTerminalTab?(tabId: string): Promise<{ archiveId: string } | void>
   sleepWorktree(worktreeId: string): void
   // Why: a phone opening a worktree wakes its slept agents by asking the host
   // renderer to run its own navigation-free wake (experimental agent sleep);
@@ -2422,6 +2431,7 @@ export class OrcaRuntimeService {
     Promise<RuntimeMobileSessionCreateTerminalResult>
   >()
   private readonly terminalCreateIdempotency = new RemoteRuntimeTerminalCreateIdempotency()
+  private headlessTerminalArchiveByOperationId = new Map<string, Promise<string>>()
   // Why: concurrent clients sleeping one host workspace must share one physical teardown.
   private terminalSleepByWorktreeId = new Map<string, Promise<RuntimeWorktreeTerminalSleepResult>>()
   private terminalMutationTailByWorktreeId = new Map<string, Promise<void>>()
@@ -5998,17 +6008,21 @@ export class OrcaRuntimeService {
       // the relay when no renderer owns the parent: an adopted tab needs the
       // renderer's live pin guard and durable close transaction.
       if (closingWholeParent && !this.tabs.has(tab.parentTabId)) {
-        this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab, {
+        const archiveId =
+          options.reason === undefined || options.reason === 'user'
+            ? await this.archiveHeadlessMobileTerminalTab(worktreeId, tab)
+            : undefined
+        await this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab, {
           killPtys: options.reason === undefined || options.reason === 'user'
         })
         this.notifyRendererOfHeadlessTerminalClose(tab.parentTabId)
         this.store?.flushOrThrow?.()
-        return { closed: true }
+        return { closed: true, ...(archiveId ? { archiveId } : {}) }
       }
       if (closingWholeParent && this.notifier?.closeTerminalTab) {
         // Why: whole-tab close is a lifecycle transaction. The renderer reply
         // arrives only after canonical retirement and a forced session flush.
-        await this.notifier.closeTerminalTab(tab.parentTabId)
+        const closeResult = await this.notifier.closeTerminalTab(tab.parentTabId)
         const remainingSnapshot = this.mobileSessionTabsByWorktree.get(worktreeId)
         const remainingTab = remainingSnapshot?.tabs.find(
           (candidate): candidate is RuntimeMobileSessionTerminalTab =>
@@ -6020,24 +6034,31 @@ export class OrcaRuntimeService {
           this.isRuntimeOwnedHeadlessMobileTab(worktreeId, remainingTab)
         ) {
           // Why: after relay recovery the renderer can acknowledge a tab it no longer mirrors; the HUB must still retire its SSH-owned surface.
-          this.closeHeadlessMobileTerminalTab(worktreeId, remainingSnapshot, remainingTab)
+          const archiveId = await this.archiveHeadlessMobileTerminalTab(worktreeId, remainingTab)
+          await this.closeHeadlessMobileTerminalTab(worktreeId, remainingSnapshot, remainingTab)
           this.notifyRendererOfHeadlessTerminalClose(tab.parentTabId)
           this.store?.flushOrThrow?.()
+          return { closed: true, ...(archiveId ? { archiveId } : {}) }
         }
-        return { closed: true }
+        return {
+          closed: true,
+          ...(closeResult?.archiveId ? { archiveId: closeResult.archiveId } : {})
+        }
       }
       // Why: notifier implementations without the acknowledged relay may expose
       // only raw pane close. Runtime-owned parents still need de-persist + kill.
       if (closingWholeParent && this.isRuntimeOwnedHeadlessMobileTab(worktreeId, tab)) {
-        this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
+        const archiveId = await this.archiveHeadlessMobileTerminalTab(worktreeId, tab)
+        await this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
         this.notifyRendererOfHeadlessTerminalClose(tab.parentTabId)
         this.store?.flushOrThrow?.()
-        return { closed: true }
+        return { closed: true, ...(archiveId ? { archiveId } : {}) }
       }
       if (!this.notifier?.closeTerminal) {
-        this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
+        const archiveId = await this.archiveHeadlessMobileTerminalTab(worktreeId, tab)
+        await this.closeHeadlessMobileTerminalTab(worktreeId, snapshot!, tab)
         this.store?.flushOrThrow?.()
-        return { closed: true }
+        return { closed: true, ...(archiveId ? { archiveId } : {}) }
       }
       if (tab.id === tabId) {
         const pty = this.findPtyForMobileTerminalTab(worktreeId, tab)
@@ -6188,18 +6209,138 @@ export class OrcaRuntimeService {
     this.emitMobileSessionTabsSnapshot(nextSnapshot)
   }
 
-  private closeHeadlessMobileTerminalTab(
+  private async archiveHeadlessMobileTerminalTab(
+    worktreeId: string,
+    tab: RuntimeMobileSessionTerminalTab
+  ): Promise<string> {
+    if (!this.store?.getWorkspaceSession || !this.store.createTerminalArchiveStore) {
+      throw new Error('terminal_archive_unavailable')
+    }
+    const executionHostId = this.getWorkspaceSessionHostIdForWorktree(worktreeId)
+    const session = this.store.getWorkspaceSession(executionHostId)
+    const captured = captureTerminalArchiveTab({
+      session,
+      worktreeId,
+      tabId: tab.parentTabId
+    })
+    if (!captured) {
+      throw new Error('terminal_archive_capture_unavailable')
+    }
+    const snapshots = new WeakMap<ArchivedTerminalPane, TerminalArchivePaneSnapshotCapture>()
+    for (const [leafId, pane] of Object.entries(captured.panesByLeafId)) {
+      const ptyId = session.terminalLayoutsByTabId[tab.parentTabId]?.ptyIdsByLeafId?.[leafId]
+      const fromBuffer = (
+        buffer: string,
+        source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar',
+        truncated = false
+      ): TerminalArchivePaneSnapshotCapture =>
+        buffer.length === 0
+          ? { kind: 'captured-empty' }
+          : {
+              kind: 'captured-bytes',
+              buffer,
+              source,
+              truncated,
+              byteLength: getUtf8ByteLength(buffer)
+            }
+      const providerSnapshot = ptyId
+        ? await this.serializeProviderTerminalBuffer(ptyId, { scrollbackRows: 50_000 })
+        : null
+      const archivedPane = providerSnapshot?.cwd ? { ...pane, cwd: providerSnapshot.cwd } : pane
+      captured.panesByLeafId[leafId] = archivedPane
+      if (providerSnapshot) {
+        snapshots.set(
+          archivedPane,
+          fromBuffer(providerSnapshot.scrollbackAnsi ?? providerSnapshot.data, 'daemon-headless')
+        )
+        continue
+      }
+      const rendererSnapshot = ptyId
+        ? await this.serializeRendererTerminalBuffer(ptyId, { scrollbackRows: 50_000 })
+        : null
+      if (rendererSnapshot) {
+        snapshots.set(archivedPane, fromBuffer(rendererSnapshot.data, 'renderer'))
+        continue
+      }
+      const layout = session.terminalLayoutsByTabId[tab.parentTabId]
+      const persisted =
+        layout?.buffersByLeafId?.[leafId] ??
+        (layout?.scrollbackRefsByLeafId?.[leafId]
+          ? this.store.readTerminalScrollbackSnapshot?.(layout.scrollbackRefsByLeafId[leafId])
+          : null)
+      if (typeof persisted === 'string') {
+        snapshots.set(archivedPane, fromBuffer(persisted, 'session-sidecar'))
+        continue
+      }
+      const relayTail = ptyId
+        ? await this.serializeHeadlessTerminalBuffer(ptyId, { scrollbackRows: 50_000 })
+        : null
+      snapshots.set(
+        archivedPane,
+        relayTail ? fromBuffer(relayTail.data, 'relay-tail', true) : { kind: 'unavailable' }
+      )
+    }
+    const operationId = `user-close:${tab.parentTabId}:${makeTerminalArchiveSourcePaneSignature(
+      captured.panesByLeafId,
+      captured.sourcePaneIdentityByLeafId
+    )}`
+    const inFlight = this.headlessTerminalArchiveByOperationId.get(operationId)
+    if (inFlight) {
+      return await inFlight
+    }
+    const archiveStore = this.store.createTerminalArchiveStore({
+      capture: async (pane) => snapshots.get(pane) ?? { kind: 'unavailable' }
+    })
+    let archivePromise: Promise<string>
+    archivePromise = archiveStore
+      .archiveTerminalTab({
+        operationId,
+        sourceTabId: tab.parentTabId,
+        executionHostId,
+        worktreeId,
+        title: captured.tab.customTitle || captured.tab.title,
+        ...(captured.tab.defaultTitle ? { defaultTitle: captured.tab.defaultTitle } : {}),
+        ...(captured.tab.color !== undefined ? { color: captured.tab.color } : {}),
+        layout: captured.layout,
+        panesByLeafId: captured.panesByLeafId,
+        sourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId,
+        reason: 'user-close',
+        createdAt: captured.tab.createdAt,
+        capturedAt: Date.now()
+      })
+      .then((archive) => archive.id)
+      .finally(() => {
+        archiveStore.dispose()
+        if (this.headlessTerminalArchiveByOperationId.get(operationId) === archivePromise) {
+          this.headlessTerminalArchiveByOperationId.delete(operationId)
+        }
+      })
+    this.headlessTerminalArchiveByOperationId.set(operationId, archivePromise)
+    return await archivePromise
+  }
+
+  private async closeHeadlessMobileTerminalTab(
     worktreeId: string,
     snapshot: RuntimeMobileSessionTabsSnapshot,
     tab: RuntimeMobileSessionTerminalTab,
     options: { killPtys?: boolean } = {}
-  ): void {
+  ): Promise<void> {
     const closedParentTabId = tab.parentTabId
-    const projectedPtyIds = this.removePersistedHeadlessTerminalTab(worktreeId, closedParentTabId)
+    const session = this.getWorkspaceSessionForWorktree(worktreeId)
+    if (!session) {
+      throw new Error('workspace_session_unavailable')
+    }
+    const projected = closeTerminalTabInWorkspaceSession(session, worktreeId, closedParentTabId)
+    if (projected.pinned) {
+      throw new Error('terminal_tab_pinned')
+    }
+    if (!projected.closed) {
+      throw new Error('tab_not_found')
+    }
     // Why: local provider ids can be reused after restart, so a dormant
     // persisted id is not kill authority. SSH relay ids remain durable exact
     // identities even before pane metadata reconnects.
-    const ptyIdsToKill = new Set(projectedPtyIds.filter((ptyId) => parseAppSshPtyId(ptyId)))
+    const ptyIdsToKill = new Set(projected.ptyIdsToKill.filter((ptyId) => parseAppSshPtyId(ptyId)))
     for (const candidate of snapshot.tabs) {
       if (candidate.type !== 'terminal' || candidate.parentTabId !== closedParentTabId) {
         continue
@@ -6221,9 +6362,16 @@ export class OrcaRuntimeService {
     }
     if (options.killPtys !== false) {
       for (const ptyId of ptyIdsToKill) {
-        this.ptyController?.kill(ptyId)
+        const stopped = this.ptyController?.stopAndWait
+          ? await this.ptyController.stopAndWait(ptyId)
+          : Boolean(this.ptyController?.kill(ptyId))
+        if (!stopped && this.ptyController?.hasPty?.(ptyId) !== false) {
+          throw new Error('terminal_retirement_failed')
+        }
       }
     }
+    // Why: persistence must retain the visible owner until every exact provider teardown succeeded.
+    this.removePersistedHeadlessTerminalTab(worktreeId, closedParentTabId)
     const nextTabs = snapshot.tabs.filter((candidate) => {
       if (candidate.type !== 'terminal' || candidate.parentTabId !== closedParentTabId) {
         return true
@@ -22912,7 +23060,9 @@ export class OrcaRuntimeService {
         if (surface) {
           // Why: paired viewers keep ended streams mounted until the HUB publishes removal, so explicit close uses the durable host-tab transaction instead of viewer-local exit handling.
           try {
-            await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId)
+            await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId, {
+              reason: 'pane-only'
+            })
           } catch (error) {
             if (!(error instanceof Error) || error.message !== 'workspace_session_unavailable') {
               throw error
@@ -22948,15 +23098,31 @@ export class OrcaRuntimeService {
       }
       // Why: a handle-addressed CLI/automation close is an explicit intent, so
       // it must stay destructive under the non-user close adjudication gate.
-      await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId, { reason: 'user' })
+      const closeResult = await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId, {
+        reason: 'user'
+      })
       this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
-      return { handle, tabId, closeMode: 'tab', ptyKilled: false }
+      return {
+        handle,
+        tabId,
+        closeMode: 'tab',
+        ptyKilled: false,
+        ...(closeResult.archiveId ? { archiveId: closeResult.archiveId } : {})
+      }
     }
     this.assertGraphReady()
     const { leaf } = this.getLiveLeafForHandle(handle)
-    await this.closeMobileSessionTab(`id:${leaf.worktreeId}`, leaf.tabId, { reason: 'user' })
+    const closeResult = await this.closeMobileSessionTab(`id:${leaf.worktreeId}`, leaf.tabId, {
+      reason: 'user'
+    })
     this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
-    return { handle, tabId: leaf.tabId, closeMode: 'tab', ptyKilled: false }
+    return {
+      handle,
+      tabId: leaf.tabId,
+      closeMode: 'tab',
+      ptyKilled: false,
+      ...(closeResult.archiveId ? { archiveId: closeResult.archiveId } : {})
+    }
   }
 
   async splitTerminal(

--- a/src/main/runtime/orchestration/coordinator.test.ts
+++ b/src/main/runtime/orchestration/coordinator.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OrchestrationDb } from './db'
 import { reconcileLifecycleMessage } from './lifecycle-reconciliation'
 import {
@@ -177,6 +177,31 @@ describe('Coordinator', () => {
 
     expect(db.getDispatchContext(task.id)?.assignee_pane_key).toBe('tab_a:leaf_a')
 
+    insertWorkerDone(db, { taskId: task.id })
+    await runPromise
+  })
+
+  it('persists dispatch task evidence before the worker can emit a hook', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = createMockRuntime()
+    const persistTaskEvidence = vi.fn()
+    runtime.terminals = [{ handle: 'term_a', worktreeId: 'wt1', connected: true, writable: true }]
+    const withDurableEvidence = Object.assign(runtime, {
+      persistTerminalOrchestrationTask: persistTaskEvidence
+    })
+    const task = db.createTask({ spec: 'implement feature' })
+    const coordinator = new Coordinator(db, withDurableEvidence, {
+      spec: 'build it',
+      coordinatorHandle: 'coord',
+      pollIntervalMs: 50
+    })
+
+    const runPromise = coordinator.run()
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100)
+    })
+
+    expect(persistTaskEvidence).toHaveBeenCalledWith('term_a', task.id)
     insertWorkerDone(db, { taskId: task.id })
     await runPromise
   })

--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -34,6 +34,8 @@ export type CoordinatorRuntime = {
   } | null>
   // Why: optional so lightweight runtime fakes keep compiling; when present, dispatch records the assignee's remint-stable pane identity.
   getTerminalPaneKey?(handle: string): string | null
+  // Why: durable task evidence must exist before the worker can emit its first hook or die.
+  persistTerminalOrchestrationTask?(handle: string, taskId: string): void
   // Why: Windows can host native and WSL workers at once, so the worker pane (not the coordinator) picks the packaged CLI name.
   getTerminalOrchestrationCliCommand?(handle: string): 'orca' | 'orca-ide'
 }
@@ -456,6 +458,11 @@ export class Coordinator {
       targetHandle,
       this.runtime.getTerminalPaneKey?.(targetHandle) ?? undefined
     )
+    try {
+      this.runtime.persistTerminalOrchestrationTask?.(targetHandle, task.id)
+    } catch (error) {
+      this.opts.onLog(`Failed to persist terminal task evidence for ${task.id}: ${error}`)
+    }
 
     // Why: dispatched agents use orca-dev in dev mode to reach the dev runtime's socket, not production (Section 6.4).
     const preamble = buildDispatchPreamble({

--- a/src/main/ssh/ssh-archived-exit-recovery.ts
+++ b/src/main/ssh/ssh-archived-exit-recovery.ts
@@ -1,0 +1,11 @@
+const archivedExitRecoveryByPtyId = new Map<string, string>()
+
+export function beginArchivedSshPtyExitRecovery(ptyId: string, archiveId: string): void {
+  archivedExitRecoveryByPtyId.set(ptyId, archiveId)
+}
+
+export function takeArchivedSshPtyExitRecovery(ptyId: string): string | undefined {
+  const archiveId = archivedExitRecoveryByPtyId.get(ptyId)
+  archivedExitRecoveryByPtyId.delete(ptyId)
+  return archiveId
+}

--- a/src/main/ssh/ssh-relay-session-lost-worker.test.ts
+++ b/src/main/ssh/ssh-relay-session-lost-worker.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SshRelaySession } from './ssh-relay-session'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
+import type { WorkspaceSessionState } from '../../shared/types'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+const { muxRequestMock, archiveLostTerminalWorkerMock } = vi.hoisted(() => ({
+  muxRequestMock: vi.fn(),
+  archiveLostTerminalWorkerMock: vi.fn()
+}))
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
+vi.mock('./ssh-relay-deploy-helpers', () => ({ execCommand: vi.fn().mockResolvedValue('') }))
+vi.mock('../terminal-lost-worker-archive', () => ({
+  archiveLostTerminalWorker: archiveLostTerminalWorkerMock
+}))
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    notify = vi.fn()
+    request = muxRequestMock
+    onNotification = vi.fn().mockReturnValue(() => {})
+    onRequest = vi.fn().mockReturnValue(() => {})
+    onDispose = vi.fn().mockReturnValue(() => {})
+    dispose = vi.fn()
+    isDisposed = vi.fn().mockReturnValue(false)
+  }
+}))
+vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('not found'),
+  isSshPtyIdentityMismatchError: (err: unknown) =>
+    (err instanceof Error ? err.message : String(err)).includes('identity mismatch'),
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-git-provider', () => ({
+  SshGitProvider: class MockSshGitProvider {}
+}))
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn().mockReturnValue({
+    dispose: vi.fn(),
+    attach: vi.fn().mockResolvedValue(undefined),
+    attachForReconnect: vi.fn().mockResolvedValue({})
+  }),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  isCurrentPtyExit: vi.fn(() => true)
+}))
+vi.mock('../ipc/pty-renderer-delivery-router', () => ({
+  routeExternalPtyData: vi.fn(),
+  routeExternalPtyReplay: vi.fn(),
+  routeExternalPtyExit: vi.fn()
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+const { getSshPtyProvider, getPtyIdsForConnection } = await import('../ipc/pty')
+const { routeExternalPtyExit } = await import('../ipc/pty-renderer-delivery-router')
+
+const REVIVE_WORKTREE_ID = 'repo-1::/worktree'
+const REVIVE_TAB_ID = 'tab-1'
+const REVIVE_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const REVIVE_PANE_KEY = `${REVIVE_TAB_ID}:${REVIVE_LEAF_ID}`
+const RELAY_LOST_WORKER: RelayPtyLostEntry = {
+  id: 'ssh:target-1@@pty-lost',
+  kind: 'recognized-worker',
+  reason: 'process-not-running',
+  pid: 42,
+  cols: 80,
+  rows: 24,
+  cwd: '/repo',
+  worktreeId: REVIVE_WORKTREE_ID,
+  tabId: REVIVE_TAB_ID,
+  paneKey: REVIVE_PANE_KEY
+}
+
+function workspaceSessionForRelayLostWorker(workerHint = false): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: {
+      [REVIVE_WORKTREE_ID]: [
+        {
+          id: REVIVE_TAB_ID,
+          worktreeId: REVIVE_WORKTREE_ID,
+          title: 'Worker',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 10,
+          ptyId: RELAY_LOST_WORKER.id
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      [REVIVE_TAB_ID]: {
+        root: { type: 'leaf', leafId: REVIVE_LEAF_ID },
+        activeLeafId: REVIVE_LEAF_ID,
+        expandedLeafId: null
+      }
+    },
+    terminalPtyIncarnationsByPaneKey: { [REVIVE_PANE_KEY]: 'incarnation-1' },
+    terminalArchiveHintsByPaneKey: {
+      [REVIVE_PANE_KEY]: workerHint ? { launchAgent: 'codex', startedAt: 10 } : { cwd: '/repo' }
+    }
+  }
+}
+
+function configureStagedPtyRevive(args: {
+  serialize: ReturnType<typeof vi.fn>
+  revive: ReturnType<typeof vi.fn>
+  reattachPtyIds?: string[]
+}): { attachForReconnect: ReturnType<typeof vi.fn> } {
+  const attachForReconnect = vi.fn().mockResolvedValue({})
+  vi.mocked(getSshPtyProvider)
+    .mockReset()
+    .mockReturnValueOnce({
+      serialize: args.serialize,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    .mockReturnValue({
+      revive: args.revive,
+      attachForReconnect,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+  vi.mocked(getPtyIdsForConnection).mockReturnValueOnce(['ssh:target-1@@pty-lost'])
+  vi.mocked(getPtyIdsForConnection).mockReturnValue(args.reattachPtyIds ?? [])
+  return { attachForReconnect }
+}
+
+async function establishRelaySession() {
+  const deps = createMockDeps()
+  const session = new SshRelaySession(
+    'target-1',
+    deps.getMainWindow,
+    deps.mockStore,
+    deps.mockPortForward
+  )
+  await session.establish(deps.mockConn)
+  return { ...deps, session }
+}
+
+describe('SshRelaySession lost-worker archive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
+    muxRequestMock.mockReset()
+    muxRequestMock.mockResolvedValue([])
+    archiveLostTerminalWorkerMock.mockReset()
+    vi.mocked(getSshPtyProvider)
+      .mockReset()
+      .mockReturnValue({
+        dispose: vi.fn(),
+        attach: vi.fn().mockResolvedValue(undefined),
+        attachForReconnect: vi.fn().mockResolvedValue({})
+      } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockDeploySuccess()
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+  })
+
+  it.each([
+    'typed recognized',
+    'typed unclassified worker hint',
+    'typed unclassified',
+    'legacy',
+    'malformed typed',
+    'serialize failure',
+    'archive failure'
+  ])('keeps staged PTY revive %s on its compatible recovery path', async (state) => {
+    const { mockConn, mockStore, session } = await establishRelaySession()
+    vi.clearAllMocks()
+    mockDeploySuccess()
+    const serialize = vi.fn().mockResolvedValue('staged-pty-state')
+    const revive = vi.fn()
+    const lost = state.startsWith('typed unclassified')
+      ? { ...RELAY_LOST_WORKER, kind: 'unclassified' as const }
+      : RELAY_LOST_WORKER
+    if (state === 'serialize failure') {
+      serialize.mockRejectedValue(new Error('old relay stopped before serialize reply'))
+    } else if (state === 'malformed typed') {
+      revive.mockRejectedValue(new Error('typed outcome validation failed'))
+    } else if (state === 'legacy') {
+      revive.mockResolvedValue({
+        mode: 'legacy',
+        diagnosticCode: 'pty-revive-outcome-unavailable',
+        outcome: { outcomeVersion: 1, revived: [], lost: [RELAY_LOST_WORKER], diagnostics: [] }
+      })
+    } else {
+      revive.mockResolvedValue({
+        mode: 'typed',
+        outcome: { outcomeVersion: 1, revived: [], lost: [lost], diagnostics: [] }
+      })
+    }
+    archiveLostTerminalWorkerMock.mockResolvedValue(
+      state === 'archive failure'
+        ? { kind: 'error', code: 'durability-failed' }
+        : {
+            kind: 'archived',
+            archive: {},
+            operationId: 'relay-worker-lost:tab-1',
+            ptyIdsToKill: [RELAY_LOST_WORKER.id]
+          }
+    )
+    mockStore.getWorkspaceSession = vi
+      .fn()
+      .mockReturnValue(
+        workspaceSessionForRelayLostWorker(state === 'typed unclassified worker hint')
+      )
+    const archived = state === 'typed recognized' || state === 'typed unclassified worker hint'
+    const fallbackPtyIds = archived ? [] : ['ssh:target-1@@pty-fallback']
+    const { attachForReconnect } = configureStagedPtyRevive({
+      serialize,
+      revive,
+      reattachPtyIds: fallbackPtyIds
+    })
+
+    await session.reconnect(mockConn)
+
+    expect(serialize).toHaveBeenCalledWith(['pty-lost'], { formatVersion: 2 })
+    expect(revive).toHaveBeenCalledTimes(state === 'serialize failure' ? 0 : 1)
+    expect(archiveLostTerminalWorkerMock).toHaveBeenCalledTimes(
+      archived || state === 'archive failure' ? 1 : 0
+    )
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledTimes(
+      archived ? 1 : fallbackPtyIds.length
+    )
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
+      'target-1',
+      archived ? 'pty-lost' : 'pty-fallback',
+      archived ? 'expired' : 'attached'
+    )
+    expect(routeExternalPtyExit).toHaveBeenCalledTimes(archived ? 1 : 0)
+    expect(session.getState()).toBe('ready')
+    if (state === 'typed unclassified') {
+      expect(mockStore.getWorkspaceSession).toHaveBeenCalledWith('ssh:target-1')
+    }
+    if (state === 'typed unclassified worker hint') {
+      expect(archiveLostTerminalWorkerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          candidate: expect.objectContaining({
+            relayEvidence: expect.objectContaining({ kind: 'unclassified' })
+          })
+        })
+      )
+    }
+    if (fallbackPtyIds.length > 0) {
+      expect(attachForReconnect).toHaveBeenCalledWith('pty-fallback')
+    }
+    if (state === 'archive failure') {
+      expect(archiveLostTerminalWorkerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          candidate: expect.objectContaining({ relayEvidence: RELAY_LOST_WORKER })
+        })
+      )
+      expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
+        'target-1',
+        'pty-lost',
+        'expired'
+      )
+    }
+  })
+})

--- a/src/main/ssh/ssh-relay-session-lost-worker.test.ts
+++ b/src/main/ssh/ssh-relay-session-lost-worker.test.ts
@@ -220,7 +220,7 @@ describe('SshRelaySession lost-worker archive', () => {
         ? { kind: 'error', code: 'durability-failed' }
         : {
             kind: 'archived',
-            archive: {},
+            archive: { id: 'archive-1' },
             operationId: 'relay-worker-lost:tab-1',
             ptyIdsToKill: [RELAY_LOST_WORKER.id]
           }
@@ -253,7 +253,15 @@ describe('SshRelaySession lost-worker archive', () => {
       archived ? 'pty-lost' : 'pty-fallback',
       archived ? 'expired' : 'attached'
     )
-    expect(routeExternalPtyExit).toHaveBeenCalledTimes(archived ? 1 : 0)
+    if (archived) {
+      expect(routeExternalPtyExit).toHaveBeenCalledWith({
+        id: RELAY_LOST_WORKER.id,
+        code: -1,
+        lostWorkerRecovery: { kind: 'archived', archiveId: 'archive-1' }
+      })
+    } else {
+      expect(routeExternalPtyExit).not.toHaveBeenCalled()
+    }
     expect(session.getState()).toBe('ready')
     if (state === 'typed unclassified') {
       expect(mockStore.getWorkspaceSession).toHaveBeenCalledWith('ssh:target-1')

--- a/src/main/ssh/ssh-relay-session-lost-worker.test.ts
+++ b/src/main/ssh/ssh-relay-session-lost-worker.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SshRelaySession } from './ssh-relay-session'
 import { getDefaultWorkspaceSession } from '../../shared/constants'
 import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
+import { decodeRelayStagedPtySnapshots } from '../../shared/relay-staged-pty-snapshots'
 import type { WorkspaceSessionState } from '../../shared/types'
 import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
 
@@ -134,8 +135,9 @@ function configureStagedPtyRevive(args: {
   serialize: ReturnType<typeof vi.fn>
   revive: ReturnType<typeof vi.fn>
   reattachPtyIds?: string[]
-}): { attachForReconnect: ReturnType<typeof vi.fn> } {
+}): { attachForReconnect: ReturnType<typeof vi.fn>; shutdown: ReturnType<typeof vi.fn> } {
   const attachForReconnect = vi.fn().mockResolvedValue({})
+  const shutdown = vi.fn().mockResolvedValue(undefined)
   vi.mocked(getSshPtyProvider)
     .mockReset()
     .mockReturnValueOnce({
@@ -144,13 +146,13 @@ function configureStagedPtyRevive(args: {
     } as unknown as ReturnType<typeof getSshPtyProvider>)
     .mockReturnValue({
       revive: args.revive,
-      shutdown: vi.fn().mockResolvedValue(undefined),
+      shutdown,
       attachForReconnect,
       dispose: vi.fn()
     } as unknown as ReturnType<typeof getSshPtyProvider>)
   vi.mocked(getPtyIdsForConnection).mockReturnValueOnce(['ssh:target-1@@pty-lost'])
   vi.mocked(getPtyIdsForConnection).mockReturnValue(args.reattachPtyIds ?? [])
-  return { attachForReconnect }
+  return { attachForReconnect, shutdown }
 }
 
 async function establishRelaySession() {
@@ -163,6 +165,24 @@ async function establishRelaySession() {
   )
   await session.establish(deps.mockConn)
   return { ...deps, session }
+}
+
+type SshRelaySessionArchiveInternals = {
+  archiveRelayLostWorker: (args: {
+    lost: RelayPtyLostEntry
+    session: WorkspaceSessionState
+    stagedSnapshots: ReturnType<typeof decodeRelayStagedPtySnapshots>
+  }) => Promise<void>
+  archiveRelayLostWorkerGroups: (
+    lost: readonly RelayPtyLostEntry[],
+    stagedSnapshots: ReturnType<typeof decodeRelayStagedPtySnapshots>
+  ) => Promise<void>
+  reattachKnownPtys: (shouldContinue: () => boolean) => Promise<void>
+  retryTerminationPendingPtys: () => Promise<void>
+}
+
+function archiveInternals(session: SshRelaySession): SshRelaySessionArchiveInternals {
+  return session as unknown as SshRelaySessionArchiveInternals
 }
 
 describe('SshRelaySession lost-worker archive', () => {
@@ -223,7 +243,8 @@ describe('SshRelaySession lost-worker archive', () => {
             kind: 'archived',
             archive: { id: 'archive-1' },
             operationId: 'relay-worker-lost:tab-1',
-            ptyIdsToKill: [RELAY_LOST_WORKER.id]
+            ptyIdsToKill: [RELAY_LOST_WORKER.id],
+            archiveCompletionOwner: true
           }
     )
     mockStore.getWorkspaceSession = vi
@@ -291,5 +312,112 @@ describe('SshRelaySession lost-worker archive', () => {
         'expired'
       )
     }
+  })
+
+  it('selects worker evidence when an ordinary loss appears first in its tab group', async () => {
+    const { mockStore, session } = await establishRelaySession()
+    const persistedSession = workspaceSessionForRelayLostWorker()
+    mockStore.getWorkspaceSession = vi.fn().mockReturnValue(persistedSession)
+    archiveLostTerminalWorkerMock.mockResolvedValue({ kind: 'error', code: 'capture-unavailable' })
+
+    await archiveInternals(session).archiveRelayLostWorkerGroups(
+      [
+        { ...RELAY_LOST_WORKER, id: 'ssh:target-1@@ordinary-first', kind: 'ordinary-shell' },
+        RELAY_LOST_WORKER
+      ],
+      decodeRelayStagedPtySnapshots(JSON.stringify({ schemaVersion: 2, entries: [] }))
+    )
+
+    expect(archiveLostTerminalWorkerMock).toHaveBeenCalledOnce()
+    expect(archiveLostTerminalWorkerMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidate: expect.objectContaining({ relayEvidence: RELAY_LOST_WORKER })
+      })
+    )
+  })
+
+  it('does not repeat physical shutdown when this reconnect joined an in-flight archive', async () => {
+    const { mockConn, mockStore, session } = await establishRelaySession()
+    const serialize = vi.fn().mockResolvedValue('staged-pty-state')
+    const revive = vi.fn().mockResolvedValue({
+      mode: 'typed',
+      outcome: { outcomeVersion: 1, revived: [], lost: [RELAY_LOST_WORKER], diagnostics: [] }
+    })
+    archiveLostTerminalWorkerMock.mockResolvedValue({
+      kind: 'archived',
+      archive: { id: 'archive-1' },
+      operationId: 'relay-worker-lost:tab-1',
+      ptyIdsToKill: [RELAY_LOST_WORKER.id],
+      archiveCompletionOwner: false
+    })
+    mockStore.getWorkspaceSession = vi.fn().mockReturnValue(workspaceSessionForRelayLostWorker())
+    const { shutdown } = configureStagedPtyRevive({ serialize, revive })
+
+    await session.reconnect(mockConn)
+
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(routeExternalPtyExit).not.toHaveBeenCalled()
+  })
+
+  it('fails closed with the legacy-envelope diagnostic instead of fabricating a tail', async () => {
+    const { mockStore, session } = await establishRelaySession()
+    const persistedSession = workspaceSessionForRelayLostWorker()
+    mockStore.getWorkspaceSession = vi.fn().mockReturnValue(persistedSession)
+    const diagnostic = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    archiveLostTerminalWorkerMock.mockImplementation(async ({ snapshotSource }) => {
+      await expect(
+        snapshotSource.capture({ archivedLeafId: REVIVE_LEAF_ID, cwd: '/repo' })
+      ).resolves.toEqual({ kind: 'unavailable' })
+      return { kind: 'error', code: 'capture-unavailable' }
+    })
+
+    await archiveInternals(session).archiveRelayLostWorker({
+      lost: RELAY_LOST_WORKER,
+      session: persistedSession,
+      stagedSnapshots: decodeRelayStagedPtySnapshots(JSON.stringify([]))
+    })
+
+    expect(diagnostic).toHaveBeenCalledWith(
+      '[ssh-relay-session] lost-worker archive diagnostic',
+      expect.objectContaining({ stage: 'staged-state-legacy', paneKey: REVIVE_PANE_KEY })
+    )
+    diagnostic.mockRestore()
+  })
+
+  it('keeps a failed physical shutdown pending, excludes it from reattach, and retries it', async () => {
+    const { mockStore, session } = await establishRelaySession()
+    const shutdown = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('remote unavailable'))
+      .mockResolvedValueOnce(undefined)
+    const attachForReconnect = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      shutdown,
+      attachForReconnect,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      {
+        targetId: 'target-1',
+        ptyId: 'pty-lost',
+        state: 'termination-pending',
+        worktreeId: REVIVE_WORKTREE_ID,
+        tabId: REVIVE_TAB_ID,
+        leafId: REVIVE_LEAF_ID
+      }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+
+    await archiveInternals(session).retryTerminationPendingPtys()
+    await archiveInternals(session).reattachKnownPtys(() => true)
+    expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalled()
+    expect(attachForReconnect).not.toHaveBeenCalled()
+
+    await archiveInternals(session).retryTerminationPendingPtys()
+    expect(shutdown).toHaveBeenCalledTimes(2)
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
+      'target-1',
+      'pty-lost',
+      'terminated'
+    )
   })
 })

--- a/src/main/ssh/ssh-relay-session-lost-worker.test.ts
+++ b/src/main/ssh/ssh-relay-session-lost-worker.test.ts
@@ -144,6 +144,7 @@ function configureStagedPtyRevive(args: {
     } as unknown as ReturnType<typeof getSshPtyProvider>)
     .mockReturnValue({
       revive: args.revive,
+      shutdown: vi.fn().mockResolvedValue(undefined),
       attachForReconnect,
       dispose: vi.fn()
     } as unknown as ReturnType<typeof getSshPtyProvider>)
@@ -251,7 +252,7 @@ describe('SshRelaySession lost-worker archive', () => {
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
       'target-1',
       archived ? 'pty-lost' : 'pty-fallback',
-      archived ? 'expired' : 'attached'
+      archived ? 'terminated' : 'attached'
     )
     if (archived) {
       expect(routeExternalPtyExit).toHaveBeenCalledWith({

--- a/src/main/ssh/ssh-relay-session-lost-worker.test.ts
+++ b/src/main/ssh/ssh-relay-session-lost-worker.test.ts
@@ -454,4 +454,44 @@ describe('SshRelaySession lost-worker archive', () => {
       'terminated'
     )
   })
+
+  it('retries termination-pending leases before initial establish can reattach', async () => {
+    const deps = createMockDeps()
+    const shutdown = vi.fn().mockResolvedValue(undefined)
+    const attachForReconnect = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      shutdown,
+      attachForReconnect,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(deps.mockStore.getSshRemotePtyLeases).mockReturnValue([
+      {
+        targetId: 'target-1',
+        ptyId: 'pty-pending',
+        state: 'termination-pending',
+        worktreeId: REVIVE_WORKTREE_ID,
+        tabId: REVIVE_TAB_ID,
+        leafId: REVIVE_LEAF_ID
+      }
+    ] as ReturnType<typeof deps.mockStore.getSshRemotePtyLeases>)
+    const session = new SshRelaySession(
+      'target-1',
+      deps.getMainWindow,
+      deps.mockStore,
+      deps.mockPortForward
+    )
+
+    await session.establish(deps.mockConn)
+
+    expect(shutdown).toHaveBeenCalledWith('ssh:target-1@@pty-pending', {
+      immediate: true,
+      keepHistory: false
+    })
+    expect(deps.mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
+      'target-1',
+      'pty-pending',
+      'terminated'
+    )
+    expect(attachForReconnect).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/ssh/ssh-relay-session-lost-worker.test.ts
+++ b/src/main/ssh/ssh-relay-session-lost-worker.test.ts
@@ -3,6 +3,7 @@ import { SshRelaySession } from './ssh-relay-session'
 import { getDefaultWorkspaceSession } from '../../shared/constants'
 import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
 import { decodeRelayStagedPtySnapshots } from '../../shared/relay-staged-pty-snapshots'
+import { takeArchivedSshPtyExitRecovery } from './ssh-archived-exit-recovery'
 import type { WorkspaceSessionState } from '../../shared/types'
 import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
 
@@ -179,6 +180,11 @@ type SshRelaySessionArchiveInternals = {
   ) => Promise<void>
   reattachKnownPtys: (shouldContinue: () => boolean) => Promise<void>
   retryTerminationPendingPtys: () => Promise<void>
+  shutdownArchivedRelayPtys: (
+    ptyIds: readonly string[],
+    archiveId: string,
+    tabId: string
+  ) => Promise<void>
 }
 
 function archiveInternals(session: SshRelaySession): SshRelaySessionArchiveInternals {
@@ -236,17 +242,20 @@ describe('SshRelaySession lost-worker archive', () => {
         outcome: { outcomeVersion: 1, revived: [], lost: [lost], diagnostics: [] }
       })
     }
-    archiveLostTerminalWorkerMock.mockResolvedValue(
-      state === 'archive failure'
-        ? { kind: 'error', code: 'durability-failed' }
-        : {
-            kind: 'archived',
-            archive: { id: 'archive-1' },
-            operationId: 'relay-worker-lost:tab-1',
-            ptyIdsToKill: [RELAY_LOST_WORKER.id],
-            archiveCompletionOwner: true
-          }
-    )
+    if (state === 'archive failure') {
+      archiveLostTerminalWorkerMock.mockResolvedValue({ kind: 'error', code: 'durability-failed' })
+    } else {
+      archiveLostTerminalWorkerMock.mockImplementation(async ({ completeArchive }) => {
+        const result = {
+          kind: 'archived' as const,
+          archive: { id: 'archive-1' },
+          operationId: 'relay-worker-lost:tab-1',
+          ptyIdsToKill: [RELAY_LOST_WORKER.id]
+        }
+        await completeArchive?.(result)
+        return result
+      })
+    }
     mockStore.getWorkspaceSession = vi
       .fn()
       .mockReturnValue(
@@ -347,8 +356,7 @@ describe('SshRelaySession lost-worker archive', () => {
       kind: 'archived',
       archive: { id: 'archive-1' },
       operationId: 'relay-worker-lost:tab-1',
-      ptyIdsToKill: [RELAY_LOST_WORKER.id],
-      archiveCompletionOwner: false
+      ptyIdsToKill: [RELAY_LOST_WORKER.id]
     })
     mockStore.getWorkspaceSession = vi.fn().mockReturnValue(workspaceSessionForRelayLostWorker())
     const { shutdown } = configureStagedPtyRevive({ serialize, revive })
@@ -357,6 +365,28 @@ describe('SshRelaySession lost-worker archive', () => {
 
     expect(shutdown).not.toHaveBeenCalled()
     expect(routeExternalPtyExit).not.toHaveBeenCalled()
+  })
+
+  it('releases synthetic archive-exit recovery registrations after routing the receipt', async () => {
+    const { session } = await establishRelaySession()
+    const shutdown = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      shutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+
+    await archiveInternals(session).shutdownArchivedRelayPtys(
+      [RELAY_LOST_WORKER.id],
+      'archive-1',
+      REVIVE_TAB_ID
+    )
+
+    expect(takeArchivedSshPtyExitRecovery(RELAY_LOST_WORKER.id)).toBeUndefined()
+    expect(routeExternalPtyExit).toHaveBeenCalledWith({
+      id: RELAY_LOST_WORKER.id,
+      code: -1,
+      lostWorkerRecovery: { kind: 'archived', archiveId: 'archive-1' }
+    })
   })
 
   it('fails closed with the legacy-envelope diagnostic instead of fabricating a tail', async () => {
@@ -379,7 +409,11 @@ describe('SshRelaySession lost-worker archive', () => {
 
     expect(diagnostic).toHaveBeenCalledWith(
       '[ssh-relay-session] lost-worker archive diagnostic',
-      expect.objectContaining({ stage: 'staged-state-legacy', paneKey: REVIVE_PANE_KEY })
+      expect.objectContaining({
+        stage: 'staged-state-legacy',
+        paneKey: REVIVE_PANE_KEY,
+        attempt: expect.any(Number)
+      })
     )
     diagnostic.mockRestore()
   })

--- a/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
@@ -139,13 +139,16 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       incarnationId
     })
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith({
-      worktreeId: 'worktree-1',
-      tabId: 'tab-1',
-      leafId: INCARNATION_LEAF_ID,
-      ptyId: APP_PTY_ID,
-      incarnationId
-    })
+    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
+      {
+        worktreeId: 'worktree-1',
+        tabId: 'tab-1',
+        leafId: INCARNATION_LEAF_ID,
+        ptyId: APP_PTY_ID,
+        incarnationId
+      },
+      'ssh:target-1'
+    )
     expect(vi.mocked(mockStore.persistPtyBinding).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(mockStore.markSshRemotePtyLease).mock.invocationCallOrder[0]!
     )
@@ -237,7 +240,8 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     })
     expect(setPtyOwnership).toHaveBeenCalledWith(APP_PTY_ID, 'target-1')
     expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ ptyId: APP_PTY_ID, incarnationId: currentIncarnationId })
+      expect.objectContaining({ ptyId: APP_PTY_ID, incarnationId: currentIncarnationId }),
+      'ssh:target-1'
     )
     expect(routeExternalPtyReplay).toHaveBeenCalledWith({
       id: APP_PTY_ID,

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -6,9 +6,15 @@ import {
   AGENT_HOOK_INSTALL_PLUGINS_METHOD
 } from '../../shared/agent-hook-relay'
 import { SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD } from '../../shared/ssh-types'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
+import type { WorkspaceSessionState } from '../../shared/types'
 import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
 
-const { muxRequestMock } = vi.hoisted(() => ({ muxRequestMock: vi.fn() }))
+const { muxRequestMock, archiveLostTerminalWorkerMock } = vi.hoisted(() => ({
+  muxRequestMock: vi.fn(),
+  archiveLostTerminalWorkerMock: vi.fn()
+}))
 
 vi.mock('./ssh-relay-deploy', () => ({
   deployAndLaunchRelay: vi.fn()
@@ -16,6 +22,10 @@ vi.mock('./ssh-relay-deploy', () => ({
 
 vi.mock('./ssh-relay-deploy-helpers', () => ({
   execCommand: vi.fn().mockResolvedValue('')
+}))
+
+vi.mock('../terminal-lost-worker-archive', () => ({
+  archiveLostTerminalWorker: archiveLostTerminalWorkerMock
 }))
 
 vi.mock('./ssh-channel-multiplexer', () => {
@@ -97,6 +107,7 @@ const { getRemoteHostPlatform } = await import('./ssh-remote-platform')
 const {
   registerSshPtyProvider,
   unregisterSshPtyProvider,
+  getSshPtyProvider,
   getPtyIdsForConnection,
   clearProviderPtyState,
   deletePtyOwnership,
@@ -109,12 +120,109 @@ const { registerSshGitProvider, unregisterSshGitProvider } =
 const { routeExternalPtyData, routeExternalPtyReplay, routeExternalPtyExit } =
   await import('../ipc/pty-renderer-delivery-router')
 
+const REVIVE_WORKTREE_ID = 'repo-1::/worktree'
+const REVIVE_TAB_ID = 'tab-1'
+const REVIVE_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const REVIVE_PANE_KEY = `${REVIVE_TAB_ID}:${REVIVE_LEAF_ID}`
+const RELAY_LOST_WORKER: RelayPtyLostEntry = {
+  id: 'ssh:target-1@@pty-lost',
+  kind: 'recognized-worker',
+  reason: 'process-not-running',
+  pid: 42,
+  cols: 80,
+  rows: 24,
+  cwd: '/repo',
+  worktreeId: REVIVE_WORKTREE_ID,
+  tabId: REVIVE_TAB_ID,
+  paneKey: REVIVE_PANE_KEY
+}
+
+function workspaceSessionForRelayLostWorker(workerHint = false): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: {
+      [REVIVE_WORKTREE_ID]: [
+        {
+          id: REVIVE_TAB_ID,
+          worktreeId: REVIVE_WORKTREE_ID,
+          title: 'Worker',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 10,
+          ptyId: RELAY_LOST_WORKER.id
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      [REVIVE_TAB_ID]: {
+        root: { type: 'leaf', leafId: REVIVE_LEAF_ID },
+        activeLeafId: REVIVE_LEAF_ID,
+        expandedLeafId: null
+      }
+    },
+    terminalPtyIncarnationsByPaneKey: { [REVIVE_PANE_KEY]: 'incarnation-1' },
+    terminalArchiveHintsByPaneKey: {
+      [REVIVE_PANE_KEY]: workerHint ? { launchAgent: 'codex', startedAt: 10 } : { cwd: '/repo' }
+    }
+  }
+}
+
+function configureStagedPtyRevive(args: {
+  serialize: ReturnType<typeof vi.fn>
+  revive: ReturnType<typeof vi.fn>
+  reattachPtyIds?: string[]
+}): { attachForReconnect: ReturnType<typeof vi.fn> } {
+  const attachForReconnect = vi.fn().mockResolvedValue({})
+  vi.mocked(getSshPtyProvider)
+    .mockReset()
+    .mockReturnValueOnce({
+      serialize: args.serialize,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    .mockReturnValue({
+      revive: args.revive,
+      attachForReconnect,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+  vi.mocked(getPtyIdsForConnection).mockReturnValueOnce(['ssh:target-1@@pty-lost'])
+  vi.mocked(getPtyIdsForConnection).mockReturnValue(args.reattachPtyIds ?? [])
+  return { attachForReconnect }
+}
+
+function mockReconnectPtyProvider(attachForReconnect: ReturnType<typeof vi.fn>): void {
+  vi.mocked(getSshPtyProvider).mockReturnValue({
+    attachForReconnect,
+    dispose: vi.fn()
+  } as unknown as ReturnType<typeof getSshPtyProvider>)
+}
+
+async function establishRelaySession() {
+  const deps = createMockDeps()
+  const session = new SshRelaySession(
+    'target-1',
+    deps.getMainWindow,
+    deps.mockStore,
+    deps.mockPortForward
+  )
+  await session.establish(deps.mockConn)
+  return { ...deps, session }
+}
+
 describe('SshRelaySession', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     delete process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
     muxRequestMock.mockReset()
     muxRequestMock.mockResolvedValue([])
+    archiveLostTerminalWorkerMock.mockReset()
+    vi.mocked(getSshPtyProvider)
+      .mockReset()
+      .mockReturnValue({
+        dispose: vi.fn(),
+        attach: vi.fn().mockResolvedValue(undefined),
+        attachForReconnect: vi.fn().mockResolvedValue({})
+      } as unknown as ReturnType<typeof getSshPtyProvider>)
     mockDeploySuccess()
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
   })
@@ -397,12 +505,8 @@ describe('SshRelaySession', () => {
     vi.clearAllMocks()
     mockDeploySuccess()
 
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1', 'pty-2'])
 
     await session.reconnect(mockConn)
@@ -411,19 +515,115 @@ describe('SshRelaySession', () => {
     expect(mockAttach).toHaveBeenCalledWith('pty-2')
   })
 
+  it.each([
+    'typed recognized',
+    'typed unclassified worker hint',
+    'typed unclassified',
+    'legacy',
+    'malformed typed',
+    'serialize failure',
+    'archive failure'
+  ])('keeps staged PTY revive %s on its compatible recovery path', async (state) => {
+    const { mockConn, mockStore, session } = await establishRelaySession()
+    vi.clearAllMocks()
+    mockDeploySuccess()
+    const serialize = vi.fn().mockResolvedValue('staged-pty-state')
+    const revive = vi.fn()
+    const lost = state.startsWith('typed unclassified')
+      ? { ...RELAY_LOST_WORKER, kind: 'unclassified' as const }
+      : RELAY_LOST_WORKER
+    if (state === 'serialize failure') {
+      serialize.mockRejectedValue(new Error('old relay stopped before serialize reply'))
+    } else if (state === 'malformed typed') {
+      revive.mockRejectedValue(new Error('typed outcome validation failed'))
+    } else if (state === 'legacy') {
+      revive.mockResolvedValue({
+        mode: 'legacy',
+        diagnosticCode: 'pty-revive-outcome-unavailable',
+        outcome: { outcomeVersion: 1, revived: [], lost: [RELAY_LOST_WORKER], diagnostics: [] }
+      })
+    } else {
+      revive.mockResolvedValue({
+        mode: 'typed',
+        outcome: { outcomeVersion: 1, revived: [], lost: [lost], diagnostics: [] }
+      })
+    }
+    archiveLostTerminalWorkerMock.mockResolvedValue(
+      state === 'archive failure'
+        ? { kind: 'error', code: 'durability-failed' }
+        : {
+            kind: 'archived',
+            archive: {},
+            operationId: 'relay-worker-lost:tab-1',
+            ptyIdsToKill: [RELAY_LOST_WORKER.id]
+          }
+    )
+    mockStore.getWorkspaceSession = vi
+      .fn()
+      .mockReturnValue(
+        workspaceSessionForRelayLostWorker(state === 'typed unclassified worker hint')
+      )
+    const archived = state === 'typed recognized' || state === 'typed unclassified worker hint'
+    const fallbackPtyIds = archived ? [] : ['ssh:target-1@@pty-fallback']
+    const { attachForReconnect } = configureStagedPtyRevive({
+      serialize,
+      revive,
+      reattachPtyIds: fallbackPtyIds
+    })
+
+    await session.reconnect(mockConn)
+
+    expect(serialize).toHaveBeenCalledWith(['pty-lost'], { formatVersion: 2 })
+    expect(revive).toHaveBeenCalledTimes(state === 'serialize failure' ? 0 : 1)
+    expect(archiveLostTerminalWorkerMock).toHaveBeenCalledTimes(
+      archived || state === 'archive failure' ? 1 : 0
+    )
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledTimes(
+      archived ? 1 : fallbackPtyIds.length
+    )
+    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
+      'target-1',
+      archived ? 'pty-lost' : 'pty-fallback',
+      archived ? 'expired' : 'attached'
+    )
+    expect(routeExternalPtyExit).toHaveBeenCalledTimes(archived ? 1 : 0)
+    expect(session.getState()).toBe('ready')
+    if (state === 'typed unclassified') {
+      expect(mockStore.getWorkspaceSession).toHaveBeenCalledWith('ssh:target-1')
+    }
+    if (state === 'typed unclassified worker hint') {
+      expect(archiveLostTerminalWorkerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          candidate: expect.objectContaining({
+            relayEvidence: expect.objectContaining({ kind: 'unclassified' })
+          })
+        })
+      )
+    }
+    if (fallbackPtyIds.length > 0) {
+      expect(attachForReconnect).toHaveBeenCalledWith('pty-fallback')
+    }
+    if (state === 'archive failure') {
+      expect(archiveLostTerminalWorkerMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          candidate: expect.objectContaining({ relayEvidence: RELAY_LOST_WORKER })
+        })
+      )
+      expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
+        'target-1',
+        'pty-lost',
+        'expired'
+      )
+    }
+  })
+
   it('forwards reconnect replay after the attach attempt is still current', async () => {
-    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
-    await session.establish(mockConn)
+    const { mockConn, session } = await establishRelaySession()
     vi.clearAllMocks()
     mockDeploySuccess()
 
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue({ replay: 'restored-output' })
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
 
     await session.reconnect(mockConn)
@@ -435,18 +635,12 @@ describe('SshRelaySession', () => {
   })
 
   it('drops identical reconnect replay payloads inside one reconnect burst', async () => {
-    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
-    await session.establish(mockConn)
+    const { mockConn, session } = await establishRelaySession()
     vi.clearAllMocks()
     mockDeploySuccess()
 
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue({ replay: 'same-output' })
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
 
     await session.reconnect(mockConn)
@@ -458,12 +652,8 @@ describe('SshRelaySession', () => {
 
   it('establish re-attaches owned PTYs after explicit disconnect', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['ssh:target-1@@pty-1'])
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
@@ -477,12 +667,8 @@ describe('SshRelaySession', () => {
 
   it('establish re-attaches durable leases after app restart', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
       { targetId: 'target-1', ptyId: 'pty-live', state: 'detached' },
@@ -501,12 +687,8 @@ describe('SshRelaySession', () => {
 
   it('forwards a lease tab identity to reattach so a reset relay cannot cross-wire it', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
       { targetId: 'target-1', ptyId: 'pty-1', state: 'detached', tabId: 'tab-a' }
@@ -520,12 +702,8 @@ describe('SshRelaySession', () => {
 
   it('forwards a lease pane identity when leaf identity is available', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue(undefined)
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
     const leafId = '11111111-1111-4111-8111-111111111111'
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
@@ -542,20 +720,14 @@ describe('SshRelaySession', () => {
   })
 
   it('does not expire a live reused relay id when attach rejects identity mismatch', async () => {
-    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
-    await session.establish(mockConn)
+    const { mockConn, mockStore, session } = await establishRelaySession()
     vi.clearAllMocks()
     mockDeploySuccess()
 
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi
       .fn()
       .mockRejectedValueOnce(new Error('PTY "pty-1" not found (identity mismatch)'))
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
     const staleLeafId = '11111111-1111-4111-8111-111111111111'
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
@@ -577,25 +749,18 @@ describe('SshRelaySession', () => {
     expect(clearProviderPtyState).not.toHaveBeenCalledWith('ssh:target-1@@pty-1')
     expect(deletePtyOwnership).not.toHaveBeenCalledWith('ssh:target-1@@pty-1')
     expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith('target-1', 'pty-1', 'expired')
-    expect(routeExternalPtyExit).not.toHaveBeenCalledWith({
-      id: 'ssh:target-1@@pty-1',
-      code: -1
-    })
+    expect(routeExternalPtyExit).not.toHaveBeenCalledWith({ id: 'ssh:target-1@@pty-1', code: -1 })
   })
 
   it('rejects establish if detach wins while reattach is in flight', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const { getSshPtyProvider } = await import('../ipc/pty')
     let resolveAttach!: () => void
     const mockAttach = vi.fn().mockReturnValue(
       new Promise<void>((resolve) => {
         resolveAttach = resolve
       })
     )
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
@@ -614,23 +779,17 @@ describe('SshRelaySession', () => {
   })
 
   it('does not mark PTYs attached if detach wins while reattach is in flight', async () => {
-    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
-    await session.establish(mockConn)
+    const { mockConn, mockStore, session } = await establishRelaySession()
     vi.clearAllMocks()
     mockDeploySuccess()
 
-    const { getSshPtyProvider } = await import('../ipc/pty')
     let resolveAttach!: () => void
     const mockAttach = vi.fn().mockReturnValue(
       new Promise<void>((resolve) => {
         resolveAttach = resolve
       })
     )
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-1'])
 
     const reconnect = session.reconnect(mockConn)
@@ -648,21 +807,15 @@ describe('SshRelaySession', () => {
   })
 
   it('invalidates and broadcasts remote PTYs that cannot reattach after relay reconnect', async () => {
-    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
-    await session.establish(mockConn)
+    const { mockConn, session } = await establishRelaySession()
     vi.clearAllMocks()
     mockDeploySuccess()
 
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi
       .fn()
       .mockRejectedValueOnce(new Error('PTY "pty-stale" not found'))
       .mockResolvedValueOnce(undefined)
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-stale', 'pty-live'])
 
     await session.reconnect(mockConn)
@@ -678,20 +831,14 @@ describe('SshRelaySession', () => {
   })
 
   it('routes transient reattach failures through relay-lost retry handling', async () => {
-    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+    const { mockConn, mockStore, session } = await establishRelaySession()
     const onRelayLost = vi.fn()
     session.setOnRelayLost(onRelayLost)
-    await session.establish(mockConn)
     vi.clearAllMocks()
     mockDeploySuccess()
 
-    const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockRejectedValue(new Error('Multiplexer disposed'))
-    vi.mocked(getSshPtyProvider).mockReturnValue({
-      attachForReconnect: mockAttach,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    mockReconnectPtyProvider(mockAttach)
     vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-live'])
 
     await session.reconnect(mockConn)

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -6,15 +6,9 @@ import {
   AGENT_HOOK_INSTALL_PLUGINS_METHOD
 } from '../../shared/agent-hook-relay'
 import { SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD } from '../../shared/ssh-types'
-import { getDefaultWorkspaceSession } from '../../shared/constants'
-import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
-import type { WorkspaceSessionState } from '../../shared/types'
 import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
 
-const { muxRequestMock, archiveLostTerminalWorkerMock } = vi.hoisted(() => ({
-  muxRequestMock: vi.fn(),
-  archiveLostTerminalWorkerMock: vi.fn()
-}))
+const { muxRequestMock } = vi.hoisted(() => ({ muxRequestMock: vi.fn() }))
 
 vi.mock('./ssh-relay-deploy', () => ({
   deployAndLaunchRelay: vi.fn()
@@ -22,10 +16,6 @@ vi.mock('./ssh-relay-deploy', () => ({
 
 vi.mock('./ssh-relay-deploy-helpers', () => ({
   execCommand: vi.fn().mockResolvedValue('')
-}))
-
-vi.mock('../terminal-lost-worker-archive', () => ({
-  archiveLostTerminalWorker: archiveLostTerminalWorkerMock
 }))
 
 vi.mock('./ssh-channel-multiplexer', () => {
@@ -120,76 +110,6 @@ const { registerSshGitProvider, unregisterSshGitProvider } =
 const { routeExternalPtyData, routeExternalPtyReplay, routeExternalPtyExit } =
   await import('../ipc/pty-renderer-delivery-router')
 
-const REVIVE_WORKTREE_ID = 'repo-1::/worktree'
-const REVIVE_TAB_ID = 'tab-1'
-const REVIVE_LEAF_ID = '11111111-1111-4111-8111-111111111111'
-const REVIVE_PANE_KEY = `${REVIVE_TAB_ID}:${REVIVE_LEAF_ID}`
-const RELAY_LOST_WORKER: RelayPtyLostEntry = {
-  id: 'ssh:target-1@@pty-lost',
-  kind: 'recognized-worker',
-  reason: 'process-not-running',
-  pid: 42,
-  cols: 80,
-  rows: 24,
-  cwd: '/repo',
-  worktreeId: REVIVE_WORKTREE_ID,
-  tabId: REVIVE_TAB_ID,
-  paneKey: REVIVE_PANE_KEY
-}
-
-function workspaceSessionForRelayLostWorker(workerHint = false): WorkspaceSessionState {
-  return {
-    ...getDefaultWorkspaceSession(),
-    tabsByWorktree: {
-      [REVIVE_WORKTREE_ID]: [
-        {
-          id: REVIVE_TAB_ID,
-          worktreeId: REVIVE_WORKTREE_ID,
-          title: 'Worker',
-          customTitle: null,
-          color: null,
-          sortOrder: 0,
-          createdAt: 10,
-          ptyId: RELAY_LOST_WORKER.id
-        }
-      ]
-    },
-    terminalLayoutsByTabId: {
-      [REVIVE_TAB_ID]: {
-        root: { type: 'leaf', leafId: REVIVE_LEAF_ID },
-        activeLeafId: REVIVE_LEAF_ID,
-        expandedLeafId: null
-      }
-    },
-    terminalPtyIncarnationsByPaneKey: { [REVIVE_PANE_KEY]: 'incarnation-1' },
-    terminalArchiveHintsByPaneKey: {
-      [REVIVE_PANE_KEY]: workerHint ? { launchAgent: 'codex', startedAt: 10 } : { cwd: '/repo' }
-    }
-  }
-}
-
-function configureStagedPtyRevive(args: {
-  serialize: ReturnType<typeof vi.fn>
-  revive: ReturnType<typeof vi.fn>
-  reattachPtyIds?: string[]
-}): { attachForReconnect: ReturnType<typeof vi.fn> } {
-  const attachForReconnect = vi.fn().mockResolvedValue({})
-  vi.mocked(getSshPtyProvider)
-    .mockReset()
-    .mockReturnValueOnce({
-      serialize: args.serialize,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
-    .mockReturnValue({
-      revive: args.revive,
-      attachForReconnect,
-      dispose: vi.fn()
-    } as unknown as ReturnType<typeof getSshPtyProvider>)
-  vi.mocked(getPtyIdsForConnection).mockReturnValueOnce(['ssh:target-1@@pty-lost'])
-  vi.mocked(getPtyIdsForConnection).mockReturnValue(args.reattachPtyIds ?? [])
-  return { attachForReconnect }
-}
-
 function mockReconnectPtyProvider(attachForReconnect: ReturnType<typeof vi.fn>): void {
   vi.mocked(getSshPtyProvider).mockReturnValue({
     attachForReconnect,
@@ -215,7 +135,6 @@ describe('SshRelaySession', () => {
     delete process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
     muxRequestMock.mockReset()
     muxRequestMock.mockResolvedValue([])
-    archiveLostTerminalWorkerMock.mockReset()
     vi.mocked(getSshPtyProvider)
       .mockReset()
       .mockReturnValue({
@@ -513,108 +432,6 @@ describe('SshRelaySession', () => {
 
     expect(mockAttach).toHaveBeenCalledWith('pty-1')
     expect(mockAttach).toHaveBeenCalledWith('pty-2')
-  })
-
-  it.each([
-    'typed recognized',
-    'typed unclassified worker hint',
-    'typed unclassified',
-    'legacy',
-    'malformed typed',
-    'serialize failure',
-    'archive failure'
-  ])('keeps staged PTY revive %s on its compatible recovery path', async (state) => {
-    const { mockConn, mockStore, session } = await establishRelaySession()
-    vi.clearAllMocks()
-    mockDeploySuccess()
-    const serialize = vi.fn().mockResolvedValue('staged-pty-state')
-    const revive = vi.fn()
-    const lost = state.startsWith('typed unclassified')
-      ? { ...RELAY_LOST_WORKER, kind: 'unclassified' as const }
-      : RELAY_LOST_WORKER
-    if (state === 'serialize failure') {
-      serialize.mockRejectedValue(new Error('old relay stopped before serialize reply'))
-    } else if (state === 'malformed typed') {
-      revive.mockRejectedValue(new Error('typed outcome validation failed'))
-    } else if (state === 'legacy') {
-      revive.mockResolvedValue({
-        mode: 'legacy',
-        diagnosticCode: 'pty-revive-outcome-unavailable',
-        outcome: { outcomeVersion: 1, revived: [], lost: [RELAY_LOST_WORKER], diagnostics: [] }
-      })
-    } else {
-      revive.mockResolvedValue({
-        mode: 'typed',
-        outcome: { outcomeVersion: 1, revived: [], lost: [lost], diagnostics: [] }
-      })
-    }
-    archiveLostTerminalWorkerMock.mockResolvedValue(
-      state === 'archive failure'
-        ? { kind: 'error', code: 'durability-failed' }
-        : {
-            kind: 'archived',
-            archive: {},
-            operationId: 'relay-worker-lost:tab-1',
-            ptyIdsToKill: [RELAY_LOST_WORKER.id]
-          }
-    )
-    mockStore.getWorkspaceSession = vi
-      .fn()
-      .mockReturnValue(
-        workspaceSessionForRelayLostWorker(state === 'typed unclassified worker hint')
-      )
-    const archived = state === 'typed recognized' || state === 'typed unclassified worker hint'
-    const fallbackPtyIds = archived ? [] : ['ssh:target-1@@pty-fallback']
-    const { attachForReconnect } = configureStagedPtyRevive({
-      serialize,
-      revive,
-      reattachPtyIds: fallbackPtyIds
-    })
-
-    await session.reconnect(mockConn)
-
-    expect(serialize).toHaveBeenCalledWith(['pty-lost'], { formatVersion: 2 })
-    expect(revive).toHaveBeenCalledTimes(state === 'serialize failure' ? 0 : 1)
-    expect(archiveLostTerminalWorkerMock).toHaveBeenCalledTimes(
-      archived || state === 'archive failure' ? 1 : 0
-    )
-    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledTimes(
-      archived ? 1 : fallbackPtyIds.length
-    )
-    expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
-      'target-1',
-      archived ? 'pty-lost' : 'pty-fallback',
-      archived ? 'expired' : 'attached'
-    )
-    expect(routeExternalPtyExit).toHaveBeenCalledTimes(archived ? 1 : 0)
-    expect(session.getState()).toBe('ready')
-    if (state === 'typed unclassified') {
-      expect(mockStore.getWorkspaceSession).toHaveBeenCalledWith('ssh:target-1')
-    }
-    if (state === 'typed unclassified worker hint') {
-      expect(archiveLostTerminalWorkerMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          candidate: expect.objectContaining({
-            relayEvidence: expect.objectContaining({ kind: 'unclassified' })
-          })
-        })
-      )
-    }
-    if (fallbackPtyIds.length > 0) {
-      expect(attachForReconnect).toHaveBeenCalledWith('pty-fallback')
-    }
-    if (state === 'archive failure') {
-      expect(archiveLostTerminalWorkerMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          candidate: expect.objectContaining({ relayEvidence: RELAY_LOST_WORKER })
-        })
-      )
-      expect(mockStore.markSshRemotePtyLease).not.toHaveBeenCalledWith(
-        'target-1',
-        'pty-lost',
-        'expired'
-      )
-    }
   })
 
   it('forwards reconnect replay after the attach attempt is still current', async () => {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1167,7 +1167,9 @@ export class SshRelaySession {
       })
       return
     }
-    await this.shutdownArchivedRelayPtys(result.ptyIdsToKill, result.archive.id, tabId)
+    if (result.archiveCompletionOwner) {
+      await this.shutdownArchivedRelayPtys(result.ptyIdsToKill, result.archive.id, tabId)
+    }
   }
 
   private async shutdownArchivedRelayPtys(

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -73,6 +73,10 @@ import { captureTerminalArchiveTab } from '../../shared/workspace-session-termin
 import { captureTerminalArchiveBuffer } from '../../shared/terminal-archive-snapshot-capture'
 import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
 import { createRelayLostWorkerSnapshotSource } from '../terminal-lost-worker-snapshot-source'
+import {
+  beginArchivedSshPtyExitRecovery,
+  takeArchivedSshPtyExitRecovery
+} from './ssh-archived-exit-recovery'
 import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
 import {
   decodeRelayStagedPtySnapshots,
@@ -83,8 +87,6 @@ export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' 
 
 type SshPtyExitPayload = Parameters<SshPtyExitCallback>[0]
 type PendingPtyReattach = { exits: SshPtyExitPayload[] }
-type PendingArchivedExitRecovery = { archiveId: string; receiptDelivered: boolean }
-
 type RemoteCliBridgeEnv = {
   remoteHome: string
   binDir: string
@@ -163,7 +165,7 @@ export class SshRelaySession {
   private forwardedReattachReplayByPty = new Map<string, ForwardedReplayFingerprint>()
   private pendingPtyReattaches = new Map<string, PendingPtyReattach>()
   private pendingPtyReviveState: string | null = null
-  private archivedExitRecoveryByPtyId = new Map<string, PendingArchivedExitRecovery>()
+  private lostWorkerArchiveAttempt = 0
 
   constructor(
     readonly targetId: string,
@@ -957,24 +959,20 @@ export class SshRelaySession {
 
   private retireExitedPty(payload: SshPtyExitPayload): void {
     const relayPtyId = toRelaySshPtyId(this.targetId, payload.id)
-    const recovery = this.archivedExitRecoveryByPtyId.get(payload.id)
-    this.archivedExitRecoveryByPtyId.delete(payload.id)
+    const archiveId = takeArchivedSshPtyExitRecovery(payload.id)
     clearProviderPtyState(payload.id)
     deletePtyOwnership(payload.id)
     this.forwardedReattachReplayByPty.delete(payload.id)
     this.store.markSshRemotePtyLease(this.targetId, relayPtyId, 'terminated')
     this.runtime?.onPtyExit(payload.id, payload.code, payload.incarnationId)
-    if (recovery?.receiptDelivered) {
-      return
-    }
-    if (!recovery) {
+    if (!archiveId) {
       routeExternalPtyExit(payload)
       return
     }
     routeExternalPtyExit({
       id: payload.id,
       code: payload.code,
-      lostWorkerRecovery: { kind: 'archived', archiveId: recovery.archiveId }
+      lostWorkerRecovery: { kind: 'archived', archiveId }
     })
   }
 
@@ -1011,6 +1009,7 @@ export class SshRelaySession {
     if (!provider || ptyIds.length === 0) {
       return
     }
+    this.lostWorkerArchiveAttempt += 1
     try {
       this.pendingPtyReviveState = await provider.serialize(ptyIds, { formatVersion: 2 })
     } catch (error) {
@@ -1156,7 +1155,9 @@ export class SshRelaySession {
         relayEvidence: lost
       },
       frozenSession: session,
-      snapshotSource
+      snapshotSource,
+      completeArchive: ({ archive, ptyIdsToKill }) =>
+        this.shutdownArchivedRelayPtys(ptyIdsToKill, archive.id, tabId)
     })
     if (result.kind !== 'archived') {
       this.reportLostWorkerArchiveDiagnostic({
@@ -1165,10 +1166,6 @@ export class SshRelaySession {
         paneKey,
         error: new Error(result.code)
       })
-      return
-    }
-    if (result.archiveCompletionOwner) {
-      await this.shutdownArchivedRelayPtys(result.ptyIdsToKill, result.archive.id, tabId)
     }
   }
 
@@ -1180,7 +1177,7 @@ export class SshRelaySession {
     const provider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
     for (const ptyId of ptyIds) {
       // Why: shutdown can synchronously emit onExit, which must carry the archive receipt instead of a normal exit.
-      this.archivedExitRecoveryByPtyId.set(ptyId, { archiveId, receiptDelivered: false })
+      beginArchivedSshPtyExitRecovery(ptyId, archiveId)
     }
     const outcomes = provider
       ? await Promise.allSettled(
@@ -1210,15 +1207,14 @@ export class SshRelaySession {
       }
       clearProviderPtyState(ptyId)
       deletePtyOwnership(ptyId)
-      const recovery = this.archivedExitRecoveryByPtyId.get(ptyId)
-      if (recovery && !recovery.receiptDelivered) {
-        recovery.receiptDelivered = true
+      const recoveredArchiveId = takeArchivedSshPtyExitRecovery(ptyId)
+      if (recoveredArchiveId) {
         routeExternalPtyExit({
           id: ptyId,
           code: -1,
           lostWorkerRecovery: {
             kind: 'archived',
-            archiveId: recovery.archiveId
+            archiveId: recoveredArchiveId
           }
         })
       }
@@ -1273,12 +1269,14 @@ export class SshRelaySession {
     tabId?: string
     paneKey?: string
     error?: unknown
+    attempt?: number
   }): void {
     console.warn('[ssh-relay-session] lost-worker archive diagnostic', {
       targetId: this.targetId,
       tabId: args.tabId,
       paneKey: args.paneKey,
       stage: args.stage,
+      attempt: args.attempt ?? this.lostWorkerArchiveAttempt,
       error: args.error instanceof Error ? args.error.message : undefined
     })
   }

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -77,6 +77,10 @@ import type { ArchivedTerminalPane } from '../../shared/terminal-archive-types'
 import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
 import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
 import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
+import {
+  decodeRelayStagedPtySnapshots,
+  type RelayStagedPtySnapshots
+} from '../../shared/relay-staged-pty-snapshots'
 
 export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' | 'disposed'
 
@@ -411,6 +415,7 @@ export class SshRelaySession {
         throw new Error('Relay connection lost during provider registration')
       }
 
+      await this.retryTerminationPendingPtys()
       await this.reviveStagedPtysAfterProviderRegistration()
 
       // Why: dispose() during registration/attach already cleaned up, but this.mux was reassigned above — clean up the new mux so it doesn't leak.
@@ -996,9 +1001,10 @@ export class SshRelaySession {
     }
     try {
       this.pendingPtyReviveState = await provider.serialize(ptyIds, { formatVersion: 2 })
-    } catch {
+    } catch (error) {
       // The old relay may already be gone; leases and persisted hints remain the only honest fallback.
       this.pendingPtyReviveState = null
+      this.reportLostWorkerArchiveDiagnostic({ stage: 'stage-serialize', error })
     }
   }
 
@@ -1012,20 +1018,64 @@ export class SshRelaySession {
     if (!provider) {
       return
     }
+    const stagedSnapshots = decodeRelayStagedPtySnapshots(state)
     try {
       const revived = await provider.revive(state, { formatVersion: 2 })
       if (revived.mode !== 'typed') {
         return
       }
-      for (const lost of revived.outcome.lost) {
-        await this.archiveRelayLostWorker(lost)
-      }
-    } catch {
+      await this.archiveRelayLostWorkerGroups(revived.outcome.lost, stagedSnapshots)
+    } catch (error) {
       // A malformed capable response is fail-closed in the provider adapter; never retry revive here.
+      this.reportLostWorkerArchiveDiagnostic({ stage: 'revive', error })
     }
   }
 
-  private async archiveRelayLostWorker(lost: RelayPtyLostEntry): Promise<void> {
+  private async archiveRelayLostWorkerGroups(
+    lostEntries: readonly RelayPtyLostEntry[],
+    stagedSnapshots: RelayStagedPtySnapshots
+  ): Promise<void> {
+    const executionHostId = toSshExecutionHostId(this.targetId)
+    const entriesByTab = new Map<string, RelayPtyLostEntry[]>()
+    for (const lost of lostEntries) {
+      if (!lost.worktreeId || !lost.tabId || !lost.paneKey) {
+        continue
+      }
+      const key = `${lost.worktreeId}\u0000${lost.tabId}`
+      const entries = entriesByTab.get(key) ?? []
+      entries.push(lost)
+      entriesByTab.set(key, entries)
+    }
+
+    for (const entries of entriesByTab.values()) {
+      const [first] = entries
+      if (!first?.worktreeId || !first.tabId) {
+        continue
+      }
+      const session = this.store.getWorkspaceSession(executionHostId)
+      const workerEvidence = entries.find((entry) => {
+        const hint = entry.paneKey
+          ? session.terminalArchiveHintsByPaneKey?.[entry.paneKey]
+          : undefined
+        return entry.kind === 'recognized-worker' || classifyLostTerminal(hint).kind === 'worker'
+      })
+      if (!workerEvidence) {
+        continue
+      }
+      await this.archiveRelayLostWorker({
+        lost: workerEvidence,
+        session,
+        stagedSnapshots
+      })
+    }
+  }
+
+  private async archiveRelayLostWorker(args: {
+    lost: RelayPtyLostEntry
+    session: ReturnType<Store['getWorkspaceSession']>
+    stagedSnapshots: RelayStagedPtySnapshots
+  }): Promise<void> {
+    const { lost, session, stagedSnapshots } = args
     const worktreeId = lost.worktreeId
     const tabId = lost.tabId
     const paneKey = lost.paneKey
@@ -1033,11 +1083,6 @@ export class SshRelaySession {
       return
     }
     const executionHostId = toSshExecutionHostId(this.targetId)
-    const session = this.store.getWorkspaceSession(executionHostId)
-    const hint = session.terminalArchiveHintsByPaneKey?.[paneKey]
-    if (lost.kind !== 'recognized-worker' && classifyLostTerminal(hint).kind !== 'worker') {
-      return
-    }
     const captured = captureTerminalArchiveTab({ session, worktreeId, tabId })
     if (!captured) {
       return
@@ -1062,17 +1107,38 @@ export class SshRelaySession {
                 byteLength: getUtf8ByteLength(sidecar)
               }
         }
-        if (makePaneKey(tabId, leafId) !== paneKey || !lost.replayTail) {
+        const expectedSource = captured.sourcePaneIdentityByLeafId[leafId]
+        const staged = expectedSource
+          ? stagedSnapshots.snapshotsByPaneKey.get(expectedSource.paneKey)
+          : undefined
+        if (!staged || staged.sourceIncarnationId !== expectedSource?.incarnationId) {
+          this.reportLostWorkerArchiveDiagnostic({
+            stage:
+              stagedSnapshots.kind === 'legacy'
+                ? 'staged-state-legacy'
+                : stagedSnapshots.kind === 'missing'
+                  ? 'staged-state-missing'
+                  : stagedSnapshots.kind === 'invalid'
+                    ? 'envelope-parse'
+                    : 'archive',
+            tabId,
+            paneKey: expectedSource?.paneKey,
+            error: stagedSnapshots.kind === 'v2' ? undefined : new Error(stagedSnapshots.kind)
+          })
           return { kind: 'unavailable' }
         }
-        return lost.replayTail.data.length === 0
+        const replayTail = staged.replayTail
+        if (!replayTail || (replayTail.data.length === 0 && replayTail.truncated)) {
+          return { kind: 'unavailable' }
+        }
+        return replayTail.data.length === 0
           ? { kind: 'captured-empty' }
           : {
               kind: 'captured-bytes',
-              buffer: lost.replayTail.data,
+              buffer: replayTail.data,
               source: 'relay-tail',
-              truncated: lost.replayTail.truncated,
-              byteLength: lost.replayTail.byteLength
+              truncated: replayTail.truncated,
+              byteLength: replayTail.byteLength
             }
       }
     }
@@ -1083,6 +1149,7 @@ export class SshRelaySession {
         executionHostId,
         worktreeId,
         tabId,
+        sshTerminationTargetId: this.targetId,
         expectedSourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId,
         relayEvidence: lost
       },
@@ -1090,14 +1157,49 @@ export class SshRelaySession {
       snapshotSource
     })
     if (result.kind !== 'archived') {
+      this.reportLostWorkerArchiveDiagnostic({
+        stage: 'archive',
+        tabId,
+        paneKey,
+        error: new Error(result.code)
+      })
       return
     }
-    this.store.markSshRemotePtyLease(
-      this.targetId,
-      toRelaySshPtyId(this.targetId, lost.id),
-      'expired'
-    )
-    for (const ptyId of result.ptyIdsToKill) {
+    await this.shutdownArchivedRelayPtys(result.ptyIdsToKill, result.archive.id, tabId)
+  }
+
+  private async shutdownArchivedRelayPtys(
+    ptyIds: readonly string[],
+    archiveId: string,
+    tabId: string
+  ): Promise<void> {
+    const provider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    const outcomes = provider
+      ? await Promise.allSettled(
+          ptyIds.map((ptyId) => provider.shutdown(ptyId, { immediate: true, keepHistory: false }))
+        )
+      : ptyIds.map(
+          () => ({ status: 'rejected', reason: new Error('SSH provider unavailable') }) as const
+        )
+    for (const [index, outcome] of outcomes.entries()) {
+      const ptyId = ptyIds[index]
+      if (!ptyId) {
+        continue
+      }
+      const succeeded = outcome.status === 'fulfilled' || isSshPtyNotFoundError(outcome.reason)
+      if (succeeded) {
+        this.store.markSshRemotePtyLease(
+          this.targetId,
+          toRelaySshPtyId(this.targetId, ptyId),
+          'terminated'
+        )
+      } else {
+        this.reportLostWorkerArchiveDiagnostic({
+          stage: 'shutdown',
+          tabId,
+          error: outcome.reason
+        })
+      }
       clearProviderPtyState(ptyId)
       deletePtyOwnership(ptyId)
       routeExternalPtyExit({
@@ -1105,16 +1207,79 @@ export class SshRelaySession {
         code: -1,
         lostWorkerRecovery: {
           kind: 'archived',
-          archiveId: result.archive.id
+          archiveId
         }
       })
     }
   }
 
+  private async retryTerminationPendingPtys(): Promise<void> {
+    const provider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    if (!provider) {
+      return
+    }
+    const pending = this.store
+      .getSshRemotePtyLeases(this.targetId)
+      .filter((lease) => lease.state === 'termination-pending')
+    const outcomes = await Promise.allSettled(
+      pending.map((lease) =>
+        provider.shutdown(toAppSshPtyId(this.targetId, lease.ptyId), {
+          immediate: true,
+          keepHistory: false
+        })
+      )
+    )
+    for (const [index, outcome] of outcomes.entries()) {
+      const lease = pending[index]
+      if (!lease) {
+        continue
+      }
+      const appPtyId = toAppSshPtyId(this.targetId, lease.ptyId)
+      if (outcome.status === 'fulfilled' || isSshPtyNotFoundError(outcome.reason)) {
+        this.store.markSshRemotePtyLease(this.targetId, lease.ptyId, 'terminated')
+        clearProviderPtyState(appPtyId)
+        deletePtyOwnership(appPtyId)
+      } else {
+        this.reportLostWorkerArchiveDiagnostic({
+          stage: 'shutdown',
+          tabId: lease.tabId,
+          error: outcome.reason
+        })
+      }
+    }
+  }
+
+  private reportLostWorkerArchiveDiagnostic(args: {
+    stage:
+      | 'stage-serialize'
+      | 'staged-state-legacy'
+      | 'staged-state-missing'
+      | 'envelope-parse'
+      | 'revive'
+      | 'archive'
+      | 'shutdown'
+    tabId?: string
+    paneKey?: string
+    error?: unknown
+  }): void {
+    console.warn('[ssh-relay-session] lost-worker archive diagnostic', {
+      targetId: this.targetId,
+      tabId: args.tabId,
+      paneKey: args.paneKey,
+      stage: args.stage,
+      error: args.error instanceof Error ? args.error.message : undefined
+    })
+  }
+
   private async reattachKnownPtys(shouldContinue: () => boolean): Promise<void> {
     const activeLeases = this.store
       .getSshRemotePtyLeases(this.targetId)
-      .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+      .filter(
+        (lease) =>
+          lease.state !== 'termination-pending' &&
+          lease.state !== 'terminated' &&
+          lease.state !== 'expired'
+      )
     const activeLeaseByPtyId = new Map(activeLeases.map((lease) => [lease.ptyId, lease]))
     const leasedPtyIds = activeLeases.map((lease) => lease.ptyId)
     // Why: pass pane identity so the relay can reject cross-generation id collisions; tabId falls back for pre-leafId leases.

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -69,13 +69,10 @@ import { toSshExecutionHostId, type ExecutionHostId } from '../../shared/executi
 import { isTerminalLeafId, makePaneKey } from '../../shared/stable-pane-id'
 import { isValidTerminalTabId } from '../../shared/terminal-tab-id'
 import { classifyLostTerminal } from '../../shared/terminal-lost-worker-policy'
-import {
-  captureTerminalArchiveTab,
-  type TerminalArchivePaneSnapshotCapture
-} from '../../shared/workspace-session-terminal-archive'
-import type { ArchivedTerminalPane } from '../../shared/terminal-archive-types'
+import { captureTerminalArchiveTab } from '../../shared/workspace-session-terminal-archive'
 import { captureTerminalArchiveBuffer } from '../../shared/terminal-archive-snapshot-capture'
 import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
+import { createRelayLostWorkerSnapshotSource } from '../terminal-lost-worker-snapshot-source'
 import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
 import {
   decodeRelayStagedPtySnapshots,
@@ -1102,9 +1099,8 @@ export class SshRelaySession {
     if (!captured) {
       return
     }
-    const snapshotSource = {
-      capture: async (pane: ArchivedTerminalPane): Promise<TerminalArchivePaneSnapshotCapture> => {
-        const leafId = pane.archivedLeafId
+    const snapshotSource = createRelayLostWorkerSnapshotSource({
+      captureSessionSidecar: (leafId) => {
         const layout = session.terminalLayoutsByTabId[tabId]
         const sidecar =
           layout?.buffersByLeafId?.[leafId] ??
@@ -1114,6 +1110,9 @@ export class SshRelaySession {
         if (typeof sidecar === 'string') {
           return captureTerminalArchiveBuffer({ buffer: sidecar, source: 'session-sidecar' })
         }
+        return undefined
+      },
+      captureRelayTail: (leafId) => {
         const expectedSource = captured.sourcePaneIdentityByLeafId[leafId]
         const staged = expectedSource
           ? stagedSnapshots.snapshotsByPaneKey.get(expectedSource.paneKey)
@@ -1144,7 +1143,7 @@ export class SshRelaySession {
           truncated: replayTail.truncated
         })
       }
-    }
+    })
     const result = await archiveLostTerminalWorker({
       owner: this.store,
       candidate: {

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1154,6 +1154,7 @@ export class SshRelaySession {
         worktreeId,
         tabId,
         sshTerminationTargetId: this.targetId,
+        attempt: this.lostWorkerArchiveAttempt,
         expectedSourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId,
         relayEvidence: lost
       },

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1043,13 +1043,16 @@ export class SshRelaySession {
             })
             // Why: reconnect may be the first new-relay response that can backfill exact exit fencing.
             try {
-              this.store.persistPtyBinding({
-                worktreeId: lease.worktreeId,
-                tabId: lease.tabId,
-                leafId: lease.leafId,
-                ptyId: appPtyId,
-                incarnationId: attachResult.incarnationId
-              })
+              this.store.persistPtyBinding(
+                {
+                  worktreeId: lease.worktreeId,
+                  tabId: lease.tabId,
+                  leafId: lease.leafId,
+                  ptyId: appPtyId,
+                  incarnationId: attachResult.incarnationId
+                },
+                toSshExecutionHostId(this.targetId)
+              )
             } catch (error) {
               // Why: this backfill improves future fencing but must not disconnect an already-live relay PTY.
               console.error('[ssh-relay-session] Failed to persist reconnect incarnation:', error)

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1100,6 +1100,7 @@ export class SshRelaySession {
     if (!captured) {
       return
     }
+    const reconnectAttempt = this.abortController
     const snapshotSource = createRelayLostWorkerSnapshotSource({
       captureSessionSidecar: (leafId) => {
         const layout = session.terminalLayoutsByTabId[tabId]
@@ -1158,6 +1159,14 @@ export class SshRelaySession {
       },
       frozenSession: session,
       snapshotSource,
+      ...(reconnectAttempt
+        ? {
+            isCaptureAttemptCurrent: () =>
+              this.abortController === reconnectAttempt &&
+              !reconnectAttempt.signal.aborted &&
+              !this.isDisposed()
+          }
+        : {}),
       completeArchive: ({ archive, ptyIdsToKill }) =>
         this.shutdownArchivedRelayPtys(ptyIdsToKill, archive.id, tabId)
     })

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -74,7 +74,7 @@ import {
   type TerminalArchivePaneSnapshotCapture
 } from '../../shared/workspace-session-terminal-archive'
 import type { ArchivedTerminalPane } from '../../shared/terminal-archive-types'
-import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import { captureTerminalArchiveBuffer } from '../../shared/terminal-archive-snapshot-capture'
 import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
 import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
 import {
@@ -1097,15 +1097,7 @@ export class SshRelaySession {
             ? this.store.readTerminalScrollbackSnapshot(layout.scrollbackRefsByLeafId[leafId])
             : null)
         if (typeof sidecar === 'string') {
-          return sidecar.length === 0
-            ? { kind: 'captured-empty' }
-            : {
-                kind: 'captured-bytes',
-                buffer: sidecar,
-                source: 'session-sidecar',
-                truncated: false,
-                byteLength: getUtf8ByteLength(sidecar)
-              }
+          return captureTerminalArchiveBuffer({ buffer: sidecar, source: 'session-sidecar' })
         }
         const expectedSource = captured.sourcePaneIdentityByLeafId[leafId]
         const staged = expectedSource
@@ -1128,18 +1120,14 @@ export class SshRelaySession {
           return { kind: 'unavailable' }
         }
         const replayTail = staged.replayTail
-        if (!replayTail || (replayTail.data.length === 0 && replayTail.truncated)) {
+        if (!replayTail) {
           return { kind: 'unavailable' }
         }
-        return replayTail.data.length === 0
-          ? { kind: 'captured-empty' }
-          : {
-              kind: 'captured-bytes',
-              buffer: replayTail.data,
-              source: 'relay-tail',
-              truncated: replayTail.truncated,
-              byteLength: replayTail.byteLength
-            }
+        return captureTerminalArchiveBuffer({
+          buffer: replayTail.data,
+          source: 'relay-tail',
+          truncated: replayTail.truncated
+        })
       }
     }
     const result = await archiveLostTerminalWorker({

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1098,7 +1098,16 @@ export class SshRelaySession {
       'expired'
     )
     for (const ptyId of result.ptyIdsToKill) {
-      routeExternalPtyExit({ id: ptyId, code: -1 })
+      clearProviderPtyState(ptyId)
+      deletePtyOwnership(ptyId)
+      routeExternalPtyExit({
+        id: ptyId,
+        code: -1,
+        lostWorkerRecovery: {
+          kind: 'archived',
+          archiveId: result.archive.id
+        }
+      })
     }
   }
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -86,6 +86,7 @@ export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' 
 
 type SshPtyExitPayload = Parameters<SshPtyExitCallback>[0]
 type PendingPtyReattach = { exits: SshPtyExitPayload[] }
+type PendingArchivedExitRecovery = { archiveId: string; receiptDelivered: boolean }
 
 type RemoteCliBridgeEnv = {
   remoteHome: string
@@ -165,6 +166,7 @@ export class SshRelaySession {
   private forwardedReattachReplayByPty = new Map<string, ForwardedReplayFingerprint>()
   private pendingPtyReattaches = new Map<string, PendingPtyReattach>()
   private pendingPtyReviveState: string | null = null
+  private archivedExitRecoveryByPtyId = new Map<string, PendingArchivedExitRecovery>()
 
   constructor(
     readonly targetId: string,
@@ -958,12 +960,25 @@ export class SshRelaySession {
 
   private retireExitedPty(payload: SshPtyExitPayload): void {
     const relayPtyId = toRelaySshPtyId(this.targetId, payload.id)
+    const recovery = this.archivedExitRecoveryByPtyId.get(payload.id)
+    this.archivedExitRecoveryByPtyId.delete(payload.id)
     clearProviderPtyState(payload.id)
     deletePtyOwnership(payload.id)
     this.forwardedReattachReplayByPty.delete(payload.id)
     this.store.markSshRemotePtyLease(this.targetId, relayPtyId, 'terminated')
     this.runtime?.onPtyExit(payload.id, payload.code, payload.incarnationId)
-    routeExternalPtyExit(payload)
+    if (recovery?.receiptDelivered) {
+      return
+    }
+    if (!recovery) {
+      routeExternalPtyExit(payload)
+      return
+    }
+    routeExternalPtyExit({
+      id: payload.id,
+      code: payload.code,
+      lostWorkerRecovery: { kind: 'archived', archiveId: recovery.archiveId }
+    })
   }
 
   private replayFingerprint(data: string): string {
@@ -1162,6 +1177,10 @@ export class SshRelaySession {
     tabId: string
   ): Promise<void> {
     const provider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    for (const ptyId of ptyIds) {
+      // Why: shutdown can synchronously emit onExit, which must carry the archive receipt instead of a normal exit.
+      this.archivedExitRecoveryByPtyId.set(ptyId, { archiveId, receiptDelivered: false })
+    }
     const outcomes = provider
       ? await Promise.allSettled(
           ptyIds.map((ptyId) => provider.shutdown(ptyId, { immediate: true, keepHistory: false }))
@@ -1190,14 +1209,18 @@ export class SshRelaySession {
       }
       clearProviderPtyState(ptyId)
       deletePtyOwnership(ptyId)
-      routeExternalPtyExit({
-        id: ptyId,
-        code: -1,
-        lostWorkerRecovery: {
-          kind: 'archived',
-          archiveId
-        }
-      })
+      const recovery = this.archivedExitRecoveryByPtyId.get(ptyId)
+      if (recovery && !recovery.receiptDelivered) {
+        recovery.receiptDelivered = true
+        routeExternalPtyExit({
+          id: ptyId,
+          code: -1,
+          lostWorkerRecovery: {
+            kind: 'archived',
+            archiveId: recovery.archiveId
+          }
+        })
+      }
     }
   }
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -312,6 +312,8 @@ export class SshRelaySession {
         throw new Error('Session disposed during establish')
       }
 
+      await this.retryTerminationPendingPtys()
+
       // Why: explicit disconnect keeps PTY ownership, so a later manual connect must reattach those remote PTYs.
       await this.reattachKnownPtys(ownsAttempt)
 

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -68,6 +68,15 @@ import { runRemoteOrcaCli } from './ssh-remote-orca-cli'
 import { toSshExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
 import { isTerminalLeafId, makePaneKey } from '../../shared/stable-pane-id'
 import { isValidTerminalTabId } from '../../shared/terminal-tab-id'
+import { classifyLostTerminal } from '../../shared/terminal-lost-worker-policy'
+import {
+  captureTerminalArchiveTab,
+  type TerminalArchivePaneSnapshotCapture
+} from '../../shared/workspace-session-terminal-archive'
+import type { ArchivedTerminalPane } from '../../shared/terminal-archive-types'
+import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import { archiveLostTerminalWorker } from '../terminal-lost-worker-archive'
+import type { RelayPtyLostEntry } from '../../shared/pty-revive-protocol'
 
 export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' | 'disposed'
 
@@ -151,6 +160,7 @@ export class SshRelaySession {
   private remoteCliBridgeEnv: RemoteCliBridgeEnv | null = null
   private forwardedReattachReplayByPty = new Map<string, ForwardedReplayFingerprint>()
   private pendingPtyReattaches = new Map<string, PendingPtyReattach>()
+  private pendingPtyReviveState: string | null = null
 
   constructor(
     readonly targetId: string,
@@ -345,6 +355,7 @@ export class SshRelaySession {
     this.stopPortScanning()
     await this.portForwardManager.removeAllForwards(this.targetId)
     this.broadcastEmptyLists()
+    await this.stagePtyReviveBeforeProviderTeardown()
     this.teardownProviders('connection_lost')
 
     try {
@@ -399,6 +410,8 @@ export class SshRelaySession {
       if (mux.isDisposed()) {
         throw new Error('Relay connection lost during provider registration')
       }
+
+      await this.reviveStagedPtysAfterProviderRegistration()
 
       // Why: dispose() during registration/attach already cleaned up, but this.mux was reassigned above — clean up the new mux so it doesn't leak.
       if (!ownsAttempt()) {
@@ -971,6 +984,122 @@ export class SshRelaySession {
       return
     }
     routeExternalPtyReplay({ id: appPtyId, data })
+  }
+
+  private async stagePtyReviveBeforeProviderTeardown(): Promise<void> {
+    const provider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    const ptyIds = getPtyIdsForConnection(this.targetId).map((ptyId) =>
+      toRelaySshPtyId(this.targetId, ptyId)
+    )
+    if (!provider || ptyIds.length === 0) {
+      return
+    }
+    try {
+      this.pendingPtyReviveState = await provider.serialize(ptyIds, { formatVersion: 2 })
+    } catch {
+      // The old relay may already be gone; leases and persisted hints remain the only honest fallback.
+      this.pendingPtyReviveState = null
+    }
+  }
+
+  private async reviveStagedPtysAfterProviderRegistration(): Promise<void> {
+    const state = this.pendingPtyReviveState
+    this.pendingPtyReviveState = null
+    if (!state) {
+      return
+    }
+    const provider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    if (!provider) {
+      return
+    }
+    try {
+      const revived = await provider.revive(state, { formatVersion: 2 })
+      if (revived.mode !== 'typed') {
+        return
+      }
+      for (const lost of revived.outcome.lost) {
+        await this.archiveRelayLostWorker(lost)
+      }
+    } catch {
+      // A malformed capable response is fail-closed in the provider adapter; never retry revive here.
+    }
+  }
+
+  private async archiveRelayLostWorker(lost: RelayPtyLostEntry): Promise<void> {
+    const worktreeId = lost.worktreeId
+    const tabId = lost.tabId
+    const paneKey = lost.paneKey
+    if (!worktreeId || !tabId || !paneKey) {
+      return
+    }
+    const executionHostId = toSshExecutionHostId(this.targetId)
+    const session = this.store.getWorkspaceSession(executionHostId)
+    const hint = session.terminalArchiveHintsByPaneKey?.[paneKey]
+    if (lost.kind !== 'recognized-worker' && classifyLostTerminal(hint).kind !== 'worker') {
+      return
+    }
+    const captured = captureTerminalArchiveTab({ session, worktreeId, tabId })
+    if (!captured) {
+      return
+    }
+    const snapshotSource = {
+      capture: async (pane: ArchivedTerminalPane): Promise<TerminalArchivePaneSnapshotCapture> => {
+        const leafId = pane.archivedLeafId
+        const layout = session.terminalLayoutsByTabId[tabId]
+        const sidecar =
+          layout?.buffersByLeafId?.[leafId] ??
+          (layout?.scrollbackRefsByLeafId?.[leafId]
+            ? this.store.readTerminalScrollbackSnapshot(layout.scrollbackRefsByLeafId[leafId])
+            : null)
+        if (typeof sidecar === 'string') {
+          return sidecar.length === 0
+            ? { kind: 'captured-empty' }
+            : {
+                kind: 'captured-bytes',
+                buffer: sidecar,
+                source: 'session-sidecar',
+                truncated: false,
+                byteLength: getUtf8ByteLength(sidecar)
+              }
+        }
+        if (makePaneKey(tabId, leafId) !== paneKey || !lost.replayTail) {
+          return { kind: 'unavailable' }
+        }
+        return lost.replayTail.data.length === 0
+          ? { kind: 'captured-empty' }
+          : {
+              kind: 'captured-bytes',
+              buffer: lost.replayTail.data,
+              source: 'relay-tail',
+              truncated: lost.replayTail.truncated,
+              byteLength: lost.replayTail.byteLength
+            }
+      }
+    }
+    const result = await archiveLostTerminalWorker({
+      owner: this.store,
+      candidate: {
+        reason: 'relay-worker-lost',
+        executionHostId,
+        worktreeId,
+        tabId,
+        expectedSourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId,
+        relayEvidence: lost
+      },
+      frozenSession: session,
+      snapshotSource
+    })
+    if (result.kind !== 'archived') {
+      return
+    }
+    this.store.markSshRemotePtyLease(
+      this.targetId,
+      toRelaySshPtyId(this.targetId, lost.id),
+      'expired'
+    )
+    for (const ptyId of result.ptyIdsToKill) {
+      routeExternalPtyExit({ id: ptyId, code: -1 })
+    }
   }
 
   private async reattachKnownPtys(shouldContinue: () => boolean): Promise<void> {

--- a/src/main/terminal-archive-contracts.ts
+++ b/src/main/terminal-archive-contracts.ts
@@ -1,0 +1,41 @@
+import type {
+  ArchivedTerminalLayout,
+  ArchivedTerminalPane,
+  TerminalArchiveReason
+} from '../shared/terminal-archive-types'
+import type { ExecutionHostId } from '../shared/execution-host'
+import type { WorkspaceSessionTerminalTabCloseResult } from '../shared/workspace-session-terminal-tab-close'
+import type { TerminalArchiveSourcePaneIdentity } from './terminal-archive-source-pane-signature'
+
+export type ArchiveTerminalTabRequest = {
+  operationId: string
+  sourceTabId: string
+  executionHostId: ExecutionHostId
+  runtimeEnvironmentId?: string
+  worktreeId: string
+  title: string
+  defaultTitle?: string
+  color?: string | null
+  layout: ArchivedTerminalLayout
+  panesByLeafId: Record<string, ArchivedTerminalPane>
+  sourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
+  reason: TerminalArchiveReason
+  createdAt?: number
+  capturedAt?: number
+  archivedAt?: number
+}
+
+export type LostTerminalArchiveRetirement = {
+  worktreeId: string
+  tabId: string
+  executionHostId: ExecutionHostId
+  sshTerminationTargetId?: string
+}
+
+export type LostTerminalArchiveRetirementResult = WorkspaceSessionTerminalTabCloseResult
+
+export type TerminalArchiveListFilter = { executionHostId?: ExecutionHostId; worktreeId?: string }
+
+export type TerminalArchiveRestoreTarget = { executionHostId?: ExecutionHostId }
+
+export type PruneResult = { prunedIds: string[]; deletedSnapshotRefs: string[] }

--- a/src/main/terminal-archive-expiry-scheduler.ts
+++ b/src/main/terminal-archive-expiry-scheduler.ts
@@ -1,0 +1,61 @@
+const INITIAL_PRUNE_RETRY_DELAY_MS = 1_000
+const MAX_PRUNE_RETRY_DELAY_MS = 60_000
+const MAX_TIMER_DELAY_MS = 2_147_483_647
+
+export class TerminalArchiveExpiryScheduler {
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private disposed = false
+  private retryDelayMs = INITIAL_PRUNE_RETRY_DELAY_MS
+
+  constructor(
+    private readonly now: () => number,
+    private readonly prune: () => Promise<void>
+  ) {}
+
+  schedule(nextExpiry: number | null): void {
+    if (this.disposed) {
+      return
+    }
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+    if (nextExpiry === null) {
+      return
+    }
+    const delay = Math.max(0, Math.min(nextExpiry - this.now(), MAX_TIMER_DELAY_MS))
+    this.scheduleAfter(delay)
+  }
+
+  dispose(): void {
+    this.disposed = true
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  private scheduleAfter(delay: number): void {
+    if (this.disposed) {
+      return
+    }
+    this.timer = setTimeout(() => {
+      this.timer = null
+      void this.prune().then(
+        () => {
+          this.retryDelayMs = INITIAL_PRUNE_RETRY_DELAY_MS
+        },
+        () => {
+          if (this.disposed) {
+            return
+          }
+          console.warn('[terminal-archive] Failed to prune expired archives; retrying')
+          const retryDelay = this.retryDelayMs
+          this.retryDelayMs = Math.min(this.retryDelayMs * 2, MAX_PRUNE_RETRY_DELAY_MS)
+          this.scheduleAfter(retryDelay)
+        }
+      )
+    }, delay)
+    this.timer.unref?.()
+  }
+}

--- a/src/main/terminal-archive-failure.ts
+++ b/src/main/terminal-archive-failure.ts
@@ -1,0 +1,13 @@
+export type TerminalArchiveFailureCode =
+  | 'not-owned'
+  | 'stale-source'
+  | 'capture-unavailable'
+  | 'contract-invalid'
+
+/** A bounded failure classification for policy callers; never includes terminal content. */
+export class TerminalArchiveError extends Error {
+  constructor(readonly code: TerminalArchiveFailureCode) {
+    super(code)
+    this.name = 'TerminalArchiveError'
+  }
+}

--- a/src/main/terminal-archive-snapshot-staging.ts
+++ b/src/main/terminal-archive-snapshot-staging.ts
@@ -1,0 +1,68 @@
+import type { ArchivedTerminalPane, ArchivedTerminalTab } from '../shared/terminal-archive-types'
+import type { TerminalArchivePaneSnapshotInput } from '../shared/workspace-session-terminal-archive'
+import { TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT } from '../shared/terminal-scrollback-limits'
+import {
+  deleteTerminalScrollbackSnapshotSync,
+  trailingUtf8Bytes,
+  writeTerminalArchiveScrollbackSnapshotSync
+} from './terminal-scrollback-snapshots'
+import type { TerminalScrollbackSnapshotStorage } from './terminal-scrollback-snapshots'
+
+export function stageTerminalArchivePaneSnapshot(args: {
+  archiveId: string
+  snapshotVersion: string
+  pane: ArchivedTerminalPane
+  snapshot: TerminalArchivePaneSnapshotInput
+  storage: TerminalScrollbackSnapshotStorage | undefined
+}): { pane: ArchivedTerminalPane; writtenRef?: string } {
+  const cappedBuffer = trailingUtf8Bytes(
+    args.snapshot.buffer,
+    TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT
+  )
+  const written = writeTerminalArchiveScrollbackSnapshotSync({
+    archiveId: args.archiveId,
+    leafId: args.pane.archivedLeafId,
+    buffer: cappedBuffer.toString('utf-8'),
+    snapshotVersion: args.snapshotVersion,
+    storage: args.storage
+  })
+  if (written.kind === 'failed') {
+    throw new Error('Failed to write terminal archive scrollback snapshot')
+  }
+  if (written.kind === 'empty') {
+    return { pane: args.pane }
+  }
+  return {
+    pane: {
+      ...args.pane,
+      snapshot: {
+        ref: written.ref,
+        byteLength: written.byteLength,
+        truncated:
+          args.snapshot.truncated === true ||
+          Buffer.byteLength(args.snapshot.buffer, 'utf-8') > cappedBuffer.byteLength ||
+          written.truncated,
+        source: args.snapshot.source
+      }
+    },
+    writtenRef: written.ref
+  }
+}
+
+export function deleteUnreferencedTerminalArchiveSnapshots(args: {
+  archives: readonly ArchivedTerminalTab[]
+  isLive: (ref: string) => boolean
+  storage: TerminalScrollbackSnapshotStorage | undefined
+}): string[] {
+  const deletedRefs: string[] = []
+  for (const archive of args.archives) {
+    for (const pane of Object.values(archive.panesByLeafId)) {
+      const ref = pane.snapshot?.ref
+      if (ref && !args.isLive(ref)) {
+        deleteTerminalScrollbackSnapshotSync(ref, args.storage)
+        deletedRefs.push(ref)
+      }
+    }
+  }
+  return deletedRefs
+}

--- a/src/main/terminal-archive-source-pane-signature.ts
+++ b/src/main/terminal-archive-source-pane-signature.ts
@@ -1,0 +1,25 @@
+import { createHash } from 'node:crypto'
+import type { ArchivedTerminalPane } from '../shared/terminal-archive-types'
+
+export type TerminalArchiveSourcePaneIdentity = {
+  paneKey: string
+  incarnationId: string
+}
+
+export function makeTerminalArchiveSourcePaneSignature(
+  panesByLeafId: Record<string, ArchivedTerminalPane>,
+  sourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
+): string {
+  const leafIds = Object.keys(panesByLeafId).sort()
+  if (leafIds.length !== Object.keys(sourcePaneIdentityByLeafId).length) {
+    throw new Error('Terminal archive source pane identities must match archived panes')
+  }
+  const canonical = leafIds.map((leafId) => {
+    const sourcePane = sourcePaneIdentityByLeafId[leafId]
+    if (!sourcePane?.paneKey || !sourcePane.incarnationId) {
+      throw new Error('Terminal archive source pane identities must include an incarnation')
+    }
+    return [leafId, sourcePane.paneKey, sourcePane.incarnationId]
+  })
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex')
+}

--- a/src/main/terminal-archive-store.test.ts
+++ b/src/main/terminal-archive-store.test.ts
@@ -1,0 +1,387 @@
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ArchivedTerminalTab } from '../shared/terminal-archive-types'
+import type { TerminalArchiveSnapshotSource } from '../shared/workspace-session-terminal-archive'
+import { TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT } from '../shared/terminal-scrollback-limits'
+import {
+  TerminalArchiveStore,
+  type ArchiveTerminalTabRequest,
+  type TerminalArchiveRepository
+} from './terminal-archive-store'
+import { readTerminalScrollbackSnapshotSync } from './terminal-scrollback-snapshots'
+
+const testState = vi.hoisted(() => ({ root: '' }))
+
+vi.mock('electron', () => ({ app: { getPath: () => testState.root } }))
+
+const WORKTREE_ID = 'repo-1::/worktree'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1_000
+
+function request(overrides: Partial<ArchiveTerminalTabRequest> = {}): ArchiveTerminalTabRequest {
+  return {
+    operationId: 'close-intent-1',
+    sourceTabId: 'tab-1',
+    executionHostId: 'local',
+    worktreeId: WORKTREE_ID,
+    title: 'Terminal',
+    layout: {
+      root: { type: 'leaf', leafId: LEAF_ID },
+      activeLeafId: LEAF_ID,
+      expandedLeafId: null
+    },
+    panesByLeafId: {
+      [LEAF_ID]: {
+        archivedLeafId: LEAF_ID,
+        cwd: '/worktree',
+        startupCommand: 'token-like-command-must-not-be-logged'
+      }
+    },
+    sourcePaneIdentityByLeafId: {
+      [LEAF_ID]: { paneKey: `tab-1:${LEAF_ID}`, incarnationId: 'original-incarnation' }
+    },
+    reason: 'user-close',
+    ...overrides
+  }
+}
+
+function repository(options: { failFlush?: boolean } = {}): {
+  value: TerminalArchiveRepository
+  archives: Record<string, ArchivedTerminalTab>
+} {
+  let archives: Record<string, ArchivedTerminalTab> = {}
+  const storage = { snapshotRoot: join(testState.root, 'terminal-scrollback') }
+  return {
+    get archives() {
+      return archives
+    },
+    value: {
+      getTerminalArchives: () => ({ ...archives }),
+      replaceTerminalArchivesAndFlush: (next) => {
+        if (options.failFlush) {
+          throw new Error('disk unavailable')
+        }
+        archives = { ...next }
+      },
+      getTerminalArchiveRetentionDays: () => 7,
+      isExecutionHostReachable: (hostId) => hostId === 'local',
+      worktreeExists: (worktreeId, hostId) => worktreeId === WORKTREE_ID && hostId === 'local',
+      isTerminalScrollbackSnapshotLive: (ref) =>
+        Object.values(archives).some((archive) =>
+          Object.values(archive.panesByLeafId).some((pane) => pane.snapshot?.ref === ref)
+        ),
+      terminalScrollbackSnapshotStorage: storage
+    }
+  }
+}
+
+function source(buffer = 'snapshot'): TerminalArchiveSnapshotSource {
+  return {
+    capture: vi.fn(async () => ({
+      kind: 'captured-bytes' as const,
+      buffer,
+      source: 'renderer' as const,
+      truncated: false,
+      byteLength: Buffer.byteLength(buffer)
+    }))
+  }
+}
+
+describe('TerminalArchiveStore', () => {
+  beforeEach(() => {
+    testState.root = mkdtempSync(join(tmpdir(), 'orca-terminal-archive-'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    rmSync(testState.root, { recursive: true, force: true })
+  })
+
+  it('writes archive metadata atomically and de-duplicates the close operation', async () => {
+    const repo = repository()
+    const snapshotSource = source()
+    const store = new TerminalArchiveStore(repo.value, snapshotSource, () => 100)
+
+    const first = await store.archiveTerminalTab(request())
+    const retried = await store.archiveTerminalTab(request())
+
+    expect(retried.id).toBe(first.id)
+    expect(Object.keys(repo.archives)).toEqual([first.id])
+    expect(snapshotSource.capture).toHaveBeenCalledTimes(2)
+    expect(first.panesByLeafId[LEAF_ID]?.snapshot?.ref).toMatch(/^v1a-[0-9a-f]{32}$/)
+  })
+
+  it('uses the store clock instead of a request timestamp for pruning and expiry', async () => {
+    let currentTime = 100
+    const repo = repository()
+    const store = new TerminalArchiveStore(repo.value, source(), () => currentTime)
+    const first = await store.archiveTerminalTab(request())
+
+    currentTime = 200
+    const second = await store.archiveTerminalTab(
+      request({ operationId: 'close-intent-2', archivedAt: RETENTION_MS * 2 })
+    )
+
+    expect(repo.archives[first.id]).toBeDefined()
+    expect(second.archivedAt).toBe(currentTime)
+    expect(second.expiresAt).toBe(currentTime + RETENTION_MS)
+  })
+
+  it('does not make a successful archive immediately expired from a stale request timestamp', async () => {
+    const currentTime = RETENTION_MS * 2
+    const repo = repository()
+    const store = new TerminalArchiveStore(repo.value, source(), () => currentTime)
+
+    const archive = await store.archiveTerminalTab(request({ archivedAt: 0 }))
+
+    expect(archive.archivedAt).toBe(currentTime)
+    expect(archive.expiresAt).toBe(currentTime + RETENTION_MS)
+    expect(repo.archives[archive.id]).toBeDefined()
+  })
+
+  it('recaptures and replaces the same archive record when a durable close retry has new output', async () => {
+    const repo = repository()
+    const snapshotSource: TerminalArchiveSnapshotSource = {
+      capture: vi
+        .fn()
+        .mockResolvedValueOnce({
+          kind: 'captured-bytes',
+          buffer: 'before retirement failed',
+          source: 'renderer',
+          truncated: false,
+          byteLength: 24
+        })
+        .mockResolvedValueOnce({
+          kind: 'captured-bytes',
+          buffer: 'after retry captured output',
+          source: 'renderer',
+          truncated: false,
+          byteLength: 27
+        })
+    }
+    const store = new TerminalArchiveStore(repo.value, snapshotSource, () => 100)
+
+    const first = await store.archiveTerminalTab(request())
+    const retried = await store.archiveTerminalTab(request())
+    const snapshot = retried.panesByLeafId[LEAF_ID]?.snapshot
+
+    expect(retried.id).toBe(first.id)
+    expect(Object.keys(repo.archives)).toEqual([first.id])
+    expect(retried.sourcePaneSignature).toMatch(/^[0-9a-f]{64}$/)
+    expect(snapshotSource.capture).toHaveBeenCalledTimes(2)
+    expect(snapshot?.ref).not.toBe(first.panesByLeafId[LEAF_ID]?.snapshot?.ref)
+    expect(
+      snapshot &&
+        readTerminalScrollbackSnapshotSync(
+          snapshot.ref,
+          repo.value.terminalScrollbackSnapshotStorage
+        )
+    ).toBe('after retry captured output')
+  })
+
+  it('rejects a retry whose source pane incarnation changed', async () => {
+    const repo = repository()
+    const snapshotSource = source()
+    const store = new TerminalArchiveStore(repo.value, snapshotSource, () => 100)
+
+    await store.archiveTerminalTab(request())
+
+    await expect(
+      store.archiveTerminalTab(
+        request({
+          sourcePaneIdentityByLeafId: {
+            [LEAF_ID]: { paneKey: `tab-1:${LEAF_ID}`, incarnationId: 'replacement-incarnation' }
+          }
+        })
+      )
+    ).rejects.toThrow('different source pane incarnation')
+    expect(snapshotSource.capture).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails the archive when every snapshot source is unavailable', async () => {
+    const repo = repository()
+    const snapshotSource: TerminalArchiveSnapshotSource = {
+      capture: async () => ({ kind: 'unavailable' })
+    }
+    const store = new TerminalArchiveStore(repo.value, snapshotSource)
+
+    await expect(store.archiveTerminalTab(request())).rejects.toThrow(
+      'Terminal scrollback capture unavailable'
+    )
+    expect(repo.archives).toEqual({})
+  })
+
+  it('archives a known-empty terminal without writing a sidecar', async () => {
+    const repo = repository()
+    const snapshotSource: TerminalArchiveSnapshotSource = {
+      capture: async () => ({ kind: 'captured-empty' })
+    }
+    const store = new TerminalArchiveStore(repo.value, snapshotSource)
+
+    const archive = await store.archiveTerminalTab(request())
+
+    expect(archive.panesByLeafId[LEAF_ID]?.snapshot).toBeUndefined()
+    expect(repo.archives[archive.id]).toBeDefined()
+    expect(existsSync(join(testState.root, 'terminal-scrollback'))).toBe(false)
+  })
+
+  it('removes already-written sidecars when a later pane capture fails', async () => {
+    const repo = repository()
+    const secondLeaf = '22222222-2222-4222-8222-222222222222'
+    const snapshotSource: TerminalArchiveSnapshotSource = {
+      capture: vi
+        .fn()
+        .mockResolvedValueOnce({
+          kind: 'captured-bytes',
+          buffer: 'first',
+          source: 'renderer',
+          truncated: false,
+          byteLength: 5
+        })
+        .mockRejectedValueOnce(new Error('second capture failed'))
+    }
+    const store = new TerminalArchiveStore(repo.value, snapshotSource)
+
+    await expect(
+      store.archiveTerminalTab(
+        request({
+          panesByLeafId: {
+            [LEAF_ID]: { archivedLeafId: LEAF_ID, cwd: '/worktree' },
+            [secondLeaf]: { archivedLeafId: secondLeaf, cwd: '/worktree' }
+          },
+          sourcePaneIdentityByLeafId: {
+            [LEAF_ID]: { paneKey: `tab-1:${LEAF_ID}`, incarnationId: 'original-incarnation' },
+            [secondLeaf]: { paneKey: `tab-1:${secondLeaf}`, incarnationId: 'second-incarnation' }
+          }
+        })
+      )
+    ).rejects.toThrow('second capture failed')
+
+    expect(repo.archives).toEqual({})
+    expect(existsSync(join(testState.root, 'terminal-scrollback'))).toBe(true)
+    expect(readdirSync(join(testState.root, 'terminal-scrollback'))).toEqual([])
+  })
+
+  it('does not retain sidecars when the metadata flush fails', async () => {
+    const repo = repository({ failFlush: true })
+    const store = new TerminalArchiveStore(repo.value, source())
+
+    await expect(store.archiveTerminalTab(request())).rejects.toThrow('disk unavailable')
+
+    expect(repo.archives).toEqual({})
+    expect(readdirSync(join(testState.root, 'terminal-scrollback'))).toEqual([])
+  })
+
+  it('caps a UTF-8 snapshot at the replay limit without logging the command', async () => {
+    const repo = repository()
+    const warn = vi.spyOn(console, 'warn')
+    const log = vi.spyOn(console, 'log')
+    const store = new TerminalArchiveStore(repo.value, source('🦊'.repeat(200_000)))
+
+    const archive = await store.archiveTerminalTab(request())
+    const snapshot = archive.panesByLeafId[LEAF_ID]?.snapshot
+    const replay = snapshot
+      ? readTerminalScrollbackSnapshotSync(
+          snapshot.ref,
+          repo.value.terminalScrollbackSnapshotStorage
+        )
+      : null
+
+    expect(snapshot?.byteLength).toBeLessThanOrEqual(TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT)
+    expect(snapshot?.truncated).toBe(true)
+    expect(replay?.endsWith('🦊')).toBe(true)
+    expect(`${warn.mock.calls}${log.mock.calls}`).not.toContain(
+      'token-like-command-must-not-be-logged'
+    )
+    warn.mockRestore()
+    log.mockRestore()
+  })
+
+  it('keeps host and worktree validation errors stable before restore is implemented', async () => {
+    const repo = repository()
+    const store = new TerminalArchiveStore(repo.value, source(), () => 100)
+    const archive = await store.archiveTerminalTab(request())
+
+    await expect(
+      store.restoreTerminalArchive(archive.id, { executionHostId: 'ssh:other' })
+    ).resolves.toEqual({
+      ok: false,
+      code: 'archive_host_mismatch',
+      archiveId: archive.id
+    })
+    await expect(store.restoreTerminalArchive(archive.id)).resolves.toEqual({
+      ok: false,
+      code: 'not_implemented',
+      archiveId: archive.id
+    })
+    repo.value.worktreeExists = () => false
+    await expect(store.restoreTerminalArchive(archive.id)).resolves.toEqual({
+      ok: false,
+      code: 'archive_worktree_missing',
+      archiveId: archive.id
+    })
+  })
+
+  it('flushes expired metadata before deleting an unreferenced archive sidecar', async () => {
+    const repo = repository()
+    const store = new TerminalArchiveStore(repo.value, source(), () => 0)
+    const archive = await store.archiveTerminalTab(request())
+    const ref = archive.panesByLeafId[LEAF_ID]?.snapshot?.ref
+
+    const result = await store.pruneExpiredTerminalArchives(7 * 24 * 60 * 60 * 1_000)
+
+    expect(result.prunedIds).toEqual([archive.id])
+    expect(ref && result.deletedSnapshotRefs).toContain(ref)
+    expect(repo.archives).toEqual({})
+    expect(ref && existsSync(join(testState.root, 'terminal-scrollback', `${ref}.bin`))).toBe(false)
+  })
+
+  it('retries a failed timer prune with a bounded backoff and a non-sensitive diagnostic', async () => {
+    vi.useFakeTimers()
+    let currentTime = 0
+    const repo = repository()
+    const replace = repo.value.replaceTerminalArchivesAndFlush
+    let failNextPrune = true
+    repo.value.replaceTerminalArchivesAndFlush = (archives) => {
+      if (failNextPrune && Object.keys(archives).length === 0) {
+        failNextPrune = false
+        throw new Error('disk unavailable')
+      }
+      replace(archives)
+    }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const store = new TerminalArchiveStore(repo.value, source(), () => currentTime)
+    const archive = await store.archiveTerminalTab(request())
+
+    currentTime = RETENTION_MS
+    await vi.advanceTimersByTimeAsync(RETENTION_MS)
+
+    expect(repo.archives[archive.id]).toBeDefined()
+    expect(warn).toHaveBeenCalledWith(
+      '[terminal-archive] Failed to prune expired archives; retrying'
+    )
+    expect(vi.getTimerCount()).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(repo.archives[archive.id]).toBeDefined()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(repo.archives).toEqual({})
+    warn.mockRestore()
+  })
+
+  it('cancels the expiry timer when disposed', async () => {
+    vi.useFakeTimers()
+    let currentTime = 0
+    const repo = repository()
+    const store = new TerminalArchiveStore(repo.value, source(), () => currentTime)
+    const archive = await store.archiveTerminalTab(request())
+
+    store.dispose()
+    currentTime = RETENTION_MS
+    await vi.advanceTimersByTimeAsync(RETENTION_MS * 2)
+
+    expect(repo.archives[archive.id]).toBeDefined()
+  })
+})

--- a/src/main/terminal-archive-store.test.ts
+++ b/src/main/terminal-archive-store.test.ts
@@ -5,11 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ArchivedTerminalTab } from '../shared/terminal-archive-types'
 import type { TerminalArchiveSnapshotSource } from '../shared/workspace-session-terminal-archive'
 import { TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT } from '../shared/terminal-scrollback-limits'
-import {
-  TerminalArchiveStore,
-  type ArchiveTerminalTabRequest,
-  type TerminalArchiveRepository
-} from './terminal-archive-store'
+import { TerminalArchiveStore, type TerminalArchiveRepository } from './terminal-archive-store'
+import type { ArchiveTerminalTabRequest } from './terminal-archive-contracts'
 import { readTerminalScrollbackSnapshotSync } from './terminal-scrollback-snapshots'
 
 const testState = vi.hoisted(() => ({ root: '' }))

--- a/src/main/terminal-archive-store.test.ts
+++ b/src/main/terminal-archive-store.test.ts
@@ -68,6 +68,11 @@ function repository(options: { failFlush?: boolean } = {}): {
       getTerminalArchiveRetentionDays: () => 7,
       isExecutionHostReachable: (hostId) => hostId === 'local',
       worktreeExists: (worktreeId, hostId) => worktreeId === WORKTREE_ID && hostId === 'local',
+      // This fixture explicitly authorizes only its local test worktree; rejection has dedicated cases below.
+      isTerminalArchiveRequestOwned: (archiveRequest) =>
+        archiveRequest.executionHostId === 'local' &&
+        archiveRequest.worktreeId === WORKTREE_ID &&
+        archiveRequest.sourceTabId === 'tab-1',
       isTerminalScrollbackSnapshotLive: (ref) =>
         Object.values(archives).some((archive) =>
           Object.values(archive.panesByLeafId).some((pane) => pane.snapshot?.ref === ref)
@@ -196,7 +201,7 @@ describe('TerminalArchiveStore', () => {
           }
         })
       )
-    ).rejects.toThrow('different source pane incarnation')
+    ).rejects.toMatchObject({ code: 'stale-source' })
     expect(snapshotSource.capture).toHaveBeenCalledTimes(1)
   })
 
@@ -207,10 +212,45 @@ describe('TerminalArchiveStore', () => {
     }
     const store = new TerminalArchiveStore(repo.value, snapshotSource)
 
-    await expect(store.archiveTerminalTab(request())).rejects.toThrow(
-      'Terminal scrollback capture unavailable'
-    )
+    await expect(store.archiveTerminalTab(request())).rejects.toMatchObject({
+      code: 'capture-unavailable'
+    })
     expect(repo.archives).toEqual({})
+  })
+
+  it('rejects an unowned host/worktree/PTY request before sidecar capture', async () => {
+    const repo = repository()
+    const snapshotSource = source()
+    repo.value.isTerminalArchiveRequestOwned = vi.fn(() => false)
+    const store = new TerminalArchiveStore(repo.value, snapshotSource)
+
+    await expect(store.archiveTerminalTab(request())).rejects.toMatchObject({ code: 'not-owned' })
+
+    expect(snapshotSource.capture).not.toHaveBeenCalled()
+    expect(repo.archives).toEqual({})
+    expect(existsSync(join(testState.root, 'terminal-scrollback'))).toBe(false)
+  })
+
+  it('rechecks ownership after capture and rolls back staged sidecars on a topology CAS loss', async () => {
+    const repo = repository()
+    const ownership = vi
+      .fn<
+        (
+          request: Parameters<TerminalArchiveRepository['isTerminalArchiveRequestOwned']>[0]
+        ) => boolean
+      >()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+    repo.value.isTerminalArchiveRequestOwned = ownership
+    const snapshotSource = source()
+    const store = new TerminalArchiveStore(repo.value, snapshotSource)
+
+    await expect(store.archiveTerminalTab(request())).rejects.toMatchObject({ code: 'not-owned' })
+
+    expect(ownership).toHaveBeenCalledTimes(2)
+    expect(snapshotSource.capture).toHaveBeenCalledTimes(1)
+    expect(repo.archives).toEqual({})
+    expect(readdirSync(join(testState.root, 'terminal-scrollback'))).toEqual([])
   })
 
   it('archives a known-empty terminal without writing a sidecar', async () => {

--- a/src/main/terminal-archive-store.ts
+++ b/src/main/terminal-archive-store.ts
@@ -25,6 +25,7 @@ import {
   deleteUnreferencedTerminalArchiveSnapshots,
   stageTerminalArchivePaneSnapshot
 } from './terminal-archive-snapshot-staging'
+import { TerminalArchiveError } from './terminal-archive-failure'
 
 export type ArchiveTerminalTabRequest = {
   operationId: string
@@ -65,6 +66,13 @@ export type TerminalArchiveRepository = {
   getTerminalArchiveRetentionDays(): number
   isExecutionHostReachable(hostId: ExecutionHostId): boolean
   worktreeExists(worktreeId: string, hostId: ExecutionHostId): boolean
+  /** Must fail closed before and after snapshot capture. */
+  isTerminalArchiveRequestOwned(request: {
+    executionHostId: ExecutionHostId
+    worktreeId: string
+    sourceTabId: string
+    sourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
+  }): boolean
   isTerminalScrollbackSnapshotLive(ref: string): boolean
   terminalScrollbackSnapshotStorage?: TerminalScrollbackSnapshotStorage
 }
@@ -86,6 +94,7 @@ export class TerminalArchiveStore {
 
   archiveTerminalTab(request: ArchiveTerminalTabRequest): Promise<ArchivedTerminalTab> {
     return this.runSerial(async () => {
+      this.assertRequestOwned(request)
       const now = this.now()
       this.pruneAt(now)
       const sourcePaneSignature = makeTerminalArchiveSourcePaneSignature(
@@ -104,7 +113,7 @@ export class TerminalArchiveStore {
       if (
         operationArchives.some((archive) => archive.sourcePaneSignature !== sourcePaneSignature)
       ) {
-        throw new Error('Terminal archive operation targets a different source pane incarnation')
+        throw new TerminalArchiveError('stale-source')
       }
 
       const archiveId = existing?.id ?? randomUUID()
@@ -115,7 +124,7 @@ export class TerminalArchiveStore {
         for (const [leafId, pane] of Object.entries(request.panesByLeafId)) {
           const snapshot = await this.snapshotSource.capture(pane)
           if (snapshot.kind === 'unavailable') {
-            throw new Error('Terminal scrollback capture unavailable')
+            throw new TerminalArchiveError('capture-unavailable')
           }
           if (snapshot.kind === 'captured-empty') {
             panesByLeafId[leafId] = pane
@@ -167,6 +176,8 @@ export class TerminalArchiveStore {
             : {}),
           restoreCount: existing?.restoreCount ?? 0
         }) as ArchivedTerminalTab
+        // Capture awaits external sources, so recheck the exact main-owned fence before commit.
+        this.assertRequestOwned(request)
         this.repository.replaceTerminalArchivesAndFlush({
           ...this.repository.getTerminalArchives(),
           [archive.id]: archive
@@ -254,6 +265,19 @@ export class TerminalArchiveStore {
 
   dispose(): void {
     this.expiryScheduler.dispose()
+  }
+
+  private assertRequestOwned(request: ArchiveTerminalTabRequest): void {
+    if (
+      this.repository.isTerminalArchiveRequestOwned({
+        executionHostId: request.executionHostId,
+        worktreeId: request.worktreeId,
+        sourceTabId: request.sourceTabId,
+        sourcePaneIdentityByLeafId: request.sourcePaneIdentityByLeafId
+      }) !== true
+    ) {
+      throw new TerminalArchiveError('not-owned')
+    }
   }
 
   private pruneAt(now: number): PruneResult {

--- a/src/main/terminal-archive-store.ts
+++ b/src/main/terminal-archive-store.ts
@@ -5,12 +5,10 @@ import {
   toArchivedTerminalTabSummary
 } from '../shared/terminal-archive-types'
 import type {
-  ArchivedTerminalLayout,
   ArchivedTerminalPane,
   ArchivedTerminalTab,
   ArchivedTerminalTabSummary,
-  RestoreTerminalArchiveResult,
-  TerminalArchiveReason
+  RestoreTerminalArchiveResult
 } from '../shared/terminal-archive-types'
 import type { TerminalArchiveSnapshotSource } from '../shared/workspace-session-terminal-archive'
 import type { ExecutionHostId } from '../shared/execution-host'
@@ -26,39 +24,14 @@ import {
   stageTerminalArchivePaneSnapshot
 } from './terminal-archive-snapshot-staging'
 import { TerminalArchiveError } from './terminal-archive-failure'
-
-export type ArchiveTerminalTabRequest = {
-  operationId: string
-  sourceTabId: string
-  executionHostId: ExecutionHostId
-  runtimeEnvironmentId?: string
-  worktreeId: string
-  title: string
-  defaultTitle?: string
-  color?: string | null
-  layout: ArchivedTerminalLayout
-  panesByLeafId: Record<string, ArchivedTerminalPane>
-  sourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
-  reason: TerminalArchiveReason
-  createdAt?: number
-  capturedAt?: number
-  /** Ignored so a caller cannot set the archive TTL or GC clock. */
-  archivedAt?: number
-}
-
-export type TerminalArchiveListFilter = {
-  executionHostId?: ExecutionHostId
-  worktreeId?: string
-}
-
-export type TerminalArchiveRestoreTarget = {
-  executionHostId?: ExecutionHostId
-}
-
-export type PruneResult = {
-  prunedIds: string[]
-  deletedSnapshotRefs: string[]
-}
+import type {
+  ArchiveTerminalTabRequest,
+  LostTerminalArchiveRetirement,
+  LostTerminalArchiveRetirementResult,
+  PruneResult,
+  TerminalArchiveListFilter,
+  TerminalArchiveRestoreTarget
+} from './terminal-archive-contracts'
 
 export type TerminalArchiveRepository = {
   getTerminalArchives(): Record<string, ArchivedTerminalTab>
@@ -66,7 +39,6 @@ export type TerminalArchiveRepository = {
   getTerminalArchiveRetentionDays(): number
   isExecutionHostReachable(hostId: ExecutionHostId): boolean
   worktreeExists(worktreeId: string, hostId: ExecutionHostId): boolean
-  /** Must fail closed before and after snapshot capture. */
   isTerminalArchiveRequestOwned(request: {
     executionHostId: ExecutionHostId
     worktreeId: string
@@ -74,6 +46,10 @@ export type TerminalArchiveRepository = {
     sourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
   }): boolean
   isTerminalScrollbackSnapshotLive(ref: string): boolean
+  commitLostTerminalArchiveAndRetire?(
+    archives: Record<string, ArchivedTerminalTab>,
+    retirement: LostTerminalArchiveRetirement
+  ): LostTerminalArchiveRetirementResult
   terminalScrollbackSnapshotStorage?: TerminalScrollbackSnapshotStorage
 }
 
@@ -93,6 +69,16 @@ export class TerminalArchiveStore {
   }
 
   archiveTerminalTab(request: ArchiveTerminalTabRequest): Promise<ArchivedTerminalTab> {
+    return this.archiveTerminalTabWithCommit(request, (archive, archives) => {
+      this.repository.replaceTerminalArchivesAndFlush(archives)
+      return archive
+    })
+  }
+
+  archiveTerminalTabWithCommit<TResult>(
+    request: ArchiveTerminalTabRequest,
+    commit: (archive: ArchivedTerminalTab, archives: Record<string, ArchivedTerminalTab>) => TResult
+  ): Promise<TResult> {
     return this.runSerial(async () => {
       this.assertRequestOwned(request)
       const now = this.now()
@@ -176,9 +162,8 @@ export class TerminalArchiveStore {
             : {}),
           restoreCount: existing?.restoreCount ?? 0
         }) as ArchivedTerminalTab
-        // Capture awaits external sources, so recheck the exact main-owned fence before commit.
         this.assertRequestOwned(request)
-        this.repository.replaceTerminalArchivesAndFlush({
+        const committed = commit(archive, {
           ...this.repository.getTerminalArchives(),
           [archive.id]: archive
         })
@@ -190,7 +175,7 @@ export class TerminalArchiveStore {
           })
         }
         this.schedulePrune()
-        return archive
+        return committed
       } catch (error) {
         for (const ref of writtenRefs) {
           deleteTerminalScrollbackSnapshotSync(
@@ -201,6 +186,13 @@ export class TerminalArchiveStore {
         throw error
       }
     })
+  }
+
+  commitLostTerminalArchiveAndRetire(
+    archives: Record<string, ArchivedTerminalTab>,
+    retirement: LostTerminalArchiveRetirement
+  ): LostTerminalArchiveRetirementResult | undefined {
+    return this.repository.commitLostTerminalArchiveAndRetire?.(archives, retirement)
   }
 
   listTerminalArchives(
@@ -248,7 +240,6 @@ export class TerminalArchiveStore {
       if (target.executionHostId && target.executionHostId !== archive.executionHostId) {
         return { ok: false, code: 'archive_host_mismatch', archiveId: id }
       }
-      // B2 replaces this metadata preflight with a live execution-host probe.
       if (!this.repository.isExecutionHostReachable(archive.executionHostId)) {
         return { ok: false, code: 'archive_host_unreachable', archiveId: id }
       }
@@ -291,7 +282,6 @@ export class TerminalArchiveStore {
     for (const archive of expired) {
       delete next[archive.id]
     }
-    // Metadata must be durable before removing bytes; a crash can leave only harmless orphans.
     this.repository.replaceTerminalArchivesAndFlush(next)
     const deletedSnapshotRefs = deleteUnreferencedTerminalArchiveSnapshots({
       archives: expired,

--- a/src/main/terminal-archive-store.ts
+++ b/src/main/terminal-archive-store.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from 'node:crypto'
+import {
+  archivedTerminalTabSchema,
+  normalizeTerminalArchiveRetentionDays,
+  toArchivedTerminalTabSummary
+} from '../shared/terminal-archive-types'
+import type {
+  ArchivedTerminalLayout,
+  ArchivedTerminalPane,
+  ArchivedTerminalTab,
+  ArchivedTerminalTabSummary,
+  RestoreTerminalArchiveResult,
+  TerminalArchiveReason
+} from '../shared/terminal-archive-types'
+import type { TerminalArchiveSnapshotSource } from '../shared/workspace-session-terminal-archive'
+import type { ExecutionHostId } from '../shared/execution-host'
+import { deleteTerminalScrollbackSnapshotSync } from './terminal-scrollback-snapshots'
+import type { TerminalScrollbackSnapshotStorage } from './terminal-scrollback-snapshots'
+import { TerminalArchiveExpiryScheduler } from './terminal-archive-expiry-scheduler'
+import {
+  makeTerminalArchiveSourcePaneSignature,
+  type TerminalArchiveSourcePaneIdentity
+} from './terminal-archive-source-pane-signature'
+import {
+  deleteUnreferencedTerminalArchiveSnapshots,
+  stageTerminalArchivePaneSnapshot
+} from './terminal-archive-snapshot-staging'
+
+export type ArchiveTerminalTabRequest = {
+  operationId: string
+  sourceTabId: string
+  executionHostId: ExecutionHostId
+  runtimeEnvironmentId?: string
+  worktreeId: string
+  title: string
+  defaultTitle?: string
+  color?: string | null
+  layout: ArchivedTerminalLayout
+  panesByLeafId: Record<string, ArchivedTerminalPane>
+  sourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
+  reason: TerminalArchiveReason
+  createdAt?: number
+  capturedAt?: number
+  /** Ignored so a caller cannot set the archive TTL or GC clock. */
+  archivedAt?: number
+}
+
+export type TerminalArchiveListFilter = {
+  executionHostId?: ExecutionHostId
+  worktreeId?: string
+}
+
+export type TerminalArchiveRestoreTarget = {
+  executionHostId?: ExecutionHostId
+}
+
+export type PruneResult = {
+  prunedIds: string[]
+  deletedSnapshotRefs: string[]
+}
+
+export type TerminalArchiveRepository = {
+  getTerminalArchives(): Record<string, ArchivedTerminalTab>
+  replaceTerminalArchivesAndFlush(archives: Record<string, ArchivedTerminalTab>): void
+  getTerminalArchiveRetentionDays(): number
+  isExecutionHostReachable(hostId: ExecutionHostId): boolean
+  worktreeExists(worktreeId: string, hostId: ExecutionHostId): boolean
+  isTerminalScrollbackSnapshotLive(ref: string): boolean
+  terminalScrollbackSnapshotStorage?: TerminalScrollbackSnapshotStorage
+}
+
+export class TerminalArchiveStore {
+  private serial: Promise<void> = Promise.resolve()
+  private readonly expiryScheduler: TerminalArchiveExpiryScheduler
+
+  constructor(
+    private readonly repository: TerminalArchiveRepository,
+    private readonly snapshotSource: TerminalArchiveSnapshotSource,
+    private readonly now: () => number = () => Date.now()
+  ) {
+    this.expiryScheduler = new TerminalArchiveExpiryScheduler(this.now, () =>
+      this.pruneExpiredTerminalArchives(this.now()).then(() => undefined)
+    )
+    this.schedulePrune()
+  }
+
+  archiveTerminalTab(request: ArchiveTerminalTabRequest): Promise<ArchivedTerminalTab> {
+    return this.runSerial(async () => {
+      const now = this.now()
+      this.pruneAt(now)
+      const sourcePaneSignature = makeTerminalArchiveSourcePaneSignature(
+        request.panesByLeafId,
+        request.sourcePaneIdentityByLeafId
+      )
+      const operationArchives = Object.values(this.repository.getTerminalArchives()).filter(
+        (archive) =>
+          archive.operationId === request.operationId &&
+          archive.executionHostId === request.executionHostId &&
+          archive.sourceTabId === request.sourceTabId
+      )
+      const existing = operationArchives.find(
+        (archive) => archive.sourcePaneSignature === sourcePaneSignature
+      )
+      if (
+        operationArchives.some((archive) => archive.sourcePaneSignature !== sourcePaneSignature)
+      ) {
+        throw new Error('Terminal archive operation targets a different source pane incarnation')
+      }
+
+      const archiveId = existing?.id ?? randomUUID()
+      const snapshotVersion = randomUUID()
+      const panesByLeafId: Record<string, ArchivedTerminalPane> = {}
+      const writtenRefs: string[] = []
+      try {
+        for (const [leafId, pane] of Object.entries(request.panesByLeafId)) {
+          const snapshot = await this.snapshotSource.capture(pane)
+          if (snapshot.kind === 'unavailable') {
+            throw new Error('Terminal scrollback capture unavailable')
+          }
+          if (snapshot.kind === 'captured-empty') {
+            panesByLeafId[leafId] = pane
+            continue
+          }
+          const staged = stageTerminalArchivePaneSnapshot({
+            archiveId,
+            snapshotVersion,
+            pane,
+            snapshot,
+            storage: this.repository.terminalScrollbackSnapshotStorage
+          })
+          panesByLeafId[leafId] = staged.pane
+          if (staged.writtenRef) {
+            writtenRefs.push(staged.writtenRef)
+          }
+        }
+        const archive = archivedTerminalTabSchema.parse({
+          schemaVersion: 1,
+          id: archiveId,
+          operationId: request.operationId,
+          sourceTabId: request.sourceTabId,
+          sourcePaneSignature,
+          executionHostId: request.executionHostId,
+          ...(request.runtimeEnvironmentId
+            ? { runtimeEnvironmentId: request.runtimeEnvironmentId }
+            : {}),
+          worktreeId: request.worktreeId,
+          title: request.title,
+          ...(request.defaultTitle ? { defaultTitle: request.defaultTitle } : {}),
+          ...(request.color !== undefined ? { color: request.color } : {}),
+          layout: request.layout,
+          panesByLeafId,
+          reason: request.reason,
+          ...(request.createdAt !== undefined ? { createdAt: request.createdAt } : {}),
+          ...(request.capturedAt !== undefined ? { capturedAt: request.capturedAt } : {}),
+          archivedAt: now,
+          expiresAt:
+            now +
+            normalizeTerminalArchiveRetentionDays(
+              this.repository.getTerminalArchiveRetentionDays()
+            ) *
+              24 *
+              60 *
+              60 *
+              1_000,
+          ...(existing?.lastRestoredAt !== undefined
+            ? { lastRestoredAt: existing.lastRestoredAt }
+            : {}),
+          restoreCount: existing?.restoreCount ?? 0
+        }) as ArchivedTerminalTab
+        this.repository.replaceTerminalArchivesAndFlush({
+          ...this.repository.getTerminalArchives(),
+          [archive.id]: archive
+        })
+        if (existing) {
+          deleteUnreferencedTerminalArchiveSnapshots({
+            archives: [existing],
+            isLive: (ref) => this.repository.isTerminalScrollbackSnapshotLive(ref),
+            storage: this.repository.terminalScrollbackSnapshotStorage
+          })
+        }
+        this.schedulePrune()
+        return archive
+      } catch (error) {
+        for (const ref of writtenRefs) {
+          deleteTerminalScrollbackSnapshotSync(
+            ref,
+            this.repository.terminalScrollbackSnapshotStorage
+          )
+        }
+        throw error
+      }
+    })
+  }
+
+  listTerminalArchives(
+    filter: TerminalArchiveListFilter = {}
+  ): Promise<ArchivedTerminalTabSummary[]> {
+    return this.runSerial(async () => {
+      this.pruneAt(this.now())
+      return Object.values(this.repository.getTerminalArchives())
+        .filter(
+          (archive) =>
+            (!filter.executionHostId || archive.executionHostId === filter.executionHostId) &&
+            (!filter.worktreeId || archive.worktreeId === filter.worktreeId)
+        )
+        .sort((left, right) => right.archivedAt - left.archivedAt)
+        .map((archive) =>
+          toArchivedTerminalTabSummary(archive, {
+            worktreeMissing: !this.repository.worktreeExists(
+              archive.worktreeId,
+              archive.executionHostId
+            )
+          })
+        )
+    })
+  }
+
+  restoreTerminalArchive(
+    id: string,
+    target: TerminalArchiveRestoreTarget = {}
+  ): Promise<RestoreTerminalArchiveResult> {
+    return this.runSerial(async () => {
+      const now = this.now()
+      const beforePrune = this.repository.getTerminalArchives()[id]
+      if (beforePrune?.expiresAt <= now) {
+        this.pruneAt(now)
+        return { ok: false, code: 'archive_expired', archiveId: id }
+      }
+      this.pruneAt(now)
+      const archive = this.repository.getTerminalArchives()[id]
+      if (!archive) {
+        return { ok: false, code: 'archive_not_found', archiveId: id }
+      }
+      if (archive.expiresAt <= now) {
+        return { ok: false, code: 'archive_expired', archiveId: id }
+      }
+      if (target.executionHostId && target.executionHostId !== archive.executionHostId) {
+        return { ok: false, code: 'archive_host_mismatch', archiveId: id }
+      }
+      // B2 replaces this metadata preflight with a live execution-host probe.
+      if (!this.repository.isExecutionHostReachable(archive.executionHostId)) {
+        return { ok: false, code: 'archive_host_unreachable', archiveId: id }
+      }
+      if (!this.repository.worktreeExists(archive.worktreeId, archive.executionHostId)) {
+        return { ok: false, code: 'archive_worktree_missing', archiveId: id }
+      }
+      return { ok: false, code: 'not_implemented', archiveId: id }
+    })
+  }
+
+  pruneExpiredTerminalArchives(now: number): Promise<PruneResult> {
+    return this.runSerial(async () => this.pruneAt(now))
+  }
+
+  dispose(): void {
+    this.expiryScheduler.dispose()
+  }
+
+  private pruneAt(now: number): PruneResult {
+    const archives = this.repository.getTerminalArchives()
+    const expired = Object.values(archives).filter((archive) => archive.expiresAt <= now)
+    if (expired.length === 0) {
+      this.schedulePrune()
+      return { prunedIds: [], deletedSnapshotRefs: [] }
+    }
+    const next = { ...archives }
+    for (const archive of expired) {
+      delete next[archive.id]
+    }
+    // Metadata must be durable before removing bytes; a crash can leave only harmless orphans.
+    this.repository.replaceTerminalArchivesAndFlush(next)
+    const deletedSnapshotRefs = deleteUnreferencedTerminalArchiveSnapshots({
+      archives: expired,
+      isLive: (ref) => this.repository.isTerminalScrollbackSnapshotLive(ref),
+      storage: this.repository.terminalScrollbackSnapshotStorage
+    })
+    this.schedulePrune()
+    return { prunedIds: expired.map((archive) => archive.id), deletedSnapshotRefs }
+  }
+
+  private schedulePrune(): void {
+    const nextExpiry = Object.values(this.repository.getTerminalArchives()).reduce<number | null>(
+      (nearest, archive) =>
+        nearest === null || archive.expiresAt < nearest ? archive.expiresAt : nearest,
+      null
+    )
+    this.expiryScheduler.schedule(nextExpiry)
+  }
+
+  private runSerial<T>(operation: () => Promise<T> | T): Promise<T> {
+    const result = this.serial.then(operation, operation)
+    this.serial = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+}

--- a/src/main/terminal-lost-worker-archive-write.ts
+++ b/src/main/terminal-lost-worker-archive-write.ts
@@ -9,9 +9,11 @@ import type { TerminalArchiveStore } from './terminal-archive-store'
 export function writeLostWorkerTerminalArchive(
   store: TerminalArchiveStore,
   request: ArchiveTerminalTabRequest,
-  retirement: LostTerminalArchiveRetirement
+  retirement: LostTerminalArchiveRetirement,
+  beforeCommit?: () => void
 ): Promise<{ archive: ArchivedTerminalTab; ptyIdsToKill: string[] }> {
   return store.archiveTerminalTabWithCommit(request, (archive, archives) => {
+    beforeCommit?.()
     const committed = store.commitLostTerminalArchiveAndRetire(archives, retirement)
     if (!committed) {
       throw new Error('lost-worker archive retirement is unavailable')

--- a/src/main/terminal-lost-worker-archive-write.ts
+++ b/src/main/terminal-lost-worker-archive-write.ts
@@ -1,0 +1,24 @@
+import type { ArchivedTerminalTab } from '../shared/terminal-archive-types'
+import { TerminalArchiveError } from './terminal-archive-failure'
+import type {
+  ArchiveTerminalTabRequest,
+  LostTerminalArchiveRetirement
+} from './terminal-archive-contracts'
+import type { TerminalArchiveStore } from './terminal-archive-store'
+
+export function writeLostWorkerTerminalArchive(
+  store: TerminalArchiveStore,
+  request: ArchiveTerminalTabRequest,
+  retirement: LostTerminalArchiveRetirement
+): Promise<{ archive: ArchivedTerminalTab; ptyIdsToKill: string[] }> {
+  return store.archiveTerminalTabWithCommit(request, (archive, archives) => {
+    const committed = store.commitLostTerminalArchiveAndRetire(archives, retirement)
+    if (!committed) {
+      throw new Error('lost-worker archive retirement is unavailable')
+    }
+    if (!committed.closed) {
+      throw new TerminalArchiveError('stale-source')
+    }
+    return { archive, ptyIdsToKill: committed.ptyIdsToKill }
+  })
+}

--- a/src/main/terminal-lost-worker-archive.test.ts
+++ b/src/main/terminal-lost-worker-archive.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultWorkspaceSession } from '../shared/constants'
+import {
+  captureTerminalArchiveTab,
+  retireArchivedTerminalTab,
+  type TerminalArchiveSnapshotSource
+} from '../shared/workspace-session-terminal-archive'
+import type { WorkspaceSessionState } from '../shared/types'
+import { TerminalArchiveStore, type TerminalArchiveRepository } from './terminal-archive-store'
+import { archiveLostTerminalWorker } from './terminal-lost-worker-archive'
+
+const WORKTREE_ID = 'repo-1::/worktree'
+const TAB_ID = 'tab-1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function session(): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: {
+      [WORKTREE_ID]: [
+        {
+          id: TAB_ID,
+          worktreeId: WORKTREE_ID,
+          title: 'Worker',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 10,
+          ptyId: 'pty-1'
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      [TAB_ID]: {
+        root: { type: 'leaf', leafId: LEAF_ID },
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+      }
+    },
+    terminalPtyIncarnationsByPaneKey: { [`${TAB_ID}:${LEAF_ID}`]: 'incarnation-1' },
+    terminalArchiveHintsByPaneKey: {
+      [`${TAB_ID}:${LEAF_ID}`]: { launchAgent: 'codex', startedAt: 10 }
+    }
+  }
+}
+
+function owner(
+  sessionState: WorkspaceSessionState,
+  beforeArchiveFlush?: () => void,
+  ownership: 'matching' | 'deny' = 'matching'
+) {
+  let archives = {}
+  let persistedSession = sessionState
+  const repository: TerminalArchiveRepository = {
+    getTerminalArchives: () => archives,
+    replaceTerminalArchivesAndFlush: (next) => {
+      beforeArchiveFlush?.()
+      archives = next
+    },
+    getTerminalArchiveRetentionDays: () => 7,
+    isExecutionHostReachable: () => true,
+    worktreeExists: () => true,
+    isTerminalArchiveRequestOwned: (request) => {
+      if (ownership === 'deny') {
+        return false
+      }
+      const captured = captureTerminalArchiveTab({
+        session: persistedSession,
+        worktreeId: request.worktreeId,
+        tabId: request.sourceTabId
+      })
+      return Boolean(
+        captured &&
+        Object.keys(captured.sourcePaneIdentityByLeafId).length ===
+          Object.keys(request.sourcePaneIdentityByLeafId).length &&
+        Object.entries(captured.sourcePaneIdentityByLeafId).every(
+          ([leafId, identity]) =>
+            request.sourcePaneIdentityByLeafId[leafId]?.paneKey === identity.paneKey &&
+            request.sourcePaneIdentityByLeafId[leafId]?.incarnationId === identity.incarnationId
+        )
+      )
+    },
+    isTerminalScrollbackSnapshotLive: () => false
+  }
+  const retireArchivedTerminalTabAndFlush = vi.fn((args: { worktreeId: string; tabId: string }) => {
+    const retired = retireArchivedTerminalTab(persistedSession, args.worktreeId, args.tabId)
+    persistedSession = retired.session
+    return retired
+  })
+  return {
+    archives: () => archives,
+    retireArchivedTerminalTabAndFlush,
+    value: {
+      getWorkspaceSession: () => persistedSession,
+      retireArchivedTerminalTabAndFlush,
+      createTerminalArchiveStore: (snapshotSource: TerminalArchiveSnapshotSource) =>
+        new TerminalArchiveStore(repository, snapshotSource, () => 100)
+    }
+  }
+}
+
+describe('archiveLostTerminalWorker', () => {
+  it('archives before retiring and returns only main-owned kill authority', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'daemon-worker-lost',
+        executionHostId: 'local',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) }
+    })
+
+    expect(result).toMatchObject({
+      kind: 'archived',
+      operationId: expect.stringMatching(/^daemon-worker-lost:tab-1:[0-9a-f]{64}$/)
+    })
+    expect(Object.keys(archiveOwner.archives())).toHaveLength(1)
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).toHaveBeenCalledWith({
+      worktreeId: WORKTREE_ID,
+      tabId: TAB_ID,
+      executionHostId: 'local'
+    })
+  })
+
+  it('rejects a stale source incarnation before archive or retirement', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'relay-worker-lost',
+        executionHostId: 'local',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'replacement' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) }
+    })
+
+    expect(result).toEqual({ kind: 'error', code: 'stale-source' })
+    expect(archiveOwner.archives()).toEqual({})
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
+  })
+
+  it('rejects relay evidence whose source incarnation does not match the required CAS identity', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'relay-worker-lost',
+        executionHostId: 'local',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        },
+        relayEvidence: {
+          id: 'relay-pty',
+          paneKey: `${TAB_ID}:${LEAF_ID}`,
+          sourceIncarnationId: 'stale-incarnation'
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) }
+    })
+
+    expect(result).toEqual({ kind: 'error', code: 'stale-source' })
+    expect(archiveOwner.archives()).toEqual({})
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
+  })
+
+  it('maps an explicit Store ownership denial to a permanent not-owned result', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession, undefined, 'deny')
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'daemon-worker-lost',
+        executionHostId: 'local',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) }
+    })
+
+    expect(result).toEqual({ kind: 'error', code: 'not-owned' })
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
+  })
+
+  it('keeps the tab live when capture or archive metadata durability fails', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'daemon-worker-lost',
+        executionHostId: 'local',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'unavailable' }) }
+    })
+
+    expect(result).toEqual({ kind: 'error', code: 'capture-unavailable' })
+    expect(archiveOwner.archives()).toEqual({})
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
+  })
+
+  it('keeps the tab live when archive metadata flush fails', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession, () => {
+      throw new Error('disk unavailable')
+    })
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'daemon-worker-lost',
+        executionHostId: 'local',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) }
+    })
+
+    expect(result).toEqual({ kind: 'error', code: 'durability-failed' })
+    expect(archiveOwner.archives()).toEqual({})
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/terminal-lost-worker-archive.test.ts
+++ b/src/main/terminal-lost-worker-archive.test.ts
@@ -219,6 +219,90 @@ describe('archiveLostTerminalWorker', () => {
     expect(completeArchive).toHaveBeenCalledOnce()
   })
 
+  it('checks the reconnect attempt fence before every pre-commit leaf capture', async () => {
+    const secondLeafId = '22222222-2222-4222-8222-222222222222'
+    const frozenSession = session()
+    frozenSession.terminalLayoutsByTabId[TAB_ID] = {
+      ...frozenSession.terminalLayoutsByTabId[TAB_ID],
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        first: { type: 'leaf', leafId: LEAF_ID },
+        second: { type: 'leaf', leafId: secondLeafId }
+      },
+      ptyIdsByLeafId: { [LEAF_ID]: 'pty-1', [secondLeafId]: 'pty-2' }
+    }
+    frozenSession.terminalPtyIncarnationsByPaneKey = {
+      [`${TAB_ID}:${LEAF_ID}`]: 'incarnation-1',
+      [`${TAB_ID}:${secondLeafId}`]: 'incarnation-2'
+    }
+    frozenSession.terminalArchiveHintsByPaneKey = {
+      ...frozenSession.terminalArchiveHintsByPaneKey,
+      [`${TAB_ID}:${secondLeafId}`]: { launchAgent: 'codex', startedAt: 10 }
+    }
+    const archiveOwner = owner(frozenSession)
+    let attemptCurrent = true
+    const capture = vi.fn(async () => {
+      attemptCurrent = false
+      return { kind: 'captured-empty' as const }
+    })
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'relay-worker-lost',
+        executionHostId: 'ssh:target-1',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' },
+          [secondLeafId]: {
+            paneKey: `${TAB_ID}:${secondLeafId}`,
+            incarnationId: 'incarnation-2'
+          }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture },
+      isCaptureAttemptCurrent: () => attemptCurrent
+    })
+
+    expect(result).toEqual({ kind: 'error', code: 'capture-unavailable' })
+    expect(capture).toHaveBeenCalledOnce()
+    expect(archiveOwner.archives()).toEqual({})
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
+  })
+
+  it('continues completion after the archive commit loses the reconnect fence', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+    let attemptCurrent = true
+    const completeArchive = vi.fn(async () => {
+      attemptCurrent = false
+    })
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'relay-worker-lost',
+        executionHostId: 'ssh:target-1',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) },
+      isCaptureAttemptCurrent: () => attemptCurrent,
+      completeArchive
+    })
+
+    expect(result).toMatchObject({ kind: 'archived' })
+    expect(completeArchive).toHaveBeenCalledOnce()
+    expect(attemptCurrent).toBe(false)
+  })
+
   it('uses the renderer completion when it wins a cross-entry SSH race', async () => {
     const frozenSession = session()
     const archiveOwner = owner(frozenSession)

--- a/src/main/terminal-lost-worker-archive.test.ts
+++ b/src/main/terminal-lost-worker-archive.test.ts
@@ -307,6 +307,37 @@ describe('archiveLostTerminalWorker', () => {
     expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
   })
 
+  it('checks the reconnect attempt fence after a single leaf capture before commit', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+    let attemptCurrent = true
+    const capture = vi.fn(async () => {
+      attemptCurrent = false
+      return { kind: 'captured-empty' as const }
+    })
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'relay-worker-lost',
+        executionHostId: 'ssh:target-1',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture },
+      isCaptureAttemptCurrent: () => attemptCurrent
+    })
+
+    expect(result).toEqual({ kind: 'error', code: 'capture-unavailable' })
+    expect(capture).toHaveBeenCalledOnce()
+    expect(archiveOwner.archives()).toEqual({})
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
+  })
+
   it('continues completion after the archive commit loses the reconnect fence', async () => {
     const frozenSession = session()
     const archiveOwner = owner(frozenSession)

--- a/src/main/terminal-lost-worker-archive.test.ts
+++ b/src/main/terminal-lost-worker-archive.test.ts
@@ -132,6 +132,43 @@ describe('archiveLostTerminalWorker', () => {
     })
   })
 
+  it('shares one archive attempt across concurrent lost-worker entry points', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+    let releaseCapture: (() => void) | undefined
+    const capture = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releaseCapture = resolve
+        }).then(() => ({ kind: 'captured-empty' as const }))
+    )
+    const request = {
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'daemon-worker-lost' as const,
+        executionHostId: 'local' as const,
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture }
+    }
+
+    const first = archiveLostTerminalWorker(request)
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce())
+    const second = archiveLostTerminalWorker(request)
+    releaseCapture?.()
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ kind: 'archived' }),
+      expect.objectContaining({ kind: 'archived' })
+    ])
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).toHaveBeenCalledOnce()
+  })
+
   it('rejects a stale source incarnation before archive or retirement', async () => {
     const frozenSession = session()
     const archiveOwner = owner(frozenSession)

--- a/src/main/terminal-lost-worker-archive.test.ts
+++ b/src/main/terminal-lost-worker-archive.test.ts
@@ -132,7 +132,7 @@ describe('archiveLostTerminalWorker', () => {
     })
   })
 
-  it('shares one archive attempt across concurrent lost-worker entry points', async () => {
+  it('deduplicates overlapping relay reconnect attempts and grants kill authority once', async () => {
     const frozenSession = session()
     const archiveOwner = owner(frozenSession)
     let releaseCapture: (() => void) | undefined
@@ -145,7 +145,7 @@ describe('archiveLostTerminalWorker', () => {
     const request = {
       owner: archiveOwner.value,
       candidate: {
-        reason: 'daemon-worker-lost' as const,
+        reason: 'relay-worker-lost' as const,
         executionHostId: 'local' as const,
         worktreeId: WORKTREE_ID,
         tabId: TAB_ID,
@@ -163,8 +163,8 @@ describe('archiveLostTerminalWorker', () => {
     releaseCapture?.()
 
     await expect(Promise.all([first, second])).resolves.toEqual([
-      expect.objectContaining({ kind: 'archived' }),
-      expect.objectContaining({ kind: 'archived' })
+      expect.objectContaining({ kind: 'archived', archiveCompletionOwner: true }),
+      expect.objectContaining({ kind: 'archived', archiveCompletionOwner: false })
     ])
     expect(archiveOwner.retireArchivedTerminalTabAndFlush).toHaveBeenCalledOnce()
   })

--- a/src/main/terminal-lost-worker-archive.test.ts
+++ b/src/main/terminal-lost-worker-archive.test.ts
@@ -414,6 +414,6 @@ describe('archiveLostTerminalWorker', () => {
 
     expect(result).toEqual({ kind: 'error', code: 'durability-failed' })
     expect(archiveOwner.archives()).toEqual({})
-    expect(archiveOwner.retireArchivedTerminalTabAndFlush).not.toHaveBeenCalled()
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/terminal-lost-worker-archive.test.ts
+++ b/src/main/terminal-lost-worker-archive.test.ts
@@ -219,6 +219,40 @@ describe('archiveLostTerminalWorker', () => {
     expect(completeArchive).toHaveBeenCalledOnce()
   })
 
+  it('correlates post-commit completion failures with the operation and attempt', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+    const diagnostic = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'relay-worker-lost',
+        executionHostId: 'ssh:target-1',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        attempt: 7,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) },
+      completeArchive: vi.fn().mockRejectedValue(new Error('shutdown unavailable'))
+    })
+
+    expect(result).toMatchObject({ kind: 'archived' })
+    expect(diagnostic).toHaveBeenCalledWith(
+      '[terminal-lost-worker-archive] completion diagnostic',
+      expect.objectContaining({
+        attempt: 7,
+        operationId: expect.stringMatching(/^relay-worker-lost:tab-1:[0-9a-f]{64}$/),
+        error: 'shutdown unavailable'
+      })
+    )
+    diagnostic.mockRestore()
+  })
+
   it('checks the reconnect attempt fence before every pre-commit leaf capture', async () => {
     const secondLeafId = '22222222-2222-4222-8222-222222222222'
     const frozenSession = session()

--- a/src/main/terminal-lost-worker-archive.test.ts
+++ b/src/main/terminal-lost-worker-archive.test.ts
@@ -48,7 +48,8 @@ function session(): WorkspaceSessionState {
 function owner(
   sessionState: WorkspaceSessionState,
   beforeArchiveFlush?: () => void,
-  ownership: 'matching' | 'deny' = 'matching'
+  ownership: 'matching' | 'deny' = 'matching',
+  retirement: 'matching' | 'deny' = 'matching'
 ) {
   let archives = {}
   let persistedSession = sessionState
@@ -84,16 +85,31 @@ function owner(
     isTerminalScrollbackSnapshotLive: () => false
   }
   const retireArchivedTerminalTabAndFlush = vi.fn((args: { worktreeId: string; tabId: string }) => {
-    const retired = retireArchivedTerminalTab(persistedSession, args.worktreeId, args.tabId)
+    if (retirement === 'deny') {
+      return {
+        ...retireArchivedTerminalTab(persistedSession, args.worktreeId, args.tabId),
+        closed: false,
+        ptyIdsToKill: [],
+        session: persistedSession
+      }
+    }
+    return retireArchivedTerminalTab(persistedSession, args.worktreeId, args.tabId)
+  })
+  repository.commitLostTerminalArchiveAndRetire = (nextArchives, args) => {
+    const retired = retireArchivedTerminalTabAndFlush(args)
+    if (!retired.closed) {
+      return retired
+    }
+    beforeArchiveFlush?.()
+    archives = nextArchives
     persistedSession = retired.session
     return retired
-  })
+  }
   return {
     archives: () => archives,
     retireArchivedTerminalTabAndFlush,
     value: {
       getWorkspaceSession: () => persistedSession,
-      retireArchivedTerminalTabAndFlush,
       createTerminalArchiveStore: (snapshotSource: TerminalArchiveSnapshotSource) =>
         new TerminalArchiveStore(repository, snapshotSource, () => 100)
     }
@@ -132,7 +148,7 @@ describe('archiveLostTerminalWorker', () => {
     })
   })
 
-  it('deduplicates overlapping relay reconnect attempts and grants kill authority once', async () => {
+  it('deduplicates overlapping relay reconnect attempts and completes physical shutdown once', async () => {
     const frozenSession = session()
     const archiveOwner = owner(frozenSession)
     let releaseCapture: (() => void) | undefined
@@ -154,7 +170,8 @@ describe('archiveLostTerminalWorker', () => {
         }
       },
       frozenSession,
-      snapshotSource: { capture }
+      snapshotSource: { capture },
+      completeArchive: vi.fn().mockResolvedValue(undefined)
     }
 
     const first = archiveLostTerminalWorker(request)
@@ -163,9 +180,114 @@ describe('archiveLostTerminalWorker', () => {
     releaseCapture?.()
 
     await expect(Promise.all([first, second])).resolves.toEqual([
-      expect.objectContaining({ kind: 'archived', archiveCompletionOwner: true }),
-      expect.objectContaining({ kind: 'archived', archiveCompletionOwner: false })
+      expect.objectContaining({ kind: 'archived' }),
+      expect.objectContaining({ kind: 'archived' })
     ])
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).toHaveBeenCalledOnce()
+    expect(request.completeArchive).toHaveBeenCalledOnce()
+  })
+
+  it('keeps SSH pending retirement and shutdown completion inside the renderer-owned operation', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+    const completeArchive = vi.fn().mockResolvedValue(undefined)
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'relay-worker-lost',
+        executionHostId: 'ssh:target-1',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        sshTerminationTargetId: 'target-1',
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) },
+      completeArchive
+    })
+
+    expect(result).toMatchObject({ kind: 'archived' })
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).toHaveBeenCalledWith({
+      worktreeId: WORKTREE_ID,
+      tabId: TAB_ID,
+      executionHostId: 'ssh:target-1',
+      sshTerminationTargetId: 'target-1'
+    })
+    expect(completeArchive).toHaveBeenCalledOnce()
+  })
+
+  it('uses the renderer completion when it wins a cross-entry SSH race', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession)
+    let releaseCapture: (() => void) | undefined
+    const capture = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releaseCapture = resolve
+        }).then(() => ({ kind: 'captured-empty' as const }))
+    )
+    const rendererCompletion = vi.fn().mockResolvedValue(undefined)
+    const relayCompletion = vi.fn().mockResolvedValue(undefined)
+    const request = {
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'relay-worker-lost' as const,
+        executionHostId: 'ssh:target-1' as const,
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        sshTerminationTargetId: 'target-1',
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture },
+      completeArchive: rendererCompletion
+    }
+
+    const renderer = archiveLostTerminalWorker(request)
+    await vi.waitFor(() => expect(capture).toHaveBeenCalledOnce())
+    const relay = archiveLostTerminalWorker({ ...request, completeArchive: relayCompletion })
+    releaseCapture?.()
+
+    await expect(Promise.all([renderer, relay])).resolves.toEqual([
+      expect.objectContaining({ kind: 'archived' }),
+      expect.objectContaining({ kind: 'archived' })
+    ])
+    expect(rendererCompletion).toHaveBeenCalledOnce()
+    expect(relayCompletion).not.toHaveBeenCalled()
+    expect(archiveOwner.retireArchivedTerminalTabAndFlush).toHaveBeenCalledWith({
+      worktreeId: WORKTREE_ID,
+      tabId: TAB_ID,
+      executionHostId: 'ssh:target-1',
+      sshTerminationTargetId: 'target-1'
+    })
+  })
+
+  it('does not write archive metadata when atomic retirement rejects the source', async () => {
+    const frozenSession = session()
+    const archiveOwner = owner(frozenSession, undefined, 'matching', 'deny')
+
+    const result = await archiveLostTerminalWorker({
+      owner: archiveOwner.value,
+      candidate: {
+        reason: 'daemon-worker-lost',
+        executionHostId: 'local',
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        expectedSourcePaneIdentityByLeafId: {
+          [LEAF_ID]: { paneKey: `${TAB_ID}:${LEAF_ID}`, incarnationId: 'incarnation-1' }
+        }
+      },
+      frozenSession,
+      snapshotSource: { capture: async () => ({ kind: 'captured-empty' }) }
+    })
+
+    expect(result).toEqual({ kind: 'error', code: 'stale-source' })
+    expect(archiveOwner.archives()).toEqual({})
     expect(archiveOwner.retireArchivedTerminalTabAndFlush).toHaveBeenCalledOnce()
   })
 

--- a/src/main/terminal-lost-worker-archive.ts
+++ b/src/main/terminal-lost-worker-archive.ts
@@ -17,6 +17,7 @@ export type TerminalLostWorkerArchiveCandidate = {
   worktreeId: string
   tabId: string
   runtimeEnvironmentId?: string
+  sshTerminationTargetId?: string
   expectedSourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
   relayEvidence?: Pick<
     RelayPtyLostEntry,
@@ -39,6 +40,7 @@ export type TerminalLostWorkerArchiveOwner = {
     worktreeId: string
     tabId: string
     executionHostId: ExecutionHostId
+    sshTerminationTargetId?: string
   }): { closed: boolean; ptyIdsToKill: string[] }
   createTerminalArchiveStore(snapshotSource: TerminalArchiveSnapshotSource): TerminalArchiveStore
 }
@@ -164,7 +166,10 @@ export async function archiveLostTerminalWorker(args: {
     const retired = args.owner.retireArchivedTerminalTabAndFlush({
       worktreeId: args.candidate.worktreeId,
       tabId: args.candidate.tabId,
-      executionHostId: args.candidate.executionHostId
+      executionHostId: args.candidate.executionHostId,
+      ...(args.candidate.sshTerminationTargetId
+        ? { sshTerminationTargetId: args.candidate.sshTerminationTargetId }
+        : {})
     })
     if (!retired.closed) {
       return { kind: 'error', code: 'stale-source' }

--- a/src/main/terminal-lost-worker-archive.ts
+++ b/src/main/terminal-lost-worker-archive.ts
@@ -52,6 +52,7 @@ export type TerminalLostWorkerArchiveReceipt = {
   archive: ArchivedTerminalTab
   operationId: string
   ptyIdsToKill: string[]
+  archiveCompletionOwner: boolean
 }
 
 export type TerminalLostWorkerArchiveResult =
@@ -148,7 +149,8 @@ export async function archiveLostTerminalWorker(args: {
   const inFlightKey = `${args.candidate.reason}:${args.candidate.executionHostId}:${args.candidate.tabId}:${sourcePaneSignature}`
   const existing = lostWorkerArchiveInFlight.get(inFlightKey)
   if (existing) {
-    return await existing
+    const settled = await existing
+    return settled.kind === 'archived' ? { ...settled, archiveCompletionOwner: false } : settled
   }
   const operation = archiveLostTerminalWorkerOnce({
     ...args,
@@ -208,7 +210,8 @@ async function archiveLostTerminalWorkerOnce(args: {
       kind: 'archived',
       archive,
       operationId: args.operationId,
-      ptyIdsToKill: retired.ptyIdsToKill
+      ptyIdsToKill: retired.ptyIdsToKill,
+      archiveCompletionOwner: true
     }
   } catch (error) {
     return { kind: 'error', code: terminalArchiveFailureCode(error) }

--- a/src/main/terminal-lost-worker-archive.ts
+++ b/src/main/terminal-lost-worker-archive.ts
@@ -216,7 +216,14 @@ async function archiveLostTerminalWorkerOnce(args: {
         ...(args.candidate.sshTerminationTargetId
           ? { sshTerminationTargetId: args.candidate.sshTerminationTargetId }
           : {})
-      }
+      },
+      args.isCaptureAttemptCurrent
+        ? () => {
+            if (!args.isCaptureAttemptCurrent?.()) {
+              throw new TerminalArchiveError('capture-unavailable')
+            }
+          }
+        : undefined
     )
     try {
       await args.completeArchive?.({

--- a/src/main/terminal-lost-worker-archive.ts
+++ b/src/main/terminal-lost-worker-archive.ts
@@ -109,6 +109,7 @@ export async function archiveLostTerminalWorker(args: {
   candidate: TerminalLostWorkerArchiveCandidate
   frozenSession: WorkspaceSessionState
   snapshotSource: TerminalArchiveSnapshotSource
+  isCaptureAttemptCurrent?: () => boolean
   completeArchive?: (args: {
     archive: ArchivedTerminalTab
     ptyIdsToKill: readonly string[]
@@ -169,6 +170,7 @@ async function archiveLostTerminalWorkerOnce(args: {
   candidate: TerminalLostWorkerArchiveCandidate
   frozenSession: WorkspaceSessionState
   snapshotSource: TerminalArchiveSnapshotSource
+  isCaptureAttemptCurrent?: () => boolean
   completeArchive?: (args: {
     archive: ArchivedTerminalTab
     ptyIdsToKill: readonly string[]
@@ -176,7 +178,15 @@ async function archiveLostTerminalWorkerOnce(args: {
   captured: NonNullable<ReturnType<typeof captureTerminalArchiveTab>>
   operationId: string
 }): Promise<TerminalLostWorkerArchiveResult> {
-  const archiveStore = args.owner.createTerminalArchiveStore(args.snapshotSource)
+  const snapshotSource = args.isCaptureAttemptCurrent
+    ? {
+        capture: async (pane: Parameters<TerminalArchiveSnapshotSource['capture']>[0]) =>
+          args.isCaptureAttemptCurrent?.()
+            ? args.snapshotSource.capture(pane)
+            : ({ kind: 'unavailable' } as const)
+      }
+    : args.snapshotSource
+  const archiveStore = args.owner.createTerminalArchiveStore(snapshotSource)
   try {
     const archived = await writeLostWorkerTerminalArchive(
       archiveStore,

--- a/src/main/terminal-lost-worker-archive.ts
+++ b/src/main/terminal-lost-worker-archive.ts
@@ -21,6 +21,7 @@ export type TerminalLostWorkerArchiveCandidate = {
   tabId: string
   runtimeEnvironmentId?: string
   sshTerminationTargetId?: string
+  attempt?: number
   expectedSourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
   relayEvidence?: Pick<
     RelayPtyLostEntry,
@@ -228,6 +229,8 @@ async function archiveLostTerminalWorkerOnce(args: {
         reason: args.candidate.reason,
         executionHostId: args.candidate.executionHostId,
         tabId: args.candidate.tabId,
+        attempt: args.candidate.attempt ?? 'archive-completion',
+        operationId: args.operationId,
         error: error instanceof Error ? error.message : String(error)
       })
     }

--- a/src/main/terminal-lost-worker-archive.ts
+++ b/src/main/terminal-lost-worker-archive.ts
@@ -1,0 +1,178 @@
+import { captureTerminalArchiveTab } from '../shared/workspace-session-terminal-archive'
+import type { TerminalArchiveSnapshotSource } from '../shared/workspace-session-terminal-archive'
+import type { ExecutionHostId } from '../shared/execution-host'
+import type { RelayPtyLostEntry } from '../shared/pty-revive-protocol'
+import type { TerminalArchiveReason, ArchivedTerminalTab } from '../shared/terminal-archive-types'
+import type { WorkspaceSessionState } from '../shared/types'
+import { makeTerminalArchiveSourcePaneSignature } from './terminal-archive-source-pane-signature'
+import type { TerminalArchiveSourcePaneIdentity } from './terminal-archive-source-pane-signature'
+import type { TerminalArchiveStore } from './terminal-archive-store'
+import { TerminalArchiveError } from './terminal-archive-failure'
+
+type LostWorkerArchiveReason = Exclude<TerminalArchiveReason, 'user-close'>
+
+export type TerminalLostWorkerArchiveCandidate = {
+  reason: LostWorkerArchiveReason
+  executionHostId: ExecutionHostId
+  worktreeId: string
+  tabId: string
+  runtimeEnvironmentId?: string
+  expectedSourcePaneIdentityByLeafId: Record<string, TerminalArchiveSourcePaneIdentity>
+  relayEvidence?: Pick<
+    RelayPtyLostEntry,
+    | 'id'
+    | 'sourceIncarnationId'
+    | 'paneKey'
+    | 'tabId'
+    | 'worktreeId'
+    | 'terminalHandle'
+    | 'replayTail'
+    | 'durableLaunch'
+    | 'providerSession'
+    | 'orchestrationTaskId'
+  >
+}
+
+export type TerminalLostWorkerArchiveOwner = {
+  getWorkspaceSession(hostId: ExecutionHostId): WorkspaceSessionState
+  retireArchivedTerminalTabAndFlush(args: {
+    worktreeId: string
+    tabId: string
+    executionHostId: ExecutionHostId
+  }): { closed: boolean; ptyIdsToKill: string[] }
+  createTerminalArchiveStore(snapshotSource: TerminalArchiveSnapshotSource): TerminalArchiveStore
+}
+
+export type TerminalLostWorkerArchiveReceipt = {
+  kind: 'archived'
+  archive: ArchivedTerminalTab
+  operationId: string
+  ptyIdsToKill: string[]
+}
+
+export type TerminalLostWorkerArchiveResult =
+  | TerminalLostWorkerArchiveReceipt
+  | {
+      kind: 'error'
+      code:
+        | 'not-owned'
+        | 'stale-source'
+        | 'capture-unavailable'
+        | 'contract-invalid'
+        | 'durability-failed'
+    }
+
+function sourceIdentityMatches(
+  expected: Record<string, TerminalArchiveSourcePaneIdentity>,
+  actual: Record<string, TerminalArchiveSourcePaneIdentity>
+): boolean {
+  const expectedLeaves = Object.keys(expected)
+  return (
+    expectedLeaves.length === Object.keys(actual).length &&
+    expectedLeaves.every(
+      (leafId) =>
+        expected[leafId]?.paneKey === actual[leafId]?.paneKey &&
+        expected[leafId]?.incarnationId === actual[leafId]?.incarnationId
+    )
+  )
+}
+
+function relayEvidenceMatchesSource(candidate: TerminalLostWorkerArchiveCandidate): boolean {
+  const sourceIncarnationId = candidate.relayEvidence?.sourceIncarnationId
+  if (!sourceIncarnationId) {
+    return true
+  }
+  const sourcePaneKey = candidate.relayEvidence?.paneKey
+  return Boolean(
+    sourcePaneKey &&
+    Object.values(candidate.expectedSourcePaneIdentityByLeafId).some(
+      (identity) =>
+        identity.paneKey === sourcePaneKey && identity.incarnationId === sourceIncarnationId
+    )
+  )
+}
+
+function terminalArchiveFailureCode(
+  error: unknown
+): Extract<TerminalLostWorkerArchiveResult, { kind: 'error' }>['code'] {
+  if (error instanceof TerminalArchiveError) {
+    return error.code
+  }
+  if (error instanceof Error && error.name === 'ZodError') {
+    return 'contract-invalid'
+  }
+  return 'durability-failed'
+}
+
+/** Archives main-owned lost-worker state before exposing any retirement authority. */
+export async function archiveLostTerminalWorker(args: {
+  owner: TerminalLostWorkerArchiveOwner
+  candidate: TerminalLostWorkerArchiveCandidate
+  frozenSession: WorkspaceSessionState
+  snapshotSource: TerminalArchiveSnapshotSource
+}): Promise<TerminalLostWorkerArchiveResult> {
+  if (!relayEvidenceMatchesSource(args.candidate)) {
+    return { kind: 'error', code: 'stale-source' }
+  }
+  const persistedSession = args.owner.getWorkspaceSession(args.candidate.executionHostId)
+  const session = {
+    ...args.frozenSession,
+    terminalArchiveHintsByPaneKey: persistedSession.terminalArchiveHintsByPaneKey,
+    terminalPtyIncarnationsByPaneKey: persistedSession.terminalPtyIncarnationsByPaneKey
+  }
+  const captured = captureTerminalArchiveTab({
+    session,
+    worktreeId: args.candidate.worktreeId,
+    tabId: args.candidate.tabId
+  })
+  if (!captured) {
+    return { kind: 'error', code: 'capture-unavailable' }
+  }
+  if (
+    !sourceIdentityMatches(
+      args.candidate.expectedSourcePaneIdentityByLeafId,
+      captured.sourcePaneIdentityByLeafId
+    )
+  ) {
+    return { kind: 'error', code: 'stale-source' }
+  }
+  const sourcePaneSignature = makeTerminalArchiveSourcePaneSignature(
+    captured.panesByLeafId,
+    captured.sourcePaneIdentityByLeafId
+  )
+  const operationId = `${args.candidate.reason}:${args.candidate.tabId}:${sourcePaneSignature}`
+  const archiveStore = args.owner.createTerminalArchiveStore(args.snapshotSource)
+  try {
+    const archive = await archiveStore.archiveTerminalTab({
+      operationId,
+      sourceTabId: args.candidate.tabId,
+      executionHostId: args.candidate.executionHostId,
+      ...(args.candidate.runtimeEnvironmentId
+        ? { runtimeEnvironmentId: args.candidate.runtimeEnvironmentId }
+        : {}),
+      worktreeId: args.candidate.worktreeId,
+      title: captured.tab.customTitle || captured.tab.title,
+      ...(captured.tab.defaultTitle ? { defaultTitle: captured.tab.defaultTitle } : {}),
+      ...(captured.tab.color !== undefined ? { color: captured.tab.color } : {}),
+      layout: captured.layout,
+      panesByLeafId: captured.panesByLeafId,
+      sourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId,
+      reason: args.candidate.reason,
+      createdAt: captured.tab.createdAt,
+      capturedAt: Date.now()
+    })
+    const retired = args.owner.retireArchivedTerminalTabAndFlush({
+      worktreeId: args.candidate.worktreeId,
+      tabId: args.candidate.tabId,
+      executionHostId: args.candidate.executionHostId
+    })
+    if (!retired.closed) {
+      return { kind: 'error', code: 'stale-source' }
+    }
+    return { kind: 'archived', archive, operationId, ptyIdsToKill: retired.ptyIdsToKill }
+  } catch (error) {
+    return { kind: 'error', code: terminalArchiveFailureCode(error) }
+  } finally {
+    archiveStore.dispose()
+  }
+}

--- a/src/main/terminal-lost-worker-archive.ts
+++ b/src/main/terminal-lost-worker-archive.ts
@@ -11,6 +11,8 @@ import { TerminalArchiveError } from './terminal-archive-failure'
 
 type LostWorkerArchiveReason = Exclude<TerminalArchiveReason, 'user-close'>
 
+const lostWorkerArchiveInFlight = new Map<string, Promise<TerminalLostWorkerArchiveResult>>()
+
 export type TerminalLostWorkerArchiveCandidate = {
   reason: LostWorkerArchiveReason
   executionHostId: ExecutionHostId
@@ -143,24 +145,52 @@ export async function archiveLostTerminalWorker(args: {
     captured.sourcePaneIdentityByLeafId
   )
   const operationId = `${args.candidate.reason}:${args.candidate.tabId}:${sourcePaneSignature}`
+  const inFlightKey = `${args.candidate.reason}:${args.candidate.executionHostId}:${args.candidate.tabId}:${sourcePaneSignature}`
+  const existing = lostWorkerArchiveInFlight.get(inFlightKey)
+  if (existing) {
+    return await existing
+  }
+  const operation = archiveLostTerminalWorkerOnce({
+    ...args,
+    captured,
+    operationId
+  })
+  lostWorkerArchiveInFlight.set(inFlightKey, operation)
+  try {
+    return await operation
+  } finally {
+    if (lostWorkerArchiveInFlight.get(inFlightKey) === operation) {
+      lostWorkerArchiveInFlight.delete(inFlightKey)
+    }
+  }
+}
+
+async function archiveLostTerminalWorkerOnce(args: {
+  owner: TerminalLostWorkerArchiveOwner
+  candidate: TerminalLostWorkerArchiveCandidate
+  frozenSession: WorkspaceSessionState
+  snapshotSource: TerminalArchiveSnapshotSource
+  captured: NonNullable<ReturnType<typeof captureTerminalArchiveTab>>
+  operationId: string
+}): Promise<TerminalLostWorkerArchiveResult> {
   const archiveStore = args.owner.createTerminalArchiveStore(args.snapshotSource)
   try {
     const archive = await archiveStore.archiveTerminalTab({
-      operationId,
+      operationId: args.operationId,
       sourceTabId: args.candidate.tabId,
       executionHostId: args.candidate.executionHostId,
       ...(args.candidate.runtimeEnvironmentId
         ? { runtimeEnvironmentId: args.candidate.runtimeEnvironmentId }
         : {}),
       worktreeId: args.candidate.worktreeId,
-      title: captured.tab.customTitle || captured.tab.title,
-      ...(captured.tab.defaultTitle ? { defaultTitle: captured.tab.defaultTitle } : {}),
-      ...(captured.tab.color !== undefined ? { color: captured.tab.color } : {}),
-      layout: captured.layout,
-      panesByLeafId: captured.panesByLeafId,
-      sourcePaneIdentityByLeafId: captured.sourcePaneIdentityByLeafId,
+      title: args.captured.tab.customTitle || args.captured.tab.title,
+      ...(args.captured.tab.defaultTitle ? { defaultTitle: args.captured.tab.defaultTitle } : {}),
+      ...(args.captured.tab.color !== undefined ? { color: args.captured.tab.color } : {}),
+      layout: args.captured.layout,
+      panesByLeafId: args.captured.panesByLeafId,
+      sourcePaneIdentityByLeafId: args.captured.sourcePaneIdentityByLeafId,
       reason: args.candidate.reason,
-      createdAt: captured.tab.createdAt,
+      createdAt: args.captured.tab.createdAt,
       capturedAt: Date.now()
     })
     const retired = args.owner.retireArchivedTerminalTabAndFlush({
@@ -174,7 +204,12 @@ export async function archiveLostTerminalWorker(args: {
     if (!retired.closed) {
       return { kind: 'error', code: 'stale-source' }
     }
-    return { kind: 'archived', archive, operationId, ptyIdsToKill: retired.ptyIdsToKill }
+    return {
+      kind: 'archived',
+      archive,
+      operationId: args.operationId,
+      ptyIdsToKill: retired.ptyIdsToKill
+    }
   } catch (error) {
     return { kind: 'error', code: terminalArchiveFailureCode(error) }
   } finally {

--- a/src/main/terminal-lost-worker-archive.ts
+++ b/src/main/terminal-lost-worker-archive.ts
@@ -8,6 +8,7 @@ import { makeTerminalArchiveSourcePaneSignature } from './terminal-archive-sourc
 import type { TerminalArchiveSourcePaneIdentity } from './terminal-archive-source-pane-signature'
 import type { TerminalArchiveStore } from './terminal-archive-store'
 import { TerminalArchiveError } from './terminal-archive-failure'
+import { writeLostWorkerTerminalArchive } from './terminal-lost-worker-archive-write'
 
 type LostWorkerArchiveReason = Exclude<TerminalArchiveReason, 'user-close'>
 
@@ -38,12 +39,6 @@ export type TerminalLostWorkerArchiveCandidate = {
 
 export type TerminalLostWorkerArchiveOwner = {
   getWorkspaceSession(hostId: ExecutionHostId): WorkspaceSessionState
-  retireArchivedTerminalTabAndFlush(args: {
-    worktreeId: string
-    tabId: string
-    executionHostId: ExecutionHostId
-    sshTerminationTargetId?: string
-  }): { closed: boolean; ptyIdsToKill: string[] }
   createTerminalArchiveStore(snapshotSource: TerminalArchiveSnapshotSource): TerminalArchiveStore
 }
 
@@ -52,7 +47,6 @@ export type TerminalLostWorkerArchiveReceipt = {
   archive: ArchivedTerminalTab
   operationId: string
   ptyIdsToKill: string[]
-  archiveCompletionOwner: boolean
 }
 
 export type TerminalLostWorkerArchiveResult =
@@ -115,6 +109,10 @@ export async function archiveLostTerminalWorker(args: {
   candidate: TerminalLostWorkerArchiveCandidate
   frozenSession: WorkspaceSessionState
   snapshotSource: TerminalArchiveSnapshotSource
+  completeArchive?: (args: {
+    archive: ArchivedTerminalTab
+    ptyIdsToKill: readonly string[]
+  }) => Promise<void>
 }): Promise<TerminalLostWorkerArchiveResult> {
   if (!relayEvidenceMatchesSource(args.candidate)) {
     return { kind: 'error', code: 'stale-source' }
@@ -149,8 +147,7 @@ export async function archiveLostTerminalWorker(args: {
   const inFlightKey = `${args.candidate.reason}:${args.candidate.executionHostId}:${args.candidate.tabId}:${sourcePaneSignature}`
   const existing = lostWorkerArchiveInFlight.get(inFlightKey)
   if (existing) {
-    const settled = await existing
-    return settled.kind === 'archived' ? { ...settled, archiveCompletionOwner: false } : settled
+    return await existing
   }
   const operation = archiveLostTerminalWorkerOnce({
     ...args,
@@ -172,46 +169,63 @@ async function archiveLostTerminalWorkerOnce(args: {
   candidate: TerminalLostWorkerArchiveCandidate
   frozenSession: WorkspaceSessionState
   snapshotSource: TerminalArchiveSnapshotSource
+  completeArchive?: (args: {
+    archive: ArchivedTerminalTab
+    ptyIdsToKill: readonly string[]
+  }) => Promise<void>
   captured: NonNullable<ReturnType<typeof captureTerminalArchiveTab>>
   operationId: string
 }): Promise<TerminalLostWorkerArchiveResult> {
   const archiveStore = args.owner.createTerminalArchiveStore(args.snapshotSource)
   try {
-    const archive = await archiveStore.archiveTerminalTab({
-      operationId: args.operationId,
-      sourceTabId: args.candidate.tabId,
-      executionHostId: args.candidate.executionHostId,
-      ...(args.candidate.runtimeEnvironmentId
-        ? { runtimeEnvironmentId: args.candidate.runtimeEnvironmentId }
-        : {}),
-      worktreeId: args.candidate.worktreeId,
-      title: args.captured.tab.customTitle || args.captured.tab.title,
-      ...(args.captured.tab.defaultTitle ? { defaultTitle: args.captured.tab.defaultTitle } : {}),
-      ...(args.captured.tab.color !== undefined ? { color: args.captured.tab.color } : {}),
-      layout: args.captured.layout,
-      panesByLeafId: args.captured.panesByLeafId,
-      sourcePaneIdentityByLeafId: args.captured.sourcePaneIdentityByLeafId,
-      reason: args.candidate.reason,
-      createdAt: args.captured.tab.createdAt,
-      capturedAt: Date.now()
-    })
-    const retired = args.owner.retireArchivedTerminalTabAndFlush({
-      worktreeId: args.candidate.worktreeId,
-      tabId: args.candidate.tabId,
-      executionHostId: args.candidate.executionHostId,
-      ...(args.candidate.sshTerminationTargetId
-        ? { sshTerminationTargetId: args.candidate.sshTerminationTargetId }
-        : {})
-    })
-    if (!retired.closed) {
-      return { kind: 'error', code: 'stale-source' }
+    const archived = await writeLostWorkerTerminalArchive(
+      archiveStore,
+      {
+        operationId: args.operationId,
+        sourceTabId: args.candidate.tabId,
+        executionHostId: args.candidate.executionHostId,
+        ...(args.candidate.runtimeEnvironmentId
+          ? { runtimeEnvironmentId: args.candidate.runtimeEnvironmentId }
+          : {}),
+        worktreeId: args.candidate.worktreeId,
+        title: args.captured.tab.customTitle || args.captured.tab.title,
+        ...(args.captured.tab.defaultTitle ? { defaultTitle: args.captured.tab.defaultTitle } : {}),
+        ...(args.captured.tab.color !== undefined ? { color: args.captured.tab.color } : {}),
+        layout: args.captured.layout,
+        panesByLeafId: args.captured.panesByLeafId,
+        sourcePaneIdentityByLeafId: args.captured.sourcePaneIdentityByLeafId,
+        reason: args.candidate.reason,
+        createdAt: args.captured.tab.createdAt,
+        capturedAt: Date.now()
+      },
+      {
+        worktreeId: args.candidate.worktreeId,
+        tabId: args.candidate.tabId,
+        executionHostId: args.candidate.executionHostId,
+        ...(args.candidate.sshTerminationTargetId
+          ? { sshTerminationTargetId: args.candidate.sshTerminationTargetId }
+          : {})
+      }
+    )
+    try {
+      await args.completeArchive?.({
+        archive: archived.archive,
+        ptyIdsToKill: archived.ptyIdsToKill
+      })
+    } catch (error) {
+      // Why: metadata and retirement are already durable, so completion failures cannot reopen the transaction.
+      console.warn('[terminal-lost-worker-archive] completion diagnostic', {
+        reason: args.candidate.reason,
+        executionHostId: args.candidate.executionHostId,
+        tabId: args.candidate.tabId,
+        error: error instanceof Error ? error.message : String(error)
+      })
     }
     return {
       kind: 'archived',
-      archive,
+      archive: archived.archive,
       operationId: args.operationId,
-      ptyIdsToKill: retired.ptyIdsToKill,
-      archiveCompletionOwner: true
+      ptyIdsToKill: archived.ptyIdsToKill
     }
   } catch (error) {
     return { kind: 'error', code: terminalArchiveFailureCode(error) }

--- a/src/main/terminal-lost-worker-snapshot-source.test.ts
+++ b/src/main/terminal-lost-worker-snapshot-source.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createDaemonLostWorkerSnapshotSource,
+  createRelayLostWorkerSnapshotSource
+} from './terminal-lost-worker-snapshot-source'
+
+const pane = (archivedLeafId: string) => ({ archivedLeafId, cwd: '/worktree' })
+
+const captured = (source: 'daemon-headless' | 'relay-tail' | 'session-sidecar') => ({
+  kind: 'captured-bytes' as const,
+  buffer: source,
+  source,
+  truncated: false,
+  byteLength: source.length
+})
+
+describe('lost-worker snapshot source', () => {
+  it('uses a staged relay tail only when a session sidecar is unavailable', async () => {
+    const sidecar = vi.fn().mockReturnValue(undefined)
+    const relayTail = vi.fn().mockReturnValue(captured('relay-tail'))
+    const source = createRelayLostWorkerSnapshotSource({
+      captureSessionSidecar: sidecar,
+      captureRelayTail: relayTail
+    })
+
+    await expect(source.capture(pane('sibling'))).resolves.toMatchObject({ source: 'relay-tail' })
+    expect(sidecar).toHaveBeenCalledWith('sibling')
+    expect(relayTail).toHaveBeenCalledWith('sibling')
+  })
+
+  it('uses a daemon sibling probe only after its sidecar is unavailable', async () => {
+    const sidecar = vi.fn().mockReturnValue(undefined)
+    const siblingProbe = vi.fn().mockReturnValue(captured('daemon-headless'))
+    const source = createDaemonLostWorkerSnapshotSource({
+      lostLeafId: 'lost',
+      captureLostLeaf: () => captured('daemon-headless'),
+      captureSessionSidecar: sidecar,
+      captureSiblingColdRestore: siblingProbe
+    })
+
+    await expect(source.capture(pane('sibling'))).resolves.toMatchObject({
+      source: 'daemon-headless'
+    })
+    expect(sidecar).toHaveBeenCalledWith('sibling')
+    expect(siblingProbe).toHaveBeenCalledWith('sibling')
+  })
+
+  it('never probes a sibling for the original lost leaf', async () => {
+    const siblingProbe = vi.fn().mockReturnValue(captured('daemon-headless'))
+    const source = createDaemonLostWorkerSnapshotSource({
+      lostLeafId: 'lost',
+      captureLostLeaf: () => captured('daemon-headless'),
+      captureSessionSidecar: () => undefined,
+      captureSiblingColdRestore: siblingProbe
+    })
+
+    await expect(source.capture(pane('lost'))).resolves.toMatchObject({ source: 'daemon-headless' })
+    expect(siblingProbe).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/terminal-lost-worker-snapshot-source.ts
+++ b/src/main/terminal-lost-worker-snapshot-source.ts
@@ -1,0 +1,62 @@
+import type { ArchivedTerminalPane } from '../shared/terminal-archive-types'
+import {
+  createPrioritizedTerminalArchiveSnapshotSource,
+  type TerminalArchivePaneSnapshotCapture,
+  type TerminalArchiveSnapshotSource
+} from '../shared/workspace-session-terminal-archive'
+
+type CaptureByLeafId = (
+  leafId: string
+) =>
+  | Promise<TerminalArchivePaneSnapshotCapture | undefined>
+  | TerminalArchivePaneSnapshotCapture
+  | undefined
+
+function unavailable(): TerminalArchivePaneSnapshotCapture {
+  return { kind: 'unavailable' }
+}
+
+function sourceFromLeafCapture(captureByLeafId: CaptureByLeafId): TerminalArchiveSnapshotSource {
+  return {
+    async capture(pane: ArchivedTerminalPane): Promise<TerminalArchivePaneSnapshotCapture> {
+      return (await captureByLeafId(pane.archivedLeafId)) ?? unavailable()
+    }
+  }
+}
+
+/** Keeps the two lost-worker paths on the same authority ordering without inventing a capture for a missing leaf. */
+export function createRelayLostWorkerSnapshotSource(args: {
+  captureSessionSidecar: CaptureByLeafId
+  captureRelayTail: CaptureByLeafId
+}): TerminalArchiveSnapshotSource {
+  return createPrioritizedTerminalArchiveSnapshotSource({
+    sessionSidecar: sourceFromLeafCapture(args.captureSessionSidecar),
+    relayTail: sourceFromLeafCapture(args.captureRelayTail)
+  })
+}
+
+export function createDaemonLostWorkerSnapshotSource(args: {
+  lostLeafId: string
+  captureLostLeaf: () =>
+    | Promise<TerminalArchivePaneSnapshotCapture>
+    | TerminalArchivePaneSnapshotCapture
+  captureSessionSidecar: CaptureByLeafId
+  captureSiblingColdRestore: CaptureByLeafId
+}): TerminalArchiveSnapshotSource {
+  return createPrioritizedTerminalArchiveSnapshotSource({
+    daemonAuthoritative: {
+      async capture(pane: ArchivedTerminalPane): Promise<TerminalArchivePaneSnapshotCapture> {
+        return pane.archivedLeafId === args.lostLeafId
+          ? await args.captureLostLeaf()
+          : unavailable()
+      }
+    },
+    sessionSidecar: sourceFromLeafCapture(async (leafId) => {
+      const sidecar = await args.captureSessionSidecar(leafId)
+      if (sidecar) {
+        return sidecar
+      }
+      return leafId === args.lostLeafId ? undefined : await args.captureSiblingColdRestore(leafId)
+    })
+  })
+}

--- a/src/main/terminal-scrollback-snapshots.test.ts
+++ b/src/main/terminal-scrollback-snapshots.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ArchivedTerminalTab } from '../shared/terminal-archive-types'
+import { getDefaultWorkspaceSession } from '../shared/constants'
+import {
+  collectTerminalArchiveScrollbackSnapshotRefs,
+  collectTerminalScrollbackSnapshotRefs,
+  makeTerminalArchiveScrollbackSnapshotRef,
+  makeTerminalScrollbackSnapshotRef,
+  readTerminalScrollbackSnapshotSync,
+  writeTerminalArchiveScrollbackSnapshotSync
+} from './terminal-scrollback-snapshots'
+
+const testState = vi.hoisted(() => ({ root: '' }))
+
+vi.mock('electron', () => ({ app: { getPath: () => testState.root } }))
+
+const ARCHIVE_ID = '11111111-1111-4111-8111-111111111111'
+const LEAF_ID = '22222222-2222-4222-8222-222222222222'
+
+describe('terminal scrollback archive references', () => {
+  beforeEach(() => {
+    testState.root = mkdtempSync(join(tmpdir(), 'orca-scrollback-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.root, { recursive: true, force: true })
+  })
+
+  it('uses a separate stable namespace for archive refs while sharing the sidecar reader', () => {
+    const activeRef = makeTerminalScrollbackSnapshotRef('tab-1', LEAF_ID)
+    const archiveRef = makeTerminalArchiveScrollbackSnapshotRef(ARCHIVE_ID, LEAF_ID)
+    const storage = { snapshotRoot: join(testState.root, 'terminal-scrollback') }
+    const written = writeTerminalArchiveScrollbackSnapshotSync({
+      archiveId: ARCHIVE_ID,
+      leafId: LEAF_ID,
+      buffer: 'archive scrollback',
+      storage
+    })
+
+    expect(activeRef).toMatch(/^v1-[0-9a-f]{32}$/)
+    expect(archiveRef).toMatch(/^v1a-[0-9a-f]{32}$/)
+    expect(written).toMatchObject({ kind: 'written', ref: archiveRef })
+    expect(readTerminalScrollbackSnapshotSync(archiveRef, storage)).toBe('archive scrollback')
+  })
+
+  it('distinguishes a known-empty archive buffer from an archive sidecar write failure', () => {
+    const empty = writeTerminalArchiveScrollbackSnapshotSync({
+      archiveId: ARCHIVE_ID,
+      leafId: LEAF_ID,
+      buffer: '',
+      storage: { snapshotRoot: join(testState.root, 'terminal-scrollback') }
+    })
+    const blockedRoot = join(testState.root, 'blocked-snapshot-root')
+    writeFileSync(blockedRoot, 'not a directory')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const failed = writeTerminalArchiveScrollbackSnapshotSync({
+      archiveId: ARCHIVE_ID,
+      leafId: LEAF_ID,
+      buffer: 'scrollback',
+      storage: { snapshotRoot: blockedRoot }
+    })
+    warn.mockRestore()
+
+    expect(empty).toEqual({ kind: 'empty' })
+    expect(failed).toEqual({ kind: 'failed' })
+  })
+
+  it('collects live active and archive refs separately for a shared GC decision', () => {
+    const activeRef = makeTerminalScrollbackSnapshotRef('tab-1', LEAF_ID)
+    const archiveRef = makeTerminalArchiveScrollbackSnapshotRef(ARCHIVE_ID, LEAF_ID)
+    const session = {
+      ...getDefaultWorkspaceSession(),
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf' as const, leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          scrollbackRefsByLeafId: { [LEAF_ID]: activeRef }
+        }
+      }
+    }
+    const archives: Record<string, ArchivedTerminalTab> = {
+      [ARCHIVE_ID]: {
+        schemaVersion: 1,
+        id: ARCHIVE_ID,
+        operationId: 'close-1',
+        sourceTabId: 'tab-1',
+        executionHostId: 'local',
+        worktreeId: 'repo-1::/worktree',
+        title: 'Terminal',
+        layout: {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null
+        },
+        panesByLeafId: {
+          [LEAF_ID]: {
+            archivedLeafId: LEAF_ID,
+            cwd: '/worktree',
+            snapshot: { ref: archiveRef, byteLength: 1, truncated: false, source: 'renderer' }
+          }
+        },
+        reason: 'user-close',
+        archivedAt: 1,
+        expiresAt: 2,
+        restoreCount: 0
+      }
+    }
+
+    expect(collectTerminalScrollbackSnapshotRefs(session)).toEqual(new Set([activeRef]))
+    expect(collectTerminalArchiveScrollbackSnapshotRefs(archives)).toEqual(new Set([archiveRef]))
+  })
+})

--- a/src/main/terminal-scrollback-snapshots.ts
+++ b/src/main/terminal-scrollback-snapshots.ts
@@ -12,6 +12,7 @@ import {
 import { dirname, join } from 'node:path'
 import { app } from 'electron'
 import type { WorkspaceSessionState } from '../shared/types'
+import type { ArchivedTerminalTab } from '../shared/terminal-archive-types'
 import {
   TERMINAL_SCROLLBACK_REPLAY_BYTE_LIMIT,
   TERMINAL_SCROLLBACK_STORE_BYTE_LIMIT
@@ -19,6 +20,7 @@ import {
 
 const SNAPSHOT_DIR_NAME = 'terminal-scrollback'
 const REF_PREFIX = 'v1'
+const ARCHIVE_REF_PREFIX = 'v1a'
 
 export type TerminalScrollbackSnapshotStorage = {
   snapshotRoot?: string
@@ -42,8 +44,20 @@ export function makeTerminalScrollbackSnapshotRef(tabId: string, leafId: string)
   return `${REF_PREFIX}-${hash}`
 }
 
+export function makeTerminalArchiveScrollbackSnapshotRef(
+  archiveId: string,
+  leafId: string,
+  snapshotVersion = ''
+): string {
+  const hash = createHash('sha256')
+    .update(`archive\0${archiveId}\0${leafId}\0${snapshotVersion}`)
+    .digest('hex')
+    .slice(0, 32)
+  return `${ARCHIVE_REF_PREFIX}-${hash}`
+}
+
 function snapshotPath(ref: string, snapshotRoot: string): string | null {
-  if (!/^v1-[0-9a-f]{32}$/.test(ref)) {
+  if (!/^(?:v1|v1a)-[0-9a-f]{32}$/.test(ref)) {
     return null
   }
   return join(snapshotRoot, `${ref}.bin`)
@@ -63,7 +77,7 @@ function snapshotReadPaths(ref: string, storage?: TerminalScrollbackSnapshotStor
   return fallbackPath ? [primaryPath, fallbackPath] : [primaryPath]
 }
 
-function trailingUtf8Bytes(value: string, maxBytes: number): Buffer {
+export function trailingUtf8Bytes(value: string, maxBytes: number): Buffer {
   const bytes = Buffer.from(value, 'utf-8')
   if (bytes.length <= maxBytes) {
     return bytes
@@ -133,6 +147,60 @@ export function writeTerminalScrollbackSnapshotSync(args: {
   }
 }
 
+export type TerminalArchiveScrollbackSnapshotWriteResult =
+  | { kind: 'written'; ref: string; byteLength: number; truncated: boolean }
+  | { kind: 'empty' }
+  | { kind: 'failed' }
+
+export function writeTerminalArchiveScrollbackSnapshotSync(args: {
+  archiveId: string
+  leafId: string
+  buffer: string
+  snapshotVersion?: string
+  storage?: TerminalScrollbackSnapshotStorage
+}): TerminalArchiveScrollbackSnapshotWriteResult {
+  if (!args.buffer) {
+    return { kind: 'empty' }
+  }
+  const ref = makeTerminalArchiveScrollbackSnapshotRef(
+    args.archiveId,
+    args.leafId,
+    args.snapshotVersion
+  )
+  const snapshotRoot = getSnapshotRoot(args.storage)
+  const path = snapshotPath(ref, snapshotRoot)
+  if (!path) {
+    return { kind: 'failed' }
+  }
+  const sourceByteLength = Buffer.byteLength(args.buffer, 'utf-8')
+  const bytes = trailingUtf8Bytes(args.buffer, TERMINAL_SCROLLBACK_STORE_BYTE_LIMIT)
+  try {
+    mkdirSync(snapshotRoot, { recursive: true, mode: 0o700 })
+    const tmpPath = `${path}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
+    let renamed = false
+    try {
+      writeFileSync(tmpPath, bytes, { mode: 0o600 })
+      renameSync(tmpPath, path)
+      renamed = true
+    } finally {
+      if (!renamed) {
+        rmSync(tmpPath, { force: true })
+      }
+    }
+    return {
+      kind: 'written',
+      ref,
+      byteLength: bytes.byteLength,
+      truncated: bytes.byteLength < sourceByteLength
+    }
+  } catch (err) {
+    console.warn(
+      `[terminal-scrollback] Failed to write archive snapshot: ${err instanceof Error ? err.message : String(err)}`
+    )
+    return { kind: 'failed' }
+  }
+}
+
 export function readTerminalScrollbackSnapshotSync(
   ref: string,
   storage?: TerminalScrollbackSnapshotStorage
@@ -165,6 +233,20 @@ export function collectTerminalScrollbackSnapshotRefs(session: WorkspaceSessionS
   for (const layout of Object.values(session.terminalLayoutsByTabId ?? {})) {
     for (const ref of Object.values(layout.scrollbackRefsByLeafId ?? {})) {
       refs.add(ref)
+    }
+  }
+  return refs
+}
+
+export function collectTerminalArchiveScrollbackSnapshotRefs(
+  archives: Record<string, ArchivedTerminalTab> | undefined
+): Set<string> {
+  const refs = new Set<string>()
+  for (const archive of Object.values(archives ?? {})) {
+    for (const pane of Object.values(archive.panesByLeafId)) {
+      if (pane.snapshot?.ref) {
+        refs.add(pane.snapshot.ref)
+      }
     }
   }
   return refs

--- a/src/main/window/terminal-tab-close-request-relay.test.ts
+++ b/src/main/window/terminal-tab-close-request-relay.test.ts
@@ -68,4 +68,23 @@ describe('requestTerminalTabCloseFromRenderer', () => {
 
     await expect(pending).rejects.toThrow('terminal_tab_pinned')
   })
+
+  it('returns the durable archive id from the targeted renderer acknowledgement', async () => {
+    const { requestTerminalTabCloseFromRenderer } =
+      await import('./terminal-tab-close-request-relay')
+    const webContents = { isDestroyed: () => false, send: vi.fn() }
+    const pending = requestTerminalTabCloseFromRenderer(
+      { isDestroyed: () => false, webContents } as never,
+      'tab-archive'
+    )
+    const request = webContents.send.mock.calls[0]?.[1] as { requestId: string }
+
+    ipcEmitter.emit(
+      'ui:terminalTabCloseResponse',
+      { sender: webContents },
+      { requestId: request.requestId, archiveId: '11111111-1111-4111-8111-111111111111' }
+    )
+
+    await expect(pending).resolves.toEqual({ archiveId: '11111111-1111-4111-8111-111111111111' })
+  })
 })

--- a/src/main/window/terminal-tab-close-request-relay.ts
+++ b/src/main/window/terminal-tab-close-request-relay.ts
@@ -12,12 +12,12 @@ const TERMINAL_TAB_CLOSE_TIMEOUT_MS = 20_000
 export async function requestTerminalTabCloseFromRenderer(
   mainWindow: BrowserWindow,
   tabId: string
-): Promise<void> {
+): Promise<{ archiveId: string } | void> {
   if (mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) {
     throw new Error('renderer_unavailable')
   }
   const requestId = randomUUID()
-  await new Promise<void>((resolve, reject) => {
+  return await new Promise<{ archiveId: string } | void>((resolve, reject) => {
     const timeout = setTimeout(() => {
       ipcMain.removeListener('ui:terminalTabCloseResponse', onResponse)
       reject(new Error('terminal_tab_close_timeout'))
@@ -33,7 +33,7 @@ export async function requestTerminalTabCloseFromRenderer(
       if (response.error) {
         reject(new Error(response.error))
       } else {
-        resolve()
+        resolve(response.archiveId ? { archiveId: response.archiveId } : undefined)
       }
     }
     ipcMain.on('ui:terminalTabCloseResponse', onResponse)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1321,6 +1321,8 @@ export type PreloadApi = {
       terminalColorQueryReplies?: { foreground?: string; background?: string }
       // Why: mark the PTY hidden before its first byte so the delivery gate owns spawn-time queries (terminal-query-authority.md §races).
       initiallyHidden?: boolean
+      // Why: a sleeping-record wake is a deliberate resume, not an unexpected worker loss.
+      controlledHibernationWake?: boolean
       // Why: main sync-flushes the (worktreeId,tabId,leafId→ptyId) binding before pty:spawn returns to close a SIGKILL race (INVESTIGATION.md).
       tabId?: string
       leafId?: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3269,7 +3269,7 @@ export type PreloadApi = {
       fromPaneKey: string
       toPaneKey: string
       ptyId?: string
-    }) => void
+    }) => Promise<{ kind: 'transferred' | 'not-owned' | 'durability-failed' }>
   }
   mobile: {
     listNetworkInterfaces: () => Promise<{

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -18,6 +18,7 @@ import type {
   TerminalTabCloseRequest,
   TerminalTabCloseResponse
 } from '../shared/terminal-tab-close'
+import type { TerminalArchiveRendererCloseRequest } from '../shared/terminal-archive-types'
 import type {
   LocalLogTailChangedPayload,
   LocalLogTailReadArgs,
@@ -1343,6 +1344,9 @@ export type PreloadApi = {
     signal: (id: string, signal: string) => void
     clearBuffer: (id: string) => void
     kill: (id: string, opts?: { keepHistory?: boolean }) => Promise<void>
+    archiveTerminalTab: (
+      request: TerminalArchiveRendererCloseRequest
+    ) => Promise<{ archiveId: string }>
     ackColdRestore: (id: string) => void
     ackData: (id: string, charCount: number, processedChars?: number) => void
     onDeliveryResyncRequest: (callback: (payload: { requestId: number }) => void) => () => void

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -18,7 +18,11 @@ import type {
   TerminalTabCloseRequest,
   TerminalTabCloseResponse
 } from '../shared/terminal-tab-close'
-import type { TerminalArchiveRendererCloseRequest } from '../shared/terminal-archive-types'
+import type {
+  TerminalArchiveRendererCloseRequest,
+  TerminalLostWorkerRendererReceipt,
+  TerminalLostWorkerRendererRequest
+} from '../shared/terminal-archive-types'
 import type {
   LocalLogTailChangedPayload,
   LocalLogTailReadArgs,
@@ -1347,6 +1351,9 @@ export type PreloadApi = {
     archiveTerminalTab: (
       request: TerminalArchiveRendererCloseRequest
     ) => Promise<{ archiveId: string }>
+    handleLostTerminalCandidate: (
+      request: TerminalLostWorkerRendererRequest
+    ) => Promise<TerminalLostWorkerRendererReceipt>
     ackColdRestore: (id: string) => void
     ackData: (id: string, charCount: number, processedChars?: number) => void
     onDeliveryResyncRequest: (callback: (payload: { requestId: number }) => void) => () => void

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1470,7 +1470,12 @@ export type PreloadApi = {
     /** Title-only replay snapshot for (re)attach; attention facts never replay. */
     getSideEffectSnapshot: (id: string) => Promise<TerminalSideEffectBatch | null>
     onExit: (
-      callback: (data: { id: string; code: number; preserveRendererBinding?: boolean }) => void
+      callback: (data: {
+        id: string
+        code: number
+        preserveRendererBinding?: boolean
+        lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+      }) => void
     ) => () => void
     onSerializeBufferRequest: (
       callback: (data: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1339,6 +1339,7 @@ export type PreloadApi = {
       sessionExpired?: boolean
       coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }
       startupCwdFallback?: { kind: 'worktree'; cwd: string }
+      lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
     }>
     write: (id: string, data: string) => void
     writeAccepted: (id: string, data: string) => Promise<boolean>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -821,6 +821,8 @@ const api = {
       terminalColorQueryReplies?: { foreground?: string; background?: string }
       // Why: marks the PTY hidden before its first byte so the delivery gate + model responder own spawn-time queries (terminal-query-authority.md §races).
       initiallyHidden?: boolean
+      // Why: a sleeping-record wake is a deliberate resume, not an unexpected worker loss.
+      controlledHibernationWake?: boolean
       // Why: closes the SIGKILL race (INVESTIGATION.md) — main sync-flushes the (worktreeId, tabId, leafId → ptyId) binding before pty:spawn returns.
       tabId?: string
       leafId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4456,9 +4456,8 @@ const api = {
       fromPaneKey: string
       toPaneKey: string
       ptyId?: string
-    }): void => {
-      ipcRenderer.send('agentStatus:transferPaneAuthority', args)
-    }
+    }): Promise<{ kind: 'transferred' | 'not-owned' | 'durability-failed' }> =>
+      ipcRenderer.invoke('agentStatus:transferPaneAuthority', args)
   },
 
   speech: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -925,6 +925,9 @@ const api = {
 
     archiveTerminalTab: (request) => ipcRenderer.invoke('pty:archiveTerminalTab', request),
 
+    handleLostTerminalCandidate: (request) =>
+      ipcRenderer.invoke('pty:handleLostTerminalCandidate', request),
+
     listSessions: (): Promise<{ id: string; cwd: string; title: string }[]> =>
       ipcRenderer.invoke('pty:listSessions'),
     getAuthoritativeBufferSnapshotCapabilities: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -923,6 +923,8 @@ const api = {
     kill: (id: string, opts?: { keepHistory?: boolean }): Promise<void> =>
       ipcRenderer.invoke('pty:kill', { id, keepHistory: opts?.keepHistory ?? false }),
 
+    archiveTerminalTab: (request) => ipcRenderer.invoke('pty:archiveTerminalTab', request),
+
     listSessions: (): Promise<{ id: string; cwd: string; title: string }[]> =>
       ipcRenderer.invoke('pty:listSessions'),
     getAuthoritativeBufferSnapshotCapabilities: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -18,6 +18,7 @@ import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 import type { StartupCommandDelivery } from '../shared/codex-startup-delivery'
+import type { TerminalLostWorkerRendererReceipt } from '../shared/terminal-archive-types'
 import type {
   AgentProviderSessionMetadata,
   SleepingAgentLaunchConfig
@@ -1063,10 +1064,22 @@ const api = {
       ipcRenderer.invoke('pty:sideEffectSnapshot', { id }),
 
     onExit: (
-      callback: (data: { id: string; code: number; preserveRendererBinding?: boolean }) => void
+      callback: (data: {
+        id: string
+        code: number
+        preserveRendererBinding?: boolean
+        lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+      }) => void
     ): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, data: { id: string; code: number }) =>
-        callback(data)
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: {
+          id: string
+          code: number
+          preserveRendererBinding?: boolean
+          lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+        }
+      ) => callback(data)
       ipcRenderer.on('pty:exit', listener)
       return () => ipcRenderer.removeListener('pty:exit', listener)
     },

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -499,6 +499,12 @@ describe('PtyHandler', () => {
     ).rejects.toThrow(`PTY persistence request exceeds ${MAX_RELAY_PTY_SESSIONS} entries`)
   })
 
+  it('rejects duplicate requested PTY ids before serialization', async () => {
+    await expect(
+      dispatcher.callRequest('pty.serialize', { ids: ['pty-1', 'pty-1'], formatVersion: 2 })
+    ).rejects.toThrow('duplicate PTY ids')
+  })
+
   it('spawns a PTY without post-Node-18 array copy methods', async () => {
     const descriptor = Object.getOwnPropertyDescriptor(Array.prototype, 'toReversed')
     Reflect.deleteProperty(Array.prototype, 'toReversed')
@@ -3076,6 +3082,73 @@ describe('PtyHandler', () => {
 
     expect(JSON.parse(state)).toBeInstanceOf(Array)
     expect(legacyRevive).toBeUndefined()
+  })
+
+  it('rejects v2 state on the legacy revive path before probing or spawning', async () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      await expect(
+        dispatcher.callRequest('pty.revive', {
+          state: JSON.stringify({
+            schemaVersion: 2,
+            entries: [
+              {
+                id: 'pty-worker',
+                pid: process.pid,
+                sourceIncarnationId: 'incarnation-worker',
+                cols: 80,
+                rows: 24,
+                cwd: '/repo',
+                durableLaunch: { launchAgent: 'codex' }
+              }
+            ]
+          })
+        })
+      ).rejects.toThrow('requires typed revive')
+
+      expect(killSpy).not.toHaveBeenCalled()
+      expect(mockPtySpawn).not.toHaveBeenCalled()
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('rejects duplicate v2 state ids before any revive side effect', async () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      await expect(
+        dispatcher.callRequest('pty.revive', {
+          formatVersion: 2,
+          state: JSON.stringify({
+            schemaVersion: 2,
+            entries: [
+              {
+                id: 'pty-duplicate',
+                pid: process.pid,
+                sourceIncarnationId: 'incarnation-shell',
+                cols: 80,
+                rows: 24,
+                cwd: '/repo'
+              },
+              {
+                id: 'pty-duplicate',
+                pid: process.pid,
+                sourceIncarnationId: 'incarnation-worker',
+                cols: 80,
+                rows: 24,
+                cwd: '/repo',
+                durableLaunch: { launchAgent: 'codex' }
+              }
+            ]
+          })
+        })
+      ).rejects.toThrow('duplicate PTY ids')
+
+      expect(killSpy).not.toHaveBeenCalled()
+      expect(mockPtySpawn).not.toHaveBeenCalled()
+    } finally {
+      killSpy.mockRestore()
+    }
   })
 
   it('returns a recognized worker as lost before probing or spawning it', async () => {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -3067,6 +3067,150 @@ describe('PtyHandler', () => {
     ])
     expect(handler.activePtyCount).toBe(0)
   })
+
+  it('keeps legacy persistence behavior until a caller explicitly requests v2', async () => {
+    await spawnPty({ command: 'codex', launchAgent: 'codex' })
+
+    const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+    const legacyRevive = await dispatcher.callRequest('pty.revive', { state })
+
+    expect(JSON.parse(state)).toBeInstanceOf(Array)
+    expect(legacyRevive).toBeUndefined()
+  })
+
+  it('returns a recognized worker as lost before probing or spawning it', async () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      const result = (await dispatcher.callRequest('pty.revive', {
+        formatVersion: 2,
+        state: JSON.stringify({
+          schemaVersion: 2,
+          entries: [
+            {
+              id: 'pty-worker',
+              pid: process.pid,
+              sourceIncarnationId: 'incarnation-worker',
+              cols: 80,
+              rows: 24,
+              cwd: '/repo',
+              durableLaunch: { launchAgent: 'codex', startupCommand: 'codex --full-auto' }
+            }
+          ]
+        })
+      })) as { lost: { kind: string; reason: string }[] }
+
+      expect(result.lost).toEqual([
+        expect.objectContaining({
+          kind: 'recognized-worker',
+          reason: 'worker-replacement-forbidden'
+        })
+      ])
+      expect(killSpy).not.toHaveBeenCalled()
+      expect(mockPtySpawn).not.toHaveBeenCalled()
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('reports typed lost outcomes for dead ordinary and legacy-unclassified entries', async () => {
+    const deadPid = process.pid + 1_000_000
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('must not probe unclassified state')
+    })
+    try {
+      const ordinary = (await dispatcher.callRequest('pty.revive', {
+        formatVersion: 2,
+        state: JSON.stringify({
+          schemaVersion: 2,
+          entries: [
+            {
+              id: 'pty-dead',
+              pid: deadPid,
+              sourceIncarnationId: 'incarnation-dead',
+              cols: 80,
+              rows: 24,
+              cwd: '/repo'
+            }
+          ]
+        })
+      })) as { lost: { kind: string; reason: string }[] }
+      const legacy = (await dispatcher.callRequest('pty.revive', {
+        formatVersion: 2,
+        state: JSON.stringify([
+          { id: 'pty-legacy', pid: deadPid, cols: 80, rows: 24, cwd: '/repo' }
+        ])
+      })) as { lost: { kind: string }[]; diagnostics: { code: string }[] }
+
+      expect(ordinary.lost).toEqual([
+        expect.objectContaining({ kind: 'ordinary-shell', reason: 'process-not-running' })
+      ])
+      expect(legacy.lost).toEqual([expect.objectContaining({ kind: 'unclassified' })])
+      expect(legacy.diagnostics).toContainEqual({ code: 'legacy-state' })
+      expect(killSpy).toHaveBeenCalledOnce()
+      expect(mockPtySpawn).not.toHaveBeenCalled()
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('coalesces concurrent typed ordinary revival into one replacement and one outcome', async () => {
+    const state = JSON.stringify({
+      schemaVersion: 2,
+      entries: [
+        {
+          id: 'pty-concurrent',
+          pid: process.pid,
+          sourceIncarnationId: 'incarnation-concurrent',
+          cols: 80,
+          rows: 24,
+          cwd: '/repo'
+        }
+      ]
+    })
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      const [first, second] = await Promise.all([
+        dispatcher.callRequest('pty.revive', { state, formatVersion: 2 }),
+        dispatcher.callRequest('pty.revive', { state, formatVersion: 2 })
+      ])
+
+      expect(first).toEqual(second)
+      expect(first).toMatchObject({
+        revived: [{ id: 'pty-concurrent', disposition: 'replacement-spawned' }]
+      })
+      expect(mockPtySpawn).toHaveBeenCalledOnce()
+    } finally {
+      killSpy.mockRestore()
+    }
+  })
+
+  it('reports an identity collision as lost instead of adopting another pane PTY', async () => {
+    await spawnPty({ env: { ORCA_PANE_KEY: 'tab-live:leaf-live' }, tabId: 'tab-live' })
+
+    const result = (await dispatcher.callRequest('pty.revive', {
+      formatVersion: 2,
+      state: JSON.stringify({
+        schemaVersion: 2,
+        entries: [
+          {
+            id: 'pty-1',
+            pid: process.pid,
+            sourceIncarnationId: 'old-incarnation',
+            cols: 80,
+            rows: 24,
+            cwd: '/repo',
+            paneKey: 'tab-other:leaf-other',
+            tabId: 'tab-other'
+          }
+        ]
+      })
+    })) as { revived: unknown[]; lost: { id: string }[]; diagnostics: { code: string }[] }
+
+    expect(result.revived).toEqual([])
+    expect(result.lost).toEqual([expect.objectContaining({ id: 'pty-1' })])
+    expect(result.diagnostics).toContainEqual({ code: 'entry-invalid', id: 'pty-1' })
+    expect(mockPtySpawn).toHaveBeenCalledOnce()
+  })
 })
 
 describe('attachIdentityMismatches', () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1489,6 +1489,9 @@ export class PtyHandler {
 
   private async revive(params: Record<string, unknown>): Promise<void | RelayPtyReviveOutcomeV1> {
     const state = parseRelayPtyPersistenceState(params.state, MAX_RELAY_PTY_SESSIONS)
+    if (state.formatVersion === 2 && params.formatVersion !== 2) {
+      throw new Error('PTY persistence v2 state requires typed revive')
+    }
     if (params.formatVersion !== 2) {
       await this.reviveLegacy(state.entries)
       return

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -39,6 +39,19 @@ import {
   mergeGitConfigEnvProtocol
 } from '../shared/git-credential-prompt-env'
 import { isTuiAgent } from '../shared/tui-agent-config'
+import {
+  normalizeAgentProviderSession,
+  type AgentProviderSessionMetadata
+} from '../shared/agent-session-resume'
+import {
+  RELAY_PTY_REVIVE_OUTCOME_VERSION,
+  type RelayPtyDurableLaunch,
+  type RelayPtyLostEntry,
+  type RelayPtyReviveDiagnostic,
+  type RelayPtyReviveOutcomeV1,
+  type RelayPtyRevivedEntry
+} from '../shared/pty-revive-protocol'
+import { clampUtf8TextTail, measureUtf8ByteLength } from '../shared/utf8-byte-limits'
 import { forceKillPosixPtyProcessGroups } from '../main/pty/posix-pty-process-groups'
 import { stripInheritedBuildModeEnv } from '../main/pty/build-mode-env'
 import {
@@ -63,10 +76,12 @@ import { PtyOutputBroadcast } from './pty-output-broadcast'
 import {
   assertRelayPtyPersistenceFieldWithinLimit,
   assertRelayPtyRetainedFieldsWithinLimits,
-  parseRelayPtyPersistenceEnvelope,
+  parseRelayPtyPersistenceState,
   parseRelayPtyPersistenceIds,
   sanitizeRelayPtyEnvToDelete,
   serializeRelayPtyPersistenceEnvelope,
+  MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES,
+  MAX_RELAY_PTY_LOST_TAIL_BYTES,
   type RelayPtyIdentity,
   type RelayPtyPersistenceEntry
 } from './pty-persistence-envelope'
@@ -92,6 +107,7 @@ type ManagedPty = {
   pty: IPty
   initialCwd: string
   buffered: string
+  bufferedTruncated?: boolean
   /** Timer for SIGKILL fallback after a graceful SIGTERM shutdown. */
   killTimer?: ReturnType<typeof setTimeout>
   /** True once disposeManagedPty has run; blocks double-dispose and makes post-dispose calls fail "not found" not silently. */
@@ -116,6 +132,10 @@ type ManagedPty = {
   startupIngressIntent?: ReturnType<typeof parsePtyStartupIngressIntent>
   ownerBackend: PtyOwnerBackend
   agentSessionOwners?: AgentSessionOwnerBinding[]
+  durableLaunch?: RelayPtyDurableLaunch
+  providerSession?: AgentProviderSessionMetadata
+  orchestrationTaskId?: string
+  revivedFromIncarnationId?: string
 }
 
 type RelayAgentSessionCreateResult = {
@@ -128,6 +148,54 @@ type RelayAgentSessionCreateResult = {
 const AGENT_SESSION_CREATE_OPERATION_ID_PATTERN = /^[A-Za-z0-9_-]{43}$/
 const AGENT_SESSION_CREATE_OPERATION_RETENTION_MS = 24 * 60 * 60 * 1000
 const AGENT_SESSION_CREATE_OPERATION_LIMIT = 4_096
+
+type RelayPtyTypedReviveEntryResult = {
+  revived?: RelayPtyRevivedEntry
+  lost?: RelayPtyLostEntry
+  diagnostics?: RelayPtyReviveDiagnostic[]
+}
+
+type PendingRelayPtyReviveOperation = {
+  key: string
+  operation: Promise<RelayPtyTypedReviveEntryResult>
+}
+
+type RelayPtyArchiveContext = {
+  providerSession?: AgentProviderSessionMetadata
+  orchestrationTaskId?: string
+}
+
+function withinPersistenceFieldLimit(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    !measureUtf8ByteLength(value, { stopAfterBytes: MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES })
+      .exceededLimit
+  )
+}
+
+function normalizeRelayPtyArchiveContext(value: unknown): RelayPtyArchiveContext {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+  const context = value as Record<string, unknown>
+  const candidateProviderSession =
+    normalizeAgentProviderSession(context.providerSession) ?? undefined
+  const providerSession =
+    candidateProviderSession &&
+    withinPersistenceFieldLimit(candidateProviderSession.id) &&
+    (!candidateProviderSession.transcriptPath ||
+      withinPersistenceFieldLimit(candidateProviderSession.transcriptPath))
+      ? candidateProviderSession
+      : undefined
+  const orchestrationTaskId = withinPersistenceFieldLimit(context.orchestrationTaskId)
+    ? context.orchestrationTaskId
+    : undefined
+  return {
+    ...(providerSession ? { providerSession } : {}),
+    ...(orchestrationTaskId ? { orchestrationTaskId } : {})
+  }
+}
 
 type ManagedStartupCommand = {
   command: string
@@ -184,7 +252,7 @@ function disposeManagedPty(managed: ManagedPty): void {
 const DEFAULT_GRACE_TIME_MS = DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS * 1000
 export const IMMEDIATE_PTY_EXIT_TIMEOUT_MS = 8_000
 export const MAX_RELAY_PTY_SESSIONS = 50
-export const REPLAY_BUFFER_MAX = 100 * 1024
+export const REPLAY_BUFFER_MAX = MAX_RELAY_PTY_LOST_TAIL_BYTES
 const INTERACTIVE_OUTPUT_WINDOW_MS = 100
 const INTERACTIVE_OUTPUT_MAX_CHARS = 1024
 const INTERACTIVE_REDRAW_MAX_CHARS = 16 * 1024
@@ -280,7 +348,7 @@ export class PtyHandler {
   private lastInputAtByPty = new Map<string, number>()
   private interactiveOutputCharsByPty = new Map<string, number>()
   private pendingSpawnCount = 0
-  private pendingReviveIds = new Set<string>()
+  private pendingReviveOperations = new Map<string, PendingRelayPtyReviveOperation>()
   private creationFenced = false
   private pendingCreationDrainResolvers = new Set<() => void>()
   private worktreeRemovalCoordinator: RelayPtyWorktreeRemovalCoordinator | null = null
@@ -458,6 +526,7 @@ export class PtyHandler {
     managed.buffered += data
     if (managed.buffered.length > REPLAY_BUFFER_MAX) {
       managed.buffered = managed.buffered.slice(-REPLAY_BUFFER_MAX)
+      managed.bufferedTruncated = true
     }
   }
 
@@ -608,7 +677,9 @@ export class PtyHandler {
     this.dispatcher.onRequest('pty.getCapabilities', async () => ({
       startupIngressVersion: PTY_STARTUP_INGRESS_VERSION,
       agentSessionClaimVersion: AGENT_SESSION_EXECUTION_OWNER_PROTOCOL_VERSION,
-      agentSessionCreateOperationVersion: AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION
+      agentSessionCreateOperationVersion: AGENT_SESSION_CREATE_OPERATION_PROTOCOL_VERSION,
+      ptyPersistenceEnvelopeVersion: 2,
+      ptyReviveOutcomeVersion: RELAY_PTY_REVIVE_OUTCOME_VERSION
     }))
     this.dispatcher.onRequest('pty.listProcesses', () => this.listProcesses())
     this.dispatcher.onRequest('pty.getDefaultShell', async () => resolveDefaultShell())
@@ -922,7 +993,7 @@ export class PtyHandler {
     let id: string
     do {
       id = `pty-${this.nextId++}`
-    } while (this.ptys.has(id) || this.pendingReviveIds.has(id))
+    } while (this.ptys.has(id) || this.pendingReviveOperations.has(id))
 
     // Why: augmenter values override renderer env so remote paths and hook coords win over local userData.
     const paneKey = typeof env?.ORCA_PANE_KEY === 'string' ? env.ORCA_PANE_KEY : undefined
@@ -947,6 +1018,15 @@ export class PtyHandler {
       envToDelete
     })
     const command = typeof params.command === 'string' ? params.command : undefined
+    const archiveContext = normalizeRelayPtyArchiveContext(params.archiveContext)
+    const durableLaunch: RelayPtyDurableLaunch = {
+      ...(withinPersistenceFieldLimit(command) ? { startupCommand: command } : {}),
+      ...(withinPersistenceFieldLimit(resolvedShellOverride)
+        ? { shellOverride: resolvedShellOverride }
+        : {}),
+      ...(isTuiAgent(params.launchAgent) ? { launchAgent: params.launchAgent } : {}),
+      startedAt: Date.now()
+    }
     const terminalWindowsWslDistro =
       typeof params.terminalWindowsWslDistro === 'string' ? params.terminalWindowsWslDistro : null
     const commandDelivery = params.commandDelivery === 'provider' ? 'provider' : 'renderer'
@@ -1021,6 +1101,13 @@ export class PtyHandler {
       ...(explicitTerm !== undefined ? { explicitTerm } : {}),
       envToDelete,
       gitCredentialPromptGuarded,
+      durableLaunch,
+      ...(archiveContext.providerSession
+        ? { providerSession: archiveContext.providerSession }
+        : {}),
+      ...(archiveContext.orchestrationTaskId
+        ? { orchestrationTaskId: archiveContext.orchestrationTaskId }
+        : {}),
       ownerBackend: resolvePtyOwnerBackend({
         platform: process.platform,
         shellPath: shell,
@@ -1349,6 +1436,7 @@ export class PtyHandler {
 
   private async serialize(params: Record<string, unknown>): Promise<string> {
     const ids = parseRelayPtyPersistenceIds(params.ids, MAX_RELAY_PTY_SESSIONS)
+    const formatVersion = params.formatVersion === 2 ? 2 : undefined
     const entries: RelayPtyPersistenceEntry[] = []
     for (const id of ids) {
       const managed = this.ptys.get(id)
@@ -1356,7 +1444,7 @@ export class PtyHandler {
         continue
       }
       const { pid, cols, rows } = managed.pty
-      entries.push({
+      const entry: RelayPtyPersistenceEntry = {
         id,
         pid,
         cols,
@@ -1370,16 +1458,64 @@ export class PtyHandler {
         envToDelete: managed.envToDelete,
         gitCredentialPromptGuarded: managed.gitCredentialPromptGuarded,
         ...(managed.terminalHandle ? { terminalHandle: managed.terminalHandle } : {})
-      })
+      }
+      if (formatVersion === 2) {
+        const tail = clampUtf8TextTail(managed.buffered, MAX_RELAY_PTY_LOST_TAIL_BYTES)
+        entries.push({
+          ...entry,
+          sourceIncarnationId: managed.incarnationId,
+          replayTail: {
+            data: tail.text,
+            encoding: 'utf8',
+            byteLength: tail.bytes,
+            truncated:
+              managed.bufferedTruncated === true || tail.text.length !== managed.buffered.length
+          },
+          durableLaunch: managed.durableLaunch,
+          ...(this.agentSessionOwners.listForPty(id).length
+            ? { agentOwners: this.agentSessionOwners.listForPty(id) }
+            : {}),
+          ...(managed.providerSession ? { providerSession: managed.providerSession } : {}),
+          ...(managed.orchestrationTaskId
+            ? { orchestrationTaskId: managed.orchestrationTaskId }
+            : {})
+        })
+      } else {
+        entries.push(entry)
+      }
     }
-    return serializeRelayPtyPersistenceEnvelope(entries, MAX_RELAY_PTY_SESSIONS)
+    return serializeRelayPtyPersistenceEnvelope(entries, MAX_RELAY_PTY_SESSIONS, formatVersion)
   }
 
-  private async revive(params: Record<string, unknown>): Promise<void> {
-    const entries = parseRelayPtyPersistenceEnvelope(params.state, MAX_RELAY_PTY_SESSIONS)
+  private async revive(params: Record<string, unknown>): Promise<void | RelayPtyReviveOutcomeV1> {
+    const state = parseRelayPtyPersistenceState(params.state, MAX_RELAY_PTY_SESSIONS)
+    if (params.formatVersion !== 2) {
+      await this.reviveLegacy(state.entries)
+      return
+    }
 
+    const results = await Promise.all(
+      state.entries.map((entry) => this.reviveTypedEntry(entry, state.formatVersion))
+    )
+    return {
+      outcomeVersion: RELAY_PTY_REVIVE_OUTCOME_VERSION,
+      revived: results.flatMap((result) => (result.revived ? [result.revived] : [])),
+      lost: results.flatMap((result) => (result.lost ? [result.lost] : [])),
+      diagnostics: [
+        ...(state.formatVersion === 'legacy' ? [{ code: 'legacy-state' as const }] : []),
+        ...results.flatMap((result) => result.diagnostics ?? [])
+      ]
+    }
+  }
+
+  private async reviveLegacy(entries: readonly RelayPtyPersistenceEntry[]): Promise<void> {
     for (const entry of entries) {
-      if (this.ptys.has(entry.id) || this.pendingReviveIds.has(entry.id)) {
+      if (this.ptys.has(entry.id)) {
+        continue
+      }
+      const pending = this.pendingReviveOperations.get(entry.id)
+      if (pending) {
+        await pending.operation
         continue
       }
       // Only re-attach if the original process is still alive
@@ -1392,20 +1528,168 @@ export class PtyHandler {
         ? splitWorktreeId(entry.worktreeId)?.worktreePath
         : undefined
       const finishCreation = this.beginPtyCreation([ownedPath, entry.cwd])
-      this.pendingReviveIds.add(entry.id)
+      const operation = this.reviveEntry(entry).then(() => ({}))
+      this.pendingReviveOperations.set(entry.id, {
+        key: this.reviveOperationKey(entry, 'legacy-request'),
+        operation
+      })
       try {
-        await this.reviveEntry(entry)
+        await operation
       } finally {
-        this.pendingReviveIds.delete(entry.id)
+        if (this.pendingReviveOperations.get(entry.id)?.operation === operation) {
+          this.pendingReviveOperations.delete(entry.id)
+        }
         finishCreation()
       }
     }
   }
 
-  private async reviveEntry(entry: RelayPtyPersistenceEntry): Promise<void> {
+  private async reviveTypedEntry(
+    entry: RelayPtyPersistenceEntry,
+    formatVersion: 2 | 'legacy'
+  ): Promise<RelayPtyTypedReviveEntryResult> {
+    const key = this.reviveOperationKey(entry, `typed-${formatVersion}`)
+    const pending = this.pendingReviveOperations.get(entry.id)
+    if (pending) {
+      if (pending.key === key) {
+        return await pending.operation
+      }
+      await pending.operation
+      return this.reviveTypedEntry(entry, formatVersion)
+    }
+    const operation = this.reviveTypedEntryOnce(entry, formatVersion)
+    this.pendingReviveOperations.set(entry.id, { key, operation })
+    try {
+      return await operation
+    } finally {
+      if (this.pendingReviveOperations.get(entry.id)?.operation === operation) {
+        this.pendingReviveOperations.delete(entry.id)
+      }
+    }
+  }
+
+  private async reviveTypedEntryOnce(
+    entry: RelayPtyPersistenceEntry,
+    formatVersion: 2 | 'legacy'
+  ): Promise<RelayPtyTypedReviveEntryResult> {
+    const kind = this.reviveKindFor(entry, formatVersion)
+    const existing = this.ptys.get(entry.id)
+    if (existing) {
+      if (this.isCompatibleReviveIdentity(existing, entry)) {
+        return {
+          revived: {
+            id: entry.id,
+            disposition: 'already-managed',
+            incarnationId: existing.incarnationId,
+            ...(existing.paneKey ? { paneKey: existing.paneKey } : {}),
+            ...(existing.tabId ? { tabId: existing.tabId } : {})
+          }
+        }
+      }
+      return {
+        lost: this.toLostReviveEntry(entry, kind, 'process-not-running'),
+        diagnostics: [{ code: 'entry-invalid', id: entry.id }]
+      }
+    }
+    if (kind === 'recognized-worker') {
+      return { lost: this.toLostReviveEntry(entry, kind, 'worker-replacement-forbidden') }
+    }
+    if (kind === 'unclassified') {
+      return { lost: this.toLostReviveEntry(entry, kind, 'process-not-running') }
+    }
+    try {
+      process.kill(entry.pid, 0)
+    } catch {
+      return { lost: this.toLostReviveEntry(entry, kind, 'process-not-running') }
+    }
+    const ownedPath = entry.worktreeId ? splitWorktreeId(entry.worktreeId)?.worktreePath : undefined
+    const finishCreation = this.beginPtyCreation([ownedPath, entry.cwd])
+    try {
+      const incarnationId = await this.reviveEntry(entry, true)
+      return incarnationId
+        ? {
+            revived: {
+              id: entry.id,
+              disposition: 'replacement-spawned',
+              incarnationId,
+              ...(entry.paneKey ? { paneKey: entry.paneKey } : {}),
+              ...(entry.tabId ? { tabId: entry.tabId } : {})
+            }
+          }
+        : { lost: this.toLostReviveEntry(entry, kind, 'pty-runtime-unavailable') }
+    } finally {
+      finishCreation()
+    }
+  }
+
+  private reviveKindFor(
+    entry: RelayPtyPersistenceEntry,
+    formatVersion: 2 | 'legacy'
+  ): RelayPtyLostEntry['kind'] {
+    if (formatVersion === 'legacy') {
+      return 'unclassified'
+    }
+    return entry.durableLaunch?.launchAgent ||
+      entry.providerSession ||
+      entry.orchestrationTaskId ||
+      entry.agentOwners?.length
+      ? 'recognized-worker'
+      : 'ordinary-shell'
+  }
+
+  private reviveOperationKey(entry: RelayPtyPersistenceEntry, protocol: string): string {
+    return `${protocol}:${JSON.stringify(entry)}`
+  }
+
+  private isCompatibleReviveIdentity(
+    managed: ManagedPty,
+    entry: RelayPtyPersistenceEntry
+  ): boolean {
+    return (
+      managed.paneKey === entry.paneKey &&
+      managed.tabId === entry.tabId &&
+      managed.attachIdentity?.paneKey === entry.attachIdentity?.paneKey &&
+      managed.attachIdentity?.tabId === entry.attachIdentity?.tabId &&
+      (entry.sourceIncarnationId === undefined ||
+        managed.incarnationId === entry.sourceIncarnationId ||
+        managed.revivedFromIncarnationId === entry.sourceIncarnationId)
+    )
+  }
+
+  private toLostReviveEntry(
+    entry: RelayPtyPersistenceEntry,
+    kind: RelayPtyLostEntry['kind'],
+    reason: RelayPtyLostEntry['reason']
+  ): RelayPtyLostEntry {
+    return {
+      id: entry.id,
+      kind,
+      reason,
+      pid: entry.pid,
+      cols: entry.cols,
+      rows: entry.rows,
+      cwd: entry.cwd,
+      ...(entry.sourceIncarnationId ? { sourceIncarnationId: entry.sourceIncarnationId } : {}),
+      ...(entry.paneKey ? { paneKey: entry.paneKey } : {}),
+      ...(entry.tabId ? { tabId: entry.tabId } : {}),
+      ...(entry.attachIdentity ? { attachIdentity: entry.attachIdentity } : {}),
+      ...(entry.worktreeId ? { worktreeId: entry.worktreeId } : {}),
+      ...(entry.terminalHandle ? { terminalHandle: entry.terminalHandle } : {}),
+      ...(entry.replayTail ? { replayTail: entry.replayTail } : {}),
+      ...(entry.durableLaunch ? { durableLaunch: entry.durableLaunch } : {}),
+      ...(entry.agentOwners?.length ? { agentOwners: entry.agentOwners } : {}),
+      ...(entry.providerSession ? { providerSession: entry.providerSession } : {}),
+      ...(entry.orchestrationTaskId ? { orchestrationTaskId: entry.orchestrationTaskId } : {})
+    }
+  }
+
+  private async reviveEntry(
+    entry: RelayPtyPersistenceEntry,
+    allowRuntimeUnavailable = false
+  ): Promise<string | null> {
     const ptyMod = await this.loadPty()
     if (!ptyMod) {
-      return
+      return null
     }
     // Why: pane identity comes from the serialized entry (not env) since hook scripts exit without ORCA_PANE_KEY.
     const revivedEnv: Record<string, string> = {}
@@ -1442,17 +1726,30 @@ export class PtyHandler {
       Object.assign(spawnEnv, gitCredentialPromptGuardEnv(spawnEnv, process.platform))
     }
     const shellLaunch = getRelayShellLaunchConfig(shell, spawnEnv)
-    const term = ptyMod.spawn(shell, shellLaunch.args, {
-      name: spawnEnv.TERM ?? 'xterm-256color',
-      cols: entry.cols,
-      rows: entry.rows,
-      cwd: entry.cwd,
-      // Why: no provider-delivered command is waiting for a ready marker.
-      env: { ...spawnEnv, ORCA_SHELL_READY_MARKER: '0', ...shellLaunch.env }
-    })
+    let term: IPty
+    try {
+      term = ptyMod.spawn(shell, shellLaunch.args, {
+        name: spawnEnv.TERM ?? 'xterm-256color',
+        cols: entry.cols,
+        rows: entry.rows,
+        cwd: entry.cwd,
+        // Why: no provider-delivered command is waiting for a ready marker.
+        env: { ...spawnEnv, ORCA_SHELL_READY_MARKER: '0', ...shellLaunch.env }
+      })
+    } catch (error) {
+      if (isMissingNodePtyNativeBinding(error)) {
+        this.invalidatePtyModuleAfterBindingFailure()
+        if (allowRuntimeUnavailable) {
+          return null
+        }
+        throw new Error('node-pty is not available on this remote host')
+      }
+      throw error
+    }
+    const incarnationId = randomUUID()
     this.wireAndStore({
       id: entry.id,
-      incarnationId: randomUUID(),
+      incarnationId,
       pty: term,
       initialCwd: entry.cwd,
       buffered: '',
@@ -1467,6 +1764,7 @@ export class PtyHandler {
         platform: process.platform,
         shellPath: shell
       }),
+      ...(entry.sourceIncarnationId ? { revivedFromIncarnationId: entry.sourceIncarnationId } : {}),
       ...(entry.terminalHandle ? { terminalHandle: entry.terminalHandle } : {})
     })
 
@@ -1474,6 +1772,7 @@ export class PtyHandler {
     if (match) {
       this.nextId = Math.max(this.nextId, Number.parseInt(match[1], 10) + 1)
     }
+    return incarnationId
   }
 
   startGraceTimer(onExpire: () => void, timeoutMs = this.graceTimeMs): void {

--- a/src/relay/pty-persistence-entry-normalization.ts
+++ b/src/relay/pty-persistence-entry-normalization.ts
@@ -2,20 +2,17 @@ import {
   normalizeAgentProviderSession,
   type AgentProviderSessionMetadata
 } from '../shared/agent-session-resume'
-import {
-  isAgentSessionOwnerBinding,
-  type AgentSessionOwnerBinding
-} from '../shared/agent-session-host-authority'
+import { normalizeAgentSessionOwnerBindings } from '../shared/agent-session-owner-wire-normalization'
+import type { AgentSessionOwnerBinding } from '../shared/agent-session-host-authority'
+import { assertRelayPtyPersistenceFieldWithinLimit } from '../shared/pty-persistence-wire-limits'
 import type { RelayPtyDurableLaunch, RelayPtyReplayTail } from '../shared/pty-revive-protocol'
 import { isTuiAgent } from '../shared/tui-agent-config'
 import { measureUtf8ByteLength } from '../shared/utf8-byte-limits'
 import { terminalSizeAdmissionError } from '../shared/terminal-size-limits'
 import { normalizeRelayPtyV2EntryBasics } from './pty-persistence-v2-entry-basics'
 import {
-  MAX_RELAY_PTY_ENV_DELETE_KEYS,
   MAX_RELAY_PTY_LOST_TAIL_BYTES,
   MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES,
-  MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES,
   MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES,
   sanitizeRelayPtyEnvToDelete,
   type RelayPtyIdentity,
@@ -84,6 +81,7 @@ export function normalizeRelayPtyPersistenceEntry(
     )
   }
   const v2Basics = v2 ? normalizeRelayPtyV2EntryBasics(entry) : undefined
+  const id = requiredString(entry.id, 'id', !v2)
   const attachIdentity = v2Basics?.attachIdentity ?? normalizeLegacyIdentity(entry.attachIdentity)
   const paneKey = optionalString(entry.paneKey, 'paneKey')
   const tabId = optionalString(entry.tabId, 'tabId')
@@ -99,13 +97,13 @@ export function normalizeRelayPtyPersistenceEntry(
     : undefined
   const replayTail = v2 ? normalizeReplayTail(entry.replayTail) : undefined
   const durableLaunch = v2 ? normalizeDurableLaunch(entry.durableLaunch) : undefined
-  const agentOwners = v2 ? normalizeAgentOwners(entry.agentOwners) : undefined
+  const agentOwners = v2 ? normalizeAgentOwners(entry.agentOwners, id) : undefined
   const providerSession = v2 ? normalizeProviderSession(entry.providerSession) : undefined
   const orchestrationTaskId = v2
     ? optionalString(entry.orchestrationTaskId, 'orchestrationTaskId')
     : undefined
   return {
-    id: requiredString(entry.id, 'id', !v2),
+    id,
     pid: positiveSafeInteger(entry.pid, 'pid'),
     cols,
     rows,
@@ -131,14 +129,6 @@ export function normalizeRelayPtyPersistenceEntry(
 
 export function serializedRelayPtyPersistenceEntry(value: unknown): number {
   return Buffer.byteLength(JSON.stringify(value), 'utf8')
-}
-
-export function assertRelayPtyPersistenceFieldWithinLimit(field: string, value: string): void {
-  if (Buffer.byteLength(value, 'utf8') > MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES) {
-    throw new Error(
-      `PTY persistence field "${field}" exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`
-    )
-  }
 }
 
 function normalizeLegacyIdentity(value: unknown): RelayPtyIdentity | undefined {
@@ -205,18 +195,14 @@ function normalizeDurableLaunch(value: unknown): RelayPtyDurableLaunch | undefin
   }
 }
 
-function normalizeAgentOwners(value: unknown): AgentSessionOwnerBinding[] | undefined {
+function normalizeAgentOwners(
+  value: unknown,
+  entryId: string
+): AgentSessionOwnerBinding[] | undefined {
   if (value === undefined) {
     return undefined
   }
-  if (
-    !Array.isArray(value) ||
-    value.length > MAX_RELAY_PTY_ENV_DELETE_KEYS ||
-    !value.every(isAgentSessionOwnerBinding)
-  ) {
-    throw new Error('PTY persistence agent owners are invalid')
-  }
-  return value
+  return normalizeAgentSessionOwnerBindings(value, entryId, 'PTY persistence')
 }
 
 function normalizeProviderSession(value: unknown): AgentProviderSessionMetadata | undefined {

--- a/src/relay/pty-persistence-entry-normalization.ts
+++ b/src/relay/pty-persistence-entry-normalization.ts
@@ -1,0 +1,287 @@
+import {
+  normalizeAgentProviderSession,
+  type AgentProviderSessionMetadata
+} from '../shared/agent-session-resume'
+import {
+  isAgentSessionOwnerBinding,
+  type AgentSessionOwnerBinding
+} from '../shared/agent-session-host-authority'
+import type { RelayPtyDurableLaunch, RelayPtyReplayTail } from '../shared/pty-revive-protocol'
+import { isTuiAgent } from '../shared/tui-agent-config'
+import { measureUtf8ByteLength } from '../shared/utf8-byte-limits'
+import { terminalSizeAdmissionError } from '../shared/terminal-size-limits'
+import { normalizeRelayPtyV2EntryBasics } from './pty-persistence-v2-entry-basics'
+import {
+  MAX_RELAY_PTY_ENV_DELETE_KEYS,
+  MAX_RELAY_PTY_LOST_TAIL_BYTES,
+  MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES,
+  MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES,
+  MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES,
+  sanitizeRelayPtyEnvToDelete,
+  type RelayPtyIdentity,
+  type RelayPtyPersistenceEntry
+} from './pty-persistence-envelope'
+
+export function assertV2EnvelopeRetainedBytes(entries: readonly RelayPtyPersistenceEntry[]): void {
+  let retainedBytes = 0
+  for (const entry of entries) {
+    assertRelayPtyPersistenceEntrySize(entry)
+    const entryBytes = serializedRelayPtyPersistenceEntry(entry)
+    if (entryBytes > MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES) {
+      throw new Error(
+        `PTY persistence entry exceeds ${MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES} retained bytes`
+      )
+    }
+    retainedBytes += entryBytes
+    if (retainedBytes > MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES) {
+      throw new Error(
+        `PTY persistence state exceeds ${MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES} retained bytes`
+      )
+    }
+  }
+}
+
+export function assertRelayPtyPersistenceEntrySize(entry: Partial<RelayPtyPersistenceEntry>): void {
+  const sizeError = terminalSizeAdmissionError(entry.cols, entry.rows, 'PTY persistence entry', {
+    allowMissing: true
+  })
+  if (sizeError) {
+    throw new Error(sizeError)
+  }
+}
+
+export function normalizeRelayPtyPersistenceEntry(
+  value: unknown,
+  index: number,
+  v2: boolean
+): RelayPtyPersistenceEntry {
+  const entry = requiredRecord(value, `PTY persistence entry ${index}`)
+  if (v2) {
+    assertExactKeys(
+      entry,
+      [
+        'id',
+        'pid',
+        'sourceIncarnationId',
+        'cols',
+        'rows',
+        'cwd',
+        'paneKey',
+        'tabId',
+        'attachIdentity',
+        'worktreeId',
+        'terminalHandle',
+        'explicitTerm',
+        'envToDelete',
+        'gitCredentialPromptGuarded',
+        'replayTail',
+        'durableLaunch',
+        'agentOwners',
+        'providerSession',
+        'orchestrationTaskId'
+      ],
+      `PTY persistence entry ${index}`
+    )
+  }
+  const v2Basics = v2 ? normalizeRelayPtyV2EntryBasics(entry) : undefined
+  const attachIdentity = v2Basics?.attachIdentity ?? normalizeLegacyIdentity(entry.attachIdentity)
+  const paneKey = optionalString(entry.paneKey, 'paneKey')
+  const tabId = optionalString(entry.tabId, 'tabId')
+  const worktreeId = optionalString(entry.worktreeId, 'worktreeId')
+  const terminalHandle = optionalString(entry.terminalHandle, 'terminalHandle')
+  const explicitTerm = optionalString(entry.explicitTerm, 'explicitTerm')
+  const envToDelete = v2 ? v2Basics?.envToDelete : sanitizeRelayPtyEnvToDelete(entry.envToDelete)
+  const cols = positiveSafeIntegerOrDefault(entry.cols, 'cols', 80)
+  const rows = positiveSafeIntegerOrDefault(entry.rows, 'rows', 24)
+  assertRelayPtyPersistenceEntrySize({ cols, rows })
+  const sourceIncarnationId = v2
+    ? requiredString(entry.sourceIncarnationId, 'sourceIncarnationId', false)
+    : undefined
+  const replayTail = v2 ? normalizeReplayTail(entry.replayTail) : undefined
+  const durableLaunch = v2 ? normalizeDurableLaunch(entry.durableLaunch) : undefined
+  const agentOwners = v2 ? normalizeAgentOwners(entry.agentOwners) : undefined
+  const providerSession = v2 ? normalizeProviderSession(entry.providerSession) : undefined
+  const orchestrationTaskId = v2
+    ? optionalString(entry.orchestrationTaskId, 'orchestrationTaskId')
+    : undefined
+  return {
+    id: requiredString(entry.id, 'id', !v2),
+    pid: positiveSafeInteger(entry.pid, 'pid'),
+    cols,
+    rows,
+    cwd: requiredString(entry.cwd, 'cwd', !v2),
+    ...(sourceIncarnationId === undefined ? {} : { sourceIncarnationId }),
+    ...(paneKey === undefined ? {} : { paneKey }),
+    ...(tabId === undefined ? {} : { tabId }),
+    ...(attachIdentity === undefined ? {} : { attachIdentity }),
+    ...(worktreeId === undefined ? {} : { worktreeId }),
+    ...(terminalHandle === undefined ? {} : { terminalHandle }),
+    ...(explicitTerm === undefined ? {} : { explicitTerm }),
+    ...(envToDelete === undefined ? {} : { envToDelete }),
+    gitCredentialPromptGuarded: v2
+      ? v2Basics!.gitCredentialPromptGuarded
+      : entry.gitCredentialPromptGuarded === true,
+    ...(replayTail === undefined ? {} : { replayTail }),
+    ...(durableLaunch === undefined ? {} : { durableLaunch }),
+    ...(agentOwners === undefined ? {} : { agentOwners }),
+    ...(providerSession === undefined ? {} : { providerSession }),
+    ...(orchestrationTaskId === undefined ? {} : { orchestrationTaskId })
+  }
+}
+
+export function serializedRelayPtyPersistenceEntry(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8')
+}
+
+export function assertRelayPtyPersistenceFieldWithinLimit(field: string, value: string): void {
+  if (Buffer.byteLength(value, 'utf8') > MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES) {
+    throw new Error(
+      `PTY persistence field "${field}" exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`
+    )
+  }
+}
+
+function normalizeLegacyIdentity(value: unknown): RelayPtyIdentity | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  const identity = value as Record<string, unknown>
+  const paneKey = optionalString(identity.paneKey, 'attachIdentity.paneKey')
+  const tabId = optionalString(identity.tabId, 'attachIdentity.tabId')
+  return paneKey === undefined && tabId === undefined ? undefined : { paneKey, tabId }
+}
+
+function normalizeReplayTail(value: unknown): RelayPtyReplayTail | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  const tail = requiredRecord(value, 'replayTail')
+  assertExactKeys(tail, ['data', 'encoding', 'byteLength', 'truncated'], 'replayTail')
+  if (
+    tail.encoding !== 'utf8' ||
+    typeof tail.truncated !== 'boolean' ||
+    typeof tail.data !== 'string'
+  ) {
+    throw new Error('PTY persistence replay tail is invalid')
+  }
+  const byteLength = nonNegativeSafeInteger(tail.byteLength, 'replayTail.byteLength')
+  if (
+    measureUtf8ByteLength(tail.data).byteLength !== byteLength ||
+    byteLength > MAX_RELAY_PTY_LOST_TAIL_BYTES
+  ) {
+    throw new Error('PTY persistence replay tail is invalid')
+  }
+  return { data: tail.data, encoding: 'utf8', byteLength, truncated: tail.truncated }
+}
+
+function normalizeDurableLaunch(value: unknown): RelayPtyDurableLaunch | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  const launch = requiredRecord(value, 'durableLaunch')
+  assertExactKeys(
+    launch,
+    ['startupCommand', 'shellOverride', 'launchAgent', 'startedAt'],
+    'durableLaunch'
+  )
+  const startupCommand = optionalString(launch.startupCommand, 'durableLaunch.startupCommand')
+  const shellOverride = optionalString(launch.shellOverride, 'durableLaunch.shellOverride')
+  if (launch.launchAgent !== undefined && !isTuiAgent(launch.launchAgent)) {
+    throw new Error('PTY persistence durable launch agent is invalid')
+  }
+  if (
+    launch.startedAt !== undefined &&
+    (typeof launch.startedAt !== 'number' ||
+      !Number.isFinite(launch.startedAt) ||
+      launch.startedAt < 0)
+  ) {
+    throw new Error('PTY persistence durable launch startedAt is invalid')
+  }
+  return {
+    ...(startupCommand === undefined ? {} : { startupCommand }),
+    ...(shellOverride === undefined ? {} : { shellOverride }),
+    ...(launch.launchAgent === undefined ? {} : { launchAgent: launch.launchAgent }),
+    ...(launch.startedAt === undefined ? {} : { startedAt: launch.startedAt as number })
+  }
+}
+
+function normalizeAgentOwners(value: unknown): AgentSessionOwnerBinding[] | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_RELAY_PTY_ENV_DELETE_KEYS ||
+    !value.every(isAgentSessionOwnerBinding)
+  ) {
+    throw new Error('PTY persistence agent owners are invalid')
+  }
+  return value
+}
+
+function normalizeProviderSession(value: unknown): AgentProviderSessionMetadata | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  const record = requiredRecord(value, 'providerSession')
+  assertExactKeys(record, ['key', 'id', 'transcriptPath'], 'providerSession')
+  const providerSession = normalizeAgentProviderSession(record)
+  if (!providerSession) {
+    throw new Error('PTY persistence provider session is invalid')
+  }
+  assertRelayPtyPersistenceFieldWithinLimit('providerSession.id', providerSession.id)
+  if (providerSession.transcriptPath) {
+    assertRelayPtyPersistenceFieldWithinLimit(
+      'providerSession.transcriptPath',
+      providerSession.transcriptPath
+    )
+  }
+  return providerSession
+}
+
+export function requiredString(value: unknown, field: string, allowEmpty = true): string {
+  if (typeof value !== 'string' || (!allowEmpty && value.length === 0)) {
+    throw new Error(`PTY persistence field "${field}" must be a string`)
+  }
+  assertRelayPtyPersistenceFieldWithinLimit(field, value)
+  return value
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  return value === undefined ? undefined : requiredString(value, field)
+}
+
+function positiveSafeInteger(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`PTY persistence field "${field}" must be a positive safe integer`)
+  }
+  return value
+}
+
+function positiveSafeIntegerOrDefault(value: unknown, field: string, fallback: number): number {
+  return value === undefined ? fallback : positiveSafeInteger(value, field)
+}
+
+function nonNegativeSafeInteger(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`PTY persistence field "${field}" must be a non-negative safe integer`)
+  }
+  return value
+}
+
+export function requiredRecord(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`)
+  }
+  return value as Record<string, unknown>
+}
+
+export function assertExactKeys(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  name: string
+): void {
+  if (Object.keys(record).some((key) => !keys.includes(key))) {
+    throw new Error(`${name} contains an unknown field`)
+  }
+}

--- a/src/relay/pty-persistence-envelope.test.ts
+++ b/src/relay/pty-persistence-envelope.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES,
   MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES,
   MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES,
   MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES,
@@ -23,6 +24,27 @@ function entry(index: number, overrides: Partial<RelayPtyPersistenceEntry> = {})
   }
 }
 
+function agentOwner(ptyId = 'pty-1') {
+  return {
+    claim: {
+      digestVersion: 1 as const,
+      keyId: 'claim-key',
+      identityDigest: 'a'.repeat(43),
+      worktreeScopeDigest: 'b'.repeat(43),
+      agent: 'codex' as const
+    },
+    generation: 'generation-1',
+    phase: 'live' as const,
+    ptyId,
+    surface: {
+      worktreeId: 'repo::/repo',
+      tabId: 'tab-1',
+      leafId: '11111111-1111-4111-8111-111111111111',
+      terminalHandle: 'term_abc123'
+    }
+  }
+}
+
 describe('relay PTY persistence envelope', () => {
   it('round-trips normal state without changing retained fields', () => {
     const entries = [
@@ -43,24 +65,6 @@ describe('relay PTY persistence envelope', () => {
   })
 
   it('keeps the default array wire while round-tripping a strict v2 envelope', () => {
-    const owner = {
-      claim: {
-        digestVersion: 1 as const,
-        keyId: 'claim-key',
-        identityDigest: 'a'.repeat(43),
-        worktreeScopeDigest: 'b'.repeat(43),
-        agent: 'codex' as const
-      },
-      generation: 'generation-1',
-      phase: 'live' as const,
-      ptyId: 'pty-1',
-      surface: {
-        worktreeId: 'repo::/repo',
-        tabId: 'tab-1',
-        leafId: '11111111-1111-4111-8111-111111111111',
-        terminalHandle: 'term_abc123'
-      }
-    }
     const v2 = entry(1, {
       sourceIncarnationId: 'incarnation-1',
       replayTail: { data: 'tail', encoding: 'utf8', byteLength: 4, truncated: false },
@@ -70,7 +74,7 @@ describe('relay PTY persistence envelope', () => {
         launchAgent: 'codex',
         startedAt: 42
       },
-      agentOwners: [owner],
+      agentOwners: [agentOwner()],
       providerSession: { key: 'session_id', id: 'session-1' },
       orchestrationTaskId: 'task-1'
     })
@@ -159,6 +163,75 @@ describe('relay PTY persistence envelope', () => {
         50
       )
     ).toThrow('unknown field')
+  })
+
+  it('rejects duplicate v2 PTY ids before serialization or parsing', () => {
+    const v2 = entry(1, { sourceIncarnationId: 'incarnation-1' })
+
+    expect(() => serializeRelayPtyPersistenceEnvelope([v2, { ...v2 }], 50, 2)).toThrow(
+      'duplicate PTY ids'
+    )
+    expect(() =>
+      parseRelayPtyPersistenceState(
+        JSON.stringify({ schemaVersion: 2, entries: [v2, { ...v2, cwd: '/other' }] }),
+        50
+      )
+    ).toThrow('duplicate PTY ids')
+  })
+
+  it('rejects unknown nested agent-owner fields and mismatched owner PTY ids', () => {
+    const v2 = entry(1, { sourceIncarnationId: 'incarnation-1' })
+
+    expect(() =>
+      parseRelayPtyPersistenceState(
+        JSON.stringify({
+          schemaVersion: 2,
+          entries: [
+            {
+              ...v2,
+              agentOwners: [
+                { ...agentOwner(), claim: { ...agentOwner().claim, hookPayload: 'private' } }
+              ]
+            }
+          ]
+        }),
+        50
+      )
+    ).toThrow('unknown field')
+    expect(() =>
+      parseRelayPtyPersistenceState(
+        JSON.stringify({
+          schemaVersion: 2,
+          entries: [{ ...v2, agentOwners: [agentOwner('other-pty')] }]
+        }),
+        50
+      )
+    ).toThrow('agent owner is invalid')
+  })
+
+  it('retains an explicit truncated replay-tail marker when an entry budget removes all data', () => {
+    const replayTail = { data: 'tail', encoding: 'utf8' as const, byteLength: 4, truncated: false }
+    const truncatedMarker = { data: '', encoding: 'utf8' as const, byteLength: 0, truncated: true }
+    const v2 = entry(1, {
+      cwd: 'c'.repeat(MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES),
+      sourceIncarnationId: 'incarnation-1',
+      durableLaunch: { startupCommand: '', launchAgent: 'codex' },
+      replayTail
+    })
+    const fillBytes =
+      MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES -
+      Buffer.byteLength(JSON.stringify({ ...v2, replayTail: truncatedMarker }), 'utf8')
+    v2.durableLaunch!.startupCommand = 'x'.repeat(fillBytes)
+
+    const serialized = serializeRelayPtyPersistenceEnvelope([v2], 50, 2)
+
+    expect(parseRelayPtyPersistenceState(serialized, 50).entries[0]?.replayTail).toEqual(
+      truncatedMarker
+    )
+    v2.durableLaunch!.startupCommand = 'x'.repeat(fillBytes + 1)
+    expect(() => serializeRelayPtyPersistenceEnvelope([v2], 50, 2)).toThrow(
+      'cannot retain a truncated replay tail'
+    )
   })
 
   it('accepts the field limit and rejects limit plus one', () => {

--- a/src/relay/pty-persistence-envelope.test.ts
+++ b/src/relay/pty-persistence-envelope.test.ts
@@ -3,6 +3,7 @@ import {
   MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES,
   MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES,
   MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES,
+  parseRelayPtyPersistenceState,
   parseRelayPtyPersistenceEnvelope,
   serializeRelayPtyPersistenceEnvelope,
   type RelayPtyPersistenceEntry
@@ -39,6 +40,125 @@ describe('relay PTY persistence envelope', () => {
     const serialized = serializeRelayPtyPersistenceEnvelope(entries, 50)
 
     expect(parseRelayPtyPersistenceEnvelope(serialized, 50)).toEqual(entries)
+  })
+
+  it('keeps the default array wire while round-tripping a strict v2 envelope', () => {
+    const owner = {
+      claim: {
+        digestVersion: 1 as const,
+        keyId: 'claim-key',
+        identityDigest: 'a'.repeat(43),
+        worktreeScopeDigest: 'b'.repeat(43),
+        agent: 'codex' as const
+      },
+      generation: 'generation-1',
+      phase: 'live' as const,
+      ptyId: 'pty-1',
+      surface: {
+        worktreeId: 'repo::/repo',
+        tabId: 'tab-1',
+        leafId: '11111111-1111-4111-8111-111111111111',
+        terminalHandle: 'term_abc123'
+      }
+    }
+    const v2 = entry(1, {
+      sourceIncarnationId: 'incarnation-1',
+      replayTail: { data: 'tail', encoding: 'utf8', byteLength: 4, truncated: false },
+      durableLaunch: {
+        startupCommand: 'codex --resume session-1',
+        shellOverride: '/bin/zsh',
+        launchAgent: 'codex',
+        startedAt: 42
+      },
+      agentOwners: [owner],
+      providerSession: { key: 'session_id', id: 'session-1' },
+      orchestrationTaskId: 'task-1'
+    })
+
+    const legacy = serializeRelayPtyPersistenceEnvelope([entry(1)], 50)
+    const serialized = serializeRelayPtyPersistenceEnvelope([v2], 50, 2)
+
+    expect(JSON.parse(legacy)).toBeInstanceOf(Array)
+    expect(parseRelayPtyPersistenceState(serialized, 50)).toEqual({
+      formatVersion: 2,
+      entries: [v2]
+    })
+  })
+
+  it('trims a v2 replay tail by UTF-8 bytes before dropping metadata', () => {
+    const emojiTail = '😀'.repeat(25_600)
+    const serialized = serializeRelayPtyPersistenceEnvelope(
+      [
+        entry(1, {
+          sourceIncarnationId: 'incarnation-1',
+          cwd: `/repo/${'x'.repeat(30 * 1024)}`,
+          replayTail: {
+            data: emojiTail,
+            encoding: 'utf8',
+            byteLength: Buffer.byteLength(emojiTail, 'utf8'),
+            truncated: false
+          },
+          durableLaunch: { startupCommand: 'codex --resume session-1', launchAgent: 'codex' }
+        })
+      ],
+      50,
+      2
+    )
+
+    const parsed = parseRelayPtyPersistenceState(serialized, 50)
+    const restored = parsed.entries[0]!
+    expect(restored.cwd).toContain('/repo/')
+    expect(restored.durableLaunch).toEqual({
+      startupCommand: 'codex --resume session-1',
+      launchAgent: 'codex'
+    })
+    expect(restored.replayTail).toMatchObject({ encoding: 'utf8', truncated: true })
+    expect(Buffer.byteLength(restored.replayTail!.data, 'utf8')).toBe(
+      restored.replayTail!.byteLength
+    )
+    expect(restored.replayTail!.data.endsWith('😀')).toBe(true)
+  })
+
+  it('rejects unknown v2 fields instead of guessing a version from entry shape', () => {
+    expect(() =>
+      parseRelayPtyPersistenceState(
+        JSON.stringify({
+          schemaVersion: 2,
+          entries: [{ ...entry(1), sourceIncarnationId: 'incarnation-1', unknown: true }]
+        }),
+        50
+      )
+    ).toThrow('unknown field')
+    expect(() =>
+      parseRelayPtyPersistenceState(
+        JSON.stringify({
+          schemaVersion: 2,
+          entries: [
+            {
+              ...entry(1),
+              sourceIncarnationId: 'incarnation-1',
+              attachIdentity: { paneKey: 'pane-1', unexpected: true }
+            }
+          ]
+        }),
+        50
+      )
+    ).toThrow('unknown field')
+    expect(() =>
+      parseRelayPtyPersistenceState(
+        JSON.stringify({
+          schemaVersion: 2,
+          entries: [
+            {
+              ...entry(1),
+              sourceIncarnationId: 'incarnation-1',
+              providerSession: { key: 'session_id', id: 'session-1', unexpected: true }
+            }
+          ]
+        }),
+        50
+      )
+    ).toThrow('unknown field')
   })
 
   it('accepts the field limit and rejects limit plus one', () => {

--- a/src/relay/pty-persistence-envelope.ts
+++ b/src/relay/pty-persistence-envelope.ts
@@ -1,11 +1,24 @@
+import type { AgentProviderSessionMetadata } from '../shared/agent-session-resume'
+import type { AgentSessionOwnerBinding } from '../shared/agent-session-host-authority'
+import type { RelayPtyDurableLaunch, RelayPtyReplayTail } from '../shared/pty-revive-protocol'
+import { clampUtf8TextTail } from '../shared/utf8-byte-limits'
 import { assertJsonTextStructureWithinLimits } from '../shared/json-text-structure-limit'
 import { stringifyJsonWithinByteLimit } from '../shared/node-bounded-json-stringify'
-import { terminalSizeAdmissionError } from '../shared/terminal-size-limits'
+import {
+  assertRelayPtyPersistenceEntrySize,
+  assertV2EnvelopeRetainedBytes,
+  assertExactKeys,
+  normalizeRelayPtyPersistenceEntry,
+  requiredRecord,
+  requiredString,
+  serializedRelayPtyPersistenceEntry
+} from './pty-persistence-entry-normalization'
 
 export const MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES = 8 * 1024 * 1024
 export const MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES = 64 * 1024
 export const MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES = 128 * 1024
 export const MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES = 6 * 1024 * 1024
+export const MAX_RELAY_PTY_LOST_TAIL_BYTES = 100 * 1024
 export const MAX_RELAY_PTY_ENV_DELETE_KEYS = 1_024
 
 const PTY_PERSISTENCE_JSON_STRUCTURE_LIMITS = {
@@ -21,6 +34,7 @@ export type RelayPtyIdentity = {
 export type RelayPtyPersistenceEntry = {
   id: string
   pid: number
+  sourceIncarnationId?: string
   cols: number
   rows: number
   cwd: string
@@ -32,6 +46,11 @@ export type RelayPtyPersistenceEntry = {
   explicitTerm?: string
   envToDelete?: string[]
   gitCredentialPromptGuarded?: boolean
+  replayTail?: RelayPtyReplayTail
+  durableLaunch?: RelayPtyDurableLaunch
+  agentOwners?: AgentSessionOwnerBinding[]
+  providerSession?: AgentProviderSessionMetadata
+  orchestrationTaskId?: string
 }
 
 export type RelayPtyRetainedFields = Pick<
@@ -46,6 +65,10 @@ export type RelayPtyRetainedFields = Pick<
   | 'explicitTerm'
   | 'envToDelete'
 >
+
+export type RelayPtyParsedPersistenceState =
+  | { formatVersion: 'legacy'; entries: RelayPtyPersistenceEntry[] }
+  | { formatVersion: 2; entries: RelayPtyPersistenceEntry[] }
 
 export function sanitizeRelayPtyEnvToDelete(value: unknown): string[] {
   return Array.isArray(value)
@@ -92,17 +115,32 @@ export function assertRelayPtyRetainedFieldsWithinLimits(fields: RelayPtyRetaine
 
 export function serializeRelayPtyPersistenceEnvelope(
   entries: readonly RelayPtyPersistenceEntry[],
-  maxEntries: number
+  maxEntries: number,
+  formatVersion?: 2
 ): string {
   assertEnvelopeEntryCount(entries, maxEntries)
-  assertEnvelopeRetainedBytes(entries)
-  return stringifyJsonWithinByteLimit(entries, MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES).serialized
+  if (formatVersion !== 2) {
+    assertLegacyEnvelopeRetainedBytes(entries)
+    return stringifyJsonWithinByteLimit(entries, MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES).serialized
+  }
+  const boundedEntries = boundV2Entries(entries, maxEntries)
+  return stringifyJsonWithinByteLimit(
+    { schemaVersion: 2, entries: boundedEntries },
+    MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES
+  ).serialized
 }
 
 export function parseRelayPtyPersistenceEnvelope(
   state: unknown,
   maxEntries: number
 ): RelayPtyPersistenceEntry[] {
+  return parseRelayPtyPersistenceState(state, maxEntries).entries
+}
+
+export function parseRelayPtyPersistenceState(
+  state: unknown,
+  maxEntries: number
+): RelayPtyParsedPersistenceState {
   if (typeof state !== 'string') {
     throw new Error('PTY persistence state must be JSON text')
   }
@@ -110,7 +148,11 @@ export function parseRelayPtyPersistenceEnvelope(
     throw new Error(`PTY persistence state exceeds ${MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES} bytes`)
   }
   assertJsonTextStructureWithinLimits(state, PTY_PERSISTENCE_JSON_STRUCTURE_LIMITS)
-  return normalizeEnvelope(JSON.parse(state) as unknown, maxEntries)
+  const parsed = JSON.parse(state) as unknown
+  if (Array.isArray(parsed)) {
+    return { formatVersion: 'legacy', entries: normalizeLegacyEnvelope(parsed, maxEntries) }
+  }
+  return normalizeV2Envelope(parsed, maxEntries)
 }
 
 export function parseRelayPtyPersistenceIds(value: unknown, maxEntries: number): string[] {
@@ -120,15 +162,95 @@ export function parseRelayPtyPersistenceIds(value: unknown, maxEntries: number):
   return value.map((id) => requiredString(id, 'id'))
 }
 
-function normalizeEnvelope(value: unknown, maxEntries: number): RelayPtyPersistenceEntry[] {
-  if (!Array.isArray(value)) {
-    throw new Error(`PTY persistence state exceeds ${maxEntries} entries`)
-  }
+function normalizeLegacyEnvelope(value: unknown[], maxEntries: number): RelayPtyPersistenceEntry[] {
   assertEnvelopeEntryCount(value, maxEntries)
-
-  const entries = value.map((entry, index) => normalizeEntry(entry, index))
-  assertEnvelopeRetainedBytes(entries)
+  const entries = value.map((entry, index) =>
+    normalizeRelayPtyPersistenceEntry(entry, index, false)
+  )
+  assertLegacyEnvelopeRetainedBytes(entries)
   return entries
+}
+
+function normalizeV2Envelope(value: unknown, maxEntries: number): RelayPtyParsedPersistenceState {
+  const envelope = requiredRecord(value, 'PTY persistence v2 envelope')
+  assertExactKeys(envelope, ['schemaVersion', 'entries'], 'PTY persistence v2 envelope')
+  if (envelope.schemaVersion !== 2 || !Array.isArray(envelope.entries)) {
+    throw new Error('PTY persistence envelope version is unsupported')
+  }
+  assertEnvelopeEntryCount(envelope.entries, maxEntries)
+  const entries = envelope.entries.map((entry, index) =>
+    normalizeRelayPtyPersistenceEntry(entry, index, true)
+  )
+  assertV2EnvelopeRetainedBytes(entries)
+  return { formatVersion: 2, entries }
+}
+
+function boundV2Entries(
+  entries: readonly RelayPtyPersistenceEntry[],
+  maxEntries: number
+): RelayPtyPersistenceEntry[] {
+  const normalized = entries.map((entry, index) =>
+    normalizeRelayPtyPersistenceEntry(entry, index, true)
+  )
+  assertEnvelopeEntryCount(normalized, maxEntries)
+  let retainedBytes = 0
+  return normalized.map((entry) => {
+    const withoutTail = { ...entry }
+    delete withoutTail.replayTail
+    const metadataBytes = serializedRelayPtyPersistenceEntry(withoutTail)
+    if (metadataBytes > MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES) {
+      throw new Error(
+        `PTY persistence entry exceeds ${MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES} retained bytes`
+      )
+    }
+    if (retainedBytes + metadataBytes > MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES) {
+      throw new Error(
+        `PTY persistence state exceeds ${MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES} retained bytes`
+      )
+    }
+    let tailBudget = Math.max(
+      0,
+      Math.min(
+        MAX_RELAY_PTY_LOST_TAIL_BYTES,
+        MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES - metadataBytes,
+        MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES - retainedBytes - metadataBytes
+      )
+    )
+    let replayTail = boundReplayTail(entry, tailBudget)
+    while (replayTail) {
+      const candidate = { ...entry, replayTail }
+      const candidateBytes = serializedRelayPtyPersistenceEntry(candidate)
+      const excess = Math.max(
+        candidateBytes - MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES,
+        retainedBytes + candidateBytes - MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES
+      )
+      if (excess <= 0) {
+        retainedBytes += candidateBytes
+        return candidate
+      }
+      tailBudget = Math.max(0, replayTail.byteLength - excess - 4)
+      replayTail = tailBudget > 0 ? boundReplayTail(entry, tailBudget) : undefined
+    }
+    retainedBytes += metadataBytes
+    return withoutTail
+  })
+}
+
+function boundReplayTail(
+  entry: RelayPtyPersistenceEntry,
+  maxBytes: number
+): RelayPtyReplayTail | undefined {
+  const tail = entry.replayTail
+  if (!tail) {
+    return undefined
+  }
+  const clamped = clampUtf8TextTail(tail.data, maxBytes)
+  return {
+    data: clamped.text,
+    encoding: 'utf8',
+    byteLength: clamped.bytes,
+    truncated: tail.truncated || clamped.bytes !== tail.byteLength
+  }
 }
 
 function assertEnvelopeEntryCount(value: readonly unknown[], maxEntries: number): void {
@@ -140,19 +262,10 @@ function assertEnvelopeEntryCount(value: readonly unknown[], maxEntries: number)
   }
 }
 
-function assertEnvelopeRetainedBytes(entries: readonly RelayPtyRetainedFields[]): void {
+function assertLegacyEnvelopeRetainedBytes(entries: readonly RelayPtyRetainedFields[]): void {
   let retainedBytes = 0
   for (const entry of entries) {
-    const dimensions = entry as Partial<RelayPtyPersistenceEntry>
-    const sizeError = terminalSizeAdmissionError(
-      dimensions.cols,
-      dimensions.rows,
-      'PTY persistence entry',
-      { allowMissing: true }
-    )
-    if (sizeError) {
-      throw new Error(sizeError)
-    }
+    assertRelayPtyPersistenceEntrySize(entry)
     retainedBytes += assertRelayPtyRetainedFieldsWithinLimits(entry)
     if (retainedBytes > MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES) {
       throw new Error(
@@ -162,82 +275,4 @@ function assertEnvelopeRetainedBytes(entries: readonly RelayPtyRetainedFields[])
   }
 }
 
-function normalizeEntry(value: unknown, index: number): RelayPtyPersistenceEntry {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error(`PTY persistence entry ${index} must be an object`)
-  }
-  const entry = value as Record<string, unknown>
-  const attachIdentity = normalizeIdentity(entry.attachIdentity)
-  const paneKey = optionalString(entry.paneKey, 'paneKey')
-  const tabId = optionalString(entry.tabId, 'tabId')
-  const worktreeId = optionalString(entry.worktreeId, 'worktreeId')
-  const terminalHandle = optionalString(entry.terminalHandle, 'terminalHandle')
-  const explicitTerm = optionalString(entry.explicitTerm, 'explicitTerm')
-  const envToDelete = sanitizeRelayPtyEnvToDelete(entry.envToDelete)
-  const cols = positiveSafeIntegerOrDefault(entry.cols, 'cols', 80)
-  const rows = positiveSafeIntegerOrDefault(entry.rows, 'rows', 24)
-  const sizeError = terminalSizeAdmissionError(cols, rows, 'PTY persistence entry')
-  if (sizeError) {
-    throw new Error(sizeError)
-  }
-
-  return {
-    id: requiredString(entry.id, 'id'),
-    pid: positiveSafeInteger(entry.pid, 'pid'),
-    cols,
-    rows,
-    cwd: requiredString(entry.cwd, 'cwd'),
-    ...(paneKey === undefined ? {} : { paneKey }),
-    ...(tabId === undefined ? {} : { tabId }),
-    ...(attachIdentity === undefined ? {} : { attachIdentity }),
-    ...(worktreeId === undefined ? {} : { worktreeId }),
-    ...(terminalHandle === undefined ? {} : { terminalHandle }),
-    ...(explicitTerm === undefined ? {} : { explicitTerm }),
-    ...(Array.isArray(entry.envToDelete) ? { envToDelete } : {}),
-    gitCredentialPromptGuarded: entry.gitCredentialPromptGuarded === true
-  }
-}
-
-function normalizeIdentity(value: unknown): RelayPtyIdentity | undefined {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined
-  }
-  const identity = value as Record<string, unknown>
-  const paneKey = optionalString(identity.paneKey, 'attachIdentity.paneKey')
-  const tabId = optionalString(identity.tabId, 'attachIdentity.tabId')
-  return paneKey === undefined && tabId === undefined ? undefined : { paneKey, tabId }
-}
-
-function requiredString(value: unknown, field: string): string {
-  if (typeof value !== 'string') {
-    throw new Error(`PTY persistence field "${field}" must be a string`)
-  }
-  assertRelayPtyPersistenceFieldWithinLimit(field, value)
-  return value
-}
-
-function optionalString(value: unknown, field: string): string | undefined {
-  if (value === undefined) {
-    return undefined
-  }
-  return requiredString(value, field)
-}
-
-export function assertRelayPtyPersistenceFieldWithinLimit(field: string, value: string): void {
-  if (Buffer.byteLength(value, 'utf8') > MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES) {
-    throw new Error(
-      `PTY persistence field "${field}" exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`
-    )
-  }
-}
-
-function positiveSafeInteger(value: unknown, field: string): number {
-  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
-    throw new Error(`PTY persistence field "${field}" must be a positive safe integer`)
-  }
-  return value as number
-}
-
-function positiveSafeIntegerOrDefault(value: unknown, field: string, fallback: number): number {
-  return value === undefined ? fallback : positiveSafeInteger(value, field)
-}
+export { assertRelayPtyPersistenceFieldWithinLimit } from './pty-persistence-entry-normalization'

--- a/src/relay/pty-persistence-envelope.ts
+++ b/src/relay/pty-persistence-envelope.ts
@@ -1,5 +1,6 @@
 import type { AgentProviderSessionMetadata } from '../shared/agent-session-resume'
 import type { AgentSessionOwnerBinding } from '../shared/agent-session-host-authority'
+import { assertRelayPtyPersistenceFieldWithinLimit } from '../shared/pty-persistence-wire-limits'
 import type { RelayPtyDurableLaunch, RelayPtyReplayTail } from '../shared/pty-revive-protocol'
 import { clampUtf8TextTail } from '../shared/utf8-byte-limits'
 import { assertJsonTextStructureWithinLimits } from '../shared/json-text-structure-limit'
@@ -15,7 +16,6 @@ import {
 } from './pty-persistence-entry-normalization'
 
 export const MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES = 8 * 1024 * 1024
-export const MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES = 64 * 1024
 export const MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES = 128 * 1024
 export const MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES = 6 * 1024 * 1024
 export const MAX_RELAY_PTY_LOST_TAIL_BYTES = 100 * 1024
@@ -84,12 +84,8 @@ export function assertRelayPtyRetainedFieldsWithinLimits(fields: RelayPtyRetaine
     if (value === undefined) {
       return
     }
+    assertRelayPtyPersistenceFieldWithinLimit(field, value)
     const bytes = Buffer.byteLength(value, 'utf8')
-    if (bytes > MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES) {
-      throw new Error(
-        `PTY persistence field "${field}" exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`
-      )
-    }
     retainedBytes += bytes
   }
 
@@ -159,7 +155,9 @@ export function parseRelayPtyPersistenceIds(value: unknown, maxEntries: number):
   if (!Array.isArray(value) || value.length > maxEntries) {
     throw new Error(`PTY persistence request exceeds ${maxEntries} entries`)
   }
-  return value.map((id) => requiredString(id, 'id'))
+  const ids = value.map((id) => requiredString(id, 'id'))
+  assertUniquePtyIds(ids, 'PTY persistence request')
+  return ids
 }
 
 function normalizeLegacyEnvelope(value: unknown[], maxEntries: number): RelayPtyPersistenceEntry[] {
@@ -181,6 +179,10 @@ function normalizeV2Envelope(value: unknown, maxEntries: number): RelayPtyParsed
   const entries = envelope.entries.map((entry, index) =>
     normalizeRelayPtyPersistenceEntry(entry, index, true)
   )
+  assertUniquePtyIds(
+    entries.map((entry) => entry.id),
+    'PTY persistence v2 envelope'
+  )
   assertV2EnvelopeRetainedBytes(entries)
   return { formatVersion: 2, entries }
 }
@@ -193,6 +195,10 @@ function boundV2Entries(
     normalizeRelayPtyPersistenceEntry(entry, index, true)
   )
   assertEnvelopeEntryCount(normalized, maxEntries)
+  assertUniquePtyIds(
+    normalized.map((entry) => entry.id),
+    'PTY persistence v2 envelope'
+  )
   let retainedBytes = 0
   return normalized.map((entry) => {
     const withoutTail = { ...entry }
@@ -208,6 +214,25 @@ function boundV2Entries(
         `PTY persistence state exceeds ${MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES} retained bytes`
       )
     }
+    const sourceReplayTail = entry.replayTail
+    if (!sourceReplayTail) {
+      retainedBytes += metadataBytes
+      return withoutTail
+    }
+    const minimumTail: RelayPtyReplayTail = {
+      data: '',
+      encoding: 'utf8',
+      byteLength: 0,
+      truncated: true
+    }
+    const minimumCandidate = { ...entry, replayTail: minimumTail }
+    const minimumCandidateBytes = serializedRelayPtyPersistenceEntry(minimumCandidate)
+    if (
+      minimumCandidateBytes > MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES ||
+      retainedBytes + minimumCandidateBytes > MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES
+    ) {
+      throw new Error('PTY persistence state cannot retain a truncated replay tail')
+    }
     let tailBudget = Math.max(
       0,
       Math.min(
@@ -216,8 +241,8 @@ function boundV2Entries(
         MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES - retainedBytes - metadataBytes
       )
     )
-    let replayTail = boundReplayTail(entry, tailBudget)
-    while (replayTail) {
+    let replayTail = boundReplayTail(sourceReplayTail, tailBudget)
+    while (true) {
       const candidate = { ...entry, replayTail }
       const candidateBytes = serializedRelayPtyPersistenceEntry(candidate)
       const excess = Math.max(
@@ -228,22 +253,16 @@ function boundV2Entries(
         retainedBytes += candidateBytes
         return candidate
       }
+      if (replayTail.byteLength === 0) {
+        throw new Error('PTY persistence state cannot retain a truncated replay tail')
+      }
       tailBudget = Math.max(0, replayTail.byteLength - excess - 4)
-      replayTail = tailBudget > 0 ? boundReplayTail(entry, tailBudget) : undefined
+      replayTail = boundReplayTail(sourceReplayTail, tailBudget)
     }
-    retainedBytes += metadataBytes
-    return withoutTail
   })
 }
 
-function boundReplayTail(
-  entry: RelayPtyPersistenceEntry,
-  maxBytes: number
-): RelayPtyReplayTail | undefined {
-  const tail = entry.replayTail
-  if (!tail) {
-    return undefined
-  }
+function boundReplayTail(tail: RelayPtyReplayTail, maxBytes: number): RelayPtyReplayTail {
   const clamped = clampUtf8TextTail(tail.data, maxBytes)
   return {
     data: clamped.text,
@@ -262,6 +281,12 @@ function assertEnvelopeEntryCount(value: readonly unknown[], maxEntries: number)
   }
 }
 
+function assertUniquePtyIds(ids: readonly string[], scope: string): void {
+  if (new Set(ids).size !== ids.length) {
+    throw new Error(`${scope} contains duplicate PTY ids`)
+  }
+}
+
 function assertLegacyEnvelopeRetainedBytes(entries: readonly RelayPtyRetainedFields[]): void {
   let retainedBytes = 0
   for (const entry of entries) {
@@ -275,4 +300,7 @@ function assertLegacyEnvelopeRetainedBytes(entries: readonly RelayPtyRetainedFie
   }
 }
 
-export { assertRelayPtyPersistenceFieldWithinLimit } from './pty-persistence-entry-normalization'
+export {
+  assertRelayPtyPersistenceFieldWithinLimit,
+  MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES
+} from '../shared/pty-persistence-wire-limits'

--- a/src/relay/pty-persistence-v2-entry-basics.ts
+++ b/src/relay/pty-persistence-v2-entry-basics.ts
@@ -1,5 +1,6 @@
+import { assertRelayPtyPersistenceFieldWithinLimit } from '../shared/pty-persistence-wire-limits'
+
 const MAX_ENV_DELETE_KEYS = 1_024
-const MAX_PERSISTENCE_FIELD_BYTES = 64 * 1024
 
 export type RelayPtyV2EntryBasics = {
   attachIdentity?: { paneKey?: string; tabId?: string }
@@ -72,9 +73,7 @@ function optionalString(value: unknown, field: string): string | undefined {
 }
 
 function assertFieldSize(field: string, value: string): void {
-  if (Buffer.byteLength(value, 'utf8') > MAX_PERSISTENCE_FIELD_BYTES) {
-    throw new Error(`PTY persistence field "${field}" exceeds ${MAX_PERSISTENCE_FIELD_BYTES} bytes`)
-  }
+  assertRelayPtyPersistenceFieldWithinLimit(field, value)
 }
 
 function assertExactKeys(

--- a/src/relay/pty-persistence-v2-entry-basics.ts
+++ b/src/relay/pty-persistence-v2-entry-basics.ts
@@ -1,0 +1,88 @@
+const MAX_ENV_DELETE_KEYS = 1_024
+const MAX_PERSISTENCE_FIELD_BYTES = 64 * 1024
+
+export type RelayPtyV2EntryBasics = {
+  attachIdentity?: { paneKey?: string; tabId?: string }
+  envToDelete?: string[]
+  gitCredentialPromptGuarded: boolean
+}
+
+export function normalizeRelayPtyV2EntryBasics(
+  entry: Record<string, unknown>
+): RelayPtyV2EntryBasics {
+  return {
+    ...normalizeAttachIdentity(entry.attachIdentity),
+    ...normalizeEnvToDelete(entry.envToDelete),
+    gitCredentialPromptGuarded: normalizeGitCredentialPromptGuarded(
+      entry.gitCredentialPromptGuarded
+    )
+  }
+}
+
+function normalizeAttachIdentity(value: unknown): Pick<RelayPtyV2EntryBasics, 'attachIdentity'> {
+  if (value === undefined) {
+    return {}
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('PTY persistence attach identity is invalid')
+  }
+  const identity = value as Record<string, unknown>
+  assertExactKeys(identity, ['paneKey', 'tabId'], 'attachIdentity')
+  const paneKey = optionalString(identity.paneKey, 'attachIdentity.paneKey')
+  const tabId = optionalString(identity.tabId, 'attachIdentity.tabId')
+  return paneKey === undefined && tabId === undefined ? {} : { attachIdentity: { paneKey, tabId } }
+}
+
+function normalizeEnvToDelete(value: unknown): Pick<RelayPtyV2EntryBasics, 'envToDelete'> {
+  if (value === undefined) {
+    return {}
+  }
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_ENV_DELETE_KEYS ||
+    !value.every((key) => typeof key === 'string' && key.length > 0)
+  ) {
+    throw new Error('PTY persistence envToDelete is invalid')
+  }
+  for (const key of value) {
+    assertFieldSize('envToDelete', key)
+  }
+  return { envToDelete: value }
+}
+
+function normalizeGitCredentialPromptGuarded(value: unknown): boolean {
+  if (value === undefined) {
+    return false
+  }
+  if (typeof value !== 'boolean') {
+    throw new Error('PTY persistence git credential guard is invalid')
+  }
+  return value
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (typeof value !== 'string') {
+    throw new Error(`PTY persistence field "${field}" must be a string`)
+  }
+  assertFieldSize(field, value)
+  return value
+}
+
+function assertFieldSize(field: string, value: string): void {
+  if (Buffer.byteLength(value, 'utf8') > MAX_PERSISTENCE_FIELD_BYTES) {
+    throw new Error(`PTY persistence field "${field}" exceeds ${MAX_PERSISTENCE_FIELD_BYTES} bytes`)
+  }
+}
+
+function assertExactKeys(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+  name: string
+): void {
+  if (Object.keys(record).some((key) => !keys.includes(key))) {
+    throw new Error(`${name} contains an unknown field`)
+  }
+}

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -132,7 +132,7 @@ import { matchesRecentTabSwitcherChord } from '../../../shared/window-shortcut-p
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { useContextualTour } from './contextual-tours/use-contextual-tour'
 import { openTabBarEntry, type TabCreateEntryArgs } from './tab-bar/tab-create-entry-action'
-import { closeTerminalTab } from './terminal/terminal-tab-actions'
+import { closeTerminalTab, closeTerminalTabAsync } from './terminal/terminal-tab-actions'
 import { translate } from '@/i18n/i18n'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { getResolvedExecutionHostIdForWorktree } from '@/lib/resolved-worktree-execution-host'
@@ -143,6 +143,14 @@ const EditorPanel = lazy(() => import('./editor/EditorPanel'))
 // Why: gate handler runs after a dialog advances so a stray carry-over click can't act on the next dialog; ~200ms absorbs a physical double-click while staying responsive.
 const CLOSE_DIALOG_DEBOUNCE_MS = 200
 const CHILD_PROCESS_CHECK_CONCURRENCY = 8
+
+async function closeTerminalTabFromBulk(tabId: string): Promise<void> {
+  try {
+    await closeTerminalTabAsync(tabId)
+  } catch {
+    // The close transaction preserves the tab and exposes its own retry affordance.
+  }
+}
 const EDITOR_TAB_CONTENT_TYPES = new Set<TabContentType>([
   'editor',
   'diff',
@@ -278,7 +286,6 @@ function Terminal(): React.JSX.Element | null {
   const activeTabId = useAppStore((s) => s.activeTabId)
   const activeTabIdByWorktree = useAppStore((s) => s.activeTabIdByWorktree)
   const createTab = useAppStore((s) => s.createTab)
-  const closeTab = useAppStore((s) => s.closeTab)
   const setActiveTab = useAppStore((s) => s.setActiveTab)
   const setActiveWorktree = useAppStore((s) => s.setActiveWorktree)
   const setTabCustomTitle = useAppStore((s) => s.setTabCustomTitle)
@@ -1424,59 +1431,61 @@ function Terminal(): React.JSX.Element | null {
       const state = useAppStore.getState()
       const order = state.tabBarOrderByWorktree[activeWorktreeId] ?? []
       const dirtyFileIds: string[] = []
-      for (const id of order) {
-        if (id === tabId) {
-          continue
-        }
-        const unifiedTab = (state.unifiedTabsByWorktree[activeWorktreeId] ?? []).find(
-          (candidate) => candidate.id === id || candidate.entityId === id
-        )
-        if (unifiedTab?.isPinned) {
-          continue
-        }
-        const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
-        if (
-          isWebRuntimeSessionActive(runtimeEnvironmentId) &&
-          (unifiedTab?.contentType === 'terminal' ||
-            (unifiedTab?.contentType === 'browser' &&
-              browserWorkspaceHasRemoteOwner(state, unifiedTab.entityId, runtimeEnvironmentId)))
-        ) {
-          if (unifiedTab.contentType === 'terminal') {
-            // Why: paired-host bulk close must revoke renderer resume and hook authority, not just remove the host session tab.
-            closeTerminalTab(unifiedTab.entityId)
-          } else {
-            void closeWebRuntimeSessionTab({
-              worktreeId: activeWorktreeId,
-              tabId: unifiedTab.id,
-              environmentId: runtimeEnvironmentId,
-              reason: 'user'
-            })
-          }
-          continue
-        }
-        if ((state.tabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)) {
-          closeTab(id)
-        } else if (
-          state.openFiles.some((file) => file.worktreeId === activeWorktreeId && file.id === id)
-        ) {
-          const file = state.openFiles.find((candidate) => candidate.id === id)
-          if (file?.isDirty) {
-            dirtyFileIds.push(id)
+      void (async () => {
+        for (const id of order) {
+          if (id === tabId) {
             continue
           }
-          closeFile(id)
-        } else if (
-          (state.browserTabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)
-        ) {
-          destroyWorkspaceWebviews(state.browserPagesByWorkspace, id)
-          closeBrowserTab(id)
+          const unifiedTab = (state.unifiedTabsByWorktree[activeWorktreeId] ?? []).find(
+            (candidate) => candidate.id === id || candidate.entityId === id
+          )
+          if (unifiedTab?.isPinned) {
+            continue
+          }
+          const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
+          if (
+            isWebRuntimeSessionActive(runtimeEnvironmentId) &&
+            (unifiedTab?.contentType === 'terminal' ||
+              (unifiedTab?.contentType === 'browser' &&
+                browserWorkspaceHasRemoteOwner(state, unifiedTab.entityId, runtimeEnvironmentId)))
+          ) {
+            if (unifiedTab.contentType === 'terminal') {
+              // Why: paired-host bulk close must revoke renderer resume and hook authority, not just remove the host session tab.
+              await closeTerminalTabFromBulk(unifiedTab.entityId)
+            } else {
+              void closeWebRuntimeSessionTab({
+                worktreeId: activeWorktreeId,
+                tabId: unifiedTab.id,
+                environmentId: runtimeEnvironmentId,
+                reason: 'user'
+              })
+            }
+            continue
+          }
+          if ((state.tabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)) {
+            await closeTerminalTabFromBulk(id)
+          } else if (
+            state.openFiles.some((file) => file.worktreeId === activeWorktreeId && file.id === id)
+          ) {
+            const file = state.openFiles.find((candidate) => candidate.id === id)
+            if (file?.isDirty) {
+              dirtyFileIds.push(id)
+              continue
+            }
+            closeFile(id)
+          } else if (
+            (state.browserTabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)
+          ) {
+            destroyWorkspaceWebviews(state.browserPagesByWorkspace, id)
+            closeBrowserTab(id)
+          }
         }
-      }
-      if (dirtyFileIds.length > 0) {
-        queueEditorCloseRequests(dirtyFileIds)
-      }
+        if (dirtyFileIds.length > 0) {
+          queueEditorCloseRequests(dirtyFileIds)
+        }
+      })()
     },
-    [activeWorktreeId, closeBrowserTab, closeFile, closeTab, queueEditorCloseRequests]
+    [activeWorktreeId, closeBrowserTab, closeFile, queueEditorCloseRequests]
   )
 
   const handleCloseTabsToRight = useCallback(
@@ -1492,56 +1501,58 @@ function Terminal(): React.JSX.Element | null {
       }
       const rightIds = currentOrder.slice(index + 1)
       const dirtyFileIds: string[] = []
-      for (const id of rightIds) {
-        const unifiedTab = (state.unifiedTabsByWorktree[activeWorktreeId] ?? []).find(
-          (candidate) => candidate.id === id || candidate.entityId === id
-        )
-        if (unifiedTab?.isPinned) {
-          continue
-        }
-        const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
-        if (
-          isWebRuntimeSessionActive(runtimeEnvironmentId) &&
-          (unifiedTab?.contentType === 'terminal' ||
-            (unifiedTab?.contentType === 'browser' &&
-              browserWorkspaceHasRemoteOwner(state, unifiedTab.entityId, runtimeEnvironmentId)))
-        ) {
-          if (unifiedTab.contentType === 'terminal') {
-            // Why: route terminal close through the destructive local lifecycle boundary before the paired-host RPC.
-            closeTerminalTab(unifiedTab.entityId)
-          } else {
-            void closeWebRuntimeSessionTab({
-              worktreeId: activeWorktreeId,
-              tabId: unifiedTab.id,
-              environmentId: runtimeEnvironmentId,
-              reason: 'user'
-            })
-          }
-          continue
-        }
-        if ((state.tabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)) {
-          closeTab(id)
-        } else if (
-          state.openFiles.some((file) => file.worktreeId === activeWorktreeId && file.id === id)
-        ) {
-          const file = state.openFiles.find((candidate) => candidate.id === id)
-          if (file?.isDirty) {
-            dirtyFileIds.push(id)
+      void (async () => {
+        for (const id of rightIds) {
+          const unifiedTab = (state.unifiedTabsByWorktree[activeWorktreeId] ?? []).find(
+            (candidate) => candidate.id === id || candidate.entityId === id
+          )
+          if (unifiedTab?.isPinned) {
             continue
           }
-          closeFile(id)
-        } else if (
-          (state.browserTabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)
-        ) {
-          destroyWorkspaceWebviews(state.browserPagesByWorkspace, id)
-          closeBrowserTab(id)
+          const runtimeEnvironmentId = getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId)
+          if (
+            isWebRuntimeSessionActive(runtimeEnvironmentId) &&
+            (unifiedTab?.contentType === 'terminal' ||
+              (unifiedTab?.contentType === 'browser' &&
+                browserWorkspaceHasRemoteOwner(state, unifiedTab.entityId, runtimeEnvironmentId)))
+          ) {
+            if (unifiedTab.contentType === 'terminal') {
+              // Why: route terminal close through the destructive local lifecycle boundary before the paired-host RPC.
+              await closeTerminalTabFromBulk(unifiedTab.entityId)
+            } else {
+              void closeWebRuntimeSessionTab({
+                worktreeId: activeWorktreeId,
+                tabId: unifiedTab.id,
+                environmentId: runtimeEnvironmentId,
+                reason: 'user'
+              })
+            }
+            continue
+          }
+          if ((state.tabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)) {
+            await closeTerminalTabFromBulk(id)
+          } else if (
+            state.openFiles.some((file) => file.worktreeId === activeWorktreeId && file.id === id)
+          ) {
+            const file = state.openFiles.find((candidate) => candidate.id === id)
+            if (file?.isDirty) {
+              dirtyFileIds.push(id)
+              continue
+            }
+            closeFile(id)
+          } else if (
+            (state.browserTabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)
+          ) {
+            destroyWorkspaceWebviews(state.browserPagesByWorkspace, id)
+            closeBrowserTab(id)
+          }
         }
-      }
-      if (dirtyFileIds.length > 0) {
-        queueEditorCloseRequests(dirtyFileIds)
-      }
+        if (dirtyFileIds.length > 0) {
+          queueEditorCloseRequests(dirtyFileIds)
+        }
+      })()
     },
-    [activeWorktreeId, closeBrowserTab, closeFile, closeTab, queueEditorCloseRequests]
+    [activeWorktreeId, closeBrowserTab, closeFile, queueEditorCloseRequests]
   )
 
   const handleCloseAllFiles = useCallback(() => {

--- a/src/renderer/src/components/shared/kill-all-terminal-surfaces.ts
+++ b/src/renderer/src/components/shared/kill-all-terminal-surfaces.ts
@@ -46,11 +46,12 @@ type KillAllTerminalSurfaceDependencies = {
     tabId: string,
     options: {
       force: true
+      reason: 'cleanup'
       localPtyTeardownOwnedExternally: true
       precomputedRetirementPlan: TerminalTabRetirementPlan
       precomputedCloseState: PrecomputedTerminalCloseState
     }
-  ) => void
+  ) => void | Promise<void>
   killPty: (ptyId: string) => Promise<void>
   now: () => number
   yieldToRenderer: () => Promise<void>
@@ -216,8 +217,9 @@ export async function runKillAllTerminalSurfaces(
       )
       let closeFailed = false
       try {
-        deps.closeSurface(targetId, {
+        await deps.closeSurface(targetId, {
           force: true,
+          reason: 'cleanup',
           localPtyTeardownOwnedExternally: true,
           precomputedRetirementPlan: retirementPlan,
           precomputedCloseState: {

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -251,7 +251,7 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
     expect(event.detail).toEqual({ tabId: 'terminal-1' })
   })
 
-  it('revokes local terminal state before paired-host bulk close', async () => {
+  it('waits for the paired-host archive receipt before closing the local terminal mirror', async () => {
     const secondTerminal = {
       id: 'terminal-2',
       ptyId: 'remote:env-1@@pty-2',
@@ -301,21 +301,34 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
       }
     }
     mocks.isWebRuntimeSessionActive.mockReturnValue(true)
+    let resolveHostReceipt: (receipt: { closed: true; archiveId: string }) => void = () => {}
+    const hostReceipt = new Promise<{ closed: true; archiveId: string }>((resolve) => {
+      resolveHostReceipt = resolve
+    })
+    mocks.closeWebRuntimeSessionTab.mockReturnValue(hostReceipt)
     const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
     const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
 
     model.commands.closeOthers(firstUnified.id)
 
-    expect(mocks.closeTab).toHaveBeenCalledWith(
-      'terminal-2',
-      expect.objectContaining({ remoteCloseOwnedByHost: true })
+    await vi.waitFor(() =>
+      expect(mocks.closeWebRuntimeSessionTab).toHaveBeenCalledWith({
+        worktreeId: 'wt-1',
+        tabId: 'terminal-2',
+        environmentId: 'env-1',
+        reason: 'user'
+      })
     )
-    expect(mocks.closeWebRuntimeSessionTab).toHaveBeenCalledWith({
-      worktreeId: 'wt-1',
-      tabId: 'terminal-2',
-      environmentId: 'env-1',
-      reason: 'user'
-    })
+    expect(mocks.closeTab).not.toHaveBeenCalled()
+
+    resolveHostReceipt({ closed: true, archiveId: '11111111-1111-4111-8111-111111111111' })
+
+    await vi.waitFor(() =>
+      expect(mocks.closeTab).toHaveBeenCalledWith('terminal-2', {
+        reason: undefined,
+        remoteCloseOwnedByHost: true
+      })
+    )
   })
 
   it('records terminal split completion when splitting a single terminal tab group', async () => {

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -21,7 +21,7 @@ import {
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
 } from '../../runtime/web-runtime-session'
-import { closeTerminalTab } from '../terminal/terminal-tab-actions'
+import { closeTerminalTab, closeTerminalTabAsync } from '../terminal/terminal-tab-actions'
 import { openTabBarEntry, type TabCreateEntryArgs } from '../tab-bar/tab-create-entry-action'
 import { openMobileEmulatorTab } from '@/lib/open-mobile-emulator-tab'
 import { ensureSimulatorTab, getSimulatorTabForWorktree } from '@/lib/ensure-simulator-tab'
@@ -76,7 +76,6 @@ export function useTabGroupWorkspaceModel({
   const closeUnifiedTab = useAppStore((state) => state.closeUnifiedTab)
   const closeEmptyGroup = useAppStore((state) => state.closeEmptyGroup)
   const createTab = useAppStore((state) => state.createTab)
-  const closeTab = useAppStore((state) => state.closeTab)
   const setActiveTab = useAppStore((state) => state.setActiveTab)
   const setActiveFile = useAppStore((state) => state.setActiveFile)
   const setActiveTabType = useAppStore((state) => state.setActiveTabType)
@@ -285,53 +284,57 @@ export function useTabGroupWorkspaceModel({
 
   const closeMany = useCallback(
     (itemIds: string[]) => {
-      for (const itemId of itemIds) {
-        const item = groupTabs.find((candidate) => candidate.id === itemId)
-        if (!item || item.isPinned) {
-          continue
-        }
-        const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
-          useAppStore.getState(),
-          worktreeId
-        )
-        if (item.contentType === 'terminal' && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
-          // Why: revoke local resume + hook authority before the host removes its canonical tab.
-          closeTerminalTab(item.entityId)
-          continue
-        }
-        if (item.contentType === 'browser') {
-          // Why: see closeItem — host-close a remote-owned browser or pageless host-mirror; always remove the visible tab.
-          const browserState = useAppStore.getState()
-          const hasLocalPages =
-            (browserState.browserPagesByWorkspace[item.entityId] ?? []).length > 0
-          const shouldCloseOnHost =
-            isWebRuntimeSessionActive(runtimeEnvironmentId) &&
-            (browserWorkspaceHasRemoteOwner(browserState, item.entityId, runtimeEnvironmentId) ||
-              !hasLocalPages)
-          if (shouldCloseOnHost) {
-            void closeWebRuntimeSessionTab({
-              worktreeId,
-              tabId: item.id,
-              environmentId: runtimeEnvironmentId,
-              reason: 'user'
-            })
+      void (async () => {
+        for (const itemId of itemIds) {
+          const item = groupTabs.find((candidate) => candidate.id === itemId)
+          if (!item || item.isPinned) {
+            continue
           }
-          destroyWorkspaceWebviews(browserState.browserPagesByWorkspace, item.entityId)
-          closeBrowserTab(item.entityId)
-          closeUnifiedTab(item.id)
-        } else if (item.contentType === 'terminal') {
-          closeTab(item.entityId)
-        } else if (item.contentType === 'simulator') {
-          closeUnifiedTab(item.id)
-        } else {
-          const canCloseTab = closeEditorIfUnreferenced(item.entityId, item.id)
-          if (canCloseTab) {
+          const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(
+            useAppStore.getState(),
+            worktreeId
+          )
+          if (item.contentType === 'terminal') {
+            // Why: every user bulk close shares the durable archive/retirement transaction.
+            try {
+              await closeTerminalTabAsync(item.entityId)
+            } catch {
+              // The transaction keeps the live tab and exposes retry feedback.
+            }
+            continue
+          }
+          if (item.contentType === 'browser') {
+            // Why: see closeItem — host-close a remote-owned browser or pageless host-mirror; always remove the visible tab.
+            const browserState = useAppStore.getState()
+            const hasLocalPages =
+              (browserState.browserPagesByWorkspace[item.entityId] ?? []).length > 0
+            const shouldCloseOnHost =
+              isWebRuntimeSessionActive(runtimeEnvironmentId) &&
+              (browserWorkspaceHasRemoteOwner(browserState, item.entityId, runtimeEnvironmentId) ||
+                !hasLocalPages)
+            if (shouldCloseOnHost) {
+              void closeWebRuntimeSessionTab({
+                worktreeId,
+                tabId: item.id,
+                environmentId: runtimeEnvironmentId,
+                reason: 'user'
+              })
+            }
+            destroyWorkspaceWebviews(browserState.browserPagesByWorkspace, item.entityId)
+            closeBrowserTab(item.entityId)
             closeUnifiedTab(item.id)
+          } else if (item.contentType === 'simulator') {
+            closeUnifiedTab(item.id)
+          } else {
+            const canCloseTab = closeEditorIfUnreferenced(item.entityId, item.id)
+            if (canCloseTab) {
+              closeUnifiedTab(item.id)
+            }
           }
         }
-      }
+      })()
     },
-    [closeBrowserTab, closeEditorIfUnreferenced, closeTab, closeUnifiedTab, groupTabs, worktreeId]
+    [closeBrowserTab, closeEditorIfUnreferenced, closeUnifiedTab, groupTabs, worktreeId]
   )
 
   const activateTerminal = useCallback(

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -116,6 +116,7 @@ type StoreState = {
       title?: string
       launchAgent?: string
       shellOverride?: string
+      pendingActivationSpawn?: true | number
     }[]
   >
   ptyIdsByTabId?: Record<string, string[]>
@@ -764,6 +765,8 @@ describe('connectPanePty', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    vi.mocked(getEagerPtyBufferHandle).mockReset()
+    vi.mocked(getEagerPtyBufferHandle).mockReturnValue(undefined)
     transportFactoryQueue = []
     createdTransportOptions = []
     storeSubscribers = []
@@ -1929,12 +1932,14 @@ describe('connectPanePty', () => {
     expect(deps.clearRuntimePaneTitle).not.toHaveBeenCalled()
     expect(deps.clearTabPtyId).not.toHaveBeenCalled()
     expect(manager.closePane).not.toHaveBeenCalled()
+    expect(window.api.pty.handleLostTerminalCandidate).not.toHaveBeenCalled()
 
     pending = false
     settleDeferredPtyShutdownExits(['pty-pane-2'], 'committed')
     expect(deps.consumeSuppressedPtyExit).toHaveBeenCalledWith('pty-pane-2')
     expect(deps.clearRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 2)
     expect(deps.clearTabPtyId).not.toHaveBeenCalled()
+    expect(window.api.pty.handleLostTerminalCandidate).not.toHaveBeenCalled()
   })
 
   it('keeps renderer state intact for an exit deferred through rollback', async () => {
@@ -2032,6 +2037,7 @@ describe('connectPanePty', () => {
     expect(writesAfterExit).toContain('\x1b[?2004l')
     // A hidden pane must not respawn on exit — the wake waits for the reveal.
     expect(transport.connect.mock.calls.length).toBe(connectCallsBeforeExit)
+    expect(window.api.pty.handleLostTerminalCandidate).not.toHaveBeenCalled()
 
     binding.noteVisibilityResume()
     await flushAsyncTicks()
@@ -2042,6 +2048,7 @@ describe('connectPanePty', () => {
       | undefined
     expect(resumeConnectOptions?.command).toContain('--resume')
     expect(resumeConnectOptions?.command).toContain('sess-hibernated-1')
+    expect(window.api.pty.handleLostTerminalCandidate).not.toHaveBeenCalled()
 
     // The wake is one-shot: a second reveal must not spawn again.
     const connectCallsAfterWake = transport.connect.mock.calls.length
@@ -2560,6 +2567,26 @@ describe('connectPanePty', () => {
 
     expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
     expect(manager.closePane).not.toHaveBeenCalled()
+    expect(window.api.pty.handleLostTerminalCandidate).not.toHaveBeenCalled()
+  })
+
+  it('does not classify a user-disposed pane as a lost worker or spawn a replacement', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    transportFactoryQueue.push(transport)
+    const binding = connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps() as never
+    )
+    await flushAsyncTicks(10)
+    const connectCallsBeforeDispose = transport.connect.mock.calls.length
+
+    binding.dispose()
+    await flushAsyncTicks(10)
+
+    expect(window.api.pty.handleLostTerminalCandidate).not.toHaveBeenCalled()
+    expect(transport.connect).toHaveBeenCalledTimes(connectCallsBeforeDispose)
   })
 
   it('tears down the sole terminal when a reattached (not freshly spawned) PTY exits', async () => {
@@ -2579,6 +2606,7 @@ describe('connectPanePty', () => {
 
     expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
     expect(manager.closePane).not.toHaveBeenCalled()
+    expect(window.api.pty.handleLostTerminalCandidate).not.toHaveBeenCalled()
   })
 
   it('rebinds a provider replacement without granting fresh-spawn exit protection', async () => {
@@ -17536,13 +17564,34 @@ describe('connectPanePty', () => {
     expect(mockStoreState.removeDeferredSshReconnectTarget).not.toHaveBeenCalled()
   })
 
-  it('asks the main-owned gate before no-id deferred SSH recovery and closes an archived tab', async () => {
+  it.each([
+    {
+      name: 'archives a no-hint deferred SSH recovery',
+      receipt: { kind: 'archived' as const, archiveId: 'archive-no-id' },
+      expectedConnectCalls: 0
+    },
+    {
+      name: 'fresh-spawns an ordinary no-hint deferred SSH recovery',
+      receipt: { kind: 'ordinary-shell' as const },
+      expectedConnectCalls: 1
+    },
+    {
+      name: 'keeps a retryable no-hint deferred SSH recovery open',
+      receipt: { kind: 'retryable-error' as const, code: 'capture-unavailable' as const },
+      expectedConnectCalls: 0
+    }
+  ])('$name only after the main-owned recovery gate', async ({ receipt, expectedConnectCalls }) => {
     const { connectPanePty } = await import('./pty-connection')
-    const transport = createMockTransport()
+    const transport = createMockTransport('fresh-no-hint-pty')
     transportFactoryQueue.push(transport)
-    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockResolvedValue({
-      kind: 'archived',
-      archiveId: 'archive-no-id'
+    const recoveryOrder: string[] = []
+    vi.mocked(window.api.ssh.connect).mockImplementation(async () => {
+      recoveryOrder.push('ssh-connected')
+      return { targetId: 'conn-1', status: 'connected', error: null, reconnectAttempt: 0 }
+    })
+    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockImplementation(async () => {
+      recoveryOrder.push('main-gate')
+      return receipt
     })
     mockStoreState = {
       ...mockStoreState,
@@ -17553,15 +17602,32 @@ describe('connectPanePty', () => {
       deferredSshSessionIdsByTabId: {}
     }
 
-    connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+    const deps = createDeps()
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
     await flushAsyncTicks(20)
 
     expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledOnce()
-    expect(transport.connect).not.toHaveBeenCalled()
-    expect(mockStoreState.closeTab).toHaveBeenCalledWith(
-      'tab-1',
-      expect.objectContaining({ localPtyTeardownOwnedExternally: true })
-    )
+    expect(recoveryOrder).toEqual(['ssh-connected', 'main-gate'])
+    expect(transport.connect).toHaveBeenCalledTimes(expectedConnectCalls)
+    if (receipt.kind === 'archived') {
+      expect(mockStoreState.closeTab).toHaveBeenCalledWith(
+        'tab-1',
+        expect.objectContaining({ localPtyTeardownOwnedExternally: true })
+      )
+      expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+    } else if (receipt.kind === 'retryable-error') {
+      expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+      expect(transport.connect).not.toHaveBeenCalled()
+      expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+        1,
+        'Terminal recovery is pending archive (capture-unavailable).'
+      )
+    } else {
+      expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+      expect(transport.connect).toHaveBeenCalledWith(
+        expect.not.objectContaining({ sessionId: expect.any(String) })
+      )
+    }
   })
 
   it('keeps a deferred SSH tab when archive capture throws before the helper returns', async () => {
@@ -17612,6 +17678,64 @@ describe('connectPanePty', () => {
     }
   })
 
+  it.each([
+    { name: 'fresh-spawns an ordinary shell', receipt: { kind: 'ordinary-shell' as const } },
+    {
+      name: 'closes an archived worker tab',
+      receipt: { kind: 'archived' as const, archiveId: 'archive-expired-session' }
+    },
+    {
+      name: 'keeps a retryable worker tab open',
+      receipt: { kind: 'retryable-error' as const, code: 'durability-failed' as const }
+    }
+  ])('handles a deferred SSH sessionExpired result: $name', async ({ receipt }) => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('fresh-after-expired-session')
+    transport.connect.mockImplementation(async (opts: { sessionId?: string }) => {
+      if (opts.sessionId) {
+        return { id: opts.sessionId, sessionExpired: true }
+      }
+      return 'fresh-after-expired-session'
+    })
+    transportFactoryQueue.push(transport)
+    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockResolvedValue(receipt)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': 'expired-session' }
+    }
+    const deps = createDeps()
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledOnce()
+    if (receipt.kind === 'ordinary-shell') {
+      expect(transport.connect).toHaveBeenCalledTimes(2)
+      expect(deps.clearExitedPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'expired-session')
+      expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'expired-session')
+      expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+    } else if (receipt.kind === 'archived') {
+      expect(transport.connect).toHaveBeenCalledTimes(1)
+      expect(mockStoreState.closeTab).toHaveBeenCalledWith(
+        'tab-1',
+        expect.objectContaining({ localPtyTeardownOwnedExternally: true })
+      )
+      expect(deps.clearTabPtyId).not.toHaveBeenCalled()
+    } else {
+      expect(transport.connect).toHaveBeenCalledTimes(1)
+      expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+      expect(deps.clearTabPtyId).not.toHaveBeenCalled()
+      expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+        1,
+        'Terminal recovery is pending archive (durability-failed).'
+      )
+    }
+  })
+
   it('spawns a fresh PTY when a deferred SSH session expired', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
@@ -17650,6 +17774,257 @@ describe('connectPanePty', () => {
     expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'expired-session')
     expect(deps.syncPanePtyLayoutBinding).toHaveBeenCalledWith(1, 'fresh-ssh-pty')
     expect(deps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-ssh-pty')
+  })
+
+  it.each([
+    { name: 'fresh-spawns an ordinary shell', receipt: { kind: 'ordinary-shell' as const } },
+    {
+      name: 'closes an archived worker tab',
+      receipt: { kind: 'archived' as const, archiveId: 'archive-attach-failed' }
+    },
+    {
+      name: 'keeps a retryable worker tab open',
+      receipt: { kind: 'retryable-error' as const, code: 'durability-failed' as const }
+    }
+  ])('handles a detached attach throw: $name', async ({ receipt }) => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('fresh-after-attach-throw')
+    transport.attach.mockImplementation(() => {
+      throw new Error('detached attach failed')
+    })
+    transportFactoryQueue.push(transport)
+    vi.mocked(getEagerPtyBufferHandle).mockReturnValue({} as never)
+    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockResolvedValue(receipt)
+    const deps = createDeps()
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(transport.attach).toHaveBeenCalledWith(
+      expect.objectContaining({ existingPtyId: 'tab-pty' })
+    )
+    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledOnce()
+    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(1, 'detached attach failed')
+    if (receipt.kind === 'ordinary-shell') {
+      expect(deps.clearTabPtyId).toHaveBeenCalledWith('tab-1', 'tab-pty')
+      expect(transport.connect).toHaveBeenCalledTimes(1)
+      expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+    } else if (receipt.kind === 'archived') {
+      expect(deps.clearTabPtyId).not.toHaveBeenCalled()
+      expect(transport.connect).not.toHaveBeenCalled()
+      expect(mockStoreState.closeTab).toHaveBeenCalledWith(
+        'tab-1',
+        expect.objectContaining({ localPtyTeardownOwnedExternally: true })
+      )
+    } else {
+      expect(deps.clearTabPtyId).not.toHaveBeenCalled()
+      expect(transport.connect).not.toHaveBeenCalled()
+      expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+      expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+        1,
+        'Terminal recovery is pending archive (durability-failed).'
+      )
+    }
+  })
+
+  it('keeps the detached tab when the preload lost-worker handoff is unavailable', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('unexpected-fresh-after-missing-handoff')
+    transport.attach.mockImplementation(() => {
+      throw new Error('detached attach failed')
+    })
+    transportFactoryQueue.push(transport)
+    vi.mocked(getEagerPtyBufferHandle).mockReturnValue({} as never)
+    const api = window.api.pty as { handleLostTerminalCandidate?: unknown }
+    const savedHandler = api.handleLostTerminalCandidate
+    Reflect.deleteProperty(api, 'handleLostTerminalCandidate')
+    const deps = createDeps()
+
+    try {
+      connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+      await flushAsyncTicks(20)
+
+      expect(transport.attach).toHaveBeenCalledOnce()
+      expect(transport.connect).not.toHaveBeenCalled()
+      expect(deps.clearTabPtyId).not.toHaveBeenCalled()
+      expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+      expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+        1,
+        'Terminal recovery could not be archived. Try again shortly.'
+      )
+    } finally {
+      api.handleLostTerminalCandidate = savedHandler
+    }
+  })
+
+  it('coalesces simultaneous and repeat all-dead split-pane recovery into one archive operation', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const archiveGate = createDeferred<{ kind: 'archived'; archiveId: string }>()
+    let archiveOperations = 0
+    let sharedArchiveResult: Promise<{ kind: 'archived'; archiveId: string }> | null = null
+    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockImplementation(() => {
+      if (!sharedArchiveResult) {
+        archiveOperations += 1
+        sharedArchiveResult = archiveGate.promise
+      }
+      return sharedArchiveResult
+    })
+    const firstTransport = createMockTransport()
+    const secondTransport = createMockTransport()
+    const repeatTransport = createMockTransport()
+    transportFactoryQueue.push(firstTransport, secondTransport, repeatTransport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: null, pendingActivationSpawn: 2 }]
+      },
+      ptyIdsByTabId: { 'tab-1': [] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: LEAF_1 },
+            second: { type: 'leaf', leafId: LEAF_2 }
+          },
+          activeLeafId: LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    } as StoreState
+    const sharedTransports = { current: new Map() }
+    const firstDeps = createDeps({ paneTransportsRef: sharedTransports })
+    const secondDeps = createDeps({ paneTransportsRef: sharedTransports })
+    let semanticCloseCount = 0
+    let tabClosed = false
+    mockStoreState.closeTab.mockImplementation(() => {
+      if (!tabClosed) {
+        tabClosed = true
+        semanticCloseCount += 1
+      }
+    })
+    const manager = createManager(2)
+
+    connectPanePty(createPane(1) as never, manager as never, firstDeps as never)
+    connectPanePty(createPane(2) as never, manager as never, secondDeps as never)
+    await flushAsyncTicks(10)
+
+    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledTimes(2)
+    expect(archiveOperations).toBe(1)
+    expect(firstTransport.connect).not.toHaveBeenCalled()
+    expect(secondTransport.connect).not.toHaveBeenCalled()
+
+    archiveGate.resolve({ kind: 'archived', archiveId: 'archive-split-all-dead' })
+    await flushAsyncTicks(20)
+
+    // A later activation can ask again, but the main-owned operation remains idempotently archived.
+    connectPanePty(
+      createPane(1) as never,
+      manager as never,
+      createDeps({ paneTransportsRef: sharedTransports }) as never
+    )
+    await flushAsyncTicks(20)
+
+    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledTimes(3)
+    expect(archiveOperations).toBe(1)
+    expect(repeatTransport.connect).not.toHaveBeenCalled()
+    expect(semanticCloseCount).toBe(1)
+  })
+
+  it('keeps the all-dead split activation marker for the slow sibling after an ordinary fallback', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const firstTransport = createMockTransport('fresh-all-dead-pane-1')
+    const secondTransport = createMockTransport('fresh-all-dead-pane-2')
+    transportFactoryQueue.push(firstTransport, secondTransport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: null, pendingActivationSpawn: 2 }]
+      },
+      ptyIdsByTabId: { 'tab-1': [] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: LEAF_1 },
+            second: { type: 'leaf', leafId: LEAF_2 }
+          },
+          activeLeafId: LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: {}
+        }
+      }
+    } as StoreState
+    const getActivationTab = (): { pendingActivationSpawn?: true | number } => {
+      const tab = mockStoreState.tabsByWorktree['wt-1']?.[0]
+      if (!tab) {
+        throw new Error('Expected all-dead activation tab')
+      }
+      return tab
+    }
+    const consumeActivationMarker = (): void => {
+      const nextMarker = getActivationTab().pendingActivationSpawn === 2 ? true : undefined
+      mockStoreState = {
+        ...mockStoreState,
+        tabsByWorktree: {
+          ...mockStoreState.tabsByWorktree,
+          'wt-1':
+            mockStoreState.tabsByWorktree['wt-1']?.map((candidate) => ({
+              ...candidate,
+              ...(nextMarker === undefined ? {} : { pendingActivationSpawn: nextMarker })
+            })) ?? []
+        }
+      } as StoreState
+      if (nextMarker === undefined) {
+        delete getActivationTab().pendingActivationSpawn
+      }
+    }
+    const sharedTransports = { current: new Map() }
+    const makeDeps = () => {
+      const deps = createDeps({ paneTransportsRef: sharedTransports })
+      const updateTabPtyId = deps.updateTabPtyId
+      deps.updateTabPtyId = vi.fn((...args: [string, string, string?]) => {
+        updateTabPtyId(...args)
+        consumeActivationMarker()
+      })
+      return deps
+    }
+    const firstDeps = makeDeps()
+    const secondDeps = makeDeps()
+    firstTransport.connect.mockImplementation(async () => {
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((ptyId: string) => void)
+        | undefined
+      onPtySpawn?.('fresh-all-dead-pane-1')
+      return 'fresh-all-dead-pane-1'
+    })
+    secondTransport.connect.mockImplementation(async () => {
+      const onPtySpawn = createdTransportOptions[1]?.onPtySpawn as
+        | ((ptyId: string) => void)
+        | undefined
+      onPtySpawn?.('fresh-all-dead-pane-2')
+      return 'fresh-all-dead-pane-2'
+    })
+    const manager = createManager(2)
+
+    connectPanePty(createPane(1) as never, manager as never, firstDeps as never)
+    await flushAsyncTicks(20)
+
+    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledTimes(1)
+    expect(firstTransport.connect).toHaveBeenCalledOnce()
+    expect(getActivationTab().pendingActivationSpawn).toBe(true)
+
+    connectPanePty(createPane(2) as never, manager as never, secondDeps as never)
+    await flushAsyncTicks(20)
+
+    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledTimes(2)
+    expect(secondTransport.connect).toHaveBeenCalledOnce()
+    expect(firstDeps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-all-dead-pane-1')
+    expect(secondDeps.updateTabPtyId).toHaveBeenCalledWith('tab-1', 'fresh-all-dead-pane-2')
+    expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+    expect(getActivationTab().pendingActivationSpawn).toBeUndefined()
   })
 
   it('clears the pending serializer when disposed before deferred SSH expiry resolves', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7976,7 +7976,8 @@ describe('connectPanePty', () => {
           ORCA_WORKTREE_ID: 'wt-1',
           ORCA_WORKSPACE_ID: 'wt-1',
           ORCA_AGENT_LAUNCH_TOKEN: expect.stringMatching(new RegExp(`^${UUID_RE}$`))
-        })
+        }),
+        controlledHibernationWake: true
       })
     )
     expect(mockStoreState.registerAgentLaunchConfig).toHaveBeenCalledWith(paneKey, launchConfig, {
@@ -8144,6 +8145,7 @@ describe('connectPanePty', () => {
         })
       })
     )
+    expect(transport.connect.mock.calls.at(-1)?.[0]).not.toHaveProperty('controlledHibernationWake')
     expect(mockStoreState.registerAgentLaunchConfig).toHaveBeenCalledWith(paneKey, launchConfig, {
       agentType: 'codex',
       launchToken: expect.stringMatching(new RegExp(`^${UUID_RE}$`)),
@@ -17562,7 +17564,11 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('keeps a deferred SSH tab when the archive handoff throws', async () => {
+  it('keeps a deferred SSH tab when archive capture throws before the helper returns', async () => {
+    const { shutdownBufferCaptures } = await import('./shutdown-buffer-captures')
+    shutdownBufferCaptures.set('tab-1', () => {
+      throw new Error('capture callback failed')
+    })
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     transport.connect.mockImplementation(
@@ -17575,9 +17581,6 @@ describe('connectPanePty', () => {
       }
     )
     transportFactoryQueue.push(transport)
-    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockRejectedValue(
-      new Error('capture callback failed')
-    )
     mockStoreState = {
       ...mockStoreState,
       tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
@@ -17588,16 +17591,25 @@ describe('connectPanePty', () => {
     }
     const deps = createDeps()
 
-    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
-    await flushAsyncTicks(20)
+    try {
+      connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+      await flushAsyncTicks(20)
 
-    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledOnce()
-    expect(transport.connect).toHaveBeenCalledTimes(1)
-    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
-      1,
-      'Terminal recovery is pending archive (durability-failed).'
-    )
-    expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+      expect(window.api.pty.handleLostTerminalCandidate).not.toHaveBeenCalled()
+      expect(transport.connect).toHaveBeenCalledTimes(1)
+      expect(
+        transport.connect.mock.calls.filter(
+          ([options]) => !(options as { sessionId?: string }).sessionId
+        )
+      ).toHaveLength(0)
+      expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+        1,
+        'Terminal recovery could not be archived. Try again shortly.'
+      )
+      expect(mockStoreState.closeTab).not.toHaveBeenCalled()
+    } finally {
+      shutdownBufferCaptures.delete('tab-1')
+    }
   })
 
   it('spawns a fresh PTY when a deferred SSH session expired', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -119,6 +119,8 @@ type StoreState = {
       pendingActivationSpawn?: true | number
     }[]
   >
+  openFiles: { id: string; worktreeId: string }[]
+  browserTabsByWorktree: Record<string, { id: string }[]>
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
   unreadTerminalTabs?: Record<string, true>
@@ -210,6 +212,7 @@ type StoreState = {
   markTerminalTabUnread: ReturnType<typeof vi.fn>
   markTerminalPaneUnread: ReturnType<typeof vi.fn>
   markAgentCompletionPaneUnread: ReturnType<typeof vi.fn>
+  setActiveWorktree: ReturnType<typeof vi.fn>
   closeTab: ReturnType<typeof vi.fn>
 }
 
@@ -775,6 +778,8 @@ describe('connectPanePty', () => {
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }]
       },
+      openFiles: [],
+      browserTabsByWorktree: {},
       ptyIdsByTabId: {
         'tab-1': ['tab-pty']
       },
@@ -863,6 +868,7 @@ describe('connectPanePty', () => {
       markTerminalTabUnread: vi.fn(),
       markTerminalPaneUnread: vi.fn(),
       markAgentCompletionPaneUnread: vi.fn(),
+      setActiveWorktree: vi.fn(),
       closeTab: vi.fn()
     } as StoreState
     ;(globalThis as unknown as { window: unknown }).window = {
@@ -17724,6 +17730,7 @@ describe('connectPanePty', () => {
         'tab-1',
         expect.objectContaining({ localPtyTeardownOwnedExternally: true })
       )
+      expect(mockStoreState.setActiveWorktree).toHaveBeenCalledWith(null)
       expect(deps.clearTabPtyId).not.toHaveBeenCalled()
     } else {
       expect(transport.connect).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -209,6 +209,7 @@ type StoreState = {
   markTerminalTabUnread: ReturnType<typeof vi.fn>
   markTerminalPaneUnread: ReturnType<typeof vi.fn>
   markAgentCompletionPaneUnread: ReturnType<typeof vi.fn>
+  closeTab: ReturnType<typeof vi.fn>
 }
 
 type WindowsShiftEnterPaneState = Parameters<typeof resolveWindowsShiftEnterEncodingForPane>[0]
@@ -858,7 +859,8 @@ describe('connectPanePty', () => {
       }),
       markTerminalTabUnread: vi.fn(),
       markTerminalPaneUnread: vi.fn(),
-      markAgentCompletionPaneUnread: vi.fn()
+      markAgentCompletionPaneUnread: vi.fn(),
+      closeTab: vi.fn()
     } as StoreState
     ;(globalThis as unknown as { window: unknown }).window = {
       api: {
@@ -888,7 +890,8 @@ describe('connectPanePty', () => {
           declarePendingPaneSerializer: vi.fn().mockResolvedValue(1),
           settlePaneSerializer: vi.fn().mockResolvedValue(undefined),
           clearPendingPaneSerializer: vi.fn().mockResolvedValue(undefined),
-          reportRendererSerializerReady: vi.fn().mockResolvedValue(undefined)
+          reportRendererSerializerReady: vi.fn().mockResolvedValue(undefined),
+          handleLostTerminalCandidate: vi.fn().mockResolvedValue({ kind: 'ordinary-shell' })
         },
         platform: {
           get: vi.fn(() => ({ platform: 'win32', osRelease: '10.0.26100' }))
@@ -915,6 +918,10 @@ describe('connectPanePty', () => {
       const foregroundProcess = await window.api.pty.getForegroundProcess(id)
       const hasChildProcesses = await window.api.pty.hasChildProcesses(id)
       return { foregroundProcess, hasChildProcesses }
+    })
+    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockReset()
+    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockResolvedValue({
+      kind: 'ordinary-shell'
     })
     globalThis.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
       callback(0)
@@ -6132,8 +6139,7 @@ describe('connectPanePty', () => {
     })
 
     connectPanePty(pane as never, manager as never, deps as never)
-    await Promise.resolve()
-    await Promise.resolve()
+    await flushAsyncTicks(10)
 
     expect(transport.connect).toHaveBeenNthCalledWith(
       1,
@@ -17526,6 +17532,72 @@ describe('connectPanePty', () => {
     expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
     expect(mockStoreState.removeDeferredSshSessionId).not.toHaveBeenCalled()
     expect(mockStoreState.removeDeferredSshReconnectTarget).not.toHaveBeenCalled()
+  })
+
+  it('asks the main-owned gate before no-id deferred SSH recovery and closes an archived tab', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockResolvedValue({
+      kind: 'archived',
+      archiveId: 'archive-no-id'
+    })
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: {}
+    }
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks(20)
+
+    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledOnce()
+    expect(transport.connect).not.toHaveBeenCalled()
+    expect(mockStoreState.closeTab).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({ localPtyTeardownOwnedExternally: true })
+    )
+  })
+
+  it('keeps a deferred SSH tab when the archive handoff throws', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transport.connect.mockImplementation(
+      async (opts: { sessionId?: string; callbacks?: ConnectCallbacks }) => {
+        if (opts.sessionId) {
+          opts.callbacks?.onError?.('SSH_SESSION_EXPIRED: expired-session')
+          return undefined
+        }
+        return 'unexpected-fresh-pty'
+      }
+    )
+    transportFactoryQueue.push(transport)
+    vi.mocked(window.api.pty.handleLostTerminalCandidate).mockRejectedValue(
+      new Error('capture callback failed')
+    )
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-1': [] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': 'expired-session' }
+    }
+    const deps = createDeps()
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(window.api.pty.handleLostTerminalCandidate).toHaveBeenCalledOnce()
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+      1,
+      'Terminal recovery is pending archive (durability-failed).'
+    )
+    expect(mockStoreState.closeTab).not.toHaveBeenCalled()
   })
 
   it('spawns a fresh PTY when a deferred SSH session expired', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -30,6 +30,7 @@ import {
 import { serializeWithAbsoluteCursor } from '../../../../shared/terminal-serialize-absolute-cursor'
 import { isTerminalQueryReply } from '../../../../shared/terminal-query-reply'
 import type { TerminalLostWorkerRendererReceipt } from '../../../../shared/terminal-archive-types'
+import { retireMainAuthoritativeTerminalTab } from '@/lib/main-authoritative-terminal-retirement'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
 import type { PtyTransportRecoveryState } from './pty-transport-types'
 import { createIpcPtyTransport } from './pty-transport'
@@ -4626,12 +4627,7 @@ export function connectPanePty(
         return
       }
       if (receipt.kind === 'archived') {
-        useAppStore.getState().closeTab(deps.tabId, {
-          reason: 'cleanup',
-          captureRecentlyClosed: false,
-          localPtyTeardownOwnedExternally: true,
-          runtimePtyTeardownOwnedExternally: true
-        })
+        retireMainAuthoritativeTerminalTab(deps.tabId)
         return
       }
       reportError(`Terminal recovery is pending archive (${receipt.code}).`)
@@ -5366,6 +5362,11 @@ export function connectPanePty(
           onError: (message: string): void => {
             if (isCurrent()) {
               onError(message)
+            }
+          },
+          onLostWorkerRecovery: (receipt: TerminalLostWorkerRendererReceipt): void => {
+            if (isCurrent()) {
+              applyLostWorkerRecoveryReceipt(receipt)
             }
           },
           onRecoveryStateChange: (state: PtyTransportRecoveryState): void => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4830,6 +4830,7 @@ export function connectPanePty(
           : {}),
         ...(coldRestoreOverride ? { launchToken: coldRestoreOverride.launchToken } : {}),
         ...(coldRestoreOverride ? { launchAgent: coldRestoreOverride.agent } : {}),
+        ...(coldRestoreOverride?.hasSleepingRecord ? { controlledHibernationWake: true } : {}),
         ...(shouldDeclareHiddenAtSpawn() ? { initiallyHidden: true } : {}),
         callbacks: outputCallbacks.callbacks
       })
@@ -7741,6 +7742,7 @@ export function connectPanePty(
                 ? { launchToken: coldRestoreStartup.launchToken }
                 : {}),
               ...(coldRestoreStartup?.agent ? { launchAgent: coldRestoreStartup.agent } : {}),
+              ...(coldRestoreStartup?.hasSleepingRecord ? { controlledHibernationWake: true } : {}),
               ...(shouldDeclareHiddenAtSpawn() ? { initiallyHidden: true } : {}),
               callbacks: outputCallbacks.callbacks
             })
@@ -7972,6 +7974,7 @@ export function connectPanePty(
           : {}),
         ...(coldRestoreStartup?.launchToken ? { launchToken: coldRestoreStartup.launchToken } : {}),
         ...(coldRestoreStartup?.agent ? { launchAgent: coldRestoreStartup.agent } : {}),
+        ...(coldRestoreStartup?.hasSleepingRecord ? { controlledHibernationWake: true } : {}),
         ...(shouldDeclareHiddenAtSpawn() ? { initiallyHidden: true } : {}),
         callbacks: outputCallbacks.callbacks
       })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4621,6 +4621,21 @@ export function connectPanePty(
     // Why: the hibernation wake fires from noteVisibilityResume in the outer
     // connection scope, long after this deferred-connect closure has run.
     wakeHibernatedAgentPane = () => startFreshColdRestoreAgentResume()
+    const applyLostWorkerRecoveryReceipt = (receipt: TerminalLostWorkerRendererReceipt): void => {
+      if (receipt.kind === 'ordinary-shell') {
+        return
+      }
+      if (receipt.kind === 'archived') {
+        useAppStore.getState().closeTab(deps.tabId, {
+          reason: 'cleanup',
+          captureRecentlyClosed: false,
+          localPtyTeardownOwnedExternally: true,
+          runtimePtyTeardownOwnedExternally: true
+        })
+        return
+      }
+      reportError(`Terminal recovery is pending archive (${receipt.code}).`)
+    }
     const handleAutomaticLostWorkerRecovery = async (
       fallback: () => void,
       options: { hibernating?: boolean } = {}
@@ -4638,23 +4653,14 @@ export function connectPanePty(
           reason: connectionId ? 'relay-worker-lost' : 'daemon-worker-lost'
         })
       } catch {
-        fallback()
+        reportError('Terminal recovery could not be archived. Try again shortly.')
         return
       }
       if (receipt.kind === 'ordinary-shell') {
         fallback()
         return
       }
-      if (receipt.kind === 'archived') {
-        useAppStore.getState().closeTab(deps.tabId, {
-          reason: 'cleanup',
-          captureRecentlyClosed: false,
-          localPtyTeardownOwnedExternally: true,
-          runtimePtyTeardownOwnedExternally: true
-        })
-        return
-      }
-      reportError(`Terminal recovery is pending archive (${receipt.code}).`)
+      applyLostWorkerRecoveryReceipt(receipt)
     }
     const isStartupPasteTargetCurrent = (ptyId: string | null): boolean =>
       !disposed &&
@@ -4836,6 +4842,25 @@ export function connectPanePty(
       const trackedPromise: Promise<string | null> = Promise.resolve(spawnedRaw)
         .then(async (spawnedPtyId) => {
           if (outputCallbacks.generation !== transportStreamGeneration) {
+            const gen = await preSignalPromise
+            if (typeof gen === 'number') {
+              void window.api.pty.clearPendingPaneSerializer(cacheKey, gen).catch(() => {})
+            }
+            return null
+          }
+          if (
+            spawnedPtyId &&
+            typeof spawnedPtyId === 'object' &&
+            'lostWorkerRecovery' in spawnedPtyId &&
+            spawnedPtyId.lostWorkerRecovery
+          ) {
+            if (
+              paneStartup?.launchConfig ||
+              (startupOverride && 'launchConfig' in startupOverride)
+            ) {
+              clearRegisteredStartupLaunchConfig()
+            }
+            applyLostWorkerRecoveryReceipt(spawnedPtyId.lostWorkerRecovery)
             const gen = await preSignalPromise
             if (typeof gen === 'number') {
               void window.api.pty.clearPendingPaneSerializer(cacheKey, gen).catch(() => {})
@@ -7251,6 +7276,11 @@ export function connectPanePty(
       const connectResult =
         result && typeof result === 'object' && 'id' in result ? (result as PtyConnectResult) : null
 
+      if (connectResult?.lostWorkerRecovery) {
+        applyLostWorkerRecoveryReceipt(connectResult.lostWorkerRecovery)
+        return connectResult.lostWorkerRecovery.kind === 'archived'
+      }
+
       if (connectResult?.exitedBeforeAttach) {
         // Why: the transport already delivered the dead session's final frame + exit; treat as terminal state, not a failed reattach.
         return true
@@ -7807,7 +7837,11 @@ export function connectPanePty(
                 )
               })
           } else {
-            startFreshColdRestoreAgentResume()
+            const coldRestoreStartup = buildColdRestoreAgentResumeStartup()
+            await handleAutomaticLostWorkerRecovery(
+              () => startFreshColdRestoreAgentResume(coldRestoreStartup),
+              { hibernating: coldRestoreStartup?.hasSleepingRecord === true }
+            )
           }
         })()
         return

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -29,9 +29,11 @@ import {
 } from '@/lib/pane-manager/terminal-delivery-credit'
 import { serializeWithAbsoluteCursor } from '../../../../shared/terminal-serialize-absolute-cursor'
 import { isTerminalQueryReply } from '../../../../shared/terminal-query-reply'
+import type { TerminalLostWorkerRendererReceipt } from '../../../../shared/terminal-archive-types'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
 import type { PtyTransportRecoveryState } from './pty-transport-types'
 import { createIpcPtyTransport } from './pty-transport'
+import { handleLostTerminalCandidate } from '../terminal/terminal-archive-close'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
 import { toAgentLaunchPreferences } from '@/runtime/agent-session-create-operation'
 import { createUnresolvedOwnerPtyTransport } from './unresolved-owner-pty-transport'
@@ -4619,6 +4621,41 @@ export function connectPanePty(
     // Why: the hibernation wake fires from noteVisibilityResume in the outer
     // connection scope, long after this deferred-connect closure has run.
     wakeHibernatedAgentPane = () => startFreshColdRestoreAgentResume()
+    const handleAutomaticLostWorkerRecovery = async (
+      fallback: () => void,
+      options: { hibernating?: boolean } = {}
+    ): Promise<void> => {
+      if (options.hibernating) {
+        fallback()
+        return
+      }
+      let receipt: TerminalLostWorkerRendererReceipt
+      try {
+        receipt = await handleLostTerminalCandidate({
+          tabId: deps.tabId,
+          worktreeId: deps.worktreeId,
+          leafId: deps.restoredLeafId ?? pane.leafId,
+          reason: connectionId ? 'relay-worker-lost' : 'daemon-worker-lost'
+        })
+      } catch {
+        fallback()
+        return
+      }
+      if (receipt.kind === 'ordinary-shell') {
+        fallback()
+        return
+      }
+      if (receipt.kind === 'archived') {
+        useAppStore.getState().closeTab(deps.tabId, {
+          reason: 'cleanup',
+          captureRecentlyClosed: false,
+          localPtyTeardownOwnedExternally: true,
+          runtimePtyTeardownOwnedExternally: true
+        })
+        return
+      }
+      reportError(`Terminal recovery is pending archive (${receipt.code}).`)
+    }
     const isStartupPasteTargetCurrent = (ptyId: string | null): boolean =>
       !disposed &&
       deps.paneTransportsRef.current.get(pane.id) === transport &&
@@ -7230,17 +7267,20 @@ export function connectPanePty(
           ptyId: staleSessionId ?? null
         })
         // Why: a stale restored session can fail reattach after mount; don't leave xterm alive without a backing PTY.
-        if (staleSessionId) {
-          deps.clearExitedPanePtyLayoutBinding(pane.id, staleSessionId)
-        } else {
-          deps.syncPanePtyLayoutBinding(pane.id, null)
-        }
-        if (staleSessionId) {
-          deps.clearTabPtyId(deps.tabId, staleSessionId)
-        }
-        startFreshColdRestoreAgentResume(coldRestoreStartup, {
-          forceBlankRestoredViewport: true
-        })
+        await handleAutomaticLostWorkerRecovery(
+          () => {
+            if (staleSessionId) {
+              deps.clearExitedPanePtyLayoutBinding(pane.id, staleSessionId)
+              deps.clearTabPtyId(deps.tabId, staleSessionId)
+            } else {
+              deps.syncPanePtyLayoutBinding(pane.id, null)
+            }
+            startFreshColdRestoreAgentResume(coldRestoreStartup, {
+              forceBlankRestoredViewport: true
+            })
+          },
+          { hibernating: coldRestoreStartup?.hasSleepingRecord === true }
+        )
         return false
       }
       registerEffectiveLaunchConfig(connectResult?.launchConfig, {
@@ -7252,18 +7292,21 @@ export function connectPanePty(
             : {})
       })
       if (connectResult?.sessionExpired) {
-        if (staleSessionId) {
-          deps.clearExitedPanePtyLayoutBinding(pane.id, staleSessionId)
-        } else {
-          deps.syncPanePtyLayoutBinding(pane.id, null)
-        }
-        if (staleSessionId) {
-          deps.clearTabPtyId(deps.tabId, staleSessionId)
-        }
-        // Why: SSH sleep/reconnect can invalidate the relay PTY while the tab stays mounted; replace the dead lease in-place, not a stale overlay.
-        startFreshColdRestoreAgentResume(coldRestoreStartup, {
-          forceBlankRestoredViewport: true
-        })
+        await handleAutomaticLostWorkerRecovery(
+          () => {
+            if (staleSessionId) {
+              deps.clearExitedPanePtyLayoutBinding(pane.id, staleSessionId)
+              deps.clearTabPtyId(deps.tabId, staleSessionId)
+            } else {
+              deps.syncPanePtyLayoutBinding(pane.id, null)
+            }
+            // Why: SSH sleep/reconnect can invalidate the relay PTY while the tab stays mounted; replace the dead lease in-place, not a stale overlay.
+            startFreshColdRestoreAgentResume(coldRestoreStartup, {
+              forceBlankRestoredViewport: true
+            })
+          },
+          { hibernating: coldRestoreStartup?.hasSleepingRecord === true }
+        )
         return false
       }
       const isCurrentReattachPayload = (): boolean => {
@@ -7704,11 +7747,16 @@ export function connectPanePty(
                   if (disposed) {
                     return
                   }
-                  deps.clearExitedPanePtyLayoutBinding(pane.id, pendingSessionId)
-                  deps.clearTabPtyId(deps.tabId, pendingSessionId)
-                  startFreshColdRestoreAgentResume(coldRestoreStartup, {
-                    forceBlankRestoredViewport: true
-                  })
+                  await handleAutomaticLostWorkerRecovery(
+                    () => {
+                      deps.clearExitedPanePtyLayoutBinding(pane.id, pendingSessionId)
+                      deps.clearTabPtyId(deps.tabId, pendingSessionId)
+                      startFreshColdRestoreAgentResume(coldRestoreStartup, {
+                        forceBlankRestoredViewport: true
+                      })
+                    },
+                    { hibernating: coldRestoreStartup?.hasSleepingRecord === true }
+                  )
                   return
                 }
                 const accepted = await handleReattachResult(
@@ -7745,17 +7793,18 @@ export function connectPanePty(
                 if (disposed || outputCallbacks.generation !== transportStreamGeneration) {
                   return
                 }
-                if (isSshSessionExpiredError(err)) {
-                  deps.clearExitedPanePtyLayoutBinding(pane.id, pendingSessionId)
-                  deps.clearTabPtyId(deps.tabId, pendingSessionId)
-                  startFreshColdRestoreAgentResume(coldRestoreStartup, {
-                    forceBlankRestoredViewport: true
-                  })
-                  return
-                }
-                startFreshColdRestoreAgentResume(coldRestoreStartup, {
-                  forceBlankRestoredViewport: true
-                })
+                await handleAutomaticLostWorkerRecovery(
+                  () => {
+                    if (isSshSessionExpiredError(err)) {
+                      deps.clearExitedPanePtyLayoutBinding(pane.id, pendingSessionId)
+                      deps.clearTabPtyId(deps.tabId, pendingSessionId)
+                    }
+                    startFreshColdRestoreAgentResume(coldRestoreStartup, {
+                      forceBlankRestoredViewport: true
+                    })
+                  },
+                  { hibernating: coldRestoreStartup?.hasSleepingRecord === true }
+                )
               })
           } else {
             startFreshColdRestoreAgentResume()
@@ -7771,9 +7820,11 @@ export function connectPanePty(
         ? (deps.restoredPtyIdByLeafId[deps.restoredLeafId] ?? null)
         : null
     const storeSnapshot = useAppStore.getState()
-    const existingPtyId = storeSnapshot.tabsByWorktree[deps.worktreeId]?.find(
+    const currentTab = storeSnapshot.tabsByWorktree[deps.worktreeId]?.find(
       (t) => t.id === deps.tabId
-    )?.ptyId
+    )
+    const existingPtyId = currentTab?.ptyId
+    const pendingActivationSpawn = Boolean(currentTab?.pendingActivationSpawn)
     const hasSleepingAgentSession = Boolean(getSleepingRecordForPane(storeSnapshot))
 
     // Why: the tab-level fallback must not steal a PTY a setup sibling already published while the main pane waited for split geometry.
@@ -7915,11 +7966,16 @@ export function connectPanePty(
             if (disposed) {
               return
             }
-            deps.clearExitedPanePtyLayoutBinding(pane.id, deferredReattachSessionId)
-            deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
-            startFreshColdRestoreAgentResume(coldRestoreStartup, {
-              forceBlankRestoredViewport: true
-            })
+            await handleAutomaticLostWorkerRecovery(
+              () => {
+                deps.clearExitedPanePtyLayoutBinding(pane.id, deferredReattachSessionId)
+                deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
+                startFreshColdRestoreAgentResume(coldRestoreStartup, {
+                  forceBlankRestoredViewport: true
+                })
+              },
+              { hibernating: coldRestoreStartup?.hasSleepingRecord === true }
+            )
             return
           }
           const accepted = await handleReattachResult(
@@ -7964,18 +8020,17 @@ export function connectPanePty(
             ptyId: deferredReattachSessionId,
             reason: message
           })
-          deps.clearExitedPanePtyLayoutBinding(pane.id, deferredReattachSessionId)
-          deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
-          if (connectionId && isSshSessionExpiredError(err)) {
-            startFreshColdRestoreAgentResume(coldRestoreStartup, {
-              forceBlankRestoredViewport: true
-            })
-            return
-          }
-          reportError(message)
-          startFreshColdRestoreAgentResume(coldRestoreStartup, {
-            forceBlankRestoredViewport: true
-          })
+          await handleAutomaticLostWorkerRecovery(
+            () => {
+              deps.clearExitedPanePtyLayoutBinding(pane.id, deferredReattachSessionId)
+              deps.clearTabPtyId(deps.tabId, deferredReattachSessionId)
+              reportError(message)
+              startFreshColdRestoreAgentResume(coldRestoreStartup, {
+                forceBlankRestoredViewport: true
+              })
+            },
+            { hibernating: coldRestoreStartup?.hasSleepingRecord === true }
+          )
         })
     } else if (detachedRemoteLeafPtyId || detachedLivePtyId || eagerLivePtyId) {
       // Why: mirrored web-leaf panes must attach to their exact remote PTY, not spawn a replacement host tab.
@@ -8005,8 +8060,10 @@ export function connectPanePty(
         }
       } catch (err) {
         reportError(err instanceof Error ? err.message : String(err))
-        deps.clearTabPtyId(deps.tabId, attachPtyId)
-        startFreshSpawn()
+        void handleAutomaticLostWorkerRecovery(() => {
+          deps.clearTabPtyId(deps.tabId, attachPtyId)
+          startFreshSpawn()
+        })
       }
     } else {
       allowInitialIdleCacheSeed = false
@@ -8059,6 +8116,8 @@ export function connectPanePty(
         recordPtyConnectDiagnostic(`pane=${pane.id} -> FRESH SPAWN`)
         if (sleptRemoteColdRestoreStartup || hasSleepingAgentSession) {
           startFreshColdRestoreAgentResume(sleptRemoteColdRestoreStartup ?? undefined)
+        } else if (pendingActivationSpawn) {
+          void handleAutomaticLostWorkerRecovery(() => startFreshSpawn())
         } else {
           startFreshSpawn()
         }

--- a/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
+++ b/src/renderer/src/components/terminal-pane/pty-dispatcher.ts
@@ -196,6 +196,7 @@ function attachPtySecondaryPushListeners(unsubscribes: (() => void)[]): void {
       deliverPtyExitToHandlers({
         ptyId: payload.id,
         code: payload.code,
+        ...(payload.lostWorkerRecovery ? { lostWorkerRecovery: payload.lostWorkerRecovery } : {}),
         ...(primary ? { primary } : {}),
         sidecars: sidecars ? Array.from(sidecars) : []
       })

--- a/src/renderer/src/components/terminal-pane/pty-exit-delivery.ts
+++ b/src/renderer/src/components/terminal-pane/pty-exit-delivery.ts
@@ -3,11 +3,13 @@ import {
   clearPreHandlerPtyState,
   consumePreHandlerPtyState
 } from './pty-pre-handler-buffer'
+import type { TerminalLostWorkerRendererReceipt } from '../../../../shared/terminal-archive-types'
 
 type PtyExitDelivery = {
   ptyId: string
   code: number
-  primary?: (code: number) => void
+  lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+  primary?: (code: number, lostWorkerRecovery?: TerminalLostWorkerRendererReceipt) => void
   sidecars: readonly ((code: number, context: { hadPrimary: boolean }) => void)[]
 }
 
@@ -19,14 +21,22 @@ export function deliverPtyExitToHandlers(delivery: PtyExitDelivery): void {
     if (delivery.primary) {
       clearPreHandlerPtyState(delivery.ptyId)
       try {
-        delivery.primary(delivery.code)
+        if (delivery.lostWorkerRecovery) {
+          delivery.primary(delivery.code, delivery.lostWorkerRecovery)
+        } else {
+          delivery.primary(delivery.code)
+        }
       } finally {
         // Why: ownership is final even when cleanup throws; a duplicate exit
         // must not become a new pre-handler event for a future mount.
         consumePreHandlerPtyState(delivery.ptyId)
       }
     } else {
-      bufferPreHandlerPtyExit(delivery.ptyId, delivery.code)
+      if (delivery.lostWorkerRecovery) {
+        bufferPreHandlerPtyExit(delivery.ptyId, delivery.code, delivery.lostWorkerRecovery)
+      } else {
+        bufferPreHandlerPtyExit(delivery.ptyId, delivery.code)
+      }
     }
   } catch (error) {
     firstError = error

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.test.ts
@@ -103,6 +103,16 @@ describe('pre-handler PTY buffer', () => {
     expect(onExit).toHaveBeenCalledWith(3)
   })
 
+  it('keeps an archived receipt with a buffered exit', () => {
+    const receipt = { kind: 'archived' as const, archiveId: 'archive-1' }
+    const onExit = vi.fn()
+
+    bufferPreHandlerPtyExit(EXIT_PTY_ID, -1, receipt)
+    drainPreHandlerPtyExit(EXIT_PTY_ID, onExit)
+
+    expect(onExit).toHaveBeenCalledWith(-1, receipt)
+  })
+
   it('consumes a drained exit even when its handler throws', () => {
     bufferPreHandlerPtyExit(EXIT_PTY_ID, 7)
     expect(() =>

--- a/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
+++ b/src/renderer/src/components/terminal-pane/pty-pre-handler-buffer.ts
@@ -1,5 +1,6 @@
 import { clampUtf8Tail } from './pty-eager-buffer-clamp'
 import type { PtyDataMeta } from './pty-dispatcher'
+import type { TerminalLostWorkerRendererReceipt } from '../../../../shared/terminal-archive-types'
 
 type BufferedPreHandlerPtyData = {
   data: string
@@ -14,7 +15,10 @@ type BufferedPreHandlerPtyState = {
 }
 
 const preHandlerPtyData = new Map<string, BufferedPreHandlerPtyState>()
-const preHandlerPtyExit = new Map<string, number>()
+const preHandlerPtyExit = new Map<
+  string,
+  { code: number; lostWorkerRecovery?: TerminalLostWorkerRendererReceipt }
+>()
 const consumedPreHandlerPtyExits = new Map<string, true>()
 const discardedPreHandlerPtyStates = new Map<string, ReturnType<typeof setTimeout>>()
 const DISCARDED_PRE_HANDLER_PTY_STATE_TTL_MS = 60_000
@@ -96,7 +100,11 @@ export function drainPreHandlerPtyData(
   }
 }
 
-export function bufferPreHandlerPtyExit(ptyId: string, code: number): void {
+export function bufferPreHandlerPtyExit(
+  ptyId: string,
+  code: number,
+  lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+): void {
   if (consumedPreHandlerPtyExits.has(ptyId) || discardedPreHandlerPtyStates.has(ptyId)) {
     return
   }
@@ -106,7 +114,10 @@ export function bufferPreHandlerPtyExit(ptyId: string, code: number): void {
       preHandlerPtyExit.delete(oldestPtyId)
     }
   }
-  preHandlerPtyExit.set(ptyId, code)
+  preHandlerPtyExit.set(ptyId, {
+    code,
+    ...(lostWorkerRecovery ? { lostWorkerRecovery } : {})
+  })
 }
 
 // Why: primary handlers and pane-less parked owners have fully handled this
@@ -161,14 +172,21 @@ export function hasPreHandlerPtyExit(ptyId: string): boolean {
   return preHandlerPtyExit.has(ptyId)
 }
 
-export function drainPreHandlerPtyExit(ptyId: string, handler: (code: number) => void): void {
-  const code = preHandlerPtyExit.get(ptyId)
-  if (code === undefined) {
+export function drainPreHandlerPtyExit(
+  ptyId: string,
+  handler: (code: number, lostWorkerRecovery?: TerminalLostWorkerRendererReceipt) => void
+): void {
+  const exit = preHandlerPtyExit.get(ptyId)
+  if (!exit) {
     return
   }
   preHandlerPtyExit.delete(ptyId)
   try {
-    handler(code)
+    if (exit.lostWorkerRecovery) {
+      handler(exit.code, exit.lostWorkerRecovery)
+    } else {
+      handler(exit.code)
+    }
   } finally {
     // Why: draining transfers ownership to this handler. Even when it throws,
     // a duplicate exit must not become a new pre-handler event.

--- a/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.ts
+++ b/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.ts
@@ -2,11 +2,15 @@ import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../share
 import { clampUtf8Tail } from './pty-eager-buffer-clamp'
 import { clearPreHandlerPtyState, drainPreHandlerPtyData } from './pty-pre-handler-buffer'
 import type { PtyDataMeta } from './pty-dispatcher'
+import type { TerminalLostWorkerRendererReceipt } from '../../../../shared/terminal-archive-types'
 
 export const ptyDataHandlers = new Map<string, (data: string, meta?: PtyDataMeta) => void>()
 export const ptyDataSidecars = new Map<string, Set<(data: string) => void>>()
 export const ptyReplayHandlers = new Map<string, (data: string) => void>()
-export const ptyExitHandlers = new Map<string, (code: number) => void>()
+export const ptyExitHandlers = new Map<
+  string,
+  (code: number, lostWorkerRecovery?: TerminalLostWorkerRendererReceipt) => void
+>()
 export const ptyTeardownHandlers = new Map<string, () => void>()
 export const ptyShutdownLifecycleHandlers = new Map<
   string,

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -13,6 +13,7 @@ import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TerminalOscColorQueryReplyColors } from '../../../../shared/terminal-osc-color-reply'
 import type { TuiAgent } from '../../../../shared/types'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { TerminalLostWorkerRendererReceipt } from '../../../../shared/terminal-archive-types'
 import type { PtyDataMeta } from './pty-dispatcher'
 
 export type PtyBufferSnapshot = {
@@ -47,6 +48,8 @@ export type LocalPtySessionMetadata = {
 
 export type PtyConnectResult = {
   id: string
+  /** A main-owned archive decision returned before a replacement PTY existed. */
+  lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
   /** The requested session exited while it had no primary pane handler. Its
    *  buffered final data/exit were delivered, so callers must not fresh-spawn. */
   exitedBeforeAttach?: boolean

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -80,6 +80,7 @@ type PtyCallbacks = {
   onStatus?: (shell: string) => void
   onError?: (message: string, errors?: string[]) => void
   onExit?: (code: number) => void
+  onLostWorkerRecovery?: (receipt: TerminalLostWorkerRendererReceipt) => void
   onRecoveryStateChange?: (state: PtyTransportRecoveryState) => void
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -108,6 +108,8 @@ export type PtyTransport = {
      *  first byte and the gate + model responder own spawn-time queries.
      *  Ignored by remote-runtime transports (not gate-markable). */
     initiallyHidden?: boolean
+    /** Explicitly marks the renderer-controlled wake of a hibernated agent. */
+    controlledHibernationWake?: boolean
     command?: string
     env?: Record<string, string>
     envToDelete?: string[]

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -151,6 +151,16 @@ describe('createIpcPtyTransport', () => {
     expect(spawn).toHaveBeenCalledWith(expect.objectContaining({ resumeProviderSession }))
   })
 
+  it('forwards an explicit controlled hibernation wake to the PTY spawn', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+    const transport = createIpcPtyTransport({})
+
+    await transport.connect({ url: '', controlledHibernationWake: true, callbacks: {} })
+
+    expect(spawn).toHaveBeenCalledWith(expect.objectContaining({ controlledHibernationWake: true }))
+  })
+
   it('leaves the transport silently unbound after a failed connect — sendInput drops with no write IPC (frozen-terminal repro)', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -14,13 +14,19 @@ import {
   TERMINAL_INPUT_MAX_BYTES
 } from '../../../../shared/terminal-input'
 import { CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS } from '../../../../shared/clipboard-text'
+import type { TerminalLostWorkerRendererReceipt } from '../../../../shared/terminal-archive-types'
 
 describe('createIpcPtyTransport', () => {
   const originalWindow = (globalThis as { window?: typeof window }).window
   let onData: ((payload: { id: string; data: string }) => void) | null = null
   let onReplay: ((payload: { id: string; data: string }) => void) | null = null
   let onExit:
-    | ((payload: { id: string; code: number; preserveRendererBinding?: boolean }) => void)
+    | ((payload: {
+        id: string
+        code: number
+        preserveRendererBinding?: boolean
+        lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+      }) => void)
     | null = null
 
   function flushPtySideEffects(): Promise<void> {
@@ -58,6 +64,7 @@ describe('createIpcPtyTransport', () => {
                 id: string
                 code: number
                 preserveRendererBinding?: boolean
+                lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
               }) => void
             ) => {
               onExit = callback
@@ -109,6 +116,29 @@ describe('createIpcPtyTransport', () => {
       lostWorkerRecovery: { kind: 'archived', archiveId: 'archive-1' }
     })
     expect(transport.getPtyId()).toBeNull()
+  })
+
+  it('routes an archived exit receipt to the renderer retirement callback', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const onExitCallback = vi.fn()
+    const onLostWorkerRecovery = vi.fn()
+    const onPtyExit = vi.fn()
+    const transport = createIpcPtyTransport({ onPtyExit })
+
+    await transport.connect({
+      url: '',
+      callbacks: { onExit: onExitCallback, onLostWorkerRecovery }
+    })
+
+    onExit?.({
+      id: 'pty-1',
+      code: -1,
+      lostWorkerRecovery: { kind: 'archived', archiveId: 'archive-1' }
+    })
+
+    expect(onLostWorkerRecovery).toHaveBeenCalledWith({ kind: 'archived', archiveId: 'archive-1' })
+    expect(onExitCallback).not.toHaveBeenCalled()
+    expect(onPtyExit).toHaveBeenCalledWith('pty-1')
   })
 
   it('does not create a second kill authority when a mounted pane detaches', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -89,6 +89,28 @@ describe('createIpcPtyTransport', () => {
     transport.disconnect()
   })
 
+  it('preserves an archived lost-worker receipt instead of presenting it as an exited PTY', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+    spawn.mockResolvedValueOnce({
+      id: 'dead-worker',
+      lostWorkerRecovery: { kind: 'archived', archiveId: 'archive-1' }
+    })
+    const transport = createIpcPtyTransport({})
+
+    const result = await transport.connect({
+      url: '',
+      sessionId: 'dead-worker',
+      callbacks: {}
+    })
+
+    expect(result).toEqual({
+      id: 'dead-worker',
+      lostWorkerRecovery: { kind: 'archived', archiveId: 'archive-1' }
+    })
+    expect(transport.getPtyId()).toBeNull()
+  })
+
   it('does not create a second kill authority when a mounted pane detaches', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const kill = window.api.pty.kill as unknown as ReturnType<typeof vi.fn>

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -728,6 +728,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           ...(admittedSessionId ? { sessionId: admittedSessionId } : {}),
           // Why: hidden-at-spawn mark must reach main before the PTY's first byte — ride the spawn IPC, not the visibility sync (terminal-query-authority.md).
           ...(options.initiallyHidden ? { initiallyHidden: true } : {}),
+          ...(options.controlledHibernationWake ? { controlledHibernationWake: true } : {}),
           worktreeId,
           ...(tabId ? { tabId } : {}),
           ...(leafId ? { leafId } : {}),

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -797,6 +797,17 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         return spawnResult.id
       } catch (err) {
         const msg = extractIpcErrorMessage(err, err instanceof Error ? err.message : String(err))
+        if (msg.startsWith('terminal_lost_worker_archived')) {
+          return options.sessionId
+            ? ({ id: options.sessionId, exitedBeforeAttach: true } satisfies PtyConnectResult)
+            : undefined
+        }
+        if (msg.startsWith('terminal_lost_worker_archive_pending')) {
+          storedCallbacks.onError?.('Terminal recovery is pending archive. Try again shortly.')
+          return options.sessionId
+            ? ({ id: options.sessionId, exitedBeforeAttach: true } satisfies PtyConnectResult)
+            : undefined
+        }
         if (
           connectionId &&
           options.sessionId &&

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -741,6 +741,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           ? spawnResult.launchAgent
           : undefined
 
+        if (spawnResult.lostWorkerRecovery) {
+          return {
+            id: spawnResult.id,
+            lostWorkerRecovery: spawnResult.lostWorkerRecovery
+          } satisfies PtyConnectResult
+        }
+
         // Why: on destroy mid-connect, kill only a fresh spawn — killing a reattached session (owned by the tab lifecycle) loses a live shell.
         if (destroyed) {
           if (!options.sessionId) {
@@ -797,17 +804,6 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         return spawnResult.id
       } catch (err) {
         const msg = extractIpcErrorMessage(err, err instanceof Error ? err.message : String(err))
-        if (msg.startsWith('terminal_lost_worker_archived')) {
-          return options.sessionId
-            ? ({ id: options.sessionId, exitedBeforeAttach: true } satisfies PtyConnectResult)
-            : undefined
-        }
-        if (msg.startsWith('terminal_lost_worker_archive_pending')) {
-          storedCallbacks.onError?.('Terminal recovery is pending archive. Try again shortly.')
-          return options.sessionId
-            ? ({ id: options.sessionId, exitedBeforeAttach: true } satisfies PtyConnectResult)
-            : undefined
-        }
         if (
           connectionId &&
           options.sessionId &&

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -11,6 +11,7 @@ import {
   iterateTerminalInputChunks
 } from '../../../../shared/terminal-input'
 import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
+import type { TerminalLostWorkerRendererReceipt } from '../../../../shared/terminal-archive-types'
 import {
   ptyDataHandlers,
   ptyReplayHandlers,
@@ -527,7 +528,10 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     string,
     { data: (data: string, meta?: PtyDataMeta) => void; replay: (data: string) => void }
   >()
-  const ownedExitHandlers = new Map<string, (code: number) => void>()
+  const ownedExitHandlers = new Map<
+    string,
+    (code: number, lostWorkerRecovery?: TerminalLostWorkerRendererReceipt) => void
+  >()
 
   function unregisterPtyHandlers(id: string): void {
     unregisterPtyDataAndStatusHandlers(id)
@@ -634,7 +638,10 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
 
   function registerPtyExitHandler(id: string): boolean {
     const hadBufferedExit = hasPreHandlerPtyExit(id)
-    const exitHandler = (code: number): void => {
+    const exitHandler = (
+      code: number,
+      lostWorkerRecovery?: TerminalLostWorkerRendererReceipt
+    ): void => {
       if (ptyId !== null && ptyId !== id) {
         // Why: a preserved sleep/reconnect session can report its old exit after this transport already rebound to a replacement PTY.
         unregisterPtyHandlers(id)
@@ -644,6 +651,11 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       connected = false
       ptyId = null
       unregisterPtyHandlers(id)
+      if (lostWorkerRecovery && storedCallbacks.onLostWorkerRecovery) {
+        storedCallbacks.onLostWorkerRecovery(lostWorkerRecovery)
+        onPtyExit?.(id)
+        return
+      }
       storedCallbacks.onExit?.(code)
       storedCallbacks.onDisconnect?.()
       onPtyExit?.(id)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1577,7 +1577,7 @@ export function useTerminalPaneLifecycle({
       }
       if (mgr.getPanes().length <= 1) {
         // Why: route through closeTerminalTab (not raw closeTab) so a pinned tab hits the confirmation guard — this was the one path that silently dropped pinned tabs.
-        closeTerminalTab(tabId)
+        closeTerminalTab(tabId, { reason: 'pane-only' })
       } else {
         mgr.closePane(detail.paneRuntimeId)
         scheduleRuntimeGraphSync()

--- a/src/renderer/src/components/terminal/close-local-terminal-tab-state.ts
+++ b/src/renderer/src/components/terminal/close-local-terminal-tab-state.ts
@@ -11,6 +11,7 @@ export function closeLocalTerminalTabState(
     captureRecentlyClosed?: boolean
     remoteCloseOwnedByHost?: boolean
     localPtyTeardownOwnedExternally?: boolean
+    runtimePtyTeardownOwnedExternally?: boolean
     precomputedRetirementPlan?: TerminalTabRetirementPlan
   }
 ): void {
@@ -24,6 +25,7 @@ export function closeLocalTerminalTabState(
       options?.captureRecentlyClosed !== undefined ||
       options?.remoteCloseOwnedByHost ||
       options?.localPtyTeardownOwnedExternally ||
+      options?.runtimePtyTeardownOwnedExternally ||
       options?.precomputedRetirementPlan
     ) {
       state.closeTab(terminalTabId, options)

--- a/src/renderer/src/components/terminal/terminal-archive-close.ts
+++ b/src/renderer/src/components/terminal/terminal-archive-close.ts
@@ -5,6 +5,10 @@ import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { resolveWorktreeOperationRouteResult } from '@/lib/worktree-operation-route'
 import { useAppStore } from '@/store'
 import { getUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
+import type {
+  TerminalArchiveReason,
+  TerminalLostWorkerRendererReceipt
+} from '../../../../shared/terminal-archive-types'
 
 export type TerminalArchiveCloseReceipt = {
   archiveId: string
@@ -82,4 +86,51 @@ export async function archiveTerminalTabBeforeRetirement(
     snapshotsByLeafId
   })
   return { archiveId: result.archiveId, topologyFingerprint: expectedTopologyFingerprint }
+}
+
+/** Main decides whether this established terminal was a worker before any fallback clears it. */
+export async function handleLostTerminalCandidate(args: {
+  tabId: string
+  worktreeId: string
+  leafId: string
+  reason: Exclude<TerminalArchiveReason, 'user-close'>
+}): Promise<TerminalLostWorkerRendererReceipt> {
+  shutdownBufferCaptures.get(args.tabId)?.({ includeLocalBuffers: true })
+  const state = useAppStore.getState()
+  const routing = resolveWorktreeOperationRouteResult(state, args.worktreeId)
+  const executionHostId =
+    (routing.kind === 'resolved' ? routing.route.executionHostId : null) ??
+    getExecutionHostIdForWorktree(state, args.worktreeId) ??
+    'local'
+  const layout = state.terminalLayoutsByTabId[args.tabId]
+  const snapshotsByLeafId = Object.fromEntries(
+    Object.entries(layout?.buffersByLeafId ?? {}).map(([leafId, buffer]) => [
+      leafId,
+      {
+        buffer,
+        source: 'renderer' as const,
+        truncated: false,
+        byteLength: getUtf8ByteLength(buffer)
+      }
+    ])
+  )
+  const handler = window.api.pty.handleLostTerminalCandidate
+  if (typeof handler !== 'function') {
+    throw new Error('terminal_lost_worker_handoff_unavailable')
+  }
+  try {
+    return await handler({
+      worktreeId: args.worktreeId,
+      tabId: args.tabId,
+      leafId: args.leafId,
+      reason: args.reason,
+      executionHostId,
+      ...(routing.kind === 'resolved' && routing.route.runtimeEnvironmentId
+        ? { runtimeEnvironmentId: routing.route.runtimeEnvironmentId }
+        : {}),
+      snapshotsByLeafId
+    })
+  } catch {
+    return { kind: 'retryable-error', code: 'durability-failed' }
+  }
 }

--- a/src/renderer/src/components/terminal/terminal-archive-close.ts
+++ b/src/renderer/src/components/terminal/terminal-archive-close.ts
@@ -1,0 +1,85 @@
+import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
+import { translate } from '@/i18n/i18n'
+import { buildWorkspaceSessionPayload } from '@/lib/workspace-session'
+import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { resolveWorktreeOperationRouteResult } from '@/lib/worktree-operation-route'
+import { useAppStore } from '@/store'
+import { getUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
+
+export type TerminalArchiveCloseReceipt = {
+  archiveId: string
+  topologyFingerprint: string
+}
+
+export function canArchiveTerminalTabClose(): boolean {
+  return typeof window !== 'undefined' && typeof window.api?.pty?.archiveTerminalTab === 'function'
+}
+
+export function terminalArchiveCloseUnavailableError(): Error {
+  return new Error(
+    translate(
+      'auto.components.terminal.terminal.archive.close.d45b935f2b',
+      'Terminal archive protection is unavailable. Keep this tab open and reload Orca.'
+    )
+  )
+}
+
+function topologyFingerprint(tabId: string): string {
+  const layout = useAppStore.getState().terminalLayoutsByTabId[tabId]
+  return JSON.stringify({
+    root: layout?.root ?? null,
+    ptyIdsByLeafId: Object.entries(layout?.ptyIdsByLeafId ?? {}).sort(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  })
+}
+
+export function isTerminalArchiveTopologyCurrent(
+  tabId: string,
+  expectedFingerprint: string
+): boolean {
+  return topologyFingerprint(tabId) === expectedFingerprint
+}
+
+export async function archiveTerminalTabBeforeRetirement(
+  tabId: string,
+  worktreeId: string
+): Promise<TerminalArchiveCloseReceipt> {
+  // Why: xterm is the only complete SSH scrollback source before the provider is retired.
+  shutdownBufferCaptures.get(tabId)?.({ includeLocalBuffers: true })
+  const state = useAppStore.getState()
+  const routing = resolveWorktreeOperationRouteResult(state, worktreeId)
+  const executionHostId =
+    (routing.kind === 'resolved' ? routing.route.executionHostId : null) ??
+    getExecutionHostIdForWorktree(state, worktreeId) ??
+    'local'
+  const layout = state.terminalLayoutsByTabId[tabId]
+  const expectedTopologyFingerprint = topologyFingerprint(tabId)
+  const snapshotsByLeafId = Object.fromEntries(
+    Object.entries(layout?.buffersByLeafId ?? {}).map(([leafId, buffer]) => [
+      leafId,
+      {
+        buffer,
+        source: 'renderer' as const,
+        truncated: false,
+        byteLength: getUtf8ByteLength(buffer)
+      }
+    ])
+  )
+  const session = {
+    ...buildWorkspaceSessionPayload(state),
+    // Archive capture retains local bytes that ordinary session persistence intentionally drops.
+    terminalLayoutsByTabId: state.terminalLayoutsByTabId
+  }
+  const result = await window.api.pty.archiveTerminalTab({
+    session,
+    worktreeId,
+    tabId,
+    executionHostId,
+    ...(routing.kind === 'resolved' && routing.route.runtimeEnvironmentId
+      ? { runtimeEnvironmentId: routing.route.runtimeEnvironmentId }
+      : {}),
+    snapshotsByLeafId
+  })
+  return { archiveId: result.archiveId, topologyFingerprint: expectedTopologyFingerprint }
+}

--- a/src/renderer/src/components/terminal/terminal-tab-actions-kill-all.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions-kill-all.test.ts
@@ -81,10 +81,10 @@ describe('closeTerminalTab kill-all routing', () => {
       })
     )
 
-    closeTerminalTab('terminal-1', { force: true })
+    closeTerminalTab('terminal-1', { force: true, reason: 'cleanup' })
 
     expect(requestPinnedTabCloseConfirm).not.toHaveBeenCalled()
-    expect(closeTab).toHaveBeenCalledWith('terminal-1', { reason: undefined })
+    expect(closeTab).toHaveBeenCalledWith('terminal-1', { reason: 'cleanup' })
     expect(closeUnifiedTab).not.toHaveBeenCalled()
   })
 
@@ -94,9 +94,9 @@ describe('closeTerminalTab kill-all routing', () => {
     })
     getStateMock.mockReturnValue(state)
 
-    closeTerminalTab('terminal-1', { force: true })
+    closeTerminalTab('terminal-1', { force: true, reason: 'cleanup' })
 
-    expect(state.closeTab).toHaveBeenCalledWith('terminal-1')
+    expect(state.closeTab).toHaveBeenCalledWith('terminal-1', { reason: 'cleanup' })
     expect(state.setActiveFile).toHaveBeenCalledWith('editor-1')
     expect(state.setActiveTabType).toHaveBeenCalledWith('editor')
     expect(state.closeFile).not.toHaveBeenCalled()
@@ -111,8 +111,9 @@ describe('closeTerminalTab kill-all routing', () => {
     })
     getStateMock.mockReturnValue(state)
 
-    closeTerminalTab('terminal-1', { force: true })
+    closeTerminalTab('terminal-1', { force: true, reason: 'cleanup' })
 
+    expect(state.closeTab).toHaveBeenCalledWith('terminal-1', { reason: 'cleanup' })
     expect(state.setActiveBrowserTab).toHaveBeenCalledWith('browser-1')
     expect(state.setActiveTabType).toHaveBeenCalledWith('browser')
     expect(state.closeBrowserTab).not.toHaveBeenCalled()
@@ -124,8 +125,9 @@ describe('closeTerminalTab kill-all routing', () => {
     const state = baseState()
     getStateMock.mockReturnValue(state)
 
-    closeTerminalTab('terminal-1', { force: true })
+    closeTerminalTab('terminal-1', { force: true, reason: 'cleanup' })
 
+    expect(state.closeTab).toHaveBeenCalledWith('terminal-1', { reason: 'cleanup' })
     expect(state.setActiveWorktree).toHaveBeenCalledWith(null)
     expect(state.setActiveFile).not.toHaveBeenCalled()
     expect(state.setActiveBrowserTab).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
@@ -1,25 +1,32 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
-  activateWebRuntimeSessionTabMock,
   closeWebRuntimeSessionTabMock,
-  createWebRuntimeSessionTerminalMock,
   getLatestWebSessionTabsPublicationEpochMock,
   getStateMock,
   isWebRuntimeSessionActiveMock,
   isWebTerminalSurfaceTabIdMock,
   resolveHostSessionTabIdForWebSessionTabMock,
-  toHostSessionTabIdMock
+  toHostSessionTabIdMock,
+  archiveTerminalTabBeforeRetirementMock,
+  canArchiveTerminalTabCloseMock,
+  isTerminalArchiveTopologyCurrentMock,
+  terminalArchiveCloseUnavailableErrorMock
 } = vi.hoisted(() => ({
-  activateWebRuntimeSessionTabMock: vi.fn(),
   closeWebRuntimeSessionTabMock: vi.fn(),
-  createWebRuntimeSessionTerminalMock: vi.fn(),
   getLatestWebSessionTabsPublicationEpochMock: vi.fn(() => 'epoch-1'),
   getStateMock: vi.fn(),
   isWebRuntimeSessionActiveMock: vi.fn(),
   isWebTerminalSurfaceTabIdMock: vi.fn(() => false),
   resolveHostSessionTabIdForWebSessionTabMock: vi.fn<() => string | null>(() => null),
-  toHostSessionTabIdMock: vi.fn((tabId: string) => tabId)
+  toHostSessionTabIdMock: vi.fn((tabId: string) => tabId),
+  archiveTerminalTabBeforeRetirementMock: vi.fn(),
+  canArchiveTerminalTabCloseMock: vi.fn(() => false),
+  isTerminalArchiveTopologyCurrentMock: vi.fn(() => true),
+  terminalArchiveCloseUnavailableErrorMock: vi.fn(
+    () =>
+      new Error('Terminal archive protection is unavailable. Keep this tab open and reload Orca.')
+  )
 }))
 
 vi.mock('@/store', () => ({
@@ -29,9 +36,7 @@ vi.mock('@/store', () => ({
 }))
 
 vi.mock('@/runtime/web-runtime-session', () => ({
-  activateWebRuntimeSessionTab: activateWebRuntimeSessionTabMock,
   closeWebRuntimeSessionTab: closeWebRuntimeSessionTabMock,
-  createWebRuntimeSessionTerminal: createWebRuntimeSessionTerminalMock,
   isWebRuntimeSessionActive: isWebRuntimeSessionActiveMock,
   isWebTerminalSurfaceTabId: isWebTerminalSurfaceTabIdMock,
   toHostSessionTabId: toHostSessionTabIdMock
@@ -42,138 +47,14 @@ vi.mock('@/runtime/web-session-tabs-sync', () => ({
   resolveHostSessionTabIdForWebSessionTab: resolveHostSessionTabIdForWebSessionTabMock
 }))
 
-import {
-  closeOtherTerminalTabs,
-  closeTerminalTab,
-  closeTerminalTabsToRight
-} from './terminal-tab-actions'
-import { createNewTerminalTab } from './terminal-tab-create'
+vi.mock('./terminal-archive-close', () => ({
+  archiveTerminalTabBeforeRetirement: archiveTerminalTabBeforeRetirementMock,
+  canArchiveTerminalTabClose: canArchiveTerminalTabCloseMock,
+  isTerminalArchiveTopologyCurrent: isTerminalArchiveTopologyCurrentMock,
+  terminalArchiveCloseUnavailableError: terminalArchiveCloseUnavailableErrorMock
+}))
 
-describe('createNewTerminalTab', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    createWebRuntimeSessionTerminalMock.mockResolvedValue(true)
-    isWebRuntimeSessionActiveMock.mockReturnValue(false)
-  })
-
-  it('creates a local terminal tab outside the paired web runtime', () => {
-    const createTab = vi.fn(() => ({ id: 'tab-1' }))
-    const setActiveTabType = vi.fn()
-    const setTabBarOrder = vi.fn()
-    getStateMock
-      .mockReturnValueOnce({
-        settings: { activeRuntimeEnvironmentId: null },
-        createTab,
-        setActiveTabType,
-        setTabBarOrder
-      })
-      .mockReturnValueOnce({
-        tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
-        openFiles: [],
-        tabBarOrderByWorktree: {},
-        setTabBarOrder
-      })
-
-    createNewTerminalTab('wt-1', 'zsh')
-
-    expect(createTab).toHaveBeenCalledWith('wt-1', undefined, 'zsh', undefined)
-    expect(setActiveTabType).toHaveBeenCalledWith('terminal')
-    expect(setTabBarOrder).toHaveBeenCalledWith('wt-1', ['tab-1'])
-    expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
-  })
-
-  it('delegates terminal creation to the host runtime in paired web clients', () => {
-    const createTab = vi.fn(() => ({ id: 'tab-1' }))
-    const setActiveTabType = vi.fn()
-    isWebRuntimeSessionActiveMock.mockReturnValue(true)
-    getStateMock.mockReturnValue({
-      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
-      createTab,
-      setActiveTabType
-    })
-
-    createNewTerminalTab('wt-1', 'pwsh')
-
-    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
-      worktreeId: 'wt-1',
-      environmentId: 'web-runtime',
-      command: 'pwsh',
-      activate: true
-    })
-    expect(createTab).not.toHaveBeenCalled()
-    expect(setActiveTabType).not.toHaveBeenCalled()
-  })
-
-  it('delegates terminal creation to the explicit owner runtime when another runtime is focused', () => {
-    const createTab = vi.fn(() => ({ id: 'tab-1' }))
-    const setActiveTabType = vi.fn()
-    isWebRuntimeSessionActiveMock.mockReturnValue(true)
-    getStateMock.mockReturnValue({
-      settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
-      repos: [{ id: 'repo-1', executionHostId: 'runtime:owner-runtime', connectionId: null }],
-      worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }] },
-      createTab,
-      setActiveTabType
-    })
-
-    createNewTerminalTab('wt-1', 'pwsh')
-
-    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
-      worktreeId: 'wt-1',
-      environmentId: 'owner-runtime',
-      command: 'pwsh',
-      activate: true
-    })
-    expect(createTab).not.toHaveBeenCalled()
-  })
-
-  it('creates local terminal tabs with a requested startup cwd', () => {
-    const createTab = vi.fn(() => ({ id: 'tab-1' }))
-    const setActiveTabType = vi.fn()
-    const setTabBarOrder = vi.fn()
-    getStateMock
-      .mockReturnValueOnce({
-        settings: { activeRuntimeEnvironmentId: null },
-        createTab,
-        setActiveTabType,
-        setTabBarOrder
-      })
-      .mockReturnValueOnce({
-        tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
-        openFiles: [],
-        tabBarOrderByWorktree: {},
-        setTabBarOrder
-      })
-
-    createNewTerminalTab('wt-1', undefined, { startupCwd: '/repo/packages/app' })
-
-    expect(createTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
-      startupCwd: '/repo/packages/app'
-    })
-    expect(setActiveTabType).toHaveBeenCalledWith('terminal')
-  })
-
-  it('delegates requested startup cwd to host runtime terminals', () => {
-    const createTab = vi.fn(() => ({ id: 'tab-1' }))
-    isWebRuntimeSessionActiveMock.mockReturnValue(true)
-    getStateMock.mockReturnValue({
-      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
-      createTab,
-      setActiveTabType: vi.fn()
-    })
-
-    createNewTerminalTab('wt-1', undefined, { startupCwd: '/repo/packages/app' })
-
-    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
-      worktreeId: 'wt-1',
-      environmentId: 'web-runtime',
-      command: undefined,
-      cwd: '/repo/packages/app',
-      activate: true
-    })
-    expect(createTab).not.toHaveBeenCalled()
-  })
-})
+import { closeTerminalTab } from './terminal-tab-actions'
 
 describe('closeTerminalTab', () => {
   beforeEach(() => {
@@ -181,9 +62,15 @@ describe('closeTerminalTab', () => {
     isWebRuntimeSessionActiveMock.mockReturnValue(false)
     resolveHostSessionTabIdForWebSessionTabMock.mockReturnValue(null)
     isWebTerminalSurfaceTabIdMock.mockReturnValue(false)
+    canArchiveTerminalTabCloseMock.mockReturnValue(false)
+    isTerminalArchiveTopologyCurrentMock.mockReturnValue(true)
+    closeWebRuntimeSessionTabMock.mockResolvedValue({
+      closed: true,
+      archiveId: '11111111-1111-4111-8111-111111111111'
+    })
   })
 
-  it('delegates host-backed terminal closes to the paired runtime', () => {
+  it('delegates host-backed terminal closes to the paired runtime after its archive receipt', async () => {
     const closeTab = vi.fn()
     isWebRuntimeSessionActiveMock.mockReturnValue(true)
     resolveHostSessionTabIdForWebSessionTabMock.mockReturnValue('host-tab-1')
@@ -200,16 +87,110 @@ describe('closeTerminalTab', () => {
 
     closeTerminalTab('local-tab-1')
 
-    expect(closeTab).toHaveBeenCalledWith('local-tab-1', {
-      reason: undefined,
-      remoteCloseOwnedByHost: true
-    })
+    await vi.waitFor(() =>
+      expect(closeTab).toHaveBeenCalledWith('local-tab-1', {
+        reason: undefined,
+        remoteCloseOwnedByHost: true
+      })
+    )
     expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
       tabId: 'host-tab-1',
       environmentId: 'web-runtime',
       reason: 'user'
     })
+  })
+
+  it('archives a user close before retirement and suppresses the duplicate recent-close snapshot', async () => {
+    const closeTab = vi.fn()
+    let resolveArchive: (receipt: {
+      archiveId: string
+      topologyFingerprint: string
+    }) => void = () => {}
+    canArchiveTerminalTabCloseMock.mockReturnValue(true)
+    archiveTerminalTabBeforeRetirementMock.mockReturnValue(
+      new Promise<{ archiveId: string; topologyFingerprint: string }>((resolve) => {
+        resolveArchive = resolve
+      })
+    )
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: null },
+      repos: [{ id: 'repo-1', executionHostId: 'local', connectionId: null }],
+      worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }] },
+      tabsByWorktree: {
+        'wt-1': [
+          { id: 'local-tab-1', ptyId: null },
+          { id: 'local-tab-2', ptyId: null }
+        ]
+      },
+      unifiedTabsByWorktree: {},
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: {},
+      lastKnownRelayPtyIdByTabId: {},
+      deferredSshSessionIdsByTabId: {},
+      pendingReconnectPtyIdByTabId: {},
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'local-tab-1',
+      openFiles: [],
+      closeTab,
+      setActiveTab: vi.fn()
+    })
+
+    closeTerminalTab('local-tab-1')
+
+    expect(archiveTerminalTabBeforeRetirementMock).toHaveBeenCalledWith('local-tab-1', 'wt-1')
+    expect(closeTab).not.toHaveBeenCalled()
+    resolveArchive({
+      archiveId: '11111111-1111-4111-8111-111111111111',
+      topologyFingerprint: 'stable'
+    })
+    await vi.waitFor(() =>
+      expect(closeTab).toHaveBeenCalledWith(
+        'local-tab-1',
+        expect.objectContaining({ captureRecentlyClosed: false })
+      )
+    )
+  })
+
+  it('keeps the live tab when teardown fails after archiving', async () => {
+    const closeTab = vi.fn()
+    const onError = vi.fn()
+    canArchiveTerminalTabCloseMock.mockReturnValue(true)
+    archiveTerminalTabBeforeRetirementMock.mockResolvedValue({
+      archiveId: '11111111-1111-4111-8111-111111111111',
+      topologyFingerprint: 'stable'
+    })
+    vi.stubGlobal('window', {
+      api: { pty: { kill: vi.fn().mockRejectedValue(new Error('SSH disconnected')) } }
+    })
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: null },
+      repos: [{ id: 'repo-1', executionHostId: 'local', connectionId: null }],
+      worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }] },
+      tabsByWorktree: {
+        'wt-1': [
+          { id: 'local-tab-1', ptyId: 'local-pty-1' },
+          { id: 'local-tab-2', ptyId: null }
+        ]
+      },
+      unifiedTabsByWorktree: {},
+      ptyIdsByTabId: { 'local-tab-1': ['local-pty-1'] },
+      terminalLayoutsByTabId: {},
+      lastKnownRelayPtyIdByTabId: {},
+      deferredSshSessionIdsByTabId: {},
+      pendingReconnectPtyIdByTabId: {},
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'local-tab-1',
+      openFiles: [],
+      closeTab,
+      setActiveTab: vi.fn()
+    })
+
+    closeTerminalTab('local-tab-1', { onError })
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(expect.any(Error)))
+    expect(closeTab).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
   })
 
   it('lets the HUB snapshot adjudicate a stream exit', () => {
@@ -262,7 +243,7 @@ describe('closeTerminalTab', () => {
     expect(closeWebRuntimeSessionTabMock).not.toHaveBeenCalled()
   })
 
-  it('sends hostCloseReason on the wire without tagging the local close reason', () => {
+  it('sends hostCloseReason on the wire without tagging the local close reason', async () => {
     // Why: parked-tab lifecycle closes must reach the host as 'pty-exit' so it
     // can adjudicate them, while local guards keyed off `reason` still apply.
     const closeTab = vi.fn()
@@ -284,10 +265,12 @@ describe('closeTerminalTab', () => {
       lifecyclePtyId: 'remote:web-runtime@@term-1'
     })
 
-    expect(closeTab).toHaveBeenCalledWith('local-tab-1', {
-      reason: undefined,
-      remoteCloseOwnedByHost: true
-    })
+    await vi.waitFor(() =>
+      expect(closeTab).toHaveBeenCalledWith('local-tab-1', {
+        reason: undefined,
+        remoteCloseOwnedByHost: true
+      })
+    )
     expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
       tabId: 'host-tab-1',
@@ -362,7 +345,7 @@ describe('closeTerminalTab', () => {
     expect(closeWebRuntimeSessionTabMock).not.toHaveBeenCalled()
   })
 
-  it('closes unified-only terminal tabs when tabsByWorktree is missing the row', () => {
+  it('closes unified-only terminal tabs for cleanup when tabsByWorktree is missing the row', () => {
     const closeTab = vi.fn()
     const closeUnifiedTab = vi.fn()
     getStateMock.mockReturnValue({
@@ -396,9 +379,9 @@ describe('closeTerminalTab', () => {
       setActiveWorktree: vi.fn()
     })
 
-    closeTerminalTab('terminal-entity-1')
+    closeTerminalTab('terminal-entity-1', { reason: 'cleanup' })
 
-    expect(closeTab).toHaveBeenCalledWith('terminal-entity-1', { reason: undefined })
+    expect(closeTab).toHaveBeenCalledWith('terminal-entity-1', { reason: 'cleanup' })
     expect(closeUnifiedTab).not.toHaveBeenCalled()
   })
 
@@ -451,14 +434,14 @@ describe('closeTerminalTab', () => {
       setActiveWorktree: vi.fn()
     })
 
-    closeTerminalTab('terminal-entity-1')
+    closeTerminalTab('terminal-entity-1', { reason: 'cleanup' })
 
     expect(setActiveTab).toHaveBeenCalledWith('terminal-entity-2')
-    expect(closeTab).toHaveBeenCalledWith('terminal-entity-1', { reason: undefined })
+    expect(closeTab).toHaveBeenCalledWith('terminal-entity-1', { reason: 'cleanup' })
     expect(closeUnifiedTab).not.toHaveBeenCalled()
   })
 
-  it('routes closes on a remote worktree to the host even when the local→host map has no entry', () => {
+  it('routes closes on a remote worktree to the host even when the local→host map has no entry', async () => {
     // Why: regression for the close-reappear bug. On a remote-owned worktree the
     // tab is host-authoritative; when the map has no entry (e.g. a plain-UUID host
     // tab id) the close must still reach the host via the decoded id, or the
@@ -480,10 +463,12 @@ describe('closeTerminalTab', () => {
 
     closeTerminalTab('plain-uuid-tab')
 
-    expect(closeTab).toHaveBeenCalledWith('plain-uuid-tab', {
-      reason: undefined,
-      remoteCloseOwnedByHost: true
-    })
+    await vi.waitFor(() =>
+      expect(closeTab).toHaveBeenCalledWith('plain-uuid-tab', {
+        reason: undefined,
+        remoteCloseOwnedByHost: true
+      })
+    )
     expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
       worktreeId: 'wt-1',
       tabId: 'plain-uuid-tab',
@@ -565,12 +550,12 @@ describe('closeTerminalTab', () => {
       })
     )
 
-    closeTerminalTab('pinned-entity-1', { onClosed })
+    closeTerminalTab('pinned-entity-1', { onClosed, reason: 'cleanup' })
     expect(onClosed).not.toHaveBeenCalled()
     const { onConfirm } = requestPinnedTabCloseConfirm.mock.calls[0][0] as { onConfirm: () => void }
     onConfirm()
 
-    expect(closeTab).toHaveBeenCalledWith('pinned-entity-1', { reason: undefined })
+    expect(closeTab).toHaveBeenCalledWith('pinned-entity-1', { reason: 'cleanup' })
     expect(closeUnifiedTab).not.toHaveBeenCalled()
     expect(onClosed).toHaveBeenCalledTimes(1)
   })
@@ -650,10 +635,10 @@ describe('closeTerminalTab', () => {
       })
     )
 
-    closeTerminalTab('pinned-entity-1')
+    closeTerminalTab('pinned-entity-1', { reason: 'cleanup' })
 
     expect(requestPinnedTabCloseConfirm).not.toHaveBeenCalled()
-    expect(closeTab).toHaveBeenCalledWith('pinned-entity-1', { reason: undefined })
+    expect(closeTab).toHaveBeenCalledWith('pinned-entity-1', { reason: 'cleanup' })
     expect(closeUnifiedTab).not.toHaveBeenCalled()
   })
 
@@ -694,12 +679,15 @@ describe('closeTerminalTab', () => {
       setActiveTab: vi.fn()
     })
 
-    closeTerminalTab('tab-1', { captureRecentlyClosed: false })
+    closeTerminalTab('tab-1', { reason: 'pty-exit', captureRecentlyClosed: false })
 
-    expect(closeTab).toHaveBeenCalledWith('tab-1', { captureRecentlyClosed: false })
+    expect(closeTab).toHaveBeenCalledWith('tab-1', {
+      reason: 'pty-exit',
+      captureRecentlyClosed: false
+    })
   })
 
-  it('keeps the plain user-close call shape when no close options are given', () => {
+  it('keeps a user tab live when archive capability is unavailable', () => {
     const closeTab = vi.fn()
     getStateMock.mockReturnValue({
       settings: { activeRuntimeEnvironmentId: null },
@@ -715,92 +703,10 @@ describe('closeTerminalTab', () => {
       setActiveTab: vi.fn()
     })
 
-    closeTerminalTab('tab-1')
+    const onError = vi.fn()
+    closeTerminalTab('tab-1', { onError })
 
-    expect(closeTab).toHaveBeenCalledWith('tab-1')
-  })
-})
-
-describe('closeOtherTerminalTabs', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    isWebRuntimeSessionActiveMock.mockReturnValue(false)
-  })
-
-  it('delegates other terminal closes to the host runtime in paired web clients', () => {
-    const setActiveTab = vi.fn()
-    const closeTab = vi.fn()
-    isWebRuntimeSessionActiveMock.mockReturnValue(true)
-    getStateMock.mockReturnValue({
-      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
-      tabsByWorktree: {
-        'wt-1': [{ id: 'keep' }, { id: 'close-a' }, { id: 'close-b' }]
-      },
-      setActiveTab,
-      closeTab
-    })
-
-    closeOtherTerminalTabs('keep', 'wt-1')
-
-    expect(setActiveTab).toHaveBeenCalledWith('keep')
-    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledTimes(2)
-    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
-      worktreeId: 'wt-1',
-      tabId: 'close-a',
-      environmentId: 'web-runtime',
-      reason: 'user'
-    })
-    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
-      worktreeId: 'wt-1',
-      tabId: 'close-b',
-      environmentId: 'web-runtime',
-      reason: 'user'
-    })
-    expect(closeTab).toHaveBeenCalledTimes(2)
-    expect(closeTab).toHaveBeenNthCalledWith(1, 'close-a', { remoteCloseOwnedByHost: true })
-    expect(closeTab).toHaveBeenNthCalledWith(2, 'close-b', { remoteCloseOwnedByHost: true })
-  })
-})
-
-describe('closeTerminalTabsToRight', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    isWebRuntimeSessionActiveMock.mockReturnValue(false)
-  })
-
-  it('delegates terminal tabs to the host while still closing local editor tabs to the right', () => {
-    const closeTab = vi.fn()
-    const closeFile = vi.fn()
-    isWebRuntimeSessionActiveMock.mockReturnValue(true)
-    getStateMock.mockReturnValue({
-      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
-      tabsByWorktree: {
-        'wt-1': [{ id: 'term-a' }, { id: 'term-b' }, { id: 'term-c' }]
-      },
-      openFiles: [{ id: 'file-b', worktreeId: 'wt-1' }],
-      tabBarOrderByWorktree: { 'wt-1': ['term-a', 'file-b', 'term-b', 'term-c'] },
-      closeTab,
-      closeFile
-    })
-
-    closeTerminalTabsToRight('term-a', 'wt-1')
-
-    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledTimes(2)
-    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
-      worktreeId: 'wt-1',
-      tabId: 'term-b',
-      environmentId: 'web-runtime',
-      reason: 'user'
-    })
-    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
-      worktreeId: 'wt-1',
-      tabId: 'term-c',
-      environmentId: 'web-runtime',
-      reason: 'user'
-    })
-    expect(closeFile).toHaveBeenCalledWith('file-b')
-    expect(closeTab).toHaveBeenCalledTimes(2)
-    expect(closeTab).toHaveBeenNthCalledWith(1, 'term-b', { remoteCloseOwnedByHost: true })
-    expect(closeTab).toHaveBeenNthCalledWith(2, 'term-c', { remoteCloseOwnedByHost: true })
+    expect(closeTab).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledWith(expect.any(Error))
   })
 })

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -1,7 +1,6 @@
+import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
-import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
 import {
-  activateWebRuntimeSessionTab,
   closeWebRuntimeSessionTab,
   isWebRuntimeSessionActive,
   toHostSessionTabId
@@ -18,6 +17,18 @@ import type {
 } from '@/store/slices/terminal-tab-retirement'
 import { closeLocalTerminalTabState } from './close-local-terminal-tab-state'
 import { getTerminalIncarnationHandle } from './terminal-close-incarnation'
+import { awaitTerminalTabClose } from './terminal-tab-close-completion'
+import { isPinnedVisibleTerminalTab } from './terminal-tab-pin-visibility'
+import {
+  reportTerminalCloseError,
+  retireArchivedTerminalPtys
+} from './terminal-tab-retirement-transaction'
+import {
+  archiveTerminalTabBeforeRetirement,
+  canArchiveTerminalTabClose,
+  isTerminalArchiveTopologyCurrent,
+  terminalArchiveCloseUnavailableError
+} from './terminal-archive-close'
 import {
   getWorktreeTerminalTabIds,
   resolveTerminalCloseTarget,
@@ -26,21 +37,6 @@ import {
 } from './terminal-close-target'
 export type { PrecomputedTerminalCloseState } from './terminal-close-target'
 export { closeOtherTerminalTabs, closeTerminalTabsToRight } from './terminal-tab-bulk-actions'
-
-type TerminalTabActionState = ReturnType<typeof useAppStore.getState>
-
-function isPinnedVisibleTab(
-  state: TerminalTabActionState,
-  worktreeId: string,
-  visibleId: string
-): boolean {
-  return (
-    (state.unifiedTabsByWorktree?.[worktreeId] ?? []).some(
-      (tab) => (tab.id === visibleId || tab.entityId === visibleId) && tab.isPinned
-    ) ?? false
-  )
-}
-
 export function closeTerminalTab(
   tabId: string,
   options?: {
@@ -55,10 +51,15 @@ export function closeTerminalTab(
     lifecyclePtyId?: string
     captureRecentlyClosed?: boolean
     localPtyTeardownOwnedExternally?: boolean
+    runtimePtyTeardownOwnedExternally?: boolean
     precomputedRetirementPlan?: TerminalTabRetirementPlan
     precomputedCloseState?: PrecomputedTerminalCloseState
-    onClosed?: () => void
+    /** Internal re-entry after the archive durability boundary succeeds. */
+    archiveCommitted?: boolean
+    archiveId?: string
+    onClosed?: (archiveId?: string) => void
     onCancel?: () => void
+    onError?: (error: Error) => void
   }
 ): void {
   const state = useAppStore.getState()
@@ -69,7 +70,7 @@ export function closeTerminalTab(
   )
   const target = resolveTerminalCloseTarget(state, tabId, precomputedCloseState)
   if (!target) {
-    options?.onClosed?.()
+    options?.onClosed?.(options?.archiveId)
     return
   }
   const { worktreeId: owningWorktreeId, terminalTabId } = target
@@ -78,13 +79,12 @@ export function closeTerminalTab(
     options?.onCancel?.()
     return
   }
-
   // Why: a pinned tab routes through the confirmation guard instead of closing
   // outright. `force` is the post-confirmation re-entry, which skips the guard.
   if (
     options?.reason !== 'pty-exit' &&
     !options?.force &&
-    isPinnedVisibleTab(state, owningWorktreeId, terminalTabId)
+    isPinnedVisibleTerminalTab(owningWorktreeId, terminalTabId)
   ) {
     // Why: background lifecycle callers cannot safely wait on a modal whose
     // owner may be unattended; reject pinned tabs without bypassing the guard.
@@ -100,7 +100,6 @@ export function closeTerminalTab(
     })
     return
   }
-
   const runtimeEnvironmentId = worktreeRoute.runtimeEnvironmentId
   if (runtimeEnvironmentId && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
     if (options?.reason === 'pty-exit') {
@@ -131,22 +130,28 @@ export function closeTerminalTab(
       wireReason === 'user'
         ? null
         : getLatestWebSessionTabsPublicationEpoch(runtimeEnvironmentId, owningWorktreeId)
-    // Why: prune local mirrors immediately so close feels responsive while the
-    // host session snapshot catches up.
-    closeLocalTerminalTabState(terminalTabId, {
-      reason: options?.reason,
-      ...(options?.captureRecentlyClosed !== undefined
-        ? { captureRecentlyClosed: options.captureRecentlyClosed }
-        : {}),
-      remoteCloseOwnedByHost: true,
-      ...(options?.localPtyTeardownOwnedExternally
-        ? { localPtyTeardownOwnedExternally: true }
-        : {}),
-      ...(options?.precomputedRetirementPlan
-        ? { precomputedRetirementPlan: options.precomputedRetirementPlan }
-        : {})
-    })
-    void closeWebRuntimeSessionTab({
+    // Archive-capable clients wait for the host durability receipt; older preloads stay optimistic.
+    const closeLocalMirror = (archiveId = options?.archiveId): void => {
+      closeLocalTerminalTabState(terminalTabId, {
+        reason: options?.reason,
+        ...(options?.captureRecentlyClosed !== undefined
+          ? { captureRecentlyClosed: options.captureRecentlyClosed }
+          : {}),
+        remoteCloseOwnedByHost: true,
+        ...(options?.localPtyTeardownOwnedExternally
+          ? { localPtyTeardownOwnedExternally: true }
+          : {}),
+        ...(options?.precomputedRetirementPlan
+          ? { precomputedRetirementPlan: options.precomputedRetirementPlan }
+          : {})
+      })
+      options?.onClosed?.(archiveId)
+    }
+    if (options?.reason === 'pane-only') {
+      closeLocalMirror()
+      return
+    }
+    const hostClose = closeWebRuntimeSessionTab({
       worktreeId: owningWorktreeId,
       tabId: hostBackedTabId,
       environmentId: runtimeEnvironmentId,
@@ -160,10 +165,87 @@ export function closeTerminalTab(
           }
         : {})
     })
-    options?.onClosed?.()
+    if (wireReason === 'user') {
+      void Promise.resolve(hostClose)
+        .then((receipt) => {
+          if (!receipt.closed || receipt.refused || !receipt.archiveId) {
+            throw new Error(
+              translate(
+                'auto.components.terminal.terminal.tab.actions.a4f4c513c5',
+                'Terminal archive protection did not receive a durable host receipt.'
+              )
+            )
+          }
+          closeLocalMirror(receipt.archiveId)
+        })
+        .catch((error: unknown) => {
+          const archiveError =
+            error instanceof Error ? error : new Error('terminal_tab_close_failed')
+          reportTerminalCloseError(archiveError, options?.onError, () =>
+            closeTerminalTab(tabId, options)
+          )
+        })
+      return
+    }
+    void Promise.resolve(hostClose)
+      .then((receipt) => {
+        if (!receipt.closed || receipt.refused) {
+          throw new Error(
+            translate(
+              'auto.components.terminal.terminal.tab.actions.fddc720203',
+              'The execution host refused to close this tab.'
+            )
+          )
+        }
+        closeLocalMirror()
+      })
+      .catch((error: unknown) => {
+        const closeError = error instanceof Error ? error : new Error('terminal_tab_close_failed')
+        reportTerminalCloseError(closeError, options?.onError, () =>
+          closeTerminalTab(tabId, options)
+        )
+      })
     return
   }
-
+  const archiveReason = options?.reason ?? options?.hostCloseReason ?? 'user'
+  if (!options?.archiveCommitted && archiveReason === 'user') {
+    if (!canArchiveTerminalTabClose()) {
+      reportTerminalCloseError(terminalArchiveCloseUnavailableError(), options?.onError, () =>
+        closeTerminalTab(tabId, options)
+      )
+      return
+    }
+    void archiveTerminalTabBeforeRetirement(terminalTabId, owningWorktreeId)
+      .then(async (receipt) => {
+        if (!isTerminalArchiveTopologyCurrent(terminalTabId, receipt.topologyFingerprint)) {
+          throw new Error(
+            translate(
+              'auto.components.terminal.terminal.tab.actions.43cd15a02d',
+              'Terminal layout changed while archiving. Retry close to archive the latest panes.'
+            )
+          )
+        }
+        const retirementPlan = await retireArchivedTerminalPtys(terminalTabId, owningWorktreeId)
+        closeTerminalTab(tabId, {
+          ...options,
+          archiveCommitted: true,
+          archiveId: receipt.archiveId,
+          captureRecentlyClosed: false,
+          precomputedCloseState: undefined,
+          // The state transition follows successful provider teardown; it must not issue a second kill.
+          localPtyTeardownOwnedExternally: true,
+          runtimePtyTeardownOwnedExternally: true,
+          precomputedRetirementPlan: retirementPlan
+        })
+      })
+      .catch((error: unknown) => {
+        const archiveError = error instanceof Error ? error : new Error('terminal_archive_failed')
+        reportTerminalCloseError(archiveError, options?.onError, () =>
+          closeTerminalTab(tabId, options)
+        )
+      })
+    return
+  }
   const currentTerminalTabIds = precomputedCloseState
     ? null
     : getWorktreeTerminalTabIds(state, owningWorktreeId)
@@ -177,6 +259,9 @@ export function closeTerminalTab(
         : {}),
       ...(options?.localPtyTeardownOwnedExternally
         ? { localPtyTeardownOwnedExternally: true }
+        : {}),
+      ...(options?.runtimePtyTeardownOwnedExternally
+        ? { runtimePtyTeardownOwnedExternally: true }
         : {}),
       ...(options?.precomputedRetirementPlan
         ? { precomputedRetirementPlan: options.precomputedRetirementPlan }
@@ -200,10 +285,9 @@ export function closeTerminalTab(
         }
       }
     }
-    options?.onClosed?.()
+    options?.onClosed?.(options?.archiveId)
     return
   }
-
   if (state.activeWorktreeId === owningWorktreeId && terminalTabId === state.activeTabId) {
     const currentIndex = currentTerminalTabIds?.indexOf(terminalTabId) ?? -1
     const nextTabId = precomputedCloseState
@@ -220,44 +304,21 @@ export function closeTerminalTab(
       ? { captureRecentlyClosed: options.captureRecentlyClosed }
       : {}),
     ...(options?.localPtyTeardownOwnedExternally ? { localPtyTeardownOwnedExternally: true } : {}),
+    ...(options?.runtimePtyTeardownOwnedExternally
+      ? { runtimePtyTeardownOwnedExternally: true }
+      : {}),
     ...(options?.precomputedRetirementPlan
       ? { precomputedRetirementPlan: options.precomputedRetirementPlan }
       : {})
   })
-  options?.onClosed?.()
+  options?.onClosed?.(options?.archiveId)
 }
 
-export function activateTerminalTab(tabId: string): void {
-  const s = useAppStore.getState()
-  const owningWorktreeId =
-    Object.entries(s.tabsByWorktree).find(([, worktreeTabs]) =>
-      worktreeTabs.some((tab) => tab.id === tabId)
-    )?.[0] ?? null
-  const worktreeRoute = resolveTerminalWorktreeRoute(s, owningWorktreeId)
-  if (!worktreeRoute) {
-    return
-  }
-  const runtimeEnvironmentId = worktreeRoute.runtimeEnvironmentId
-  if (owningWorktreeId && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
-    // Why: activation needs to update the host's active tab as well as the
-    // local optimistic state, otherwise the next host snapshot snaps back.
-    void activateWebRuntimeSessionTab({
-      worktreeId: owningWorktreeId,
-      tabId,
-      environmentId: runtimeEnvironmentId
-    })
-  }
-  s.setActiveTab(tabId)
-  s.setActiveTabType('terminal')
+export function closeTerminalTabAsync(
+  tabId: string,
+  options?: Parameters<typeof closeTerminalTab>[1]
+): Promise<void> {
+  return awaitTerminalTabClose(closeTerminalTab, tabId, options)
 }
 
-export function toggleTerminalPaneExpand(tabId: string): void {
-  useAppStore.getState().setActiveTab(tabId)
-  requestAnimationFrame(() => {
-    window.dispatchEvent(
-      new CustomEvent(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, {
-        detail: { tabId }
-      })
-    )
-  })
-}
+export { activateTerminalTab, toggleTerminalPaneExpand } from './terminal-tab-activation'

--- a/src/renderer/src/components/terminal/terminal-tab-activation.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-activation.ts
@@ -1,0 +1,39 @@
+import { TOGGLE_TERMINAL_PANE_EXPAND_EVENT } from '@/constants/terminal'
+import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
+import { useAppStore } from '@/store'
+import {
+  activateWebRuntimeSessionTab,
+  isWebRuntimeSessionActive
+} from '@/runtime/web-runtime-session'
+
+export function activateTerminalTab(tabId: string): void {
+  const state = useAppStore.getState()
+  const owningWorktreeId =
+    Object.entries(state.tabsByWorktree).find(([, tabs]) =>
+      tabs.some((tab) => tab.id === tabId)
+    )?.[0] ?? null
+  const route = resolveTerminalWorktreeRoute(state, owningWorktreeId)
+  if (!route) {
+    return
+  }
+  if (owningWorktreeId && isWebRuntimeSessionActive(route.runtimeEnvironmentId)) {
+    void activateWebRuntimeSessionTab({
+      worktreeId: owningWorktreeId,
+      tabId,
+      environmentId: route.runtimeEnvironmentId
+    })
+  }
+  state.setActiveTab(tabId)
+  state.setActiveTabType('terminal')
+}
+
+export function toggleTerminalPaneExpand(tabId: string): void {
+  useAppStore.getState().setActiveTab(tabId)
+  requestAnimationFrame(() => {
+    window.dispatchEvent(
+      new CustomEvent(TOGGLE_TERMINAL_PANE_EXPAND_EVENT, {
+        detail: { tabId }
+      })
+    )
+  })
+}

--- a/src/renderer/src/components/terminal/terminal-tab-bulk-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-bulk-actions.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  archiveTerminalTabBeforeRetirementMock,
+  canArchiveTerminalTabCloseMock,
+  closeWebRuntimeSessionTabMock,
+  getLatestWebSessionTabsPublicationEpochMock,
+  getStateMock,
+  isWebRuntimeSessionActiveMock,
+  isWebTerminalSurfaceTabIdMock,
+  isTerminalArchiveTopologyCurrentMock,
+  resolveHostSessionTabIdForWebSessionTabMock,
+  terminalArchiveCloseUnavailableErrorMock,
+  toHostSessionTabIdMock
+} = vi.hoisted(() => ({
+  archiveTerminalTabBeforeRetirementMock: vi.fn(),
+  canArchiveTerminalTabCloseMock: vi.fn(() => false),
+  closeWebRuntimeSessionTabMock: vi.fn(),
+  getLatestWebSessionTabsPublicationEpochMock: vi.fn(() => 'epoch-1'),
+  getStateMock: vi.fn(),
+  isWebRuntimeSessionActiveMock: vi.fn(),
+  isWebTerminalSurfaceTabIdMock: vi.fn(() => false),
+  isTerminalArchiveTopologyCurrentMock: vi.fn(() => true),
+  resolveHostSessionTabIdForWebSessionTabMock: vi.fn<() => string | null>(() => null),
+  terminalArchiveCloseUnavailableErrorMock: vi.fn(
+    () =>
+      new Error('Terminal archive protection is unavailable. Keep this tab open and reload Orca.')
+  ),
+  toHostSessionTabIdMock: vi.fn((tabId: string) => tabId)
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: getStateMock
+  }
+}))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  closeWebRuntimeSessionTab: closeWebRuntimeSessionTabMock,
+  isWebRuntimeSessionActive: isWebRuntimeSessionActiveMock,
+  isWebTerminalSurfaceTabId: isWebTerminalSurfaceTabIdMock,
+  toHostSessionTabId: toHostSessionTabIdMock
+}))
+
+vi.mock('@/runtime/web-session-tabs-sync', () => ({
+  getLatestWebSessionTabsPublicationEpoch: getLatestWebSessionTabsPublicationEpochMock,
+  resolveHostSessionTabIdForWebSessionTab: resolveHostSessionTabIdForWebSessionTabMock
+}))
+
+vi.mock('./terminal-archive-close', () => ({
+  archiveTerminalTabBeforeRetirement: archiveTerminalTabBeforeRetirementMock,
+  canArchiveTerminalTabClose: canArchiveTerminalTabCloseMock,
+  isTerminalArchiveTopologyCurrent: isTerminalArchiveTopologyCurrentMock,
+  terminalArchiveCloseUnavailableError: terminalArchiveCloseUnavailableErrorMock
+}))
+
+import { closeOtherTerminalTabs, closeTerminalTabsToRight } from './terminal-tab-actions'
+
+describe('closeOtherTerminalTabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isWebRuntimeSessionActiveMock.mockReturnValue(false)
+  })
+
+  it('delegates other terminal closes to the host runtime in paired web clients', async () => {
+    const setActiveTab = vi.fn()
+    const closeTab = vi.fn()
+    let resolveFirstReceipt: (receipt: { closed: true; archiveId: string }) => void = () => {}
+    let resolveSecondReceipt: (receipt: { closed: true; archiveId: string }) => void = () => {}
+    const firstReceipt = new Promise<{ closed: true; archiveId: string }>((resolve) => {
+      resolveFirstReceipt = resolve
+    })
+    const secondReceipt = new Promise<{ closed: true; archiveId: string }>((resolve) => {
+      resolveSecondReceipt = resolve
+    })
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    closeWebRuntimeSessionTabMock
+      .mockReturnValueOnce(firstReceipt)
+      .mockReturnValueOnce(secondReceipt)
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'keep' }, { id: 'close-a' }, { id: 'close-b' }]
+      },
+      setActiveTab,
+      closeTab
+    })
+
+    const closePromise = closeOtherTerminalTabs('keep', 'wt-1')
+
+    expect(setActiveTab).toHaveBeenCalledWith('keep')
+    await vi.waitFor(() => expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledTimes(1))
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'close-a',
+      environmentId: 'web-runtime',
+      reason: 'user'
+    })
+    expect(closeTab).not.toHaveBeenCalled()
+
+    resolveFirstReceipt({ closed: true, archiveId: '11111111-1111-4111-8111-111111111111' })
+    await vi.waitFor(() =>
+      expect(closeTab).toHaveBeenCalledWith('close-a', {
+        reason: undefined,
+        remoteCloseOwnedByHost: true
+      })
+    )
+    await vi.waitFor(() => expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledTimes(2))
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenLastCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'close-b',
+      environmentId: 'web-runtime',
+      reason: 'user'
+    })
+    expect(closeTab).toHaveBeenCalledTimes(1)
+
+    resolveSecondReceipt({ closed: true, archiveId: '22222222-2222-4222-8222-222222222222' })
+    await closePromise
+
+    expect(closeTab).toHaveBeenCalledTimes(2)
+    expect(closeTab).toHaveBeenNthCalledWith(2, 'close-b', {
+      reason: undefined,
+      remoteCloseOwnedByHost: true
+    })
+  })
+})
+
+describe('closeTerminalTabsToRight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isWebRuntimeSessionActiveMock.mockReturnValue(false)
+  })
+
+  it('delegates terminal tabs to the host while still closing local editor tabs to the right', async () => {
+    const closeTab = vi.fn()
+    const closeFile = vi.fn()
+    let resolveFirstReceipt: (receipt: { closed: true; archiveId: string }) => void = () => {}
+    let resolveSecondReceipt: (receipt: { closed: true; archiveId: string }) => void = () => {}
+    const firstReceipt = new Promise<{ closed: true; archiveId: string }>((resolve) => {
+      resolveFirstReceipt = resolve
+    })
+    const secondReceipt = new Promise<{ closed: true; archiveId: string }>((resolve) => {
+      resolveSecondReceipt = resolve
+    })
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    closeWebRuntimeSessionTabMock
+      .mockReturnValueOnce(firstReceipt)
+      .mockReturnValueOnce(secondReceipt)
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'term-a' }, { id: 'term-b' }, { id: 'term-c' }]
+      },
+      openFiles: [{ id: 'file-b', worktreeId: 'wt-1' }],
+      tabBarOrderByWorktree: { 'wt-1': ['term-a', 'file-b', 'term-b', 'term-c'] },
+      closeTab,
+      closeFile
+    })
+
+    const closePromise = closeTerminalTabsToRight('term-a', 'wt-1')
+
+    expect(closeFile).toHaveBeenCalledWith('file-b')
+    await vi.waitFor(() => expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledTimes(1))
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'term-b',
+      environmentId: 'web-runtime',
+      reason: 'user'
+    })
+    expect(closeTab).not.toHaveBeenCalled()
+
+    resolveFirstReceipt({ closed: true, archiveId: '33333333-3333-4333-8333-333333333333' })
+    await vi.waitFor(() =>
+      expect(closeTab).toHaveBeenCalledWith('term-b', {
+        reason: undefined,
+        remoteCloseOwnedByHost: true
+      })
+    )
+    await vi.waitFor(() => expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledTimes(2))
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenLastCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'term-c',
+      environmentId: 'web-runtime',
+      reason: 'user'
+    })
+    expect(closeTab).toHaveBeenCalledTimes(1)
+
+    resolveSecondReceipt({ closed: true, archiveId: '44444444-4444-4444-8444-444444444444' })
+    await closePromise
+
+    expect(closeTab).toHaveBeenCalledTimes(2)
+    expect(closeTab).toHaveBeenNthCalledWith(2, 'term-c', {
+      reason: undefined,
+      remoteCloseOwnedByHost: true
+    })
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-tab-bulk-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-bulk-actions.ts
@@ -1,12 +1,7 @@
 import type { TabContentType } from '../../../../shared/types'
-import {
-  hasUnroutableTerminalWorktreeOwner,
-  resolveTerminalWorktreeRoute
-} from '@/lib/terminal-worktree-route'
-import { closeWebRuntimeSessionTab, isWebRuntimeSessionActive } from '@/runtime/web-runtime-session'
+import { hasUnroutableTerminalWorktreeOwner } from '@/lib/terminal-worktree-route'
 import { useAppStore } from '@/store'
 import { reconcileTabOrder } from '../tab-bar/reconcile-order'
-import { closeLocalTerminalTabState } from './close-local-terminal-tab-state'
 
 const EDITOR_TAB_CONTENT_TYPES = new Set<TabContentType>([
   'editor',
@@ -16,6 +11,12 @@ const EDITOR_TAB_CONTENT_TYPES = new Set<TabContentType>([
 ])
 
 type TerminalTabBulkActionState = ReturnType<typeof useAppStore.getState>
+
+async function requestUserTerminalClose(tabId: string): Promise<void> {
+  // Keep bulk actions behind the same pinned/archive/retirement boundary as a single-tab close.
+  const { closeTerminalTabAsync } = await import('./terminal-tab-actions')
+  await closeTerminalTabAsync(tabId)
+}
 
 function isPinnedVisibleTab(
   state: TerminalTabBulkActionState,
@@ -29,7 +30,10 @@ function isPinnedVisibleTab(
   )
 }
 
-export function closeOtherTerminalTabs(tabId: string, activeWorktreeId: string | null): void {
+export async function closeOtherTerminalTabs(
+  tabId: string,
+  activeWorktreeId: string | null
+): Promise<void> {
   if (!activeWorktreeId) {
     return
   }
@@ -39,31 +43,22 @@ export function closeOtherTerminalTabs(tabId: string, activeWorktreeId: string |
   }
   const currentTabs = state.tabsByWorktree[activeWorktreeId] ?? []
   state.setActiveTab(tabId)
-  const runtimeEnvironmentId = resolveTerminalWorktreeRoute(
-    state,
-    activeWorktreeId
-  )?.runtimeEnvironmentId
-  const closeHostTerminalTabs = isWebRuntimeSessionActive(runtimeEnvironmentId)
   for (const tab of currentTabs) {
     if (tab.id === tabId || isPinnedVisibleTab(state, activeWorktreeId, tab.id)) {
       continue
     }
-    if (closeHostTerminalTabs) {
-      // Why: prune the mirror immediately, then close on its authoritative host so snapshots converge.
-      closeLocalTerminalTabState(tab.id, { remoteCloseOwnedByHost: true })
-      void closeWebRuntimeSessionTab({
-        worktreeId: activeWorktreeId,
-        tabId: tab.id,
-        environmentId: runtimeEnvironmentId,
-        reason: 'user'
-      })
-    } else {
-      state.closeTab(tab.id)
+    try {
+      await requestUserTerminalClose(tab.id)
+    } catch {
+      // The close boundary exposes retry feedback; independent tabs still proceed.
     }
   }
 }
 
-export function closeTerminalTabsToRight(tabId: string, activeWorktreeId: string | null): void {
+export async function closeTerminalTabsToRight(
+  tabId: string,
+  activeWorktreeId: string | null
+): Promise<void> {
   if (!activeWorktreeId) {
     return
   }
@@ -74,11 +69,6 @@ export function closeTerminalTabsToRight(tabId: string, activeWorktreeId: string
   }
   const currentTerminalTabs = state.tabsByWorktree[activeWorktreeId] ?? []
   const currentEditorFiles = state.openFiles.filter((file) => file.worktreeId === activeWorktreeId)
-  const runtimeEnvironmentId = resolveTerminalWorktreeRoute(
-    state,
-    activeWorktreeId
-  )?.runtimeEnvironmentId
-  const closeHostTerminalTabs = isWebRuntimeSessionActive(runtimeEnvironmentId)
   const terminalIds = currentTerminalTabs.map((tab) => tab.id)
   const terminalIdSet = new Set(terminalIds)
   const orderedIds = reconcileTabOrder(
@@ -96,17 +86,10 @@ export function closeTerminalTabsToRight(tabId: string, activeWorktreeId: string
       continue
     }
     if (terminalIdSet.has(id)) {
-      if (closeHostTerminalTabs) {
-        // Why: prune the mirror immediately, then close on its authoritative host so snapshots converge.
-        closeLocalTerminalTabState(id, { remoteCloseOwnedByHost: true })
-        void closeWebRuntimeSessionTab({
-          worktreeId: activeWorktreeId,
-          tabId: id,
-          environmentId: runtimeEnvironmentId,
-          reason: 'user'
-        })
-      } else {
-        state.closeTab(id)
+      try {
+        await requestUserTerminalClose(id)
+      } catch {
+        // The close boundary exposes retry feedback; independent tabs still proceed.
       }
       continue
     }

--- a/src/renderer/src/components/terminal/terminal-tab-close-completion.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-close-completion.ts
@@ -1,0 +1,51 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+
+type TerminalCloseCallbacks = {
+  onClosed?: (archiveId?: string) => void
+  onCancel?: () => void
+  onError?: (error: Error) => void
+}
+
+export function awaitTerminalTabClose<TOptions extends TerminalCloseCallbacks>(
+  close: (tabId: string, options?: TOptions) => void,
+  tabId: string,
+  options?: TOptions
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    close(tabId, {
+      ...options,
+      onClosed: (archiveId) => {
+        options?.onClosed?.(archiveId)
+        resolve()
+      },
+      onCancel: () => {
+        options?.onCancel?.()
+        reject(new Error('terminal_tab_close_cancelled'))
+      },
+      onError: (error) => {
+        if (options?.onError) {
+          options.onError(error)
+        } else {
+          toast.error(
+            translate(
+              'auto.components.terminal.terminal.tab.close.completion.cbbc80b16f',
+              'Terminal was not closed'
+            ),
+            {
+              description: error.message,
+              action: {
+                label: translate(
+                  'auto.components.terminal.terminal.tab.close.completion.814c051db5',
+                  'Retry'
+                ),
+                onClick: () => void awaitTerminalTabClose(close, tabId, options).catch(() => {})
+              }
+            }
+          )
+        }
+        reject(error)
+      }
+    } as TOptions)
+  })
+}

--- a/src/renderer/src/components/terminal/terminal-tab-create.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-create.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createWebRuntimeSessionTerminalMock, getStateMock, isWebRuntimeSessionActiveMock } =
+  vi.hoisted(() => ({
+    createWebRuntimeSessionTerminalMock: vi.fn(),
+    getStateMock: vi.fn(),
+    isWebRuntimeSessionActiveMock: vi.fn()
+  }))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: getStateMock
+  }
+}))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: createWebRuntimeSessionTerminalMock,
+  isWebRuntimeSessionActive: isWebRuntimeSessionActiveMock
+}))
+
+import { createNewTerminalTab } from './terminal-tab-create'
+
+describe('createNewTerminalTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createWebRuntimeSessionTerminalMock.mockResolvedValue(true)
+    isWebRuntimeSessionActiveMock.mockReturnValue(false)
+  })
+
+  it('creates a local terminal tab outside the paired web runtime', () => {
+    const createTab = vi.fn(() => ({ id: 'tab-1' }))
+    const setActiveTabType = vi.fn()
+    const setTabBarOrder = vi.fn()
+    getStateMock
+      .mockReturnValueOnce({
+        settings: { activeRuntimeEnvironmentId: null },
+        createTab,
+        setActiveTabType,
+        setTabBarOrder
+      })
+      .mockReturnValueOnce({
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+        openFiles: [],
+        tabBarOrderByWorktree: {},
+        setTabBarOrder
+      })
+
+    createNewTerminalTab('wt-1', 'zsh')
+
+    expect(createTab).toHaveBeenCalledWith('wt-1', undefined, 'zsh', undefined)
+    expect(setActiveTabType).toHaveBeenCalledWith('terminal')
+    expect(setTabBarOrder).toHaveBeenCalledWith('wt-1', ['tab-1'])
+    expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
+  })
+
+  it('delegates terminal creation to the host runtime in paired web clients', () => {
+    const createTab = vi.fn(() => ({ id: 'tab-1' }))
+    const setActiveTabType = vi.fn()
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
+      createTab,
+      setActiveTabType
+    })
+
+    createNewTerminalTab('wt-1', 'pwsh')
+
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      environmentId: 'web-runtime',
+      command: 'pwsh',
+      activate: true
+    })
+    expect(createTab).not.toHaveBeenCalled()
+    expect(setActiveTabType).not.toHaveBeenCalled()
+  })
+
+  it('delegates terminal creation to the explicit owner runtime when another runtime is focused', () => {
+    const createTab = vi.fn(() => ({ id: 'tab-1' }))
+    const setActiveTabType = vi.fn()
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
+      repos: [{ id: 'repo-1', executionHostId: 'runtime:owner-runtime', connectionId: null }],
+      worktreesByRepo: { 'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }] },
+      createTab,
+      setActiveTabType
+    })
+
+    createNewTerminalTab('wt-1', 'pwsh')
+
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      environmentId: 'owner-runtime',
+      command: 'pwsh',
+      activate: true
+    })
+    expect(createTab).not.toHaveBeenCalled()
+  })
+
+  it('creates local terminal tabs with a requested startup cwd', () => {
+    const createTab = vi.fn(() => ({ id: 'tab-1' }))
+    const setActiveTabType = vi.fn()
+    const setTabBarOrder = vi.fn()
+    getStateMock
+      .mockReturnValueOnce({
+        settings: { activeRuntimeEnvironmentId: null },
+        createTab,
+        setActiveTabType,
+        setTabBarOrder
+      })
+      .mockReturnValueOnce({
+        tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+        openFiles: [],
+        tabBarOrderByWorktree: {},
+        setTabBarOrder
+      })
+
+    createNewTerminalTab('wt-1', undefined, { startupCwd: '/repo/packages/app' })
+
+    expect(createTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
+      startupCwd: '/repo/packages/app'
+    })
+    expect(setActiveTabType).toHaveBeenCalledWith('terminal')
+  })
+
+  it('delegates requested startup cwd to host runtime terminals', () => {
+    const createTab = vi.fn(() => ({ id: 'tab-1' }))
+    isWebRuntimeSessionActiveMock.mockReturnValue(true)
+    getStateMock.mockReturnValue({
+      settings: { activeRuntimeEnvironmentId: 'web-runtime' },
+      createTab,
+      setActiveTabType: vi.fn()
+    })
+
+    createNewTerminalTab('wt-1', undefined, { startupCwd: '/repo/packages/app' })
+
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      environmentId: 'web-runtime',
+      command: undefined,
+      cwd: '/repo/packages/app',
+      activate: true
+    })
+    expect(createTab).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-tab-pin-visibility.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-pin-visibility.ts
@@ -1,0 +1,9 @@
+import { useAppStore } from '@/store'
+
+export function isPinnedVisibleTerminalTab(worktreeId: string, visibleId: string): boolean {
+  return (
+    (useAppStore.getState().unifiedTabsByWorktree?.[worktreeId] ?? []).some(
+      (tab) => (tab.id === visibleId || tab.entityId === visibleId) && tab.isPinned
+    ) ?? false
+  )
+}

--- a/src/renderer/src/components/terminal/terminal-tab-retirement-transaction.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-retirement-transaction.ts
@@ -1,0 +1,76 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { useAppStore } from '@/store'
+import {
+  buildTerminalTabRetirementPlan,
+  type TerminalTabRetirementPlan
+} from '@/store/slices/terminal-tab-retirement'
+
+export function reportTerminalCloseError(
+  error: Error,
+  onError?: (error: Error) => void,
+  retry?: () => void
+): void {
+  if (onError) {
+    onError(error)
+    return
+  }
+  toast.error(
+    translate(
+      'auto.components.terminal.terminal.tab.retirement.transaction.bca566909a',
+      'Terminal was not closed'
+    ),
+    {
+      description: error.message,
+      action: {
+        label: translate(
+          'auto.components.terminal.terminal.tab.retirement.transaction.b2c07ffc64',
+          'Retry'
+        ),
+        onClick: retry ?? (() => {})
+      }
+    }
+  )
+}
+
+export async function retireArchivedTerminalPtys(
+  tabId: string,
+  worktreeId: string
+): Promise<TerminalTabRetirementPlan> {
+  const state = useAppStore.getState()
+  const plan = buildTerminalTabRetirementPlan(state, tabId)
+  if (plan.unroutablePtyIds.length > 0) {
+    throw new Error(
+      translate(
+        'auto.components.terminal.terminal.tab.retirement.transaction.66acba8f75',
+        'Terminal ownership changed and cannot be safely retired. Retry close.'
+      )
+    )
+  }
+  const route = resolveTerminalWorktreeRoute(state, worktreeId)
+  const teardowns: Promise<unknown>[] = plan.localOrSshPtyIds.map((ptyId) =>
+    window.api.pty.kill(ptyId)
+  )
+  for (const terminal of plan.runtimeTerminals) {
+    const environmentId = terminal.environmentId ?? route?.runtimeEnvironmentId
+    teardowns.push(
+      callRuntimeRpc(
+        environmentId ? { kind: 'environment', environmentId } : { kind: 'local' },
+        'terminal.close',
+        { terminal: terminal.handle }
+      )
+    )
+  }
+  const results = await Promise.allSettled(teardowns)
+  if (results.some((result) => result.status === 'rejected')) {
+    throw new Error(
+      translate(
+        'auto.components.terminal.terminal.tab.retirement.transaction.1f62db337b',
+        'Terminal retirement failed. The archived tab remains open; retry close.'
+      )
+    )
+  }
+  return plan
+}

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -1446,6 +1446,7 @@ describe('useIpcEvents updater integration', () => {
 
   it('clears stale remote PTYs when an SSH connection fully disconnects', async () => {
     const clearTabPtyId = vi.fn()
+    const persistWorkspaceSessionByHost = vi.fn()
     const setSshConnectionState = vi.fn()
     const setSshTargetsMetadata = vi.fn()
     const clearRemovedSshTargetState = vi.fn()
@@ -1498,16 +1499,23 @@ describe('useIpcEvents updater integration', () => {
       clearRemoteDetectedAgents: vi.fn(),
       clearRemovedSshTargetState,
       clearTabPtyId,
-      repos: [{ id: 'repo-1', connectionId: 'conn-1' }],
+      repos: [
+        { id: 'repo-1', connectionId: 'conn-1' },
+        { id: 'repo-2', connectionId: 'conn-1' }
+      ],
       worktreesByRepo: {
-        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }],
+        'repo-2': [{ id: 'wt-2', repoId: 'repo-2' }]
       },
       tabsByWorktree: {
         'wt-1': [
           { id: 'tab-1', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Terminal 1' },
           { id: 'tab-2', ptyId: null, worktreeId: 'wt-1', title: 'Terminal 2' }
-        ]
+        ],
+        'wt-2': [{ id: 'tab-3', ptyId: 'pty-3', worktreeId: 'wt-2', title: 'Terminal 3' }]
       },
+      terminalArchiveHintsByPaneKey: { 'tab-1:leaf-1': { archiveId: 'archive-1' } },
+      terminalPtyIncarnationsByPaneKey: { 'tab-1:leaf-1': 'incarnation-1' },
       sshTargetLabels: new Map<string, string>([['conn-1', 'Remote']]),
       settings: {
         terminalFontSize: 13,
@@ -1557,6 +1565,9 @@ describe('useIpcEvents updater integration', () => {
     }))
     vi.doMock('@/lib/zoom-events', () => ({
       dispatchZoomLevelChanged: vi.fn()
+    }))
+    vi.doMock('@/lib/workspace-session-host-persistence', () => ({
+      persistWorkspaceSessionByHost
     }))
 
     vi.stubGlobal('window', {
@@ -1683,7 +1694,15 @@ describe('useIpcEvents updater integration', () => {
       expect.objectContaining({ status: 'disconnected' })
     )
     expect(clearTabPtyId).toHaveBeenCalledWith('tab-1')
+    expect(clearTabPtyId).toHaveBeenCalledWith('tab-3')
     expect(clearTabPtyId).not.toHaveBeenCalledWith('tab-2')
+    expect(clearTabPtyId).toHaveBeenCalledTimes(2)
+    // Why: the disconnect event only removes renderer bindings; host durability evidence must survive to classify reconnects.
+    expect(persistWorkspaceSessionByHost).not.toHaveBeenCalled()
+    expect(storeState.terminalArchiveHintsByPaneKey).toEqual({
+      'tab-1:leaf-1': { archiveId: 'archive-1' }
+    })
+    expect(storeState.terminalPtyIncarnationsByPaneKey).toEqual({ 'tab-1:leaf-1': 'incarnation-1' })
     expect(storeState.clearRemoteDetectedAgents).toHaveBeenCalledWith('conn-1')
 
     setSshConnectionState.mockClear()

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -6,6 +6,7 @@ import {
   buildNewWorkspaceShortcutModalData,
   getNewlyConnectedRuntimeEnvironmentIds,
   getNewlyDisconnectedRuntimeEnvironmentIds,
+  getSshReconnectActivationSpawnSuppression,
   getRuntimeProjectRefreshEnvironmentIds,
   openNewWorkspaceFromShortcut,
   resolveBrowserSessionTabTarget,
@@ -65,6 +66,24 @@ describe('getNewlyDisconnectedRuntimeEnvironmentIds', () => {
       'env-b'
     ])
     expect(getNewlyDisconnectedRuntimeEnvironmentIds(['env-a'], ['env-a', 'env-b'])).toEqual([])
+  })
+})
+
+describe('getSshReconnectActivationSpawnSuppression', () => {
+  it('keeps one gate token for every split leaf during reconnect remount', () => {
+    expect(
+      getSshReconnectActivationSpawnSuppression({
+        root: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          second: { type: 'leaf', leafId: STALE_LEAF_ID }
+        },
+        activeLeafId: FUTURE_LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {}
+      })
+    ).toBe(2)
   })
 })
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1928,6 +1928,17 @@ export function useIpcEvents(): void {
           })
           return
         }
+        const terminalTarget = (store.unifiedTabsByWorktree[worktreeId] ?? []).find(
+          (tab) => tab.contentType === 'terminal' && (tab.id === tabId || tab.entityId === tabId)
+        )
+        if (terminalTarget) {
+          guardPinnedTabClose({
+            isPinned: isPinnedSessionTab(store, worktreeId, terminalTarget.entityId),
+            tabLabel: resolvePinnedTabLabel(store, worktreeId, terminalTarget.entityId),
+            onClose: () => closeTerminalTab(terminalTarget.entityId)
+          })
+          return
+        }
         guardPinnedTabClose({
           isPinned: isPinnedSessionTab(store, worktreeId, tabId),
           tabLabel: resolvePinnedTabLabel(store, worktreeId, tabId),
@@ -2013,17 +2024,21 @@ export function useIpcEvents(): void {
       unsubs.push(
         window.api.ui.onTerminalTabCloseRequest(({ requestId, tabId }) => {
           let responded = false
-          const respond = (error?: string): void => {
+          const respond = (error?: string, archiveId?: string): void => {
             if (responded) {
               return
             }
             responded = true
-            window.api.ui.respondTerminalTabClose({ requestId, ...(error ? { error } : {}) })
+            window.api.ui.respondTerminalTabClose({
+              requestId,
+              ...(error ? { error } : {}),
+              ...(archiveId ? { archiveId } : {})
+            })
           }
           closeTerminalTab(tabId, {
             rejectPinned: true,
             onCancel: () => respond('terminal_tab_pinned'),
-            onClosed: () => {
+            onClosed: (archiveId) => {
               void (async () => {
                 const state = useAppStore.getState()
                 await persistWorkspaceSessionByHost(
@@ -2031,11 +2046,12 @@ export function useIpcEvents(): void {
                   buildWorkspaceSessionPayload(state),
                   state
                 )
-                respond()
+                respond(undefined, archiveId)
               })().catch((error: unknown) => {
                 respond(error instanceof Error ? error.message : 'terminal_tab_close_failed')
               })
-            }
+            },
+            onError: (error) => respond(error.message)
           })
         })
       )

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -791,6 +791,27 @@ export function getNewlyDisconnectedRuntimeEnvironmentIds(
   return getNewlyConnectedRuntimeEnvironmentIds(next, previous)
 }
 
+function countTerminalLayoutLeaves(node: TerminalPaneLayoutNode | null | undefined): number {
+  if (!node) {
+    return 0
+  }
+  if (node.type === 'leaf') {
+    return 1
+  }
+  return countTerminalLayoutLeaves(node.first) + countTerminalLayoutLeaves(node.second)
+}
+
+export function getSshReconnectActivationSpawnSuppression(
+  layout: TerminalLayoutSnapshot | undefined
+): true | number {
+  const paneCount = Math.max(
+    1,
+    countTerminalLayoutLeaves(layout?.root),
+    Object.keys(layout?.ptyIdsByLeafId ?? {}).length
+  )
+  return paneCount === 1 ? true : paneCount
+}
+
 export function getRuntimeProjectRefreshEnvironmentIds(args: {
   previousDesired: readonly string[]
   nextDesired: readonly string[]
@@ -2790,8 +2811,10 @@ export function useIpcEvents(): void {
                           ...t,
                           generation: (t.generation ?? 0) + 1,
                           // Why: a reconnect remount with no bindable PTY must
-                          // pass the main-owned lost-worker gate before fresh spawn.
-                          pendingActivationSpawn: true
+                          // pass the main-owned lost-worker gate before fresh spawn; split panes need one token each.
+                          pendingActivationSpawn: getSshReconnectActivationSpawnSuppression(
+                            s.terminalLayoutsByTabId[t.id]
+                          )
                         }
                       : t
                   )

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -141,6 +141,12 @@ import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
 import { resolveAgentPaneAuthorityKey } from '@/store/slices/agent-pane-authority'
 import { translate } from '@/i18n/i18n'
 import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
+import {
+  beginRemoteWorkspaceSnapshotApply,
+  finishRemoteWorkspaceSnapshotApply,
+  isRemoteWorkspaceSnapshotApplyInProgress
+} from '@/lib/remote-workspace-snapshot-gate'
+import { reapplyMainAuthoritativeTerminalRetirements } from '@/lib/main-authoritative-terminal-retirement'
 import { initialAgentTabViewModeProps } from '@/lib/native-chat-initial-view-mode'
 import { getConnectionIdFromState } from '@/lib/connection-context'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
@@ -254,10 +260,6 @@ const MAX_PENDING_AGENT_STATUS_EVENTS = 100
 const MAX_PENDING_MOBILE_STATE_EVENTS = 300
 // Why: a rename's event burst lags the on-disk move; shield both ids from the deletion diff for a grace window.
 const WORKTREE_RENAME_PURGE_GRACE_MS = 20_000
-let remoteWorkspaceSnapshotApplyDepth = 0
-let remoteWorkspaceSnapshotWriteSuppressUntil = 0
-const REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS = 1000
-
 function isAgentStatusForRecentlyClosedTab(
   store: Pick<AppState, 'recentlyClosedAgentStatusTabIds' | 'recentlyRetiredAgentStatusPaneKeys'>,
   paneKey: string
@@ -414,11 +416,7 @@ function activateExistingLeafInLayout(
   }
 }
 
-export function isRemoteWorkspaceSnapshotApplyInProgress(): boolean {
-  return (
-    remoteWorkspaceSnapshotApplyDepth > 0 || Date.now() < remoteWorkspaceSnapshotWriteSuppressUntil
-  )
-}
+export { isRemoteWorkspaceSnapshotApplyInProgress }
 
 async function waitForWorkspaceSessionReady(): Promise<boolean> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
@@ -556,12 +554,13 @@ async function applyRemoteWorkspaceSnapshot(
   const current = buildWorkspaceSessionPayload(useAppStore.getState())
   const merged = mergeRemoteWorkspaceSession(current, remoteSession, targetId)
   const store = useAppStore.getState()
-  remoteWorkspaceSnapshotApplyDepth += 1
+  beginRemoteWorkspaceSnapshotApply()
   try {
     store.hydrateWorkspaceSession(merged)
     store.hydrateTabsSession(merged)
     store.hydrateEditorSession(merged)
     store.hydrateBrowserSession(merged)
+    reapplyMainAuthoritativeTerminalRetirements()
     store.markRemoteWorkspaceHydrated(targetId)
     store.setRemoteWorkspaceSyncStatus(targetId, {
       phase: 'synced',
@@ -574,9 +573,7 @@ async function applyRemoteWorkspaceSnapshot(
     await useAppStore.getState().reconnectPersistedTerminals()
   } finally {
     // Why: reattach updates pty ids/titles after hydration; they came from the snapshot, don't echo back as a new revision.
-    remoteWorkspaceSnapshotWriteSuppressUntil =
-      Date.now() + REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS
-    remoteWorkspaceSnapshotApplyDepth -= 1
+    finishRemoteWorkspaceSnapshotApply()
   }
 }
 

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2785,7 +2785,15 @@ export function useIpcEvents(): void {
                 tabsByWorktree: {
                   ...s.tabsByWorktree,
                   [worktreeId]: (s.tabsByWorktree[worktreeId] ?? []).map((t) =>
-                    needsRetry(t) ? { ...t, generation: (t.generation ?? 0) + 1 } : t
+                    needsRetry(t)
+                      ? {
+                          ...t,
+                          generation: (t.generation ?? 0) + 1,
+                          // Why: a reconnect remount with no bindable PTY must
+                          // pass the main-owned lost-worker gate before fresh spawn.
+                          pendingActivationSpawn: true
+                        }
+                      : t
                   )
                 }
               }))

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2762,6 +2762,34 @@
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
           }
+        },
+        "terminal": {
+          "archive": {
+            "close": {
+              "d45b935f2b": "Terminal archive protection is unavailable. Keep this tab open and reload Orca."
+            }
+          },
+          "tab": {
+            "actions": {
+              "a4f4c513c5": "Terminal archive protection did not receive a durable host receipt.",
+              "fddc720203": "The execution host refused to close this tab.",
+              "43cd15a02d": "Terminal layout changed while archiving. Retry close to archive the latest panes."
+            },
+            "close": {
+              "completion": {
+                "cbbc80b16f": "Terminal was not closed",
+                "814c051db5": "Retry"
+              }
+            },
+            "retirement": {
+              "transaction": {
+                "bca566909a": "Terminal was not closed",
+                "b2c07ffc64": "Retry",
+                "66acba8f75": "Terminal ownership changed and cannot be safely retired. Retry close.",
+                "1f62db337b": "Terminal retirement failed. The archived tab remains open; retry close."
+              }
+            }
+          }
         }
       },
       "tab": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2739,6 +2739,34 @@
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
           }
+        },
+        "terminal": {
+          "archive": {
+            "close": {
+              "d45b935f2b": "Terminal archive protection is unavailable. Keep this tab open and reload Orca."
+            }
+          },
+          "tab": {
+            "actions": {
+              "a4f4c513c5": "Terminal archive protection did not receive a durable host receipt.",
+              "fddc720203": "The execution host refused to close this tab.",
+              "43cd15a02d": "Terminal layout changed while archiving. Retry close to archive the latest panes."
+            },
+            "close": {
+              "completion": {
+                "cbbc80b16f": "Terminal was not closed",
+                "814c051db5": "Retry"
+              }
+            },
+            "retirement": {
+              "transaction": {
+                "bca566909a": "Terminal was not closed",
+                "b2c07ffc64": "Retry",
+                "66acba8f75": "Terminal ownership changed and cannot be safely retired. Retry close.",
+                "1f62db337b": "Terminal retirement failed. The archived tab remains open; retry close."
+              }
+            }
+          }
         }
       },
       "tab": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2739,6 +2739,34 @@
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
           }
+        },
+        "terminal": {
+          "archive": {
+            "close": {
+              "d45b935f2b": "Terminal archive protection is unavailable. Keep this tab open and reload Orca."
+            }
+          },
+          "tab": {
+            "actions": {
+              "a4f4c513c5": "Terminal archive protection did not receive a durable host receipt.",
+              "fddc720203": "The execution host refused to close this tab.",
+              "43cd15a02d": "Terminal layout changed while archiving. Retry close to archive the latest panes."
+            },
+            "close": {
+              "completion": {
+                "cbbc80b16f": "Terminal was not closed",
+                "814c051db5": "Retry"
+              }
+            },
+            "retirement": {
+              "transaction": {
+                "bca566909a": "Terminal was not closed",
+                "b2c07ffc64": "Retry",
+                "66acba8f75": "Terminal ownership changed and cannot be safely retired. Retry close.",
+                "1f62db337b": "Terminal retirement failed. The archived tab remains open; retry close."
+              }
+            }
+          }
         }
       },
       "tab": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2739,6 +2739,34 @@
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
           }
+        },
+        "terminal": {
+          "archive": {
+            "close": {
+              "d45b935f2b": "Terminal archive protection is unavailable. Keep this tab open and reload Orca."
+            }
+          },
+          "tab": {
+            "actions": {
+              "a4f4c513c5": "Terminal archive protection did not receive a durable host receipt.",
+              "fddc720203": "The execution host refused to close this tab.",
+              "43cd15a02d": "Terminal layout changed while archiving. Retry close to archive the latest panes."
+            },
+            "close": {
+              "completion": {
+                "cbbc80b16f": "Terminal was not closed",
+                "814c051db5": "Retry"
+              }
+            },
+            "retirement": {
+              "transaction": {
+                "bca566909a": "Terminal was not closed",
+                "b2c07ffc64": "Retry",
+                "66acba8f75": "Terminal ownership changed and cannot be safely retired. Retry close.",
+                "1f62db337b": "Terminal retirement failed. The archived tab remains open; retry close."
+              }
+            }
+          }
         }
       },
       "tab": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2739,6 +2739,34 @@
             "disconnectedBody": "Automatic retries stopped. Reconnect to resume this terminal session.",
             "reconnectButton": "Reconnect"
           }
+        },
+        "terminal": {
+          "archive": {
+            "close": {
+              "d45b935f2b": "Terminal archive protection is unavailable. Keep this tab open and reload Orca."
+            }
+          },
+          "tab": {
+            "actions": {
+              "a4f4c513c5": "Terminal archive protection did not receive a durable host receipt.",
+              "fddc720203": "The execution host refused to close this tab.",
+              "43cd15a02d": "Terminal layout changed while archiving. Retry close to archive the latest panes."
+            },
+            "close": {
+              "completion": {
+                "cbbc80b16f": "Terminal was not closed",
+                "814c051db5": "Retry"
+              }
+            },
+            "retirement": {
+              "transaction": {
+                "bca566909a": "Terminal was not closed",
+                "b2c07ffc64": "Retry",
+                "66acba8f75": "Terminal ownership changed and cannot be safely retired. Retry close.",
+                "1f62db337b": "Terminal retirement failed. The archived tab remains open; retry close."
+              }
+            }
+          }
         }
       },
       "tab": {

--- a/src/renderer/src/lib/main-authoritative-terminal-retirement.ts
+++ b/src/renderer/src/lib/main-authoritative-terminal-retirement.ts
@@ -1,0 +1,37 @@
+import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
+import { suppressRemoteWorkspaceSnapshotWrites } from './remote-workspace-snapshot-gate'
+
+const retiredTabIds = new Set<string>()
+const MAX_RETIRED_TAB_IDS = 256
+
+function closeRetiredTerminalTab(tabId: string): void {
+  suppressRemoteWorkspaceSnapshotWrites()
+  closeTerminalTab(tabId, {
+    force: true,
+    reason: 'cleanup',
+    captureRecentlyClosed: false,
+    localPtyTeardownOwnedExternally: true,
+    runtimePtyTeardownOwnedExternally: true
+  })
+}
+
+/** Records a main-side archive retirement before closing the renderer mirror. */
+export function retireMainAuthoritativeTerminalTab(tabId: string): void {
+  if (!retiredTabIds.has(tabId)) {
+    retiredTabIds.add(tabId)
+    if (retiredTabIds.size > MAX_RETIRED_TAB_IDS) {
+      const oldestTabId = retiredTabIds.values().next().value
+      if (typeof oldestTabId === 'string') {
+        retiredTabIds.delete(oldestTabId)
+      }
+    }
+  }
+  closeRetiredTerminalTab(tabId)
+}
+
+/** A queued SSH snapshot can predate the archive; reapply main retirement after hydration. */
+export function reapplyMainAuthoritativeTerminalRetirements(): void {
+  for (const tabId of retiredTabIds) {
+    closeRetiredTerminalTab(tabId)
+  }
+}

--- a/src/renderer/src/lib/remote-workspace-snapshot-gate.ts
+++ b/src/renderer/src/lib/remote-workspace-snapshot-gate.ts
@@ -1,0 +1,21 @@
+let snapshotApplyDepth = 0
+let writeSuppressUntil = 0
+
+const REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS = 1000
+
+export function isRemoteWorkspaceSnapshotApplyInProgress(): boolean {
+  return snapshotApplyDepth > 0 || Date.now() < writeSuppressUntil
+}
+
+export function beginRemoteWorkspaceSnapshotApply(): void {
+  snapshotApplyDepth += 1
+}
+
+export function finishRemoteWorkspaceSnapshotApply(): void {
+  writeSuppressUntil = Date.now() + REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS
+  snapshotApplyDepth = Math.max(0, snapshotApplyDepth - 1)
+}
+
+export function suppressRemoteWorkspaceSnapshotWrites(): void {
+  writeSuppressUntil = Date.now() + REMOTE_WORKSPACE_SNAPSHOT_WRITE_SUPPRESS_MS
+}

--- a/src/renderer/src/lib/workspace-session-host-field-ownership.ts
+++ b/src/renderer/src/lib/workspace-session-host-field-ownership.ts
@@ -39,6 +39,7 @@ export const WORKSPACE_SESSION_FIELD_OWNERSHIP = {
   browserPagesByWorkspace: 'browserWorkspaceKeyed',
   markdownFrontmatterVisible: 'fileKeyed',
   sleepingAgentSessionsByPaneKey: 'sleepingAgentKeyed',
+  terminalArchiveHintsByPaneKey: 'paneKeyed',
   terminalPtyIncarnationsByPaneKey: 'paneKeyed',
   // Why: this host-issued fence must never collide while unified renderer state merges equal repo ids across hosts.
   terminalTopologyRevisionByRepoId: 'hostPrivate',

--- a/src/renderer/src/runtime/mobile-session-tab-close.ts
+++ b/src/renderer/src/runtime/mobile-session-tab-close.ts
@@ -10,6 +10,9 @@ export function closeMobileSessionTabInStore(
   const unifiedTab = (store.unifiedTabsByWorktree[worktreeId] ?? []).find(
     (tab) => tab.id === tabId || tab.entityId === tabId
   )
+  if (unifiedTab?.contentType === 'terminal') {
+    return false
+  }
   if (unifiedTab && EDITOR_SESSION_CONTENT_TYPES.has(unifiedTab.contentType)) {
     store.closeFile(unifiedTab.entityId)
     return true

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -1424,7 +1424,7 @@ describe('web runtime session tab actions', () => {
         tabId: 'local-browser-unified',
         reason: 'user'
       })
-    ).resolves.toBe(true)
+    ).resolves.toEqual({})
 
     expect(runtimeCall).toHaveBeenNthCalledWith(1, {
       selector: ENVIRONMENT_ID,
@@ -1481,14 +1481,14 @@ describe('web runtime session tab actions', () => {
         publicationEpoch: 'epoch-1',
         terminalHandle: 'term-1'
       })
-    ).resolves.toBe(true)
+    ).resolves.toEqual({})
     await expect(
       closeWebRuntimeSessionTab({
         worktreeId: WORKTREE_ID,
         tabId: 'local-browser-unified',
         reason: 'user'
       })
-    ).resolves.toBe(true)
+    ).resolves.toEqual({})
 
     expect(runtimeCall).toHaveBeenNthCalledWith(1, {
       selector: ENVIRONMENT_ID,
@@ -1566,7 +1566,7 @@ describe('web runtime session tab actions', () => {
         publicationEpoch: 'epoch-1',
         terminalHandle: 'term-1'
       })
-    ).resolves.toBe(false)
+    ).resolves.toEqual({ closed: false })
 
     expect(runtimeCall).toHaveBeenNthCalledWith(
       1,
@@ -1617,7 +1617,7 @@ describe('web runtime session tab actions', () => {
         publicationEpoch: 'epoch-1',
         terminalHandle: 'term-1'
       })
-    ).resolves.toBe(true)
+    ).resolves.toEqual({ closed: true, refused: true, snapshotRepublished: true })
 
     expect(
       isWebSessionCloseIntentPending(
@@ -1668,7 +1668,7 @@ describe('web runtime session tab actions', () => {
         publicationEpoch: 'epoch-1',
         terminalHandle: 'term-1'
       })
-    ).resolves.toBe(true)
+    ).resolves.toEqual({ closed: true, refused: true })
 
     expect(
       isWebSessionCloseIntentPending(
@@ -1703,7 +1703,7 @@ describe('web runtime session tab actions', () => {
         tabId: 'local-browser-unified',
         reason: 'user'
       })
-    ).resolves.toBe(false)
+    ).resolves.toEqual({ closed: false })
 
     expect(
       isWebSessionCloseIntentPending(

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -659,7 +659,7 @@ export async function activateWebRuntimeSessionTab(args: {
   tabId: string
   environmentId?: string | null
 }): Promise<boolean> {
-  return callWebRuntimeSessionTabMethod('session.tabs.activate', args)
+  return (await callWebRuntimeSessionTabMethod('session.tabs.activate', args)) === true
 }
 
 export async function closeWebRuntimeSessionTab(args: {
@@ -669,8 +669,10 @@ export async function closeWebRuntimeSessionTab(args: {
   reason: RuntimeSessionTabCloseReason
   publicationEpoch?: string | null
   terminalHandle?: string | null
-}): Promise<boolean> {
-  return callWebRuntimeSessionTabMethod('session.tabs.close', args)
+}): Promise<RuntimeMobileSessionTabCloseResult | { closed: false }> {
+  return (await callWebRuntimeSessionTabMethod('session.tabs.close', args)) as
+    | RuntimeMobileSessionTabCloseResult
+    | { closed: false }
 }
 
 export async function moveWebRuntimeSessionTab(
@@ -790,7 +792,7 @@ async function callWebRuntimeSessionTabMethod(
     publicationEpoch?: string | null
     terminalHandle?: string | null
   }
-): Promise<boolean> {
+): Promise<boolean | RuntimeMobileSessionTabCloseResult | { closed: false }> {
   const environmentId =
     args.environmentId?.trim() ??
     useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() ??
@@ -879,7 +881,7 @@ async function callWebRuntimeSessionTabMethod(
         expectedEnvironmentPairingRevision: intentOwner.pairingRevision
       })
     }
-    return true
+    return isClose ? (result ?? { closed: false }) : true
   } catch (error) {
     for (const hostTabId of closeIntentTabIds) {
       clearWebSessionCloseIntent(intentOwner, args.worktreeId, hostTabId)
@@ -895,7 +897,7 @@ async function callWebRuntimeSessionTabMethod(
       `[web-runtime-session] failed to ${isClose ? 'close' : 'activate'} tab:`,
       error instanceof Error ? error.message : String(error)
     )
-    return false
+    return isClose ? { closed: false } : false
   }
 }
 

--- a/src/renderer/src/store/slices/agent-pane-authority.test.ts
+++ b/src/renderer/src/store/slices/agent-pane-authority.test.ts
@@ -18,6 +18,7 @@ const dropByTabPrefix = vi.fn()
 beforeEach(() => {
   resetAgentPaneAuthorityAliasesForTests()
   vi.clearAllMocks()
+  transferPaneAuthority.mockResolvedValue({ kind: 'transferred' })
   vi.stubGlobal('window', {
     api: {
       agentStatus: {
@@ -69,7 +70,7 @@ describe('agent pane authority', () => {
     expect(retirePaneAuthority).toHaveBeenCalledWith(TARGET)
   })
 
-  it('keeps a physical pane routed through chained detaches until its current owner closes', () => {
+  it('keeps a physical pane routed through chained detaches until its current owner closes', async () => {
     const store = createTestStore()
     store.getState().setAgentStatus(SOURCE, { state: 'working', prompt: 'source' })
     store.setState({
@@ -94,6 +95,7 @@ describe('agent pane authority', () => {
     store
       .getState()
       .transferAgentPaneAuthority({ fromPaneKey: TARGET, toPaneKey: FINAL, ptyId: 'pty-1' })
+    await vi.waitFor(() => expect(resolveAgentPaneAuthorityKey(SOURCE)).toBe(FINAL))
     store.getState().dropAgentStatusByTabPrefix('tab-source')
 
     expect(resolveAgentPaneAuthorityKey(SOURCE)).toBe(FINAL)
@@ -121,5 +123,79 @@ describe('agent pane authority', () => {
     expect(store.getState().agentStatusByPaneKey[SOURCE]).toBeUndefined()
     expect(store.getState().agentStatusByPaneKey[FINAL]).toBeUndefined()
     expect(store.getState().recentlyRetiredAgentStatusPaneKeys[SOURCE]).toBe(true)
+  })
+
+  it('commits renderer authority only after main acknowledges the durable transfer', async () => {
+    let resolveTransfer: ((result: { kind: 'transferred' }) => void) | undefined
+    transferPaneAuthority.mockImplementationOnce(
+      () =>
+        new Promise((resolve: (result: { kind: 'transferred' }) => void) => {
+          resolveTransfer = resolve
+        })
+    )
+    const store = createTestStore()
+    store.getState().setAgentStatus(SOURCE, { state: 'working', prompt: 'source' })
+
+    store
+      .getState()
+      .transferAgentPaneAuthority({ fromPaneKey: SOURCE, toPaneKey: TARGET, ptyId: 'pty-1' })
+
+    expect(resolveAgentPaneAuthorityKey(SOURCE)).toBe(SOURCE)
+    expect(store.getState().agentStatusByPaneKey[SOURCE]?.prompt).toBe('source')
+    await vi.waitFor(() => expect(resolveTransfer).toBeTypeOf('function'))
+    resolveTransfer!({ kind: 'transferred' })
+    await vi.waitFor(() => expect(resolveAgentPaneAuthorityKey(SOURCE)).toBe(TARGET))
+    expect(store.getState().agentStatusByPaneKey[TARGET]?.prompt).toBe('source')
+  })
+
+  it('keeps renderer authority at the source when main rejects the durable transfer', async () => {
+    transferPaneAuthority.mockResolvedValueOnce({ kind: 'not-owned' })
+    const store = createTestStore()
+    store.getState().setAgentStatus(SOURCE, { state: 'working', prompt: 'source' })
+
+    store
+      .getState()
+      .transferAgentPaneAuthority({ fromPaneKey: SOURCE, toPaneKey: TARGET, ptyId: 'pty-1' })
+    await vi.waitFor(() => expect(transferPaneAuthority).toHaveBeenCalledTimes(1))
+
+    expect(resolveAgentPaneAuthorityKey(SOURCE)).toBe(SOURCE)
+    expect(store.getState().agentStatusByPaneKey[SOURCE]?.prompt).toBe('source')
+    expect(store.getState().agentStatusByPaneKey[TARGET]).toBeUndefined()
+  })
+
+  it('keeps renderer authority at the source when durability retries are exhausted', async () => {
+    vi.useFakeTimers()
+    try {
+      transferPaneAuthority.mockResolvedValue({ kind: 'durability-failed' })
+      const store = createTestStore()
+      store.getState().setAgentStatus(SOURCE, { state: 'working', prompt: 'source' })
+
+      store
+        .getState()
+        .transferAgentPaneAuthority({ fromPaneKey: SOURCE, toPaneKey: TARGET, ptyId: 'pty-1' })
+      await vi.runAllTimersAsync()
+
+      expect(transferPaneAuthority).toHaveBeenCalledTimes(3)
+      expect(resolveAgentPaneAuthorityKey(SOURCE)).toBe(SOURCE)
+      expect(store.getState().agentStatusByPaneKey[SOURCE]?.prompt).toBe('source')
+      expect(store.getState().agentStatusByPaneKey[TARGET]).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps renderer authority at the source when the IPC invoke rejects', async () => {
+    transferPaneAuthority.mockRejectedValueOnce(new Error('IPC closed'))
+    const store = createTestStore()
+    store.getState().setAgentStatus(SOURCE, { state: 'working', prompt: 'source' })
+
+    store
+      .getState()
+      .transferAgentPaneAuthority({ fromPaneKey: SOURCE, toPaneKey: TARGET, ptyId: 'pty-1' })
+    await vi.waitFor(() => expect(transferPaneAuthority).toHaveBeenCalledTimes(1))
+
+    expect(resolveAgentPaneAuthorityKey(SOURCE)).toBe(SOURCE)
+    expect(store.getState().agentStatusByPaneKey[SOURCE]?.prompt).toBe('source')
+    expect(store.getState().agentStatusByPaneKey[TARGET]).toBeUndefined()
   })
 })

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -47,17 +47,30 @@ import {
 import { createFreshnessScheduler } from './agent-status-freshness-scheduler'
 import { retainTransientAgentStatusClearedConnection } from '@/lib/transient-agent-status-clear-retention'
 
-function persistAgentPaneAuthorityTransfer(
-  args: { fromPaneKey: string; toPaneKey: string; ptyId?: string },
-  attempt = 0
-): void {
-  const request = window.api?.agentStatus?.transferPaneAuthority?.(args)
-  void Promise.resolve(request).then((result) => {
-    if (result?.kind === 'durability-failed' && attempt < 2) {
-      // Renderer membership moves first; retry only a confirmed transient durable failure.
-      setTimeout(() => persistAgentPaneAuthorityTransfer(args, attempt + 1), 100 * (attempt + 1))
+function persistAgentPaneAuthorityTransfer(args: {
+  fromPaneKey: string
+  toPaneKey: string
+  ptyId?: string
+}): Promise<boolean> {
+  return (async () => {
+    for (let attempt = 0; attempt <= 2; attempt += 1) {
+      try {
+        const result = await (typeof window === 'undefined'
+          ? undefined
+          : window.api?.agentStatus?.transferPaneAuthority?.(args))
+        if (result?.kind === 'transferred') {
+          return true
+        }
+        if (result?.kind !== 'durability-failed' || attempt === 2) {
+          return false
+        }
+      } catch {
+        return false
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 100 * (attempt + 1)))
     }
-  })
+    return false
+  })()
 }
 
 /** Snapshot of a finished/vanished agent status entry, kept so the dashboard and sidebar hover
@@ -1196,6 +1209,67 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
     }
   })
 
+  let agentPaneAuthorityTransferQueue = Promise.resolve()
+
+  const commitAgentPaneAuthorityTransfer = (args: {
+    fromPaneKey: string
+    toPaneKey: string
+    ptyId?: string | null
+  }): void => {
+    const transfer = transferAgentPaneAuthorityAlias(args)
+    if (!transfer || transfer.previousOwnerPaneKey === transfer.ownerPaneKey) {
+      return
+    }
+    const from = transfer.previousOwnerPaneKey
+    const to = transfer.ownerPaneKey
+    const targetTabId = getTabIdFromPaneKey(to) ?? undefined
+    const targetLeafId = getLeafIdFromPaneKey(to) ?? undefined
+    set((s) => ({
+      agentStatusByPaneKey: movePaneKeyedRecord(s.agentStatusByPaneKey, from, to, (entry) => ({
+        ...entry,
+        paneKey: to,
+        tabId: targetTabId
+      })),
+      runtimeAgentOrchestrationByPaneKey: movePaneKeyedRecord(
+        s.runtimeAgentOrchestrationByPaneKey,
+        from,
+        to
+      ),
+      retainedAgentsByPaneKey: movePaneKeyedRecord(
+        s.retainedAgentsByPaneKey,
+        from,
+        to,
+        (retained) => ({
+          ...retained,
+          entry: { ...retained.entry, paneKey: to, tabId: targetTabId },
+          tab: targetTabId ? { ...retained.tab, id: targetTabId } : retained.tab
+        })
+      ),
+      sleepingAgentSessionsByPaneKey: movePaneKeyedRecord(
+        s.sleepingAgentSessionsByPaneKey,
+        from,
+        to,
+        (record) => ({ ...record, paneKey: to, tabId: targetTabId })
+      ),
+      agentLaunchConfigByPaneKey: movePaneKeyedRecord(
+        s.agentLaunchConfigByPaneKey,
+        from,
+        to,
+        (entry) => ({
+          ...entry,
+          identity: { ...entry.identity, tabId: targetTabId, leafId: targetLeafId }
+        })
+      ),
+      acknowledgedAgentsByPaneKey: movePaneKeyedRecord(s.acknowledgedAgentsByPaneKey, from, to),
+      paneForegroundAgentByPaneKey: movePaneKeyedRecord(s.paneForegroundAgentByPaneKey, from, to),
+      unreadTerminalPanes: movePaneKeyedRecord(s.unreadTerminalPanes, from, to),
+      unreadAgentCompletionPanes: movePaneKeyedRecord(s.unreadAgentCompletionPanes, from, to),
+      lastTerminalInputAtByPaneKey: movePaneKeyedRecord(s.lastTerminalInputAtByPaneKey, from, to),
+      cacheTimerByKey: movePaneKeyedRecord(s.cacheTimerByKey, from, to),
+      retentionSuppressedPaneKeys: movePaneKeyedRecord(s.retentionSuppressedPaneKeys, from, to)
+    }))
+  }
+
   const clearSleepingAgentSessionsByPaneKey = (paneKeys: readonly string[]): void => {
     if (paneKeys.length === 0) {
       return
@@ -1317,65 +1391,17 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
     },
 
     transferAgentPaneAuthority: ({ fromPaneKey, toPaneKey, ptyId }) => {
-      const transfer = transferAgentPaneAuthorityAlias({ fromPaneKey, toPaneKey, ptyId })
-      if (!transfer || transfer.previousOwnerPaneKey === transfer.ownerPaneKey) {
-        return
-      }
-      const from = transfer.previousOwnerPaneKey
-      const to = transfer.ownerPaneKey
-      const targetTabId = getTabIdFromPaneKey(to) ?? undefined
-      const targetLeafId = getLeafIdFromPaneKey(to) ?? undefined
-      set((s) => ({
-        agentStatusByPaneKey: movePaneKeyedRecord(s.agentStatusByPaneKey, from, to, (entry) => ({
-          ...entry,
-          paneKey: to,
-          tabId: targetTabId
-        })),
-        runtimeAgentOrchestrationByPaneKey: movePaneKeyedRecord(
-          s.runtimeAgentOrchestrationByPaneKey,
-          from,
-          to
-        ),
-        retainedAgentsByPaneKey: movePaneKeyedRecord(
-          s.retainedAgentsByPaneKey,
-          from,
-          to,
-          (retained) => ({
-            ...retained,
-            entry: { ...retained.entry, paneKey: to, tabId: targetTabId },
-            tab: targetTabId ? { ...retained.tab, id: targetTabId } : retained.tab
-          })
-        ),
-        sleepingAgentSessionsByPaneKey: movePaneKeyedRecord(
-          s.sleepingAgentSessionsByPaneKey,
-          from,
-          to,
-          (record) => ({ ...record, paneKey: to, tabId: targetTabId })
-        ),
-        agentLaunchConfigByPaneKey: movePaneKeyedRecord(
-          s.agentLaunchConfigByPaneKey,
-          from,
-          to,
-          (entry) => ({
-            ...entry,
-            identity: { ...entry.identity, tabId: targetTabId, leafId: targetLeafId }
-          })
-        ),
-        acknowledgedAgentsByPaneKey: movePaneKeyedRecord(s.acknowledgedAgentsByPaneKey, from, to),
-        paneForegroundAgentByPaneKey: movePaneKeyedRecord(s.paneForegroundAgentByPaneKey, from, to),
-        unreadTerminalPanes: movePaneKeyedRecord(s.unreadTerminalPanes, from, to),
-        unreadAgentCompletionPanes: movePaneKeyedRecord(s.unreadAgentCompletionPanes, from, to),
-        lastTerminalInputAtByPaneKey: movePaneKeyedRecord(s.lastTerminalInputAtByPaneKey, from, to),
-        cacheTimerByKey: movePaneKeyedRecord(s.cacheTimerByKey, from, to),
-        retentionSuppressedPaneKeys: movePaneKeyedRecord(s.retentionSuppressedPaneKeys, from, to)
-      }))
-      if (typeof window !== 'undefined') {
-        persistAgentPaneAuthorityTransfer({
-          fromPaneKey: from,
-          toPaneKey: to,
-          ...(transfer.ptyId ? { ptyId: transfer.ptyId } : {})
+      // Why: chained detaches must commit in main's acknowledged order so a later target is never sent before its predecessor exists.
+      agentPaneAuthorityTransferQueue = agentPaneAuthorityTransferQueue.then(async () => {
+        const transferred = await persistAgentPaneAuthorityTransfer({
+          fromPaneKey,
+          toPaneKey,
+          ...(ptyId ? { ptyId } : {})
         })
-      }
+        if (transferred) {
+          commitAgentPaneAuthorityTransfer({ fromPaneKey, toPaneKey, ptyId })
+        }
+      })
     },
 
     setRuntimeAgentOrchestrationByPaneKey: (entries) => {

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -47,6 +47,19 @@ import {
 import { createFreshnessScheduler } from './agent-status-freshness-scheduler'
 import { retainTransientAgentStatusClearedConnection } from '@/lib/transient-agent-status-clear-retention'
 
+function persistAgentPaneAuthorityTransfer(
+  args: { fromPaneKey: string; toPaneKey: string; ptyId?: string },
+  attempt = 0
+): void {
+  const request = window.api?.agentStatus?.transferPaneAuthority?.(args)
+  void Promise.resolve(request).then((result) => {
+    if (result?.kind === 'durability-failed' && attempt < 2) {
+      // Renderer membership moves first; retry only a confirmed transient durable failure.
+      setTimeout(() => persistAgentPaneAuthorityTransfer(args, attempt + 1), 100 * (attempt + 1))
+    }
+  })
+}
+
 /** Snapshot of a finished/vanished agent status entry, kept so the dashboard and sidebar hover
  *  keep showing the completion until the user clicks the worktree. `worktreeId` is stamped at
  *  retention time so the row's home is known even after its tab/pty is gone. */
@@ -1357,7 +1370,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         retentionSuppressedPaneKeys: movePaneKeyedRecord(s.retentionSuppressedPaneKeys, from, to)
       }))
       if (typeof window !== 'undefined') {
-        window.api?.agentStatus?.transferPaneAuthority?.({
+        persistAgentPaneAuthorityTransfer({
           fromPaneKey: from,
           toPaneKey: to,
           ...(transfer.ptyId ? { ptyId: transfer.ptyId } : {})

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -251,7 +251,7 @@ describe('TabsSlice', () => {
       // Activate t2 so closing it tests neighbor selection
       store.getState().activateTab(t2.id)
 
-      const result = store.getState().closeUnifiedTab(t2.id)
+      const result = store.getState().closeUnifiedTab(t2.id, { terminalRetirementHandled: true })
 
       expect(result).toEqual({ closedTabId: t2.id, wasLastTab: false, worktreeId: WT })
       const state = store.getState()
@@ -265,7 +265,7 @@ describe('TabsSlice', () => {
       const t2 = store.getState().createUnifiedTab(WT, 'terminal')
       // t2 is already active (last created)
 
-      const result = store.getState().closeUnifiedTab(t2.id)
+      const result = store.getState().closeUnifiedTab(t2.id, { terminalRetirementHandled: true })
 
       expect(result?.wasLastTab).toBe(false)
       expect(store.getState().groupsByWorktree[WT][0].activeTabId).toBe(t1.id)
@@ -274,7 +274,7 @@ describe('TabsSlice', () => {
     it('returns wasLastTab: true when closing the only tab', () => {
       const t1 = store.getState().createUnifiedTab(WT, 'terminal')
 
-      const result = store.getState().closeUnifiedTab(t1.id)
+      const result = store.getState().closeUnifiedTab(t1.id, { terminalRetirementHandled: true })
 
       expect(result?.wasLastTab).toBe(true)
       expect(store.getState().unifiedTabsByWorktree[WT]).toHaveLength(0)
@@ -287,7 +287,7 @@ describe('TabsSlice', () => {
       const t3 = store.getState().createUnifiedTab(WT, 'terminal')
       // t3 is active
 
-      store.getState().closeUnifiedTab(t1.id)
+      store.getState().closeUnifiedTab(t1.id, { terminalRetirementHandled: true })
 
       expect(store.getState().groupsByWorktree[WT][0].activeTabId).toBe(t3.id)
     })
@@ -432,7 +432,7 @@ describe('TabsSlice', () => {
       // Visit order ...→t3→t1→t3; closing t3 should jump to t1 (MRU previous), not the visual neighbor t2.
       store.getState().activateTab(t1.id)
       store.getState().activateTab(t3.id)
-      store.getState().closeUnifiedTab(t3.id)
+      store.getState().closeUnifiedTab(t3.id, { terminalRetirementHandled: true })
 
       expect(store.getState().groupsByWorktree[WT][0].activeTabId).toBe(t1.id)
       // t2 should still exist and not be active
@@ -502,7 +502,7 @@ describe('TabsSlice', () => {
         activeGroupIdByWorktree: { [WT]: groupId }
       })
 
-      store.getState().closeUnifiedTab('b')
+      store.getState().closeUnifiedTab('b', { terminalRetirementHandled: true })
 
       // MRU only contains 'b' itself, so fallback picks the right neighbor 'c'.
       expect(store.getState().groupsByWorktree[WT][0].activeTabId).toBe('c')
@@ -529,7 +529,7 @@ describe('TabsSlice', () => {
       // Re-focus the second group via t2, then close it: expect the same-group previous tab (t3), not a source-group neighbor.
       store.getState().activateTab(t3.id)
       store.getState().activateTab(t2.id)
-      store.getState().closeUnifiedTab(t2.id)
+      store.getState().closeUnifiedTab(t2.id, { terminalRetirementHandled: true })
 
       const secondGroup = store.getState().groupsByWorktree[WT].find((g) => g.id === secondGroupId)
       expect(secondGroup?.activeTabId).toBe(t3.id)
@@ -1341,9 +1341,9 @@ describe('TabsSlice', () => {
 
   describe('closeOtherTabs', () => {
     it('closes all tabs except the target and pinned tabs', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t3 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'editor')
+      const t2 = store.getState().createUnifiedTab(WT, 'editor')
+      const t3 = store.getState().createUnifiedTab(WT, 'editor')
 
       store.getState().pinTab(t1.id)
 
@@ -1357,8 +1357,8 @@ describe('TabsSlice', () => {
     })
 
     it('activates the target tab', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'editor')
+      store.getState().createUnifiedTab(WT, 'editor')
 
       store.getState().closeOtherTabs(t1.id)
 
@@ -1370,16 +1370,24 @@ describe('TabsSlice', () => {
       const closed = store.getState().closeOtherTabs(t1.id)
       expect(closed).toEqual([])
     })
+
+    it('leaves terminal rows for the archive transaction', () => {
+      const target = store.getState().createUnifiedTab(WT, 'editor')
+      const terminal = store.getState().createUnifiedTab(WT, 'terminal')
+
+      expect(store.getState().closeOtherTabs(target.id)).toEqual([])
+      expect(store.getState().unifiedTabsByWorktree[WT].map((tab) => tab.id)).toContain(terminal.id)
+    })
   })
 
   // ─── closeTabsToRight ─────────────────────────────────────────────
 
   describe('closeTabsToRight', () => {
     it('closes unpinned tabs to the right of target', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t3 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t4 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'editor')
+      const t2 = store.getState().createUnifiedTab(WT, 'editor')
+      const t3 = store.getState().createUnifiedTab(WT, 'editor')
+      const t4 = store.getState().createUnifiedTab(WT, 'editor')
 
       store.getState().pinTab(t3.id)
 
@@ -1391,8 +1399,8 @@ describe('TabsSlice', () => {
     })
 
     it('activates target if active tab was closed', () => {
-      const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      store.getState().createUnifiedTab(WT, 'terminal')
+      const t1 = store.getState().createUnifiedTab(WT, 'editor')
+      store.getState().createUnifiedTab(WT, 'editor')
       // last created tab is active
 
       store.getState().closeTabsToRight(t1.id)
@@ -1757,7 +1765,7 @@ describe('TabsSlice', () => {
 
       // Activate the terminal tab, then close it
       store.getState().activateTab(term.id)
-      store.getState().closeUnifiedTab(term.id)
+      store.getState().closeUnifiedTab(term.id, { terminalRetirementHandled: true })
 
       expect(store.getState().groupsByWorktree[WT][0].activeTabId).toBe(editor.id)
     })

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -878,11 +878,8 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     }
 
     if (tab.contentType === 'terminal' && !opts?.terminalRetirementHandled) {
-      const dedupedGroupOrder = dedupeTabOrder(group.tabOrder)
-      const wasLastTab = dedupeTabOrder(dedupedGroupOrder.filter((id) => id !== tabId)).length === 0
-      // Why: unified-only hydrated tabs still own provider sessions without a legacy row, so retire every terminal close by entity id.
-      get().closeTab(tab.entityId, { recordInteraction: opts?.recordInteraction })
-      return { closedTabId: tabId, wasLastTab, worktreeId }
+      // Why: archive-first retirement is asynchronous and lives outside this synchronous visual-state slice.
+      return null
     }
 
     const dedupedGroupOrder = dedupeTabOrder(group.tabOrder)
@@ -1191,7 +1188,13 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       return []
     }
     const closedIds = (state.unifiedTabsByWorktree[worktreeId] ?? [])
-      .filter((item) => item.groupId === group.id && item.id !== tabId && !item.isPinned)
+      .filter(
+        (item) =>
+          item.groupId === group.id &&
+          item.id !== tabId &&
+          !item.isPinned &&
+          item.contentType !== 'terminal'
+      )
       .map((item) => item.id)
     for (const id of closedIds) {
       get().closeUnifiedTab(id)
@@ -1214,13 +1217,12 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
     if (index === -1) {
       return []
     }
-    const closableIds = group.tabOrder
-      .slice(index + 1)
-      .filter(
-        (id) =>
-          !(state.unifiedTabsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === id)
-            ?.isPinned
+    const closableIds = group.tabOrder.slice(index + 1).filter((id) => {
+      const candidate = (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+        (item) => item.id === id
       )
+      return !candidate?.isPinned && candidate?.contentType !== 'terminal'
+    })
     for (const id of closableIds) {
       get().closeUnifiedTab(id)
     }

--- a/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
+++ b/src/renderer/src/store/slices/terminal-pane-detach-agent-identity.test.ts
@@ -1,9 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveWindowsShiftEnterEncodingForPane } from '@/components/terminal-pane/terminal-windows-shift-enter'
 import { createTestStore, makeTab, makeWorktree, seedStore } from './store-test-helpers'
 
+const transferPaneAuthority = vi.fn()
+
+beforeEach(() => {
+  transferPaneAuthority.mockReset()
+  transferPaneAuthority.mockResolvedValue({ kind: 'transferred' })
+  vi.stubGlobal('window', { api: { agentStatus: { transferPaneAuthority } } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
 describe('syncPaneDetachPtyOwnership agent identity', () => {
-  it('moves process, hook, launch, and resume authority to the detached leaf', () => {
+  it('moves process, hook, launch, and resume authority to the detached leaf after main acknowledges it', async () => {
     const store = createTestStore()
     const worktreeId = 'repo::/repo/worktree'
     const sourceTabId = 'tab-source'
@@ -77,6 +89,11 @@ describe('syncPaneDetachPtyOwnership agent identity', () => {
       sourceTabId,
       targetTabId
     })
+
+    await vi.waitFor(() => expect(transferPaneAuthority).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() =>
+      expect(store.getState().agentStatusByPaneKey[targetPaneKey]).toBeDefined()
+    )
 
     const state = store.getState()
     expect(state.paneForegroundAgentByPaneKey[sourcePaneKey]).toBeUndefined()

--- a/src/renderer/src/store/slices/terminal-tab-retirement-store.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-retirement-store.test.ts
@@ -244,7 +244,7 @@ describe('terminal tab retirement store boundary', () => {
     expect(store.getState().lastKnownRelayPtyIdByTabId['closed-tab']).toBeUndefined()
   })
 
-  it('retires a unified-only terminal instead of removing only its wrapper', async () => {
+  it('keeps a unified-only terminal until archive-first close hands off retirement', () => {
     const store = createRetirementStore()
     const unified = makeUnifiedTab({
       id: 'unified-tab-1',
@@ -268,11 +268,12 @@ describe('terminal tab retirement store boundary', () => {
       ptyIdsByTabId: { 'terminal-tab-1': ['pty-unified-only'] }
     })
 
-    store.getState().closeUnifiedTab(unified.id)
-    await vi.waitFor(() => expect(mockKill).toHaveBeenCalledWith('pty-unified-only'))
+    const result = store.getState().closeUnifiedTab(unified.id)
 
-    expect(store.getState().unifiedTabsByWorktree['wt-1']).toEqual([])
-    expect(store.getState().ptyIdsByTabId['terminal-tab-1']).toBeUndefined()
+    expect(result).toBeNull()
+    expect(mockKill).not.toHaveBeenCalled()
+    expect(store.getState().unifiedTabsByWorktree['wt-1']).toEqual([unified])
+    expect(store.getState().ptyIdsByTabId['terminal-tab-1']).toEqual(['pty-unified-only'])
   })
 
   it('lets a paired host own runtime teardown while pruning local state', async () => {

--- a/src/renderer/src/store/slices/terminal-tab-retirement.ts
+++ b/src/renderer/src/store/slices/terminal-tab-retirement.ts
@@ -10,7 +10,7 @@ import { resolveWorktreeOperationRouteResult } from '@/lib/worktree-operation-ro
 import { parseExecutionHostId } from '../../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 
-export type TerminalTabCloseReason = 'user' | 'cleanup' | 'pty-exit'
+export type TerminalTabCloseReason = 'user' | 'cleanup' | 'pty-exit' | 'pane-only'
 
 export type TerminalTabRetirementState = WorktreeRuntimeOwnerState &
   Pick<

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -581,6 +581,7 @@ export type TerminalSlice = {
       captureRecentlyClosed?: boolean
       remoteCloseOwnedByHost?: boolean
       localPtyTeardownOwnedExternally?: boolean
+      runtimePtyTeardownOwnedExternally?: boolean
       precomputedRetirementPlan?: TerminalTabRetirementPlan
     }
   ) => void
@@ -1176,7 +1177,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ? []
         : retirementPlan.localOrSshPtyIds.map(async (ptyId) => window.api.pty.kill(ptyId))
       const localOrSshTaskCount = retirementTasks.length
-      if (!opts?.remoteCloseOwnedByHost) {
+      if (!opts?.remoteCloseOwnedByHost && !opts?.runtimePtyTeardownOwnedExternally) {
         for (const terminal of retirementPlan.runtimeTerminals) {
           if (!terminal.environmentId && !fallbackWorktreeRoute) {
             continue

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -818,7 +818,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
       drop: () => {},
       dropByTabPrefix: () => {},
       retirePaneAuthority: () => {},
-      transferPaneAuthority: () => {}
+      transferPaneAuthority: async () => ({ kind: 'not-owned' as const })
     },
     mobile: {
       listNetworkInterfaces: () => Promise.resolve({ interfaces: [] }),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2951,6 +2951,8 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     kill: () => Promise.resolve(),
     // A web client must ask its runtime owner to archive; pretending this local shim succeeded would permit data loss.
     archiveTerminalTab: () => Promise.reject(new Error('terminal_archive_unavailable')),
+    handleLostTerminalCandidate: () =>
+      Promise.resolve({ kind: 'retryable-error', code: 'durability-failed' }),
     ackColdRestore: () => {},
     ackData: () => {},
     onDeliveryResyncRequest: () => noopUnsubscribe,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2949,6 +2949,8 @@ function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
     // Web panes clear the host buffer via the terminal.clearBuffer runtime RPC.
     clearBuffer: () => {},
     kill: () => Promise.resolve(),
+    // A web client must ask its runtime owner to archive; pretending this local shim succeeded would permit data loss.
+    archiveTerminalTab: () => Promise.reject(new Error('terminal_archive_unavailable')),
     ackColdRestore: () => {},
     ackData: () => {},
     onDeliveryResyncRequest: () => noopUnsubscribe,

--- a/src/shared/agent-session-owner-wire-normalization.ts
+++ b/src/shared/agent-session-owner-wire-normalization.ts
@@ -1,0 +1,80 @@
+import {
+  isAgentSessionOwnerBinding,
+  type AgentSessionOwnerBinding
+} from './agent-session-host-authority'
+
+const MAX_AGENT_SESSION_OWNER_BINDINGS = 1_024
+
+export function normalizeAgentSessionOwnerBindings(
+  value: unknown,
+  entryId: string,
+  context: string
+): AgentSessionOwnerBinding[] {
+  if (!Array.isArray(value) || value.length > MAX_AGENT_SESSION_OWNER_BINDINGS) {
+    throw new Error(`${context} agent owners are invalid`)
+  }
+  return value.map((owner) => normalizeAgentSessionOwnerBinding(owner, entryId, context))
+}
+
+function normalizeAgentSessionOwnerBinding(
+  value: unknown,
+  entryId: string,
+  context: string
+): AgentSessionOwnerBinding {
+  const owner = requiredRecord(value, `${context} agent owner`)
+  assertExactKeys(
+    owner,
+    ['claim', 'generation', 'phase', 'ptyId', 'surface'],
+    `${context} agent owner`
+  )
+  const claim = requiredRecord(owner.claim, `${context} agent owner claim`)
+  assertExactKeys(
+    claim,
+    ['digestVersion', 'keyId', 'identityDigest', 'worktreeScopeDigest', 'agent'],
+    `${context} agent owner claim`
+  )
+  const surface = requiredRecord(owner.surface, `${context} agent owner surface`)
+  assertExactKeys(
+    surface,
+    ['worktreeId', 'tabId', 'leafId', 'terminalHandle'],
+    `${context} agent owner surface`
+  )
+  if (!isAgentSessionOwnerBinding(owner) || owner.ptyId !== entryId) {
+    throw new Error(`${context} agent owner is invalid`)
+  }
+  return {
+    claim: {
+      digestVersion: owner.claim.digestVersion,
+      keyId: owner.claim.keyId,
+      identityDigest: owner.claim.identityDigest,
+      worktreeScopeDigest: owner.claim.worktreeScopeDigest,
+      agent: owner.claim.agent
+    },
+    generation: owner.generation,
+    phase: owner.phase,
+    ptyId: owner.ptyId,
+    surface: {
+      worktreeId: owner.surface.worktreeId,
+      tabId: owner.surface.tabId,
+      leafId: owner.surface.leafId,
+      terminalHandle: owner.surface.terminalHandle
+    }
+  }
+}
+
+function requiredRecord(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name} is invalid`)
+  }
+  return value as Record<string, unknown>
+}
+
+function assertExactKeys(
+  record: Record<string, unknown>,
+  allowed: readonly string[],
+  name: string
+): void {
+  if (Object.keys(record).some((key) => !allowed.includes(key))) {
+    throw new Error(`${name} contains an unknown field`)
+  }
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -33,6 +33,13 @@ import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from './terminal-scrollback-policy'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
+import { DEFAULT_TERMINAL_ARCHIVE_RETENTION_DAYS } from './terminal-archive-types'
+
+export {
+  DEFAULT_TERMINAL_ARCHIVE_RETENTION_DAYS,
+  MAX_TERMINAL_ARCHIVE_RETENTION_DAYS,
+  MIN_TERMINAL_ARCHIVE_RETENTION_DAYS
+} from './terminal-archive-types'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -251,6 +258,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     claudeAgentTeamsMode: 'off',
     setupScriptLaunchMode: 'new-tab',
     terminalScrollbackRows: DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT,
+    terminalArchiveRetentionDays: DEFAULT_TERMINAL_ARCHIVE_RETENTION_DAYS,
     httpProxyUrl: '',
     httpProxyBypassRules: '',
     electronHttp1CompatibilityMode: false,
@@ -414,6 +422,7 @@ export function getDefaultPersistedState(homedir: string): PersistedState {
     githubCache: { pr: {}, issue: {} },
     workspaceSession: getDefaultWorkspaceSession(),
     workspaceSessionsByHostId: {},
+    terminalArchivesById: {},
     sshTargets: [],
     deletedSshConfigAliases: [],
     sshRemotePtyLeases: [],
@@ -501,6 +510,7 @@ export function getDefaultWorkspaceSession(): WorkspaceSessionState {
     activeTabId: null,
     tabsByWorktree: {},
     terminalLayoutsByTabId: {},
+    terminalArchiveHintsByPaneKey: {},
     openFilesByWorktree: {},
     markdownFrontmatterVisible: {},
     browserTabsByWorktree: {},

--- a/src/shared/pty-persistence-wire-limits.ts
+++ b/src/shared/pty-persistence-wire-limits.ts
@@ -1,0 +1,18 @@
+import { measureUtf8ByteLength } from './utf8-byte-limits'
+
+export const MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES = 64 * 1024
+
+export function isRelayPtyPersistenceFieldWithinLimit(
+  value: string,
+  maxBytes = MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES
+): boolean {
+  return !measureUtf8ByteLength(value, { stopAfterBytes: maxBytes }).exceededLimit
+}
+
+export function assertRelayPtyPersistenceFieldWithinLimit(field: string, value: string): void {
+  if (!isRelayPtyPersistenceFieldWithinLimit(value)) {
+    throw new Error(
+      `PTY persistence field "${field}" exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`
+    )
+  }
+}

--- a/src/shared/pty-revive-outcome-fields.ts
+++ b/src/shared/pty-revive-outcome-fields.ts
@@ -1,14 +1,19 @@
 import { normalizeAgentProviderSession } from './agent-session-resume'
-import { isAgentSessionOwnerBinding } from './agent-session-host-authority'
+import { normalizeAgentSessionOwnerBindings } from './agent-session-owner-wire-normalization'
+import {
+  isRelayPtyPersistenceFieldWithinLimit,
+  MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES
+} from './pty-persistence-wire-limits'
 import type {
   RelayPtyLostEntry,
   RelayPtyReviveDiagnostic,
   RelayPtyRevivedEntry
 } from './pty-revive-protocol'
 import { isTuiAgent } from './tui-agent-config'
+import { terminalSizeAdmissionError } from './terminal-size-limits'
 import { measureUtf8ByteLength } from './utf8-byte-limits'
 
-const MAX_RELAY_PTY_REVIVE_FIELD_BYTES = 64 * 1024
+export const MAX_RELAY_PTY_REVIVE_FIELD_BYTES = MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES
 const MAX_RELAY_PTY_REVIVE_REPLAY_TAIL_BYTES = 100 * 1024
 
 export function normalizeRelayPtyRevivedEntry(value: unknown): RelayPtyRevivedEntry {
@@ -70,13 +75,18 @@ export function normalizeRelayPtyLostEntry(value: unknown): RelayPtyLostEntry {
   ) {
     throw new Error('PTY revive lost entry reason is invalid')
   }
+  const id = requiredString(entry.id, 'PTY revive lost entry id')
+  const sizeError = terminalSizeAdmissionError(entry.cols, entry.rows, 'PTY revive lost entry')
+  if (sizeError) {
+    throw new Error(sizeError)
+  }
   return {
-    id: requiredString(entry.id, 'PTY revive lost entry id'),
+    id,
     kind: entry.kind,
     reason: entry.reason,
     pid: positiveSafeInteger(entry.pid, 'PTY revive lost entry pid'),
-    cols: positiveSafeInteger(entry.cols, 'PTY revive lost entry cols'),
-    rows: positiveSafeInteger(entry.rows, 'PTY revive lost entry rows'),
+    cols: entry.cols as number,
+    rows: entry.rows as number,
     cwd: requiredString(entry.cwd, 'PTY revive lost entry cwd'),
     ...optionalStringField(entry, 'sourceIncarnationId', 'PTY revive lost entry'),
     ...optionalStringField(entry, 'paneKey', 'PTY revive lost entry'),
@@ -86,7 +96,7 @@ export function normalizeRelayPtyLostEntry(value: unknown): RelayPtyLostEntry {
     ...optionalStringField(entry, 'terminalHandle', 'PTY revive lost entry'),
     ...optionalReplayTail(entry.replayTail),
     ...optionalDurableLaunch(entry.durableLaunch),
-    ...optionalAgentOwners(entry.agentOwners),
+    ...optionalAgentOwners(entry.agentOwners, id),
     ...optionalProviderSession(entry.providerSession),
     ...optionalStringField(entry, 'orchestrationTaskId', 'PTY revive lost entry')
   }
@@ -136,7 +146,12 @@ function optionalReplayTail(value: unknown): Pick<RelayPtyLostEntry, 'replayTail
   if (tail.encoding !== 'utf8' || typeof tail.truncated !== 'boolean') {
     throw new Error('PTY revive replay tail is invalid')
   }
-  const data = requiredString(tail.data, 'PTY revive replay tail data', true)
+  const data = requiredString(
+    tail.data,
+    'PTY revive replay tail data',
+    true,
+    MAX_RELAY_PTY_REVIVE_REPLAY_TAIL_BYTES
+  )
   const byteLength = nonNegativeSafeInteger(tail.byteLength, 'PTY revive replay tail byteLength')
   if (
     byteLength > MAX_RELAY_PTY_REVIVE_REPLAY_TAIL_BYTES ||
@@ -186,37 +201,45 @@ function optionalDurableLaunch(value: unknown): Pick<RelayPtyLostEntry, 'durable
   }
 }
 
-function optionalAgentOwners(value: unknown): Pick<RelayPtyLostEntry, 'agentOwners'> {
+function optionalAgentOwners(
+  value: unknown,
+  entryId: string
+): Pick<RelayPtyLostEntry, 'agentOwners'> {
   if (value === undefined) {
     return {}
   }
-  if (!Array.isArray(value) || !value.every(isAgentSessionOwnerBinding)) {
-    throw new Error('PTY revive agent owners are invalid')
-  }
-  return { agentOwners: value }
+  return { agentOwners: normalizeAgentSessionOwnerBindings(value, entryId, 'PTY revive') }
 }
 
 function optionalProviderSession(value: unknown): Pick<RelayPtyLostEntry, 'providerSession'> {
   if (value === undefined) {
     return {}
   }
-  const providerSession = normalizeAgentProviderSession(value)
+  const record = requireRelayPtyReviveRecord(value, 'PTY revive provider session')
+  assertExactKeys(record, ['key', 'id', 'transcriptPath'], 'PTY revive provider session')
+  const providerSession = normalizeAgentProviderSession(record)
   if (
     !providerSession ||
-    measureUtf8ByteLength(providerSession.id, { stopAfterBytes: MAX_RELAY_PTY_REVIVE_FIELD_BYTES })
-      .exceededLimit ||
+    !isRelayPtyPersistenceFieldWithinLimit(providerSession.id) ||
     (providerSession.transcriptPath &&
-      measureUtf8ByteLength(providerSession.transcriptPath, {
-        stopAfterBytes: MAX_RELAY_PTY_REVIVE_FIELD_BYTES
-      }).exceededLimit)
+      !isRelayPtyPersistenceFieldWithinLimit(providerSession.transcriptPath))
   ) {
     throw new Error('PTY revive provider session is invalid')
   }
   return { providerSession }
 }
 
-function requiredString(value: unknown, name: string, allowEmpty = false): string {
-  if (typeof value !== 'string' || (!allowEmpty && value.length === 0)) {
+function requiredString(
+  value: unknown,
+  name: string,
+  allowEmpty = false,
+  maxBytes = MAX_RELAY_PTY_REVIVE_FIELD_BYTES
+): string {
+  if (
+    typeof value !== 'string' ||
+    (!allowEmpty && value.length === 0) ||
+    !isRelayPtyPersistenceFieldWithinLimit(value, maxBytes)
+  ) {
     throw new Error(`${name} is invalid`)
   }
   return value

--- a/src/shared/pty-revive-outcome-fields.ts
+++ b/src/shared/pty-revive-outcome-fields.ts
@@ -1,0 +1,260 @@
+import { normalizeAgentProviderSession } from './agent-session-resume'
+import { isAgentSessionOwnerBinding } from './agent-session-host-authority'
+import type {
+  RelayPtyLostEntry,
+  RelayPtyReviveDiagnostic,
+  RelayPtyRevivedEntry
+} from './pty-revive-protocol'
+import { isTuiAgent } from './tui-agent-config'
+import { measureUtf8ByteLength } from './utf8-byte-limits'
+
+const MAX_RELAY_PTY_REVIVE_FIELD_BYTES = 64 * 1024
+const MAX_RELAY_PTY_REVIVE_REPLAY_TAIL_BYTES = 100 * 1024
+
+export function normalizeRelayPtyRevivedEntry(value: unknown): RelayPtyRevivedEntry {
+  const entry = requireRelayPtyReviveRecord(value, 'PTY revive revived entry')
+  assertExactKeys(
+    entry,
+    ['id', 'disposition', 'incarnationId', 'paneKey', 'tabId'],
+    'PTY revive revived entry'
+  )
+  if (entry.disposition !== 'replacement-spawned' && entry.disposition !== 'already-managed') {
+    throw new Error('PTY revive revived entry disposition is invalid')
+  }
+  return {
+    id: requiredString(entry.id, 'PTY revive revived entry id'),
+    disposition: entry.disposition,
+    incarnationId: requiredString(entry.incarnationId, 'PTY revive revived entry incarnationId'),
+    ...optionalStringField(entry, 'paneKey', 'PTY revive revived entry'),
+    ...optionalStringField(entry, 'tabId', 'PTY revive revived entry')
+  }
+}
+
+export function normalizeRelayPtyLostEntry(value: unknown): RelayPtyLostEntry {
+  const entry = requireRelayPtyReviveRecord(value, 'PTY revive lost entry')
+  assertExactKeys(
+    entry,
+    [
+      'id',
+      'kind',
+      'reason',
+      'pid',
+      'sourceIncarnationId',
+      'cols',
+      'rows',
+      'cwd',
+      'paneKey',
+      'tabId',
+      'attachIdentity',
+      'worktreeId',
+      'terminalHandle',
+      'replayTail',
+      'durableLaunch',
+      'agentOwners',
+      'providerSession',
+      'orchestrationTaskId'
+    ],
+    'PTY revive lost entry'
+  )
+  if (
+    entry.kind !== 'recognized-worker' &&
+    entry.kind !== 'ordinary-shell' &&
+    entry.kind !== 'unclassified'
+  ) {
+    throw new Error('PTY revive lost entry kind is invalid')
+  }
+  if (
+    entry.reason !== 'worker-replacement-forbidden' &&
+    entry.reason !== 'process-not-running' &&
+    entry.reason !== 'pty-runtime-unavailable'
+  ) {
+    throw new Error('PTY revive lost entry reason is invalid')
+  }
+  return {
+    id: requiredString(entry.id, 'PTY revive lost entry id'),
+    kind: entry.kind,
+    reason: entry.reason,
+    pid: positiveSafeInteger(entry.pid, 'PTY revive lost entry pid'),
+    cols: positiveSafeInteger(entry.cols, 'PTY revive lost entry cols'),
+    rows: positiveSafeInteger(entry.rows, 'PTY revive lost entry rows'),
+    cwd: requiredString(entry.cwd, 'PTY revive lost entry cwd'),
+    ...optionalStringField(entry, 'sourceIncarnationId', 'PTY revive lost entry'),
+    ...optionalStringField(entry, 'paneKey', 'PTY revive lost entry'),
+    ...optionalStringField(entry, 'tabId', 'PTY revive lost entry'),
+    ...optionalIdentity(entry.attachIdentity),
+    ...optionalStringField(entry, 'worktreeId', 'PTY revive lost entry'),
+    ...optionalStringField(entry, 'terminalHandle', 'PTY revive lost entry'),
+    ...optionalReplayTail(entry.replayTail),
+    ...optionalDurableLaunch(entry.durableLaunch),
+    ...optionalAgentOwners(entry.agentOwners),
+    ...optionalProviderSession(entry.providerSession),
+    ...optionalStringField(entry, 'orchestrationTaskId', 'PTY revive lost entry')
+  }
+}
+
+export function normalizeRelayPtyReviveDiagnostic(value: unknown): RelayPtyReviveDiagnostic {
+  const diagnostic = requireRelayPtyReviveRecord(value, 'PTY revive diagnostic')
+  assertExactKeys(diagnostic, ['code', 'id'], 'PTY revive diagnostic')
+  if (
+    diagnostic.code !== 'legacy-state' &&
+    diagnostic.code !== 'entry-already-pending' &&
+    diagnostic.code !== 'entry-invalid' &&
+    diagnostic.code !== 'state-budget-reduced'
+  ) {
+    throw new Error('PTY revive diagnostic code is invalid')
+  }
+  return {
+    code: diagnostic.code,
+    ...optionalStringField(diagnostic, 'id', 'PTY revive diagnostic')
+  }
+}
+
+export function requireRelayPtyReviveRecord(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${name} is invalid`)
+  }
+  return value as Record<string, unknown>
+}
+
+function optionalIdentity(value: unknown): Pick<RelayPtyLostEntry, 'attachIdentity'> {
+  if (value === undefined) {
+    return {}
+  }
+  const identity = requireRelayPtyReviveRecord(value, 'PTY revive attach identity')
+  assertExactKeys(identity, ['paneKey', 'tabId'], 'PTY revive attach identity')
+  const paneKey = optionalString(identity.paneKey, 'PTY revive attach identity paneKey')
+  const tabId = optionalString(identity.tabId, 'PTY revive attach identity tabId')
+  return paneKey === undefined && tabId === undefined ? {} : { attachIdentity: { paneKey, tabId } }
+}
+
+function optionalReplayTail(value: unknown): Pick<RelayPtyLostEntry, 'replayTail'> {
+  if (value === undefined) {
+    return {}
+  }
+  const tail = requireRelayPtyReviveRecord(value, 'PTY revive replay tail')
+  assertExactKeys(tail, ['data', 'encoding', 'byteLength', 'truncated'], 'PTY revive replay tail')
+  if (tail.encoding !== 'utf8' || typeof tail.truncated !== 'boolean') {
+    throw new Error('PTY revive replay tail is invalid')
+  }
+  const data = requiredString(tail.data, 'PTY revive replay tail data', true)
+  const byteLength = nonNegativeSafeInteger(tail.byteLength, 'PTY revive replay tail byteLength')
+  if (
+    byteLength > MAX_RELAY_PTY_REVIVE_REPLAY_TAIL_BYTES ||
+    measureUtf8ByteLength(data).byteLength !== byteLength
+  ) {
+    throw new Error('PTY revive replay tail byteLength is invalid')
+  }
+  return { replayTail: { data, encoding: 'utf8', byteLength, truncated: tail.truncated } }
+}
+
+function optionalDurableLaunch(value: unknown): Pick<RelayPtyLostEntry, 'durableLaunch'> {
+  if (value === undefined) {
+    return {}
+  }
+  const launch = requireRelayPtyReviveRecord(value, 'PTY revive durable launch')
+  assertExactKeys(
+    launch,
+    ['startupCommand', 'shellOverride', 'launchAgent', 'startedAt'],
+    'PTY revive durable launch'
+  )
+  const startupCommand = optionalString(
+    launch.startupCommand,
+    'PTY revive durable launch startupCommand'
+  )
+  const shellOverride = optionalString(
+    launch.shellOverride,
+    'PTY revive durable launch shellOverride'
+  )
+  if (launch.launchAgent !== undefined && !isTuiAgent(launch.launchAgent)) {
+    throw new Error('PTY revive durable launch agent is invalid')
+  }
+  if (
+    launch.startedAt !== undefined &&
+    (typeof launch.startedAt !== 'number' ||
+      !Number.isFinite(launch.startedAt) ||
+      launch.startedAt < 0)
+  ) {
+    throw new Error('PTY revive durable launch startedAt is invalid')
+  }
+  return {
+    durableLaunch: {
+      ...(startupCommand === undefined ? {} : { startupCommand }),
+      ...(shellOverride === undefined ? {} : { shellOverride }),
+      ...(launch.launchAgent === undefined ? {} : { launchAgent: launch.launchAgent }),
+      ...(launch.startedAt === undefined ? {} : { startedAt: launch.startedAt as number })
+    }
+  }
+}
+
+function optionalAgentOwners(value: unknown): Pick<RelayPtyLostEntry, 'agentOwners'> {
+  if (value === undefined) {
+    return {}
+  }
+  if (!Array.isArray(value) || !value.every(isAgentSessionOwnerBinding)) {
+    throw new Error('PTY revive agent owners are invalid')
+  }
+  return { agentOwners: value }
+}
+
+function optionalProviderSession(value: unknown): Pick<RelayPtyLostEntry, 'providerSession'> {
+  if (value === undefined) {
+    return {}
+  }
+  const providerSession = normalizeAgentProviderSession(value)
+  if (
+    !providerSession ||
+    measureUtf8ByteLength(providerSession.id, { stopAfterBytes: MAX_RELAY_PTY_REVIVE_FIELD_BYTES })
+      .exceededLimit ||
+    (providerSession.transcriptPath &&
+      measureUtf8ByteLength(providerSession.transcriptPath, {
+        stopAfterBytes: MAX_RELAY_PTY_REVIVE_FIELD_BYTES
+      }).exceededLimit)
+  ) {
+    throw new Error('PTY revive provider session is invalid')
+  }
+  return { providerSession }
+}
+
+function requiredString(value: unknown, name: string, allowEmpty = false): string {
+  if (typeof value !== 'string' || (!allowEmpty && value.length === 0)) {
+    throw new Error(`${name} is invalid`)
+  }
+  return value
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  return value === undefined ? undefined : requiredString(value, name)
+}
+
+function optionalStringField(
+  record: Record<string, unknown>,
+  key: string,
+  name: string
+): Record<string, string> {
+  const value = optionalString(record[key], `${name} ${key}`)
+  return value === undefined ? {} : { [key]: value }
+}
+
+function positiveSafeInteger(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} is invalid`)
+  }
+  return value
+}
+
+function nonNegativeSafeInteger(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} is invalid`)
+  }
+  return value
+}
+
+function assertExactKeys(
+  record: Record<string, unknown>,
+  allowed: readonly string[],
+  name: string
+): void {
+  if (Object.keys(record).some((key) => !allowed.includes(key))) {
+    throw new Error(`${name} contains an unknown field`)
+  }
+}

--- a/src/shared/pty-revive-outcome-normalization.test.ts
+++ b/src/shared/pty-revive-outcome-normalization.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_RELAY_PTY_REVIVE_FIELD_BYTES,
+  normalizeRelayPtyLostEntry,
+  normalizeRelayPtyRevivedEntry
+} from './pty-revive-outcome-fields'
+import { normalizeRelayPtyReviveOutcome } from './pty-revive-outcome-normalization'
+import { MAX_TERMINAL_COLS, MAX_TERMINAL_ROWS } from './terminal-size-limits'
+
+function lostEntry(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'pty-1',
+    kind: 'ordinary-shell',
+    reason: 'process-not-running',
+    pid: 42,
+    cols: 80,
+    rows: 24,
+    cwd: '/repo',
+    ...overrides
+  }
+}
+
+function owner(ptyId = 'pty-1'): Record<string, unknown> {
+  return {
+    claim: {
+      digestVersion: 1,
+      keyId: 'claim-key',
+      identityDigest: 'a'.repeat(43),
+      worktreeScopeDigest: 'b'.repeat(43),
+      agent: 'codex'
+    },
+    generation: 'generation-1',
+    phase: 'live',
+    ptyId,
+    surface: {
+      worktreeId: 'repo::/repo',
+      tabId: 'tab-1',
+      leafId: '11111111-1111-4111-8111-111111111111',
+      terminalHandle: 'term_abc123'
+    }
+  }
+}
+
+describe('relay PTY revive outcome normalization', () => {
+  it('accepts typed strings at the field byte limit and rejects one byte over', () => {
+    const field = 'x'.repeat(MAX_RELAY_PTY_REVIVE_FIELD_BYTES)
+
+    expect(() => normalizeRelayPtyLostEntry(lostEntry({ cwd: field }))).not.toThrow()
+    expect(() =>
+      normalizeRelayPtyLostEntry(lostEntry({ durableLaunch: { startupCommand: field } }))
+    ).not.toThrow()
+    expect(() =>
+      normalizeRelayPtyRevivedEntry({
+        id: 'pty-1',
+        disposition: 'already-managed',
+        incarnationId: field
+      })
+    ).not.toThrow()
+    expect(() => normalizeRelayPtyLostEntry(lostEntry({ cwd: `${field}x` }))).toThrow(
+      'PTY revive lost entry cwd is invalid'
+    )
+    expect(() =>
+      normalizeRelayPtyLostEntry(lostEntry({ durableLaunch: { startupCommand: `${field}x` } }))
+    ).toThrow('PTY revive durable launch startupCommand is invalid')
+    expect(() =>
+      normalizeRelayPtyRevivedEntry({
+        id: 'pty-1',
+        disposition: 'already-managed',
+        incarnationId: `${field}x`
+      })
+    ).toThrow('PTY revive revived entry incarnationId is invalid')
+  })
+
+  it('uses terminal dimension admission limits for typed lost entries', () => {
+    expect(() =>
+      normalizeRelayPtyLostEntry(lostEntry({ cols: MAX_TERMINAL_COLS, rows: MAX_TERMINAL_ROWS }))
+    ).not.toThrow()
+    expect(() => normalizeRelayPtyLostEntry(lostEntry({ cols: MAX_TERMINAL_COLS + 1 }))).toThrow(
+      `1 through ${MAX_TERMINAL_COLS}`
+    )
+    expect(() => normalizeRelayPtyLostEntry(lostEntry({ rows: Number.MAX_SAFE_INTEGER }))).toThrow(
+      `1 through ${MAX_TERMINAL_ROWS}`
+    )
+  })
+
+  it('keeps the replay-tail-specific 100 KiB allowance', () => {
+    const tail = 'x'.repeat(100 * 1024)
+
+    expect(() =>
+      normalizeRelayPtyLostEntry(
+        lostEntry({
+          replayTail: { data: tail, encoding: 'utf8', byteLength: tail.length, truncated: false }
+        })
+      )
+    ).not.toThrow()
+    expect(() =>
+      normalizeRelayPtyLostEntry(
+        lostEntry({
+          replayTail: {
+            data: `${tail}x`,
+            encoding: 'utf8',
+            byteLength: tail.length + 1,
+            truncated: false
+          }
+        })
+      )
+    ).toThrow('PTY revive replay tail data is invalid')
+  })
+
+  it('fails closed on unknown provider-session and nested owner fields', () => {
+    const outcome = (entry: Record<string, unknown>) =>
+      normalizeRelayPtyReviveOutcome({
+        outcomeVersion: 1,
+        revived: [],
+        lost: [entry],
+        diagnostics: []
+      })
+
+    expect(() =>
+      outcome(
+        lostEntry({ providerSession: { key: 'session_id', id: 'session-1', prompt: 'private' } })
+      )
+    ).toThrow('unknown field')
+    expect(() =>
+      outcome(
+        lostEntry({
+          agentOwners: [
+            {
+              ...owner(),
+              surface: { ...(owner().surface as Record<string, unknown>), hook: 'private' }
+            }
+          ]
+        })
+      )
+    ).toThrow('unknown field')
+    expect(() => outcome(lostEntry({ agentOwners: [owner('pty-other')] }))).toThrow(
+      'agent owner is invalid'
+    )
+  })
+})

--- a/src/shared/pty-revive-outcome-normalization.ts
+++ b/src/shared/pty-revive-outcome-normalization.ts
@@ -1,0 +1,86 @@
+import { measureUtf8ByteLength } from './utf8-byte-limits'
+import {
+  MAX_RELAY_PTY_REVIVE_ENTRIES,
+  MAX_RELAY_PTY_REVIVE_OUTCOME_BYTES,
+  RELAY_PTY_REVIVE_OUTCOME_VERSION,
+  type RelayPtyReviveOutcomeV1
+} from './pty-revive-protocol'
+import {
+  normalizeRelayPtyLostEntry,
+  normalizeRelayPtyReviveDiagnostic,
+  normalizeRelayPtyRevivedEntry,
+  requireRelayPtyReviveRecord
+} from './pty-revive-outcome-fields'
+
+export function normalizeRelayPtyReviveOutcome(value: unknown): RelayPtyReviveOutcomeV1 {
+  assertOutcomeByteLimit(value)
+  const outcome = requireRelayPtyReviveRecord(value, 'PTY revive outcome')
+  assertExactKeys(
+    outcome,
+    ['outcomeVersion', 'revived', 'lost', 'diagnostics'],
+    'PTY revive outcome'
+  )
+  if (outcome.outcomeVersion !== RELAY_PTY_REVIVE_OUTCOME_VERSION) {
+    throw new Error('PTY revive outcome version is unsupported')
+  }
+  const revived = normalizeArray(
+    outcome.revived,
+    'PTY revive outcome revived',
+    normalizeRelayPtyRevivedEntry
+  )
+  const lost = normalizeArray(outcome.lost, 'PTY revive outcome lost', normalizeRelayPtyLostEntry)
+  if (revived.length + lost.length > MAX_RELAY_PTY_REVIVE_ENTRIES) {
+    throw new Error('PTY revive outcome has too many entries')
+  }
+  if (
+    new Set([...revived, ...lost].map((entry) => entry.id)).size !==
+    revived.length + lost.length
+  ) {
+    throw new Error('PTY revive outcome entry ids are duplicated')
+  }
+  return {
+    outcomeVersion: RELAY_PTY_REVIVE_OUTCOME_VERSION,
+    revived,
+    lost,
+    diagnostics: normalizeArray(
+      outcome.diagnostics,
+      'PTY revive outcome diagnostics',
+      normalizeRelayPtyReviveDiagnostic
+    )
+  }
+}
+
+function assertOutcomeByteLimit(value: unknown): void {
+  let serialized: string
+  try {
+    serialized = JSON.stringify(value)
+  } catch {
+    throw new Error('PTY revive outcome must be JSON-compatible')
+  }
+  if (typeof serialized !== 'string') {
+    throw new Error('PTY revive outcome must be JSON-compatible')
+  }
+  if (
+    measureUtf8ByteLength(serialized, { stopAfterBytes: MAX_RELAY_PTY_REVIVE_OUTCOME_BYTES })
+      .exceededLimit
+  ) {
+    throw new Error(`PTY revive outcome exceeds ${MAX_RELAY_PTY_REVIVE_OUTCOME_BYTES} bytes`)
+  }
+}
+
+function normalizeArray<T>(value: unknown, name: string, normalize: (entry: unknown) => T): T[] {
+  if (!Array.isArray(value) || value.length > MAX_RELAY_PTY_REVIVE_ENTRIES) {
+    throw new Error(`${name} is invalid`)
+  }
+  return value.map(normalize)
+}
+
+function assertExactKeys(
+  record: Record<string, unknown>,
+  allowed: readonly string[],
+  name: string
+): void {
+  if (Object.keys(record).some((key) => !allowed.includes(key))) {
+    throw new Error(`${name} contains an unknown field`)
+  }
+}

--- a/src/shared/pty-revive-protocol.ts
+++ b/src/shared/pty-revive-protocol.ts
@@ -1,0 +1,69 @@
+import type { AgentProviderSessionMetadata } from './agent-session-resume'
+import type { AgentSessionOwnerBinding } from './agent-session-host-authority'
+import type { TuiAgent } from './types'
+
+export const RELAY_PTY_REVIVE_OUTCOME_VERSION = 1 as const
+export const MAX_RELAY_PTY_REVIVE_OUTCOME_BYTES = 8 * 1024 * 1024
+export const MAX_RELAY_PTY_REVIVE_ENTRIES = 50
+
+export type RelayPtyReplayTail = {
+  data: string
+  encoding: 'utf8'
+  byteLength: number
+  truncated: boolean
+}
+
+export type RelayPtyDurableLaunch = {
+  startupCommand?: string
+  shellOverride?: string
+  launchAgent?: TuiAgent
+  startedAt?: number
+}
+
+export type RelayPtyRevivedEntry = {
+  id: string
+  disposition: 'replacement-spawned' | 'already-managed'
+  incarnationId: string
+  paneKey?: string
+  tabId?: string
+}
+
+export type RelayPtyLostEntry = {
+  id: string
+  kind: 'recognized-worker' | 'ordinary-shell' | 'unclassified'
+  reason: 'worker-replacement-forbidden' | 'process-not-running' | 'pty-runtime-unavailable'
+  pid: number
+  sourceIncarnationId?: string
+  cols: number
+  rows: number
+  cwd: string
+  paneKey?: string
+  tabId?: string
+  attachIdentity?: { paneKey?: string; tabId?: string }
+  worktreeId?: string
+  terminalHandle?: string
+  replayTail?: RelayPtyReplayTail
+  durableLaunch?: RelayPtyDurableLaunch
+  agentOwners?: AgentSessionOwnerBinding[]
+  providerSession?: AgentProviderSessionMetadata
+  orchestrationTaskId?: string
+}
+
+export type RelayPtyReviveDiagnostic = {
+  code: 'legacy-state' | 'entry-already-pending' | 'entry-invalid' | 'state-budget-reduced'
+  id?: string
+}
+
+export type RelayPtyReviveOutcomeV1 = {
+  outcomeVersion: typeof RELAY_PTY_REVIVE_OUTCOME_VERSION
+  revived: RelayPtyRevivedEntry[]
+  lost: RelayPtyLostEntry[]
+  diagnostics: RelayPtyReviveDiagnostic[]
+}
+
+export type PtyReviveResult =
+  | { mode: 'typed'; outcome: RelayPtyReviveOutcomeV1 }
+  | { mode: 'legacy'; diagnosticCode: 'pty-revive-outcome-unavailable' }
+  | { mode: 'not-applicable' }
+
+export { normalizeRelayPtyReviveOutcome } from './pty-revive-outcome-normalization'

--- a/src/shared/relay-staged-pty-snapshots.test.ts
+++ b/src/shared/relay-staged-pty-snapshots.test.ts
@@ -29,6 +29,19 @@ describe('decodeRelayStagedPtySnapshots', () => {
     expect(decoded.snapshotsByPaneKey.size).toBe(0)
   })
 
+  it('fails the entire envelope when one entry is malformed', () => {
+    const valid = v2Entry(1)
+    const decoded = decodeRelayStagedPtySnapshots(
+      JSON.stringify({
+        schemaVersion: 2,
+        entries: [valid, { ...v2Entry(2), sourceIncarnationId: null }]
+      })
+    )
+
+    expect(decoded).toMatchObject({ kind: 'invalid' })
+    expect(decoded.snapshotsByPaneKey.size).toBe(0)
+  })
+
   it('distinguishes the legacy array envelope from a missing staged state', () => {
     expect(decodeRelayStagedPtySnapshots(JSON.stringify([v2Entry(1)]))).toMatchObject({
       kind: 'legacy'

--- a/src/shared/relay-staged-pty-snapshots.test.ts
+++ b/src/shared/relay-staged-pty-snapshots.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { decodeRelayStagedPtySnapshots } from './relay-staged-pty-snapshots'
+
+function v2Entry(index: number) {
+  const data = `tail-${index}`
+  return {
+    id: `pty-${index}`,
+    paneKey: `tab-${index}:11111111-1111-4111-8111-${String(index).padStart(12, '0')}`,
+    sourceIncarnationId: `incarnation-${index}`,
+    replayTail: { data, encoding: 'utf8', byteLength: data.length, truncated: false }
+  }
+}
+
+describe('decodeRelayStagedPtySnapshots', () => {
+  it('accepts exactly the relay 50-entry limit without dropping a pane tail', () => {
+    const entries = Array.from({ length: 50 }, (_, index) => v2Entry(index))
+    const decoded = decodeRelayStagedPtySnapshots(JSON.stringify({ schemaVersion: 2, entries }))
+
+    expect(decoded.kind).toBe('v2')
+    expect(decoded.snapshotsByPaneKey.size).toBe(50)
+    expect(decoded.snapshotsByPaneKey.get(entries[49]!.paneKey)?.replayTail?.data).toBe('tail-49')
+  })
+
+  it('fails closed instead of truncating a 51-entry staged envelope', () => {
+    const entries = Array.from({ length: 51 }, (_, index) => v2Entry(index))
+    const decoded = decodeRelayStagedPtySnapshots(JSON.stringify({ schemaVersion: 2, entries }))
+
+    expect(decoded).toMatchObject({ kind: 'invalid' })
+    expect(decoded.snapshotsByPaneKey.size).toBe(0)
+  })
+
+  it('distinguishes the legacy array envelope from a missing staged state', () => {
+    expect(decodeRelayStagedPtySnapshots(JSON.stringify([v2Entry(1)]))).toMatchObject({
+      kind: 'legacy'
+    })
+    expect(decodeRelayStagedPtySnapshots(null)).toMatchObject({ kind: 'missing' })
+  })
+})

--- a/src/shared/relay-staged-pty-snapshots.ts
+++ b/src/shared/relay-staged-pty-snapshots.ts
@@ -17,7 +17,6 @@ export type RelayStagedPtySnapshots =
 
 const EMPTY_SNAPSHOTS = new Map<string, RelayStagedPtySnapshot>()
 
-/** Decodes only the v2 fields main may use before a replacement PTY is exposed. */
 export function decodeRelayStagedPtySnapshots(state: string | null): RelayStagedPtySnapshots {
   if (state === null) {
     return { kind: 'missing', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
@@ -55,7 +54,7 @@ export function decodeRelayStagedPtySnapshots(state: string | null): RelayStaged
         typeof candidate.paneKey !== 'string' ||
         typeof candidate.sourceIncarnationId !== 'string'
       ) {
-        continue
+        return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
       }
       if (snapshotsByPaneKey.has(candidate.paneKey)) {
         return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }

--- a/src/shared/relay-staged-pty-snapshots.ts
+++ b/src/shared/relay-staged-pty-snapshots.ts
@@ -1,0 +1,100 @@
+import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
+import { MAX_RELAY_PTY_REVIVE_ENTRIES, type RelayPtyReplayTail } from './pty-revive-protocol'
+import { getUtf8ByteLength } from './utf8-byte-limits'
+
+const MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES = 8 * 1024 * 1024
+
+export type RelayStagedPtySnapshot = {
+  sourceIncarnationId: string
+  replayTail?: RelayPtyReplayTail
+}
+
+export type RelayStagedPtySnapshots =
+  | { kind: 'missing'; snapshotsByPaneKey: ReadonlyMap<string, RelayStagedPtySnapshot> }
+  | { kind: 'legacy'; snapshotsByPaneKey: ReadonlyMap<string, RelayStagedPtySnapshot> }
+  | { kind: 'invalid'; snapshotsByPaneKey: ReadonlyMap<string, RelayStagedPtySnapshot> }
+  | { kind: 'v2'; snapshotsByPaneKey: ReadonlyMap<string, RelayStagedPtySnapshot> }
+
+const EMPTY_SNAPSHOTS = new Map<string, RelayStagedPtySnapshot>()
+
+/** Decodes only the v2 fields main may use before a replacement PTY is exposed. */
+export function decodeRelayStagedPtySnapshots(state: string | null): RelayStagedPtySnapshots {
+  if (state === null) {
+    return { kind: 'missing', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+  }
+  if (getUtf8ByteLength(state) > MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES) {
+    return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+  }
+  try {
+    assertJsonTextStructureWithinLimits(state, { structuralTokens: 131_072, nestingDepth: 8 })
+    const value = JSON.parse(state) as unknown
+    if (Array.isArray(value)) {
+      return { kind: 'legacy', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+    }
+    if (!value || typeof value !== 'object') {
+      return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+    }
+    const envelope = value as { schemaVersion?: unknown; entries?: unknown }
+    if (envelope.schemaVersion !== 2 || !Array.isArray(envelope.entries)) {
+      return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+    }
+    if (envelope.entries.length > MAX_RELAY_PTY_REVIVE_ENTRIES) {
+      return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+    }
+    const snapshotsByPaneKey = new Map<string, RelayStagedPtySnapshot>()
+    for (const entry of envelope.entries) {
+      if (!entry || typeof entry !== 'object') {
+        return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+      }
+      const candidate = entry as {
+        paneKey?: unknown
+        sourceIncarnationId?: unknown
+        replayTail?: unknown
+      }
+      if (
+        typeof candidate.paneKey !== 'string' ||
+        typeof candidate.sourceIncarnationId !== 'string'
+      ) {
+        continue
+      }
+      if (snapshotsByPaneKey.has(candidate.paneKey)) {
+        return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+      }
+      const replayTail = decodeReplayTail(candidate.replayTail)
+      if (candidate.replayTail !== undefined && replayTail === null) {
+        return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+      }
+      snapshotsByPaneKey.set(candidate.paneKey, {
+        sourceIncarnationId: candidate.sourceIncarnationId,
+        ...(replayTail ? { replayTail } : {})
+      })
+    }
+    return { kind: 'v2', snapshotsByPaneKey }
+  } catch {
+    return { kind: 'invalid', snapshotsByPaneKey: EMPTY_SNAPSHOTS }
+  }
+}
+
+function decodeReplayTail(value: unknown): RelayPtyReplayTail | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const tail = value as Partial<RelayPtyReplayTail>
+  if (
+    typeof tail.data !== 'string' ||
+    tail.encoding !== 'utf8' ||
+    typeof tail.byteLength !== 'number' ||
+    !Number.isSafeInteger(tail.byteLength) ||
+    tail.byteLength < 0 ||
+    typeof tail.truncated !== 'boolean' ||
+    getUtf8ByteLength(tail.data) !== tail.byteLength
+  ) {
+    return null
+  }
+  return {
+    data: tail.data,
+    encoding: 'utf8',
+    byteLength: tail.byteLength,
+    truncated: tail.truncated
+  }
+}

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -285,6 +285,8 @@ export type RuntimeMobileSessionTabMoveResult = {
 
 export type RuntimeMobileSessionTabCloseResult = {
   closed: true
+  /** Present when a user whole-tab close crossed the archive durability boundary. */
+  archiveId?: string
   refused?: true
   refusalReason?:
     | 'missing-intent'
@@ -300,7 +302,7 @@ export type RuntimeMobileSessionTabCloseResult = {
 // Why: lets the host tell a user's close from a client-lifecycle echo
 // ('pty-exit'/'cleanup') and adjudicate against its own PTY liveness.
 // Absent on legacy clients, where the existing close endpoint remains user intent.
-export type RuntimeSessionTabCloseReason = 'user' | 'pty-exit' | 'cleanup'
+export type RuntimeSessionTabCloseReason = 'user' | 'pty-exit' | 'cleanup' | 'pane-only'
 
 export type RuntimeMobileSessionTabsSnapshot = {
   worktree: string
@@ -673,6 +675,7 @@ export type RuntimeTerminalClose = {
   tabId: string
   /** Present for the durable whole-tab lifecycle without changing legacy receipts. */
   closeMode?: 'tab'
+  archiveId?: string
   ptyKilled: boolean
 }
 

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -132,7 +132,12 @@ export type SshMutationExpectation = {
   expectedSshConnectionGeneration?: number
 }
 
-export type SshRemotePtyLeaseState = 'attached' | 'detached' | 'terminated' | 'expired'
+export type SshRemotePtyLeaseState =
+  | 'attached'
+  | 'detached'
+  | 'termination-pending'
+  | 'terminated'
+  | 'expired'
 
 export type SshRemotePtyLease = {
   targetId: string

--- a/src/shared/terminal-archive-snapshot-capture.test.ts
+++ b/src/shared/terminal-archive-snapshot-capture.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { captureTerminalArchiveBuffer } from './terminal-archive-snapshot-capture'
+
+describe('captureTerminalArchiveBuffer', () => {
+  it('accepts only a non-truncated empty buffer as a proven empty capture', () => {
+    expect(captureTerminalArchiveBuffer({ buffer: '', source: 'renderer' })).toEqual({
+      kind: 'captured-empty'
+    })
+    expect(
+      captureTerminalArchiveBuffer({ buffer: '', source: 'relay-tail', truncated: true })
+    ).toEqual({ kind: 'unavailable' })
+  })
+
+  it('preserves bounded data provenance for a non-empty capture', () => {
+    expect(
+      captureTerminalArchiveBuffer({ buffer: 'hello', source: 'daemon-headless', truncated: true })
+    ).toEqual({
+      kind: 'captured-bytes',
+      buffer: 'hello',
+      source: 'daemon-headless',
+      truncated: true,
+      byteLength: 5
+    })
+  })
+})

--- a/src/shared/terminal-archive-snapshot-capture.test.ts
+++ b/src/shared/terminal-archive-snapshot-capture.test.ts
@@ -11,6 +11,17 @@ describe('captureTerminalArchiveBuffer', () => {
     ).toEqual({ kind: 'unavailable' })
   })
 
+  it.each([
+    ['renderer lost-worker candidate', 'renderer'],
+    ['daemon pre-spawn recovery', 'daemon-headless'],
+    ['SSH relay upgrade', 'relay-tail'],
+    ['user-close recovery', 'session-sidecar']
+  ] as const)('%s fails closed for an empty truncated buffer', (_entry, source) => {
+    expect(captureTerminalArchiveBuffer({ buffer: '', source, truncated: true })).toEqual({
+      kind: 'unavailable'
+    })
+  })
+
   it('preserves bounded data provenance for a non-empty capture', () => {
     expect(
       captureTerminalArchiveBuffer({ buffer: 'hello', source: 'daemon-headless', truncated: true })

--- a/src/shared/terminal-archive-snapshot-capture.ts
+++ b/src/shared/terminal-archive-snapshot-capture.ts
@@ -1,0 +1,24 @@
+import { getUtf8ByteLength } from './utf8-byte-limits'
+import type {
+  TerminalArchivePaneSnapshotCapture,
+  TerminalArchivePaneSnapshotInput
+} from './workspace-session-terminal-archive'
+
+/** Applies the archive contract that a budget-truncated empty tail is not proof of emptiness. */
+export function captureTerminalArchiveBuffer(args: {
+  buffer: string
+  source: TerminalArchivePaneSnapshotInput['source']
+  truncated?: boolean
+}): TerminalArchivePaneSnapshotCapture {
+  const truncated = args.truncated ?? false
+  if (args.buffer.length === 0) {
+    return truncated ? { kind: 'unavailable' } : { kind: 'captured-empty' }
+  }
+  return {
+    kind: 'captured-bytes',
+    buffer: args.buffer,
+    source: args.source,
+    truncated,
+    byteLength: getUtf8ByteLength(args.buffer)
+  }
+}

--- a/src/shared/terminal-archive-types.ts
+++ b/src/shared/terminal-archive-types.ts
@@ -147,6 +147,30 @@ export type TerminalArchiveRendererCloseRequest = {
   snapshotsByLeafId: Record<string, TerminalArchiveRendererSnapshot>
 }
 
+/** A renderer reports a stale established pane; main owns all durable facts. */
+export type TerminalLostWorkerRendererRequest = {
+  leafId: string
+  worktreeId: string
+  tabId: string
+  executionHostId: ExecutionHostId
+  runtimeEnvironmentId?: string
+  snapshotsByLeafId: Record<string, TerminalArchiveRendererSnapshot>
+  reason: Exclude<TerminalArchiveReason, 'user-close'>
+}
+
+export type TerminalLostWorkerRendererReceipt =
+  | { kind: 'archived'; archiveId: string }
+  | { kind: 'ordinary-shell' }
+  | {
+      kind: 'retryable-error'
+      code:
+        | 'not-owned'
+        | 'stale-source'
+        | 'capture-unavailable'
+        | 'contract-invalid'
+        | 'durability-failed'
+    }
+
 export const archivedTerminalPaneSchema = z
   .object({
     archivedLeafId: z.string().min(1),

--- a/src/shared/terminal-archive-types.ts
+++ b/src/shared/terminal-archive-types.ts
@@ -1,0 +1,285 @@
+import { z } from 'zod'
+import {
+  normalizeAgentProviderSession,
+  RESUMABLE_TUI_AGENTS,
+  type AgentProviderSessionMetadata,
+  type ResumableTuiAgent
+} from './agent-session-resume'
+import { normalizeExecutionHostId, type ExecutionHostId } from './execution-host'
+import { isTuiAgent } from './tui-agent-config'
+import type { TuiAgent } from './types'
+
+export const TERMINAL_ARCHIVE_SCHEMA_VERSION = 1 as const
+export const DEFAULT_TERMINAL_ARCHIVE_RETENTION_DAYS = 7
+export const MIN_TERMINAL_ARCHIVE_RETENTION_DAYS = 1
+export const MAX_TERMINAL_ARCHIVE_RETENTION_DAYS = 365
+
+export const TERMINAL_ARCHIVE_REASONS = [
+  'user-close',
+  'relay-worker-lost',
+  'daemon-worker-lost'
+] as const
+
+export type TerminalArchiveReason = (typeof TERMINAL_ARCHIVE_REASONS)[number]
+
+export const TERMINAL_ARCHIVE_CLOSE_EXCLUSIONS = [
+  'cleanup',
+  'pty-exit',
+  'app-shutdown',
+  'hibernation',
+  'pane-close'
+] as const
+
+export type TerminalArchiveCloseExclusion = (typeof TERMINAL_ARCHIVE_CLOSE_EXCLUSIONS)[number]
+export type TerminalArchiveCloseReason = TerminalArchiveReason | TerminalArchiveCloseExclusion
+
+export const TERMINAL_ARCHIVE_SNAPSHOT_SOURCES = [
+  'renderer',
+  'daemon-headless',
+  'relay-tail',
+  'session-sidecar'
+] as const
+
+export type TerminalArchiveSnapshotSourceName = (typeof TERMINAL_ARCHIVE_SNAPSHOT_SOURCES)[number]
+
+export const TERMINAL_ARCHIVE_HINT_SOURCES = [
+  'spawn',
+  'launch',
+  'hook',
+  'sleeping-session'
+] as const
+
+export type TerminalArchiveHintSource = (typeof TERMINAL_ARCHIVE_HINT_SOURCES)[number]
+
+export const TERMINAL_ARCHIVE_HINT_FIELDS = [
+  'cwd',
+  'startupCommand',
+  'shellOverride',
+  'launchAgent',
+  'providerSession',
+  'orchestrationTaskId'
+] as const
+
+export type TerminalArchiveHintField = (typeof TERMINAL_ARCHIVE_HINT_FIELDS)[number]
+
+const executionHostIdSchema = z
+  .string()
+  .transform((value, ctx) => {
+    const hostId = normalizeExecutionHostId(value)
+    if (!hostId) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'invalid execution host id' })
+      return z.NEVER
+    }
+    return hostId
+  })
+  .pipe(z.custom<ExecutionHostId>())
+
+const agentProviderSessionSchema = z
+  .object({
+    key: z.enum(['session_id', 'conversation_id']),
+    id: z.string().min(1).max(512),
+    transcriptPath: z.string().min(1).optional()
+  })
+  .strict()
+  .transform((raw, ctx) => {
+    const normalized = normalizeAgentProviderSession(raw)
+    if (!normalized) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'invalid provider session' })
+      return z.NEVER
+    }
+    return normalized
+  })
+
+const resumableAgentSchema = z.enum(RESUMABLE_TUI_AGENTS)
+
+const archiveLayoutNodeSchema = z.lazy(() =>
+  z.union([
+    z.object({ type: z.literal('leaf'), leafId: z.string().min(1) }).strict(),
+    z
+      .object({
+        type: z.literal('split'),
+        direction: z.enum(['vertical', 'horizontal']),
+        first: archiveLayoutNodeSchema,
+        second: archiveLayoutNodeSchema,
+        ratio: z.number().finite().min(0).max(1).optional()
+      })
+      .strict()
+  ])
+)
+
+export const archivedTerminalLayoutSchema = z
+  .object({
+    root: archiveLayoutNodeSchema.nullable(),
+    activeLeafId: z.string().min(1).nullable(),
+    expandedLeafId: z.string().min(1).nullable(),
+    titlesByLeafId: z.record(z.string().min(1), z.string()).optional()
+  })
+  .strict()
+
+export type ArchivedTerminalLayout = z.infer<typeof archivedTerminalLayoutSchema>
+
+export const terminalArchiveSnapshotSchema = z
+  .object({
+    ref: z.string().regex(/^v1a-[0-9a-f]{32}$/),
+    byteLength: z.number().int().nonnegative(),
+    truncated: z.boolean(),
+    source: z.enum(TERMINAL_ARCHIVE_SNAPSHOT_SOURCES)
+  })
+  .strict()
+
+export type TerminalArchiveSnapshot = z.infer<typeof terminalArchiveSnapshotSchema>
+
+export const archivedTerminalPaneSchema = z
+  .object({
+    archivedLeafId: z.string().min(1),
+    cwd: z.string(),
+    shellOverride: z.string().min(1).optional(),
+    startupCommand: z.string().min(1).optional(),
+    startedAt: z.number().finite().nonnegative().optional(),
+    snapshot: terminalArchiveSnapshotSchema.optional(),
+    agent: z
+      .object({
+        type: resumableAgentSchema,
+        providerSession: agentProviderSessionSchema
+      })
+      .strict()
+      .optional(),
+    orchestrationTaskId: z.string().min(1).max(512).optional()
+  })
+  .strict()
+
+export type ArchivedTerminalPane = Omit<z.infer<typeof archivedTerminalPaneSchema>, 'agent'> & {
+  agent?: { type: ResumableTuiAgent; providerSession: AgentProviderSessionMetadata }
+}
+
+export const archivedTerminalTabSchema = z
+  .object({
+    schemaVersion: z.literal(TERMINAL_ARCHIVE_SCHEMA_VERSION),
+    id: z.string().uuid(),
+    operationId: z.string().min(1).max(512),
+    sourceTabId: z.string().min(1),
+    sourcePaneSignature: z
+      .string()
+      .regex(/^[0-9a-f]{64}$/)
+      .optional(),
+    executionHostId: executionHostIdSchema,
+    runtimeEnvironmentId: z.string().min(1).optional(),
+    worktreeId: z.string().min(1),
+    title: z.string(),
+    defaultTitle: z.string().optional(),
+    color: z.string().nullable().optional(),
+    layout: archivedTerminalLayoutSchema,
+    panesByLeafId: z.record(z.string().min(1), archivedTerminalPaneSchema),
+    reason: z.enum(TERMINAL_ARCHIVE_REASONS),
+    createdAt: z.number().finite().nonnegative().optional(),
+    capturedAt: z.number().finite().nonnegative().optional(),
+    archivedAt: z.number().finite().nonnegative(),
+    expiresAt: z.number().finite().nonnegative(),
+    lastRestoredAt: z.number().finite().nonnegative().optional(),
+    restoreCount: z.number().int().nonnegative()
+  })
+  .strict()
+
+export type ArchivedTerminalTab = Omit<
+  z.infer<typeof archivedTerminalTabSchema>,
+  'executionHostId' | 'panesByLeafId'
+> & {
+  executionHostId: ExecutionHostId
+  panesByLeafId: Record<string, ArchivedTerminalPane>
+}
+
+export const terminalArchivesByIdSchema = z.record(z.string().uuid(), archivedTerminalTabSchema)
+
+export const terminalArchiveHintSchema = z
+  .object({
+    cwd: z.string().min(1).optional(),
+    startupCommand: z.string().min(1).optional(),
+    shellOverride: z.string().min(1).optional(),
+    launchAgent: z.custom<TuiAgent>(isTuiAgent).optional(),
+    providerSession: agentProviderSessionSchema.optional(),
+    orchestrationTaskId: z.string().min(1).max(512).optional(),
+    startedAt: z.number().finite().nonnegative().optional(),
+    fieldSources: z
+      .object({
+        cwd: z.enum(TERMINAL_ARCHIVE_HINT_SOURCES).optional(),
+        startupCommand: z.enum(TERMINAL_ARCHIVE_HINT_SOURCES).optional(),
+        shellOverride: z.enum(TERMINAL_ARCHIVE_HINT_SOURCES).optional(),
+        launchAgent: z.enum(TERMINAL_ARCHIVE_HINT_SOURCES).optional(),
+        providerSession: z.enum(TERMINAL_ARCHIVE_HINT_SOURCES).optional(),
+        orchestrationTaskId: z.enum(TERMINAL_ARCHIVE_HINT_SOURCES).optional()
+      })
+      .strict()
+      .optional()
+  })
+  .strict()
+
+export type TerminalArchiveHint = Omit<
+  z.infer<typeof terminalArchiveHintSchema>,
+  'providerSession'
+> & {
+  providerSession?: AgentProviderSessionMetadata
+}
+
+export const terminalArchiveHintsByPaneKeySchema = z.record(
+  z.string().min(1),
+  terminalArchiveHintSchema
+)
+
+export type ArchivedTerminalTabSummary = {
+  id: string
+  operationId: string
+  executionHostId: ExecutionHostId
+  worktreeId: string
+  title: string
+  archivedAt: number
+  expiresAt: number
+  reason: TerminalArchiveReason
+  restoreCount: number
+  worktreeMissing?: boolean
+}
+
+export const TERMINAL_ARCHIVE_ERROR_CODES = [
+  'archive_not_found',
+  'archive_expired',
+  'archive_host_unreachable',
+  'archive_worktree_missing',
+  'archive_host_mismatch',
+  'not_implemented'
+] as const
+
+export type TerminalArchiveErrorCode = (typeof TERMINAL_ARCHIVE_ERROR_CODES)[number]
+
+export type RestoreTerminalArchiveResult = {
+  ok: false
+  code: TerminalArchiveErrorCode
+  archiveId: string
+}
+
+export function normalizeTerminalArchiveRetentionDays(value: unknown): number {
+  const numeric = typeof value === 'number' ? value : Number.NaN
+  if (!Number.isFinite(numeric)) {
+    return DEFAULT_TERMINAL_ARCHIVE_RETENTION_DAYS
+  }
+  return Math.min(
+    MAX_TERMINAL_ARCHIVE_RETENTION_DAYS,
+    Math.max(MIN_TERMINAL_ARCHIVE_RETENTION_DAYS, Math.round(numeric))
+  )
+}
+
+export function toArchivedTerminalTabSummary(
+  archive: ArchivedTerminalTab,
+  options: { worktreeMissing?: boolean } = {}
+): ArchivedTerminalTabSummary {
+  return {
+    id: archive.id,
+    operationId: archive.operationId,
+    executionHostId: archive.executionHostId,
+    worktreeId: archive.worktreeId,
+    title: archive.title,
+    archivedAt: archive.archivedAt,
+    expiresAt: archive.expiresAt,
+    reason: archive.reason,
+    restoreCount: archive.restoreCount,
+    ...(options.worktreeMissing ? { worktreeMissing: true } : {})
+  }
+}

--- a/src/shared/terminal-archive-types.ts
+++ b/src/shared/terminal-archive-types.ts
@@ -7,7 +7,7 @@ import {
 } from './agent-session-resume'
 import { normalizeExecutionHostId, type ExecutionHostId } from './execution-host'
 import { isTuiAgent } from './tui-agent-config'
-import type { TuiAgent } from './types'
+import type { TuiAgent, WorkspaceSessionState } from './types'
 
 export const TERMINAL_ARCHIVE_SCHEMA_VERSION = 1 as const
 export const DEFAULT_TERMINAL_ARCHIVE_RETENTION_DAYS = 7
@@ -128,6 +128,24 @@ export const terminalArchiveSnapshotSchema = z
   .strict()
 
 export type TerminalArchiveSnapshot = z.infer<typeof terminalArchiveSnapshotSchema>
+
+/** Renderer-owned xterm bytes captured before a user closes an entire tab. */
+export type TerminalArchiveRendererSnapshot = {
+  buffer: string
+  source: 'renderer'
+  truncated: boolean
+  byteLength: number
+}
+
+/** Narrow renderer → main handoff; main supplies the authoritative pane identities. */
+export type TerminalArchiveRendererCloseRequest = {
+  session: WorkspaceSessionState
+  worktreeId: string
+  tabId: string
+  executionHostId: ExecutionHostId
+  runtimeEnvironmentId?: string
+  snapshotsByLeafId: Record<string, TerminalArchiveRendererSnapshot>
+}
 
 export const archivedTerminalPaneSchema = z
   .object({

--- a/src/shared/terminal-lost-worker-policy.test.ts
+++ b/src/shared/terminal-lost-worker-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { classifyLostTerminal } from './terminal-lost-worker-policy'
+
+describe('classifyLostTerminal', () => {
+  it('classifies every durable worker fact independently and together', () => {
+    expect(
+      classifyLostTerminal({ providerSession: { key: 'session_id', id: 'session-1' } })
+    ).toEqual({ kind: 'worker', evidence: ['provider-session'] })
+    expect(classifyLostTerminal({ orchestrationTaskId: 'task-1' })).toEqual({
+      kind: 'worker',
+      evidence: ['orchestration-task']
+    })
+    expect(classifyLostTerminal({ launchAgent: 'codex' })).toEqual({
+      kind: 'worker',
+      evidence: ['launch-agent']
+    })
+    expect(
+      classifyLostTerminal({
+        providerSession: { key: 'conversation_id', id: 'conversation-1' },
+        orchestrationTaskId: 'task-1',
+        launchAgent: 'claude'
+      })
+    ).toEqual({
+      kind: 'worker',
+      evidence: ['provider-session', 'orchestration-task', 'launch-agent']
+    })
+  })
+
+  it('fails closed for malformed durable facts and agent-like commands', () => {
+    expect(
+      classifyLostTerminal({
+        providerSession: { key: 'unknown', id: 'session-1' } as never,
+        orchestrationTaskId: ' task-1 ',
+        launchAgent: 'unknown' as never
+      })
+    ).toEqual({ kind: 'ordinary-shell' })
+    expect(
+      classifyLostTerminal({
+        startupCommand: 'codex --resume session-1'
+      } as never)
+    ).toEqual({ kind: 'ordinary-shell' })
+  })
+})

--- a/src/shared/terminal-lost-worker-policy.ts
+++ b/src/shared/terminal-lost-worker-policy.ts
@@ -1,0 +1,36 @@
+import { normalizeAgentProviderSession } from './agent-session-resume'
+import { isTuiAgent } from './tui-agent-config'
+import type { TerminalArchiveHint } from './terminal-archive-types'
+
+export type LostTerminalClassification =
+  | {
+      kind: 'worker'
+      evidence: ('provider-session' | 'orchestration-task' | 'launch-agent')[]
+    }
+  | { kind: 'ordinary-shell' }
+
+function hasBoundedTaskId(value: unknown): value is string {
+  return (
+    typeof value === 'string' && value.length > 0 && value.length <= 512 && value.trim() === value
+  )
+}
+
+/** Classifies only durable facts; startup commands are never worker evidence. */
+export function classifyLostTerminal(
+  hint:
+    | Pick<TerminalArchiveHint, 'providerSession' | 'orchestrationTaskId' | 'launchAgent'>
+    | null
+    | undefined
+): LostTerminalClassification {
+  const evidence: ('provider-session' | 'orchestration-task' | 'launch-agent')[] = []
+  if (normalizeAgentProviderSession(hint?.providerSession)) {
+    evidence.push('provider-session')
+  }
+  if (hasBoundedTaskId(hint?.orchestrationTaskId)) {
+    evidence.push('orchestration-task')
+  }
+  if (isTuiAgent(hint?.launchAgent)) {
+    evidence.push('launch-agent')
+  }
+  return evidence.length > 0 ? { kind: 'worker', evidence } : { kind: 'ordinary-shell' }
+}

--- a/src/shared/terminal-tab-close.ts
+++ b/src/shared/terminal-tab-close.ts
@@ -6,4 +6,5 @@ export type TerminalTabCloseRequest = {
 export type TerminalTabCloseResponse = {
   requestId: string
   error?: string
+  archiveId?: string
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -43,6 +43,7 @@ import type {
 import type { UsagePercentageDisplay } from './usage-percentage-display'
 import type { StatusBarUsageMode } from './status-bar-usage-mode'
 import type { PersistedNativeChatSessionOptions } from './native-chat-session-options'
+import type { ArchivedTerminalTab, TerminalArchiveHint } from './terminal-archive-types'
 
 // Re-exported for backward compat with renderer call sites that import
 // `WorkspaceCreateTelemetrySource` from '../../../shared/types'.
@@ -1087,6 +1088,8 @@ export type WorkspaceSessionState = {
   /** Keys may be legacy raw worktree IDs or canonical WorkspaceKey values. */
   tabsByWorktree: Record<string, TerminalTab[]>
   terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
+  /** Capture-only terminal facts. These never become a second live-agent authority. */
+  terminalArchiveHintsByPaneKey?: Record<string, TerminalArchiveHint>
   /** Worktree IDs that had at least one tab with a live PTY at shutdown.
    *  Used on startup to eagerly re-spawn PTY processes so the Active filter
    *  works immediately after restart. */
@@ -2725,6 +2728,8 @@ export type GlobalSettings = {
   /** Where the repo setup script runs on workspace create; defaults to a background "Setup" tab to keep the main terminal usable. */
   setupScriptLaunchMode: SetupScriptLaunchMode
   terminalScrollbackRows: number
+  /** Durable terminal archives expire after this many days; intentionally no infinite-retention mode. */
+  terminalArchiveRetentionDays?: number
   /** Optional app-level proxy for Electron networking and local PTYs; empty preserves system/inherited proxy env. */
   httpProxyUrl?: string
   /** Optional semicolon/comma/newline-separated bypass rules for httpProxyUrl. */
@@ -3463,6 +3468,8 @@ export type PersistedState = {
   workspaceSession: WorkspaceSessionState
   /** Per-execution-host session partitions for non-'local' hosts (ssh:/runtime:); 'local' stays in workspaceSession so pre-partition builds keep working. */
   workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
+  /** Main-owned archive metadata; scrollback bytes remain in terminal-scrollback sidecars. */
+  terminalArchivesById: Record<string, ArchivedTerminalTab>
   sshTargets: SshTarget[]
   /** SSH config aliases the user deleted; suppresses re-import from ~/.ssh/config so a deleted host doesn't reappear. */
   deletedSshConfigAliases: string[]

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -22,6 +22,7 @@ import { isTuiAgent } from './tui-agent-config'
 import { normalizeBrowserHistoryEntries } from './workspace-session-browser-history'
 import { isWorkspaceKey } from './workspace-scope'
 import { sleepingAgentSessionsByPaneKeySchema } from './workspace-session-sleeping-agents'
+import { terminalArchiveHintsByPaneKeySchema } from './terminal-archive-types'
 
 // ─── Terminal pane layout (recursive) ───────────────────────────────
 
@@ -253,6 +254,7 @@ export const workspaceSessionStateSchema: z.ZodType<WorkspaceSessionState> = z.o
   activeTabId: z.string().nullable(),
   tabsByWorktree: z.record(z.string(), z.array(terminalTabSchema)),
   terminalLayoutsByTabId: z.record(terminalTabIdSchema, terminalLayoutSnapshotSchema),
+  terminalArchiveHintsByPaneKey: terminalArchiveHintsByPaneKeySchema.optional(),
   activeWorktreeIdsOnShutdown: z.array(z.string()).optional(),
   openFilesByWorktree: z.record(z.string(), z.array(persistedOpenFileSchema)).optional(),
   activeFileIdByWorktree: z.record(z.string(), z.string().nullable()).optional(),

--- a/src/shared/workspace-session-terminal-archive.test.ts
+++ b/src/shared/workspace-session-terminal-archive.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest'
+import { archivedTerminalPaneSchema, terminalArchiveHintSchema } from './terminal-archive-types'
+import {
+  captureTerminalArchiveTab,
+  createPrioritizedTerminalArchiveSnapshotSource,
+  mergeTerminalArchiveHint,
+  retireArchivedTerminalTab,
+  shouldArchiveTerminalClose
+} from './workspace-session-terminal-archive'
+import { getDefaultWorkspaceSession } from './constants'
+import type { WorkspaceSessionState } from './types'
+
+const WORKTREE_ID = 'repo-1::/worktree'
+const TAB_ID = 'terminal-1'
+const LEFT_LEAF = '11111111-1111-4111-8111-111111111111'
+const RIGHT_LEAF = '22222222-2222-4222-8222-222222222222'
+
+function session(): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: {
+      [WORKTREE_ID]: [
+        {
+          id: TAB_ID,
+          ptyId: 'shared-pty',
+          worktreeId: WORKTREE_ID,
+          title: 'Agent',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 10,
+          startupCwd: '/worktree'
+        },
+        {
+          id: 'other-tab',
+          ptyId: 'shared-pty',
+          worktreeId: WORKTREE_ID,
+          title: 'Other',
+          customTitle: null,
+          color: null,
+          sortOrder: 1,
+          createdAt: 11
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      [TAB_ID]: {
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          ratio: 0.3,
+          first: { type: 'leaf', leafId: LEFT_LEAF },
+          second: { type: 'leaf', leafId: RIGHT_LEAF }
+        },
+        activeLeafId: RIGHT_LEAF,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEFT_LEAF]: 'shared-pty', [RIGHT_LEAF]: 'shared-pty' },
+        titlesByLeafId: { [LEFT_LEAF]: 'Build', [RIGHT_LEAF]: 'Agent' }
+      }
+    },
+    terminalPtyIncarnationsByPaneKey: {
+      [`${TAB_ID}:${LEFT_LEAF}`]: 'left-incarnation',
+      [`${TAB_ID}:${RIGHT_LEAF}`]: 'right-incarnation'
+    },
+    terminalArchiveHintsByPaneKey: {
+      [`${TAB_ID}:${RIGHT_LEAF}`]: {
+        cwd: '/worktree',
+        startupCommand: 'codex --dangerously-bypass-approvals-and-sandbox',
+        launchAgent: 'codex',
+        providerSession: { key: 'session_id', id: 'session-1' },
+        orchestrationTaskId: 'task-1',
+        startedAt: 5
+      }
+    }
+  }
+}
+
+describe('workspace terminal archive transition', () => {
+  it('captures split layout fidelity while stripping process identities', () => {
+    const captured = captureTerminalArchiveTab({
+      session: session(),
+      worktreeId: WORKTREE_ID,
+      tabId: TAB_ID
+    })
+
+    expect(captured?.layout).toEqual({
+      root: {
+        type: 'split',
+        direction: 'vertical',
+        ratio: 0.3,
+        first: { type: 'leaf', leafId: LEFT_LEAF },
+        second: { type: 'leaf', leafId: RIGHT_LEAF }
+      },
+      activeLeafId: RIGHT_LEAF,
+      expandedLeafId: null,
+      titlesByLeafId: { [LEFT_LEAF]: 'Build', [RIGHT_LEAF]: 'Agent' }
+    })
+    expect(JSON.stringify(captured?.layout)).not.toContain('pty')
+    expect(captured?.panesByLeafId[RIGHT_LEAF]).toMatchObject({
+      cwd: '/worktree',
+      agent: { type: 'codex', providerSession: { id: 'session-1' } }
+    })
+    expect(captured?.sourcePaneIdentityByLeafId).toEqual({
+      [LEFT_LEAF]: { paneKey: `${TAB_ID}:${LEFT_LEAF}`, incarnationId: 'left-incarnation' },
+      [RIGHT_LEAF]: { paneKey: `${TAB_ID}:${RIGHT_LEAF}`, incarnationId: 'right-incarnation' }
+    })
+  })
+
+  it('prefers hook facts while retaining the earliest start time', () => {
+    const merged = mergeTerminalArchiveHint(
+      {
+        cwd: '/worktree',
+        launchAgent: 'codex',
+        providerSession: { key: 'session_id', id: 'old-session' },
+        startedAt: 40
+      },
+      {
+        providerSession: { key: 'session_id', id: 'hook-session' },
+        orchestrationTaskId: 'task-2',
+        startedAt: 20
+      },
+      'hook'
+    )
+
+    expect(merged.providerSession?.id).toBe('hook-session')
+    expect(merged.orchestrationTaskId).toBe('task-2')
+    expect(merged.startedAt).toBe(20)
+  })
+
+  it('does not let a late launch default overwrite hook facts', () => {
+    const fromHook = mergeTerminalArchiveHint(
+      undefined,
+      {
+        cwd: '/authoritative-worktree',
+        shellOverride: '/bin/zsh',
+        launchAgent: 'codex'
+      },
+      'hook'
+    )
+    const merged = mergeTerminalArchiveHint(
+      fromHook,
+      {
+        cwd: '/launch-default',
+        shellOverride: '/bin/bash',
+        launchAgent: 'claude'
+      },
+      'launch'
+    )
+
+    expect(merged).toMatchObject({
+      cwd: '/authoritative-worktree',
+      shellOverride: '/bin/zsh',
+      launchAgent: 'codex'
+    })
+  })
+
+  it('does not let a late spawn default overwrite sleeping-session facts', () => {
+    const fromSleepingSession = mergeTerminalArchiveHint(
+      undefined,
+      {
+        cwd: '/resumed-worktree',
+        startupCommand: 'codex resume',
+        launchAgent: 'codex'
+      },
+      'sleeping-session'
+    )
+    const merged = mergeTerminalArchiveHint(
+      fromSleepingSession,
+      {
+        cwd: '/spawn-default',
+        startupCommand: 'codex',
+        launchAgent: 'claude'
+      },
+      'spawn'
+    )
+
+    expect(merged).toMatchObject({
+      cwd: '/resumed-worktree',
+      startupCommand: 'codex resume',
+      launchAgent: 'codex'
+    })
+  })
+
+  it.each([
+    [
+      'pane agent provider session',
+      archivedTerminalPaneSchema,
+      {
+        archivedLeafId: LEFT_LEAF,
+        cwd: '/worktree',
+        agent: {
+          type: 'codex',
+          providerSession: { key: 'session_id', id: 'session-1', unexpected: 'field' }
+        }
+      }
+    ],
+    [
+      'archive hint provider session',
+      terminalArchiveHintSchema,
+      {
+        providerSession: { key: 'session_id', id: 'session-1', unexpected: 'field' }
+      }
+    ]
+  ])('rejects unknown nested fields in %s', (_description, schema, value) => {
+    expect(schema.safeParse(value).success).toBe(false)
+  })
+
+  it.each(['cleanup', 'pty-exit', 'app-shutdown', 'hibernation', 'pane-close'] as const)(
+    'does not archive %s',
+    (reason) => {
+      expect(shouldArchiveTerminalClose(reason)).toBe(false)
+    }
+  )
+
+  it('does not kill a PTY still owned by another tab when retiring', () => {
+    const retired = retireArchivedTerminalTab(session(), WORKTREE_ID, TAB_ID)
+
+    expect(retired.closed).toBe(true)
+    expect(retired.ptyIdsToKill).toEqual([])
+    expect(retired.session.terminalArchiveHintsByPaneKey).toBeUndefined()
+  })
+
+  it('uses daemon snapshots before renderer, sidecar, and relay fallbacks', async () => {
+    const renderer = {
+      capture: async () => ({
+        kind: 'captured-bytes' as const,
+        buffer: 'renderer',
+        source: 'renderer' as const,
+        truncated: false,
+        byteLength: 8
+      })
+    }
+    const source = createPrioritizedTerminalArchiveSnapshotSource({
+      daemonAuthoritative: { capture: async () => ({ kind: 'unavailable' as const }) },
+      rendererSerializer: renderer,
+      sessionSidecar: {
+        capture: async () => ({
+          kind: 'captured-bytes' as const,
+          buffer: 'sidecar',
+          source: 'session-sidecar' as const,
+          truncated: false,
+          byteLength: 7
+        })
+      },
+      relayTail: {
+        capture: async () => ({
+          kind: 'captured-bytes' as const,
+          buffer: 'relay',
+          source: 'relay-tail' as const,
+          truncated: true,
+          byteLength: 5
+        })
+      }
+    })
+    const captured = await source.capture({ archivedLeafId: LEFT_LEAF, cwd: '/worktree' })
+
+    expect(captured).toMatchObject({ kind: 'captured-bytes', source: 'renderer' })
+  })
+})

--- a/src/shared/workspace-session-terminal-archive.test.ts
+++ b/src/shared/workspace-session-terminal-archive.test.ts
@@ -4,6 +4,7 @@ import {
   captureTerminalArchiveTab,
   createPrioritizedTerminalArchiveSnapshotSource,
   mergeTerminalArchiveHint,
+  moveTerminalArchivePaneDurableState,
   retireArchivedTerminalTab,
   shouldArchiveTerminalClose
 } from './workspace-session-terminal-archive'
@@ -179,6 +180,34 @@ describe('workspace terminal archive transition', () => {
       startupCommand: 'codex resume',
       launchAgent: 'codex'
     })
+  })
+
+  it('does not persist malformed task or launch-agent evidence', () => {
+    expect(
+      mergeTerminalArchiveHint(
+        undefined,
+        { orchestrationTaskId: ' task-1 ', launchAgent: 'unknown' as never },
+        'hook'
+      )
+    ).toEqual({})
+  })
+
+  it('moves pane hint and incarnation as one authority transfer', () => {
+    const moved = moveTerminalArchivePaneDurableState({
+      session: session(),
+      fromPaneKey: `${TAB_ID}:${RIGHT_LEAF}`,
+      toPaneKey: `${TAB_ID}:${LEFT_LEAF}`
+    })
+
+    expect(moved.terminalArchiveHintsByPaneKey?.[`${TAB_ID}:${RIGHT_LEAF}`]).toBeUndefined()
+    expect(moved.terminalPtyIncarnationsByPaneKey?.[`${TAB_ID}:${RIGHT_LEAF}`]).toBeUndefined()
+    expect(moved.terminalArchiveHintsByPaneKey?.[`${TAB_ID}:${LEFT_LEAF}`]).toMatchObject({
+      launchAgent: 'codex',
+      orchestrationTaskId: 'task-1'
+    })
+    expect(moved.terminalPtyIncarnationsByPaneKey?.[`${TAB_ID}:${LEFT_LEAF}`]).toBe(
+      'right-incarnation'
+    )
   })
 
   it.each([

--- a/src/shared/workspace-session-terminal-archive.ts
+++ b/src/shared/workspace-session-terminal-archive.ts
@@ -10,6 +10,7 @@ import type {
 } from './terminal-archive-types'
 import { TERMINAL_ARCHIVE_HINT_FIELDS } from './terminal-archive-types'
 import { makePaneKey } from './stable-pane-id'
+import { isTuiAgent } from './tui-agent-config'
 import type { TerminalLayoutSnapshot, TerminalTab, WorkspaceSessionState } from './types'
 import { closeTerminalTabInWorkspaceSession } from './workspace-session-terminal-tab-close'
 
@@ -140,9 +141,12 @@ function normalizeHint(input: Partial<TerminalArchiveHint>): Partial<TerminalArc
     ...(typeof input.shellOverride === 'string' && input.shellOverride
       ? { shellOverride: input.shellOverride }
       : {}),
-    ...(input.launchAgent ? { launchAgent: input.launchAgent } : {}),
+    ...(isTuiAgent(input.launchAgent) ? { launchAgent: input.launchAgent } : {}),
     ...(providerSession ? { providerSession } : {}),
-    ...(typeof input.orchestrationTaskId === 'string' && input.orchestrationTaskId
+    ...(typeof input.orchestrationTaskId === 'string' &&
+    input.orchestrationTaskId.length > 0 &&
+    input.orchestrationTaskId.length <= 512 &&
+    input.orchestrationTaskId.trim() === input.orchestrationTaskId
       ? { orchestrationTaskId: input.orchestrationTaskId }
       : {}),
     ...(typeof input.startedAt === 'number' && Number.isFinite(input.startedAt)
@@ -222,6 +226,39 @@ export function mergeTerminalArchiveHintIntoSession(args: {
       ...args.session.terminalArchiveHintsByPaneKey,
       [args.paneKey]: mergeTerminalArchiveHint(current, args.hint, args.source)
     }
+  }
+}
+
+/** Moves the two pane-keyed durable facts together when main proves PTY ownership. */
+export function moveTerminalArchivePaneDurableState(args: {
+  session: WorkspaceSessionState
+  fromPaneKey: string
+  toPaneKey: string
+}): WorkspaceSessionState {
+  if (args.fromPaneKey === args.toPaneKey) {
+    return args.session
+  }
+  const hint = args.session.terminalArchiveHintsByPaneKey?.[args.fromPaneKey]
+  const incarnation = args.session.terminalPtyIncarnationsByPaneKey?.[args.fromPaneKey]
+  if (!hint && !incarnation) {
+    return args.session
+  }
+  const hints = { ...args.session.terminalArchiveHintsByPaneKey }
+  const incarnations = { ...args.session.terminalPtyIncarnationsByPaneKey }
+  if (hint) {
+    hints[args.toPaneKey] = hint
+    delete hints[args.fromPaneKey]
+  }
+  if (incarnation) {
+    incarnations[args.toPaneKey] = incarnation
+    delete incarnations[args.fromPaneKey]
+  }
+  return {
+    ...args.session,
+    ...(Object.keys(hints).length > 0 ? { terminalArchiveHintsByPaneKey: hints } : {}),
+    ...(Object.keys(incarnations).length > 0
+      ? { terminalPtyIncarnationsByPaneKey: incarnations }
+      : {})
   }
 }
 

--- a/src/shared/workspace-session-terminal-archive.ts
+++ b/src/shared/workspace-session-terminal-archive.ts
@@ -1,0 +1,271 @@
+import { isResumableTuiAgent, normalizeAgentProviderSession } from './agent-session-resume'
+import type { AgentProviderSessionMetadata } from './agent-session-resume'
+import type {
+  ArchivedTerminalLayout,
+  ArchivedTerminalPane,
+  TerminalArchiveCloseReason,
+  TerminalArchiveHint,
+  TerminalArchiveHintField,
+  TerminalArchiveHintSource
+} from './terminal-archive-types'
+import { TERMINAL_ARCHIVE_HINT_FIELDS } from './terminal-archive-types'
+import { makePaneKey } from './stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab, WorkspaceSessionState } from './types'
+import { closeTerminalTabInWorkspaceSession } from './workspace-session-terminal-tab-close'
+
+export type CapturedTerminalArchiveTab = {
+  tab: TerminalTab
+  layout: ArchivedTerminalLayout
+  panesByLeafId: Record<string, ArchivedTerminalPane>
+  sourcePaneIdentityByLeafId: Record<string, { paneKey: string; incarnationId: string }>
+}
+
+export type { TerminalArchiveHintSource } from './terminal-archive-types'
+
+export function shouldArchiveTerminalClose(reason: TerminalArchiveCloseReason): boolean {
+  return (
+    reason === 'user-close' || reason === 'relay-worker-lost' || reason === 'daemon-worker-lost'
+  )
+}
+
+function archiveLayout(layout: TerminalLayoutSnapshot | undefined): ArchivedTerminalLayout {
+  return {
+    root: layout?.root ? structuredClone(layout.root) : null,
+    activeLeafId: layout?.activeLeafId ?? null,
+    expandedLeafId: layout?.expandedLeafId ?? null,
+    ...(layout?.titlesByLeafId ? { titlesByLeafId: { ...layout.titlesByLeafId } } : {})
+  }
+}
+
+function collectLeafIds(node: ArchivedTerminalLayout['root'], output: string[] = []): string[] {
+  if (!node) {
+    return output
+  }
+  if (node.type === 'leaf') {
+    output.push(node.leafId)
+    return output
+  }
+  collectLeafIds(node.first, output)
+  collectLeafIds(node.second, output)
+  return output
+}
+
+function paneFromHint(
+  leafId: string,
+  tab: TerminalTab,
+  hint: TerminalArchiveHint | undefined
+): ArchivedTerminalPane {
+  const providerSession = hint?.providerSession
+  const agent = hint?.launchAgent
+  return {
+    archivedLeafId: leafId,
+    cwd: hint?.cwd ?? tab.startupCwd ?? '',
+    ...((hint?.shellOverride ?? tab.shellOverride)
+      ? { shellOverride: hint?.shellOverride ?? tab.shellOverride }
+      : {}),
+    ...(hint?.startupCommand ? { startupCommand: hint.startupCommand } : {}),
+    ...(hint?.startedAt !== undefined ? { startedAt: hint.startedAt } : {}),
+    ...(agent && providerSession && isResumableTuiAgent(agent)
+      ? { agent: { type: agent, providerSession } }
+      : {}),
+    ...(hint?.orchestrationTaskId ? { orchestrationTaskId: hint.orchestrationTaskId } : {})
+  }
+}
+
+/** Captures only durable, non-process identity. PTY ids and incarnations deliberately stay out. */
+export function captureTerminalArchiveTab(args: {
+  session: WorkspaceSessionState
+  worktreeId: string
+  tabId: string
+}): CapturedTerminalArchiveTab | null {
+  const tab = args.session.tabsByWorktree[args.worktreeId]?.find((entry) => entry.id === args.tabId)
+  if (!tab) {
+    return null
+  }
+  const layout = archiveLayout(args.session.terminalLayoutsByTabId[args.tabId])
+  const leafIds = collectLeafIds(layout.root)
+  if (leafIds.length === 0) {
+    return null
+  }
+  const panesByLeafId: Record<string, ArchivedTerminalPane> = {}
+  const sourcePaneIdentityByLeafId: CapturedTerminalArchiveTab['sourcePaneIdentityByLeafId'] = {}
+  for (const leafId of leafIds) {
+    const paneKey = makePaneKey(args.tabId, leafId)
+    const incarnationId = args.session.terminalPtyIncarnationsByPaneKey?.[paneKey]
+    if (!incarnationId) {
+      return null
+    }
+    panesByLeafId[leafId] = paneFromHint(
+      leafId,
+      tab,
+      args.session.terminalArchiveHintsByPaneKey?.[paneKey]
+    )
+    sourcePaneIdentityByLeafId[leafId] = { paneKey, incarnationId }
+  }
+  return { tab: { ...tab }, layout, panesByLeafId, sourcePaneIdentityByLeafId }
+}
+
+export function retireArchivedTerminalTab(
+  session: WorkspaceSessionState,
+  worktreeId: string,
+  tabId: string
+): ReturnType<typeof closeTerminalTabInWorkspaceSession> {
+  const closed = closeTerminalTabInWorkspaceSession(session, worktreeId, tabId)
+  if (!closed.closed || !session.terminalArchiveHintsByPaneKey) {
+    return closed
+  }
+  const hints = { ...session.terminalArchiveHintsByPaneKey }
+  for (const paneKey of Object.keys(hints)) {
+    if (paneKey.startsWith(`${tabId}:`)) {
+      delete hints[paneKey]
+    }
+  }
+  const { terminalArchiveHintsByPaneKey: _removedHints, ...sessionWithoutHints } = closed.session
+  return {
+    ...closed,
+    session: {
+      ...sessionWithoutHints,
+      ...(Object.keys(hints).length > 0 ? { terminalArchiveHintsByPaneKey: hints } : {})
+    }
+  }
+}
+
+function normalizeHint(input: Partial<TerminalArchiveHint>): Partial<TerminalArchiveHint> {
+  const providerSession = normalizeAgentProviderSession(input.providerSession)
+  return {
+    ...(typeof input.cwd === 'string' && input.cwd ? { cwd: input.cwd } : {}),
+    ...(typeof input.startupCommand === 'string' && input.startupCommand
+      ? { startupCommand: input.startupCommand }
+      : {}),
+    ...(typeof input.shellOverride === 'string' && input.shellOverride
+      ? { shellOverride: input.shellOverride }
+      : {}),
+    ...(input.launchAgent ? { launchAgent: input.launchAgent } : {}),
+    ...(providerSession ? { providerSession } : {}),
+    ...(typeof input.orchestrationTaskId === 'string' && input.orchestrationTaskId
+      ? { orchestrationTaskId: input.orchestrationTaskId }
+      : {}),
+    ...(typeof input.startedAt === 'number' && Number.isFinite(input.startedAt)
+      ? { startedAt: input.startedAt }
+      : {})
+  }
+}
+
+const terminalArchiveHintSourceRank: Record<TerminalArchiveHintSource, number> = {
+  spawn: 0,
+  launch: 1,
+  'sleeping-session': 2,
+  hook: 3
+}
+
+function mergeHintField<K extends TerminalArchiveHintField>(args: {
+  current: TerminalArchiveHint | undefined
+  incoming: Partial<TerminalArchiveHint>
+  source: TerminalArchiveHintSource
+  field: K
+  merged: Partial<TerminalArchiveHint>
+  fieldSources: NonNullable<TerminalArchiveHint['fieldSources']>
+}): void {
+  const currentValue = args.current?.[args.field]
+  const incomingValue = args.incoming[args.field]
+  const currentSource = args.current?.fieldSources?.[args.field] ?? 'spawn'
+  if (
+    incomingValue !== undefined &&
+    (currentValue === undefined ||
+      terminalArchiveHintSourceRank[args.source] >= terminalArchiveHintSourceRank[currentSource])
+  ) {
+    args.merged[args.field] = incomingValue
+    args.fieldSources[args.field] = args.source
+    return
+  }
+  if (currentValue !== undefined) {
+    args.merged[args.field] = currentValue
+    if (args.current?.fieldSources?.[args.field]) {
+      args.fieldSources[args.field] = args.current.fieldSources[args.field]
+    }
+  }
+}
+
+/** Hook and sleeping-session facts are more authoritative than launch defaults. */
+export function mergeTerminalArchiveHint(
+  current: TerminalArchiveHint | undefined,
+  incoming: Partial<TerminalArchiveHint>,
+  source: TerminalArchiveHintSource
+): TerminalArchiveHint {
+  const next = normalizeHint(incoming)
+  const merged: Partial<TerminalArchiveHint> = {}
+  const fieldSources: NonNullable<TerminalArchiveHint['fieldSources']> = {}
+  for (const field of TERMINAL_ARCHIVE_HINT_FIELDS) {
+    mergeHintField({ current, incoming: next, source, field, merged, fieldSources })
+  }
+  const startedAt =
+    current?.startedAt !== undefined && next.startedAt !== undefined
+      ? Math.min(current.startedAt, next.startedAt)
+      : (current?.startedAt ?? next.startedAt)
+  return {
+    ...merged,
+    ...(startedAt !== undefined ? { startedAt } : {}),
+    ...(Object.keys(fieldSources).length > 0 ? { fieldSources } : {})
+  } as TerminalArchiveHint
+}
+
+export function mergeTerminalArchiveHintIntoSession(args: {
+  session: WorkspaceSessionState
+  paneKey: string
+  hint: Partial<TerminalArchiveHint>
+  source: TerminalArchiveHintSource
+}): WorkspaceSessionState {
+  const current = args.session.terminalArchiveHintsByPaneKey?.[args.paneKey]
+  return {
+    ...args.session,
+    terminalArchiveHintsByPaneKey: {
+      ...args.session.terminalArchiveHintsByPaneKey,
+      [args.paneKey]: mergeTerminalArchiveHint(current, args.hint, args.source)
+    }
+  }
+}
+
+export type TerminalArchivePaneSnapshotInput = {
+  kind: 'captured-bytes'
+  buffer: string
+  source: 'renderer' | 'daemon-headless' | 'relay-tail' | 'session-sidecar'
+  truncated: boolean
+  byteLength: number
+}
+
+export type TerminalArchivePaneSnapshotCapture =
+  | TerminalArchivePaneSnapshotInput
+  | { kind: 'captured-empty' }
+  | { kind: 'unavailable' }
+
+export type TerminalArchiveSnapshotSource = {
+  capture(pane: ArchivedTerminalPane): Promise<TerminalArchivePaneSnapshotCapture>
+}
+
+/** The Store sees one capture seam; this adapter keeps authority order consistent across hosts. */
+export function createPrioritizedTerminalArchiveSnapshotSource(sources: {
+  daemonAuthoritative?: TerminalArchiveSnapshotSource
+  rendererSerializer?: TerminalArchiveSnapshotSource
+  sessionSidecar?: TerminalArchiveSnapshotSource
+  relayTail?: TerminalArchiveSnapshotSource
+}): TerminalArchiveSnapshotSource {
+  const ordered = [
+    sources.daemonAuthoritative,
+    sources.rendererSerializer,
+    sources.sessionSidecar,
+    sources.relayTail
+  ]
+  return {
+    async capture(pane) {
+      for (const source of ordered) {
+        const captured = await source?.capture(pane)
+        if (captured && captured.kind !== 'unavailable') {
+          return captured
+        }
+      }
+      return { kind: 'unavailable' }
+    }
+  }
+}
+
+export type TerminalArchiveProviderSession = AgentProviderSessionMetadata

--- a/tests/e2e/daemon-crash-lost-worker-archive.spec.ts
+++ b/tests/e2e/daemon-crash-lost-worker-archive.spec.ts
@@ -1,0 +1,518 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+
+import { DaemonClient } from '../../src/main/daemon/client'
+import {
+  getDaemonPidPath,
+  getDaemonSocketPath,
+  getDaemonTokenPath
+} from '../../src/main/daemon/daemon-spawner'
+import { PROTOCOL_VERSION, type ListSessionsResult } from '../../src/main/daemon/types'
+import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
+import { TEST_REPO_PATH_FILE } from './global-setup'
+import { emitCodexHookStatus, readHookEndpoint } from './helpers/agent-hook-endpoint'
+import { test, expect } from './helpers/orca-app'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import {
+  getTerminalContent,
+  waitForActivePaneHookDescriptor,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+
+type PaneIdentity = {
+  cols: number
+  leafId: string
+  ptyId: string
+  rows: number
+}
+
+type PersistedArchive = {
+  reason?: string
+  sourceTabId?: string
+}
+
+type PersistedData = {
+  terminalArchivesById?: Record<string, PersistedArchive>
+  workspaceSession?: {
+    terminalArchiveHintsByPaneKey?: Record<string, { launchAgent?: string }>
+  }
+}
+
+function writeDaemonRpcProbe(root: string): {
+  logPath: string
+  probePath: string
+} {
+  mkdirSync(root, { recursive: true })
+  const logPath = path.join(root, 'daemon-create-or-attach.ndjson')
+  const probePath = path.join(root, 'daemon-rpc-probe.cjs')
+
+  writeFileSync(
+    probePath,
+    `const { appendFileSync } = require('node:fs')
+const net = require('node:net')
+
+const logPath = process.env.ORCA_E2E_DAEMON_CREATE_LOG
+if (logPath && process.argv.some((argument) => String(argument).includes('daemon-entry'))) {
+  const bufferedBySocket = new WeakMap()
+  const originalEmit = net.Socket.prototype.emit
+
+  net.Socket.prototype.emit = function emitWithCreateOrAttachTrace(event, ...arguments) {
+    if (event === 'data') {
+      const previous = bufferedBySocket.get(this) || ''
+      const next = previous + Buffer.from(arguments[0]).toString('utf8')
+      const lines = next.split('\\n')
+      bufferedBySocket.set(this, lines.pop() || '')
+
+      for (const line of lines) {
+        try {
+          const message = JSON.parse(line)
+          if (message.type === 'createOrAttach') {
+            appendFileSync(logPath, JSON.stringify({
+              attachOnly: message.payload?.attachOnly === true,
+              hasHistorySeed: typeof message.payload?.historySeed === 'string' && message.payload.historySeed.length > 0,
+              pid: process.pid,
+              sessionId: message.payload?.sessionId,
+            }) + '\\n')
+          }
+        } catch {
+          // Observability must never alter a daemon request when a chunk is not NDJSON.
+        }
+      }
+    }
+
+    return originalEmit.call(this, event, ...arguments)
+  }
+}
+
+`
+  )
+  writeFileSync(logPath, '')
+  return { logPath, probePath }
+}
+
+function readDaemonPid(userDataDir: string): number | null {
+  const pidPath = getDaemonPidPath(path.join(userDataDir, 'daemon'))
+  if (!existsSync(pidPath)) {
+    return null
+  }
+
+  try {
+    const raw = readFileSync(pidPath, 'utf8')
+    const parsed = JSON.parse(raw) as { pid?: unknown }
+    const pid = parsed.pid
+    return Number.isInteger(pid) && pid > 0 ? pid : null
+  } catch {
+    return null
+  }
+}
+
+function forceKillDaemon(pid: number): void {
+  if (process.platform === 'win32') {
+    execFileSync('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' })
+    return
+  }
+
+  process.kill(pid, 'SIGKILL')
+}
+
+function readPersistedData(userDataDir: string): PersistedData | null {
+  const statePath = path.join(
+    userDataDir,
+    'profiles',
+    DEFAULT_LOCAL_ORCA_PROFILE_ID,
+    'orca-data.json'
+  )
+  if (!existsSync(statePath)) {
+    return null
+  }
+
+  return JSON.parse(readFileSync(statePath, 'utf8')) as PersistedData
+}
+
+function workerArchives(data: PersistedData | null, tabId: string): [string, PersistedArchive][] {
+  return Object.entries(data?.terminalArchivesById ?? {}).filter(
+    ([, archive]) => archive.reason === 'daemon-worker-lost' && archive.sourceTabId === tabId
+  )
+}
+
+function historyContains(userDataDir: string, marker: string): boolean {
+  const historyRoot = path.join(userDataDir, 'terminal-history')
+  if (!existsSync(historyRoot)) {
+    return false
+  }
+
+  const pending = [historyRoot]
+  while (pending.length > 0) {
+    const current = pending.pop()
+    if (!current) {
+      continue
+    }
+
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const entryPath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        pending.push(entryPath)
+      } else if (entry.isFile() && readFileSync(entryPath).includes(marker)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+async function readPaneIdentity(page: Page, tabId: string): Promise<PaneIdentity | null> {
+  return page.evaluate((requestedTabId) => {
+    const pane =
+      window.__paneManagers?.get(requestedTabId)?.getActivePane?.() ??
+      window.__paneManagers?.get(requestedTabId)?.getPanes?.()[0] ??
+      null
+    const leafId = pane?.container.dataset.leafId
+    const ptyId = pane?.container.dataset.ptyId
+    if (!ptyId || !leafId) {
+      return null
+    }
+
+    return {
+      cols: pane.terminal.cols,
+      leafId,
+      ptyId,
+      rows: pane.terminal.rows
+    }
+  }, tabId)
+}
+
+async function getPaneIdentity(page: Page, tabId: string): Promise<PaneIdentity> {
+  let identity: PaneIdentity | null = null
+  await expect
+    .poll(
+      async () => {
+        identity = await readPaneIdentity(page, tabId)
+        return identity
+      },
+      {
+        timeout: 15_000,
+        message: `Pane for tab ${tabId} did not receive a PTY binding`
+      }
+    )
+    .not.toBeNull()
+  if (!identity) {
+    throw new Error(`Pane for tab ${tabId} lost its PTY binding after the readiness check`)
+  }
+  return identity
+}
+
+async function activateTerminalTab(page: Page, tabId: string): Promise<void> {
+  await page.evaluate((requestedTabId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+
+    store.getState().setActiveTab(requestedTabId)
+    store.getState().setActiveTabType('terminal')
+  }, tabId)
+  await expect
+    .poll(() =>
+      page.locator('[data-testid="sortable-tab"][data-active="true"]').getAttribute('data-tab-id')
+    )
+    .toBe(tabId)
+}
+
+async function waitForTerminalOnTab(page: Page, tabId: string): Promise<void> {
+  await activateTerminalTab(page, tabId)
+  await waitForActiveTerminalManager(page, 30_000)
+}
+
+async function waitForArchivedWorkerPaneRetirement(page: Page, tabId: string): Promise<void> {
+  await expect(page.locator(`[data-testid="sortable-tab"][data-tab-id="${tabId}"]`)).toHaveCount(
+    0,
+    { timeout: 30_000 }
+  )
+  // Why: closeTab removes the tab before TerminalPane's unmount cleanup deletes its E2E manager.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          (requestedTabId) => window.__paneManagers?.has(requestedTabId) ?? false,
+          tabId
+        ),
+      {
+        timeout: 5_000,
+        message: `Archived worker tab ${tabId} retained a PaneManager after unmount`
+      }
+    )
+    .toBe(false)
+}
+
+async function createTerminalTab(page: Page, worktreeId: string): Promise<string> {
+  const tabsBefore = await page.locator('[data-testid="sortable-tab"]').count()
+  const tabId = await page.evaluate((requestedWorktreeId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+
+    return store.getState().createTab(requestedWorktreeId).id
+  }, worktreeId)
+
+  await expect
+    .poll(() => page.locator('[data-testid="sortable-tab"]').count(), {
+      timeout: 5_000,
+      message: 'New terminal tab did not render'
+    })
+    .toBe(tabsBefore + 1)
+  await expect(
+    page.locator(`[data-testid="sortable-tab"][data-tab-id="${tabId}"]`)
+  ).toHaveAttribute('data-active', 'true')
+  return tabId
+}
+
+async function reloadAndWaitForStore(page: Page, worktreeId: string): Promise<void> {
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(() => Boolean(window.__store))
+  await expect
+    .poll(() => page.evaluate(() => window.__store.getState().activeWorktreeId))
+    .toBe(worktreeId)
+}
+
+async function listDaemonSessions(userDataDir: string): Promise<ListSessionsResult['sessions']> {
+  const daemonRoot = path.join(userDataDir, 'daemon')
+  const client = new DaemonClient({
+    protocolVersion: PROTOCOL_VERSION,
+    socketPath: getDaemonSocketPath(daemonRoot),
+    tokenPath: getDaemonTokenPath(daemonRoot)
+  })
+
+  try {
+    await client.ensureConnected()
+    return (await client.request<ListSessionsResult>('listSessions', undefined)).sessions
+  } finally {
+    client.disconnect()
+  }
+}
+
+test.describe('daemon crash lost worker archive', () => {
+  test.setTimeout(180_000)
+
+  test('archives a recognized worker without a replacement while cold-restoring one ordinary shell', async (// oxlint-disable-next-line no-empty-pattern -- The restart fixture owns Electron lifecycle instead of the shared fixtures.
+  {}, testInfo) => {
+    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf8').trim()
+    if (!repoPath || !existsSync(repoPath)) {
+      test.skip(true, 'Global setup did not produce a seeded test repo')
+      return
+    }
+
+    const probeRoot = path.join(
+      tmpdir(),
+      `orca-daemon-crash-archive-${testInfo.testId.replaceAll(/[^a-zA-Z0-9]/g, '-')}`
+    )
+    const { logPath, probePath } = writeDaemonRpcProbe(probeRoot)
+    const restartSession = createRestartSession(testInfo, {
+      NODE_OPTIONS: `--require=${probePath}`,
+      ORCA_E2E_DAEMON_CREATE_LOG: logPath
+    })
+
+    let firstApp: ElectronApplication | null = null
+    let restartedApp: ElectronApplication | null = null
+
+    try {
+      const firstLaunch = await restartSession.launch()
+      firstApp = firstLaunch.app
+      const page = firstLaunch.page
+      const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
+      await expect
+        .poll(() => page.evaluate(() => window.__store?.getState().hydrationSucceeded === true), {
+          timeout: 30_000,
+          message: 'Workspace hydration did not complete before recording the worker hint'
+        })
+        .toBe(true)
+
+      const workerTabId = await createTerminalTab(page, worktreeId)
+      await waitForTerminalOnTab(page, workerTabId)
+      const workerPane = await getPaneIdentity(page, workerTabId)
+      const workerMarker = `WORKER-ARCHIVE-${testInfo.retry}-${Date.now()}`
+      await page.evaluate(
+        ({ marker, ptyId }) => window.api.pty.write(ptyId, `printf '${marker}\\n'\\n`),
+        { marker: workerMarker, ptyId: workerPane.ptyId }
+      )
+      await waitForTerminalOutput(page, workerMarker)
+
+      const hookEndpoint = await readHookEndpoint(firstApp)
+      const workerHookDescriptor = await waitForActivePaneHookDescriptor(page)
+      await emitCodexHookStatus(hookEndpoint, {
+        paneKey: workerHookDescriptor.paneKey,
+        prompt: 'daemon crash archive e2e worker marker',
+        state: 'working',
+        worktreeId
+      })
+      let workerHintBeforeCrash: string | undefined
+      await expect
+        .poll(() => {
+          const hint = readPersistedData(restartSession.userDataDir)?.workspaceSession
+            ?.terminalArchiveHintsByPaneKey?.[workerHookDescriptor.paneKey]
+          workerHintBeforeCrash = hint?.launchAgent
+          return workerHintBeforeCrash
+        })
+        .toBe('codex')
+
+      await reloadAndWaitForStore(page, worktreeId)
+      await waitForTerminalOnTab(page, workerTabId)
+      await waitForTerminalOutput(page, workerMarker)
+      expect(
+        readPersistedData(restartSession.userDataDir)?.workspaceSession
+          ?.terminalArchiveHintsByPaneKey?.[workerHookDescriptor.paneKey]?.launchAgent
+      ).toBe('codex')
+
+      const ordinaryTabId = await createTerminalTab(page, worktreeId)
+      await waitForTerminalOnTab(page, ordinaryTabId)
+      const ordinaryPane = await getPaneIdentity(page, ordinaryTabId)
+      const ordinaryMarker = `ORDINARY-COLD-RESTORE-${testInfo.retry}-${Date.now()}`
+      await page.evaluate(
+        ({ marker, ptyId }) => window.api.pty.write(ptyId, `printf '${marker}\\n'\\n`),
+        { marker: ordinaryMarker, ptyId: ordinaryPane.ptyId }
+      )
+      await waitForTerminalOutput(page, ordinaryMarker)
+
+      await expect
+        .poll(() => workerArchives(readPersistedData(restartSession.userDataDir), workerTabId))
+        .toHaveLength(0)
+      await expect
+        .poll(() => historyContains(restartSession.userDataDir, workerMarker), { timeout: 20_000 })
+        .toBe(true)
+      await expect
+        .poll(() => historyContains(restartSession.userDataDir, ordinaryMarker), {
+          timeout: 20_000
+        })
+        .toBe(true)
+
+      // Start the count at the crash boundary; the ordinary restore proves this probe saw real daemon RPC.
+      writeFileSync(logPath, '')
+      await expect.poll(() => readDaemonPid(restartSession.userDataDir)).not.toBeNull()
+      const daemonPid = readDaemonPid(restartSession.userDataDir)
+      if (daemonPid === null) {
+        throw new Error('Daemon PID disappeared before the crash injection')
+      }
+      forceKillDaemon(daemonPid)
+
+      // [PROBE] 分叉实验：hint 是被 daemon crash 弄丢的，还是被 reload 后渲染进程回写抹掉的
+      const readHintNow = (): string | null =>
+        readPersistedData(restartSession.userDataDir)?.workspaceSession
+          ?.terminalArchiveHintsByPaneKey?.[workerHookDescriptor.paneKey]?.launchAgent ?? null
+      const hintImmediatelyAfterCrash = readHintNow()
+      await page.waitForTimeout(1500)
+      const hintBeforeReload = readHintNow()
+
+      await reloadAndWaitForStore(page, worktreeId)
+      const hintAfterReload = readHintNow()
+      console.log(
+        `[PROBE] afterCrash=${JSON.stringify(hintImmediatelyAfterCrash)} beforeReload=${JSON.stringify(hintBeforeReload)} afterReload=${JSON.stringify(hintAfterReload)}`
+      )
+      await waitForTerminalOnTab(page, ordinaryTabId)
+      await waitForTerminalOutput(page, ordinaryMarker)
+      await expect(
+        page.locator(`[data-testid="sortable-tab"][data-tab-id="${ordinaryTabId}"]`)
+      ).toHaveCount(1)
+      await expect.poll(() => readDaemonPid(restartSession.userDataDir)).not.toBe(daemonPid)
+      const postCrashDurableState = () => {
+        const persisted = readPersistedData(restartSession.userDataDir)
+        return JSON.stringify({
+          ordinaryHistoryPresent: historyContains(restartSession.userDataDir, ordinaryMarker),
+          workerArchiveIds: workerArchives(persisted, workerTabId).map(([archiveId]) => archiveId),
+          workerHintBeforeCrash,
+          workerHint:
+            persisted?.workspaceSession?.terminalArchiveHintsByPaneKey?.[
+              workerHookDescriptor.paneKey
+            ]?.launchAgent ?? null
+        })
+      }
+      await expect
+        .poll(postCrashDurableState, {
+          timeout: 30_000,
+          message: 'Durable-state probe missed the ordinary shell history positive control'
+        })
+        .toContain('"ordinaryHistoryPresent":true')
+      await expect
+        .poll(postCrashDurableState, {
+          timeout: 30_000,
+          message: 'Recognized worker did not produce a durable daemon-worker-lost archive'
+        })
+        .toMatch(/"workerArchiveIds":\[".+"\]/)
+      await expect
+        .poll(() => workerArchives(readPersistedData(restartSession.userDataDir), workerTabId))
+        .toHaveLength(1)
+      const archiveIdAfterCrash = workerArchives(
+        readPersistedData(restartSession.userDataDir),
+        workerTabId
+      )[0]?.[0]
+      expect(archiveIdAfterCrash).toBeTruthy()
+      await waitForArchivedWorkerPaneRetirement(page, workerTabId)
+      await expect
+        .poll(
+          () =>
+            readPersistedData(restartSession.userDataDir)?.workspaceSession
+              ?.terminalArchiveHintsByPaneKey?.[workerHookDescriptor.paneKey]
+        )
+        .toBeUndefined()
+
+      const sessionsAfterArchive = await listDaemonSessions(restartSession.userDataDir)
+      expect(
+        sessionsAfterArchive.filter((session) => session.sessionId === workerPane.ptyId)
+      ).toHaveLength(0)
+      const ordinarySessions = sessionsAfterArchive.filter(
+        (session) => session.sessionId === ordinaryPane.ptyId
+      )
+      expect(ordinarySessions).toHaveLength(1)
+      expect(ordinarySessions[0]?.pid).toBeGreaterThan(0)
+
+      await reloadAndWaitForStore(page, worktreeId)
+      await waitForTerminalOnTab(page, ordinaryTabId)
+      await waitForTerminalOutput(page, ordinaryMarker)
+      await expect(
+        page.locator(`[data-testid="sortable-tab"][data-tab-id="${workerTabId}"]`)
+      ).toHaveCount(0)
+      await expect(page.locator('[data-testid="sortable-tab"][data-active="true"]')).toHaveCount(1)
+      expect(await getTerminalContent(page)).toContain(ordinaryMarker)
+
+      const archivesBeforeRestart = workerArchives(
+        readPersistedData(restartSession.userDataDir),
+        workerTabId
+      )
+      expect(archivesBeforeRestart).toHaveLength(1)
+      expect(archivesBeforeRestart[0]?.[0]).toBe(archiveIdAfterCrash)
+
+      await restartSession.close(firstApp)
+      firstApp = null
+      const restartLaunch = await restartSession.launch()
+      restartedApp = restartLaunch.app
+      const restartedPage = restartLaunch.page
+      await expect
+        .poll(() => restartedPage.evaluate(() => window.__store.getState().activeWorktreeId))
+        .toBe(worktreeId)
+      await waitForTerminalOnTab(restartedPage, ordinaryTabId)
+      await waitForTerminalOutput(restartedPage, ordinaryMarker)
+
+      await expect(
+        restartedPage.locator(`[data-testid="sortable-tab"][data-tab-id="${workerTabId}"]`)
+      ).toHaveCount(0)
+      expect(workerArchives(readPersistedData(restartSession.userDataDir), workerTabId)).toEqual(
+        archivesBeforeRestart
+      )
+      expect(await getTerminalContent(restartedPage)).toContain(ordinaryMarker)
+    } finally {
+      if (restartedApp) {
+        await restartSession.close(restartedApp)
+      }
+      if (firstApp) {
+        await restartSession.close(firstApp)
+      }
+      await restartSession.dispose()
+      rmSync(probeRoot, { force: true, recursive: true })
+    }
+  })
+})

--- a/tests/e2e/daemon-crash-lost-worker-archive.spec.ts
+++ b/tests/e2e/daemon-crash-lost-worker-archive.spec.ts
@@ -92,25 +92,31 @@ async function installCreateOrAttachTrace(app: ElectronApplication): Promise<voi
     const trace: TraceEntry[] = []
     scope.__orcaCreateOrAttachTrace = trace
 
-    // Why via `process.mainModule`: Playwright evaluates this function in a
-    // scope that has no module-level `require`, and a dynamic `import()` would
-    // be rewritten by the test transform. The main entry is CommonJS, so its
-    // module object still carries a working `require`.
-    const mainModule = (
-      process as typeof process & {
-        mainModule?: { require?: (id: string) => unknown }
-      }
-    ).mainModule
-    if (typeof mainModule?.require !== 'function') {
+    // Why not a plain `require`: Playwright evaluates this function in a scope
+    // with no module-level `require`, and a dynamic `import()` would be
+    // rewritten by the test transform. `process.getBuiltinModule` is the
+    // supported way to reach a builtin from such a scope and, unlike
+    // `process.mainModule` (deprecated, and gone the moment main becomes ESM),
+    // it does not bind this probe to the main entry staying CommonJS.
+    type NetModule = {
+      Socket: { prototype: { write: (this: unknown, ...args: unknown[]) => boolean } }
+    }
+    const runtime = process as typeof process & {
+      getBuiltinModule?: (id: string) => unknown
+      mainModule?: { require?: (id: string) => unknown }
+    }
+    const netModule =
+      typeof runtime.getBuiltinModule === 'function'
+        ? (runtime.getBuiltinModule('node:net') as NetModule)
+        : typeof runtime.mainModule?.require === 'function'
+          ? (runtime.mainModule.require('node:net') as NetModule)
+          : null
+    if (!netModule) {
       throw new Error(
-        `createOrAttach trace cannot reach node:net (process.mainModule=${typeof mainModule})`
+        `createOrAttach trace cannot reach node:net (getBuiltinModule=${typeof runtime.getBuiltinModule}, mainModule=${typeof runtime.mainModule})`
       )
     }
-    const socketPrototype = (
-      mainModule.require('node:net') as {
-        Socket: { prototype: { write: (this: unknown, ...args: unknown[]) => boolean } }
-      }
-    ).Socket.prototype
+    const socketPrototype = netModule.Socket.prototype
     const originalWrite = socketPrototype.write
     socketPrototype.write = function writeWithCreateOrAttachTrace(
       this: unknown,
@@ -698,13 +704,30 @@ test.describe('daemon crash lost worker archive', () => {
         )
         .toBe('codex')
 
+      // Why an ordinary shell here too: the brief requires the zero-replacement
+      // assertion to carry a same-run positive control from an ordinary shell
+      // (B3c-e2e-daemon-crash-brief.md:53). The worker's own attach-only count
+      // cannot serve as that control — a spawn that reaches the dying daemon is
+      // retried after the respawn, so it is not an exact quantity.
+      const ordinaryTabId = await createTerminalTab(page, worktreeId)
+      await waitForTerminalOnTab(page, ordinaryTabId)
+      const ordinaryPane = await getPaneIdentity(page, ordinaryTabId)
+      const ordinaryMarker = `RACE-ORDINARY-${testInfo.retry}-${Date.now()}`
+      await page.evaluate(
+        ({ marker, ptyId }) => window.api.pty.write(ptyId, `printf '${marker}\\n'\\n`),
+        { marker: ordinaryMarker, ptyId: ordinaryPane.ptyId }
+      )
+      await waitForTerminalOutput(page, ordinaryMarker)
+
       // Why wait for durable history: the recovery path can only archive what it
       // can capture, and the cold-restore payload is rebuilt from the on-disk
       // terminal history. Killing the daemon before the flush lands turns this
       // scenario into a `capture-unavailable` receipt that proves nothing.
-      await expect
-        .poll(() => historyContains(restartSession.userDataDir, workerMarker), { timeout: 20_000 })
-        .toBe(true)
+      for (const marker of [workerMarker, ordinaryMarker]) {
+        await expect
+          .poll(() => historyContains(restartSession.userDataDir, marker), { timeout: 20_000 })
+          .toBe(true)
+      }
 
       // Start the count at the crash boundary so pre-crash mounts can't be
       // mistaken for a recovery-time replacement request.
@@ -720,6 +743,28 @@ test.describe('daemon crash lost worker archive', () => {
       // calls land inside the same recovery window. The dead daemon is respawned
       // lazily by the first call that hits it (daemon-pty-adapter.ts:1442), which
       // is exactly the contention this scenario is about.
+      //
+      // What this does and does not lock, stated plainly: both calls name the
+      // same pane, so they merge at the pane-level reservation
+      // (`paneSpawnReservationsByPaneKey`, pty.ts:5068) — one layer above the
+      // archive-level `lostWorkerArchiveInFlight` map (pty.ts:2014). So this
+      // proves "concurrent callers yield exactly one archive and no
+      // replacement", NOT that the archive map itself dedupes.
+      //
+      // Two panes of one tab would give two admissions sharing a tab-level
+      // `operationKey`, but that construction cannot finish an archive on *this*
+      // path: under normal local persistence the non-calling leaf has no
+      // snapshot source — local layouts have `buffersByLeafId` and
+      // `scrollbackRefsByLeafId` pruned on persist
+      // (workspace-session-terminal-buffers.ts:79-125), only the calling leaf
+      // may use cold-restore data (pty.ts:2044-2055), and a single `unavailable`
+      // leaf fails the whole capture (terminal-archive-store.ts:124-128). That
+      // is a product gap tracked separately, and it is a statement about this
+      // daemon pre-spawn path, not proof that the map is unreachable in general:
+      // the renderer candidate handler (pty.ts:1838-1980) can supply
+      // `snapshotsByLeafId` and reach the same map. Locking that belongs in a
+      // main-IPC integration test, not here — left uncovered deliberately rather
+      // than papered over.
       const raceReceipts = (await page.evaluate(
         async ({ cwd, pane, tabId, requestedWorktreeId }) =>
           Promise.all(
@@ -737,6 +782,29 @@ test.describe('daemon crash lost worker archive', () => {
           ),
         { cwd: repoPath, pane: workerPane, requestedWorktreeId: worktreeId, tabId: workerTabId }
       )) as LostWorkerSpawnReceipt[]
+
+      // Why the ordinary shell restores after the worker race rather than inside
+      // it: it is the same-run positive control for the probe, not part of the
+      // contention under test, and keeping it out of that batch leaves the two
+      // worker admissions competing only with each other.
+      await page.evaluate(
+        ({ cwd, ordinary, ordinaryTab, requestedWorktreeId }) =>
+          window.api.pty.spawn({
+            cols: ordinary.cols,
+            cwd,
+            leafId: ordinary.leafId,
+            rows: ordinary.rows,
+            sessionId: ordinary.ptyId,
+            tabId: ordinaryTab,
+            worktreeId: requestedWorktreeId
+          }),
+        {
+          cwd: repoPath,
+          ordinary: ordinaryPane,
+          ordinaryTab: ordinaryTabId,
+          requestedWorktreeId: worktreeId
+        }
+      )
 
       // Why project the receipts instead of asserting `.kind` twice: a failure
       // then reports the recovery `code` that explains it instead of a bare
@@ -758,12 +826,37 @@ test.describe('daemon crash lost worker archive', () => {
           message: 'Concurrent lost-worker spawns did not settle on exactly one durable archive'
         })
         .toHaveLength(1)
+      // Why bind the receipts to the durable row: two receipts agreeing on an ID
+      // does not prove that ID is the archive that landed. Without this, both
+      // callers could share one wrong ID while the real archive persisted under
+      // another and the count-of-one above would still pass. (Cross-restart
+      // stability of an archive ID is covered by the first test.)
+      const durableRaceArchives = workerArchives(
+        readPersistedData(restartSession.userDataDir),
+        workerTabId
+      )
+      expect(durableRaceArchives[0]?.[0]).toBe(raceOutcomes[0]?.archiveId)
 
-      // Positive control for this run's probe: the recovery path must have sent
-      // at least one attach-only request, otherwise the zero below proves nothing.
-      // Why not an exact count: a spawn that reaches the daemon while it is dying
-      // is retried once after the respawn (daemon-pty-adapter.ts:1442), so one or
-      // two attach-only requests are both correct here.
+      // Same-run positive controls before the zero: the ordinary shell must show
+      // exactly one cold restore, and the recovery path at least one attach-only
+      // request. Without them a zero over an unwired probe is vacuously true.
+      // Why the worker count is not exact: a spawn that reaches the daemon while
+      // it is dying is retried once after the respawn
+      // (daemon-pty-adapter.ts:1442), so one or two are both correct.
+      await expect
+        .poll(
+          async () =>
+            countCreateOrAttach(
+              await readCreateOrAttachTrace(tracedApp),
+              (entry) =>
+                entry.sessionId === ordinaryPane.ptyId && !entry.attachOnly && entry.hasHistorySeed
+            ),
+          {
+            timeout: 20_000,
+            message: 'Main-side probe never observed the ordinary shell cold restore'
+          }
+        )
+        .toBe(1)
       await expect
         .poll(
           async () =>

--- a/tests/e2e/daemon-crash-lost-worker-archive.spec.ts
+++ b/tests/e2e/daemon-crash-lost-worker-archive.spec.ts
@@ -1,6 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import path from 'node:path'
 
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
@@ -31,6 +30,21 @@ type PaneIdentity = {
   rows: number
 }
 
+type DaemonCreateTrace = {
+  attachOnly: boolean
+  hasHistorySeed: boolean
+  pid: number
+  sessionId: string
+}
+
+type LostWorkerSpawnReceipt = {
+  lostWorkerRecovery?: {
+    archiveId?: string
+    code?: string
+    kind: 'archived' | 'retryable-error'
+  }
+}
+
 type PersistedArchive = {
   reason?: string
   sourceTabId?: string
@@ -43,56 +57,136 @@ type PersistedData = {
   }
 }
 
-function writeDaemonRpcProbe(root: string): {
-  logPath: string
-  probePath: string
-} {
-  mkdirSync(root, { recursive: true })
-  const logPath = path.join(root, 'daemon-create-or-attach.ndjson')
-  const probePath = path.join(root, 'daemon-rpc-probe.cjs')
+/**
+ * Record every `createOrAttach` request from the process that *sends* it.
+ *
+ * Why installed through `app.evaluate` instead of a `--require` preload:
+ * Playwright deletes `NODE_OPTIONS` before it launches Electron
+ * (`playwright-core/lib/server/electron/electron.js:169`, right before
+ * `launchProcess`), so an env-injected probe never loads in any process —
+ * neither the daemon nor main. Playwright's own main-process channel is the
+ * only injection vector that survives that deletion.
+ *
+ * Why the Electron main process is the right place to watch: this test
+ * force-kills the daemon, so a probe living inside it dies with the incarnation
+ * whose recovery it exists to observe. Main survives every renderer reload and
+ * the daemon respawn, and it is the sole sender of `createOrAttach` —
+ * `DaemonClient.request()` writes the NDJSON request onto its outbound control
+ * socket (`src/main/daemon/client.ts:238`), so the trace spans both daemon
+ * incarnations.
+ */
+async function installCreateOrAttachTrace(app: ElectronApplication): Promise<void> {
+  await app.evaluate(() => {
+    type TraceEntry = {
+      attachOnly: boolean
+      hasHistorySeed: boolean
+      pid: number
+      sessionId: string
+    }
+    const scope = globalThis as typeof globalThis & {
+      __orcaCreateOrAttachTrace?: TraceEntry[]
+    }
+    if (scope.__orcaCreateOrAttachTrace) {
+      return
+    }
+    const trace: TraceEntry[] = []
+    scope.__orcaCreateOrAttachTrace = trace
 
-  writeFileSync(
-    probePath,
-    `const { appendFileSync } = require('node:fs')
-const net = require('node:net')
-
-const logPath = process.env.ORCA_E2E_DAEMON_CREATE_LOG
-if (logPath && process.argv.some((argument) => String(argument).includes('daemon-entry'))) {
-  const bufferedBySocket = new WeakMap()
-  const originalEmit = net.Socket.prototype.emit
-
-  net.Socket.prototype.emit = function emitWithCreateOrAttachTrace(event, ...arguments) {
-    if (event === 'data') {
-      const previous = bufferedBySocket.get(this) || ''
-      const next = previous + Buffer.from(arguments[0]).toString('utf8')
-      const lines = next.split('\\n')
-      bufferedBySocket.set(this, lines.pop() || '')
-
-      for (const line of lines) {
-        try {
-          const message = JSON.parse(line)
-          if (message.type === 'createOrAttach') {
-            appendFileSync(logPath, JSON.stringify({
-              attachOnly: message.payload?.attachOnly === true,
-              hasHistorySeed: typeof message.payload?.historySeed === 'string' && message.payload.historySeed.length > 0,
-              pid: process.pid,
-              sessionId: message.payload?.sessionId,
-            }) + '\\n')
+    // Why via `process.mainModule`: Playwright evaluates this function in a
+    // scope that has no module-level `require`, and a dynamic `import()` would
+    // be rewritten by the test transform. The main entry is CommonJS, so its
+    // module object still carries a working `require`.
+    const mainModule = (
+      process as typeof process & {
+        mainModule?: { require?: (id: string) => unknown }
+      }
+    ).mainModule
+    if (typeof mainModule?.require !== 'function') {
+      throw new Error(
+        `createOrAttach trace cannot reach node:net (process.mainModule=${typeof mainModule})`
+      )
+    }
+    const socketPrototype = (
+      mainModule.require('node:net') as {
+        Socket: { prototype: { write: (this: unknown, ...args: unknown[]) => boolean } }
+      }
+    ).Socket.prototype
+    const originalWrite = socketPrototype.write
+    socketPrototype.write = function writeWithCreateOrAttachTrace(
+      this: unknown,
+      ...args: unknown[]
+    ): boolean {
+      const chunk = args[0]
+      if (typeof chunk === 'string' || Buffer.isBuffer(chunk)) {
+        const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+        // Why the substring test first: this hook sees every main-process socket
+        // write (runtime WebSocket, hook endpoint, PTY keystrokes); parsing all
+        // of them as JSON would burn time on writes that can never be a request.
+        if (text.includes('"createOrAttach"')) {
+          // Why splitting is enough: encodeNdjson/encodeBoundedNdjson emit
+          // exactly one complete line per write() call, so no request message
+          // can span two chunks.
+          for (const line of text.split('\n')) {
+            if (!line) {
+              continue
+            }
+            try {
+              const message = JSON.parse(line) as {
+                type?: string
+                payload?: { attachOnly?: boolean; historySeed?: string; sessionId?: string }
+              }
+              if (message.type === 'createOrAttach') {
+                trace.push({
+                  attachOnly: message.payload?.attachOnly === true,
+                  hasHistorySeed:
+                    typeof message.payload?.historySeed === 'string' &&
+                    message.payload.historySeed.length > 0,
+                  pid: process.pid,
+                  sessionId: message.payload?.sessionId ?? ''
+                })
+              }
+            } catch {
+              // Observability must never alter a daemon request when a chunk is not NDJSON.
+            }
           }
-        } catch {
-          // Observability must never alter a daemon request when a chunk is not NDJSON.
         }
       }
-    }
 
-    return originalEmit.call(this, event, ...arguments)
-  }
+      return originalWrite.apply(this, args)
+    }
+  })
 }
 
-`
-  )
-  writeFileSync(logPath, '')
-  return { logPath, probePath }
+async function readCreateOrAttachTrace(app: ElectronApplication): Promise<DaemonCreateTrace[]> {
+  return await app.evaluate(() => {
+    type TraceEntry = {
+      attachOnly: boolean
+      hasHistorySeed: boolean
+      pid: number
+      sessionId: string
+    }
+    const scope = globalThis as typeof globalThis & {
+      __orcaCreateOrAttachTrace?: TraceEntry[]
+    }
+    return scope.__orcaCreateOrAttachTrace ? [...scope.__orcaCreateOrAttachTrace] : []
+  })
+}
+
+/** Restart the count without detaching the hook, which closes over the array. */
+async function resetCreateOrAttachTrace(app: ElectronApplication): Promise<void> {
+  await app.evaluate(() => {
+    const scope = globalThis as typeof globalThis & {
+      __orcaCreateOrAttachTrace?: unknown[]
+    }
+    scope.__orcaCreateOrAttachTrace?.splice(0)
+  })
+}
+
+function countCreateOrAttach(
+  trace: DaemonCreateTrace[],
+  match: (entry: DaemonCreateTrace) => boolean
+): number {
+  return trace.filter(match).length
 }
 
 function readDaemonPid(userDataDir: string): number | null {
@@ -308,22 +402,16 @@ test.describe('daemon crash lost worker archive', () => {
       return
     }
 
-    const probeRoot = path.join(
-      tmpdir(),
-      `orca-daemon-crash-archive-${testInfo.testId.replaceAll(/[^a-zA-Z0-9]/g, '-')}`
-    )
-    const { logPath, probePath } = writeDaemonRpcProbe(probeRoot)
-    const restartSession = createRestartSession(testInfo, {
-      NODE_OPTIONS: `--require=${probePath}`,
-      ORCA_E2E_DAEMON_CREATE_LOG: logPath
-    })
+    const restartSession = createRestartSession(testInfo)
 
     let firstApp: ElectronApplication | null = null
     let restartedApp: ElectronApplication | null = null
 
     try {
       const firstLaunch = await restartSession.launch()
-      firstApp = firstLaunch.app
+      const tracedApp = firstLaunch.app
+      firstApp = tracedApp
+      await installCreateOrAttachTrace(tracedApp)
       const page = firstLaunch.page
       const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
       await expect
@@ -392,7 +480,7 @@ test.describe('daemon crash lost worker archive', () => {
         .toBe(true)
 
       // Start the count at the crash boundary; the ordinary restore proves this probe saw real daemon RPC.
-      writeFileSync(logPath, '')
+      await resetCreateOrAttachTrace(tracedApp)
       await expect.poll(() => readDaemonPid(restartSession.userDataDir)).not.toBeNull()
       const daemonPid = readDaemonPid(restartSession.userDataDir)
       if (daemonPid === null) {
@@ -460,6 +548,43 @@ test.describe('daemon crash lost worker archive', () => {
         )
         .toBeUndefined()
 
+      // Why poll the two positive counts before asserting the zero: a negative
+      // assertion over an unwired probe is vacuously true. Requiring the same
+      // run to show the ordinary shell's cold restore and the worker's
+      // attach-only probe proves this trace records real RPC, so the zero below
+      // means "no replacement was requested" rather than "nothing was watching".
+      await expect
+        .poll(
+          async () => {
+            const trace = await readCreateOrAttachTrace(tracedApp)
+            return {
+              ordinaryColdRestores: countCreateOrAttach(
+                trace,
+                (entry) =>
+                  entry.sessionId === ordinaryPane.ptyId &&
+                  !entry.attachOnly &&
+                  entry.hasHistorySeed
+              ),
+              workerAttachOnlyRequests: countCreateOrAttach(
+                trace,
+                (entry) => entry.sessionId === workerPane.ptyId && entry.attachOnly
+              )
+            }
+          },
+          {
+            timeout: 20_000,
+            message:
+              'Main-side createOrAttach trace never observed the post-crash recovery RPC (ordinary cold restore + worker attach-only)'
+          }
+        )
+        .toEqual({ ordinaryColdRestores: 1, workerAttachOnlyRequests: 1 })
+      expect(
+        countCreateOrAttach(
+          await readCreateOrAttachTrace(tracedApp),
+          (entry) => entry.sessionId === workerPane.ptyId && !entry.attachOnly
+        )
+      ).toBe(0)
+
       const sessionsAfterArchive = await listDaemonSessions(restartSession.userDataDir)
       expect(
         sessionsAfterArchive.filter((session) => session.sessionId === workerPane.ptyId)
@@ -512,7 +637,157 @@ test.describe('daemon crash lost worker archive', () => {
         await restartSession.close(firstApp)
       }
       await restartSession.dispose()
-      rmSync(probeRoot, { force: true, recursive: true })
+    }
+  })
+
+  // Why a separate test instead of another beat in the timeline above: the race
+  // needs the recovery window that exists only *before* the archive lands — the
+  // hint is still on disk and the in-flight dedupe entry has not been deleted
+  // yet. After the first test's reload-driven archive both preconditions are
+  // gone, and moving the concurrent spawn earlier would replace that reload with
+  // a hand-rolled spawn and lose the reload path's coverage.
+  test('collapses concurrent lost-worker spawns into one archive without a replacement', async (// oxlint-disable-next-line no-empty-pattern -- The restart fixture owns Electron lifecycle instead of the shared fixtures.
+  {}, testInfo) => {
+    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf8').trim()
+    if (!repoPath || !existsSync(repoPath)) {
+      test.skip(true, 'Global setup did not produce a seeded test repo')
+      return
+    }
+
+    const restartSession = createRestartSession(testInfo)
+
+    let app: ElectronApplication | null = null
+
+    try {
+      const launched = await restartSession.launch()
+      const tracedApp = launched.app
+      app = tracedApp
+      await installCreateOrAttachTrace(tracedApp)
+      const page = launched.page
+      const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
+      await expect
+        .poll(() => page.evaluate(() => window.__store?.getState().hydrationSucceeded === true), {
+          timeout: 30_000,
+          message: 'Workspace hydration did not complete before recording the worker hint'
+        })
+        .toBe(true)
+
+      const workerTabId = await createTerminalTab(page, worktreeId)
+      await waitForTerminalOnTab(page, workerTabId)
+      const workerPane = await getPaneIdentity(page, workerTabId)
+      const workerMarker = `RACE-WORKER-${testInfo.retry}-${Date.now()}`
+      await page.evaluate(
+        ({ marker, ptyId }) => window.api.pty.write(ptyId, `printf '${marker}\\n'\\n`),
+        { marker: workerMarker, ptyId: workerPane.ptyId }
+      )
+      await waitForTerminalOutput(page, workerMarker)
+
+      const hookEndpoint = await readHookEndpoint(tracedApp)
+      const workerHookDescriptor = await waitForActivePaneHookDescriptor(page)
+      await emitCodexHookStatus(hookEndpoint, {
+        paneKey: workerHookDescriptor.paneKey,
+        prompt: 'daemon crash archive e2e race marker',
+        state: 'working',
+        worktreeId
+      })
+      await expect
+        .poll(
+          () =>
+            readPersistedData(restartSession.userDataDir)?.workspaceSession
+              ?.terminalArchiveHintsByPaneKey?.[workerHookDescriptor.paneKey]?.launchAgent
+        )
+        .toBe('codex')
+
+      // Why wait for durable history: the recovery path can only archive what it
+      // can capture, and the cold-restore payload is rebuilt from the on-disk
+      // terminal history. Killing the daemon before the flush lands turns this
+      // scenario into a `capture-unavailable` receipt that proves nothing.
+      await expect
+        .poll(() => historyContains(restartSession.userDataDir, workerMarker), { timeout: 20_000 })
+        .toBe(true)
+
+      // Start the count at the crash boundary so pre-crash mounts can't be
+      // mistaken for a recovery-time replacement request.
+      await resetCreateOrAttachTrace(tracedApp)
+      await expect.poll(() => readDaemonPid(restartSession.userDataDir)).not.toBeNull()
+      const daemonPid = readDaemonPid(restartSession.userDataDir)
+      if (daemonPid === null) {
+        throw new Error('Daemon PID disappeared before the crash injection')
+      }
+      forceKillDaemon(daemonPid)
+
+      // Why no reload before this: the renderer must stay mounted so both spawn
+      // calls land inside the same recovery window. The dead daemon is respawned
+      // lazily by the first call that hits it (daemon-pty-adapter.ts:1442), which
+      // is exactly the contention this scenario is about.
+      const raceReceipts = (await page.evaluate(
+        async ({ cwd, pane, tabId, requestedWorktreeId }) =>
+          Promise.all(
+            [0, 1].map(() =>
+              window.api.pty.spawn({
+                cols: pane.cols,
+                cwd,
+                leafId: pane.leafId,
+                rows: pane.rows,
+                sessionId: pane.ptyId,
+                tabId,
+                worktreeId: requestedWorktreeId
+              })
+            )
+          ),
+        { cwd: repoPath, pane: workerPane, requestedWorktreeId: worktreeId, tabId: workerTabId }
+      )) as LostWorkerSpawnReceipt[]
+
+      // Why project the receipts instead of asserting `.kind` twice: a failure
+      // then reports the recovery `code` that explains it instead of a bare
+      // "retryable-error".
+      const raceOutcomes = raceReceipts.map((receipt) => ({
+        archiveId: receipt.lostWorkerRecovery?.archiveId ?? null,
+        code: receipt.lostWorkerRecovery?.code ?? null,
+        kind: receipt.lostWorkerRecovery?.kind ?? 'missing'
+      }))
+      expect(raceOutcomes).toEqual([
+        { archiveId: expect.any(String), code: null, kind: 'archived' },
+        { archiveId: expect.any(String), code: null, kind: 'archived' }
+      ])
+      expect(raceOutcomes[1]?.archiveId).toBe(raceOutcomes[0]?.archiveId)
+
+      await expect
+        .poll(() => workerArchives(readPersistedData(restartSession.userDataDir), workerTabId), {
+          timeout: 20_000,
+          message: 'Concurrent lost-worker spawns did not settle on exactly one durable archive'
+        })
+        .toHaveLength(1)
+
+      // Positive control for this run's probe: the recovery path must have sent
+      // at least one attach-only request, otherwise the zero below proves nothing.
+      // Why not an exact count: a spawn that reaches the daemon while it is dying
+      // is retried once after the respawn (daemon-pty-adapter.ts:1442), so one or
+      // two attach-only requests are both correct here.
+      await expect
+        .poll(
+          async () =>
+            countCreateOrAttach(
+              await readCreateOrAttachTrace(tracedApp),
+              (entry) => entry.sessionId === workerPane.ptyId && entry.attachOnly
+            ),
+          {
+            timeout: 20_000,
+            message: 'Main-side probe never observed the attach-only recovery request'
+          }
+        )
+        .toBeGreaterThan(0)
+      expect(
+        countCreateOrAttach(
+          await readCreateOrAttachTrace(tracedApp),
+          (entry) => entry.sessionId === workerPane.ptyId && !entry.attachOnly
+        )
+      ).toBe(0)
+    } finally {
+      if (app) {
+        await restartSession.close(app)
+      }
+      await restartSession.dispose()
     }
   })
 })

--- a/tests/e2e/helpers/docker-ssh-relay-bundle-patch.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-bundle-patch.ts
@@ -1,0 +1,127 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import {
+  execDockerSshRelayTargetCommand,
+  shellQuote,
+  type DockerSshRelayTarget
+} from './docker-ssh-relay-target'
+
+export type DockerRelayReviveMode = 'typed-lost' | 'legacy' | 'malformed'
+
+export type DockerRelayProbe = {
+  capabilityPath: string
+  loadedPath: string
+  revivePath: string
+  spawnPath: string
+}
+
+const RELAY_CAPABILITIES_NEEDLE =
+  'this.dispatcher.onRequest("pty.getCapabilities",async()=>({startupIngressVersion:es,agentSessionClaimVersion:np,agentSessionCreateOperationVersion:ip,ptyPersistenceEnvelopeVersion:2,ptyReviveOutcomeVersion:Ji}))'
+const RELAY_REVIVE_NEEDLE = 'this.dispatcher.onRequest("pty.revive",e=>this.revive(e))'
+const RELAY_SPAWN_NEEDLE = 'this.dispatcher.onRequest("pty.spawn",(e,r)=>this.spawn(e,r))'
+const INSTRUMENTATION_MARKER = '__orcaE2eRelayMixedVersionMarker'
+
+export function createDockerRelayProbe(testId: string): DockerRelayProbe {
+  const root = `/tmp/orca-e2e-relay-${testId}-${Date.now()}`
+  return {
+    capabilityPath: `${root}-capability`,
+    loadedPath: `${root}-loaded`,
+    revivePath: `${root}-revive`,
+    spawnPath: `${root}-spawn`
+  }
+}
+
+export function patchDockerRelayBundle(
+  mode: DockerRelayReviveMode,
+  probe: DockerRelayProbe
+): () => void {
+  const originals = ['linux-x64', 'linux-arm64'].map((platform) => {
+    const relayPath = path.join(process.cwd(), 'out', 'relay', platform, 'relay.js')
+    return { relayPath, source: readFileSync(relayPath, 'utf8') }
+  })
+  for (const { relayPath, source } of originals) {
+    writeFileSync(relayPath, patchDockerRelaySource(source, mode, probe))
+  }
+  return () => {
+    for (const { relayPath, source } of originals) {
+      writeFileSync(relayPath, source)
+    }
+  }
+}
+
+export function readDockerRelayProbe(target: DockerSshRelayTarget, filePath: string): string[] {
+  const output = execDockerSshRelayTargetCommand(
+    target,
+    `test -f ${shellQuote(filePath)} && cat ${shellQuote(filePath)} || true`
+  )
+  return output.split('\n').filter(Boolean)
+}
+
+export function clearDockerRelayProbe(target: DockerSshRelayTarget, probe: DockerRelayProbe): void {
+  execDockerSshRelayTargetCommand(
+    target,
+    `rm -f ${[probe.capabilityPath, probe.revivePath, probe.spawnPath].map(shellQuote).join(' ')}`
+  )
+}
+
+function relayInstrumentation(probe: DockerRelayProbe): string {
+  return [
+    `const ${INSTRUMENTATION_MARKER}=true`,
+    'const __orcaE2eFs=require("node:fs")',
+    `const __orcaE2eCapabilityPath=${JSON.stringify(probe.capabilityPath)}`,
+    `const __orcaE2eLoadedPath=${JSON.stringify(probe.loadedPath)}`,
+    `const __orcaE2eRevivePath=${JSON.stringify(probe.revivePath)}`,
+    `const __orcaE2eSpawnPath=${JSON.stringify(probe.spawnPath)}`,
+    '__orcaE2eFs.appendFileSync(__orcaE2eLoadedPath,"loaded\\n")',
+    'const __orcaE2eRecord=kind=>__orcaE2eFs.appendFileSync(kind.startsWith("capability")?__orcaE2eCapabilityPath:kind.startsWith("revive")?__orcaE2eRevivePath:__orcaE2eSpawnPath,kind+"\\n")',
+    'const __orcaE2eLost=state=>{const entries=JSON.parse(state).entries||[];return{outcomeVersion:1,revived:[],lost:entries.map(entry=>{const lost={id:entry.id,kind:"recognized-worker",reason:"worker-replacement-forbidden",pid:entry.pid,cols:entry.cols,rows:entry.rows,cwd:entry.cwd};for(const key of["sourceIncarnationId","paneKey","tabId","attachIdentity","worktreeId","terminalHandle","replayTail","durableLaunch","agentOwners","providerSession","orchestrationTaskId"]){if(entry[key]!==undefined)lost[key]=entry[key]}return lost}),diagnostics:[]}}'
+  ].join(';')
+}
+
+function patchDockerRelaySource(
+  original: string,
+  mode: DockerRelayReviveMode,
+  probe: DockerRelayProbe
+): string {
+  if (original.includes(INSTRUMENTATION_MARKER)) {
+    throw new Error('Docker relay bundle already has an E2E mixed-version patch')
+  }
+  const replacements: [string, string][] = [
+    [
+      RELAY_SPAWN_NEEDLE,
+      'this.dispatcher.onRequest("pty.spawn",(e,r)=>(__orcaE2eRecord("spawn"),this.spawn(e,r)))'
+    ],
+    [RELAY_REVIVE_NEEDLE, reviveHandler(mode)],
+    [RELAY_CAPABILITIES_NEEDLE, capabilityHandler(mode)]
+  ]
+  let patched = original
+  for (const [needle, replacement] of replacements) {
+    if (!patched.includes(needle)) {
+      throw new Error(`Docker relay bundle is missing E2E seam: ${needle.slice(0, 64)}`)
+    }
+    patched = patched.replace(needle, replacement)
+  }
+  const newline = patched.indexOf('\n')
+  if (!patched.startsWith('#!') || newline === -1) {
+    throw new Error('Docker relay bundle lost its executable shebang')
+  }
+  return `${patched.slice(0, newline + 1)}${relayInstrumentation(probe)};\n${patched.slice(newline + 1)}`
+}
+
+function capabilityHandler(mode: DockerRelayReviveMode): string {
+  if (mode === 'legacy') {
+    return 'this.dispatcher.onRequest("pty.getCapabilities",async()=>{__orcaE2eRecord("capability:legacy");return{startupIngressVersion:es,agentSessionClaimVersion:np,agentSessionCreateOperationVersion:ip}})'
+  }
+  return 'this.dispatcher.onRequest("pty.getCapabilities",async()=>{__orcaE2eRecord("capability:typed");return{startupIngressVersion:es,agentSessionClaimVersion:np,agentSessionCreateOperationVersion:ip,ptyPersistenceEnvelopeVersion:2,ptyReviveOutcomeVersion:Ji}})'
+}
+
+function reviveHandler(mode: DockerRelayReviveMode): string {
+  if (mode === 'typed-lost') {
+    return 'this.dispatcher.onRequest("pty.revive",e=>{__orcaE2eRecord(`revive:${e.formatVersion===2?"typed":"legacy"}`);return e.formatVersion===2?__orcaE2eLost(e.state):this.revive(e)})'
+  }
+  if (mode === 'malformed') {
+    return 'this.dispatcher.onRequest("pty.revive",e=>{__orcaE2eRecord(`revive:${e.formatVersion===2?"typed":"legacy"}`);return e.formatVersion===2?{outcomeVersion:1,revived:"invalid",lost:[],diagnostics:[]}:this.revive(e)})'
+  }
+  return 'this.dispatcher.onRequest("pty.revive",e=>{__orcaE2eRecord(`revive:${e.formatVersion===2?"typed":"legacy"}`);return this.revive(e)})'
+}

--- a/tests/e2e/helpers/docker-ssh-relay-bundle-patch.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-bundle-patch.ts
@@ -12,6 +12,7 @@ export type DockerRelayReviveMode = 'typed-lost' | 'typed-mixed' | 'legacy' | 'm
 export type DockerRelayProbe = {
   capabilityPath: string
   loadedPath: string
+  ptyPidPath: string
   revivePath: string
   spawnPath: string
 }
@@ -27,6 +28,7 @@ export function createDockerRelayProbe(testId: string): DockerRelayProbe {
   return {
     capabilityPath: `${root}-capability`,
     loadedPath: `${root}-loaded`,
+    ptyPidPath: `${root}-pty-pids`,
     revivePath: `${root}-revive`,
     spawnPath: `${root}-spawn`
   }
@@ -61,7 +63,7 @@ export function readDockerRelayProbe(target: DockerSshRelayTarget, filePath: str
 export function clearDockerRelayProbe(target: DockerSshRelayTarget, probe: DockerRelayProbe): void {
   execDockerSshRelayTargetCommand(
     target,
-    `rm -f ${[probe.capabilityPath, probe.revivePath, probe.spawnPath].map(shellQuote).join(' ')}`
+    `rm -f ${[probe.capabilityPath, probe.ptyPidPath, probe.revivePath, probe.spawnPath].map(shellQuote).join(' ')}`
   )
 }
 
@@ -71,11 +73,13 @@ function relayInstrumentation(probe: DockerRelayProbe): string {
     'const __orcaE2eFs=require("node:fs")',
     `const __orcaE2eCapabilityPath=${JSON.stringify(probe.capabilityPath)}`,
     `const __orcaE2eLoadedPath=${JSON.stringify(probe.loadedPath)}`,
+    `const __orcaE2ePtyPidPath=${JSON.stringify(probe.ptyPidPath)}`,
     `const __orcaE2eRevivePath=${JSON.stringify(probe.revivePath)}`,
     `const __orcaE2eSpawnPath=${JSON.stringify(probe.spawnPath)}`,
     '__orcaE2eFs.appendFileSync(__orcaE2eLoadedPath,"loaded\\n")',
     'const __orcaE2eRecord=kind=>__orcaE2eFs.appendFileSync(kind.startsWith("capability")?__orcaE2eCapabilityPath:kind.startsWith("revive")?__orcaE2eRevivePath:__orcaE2eSpawnPath,kind+"\\n")',
-    'const __orcaE2eLost=state=>{const entries=JSON.parse(state).entries||[];return{outcomeVersion:1,revived:[],lost:entries.map(entry=>{const lost={id:entry.id,kind:"recognized-worker",reason:"worker-replacement-forbidden",pid:entry.pid,cols:entry.cols,rows:entry.rows,cwd:entry.cwd};for(const key of["sourceIncarnationId","paneKey","tabId","attachIdentity","worktreeId","terminalHandle","replayTail","durableLaunch","agentOwners","providerSession","orchestrationTaskId"]){if(entry[key]!==undefined)lost[key]=entry[key]}return lost}),diagnostics:[]}}',
+    'const __orcaE2eRecordPtyPids=entries=>{for(const entry of entries){if(Number.isInteger(entry.pid)&&entry.pid>0)__orcaE2eFs.appendFileSync(__orcaE2ePtyPidPath,String(entry.pid)+"\\n")}}',
+    'const __orcaE2eLost=state=>{const entries=JSON.parse(state).entries||[];__orcaE2eRecordPtyPids(entries);return{outcomeVersion:1,revived:[],lost:entries.map(entry=>{const lost={id:entry.id,kind:"recognized-worker",reason:"worker-replacement-forbidden",pid:entry.pid,cols:entry.cols,rows:entry.rows,cwd:entry.cwd};for(const key of["sourceIncarnationId","paneKey","tabId","attachIdentity","worktreeId","terminalHandle","replayTail","durableLaunch","agentOwners","providerSession","orchestrationTaskId"]){if(entry[key]!==undefined)lost[key]=entry[key]}return lost}),diagnostics:[]}}',
     'const __orcaE2eMixed=state=>{const entries=JSON.parse(state).entries||[];const lost=__orcaE2eLost(state).lost;return{outcomeVersion:1,lost:lost.slice(0,1),revived:entries.slice(1).map(entry=>{const revived={id:entry.id,disposition:"replacement-spawned",incarnationId:`e2e-replacement-${entry.id}`};for(const key of["paneKey","tabId"]){if(entry[key]!==undefined)revived[key]=entry[key]}return revived}),diagnostics:[]}}'
   ].join(';')
 }

--- a/tests/e2e/helpers/docker-ssh-relay-bundle-patch.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-bundle-patch.ts
@@ -7,7 +7,7 @@ import {
   type DockerSshRelayTarget
 } from './docker-ssh-relay-target'
 
-export type DockerRelayReviveMode = 'typed-lost' | 'legacy' | 'malformed'
+export type DockerRelayReviveMode = 'typed-lost' | 'typed-mixed' | 'legacy' | 'malformed'
 
 export type DockerRelayProbe = {
   capabilityPath: string
@@ -75,7 +75,8 @@ function relayInstrumentation(probe: DockerRelayProbe): string {
     `const __orcaE2eSpawnPath=${JSON.stringify(probe.spawnPath)}`,
     '__orcaE2eFs.appendFileSync(__orcaE2eLoadedPath,"loaded\\n")',
     'const __orcaE2eRecord=kind=>__orcaE2eFs.appendFileSync(kind.startsWith("capability")?__orcaE2eCapabilityPath:kind.startsWith("revive")?__orcaE2eRevivePath:__orcaE2eSpawnPath,kind+"\\n")',
-    'const __orcaE2eLost=state=>{const entries=JSON.parse(state).entries||[];return{outcomeVersion:1,revived:[],lost:entries.map(entry=>{const lost={id:entry.id,kind:"recognized-worker",reason:"worker-replacement-forbidden",pid:entry.pid,cols:entry.cols,rows:entry.rows,cwd:entry.cwd};for(const key of["sourceIncarnationId","paneKey","tabId","attachIdentity","worktreeId","terminalHandle","replayTail","durableLaunch","agentOwners","providerSession","orchestrationTaskId"]){if(entry[key]!==undefined)lost[key]=entry[key]}return lost}),diagnostics:[]}}'
+    'const __orcaE2eLost=state=>{const entries=JSON.parse(state).entries||[];return{outcomeVersion:1,revived:[],lost:entries.map(entry=>{const lost={id:entry.id,kind:"recognized-worker",reason:"worker-replacement-forbidden",pid:entry.pid,cols:entry.cols,rows:entry.rows,cwd:entry.cwd};for(const key of["sourceIncarnationId","paneKey","tabId","attachIdentity","worktreeId","terminalHandle","replayTail","durableLaunch","agentOwners","providerSession","orchestrationTaskId"]){if(entry[key]!==undefined)lost[key]=entry[key]}return lost}),diagnostics:[]}}',
+    'const __orcaE2eMixed=state=>{const entries=JSON.parse(state).entries||[];const lost=__orcaE2eLost(state).lost;return{outcomeVersion:1,lost:lost.slice(0,1),revived:entries.slice(1).map(entry=>{const revived={id:entry.id,disposition:"replacement-spawned",incarnationId:`e2e-replacement-${entry.id}`};for(const key of["paneKey","tabId"]){if(entry[key]!==undefined)revived[key]=entry[key]}return revived}),diagnostics:[]}}'
   ].join(';')
 }
 
@@ -119,6 +120,9 @@ function capabilityHandler(mode: DockerRelayReviveMode): string {
 function reviveHandler(mode: DockerRelayReviveMode): string {
   if (mode === 'typed-lost') {
     return 'this.dispatcher.onRequest("pty.revive",e=>{__orcaE2eRecord(`revive:${e.formatVersion===2?"typed":"legacy"}`);return e.formatVersion===2?__orcaE2eLost(e.state):this.revive(e)})'
+  }
+  if (mode === 'typed-mixed') {
+    return 'this.dispatcher.onRequest("pty.revive",e=>{__orcaE2eRecord(`revive:${e.formatVersion===2?"typed":"legacy"}`);return e.formatVersion===2?__orcaE2eMixed(e.state):this.revive(e)})'
   }
   if (mode === 'malformed') {
     return 'this.dispatcher.onRequest("pty.revive",e=>{__orcaE2eRecord(`revive:${e.formatVersion===2?"typed":"legacy"}`);return e.formatVersion===2?{outcomeVersion:1,revived:"invalid",lost:[],diagnostics:[]}:this.revive(e)})'

--- a/tests/e2e/helpers/docker-ssh-relay-session-capture.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-session-capture.ts
@@ -1,0 +1,222 @@
+import type { ElectronApplication } from '@stablyai/playwright-test'
+
+export type DockerRelaySnapshotCapture = {
+  archiveAttempt: number
+  leafId: string
+  lostPaneKey: string | null
+  lostReplayTail: 'present' | 'absent'
+  paneKeyMatchesLost: boolean
+  result: 'captured-bytes' | 'captured-empty' | 'unavailable'
+  sidecar: 'inline' | 'scrollback-ref' | 'none'
+  source: string | null
+}
+
+type RelaySessionForE2E = {
+  currentConnection?: unknown
+  reconnect: (connection: unknown, graceTimeSeconds?: number) => Promise<void>
+}
+
+type MainE2EScope = typeof globalThis & {
+  __orcaE2eRelaySessions?: Map<string, RelaySessionForE2E>
+  __orcaE2eRestoreMapSet?: () => void
+  __orcaE2eRelaySnapshotCaptures?: DockerRelaySnapshotCapture[]
+  __orcaE2eRestoreRelaySnapshotProbe?: () => void
+}
+
+export async function installDockerRelaySessionCapture(app: ElectronApplication): Promise<void> {
+  await app.evaluate(() => {
+    const scope = globalThis as MainE2EScope
+    if (!scope.__orcaE2eRelaySessions) {
+      const sessions = new Map<string, RelaySessionForE2E>()
+      const originalSet = Map.prototype.set
+      Map.prototype.set = function captureRelaySession(key: unknown, value: unknown) {
+        const candidate = value as Partial<RelaySessionForE2E> & { targetId?: unknown }
+        if (
+          typeof key === 'string' &&
+          candidate?.targetId === key &&
+          typeof candidate.reconnect === 'function'
+        ) {
+          Reflect.apply(originalSet, sessions, [key, candidate as RelaySessionForE2E])
+        }
+        return Reflect.apply(originalSet, this, [key, value])
+      }
+      scope.__orcaE2eRelaySessions = sessions
+      scope.__orcaE2eRestoreMapSet = () => {
+        Map.prototype.set = originalSet
+        delete scope.__orcaE2eRelaySessions
+        delete scope.__orcaE2eRestoreMapSet
+      }
+    }
+  })
+}
+
+export async function assertDockerRelaySessionCaptured(
+  app: ElectronApplication,
+  targetId: string
+): Promise<void> {
+  await app.evaluate((_electron, id) => {
+    if (!(globalThis as MainE2EScope).__orcaE2eRelaySessions?.has(id)) {
+      throw new Error(`SSH relay session ${id} was not captured during target connection`)
+    }
+  }, targetId)
+}
+
+export async function reconnectCapturedDockerRelay(
+  app: ElectronApplication,
+  targetId: string
+): Promise<void> {
+  await app.evaluate(async (_electron, id) => {
+    const scope = globalThis as MainE2EScope
+    const session = scope.__orcaE2eRelaySessions?.get(id)
+    if (!session?.currentConnection) {
+      throw new Error(`SSH relay session ${id} has no live connection`)
+    }
+    await session.reconnect(session.currentConnection, 1)
+  }, targetId)
+}
+
+export async function capturedDockerRelayWorkspacePtyCount(
+  app: ElectronApplication,
+  targetId: string,
+  tabId: string
+): Promise<number> {
+  return app.evaluate(
+    (_electron, { targetId: capturedTargetId, tabId: capturedTabId }) => {
+      const session = (globalThis as MainE2EScope).__orcaE2eRelaySessions?.get(capturedTargetId) as
+        | (RelaySessionForE2E & { store?: { getWorkspaceSession?: (hostId: string) => unknown } })
+        | undefined
+      const workspaceSession = session?.store?.getWorkspaceSession?.(`ssh:${capturedTargetId}`) as
+        | { terminalLayoutsByTabId?: Record<string, { ptyIdsByLeafId?: Record<string, string> }> }
+        | undefined
+      return Object.keys(
+        workspaceSession?.terminalLayoutsByTabId?.[capturedTabId]?.ptyIdsByLeafId ?? {}
+      ).length
+    },
+    { targetId, tabId }
+  )
+}
+
+export async function installDockerRelaySnapshotCaptureProbe(
+  app: ElectronApplication,
+  targetId: string
+): Promise<void> {
+  await app.evaluate((_electron, capturedTargetId) => {
+    const scope = globalThis as MainE2EScope
+    if (scope.__orcaE2eRestoreRelaySnapshotProbe) {
+      return
+    }
+    const session = scope.__orcaE2eRelaySessions?.get(capturedTargetId) as
+      | (RelaySessionForE2E & {
+          archiveRelayLostWorker?: (lost: unknown) => Promise<void>
+          store?: {
+            createTerminalArchiveStore?: (snapshotSource: {
+              capture: (pane: unknown) => Promise<unknown>
+            }) => unknown
+            getWorkspaceSession?: (hostId: string) => unknown
+          }
+        })
+      | undefined
+    const store = session?.store
+    const originalArchiveRelayLostWorker = session?.archiveRelayLostWorker
+    const originalCreateTerminalArchiveStore = store?.createTerminalArchiveStore
+    if (
+      !session ||
+      !store ||
+      !originalArchiveRelayLostWorker ||
+      !originalCreateTerminalArchiveStore ||
+      !store.getWorkspaceSession
+    ) {
+      throw new Error(
+        `SSH relay session ${capturedTargetId} cannot expose its archive snapshot seam`
+      )
+    }
+
+    let archiveAttempt = 0
+    let currentLost: Record<string, unknown> | null = null
+    const captures: DockerRelaySnapshotCapture[] = []
+    session.archiveRelayLostWorker = async (lost: unknown) => {
+      archiveAttempt += 1
+      currentLost = lost as Record<string, unknown>
+      try {
+        await originalArchiveRelayLostWorker.call(session, lost)
+      } finally {
+        currentLost = null
+      }
+    }
+    store.createTerminalArchiveStore = (snapshotSource) => {
+      const observedSnapshotSource = {
+        capture: async (pane: unknown) => {
+          const archivedPane = pane as { archivedLeafId?: unknown }
+          const leafId = String(archivedPane.archivedLeafId ?? '')
+          const lost = currentLost
+          const tabId = typeof lost?.tabId === 'string' ? lost.tabId : ''
+          const paneKey = typeof lost?.paneKey === 'string' ? lost.paneKey : null
+          const sessionState = store.getWorkspaceSession?.(`ssh:${capturedTargetId}`) as
+            | {
+                terminalLayoutsByTabId?: Record<
+                  string,
+                  {
+                    buffersByLeafId?: Record<string, unknown>
+                    scrollbackRefsByLeafId?: Record<string, unknown>
+                  }
+                >
+              }
+            | undefined
+          const layout = sessionState?.terminalLayoutsByTabId?.[tabId]
+          const hasInlineSidecar = typeof layout?.buffersByLeafId?.[leafId] === 'string'
+          const hasScrollbackRef = typeof layout?.scrollbackRefsByLeafId?.[leafId] === 'string'
+          const result = (await snapshotSource.capture(pane)) as {
+            kind?: unknown
+            source?: unknown
+          }
+          const resultKind = result.kind
+          if (
+            resultKind !== 'captured-bytes' &&
+            resultKind !== 'captured-empty' &&
+            resultKind !== 'unavailable'
+          ) {
+            throw new Error(`Unexpected relay snapshot result: ${String(resultKind)}`)
+          }
+          captures.push({
+            archiveAttempt,
+            leafId,
+            lostPaneKey: paneKey,
+            lostReplayTail:
+              typeof (lost?.replayTail as { data?: unknown } | undefined)?.data === 'string'
+                ? 'present'
+                : 'absent',
+            paneKeyMatchesLost: paneKey === `${tabId}:${leafId}`,
+            result: resultKind,
+            sidecar: hasInlineSidecar ? 'inline' : hasScrollbackRef ? 'scrollback-ref' : 'none',
+            source: typeof result.source === 'string' ? result.source : null
+          })
+          return result
+        }
+      }
+      return Reflect.apply(originalCreateTerminalArchiveStore, store, [observedSnapshotSource])
+    }
+    scope.__orcaE2eRelaySnapshotCaptures = captures
+    scope.__orcaE2eRestoreRelaySnapshotProbe = () => {
+      session.archiveRelayLostWorker = originalArchiveRelayLostWorker
+      store.createTerminalArchiveStore = originalCreateTerminalArchiveStore
+      delete scope.__orcaE2eRelaySnapshotCaptures
+      delete scope.__orcaE2eRestoreRelaySnapshotProbe
+    }
+  }, targetId)
+}
+
+export async function readDockerRelaySnapshotCaptures(
+  app: ElectronApplication
+): Promise<DockerRelaySnapshotCapture[]> {
+  return app.evaluate(() => [
+    ...((globalThis as MainE2EScope).__orcaE2eRelaySnapshotCaptures ?? [])
+  ])
+}
+
+export async function releaseDockerRelaySessionCapture(app: ElectronApplication): Promise<void> {
+  await app.evaluate(() => {
+    const scope = globalThis as MainE2EScope
+    scope.__orcaE2eRestoreRelaySnapshotProbe?.()
+    scope.__orcaE2eRestoreMapSet?.()
+  })
+}

--- a/tests/e2e/helpers/docker-ssh-relay-session-capture.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-session-capture.ts
@@ -107,7 +107,7 @@ export async function installDockerRelaySnapshotCaptureProbe(
     }
     const session = scope.__orcaE2eRelaySessions?.get(capturedTargetId) as
       | (RelaySessionForE2E & {
-          archiveRelayLostWorker?: (lost: unknown) => Promise<void>
+          archiveRelayLostWorker?: (args: unknown) => Promise<void>
           store?: {
             createTerminalArchiveStore?: (snapshotSource: {
               capture: (pane: unknown) => Promise<unknown>
@@ -134,11 +134,14 @@ export async function installDockerRelaySnapshotCaptureProbe(
     let archiveAttempt = 0
     let currentLost: Record<string, unknown> | null = null
     const captures: DockerRelaySnapshotCapture[] = []
-    session.archiveRelayLostWorker = async (lost: unknown) => {
+    session.archiveRelayLostWorker = async (args: unknown) => {
       archiveAttempt += 1
-      currentLost = lost as Record<string, unknown>
+      currentLost =
+        args && typeof args === 'object' && 'lost' in args
+          ? ((args as { lost?: unknown }).lost as Record<string, unknown>)
+          : (args as Record<string, unknown>)
       try {
-        await originalArchiveRelayLostWorker.call(session, lost)
+        await originalArchiveRelayLostWorker.call(session, args)
       } finally {
         currentLost = null
       }

--- a/tests/e2e/helpers/docker-ssh-relay-target.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-target.ts
@@ -44,6 +44,22 @@ export function execDockerSshRelayTargetCommand(
   })
 }
 
+export function dockerSshPidsAreGone(
+  target: DockerSshRelayTarget,
+  pids: readonly number[]
+): boolean {
+  const uniquePids = [...new Set(pids)]
+  if (uniquePids.length === 0 || uniquePids.some((pid) => !Number.isSafeInteger(pid) || pid <= 0)) {
+    return false
+  }
+  return (
+    execDockerSshRelayTargetCommand(
+      target,
+      uniquePids.map((pid) => `test ! -e /proc/${pid}`).join(' && ')
+    ) === ''
+  )
+}
+
 function sshArgs(target: DockerSshRelayTarget, command: string): string[] {
   return [
     '-i',

--- a/tests/e2e/ssh-docker-mixed-version-lost-worker-archive.spec.ts
+++ b/tests/e2e/ssh-docker-mixed-version-lost-worker-archive.spec.ts
@@ -406,8 +406,9 @@ test.describe('Docker SSH mixed-version lost-worker archive', () => {
           expect.objectContaining({
             lostReplayTail: 'present',
             paneKeyMatchesLost: false,
-            result: 'unavailable',
-            sidecar: 'none'
+            result: 'captured-bytes',
+            sidecar: 'none',
+            source: 'relay-tail'
           })
         ])
       )

--- a/tests/e2e/ssh-docker-mixed-version-lost-worker-archive.spec.ts
+++ b/tests/e2e/ssh-docker-mixed-version-lost-worker-archive.spec.ts
@@ -41,7 +41,6 @@ const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
 
 type PersistedData = {
   terminalArchivesById?: Record<string, { reason?: string; sourceTabId?: string }>
-  sshRemotePtyLeases?: { state?: string; tabId?: string; targetId?: string }[]
   workspaceSessionsByHostId?: Record<
     string,
     {
@@ -65,7 +64,6 @@ type DockerRelayScenario = {
 
 type DurableRelayState = {
   archiveIds: string[]
-  leaseStates: string[]
   tabInTabsByWorktree: boolean
   tabInUnifiedTabs: boolean
 }
@@ -89,7 +87,6 @@ function readDurableRelayState(
   if (!existsSync(statePath)) {
     return {
       archiveIds: [],
-      leaseStates: [],
       tabInTabsByWorktree: false,
       tabInUnifiedTabs: false
     }
@@ -102,9 +99,6 @@ function readDurableRelayState(
         ([, archive]) => archive.reason === 'relay-worker-lost' && archive.sourceTabId === tabId
       )
       .map(([archiveId]) => archiveId),
-    leaseStates: (data.sshRemotePtyLeases ?? [])
-      .filter((lease) => lease.targetId === targetId && lease.tabId === tabId)
-      .map((lease) => lease.state ?? 'missing-state'),
     tabInTabsByWorktree: (session?.tabsByWorktree?.[worktreeId] ?? []).some(
       (tab) => tab.id === tabId
     ),
@@ -278,7 +272,19 @@ test.describe('Docker SSH mixed-version lost-worker archive', () => {
         .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.revivePath))
         .toEqual(['revive:typed'])
       const archiveId = await waitForSingleArchive(scenario)
-      const durable = await typedArchiveDurabilityProbe(scenario)
+      await typedArchiveDurabilityProbe(scenario)
+      await expect.poll(() => inspectTabDom(scenario.page, scenario.tabId)).toEqual([])
+      await expect
+        .poll(() =>
+          scenario.page.locator(`[data-pty-id=${JSON.stringify(scenario.ptyId)}]`).count()
+        )
+        .toBe(0)
+      const durable = readDurableRelayState(
+        scenario.userDataDir,
+        scenario.targetId,
+        scenario.tabId,
+        scenario.worktreeId
+      )
       const remainingTabDom = await inspectTabDom(scenario.page, scenario.tabId)
       const remainingPtyDom = await scenario.page
         .locator(`[data-pty-id=${JSON.stringify(scenario.ptyId)}]`)
@@ -289,11 +295,10 @@ test.describe('Docker SSH mixed-version lost-worker archive', () => {
           remainingPtyDom,
           remainingTabDom
         },
-        'typed archive must retire the main durable tab, expire its SSH lease, and remove every DOM tab node'
+        'typed archive must retire the main durable tab and remove every DOM tab node'
       ).toEqual({
         durable: {
           archiveIds: [archiveId],
-          leaseStates: ['expired'],
           tabInTabsByWorktree: false,
           tabInUnifiedTabs: false
         },
@@ -367,9 +372,9 @@ test.describe('Docker SSH mixed-version lost-worker archive', () => {
   })
 
   // oxlint-disable-next-line no-empty-pattern -- Playwright fixture callbacks require object destructuring here.
-  test('archives a split relay tab without leaving a replacement shell beside it', async ({}, testInfo) => {
+  test('archives a split relay tab when a lost worker has a revived ordinary sibling', async ({}, testInfo) => {
     test.slow()
-    await withDockerRelayScenario(testInfo, 'typed-lost', async (scenario) => {
+    await withDockerRelayScenario(testInfo, 'typed-mixed', async (scenario) => {
       await splitActiveTerminalPane(scenario.page, 'vertical')
       await expect
         .poll(() =>

--- a/tests/e2e/ssh-docker-mixed-version-lost-worker-archive.spec.ts
+++ b/tests/e2e/ssh-docker-mixed-version-lost-worker-archive.spec.ts
@@ -25,6 +25,7 @@ import {
 } from './helpers/docker-ssh-relay-session-capture'
 import {
   cleanupDockerSshRelayTarget,
+  dockerSshPidsAreGone,
   startDockerSshRelayTarget,
   type DockerSshRelayTarget
 } from './helpers/docker-ssh-relay-target'
@@ -70,6 +71,10 @@ type DurableRelayState = {
 
 function readArchiveRows(userDataDir: string, tabId: string): string[] {
   return readDurableRelayState(userDataDir, '', tabId, '').archiveIds
+}
+
+function readDockerRelayPtyPids(scenario: DockerRelayScenario): number[] {
+  return readDockerRelayProbe(scenario.target, scenario.probe.ptyPidPath).map(Number)
 }
 
 function readDurableRelayState(
@@ -271,6 +276,8 @@ test.describe('Docker SSH mixed-version lost-worker archive', () => {
       await expect
         .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.revivePath))
         .toEqual(['revive:typed'])
+      await expect.poll(() => readDockerRelayPtyPids(scenario)).toHaveLength(1)
+      const remotePtyPids = readDockerRelayPtyPids(scenario)
       const archiveId = await waitForSingleArchive(scenario)
       await typedArchiveDurabilityProbe(scenario)
       await expect.poll(() => inspectTabDom(scenario.page, scenario.tabId)).toEqual([])
@@ -313,6 +320,7 @@ test.describe('Docker SSH mixed-version lost-worker archive', () => {
       await expect(
         scenario.page.locator(`[data-testid="sortable-tab"][data-tab-id="${scenario.tabId}"]`)
       ).toHaveCount(0)
+      await expect.poll(() => dockerSshPidsAreGone(scenario.target, remotePtyPids)).toBe(true)
       expect(readDockerRelayProbe(scenario.target, scenario.probe.spawnPath)).toEqual([])
       testInfo.annotations.push({ type: 'relay-worker-archive', description: archiveId })
     })

--- a/tests/e2e/ssh-docker-mixed-version-lost-worker-archive.spec.ts
+++ b/tests/e2e/ssh-docker-mixed-version-lost-worker-archive.spec.ts
@@ -1,0 +1,428 @@
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import type { ElectronApplication, Page, TestInfo } from '@stablyai/playwright-test'
+
+import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
+import { test, expect } from './helpers/orca-app'
+import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
+import {
+  clearDockerRelayProbe,
+  createDockerRelayProbe,
+  patchDockerRelayBundle,
+  readDockerRelayProbe,
+  type DockerRelayProbe,
+  type DockerRelayReviveMode
+} from './helpers/docker-ssh-relay-bundle-patch'
+import {
+  assertDockerRelaySessionCaptured,
+  capturedDockerRelayWorkspacePtyCount,
+  installDockerRelaySessionCapture,
+  installDockerRelaySnapshotCaptureProbe,
+  readDockerRelaySnapshotCaptures,
+  reconnectCapturedDockerRelay,
+  releaseDockerRelaySessionCapture
+} from './helpers/docker-ssh-relay-session-capture'
+import {
+  cleanupDockerSshRelayTarget,
+  startDockerSshRelayTarget,
+  type DockerSshRelayTarget
+} from './helpers/docker-ssh-relay-target'
+import { createRestartSession } from './helpers/orca-restart'
+import { getActiveTabId, getActiveWorktreeId, waitForSessionReady } from './helpers/store'
+import {
+  splitActiveTerminalPane,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+
+const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
+
+type PersistedData = {
+  terminalArchivesById?: Record<string, { reason?: string; sourceTabId?: string }>
+  sshRemotePtyLeases?: { state?: string; tabId?: string; targetId?: string }[]
+  workspaceSessionsByHostId?: Record<
+    string,
+    {
+      tabsByWorktree?: Record<string, { id?: string }[]>
+      unifiedTabs?: Record<string, { entityId?: string; id?: string }[]>
+    }
+  >
+}
+
+type DockerRelayScenario = {
+  app: ElectronApplication
+  page: Page
+  probe: DockerRelayProbe
+  ptyId: string
+  tabId: string
+  target: DockerSshRelayTarget
+  targetId: string
+  userDataDir: string
+  worktreeId: string
+}
+
+type DurableRelayState = {
+  archiveIds: string[]
+  leaseStates: string[]
+  tabInTabsByWorktree: boolean
+  tabInUnifiedTabs: boolean
+}
+
+function readArchiveRows(userDataDir: string, tabId: string): string[] {
+  return readDurableRelayState(userDataDir, '', tabId, '').archiveIds
+}
+
+function readDurableRelayState(
+  userDataDir: string,
+  targetId: string,
+  tabId: string,
+  worktreeId: string
+): DurableRelayState {
+  const statePath = path.join(
+    userDataDir,
+    'profiles',
+    DEFAULT_LOCAL_ORCA_PROFILE_ID,
+    'orca-data.json'
+  )
+  if (!existsSync(statePath)) {
+    return {
+      archiveIds: [],
+      leaseStates: [],
+      tabInTabsByWorktree: false,
+      tabInUnifiedTabs: false
+    }
+  }
+  const data = JSON.parse(readFileSync(statePath, 'utf8')) as PersistedData
+  const session = targetId ? data.workspaceSessionsByHostId?.[`ssh:${targetId}`] : undefined
+  return {
+    archiveIds: Object.entries(data.terminalArchivesById ?? {})
+      .filter(
+        ([, archive]) => archive.reason === 'relay-worker-lost' && archive.sourceTabId === tabId
+      )
+      .map(([archiveId]) => archiveId),
+    leaseStates: (data.sshRemotePtyLeases ?? [])
+      .filter((lease) => lease.targetId === targetId && lease.tabId === tabId)
+      .map((lease) => lease.state ?? 'missing-state'),
+    tabInTabsByWorktree: (session?.tabsByWorktree?.[worktreeId] ?? []).some(
+      (tab) => tab.id === tabId
+    ),
+    tabInUnifiedTabs: (session?.unifiedTabs?.[worktreeId] ?? []).some(
+      (tab) => tab.id === tabId || tab.entityId === tabId
+    )
+  }
+}
+
+async function waitForTerminal(page: Page): Promise<{ ptyId: string; tabId: string }> {
+  await waitForActiveTerminalManager(page, 60_000)
+  const ptyId = await waitForActivePanePtyId(page, 60_000)
+  const tabId = await getActiveTabId(page)
+  if (!tabId) {
+    throw new Error('Remote terminal did not expose an active tab ID')
+  }
+  return { ptyId, tabId }
+}
+
+async function withDockerRelayScenario(
+  testInfo: TestInfo,
+  mode: DockerRelayReviveMode,
+  run: (scenario: DockerRelayScenario) => Promise<void>
+): Promise<void> {
+  const probe = createDockerRelayProbe(`${mode}-${testInfo.workerIndex}`)
+  const restorePatchedBundle = patchDockerRelayBundle(mode, probe)
+  const restartSession = createRestartSession(testInfo)
+  let app: ElectronApplication | null = null
+  let target: DockerSshRelayTarget | null = null
+  try {
+    const launch = await restartSession.launch()
+    app = launch.app
+    await waitForSessionReady(launch.page)
+    for (const platform of ['linux-x64', 'linux-arm64']) {
+      expect(
+        readFileSync(path.join(process.cwd(), 'out', 'relay', platform, 'relay.js'), 'utf8')
+      ).toContain('__orcaE2eRelayMixedVersionMarker')
+    }
+    expect(await app.evaluate((_electron) => process.env.ORCA_RELAY_PATH ?? null)).toBe(
+      path.join(process.cwd(), 'out', 'relay')
+    )
+    await installDockerRelaySessionCapture(app)
+    target = startDockerSshRelayTarget(testInfo)
+    const remote = await connectDockerSshRelayTarget(launch.page, target)
+    await assertDockerRelaySessionCaptured(app, remote.targetId)
+    const { ptyId, tabId } = await waitForTerminal(launch.page)
+    const worktreeId = await getActiveWorktreeId(launch.page)
+    if (!worktreeId) {
+      throw new Error('Remote terminal did not expose an active worktree ID')
+    }
+    await expect
+      .poll(() => readDockerRelayProbe(target!, probe.loadedPath), {
+        timeout: 30_000,
+        message: 'patched Docker relay did not write its unconditional load marker'
+      })
+      .toContain('loaded')
+    await expect
+      .poll(() => readDockerRelayProbe(target!, probe.spawnPath), {
+        timeout: 30_000,
+        message: 'relay pty.spawn probe missed the initial remote shell positive control'
+      })
+      .toEqual(['spawn'])
+    const liveMarker = `RELAY_RECONNECT_LIVE_${Date.now()}`
+    await launch.page
+      .locator(`[data-pty-id=${JSON.stringify(ptyId)}] .xterm-helper-textarea`)
+      .focus()
+    await launch.page.keyboard.type(`printf '${liveMarker}\\n'`)
+    await launch.page.keyboard.press('Enter')
+    await waitForTerminalOutput(launch.page, liveMarker)
+    clearDockerRelayProbe(target, probe)
+    await run({
+      app,
+      page: launch.page,
+      probe,
+      ptyId,
+      tabId,
+      target,
+      targetId: remote.targetId,
+      userDataDir: restartSession.userDataDir,
+      worktreeId
+    })
+  } finally {
+    if (app) {
+      await releaseDockerRelaySessionCapture(app)
+    }
+    cleanupDockerSshRelayTarget(target)
+    if (app) {
+      await restartSession.close(app)
+    }
+    await restartSession.dispose()
+    restorePatchedBundle()
+  }
+}
+
+async function reconnectScenario(scenario: DockerRelayScenario): Promise<void> {
+  await reconnectCapturedDockerRelay(scenario.app, scenario.targetId)
+}
+
+async function waitForSingleArchive(
+  scenario: DockerRelayScenario,
+  diagnostic?: unknown
+): Promise<string> {
+  let archiveId: string | undefined
+  await expect
+    .poll(() => readArchiveRows(scenario.userDataDir, scenario.tabId), {
+      timeout: 30_000,
+      message: `typed recognized relay loss did not create a durable archive${
+        diagnostic ? `; diagnostic=${JSON.stringify(diagnostic)}` : ''
+      }`
+    })
+    .toHaveLength(1)
+  archiveId = readArchiveRows(scenario.userDataDir, scenario.tabId)[0]
+  if (!archiveId) {
+    throw new Error('Durable relay-worker-lost archive has no ID')
+  }
+  return archiveId
+}
+
+async function typedArchiveDurabilityProbe(
+  scenario: DockerRelayScenario
+): Promise<DurableRelayState> {
+  let durable: DurableRelayState | undefined
+  await expect
+    .poll(
+      () => {
+        durable = readDurableRelayState(
+          scenario.userDataDir,
+          scenario.targetId,
+          scenario.tabId,
+          scenario.worktreeId
+        )
+        return durable.archiveIds.length
+      },
+      { timeout: 30_000, message: 'typed recognized relay loss did not write its durable archive' }
+    )
+    .toBe(1)
+  if (!durable) {
+    throw new Error('Typed relay archive durability probe did not produce a state')
+  }
+  return durable
+}
+
+async function inspectTabDom(page: Page, tabId: string): Promise<unknown[]> {
+  return page.evaluate((expectedTabId) => {
+    return Array.from(document.querySelectorAll<HTMLElement>('[data-tab-id]'))
+      .filter((element) => element.dataset.tabId === expectedTabId)
+      .map((element) => ({
+        className: element.className,
+        dataTestId: element.dataset.testid ?? null,
+        role: element.getAttribute('role'),
+        tagName: element.tagName,
+        text: element.textContent?.trim() ?? ''
+      }))
+  }, tabId)
+}
+
+test.describe('Docker SSH mixed-version lost-worker archive', () => {
+  test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run Docker-backed SSH tests.')
+  test.skip(process.platform === 'win32', 'Docker SSH relay fixture uses a Linux relay bundle.')
+
+  // oxlint-disable-next-line no-empty-pattern -- Playwright fixture callbacks require object destructuring here.
+  test('archives a typed recognized worker without creating a replacement shell', async ({}, testInfo) => {
+    test.slow()
+    await withDockerRelayScenario(testInfo, 'typed-lost', async (scenario) => {
+      await reconnectScenario(scenario)
+
+      await expect
+        .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.capabilityPath))
+        .toEqual(['capability:typed', 'capability:typed'])
+      await expect
+        .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.revivePath))
+        .toEqual(['revive:typed'])
+      const archiveId = await waitForSingleArchive(scenario)
+      const durable = await typedArchiveDurabilityProbe(scenario)
+      const remainingTabDom = await inspectTabDom(scenario.page, scenario.tabId)
+      const remainingPtyDom = await scenario.page
+        .locator(`[data-pty-id=${JSON.stringify(scenario.ptyId)}]`)
+        .count()
+      expect(
+        {
+          durable,
+          remainingPtyDom,
+          remainingTabDom
+        },
+        'typed archive must retire the main durable tab, expire its SSH lease, and remove every DOM tab node'
+      ).toEqual({
+        durable: {
+          archiveIds: [archiveId],
+          leaseStates: ['expired'],
+          tabInTabsByWorktree: false,
+          tabInUnifiedTabs: false
+        },
+        remainingPtyDom: 0,
+        remainingTabDom: []
+      })
+      await expect
+        .poll(() =>
+          scenario.page.locator(`[data-pty-id=${JSON.stringify(scenario.ptyId)}]`).count()
+        )
+        .toBe(0)
+      await expect(
+        scenario.page.locator(`[data-testid="sortable-tab"][data-tab-id="${scenario.tabId}"]`)
+      ).toHaveCount(0)
+      expect(readDockerRelayProbe(scenario.target, scenario.probe.spawnPath)).toEqual([])
+      testInfo.annotations.push({ type: 'relay-worker-archive', description: archiveId })
+    })
+  })
+
+  // oxlint-disable-next-line no-empty-pattern -- Playwright fixture callbacks require object destructuring here.
+  test('keeps a legacy relay connected and retryable without inventing an archive', async ({}, testInfo) => {
+    test.slow()
+    await withDockerRelayScenario(testInfo, 'legacy', async (scenario) => {
+      await reconnectScenario(scenario)
+
+      await expect
+        .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.capabilityPath))
+        .toEqual(['capability:legacy', 'capability:legacy'])
+      await expect
+        .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.revivePath))
+        .toEqual(['revive:legacy'])
+      expect(readArchiveRows(scenario.userDataDir, scenario.tabId)).toEqual([])
+      await expect(
+        scenario.page.locator(`[data-testid="sortable-tab"][data-tab-id="${scenario.tabId}"]`)
+      ).toHaveCount(1)
+      await expect(
+        scenario.page.locator(`[data-pty-id=${JSON.stringify(scenario.ptyId)}]`)
+      ).toHaveCount(1)
+      expect(readDockerRelayProbe(scenario.target, scenario.probe.spawnPath)).toEqual([])
+
+      const retryMarker = `LEGACY_RELAY_RETRYABLE_${Date.now()}`
+      await scenario.page.evaluate(
+        ({ ptyId, marker }) => window.api.pty.write(ptyId, `printf '${marker}\\n'\r`),
+        { ptyId: scenario.ptyId, marker: retryMarker }
+      )
+      await waitForTerminalOutput(scenario.page, retryMarker)
+    })
+  })
+
+  // oxlint-disable-next-line no-empty-pattern -- Playwright fixture callbacks require object destructuring here.
+  test('fails closed on a malformed typed response without a legacy revive retry', async ({}, testInfo) => {
+    test.slow()
+    await withDockerRelayScenario(testInfo, 'malformed', async (scenario) => {
+      await reconnectScenario(scenario)
+
+      await expect
+        .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.capabilityPath))
+        .toEqual(['capability:typed', 'capability:typed'])
+      await expect
+        .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.revivePath))
+        .toEqual(['revive:typed'])
+      expect(readArchiveRows(scenario.userDataDir, scenario.tabId)).toEqual([])
+      await expect(
+        scenario.page.locator(`[data-testid="sortable-tab"][data-tab-id="${scenario.tabId}"]`)
+      ).toHaveCount(1)
+      await expect(
+        scenario.page.locator(`[data-pty-id=${JSON.stringify(scenario.ptyId)}]`)
+      ).toHaveCount(1)
+      expect(readDockerRelayProbe(scenario.target, scenario.probe.spawnPath)).toEqual([])
+    })
+  })
+
+  // oxlint-disable-next-line no-empty-pattern -- Playwright fixture callbacks require object destructuring here.
+  test('archives a split relay tab without leaving a replacement shell beside it', async ({}, testInfo) => {
+    test.slow()
+    await withDockerRelayScenario(testInfo, 'typed-lost', async (scenario) => {
+      await splitActiveTerminalPane(scenario.page, 'vertical')
+      await expect
+        .poll(() =>
+          scenario.page.evaluate((tabId) => {
+            return (window.__paneManagers?.get(tabId)?.getPanes?.() ?? [])
+              .map((pane) => pane.container.dataset.ptyId)
+              .filter((ptyId): ptyId is string => Boolean(ptyId))
+          }, scenario.tabId)
+        )
+        .toHaveLength(2)
+      await expect
+        .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.spawnPath))
+        .toEqual(['spawn'])
+      await expect
+        .poll(() =>
+          capturedDockerRelayWorkspacePtyCount(scenario.app, scenario.targetId, scenario.tabId)
+        )
+        .toBe(2)
+      clearDockerRelayProbe(scenario.target, scenario.probe)
+      await installDockerRelaySnapshotCaptureProbe(scenario.app, scenario.targetId)
+
+      await reconnectScenario(scenario)
+
+      await expect
+        .poll(() => readDockerRelayProbe(scenario.target, scenario.probe.revivePath))
+        .toEqual(['revive:typed'])
+      const snapshotCaptures = await readDockerRelaySnapshotCaptures(scenario.app)
+      await testInfo.attach('relay-split-snapshot-captures.json', {
+        body: JSON.stringify(snapshotCaptures, null, 2),
+        contentType: 'application/json'
+      })
+      expect(snapshotCaptures).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            lostReplayTail: 'present',
+            paneKeyMatchesLost: false,
+            result: 'unavailable',
+            sidecar: 'none'
+          })
+        ])
+      )
+      await waitForSingleArchive(scenario, snapshotCaptures)
+      await expect(
+        scenario.page.locator(`[data-testid="sortable-tab"][data-tab-id="${scenario.tabId}"]`)
+      ).toHaveCount(0)
+      await expect
+        .poll(() =>
+          scenario.page
+            .locator(`[data-pty-id][data-tab-id=${JSON.stringify(scenario.tabId)}]`)
+            .count()
+        )
+        .toBe(0)
+      expect(readDockerRelayProbe(scenario.target, scenario.probe.spawnPath)).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Motivation

When a recognized worker's PTY is lost (daemon crash, SSH relay upgrade, dead remote process) or a user closes a tab, terminal history could be silently dropped or the tab left in a broken state: the all-leaf capture invariant (`terminal-archive-store.ts`) fails closed for multi-pane tabs whose sibling leaves have no snapshot source, SSH archives never retired their tab, and several exit/receipt races could close a replacement PTY or lose the archived-exit receipt.

## What this PR does

- **Durable archive store for tab close and lost workers**: every user tab close and lost-worker path routes through a single durable archive transition; archive metadata, tab retirement, and SSH `termination-pending` leases commit in **one atomic flush** with rollback on failure.
- **Typed revive protocol + v2 persistence envelope**: staged pre-teardown serialization gives every entry a `replayTail` bound to its `sourceIncarnationId`; the archive snapshot source resolves sibling leaves by paneKey with same-generation validation. Whole-envelope validation rejects malformed v2 payloads (fail-closed, no per-entry salvage).
- **Fail-closed cold probe** (`probeColdRestore` discriminated union): log read/decode/generation/replay failures are reported as completeness-lost instead of being disguised as untruncated snapshots; `captured-empty` requires provably empty (`data.length===0 && truncated===false`), unified across all four capture entry points via a shared constructor.
- **Exit/receipt correctness under PTY id reuse**: archived-exit receipts are bound to their incarnation (a replacement cannot consume an older generation's receipt; a rejected old-generation exit no longer suppresses the synthetic archived exit), reconnect-attempt abort is fenced up to (and re-checked at) archive commit, and shutdown cleanup/synthetic exits only act on the incarnation the shutdown captured — a plain kill can no longer close a replacement spawned during the await window.
- **Renderer-first completion**: the renderer's first/only exit for an archived PTY carries the archive receipt (pre-registered before shutdown to survive synchronous provider exits).

## Validation scope

Mixed-version SSH archive success is guaranteed only when **both ends support the v2 staged serializer**. A legacy (pre-v2) envelope is expected to fail closed with distinct diagnostics (`staged-state-legacy` / `staged-state-missing`) — no second-hand data is fabricated.

## Testing

- Unit/integration: capture fence (per-leaf + pre-commit), Store-level flush failure injection asserting three-way rollback, receipt incarnation binding (both race directions), plain kill/stop id-reuse (three caller paths), envelope validation, cold-probe failure taxonomy.
- E2E (Docker SSH relay, mixed-version): 4 scenarios including a true mixed outcome (one recognized worker lost + one ordinary sibling revived) and remote-process termination assertions — 4 passed.
- Full suite: no new failures vs. base (3 pre-existing environment-sensitive failures unrelated to this change).

## ELI5

When a terminal worker dies (crash, SSH upgrade, closed tab), history could vanish or tabs stuck broken. This archives lost workers more safely, retires tabs cleanly, and handles mixed-version SSH revive so you keep history and a consistent UI.
