### PR TITLE
fix(codex): tell the user when a resumed pane is pinned to another account

### DIFF
--- a/src/main/codex/codex-pane-launch-account.test.ts
+++ b/src/main/codex/codex-pane-launch-account.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import type { CodexManagedAccount, GlobalSettings } from '../../shared/types'
+import { resolveCodexPaneLaunchAccount } from './codex-pane-launch-account'
+
+const SYSTEM_HOME = '/Users/example/.codex'
+
+function managedAccount(overrides: Partial<CodexManagedAccount>): CodexManagedAccount {
+  return {
+    id: 'account-a',
+    email: 'a@example.com',
+    managedHomePath: '/data/codex-accounts/account-a/home',
+    createdAt: 0,
+    updatedAt: 0,
+    lastAuthenticatedAt: 0,
+    ...overrides
+  }
+}
+
+function settings(args: {
+  host?: string | null
+  wsl?: Record<string, string | null>
+  accounts?: CodexManagedAccount[]
+}): GlobalSettings {
+  return {
+    activeCodexManagedAccountId: args.host ?? null,
+    activeCodexManagedAccountIdsByRuntime: { host: args.host ?? null, wsl: args.wsl ?? {} },
+    codexManagedAccounts: args.accounts ?? []
+  } as GlobalSettings
+}
+
+describe('resolveCodexPaneLaunchAccount', () => {
+  it('records the selected account for an ordinary spawn', () => {
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: false,
+        launchCodexHomePath: '/data/codex-accounts/account-b/home',
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({ host: 'account-b' }),
+        target: { runtime: 'host' }
+      })
+    ).toEqual({ selectionKey: 'host', accountId: 'account-b' })
+  })
+
+  it('records the origin account a resume pinned the pane to, not the selection', () => {
+    const accounts = [
+      managedAccount({ id: 'account-a' }),
+      managedAccount({ id: 'account-b', managedHomePath: '/data/codex-accounts/account-b/home' })
+    ]
+
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: true,
+        launchCodexHomePath: '/data/codex-accounts/account-a/home',
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({ host: 'account-b', accounts }),
+        target: { runtime: 'host' }
+      })
+    ).toEqual({ selectionKey: 'host', accountId: 'account-a' })
+  })
+
+  it('records the same account a resume pinned to when it is already selected', () => {
+    const accounts = [managedAccount({ id: 'account-a' })]
+
+    // Why: the sweep compares this against the live selection, so an equal
+    // account must still be recorded — it is simply not reported stale.
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: true,
+        launchCodexHomePath: '/data/codex-accounts/account-a/home',
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({ host: 'account-a', accounts }),
+        target: { runtime: 'host' }
+      })
+    ).toEqual({ selectionKey: 'host', accountId: 'account-a' })
+  })
+
+  it('maps a resume redirected to the real system home to the system-default account', () => {
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: true,
+        launchCodexHomePath: SYSTEM_HOME,
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({
+          host: 'account-a',
+          accounts: [managedAccount({ id: 'account-a' })]
+        }),
+        target: { runtime: 'host' }
+      })
+    ).toEqual({ selectionKey: 'host', accountId: null })
+  })
+
+  it('maps a resume that injects no CODEX_HOME to the system-default account', () => {
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: true,
+        launchCodexHomePath: null,
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({ host: 'account-a', accounts: [managedAccount({ id: 'account-a' })] }),
+        target: { runtime: 'host' }
+      })
+    ).toEqual({ selectionKey: 'host', accountId: null })
+  })
+
+  it('refuses to attribute a resume home no account owns', () => {
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: true,
+        launchCodexHomePath: '/data/codex-runtime-home/home',
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({ host: 'account-a', accounts: [managedAccount({ id: 'account-a' })] }),
+        target: { runtime: 'host' }
+      })
+    ).toBeNull()
+  })
+
+  it('does not let a host account answer for a WSL pane on the same path', () => {
+    const accounts = [
+      managedAccount({
+        id: 'host-account',
+        managedHomePath: '//wsl.localhost/Ubuntu/home/u/.codex'
+      })
+    ]
+
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: true,
+        launchCodexHomePath: '//wsl.localhost/Ubuntu/home/u/.codex',
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({ wsl: { Ubuntu: 'wsl-account' }, accounts }),
+        target: { runtime: 'wsl', wslDistro: 'Ubuntu' }
+      })
+    ).toBeNull()
+  })
+
+  it('attributes a WSL resume home to the account on that distro lane', () => {
+    const accounts = [
+      managedAccount({
+        id: 'wsl-account',
+        managedHomeRuntime: 'wsl',
+        wslDistro: 'Ubuntu',
+        managedHomePath: '\\\\wsl$\\Ubuntu\\home\\u\\.codex-a'
+      })
+    ]
+
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: true,
+        launchCodexHomePath: '//wsl.localhost/Ubuntu/home/u/.codex-a',
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: settings({ wsl: { Ubuntu: 'other-wsl-account' }, accounts }),
+        target: { runtime: 'wsl', wslDistro: 'Ubuntu' }
+      })
+    ).toEqual({ selectionKey: 'wsl:Ubuntu', accountId: 'wsl-account' })
+  })
+
+  it('tolerates settings that carry no managed account roster', () => {
+    expect(
+      resolveCodexPaneLaunchAccount({
+        pinnedByResume: true,
+        launchCodexHomePath: '/data/codex-accounts/account-a/home',
+        systemCodexHomePath: SYSTEM_HOME,
+        settings: { activeCodexManagedAccountId: null } as GlobalSettings,
+        target: { runtime: 'host' }
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/codex/codex-pane-launch-account.ts
+++ b/src/main/codex/codex-pane-launch-account.ts
@@ -66,8 +66,11 @@ function resolveCodexHomeOwnerAccountId(args: {
       getCodexSelectionLaneKey(getCodexSelectionTargetForAccount(account)) === laneKey &&
       normalizeRuntimePathForComparison(account.managedHomePath) === launchHome
   )
-  // Why: the shared runtime mirror hot-swaps to whichever account is selected, so
-  // an unattributable home is no evidence the pane is on a different one. A
-  // wrong restart notice silently drops every keystroke in that terminal.
+  // Why: an unowned home cannot be named, and naming the account a pane is stuck
+  // on is the prompt's whole job — so decline rather than guess. A wrong notice
+  // silently drops every keystroke in that terminal. Note the shared runtime
+  // mirror only hot-swaps to the current selection on the legacy flag-OFF lane;
+  // a pane resumed into it after the per-account rollout is genuinely stale but
+  // still unnameable, so that cohort stays unreported.
   return owner ? owner.id : undefined
 }

--- a/src/main/codex/codex-pane-launch-account.ts
+++ b/src/main/codex/codex-pane-launch-account.ts
@@ -1,0 +1,73 @@
+import type { GlobalSettings } from '../../shared/types'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import {
+  getCodexSelectionLaneKey,
+  getCodexSelectionTargetForAccount,
+  getSelectedCodexAccountIdForTarget,
+  type CodexAccountSelectionTarget
+} from '../codex-accounts/runtime-selection'
+import type { CodexPaneAccountRecord } from './codex-pane-account-registry'
+
+type CodexPaneLaunchAccountSettings = Pick<
+  GlobalSettings,
+  'activeCodexManagedAccountId' | 'activeCodexManagedAccountIdsByRuntime' | 'codexManagedAccounts'
+>
+
+/**
+ * Resolves which Codex account a PTY is actually launching under.
+ *
+ * Why: an automatic session resume deliberately pins CODEX_HOME to the home
+ * that owns the session rather than to the current selection, so a cold-restored
+ * pane can come back on an account the user already switched away from. Naming
+ * that real account — instead of the selection Orca ignored — is what lets the
+ * restart prompt tell the user which account the pane is stuck on.
+ *
+ * Returns null when the launch cannot be attributed, which keeps the pane out of
+ * the stale-pane report entirely.
+ */
+export function resolveCodexPaneLaunchAccount(args: {
+  pinnedByResume: boolean
+  launchCodexHomePath: string | null
+  systemCodexHomePath: string
+  settings: CodexPaneLaunchAccountSettings
+  target: CodexAccountSelectionTarget
+}): CodexPaneAccountRecord | null {
+  const selectionKey = getCodexSelectionLaneKey(args.target)
+  if (!args.pinnedByResume) {
+    return {
+      selectionKey,
+      accountId: getSelectedCodexAccountIdForTarget(args.settings, args.target)
+    }
+  }
+  const accountId = resolveCodexHomeOwnerAccountId(args)
+  return accountId === undefined ? null : { selectionKey, accountId }
+}
+
+/** undefined when no account owns the home; null means the system-default account. */
+function resolveCodexHomeOwnerAccountId(args: {
+  launchCodexHomePath: string | null
+  systemCodexHomePath: string
+  settings: CodexPaneLaunchAccountSettings
+  target: CodexAccountSelectionTarget
+}): string | null | undefined {
+  // Why: no injected CODEX_HOME means Codex reads the user's own home.
+  if (!args.launchCodexHomePath) {
+    return null
+  }
+  const launchHome = normalizeRuntimePathForComparison(args.launchCodexHomePath)
+  if (launchHome === normalizeRuntimePathForComparison(args.systemCodexHomePath)) {
+    return null
+  }
+  const laneKey = getCodexSelectionLaneKey(args.target)
+  const owner = args.settings.codexManagedAccounts?.find(
+    (account) =>
+      // Why: a WSL pane resolves its account from its own per-distro lane, so a
+      // host account's home must never answer for it (and vice versa).
+      getCodexSelectionLaneKey(getCodexSelectionTargetForAccount(account)) === laneKey &&
+      normalizeRuntimePathForComparison(account.managedHomePath) === launchHome
+  )
+  // Why: the shared runtime mirror hot-swaps to whichever account is selected, so
+  // an unattributable home is no evidence the pane is on a different one. A
+  // wrong restart notice silently drops every keystroke in that terminal.
+  return owner ? owner.id : undefined
+}

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -13638,6 +13638,126 @@ describe('registerPtyHandlers', () => {
     expect(forgetCodexPaneAccountMock).toHaveBeenCalledWith('pty-resumed')
   })
 
+  // Why: the runtime controller is the CLI/relay resume path, and it repeats the
+  // same recording call the ipc handler makes. Without its own coverage a revert
+  // there is invisible.
+  it('records the origin account for a resumed Codex pane spawned by the runtime controller', async () => {
+    type RuntimeSpawnController = {
+      spawn(args: Record<string, unknown>): Promise<{ id: string }>
+    }
+    setLocalPtyProvider({
+      spawn: vi.fn(async () => ({ id: 'pty-runtime-resumed' })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+    const runtime = {
+      setPtyController: vi.fn(),
+      registerPty: vi.fn(),
+      noteTerminalSpawnCommand: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+    const getSettings = vi.fn().mockReturnValue({
+      activeCodexManagedAccountId: 'account-b',
+      codexManagedAccounts: [
+        { id: 'account-a', managedHomePath: '/managed/origin/home' },
+        { id: 'account-b', managedHomePath: '/managed/current/home' }
+      ]
+    })
+    handlers.clear()
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      vi.fn(() => '/managed/current/home'),
+      getSettings as never,
+      undefined,
+      undefined,
+      { prepareCodexSessionResume: async () => ({ codexHomePath: '/managed/origin/home' }) }
+    )
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+    await controller.spawn({
+      cols: 80,
+      rows: 24,
+      worktreeId: 'wt-runtime',
+      command: 'codex resume session-a',
+      launchAgent: 'codex',
+      resumeProviderSession: {
+        key: 'session_id',
+        id: 'session-a',
+        transcriptPath: '/managed/origin/home/sessions/2026/07/20/rollout-a.jsonl'
+      }
+    })
+
+    expect(recordCodexPaneAccountMock.mock.calls).toEqual([
+      ['pty-runtime-resumed', { selectionKey: 'host', accountId: 'account-a' }]
+    ])
+    expect(forgetCodexPaneAccountMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves a runtime-controller resumed Codex pane unattributed when no account owns its home', async () => {
+    type RuntimeSpawnController = {
+      spawn(args: Record<string, unknown>): Promise<{ id: string }>
+    }
+    setLocalPtyProvider({
+      spawn: vi.fn(async () => ({ id: 'pty-runtime-resumed' })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+    const runtime = {
+      setPtyController: vi.fn(),
+      registerPty: vi.fn(),
+      noteTerminalSpawnCommand: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn()
+    }
+    const getSettings = vi.fn().mockReturnValue({
+      activeCodexManagedAccountId: 'account-b',
+      codexManagedAccounts: [{ id: 'account-b', managedHomePath: '/managed/current/home' }]
+    })
+    handlers.clear()
+    registerPtyHandlers(
+      mainWindow as never,
+      runtime as never,
+      vi.fn(() => '/managed/current/home'),
+      getSettings as never,
+      undefined,
+      undefined,
+      { prepareCodexSessionResume: async () => ({ codexHomePath: '/managed/shared-mirror/home' }) }
+    )
+    const controller = runtime.setPtyController.mock.calls[0]?.[0] as RuntimeSpawnController
+
+    await controller.spawn({
+      cols: 80,
+      rows: 24,
+      worktreeId: 'wt-runtime',
+      command: 'codex resume session-a',
+      launchAgent: 'codex',
+      resumeProviderSession: {
+        key: 'session_id',
+        id: 'session-a',
+        transcriptPath: '/managed/shared-mirror/home/sessions/2026/07/20/rollout-a.jsonl'
+      }
+    })
+
+    expect(recordCodexPaneAccountMock).not.toHaveBeenCalled()
+    expect(forgetCodexPaneAccountMock).toHaveBeenCalledWith('pty-runtime-resumed')
+  })
+
   it('seeds cold restore at recovered dimensions with a legacy dimensionless fallback', async () => {
     const oscLinks = [{ row: 0, startCol: 0, endCol: 8, uri: 'https://example.com/restored' }]
     const coldRestore = {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -13632,8 +13632,8 @@ describe('registerPtyHandlers', () => {
       }
     })
 
-    // Why: the shared mirror hot-swaps to the selected account, so guessing here
-    // would raise a restart notice that blocks a correctly-signed-in pane's input.
+    // Why: an unowned home cannot be named, so guessing here would raise a
+    // restart notice that blocks a correctly-signed-in pane's input.
     expect(recordCodexPaneAccountMock).not.toHaveBeenCalled()
     expect(forgetCodexPaneAccountMock).toHaveBeenCalledWith('pty-resumed')
   })

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -13545,6 +13545,99 @@ describe('registerPtyHandlers', () => {
     ])
   })
 
+  it('records the origin account a resumed Codex pane is pinned to', async () => {
+    setLocalPtyProvider({
+      spawn: vi.fn(async () => ({ id: 'pty-resumed' })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+    const getSettings = vi.fn().mockReturnValue({
+      activeCodexManagedAccountId: 'account-b',
+      codexManagedAccounts: [
+        { id: 'account-a', managedHomePath: '/managed/origin/home' },
+        { id: 'account-b', managedHomePath: '/managed/current/home' }
+      ]
+    })
+    registerPtyHandlers(
+      mainWindow as never,
+      undefined,
+      vi.fn(() => '/managed/current/home'),
+      getSettings as never,
+      undefined,
+      undefined,
+      { prepareCodexSessionResume: async () => ({ codexHomePath: '/managed/origin/home' }) }
+    )
+
+    await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      command: 'codex resume session-a',
+      launchAgent: 'codex',
+      resumeProviderSession: {
+        key: 'session_id',
+        id: 'session-a',
+        transcriptPath: '/managed/origin/home/sessions/2026/07/20/rollout-a.jsonl'
+      }
+    })
+
+    // Why: the resume deliberately overrides the selection, so the pane really
+    // is on account-a. Recording that is what makes the restart prompt appear.
+    expect(recordCodexPaneAccountMock.mock.calls).toEqual([
+      ['pty-resumed', { selectionKey: 'host', accountId: 'account-a' }]
+    ])
+    expect(forgetCodexPaneAccountMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves a resumed Codex pane unattributed when no account owns its home', async () => {
+    setLocalPtyProvider({
+      spawn: vi.fn(async () => ({ id: 'pty-resumed' })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+    const getSettings = vi.fn().mockReturnValue({
+      activeCodexManagedAccountId: 'account-b',
+      codexManagedAccounts: [{ id: 'account-b', managedHomePath: '/managed/current/home' }]
+    })
+    registerPtyHandlers(
+      mainWindow as never,
+      undefined,
+      vi.fn(() => '/managed/current/home'),
+      getSettings as never,
+      undefined,
+      undefined,
+      { prepareCodexSessionResume: async () => ({ codexHomePath: '/managed/shared-mirror/home' }) }
+    )
+
+    await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      command: 'codex resume session-a',
+      launchAgent: 'codex',
+      resumeProviderSession: {
+        key: 'session_id',
+        id: 'session-a',
+        transcriptPath: '/managed/shared-mirror/home/sessions/2026/07/20/rollout-a.jsonl'
+      }
+    })
+
+    // Why: the shared mirror hot-swaps to the selected account, so guessing here
+    // would raise a restart notice that blocks a correctly-signed-in pane's input.
+    expect(recordCodexPaneAccountMock).not.toHaveBeenCalled()
+    expect(forgetCodexPaneAccountMock).toHaveBeenCalledWith('pty-resumed')
+  })
+
   it('seeds cold restore at recovered dimensions with a legacy dimensionless fallback', async () => {
     const oscLinks = [{ row: 0, startCol: 0, endCol: 8, uri: 'https://example.com/restored' }]
     const coldRestore = {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -160,15 +160,13 @@ import {
 import { setTerminalViewAttributes } from '../runtime/terminal-view-attribute-store'
 import { validateTerminalViewAttributes } from '../../shared/terminal-view-attributes'
 import type { PtyModelRestoreReason } from '../../shared/pty-model-restore-marker'
-import {
-  getCodexSelectionLaneKey,
-  getSelectedCodexAccountIdForTarget,
-  type CodexAccountSelectionTarget
-} from '../codex-accounts/runtime-selection'
+import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
 import {
   forgetCodexPaneAccount,
   recordCodexPaneAccount
 } from '../codex/codex-pane-account-registry'
+import { resolveCodexPaneLaunchAccount } from '../codex/codex-pane-launch-account'
+import { getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { isCodexSystemDefaultRealHomeEnabled } from '../codex/codex-real-home-flag'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { buildConfiguredProxyEnv, type NetworkProxySettings } from '../../shared/network-proxy'
@@ -832,27 +830,33 @@ function getCompatibleSelectedCodexHomePath(
 // way to tell later that a pane still runs Codex as the previously selected
 // account. A reattach inherits that baked environment rather than choosing one,
 // so re-recording it under the current selection would erase the very evidence
-// that the pane is stale. A resume-pinned pane is deliberately on its session's
-// own account, so it is forgotten rather than recorded as stale.
+// that the pane is stale.
 function recordCodexPaneAccountForSpawn(args: {
   ptyId: string | undefined
   isDaemonHostSpawn: boolean
   isReattach: boolean
   pinnedByResume: boolean
+  launchCodexHomePath: string | null
   target: CodexAccountSelectionTarget
   settings: GlobalSettings | undefined
 }): void {
   if (!args.ptyId || !args.isDaemonHostSpawn || args.isReattach) {
     return
   }
-  if (args.pinnedByResume || !args.settings) {
+  const record = args.settings
+    ? resolveCodexPaneLaunchAccount({
+        pinnedByResume: args.pinnedByResume,
+        launchCodexHomePath: args.launchCodexHomePath,
+        systemCodexHomePath: getSystemCodexHomePath(),
+        settings: args.settings,
+        target: args.target
+      })
+    : null
+  if (!record) {
     forgetCodexPaneAccount(args.ptyId)
     return
   }
-  recordCodexPaneAccount(args.ptyId, {
-    selectionKey: getCodexSelectionLaneKey(args.target),
-    accountId: getSelectedCodexAccountIdForTarget(args.settings, args.target)
-  })
+  recordCodexPaneAccount(args.ptyId, record)
 }
 
 function readEnvWithProcessFallback(
@@ -3699,6 +3703,7 @@ export function registerPtyHandlers(
           isDaemonHostSpawn,
           isReattach: result.isReattach === true,
           pinnedByResume: Boolean(codexResumeHome),
+          launchCodexHomePath: selectedCodexHomePath,
           target: codexSelectionTarget,
           settings: getSettings?.()
         })
@@ -4741,6 +4746,7 @@ export function registerPtyHandlers(
           isDaemonHostSpawn,
           isReattach: result.isReattach === true,
           pinnedByResume: Boolean(codexResumeHome),
+          launchCodexHomePath: selectedCodexHomePath,
           target: codexSelectionTarget,
           settings: getSettings?.()
         })

--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -7,6 +7,7 @@ import { selectCodexRestartInputs } from './codex-restart-chip-inputs'
 import { translate } from '@/i18n/i18n'
 import { shouldFocusMobileDriverAction } from './terminal-pane/mobile-driver-overlay-focus'
 import { buildCodexRestartNoticeKey } from './codex-restart-notice-key'
+import { awaitsCodexRestartAnswer } from './codex-restart-notice-state'
 import type { CodexRestartNotice } from '../store/slices/terminals'
 
 const EMPTY_TABS: { id: string }[] = []
@@ -22,12 +23,13 @@ export function collectStalePtyIdsForTabs({
 }): string[] {
   // Why: an already-requested restart runs when its pane next mounts. Keeping it
   // out of the prompt is what stops the panel from sticking on a worktree whose
-  // stale pane is parked or deferred and cannot answer the request yet.
+  // stale pane is parked or deferred and cannot answer the request yet. A
+  // dismissed notice is likewise answered — it only survives as launch-account
+  // memory.
   return tabs.flatMap((tab) =>
-    (ptyIdsByTabId[tab.id] ?? []).filter((ptyId) => {
-      const notice = codexRestartNoticeByPtyId[ptyId]
-      return Boolean(notice) && !notice?.restartRequested
-    })
+    (ptyIdsByTabId[tab.id] ?? []).filter((ptyId) =>
+      awaitsCodexRestartAnswer(codexRestartNoticeByPtyId[ptyId])
+    )
   )
 }
 
@@ -51,15 +53,13 @@ export function collectStaleWorktreePtyIds({
 
 export function dismissStaleWorktreePtyIds(
   staleWorktreePtyIds: string[],
-  clearCodexRestartNotice: (ptyId: string) => void,
+  dismissCodexRestartNotices: (ptyIds: string[]) => void,
   forgetLaunchAccounts: (ptyIds: string[]) => void
 ): void {
   // Why: restart notices are stored per PTY, but the workspace host presents
-  // one shared prompt. Clearing all matching PTY notices keeps every pane in
+  // one shared prompt. Dismissing all matching PTY notices keeps every pane in
   // that worktree consistent with the dismissal.
-  for (const ptyId of staleWorktreePtyIds) {
-    clearCodexRestartNotice(ptyId)
-  }
+  dismissCodexRestartNotices(staleWorktreePtyIds)
   // Why: notices are renderer-only, so without dropping the on-disk launch
   // record the startup sweep re-raises this exact prompt — and re-blocks the
   // pane's input — after every app restart the user already answered.
@@ -104,7 +104,7 @@ export default function CodexRestartChip({
     ? codexRestartNoticeByPtyId[staleWorktreePtyIds[0]]
     : undefined
   const queueCodexPaneRestarts = useAppStore((s) => s.queueCodexPaneRestarts)
-  const clearCodexRestartNotice = useAppStore((s) => s.clearCodexRestartNotice)
+  const dismissCodexRestartNotices = useAppStore((s) => s.dismissCodexRestartNotices)
 
   const noticeKey = restartNotice ? buildCodexRestartNoticeKey(restartNotice) : null
 
@@ -117,7 +117,7 @@ export default function CodexRestartChip({
   }
 
   const handleDismiss = (): void => {
-    dismissStaleWorktreePtyIds(staleWorktreePtyIds, clearCodexRestartNotice, (ptyIds) => {
+    dismissStaleWorktreePtyIds(staleWorktreePtyIds, dismissCodexRestartNotices, (ptyIds) => {
       void window.api.codexAccounts.forgetStalePanes({ ptyIds }).catch((err: unknown) => {
         console.warn('Failed to forget dismissed Codex pane accounts:', err)
       })

--- a/src/renderer/src/components/codex-restart-chip-inputs.test.ts
+++ b/src/renderer/src/components/codex-restart-chip-inputs.test.ts
@@ -32,9 +32,32 @@ describe('selectCodexRestartInputs', () => {
     )
   })
 
+  it('re-idles once every surviving notice is answered', () => {
+    // Why: answered notices linger as launch-account memory for the pty's whole
+    // life, so existence alone would keep every chip subscribed to pty churn.
+    const dismissed: CodexRestartInputsState = {
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      codexRestartNoticeByPtyId: {
+        'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b', dismissed: true }
+      }
+    }
+    expect(selectCodexRestartInputs(dismissed)).toBe(EMPTY_CODEX_RESTART_INPUTS)
+
+    const alsoUnanswered: CodexRestartInputsState = {
+      ...dismissed,
+      codexRestartNoticeByPtyId: {
+        ...dismissed.codexRestartNoticeByPtyId,
+        'pty-2': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+      }
+    }
+    expect(selectCodexRestartInputs(alsoUnanswered)).not.toBe(EMPTY_CODEX_RESTART_INPUTS)
+  })
+
   it('exposes both live maps the instant a restart notice exists', () => {
     const ptyIdsByTabId = { 'tab-1': ['pty-1'] }
-    const codexRestartNoticeByPtyId = { 'pty-1': {} as never }
+    const codexRestartNoticeByPtyId = {
+      'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+    }
     const state: CodexRestartInputsState = { ptyIdsByTabId, codexRestartNoticeByPtyId }
     const selected = selectCodexRestartInputs(state)
     // Live references pass straight through so the stale-pty memo + notice lookup derive fully.
@@ -47,7 +70,9 @@ describe('selectCodexRestartInputs', () => {
     const ptyIdsByTabId = { 'tab-1': ['pty-1'] }
     const s1: CodexRestartInputsState = {
       ptyIdsByTabId,
-      codexRestartNoticeByPtyId: { 'pty-1': {} as never }
+      codexRestartNoticeByPtyId: {
+        'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+      }
     }
     const r1 = selectCodexRestartInputs(s1)
     expect(shallow(r1, selectCodexRestartInputs(s1))).toBe(true)

--- a/src/renderer/src/components/codex-restart-chip-inputs.ts
+++ b/src/renderer/src/components/codex-restart-chip-inputs.ts
@@ -1,3 +1,4 @@
+import { awaitsCodexRestartAnswer } from './codex-restart-notice-state'
 import type { AppState } from '@/store/types'
 
 export type CodexRestartInputsState = Pick<AppState, 'ptyIdsByTabId' | 'codexRestartNoticeByPtyId'>
@@ -27,7 +28,10 @@ export const EMPTY_CODEX_RESTART_INPUTS: CodexRestartInputs = Object.freeze({
  * `useShallow` subscription skips re-renders on unrelated pty-lifecycle churn.
  */
 export function selectCodexRestartInputs(s: CodexRestartInputsState): CodexRestartInputs {
-  if (Object.keys(s.codexRestartNoticeByPtyId).length === 0) {
+  // Why: answered notices linger as launch-account memory for the life of the
+  // pty, so gating on mere existence would leave every chip permanently
+  // subscribed to that churn after a single dismissal.
+  if (!Object.values(s.codexRestartNoticeByPtyId).some(awaitsCodexRestartAnswer)) {
     return EMPTY_CODEX_RESTART_INPUTS
   }
   return {

--- a/src/renderer/src/components/codex-restart-chip.test.ts
+++ b/src/renderer/src/components/codex-restart-chip.test.ts
@@ -98,15 +98,28 @@ describe('CodexRestartChip helpers', () => {
   })
 
   it('dismisses every stale PTY notice in the worktree prompt', () => {
-    const clearCodexRestartNotice = vi.fn()
+    const dismissCodexRestartNotices = vi.fn()
     const forgetLaunchAccounts = vi.fn()
 
-    dismissStaleWorktreePtyIds(['pty-1', 'pty-3'], clearCodexRestartNotice, forgetLaunchAccounts)
+    dismissStaleWorktreePtyIds(['pty-1', 'pty-3'], dismissCodexRestartNotices, forgetLaunchAccounts)
 
-    expect(clearCodexRestartNotice).toHaveBeenNthCalledWith(1, 'pty-1')
-    expect(clearCodexRestartNotice).toHaveBeenNthCalledWith(2, 'pty-3')
-    expect(clearCodexRestartNotice).toHaveBeenCalledTimes(2)
+    expect(dismissCodexRestartNotices).toHaveBeenCalledWith(['pty-1', 'pty-3'])
     expect(forgetLaunchAccounts).toHaveBeenCalledWith(['pty-1', 'pty-3'])
+  })
+
+  it('drops dismissed PTYs from the prompt while keeping their launch account', () => {
+    expect(
+      collectStalePtyIdsForTabs({
+        tabs: [{ id: 'tab-1' }],
+        ptyIdsByTabId: {
+          'tab-1': ['pty-1', 'pty-2']
+        },
+        codexRestartNoticeByPtyId: {
+          'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b', dismissed: true },
+          'pty-2': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+        }
+      })
+    ).toEqual(['pty-2'])
   })
 
   it('renders only account-resolution actions without an external-store update loop', async () => {
@@ -188,7 +201,131 @@ describe('CodexRestartChip helpers', () => {
 
     // Why: without this the startup sweep re-raises the prompt the user just answered.
     expect(forgetStalePanes).toHaveBeenCalledWith({ ptyIds: ['pty-1'] })
-    expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+    expect(container.textContent).toBe('')
+    // Why: the record survives as the pane's launch-account memory, but marked
+    // answered so it neither prompts again nor blocks the pane's keyboard.
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: 'old@example.com',
+      nextAccountLabel: 'new@example.com',
+      dismissed: true
+    })
+  })
+
+  it('stays closed when the user re-selects the account the pane launched under', async () => {
+    const forgetStalePanes = vi.fn(() => Promise.resolve())
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { codexAccounts: { forgetStalePanes } }
+    })
+    useAppStore.setState({
+      tabsByWorktree: {
+        'worktree-1': [
+          {
+            id: 'tab-1',
+            worktreeId: 'worktree-1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    })
+    useAppStore
+      .getState()
+      .markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'old@example.com',
+          nextAccountLabel: 'new@example.com'
+        }
+      ])
+    await act(async () => {
+      root.render(React.createElement(CodexRestartChip, { worktreeId: 'worktree-1' }))
+    })
+    const dismissButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Keep old account'
+    )
+    await act(async () => {
+      dismissButton?.click()
+    })
+
+    // Re-select the pane's original account: it never left it, so there is
+    // nothing to restart and nothing to prompt about.
+    await act(async () => {
+      useAppStore.getState().markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'new@example.com',
+          nextAccountLabel: 'old@example.com'
+        }
+      ])
+    })
+
+    expect(container.textContent).toBe('')
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeUndefined()
+  })
+
+  it('reopens the prompt when a dismissed pane is out of date against a third account', async () => {
+    const forgetStalePanes = vi.fn(() => Promise.resolve())
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { codexAccounts: { forgetStalePanes } }
+    })
+    useAppStore.setState({
+      tabsByWorktree: {
+        'worktree-1': [
+          {
+            id: 'tab-1',
+            worktreeId: 'worktree-1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    })
+    useAppStore
+      .getState()
+      .markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'old@example.com',
+          nextAccountLabel: 'new@example.com'
+        }
+      ])
+    await act(async () => {
+      root.render(React.createElement(CodexRestartChip, { worktreeId: 'worktree-1' }))
+    })
+    const dismissButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Keep old account'
+    )
+    await act(async () => {
+      dismissButton?.click()
+    })
+    expect(container.textContent).toBe('')
+
+    await act(async () => {
+      useAppStore.getState().markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'new@example.com',
+          nextAccountLabel: 'third@example.com'
+        }
+      ])
+    })
+
+    // Why: the dismissal answered "keep old instead of new", not "never prompt
+    // again"; the pane really is out of date against third@example.com.
+    expect(container.textContent).toContain('Codex is still signed in as old@example.com')
+    expect(container.textContent).toContain('Restart this session to use third@example.com')
   })
 
   it('closes the prompt after Restart even when no mounted pane can run it yet', async () => {

--- a/src/renderer/src/components/codex-restart-notice-state.ts
+++ b/src/renderer/src/components/codex-restart-notice-state.ts
@@ -1,0 +1,18 @@
+type CodexRestartNoticeState = { restartRequested?: true; dismissed?: true } | null | undefined
+
+/**
+ * True while the pane must not accept keystrokes.
+ *
+ * Why the two answered states differ: a requested restart still leaves the pane
+ * running under the old account until it actually relaunches, so its input stays
+ * blocked. A dismissal is the user choosing to keep that account, so blocking
+ * their keyboard would punish them for answering.
+ */
+export function blocksCodexPaneInput(notice: CodexRestartNoticeState): boolean {
+  return Boolean(notice) && !notice?.dismissed
+}
+
+/** True while the restart prompt still has an unanswered question for the user. */
+export function awaitsCodexRestartAnswer(notice: CodexRestartNoticeState): boolean {
+  return Boolean(notice) && !notice?.dismissed && !notice?.restartRequested
+}

--- a/src/renderer/src/components/status-bar/codex-restart-status-summary.test.ts
+++ b/src/renderer/src/components/status-bar/codex-restart-status-summary.test.ts
@@ -78,6 +78,25 @@ describe('summarizeCodexRestartStatus', () => {
     })
   })
 
+  it('stops offering sessions the user chose to keep on the old account', () => {
+    expect(
+      summarizeCodexRestartStatus({
+        tabsByWorktree: { wt1: [{ id: 'tab-1' }] },
+        ptyIdsByTabId: { 'tab-1': ['pty-1', 'pty-2'] },
+        codexRestartNoticeByPtyId: {
+          // Why: the dismissed record survives only as launch-account memory.
+          'pty-1': { previousAccountLabel: 'a', nextAccountLabel: 'b', dismissed: true },
+          'pty-2': { previousAccountLabel: 'a', nextAccountLabel: 'b' }
+        }
+      })
+    ).toEqual({
+      stalePtyIds: ['pty-2'],
+      staleSessionCount: 1,
+      staleTabCount: 1,
+      staleWorktreeCount: 1
+    })
+  })
+
   it('hides the prompt once every stale session has a requested restart', () => {
     expect(
       summarizeCodexRestartStatus({

--- a/src/renderer/src/components/status-bar/codex-restart-status-summary.ts
+++ b/src/renderer/src/components/status-bar/codex-restart-status-summary.ts
@@ -1,3 +1,4 @@
+import { awaitsCodexRestartAnswer } from '@/components/codex-restart-notice-state'
 import type { CodexRestartNotice } from '@/store/slices/terminals'
 
 type TabLookup = Record<string, { id: string }[]>
@@ -28,9 +29,10 @@ export function summarizeCodexRestartStatus({
   codexRestartNoticeByPtyId
 }: CodexRestartStatusSummaryInput): CodexRestartStatusSummary {
   // Why: a requested restart is already scheduled for its pane's next mount, so
-  // re-offering it here would leave a prompt whose button does nothing.
+  // re-offering it here would leave a prompt whose button does nothing; a
+  // dismissed notice survives only as launch-account memory.
   const stalePtyIds = Object.entries(codexRestartNoticeByPtyId)
-    .filter(([, notice]) => notice && !notice.restartRequested)
+    .filter(([, notice]) => awaitsCodexRestartAnswer(notice))
     .map(([ptyId]) => ptyId)
   if (stalePtyIds.length === 0) {
     return EMPTY_CODEX_RESTART_STATUS_SUMMARY

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -176,7 +176,12 @@ type StoreState = {
   } | null
   codexRestartNoticeByPtyId: Record<
     string,
-    { previousAccountLabel: string; nextAccountLabel: string }
+    {
+      previousAccountLabel: string
+      nextAccountLabel: string
+      restartRequested?: true
+      dismissed?: true
+    }
   >
   deferredSshReconnectTargets: string[]
   deferredSshSessionIdsByTabId: Record<string, string>
@@ -4473,6 +4478,112 @@ describe('connectPanePty', () => {
       ),
       codexRestartNoticeByPtyId: {
         'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B' }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).not.toHaveBeenCalled()
+  })
+
+  it('restores input to a Codex pane whose restart notice the user dismissed', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-live')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-live'] },
+      // Why: the record survives a dismissal as launch-account memory, so the
+      // input gate has to read the marker rather than the record's existence.
+      codexRestartNoticeByPtyId: {
+        'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B', dismissed: true }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('restores input through the tab fallback when the dismissed pane has no live PTY binding', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport(null)
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-live'] },
+      codexRestartNoticeByPtyId: {
+        'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B', dismissed: true }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps()
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('keeps blocking input on a pane whose restart is requested but not yet run', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-live')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-live' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-live'] },
+      // Why: unlike a dismissal, a queued restart leaves the pane running under
+      // the old account until it actually relaunches.
+      codexRestartNoticeByPtyId: {
+        'pty-live': { previousAccountLabel: 'A', nextAccountLabel: 'B', restartRequested: true }
       }
     }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4651,6 +4651,45 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).not.toHaveBeenCalled()
   })
 
+  it('keeps a bound pane with no notice typing while a sibling holds a queued restart', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-plain-shell')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      // Why: a requested restart hides the prompt, so blocking this record-less
+      // pane through `tab.ptyId` would leave a dead keyboard and nothing to answer.
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-sibling' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-plain-shell', 'pty-sibling'] },
+      codexRestartNoticeByPtyId: {
+        'pty-sibling': { previousAccountLabel: 'A', nextAccountLabel: 'B', restartRequested: true }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps({
+      paneTransportsRef: { current: new Map([[2, createMockTransport('pty-sibling')]]) }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('pty-plain-shell')
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
   it('keeps blocking input on a pane whose restart is requested but not yet run', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4571,6 +4571,86 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).toHaveBeenCalledWith('a')
   })
 
+  it('keeps a dismissed split pane typing while a sibling still holds the prompt', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-dismissed')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      // Why: `tab.ptyId` is whichever pane bound last, so a sibling's unanswered
+      // notice would otherwise kill this pane's keyboard with no prompt of its own.
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-sibling' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-dismissed', 'pty-sibling'] },
+      codexRestartNoticeByPtyId: {
+        'pty-dismissed': { previousAccountLabel: 'A', nextAccountLabel: 'B', dismissed: true },
+        'pty-sibling': { previousAccountLabel: 'A', nextAccountLabel: 'C' }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps({
+      // Why: the sibling already holds `tab.ptyId`, which is what makes this a
+      // split rather than this pane adopting the tab's binding.
+      paneTransportsRef: { current: new Map([[2, createMockTransport('pty-sibling')]]) }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('pty-dismissed')
+    expect(transport.sendInput).toHaveBeenCalledWith('a')
+  })
+
+  it('keeps blocking a pane with its own unanswered notice next to a dismissed sibling', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+
+    const transport = createMockTransport('pty-stale')
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-sibling' }] },
+      ptyIdsByTabId: { 'tab-1': ['pty-stale', 'pty-sibling'] },
+      codexRestartNoticeByPtyId: {
+        'pty-stale': { previousAccountLabel: 'A', nextAccountLabel: 'B' },
+        'pty-sibling': { previousAccountLabel: 'A', nextAccountLabel: 'B', dismissed: true }
+      }
+    }
+
+    const pane = createPane(1)
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    const deps = createDeps({
+      paneTransportsRef: { current: new Map([[2, createMockTransport('pty-sibling')]]) }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+
+    expect(onDataHandler).toBeDefined()
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    ;(onDataHandler as (data: string) => void)('a')
+
+    expect((transport.getPtyId as unknown as () => string | null)()).toBe('pty-stale')
+    expect(transport.sendInput).not.toHaveBeenCalled()
+  })
+
   it('keeps blocking input on a pane whose restart is requested but not yet run', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -827,14 +827,17 @@ function isCodexPaneStale(args: {
   if (!hasCodexRestartNotices(codexRestartNoticeByPtyId)) {
     return false
   }
-  // Why: the pane's own record is the last word. `tab.ptyId` names whichever
-  // pane bound last, so in a split tab consulting it would keep this pane's
-  // keyboard dead over a sibling's prompt the user cannot answer for this pane.
-  const paneNotice = args.panePtyId ? codexRestartNoticeByPtyId[args.panePtyId] : undefined
-  if (paneNotice) {
-    return blocksCodexPaneInput(paneNotice)
+  // Why: a bound pane's own record is the last word — its ptyId is exactly the
+  // shell its keystrokes reach. `tab.ptyId` names whichever pane bound last, so
+  // in a split tab consulting it would kill this pane's keyboard over a
+  // sibling's notice, with no prompt on screen once that sibling is answered.
+  if (args.panePtyId) {
+    return blocksCodexPaneInput(codexRestartNoticeByPtyId[args.panePtyId])
   }
 
+  // Why: only an unbound pane needs the tab's persisted id. Both transports
+  // refuse writes while their pty binding is null, so a keystroke here arms
+  // recovery, which reattaches to that id — the shell this pane is about to own.
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)
   if (tab?.ptyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[tab.ptyId])) {
     return true

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -828,16 +828,17 @@ function isCodexPaneStale(args: {
     return false
   }
   // Why: a bound pane's own record is the last word — its ptyId is exactly the
-  // shell its keystrokes reach. `tab.ptyId` names whichever pane bound last, so
-  // in a split tab consulting it would kill this pane's keyboard over a
-  // sibling's notice, with no prompt on screen once that sibling is answered.
+  // shell its keystrokes reach. `tab.ptyId` holds one sibling's id, not this
+  // pane's, so in a split tab consulting it would kill this pane's keyboard over
+  // that sibling's notice, with no prompt on screen once the sibling is answered.
   if (args.panePtyId) {
     return blocksCodexPaneInput(codexRestartNoticeByPtyId[args.panePtyId])
   }
 
   // Why: only an unbound pane needs the tab's persisted id. Both transports
   // refuse writes while their pty binding is null, so a keystroke here arms
-  // recovery, which reattaches to that id — the shell this pane is about to own.
+  // recovery — a coarser signal than a bound pane's own record, but the tab's id
+  // is the only evidence available of which shell this pane is about to own.
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)
   if (tab?.ptyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[tab.ptyId])) {
     return true

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5,6 +5,7 @@ import type { IBuffer, IDisposable } from '@xterm/xterm'
 import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
 import { detectAgentStatusFromTitle, agentTypeToIconAgent, isClaudeAgent } from '@/lib/agent-status'
 import { resolvePaneTitleDecision } from './terminal-title-evidence'
+import { blocksCodexPaneInput } from '../codex-restart-notice-state'
 import { resolveLiveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
@@ -826,12 +827,12 @@ function isCodexPaneStale(args: {
   if (!hasCodexRestartNotices(codexRestartNoticeByPtyId)) {
     return false
   }
-  if (args.panePtyId && codexRestartNoticeByPtyId[args.panePtyId]) {
+  if (args.panePtyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[args.panePtyId])) {
     return true
   }
 
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)
-  if (tab?.ptyId && codexRestartNoticeByPtyId[tab.ptyId]) {
+  if (tab?.ptyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[tab.ptyId])) {
     return true
   }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -827,8 +827,12 @@ function isCodexPaneStale(args: {
   if (!hasCodexRestartNotices(codexRestartNoticeByPtyId)) {
     return false
   }
-  if (args.panePtyId && blocksCodexPaneInput(codexRestartNoticeByPtyId[args.panePtyId])) {
-    return true
+  // Why: the pane's own record is the last word. `tab.ptyId` names whichever
+  // pane bound last, so in a split tab consulting it would keep this pane's
+  // keyboard dead over a sibling's prompt the user cannot answer for this pane.
+  const paneNotice = args.panePtyId ? codexRestartNoticeByPtyId[args.panePtyId] : undefined
+  if (paneNotice) {
+    return blocksCodexPaneInput(paneNotice)
   }
 
   const tab = (state.tabsByWorktree[args.worktreeId] ?? []).find((entry) => entry.id === args.tabId)

--- a/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '../index'
+
+const A = 'a@example.com'
+const B = 'b@example.com'
+const C = 'c@example.com'
+
+function switchAccount(ptyId: string, from: string, to: string): void {
+  useAppStore
+    .getState()
+    .markCodexRestartNotices([{ ptyId, previousAccountLabel: from, nextAccountLabel: to }])
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState(), true)
+})
+
+describe('codex restart notice lifecycle', () => {
+  it('raises no notice when the pane returns to the account it launched under', () => {
+    switchAccount('pty-1', A, B)
+    switchAccount('pty-1', B, A)
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeUndefined()
+  })
+
+  it('keeps the launch account after a dismissal so re-selecting it raises no notice', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    switchAccount('pty-1', B, A)
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeUndefined()
+  })
+
+  it('marks a dismissal instead of erasing the pane record', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: B,
+      dismissed: true
+    })
+  })
+
+  it('re-raises the prompt against the pane launch account when a third account is selected', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    switchAccount('pty-1', B, C)
+
+    // Why: over-suppressing here would silently strand the pane on A while the
+    // user works under C; the labels must name the launch account, not B.
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: C
+    })
+  })
+
+  it('drops a queued restart when the user dismisses the same pane', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().queueCodexPaneRestarts(['pty-1'])
+
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: B,
+      dismissed: true
+    })
+    expect(useAppStore.getState().pendingCodexPaneRestartIds).toEqual({})
+  })
+
+  it('leaves the notice map identity alone when nothing is dismissable', () => {
+    switchAccount('pty-1', A, B)
+    const before = useAppStore.getState().codexRestartNoticeByPtyId
+
+    useAppStore.getState().dismissCodexRestartNotices(['pty-unknown'])
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId).toBe(before)
+  })
+
+  it('still deletes the record when the pane actually restarts', () => {
+    switchAccount('pty-1', A, B)
+
+    // Why: the relaunched pane genuinely runs under B, so its launch-account
+    // memory must reset rather than linger and suppress a later B -> A prompt.
+    useAppStore.getState().clearCodexRestartNotice('pty-1')
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeUndefined()
+    switchAccount('pty-1', B, A)
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: B,
+      nextAccountLabel: A
+    })
+  })
+})

--- a/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
@@ -57,6 +57,22 @@ describe('codex restart notice lifecycle', () => {
     })
   })
 
+  it('leaves a dismissal answered when the active account is re-marked unchanged', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    // Why: adding an account and reauthenticating the active one both re-mark
+    // live panes with the selection unchanged. Nothing about the pane moved, so
+    // resurrecting the prompt would also re-block a keyboard the user freed.
+    switchAccount('pty-1', B, B)
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: B,
+      dismissed: true
+    })
+  })
+
   it('drops a queued restart when the user dismisses the same pane', () => {
     switchAccount('pty-1', A, B)
     useAppStore.getState().queueCodexPaneRestarts(['pty-1'])

--- a/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/codex-restart-notice-lifecycle.test.ts
@@ -71,6 +71,21 @@ describe('codex restart notice lifecycle', () => {
     expect(useAppStore.getState().pendingCodexPaneRestartIds).toEqual({})
   })
 
+  it('re-blocks a dismissed pane once a restart is queued for it', () => {
+    switchAccount('pty-1', A, B)
+    useAppStore.getState().dismissCodexRestartNotices(['pty-1'])
+
+    useAppStore.getState().queueCodexPaneRestarts(['pty-1'])
+
+    // Why: the pane still runs under A until it relaunches, so the dismissal
+    // that freed its keyboard must not outlive the restart request.
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: A,
+      nextAccountLabel: B,
+      restartRequested: true
+    })
+  })
+
   it('leaves the notice map identity alone when nothing is dismissable', () => {
     switchAccount('pty-1', A, B)
     const before = useAppStore.getState().codexRestartNoticeByPtyId

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -466,6 +466,10 @@ export type CodexRestartNotice = {
    *  because `previousAccountLabel` is the only memory of the account this pane
    *  actually launched under, which drives the A -> B -> A collapse. */
   restartRequested?: true
+  /** Set when the user answers "Keep old account". Same reason the record has to
+   *  survive: deleting it erased the launch account, so re-selecting it looked
+   *  like a fresh switch and raised an inverted prompt that killed pane input. */
+  dismissed?: true
 }
 
 export type TerminalSlice = {
@@ -647,6 +651,7 @@ export type TerminalSlice = {
     notices: { ptyId: string; previousAccountLabel: string; nextAccountLabel: string }[]
   ) => void
   clearCodexRestartNotice: (ptyId: string) => void
+  dismissCodexRestartNotices: (ptyIds: string[]) => void
   setTabPaneExpanded: (tabId: string, expanded: boolean) => void
   setTabCanExpandPane: (tabId: string, canExpand: boolean) => void
   setTabLayout: (tabId: string, layout: TerminalLayoutSnapshot | null) => void
@@ -2847,6 +2852,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           nextAccountLabel: notice.nextAccountLabel,
           // Why: a queued restart relaunches under whatever account is selected
           // when it runs, so a later switch does not reopen an answered prompt.
+          // A dismissal is deliberately not carried over — it answered "keep the
+          // old account instead of B", which says nothing about a later C.
           ...(existing?.restartRequested ? { restartRequested: true as const } : {})
         }
       }
@@ -2866,6 +2873,34 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const nextPendingCodexPaneRestartIds = { ...s.pendingCodexPaneRestartIds }
       delete next[ptyId]
       delete nextPendingCodexPaneRestartIds[ptyId]
+      return {
+        codexRestartNoticeByPtyId: next,
+        pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds
+      }
+    })
+  },
+
+  dismissCodexRestartNotices: (ptyIds) => {
+    set((s) => {
+      // Why: keeping the old account is an answer, not a restart — the record
+      // stays so `previousAccountLabel` still names the pane's launch account,
+      // but every consumer treats it as answered (prompt hidden, input freed).
+      const next = { ...s.codexRestartNoticeByPtyId }
+      const nextPendingCodexPaneRestartIds = { ...s.pendingCodexPaneRestartIds }
+      let changed = false
+      for (const ptyId of ptyIds) {
+        const notice = next[ptyId]
+        if (!notice || notice.dismissed) {
+          continue
+        }
+        const { restartRequested: _restartRequested, ...kept } = notice
+        next[ptyId] = { ...kept, dismissed: true }
+        delete nextPendingCodexPaneRestartIds[ptyId]
+        changed = true
+      }
+      if (!changed) {
+        return {}
+      }
       return {
         codexRestartNoticeByPtyId: next,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2856,9 +2856,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
           nextAccountLabel: notice.nextAccountLabel,
           // Why: a queued restart relaunches under whatever account is selected
           // when it runs, so a later switch does not reopen an answered prompt.
-          // A dismissal is deliberately not carried over — it answered "keep the
-          // old account instead of B", which says nothing about a later C.
-          ...(existing?.restartRequested ? { restartRequested: true as const } : {})
+          ...(existing?.restartRequested ? { restartRequested: true as const } : {}),
+          // Why: a dismissal answered one question — "keep the launch account
+          // instead of this one". Only a genuinely different target re-asks it,
+          // so a later C reopens the prompt while adding an account or
+          // reauthenticating the active one (both re-mark live panes with the
+          // selection unchanged) must not resurrect it and re-mute the pane.
+          ...(existing?.dismissed && existing.nextAccountLabel === notice.nextAccountLabel
+            ? { dismissed: true as const }
+            : {})
         }
       }
       return {

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2802,7 +2802,11 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       for (const ptyId of ptyIds) {
         const notice = nextCodexRestartNoticeByPtyId[ptyId]
         if (notice) {
-          nextCodexRestartNoticeByPtyId[ptyId] = { ...notice, restartRequested: true }
+          // Why: mirror of the strip in dismissCodexRestartNotices. A queued
+          // restart leaves the pane on the old account until it relaunches, so
+          // it must re-block input that an earlier dismissal had freed.
+          const { dismissed: _dismissed, ...kept } = notice
+          nextCodexRestartNoticeByPtyId[ptyId] = { ...kept, restartRequested: true }
         }
       }
       return {


### PR DESCRIPTION
Stacked on #10802 (base: `brennanb2025/codex-notice-dismissed-state`), which is itself stacked on #10770. **Review only the top commit.**

## Root cause

Issue #10757's reporter sees a Codex TUI reading `0% left` (old account) under an Orca status bar reading `78% left` (new one), "no matter how many times I restart the application." There are two independent mechanisms behind that. #10770 fixes the first (CODEX_HOME baked into a daemon-kept shell). This is the second.

`prepareCodexSessionResumeForLaunch` (`src/main/index.ts`) ends with:

```ts
const resumeHome = migrated.useRealCodexHome ? systemHomePath : sessionSource.homePath
```

That value becomes `codexResumeHome.codexHomePath`, which `src/main/ipc/pty.ts` then uses **as** `selectedCodexHomePath`, overriding the current account selection. This is deliberate — Orca refuses to resume a rollout under an account that does not own it, "to avoid using a different account."

The bug is that it happens **silently**. `recordCodexPaneAccountForSpawn` read the pin as "intentional, nothing to say" and called `forgetCodexPaneAccount`, so the pane was never reported by `listStaleCodexPanes` and the startup sweep never raised a prompt. The user switched accounts, the pane cold-restored, and it came back on the old account with no indication.

**The pin is not changing.** Resume still follows the originating account. This PR only makes Orca say so.

## The fix

Record the account that actually owns the pinned home instead of forgetting the pane. No new UI — `CodexRestartChip` already renders exactly the right message ("Codex is still signed in as {previous}. Restart this session to use {next}."), it just never fired for these panes.

New `src/main/codex/codex-pane-launch-account.ts` maps an effective CODEX_HOME back to an account id:

| Launch home | Attributed to |
| --- | --- |
| none injected | system-default account (`null`) |
| the real system home (`migrated.useRealCodexHome`) | system-default account (`null`) |
| a `codexManagedAccounts[].managedHomePath` on the **same selection lane** | that account |
| anything else | **not recorded** |

The last row is the load-bearing one. A restart notice blocks *all* pane input (`isCodexPaneStale` → `pty-connection.ts:819`), so a wrong attribution turns a correctly-signed-in terminal into one that silently ignores typing. The shared runtime mirror (`codex-runtime-home/home`) hot-swaps to whichever account is selected, so a pane resumed into it is *not* on a different account — guessing "system default" there would be a false positive. Under the flag-OFF lane every host account launches from that mirror, so those installs keep today's behavior exactly.

Lane matching (`getCodexSelectionLaneKey`) means a WSL pane is only ever attributed to an account on its own per-distro lane. (In practice `prepareCodexSessionResumeForLaunch` returns `null` for WSL targets today, so this is belt-and-braces against that changing.)

`recordCodexPaneAccountForSpawn` now passes the **effective** `selectedCodexHomePath` rather than the raw resume home, so a home dropped by `getCompatibleSelectedCodexHomePath` (host/WSL incompatibility) is attributed to what the shell will really run against, not to what was requested.

## Mutation proof

Every new test was mutation-proved. Five separate reverts, each run against the new suites:

| Mutation | Tests that failed |
| --- | --- |
| A. Resume-pinned returns `null` (the pre-fix `forgetCodexPaneAccount` behavior) | 5 of 9 unit tests + the pty integration test (`recordCodexPaneAccount` calls `[]` vs `['pty-resumed', {accountId: 'account-a'}]`) |
| B. Restore the old `if (args.pinnedByResume) { forget; return }` guard in `pty.ts` | the pty integration test |
| C. Drop the selection-lane check from the account lookup | `does not let a host account answer for a WSL pane on the same path` |
| D. Drop the system-home branch | `maps a resume redirected to the real system home to the system-default account` |
| E. Return `null` instead of `undefined` for an unowned home (guess system default) | `refuses to attribute a resume home no account owns`, the WSL-lane test, and `tolerates settings that carry no managed account roster` |

All 9 unit tests and both integration tests are covered by at least one mutation. The four tests that survive mutation A are the false-positive guards — they assert `null` on both sides of A by design, and mutations C/D/E are what discriminate them.

## Gates

All run locally, all green:

- `npx tsc --noEmit -p config/tsconfig.node.json`
- `npx tsc --noEmit -p config/tsconfig.tc.cli.json`
- `npx tsc --noEmit -p config/tsconfig.tc.web.json`
- `npx oxlint` (exit 0; warnings are pre-existing, none in changed files)
- `node config/scripts/check-max-lines-ratchet.mjs` — OK, no new bypasses
- `npx vitest run --config config/vitest.config.ts src/main/codex/ src/main/ipc/pty.test.ts` — 39 files, 964 passed
- plus `src/main/ipc/codex-accounts.test.ts`, `codex-restart-chip{,-inputs}.test.ts`, `codex-session-restart.test.ts`, `codex-restart-notice-lifecycle.test.ts` — 44 passed

No new file is reachable from the CLI graph (`pty.ts` and `codex-pane-account-registry.ts` are not in `config/tsconfig.cli.json`), so no explicit-file-list change was needed. No user-facing strings added.

## Restart loop — checked, not assumed

The obvious hazard is that the chip's Restart re-triggers the same auto-resume, re-pins to the old account, and the chip comes straight back. Traced end to end:

1. `CODEX_ACCOUNT_RESTART_STARTUP` is `{ command: 'codex', startupCommandDelivery: 'shell-ready' }` — no `resumeProviderSession`, no `launchConfig`. An existing `toEqual` assertion in `codex-session-restart.test.ts` pins that shape.
2. `handleRestartCodexPane` calls `clearTabPtyId` and passes no `restoredLeafId`/`restoredPtyIdByLeafId` (neither is ever passed from `TerminalPane` in production), so `restoredSessionId`, `detachedLivePtyId`, and `detachedRemoteLeafPtyId` all resolve `null` → the fresh-spawn branch.
3. On that branch a resume is only rebuilt when `sleptRemoteColdRestoreStartup || hasSleepingAgentSession`. The former needs a remote-runtime restored session id (`null` here); the latter needs a sleeping record for the pane key, which the earlier cold restore consumed via `clearSleepingRecordAfterColdRestoreSpawn`.

So in the acceptance scenario the restart spawns plain `codex` under the new account and the chip does not return.

**One narrow residual, pre-existing and reported rather than fixed:** `clearSleepingRecordAfterColdRestoreSpawn` only clears when `!startup.useLiveEntry` (`pty-connection.ts:4613`). If a live agent-status entry and a stale sleeping record coexist for one pane key (the hibernation-wake path), the record survives and a subsequent chip Restart *would* rebuild a resume and re-pin. This is behavior on the base branch, not introduced here — it applies equally to a non-pinned pane whose restart re-resumes. This PR makes it visible where it previously went unreported. Closing it means threading a "do not auto-resume" flag through `connectPanePty` into `pty-connection.ts`, which is out of scope for this change and overlaps a file a sibling PR is editing.

## Dismissal composes with #10802

Dismiss ("Keep old account") marks the renderer notice `dismissed` **and** calls `codexAccounts:forgetStalePanes`, which deletes the on-disk record. This PR only writes at spawn time, so it never resurrects a dismissed record for a live pane. Note that if the pane later cold-restores again (a genuinely new Codex process re-pinned to the old account), it is re-recorded and can prompt again — correct, in my read, since the earlier dismissal answered for a process that no longer exists.

## Not verified

- **No live app run.** Verification is static tracing plus unit/integration tests. Acceptance items 1–4 were reasoned through and covered at the unit boundary, not exercised in a running Orca.
- **The startup sweep is one-shot.** `markRestoredStaleCodexSessionsForRestart` fires once from `App.tsx` over PTYs live at that moment. A pane that cold-restores *after* the sweep has run gets its record written but no chip until the next app launch. That is the startup-sweep bind race a sibling agent is fixing on a separate branch off #10770; I did not duplicate it. Until that lands, acceptance item 1 can present one launch later than ideal.
- **Windows / WSL untested on real hardware.** The WSL lane logic is unit-tested with both UNC spellings (`//wsl.localhost/...` and `\\wsl$\...`) through `normalizeRuntimePathForComparison`, but no Windows run.
- **Local baseline caveat:** this machine runs Node 26 against a repo pinned to Node 24; the known ~41 pre-existing localStorage failures are in untouched suites and were not re-triggered by any suite I ran.
