### PR TITLE
Fix SSH directory browsing fallback on POSIX hosts

### DIFF
--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -68,7 +68,9 @@ describe('registerSshBrowseHandler', () => {
         { name: 'README.md', isDirectory: false }
       ]
     })
-    expect(exec).toHaveBeenCalledWith('cd "$HOME" && pwd && command ls -1Ap')
+    expect(exec).toHaveBeenCalledWith(
+      `printf '%s\\n' '__ORCA_POSIX_BROWSE__' >&2 && cd "$HOME" && pwd && command ls -1Ap`
+    )
     expect(channel.listenerCount('data')).toBe(0)
     expect(channel.listenerCount('exit')).toBe(0)
     expect(channel.listenerCount('close')).toBe(0)
@@ -95,7 +97,9 @@ describe('registerSshBrowseHandler', () => {
       resolvedPath: "/tmp/it's here",
       entries: []
     })
-    expect(exec).toHaveBeenCalledWith("cd '/tmp/it'\\''s here' && pwd && command ls -1Ap")
+    expect(exec).toHaveBeenCalledWith(
+      "printf '%s\\n' '__ORCA_POSIX_BROWSE__' >&2 && cd '/tmp/it'\\''s here' && pwd && command ls -1Ap"
+    )
   })
 
   it('falls back to PowerShell when a Windows SSH shell rejects POSIX exec', async () => {
@@ -134,7 +138,10 @@ describe('registerSshBrowseHandler', () => {
       ]
     })
     expect(exec).toHaveBeenCalledTimes(2)
-    expect(exec).toHaveBeenNthCalledWith(1, "cd 'C:/Users/alice' && pwd && command ls -1Ap")
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
+      "printf '%s\\n' '__ORCA_POSIX_BROWSE__' >&2 && cd 'C:/Users/alice' && pwd && command ls -1Ap"
+    )
     expect(exec.mock.calls[1]?.[0]).toMatch(/^powershell\.exe /)
     expect(exec.mock.calls[1]?.[1]).toEqual({ wrapCommand: false })
 
@@ -285,10 +292,9 @@ describe('registerSshBrowseHandler', () => {
     }
   )
 
