### PR TITLE
feat: add support for custom agents in terminal tabs- Introduced a ne…

### DIFF
--- a/src/main/external-editor-launch.ts
+++ b/src/main/external-editor-launch.ts
@@ -1,9 +1,10 @@
+import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { basename, posix, win32 } from 'node:path'
 import { parseWslUncPath } from '../shared/wsl-paths'
 import { isVsCodeLauncherExecutable } from '../shared/vscode-remote-ssh-launcher'
 import { resolveCliCommand } from './codex-cli/command'
-import { getCmdExePath } from './win32-utils'
+import { getCmdExePath, getSpawnArgsForWindows } from './win32-utils'
 
 export const EXTERNAL_EDITOR_CLI_COMMAND = 'code'
 const WINDOWS_CONSOLE_EDITORS = new Set(['nvim', 'vim'])
@@ -216,4 +217,47 @@ export function resolveVsCodeRemoteSshLaunchSpec(
     spawnCmd: editorCommand,
     spawnArgs: ['--remote', `ssh-remote+${authority}`, pathValue]
   }
+}
+
+export async function launchExternalEditor(launchSpec: ExternalEditorLaunchSpec): Promise<void> {
+  const { spawnCmd, spawnArgs } =
+    launchSpec.kind === 'executable'
+      ? getSpawnArgsForWindows(launchSpec.spawnCmd, launchSpec.spawnArgs)
+      : { spawnCmd: launchSpec.spawnCmd, spawnArgs: launchSpec.spawnArgs }
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn(spawnCmd, spawnArgs, {
+      detached: true,
+      stdio: 'ignore',
+      // Why: terminal editors such as nvim need a visible console on Windows;
+      // GUI editor launches stay hidden to avoid command-shim flashes.
+      windowsHide: launchSpec.hideWindowsConsole
+    })
+    let settled = false
+
+    function cleanup(): void {
+      child.off('error', onError)
+      child.off('spawn', onSpawn)
+    }
+
+    function settle(callback: () => void): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      callback()
+    }
+
+    function onError(error: Error): void {
+      settle(() => rejectPromise(error))
+    }
+
+    function onSpawn(): void {
+      child.unref()
+      settle(resolvePromise)
+    }
+    child.once('error', onError)
+    child.once('spawn', onSpawn)
+  })
 }

--- a/src/main/ipc/icon-image-pickers.ts
+++ b/src/main/ipc/icon-image-pickers.ts
@@ -1,0 +1,78 @@
+import { ipcMain, dialog } from 'electron'
+import { basename, extname } from 'node:path'
+import { readFile, stat } from 'node:fs/promises'
+import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
+
+const REPO_ICON_IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png'
+}
+
+const AGENT_ICON_IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon'
+}
+
+type IconImagePickOptions = {
+  filters: Electron.FileFilter[]
+  mimeTypes: Record<string, string>
+  unsupportedError: string
+  tooLargeError: string
+}
+
+async function pickIconImageFile(
+  options: IconImagePickOptions
+): Promise<{ dataUrl: string; fileName: string } | null> {
+  const result = await dialog.showOpenDialog({
+    properties: ['openFile'],
+    filters: options.filters
+  })
+  if (result.canceled || result.filePaths.length === 0) {
+    return null
+  }
+  const filePath = result.filePaths[0]!
+  const extension = extname(filePath).toLowerCase()
+  const mimeType = options.mimeTypes[extension]
+  if (!mimeType) {
+    throw new Error(options.unsupportedError)
+  }
+  const stats = await stat(filePath)
+  if (stats.size > MAX_REPO_ICON_UPLOAD_BYTES) {
+    throw new Error(options.tooLargeError)
+  }
+  const buffer = await readFile(filePath)
+  return {
+    dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
+    fileName: basename(filePath)
+  }
+}
+
+export function registerIconImagePickerHandlers(): void {
+  ipcMain.handle('shell:pickRepoIconImage', () =>
+    pickIconImageFile({
+      filters: [{ name: 'Repo icon images', extensions: ['png'] }],
+      mimeTypes: REPO_ICON_IMAGE_MIME_TYPES,
+      unsupportedError: 'Repo icons must be PNG files.',
+      tooLargeError: 'Repo icon image must be 256KB or smaller.'
+    })
+  )
+
+  ipcMain.handle('shell:pickAgentIconImage', () =>
+    pickIconImageFile({
+      filters: [
+        {
+          name: 'Images',
+          extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico']
+        }
+      ],
+      mimeTypes: AGENT_ICON_IMAGE_MIME_TYPES,
+      unsupportedError: 'Unsupported image format.',
+      tooLargeError: 'Image must be 256KB or smaller.'
+    })
+  )
+}

--- a/src/main/ipc/icon-image-pickers.ts
+++ b/src/main/ipc/icon-image-pickers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, dialog } from 'electron'
 import { basename, extname } from 'node:path'
