### PR TITLE
feat(source-control): add Commit & Amend Last Commit dropdown action

### DIFF
--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -2096,6 +2096,22 @@ export async function getStagedCommitContext(
   }
 }
 
+// Why: surface whichever channel carries the useful message. Pre-commit/GPG
+// hook failures write to stderr; "nothing to commit, working tree clean"
+// writes to stdout. Try stderr first, fall back to stdout, then error.message.
+function gitErrorFromException(error: unknown, fallback: string): string {
+  const readField = (field: string): string | null => {
+    if (typeof error === 'object' && error && field in error) {
+      const v = (error as Record<string, unknown>)[field]
+      if (typeof v === 'string' && v.length > 0) {
+        return v
+      }
+    }
+    return null
+  }
+  return readField('stderr') ?? readField('stdout') ?? (error instanceof Error ? error.message : fallback)
+}
+
 export async function commitChanges(
   worktreePath: string,
   message: string,
@@ -2106,21 +2122,25 @@ export async function commitChanges(
     await gitExecFileAsync(['commit', '-m', message], gitOptionsForWorktree(worktreePath, options))
     return { success: true }
   } catch (error) {
-    // Why: useful message may be on stderr (hook/GPG failures) or stdout ("nothing to commit"), so try both then message.
-    const readStringField = (field: string): string | null => {
-      if (typeof error === 'object' && error && field in error) {
-        const v = (error as Record<string, unknown>)[field]
-        if (typeof v === 'string' && v.length > 0) {
-          return v
-        }
-      }
-      return null
-    }
-    const errorMessage =
-      readStringField('stderr') ??
-      readStringField('stdout') ??
-      (error instanceof Error ? error.message : 'Commit failed')
-    return { success: false, error: errorMessage }
+    return { success: false, error: gitErrorFromException(error, 'Commit failed') }
+  } finally {
+    invalidateGitReadCaches()
+  }
+}
+
+export async function amendChanges(
+  worktreePath: string,
+  options: GitRuntimeOptions = {}
+): Promise<{ success: boolean; error?: string }> {
+  invalidateGitReadCaches()
+  try {
+    await gitExecFileAsync(
+      ['commit', '--amend', '--no-edit'],
+      gitOptionsForWorktree(worktreePath, options)
+    )
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: gitErrorFromException(error, 'Amend failed') }
   } finally {
     invalidateGitReadCaches()
   }

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -47,6 +47,7 @@ import {
   detectConflictOperation,
   getDiff,
   commitChanges,
+  amendChanges,
   stageFile,
   unstageFile,
   bulkStageFiles,
@@ -1427,6 +1428,29 @@ export function registerFilesystemHandlers(
         worktreePath
       )
       return commitChanges(worktreePath, args.message, gitOptions)
+    }
+  )
+
+  ipcMain.handle(
+    'git:amend',
+    async (
+      _event,
+      args: { worktreePath: string; connectionId?: string }
+    ): Promise<{ success: boolean; error?: string }> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.amend(args.worktreePath)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      return amendChanges(worktreePath, gitOptions)
     }
   )
 

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -28,6 +28,7 @@ export type IGitProvider = {
   checkIgnoredPaths(worktreePath: string, relativePaths: string[]): Promise<string[]>
   getHistory(worktreePath: string, options?: GitHistoryOptions): Promise<GitHistoryResult>
   commit(worktreePath: string, message: string): Promise<{ success: boolean; error?: string }>
+  amend(worktreePath: string): Promise<{ success: boolean; error?: string }>
   getStagedCommitContext(worktreePath: string): Promise<CommitMessageDraftContext | null>
   getDiff(
     worktreePath: string,

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -226,7 +226,7 @@ export class SshGitProvider implements IGitProvider {
   async amend(
     worktreePath: string
   ): Promise<{ success: boolean; error?: string }> {
-    return this.runWithDiffDedupeClear(
+    return this.runWithGitReadInvalidation(
       async () =>
         (await this.mux.request('git.amend', {
           worktreePath

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -223,6 +223,17 @@ export class SshGitProvider implements IGitProvider {
     )
   }
 
+  async amend(
+    worktreePath: string
+  ): Promise<{ success: boolean; error?: string }> {
+    return this.runWithDiffDedupeClear(
+      async () =>
+        (await this.mux.request('git.amend', {
+          worktreePath
+        })) as { success: boolean; error?: string }
+    )
+  }
+
   async getStagedCommitContext(worktreePath: string): Promise<CommitMessageDraftContext | null> {
     const branchPromise = this.exec(['branch', '--show-current'], worktreePath).catch(() => ({
       stdout: ''

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -34,6 +34,7 @@ import {
   bulkStageFiles,
   bulkUnstageFiles,
   commitChanges,
+  amendChanges,
   detectConflictOperation,
   discardChanges,
   getBranchCompare,
@@ -629,6 +630,20 @@ export class RuntimeGitCommands {
       return provider.commit(target.worktree.path, message)
     }
     return commitChanges(target.worktree.path, message, localGitOptionsForTarget(target))
+  }
+
+  async amendRuntimeGit(
+    worktreeSelector: string
+  ): Promise<{ success: boolean; error?: string }> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+    if (target.connectionId) {
+      if (!provider) {
+        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+      }
+      return provider.amend(target.worktree.path)
+    }
+    return amendChanges(target.worktree.path, localGitOptionsForTarget(target))
   }
 
   async generateRuntimeCommitMessage(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10114,6 +10114,9 @@ export class OrcaRuntimeService {
   commitRuntimeGit: RuntimeGitCommands['commitRuntimeGit'] = this.gitCommands.commitRuntimeGit.bind(
     this.gitCommands
   )
+  amendRuntimeGit: RuntimeGitCommands['amendRuntimeGit'] = this.gitCommands.amendRuntimeGit.bind(
+    this.gitCommands
+  )
   generateRuntimeCommitMessage: RuntimeGitCommands['generateRuntimeCommitMessage'] =
     this.gitCommands.generateRuntimeCommitMessage.bind(this.gitCommands)
   discoverRuntimeCommitMessageModels: RuntimeGitCommands['discoverRuntimeCommitMessageModels'] =

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -98,6 +98,8 @@ export const GitCommit = WorktreeSelector.extend({
     .pipe(z.string().min(1, 'Missing commit message'))
 })
 
+export const GitAmend = WorktreeSelector.extend({})
+
 const CommitMessageModelCapability = z.object({
   id: z.string(),
   label: z.string(),

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -7,6 +7,7 @@ import {
   GitCheckIgnored,
   GitCheckout,
   GitCommit,
+  GitAmend,
   GitCommitCompare,
   GitFilePath,
   GitForkSync,
@@ -171,6 +172,12 @@ export const GIT_METHODS: RpcMethod[] = [
     params: GitCommit,
     handler: async (params, { runtime }) =>
       runtime.commitRuntimeGit(params.worktree, params.message)
+  }),
+  defineMethod({
+    name: 'git.amend',
+    params: GitAmend,
+    handler: async (params, { runtime }) =>
+      runtime.amendRuntimeGit(params.worktree)
   }),
   ...GIT_COMMIT_MESSAGE_GENERATION_METHODS,
   defineMethod({

--- a/src/preload/api/git-operation-api.ts
+++ b/src/preload/api/git-operation-api.ts
@@ -46,6 +46,10 @@ export type GitOperationApi = {
     message: string
     connectionId?: string
   }) => Promise<{ success: boolean; error?: string }>
+  amend: (args: {
+    worktreePath: string
+    connectionId?: string
+  }) => Promise<{ success: boolean; error?: string }>
   generateCommitMessage: (args: {
     worktreePath: string
     /** Raw (unstripped) worktree meta key; validated against worktreePath in main. */

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3556,6 +3556,10 @@ const api = {
       message: string
       connectionId?: string
     }): Promise<{ success: boolean; error?: string }> => ipcRenderer.invoke('git:commit', args),
+    amend: (args: {
+      worktreePath: string
+      connectionId?: string
+    }): Promise<{ success: boolean; error?: string }> => ipcRenderer.invoke('git:amend', args),
     generateCommitMessage: (args: {
       worktreePath: string
       worktreeId?: string

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -150,6 +150,22 @@ export async function worktreeIsCleanOp(
   return { clean, stdout: clean ? undefined : stdout }
 }
 
+// Why: surface whichever channel carries the useful message. Pre-commit/GPG
+// hook failures write to stderr; "nothing to commit, working tree clean"
+// writes to stdout. Try stderr first, fall back to stdout, then error.message.
+function gitErrorFromException(error: unknown, fallback: string): string {
+  const readField = (field: string): string | null => {
+    if (typeof error === 'object' && error && field in error) {
+      const v = (error as Record<string, unknown>)[field]
+      if (typeof v === 'string' && v.length > 0) {
+        return v
+      }
+    }
+    return null
+  }
+  return readField('stderr') ?? readField('stdout') ?? (error instanceof Error ? error.message : fallback)
+}
+
 export async function commitChangesRelay(
   git: GitExec,
   worktreePath: string,
@@ -167,23 +183,18 @@ export async function commitChangesRelay(
     await git(['commit', '-m', message], worktreePath)
     return { success: true }
   } catch (error) {
-    // Why: surface whichever channel carries the useful message. Pre-commit/GPG
-    // hook failures write to stderr; "nothing to commit, working tree clean"
-    // writes to stdout. Try stderr first, fall back to stdout, then error.message.
-    // Mirrors commitChanges in src/main/git/status.ts — keep the two paths in sync.
-    const readStringField = (field: string): string | null => {
-      if (typeof error === 'object' && error && field in error) {
-        const v = (error as Record<string, unknown>)[field]
-        if (typeof v === 'string' && v.length > 0) {
-          return v
-        }
-      }
-      return null
-    }
-    const errorMessage =
-      readStringField('stderr') ??
-      readStringField('stdout') ??
-      (error instanceof Error ? error.message : 'Commit failed')
-    return { success: false, error: errorMessage }
+    return { success: false, error: gitErrorFromException(error, 'Commit failed') }
+  }
+}
+
+export async function amendChangesRelay(
+  git: GitExec,
+  worktreePath: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await git(['commit', '--amend', '--no-edit'], worktreePath)
+    return { success: true }
+  } catch (error) {
+    return { success: false, error: gitErrorFromException(error, 'Amend failed') }
   }
 }

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -43,6 +43,7 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.checkIgnored')
     expect(methods).toContain('git.history')
     expect(methods).toContain('git.commit')
+    expect(methods).toContain('git.amend')
     expect(methods).toContain('git.diff')
     expect(methods).toContain('git.stage')
     expect(methods).toContain('git.unstage')

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -39,6 +39,7 @@ import { commitCompare as commitCompareOp, commitDiffEntry } from './git-handler
 import {
   areRelayWorktreePathsEqual,
   commitChangesRelay,
+  amendChangesRelay,
   addWorktreeOp,
   removeWorktreeOp,
   worktreeIsCleanOp
@@ -213,6 +214,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.checkIgnored', (p) => this.checkIgnored(p))
     this.dispatcher.onRequest('git.history', (p) => this.history(p))
     this.dispatcher.onRequest('git.commit', (p) => this.commit(p))
+    this.dispatcher.onRequest('git.amend', (p) => this.amend(p))
     this.dispatcher.onRequest('git.diff', (p, context) => this.getDiff(p, context))
     this.dispatcher.onRequest('git.stage', (p) => this.stage(p))
     this.dispatcher.onRequest('git.unstage', (p) => this.unstage(p))
@@ -525,6 +527,18 @@ export class GitHandler {
     const message = params.message as string
     try {
       return await commitChangesRelay(this.git.bind(this), worktreePath, message)
+    } finally {
+      this.clearGitMutationReadCaches()
+    }
+  }
+
+  private async amend(
+    params: Record<string, unknown>
+  ): Promise<{ success: boolean; error?: string }> {
+    this.clearGitMutationReadCaches()
+    const worktreePath = params.worktreePath as string
+    try {
+      return await amendChangesRelay(this.git.bind(this), worktreePath)
     } finally {
       this.clearGitMutationReadCaches()
     }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-action-context.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-action-context.ts
@@ -37,6 +37,7 @@ export type DropdownActionContext = {
   canCommit: boolean
   stagedCount: number
   hasUnresolvedConflicts: boolean
+  hasHeadCommit: boolean
 }
 
 export function deriveDropdownActionContext(inputs: DropdownActionInputs): DropdownActionContext {
@@ -56,7 +57,8 @@ export function deriveDropdownActionContext(inputs: DropdownActionInputs): Dropd
     hasCurrentBranch = true,
     canPushLinkedReviewWithoutUpstream = false,
     rebaseBaseRef,
-    isPullRequestOperationActive = false
+    isPullRequestOperationActive = false,
+    hasHeadCommit = true
   } = inputs
 
   const hasStaged = stagedCount > 0
@@ -138,6 +140,7 @@ export function deriveDropdownActionContext(inputs: DropdownActionInputs): Dropd
     commitDisabledReason,
     canCommit,
     stagedCount,
-    hasUnresolvedConflicts
+    hasUnresolvedConflicts,
+    hasHeadCommit
   }
 }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-action-context.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-action-context.ts
@@ -35,6 +35,8 @@ export type DropdownActionContext = {
   globalBusy: boolean
   commitDisabledReason: ReturnType<typeof resolveCommitDisabledReason>
   canCommit: boolean
+  stagedCount: number
+  hasUnresolvedConflicts: boolean
 }
 
 export function deriveDropdownActionContext(inputs: DropdownActionInputs): DropdownActionContext {
@@ -134,6 +136,8 @@ export function deriveDropdownActionContext(inputs: DropdownActionInputs): Dropd
     forcePushTitle,
     globalBusy,
     commitDisabledReason,
-    canCommit
+    canCommit,
+    stagedCount,
+    hasUnresolvedConflicts
   }
 }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
@@ -9,6 +9,7 @@ export type CommitDropdownItems = {
   commit: DropdownItem
   commitPush: DropdownItem
   commitSync: DropdownItem
+  commitAmend: DropdownItem
 }
 
 export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDropdownItems {
@@ -25,7 +26,9 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
     behind,
     shouldForcePushWithLease,
     commitDisabledReason,
-    canCommit
+    canCommit,
+    stagedCount,
+    hasUnresolvedConflicts
   } = ctx
 
   const commit: DropdownItem = {
@@ -113,5 +116,22 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
       commitDisabledReason !== null
   }
 
-  return { commit, commitPush, commitSync }
+  // Why: amend reuses the last commit message (--no-edit), so it doesn't require hasMessage.
+  const amendDisabledReason: string | null =
+    hasUnresolvedConflicts
+      ? 'Resolve conflicts before amending'
+      : stagedCount === 0
+        ? 'Stage at least one file to amend'
+        : null
+  const commitAmend: DropdownItem = {
+    kind: 'commit_amend',
+    label: translate(
+      'auto.components.right.sidebar.source.control.dropdown.items.9c745c2ea7',
+      'Commit & Amend Last Commit'
+    ),
+    title: amendDisabledReason ?? 'Amend staged changes to the last commit',
+    disabled: globalBusy || amendDisabledReason !== null
+  }
+
+  return { commit, commitPush, commitSync, commitAmend }
 }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
@@ -28,7 +28,8 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
     commitDisabledReason,
     canCommit,
     stagedCount,
-    hasUnresolvedConflicts
+    hasUnresolvedConflicts,
+    conflictOperation
   } = ctx
 
   const commit: DropdownItem = {
@@ -117,8 +118,9 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
   }
 
   // Why: amend reuses the last commit message (--no-edit), so it doesn't require hasMessage.
+  // A merge/rebase/cherry-pick can stay active after conflicts resolve, so gate on conflictOperation too.
   const amendDisabledReason: string | null =
-    hasUnresolvedConflicts
+    hasUnresolvedConflicts || conflictOperation !== 'unknown'
       ? 'Resolve conflicts before amending'
       : stagedCount === 0
         ? 'Stage at least one file to amend'

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-commit-items.ts
@@ -29,6 +29,7 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
     canCommit,
     stagedCount,
     hasUnresolvedConflicts,
+    hasHeadCommit,
     conflictOperation
   } = ctx
 
@@ -119,12 +120,15 @@ export function buildCommitDropdownItems(ctx: DropdownActionContext): CommitDrop
 
   // Why: amend reuses the last commit message (--no-edit), so it doesn't require hasMessage.
   // A merge/rebase/cherry-pick can stay active after conflicts resolve, so gate on conflictOperation too.
+  // An unborn HEAD has nothing to amend — git rejects it with "You have nothing to amend."
   const amendDisabledReason: string | null =
     hasUnresolvedConflicts || conflictOperation !== 'unknown'
       ? 'Resolve conflicts before amending'
-      : stagedCount === 0
-        ? 'Stage at least one file to amend'
-        : null
+      : !hasHeadCommit
+        ? 'Make an initial commit before amending'
+        : stagedCount === 0
+          ? 'Stage at least one file to amend'
+          : null
   const commitAmend: DropdownItem = {
     kind: 'commit_amend',
     label: translate(

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-item-types.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-item-types.ts
@@ -14,6 +14,7 @@ export type DropdownActionKind =
   | 'commit'
   | 'commit_push'
   | 'commit_sync'
+  | 'commit_amend'
   | 'abort_merge'
   | 'abort_rebase'
   | 'create_pr'

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -37,6 +37,7 @@ describe('resolveDropdownItems', () => {
       'commit',
       'commit_push',
       'commit_sync',
+      'commit_amend',
       'separator',
       'push',
       'force_push',
@@ -61,6 +62,23 @@ describe('resolveDropdownItems', () => {
     expect(byKind.commit.disabled).toBe(true)
     expect(byKind.commit_push.disabled).toBe(true)
     expect(byKind.commit_sync.disabled).toBe(true)
+    expect(byKind.commit_amend.disabled).toBe(true)
+  })
+
+  it('enables commit_amend without a message since --no-edit reuses the last message', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        stagedCount: 1,
+        hasMessage: false,
+        upstreamStatus: { hasUpstream: true, ahead: 1, behind: 0 }
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    expect(byKind.commit.disabled).toBe(true)
+    expect(byKind.commit_amend.disabled).toBe(false)
+    expect(byKind.commit_amend.title).toBe('Amend staged changes to the last commit')
   })
 
   it('enables commit actions when staged files also have unstaged changes', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -18,6 +18,7 @@ function inputs(overrides: Partial<DropdownActionInputs> = {}): DropdownActionIn
     hasUnresolvedConflicts: false,
     isCommitting: false,
     isRemoteOperationActive: false,
+    hasHeadCommit: true,
     upstreamStatus: undefined,
     ...overrides
   }
@@ -95,6 +96,23 @@ describe('resolveDropdownItems', () => {
     )
     expect(byKind.commit_amend.disabled).toBe(true)
     expect(byKind.commit_amend.title).toBe('Resolve conflicts before amending')
+  })
+
+  it('disables commit_amend when HEAD is unborn even with staged files', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        stagedCount: 1,
+        hasMessage: true,
+        hasHeadCommit: false,
+        upstreamStatus: { hasUpstream: true, ahead: 1, behind: 0 }
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    expect(byKind.commit.disabled).toBe(false)
+    expect(byKind.commit_amend.disabled).toBe(true)
+    expect(byKind.commit_amend.title).toBe('Make an initial commit before amending')
   })
 
   it('enables commit actions when staged files also have unstaged changes', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -81,6 +81,22 @@ describe('resolveDropdownItems', () => {
     expect(byKind.commit_amend.title).toBe('Amend staged changes to the last commit')
   })
 
+  it('disables commit_amend during an active merge/rebase/cherry-pick even without unresolved conflicts', () => {
+    const items = resolveDropdownItems(
+      inputs({
+        stagedCount: 1,
+        hasMessage: false,
+        conflictOperation: 'merge',
+        upstreamStatus: { hasUpstream: true, ahead: 1, behind: 0 }
+      })
+    )
+    const byKind = Object.fromEntries(
+      items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
+    )
+    expect(byKind.commit_amend.disabled).toBe(true)
+    expect(byKind.commit_amend.title).toBe('Resolve conflicts before amending')
+  })
+
   it('enables commit actions when staged files also have unstaged changes', () => {
     const items = resolveDropdownItems(
       inputs({

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -13,7 +13,7 @@ import { buildHostedReviewDropdownItems } from './source-control-dropdown-review
  */
 export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntry[] {
   const ctx = deriveDropdownActionContext(inputs)
-  const { commit, commitPush, commitSync } = buildCommitDropdownItems(ctx)
+  const { commit, commitPush, commitSync, commitAmend } = buildCommitDropdownItems(ctx)
   const { push, forcePush, pull, fastForward, sync, rebase, fetch, publish } =
     buildRemoteDropdownItems(ctx)
   const { createPR, pushCreatePR } = buildHostedReviewDropdownItems(ctx)
@@ -23,6 +23,7 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     commit,
     commitPush,
     commitSync,
+    commitAmend,
     { kind: 'separator', id: 'before-remote' },
     push,
     forcePush,

--- a/src/renderer/src/components/right-sidebar/source-control-primary-action-types.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-primary-action-types.ts
@@ -51,6 +51,9 @@ export type PrimaryActionInputs = {
   // Why: branch-compare counts feed Create Review intent eligibility and
   // force-push labels; publishing itself can push the current HEAD even at 0.
   branchCommitsAhead?: number
+  // Why: an unborn HEAD (no commits yet) has nothing to amend. Default true so
+  // callers that don't know omit the guard rather than blocking amend wrongly.
+  hasHeadCommit?: boolean
   // Why: detached HEAD can look like an unpublished branch from upstream
   // status alone, but it has no branch ref that Publish Branch can push.
   hasCurrentBranch?: boolean

--- a/src/renderer/src/components/right-sidebar/source-control/commit/use-commit-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/commit/use-commit-action.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import type { GitConflictOperation } from '../../../../../../shared/git-status-types'
 import { getConnectionId } from '@/lib/connection-context'
 import { amendRuntimeGit, commitRuntimeGit } from '@/runtime/runtime-git-client'
 import type { SourceControlOperationTarget } from '../listing/operation-target'
@@ -20,6 +21,7 @@ export function useSourceControlCommitAction({
   commitInFlightRef,
   commitMessage,
   compareBaseRef,
+  conflictOperation,
   refreshActiveGitStatusAfterMutation,
   refreshBranchCompareRef,
   refreshGitHistoryRef,
@@ -37,6 +39,7 @@ export function useSourceControlCommitAction({
   commitInFlightRef: SourceControlWorktreeOperationState['commitInFlightRef']
   commitMessage: string
   compareBaseRef: string | null
+  conflictOperation: GitConflictOperation
   refreshActiveGitStatusAfterMutation: SourceControlStatusRefresh['refreshActiveGitStatusAfterMutation']
   refreshBranchCompareRef: React.RefObject<() => Promise<void>>
   refreshGitHistoryRef: React.RefObject<() => Promise<void>>
@@ -173,7 +176,7 @@ export function useSourceControlCommitAction({
     if (!target) {
       return false
     }
-    if (stagedCount === 0 || unresolvedConflictCount > 0) {
+    if (stagedCount === 0 || unresolvedConflictCount > 0 || conflictOperation !== 'unknown') {
       return false
     }
     if (commitInFlightRef.current[target.worktreeId]) {
@@ -222,6 +225,7 @@ export function useSourceControlCommitAction({
     beginGitBranchCompareRequest,
     commitInFlightRef,
     compareBaseRef,
+    conflictOperation,
     refreshActiveGitStatusAfterMutation,
     refreshBranchCompareRef,
     refreshGitHistoryRef,

--- a/src/renderer/src/components/right-sidebar/source-control/commit/use-commit-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/commit/use-commit-action.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 import { getConnectionId } from '@/lib/connection-context'
-import { commitRuntimeGit } from '@/runtime/runtime-git-client'
+import { amendRuntimeGit, commitRuntimeGit } from '@/runtime/runtime-git-client'
 import type { SourceControlOperationTarget } from '../listing/operation-target'
 import type { SourceControlStoreActions } from '../listing/use-store-actions'
 import type { SourceControlWorktreeContext } from '../listing/use-worktree-context'
@@ -159,7 +159,80 @@ export function useSourceControlCommitAction({
     ]
   )
 
-  return { handleCommit }
+  // Why: amend reuses the last commit message (--no-edit), so there is no message param and no draft clearing.
+  const handleAmend = useCallback(async (): Promise<boolean> => {
+    const target =
+      activeWorktreeId && worktreePath
+        ? {
+            settings: activeRepoSettings,
+            worktreeId: activeWorktreeId,
+            worktreePath,
+            connectionId: getConnectionId(activeWorktreeId) ?? undefined
+          }
+        : null
+    if (!target) {
+      return false
+    }
+    if (stagedCount === 0 || unresolvedConflictCount > 0) {
+      return false
+    }
+    if (commitInFlightRef.current[target.worktreeId]) {
+      return false
+    }
+    commitInFlightRef.current[target.worktreeId] = true
+
+    setCommitInFlightByWorktree((prev) => ({ ...prev, [target.worktreeId]: true }))
+    setCommitErrorForWorktree(target.worktreeId, null)
+    try {
+      const result = await amendRuntimeGit({
+        settings: target.settings,
+        worktreeId: target.worktreeId,
+        worktreePath: target.worktreePath,
+        connectionId: target.connectionId
+      })
+      if (!result.success) {
+        setCommitErrorForWorktree(target.worktreeId, result.error ?? 'Amend failed')
+        return false
+      }
+      setCommitErrorForWorktree(target.worktreeId, null)
+      void refreshActiveGitStatusAfterMutation()
+      if (compareBaseRef) {
+        beginGitBranchCompareRequest(
+          target.worktreeId,
+          `${target.worktreeId}:${compareBaseRef}:${Date.now()}:post-amend`,
+          compareBaseRef
+        )
+      }
+      void refreshBranchCompareRef.current()
+      void refreshGitHistoryRef.current()
+      return true
+    } catch (error) {
+      setCommitErrorForWorktree(
+        target.worktreeId,
+        error instanceof Error ? error.message : 'Amend failed'
+      )
+      return false
+    } finally {
+      setCommitInFlightByWorktree((prev) => ({ ...prev, [target.worktreeId]: false }))
+      commitInFlightRef.current[target.worktreeId] = false
+    }
+  }, [
+    activeRepoSettings,
+    activeWorktreeId,
+    beginGitBranchCompareRequest,
+    commitInFlightRef,
+    compareBaseRef,
+    refreshActiveGitStatusAfterMutation,
+    refreshBranchCompareRef,
+    refreshGitHistoryRef,
+    setCommitErrorForWorktree,
+    setCommitInFlightByWorktree,
+    stagedCount,
+    unresolvedConflictCount,
+    worktreePath
+  ])
+
+  return { handleCommit, handleAmend }
 }
 
 export type SourceControlCommitAction = ReturnType<typeof useSourceControlCommitAction>

--- a/src/renderer/src/components/right-sidebar/source-control/commit/use-commit-action.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/commit/use-commit-action.ts
@@ -176,6 +176,10 @@ export function useSourceControlCommitAction({
     if (!target) {
       return false
     }
+    // Why: an unborn HEAD has nothing to amend — `git commit --amend --no-edit` would fail with "You have nothing to amend."
+    if (!activeWorktree?.head?.trim()) {
+      return false
+    }
     if (stagedCount === 0 || unresolvedConflictCount > 0 || conflictOperation !== 'unknown') {
       return false
     }
@@ -221,6 +225,7 @@ export function useSourceControlCommitAction({
     }
   }, [
     activeRepoSettings,
+    activeWorktree?.head,
     activeWorktreeId,
     beginGitBranchCompareRequest,
     commitInFlightRef,

--- a/src/renderer/src/components/right-sidebar/source-control/commit/use-commit-flows.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/commit/use-commit-flows.ts
@@ -67,6 +67,7 @@ export function useSourceControlCommitFlows(foundation: SourceControlPanelFounda
     commitInFlightRef,
     commitMessage,
     compareBaseRef,
+    conflictOperation,
     refreshActiveGitStatusAfterMutation,
     refreshBranchCompareRef,
     refreshGitHistoryRef,

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-model.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-model.ts
@@ -100,7 +100,8 @@ export function useSourceControlPanelModel() {
     isCreatingPr,
     hostedReviewReviewLabel: hostedReviewCreateCopy.reviewLabel,
     conflictOperation,
-    effectiveBaseRef
+    effectiveBaseRef,
+    hasHeadCommit: Boolean(activeWorktree?.head?.trim())
   })
   const actionDispatch = useSourceControlActionDispatch({
     createPrHeaderAction: actionModel.createPrHeaderAction,

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-model.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-model.ts
@@ -69,6 +69,7 @@ export function useSourceControlPanelModel() {
   const {
     handleAbortMerge,
     handleAbortRebase,
+    handleAmend,
     handleCommit,
     runCompoundCommitAction,
     runRemoteAction
@@ -105,6 +106,7 @@ export function useSourceControlPanelModel() {
     createPrHeaderAction: actionModel.createPrHeaderAction,
     handleAbortMerge,
     handleAbortRebase,
+    handleAmend,
     handleCommit,
     handleCreatePullRequest,
     handleStageAllPrimary,

--- a/src/renderer/src/components/right-sidebar/source-control/review/use-action-dispatch.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/use-action-dispatch.ts
@@ -19,6 +19,7 @@ export function useSourceControlActionDispatch({
   createPrHeaderAction,
   handleAbortMerge,
   handleAbortRebase,
+  handleAmend,
   handleCommit,
   handleCreatePullRequest,
   handleStageAllPrimary,
@@ -35,6 +36,7 @@ export function useSourceControlActionDispatch({
   createPrHeaderAction: SourceControlActionModel['createPrHeaderAction']
   handleAbortMerge: SourceControlConflictAbort['handleAbortMerge']
   handleAbortRebase: SourceControlConflictAbort['handleAbortRebase']
+  handleAmend: SourceControlCommitAction['handleAmend']
   handleCommit: SourceControlCommitAction['handleCommit']
   handleCreatePullRequest: SourceControlHostedReviewCreation['handleCreatePullRequest']
   handleStageAllPrimary: SourceControlFileListing['handleStageAllPrimary']
@@ -64,6 +66,9 @@ export function useSourceControlActionDispatch({
         case 'commit_sync':
           void runCompoundCommitAction('sync')
           return
+        case 'commit_amend':
+          void handleAmend()
+          return
         case 'abort_merge':
           void handleAbortMerge()
           return
@@ -88,6 +93,7 @@ export function useSourceControlActionDispatch({
       }
     },
     [
+      handleAmend,
       handleCommit,
       handleCreatePullRequest,
       handleAbortMerge,

--- a/src/renderer/src/components/right-sidebar/source-control/review/use-action-model.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/use-action-model.ts
@@ -36,7 +36,8 @@ export function useSourceControlActionModel({
   isCreatingPr,
   hostedReviewReviewLabel,
   conflictOperation,
-  effectiveBaseRef
+  effectiveBaseRef,
+  hasHeadCommit
 }: {
   grouped: SourceControlEntryGroups
   commitMessage: string
@@ -62,6 +63,7 @@ export function useSourceControlActionModel({
   hostedReviewReviewLabel: string
   conflictOperation: DropdownInput['conflictOperation']
   effectiveBaseRef: string | null
+  hasHeadCommit: boolean
 }) {
   const hasUnstagedChanges = grouped.unstaged.length > 0 || grouped.untracked.length > 0
   const hasStageableChanges = useMemo(
@@ -215,7 +217,8 @@ export function useSourceControlActionModel({
           branchSummary?.status === 'ready' ? (branchSummary.commitsAhead ?? 0) : undefined,
         hasCurrentBranch: Boolean(branchName),
         canPushLinkedReviewWithoutUpstream: canUseHostedReviewPushTarget,
-        rebaseBaseRef: effectiveBaseRef
+        rebaseBaseRef: effectiveBaseRef,
+        hasHeadCommit
       }),
     [
       commitMessage,
@@ -240,7 +243,8 @@ export function useSourceControlActionModel({
       branchName,
       effectiveBaseRef,
       remoteStatusForActions,
-      unresolvedConflictCount
+      unresolvedConflictCount,
+      hasHeadCommit
     ]
   )
   return {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12209,7 +12209,8 @@
                   "226b85a3a7": "Fetch",
                   "323bb614aa": "Commit & Sync",
                   "2b8e6595fd": "Commit",
-                  "04d709801d": "Fetch from remote without merging"
+                  "04d709801d": "Fetch from remote without merging",
+                  "9c745c2ea7": "Commit & Amend Last Commit"
                 }
               },
               "primary": {

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -654,6 +654,24 @@ export async function commitRuntimeGit(
   )
 }
 
+export async function amendRuntimeGit(
+  context: RuntimeGitContext
+): Promise<{ success: boolean; error?: string }> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    return window.api.git.amend({
+      worktreePath: resolveLocalWorktreePath(context),
+      connectionId: context.connectionId
+    })
+  }
+  return callRuntimeRpc<{ success: boolean; error?: string }>(
+    target,
+    'git.amend',
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
+    { timeoutMs: 30_000 }
+  )
+}
+
 export async function generateRuntimeCommitMessage(
   context: RuntimeGitContext,
   overrides?: RuntimeGenerateCommitMessageOverrides

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2276,6 +2276,12 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
         message
       })
     },
+    amend: async ({ worktreePath }) => {
+      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
+      return callRuntimeResult('git.amend', {
+        worktree: toRuntimeWorktreeSelector(worktree.id)
+      })
+    },
     generateCommitMessage: async () => ({
       success: false,
       error: translate(


### PR DESCRIPTION
## ELI5

Adds a "Commit & Amend Last Commit" option to the Source Control panel's commit dropdown. It runs `git commit --amend --no-edit` — re-staging your changes onto the last commit without rewriting its message.

## What Changed

- New dropdown action `commit_amend` in the Source Control commit split-button, appearing after "Commit & Sync".
- Executes `git commit --amend --no-edit` across every execution path: local (IPC/preload), SSH provider, and relay handler, plus the runtime RPC method and web preload API.
- Extracted the shared git error-normalization helper (`gitErrorFromException`) used by both commit and amend in `status.ts` and `git-handler-worktree-ops.ts`.

## Why

Users frequently amend the last commit while keeping its message (e.g. adding a forgotten file, a fixup, or a CI-triggering no-op change). Doing this today requires either the terminal or a separate amend UI; a first-class dropdown action makes it one click. The action is gated on the same readiness as commit (staged files, no unresolved conflicts, no active merge/rebase/cherry-pick), plus a non-empty HEAD (an unborn HEAD has nothing to amend).

## Linked Issue

No GitHub issue was opened for this change — it was requested directly. (Template says there should always be one; happy to open and link if a maintainer prefers.)

## Visual Proof

<img width="229" height="459" alt="626829329-a8f2aa63-6f80-4fe0-b646-df08944d41de" src="https://github.com/user-attachments/assets/4593342b-c641-4ce7-967d-dbee24784ae5" />

## Testing

Verified locally on Linux:
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm test` — pass (53,432 tests; the 7 failures are pre-existing locale/node-pty/wire-compat issues unrelated to this PR)
- `pnpm build` — pass

Added/updated tests: dropdown rendering + disabled states for commit_amend (active git operation, unborn HEAD), and relay handler registration for `git.amend`.

Platforms actually tested: Linux. Not yet run on macOS/Windows/SSH, but the change follows the existing commit dispatch chain which already abstracts those.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented and reviewed with Claude Code (Anthropic), including AI-assisted code review (CodeRabbit). No other AI tooling.

## Review

Reviewed via CodeRabbit. Two actionable findings were addressed:
1. Disable amend during any active git operation (`conflictOperation !== 'unknown'`), not only when conflicts are unresolved.
2. Block amend on an unborn HEAD (no commits yet) — `git commit --amend` fails with "You have nothing to amend."

## Agent skill upstream boundary

- [x] Not applicable — this change adds a git dropdown action and touches no agent-skill installer source or documentation.

## Notes

- **Security**: no new input surface — the action is parameterless; `git commit --amend --no-edit` runs via `execFile` (no shell interpolation).
- **Cross-platform**: platform-agnostic; flows through the existing local / SSH / relay dispatch chain.
- **Remote SSH**: relay handler `git.amend` and SSH provider `amend` follow the existing mutation pattern with cache invalidation fencing.
- **Mobile / backwards compat**: no effect; new IPC channel and RPC method are additive.
- **Performance**: no hot-path cost.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: FilipeTagliatti
