### PR TITLE
perf(mobile-sync): memoize the agent-status projection per entry

### DIFF
--- a/config/scripts/mobile-agent-status-projection-benchmark.mjs
+++ b/config/scripts/mobile-agent-status-projection-benchmark.mjs
@@ -43,8 +43,8 @@ for (const [name, value] of [
   }
 }
 
-function serializeEntry(paneKey, entry) {
-  return JSON.stringify({
+function toRow(paneKey, entry) {
+  return {
     paneKey,
     entryPaneKey: entry.paneKey,
     state: entry.state,
@@ -64,15 +64,20 @@ function serializeEntry(paneKey, entry) {
     interactivePrompt: entry.interactivePrompt ?? null,
     lastAssistantMessage: entry.lastAssistantMessage ?? null,
     interrupted: entry.interrupted ?? null
-  })
+  }
 }
 
-// Pre-fix: serialize the whole map every time.
+function serializeEntry(paneKey, entry) {
+  return JSON.stringify(toRow(paneKey, entry))
+}
+
+// Pre-fix: build plain rows and stringify the array once — no per-row roundtrip,
+// which the original never paid and which would inflate the reported speedup.
 function buildFull(map) {
   return JSON.stringify(
     Object.entries(map)
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([paneKey, entry]) => JSON.parse(serializeEntry(paneKey, entry)))
+      .map(([paneKey, entry]) => toRow(paneKey, entry))
   )
 }
 
@@ -169,6 +174,12 @@ for (const agents of [3, 8, 20, 40]) {
   const cachedBuilder = makeCachedBuilder()
   if (buildFull(map) !== cachedBuilder(map)) {
     throw new Error(`projection mismatch at ${agents} agents`)
+  }
+  // Why also after a ping: the cold call reuses nothing, so a stale-row bug would
+  // only surface once the cache is actually exercised.
+  const pinged = ping(map, 0)
+  if (buildFull(pinged) !== cachedBuilder(pinged)) {
+    throw new Error(`projection mismatch after a ping at ${agents} agents`)
   }
   const full = measure(buildFull, map)
   const cached = measure(makeCachedBuilder(), map)

--- a/config/scripts/mobile-agent-status-projection-benchmark.mjs
+++ b/config/scripts/mobile-agent-status-projection-benchmark.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Benchmark: cost of the mobile agent-status projection per store mutation.
+//
+// buildRuntimeMobileAgentStatusProjection runs on the App.tsx global store
+// subscriber. setAgentStatus replaces one entry and re-spreads
+// agentStatusByPaneKey, which defeats the reference-equality skip gate, so before
+// the fix EVERY live agent was re-serialized on EVERY status ping — each carrying
+// a prompt, a 20-entry stateHistory, toolInput, and an 8 KB-capped
+// lastAssistantMessage.
+//
+// The fix memoizes each row's JSON by entry identity, mirroring the
+// cachedTabsProjection pattern already in the same file, so a ping re-serializes
+// only the agent that actually changed.
+//
+// The bucket width is re-read from the real module so a drifted constant fails
+// loudly here instead of quietly changing what this benchmark measures.
+import { readFileSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
+import { fileURLToPath } from 'node:url'
+
+const GRAPH_SOURCE = readFileSync(
+  fileURLToPath(new URL('../../src/renderer/src/runtime/sync-runtime-graph.ts', import.meta.url)),
+  'utf8'
+)
+
+const bucketMatch = GRAPH_SOURCE.match(/AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS = ([0-9_]+)/)
+if (!bucketMatch) {
+  throw new Error(
+    'sync-runtime-graph.ts no longer defines the updatedAt bucket; re-sync this benchmark.'
+  )
+}
+const BUCKET_MS = Number(bucketMatch[1].replaceAll('_', ''))
+
+const ITERATIONS = Number.parseInt(process.env.ORCA_AGENT_PROJECTION_BENCH_ITERATIONS ?? '400', 10)
+const WARMUP = Number.parseInt(process.env.ORCA_AGENT_PROJECTION_BENCH_WARMUP ?? '60', 10)
+
+for (const [name, value] of [
+  ['ORCA_AGENT_PROJECTION_BENCH_ITERATIONS', ITERATIONS],
+  ['ORCA_AGENT_PROJECTION_BENCH_WARMUP', WARMUP]
+]) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, received ${value}`)
+  }
+}
+
+function serializeEntry(paneKey, entry) {
+  return JSON.stringify({
+    paneKey,
+    entryPaneKey: entry.paneKey,
+    state: entry.state,
+    prompt: entry.prompt,
+    updatedAtBucket: Math.floor(entry.updatedAt / BUCKET_MS),
+    stateStartedAt: entry.stateStartedAt,
+    agentType: entry.agentType ?? null,
+    terminalTitle: entry.terminalTitle ?? null,
+    stateHistory: entry.stateHistory.map((history) => ({
+      state: history.state,
+      prompt: history.prompt,
+      startedAt: history.startedAt,
+      interrupted: history.interrupted ?? null
+    })),
+    toolName: entry.toolName ?? null,
+    toolInput: entry.toolInput ?? null,
+    interactivePrompt: entry.interactivePrompt ?? null,
+    lastAssistantMessage: entry.lastAssistantMessage ?? null,
+    interrupted: entry.interrupted ?? null
+  })
+}
+
+// Pre-fix: serialize the whole map every time.
+function buildFull(map) {
+  return JSON.stringify(
+    Object.entries(map)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([paneKey, entry]) => JSON.parse(serializeEntry(paneKey, entry)))
+  )
+}
+
+// Post-fix: reuse each row's JSON while its entry object is unchanged.
+function makeCachedBuilder() {
+  let cache = null
+  return (map) => {
+    if (cache?.source === map) {
+      return cache.projection
+    }
+    const previous = cache?.entries
+    const entries = new Map()
+    const parts = []
+    for (const [paneKey, entry] of Object.entries(map).sort(([a], [b]) => a.localeCompare(b))) {
+      const prior = previous?.get(paneKey)
+      const row =
+        prior?.entry === entry ? prior : { entry, projection: serializeEntry(paneKey, entry) }
+      entries.set(paneKey, row)
+      parts.push(row.projection)
+    }
+    const projection = `[${parts.join(',')}]`
+    cache = { source: map, entries, projection }
+    return projection
+  }
+}
+
+// A live agent as the store actually holds it.
+function makeEntry(index, updatedAt) {
+  return {
+    paneKey: `tab-${index}:leaf-0`,
+    state: 'working',
+    prompt: 'implement the feature and run the tests '.repeat(4),
+    updatedAt,
+    stateStartedAt: 1740000000000,
+    agentType: 'claude',
+    terminalTitle: `agent ${index}`,
+    stateHistory: Array.from({ length: 20 }, (_value, step) => ({
+      state: 'working',
+      prompt: `step ${step} of the current turn`,
+      startedAt: 1740000000000 + step,
+      interrupted: null
+    })),
+    toolName: 'shell_command',
+    toolInput: 'rg --line-number "pattern" src/ '.repeat(8),
+    interactivePrompt: null,
+    // The cap the store applies to assistant text.
+    lastAssistantMessage: 'x'.repeat(8000),
+    interrupted: null
+  }
+}
+
+function makeMap(agents) {
+  const map = {}
+  for (let index = 0; index < agents; index += 1) {
+    map[`tab-${index}:leaf-0`] = makeEntry(index, 1740000000000 + index * BUCKET_MS)
+  }
+  return map
+}
+
+// One status ping: one entry replaced, the map re-spread, every other entry
+// reference-identical — exactly what setAgentStatus produces.
+function ping(map, round) {
+  return {
+    ...map,
+    'tab-0:leaf-0': makeEntry(0, 1740000000000 + BUCKET_MS * (round + 1))
+  }
+}
+
+function measure(build, map) {
+  let current = map
+  for (let index = 0; index < WARMUP; index += 1) {
+    current = ping(current, index)
+    build(current)
+  }
+  const samples = []
+  for (let round = 0; round < 5; round += 1) {
+    const start = performance.now()
+    for (let index = 0; index < ITERATIONS; index += 1) {
+      current = ping(current, index)
+      build(current)
+    }
+    samples.push((performance.now() - start) / ITERATIONS)
+  }
+  samples.sort((a, b) => a - b)
+  return samples[2]
+}
+
+const pad = (value, width) => String(value).padStart(width)
+console.log('Mobile agent-status projection, per status ping (one agent changed)')
+console.log(`bucket=${BUCKET_MS}ms iterations=${ITERATIONS} warmup=${WARMUP} (median of 5 rounds)`)
+console.log(`${pad('agents', 8)} ${pad('full', 11)} ${pad('cached', 11)} ${pad('speedup', 9)}`)
+for (const agents of [3, 8, 20, 40]) {
+  const map = makeMap(agents)
+  const cachedBuilder = makeCachedBuilder()
+  if (buildFull(map) !== cachedBuilder(map)) {
+    throw new Error(`projection mismatch at ${agents} agents`)
+  }
+  const full = measure(buildFull, map)
+  const cached = measure(makeCachedBuilder(), map)
+  console.log(
+    `${pad(agents, 8)} ${pad(`${full.toFixed(4)} ms`, 11)} ${pad(`${cached.toFixed(4)} ms`, 11)} ${pad(`${(full / cached).toFixed(1)}x`, 9)}`
+  )
+}
+console.log(
+  '\nThis runs on the global store subscriber, so the cost is paid per status ping\nand scales with the number of agents running in parallel — the workload this\napp exists for.'
+)

--- a/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '@/store/types'
+import {
+  AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS_FOR_TESTS,
+  buildRuntimeMobileAgentStatusProjectionForTests,
+  resetRuntimeMobileAgentStatusProjectionCacheForTests
+} from './sync-runtime-graph'
+
+// Reference: the pre-change whole-array serialization, kept verbatim. The bucket
+// width is read from the module under test so a drifted constant cannot make this
+// reference silently disagree for a reason unrelated to the change.
+const BUCKET_MS = AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS_FOR_TESTS
+function referenceProjection(map: AppState['agentStatusByPaneKey']): string {
+  return JSON.stringify(
+    Object.entries(map)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([paneKey, entry]) => ({
+        paneKey,
+        entryPaneKey: entry.paneKey,
+        state: entry.state,
+        prompt: entry.prompt,
+        updatedAtBucket: Math.floor(entry.updatedAt / BUCKET_MS),
+        stateStartedAt: entry.stateStartedAt,
+        agentType: entry.agentType ?? null,
+        terminalTitle: entry.terminalTitle ?? null,
+        stateHistory: entry.stateHistory.map((history) => ({
+          state: history.state,
+          prompt: history.prompt,
+          startedAt: history.startedAt,
+          interrupted: history.interrupted ?? null
+        })),
+        toolName: entry.toolName ?? null,
+        toolInput: entry.toolInput ?? null,
+        interactivePrompt: entry.interactivePrompt ?? null,
+        lastAssistantMessage: entry.lastAssistantMessage ?? null,
+        interrupted: entry.interrupted ?? null
+      }))
+  )
+}
+
+function makeEntry(index: number, overrides: Record<string, unknown> = {}): never {
+  return {
+    paneKey: `tab-${index}:leaf-0`,
+    state: 'working',
+    prompt: `prompt ${index} with "quotes" and \\ backslash`,
+    updatedAt: 1740000000000 + index * 17,
+    stateStartedAt: 1740000000000,
+    agentType: 'claude',
+    terminalTitle: `agent ${index} 日本 \u{1f389}`,
+    stateHistory: Array.from({ length: 3 }, (_value, h) => ({
+      state: 'working',
+      prompt: `step ${h}`,
+      startedAt: 1740000000000 + h
+    })),
+    toolName: 'shell_command',
+    toolInput: 'ls -la',
+    lastAssistantMessage: 'answer',
+    ...overrides
+  } as never
+}
+
+describe('mobile agent-status projection equivalence', () => {
+  it('matches the whole-array serialization across shapes and cache reuse', () => {
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const shapes: AppState['agentStatusByPaneKey'][] = []
+    shapes.push({})
+    shapes.push({ 'tab-0:leaf-0': makeEntry(0) })
+    const many: AppState['agentStatusByPaneKey'] = {}
+    for (let index = 0; index < 12; index += 1) {
+      many[`tab-${index}:leaf-0`] = makeEntry(index)
+    }
+    shapes.push(many)
+    // Optional fields absent entirely, which the ?? null fallbacks must cover.
+    shapes.push({
+      'tab-9:leaf-1': makeEntry(9, {
+        agentType: undefined,
+        terminalTitle: undefined,
+        toolName: undefined,
+        toolInput: undefined,
+        interactivePrompt: undefined,
+        lastAssistantMessage: undefined,
+        interrupted: undefined
+      })
+    })
+    // Keys deliberately out of insertion order to pin the sort.
+    shapes.push({
+      'tab-z:leaf-0': makeEntry(2),
+      'tab-a:leaf-0': makeEntry(1),
+      'tab-m:leaf-0': makeEntry(3)
+    })
+
+    for (const [index, shape] of shapes.entries()) {
+      expect({
+        index,
+        projection: buildRuntimeMobileAgentStatusProjectionForTests(shape)
+      }).toEqual({ index, projection: referenceProjection(shape) })
+    }
+
+    // Now exercise the cache: replace one entry the way setAgentStatus does and
+    // confirm the reused rows still produce the reference output. The changes must
+    // be observable in the projection — a sub-bucket updatedAt nudge is not, so a
+    // stale-entry reuse bug would slip through.
+    let current = many
+    for (let round = 0; round < 4; round += 1) {
+      current = {
+        ...current,
+        'tab-0:leaf-0': makeEntry(0, {
+          updatedAt: 1740000000000 + BUCKET_MS * 3 * (round + 1),
+          state: round % 2 === 0 ? 'done' : 'working',
+          prompt: `changed prompt round ${round}`,
+          lastAssistantMessage: `answer round ${round}`
+        })
+      }
+      expect({
+        round,
+        projection: buildRuntimeMobileAgentStatusProjectionForTests(current)
+      }).toEqual({ round, projection: referenceProjection(current) })
+    }
+  })
+})

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -68,6 +68,15 @@ type TabsProjectionCache = {
   entries: Map<string, TabsProjectionCacheEntry>
   projection: string
 }
+type AgentStatusProjectionCacheEntry = {
+  entry: AppState['agentStatusByPaneKey'][string]
+  projection: string
+}
+type AgentStatusProjectionCache = {
+  source: AppState['agentStatusByPaneKey']
+  entries: Map<string, AgentStatusProjectionCacheEntry>
+  projection: string
+}
 
 const registeredTabs = new Map<string, RegisteredTerminalTab>()
 // Why: registration time suppresses the "no live transport" warning during the async PTY-connect window; after the grace period it's a real stuck state.
@@ -129,6 +138,7 @@ function jsonContentEquals(a: unknown, b: unknown): boolean {
   return true
 }
 let cachedTabsProjection: TabsProjectionCache | null = null
+let cachedAgentStatusProjection: AgentStatusProjectionCache | null = null
 let cachedOpenFileIndexesSource: AppState['openFiles'] | null = null
 let cachedOpenFileIndexes: OpenFileIndexes | null = null
 let cachedEditorDraftsSource: AppState['editorDrafts'] | null = null
@@ -491,35 +501,76 @@ function buildRuntimeMobileEditorDraftsProjection(editorDrafts: AppState['editor
   )
 }
 
+function serializeRuntimeMobileAgentStatusEntry(
+  paneKey: string,
+  entry: AppState['agentStatusByPaneKey'][string]
+): string {
+  return JSON.stringify({
+    paneKey,
+    entryPaneKey: entry.paneKey,
+    state: entry.state,
+    prompt: entry.prompt,
+    updatedAtBucket: Math.floor(entry.updatedAt / AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS),
+    stateStartedAt: entry.stateStartedAt,
+    agentType: entry.agentType ?? null,
+    terminalTitle: entry.terminalTitle ?? null,
+    stateHistory: entry.stateHistory.map((history) => ({
+      state: history.state,
+      prompt: history.prompt,
+      startedAt: history.startedAt,
+      interrupted: history.interrupted ?? null
+    })),
+    toolName: entry.toolName ?? null,
+    toolInput: entry.toolInput ?? null,
+    // Why: include so a newly-captured AskUserQuestion prompt re-fires the mobile republish even when no other field changed.
+    interactivePrompt: entry.interactivePrompt ?? null,
+    lastAssistantMessage: entry.lastAssistantMessage ?? null,
+    interrupted: entry.interrupted ?? null
+  })
+}
+
 function buildRuntimeMobileAgentStatusProjection(
   agentStatusByPaneKey: AppState['agentStatusByPaneKey']
 ): string {
-  return JSON.stringify(
-    Object.entries(agentStatusByPaneKey)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([paneKey, entry]) => ({
-        paneKey,
-        entryPaneKey: entry.paneKey,
-        state: entry.state,
-        prompt: entry.prompt,
-        updatedAtBucket: Math.floor(entry.updatedAt / AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS),
-        stateStartedAt: entry.stateStartedAt,
-        agentType: entry.agentType ?? null,
-        terminalTitle: entry.terminalTitle ?? null,
-        stateHistory: entry.stateHistory.map((history) => ({
-          state: history.state,
-          prompt: history.prompt,
-          startedAt: history.startedAt,
-          interrupted: history.interrupted ?? null
-        })),
-        toolName: entry.toolName ?? null,
-        toolInput: entry.toolInput ?? null,
-        // Why: include so a newly-captured AskUserQuestion prompt re-fires the mobile republish even when no other field changed.
-        interactivePrompt: entry.interactivePrompt ?? null,
-        lastAssistantMessage: entry.lastAssistantMessage ?? null,
-        interrupted: entry.interrupted ?? null
-      }))
-  )
+  if (cachedAgentStatusProjection?.source === agentStatusByPaneKey) {
+    return cachedAgentStatusProjection.projection
+  }
+
+  // Why per-entry: a status ping replaces one entry and re-spreads the map, so
+  // without this every other live agent — each carrying a 20-entry history and an
+  // 8 KB message — is re-serialized to discover it did not change.
+  const previousEntries = cachedAgentStatusProjection?.entries
+  const entries = new Map<string, AgentStatusProjectionCacheEntry>()
+  const parts: string[] = []
+
+  for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey).sort(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    const previous = previousEntries?.get(paneKey)
+    const cached =
+      previous?.entry === entry
+        ? previous
+        : { entry, projection: serializeRuntimeMobileAgentStatusEntry(paneKey, entry) }
+    entries.set(paneKey, cached)
+    parts.push(cached.projection)
+  }
+
+  const projection = `[${parts.join(',')}]`
+  cachedAgentStatusProjection = { source: agentStatusByPaneKey, entries, projection }
+  return projection
+}
+
+export function buildRuntimeMobileAgentStatusProjectionForTests(
+  agentStatusByPaneKey: AppState['agentStatusByPaneKey']
+): string {
+  return buildRuntimeMobileAgentStatusProjection(agentStatusByPaneKey)
+}
+
+export const AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS_FOR_TESTS =
+  AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS
+
+export function resetRuntimeMobileAgentStatusProjectionCacheForTests(): void {
+  cachedAgentStatusProjection = null
 }
 
 export function runtimeMobileSessionSyncKeysEqual(


### PR DESCRIPTION
## Summary

`buildRuntimeMobileAgentStatusProjection` runs on the **App.tsx global store subscriber** — it fires on every store mutation. It re-serialized **every live agent** on **every status ping**.

`setAgentStatus` replaces one entry and re-spreads `agentStatusByPaneKey`, so the new map reference defeats the reference-equality skip gate in `canSkipRuntimeMobileSessionSyncKeyBuild`. Each ping then paid to serialize every *other* agent — prompt, 20-entry `stateHistory`, `toolInput`, and an 8 KB-capped `lastAssistantMessage` — only to discover none of them had changed.

This was the only uncached projection on that subscriber path. `cachedTabsProjection`, a few functions above in the same file, already uses the identity-keyed pattern applied here.

## ELI5

Orca keeps a compact text summary of every running agent so it can tell the mobile app what changed.

Every time *one* agent reports progress, it rebuilt the summary for **all** of them from scratch — re-copying each one's full prompt, its last 20 steps, and up to 8 KB of its most recent message. With eight agents running, seven of those were rewritten character-for-character into exactly what they already said.

Now each agent's summary is remembered until that agent actually changes. A ping rewrites one entry instead of all of them.

## Screenshots

No visual change.

## Proof of performance improvement

`node config/scripts/mobile-agent-status-projection-benchmark.mjs` (new):

```
bucket=30000ms iterations=400 warmup=60 (median of 5 rounds)
  agents        full      cached   speedup
       3   0.0690 ms   0.0117 ms      5.9x
       8   0.1813 ms   0.0145 ms     12.5x
      20   0.4540 ms   0.0425 ms     10.7x
      40   0.8813 ms   0.0630 ms     14.0x
```

The benchmark reproduces the real trigger — one entry replaced, the map re-spread, every other entry reference-identical, which is exactly what `setAgentStatus` produces. It asserts both versions emit identical output before timing, and re-reads `AGENT_STATUS_SYNC_UPDATED_AT_BUCKET_MS` from the real module so a drifted constant fails loudly instead of quietly changing what is measured.

**The cost scales with agents running in parallel** — the workload this app exists for.

## Proof of zero regression

The output is **byte-identical**. That is the whole safety argument, and it needed proving because the change swaps `JSON.stringify(array)` for `'[' + parts.join(',') + ']'`.

First, that the two forms agree at all: verified across 17 shapes including the cases where `JSON.stringify` behaves specially — `undefined`, `null`, `NaN`, `Infinity`, `-0`, `1e21`, lone surrogates, `Date`, a custom `toJSON`, and arrays containing functions/symbols. Zero mismatches.

Then, that the *real* function agrees with the *old* function: the new test keeps a verbatim copy of the pre-change whole-array serialization and asserts equality across empty / single / 12-agent / all-optionals-absent / out-of-sort-order maps, plus four rounds of cache reuse.

**Mutation testing.** Two findings, both in my own tests:

| mutant | result |
|---|---|
| reuse a cached row without checking entry identity | **fails** |
| fast path ignores the source map identity | **fails** |
| join with `;` instead of `,` | **fails** |
| drop the `localeCompare` sort | **fails** |

The stale-entry-reuse mutant — the single most important one, since cache invalidation is the entire risk this change introduces — **initially survived**. My cache-reuse rounds nudged `updatedAt` by 5000 ms, but the bucket is 30000 ms, so the projection didn't change and a broken cache looked correct. I made each round's change observable (state, prompt, message, and a full-bucket time step) and it now dies.

Separately, my first version of the test failed against correct code because I hardcoded `BUCKET_MS = 1000` instead of the real `30_000`. The test now imports the constant so it cannot drift.

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — **509/509** across `src/renderer/src/runtime/`; full suite **2 failures / 36,935**, both pre-existing
- [x] Added a test that would catch the regression

### Pre-existing test failures

`pnpm test` is already red on `main`. This run shows **only** `agent-exec-handler.test.ts` ×2, which assert against the machine's real `process.env` — a strict subset of the known baseline pool, and neither imports the changed code. Across eight full-suite runs in this series, two consecutive runs on *unmodified* `main` produced different failure sets, which is what establishes the pool as pre-existing.

## Review loop count + verdict

**3 review loops: independent re-measurement, mutation-driven revision, and final risk review. Final verdict: ship.**

Found by the round-2 discovery sweep, then re-measured independently by me before implementation (5.5×-12.5× on my own harness, matching the finder's numbers), followed by the mutation loop above which drove two test revisions.

The same sweep **rejected** a neighbouring candidate with numbers rather than reporting it: `resolvePaneKey`'s O(all tabs) nested scan in `useIpcEvents.ts` runs per `agentStatus:set` event and looks like the same class of problem, but measures **0.26 µs at 30 tabs and 0.60 µs at 96 tabs**. An index would save well under a microsecond. Not worth a PR.

Reviewer attention is most useful on **the join-vs-stringify equivalence**. If there is an entry shape reachable in practice where per-row serialization diverges from whole-array serialization, that is the bug this change could have.

## AI Review Report

Risks reviewed:

- **Cache invalidation.** Three independent guards: the map identity fast path, per-entry object identity, and re-sorting keys on every rebuild. Each is pinned by a mutant that fails without it.
- **Key ordering.** The `localeCompare` sort is preserved and pinned by an out-of-insertion-order fixture, so a map whose keys arrive in a different order still yields the same projection — important because this value is compared for equality to decide whether to republish.
- **Unbounded cache growth.** The cache is fully rebuilt per call and keyed to a single `source` map, so entries for removed panes are dropped on the next build rather than accumulating. No eviction policy needed.
- **Optional-field handling.** The `?? null` fallbacks are unchanged and covered by an all-optionals-absent fixture.

Cross-platform: no path, shell, keyboard, or platform-dependent behaviour touched — this is pure in-memory serialization in the renderer. Identical on macOS/Linux/Windows and for local, SSH, WSL, and remote-runtime hosts; the projection feeds the mobile sync graph the same way on every host.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or IPC surface. The projection contains the same fields as before and is used the same way — as a change-detection key for the mobile republish. Agent prompts and assistant messages were already included and remain subject to the same 8 KB cap; nothing newly enters or leaves the payload. The cache holds references to store objects the renderer already retains, adds no persistence, and cannot outlive the store map it is keyed to. No dependency changes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
