### PR TITLE
fix(runtime): allow CLI to close background terminal tabs missing persisted session records

### DIFF
--- a/config/scripts/runtime-serve-terminal-smoke.mjs
+++ b/config/scripts/runtime-serve-terminal-smoke.mjs
@@ -17,6 +17,7 @@
  *   - the server emits its ready payload with a pairing offer,
  *   - a paired client can list worktrees and create a terminal,
  *   - a command run in that terminal produces its output,
+ *   - the CLI can close that runtime-owned terminal tab and remove it from listings,
  *   - the server exits when asked.
  */
 import { spawn, spawnSync } from 'node:child_process'
@@ -148,6 +149,18 @@ async function waitForNonce(pairingCode, terminalHandle, nonce) {
     const read = orca(pairingCode, ['terminal', 'read', '--terminal', terminalHandle])
     const tail = (read?.terminal?.tail ?? []).map((entry) => String(entry)).join('\n')
     if (tail.includes(nonce)) {
+      return true
+    }
+    await new Promise((r) => setTimeout(r, 1_000))
+  }
+  return false
+}
+
+async function waitForTerminalRemoval(pairingCode, worktreeId, terminalHandle) {
+  const deadline = Date.now() + OUTPUT_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    const listed = orca(pairingCode, ['terminal', 'list', '--worktree', worktreeId])
+    if (!listed?.terminals?.some((terminal) => terminal.handle === terminalHandle)) {
       return true
     }
     await new Promise((r) => setTimeout(r, 1_000))
@@ -300,6 +313,21 @@ async function main() {
       )
     }
     log('terminal round trip OK')
+
+    const closed = orca(pairingCode, [
+      'terminal',
+      'close',
+      '--terminal',
+      terminal.handle,
+      '--tab'
+    ])?.close
+    if (closed?.handle !== terminal.handle) {
+      throw new Error('terminal.close --tab returned no matching close receipt')
+    }
+    if (!(await waitForTerminalRemoval(pairingCode, created.id, terminal.handle))) {
+      throw new Error(`closed terminal ${terminal.handle} remained in terminal.list`)
+    }
+    log('terminal close OK')
   } catch (error) {
     fail(error instanceof Error ? error.message : String(error))
   } finally {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15799,6 +15799,46 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('closes a background terminal that failed adoption before persistence', async () => {
+    const emptySession = makeWorkspaceSessionWithHeadlessTerminal({
+      activeTabId: null,
+      activeTabIdByWorktree: {},
+      tabsByWorktree: { [TEST_WORKTREE_ID]: [] },
+      terminalLayoutsByTabId: {}
+    })
+    const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(emptySession)
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-unadopted' })
+    const kill = vi.fn(() => true)
+    const closeTerminal = vi.fn()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      revealTerminalSession: vi.fn().mockRejectedValue(new Error('Renderer timed out')),
+      closeTerminal
+    } as never)
+
+    try {
+      const created = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+      await expect(runtime.closeTerminalTab(created.handle)).resolves.toMatchObject({
+        handle: created.handle,
+        tabId: created.tabId,
+        closeMode: 'tab'
+      })
+      expect(kill).toHaveBeenCalledWith('pty-unadopted')
+      expect(closeTerminal).toHaveBeenCalledWith(created.tabId)
+      expect(getSession().tabsByWorktree[TEST_WORKTREE_ID]).toEqual([])
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('returns an actionable warning when default discoverability has no renderer notifier', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9298,6 +9298,7 @@ export class OrcaRuntimeService {
       // renderer's live pin guard and durable close transaction.
       if (closingWholeParent && !this.tabs.has(tab.parentTabId)) {
         this.closeHeadlessMobileTerminalTab(worktreeId, snapshot, tab, {
+          allowMissingPersistedTab: true,
           killPtys: options.reason === undefined || options.reason === 'user'
         })
         this.notifyRendererOfHeadlessTerminalClose(tab.parentTabId)


### PR DESCRIPTION
## Summary

Resolves #10747.

CLI `terminal close --tab` now closes runtime-owned background terminal tabs even when renderer adoption timed out before the tab could be persisted. The runtime permits the missing persisted record only on the whole-parent, runtime-owned cleanup path; unavailable sessions and pinned persisted tabs retain their existing error behavior.

The change also adds a focused regression and extends the real `orcad` terminal smoke test to close the created tab and verify that its handle disappears from `terminal list`.

## Testing

### macOS

- `pnpm exec vitest run src/main/runtime/orca-runtime.test.ts -t "closes a background terminal that failed adoption before persistence"` — passed after the final rebase (1 passed).
- `pnpm typecheck` — passed after the final rebase.
- `pnpm lint` — passed after the final rebase.
- `pnpm test` — attempted; the shared host was heavily saturated and produced unrelated suite-wide timeout failures, so the run was interrupted rather than treated as PR evidence.

### Linux openclaw

Ubuntu Linux x86_64:

- Focused regression above — passed after the final rebase (1 passed).
- `pnpm smoke:orcad-terminal` — passed after the final rebase. It built the real CLI and Node runtime, created and exercised a terminal, ran `terminal close --tab`, and verified that the closed handle disappeared from `terminal list`.
- `pnpm build` — passed.
- Full `src/main/runtime/orca-runtime.test.ts` — 1,185 passed, 1 skipped, 1 unrelated flaky failure; the isolated failing test passed on rerun.
- `pnpm test` — attempted twice; the shell stopped the suite under machine load. The later run reached 970 passed files / 21,448 passed tests with 2 unrelated failing files / 5 failing tests before stopping, so no clean full-suite claim is made.

## Readiness

- P0/P1/P2 findings: none.
- Security and supply chain: no dependency, lockfile, secret, shell, eval, or command-construction changes.
- Performance and resources: no production polling, retries, or unbounded state added; smoke polling is bounded to 30 seconds.
- SSH and remoting: cleanup remains owned by the execution host and retains durable SSH PTY identity; no wire fields or opcodes changed.
- Compatibility: the runtime path is shared by git worktrees and folder workspaces; behavior is platform-neutral across macOS, Linux, and Windows; no Git-provider-specific behavior changed.
- Mobile/backward compatibility: internal additive runtime behavior only; no protocol, schema, or persisted-data format changed.

## Visual proof

N/A — this is a headless CLI/runtime behavior change with no rendered UI or visual output.