### PR TITLE
fix(tabs): keep the first tab click after a browser pane takes focus

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-strip-pointer-activation.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-strip-pointer-activation.test.tsx
@@ -4,6 +4,7 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { TAB_DRAG_ACTIVATION_DISTANCE_PX } from '../tab-group/useTabDragSplit'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
+import { isTabStripPointerGestureActive } from './tab-strip-pointer-gesture'
 
 function pointerDownEvent(clientX: number, clientY: number, button = 0): React.PointerEvent {
   return { button, clientX, clientY } as unknown as React.PointerEvent
@@ -109,14 +110,44 @@ describe('useTabStripPointerActivation', () => {
     expect(onActivate).toHaveBeenCalledTimes(1)
   })
 
-  it('flushes a pending press on window focus', () => {
+  it('flushes gesture state on window focus without dropping the click', () => {
     const onActivate = vi.fn()
     const { result } = renderHook(() => useTabStripPointerActivation({ onActivate }))
 
     act(() => result.current.onPointerDown(pointerDownEvent(10, 10)))
+    expect(isTabStripPointerGestureActive()).toBe(true)
+
+    // Why: a browser-pane <webview> returning focus to the host fires window
+    // focus mid-press. #7316 wanted the scroll-suppression token released here,
+    // but cancelling also swallowed the click that caused the focus change.
     act(() => window.dispatchEvent(new Event('focus')))
+    expect(isTabStripPointerGestureActive()).toBe(false)
+
+    firePointer('pointerup', 10, 10)
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('activates the first tab click after a focused webview hands focus back', () => {
+    const onActivate = vi.fn()
+    const { result } = renderHook(() => useTabStripPointerActivation({ onActivate }))
+
+    // Real ordering captured over CDP with a focused browser-pane guest.
+    act(() => result.current.onPointerDown(pointerDownEvent(320, 19)))
+    act(() => window.dispatchEvent(new Event('focus')))
+    firePointer('pointerup', 320, 19)
+
+    expect(onActivate).toHaveBeenCalledTimes(1)
+  })
+
+  it('still suppresses activation when the window blurs mid-press', () => {
+    const onActivate = vi.fn()
+    const { result } = renderHook(() => useTabStripPointerActivation({ onActivate }))
+
+    act(() => result.current.onPointerDown(pointerDownEvent(10, 10)))
+    act(() => window.dispatchEvent(new Event('blur')))
     firePointer('pointerup', 10, 10)
 
     expect(onActivate).not.toHaveBeenCalled()
+    expect(isTabStripPointerGestureActive()).toBe(false)
   })
 })

--- a/src/renderer/src/components/tab-bar/tab-strip-pointer-activation.ts
+++ b/src/renderer/src/components/tab-bar/tab-strip-pointer-activation.ts
@@ -56,7 +56,7 @@ export function useTabStripPointerActivation({
         window.removeEventListener('pointerup', onPointerUp)
         window.removeEventListener('pointercancel', onPointerCancel)
         window.removeEventListener('blur', onPointerCancel)
-        window.removeEventListener('focus', onPointerCancel)
+        window.removeEventListener('focus', onWindowFocus)
         releaseTabStripPointerGesture()
         cleanupRef.current = null
       }
@@ -74,11 +74,18 @@ export function useTabStripPointerActivation({
       const onPointerCancel = (): void => {
         cleanup()
       }
+      // Why: clicking a tab while a browser-pane <webview> holds focus fires
+      // window focus between this press's pointerdown and pointerup. Cancelling
+      // there dropped that click entirely, so only flush the scroll-suppression
+      // token #7316 wanted released and let the release still judge click-vs-drag.
+      const onWindowFocus = (): void => {
+        releaseTabStripPointerGesture()
+      }
 
       window.addEventListener('pointerup', onPointerUp)
       window.addEventListener('pointercancel', onPointerCancel)
       window.addEventListener('blur', onPointerCancel)
-      window.addEventListener('focus', onPointerCancel)
+      window.addEventListener('focus', onWindowFocus)
       cleanupRef.current = cleanup
     },
     [disabled]


### PR DESCRIPTION
## Summary

Clicking a tab while a browser pane has keyboard focus did nothing — you had to click twice. This makes the first click work.

Repro on `main`: open a browser tab, click anywhere **inside the page**, then click another tab in the strip. Nothing happens. Click again and it switches.

Tab activation is deferred to `pointerup`, and #7316 also cancelled a pending press on window `blur`/`focus` so a press whose release never arrived could not leak the strip's scroll-suppression token. But an Electron `<webview>` guest handing focus back to the host fires a real window `focus` event **between** that press's pointerdown and pointerup. Captured with a listener registered exactly the way the hook registers its own:

```
pointerdown            target=SPAN (the tab)
HOOK-would-fire:focus  target=WINDOW      <- cancel ran here
pointerup              target=SPAN        <- listener already removed
```

`onPointerCancel` → `cleanup()` removed the `pointerup` listener, so `onActivate()` never fired. The events reach React fine — nothing calls `stopPropagation` — the handler simply has nothing left to run.

Fix: window `focus` now releases the gesture token (which is what #7316 wanted) without cancelling the press, so the release still judges click-vs-drag. `blur` still cancels.

## Screenshots

<!-- RECORDING GOES HERE -->

Before: with a browser page focused, the first click on a terminal tab does nothing; the second switches.
After: the first click switches.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Notes on the runs:

- `pnpm lint` reports pre-existing unlocalized strings in `src/renderer/src/components/settings/terminal-advanced-platform-search.ts` and `terminal-pane-appearance-search.ts` ("Ghostty"). Identical on a clean tree with this branch stashed; untouched by this PR.
- `pnpm test`: 36876 passed. 45 failures across 8 files, all pre-existing and unrelated — verified by running exactly those 8 files on clean `main` (`4ada3f8b2`), where they fail identically. They live in `src/relay/`, `right-sidebar/`, `sidebar/` and `browser-pane/markup/`; none in the files this PR touches. `tab-bar` 246/246 and `tab-group` 71/71 pass.
- The existing `flushes a pending press on window focus` test encoded the cancelling behaviour, so it is rewritten to assert the token is released **and** the click still lands. Two tests added, one of which replays the real captured event ordering.
- Mutation-checked: restoring `focus → onPointerCancel` fails exactly the two new tests and nothing else.

## AI Review Report

Reviewed with Claude Code. Risks checked:

- **Cross-platform.** No platform branching added or changed. The listeners are `window` `focus`/`blur`, which fire on all three platforms; nothing here reads `metaKey`/`ctrlKey`, key labels, or paths. The behaviour difference this fixes is Chromium's focus transfer out of a `<webview>`, which is identical on macOS, Linux and Windows. Verified on macOS; no macOS-only API is involved.
- **Regression risk on the original fix.** The concern behind #7316 was a leaked scroll-suppression token, not activation. The token is still released on `focus` (and on `blur`, `pointerup`, `pointercancel`, and unmount), so the leak stays closed. This was the main thing flagged, and it is why the fix releases the token rather than removing the listener.
- **Stray activation.** If a press is released while the window is unfocused, the `pointerup` listener now survives until the next press or unmount. Mouse capture delivers the release to the window in practice, and any later press calls `cleanupRef.current?.()` first, so a stale listener cannot accumulate. Judged acceptable; `blur` still cancels the alt-tab-away case.
- **SSH / remote / local.** Pure renderer input handling. No PTY, filesystem, process, or network path involved; identical for local, SSH and remote-runtime worktrees.
- **Agents / integrations / git providers.** None touched. The tab strip is provider- and agent-neutral.
- **Performance.** Strictly less work than before: one listener callback no longer tears down the gesture. No new allocations, timers, or hot-path work.
- **UI quality.** No visual change — no markup, tokens, styles, or layout touched. Only which click is honoured.

## Security Audit

Low risk. No input parsing, no command execution, no path handling, no auth, secrets, IPC, or dependency changes. The diff adds one local function and re-points one existing listener registration within the same module. No data crosses a process or trust boundary, and nothing new is rendered from untrusted input.

## Notes

- No platform-specific behaviour. Verified on macOS; the mechanism is Chromium focus transfer from a `<webview>` guest and is not macOS-specific.
- Behaviour is unchanged when the browser page was never focused — the first click already worked and still does. A control case covering this is part of the verification.
- X: https://x.com/nduongg04

## ELI5

If a browser pane had keyboard focus, the first click on another tab did nothing and you needed a second click. This fixes the focus/blur handling so one click switches tabs.
