### PR TITLE
fix(terminal): kill floating, setup, and folder-workspace PTYs on tab close

### DIFF
--- a/src/renderer/src/lib/terminal-worktree-route.test.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.test.ts
@@ -3,7 +3,10 @@ import type { AppState } from '@/store/types'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { brandEphemeralSetupTerminalWorktreeId } from '../../../shared/ephemeral-setup-terminal-worktree-id'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
-import { resolveTerminalWorktreeRoute } from './terminal-worktree-route'
+import {
+  resolveTerminalHostOwnership,
+  resolveTerminalWorktreeRoute
+} from './terminal-worktree-route'
 
 const EPHEMERAL_ID = brandEphemeralSetupTerminalWorktreeId(
   'settings-mobile-emulator-orca-cli-skill-terminal'
@@ -68,5 +71,109 @@ describe('resolveTerminalWorktreeRoute', () => {
 
   it('does not treat a folder workspace as an unresolved worktree', () => {
     expect(resolveTerminalWorktreeRoute(localState(), folderWorkspaceKey('abc-123'))).not.toBeNull()
+  })
+})
+
+// STA-2639: teardown must follow the PTY's real host while spawn stays free to prefer a focused
+// runtime. Both purposes are asserted per shape so they cannot silently drift into agreement.
+describe('resolveTerminalHostOwnership teardown', () => {
+  const focusedState = (overrides: Partial<AppState> = {}): AppState =>
+    localState({
+      settings: { activeRuntimeEnvironmentId: 'hub-a' },
+      runtimeEnvironments: [{ id: 'hub-a' }],
+      ...overrides
+    } as unknown as Partial<AppState>)
+
+  it('scopes an ephemeral setup terminal to the runtime for spawn but not for teardown', () => {
+    const state = focusedState()
+    expect(resolveTerminalHostOwnership(state, EPHEMERAL_ID, 'spawn')).toEqual({
+      kind: 'runtime',
+      runtimeEnvironmentId: 'hub-a'
+    })
+    expect(resolveTerminalHostOwnership(state, EPHEMERAL_ID, 'teardown')).toEqual({
+      kind: 'local-or-ssh',
+      runtimeEnvironmentId: null
+    })
+  })
+
+  it('keeps a plain local folder workspace local for teardown while a runtime is focused', () => {
+    const state = focusedState({
+      folderWorkspaces: [{ id: 'fw-1', projectGroupId: 'pg-1', connectionId: null }],
+      projectGroups: [{ id: 'pg-1', connectionId: null, executionHostId: null }]
+    } as unknown as Partial<AppState>)
+    expect(resolveTerminalHostOwnership(state, folderWorkspaceKey('fw-1'), 'teardown')).toEqual({
+      kind: 'local-or-ssh',
+      runtimeEnvironmentId: null
+    })
+  })
+
+  it('keeps a HUB-owned folder workspace on its runtime for teardown', () => {
+    const state = focusedState({
+      folderWorkspaces: [{ id: 'fw-1', projectGroupId: 'pg-1', connectionId: null }],
+      projectGroups: [{ id: 'pg-1', connectionId: null, executionHostId: 'runtime:hub-a' }]
+    } as unknown as Partial<AppState>)
+    expect(resolveTerminalHostOwnership(state, folderWorkspaceKey('fw-1'), 'teardown')).toEqual({
+      kind: 'runtime',
+      runtimeEnvironmentId: 'hub-a'
+    })
+  })
+
+  it('keeps a hostless worktree on the focused runtime for teardown too', () => {
+    // Why: unlike the host-agnostic surfaces, an ownerless worktree row really does spawn on the
+    // focused HUB, and its wake hint is `ssh:`-shaped — downgrading it would kill the wrong host.
+    const state = focusedState({
+      repos: [{ id: 'repo-1', connectionId: null, executionHostId: null }],
+      worktreesByRepo: { 'repo-1': [{ id: 'repo-1::/w', repoId: 'repo-1' }] }
+    } as unknown as Partial<AppState>)
+    for (const purpose of ['spawn', 'teardown'] as const) {
+      expect(resolveTerminalHostOwnership(state, 'repo-1::/w', purpose)).toEqual({
+        kind: 'runtime',
+        runtimeEnvironmentId: 'hub-a'
+      })
+    }
+  })
+
+  it('keeps an explicitly runtime-owned worktree on its runtime for teardown', () => {
+    const state = focusedState({
+      worktreesByRepo: {
+        'repo-1': [{ id: 'repo-1::/w', repoId: 'repo-1', runtimeOwnerEnvironmentId: 'hub-a' }]
+      }
+    } as unknown as Partial<AppState>)
+    expect(resolveTerminalHostOwnership(state, 'repo-1::/w', 'teardown')).toEqual({
+      kind: 'runtime',
+      runtimeEnvironmentId: 'hub-a'
+    })
+  })
+
+  it('keeps an SSH-owned worktree killable by the paired client', () => {
+    const state = localState({
+      repos: [{ id: 'repo-1', connectionId: 'conn-1', executionHostId: 'ssh:conn-1' }],
+      worktreesByRepo: { 'repo-1': [{ id: 'repo-1::/w', repoId: 'repo-1', hostId: 'ssh:conn-1' }] }
+    } as unknown as Partial<AppState>)
+    expect(resolveTerminalHostOwnership(state, 'repo-1::/w', 'teardown')).toEqual({
+      kind: 'local-or-ssh',
+      runtimeEnvironmentId: null
+    })
+  })
+
+  it('fails a worktree with unparseable host metadata closed', () => {
+    // Why: a host string we cannot classify is not evidence of a local process.
+    const state = localState({
+      repos: [{ id: 'repo-1', connectionId: null, executionHostId: 'nonsense:' }],
+      worktreesByRepo: { 'repo-1': [{ id: 'repo-1::/w', repoId: 'repo-1', hostId: 'nonsense:' }] }
+    } as unknown as Partial<AppState>)
+    for (const purpose of ['spawn', 'teardown'] as const) {
+      expect(resolveTerminalHostOwnership(state, 'repo-1::/w', purpose)).toEqual({
+        kind: 'unresolved',
+        runtimeEnvironmentId: null
+      })
+    }
+  })
+
+  it('fails a missing worktree id closed for teardown', () => {
+    expect(resolveTerminalHostOwnership(localState(), null, 'teardown')).toEqual({
+      kind: 'unresolved',
+      runtimeEnvironmentId: null
+    })
   })
 })

--- a/src/renderer/src/lib/terminal-worktree-route.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.ts
@@ -1,8 +1,13 @@
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { isEphemeralSetupTerminalWorktreeId } from '../../../shared/ephemeral-setup-terminal-worktree-id'
+import { parseExecutionHostId } from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import type { AppState } from '@/store/types'
-import { getRuntimeEnvironmentIdForWorktree } from './worktree-runtime-owner'
+import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  getRuntimeEnvironmentIdForWorktree,
+  type WorktreeRuntimeOwnerState
+} from './worktree-runtime-owner'
 import { resolveWorktreeOperationRouteResult } from './worktree-operation-route'
 import { getSingleFocusedRuntimeEnvironmentId } from './single-runtime-legacy-owner'
 