-import { readFile, stat } from 'node:fs/promises'
+import { open } from 'node:fs/promises'
 import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
 
 const REPO_ICON_IMAGE_MIME_TYPES: Record<string, string> = {
@@ -41,14 +41,23 @@ async function pickIconImageFile(
   if (!mimeType) {
     throw new Error(options.unsupportedError)
   }
-  const stats = await stat(filePath)
-  if (stats.size > MAX_REPO_ICON_UPLOAD_BYTES) {
-    throw new Error(options.tooLargeError)
-  }
-  const buffer = await readFile(filePath)
-  return {
-    dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
-    fileName: basename(filePath)
+  // Why: stat→readFile is a TOCTOU window — a file swap between the size check
+  // and the read can bypass the cap. Open one fd and bound the read by the
+  // limit so the size cap is enforced by the read itself, not a separate lookup.
+  const handle = await open(filePath, 'r')
+  try {
+    const probe = Buffer.alloc(MAX_REPO_ICON_UPLOAD_BYTES + 1)
+    const { bytesRead } = await handle.read(probe, 0, MAX_REPO_ICON_UPLOAD_BYTES + 1, 0)
+    if (bytesRead > MAX_REPO_ICON_UPLOAD_BYTES) {
+      throw new Error(options.tooLargeError)
+    }
+    const buffer = probe.subarray(0, bytesRead)
+    return {
+      dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
+      fileName: basename(filePath)
+    }
+  } finally {
+    await handle.close()
   }
 }
 

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -23,6 +23,7 @@ const {
   registerDiagnosticsHandlersMock,
   registerTerminalRenderDesyncEvidenceHandlerMock,
   registerShellHandlersMock,
+  registerIconImagePickerHandlersMock,
   registerPetHandlersMock,
   registerSessionHandlersMock,
   registerUIHandlersMock,
@@ -88,6 +89,7 @@ const {
   registerDiagnosticsHandlersMock: vi.fn(),
   registerTerminalRenderDesyncEvidenceHandlerMock: vi.fn(),
   registerShellHandlersMock: vi.fn(),
+  registerIconImagePickerHandlersMock: vi.fn(),
   registerPetHandlersMock: vi.fn(),
   registerSessionHandlersMock: vi.fn(),
   registerUIHandlersMock: vi.fn(),
@@ -258,6 +260,10 @@ vi.mock('./shell', () => ({
   registerShellHandlers: registerShellHandlersMock
 }))
 
+vi.mock('./icon-image-pickers', () => ({
+  registerIconImagePickerHandlers: registerIconImagePickerHandlersMock
+}))
+
 vi.mock('./pet', () => ({
   registerPetHandlers: registerPetHandlersMock
 }))
@@ -406,6 +412,7 @@ describe('registerCoreHandlers', () => {
     registerDiagnosticsHandlersMock.mockReset()
     registerTerminalRenderDesyncEvidenceHandlerMock.mockReset()
     registerShellHandlersMock.mockReset()
+    registerIconImagePickerHandlersMock.mockReset()
     registerPetHandlersMock.mockReset()
     registerSessionHandlersMock.mockReset()
     registerUIHandlersMock.mockReset()
@@ -546,6 +553,7 @@ describe('registerCoreHandlers', () => {
     expect(registerCliHandlersMock).toHaveBeenCalled()
     expect(registerPreflightHandlersMock).toHaveBeenCalled()
     expect(registerShellHandlersMock).toHaveBeenCalledWith(store)
+    expect(registerIconImagePickerHandlersMock).toHaveBeenCalled()
     expect(registerClipboardHandlersMock).toHaveBeenCalledWith(store)
     expect(registerUpdaterHandlersMock).toHaveBeenCalled()
     expect(setTrustedBrowserRendererWebContentsIdMock).toHaveBeenCalledWith(null)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -47,6 +47,7 @@ import { registerKeybindingHandlers } from './keybindings'
 import { registerTelemetryHandlers } from './telemetry'
 import { registerBrowserHandlers } from './browser'
 import { registerShellHandlers } from './shell'
+import { registerIconImagePickerHandlers } from './icon-image-pickers'
 import { registerPetHandlers } from './pet'
 import { registerUIHandlers, setTrustedUIRendererWebContentsId } from './ui'
 import { registerEmulatorFrameStreamHandlers } from './emulator-frame-stream'
@@ -185,6 +186,7 @@ export function registerCoreHandlers(
   })
   registerBrowserHandlers()
   registerShellHandlers(store)
+  registerIconImagePickerHandlers()
   registerPetHandlers()
   registerSessionHandlers(store)
   registerUIHandlers(store)

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -1,29 +1,22 @@
 import { ipcMain, shell, dialog } from 'electron'
-import { spawn } from 'node:child_process'
-import { constants, copyFile, readFile, stat } from 'node:fs/promises'
-import { basename, extname, isAbsolute, normalize, posix, win32 } from 'node:path'
+import { constants, copyFile, stat } from 'node:fs/promises'
+import { isAbsolute, normalize, posix, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type {
   ShellOpenExternalEditorRequest,
   ShellOpenExternalEditorResult,
   ShellOpenLocalPathResult
 } from '../../shared/shell-open-types'
-import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
 import type { Store } from '../persistence'
-import { getSpawnArgsForWindows } from '../win32-utils'
 import {
   EXTERNAL_EDITOR_CLI_COMMAND,
+  launchExternalEditor,
   resolveExternalEditorLaunchSpec,
-  resolveVsCodeRemoteSshLaunchSpec,
-  type ExternalEditorLaunchSpec
+  resolveVsCodeRemoteSshLaunchSpec
 } from '../external-editor-launch'
 import { resolveVsCodeSshAuthority } from '../ssh/vscode-ssh-authority'
 
 export { EXTERNAL_EDITOR_CLI_COMMAND }
-
-const REPO_ICON_IMAGE_MIME_TYPES: Record<string, string> = {
-  '.png': 'image/png'
-}
 
 async function pathExists(pathValue: string): Promise<boolean> {
   try {
@@ -70,49 +63,6 @@ async function openInFileManager(
   } catch {
     return { ok: false, reason: 'launch-failed' }
   }
-}
-
-async function launchExternalEditor(launchSpec: ExternalEditorLaunchSpec): Promise<void> {
-  const { spawnCmd, spawnArgs } =
-    launchSpec.kind === 'executable'
-      ? getSpawnArgsForWindows(launchSpec.spawnCmd, launchSpec.spawnArgs)
-      : { spawnCmd: launchSpec.spawnCmd, spawnArgs: launchSpec.spawnArgs }
-
-  await new Promise<void>((resolvePromise, rejectPromise) => {
-    const child = spawn(spawnCmd, spawnArgs, {
-      detached: true,
-      stdio: 'ignore',
-      // Why: terminal editors such as nvim need a visible console on Windows;
-      // GUI editor launches stay hidden to avoid command-shim flashes.
-      windowsHide: launchSpec.hideWindowsConsole
-    })
-    let settled = false
-
-    function cleanup(): void {
-      child.off('error', onError)
-      child.off('spawn', onSpawn)
-    }
-
-    function settle(callback: () => void): void {
-      if (settled) {
-        return
-      }
-      settled = true
-      cleanup()
-      callback()
-    }
-
-    function onError(error: Error): void {
-      settle(() => rejectPromise(error))
-    }
-
-    function onSpawn(): void {
-      child.unref()
-      settle(resolvePromise)
-    }
-    child.once('error', onError)
-    child.once('spawn', onSpawn)
-  })
 }
 
 async function openInExternalEditor(
@@ -295,37 +245,6 @@ export function registerShellHandlers(store: Store): void {
     }
     return result.filePaths[0]
   })
-
-  ipcMain.handle(
-    'shell:pickRepoIconImage',
-    async (): Promise<{ dataUrl: string; fileName: string } | null> => {
-      const result = await dialog.showOpenDialog({
-        properties: ['openFile'],
-        filters: [{ name: 'Repo icon images', extensions: ['png'] }]
-      })
-      if (result.canceled || result.filePaths.length === 0) {
-        return null
-      }
-
-      const filePath = result.filePaths[0]
-      const extension = extname(filePath).toLowerCase()
-      const mimeType = REPO_ICON_IMAGE_MIME_TYPES[extension]
-      if (!mimeType) {
-        throw new Error('Repo icons must be PNG files.')
-      }
-
-      const stats = await stat(filePath)
-      if (stats.size > MAX_REPO_ICON_UPLOAD_BYTES) {
-        throw new Error('Repo icon image must be 256KB or smaller.')
-      }
-
-      const buffer = await readFile(filePath)
-      return {
-        dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
-        fileName: basename(filePath)
-      }
-    }
-  )
 
   ipcMain.handle('shell:pickAudio', async (): Promise<string | null> => {
     const result = await dialog.showOpenDialog({

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2313,6 +2313,7 @@ export type PreloadApi = {
     pickAttachment: () => Promise<string | null>
     pickImage: () => Promise<string | null>
     pickRepoIconImage: () => Promise<{ dataUrl: string; fileName: string } | null>
+    pickAgentIconImage: () => Promise<{ dataUrl: string; fileName: string } | null>
     pickAudio: () => Promise<string | null>
     pickDirectory: (args: { defaultPath?: string }) => Promise<string | null>
     copyFile: (args: { srcPath: string; destPath: string }) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2239,6 +2239,9 @@ const api = {
     pickRepoIconImage: (): Promise<{ dataUrl: string; fileName: string } | null> =>
       ipcRenderer.invoke('shell:pickRepoIconImage'),
 
+    pickAgentIconImage: (): Promise<{ dataUrl: string; fileName: string } | null> =>
+      ipcRenderer.invoke('shell:pickAgentIconImage'),
+
     pickAudio: (): Promise<string | null> => ipcRenderer.invoke('shell:pickAudio'),
 
     pickDirectory: (args: { defaultPath?: string }): Promise<string | null> =>

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -963,6 +963,21 @@ export default function NewWorkspaceComposerCard({
   const [selectedCustomAgentId, setSelectedCustomAgentId] = React.useState<string | null>(
     defaultCustomAgentId
   )
+  // Why: the composer mounts before settings hydrate, so a default custom agent
+  // that lands later (or is cleared after the agent is deleted) must propagate
+  // to the combobox instead of pinning a stale mount-time id that no longer
+  // resolves to a custom agent.
+  React.useEffect(() => {
+    setSelectedCustomAgentId((current) => {
+      if (defaultCustomAgentId && customAgents.some((a) => a.id === defaultCustomAgentId)) {
+        return defaultCustomAgentId
+      }
+      if (current && customAgents.some((a) => a.id === current)) {
+        return current
+      }
+      return null
+    })
+  }, [defaultCustomAgentId, customAgents])
   const handleCustomAgentSelect = React.useCallback(
     (agent: CustomAgent | null): void => {
       setSelectedCustomAgentId(agent?.id ?? null)

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -52,7 +52,8 @@ import type {
   SetupAgentStartupPolicy,
   OrcaHooks,
   SparsePreset,
-  TuiAgent
+  TuiAgent,
+  CustomAgent
 } from '../../../shared/types'
 import SparseCheckoutPresetSelect from '@/components/sparse/SparseCheckoutPresetSelect'
 import SmartWorkspaceNameField, {
@@ -145,7 +146,7 @@ type NewWorkspaceComposerCardProps = {
   createDisabled: boolean
   projectError: string | null
   creating: boolean
-  onCreate: () => void
+  onCreate: (customLaunchAgentId?: string | null) => void
   note: string
   onNoteChange: (value: string) => void
   setupConfig: SetupConfig | null
@@ -956,7 +957,30 @@ export default function NewWorkspaceComposerCard({
   const activeModal = useAppStore((s) => s.activeModal)
   const defaultTuiAgent = useAppStore((s) => s.settings?.defaultTuiAgent ?? null)
   const disabledTuiAgents = useAppStore((s) => s.settings?.disabledTuiAgents ?? [])
+  const customAgents = useAppStore((s) => s.settings?.customAgents ?? [])
+  const defaultCustomAgentId = useAppStore((s) => s.settings?.defaultCustomAgentId ?? null)
   const updateSettings = useAppStore((s) => s.updateSettings)
+  const [selectedCustomAgentId, setSelectedCustomAgentId] = React.useState<string | null>(
+    defaultCustomAgentId
+  )
+  const handleCustomAgentSelect = React.useCallback(
+    (agent: CustomAgent | null): void => {
+      setSelectedCustomAgentId(agent?.id ?? null)
+      if (agent !== null) {
+        onQuickAgentChange(null)
+      }
+    },
+    [onQuickAgentChange]
+  )
+  const handleQuickAgentChange = React.useCallback(
+    (next: TuiAgent | null): void => {
+      if (next !== null && selectedCustomAgentId !== null) {
+        setSelectedCustomAgentId(null)
+      }
+      onQuickAgentChange(next)
+    },
+    [onQuickAgentChange, selectedCustomAgentId]
+  )
   const nameInputFocusFrameRef = React.useRef<number | null>(null)
   const branchNameInputId = React.useId()
   const submitShortcutModifierLabel = getScreenSubmitModifierLabel()
@@ -1455,12 +1479,15 @@ export default function NewWorkspaceComposerCard({
           <AgentCombobox
             agents={visibleQuickAgents}
             value={quickAgent}
-            onValueChange={onQuickAgentChange}
+            onValueChange={handleQuickAgentChange}
             onOpenManageAgents={onOpenAgentSettings}
             defaultAgent={defaultTuiAgent}
             onSetDefault={handleSetDefaultAgent}
             triggerClassName="h-9 w-full border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
-            onTriggerEnter={createDisabled ? undefined : onCreate}
+            onTriggerEnter={createDisabled ? undefined : () => void onCreate(selectedCustomAgentId)}
+            customAgents={customAgents}
+            selectedCustomAgentId={selectedCustomAgentId}
+            onCustomAgentSelect={handleCustomAgentSelect}
           />
         </div>
 
@@ -1787,7 +1814,7 @@ export default function NewWorkspaceComposerCard({
           </button>
         ) : null}
         <Button
-          onClick={() => void onCreate()}
+          onClick={() => void onCreate(selectedCustomAgentId)}
           disabled={createDisabled}
           size="sm"
           className="text-xs"

--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -1,33 +1,24 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { ArrowRight, Check, ChevronsUpDown, Star, Terminal } from 'lucide-react'
+import { ArrowRight, ChevronsUpDown, Terminal } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import {
-  Command,
-  CommandEmpty,
-  CommandInput,
-  CommandItem,
-  CommandList
-} from '@/components/ui/command'
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger
-} from '@/components/ui/context-menu'
+import { Command, CommandEmpty, CommandInput, CommandList } from '@/components/ui/command'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { AgentIcon, type AgentCatalogEntry } from '@/lib/agent-catalog'
 import {
   agentPickerBlankTerminalMatches,
   getAgentPickerCommandValue,
-  searchAgentPickerEntries
+  searchAgentPickerEntries,
+  searchCustomAgentPickerEntries
 } from '@/lib/agent-picker-search'
 import { cn } from '@/lib/utils'
-import type { TuiAgent } from '../../../../shared/types'
+import type { CustomAgent, TuiAgent } from '../../../../shared/types'
+import { CustomAgentIcon } from './CustomAgentIcon'
 import {
   createAgentComboboxCommandState,
   resolveAgentComboboxCommandState,
   updateAgentComboboxCommandValue
 } from './agent-combobox-command-state'
+import { renderItem } from './agent-combobox-item-renderer'
 import { translate } from '@/i18n/i18n'
 
 type DefaultAgentPreference = TuiAgent | 'blank' | null
@@ -53,65 +44,19 @@ type AgentComboboxProps = {
   allowNarrowTrigger?: boolean
   allowBlankTerminal?: boolean
   emptyLabel?: string
+  /** User-defined custom agents shown in a separate section of the dropdown. */
+  customAgents?: CustomAgent[]
+  /** ID of the currently selected custom agent, or null when none is selected. */
+  selectedCustomAgentId?: string | null
+  /** Called when the user picks a custom agent (or null to clear the selection). */
+  onCustomAgentSelect?: (agent: CustomAgent | null) => void
 }
 
 const BLANK_VALUE = '__none__'
 const TRIGGER_MIN_WIDTH_CLASS = '!min-w-[260px]'
-
-type ItemRenderArgs = {
-  key: string
-  itemValue: string
-  isChecked: boolean
-  isDefault: boolean
-  onSelect: () => void
-  onSetDefault?: () => void
-  icon: React.ReactNode
-  label: string
-}
-
-function renderItem({
-  key,
-  itemValue,
-  isChecked,
-  isDefault,
-  onSelect,
-  onSetDefault,
-  icon,
-  label
-}: ItemRenderArgs): React.ReactNode {
-  const row = (
-    <CommandItem
-      key={key}
-      value={itemValue}
-      onSelect={onSelect}
-      className="items-center gap-2 px-3 py-1.5"
-    >
-      <Check className={cn('size-4 text-foreground', isChecked ? 'opacity-100' : 'opacity-0')} />
-      <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-        {icon}
-        <span className="truncate">{label}</span>
-      </span>
-    </CommandItem>
-  )
-  if (!onSetDefault) {
-    return row
-  }
-  return (
-    // Why: z-[70] sits above PopoverContent's z-[60] so the right-click menu
-    // renders in front of the still-open combobox popover instead of behind it.
-    <ContextMenu key={key}>
-      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
-      <ContextMenuContent className="z-[70]">
-        <ContextMenuItem onSelect={onSetDefault} disabled={isDefault}>
-          <Star className="size-3.5" />
-          {isDefault
-            ? translate('auto.components.agent.AgentCombobox.1b0d6965fa', 'Current default')
-            : translate('auto.components.agent.AgentCombobox.9c6b59fe58', 'Set as default')}
-        </ContextMenuItem>
-      </ContextMenuContent>
-    </ContextMenu>
-  )
-}
+// Why: stable reference so useMemo dependencies don't re-fire every render
+// when callers pass `customAgents` as undefined.
+const EMPTY_CUSTOM_AGENTS: readonly CustomAgent[] = []
 
 export default function AgentCombobox({
   agents,
@@ -125,7 +70,10 @@ export default function AgentCombobox({
   onTriggerEnter,
   allowNarrowTrigger = false,
   allowBlankTerminal = true,
-  emptyLabel
+  emptyLabel,
+  customAgents,
+  selectedCustomAgentId,
+  onCustomAgentSelect
 }: AgentComboboxProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -142,6 +90,18 @@ export default function AgentCombobox({
     [agents, value]
   )
   const filteredAgents = useMemo(() => searchAgentPickerEntries(agents, query), [agents, query])
+  const customAgentsList = customAgents ?? EMPTY_CUSTOM_AGENTS
+  const filteredCustomAgents = useMemo(
+    () => searchCustomAgentPickerEntries(customAgentsList, query),
+    [customAgentsList, query]
+  )
+  const selectedCustomAgent = useMemo<CustomAgent | null>(
+    () =>
+      selectedCustomAgentId
+        ? (customAgentsList.find((a) => a.id === selectedCustomAgentId) ?? null)
+        : null,
+    [customAgentsList, selectedCustomAgentId]
+  )
   const blankMatchesQuery = useMemo(
     () => allowBlankTerminal && agentPickerBlankTerminalMatches(query),
     [allowBlankTerminal, query]
@@ -151,6 +111,8 @@ export default function AgentCombobox({
     blankMatchesQuery,
     currentValue: value,
     filteredAgents,
+    filteredCustomAgents,
+    selectedCustomAgentId,
     rawQuery: query
   })
   const resolvedCommandState = resolveAgentComboboxCommandState(
@@ -207,23 +169,41 @@ export default function AgentCombobox({
     (nextOpen: boolean) => {
       setOpen(nextOpen)
       if (nextOpen) {
-        setCommandState(createAgentComboboxCommandState(value ?? BLANK_VALUE))
+        setCommandState(
+          createAgentComboboxCommandState(selectedCustomAgentId ?? value ?? BLANK_VALUE)
+        )
         return
       }
       cancelFocusFrame()
       setQuery('')
     },
-    [cancelFocusFrame, value]
+    [cancelFocusFrame, value, selectedCustomAgentId]
   )
 
   const handleSelect = useCallback(
     (nextValue: TuiAgent | null) => {
       onValueChange(nextValue)
+      if (nextValue !== null && onCustomAgentSelect) {
+        onCustomAgentSelect(null)
+      }
       setOpen(false)
       setQuery('')
       onValueSelected?.(nextValue)
     },
-    [onValueChange, onValueSelected]
+    [onValueChange, onValueSelected, onCustomAgentSelect]
+  )
+
+  const handleCustomAgentSelect = useCallback(
+    (agent: CustomAgent | null) => {
+      onCustomAgentSelect?.(agent)
+      if (agent !== null) {
+        onValueChange(null)
+      }
+      setOpen(false)
+      setQuery('')
+      onValueSelected?.(null)
+    },
+    [onCustomAgentSelect, onValueChange, onValueSelected]
   )
 
   // Why: mirror RepoCombobox's trigger-keydown handling — the button-style
@@ -250,7 +230,9 @@ export default function AgentCombobox({
       }
       if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
         event.preventDefault()
-        setCommandState(createAgentComboboxCommandState(value ?? BLANK_VALUE))
+        setCommandState(
+          createAgentComboboxCommandState(selectedCustomAgentId ?? value ?? BLANK_VALUE)
+        )
         setOpen(true)
         return
       }
@@ -259,12 +241,14 @@ export default function AgentCombobox({
       }
       if (event.key.length === 1 && /\S/.test(event.key)) {
         event.preventDefault()
-        setCommandState(createAgentComboboxCommandState(value ?? BLANK_VALUE))
+        setCommandState(
+          createAgentComboboxCommandState(selectedCustomAgentId ?? value ?? BLANK_VALUE)
+        )
         setQuery(event.key)
         setOpen(true)
       }
     },
-    [open, onTriggerEnter, value]
+    [open, onTriggerEnter, value, selectedCustomAgentId]
   )
 
   return (
@@ -287,7 +271,12 @@ export default function AgentCombobox({
             )}
             data-agent-combobox-root="true"
           >
-            {selectedAgent ? (
+            {selectedCustomAgent ? (
+              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                <CustomAgentIcon agent={selectedCustomAgent} />
+                <span className="truncate">{selectedCustomAgent.label}</span>
+              </span>
+            ) : selectedAgent ? (
               <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
                 <AgentIcon agent={selectedAgent.id} />
                 <span className="truncate">{selectedAgent.label}</span>
@@ -337,9 +326,14 @@ export default function AgentCombobox({
                 ? renderItem({
                     key: BLANK_VALUE,
                     itemValue: BLANK_VALUE,
-                    isChecked: value === null,
+                    isChecked: value === null && !selectedCustomAgentId,
                     isDefault: defaultAgent === 'blank',
-                    onSelect: () => handleSelect(null),
+                    onSelect: () => {
+                      handleSelect(null)
+                      if (onCustomAgentSelect) {
+                        onCustomAgentSelect(null)
+                      }
+                    },
                     onSetDefault: onSetDefault ? () => onSetDefault('blank') : undefined,
                     icon: <Terminal className="size-3.5" />,
                     label: translate(
@@ -352,7 +346,7 @@ export default function AgentCombobox({
                 renderItem({
                   key: agent.id,
                   itemValue: agent.id,
-                  isChecked: value === agent.id,
+                  isChecked: value === agent.id && !selectedCustomAgentId,
                   isDefault: defaultAgent === agent.id,
                   onSelect: () => handleSelect(agent.id),
                   onSetDefault: onSetDefault ? () => onSetDefault(agent.id) : undefined,
@@ -360,6 +354,24 @@ export default function AgentCombobox({
                   label: agent.label
                 })
               )}
+              {filteredCustomAgents.length > 0 ? (
+                <>
+                  <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/60">
+                    {translate('auto.components.agent.AgentCombobox.customAgents', 'Custom agents')}
+                  </div>
+                  {filteredCustomAgents.map((agent) =>
+                    renderItem({
+                      key: agent.id,
+                      itemValue: agent.id,
+                      isChecked: selectedCustomAgentId === agent.id,
+                      isDefault: false,
+                      onSelect: () => handleCustomAgentSelect(agent),
+                      icon: <CustomAgentIcon agent={agent} />,
+                      label: agent.label
+                    })
+                  )}
+                </>
+              ) : null}
             </CommandList>
             {onOpenManageAgents ? (
               <div className="border-t border-border">

--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -183,9 +183,11 @@ export default function AgentCombobox({
   const handleSelect = useCallback(
     (nextValue: TuiAgent | null) => {
       onValueChange(nextValue)
-      if (nextValue !== null && onCustomAgentSelect) {
-        onCustomAgentSelect(null)
-      }
+      // Why: selecting any standard value (including Blank Terminal / null)
+      // clears a custom-agent selection so the trigger never shows a stale
+      // custom agent while value is null. Centralizing here removes the need
+      // for call sites to duplicate the clear (and forget it).
+      onCustomAgentSelect?.(null)
       setOpen(false)
       setQuery('')
       onValueSelected?.(nextValue)
@@ -328,12 +330,7 @@ export default function AgentCombobox({
                     itemValue: BLANK_VALUE,
                     isChecked: value === null && !selectedCustomAgentId,
                     isDefault: defaultAgent === 'blank',
-                    onSelect: () => {
-                      handleSelect(null)
-                      if (onCustomAgentSelect) {
-                        onCustomAgentSelect(null)
-                      }
-                    },
+                    onSelect: () => handleSelect(null),
                     onSetDefault: onSetDefault ? () => onSetDefault('blank') : undefined,
                     icon: <Terminal className="size-3.5" />,
                     label: translate(

--- a/src/renderer/src/components/agent/CustomAgentIcon.tsx
+++ b/src/renderer/src/components/agent/CustomAgentIcon.tsx
@@ -1,0 +1,81 @@
+import type { CustomAgent } from '../../../../shared/types'
+
+type CustomAgentIconProps = {
+  agent: CustomAgent
+  /** Pixel size of the rendered icon. Defaults to 14 (combobox density). */
+  size?: number
+}
+
+/**
+ * Render a custom agent's identity glyph. Falls back through:
+ *   1. user-provided iconUrl
+ *   2. Google favicon service for a declared domain
+ *   3. a colored tile with the label's first letter
+ *
+ * Shared by the agent combobox and the terminal tab leading icon so icon
+ * updates made in settings propagate to every surface that shows the glyph.
+ */
+export function CustomAgentIcon({ agent, size = 14 }: CustomAgentIconProps): React.JSX.Element {
+  if (agent.iconUrl) {
+    return (
+      <img
+        src={agent.iconUrl}
+        width={size}
+        height={size}
+        alt=""
+        aria-hidden
+        style={{ borderRadius: 2 }}
+      />
+    )
+  }
+  if (agent.faviconDomain) {
+    return (
+      <img
+        src={`https://www.google.com/s2/favicons?domain=${agent.faviconDomain}&sz=64`}
+        width={size}
+        height={size}
+        alt=""
+        aria-hidden
+        style={{ borderRadius: 2 }}
+      />
+    )
+  }
+  return <CustomAgentLetterTile agent={agent} size={size} />
+}
+
+/**
+ * SVG letter tile used when no image source is available. Sized via the SVG
+ * viewBox so callers can render at any pixel size without re-styling.
+ */
+function CustomAgentLetterTile({
+  agent,
+  size
+}: {
+  agent: CustomAgent
+  size: number
+}): React.JSX.Element {
+  const letter = agent.label.charAt(0).toUpperCase()
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+      className="text-current"
+    >
+      <rect width="14" height="14" rx="3" fill="currentColor" fillOpacity="0.2" />
+      <text
+        x="7"
+        y="10.5"
+        textAnchor="middle"
+        fontSize="8.5"
+        fill="currentColor"
+        fontWeight="700"
+        fontFamily="system-ui, -apple-system, sans-serif"
+      >
+        {letter}
+      </text>
+    </svg>
+  )
+}

--- a/src/renderer/src/components/agent/CustomAgentIcon.tsx
+++ b/src/renderer/src/components/agent/CustomAgentIcon.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { CustomAgent } from '../../../../shared/types'
 
 type CustomAgentIconProps = {
@@ -16,26 +17,23 @@ type CustomAgentIconProps = {
  * updates made in settings propagate to every surface that shows the glyph.
  */
 export function CustomAgentIcon({ agent, size = 14 }: CustomAgentIconProps): React.JSX.Element {
-  if (agent.iconUrl) {
+  // Why: a remote iconUrl/favicon can 404 or be blocked; track one error flag
+  // so the <img> degrades to the letter tile instead of showing a broken icon.
+  const [imgError, setImgError] = useState(false)
+  const src = agent.iconUrl
+    ? agent.iconUrl
+    : agent.faviconDomain
+      ? `https://www.google.com/s2/favicons?domain=${encodeURIComponent(agent.faviconDomain)}&sz=64`
+      : null
+  if (src && !imgError) {
     return (
       <img
-        src={agent.iconUrl}
+        src={src}
         width={size}
         height={size}
         alt=""
         aria-hidden
-        style={{ borderRadius: 2 }}
-      />
-    )
-  }
-  if (agent.faviconDomain) {
-    return (
-      <img
-        src={`https://www.google.com/s2/favicons?domain=${agent.faviconDomain}&sz=64`}
-        width={size}
-        height={size}
-        alt=""
-        aria-hidden
+        onError={() => setImgError(true)}
         style={{ borderRadius: 2 }}
       />
     )

--- a/src/renderer/src/components/agent/agent-combobox-item-renderer.tsx
+++ b/src/renderer/src/components/agent/agent-combobox-item-renderer.tsx
@@ -1,0 +1,70 @@
+import { Check, Star } from 'lucide-react'
+import { CommandItem } from '@/components/ui/command'
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger
+} from '@/components/ui/context-menu'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+
+export type ItemRenderArgs = {
+  key: string
+  itemValue: string
+  isChecked: boolean
+  isDefault: boolean
+  onSelect: () => void
+  onSetDefault?: () => void
+  icon: React.ReactNode
+  label: string
+}
+
+/**
+ * Render a single agent row inside the combobox list. When `onSetDefault` is
+ * provided, the row is wrapped in a right-click context menu offering a
+ * "Set as default" action; otherwise the bare row is returned.
+ */
+export function renderItem({
+  key,
+  itemValue,
+  isChecked,
+  isDefault,
+  onSelect,
+  onSetDefault,
+  icon,
+  label
+}: ItemRenderArgs): React.ReactNode {
+  const row = (
+    <CommandItem
+      key={key}
+      value={itemValue}
+      onSelect={onSelect}
+      className="items-center gap-2 px-3 py-1.5"
+    >
+      <Check className={cn('size-4 text-foreground', isChecked ? 'opacity-100' : 'opacity-0')} />
+      <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+        {icon}
+        <span className="truncate">{label}</span>
+      </span>
+    </CommandItem>
+  )
+  if (!onSetDefault) {
+    return row
+  }
+  return (
+    // Why: z-[70] sits above PopoverContent's z-[60] so the right-click menu
+    // renders in front of the still-open combobox popover instead of behind it.
+    <ContextMenu key={key}>
+      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      <ContextMenuContent className="z-[70]">
+        <ContextMenuItem onSelect={onSetDefault} disabled={isDefault}>
+          <Star className="size-3.5" />
+          {isDefault
+            ? translate('auto.components.agent.AgentCombobox.1b0d6965fa', 'Current default')
+            : translate('auto.components.agent.AgentCombobox.9c6b59fe58', 'Set as default')}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  )
+}

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -58,6 +58,8 @@ import {
 } from '../../../../shared/tui-agent-permissions'
 import { getSettingOwnershipSummary } from './setting-ownership'
 import { translate } from '@/i18n/i18n'
+import { toast } from 'sonner'
+import { CustomAgentIcon } from '../agent/CustomAgentIcon'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { parseAgentDefaultEnvDraft, stringifyAgentDefaultEnvDraft } from './agent-default-env-draft'
 
@@ -683,38 +685,6 @@ function DefaultAgentPill({ active, onClick, children }: DefaultAgentPillProps):
   )
 }
 
-function CustomAgentDefaultPillIcon({ agent }: { agent: CustomAgent }): React.JSX.Element {
-  if (agent.iconUrl) {
-    return (
-      <img
-        src={agent.iconUrl}
-        width={14}
-        height={14}
-        alt=""
-        aria-hidden
-        style={{ borderRadius: 2 }}
-      />
-    )
-  }
-  if (agent.faviconDomain) {
-    return (
-      <img
-        src={`https://www.google.com/s2/favicons?domain=${agent.faviconDomain}&sz=64`}
-        width={14}
-        height={14}
-        alt=""
-        aria-hidden
-        style={{ borderRadius: 2 }}
-      />
-    )
-  }
-  return (
-    <span className="flex size-3.5 shrink-0 items-center justify-center rounded-[3px] bg-muted text-[8px] font-bold text-muted-foreground">
-      {agent.label.charAt(0).toUpperCase()}
-    </span>
-  )
-}
-
 export function AgentsPane({
   settings,
   updateSettings,
@@ -841,7 +811,12 @@ export function AgentsPane({
   }
 
   const deleteCustomAgent = (id: string): void => {
-    updateSettings({ customAgents: customAgents.filter((a) => a.id !== id) })
+    updateSettings({
+      customAgents: customAgents.filter((a) => a.id !== id),
+      // Why: clear the default if it pointed at the deleted agent so the
+      // picker doesn't pin a stale id that no longer resolves to an agent.
+      ...(defaultCustomAgentId === id ? { defaultCustomAgentId: null } : {})
+    })
   }
 
   // Why: null means detection is in flight, not "all agents are installed".
@@ -927,7 +902,7 @@ export function AgentsPane({
                     active={isActive}
                     onClick={() => setDefaultCustomAgent(isActive ? null : agent.id)}
                   >
-                    <CustomAgentDefaultPillIcon agent={agent} />
+                    <CustomAgentIcon agent={agent} />
                     {agent.label}
                     {isActive && <Check className="size-3.5" />}
                   </DefaultAgentPill>
@@ -1155,6 +1130,8 @@ function CustomAgentEditor({
       .join('\n')
   })
   const [error, setError] = useState<string | null>(null)
+  // Why: associate each field label with its input for screen-reader users.
+  const editorInputBase = useId()
 
   const handleSave = (): void => {
     const trimmedLabel = label.trim()
@@ -1212,10 +1189,11 @@ function CustomAgentEditor({
     <div className="space-y-3 rounded-md border border-border/60 bg-background/30 p-3">
       <div className="grid gap-2 sm:grid-cols-2">
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-muted-foreground">
+          <label htmlFor={`${editorInputBase}-name`} className="text-xs text-muted-foreground">
             {translate('auto.components.settings.AgentsPane.customAgentName', 'Name')}
           </label>
           <Input
+            id={`${editorInputBase}-name`}
             value={label}
             onChange={(e) => {
               setLabel(e.target.value)
@@ -1232,10 +1210,11 @@ function CustomAgentEditor({
           />
         </div>
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-muted-foreground">
+          <label htmlFor={`${editorInputBase}-cmd`} className="text-xs text-muted-foreground">
             {translate('auto.components.settings.AgentsPane.customAgentCmd', 'Command')}
           </label>
           <Input
+            id={`${editorInputBase}-cmd`}
             value={cmd}
             onChange={(e) => {
               setCmd(e.target.value)
@@ -1253,10 +1232,11 @@ function CustomAgentEditor({
         </div>
       </div>
       <div className="flex flex-col gap-1">
-        <label className="text-xs text-muted-foreground">
+        <label htmlFor={`${editorInputBase}-args`} className="text-xs text-muted-foreground">
           {translate('auto.components.settings.AgentsPane.customAgentArgs', 'Arguments')}
         </label>
         <Input
+          id={`${editorInputBase}-args`}
           value={args}
           onChange={(e) => setArgs(e.target.value)}
           placeholder={translate(
@@ -1268,13 +1248,14 @@ function CustomAgentEditor({
         />
       </div>
       <div className="flex flex-col gap-1">
-        <label className="text-xs text-muted-foreground">
+        <label htmlFor={`${editorInputBase}-env`} className="text-xs text-muted-foreground">
           {translate(
             'auto.components.settings.AgentsPane.customAgentEnv',
             'Environment (one KEY=VALUE per line)'
           )}
         </label>
         <textarea
+          id={`${editorInputBase}-env`}
           value={envText}
           onChange={(e) => setEnvText(e.target.value)}
           placeholder={translate(
@@ -1288,11 +1269,12 @@ function CustomAgentEditor({
       </div>
       <div className="grid gap-2 sm:grid-cols-2">
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-muted-foreground">
+          <label htmlFor={`${editorInputBase}-icon`} className="text-xs text-muted-foreground">
             {translate('auto.components.settings.AgentsPane.customAgentIconUrl', 'Icon URL')}
           </label>
           <div className="flex gap-1.5">
             <Input
+              id={`${editorInputBase}-icon`}
               value={iconUrl}
               onChange={(e) => setIconUrl(e.target.value)}
               placeholder={translate(
@@ -1307,9 +1289,13 @@ function CustomAgentEditor({
               variant="outline"
               size="xs"
               onClick={async () => {
-                const result = await window.api.shell.pickAgentIconImage()
-                if (result?.dataUrl) {
-                  setIconUrl(result.dataUrl)
+                try {
+                  const result = await window.api.shell.pickAgentIconImage()
+                  if (result?.dataUrl) {
+                    setIconUrl(result.dataUrl)
+                  }
+                } catch (err) {
+                  toast.error(err instanceof Error ? err.message : String(err))
                 }
               }}
               className="h-7 shrink-0 gap-1 text-xs"
@@ -1320,13 +1306,14 @@ function CustomAgentEditor({
           </div>
         </div>
         <div className="flex flex-col gap-1">
-          <label className="text-xs text-muted-foreground">
+          <label htmlFor={`${editorInputBase}-favicon`} className="text-xs text-muted-foreground">
             {translate(
               'auto.components.settings.AgentsPane.customAgentFaviconDomain',
               'Favicon Domain'
             )}
           </label>
           <Input
+            id={`${editorInputBase}-favicon`}
             value={faviconDomain}
             onChange={(e) => setFaviconDomain(e.target.value)}
             placeholder={translate(
@@ -1433,29 +1420,7 @@ function CustomAgentsSection({
             return (
               <div key={agent.id} className="flex flex-wrap items-start gap-3 py-3">
                 <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/50 bg-background/50">
-                  {agent.iconUrl ? (
-                    <img
-                      src={agent.iconUrl}
-                      width={16}
-                      height={16}
-                      alt=""
-                      aria-hidden
-                      style={{ borderRadius: 2 }}
-                    />
-                  ) : agent.faviconDomain ? (
-                    <img
-                      src={`https://www.google.com/s2/favicons?domain=${agent.faviconDomain}&sz=64`}
-                      width={16}
-                      height={16}
-                      alt=""
-                      aria-hidden
-                      style={{ borderRadius: 2 }}
-                    />
-                  ) : (
-                    <span className="text-xs font-medium text-muted-foreground">
-                      {agent.label.charAt(0).toUpperCase()}
-                    </span>
-                  )}
+                  <CustomAgentIcon agent={agent} size={16} />
                 </div>
                 <div className="min-w-0 flex-1 sm:min-w-[12rem]">
                   <div className="flex items-center gap-2">

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -7,11 +7,15 @@ import {
   Check,
   ChevronDown,
   ExternalLink,
+  FolderOpen,
   Info,
+  Pencil,
+  Plus,
   RefreshCw,
-  Terminal
+  Terminal,
+  Trash2
 } from 'lucide-react'
-import type { GlobalSettings, TuiAgent } from '../../../../shared/types'
+import type { CustomAgent, GlobalSettings, TuiAgent } from '../../../../shared/types'
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
 import { useDetectedAgents, type AgentDetectionTarget } from '@/hooks/useDetectedAgents'
 import { useAppStore } from '@/store'
@@ -679,6 +683,38 @@ function DefaultAgentPill({ active, onClick, children }: DefaultAgentPillProps):
   )
 }
 
+function CustomAgentDefaultPillIcon({ agent }: { agent: CustomAgent }): React.JSX.Element {
+  if (agent.iconUrl) {
+    return (
+      <img
+        src={agent.iconUrl}
+        width={14}
+        height={14}
+        alt=""
+        aria-hidden
+        style={{ borderRadius: 2 }}
+      />
+    )
+  }
+  if (agent.faviconDomain) {
+    return (
+      <img
+        src={`https://www.google.com/s2/favicons?domain=${agent.faviconDomain}&sz=64`}
+        width={14}
+        height={14}
+        alt=""
+        aria-hidden
+        style={{ borderRadius: 2 }}
+      />
+    )
+  }
+  return (
+    <span className="flex size-3.5 shrink-0 items-center justify-center rounded-[3px] bg-muted text-[8px] font-bold text-muted-foreground">
+      {agent.label.charAt(0).toUpperCase()}
+    </span>
+  )
+}
+
 export function AgentsPane({
   settings,
   updateSettings,
@@ -724,6 +760,7 @@ export function AgentsPane({
   )
 
   const defaultAgent = settings.defaultTuiAgent
+  const defaultCustomAgentId = settings.defaultCustomAgentId ?? null
   const agentOwnership = getSettingOwnershipSummary('agentLaunchDefaults')
   const cmdOverrides = settings.agentCmdOverrides ?? {}
   const agentDefaultArgs = settings.agentDefaultArgs ?? {}
@@ -735,7 +772,13 @@ export function AgentsPane({
   const disabledAgents = normalizeDisabledTuiAgents(settings.disabledTuiAgents)
 
   const setDefault = (id: TuiAgent | 'blank' | null): void => {
-    updateSettings({ defaultTuiAgent: id })
+    // Why: setting a TuiAgent/blank default clears any custom default so the
+    // two never compete; custom default takes priority when set.
+    updateSettings({ defaultTuiAgent: id, defaultCustomAgentId: null })
+  }
+
+  const setDefaultCustomAgent = (id: string | null): void => {
+    updateSettings({ defaultCustomAgentId: id })
   }
 
   const setAgentEnabled = (id: TuiAgent, enabled: boolean): void => {
@@ -786,6 +829,21 @@ export function AgentsPane({
     )
   }
 
+  const customAgents = settings.customAgents ?? []
+
+  const saveCustomAgent = (agent: CustomAgent): void => {
+    const existing = customAgents.findIndex((a) => a.id === agent.id)
+    const next =
+      existing >= 0
+        ? customAgents.map((a) => (a.id === agent.id ? agent : a))
+        : [...customAgents, agent]
+    updateSettings({ customAgents: next })
+  }
+
+  const deleteCustomAgent = (id: string): void => {
+    updateSettings({ customAgents: customAgents.filter((a) => a.id !== id) })
+  }
+
   // Why: null means detection is in flight, not "all agents are installed".
   // Showing the full catalog here makes the default-agent picker flash invalid
   // options while switching between Windows and WSL detection contexts.
@@ -800,12 +858,14 @@ export function AgentsPane({
 
   // Why: 'blank' is an explicit no-agent preference, not an auto fallback,
   // so the Auto pill should only light up when the default is null OR when a
-  // selected agent id is no longer detected on PATH.
+  // selected agent id is no longer detected on PATH. A custom default overrides
+  // TuiAgent selection, so Auto must not light up while a custom default is set.
   const isAutoDefault =
-    defaultAgent === null ||
-    (defaultAgent !== 'blank' &&
-      (!detectedIds?.has(defaultAgent) || !isTuiAgentEnabled(defaultAgent, disabledAgents)))
-  const isBlankDefault = defaultAgent === 'blank'
+    defaultCustomAgentId === null &&
+    (defaultAgent === null ||
+      (defaultAgent !== 'blank' &&
+        (!detectedIds?.has(defaultAgent) || !isTuiAgentEnabled(defaultAgent, disabledAgents))))
+  const isBlankDefault = defaultCustomAgentId === null && defaultAgent === 'blank'
 
   return (
     <div className="space-y-8">
@@ -835,7 +895,9 @@ export function AgentsPane({
           </DefaultAgentPill>
 
           {enabledDetectedAgents.map((agent) => {
-            const isActive = defaultAgent === agent.id
+            // Why: a custom default overrides TuiAgent selection, so a TuiAgent
+            // pill is only active when no custom default is set.
+            const isActive = defaultCustomAgentId === null && defaultAgent === agent.id
             return (
               <DefaultAgentPill
                 key={agent.id}
@@ -848,6 +910,31 @@ export function AgentsPane({
               </DefaultAgentPill>
             )
           })}
+
+          {customAgents.length > 0 && (
+            <div className="flex w-full flex-wrap gap-2 pt-1">
+              <span className="w-full text-[10px] font-medium uppercase tracking-wide text-muted-foreground/60">
+                {translate(
+                  'auto.components.settings.AgentsPane.customAgentsDefaultGroup',
+                  'Custom agents'
+                )}
+              </span>
+              {customAgents.map((agent) => {
+                const isActive = defaultCustomAgentId === agent.id
+                return (
+                  <DefaultAgentPill
+                    key={agent.id}
+                    active={isActive}
+                    onClick={() => setDefaultCustomAgent(isActive ? null : agent.id)}
+                  >
+                    <CustomAgentDefaultPillIcon agent={agent} />
+                    {agent.label}
+                    {isActive && <Check className="size-3.5" />}
+                  </DefaultAgentPill>
+                )
+              })}
+            </div>
+          )}
         </div>
       </section>
 
@@ -872,6 +959,12 @@ export function AgentsPane({
       <AgentCacheTimerSection settings={settings} updateSettings={updateSettings} />
 
       <AgentPermissionsSetting mode={agentPermissionMode} onChange={saveAgentPermissionMode} />
+
+      <CustomAgentsSection
+        customAgents={customAgents}
+        onSave={saveCustomAgent}
+        onDelete={deleteCustomAgent}
+      />
 
       {detectedAgents.length > 0 && (
         <section className="space-y-3">
@@ -1027,6 +1120,402 @@ export function AgentsPane({
         </div>
       )}
     </div>
+  )
+}
+
+function createCustomAgentId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ??
+    `custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  )
+}
+
+type CustomAgentEditorProps = {
+  initial?: CustomAgent
+  onSave: (agent: CustomAgent) => void
+  onCancel: () => void
+}
+
+function CustomAgentEditor({
+  initial,
+  onSave,
+  onCancel
+}: CustomAgentEditorProps): React.JSX.Element {
+  const [label, setLabel] = useState(initial?.label ?? '')
+  const [cmd, setCmd] = useState(initial?.cmd ?? '')
+  const [args, setArgs] = useState(initial?.args ?? '')
+  const [iconUrl, setIconUrl] = useState(initial?.iconUrl ?? '')
+  const [faviconDomain, setFaviconDomain] = useState(initial?.faviconDomain ?? '')
+  const [envText, setEnvText] = useState(() => {
+    if (!initial?.env) {
+      return ''
+    }
+    return Object.entries(initial.env)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('\n')
+  })
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSave = (): void => {
+    const trimmedLabel = label.trim()
+    const trimmedCmd = cmd.trim()
+    if (!trimmedLabel) {
+      setError(
+        translate('auto.components.settings.AgentsPane.customAgentNameRequired', 'Name is required')
+      )
+      return
+    }
+    if (!trimmedCmd) {
+      setError(
+        translate(
+          'auto.components.settings.AgentsPane.customAgentCmdRequired',
+          'Command is required'
+        )
+      )
+      return
+    }
+
+    const env: Record<string, string> = {}
+    for (const line of envText.split('\n')) {
+      const trimmedLine = line.trim()
+      if (!trimmedLine) {
+        continue
+      }
+      const eqIndex = trimmedLine.indexOf('=')
+      if (eqIndex <= 0) {
+        setError(
+          translate(
+            'auto.components.settings.AgentsPane.customAgentEnvFormat',
+            'Environment must be KEY=VALUE per line'
+          )
+        )
+        return
+      }
+      env[trimmedLine.slice(0, eqIndex).trim()] = trimmedLine.slice(eqIndex + 1).trim()
+    }
+
+    const trimmedIconUrl = iconUrl.trim()
+    const trimmedFaviconDomain = faviconDomain.trim()
+
+    onSave({
+      id: initial?.id ?? createCustomAgentId(),
+      label: trimmedLabel,
+      cmd: trimmedCmd,
+      ...(args.trim() ? { args: args.trim() } : {}),
+      ...(Object.keys(env).length > 0 ? { env } : {}),
+      ...(trimmedIconUrl ? { iconUrl: trimmedIconUrl } : {}),
+      ...(trimmedFaviconDomain ? { faviconDomain: trimmedFaviconDomain } : {})
+    })
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border border-border/60 bg-background/30 p-3">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-muted-foreground">
+            {translate('auto.components.settings.AgentsPane.customAgentName', 'Name')}
+          </label>
+          <Input
+            value={label}
+            onChange={(e) => {
+              setLabel(e.target.value)
+              if (error) {
+                setError(null)
+              }
+            }}
+            placeholder={translate(
+              'auto.components.settings.AgentsPane.customAgentNamePlaceholder',
+              'My Agent'
+            )}
+            className="h-7 text-xs"
+            spellCheck={false}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-muted-foreground">
+            {translate('auto.components.settings.AgentsPane.customAgentCmd', 'Command')}
+          </label>
+          <Input
+            value={cmd}
+            onChange={(e) => {
+              setCmd(e.target.value)
+              if (error) {
+                setError(null)
+              }
+            }}
+            placeholder={translate(
+              'auto.components.settings.AgentsPane.customAgentCmdPlaceholder',
+              'my-agent'
+            )}
+            className="h-7 font-mono text-xs"
+            spellCheck={false}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">
+          {translate('auto.components.settings.AgentsPane.customAgentArgs', 'Arguments')}
+        </label>
+        <Input
+          value={args}
+          onChange={(e) => setArgs(e.target.value)}
+          placeholder={translate(
+            'auto.components.settings.AgentsPane.customAgentArgsPlaceholder',
+            '--flag value'
+          )}
+          className="h-7 font-mono text-xs"
+          spellCheck={false}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.AgentsPane.customAgentEnv',
+            'Environment (one KEY=VALUE per line)'
+          )}
+        </label>
+        <textarea
+          value={envText}
+          onChange={(e) => setEnvText(e.target.value)}
+          placeholder={translate(
+            'auto.components.settings.AgentsPane.customAgentEnvPlaceholder',
+            'API_KEY=xxx\nMODEL=gpt-4'
+          )}
+          rows={3}
+          spellCheck={false}
+          className="w-full resize-y rounded-md border border-input bg-transparent px-2 py-1 font-mono text-xs outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-muted-foreground">
+            {translate('auto.components.settings.AgentsPane.customAgentIconUrl', 'Icon URL')}
+          </label>
+          <div className="flex gap-1.5">
+            <Input
+              value={iconUrl}
+              onChange={(e) => setIconUrl(e.target.value)}
+              placeholder={translate(
+                'auto.components.settings.AgentsPane.customAgentIconUrlPlaceholder',
+                'https://example.com/icon.png'
+              )}
+              className="h-7 flex-1 text-xs"
+              spellCheck={false}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={async () => {
+                const result = await window.api.shell.pickAgentIconImage()
+                if (result?.dataUrl) {
+                  setIconUrl(result.dataUrl)
+                }
+              }}
+              className="h-7 shrink-0 gap-1 text-xs"
+            >
+              <FolderOpen className="size-3" />
+              {translate('auto.components.settings.AgentsPane.customAgentIconBrowse', 'Browse')}
+            </Button>
+          </div>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.AgentsPane.customAgentFaviconDomain',
+              'Favicon Domain'
+            )}
+          </label>
+          <Input
+            value={faviconDomain}
+            onChange={(e) => setFaviconDomain(e.target.value)}
+            placeholder={translate(
+              'auto.components.settings.AgentsPane.customAgentFaviconDomainPlaceholder',
+              'example.com'
+            )}
+            className="h-7 font-mono text-xs"
+            spellCheck={false}
+          />
+        </div>
+      </div>
+      {error && <p className="text-[11px] text-destructive">{error}</p>}
+      <div className="flex items-center justify-end gap-2">
+        <Button type="button" variant="ghost" size="xs" onClick={onCancel} className="h-7 text-xs">
+          {translate('auto.components.settings.AgentsPane.customAgentCancel', 'Cancel')}
+        </Button>
+        <Button
+          type="button"
+          variant="default"
+          size="xs"
+          onClick={handleSave}
+          className="h-7 text-xs"
+        >
+          {translate('auto.components.settings.AgentsPane.customAgentSave', 'Save')}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+type CustomAgentsSectionProps = {
+  customAgents: CustomAgent[]
+  onSave: (agent: CustomAgent) => void
+  onDelete: (id: string) => void
+}
+
+function CustomAgentsSection({
+  customAgents,
+  onSave,
+  onDelete
+}: CustomAgentsSectionProps): React.JSX.Element {
+  const [isAdding, setIsAdding] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+
+  return (
+    <section className="space-y-3">
+      <SettingsSubsectionHeader
+        title={translate('auto.components.settings.AgentsPane.customAgentsTitle', 'Custom Agents')}
+        description={translate(
+          'auto.components.settings.AgentsPane.customAgentsDescription',
+          'Add your own CLI agents that are not in the built-in catalog.'
+        )}
+        action={
+          !isAdding ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => {
+                setIsAdding(true)
+                setEditingId(null)
+              }}
+              className="h-7 gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <Plus className="size-3" />
+              {translate('auto.components.settings.AgentsPane.customAgentAdd', 'Add')}
+            </Button>
+          ) : null
+        }
+      />
+
+      {isAdding && (
+        <CustomAgentEditor
+          onSave={(agent) => {
+            onSave(agent)
+            setIsAdding(false)
+          }}
+          onCancel={() => setIsAdding(false)}
+        />
+      )}
+
+      {customAgents.length > 0 && (
+        <div className="divide-y divide-border/40">
+          {customAgents.map((agent) => {
+            const isEditing = editingId === agent.id
+            if (isEditing) {
+              return (
+                <CustomAgentEditor
+                  key={agent.id}
+                  initial={agent}
+                  onSave={(updated) => {
+                    onSave(updated)
+                    setEditingId(null)
+                  }}
+                  onCancel={() => setEditingId(null)}
+                />
+              )
+            }
+            const envSummary = agent.env
+              ? Object.entries(agent.env)
+                  .map(([k, v]) => `${k}=${v}`)
+                  .join(' ')
+              : ''
+            return (
+              <div key={agent.id} className="flex flex-wrap items-start gap-3 py-3">
+                <div className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border/50 bg-background/50">
+                  {agent.iconUrl ? (
+                    <img
+                      src={agent.iconUrl}
+                      width={16}
+                      height={16}
+                      alt=""
+                      aria-hidden
+                      style={{ borderRadius: 2 }}
+                    />
+                  ) : agent.faviconDomain ? (
+                    <img
+                      src={`https://www.google.com/s2/favicons?domain=${agent.faviconDomain}&sz=64`}
+                      width={16}
+                      height={16}
+                      alt=""
+                      aria-hidden
+                      style={{ borderRadius: 2 }}
+                    />
+                  ) : (
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {agent.label.charAt(0).toUpperCase()}
+                    </span>
+                  )}
+                </div>
+                <div className="min-w-0 flex-1 sm:min-w-[12rem]">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium leading-none">{agent.label}</span>
+                    <SettingsBadge tone="muted">
+                      {translate('auto.components.settings.AgentsPane.customAgentBadge', 'Custom')}
+                    </SettingsBadge>
+                  </div>
+                  <div className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
+                    {agent.cmd}
+                    {agent.args && <span className="ml-1.5 text-foreground/70">{agent.args}</span>}
+                    {envSummary && <span className="ml-1.5 text-foreground/60">{envSummary}</span>}
+                  </div>
+                </div>
+                <div className="ml-auto flex shrink-0 items-center gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => {
+                      setEditingId(agent.id)
+                      setIsAdding(false)
+                    }}
+                    aria-label={translate(
+                      'auto.components.settings.AgentsPane.customAgentEdit',
+                      'Edit custom agent'
+                    )}
+                    className="size-7 text-muted-foreground hover:text-foreground"
+                  >
+                    <Pencil className="size-3.5" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => onDelete(agent.id)}
+                    aria-label={translate(
+                      'auto.components.settings.AgentsPane.customAgentDelete',
+                      'Delete custom agent'
+                    )}
+                    className="size-7 text-muted-foreground hover:text-destructive"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {customAgents.length === 0 && !isAdding && (
+        <div className="flex items-center justify-center rounded-md border border-dashed border-border/50 py-6 text-sm text-muted-foreground">
+          {translate(
+            'auto.components.settings.AgentsPane.customAgentsEmpty',
+            'No custom agents. Click "Add" to create one.'
+          )}
+        </div>
+      )}
+    </section>
   )
 }
 

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -7,8 +7,8 @@ import { useAppStore } from '@/store'
 import { useAgentDetectionTargetForWorktree } from '@/hooks/useAgentDetectionTarget'
 import { useDetectedAgents } from '@/hooks/useDetectedAgents'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
-import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
-import type { TuiAgent } from '../../../../shared/types'
+import { launchAgentInNewTab, launchCustomAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
+import type { TuiAgent, CustomAgent } from '../../../../shared/types'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 import { filterEnabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import { translate } from '@/i18n/i18n'
@@ -108,6 +108,7 @@ function QuickLaunchAgentMenuItemsInner({
   const { detectedIds } = useDetectedAgents(agentDetectionTarget)
   const defaultAgent = useAppStore((s) => s.settings?.defaultTuiAgent)
   const disabledAgents = useAppStore((s) => s.settings?.disabledTuiAgents ?? [])
+  const customAgents = useAppStore((s) => s.settings?.customAgents ?? [])
   const openSettingsPage = useAppStore((s) => s.openSettingsPage)
   const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
   const newAgentShortcut = useOptionalShortcutLabel('tab.newAgent')
@@ -171,6 +172,31 @@ function QuickLaunchAgentMenuItemsInner({
     [worktreeId, groupId, onFocusTerminal, prompt, promptDelivery, launchSource, onPromptDelivered]
   )
 
+  const runCustomLaunch = useCallback(
+    (agent: CustomAgent) => {
+      const result = launchCustomAgentInNewTab({
+        agent,
+        worktreeId,
+        groupId,
+        ...(prompt !== undefined ? { prompt } : {}),
+        ...(launchSource !== undefined ? { launchSource } : {}),
+        ...(onPromptDelivered !== undefined ? { onPromptDelivered } : {})
+      })
+      if (!result) {
+        toast.error(
+          translate(
+            'auto.components.tab.bar.QuickLaunchButton.465e432ef1',
+            'Could not build launch command for {{value0}}.',
+            { value0: agent.label }
+          )
+        )
+        return
+      }
+      onFocusTerminal(result.tabId)
+    },
+    [worktreeId, groupId, onFocusTerminal, prompt, launchSource, onPromptDelivered]
+  )
+
   const enabledDetectedIds = detectedIds ? filterEnabledTuiAgents(detectedIds, disabledAgents) : []
   const agents = detectedIds ? orderAgents(defaultAgent, enabledDetectedIds) : []
 
@@ -213,6 +239,31 @@ function QuickLaunchAgentMenuItemsInner({
           </DropdownMenuItem>
         )
       })}
+      {customAgents.length > 0 ? (
+        <>
+          <DropdownMenuItem
+            disabled
+            className="gap-2 px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/60"
+          >
+            {translate('auto.components.tab.bar.QuickLaunchButton.customAgents', 'Custom agents')}
+          </DropdownMenuItem>
+          {customAgents.map((agent) => (
+            <DropdownMenuItem
+              key={agent.id}
+              onSelect={() => runCustomLaunch(agent)}
+              className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
+              title={translate(
+                'auto.components.tab.bar.QuickLaunchButton.ec2adf093e',
+                'Launch {{value0}} in a new terminal',
+                { value0: agent.label }
+              )}
+            >
+              <CustomAgentListItemIcon agent={agent} />
+              <span className="flex-1">{agent.label}</span>
+            </DropdownMenuItem>
+          ))}
+        </>
+      ) : null}
       <DropdownMenuItem
         onSelect={openAgentSettings}
         className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium text-muted-foreground"
@@ -221,6 +272,38 @@ function QuickLaunchAgentMenuItemsInner({
         {translate('auto.components.tab.bar.QuickLaunchButton.348a04c1ad', 'Agent settings…')}
       </DropdownMenuItem>
     </>
+  )
+}
+
+function CustomAgentListItemIcon({ agent }: { agent: CustomAgent }): React.JSX.Element {
+  if (agent.iconUrl) {
+    return (
+      <img
+        src={agent.iconUrl}
+        width={14}
+        height={14}
+        alt=""
+        aria-hidden
+        style={{ borderRadius: 2 }}
+      />
+    )
+  }
+  if (agent.faviconDomain) {
+    return (
+      <img
+        src={`https://www.google.com/s2/favicons?domain=${agent.faviconDomain}&sz=64`}
+        width={14}
+        height={14}
+        alt=""
+        aria-hidden
+        style={{ borderRadius: 2 }}
+      />
+    )
+  }
+  return (
+    <span className="flex size-3.5 shrink-0 items-center justify-center rounded-[3px] bg-muted text-[8px] font-bold text-muted-foreground">
+      {agent.label.charAt(0).toUpperCase()}
+    </span>
   )
 }
 

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -180,6 +180,7 @@ function QuickLaunchAgentMenuItemsInner({
         worktreeId,
         groupId,
         ...(prompt !== undefined ? { prompt } : {}),
+        ...(promptDelivery !== undefined ? { promptDelivery } : {}),
         ...(launchSource !== undefined ? { launchSource } : {}),
         ...(onPromptDelivered !== undefined ? { onPromptDelivered } : {})
       })
@@ -195,7 +196,7 @@ function QuickLaunchAgentMenuItemsInner({
       }
       onFocusTerminal(result.tabId)
     },
-    [worktreeId, groupId, onFocusTerminal, prompt, launchSource, onPromptDelivered]
+    [worktreeId, groupId, onFocusTerminal, prompt, promptDelivery, launchSource, onPromptDelivered]
   )
 
   const enabledDetectedIds = detectedIds ? filterEnabledTuiAgents(detectedIds, disabledAgents) : []

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -12,6 +12,7 @@ import type { TuiAgent, CustomAgent } from '../../../../shared/types'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
 import { filterEnabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import { translate } from '@/i18n/i18n'
+import { CustomAgentIcon } from '../agent/CustomAgentIcon'
 
 export type QuickLaunchAgentMenuItemsProps = {
   worktreeId: string
@@ -258,7 +259,7 @@ function QuickLaunchAgentMenuItemsInner({
                 { value0: agent.label }
               )}
             >
-              <CustomAgentListItemIcon agent={agent} />
+              <CustomAgentIcon agent={agent} size={14} />
               <span className="flex-1">{agent.label}</span>
             </DropdownMenuItem>
           ))}
@@ -272,38 +273,6 @@ function QuickLaunchAgentMenuItemsInner({
         {translate('auto.components.tab.bar.QuickLaunchButton.348a04c1ad', 'Agent settings…')}
       </DropdownMenuItem>
     </>
-  )
-}
-
-function CustomAgentListItemIcon({ agent }: { agent: CustomAgent }): React.JSX.Element {
-  if (agent.iconUrl) {
-    return (
-      <img
-        src={agent.iconUrl}
-        width={14}
-        height={14}
-        alt=""
-        aria-hidden
-        style={{ borderRadius: 2 }}
-      />
-    )
-  }
-  if (agent.faviconDomain) {
-    return (
-      <img
-        src={`https://www.google.com/s2/favicons?domain=${agent.faviconDomain}&sz=64`}
-        width={14}
-        height={14}
-        alt=""
-        aria-hidden
-        style={{ borderRadius: 2 }}
-      />
-    )
-  }
-  return (
-    <span className="flex size-3.5 shrink-0 items-center justify-center rounded-[3px] bg-muted text-[8px] font-bold text-muted-foreground">
-      {agent.label.charAt(0).toUpperCase()}
-    </span>
   )
 }
 

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { X, Minimize2, Pin } from 'lucide-react'
 import { stripLeadingAgentTitleDecoration } from '../../../../shared/agent-title-decoration'
@@ -6,9 +6,9 @@ import { useTabAgent } from '@/lib/use-tab-agent'
 import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useAppStore } from '@/store'
 import type { TerminalTab } from '../../../../shared/types'
 import type { TabDragItemData } from '../tab-group/useTabDragSplit'
-import { useAppStore } from '../../store'
 import {
   ACTIVE_TAB_INDICATOR_CLASSES,
   getDropIndicatorClasses,
@@ -23,6 +23,7 @@ import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-widt
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
 import { TerminalTabLeadingIcon } from './TerminalTabLeadingIcon'
+import { useTabRename } from './use-tab-rename'
 import {
   hasUnreadAgentCompletionForTerminalTab,
   isTerminalTabActivityLive,
@@ -113,6 +114,14 @@ export default function SortableTab({
   // Why: use hook status + title evidence so the icon reflects the harness running now, not just the launch command.
   const tabAgent = useTabAgent(tab)
 
+  // Look up custom agent info for icon rendering when launchAgent is absent.
+  const customAgent = useAppStore((s) => {
+    if (!tab.customLaunchAgentId) {
+      return null
+    }
+    return s.settings?.customAgents?.find((a) => a.id === tab.customLaunchAgentId) ?? null
+  })
+
   // Why: with a provider icon shown, strip the agent's own leading glyph so the tab doesn't show two icons for one agent.
   const displayTitle =
     tab.customTitle ?? (tabAgent ? stripLeadingAgentTitleDecoration(tab.title) : tab.title)
@@ -126,61 +135,18 @@ export default function SortableTab({
   // Why: no transform/transition/opacity so tabs stay anchored during drag, only the insertion bar moves (see TabBar.tsx).
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
-  const [isEditing, setIsEditing] = useState(false)
+  const {
+    isEditing,
+    renameValue,
+    setRenameValue,
+    handleRenameOpen,
+    commitRename,
+    cancelRename,
+    setRenameInputElement
+  } = useTabRename({ tab, renamingTabId, setRenamingTabId, onSetCustomTitle })
   // Why: a live working/needs-input state is newer than a prior-turn unread, so it owns the icon until the turn ends.
   const showUnreadActivity =
     hasUnreadActivity && !isEditing && !isTerminalTabActivityLive(activityStatus)
-  const [renameValue, setRenameValue] = useState('')
-  const renameFocusFrameRef = useRef<number | null>(null)
-  // Why: onBlur fires during Input unmount; mark rename resolved so it can't re-commit and overwrite discarded edits.
-  const committedOrCancelledRef = useRef(false)
-
-  const handleRenameOpen = useCallback(() => {
-    committedOrCancelledRef.current = false
-    // Why: snapshot title once; don't refresh if tab.title changes mid-edit (e.g. OSC) so the user's edits aren't overwritten.
-    setRenameValue(tab.customTitle ?? tab.title)
-    setIsEditing(true)
-  }, [tab.customTitle, tab.title])
-
-  const commitRename = useCallback(() => {
-    if (committedOrCancelledRef.current) {
-      return
-    }
-    committedOrCancelledRef.current = true
-    const trimmed = renameValue.trim()
-    onSetCustomTitle(tab.id, trimmed.length > 0 ? trimmed : null)
-    setIsEditing(false)
-  }, [renameValue, onSetCustomTitle, tab.id])
-
-  const cancelRename = useCallback(() => {
-    committedOrCancelledRef.current = true
-    setIsEditing(false)
-  }, [])
-
-  const setRenameInputElement = useCallback((input: HTMLInputElement | null) => {
-    if (renameFocusFrameRef.current !== null) {
-      cancelAnimationFrame(renameFocusFrameRef.current)
-      renameFocusFrameRef.current = null
-    }
-    if (!input) {
-      return
-    }
-    // Why: defer past Radix menu teardown/focus restore; key off input mount so title updates don't re-select edited text.
-    renameFocusFrameRef.current = requestAnimationFrame(() => {
-      renameFocusFrameRef.current = null
-      input.focus()
-      input.select()
-    })
-  }, [])
-
-  // Why: the tab.rename shortcut routes through store renamingTabId; open the editor and clear it so it fires once.
-  useEffect(() => {
-    if (renamingTabId !== tab.id) {
-      return
-    }
-    handleRenameOpen()
-    setRenamingTabId(null)
-  }, [renamingTabId, tab.id, handleRenameOpen, setRenamingTabId])
 
   useEffect(() => {
     const closeMenu = (): void => setMenuOpen(false)
@@ -270,6 +236,7 @@ export default function SortableTab({
         shell={shellForIcon}
         showUnreadActivity={showUnreadActivity}
         isActive={isActive}
+        customAgent={customAgent}
       />
       {isPinned && !isEditing && (
         <Pin className="mr-1 size-3 shrink-0 text-muted-foreground" aria-hidden />

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -123,8 +123,12 @@ export default function SortableTab({
   })
 
   // Why: with a provider icon shown, strip the agent's own leading glyph so the tab doesn't show two icons for one agent.
+  // Why: a pure custom-agent tab has no tabAgent, but its generated title may
+  // still carry a leading agent glyph — strip it whenever any agent (built-in
+  // or custom) is bound so the tab doesn't render a duplicate glyph.
   const displayTitle =
-    tab.customTitle ?? (tabAgent ? stripLeadingAgentTitleDecoration(tab.title) : tab.title)
+    tab.customTitle ??
+    (tabAgent || customAgent ? stripLeadingAgentTitleDecoration(tab.title) : tab.title)
 
   const { attributes, listeners, setNodeRef } = useSortable({
     id: tab.id,

--- a/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabLeadingIcon.tsx
@@ -1,7 +1,8 @@
 import { AgentStateDot, type AgentDotState } from '@/components/AgentStateDot'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { cn } from '@/lib/utils'
-import type { TerminalTab, TuiAgent } from '../../../../shared/types'
+import type { CustomAgent, TerminalTab, TuiAgent } from '../../../../shared/types'
+import { CustomAgentIcon } from '../agent/CustomAgentIcon'
 import { FilledBellIcon } from '../sidebar/WorktreeCardHelpers'
 import { ShellIcon } from './shell-icons'
 import type { TerminalTabActivityStatus } from './terminal-tab-activity-status'
@@ -13,10 +14,12 @@ type TerminalTabLeadingIconProps = {
   shell: TerminalTab['shellOverride']
   showUnreadActivity: boolean
   isActive: boolean
+  customAgent?: CustomAgent | null
 }
 
 type TerminalTabAgentIdentityIconProps = {
-  agent: TuiAgent
+  agent: TuiAgent | null
+  customAgent?: CustomAgent | null
   isActive: boolean
   className?: string
 }
@@ -42,12 +45,31 @@ function activityDotState(status: TerminalTabActivityStatus): AgentDotState | nu
   }
 }
 
-/** Keep the provider glyph treatment identical across every terminal-tab state. */
+/** Keep the provider glyph treatment identical across every terminal-tab state.
+ *  Why: a custom agent is the user's explicit launch choice and may wrap a
+ *  known TuiAgent (e.g. a `claude` wrapper), so its identity icon takes
+ *  precedence over any title/process-detected TuiAgent to avoid showing the
+ *  wrong glyph and to reflect icon updates made in settings. */
 function TerminalTabAgentIdentityIcon({
   agent,
+  customAgent,
   isActive,
   className
-}: TerminalTabAgentIdentityIconProps): React.JSX.Element {
+}: TerminalTabAgentIdentityIconProps): React.JSX.Element | null {
+  if (customAgent) {
+    return (
+      <span
+        className={cn('inline-flex', !isActive && 'opacity-70', className)}
+        data-agent-icon={customAgent.id}
+        aria-hidden
+      >
+        <CustomAgentIcon agent={customAgent} size={12} />
+      </span>
+    )
+  }
+  if (!agent) {
+    return null
+  }
   return (
     <span
       className={cn('inline-flex', !isActive && 'opacity-70', className)}
@@ -65,8 +87,19 @@ export function TerminalTabLeadingIcon({
   activityStatus,
   shell,
   showUnreadActivity,
-  isActive
+  isActive,
+  customAgent
 }: TerminalTabLeadingIconProps): React.JSX.Element {
+  const identityIcon =
+    customAgent || agent ? (
+      <TerminalTabAgentIdentityIcon
+        agent={agent}
+        customAgent={customAgent}
+        isActive={isActive}
+        className="mr-1 shrink-0"
+      />
+    ) : null
+
   if (showUnreadActivity) {
     return (
       <span
@@ -78,7 +111,7 @@ export function TerminalTabLeadingIcon({
         className="mr-1 inline-flex shrink-0 items-center gap-1"
       >
         <FilledBellIcon className="size-3 text-amber-500 drop-shadow-sm" />
-        {agent ? <TerminalTabAgentIdentityIcon agent={agent} isActive={isActive} /> : null}
+        {identityIcon}
       </span>
     )
   }
@@ -94,15 +127,13 @@ export function TerminalTabLeadingIcon({
         <AgentStateDot state={dotState} size="md" />
         {/* Why: status and identity answer different questions. Keep the agent
             logo beside the state glyph so parallel tabs remain scannable. */}
-        {agent ? <TerminalTabAgentIdentityIcon agent={agent} isActive={isActive} /> : null}
+        {identityIcon}
       </span>
     )
   }
 
-  if (agent) {
-    return (
-      <TerminalTabAgentIdentityIcon agent={agent} isActive={isActive} className="mr-1 shrink-0" />
-    )
+  if (identityIcon) {
+    return identityIcon
   }
 
   // Why: ShellIcon renders a colored brand-style tile for PowerShell, CMD,

--- a/src/renderer/src/components/tab-bar/use-tab-rename.ts
+++ b/src/renderer/src/components/tab-bar/use-tab-rename.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { TerminalTab } from '../../../../shared/types'
+
+type UseTabRenameArgs = {
+  tab: TerminalTab
+  renamingTabId: string | null
+  setRenamingTabId: (id: string | null) => void
+  onSetCustomTitle: (tabId: string, title: string | null) => void
+}
+
+type UseTabRenameResult = {
+  isEditing: boolean
+  renameValue: string
+  setRenameValue: (value: string) => void
+  handleRenameOpen: () => void
+  commitRename: () => void
+  cancelRename: () => void
+  setRenameInputElement: (input: HTMLInputElement | null) => void
+}
+
+export function useTabRename({
+  tab,
+  renamingTabId,
+  setRenamingTabId,
+  onSetCustomTitle
+}: UseTabRenameArgs): UseTabRenameResult {
+  const [isEditing, setIsEditing] = useState(false)
+  const [renameValue, setRenameValue] = useState('')
+  const renameFocusFrameRef = useRef<number | null>(null)
+  // Why: onBlur fires during Input unmount; mark rename resolved so it can't re-commit and overwrite discarded edits.
+  const committedOrCancelledRef = useRef(false)
+
+  const handleRenameOpen = useCallback(() => {
+    committedOrCancelledRef.current = false
+    // Why: snapshot title once; don't refresh if tab.title changes mid-edit (e.g. OSC) so the user's edits aren't overwritten.
+    setRenameValue(tab.customTitle ?? tab.title)
+    setIsEditing(true)
+  }, [tab.customTitle, tab.title])
+
+  const commitRename = useCallback(() => {
+    if (committedOrCancelledRef.current) {
+      return
+    }
+    committedOrCancelledRef.current = true
+    const trimmed = renameValue.trim()
+    onSetCustomTitle(tab.id, trimmed.length > 0 ? trimmed : null)
+    setIsEditing(false)
+  }, [renameValue, onSetCustomTitle, tab.id])
+
+  const cancelRename = useCallback(() => {
+    committedOrCancelledRef.current = true
+    setIsEditing(false)
+  }, [])
+
+  const setRenameInputElement = useCallback((input: HTMLInputElement | null) => {
+    if (renameFocusFrameRef.current !== null) {
+      cancelAnimationFrame(renameFocusFrameRef.current)
+      renameFocusFrameRef.current = null
+    }
+    if (!input) {
+      return
+    }
+    // Why: defer past Radix menu teardown/focus restore; key off input mount so title updates don't re-select edited text.
+    renameFocusFrameRef.current = requestAnimationFrame(() => {
+      renameFocusFrameRef.current = null
+      input.focus()
+      input.select()
+    })
+  }, [])
+
+  // Why: the tab.rename shortcut routes through store renamingTabId; open the editor and clear it so it fires once.
+  useEffect(() => {
+    if (renamingTabId !== tab.id) {
+      return
+    }
+    handleRenameOpen()
+    setRenamingTabId(null)
+  }, [renamingTabId, tab.id, handleRenameOpen, setRenamingTabId])
+
+  return {
+    isEditing,
+    renameValue,
+    setRenameValue,
+    handleRenameOpen,
+    commitRename,
+    cancelRename,
+    setRenameInputElement
+  }
+}

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
@@ -148,6 +148,8 @@ export function useTabGroupWorkspaceModel({
             startupCwd: terminalTab?.startupCwd,
             // Why: rebuilt from the unified-tab model, so copy store-only launchAgent or the provider icon is missing until the first hook.
             launchAgent: terminalTab?.launchAgent,
+            // Why: same reason as launchAgent — without this the tab bar falls back to the default shell icon for custom-agent tabs.
+            customLaunchAgentId: terminalTab?.customLaunchAgentId,
             pendingActivationSpawn: terminalTab?.pendingActivationSpawn
           }
         }),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2839,7 +2839,8 @@
             "ec2adf093e": "Launch {{value0}} in a new terminal",
             "465e432ef1": "Could not build launch command for {{value0}}.",
             "e518f544b1": "No agents detected",
-            "8dea9b5cdf": "No enabled agents"
+            "8dea9b5cdf": "No enabled agents",
+            "customAgents": "Custom agents"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "Switch Tab",
@@ -5143,6 +5144,31 @@
           "25a41a9aad": "Re-detect agents installed on the active server",
           "remoteDetectionFailed": "Couldn’t detect installed agents. Check the host connection and try again.",
           "retryDetection": "Retry",
+          "customAgentsTitle": "Custom Agents",
+          "customAgentsDescription": "Add your own CLI agents that are not in the built-in catalog.",
+          "customAgentAdd": "Add",
+          "customAgentName": "Name",
+          "customAgentNamePlaceholder": "My Agent",
+          "customAgentCmd": "Command",
+          "customAgentCmdPlaceholder": "my-agent",
+          "customAgentArgs": "Arguments",
+          "customAgentArgsPlaceholder": "--flag value",
+          "customAgentEnv": "Environment (one KEY=VALUE per line)",
+          "customAgentEnvPlaceholder": "API_KEY=xxx\nMODEL=gpt-4",
+          "customAgentNameRequired": "Name is required",
+          "customAgentCmdRequired": "Command is required",
+          "customAgentEnvFormat": "Environment must be KEY=VALUE per line",
+          "customAgentCancel": "Cancel",
+          "customAgentSave": "Save",
+          "customAgentBadge": "Custom",
+          "customAgentIconUrl": "Icon URL",
+          "customAgentIconUrlPlaceholder": "https://example.com/icon.png",
+          "customAgentFaviconDomain": "Favicon Domain",
+          "customAgentFaviconDomainPlaceholder": "example.com",
+          "customAgentIconBrowse": "Browse",
+          "customAgentEdit": "Edit custom agent",
+          "customAgentDelete": "Delete custom agent",
+          "customAgentsEmpty": "No custom agents. Click \"Add\" to create one.",
           "02e0143be5": "Installed",
           "110b74b022": "No agent (blank terminal)",
           "92033495ff": "Auto",
@@ -5181,7 +5207,8 @@
           "3f1bdf3cb4": "Environment text is too large to parse safely.",
           "codexSessionSource": "Codex home to import from",
           "codexSessionSourceInfo": "About importing Codex history",
-          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex."
+          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex.",
+          "customAgentsDefaultGroup": "Custom agents"
         },
         "AppIconSelector": {
           "d5a112dc9b": "Next icon",
@@ -13169,7 +13196,8 @@
           "579c768bde": "No agents match your search.",
           "48c6a5a9b4": "Search agents...",
           "9c6b59fe58": "Set as default",
-          "1b0d6965fa": "Current default"
+          "1b0d6965fa": "Current default",
+          "customAgents": "Custom agents"
         },
         "AgentSettingsDialog": {
           "50cdb57c03": "Manage AI agents, set a default, and customize commands.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2816,7 +2816,8 @@
             "ec2adf093e": "Iniciar {{value0}} en un nuevo terminal",
             "465e432ef1": "No se pudo generar el comando de inicio para {{value0}}.",
             "e518f544b1": "No se detectaron agentes",
-            "8dea9b5cdf": "No hay agentes habilitados"
+            "8dea9b5cdf": "No hay agentes habilitados",
+            "customAgents": "Agents personalizados"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "Cambiar pestaña",
@@ -5158,7 +5159,33 @@
           "03e1a5081a": "on {{value0}}",
           "25a41a9aad": "Re-detect agents installed on the active server",
           "remoteDetectionFailed": "Couldn’t detect installed agents. Check the host connection and try again.",
-          "retryDetection": "Retry"
+          "retryDetection": "Retry",
+          "customAgentsTitle": "Agents Personalizados",
+          "customAgentsDescription": "Agrega tus propios agents CLI que no están en el catálogo integrado.",
+          "customAgentAdd": "Agregar",
+          "customAgentName": "Nombre",
+          "customAgentNamePlaceholder": "Mi Agent",
+          "customAgentCmd": "Comando",
+          "customAgentCmdPlaceholder": "my-agent",
+          "customAgentArgs": "Argumentos",
+          "customAgentArgsPlaceholder": "--flag value",
+          "customAgentEnv": "Entorno (un KEY=VALUE por línea)",
+          "customAgentEnvPlaceholder": "API_KEY=xxx\nMODEL=gpt-4",
+          "customAgentNameRequired": "El nombre es obligatorio",
+          "customAgentCmdRequired": "El comando es obligatorio",
+          "customAgentEnvFormat": "El entorno debe tener el formato KEY=VALUE por línea",
+          "customAgentCancel": "Cancelar",
+          "customAgentSave": "Guardar",
+          "customAgentBadge": "Personalizado",
+          "customAgentIconUrl": "URL del icono",
+          "customAgentIconUrlPlaceholder": "https://example.com/icon.png",
+          "customAgentFaviconDomain": "Dominio Favicon",
+          "customAgentFaviconDomainPlaceholder": "example.com",
+          "customAgentIconBrowse": "Examinar",
+          "customAgentEdit": "Editar agent personalizado",
+          "customAgentDelete": "Eliminar agent personalizado",
+          "customAgentsEmpty": "No hay agents personalizados. Haz clic en \"Agregar\" para crear uno.",
+          "customAgentsDefaultGroup": "Agents personalizados"
         },
         "AppIconSelector": {
           "d5a112dc9b": "Icono siguiente",
@@ -13146,7 +13173,8 @@
           "579c768bde": "Ningún agente coincide con su búsqueda.",
           "48c6a5a9b4": "Agentes de búsqueda...",
           "9c6b59fe58": "Establecer como predeterminado",
-          "1b0d6965fa": "Valor predeterminado actual"
+          "1b0d6965fa": "Valor predeterminado actual",
+          "customAgents": "Agents personalizados"
         },
         "AgentSettingsDialog": {
           "50cdb57c03": "Administre agents de IA, establezca un valor predeterminado y personalice comandos.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2812,12 +2812,12 @@
             "8e9d603a09": "Desanclar pestaña"
           },
           "QuickLaunchButton": {
-            "348a04c1ad": "Ajustes de Agents…",
+            "348a04c1ad": "Ajustes de agentes…",
             "ec2adf093e": "Iniciar {{value0}} en un nuevo terminal",
             "465e432ef1": "No se pudo generar el comando de inicio para {{value0}}.",
             "e518f544b1": "No se detectaron agentes",
             "8dea9b5cdf": "No hay agentes habilitados",
-            "customAgents": "Agents personalizados"
+            "customAgents": "Agentes personalizados"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "Cambiar pestaña",
@@ -3730,14 +3730,14 @@
           "tipReadOnly": "La skill aquí está en una ubicación de solo lectura, así que no se puede actualizar hasta que cambies sus permisos.",
           "tipInRepo": "La skill aquí vive dentro de un proyecto, no en tus skills globales; Orca solo actualiza las globales.",
           "tipPluginCache": "La skill aquí la gestiona un plugin; actualiza el plugin en su lugar.",
-          "skippedReasonUnrecognized": "The copy here doesn’t match the official version — it may be modified, or a different skill with the same name. Orca left it out of the update so it won’t overwrite it. Remove it if you want Orca to update this skill.",
+          "skippedReasonUnrecognized": "The copy here doesn't match the official version — it may be modified, or a different skill with the same name. Orca left it out of the update so it won't overwrite it. Remove it if you want Orca to update this skill.",
           "skippedReasonReadOnly": "This copy is in a read-only location, so Orca left it out of the update. Change its permissions to let Orca update it.",
-          "skippedReasonInaccessible": "Orca couldn’t read this copy, so it left the skill out of the update.",
+          "skippedReasonInaccessible": "Orca couldn't read this copy, so it left the skill out of the update.",
           "skippedReasonInRepo": "This is a project skill, not a global one — Orca only updates your global skills, so it left this out of the update.",
           "skippedReasonPluginCache": "A plugin manages this skill, so Orca left it out of the update — update the plugin instead.",
-          "skippedReasonExternalLink": "This copy is a shortcut pointing outside Orca’s skill folders, so Orca left it out of the update.",
+          "skippedReasonExternalLink": "This copy is a shortcut pointing outside Orca's skill folders, so Orca left it out of the update.",
           "skippedReasonBrokenLink": "This copy is a shortcut to something that no longer exists, so Orca left it out — you can safely delete it.",
-          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one."
+          "skippedReasonDuplicate": "This is a separate copy, so the update won't reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one."
         },
         "SkillFreshnessUpdateDialog": {
           "title": "Actualizar skills",
@@ -4874,7 +4874,7 @@
         "ForgetSshWorkspaceDialog": {
           "reconnectFailed": "Error de reconexión",
           "forgetBody": "Elimina este espacio de trabajo solo de Orca. Los archivos, el worktree de Git y las ramas en {{host}} permanecen intactos.",
-          "title": "¿Eliminar “{{name}}”?",
+          "title": "¿Eliminar \"{{name}}\"?",
           "disconnectedBody": "El host SSH de este espacio de trabajo no está conectado. Reconéctalo para eliminarlo también en el remoto, o elimínalo solo de Orca.",
           "ghostBody": "{{host}} ya no es un host SSH guardado, por lo que este espacio de trabajo ya no está conectado a un host activo. Solo se puede eliminar de Orca — los archivos y ramas en el remoto permanecen intactos.",
           "cancel": "Cancelar",
@@ -5157,14 +5157,14 @@
           "codexSessionSourceInfo": "Sobre la importación del historial de Codex",
           "codexSessionSourceTooltip": "Orca ejecuta Codex en un directorio aislado. Señala aquí a tu directorio Codex existente para importar el historial de sesiones. Dejar vacío usa ~/.codex.",
           "03e1a5081a": "on {{value0}}",
-          "25a41a9aad": "Re-detect agents installed on the active server",
-          "remoteDetectionFailed": "Couldn’t detect installed agents. Check the host connection and try again.",
-          "retryDetection": "Retry",
-          "customAgentsTitle": "Agents Personalizados",
-          "customAgentsDescription": "Agrega tus propios agents CLI que no están en el catálogo integrado.",
+          "25a41a9aad": "Re-detectar los agentes instalados en el servidor activo",
+          "remoteDetectionFailed": "No se pudieron detectar los agentes instalados. Comprueba la conexión del host e inténtalo de nuevo.",
+          "retryDetection": "Reintentar",
+          "customAgentsTitle": "Agentes personalizados",
+          "customAgentsDescription": "Agrega tus propios agentes CLI que no están en el catálogo integrado.",
           "customAgentAdd": "Agregar",
           "customAgentName": "Nombre",
-          "customAgentNamePlaceholder": "Mi Agent",
+          "customAgentNamePlaceholder": "Mi agente",
           "customAgentCmd": "Comando",
           "customAgentCmdPlaceholder": "my-agent",
           "customAgentArgs": "Argumentos",
@@ -5182,10 +5182,10 @@
           "customAgentFaviconDomain": "Dominio Favicon",
           "customAgentFaviconDomainPlaceholder": "example.com",
           "customAgentIconBrowse": "Examinar",
-          "customAgentEdit": "Editar agent personalizado",
-          "customAgentDelete": "Eliminar agent personalizado",
-          "customAgentsEmpty": "No hay agents personalizados. Haz clic en \"Agregar\" para crear uno.",
-          "customAgentsDefaultGroup": "Agents personalizados"
+          "customAgentEdit": "Editar agente personalizado",
+          "customAgentDelete": "Eliminar agente personalizado",
+          "customAgentsEmpty": "No hay agentes personalizados. Haz clic en \"Agregar\" para crear uno.",
+          "customAgentsDefaultGroup": "Agentes personalizados"
         },
         "AppIconSelector": {
           "d5a112dc9b": "Icono siguiente",
@@ -11755,12 +11755,12 @@
           },
           "FeatureTipsModal": {
             "c169298e4d": "Hecho",
-            "3c6c478462": "X termina, envíale la tarea de revisión”.",
+            "3c6c478462": "X termina, envíale la tarea de revisión.",
             "298301b7a0": "worktree",
-            "864e2db28f": "“Cuando el agente en",
-            "7fc6f02099": "y crear PR para cada uno”.",
+            "864e2db28f": "\"Cuando el agente en",
+            "7fc6f02099": "y crear PR para cada uno.\"",
             "27c567a89c": "worktrees",
-            "55846c7f95": "“Divide este PR en dos",
+            "55846c7f95": "\"Divide este PR en dos",
             "4795ac2d4a": "Prueba a pedir:",
             "53905bd076": "Vista previa de desarrollo: abriendo la terminal de configuración de skills.",
             "1da82af45b": "Orca CLI necesita atención",
@@ -13168,16 +13168,16 @@
       },
       "agent": {
         "AgentCombobox": {
-          "19522e25ee": "Administrar agents",
+          "19522e25ee": "Administrar agentes",
           "986f946354": "Terminal en blanco",
           "579c768bde": "Ningún agente coincide con su búsqueda.",
-          "48c6a5a9b4": "Agentes de búsqueda...",
+          "48c6a5a9b4": "Buscar agentes...",
           "9c6b59fe58": "Establecer como predeterminado",
           "1b0d6965fa": "Valor predeterminado actual",
-          "customAgents": "Agents personalizados"
+          "customAgents": "Agentes personalizados"
         },
         "AgentSettingsDialog": {
-          "50cdb57c03": "Administre agents de IA, establezca un valor predeterminado y personalice comandos.",
+          "50cdb57c03": "Administre agentes de IA, establezca un valor predeterminado y personalice comandos.",
           "fc0268e4ed": "Agentes"
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2816,7 +2816,8 @@
             "ec2adf093e": "新規 terminal で {{value0}} を起動",
             "465e432ef1": "{{value0}} の起動コマンドを構築できませんでした。",
             "e518f544b1": "agents が検出されませんでした",
-            "8dea9b5cdf": "有効な agents がありません"
+            "8dea9b5cdf": "有効な agents がありません",
+            "customAgents": "カスタム agents"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "タブの切り替え",
@@ -5143,7 +5144,33 @@
           "03e1a5081a": "on {{value0}}",
           "25a41a9aad": "Re-detect agents installed on the active server",
           "remoteDetectionFailed": "Couldn’t detect installed agents. Check the host connection and try again.",
-          "retryDetection": "Retry"
+          "retryDetection": "Retry",
+          "customAgentsTitle": "カスタム Agent",
+          "customAgentsDescription": "組み込みカタログにない独自の CLI agent を追加します。",
+          "customAgentAdd": "追加",
+          "customAgentName": "名前",
+          "customAgentNamePlaceholder": "マイ Agent",
+          "customAgentCmd": "コマンド",
+          "customAgentCmdPlaceholder": "my-agent",
+          "customAgentArgs": "引数",
+          "customAgentArgsPlaceholder": "--flag value",
+          "customAgentEnv": "環境変数（1行に1つずつ KEY=VALUE）",
+          "customAgentEnvPlaceholder": "API_KEY=xxx\nMODEL=gpt-4",
+          "customAgentNameRequired": "名前は必須です",
+          "customAgentCmdRequired": "コマンドは必須です",
+          "customAgentEnvFormat": "環境変数は1行につき1つの KEY=VALUE 形式にしてください",
+          "customAgentCancel": "キャンセル",
+          "customAgentSave": "保存",
+          "customAgentBadge": "カスタム",
+          "customAgentIconUrl": "アイコン URL",
+          "customAgentIconUrlPlaceholder": "https://example.com/icon.png",
+          "customAgentFaviconDomain": "Favicon ドメイン",
+          "customAgentFaviconDomainPlaceholder": "example.com",
+          "customAgentIconBrowse": "参照",
+          "customAgentEdit": "カスタム agent を編集",
+          "customAgentDelete": "カスタム agent を削除",
+          "customAgentsEmpty": "カスタム agent がありません。「追加」をクリックして作成してください。",
+          "customAgentsDefaultGroup": "カスタム agents"
         },
         "AppIconSelector": {
           "d5a112dc9b": "次へのアイコン",
@@ -13146,7 +13173,8 @@
           "579c768bde": "検索に一致する agents はありません。",
           "48c6a5a9b4": "agents を検索...",
           "9c6b59fe58": "デフォルトとして設定",
-          "1b0d6965fa": "現在のデフォルト"
+          "1b0d6965fa": "現在のデフォルト",
+          "customAgents": "カスタム agents"
         },
         "AgentSettingsDialog": {
           "50cdb57c03": "AI agents を管理し、デフォルトを設定し、コマンドをカスタマイズします。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2816,7 +2816,8 @@
             "ec2adf093e": "새 terminal에서 {{value0}} 실행",
             "465e432ef1": "{{value0}}에 대한 실행 명령을 작성할 수 없습니다.",
             "e518f544b1": "감지된 agents가 없습니다.",
-            "8dea9b5cdf": "활성화된 agents가 없습니다."
+            "8dea9b5cdf": "활성화된 agents가 없습니다.",
+            "customAgents": "사용자 정의 agents"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "탭 전환",
@@ -5143,7 +5144,33 @@
           "03e1a5081a": "on {{value0}}",
           "25a41a9aad": "Re-detect agents installed on the active server",
           "remoteDetectionFailed": "Couldn’t detect installed agents. Check the host connection and try again.",
-          "retryDetection": "Retry"
+          "retryDetection": "Retry",
+          "customAgentsTitle": "사용자 정의 Agent",
+          "customAgentsDescription": "내장 카탈로그에 없는 자체 CLI agent를 추가합니다.",
+          "customAgentAdd": "추가",
+          "customAgentName": "이름",
+          "customAgentNamePlaceholder": "나의 Agent",
+          "customAgentCmd": "명령",
+          "customAgentCmdPlaceholder": "my-agent",
+          "customAgentArgs": "인수",
+          "customAgentArgsPlaceholder": "--flag value",
+          "customAgentEnv": "환경 변수 (한 줄에 하나씩 KEY=VALUE)",
+          "customAgentEnvPlaceholder": "API_KEY=xxx\nMODEL=gpt-4",
+          "customAgentNameRequired": "이름은 필수 항목입니다",
+          "customAgentCmdRequired": "명령은 필수 항목입니다",
+          "customAgentEnvFormat": "환경 변수는 한 줄에 하나의 KEY=VALUE 형식이어야 합니다",
+          "customAgentCancel": "취소",
+          "customAgentSave": "저장",
+          "customAgentBadge": "사용자 정의",
+          "customAgentIconUrl": "아이콘 URL",
+          "customAgentIconUrlPlaceholder": "https://example.com/icon.png",
+          "customAgentFaviconDomain": "Favicon 도메인",
+          "customAgentFaviconDomainPlaceholder": "example.com",
+          "customAgentIconBrowse": "찾아보기",
+          "customAgentEdit": "사용자 정의 agent 편집",
+          "customAgentDelete": "사용자 정의 agent 삭제",
+          "customAgentsEmpty": "사용자 정의 agent가 없습니다. \"추가\"를 클릭하여 만드세요.",
+          "customAgentsDefaultGroup": "사용자 정의 agents"
         },
         "AppIconSelector": {
           "d5a112dc9b": "다음 아이콘",
@@ -13146,7 +13173,8 @@
           "579c768bde": "검색어와 일치하는 agents가 없습니다.",
           "48c6a5a9b4": "agents 검색...",
           "9c6b59fe58": "기본값으로 설정",
-          "1b0d6965fa": "현재 기본값"
+          "1b0d6965fa": "현재 기본값",
+          "customAgents": "사용자 정의 agents"
         },
         "AgentSettingsDialog": {
           "50cdb57c03": "AI agents를 관리하고, 기본값을 설정하고, 명령을 사용자 정의하세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2816,7 +2816,8 @@
             "ec2adf093e": "在新终端中启动 {{value0}}",
             "465e432ef1": "无法为 {{value0}} 构建启动命令。",
             "e518f544b1": "未检测到智能体",
-            "8dea9b5cdf": "没有启用智能体"
+            "8dea9b5cdf": "没有启用智能体",
+            "customAgents": "自定义智能体"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "切换选项卡",
@@ -5143,7 +5144,33 @@
           "03e1a5081a": "on {{value0}}",
           "25a41a9aad": "Re-detect agents installed on the active server",
           "remoteDetectionFailed": "Couldn’t detect installed agents. Check the host connection and try again.",
-          "retryDetection": "Retry"
+          "retryDetection": "Retry",
+          "customAgentsTitle": "自定义智能体",
+          "customAgentsDescription": "添加不在内置目录中的自定义 CLI 智能体。",
+          "customAgentAdd": "添加",
+          "customAgentName": "名称",
+          "customAgentNamePlaceholder": "我的智能体",
+          "customAgentCmd": "命令",
+          "customAgentCmdPlaceholder": "my-agent",
+          "customAgentArgs": "参数",
+          "customAgentArgsPlaceholder": "--flag value",
+          "customAgentEnv": "环境变量（每行一个 KEY=VALUE）",
+          "customAgentEnvPlaceholder": "API_KEY=xxx\nMODEL=gpt-4",
+          "customAgentNameRequired": "名称为必填项",
+          "customAgentCmdRequired": "命令为必填项",
+          "customAgentEnvFormat": "环境变量必须每行一个 KEY=VALUE 格式",
+          "customAgentCancel": "取消",
+          "customAgentSave": "保存",
+          "customAgentBadge": "自定义",
+          "customAgentIconUrl": "图标 URL",
+          "customAgentIconUrlPlaceholder": "https://example.com/icon.png",
+          "customAgentFaviconDomain": "Favicon 域名",
+          "customAgentFaviconDomainPlaceholder": "example.com",
+          "customAgentIconBrowse": "浏览",
+          "customAgentEdit": "编辑自定义智能体",
+          "customAgentDelete": "删除自定义智能体",
+          "customAgentsEmpty": "暂无自定义智能体。点击「添加」创建一个。",
+          "customAgentsDefaultGroup": "自定义智能体"
         },
         "AppIconSelector": {
           "d5a112dc9b": "下一个图标",
@@ -13146,7 +13173,8 @@
           "579c768bde": "没有智能体符合您的搜索。",
           "48c6a5a9b4": "搜索智能体...",
           "9c6b59fe58": "设置为默认值",
-          "1b0d6965fa": "当前默认值"
+          "1b0d6965fa": "当前默认值",
+          "customAgents": "自定义智能体"
         },
         "AgentSettingsDialog": {
           "50cdb57c03": "管理 AI 智能体、设置默认值并自定义命令。",

--- a/src/renderer/src/lib/agent-picker-search.ts
+++ b/src/renderer/src/lib/agent-picker-search.ts
@@ -1,4 +1,5 @@
 import type { AgentCatalogEntry } from '@/lib/agent-catalog'
+import type { CustomAgent } from '../../../shared/types'
 import { isClipboardTextByteLengthOverLimit } from '../../../shared/clipboard-text'
 
 type RankedAgent = {
@@ -22,12 +23,16 @@ export function getAgentPickerCommandValue({
   blankMatchesQuery,
   currentValue,
   filteredAgents,
+  filteredCustomAgents,
+  selectedCustomAgentId,
   rawQuery
 }: {
   blankValue: string
   blankMatchesQuery: boolean
   currentValue: AgentCatalogEntry['id'] | null
   filteredAgents: readonly AgentCatalogEntry[]
+  filteredCustomAgents?: readonly CustomAgent[]
+  selectedCustomAgentId?: string | null
   rawQuery: string
 }): string {
   const query = getAgentPickerSearchQuery(rawQuery)
@@ -35,12 +40,12 @@ export function getAgentPickerCommandValue({
     return ''
   }
   if (!query) {
-    return currentValue ?? blankValue
+    return selectedCustomAgentId ?? currentValue ?? blankValue
   }
   if (blankMatchesQuery) {
     return blankValue
   }
-  return filteredAgents[0]?.id ?? ''
+  return filteredAgents[0]?.id ?? filteredCustomAgents?.[0]?.id ?? ''
 }
 
 export function searchAgentPickerEntries(
@@ -58,6 +63,34 @@ export function searchAgentPickerEntries(
   const matches: RankedAgent[] = []
   agents.forEach((agent, index) => {
     const score = scoreAgent(agent, query)
+    if (score !== NO_MATCH) {
+      matches.push({ agent, score, index })
+    }
+  })
+
+  matches.sort((a, b) => a.score - b.score || a.index - b.index)
+  return matches.map((m) => m.agent)
+}
+
+export function searchCustomAgentPickerEntries(
+  agents: readonly CustomAgent[],
+  rawQuery: string
+): CustomAgent[] {
+  const query = getAgentPickerSearchQuery(rawQuery)
+  if (query === null) {
+    return []
+  }
+  if (!query) {
+    return [...agents]
+  }
+
+  const matches: { agent: CustomAgent; score: number; index: number }[] = []
+  agents.forEach((agent, index) => {
+    const score = Math.min(
+      scoreCandidate(query, agent.label, 0),
+      scoreCandidate(query, agent.id, 600),
+      scoreCandidate(query, agent.cmd, 650)
+    )
     if (score !== NO_MATCH) {
       matches.push({ agent, score, index })
     }

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -341,3 +341,9 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     ...(promptDeliveryResult ? { promptDeliveryResult } : {})
   }
 }
+
+export type LaunchCustomAgentResult = {
+  tabId: string
+} | null
+
+export { launchCustomAgentInNewTab } from './launch-custom-agent-in-new-tab'

--- a/src/renderer/src/lib/launch-custom-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-custom-agent-in-new-tab.ts
@@ -1,0 +1,67 @@
+import { useAppStore } from '@/store'
+import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
+import type { CustomAgent } from '../../../shared/types'
+import type { LaunchSource } from '../../../shared/telemetry-events'
+
+export type LaunchCustomAgentResult = {
+  tabId: string
+} | null
+
+/** Launch a user-defined custom agent (not in the built-in TuiAgent catalog). */
+export function launchCustomAgentInNewTab(args: {
+  agent: CustomAgent
+  worktreeId: string
+  groupId?: string
+  prompt?: string
+  launchSource?: LaunchSource
+  onPromptDelivered?: () => void
+}): LaunchCustomAgentResult {
+  const { agent, worktreeId, groupId, prompt, launchSource, onPromptDelivered } = args
+  const store = useAppStore.getState()
+
+  const command = [agent.cmd, agent.args].filter(Boolean).join(' ')
+  if (!command.trim()) {
+    return null
+  }
+
+  const tab = store.createTab(worktreeId, groupId, undefined, {
+    quickCommandLabel: agent.label,
+    customLaunchAgentId: agent.id
+  })
+
+  store.queueTabStartupCommand(tab.id, {
+    command,
+    ...(agent.env && Object.keys(agent.env).length > 0 ? { env: agent.env } : {}),
+    telemetry: {
+      agent_kind: 'other',
+      launch_source: launchSource ?? 'tab_bar_quick_launch',
+      request_kind: 'new'
+    }
+  })
+
+  if (prompt?.trim()) {
+    store.queueTabStartupCommand(tab.id, {
+      command: prompt,
+      delivery: 'terminal-paste'
+    })
+    onPromptDelivered?.()
+  }
+
+  store.setActiveTabType('terminal')
+
+  const fresh = useAppStore.getState()
+  const termIds = (fresh.tabsByWorktree[worktreeId] ?? []).map((t) => t.id)
+  const editorIds = fresh.openFiles.filter((f) => f.worktreeId === worktreeId).map((f) => f.id)
+  const browserIds = (fresh.browserTabsByWorktree?.[worktreeId] ?? []).map((t) => t.id)
+  const base = reconcileTabOrder(
+    fresh.tabBarOrderByWorktree[worktreeId],
+    termIds,
+    editorIds,
+    browserIds
+  )
+  const order = base.filter((id) => id !== tab.id)
+  order.push(tab.id)
+  fresh.setTabBarOrder(worktreeId, order)
+
+  return { tabId: tab.id }
+}

--- a/src/renderer/src/lib/launch-custom-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-custom-agent-in-new-tab.ts
@@ -1,5 +1,8 @@
+import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
+import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
+import { translate } from '@/i18n/i18n'
 import type { CustomAgent } from '../../../shared/types'
 import type { LaunchSource } from '../../../shared/telemetry-events'
 
@@ -13,10 +16,24 @@ export function launchCustomAgentInNewTab(args: {
   worktreeId: string
   groupId?: string
   prompt?: string
+  /** How to deliver an initial prompt. `auto-submit` (default) pastes+submits at
+   *  terminal startup; `draft` and `submit-after-ready` wait for the agent's
+   *  input-ready signal then bracketed-paste without/with Enter — mirroring the
+   *  built-in agent launch path so callers requesting those modes keep their
+   *  semantics instead of always degrading to a startup paste. */
+  promptDelivery?: 'auto-submit' | 'draft' | 'submit-after-ready'
   launchSource?: LaunchSource
   onPromptDelivered?: () => void
 }): LaunchCustomAgentResult {
-  const { agent, worktreeId, groupId, prompt, launchSource, onPromptDelivered } = args
+  const {
+    agent,
+    worktreeId,
+    groupId,
+    prompt,
+    promptDelivery = 'auto-submit',
+    launchSource,
+    onPromptDelivered
+  } = args
   const store = useAppStore.getState()
 
   const command = [agent.cmd, agent.args].filter(Boolean).join(' ')
@@ -39,12 +56,42 @@ export function launchCustomAgentInNewTab(args: {
     }
   })
 
-  if (prompt?.trim()) {
-    store.queueTabStartupCommand(tab.id, {
-      command: prompt,
-      delivery: 'terminal-paste'
-    })
-    onPromptDelivered?.()
+  const trimmedPrompt = prompt?.trim() ?? ''
+  if (trimmedPrompt) {
+    if (promptDelivery === 'draft' || promptDelivery === 'submit-after-ready') {
+      // Why: mirror the built-in agent launch path — wait for the agent's
+      // input-ready (bracketed-paste handshake) signal, then paste the prompt
+      // as an editable draft (draft) or paste+Enter (submit-after-ready). A
+      // custom CLI that never reaches the handshake times out and surfaces a
+      // toast instead of silently dropping the prompt.
+      const submit = promptDelivery === 'submit-after-ready'
+      void pasteDraftWhenAgentReady({
+        tabId: tab.id,
+        content: trimmedPrompt,
+        submit,
+        onTimeout: () => {
+          toast.message(
+            translate(
+              'auto.lib.launch.agent.in.new.tab.a5a1f7033f',
+              "Your {{value0}} wasn't sent — paste it once the agent is ready.",
+              { value0: submit ? 'prompt' : 'notes' }
+            )
+          )
+        }
+      })
+        .then((delivered) => {
+          if (delivered) {
+            onPromptDelivered?.()
+          }
+        })
+        .catch((error) => console.error('Custom agent prompt delivery failed', error))
+    } else {
+      store.queueTabStartupCommand(tab.id, {
+        command: trimmedPrompt,
+        delivery: 'terminal-paste'
+      })
+      onPromptDelivered?.()
+    }
   }
 
   store.setActiveTabType('terminal')

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -794,7 +794,8 @@ function buildTerminalUnifiedTab(
     createdAt: tab.createdAt,
     isPreview: false,
     isPinned: tab.isPinned === true,
-    ...(viewMode ? { viewMode } : {})
+    ...(viewMode ? { viewMode } : {}),
+    ...(tab.customLaunchAgentId ? { customLaunchAgentId: tab.customLaunchAgentId } : {})
   }
 }
 

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -127,6 +127,30 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
         sanitizedUpdates.agentDefaultEnv = normalizeTuiAgentEnvRecord(updates.agentDefaultEnv)
         sanitizedUpdates.agentYoloDefaultsMigrated = true
       }
+      if ('customAgents' in updates) {
+        const raw = Array.isArray(updates.customAgents) ? updates.customAgents : []
+        sanitizedUpdates.customAgents = raw
+          .filter(
+            (a): a is NonNullable<typeof a> =>
+              a != null &&
+              typeof a.id === 'string' &&
+              typeof a.label === 'string' &&
+              typeof a.cmd === 'string' &&
+              a.label.trim() !== '' &&
+              a.cmd.trim() !== ''
+          )
+          .map((a) => ({
+            id: a.id,
+            label: a.label.trim(),
+            cmd: a.cmd.trim(),
+            ...(a.args && a.args.trim() ? { args: a.args.trim() } : {}),
+            ...(a.env && Object.keys(a.env).length > 0 ? { env: a.env } : {}),
+            ...(a.iconUrl && a.iconUrl.trim() ? { iconUrl: a.iconUrl.trim() } : {}),
+            ...(a.faviconDomain && a.faviconDomain.trim()
+              ? { faviconDomain: a.faviconDomain.trim() }
+              : {})
+          }))
+      }
       if ('uiLanguage' in updates) {
         sanitizedUpdates.uiLanguage = normalizeUiLanguage(updates.uiLanguage)
       }

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
-import type { GlobalSettings } from '../../../../shared/types'
+import type { CustomAgent, GlobalSettings } from '../../../../shared/types'
 import { toast } from 'sonner'
 import {
   clearRuntimeCompatibilityCache,
@@ -129,27 +129,53 @@ export const createSettingsSlice: StateCreator<AppState, [], [], SettingsSlice> 
       }
       if ('customAgents' in updates) {
         const raw = Array.isArray(updates.customAgents) ? updates.customAgents : []
-        sanitizedUpdates.customAgents = raw
-          .filter(
-            (a): a is NonNullable<typeof a> =>
-              a != null &&
-              typeof a.id === 'string' &&
-              typeof a.label === 'string' &&
-              typeof a.cmd === 'string' &&
-              a.label.trim() !== '' &&
-              a.cmd.trim() !== ''
-          )
-          .map((a) => ({
-            id: a.id,
+        const validCustomAgents = raw.filter(
+          (a): a is NonNullable<typeof a> =>
+            a != null &&
+            typeof a.id === 'string' &&
+            a.id.trim() !== '' &&
+            typeof a.label === 'string' &&
+            typeof a.cmd === 'string' &&
+            a.label.trim() !== '' &&
+            a.cmd.trim() !== ''
+        )
+        // Why: last-write-wins dedup by trimmed id so a re-imported agent
+        // replaces the prior entry instead of producing duplicate ids, and
+        // type-guard every optional field so a non-string value (e.g. a number
+        // sneaking in via {args: 1}) can't throw inside .trim() and abort the
+        // whole settings update.
+        sanitizedUpdates.customAgents = validCustomAgents.reduce<CustomAgent[]>((acc, a) => {
+          const id = a.id.trim()
+          const envRaw = a.env
+          const env =
+            envRaw && typeof envRaw === 'object' && !Array.isArray(envRaw)
+              ? Object.fromEntries(
+                  Object.entries(envRaw).filter(
+                    (entry): entry is [string, string] => typeof entry[1] === 'string'
+                  )
+                )
+              : undefined
+          const entry: CustomAgent = {
+            id,
             label: a.label.trim(),
             cmd: a.cmd.trim(),
-            ...(a.args && a.args.trim() ? { args: a.args.trim() } : {}),
-            ...(a.env && Object.keys(a.env).length > 0 ? { env: a.env } : {}),
-            ...(a.iconUrl && a.iconUrl.trim() ? { iconUrl: a.iconUrl.trim() } : {}),
-            ...(a.faviconDomain && a.faviconDomain.trim()
+            ...(typeof a.args === 'string' && a.args.trim() ? { args: a.args.trim() } : {}),
+            ...(env && Object.keys(env).length > 0 ? { env } : {}),
+            ...(typeof a.iconUrl === 'string' && a.iconUrl.trim()
+              ? { iconUrl: a.iconUrl.trim() }
+              : {}),
+            ...(typeof a.faviconDomain === 'string' && a.faviconDomain.trim()
               ? { faviconDomain: a.faviconDomain.trim() }
               : {})
-          }))
+          }
+          const existingIndex = acc.findIndex((c) => c.id === id)
+          if (existingIndex >= 0) {
+            acc[existingIndex] = entry
+          } else {
+            acc.push(entry)
+          }
+          return acc
+        }, [])
       }
       if ('uiLanguage' in updates) {
         sanitizedUpdates.uiLanguage = normalizeUiLanguage(updates.uiLanguage)

--- a/src/renderer/src/store/slices/tabs-hydration.ts
+++ b/src/renderer/src/store/slices/tabs-hydration.ts
@@ -224,7 +224,8 @@ function hydrateLegacyFormat(
         sortOrder: tt.sortOrder,
         createdAt: tt.createdAt,
         isPreview: false,
-        isPinned: false
+        isPinned: false,
+        ...(tt.customLaunchAgentId ? { customLaunchAgentId: tt.customLaunchAgentId } : {})
       })
       tabOrder.push(tt.id)
     }

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -1831,7 +1831,8 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
               customLabel: tab.customTitle,
               color: tab.color,
               sortOrder: tab.sortOrder,
-              createdAt: tab.createdAt
+              createdAt: tab.createdAt,
+              ...(tab.customLaunchAgentId ? { customLaunchAgentId: tab.customLaunchAgentId } : {})
             }))
     const reconciledUnifiedTabs =
       restoredLegacyTabs.length > 0 ? [...unifiedTabs, ...restoredLegacyTabs] : unifiedTabs

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -567,6 +567,8 @@ export type TerminalSlice = {
       id?: string
       /** Coding-harness agent launched here, recorded so the tab bar shows the provider icon before the agent's first hook event. */
       launchAgent?: TuiAgent
+      /** ID of a user-defined custom agent that launched this tab. */
+      customLaunchAgentId?: string
       quickCommandLabel?: string | null
       /** Initial native-chat view mode; agent launches pass 'chat' when openAgentTabsInChatByDefault is on, else omitted for the 'terminal' default. */
       viewMode?: Tab['viewMode']
@@ -967,6 +969,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ...(createdShellOverride !== undefined ? { shellOverride: createdShellOverride } : {}),
         ...(startupCwd && startupCwd.length > 0 ? { startupCwd } : {}),
         ...(options?.launchAgent ? { launchAgent: options.launchAgent } : {}),
+        ...(options?.customLaunchAgentId
+          ? { customLaunchAgentId: options.customLaunchAgentId }
+          : {}),
         // Why: mark click-caused (not work-caused) spawns so updateTabPtyId skips the activity/sortEpoch bump that would reorder Recent/Smart on click.
         ...(options?.pendingActivationSpawn ? { pendingActivationSpawn: true } : {})
       }
@@ -1036,7 +1041,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         sortOrder: cleanedGroupOrder.length,
         createdAt: tab.createdAt,
         // Why: omit for non-agent tabs so they keep the implicit 'terminal' view mode.
-        ...(options?.viewMode ? { viewMode: options.viewMode } : {})
+        ...(options?.viewMode ? { viewMode: options.viewMode } : {}),
+        ...(tab.customLaunchAgentId ? { customLaunchAgentId: tab.customLaunchAgentId } : {})
       }
       const nextGroupOrder = dedupeTabOrder([...cleanedGroupOrder, unifiedTab.id])
       const nextRecent = shouldActivate

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2914,6 +2914,7 @@ function createShellApi(): NonNullable<Partial<PreloadApi>['shell']> {
     pickAttachment: () => Promise.resolve(null),
     pickImage: () => Promise.resolve(null),
     pickRepoIconImage: () => Promise.resolve(null),
+    pickAgentIconImage: () => Promise.resolve(null),
     pickAudio: () => Promise.resolve(null),
     pickDirectory: () => Promise.resolve(null),
     copyFile: () => Promise.resolve()

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -325,6 +325,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     agentDefaultArgs: { ...DEFAULT_TUI_AGENT_ARGS },
     agentDefaultEnv: { ...DEFAULT_TUI_AGENT_ENV },
     agentYoloDefaultsMigrated: true,
+    customAgents: [],
     agentStatusHooksEnabled: true,
     tabAutoGenerateTitle: false,
     confirmClosePinnedTab: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -832,6 +832,11 @@ export type Tab = {
    *  underneath; `'terminal'` (the default for legacy/missing) shows the raw
    *  xterm. Optional so sessions persisted before this field hydrate cleanly. */
   viewMode?: 'terminal' | 'chat'
+  /** Why: mirror of TerminalTab.customLaunchAgentId so the unified tab model
+   *  preserves the custom agent binding across reconcile/hydration/runtime
+   *  sync. Without this, rebuilds from the unified model drop the field and
+   *  the tab bar falls back to the default shell icon. */
+  customLaunchAgentId?: string
 }
 
 export type TabGroup = {
@@ -886,6 +891,8 @@ export type TerminalTab = {
    *  hook status overrides this once the agent does anything. Plain terminals
    *  and manually-started agents omit it. */
   launchAgent?: TuiAgent
+  /** ID of a user-defined custom agent that launched this tab (not in TuiAgent catalog). */
+  customLaunchAgentId?: string
   /** Why: when `setActiveWorktree` bumps generation on all-dead tabs to drive a
    *  TerminalPane remount, the fresh PTY that results is caused by navigation,
    *  not by the user doing work. Without this flag the resulting
@@ -2477,6 +2484,24 @@ export type ClaudeManagedAccountRuntimeSelection = {
   wsl: Record<string, string | null>
 }
 
+/** User-defined custom agent that is not part of the built-in TuiAgent catalog. */
+export type CustomAgent = {
+  /** Stable unique identifier (generated at creation time). */
+  id: string
+  /** Display name shown in the agent picker and settings. */
+  label: string
+  /** CLI binary name or absolute path used to launch the agent. */
+  cmd: string
+  /** Default arguments appended after the command. */
+  args?: string
+  /** Default environment variables for the agent process. */
+  env?: Record<string, string>
+  /** Direct image URL for the agent icon (data URL or remote URL). */
+  iconUrl?: string
+  /** Domain for Google's favicon service as an icon fallback. */
+  faviconDomain?: string
+}
+
 /** All AI coding agents Orca knows how to launch. Used for the agent picker in the new-workspace
  *  flow and for the default-agent setting. Extend this union as new agents are added. */
 export type TuiAgent =
@@ -2842,6 +2867,8 @@ export type GlobalSettings = {
    *  - 'blank': blank terminal (no agent launched)
    *  - TuiAgent: a specific agent id */
   defaultTuiAgent: TuiAgent | 'blank' | null
+  /** ID of a user-defined custom agent to use as default; takes priority over defaultTuiAgent when set. */
+  defaultCustomAgentId?: string | null
   /** Agents hidden from picker/auto-launch; detection stays a raw PATH snapshot. */
   disabledTuiAgents: TuiAgent[]
   /** One-shot guard: start Claude Agent Teams hidden for existing profiles without overriding later opt-ins. */
@@ -2894,6 +2921,8 @@ export type GlobalSettings = {
   agentDefaultEnv?: Partial<Record<TuiAgent, Record<string, string>>>
   /** One-shot guard for adding yolo-mode default args to untouched agent launch profiles. */
   agentYoloDefaultsMigrated?: boolean
+  /** User-defined custom agents that appear alongside built-in agents in the picker. */
+  customAgents?: CustomAgent[]
   /** Why: disabling must persist so startup doesn't reinstall global agent hook entries the user just removed. */
   agentStatusHooksEnabled: boolean
   /** Dismissed freshness tuples: no write authority, just suppress re-nudging the same official placement/revision. */

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -89,8 +89,10 @@ const terminalTabSchema = z.object({
     .catch(undefined),
   // Why: persist the custom agent id so a restored tab keeps its custom agent
   // icon. Without this, Zod strips the field on parse and the tab bar falls
-  // back to the default shell icon after session restore.
-  customLaunchAgentId: z.string().optional()
+  // back to the default shell icon after session restore. `.catch(undefined)`
+  // tolerates a null/garbage value from a corrupted session so the whole-session
+  // parse degrades to "no custom agent" instead of resetting every tab.
+  customLaunchAgentId: z.string().min(1).optional().catch(undefined)
 })
 
 // ─── Unified tab model ──────────────────────────────────────────────
@@ -129,8 +131,9 @@ const tabSchema = z.object({
   // undefined → 'terminal' in the renderer.
   viewMode: z.enum(['terminal', 'chat']).catch('terminal').optional(),
   // Why: mirror of TerminalTab.customLaunchAgentId so the unified tab model
-  // preserves the custom agent binding across session restore.
-  customLaunchAgentId: z.string().optional()
+  // preserves the custom agent binding across session restore. `.catch(...)`
+  // keeps a corrupted null/garbage id from failing the whole-session parse.
+  customLaunchAgentId: z.string().min(1).optional().catch(undefined)
 })
 
 const tabGroupSchema = z.object({

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -86,7 +86,11 @@ const terminalTabSchema = z.object({
   launchAgent: z
     .custom<TuiAgent>((v) => isTuiAgent(v))
     .optional()
-    .catch(undefined)
+    .catch(undefined),
+  // Why: persist the custom agent id so a restored tab keeps its custom agent
+  // icon. Without this, Zod strips the field on parse and the tab bar falls
+  // back to the default shell icon after session restore.
+  customLaunchAgentId: z.string().optional()
 })
 
 // ─── Unified tab model ──────────────────────────────────────────────
@@ -123,7 +127,10 @@ const tabSchema = z.object({
   // newer build that wrote an unrecognized mode) by degrading to the safe
   // default instead of failing the whole-session parse. Legacy/missing stays
   // undefined → 'terminal' in the renderer.
-  viewMode: z.enum(['terminal', 'chat']).catch('terminal').optional()
+  viewMode: z.enum(['terminal', 'chat']).catch('terminal').optional(),
+  // Why: mirror of TerminalTab.customLaunchAgentId so the unified tab model
+  // preserves the custom agent binding across session restore.
+  customLaunchAgentId: z.string().optional()
 })
 
 const tabGroupSchema = z.object({


### PR DESCRIPTION
…w CustomAgent type to  user- agents not in the built-in catalog.- Updated SortableTab and TerminalTabLeadingIcon components to handle custom agent  and titles.-    to include customLaunchAgentId for proper icon  and tab state persistence.- Implemented  to launch custom agents in new tabs, including command and environment variable handling.- Added localization strings for custom agent management in multiple languages.- Updated settings and state management to accommodate custom agents,  they are stored and  correctly.

## Summary

add support for custom agents.

## 

- Add screenshots or a screen recording for any new or changed UI .
- If there is no  change, say `No visual change`.
<img width="1259" height="810" alt="image" src="https://github.com/user-attachments/assets/c76808ea-24c9-4cc6-aef6-c10cc989d1d5" />
<img width="1277" height="591" alt="image" src="https://github.com/user-attachments/assets/9a5f2456-3154-4c79-9817-78934e46cd3a" />
<img width="734" height="1169" alt="image" src="https://github.com/user-attachments/assets/522b8568-5cb3-4487-9fd3-de254ef752be" />
<img width="384" height="190" alt="image" src="https://github.com/user-attachments/assets/17e48a18-f8e7-4fef-b863-f0a7f345d936" />



## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch , or explained why tests were not needed

## AI Review Report

 the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or  as a result.
Confirm that the review  checked cross-platform  for macOS, Linux, and Windows, including shortcuts, labels, paths, shell , and any -specific platform differences touched by this PR.

## Security Audit

Provide a basic security audit summary from your AI coding agent. Call out any input handling, command , path handling, auth, secrets, , or IPC risks that were reviewed, plus any follow-up needed.

## Notes

Call out any platform-specific behavior, risks, or follow-up work.

## ELI5

You can now launch your own custom agents (not just built-in ones) as terminal tabs, with proper , titles, and settings. That makes Orca work with agents you define yourself, not only the catalog list.
