### PR TITLE
fix(folder-workspace): show nested registered repos

### DIFF
--- a/src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.tsx
@@ -46,6 +46,7 @@ export default function FolderWorkspacePrChecksPanel({
         activeWorkspaceKey,
         activeWorktreeId,
         folderWorkspaces,
+        repos,
         workspaceLineageByChildKey,
         worktreeLineageById,
         worktreesByRepo
@@ -54,6 +55,7 @@ export default function FolderWorkspacePrChecksPanel({
       activeWorkspaceKey,
       activeWorktreeId,
       folderWorkspaces,
+      repos,
       workspaceLineageByChildKey,
       worktreeLineageById,
       worktreesByRepo

--- a/src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.tsx
@@ -33,6 +33,7 @@ export default function FolderWorkspaceWorktreesPanel(): React.JSX.Element {
       activeWorkspaceKey,
       activeWorktreeId,
       folderWorkspaces,
+      repos,
       workspaceLineageByChildKey,
       worktreeLineageById,
       worktreesByRepo

--- a/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts
+++ b/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type {
   FolderWorkspace,
+  Repo,
   Worktree,
   WorktreeLineage,
   WorkspaceLineage
@@ -24,6 +25,18 @@ function makeFolder(id = 'folder-1'): FolderWorkspace {
     lastActivityAt: 0,
     createdAt: 0,
     updatedAt: 0
+  }
+}
+
+function makeRepo(overrides: Partial<Repo> & { id: string }): Repo {
+  const { id, ...rest } = overrides
+  return {
+    id,
+    path: `/repos/${id}`,
+    displayName: id,
+    badgeColor: '#fff',
+    addedAt: 1,
+    ...rest
   }
 }
 
@@ -97,6 +110,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       activeWorkspaceKey: folderWorkspaceKey('folder-1'),
       activeWorktreeId: null,
       folderWorkspaces: [makeFolder()],
+      repos: [],
       workspaceLineageByChildKey: {
         [alpha.id]: makeWorkspaceLineage(alpha),
         [beta.id]: makeWorkspaceLineage(beta),
@@ -128,6 +142,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       activeWorkspaceKey: folderWorkspaceKey('folder-1'),
       activeWorktreeId: null,
       folderWorkspaces: [makeFolder()],
+      repos: [],
       workspaceLineageByChildKey: {
         [visible.id]: makeWorkspaceLineage(visible),
         [archived.id]: makeWorkspaceLineage(archived),
@@ -157,6 +172,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       activeWorkspaceKey: folderWorkspaceKey('folder-1'),
       activeWorktreeId: null,
       folderWorkspaces: [makeFolder()],
+      repos: [],
       workspaceLineageByChildKey: { [parent.id]: makeWorkspaceLineage(parent) },
       worktreeLineageById: { [nested.id]: makeWorktreeLineage(nested, parent) },
       worktreesByRepo: { 'repo-1': [parent, nested] }
@@ -186,6 +202,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       activeWorkspaceKey: folderWorkspaceKey('folder-1'),
       activeWorktreeId: null,
       folderWorkspaces: [makeFolder()],
+      repos: [],
       workspaceLineageByChildKey: { [parent.id]: makeWorkspaceLineage(parent) },
       worktreeLineageById: {},
       worktreesByRepo: { 'repo-1': [parent, inlineNested] }
@@ -208,6 +225,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       activeWorkspaceKey: folderWorkspaceKey('folder-1'),
       activeWorktreeId: null,
       folderWorkspaces: [makeFolder()],
+      repos: [],
       workspaceLineageByChildKey: { [parent.id]: makeWorkspaceLineage(parent) },
       worktreeLineageById: {
         [nested.id]: {
@@ -243,6 +261,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       activeWorkspaceKey: folderWorkspaceKey('folder-1'),
       activeWorktreeId: null,
       folderWorkspaces: [makeFolder()],
+      repos: [],
       workspaceLineageByChildKey: { [parent.id]: makeWorkspaceLineage(parent) },
       worktreeLineageById: {
         [hostChild.id]: makeWorktreeLineage(hostChild, parent),
@@ -262,6 +281,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       activeWorkspaceKey: folderWorkspaceKey('folder-1'),
       activeWorktreeId: null,
       folderWorkspaces: [makeFolder()],
+      repos: [],
       workspaceLineageByChildKey: { [parent.id]: makeWorkspaceLineage(parent) },
       worktreeLineageById: {
         [parent.id]: makeWorktreeLineage(parent, nested),
@@ -272,5 +292,95 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
 
     expect(result.lineageChildrenByParentId.size).toBe(0)
     expect(result.rootChildWorktrees.map((worktree) => worktree.id)).toEqual([parent.id])
+  })
+
+  it('includes registered git repo worktrees nested under the active folder workspace', () => {
+    const nestedRepo = makeRepo({
+      id: 'repo-nested',
+      path: '/folder/gok-ai-handoff',
+      displayName: 'gok-ai-handoff',
+      kind: 'git'
+    })
+    const siblingNamedPrefix = makeRepo({
+      id: 'repo-prefix',
+      path: '/folder-tools/gok-ai-handoff',
+      displayName: 'prefix',
+      kind: 'git'
+    })
+    const folderRepo = makeRepo({
+      id: 'repo-folder',
+      path: '/folder/group',
+      displayName: 'group',
+      kind: 'folder'
+    })
+    const nestedWorktree = makeWorktree({
+      id: 'repo-nested::/folder/gok-ai-handoff',
+      repoId: nestedRepo.id,
+      path: nestedRepo.path,
+      displayName: 'gok-ai-handoff',
+      lastActivityAt: 20
+    })
+    const existingLineage = makeWorktree({
+      id: 'repo-1::/attached',
+      displayName: 'attached',
+      lastActivityAt: 10
+    })
+    const prefixWorktree = makeWorktree({
+      id: 'repo-prefix::/folder-tools/gok-ai-handoff',
+      repoId: siblingNamedPrefix.id,
+      path: siblingNamedPrefix.path
+    })
+    const folderRepoWorktree = makeWorktree({
+      id: 'repo-folder::/folder/group',
+      repoId: folderRepo.id,
+      path: folderRepo.path
+    })
+
+    const result = getAttachedWorktreesForFolderWorkspace({
+      activeWorkspaceKey: folderWorkspaceKey('folder-1'),
+      activeWorktreeId: null,
+      folderWorkspaces: [makeFolder()],
+      repos: [nestedRepo, siblingNamedPrefix, folderRepo],
+      workspaceLineageByChildKey: { [existingLineage.id]: makeWorkspaceLineage(existingLineage) },
+      worktreeLineageById: {},
+      worktreesByRepo: {
+        'repo-1': [existingLineage],
+        [nestedRepo.id]: [nestedWorktree],
+        [siblingNamedPrefix.id]: [prefixWorktree],
+        [folderRepo.id]: [folderRepoWorktree]
+      }
+    })
+
+    expect(result.childWorktrees.map((worktree) => worktree.id)).toEqual([
+      nestedWorktree.id,
+      existingLineage.id
+    ])
+  })
+
+  it('does not include nested repo worktrees from another folder workspace connection', () => {
+    const nestedRepo = makeRepo({
+      id: 'repo-ssh',
+      path: '/folder/remote-repo',
+      displayName: 'remote-repo',
+      kind: 'git',
+      connectionId: 'ssh-1'
+    })
+    const nestedWorktree = makeWorktree({
+      id: 'repo-ssh::/folder/remote-repo',
+      repoId: nestedRepo.id,
+      path: nestedRepo.path
+    })
+
+    const result = getAttachedWorktreesForFolderWorkspace({
+      activeWorkspaceKey: folderWorkspaceKey('folder-1'),
+      activeWorktreeId: null,
+      folderWorkspaces: [makeFolder()],
+      repos: [nestedRepo],
+      workspaceLineageByChildKey: {},
+      worktreeLineageById: {},
+      worktreesByRepo: { [nestedRepo.id]: [nestedWorktree] }
+    })
+
+    expect(result.childWorktrees).toEqual([])
   })
 })

--- a/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.ts
+++ b/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.ts
@@ -1,12 +1,17 @@
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import type {
   FolderWorkspace,
+  Repo,
   Worktree,
   WorktreeLineage,
   WorkspaceLineage
 } from '../../../../shared/types'
 import { compareWorktreeDisplayName } from '@/lib/worktree-display-name-order'
 import { getProjectedWorktreeLineageChildrenByParentId } from '../sidebar/worktree-lineage-projection'
+import {
+  isPathInsideOrEqual,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
 
 export type AttachedWorktreeResolution = {
   folderWorkspace: FolderWorkspace | null
@@ -19,6 +24,7 @@ type AttachedWorktreeResolverArgs = {
   activeWorkspaceKey: string | null
   activeWorktreeId: string | null
   folderWorkspaces: readonly FolderWorkspace[]
+  repos: readonly Repo[]
   workspaceLineageByChildKey: Record<string, WorkspaceLineage>
   worktreeLineageById: Record<string, WorktreeLineage>
   worktreesByRepo: Record<string, readonly Worktree[]>
@@ -32,6 +38,7 @@ export function getAttachedWorktreesForFolderWorkspace({
   activeWorkspaceKey,
   activeWorktreeId,
   folderWorkspaces,
+  repos,
   workspaceLineageByChildKey,
   worktreeLineageById,
   worktreesByRepo
@@ -54,11 +61,15 @@ export function getAttachedWorktreesForFolderWorkspace({
 
   const folderKey = folderWorkspaceKey(folderWorkspace.id)
   const worktreeById = getWorktreeById(worktreesByRepo)
-  const childWorktrees = Object.values(workspaceLineageByChildKey)
+  const lineageChildWorktrees = Object.values(workspaceLineageByChildKey)
     .filter((lineage) => lineage.parentWorkspaceKey === folderKey)
     .map((lineage) => getLineageChildWorktree(lineage, worktreeById))
     .filter((worktree): worktree is Worktree => worktree !== null)
-    .sort(sortWorktreesByRecentActivity)
+
+  const childWorktrees = mergeUniqueWorktrees([
+    ...lineageChildWorktrees,
+    ...getNestedRegisteredRepoWorktrees(folderWorkspace, repos, worktreesByRepo)
+  ]).sort(sortWorktreesByRecentActivity)
 
   const childWorktreeIds = new Set(childWorktrees.map((worktree) => worktree.id))
   const lineageChildrenByParentId = getLineageChildrenByParentId(
@@ -84,6 +95,42 @@ export function getAttachedWorktreesForFolderWorkspace({
     lineageChildrenByParentId,
     rootChildWorktrees
   }
+}
+
+function getNestedRegisteredRepoWorktrees(
+  folderWorkspace: FolderWorkspace,
+  repos: readonly Repo[],
+  worktreesByRepo: Record<string, readonly Worktree[]>
+): Worktree[] {
+  return repos
+    .filter((repo) => repo.kind !== 'folder')
+    .filter((repo) => sameConnection(repo.connectionId, folderWorkspace.connectionId))
+    .filter((repo) => isNestedPath(folderWorkspace.folderPath, repo.path))
+    .flatMap((repo) =>
+      (worktreesByRepo[repo.id] ?? []).filter(
+        (worktree) =>
+          !worktree.isArchived && isNestedPath(folderWorkspace.folderPath, worktree.path)
+      )
+    )
+}
+
+function mergeUniqueWorktrees(worktrees: readonly Worktree[]): Worktree[] {
+  return [...new Map(worktrees.map((worktree) => [worktree.id, worktree])).values()]
+}
+
+function sameConnection(
+  left: string | null | undefined,
+  right: string | null | undefined
+): boolean {
+  return (left ?? null) === (right ?? null)
+}
+
+function isNestedPath(rootPath: string, candidatePath: string): boolean {
+  return (
+    normalizeRuntimePathForComparison(rootPath) !==
+      normalizeRuntimePathForComparison(candidatePath) &&
+    isPathInsideOrEqual(rootPath, candidatePath)
+  )
 }
 
 export function getLineageChildrenByParentId(


### PR DESCRIPTION
## Summary
- include already-registered Git repo worktrees when their paths live under the active folder workspace
- keep folder repos, sibling path prefixes, archived worktrees, and different connection IDs out of the folder workspace attached list
- pass repo state through the folder workspace worktrees and PR checks panels so both surfaces use the same resolution

## Why
A folder workspace can be a non-Git parent directory that contains multiple registered Git repositories. Those nested repos were invisible in the folder workspace worktree/PR-check surfaces unless they were created through folder-workspace lineage. This makes existing registered nested repos visible without changing the nested repo import flow.

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.test.tsx
- pnpm run typecheck:web
- pnpm exec oxfmt --check src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.ts src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.tsx src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.tsx
- pnpm exec oxlint src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.ts src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts src/renderer/src/components/right-sidebar/FolderWorkspaceWorktreesPanel.tsx src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.tsx

Note: dependencies were linked with pnpm install --frozen-lockfile --ignore-scripts for this renderer-only validation.

## ELI5

Folder workspaces that contain nested registered git repos no longer hide those repos. You see and work with nested projects under the folder workspace instead of missing them.
