### PR TITLE
fix(codex): rank the Codex resume rescan by selected account, not settings insertion order

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -362,6 +362,22 @@ export class CodexRuntimeHomeService {
     return homes.filter((home, index) => homes.indexOf(home) === index)
   }
 
+  /**
+   * The account-owned CODEX_HOME the current HOST selection runs against, or
+   * null when the selection is not routed to one (system default, or the
+   * flag-OFF shared mirror, which every account hot-swaps and so names no
+   * account).
+   *
+   * Read-only on purpose: session discovery ranks homes with this before any
+   * launch prep, so it must create no directories and sync no auth.
+   */
+  getSelectedHostAccountCodexHomePath(): string | null {
+    const selfContainedAccount = this.getSelfContainedManagedHostAccount()
+    return selfContainedAccount
+      ? this.getTrustedSelfContainedManagedHomePath(selfContainedAccount)
+      : null
+  }
+
   // Why: the real-home hook installer flips this gate off when the trust-grant
   // client reports the host incapable, keeping that host byte-identical to the
   // managed lane instead of shipping status-blind panes.

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -226,6 +226,111 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
   })
 })
 
+describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
+  const sessionId = '019f81b9-19a9-7651-a8d1-352d9420bd11'
+  const systemHome = join('/Users', 'example', '.codex')
+  const sharedMirror = join('/userData', 'codex-runtime-home', 'home')
+  const accountAHome = join('/userData', 'codex-accounts', 'account-a', 'home')
+  const accountBHome = join('/userData', 'codex-accounts', 'account-b', 'home')
+
+  const rolloutIn = (homePath: string): string =>
+    join(homePath, 'sessions', '2026', '07', '20', `rollout-2026-07-20T15-50-19-${sessionId}.jsonl`)
+
+  // Why: PR #10770 hardlinks one rollout into every managed home, so the id alone stops naming an account.
+  const listRolloutInEveryHome = async function* (sessionsRoot: string): AsyncIterable<string> {
+    yield join(sessionsRoot, '2026', '07', '20', `rollout-2026-07-20T15-50-19-${sessionId}.jsonl`)
+  }
+
+  const listRolloutOnlyIn = (homePath: string) =>
+    async function* (sessionsRoot: string): AsyncIterable<string> {
+      if (sessionsRoot === join(homePath, 'sessions')) {
+        yield* listRolloutInEveryHome(sessionsRoot)
+      }
+    }
+
+  it('resumes into the selected account home whatever order the homes arrive in', async () => {
+    for (const trustedCodexHomes of [
+      [systemHome, sharedMirror, accountAHome, accountBHome],
+      [systemHome, sharedMirror, accountBHome, accountAHome],
+      [accountBHome, accountAHome, sharedMirror, systemHome]
+    ]) {
+      await expect(
+        findTrustedCodexSessionResume({
+          sessionId,
+          transcriptPath: undefined,
+          trustedCodexHomes,
+          selectedAccountCodexHome: accountBHome,
+          systemCodexHomePath: systemHome,
+          listSessionFiles: listRolloutInEveryHome
+        })
+      ).resolves.toEqual({ homePath: accountBHome, transcriptPath: rolloutIn(accountBHome) })
+    }
+  })
+
+  it('falls back to the real system home when no account home is selected', async () => {
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId,
+        transcriptPath: undefined,
+        trustedCodexHomes: [sharedMirror, accountAHome, systemHome],
+        selectedAccountCodexHome: null,
+        systemCodexHomePath: systemHome,
+        listSessionFiles: listRolloutInEveryHome
+      })
+    ).resolves.toEqual({ homePath: systemHome, transcriptPath: rolloutIn(systemHome) })
+  })
+
+  it('orders the remaining homes by path so insertion order never decides', async () => {
+    for (const trustedCodexHomes of [
+      [accountBHome, sharedMirror, accountAHome],
+      [accountAHome, accountBHome, sharedMirror]
+    ]) {
+      await expect(
+        findTrustedCodexSessionResume({
+          sessionId,
+          transcriptPath: undefined,
+          trustedCodexHomes,
+          selectedAccountCodexHome: null,
+          systemCodexHomePath: systemHome,
+          listSessionFiles: listRolloutInEveryHome
+        })
+      ).resolves.toEqual({ homePath: accountAHome, transcriptPath: rolloutIn(accountAHome) })
+    }
+  })
+
+  it('still resumes the only home holding the id, selected or not', async () => {
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId,
+        transcriptPath: undefined,
+        trustedCodexHomes: [systemHome, sharedMirror, accountAHome, accountBHome],
+        selectedAccountCodexHome: accountAHome,
+        systemCodexHomePath: systemHome,
+        listSessionFiles: listRolloutOnlyIn(accountBHome)
+      })
+    ).resolves.toEqual({ homePath: accountBHome, transcriptPath: rolloutIn(accountBHome) })
+  })
+
+  it('does not rescan into the selected account home when transcript provenance was rejected', async () => {
+    const listSessionFiles = vi.fn((): AsyncIterable<string> => {
+      throw new Error('must not scan')
+    })
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId,
+        transcriptPath: rolloutIn(accountBHome),
+        trustedCodexHomes: [systemHome, accountAHome, accountBHome],
+        selectedAccountCodexHome: accountAHome,
+        systemCodexHomePath: systemHome,
+        fileIsRegular: () => false,
+        listSessionFiles
+      })
+    ).resolves.toBeNull()
+    expect(listSessionFiles).not.toHaveBeenCalled()
+  })
+})
+
 describe('claimsCodexRolloutLayout', () => {
   it('is true for a rollout path even if the file is missing', () => {
     expect(

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -250,7 +250,9 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
   const rolloutIn = (homePath: string): string =>
     join(homePath, 'sessions', '2026', '07', '20', `rollout-2026-07-20T15-50-19-${sessionId}.jsonl`)
 
-  // Why: PR #10770 hardlinks one rollout into every managed home, so the id alone stops naming an account.
+  // Why: one id already lives in several homes on main — the one-shot migrateLegacySessions copies
+  // each per-account rollout into the shared mirror and leaves the original. #10770 widens this to
+  // every managed home. Either way the id alone stops naming an account.
   const listRolloutInEveryHome = async function* (sessionsRoot: string): AsyncIterable<string> {
     yield join(sessionsRoot, '2026', '07', '20', `rollout-2026-07-20T15-50-19-${sessionId}.jsonl`)
   }

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -13,7 +13,8 @@ const tempRoots: string[] = []
 // Why: the ranking inputs are required by design; cases below that never reach the rescan stay neutral.
 const withoutHomeRanking = {
   getSelectedAccountCodexHome: (): string | null => null,
-  systemCodexHomePath: null
+  systemCodexHomePath: null,
+  sharedRuntimeCodexHomePath: null
 }
 
 afterEach(() => {
@@ -274,6 +275,7 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
           trustedCodexHomes,
           getSelectedAccountCodexHome: () => accountBHome,
           systemCodexHomePath: systemHome,
+          sharedRuntimeCodexHomePath: sharedMirror,
           listSessionFiles: listRolloutInEveryHome
         })
       ).resolves.toEqual({ homePath: accountBHome, transcriptPath: rolloutIn(accountBHome) })
@@ -288,15 +290,36 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
         trustedCodexHomes: [sharedMirror, accountAHome, systemHome],
         getSelectedAccountCodexHome: () => null,
         systemCodexHomePath: systemHome,
+        sharedRuntimeCodexHomePath: sharedMirror,
         listSessionFiles: listRolloutInEveryHome
       })
     ).resolves.toEqual({ homePath: systemHome, transcriptPath: rolloutIn(systemHome) })
   })
 
