### PR TITLE
perf(ai-vault): keep the JSONL line carry linear

### DIFF
--- a/src/main/ai-vault/session-scanner-parse-cache.test.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.test.ts
@@ -128,6 +128,45 @@ describe('parseAgentSessionFileCached', () => {
     expect(incremental?.totalTokens).toBe(420)
   })
 
+  it('parses an oversized record without quadratic carry copying', async () => {
+    const root = await makeTempDir()
+    const path = join(root, 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee.jsonl')
+    // One tool result far larger than a stream chunk. Re-joining the held-over
+    // partial line per chunk copies O(record^2); the piece list joins once.
+    const recordBytes = 4 * 1024 * 1024
+    await writeFile(
+      path,
+      `${[
+        userRecord(0, 'question'),
+        assistantRecord(1, 'x'.repeat(recordBytes)),
+        assistantRecord(2, 'tail answer')
+      ].join('\n')}\n`
+    )
+
+    const originalConcat = Buffer.concat
+    let concatenatedBytes = 0
+    Buffer.concat = ((list: readonly Uint8Array[], totalLength?: number) => {
+      const joined = originalConcat(list as Uint8Array[], totalLength)
+      concatenatedBytes += joined.length
+      return joined
+    }) as typeof Buffer.concat
+    try {
+      const stats = createSessionParseStats()
+      const parsed = await parseAgentSessionFileCached(
+        await claudeCandidate(path),
+        process.platform,
+        stats
+      )
+      expect(parsed).not.toBeNull()
+    } finally {
+      Buffer.concat = originalConcat
+    }
+
+    // Linear joins the record about once; the quadratic form copied many times
+    // that, growing with the square of the record size.
+    expect(concatenatedBytes).toBeLessThan(recordBytes * 4)
+  })
+
   it('shows a trailing unterminated line without double-counting it later', async () => {
     const root = await makeTempDir()
     const path = join(root, 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee.jsonl')

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -311,12 +311,28 @@ async function consumeCompleteJsonlLines(args: {
 }): Promise<JsonlReadResult> {
   let consumedThrough = args.start
   let bytesRead = 0
-  let remainder: Buffer | null = null
+  // Why a piece list: re-joining the partial line with every chunk made one
+  // oversized record (a big tool result) cost O(record^2). Joining once, when a
+  // newline finally arrives, keeps it linear.
+  let remainderParts: Buffer[] = []
+  let remainderLength = 0
 
   const stream = createReadStream(args.path, { start: args.start })
   for await (const chunk of stream as AsyncIterable<Buffer>) {
     bytesRead += chunk.length
-    const data = remainder ? Buffer.concat([remainder, chunk]) : chunk
+    // Why check the chunk alone: the pieces held over are all mid-line, so none
+    // of them contains a newline.
+    if (!chunk.includes(NEWLINE_BYTE)) {
+      remainderParts.push(chunk)
+      remainderLength += chunk.length
+      continue
+    }
+    const data =
+      remainderLength > 0
+        ? Buffer.concat([...remainderParts, chunk], remainderLength + chunk.length)
+        : chunk
+    remainderParts = []
+    remainderLength = 0
     let lineStart = 0
     let newlineIndex = data.indexOf(NEWLINE_BYTE, lineStart)
     while (newlineIndex !== -1) {
@@ -329,13 +345,19 @@ async function consumeCompleteJsonlLines(args: {
       newlineIndex = data.indexOf(NEWLINE_BYTE, lineStart)
     }
     consumedThrough += lineStart
-    // Copy the tail so retaining it doesn't pin the whole chunk buffer.
-    remainder = lineStart < data.length ? Buffer.from(data.subarray(lineStart)) : null
+    if (lineStart < data.length) {
+      // Copy the tail so retaining it doesn't pin the whole chunk buffer.
+      remainderParts = [Buffer.from(data.subarray(lineStart))]
+      remainderLength = data.length - lineStart
+    }
   }
+
+  const trailingPartialLine =
+    remainderLength > 0 ? Buffer.concat(remainderParts, remainderLength).toString('utf-8') : null
 
   return {
     consumedThrough,
-    trailingPartialLine: remainder && remainder.length > 0 ? remainder.toString('utf-8') : null,
+    trailingPartialLine,
     bytesRead
   }
 }


### PR DESCRIPTION
## Summary

`consumeCompleteJsonlLines` re-joined its held-over partial line with **every** stream chunk, so one oversized JSONL record — a large tool result — cost **O(record²)**.

It backs `parseResumableCandidate`, the incremental-parse path for every resumable agent transcript (claude, codex, cursor, copilot, droid, gemini-jsonl, antigravity), so the whole AI Vault corpus paid it.

This is the same defect class as #10742 and #10777, found by sweeping for the pattern after those landed. Third and final site.

## ELI5

Session transcripts are read in 64 KB chunks, and a chunk usually ends mid-line. So the reader holds that partial line aside and glues it onto the next chunk.

When a single record is enormous — an agent pasting in a whole file it just read — that line spans *many* chunks. The old code **rebuilt the entire held-aside pile on every chunk**: glue 64 KB, then re-glue 128 KB, then 192 KB, and so on. The work grew with the square of the record.

Now it keeps the pieces in a list and glues them once, when a newline finally shows up.

## Screenshots

No visual change.

## Proof of performance improvement

Transcript with one oversized record, measured against the real streaming reader:

| record size | before | after | speedup |
|---|---|---|---|
| 1 MB | 1.29 ms | 0.40 ms | 3.22× |
| 3 MB | 5.36 ms | 1.27 ms | 4.22× |
| 5 MB | 12.63 ms | 2.79 ms | 4.53× |
| 8 MB | 35.35 ms | 3.16 ms | **11.20×** |
| **control: no oversized record** | 1.83 ms | 1.85 ms | **0.99×** |

**The widening ratio is the point** — a constant-factor win holds its ratio; this grows with the record, because the number of re-copies does. The control row matters just as much: a transcript of ordinary records never enters the new branch, so there is no cost to the common case.

Every row asserts byte-identical output (`consumedThrough`, `bytesRead`, and line count all match) before timing.

## Proof of zero regression

Behaviour is unchanged — same lines, same byte offsets, same trailing-partial-line handling. Only the copying strategy differs.

The byte-offset contract is the sensitive part: `consumedThrough` must count **bytes, not decoded characters**, so a resumed read starts exactly where the last complete line ended. That arithmetic is untouched; the pieces are joined into the same `data` buffer the old code built, and offsets are computed from it identically.

**Regression test** parses a transcript with a 4 MB record and asserts it still resolves.

A wall-clock threshold was the wrong instrument — the absolute times here are small enough that timing is flaky in CI. The test **counts bytes copied** through `Buffer.concat`, which is deterministic:

- linear (fixed): comfortably under the `recordBytes * 4` budget
- quadratic (mutant): **140,432,195 bytes against a 16,777,216 budget** — fails by 8.4×

I verified that by reintroducing the quadratic form and watching the test fail.

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — **209/209** across `src/main/ai-vault/`; full suite **2 failures / 36,928**, both pre-existing
- [x] Added a test that would catch the regression

### Pre-existing test failures

`pnpm test` is already red on `main`. This run shows **only** `agent-exec-handler.test.ts` ×2, which assert against the machine's real `process.env` — the cleanest run of this series, and a strict subset of the known baseline pool. Neither imports the changed code.

## Review loop count + verdict

**2 review loops: independent re-measurement and final risk review. Final verdict: ship.**

Found by a targeted sweep for the #10742 pattern. The automated verifier for this candidate hit an API error mid-run, so **I measured it independently myself** rather than accept the claim — the numbers above are my own, not the finder's.

The same sweep **rejected** a second same-pattern site with numbers rather than reporting it: `scrcpy-stream-session.ts` re-concatenates `pendingVideo` per socket chunk, which is genuinely the same shape, but at the shipped `max_size=1280` default frames are ~33 KB and the win is ~90 µs per *second* of streaming. It only reaches 9.75× at 512 KB frames, which that configuration never emits. Not worth a PR; recorded here in case the default changes.

## AI Review Report

Risks reviewed:

- **Byte-offset drift.** The highest-risk property, since a wrong `consumedThrough` would make a resumed parse skip or duplicate records. Pieces are joined into the same buffer shape the old path built, and `lineStart` arithmetic is unchanged — confirmed by output equality across all measured sizes and by the existing incremental-parse and truncation tests (`incrementally parses appended lines and matches a cold parse exactly`, `falls back to a full parse when the file is truncated`, `detects a grown rewrite via the resume-point newline guard`).
- **CRLF handling.** Untouched — the `CARRIAGE_RETURN_BYTE` trim still runs against the joined buffer, and `parses CRLF transcripts identically to the streaming parser` still passes. Relevant on Windows.
- **Trailing partial line.** Now joined from the piece list at the end rather than held as a single buffer; returns the same string, including when the file ends mid-record.
- **Chunk-buffer retention.** The original copied the tail with `Buffer.from(...)` so a retained remainder would not pin the whole chunk. That copy is preserved.

Cross-platform: no path, shell, or platform-dependent behaviour touched. Works identically for local, SSH, WSL, and remote hosts, and for folder workspaces as well as git worktrees.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or IPC surface. Transcript paths still arrive through the same scanner and the same stream API. This change **reduces** the memory a maliciously oversized record can cause to be copied — from O(record²) to O(record) — so it narrows rather than widens the exposure to a hostile transcript. No dependency changes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
