### PR TITLE
fix(ssh): connect to Linux hosts that cannot compile node-pty

### DIFF
--- a/src/main/ssh/ssh-relay-build-toolchain.test.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.test.ts
@@ -3,6 +3,7 @@ import {
   buildToolchainProbeCommand,
   parseBuildToolchainProbe,
   formatMissingToolchainError,
+  formatSkippedNodePtyWarning,
   shouldProbeBuildToolchainAfterNativeDepsFailure
 } from './ssh-relay-build-toolchain'
 
@@ -107,5 +108,20 @@ describe('formatMissingToolchainError', () => {
     expect(msg).toContain('a C++ compiler (g++ or clang++)')
     expect(msg).not.toMatch(/\(make,/)
     expect(msg).toContain('sudo pacman -S --needed base-devel python')
+  })
+})
+
+describe('formatSkippedNodePtyWarning', () => {
+  it('quotes the tailored install command when a package manager was detected', () => {
+    const warning = formatSkippedNodePtyWarning(parseBuildToolchainProbe('PKG dnf'))
+    expect(warning).toContain('skipping node-pty')
+    expect(warning).toContain('sudo dnf install -y make gcc gcc-c++ python3')
+  })
+
+  it('stays distro-neutral when no package manager was detected', () => {
+    // The hint list is the cross-distro menu here; quoting its first line would name Debian on any host.
+    const warning = formatSkippedNodePtyWarning(parseBuildToolchainProbe(''))
+    expect(warning).not.toContain('apt-get')
+    expect(warning).toContain('install a C/C++ toolchain')
   })
 })

