### PR TITLE
fix: prevent listen EINVAL on long sun_path in SSH relay

### DIFF
--- a/src/main/ssh/ssh-relay-endpoints.test.ts
+++ b/src/main/ssh/ssh-relay-endpoints.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { relayEndpointForHost } from './ssh-relay-endpoints'
+import { getRemoteHostPlatform } from './ssh-remote-platform'
+
+const SOCK_NAME = 'relay-1234567890abcdef.sock'
+
+function asciiEndpointWithLength(byteLength: number): { remoteDir: string; sockName: string } {
+  return {
+    remoteDir: `/${'a'.repeat(byteLength - Buffer.byteLength(SOCK_NAME, 'utf8') - 2)}`,
+    sockName: SOCK_NAME
+  }
+}
+
+describe('ssh-relay-endpoints', () => {
+  describe('relayEndpointForHost', () => {
+    it('keeps Linux paths at the 107-byte limit', () => {
+      const hostPlatform = getRemoteHostPlatform('linux-x64')
+      const { remoteDir, sockName } = asciiEndpointWithLength(107)
+      const result = relayEndpointForHost(hostPlatform, remoteDir, sockName)
+      expect(result).toBe(`${remoteDir}/${sockName}`)
+      expect(Buffer.byteLength(result, 'utf8')).toBe(107)
+    })
+
+    it('shortens Linux paths above the 107-byte limit', () => {
+      const hostPlatform = getRemoteHostPlatform('linux-x64')
+      const { remoteDir, sockName } = asciiEndpointWithLength(108)
+      const result = relayEndpointForHost(hostPlatform, remoteDir, sockName)
+      expect(result).not.toBe(`${remoteDir}/${sockName}`)
+      expect(result).toMatch(/relay-1234567890abcdef\.sock$/)
+      expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(107)
+    })
+
+    it('keeps Darwin paths at the 103-byte limit and shortens 104 bytes', () => {
+      const hostPlatform = getRemoteHostPlatform('darwin-arm64')
+      const atLimit = asciiEndpointWithLength(103)
+      const overLimit = asciiEndpointWithLength(104)
+
+      expect(relayEndpointForHost(hostPlatform, atLimit.remoteDir, atLimit.sockName)).toBe(
+        `${atLimit.remoteDir}/${atLimit.sockName}`
+      )
+      const shortened = relayEndpointForHost(hostPlatform, overLimit.remoteDir, overLimit.sockName)
+      expect(shortened).not.toBe(`${overLimit.remoteDir}/${overLimit.sockName}`)
+      expect(Buffer.byteLength(shortened, 'utf8')).toBeLessThanOrEqual(103)
+    })
+
+    it('measures non-ASCII paths in UTF-8 bytes', () => {
+      const hostPlatform = getRemoteHostPlatform('darwin-x64')
+      const remoteDir = `/${'é'.repeat(38)}`
+      const fullPath = `${remoteDir}/${SOCK_NAME}`
+
+      expect(fullPath.length).toBeLessThanOrEqual(103)
+      expect(Buffer.byteLength(fullPath, 'utf8')).toBeGreaterThan(103)
+      const shortened = relayEndpointForHost(hostPlatform, remoteDir, SOCK_NAME)
+      expect(shortened).not.toBe(fullPath)
+      expect(Buffer.byteLength(shortened, 'utf8')).toBeLessThanOrEqual(103)
+    })
+
+    it('keeps version isolation when shortening into the relay parent directory', () => {
+      const hostPlatform = getRemoteHostPlatform('linux-x64')
+      const remoteDir = `/home/user/.orca-remote/relay-${'v'.repeat(100)}`
+      const result = relayEndpointForHost(hostPlatform, remoteDir, SOCK_NAME)
+
+      expect(result).toMatch(
+        /^\/home\/user\/\.orca-remote\/[a-f0-9]{12}-relay-1234567890abcdef\.sock$/
+      )
+    })
+
+    it('falls back to a target-identifiable /tmp path if the parent path is too long', () => {
+      const hostPlatform = getRemoteHostPlatform('linux-x64')
+      const remoteDir = `/${'a'.repeat(100)}/.orca-remote/relay-v1`
+      const result = relayEndpointForHost(hostPlatform, remoteDir, SOCK_NAME)
+      expect(result).toMatch(/^\/tmp\/orca-[a-f0-9]{12}-relay-1234567890abcdef\.sock$/)
+      expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(107)
+    })
+
+    it('returns the complete Windows named pipe format', () => {
+      const hostPlatform = getRemoteHostPlatform('win32-x64')
+      const remoteDir = 'C:/Users/user/.orca-remote/relay'
+      const sockName = 'relay.sock'
+      const result = relayEndpointForHost(hostPlatform, remoteDir, sockName)
+      expect(result).toMatch(/^\\\\\.\\pipe\\orca-relay-[a-f0-9]{20}$/)
+    })
+  })
+})