+  // Why: `/Users/…` already wins the tier-3 byte order, so the case above cannot tell the
+  // system-home tier apart from the path tie-break. Pin it with a home that sorts last.
+  it('ranks the real system home above the others even when its path sorts last', async () => {
+    const lateSortingSystemHome = join('/var', 'lib', 'orca', '.codex')
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId,
+        transcriptPath: undefined,
+        trustedCodexHomes: [sharedMirror, accountAHome, lateSortingSystemHome],
+        getSelectedAccountCodexHome: () => null,
+        systemCodexHomePath: lateSortingSystemHome,
+        sharedRuntimeCodexHomePath: sharedMirror,
+        listSessionFiles: listRolloutInEveryHome
+      })
+    ).resolves.toEqual({
+      homePath: lateSortingSystemHome,
+      transcriptPath: rolloutIn(lateSortingSystemHome)
+    })
+  })
+
   it('orders the remaining homes by path so insertion order never decides', async () => {
     for (const trustedCodexHomes of [
-      [accountBHome, sharedMirror, accountAHome],
-      [accountAHome, accountBHome, sharedMirror]
+      [accountBHome, accountAHome],
+      [accountAHome, accountBHome]
     ]) {
       await expect(
         findTrustedCodexSessionResume({
@@ -305,25 +328,30 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
           trustedCodexHomes,
           getSelectedAccountCodexHome: () => null,
           systemCodexHomePath: systemHome,
+          sharedRuntimeCodexHomePath: sharedMirror,
           listSessionFiles: listRolloutInEveryHome
         })
       ).resolves.toEqual({ homePath: accountAHome, transcriptPath: rolloutIn(accountAHome) })
     }
   })
 
-  it('prefers a per-account home over the shared mirror when the system home lacks the id', async () => {
-    // Why: 'codex-accounts' sorts before 'codex-runtime-home', so tier 3 flips the pre-ranking
-    // winner here. Deliberate: the mirror is hot-swapped and names no account, the account home does.
+  // Why: the mirror is the only home whose win migrates the rollout into ~/.codex
+  // (prepareLegacySharedCodexSessionResume), which is how a system-default selection resumes on the
+  // real home. 'codex-accounts' sorts before 'codex-runtime-home', so path order alone would hand
+  // that selection to an arbitrary account instead. One-shot legacy migration already copies
+  // per-account rollouts into the mirror, so both really do hold the id.
+  it('prefers the shared mirror over a per-account home when the system home lacks the id', async () => {
     await expect(
       findTrustedCodexSessionResume({
         sessionId,
         transcriptPath: undefined,
-        trustedCodexHomes: [systemHome, sharedMirror, accountAHome],
+        trustedCodexHomes: [systemHome, accountAHome, sharedMirror],
         getSelectedAccountCodexHome: () => null,
         systemCodexHomePath: systemHome,
+        sharedRuntimeCodexHomePath: sharedMirror,
         listSessionFiles: listRolloutIn(sharedMirror, accountAHome)
       })
-    ).resolves.toEqual({ homePath: accountAHome, transcriptPath: rolloutIn(accountAHome) })
+    ).resolves.toEqual({ homePath: sharedMirror, transcriptPath: rolloutIn(sharedMirror) })
   })
 
   it('ranks Windows homes case-insensitively and keeps the caller path spelling', async () => {
@@ -345,6 +373,7 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
         // Why: settings and discovery can disagree on drive/segment case; the selection must still match.
         getSelectedAccountCodexHome: () => windowsAccountBHome.toLowerCase(),
         systemCodexHomePath: windowsSystemHome,
+        sharedRuntimeCodexHomePath: null,
         listSessionFiles
       })
     ).resolves.toEqual({
@@ -361,6 +390,7 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
         trustedCodexHomes: [systemHome, sharedMirror, accountAHome, accountBHome],
         getSelectedAccountCodexHome: () => accountAHome,
         systemCodexHomePath: systemHome,
+        sharedRuntimeCodexHomePath: sharedMirror,
         listSessionFiles: listRolloutIn(accountBHome)
       })
     ).resolves.toEqual({ homePath: accountBHome, transcriptPath: rolloutIn(accountBHome) })