--- a/src/main/ssh/ssh-relay-build-toolchain.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.ts
@@ -130,7 +130,13 @@ export function toolchainInstallHintLines(status: BuildToolchainStatus): string[
 
 /** One-line summary for the deploy log when node-pty is skipped rather than compiled. */
 export function formatSkippedNodePtyWarning(status: BuildToolchainStatus): string {
-  const hint = toolchainInstallHintLines(status)[0]?.trim() ?? 'install a C/C++ toolchain'
+  // Why: with no package manager detected the hint list is the cross-distro menu, whose first line
+  // is Debian's — quoting it alone would name the wrong distro, so stay neutral instead.
+  const hintLines = toolchainInstallHintLines(status)
+  const hint =
+    hintLines.length === 1
+      ? hintLines[0].trim()
+      : 'install a C/C++ toolchain (make, a C++ compiler, python3)'
   return (
     `missing build tools (${missingToolNames(status).join(', ')}); skipping node-pty so the ` +
     `connection still serves files and git. Remote terminals need: ${hint}`

--- a/src/main/ssh/ssh-relay-build-toolchain.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.ts
@@ -97,10 +97,7 @@ export function shouldProbeBuildToolchainAfterNativeDepsFailure(message: string)
   )
 }
 
-export function formatMissingToolchainError(
-  status: BuildToolchainStatus,
-  underlyingError: string
-): string {
+function missingToolNames(status: BuildToolchainStatus): string[] {
   const present = new Set(status.present)
   const missing: string[] = []
   if (!present.has('make')) {
@@ -112,27 +109,48 @@ export function formatMissingToolchainError(
   if (!hasPython(present)) {
     missing.push('python3')
   }
+  return missing
+}
 
+/** Install hint for the host's package manager, or the cross-distro list when it is unknown. */
+export function toolchainInstallHintLines(status: BuildToolchainStatus): string[] {
   const tailored = status.packageManager
     ? PACKAGE_MANAGER_HINTS.find((hint) => hint.bin === status.packageManager)?.install
     : null
+  if (tailored) {
+    return [`  ${tailored}`]
+  }
+  return [
+    '  Debian/Ubuntu:  sudo apt-get install -y build-essential python3',
+    '  Fedora/RHEL:    sudo dnf install -y make gcc gcc-c++ python3',
+    '  Arch:           sudo pacman -S --needed base-devel python',
+    '  Alpine:         sudo apk add build-base python3'
+  ]
+}
 
+/** One-line summary for the deploy log when node-pty is skipped rather than compiled. */
+export function formatSkippedNodePtyWarning(status: BuildToolchainStatus): string {
+  const hint = toolchainInstallHintLines(status)[0]?.trim() ?? 'install a C/C++ toolchain'
+  return (
+    `missing build tools (${missingToolNames(status).join(', ')}); skipping node-pty so the ` +
+    `connection still serves files and git. Remote terminals need: ${hint}`
+  )
+}
+
+export function formatMissingToolchainError(
+  status: BuildToolchainStatus,
+  underlyingError: string
+): string {
   const lines = [
-    `The remote host is missing the C/C++ build tools (${missing.join(', ')}) needed to ` +
-      `compile Orca's relay native modules (node-pty, @parcel/watcher). node-pty has no ` +
+    `The remote host is missing the C/C++ build tools (${missingToolNames(status).join(', ')}) ` +
+      `needed to compile Orca's relay native modules (node-pty, @parcel/watcher). node-pty has no ` +
       `prebuilt binary for Linux, so they must be compiled on the remote host.`,
     '',
-    'Install the build tools on the remote host, then reconnect:'
+    'Install the build tools on the remote host, then reconnect:',
+    ...toolchainInstallHintLines(status),
+    '',
+    `Underlying install error: ${underlyingError}`
   ]
-  if (tailored) {
-    lines.push(`  ${tailored}`)
-  } else {
-    lines.push('  Debian/Ubuntu:  sudo apt-get install -y build-essential python3')
-    lines.push('  Fedora/RHEL:    sudo dnf install -y make gcc gcc-c++ python3')
-    lines.push('  Arch:           sudo pacman -S --needed base-devel python')
-    lines.push('  Alpine:         sudo apk add build-base python3')
-  }
-  lines.push('', `Underlying install error: ${underlyingError}`)
   return lines.join('\n')
 }
 

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -967,6 +967,8 @@ async function installNativeDepsWithoutNodePty(
   const resetCommand = resetNativeDepsCommand(hostPlatform, [
     ...new Set<RelayNativeDepName>([...resetDeps, 'node-pty'])
   ])
+  // Why: POSIX-only command shape (`;` chaining, `2>&1`) — safe because the only caller is gated on a
+  // linux platform. Widen that gate and this needs the Windows branch installNativeDeps already has.
   await execHostCommand(
     conn,
     hostPlatform,

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -40,6 +40,7 @@ import { createSshOperationAbortError, shellEscape } from './ssh-connection-util
 import {
   probeBuildToolchain,
   formatMissingToolchainError,
+  formatSkippedNodePtyWarning,
   shouldProbeBuildToolchainAfterNativeDepsFailure
 } from './ssh-relay-build-toolchain'
 import {
@@ -751,29 +752,32 @@ async function installNativeDeps(
   resetDeps: RelayNativeDepName[] = [],
   namespace?: RelayInstallNamespace
 ): Promise<void> {
+  const writeRelayPackageJson = async (deps: Record<string, string>): Promise<void> => {
+    await writeRelayFile(
+      conn,
+      hostPlatform,
+      joinRemotePath(hostPlatform, remoteDir, 'package.json'),
+      `${JSON.stringify({
+        name: 'orca-relay',
+        version: '1.0.0',
+        private: true,
+        type: 'commonjs',
+        dependencies: deps,
+        allowScripts: RELAY_NATIVE_DEP_SCRIPT_ALLOWLIST
+      })}\n`,
+      {
+        signal,
+        sftpNamespace: namespace
+          ? relaySftpNamespaceMapping(namespace, hostPlatform, remoteDir, 'package.json')
+          : undefined
+      }
+    )
+  }
+
   // Why: node-pty's prebuild spawns `node` as a child, so node must be in PATH (commandWithNodePath) or it fails exit 127.
   // Why: npm init -y rejects '+' in content-hashed dir names, so write a fixed minimal package.json instead.
   // Why: type:commonjs pins module resolution against Node default flips or a remote ~/.npmrc type=module.
-  const pkgJson = `${JSON.stringify({
-    name: 'orca-relay',
-    version: '1.0.0',
-    private: true,
-    type: 'commonjs',
-    dependencies: RELAY_NATIVE_DEPS,
-    allowScripts: RELAY_NATIVE_DEP_SCRIPT_ALLOWLIST
-  })}\n`
-  await writeRelayFile(
-    conn,
-    hostPlatform,
-    joinRemotePath(hostPlatform, remoteDir, 'package.json'),
-    pkgJson,
-    {
-      signal,
-      sftpNamespace: namespace
-        ? relaySftpNamespaceMapping(namespace, hostPlatform, remoteDir, 'package.json')
-        : undefined
-    }
-  )
+  await writeRelayPackageJson(RELAY_NATIVE_DEPS)
 
   try {
     const installArgs = Object.entries(RELAY_NATIVE_DEPS)
@@ -819,7 +823,30 @@ async function installNativeDeps(
     if (platform.startsWith('linux') && shouldProbeBuildToolchainAfterNativeDepsFailure(msg)) {
       const toolchain = await probeBuildToolchain(conn, hostPlatform, signal)
       if (toolchain?.toolchainMissing) {
-        throw new Error(formatMissingToolchainError(toolchain, msg))
+        // Why: node-pty is the only dep that needs a compiler, and it only backs terminals. Retry
+        // without it so files/git/editor still connect instead of failing the host outright; a
+        // missing native dep is already non-fatal below. Rethrow the actionable error if even that
+        // fails, so a host broken for some other reason still reports the toolchain gap.
+        console.warn(
+          `[ssh-relay][NPTY-SKIP-NO-TOOLCHAIN] ${remoteDir} (${platform}): ${formatSkippedNodePtyWarning(toolchain)}`
+        )
+        try {
+          await installNativeDepsWithoutNodePty(
+            conn,
+            remoteDir,
+            hostPlatform,
+            nodePath,
+            writeRelayPackageJson,
+            signal
+          )
+        } catch (retryErr) {
+          if (isUnconfirmedSshCommandTermination(retryErr)) {
+            throw retryErr
+          }
+          signal?.throwIfAborted()
+          throw new Error(formatMissingToolchainError(toolchain, msg))
+        }
+        return
       }
     }
     throw err
@@ -895,6 +922,43 @@ function resetNativeDepsCommand(
     )
   }
   return commands.join('; ')
+}
+
+/**
+ * Reinstall the relay's native deps with node-pty dropped, for hosts that cannot compile it.
+ *
+ * Why: npm reconciles every dependency in package.json, not just the ones named on the command
+ * line, so node-pty has to leave the manifest too — naming only @parcel/watcher still rebuilds it.
+ */
+async function installNativeDepsWithoutNodePty(
+  conn: SshConnection,
+  remoteDir: string,
+  hostPlatform: RemoteHostPlatform,
+  nodePath: string,
+  writeRelayPackageJson: (deps: Record<string, string>) => Promise<void>,
+  signal?: AbortSignal
+): Promise<void> {
+  const deps = Object.fromEntries(
+    Object.entries(RELAY_NATIVE_DEPS).filter(([dep]) => dep !== 'node-pty')
+  )
+  await writeRelayPackageJson(deps)
+  const installArgs = Object.entries(deps)
+    .map(([dep, version]) => shellEscape(`${dep}@${version}`))
+    .join(' ')
+  // Why: the failed attempt leaves an unbuildable node-pty behind; clear it so npm prunes rather
+  // than rebuilds it.
+  const resetCommand = resetNativeDepsCommand(hostPlatform, ['node-pty'])
+  await execHostCommand(
+    conn,
+    hostPlatform,
+    commandWithNodePath(
+      hostPlatform,
+      nodePath,
+      remoteDir,
+      `${resetCommand}; npm install --ignore-scripts=false --omit=dev --no-audit --no-fund ${installArgs} 2>&1`
+    ),
+    { timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS, signal }
+  )
 }
 
 async function rebuildNativeDeps(

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -837,6 +837,7 @@ async function installNativeDeps(
             hostPlatform,
             nodePath,
             writeRelayPackageJson,
+            resetDeps,
             signal
           )
         } catch (retryErr) {
@@ -844,8 +845,23 @@ async function installNativeDeps(
             throw retryErr
           }
           signal?.throwIfAborted()
-          throw new Error(formatMissingToolchainError(toolchain, msg))
+          // The thrown toolchain message is built from the original error, so log the retry's own
+          // cause (registry, ENOSPC, EACCES) rather than losing it.
+          console.warn(
+            `[ssh-relay][NPTY-SKIP-RETRY-FAIL] node-pty-less reinstall failed at ${remoteDir} (${platform}): ${(retryErr as Error).message}`
+          )
+          throw new Error(formatMissingToolchainError(toolchain, msg), { cause: retryErr })
         }
+        // Why: this early return skips the probe below, so verify the dep that does have a prebuilt —
+        // a @parcel/watcher that installs but can't load would leave file watching silently dead.
+        await warnIfWatcherUnloadableWithoutNodePty(
+          conn,
+          remoteDir,
+          platform,
+          hostPlatform,
+          nodePath,
+          signal
+        )
         return
       }
     }
@@ -936,6 +952,7 @@ async function installNativeDepsWithoutNodePty(
   hostPlatform: RemoteHostPlatform,
   nodePath: string,
   writeRelayPackageJson: (deps: Record<string, string>) => Promise<void>,
+  resetDeps: RelayNativeDepName[],
   signal?: AbortSignal
 ): Promise<void> {
   const deps = Object.fromEntries(
@@ -946,8 +963,10 @@ async function installNativeDepsWithoutNodePty(
     .map(([dep, version]) => shellEscape(`${dep}@${version}`))
     .join(' ')
   // Why: the failed attempt leaves an unbuildable node-pty behind; clear it so npm prunes rather
-  // than rebuilds it.
-  const resetCommand = resetNativeDepsCommand(hostPlatform, ['node-pty'])
+  // than rebuilds it. Keep the caller's resets too — a repair reconnect still needs them.
+  const resetCommand = resetNativeDepsCommand(hostPlatform, [
+    ...new Set<RelayNativeDepName>([...resetDeps, 'node-pty'])
+  ])
   await execHostCommand(
     conn,
     hostPlatform,
@@ -959,6 +978,40 @@ async function installNativeDepsWithoutNodePty(
     ),
     { timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS, signal }
   )
+}
+
+/**
+ * Report an unloadable @parcel/watcher after node-pty was skipped, without failing the connection.
+ *
+ * Why: node-pty is expected missing here, but a @parcel/watcher prebuilt that installs and still
+ * can't require() (glibc below the floor — docs/reference/linux-glibc-compatibility.md) means dead
+ * file watching. No rebuild: node-pty provably can't compile on this host, so it would only fail.
+ */
+async function warnIfWatcherUnloadableWithoutNodePty(
+  conn: SshConnection,
+  remoteDir: string,
+  platform: RelayPlatform,
+  hostPlatform: RemoteHostPlatform,
+  nodePath: string,
+  signal?: AbortSignal
+): Promise<void> {
+  try {
+    const probe = await probeInstalledNativeDeps(conn, remoteDir, hostPlatform, nodePath, signal)
+    if (probe.missing.includes('@parcel/watcher')) {
+      console.warn(
+        `[ssh-relay][WATCHER-MISSING-NPTY-SKIPPED] @parcel/watcher installed but require() failed at ${remoteDir} (${platform}); remote file watching is unavailable. stdout=${probe.output.trim().slice(-200)} stderr=${probe.stderr.trim().slice(-500)}`
+      )
+    }
+  } catch (err) {
+    if (isUnconfirmedSshCommandTermination(err)) {
+      throw err
+    }
+    signal?.throwIfAborted()
+    // Degraded-mode diagnostics must never cost the connection the retry just salvaged.
+    console.warn(
+      `[ssh-relay][WATCHER-PROBE-FAIL] native deps probe failed after skipping node-pty at ${remoteDir} (${platform}): ${(err as Error).message}`
+    )
+  }
 }
 
 async function rebuildNativeDeps(

--- a/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
@@ -54,6 +54,27 @@ export function makeMockConnection(capture: SftpWriteCapture): SshConnection {
 
 export type ExecResponse = string | { reject: string }
 
+// Repair reconnect (isRelayAlreadyInstalled → true) where BOTH native deps are broken and the host
+// cannot compile node-pty, so the caller's resets must survive into the node-pty-less reinstall.
+export function makeRepairToolchainSkipExecResponses(): ExecResponse[] {
+  const bothMissing = 'ORCA-NATIVE-DEPS-MISSING:node-pty,@parcel/watcher\nMISSING'
+  return [
+    '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+    '/home/u',
+    bothMissing, // health probe before lock
+    bothMissing, // re-probe under the repair lock
+    '', // SFTP-namespace install-owner marker (repair)
+    { reject: 'gyp ERR! stack Error: not found: make' },
+    'PKG apk', // toolchain probe: no HAVE lines
+    '', // reset both deps + reinstall without node-pty
+    'ORCA-NATIVE-DEPS-MISSING:node-pty\nMISSING\n', // watcher probe: only node-pty still absent
+    '', // cat probe stderr
+    '', // rm -f probe stderr
+    'DEAD',
+    'READY'
+  ]
+}
+
 export function decodePowerShellCommand(command: string): string | null {
   const match = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)
   return match ? Buffer.from(match[1], 'base64').toString('utf16le') : null

--- a/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
@@ -61,13 +61,15 @@ export function decodePowerShellCommand(command: string): string | null {
 
 // Happy-path exec order: uname, $HOME, mkdir, chmod node, npm install, chmod prebuilds, probe, [cat stderr + rm if MISSING], [rebuild → chmod → re-probe if MISSING], DEAD, READY.
 // When the probe rejects (SSH channel close or vanished install dir), the catch skips both stderr-capture and the rm.
+// A failed npm install takes one of the two early branches below instead, which never reach `probe`.
 export function makeExecResponses(opts: {
   npmInstall: 'ok' | { reject: string }
+  // Only consumed when npmInstall is 'ok'; defaults to a healthy install.
   // 'ok'      : probe resolves with the sentinel; rm runs once
   // 'missing' : probe resolves with 'MISSING'; cat stderr + rm both run
   // 'dir-gone': probe rejects (cd-failure), exec rejects directly
   // { reject }: probe rejects with custom error (e.g. SSH channel)
-  probe: 'ok' | 'missing' | 'dir-gone' | { reject: string }
+  probe?: 'ok' | 'missing' | 'dir-gone' | { reject: string }
   // Override probe stdout entirely for shell-noise/pollution-prefix pressure tests.
   probeStdoutOverride?: string
   // Result after the automatic rebuild; defaults to missing so legacy tests still exercise the degraded-mode warning.
@@ -77,6 +79,8 @@ export function makeExecResponses(opts: {
   // Result of the node-pty-less reinstall the catch attempts when the toolchain is missing.
   // Omit for hosts that never reach it (full toolchain, or a non-build npm failure).
   nodePtySkipRetry?: 'ok' | { reject: string }
+  // Whether @parcel/watcher loads on the skip path; node-pty is always absent there by construction.
+  nodePtySkipWatcher?: 'ok' | 'missing'
 }): ExecResponse[] {
   // A failed npm install aborts after the catch probes the toolchain, unless the node-pty-less
   // reinstall succeeds; only then are the chmod/probe/launch slots reached.
@@ -91,26 +95,44 @@ export function makeExecResponses(opts: {
       ...(opts.nodePtySkipRetry ? [opts.nodePtySkipRetry] : []) // reinstall also rejects
     ]
   }
+  if (opts.npmInstall !== 'ok') {
+    // Skip path, exactly as production runs it: no chmod-prebuilds (node-pty is gone) and no rebuild
+    // (it provably can't compile here). The probe still runs to catch a dead @parcel/watcher.
+    return [
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      '', // mkdir remoteDir (uploadRelay)
+      '', // chmod +x node
+      opts.npmInstall, // npm install rejects on the missing compiler
+      opts.toolchainProbe ?? 'HAVE python3\nPKG dnf',
+      '', // rm -rf node-pty + reinstall without it
+      // node-pty is always reported missing here; the probe never resolves OK, so cat + rm both run.
+      opts.nodePtySkipWatcher === 'missing'
+        ? 'ORCA-NATIVE-DEPS-MISSING:node-pty,@parcel/watcher\nMISSING\n'
+        : 'ORCA-NATIVE-DEPS-MISSING:node-pty\nMISSING\n',
+      '', // cat probe stderr
+      '', // rm -f probe stderr
+      'DEAD',
+      'READY'
+    ]
+  }
+  const probe = opts.probe ?? 'ok'
   const probeSlot: ExecResponse =
     opts.probeStdoutOverride !== undefined
       ? opts.probeStdoutOverride
-      : opts.probe === 'ok'
+      : probe === 'ok'
         ? 'ORCA-NPTY-PROBE-OK\n'
-        : opts.probe === 'missing'
+        : probe === 'missing'
           ? 'MISSING\n' // shell-level `|| echo MISSING` after require throw
-          : opts.probe === 'dir-gone'
+          : probe === 'dir-gone'
             ? { reject: 'cd: no such file or directory' }
-            : opts.probe
+            : probe
   const slots: ExecResponse[] = [
     '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
     '/home/u',
     '', // mkdir remoteDir (uploadRelay)
     '', // chmod +x node
-    opts.npmInstall === 'ok' ? '' : opts.npmInstall,
-    // Toolchain probe + node-pty-less reinstall, only when the first install failed to build.
-    ...(opts.npmInstall === 'ok'
-      ? []
-      : [opts.toolchainProbe ?? 'HAVE python3\nPKG dnf', '' as ExecResponse]),
+    '', // npm install native deps
     '', // chmod prebuilds
     probeSlot
   ]

--- a/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-fixture.ts
@@ -1,0 +1,138 @@
+// Why: shared by the native-deps install specs so each file stays under the max-lines cap; the
+// vi.mock of ./ssh-relay-deploy-helpers in the importing spec is hoisted, so execCommand is mocked here too.
+import { EventEmitter } from 'node:events'
+import { vi } from 'vitest'
+
+import { execCommand } from './ssh-relay-deploy-helpers'
+import type { SshConnection } from './ssh-connection'
+
+export type SftpWriteCapture = {
+  paths: string[]
+  contents: Record<string, string>
+  // execCommand call count observed when ws.end() ran, per path — pins "package.json written before npm install".
+  execCallCountAtWrite: Record<string, number>
+}
+
+type SftpCallback = (err: Error | null, resolved?: string) => void
+const NO_SUCH_SFTP_FILE = Object.assign(new Error('No such file'), { code: 2 })
+
+export function makeMockConnection(capture: SftpWriteCapture): SshConnection {
+  // Why: production attaches/removes real listeners (including prependOnceListener), so the fake must be an emitter.
+  const sftpCreate = (): unknown => {
+    const sftp = new EventEmitter()
+    return Object.assign(sftp, {
+      mkdir: vi.fn((_p: string, cb: SftpCallback) => cb(null)),
+      // This host's shell home and SFTP start directory agree, so no namespace redirect is possible.
+      realpath: vi.fn((_p: string, cb: SftpCallback) => cb(null, '/home/u')),
+      lstat: vi.fn((_p: string, cb: SftpCallback) => cb(NO_SUCH_SFTP_FILE)),
+      createWriteStream: vi.fn().mockImplementation((path: string) => {
+        capture.paths.push(path)
+        const ws = new EventEmitter()
+        return Object.assign(ws, {
+          end: vi.fn((data?: string) => {
+            capture.contents[path] = `${capture.contents[path] ?? ''}${data ?? ''}`
+            capture.execCallCountAtWrite[path] = vi.mocked(execCommand).mock.calls.length
+            setTimeout(() => ws.emit('close'), 0)
+          })
+        })
+      }),
+      end: vi.fn(() => setTimeout(() => sftp.emit('close'), 0))
+    })
+  }
+  return {
+    canRunConcurrentExecCommands: vi.fn().mockReturnValue(false),
+    exec: vi.fn().mockResolvedValue({
+      on: vi.fn(),
+      stderr: { on: vi.fn() },
+      stdin: {},
+      stdout: { on: vi.fn() },
+      close: vi.fn()
+    }),
+    sftp: vi.fn().mockImplementation(() => Promise.resolve(sftpCreate()))
+  } as unknown as SshConnection
+}
+
+export type ExecResponse = string | { reject: string }
+
+export function decodePowerShellCommand(command: string): string | null {
+  const match = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)
+  return match ? Buffer.from(match[1], 'base64').toString('utf16le') : null
+}
+
+// Happy-path exec order: uname, $HOME, mkdir, chmod node, npm install, chmod prebuilds, probe, [cat stderr + rm if MISSING], [rebuild → chmod → re-probe if MISSING], DEAD, READY.
+// When the probe rejects (SSH channel close or vanished install dir), the catch skips both stderr-capture and the rm.
+export function makeExecResponses(opts: {
+  npmInstall: 'ok' | { reject: string }
+  // 'ok'      : probe resolves with the sentinel; rm runs once
+  // 'missing' : probe resolves with 'MISSING'; cat stderr + rm both run
+  // 'dir-gone': probe rejects (cd-failure), exec rejects directly
+  // { reject }: probe rejects with custom error (e.g. SSH channel)
+  probe: 'ok' | 'missing' | 'dir-gone' | { reject: string }
+  // Override probe stdout entirely for shell-noise/pollution-prefix pressure tests.
+  probeStdoutOverride?: string
+  // Result after the automatic rebuild; defaults to missing so legacy tests still exercise the degraded-mode warning.
+  repairProbe?: 'ok' | 'missing'
+  // Raw stdout for the toolchain probe in installNativeDeps' catch; defaults to a full toolchain so the original npm error propagates unchanged.
+  toolchainProbe?: string
+  // Result of the node-pty-less reinstall the catch attempts when the toolchain is missing.
+  // Omit for hosts that never reach it (full toolchain, or a non-build npm failure).
+  nodePtySkipRetry?: 'ok' | { reject: string }
+}): ExecResponse[] {
+  // A failed npm install aborts after the catch probes the toolchain, unless the node-pty-less
+  // reinstall succeeds; only then are the chmod/probe/launch slots reached.
+  if (opts.npmInstall !== 'ok' && opts.nodePtySkipRetry !== 'ok') {
+    return [
+      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+      '/home/u',
+      '', // mkdir remoteDir (uploadRelay)
+      '', // chmod +x node
+      opts.npmInstall, // npm install rejects
+      opts.toolchainProbe ?? 'HAVE make\nHAVE g++\nHAVE cc\nHAVE python3\nPKG apt-get',
+      ...(opts.nodePtySkipRetry ? [opts.nodePtySkipRetry] : []) // reinstall also rejects
+    ]
+  }
+  const probeSlot: ExecResponse =
+    opts.probeStdoutOverride !== undefined
+      ? opts.probeStdoutOverride
+      : opts.probe === 'ok'
+        ? 'ORCA-NPTY-PROBE-OK\n'
+        : opts.probe === 'missing'
+          ? 'MISSING\n' // shell-level `|| echo MISSING` after require throw
+          : opts.probe === 'dir-gone'
+            ? { reject: 'cd: no such file or directory' }
+            : opts.probe
+  const slots: ExecResponse[] = [
+    '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
+    '/home/u',
+    '', // mkdir remoteDir (uploadRelay)
+    '', // chmod +x node
+    opts.npmInstall === 'ok' ? '' : opts.npmInstall,
+    // Toolchain probe + node-pty-less reinstall, only when the first install failed to build.
+    ...(opts.npmInstall === 'ok'
+      ? []
+      : [opts.toolchainProbe ?? 'HAVE python3\nPKG dnf', '' as ExecResponse]),
+    '', // chmod prebuilds
+    probeSlot
+  ]
+  // Cleanup execs only run when the probe resolved (not when it rejected).
+  const probeResolved = typeof probeSlot === 'string'
+  if (probeResolved) {
+    const probeOk = probeSlot.includes('ORCA-NPTY-PROBE-OK')
+    if (!probeOk) {
+      slots.push('') // cat stderr (graceful failure path captures detail)
+    }
+    slots.push('') // rm -f stderr (best-effort cleanup)
+    if (!probeOk) {
+      slots.push('') // npm rebuild with lifecycle scripts explicitly enabled
+      slots.push('') // chmod prebuilds after rebuild
+      const repairProbe = opts.repairProbe === 'ok' ? 'ORCA-NPTY-PROBE-OK\n' : 'MISSING\n'
+      slots.push(repairProbe)
+      if (!repairProbe.includes('ORCA-NPTY-PROBE-OK')) {
+        slots.push('') // cat stderr after unsuccessful rebuild
+      }
+      slots.push('') // rm -f stderr after rebuild probe
+    }
+  }
+  slots.push('DEAD', 'READY')
+  return slots
+}

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -183,7 +183,6 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
       makeExecResponses({
         npmInstall: { reject: 'gyp ERR! stack Error: not found: make' },
         nodePtySkipRetry: 'ok',
-        probe: 'missing',
         toolchainProbe: 'PKG apk'
       })
     )
@@ -196,6 +195,13 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     const reinstall = execCalls.findLast((c) => c.includes('npm install')) ?? ''
     expect(reinstall).toContain('@parcel/watcher@')
     expect(reinstall).not.toContain('node-pty@')
+    // The skip path must stop here: rebuilding is pointless on a host with no compiler.
+    expect(execCalls.some((c) => c.includes('npm rebuild'))).toBe(false)
+    // node-pty is legitimately absent, so its probe result must not raise the degraded-mode alarm.
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0] ?? ''))
+    expect(warnMessages.some((m) => m.includes('[ssh-relay][WATCHER-MISSING-NPTY-SKIPPED]'))).toBe(
+      false
+    )
     // The rewritten manifest must drop node-pty too, or npm reconciles it back and rebuilds.
     const pkgPath = sftpCapture.paths.findLast((p) => p.endsWith('/package.json')) as string
     // The capture concatenates every write to a path; the rewrite is the last manifest line.
@@ -203,6 +209,48 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     const deps = (JSON.parse(latest) as { dependencies: object }).dependencies
     expect(deps).toHaveProperty('@parcel/watcher')
     expect(deps).not.toHaveProperty('node-pty')
+  })
+
+  it('warns when @parcel/watcher is also unloadable after node-pty was skipped', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: { reject: 'gyp ERR! stack Error: not found: make' },
+        nodePtySkipRetry: 'ok',
+        nodePtySkipWatcher: 'missing'
+      })
+    )
+
+    // Watcher failure (e.g. glibc below the floor) is non-fatal, but silent dead file watching is not acceptable.
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0] ?? ''))
+    expect(warnMessages.some((m) => m.includes('[ssh-relay][WATCHER-MISSING-NPTY-SKIPPED]'))).toBe(
+      true
+    )
+    expect(vi.mocked(finalizeInstall)).toHaveBeenCalledTimes(1)
+    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
+    expect(execCalls.some((c) => c.includes('npm rebuild'))).toBe(false)
+  })
+
+  it('hard-fails on a gyp error when the remote toolchain is actually complete', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: { reject: 'gyp ERR! stack Error: not found: make' },
+        // Probe contradicts the gyp output: the tools are all there, so the real cause is unknown.
+        toolchainProbe: 'HAVE make\nHAVE g++\nHAVE python3\nPKG apt-get'
+      })
+    )
+
+    const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
+    // Degrading here would silently drop terminals on a host that can build them.
+    expect((error as Error).message).toContain('gyp ERR!')
+    expect((error as Error).message).not.toContain('build tools')
+
+    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
+    expect(execCalls.filter((c) => c.includes('npm install'))).toHaveLength(1)
+    expect(execCalls.some((c) => c.includes("rm -rf 'node_modules/node-pty'"))).toBe(false)
+    expect(vi.mocked(finalizeInstall)).not.toHaveBeenCalled()
   })
 
   it('still reports the actionable build-tools error when the node-pty-less retry also fails', async () => {
@@ -226,6 +274,15 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     expect(message).toContain('sudo apk add build-base python3')
     // The raw npm/node-gyp output is preserved for triage, not discarded.
     expect(message).toContain('not found: make')
+    // The retry's own cause is unrelated to the toolchain, so it must survive as cause + a log line.
+    expect((error as Error).cause).toBeInstanceOf(Error)
+    expect(((error as Error).cause as Error).message).toContain('registry unreachable')
+    const warnMessages = warnSpy.mock.calls.map((args) => String(args[0] ?? ''))
+    expect(
+      warnMessages.some(
+        (m) => m.includes('[ssh-relay][NPTY-SKIP-RETRY-FAIL]') && m.includes('registry unreachable')
+      )
+    ).toBe(true)
     expect(vi.mocked(finalizeInstall)).not.toHaveBeenCalled()
   })
 

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -1,6 +1,5 @@
 // Why: regression coverage for the install-probe contract — the "node-pty is not available" bug shipped because every guard layer was silent.
 
