### PR TITLE
fix(ssh): stop remote terminals fail-opening to local PTY

### DIFF
--- a/src/main/providers/ssh-pty-notification-routing.test.ts
+++ b/src/main/providers/ssh-pty-notification-routing.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import { subscribeSshPtyNotifications } from './ssh-pty-notification-routing'
+
+type MockMux = {
+  onNotification: ReturnType<typeof vi.fn>
+}
+
+function createSubscription() {
+  const mux: MockMux = {
+    onNotification: vi.fn()
+  }
+  const dataListeners = new Set<(payload: { id: string; data: string }) => void>()
+  const replayListeners = new Set<(payload: { id: string; data: string }) => void>()
+  const exitListeners = new Set<(payload: { id: string; code: number }) => void>()
+  const livePtyIds = new Set<string>()
+  const recordExit = vi.fn()
+  const toAppPtyId = vi.fn((id: string) => `ssh:conn@@${id}`)
+
+  subscribeSshPtyNotifications({
+    mux: mux as never,
+    toAppPtyId,
+    dataListeners: dataListeners as never,
+    replayListeners: replayListeners as never,
+    exitListeners: exitListeners as never,
+    livePtyIds,
+    recordExit
+  })
+
+  const handler = mux.onNotification.mock.calls[0]?.[0] as (
+    method: string,
+    params: Record<string, unknown>
+  ) => void
+  if (!handler) {
+    throw new Error('notification handler was not registered')
+  }
+
+  return {
+    handler,
+    toAppPtyId,
+    dataListeners,
+    replayListeners,
+    exitListeners,
+    livePtyIds,
+    recordExit
+  }
+}
+
+describe('subscribeSshPtyNotifications', () => {
+  it('ignores non-PTY notifications without mapping params.id', () => {
+    const { handler, toAppPtyId } = createSubscription()
+
+    expect(() => handler('workspace.changed', { snapshot: { revision: 1 } })).not.toThrow()
+    expect(() =>
+      handler('fs.changed', {
+        events: [{ kind: 'update', absolutePath: '/tmp/repo/file.txt' }]
+      })
+    ).not.toThrow()
+    expect(toAppPtyId).not.toHaveBeenCalled()
+  })
+
+  it('routes pty.data after validating the string id', () => {
+    const { handler, toAppPtyId, dataListeners, livePtyIds } = createSubscription()
+    const onData = vi.fn()
+    dataListeners.add(onData)
+
+    handler('pty.data', { id: 'pty-1', data: 'hello', rawLength: 5, seq: 9 })
+
+    expect(toAppPtyId).toHaveBeenCalledWith('pty-1')
+    expect(livePtyIds.has('ssh:conn@@pty-1')).toBe(true)
+    expect(onData).toHaveBeenCalledWith({
+      id: 'ssh:conn@@pty-1',
+      data: 'hello',
+      sequenceChars: 5,
+      seq: 9
+    })
+  })
+
+  it('records pty.exit with the validated relay id', () => {
+    const { handler, exitListeners, livePtyIds, recordExit } = createSubscription()
+    const onExit = vi.fn()
+    exitListeners.add(onExit)
+    livePtyIds.add('ssh:conn@@pty-1')
+
+    handler('pty.exit', {
+      id: 'pty-1',
+      code: 0,
+      incarnationId: 'incarnation-1'
+    })
+
+    expect(recordExit).toHaveBeenCalledWith('pty-1', 'incarnation-1')
+    expect(livePtyIds.has('ssh:conn@@pty-1')).toBe(false)
+    expect(onExit).toHaveBeenCalledWith({
+      id: 'ssh:conn@@pty-1',
+      code: 0,
+      incarnationId: 'incarnation-1'
+    })
+  })
+
+  it('ignores PTY methods with missing ids', () => {
+    const { handler, toAppPtyId, dataListeners } = createSubscription()
+    const onData = vi.fn()
+    dataListeners.add(onData)
+
+    expect(() => handler('pty.data', { data: 'orphan' })).not.toThrow()
+    expect(toAppPtyId).not.toHaveBeenCalled()
+    expect(onData).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/providers/ssh-pty-notification-routing.ts
+++ b/src/main/providers/ssh-pty-notification-routing.ts
@@ -18,9 +18,19 @@ export function subscribeSshPtyNotifications(args: {
   recordExit: (relayPtyId: string, incarnationId: unknown) => void
 }): () => void {
   return args.mux.onNotification((method, params) => {
-    const id = args.toAppPtyId(params.id as string)
+    // Why: mux delivers every method to generic handlers; non-PTY payloads
+    // (workspace.changed, fs.changed, …) have no `id` and must not reach
+    // toAppPtyId → startsWith.
+    if (method !== 'pty.exit' && method !== 'pty.data' && method !== 'pty.replay') {
+      return
+    }
+    if (typeof params.id !== 'string' || params.id.length === 0) {
+      return
+    }
+    const relayPtyId = params.id
+    const id = args.toAppPtyId(relayPtyId)
     if (method === 'pty.exit') {
-      args.recordExit(params.id as string, params.incarnationId)
+      args.recordExit(relayPtyId, params.incarnationId)
       args.livePtyIds.delete(id)
       for (const listener of args.exitListeners) {
         listener({
@@ -31,9 +41,6 @@ export function subscribeSshPtyNotifications(args: {
             : {})
         })
       }
-      return
-    }
-    if (method !== 'pty.data' && method !== 'pty.replay') {
       return
     }
     args.livePtyIds.add(id)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -15528,6 +15528,31 @@ describe('connectPanePty', () => {
     expect(createRemoteRuntimePtyTransport).toHaveBeenCalledWith('hub-a', expect.any(Object))
   })
 
+  it('still spawns locally when the worktree row itself proves a local host', async () => {
+    // The hydration guard must key off "nothing names the host", not "no repo row" — a
+    // worktree stamped hostId 'local' is resolved even before its repo merges.
+    const { connectPanePty } = await import('./pty-connection')
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-local': [{ id: 'tab-1', ptyId: null }] },
+      worktreesByRepo: {
+        repo1: [{ id: 'wt-local', repoId: 'repo1', path: '/tmp/wt-local', hostId: 'local' }]
+      },
+      repos: []
+    } as StoreState
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({ worktreeId: 'wt-local', cwd: '/tmp/wt-local' }) as never
+    )
+
+    expect(createIpcPtyTransport).toHaveBeenCalled()
+  })
+
   it('withholds a local spawn while a repo-backed worktree has no hydrated host', async () => {
     // Regression: an SSH worktree whose repo row hadn't merged yet resolved to a null
     // connectionId and spawned on the local daemon with the remote cwd, so the pane never

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -15528,6 +15528,36 @@ describe('connectPanePty', () => {
     expect(createRemoteRuntimePtyTransport).toHaveBeenCalledWith('hub-a', expect.any(Object))
   })
 
+  it('withholds a local spawn while a repo-backed worktree has no hydrated host', async () => {
+    // Regression: an SSH worktree whose repo row hadn't merged yet resolved to a null
+    // connectionId and spawned on the local daemon with the remote cwd, so the pane never
+    // bound a PTY (Docker SSH watcher-isolation timeout).
+    const { connectPanePty } = await import('./pty-connection')
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-remote': [{ id: 'tab-1', ptyId: null }] },
+      // Why: the worktree row exists (so the owner is not "ambiguous") but its repo has
+      // not landed yet — exactly the window that used to fail open to local.
+      worktreesByRepo: {
+        repo1: [{ id: 'wt-remote', repoId: 'repo1', path: '/tmp/orca-docker-relay-perf-repo' }]
+      },
+      repos: []
+    } as StoreState
+
+    const deps = createDeps({
+      worktreeId: 'wt-remote',
+      cwd: '/tmp/orca-docker-relay-perf-repo'
+    })
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+
+    expect(createIpcPtyTransport).not.toHaveBeenCalled()
+    expect(createRemoteRuntimePtyTransport).not.toHaveBeenCalled()
+  })
+
   it('keeps the floating terminal local even while a runtime is active', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -13,7 +13,7 @@ import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { isEphemeralSetupTerminalWorktreeId } from '../../../../shared/ephemeral-setup-terminal-worktree-id'
 import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
-import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
+import { isRuntimeOwnedSshTargetId, parseExecutionHostId } from '../../../../shared/execution-host'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
 import { isWorktreeRemovalFenceError } from '../../../../shared/worktree-removal-fence-error'
 import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-color-reply'
@@ -3234,13 +3234,18 @@ export function connectPanePty(
       ? mirroredRuntimeEnvironmentId
       : null
   // Why: host-agnostic synthetic ids (floating terminal, inline setup panels) have no repo
-  // row by design, so `undefined` there is resolved-local, not pending hydration (#10151).
-  // For a repo-backed worktree it means the repo hasn't hydrated: coalescing to null would
-  // fail-open a remote cwd onto the local daemon (ENOENT on Docker SSH paths).
+  // row by design, and a worktree row stamped 'local' proves its host on its own — both are
+  // resolved-local, not pending hydration (#10151). Only when nothing names the host does
+  // `undefined` mean the repo hasn't merged yet; coalescing that to null would fail-open a
+  // remote cwd onto the local daemon (ENOENT on Docker SSH paths).
+  const hostAgnosticTerminalWorktree =
+    deps.worktreeId === FLOATING_TERMINAL_WORKTREE_ID ||
+    isEphemeralSetupTerminalWorktreeId(deps.worktreeId)
+  const worktreeProvesLocalHost = parseExecutionHostId(worktree?.hostId)?.kind === 'local'
   const connectionOwnerHydrating =
     !terminalOwnerUnresolved &&
-    deps.worktreeId !== FLOATING_TERMINAL_WORKTREE_ID &&
-    !isEphemeralSetupTerminalWorktreeId(deps.worktreeId) &&
+    !hostAgnosticTerminalWorktree &&
+    !worktreeProvesLocalHost &&
     runtimeEnvironmentId === null &&
     worktreeConnectionId === undefined
   // Why: an SSH host nested under a HUB is execution identity, not permission for the paired client to dial that host.

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -10,6 +10,8 @@ import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { isEphemeralSetupTerminalWorktreeId } from '../../../../shared/ephemeral-setup-terminal-worktree-id'
 import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
 import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
@@ -3231,10 +3233,16 @@ export function connectPanePty(
     : mirroredRuntimeEnvironmentId
       ? mirroredRuntimeEnvironmentId
       : null
-  // Why: undefined means the backing repo has not hydrated yet. Coalescing to null
-  // would fail-open a remote cwd onto the local daemon (ENOENT on Docker SSH paths).
+  // Why: host-agnostic synthetic ids (floating terminal, inline setup panels) have no repo
+  // row by design, so `undefined` there is resolved-local, not pending hydration (#10151).
+  // For a repo-backed worktree it means the repo hasn't hydrated: coalescing to null would
+  // fail-open a remote cwd onto the local daemon (ENOENT on Docker SSH paths).
   const connectionOwnerHydrating =
-    !terminalOwnerUnresolved && runtimeEnvironmentId === null && worktreeConnectionId === undefined
+    !terminalOwnerUnresolved &&
+    deps.worktreeId !== FLOATING_TERMINAL_WORKTREE_ID &&
+    !isEphemeralSetupTerminalWorktreeId(deps.worktreeId) &&
+    runtimeEnvironmentId === null &&
+    worktreeConnectionId === undefined
   // Why: an SSH host nested under a HUB is execution identity, not permission for the paired client to dial that host.
   const connectionId =
     !terminalOwnerUnresolved && !connectionOwnerHydrating && runtimeEnvironmentId === null

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3231,9 +3231,13 @@ export function connectPanePty(
     : mirroredRuntimeEnvironmentId
       ? mirroredRuntimeEnvironmentId
       : null
+  // Why: undefined means the backing repo has not hydrated yet. Coalescing to null
+  // would fail-open a remote cwd onto the local daemon (ENOENT on Docker SSH paths).
+  const connectionOwnerHydrating =
+    !terminalOwnerUnresolved && runtimeEnvironmentId === null && worktreeConnectionId === undefined
   // Why: an SSH host nested under a HUB is execution identity, not permission for the paired client to dial that host.
   const connectionId =
-    !terminalOwnerUnresolved && runtimeEnvironmentId === null
+    !terminalOwnerUnresolved && !connectionOwnerHydrating && runtimeEnvironmentId === null
       ? (worktreeConnectionId ?? null)
       : null
   const shellOverride = tab?.shellOverride
@@ -3518,13 +3522,16 @@ export function connectPanePty(
         }
       : {})
   }
-  const transport = terminalOwnerUnresolved
-    ? createUnresolvedOwnerPtyTransport(
-        'Workspace identity is ambiguous across hosts. Refresh projects and try again.'
-      )
-    : runtimeEnvironmentId
-      ? createRemoteRuntimePtyTransport(runtimeEnvironmentId, transportOptions)
-      : createIpcPtyTransport(transportOptions)
+  const transport =
+    terminalOwnerUnresolved || connectionOwnerHydrating
+      ? createUnresolvedOwnerPtyTransport(
+          terminalOwnerUnresolved
+            ? 'Workspace identity is ambiguous across hosts. Refresh projects and try again.'
+            : 'Workspace host is still loading. Retry when the project finishes hydrating.'
+        )
+      : runtimeEnvironmentId
+        ? createRemoteRuntimePtyTransport(runtimeEnvironmentId, transportOptions)
+        : createIpcPtyTransport(transportOptions)
   const canSendDesktopQueryReply = (): boolean => {
     const ptyId = transport.getPtyId()
     return !ptyId || !isPtyLocked(ptyId)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -40,6 +40,7 @@ import { toAgentLaunchPreferences } from '@/runtime/agent-session-create-operati
 import { createUnresolvedOwnerPtyTransport } from './unresolved-owner-pty-transport'
 import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
 import { getConnectionId } from '@/lib/connection-context'
+import { recordTerminalTabParkedOnUnresolvedHost } from '@/lib/parked-terminal-host-hydration'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import {
   getCachedWindowsTerminalCapabilities,
@@ -3534,6 +3535,11 @@ export function connectPanePty(
           }
         }
       : {})
+  }
+  if (connectionOwnerHydrating) {
+    // Why: this pane holds an inert transport until its host resolves; register it so
+    // the repos:changed handler remounts it instead of leaving the terminal blank.
+    recordTerminalTabParkedOnUnresolvedHost(deps.worktreeId, deps.tabId)
   }
   const transport =
     terminalOwnerUnresolved || connectionOwnerHydrating

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -7885,3 +7885,91 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(setAgentStatus).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('parked terminal recovery on repos:changed', () => {
+  it('remounts a pane that parked on an unresolved host once repos hydrate', async () => {
+    vi.resetModules()
+    const remountTerminalTabForRecovery = vi.fn(() => true)
+    let reposChangedListener: (() => void) | undefined
+
+    const state = {
+      settings: { activeRuntimeEnvironmentId: null },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      worktreesByRepo: { repo1: [{ id: 'wt-1', repoId: 'repo1' }] },
+      folderWorkspaces: [],
+      projectGroups: [],
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      ptyIdsByTabId: {},
+      remountTerminalTabForRecovery,
+      fetchRepos: vi.fn(() => Promise.resolve()),
+      fetchProjectGroups: vi.fn(() => Promise.resolve()),
+      fetchFolderWorkspaces: vi.fn(() => Promise.resolve())
+    }
+
+    vi.doMock('react', async () => {
+      const actual = await vi.importActual<typeof ReactModule>('react')
+      return { ...actual, useEffect: (effect: () => void | (() => void)) => void effect() }
+    })
+    vi.doMock('../store', () => ({
+      useAppStore: { subscribe: vi.fn(() => () => {}), getState: () => state }
+    }))
+    // Why: this hook registers dozens of IPC namespaces at mount; auto-stub every
+    // unspecified listener so the test asserts the repos:changed wiring, not the mock surface.
+    const noopListener = (): (() => void) => () => {}
+    const autoStubNamespace = new Proxy(
+      {},
+      {
+        get:
+          () =>
+          (...args: unknown[]) => {
+            const maybeCallback = args[0]
+            if (typeof maybeCallback === 'function') {
+              return noopListener()
+            }
+            // Why: a resolving promise would run the hook's .then() handlers against
+            // store setters this test does not model, surfacing as unhandled rejections
+            // that Vitest flags as possible false positives. A pending promise leaves
+            // those unrelated paths dormant.
+            return new Promise(() => {})
+          }
+      }
+    )
+    const api = new Proxy(
+      {
+        repos: {
+          onChanged: (cb: () => void) => {
+            reposChangedListener = cb
+            return () => {}
+          }
+        }
+      } as Record<string, unknown>,
+      {
+        get: (target, prop: string) => target[prop] ?? autoStubNamespace
+      }
+    )
+    vi.stubGlobal('window', { api })
+
+    const { recordTerminalTabParkedOnUnresolvedHost, clearTerminalTabsParkedOnUnresolvedHost } =
+      await import('@/lib/parked-terminal-host-hydration')
+    clearTerminalTabsParkedOnUnresolvedHost()
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    expect(reposChangedListener).toBeDefined()
+
+    // No parked pane yet: a refresh must not remount anything.
+    reposChangedListener?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(remountTerminalTabForRecovery).not.toHaveBeenCalled()
+
+    // The pane parks (its repo row had not merged when it mounted), then repos land.
+    recordTerminalTabParkedOnUnresolvedHost('wt-1', 'tab-1')
+    reposChangedListener?.()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(remountTerminalTabForRecovery).toHaveBeenCalledWith('tab-1')
+    clearTerminalTabsParkedOnUnresolvedHost()
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '../store'
 import { shouldRetryPaneSpawnOnSshReconnect } from './ssh-reconnect-pane-retry'
+import { getTabIdsAwaitingHostHydrationRemount } from '@/lib/parked-terminal-host-hydration'
 import { applyWorktreeHeadIdentities } from './worktree-head-identity-apply'
 import { getWorktreeMapFromState, getRepoMapFromState } from '@/store/selectors'
 import { applyUIZoom } from '@/lib/ui-zoom'
@@ -730,6 +731,14 @@ function isRuntimeEnvironmentActive(): boolean {
   return Boolean(useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim())
 }
 
+/** Remount panes that parked with no PTY while their owning host was unknown. */
+function remountTerminalTabsAwaitingHostHydration(): void {
+  const store = useAppStore.getState()
+  for (const tabId of getTabIdsAwaitingHostHydrationRemount(store)) {
+    store.remountTerminalTabForRecovery(tabId)
+  }
+}
+
 function getActiveRuntimeEnvironmentId(): string | null {
   return useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
 }
@@ -1126,12 +1135,13 @@ export function useIpcEvents(): void {
             await state.fetchReposForAllHosts()
             await state.fetchProjectGroupsForAllHosts()
             await state.fetchFolderWorkspacesForAllHosts()
+            remountTerminalTabsAwaitingHostHydration()
           })()
           return
         }
         void state.fetchProjectGroups()
         void state.fetchFolderWorkspaces()
-        void state.fetchRepos()
+        void state.fetchRepos().then(remountTerminalTabsAwaitingHostHydration)
       })
     )
 

--- a/src/renderer/src/lib/parked-terminal-host-hydration.test.ts
+++ b/src/renderer/src/lib/parked-terminal-host-hydration.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import { getTabIdsAwaitingHostHydrationRemount } from './parked-terminal-host-hydration'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearTerminalTabsParkedOnUnresolvedHost,
+  getTabIdsAwaitingHostHydrationRemount,
+  recordTerminalTabParkedOnUnresolvedHost
+} from './parked-terminal-host-hydration'
 
 const baseState = {
   folderWorkspaces: [],
@@ -10,34 +14,59 @@ const baseState = {
   ptyIdsByTabId: {}
 }
 
+beforeEach(() => {
+  clearTerminalTabsParkedOnUnresolvedHost()
+})
+
 describe('getTabIdsAwaitingHostHydrationRemount', () => {
-  it('remounts a PTY-less tab once its owning host is known', () => {
+  it('remounts a parked tab once its owning host is known', () => {
+    recordTerminalTabParkedOnUnresolvedHost('wt-1', 'tab-1')
     expect(getTabIdsAwaitingHostHydrationRemount(baseState as never)).toEqual(['tab-1'])
   })
 
-  it('leaves tabs alone while the owner is still unresolved', () => {
-    // repos: [] → getConnectionIdFromState returns undefined, the same state the
-    // pane already parked on, so remounting would just re-park it in a loop.
-    const state = { ...baseState, repos: [] }
-    expect(getTabIdsAwaitingHostHydrationRemount(state as never)).toEqual([])
+  it('ignores tabs that never parked', () => {
+    // A tab whose shell merely exited also has no PTY; remounting it on every
+    // repos:changed would churn a terminal the user is looking at.
+    expect(getTabIdsAwaitingHostHydrationRemount(baseState as never)).toEqual([])
   })
 
-  it('does not disturb a tab that already holds a PTY', () => {
-    const state = {
+  it('remounts a parked tab only once per park', () => {
+    recordTerminalTabParkedOnUnresolvedHost('wt-1', 'tab-1')
+    expect(getTabIdsAwaitingHostHydrationRemount(baseState as never)).toEqual(['tab-1'])
+    // repos:changed fires repeatedly; the second pass must not remount again.
+    expect(getTabIdsAwaitingHostHydrationRemount(baseState as never)).toEqual([])
+  })
+
+  it('keeps a parked tab pending while the owner is still unresolved', () => {
+    recordTerminalTabParkedOnUnresolvedHost('wt-1', 'tab-1')
+    const unresolved = { ...baseState, repos: [] }
+    expect(getTabIdsAwaitingHostHydrationRemount(unresolved as never)).toEqual([])
+    // Once the repo lands, the still-parked tab is recovered.
+    expect(getTabIdsAwaitingHostHydrationRemount(baseState as never)).toEqual(['tab-1'])
+  })
+
+  it('drops a parked tab that acquired a PTY by other means', () => {
+    recordTerminalTabParkedOnUnresolvedHost('wt-1', 'tab-1')
+    const withPty = {
       ...baseState,
       tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'ssh:conn-1@@pty-1' }] }
     }
-    expect(getTabIdsAwaitingHostHydrationRemount(state as never)).toEqual([])
+    expect(getTabIdsAwaitingHostHydrationRemount(withPty as never)).toEqual([])
   })
 
-  it('does not remount a tab whose PTY is tracked only by live id', () => {
-    // A freshly spawned pane can publish into ptyIdsByTabId before the tab row
-    // carries the id; remounting there would kill a healthy terminal.
+  it('does not remount a parked tab whose PTY is tracked only by live id', () => {
+    recordTerminalTabParkedOnUnresolvedHost('wt-1', 'tab-1')
     const state = { ...baseState, ptyIdsByTabId: { 'tab-1': ['pty-1'] } }
     expect(getTabIdsAwaitingHostHydrationRemount(state as never)).toEqual([])
   })
 
-  it('remounts local worktrees too, not just SSH ones', () => {
+  it('forgets a parked tab that was closed before its host resolved', () => {
+    recordTerminalTabParkedOnUnresolvedHost('wt-1', 'tab-gone')
+    expect(getTabIdsAwaitingHostHydrationRemount(baseState as never)).toEqual([])
+  })
+
+  it('recovers local worktrees too, not just SSH ones', () => {
+    recordTerminalTabParkedOnUnresolvedHost('wt-1', 'tab-1')
     const state = { ...baseState, repos: [{ id: 'repo1', connectionId: null }] }
     expect(getTabIdsAwaitingHostHydrationRemount(state as never)).toEqual(['tab-1'])
   })

--- a/src/renderer/src/lib/parked-terminal-host-hydration.test.ts
+++ b/src/renderer/src/lib/parked-terminal-host-hydration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { getTabIdsAwaitingHostHydrationRemount } from './parked-terminal-host-hydration'
+
+const baseState = {
+  folderWorkspaces: [],
+  projectGroups: [],
+  repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+  worktreesByRepo: { repo1: [{ id: 'wt-1', repoId: 'repo1' }] },
+  tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+  ptyIdsByTabId: {}
+}
+
+describe('getTabIdsAwaitingHostHydrationRemount', () => {
+  it('remounts a PTY-less tab once its owning host is known', () => {
+    expect(getTabIdsAwaitingHostHydrationRemount(baseState as never)).toEqual(['tab-1'])
+  })
+
+  it('leaves tabs alone while the owner is still unresolved', () => {
+    // repos: [] → getConnectionIdFromState returns undefined, the same state the
+    // pane already parked on, so remounting would just re-park it in a loop.
+    const state = { ...baseState, repos: [] }
+    expect(getTabIdsAwaitingHostHydrationRemount(state as never)).toEqual([])
+  })
+
+  it('does not disturb a tab that already holds a PTY', () => {
+    const state = {
+      ...baseState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'ssh:conn-1@@pty-1' }] }
+    }
+    expect(getTabIdsAwaitingHostHydrationRemount(state as never)).toEqual([])
+  })
+
+  it('does not remount a tab whose PTY is tracked only by live id', () => {
+    // A freshly spawned pane can publish into ptyIdsByTabId before the tab row
+    // carries the id; remounting there would kill a healthy terminal.
+    const state = { ...baseState, ptyIdsByTabId: { 'tab-1': ['pty-1'] } }
+    expect(getTabIdsAwaitingHostHydrationRemount(state as never)).toEqual([])
+  })
+
+  it('remounts local worktrees too, not just SSH ones', () => {
+    const state = { ...baseState, repos: [{ id: 'repo1', connectionId: null }] }
+    expect(getTabIdsAwaitingHostHydrationRemount(state as never)).toEqual(['tab-1'])
+  })
+})

--- a/src/renderer/src/lib/parked-terminal-host-hydration.ts
+++ b/src/renderer/src/lib/parked-terminal-host-hydration.ts
@@ -4,8 +4,25 @@ import type { AppState } from '@/store/types'
 type ParkedPaneHostState = Parameters<typeof getConnectionIdFromState>[0] &
   Pick<AppState, 'tabsByWorktree' | 'ptyIdsByTabId'>
 
+// Why: only panes that actually parked on the unresolved-host guard may be
+// remounted. Keying off "tab has no PTY" instead would also churn tabs whose
+// shell merely exited, remounting them on every repos:changed.
+const parkedTabIdsByWorktreeId = new Map<string, Set<string>>()
+
+/** Record that a pane withheld its spawn because its worktree had no known host. */
+export function recordTerminalTabParkedOnUnresolvedHost(worktreeId: string, tabId: string): void {
+  const parked = parkedTabIdsByWorktreeId.get(worktreeId) ?? new Set<string>()
+  parked.add(tabId)
+  parkedTabIdsByWorktreeId.set(worktreeId, parked)
+}
+
+/** Test seam: drop all parked bookkeeping. */
+export function clearTerminalTabsParkedOnUnresolvedHost(): void {
+  parkedTabIdsByWorktreeId.clear()
+}
+
 /**
- * Tabs parked with no PTY on a worktree whose owning host has since hydrated.
+ * Parked tabs whose owning host has since hydrated, consumed as they are returned.
  *
  * connectPanePty withholds the spawn while a repo-backed worktree has no known
  * host, so those panes hold an inert transport until something remounts them.
@@ -15,21 +32,27 @@ type ParkedPaneHostState = Parameters<typeof getConnectionIdFromState>[0] &
  */
 export function getTabIdsAwaitingHostHydrationRemount(state: ParkedPaneHostState): string[] {
   const remountable: string[] = []
-  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree ?? {})) {
-    if (tabs.length === 0) {
-      continue
-    }
+  for (const [worktreeId, parkedTabIds] of parkedTabIdsByWorktreeId) {
     // Why: undefined means the owner is still unresolved, which is the state the
-    // pane already parked on; only a now-known host warrants a remount.
+    // pane already parked on; remounting would just re-park it in a loop.
     if (getConnectionIdFromState(state, worktreeId) === undefined) {
       continue
     }
-    for (const tab of tabs) {
-      const hasLivePty = (state.ptyIdsByTabId?.[tab.id]?.length ?? 0) > 0
-      if (!tab.ptyId && !hasLivePty) {
-        remountable.push(tab.id)
+    const tabs = state.tabsByWorktree?.[worktreeId] ?? []
+    for (const tabId of parkedTabIds) {
+      const tab = tabs.find((candidate) => candidate.id === tabId)
+      const hasLivePty = (state.ptyIdsByTabId?.[tabId]?.length ?? 0) > 0
+      // Remount only a tab that still exists and still has no PTY. Either way the
+      // entry is consumed below: a closed tab is gone, and one that acquired a PTY
+      // by other means is no longer parked.
+      if (tab && !tab.ptyId && !hasLivePty) {
+        remountable.push(tabId)
       }
     }
+    // Why: consume every entry so a remount is attempted once per park. If the
+    // retry parks again it re-registers, so this cannot spin on repeated
+    // repos:changed events. Cleared after iterating to avoid mutating the live Set.
+    parkedTabIdsByWorktreeId.delete(worktreeId)
   }
   return remountable
 }

--- a/src/renderer/src/lib/parked-terminal-host-hydration.ts
+++ b/src/renderer/src/lib/parked-terminal-host-hydration.ts
@@ -1,0 +1,35 @@
+import { getConnectionIdFromState } from './connection-owner-resolution'
+import type { AppState } from '@/store/types'
+
+type ParkedPaneHostState = Parameters<typeof getConnectionIdFromState>[0] &
+  Pick<AppState, 'tabsByWorktree' | 'ptyIdsByTabId'>
+
+/**
+ * Tabs parked with no PTY on a worktree whose owning host has since hydrated.
+ *
+ * connectPanePty withholds the spawn while a repo-backed worktree has no known
+ * host, so those panes hold an inert transport until something remounts them.
+ * Nothing else bumps their generation — an SSH state change only covers tabs on
+ * a connected target, so a pane parked before its repo row merged would sit
+ * inert until the user reopened it.
+ */
+export function getTabIdsAwaitingHostHydrationRemount(state: ParkedPaneHostState): string[] {
+  const remountable: string[] = []
+  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree ?? {})) {
+    if (tabs.length === 0) {
+      continue
+    }
+    // Why: undefined means the owner is still unresolved, which is the state the
+    // pane already parked on; only a now-known host warrants a remount.
+    if (getConnectionIdFromState(state, worktreeId) === undefined) {
+      continue
+    }
+    for (const tab of tabs) {
+      const hasLivePty = (state.ptyIdsByTabId?.[tab.id]?.length ?? 0) > 0
+      if (!tab.ptyId && !hasLivePty) {
+        remountable.push(tab.id)
+      }
+    }
+  }
+  return remountable
+}

--- a/tests/e2e/helpers/docker-ssh-relay-connection.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-connection.ts
@@ -64,17 +64,58 @@ export async function connectDockerSshRelayTarget(
         if ('error' in result) {
           throw new Error(result.error)
         }
+        // Why: fetchRepos is generation-gated and can drop a stale refresh that
+        // races this add; without the repo row, terminal spawn fails open to local
+        // with the remote Docker cwd and never binds a PTY.
         await store.getState().fetchRepos()
+        if (!store.getState().repos.some((repo) => repo.id === result.repo.id)) {
+          store.setState((state) => ({
+            repos: state.repos.some((repo) => repo.id === result.repo.id)
+              ? state.repos
+              : [...state.repos, result.repo]
+          }))
+        }
         await store.getState().fetchWorktrees(result.repo.id)
         const worktree = (store.getState().worktreesByRepo[result.repo.id] ?? [])[0]
         if (!worktree) {
           throw new Error(`No remote worktree found for ${result.repo.path}`)
+        }
+        // Why: pane routing needs a hydrated connectionId before spawn; wait so a
+        // late repo merge cannot leave the terminal on an unresolved owner transport.
+        const deadline = Date.now() + 15_000
+        while (Date.now() < deadline) {
+          const connectionId = store
+            .getState()
+            .repos.find((repo) => repo.id === result.repo.id)?.connectionId
+          if (connectionId === createdTarget.id) {
+            break
+          }
+          await new Promise((resolve) => setTimeout(resolve, 25))
+        }
+        const hydratedConnectionId = store
+          .getState()
+          .repos.find((repo) => repo.id === result.repo.id)?.connectionId
+        if (hydratedConnectionId !== createdTarget.id) {
+          throw new Error(
+            `Remote repo ${result.repo.id} never hydrated with connectionId ${createdTarget.id}`
+          )
         }
         store.getState().setActiveWorktree(worktree.id)
         if ((store.getState().tabsByWorktree[worktree.id] ?? []).length === 0) {
           store.getState().createTab(worktree.id)
         }
         store.getState().setActiveTabType('terminal')
+        // Why: a pane that mounted during hydration used the unresolved-owner
+        // transport; bump generation so TerminalPane remounts with SSH routing.
+        store.setState((state) => ({
+          tabsByWorktree: {
+            ...state.tabsByWorktree,
+            [worktree.id]: (state.tabsByWorktree[worktree.id] ?? []).map((tab) => ({
+              ...tab,
+              generation: (tab.generation ?? 0) + 1
+            }))
+          }
+        }))
         return {
           targetId: createdTarget.id,
           repoId: result.repo.id,

--- a/tests/e2e/helpers/docker-ssh-relay-connection.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-connection.ts
@@ -64,58 +64,17 @@ export async function connectDockerSshRelayTarget(
         if ('error' in result) {
           throw new Error(result.error)
         }
-        // Why: fetchRepos is generation-gated and can drop a stale refresh that
-        // races this add; without the repo row, terminal spawn fails open to local
-        // with the remote Docker cwd and never binds a PTY.
         await store.getState().fetchRepos()
-        if (!store.getState().repos.some((repo) => repo.id === result.repo.id)) {
-          store.setState((state) => ({
-            repos: state.repos.some((repo) => repo.id === result.repo.id)
-              ? state.repos
-              : [...state.repos, result.repo]
-          }))
-        }
         await store.getState().fetchWorktrees(result.repo.id)
         const worktree = (store.getState().worktreesByRepo[result.repo.id] ?? [])[0]
         if (!worktree) {
           throw new Error(`No remote worktree found for ${result.repo.path}`)
-        }
-        // Why: pane routing needs a hydrated connectionId before spawn; wait so a
-        // late repo merge cannot leave the terminal on an unresolved owner transport.
-        const deadline = Date.now() + 15_000
-        while (Date.now() < deadline) {
-          const connectionId = store
-            .getState()
-            .repos.find((repo) => repo.id === result.repo.id)?.connectionId
-          if (connectionId === createdTarget.id) {
-            break
-          }
-          await new Promise((resolve) => setTimeout(resolve, 25))
-        }
-        const hydratedConnectionId = store
-          .getState()
-          .repos.find((repo) => repo.id === result.repo.id)?.connectionId
-        if (hydratedConnectionId !== createdTarget.id) {
-          throw new Error(
-            `Remote repo ${result.repo.id} never hydrated with connectionId ${createdTarget.id}`
-          )
         }
         store.getState().setActiveWorktree(worktree.id)
         if ((store.getState().tabsByWorktree[worktree.id] ?? []).length === 0) {
           store.getState().createTab(worktree.id)
         }
         store.getState().setActiveTabType('terminal')
-        // Why: a pane that mounted during hydration used the unresolved-owner
-        // transport; bump generation so TerminalPane remounts with SSH routing.
-        store.setState((state) => ({
-          tabsByWorktree: {
-            ...state.tabsByWorktree,
-            [worktree.id]: (state.tabsByWorktree[worktree.id] ?? []).map((tab) => ({
-              ...tab,
-              generation: (tab.generation ?? 0) + 1
-            }))
-          }
-        }))
         return {
           targetId: createdTarget.id,
           repoId: result.repo.id,


### PR DESCRIPTION
## Summary
Fixes the release-gate failure in [run 30194699449](https://github.com/stablyai/orca/actions/runs/30194699449), where `ssh-docker-watcher-isolation` timed out on `Active terminal pane did not receive a PTY binding`.

**Root cause, in two halves.** A remote worktree whose repo row hadn't hydrated resolved to a `null` connectionId, so the terminal spawned through the **local** daemon with a container-only cwd (`/tmp/orca-docker-relay-perf-repo`) and died on ENOENT. Withholding that spawn fixes the wrong-host PTY but is only half the bug: nothing then remounted the pane once the repo row merged, so the terminal still never opened.

Separately, SSH PTY notification routing mapped `params.id` **before** filtering methods, so `workspace.changed` / `fs.changed` (which carry no `id`) threw `Cannot read properties of undefined (reading 'startsWith')` on every relay notification.

## Changes
- **`pty-connection.ts`** — fail closed while a repo-backed worktree's host is unknown, instead of coalescing `undefined` to local. Host-agnostic ids (floating terminal, inline setup panels) and worktrees whose own `hostId` proves local keep their existing paths.
- **`parked-terminal-host-hydration.ts`** (new) — track panes that withheld their spawn; `useIpcEvents` remounts them on `repos:changed` once their owner resolves. Entries are consumed once per park, so recovery cannot churn a live terminal or spin on repeated refreshes.
- **`ssh-pty-notification-routing.ts`** — allowlist `pty.exit` / `pty.data` / `pty.replay`, then validate the id before mapping.

## Verification note
An earlier revision also changed the e2e helper to wait for hydrated state. Reverting *only* that helper showed the test still failed — proving the green run was carried by the test, not the fix, and exposing the missing remount above. **The helper change is fully reverted** (`git diff main -- tests/e2e/` is empty): the suite now passes against the original helper, exercising the real race.

## Test plan
- [x] `vitest terminal-pane/ lib/ hooks/ providers/` → 6510 passed
- [x] `pnpm run test:e2e:ssh-docker-watcher-isolation` → 2 passed **with the unmodified helper**
- [x] New coverage: notification routing (4), hydration guard, local-stamped worktree, parked-pane recovery (8, incl. must-not-remount and consume-once), and the `repos:changed` wiring itself

## Regressions caught during review
Three, all in my own patches, all fixed before merge:
1. **Inline setup terminals failed closed** (regressing #10151) — caught by CI's `verify` on an existing test; they have no repo row by design.
2. **Local worktrees stamped `hostId: 'local'`** were also over-blocked — no test covered it; found by probing the guard directly.
3. **Remount churn** — the first recovery keyed off "tab has no PTY", which also matched tabs whose shell merely exited, remounting them on every `repos:changed`.
