### PR TITLE
feat(terminal): make the contrast floor user-configurable (#10754)

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -9,6 +9,7 @@ import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-ki
 import { replayPreviewConnectionSnapshot } from './preview-terminal-snapshot-replay'
 import { useEffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/use-effective-mac-option-as-alt'
 import {
+  applyPreviewMinimumContrastRatio,
   buildPreviewAppearanceOptions,
   buildPreviewTerminalOptions
 } from './preview-terminal-options'
@@ -431,8 +432,9 @@ export function AgentTerminalPreview({
       terminal.options,
       buildPreviewAppearanceOptions(settings, macOptionAsAlt === 'true')
     )
+    applyPreviewMinimumContrastRatio(terminal.options, settings, terminalTheme, terminalMode)
     syncPreviewTerminalLigatures(terminal, settings)
-  }, [settings, macOptionAsAlt])
+  }, [settings, macOptionAsAlt, terminalTheme, terminalMode])
 
   return (
     // Why: a size FIXED by the viewport (not shrink-to-fit) + overflow-hidden

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.test.ts
@@ -16,7 +16,8 @@ const SETTINGS = {
   terminalCursorBlink: false,
   terminalLineHeight: 1.4,
   terminalWordSeparator: ' ()[]',
-  terminalScrollSensitivity: 3
+  terminalScrollSensitivity: 3,
+  terminalMinimumContrastRatio: 7
 } as unknown as GlobalSettings
 
 describe('buildPreviewAppearanceOptions', () => {
@@ -72,6 +73,7 @@ describe('buildPreviewTerminalOptions', () => {
     expect(options.vtExtensions?.kittyKeyboard).toBe(true)
     expect(options.windowsPty).toBeUndefined()
     expect(options.cols).toBe(100)
+    expect(options.minimumContrastRatio).toBe(7)
   })
 
   it('mirrors the ConPTY backend and kitty withhold a local Windows pane resolves', () => {

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-options.ts
@@ -13,6 +13,22 @@ import { buildLocalConptyTerminalOptions } from '@/lib/pane-manager/windows-pty-
 import { buildFontFamily } from '@/components/terminal-pane/layout-serialization'
 import { resolveTerminalMinimumContrastRatio } from '@/lib/terminal-contrast-correction'
 
+export function applyPreviewMinimumContrastRatio(
+  options: ITerminalOptions,
+  settings: GlobalSettings | null,
+  theme: ITheme | null,
+  themeMode: 'dark' | 'light'
+): void {
+  const minimumContrastRatio = resolveTerminalMinimumContrastRatio(
+    theme?.background,
+    themeMode,
+    settings?.terminalMinimumContrastRatio
+  )
+  if (options.minimumContrastRatio !== minimumContrastRatio) {
+    options.minimumContrastRatio = minimumContrastRatio
+  }
+}
+
 /** Options a live settings change can write onto an open preview terminal. */
 export function buildPreviewAppearanceOptions(
   settings: GlobalSettings | null,
@@ -80,7 +96,8 @@ export function buildPreviewTerminalOptions(args: {
     theme: args.theme ?? undefined,
     minimumContrastRatio: resolveTerminalMinimumContrastRatio(
       args.theme?.background,
-      args.themeMode
+      args.themeMode,
+      args.settings?.terminalMinimumContrastRatio
     )
   }
 }

--- a/src/renderer/src/components/settings/SettingsFormControls.number-field.test.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.number-field.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NumberField } from './SettingsFormControls'
+
+afterEach(cleanup)
+
+describe('NumberField optional value', () => {
+  it('shows the automatic placeholder and resets when the input is cleared', () => {
+    const onReset = vi.fn()
+    const { rerender } = render(
+      <NumberField
+        label="Minimum Contrast"
+        description="Contrast floor"
+        value={undefined}
+        min={1}
+        max={21}
+        placeholder="Automatic"
+        onChange={vi.fn()}
+        onReset={onReset}
+      />
+    )
+    const input = screen.getByRole('spinbutton') as HTMLInputElement
+    expect(input.placeholder).toBe('Automatic')
+    expect(input.value).toBe('')
+
+    rerender(
+      <NumberField
+        label="Minimum Contrast"
+        description="Contrast floor"
+        value={7}
+        min={1}
+        max={21}
+        placeholder="Automatic"
+        onChange={vi.fn()}
+        onReset={onReset}
+      />
+    )
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.blur(input)
+
+    expect(onReset).toHaveBeenCalledOnce()
+    expect(input.value).toBe('')
+  })
+})

--- a/src/renderer/src/components/settings/SettingsFormControls.tsx
+++ b/src/renderer/src/components/settings/SettingsFormControls.tsx
@@ -262,12 +262,14 @@ type ColorFieldProps = {
 type NumberFieldProps = {
   label: string
   description: string
-  value: number
+  value?: number
   defaultValue?: number
   min: number
   max: number
   step?: number
   onChange: (value: number) => void
+  onReset?: () => void
+  placeholder?: string
   suffix?: string
 }
 
@@ -313,6 +315,8 @@ export function NumberField({
   max,
   step = 1,
   onChange,
+  onReset,
+  placeholder,
   suffix
 }: NumberFieldProps): React.JSX.Element {
   const [draft, setDraft] = useState(Number.isFinite(value) ? String(value) : '')
@@ -327,7 +331,11 @@ export function NumberField({
   const commit = (): void => {
     const trimmed = draft.trim()
     if (trimmed === '') {
-      // Empty input — reset to current value rather than committing 0
+      if (onReset) {
+        onReset()
+        setDraft('')
+        return
+      }
       setDraft(Number.isFinite(value) ? String(value) : '')
       return
     }
@@ -364,6 +372,7 @@ export function NumberField({
             max={max}
             step={step}
             value={draft}
+            placeholder={placeholder}
             onChange={(e) => setDraft(e.target.value)}
             onBlur={commit}
             onKeyDown={(e) => {

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -206,7 +206,8 @@ export function TerminalSettingsPreview({
     // Why: share applyTerminalAppearance's gating helper (#7934) so the preview can't drift from live panes.
     terminal.options.minimumContrastRatio = resolveTerminalMinimumContrastRatio(
       composedTheme.background,
-      effectiveMode
+      effectiveMode,
+      settings.terminalMinimumContrastRatio
     )
     // Why: xterm renders an alpha-channel background opaque unless allowTransparency is set (matches applyTerminalAppearance).
     terminal.options.allowTransparency =
@@ -218,7 +219,12 @@ export function TerminalSettingsPreview({
     // Why reset() not clear(): buffer ends mid-line on the prompt, so clear()+write would duplicate the trailing fragment.
     terminal.reset()
     terminal.write(PREVIEW_BUFFER)
-  }, [composedTheme, effectiveMode, settings.terminalBackgroundOpacity])
+  }, [
+    composedTheme,
+    effectiveMode,
+    settings.terminalBackgroundOpacity,
+    settings.terminalMinimumContrastRatio
+  ])
 
   useEffect(() => {
     const terminal = terminalRef.current

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -7,6 +7,7 @@ import { Switch } from '../ui/switch'
 import { ColorField, NumberField } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
 import { clampNumber } from '@/lib/terminal-theme'
+import { MAX_CONTRAST_RATIO, MIN_CONTRAST_RATIO } from '@/lib/terminal-contrast-correction'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 
@@ -255,6 +256,48 @@ export function TerminalWindowSection({
                 terminalMouseHideWhileTyping: checked
               })
             }
+          />
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.TerminalWindowSection.1a23894d84',
+            'Minimum Contrast'
+          )}
+          description={translate(
+            'auto.components.settings.TerminalWindowSection.9f2eadb63a',
+            'Lift text that is too close to its background color.'
+          )}
+          keywords={['contrast', 'readability', 'legibility', 'wcag', 'color']}
+        >
+          <NumberField
+            label={translate(
+              'auto.components.settings.TerminalWindowSection.1a23894d84',
+              'Minimum Contrast'
+            )}
+            description={translate(
+              'auto.components.settings.TerminalWindowSection.926624a9ea',
+              'Set a fixed minimum contrast ratio between text and its background. Leave blank for automatic: 3 on dark backgrounds, 4.5 on light backgrounds. Set 1 to render the exact colors programs send.'
+            )}
+            value={settings.terminalMinimumContrastRatio}
+            min={MIN_CONTRAST_RATIO}
+            max={MAX_CONTRAST_RATIO}
+            step={0.5}
+            placeholder={translate(
+              'auto.components.settings.TerminalWindowSection.3d992f9745',
+              'Automatic'
+            )}
+            suffix="1–21"
+            onChange={(value) =>
+              updateSettings({
+                terminalMinimumContrastRatio: clampNumber(
+                  value,
+                  MIN_CONTRAST_RATIO,
+                  MAX_CONTRAST_RATIO
+                )
+              })
+            }
+            onReset={() => updateSettings({ terminalMinimumContrastRatio: undefined })}
           />
         </SearchableSetting>
 

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -13,6 +13,7 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalCursorStyle: 'Cursor Style',
   terminalCursorBlink: 'Cursor Blink',
   terminalCursorOpacity: 'Cursor Opacity',
+  terminalMinimumContrastRatio: 'Minimum Contrast',
   terminalMouseHideWhileTyping: 'Mouse Hide While Typing',
   terminalWordSeparator: 'Word Separator',
   primarySelectionMiddleClickPaste: 'Middle-click Paste from Selection',

--- a/src/renderer/src/components/settings/terminal-window-setup-search.ts
+++ b/src/renderer/src/components/settings/terminal-window-setup-search.ts
@@ -117,6 +117,26 @@ export const getTerminalWindowSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate('auto.components.settings.terminal.search.f89b96dc4e', 'Minimum Contrast'),
+    description: translate(
+      'auto.components.settings.terminal.search.2a6e5a18de',
+      'Lift text that is too close to its background color.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.terminal.search.a6dcfe179e', 'contrast'),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.2bb60a2cdd',
+        'readability'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.4fbdfcb1ae',
+        'legibility'
+      ),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.6e42c477dc', 'wcag'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.674b7c8436', 'color')
+    ]
+  },
+  {
     title: translate('auto.components.settings.terminal.search.aed2a4b4eb', 'Color Overrides'),
     description: translate(
       'auto.components.settings.terminal.search.3023e01415',

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -169,7 +169,8 @@ export function applyTerminalAppearance(
     // Why value-gated: writing minimumContrastRatio clears xterm's contrast cache, so skip on no-op re-applies.
     const minimumContrastRatio = resolveTerminalMinimumContrastRatio(
       theme?.background,
-      appearance.mode
+      appearance.mode,
+      settings.terminalMinimumContrastRatio
     )
     if (pane.terminal.options.minimumContrastRatio !== minimumContrastRatio) {
       pane.terminal.options.minimumContrastRatio = minimumContrastRatio

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8378,7 +8378,11 @@
           "cf37ff69f6": "Base",
           "8abdab9f7c": "Restart now",
           "907131d741": "Restarting…",
-          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved."
+          "605a35d600": "Not applied by the terminal renderer yet — xterm.js has no bold color slot. A saved value is preserved.",
+          "1a23894d84": "Minimum Contrast",
+          "9f2eadb63a": "Lift text that is too close to its background color.",
+          "926624a9ea": "Set a fixed minimum contrast ratio between text and its background. Leave blank for automatic: 3 on dark backgrounds, 4.5 on light backgrounds. Set 1 to render the exact colors programs send.",
+          "3d992f9745": "Automatic"
         },
         "UIZoomControl": {
           "c2c64b24d0": "Reset"
@@ -10009,7 +10013,13 @@
               "title": "Theme Mode",
               "keyword_target": "target",
               "keyword_editing": "editing"
-            }
+            },
+            "f89b96dc4e": "Minimum Contrast",
+            "2a6e5a18de": "Lift text that is too close to its background color.",
+            "a6dcfe179e": "contrast",
+            "2bb60a2cdd": "readability",
+            "4fbdfcb1ae": "legibility",
+            "6e42c477dc": "wcag"
           },
           "windows": {
             "search": {

--- a/src/renderer/src/lib/terminal-contrast-correction.test.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   DARK_BG_MIN_CONTRAST,
   LIGHT_BG_MIN_CONTRAST,
+  MAX_CONTRAST_RATIO,
+  MIN_CONTRAST_RATIO,
   resolveTerminalMinimumContrastRatio
 } from './terminal-contrast-correction'
 import { TERMINAL_THEME_CATALOG } from './terminal-themes'
@@ -39,6 +41,47 @@ describe('resolveTerminalMinimumContrastRatio', () => {
 
   it('treats an undefined/transparent background as dark', () => {
     expect(resolveTerminalMinimumContrastRatio(undefined, 'dark')).toBe(DARK_BG_MIN_CONTRAST)
+  })
+})
+
+// #10754: the floor rewrites foregrounds a TUI picked on purpose, so it has to be opt-out per user.
+describe('resolveTerminalMinimumContrastRatio override', () => {
+  it('honors an explicit override over the luminance-gated default', () => {
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', 1)).toBe(MIN_CONTRAST_RATIO)
+    expect(resolveTerminalMinimumContrastRatio('#ffffff', 'light', 7)).toBe(7)
+  })
+
+  it('clamps an out-of-range override into the accepted window', () => {
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', 0)).toBe(MIN_CONTRAST_RATIO)
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', -5)).toBe(MIN_CONTRAST_RATIO)
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', 99)).toBe(MAX_CONTRAST_RATIO)
+  })
+
+  it('falls back to the default when the override is absent or not a finite number', () => {
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', undefined)).toBe(
+      DARK_BG_MIN_CONTRAST
+    )
+    expect(resolveTerminalMinimumContrastRatio('#1e242a', 'dark', Number.NaN)).toBe(
+      DARK_BG_MIN_CONTRAST
+    )
+    expect(resolveTerminalMinimumContrastRatio('#ffffff', 'light', Number.NaN)).toBe(
+      LIGHT_BG_MIN_CONTRAST
+    )
+  })
+
+  // The reported case: a Powerline statusline draws the seam between two pills in the neighbouring
+  // segment's background (xterm 238 on 237, ~1.17:1) and dims secondary text (245 on 238, ~2.82:1).
+  // Both sit under the default floor, so xterm lifts them into a visible line and flattens the
+  // hierarchy. An override of 1 has to leave them alone.
+  it('exposes the opt-out floor for deliberately low-contrast Powerline colors', () => {
+    const DARK_BG = '#1e242a'
+    const seam = contrastRatio('#3a3a3a', '#444444') // xterm 237 vs 238
+    const secondaryText = contrastRatio('#444444', '#8a8a8a') // xterm 238 vs 245
+
+    expect(seam).toBeLessThan(resolveTerminalMinimumContrastRatio(DARK_BG, 'dark'))
+    expect(secondaryText).toBeLessThan(resolveTerminalMinimumContrastRatio(DARK_BG, 'dark'))
+
+    expect(resolveTerminalMinimumContrastRatio(DARK_BG, 'dark', 1)).toBe(MIN_CONTRAST_RATIO)
   })
 })
 

--- a/src/renderer/src/lib/terminal-contrast-correction.ts
+++ b/src/renderer/src/lib/terminal-contrast-correction.ts
@@ -11,12 +11,24 @@ import { isTerminalBackgroundLight } from '@/lib/terminal-title-contrast'
 export const LIGHT_BG_MIN_CONTRAST = 4.5
 export const DARK_BG_MIN_CONTRAST = 3
 
+// xterm treats 1 as "never correct"; 21 is the largest ratio that exists (black on white).
+export const MIN_CONTRAST_RATIO = 1
+export const MAX_CONTRAST_RATIO = 21
+
 // Why gate by background luminance, not app mode (#7934): either theme slot can hold either kind of
 // theme (match-dark-mode, or a light theme in the dark slot), so follow the composed background.
+// Why an override (#10754): the correction rewrites foregrounds a TUI chose deliberately. Powerline
+// statuslines draw the seam between two segments in the neighbouring background color (~1.2:1 by
+// design) and dim their secondary text below 3:1, so the floor turns invisible seams into bright
+// lines. Setting 1 opts out per user, matching VS Code's terminal.integrated.minimumContrastRatio.
 export function resolveTerminalMinimumContrastRatio(
   background: string | undefined,
-  appSurface: 'dark' | 'light'
+  appSurface: 'dark' | 'light',
+  override?: number
 ): number {
+  if (override !== undefined && Number.isFinite(override)) {
+    return Math.min(Math.max(override, MIN_CONTRAST_RATIO), MAX_CONTRAST_RATIO)
+  }
   return isTerminalBackgroundLight(background, { appSurface })
     ? LIGHT_BG_MIN_CONTRAST
     : DARK_BG_MIN_CONTRAST

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -147,6 +147,8 @@ export type GlobalSettings = {
   terminalMouseHideWhileTyping?: boolean
   terminalWordSeparator?: string
   terminalCursorOpacity?: number
+  /** xterm's foreground/background contrast floor; 1 disables correction. */
+  terminalMinimumContrastRatio?: number
   terminalQuickCommands?: TerminalQuickCommand[]
   windowBackgroundBlur?: boolean
   /** Windows-only: close (X) hides to tray instead of quitting; the tray icon is always present regardless. */

--- a/tests/e2e/terminal-minimum-contrast-setting.spec.ts
+++ b/tests/e2e/terminal-minimum-contrast-setting.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * E2E for #10754: the terminal contrast floor must be user-configurable.
+ *
+ * User Prompt:
+ * - a TUI's deliberately low-contrast colors (Powerline seams, dimmed secondary text) must be
+ *   renderable untouched, so the correction needs an opt-out that reaches every live pane
+ *
+ * Why compare renders instead of asserting one color: xterm applies the correction in the renderer,
+ * so the cell's SGR attributes keep reporting the original color whatever the floor does, and the
+ * painted value is shifted by DPR and the compositor's color management. Two renders of the same
+ * buffer under different floors are directly comparable though, so the test drives the setting to
+ * both ends of its range and asserts the pixels move, then come back. That also stays valid whether
+ * the harness runs a light or dark terminal theme, which decides the default floor.
+ */
+
+import { PNG } from 'pngjs'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  discoverActivePtyId,
+  execInTerminal,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { waitForSessionReady, ensureTerminalVisible } from './helpers/store'
+
+const PROBE_MARKER = 'CONTRAST_PROBE'
+// xterm 240 on 236 (1.97:1) and 245 on 238 (2.82:1): the two shapes the report is about, a Powerline
+// seam and dimmed secondary text. Solid blocks so each cell is a flat slab of the foreground color.
+const PROBE_COMMAND = [
+  `printf '${PROBE_MARKER} '`,
+  `printf '\\033[48;5;236m\\033[38;5;240m${'█'.repeat(24)}\\033[0m'`,
+  `printf '\\033[48;5;238m\\033[38;5;245m${'█'.repeat(24)}\\033[0m\\n'`
+].join(' && ')
+
+// Antialiasing and subpixel work leave small per-pixel jitter that is not a color change.
+const CHANNEL_TOLERANCE = 4
+
+type Box = { x: number; y: number; width: number; height: number }
+
+async function readTerminalScreenBox(page: Page): Promise<Box> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const screen = pane?.container.querySelector<HTMLElement>('.xterm-screen')
+    if (!screen) {
+      throw new Error('No active terminal pane to capture')
+    }
+    const rect = screen.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0) {
+      throw new Error('Active terminal screen is not visible for raster capture')
+    }
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+  })
+}
+
+/** The floor xterm is actually enforcing on the live pane, not the stored setting. */
+async function readAppliedContrastRatio(page: Page): Promise<number | undefined> {
+  return page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    return pane?.terminal?.options?.minimumContrastRatio
+  })
+}
+
+async function captureTerminal(page: Page, box: Box): Promise<PNG> {
+  return PNG.sync.read(await page.screenshot({ clip: box }))
+}
+
+function countChangedPixels(a: PNG, b: PNG): number {
+  if (a.data.length !== b.data.length) {
+    throw new Error('Captures differ in size; the pane was resized mid-test')
+  }
+  let changed = 0
+  for (let i = 0; i < a.data.length; i += 4) {
+    if (
+      Math.abs(a.data[i] - b.data[i]) > CHANNEL_TOLERANCE ||
+      Math.abs(a.data[i + 1] - b.data[i + 1]) > CHANNEL_TOLERANCE ||
+      Math.abs(a.data[i + 2] - b.data[i + 2]) > CHANNEL_TOLERANCE
+    ) {
+      changed += 1
+    }
+  }
+  return changed
+}
+
+async function setMinimumContrast(page: Page, value: number): Promise<void> {
+  await page.evaluate(async (ratio) => {
+    await window.__store?.getState().updateSettings({ terminalMinimumContrastRatio: ratio })
+  }, value)
+  await expect.poll(async () => readAppliedContrastRatio(page), { timeout: 10_000 }).toBe(value)
+}
+
+test.describe('terminal minimum contrast setting', () => {
+  test('drives the live pane floor and repaints low-contrast colors', async ({
+    orcaPage: page
+  }) => {
+    await waitForSessionReady(page)
+    await ensureTerminalVisible(page)
+    await waitForActiveTerminalManager(page)
+
+    // A blinking cursor would register as a pixel change unrelated to the floor.
+    await page.evaluate(async () => {
+      await window.__store?.getState().updateSettings({ terminalCursorBlink: false })
+    })
+
+    const ptyId = await discoverActivePtyId(page)
+    await execInTerminal(page, ptyId, PROBE_COMMAND)
+    await waitForTerminalOutput(page, PROBE_MARKER)
+
+    const box = await readTerminalScreenBox(page)
+
+    // 1 is the opt-out the report asks for: xterm performs no correction at all.
+    await setMinimumContrast(page, 1)
+    const uncorrected = await captureTerminal(page, box)
+
+    // 21 forces the strongest possible correction, so any pane still honoring the setting must
+    // visibly repaint the probe. This end of the range works on a light or dark theme alike.
+    await setMinimumContrast(page, 21)
+    const corrected = await captureTerminal(page, box)
+    expect(countChangedPixels(uncorrected, corrected)).toBeGreaterThan(500)
+
+    // Going back must restore the untouched colors, so the opt-out is not one-way and the value is
+    // re-read rather than latched. Repainting the existing buffer also proves the pane does not
+    // need a reprint or restart for the setting to take effect.
+    await setMinimumContrast(page, 1)
+    const restored = await captureTerminal(page, box)
+    expect(countChangedPixels(uncorrected, restored)).toBeLessThan(100)
+  })
+})


### PR DESCRIPTION
Fixes #10754.

## Summary

Adds an optional `terminalMinimumContrastRatio` preference under Settings → Appearance → Terminal → Advanced. Blank keeps Orca's existing automatic floor (3 on dark backgrounds, 4.5 on light backgrounds); values are clamped to 1–21; setting 1 disables xterm contrast correction so TUIs can render deliberately low-contrast colors unchanged.

The preference applies live to normal terminal panes, the settings preview, and dashboard terminal previews. Clearing the field removes the override and returns to automatic behavior without restarting a pane.

## Implementation

- Extends `GlobalSettings` with an optional, backward-compatible field.
- Centralizes bounds and fallback behavior in `resolveTerminalMinimumContrastRatio`.
- Value-gates live xterm writes so unrelated settings changes do not clear the contrast cache.
- Extends the existing `NumberField` control with an optional reset path and an `Automatic` placeholder.
- Adds settings search metadata and English catalog entries using current localization conventions.
- Adds focused unit coverage plus an Electron E2E that drives a live PTY, changes the floor from 1 → 21 → 1, and verifies the existing buffer visibly repaints and restores.

## Visual proof (macOS local, final rebased tree)

Both images are uncropped Orca Electron/CDP captures of the same preview and buffer.

**Contrast correction forced to 21**

![Minimum contrast 21](https://github.com/user-attachments/assets/9edb7ee3-9f31-4878-9bf8-7e8466dd730a)

**Contrast correction disabled at 1 (program colors preserved)**

![Minimum contrast 1](https://github.com/user-attachments/assets/f42432b7-ad23-429c-9928-c6608e231b44)

The backing store reported 21 and 1 after the UI commits. Clearing the field then reported no stored value and restored the blank `Automatic` state.

## Testing

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] Focused Vitest: 7 files, 82 tests passed
- [x] Electron E2E: `terminal-minimum-contrast-setting.spec.ts` passed on the final rebased commit
- [x] Real macOS Orca Electron/CDP validation on an isolated profile: 21 and 1 visibly repainted the terminal preview; clearing restored automatic state
- [x] Electron development build completed as part of the CDP launch; the E2E bundle also completed
- [x] Localization catalog and extraction verification (included in `pnpm run lint`)

An attempted repository-wide `pnpm test` run was stopped after host-wide contention from several concurrent worktree suites caused unrelated timeout and watcher-starvation failures across SSH relay, persistence, source control, sidebar, and orchestration tests. The focused renderer tests and the live Electron E2E both pass on the final rebased commit.

## Readiness review

- **P0/P1/P2:** none found after review and fixes.
- **Security/supply chain:** no dependency, lockfile, command execution, path, credential, or new IPC surface. The numeric value is finite-checked and clamped before reaching xterm.
- **Performance/resources:** no timers, listeners, subscriptions, or unbounded collections added; live option writes are value-gated.
- **SSH/remoting:** renderer-only display preference; it applies to panes regardless of execution host and does not infer process liveness or cross the SSH execution boundary.
- **Mixed-version compatibility:** optional local settings field; no RPC params, stream opcodes, or host-published payload changed. Old clients ignore it and new clients retain existing defaults when absent.
- **Cross-platform/provider compatibility:** no platform, path, shortcut, shell, Git, GitHub, or GitLab behavior changed. The same renderer path is used on macOS, Linux, Windows, folder workspaces, git worktrees, and remote panes.
- **Mobile-facing assessment:** no mobile schema, storage, rendering, or wire surface changed.

## Notes

Ghostty's own `minimum-contrast` setting remains unmapped in the Ghostty importer and is intentionally out of scope.

X: @Nyanako0129