-import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', () => ({
@@ -77,129 +76,13 @@ import {
 } from './ssh-relay-versioned-install'
 import { acquireInstallLock } from './ssh-relay-install-lock'
 import { tryAcquireRelayRepairLock } from './ssh-relay-repair-lock'
-import type { SshConnection } from './ssh-connection'
-
-type SftpWriteCapture = {
-  paths: string[]
-  contents: Record<string, string>
-  // execCommand call count observed when ws.end() ran, per path — pins "package.json written before npm install".
-  execCallCountAtWrite: Record<string, number>
-}
-
-type SftpCallback = (err: Error | null, resolved?: string) => void
-const NO_SUCH_SFTP_FILE = Object.assign(new Error('No such file'), { code: 2 })
-
-function makeMockConnection(capture: SftpWriteCapture): SshConnection {
-  // Why: production attaches/removes real listeners (including prependOnceListener), so the fake must be an emitter.
-  const sftpCreate = (): unknown => {
-    const sftp = new EventEmitter()
-    return Object.assign(sftp, {
-      mkdir: vi.fn((_p: string, cb: SftpCallback) => cb(null)),
-      // This host's shell home and SFTP start directory agree, so no namespace redirect is possible.
-      realpath: vi.fn((_p: string, cb: SftpCallback) => cb(null, '/home/u')),
-      lstat: vi.fn((_p: string, cb: SftpCallback) => cb(NO_SUCH_SFTP_FILE)),
-      createWriteStream: vi.fn().mockImplementation((path: string) => {
-        capture.paths.push(path)
-        const ws = new EventEmitter()
-        return Object.assign(ws, {
-          end: vi.fn((data?: string) => {
-            capture.contents[path] = `${capture.contents[path] ?? ''}${data ?? ''}`
-            capture.execCallCountAtWrite[path] = vi.mocked(execCommand).mock.calls.length
-            setTimeout(() => ws.emit('close'), 0)
-          })
-        })
-      }),
-      end: vi.fn(() => setTimeout(() => sftp.emit('close'), 0))
-    })
-  }
-  return {
-    canRunConcurrentExecCommands: vi.fn().mockReturnValue(false),
-    exec: vi.fn().mockResolvedValue({
-      on: vi.fn(),
-      stderr: { on: vi.fn() },
-      stdin: {},
-      stdout: { on: vi.fn() },
-      close: vi.fn()
-    }),
-    sftp: vi.fn().mockImplementation(() => Promise.resolve(sftpCreate()))
-  } as unknown as SshConnection
-}
-
-type ExecResponse = string | { reject: string }
-
-function decodePowerShellCommand(command: string): string | null {
-  const match = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)/)
-  return match ? Buffer.from(match[1], 'base64').toString('utf16le') : null
-}
-
-// Happy-path exec order: uname, $HOME, mkdir, chmod node, npm install, chmod prebuilds, probe, [cat stderr + rm if MISSING], [rebuild → chmod → re-probe if MISSING], DEAD, READY.
-// When the probe rejects (SSH channel close or vanished install dir), the catch skips both stderr-capture and the rm.
-function makeExecResponses(opts: {
-  npmInstall: 'ok' | { reject: string }
-  // 'ok'      : probe resolves with the sentinel; rm runs once
-  // 'missing' : probe resolves with 'MISSING'; cat stderr + rm both run
-  // 'dir-gone': probe rejects (cd-failure), exec rejects directly
-  // { reject }: probe rejects with custom error (e.g. SSH channel)
-  probe: 'ok' | 'missing' | 'dir-gone' | { reject: string }
-  // Override probe stdout entirely for shell-noise/pollution-prefix pressure tests.
-  probeStdoutOverride?: string
-  // Result after the automatic rebuild; defaults to missing so legacy tests still exercise the degraded-mode warning.
-  repairProbe?: 'ok' | 'missing'
-  // Raw stdout for the toolchain probe in installNativeDeps' catch; defaults to a full toolchain so the original npm error propagates unchanged.
-  toolchainProbe?: string
-}): ExecResponse[] {
-  // npm install failure aborts after the catch probes the toolchain; no chmod/probe/launch slots are reached.
-  if (opts.npmInstall !== 'ok') {
-    return [
-      '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
-      '/home/u',
-      '', // mkdir remoteDir (uploadRelay)
-      '', // chmod +x node
-      opts.npmInstall, // npm install rejects
-      opts.toolchainProbe ?? 'HAVE make\nHAVE g++\nHAVE cc\nHAVE python3\nPKG apt-get'
-    ]
-  }
-  const probeSlot: ExecResponse =
-    opts.probeStdoutOverride !== undefined
-      ? opts.probeStdoutOverride
-      : opts.probe === 'ok'
-        ? 'ORCA-NPTY-PROBE-OK\n'
-        : opts.probe === 'missing'
-          ? 'MISSING\n' // shell-level `|| echo MISSING` after require throw
-          : opts.probe === 'dir-gone'
-            ? { reject: 'cd: no such file or directory' }
-            : opts.probe
-  const slots: ExecResponse[] = [
-    '__ORCA_REMOTE_PLATFORM__ Linux x86_64',
-    '/home/u',
-    '', // mkdir remoteDir (uploadRelay)
-    '', // chmod +x node
-    opts.npmInstall === 'ok' ? '' : opts.npmInstall,
-    '', // chmod prebuilds
-    probeSlot
-  ]
-  // Cleanup execs only run when the probe resolved (not when it rejected).
-  const probeResolved = typeof probeSlot === 'string'
-  if (probeResolved) {
-    const probeOk = probeSlot.includes('ORCA-NPTY-PROBE-OK')
-    if (!probeOk) {
-      slots.push('') // cat stderr (graceful failure path captures detail)
-    }
-    slots.push('') // rm -f stderr (best-effort cleanup)
-    if (!probeOk) {
-      slots.push('') // npm rebuild with lifecycle scripts explicitly enabled
-      slots.push('') // chmod prebuilds after rebuild
-      const repairProbe = opts.repairProbe === 'ok' ? 'ORCA-NPTY-PROBE-OK\n' : 'MISSING\n'
-      slots.push(repairProbe)
-      if (!repairProbe.includes('ORCA-NPTY-PROBE-OK')) {
-        slots.push('') // cat stderr after unsuccessful rebuild
-      }
-      slots.push('') // rm -f stderr after rebuild probe
-    }
-  }
-  slots.push('DEAD', 'READY')
-  return slots
-}
+import {
+  decodePowerShellCommand,
+  makeExecResponses,
+  makeMockConnection,
+  type ExecResponse,
+  type SftpWriteCapture
+} from './ssh-relay-native-deps-install-fixture'
 
 describe('installNativeDeps (via deployAndLaunchRelay)', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
@@ -294,14 +177,43 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     expect(warnMessages.some((m) => m.includes('[ssh-relay][NATIVE-DEPS-INSTALL-FAIL]'))).toBe(true)
   })
 
