### PR TITLE
fix(codex): keep a dismissed restart notice from killing the pane's keyboard

### DIFF
--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -7,6 +7,7 @@ import { selectCodexRestartInputs } from './codex-restart-chip-inputs'
 import { translate } from '@/i18n/i18n'
 import { shouldFocusMobileDriverAction } from './terminal-pane/mobile-driver-overlay-focus'
 import { buildCodexRestartNoticeKey } from './codex-restart-notice-key'
+import { awaitsCodexRestartAnswer } from './codex-restart-notice-state'
 import type { CodexRestartNotice } from '../store/slices/terminals'
 
 const EMPTY_TABS: { id: string }[] = []
@@ -22,12 +23,13 @@ export function collectStalePtyIdsForTabs({
 }): string[] {
   // Why: an already-requested restart runs when its pane next mounts. Keeping it
   // out of the prompt is what stops the panel from sticking on a worktree whose
-  // stale pane is parked or deferred and cannot answer the request yet.
+  // stale pane is parked or deferred and cannot answer the request yet. A
+  // dismissed notice is likewise answered — it only survives as launch-account
+  // memory.
   return tabs.flatMap((tab) =>
-    (ptyIdsByTabId[tab.id] ?? []).filter((ptyId) => {
-      const notice = codexRestartNoticeByPtyId[ptyId]
-      return Boolean(notice) && !notice?.restartRequested
-    })
+    (ptyIdsByTabId[tab.id] ?? []).filter((ptyId) =>
+      awaitsCodexRestartAnswer(codexRestartNoticeByPtyId[ptyId])
+    )
   )
 }
 
