### PR TITLE
fix(daemon): retire a daemon left empty by an unclean client disconnect

### DIFF
--- a/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
+++ b/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
@@ -3,12 +3,13 @@ import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 
 describe('foreground-confirmation daemon protocol', () => {
   it('rejects daemons from before the fresh-confirmation RPC', () => {
-    expect(PROTOCOL_VERSION).toBe(28)
+    expect(PROTOCOL_VERSION).toBe(29)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(19)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(22)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(23)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(24)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(25)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(26)
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(28)
   })
 })

--- a/src/main/daemon/daemon-idle-shutdown.test.ts
+++ b/src/main/daemon/daemon-idle-shutdown.test.ts
@@ -155,6 +155,7 @@ describe('current daemon lifecycle retirement', () => {
     options: {
       launchNonce?: string
       protocolVersion?: number
+      idleSelfShutdownTimeoutMs?: number
     } = {}
   ): Promise<void> {
     server = new DaemonServer({
@@ -165,6 +166,7 @@ describe('current daemon lifecycle retirement', () => {
         ? { protocolVersion: options.protocolVersion }
         : {}),
       initialAdoptionTestConfig: { timeoutMs: 100, clock },
+      idleSelfShutdownTimeoutMs: options.idleSelfShutdownTimeoutMs ?? 10_000,
       onIdleShutdown,
       spawnSubprocess: () => subprocess
     })
@@ -683,6 +685,93 @@ describe('current daemon lifecycle retirement', () => {
     await waitFor(() => onIdleShutdown.mock.calls.length === 1)
 
     expect(readFileSync(tokenPath, 'utf8')).toBe('replacement-token')
+  })
+
+  // ── Post-use idle self-shutdown (#9138) ────────────────────────────────────
+  // An app update spawns a new daemon generation and leaves the old one running. Nothing retired
+  // it, so its agent sessions accumulated across updates — four generations and 25 GB of swap in
+  // the field report. These cover the timer plus the races that make it safe.
+
+  it('arms the idle timer once a used daemon has no clients and no sessions', async () => {
+    // The gap the timer closes. A clean disconnect already sets retirementRequested, so a daemon
+    // that drains later still exits. An app killed by an update, a crash, or force-quit leaves a
+    // fully authenticated client record behind: retirement is never requested, and the daemon
+    // outlives every generation that follows it.
+    await startServer()
+    const daemon = server as unknown as {
+      initialAdoptionDeadlineMs: number | null
+      idleSelfShutdownTimer: unknown
+      reevaluateIdleShutdown(): void
+    }
+    // Past first adoption, so the short never-adopted deadline no longer owns this window.
+    daemon.initialAdoptionDeadlineMs = null
+    daemon.reevaluateIdleShutdown()
+
+    expect(daemon.idleSelfShutdownTimer).not.toBeNull()
+    clock.advanceBy(10_000)
+    await waitFor(() => onIdleShutdown.mock.calls.length === 1)
+  })
+
+  it('never arms the timer while a session is still live', async () => {
+    // A background agent is live work. The daemon must outlive its client for warm reattach.
+    await startServer()
+    const client = new DaemonClient({ socketPath, tokenPath })
+    await client.ensureConnected()
+    await client.request('createOrAttach', { sessionId: 'live-agent', cols: 80, rows: 24 })
+    client.disconnect()
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    const daemon = server as unknown as { idleSelfShutdownTimer: unknown }
+    expect(daemon.idleSelfShutdownTimer).toBeNull()
+    clock.advanceBy(10_000)
+    expect(onIdleShutdown).not.toHaveBeenCalled()
+  })
+
+  it('cancels the timer when a client reconnects before it expires', async () => {
+    await startServer()
+    const daemon = server as unknown as {
+      initialAdoptionDeadlineMs: number | null
+      idleSelfShutdownTimer: unknown
+      reevaluateIdleShutdown(): void
+    }
+    daemon.initialAdoptionDeadlineMs = null
+    daemon.reevaluateIdleShutdown()
+    expect(daemon.idleSelfShutdownTimer).not.toBeNull()
+
+    // A full client pair re-owns the endpoint; isIdle() goes false and the timer is dropped.
+    const client = new DaemonClient({ socketPath, tokenPath })
+    await client.ensureConnected()
+    await client.request('createOrAttach', { sessionId: 'reclaimed', cols: 80, rows: 24 })
+    expect(daemon.idleSelfShutdownTimer).toBeNull()
+
+    clock.advanceBy(10_000)
+    expect(onIdleShutdown).not.toHaveBeenCalled()
+    client.disconnect()
+  })
+
+  it('does not fire when a session is created after the timer was armed', async () => {
+    // The race the design calls out. Cancelling on create is the fast path, not the guarantee:
+    // this proves the expiry re-check independently prevents killing a live session, so a lost or
+    // late cancel is non-destructive rather than fatal.
+    await startServer()
+    const client = new DaemonClient({ socketPath, tokenPath })
+    await client.ensureConnected()
+    const daemon = server as unknown as {
+      initialAdoptionDeadlineMs: number | null
+      idleSelfShutdownTimer: unknown
+      onIdleSelfShutdownExpiry(): void
+    }
+    daemon.initialAdoptionDeadlineMs = null
+    await client.request('createOrAttach', { sessionId: 'late-arrival', cols: 80, rows: 24 })
+
+    // Re-arm as if the create had raced past the cancel, then reach expiry with a live session.
+    daemon.idleSelfShutdownTimer = clock.setTimeout(() => {
+      daemon.onIdleSelfShutdownExpiry()
+    }, 10_000)
+    clock.advanceBy(10_000)
+
+    expect(onIdleShutdown).not.toHaveBeenCalled()
+    client.disconnect()
   })
 })
 

--- a/src/main/daemon/daemon-protocol-version.test.ts
+++ b/src/main/daemon/daemon-protocol-version.test.ts
@@ -9,14 +9,16 @@ import {
 } from './daemon-protocol-version'
 
 describe('daemon protocol version', () => {
-  it('ships preflight-cache replacement after completion inspection', () => {
-    expect(PROTOCOL_VERSION).toBe(28)
+  it('ships idle self-shutdown after preflight-cache replacement', () => {
+    expect(PROTOCOL_VERSION).toBe(29)
     expect(COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION).toBe(27)
     expect(GET_FOREGROUND_PROCESS_PROTOCOL_VERSION).toBe(11)
     expect(AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION).toBe(26)
+    // Why every prior version stays listed: a running daemon from any earlier generation must still
+    // be adoptable so its live PTYs survive the upgrade that introduced this bump.
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toEqual(
-      Array.from({ length: 27 }, (_, index) => index + 1)
+      Array.from({ length: 28 }, (_, index) => index + 1)
     )
   })
 })

--- a/src/main/daemon/daemon-protocol-version.ts
+++ b/src/main/daemon/daemon-protocol-version.ts
@@ -1,6 +1,8 @@
 // Why: daemons survive app updates, so wire behavior must be version-gated.
-// v28 replaces v26/v27 daemons that can retain permanent macOS preflight rejections (#9756).
-export const PROTOCOL_VERSION = 28
+// v29 adds zero-client/zero-session idle self-shutdown so an abandoned generation retires itself
+// (#9138). Idle policy is baked into the daemon binary, so already-running v28 and older daemons
+// cannot acquire it; app-side legacy retirement covers those.
+export const PROTOCOL_VERSION = 29
 export const COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION = 27
 export const GET_FOREGROUND_PROCESS_PROTOCOL_VERSION = 11
 export const PTY_STARTUP_INGRESS_PROTOCOL_VERSION = 25
@@ -9,7 +11,8 @@ export const AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION = 26
 export const GIT_CREDENTIAL_GUARD_HOST_PROTOCOL_VERSION = 22
 export const CLEAN_DISCONNECT_PROTOCOL_VERSION = 24
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
-  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+  28
 ] as const
 
 export function supportsPtyStartupIngress(protocolVersion: number): boolean {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -46,6 +46,8 @@ export type DaemonServerOptions = {
   /** Direct-construction seam for protocol fixture tests; production never overrides it. */
   protocolVersion?: number
   onIdleShutdown?: () => void
+  /** Test seam for the post-use idle timer; production uses IDLE_SELF_SHUTDOWN_TIMEOUT_MS. */
+  idleSelfShutdownTimeoutMs?: number
   /** Direct-construction-only controls; production uses the compiled initial-adoption timeout. */
   initialAdoptionTestConfig?: {
     timeoutMs: number
@@ -93,6 +95,10 @@ type PendingShutdownReply = {
 export class DaemonServer {
   // Why: survive long enough to adopt a first client pair, but don't orphan forever if the parent crashes first.
   private static readonly INITIAL_ADOPTION_TIMEOUT_MS = 2 * 60 * 1000
+  // Why 30 minutes (#9138): long enough that a brief app restart or update reconnects to the same
+  // daemon and keeps warm reattach, short enough that a generation left behind by an update exits
+  // the same day instead of holding its PTYs forever.
+  private static readonly IDLE_SELF_SHUTDOWN_TIMEOUT_MS = 30 * 60 * 1000
   private static readonly SHUTDOWN_REPLY_FLUSH_TIMEOUT_MS = 1_000
   private server: Server | null = null
   private token: string
@@ -113,6 +119,11 @@ export class DaemonServer {
   private idleShutdownState: 'running' | 'idle-shutdown-pending' | 'shutting-down' = 'running'
   private initialAdoptionTimer: unknown | null = null
   private initialAdoptionDeadlineMs: number | null = null
+  // Why separate from the adoption timer: that one only covers the window before the first client
+  // ever connects. This one covers a daemon that was used and then abandoned, which is the shape an
+  // app update leaves behind (#9138).
+  private idleSelfShutdownTimer: unknown | null = null
+  private idleSelfShutdownTimeoutMs: number
   private retirementRequested = false
   private shutdownPromise: Promise<void> | null = null
   private ordinaryShutdownServerClose: Promise<void> | null = null
@@ -174,6 +185,8 @@ export class DaemonServer {
     this.onIdleShutdown = opts.onIdleShutdown ?? (() => {})
     this.initialAdoptionTimeoutMs =
       opts.initialAdoptionTestConfig?.timeoutMs ?? DaemonServer.INITIAL_ADOPTION_TIMEOUT_MS
+    this.idleSelfShutdownTimeoutMs =
+      opts.idleSelfShutdownTimeoutMs ?? DaemonServer.IDLE_SELF_SHUTDOWN_TIMEOUT_MS
     this.lifecycleClock = opts.initialAdoptionTestConfig?.clock ?? {
       setTimeout: (callback, delayMs) => {
         const timer = setTimeout(callback, delayMs)
@@ -241,6 +254,7 @@ export class DaemonServer {
   private beginOrdinaryShutdownFence(): Promise<void> {
     this.idleShutdownState = 'shutting-down'
     this.cancelInitialAdoptionTimer()
+    this.cancelIdleSelfShutdownTimer()
     this.ordinaryShutdownServerClose ??= this.beginServerClose()
     return this.ordinaryShutdownServerClose
   }
@@ -310,6 +324,7 @@ export class DaemonServer {
   }
 
   private reevaluateIdleShutdown(): void {
+    this.reevaluateIdleSelfShutdown()
     if (this.idleShutdownState !== 'running') {
       return
     }
@@ -347,6 +362,58 @@ export class DaemonServer {
     this.reevaluateIdleShutdown()
   }
 
+  /**
+   * Arm/cancel the post-use idle timer (#9138). An app update spawns a new daemon generation and
+   * leaves the old one running; nothing retires it, so its agent sessions accumulate across updates.
+   * A daemon that still holds a session never arms this — a background agent is live work.
+   */
+  private reevaluateIdleSelfShutdown(): void {
+    if (this.idleShutdownState !== 'running') {
+      this.cancelIdleSelfShutdownTimer()
+      return
+    }
+    if (!this.isIdle()) {
+      this.cancelIdleSelfShutdownTimer()
+      return
+    }
+    // Why defer to the adoption timer: before the first client pair it already owns the
+    // never-adopted case on a much shorter deadline. Two live timers for one condition would race
+    // and double-count in lifecycle assertions.
+    if (this.initialAdoptionDeadlineMs !== null) {
+      this.cancelIdleSelfShutdownTimer()
+      return
+    }
+    if (this.idleSelfShutdownTimer !== null) {
+      return
+    }
+    this.idleSelfShutdownTimer = this.lifecycleClock.setTimeout(() => {
+      this.onIdleSelfShutdownExpiry()
+    }, this.idleSelfShutdownTimeoutMs)
+  }
+
+  /**
+   * Why re-check rather than trust the timer: a client can connect or a session can be created
+   * between arming and expiry. Cancelling on create is the fast path, not the guarantee — this
+   * re-test plus beginIdleShutdown's own is what makes a lost or late cancel non-destructive.
+   */
+  private onIdleSelfShutdownExpiry(): void {
+    this.idleSelfShutdownTimer = null
+    if (this.idleShutdownState !== 'running' || !this.isIdle()) {
+      return
+    }
+    this.log.log('shutdown', { reason: 'idle-self' })
+    this.retirementRequested = true
+    this.beginIdleShutdown()
+  }
+
+  private cancelIdleSelfShutdownTimer(): void {
+    if (this.idleSelfShutdownTimer === null) {
+      return
+    }
+    this.lifecycleClock.clearTimeout(this.idleSelfShutdownTimer)
+    this.idleSelfShutdownTimer = null
+  }
+
   private cancelInitialAdoptionTimer(): void {
     if (this.initialAdoptionTimer === null) {
       return
@@ -357,6 +424,7 @@ export class DaemonServer {
 
   private beginIdleShutdown(): void {
     this.initialAdoptionTimer = null
+    this.cancelIdleSelfShutdownTimer()
     if (this.idleShutdownState !== 'running') {
       return
     }
@@ -691,6 +759,9 @@ export class DaemonServer {
           // Why: a control-only replacement can't own terminal admission or erase the prior client's retirement request.
           throw new Error('Daemon client connection is incomplete; reconnect')
         }
+        // Why cancel before the counter: once a create is admitted the daemon is no longer idle, and
+        // the idle timer must not fire while this operation is in flight (#9138).
+        this.cancelIdleSelfShutdownTimer()
         this.createOrAttachInFlight++
         const p = request.payload
         let routedSessionId = p.sessionId


### PR DESCRIPTION
Partial fix for #9138. Implements section 6 of the reviewed design in [AmethystLiang's comment](https://github.com/stablyai/orca/issues/9138#issuecomment-list), which states that piece may ship independently because it never infers ownership and never acts while a session exists.

## The bug

Each app update spawns a new versioned daemon (`daemon-vNN`) and deliberately leaves the previous generation running so its PTYs survive the upgrade.

**Correction to an earlier version of this description:** it claimed retirement "was never built". That is wrong — #9277 added event-driven retirement for empty daemons, including an e2e spec proving a v22 legacy daemon stays reattachable while a v24 retires. This PR adds one uncovered case on top of that, described below.

The field report found four generations coexisting, 370 stray processes, and 25 GB of swap — each stray agent session holding 300–450 MB plus MCP children.

## Why the existing retirement path misses it

The daemon exits only when `isIdle()` is true, which requires zero sessions (`daemon-server.ts:303`). Two things that sound like the fix aren't:

- `pruneOldDaemonHosts` is **Windows-only and deletes directories, not processes** (`daemon-host-relocation.ts:321`). The reporters are on macOS.
- A **clean** disconnect already sets `retirementRequested`, so a daemon that drains later does exit today.

The gap is a client that never disconnects cleanly — an app killed by an update, a crash, or force-quit. `recordFullyAuthenticatedDisconnect` never runs, so `retirementRequested` is never set, and nothing re-checks afterwards. The daemon then outlives every generation after it.

**This PR does not fix the reported symptom.** The leaked generations in #9138 were *holding live agent sessions* — the reporter found "`claude` processes up to ~1.8 days old, several hundred MB RSS each", and the original report lists 22, 11, and 8 direct children per stale daemon. This timer never arms while a session is live, because that is what protects warm reattach. So on the machines in those reports it changes nothing.

What it does close is a real hole in the retirement state machine: a daemon that becomes empty after its client died uncleanly currently stays alive forever. That is worth fixing on its own, but it is not the memory leak.

Reaping generations that still hold unclaimed sessions needs the cross-profile ownership snapshot from sections 1-5 of the reviewed design, and per that design its first release is audit-only.

## The change

The daemon arms a 30-minute timer when it has **zero clients and zero sessions**, and exits on expiry.

- A daemon **holding a session never arms it** — a background agent is live work, and warm reattach must keep working.
- The timer defers to the existing 2-minute adoption deadline before the first client pair, so the two never race.
- Expiry re-checks idleness rather than trusting the timer. Cancel-on-create is the fast path, not the guarantee.

**30 minutes** is chosen so a brief restart or update reconnects to the same daemon and keeps warm reattach, while a generation left behind by an update exits the same day instead of persisting for weeks.

`PROTOCOL_VERSION` → 29, since idle policy is baked into the daemon binary. 28 joins `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` so running v28 daemons stay adoptable across this upgrade.

## Scope — what this does not fix

**Daemons already running on a user's machine are unaffected.** v28-and-older binaries cannot acquire idle policy; it ships inside the daemon. Those need app-side legacy retirement, which depends on the cross-profile ownership snapshot in sections 1–5 of the design and is not in this PR.

So: this stops *future* generations from being abandoned. Reaping *existing* ones is follow-up work, and per the design its first release is audit-only.

## Verification

- `vitest src/main/daemon` — **1,122 passed**, 2 skipped
- 4 new tests: arms when abandoned, never arms with a live session, cancels on client reconnect, and does not fire when a session is created after arming
- E2E: `terminal-restart-persistence` + `restart-restore-terminal-input` — **8 passed** (warm reattach across real quit/relaunch, the behaviour most at risk here)
- `tsc --noEmit -p config/tsconfig.node.json`, oxlint, oxfmt — clean

**Mutation-tested.** Removing the expiry idleness re-check alone does *not* fail, because `beginIdleShutdown` independently re-tests. Removing both does. The re-check is deliberate defense in depth, and the comment says so rather than implying it is load-bearing alone.

## Unrelated flake worth flagging

`headless-serve-desktop-activation.spec.ts` fails ~2 in 3 runs **on `main`** at the same rate as on this branch (`promotedPtyId` differs — the daemon terminal is replaced). Not caused by this PR; I verified by running it repeatedly on both. Likely related to #10518, since PR CI never runs the E2E suite.