-  it('rewrites the npm failure into an actionable build-tools message when the remote toolchain is missing', async () => {
+  it('connects without node-pty when the remote toolchain is missing, instead of failing the host', async () => {
     const conn = makeMockConnection(sftpCapture)
     feed(
       makeExecResponses({
         npmInstall: { reject: 'gyp ERR! stack Error: not found: make' },
-        probe: 'ok',
-        // No HAVE lines + apk present: the tailored hint must come from the remote probe, not a hardcoded apt fallback.
+        nodePtySkipRetry: 'ok',
+        probe: 'missing',
         toolchainProbe: 'PKG apk'
+      })
+    )
+
+    // node-pty only backs terminals, so a host that cannot compile it still gets files and git.
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+    expect(vi.mocked(finalizeInstall)).toHaveBeenCalled()
+
+    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
+    const reinstall = execCalls.findLast((c) => c.includes('npm install')) ?? ''
+    expect(reinstall).toContain('@parcel/watcher@')
+    expect(reinstall).not.toContain('node-pty@')
+    // The rewritten manifest must drop node-pty too, or npm reconciles it back and rebuilds.
+    const pkgPath = sftpCapture.paths.findLast((p) => p.endsWith('/package.json')) as string
+    // The capture concatenates every write to a path; the rewrite is the last manifest line.
+    const latest = sftpCapture.contents[pkgPath].trim().split('\n').at(-1) as string
+    const deps = (JSON.parse(latest) as { dependencies: object }).dependencies
+    expect(deps).toHaveProperty('@parcel/watcher')
+    expect(deps).not.toHaveProperty('node-pty')
+  })
+
+  it('still reports the actionable build-tools error when the node-pty-less retry also fails', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: { reject: 'gyp ERR! stack Error: not found: make' },
+        // No HAVE lines + apk present: the tailored hint must come from the remote probe, not a hardcoded apt fallback.
+        toolchainProbe: 'PKG apk',
+        nodePtySkipRetry: { reject: 'npm ERR! registry unreachable' },
+        probe: 'ok'
       })
     )
 
