### PR TITLE
fix(runtime): refuse SSH hosts in project setup instead of acting locally

### DIFF
--- a/src/cli/specs/project.ts
+++ b/src/cli/specs/project.ts
@@ -27,7 +27,10 @@ export const PROJECT_COMMAND_SPECS: CommandSpec[] = [
     usage:
       'orca project setup-existing-folder --project <id> --host <host-id> --path <path> [--kind git|folder] [--display-name <name>] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'project', 'host', 'path', 'kind', 'display-name'],
-    notes: ['For remote runtimes, --path must be an absolute path on the remote server.'],
+    notes: [
+      'For remote runtimes, --path must be an absolute path on the remote server.',
+      'SSH targets are set up through the desktop UI because the desktop client owns SSH connections.'
+    ],
     examples: [
       'orca project setup-existing-folder --project github:stablyai/orca --host local --path ~/orca',
       'orca project setup-existing-folder --project github:stablyai/orca --host runtime:gpu --path /home/me/orca --kind git --json'

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7160,7 +7160,21 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('refuses SSH hosts instead of setting the project up on the local machine', async () => {
-    const spawnSpy = vi.spyOn(gitRunner, 'gitSpawn')
+    // Why: both inputs must be paths the pre-guard code would have accepted. An unwritable
+    // destination fails at mkdir and a non-repo path fails at isGitRepo, which would leave the
+    // side-effect assertions below unable to observe the local clone/probe they exist to catch.
+    const destination = await mkdtemp(join(tmpdir(), 'orca-runtime-ssh-guard-'))
+    const existingFolder = join(destination, 'orca')
+    mkdirSync(existingFolder, { recursive: true })
+    execFileSync('git', ['init'], { cwd: existingFolder, stdio: 'ignore' })
+    const spawnSpy = vi.spyOn(gitRunner, 'gitSpawn').mockImplementation(() => {
+      // Why: unreachable while the guard holds; stubbed so a regression records the call
+      // instead of shelling out to a real network clone.
+      const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter }
+      proc.stderr = new EventEmitter()
+      queueMicrotask(() => proc.emit('close', 1, null))
+      return proc as never
+    })
     const repos: Record<string, unknown>[] = []
     const runtimeStore = {
       ...store,
@@ -7172,29 +7186,37 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
     try {
-      await expect(
-        runtime.setupProjectClone({
+      const cloneError = await runtime
+        .setupProjectClone({
           projectId: 'github:stablyai/orca',
           hostId: 'ssh:openclaw',
           url: 'https://example.com/orca.git',
-          destination: '/home/brennan'
+          destination
         })
-      ).rejects.toThrow(/SSH hosts are not supported/)
-
-      await expect(
-        runtime.setupProjectExistingFolder({
+        .catch((error: unknown) => error)
+      const existingFolderError = await runtime
+        .setupProjectExistingFolder({
           projectId: 'github:stablyai/orca',
           hostId: 'ssh:openclaw',
-          path: '/home/brennan/orca',
+          path: existingFolder,
           kind: 'git'
         })
-      ).rejects.toThrow(/SSH hosts are not supported/)
+        .catch((error: unknown) => error)
 
-      // Why: the defect was a silent local clone/probe recorded as remote, not a bad message.
+      // Why: the defect was a silent local clone/probe recorded as remote, not a bad message,
+      // so the absent side effects are asserted before the wording. Both calls are awaited
+      // first so a regression reports the corruption rather than stopping at the first throw.
       expect(spawnSpy).not.toHaveBeenCalled()
       expect(repos).toHaveLength(0)
+      expect(cloneError).toMatchObject({
+        message: expect.stringMatching(/SSH hosts are not supported/)
+      })
+      expect(existingFolderError).toMatchObject({
+        message: expect.stringMatching(/SSH hosts are not supported/)
+      })
     } finally {
       spawnSpy.mockRestore()
+      await rm(destination, { recursive: true, force: true })
     }
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7159,6 +7159,45 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('refuses SSH hosts instead of setting the project up on the local machine', async () => {
+    const spawnSpy = vi.spyOn(gitRunner, 'gitSpawn')
+    const repos: Record<string, unknown>[] = []
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [...repos] as never,
+      addRepo: (repo: Record<string, unknown>) => {
+        repos.push(repo)
+      }
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    try {
+      await expect(
+        runtime.setupProjectClone({
+          projectId: 'github:stablyai/orca',
+          hostId: 'ssh:openclaw',
+          url: 'https://example.com/orca.git',
+          destination: '/home/brennan'
+        })
+      ).rejects.toThrow(/SSH hosts are not supported/)
+
+      await expect(
+        runtime.setupProjectExistingFolder({
+          projectId: 'github:stablyai/orca',
+          hostId: 'ssh:openclaw',
+          path: '/home/brennan/orca',
+          kind: 'git'
+        })
+      ).rejects.toThrow(/SSH hosts are not supported/)
+
+      // Why: the defect was a silent local clone/probe recorded as remote, not a bad message.
+      expect(spawnSpy).not.toHaveBeenCalled()
+      expect(repos).toHaveLength(0)
+    } finally {
+      spawnSpy.mockRestore()
+    }
+  })
+
   it('adopts public clone repos into host-qualified project setup', async () => {
     const destination = await mkdtemp(join(tmpdir(), 'orca-runtime-project-clone-'))
     const clonePath = join(destination, 'orca')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1801,6 +1801,19 @@ function runtimeRepoMatchesExecutionHost(
   return repo.connectionId == null
 }
 
+// Why: this runtime only has local git and local fs, so an ssh: host here would clone and
+// probe the wrong machine and then register the result as remote. SSH setup is owned by the
+// desktop IPC path (addRemoteRepoFromPath / cloneRemoteRepo), which the renderer routes to;
+// only `local` and `runtime:` legitimately reach these RPCs.
+function assertProjectHostSetupHostIsSupported(hostId: ExecutionHostId | null | undefined): void {
+  if (parseExecutionHostId(hostId)?.kind !== 'ssh') {
+    return
+  }
+  throw new Error(
+    'SSH hosts are not supported by this operation. Set the project up from the Orca desktop app, which owns the SSH connection.'
+  )
+}
+
 function getRuntimeFolderWorkspaceInstanceId(repo: Repo, instanceId: string): string {
   return `${getRuntimeFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
 }
@@ -14929,6 +14942,7 @@ export class OrcaRuntimeService {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
+    assertProjectHostSetupHostIsSupported(args.hostId)
     let repo = await this.addRepo(args.path, args.kind === 'folder' ? 'folder' : 'git', args.hostId)
     let setup = getProjectHostSetupForRepo(this.listProjectHostSetups(), repo)
     if (setup.projectId !== args.projectId) {
@@ -14971,6 +14985,8 @@ export class OrcaRuntimeService {
   }
 
   async setupProjectClone(args: ProjectHostSetupCloneArgs): Promise<ProjectHostSetupResult> {
+    // Why: guard before cloneRepo, which would otherwise clone to the local disk.
+    assertProjectHostSetupHostIsSupported(args.hostId)
     const repo = await this.cloneRepo(args.url, args.destination, args.hostId)
     return await this.setupProjectExistingFolder({
       projectId: args.projectId,


### PR DESCRIPTION
## Before / After

**Before — the loud failure.** Setting up a project on an SSH host from the CLI fails with an error about a path on the *local* machine:

```
$ orca project setup-clone --project github:stablyai/orca \
    --host ssh:openclaw --url ... --destination /home/brennan
ENOENT: no such file or directory, mkdir '/home/brennan'
```

Nothing on `openclaw` was ever contacted — a target that doesn't exist at all (`--host ssh:this-target-does-not-exist-xyz`) produces the identical error.

**Before — the quiet failure, which is the real problem.** Pick a destination that happens to exist locally and the same command *succeeds*:

```
$ orca project setup-clone --project github:stablyai/orca \
    --host ssh:openclaw --url ... --destination ~/src
...
hostId: ssh:openclaw
path: /Users/brennan/src/orca
...
```

Orca reports the project as set up on `openclaw` and shows it there. But nothing was ever put on `openclaw` — the checkout is on the local Mac, and every later operation on that project keeps running on the Mac while the UI attributes it to the SSH host. The user is never told. There is no error to search for and nothing in the output looks wrong unless you notice the local path sitting under a remote host.

**After.** The command refuses immediately and says where to go instead:

```
$ orca project setup-clone --project github:stablyai/orca \
    --host ssh:openclaw --url ... --destination ~/src
SSH hosts are not supported by this operation. Set the project up from the Orca desktop app, which owns the SSH connection.
```

Exit code 1. Nothing is cloned, nothing is registered, no misattributed project is left behind. `orca project setup-existing-folder --host ssh:...` behaves the same way, and both commands now say so in `--help`.

**Unchanged.** Setting up projects on SSH hosts from the Orca desktop app works exactly as before — that path always did the real remote work and is where users are pointed. `--host local` and `--host runtime:<env>` are untouched.

## Problem

`projectHostSetup.clone` and `projectHostSetup.setupExistingFolder` accept an `executionHostId` and thread it all the way down, but never use it for **routing**:

- `cloneRepoAfterPathLock` runs an unconditional local `mkdir` and a local `gitSpawn(['clone', ...])`. `executionHostId` is used in exactly one place — `runtimeRepoMatchesExecutionHost` at the existing-repo lookup — never to pick a transport.
- `addRepo` validates with `isGitRepo(path)`, which is `existsSync`/`statSync` on the local box.

So `--host ssh:<target>` clones and probes on the **local** machine, then registers the result as living on the SSH host.

Found while setting up a real SSH host from the CLI:

```
$ orca project setup-clone --project github:stablyai/orca \
    --host ssh:openclaw --url ... --destination /home/brennan/orca
ENOENT: no such file or directory, mkdir '/home/brennan'
```

A deliberately fake target (`--host ssh:this-target-does-not-exist-xyz`) produces the identical error, confirming the SSH target is never resolved.

That only failed loudly because `/home/brennan` doesn't exist on macOS. With a plausible local destination the clone **succeeds** and writes a `ProjectHostSetup` record claiming a local checkout lives on the remote — silent state corruption rather than an error.

## Why fail closed rather than route it

The two layers are complementary today, and the split is deliberate:

| host | path |
| --- | --- |
| `local`, `ssh:` | desktop IPC → `addLocalRepoFromPath` / `addRemoteRepoFromPath`, `cloneRemoteRepo` |
| `runtime:` | runtime RPC (this code) |

The renderer's `getProjectSetupRuntimeTarget` maps **only** `runtime:` to the runtime RPC; every `ssh:` variant — including ephemeral-VM `ssh:runtime-ssh-*` — goes to IPC. The IPC handler symmetrically rejects `runtime:` with *"Runtime hosts must be set up through the runtime projectHostSetup.setupExistingFolder RPC."*

So no legitimate caller sends `ssh:` here; only the CLI can, and it is always wrong. This PR makes that explicit instead of silently doing local work.

Routing these RPCs through the SSH providers is a follow-up — `SshGitProvider.clone()` and `addRemoteRepoFromPath` already exist and are what the desktop calls, so the capability is there; it just isn't wired to the RPC.

## Test

`refuses SSH hosts instead of setting the project up on the local machine` asserts both entry points reject, and — the part that matters — that `gitSpawn` was never called and no repo was registered. Verified it fails without the guard, with the same `ENOENT ... mkdir` seen in production.

## Validation

- `orca-runtime.test.ts`: 880/880 pass
- `typecheck:tsc:node`: clean
- `oxlint` on both files: clean
- `check:max-lines-ratchet`: OK, no new bypasses