@@ -10,39 +15,129 @@ export type TerminalWorktreeRoute = {
   runtimeEnvironmentId: string | null
 }
 
-export function resolveTerminalWorktreeRoute(
-  state: AppState,
-  worktreeId: string | null | undefined
-): TerminalWorktreeRoute | null {
+/**
+ * Which host owns a terminal surface. Spawn and teardown both resolve it here so they can never
+ * disagree about whether an id is routable — #9994 fixed spawn only, and STA-2639 was the teardown
+ * half of that same asymmetry.
+ */
+export type TerminalHostOwnership =
+  | { kind: 'local-or-ssh'; runtimeEnvironmentId: null }
+  | { kind: 'runtime'; runtimeEnvironmentId: string }
+  | { kind: 'unresolved'; runtimeEnvironmentId: null }
+
+/**
+ * `spawn` asks which host should start a new process, so a merely focused runtime is a fine guess.
+ * `teardown` asks which provider can kill an existing one, where that same guess strands the local
+ * PTY the surface was actually spawned on.
+ */
+export type TerminalHostOwnershipPurpose = 'spawn' | 'teardown'
+
+const UNRESOLVED_TERMINAL_HOST: TerminalHostOwnership = {
+  kind: 'unresolved',
+  runtimeEnvironmentId: null
+}
+const LOCAL_OR_SSH_TERMINAL_HOST: TerminalHostOwnership = {
+  kind: 'local-or-ssh',
+  runtimeEnvironmentId: null
+}
+
+function ownershipForRuntimeEnvironmentId(
+  runtimeEnvironmentId: string | null
+): TerminalHostOwnership {
+  return runtimeEnvironmentId
+    ? { kind: 'runtime', runtimeEnvironmentId }
+    : LOCAL_OR_SSH_TERMINAL_HOST
+}
+
+export function resolveTerminalHostOwnership(
+  state: WorktreeRuntimeOwnerState,
+  worktreeId: string | null | undefined,
+  purpose: TerminalHostOwnershipPurpose
+): TerminalHostOwnership {
   if (!worktreeId) {
-    return { runtimeEnvironmentId: null }
+    // Why: a tab with no owning row proves nothing about its host, so teardown cannot claim its PTY.
+    return purpose === 'teardown' ? UNRESOLVED_TERMINAL_HOST : LOCAL_OR_SSH_TERMINAL_HOST
   }
   if (
     worktreeId === FLOATING_TERMINAL_WORKTREE_ID ||
     parseWorkspaceKey(worktreeId)?.type === 'folder'
   ) {
-    return { runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId) }
+    return resolveFloatingScopeOwnership(
+      state,
+      worktreeId,
+      purpose,
+      getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    )
   }
   // Why: inline setup/onboarding terminals (skill installs, feature tips) have no worktree row,
   // so the strict owner resolver reports them as an unresolved cross-host worktree. Scope them to
   // the active runtime — so a remote skill install lands on that runtime — falling back to local
   // when none is focused, instead of failing them closed.
   if (isEphemeralSetupTerminalWorktreeId(worktreeId)) {
-    return { runtimeEnvironmentId: getSingleFocusedRuntimeEnvironmentId(state) }
+    return resolveFloatingScopeOwnership(
+      state,
+      worktreeId,
+      purpose,
+      getSingleFocusedRuntimeEnvironmentId(state)
+    )
   }
   const resolution = resolveWorktreeOperationRouteResult(state, worktreeId)
   if (resolution.kind === 'resolved') {
-    return { runtimeEnvironmentId: resolution.route.runtimeEnvironmentId }
+    if (resolution.route.runtimeEnvironmentId) {
+      // Why: a real worktree row keeps its runtime owner on teardown. Unlike the host-agnostic
+      // surfaces above, its HUB-native wake hints are `ssh:`-shaped rather than `remote:`-prefixed,
+      // so downgrading to local here would kill a paired-client PTY that lives on the HUB (#9994).
+      return { kind: 'runtime', runtimeEnvironmentId: resolution.route.runtimeEnvironmentId }
+    }
+    const parsed = parseExecutionHostId(resolution.route.executionHostId)
+    return parsed?.kind === 'local' || parsed?.kind === 'ssh'
+      ? LOCAL_OR_SSH_TERMINAL_HOST
+      : UNRESOLVED_TERMINAL_HOST
   }
   if (
+    purpose === 'spawn' &&
     state.worktreesByRepo === undefined &&
     state.detectedWorktreesByRepo === undefined &&
     state.repos === undefined
   ) {
-    // Why: narrow unit/legacy adapters can omit all owner catalogs; production stores always provide them and still fail closed above.
-    return { runtimeEnvironmentId: getSingleFocusedRuntimeEnvironmentId(state) }
+    // Why: narrow unit/legacy adapters can omit all owner catalogs; production stores always provide
+    // them and still fail closed above. Teardown never takes this fail-open — it would kill on a guess.
+    return ownershipForRuntimeEnvironmentId(getSingleFocusedRuntimeEnvironmentId(state))
   }
-  return null
+  return UNRESOLVED_TERMINAL_HOST
+}
+
+/**
+ * Host ownership for the host-agnostic surfaces — floating, folder workspace, ephemeral setup.
+ * Safe to downgrade on teardown because these never hold an `ssh:`-shaped HUB wake hint: a
+ * runtime-hosted one carries a `remote:` id, which is routed before ownership is consulted.
+ */
+function resolveFloatingScopeOwnership(
+  state: WorktreeRuntimeOwnerState,
+  worktreeId: string,
+  purpose: TerminalHostOwnershipPurpose,
+  runtimeEnvironmentId: string | null
+): TerminalHostOwnership {
+  if (
+    purpose === 'spawn' ||
+    !runtimeEnvironmentId ||
+    getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  ) {
+    return ownershipForRuntimeEnvironmentId(runtimeEnvironmentId)
+  }
+  // Why: this surface publishes no runtime owner and only looks runtime-owned because exactly one
+  // runtime is focused — a guess that flips as catalogs hydrate, stranding the local PTY (STA-2639).
+  return LOCAL_OR_SSH_TERMINAL_HOST
+}
+
+export function resolveTerminalWorktreeRoute(
+  state: AppState,
+  worktreeId: string | null | undefined
+): TerminalWorktreeRoute | null {
+  const ownership = resolveTerminalHostOwnership(state, worktreeId, 'spawn')
+  return ownership.kind === 'unresolved'
+    ? null
+    : { runtimeEnvironmentId: ownership.runtimeEnvironmentId }
 }
 
 export function hasUnroutableTerminalWorktreeOwner(state: AppState, worktreeId: string): boolean {

--- a/src/renderer/src/store/slices/terminal-tab-retirement.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-retirement.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
 import type { TerminalTab } from '../../../../shared/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { brandEphemeralSetupTerminalWorktreeId } from '../../../../shared/ephemeral-setup-terminal-worktree-id'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
   buildTerminalTabRetirementPlan,
   buildTerminalTabRetirementPlans,
@@ -230,6 +233,115 @@ describe('terminal tab retirement planning', () => {
 
     expect(plan.localOrSshPtyIds).toEqual([])
     expect(plan.unroutablePtyIds).toEqual(['ssh:private@@pty-1'])
+  })
+
+  // STA-2639: these surfaces publish no runtime owner, so teardown read them as unresolved and
+  // dropped their ordinary local PTYs instead of killing them.
+  describe('host-agnostic terminal surfaces are killed, not dropped', () => {
+    const localSurfaces: [string, string][] = [
+      ['floating terminal', FLOATING_TERMINAL_WORKTREE_ID],
+      ['ephemeral setup terminal', brandEphemeralSetupTerminalWorktreeId('panel-1')],
+      ['folder workspace', folderWorkspaceKey('fw-1')]
+    ]
+
+    for (const [label, worktreeId] of localSurfaces) {
+      it(`kills a local ${label} PTY while a runtime is focused`, () => {
+        // Why: a focused runtime must not make a local surface read as runtime-owned — that focus
+        // also flips as the runtime catalog hydrates, so teardown cannot trust it.
+        const state = makeState({
+          settings: { activeRuntimeEnvironmentId: 'hub-a' },
+          runtimeEnvironments: [{ id: 'hub-a' }],
+          folderWorkspaces: [{ id: 'fw-1', projectGroupId: 'pg-1', connectionId: null }],
+          projectGroups: [{ id: 'pg-1', connectionId: null, executionHostId: null }],
+          tabsByWorktree: { [worktreeId]: [makeTab('tab-1', worktreeId, 'pty-1')] }
+        } as unknown as Partial<RetirementState>)
+
+        const plan = buildTerminalTabRetirementPlan(state, 'tab-1')
+
+        expect(plan.localOrSshPtyIds).toEqual(['pty-1'])
+        expect(plan.unroutablePtyIds).toEqual([])
+      })
+    }
+
+    it('closes a runtime-hosted floating terminal over RPC instead of killing it locally', () => {
+      const state = makeState({
+        settings: { activeRuntimeEnvironmentId: 'hub-a' },
+        runtimeEnvironments: [{ id: 'hub-a' }],
+        tabsByWorktree: {
+          [FLOATING_TERMINAL_WORKTREE_ID]: [
+            makeTab('tab-1', FLOATING_TERMINAL_WORKTREE_ID, 'remote:hub-a@@handle-1')
+          ]
+        }
+      } as unknown as Partial<RetirementState>)
+
+      const plan = buildTerminalTabRetirementPlan(state, 'tab-1')
+
+      expect(plan.localOrSshPtyIds).toEqual([])
+      expect(plan.runtimeTerminals).toEqual([
+        { ptyId: 'remote:hub-a@@handle-1', environmentId: 'hub-a', handle: 'handle-1' }
+      ])
+    })
+
+    it('never kills a HUB-owned folder workspace PTY', () => {
+      const state = makeState({
+        folderWorkspaces: [{ id: 'fw-1', projectGroupId: 'pg-1', connectionId: null }],
+        projectGroups: [{ id: 'pg-1', connectionId: null, executionHostId: 'runtime:hub-a' }],
+        tabsByWorktree: {
+          [folderWorkspaceKey('fw-1')]: [makeTab('tab-1', folderWorkspaceKey('fw-1'), 'pty-hub')]
+        }
+      } as unknown as Partial<RetirementState>)
+
+      const plan = buildTerminalTabRetirementPlan(state, 'tab-1')
+
+      expect(plan.localOrSshPtyIds).toEqual([])
+      expect(plan.unroutablePtyIds).toEqual(['pty-hub'])
+    })
+
+    it('never kills a HUB wake hint on a worktree owned only by the focused runtime', () => {
+      // Why: an ownerless mixed-version row legitimately spawns on the focused HUB (see
+      // pty-connection "uses the focused runtime only for ownerless mixed-version publications"),
+      // and its wake hint is `ssh:`-shaped, not `remote:` — killing it would hit the wrong host.
+      const state = makeState({
+        repos: [{ id: 'repo1', connectionId: null }],
+        worktreesByRepo: { repo1: [{ id: 'wt-legacy', repoId: 'repo1' }] },
+        settings: { activeRuntimeEnvironmentId: 'legacy-hub' },
+        runtimeEnvironments: [{ id: 'legacy-hub' }],
+        tabsByWorktree: {
+          'wt-legacy': [makeTab('tab-1', 'wt-legacy', 'ssh:hub-private@@pty-2')]
+        }
+      } as unknown as Partial<RetirementState>)
+
+      const plan = buildTerminalTabRetirementPlan(state, 'tab-1')
+
+      expect(plan.localOrSshPtyIds).toEqual([])
+      expect(plan.unroutablePtyIds).toEqual(['ssh:hub-private@@pty-2'])
+    })
+
+    it('never kills a PTY whose owning tab row is already gone', () => {
+      // Why: a vanished row is the ambiguity #9994 guards — nothing proves which host holds the PTY.
+      const state = makeState({ ptyIdsByTabId: { 'tab-1': ['pty-ghost'] } })
+
+      const plan = buildTerminalTabRetirementPlan(state, 'tab-1')
+
+      expect(plan.localOrSshPtyIds).toEqual([])
+      expect(plan.unroutablePtyIds).toEqual(['pty-ghost'])
+    })
+
+    it('never kills an unknown worktree PTY when every owner catalog is absent', () => {
+      // Why: spawn falls back to the focused runtime (local when none) while catalogs load, but
+      // teardown taking that fail-open would kill an unidentified PTY on a guess.
+      const state = makeState({
+        worktreesByRepo: undefined,
+        detectedWorktreesByRepo: undefined,
+        repos: undefined,
+        tabsByWorktree: { 'wt-unknown': [makeTab('tab-1', 'wt-unknown', 'pty-1')] }
+      } as unknown as Partial<RetirementState>)
+
+      const plan = buildTerminalTabRetirementPlan(state, 'tab-1')
+
+      expect(plan.localOrSshPtyIds).toEqual([])
+      expect(plan.unroutablePtyIds).toEqual(['pty-1'])
+    })
   })
 
   it('deduplicates batch-owned PTYs while protecting owners outside the close set', () => {

--- a/src/renderer/src/store/slices/terminal-tab-retirement.ts
+++ b/src/renderer/src/store/slices/terminal-tab-retirement.ts
@@ -1,13 +1,13 @@
 import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
 import type { AppState } from '../types'
 import {
-  getExecutionHostIdForWorktree,
   getRuntimeEnvironmentIdForWorktree,
   type WorktreeRuntimeOwnerState
 } from '@/lib/worktree-runtime-owner'
 import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
-import { resolveWorktreeOperationRouteResult } from '@/lib/worktree-operation-route'
-import { parseExecutionHostId } from '../../../../shared/execution-host'
+import { resolveTerminalHostOwnership } from '@/lib/terminal-worktree-route'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { isEphemeralSetupTerminalWorktreeId } from '../../../../shared/ephemeral-setup-terminal-worktree-id'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 
 export type TerminalTabCloseReason = 'user' | 'cleanup' | 'pty-exit'
@@ -111,32 +111,20 @@ function hasOwnerOutsideTargets(
   return false
 }
 
-function getProviderOwnership(
-  state: TerminalTabRetirementState,
+/** Worktree-id shape for diagnostics; raw ids embed absolute paths and must not be logged. */
+export function classifyTerminalRetirementWorktree(
   worktreeId: string | null
-): { kind: 'local-or-ssh' } | { kind: 'runtime'; environmentId: string } | { kind: 'unresolved' } {
+): 'floating' | 'ephemeral-setup' | 'folder-workspace' | 'worktree' | 'absent' {
   if (!worktreeId) {
-    return { kind: 'unresolved' }
+    return 'absent'
   }
-  if (parseWorkspaceKey(worktreeId)?.type === 'folder') {
-    const parsed = parseExecutionHostId(getExecutionHostIdForWorktree(state, worktreeId))
-    return parsed?.kind === 'runtime'
-      ? { kind: 'runtime', environmentId: parsed.environmentId }
-      : parsed?.kind === 'local' || parsed?.kind === 'ssh'
-        ? { kind: 'local-or-ssh' }
-        : { kind: 'unresolved' }
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return 'floating'
   }
-  const resolution = resolveWorktreeOperationRouteResult(state, worktreeId)
-  if (resolution.kind !== 'resolved') {
-    return { kind: 'unresolved' }
+  if (isEphemeralSetupTerminalWorktreeId(worktreeId)) {
+    return 'ephemeral-setup'
   }
-  if (resolution.route.runtimeEnvironmentId) {
-    return { kind: 'runtime', environmentId: resolution.route.runtimeEnvironmentId }
-  }
-  const parsed = parseExecutionHostId(resolution.route.executionHostId)
-  return parsed?.kind === 'local' || parsed?.kind === 'ssh'
-    ? { kind: 'local-or-ssh' }
-    : { kind: 'unresolved' }
+  return parseWorkspaceKey(worktreeId)?.type === 'folder' ? 'folder-workspace' : 'worktree'
 }
 
 export function isTerminalTabPresent(
@@ -188,7 +176,7 @@ export function buildTerminalTabRetirementPlans(
     const runtimeTerminals: TerminalTabRetirementPlan['runtimeTerminals'] = []
     const cleanupOnlyPtyIds: string[] = []
     const unroutablePtyIds: string[] = []
-    const providerOwnership = getProviderOwnership(state, worktreeId)
+    const providerOwnership = resolveTerminalHostOwnership(state, worktreeId, 'teardown')
 
     for (const ptyId of ptyIds) {
       const ownerIdentity = getTerminalPtyOwnershipIdentity(state, ptyId, worktreeId)

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -113,6 +113,7 @@ import {
 } from './agent-status'
 import {
   buildTerminalTabRetirementPlan,
+  classifyTerminalRetirementWorktree,
   isTerminalTabPresent,
   removeSleepingAgentSessionsForTab,
   type TerminalTabCloseReason,
@@ -1190,8 +1191,11 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         }
       }
       if (retirementPlan.unroutablePtyIds.length > 0) {
-        console.warn('[terminal-retirement] skipped unroutable runtime handles', {
+        // Why: log the worktree SHAPE, never the id — worktree ids embed absolute paths. The old
+        // "runtime handles" wording described ids that are usually plain local ones, hiding STA-2639.
+        console.warn('[terminal-retirement] skipped PTYs with no resolvable owner', {
           tabId,
+          worktreeKind: classifyTerminalRetirementWorktree(retirementPlan.worktreeId),
           count: retirementPlan.unroutablePtyIds.length
         })
       }


### PR DESCRIPTION
Fixes [STA-2639](https://linear.app/stably/issue/STA-2639/bug-closing-a-floating-or-ephemeral-setup-terminal-tab-leaks-its-pty). Related to #9744.

## The bug

Closing a terminal tab whose surface publishes no runtime owner left its PTY running. The shell survived the tab, kept its CPU/memory, and **survived app quit** (daemon-backed sessions are preserved by design). The only way to reclaim it was to notice it manually in Resource Manager → "Kill N orphan terminals".

`buildTerminalTabRetirementPlan` filed the PTY into `plan.unroutablePtyIds` — a bucket nothing kills. `closeTab` only `console.warn`'d, and the message said "skipped unroutable **runtime handles**" while the skipped ids were ordinary **local** ones, which is a large part of why this went unnoticed.

## ELI5

Two people were asked the same question — *"which computer is this terminal running on?"*

The person who **starts** terminals had been told about the odd ones: the floating terminal, the little setup terminals that pop up to install a skill, plain folders. The person who **shuts them down** was never told. So when you closed one of those tabs, the shutdown person shrugged, said "no idea whose that is", and walked away — leaving the program running forever.

Worse: if you had a remote machine *selected*, the shutdown person assumed anything unfamiliar must live over there, and left your local program running too.

Now there's one person answering that question for both jobs, with one rule change: when **starting** a terminal it's fine to assume "probably the remote machine I've got selected", but when **shutting one down** you must have it in writing. Guessing on shutdown means either leaving a program running forever, or — worse — killing something on the wrong machine.

## Root cause

`getProviderOwnership` (teardown) and `resolveTerminalWorktreeRoute` (spawn) were two independent re-derivations of the same question, both added in `41751dd90d` (#9994), and only the spawn side learned about the host-agnostic ids. This is the teardown half of `8a23618310` (#10151), which fixed spawn only.

A second instance of the same defect: `getSingleFocusedRuntimeEnvironmentId` ("exactly one runtime is focused") is a **spawn-time guess** that was being reused as **teardown-time evidence**, so a plain local surface read as runtime-owned merely because a runtime happened to be focused.

## The change

`resolveTerminalHostOwnership(state, worktreeId, purpose)` is now the single source of truth for both paths:

- **`spawn`** — "which host should start a new process?" A focused runtime is a fine guess, so remote skill installs still land on the runtime.
- **`teardown`** — "which provider can actually kill this process?" Requires an *explicitly published* runtime owner.

The teardown downgrade is scoped to the **host-agnostic surfaces only** (floating / folder workspace / ephemeral setup), whose runtime-hosted instances always carry a `remote:` id that is routed to `terminal.close` before ownership is consulted. Real worktree rows keep their runtime owner, because their HUB-native wake hints are `ssh:`-shaped and downgrading one would kill a PTY on the wrong host — exactly what #9994 guards.

## Proof of fix

Same states through `buildTerminalTabRetirementPlan`, before and after:

| state | before | after |
|---|---|---|
| floating terminal | `pty.kill([])` 🔴 | `pty.kill(["pty-1"])` ✅ |
| floating + focused runtime | `pty.kill([])` 🔴 | `pty.kill(["pty-1"])` ✅ |
| ephemeral setup terminal | `pty.kill([])` 🔴 | `pty.kill(["pty-1"])` ✅ |
| ephemeral + focused runtime | `pty.kill([])` 🔴 | `pty.kill(["pty-1"])` ✅ |
| local folder workspace + focused runtime | `pty.kill([])` 🔴 | `pty.kill(["pty-1"])` ✅ |

The folder-workspace row is **wider than the ticket**, which named only the two synthetic ids. It needs no synthetic id at all — any user with a runtime configured could leak a PTY from an ordinary folder workspace. Called out here rather than folded in silently.

## Proof of no regressions

Every fail-closed guard is unchanged, verified on the same states:

| state | before | after |
|---|---|---|
| HUB wake hint (ownerless row + focused runtime) | `unroutable` | `unroutable` ✅ |
| HUB-owned folder workspace | `unroutable` | `unroutable` ✅ |
| ambiguous duplicate worktree rows (#9994) | `unroutable` | `unroutable` ✅ |
| stale / unknown worktree (#9994) | `unroutable` | `unroutable` ✅ |
| ghost tab (row already removed) | `unroutable` | `unroutable` ✅ |
| runtime-hosted floating (`remote:` id) | `terminal.close(["h1"])` | `terminal.close(["h1"])` ✅ |

- **Full renderer suite: 1817 files, 16,364 tests, 0 failures.**
- Both `41751dd90d` pinned tests and the Close All revalidation test pass **unmodified**.
- **Spawn parity:** a 4320-case differential matrix (catalog shape × runtime set × focus × hydration × id) against the pre-change implementation found **0 diffs** for valid shapes. The one intentional change: a resolved route with unparseable host metadata now fails closed instead of resolving local.
- `tsc` (web + node), `oxlint`, `oxfmt`, max-lines ratchet: clean.

**Mutation testing (7/7 caught).** Every guard was deleted individually and a test failed each time. This mattered — two early tests passed *with the guard removed*: one fixture had a focused runtime that masked the mutation, and two guards had no coverage at all (flagged in review). Both were fixed, so no test here is tautological.

## Cross-platform / SSH / runtime

Pure routing logic; no platform-specific API or path handling added. The `pty.kill` path is unchanged, so macOS / Linux / Windows-ConPTY behave identically. SSH-owned worktrees stay killable by the paired client (now pinned by a test); HUB-owned and nested SSH-under-HUB surfaces stay fail-closed. Folder workspaces and git worktrees are both covered. Web clients are unaffected (`pty.kill` is a no-op stub there — the host owns teardown).

## Perf

Runs once per closed tab. Close All over **500 tabs plans in 1.9ms**, with all 500 PTYs correctly routed to kill.

## Diagnostics

The warn now reads `skipped PTYs with no resolvable owner` and reports a worktree **shape** (`floating` / `ephemeral-setup` / `folder-workspace` / `worktree` / `absent`) — never the raw id, since worktree ids embed absolute filesystem paths.

## Follow-ups (pre-existing, not caused by this change)

1. **Destructive close RPCs still use spawn-purpose resolution** — `terminal-tab-actions.ts` / `terminal-tab-bulk-actions.ts` decide host-authoritative close via `resolveTerminalWorktreeRoute`, so an ownerless-but-focused surface can emit a close RPC to a runtime that never published ownership. The PTY is still killed correctly; this is UI/routing drift.
2. **`Close All` ownership resolution is O(tabs × detected-catalog size)** — `getRuntimeEnvironmentIdForWorktree` and `getExplicitRuntimeEnvironmentIdForWorktree` each rescan detected catalogs per tab. Not hot at realistic sizes (1.9ms/500 tabs) but worth indexing.
3. **`unroutablePtyIds` is still warn-only** — better diagnosed now, but a PTY landing there is still a silent leak until the user opens Resource Manager.
4. **`DaemonPtyAdapter.reconcileOnStartup` has no non-test callers** — it is the mechanism that would reap stranded sessions on next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
