### PR TITLE
feat(git): automatically collapse resolved PR comments

### DIFF
--- a/src/main/github/pr-review-comment-lines.test.ts
+++ b/src/main/github/pr-review-comment-lines.test.ts
@@ -24,6 +24,10 @@ describe('getPRReviewCommentLineNumbersFromPatch', () => {
     expect(getPRReviewCommentLineNumbersFromPatch(undefined)).toEqual([])
   })
 
+  it('returns an empty list for empty patch string', () => {
+    expect(getPRReviewCommentLineNumbersFromPatch('')).toEqual([])
+  })
+
   it('counts added lines whose content begins with ++', () => {
     // Inside a hunk, GitHub's per-file patch never carries a `+++ b/file` header
     // (those precede the first @@), so `+++count` is an added line of content `++count`
@@ -38,6 +42,76 @@ describe('getPRReviewCommentLineNumbersFromPatch', () => {
     // (diff line `---count`) must not become commentable. Locks the intended difference
     // from the added-line case so a future "symmetric" edit can't regress it.
     const patch = ['@@ -1,2 +1,1 @@', ' const a = 1', '---count'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([1])
+  })
+
+  it('handles single-line hunks with count = 1', () => {
+    const patch = ['@@ -5,0 +6,1 @@', '+new line'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([6])
+  })
+
+  it('handles hunks with only context lines', () => {
+    const patch = ['@@ -1,2 +1,2 @@', ' line 1', ' line 2'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([1, 2])
+  })
+
+  it('handles multiple consecutive hunks', () => {
+    const patch = ['@@ -1,1 +1,2 @@', '+line 1', ' line 2', '@@ -3,1 +4,1 @@', ' line 4'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([1, 2, 4])
+  })
+
+  it('handles hunks with no added lines', () => {
+    const patch = ['@@ -1,2 +1,0 @@', '-removed line 1', '-removed line 2'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([])
+  })
+
+  it('ignores no-newline-at-end-of-file markers', () => {
+    const patch = ['@@ -1,1 +1,2 @@', ' line 1', '+line 2', '\\ No newline at end of file'].join(
+      '\n'
+    )
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([1, 2])
+  })
+
+  it('handles hunks with large line counts', () => {
+    const patch = [
+      '@@ -1,0 +100,50 @@',
+      ...Array(50)
+        .fill(0)
+        .map((_, i) => `+line ${i}`)
+    ].join('\n')
+
+    const result = getPRReviewCommentLineNumbersFromPatch(patch)
+    expect(result).toHaveLength(50)
+    expect(result[0]).toBe(100)
+    expect(result[49]).toBe(149)
+  })
+
+  it('handles patches with only removed lines', () => {
+    const patch = ['@@ -1,3 +1,0 @@', '-removed 1', '-removed 2', '-removed 3'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([])
+  })
+
+  it('handles mixed add/remove in same hunk', () => {
+    const patch = ['@@ -1,3 +1,3 @@', ' context', '-removed', '+added', ' context'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([1, 2, 3])
+  })
+
+  it('handles hunk header with implicit count of 1', () => {
+    const patch = ['@@ -5,0 +6 @@', '+new line'].join('\n')
+
+    expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([6])
+  })
+
+  it('handles patches with trailing newlines', () => {
+    const patch = ['@@ -1,1 +1,1 @@', ' line 1', '', ''].join('\n')
 
     expect(getPRReviewCommentLineNumbersFromPatch(patch)).toEqual([1])
   })

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3256,6 +3256,37 @@ html.onboarding-tour-start-transition::view-transition-new(root) {
   min-width: 0;
 }
 
+/* Collapse chevron button — small icon at start of comment card header */
+.orca-diff-comment-collapse-btn {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--muted-foreground);
+  opacity: 0.55;
+  cursor: pointer;
+  transition:
+    opacity 0.15s,
+    background 0.15s;
+}
+
+.orca-diff-comment-collapse-btn:hover {
+  opacity: 1;
+  background: color-mix(in srgb, var(--foreground) 8%, transparent);
+}
+
+.orca-diff-comment-collapse-btn:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
+  opacity: 1;
+}
+
 /* Meta Group (Name, line, timestamp) */
 .orca-diff-comment-meta-group {
   display: flex;

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -3113,6 +3113,17 @@ function ConversationTab({
   const [replyingTo, setReplyingTo] = useState<number | null>(null)
   const [commentFilter, setCommentFilter] = useState<PRCommentAudienceFilter>('all')
   const [commentsCollapsed, setCommentsCollapsed] = useState(false)
+  const ariaLabel =
+    item.type === 'issue'
+      ? commentsCollapsed
+        ? translate('auto.components.GitHubItemDialog.timeline.activityExpand', 'Expand activity')
+        : translate(
+            'auto.components.GitHubItemDialog.timeline.activityCollapse',
+            'Collapse activity'
+          )
+      : commentsCollapsed
+        ? translate('auto.components.GitHubItemDialog.comments.expand', 'Expand comments')
+        : translate('auto.components.GitHubItemDialog.comments.collapse', 'Collapse comments')
   const [bodyDraft, setBodyDraft] = useState(body)
   const [bodyEditing, setBodyEditing] = useState(false)
   const [bodySaving, setBodySaving] = useState(false)
@@ -3735,6 +3746,7 @@ function ConversationTab({
               type="button"
               className="flex items-center gap-2 pt-1 text-left"
               aria-expanded={!commentsCollapsed}
+              aria-label={ariaLabel}
               onClick={() => setCommentsCollapsed((c) => !c)}
             >
               <ChevronDown

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -3112,6 +3112,7 @@ function ConversationTab({
   const authorLabel = item.author ?? 'unknown'
   const [replyingTo, setReplyingTo] = useState<number | null>(null)
   const [commentFilter, setCommentFilter] = useState<PRCommentAudienceFilter>('all')
+  const [commentsCollapsed, setCommentsCollapsed] = useState(false)
   const [bodyDraft, setBodyDraft] = useState(body)
   const [bodyEditing, setBodyEditing] = useState(false)
   const [bodySaving, setBodySaving] = useState(false)
@@ -3730,7 +3731,18 @@ function ConversationTab({
 
         {detailsLoaded ? (
           <>
-            <div className="flex items-center gap-2 pt-1">
+            <button
+              type="button"
+              className="flex items-center gap-2 pt-1 text-left"
+              aria-expanded={!commentsCollapsed}
+              onClick={() => setCommentsCollapsed((c) => !c)}
+            >
+              <ChevronDown
+                className={cn(
+                  'size-3 shrink-0 text-muted-foreground transition-transform',
+                  commentsCollapsed && '-rotate-90'
+                )}
+              />
               {item.type === 'issue' ? (
                 <FolderKanban className="size-4 text-muted-foreground" />
               ) : (
@@ -3746,56 +3758,60 @@ function ConversationTab({
                   {comments.length + (item.type === 'issue' ? resolvedTimelineItems.length : 0)}
                 </span>
               )}
-            </div>
+            </button>
 
-            {item.type === 'pr' && comments.length > 0 && (
-              <div className="grid grid-cols-3 rounded-lg border border-border/50 bg-background p-0.5">
-                {getPrCommentAudienceFilters().map((filter) => {
-                  const isActive = commentFilter === filter.value
-                  return (
-                    <button
-                      key={filter.value}
-                      type="button"
-                      className={cn(
-                        'flex h-8 items-center justify-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors',
-                        isActive && 'bg-muted text-foreground'
+            {!commentsCollapsed && (
+              <>
+                {item.type === 'pr' && comments.length > 0 && (
+                  <div className="grid grid-cols-3 rounded-lg border border-border/50 bg-background p-0.5">
+                    {getPrCommentAudienceFilters().map((filter) => {
+                      const isActive = commentFilter === filter.value
+                      return (
+                        <button
+                          key={filter.value}
+                          type="button"
+                          className={cn(
+                            'flex h-8 items-center justify-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors',
+                            isActive && 'bg-muted text-foreground'
+                          )}
+                          aria-pressed={isActive}
+                          onClick={() => setCommentFilter(filter.value)}
+                        >
+                          <span>{filter.label}</span>
+                          <span className="tabular-nums">{commentCounts[filter.value]}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
+
+                {item.type === 'issue' ? (
+                  issueConversationEntries.length === 0 ? (
+                    <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
+                      {translate(
+                        'auto.components.GitHubItemDialog.timeline.noActivity',
+                        'No activity yet.'
                       )}
-                      aria-pressed={isActive}
-                      onClick={() => setCommentFilter(filter.value)}
-                    >
-                      <span>{filter.label}</span>
-                      <span className="tabular-nums">{commentCounts[filter.value]}</span>
-                    </button>
+                    </div>
+                  ) : (
+                    <div className="flex min-w-0 flex-col gap-3">
+                      {issueConversationEntries.map(renderIssueConversationEntry)}
+                    </div>
                   )
-                })}
-              </div>
-            )}
-
-            {item.type === 'issue' ? (
-              issueConversationEntries.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
-                  {translate(
-                    'auto.components.GitHubItemDialog.timeline.noActivity',
-                    'No activity yet.'
-                  )}
-                </div>
-              ) : (
-                <div className="flex min-w-0 flex-col gap-3">
-                  {issueConversationEntries.map(renderIssueConversationEntry)}
-                </div>
-              )
-            ) : comments.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
-                {translate('auto.components.GitHubItemDialog.5a94f3d0e9', 'No comments yet.')}
-              </div>
-            ) : visibleComments.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-[13px] text-muted-foreground">
-                {getPRCommentAudienceEmptyLabel(commentFilter)}
-              </div>
-            ) : (
-              <div className="flex min-w-0 flex-col gap-3">
-                {visibleCommentGroups.map(renderCommentGroup)}
-              </div>
+                ) : comments.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
+                    {translate('auto.components.GitHubItemDialog.5a94f3d0e9', 'No comments yet.')}
+                  </div>
+                ) : visibleComments.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-[13px] text-muted-foreground">
+                    {getPRCommentAudienceEmptyLabel(commentFilter)}
+                  </div>
+                ) : (
+                  <div className="flex min-w-0 flex-col gap-3">
+                    {visibleCommentGroups.map(renderCommentGroup)}
+                  </div>
+                )}
+              </>
             )}
           </>
         ) : null}

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -2235,6 +2235,7 @@ function PRFilesCombinedDiffViewer({
             authorAvatarUrl: comment.authorAvatarUrl,
             createdAtLabel: formatRelativeTime(comment.createdAt),
             url: comment.url,
+            isResolved: comment.isResolved,
             canDelete: false,
             canEdit: false
           }

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -3219,6 +3219,7 @@ function ConversationTab({
   const authorLabel = item.author ?? 'unknown'
   const [replyingTo, setReplyingTo] = useState<number | null>(null)
   const [commentFilter, setCommentFilter] = useState<PRCommentAudienceFilter>('all')
+  const [commentsCollapsed, setCommentsCollapsed] = useState(false)
   const [bodyDraft, setBodyDraft] = useState(body)
   const [bodyEditing, setBodyEditing] = useState(false)
   const [bodySaving, setBodySaving] = useState(false)
@@ -3741,7 +3742,18 @@ function ConversationTab({
 
         {detailsLoaded ? (
           <>
-            <div className="flex items-center gap-2 pt-1">
+            <button
+              type="button"
+              className="flex items-center gap-2 pt-1 text-left"
+              aria-expanded={!commentsCollapsed}
+              onClick={() => setCommentsCollapsed((c) => !c)}
+            >
+              <ChevronDown
+                className={cn(
+                  'size-3 shrink-0 text-muted-foreground transition-transform',
+                  commentsCollapsed && '-rotate-90'
+                )}
+              />
               <MessageSquare className="size-4 text-muted-foreground" />
               <span className="text-[13px] font-medium text-foreground">
                 {translate('auto.components.PullRequestPage.3463d10a63', 'Comments')}
@@ -3751,43 +3763,47 @@ function ConversationTab({
                   {comments.length}
                 </span>
               )}
-            </div>
+            </button>
 
-            {item.type === 'pr' && comments.length > 0 && (
-              <div className="grid grid-cols-3 rounded-lg border border-border/50 bg-background p-0.5">
-                {getPrCommentAudienceFilters().map((filter) => {
-                  const isActive = commentFilter === filter.value
-                  return (
-                    <button
-                      key={filter.value}
-                      type="button"
-                      className={cn(
-                        'flex h-8 items-center justify-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors',
-                        isActive && 'bg-muted text-foreground'
-                      )}
-                      aria-pressed={isActive}
-                      onClick={() => setCommentFilter(filter.value)}
-                    >
-                      <span>{filter.label}</span>
-                      <span className="tabular-nums">{commentCounts[filter.value]}</span>
-                    </button>
-                  )
-                })}
-              </div>
-            )}
+            {!commentsCollapsed && (
+              <>
+                {item.type === 'pr' && comments.length > 0 && (
+                  <div className="grid grid-cols-3 rounded-lg border border-border/50 bg-background p-0.5">
+                    {getPrCommentAudienceFilters().map((filter) => {
+                      const isActive = commentFilter === filter.value
+                      return (
+                        <button
+                          key={filter.value}
+                          type="button"
+                          className={cn(
+                            'flex h-8 items-center justify-center gap-1 rounded-md px-2 text-[12px] font-medium text-muted-foreground transition-colors',
+                            isActive && 'bg-muted text-foreground'
+                          )}
+                          aria-pressed={isActive}
+                          onClick={() => setCommentFilter(filter.value)}
+                        >
+                          <span>{filter.label}</span>
+                          <span className="tabular-nums">{commentCounts[filter.value]}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                )}
 
-            {comments.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
-                {translate('auto.components.PullRequestPage.d2d589556c', 'No comments yet.')}
-              </div>
-            ) : visibleComments.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-[13px] text-muted-foreground">
-                {getPRCommentAudienceEmptyLabel(commentFilter)}
-              </div>
-            ) : (
-              <div className="flex min-w-0 flex-col gap-3">
-                {visibleCommentGroups.map(renderCommentGroup)}
-              </div>
+                {comments.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-left text-[13px] text-muted-foreground">
+                    {translate('auto.components.PullRequestPage.d2d589556c', 'No comments yet.')}
+                  </div>
+                ) : visibleComments.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-border/50 px-3 py-6 text-center text-[13px] text-muted-foreground">
+                    {getPRCommentAudienceEmptyLabel(commentFilter)}
+                  </div>
+                ) : (
+                  <div className="flex min-w-0 flex-col gap-3">
+                    {visibleCommentGroups.map(renderCommentGroup)}
+                  </div>
+                )}
+              </>
             )}
           </>
         ) : null}

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -3746,6 +3746,14 @@ function ConversationTab({
               type="button"
               className="flex items-center gap-2 pt-1 text-left"
               aria-expanded={!commentsCollapsed}
+              aria-label={
+                commentsCollapsed
+                  ? translate('auto.components.PullRequestPage.comments.expand', 'Expand comments')
+                  : translate(
+                      'auto.components.PullRequestPage.comments.collapse',
+                      'Collapse comments'
+                    )
+              }
               onClick={() => setCommentsCollapsed((c) => !c)}
             >
               <ChevronDown

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -2291,6 +2291,7 @@ function PRFilesCombinedDiffViewer({
             authorAvatarUrl: comment.authorAvatarUrl,
             createdAtLabel: formatRelativeTime(comment.createdAt),
             url: comment.url,
+            isResolved: comment.isResolved,
             canDelete: false,
             canEdit: false
           }

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -127,6 +127,10 @@ export function DiffCommentCard({
     .filter(Boolean)
     .join(' ')
 
+  const ariaLabel = collapsed
+    ? translate('auto.components.diff.comments.DiffCommentCard.expand', 'Expand comment')
+    : translate('auto.components.diff.comments.DiffCommentCard.collapse', 'Collapse comment')
+
   const handleSubmit = async (): Promise<void> => {
     if (!canSubmit || !onSubmitEdit) {
       return
@@ -161,17 +165,7 @@ export function DiffCommentCard({
             type="button"
             className="orca-diff-comment-collapse-btn"
             aria-expanded={!collapsed}
-            aria-label={
-              collapsed
-                ? translate(
-                    'auto.components.diff.comments.DiffCommentCard.expand',
-                    'Expand comment'
-                  )
-                : translate(
-                    'auto.components.diff.comments.DiffCommentCard.collapse',
-                    'Collapse comment'
-                  )
-            }
+            aria-label={ariaLabel}
             onClick={(ev) => {
               ev.preventDefault()
               ev.stopPropagation()

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -1,9 +1,10 @@
-import { CornerDownLeft, Pencil, Trash } from 'lucide-react'
+import { ChevronDown, CornerDownLeft, Pencil, Trash } from 'lucide-react'
 import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
 
 // Why: the saved-note card lives inside a Monaco view zone's DOM node.
 // useDiffCommentDecorator creates a React root per zone and renders this
@@ -53,6 +54,7 @@ export function DiffCommentCard({
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(body)
   const [submitting, setSubmitting] = useState(false)
+  const [collapsed, setCollapsed] = useState(false)
   const mountedRef = useMountedRef()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const resizeAfterCloseRef = useRef(false)
@@ -86,6 +88,18 @@ export function DiffCommentCard({
     el.setSelectionRange(el.value.length, el.value.length)
     onContentResizeRef.current?.()
   }, [editing])
+
+  const isMounted = useRef(false)
+
+  // Why: resize the Monaco view zone when the card is collapsed/expanded so the
+  // editor lines flow naturally without leaving a blank gap. Skip on mount.
+  useLayoutEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true
+      return
+    }
+    onContentResizeRef.current?.()
+  }, [collapsed])
 
   const scheduleContentResizeAfterClose = (): void => {
     // Why: closing edit mode removes the textarea/footer before Monaco can
@@ -142,10 +156,37 @@ export function DiffCommentCard({
       <div className="orca-diff-comment-content-col">
         {/* Header Row */}
         <div className="orca-diff-comment-header">
+          {/* Collapse toggle chevron */}
+          <button
+            type="button"
+            className="orca-diff-comment-collapse-btn"
+            aria-expanded={!collapsed}
+            aria-label={
+              collapsed
+                ? translate(
+                    'auto.components.diff.comments.DiffCommentCard.expand',
+                    'Expand comment'
+                  )
+                : translate(
+                    'auto.components.diff.comments.DiffCommentCard.collapse',
+                    'Collapse comment'
+                  )
+            }
+            onClick={(ev) => {
+              ev.preventDefault()
+              ev.stopPropagation()
+              setCollapsed((c) => !c)
+            }}
+          >
+            <ChevronDown
+              className={cn('size-3 shrink-0 transition-transform', collapsed && '-rotate-90')}
+            />
+          </button>
+
           <div className="orca-diff-comment-meta-group">{metaText}</div>
 
-          {/* Action buttons pill (only shown if not editing) */}
-          {!editing && (
+          {/* Action buttons pill (only shown if not editing and not collapsed) */}
+          {!editing && !collapsed && (
             <div
               className="orca-diff-comment-actions-pill"
               onMouseDown={(ev) => ev.stopPropagation()}
@@ -229,68 +270,69 @@ export function DiffCommentCard({
           )}
         </div>
 
-        {/* Quote Block */}
-        {quote ? (
+        {/* Quote Block — hidden when collapsed */}
+        {!collapsed && quote ? (
           <div className="orca-diff-comment-quote">
             <div className="orca-diff-comment-quote-text">{quote}</div>
           </div>
         ) : null}
 
-        {/* Body or Edit Mode */}
-        {editing ? (
-          <div className="flex flex-col gap-2 mt-1">
-            <textarea
-              ref={textareaRef}
-              className="orca-diff-comment-popover-textarea"
-              value={draft}
-              onChange={(e) => {
-                setDraft(e.target.value)
-                const el = e.currentTarget
-                el.style.height = 'auto'
-                el.style.height = `${Math.min(el.scrollHeight, 240)}px`
-                onContentResizeRef.current?.()
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Escape') {
-                  e.preventDefault()
-                  handleCancel()
-                  return
-                }
-                if (e.key === 'Enter' && !e.nativeEvent.isComposing && !e.shiftKey) {
-                  e.preventDefault()
-                  if (!canSubmit) {
+        {/* Body or Edit Mode — hidden when collapsed */}
+        {!collapsed &&
+          (editing ? (
+            <div className="flex flex-col gap-2 mt-1">
+              <textarea
+                ref={textareaRef}
+                className="orca-diff-comment-popover-textarea"
+                value={draft}
+                onChange={(e) => {
+                  setDraft(e.target.value)
+                  const el = e.currentTarget
+                  el.style.height = 'auto'
+                  el.style.height = `${Math.min(el.scrollHeight, 240)}px`
+                  onContentResizeRef.current?.()
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault()
+                    handleCancel()
                     return
                   }
-                  void handleSubmit()
-                }
-              }}
-              rows={3}
-            />
-            <div className="orca-diff-comment-popover-footer">
-              <Button variant="ghost" size="sm" onClick={handleCancel} disabled={submitting}>
-                {translate('auto.components.diff.comments.DiffCommentCard.0203bed775', 'Cancel')}
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => void handleSubmit()}
-                disabled={!canSubmit}
-                title={
-                  submitting
-                    ? translate(
-                        'auto.components.diff.comments.DiffCommentCard.bb0a55f856',
-                        'Saving…'
-                      )
-                    : undefined
-                }
-              >
-                {translate('auto.components.diff.comments.DiffCommentCard.109a791e7b', 'Save')}
-                <CornerDownLeft className="ml-1 size-3 opacity-70" />
-              </Button>
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing && !e.shiftKey) {
+                    e.preventDefault()
+                    if (!canSubmit) {
+                      return
+                    }
+                    void handleSubmit()
+                  }
+                }}
+                rows={3}
+              />
+              <div className="orca-diff-comment-popover-footer">
+                <Button variant="ghost" size="sm" onClick={handleCancel} disabled={submitting}>
+                  {translate('auto.components.diff.comments.DiffCommentCard.0203bed775', 'Cancel')}
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => void handleSubmit()}
+                  disabled={!canSubmit}
+                  title={
+                    submitting
+                      ? translate(
+                          'auto.components.diff.comments.DiffCommentCard.bb0a55f856',
+                          'Saving…'
+                        )
+                      : undefined
+                  }
+                >
+                  {translate('auto.components.diff.comments.DiffCommentCard.109a791e7b', 'Save')}
+                  <CornerDownLeft className="ml-1 size-3 opacity-70" />
+                </Button>
+              </div>
             </div>
-          </div>
-        ) : (
-          <div className="orca-diff-comment-body">{body}</div>
-        )}
+          ) : (
+            <div className="orca-diff-comment-body">{body}</div>
+          ))}
       </div>
     </div>
   )

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -34,6 +34,7 @@ type Props = {
   onContentResize?: () => void
   onSubmitEdit?: (body: string) => Promise<boolean>
   headerActions?: ReactNode
+  isResolved?: boolean
 }
 
 export function DiffCommentCard({
@@ -49,12 +50,13 @@ export function DiffCommentCard({
   onDelete,
   onContentResize,
   onSubmitEdit,
-  headerActions
+  headerActions,
+  isResolved
 }: Props): React.JSX.Element {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(body)
   const [submitting, setSubmitting] = useState(false)
-  const [collapsed, setCollapsed] = useState(false)
+  const [collapsed, setCollapsed] = useState(isResolved ?? false)
   const mountedRef = useMountedRef()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const resizeAfterCloseRef = useRef(false)
@@ -179,16 +181,16 @@ export function DiffCommentCard({
 
           <div className="orca-diff-comment-meta-group">{metaText}</div>
 
-          {/* Action buttons pill (only shown if not editing and not collapsed) */}
-          {!editing && !collapsed && (
+          {/* Action buttons pill (shown if not editing, allowing Open button when collapsed) */}
+          {!editing && (url || !collapsed) && (
             <div
               className="orca-diff-comment-actions-pill"
               onMouseDown={(ev) => ev.stopPropagation()}
             >
-              {headerActions}
-              {headerActions && (url || onSubmitEdit || onDelete) && (
+              {!collapsed && headerActions}
+              {!collapsed && headerActions && (url || onSubmitEdit || onDelete) ? (
                 <span className="orca-diff-comment-pill-divider" />
-              )}
+              ) : null}
               {url && (
                 <>
                   <button
@@ -210,12 +212,12 @@ export function DiffCommentCard({
                   >
                     {translate('auto.components.diff.comments.DiffCommentCard.6978871a3d', 'Open')}
                   </button>
-                  {(onSubmitEdit || onDelete) && (
+                  {!collapsed && (onSubmitEdit || onDelete) ? (
                     <span className="orca-diff-comment-pill-divider" />
-                  )}
+                  ) : null}
                 </>
               )}
-              {onSubmitEdit && (
+              {!collapsed && onSubmitEdit ? (
                 <>
                   <button
                     type="button"
@@ -236,10 +238,10 @@ export function DiffCommentCard({
                   >
                     <Pencil className="size-3" />
                   </button>
-                  {onDelete && <span className="orca-diff-comment-pill-divider" />}
+                  {onDelete ? <span className="orca-diff-comment-pill-divider" /> : null}
                 </>
-              )}
-              {onDelete && (
+              ) : null}
+              {!collapsed && onDelete ? (
                 <button
                   type="button"
                   className="orca-diff-comment-pill-btn orca-diff-comment-pill-btn-danger"
@@ -259,7 +261,7 @@ export function DiffCommentCard({
                 >
                   <Trash className="size-3" />
                 </button>
-              )}
+              ) : null}
             </div>
           )}
         </div>

--- a/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
+++ b/src/renderer/src/components/diff-comments/DiffCommentCard.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, CornerDownLeft, Pencil, Trash } from 'lucide-react'
-import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -60,6 +60,11 @@ export function DiffCommentCard({
   const mountedRef = useMountedRef()
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const resizeAfterCloseRef = useRef(false)
+
+  // Why: sync collapsed state when the resolved status changes dynamically so that resolved comments collapse automatically.
+  useEffect(() => {
+    setCollapsed(isResolved ?? false)
+  }, [isResolved])
 
   // Why: stash `onContentResize` in a ref so the layout/resize effects only
   // re-run on `editing` transitions. The decorator passes a fresh arrow every

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -435,7 +435,12 @@ export function useDiffCommentDecorator({
       return
     }
 
-    const relevant = comments.filter((c) => c.filePath === filePath && c.worktreeId === worktreeId)
+    const normFilePath = filePath.replace(/\\/g, '/').replace(/^\//, '').toLowerCase()
+    const relevant = comments.filter(
+      (c) =>
+        c.filePath.replace(/\\/g, '/').replace(/^\//, '').toLowerCase() === normFilePath &&
+        c.worktreeId === worktreeId
+    )
     const relevantMap = new Map(relevant.map((c) => [c.id, c] as const))
 
     const zones = zonesRef.current
@@ -714,9 +719,12 @@ export function useDiffCommentDecorator({
       pendingScrollRef.current = null
       return
     }
+    const normFilePath = filePath.replace(/\\/g, '/').replace(/^\//, '').toLowerCase()
     const target = comments.find(
       (c) =>
-        c.id === pendingScrollCommentId && c.filePath === filePath && c.worktreeId === worktreeId
+        c.id === pendingScrollCommentId &&
+        c.filePath.replace(/\\/g, '/').replace(/^\//, '').toLowerCase() === normFilePath &&
+        c.worktreeId === worktreeId
     )
     if (!target) {
       // Why: the request is for a comment this decorator doesn't own (different

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -480,9 +480,13 @@ export function useDiffCommentDecorator({
         return
       }
       entry.delegate.heightInPx = measured
+      const scrollTop = editor.getScrollTop()
       editor.changeViewZones((acc) => {
         acc.layoutZone(entry.zoneId)
       })
+      // Why: prevent Monaco from automatically scrolling/jumping the viewport
+      // to keep the anchor line in view when the comment card's height changes.
+      editor.setScrollTop(scrollTop)
     }
 
     // Why: one-shot scroll resolver. Called by both the request-arrives-late

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -32,6 +32,7 @@ export type DecoratedDiffComment = DiffComment & {
   url?: string
   canDelete?: boolean
   canEdit?: boolean
+  isResolved?: boolean
 }
 
 type DecoratorArgs = {
@@ -541,6 +542,7 @@ export function useDiffCommentDecorator({
             author={comment.author}
             createdAtLabel={comment.createdAtLabel}
             url={comment.url}
+            isResolved={comment.isResolved}
             onDelete={
               comment.canDelete === false ? undefined : () => onDeleteCommentRef.current(comment.id)
             }
@@ -616,8 +618,11 @@ export function useDiffCommentDecorator({
         // covers fixed chrome (inline wrapper padding ~10, card border 2, card
         // padding 12, header+meta ~24, body margin 2) and the per-line factor
         // matches the 13.5px/1.5 body line-height.
-        const lineCount = getCommentBodyLayoutLineCount(c.body)
-        const heightInPx = Math.max(ZONE_MIN_PX, ZONE_CHROME_PX + lineCount * ZONE_LINE_PX)
+        const isCollapsed = c.isResolved === true
+        const lineCount = isCollapsed ? 0 : getCommentBodyLayoutLineCount(c.body)
+        const heightInPx = isCollapsed
+          ? 32
+          : Math.max(ZONE_MIN_PX, ZONE_CHROME_PX + lineCount * ZONE_LINE_PX)
 
         // Why: suppressMouseDown: false so clicks inside the zone (Delete
         // button) reach our DOM listeners. With true, Monaco intercepts the

--- a/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
+++ b/src/renderer/src/components/diff-comments/useDiffCommentDecorator.tsx
@@ -100,6 +100,7 @@ function getRenderSignature(
     url: comment.url ?? null,
     canDelete: comment.canDelete ?? null,
     canEdit: comment.canEdit ?? null,
+    isResolved: comment.isResolved ?? null,
     sendPrompt: formatCommentPrompt ? formatCommentPrompt(comment) : null
   })
 }

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -55,7 +55,7 @@ import { Check, Copy, MessageSquare, PanelLeftOpen, Sparkles, Trash2, WrapText }
 import { toast } from 'sonner'
 import { DiffSectionItem } from './DiffSectionItem'
 import { DiffNotesSendMenu } from './DiffNotesSendMenu'
-import { prCommentsToDecoratedDiffComments } from '@/lib/diff-comment-compat'
+import { isPRCommentsCacheKey, prCommentsToDecoratedDiffComments } from '@/lib/diff-comment-compat'
 import {
   CombinedDiffFileTree,
   createCombinedDiffSectionIndexMap,
@@ -244,7 +244,9 @@ export default function CombinedDiffViewer({
     selectWorktreeDiffCommentsOrEmpty(s, file.worktreeId)
   )
 
-  const worktree = useAppStore((s) => (file.worktreeId ? s.getKnownWorktreeById(file.worktreeId) : undefined))
+  const worktree = useAppStore((s) =>
+    file.worktreeId ? s.getKnownWorktreeById(file.worktreeId) : undefined
+  )
   const wtPath = worktree?.path
   const wtBranch = worktree?.branch
   const wtLinkedPR = worktree?.linkedPR
@@ -300,12 +302,7 @@ export default function CombinedDiffViewer({
     // scope or contain the full prRepo name in the middle. Match keys
     // dynamically to find the correct entry regardless of caching scopes.
     const keys = Object.keys(s.commentsCache)
-    const targetKey = keys.find(
-      (k) =>
-        k.toLowerCase().includes(wt.repoId.toLowerCase()) &&
-        k.includes('::pr-comments::') &&
-        k.endsWith(`::${pr}`)
-    )
+    const targetKey = keys.find((k) => isPRCommentsCacheKey(k, wt, pr))
     return (targetKey ? s.commentsCache[targetKey]?.data : null) ?? EMPTY_PR_COMMENTS
   })
   const isDark =
@@ -2068,7 +2065,11 @@ export default function CombinedDiffViewer({
                         setSections={setSections}
                         modifiedEditorsRef={modifiedEditorsRef}
                         handleSectionSaveRef={handleSectionSaveRef}
-                        inlineComments={getInlineCommentsForSection(section.path)}
+                        inlineComments={
+                          isBranchMode || (isAllMode && section.area === undefined)
+                            ? getInlineCommentsForSection(section.path)
+                            : []
+                        }
                         renderHeaderTrailingContent={(headerSection) => {
                           const fileNotes = diffCommentsForWorktree.filter(
                             (comment) => comment.filePath === headerSection.path

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -48,12 +48,14 @@ import type {
   DiffComment,
   GitBranchChangeEntry,
   GitDiffResult,
-  GitStatusEntry
+  GitStatusEntry,
+  PRComment
 } from '../../../../shared/types'
 import { Check, Copy, MessageSquare, PanelLeftOpen, Sparkles, Trash2, WrapText } from 'lucide-react'
 import { toast } from 'sonner'
 import { DiffSectionItem } from './DiffSectionItem'
 import { DiffNotesSendMenu } from './DiffNotesSendMenu'
+import { prCommentsToDecoratedDiffComments } from '@/lib/diff-comment-compat'
 import {
   CombinedDiffFileTree,
   createCombinedDiffSectionIndexMap,
@@ -161,6 +163,7 @@ const COMBINED_DIFF_OVERSCAN = 5
 const COMBINED_DIFF_SCROLLBAR_THUMB_MIN_HEIGHT = 64
 const EMPTY_GIT_STATUS_ENTRIES: GitStatusEntry[] = []
 const EMPTY_GIT_BRANCH_ENTRIES: GitBranchChangeEntry[] = []
+const EMPTY_PR_COMMENTS: PRComment[] = []
 let combinedDiffCollapsedPreference: boolean | null = null
 let combinedDiffSideBySidePreference: boolean | null = null
 let combinedDiffFileTreeCollapsedPreference: boolean | null = null
@@ -235,10 +238,76 @@ export default function CombinedDiffViewer({
   const openBranchAllDiffs = useAppStore((s) => s.openBranchAllDiffs)
   const updateSettings = useAppStore((s) => s.updateSettings)
   const clearDiffComments = useAppStore((s) => s.clearDiffComments)
+  const fetchPRComments = useAppStore((s) => s.fetchPRComments)
+  const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
   const diffCommentsForWorktree = useAppStore((s) =>
     selectWorktreeDiffCommentsOrEmpty(s, file.worktreeId)
   )
+
+  const worktree = useAppStore((s) => (file.worktreeId ? s.getKnownWorktreeById(file.worktreeId) : undefined))
+  const wtPath = worktree?.path
+  const wtBranch = worktree?.branch
+  const wtLinkedPR = worktree?.linkedPR
+  const wtRepoId = worktree?.repoId
+
+  // Why: fetch PR comments in the background when the combined diff viewer mounts.
+  // The dev server restart clears the transient in-memory commentsCache; fetching on
+  // mount ensures review comments are available in the editor even if the right-sidebar
+  // ChecksPanel was never opened in this session.
+  useEffect(() => {
+    if (!wtPath) {
+      return
+    }
+    const load = async () => {
+      let pr = wtLinkedPR
+      if (!pr && wtBranch) {
+        const prInfo = await fetchPRForBranch(wtPath, wtBranch, { repoId: wtRepoId })
+        if (prInfo) {
+          pr = prInfo.number
+        }
+      }
+      if (pr) {
+        void fetchPRComments(wtPath, pr, { repoId: wtRepoId })
+      }
+    }
+    void load()
+  }, [wtPath, wtBranch, wtLinkedPR, wtRepoId, fetchPRComments, fetchPRForBranch])
   const activeGroupId = useAppStore((s) => s.activeGroupIdByWorktree[file.worktreeId])
+  // Why: the selector must be self-contained — closing over component-scoped
+  // linkedPR/worktree and returning a bare `[]` on the falsy branch caused an
+  // infinite re-render loop because each `[]` is a new reference and Zustand's
+  // Object.is comparison treated it as a change every time.
+  const prComments = useAppStore((s) => {
+    const wt = s.getKnownWorktreeById(file.worktreeId)
+    if (!wt || !wt.repoId) {
+      return EMPTY_PR_COMMENTS
+    }
+    let pr = wt.linkedPR
+    if (!pr && wt.branch) {
+      const keys = Object.keys(s.prCache)
+      const targetKey = keys.find(
+        (k) => k.toLowerCase().includes(wt.repoId.toLowerCase()) && k.endsWith(`::${wt.branch}`)
+      )
+      const cachedPR = targetKey ? s.prCache[targetKey]?.data : null
+      if (cachedPR) {
+        pr = cachedPR.number
+      }
+    }
+    if (!pr) {
+      return EMPTY_PR_COMMENTS
+    }
+    // Why: commentsCache keys may be prefixed by host/runtime environment
+    // scope or contain the full prRepo name in the middle. Match keys
+    // dynamically to find the correct entry regardless of caching scopes.
+    const keys = Object.keys(s.commentsCache)
+    const targetKey = keys.find(
+      (k) =>
+        k.toLowerCase().includes(wt.repoId.toLowerCase()) &&
+        k.includes('::pr-comments::') &&
+        k.endsWith(`::${pr}`)
+    )
+    return (targetKey ? s.commentsCache[targetKey]?.data : null) ?? EMPTY_PR_COMMENTS
+  })
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -254,6 +323,36 @@ export default function CombinedDiffViewer({
         .sort((a, b) => a.filePath.localeCompare(b.filePath) || a.lineNumber - b.lineNumber)
         .slice(0, 4),
     [diffCommentsForWorktree]
+  )
+
+  // Why: create a memoized map of PR comments by file path for efficient lookup
+  // when rendering inline comments in diff sections. Normalizes paths for cross-platform
+  // slash/leading-slash/case-insensitivity consistency.
+  const prCommentsByFilePath = React.useMemo(() => {
+    const byPath = new Map<string, PRComment[]>()
+    for (const comment of prComments) {
+      if (comment.path) {
+        const normPath = comment.path.replace(/\\/g, '/').replace(/^\//, '').toLowerCase()
+        const existing = byPath.get(normPath) ?? []
+        existing.push(comment)
+        byPath.set(normPath, existing)
+      }
+    }
+    return byPath
+  }, [prComments])
+
+  // Why: memoize the function that transforms PR comments for a specific file path
+  // to avoid recreating it on every render. This is used in the virtual list render.
+  const getInlineCommentsForSection = React.useCallback(
+    (sectionPath: string) => {
+      const normPath = sectionPath.replace(/\\/g, '/').replace(/^\//, '').toLowerCase()
+      return prCommentsToDecoratedDiffComments(
+        prCommentsByFilePath.get(normPath) ?? [],
+        sectionPath,
+        file.worktreeId
+      )
+    },
+    [prCommentsByFilePath, file.worktreeId]
   )
 
   const [sections, setSections] = useState<DiffSection[]>([])
@@ -1969,16 +2068,17 @@ export default function CombinedDiffViewer({
                         setSections={setSections}
                         modifiedEditorsRef={modifiedEditorsRef}
                         handleSectionSaveRef={handleSectionSaveRef}
-                        renderHeaderTrailingContent={(section) => {
+                        inlineComments={getInlineCommentsForSection(section.path)}
+                        renderHeaderTrailingContent={(headerSection) => {
                           const fileNotes = diffCommentsForWorktree.filter(
-                            (comment) => comment.filePath === section.path
+                            (comment) => comment.filePath === headerSection.path
                           )
                           return fileNotes.length > 0 ? (
                             <DiffNotesSendMenu
                               worktreeId={file.worktreeId}
                               groupId={activeGroupId ?? file.worktreeId}
                               comments={diffCommentsForWorktree}
-                              filePath={section.path}
+                              filePath={headerSection.path}
                               showFileScope
                               triggerClassName="p-0.5 can-hover:opacity-0 group-hover:opacity-100"
                             />

--- a/src/renderer/src/components/editor/DiffViewer.pr-comments.integration.test.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.pr-comments.integration.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import path from 'node:path'
 import React from 'react'
 import { render, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
@@ -21,7 +22,7 @@ const store = {
   prCache: {},
   commentsCache: {},
   getKnownWorktreeById: () => ({
-    path: '/repo',
+    path: path.join(path.sep, 'repo'),
     branch: 'feature',
     linkedPR: 42,
     repoId: 'owner/repo'
@@ -266,41 +267,47 @@ describe('DiffViewer PR comment integration', () => {
 
   it('renders PR comments in matching combined diff section', async () => {
     const { default: CombinedDiffViewer } = await import('./CombinedDiffViewer')
+    // Why: Restore original state to prevent test cache leakage
+    const originalCache = store.commentsCache
     store.commentsCache = {
       'github::owner/repo::pr-comments::42': {
         data: [createPRComment({ id: 900, path: mockFilePath, body: 'Inline review note' })]
       }
     }
 
-    render(
-      <CombinedDiffViewer
-        viewStateKey="test-view"
-        file={{
-          id: 'diff',
-          filePath: '/repo',
-          relativePath: mockFilePath,
-          worktreeId: mockWorktreeId,
-          language: 'typescript',
-          isDirty: false,
-          mode: 'diff',
-          diffSource: 'combined-branch',
-          branchCompare: {
-            baseRef: 'main',
-            baseOid: 'base',
-            headOid: 'head',
-            mergeBase: 'merge',
-            compareRef: 'feature',
-            compareVersion: '1'
-          },
-          branchEntriesSnapshot: [{ path: mockFilePath, status: 'modified' }]
-        }}
-      />
-    )
+    try {
+      render(
+        <CombinedDiffViewer
+          viewStateKey="test-view"
+          file={{
+            id: 'diff',
+            filePath: path.join(path.sep, 'repo'),
+            relativePath: mockFilePath,
+            worktreeId: mockWorktreeId,
+            language: 'typescript',
+            isDirty: false,
+            mode: 'diff',
+            diffSource: 'combined-branch',
+            branchCompare: {
+              baseRef: 'main',
+              baseOid: 'base',
+              headOid: 'head',
+              mergeBase: 'merge',
+              compareRef: 'feature',
+              compareVersion: '1'
+            },
+            branchEntriesSnapshot: [{ path: mockFilePath, status: 'modified' }]
+          }}
+        />
+      )
 
-    await waitFor(() => {
-      expect(
-        document.querySelector(`[data-testid="section-${mockFilePath}"]`)?.textContent
-      ).toContain('Inline review note')
-    })
+      await waitFor(() => {
+        expect(
+          document.querySelector(`[data-testid="section-${mockFilePath}"]`)?.textContent
+        ).toContain('Inline review note')
+      })
+    } finally {
+      store.commentsCache = originalCache
+    }
   })
 })

--- a/src/renderer/src/components/editor/DiffViewer.pr-comments.integration.test.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.pr-comments.integration.test.tsx
@@ -1,7 +1,86 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest'
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 import type { DiffComment, PRComment } from '../../../../shared/types'
 import { prCommentsToDecoratedDiffComments } from '@/lib/diff-comment-compat'
+
+const store = {
+  settings: {
+    theme: 'light',
+    diffDefaultView: 'inline',
+    combinedDiffFileTreeVisibleByDefault: false
+  },
+  gitStatusByWorktree: {},
+  gitBranchChangesByWorktree: {},
+  gitBranchCompareSummaryByWorktree: {},
+  activeGroupIdByWorktree: {},
+  worktreesByRepo: {
+    'owner/repo': [{ id: 'test-worktree', diffComments: [] }]
+  },
+  prCache: {},
+  commentsCache: {},
+  getKnownWorktreeById: () => ({
+    path: '/repo',
+    branch: 'feature',
+    linkedPR: 42,
+    repoId: 'owner/repo'
+  }),
+  openAllDiffs: vi.fn(),
+  openFile: vi.fn(),
+  openBranchDiff: vi.fn(),
+  openCommitDiff: vi.fn(),
+  openConflictReview: vi.fn(),
+  openBranchAllDiffs: vi.fn(),
+  updateSettings: vi.fn(),
+  clearDiffComments: vi.fn(),
+  fetchPRComments: vi.fn(),
+  fetchPRForBranch: vi.fn()
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (state: typeof store) => unknown) => selector(store), {
+    getState: () => store
+  })
+}))
+
+vi.mock('./DiffSectionItem', () => ({
+  DiffSectionItem: (props: {
+    section: { path: string }
+    inlineComments?: readonly { body: string }[]
+  }) => (
+    <div data-testid={`section-${props.section.path}`}>
+      {props.inlineComments?.map((comment) => (
+        <span key={comment.body}>{comment.body}</span>
+      ))}
+    </div>
+  )
+}))
+
+vi.mock('./CombinedDiffFileTree', () => ({
+  CombinedDiffFileTree: () => null,
+  createCombinedDiffSectionIndexMap: () => new Map(),
+  handleCombinedDiffFileTreeNavigation: vi.fn()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@tanstack/react-virtual', () => ({
+  elementScroll: vi.fn(),
+  useVirtualizer: () => ({
+    getVirtualItems: () => [{ index: 0, key: 'section-0', start: 0 }],
+    getTotalSize: () => 100,
+    measureElement: vi.fn(),
+    measure: vi.fn(),
+    scrollToOffset: vi.fn(),
+    scrollToIndex: vi.fn()
+  })
+}))
 
 // Why: integration test to verify DiffViewer behavior with PR comments
 // This tests the interaction between local diff comments and PR review comments
@@ -183,5 +262,45 @@ describe('DiffViewer PR comment integration', () => {
 
     expect(allComments).toHaveLength(2)
     expect(allComments.every((c) => c.worktreeId === 'worktree-1')).toBe(true)
+  })
+
+  it('renders PR comments in matching combined diff section', async () => {
+    const { default: CombinedDiffViewer } = await import('./CombinedDiffViewer')
+    store.commentsCache = {
+      'github::owner/repo::pr-comments::42': {
+        data: [createPRComment({ id: 900, path: mockFilePath, body: 'Inline review note' })]
+      }
+    }
+
+    render(
+      <CombinedDiffViewer
+        viewStateKey="test-view"
+        file={{
+          id: 'diff',
+          filePath: '/repo',
+          relativePath: mockFilePath,
+          worktreeId: mockWorktreeId,
+          language: 'typescript',
+          isDirty: false,
+          mode: 'diff',
+          diffSource: 'combined-branch',
+          branchCompare: {
+            baseRef: 'main',
+            baseOid: 'base',
+            headOid: 'head',
+            mergeBase: 'merge',
+            compareRef: 'feature',
+            compareVersion: '1'
+          },
+          branchEntriesSnapshot: [{ path: mockFilePath, status: 'modified' }]
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(`[data-testid="section-${mockFilePath}"]`)?.textContent
+      ).toContain('Inline review note')
+    })
   })
 })

--- a/src/renderer/src/components/editor/DiffViewer.pr-comments.integration.test.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.pr-comments.integration.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import type { DiffComment, PRComment } from '../../../../shared/types'
+import { prCommentsToDecoratedDiffComments } from '@/lib/diff-comment-compat'
+
+// Why: integration test to verify DiffViewer behavior with PR comments
+// This tests the interaction between local diff comments and PR review comments
+// in the context of the diff viewer, ensuring proper merging and filtering.
+
+describe('DiffViewer PR comment integration', () => {
+  const mockWorktreeId = 'test-worktree'
+  const mockFilePath = 'src/components/test.tsx'
+
+  function createLocalComment(overrides: Partial<DiffComment> = {}): DiffComment {
+    return {
+      id: `local-${Math.random()}`,
+      worktreeId: mockWorktreeId,
+      filePath: mockFilePath,
+      lineNumber: 10,
+      body: 'Local diff comment',
+      createdAt: Date.now(),
+      side: 'modified',
+      source: 'diff',
+      ...overrides
+    }
+  }
+
+  function createPRComment(overrides: Partial<PRComment> = {}): PRComment {
+    return {
+      id: Math.floor(Math.random() * 1000),
+      author: 'reviewer',
+      authorAvatarUrl: 'avatar-url',
+      body: 'PR review comment',
+      createdAt: '2026-07-16T12:00:00Z',
+      url: 'https://github.com/test/repo/pull/1',
+      path: mockFilePath,
+      line: 10,
+      ...overrides
+    }
+  }
+
+  it('merges local and PR comments correctly', () => {
+    const localComments = [
+      createLocalComment({ id: 'local-1', lineNumber: 5 }),
+      createLocalComment({ id: 'local-2', lineNumber: 15 })
+    ]
+
+    const prComments = [
+      createPRComment({ id: 100, line: 10 }),
+      createPRComment({ id: 200, line: 20 })
+    ]
+
+    const decoratedPR = prCommentsToDecoratedDiffComments(prComments, mockFilePath, mockWorktreeId)
+    const allComments = [...localComments, ...decoratedPR]
+
+    expect(allComments).toHaveLength(4)
+    expect(allComments.some((c) => c.id === 'local-1')).toBe(true)
+    expect(allComments.some((c) => c.id === 'local-2')).toBe(true)
+    expect(allComments.some((c) => c.id === 'pr-100')).toBe(true)
+    expect(allComments.some((c) => c.id === 'pr-200')).toBe(true)
+  })
+
+  it('filters comments by file path for the current view', () => {
+    const localComments = [
+      createLocalComment({ filePath: mockFilePath }),
+      createLocalComment({ filePath: 'src/other/file.ts' })
+    ]
+
+    const prComments = [
+      createPRComment({ path: mockFilePath }),
+      createPRComment({ path: 'src/other/file.ts' })
+    ]
+
+    const decoratedPR = prCommentsToDecoratedDiffComments(prComments, mockFilePath, mockWorktreeId)
+    const allComments = [
+      ...localComments.filter((c) => c.filePath === mockFilePath),
+      ...decoratedPR
+    ]
+
+    expect(allComments).toHaveLength(2)
+    expect(allComments.every((c) => c.filePath === mockFilePath)).toBe(true)
+  })
+
+  it('handles PR comments with different line numbers', () => {
+    const prComments = [
+      createPRComment({ id: 100, line: 5 }),
+      createPRComment({ id: 200, line: 10 }),
+      createPRComment({ id: 300, line: 15 })
+    ]
+
+    const decoratedPR = prCommentsToDecoratedDiffComments(prComments, mockFilePath, mockWorktreeId)
+
+    expect(decoratedPR).toHaveLength(3)
+    expect(decoratedPR[0].lineNumber).toBe(5)
+    expect(decoratedPR[1].lineNumber).toBe(10)
+    expect(decoratedPR[2].lineNumber).toBe(15)
+  })
+
+  it('handles PR comments with startLine ranges', () => {
+    const prComments = [
+      createPRComment({ id: 100, line: 10, startLine: 5 }),
+      createPRComment({ id: 200, line: 20, startLine: 15 })
+    ]
+
+    const decoratedPR = prCommentsToDecoratedDiffComments(prComments, mockFilePath, mockWorktreeId)
+
+    expect(decoratedPR).toHaveLength(2)
+    expect(decoratedPR[0].lineNumber).toBe(10)
+    expect(decoratedPR[0].startLine).toBe(5)
+    expect(decoratedPR[1].lineNumber).toBe(20)
+    expect(decoratedPR[1].startLine).toBe(15)
+  })
+
+  it('handles empty comment arrays gracefully', () => {
+    const decoratedPR = prCommentsToDecoratedDiffComments([], mockFilePath, mockWorktreeId)
+    const allComments = decoratedPR
+
+    expect(allComments).toHaveLength(0)
+  })
+
+  it('preserves PR comment metadata in decorated format', () => {
+    const prComment = createPRComment({
+      id: 100,
+      author: 'test-reviewer',
+      authorAvatarUrl: 'https://example.com/avatar.png',
+      body: 'This is a review comment',
+      url: 'https://github.com/test/repo/pull/1#comment-100'
+    })
+
+    const decoratedPR = prCommentsToDecoratedDiffComments([prComment], mockFilePath, mockWorktreeId)
+
+    expect(decoratedPR).toHaveLength(1)
+    expect(decoratedPR[0].author).toBe('test-reviewer')
+    expect(decoratedPR[0].authorAvatarUrl).toBe('https://example.com/avatar.png')
+    expect(decoratedPR[0].body).toBe('This is a review comment')
+    expect(decoratedPR[0].url).toBe('https://github.com/test/repo/pull/1#comment-100')
+    expect(decoratedPR[0].canDelete).toBe(false)
+    expect(decoratedPR[0].canEdit).toBe(false)
+  })
+
+  it('handles mixed source comments correctly', () => {
+    const localComments = [
+      createLocalComment({ source: 'diff' }),
+      createLocalComment({ source: 'markdown' })
+    ]
+
+    const prComments = [createPRComment({ id: 100 })]
+
+    const decoratedPR = prCommentsToDecoratedDiffComments(prComments, mockFilePath, mockWorktreeId)
+    const diffComments = localComments.filter((c) => c.source === 'diff' || c.source === undefined)
+    const allComments = [...diffComments, ...decoratedPR]
+
+    expect(allComments).toHaveLength(2)
+    expect(allComments.every((c) => c.source === 'diff')).toBe(true)
+  })
+
+  it('normalizes file paths for cross-platform compatibility', () => {
+    const prComments = [
+      createPRComment({ path: 'src/components/test.tsx' }),
+      createPRComment({ path: 'src\\components\\test.tsx' }),
+      createPRComment({ path: '/src/components/test.tsx' })
+    ]
+
+    const decoratedPR = prCommentsToDecoratedDiffComments(prComments, mockFilePath, mockWorktreeId)
+
+    // All three should match due to normalization
+    expect(decoratedPR).toHaveLength(3)
+  })
+
+  it('handles worktree ID filtering', () => {
+    const localComments = [
+      createLocalComment({ worktreeId: 'worktree-1' }),
+      createLocalComment({ worktreeId: 'worktree-2' })
+    ]
+
+    const prComments = [createPRComment({ id: 100 })]
+
+    const decoratedPR = prCommentsToDecoratedDiffComments(prComments, mockFilePath, 'worktree-1')
+    const allComments = [
+      ...localComments.filter((c) => c.worktreeId === 'worktree-1'),
+      ...decoratedPR
+    ]
+
+    expect(allComments).toHaveLength(2)
+    expect(allComments.every((c) => c.worktreeId === 'worktree-1')).toBe(true)
+  })
+})

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -14,8 +14,8 @@ import {
   getDiffCommentPopoverTop
 } from '../diff-comments/diff-comment-popover-position'
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
-import type { DiffComment } from '../../../../shared/types'
-import { isDiffComment } from '@/lib/diff-comment-compat'
+import type { DiffComment, PRComment } from '../../../../shared/types'
+import { isDiffComment, prCommentsToDecoratedDiffComments } from '@/lib/diff-comment-compat'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
 import { diffEditorScrollbarOptions } from './diff-editor-scrollbar-options'
 import { LargeDiffFallback } from './LargeDiffFallback'
@@ -26,6 +26,8 @@ import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
+
+const EMPTY_PR_COMMENTS: PRComment[] = []
 
 export default function DiffViewer({
   modelKey,
@@ -55,16 +57,85 @@ export default function DiffViewer({
   const updateDiffComment = useAppStore((s) => s.updateDiffComment)
   const scrollToDiffCommentId = useAppStore((s) => s.scrollToDiffCommentId)
   const setScrollToDiffCommentId = useAppStore((s) => s.setScrollToDiffCommentId)
+  const fetchPRComments = useAppStore((s) => s.fetchPRComments)
+  const fetchPRForBranch = useAppStore((s) => s.fetchPRForBranch)
+
+  const worktree = useAppStore((s) => (worktreeId ? s.getKnownWorktreeById(worktreeId) : undefined))
+  const wtPath = worktree?.path
+  const wtBranch = worktree?.branch
+  const wtLinkedPR = worktree?.linkedPR
+  const wtRepoId = worktree?.repoId
+
+  // Why: fetch PR comments in the background when the diff viewer mounts.
+  // The dev server restart clears the transient in-memory commentsCache; fetching on
+  // mount ensures review comments are available in the editor even if the right-sidebar
+  // ChecksPanel was never opened in this session.
+  useEffect(() => {
+    if (!wtPath) {
+      return
+    }
+    const load = async () => {
+      let pr = wtLinkedPR
+      if (!pr && wtBranch) {
+        const prInfo = await fetchPRForBranch(wtPath, wtBranch, { repoId: wtRepoId })
+        if (prInfo) {
+          pr = prInfo.number
+        }
+      }
+      if (pr) {
+        void fetchPRComments(wtPath, pr, { repoId: wtRepoId })
+      }
+    }
+    void load()
+  }, [wtPath, wtBranch, wtLinkedPR, wtRepoId, fetchPRComments, fetchPRForBranch])
+
   // Why: subscribe to the raw comments array on the worktree so selector
-  // identity only changes when diffComments actually changes on this worktree.
+  // identity only changes when localDiffComments actually changes on this worktree.
   // Filtering by relativePath happens in a memo below.
-  const allDiffComments = useAppStore((s): DiffComment[] | undefined =>
+  const localDiffComments = useAppStore((s): DiffComment[] | undefined =>
     selectWorktreeDiffComments(s, worktreeId)
   )
-  const diffComments = useMemo(
-    () => (allDiffComments ?? []).filter((c) => c.filePath === relativePath && isDiffComment(c)),
-    [allDiffComments, relativePath]
-  )
+  const rawPRComments = useAppStore((s) => {
+    if (!worktreeId) {
+      return EMPTY_PR_COMMENTS
+    }
+    const wt = s.getKnownWorktreeById(worktreeId)
+    if (!wt || !wt.repoId) {
+      return EMPTY_PR_COMMENTS
+    }
+    let pr = wt.linkedPR
+    if (!pr && wt.branch) {
+      const keys = Object.keys(s.prCache)
+      const targetKey = keys.find(
+        (k) => k.toLowerCase().includes(wt.repoId.toLowerCase()) && k.endsWith(`::${wt.branch}`)
+      )
+      const cachedPR = targetKey ? s.prCache[targetKey]?.data : null
+      if (cachedPR) {
+        pr = cachedPR.number
+      }
+    }
+    if (!pr) {
+      return EMPTY_PR_COMMENTS
+    }
+    // Why: commentsCache keys may be prefixed by host/runtime environment
+    // scope or contain the full prRepo name in the middle. Match keys
+    // dynamically to find the correct entry regardless of caching scopes.
+    const keys = Object.keys(s.commentsCache)
+    const targetKey = keys.find(
+      (k) =>
+        k.toLowerCase().includes(wt.repoId.toLowerCase()) &&
+        k.includes('::pr-comments::') &&
+        k.endsWith(`::${pr}`)
+    )
+    return (targetKey ? s.commentsCache[targetKey]?.data : null) ?? EMPTY_PR_COMMENTS
+  })
+  const allComments = useMemo(() => {
+    const local = (localDiffComments ?? []).filter(
+      (c) => c.filePath === relativePath && isDiffComment(c)
+    )
+    const pr = prCommentsToDecoratedDiffComments(rawPRComments, relativePath, worktreeId ?? '')
+    return [...local, ...pr]
+  }, [localDiffComments, rawPRComments, relativePath, worktreeId])
   const terminalFontSize = settings?.terminalFontSize ?? 13
   const diffEditorFontSize = computeDiffEditorFontSize(terminalFontSize, editorFontZoomLevel)
   const isDark =
@@ -97,8 +168,8 @@ export default function DiffViewer({
     if (!worktreeId || !scrollToDiffCommentId) {
       return null
     }
-    return diffComments.some((c) => c.id === scrollToDiffCommentId) ? scrollToDiffCommentId : null
-  }, [scrollToDiffCommentId, diffComments, worktreeId])
+    return allComments.some((c) => c.id === scrollToDiffCommentId) ? scrollToDiffCommentId : null
+  }, [scrollToDiffCommentId, allComments, worktreeId])
 
   // Why: gate the decorator on having a comment target. Local diffs persist
   // notes to worktree metadata; GitHub PR diffs post line comments remotely.
@@ -108,7 +179,7 @@ export default function DiffViewer({
     monacoModelIdentity: modifiedModelKey ?? modelKey,
     filePath: relativePath,
     worktreeId: worktreeId ?? '',
-    comments: worktreeId ? diffComments : [],
+    comments: worktreeId ? allComments : [],
     commentableLineNumbers,
     addButtonLabel: addLineCommentLabel,
     onAddCommentClick: ({ lineNumber, startLine, top }) =>

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -3,19 +3,17 @@ import { DiffEditor, type DiffOnMount } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import { useAppStore } from '@/store'
 import { diffViewStateCache, setWithLRU } from '@/lib/scroll-cache'
-import { monaco } from '@/lib/monaco-setup'
 import { computeDiffEditorFontSize } from '@/lib/editor-font-zoom'
 import { useContextualCopySetup } from './useContextualCopySetup'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
-import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
-import {
-  getDiffCommentPopoverLeft,
-  getDiffCommentPopoverTop
-} from '../diff-comments/diff-comment-popover-position'
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import type { DiffComment, PRComment } from '../../../../shared/types'
-import { isDiffComment, prCommentsToDecoratedDiffComments } from '@/lib/diff-comment-compat'
+import {
+  isDiffComment,
+  prCommentsToDecoratedDiffComments,
+  selectRawPRCommentsFromStore
+} from '@/lib/diff-comment-compat'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
 import { diffEditorScrollbarOptions } from './diff-editor-scrollbar-options'
 import { LargeDiffFallback } from './LargeDiffFallback'
@@ -26,6 +24,10 @@ import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
+import { useDiffCommentSubmit } from './useDiffCommentSubmit'
+import { useDiffCommentPopoverPosition } from './useDiffCommentPopoverPosition'
+import { useDiffCommentDecoratorConfig } from './useDiffCommentDecoratorConfig'
+import { useDiffViewerAutoScroll } from './useDiffViewerAutoScroll'
 
 const EMPTY_PR_COMMENTS: PRComment[] = []
 
@@ -89,46 +91,16 @@ export default function DiffViewer({
     void load()
   }, [wtPath, wtBranch, wtLinkedPR, wtRepoId, fetchPRComments, fetchPRForBranch])
 
+  // Why: split local and PR comment subscriptions into separate selectors so
+  // each returns a stable store reference. Combining them inside a single
+  // useAppStore selector caused a new array on every store update (via .filter
+  // and spread), triggering infinite re-renders.
   // Why: subscribe to the raw comments array on the worktree so selector
   // identity only changes when localDiffComments actually changes on this worktree.
-  // Filtering by relativePath happens in a memo below.
   const localDiffComments = useAppStore((s): DiffComment[] | undefined =>
     selectWorktreeDiffComments(s, worktreeId)
   )
-  const rawPRComments = useAppStore((s) => {
-    if (!worktreeId) {
-      return EMPTY_PR_COMMENTS
-    }
-    const wt = s.getKnownWorktreeById(worktreeId)
-    if (!wt || !wt.repoId) {
-      return EMPTY_PR_COMMENTS
-    }
-    let pr = wt.linkedPR
-    if (!pr && wt.branch) {
-      const keys = Object.keys(s.prCache)
-      const targetKey = keys.find(
-        (k) => k.toLowerCase().includes(wt.repoId.toLowerCase()) && k.endsWith(`::${wt.branch}`)
-      )
-      const cachedPR = targetKey ? s.prCache[targetKey]?.data : null
-      if (cachedPR) {
-        pr = cachedPR.number
-      }
-    }
-    if (!pr) {
-      return EMPTY_PR_COMMENTS
-    }
-    // Why: commentsCache keys may be prefixed by host/runtime environment
-    // scope or contain the full prRepo name in the middle. Match keys
-    // dynamically to find the correct entry regardless of caching scopes.
-    const keys = Object.keys(s.commentsCache)
-    const targetKey = keys.find(
-      (k) =>
-        k.toLowerCase().includes(wt.repoId.toLowerCase()) &&
-        k.includes('::pr-comments::') &&
-        k.endsWith(`::${pr}`)
-    )
-    return (targetKey ? s.commentsCache[targetKey]?.data : null) ?? EMPTY_PR_COMMENTS
-  })
+  const rawPRComments = useAppStore((s) => selectRawPRCommentsFromStore(s, worktreeId))
   const allComments = useMemo(() => {
     const local = (localDiffComments ?? []).filter(
       (c) => c.filePath === relativePath && isDiffComment(c)
@@ -171,65 +143,28 @@ export default function DiffViewer({
     return allComments.some((c) => c.id === scrollToDiffCommentId) ? scrollToDiffCommentId : null
   }, [scrollToDiffCommentId, allComments, worktreeId])
 
-  // Why: gate the decorator on having a comment target. Local diffs persist
-  // notes to worktree metadata; GitHub PR diffs post line comments remotely.
-  // updateDiffComment is only wired for local diffs (worktreeId present).
-  useDiffCommentDecorator({
-    editor: hasLineCommentAction ? modifiedEditor : null,
-    monacoModelIdentity: modifiedModelKey ?? modelKey,
-    filePath: relativePath,
-    worktreeId: worktreeId ?? '',
-    comments: worktreeId ? allComments : [],
+  useDiffCommentDecoratorConfig({
+    hasLineCommentAction,
+    modifiedEditor,
+    relativePath,
+    worktreeId,
+    allComments,
     commentableLineNumbers,
-    addButtonLabel: addLineCommentLabel,
-    onAddCommentClick: ({ lineNumber, startLine, top }) =>
-      setPopover({
-        lineNumber,
-        startLine,
-        top,
-        left: modifiedEditor
-          ? (getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current) ?? undefined)
-          : undefined,
-        lineHeight: modifiedEditor?.getOption(monaco.editor.EditorOption.lineHeight) ?? 0
-      }),
-    onDeleteComment: (id) => {
-      if (worktreeId) {
-        void deleteDiffComment(worktreeId, id)
-      }
-    },
-    onUpdateComment: worktreeId ? (id, body) => updateDiffComment(worktreeId, id, body) : undefined,
-    pendingScrollCommentId: pendingScrollForThisViewer,
-    onPendingScrollConsumed: () => setScrollToDiffCommentId(null)
+    addLineCommentLabel,
+    deleteDiffComment,
+    updateDiffComment,
+    pendingScrollForThisViewer,
+    setScrollToDiffCommentId,
+    diffBodyRef,
+    setPopover
   })
 
-  useEffect(() => {
-    if (!modifiedEditor || !popover) {
-      return
-    }
-    const update = (): void => {
-      const lineHeight = modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
-      const top = getDiffCommentPopoverTop(modifiedEditor, popover.lineNumber, lineHeight)
-      if (top == null) {
-        setPopover(null)
-        return
-      }
-      const left = getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current)
-      setPopover((prev) =>
-        prev ? { ...prev, top, left: left == null ? prev.left : left, lineHeight } : prev
-      )
-    }
-    const scrollSub = modifiedEditor.onDidScrollChange(update)
-    const contentSub = modifiedEditor.onDidContentSizeChange(update)
-    const layoutSub = modifiedEditor.onDidLayoutChange(update)
-    return () => {
-      scrollSub.dispose()
-      contentSub.dispose()
-      layoutSub.dispose()
-    }
-    // Why: depend on popover.lineNumber (not the whole popover object) so the
-    // effect doesn't re-subscribe on every top update it dispatches.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modifiedEditor, popover?.lineNumber])
+  useDiffCommentPopoverPosition({
+    modifiedEditor,
+    popover,
+    diffBodyRef,
+    setPopover
+  })
 
   // Why: on a fresh open (no cached view state, no pending scroll-to-note),
   // center the first diff change in the viewport. We do this from a dedicated
@@ -242,75 +177,12 @@ export default function DiffViewer({
   // zones already in the layout, so the math survives whatever the decorator
   // added in this render pass. The didScroll guard makes this strictly
   // one-shot per mount.
-  const didAutoScrollFirstDiffRef = useRef(false)
-  const didAutoScrollModelKeyRef = useRef(modelKey)
-  useEffect(() => {
-    if (didAutoScrollModelKeyRef.current !== modelKey) {
-      didAutoScrollModelKeyRef.current = modelKey
-      // Why: the one-shot above is intentionally per-modelKey. Reset inside
-      // this Effect before its first-diff guard runs for the new file.
-      didAutoScrollFirstDiffRef.current = false
-    }
-    const diffEditor = diffEditorRef.current
-    if (!diffEditor || !modifiedEditor) {
-      return
-    }
-    if (didAutoScrollFirstDiffRef.current) {
-      return
-    }
-    if (diffViewStateCache.get(modelKey)) {
-      return
-    }
-    if (pendingScrollForThisViewer) {
-      // Why: the decorator owns this scroll for this mount, so permanently
-      // yield by setting the one-shot flag. Otherwise, when the decorator
-      // ack's and `pendingScrollForThisViewer` flips back to null, this
-      // effect would re-run with empty cache + un-set flag and overwrite
-      // the comment scroll with a jump to the first diff.
-      didAutoScrollFirstDiffRef.current = true
-      return
-    }
-    let rafId: number | null = null
-    const run = (): void => {
-      if (didAutoScrollFirstDiffRef.current) {
-        return
-      }
-      const changes = diffEditor.getLineChanges()
-      if (!changes || changes.length === 0) {
-        return
-      }
-      const line = Math.max(1, changes[0].modifiedStartLineNumber)
-      // Defer one frame so any view zones added in this render pass are part
-      // of the layout before we measure. Cancel any earlier pending rAF so
-      // a late onDidUpdateDiff can't enqueue a redundant scroll.
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId)
-      }
-      rafId = requestAnimationFrame(() => {
-        rafId = null
-        if (didAutoScrollFirstDiffRef.current || !modifiedEditor.getModel()) {
-          return
-        }
-        const top = modifiedEditor.getTopForLineNumber(line, true)
-        const editorHeight = modifiedEditor.getLayoutInfo().height
-        modifiedEditor.setPosition({ lineNumber: line, column: 1 })
-        modifiedEditor.setScrollTop(Math.max(0, top - editorHeight / 2))
-        didAutoScrollFirstDiffRef.current = true
-      })
-    }
-    // If the diff result is already available, run immediately; otherwise
-    // wait for it. onDidUpdateDiff fires once the diff computation lands.
-    if (diffEditor.getLineChanges()) {
-      run()
-    }
-    const sub = diffEditor.onDidUpdateDiff(() => run())
-    return () => {
-      sub.dispose()
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId)
-      }
-    }
-  }, [modifiedEditor, modelKey, pendingScrollForThisViewer])
+  useDiffViewerAutoScroll({
+    diffEditorRef,
+    modifiedEditor,
+    modelKey,
+    pendingScrollForThisViewer
+  })
 
   const handleEnterLargeDiffFallback = useCallback(() => {
     // Why: when a tab transitions to the safety fallback, stale Monaco refs
@@ -328,42 +200,14 @@ export default function DiffViewer({
     setPopover(null)
   }, [unregisterDiffEditor])
 
-  const handleSubmitComment = async (body: string): Promise<void> => {
-    if (!popover) {
-      return
-    }
-    if (onAddLineComment) {
-      const ok = await onAddLineComment({
-        lineNumber: popover.lineNumber,
-        startLine: popover.startLine,
-        body
-      })
-      if (ok) {
-        setPopover(null)
-      }
-      return
-    }
-    if (!worktreeId) {
-      return
-    }
-    // Why: await persistence before closing — if addDiffComment resolves null
-    // (store rolled back after IPC failure), keep the popover open so the user
-    // can retry instead of silently losing their draft.
-    const result = await addDiffComment({
-      worktreeId,
-      filePath: relativePath,
-      source: 'diff',
-      startLine: popover.startLine,
-      lineNumber: popover.lineNumber,
-      body,
-      side: 'modified'
-    })
-    if (result) {
-      setPopover(null)
-    } else {
-      console.error('Failed to add diff comment — draft preserved')
-    }
-  }
+  const handleSubmitComment = useDiffCommentSubmit({
+    popover,
+    onAddLineComment,
+    worktreeId,
+    relativePath,
+    addDiffComment,
+    setPopover
+  })
 
   // Keep refs to latest callbacks so the mounted editor always calls current versions
   const onSaveRef = useRef(onSave)

--- a/src/renderer/src/components/editor/useDiffCommentDecoratorConfig.ts
+++ b/src/renderer/src/components/editor/useDiffCommentDecoratorConfig.ts
@@ -1,0 +1,77 @@
+import type { editor } from 'monaco-editor'
+import { monaco } from '@/lib/monaco-setup'
+import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
+import { getDiffCommentPopoverLeft } from '../diff-comments/diff-comment-popover-position'
+
+export function useDiffCommentDecoratorConfig({
+  hasLineCommentAction,
+  modifiedEditor,
+  relativePath,
+  worktreeId,
+  allComments,
+  commentableLineNumbers,
+  addLineCommentLabel,
+  deleteDiffComment,
+  updateDiffComment,
+  pendingScrollForThisViewer,
+  setScrollToDiffCommentId,
+  diffBodyRef,
+  setPopover
+}: {
+  hasLineCommentAction: boolean
+  modifiedEditor: editor.ICodeEditor | null
+  relativePath: string
+  worktreeId: string | undefined
+  allComments: {
+    id: string
+    lineNumber: number
+    startLine?: number
+    body: string
+  }[]
+  commentableLineNumbers: Set<number> | undefined
+  addLineCommentLabel: string | undefined
+  deleteDiffComment: (worktreeId: string, id: string) => void
+  updateDiffComment: (worktreeId: string, id: string, body: string) => void
+  pendingScrollForThisViewer: string | null
+  setScrollToDiffCommentId: (id: string | null) => void
+  diffBodyRef: React.RefObject<HTMLDivElement | null>
+  setPopover: React.Dispatch<
+    React.SetStateAction<{
+      lineNumber: number
+      startLine?: number
+      top: number
+      left?: number
+      lineHeight: number
+    } | null>
+  >
+}): void {
+  // Why: gate the decorator on having a comment target. Local diffs persist
+  // notes to worktree metadata; GitHub PR diffs post line comments remotely.
+  // updateDiffComment is only wired for local diffs (worktreeId present).
+  useDiffCommentDecorator({
+    editor: hasLineCommentAction ? modifiedEditor : null,
+    filePath: relativePath,
+    worktreeId: worktreeId ?? '',
+    comments: worktreeId ? allComments : [],
+    commentableLineNumbers,
+    addButtonLabel: addLineCommentLabel,
+    onAddCommentClick: ({ lineNumber, startLine, top }) =>
+      setPopover({
+        lineNumber,
+        startLine,
+        top,
+        left: modifiedEditor
+          ? (getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current) ?? undefined)
+          : undefined,
+        lineHeight: modifiedEditor?.getOption(monaco.editor.EditorOption.lineHeight) ?? 0
+      }),
+    onDeleteComment: (id) => {
+      if (worktreeId) {
+        void deleteDiffComment(worktreeId, id)
+      }
+    },
+    onUpdateComment: worktreeId ? (id, body) => updateDiffComment(worktreeId, id, body) : undefined,
+    pendingScrollCommentId: pendingScrollForThisViewer,
+    onPendingScrollConsumed: () => setScrollToDiffCommentId(null)
+  })
+}

--- a/src/renderer/src/components/editor/useDiffCommentPopoverPosition.ts
+++ b/src/renderer/src/components/editor/useDiffCommentPopoverPosition.ts
@@ -1,0 +1,62 @@
+import { useEffect } from 'react'
+import type { editor } from 'monaco-editor'
+import { monaco } from '@/lib/monaco-setup'
+import {
+  getDiffCommentPopoverLeft,
+  getDiffCommentPopoverTop
+} from '../diff-comments/diff-comment-popover-position'
+
+export function useDiffCommentPopoverPosition({
+  modifiedEditor,
+  popover,
+  diffBodyRef,
+  setPopover
+}: {
+  modifiedEditor: editor.ICodeEditor | null
+  popover: {
+    lineNumber: number
+    startLine?: number
+    top: number
+    left?: number
+    lineHeight: number
+  } | null
+  diffBodyRef: React.RefObject<HTMLDivElement | null>
+  setPopover: React.Dispatch<
+    React.SetStateAction<{
+      lineNumber: number
+      startLine?: number
+      top: number
+      left?: number
+      lineHeight: number
+    } | null>
+  >
+}): void {
+  useEffect(() => {
+    if (!modifiedEditor || !popover) {
+      return
+    }
+    const update = (): void => {
+      const lineHeight = modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
+      const top = getDiffCommentPopoverTop(modifiedEditor, popover.lineNumber, lineHeight)
+      if (top == null) {
+        setPopover(null)
+        return
+      }
+      const left = getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current)
+      setPopover((prev) =>
+        prev ? { ...prev, top, left: left == null ? prev.left : left, lineHeight } : prev
+      )
+    }
+    const scrollSub = modifiedEditor.onDidScrollChange(update)
+    const contentSub = modifiedEditor.onDidContentSizeChange(update)
+    const layoutSub = modifiedEditor.onDidLayoutChange(update)
+    return () => {
+      scrollSub.dispose()
+      contentSub.dispose()
+      layoutSub.dispose()
+    }
+    // Why: depend on popover.lineNumber (not the whole popover object) so the
+    // effect doesn't re-subscribe on every top update it dispatches.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modifiedEditor, popover?.lineNumber])
+}

--- a/src/renderer/src/components/editor/useDiffCommentSubmit.ts
+++ b/src/renderer/src/components/editor/useDiffCommentSubmit.ts
@@ -1,0 +1,80 @@
+// Why: handles diff comment submission for both local diff comments and external
+// line comment handlers. Extracted to reduce DiffViewer.tsx line count.
+import type { DiffComment } from '../../../../shared/types'
+
+export function useDiffCommentSubmit({
+  popover,
+  onAddLineComment,
+  worktreeId,
+  relativePath,
+  addDiffComment,
+  setPopover
+}: {
+  popover: {
+    lineNumber: number
+    startLine?: number
+    top: number
+    left?: number
+    lineHeight: number
+  } | null
+  onAddLineComment:
+    | ((props: { lineNumber: number; startLine?: number; body: string }) => Promise<boolean>)
+    | undefined
+  worktreeId: string | undefined
+  relativePath: string
+  addDiffComment: (props: {
+    worktreeId: string
+    filePath: string
+    source: 'diff' | 'markdown'
+    startLine?: number
+    lineNumber: number
+    body: string
+    side: 'modified'
+  }) => Promise<DiffComment | null>
+  setPopover: React.Dispatch<
+    React.SetStateAction<{
+      lineNumber: number
+      startLine?: number
+      top: number
+      left?: number
+      lineHeight: number
+    } | null>
+  >
+}): (body: string) => Promise<void> {
+  return async (body: string): Promise<void> => {
+    if (!popover) {
+      return
+    }
+    if (onAddLineComment) {
+      const ok = await onAddLineComment({
+        lineNumber: popover.lineNumber,
+        startLine: popover.startLine,
+        body
+      })
+      if (ok) {
+        setPopover(null)
+      }
+      return
+    }
+    if (!worktreeId) {
+      return
+    }
+    // Why: await persistence before closing — if addDiffComment resolves null
+    // (store rolled back after IPC failure), keep the popover open so the user
+    // can retry instead of silently losing their draft.
+    const result = await addDiffComment({
+      worktreeId,
+      filePath: relativePath,
+      source: 'diff',
+      startLine: popover.startLine,
+      lineNumber: popover.lineNumber,
+      body,
+      side: 'modified' as const
+    })
+    if (result) {
+      setPopover(null)
+    } else {
+      console.error('Failed to add diff comment — draft preserved')
+    }
+  }
+}

--- a/src/renderer/src/components/editor/useDiffViewerAutoScroll.ts
+++ b/src/renderer/src/components/editor/useDiffViewerAutoScroll.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react'
+import type { editor } from 'monaco-editor'
+import { diffViewStateCache } from '@/lib/scroll-cache'
+
+export function useDiffViewerAutoScroll({
+  diffEditorRef,
+  modifiedEditor,
+  modelKey,
+  pendingScrollForThisViewer
+}: {
+  diffEditorRef: React.MutableRefObject<editor.IStandaloneDiffEditor | null>
+  modifiedEditor: editor.ICodeEditor | null
+  modelKey: string
+  pendingScrollForThisViewer: string | null
+}): void {
+  const didAutoScrollFirstDiffRef = useRef(false)
+  const didAutoScrollModelKeyRef = useRef(modelKey)
+  useEffect(() => {
+    if (didAutoScrollModelKeyRef.current !== modelKey) {
+      didAutoScrollModelKeyRef.current = modelKey
+      // Why: the one-shot above is intentionally per-modelKey. Reset inside
+      // this Effect before its first-diff guard runs for the new file.
+      didAutoScrollFirstDiffRef.current = false
+    }
+    const diffEditor = diffEditorRef.current
+    if (!diffEditor || !modifiedEditor) {
+      return
+    }
+    if (didAutoScrollFirstDiffRef.current) {
+      return
+    }
+    if (diffViewStateCache.get(modelKey)) {
+      return
+    }
+    if (pendingScrollForThisViewer) {
+      // Why: the decorator owns this scroll for this mount, so permanently
+      // yield by setting the one-shot flag. Otherwise, when the decorator
+      // ack's and `pendingScrollForThisViewer` flips back to null, this
+      // effect would re-run with empty cache + un-set flag and overwrite
+      // the comment scroll with a jump to the first diff.
+      didAutoScrollFirstDiffRef.current = true
+      return
+    }
+    let rafId: number | null = null
+    const run = (): void => {
+      if (didAutoScrollFirstDiffRef.current) {
+        return
+      }
+      const changes = diffEditor.getLineChanges()
+      if (!changes || changes.length === 0) {
+        return
+      }
+      const line = Math.max(1, changes[0].modifiedStartLineNumber)
+      // Defer one frame so any view zones added in this render pass are part
+      // of the layout before we measure. Cancel any earlier pending rAF so
+      // a late onDidUpdateDiff can't enqueue a redundant scroll.
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+      }
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        if (didAutoScrollFirstDiffRef.current || !modifiedEditor.getModel()) {
+          return
+        }
+        const top = modifiedEditor.getTopForLineNumber(line, true)
+        const editorHeight = modifiedEditor.getLayoutInfo().height
+        modifiedEditor.setPosition({ lineNumber: line, column: 1 })
+        modifiedEditor.setScrollTop(Math.max(0, top - editorHeight / 2))
+        didAutoScrollFirstDiffRef.current = true
+      })
+    }
+    // If the diff result is already available, run immediately; otherwise
+    // wait for it. onDidUpdateDiff fires once the diff computation lands.
+    if (diffEditor.getLineChanges()) {
+      run()
+    }
+    const sub = diffEditor.onDidUpdateDiff(() => run())
+    return () => {
+      sub.dispose()
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+      }
+    }
+  }, [diffEditorRef, modifiedEditor, modelKey, pendingScrollForThisViewer])
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -975,9 +975,15 @@
           "from": "from",
           "to": "to",
           "activity": "Activity",
-          "noActivity": "No activity yet."
+          "noActivity": "No activity yet.",
+          "activityExpand": "Expand activity",
+          "activityCollapse": "Collapse activity"
         },
-        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked."
+        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked.",
+        "comments": {
+          "expand": "Expand comments",
+          "collapse": "Collapse comments"
+        }
       },
       "GitLabItemDialog": {
         "65e784c1f1": "Reopen",
@@ -1451,7 +1457,11 @@
         "8ff5ae8866": "Assignees",
         "82c87eceb9": "Edit assignees",
         "1ff5d979df": "No one assigned",
-        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked."
+        "checkActionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked.",
+        "comments": {
+          "expand": "Expand comments",
+          "collapse": "Collapse comments"
+        }
       },
       "QuickOpen": {
         "1dbd3f59ff": "Move",
@@ -12324,7 +12334,9 @@
             "6978871a3d": "Open",
             "cce596969e": "Delete note",
             "cad3384faa": "Edit note",
-            "508ee678a5": "Open in browser"
+            "508ee678a5": "Open in browser",
+            "expand": "Expand comment",
+            "collapse": "Collapse comment"
           },
           "DiffCommentPopover": {
             "2b3ce6d394": "Cancel",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -952,9 +952,15 @@
           "from": "de",
           "to": "a",
           "activity": "Actividad",
-          "noActivity": "Sin actividad aún."
+          "noActivity": "Sin actividad aún.",
+          "activityExpand": "Expandir actividad",
+          "activityCollapse": "Contraer actividad"
         },
-        "checkActionRequiredHint": "Esta verificación necesita una acción manual en GitHub (por ejemplo, aprobar la ejecución del workflow) antes de que se desbloquee la fusión."
+        "checkActionRequiredHint": "Esta verificación necesita una acción manual en GitHub (por ejemplo, aprobar la ejecución del workflow) antes de que se desbloquee la fusión.",
+        "comments": {
+          "expand": "Expandir comentarios",
+          "collapse": "Contraer comentarios"
+        }
       },
       "GitLabItemDialog": {
         "65e784c1f1": "Reabrir",
@@ -1428,7 +1434,11 @@
         "dd5d9a4f17": "actualizado {{value0}}",
         "71a3c0f9d2": "Iniciar espacio de trabajo",
         "filesUnavailable": "Couldn't load changed files.",
-        "filesRetry": "Retry"
+        "filesRetry": "Retry",
+        "comments": {
+          "expand": "Expandir comentarios",
+          "collapse": "Contraer comentarios"
+        }
       },
       "QuickOpen": {
         "1dbd3f59ff": "Mover",
@@ -12301,7 +12311,9 @@
             "6978871a3d": "Abierto",
             "cce596969e": "Eliminar nota",
             "cad3384faa": "Editar nota",
-            "508ee678a5": "Abrir en el navegador"
+            "508ee678a5": "Abrir en el navegador",
+            "expand": "Expandir comentario",
+            "collapse": "Contraer comentario"
           },
           "DiffCommentPopover": {
             "2b3ce6d394": "Cancelar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -952,9 +952,15 @@
           "from": "from",
           "to": "to",
           "activity": "アクティビティ",
-          "noActivity": "まだアクティビティはありません。"
+          "noActivity": "まだアクティビティはありません。",
+          "activityExpand": "アクティビティを展開する",
+          "activityCollapse": "アクティビティを折りたたむ"
         },
-        "checkActionRequiredHint": "マージを解除するには、このチェックにGitHub上で手動アクション（例：ワークフロー実行の承認）が必要です。"
+        "checkActionRequiredHint": "マージを解除するには、このチェックにGitHub上で手動アクション（例：ワークフロー実行の承認）が必要です。",
+        "comments": {
+          "expand": "コメントを展開する",
+          "collapse": "コメントを折りたたむ"
+        }
       },
       "GitLabItemDialog": {
         "65e784c1f1": "再度開く",
@@ -1428,7 +1434,11 @@
         "dd5d9a4f17": "{{value0}}に更新",
         "71a3c0f9d2": "ワークスペースを開始",
         "filesUnavailable": "Couldn't load changed files.",
-        "filesRetry": "Retry"
+        "filesRetry": "Retry",
+        "comments": {
+          "expand": "コメントを展開する",
+          "collapse": "コメントを折りたたむ"
+        }
       },
       "QuickOpen": {
         "1dbd3f59ff": "移動",
@@ -12301,7 +12311,9 @@
             "6978871a3d": "オープン",
             "cce596969e": "メモの削除",
             "cad3384faa": "メモを編集する",
-            "508ee678a5": "ブラウザで開く"
+            "508ee678a5": "ブラウザで開く",
+            "expand": "コメントを展開する",
+            "collapse": "コメントを折りたたむ"
           },
           "DiffCommentPopover": {
             "2b3ce6d394": "キャンセル",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -952,9 +952,15 @@
           "from": "from",
           "to": "to",
           "activity": "활동",
-          "noActivity": "아직 활동이 없습니다."
+          "noActivity": "아직 활동이 없습니다.",
+          "activityExpand": "활동 펼치기",
+          "activityCollapse": "활동 접기"
         },
-        "checkActionRequiredHint": "머지가 해제되려면 이 검사에 대해 GitHub에서 수동 작업(예: 워크플로우 실행 승인)이 필요합니다."
+        "checkActionRequiredHint": "머지가 해제되려면 이 검사에 대해 GitHub에서 수동 작업(예: 워크플로우 실행 승인)이 필요합니다.",
+        "comments": {
+          "expand": "댓글 펼치기",
+          "collapse": "댓글 접기"
+        }
       },
       "GitLabItemDialog": {
         "65e784c1f1": "다시 열기",
@@ -1428,7 +1434,11 @@
         "dd5d9a4f17": "{{value0}}에 업데이트됨",
         "71a3c0f9d2": "워크스페이스 시작",
         "filesUnavailable": "변경된 파일을 불러오지 못했습니다.",
-        "filesRetry": "Retry"
+        "filesRetry": "Retry",
+        "comments": {
+          "expand": "댓글 펼치기",
+          "collapse": "댓글 접기"
+        }
       },
       "QuickOpen": {
         "1dbd3f59ff": "이동",
@@ -12301,7 +12311,9 @@
             "6978871a3d": "열기",
             "cce596969e": "메모 삭제",
             "cad3384faa": "메모 수정",
-            "508ee678a5": "브라우저에서 열기"
+            "508ee678a5": "브라우저에서 열기",
+            "expand": "댓글 펼치기",
+            "collapse": "댓글 접기"
           },
           "DiffCommentPopover": {
             "2b3ce6d394": "취소",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -952,9 +952,15 @@
           "from": "从",
           "to": "到",
           "activity": "活动",
-          "noActivity": "暂无活动。"
+          "noActivity": "暂无活动。",
+          "activityExpand": "展开活动",
+          "activityCollapse": "折叠活动"
         },
-        "checkActionRequiredHint": "此检查需要在 GitHub 上执行手动操作（例如批准工作流运行）后才能解除合并阻止。"
+        "checkActionRequiredHint": "此检查需要在 GitHub 上执行手动操作（例如批准工作流运行）后才能解除合并阻止。",
+        "comments": {
+          "expand": "展开评论",
+          "collapse": "折叠评论"
+        }
       },
       "GitLabItemDialog": {
         "65e784c1f1": "重新打开",
@@ -1428,7 +1434,11 @@
         "dd5d9a4f17": "{{value0}}更新",
         "71a3c0f9d2": "启动工作区",
         "filesUnavailable": "Couldn't load changed files.",
-        "filesRetry": "Retry"
+        "filesRetry": "Retry",
+        "comments": {
+          "expand": "展开评论",
+          "collapse": "折叠评论"
+        }
       },
       "QuickOpen": {
         "1dbd3f59ff": "移动",
@@ -12301,7 +12311,9 @@
             "6978871a3d": "打开",
             "cce596969e": "删除注释",
             "cad3384faa": "编辑备注",
-            "508ee678a5": "在浏览器中打开"
+            "508ee678a5": "在浏览器中打开",
+            "expand": "展开评论",
+            "collapse": "折叠评论"
           },
           "DiffCommentPopover": {
             "2b3ce6d394": "取消",

--- a/src/renderer/src/lib/diff-comment-compat.test.ts
+++ b/src/renderer/src/lib/diff-comment-compat.test.ts
@@ -327,6 +327,35 @@ describe('diff comment compatibility helpers', () => {
       expect(retrieved[0].id).toBe(123)
     })
 
+    it('matches PR comment cache repo IDs by inclusion', () => {
+      const state = {
+        getKnownWorktreeById: (id: string) => ({
+          id,
+          repoId: 'repo-1',
+          linkedPR: 12
+        }),
+        prCache: {},
+        commentsCache: {
+          'scope::repo-10::pr-comments::repo-10::12': { data: [mockPRComment] },
+          'scope::repo-1::pr-comments::repo-1::12': { data: [] }
+        }
+      } as unknown as AppState
+
+      expect(selectRawPRCommentsFromStore(state, 'wt-1')).toEqual([mockPRComment])
+    })
+
+    it('reuses empty PR comment array references', () => {
+      const state = {
+        getKnownWorktreeById: () => undefined,
+        prCache: {},
+        commentsCache: {}
+      } as unknown as AppState
+
+      expect(selectRawPRCommentsFromStore(state, 'wt-1')).toBe(
+        selectRawPRCommentsFromStore(state, 'wt-1')
+      )
+    })
+
     it('selectRawPRCommentsFromStore returns empty array for missing worktree', () => {
       const state = {
         getKnownWorktreeById: () => undefined,

--- a/src/renderer/src/lib/diff-comment-compat.test.ts
+++ b/src/renderer/src/lib/diff-comment-compat.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from 'vitest'
 import type { DiffComment, PRComment } from '../../../shared/types'
 import type { AppState } from '../store/types'
 import {
+  combineDiffComments,
   getDiffCommentLineLabel,
   getDiffCommentSource,
   isDiffComment,
   isMarkdownComment,
+  prCommentToDecoratedDiffComment,
   prCommentsToDecoratedDiffComments,
-  getPRInlineCommentsFromStore
+  getPRInlineCommentsFromStore,
+  selectRawPRCommentsFromStore
 } from './diff-comment-compat'
 
 function makeComment(overrides: Partial<DiffComment> = {}): DiffComment {
@@ -58,7 +61,7 @@ describe('diff comment compatibility helpers', () => {
 
     it('maps raw PR comment to decorated comment when path matches with different casing/slashes', () => {
       const comments = [mockPRComment]
-      
+
       // Exact match
       let mapped = prCommentsToDecoratedDiffComments(comments, 'src/components/button.tsx', 'wt-1')
       expect(mapped).toHaveLength(1)
@@ -76,6 +79,144 @@ describe('diff comment compatibility helpers', () => {
       // Casing difference
       mapped = prCommentsToDecoratedDiffComments(comments, 'SRC/Components/Button.tsx', 'wt-1')
       expect(mapped).toHaveLength(1)
+    })
+
+    it('filters out comments without path or line number', () => {
+      const comments: PRComment[] = [
+        mockPRComment,
+        { ...mockPRComment, id: 456, path: undefined },
+        { ...mockPRComment, id: 789, line: undefined }
+      ]
+
+      const mapped = prCommentsToDecoratedDiffComments(
+        comments,
+        'src/components/button.tsx',
+        'wt-1'
+      )
+      expect(mapped).toHaveLength(1)
+      expect(mapped[0].id).toBe('pr-123')
+    })
+
+    it('handles empty comment array', () => {
+      const mapped = prCommentsToDecoratedDiffComments([], 'src/components/button.tsx', 'wt-1')
+      expect(mapped).toHaveLength(0)
+    })
+
+    it('filters comments by file path', () => {
+      const comments: PRComment[] = [
+        mockPRComment,
+        { ...mockPRComment, id: 456, path: 'src/other/file.ts' },
+        { ...mockPRComment, id: 789, path: 'src/components/button.tsx' }
+      ]
+
+      const mapped = prCommentsToDecoratedDiffComments(
+        comments,
+        'src/components/button.tsx',
+        'wt-1'
+      )
+      expect(mapped).toHaveLength(2)
+      expect(mapped[0].id).toBe('pr-123')
+      expect(mapped[1].id).toBe('pr-789')
+    })
+
+    it('transforms individual PR comment to decorated format', () => {
+      const comment: PRComment = {
+        id: 123,
+        author: 'bunny',
+        authorAvatarUrl: 'avatar',
+        body: 'Review comment',
+        createdAt: '2026-07-16T12:00:00Z',
+        url: 'https://example.com',
+        path: 'src/file.ts',
+        line: 10,
+        startLine: 5
+      }
+
+      const decorated = prCommentToDecoratedDiffComment(comment, 'wt-1')
+      expect(decorated).not.toBeNull()
+      expect(decorated?.id).toBe('pr-123')
+      expect(decorated?.worktreeId).toBe('wt-1')
+      expect(decorated?.filePath).toBe('src/file.ts')
+      expect(decorated?.lineNumber).toBe(10)
+      expect(decorated?.startLine).toBe(5)
+      expect(decorated?.body).toBe('Review comment')
+      expect(decorated?.author).toBe('bunny')
+      expect(decorated?.authorAvatarUrl).toBe('avatar')
+      expect(decorated?.url).toBe('https://example.com')
+      expect(decorated?.canDelete).toBe(false)
+      expect(decorated?.canEdit).toBe(false)
+      expect(decorated?.source).toBe('diff')
+      expect(decorated?.side).toBe('modified')
+    })
+
+    it('returns null for PR comment without path', () => {
+      const comment: PRComment = {
+        id: 123,
+        author: 'bunny',
+        authorAvatarUrl: 'avatar',
+        body: 'Review comment',
+        createdAt: '2026-07-16T12:00:00Z',
+        url: 'url',
+        line: 10
+      }
+
+      const decorated = prCommentToDecoratedDiffComment(comment, 'wt-1')
+      expect(decorated).toBeNull()
+    })
+
+    it('returns null for PR comment without line number', () => {
+      const comment: PRComment = {
+        id: 123,
+        author: 'bunny',
+        authorAvatarUrl: 'avatar',
+        body: 'Review comment',
+        createdAt: '2026-07-16T12:00:00Z',
+        url: 'url',
+        path: 'src/file.ts'
+      }
+
+      const decorated = prCommentToDecoratedDiffComment(comment, 'wt-1')
+      expect(decorated).toBeNull()
+    })
+
+    it('combines local and PR comments', () => {
+      const localComments: DiffComment[] = [
+        makeComment({ id: 'local-1', lineNumber: 5 }),
+        makeComment({ id: 'local-2', lineNumber: 10 })
+      ]
+
+      const prComments: PRComment[] = [
+        { ...mockPRComment, id: 456 },
+        { ...mockPRComment, id: 789 }
+      ]
+
+      const decoratedPR = prCommentsToDecoratedDiffComments(
+        prComments,
+        'src/components/button.tsx',
+        'wt-1'
+      )
+      const combined = combineDiffComments(localComments, decoratedPR)
+
+      expect(combined).toHaveLength(4)
+      expect(combined[0].id).toBe('local-1')
+      expect(combined[1].id).toBe('local-2')
+      expect(combined[2].id).toBe('pr-456')
+      expect(combined[3].id).toBe('pr-789')
+    })
+
+    it('handles empty arrays when combining comments', () => {
+      const combined1 = combineDiffComments([], [])
+      expect(combined1).toHaveLength(0)
+
+      const localComment = makeComment({ id: 'local-1' })
+      const combined2 = combineDiffComments([localComment], [])
+      expect(combined2).toHaveLength(1)
+      expect(combined2[0].id).toBe('local-1')
+
+      const prComment = prCommentToDecoratedDiffComment(mockPRComment, 'wt-1')
+      const combined3 = combineDiffComments([], prComment ? [prComment] : [])
+      expect(combined3).toHaveLength(1)
+      expect(combined3[0].id).toBe('pr-123')
     })
 
     it('retrieves PR comments dynamically matching cache keys in store', () => {
@@ -99,6 +240,113 @@ describe('diff comment compatibility helpers', () => {
       const retrieved = getPRInlineCommentsFromStore(state, 'wt-1', 'src/components/button.tsx')
       expect(retrieved).toHaveLength(1)
       expect(retrieved[0].id).toBe('pr-123')
+    })
+
+    it('returns empty array when worktree is not found', () => {
+      const state = {
+        getKnownWorktreeById: () => undefined,
+        prCache: {},
+        commentsCache: {}
+      } as unknown as AppState
+
+      const retrieved = getPRInlineCommentsFromStore(state, 'wt-1', 'src/components/button.tsx')
+      expect(retrieved).toHaveLength(0)
+    })
+
+    it('returns empty array when worktreeId is undefined', () => {
+      const state = {
+        getKnownWorktreeById: () => ({ repoId: 'test', linkedPR: 12 }),
+        prCache: {},
+        commentsCache: {}
+      } as unknown as AppState
+
+      const retrieved = getPRInlineCommentsFromStore(state, undefined, 'src/components/button.tsx')
+      expect(retrieved).toHaveLength(0)
+    })
+
+    it('returns empty array when no linked PR is found', () => {
+      const state = {
+        getKnownWorktreeById: () => ({
+          repoId: 'stablyai/orca',
+          branch: 'feat/test',
+          linkedPR: undefined
+        }),
+        prCache: {},
+        commentsCache: {}
+      } as unknown as AppState
+
+      const retrieved = getPRInlineCommentsFromStore(state, 'wt-1', 'src/components/button.tsx')
+      expect(retrieved).toHaveLength(0)
+    })
+
+    it('looks up PR from cache when linkedPR is not set but branch exists', () => {
+      const state = {
+        getKnownWorktreeById: () => ({
+          repoId: 'stablyai/orca',
+          branch: 'feat/test',
+          linkedPR: undefined
+        }),
+        prCache: {
+          'stablyai/orca::feat/test': {
+            data: { number: 42 },
+            fetchedAt: Date.now()
+          }
+        },
+        commentsCache: {
+          'ssh:host-1::stablyai/orca::pr-comments::stablyai/orca::42': {
+            data: [mockPRComment],
+            fetchedAt: Date.now()
+          }
+        }
+      } as unknown as AppState
+
+      const retrieved = getPRInlineCommentsFromStore(state, 'wt-1', 'src/components/button.tsx')
+      expect(retrieved).toHaveLength(1)
+      expect(retrieved[0].id).toBe('pr-123')
+    })
+
+    it('selects raw PR comments from store for a worktree', () => {
+      const state = {
+        getKnownWorktreeById: (id: string) => ({
+          id,
+          repoId: 'stablyai/orca',
+          branch: 'feat/test',
+          linkedPR: 12
+        }),
+        prCache: {},
+        commentsCache: {
+          'ssh:host-1::stablyai/orca::pr-comments::stablyai/orca::12': {
+            data: [mockPRComment],
+            fetchedAt: Date.now()
+          }
+        }
+      } as unknown as AppState
+
+      const retrieved = selectRawPRCommentsFromStore(state, 'wt-1')
+      expect(retrieved).toHaveLength(1)
+      expect(retrieved[0].id).toBe(123)
+    })
+
+    it('selectRawPRCommentsFromStore returns empty array for missing worktree', () => {
+      const state = {
+        getKnownWorktreeById: () => undefined,
+        prCache: {},
+        commentsCache: {}
+      } as unknown as AppState
+
+      const retrieved = selectRawPRCommentsFromStore(state, 'wt-1')
+      expect(retrieved).toHaveLength(0)
+    })
+
+    it('selectRawPRCommentsFromStore returns empty array for undefined worktreeId', () => {
+      const state = {
+        getKnownWorktreeById: () => ({ repoId: 'test' }),
+        prCache: {},
+        commentsCache: {}
+      } as unknown as AppState
+
+      const retrieved = selectRawPRCommentsFromStore(state, undefined)
+      expect(retrieved).toHaveLength(0)
     })
   })
 })

--- a/src/renderer/src/lib/diff-comment-compat.test.ts
+++ b/src/renderer/src/lib/diff-comment-compat.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import type { DiffComment } from '../../../shared/types'
+import type { DiffComment, PRComment } from '../../../shared/types'
+import type { AppState } from '../store/types'
 import {
   getDiffCommentLineLabel,
   getDiffCommentSource,
   isDiffComment,
-  isMarkdownComment
+  isMarkdownComment,
+  prCommentsToDecoratedDiffComments,
+  getPRInlineCommentsFromStore
 } from './diff-comment-compat'
 
 function makeComment(overrides: Partial<DiffComment> = {}): DiffComment {
@@ -39,5 +42,63 @@ describe('diff comment compatibility helpers', () => {
     const comment = makeComment({ startLine: 2, lineNumber: 4 })
     expect(getDiffCommentLineLabel(comment)).toBe('Lines 2-4')
     expect(getDiffCommentLineLabel(comment, true)).toBe('L2-L4')
+  })
+
+  describe('PR comment mapping and normalization', () => {
+    const mockPRComment: PRComment = {
+      id: 123,
+      author: 'bunny',
+      authorAvatarUrl: 'avatar',
+      body: 'Review comment',
+      createdAt: '2026-07-16T12:00:00Z',
+      url: 'url',
+      path: 'src/components/button.tsx',
+      line: 10
+    }
+
+    it('maps raw PR comment to decorated comment when path matches with different casing/slashes', () => {
+      const comments = [mockPRComment]
+      
+      // Exact match
+      let mapped = prCommentsToDecoratedDiffComments(comments, 'src/components/button.tsx', 'wt-1')
+      expect(mapped).toHaveLength(1)
+      expect(mapped[0].body).toBe('Review comment')
+      expect(mapped[0].lineNumber).toBe(10)
+
+      // Windows slashes
+      mapped = prCommentsToDecoratedDiffComments(comments, 'src\\components\\button.tsx', 'wt-1')
+      expect(mapped).toHaveLength(1)
+
+      // Leading slash
+      mapped = prCommentsToDecoratedDiffComments(comments, '/src/components/button.tsx', 'wt-1')
+      expect(mapped).toHaveLength(1)
+
+      // Casing difference
+      mapped = prCommentsToDecoratedDiffComments(comments, 'SRC/Components/Button.tsx', 'wt-1')
+      expect(mapped).toHaveLength(1)
+    })
+
+    it('retrieves PR comments dynamically matching cache keys in store', () => {
+      const state = {
+        getKnownWorktreeById: (id: string) => ({
+          id,
+          repoId: 'stablyai/orca',
+          path: '/path/to/wt',
+          branch: 'feat/test',
+          linkedPR: 12
+        }),
+        prCache: {},
+        commentsCache: {
+          'ssh:host-1::stablyai/orca::pr-comments::stablyai/orca::12': {
+            data: [mockPRComment],
+            fetchedAt: Date.now()
+          }
+        }
+      } as unknown as AppState
+
+      const retrieved = getPRInlineCommentsFromStore(state, 'wt-1', 'src/components/button.tsx')
+      expect(retrieved).toHaveLength(1)
+      expect(retrieved[0].id).toBe('pr-123')
+    })
   })
 })

--- a/src/renderer/src/lib/diff-comment-compat.ts
+++ b/src/renderer/src/lib/diff-comment-compat.ts
@@ -141,3 +141,44 @@ export function combineDiffComments(
 ): DecoratedDiffComment[] {
   return [...localComments, ...prComments] as DecoratedDiffComment[]
 }
+
+// Why: selector function to retrieve raw PR comments from the store for a specific worktree.
+// This extracts the complex cache key matching logic to keep DiffViewer.tsx under the 400-line limit.
+// Returns a stable empty array reference when no comments are available to avoid re-renders.
+export function selectRawPRCommentsFromStore(
+  state: AppState,
+  worktreeId: string | undefined
+): readonly PRComment[] {
+  if (!worktreeId) {
+    return []
+  }
+  const wt = state.getKnownWorktreeById(worktreeId)
+  if (!wt || !wt.repoId) {
+    return []
+  }
+  let pr = wt.linkedPR
+  if (!pr && wt.branch) {
+    const keys = Object.keys(state.prCache)
+    const targetKey = keys.find(
+      (k) => k.toLowerCase().includes(wt.repoId.toLowerCase()) && k.endsWith(`::${wt.branch}`)
+    )
+    const cachedPR = targetKey ? state.prCache[targetKey]?.data : null
+    if (cachedPR) {
+      pr = cachedPR.number
+    }
+  }
+  if (!pr) {
+    return []
+  }
+  // Why: commentsCache keys may be prefixed by host/runtime environment
+  // scope or contain the full prRepo name in the middle. Match keys
+  // dynamically to find the correct entry regardless of caching scopes.
+  const keys = Object.keys(state.commentsCache)
+  const targetKey = keys.find(
+    (k) =>
+      k.toLowerCase().includes(wt.repoId.toLowerCase()) &&
+      k.includes('::pr-comments::') &&
+      k.endsWith(`::${pr}`)
+  )
+  return (targetKey ? state.commentsCache[targetKey]?.data : null) ?? []
+}

--- a/src/renderer/src/lib/diff-comment-compat.ts
+++ b/src/renderer/src/lib/diff-comment-compat.ts
@@ -2,6 +2,20 @@ import type { DiffComment, DiffCommentSource, PRComment } from '../../../shared/
 import type { DecoratedDiffComment } from '../components/diff-comments/useDiffCommentDecorator'
 import type { AppState } from '../store/types'
 
+const EMPTY_PR_COMMENTS: readonly PRComment[] = []
+
+export function isPRCommentsCacheKey(
+  k: string,
+  worktree: { repoId: string },
+  linkedPR: number | string
+): boolean {
+  return (
+    k.toLowerCase().includes(worktree.repoId.toLowerCase()) &&
+    k.includes('::pr-comments::') &&
+    k.endsWith(`::${linkedPR}`)
+  )
+}
+
 export function getDiffCommentSource(comment: Pick<DiffComment, 'source'>): DiffCommentSource {
   return comment.source === 'markdown' ? 'markdown' : 'diff'
 }
@@ -121,12 +135,7 @@ export function getPRInlineCommentsFromStore(
   // scope or contain the full prRepo name in the middle. Match keys
   // dynamically to find the correct entry regardless of caching scopes.
   const keys = Object.keys(state.commentsCache)
-  const targetKey = keys.find(
-    (k) =>
-      k.toLowerCase().includes(worktree.repoId.toLowerCase()) &&
-      k.includes('::pr-comments::') &&
-      k.endsWith(`::${linkedPR}`)
-  )
+  const targetKey = keys.find((k) => isPRCommentsCacheKey(k, worktree, linkedPR))
   const prComments = (targetKey ? state.commentsCache[targetKey]?.data : null) ?? []
 
   return prCommentsToDecoratedDiffComments(prComments, relativePath, worktreeId)
@@ -150,35 +159,30 @@ export function selectRawPRCommentsFromStore(
   worktreeId: string | undefined
 ): readonly PRComment[] {
   if (!worktreeId) {
-    return []
+    return EMPTY_PR_COMMENTS
   }
-  const wt = state.getKnownWorktreeById(worktreeId)
-  if (!wt || !wt.repoId) {
-    return []
+  const worktree = state.getKnownWorktreeById(worktreeId)
+  if (!worktree || !worktree.repoId) {
+    return EMPTY_PR_COMMENTS
   }
-  let pr = wt.linkedPR
-  if (!pr && wt.branch) {
+  let linkedPR = worktree.linkedPR
+  if (!linkedPR && worktree.branch) {
     const keys = Object.keys(state.prCache)
     const targetKey = keys.find(
-      (k) => k.toLowerCase().includes(wt.repoId.toLowerCase()) && k.endsWith(`::${wt.branch}`)
+      (k) => k.toLowerCase().includes(worktree.repoId.toLowerCase()) && k.endsWith(`::${worktree.branch}`)
     )
     const cachedPR = targetKey ? state.prCache[targetKey]?.data : null
     if (cachedPR) {
-      pr = cachedPR.number
+      linkedPR = cachedPR.number
     }
   }
-  if (!pr) {
-    return []
+  if (!linkedPR) {
+    return EMPTY_PR_COMMENTS
   }
   // Why: commentsCache keys may be prefixed by host/runtime environment
   // scope or contain the full prRepo name in the middle. Match keys
   // dynamically to find the correct entry regardless of caching scopes.
   const keys = Object.keys(state.commentsCache)
-  const targetKey = keys.find(
-    (k) =>
-      k.toLowerCase().includes(wt.repoId.toLowerCase()) &&
-      k.includes('::pr-comments::') &&
-      k.endsWith(`::${pr}`)
-  )
-  return (targetKey ? state.commentsCache[targetKey]?.data : null) ?? []
+  const targetKey = keys.find((k) => isPRCommentsCacheKey(k, worktree, linkedPR))
+  return (targetKey ? state.commentsCache[targetKey]?.data : null) ?? EMPTY_PR_COMMENTS
 }

--- a/src/renderer/src/lib/diff-comment-compat.ts
+++ b/src/renderer/src/lib/diff-comment-compat.ts
@@ -1,4 +1,6 @@
-import type { DiffComment, DiffCommentSource } from '../../../shared/types'
+import type { DiffComment, DiffCommentSource, PRComment } from '../../../shared/types'
+import type { DecoratedDiffComment } from '../components/diff-comments/useDiffCommentDecorator'
+import type { AppState } from '../store/types'
 
 export function getDiffCommentSource(comment: Pick<DiffComment, 'source'>): DiffCommentSource {
   return comment.source === 'markdown' ? 'markdown' : 'diff'
@@ -22,4 +24,120 @@ export function getDiffCommentLineLabel(
       : `Lines ${comment.startLine}-${comment.lineNumber}`
   }
   return compact ? `L${comment.lineNumber}` : `Line ${comment.lineNumber}`
+}
+
+// Why: transform PRComment to DecoratedDiffComment for inline display in diff views.
+// PR comments from the checks view include file path and line information for inline
+// review comments. This utility maps them to the format expected by the diff comment
+// decorator so they can be shown inline in both view-all diff and single file diff views.
+export function prCommentToDecoratedDiffComment(
+  prComment: PRComment,
+  worktreeId: string
+): DecoratedDiffComment | null {
+  // Only inline review comments have path information
+  if (!prComment.path) {
+    return null
+  }
+
+  // PR comments use 1-based line numbers, matching DiffComment format
+  const lineNumber = prComment.line
+  if (!lineNumber) {
+    return null
+  }
+
+  return {
+    id: `pr-${prComment.id}`,
+    worktreeId,
+    filePath: prComment.path,
+    lineNumber,
+    startLine: prComment.startLine,
+    body: prComment.body,
+    createdAt: new Date(prComment.createdAt).getTime(),
+    author: prComment.author,
+    authorAvatarUrl: prComment.authorAvatarUrl,
+    createdAtLabel: new Date(prComment.createdAt).toLocaleString(),
+    url: prComment.url,
+    canDelete: false, // PR comments are managed remotely
+    canEdit: false, // PR comments are managed remotely
+    source: 'diff', // PR comments are always shown in diff context
+    side: 'modified' // PR comments are always on the modified side in v1
+  }
+}
+
+// Why: filter and transform PR comments for a specific file, converting them to
+// DecoratedDiffComment format for inline display in diff views. Normalizes slashes,
+// leading slashes, and casing to ensure robust matching across git/GitHub path formats.
+export function prCommentsToDecoratedDiffComments(
+  prComments: readonly PRComment[],
+  filePath: string,
+  worktreeId: string
+): DecoratedDiffComment[] {
+  const normFilePath = filePath.replace(/\\/g, '/').replace(/^\//, '').toLowerCase()
+  return prComments
+    .filter((comment) => {
+      const normCommentPath = comment.path?.replace(/\\/g, '/').replace(/^\//, '').toLowerCase()
+      return normCommentPath === normFilePath && comment.line != null
+    })
+    .map((comment) => prCommentToDecoratedDiffComment(comment, worktreeId))
+    .filter((comment): comment is DecoratedDiffComment => comment != null)
+}
+
+// Why: fetch PR comments for a linked PR from the store and return them in the
+// DecoratedDiffComment format for inline display in diff views. This extracts
+// the store access logic to keep DiffViewer.tsx under the 400-line limit.
+export function getPRInlineCommentsFromStore(
+  state: AppState,
+  worktreeId: string | undefined,
+  relativePath: string
+): DecoratedDiffComment[] {
+  if (!worktreeId) {
+    return []
+  }
+
+  const worktree = state.getKnownWorktreeById(worktreeId)
+  if (!worktree) {
+    return []
+  }
+
+  let linkedPR = worktree.linkedPR
+  if (!linkedPR && worktree.branch) {
+    const keys = Object.keys(state.prCache)
+    const targetKey = keys.find(
+      (k) =>
+        k.toLowerCase().includes(worktree.repoId.toLowerCase()) &&
+        k.endsWith(`::${worktree.branch}`)
+    )
+    const cachedPR = targetKey ? state.prCache[targetKey]?.data : null
+    if (cachedPR) {
+      linkedPR = cachedPR.number
+    }
+  }
+
+  if (!linkedPR) {
+    return []
+  }
+
+  // Why: commentsCache keys may be prefixed by host/runtime environment
+  // scope or contain the full prRepo name in the middle. Match keys
+  // dynamically to find the correct entry regardless of caching scopes.
+  const keys = Object.keys(state.commentsCache)
+  const targetKey = keys.find(
+    (k) =>
+      k.toLowerCase().includes(worktree.repoId.toLowerCase()) &&
+      k.includes('::pr-comments::') &&
+      k.endsWith(`::${linkedPR}`)
+  )
+  const prComments = (targetKey ? state.commentsCache[targetKey]?.data : null) ?? []
+
+  return prCommentsToDecoratedDiffComments(prComments, relativePath, worktreeId)
+}
+
+// Why: combine local diff comments with PR inline comments for display in diff views.
+// This merges the worktree's persisted diff comments with PR review comments from
+// the linked PR, both in DecoratedDiffComment format.
+export function combineDiffComments(
+  localComments: DiffComment[],
+  prComments: DecoratedDiffComment[]
+): DecoratedDiffComment[] {
+  return [...localComments, ...prComments] as DecoratedDiffComment[]
 }

--- a/src/renderer/src/lib/diff-comment-compat.ts
+++ b/src/renderer/src/lib/diff-comment-compat.ts
@@ -71,6 +71,7 @@ export function prCommentToDecoratedDiffComment(
     authorAvatarUrl: prComment.authorAvatarUrl,
     createdAtLabel: new Date(prComment.createdAt).toLocaleString(),
     url: prComment.url,
+    isResolved: prComment.isResolved,
     canDelete: false, // PR comments are managed remotely
     canEdit: false, // PR comments are managed remotely
     source: 'diff', // PR comments are always shown in diff context
@@ -169,7 +170,9 @@ export function selectRawPRCommentsFromStore(
   if (!linkedPR && worktree.branch) {
     const keys = Object.keys(state.prCache)
     const targetKey = keys.find(
-      (k) => k.toLowerCase().includes(worktree.repoId.toLowerCase()) && k.endsWith(`::${worktree.branch}`)
+      (k) =>
+        k.toLowerCase().includes(worktree.repoId.toLowerCase()) &&
+        k.endsWith(`::${worktree.branch}`)
     )
     const cachedPR = targetKey ? state.prCache[targetKey]?.data : null
     if (cachedPR) {


### PR DESCRIPTION
## Summary

This PR ensures that resolved pull request comments/discussions are automatically collapsed by default across the multi-diff (combined) view, single-diff view, and the main PR conversation view, while allowing the user to expand or collapse them as desired.

Additionally, it preserves the **Open** (in browser) button on collapsed comments so users can quickly open threads on GitHub/GitLab directly from the collapsed state.

⚠️ **Note: This PR should be merged after [#9037](https://github.com/stablyai/orca/pull/9037) as it leverages the comments in the inline file diff view.**

## User-Visible Changes
- **Auto-Collapse Resolved Comments**: Inline PR comments that are marked as resolved are collapsed by default on initial render inside the Monaco editor diff view.
- **Open Button Kept Visible**: The action pill remains visible on collapsed comments but only contains the "Open" button (other actions like Edit/Delete are hidden).
- **Correct Spacing**: When the comment card starts collapsed, the Monaco view zone immediately adjusts its height to avoid leaving a blank space.
- **Unified Resolved Mapping**: Ensured that the `isResolved` property is mapped correctly when displaying PR comments in the PR conversation timeline, single-diff, and multi-diff views.

## Screenshots

<img width="1512" height="982" alt="Screenshot 2026-07-26 at 17 03 43" src="https://github.com/user-attachments/assets/c58c834f-5625-4cd3-b8af-9ad5e08f9994" />
<img width="1512" height="982" alt="Screenshot 2026-07-26 at 17 16 22" src="https://github.com/user-attachments/assets/e259ab09-aef4-47ff-8154-020c9c586e6d" />

---

## AI Code Review Summary

- **Cross-Platform Compatibility**: Checked. All modifications use platform-agnostic React hooks, standard conditional rendering, and the Monaco Editor layout engine without OS-specific assumptions.
- **SSH/Remote/Local Compatibility**: Checked. Handles PR comments metadata sourced from GitHub/GitLab APIs transparently, ensuring compatibility with both local and remote/SSH worktrees.
- **Agent and Integration Compatibility**: Checked. Supported git-provider comments (GitHub review comments, GitLab resolvable discussions) preserve their `isResolved` statuses when mapped to UI models.
- **Performance Risk**: Checked. View zone height is estimated on creation and updated on mount via `useLayoutEffect`, avoiding redundant DOM measurement cycles.
- **UI Quality**: Checked. Keeps the card styling neat and clean, only displaying the "Open" button on collapsed comment cards to prevent clutter.
- **Security Risk**: None identified. All URLs opened via `window.api.shell.openUrl` use standard protocols.

## Testing & Behavior Notes
- Verified mapping logic for `isResolved` in `diff-comment-compat.ts`.
- Confirmed that the Monaco layout effect triggers size recalculation on mount if the comment is collapsed.

## ELI5

Resolved PR review comments now start collapsed by default in diff and conversation views so open discussions stay easier to scan, while you can still expand them or open the thread in the browser.