@@ -314,11 +226,6 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     expect(message).toContain('sudo apk add build-base python3')
     // The raw npm/node-gyp output is preserved for triage, not discarded.
     expect(message).toContain('not found: make')
-
-    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
-    expect(
-      execCalls.some((c) => c.includes('command -v "$t"') && c.includes('command -v "$p"'))
-    ).toBe(true)
     expect(vi.mocked(finalizeInstall)).not.toHaveBeenCalled()
   })
 

--- a/src/main/ssh/ssh-relay-native-deps-install.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install.test.ts
@@ -80,6 +80,7 @@ import {
   decodePowerShellCommand,
   makeExecResponses,
   makeMockConnection,
+  makeRepairToolchainSkipExecResponses,
   type ExecResponse,
   type SftpWriteCapture
 } from './ssh-relay-native-deps-install-fixture'
@@ -260,8 +261,7 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
         npmInstall: { reject: 'gyp ERR! stack Error: not found: make' },
         // No HAVE lines + apk present: the tailored hint must come from the remote probe, not a hardcoded apt fallback.
         toolchainProbe: 'PKG apk',
-        nodePtySkipRetry: { reject: 'npm ERR! registry unreachable' },
-        probe: 'ok'
+        nodePtySkipRetry: { reject: 'npm ERR! registry unreachable' }
       })
     )
 
