### PR TITLE
perf(agent-status): keep the shared transcript reader's carry linear

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -971,6 +971,56 @@ describe('shared agent-hook-listener', () => {
     }
   })
 
+  it('reads the last assistant message behind an oversized line without quadratic copying', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'orca-assistant-huge-line-'))
+    const transcriptPath = join(tmpDir, 'transcript.jsonl')
+    const originalConcat = Buffer.concat
+    let concatenatedBytes = 0
+    try {
+      // The shared backward reader (readLastTextFromTranscriptOnce) stitches a
+      // line spanning many read blocks. Re-joining the carry per block copies
+      // O(line^2); the chunk list defers to one join.
+      const lineBytes = 2 * 1024 * 1024
+      writeFileSync(
+        transcriptPath,
+        `${JSON.stringify({
+          role: 'assistant',
+          content: [{ type: 'text', text: 'answer behind a huge line' }]
+        })}\n${JSON.stringify({
+          role: 'user',
+          content: [{ type: 'text', text: 'x'.repeat(lineBytes) }]
+        })}\n`
+      )
+
+      Buffer.concat = ((list: readonly Uint8Array[], totalLength?: number) => {
+        const joined = originalConcat(list as Uint8Array[], totalLength)
+        concatenatedBytes += joined.length
+        return joined
+      }) as typeof Buffer.concat
+
+      const done = normalizeHookPayload(
+        state,
+        'claude',
+        {
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: 'wt',
+          env: 'production',
+          version: '1',
+          payload: { hook_event_name: 'Stop', transcript_path: transcriptPath }
+        },
+        'production'
+      )
+
+      expect(done?.payload.lastAssistantMessage).toBe('answer behind a huge line')
+      // Linear copies once (~lineBytes); the quadratic form copied many times that.
+      expect(concatenatedBytes).toBeLessThan(lineBytes * 4)
+    } finally {
+      Buffer.concat = originalConcat
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+  })
+
   // Why these three: the prompt read scans backward from EOF and stops at the
   // first user line, so the cases that can break are a prompt spanning a chunk
   // boundary, a later prompt that must win over an earlier one, and the byte

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -1337,11 +1337,14 @@ function readLastTextFromTranscriptOnce(
     }
     const fd = openSync(transcriptPath, 'r')
     try {
-      let carryBytes: Buffer = Buffer.alloc(0)
+      // Why a chunk list: carry holds a partial line, and re-joining it per block
+      // made one oversized line (a big tool result or pasted prompt) cost O(line^2).
+      let carryChunks: Buffer[] = []
       let bytesRead = 0
-      while (bytesRead < size && bytesRead < TRANSCRIPT_MAX_SCAN_BYTES) {
-        const chunkSize = Math.min(size - bytesRead, TRANSCRIPT_CHUNK_BYTES)
-        const position = size - bytesRead - chunkSize
+      let scanEnd = size
+      while (scanEnd > 0 && bytesRead < TRANSCRIPT_MAX_SCAN_BYTES) {
+        const chunkSize = Math.min(scanEnd, TRANSCRIPT_CHUNK_BYTES)
+        const position = scanEnd - chunkSize
         const buffer = Buffer.alloc(chunkSize)
         let filled = 0
         while (filled < chunkSize) {
@@ -1351,25 +1354,30 @@ function readLastTextFromTranscriptOnce(
           }
           filled += n
         }
-        const n = filled
-        bytesRead += n
-        if (n === 0) {
+        // Why bail on a short read: the file shrank under us, so the bytes above
+        // this block no longer line up with what the earlier ones assumed.
+        if (filled < chunkSize) {
           break
         }
-        const combined = Buffer.concat([buffer.subarray(0, n), carryBytes])
-        const atStart = bytesRead >= size
-        const firstNewline = combined.indexOf(0x0a)
+        bytesRead += filled
+        scanEnd = position
+        // Why search only the new block: carry is always the run before a newline,
+        // so it holds none of its own.
+        const firstNewline = buffer.indexOf(0x0a)
+        const atStart = position === 0
         let completeRegion: Buffer
-        let nextCarry: Buffer
         if (atStart) {
-          completeRegion = combined
-          nextCarry = Buffer.alloc(0)
+          completeRegion =
+            carryChunks.length === 0 ? buffer : Buffer.concat([buffer, ...carryChunks])
+          carryChunks = []
         } else if (firstNewline === -1) {
-          completeRegion = Buffer.alloc(0)
-          nextCarry = combined
+          completeRegion = EMPTY_TRANSCRIPT_REGION
+          carryChunks.unshift(buffer)
         } else {
-          nextCarry = combined.subarray(0, firstNewline)
-          completeRegion = combined.subarray(firstNewline + 1)
+          const afterNewline = buffer.subarray(firstNewline + 1)
+          completeRegion =
+            carryChunks.length === 0 ? afterNewline : Buffer.concat([afterNewline, ...carryChunks])
+          carryChunks = [buffer.subarray(0, firstNewline)]
         }
         if (completeRegion.length > 0) {
           const extracted = findLastExtractedTranscriptLineText(
@@ -1380,7 +1388,6 @@ function readLastTextFromTranscriptOnce(
             return extracted
           }
         }
-        carryBytes = nextCarry
       }
       return undefined
     } finally {


### PR DESCRIPTION
> **Stacked on #10742.** That PR fixed the quadratic carry in the Command Code prompt reader; this applies the same fix to the *shared* reader sitting beside it. Review #10742 first — this diff is only the last 2 files (`8ebac40`).

## Summary

`readLastTextFromTranscriptOnce` re-joined its carry buffer with `Buffer.concat` on **every block that held no newline**, so a transcript whose tail is one oversized line copied **O(line²)**.

This is the same defect #10742 fixed in `readLastCommandCodeUserPromptEntryFromTranscript` — the two functions sit ~300 lines apart and share the shape. This one was missed because it already scanned backward, so it looked done.

It backs **three** readers, so every agent that resolves turn text from a transcript paid it:

| caller | what it reads |
|---|---|
| `extractUserPromptTextFromLine` | the Claude/Codex user prompt |
| `extractCommandCodeAssistantTextFromLine` | the Command Code assistant message |
| `extractAssistantTextFromLine` | the shared assistant-text reader |

## ELI5

Orca reads the session log backwards from the end, 64 KB at a time, to find the most recent message.

When a chunk ends mid-line, it has to hold that partial line aside and stick it onto the next chunk. The old code **rebuilt the whole held-aside pile every single time**. With normal short lines that's nothing. But agent turns embed a file read or command output as one enormous line — and then the pile got copied, and copied again, growing each round.

Now it keeps the pieces in a list and joins them once at the end. Same result, one copy instead of many.

## Screenshots

No visual change.

## Proof of performance improvement

Transcript whose tail is one large line, with the answer behind it:

| tail line | before | after | speedup |
|---|---|---|---|
| 1 MB | 3.02 ms | 2.24 ms | 1.35× |
| 2 MB | 6.33 ms | 4.60 ms | 1.38× |
| 3 MB | 11.35 ms | 7.23 ms | 1.57× |
| 3.9 MB | 15.24 ms | 8.87 ms | **1.72×** |

**The widening ratio is the point** — that is the quadratic signature. A constant-factor win would hold the same ratio across sizes; this one grows with the line, because the number of re-copies grows with it. Both versions returned identical text at every size (asserted in the harness before timing).

## Proof of zero regression

Behaviour is unchanged; only the copying strategy differs. The carry is still the byte run before the first newline, still stitched in the same order, and the region handed to the extractor is byte-identical.

**Regression test** (`agent-hook-listener.test.ts`): drives a `Stop` event through a transcript whose tail is a 2 MB line and asserts the assistant message still resolves.

A wall-clock threshold was the wrong instrument here — 32 MB of copying is fast enough in absolute terms that timing is flaky in CI. The test instead **counts bytes copied** through `Buffer.concat`, which is deterministic:

- linear (fixed): comfortably under the `lineBytes * 4` budget
- quadratic (mutant): **36,634,730 bytes against an 8,388,608 budget** — fails decisively

I verified that by reintroducing the quadratic form in *this function only* and confirming the test fails.

Also hardened alongside it: a **short read now bails out** rather than deriving offsets from a size the file no longer has (a truncation racing the scan).

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — **602 tests pass** across `agent-hook-listener`, roster-retention, `src/main/agent-hooks/**`, `src/main/command-code/**`, and `src/relay/agent-hook-server`; 117/117 in the touched file
- [x] Added a test that would catch the regression

### Pre-existing test failures

Full suite: 3 failures / 36,768. Two are the known `agent-exec-handler` cases that assert against the machine's real `process.env`. The third, `relay-transport › authenticates one query-free host-data socket`, is a **new name but not a new problem** — it passes 6/6 in isolation and imports nothing from the changed file. It joins the load-flaky pool this series has been tracking: across six full-suite runs, two consecutive runs on *unmodified* `main` produced different failure sets, which is what establishes the pool as pre-existing.

## Review loop count + verdict

**2 review loops: follow-up discovery verification and final risk review. Final verdict: ship.**

Found by a follow-up sweep asking "does this optimization apply elsewhere?" after #10742 merged-pending. I verified the flaw and measured it independently before writing the fix.

I also swept the rest of the repo for the same accumulator shape and **refuted the two other candidates**, rather than reporting them as finds:

- `wsl-hook-relay-sentinel.ts:107` — accumulates pre-sentinel stdout, but caps at 64 KiB and kills the child, so it cannot grow.
- `scrcpy-stream-session.ts:211` — drains via `result.pending` on every frame, so the buffer never accumulates across frames.

## AI Review Report

Risks reviewed:

- **Byte-identical stitching.** The carry list is `unshift`-ed so blocks stay in file order, and the join concatenates `[afterNewline, ...carryChunks]` in the same order the old single buffer produced. Verified by output equality at every measured size and by the existing 117-test suite, which covers boundary-straddling lines, the 4 MB cap, and multi-block prompts.
- **Short reads / concurrent truncation.** Now bails rather than computing an offset from a stale size.
- **UTF-8 safety.** A region always begins immediately after `0x0a`, and `\n` can never be part of a multi-byte sequence, so a region start is always a character boundary. `carryChunks` is never decoded alone — it is always joined with its preceding block first. (This property was swept across 260 byte-alignments when the sibling reader was changed in #10742.)

Cross-platform: no path, shell, or platform-dependent behaviour touched. CRLF transcripts are unaffected — `\r` is ordinary payload here, and only `0x0a` is treated as a separator, exactly as before. Identical on local, SSH, WSL, and relay hook paths.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or IPC surface. Transcript paths still arrive through the same guarded field and `try`/`catch`. The 4 MB `TRANSCRIPT_MAX_SCAN_BYTES` cap is preserved exactly, so a crafted transcript still cannot make the reader scan further than before — and this change *reduces* the memory a malicious oversized line can cause to be copied. No dependency changes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