@@ -378,6 +408,7 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
         trustedCodexHomes: [systemHome, accountAHome, accountBHome],
         getSelectedAccountCodexHome: () => accountAHome,
         systemCodexHomePath: systemHome,
+        sharedRuntimeCodexHomePath: sharedMirror,
         fileIsRegular: () => false,
         listSessionFiles
       })

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -10,6 +10,12 @@ import {
 
 const tempRoots: string[] = []
 
+// Why: the ranking inputs are required by design; cases below that never reach the rescan stay neutral.
+const withoutHomeRanking = {
+  getSelectedAccountCodexHome: (): string | null => null,
+  systemCodexHomePath: null
+}
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
@@ -116,7 +122,8 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
       findTrustedCodexSessionResume({
         sessionId: 'session-a',
         transcriptPath: plainPath,
-        trustedCodexHomes: [homePath]
+        trustedCodexHomes: [homePath],
+        ...withoutHomeRanking
       })
     ).resolves.toEqual({ homePath, transcriptPath: compressedPath })
 
@@ -125,7 +132,8 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
       findTrustedCodexSessionResume({
         sessionId: 'session-a',
         transcriptPath: compressedPath,
-        trustedCodexHomes: [homePath]
+        trustedCodexHomes: [homePath],
+        ...withoutHomeRanking
       })
     ).resolves.toEqual({ homePath, transcriptPath: plainPath })
   })
@@ -149,7 +157,8 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
       findTrustedCodexSessionResume({
         sessionId,
         transcriptPath: undefined,
-        trustedCodexHomes: [homePath]
+        trustedCodexHomes: [homePath],
+        ...withoutHomeRanking
       })
     ).resolves.toEqual({ homePath, transcriptPath: compressedPath })
   })
@@ -169,6 +178,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         sessionId,
         transcriptPath: undefined,
         trustedCodexHomes: ['/Users/example/.codex', '/managed/account/home'],
+        ...withoutHomeRanking,
         listSessionFiles
       })
     ).resolves.toEqual({ homePath: '/managed/account/home', transcriptPath: rolloutPath })
@@ -186,6 +196,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         sessionId: 'session-a',
         transcriptPath,
         trustedCodexHomes: ['/managed/account/home'],
+        ...withoutHomeRanking,
         fileIsRegular: () => true,
         listSessionFiles
       })
@@ -204,6 +215,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         sessionId,
         transcriptPath: `/managed/origin/home/sessions/2026/07/20/rollout-${sessionId}.jsonl`,
         trustedCodexHomes: ['/managed/origin/home', '/managed/other/home'],
+        ...withoutHomeRanking,
         fileIsRegular: () => false,
         listSessionFiles
       })
@@ -220,6 +232,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         sessionId: '../session',
         transcriptPath: undefined,
         trustedCodexHomes: ['/Users/example/.codex'],
+        ...withoutHomeRanking,
         listSessionFiles
       })
     ).resolves.toBeNull()
@@ -241,9 +254,9 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
     yield join(sessionsRoot, '2026', '07', '20', `rollout-2026-07-20T15-50-19-${sessionId}.jsonl`)
   }
 
-  const listRolloutOnlyIn = (homePath: string) =>
+  const listRolloutIn = (...homePaths: string[]) =>
     async function* (sessionsRoot: string): AsyncIterable<string> {
-      if (sessionsRoot === join(homePath, 'sessions')) {
+      if (homePaths.some((homePath) => sessionsRoot === join(homePath, 'sessions'))) {
         yield* listRolloutInEveryHome(sessionsRoot)
       }
     }
@@ -259,7 +272,7 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
           sessionId,
           transcriptPath: undefined,
           trustedCodexHomes,
-          selectedAccountCodexHome: accountBHome,
+          getSelectedAccountCodexHome: () => accountBHome,
           systemCodexHomePath: systemHome,
           listSessionFiles: listRolloutInEveryHome
         })
@@ -273,7 +286,7 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
         sessionId,
         transcriptPath: undefined,
         trustedCodexHomes: [sharedMirror, accountAHome, systemHome],
-        selectedAccountCodexHome: null,
+        getSelectedAccountCodexHome: () => null,
         systemCodexHomePath: systemHome,
         listSessionFiles: listRolloutInEveryHome
       })