-  it('surfaces the original POSIX failure when the PowerShell retry shows the host is not Windows', async () => {
+  it('does not try PowerShell after the POSIX shell started', async () => {
     const posixChannel = createMockChannel()
-    const windowsChannel = createMockChannel()
-    const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
+    const exec = vi.fn().mockResolvedValueOnce(posixChannel)
     const getConnectionManager = () => ({
       getConnection: () => ({ exec })
     })
@@ -296,22 +302,16 @@ describe('registerSshBrowseHandler', () => {
 
     const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '/root/secret' })
     await Promise.resolve()
-    // A genuine POSIX permission failure exits non-zero; it's indistinguishable
-    // from a Windows shell reject without probing, so the fallback is attempted...
-    posixChannel.stderr.emit('data', Buffer.from('ls: /root/secret: Permission denied'))
+    posixChannel.stderr.emit(
+      'data',
+      Buffer.from('__ORCA_POSIX_BROWSE__\nls: /root/secret: Permission denied')
+    )
     posixChannel.emit('exit', 1)
     posixChannel.emit('close')
-    await vi.waitFor(() => {
-      expect(windowsChannel.listenerCount('close')).toBe(1)
-    })
-    // ...but on a POSIX host the login shell can't find powershell.exe (exit 127),
-    // so the original permission error is surfaced, never masked by the retry.
-    windowsChannel.stderr.emit('data', Buffer.from('bash: powershell.exe: command not found'))
-    windowsChannel.emit('exit', 127)
-    windowsChannel.emit('close')
 
     await expect(resultPromise).rejects.toThrow('Permission denied')
-    expect(exec).toHaveBeenCalledTimes(2)
+    await expect(resultPromise).rejects.not.toThrow('__ORCA_POSIX_BROWSE__')
+    expect(exec).toHaveBeenCalledTimes(1)
   })
 
   it('surfaces the PowerShell error when the Windows fallback runs but fails', async () => {
@@ -340,7 +340,7 @@ describe('registerSshBrowseHandler', () => {
     await expect(resultPromise).rejects.toThrow('Cannot find path')
   })
 
-  it('surfaces the original POSIX error when the fallback shows powershell.exe is missing', async () => {
+  it('surfaces the original POSIX error when zsh rewrites the missing PowerShell exit', async () => {
     const posixChannel = createMockChannel()
     const windowsChannel = createMockChannel()
     const exec = vi.fn().mockResolvedValueOnce(posixChannel).mockResolvedValueOnce(windowsChannel)
@@ -358,8 +358,8 @@ describe('registerSshBrowseHandler', () => {
     await vi.waitFor(() => {
       expect(windowsChannel.listenerCount('close')).toBe(1)
     })
-    windowsChannel.stderr.emit('data', Buffer.from('sh: powershell.exe: not found'))
-    windowsChannel.emit('exit', 127)
+    windowsChannel.stderr.emit('data', Buffer.from('zsh:1: command not found: powershell.exe'))
+    windowsChannel.emit('exit', 1)
     windowsChannel.emit('close')
 
     // The original POSIX failure is the real one — don't mask it with the

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -9,15 +9,17 @@ export type RemoteDirEntry = {
 }
 
 const SSH_BROWSE_TIMEOUT_MS = 15_000
+const POSIX_BROWSE_MARKER = '__ORCA_POSIX_BROWSE__'
 
 // Why: 127 = POSIX "command not found" (locale-independent) — the Windows fallback never ran, so the original POSIX error is the real one.
 const POSIX_COMMAND_NOT_FOUND_EXIT = 127
 
-// Carries the raw exit code so the fallback can distinguish 127 (no powershell.exe → not Windows) from a genuine PowerShell error.
+// Carries the raw exit code so the fallback can distinguish a missing executable from a genuine PowerShell error.
 class RemoteBrowseError extends Error {
   constructor(
     message: string,
-    readonly exitCode: number | null
+    readonly exitCode: number | null,
+    readonly posixShellStarted = false
   ) {
     super(message)
     this.name = 'RemoteBrowseError'
@@ -48,15 +50,18 @@ export function registerSshBrowseHandler(
       try {
         return await browseWithPosixShell(conn, args.dirPath)
       } catch (posixError) {
-        // Why: only a RemoteBrowseError (ran, non-zero exit) signals a Windows shell; don't retry transport errors/timeouts as Windows.
+        // Why: transport errors/timeouts must not trigger a different command dialect.
         if (!(posixError instanceof RemoteBrowseError)) {
+          throw posixError
+        }
+        if (posixError.posixShellStarted) {
           throw posixError
         }
         try {
           return await browseWithWindowsPowerShell(conn, args.dirPath)
         } catch (fallbackError) {
-          // Why: exit 127 (no powershell.exe) → host isn't Windows, surface the original POSIX failure; otherwise PowerShell's own error is the real cause.
-          throw isPosixCommandNotFound(fallbackError) ? posixError : fallbackError
+          // Why: some SSH servers rewrite command-not-found to exit 1 or omit the status.
+          throw isPowerShellUnavailable(fallbackError) ? posixError : fallbackError
         }
       }
     }
@@ -69,8 +74,9 @@ function browseWithPosixShell(
   conn: SshBrowseConnection,
   dirPath: string
 ): Promise<{ entries: RemoteDirEntry[]; resolvedPath: string }> {
-  // Why: `command ls` skips aliases; `&&` makes a failing ls exit non-zero (not look empty); -1Ap = one-per-line + trailing / on dirs.
-  return runBrowseCommand(conn, `cd ${shellEscape(dirPath)} && pwd && command ls -1Ap`)
+  // Why: the stderr marker proves the POSIX shell started even when cd/ls fails.
+  const command = `printf '%s\\n' '${POSIX_BROWSE_MARKER}' >&2 && cd ${shellEscape(dirPath)} && pwd && command ls -1Ap`
+  return runBrowseCommand(conn, command)
 }
 
 function browseWithWindowsPowerShell(
@@ -168,18 +174,27 @@ async function runBrowseCommand(
       rejectOnce(error)
     }
     const onClose = (): void => {
+      const posixShellStarted = stderr
+        .split(/\r?\n/)
+        .some((line) => line.trim() === POSIX_BROWSE_MARKER)
+      const visibleStderr = stderr
+        .split(/\r?\n/)
+        .filter((line) => line.trim() !== POSIX_BROWSE_MARKER)
+        .join('\n')
+        .trim()
+
       // Why: a null exitCode (channel closed without exit status) isn't success; don't treat empty stdout as an empty dir.
       if (exitCode !== 0) {
         const msg =
-          stderr.trim() ||
+          visibleStderr ||
           (exitCode === null
             ? 'Remote listing failed (channel closed without exit status)'
             : `Remote listing failed (exit ${exitCode})`)
-        rejectOnce(new RemoteBrowseError(msg, exitCode))
+        rejectOnce(new RemoteBrowseError(msg, exitCode, posixShellStarted))
         return
       }
-      if (stderr.trim() && !stdout.trim()) {
-        rejectOnce(new Error(stderr.trim()))
+      if (visibleStderr && !stdout.trim()) {
+        rejectOnce(new Error(visibleStderr))
         return
       }
 
@@ -230,9 +245,18 @@ async function runBrowseCommand(
   })
 }
 
-// Why: exit 127 means powershell.exe wasn't found — the host isn't Windows, so surface the original POSIX failure instead.
-function isPosixCommandNotFound(error: unknown): boolean {
-  return error instanceof RemoteBrowseError && error.exitCode === POSIX_COMMAND_NOT_FOUND_EXIT
+function isPowerShellUnavailable(error: unknown): boolean {
+  if (!(error instanceof RemoteBrowseError)) {
+    return false
+  }
+  if (error.exitCode === POSIX_COMMAND_NOT_FOUND_EXIT) {
+    return true
+  }
+  const message = error.message.toLowerCase()
+  return (
+    message.includes('powershell.exe') &&
+    (message.includes('command not found') || message.includes('not found'))
+  )
 }
 
 // Why: single-quote to block shell injection; ~ needs $HOME since single quotes suppress tilde expansion.


### PR DESCRIPTION
## Summary

- mark successful POSIX shell startup before running the remote `cd`/`pwd`/`ls` sequence
- preserve POSIX directory-listing failures instead of retrying them through `powershell.exe`
- remove the internal shell marker from user-visible diagnostics
- recognize zsh `powershell.exe` command-not-found failures even when the SSH server reports exit code 1 instead of 127

## Root cause

The remote directory browser first executes a POSIX listing command and falls back to PowerShell for Windows OpenSSH hosts. The fallback was triggered for every `RemoteBrowseError`, including ordinary failures that occurred after a POSIX shell had already started, such as an inaccessible or invalid directory on a Debian host.

As a result, a genuine POSIX error could be replaced by a misleading message such as:

<img width="621" height="634" alt="CleanShot 2026-07-26 at 17 52 32" src="https://github.com/user-attachments/assets/63d2d22d-224f-4971-a76c-7001a5bcaf53" />

```text
zsh:1: command not found: powershell.exe
```

This made a macOS client connected to a Debian host appear to depend on PowerShell even though no Windows system was involved.

## Implementation

The POSIX browse command now writes a private marker to stderr before changing directories or invoking `ls`. If the listing later exits unsuccessfully and the marker was observed, the handler knows that the POSIX command dialect executed successfully and returns the original POSIX failure without attempting the Windows fallback.

The marker is stripped before diagnostics are surfaced, so users continue to receive only the actionable remote error. The PowerShell fallback remains available when the POSIX command wrapper never starts, preserving Windows OpenSSH support. The fallback error handling also accounts for SSH servers that rewrite command-not-found exit status 127 to 1.

## User impact

On macOS/Linux clients connected to POSIX SSH hosts, directory browsing no longer invokes `powershell.exe` after a normal remote path or permission failure. Users receive the real Debian/Linux/macOS error instead of an unrelated Windows-shell error. Windows SSH directory browsing retains its existing fallback behavior.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/ssh-browse.test.ts` — 14 tests passed
- `pnpm exec oxlint src/main/ipc/ssh-browse.ts src/main/ipc/ssh-browse.test.ts`
- `pnpm exec oxfmt --check src/main/ipc/ssh-browse.ts src/main/ipc/ssh-browse.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`

The regression coverage verifies that a confirmed POSIX-shell failure does not execute PowerShell and that the internal marker is absent from the surfaced error.

## ELI5

Browsing remote folders over SSH on Linux/macOS hosts sometimes failed because Orca mistakenly tried a PowerShell fallback after a real POSIX error. It now treats POSIX listing failures correctly and keeps error messages cleaner.