--- a/src/main/ssh/ssh-relay-endpoints.ts
+++ b/src/main/ssh/ssh-relay-endpoints.ts
@@ -8,13 +8,34 @@ import {
 
 export const WINDOWS_ACTIVE_PIPE_MARKER_PREFIX = '.windows-active-pipe-'
 
+const LINUX_UNIX_SOCKET_MAX_PATH_BYTES = 107
+const DARWIN_UNIX_SOCKET_MAX_PATH_BYTES = 103
+
 export function relayEndpointForHost(
   hostPlatform: RemoteHostPlatform,
   remoteDir: string,
   sockName: string
 ): string {
   if (!isWindowsRemoteHost(hostPlatform)) {
-    return joinRemotePath(hostPlatform, remoteDir, sockName)
+    const maxPathBytes =
+      hostPlatform.os === 'darwin'
+        ? DARWIN_UNIX_SOCKET_MAX_PATH_BYTES
+        : LINUX_UNIX_SOCKET_MAX_PATH_BYTES
+    const fullPath = joinRemotePath(hostPlatform, remoteDir, sockName)
+    if (Buffer.byteLength(fullPath, 'utf8') > maxPathBytes) {
+      const parentDir = remoteDir.includes('/relay-')
+        ? remoteDir.substring(0, remoteDir.lastIndexOf('/'))
+        : remoteDir
+      const hash = createHash('sha256').update(fullPath).digest('hex').slice(0, 12)
+      const hashedSockName = `${hash}-${sockName}`
+      const shortened = joinRemotePath(hostPlatform, parentDir, hashedSockName)
+      if (Buffer.byteLength(shortened, 'utf8') <= maxPathBytes) {
+        return shortened
+      }
+      const tmpPath = `/tmp/orca-${hashedSockName}`
+      return Buffer.byteLength(tmpPath, 'utf8') <= maxPathBytes ? tmpPath : `/tmp/orca-${hash}.sock`
+    }
+    return fullPath
   }
   const endpointHash = createHash('sha256')
     .update(`${remoteDir}\0${sockName}`)

--- a/src/main/ssh/ssh-relay-reset.test.ts
+++ b/src/main/ssh/ssh-relay-reset.test.ts
@@ -47,16 +47,21 @@ async function capturedResetScript(): Promise<string> {
   return vi.mocked(execCommand).mock.lastCall?.[1] ?? ''
 }
 
-async function runResetScript(lsofMode: LsofMode): Promise<{
+async function runResetScript(
+  lsofMode: LsofMode,
+  socketName = relaySocketNameForInstanceId('ssh-1')
+): Promise<{
   killCalls: string[]
   pgrepCalls: string[]
   socketExists: boolean
 }> {
   const script = await capturedResetScript()
-  const home = mkdtempSync(join(tmpdir(), 'orca-'))
+  const home = mkdtempSync(
+    process.platform === 'darwin' ? '/tmp/orca-reset-' : join(tmpdir(), 'orca-')
+  )
   const binDir = join(home, 'bin')
   const socketDir = join(home, '.orca-remote')
-  const socketPath = join(socketDir, relaySocketNameForInstanceId('ssh-1'))
+  const socketPath = join(socketDir, socketName)
   const killLog = join(home, 'kill.log')
   const pgrepLog = join(home, 'pgrep.log')
   mkdirSync(binDir)
@@ -152,6 +157,17 @@ describe('forceStopRelayForTarget', () => {
 
       expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
       expect(result.pgrepCalls).toEqual(['called'])
+      expect(result.socketExists).toBe(false)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'stops target-specific shortened sockets across relay versions',
+    async () => {
+      const sockName = relaySocketNameForInstanceId('ssh-1')
+      const result = await runResetScript('match', `abcdef012345-${sockName}`)
+
+      expect(result.killCalls).toEqual([`-TERM ${TARGET_PID}`, `-KILL ${TARGET_PID}`])
       expect(result.socketExists).toBe(false)
     }
   )

--- a/src/main/ssh/ssh-relay-reset.ts
+++ b/src/main/ssh/ssh-relay-reset.ts
@@ -13,7 +13,7 @@ export async function forceStopRelayForTarget(
     `sock_name=${escapedSockName}`,
     'base="${HOME}/.orca-remote"',
     'if [ -d "$base" ]; then',
-    '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name"; do',
+    '  for sock in "$base"/relay-*/"$sock_name" "$base"/"$sock_name" "$base"/*-"$sock_name" /tmp/orca-*-"$sock_name"; do',
     '    [ -S "$sock" ] || continue',
     '    pid=""',
     // Why: lsof ORs selectors by default; -a prevents reset from targeting


### PR DESCRIPTION
Resolves #10726.

### Summary

Prevents SSH relay startup from passing overlength Unix-domain socket paths to listen.

- Uses the UTF-8 byte limits of 107 bytes on Linux and 103 bytes on macOS.
- Shortens overlength endpoints with a deterministic full-path hash while retaining the target-specific socket suffix and relay-version isolation.
- Falls back to a short /tmp endpoint when the remote home path itself is too long.
- Keeps Reset Relay able to find and stop shortened endpoints across relay versions.
- Leaves Windows named-pipe behavior unchanged.

### Testing

- [x] Focused endpoint and reset tests: 11 passed.
- [x] Focused SSH deploy, live-connect, relay-loss, and system-transport suite: 44 passed, 1 platform skip.
- [x] Node typecheck.
- [x] Changed-code quality gate and full lint/reliability/localization suite.
- [x] Relay build for linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, and win32-arm64.
- [x] Production Electron bundle build.
- [x] Linux openclaw runtime proof: a 165-byte raw socket path failed with EINVAL; the actual endpoint helper produced a 50-byte path; a real installed Orca relay bound it and returned ORCA-RELAY v0.1.0 READY; cleanup left no socket residue.

### AI Review

Reviewed SSH execution ownership, disconnect/reconnect behavior, stale socket cleanup, target-scoped reset behavior, crash/cast/retry/growth risk, security and supply chain, performance/resources, backward compatibility, folder workspaces, mixed-version wire behavior, Git provider neutrality, and macOS/Linux/Windows behavior. Two proven issues found during review (Darwin byte limit and reset cleanup for shortened sockets) were fixed and covered by tests. No remaining P0, P1, or P2 finding.

### Security Audit

No dependency, lockfile, binary, credential, shell-evaluation, or network-sink changes. Relay sockets remain created atomically with mode 0600 and endpoint credentials remain separate; shortened names are deterministic identifiers, not authentication.

### Visual Proof

N/A — this is main-process SSH relay endpoint handling with no rendered UI or visible layout change.

### Compatibility

No persisted state, mobile-facing surface, RPC field, stream opcode, or published remote-wire content changed. Folder workspaces and GitHub/GitLab review flows are unaffected because the endpoint is scoped to the SSH target rather than a repository workspace or provider.