@@ -290,12 +303,54 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
           sessionId,
           transcriptPath: undefined,
           trustedCodexHomes,
-          selectedAccountCodexHome: null,
+          getSelectedAccountCodexHome: () => null,
           systemCodexHomePath: systemHome,
           listSessionFiles: listRolloutInEveryHome
         })
       ).resolves.toEqual({ homePath: accountAHome, transcriptPath: rolloutIn(accountAHome) })
     }
+  })
+
+  it('prefers a per-account home over the shared mirror when the system home lacks the id', async () => {
+    // Why: 'codex-accounts' sorts before 'codex-runtime-home', so tier 3 flips the pre-ranking
+    // winner here. Deliberate: the mirror is hot-swapped and names no account, the account home does.
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId,
+        transcriptPath: undefined,
+        trustedCodexHomes: [systemHome, sharedMirror, accountAHome],
+        getSelectedAccountCodexHome: () => null,
+        systemCodexHomePath: systemHome,
+        listSessionFiles: listRolloutIn(sharedMirror, accountAHome)
+      })
+    ).resolves.toEqual({ homePath: accountAHome, transcriptPath: rolloutIn(accountAHome) })
+  })
+
+  it('ranks Windows homes case-insensitively and keeps the caller path spelling', async () => {
+    const windowsRoot = 'C:\\Users\\Example'
+    const windowsSystemHome = `${windowsRoot}\\.codex`
+    const windowsAccountAHome = `${windowsRoot}\\AppData\\Roaming\\Orca\\codex-accounts\\a\\home`
+    const windowsAccountBHome = `${windowsRoot}\\AppData\\Roaming\\Orca\\codex-accounts\\b\\home`
+    const windowsRolloutIn = (homePath: string): string =>
+      `${join(homePath, 'sessions')}\\2026\\07\\20\\rollout-2026-07-20T15-50-19-${sessionId}.jsonl`
+    const listSessionFiles = async function* (sessionsRoot: string): AsyncIterable<string> {
+      yield `${sessionsRoot}\\2026\\07\\20\\rollout-2026-07-20T15-50-19-${sessionId}.jsonl`
+    }
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId,
+        transcriptPath: undefined,
+        trustedCodexHomes: [windowsSystemHome, windowsAccountAHome, windowsAccountBHome],
+        // Why: settings and discovery can disagree on drive/segment case; the selection must still match.
+        getSelectedAccountCodexHome: () => windowsAccountBHome.toLowerCase(),
+        systemCodexHomePath: windowsSystemHome,
+        listSessionFiles
+      })
+    ).resolves.toEqual({
+      homePath: windowsAccountBHome,
+      transcriptPath: windowsRolloutIn(windowsAccountBHome)
+    })
   })
 
   it('still resumes the only home holding the id, selected or not', async () => {
@@ -304,9 +359,9 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
         sessionId,
         transcriptPath: undefined,
         trustedCodexHomes: [systemHome, sharedMirror, accountAHome, accountBHome],
-        selectedAccountCodexHome: accountAHome,
+        getSelectedAccountCodexHome: () => accountAHome,
         systemCodexHomePath: systemHome,
-        listSessionFiles: listRolloutOnlyIn(accountBHome)
+        listSessionFiles: listRolloutIn(accountBHome)
       })
     ).resolves.toEqual({ homePath: accountBHome, transcriptPath: rolloutIn(accountBHome) })
   })
