### PR TITLE
fix(terminal): keep OSC 8 links clickable after a TUI repaint

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-osc8-link-memory.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc8-link-memory.test.ts
@@ -1,0 +1,206 @@
+import { Terminal } from '@xterm/headless'
+import type { ILink, Terminal as XtermTerminal } from '@xterm/xterm'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createRememberedOsc8LinkProvider,
+  installTerminalOsc8LinkMemory,
+  type TerminalOsc8LinkMemory
+} from './terminal-osc8-link-memory'
+
+const ESC = String.fromCharCode(27)
+const BEL = String.fromCharCode(7)
+
+function osc8(uri: string, text: string, id?: string): string {
+  return `${ESC}]8;${id ? `id=${id}` : ''};${uri}${BEL}${text}${ESC}]8;;${BEL}`
+}
+
+function createTerminal(): XtermTerminal {
+  return new Terminal({ allowProposedApi: true, cols: 80, rows: 24 }) as unknown as XtermTerminal
+}
+
+async function write(terminal: XtermTerminal, data: string): Promise<void> {
+  await new Promise<void>((resolve) => terminal.write(data, resolve))
+}
+
+/** Rewrite a row in place, the way a TUI repaint does. */
+async function repaintRow(
+  terminal: XtermTerminal,
+  oneBasedRow: number,
+  content: string
+): Promise<void> {
+  await write(terminal, `${ESC}[${oneBasedRow};1H${ESC}[2K${content}`)
+}
+
+function rowOf(terminal: XtermTerminal, needle: string): number {
+  const buffer = terminal.buffer.active
+  for (let y = 0; y < buffer.length; y++) {
+    if ((buffer.getLine(y)?.translateToString(true) ?? '').includes(needle)) {
+      return y
+    }
+  }
+  return -1
+}
+
+function registeredOscLinkCount(terminal: XtermTerminal): number {
+  // Why: guards the "handler returns false" contract — xterm's own OSC 8
+  // registration must still happen, and there is no public API to read it.
+  const core = (
+    terminal as unknown as {
+      _core: { _oscLinkService: { _dataByLinkId: Map<number, unknown> } }
+    }
+  )._core
+  return core._oscLinkService._dataByLinkId.size
+}
+
+function provideLinksFor(
+  memory: TerminalOsc8LinkMemory,
+  bufferLineNumber: number,
+  activate = vi.fn()
+): ILink[] {
+  const provider = createRememberedOsc8LinkProvider({
+    getMemory: () => memory,
+    linkTooltip: { textContent: '', style: { display: 'none' } } as unknown as HTMLElement,
+    openLinkHint: '⌘+click to open',
+    activate
+  })
+  let result: ILink[] | undefined
+  provider.provideLinks(bufferLineNumber, (links) => {
+    result = links
+  })
+  return result ?? []
+}
+
+describe('installTerminalOsc8LinkMemory', () => {
+  it('records the uri and the exact columns the anchor text occupied', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+
+    await write(terminal, `LINK: ${osc8('https://ex.net/target', 'TARGET')} tail`)
+
+    expect(memory.size()).toBe(1)
+    expect(memory.linksForRow(0)).toEqual([{ uri: 'https://ex.net/target', startX: 6, endX: 12 }])
+  })
+
+  it('does not shadow xterm’s own OSC 8 handler', async () => {
+    const terminal = createTerminal()
+    installTerminalOsc8LinkMemory(terminal)
+
+    await write(terminal, osc8('https://ex.net/passthrough', 'PASS'))
+
+    expect(registeredOscLinkCount(terminal)).toBe(1)
+  })
+
+  it('still serves the target after a repaint drops the hyperlink', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+    await write(terminal, `LINK: ${osc8('https://ex.net/target', 'TARGET')} tail`)
+
+    await repaintRow(terminal, 1, 'LINK: TARGET tail')
+
+    expect(memory.linksForRow(0)[0]?.uri).toBe('https://ex.net/target')
+  })
+
+  it('serves a repainted chip that moved to another row', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+    const uri = 'file:///tmp/image-cache/1.png'
+    await write(terminal, `\r\n\r\n  ⎿  ${osc8(uri, '[Image #1]', 'a0yme3')}`)
+    const original = rowOf(terminal, '[Image #1]')
+
+    // Why: Ink shifts its live region, so the chip reappears on a different row
+    // with no hyperlink — the row-keyed entry can never match it again.
+    await repaintRow(terminal, original + 1, '')
+    await repaintRow(terminal, original + 3, '  ⎿  [Image #1]')
+    const moved = rowOf(terminal, '[Image #1]')
+
+    expect(moved).not.toBe(original)
+    expect(memory.linksForRow(moved)).toEqual([{ uri, startX: 5, endX: 15 }])
+  })
+
+  it('prefers the exact row match over the anchor-text match', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+    await write(terminal, `A ${osc8('https://ex.net/first', 'SAME')}\r\n`)
+    await write(terminal, `B ${osc8('https://ex.net/second', 'SAME')}`)
+
+    // Row 0 keeps its own target even though 'SAME' now maps to the newer uri.
+    expect(memory.linksForRow(0)).toEqual([{ uri: 'https://ex.net/first', startX: 2, endX: 6 }])
+  })
+
+  it('stops serving a row whose text no longer matches anything remembered', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+    await write(terminal, `LINK: ${osc8('https://ex.net/target', 'TARGET')} tail`)
+
+    await repaintRow(terminal, 1, 'LINK: OTHERX tail')
+
+    expect(memory.linksForRow(0)).toEqual([])
+  })
+
+  it('ignores anchor text too short to identify a target by content', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+    await write(terminal, `go ${osc8('https://ex.net/short', 'x')}\r\n`)
+
+    await write(terminal, 'x on another row')
+
+    expect(memory.linksForRow(1)).toEqual([])
+  })
+
+  it('ignores a hyperlink whose text wrapped onto another row', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+
+    await write(terminal, `${'x'.repeat(78)}${osc8('https://ex.net/wrapped', 'WRAPPED')}`)
+
+    expect(memory.size()).toBe(0)
+  })
+
+  it('drops every marker, target and the parser handler on dispose', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+    await write(terminal, osc8('https://ex.net/first', 'FIRST'))
+    expect(memory.size()).toBe(1)
+
+    memory.dispose()
+    expect(memory.size()).toBe(0)
+    expect(memory.linksForRow(0)).toEqual([])
+
+    await write(terminal, `\r\n${osc8('https://ex.net/second', 'SECOND')}`)
+    expect(memory.size()).toBe(0)
+  })
+})
+
+describe('createRememberedOsc8LinkProvider', () => {
+  it('exposes a 1-based inclusive range over the remembered columns', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+    await write(terminal, `LINK: ${osc8('https://ex.net/target', 'TARGET')} tail`)
+    await repaintRow(terminal, 1, 'LINK: TARGET tail')
+
+    const [link] = provideLinksFor(memory, 1)
+    expect(link.text).toBe('https://ex.net/target')
+    expect(link.range).toEqual({ start: { x: 7, y: 1 }, end: { x: 12, y: 1 } })
+  })
+
+  it('activates with the remembered uri and the originating event', async () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+    await write(terminal, osc8('file:///tmp/image-cache/1.png', '[Image #1]'))
+    await repaintRow(terminal, 1, '[Image #1]')
+
+    const activate = vi.fn()
+    const links = provideLinksFor(memory, 1, activate)
+    const event = { metaKey: true } as unknown as MouseEvent
+    links[0].activate(event, links[0].text)
+
+    expect(activate).toHaveBeenCalledWith('file:///tmp/image-cache/1.png', event)
+  })
+
+  it('reports no links when nothing is remembered for the row', () => {
+    const terminal = createTerminal()
+    const memory = installTerminalOsc8LinkMemory(terminal)
+
+    expect(provideLinksFor(memory, 1)).toEqual([])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-osc8-link-memory.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc8-link-memory.ts
@@ -1,0 +1,223 @@
+import type { IDisposable, ILink, ILinkProvider, IMarker, Terminal } from '@xterm/xterm'
+
+/**
+ * Remembers OSC 8 hyperlink targets so they survive a TUI repaint.
+ *
+ * xterm binds each OSC 8 entry to a line marker and drops it when the line is
+ * erased. Revealing a hidden pane replays the output queued while it was
+ * hidden, and those frames erase the rows they repaint — so a hyperlink the TUI
+ * does not re-emit loses its `urlId`, and with it the underline, hover and
+ * Cmd+click. Measured: the entry survives the whole time the pane is hidden,
+ * dies ~15ms after it becomes visible, and is never re-registered.
+ *
+ * Plain-text URLs are unaffected because Orca re-derives those from the buffer
+ * text (terminal-url-link-hit-testing). An OSC 8 target exists only in the
+ * escape sequence, so the only way to recover it is to have kept it.
+ *
+ * Two lookups, because a TUI moves its own output: the row lookup is exact and
+ * handles links that stay put, while the text lookup finds a repainted chip
+ * (Claude Code's `[Image #1]`) after its live region shifted to another row.
+ * The text lookup can offer a link on a row that only happens to contain the
+ * same anchor text — accepted deliberately, since without it a moving chip is
+ * permanently dead.
+ */
+
+const MAX_REMEMBERED_LINKS = 128
+const MAX_REMEMBERED_TEXT_TARGETS = 128
+/** Below this, anchor text is too generic to re-offer by content alone. */
+const MIN_TEXT_TARGET_LENGTH = 3
+
+export type Osc8LinkSpan = {
+  uri: string
+  /** Zero-based, half-open [startX, endX) columns the anchor text occupies. */
+  startX: number
+  endX: number
+}
+
+export type TerminalOsc8LinkMemory = IDisposable & {
+  linksForRow(absoluteRow: number): Osc8LinkSpan[]
+  size(): number
+}
+
+type RememberedOsc8Link = Osc8LinkSpan & {
+  /** Anchor text when recorded; a repainted row must not serve a stale target. */
+  text: string
+  marker: IMarker
+}
+
+type PendingOsc8Open = {
+  uri: string
+  startX: number
+  absoluteRow: number
+}
+
+function readRowText(
+  terminal: Terminal,
+  absoluteRow: number,
+  startX: number,
+  endX: number
+): string | null {
+  const line = terminal.buffer.active.getLine(absoluteRow)
+  return line ? line.translateToString(false, startX, endX) : null
+}
+
+export function installTerminalOsc8LinkMemory(terminal: Terminal): TerminalOsc8LinkMemory {
+  const remembered: RememberedOsc8Link[] = []
+  const textTargets = new Map<string, string>()
+  let pending: PendingOsc8Open | null = null
+
+  const absoluteCursorRow = (): number =>
+    terminal.buffer.active.baseY + terminal.buffer.active.cursorY
+
+  const commit = (): void => {
+    const open = pending
+    pending = null
+    if (!open) {
+      return
+    }
+    const endX = terminal.buffer.active.cursorX
+    // Why: a link that soft-wrapped spans rows a single range can't describe.
+    if (absoluteCursorRow() !== open.absoluteRow || endX <= open.startX) {
+      return
+    }
+    const text = readRowText(terminal, open.absoluteRow, open.startX, endX)
+    if (text === null) {
+      return
+    }
+    const marker = terminal.registerMarker(0)
+    if (marker) {
+      remembered.push({ uri: open.uri, startX: open.startX, endX, text, marker })
+      while (remembered.length > MAX_REMEMBERED_LINKS) {
+        remembered.shift()?.marker.dispose()
+      }
+    }
+    if (text.trim().length >= MIN_TEXT_TARGET_LENGTH) {
+      // Why: re-inserting moves the key to the end, so the cap evicts by age
+      // and a re-used anchor keeps its newest target.
+      textTargets.delete(text)
+      textTargets.set(text, open.uri)
+      while (textTargets.size > MAX_REMEMBERED_TEXT_TARGETS) {
+        const oldest = textTargets.keys().next().value
+        if (oldest === undefined) {
+          break
+        }
+        textTargets.delete(oldest)
+      }
+    }
+  }
+
+  // Why: returning false lets xterm's built-in OSC 8 handler still run, so this
+  // observes hyperlinks without taking over rendering or registration.
+  const handlerDisposable = terminal.parser.registerOscHandler(8, (payload: string): boolean => {
+    const separator = payload.indexOf(';')
+    const uri = separator === -1 ? '' : payload.slice(separator + 1)
+    if (uri) {
+      pending = { uri, startX: terminal.buffer.active.cursorX, absoluteRow: absoluteCursorRow() }
+      return false
+    }
+    commit()
+    return false
+  })
+
+  const rowLinks = (absoluteRow: number): Osc8LinkSpan[] => {
+    const matches: Osc8LinkSpan[] = []
+    for (let index = remembered.length - 1; index >= 0; index--) {
+      const entry = remembered[index]
+      if (entry.marker.isDisposed) {
+        remembered.splice(index, 1)
+        continue
+      }
+      if (entry.marker.line !== absoluteRow) {
+        continue
+      }
+      if (readRowText(terminal, absoluteRow, entry.startX, entry.endX) !== entry.text) {
+        continue
+      }
+      matches.push({ uri: entry.uri, startX: entry.startX, endX: entry.endX })
+    }
+    return matches
+  }
+
+  const textLinks = (absoluteRow: number): Osc8LinkSpan[] => {
+    const line = terminal.buffer.active.getLine(absoluteRow)
+    if (!line) {
+      return []
+    }
+    const rowText = line.translateToString(false)
+    const matches: Osc8LinkSpan[] = []
+    for (const [text, uri] of textTargets) {
+      let from = 0
+      while (from <= rowText.length - text.length) {
+        const at = rowText.indexOf(text, from)
+        if (at === -1) {
+          break
+        }
+        from = at + text.length
+        // Why: string offsets only equal columns when no wide or combining cell
+        // shifted the row; re-reading the span proves the mapping before use.
+        if (readRowText(terminal, absoluteRow, at, at + text.length) === text) {
+          matches.push({ uri, startX: at, endX: at + text.length })
+        }
+      }
+    }
+    return matches
+  }
+
+  return {
+    linksForRow: (absoluteRow: number): Osc8LinkSpan[] => {
+      const exact = rowLinks(absoluteRow)
+      return exact.length > 0 ? exact : textLinks(absoluteRow)
+    },
+    size: () => remembered.length,
+    dispose: () => {
+      handlerDisposable.dispose()
+      for (const entry of remembered) {
+        entry.marker.dispose()
+      }
+      remembered.length = 0
+      textTargets.clear()
+      pending = null
+    }
+  }
+}
+
+type RememberedOsc8LinkProviderDeps = {
+  getMemory: () => TerminalOsc8LinkMemory | null
+  linkTooltip: HTMLElement
+  openLinkHint: string
+  activate: (uri: string, event: MouseEvent | undefined) => void
+}
+
+export function createRememberedOsc8LinkProvider(
+  deps: RememberedOsc8LinkProviderDeps
+): ILinkProvider {
+  return {
+    provideLinks: (bufferLineNumber, callback) => {
+      const memory = deps.getMemory()
+      if (!memory) {
+        callback(undefined)
+        return
+      }
+      // Why: xterm hands providers 1-based buffer rows; markers track 0-based.
+      const absoluteRow = bufferLineNumber - 1
+      const links = memory.linksForRow(absoluteRow).map(
+        (span): ILink => ({
+          range: {
+            start: { x: span.startX + 1, y: bufferLineNumber },
+            end: { x: span.endX, y: bufferLineNumber }
+          },
+          text: span.uri,
+          activate: (event) => deps.activate(span.uri, event as MouseEvent | undefined),
+          hover: () => {
+            deps.linkTooltip.textContent = `${span.uri} (${deps.openLinkHint})`
+            deps.linkTooltip.style.display = ''
+          },
+          leave: () => {
+            deps.linkTooltip.style.display = 'none'
+          }
+        })
+      )
+      callback(links.length > 0 ? links : undefined)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -32,6 +32,11 @@ import {
   installFilePathLinkClickFallback
 } from './terminal-link-handlers'
 import { createTerminalHandleLinkProvider } from './terminal-handle-links'
+import {
+  createRememberedOsc8LinkProvider,
+  installTerminalOsc8LinkMemory,
+  type TerminalOsc8LinkMemory
+} from './terminal-osc8-link-memory'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { handleTerminalWebLinkClick } from './terminal-web-link-click'
@@ -568,6 +573,8 @@ export function useTerminalPaneLifecycle({
   const terminalHandleLinkDisposablesRef = useRef(new Map<number, IDisposable>())
   const fileLinkClickFallbackDisposablesRef = useRef(new Map<number, IDisposable>())
   const httpLinkClickFallbackDisposablesRef = useRef(new Map<number, IDisposable>())
+  const osc8LinkMemoriesRef = useRef(new Map<number, TerminalOsc8LinkMemory>())
+  const osc8LinkProviderDisposablesRef = useRef(new Map<number, IDisposable>())
   // Why: read settingsRef at fire time so toggling "copy on select" applies without recreating panes.
   const selectionDisposablesRef = useRef(new Map<number, IDisposable>())
   const selectionCaptureTimersRef = useRef(new Map<number, number>())
@@ -1017,6 +1024,31 @@ export function useTerminalPaneLifecycle({
           requestOpenLinksInAppPreference
         })
         httpLinkClickFallbackDisposables.set(pane.id, httpLinkClickFallbackDisposable)
+        // Why: revealing a hidden pane replays the output queued while it was
+        // hidden, and those frames erase the rows they repaint — dropping xterm's
+        // OSC 8 entry for links a TUI never re-emits. Registered last so xterm's
+        // own provider still wins whenever the live hyperlink survives.
+        const osc8LinkMemory = installTerminalOsc8LinkMemory(pane.terminal)
+        osc8LinkMemoriesRef.current.set(pane.id, osc8LinkMemory)
+        const osc8LinkProviderDisposable = pane.terminal.registerLinkProvider(
+          createRememberedOsc8LinkProvider({
+            getMemory: () => osc8LinkMemoriesRef.current.get(pane.id) ?? null,
+            linkTooltip: pane.linkTooltip,
+            openLinkHint: urlOpenLinkHint,
+            activate: (uri, event) => {
+              const handled = handleOscLink(uri, event, {
+                ...linkDeps,
+                startupCwd: getPaneLinkCwd(pane.id),
+                runtimeEnvironmentId: linkDeps.getRuntimeEnvironmentIdForPane?.(pane.id) ?? null,
+                requestOpenLinksInAppPreference
+              })
+              if (handled) {
+                pane.terminal.clearSelection()
+              }
+            }
+          })
+        )
+        osc8LinkProviderDisposablesRef.current.set(pane.id, osc8LinkProviderDisposable)
         seedStartupSessionRestoredBanner(ptyDeps.startup, pane.id, onShowSessionRestoredBanner)
         // Why: skip empty selections so click-to-deselect doesn't clobber whatever the user last copied.
         const selectionDisposable = pane.terminal.onSelectionChange(() => {
@@ -1159,6 +1191,16 @@ export function useTerminalPaneLifecycle({
         if (httpLinkClickFallbackDisposable) {
           httpLinkClickFallbackDisposable.dispose()
           httpLinkClickFallbackDisposables.delete(paneId)
+        }
+        const osc8LinkProviderDisposable = osc8LinkProviderDisposablesRef.current.get(paneId)
+        if (osc8LinkProviderDisposable) {
+          osc8LinkProviderDisposable.dispose()
+          osc8LinkProviderDisposablesRef.current.delete(paneId)
+        }
+        const osc8LinkMemory = osc8LinkMemoriesRef.current.get(paneId)
+        if (osc8LinkMemory) {
+          osc8LinkMemory.dispose()
+          osc8LinkMemoriesRef.current.delete(paneId)
         }
         const selectionDisposable = selectionDisposablesRef.current.get(paneId)
         if (selectionDisposable) {
@@ -1614,6 +1656,14 @@ export function useTerminalPaneLifecycle({
         disposable.dispose()
       }
       httpLinkClickFallbackDisposables.clear()
+      for (const disposable of osc8LinkProviderDisposablesRef.current.values()) {
+        disposable.dispose()
+      }
+      osc8LinkProviderDisposablesRef.current.clear()
+      for (const memory of osc8LinkMemoriesRef.current.values()) {
+        memory.dispose()
+      }
+      osc8LinkMemoriesRef.current.clear()
       for (const disposable of selectionDisposables.values()) {
         disposable.dispose()
       }


### PR DESCRIPTION
## Summary

Cmd+clicking the `[Image #1]` chip in a Claude Code pane opens it in Orca's browser. Switch back to the terminal and the chip is no longer underlined or clickable, and it never recovers. Plain-text URLs on the same row keep working. This makes the link survive.

xterm binds each OSC 8 entry to a line marker and drops it when the line is erased. Revealing a hidden pane replays the output queued while it was hidden, and those frames erase the rows they repaint. Traced on one timeline (`registerLink` calls, pane visibility, and writes):

```
249070  REGISTER urlId=10  file:///…/image-cache/…/3.png  (BEL-terminated)  reg=1
251303  OVERLAY display=none   ← switch to the viewer                        reg=1
253094  OVERLAY display=flex   ← switch back                                 reg=1
253109  reg=0                  ← destroyed, 15 ms after reveal
        …no REGISTER event ever again
```

The persistent underline goes with it, because that is xterm's rendering of the cell's `urlId` rather than styling the app emitted — writing an OSC 8 link with no SGR at all still yields `urlId=5, ulStyle=5` on exactly the anchor cells.

Plain URLs survive because Orca re-derives them from buffer text (`terminal-url-link-hit-testing`). An OSC 8 target exists only in the escape sequence, so recovering it means having kept it.

Fix: observe every OSC 8 write — the handler returns `false`, so xterm's own handler still registers the link — and re-offer the remembered target through a link provider registered **last**, so a live hyperlink always wins.

Two lookups, because a TUI moves its own output:

- **Row lookup** (exact, marker-backed) covers links that stay put.
- **Anchor-text lookup** covers a chip whose live region shifted rows. Ink repaints its input box at a different row without re-emitting the sequence, which is what leaves `[Image #1]` permanently dead. Demonstrated by replaying the captured chip bytes and repainting the same text two rows down: `at original row: provider 0 ✅ provider 4 ✅` → `after row move: []`.

## Screenshots

<!-- RECORDING GOES HERE -->

Before: after returning from the image viewer tab, the `[Image #1]` chip has no underline and Cmd+click does nothing.

https://github.com/user-attachments/assets/84efd92e-87d1-49a4-be6a-f027d8ea9305

After: Cmd+hover underlines it and shows the target; Cmd+click opens the image.

https://github.com/user-attachments/assets/a4021143-5744-4a64-967a-27ba41cb2284

Note: the always-on dashed underline does **not** come back — see Notes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Notes on the runs:

- `pnpm lint` reports pre-existing unlocalized strings in `src/renderer/src/components/settings/terminal-advanced-platform-search.ts` and `terminal-pane-appearance-search.ts` ("Ghostty"). Identical on a clean tree with this branch stashed; untouched by this PR.
- `pnpm test`: 36876 passed. 45 failures across 8 files, all pre-existing and unrelated — verified by running exactly those 8 files on clean `main` (`4ada3f8b2`), where they fail identically. They live in `src/relay/`, `right-sidebar/`, `sidebar/` and `browser-pane/markup/`; none in the files this PR touches. `terminal-pane` 2440/2440 passes.
- 12 new tests drive a real `@xterm/headless` terminal with real escape sequences, including the exact byte shape Claude Code emits (`id=` param, BEL terminators).
- Mutation-checked, each failing only its own test: dropping the anchor-text fallback fails the moved-chip test; removing the text guard fails the stale-row test; returning `true` from the OSC handler fails the non-shadowing test.
- Verified end-to-end in a running app: replayed the captured chip bytes into a live pane, destroyed xterm's entry the way a repaint does, and confirmed the tooltip shows and Cmd+click opens the target. Then confirmed on the original reported flow.

## AI Review Report

Reviewed with Claude Code. Risks checked:

- **Cross-platform.** No platform branching. No `metaKey`/`ctrlKey` reads, no shortcut labels, no path separators — activation is delegated to the existing `handleOscLink`, which already owns the platform-correct modifier check and the `⌘`/`Ctrl+` hint text. `file://` URIs are handed to the existing `openDetectedFilePath` rather than parsed here, so Windows drive letters and UNC paths keep their current handling.
- **SSH / remote / local.** Renderer-only, per pane, reading the local xterm buffer. It records whatever the PTY emits regardless of where that PTY lives, and routes activation through the same path as before, which is where remote-vs-local routing already lives. No new assumption that a file or process is local.
- **Agents / integrations / git providers.** Agent-neutral: it observes OSC 8, a terminal protocol, not anything Claude Code specific. Any TUI emitting hyperlinks benefits. No provider-specific logic.
- **Performance.** This was the main thing flagged. The OSC handler does one `indexOf` per sequence. The row lookup is a bounded reverse scan (≤128 entries) that early-exits on marker line mismatch. The anchor-text lookup is the costliest path, so it only runs when the row lookup misses, and it is bounded to 128 remembered texts. Both are invoked by xterm's linkifier on hover, not per write or per render frame. Nothing added to the write path beyond the handler itself.
- **Memory.** Both stores are explicitly capped (128 links, 128 text targets) with oldest-first eviction; markers are disposed on eviction and on `dispose()`. Disposal is wired into both existing teardown paths — `onPaneClosed` and unmount — alongside the other per-pane disposables.
- **Correctness / false positives.** Flagged and accepted deliberately: the anchor-text lookup can offer a link on a row that merely contains the same anchor text. Gated behind a 3-character minimum and only ever consulted after the exact row lookup misses. Without it a moving chip never recovers. Called out again under Notes so a maintainer can push back.
- **UI quality.** No markup, tokens, styles or layout touched. The recovered link renders through xterm's existing link affordance, identical to any other terminal link.

## Security Audit

Reviewed for input handling, execution, path handling, and IPC.

- **Input handling.** The URI comes from an OSC 8 escape sequence, i.e. untrusted process output. It is stored verbatim and never parsed, executed, or interpolated here.
- **No new sink.** Activation calls the existing `handleOscLink`, so every URI goes through the same validation, scheme handling, and routing that OSC 8 links already use today — including `openTerminalHttpLink` for http(s) and `openDetectedFilePath` for `file://`. This PR does not widen what a terminal can ask Orca to open; it only lets an already-registered target stay reachable after a repaint.
- **Scheme escalation.** None. A remembered URI is exactly the one xterm registered moments earlier from the same byte stream.
- **Staleness / spoofing.** The text guard is the relevant control: a row whose text changed no longer serves its old target, so a repaint cannot silently retarget a link. The residual risk is the accepted false positive above — a row containing the same anchor text could offer a link the TUI did not intend. It cannot point anywhere the TUI did not itself emit in that session.
- **No command execution, no filesystem writes, no auth, no secrets, no IPC surface, no dependency changes.**

## Notes

- **Not covered:** the always-on dashed underline does not come back. That is the cell's `urlId` attribute, which a link provider cannot set. The chip underlines on Cmd+hover and is clickable. Restoring the persistent underline would want a `registerDecoration` overlay — happy to add it here or as a follow-up if you'd prefer it in one change.
- The anchor-text fallback is a deliberate trade (see AI Review Report). If you'd rather it were stricter — longer minimum, or row-lookup only — that is a small change and I'm glad to make it.
- No platform-specific behaviour. Verified on macOS against Claude Code v2.1.220; the mechanism is generic to any TUI that repaints its live region.
- Mobile has its own terminal path under `mobile/src/terminal` and is intentionally out of scope here.
- X: https://x.com/nduongg04

## ELI5

Clickable image chips like [Image #1] in Claude Code terminals stopped working after you switched away and back, because repaint wiped the link markers. This keeps those OSC 8 links clickable after the TUI redraws.
