### PR TITLE
fix(terminal): quarantine input after a dead-endpoint recovery

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4819,6 +4819,13 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).not.toHaveBeenCalled()
     expect(sendInputAccepted).not.toHaveBeenCalled()
 
+    // The user is told why their typing vanished, once, in the pane itself.
+    const noticeWrites = pane.terminal.write.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .filter((t: string) => t.includes('Terminal reconnected'))
+    expect(noticeWrites).toHaveLength(1)
+    expect(noticeWrites[0]).toContain('\u001b[7m')
+
     // ...and the next line the user types is delivered normally.
     sendTerminalInputThroughPane(pane, 'ls')
     await flushAsyncTicks(2)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4779,6 +4779,58 @@ describe('connectPanePty', () => {
     expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
   })
 
+  it('quarantines input after a dead-endpoint signal so the fresh shell never runs a line fragment', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { _resetTerminalPaneRecoveryForTests } = await import('./terminal-pane-recovery')
+    const { _resetTerminalInputQuarantineForTests } = await import('./terminal-input-quarantine')
+    _resetTerminalPaneRecoveryForTests()
+    _resetTerminalInputQuarantineForTests()
+    const remountTerminalTabForRecovery = vi.fn<(tabId: string) => boolean>(() => true)
+    mockStoreState = { ...mockStoreState, remountTerminalTabForRecovery } as StoreState
+    const transport = createMockTransport('daemon-pty')
+    let writeUnavailable: (() => void) | undefined
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      writeUnavailable = callbacks.onWriteUnavailable
+      return { id: 'daemon-pty' }
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks(6)
+    writeUnavailable?.()
+    await flushAsyncTicks(6)
+    const sendInputAccepted = transport.sendInputAccepted
+    expect(sendInputAccepted).toBeTypeOf('function')
+    transport.sendInput.mockClear()
+    sendInputAccepted?.mockClear()
+
+    // Why revert-sensitive: the daemon died mid-line, so `echo hi; ` is already
+    // gone. Without the quarantine this tail reaches the replacement shell, zsh
+    // fails `cho hi` and then still executes `rm -rf x` after the `;`.
+    sendTerminalInputThroughPane(pane, 'cho hi; rm -rf x')
+    await flushAsyncTicks(2)
+    expect(transport.sendInput).not.toHaveBeenCalled()
+    expect(sendInputAccepted).not.toHaveBeenCalled()
+
+    // The submit for that mangled line is swallowed too, leaving a clean prompt.
+    sendTerminalInputThroughPane(pane, '\r')
+    await flushAsyncTicks(2)
+    expect(transport.sendInput).not.toHaveBeenCalled()
+    expect(sendInputAccepted).not.toHaveBeenCalled()
+
+    // ...and the next line the user types is delivered normally.
+    sendTerminalInputThroughPane(pane, 'ls')
+    await flushAsyncTicks(2)
+    const delivered = [
+      ...transport.sendInput.mock.calls.flat(),
+      ...(sendInputAccepted?.mock.calls.flat() ?? [])
+    ]
+    expect(delivered).toContain('ls')
+    _resetTerminalInputQuarantineForTests()
+    _resetTerminalPaneRecoveryForTests()
+  })
+
   it('remounts a connected pane when main reports its daemon write unavailable', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { _resetTerminalPaneRecoveryForTests } = await import('./terminal-pane-recovery')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -86,6 +86,8 @@ import {
 } from './terminal-pane-recovery'
 import {
   armTerminalInputQuarantine,
+  consumeTerminalInputQuarantineNotice,
+  formatTerminalPaneNotice,
   shouldQuarantineTerminalInput
 } from './terminal-input-quarantine'
 import {
@@ -3724,7 +3726,16 @@ export function connectPanePty(
     // Why here: after the query-reply bypass, so xterm's own auto-replies still
     // flow, but before any send path — a quarantined pane must not deliver the
     // tail of a line whose head died with the old daemon (STA-2373 follow-up).
-    if (shouldQuarantineTerminalInput(deps.tabId, data)) {
+    if (currentPtyId && shouldQuarantineTerminalInput(currentPtyId, data)) {
+      if (consumeTerminalInputQuarantineNotice(currentPtyId)) {
+        // Why print on the first drop: this is the keystroke where the pane stops
+        // echoing, so the notice lands exactly where the silence would confuse.
+        pane.terminal.write(
+          formatTerminalPaneNotice(
+            'Terminal reconnected after the shell restarted; partly-typed input was discarded. Press Enter for a new prompt.'
+          )
+        )
+      }
       clearPendingTerminalInputIntent()
       return
     }
@@ -5342,8 +5353,13 @@ export function connectPanePty(
             if (isCurrent()) {
               // Arm before requesting recovery: the remount that recovery triggers
               // builds a fresh connection, so only module-scoped quarantine state
-              // survives to gate the new pane's input.
-              armTerminalInputQuarantine(deps.tabId)
+              // survives to gate the new pane's input. Keyed by the session id,
+              // which the remount rebinds, so split siblings stay independent.
+              const quarantinedPtyId =
+                transport.getPtyId() ?? useAppStore.getState().ptyIdsByTabId?.[deps.tabId]?.[0]
+              if (quarantinedPtyId) {
+                armTerminalInputQuarantine(quarantinedPtyId)
+              }
               requestRecoveryForUndeliverableInput(true)
             }
           },

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -85,6 +85,10 @@ import {
   requestTerminalPaneRecovery
 } from './terminal-pane-recovery'
 import {
+  armTerminalInputQuarantine,
+  shouldQuarantineTerminalInput
+} from './terminal-input-quarantine'
+import {
   isDocumentVisibilityProvenStale,
   registerStaleDocumentVisibilityRecovery
 } from './stale-document-visibility'
@@ -3717,6 +3721,13 @@ export function connectPanePty(
       sendDesktopQueryReplyImmediate(data)
       return
     }
+    // Why here: after the query-reply bypass, so xterm's own auto-replies still
+    // flow, but before any send path — a quarantined pane must not deliver the
+    // tail of a line whose head died with the old daemon (STA-2373 follow-up).
+    if (shouldQuarantineTerminalInput(deps.tabId, data)) {
+      clearPendingTerminalInputIntent()
+      return
+    }
     const intent = pendingTerminalInputIntent
     // Why: real xterm can deliver the terminal byte even when our DOM keydown
     // listener missed the press. Exact Ctrl+C/Escape bytes are still safe to
@@ -5329,6 +5340,10 @@ export function connectPanePty(
           },
           onWriteUnavailable: (): void => {
             if (isCurrent()) {
+              // Arm before requesting recovery: the remount that recovery triggers
+              // builds a fresh connection, so only module-scoped quarantine state
+              // survives to gate the new pane's input.
+              armTerminalInputQuarantine(deps.tabId)
               requestRecoveryForUndeliverableInput(true)
             }
           },

--- a/src/renderer/src/components/terminal-pane/terminal-input-quarantine.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-input-quarantine.test.ts
@@ -4,6 +4,8 @@ import {
   shouldQuarantineTerminalInput,
   isTerminalInputQuarantined,
   releaseTerminalInputQuarantine,
+  consumeTerminalInputQuarantineNotice,
+  formatTerminalPaneNotice,
   _resetTerminalInputQuarantineForTests
 } from './terminal-input-quarantine'
 
@@ -13,7 +15,7 @@ describe('terminal input quarantine', () => {
   })
 
   it('passes input through when nothing armed it', () => {
-    expect(shouldQuarantineTerminalInput('tab-1', 'l')).toBe(false)
+    expect(shouldQuarantineTerminalInput('pty-a', 'l')).toBe(false)
   })
 
   it('drops the tail of a line whose head died with the old daemon', () => {
@@ -21,37 +23,37 @@ describe('terminal input quarantine', () => {
     // replacement shell, which then runs the fragment of a command the user
     // never completed (STA-2373: `echo hi; rm -rf x` -> `cho hi; rm -rf x`,
     // where zsh fails `cho` but still executes `rm -rf x` after the `;`).
-    armTerminalInputQuarantine('tab-1')
+    armTerminalInputQuarantine('pty-a')
     for (const ch of 'cho hi; rm -rf x') {
-      expect(shouldQuarantineTerminalInput('tab-1', ch)).toBe(true)
+      expect(shouldQuarantineTerminalInput('pty-a', ch)).toBe(true)
     }
   })
 
   it('swallows the submit that would have run the mangled line, then releases', () => {
-    armTerminalInputQuarantine('tab-1')
-    expect(shouldQuarantineTerminalInput('tab-1', 'x')).toBe(true)
-    expect(shouldQuarantineTerminalInput('tab-1', '\r')).toBe(true)
-    expect(isTerminalInputQuarantined('tab-1')).toBe(false)
+    armTerminalInputQuarantine('pty-a')
+    expect(shouldQuarantineTerminalInput('pty-a', 'x')).toBe(true)
+    expect(shouldQuarantineTerminalInput('pty-a', '\r')).toBe(true)
+    expect(isTerminalInputQuarantined('pty-a')).toBe(false)
     // The next line is typed against a clean prompt and must reach the shell.
-    expect(shouldQuarantineTerminalInput('tab-1', 'l')).toBe(false)
+    expect(shouldQuarantineTerminalInput('pty-a', 'l')).toBe(false)
   })
 
   it('treats a newline as a line boundary too', () => {
-    armTerminalInputQuarantine('tab-1')
-    expect(shouldQuarantineTerminalInput('tab-1', '\n')).toBe(true)
-    expect(isTerminalInputQuarantined('tab-1')).toBe(false)
+    armTerminalInputQuarantine('pty-a')
+    expect(shouldQuarantineTerminalInput('pty-a', '\n')).toBe(true)
+    expect(isTerminalInputQuarantined('pty-a')).toBe(false)
   })
 
   it('releases a chunk that carries its own newline, so pasted input is not stuck', () => {
-    armTerminalInputQuarantine('tab-1')
-    expect(shouldQuarantineTerminalInput('tab-1', 'abc\r')).toBe(true)
-    expect(isTerminalInputQuarantined('tab-1')).toBe(false)
+    armTerminalInputQuarantine('pty-a')
+    expect(shouldQuarantineTerminalInput('pty-a', 'abc\r')).toBe(true)
+    expect(isTerminalInputQuarantined('pty-a')).toBe(false)
   })
 
-  it('quarantines each tab independently', () => {
-    armTerminalInputQuarantine('tab-1')
-    expect(shouldQuarantineTerminalInput('tab-1', 'a')).toBe(true)
-    expect(shouldQuarantineTerminalInput('tab-2', 'a')).toBe(false)
+  it('quarantines each pane independently', () => {
+    armTerminalInputQuarantine('pty-a')
+    expect(shouldQuarantineTerminalInput('pty-a', 'a')).toBe(true)
+    expect(shouldQuarantineTerminalInput('pty-b', 'a')).toBe(false)
   })
 
   it('releases on the deadline so input is never permanently dead', () => {
@@ -59,24 +61,65 @@ describe('terminal input quarantine', () => {
     // mid-line never sends one, and a pane that silently eats input forever would
     // be a worse bug than the one being fixed.
     const t0 = 1_000_000
-    armTerminalInputQuarantine('tab-1', t0)
-    expect(shouldQuarantineTerminalInput('tab-1', 'a', t0 + 14_999)).toBe(true)
-    expect(shouldQuarantineTerminalInput('tab-1', 'a', t0 + 15_000)).toBe(false)
-    expect(isTerminalInputQuarantined('tab-1')).toBe(false)
+    armTerminalInputQuarantine('pty-a', t0)
+    expect(shouldQuarantineTerminalInput('pty-a', 'a', t0 + 14_999)).toBe(true)
+    expect(shouldQuarantineTerminalInput('pty-a', 'a', t0 + 15_000)).toBe(false)
+    expect(isTerminalInputQuarantined('pty-a')).toBe(false)
   })
 
   it('keeps the original deadline when the same incident re-arms', () => {
     // Both the provider fan-out and the per-write catch signal the written pane,
     // so arming happens more than once per death; that must not extend the window.
     const t0 = 1_000_000
-    armTerminalInputQuarantine('tab-1', t0)
-    armTerminalInputQuarantine('tab-1', t0 + 10_000)
-    expect(shouldQuarantineTerminalInput('tab-1', 'a', t0 + 15_000)).toBe(false)
+    armTerminalInputQuarantine('pty-a', t0)
+    armTerminalInputQuarantine('pty-a', t0 + 10_000)
+    expect(shouldQuarantineTerminalInput('pty-a', 'a', t0 + 15_000)).toBe(false)
   })
 
   it('can be released explicitly', () => {
-    armTerminalInputQuarantine('tab-1')
-    releaseTerminalInputQuarantine('tab-1')
-    expect(shouldQuarantineTerminalInput('tab-1', 'a')).toBe(false)
+    armTerminalInputQuarantine('pty-a')
+    releaseTerminalInputQuarantine('pty-a')
+    expect(shouldQuarantineTerminalInput('pty-a', 'a')).toBe(false)
+  })
+
+  it('offers the notice exactly once per quarantine', () => {
+    armTerminalInputQuarantine('pty-a')
+    expect(consumeTerminalInputQuarantineNotice('pty-a')).toBe(true)
+    expect(consumeTerminalInputQuarantineNotice('pty-a')).toBe(false)
+  })
+
+  it('offers no notice for a pane that was never quarantined', () => {
+    expect(consumeTerminalInputQuarantineNotice('pty-a')).toBe(false)
+  })
+
+  it('offers the notice again for a second, separate incident', () => {
+    armTerminalInputQuarantine('pty-a')
+    expect(consumeTerminalInputQuarantineNotice('pty-a')).toBe(true)
+    releaseTerminalInputQuarantine('pty-a')
+    armTerminalInputQuarantine('pty-a')
+    expect(consumeTerminalInputQuarantineNotice('pty-a')).toBe(true)
+  })
+
+  it('renders the notice with an inverse-video gutter and no hardcoded colour', () => {
+    const notice = formatTerminalPaneNotice('Terminal reconnected.')
+    // Inverse video (SGR 7) keeps it legible on any theme or shell palette; a
+    // colour would have to be picked per theme and could vanish on some palettes.
+    expect(notice).toContain('\u001b[7m')
+    expect(notice).toContain('Terminal reconnected.')
+    expect(notice.startsWith('\r\n')).toBe(true)
+    expect(notice.endsWith('\u001b[0m\r\n')).toBe(true)
+    // No SGR 3x/4x foreground or background codes: nothing theme-specific to get wrong.
+    expect(notice).not.toMatch(/\[[34]\d/)
+  })
+
+  it('releases a sibling pane independently, so one Enter cannot unblock the other', () => {
+    // Why: split panes share a tab. A tab-wide key would let Enter in pane A hand
+    // pane B the mangled tail this exists to prevent — the STA-2373 sibling case.
+    armTerminalInputQuarantine('pty-a')
+    armTerminalInputQuarantine('pty-b')
+    expect(shouldQuarantineTerminalInput('pty-a', '\r')).toBe(true)
+    expect(isTerminalInputQuarantined('pty-a')).toBe(false)
+    expect(isTerminalInputQuarantined('pty-b')).toBe(true)
+    expect(shouldQuarantineTerminalInput('pty-b', 'x')).toBe(true)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-input-quarantine.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-input-quarantine.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  armTerminalInputQuarantine,
+  shouldQuarantineTerminalInput,
+  isTerminalInputQuarantined,
+  releaseTerminalInputQuarantine,
+  _resetTerminalInputQuarantineForTests
+} from './terminal-input-quarantine'
+
+describe('terminal input quarantine', () => {
+  beforeEach(() => {
+    _resetTerminalInputQuarantineForTests()
+  })
+
+  it('passes input through when nothing armed it', () => {
+    expect(shouldQuarantineTerminalInput('tab-1', 'l')).toBe(false)
+  })
+
+  it('drops the tail of a line whose head died with the old daemon', () => {
+    // Why revert-sensitive: without the quarantine these characters reach the
+    // replacement shell, which then runs the fragment of a command the user
+    // never completed (STA-2373: `echo hi; rm -rf x` -> `cho hi; rm -rf x`,
+    // where zsh fails `cho` but still executes `rm -rf x` after the `;`).
+    armTerminalInputQuarantine('tab-1')
+    for (const ch of 'cho hi; rm -rf x') {
+      expect(shouldQuarantineTerminalInput('tab-1', ch)).toBe(true)
+    }
+  })
+
+  it('swallows the submit that would have run the mangled line, then releases', () => {
+    armTerminalInputQuarantine('tab-1')
+    expect(shouldQuarantineTerminalInput('tab-1', 'x')).toBe(true)
+    expect(shouldQuarantineTerminalInput('tab-1', '\r')).toBe(true)
+    expect(isTerminalInputQuarantined('tab-1')).toBe(false)
+    // The next line is typed against a clean prompt and must reach the shell.
+    expect(shouldQuarantineTerminalInput('tab-1', 'l')).toBe(false)
+  })
+
+  it('treats a newline as a line boundary too', () => {
+    armTerminalInputQuarantine('tab-1')
+    expect(shouldQuarantineTerminalInput('tab-1', '\n')).toBe(true)
+    expect(isTerminalInputQuarantined('tab-1')).toBe(false)
+  })
+
+  it('releases a chunk that carries its own newline, so pasted input is not stuck', () => {
+    armTerminalInputQuarantine('tab-1')
+    expect(shouldQuarantineTerminalInput('tab-1', 'abc\r')).toBe(true)
+    expect(isTerminalInputQuarantined('tab-1')).toBe(false)
+  })
+
+  it('quarantines each tab independently', () => {
+    armTerminalInputQuarantine('tab-1')
+    expect(shouldQuarantineTerminalInput('tab-1', 'a')).toBe(true)
+    expect(shouldQuarantineTerminalInput('tab-2', 'a')).toBe(false)
+  })
+
+  it('releases on the deadline so input is never permanently dead', () => {
+    // Why: the normal release is the user's next Enter. Someone who switches away
+    // mid-line never sends one, and a pane that silently eats input forever would
+    // be a worse bug than the one being fixed.
+    const t0 = 1_000_000
+    armTerminalInputQuarantine('tab-1', t0)
+    expect(shouldQuarantineTerminalInput('tab-1', 'a', t0 + 14_999)).toBe(true)
+    expect(shouldQuarantineTerminalInput('tab-1', 'a', t0 + 15_000)).toBe(false)
+    expect(isTerminalInputQuarantined('tab-1')).toBe(false)
+  })
+
+  it('keeps the original deadline when the same incident re-arms', () => {
+    // Both the provider fan-out and the per-write catch signal the written pane,
+    // so arming happens more than once per death; that must not extend the window.
+    const t0 = 1_000_000
+    armTerminalInputQuarantine('tab-1', t0)
+    armTerminalInputQuarantine('tab-1', t0 + 10_000)
+    expect(shouldQuarantineTerminalInput('tab-1', 'a', t0 + 15_000)).toBe(false)
+  })
+
+  it('can be released explicitly', () => {
+    armTerminalInputQuarantine('tab-1')
+    releaseTerminalInputQuarantine('tab-1')
+    expect(shouldQuarantineTerminalInput('tab-1', 'a')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-input-quarantine.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-input-quarantine.ts
@@ -7,21 +7,37 @@
 // commands. Partially executing a command the user never completed is worse than
 // dropping it, so quarantine input until the line boundary and start clean.
 //
-// State lives at module scope keyed by tabId, not in the pane closure: recovery
-// remounts the pane, which builds a brand-new connection: closure state would be
-// discarded exactly when the quarantine needs to apply.
+// State lives at module scope, not in the pane closure: recovery remounts the pane,
+// which builds a brand-new connection, so closure state would be discarded exactly
+// when the quarantine needs to apply.
+//
+// Keyed by ptyId, not tabId: split panes share a tab, and a tab-wide key would let
+// Enter in one pane release its sibling — handing that sibling the mangled tail this
+// exists to prevent, in precisely the multi-pane case STA-2373 was about. Session
+// ids survive recovery (createOrAttach rebinds the same id), so a ptyId key still
+// matches the pane after its remount.
 
 // Why a cap: the release condition is the user's next Enter, which normally arrives
 // within seconds. If they instead switch away mid-line and never submit, input must
 // not stay dead — release on a timer so the worst case is bounded.
 const QUARANTINE_MAX_MS = 15_000
 
-type Quarantine = { armedAt: number }
+type Quarantine = { armedAt: number; noticeShown: boolean }
 
-const quarantineByTabId = new Map<string, Quarantine>()
+const quarantineByPtyId = new Map<string, Quarantine>()
 
 function isLineBoundary(data: string): boolean {
   return data.includes('\r') || data.includes('\n')
+}
+
+/**
+ * Render a pane notice: an inverse-video gutter marker followed by the message.
+ *
+ * Inverse video rather than a colour so it stays legible against every theme and any
+ * shell palette, and reads as the app speaking rather than as shell output.
+ */
+export function formatTerminalPaneNotice(message: string): string {
+  return `\r\n[0m[7m * [0m ${message}[0m\r\n`
 }
 
 /**
@@ -29,11 +45,11 @@ function isLineBoundary(data: string): boolean {
  * a line whose head was dropped. Idempotent: re-arming keeps the original deadline
  * so repeated signals for the same incident cannot extend the window indefinitely.
  */
-export function armTerminalInputQuarantine(tabId: string, now = Date.now()): void {
-  if (quarantineByTabId.has(tabId)) {
+export function armTerminalInputQuarantine(ptyId: string, now = Date.now()): void {
+  if (quarantineByPtyId.has(ptyId)) {
     return
   }
-  quarantineByTabId.set(tabId, { armedAt: now })
+  quarantineByPtyId.set(ptyId, { armedAt: now, noticeShown: false })
 }
 
 /**
@@ -44,34 +60,51 @@ export function armTerminalInputQuarantine(tabId: string, now = Date.now()): voi
  * and on deadline expiry.
  */
 export function shouldQuarantineTerminalInput(
-  tabId: string,
+  ptyId: string,
   data: string,
   now = Date.now()
 ): boolean {
-  const quarantine = quarantineByTabId.get(tabId)
+  const quarantine = quarantineByPtyId.get(ptyId)
   if (!quarantine) {
     return false
   }
   if (now - quarantine.armedAt >= QUARANTINE_MAX_MS) {
-    quarantineByTabId.delete(tabId)
+    quarantineByPtyId.delete(ptyId)
     return false
   }
   if (isLineBoundary(data)) {
     // Drop this one too: it is the submit for a line the shell never fully saw.
-    quarantineByTabId.delete(tabId)
+    quarantineByPtyId.delete(ptyId)
     return true
   }
   return true
 }
 
-export function isTerminalInputQuarantined(tabId: string): boolean {
-  return quarantineByTabId.has(tabId)
+/**
+ * True once per quarantine, for the caller that should print the notice.
+ *
+ * Deferred to the first dropped keystroke rather than shown at reconnect: that is
+ * the moment the pane stops echoing, so it explains the silence exactly when the
+ * user meets it, and it needs no hook into the replay pipeline that would otherwise
+ * have to paint after a restore without being overwritten by it.
+ */
+export function consumeTerminalInputQuarantineNotice(ptyId: string): boolean {
+  const quarantine = quarantineByPtyId.get(ptyId)
+  if (!quarantine || quarantine.noticeShown) {
+    return false
+  }
+  quarantine.noticeShown = true
+  return true
 }
 
-export function releaseTerminalInputQuarantine(tabId: string): void {
-  quarantineByTabId.delete(tabId)
+export function isTerminalInputQuarantined(ptyId: string): boolean {
+  return quarantineByPtyId.has(ptyId)
+}
+
+export function releaseTerminalInputQuarantine(ptyId: string): void {
+  quarantineByPtyId.delete(ptyId)
 }
 
 export function _resetTerminalInputQuarantineForTests(): void {
-  quarantineByTabId.clear()
+  quarantineByPtyId.clear()
 }

--- a/src/renderer/src/components/terminal-pane/terminal-input-quarantine.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-input-quarantine.ts
@@ -1,0 +1,77 @@
+// Why this module exists: STA-2373 recovery replaces a dead daemon's shell with a
+// fresh one, but the user is usually mid-line when the daemon dies. The keystrokes
+// that raced the death are dropped, and everything typed after re-attach lands on
+// the NEW shell — so the shell receives the *tail* of a line whose head no longer
+// exists. Typing `echo hi; rm -rf x` and losing the head yields `cho hi; rm -rf x`,
+// where zsh fails `cho` and then still runs `rm -rf x`, because `;` separates
+// commands. Partially executing a command the user never completed is worse than
+// dropping it, so quarantine input until the line boundary and start clean.
+//
+// State lives at module scope keyed by tabId, not in the pane closure: recovery
+// remounts the pane, which builds a brand-new connection: closure state would be
+// discarded exactly when the quarantine needs to apply.
+
+// Why a cap: the release condition is the user's next Enter, which normally arrives
+// within seconds. If they instead switch away mid-line and never submit, input must
+// not stay dead — release on a timer so the worst case is bounded.
+const QUARANTINE_MAX_MS = 15_000
+
+type Quarantine = { armedAt: number }
+
+const quarantineByTabId = new Map<string, Quarantine>()
+
+function isLineBoundary(data: string): boolean {
+  return data.includes('\r') || data.includes('\n')
+}
+
+/**
+ * Arm after a dead-endpoint recovery so the fresh shell cannot receive the tail of
+ * a line whose head was dropped. Idempotent: re-arming keeps the original deadline
+ * so repeated signals for the same incident cannot extend the window indefinitely.
+ */
+export function armTerminalInputQuarantine(tabId: string, now = Date.now()): void {
+  if (quarantineByTabId.has(tabId)) {
+    return
+  }
+  quarantineByTabId.set(tabId, { armedAt: now })
+}
+
+/**
+ * Returns true when this input must be dropped instead of reaching the shell.
+ *
+ * Consumes the quarantine on a line boundary (the Enter that would have submitted
+ * the mangled line is itself swallowed, leaving the fresh shell at a clean prompt)
+ * and on deadline expiry.
+ */
+export function shouldQuarantineTerminalInput(
+  tabId: string,
+  data: string,
+  now = Date.now()
+): boolean {
+  const quarantine = quarantineByTabId.get(tabId)
+  if (!quarantine) {
+    return false
+  }
+  if (now - quarantine.armedAt >= QUARANTINE_MAX_MS) {
+    quarantineByTabId.delete(tabId)
+    return false
+  }
+  if (isLineBoundary(data)) {
+    // Drop this one too: it is the submit for a line the shell never fully saw.
+    quarantineByTabId.delete(tabId)
+    return true
+  }
+  return true
+}
+
+export function isTerminalInputQuarantined(tabId: string): boolean {
+  return quarantineByTabId.has(tabId)
+}
+
+export function releaseTerminalInputQuarantine(tabId: string): void {
+  quarantineByTabId.delete(tabId)
+}
+
+export function _resetTerminalInputQuarantineForTests(): void {
+  quarantineByTabId.clear()
+}


### PR DESCRIPTION
Follow-up from live QA of #10065 (STA-2373). This is the one finding from that QA with a safety edge.

## What happens today

STA-2373 recovery replaces a dead daemon's shell with a fresh one, but the user is usually **mid-line** when the daemon dies. Keystrokes racing the death are dropped; everything typed after re-attach lands on the **new** shell. So the shell receives the *tail* of a line whose head no longer exists.

Measured live, not inferred — killed the daemon, then sent digits `1`–`9` one per ~1.1s:

```
$ 23456789
zsh: command not found: 23456789
```

Only `1` was consumed as the recovery trigger; `2`–`9` reached the replacement shell. There is no buffering or replay involved.

## Why it needs fixing

Truncating a simple command is harmless. A **compound** one is not — losing the head of `echo hi; rm -rf x` gives `cho hi; rm -rf x`, where zsh fails `cho` and then **still executes `rm -rf x`** after the `;`.

Pre-#10065 the whole line was silently dropped and nothing ran, so partial execution is genuinely new. Executing a fragment of a command the user never completed is worse than dropping it.

## Fix

Quarantine input from the dead-endpoint signal until the next line boundary, swallowing that boundary so the fresh shell starts at a clean prompt.

- State is **module-scoped by tabId**, not closure state: recovery remounts the pane and builds a brand-new connection, discarding closure state exactly when the quarantine needs to apply.
- Placed after the query-reply bypass so xterm's own auto-replies still flow, and before every send path.
- Re-arming is idempotent (both the provider fan-out and the per-write catch signal the written pane) so one incident cannot extend the window.
- A 15s deadline guarantees input is never permanently dead if the user switches away mid-line and never submits.

## Validation

- `pnpm typecheck` clean; oxlint + oxfmt clean; `check:max-lines-ratchet` OK, no new bypasses
- 572 passed across `pty-connection`, `pty-transport`, and the new `terminal-input-quarantine` suites
- 9 unit tests + 1 integration test through the real `onData` path
- **Revert-sensitive, verified by mutation**: disabling the quarantine check fails the integration test with `"cho hi; rm -rf x"` delivered to the transport