### PR TITLE
perf(agent-status): validate hook payloads without the JSON round trip

### DIFF
--- a/config/scripts/agent-hook-normalizer-roundtrip-benchmark.mjs
+++ b/config/scripts/agent-hook-normalizer-roundtrip-benchmark.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+// Benchmark: cost of validating an agent-status payload on every hook event.
+//
+// 13 of the 15 per-source normalizers in agent-hook-listener.ts built a plain
+// object, JSON.stringify'd it, and handed the string to parseAgentStatusPayload,
+// which runs assertJsonTextStructureWithinLimits (a per-character scan of the
+// WHOLE serialized string) plus JSON.parse — only to reach the same
+// normalizeAgentStatusObject the object path calls directly. Claude and Codex
+// were already converted, with a comment calling the round trip "pure overhead
+// on this hot per-hook path"; the other 13 were not.
+//
+// Why the gap widens with payload size: the direct path's field normalizer stops
+// at the field cap (`normalized.length < maxLength`), so it is O(cap). The round
+// trip is O(input) — and the input is bounded only by the 1 MB hook request
+// limit, since tool_response text is passed through uncapped for most sources.
+//
+// Amplifier this models in the second table: resolveToolState stores the raw
+// value in lastToolByPaneKey and inherits it until a turn reset, so one large
+// tool result is re-serialized and re-scanned on every later event of the turn.
+import { readFileSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
+import { fileURLToPath } from 'node:url'
+
+const TYPES_SOURCE = readFileSync(
+  fileURLToPath(new URL('../../src/shared/agent-status-types.ts', import.meta.url)),
+  'utf8'
+)
+
+function readMirroredConstant(name) {
+  const match = TYPES_SOURCE.match(new RegExp(`${name}\\s*=\\s*([0-9_]+)`))
+  if (!match) {
+    throw new Error(`agent-status-types.ts no longer defines ${name}; re-sync this benchmark.`)
+  }
+  return Number(match[1].replaceAll('_', ''))
+}
+
+// Read the cap the direct path clamps at, so a drifted value fails loudly here
+// instead of quietly changing what this benchmark claims.
+const ASSISTANT_MESSAGE_CAP = readMirroredConstant('AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH')
+
+const ITERATIONS = Number.parseInt(process.env.ORCA_HOOK_NORM_BENCH_ITERATIONS ?? '400', 10)
+const WARMUP = Number.parseInt(process.env.ORCA_HOOK_NORM_BENCH_WARMUP ?? '200', 10)
+
+for (const [name, value] of [
+  ['ORCA_HOOK_NORM_BENCH_ITERATIONS', ITERATIONS],
+  ['ORCA_HOOK_NORM_BENCH_WARMUP', WARMUP]
+]) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, received ${value}`)
+  }
+}
+
+const STRUCTURAL_TOKENS = 4096
+const NESTING_DEPTH = 16
+
+// Mirror of assertJsonTextStructureWithinLimits — the per-character scan the
+// round trip pays before JSON.parse even starts.
+function scanJsonStructure(content) {
+  let structuralTokens = 0
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index]
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === '"') {
+        inString = false
+      }
+      continue
+    }
+    if (character === '"') {
+      inString = true
+      continue
+    }
+    if (
+      character !== '{' &&
+      character !== '}' &&
+      character !== '[' &&
+      character !== ']' &&
+      character !== ',' &&
+      character !== ':'
+    ) {
+      continue
+    }
+    structuralTokens += 1
+    if (structuralTokens > STRUCTURAL_TOKENS) {
+      throw new Error('structuralTokens')
+    }
+    if (character === '{' || character === '[') {
+      depth += 1
+      if (depth > NESTING_DEPTH) {
+        throw new Error('nestingDepth')
+      }
+    } else if (character === '}' || character === ']') {
+      depth = Math.max(0, depth - 1)
+    }
+  }
+}
+
+// Mirror of the field normalizer's bounded walk: it stops consuming at the cap.
+function normalizeField(value, maxLength) {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  let normalized = ''
+  let newlineRun = 0
+  for (let index = 0; index < value.length && normalized.length < maxLength; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code === 13 || code === 10 || code === 0x2028 || code === 0x2029) {
+      if (code === 13 && value.charCodeAt(index + 1) === 10) {
+        index += 1
+      }
+      if (newlineRun < 2) {
+        normalized += '\n'
+      }
+      newlineRun += 1
+      continue
+    }
+    newlineRun = 0
+    normalized += value[index]
+  }
+  return normalized
+}
+
+function normalizeObject(payload) {
+  return {
+    state: payload.state,
+    prompt: normalizeField(payload.prompt, ASSISTANT_MESSAGE_CAP),
+    agentType: payload.agentType,
+    toolName: normalizeField(payload.toolName, ASSISTANT_MESSAGE_CAP),
+    toolInput: normalizeField(payload.toolInput, ASSISTANT_MESSAGE_CAP),
+    lastAssistantMessage: normalizeField(payload.lastAssistantMessage, ASSISTANT_MESSAGE_CAP)
+  }
+}
+
+// Pre-fix: serialize, scan every character, parse, then normalize.
+function validateViaRoundTrip(payload) {
+  const json = JSON.stringify(payload)
+  scanJsonStructure(json)
+  return normalizeObject(JSON.parse(json))
+}
+
+// Post-fix: normalize the object that is already in hand.
+function validateDirect(payload) {
+  return normalizeObject(payload)
+}
+
+function makePayload(messageBytes) {
+  return {
+    state: 'working',
+    prompt: 'do the thing',
+    agentType: 'grok',
+    toolName: 'shell_command',
+    toolInput: 'ls -la',
+    lastAssistantMessage: 'x'.repeat(messageBytes)
+  }
+}
+
+function measure(fn, payload) {
+  for (let index = 0; index < WARMUP; index += 1) {
+    fn(payload)
+  }
+  const samples = []
+  for (let round = 0; round < 5; round += 1) {
+    const start = performance.now()
+    for (let index = 0; index < ITERATIONS; index += 1) {
+      fn(payload)
+    }
+    samples.push((performance.now() - start) / ITERATIONS)
+  }
+  samples.sort((a, b) => a - b)
+  return samples[2]
+}
+
+const rows = []
+for (const kb of [4, 16, 64, 256]) {
+  const payload = makePayload(kb * 1024)
+  const before = validateViaRoundTrip(payload)
+  const after = validateDirect(payload)
+  if (JSON.stringify(before) !== JSON.stringify(after)) {
+    throw new Error(`normalizer mismatch at ${kb} KB`)
+  }
+  rows.push({
+    label: `${kb} KB`,
+    beforeUs: measure(validateViaRoundTrip, payload) * 1000,
+    afterUs: measure(validateDirect, payload) * 1000
+  })
+}
+
+const pad = (value, width) => String(value).padStart(width)
+console.log('Agent-status payload validation, per hook event')
+console.log(
+  `field cap=${ASSISTANT_MESSAGE_CAP} iterations=${ITERATIONS} warmup=${WARMUP} (median of 5 rounds)`
+)
+console.log(
+  `${pad('payload', 9)} ${pad('round trip', 12)} ${pad('direct', 10)} ${pad('speedup', 9)}`
+)
+for (const row of rows) {
+  console.log(
+    `${pad(row.label, 9)} ${pad(`${row.beforeUs.toFixed(1)} us`, 12)} ${pad(`${row.afterUs.toFixed(1)} us`, 10)} ${pad(`${(row.beforeUs / row.afterUs).toFixed(1)}x`, 9)}`
+  )
+}
+
+// A single large tool result is inherited across the turn, so every later event
+// re-pays the round trip on bytes that were already validated once.
+const TURN_EVENTS = 20
+const inherited = makePayload(200 * 1024)
+const beforeTurnMs = (measure(validateViaRoundTrip, inherited) * TURN_EVENTS).toFixed(2)
+const afterTurnMs = (measure(validateDirect, inherited) * TURN_EVENTS).toFixed(2)
+console.log(
+  `\nOne 200 KB tool result, inherited across ${TURN_EVENTS} later events in the same turn:` +
+    `\n  round trip ${beforeTurnMs} ms total   direct ${afterTurnMs} ms total`
+)
+console.log(
+  '\nThe direct path is flat because the field normalizer stops at the cap; the\nround trip is linear in the raw payload, which is bounded only by the 1 MB\nhook request limit.'
+)

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -20,7 +20,6 @@ import { isAbsolute, join } from 'node:path'
 import {
   AGENT_MODEL_MAX_LENGTH,
   normalizeAgentStatusPayload,
-  parseAgentStatusPayload,
   type AgentStatusState,
   type AgentSubagentSnapshot,
   type ParsedAgentStatusPayload
@@ -2684,20 +2683,18 @@ function normalizeDevinEvent(
   const interrupted =
     eventName === 'Stop' && hookPayload['is_interrupt'] === true ? true : undefined
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent('devin', eventName)
-      }),
-      agentType: 'devin',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage,
-      interrupted
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, promptText, {
+      resetOnNewTurn: isNewTurnEvent('devin', eventName)
+    }),
+    agentType: 'devin',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage,
+    interrupted
+  })
 }
 
 // Why: Kimi's auto-allowed AskUserQuestion emits PreToolUse (not PermissionRequest) while awaiting an answer; treat as waiting so the UI shows the attention icon, not a spinner.
@@ -2744,19 +2741,17 @@ function normalizeKimiEvent(
   const interrupted =
     eventName === 'Stop' && hookPayload['is_interrupt'] === true ? true : undefined
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent('kimi', eventName)
-      }),
-      agentType: 'kimi',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      lastAssistantMessage: snapshot.lastAssistantMessage,
-      interrupted
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, promptText, {
+      resetOnNewTurn: isNewTurnEvent('kimi', eventName)
+    }),
+    agentType: 'kimi',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    lastAssistantMessage: snapshot.lastAssistantMessage,
+    interrupted
+  })
 }
 
 function normalizeGeminiEvent(
@@ -2789,19 +2784,17 @@ function normalizeGeminiEvent(
     { resetOnNewTurn: isNewTurnEvent('gemini', eventName) }
   )
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent('gemini', eventName)
-      }),
-      agentType: 'gemini',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, promptText, {
+      resetOnNewTurn: isNewTurnEvent('gemini', eventName)
+    }),
+    agentType: 'gemini',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
 }
 
 function isAntigravityFeedbackTool(toolName: string | undefined): boolean {
@@ -2863,19 +2856,17 @@ function normalizeAntigravityEvent(
     { resetOnNewTurn: resetsTurn }
   )
 
-  const payload = parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, effectivePrompt, {
-        resetOnNewTurn: resetsTurn
-      }),
-      agentType: 'antigravity',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  const payload = normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, effectivePrompt, {
+      resetOnNewTurn: resetsTurn
+    }),
+    agentType: 'antigravity',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
   // Why: Antigravity can emit Stop with fullyIdle=false between tool steps; only a fully idle Stop is terminal, else the sidebar bounces done -> working and ignores later tool updates.
   if (eventName === 'Stop' && !stopStillBusy && transcriptPath) {
     state.antigravityCompletedTranscriptByPaneKey.set(paneKey, transcriptPath)
@@ -2941,21 +2932,19 @@ function normalizeAmpEvent(
     (eventName === 'agent.end' && !state.lastPromptByPaneKey.has(ampCacheKey))
   const ampPromptText = explicitPrompt ?? (canUseMessageAsPrompt ? promptText : '')
 
-  const normalized = parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      // Why: Amp tool/result events may use `message` for tool output; only lifecycle events may treat it as the turn prompt.
-      prompt: resolvePrompt(state, ampCacheKey, ampPromptText, {
-        resetOnNewTurn: isNewTurnEvent('amp', eventName)
-      }),
-      agentType: 'amp',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage,
-      interrupted
-    })
-  )
+  const normalized = normalizeAgentStatusPayload({
+    state: stateName,
+    // Why: Amp tool/result events may use `message` for tool output; only lifecycle events may treat it as the turn prompt.
+    prompt: resolvePrompt(state, ampCacheKey, ampPromptText, {
+      resetOnNewTurn: isNewTurnEvent('amp', eventName)
+    }),
+    agentType: 'amp',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage,
+    interrupted
+  })
   if (normalized && eventName === 'agent.end') {
     state.ampCompletedCacheKeys.add(ampCacheKey)
   }
@@ -3335,19 +3324,17 @@ function normalizeOpenCodeFamilyEvent(
     { resetOnNewTurn: isNewTurnEvent(source, eventName) }
   )
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent(source, eventName)
-      }),
-      agentType: source,
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, promptText, {
+      resetOnNewTurn: isNewTurnEvent(source, eventName)
+    }),
+    agentType: source,
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
 }
 
 function normalizeCursorEvent(
@@ -3395,20 +3382,18 @@ function normalizeCursorEvent(
       ? true
       : undefined
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent('cursor', eventName)
-      }),
-      agentType: 'cursor',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage,
-      interrupted
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, promptText, {
+      resetOnNewTurn: isNewTurnEvent('cursor', eventName)
+    }),
+    agentType: 'cursor',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage,
+    interrupted
+  })
 }
 
 // Why: Copilot PermissionRequest fires before allow/ask/deny (stays working); ask_user and notification prompts are the real blocked signals.
@@ -3458,19 +3443,17 @@ function normalizeCopilotEvent(
 
   const effectivePrompt = normalizedEventName === 'Notification' ? '' : promptText
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, effectivePrompt, {
-        resetOnNewTurn: isNewTurnEvent('copilot', normalizedEventName)
-      }),
-      agentType: 'copilot',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, effectivePrompt, {
+      resetOnNewTurn: isNewTurnEvent('copilot', normalizedEventName)
+    }),
+    agentType: 'copilot',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
 }
 
 function normalizePiCompatibleEvent(
@@ -3517,19 +3500,17 @@ function normalizePiCompatibleEvent(
     { resetOnNewTurn: isNewTurnEvent(agentType, eventName) }
   )
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent(agentType, eventName)
-      }),
-      agentType,
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, promptText, {
+      resetOnNewTurn: isNewTurnEvent(agentType, eventName)
+    }),
+    agentType,
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
 }
 
 function normalizeDroidEvent(
@@ -3584,19 +3565,17 @@ function normalizeDroidEvent(
   // Why: Droid Notification.message is status text, not the prompt; '' keeps resolvePrompt's cached UserPromptSubmit value.
   const effectivePrompt = eventName === 'Notification' ? '' : promptText
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, effectivePrompt, {
-        resetOnNewTurn: isNewTurnEvent('droid', eventName)
-      }),
-      agentType: 'droid',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, effectivePrompt, {
+      resetOnNewTurn: isNewTurnEvent('droid', eventName)
+    }),
+    agentType: 'droid',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
 }
 
 function normalizeCommandCodeEvent(
@@ -3623,19 +3602,17 @@ function normalizeCommandCodeEvent(
     { resetOnNewTurn: isNewTurnEvent('command-code', eventName) }
   )
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent('command-code', eventName)
-      }),
-      agentType: 'command-code',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, promptText, {
+      resetOnNewTurn: isNewTurnEvent('command-code', eventName)
+    }),
+    agentType: 'command-code',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
 }
 
 function normalizeGrokEvent(
@@ -3709,19 +3686,17 @@ function normalizeGrokEvent(
     ? ''
     : stripGrokUserQueryWrapper(promptText)
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, effectivePrompt, {
-        resetOnNewTurn: isNewTurnEvent('grok', eventName)
-      }),
-      agentType: 'grok',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, effectivePrompt, {
+      resetOnNewTurn: isNewTurnEvent('grok', eventName)
+    }),
+    agentType: 'grok',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
 }
 
 function normalizeHermesEvent(
@@ -3758,19 +3733,17 @@ function normalizeHermesEvent(
     { resetOnNewTurn: isNewTurnEvent('hermes', eventName) }
   )
 
-  return parseAgentStatusPayload(
-    JSON.stringify({
-      state: stateName,
-      prompt: resolvePrompt(state, paneKey, promptText, {
-        resetOnNewTurn: isNewTurnEvent('hermes', eventName)
-      }),
-      agentType: 'hermes',
-      toolName: snapshot.toolName,
-      toolInput: snapshot.toolInput,
-      interactivePrompt: snapshot.interactivePrompt,
-      lastAssistantMessage: snapshot.lastAssistantMessage
-    })
-  )
+  return normalizeAgentStatusPayload({
+    state: stateName,
+    prompt: resolvePrompt(state, paneKey, promptText, {
+      resetOnNewTurn: isNewTurnEvent('hermes', eventName)
+    }),
+    agentType: 'hermes',
+    toolName: snapshot.toolName,
+    toolInput: snapshot.toolInput,
+    interactivePrompt: snapshot.interactivePrompt,
+    lastAssistantMessage: snapshot.lastAssistantMessage
+  })
 }
 
 function readStringField(record: Record<string, unknown>, key: string): string | undefined {

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -509,3 +509,77 @@ describe('agentSubagentsEqual', () => {
     expect(agentSubagentsEqual([snapshot], [snapshot, { ...snapshot, id: 'b' }])).toBe(false)
   })
 })
+
+// Why: the per-source hook normalizers construct these literals and validate them
+// directly. This pins that the direct path stays identical to the JSON round trip
+// they used to take, including where stringify would have altered the payload.
+describe('normalizeAgentStatusPayload matches the JSON round trip', () => {
+  const CASES: Record<string, unknown>[] = [
+    { state: 'working', prompt: 'p', agentType: 'grok', toolName: 'sh', toolInput: 'ls' },
+    { state: 'done', prompt: '', agentType: 'devin', interrupted: true },
+    // stringify DROPS undefined-valued keys; the direct path passes them through
+    {
+      state: 'working',
+      prompt: 'p',
+      agentType: 'cursor',
+      toolName: undefined,
+      toolInput: undefined,
+      interactivePrompt: undefined,
+      lastAssistantMessage: undefined,
+      interrupted: undefined
+    },
+    // raw JSON inside a field exercises the structure scanner's in-string path
+    {
+      state: 'working',
+      prompt: 'p',
+      agentType: 'copilot',
+      interactivePrompt: JSON.stringify({ q: 'pick {one}', options: ['a', 'b'] })
+    },
+    {
+      state: 'working',
+      prompt: 'a\r\nb c',
+      agentType: 'gemini',
+      lastAssistantMessage: 'emoji \u{1f389} \u65e5\u672c\u8a9e\r\n\r\n\r\nmulti'
+    },
+    { state: 'working', prompt: 'p', agentType: 'amp', lastAssistantMessage: 'x'.repeat(50_000) },
+    { state: 'done', prompt: 'p', agentType: 'hermes', toolName: '', toolInput: '' },
+    {
+      state: 'working',
+      prompt: 'p',
+      agentType: 'droid',
+      toolInput: '{"nested":{"deep":{"deeper":[1,2,3]}}}'
+    },
+    {
+      state: 'working',
+      prompt: 'p',
+      agentType: 'kimi',
+      lastAssistantMessage: '"escaped" quotes and \\ backslashes'
+    },
+    { state: 'working', prompt: 'p', agentType: 'opencode' },
+    { state: 'done', prompt: 'p', agentType: 'antigravity', interrupted: false },
+    { state: 'working', prompt: 'p', agentType: 'pi', toolName: 'x'.repeat(9000) },
+    { state: 'working', prompt: 'x'.repeat(9000), agentType: 'omp' },
+    {
+      state: 'working',
+      prompt: 'p',
+      agentType: 'command-code',
+      lastAssistantMessage: 'tail with \u001b[0m escape codes'
+    },
+    // a lone surrogate is the case where stringify and a raw read could diverge
+    { state: 'working', prompt: 'p', agentType: 'grok', lastAssistantMessage: 'lone \ud800 pair' }
+  ]
+
+  it('produces identical output for every normalizer literal shape', () => {
+    for (const [index, payload] of CASES.entries()) {
+      expect({
+        index,
+        agent: payload.agentType,
+        value: normalizeAgentStatusPayload(payload)
+      }).toEqual({
+        index,
+        agent: payload.agentType,
+        value: parseAgentStatusPayload(JSON.stringify(payload))
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

13 of the 15 per-source hook normalizers in `agent-hook-listener.ts` built a plain object, `JSON.stringify`'d it, and handed the string to `parseAgentStatusPayload` — which runs `assertJsonTextStructureWithinLimits` (a per-character scan of the **whole** serialized string) plus `JSON.parse`, only to reach the same `normalizeAgentStatusObject` the object path calls directly.

Claude and Codex were already converted, with a comment in this file calling the round trip *"pure overhead on this hot per-hook path"*. This applies that same change to the remaining 13.

## ELI5

Every time an agent runs a tool, it reports status to Orca. Orca has to check that report is well-formed before using it.

Orca already had the report as a normal object in memory. But for 13 of the 15 agents it would **write the object out to text, read every character of that text to check its shape, then parse it back into an object** — and then run the same validation it would have run on the object it started with. Two of the 15 agents had already been fixed to skip the detour.

Now all 15 skip it. Same checks, same result, without the round trip.

## Screenshots

No visual change.

## Proof of performance improvement

`node config/scripts/agent-hook-normalizer-roundtrip-benchmark.mjs` (new):

```
field cap=8000 iterations=400 warmup=200 (median of 5 rounds)
  payload   round trip     direct   speedup
     4 KB      27.3 us    14.8 us      1.8x
    16 KB      72.4 us    28.2 us      2.6x
    64 KB     204.3 us    28.2 us      7.2x
   256 KB     773.6 us    25.5 us     30.3x

One 200 KB tool result, inherited across 20 later events in the same turn:
  round trip 11.67 ms total   direct 0.51 ms total
```

Why the gap widens: the direct path's field normalizer stops consuming at the field cap (`normalized.length < maxLength`), so it is **O(cap) — flat**. The round trip is **O(raw input)**, and that input is bounded only by the 1 MB hook request limit, since tool-response text is passed through uncapped for most sources.

**The turn-amplification row is the real story.** `resolveToolState` stores the raw value in `lastToolByPaneKey` and inherits it until a turn reset, so one large tool result was re-serialized and re-scanned on *every subsequent event of that turn*. `PreToolUse`/`PostToolUse` fire once per tool call, synchronously on the main-process HTTP handler and the relay handler, with no throttle or dedupe.

I verified this independently through the real exported functions before implementing: round-trip 32 → 778 µs across 4 KB → 256 KB, direct flat at ~40 µs.

## Proof of zero regression

Pure refactor — identical output required for every payload the normalizers can build. The subtle part is that `JSON.stringify` is **not** an identity transform: it drops `undefined`-valued keys, and it escapes lone surrogates. So "obviously equivalent" isn't good enough.

Added a table-driven equivalence suite (`agent-status-types.test.ts`) asserting `normalizeAgentStatusPayload(x)` deep-equals `parseAgentStatusPayload(JSON.stringify(x))` across 15 shapes, chosen for the cases where the round trip could have been doing real work:

- **all-`undefined` optional keys** — stringify drops them; the direct path passes them through to the same `typeof` guards
- **`interactivePrompt` holding raw JSON** — exercises the structure scanner's `inString` state, where braces inside a string must not count as structural tokens
- **lone surrogate** in a message — the one case where stringify and a raw read could genuinely diverge
- CRLF / U+2028 / blank-line runs, 50 KB over-cap messages, over-length `toolName`/`prompt`, empty strings, deep nested JSON in `toolInput`

Why this is safe by construction: the 4096-token / depth-16 structural cap cannot trip on a flat ~8-key literal (~19 structural tokens at depth 1), and nothing in `agent-status-field-normalization.ts` throws, so `parseAgentStatusPayload`'s `try`/`catch` was dead code on this path.

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — **2 failures / 36,762**, both pre-existing (see below)
- [x] 598 tests pass across `agent-hook-listener`, roster-retention, subagent-lifecycle, `src/main/agent-hooks/**`, and `src/relay/agent-hook-server`
- [x] Added tests that would catch regressions

The benchmark's equivalence guard is non-vacuous — I confirmed it throws when `validateDirect` is deliberately broken.

### Pre-existing test failures

`pnpm test` is already red on `main`. This branch's full run shows **only** `agent-exec-handler.test.ts` ×2, which assert against the machine's real `process.env`. That is a strict subset of the baseline pool, and neither imports the changed code. Across five full-suite runs in this series, two consecutive runs on *unmodified* `main` produced different failure sets — which is what establishes the pool as pre-existing rather than change-induced.

## Review loop count + verdict

**2 review loops: independent equivalence verification and final risk review. Final verdict: ship.**

This is the 4th PR in a series (#10741, #10742, #10743). It was found by the discovery pass and verified independently before implementation. The transform is mechanical and was applied by script rather than by hand — 13 sites, uniform shape — then checked by typecheck (which flagged the now-unused import), the equivalence suite, and 598 existing tests.

Reviewer attention is most useful on the **equivalence table**: if there is a payload shape the 13 normalizers can produce that isn't represented there, that's the gap worth finding.

## AI Review Report

Main risks reviewed:

- **`JSON.stringify` semantics that the direct path skips** — undefined-key dropping and surrogate escaping, both covered above with explicit test cases rather than reasoning.
- **Structural-limit enforcement loss.** These payloads are self-constructed from validated fields, not untrusted text. `parseAgentStatusPayload` remains exported and unchanged for the genuinely untrusted boundaries — `parseAgentHookJson` for HTTP request bodies and the OSC 9999 path in `agent-status-osc.ts`. Neither is touched.
- **Per-source coverage.** Coverage for droid/cursor/gemini/opencode was thin, which is why the equivalence table is table-driven across every converted source rather than spot-checking a few.

Cross-platform: no path, shell, keyboard, or platform-dependent behavior touched. Identical on macOS/Linux/Windows and across local, SSH, WSL, and relay hook paths — the change is confined to in-process object validation.

## Security Audit

This **removes** a validation step, so it deserves a direct answer: the structural cap exists to bound adversarial *text*, and it is retained at every boundary where untrusted text enters (`parseAgentHookJson` on request bodies, capped by `HOOK_REQUEST_MAX_BYTES`; the OSC path). What this PR removes is the cap being re-applied to a string Orca itself had just serialized from already-extracted fields — where it could not fail, since a flat ~8-key literal produces ~19 structural tokens against a 4096 limit.

Field-length clamping, surrogate-safe truncation, and state/agent-type validation all still run — they live in `normalizeAgentStatusObject`, which both paths reach. No new input handling, command execution, path handling, auth, secrets, or IPC surface. No dependency changes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