@@ -321,7 +376,7 @@ describe('findTrustedCodexSessionResume legacy-rescan home ranking', () => {
         sessionId,
         transcriptPath: rolloutIn(accountBHome),
         trustedCodexHomes: [systemHome, accountAHome, accountBHome],
-        selectedAccountCodexHome: accountAHome,
+        getSelectedAccountCodexHome: () => accountAHome,
         systemCodexHomePath: systemHome,
         fileIsRegular: () => false,
         listSessionFiles

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -93,10 +93,54 @@ export function claimsCodexRolloutLayout(transcriptPath: string | undefined): bo
   return CODEX_ROLLOUT_LAYOUT_PATH.test(persistedPath.replace(/\\/g, '/'))
 }
 
+/**
+ * Orders trusted homes for the legacy id rescan, lowest wins.
+ *
+ * The winning home becomes the resumed pane's CODEX_HOME, so it picks the
+ * account. Rank the currently selected account's own home first — once a
+ * rollout is hardlinked into every managed home the id alone no longer names
+ * an account, and resuming under the account the user has selected is what
+ * they asked for. The real system home ranks next because codex refreshes it
+ * directly. Everything else is ordered by normalized path so no winner ever
+ * depends on the order accounts happen to sit in settings.
+ */
+function rankTrustedCodexHomesForRescan(args: {
+  trustedCodexHomes: readonly string[]
+  selectedAccountCodexHome?: string | null
+  systemCodexHomePath?: string | null
+}): string[] {
+  const selected = args.selectedAccountCodexHome?.trim()
+  const system = args.systemCodexHomePath?.trim()
+  const selectedComparison = selected ? normalizeRuntimePathForComparison(selected) : null
+  const systemComparison = system ? normalizeRuntimePathForComparison(system) : null
+  const rankOf = (comparisonHome: string): number => {
+    if (selectedComparison && comparisonHome === selectedComparison) {
+      return 0
+    }
+    return systemComparison && comparisonHome === systemComparison ? 1 : 2
+  }
+  return args.trustedCodexHomes
+    .map((homePath) => ({ homePath, comparisonHome: normalizeRuntimePathForComparison(homePath) }))
+    .sort((left, right) => {
+      const rankDelta = rankOf(left.comparisonHome) - rankOf(right.comparisonHome)
+      if (rankDelta !== 0) {
+        return rankDelta
+      }
+      return left.comparisonHome < right.comparisonHome
+        ? -1
+        : left.comparisonHome > right.comparisonHome
+          ? 1
+          : 0
+    })
+    .map((entry) => entry.homePath)
+}
+
 export async function findTrustedCodexSessionResume(args: {
   sessionId: string
   transcriptPath: string | undefined
   trustedCodexHomes: readonly string[]
+  selectedAccountCodexHome?: string | null
+  systemCodexHomePath?: string | null
   fileIsRegular?: (filePath: string) => boolean
   listSessionFiles?: (sessionsRoot: string) => AsyncIterable<string>
 }): Promise<{ homePath: string; transcriptPath: string } | null> {
@@ -118,7 +162,7 @@ export async function findTrustedCodexSessionResume(args: {
       listCodexSessionRolloutFilesIncrementally(sessionsRoot, { batchSize: 64, yieldMs: 0 }))
   const expectedSuffix = `-${args.sessionId}.jsonl`.toLowerCase()
   const seenHomes = new Set<string>()
-  for (const homePath of args.trustedCodexHomes) {
+  for (const homePath of rankTrustedCodexHomesForRescan(args)) {
     const comparisonHome = normalizeRuntimePathForComparison(homePath)
     if (seenHomes.has(comparisonHome)) {
       continue

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -97,19 +97,22 @@ export function claimsCodexRolloutLayout(transcriptPath: string | undefined): bo
  * Orders trusted homes for the legacy id rescan, lowest wins.
  *
  * The winning home becomes the resumed pane's CODEX_HOME, so it picks the
- * account. Rank the currently selected account's own home first — once a
- * rollout is hardlinked into every managed home the id alone no longer names
- * an account, and resuming under the account the user has selected is what
+ * account. Rank the currently selected account's own home first — once the same
+ * rollout sits in several homes the id alone no longer names an account, and
+ * resuming under the account the user has selected is what
  * they asked for. The real system home ranks next because codex refreshes it
  * directly. Everything else is ordered by normalized path so no winner ever
  * depends on the order accounts happen to sit in settings.
  *
  * The shared runtime mirror ranks above the remaining homes because winning is
- * not inert for it: it is the only home that triggers the legacy migration into
- * the real system home (prepareLegacySharedCodexSessionResume), which is how a
- * system-default selection resumes on ~/.codex instead of some account's home.
- * Letting a per-account home outrank it by mere path order would silently route
- * that selection to an account the user did not pick.
+ * not inert for it: with no account selected it is the only home that triggers
+ * the legacy migration into the real system home
+ * (prepareLegacySharedCodexSessionResume, which also requires the system-default
+ * selection), and that migration is how such a resume lands on ~/.codex instead
+ * of some account's home. Letting a per-account home outrank it by mere path
+ * order would silently route that selection to an account the user did not pick.
+ * With an account selected the migration cannot fire either way, so this tier
+ * just preserves the pre-ranking order rather than inventing a new winner.
  *
  * All inputs are required, not optional: a caller that forgot one would
  * silently degrade to pure path order, which is the accident this exists to

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -103,13 +103,19 @@ export function claimsCodexRolloutLayout(transcriptPath: string | undefined): bo
  * they asked for. The real system home ranks next because codex refreshes it
  * directly. Everything else is ordered by normalized path so no winner ever
  * depends on the order accounts happen to sit in settings.
+ *
+ * Both inputs are required, not optional: a caller that forgot one would
+ * silently degrade to pure path order, which is the accident this exists to
+ * remove. The selection arrives as a thunk because resolving it stats the
+ * account's ownership marker, and the far more common provenance-present
+ * resume never reaches the ranking at all.
  */
 function rankTrustedCodexHomesForRescan(args: {
   trustedCodexHomes: readonly string[]
-  selectedAccountCodexHome?: string | null
-  systemCodexHomePath?: string | null
+  getSelectedAccountCodexHome: () => string | null
+  systemCodexHomePath: string | null
 }): string[] {
-  const selected = args.selectedAccountCodexHome?.trim()
+  const selected = args.getSelectedAccountCodexHome()?.trim()
   const system = args.systemCodexHomePath?.trim()
   const selectedComparison = selected ? normalizeRuntimePathForComparison(selected) : null
   const systemComparison = system ? normalizeRuntimePathForComparison(system) : null
@@ -139,8 +145,8 @@ export async function findTrustedCodexSessionResume(args: {
   sessionId: string
   transcriptPath: string | undefined
   trustedCodexHomes: readonly string[]
-  selectedAccountCodexHome?: string | null
-  systemCodexHomePath?: string | null
+  getSelectedAccountCodexHome: () => string | null
+  systemCodexHomePath: string | null
   fileIsRegular?: (filePath: string) => boolean
   listSessionFiles?: (sessionsRoot: string) => AsyncIterable<string>
 }): Promise<{ homePath: string; transcriptPath: string } | null> {

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -104,7 +104,14 @@ export function claimsCodexRolloutLayout(transcriptPath: string | undefined): bo
  * directly. Everything else is ordered by normalized path so no winner ever
  * depends on the order accounts happen to sit in settings.
  *
- * Both inputs are required, not optional: a caller that forgot one would
+ * The shared runtime mirror ranks above the remaining homes because winning is
+ * not inert for it: it is the only home that triggers the legacy migration into
+ * the real system home (prepareLegacySharedCodexSessionResume), which is how a
+ * system-default selection resumes on ~/.codex instead of some account's home.
+ * Letting a per-account home outrank it by mere path order would silently route
+ * that selection to an account the user did not pick.
+ *
+ * All inputs are required, not optional: a caller that forgot one would
  * silently degrade to pure path order, which is the accident this exists to
  * remove. The selection arrives as a thunk because resolving it stats the
  * account's ownership marker, and the far more common provenance-present
@@ -114,16 +121,23 @@ function rankTrustedCodexHomesForRescan(args: {
   trustedCodexHomes: readonly string[]
   getSelectedAccountCodexHome: () => string | null
   systemCodexHomePath: string | null
+  sharedRuntimeCodexHomePath: string | null
 }): string[] {
-  const selected = args.getSelectedAccountCodexHome()?.trim()
-  const system = args.systemCodexHomePath?.trim()
-  const selectedComparison = selected ? normalizeRuntimePathForComparison(selected) : null
-  const systemComparison = system ? normalizeRuntimePathForComparison(system) : null
+  const toComparisonHome = (value: string | null | undefined): string | null => {
+    const trimmed = value?.trim()
+    return trimmed ? normalizeRuntimePathForComparison(trimmed) : null
+  }
+  const selectedComparison = toComparisonHome(args.getSelectedAccountCodexHome())
+  const systemComparison = toComparisonHome(args.systemCodexHomePath)
+  const sharedRuntimeComparison = toComparisonHome(args.sharedRuntimeCodexHomePath)
   const rankOf = (comparisonHome: string): number => {
     if (selectedComparison && comparisonHome === selectedComparison) {
       return 0
     }
-    return systemComparison && comparisonHome === systemComparison ? 1 : 2
+    if (systemComparison && comparisonHome === systemComparison) {
+      return 1
+    }
+    return sharedRuntimeComparison && comparisonHome === sharedRuntimeComparison ? 2 : 3
   }
   return args.trustedCodexHomes
     .map((homePath) => ({ homePath, comparisonHome: normalizeRuntimePathForComparison(homePath) }))
@@ -147,6 +161,7 @@ export async function findTrustedCodexSessionResume(args: {
   trustedCodexHomes: readonly string[]
   getSelectedAccountCodexHome: () => string | null
   systemCodexHomePath: string | null
+  sharedRuntimeCodexHomePath: string | null
   fileIsRegular?: (filePath: string) => boolean
   listSessionFiles?: (sessionsRoot: string) => AsyncIterable<string>
 }): Promise<{ homePath: string; transcriptPath: string } | null> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -852,7 +852,11 @@ async function prepareCodexSessionResumeForLaunch(args: {
   const sessionSource = await findTrustedCodexSessionResume({
     sessionId: args.providerSession.id,
     transcriptPath: args.providerSession.transcriptPath,
-    trustedCodexHomes: trustedHomes
+    trustedCodexHomes: trustedHomes,
+    // Why: the legacy id rescan's winning home becomes this pane's CODEX_HOME, i.e. its account;
+    // rank it by the current selection so settings insertion order can never decide the account.
+    selectedAccountCodexHome: codexRuntimeHome.getSelectedHostAccountCodexHomePath(),
+    systemCodexHomePath: systemHomePath
   })
   if (!sessionSource) {
     // Why: an unverifiable Codex rollout still blocks; only paths that never claimed Codex

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -176,7 +176,7 @@ import {
   claimsCodexRolloutLayout,
   findTrustedCodexSessionResume
 } from './codex/codex-session-resume-home'
-import { getSystemCodexHomePath } from './codex/codex-home-paths'
+import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex/codex-home-paths'
 import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
 import type { AgentProviderSessionMetadata } from '../shared/agent-session-resume'
 import { getDefaultWslDistro } from './wsl'
@@ -857,7 +857,10 @@ async function prepareCodexSessionResumeForLaunch(args: {
     // rank it by the current selection so settings insertion order can never decide the account.
     // Lazy: only the legacy branch ranks, so a provenance-present resume never stats the marker.
     getSelectedAccountCodexHome: () => codexRuntimeHome!.getSelectedHostAccountCodexHomePath(),
-    systemCodexHomePath: systemHomePath
+    systemCodexHomePath: systemHomePath,
+    // Why: the mirror winning is what triggers the migration into ~/.codex below, so it must
+    // outrank the path-sorted account homes or a system-default selection resumes as an account.
+    sharedRuntimeCodexHomePath: getOrcaManagedCodexHomePath()
   })
   if (!sessionSource) {
     // Why: an unverifiable Codex rollout still blocks; only paths that never claimed Codex

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -855,7 +855,8 @@ async function prepareCodexSessionResumeForLaunch(args: {
     trustedCodexHomes: trustedHomes,
     // Why: the legacy id rescan's winning home becomes this pane's CODEX_HOME, i.e. its account;
     // rank it by the current selection so settings insertion order can never decide the account.
-    selectedAccountCodexHome: codexRuntimeHome.getSelectedHostAccountCodexHomePath(),
+    // Lazy: only the legacy branch ranks, so a provenance-present resume never stats the marker.
+    getSelectedAccountCodexHome: () => codexRuntimeHome!.getSelectedHostAccountCodexHomePath(),
     systemCodexHomePath: systemHomePath
   })
   if (!sessionSource) {


### PR DESCRIPTION
## Root cause

`findTrustedCodexSessionResume` (`src/main/codex/codex-session-resume-home.ts`) has a legacy branch — gated on `transcriptPath` being empty — that scans trusted Codex homes for a rollout **filename** ending in the session id and returns the **first** home that has one.

The caller (`prepareCodexSessionResumeForLaunch` in `src/main/index.ts`) builds that list as `[systemHome, ...getHostCodexHomePathsForSessionDiscovery()]`, which resolves to `[systemHome, sharedRuntimeMirror, ...perAccountHomes]` — and the per-account homes come out of `settings.codexManagedAccounts` in **insertion order** (`getManagedHostAccountHomesForSessionDiscovery`).

The winning home becomes the resumed pane's `CODEX_HOME`, i.e. it **picks the account**. So the account was decided by whichever one the user happened to add first.

This was masked until now because a given rollout physically existed in exactly one home, making "first match" deterministic by construction. #10770 adds a bridge that hardlinks every rollout into *every* managed account home, preserving the session-id filename — the same id then exists in all of them and the winner becomes arbitrary. This fix is correct on `main` today and correct after that bridge lands.

## Fix

Rank the homes before scanning instead of taking the first hit. `rankTrustedCodexHomesForRescan` orders by:

1. **The currently selected account's own home.** The rescan's winner *is* the account, and once the id is present in every managed home the id alone no longer names one — so the account the user has selected is the only defensible answer.
2. **The real system home.** Codex refreshes `~/.codex` directly; it is the root that owns its own rollouts.
3. **The shared runtime mirror.** Its win is the only thing that triggers the legacy migration into `~/.codex`, so it must not lose to a per-account home on path order. See the tier-3 section below.
4. **Everything else, by normalized path.** Explicit and total, so no winner can ever depend on settings insertion order.

Ordering — not filtering — keeps the early-exit cost and keeps the single-match case byte-identical.

All three ranking inputs are **required**, not optional: a caller that forgot one would silently degrade to pure path order, which is the accident this exists to remove. The selection arrives as a thunk (`getSelectedAccountCodexHome`) so the far more common provenance-present resume does not stat the account ownership marker for a ranking it never runs.

The selection itself comes from a new read-only accessor, `CodexRuntimeHomeService.getSelectedHostAccountCodexHomePath()`, returning the account-owned self-contained home (`codex-accounts/<id>/home`) for the current HOST selection, or `null`. It creates no directories and syncs no auth — resume ranking runs before launch prep, so it must not mutate the state it reads.

## What this means semantically — please read this part

The two branches now answer two different questions, and the split is deliberate:

- **Provenance present** (`transcriptPath` non-empty) → pins to the **originating** account. The recorded path names one home; if that path no longer resolves, resume is refused outright rather than retargeted. Untouched by this PR.
- **Provenance absent** (legacy records) → follows the **current selection**. There is nothing left to pin to, so the ranking answers "which account should own this now".

**Refusing legacy records outright was considered and rejected**: it would regress every pre-provenance session to no-resume, which is a far larger blast radius than choosing a defensible account.

**The consequence that is easy to miss:** the home this ranking picks is *ratified*. Once the pane launches, the next Codex hook event reports a `transcript_path` under the winning home, and `withTranscriptPath` (`src/shared/agent-session-resume.ts:124`) stamps it into the persisted provider-session metadata. From then on the session takes the provenance-present branch and is pinned there. **The first legacy resume decides that session's account permanently.**

There is no way to do better. A real rollout's `session_meta` carries no account identity at all — only `originator`, `cli_version`, `plan_type` — and post-#10770 every copy of a rollout is the same inode, so there is no provenance signal left to recover even in principle. Ranking is the only available answer, which is why it needs to be a good one.

### On the prior art

`src/main/ai-vault/codex-session-root-dedup.ts` ranks session roots as *host real home → managed homes → other homes*. This change is consistent with it and adds one tier on top rather than reusing it verbatim:

- That rank keys off a `codexHome: string | null` column where `null` **means** "host real home", inferring the rest from path shape. Here the real system home is a concrete path the caller already holds, so passing it beats sniffing segments.
- Its canonical answer is "which alias row to display" — it has no notion of a *selected account*, which is exactly the axis that disambiguates this case. It ranks the shared runtime mirror and every per-account home equally (rank 1), so it cannot break the tie this bug is about.

Within tier 3 the ai-vault rank likewise gives no ordering between the shared mirror and per-account homes, so the lexicographic tie-break is the addition, and it matches that file's own final tie-break (`filePath <`).

## Ordering inside tier 3 — the shared mirror gets its own tier

An earlier revision of this PR let path order decide between the shared runtime mirror and the
per-account homes. Because `codex-accounts` sorts before `codex-runtime-home`, every per-account
home outranked the mirror. That was disclosed as a deliberate, low-severity account switch. **It
was neither, and it is now fixed.**

The mirror winning is not inert. It is the only home that satisfies the guard in
`prepareLegacySharedCodexSessionResume` (`codex-legacy-session-resume.ts:38-42`:
`sameRuntimePath(codexHome, legacyCodexHomePath) && isHostSystemDefaultRealHome()`), which
materializes the rollout into `~/.codex` and returns `useRealCodexHome: true`. `index.ts` then sets
`resumeHome = systemHomePath`. So the mirror losing to a per-account home **silently disabled the
migration into the real home** — precisely in the system-default case, where
`getSelectedAccountCodexHome()` returns `null` and no tier-0 match exists.

Net effect of the earlier revision: with the system default selected, the pane resumed under an
arbitrary account's credentials instead of `~/.codex`, and — because the resumed pane's hook stamps
a `transcript_path` inside the winning home — stayed **permanently pinned** there. That inverts this
PR's own thesis in the one case the thesis exists to cover.

**This did not require #10770.** The one-shot `migrateLegacySessions`
(`runtime-home-service.ts:1394-1418`, reached from `migrateLegacyManagedStateIfNeeded` over
`getLegacyManagedHomes()` = `codex-accounts/<id>/home`) **copies** each per-account rollout into the
mirror and leaves the original in place. The same id therefore already lives in both a per-account
home and the mirror on `main` today.

Fix: rank the mirror explicitly, between the system home and the path-sorted remainder.

1. The currently selected account's own home.
2. The real system home.
3. The shared runtime mirror.
4. Everything else, by normalized path.

This restores the pre-ranking mirror-before-accounts order while keeping the account-vs-account
determinism the PR exists to add. Pinned by
`prefers the shared mirror over a per-account home when the system home lacks the id`.

## Test gap closed: the system-home tier was never pinned

`falls back to the real system home when no account home is selected` passed for the wrong reason.
Its fixture system home is `/Users/example/.codex`, and `'U'` (0x55) sorts before `'u'` (0x75) in
`/userData/...`, so it already won on the tier-3 byte tie-break alone — the system-home tier could
be deleted outright with the whole suite green. Added
`ranks the real system home above the others even when its path sorts last` (a `/var/lib/orca/.codex`
home that loses the byte race).

## What is deliberately unchanged

- The `transcriptPath`-non-empty refusal is untouched. That is the account-safety property that stops stale provenance from selecting a same-id rollout under another account; only *which home wins once the scan is legitimately allowed* changed.
- `resolveTrustedCodexSessionResume` (the exact-provenance path) is untouched.
- One home holding the id → identical result, selected or not.

## Mutation proof

Reverted the production hunk (`rankTrustedCodexHomesForRescan(args)` → `args.trustedCodexHomes`) and re-ran:

```
× resumes into the selected account home whatever order the homes arrive in
× falls back to the real system home when no account home is selected
× ranks the real system home above the others even when its path sorts last
× orders the remaining homes by path so insertion order never decides
× prefers the shared mirror over a per-account home when the system home lacks the id
× ranks Windows homes case-insensitively and keeps the caller path spelling
Tests  6 failed | 18 passed (24)
```

All 6 ranking tests fail without the fix. Each puts the rollout **really present** in the contending homes (via injected `listSessionFiles`), so they exercise the delta rather than a missing-file path. Two further cases are unchanged-behaviour guards and pass either way by design: "still resumes the only home holding the id" and "does not rescan when transcript provenance was rejected". Restored; file green at 24/24.

Each tier was also mutated **individually**, restoring between runs — no tier is dead weight:

| Mutation | Result |
| --- | --- |
| drop tier 1 (selected account) | 2 failed — selected-account + Windows |
| drop tier 2 (system home) | 2 failed — both system-home cases |
| drop tier 3 (shared mirror) | 1 failed — the mirror-vs-account case |
| drop the lexicographic tie-break | 2 failed — path-order + mirror cases |

Acceptance is proved by running the selected-account case over **three different orderings** of the same fixture homes and asserting the same result.

The Windows case uses drive-letter paths on purpose: `join('/Users', ...)` yields `\Users\...` on Windows, which is not drive-absolute, so the other fixtures take the POSIX branch even on Windows CI. The `C:\...` case exercises the real Windows folding — selection spelled in a different case still matches, and the returned `homePath` keeps the caller's spelling.

## Gates

| Gate | Result |
| --- | --- |
| `tsc --noEmit -p config/tsconfig.node.json` | pass |
| `tsc --noEmit -p config/tsconfig.tc.cli.json` | pass |
| `tsc --noEmit -p config/tsconfig.tc.web.json` | pass |
| `oxlint` | exit 0, 0 errors, no new warnings |
| `check-max-lines-ratchet.mjs` | OK, no new bypasses |
| `vitest src/main/codex/ src/main/codex-accounts/ src/main/ai-vault/codex-session-root-dedup.test.ts` | 800 passed, 5 skipped, 45 files |

## Not verified

- **No live multi-account run.** The ranking is driven through injected `listSessionFiles`/`fileIsRegular`; nothing here ran against real hardlinked rollouts on disk, and the #10770 bridge that creates the ambiguity is not on `main` yet.
- **Windows behaviour is covered by fixture, not by a Windows host.** The drive-letter case pins `normalizeRuntimePathForComparison`'s Windows branch on any platform, but nothing here was executed on Windows. WSL targets return before this code (`prepareCodexSessionResumeForLaunch` bails on `runtime === 'wsl'`).