@@ -681,6 +681,23 @@ describe('installNativeDeps (via deployAndLaunchRelay)', () => {
     expect(installCommand).toContain('node_modules/@parcel/watcher')
     expect(installCommand).toContain("-name 'watcher-*'")
     expect(installCommand).not.toContain("rm -rf 'node_modules/node-pty'")
+  })
+
+  it('keeps the caller resets when a repair reconnect has to drop node-pty', async () => {
+    vi.mocked(isRelayAlreadyInstalled).mockResolvedValue(true)
+    const conn = makeMockConnection(sftpCapture)
+    feed(makeRepairToolchainSkipExecResponses())
+
+    await expect(deployAndLaunchRelay(conn)).resolves.toBeDefined()
+    expect(vi.mocked(finalizeInstall)).toHaveBeenCalledTimes(1)
+
+    const execCalls = vi.mocked(execCommand).mock.calls.map(([, c]) => c)
+    const reinstall = execCalls.findLast((c) => c.includes('npm install')) ?? ''
+    expect(reinstall).not.toContain('node-pty@')
+    expect(reinstall).toContain("rm -rf 'node_modules/node-pty'")
+    // Dropping the repair's own resets here leaves npm calling the broken watcher up to date.
+    expect(reinstall).toContain("rm -rf 'node_modules/@parcel/watcher'")
+    expect(reinstall).toContain("-name 'watcher-*'")
   })
 
   it('launches an already-installed relay in degraded mode when repair throws', async () => {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -36,7 +36,8 @@ import {
   IMMEDIATE_PTY_EXIT_TIMEOUT_MS,
   MAX_RELAY_PTY_SESSIONS,
   PtyHandler,
-  attachIdentityMismatches
+  attachIdentityMismatches,
+  formatNodePtyUnavailableMessage
 } from './pty-handler'
 import type { RelayDispatcher } from './dispatcher'
 
@@ -371,6 +372,22 @@ describe('PtyHandler', () => {
       owner: (first.agentSessionEnsure as { owner: unknown }).owner
     })
     expect(mockPtySpawn).toHaveBeenCalledOnce()
+  })
+
+  it('only offers the build-tools remedy on Linux, where node-pty has no prebuild', () => {
+    const linux = formatNodePtyUnavailableMessage('linux')
+    expect(linux).toContain('Remote terminals are unavailable')
+    expect(linux).toContain('C/C++ build tools')
+    expect(linux).toContain('python3')
+
+    // Windows/macOS ship node-pty prebuilds, so "install make/g++/python3" sends the user chasing nothing.
+    for (const platform of ['win32', 'darwin'] as const) {
+      const message = formatNodePtyUnavailableMessage(platform)
+      expect(message).toContain('Remote terminals are unavailable')
+      expect(message).not.toContain('build tools')
+      expect(message).not.toContain('python3')
+      expect(message).toMatch(/reconnect/i)
+    }
   })
 
   it('normalizes a missing native binding as degraded node-pty availability', async () => {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -374,11 +374,13 @@ describe('PtyHandler', () => {
     expect(mockPtySpawn).toHaveBeenCalledOnce()
   })
 
-  it('only offers the build-tools remedy on Linux, where node-pty has no prebuild', () => {
+  it('hedges both causes on Linux and offers the build-tools remedy nowhere else', () => {
     const linux = formatNodePtyUnavailableMessage('linux')
     expect(linux).toContain('Remote terminals are unavailable')
-    expect(linux).toContain('C/C++ build tools')
+    // Conditional, not asserted: a host with build-essential can still hit an ABI/Node-version flip.
+    expect(linux).toMatch(/If it is missing the C\/C\+\+ build tools/)
     expect(linux).toContain('python3')
+    expect(linux).toContain('version and architecture match the installed binding')
 
     // Windows/macOS ship node-pty prebuilds, so "install make/g++/python3" sends the user chasing nothing.
     for (const platform of ['win32', 'darwin'] as const) {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -381,7 +381,7 @@ describe('PtyHandler', () => {
     })
 
     await expect(dispatcher.callRequest('pty.spawn', {})).rejects.toThrow(
-      'node-pty is not available on this remote host'
+      'Remote terminals are unavailable'
     )
     expect(handler.activePtyCount).toBe(0)
   })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -60,12 +60,13 @@ import {
   type AgentSessionOwnerBinding
 } from '../shared/agent-session-host-authority'
 
-// Why: only Linux compiles node-pty (no prebuilt) and can have it skipped for a missing compiler, so
-// the build-tools remedy is a closable setup gap there and wrong advice anywhere node-pty ships one.
+// Why: only Linux compiles node-pty (no prebuilt), so the build-tools remedy is a closable setup gap
+// there and wrong advice anywhere node-pty ships one. The relay only sees an unloadable binding, never
+// why — a skipped compile and a later Node/ABI flip look identical here — so Linux hedges both causes.
 export function formatNodePtyUnavailableMessage(platform: NodeJS.Platform): string {
   const remedy =
     platform === 'linux'
-      ? 'this host is missing the C/C++ build tools needed to compile node-pty. Install make, a C++ compiler, and python3 on the remote host, then reconnect.'
+      ? "node-pty's native binding is not loadable on this host. If it is missing the C/C++ build tools needed to compile node-pty, install make, a C++ compiler, and python3 on the remote host, then reconnect. Otherwise reconnect to reinstall the relay's native modules, and check that the remote Node.js version and architecture match the installed binding."
       : "node-pty's native binding failed to load on this host. Reconnect to reinstall the relay's native modules; if it persists, check that the remote Node.js version and architecture match the installed binding."
   return `Remote terminals are unavailable: ${remedy}`
 }

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -60,10 +60,15 @@ import {
   type AgentSessionOwnerBinding
 } from '../shared/agent-session-host-authority'
 
-// Why: on Linux node-pty has no prebuilt and gets skipped when the host has no compiler, so this
-// is a closable setup gap — say so instead of a bare "not available".
-const NODE_PTY_UNAVAILABLE_MESSAGE =
-  'Remote terminals are unavailable: this host is missing the C/C++ build tools needed to compile node-pty. Install make, a C++ compiler, and python3 on the remote host, then reconnect.'
+// Why: only Linux compiles node-pty (no prebuilt) and can have it skipped for a missing compiler, so
+// the build-tools remedy is a closable setup gap there and wrong advice anywhere node-pty ships one.
+export function formatNodePtyUnavailableMessage(platform: NodeJS.Platform): string {
+  const remedy =
+    platform === 'linux'
+      ? 'this host is missing the C/C++ build tools needed to compile node-pty. Install make, a C++ compiler, and python3 on the remote host, then reconnect.'
+      : "node-pty's native binding failed to load on this host. Reconnect to reinstall the relay's native modules; if it persists, check that the remote Node.js version and architecture match the installed binding."
+  return `Remote terminals are unavailable: ${remedy}`
+}
 
 function isMissingNodePtyNativeBinding(error: unknown): boolean {
   return (
@@ -1002,7 +1007,7 @@ export class PtyHandler {
   ): Promise<{ id: string; incarnationId: string }> {
     const pty = await this.loadPty()
     if (!pty) {
-      throw new Error(NODE_PTY_UNAVAILABLE_MESSAGE)
+      throw new Error(formatNodePtyUnavailableMessage(process.platform))
     }
 
     const cols = (params.cols as number) || 80
@@ -1083,7 +1088,7 @@ export class PtyHandler {
       // Why: Windows loads conpty.node only on first spawn, so handle that late binding failure here.
       if (isMissingNodePtyNativeBinding(error)) {
         this.invalidatePtyModuleAfterBindingFailure()
-        throw new Error(NODE_PTY_UNAVAILABLE_MESSAGE)
+        throw new Error(formatNodePtyUnavailableMessage(process.platform))
       }
       throw error
     }

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -60,6 +60,11 @@ import {
   type AgentSessionOwnerBinding
 } from '../shared/agent-session-host-authority'
 
+// Why: on Linux node-pty has no prebuilt and gets skipped when the host has no compiler, so this
+// is a closable setup gap — say so instead of a bare "not available".
+const NODE_PTY_UNAVAILABLE_MESSAGE =
+  'Remote terminals are unavailable: this host is missing the C/C++ build tools needed to compile node-pty. Install make, a C++ compiler, and python3 on the remote host, then reconnect.'
+
 function isMissingNodePtyNativeBinding(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -997,7 +1002,7 @@ export class PtyHandler {
   ): Promise<{ id: string; incarnationId: string }> {
     const pty = await this.loadPty()
     if (!pty) {
-      throw new Error('node-pty is not available on this remote host')
+      throw new Error(NODE_PTY_UNAVAILABLE_MESSAGE)
     }
 
     const cols = (params.cols as number) || 80
@@ -1078,7 +1083,7 @@ export class PtyHandler {
       // Why: Windows loads conpty.node only on first spawn, so handle that late binding failure here.
       if (isMissingNodePtyNativeBinding(error)) {
         this.invalidatePtyModuleAfterBindingFailure()
-        throw new Error('node-pty is not available on this remote host')
+        throw new Error(NODE_PTY_UNAVAILABLE_MESSAGE)
       }
       throw error
     }

--- a/src/relay/subprocess.test.ts
+++ b/src/relay/subprocess.test.ts
@@ -146,7 +146,7 @@ describe('Subprocess: Relay entry point', () => {
 
     const failedId = relay.send('pty.spawn', { cols: 80, rows: 24 })
     const failed = await relay.waitForResponse(failedId)
-    expect(failed.error?.message).toContain('node-pty is not available')
+    expect(failed.error?.message).toContain('Remote terminals are unavailable')
 
     writeMockNodePty(tmpDir, WORKING_NODE_PTY_MODULE)
 
@@ -171,7 +171,7 @@ describe('Subprocess: Relay entry point', () => {
 
     const failedId = relay.send('pty.spawn', { cols: 80, rows: 24 })
     const failed = await relay.waitForResponse(failedId)
-    expect(failed.error?.message).toContain('node-pty is not available')
+    expect(failed.error?.message).toContain('Remote terminals are unavailable')
 
     writeMockNodePty(tmpDir, WORKING_NODE_PTY_MODULE, true)
     const repairedId = relay.send('pty.spawn', { cols: 80, rows: 24 })


### PR DESCRIPTION
Fixes STA-2543.

`node-pty` ships prebuilds for `darwin-arm64`, `darwin-x64`, `win32-arm64` and `win32-x64` — and **none for Linux, at any architecture**. So it is always compiled on a Linux remote, and on a host without a C/C++ toolchain that build fails. Because both native deps install in a single `npm install`, that failure also took down `@parcel/watcher` (which *does* ship a working Linux prebuilt) and failed the whole connection.

This is not limited to minimal RHEL-family images as the ticket originally described: **every Linux SSH host without build tools was unusable**, which is most minimal cloud images. macOS and Windows remotes were unaffected.

## Fix

`node-pty` only backs remote terminals — the filesystem, git, and editor surfaces do not need it — and a missing native dep is *already* non-fatal further down the deploy:

```ts
// MISSING is non-fatal by design: the relay still serves fs/git/preflight;
// only native-backed ops fail on hosts that can't build the addons.
```

The only thing hard-failing the connection was the install itself. So when the existing toolchain probe confirms the compiler is missing, the deploy now reinstalls without `node-pty` instead of aborting.

The manifest has to drop it too: npm reconciles every dependency in `package.json`, not just the ones named on the command line, so naming only `@parcel/watcher` still rebuilt `node-pty` and failed again. That cost me one debugging round and is the non-obvious part of this change.

If the node-pty-less reinstall *also* fails, the actionable build-tools error is rethrown, so a host broken for some other reason still reports the toolchain gap rather than silently degrading.

The relay's PTY error also now names the remedy instead of only stating that node-pty is unavailable.

Behaviour change worth calling out: a toolchain-less Linux host now **connects in a reduced mode** rather than failing outright. Terminals report the install hint; everything else works.

## Verification

Live, on a stock Rocky Linux 10.2 aarch64 container built to the ticket's repro steps (`openssh-server git nodejs npm`, no compiler):

| | Before | After |
|---|---|---|
| `ssh.connect` | fails | **connected** |
| `fs.readDir('/etc')` over SSH | n/a | 113 entries |
| `node-pty` on remote | — | absent |
| `@parcel/watcher` on remote | — | present, `linux-arm64-glibc` prebuilt |
| remote `package.json` deps | — | `@parcel/watcher` only |
| `pty.spawn` | n/a | `Remote terminals are unavailable: this host is missing the C/C++ build tools needed to compile node-pty. Install make, a C++ compiler, and python3 on the remote host, then reconnect.` |

Gates: `src/main/ssh` + `src/relay` → 1803 passed, `tsc --noEmit` clean, oxlint and oxfmt clean. The 2 failures in `agent-exec-handler.test.ts` are pre-existing — I confirmed them on `origin/main` with this branch stashed.

## Notes for review

- The skip happens in the existing failure branch, so the happy path adds no extra round-trip and its tests are untouched.
- The shared install-spec harness moved to `ssh-relay-native-deps-install-fixture.ts`: the spec was at the 800-line lint cap and `max-lines` disables are forbidden, so extracting it was the way to add coverage. That also makes future sibling specs cheap.
- Not addressed here: the failure still costs a full npm + node-gyp attempt before the retry. Preflighting the toolchain before the first install would make it fast, but that adds a probe round-trip to every deploy — worth doing separately if the wait is a problem in practice.
- Longer term the root fix is shipping prebuilt native binaries per remote platform, already tracked as a TODO in the deploy code.