@@ -51,15 +53,13 @@ export function collectStaleWorktreePtyIds({
 
 export function dismissStaleWorktreePtyIds(
   staleWorktreePtyIds: string[],
-  clearCodexRestartNotice: (ptyId: string) => void,
+  dismissCodexRestartNotices: (ptyIds: string[]) => void,
   forgetLaunchAccounts: (ptyIds: string[]) => void
 ): void {
   // Why: restart notices are stored per PTY, but the workspace host presents
-  // one shared prompt. Clearing all matching PTY notices keeps every pane in
+  // one shared prompt. Dismissing all matching PTY notices keeps every pane in
   // that worktree consistent with the dismissal.
-  for (const ptyId of staleWorktreePtyIds) {
-    clearCodexRestartNotice(ptyId)
-  }
+  dismissCodexRestartNotices(staleWorktreePtyIds)
   // Why: notices are renderer-only, so without dropping the on-disk launch
   // record the startup sweep re-raises this exact prompt — and re-blocks the
   // pane's input — after every app restart the user already answered.
@@ -104,7 +104,7 @@ export default function CodexRestartChip({
     ? codexRestartNoticeByPtyId[staleWorktreePtyIds[0]]
     : undefined
   const queueCodexPaneRestarts = useAppStore((s) => s.queueCodexPaneRestarts)
-  const clearCodexRestartNotice = useAppStore((s) => s.clearCodexRestartNotice)
+  const dismissCodexRestartNotices = useAppStore((s) => s.dismissCodexRestartNotices)
 
   const noticeKey = restartNotice ? buildCodexRestartNoticeKey(restartNotice) : null
 
@@ -117,7 +117,7 @@ export default function CodexRestartChip({
   }
 
   const handleDismiss = (): void => {
-    dismissStaleWorktreePtyIds(staleWorktreePtyIds, clearCodexRestartNotice, (ptyIds) => {
+    dismissStaleWorktreePtyIds(staleWorktreePtyIds, dismissCodexRestartNotices, (ptyIds) => {
       void window.api.codexAccounts.forgetStalePanes({ ptyIds }).catch((err: unknown) => {
         console.warn('Failed to forget dismissed Codex pane accounts:', err)
       })

--- a/src/renderer/src/components/codex-restart-chip-inputs.test.ts
+++ b/src/renderer/src/components/codex-restart-chip-inputs.test.ts
@@ -32,9 +32,32 @@ describe('selectCodexRestartInputs', () => {
     )
   })
 
+  it('re-idles once every surviving notice is answered', () => {
+    // Why: answered notices linger as launch-account memory for the pty's whole
+    // life, so existence alone would keep every chip subscribed to pty churn.
+    const dismissed: CodexRestartInputsState = {
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      codexRestartNoticeByPtyId: {
+        'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b', dismissed: true }
+      }
+    }
+    expect(selectCodexRestartInputs(dismissed)).toBe(EMPTY_CODEX_RESTART_INPUTS)
+
+    const alsoUnanswered: CodexRestartInputsState = {
+      ...dismissed,
+      codexRestartNoticeByPtyId: {
+        ...dismissed.codexRestartNoticeByPtyId,
+        'pty-2': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+      }
+    }
+    expect(selectCodexRestartInputs(alsoUnanswered)).not.toBe(EMPTY_CODEX_RESTART_INPUTS)
+  })
+
   it('exposes both live maps the instant a restart notice exists', () => {
     const ptyIdsByTabId = { 'tab-1': ['pty-1'] }
-    const codexRestartNoticeByPtyId = { 'pty-1': {} as never }
+    const codexRestartNoticeByPtyId = {
+      'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+    }
     const state: CodexRestartInputsState = { ptyIdsByTabId, codexRestartNoticeByPtyId }
     const selected = selectCodexRestartInputs(state)
     // Live references pass straight through so the stale-pty memo + notice lookup derive fully.
@@ -47,7 +70,9 @@ describe('selectCodexRestartInputs', () => {
     const ptyIdsByTabId = { 'tab-1': ['pty-1'] }
     const s1: CodexRestartInputsState = {
       ptyIdsByTabId,
-      codexRestartNoticeByPtyId: { 'pty-1': {} as never }
+      codexRestartNoticeByPtyId: {
+        'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+      }
     }
     const r1 = selectCodexRestartInputs(s1)
     expect(shallow(r1, selectCodexRestartInputs(s1))).toBe(true)

--- a/src/renderer/src/components/codex-restart-chip-inputs.ts
+++ b/src/renderer/src/components/codex-restart-chip-inputs.ts
@@ -1,3 +1,4 @@
+import { awaitsCodexRestartAnswer } from './codex-restart-notice-state'
 import type { AppState } from '@/store/types'
 
 export type CodexRestartInputsState = Pick<AppState, 'ptyIdsByTabId' | 'codexRestartNoticeByPtyId'>
@@ -27,7 +28,10 @@ export const EMPTY_CODEX_RESTART_INPUTS: CodexRestartInputs = Object.freeze({
  * `useShallow` subscription skips re-renders on unrelated pty-lifecycle churn.
  */
 export function selectCodexRestartInputs(s: CodexRestartInputsState): CodexRestartInputs {
-  if (Object.keys(s.codexRestartNoticeByPtyId).length === 0) {
+  // Why: answered notices linger as launch-account memory for the life of the
+  // pty, so gating on mere existence would leave every chip permanently
+  // subscribed to that churn after a single dismissal.
+  if (!Object.values(s.codexRestartNoticeByPtyId).some(awaitsCodexRestartAnswer)) {
     return EMPTY_CODEX_RESTART_INPUTS
   }
   return {

--- a/src/renderer/src/components/codex-restart-chip.test.ts
+++ b/src/renderer/src/components/codex-restart-chip.test.ts
@@ -98,15 +98,28 @@ describe('CodexRestartChip helpers', () => {
   })
 
   it('dismisses every stale PTY notice in the worktree prompt', () => {
-    const clearCodexRestartNotice = vi.fn()
+    const dismissCodexRestartNotices = vi.fn()
     const forgetLaunchAccounts = vi.fn()
 
-    dismissStaleWorktreePtyIds(['pty-1', 'pty-3'], clearCodexRestartNotice, forgetLaunchAccounts)
+    dismissStaleWorktreePtyIds(['pty-1', 'pty-3'], dismissCodexRestartNotices, forgetLaunchAccounts)
 
-    expect(clearCodexRestartNotice).toHaveBeenNthCalledWith(1, 'pty-1')
-    expect(clearCodexRestartNotice).toHaveBeenNthCalledWith(2, 'pty-3')
-    expect(clearCodexRestartNotice).toHaveBeenCalledTimes(2)
+    expect(dismissCodexRestartNotices).toHaveBeenCalledWith(['pty-1', 'pty-3'])
     expect(forgetLaunchAccounts).toHaveBeenCalledWith(['pty-1', 'pty-3'])
+  })
+
+  it('drops dismissed PTYs from the prompt while keeping their launch account', () => {
+    expect(
+      collectStalePtyIdsForTabs({
+        tabs: [{ id: 'tab-1' }],
+        ptyIdsByTabId: {
+          'tab-1': ['pty-1', 'pty-2']
+        },
+        codexRestartNoticeByPtyId: {
+          'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b', dismissed: true },
+          'pty-2': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+        }
+      })
+    ).toEqual(['pty-2'])
   })
 
   it('renders only account-resolution actions without an external-store update loop', async () => {
@@ -188,7 +201,131 @@ describe('CodexRestartChip helpers', () => {
 
     // Why: without this the startup sweep re-raises the prompt the user just answered.
     expect(forgetStalePanes).toHaveBeenCalledWith({ ptyIds: ['pty-1'] })
-    expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+    expect(container.textContent).toBe('')
+    // Why: the record survives as the pane's launch-account memory, but marked
+    // answered so it neither prompts again nor blocks the pane's keyboard.
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: 'old@example.com',
+      nextAccountLabel: 'new@example.com',
+      dismissed: true
+    })
+  })
+
+  it('stays closed when the user re-selects the account the pane launched under', async () => {
+    const forgetStalePanes = vi.fn(() => Promise.resolve())
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { codexAccounts: { forgetStalePanes } }
+    })
+    useAppStore.setState({
+      tabsByWorktree: {
+        'worktree-1': [
+          {
+            id: 'tab-1',
+            worktreeId: 'worktree-1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    })
+    useAppStore
+      .getState()
+      .markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'old@example.com',
+          nextAccountLabel: 'new@example.com'
+        }
+      ])
+    await act(async () => {
+      root.render(React.createElement(CodexRestartChip, { worktreeId: 'worktree-1' }))
+    })
+    const dismissButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Keep old account'
+    )
+    await act(async () => {
+      dismissButton?.click()
+    })
+
+    // Re-select the pane's original account: it never left it, so there is
+    // nothing to restart and nothing to prompt about.
+    await act(async () => {
+      useAppStore.getState().markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'new@example.com',
+          nextAccountLabel: 'old@example.com'
+        }
+      ])
+    })
+
+    expect(container.textContent).toBe('')
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeUndefined()
+  })
+
+  it('reopens the prompt when a dismissed pane is out of date against a third account', async () => {
+    const forgetStalePanes = vi.fn(() => Promise.resolve())
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { codexAccounts: { forgetStalePanes } }
+    })
+    useAppStore.setState({
+      tabsByWorktree: {
+        'worktree-1': [
+          {
+            id: 'tab-1',
+            worktreeId: 'worktree-1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    })
+    useAppStore
+      .getState()
+      .markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'old@example.com',
+          nextAccountLabel: 'new@example.com'
+        }
+      ])
+    await act(async () => {
+      root.render(React.createElement(CodexRestartChip, { worktreeId: 'worktree-1' }))
+    })
+    const dismissButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Keep old account'
+    )
+    await act(async () => {
+      dismissButton?.click()
+    })
+    expect(container.textContent).toBe('')
+
+    await act(async () => {
+      useAppStore.getState().markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'new@example.com',
+          nextAccountLabel: 'third@example.com'
+        }
+      ])
+    })
+
+    // Why: the dismissal answered "keep old instead of new", not "never prompt
+    // again"; the pane really is out of date against third@example.com.
+    expect(container.textContent).toContain('Codex is still signed in as old@example.com')
+    expect(container.textContent).toContain('Restart this session to use third@example.com')
   })
 
   it('closes the prompt after Restart even when no mounted pane can run it yet', async () => {

--- a/src/renderer/src/components/codex-restart-notice-state.ts
+++ b/src/renderer/src/components/codex-restart-notice-state.ts
@@ -1,0 +1,18 @@
+type CodexRestartNoticeState = { restartRequested?: true; dismissed?: true } | null | undefined
+
+/**
+ * True while the pane must not accept keystrokes.
+ *
+ * Why the two answered states differ: a requested restart still leaves the pane
+ * running under the old account until it actually relaunches, so its input stays
+ * blocked. A dismissal is the user choosing to keep that account, so blocking
+ * their keyboard would punish them for answering.
+ */
+export function blocksCodexPaneInput(notice: CodexRestartNoticeState): boolean {
+  return Boolean(notice) && !notice?.dismissed
+}
+
+/** True while the restart prompt still has an unanswered question for the user. */
+export function awaitsCodexRestartAnswer(notice: CodexRestartNoticeState): boolean {
+  return Boolean(notice) && !notice?.dismissed && !notice?.restartRequested
+}

--- a/src/renderer/src/components/status-bar/codex-restart-status-summary.test.ts
+++ b/src/renderer/src/components/status-bar/codex-restart-status-summary.test.ts
@@ -78,6 +78,25 @@ describe('summarizeCodexRestartStatus', () => {
     })
   })
 
+  it('stops offering sessions the user chose to keep on the old account', () => {
+    expect(
+      summarizeCodexRestartStatus({
+        tabsByWorktree: { wt1: [{ id: 'tab-1' }] },
+        ptyIdsByTabId: { 'tab-1': ['pty-1', 'pty-2'] },
+        codexRestartNoticeByPtyId: {
+          // Why: the dismissed record survives only as launch-account memory.
+          'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b', dismissed: true },
+          'pty-2': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+        }
+      })
+    ).toEqual({
+      stalePtyIds: ['pty-2'],
+      staleSessionCount: 1,
+      staleTabCount: 1,
+      staleWorktreeCount: 1
+    })
+  })
+
   it('hides the prompt once every stale session has a requested restart', () => {
     expect(
       summarizeCodexRestartStatus({

--- a/src/renderer/src/components/status-bar/codex-restart-status-summary.ts
+++ b/src/renderer/src/components/status-bar/codex-restart-status-summary.ts
@@ -1,3 +1,4 @@
+import { awaitsCodexRestartAnswer } from '@/components/codex-restart-notice-state'
 import type { CodexRestartNotice } from '@/store/slices/terminals'
 
 type TabLookup = Record<string, { id: string }[]>
@@ -28,9 +29,10 @@ export function summarizeCodexRestartStatus({
   codexRestartNoticeByPtyId
 }: CodexRestartStatusSummaryInput): CodexRestartStatusSummary {
   // Why: a requested restart is already scheduled for its pane's next mount, so
-  // re-offering it here would leave a prompt whose button does nothing.
+  // re-offering it here would leave a prompt whose button does nothing; a
+  // dismissed notice survives only as launch-account memory.
   const stalePtyIds = Object.entries(codexRestartNoticeByPtyId)
-    .filter(([, notice]) => notice && !notice.restartRequested)
+    .filter(([, notice]) => awaitsCodexRestartAnswer(notice))
     .map(([ptyId]) => ptyId)
   if (stalePtyIds.length === 0) {
     return EMPTY_CODEX_RESTART_STATUS_SUMMARY

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -176,7 +176,12 @@ type StoreState = {
   } | null
   codexRestartNoticeByPtyId: Record<
     string,
-    { previousAccountLabel: string; nextAccountLabel: string }
+    {
+      previousAccountLabel: string
+      nextAccountLabel: string
+      restartRequested?: true
+      dismissed?: true
+    }
   >
   deferredSshReconnectTargets: string[]
   deferredSshSessionIdsByTabId: Record<string, string>
@@ -4473,6 +4478,112 @@ describe('connectPanePty', () => {
       ),
       codexRestartNoticeByPtyId: {
         'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B' }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).not.toHaveBeenCalled()
+  })
+
+  it('restores input to a Codex pane whose restart notice the user dismissed', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-live')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-live'] },
+      // Why: the record survives a dismissal as launch-account memory, so the
+      // input gate has to read the marker rather than the record's existence.
+      codexRestartNoticeByPtyId: {
+        'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B', dismissed: true }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('restores input through the tab fallback when the dismissed pane has no live PTY binding', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport(null)
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-live'] },
+      codexRestartNoticeByPtyId: {
+        'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B', dismissed: true }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('keeps blocking input on a pane whose restart is requested but not yet run', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-live')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-live'] },
+      // Why: unlike a dismissal, a queued restart leaves the pane running under
+      // the old account until it actually relaunches.
+      codexRestartNoticeByPtyId: {
+        'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B', restartRequested: true }
       }
     }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4651,6 +4651,45 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).not.toHaveBeenCalled()
   })
 
+  it('keeps a bound pane with no notice typing while a sibling holds a queued restart', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-plain-shell')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      // Why: a requested restart hides the prompt, so blocking this record-less
+      // pane through `tab.ptyId` would leave a dead keyboard and nothing to answer.
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-sibling' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-plain-shell', 'pty-sibling'] },
+      codexRestartNoticeByPtyId: {
+        'pty-sibling': { previousAccountLabel: 'A', nextAccountLabel: 'B', restartRequested: true }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps({
+      paneTransportsRef: { current: new Map([[2, createMockTransport('pty-sibling')]]) }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('pty-plain-shell')
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
   it('keeps blocking input on a pane whose restart is requested but not yet run', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4571,6 +4571,86 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).toHaveBeenCalledWith('a')
   })
 
+  it('keeps a dismissed split pane typing while a sibling still holds the prompt', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-dismissed')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      // Why: `tab.ptyId` is whichever pane bound last, so a sibling's unanswered
+      // notice would otherwise kill this pane's keyboard with no prompt of its own.
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-sibling' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-dismissed', 'pty-sibling'] },
+      codexRestartNoticeByPtyId: {
+        'pty-dismissed': { previousAccountLabel: 'A', nextAccountLabel: 'B', dismissed: true },
+        'pty-sibling': { previousAccountLabel: 'A', nextAccountLabel: 'C' }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps({
+      // Why: the sibling already holds `tab.ptyId`, which is what makes this a
+      // split rather than this pane adopting the tab's binding.
+      paneTransportsRef: { current: new Map([[2, createMockTransport('pty-sibling')]]) }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('pty-dismissed')
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('keeps blocking a pane with its own unanswered notice next to a dismissed sibling', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-stale')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-sibling' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-stale', 'pty-sibling'] },
+      codexRestartNoticeByPtyId: {
+        'pty-stale': { previousAccountLabel: 'A', nextAccountLabel: 'B' },
+        'pty-sibling': { previousAccountLabel: 'A', nextAccountLabel: 'B', dismissed: true }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps({
+      paneTransportsRef: { current: new Map([[2, createMockTransport('pty-sibling')]]) }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('pty-stale')
+    expect(transport.sendInput).not.toHaveBeenCalled()
+  })
+
   it('keeps blocking input on a pane whose restart is requested but not yet run', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -827,14 +827,17 @@ function isCodexPaneStale(args: {
   if (!hasCodexRestartNotices(codexRestartNoticeByPtyId)) {
     return false
   }
-  // Why: the pane's own record is the last word. `tab.ptyId` names whichever
-  // pane bound last, so in a split tab consulting it would keep this pane's
-  // keyboard dead over a sibling's prompt the user cannot answer for this pane.
-  const paneNotice = args.panePtyId ? codexRestartNoticeByPtyId[args.panePtyId] : undefined
-  if (paneNotice) {
-    return blocksCodexPaneInput(paneNotice)
+  // Why: a bound pane's own record is the last word — its ptyId is exactly the
+  // shell its keystrokes reach. `tab.ptyId` names whichever pane bound last, so
+  // in a split tab consulting it would kill this pane's keyboard over a
+  // sibling's notice, with no prompt on screen once that sibling is answered.
+  if (args.panePtyId) {
+    return blocksCodexPaneInput(codexRestartNoticeByPtyId[args.panePtyId])
   }
 
+  // Why: only an unbound pane needs the tab's persisted id. Both transports
+  // refuse writes while their pty binding is null, so a keystroke here arms
+  // recovery, which reattaches to that id — the shell this pane is about to own.
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)
   if (tab?.ptyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[tab.ptyId])) {
     return true

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -828,16 +828,17 @@ function isCodexPaneStale(args: {
     return false
   }
   // Why: a bound pane's own record is the last word — its ptyId is exactly the
-  // shell its keystrokes reach. `tab.ptyId` names whichever pane bound last, so
-  // in a split tab consulting it would kill this pane's keyboard over a
-  // sibling's notice, with no prompt on screen once that sibling is answered.
+  // shell its keystrokes reach. `tab.ptyId` holds one sibling's id, not this
+  // pane's, so in a split tab consulting it would kill this pane's keyboard over
+  // that sibling's notice, with no prompt on screen once the sibling is answered.
   if (args.panePtyId) {
     return blocksCodexPaneInput(codexRestartNoticeByPtyId[args.panePtyId])
   }
 
   // Why: only an unbound pane needs the tab's persisted id. Both transports
   // refuse writes while their pty binding is null, so a keystroke here arms
-  // recovery, which reattaches to that id — the shell this pane is about to own.
+  // recovery — a coarser signal than a bound pane's own record, but the tab's id
+  // is the only evidence available of which shell this pane is about to own.
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)
   if (tab?.ptyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[tab.ptyId])) {
     return true

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5,6 +5,7 @@ import type { IBuffer, IDisposable } from '@xterm/xterm'
 import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
 import { detectAgentStatusFromTitle, agentTypeToIconAgent, isClaudeAgent } from '@/lib/agent-status'
 import { resolvePaneTitleDecision } from './terminal-title-evidence'
+import { blocksCodexPaneInput } from '../codex-restart-notice-state'
 import { resolveLiveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
@@ -826,12 +827,12 @@ function isCodexPaneStale(args: {
   if (!hasCodexRestartNotices(codexRestartNoticeByPtyId)) {
     return false
   }
-  if (args.panePtyId && codexRestartNoticeByPtyId[args.panePtyId]) {
+  if (args.panePtyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[args.panePtyId])) {
     return true
   }
 
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)
-  if (tab?.ptyId && codexRestartNoticeByPtyId[tab.ptyId]) {
+  if (tab?.ptyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[tab.ptyId])) {
     return true
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -827,8 +827,12 @@ function isCodexPaneStale(args: {
   if (!hasCodexRestartNotices(codexRestartNoticeByPtyId)) {
     return false
   }
-  if (args.panePtyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[args.panePtyId])) {
-    return true
+  // Why: the pane's own record is the last word. `tab.ptyId` names whichever
+  // pane bound last, so in a split tab consulting it would keep this pane's
+  // keyboard dead over a sibling's prompt the user cannot answer for this pane.
+  const paneNotice = args.panePtyId ? codexRestartNoticeByPtyId[args.panePtyId] : undefined
+  if (paneNotice) {
+    return blocksCodexPaneInput(paneNotice)
   }
 
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)

--- a/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '../index'
+
+const A = 'a@example.com'
+const B = 'b@example.com'
+const C = 'c@example.com'
+
+function switchAccount(ptyId: string, from: string, to: string): void {
+  useAppStore
+    .getState()
+    .markCodexRestartNotices([{ ptyId, previousAccountLabel: from, nextAccountLabel: to }])
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState(), true)
+})
+
+describe('codex restart notice lifecycle', () => {
+  it('raises no notice when the pane returns to the account it launched under', () => {
+    switchAccount('pty-1', A, B)
+    switchAccount('pty-1', B, A)
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeUndefined()
+  })
+
+  it('keeps the launch account after a dismissal so re-selecting it raises no notice', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    switchAccount('pty-1', B, A)
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeUndefined()
+  })
+
+  it('marks a dismissal instead of erasing the pane record', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: B,
+      dismissed: true
+    })
+  })
+
+  it('re-raises the prompt against the pane launch account when a third account is selected', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    switchAccount('pty-1', B, C)
+
+    // Why: over-suppressing here would silently strand the pane on A while the
+    // user works under C; the labels must name the launch account, not B.
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: C
+    })
+  })
+
+  it('drops a queued restart when the user dismisses the same pane', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().queueCodexPaneRestarts(['pty-1'])
+
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: B,
+      dismissed: true
+    })
+    expect(useAppStore.getState().pendingCodexPaneRestartIds).toEqual({})
+  })
+
+  it('leaves the notice map identity alone when nothing is dismissable', () => {
+    switchAccount('pty-1', A, B)
+    const before = useAppStore.getState().codexRestartNoticeByPtyId
+
+    useAppStore.getState().dismissCodexRestartNotices(['pty-unknown'])
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId).toBe(before)
+  })
+
+  it('still deletes the record when the pane actually restarts', () => {
+    switchAccount('pty-1', A, B)
+
+    // Why: the relaunched pane genuinely runs under B, so its launch-account
+    // memory must reset rather than linger and suppress a later B -> A prompt.
+    useAppStore.getState().clearCodexRestartNotice('pty-1')
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeUndefined()
+    switchAccount('pty-1', B, A)
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: B,
+      nextAccountLabel: A
+    })
+  })
+})

--- a/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
@@ -57,6 +57,22 @@ describe('codex restart notice lifecycle', () => {
     })
   })
 
+  it('leaves a dismissal answered when the active account is re-marked unchanged', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    // Why: adding an account and reauthenticating the active one both re-mark
+    // live panes with the selection unchanged. Nothing about the pane moved, so
+    // resurrecting the prompt would also re-block a keyboard the user freed.
+    switchAccount('pty-1', B, B)
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: B,
+      dismissed: true
+    })
+  })
+
   it('drops a queued restart when the user dismisses the same pane', () => {
     switchAccount('pty-1', A, B)
     useAppStore.getState().queueCodexPaneRestarts(['pty-1'])

--- a/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
@@ -71,6 +71,21 @@ describe('codex restart notice lifecycle', () => {
     expect(useAppStore.getState().pendingCodexPaneRestartIds).toEqual({})
   })
 
+  it('re-blocks a dismissed pane once a restart is queued for it', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    useAppStore.getState().queueCodexPaneRestarts(['pty-1'])
+
+    // Why: the pane still runs under A until it relaunches, so the dismissal
+    // that freed its keyboard must not outlive the restart request.
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: B,
+      restartRequested: true
+    })
+  })
+
   it('leaves the notice map identity alone when nothing is dismissable', () => {
     switchAccount('pty-1', A, B)
     const before = useAppStore.getState().codexRestartNoticeByPtyId

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -466,6 +466,10 @@ export type CodexRestartNotice = {
    *  because `previousAccountLabel` is the only memory of the account this pane
    *  actually launched under, which drives the A -> B -> A collapse. */
   restartRequested?: true
+  /** Set when the user answers "Keep old account". Same reason the record has to
+   *  survive: deleting it erased the launch account, so re-selecting it looked
+   *  like a fresh switch and raised an inverted prompt that killed pane input. */
+  dismissed?: true
 }
 
 export type TerminalSlice = {
@@ -647,6 +651,7 @@ export type TerminalSlice = {
     notices: { ptyId: string; previousAccountLabel: string; nextAccountLabel: string }[]
   ) => void
   clearCodexRestartNotice: (ptyId: string) => void
+  dismissCodexRestartNotices: (ptyIds: string[]) => void
   setTabPaneExpanded: (tabId: string, expanded: boolean) => void
   setTabCanExpandPane: (tabId: string, canExpand: boolean) => void
   setTabLayout: (tabId: string, layout: TerminalLayoutSnapshot | null) => void
@@ -2847,6 +2852,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           nextAccountLabel: notice.nextAccountLabel,
           // Why: a queued restart relaunches under whatever account is selected
           // when it runs, so a later switch does not reopen an answered prompt.
+          // A dismissal is deliberately not carried over — it answered "keep the
+          // old account instead of B", which says nothing about a later C.
           ...(existing?.restartRequested ? { restartRequested: true as const } : {})
         }
       }
@@ -2866,6 +2873,34 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const nextPendingCodexPaneRestartIds = { ...s.pendingCodexPaneRestartIds }
       delete next[ptyId]
       delete nextPendingCodexPaneRestartIds[ptyId]
+      return {
+        codexRestartNoticeByPtyId: next,
+        pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds
+      }
+    })
+  },
+
+  dismissCodexRestartNotices: (ptyIds) => {
+    set((s) => {
+      // Why: keeping the old account is an answer, not a restart — the record
+      // stays so `previousAccountLabel` still names the pane's launch account,
+      // but every consumer treats it as answered (prompt hidden, input freed).
+      const next = { ...s.codexRestartNoticeByPtyId }
+      const nextPendingCodexPaneRestartIds = { ...s.pendingCodexPaneRestartIds }
+      let changed = false
+      for (const ptyId of ptyIds) {
+        const notice = next[ptyId]
+        if (!notice || notice.dismissed) {
+          continue
+        }
+        const { restartRequested: _restartRequested, ...kept } = notice
+        next[ptyId] = { ...kept, dismissed: true }
+        delete nextPendingCodexPaneRestartIds[ptyId]
+        changed = true
+      }
+      if (!changed) {
+        return {}
+      }
       return {
         codexRestartNoticeByPtyId: next,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2856,9 +2856,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           nextAccountLabel: notice.nextAccountLabel,
           // Why: a queued restart relaunches under whatever account is selected
           // when it runs, so a later switch does not reopen an answered prompt.
-          // A dismissal is deliberately not carried over — it answered "keep the
-          // old account instead of B", which says nothing about a later C.
-          ...(existing?.restartRequested ? { restartRequested: true as const } : {})
+          ...(existing?.restartRequested ? { restartRequested: true as const } : {}),
+          // Why: a dismissal answered one question — "keep the launch account
+          // instead of this one". Only a genuinely different target re-asks it,
+          // so a later C reopens the prompt while adding an account or
+          // reauthenticating the active one (both re-mark live panes with the
+          // selection unchanged) must not resurrect it and re-mute the pane.
+          ...(existing?.dismissed && existing.nextAccountLabel === notice.nextAccountLabel
+            ? { dismissed: true as const }
+            : {})
         }
       }
       return {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2802,7 +2802,11 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       for (const ptyId of ptyIds) {
         const notice = nextCodexRestartNoticeByPtyId[ptyId]
         if (notice) {
-          nextCodexRestartNoticeByPtyId[ptyId] = { ...notice, restartRequested: true }
+          // Why: mirror of the strip in dismissCodexRestartNotices. A queued
+          // restart leaves the pane on the old account until it relaunches, so
+          // it must re-block input that an earlier dismissal had freed.
+          const { dismissed: _dismissed, ...kept } = notice
+          nextCodexRestartNoticeByPtyId[ptyId] = { ...kept, restartRequested: true }
         }
       }
       return {


### PR DESCRIPTION
Stacked on #10770 — **base is `brennanb2025/fix-codex-account-switch`, not `main`.**

## Root cause

`isCodexPaneStale` (`pty-connection.ts:819`, consumed at the pane's `onData` handler) treats *any* Codex restart notice on a pty as "stale" and makes the handler return early — **while a notice exists, every keystroke in that pane is silently dropped.** That's deliberate: don't let work run under the wrong account. But it means any wrong notice state is a terminal that ignores typing.

Dismissing the prompt ("Keep old account") called `clearCodexRestartNotice`, which **deletes the notice record**. `previousAccountLabel` on that record is the renderer's only memory of the account the pane actually launched under, and it's what `markCodexRestartNotices` uses for its A → B → A collapse (`terminals.ts`, "a live Codex pane keeps its original launch account until it actually restarts"). With the record gone, re-selecting the pane's **original** account A read as a fresh switch:

```
markCodexRestartNotices({ previous: B, next: A })
  existing = undefined                     // record was deleted by the dismissal
  previousAccountLabel = B                 // falls back to the caller's value
  B !== A  ->  no collapse
  -> notice { previous: B, next: A }       // inverted, and false
```

The prompt then reads "Codex is still signed in as **B**. Restart this session to use **A**" with the labels backwards, and — because a notice exists — the pane's keyboard goes dead.

**Verified myself, and confirmed pre-existing on `origin/main`.** I did not take the report on faith: I wrote the repro against the store before touching anything and watched it produce `{previousAccountLabel: "b@example.com", nextAccountLabel: "a@example.com"}`. `origin/main` (fd7ebe3f47) carries a byte-identical `markCodexRestartNotices` collapse, a byte-identical `clearCodexRestartNotice`, and a byte-identical `isCodexPaneStale`, so the bug reproduces there too. #10770 does not introduce it — its startup sweep, which re-raises notices at launch, makes wrong notice state much more reachable.

## The fix

A `dismissed?: true` marker on `CodexRestartNotice`, so a dismissal is *remembered* rather than erasing the pane's launch-account memory. New store action `dismissCodexRestartNotices(ptyIds)` marks instead of deleting.

`clearCodexRestartNotice` is deliberately left alone: its other caller (`TerminalPane.tsx:1596`) fires when the pane **actually relaunches**, and there the record must genuinely die — the pane now runs under the new account, so its launch memory has to reset. Conflating the two would suppress a legitimate later prompt. There's a regression test for exactly that.

Two shared predicates in the new `codex-restart-notice-state.ts` keep the asymmetry between the two answered states in one place, honoured by every consumer:

| | `restartRequested` | `dismissed` |
|---|---|---|
| Prompt shown | no | no |
| **Pane input blocked** | **yes** | **no** |

**Justification for the input gate.** `restartRequested` means the user asked for a restart but the pane hasn't relaunched yet — it is *still running under the old account*, so letting keystrokes through would run work under the wrong account, which is the entire reason the gate exists. `dismissed` means the user explicitly chose to **keep** that account: there is no wrong-account hazard left, and leaving the terminal dead would punish them for answering the prompt. A dismissal that kills the keyboard is the worst possible outcome, so the keyboard comes back immediately.

Consumers updated: `isCodexPaneStale` (both the live-pty path and the tab-id reconnect fallback), `collectStalePtyIdsForTabs` (`CodexRestartChip.tsx`), `summarizeCodexRestartStatus` (status bar), plus `selectCodexRestartInputs` — that selector gated on "any notice exists", which would now leave every mounted chip permanently subscribed to pty-lifecycle churn after a single dismissal, so it gates on "any *unanswered* notice" instead.

**A dismissal is not carried across a later switch.** It answered "keep A instead of B", which says nothing about a later C. Switching to a genuinely different third account rebuilds the notice as `{previous: A, next: C}` — correct labels, taken from the surviving launch memory — and prompts. Over-suppressing here would silently strand the pane on A. (`restartRequested` *is* carried over, since a queued restart relaunches under whatever is selected when it runs; that behaviour is unchanged.)

**Durability across app restart composes with #10770 rather than duplicating it.** The two layers are doing different jobs: the renderer marker is in-session memory and the input unblock; `codexAccounts:forgetStalePanes` drops the on-disk launch record so the startup sweep doesn't re-raise. Dismissal still calls both. No change to the main-process registry.

## Mutation proof

Five targeted mutations, each reverting one part of the fix and re-running. Every one produced failures — no test passes with or without the production change:

| # | Mutation | Result |
|---|---|---|
| 1 | `blocksCodexPaneInput` ignores `dismissed` | **2 failed** — both input-gate tests (live-pty path + tab fallback) |
| 2 | `awaitsCodexRestartAnswer` ignores `dismissed` | **5 failed** — across all three consumers + the selector |
| 3 | `markCodexRestartNotices` carries `dismissed` forward (over-suppression) | **2 failed** — both third-account tests |
| 4 | `dismissCodexRestartNotices` deletes the record (the original bug) | **7 failed** — including the acceptance-2 repro |
| 5 | `blocksCodexPaneInput` also excludes `restartRequested` | **1 failed** — the asymmetry test |

Mutation 5 matters: it proves the "restart requested still blocks input" test is discriminating rather than passing incidentally.

## Acceptance

1. Dismiss → keyboard works again immediately — covered by the two `pty-connection` input-gate tests (mutation 1).
2. Dismiss → re-select the pane's **original** account → no prompt, keyboard alive — covered at the store level and end-to-end through the rendered chip (mutation 4).
3. Dismiss → switch to a genuinely different third account → prompt **does** appear, with the launch account in the label — covered at both levels (mutation 3).
4. Quit/relaunch after a dismiss → no re-prompt — unchanged #10770 behaviour, already covered by `codex-stale-pane-accounts.test.ts` ("stops reporting a pane the user chose to keep"), which uses a discriminating second pane; the chip test asserts `forgetStalePanes` is still called on dismiss.
5. Every new test mutation-proved, as above.

## Gates

All run and clean: `tsc` × 3 (`node`, `tc.cli`, `tc.web`), `oxlint` (exit 0, no warnings in touched files), `check-max-lines-ratchet` (no new bypasses, no `max-lines` disables added). Targeted suites 523 passed; wider sweep of `components/status-bar`, `components/terminal-pane`, `store/`, `main/codex` — 5529 passed, 0 failed.

## Not verified

- **No live app QA.** This is store + component-level verification only; I did not drive a real Codex account switch in the running app.
- Cross-platform: the change is platform-neutral renderer state (no path handling, no key modifiers), so nothing here is macOS/Linux/Windows-specific, but it was only exercised on macOS.
- Pre-existing, not touched, flagged for follow-up: because `forgetStalePanes` deletes the on-disk launch record outright, a pane that was dismissed and then survives an app restart has no launch-account memory on disk. A later switch in the new session will prompt it with whatever account was active at that moment as `previousAccountLabel`, which may not be the account it truly launched under. The prompt itself is still correct — the pane genuinely is stale — only the label can be wrong. Fixing that means teaching the main-process registry about dismissal instead of forgetting, which is #10770's contract and out of scope here.


---

## Review addendum (independent review, 4 rounds)

Four rounds of independent review ran against this branch; rounds 1–3 each found real defects, round 4 came back clean. Five commits were added on top of the original fix. **Every fix below was mutation-proved twice — once by the agent that wrote it, once independently re-run by the reviewer** (revert the production hunk → confirm the new test fails → restore → confirm it passes).

| # | Commit | Defect | Mutation proof |
|---|---|---|---|
| D1 | `f01251a6da` | `isCodexPaneStale` fell through to the tab-level check even when the pane's **own** record was `dismissed`. In a split tab, a dismissed pane beside a sibling holding a blocking notice kept a **dead keyboard with no prompt** — the exact outcome this PR exists to prevent. | revert → split-pane test fails (`sendInput` 0 calls) |
| D2 | `f01251a6da` | `queueCodexPaneRestarts` did not strip `dismissed` while `dismissCodexRestartNotices` stripped `restartRequested`. `{dismissed, restartRequested}` resolved as "dismissed wins" → input flowing in a pane with a restart queued, still on the old account. Unreachable via today's UI (both call sites filter through `awaitsCodexRestartAnswer`); landed as a state-model invariant, not a live bug. | revert → lifecycle test fails |
| D3 | `2e9f584a93` | A **bound** pane with no record of its own still inherited `tab.ptyId`'s block. Worst case: a plain shell split beside a Codex pane whose restart was already requested — the prompt is off-screen (`awaitsCodexRestartAnswer` false), so an innocent pane went **silently mute with nothing to answer**. The `tab.ptyId` fallback now runs only when `panePtyId` is null. | revert → bound-pane test fails; both null-binding fallback tests pass in **both** runs, proving the unbound protection is untouched |
| D4 | `e576362f58` | **Introduced by this PR.** `markCodexRestartNotices` dropped `dismissed` on every re-mark. `AccountsPane.tsx` re-marks live panes with the selection *unchanged* for `adding` (unconditional) and `reauth:<activeId>`, and the A→B→A collapse does not fire (it compares `existing.previousAccountLabel`, still A, against `next: B`). So **routine token reauth resurrected an answered prompt and re-muted the pane.** `dismissed` now carries forward iff `existing.nextAccountLabel === notice.nextAccountLabel`. | revert → 1 fails; make it *unconditional* → 2 third-account over-suppression tests fail. Discriminating in **both** directions |
| — | `841c7882a8` | Two comments added by this PR onto the input gate were factually wrong (`tab.ptyId` is the **first** binder, not the last; unbound-pane recovery targets `ptyIdsByTabId[tabId][0]`, not `tab.ptyId`). Comments only — the reasoning the fixes rest on ("*some sibling's* id, not this pane's") is unchanged. | n/a |

### Correction to the original description above

> "**A dismissal is not carried across a later switch.**"

This is now **only true for a genuinely different target account.** D4 changed it: a dismissal *is* carried forward when the incoming target equals the one the dismissal already answered, so adding an account or reauthing the active one cannot resurrect it. A real third account C still reopens the prompt, and the A→B→A collapse still runs first and deletes the record outright.

### Verified state-model invariant

`{dismissed, restartRequested}` is **unreachable**, re-derived after D4 across all four writers of the map: `dismiss` strips `restartRequested`; `queue` strips `dismissed`; `mark` only ever propagates flags *from* `existing`, so it cannot manufacture the pair from a single-flag record; the `setTabPtyId` migration copies verbatim. This matters because that shape would let input flow in a pane still on the old account.

### Gates

`npm run typecheck` exit 0 (all 3 projects) · `oxlint` exit 0 · **513 passed** across the 5 touched suites · **2231 passed** across all of `store/` + `status-bar/` · no `max-lines` disables added (the two in the touched files are pre-existing on `main`).

### Not verified

- **No live-app QA** anywhere in the review — source reading plus vitest only.
- **Nothing exercised on Windows**, though #10757's reporter is on Windows. The diff is platform-neutral renderer state (no path handling, no key modifiers, no git), but Windows foreground-process detection in `getLiveCodexSessionPtyIds` — the gate on whether a pane gets a notice at all — was not verified.
- The startup-sweep race was reasoned from call ordering, not reproduced.

### Scope note on #10757

This PR owns the **"Keep old account"** half only. Lost `/resume` history is PR #10801's territory and is **not** addressed here; the stuck restart panel and the across-restart stranding are largely base PR #10770 (`ed40982db0`, `1818553aa6`). Reading this PR as closing #10757 on its own would be wrong.

### Follow-ups (out of scope, not committed)

1. **Reauth of the active account never prompts anyone.** The `previousAccountLabel === nextAccountLabel` collapse swallows the `reauth:<active>` mark for panes with **no** existing record, so a pane on a stale token is never offered a restart even though `shouldPromptRestart` intends it. Pre-existing on base; shares a root cause with D4.
2. **Dismissal permanently forgets the on-disk launch account.** `forgetStalePanes` deletes the registry entry and only PTY *spawn* re-records it, so a dismissed pane that later switches to a third account and survives an app restart may be mislabelled — or not surfaced at all. #10770's contract.
3. **A `restartRequested` pane whose restart never runs** (tab parked indefinitely) stays input-blocked with no prompt on screen and no way to reopen it — both surfaces filter `restartRequested` out. Pre-existing on base.
4. **Detection failures now fail open.** A bound pane with no record is never blocked, so a genuinely-stale pane whose foreground-process inspection failed at switch time is no longer blocked by accident via a sibling. Correct trade against a guaranteed dead keyboard, but worth writing down.
