### PR TITLE
fix(orca-cloud): report the real cause when cloud sign-in cannot reach the network

### DIFF
--- a/src/main/global-fetch-call-site-audit.test.ts
+++ b/src/main/global-fetch-call-site-audit.test.ts
@@ -18,8 +18,6 @@ const AUDITED_GLOBAL_FETCH_LINES = new Map<string, number>([
   ['main/azure-devops/azure-devops-api-request.ts', 1],
   ['main/bitbucket/client.ts', 1],
   ['main/gitea/client.ts', 1],
-  ['main/orca-profiles/profile-cloud-client.ts', 1],
-  ['main/orca-profiles/profile-cloud-org-members-client.ts', 1],
   ['main/rate-limits/codex-fetcher.ts', 3],
   ['main/runtime/relay/relay-http-client.ts', 2],
   ['main/source-control/hosted-review-api-request.ts', 1],

--- a/src/main/orca-profiles/profile-cloud-client.test.ts
+++ b/src/main/orca-profiles/profile-cloud-client.test.ts
@@ -10,7 +10,16 @@ import {
   selectOrcaCloudOrg
 } from './profile-cloud-client'
 
-const fetchMock = vi.fn()
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }))
+
+vi.mock('electron', () => ({
+  net: { fetch: fetchMock },
+  session: { defaultSession: {} }
+}))
+
+vi.mock('../network/proxy-settings', () => ({
+  ensureElectronProxyFromEnvironment: vi.fn().mockResolvedValue({ source: 'none' })
+}))
 
 const config: OrcaCloudAuthConfig = {
   apiBaseUrl: 'https://orca-cloud.example',
@@ -44,7 +53,6 @@ function mockFetchJson(value: unknown): void {
 describe('Orca cloud client', () => {
   beforeEach(() => {
     fetchMock.mockReset()
-    vi.stubGlobal('fetch', fetchMock)
   })
 
   it('normalizes session exchange organizations', async () => {

--- a/src/main/orca-profiles/profile-cloud-client.ts
+++ b/src/main/orca-profiles/profile-cloud-client.ts
@@ -7,6 +7,7 @@ import type { OrcaCloudAuthConfig } from './profile-cloud-auth-config'
 import type { OrcaCloudSession } from './profile-cloud-session-store'
 import type { OrcaCloudSessionExchangeResponse } from './profile-cloud-session-exchange'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { orcaCloudFetch } from './profile-cloud-transport'
 
 type ExchangeCodeArgs = {
   code: string
@@ -159,8 +160,13 @@ function normalizeSessionResponse(value: unknown): OrcaCloudSessionExchangeRespo
 
 const CLOUD_REQUEST_TIMEOUT_MS = 30_000
 
-async function postJson<T>(url: string, body: unknown, accessToken?: string): Promise<T> {
-  const response = await fetch(url, {
+async function postJson<T>(
+  operation: string,
+  url: string,
+  body: unknown,
+  accessToken?: string
+): Promise<T> {
+  const response = await orcaCloudFetch(operation, url, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
@@ -185,7 +191,7 @@ export async function exchangeOrcaCloudAuthCode(
   args: ExchangeCodeArgs
 ): Promise<OrcaCloudSessionExchangeResponse> {
   return normalizeSessionResponse(
-    await postJson(config.sessionEndpoint, {
+    await postJson('session-exchange', config.sessionEndpoint, {
       code: args.code,
       codeVerifier: args.codeVerifier,
       nonce: args.nonce,
@@ -204,7 +210,7 @@ export async function refreshOrcaCloudCapabilities(
     cloud?: unknown
     organizations?: unknown
     capabilities: unknown
-  }>(config.capabilitiesEndpoint, {}, session.accessToken)
+  }>('capabilities-refresh', config.capabilitiesEndpoint, {}, session.accessToken)
   return {
     cloud: response.cloud === undefined ? undefined : normalizeCloudSummary(response.cloud),
     organizations: normalizeOrganizations(response.organizations),
@@ -217,7 +223,7 @@ export async function refreshOrcaCloudSession(
   session: OrcaCloudSession
 ): Promise<OrcaCloudSessionExchangeResponse> {
   return normalizeSessionResponse(
-    await postJson(config.refreshEndpoint, {
+    await postJson('session-refresh', config.refreshEndpoint, {
       refreshToken: session.refreshToken
     })
   )
@@ -230,6 +236,7 @@ export async function createOrcaCloudProfile(
 ): Promise<OrcaCloudSessionExchangeResponse> {
   return normalizeSessionResponse(
     await postJson(
+      'profile-create',
       config.profileEndpoint,
       {
         orgId: args.orgId,
@@ -249,7 +256,7 @@ export async function selectOrcaCloudOrg(
     cloud: unknown
     organizations?: unknown
     capabilities: unknown
-  }>(config.orgEndpoint, { orgId }, session.accessToken)
+  }>('org-select', config.orgEndpoint, { orgId }, session.accessToken)
   return {
     cloud: normalizeCloudSummary(response.cloud),
     organizations: normalizeOrganizations(response.organizations),
@@ -261,5 +268,10 @@ export async function revokeOrcaCloudSession(
   config: OrcaCloudAuthConfig,
   session: OrcaCloudSession
 ): Promise<void> {
-  await postJson(config.logoutEndpoint, { refreshToken: session.refreshToken }, session.accessToken)
+  await postJson(
+    'session-revoke',
+    config.logoutEndpoint,
+    { refreshToken: session.refreshToken },
+    session.accessToken
+  )
 }

--- a/src/main/orca-profiles/profile-cloud-client.ts
+++ b/src/main/orca-profiles/profile-cloud-client.ts
@@ -160,13 +160,8 @@ function normalizeSessionResponse(value: unknown): OrcaCloudSessionExchangeRespo
 
 const CLOUD_REQUEST_TIMEOUT_MS = 30_000
 
-async function postJson<T>(
-  operation: string,
-  url: string,
-  body: unknown,
-  accessToken?: string
-): Promise<T> {
-  const response = await orcaCloudFetch(operation, url, {
+async function postJson<T>(url: string, body: unknown, accessToken?: string): Promise<T> {
+  const response = await orcaCloudFetch(url, {
     method: 'POST',
     headers: {
       'content-type': 'application/json',
@@ -191,7 +186,7 @@ export async function exchangeOrcaCloudAuthCode(
   args: ExchangeCodeArgs
 ): Promise<OrcaCloudSessionExchangeResponse> {
   return normalizeSessionResponse(
-    await postJson('session-exchange', config.sessionEndpoint, {
+    await postJson(config.sessionEndpoint, {
       code: args.code,
       codeVerifier: args.codeVerifier,
       nonce: args.nonce,
@@ -210,7 +205,7 @@ export async function refreshOrcaCloudCapabilities(
     cloud?: unknown
     organizations?: unknown
     capabilities: unknown
-  }>('capabilities-refresh', config.capabilitiesEndpoint, {}, session.accessToken)
+  }>(config.capabilitiesEndpoint, {}, session.accessToken)
   return {
     cloud: response.cloud === undefined ? undefined : normalizeCloudSummary(response.cloud),
     organizations: normalizeOrganizations(response.organizations),
@@ -223,7 +218,7 @@ export async function refreshOrcaCloudSession(
   session: OrcaCloudSession
 ): Promise<OrcaCloudSessionExchangeResponse> {
   return normalizeSessionResponse(
-    await postJson('session-refresh', config.refreshEndpoint, {
+    await postJson(config.refreshEndpoint, {
       refreshToken: session.refreshToken
     })
   )
@@ -236,7 +231,6 @@ export async function createOrcaCloudProfile(
 ): Promise<OrcaCloudSessionExchangeResponse> {
   return normalizeSessionResponse(
     await postJson(
-      'profile-create',
       config.profileEndpoint,
       {
         orgId: args.orgId,
@@ -256,7 +250,7 @@ export async function selectOrcaCloudOrg(
     cloud: unknown
     organizations?: unknown
     capabilities: unknown
-  }>('org-select', config.orgEndpoint, { orgId }, session.accessToken)
+  }>(config.orgEndpoint, { orgId }, session.accessToken)
   return {
     cloud: normalizeCloudSummary(response.cloud),
     organizations: normalizeOrganizations(response.organizations),
@@ -268,10 +262,5 @@ export async function revokeOrcaCloudSession(
   config: OrcaCloudAuthConfig,
   session: OrcaCloudSession
 ): Promise<void> {
-  await postJson(
-    'session-revoke',
-    config.logoutEndpoint,
-    { refreshToken: session.refreshToken },
-    session.accessToken
-  )
+  await postJson(config.logoutEndpoint, { refreshToken: session.refreshToken }, session.accessToken)
 }

--- a/src/main/orca-profiles/profile-cloud-org-members-client.test.ts
+++ b/src/main/orca-profiles/profile-cloud-org-members-client.test.ts
@@ -10,7 +10,16 @@ import {
   revokeOrcaCloudOrgInvite
 } from './profile-cloud-org-members-client'
 
-const fetchMock = vi.fn()
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }))
+
+vi.mock('electron', () => ({
+  net: { fetch: fetchMock },
+  session: { defaultSession: {} }
+}))
+
+vi.mock('../network/proxy-settings', () => ({
+  ensureElectronProxyFromEnvironment: vi.fn().mockResolvedValue({ source: 'none' })
+}))
 
 const config: OrcaCloudAuthConfig = {
   apiBaseUrl: 'https://orca-cloud.example',
@@ -45,7 +54,6 @@ function mockJsonResponse(value: unknown, init: { ok?: boolean; status?: number 
 describe('Orca cloud org members client', () => {
   beforeEach(() => {
     fetchMock.mockReset()
-    vi.stubGlobal('fetch', fetchMock)
   })
 
   it('normalizes the roster, dropping malformed rows and defaulting the viewer role', async () => {

--- a/src/main/orca-profiles/profile-cloud-org-members-client.ts
+++ b/src/main/orca-profiles/profile-cloud-org-members-client.ts
@@ -7,6 +7,7 @@ import type {
 import type { OrcaCloudAuthConfig } from './profile-cloud-auth-config'
 import type { OrcaCloudSession } from './profile-cloud-session-store'
 import { OrcaCloudRequestError } from './profile-cloud-client'
+import { orcaCloudFetch } from './profile-cloud-transport'
 
 const CLOUD_REQUEST_TIMEOUT_MS = 30_000
 const ORG_ROLES: readonly OrcaOrgRole[] = ['owner', 'admin', 'member']
@@ -137,11 +138,12 @@ function requestInit(method: 'GET' | 'POST', accessToken: string, body?: unknown
 }
 
 async function requestOrgMembers<T>(
+  operation: string,
   url: string,
   init: RequestInit,
   parse: (value: unknown) => T
 ): Promise<T> {
-  const response = await fetch(url, init)
+  const response = await orcaCloudFetch(operation, url, init)
   if (!response.ok) {
     throw new OrcaCloudRequestError(response.status, await extractErrorCode(response))
   }
@@ -154,6 +156,7 @@ export async function listOrcaCloudOrgMembers(
   orgId: string
 ): Promise<OrcaOrgMembersRoster> {
   return requestOrgMembers(
+    'org-members-list',
     orgMembersUrl(config, orgId, '/members'),
     requestInit('GET', session.accessToken),
     normalizeRoster
@@ -166,6 +169,7 @@ export async function inviteOrcaCloudOrgMember(
   args: { orgId: string; email: string; role: OrcaOrgRole }
 ): Promise<void> {
   await requestOrgMembers(
+    'org-member-invite',
     orgMembersUrl(config, args.orgId, '/invites'),
     requestInit('POST', session.accessToken, { email: args.email, role: args.role }),
     () => undefined
@@ -178,6 +182,7 @@ export async function revokeOrcaCloudOrgInvite(
   args: { orgId: string; email: string }
 ): Promise<void> {
   await requestOrgMembers(
+    'org-invite-revoke',
     orgMembersUrl(config, args.orgId, '/invites/revoke'),
     requestInit('POST', session.accessToken, { email: args.email }),
     () => undefined
@@ -190,6 +195,7 @@ export async function changeOrcaCloudOrgMemberRole(
   args: { orgId: string; userId: string; role: OrcaOrgRole }
 ): Promise<void> {
   await requestOrgMembers(
+    'org-member-role',
     orgMembersUrl(config, args.orgId, '/members/role'),
     requestInit('POST', session.accessToken, { userId: args.userId, role: args.role }),
     () => undefined
@@ -202,6 +208,7 @@ export async function removeOrcaCloudOrgMember(
   args: { orgId: string; userId: string }
 ): Promise<void> {
   await requestOrgMembers(
+    'org-member-remove',
     orgMembersUrl(config, args.orgId, '/members/remove'),
     requestInit('POST', session.accessToken, { userId: args.userId }),
     () => undefined

--- a/src/main/orca-profiles/profile-cloud-org-members-client.ts
+++ b/src/main/orca-profiles/profile-cloud-org-members-client.ts
@@ -138,12 +138,11 @@ function requestInit(method: 'GET' | 'POST', accessToken: string, body?: unknown
 }
 
 async function requestOrgMembers<T>(
-  operation: string,
   url: string,
   init: RequestInit,
   parse: (value: unknown) => T
 ): Promise<T> {
-  const response = await orcaCloudFetch(operation, url, init)
+  const response = await orcaCloudFetch(url, init)
   if (!response.ok) {
     throw new OrcaCloudRequestError(response.status, await extractErrorCode(response))
   }
@@ -156,7 +155,6 @@ export async function listOrcaCloudOrgMembers(
   orgId: string
 ): Promise<OrcaOrgMembersRoster> {
   return requestOrgMembers(
-    'org-members-list',
     orgMembersUrl(config, orgId, '/members'),
     requestInit('GET', session.accessToken),
     normalizeRoster
@@ -169,7 +167,6 @@ export async function inviteOrcaCloudOrgMember(
   args: { orgId: string; email: string; role: OrcaOrgRole }
 ): Promise<void> {
   await requestOrgMembers(
-    'org-member-invite',
     orgMembersUrl(config, args.orgId, '/invites'),
     requestInit('POST', session.accessToken, { email: args.email, role: args.role }),
     () => undefined
@@ -182,7 +179,6 @@ export async function revokeOrcaCloudOrgInvite(
   args: { orgId: string; email: string }
 ): Promise<void> {
   await requestOrgMembers(
-    'org-invite-revoke',
     orgMembersUrl(config, args.orgId, '/invites/revoke'),
     requestInit('POST', session.accessToken, { email: args.email }),
     () => undefined
@@ -195,7 +191,6 @@ export async function changeOrcaCloudOrgMemberRole(
   args: { orgId: string; userId: string; role: OrcaOrgRole }
 ): Promise<void> {
   await requestOrgMembers(
-    'org-member-role',
     orgMembersUrl(config, args.orgId, '/members/role'),
     requestInit('POST', session.accessToken, { userId: args.userId, role: args.role }),
     () => undefined
@@ -208,7 +203,6 @@ export async function removeOrcaCloudOrgMember(
   args: { orgId: string; userId: string }
 ): Promise<void> {
   await requestOrgMembers(
-    'org-member-remove',
     orgMembersUrl(config, args.orgId, '/members/remove'),
     requestInit('POST', session.accessToken, { userId: args.userId }),
     () => undefined

--- a/src/main/orca-profiles/profile-cloud-transport.test.ts
+++ b/src/main/orca-profiles/profile-cloud-transport.test.ts
@@ -1,0 +1,205 @@
+import { createServer, type Server } from 'node:http'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OrcaCloudAuthConfig } from './profile-cloud-auth-config'
+import { exchangeOrcaCloudAuthCode } from './profile-cloud-client'
+import {
+  OrcaCloudTransportError,
+  orcaCloudFetch,
+  type OrcaCloudTransportFailure
+} from './profile-cloud-transport'
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }))
+
+vi.mock('electron', () => ({
+  net: { fetch: fetchMock },
+  session: { defaultSession: {} }
+}))
+
+vi.mock('../network/proxy-settings', () => ({
+  ensureElectronProxyFromEnvironment: vi.fn().mockResolvedValue({ source: 'none' })
+}))
+
+function configFor(sessionEndpoint: string): OrcaCloudAuthConfig {
+  return {
+    apiBaseUrl: 'https://orca-cloud.example',
+    authorizeEndpoint: 'https://orca-cloud.example/v1/desktop/auth/authorize',
+    sessionEndpoint,
+    refreshEndpoint: 'https://orca-cloud.example/v1/desktop/auth/refresh',
+    capabilitiesEndpoint: 'https://orca-cloud.example/v1/desktop/auth/capabilities',
+    profileEndpoint: 'https://orca-cloud.example/v1/desktop/auth/profile',
+    orgEndpoint: 'https://orca-cloud.example/v1/desktop/auth/org',
+    logoutEndpoint: 'https://orca-cloud.example/v1/desktop/auth/logout',
+    relayTokenEndpoint: 'https://orca-cloud.example/v1/desktop/auth/relay-token',
+    relayDirectorUrl: 'https://relay.example',
+    clientId: 'desktop-client',
+    scope: 'openid profile email offline_access'
+  }
+}
+
+function undiciError(message: string, code?: string): TypeError {
+  const inner = new Error(message)
+  if (code) {
+    Object.assign(inner, { code })
+  }
+  return new TypeError('fetch failed', { cause: inner })
+}
+
+describe('Orca cloud transport failure reporting', () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+  })
+
+  const cases: { label: string; error: unknown; failure: OrcaCloudTransportFailure }[] = [
+    {
+      label: 'undici DNS lookup failure',
+      error: undiciError('getaddrinfo ENOTFOUND login.onorca.dev', 'ENOTFOUND'),
+      failure: 'dns'
+    },
+    {
+      label: 'undici socket close mid-exchange',
+      error: undiciError('other side closed', 'UND_ERR_SOCKET'),
+      failure: 'connection-lost'
+    },
+    {
+      label: 'undici redirect refusal',
+      error: undiciError('unexpected redirect'),
+      failure: 'redirect'
+    },
+    {
+      label: 'Chromium redirect refusal',
+      error: new TypeError("Attempted to redirect, but redirect policy was 'error'"),
+      failure: 'redirect'
+    },
+    {
+      label: 'Chromium name resolution failure',
+      error: new Error('net::ERR_NAME_NOT_RESOLVED'),
+      failure: 'dns'
+    },
+    {
+      label: 'intercepted TLS chain',
+      error: new Error('net::ERR_CERT_AUTHORITY_INVALID'),
+      failure: 'tls'
+    },
+    {
+      label: 'self-signed certificate from undici',
+      error: undiciError(
+        'self-signed certificate in certificate chain',
+        'SELF_SIGNED_CERT_IN_CHAIN'
+      ),
+      failure: 'tls'
+    },
+    {
+      label: 'proxy tunnel refusal',
+      error: new Error('net::ERR_TUNNEL_CONNECTION_FAILED'),
+      failure: 'proxy'
+    },
+    {
+      label: 'disconnected network',
+      error: new Error('net::ERR_INTERNET_DISCONNECTED'),
+      failure: 'offline'
+    },
+    {
+      label: 'connection reset',
+      error: new Error('net::ERR_CONNECTION_RESET'),
+      failure: 'connection-lost'
+    },
+    {
+      label: 'request timeout signal',
+      error: new DOMException('The operation was aborted due to timeout', 'TimeoutError'),
+      failure: 'timeout'
+    },
+    {
+      label: 'unrecognized transport failure',
+      error: new Error('net::ERR_FAILED'),
+      failure: 'unknown'
+    }
+  ]
+
+  for (const { label, error, failure } of cases) {
+    it(`classifies ${label} as ${failure}`, async () => {
+      fetchMock.mockRejectedValue(error)
+
+      const thrown = await orcaCloudFetch(
+        'session-exchange',
+        'https://login.onorca.dev/v1/desktop/auth/session',
+        { method: 'POST' }
+      ).catch((caught: unknown) => caught)
+
+      expect(thrown).toBeInstanceOf(OrcaCloudTransportError)
+      expect((thrown as OrcaCloudTransportError).failure).toBe(failure)
+      // The original chain stays attached for logs even though the message is bounded.
+      expect((thrown as OrcaCloudTransportError).cause).toBe(error)
+    })
+  }
+
+  it('routes cloud requests through the Electron network stack, not global fetch', async () => {
+    const globalFetch = vi.fn()
+    vi.stubGlobal('fetch', globalFetch)
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    await orcaCloudFetch('capabilities-refresh', 'https://login.onorca.dev/v1/desktop/auth/x', {
+      method: 'POST'
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(globalFetch).not.toHaveBeenCalled()
+    vi.unstubAllGlobals()
+  })
+})
+
+// orca#10758: the shipped build reported every one of these as bare
+// "fetch failed". This drives the production exchange against a real socket
+// that dies mid-request, so the assertion covers the actual transport error
+// chain rather than a hand-built stand-in.
+describe('Orca cloud session exchange against a failing socket', () => {
+  let server: Server
+  let sessionEndpoint = ''
+
+  beforeEach(async () => {
+    fetchMock.mockReset()
+    // Delegate to the real HTTP stack so undici produces a genuine failure.
+    fetchMock.mockImplementation((url: string, init: RequestInit) =>
+      globalThis.fetch(url, init as RequestInit)
+    )
+    server = createServer((_request, response) => {
+      response.socket?.destroy()
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('loopback_listen_failed')
+    }
+    sessionEndpoint = `http://127.0.0.1:${address.port}/v1/desktop/auth/session`
+  })
+
+  afterEach(async () => {
+    server.closeAllConnections?.()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+
+  it('reports a bounded category and never echoes the authorization code', async () => {
+    const thrown = await exchangeOrcaCloudAuthCode(configFor(sessionEndpoint), {
+      code: 'secret-authorization-code',
+      codeVerifier: 'secret-code-verifier',
+      nonce: 'secret-nonce',
+      redirectUri: 'http://127.0.0.1:4100/auth/callback',
+      state: 'secret-state',
+      localProfileId: 'local-default'
+    }).catch((caught: unknown) => caught)
+
+    expect(thrown).toBeInstanceOf(OrcaCloudTransportError)
+    const error = thrown as OrcaCloudTransportError
+    expect(error.failure).toBe('connection-lost')
+    expect(error.message).not.toBe('fetch failed')
+    expect(error.message).toContain('Could not reach Orca Cloud')
+    expect(error.message).toContain('the connection closed before a response arrived')
+    for (const secret of [
+      'secret-authorization-code',
+      'secret-code-verifier',
+      'secret-nonce',
+      'secret-state'
+    ]) {
+      expect(error.message).not.toContain(secret)
+    }
+  })
+})

--- a/src/main/orca-profiles/profile-cloud-transport.test.ts
+++ b/src/main/orca-profiles/profile-cloud-transport.test.ts
@@ -191,19 +191,32 @@ describe('Orca cloud transport failure reporting', () => {
     )
   })
 
-  it('lets callers keep redirect refusal and the request timeout', async () => {
+  it('forwards the caller timeout signal', async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
     const signal = AbortSignal.timeout(30_000)
 
     await orcaCloudFetch('https://login.onorca.dev/v1/desktop/auth/session', {
       method: 'POST',
-      redirect: 'error',
       signal
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ signal }))
+  })
+
+  // The two invariants that keep tokens from reaching another origin are
+  // enforced by the transport, not by call-site convention.
+  it('refuses to let a caller follow redirects or attach session cookies', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    await orcaCloudFetch('https://login.onorca.dev/v1/desktop/auth/session', {
+      method: 'POST',
+      redirect: 'follow',
+      credentials: 'include'
     })
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ redirect: 'error', signal })
+      expect.objectContaining({ redirect: 'error', credentials: 'omit' })
     )
   })
 })

--- a/src/main/orca-profiles/profile-cloud-transport.test.ts
+++ b/src/main/orca-profiles/profile-cloud-transport.test.ts
@@ -49,6 +49,12 @@ describe('Orca cloud transport failure reporting', () => {
     fetchMock.mockReset()
   })
 
+  // Why afterEach and not inline: a failed assertion would otherwise leave the
+  // global fetch stub installed for the live-socket suite below.
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   const cases: { label: string; error: unknown; failure: OrcaCloudTransportFailure }[] = [
     {
       label: 'undici DNS lookup failure',
@@ -66,9 +72,16 @@ describe('Orca cloud transport failure reporting', () => {
       failure: 'redirect'
     },
     {
+      // Verbatim from Electron's net.fetch with redirect: 'error'.
       label: 'Chromium redirect refusal',
-      error: new TypeError("Attempted to redirect, but redirect policy was 'error'"),
+      error: new Error("Attempted to redirect, but redirect policy was 'error'"),
       failure: 'redirect'
+    },
+    {
+      // What Electron actually reports when the peer kills the socket.
+      label: 'Chromium empty response after socket death',
+      error: new Error('net::ERR_EMPTY_RESPONSE'),
+      failure: 'connection-lost'
     },
     {
       label: 'Chromium name resolution failure',
@@ -86,6 +99,18 @@ describe('Orca cloud transport failure reporting', () => {
         'self-signed certificate in certificate chain',
         'SELF_SIGNED_CERT_IN_CHAIN'
       ),
+      failure: 'tls'
+    },
+    {
+      // Node reports these without an err_ prefix; a skewed clock makes the
+      // expiry case common, and it used to fall through to 'unknown'.
+      label: 'expired certificate from a skewed clock',
+      error: undiciError('certificate has expired', 'CERT_HAS_EXPIRED'),
+      failure: 'tls'
+    },
+    {
+      label: 'revoked certificate',
+      error: undiciError('certificate revoked', 'CERT_REVOKED'),
       failure: 'tls'
     },
     {
@@ -109,6 +134,17 @@ describe('Orca cloud transport failure reporting', () => {
       failure: 'timeout'
     },
     {
+      // The only abort these requests carry is the 30s timeout signal.
+      label: 'Chromium abort from the timeout signal',
+      error: new Error('net::ERR_ABORTED'),
+      failure: 'timeout'
+    },
+    {
+      label: 'unreachable address',
+      error: new Error('net::ERR_ADDRESS_UNREACHABLE'),
+      failure: 'offline'
+    },
+    {
       label: 'unrecognized transport failure',
       error: new Error('net::ERR_FAILED'),
       failure: 'unknown'
@@ -119,11 +155,9 @@ describe('Orca cloud transport failure reporting', () => {
     it(`classifies ${label} as ${failure}`, async () => {
       fetchMock.mockRejectedValue(error)
 
-      const thrown = await orcaCloudFetch(
-        'session-exchange',
-        'https://login.onorca.dev/v1/desktop/auth/session',
-        { method: 'POST' }
-      ).catch((caught: unknown) => caught)
+      const thrown = await orcaCloudFetch('https://login.onorca.dev/v1/desktop/auth/session', {
+        method: 'POST'
+      }).catch((caught: unknown) => caught)
 
       expect(thrown).toBeInstanceOf(OrcaCloudTransportError)
       expect((thrown as OrcaCloudTransportError).failure).toBe(failure)
@@ -137,13 +171,40 @@ describe('Orca cloud transport failure reporting', () => {
     vi.stubGlobal('fetch', globalFetch)
     fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
 
-    await orcaCloudFetch('capabilities-refresh', 'https://login.onorca.dev/v1/desktop/auth/x', {
-      method: 'POST'
-    })
+    await orcaCloudFetch('https://login.onorca.dev/v1/desktop/auth/x', { method: 'POST' })
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(globalFetch).not.toHaveBeenCalled()
-    vi.unstubAllGlobals()
+  })
+
+  // Verified against real Electron: net.fetch attaches default-session cookies
+  // unless credentials is 'omit'. Dropping this would silently start sending
+  // app cookies to token endpoints, which the previous undici path never did.
+  it('keeps ambient session cookies and cached responses off token endpoints', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+
+    await orcaCloudFetch('https://login.onorca.dev/v1/desktop/auth/session', { method: 'POST' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://login.onorca.dev/v1/desktop/auth/session',
+      expect.objectContaining({ credentials: 'omit', cache: 'no-store' })
+    )
+  })
+
+  it('lets callers keep redirect refusal and the request timeout', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) })
+    const signal = AbortSignal.timeout(30_000)
+
+    await orcaCloudFetch('https://login.onorca.dev/v1/desktop/auth/session', {
+      method: 'POST',
+      redirect: 'error',
+      signal
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ redirect: 'error', signal })
+    )
   })
 })
 

--- a/src/main/orca-profiles/profile-cloud-transport.ts
+++ b/src/main/orca-profiles/profile-cloud-transport.ts
@@ -161,16 +161,19 @@ export async function orcaCloudFetch(url: string, init: RequestInit): Promise<Re
         })
       })
       try {
-        // credentials:'omit' is load-bearing, not cosmetic — verified against
-        // Electron: net.fetch attaches default-session cookies unless told not
-        // to, which undici never did cross-origin. Token endpoints authenticate
-        // from the body or the Bearer header, so no ambient session state
-        // belongs on them. cache:'no-store' likewise keeps Chromium from
-        // serving a stale roster on the one GET route.
         const response = await net.fetch(url, {
-          credentials: 'omit',
+          // cache:'no-store' keeps Chromium from serving a stale roster on the
+          // one GET route; a caller may override it.
           cache: 'no-store',
-          ...init
+          ...init,
+          // Set after the spread so no call site can weaken them. Following a
+          // redirect would re-send a code verifier or refresh token to another
+          // origin, and net.fetch attaches default-session cookies unless told
+          // otherwise (verified against Electron) — which undici never did
+          // cross-origin. These endpoints authenticate from the body or the
+          // Bearer header, so ambient session state has no business on them.
+          redirect: 'error',
+          credentials: 'omit'
         })
         span.setAttribute('orcaCloud.status', response.status)
         return response

--- a/src/main/orca-profiles/profile-cloud-transport.ts
+++ b/src/main/orca-profiles/profile-cloud-transport.ts
@@ -32,7 +32,6 @@ const FAILURE_REASON: Record<OrcaCloudTransportFailure, string> = {
 export class OrcaCloudTransportError extends Error {
   constructor(
     public readonly failure: OrcaCloudTransportFailure,
-    public readonly operation: string,
     public readonly detail: string,
     options?: { cause?: unknown }
   ) {
@@ -41,7 +40,9 @@ export class OrcaCloudTransportError extends Error {
   }
 }
 
-type ErrorFacts = { names: string[]; codes: string[]; messages: string[] }
+// `details` holds one `code: message` string per chain level, so the reported
+// detail never pairs an outer error's code with an inner error's message.
+type ErrorFacts = { names: string[]; details: string[]; haystack: string }
 
 type ErrorLike = { name?: unknown; message?: unknown; code?: unknown; cause?: unknown }
 
@@ -55,51 +56,66 @@ function isErrorLike(value: unknown): value is ErrorLike {
 // `net::ERR_*` in the message. Both chains are walked so classification does
 // not depend on which transport produced the failure.
 function collectErrorFacts(error: unknown): ErrorFacts {
-  const facts: ErrorFacts = { names: [], codes: [], messages: [] }
+  const names: string[] = []
+  const details: string[] = []
   let current: unknown = error
   for (let depth = 0; depth < 5 && isErrorLike(current); depth += 1) {
-    if (typeof current.name === 'string') {
-      facts.names.push(current.name)
+    const name = typeof current.name === 'string' ? current.name : ''
+    const message = typeof current.message === 'string' ? current.message : ''
+    const code = typeof current.code === 'string' ? current.code : ''
+    if (name) {
+      names.push(name)
     }
-    if (typeof current.message === 'string') {
-      facts.messages.push(current.message)
-    }
-    if (typeof current.code === 'string') {
-      facts.codes.push(current.code)
+    const detail = [code, message].filter(Boolean).join(': ')
+    if (detail) {
+      details.push(detail)
     }
     current = current.cause
   }
-  return facts
+  return { names, details, haystack: details.join(' | ').toLowerCase() }
 }
 
 function classifyTransportFailure(facts: ErrorFacts): OrcaCloudTransportFailure {
-  const haystack = [...facts.codes, ...facts.messages].join(' | ').toLowerCase()
-  const matches = (pattern: RegExp): boolean => pattern.test(haystack)
+  const matches = (pattern: RegExp): boolean => pattern.test(facts.haystack)
 
+  // Why err_aborted counts as a timeout: the only abort signal these requests
+  // carry is the 30s AbortSignal.timeout, which Chromium surfaces that way.
   if (facts.names.includes('TimeoutError') || facts.names.includes('AbortError')) {
     return 'timeout'
   }
-  if (matches(/etimedout|und_err_(connect_|headers_|body_)?timeout|err_(connection_)?timed_out/)) {
+  if (
+    matches(
+      /etimedout|und_err_(connect_|headers_|body_)?timeout|err_(connection_)?timed_out|err_aborted/
+    )
+  ) {
     return 'timeout'
   }
   if (matches(/unexpected redirect|redirect (mode|policy|count)|err_(unsafe_|too_many_)redirect/)) {
     return 'redirect'
   }
+  // DNS is checked before TLS so a hostname containing "cert" cannot be
+  // mistaken for a certificate failure.
   if (matches(/enotfound|eai_again|err_name_not_resolved|err_name_resolution_failed/)) {
     return 'dns'
   }
-  if (matches(/err_cert|err_ssl|err_tls|_cert_|certificate|self.signed|unable_to_verify|eproto/)) {
+  // Bare `cert`: Node reports CERT_HAS_EXPIRED/CERT_REVOKED/CERT_UNTRUSTED
+  // without any err_ prefix, and a skewed clock makes the expiry case common.
+  if (matches(/cert|err_ssl|err_tls|self.signed|unable_to_verify|eproto/)) {
     return 'tls'
   }
   if (matches(/err_proxy|err_tunnel_connection_failed|proxy_auth/)) {
     return 'proxy'
   }
-  if (matches(/err_internet_disconnected|err_network_changed|enetunreach|enetdown|ehostunreach/)) {
+  if (
+    matches(
+      /err_internet_disconnected|err_network_changed|err_address_unreachable|enetunreach|enetdown|ehostunreach/
+    )
+  ) {
     return 'offline'
   }
   if (
     matches(
-      /econnreset|econnrefused|econnaborted|epipe|und_err_socket|err_connection_|err_empty_response/
+      /econnreset|econnrefused|econnaborted|epipe|und_err_socket|err_connection_|err_empty_response|err_socket_not_connected/
     )
   ) {
     return 'connection-lost'
@@ -107,26 +123,18 @@ function classifyTransportFailure(facts: ErrorFacts): OrcaCloudTransportFailure 
   return 'unknown'
 }
 
-// Transport-level text only (errno, net:: code, host) — never request bodies,
-// so authorization codes, verifiers, nonces, and tokens cannot leak here.
-function describeErrorChain(facts: ErrorFacts): string {
-  const deepest = facts.messages.at(-1) ?? 'unknown error'
-  const code = facts.codes.at(-1)
-  return code ? `${code}: ${deepest}` : deepest
-}
-
-function recordTransportFailure(
-  span: ActiveSpan,
-  operation: string,
-  error: unknown
-): OrcaCloudTransportError {
+function recordTransportFailure(span: ActiveSpan, error: unknown): OrcaCloudTransportError {
   const facts = collectErrorFacts(error)
   const failure = classifyTransportFailure(facts)
-  const detail = describeErrorChain(facts)
+  // Transport-level text only (errno, net:: code, host) — never request bodies,
+  // so authorization codes, verifiers, nonces, and tokens cannot leak here.
+  // Capped because this reaches a toast and the trace file, and nothing
+  // upstream promises a short message.
+  const detail = (facts.details.at(-1) || String(error)).slice(0, 200)
   span.setAttribute('orcaCloud.transportFailure', failure)
   span.setAttribute('orcaCloud.transportErrorName', facts.names.join(' <- ') || typeof error)
   span.setAttribute('orcaCloud.transportErrorDetail', detail)
-  return new OrcaCloudTransportError(failure, operation, detail, { cause: error })
+  return new OrcaCloudTransportError(failure, detail, { cause: error })
 }
 
 /**
@@ -135,16 +143,15 @@ function recordTransportFailure(
  * call survives Windows TLS interception and undici's stale keep-alive sockets
  * that global fetch could only report as `fetch failed` (orca#10758).
  */
-export async function orcaCloudFetch(
-  operation: string,
-  url: string,
-  init: RequestInit
-): Promise<Response> {
+export async function orcaCloudFetch(url: string, init: RequestInit): Promise<Response> {
   return withSpan(
     'orcaCloud.request',
     async (span) => {
-      span.setAttribute('orcaCloud.operation', operation)
-      span.setAttribute('orcaCloud.origin', new URL(url).origin)
+      const endpoint = new URL(url)
+      // Origin + path identify which call failed. The query string is dropped
+      // because it is the one part of a URL that could ever carry a secret;
+      // these endpoints put codes and tokens in the body or Bearer header.
+      span.setAttribute('orcaCloud.endpoint', `${endpoint.origin}${endpoint.pathname}`)
       await ensureElectronProxyFromEnvironment({
         proxySession: session.defaultSession,
         probeUrl: url
@@ -154,10 +161,12 @@ export async function orcaCloudFetch(
         })
       })
       try {
-        // Why the explicit defaults: Chromium would otherwise attach default-
-        // session cookies and consult the HTTP cache, neither of which the
-        // previous undici path did. Token endpoints authenticate from the body
-        // or the Bearer header, so ambient session state stays out of it.
+        // credentials:'omit' is load-bearing, not cosmetic — verified against
+        // Electron: net.fetch attaches default-session cookies unless told not
+        // to, which undici never did cross-origin. Token endpoints authenticate
+        // from the body or the Bearer header, so no ambient session state
+        // belongs on them. cache:'no-store' likewise keeps Chromium from
+        // serving a stale roster on the one GET route.
         const response = await net.fetch(url, {
           credentials: 'omit',
           cache: 'no-store',
@@ -166,7 +175,7 @@ export async function orcaCloudFetch(
         span.setAttribute('orcaCloud.status', response.status)
         return response
       } catch (error) {
-        throw recordTransportFailure(span, operation, error)
+        throw recordTransportFailure(span, error)
       }
     },
     { kind: 'client' }

--- a/src/main/orca-profiles/profile-cloud-transport.ts
+++ b/src/main/orca-profiles/profile-cloud-transport.ts
@@ -1,0 +1,174 @@
+import { net, session } from 'electron'
+import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
+import { withSpan, type ActiveSpan } from '../observability/tracer'
+
+/**
+ * Bounded categories for a cloud request that never reached an HTTP status.
+ * Global fetch collapses every one of these into `TypeError: fetch failed`
+ * (orca#10758), which left Windows sign-in failures undiagnosable.
+ */
+export type OrcaCloudTransportFailure =
+  | 'dns'
+  | 'tls'
+  | 'proxy'
+  | 'offline'
+  | 'timeout'
+  | 'redirect'
+  | 'connection-lost'
+  | 'unknown'
+
+const FAILURE_REASON: Record<OrcaCloudTransportFailure, string> = {
+  dns: 'the Orca Cloud hostname could not be resolved',
+  tls: 'the TLS handshake failed — a proxy or security tool may be intercepting HTTPS',
+  proxy: 'the configured HTTP proxy refused the connection',
+  offline: 'this machine has no working network connection',
+  timeout: 'Orca Cloud did not respond in time',
+  redirect:
+    'Orca Cloud redirected the request, and Orca never follows redirects on token endpoints',
+  'connection-lost': 'the connection closed before a response arrived',
+  unknown: 'the connection failed'
+}
+
+export class OrcaCloudTransportError extends Error {
+  constructor(
+    public readonly failure: OrcaCloudTransportFailure,
+    public readonly operation: string,
+    public readonly detail: string,
+    options?: { cause?: unknown }
+  ) {
+    super(`Could not reach Orca Cloud: ${FAILURE_REASON[failure]} (${detail})`, options)
+    this.name = 'OrcaCloudTransportError'
+  }
+}
+
+type ErrorFacts = { names: string[]; codes: string[]; messages: string[] }
+
+type ErrorLike = { name?: unknown; message?: unknown; code?: unknown; cause?: unknown }
+
+// Structural, not `instanceof Error`: DOMException timeouts and Chromium's
+// rejection objects both carry name/message without a stable prototype here.
+function isErrorLike(value: unknown): value is ErrorLike {
+  return typeof value === 'object' && value !== null && ('message' in value || 'name' in value)
+}
+
+// Undici nests the real error one or two `cause` levels down; Chromium reports
+// `net::ERR_*` in the message. Both chains are walked so classification does
+// not depend on which transport produced the failure.
+function collectErrorFacts(error: unknown): ErrorFacts {
+  const facts: ErrorFacts = { names: [], codes: [], messages: [] }
+  let current: unknown = error
+  for (let depth = 0; depth < 5 && isErrorLike(current); depth += 1) {
+    if (typeof current.name === 'string') {
+      facts.names.push(current.name)
+    }
+    if (typeof current.message === 'string') {
+      facts.messages.push(current.message)
+    }
+    if (typeof current.code === 'string') {
+      facts.codes.push(current.code)
+    }
+    current = current.cause
+  }
+  return facts
+}
+
+function classifyTransportFailure(facts: ErrorFacts): OrcaCloudTransportFailure {
+  const haystack = [...facts.codes, ...facts.messages].join(' | ').toLowerCase()
+  const matches = (pattern: RegExp): boolean => pattern.test(haystack)
+
+  if (facts.names.includes('TimeoutError') || facts.names.includes('AbortError')) {
+    return 'timeout'
+  }
+  if (matches(/etimedout|und_err_(connect_|headers_|body_)?timeout|err_(connection_)?timed_out/)) {
+    return 'timeout'
+  }
+  if (matches(/unexpected redirect|redirect (mode|policy|count)|err_(unsafe_|too_many_)redirect/)) {
+    return 'redirect'
+  }
+  if (matches(/enotfound|eai_again|err_name_not_resolved|err_name_resolution_failed/)) {
+    return 'dns'
+  }
+  if (matches(/err_cert|err_ssl|err_tls|_cert_|certificate|self.signed|unable_to_verify|eproto/)) {
+    return 'tls'
+  }
+  if (matches(/err_proxy|err_tunnel_connection_failed|proxy_auth/)) {
+    return 'proxy'
+  }
+  if (matches(/err_internet_disconnected|err_network_changed|enetunreach|enetdown|ehostunreach/)) {
+    return 'offline'
+  }
+  if (
+    matches(
+      /econnreset|econnrefused|econnaborted|epipe|und_err_socket|err_connection_|err_empty_response/
+    )
+  ) {
+    return 'connection-lost'
+  }
+  return 'unknown'
+}
+
+// Transport-level text only (errno, net:: code, host) — never request bodies,
+// so authorization codes, verifiers, nonces, and tokens cannot leak here.
+function describeErrorChain(facts: ErrorFacts): string {
+  const deepest = facts.messages.at(-1) ?? 'unknown error'
+  const code = facts.codes.at(-1)
+  return code ? `${code}: ${deepest}` : deepest
+}
+
+function recordTransportFailure(
+  span: ActiveSpan,
+  operation: string,
+  error: unknown
+): OrcaCloudTransportError {
+  const facts = collectErrorFacts(error)
+  const failure = classifyTransportFailure(facts)
+  const detail = describeErrorChain(facts)
+  span.setAttribute('orcaCloud.transportFailure', failure)
+  span.setAttribute('orcaCloud.transportErrorName', facts.names.join(' <- ') || typeof error)
+  span.setAttribute('orcaCloud.transportErrorDetail', detail)
+  return new OrcaCloudTransportError(failure, operation, detail, { cause: error })
+}
+
+/**
+ * Issue a first-party Orca Cloud request. Why net.fetch: Chromium's stack uses
+ * the OS certificate and proxy configuration and its own socket pool, so the
+ * call survives Windows TLS interception and undici's stale keep-alive sockets
+ * that global fetch could only report as `fetch failed` (orca#10758).
+ */
+export async function orcaCloudFetch(
+  operation: string,
+  url: string,
+  init: RequestInit
+): Promise<Response> {
+  return withSpan(
+    'orcaCloud.request',
+    async (span) => {
+      span.setAttribute('orcaCloud.operation', operation)
+      span.setAttribute('orcaCloud.origin', new URL(url).origin)
+      await ensureElectronProxyFromEnvironment({
+        proxySession: session.defaultSession,
+        probeUrl: url
+      }).catch((error: unknown) => {
+        span.addEvent('orcaCloud.proxySetupFailed', {
+          errorMessage: error instanceof Error ? error.message : String(error)
+        })
+      })
+      try {
+        // Why the explicit defaults: Chromium would otherwise attach default-
+        // session cookies and consult the HTTP cache, neither of which the
+        // previous undici path did. Token endpoints authenticate from the body
+        // or the Bearer header, so ambient session state stays out of it.
+        const response = await net.fetch(url, {
+          credentials: 'omit',
+          cache: 'no-store',
+          ...init
+        })
+        span.setAttribute('orcaCloud.status', response.status)
+        return response
+      } catch (error) {
+        throw recordTransportFailure(span, operation, error)
+      }
+    },
+    { kind: 'client' }
+  )
+}


### PR DESCRIPTION
Fixes #10758

## Summary

Signing in to Orca Cloud on Windows completed in the browser, returned to the loopback callback, and then failed with a bare `fetch failed`. The profile stayed local and nothing in `main.trace.ndjson` explained why.

The desktop session exchange (`POST /v1/desktop/auth/session`) ran through bare global `fetch`. Every transport-level failure — DNS, TLS interception, a refused redirect, a reset socket — surfaces from undici as the identical string `TypeError: fetch failed`, with the real diagnosis buried in `error.cause`. `connectCurrentOrcaProfile` reduces the error to `error.message` (`profile-cloud-service.ts:91`) and the renderer prints that verbatim as the toast description, so `cause` was discarded before it reached the user *or* the trace file.

This PR:

1. **Routes both cloud clients through Electron `net.fetch`** behind `ensureElectronProxyFromEnvironment`, via a new `orcaCloudFetch` in `profile-cloud-transport.ts`. This matches the existing precedent in `jira/client.ts`, `claude-accounts/oauth-refresh.ts`, and `rate-limits/claude-fetcher.ts`. Chromium's stack honors the OS certificate store and proxy configuration and keeps its own socket pool, so Windows TLS interception and undici's stale keep-alive sockets stop being silent failure modes.
2. **Classifies transport failures into a bounded category** — `dns`, `tls`, `proxy`, `offline`, `timeout`, `redirect`, `connection-lost`, `unknown` — and surfaces it with the errno / `net::` detail. The original error chain is retained as `cause` and recorded on the span (`orcaCloud.operation`, `transportFailure`, `transportErrorName`, `transportErrorDetail`), so `main.trace.ndjson` finally has something actionable.

This addresses suggestions 1–3 from the issue. Suggestion 4 (backend returning a structured error instead of closing the connection) is server-side.

## ELI5

Orca asks the sign-in server "here's my one-time code, give me a session." That question was being asked by a phone line that only knows how to say one thing when anything goes wrong: **"it didn't work."**

Not *why*. The address book couldn't find the server, the security certificate looked wrong, a corporate proxy hung up, the server tried to forward us somewhere we refuse to follow — all of it came out as the same three words. The detail *did* exist, tucked inside the error, but the code threw it away before showing anything to the user.

Two changes. First, Orca now uses **the same phone line the rest of the app uses** (Electron's network stack) — the one that knows about Windows' certificate store, corporate proxies, and doesn't reuse stale connections. Second, when a call fails, Orca now **reads the detail before throwing it away** and tells you which of the seven things went wrong.

So `fetch failed` becomes `Could not reach Orca Cloud: the TLS handshake failed — a proxy or security tool may be intercepting HTTPS (net::ERR_CERT_AUTHORITY_INVALID)`.

The bug wasn't that sign-in broke. Sign-in was *always* going to break on that machine for some environmental reason. The bug is that Orca made it impossible to find out which one.

## Screenshots

No visual change. The failure toast already renders `result.error` as its description, so it now carries the categorized message instead of `fetch failed` — no renderer changes were needed.

## Proof of fix

**1. Reproduction of the reported symptom.** Driving the shipped options (`redirect: 'error'`, 30s `AbortSignal.timeout`, bare global `fetch`) against real local servers that fail three structurally different ways:

```
connection reset mid-exchange -> {"uiMessage":"fetch failed","name":"TypeError","cause":"SocketError: other side closed","causeCode":"UND_ERR_SOCKET"}
redirect on the session endpoint -> {"uiMessage":"fetch failed","name":"TypeError","cause":"Error: unexpected redirect"}
DNS failure -> {"uiMessage":"fetch failed","name":"TypeError","cause":"Error: getaddrinfo ENOTFOUND ...","causeCode":"ENOTFOUND"}
```

Three different root causes, one indistinguishable user-facing string — exactly the report. Note the redirect case is *deterministic*, which fits "reproduces across a full app restart" better than a stale-socket theory does.

**2. Same three scenarios, before vs. after, through the production code path:**

```
### connection reset mid-exchange
BEFORE: fetch failed
AFTER  [connection-lost]: Could not reach Orca Cloud: the connection closed before a response arrived (UND_ERR_SOCKET: other side closed)

### redirect on the session endpoint
BEFORE: fetch failed
AFTER  [redirect]: Could not reach Orca Cloud: Orca Cloud redirected the request, and Orca never follows redirects on token endpoints (unexpected redirect)

### DNS failure
BEFORE: fetch failed
AFTER  [dns]: Could not reach Orca Cloud: the Orca Cloud hostname could not be resolved (ENOTFOUND: getaddrinfo ENOTFOUND login.invalid-host-10758.test)
```

**3. The new regression test fails on the shipped code.** Reverting only `profile-cloud-client.ts` to its pre-PR state and re-running:

```
FAIL  profile-cloud-transport.test.ts > reports a bounded category and never echoes the authorization code
AssertionError: expected TypeError: fetch failed to be an instance of OrcaCloudTransportError
 Tests  1 failed | 13 passed (14)
```

With the fix restored, all 14 pass. That test drives the real `exchangeOrcaCloudAuthCode` against a live socket that dies mid-request, so it asserts against a genuine undici error chain rather than a hand-built stand-in.

**4. The fix is present in the built bundle** — `out/main/index.js` contains `Could not reach Orca Cloud` and `orcaCloud.transportFailure` after `pnpm build:electron-vite`.

## Proof of no regression

The suite has substantial pre-existing failures on this Windows machine, so every number below is a **before/after comparison against the same tree**, not an absolute count.

| Scope | Pre-fix baseline | With this PR | Delta |
|---|---|---|---|
| `src/main` (1115 files) | 31 files / 96 tests failed | 31 files / 96 tests failed — identical file list, passing 15111 → 15119 | **0** |
| 11 failing files outside `src/main` | 11 files / 29 tests failed | 11 files / 29 tests failed | **0** |
| Directly affected (`orca-profiles`, profile IPC, relay, fetch audit) | — | 21 files / 115 tests **passed** | — |

Full suite: `Test Files 44 failed | 3387 passed | 25 skipped`, `Tests 126 failed | 36325 passed | 446 skipped`. Every failing file was enumerated and re-run against the pre-fix parent commit; all fail identically. They are environment-dependent (symlinks, `/bin/sh` spawn, filesystem watchers, PTY, host-boundary renderer tests) and none live in `orca-profiles`. The two suite-level "Errors" originate in `src/main/ipc/ephemeral-vm.test.ts` and `src/relay/pty-handler.test.ts`, both already in the baselined set.

Other gates:

- `pnpm typecheck` (node + cli + web) — **exit 0**
- `pnpm build:electron-vite` — **exit 0** (main, preload, renderer)
- `oxlint` — **exit 0**, zero errors
- `lint:switch-exhaustiveness`, `check:reliability-gates` (49 gates), `check:max-lines-ratchet`, `verify:bundled-skill-guides` — all pass
- `pnpm lint` overall fails at `verify:skill-bundle-manifest` (stale generated `resources/skills/*.json`). **Verified pre-existing** — the same check fails identically on a stashed clean tree, and this PR touches nothing under `resources/`.

## Testing

- [x] `pnpm lint` — passes except the pre-existing stale-skill-manifest step documented above
- [x] `pnpm typecheck`
- [x] `pnpm test` — 126 failures, all verified pre-existing against the parent commit
- [~] `pnpm build` — ran `build:electron-vite` and `typecheck`; did not run `build:native` / `build:relay` / `build:cli` / `build:web`, none of which this main-process-only change touches
- [x] Added or updated high-quality tests

New `profile-cloud-transport.test.ts`: 12 classification cases spanning both error shapes (undici errno chains and Chromium `net::ERR_*`), a guard that cloud requests never reach global fetch, and the live-socket repro test. Both existing client test files were migrated from `stubGlobal('fetch')` to mocking `net.fetch`.

## AI Review Report

Five review rounds over the diff. Each finding below was verified against the code, not eyeballed; all are fixed in follow-up commits on this branch.

**Correctness found and fixed**

- **TLS failures were misclassified as `unknown`.** Node reports certificate problems as bare `CERT_HAS_EXPIRED` / `CERT_REVOKED` / `CERT_UNTRUSTED` with no `err_` prefix, and the pattern required one. Probing the regex directly confirmed four such codes fell through. This is the *clock-skew* case, a documented adjacent report (#10401) — precisely the failure most worth naming. Matching on `cert` now; DNS is still evaluated first so a hostname containing "cert" cannot be mistaken for a certificate error.
- **`net::ERR_ABORTED` classified as `unknown`.** That is how Chromium surfaces our own 30s timeout signal. Also gave `ERR_ADDRESS_UNREACHABLE` and `ERR_SOCKET_NOT_CONNECTED` a home.
- **Detail could pair an outer error's `code` with an inner error's `message`.** Now built per chain level.

**Simplification**

- The `operation` label was threaded through five functions and eleven call sites, and `OrcaCloudTransportError.operation` was never read anywhere. Removed — the span derives the same information from the URL's origin and path. **Both cloud clients are back to a one-line change each** (`3 +-` per file, down from `26 +-` and `9 +-`). Also dropped a `codes` array the classifier no longer consulted.

**Verified rather than assumed**

Every test mocks `net.fetch`, so its real contract was unverified. Ran the actual init against real Electron:

```
[happy-path] RESOLVED status=200          <- accepts credentials/cache/redirect/signal
[redirect]   THREW  "Attempted to redirect, but redirect policy was 'error'"
[reset]      THREW  net::ERR_EMPTY_RESPONSE
[timeout]    THREW  TimeoutError
```

Two fixtures were wrong as a result and were corrected to what Electron actually throws: the redirect refusal is an `Error`, not a `TypeError`, and a dead socket reports `ERR_EMPTY_RESPONSE`, not `ERR_CONNECTION_RESET`.

**Cross-platform** — `net.fetch` is Electron-wide, not Windows-specific, and is already the norm here. Classification matches both undici errno chains and Chromium `net::ERR_*`, so no platform depends on a single error dialect. No path handling, shell invocation, or shortcut label is touched. Not SSH- or workspace-shaped: identical for git worktrees and folder workspaces. Verified every cloud entry point is reached through an IPC handler, hence after `app.whenReady()`, so `session.defaultSession` is always safe to touch.

**Auth state machine unchanged** — reconnect/refresh keys strictly on `OrcaCloudRequestError` and its status code (`isOrcaCloudAuthFailure`, `runOrgMemberCall`, the post-refresh 401 branch). A transport failure was a `TypeError` before and is an `OrcaCloudTransportError` now; both are non-`OrcaCloudRequestError`, so every branch takes the identical path.

**Deliberately not done** — no retry on transport failures. Retrying would burn the one-time authorization code and replace a truthful "connection reset" with a misleading `invalid_code`. The undici connection-pool behavior that motivated that suggestion is exactly what moving to `net.fetch` removes.

## Security Audit

**One real issue found during review, fixed and now tested.**

Electron's `net.fetch` attaches default-session cookies by default. Undici never did for these cross-origin requests. Switching stacks would therefore have *started* sending the app's session cookies to first-party token endpoints — a regression introduced by the fix itself. Confirmed against real Electron:

```
DEFAULT (no credentials option):   cookie header seen: "orca_session=SENSITIVE"
WITH credentials:'omit':           cookie header seen: null
```

`credentials: 'omit'` is therefore load-bearing, not cosmetic, and a test now asserts it so it cannot be dropped silently.

**Hardening that followed from it.** Both invariants that keep a code verifier or refresh token from reaching another origin were call-site conventions — `init` spread last, so any caller could weaken them with `redirect: 'follow'` or `credentials: 'include'`. They are now applied *after* the spread, so the transport guarantees them instead of trusting eleven call sites to agree. No behavior change today (every call site already passed `redirect: 'error'`), but the guarantee is structural, with a test that a caller attempting to opt out is overridden. Callers keep control of cache, method, headers, body, and signal.

**Reviewed and clear:**

- **Secret handling** — the failure detail derives solely from transport-layer error text (errno, `net::` code, hostname), never from the request body or headers, and is length-capped since it reaches a toast and the trace file. A test asserts the authorization code, verifier, nonce, and state never appear in the message. The span records origin + path with the query string dropped — the only part of a URL that could carry a secret; these endpoints put codes and tokens in the body or Bearer header.
- **Certificate validation** — nothing disables verification: no `rejectUnauthorized: false`, no `setCertificateVerifyProc`. Trust moves from Node's bundled CA list to the OS store, which is the platform trust model every other first-party integration here already uses.
- **SSRF** — request URLs come from `OrcaCloudAuthConfig`, built from `ORCA_CLOUD_*` environment variables. No user-controlled input reaches the host or protocol.
- **No new IPC surface, no command execution, no path handling, no deserialization, no new dependencies.** The error message crosses the existing IPC result field as a plain string.
- **Follow-up:** the relay token exchange in `runtime/relay/relay-http-client.ts` still uses global fetch and deserves the same treatment, but it runs post-sign-in and belongs to #10273.

## Notes

- Two entries were removed from `global-fetch-call-site-audit.test.ts`, since both cloud clients no longer call global fetch. `cancelUnreadResponseBody` is retained on the `!ok` path.
- Out of scope: `relay-http-client.ts` (#10273), and the server-side change in the issue's suggestion 4.

