### PR TITLE
fix(mobile): deliver the notifications a reconnect missed, and never persist a watermark past them

### DIFF
--- a/mobile/src/notifications/local-notification-scheduling.ts
+++ b/mobile/src/notifications/local-notification-scheduling.ts
@@ -1,0 +1,191 @@
+import * as Notifications from 'expo-notifications'
+import { Platform } from 'react-native'
+import { loadPushNotificationsEnabled } from '../storage/preferences'
+import { buildLocalNotificationData, type DesktopNotificationSource } from './notification-routing'
+import { ensureNotificationPermissions } from './notification-permissions'
+
+export type NotificationEvent = {
+  type: 'notification'
+  source: DesktopNotificationSource
+  title: string
+  body: string
+  worktreeId?: string
+  notificationId?: string
+  // Desktop-assigned seq for reconnect catch-up (#8129); optional since older runtimes may omit it.
+  notificationSeq?: number
+  // Counter lifetime the seq belongs to (#8591); absent on older runtimes.
+  notificationEpoch?: string
+}
+
+export type DismissNotificationEvent = {
+  type: 'dismiss'
+  notificationId: string
+  notificationSeq?: number
+  notificationEpoch?: string
+}
+
+type ScheduledNotificationState = {
+  identifier?: string
+  pending?: Promise<string | null>
+  dismissAfterSchedule?: boolean
+}
+
+const scheduledNotificationsByHostAndNotificationId = new Map<string, ScheduledNotificationState>()
+
+// Why: keys never repeat and are only freed on desktop dismiss (which remote users often miss), so bound the map to stop unbounded growth.
+const MAX_SCHEDULED_NOTIFICATIONS = 256
+let maxScheduledNotifications = MAX_SCHEDULED_NOTIFICATIONS
+
+function getStoredNotificationKey(hostId: string, notificationId: string): string {
+  return `${encodeURIComponent(hostId)}:${encodeURIComponent(notificationId)}`
+}
+
+// Evict oldest settled entries (never mid-schedule); Map iteration is insertion order so the first match is oldest.
+function boundScheduledNotifications(): void {
+  while (scheduledNotificationsByHostAndNotificationId.size > maxScheduledNotifications) {
+    let evicted = false
+    for (const [key, state] of scheduledNotificationsByHostAndNotificationId) {
+      if (!state.pending) {
+        scheduledNotificationsByHostAndNotificationId.delete(key)
+        evicted = true
+        break
+      }
+    }
+    if (!evicted) {
+      break
+    }
+  }
+}
+
+/** Test-only: override the cap (pass no arg to restore the default). */
+export function setScheduledNotificationsMaxForTests(max?: number): void {
+  maxScheduledNotifications = max ?? MAX_SCHEDULED_NOTIFICATIONS
+}
+
+export function configureNotificationChannel(): void {
+  if (Platform.OS === 'android') {
+    void Notifications.setNotificationChannelAsync('orca-desktop', {
+      name: 'Desktop Notifications',
+      importance: Notifications.AndroidImportance.HIGH,
+      vibrationPattern: [0, 250],
+      lightColor: '#6366f1'
+    })
+  }
+}
+
+export async function showLocalNotification(
+  event: NotificationEvent,
+  hostId: string
+): Promise<void> {
+  const storedKey = event.notificationId
+    ? getStoredNotificationKey(hostId, event.notificationId)
+    : null
+
+  if (!storedKey) {
+    const enabled = await loadPushNotificationsEnabled()
+    if (!enabled) {
+      return
+    }
+
+    const granted = await ensureNotificationPermissions()
+    if (!granted) {
+      return
+    }
+
+    await Notifications.scheduleNotificationAsync({
+      content: {
+        title: event.title,
+        body: event.body,
+        data: buildLocalNotificationData(event, hostId),
+        ...(Platform.OS === 'android' ? { channelId: 'orca-desktop' } : {})
+      },
+      trigger: null
+    })
+    return
+  }
+
+  let state = scheduledNotificationsByHostAndNotificationId.get(storedKey)
+  if (state?.pending) {
+    return
+  }
+  if (!state) {
+    state = {}
+    scheduledNotificationsByHostAndNotificationId.set(storedKey, state)
+  }
+  const notificationState = state
+
+  const pending = (async () => {
+    const enabled = await loadPushNotificationsEnabled()
+    if (!enabled) {
+      return null
+    }
+
+    const granted = await ensureNotificationPermissions()
+    if (!granted) {
+      return null
+    }
+
+    if (notificationState.identifier) {
+      await Notifications.dismissNotificationAsync(notificationState.identifier).catch(() => {})
+      notificationState.identifier = undefined
+    }
+
+    return Notifications.scheduleNotificationAsync({
+      content: {
+        title: event.title,
+        body: event.body,
+        data: buildLocalNotificationData(event, hostId),
+        ...(Platform.OS === 'android' ? { channelId: 'orca-desktop' } : {})
+      },
+      trigger: null
+    })
+  })()
+  notificationState.pending = pending
+
+  try {
+    const scheduledIdentifier = await pending
+    if (!scheduledIdentifier) {
+      if (!notificationState.identifier) {
+        scheduledNotificationsByHostAndNotificationId.delete(storedKey)
+      }
+      return
+    }
+    if (notificationState.dismissAfterSchedule) {
+      notificationState.dismissAfterSchedule = false
+      scheduledNotificationsByHostAndNotificationId.delete(storedKey)
+      await Notifications.dismissNotificationAsync(scheduledIdentifier).catch(() => {})
+      return
+    }
+    notificationState.identifier = scheduledIdentifier
+    boundScheduledNotifications()
+  } finally {
+    if (notificationState.pending === pending) {
+      notificationState.pending = undefined
+      notificationState.dismissAfterSchedule = false
+    }
+  }
+}
+
+export async function dismissLocalNotification(
+  event: DismissNotificationEvent,
+  hostId: string
+): Promise<void> {
+  if (!event.notificationId) {
+    return
+  }
+  const storedKey = getStoredNotificationKey(hostId, event.notificationId)
+  const state = scheduledNotificationsByHostAndNotificationId.get(storedKey)
+  if (!state) {
+    return
+  }
+  if (state.pending) {
+    // Why: dismiss can arrive while the OS is still scheduling; defer it so no stale banner survives.
+    state.dismissAfterSchedule = true
+    return
+  }
+  if (!state.identifier) {
+    return
+  }
+  scheduledNotificationsByHostAndNotificationId.delete(storedKey)
+  await Notifications.dismissNotificationAsync(state.identifier).catch(() => {})
+}

--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -73,10 +73,14 @@ describe('subscribeToDesktopNotifications', () => {
     vi.clearAllMocks()
   })
 
-  async function flushAsync(): Promise<void> {
-    for (let i = 0; i < 10; i += 1) {
-      await Promise.resolve()
-    }
+  // Why the macrotask and not N microtask ticks (#8591): deliveries now run through
+  // the per-host serialization queue, so a delivery is several more `await` hops deep
+  // than it used to be and a fixed tick count silently under-drains. Yielding to the
+  // macrotask queue drains whatever depth the chain happens to have.
+  function flushAsync(): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, 0)
+    })
   }
 
   function makeDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {

--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -494,6 +494,122 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
     expect(scheduledIds.filter((id) => id === 'agent:dup')).toHaveLength(1)
   })
 
+  it('voids a persisted watermark whose epoch predates a desktop restart', async () => {
+    // #8591: the desktop's seq counter restarts at 0 each launch while this watermark
+    // is persisted. Reconnecting to a restarted desktop with seq 57 would make
+    // `57 >= 2` true and silently kill catch-up. The epoch on 'ready' is what tells
+    // the client the counter changed, so the stale watermark must be dropped.
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
+    vi.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) =>
+      key.startsWith('orca:mobileNotificationsLastSeq:')
+        ? '57'
+        : key.startsWith('orca:mobileNotificationsLastEpoch:')
+          ? 'epoch-before-restart'
+          : null
+    )
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    // Cold open under the OLD desktop process, so the watermark loads as 57.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-before-restart' })
+    await flushAsync()
+    await flushAsync()
+
+    // Desktop restarts: new epoch, counter back near 0.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-2', epoch: 'epoch-after-restart' })
+    await flushAsync()
+    await flushAsync()
+
+    const missedCall = vi
+      .mocked(sub.client.sendRequest)
+      .mock.calls.find((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    // Watermark reset to 0 and tagged with the live epoch — not the stale 57.
+    expect(missedCall?.[1]).toEqual({ lastSeenSeq: 0, epoch: 'epoch-after-restart' })
+  })
+
+  it('refuses to seed a stored watermark that lost the race to a newer live epoch', async () => {
+    // The seed read is deliberately not awaited (so subscribe doesn't block on
+    // AsyncStorage), which means it can land AFTER 'ready' already adopted the live
+    // epoch. If it seeds unconditionally it reinstates the exact stale cut #8591 is
+    // about — the reset having already happened doesn't help, because the seed runs
+    // last and wins. Only a stored epoch matching the live one may seed.
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
+
+    // Hold the storage read open so 'ready' is guaranteed to be processed first.
+    let releaseStorage: () => void = () => {}
+    const storageGate = new Promise<void>((resolve) => {
+      releaseStorage = resolve
+    })
+    vi.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) => {
+      await storageGate
+      return key.startsWith('orca:mobileNotificationsLastSeq:')
+        ? '57'
+        : key.startsWith('orca:mobileNotificationsLastEpoch:')
+          ? 'epoch-before-restart'
+          : null
+    })
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    // Live epoch adopted while the stored one is still in flight.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-after-restart' })
+    await flushAsync()
+
+    releaseStorage()
+    await flushAsync()
+
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-2', epoch: 'epoch-after-restart' })
+    await flushAsync()
+    await flushAsync()
+
+    const missedCall = vi
+      .mocked(sub.client.sendRequest)
+      .mock.calls.find((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    expect(missedCall?.[1]).toEqual({ lastSeenSeq: 0, epoch: 'epoch-after-restart' })
+  })
+
+  it('keeps the persisted watermark when the desktop epoch is unchanged', async () => {
+    // The reset must be narrow: a plain socket reap with the same desktop process
+    // still has to send the real watermark, or every reconnect re-pushes the buffer.
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
+    vi.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) =>
+      key.startsWith('orca:mobileNotificationsLastSeq:')
+        ? '57'
+        : key.startsWith('orca:mobileNotificationsLastEpoch:')
+          ? 'epoch-stable'
+          : null
+    )
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-stable' })
+    await flushAsync()
+    await flushAsync()
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-2', epoch: 'epoch-stable' })
+    await flushAsync()
+    await flushAsync()
+
+    const missedCall = vi
+      .mocked(sub.client.sendRequest)
+      .mock.calls.find((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    expect(missedCall?.[1]).toEqual({ lastSeenSeq: 57, epoch: 'epoch-stable' })
+  })
+
   it('drops an already-seen id if a replay re-includes it (defense-in-depth)', async () => {
     vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
     vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({

--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -523,11 +523,15 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
     await flushAsync()
     await flushAsync()
 
-    const missedCall = vi
+    const missedCalls = vi
       .mocked(sub.client.sendRequest)
-      .mock.calls.find((c: unknown[]) => c[0] === 'notifications.getMissedSince')
-    // Watermark reset to 0 and tagged with the live epoch — not the stale 57.
-    expect(missedCall?.[1]).toEqual({ lastSeenSeq: 0, epoch: 'epoch-after-restart' })
+      .mock.calls.filter((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    // The cold open catches up from its stored watermark against the SAME counter —
+    // 57 is meaningful there, so it is the correct cut (#8591 second pass).
+    expect(missedCalls[0]?.[1]).toEqual({ lastSeenSeq: 57, epoch: 'epoch-before-restart' })
+    // After the restart the watermark is reset to 0 and tagged with the live epoch —
+    // not the stale 57, which would make `57 >= 2` true and kill catch-up silently.
+    expect(missedCalls.at(-1)?.[1]).toEqual({ lastSeenSeq: 0, epoch: 'epoch-after-restart' })
   })
 
   it('refuses to seed a stored watermark that lost the race to a newer live epoch', async () => {
@@ -834,6 +838,88 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
       .mock.calls.find((c: unknown[]) => c[0] === 'notifications.getMissedSince')
     // Must not be 57: that seq was never shown to belong to this counter.
     expect(missedCall?.[1]).toEqual({ lastSeenSeq: 0, epoch: 'epoch-live' })
+  })
+
+  it('catches up on the FIRST connection after an upgrade, without a second ready', async () => {
+    // Round-2 review finding: catch-up hung off `connectedBefore`, which is false on
+    // the first 'ready' of a process. So a cold app open — post-upgrade, or after the
+    // OS evicted the app — adopted the epoch but never replayed. Everything between
+    // the stored watermark and the next live seq was then lost permanently, because
+    // the first live event advances the watermark past the gap.
+    //
+    // The earlier migration test masked this by emitting a SECOND 'ready'. This one
+    // emits exactly one, which is what a real cold open does.
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+    vi.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) =>
+      key.startsWith('orca:mobileNotificationsWatermark:')
+        ? JSON.stringify({ seq: 57, epoch: 'epoch-live' })
+        : null
+    )
+
+    const sub = makeClient()
+    vi.mocked(sub.client.sendRequest).mockImplementation(async (method: string) =>
+      method === 'notifications.getMissedSince'
+        ? {
+            ok: true,
+            result: {
+              epoch: 'epoch-live',
+              notifications: [
+                {
+                  type: 'notification',
+                  notificationId: 'missed-58',
+                  notificationSeq: 58,
+                  notificationEpoch: 'epoch-live',
+                  title: 'while the app was closed',
+                  body: 'b'
+                }
+              ]
+            }
+          }
+        : { ok: true, result: {} }
+    )
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-live' })
+    await flushAsync()
+    await flushAsync()
+    await flushAsync()
+
+    const missedCall = vi
+      .mocked(sub.client.sendRequest)
+      .mock.calls.find((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    // The single 'ready' must replay from the stored watermark, not skip it.
+    expect(missedCall?.[1]).toEqual({ lastSeenSeq: 57, epoch: 'epoch-live' })
+    // And the missed notification must actually reach the user.
+    expect(vi.mocked(Notifications.scheduleNotificationAsync).mock.calls.length).toBe(1)
+  })
+
+  it('does not replay the desktop buffer at a first-ever pairing', async () => {
+    // The other side of the finding above: with nothing stored, this device has never
+    // delivered for this host. Catching up would push the whole retained buffer at a
+    // user who was never subscribed for any of it.
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(AsyncStorage.getItem).mockResolvedValue(null)
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-live' })
+    await flushAsync()
+    await flushAsync()
+    await flushAsync()
+
+    expect(
+      vi
+        .mocked(sub.client.sendRequest)
+        .mock.calls.filter((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    ).toHaveLength(0)
   })
 
   it('persists seq and epoch as one value so a crash cannot split the pair', async () => {

--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -9,6 +9,7 @@ import {
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { RpcClient } from '../transport/rpc-client'
 import { loadPushNotificationsEnabled } from '../storage/preferences'
+import { resetHostNotificationSessionsForTests } from './notification-reconnect-catchup'
 
 vi.mock('expo-notifications', () => ({
   AndroidImportance: { HIGH: 'high' },
@@ -39,6 +40,10 @@ vi.mock('../storage/preferences', () => ({
 
 beforeEach(() => {
   Object.assign(Platform, { OS: 'ios', Version: 18 })
+  // Why (#8591): the reconnect watermark/seen-set now live per host at module
+  // scope so they survive the app's unsubscribe-on-disconnect. Reset between
+  // tests so each case starts from a genuine cold open.
+  resetHostNotificationSessionsForTests()
 })
 
 describe('getNotificationPermissionState', () => {

--- a/mobile/src/notifications/mobile-notifications.test.ts
+++ b/mobile/src/notifications/mobile-notifications.test.ts
@@ -506,11 +506,9 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
     } as never)
     vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
     vi.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) =>
-      key.startsWith('orca:mobileNotificationsLastSeq:')
-        ? '57'
-        : key.startsWith('orca:mobileNotificationsLastEpoch:')
-          ? 'epoch-before-restart'
-          : null
+      key.startsWith('orca:mobileNotificationsWatermark:')
+        ? JSON.stringify({ seq: 57, epoch: 'epoch-before-restart' })
+        : null
     )
 
     const sub = makeClient()
@@ -552,11 +550,9 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
     })
     vi.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) => {
       await storageGate
-      return key.startsWith('orca:mobileNotificationsLastSeq:')
-        ? '57'
-        : key.startsWith('orca:mobileNotificationsLastEpoch:')
-          ? 'epoch-before-restart'
-          : null
+      return key.startsWith('orca:mobileNotificationsWatermark:')
+        ? JSON.stringify({ seq: 57, epoch: 'epoch-before-restart' })
+        : null
     })
 
     const sub = makeClient()
@@ -588,11 +584,9 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
     } as never)
     vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('scheduled-1')
     vi.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) =>
-      key.startsWith('orca:mobileNotificationsLastSeq:')
-        ? '57'
-        : key.startsWith('orca:mobileNotificationsLastEpoch:')
-          ? 'epoch-stable'
-          : null
+      key.startsWith('orca:mobileNotificationsWatermark:')
+        ? JSON.stringify({ seq: 57, epoch: 'epoch-stable' })
+        : null
     )
 
     const sub = makeClient()
@@ -698,8 +692,8 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
     await flushAsync()
 
     expect(AsyncStorageMock.setItem).toHaveBeenCalledWith(
-      'orca:mobileNotificationsLastSeq:host-1',
-      '5'
+      'orca:mobileNotificationsWatermark:host-1',
+      JSON.stringify({ seq: 5, epoch: null })
     )
   })
 
@@ -748,8 +742,8 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
 
     // Watermark advanced to the replayed seq and was persisted.
     expect(AsyncStorageMock.setItem).toHaveBeenCalledWith(
-      'orca:mobileNotificationsLastSeq:host-1',
-      '8'
+      'orca:mobileNotificationsWatermark:host-1',
+      JSON.stringify({ seq: 8, epoch: null })
     )
 
     // Second reconnect resumes from the advanced watermark, not 0.
@@ -759,5 +753,127 @@ describe('subscribeToDesktopNotifications — reconnect catch-up', () => {
       .mocked(sub.client.sendRequest)
       .mock.calls.filter((c: unknown[]) => c[0] === 'notifications.getMissedSince')
     expect(missedCalls.at(-1)?.[1]).toEqual({ lastSeenSeq: 8 })
+  })
+
+  it('replays a terminal bell at a seq the previous desktop counter already used', async () => {
+    // Round-1 review finding: seen-keys are seq-derived, and terminal bells carry no
+    // notificationId (they key on `seq:N` alone). Epoch A delivers a bell at seq 1;
+    // after a restart, epoch B's first bell is ALSO seq 1. The catch-up path is the
+    // one that consults the seen-set, so without clearing it on epoch change the
+    // replayed post-restart bell is mistaken for a duplicate and silently skipped —
+    // #8591's silent loss again, now one notification at a time.
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+
+    const sub = makeClient()
+    // Catch-up returns epoch B's first bell — same seq 1 the old counter used.
+    sub.client.sendRequest = vi.fn(async (method: string) => {
+      if (method === 'notifications.getMissedSince') {
+        return {
+          ok: true,
+          result: {
+            epoch: 'epoch-B',
+            notifications: [{ type: 'notification', title: 'bell', body: 'B', notificationSeq: 1 }]
+          }
+        } as never
+      }
+      return { ok: true, result: undefined } as never
+    })
+
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-A' })
+    await flushAsync()
+    // A live bell under epoch A — no notificationId, so its seen-key is `seq:1`.
+    sub.onData?.({ type: 'notification', title: 'bell', body: 'A', notificationSeq: 1 })
+    await flushAsync()
+    expect(vi.mocked(Notifications.scheduleNotificationAsync).mock.calls.length).toBe(1)
+
+    // Desktop restarts; reconnect triggers catch-up against the fresh counter.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-2', epoch: 'epoch-B' })
+    await flushAsync()
+    await flushAsync()
+
+    // The post-restart bell must reach the user, not be swallowed as a stale `seq:1`.
+    expect(vi.mocked(Notifications.scheduleNotificationAsync).mock.calls.length).toBe(2)
+  })
+
+  it('does not trust a legacy epoch-less watermark against a live counter', async () => {
+    // Round-1 review finding: pre-upgrade installs stored a bare seq with no epoch.
+    // Seeding it and then treating the first observed epoch as "nothing changed"
+    // leaves 57 cutting a counter it was never measured against — #8591 reached
+    // through the upgrade path. An unprovenanced seq may not survive epoch adoption.
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+    // Only the LEGACY key exists — exactly what an upgrading install has on disk.
+    vi.mocked(AsyncStorage.getItem).mockImplementation(async (key: string) =>
+      key.startsWith('orca:mobileNotificationsLastSeq:') ? '57' : null
+    )
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    // Seed lands FIRST (no epoch known yet), so 57 is provisionally adopted...
+    await flushAsync()
+    await flushAsync()
+    // ...then the live epoch arrives for the first time.
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-live' })
+    await flushAsync()
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-2', epoch: 'epoch-live' })
+    await flushAsync()
+    await flushAsync()
+
+    const missedCall = vi
+      .mocked(sub.client.sendRequest)
+      .mock.calls.find((c: unknown[]) => c[0] === 'notifications.getMissedSince')
+    // Must not be 57: that seq was never shown to belong to this counter.
+    expect(missedCall?.[1]).toEqual({ lastSeenSeq: 0, epoch: 'epoch-live' })
+  })
+
+  it('persists seq and epoch as one value so a crash cannot split the pair', async () => {
+    // Round-1 review finding: written as two keys, a process death between the writes
+    // leaves epoch-B beside seq-57-from-A. That pair looks internally valid on the
+    // next launch and is therefore trusted — silently cutting B's first 57 events.
+    // One key means the pair is always written whole or not at all.
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('s')
+
+    const sub = makeClient()
+    subscribeToDesktopNotifications(sub.client, 'host-1')
+    sub.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-A' })
+    await flushAsync()
+    sub.onData?.({
+      type: 'notification',
+      title: 't',
+      body: 'b',
+      notificationId: 'agent:x',
+      notificationSeq: 9
+    })
+    await flushAsync()
+
+    // Every watermark write is a single key carrying both halves together.
+    const watermarkWrites = AsyncStorageMock.setItem.mock.calls.filter((c: unknown[]) =>
+      String(c[0]).startsWith('orca:mobileNotifications')
+    )
+    expect(watermarkWrites.length).toBeGreaterThan(0)
+    for (const [key, value] of watermarkWrites) {
+      expect(key).toBe('orca:mobileNotificationsWatermark:host-1')
+      expect(JSON.parse(String(value))).toHaveProperty('epoch')
+      expect(JSON.parse(String(value))).toHaveProperty('seq')
+    }
+    expect(JSON.parse(String(watermarkWrites.at(-1)?.[1]))).toEqual({
+      seq: 9,
+      epoch: 'epoch-A'
+    })
   })
 })

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -15,10 +15,13 @@ import {
 } from './local-notification-scheduling'
 import {
   adoptNotificationEpoch,
+  enqueueHostDelivery,
   getHostNotificationSession,
+  releaseQueuedShowNotificationId,
   saveWatermark,
   seedWatermarkFromStorage,
-  seenKeyForEvent
+  seenKeyForEvent,
+  shouldQueueShowForNotificationId
 } from './notification-reconnect-catchup'
 
 type SubscribeResult = {
@@ -38,11 +41,55 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
   // socket drop, so a reconnect still knows its watermark and that it reconnected.
   const session = getHostNotificationSession(hostId)
 
-  function deliverLive(
+  /**
+   * Queue one delivery on the host chain, dropping a show whose notificationId
+   * already has one queued.
+   *
+   * Why the claim is taken HERE and not inside deliverLive (#8591): the point of
+   * the dedup is to notice a second event arriving while the first is still
+   * outstanding. Inside the queued task the first has already finished, so the
+   * overlap is no longer observable — it has to be checked before enqueueing.
+   */
+  function queueDelivery(
+    type: 'notification' | 'dismiss',
+    event: NotificationEvent | DismissNotificationEvent
+  ): Promise<void> {
+    if (
+      type === 'notification' &&
+      !shouldQueueShowForNotificationId(session, event.notificationId)
+    ) {
+      return Promise.resolve()
+    }
+    return enqueueHostDelivery(session, async () => {
+      try {
+        await deliverLive(type, event)
+      } finally {
+        if (type === 'notification') {
+          releaseQueuedShowNotificationId(session, event.notificationId)
+        }
+      }
+    })
+  }
+
+  async function deliverLive(
     type: 'notification' | 'dismiss',
     event: NotificationEvent | DismissNotificationEvent
   ): Promise<void> {
     adoptNotificationEpoch(session, hostId, event.notificationEpoch)
+    // Why (#8129): mark seen on the live path too, so a later replay of an already-pushed id dedups instead of double-pushing.
+    const key = seenKeyForEvent(event)
+    if (key) {
+      session.seen.add(key)
+    }
+    if (type === 'notification') {
+      await showLocalNotification(event as NotificationEvent, hostId)
+    } else {
+      await dismissLocalNotification(event as DismissNotificationEvent, hostId)
+    }
+    // Why after the await (#8591): the watermark is a promise that everything up
+    // to this seq has been shown. Advancing it before the local notification lands
+    // means a process death in between silently drops it — the next launch asks the
+    // desktop for seq greater than one the user never saw.
     if (event.notificationSeq != null && event.notificationSeq > session.lastDeliveredSeq) {
       session.lastDeliveredSeq = event.notificationSeq
       // Persisted as a pair: a seq is only trustworthy alongside the epoch it indexes.
@@ -51,15 +98,6 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
         epoch: session.lastDeliveredEpoch
       })
     }
-    // Why (#8129): mark seen on the live path too, so a later replay of an already-pushed id dedups instead of double-pushing.
-    const key = seenKeyForEvent(event)
-    if (key) {
-      session.seen.add(key)
-    }
-    if (type === 'notification') {
-      return showLocalNotification(event as NotificationEvent, hostId)
-    }
-    return dismissLocalNotification(event as DismissNotificationEvent, hostId)
   }
 
   // Why: desktop cuts by seq > lastSeenSeq, so re-fetching from the watermark is idempotent (session.seen guards residual overlap).
@@ -83,21 +121,42 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
         return Array.isArray(result?.notifications) ? result.notifications : []
       })
       .catch(() => [])
-    for (const raw of missed) {
-      const event = raw as NotificationEvent | DismissNotificationEvent
-      const key = seenKeyForEvent(event)
-      if (key && session.seen.has(key)) {
-        continue
+    // Why the whole batch is ONE queue entry (#8591): awaiting per event returns to
+    // the event loop between replays, so a live seq 11 slots into the chain between
+    // seq 6 and 7 and persists a watermark past a notification still unshown. Why the
+    // request stays OUTSIDE the queue: sendRequest waits up to 30s, and holding the
+    // chain for that would stall live delivery on a slow link.
+    await enqueueHostDelivery(session, async () => {
+      for (const raw of missed) {
+        // Re-checked per event: the batch can start before a teardown and still be
+        // draining after it, and a torn-down host must stop pushing.
+        if (disposed) {
+          return
+        }
+        const event = raw as NotificationEvent | DismissNotificationEvent
+        const key = seenKeyForEvent(event)
+        if (key && session.seen.has(key)) {
+          continue
+        }
+        if (key) {
+          session.seen.add(key)
+        }
+        // Claimed inline rather than via queueDelivery: the batch is already one
+        // queue entry, and re-enqueueing per item is what let a live event cut in.
+        if (event.type === 'notification') {
+          if (!shouldQueueShowForNotificationId(session, event.notificationId)) {
+            continue
+          }
+          try {
+            await deliverLive('notification', event)
+          } finally {
+            releaseQueuedShowNotificationId(session, event.notificationId)
+          }
+        } else if (event.type === 'dismiss') {
+          await deliverLive('dismiss', event)
+        }
       }
-      if (key) {
-        session.seen.add(key)
-      }
-      if (event.type === 'notification') {
-        await deliverLive('notification', event)
-      } else if (event.type === 'dismiss') {
-        await deliverLive('dismiss', event)
-      }
-    }
+    })
   }
 
   seedWatermarkFromStorage(session, hostId)
@@ -169,11 +228,12 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
       if (disposed) {
         return
       }
-      if (liveEvent.type === 'notification') {
-        await deliverLive('notification', liveEvent as NotificationEvent)
-      } else {
-        await deliverLive('dismiss', liveEvent as DismissNotificationEvent)
-      }
+      // Why the queue (#8591): a live event must not overtake an in-flight
+      // catch-up replay, or it persists a watermark past seqs still unshown.
+      await queueDelivery(
+        liveEvent.type === 'notification' ? 'notification' : 'dismiss',
+        liveEvent as NotificationEvent | DismissNotificationEvent
+      )
     })()
   })
 

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -13,7 +13,7 @@ import { ensureNotificationPermissions } from './notification-permissions'
 import {
   adoptNotificationEpoch,
   getHostNotificationSession,
-  saveLastSeenSeq,
+  saveWatermark,
   seedWatermarkFromStorage,
   seenKeyForEvent
 } from './notification-reconnect-catchup'
@@ -225,7 +225,11 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     adoptNotificationEpoch(session, hostId, event.notificationEpoch)
     if (event.notificationSeq != null && event.notificationSeq > session.lastDeliveredSeq) {
       session.lastDeliveredSeq = event.notificationSeq
-      void saveLastSeenSeq(hostId, session.lastDeliveredSeq)
+      // Persisted as a pair: a seq is only trustworthy alongside the epoch it indexes.
+      void saveWatermark(hostId, {
+        seq: session.lastDeliveredSeq,
+        epoch: session.lastDeliveredEpoch
+      })
     }
     // Why (#8129): mark seen on the live path too, so a later replay of an already-pushed id dedups instead of double-pushing.
     const key = seenKeyForEvent(event)

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -1,15 +1,18 @@
-import * as Notifications from 'expo-notifications'
-import { Platform } from 'react-native'
 import type { RpcClient } from '../transport/rpc-client'
-import { loadPushNotificationsEnabled } from '../storage/preferences'
-import { buildLocalNotificationData, type DesktopNotificationSource } from './notification-routing'
 // Re-exported so the existing importers (and their vi.mock paths) keep working.
 export {
   ensureNotificationPermissions,
   getNotificationPermissionState,
   type NotificationPermissionState
 } from './notification-permissions'
-import { ensureNotificationPermissions } from './notification-permissions'
+export { setScheduledNotificationsMaxForTests } from './local-notification-scheduling'
+import {
+  configureNotificationChannel,
+  dismissLocalNotification,
+  showLocalNotification,
+  type DismissNotificationEvent,
+  type NotificationEvent
+} from './local-notification-scheduling'
 import {
   adoptNotificationEpoch,
   getHostNotificationSession,
@@ -18,194 +21,11 @@ import {
   seenKeyForEvent
 } from './notification-reconnect-catchup'
 
-type NotificationEvent = {
-  type: 'notification'
-  source: DesktopNotificationSource
-  title: string
-  body: string
-  worktreeId?: string
-  notificationId?: string
-  // Desktop-assigned seq for reconnect catch-up (#8129); optional since older runtimes may omit it.
-  notificationSeq?: number
-  // Counter lifetime the seq belongs to (#8591); absent on older runtimes.
-  notificationEpoch?: string
-}
-
-type DismissNotificationEvent = {
-  type: 'dismiss'
-  notificationId: string
-  notificationSeq?: number
-  notificationEpoch?: string
-}
-
 type SubscribeResult = {
   type: 'ready'
   subscriptionId: string
   // Desktop counter lifetime (#8591); absent from runtimes that predate it.
   epoch?: string
-}
-
-type ScheduledNotificationState = {
-  identifier?: string
-  pending?: Promise<string | null>
-  dismissAfterSchedule?: boolean
-}
-
-const scheduledNotificationsByHostAndNotificationId = new Map<string, ScheduledNotificationState>()
-
-// Why: keys never repeat and are only freed on desktop dismiss (which remote users often miss), so bound the map to stop unbounded growth.
-const MAX_SCHEDULED_NOTIFICATIONS = 256
-let maxScheduledNotifications = MAX_SCHEDULED_NOTIFICATIONS
-
-function getStoredNotificationKey(hostId: string, notificationId: string): string {
-  return `${encodeURIComponent(hostId)}:${encodeURIComponent(notificationId)}`
-}
-
-// Evict oldest settled entries (never mid-schedule); Map iteration is insertion order so the first match is oldest.
-function boundScheduledNotifications(): void {
-  while (scheduledNotificationsByHostAndNotificationId.size > maxScheduledNotifications) {
-    let evicted = false
-    for (const [key, state] of scheduledNotificationsByHostAndNotificationId) {
-      if (!state.pending) {
-        scheduledNotificationsByHostAndNotificationId.delete(key)
-        evicted = true
-        break
-      }
-    }
-    if (!evicted) {
-      break
-    }
-  }
-}
-
-/** Test-only: override the cap (pass no arg to restore the default). */
-export function setScheduledNotificationsMaxForTests(max?: number): void {
-  maxScheduledNotifications = max ?? MAX_SCHEDULED_NOTIFICATIONS
-}
-
-function configureNotificationChannel(): void {
-  if (Platform.OS === 'android') {
-    void Notifications.setNotificationChannelAsync('orca-desktop', {
-      name: 'Desktop Notifications',
-      importance: Notifications.AndroidImportance.HIGH,
-      vibrationPattern: [0, 250],
-      lightColor: '#6366f1'
-    })
-  }
-}
-
-async function showLocalNotification(event: NotificationEvent, hostId: string): Promise<void> {
-  const storedKey = event.notificationId
-    ? getStoredNotificationKey(hostId, event.notificationId)
-    : null
-
-  if (!storedKey) {
-    const enabled = await loadPushNotificationsEnabled()
-    if (!enabled) {
-      return
-    }
-
-    const granted = await ensureNotificationPermissions()
-    if (!granted) {
-      return
-    }
-
-    await Notifications.scheduleNotificationAsync({
-      content: {
-        title: event.title,
-        body: event.body,
-        data: buildLocalNotificationData(event, hostId),
-        ...(Platform.OS === 'android' ? { channelId: 'orca-desktop' } : {})
-      },
-      trigger: null
-    })
-    return
-  }
-
-  let state = scheduledNotificationsByHostAndNotificationId.get(storedKey)
-  if (state?.pending) {
-    return
-  }
-  if (!state) {
-    state = {}
-    scheduledNotificationsByHostAndNotificationId.set(storedKey, state)
-  }
-  const notificationState = state
-
-  const pending = (async () => {
-    const enabled = await loadPushNotificationsEnabled()
-    if (!enabled) {
-      return null
-    }
-
-    const granted = await ensureNotificationPermissions()
-    if (!granted) {
-      return null
-    }
-
-    if (notificationState.identifier) {
-      await Notifications.dismissNotificationAsync(notificationState.identifier).catch(() => {})
-      notificationState.identifier = undefined
-    }
-
-    return Notifications.scheduleNotificationAsync({
-      content: {
-        title: event.title,
-        body: event.body,
-        data: buildLocalNotificationData(event, hostId),
-        ...(Platform.OS === 'android' ? { channelId: 'orca-desktop' } : {})
-      },
-      trigger: null
-    })
-  })()
-  notificationState.pending = pending
-
-  try {
-    const scheduledIdentifier = await pending
-    if (!scheduledIdentifier) {
-      if (!notificationState.identifier) {
-        scheduledNotificationsByHostAndNotificationId.delete(storedKey)
-      }
-      return
-    }
-    if (notificationState.dismissAfterSchedule) {
-      notificationState.dismissAfterSchedule = false
-      scheduledNotificationsByHostAndNotificationId.delete(storedKey)
-      await Notifications.dismissNotificationAsync(scheduledIdentifier).catch(() => {})
-      return
-    }
-    notificationState.identifier = scheduledIdentifier
-    boundScheduledNotifications()
-  } finally {
-    if (notificationState.pending === pending) {
-      notificationState.pending = undefined
-      notificationState.dismissAfterSchedule = false
-    }
-  }
-}
-
-async function dismissLocalNotification(
-  event: DismissNotificationEvent,
-  hostId: string
-): Promise<void> {
-  if (!event.notificationId) {
-    return
-  }
-  const storedKey = getStoredNotificationKey(hostId, event.notificationId)
-  const state = scheduledNotificationsByHostAndNotificationId.get(storedKey)
-  if (!state) {
-    return
-  }
-  if (state.pending) {
-    // Why: dismiss can arrive while the OS is still scheduling; defer it so no stale banner survives.
-    state.dismissAfterSchedule = true
-    return
-  }
-  if (!state.identifier) {
-    return
-  }
-  scheduledNotificationsByHostAndNotificationId.delete(storedKey)
-  await Notifications.dismissNotificationAsync(state.identifier).catch(() => {})
 }
 
 // Per-connection subscription; a reconnect `ready` triggers watermarked catch-up (#8129) so already-pushed events aren't re-sent.
@@ -335,11 +155,26 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     if (disposed) {
       return
     }
-    if (event.type === 'notification') {
-      void deliverLive('notification', event as NotificationEvent)
-    } else if (event.type === 'dismiss') {
-      void deliverLive('dismiss', event as DismissNotificationEvent)
+    if (event.type !== 'notification' && event.type !== 'dismiss') {
+      return
     }
+    // Why the await (#8591): deliverLive advances the watermark. A live event landing
+    // while the persisted read is still in flight would push it past the buffered seqs
+    // the catch-up is about to ask for, and getMissedSince would cut them. Ordering is
+    // preserved — every handler waits on the same promise, and the 'ready' continuation
+    // registered on it first, so catch-up still builds its request before any live seq.
+    const liveEvent = event
+    void (async () => {
+      await session.watermarkSeeded
+      if (disposed) {
+        return
+      }
+      if (liveEvent.type === 'notification') {
+        await deliverLive('notification', liveEvent as NotificationEvent)
+      } else {
+        await deliverLive('dismiss', liveEvent as DismissNotificationEvent)
+      }
+    })()
   })
 
   return () => {

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -4,7 +4,7 @@ import type { RpcClient } from '../transport/rpc-client'
 import { loadPushNotificationsEnabled } from '../storage/preferences'
 import { buildLocalNotificationData, type DesktopNotificationSource } from './notification-routing'
 import {
-  createSeenNotificationGuard,
+  getHostNotificationSession,
   loadLastSeenSeq,
   saveLastSeenSeq,
   seenKeyForEvent
@@ -231,23 +231,22 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
 
   let subscriptionId: string | null = null
   let disposed = false
-  // Highest seq delivered (live or replay) this connection; persisted per-host so cold start resumes from the right cut.
-  let lastDeliveredSeq = 0
-  // Why: defense-in-depth dedup for replayed events if the desktop's bounded buffer evicted across a reconnect boundary.
-  const seenReplay = createSeenNotificationGuard()
+  // Why (#8591): survives the unsubscribe/resubscribe the app performs on every
+  // socket drop, so a reconnect still knows its watermark and that it reconnected.
+  const session = getHostNotificationSession(hostId)
 
   function deliverLive(
     type: 'notification' | 'dismiss',
     event: NotificationEvent | DismissNotificationEvent
   ): Promise<void> {
-    if (event.notificationSeq != null && event.notificationSeq > lastDeliveredSeq) {
-      lastDeliveredSeq = event.notificationSeq
-      void saveLastSeenSeq(hostId, lastDeliveredSeq)
+    if (event.notificationSeq != null && event.notificationSeq > session.lastDeliveredSeq) {
+      session.lastDeliveredSeq = event.notificationSeq
+      void saveLastSeenSeq(hostId, session.lastDeliveredSeq)
     }
     // Why (#8129): mark seen on the live path too, so a later replay of an already-pushed id dedups instead of double-pushing.
     const key = seenKeyForEvent(event)
     if (key) {
-      seenReplay.add(key)
+      session.seen.add(key)
     }
     if (type === 'notification') {
       return showLocalNotification(event as NotificationEvent, hostId)
@@ -255,13 +254,13 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     return dismissLocalNotification(event as DismissNotificationEvent, hostId)
   }
 
-  // Why: desktop cuts by seq > lastSeenSeq, so re-fetching from the watermark is idempotent (seenReplay guards residual overlap).
+  // Why: desktop cuts by seq > lastSeenSeq, so re-fetching from the watermark is idempotent (session.seen guards residual overlap).
   async function fetchMissed(): Promise<void> {
     if (disposed) {
       return
     }
     const missed = await client
-      .sendRequest('notifications.getMissedSince', { lastSeenSeq: lastDeliveredSeq })
+      .sendRequest('notifications.getMissedSince', { lastSeenSeq: session.lastDeliveredSeq })
       .then((response) => {
         if (!response.ok) {
           return []
@@ -273,11 +272,11 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     for (const raw of missed) {
       const event = raw as NotificationEvent | DismissNotificationEvent
       const key = seenKeyForEvent(event)
-      if (key && seenReplay.has(key)) {
+      if (key && session.seen.has(key)) {
         continue
       }
       if (key) {
-        seenReplay.add(key)
+        session.seen.add(key)
       }
       if (event.type === 'notification') {
         await deliverLive('notification', event)
@@ -288,11 +287,13 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
   }
 
   // Why: seed the watermark lazily so subscribe() doesn't block on an AsyncStorage read.
-  let watermarkLoaded = false
-  void loadLastSeenSeq(hostId).then((seq) => {
-    lastDeliveredSeq = Math.max(lastDeliveredSeq, seq)
-    watermarkLoaded = true
-  })
+  // Only the first subscription for a host needs it; later ones inherit the live value.
+  if (!session.watermarkLoaded) {
+    void loadLastSeenSeq(hostId).then((seq) => {
+      session.lastDeliveredSeq = Math.max(session.lastDeliveredSeq, seq)
+      session.watermarkLoaded = true
+    })
+  }
 
   function unsubscribeServer(id: string) {
     if (client.getState() === 'connected') {
@@ -300,7 +301,6 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     }
   }
 
-  let reconnectReadyCount = 0
   const unsubscribeStream = client.subscribe('notifications.subscribe', {}, (data: unknown) => {
     const event = data as
       | NotificationEvent
@@ -309,14 +309,15 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
       | { type: 'end' }
     if (event.type === 'ready') {
       subscriptionId = (event as SubscribeResult).subscriptionId
-      reconnectReadyCount += 1
+      const isReconnect = session.connectedBefore
+      session.connectedBefore = true
       if (disposed) {
         unsubscribeServer(subscriptionId)
         unsubscribeStream()
         return
       }
       // Why: only reconnects fetch missed; watermarkLoaded guards against fetching from a stale 0 (which re-pushes everything).
-      if (reconnectReadyCount > 1 && watermarkLoaded) {
+      if (isReconnect && session.watermarkLoaded) {
         void fetchMissed()
       }
       return

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -3,10 +3,18 @@ import { Platform } from 'react-native'
 import type { RpcClient } from '../transport/rpc-client'
 import { loadPushNotificationsEnabled } from '../storage/preferences'
 import { buildLocalNotificationData, type DesktopNotificationSource } from './notification-routing'
+// Re-exported so the existing importers (and their vi.mock paths) keep working.
+export {
+  ensureNotificationPermissions,
+  getNotificationPermissionState,
+  type NotificationPermissionState
+} from './notification-permissions'
+import { ensureNotificationPermissions } from './notification-permissions'
 import {
+  adoptNotificationEpoch,
   getHostNotificationSession,
-  loadLastSeenSeq,
   saveLastSeenSeq,
+  seedWatermarkFromStorage,
   seenKeyForEvent
 } from './notification-reconnect-catchup'
 
@@ -19,17 +27,22 @@ type NotificationEvent = {
   notificationId?: string
   // Desktop-assigned seq for reconnect catch-up (#8129); optional since older runtimes may omit it.
   notificationSeq?: number
+  // Counter lifetime the seq belongs to (#8591); absent on older runtimes.
+  notificationEpoch?: string
 }
 
 type DismissNotificationEvent = {
   type: 'dismiss'
   notificationId: string
   notificationSeq?: number
+  notificationEpoch?: string
 }
 
 type SubscribeResult = {
   type: 'ready'
   subscriptionId: string
+  // Desktop counter lifetime (#8591); absent from runtimes that predate it.
+  epoch?: string
 }
 
 type ScheduledNotificationState = {
@@ -68,36 +81,6 @@ function boundScheduledNotifications(): void {
 /** Test-only: override the cap (pass no arg to restore the default). */
 export function setScheduledNotificationsMaxForTests(max?: number): void {
   maxScheduledNotifications = max ?? MAX_SCHEDULED_NOTIFICATIONS
-}
-
-export type NotificationPermissionState = {
-  granted: boolean
-  status: string
-  canAskAgain: boolean
-  authorizationReflectsUserChoice: boolean
-}
-
-export async function getNotificationPermissionState(): Promise<NotificationPermissionState> {
-  const { status, canAskAgain } = await Notifications.getPermissionsAsync()
-  return {
-    granted: status === 'granted',
-    status,
-    canAskAgain,
-    // Why: Android <33 has no runtime notification permission, so "granted" is capability, not user consent.
-    authorizationReflectsUserChoice:
-      status === 'granted' && (Platform.OS !== 'android' || Number(Platform.Version) >= 33)
-  }
-}
-
-// Why: re-read OS state every call — users can change it in Settings while Orca is backgrounded.
-export async function ensureNotificationPermissions(): Promise<boolean> {
-  const existing = await getNotificationPermissionState()
-  if (existing.granted) {
-    return true
-  }
-
-  const { status } = await Notifications.requestPermissionsAsync()
-  return status === 'granted'
 }
 
 function configureNotificationChannel(): void {
@@ -239,6 +222,7 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     type: 'notification' | 'dismiss',
     event: NotificationEvent | DismissNotificationEvent
   ): Promise<void> {
+    adoptNotificationEpoch(session, hostId, event.notificationEpoch)
     if (event.notificationSeq != null && event.notificationSeq > session.lastDeliveredSeq) {
       session.lastDeliveredSeq = event.notificationSeq
       void saveLastSeenSeq(hostId, session.lastDeliveredSeq)
@@ -260,12 +244,18 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
       return
     }
     const missed = await client
-      .sendRequest('notifications.getMissedSince', { lastSeenSeq: session.lastDeliveredSeq })
+      .sendRequest('notifications.getMissedSince', {
+        lastSeenSeq: session.lastDeliveredSeq,
+        // Why: sending the epoch lets the desktop reject a watermark from a counter
+        // it no longer has and return the whole retained buffer instead of nothing.
+        ...(session.lastDeliveredEpoch != null ? { epoch: session.lastDeliveredEpoch } : {})
+      })
       .then((response) => {
         if (!response.ok) {
           return []
         }
-        const result = response.result as { notifications?: unknown[] } | undefined
+        const result = response.result as { notifications?: unknown[]; epoch?: string } | undefined
+        adoptNotificationEpoch(session, hostId, result?.epoch)
         return Array.isArray(result?.notifications) ? result.notifications : []
       })
       .catch(() => [])
@@ -286,14 +276,7 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     }
   }
 
-  // Why: seed the watermark lazily so subscribe() doesn't block on an AsyncStorage read.
-  // Only the first subscription for a host needs it; later ones inherit the live value.
-  if (!session.watermarkLoaded) {
-    void loadLastSeenSeq(hostId).then((seq) => {
-      session.lastDeliveredSeq = Math.max(session.lastDeliveredSeq, seq)
-      session.watermarkLoaded = true
-    })
-  }
+  seedWatermarkFromStorage(session, hostId)
 
   function unsubscribeServer(id: string) {
     if (client.getState() === 'connected') {
@@ -316,6 +299,10 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
         unsubscribeStream()
         return
       }
+      // Why before fetchMissed: adopting the epoch here is what voids a watermark
+      // left over from a previous desktop lifetime, so the catch-up request carries
+      // a watermark that means something against the counter now answering it.
+      adoptNotificationEpoch(session, hostId, (event as SubscribeResult).epoch)
       // Why: only reconnects fetch missed; watermarkLoaded guards against fetching from a stale 0 (which re-pushes everything).
       if (isReconnect && session.watermarkLoaded) {
         void fetchMissed()

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -303,14 +303,27 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
         unsubscribeStream()
         return
       }
-      // Why before fetchMissed: adopting the epoch here is what voids a watermark
-      // left over from a previous desktop lifetime, so the catch-up request carries
-      // a watermark that means something against the counter now answering it.
-      adoptNotificationEpoch(session, hostId, (event as SubscribeResult).epoch)
-      // Why: only reconnects fetch missed; watermarkLoaded guards against fetching from a stale 0 (which re-pushes everything).
-      if (isReconnect && session.watermarkLoaded) {
-        void fetchMissed()
-      }
+      const readyEpoch = (event as SubscribeResult).epoch
+      // Why (#8591) the await: on a cold app open the persisted read is still in
+      // flight, so deciding here would see watermarkLoaded false and skip catch-up —
+      // which is precisely the post-upgrade / post-process-death case that loses
+      // every notification between the stored watermark and the next live seq.
+      void (async () => {
+        await session.watermarkSeeded
+        if (disposed) {
+          return
+        }
+        // Why before fetchMissed: adopting the epoch here is what voids a watermark
+        // left over from a previous desktop lifetime, so the catch-up request carries
+        // a watermark that means something against the counter now answering it.
+        adoptNotificationEpoch(session, hostId, readyEpoch)
+        // A reconnect always catches up. A cold open catches up only when this device
+        // has delivered for this host before — a first-ever pairing must not be handed
+        // the desktop's whole retained buffer.
+        if (isReconnect || session.hadStoredWatermark) {
+          await fetchMissed()
+        }
+      })()
       return
     }
     if (event.type === 'end') {

--- a/mobile/src/notifications/notification-delivery-ordering.test.ts
+++ b/mobile/src/notifications/notification-delivery-ordering.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Notifications from 'expo-notifications'
+import { subscribeToDesktopNotifications } from './mobile-notifications'
+import { resetHostNotificationSessionsForTests } from './notification-reconnect-catchup'
+import type { RpcClient } from '../transport/rpc-client'
+import { loadPushNotificationsEnabled } from '../storage/preferences'
+
+vi.mock('expo-notifications', () => ({
+  AndroidImportance: { HIGH: 'high' },
+  setNotificationChannelAsync: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  scheduleNotificationAsync: vi.fn(),
+  dismissNotificationAsync: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', Version: 18 }
+}))
+
+const WATERMARK_KEY = 'orca:mobileNotificationsWatermark:host-1'
+const storage = new Map<string, string>()
+let getItemImpl: (key: string) => Promise<string | null> = async (key) => storage.get(key) ?? null
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn((key: string) => getItemImpl(key)),
+    setItem: vi.fn(async (key: string, value: string) => {
+      storage.set(key, value)
+    })
+  }
+}))
+
+vi.mock('../storage/preferences', () => ({
+  loadPushNotificationsEnabled: vi.fn()
+}))
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 10)
+  })
+}
+
+function persistedSeq(): number {
+  return (JSON.parse(storage.get(WATERMARK_KEY) ?? '{}') as { seq?: number }).seq ?? 0
+}
+
+describe('#8591 per-host delivery ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storage.clear()
+    getItemImpl = async (key) => storage.get(key) ?? null
+    resetHostNotificationSessionsForTests()
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('sched-1')
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+  })
+
+  it('never persists a watermark past a notification the catch-up has not shown', async () => {
+    // The watermark is a promise that everything up to that seq reached the user.
+    // If a live seq 11 is processed while catch-up is still showing seq 6, it
+    // persists 11 — and a process death before 7 is shown loses 7 forever, because
+    // the next launch asks the desktop for seq > 11. That is the original #8591
+    // loss re-entered through concurrency rather than through a restarted counter.
+    let releaseFirstShow!: () => void
+    const firstShowBlocked = new Promise<void>((resolve) => {
+      releaseFirstShow = resolve
+    })
+    let shown = 0
+    vi.mocked(Notifications.scheduleNotificationAsync).mockImplementation(async () => {
+      shown += 1
+      if (shown === 1) {
+        await firstShowBlocked
+      }
+      return 'sched-1'
+    })
+
+    let onData: ((data: unknown) => void) | null = null
+    const client = {
+      subscribe: vi.fn((_m: string, _p: unknown, cb: (data: unknown) => void) => {
+        onData = cb
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn(async (method: string) => {
+        if (method === 'notifications.getMissedSince') {
+          return {
+            ok: true,
+            result: {
+              notifications: [
+                {
+                  type: 'notification',
+                  title: 'm6',
+                  body: 'b',
+                  notificationId: 'a:6',
+                  notificationSeq: 6
+                },
+                {
+                  type: 'notification',
+                  title: 'm7',
+                  body: 'b',
+                  notificationId: 'a:7',
+                  notificationSeq: 7
+                }
+              ]
+            }
+          } as never
+        }
+        return { ok: true, result: undefined } as never
+      })
+    } as unknown as RpcClient
+
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 5, epoch: 'epoch-1' }))
+    subscribeToDesktopNotifications(client, 'host-1')
+    onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+
+    // Live seq 11 arrives while the replay is wedged on seq 6.
+    onData?.({
+      type: 'notification',
+      title: 'live-11',
+      body: 'b',
+      notificationId: 'a:11',
+      notificationSeq: 11
+    })
+    await flushAsync()
+
+    expect(persistedSeq()).toBeLessThan(6)
+
+    releaseFirstShow()
+    await flushAsync()
+
+    // Once the chain drains, everything is shown and the watermark catches up.
+    expect(persistedSeq()).toBe(11)
+    const titles = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map((call) => (call[0] as { content: { title: string } }).content.title)
+    expect(titles).toEqual(['m6', 'm7', 'live-11'])
+  })
+
+  it('shows one banner when a replay and a live event carry the same notification id', async () => {
+    // Serializing deliveries removed the overlap the old dedup relied on: the
+    // replay's show now COMPLETES before the live duplicate starts, so nothing is
+    // pending for it to observe and the user gets the same notification twice.
+    let releaseFirstShow!: () => void
+    const firstShowBlocked = new Promise<void>((resolve) => {
+      releaseFirstShow = resolve
+    })
+    let shown = 0
+    vi.mocked(Notifications.scheduleNotificationAsync).mockImplementation(async () => {
+      shown += 1
+      if (shown === 1) {
+        await firstShowBlocked
+      }
+      return `sched-${shown}`
+    })
+
+    let onData: ((data: unknown) => void) | null = null
+    const client = {
+      subscribe: vi.fn((_m: string, _p: unknown, cb: (data: unknown) => void) => {
+        onData = cb
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn(async (method: string) => {
+        if (method === 'notifications.getMissedSince') {
+          return {
+            ok: true,
+            result: {
+              notifications: [
+                {
+                  type: 'notification',
+                  title: 'dup',
+                  body: 'b',
+                  notificationId: 'agent:dup',
+                  notificationSeq: 6
+                }
+              ]
+            }
+          } as never
+        }
+        return { ok: true, result: undefined } as never
+      })
+    } as unknown as RpcClient
+
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 5, epoch: 'epoch-1' }))
+    subscribeToDesktopNotifications(client, 'host-1')
+    onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+
+    // Same id arrives live while the replay's show is still blocked. A different
+    // seq, so the seen-set does not catch it — only the queued-show claim does.
+    onData?.({
+      type: 'notification',
+      title: 'dup',
+      body: 'b',
+      notificationId: 'agent:dup',
+      notificationSeq: 7
+    })
+    await flushAsync()
+
+    releaseFirstShow()
+    await flushAsync()
+
+    expect(vi.mocked(Notifications.scheduleNotificationAsync)).toHaveBeenCalledTimes(1)
+  })
+
+  it('still delivers when the persisted watermark read never resolves', async () => {
+    // Every delivery awaits the seed, so a wedged AsyncStorage read would disable
+    // this host's notifications for the whole app lifetime — silently.
+    getItemImpl = () => new Promise<string | null>(() => {})
+
+    let onData: ((data: unknown) => void) | null = null
+    const client = {
+      subscribe: vi.fn((_m: string, _p: unknown, cb: (data: unknown) => void) => {
+        onData = cb
+        return vi.fn()
+      }),
+      getState: vi.fn(() => 'connected'),
+      sendRequest: vi.fn(async () => ({ ok: true, result: undefined }) as never)
+    } as unknown as RpcClient
+
+    vi.useFakeTimers()
+    try {
+      subscribeToDesktopNotifications(client, 'host-1')
+      onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+      onData?.({
+        type: 'notification',
+        title: 'live-1',
+        body: 'b',
+        notificationId: 'a:1',
+        notificationSeq: 1
+      })
+      await vi.advanceTimersByTimeAsync(3100)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    const titles = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map((call) => (call[0] as { content: { title: string } }).content.title)
+    expect(titles).toContain('live-1')
+  })
+})

--- a/mobile/src/notifications/notification-permissions.ts
+++ b/mobile/src/notifications/notification-permissions.ts
@@ -1,0 +1,36 @@
+import * as Notifications from 'expo-notifications'
+import { Platform } from 'react-native'
+
+// Why: OS notification-permission state, separate from the delivery pipeline in
+// mobile-notifications.ts. Nothing here touches sockets, watermarks, or the
+// scheduled-push registry — it only reflects what the OS currently allows.
+
+export type NotificationPermissionState = {
+  granted: boolean
+  status: string
+  canAskAgain: boolean
+  authorizationReflectsUserChoice: boolean
+}
+
+export async function getNotificationPermissionState(): Promise<NotificationPermissionState> {
+  const { status, canAskAgain } = await Notifications.getPermissionsAsync()
+  return {
+    granted: status === 'granted',
+    status,
+    canAskAgain,
+    // Why: Android <33 has no runtime notification permission, so "granted" is capability, not user consent.
+    authorizationReflectsUserChoice:
+      status === 'granted' && (Platform.OS !== 'android' || Number(Platform.Version) >= 33)
+  }
+}
+
+// Why: re-read OS state every call — users can change it in Settings while Orca is backgrounded.
+export async function ensureNotificationPermissions(): Promise<boolean> {
+  const existing = await getNotificationPermissionState()
+  if (existing.granted) {
+    return true
+  }
+
+  const { status } = await Notifications.requestPermissionsAsync()
+  return status === 'granted'
+}

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -29,20 +29,24 @@ function watermarkStorageKey(hostId: string): string {
 // A null epoch means "the counter this seq came from is unknown" — a legacy
 // watermark, or nothing stored. It can never be assumed to be the live counter.
 export type PersistedWatermark = { seq: number; epoch: string | null }
+// `stored` is the record's existence, independent of its seq: it answers "has this
+// device ever been subscribed to this host", which is what a cold open needs to tell
+// a returning device from a first pairing. A seq of 0 is a real answer, not an absence.
+export type LoadedWatermark = PersistedWatermark & { stored: boolean }
 
 function coerceSeq(value: unknown): number {
   const parsed = typeof value === 'number' ? value : Number(value)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
 }
 
-export async function loadWatermark(hostId: string): Promise<PersistedWatermark> {
+export async function loadWatermark(hostId: string): Promise<LoadedWatermark> {
   try {
     const raw = await AsyncStorage.getItem(watermarkStorageKey(hostId))
     if (raw != null) {
       const parsed = JSON.parse(raw) as { seq?: unknown; epoch?: unknown }
       const epoch =
         typeof parsed.epoch === 'string' && parsed.epoch.length > 0 ? parsed.epoch : null
-      return { seq: coerceSeq(parsed.seq), epoch }
+      return { seq: coerceSeq(parsed.seq), epoch, stored: true }
     }
   } catch {
     // Unreadable or malformed: fall through to the legacy key rather than throw.
@@ -51,18 +55,22 @@ export async function loadWatermark(hostId: string): Promise<PersistedWatermark>
     const legacy = await AsyncStorage.getItem(
       LEGACY_SEQ_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
     )
-    return { seq: coerceSeq(legacy), epoch: null }
+    return { seq: coerceSeq(legacy), epoch: null, stored: legacy != null }
   } catch {
-    return { seq: 0, epoch: null }
+    return { seq: 0, epoch: null, stored: false }
   }
 }
 
 export async function clearWatermark(hostId: string): Promise<void> {
-  try {
-    await AsyncStorage.removeItem(watermarkStorageKey(hostId))
-  } catch {
-    // Best-effort; a surviving key is re-validated by epoch on the next pair anyway.
-  }
+  // Why both keys: loadWatermark falls back to the legacy one, so removing only the
+  // current key would let a re-paired host resurrect a pre-#8591 seq from a counter
+  // lifetime that is long gone — the exact stale cut this fix removes.
+  await Promise.all([
+    AsyncStorage.removeItem(watermarkStorageKey(hostId)).catch(() => {}),
+    AsyncStorage.removeItem(LEGACY_SEQ_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)).catch(
+      () => {}
+    )
+  ])
 }
 
 export async function saveWatermark(hostId: string, watermark: PersistedWatermark): Promise<void> {
@@ -130,10 +138,6 @@ export type HostNotificationSession = {
   seen: ReturnType<typeof createSeenNotificationGuard>
   // False only until the host's first subscription reaches 'ready' — a true cold open.
   connectedBefore: boolean
-  // Why: gates catch-up until the persisted watermark has been read once for this
-  // host. Per host, not per subscription: a reconnect that races the very first
-  // AsyncStorage read would otherwise fetch from seq 0 and re-push the buffer.
-  watermarkLoaded: boolean
   // Why (#8591): distinguishes "this device has delivered for this host before"
   // from a first-ever pairing. Only the former may catch up on a cold open — a
   // brand-new pairing fetching from seq 0 would push the desktop's whole buffer
@@ -154,7 +158,6 @@ export function getHostNotificationSession(hostId: string): HostNotificationSess
       lastDeliveredEpoch: null,
       seen: createSeenNotificationGuard(),
       connectedBefore: false,
-      watermarkLoaded: false,
       hadStoredWatermark: false,
       watermarkSeeded: null
     }
@@ -198,14 +201,15 @@ export function adoptNotificationEpoch(
 // Why: seed the watermark lazily so subscribe() doesn't block on an AsyncStorage read.
 // Only the first subscription for a host needs it; later ones inherit the live value.
 export function seedWatermarkFromStorage(session: HostNotificationSession, hostId: string): void {
-  if (session.watermarkLoaded || session.watermarkSeeded) {
+  if (session.watermarkSeeded) {
     return
   }
-  session.watermarkSeeded = loadWatermark(hostId).then(({ seq, epoch }) => {
-    // Why: a stored seq is the proof this device already delivered for this host —
-    // the signal a cold open needs to tell "catch me up" from "first pairing".
-    // Recorded before the epoch check below, which may legitimately zero the seq.
-    if (seq > 0) {
+  session.watermarkSeeded = loadWatermark(hostId).then(({ seq, epoch, stored }) => {
+    // Why the record's existence and not `seq > 0`: adoptNotificationEpoch persists
+    // `{seq: 0, epoch}` when it voids a watermark, so a device that HAS delivered for
+    // this host reloads as seq 0. Keying on the seq would read that as a first pairing
+    // and skip catch-up for the whole window the epoch change was meant to recover.
+    if (stored) {
       session.hadStoredWatermark = true
     }
     // Why the epoch comparison: this read can land AFTER 'ready' already adopted a
@@ -219,7 +223,6 @@ export function seedWatermarkFromStorage(session: HostNotificationSession, hostI
         session.lastDeliveredEpoch = epoch
       }
     }
-    session.watermarkLoaded = true
   })
 }
 

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -134,6 +134,14 @@ export type HostNotificationSession = {
   // host. Per host, not per subscription: a reconnect that races the very first
   // AsyncStorage read would otherwise fetch from seq 0 and re-push the buffer.
   watermarkLoaded: boolean
+  // Why (#8591): distinguishes "this device has delivered for this host before"
+  // from a first-ever pairing. Only the former may catch up on a cold open — a
+  // brand-new pairing fetching from seq 0 would push the desktop's whole buffer
+  // at someone who was never subscribed for any of it.
+  hadStoredWatermark: boolean
+  // Resolves once the persisted read has landed, so the first 'ready' can wait for
+  // it instead of deciding catch-up against an unread watermark.
+  watermarkSeeded: Promise<void> | null
 }
 
 const sessionsByHost = new Map<string, HostNotificationSession>()
@@ -146,7 +154,9 @@ export function getHostNotificationSession(hostId: string): HostNotificationSess
       lastDeliveredEpoch: null,
       seen: createSeenNotificationGuard(),
       connectedBefore: false,
-      watermarkLoaded: false
+      watermarkLoaded: false,
+      hadStoredWatermark: false,
+      watermarkSeeded: null
     }
     sessionsByHost.set(hostId, session)
   }
@@ -188,10 +198,16 @@ export function adoptNotificationEpoch(
 // Why: seed the watermark lazily so subscribe() doesn't block on an AsyncStorage read.
 // Only the first subscription for a host needs it; later ones inherit the live value.
 export function seedWatermarkFromStorage(session: HostNotificationSession, hostId: string): void {
-  if (session.watermarkLoaded) {
+  if (session.watermarkLoaded || session.watermarkSeeded) {
     return
   }
-  void loadWatermark(hostId).then(({ seq, epoch }) => {
+  session.watermarkSeeded = loadWatermark(hostId).then(({ seq, epoch }) => {
+    // Why: a stored seq is the proof this device already delivered for this host —
+    // the signal a cold open needs to tell "catch me up" from "first pairing".
+    // Recorded before the epoch check below, which may legitimately zero the seq.
+    if (seq > 0) {
+      session.hadStoredWatermark = true
+    }
     // Why the epoch comparison: this read can land AFTER 'ready' already adopted a
     // live epoch. If the stored watermark belongs to a different (older) counter,
     // applying it here would silently reinstate exactly the stale cut this fixes.

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -73,6 +73,46 @@ export function createSeenNotificationGuard(): {
   }
 }
 
+// Why (#8591): app/index.tsx tears the notification subscription down on every
+// non-'connected' state and builds a fresh one on reconnect, so everything held
+// in the subscription closure — the ready counter, the delivered watermark, the
+// seen-set — is destroyed exactly when a reconnect needs it. Keeping it per host
+// at module scope is what makes the catch-up recognise a reconnect (instead of
+// mistaking it for a cold open) and keeps dedup effective across the teardown.
+export type HostNotificationSession = {
+  // Highest desktop seq delivered for this host in this app process. Outranks
+  // the persisted value, which lags because saveLastSeenSeq is fire-and-forget.
+  lastDeliveredSeq: number
+  seen: ReturnType<typeof createSeenNotificationGuard>
+  // False only until the host's first subscription reaches 'ready' — a true cold open.
+  connectedBefore: boolean
+  // Why: gates catch-up until the persisted watermark has been read once for this
+  // host. Per host, not per subscription: a reconnect that races the very first
+  // AsyncStorage read would otherwise fetch from seq 0 and re-push the buffer.
+  watermarkLoaded: boolean
+}
+
+const sessionsByHost = new Map<string, HostNotificationSession>()
+
+export function getHostNotificationSession(hostId: string): HostNotificationSession {
+  let session = sessionsByHost.get(hostId)
+  if (!session) {
+    session = {
+      lastDeliveredSeq: 0,
+      seen: createSeenNotificationGuard(),
+      connectedBefore: false,
+      watermarkLoaded: false
+    }
+    sessionsByHost.set(hostId, session)
+  }
+  return session
+}
+
+/** Test-only: drop per-host session state so each test starts from a cold open. */
+export function resetHostNotificationSessionsForTests(): void {
+  sessionsByHost.clear()
+}
+
 // Why: key for the replay dedup guard. Uses notificationId when present, but
 // disambiguates by seq so a legitimate live re-delivery of the same id at a
 // NEW seq (content refresh, allowed by the existing behaviour) is NOT treated

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -9,58 +9,65 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 // notification we already delivered. The in-memory seen-set is a second guard
 // against double-delivery for events that arrive on both the live stream and a
 // replay (e.g. a brief liveness spell before a reap).
-const LAST_SEQ_STORAGE_KEY_PREFIX = 'orca:mobileNotificationsLastSeq:'
-// Why (#8591): the watermark alone is meaningless after a desktop restart — the
-// counter it indexes is gone. Persist the epoch beside it so a reconnect can tell
-// "nothing missed" from "different counter" and refuse to trust a stale cut.
-const LAST_EPOCH_STORAGE_KEY_PREFIX = 'orca:mobileNotificationsLastEpoch:'
+// Why (#8591): a seq is meaningless without the counter it indexes — after a
+// desktop restart that counter is gone. The epoch names the counter's lifetime so
+// a reconnect can tell "nothing missed" from "different counter".
+//
+// Why ONE key holding both, rather than a key each: they are only meaningful as a
+// pair. Written separately, a process death between the two writes leaves an epoch
+// from one counter beside a seq from another — a pair that looks internally valid
+// on the next launch and is therefore trusted, silently cutting real notifications.
+// A single JSON value cannot tear that way.
+const WATERMARK_STORAGE_KEY_PREFIX = 'orca:mobileNotificationsWatermark:'
+// Pre-#8591 installs wrote the seq alone. Read once to migrate; never written.
+const LEGACY_SEQ_STORAGE_KEY_PREFIX = 'orca:mobileNotificationsLastSeq:'
 
-function lastSeqStorageKey(hostId: string): string {
-  return LAST_SEQ_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
+function watermarkStorageKey(hostId: string): string {
+  return WATERMARK_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
 }
 
-function lastEpochStorageKey(hostId: string): string {
-  return LAST_EPOCH_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
+// A null epoch means "the counter this seq came from is unknown" — a legacy
+// watermark, or nothing stored. It can never be assumed to be the live counter.
+export type PersistedWatermark = { seq: number; epoch: string | null }
+
+function coerceSeq(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
 }
 
-export async function loadLastSeenSeq(hostId: string): Promise<number> {
+export async function loadWatermark(hostId: string): Promise<PersistedWatermark> {
   try {
-    const raw = await AsyncStorage.getItem(lastSeqStorageKey(hostId))
-    const parsed = raw == null ? 0 : Number(raw)
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+    const raw = await AsyncStorage.getItem(watermarkStorageKey(hostId))
+    if (raw != null) {
+      const parsed = JSON.parse(raw) as { seq?: unknown; epoch?: unknown }
+      const epoch =
+        typeof parsed.epoch === 'string' && parsed.epoch.length > 0 ? parsed.epoch : null
+      return { seq: coerceSeq(parsed.seq), epoch }
+    }
   } catch {
-    return 0
+    // Unreadable or malformed: fall through to the legacy key rather than throw.
   }
-}
-
-// Null means "no epoch stored" — a watermark written before this field existed.
-export async function loadLastSeenEpoch(hostId: string): Promise<string | null> {
   try {
-    const raw = await AsyncStorage.getItem(lastEpochStorageKey(hostId))
-    return raw != null && raw.length > 0 ? raw : null
+    const legacy = await AsyncStorage.getItem(
+      LEGACY_SEQ_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
+    )
+    return { seq: coerceSeq(legacy), epoch: null }
   } catch {
-    return null
+    return { seq: 0, epoch: null }
   }
 }
 
-export async function saveLastSeenEpoch(hostId: string, epoch: string): Promise<void> {
-  if (!epoch) {
-    return
-  }
+export async function clearWatermark(hostId: string): Promise<void> {
   try {
-    await AsyncStorage.setItem(lastEpochStorageKey(hostId), epoch)
+    await AsyncStorage.removeItem(watermarkStorageKey(hostId))
   } catch {
-    // Best-effort, same trade-off as saveLastSeenSeq: a lost epoch degrades to the
-    // seq-only cut, never to a wrong one.
+    // Best-effort; a surviving key is re-validated by epoch on the next pair anyway.
   }
 }
 
-export async function saveLastSeenSeq(hostId: string, seq: number): Promise<void> {
-  if (!Number.isFinite(seq) || seq <= 0) {
-    return
-  }
+export async function saveWatermark(hostId: string, watermark: PersistedWatermark): Promise<void> {
   try {
-    await AsyncStorage.setItem(lastSeqStorageKey(hostId), String(seq))
+    await AsyncStorage.setItem(watermarkStorageKey(hostId), JSON.stringify(watermark))
   } catch {
     // Why: persisting the watermark is best-effort. If it fails (or lags), the
     // stored value stays BELOW what we delivered, so a later cold start can
@@ -83,6 +90,7 @@ const RECENTLY_SEEN_CAP = 512
 export function createSeenNotificationGuard(): {
   has: (id: string) => boolean
   add: (id: string) => void
+  clear: () => void
 } {
   const seen = new Set<string>()
   return {
@@ -99,6 +107,9 @@ export function createSeenNotificationGuard(): {
           seen.delete(first)
         }
       }
+    },
+    clear(): void {
+      seen.clear()
     }
   }
 }
@@ -160,12 +171,18 @@ export function adoptNotificationEpoch(
   if (!epoch || epoch === session.lastDeliveredEpoch) {
     return
   }
-  if (session.lastDeliveredEpoch !== null) {
-    // A real epoch change (not first observation): the old watermark is void.
-    session.lastDeliveredSeq = 0
-  }
+  // Why reset on a FIRST observation too (lastDeliveredEpoch === null): a seq seeded
+  // from a legacy store carries no epoch, so it cannot be shown to belong to this
+  // counter. Keeping it would let a pre-upgrade 57 cut the new counter's 1..57 —
+  // the exact #8591 failure, reached through the upgrade path instead of a restart.
+  session.lastDeliveredSeq = 0
+  // Why clear `seen`: its keys are seq-derived, and terminal-bell notifications have
+  // no notificationId at all (they key on `seq:N` alone). Across a restart the new
+  // counter re-issues those same low seqs, so a stale `seq:1` would silently drop
+  // the new counter's first bell. The dedup window belongs to one counter lifetime.
+  session.seen.clear()
   session.lastDeliveredEpoch = epoch
-  void saveLastSeenEpoch(hostId, epoch)
+  void saveWatermark(hostId, { seq: 0, epoch })
 }
 
 // Why: seed the watermark lazily so subscribe() doesn't block on an AsyncStorage read.
@@ -174,21 +191,27 @@ export function seedWatermarkFromStorage(session: HostNotificationSession, hostI
   if (session.watermarkLoaded) {
     return
   }
-  void Promise.all([loadLastSeenSeq(hostId), loadLastSeenEpoch(hostId)]).then(([seq, epoch]) => {
+  void loadWatermark(hostId).then(({ seq, epoch }) => {
     // Why the epoch comparison: this read can land AFTER 'ready' already adopted a
     // live epoch. If the stored watermark belongs to a different (older) counter,
     // applying it here would silently reinstate exactly the stale cut this fixes.
-    // Only a stored epoch matching the live one — or no live one yet — can seed.
-    const storedSeqIsCurrent =
-      session.lastDeliveredEpoch === null || session.lastDeliveredEpoch === epoch
-    if (session.lastDeliveredEpoch === null && epoch !== null) {
-      session.lastDeliveredEpoch = epoch
-    }
-    if (storedSeqIsCurrent) {
+    // A null stored epoch is a legacy watermark of unknown provenance — it may only
+    // seed while no live epoch is known, and adopting one later resets it.
+    if (session.lastDeliveredEpoch === null || session.lastDeliveredEpoch === epoch) {
       session.lastDeliveredSeq = Math.max(session.lastDeliveredSeq, seq)
+      if (session.lastDeliveredEpoch === null && epoch !== null) {
+        session.lastDeliveredEpoch = epoch
+      }
     }
     session.watermarkLoaded = true
   })
+}
+
+// Why (#8591): sessions live at module scope so they survive the subscription
+// teardown a reconnect performs. Nothing else drops them, so a host that is removed
+// and re-paired would retain its session and up to 512 seen keys until app restart.
+export function forgetHostNotificationSession(hostId: string): void {
+  sessionsByHost.delete(hostId)
 }
 
 // Why: key for the replay dedup guard. Uses notificationId when present, but

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -10,9 +10,17 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 // against double-delivery for events that arrive on both the live stream and a
 // replay (e.g. a brief liveness spell before a reap).
 const LAST_SEQ_STORAGE_KEY_PREFIX = 'orca:mobileNotificationsLastSeq:'
+// Why (#8591): the watermark alone is meaningless after a desktop restart — the
+// counter it indexes is gone. Persist the epoch beside it so a reconnect can tell
+// "nothing missed" from "different counter" and refuse to trust a stale cut.
+const LAST_EPOCH_STORAGE_KEY_PREFIX = 'orca:mobileNotificationsLastEpoch:'
 
 function lastSeqStorageKey(hostId: string): string {
   return LAST_SEQ_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
+}
+
+function lastEpochStorageKey(hostId: string): string {
+  return LAST_EPOCH_STORAGE_KEY_PREFIX + encodeURIComponent(hostId)
 }
 
 export async function loadLastSeenSeq(hostId: string): Promise<number> {
@@ -22,6 +30,28 @@ export async function loadLastSeenSeq(hostId: string): Promise<number> {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
   } catch {
     return 0
+  }
+}
+
+// Null means "no epoch stored" — a watermark written before this field existed.
+export async function loadLastSeenEpoch(hostId: string): Promise<string | null> {
+  try {
+    const raw = await AsyncStorage.getItem(lastEpochStorageKey(hostId))
+    return raw != null && raw.length > 0 ? raw : null
+  } catch {
+    return null
+  }
+}
+
+export async function saveLastSeenEpoch(hostId: string, epoch: string): Promise<void> {
+  if (!epoch) {
+    return
+  }
+  try {
+    await AsyncStorage.setItem(lastEpochStorageKey(hostId), epoch)
+  } catch {
+    // Best-effort, same trade-off as saveLastSeenSeq: a lost epoch degrades to the
+    // seq-only cut, never to a wrong one.
   }
 }
 
@@ -83,6 +113,9 @@ export type HostNotificationSession = {
   // Highest desktop seq delivered for this host in this app process. Outranks
   // the persisted value, which lags because saveLastSeenSeq is fire-and-forget.
   lastDeliveredSeq: number
+  // Counter lifetime lastDeliveredSeq belongs to; null until one is known. A
+  // mismatch on reconnect means the desktop restarted and the watermark is void.
+  lastDeliveredEpoch: string | null
   seen: ReturnType<typeof createSeenNotificationGuard>
   // False only until the host's first subscription reaches 'ready' — a true cold open.
   connectedBefore: boolean
@@ -99,6 +132,7 @@ export function getHostNotificationSession(hostId: string): HostNotificationSess
   if (!session) {
     session = {
       lastDeliveredSeq: 0,
+      lastDeliveredEpoch: null,
       seen: createSeenNotificationGuard(),
       connectedBefore: false,
       watermarkLoaded: false
@@ -111,6 +145,50 @@ export function getHostNotificationSession(hostId: string): HostNotificationSess
 /** Test-only: drop per-host session state so each test starts from a cold open. */
 export function resetHostNotificationSessionsForTests(): void {
   sessionsByHost.clear()
+}
+
+// Why (#8591): the desktop's seq counter restarts at 0 every launch, so a watermark
+// from a previous lifetime indexes a counter that no longer exists. Comparing it
+// against the fresh counter makes `lastSeenSeq >= seq` true for everything and
+// catch-up dies silently until the new process out-dispatches the old watermark.
+// Adopting the new epoch means dropping the watermark with it.
+export function adoptNotificationEpoch(
+  session: HostNotificationSession,
+  hostId: string,
+  epoch: string | undefined
+): void {
+  if (!epoch || epoch === session.lastDeliveredEpoch) {
+    return
+  }
+  if (session.lastDeliveredEpoch !== null) {
+    // A real epoch change (not first observation): the old watermark is void.
+    session.lastDeliveredSeq = 0
+  }
+  session.lastDeliveredEpoch = epoch
+  void saveLastSeenEpoch(hostId, epoch)
+}
+
+// Why: seed the watermark lazily so subscribe() doesn't block on an AsyncStorage read.
+// Only the first subscription for a host needs it; later ones inherit the live value.
+export function seedWatermarkFromStorage(session: HostNotificationSession, hostId: string): void {
+  if (session.watermarkLoaded) {
+    return
+  }
+  void Promise.all([loadLastSeenSeq(hostId), loadLastSeenEpoch(hostId)]).then(([seq, epoch]) => {
+    // Why the epoch comparison: this read can land AFTER 'ready' already adopted a
+    // live epoch. If the stored watermark belongs to a different (older) counter,
+    // applying it here would silently reinstate exactly the stale cut this fixes.
+    // Only a stored epoch matching the live one — or no live one yet — can seed.
+    const storedSeqIsCurrent =
+      session.lastDeliveredEpoch === null || session.lastDeliveredEpoch === epoch
+    if (session.lastDeliveredEpoch === null && epoch !== null) {
+      session.lastDeliveredEpoch = epoch
+    }
+    if (storedSeqIsCurrent) {
+      session.lastDeliveredSeq = Math.max(session.lastDeliveredSeq, seq)
+    }
+    session.watermarkLoaded = true
+  })
 }
 
 // Why: key for the replay dedup guard. Uses notificationId when present, but

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -146,6 +146,11 @@ export type HostNotificationSession = {
   // Resolves once the persisted read has landed, so the first 'ready' can wait for
   // it instead of deciding catch-up against an unread watermark.
   watermarkSeeded: Promise<void> | null
+  // Tail of the per-host delivery chain; see enqueueHostDelivery.
+  deliveryTail: Promise<void>
+  // notificationIds with a show queued or in flight on that chain; see
+  // shouldQueueShowForNotificationId.
+  queuedShowIds: Set<string>
 }
 
 const sessionsByHost = new Map<string, HostNotificationSession>()
@@ -159,11 +164,74 @@ export function getHostNotificationSession(hostId: string): HostNotificationSess
       seen: createSeenNotificationGuard(),
       connectedBefore: false,
       hadStoredWatermark: false,
-      watermarkSeeded: null
+      watermarkSeeded: null,
+      deliveryTail: Promise.resolve(),
+      queuedShowIds: new Set<string>()
     }
     sessionsByHost.set(hostId, session)
   }
   return session
+}
+
+/**
+ * Run `task` after every delivery already queued for this host, and return a
+ * promise for its completion.
+ *
+ * Why (#8591): the watermark is persisted by whichever delivery advances it, so
+ * replay and live delivery running concurrently can persist out of order. A live
+ * seq 11 handled while catch-up is still showing seq 6 writes watermark 11, and a
+ * process death before 7..10 are shown loses them permanently — the next launch
+ * asks the desktop for seq > 11. Serializing per host makes the watermark's
+ * monotonic advance mean "everything up to here was actually delivered".
+ *
+ * A rejected task does not break the chain: the tail swallows the failure so a
+ * single bad notification cannot wedge the host's queue forever.
+ */
+export function enqueueHostDelivery(
+  session: HostNotificationSession,
+  task: () => Promise<void>
+): Promise<void> {
+  const run = session.deliveryTail.then(task)
+  session.deliveryTail = run.catch(() => {})
+  return run
+}
+
+/**
+ * Claim a notificationId for a queued show, returning false if one is already
+ * queued or in flight for it.
+ *
+ * Why this exists (#8591): showLocalNotification deduped two same-id events by
+ * observing that the first was still pending when the second arrived. Serializing
+ * deliveries removed that overlap — the first now COMPLETES before the second
+ * starts, so the second reads no pending state and schedules a second banner for
+ * the same notification. The dedup has to happen where concurrency is still
+ * visible, which after serialization is enqueue time rather than delivery time.
+ *
+ * Only shows are tracked. A dismiss for the same id must still run: it is the
+ * mechanism that retires the notification the show created.
+ */
+export function shouldQueueShowForNotificationId(
+  session: HostNotificationSession,
+  notificationId: string | undefined
+): boolean {
+  if (notificationId == null) {
+    return true
+  }
+  if (session.queuedShowIds.has(notificationId)) {
+    return false
+  }
+  session.queuedShowIds.add(notificationId)
+  return true
+}
+
+/** Release the claim taken by shouldQueueShowForNotificationId once the show settles. */
+export function releaseQueuedShowNotificationId(
+  session: HostNotificationSession,
+  notificationId: string | undefined
+): void {
+  if (notificationId != null) {
+    session.queuedShowIds.delete(notificationId)
+  }
 }
 
 /** Test-only: drop per-host session state so each test starts from a cold open. */
@@ -200,11 +268,40 @@ export function adoptNotificationEpoch(
 
 // Why: seed the watermark lazily so subscribe() doesn't block on an AsyncStorage read.
 // Only the first subscription for a host needs it; later ones inherit the live value.
+/**
+ * Ms the persisted read may block catch-up and live delivery before they proceed
+ * without it. AsyncStorage normally answers in single-digit ms; a read that has
+ * not landed by now is assumed wedged.
+ *
+ * Why a bound at all (#8591): every delivery awaits this promise, so a read that
+ * never settles silently disables notifications for the host for the whole app
+ * lifetime — no error, no banner, nothing to see. Proceeding unseeded is strictly
+ * better: the watermark stays 0, so catch-up over-fetches and the seen-set
+ * de-duplicates, which costs a redundant request instead of every notification.
+ */
+const WATERMARK_SEED_TIMEOUT_MS = 3000
+
+function withTimeout(promise: Promise<void>, ms: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms)
+    void promise.then(
+      () => {
+        clearTimeout(timer)
+        resolve()
+      },
+      () => {
+        clearTimeout(timer)
+        resolve()
+      }
+    )
+  })
+}
+
 export function seedWatermarkFromStorage(session: HostNotificationSession, hostId: string): void {
   if (session.watermarkSeeded) {
     return
   }
-  session.watermarkSeeded = loadWatermark(hostId).then(({ seq, epoch, stored }) => {
+  const seeded = loadWatermark(hostId).then(({ seq, epoch, stored }) => {
     // Why the record's existence and not `seq > 0`: adoptNotificationEpoch persists
     // `{seq: 0, epoch}` when it voids a watermark, so a device that HAS delivered for
     // this host reloads as seq 0. Keying on the seq would read that as a first pairing
@@ -224,6 +321,9 @@ export function seedWatermarkFromStorage(session: HostNotificationSession, hostI
       }
     }
   })
+  // The late seed still applies when it eventually lands; the timeout only stops it
+  // from holding delivery hostage. `seeded` never rejects into the awaiters.
+  session.watermarkSeeded = withTimeout(seeded, WATERMARK_SEED_TIMEOUT_MS)
 }
 
 // Why (#8591): sessions live at module scope so they survive the subscription

--- a/mobile/src/notifications/notification-reconnect-teardown.test.ts
+++ b/mobile/src/notifications/notification-reconnect-teardown.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Notifications from 'expo-notifications'
+import { subscribeToDesktopNotifications } from './mobile-notifications'
+import { resetHostNotificationSessionsForTests } from './notification-reconnect-catchup'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import type { RpcClient } from '../transport/rpc-client'
+import { loadPushNotificationsEnabled } from '../storage/preferences'
+
+vi.mock('expo-notifications', () => ({
+  AndroidImportance: { HIGH: 'high' },
+  setNotificationChannelAsync: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  scheduleNotificationAsync: vi.fn(),
+  dismissNotificationAsync: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', Version: 18 }
+}))
+
+// In-memory AsyncStorage so the persisted watermark survives across the
+// subscribe/unsubscribe cycles this test exercises (the real device behaviour).
+const storage = new Map<string, string>()
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(async (k: string) => storage.get(k) ?? null),
+    setItem: vi.fn(async (k: string, v: string) => {
+      storage.set(k, v)
+    })
+  }
+}))
+
+vi.mock('../storage/preferences', () => ({
+  loadPushNotificationsEnabled: vi.fn()
+}))
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 10)
+  })
+}
+
+// Models mobile/app/index.tsx:497-537: a per-host client whose notification
+// subscription is torn down on any non-'connected' state and re-created from
+// scratch on the next 'connected'.
+function makeHostClient() {
+  let onData: ((data: unknown) => void) | null = null
+  const getMissedCalls: { lastSeenSeq: number }[] = []
+  const client = {
+    subscribe: vi.fn((_m: string, _p: unknown, cb: (data: unknown) => void) => {
+      onData = cb
+      return vi.fn(() => {
+        onData = null
+      })
+    }),
+    getState: vi.fn(() => 'connected'),
+    sendRequest: vi.fn(async (method: string, params: unknown = {}) => {
+      if (method === 'notifications.getMissedSince') {
+        getMissedCalls.push(params as { lastSeenSeq: number })
+        return { ok: true, result: { notifications: missedQueue } } as never
+      }
+      return { ok: true, result: undefined } as never
+    })
+  }
+  let missedQueue: unknown[] = []
+  return {
+    client: client as unknown as RpcClient,
+    get onData() {
+      return onData
+    },
+    getMissedCalls,
+    setMissed(events: unknown[]) {
+      missedQueue = events
+    }
+  }
+}
+
+describe('#8591 reconnect catch-up under the real app teardown lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storage.clear()
+    resetHostNotificationSessionsForTests()
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('sched-1')
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+    vi.mocked(AsyncStorage.getItem).mockClear()
+  })
+
+  it('fetches missed notifications after a disconnect tears the subscription down', async () => {
+    const host = makeHostClient()
+
+    // ── Connected: cold open, one live notification delivered (desktop seq 7).
+    const unsub = subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    host.onData?.({
+      type: 'notification',
+      title: 'live',
+      body: 'b',
+      notificationId: 'agent:live',
+      notificationSeq: 7
+    })
+    await flushAsync()
+
+    // ── Socket drops. app/index.tsx wireUp() calls unsubNotif() on the
+    // non-'connected' state, destroying the subscribeToDesktopNotifications
+    // closure (and with it reconnectReadyCount / lastDeliveredSeq).
+    unsub()
+    await flushAsync()
+
+    // ── While disconnected the desktop dispatched seq 8 and 9.
+    host.setMissed([
+      {
+        type: 'notification',
+        title: 'missed-8',
+        body: 'b',
+        notificationId: 'agent:m8',
+        notificationSeq: 8
+      },
+      {
+        type: 'notification',
+        title: 'missed-9',
+        body: 'b',
+        notificationId: 'agent:m9',
+        notificationSeq: 9
+      }
+    ])
+
+    // ── Reconnected: app re-subscribes with a FRESH closure.
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-2' })
+    await flushAsync()
+
+    // The user must be told about seq 8 and 9. Nothing else can deliver them:
+    // the desktop only fans out live, so this catch-up is the only path.
+    expect(host.getMissedCalls).toHaveLength(1)
+    expect(host.getMissedCalls[0]).toEqual({ lastSeenSeq: 7 })
+    const titles = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map((c) => (c[0] as { content: { title: string } }).content.title)
+    expect(titles).toContain('missed-8')
+    expect(titles).toContain('missed-9')
+  })
+})

--- a/mobile/src/notifications/notification-reconnect-teardown.test.ts
+++ b/mobile/src/notifications/notification-reconnect-teardown.test.ts
@@ -146,4 +146,56 @@ describe('#8591 reconnect catch-up under the real app teardown lifecycle', () =>
     expect(titles).toContain('missed-8')
     expect(titles).toContain('missed-9')
   })
+
+  it('does not re-push a live notification the catch-up replays after a teardown', async () => {
+    // Why: the seen-set lives on the host session precisely so it survives the teardown.
+    // getMissedSince cuts by seq > lastSeenSeq, but a notification delivered live in the
+    // brief window before the drop is still inside the desktop's retained buffer, so the
+    // reconnect fetch returns it again. Only the session-scoped seen-set stops a duplicate
+    // banner for something the user was already shown.
+    const host = makeHostClient()
+
+    const unsub = subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1' })
+    await flushAsync()
+    host.onData?.({
+      type: 'notification',
+      title: 'live-7',
+      body: 'b',
+      notificationId: 'agent:seven',
+      notificationSeq: 7
+    })
+    await flushAsync()
+
+    unsub()
+    await flushAsync()
+
+    // The desktop replays seq 7 alongside the genuinely-missed seq 8.
+    host.setMissed([
+      {
+        type: 'notification',
+        title: 'live-7',
+        body: 'b',
+        notificationId: 'agent:seven',
+        notificationSeq: 7
+      },
+      {
+        type: 'notification',
+        title: 'missed-8',
+        body: 'b',
+        notificationId: 'agent:m8',
+        notificationSeq: 8
+      }
+    ])
+
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-2' })
+    await flushAsync()
+
+    const titles = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map((c) => (c[0] as { content: { title: string } }).content.title)
+    expect(titles.filter((title) => title === 'live-7')).toHaveLength(1)
+    expect(titles).toContain('missed-8')
+  })
 })

--- a/mobile/src/notifications/notification-watermark-seed-race.test.ts
+++ b/mobile/src/notifications/notification-watermark-seed-race.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Notifications from 'expo-notifications'
+import { subscribeToDesktopNotifications } from './mobile-notifications'
+import {
+  clearWatermark,
+  resetHostNotificationSessionsForTests
+} from './notification-reconnect-catchup'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import type { RpcClient } from '../transport/rpc-client'
+import { loadPushNotificationsEnabled } from '../storage/preferences'
+
+vi.mock('expo-notifications', () => ({
+  AndroidImportance: { HIGH: 'high' },
+  setNotificationChannelAsync: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  scheduleNotificationAsync: vi.fn(),
+  dismissNotificationAsync: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', Version: 18 }
+}))
+
+// A storage whose reads can be held open, so a live event can be injected into the
+// exact window a real cold open has: subscription up, persisted watermark not yet read.
+const storage = new Map<string, string>()
+let heldReads: (() => void)[] = []
+let holdReads = false
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn((key: string) => {
+      const read = (): string | null => storage.get(key) ?? null
+      if (!holdReads) {
+        return Promise.resolve(read())
+      }
+      return new Promise<string | null>((resolve) => {
+        heldReads.push(() => resolve(read()))
+      })
+    }),
+    setItem: vi.fn(async (key: string, value: string) => {
+      storage.set(key, value)
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      storage.delete(key)
+    })
+  }
+}))
+
+vi.mock('../storage/preferences', () => ({
+  loadPushNotificationsEnabled: vi.fn()
+}))
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 10)
+  })
+}
+
+function releaseReads(): void {
+  const pending = heldReads
+  heldReads = []
+  for (const resolve of pending) {
+    resolve()
+  }
+}
+
+function makeHostClient() {
+  let onData: ((data: unknown) => void) | null = null
+  const getMissedCalls: { lastSeenSeq: number; epoch?: string }[] = []
+  const client = {
+    subscribe: vi.fn((_m: string, _p: unknown, cb: (data: unknown) => void) => {
+      onData = cb
+      return vi.fn(() => {
+        onData = null
+      })
+    }),
+    getState: vi.fn(() => 'connected'),
+    sendRequest: vi.fn(async (method: string, params: unknown = {}) => {
+      if (method === 'notifications.getMissedSince') {
+        getMissedCalls.push(params as { lastSeenSeq: number; epoch?: string })
+        return { ok: true, result: { notifications: [] } } as never
+      }
+      return { ok: true, result: undefined } as never
+    })
+  }
+  return {
+    client: client as unknown as RpcClient,
+    get onData() {
+      return onData
+    },
+    getMissedCalls
+  }
+}
+
+const WATERMARK_KEY = 'orca:mobileNotificationsWatermark:host-1'
+const LEGACY_KEY = 'orca:mobileNotificationsLastSeq:host-1'
+
+describe('#8591 watermark seeding races a cold open', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storage.clear()
+    heldReads = []
+    holdReads = false
+    resetHostNotificationSessionsForTests()
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('sched-1')
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+  })
+
+  it('asks for catch-up from the persisted seq even if a live event lands first', async () => {
+    // The window is real: app/index.tsx subscribes immediately, and the desktop's
+    // 'ready' plus its first live fan-out can both beat an AsyncStorage read. If the
+    // live seq is allowed to advance the watermark first, getMissedSince is asked to
+    // start from it and the desktop cuts everything the device actually missed.
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 5, epoch: 'epoch-a' }))
+    holdReads = true
+    const host = makeHostClient()
+
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-a' })
+    host.onData?.({
+      type: 'notification',
+      title: 'live-12',
+      body: 'b',
+      notificationId: 'agent:live',
+      notificationSeq: 12,
+      notificationEpoch: 'epoch-a'
+    })
+    await flushAsync()
+
+    // Nothing may be decided while the read is outstanding.
+    expect(host.getMissedCalls).toHaveLength(0)
+
+    releaseReads()
+    await flushAsync()
+
+    expect(host.getMissedCalls).toEqual([{ lastSeenSeq: 5, epoch: 'epoch-a' }])
+  })
+
+  it('treats a zeroed-but-present watermark as a returning device, not a first pairing', async () => {
+    // adoptNotificationEpoch persists {seq: 0, epoch} when it voids a watermark from a
+    // dead counter. That record still proves this device has been subscribed here, so a
+    // cold open after it must catch up — reading it as "never paired" drops the window.
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 0, epoch: 'epoch-a' }))
+    const host = makeHostClient()
+
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-a' })
+    await flushAsync()
+
+    expect(host.getMissedCalls).toEqual([{ lastSeenSeq: 0, epoch: 'epoch-a' }])
+  })
+
+  it('does not catch up on a first-ever pairing', async () => {
+    const host = makeHostClient()
+
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-a' })
+    await flushAsync()
+
+    expect(host.getMissedCalls).toEqual([])
+  })
+
+  it('clears the legacy seq key too, so an unpaired host cannot resurrect it', async () => {
+    // loadWatermark falls back to the legacy key, so leaving it behind lets a re-paired
+    // host read a pre-#8591 seq belonging to a counter lifetime that no longer exists.
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 9, epoch: 'epoch-a' }))
+    storage.set(LEGACY_KEY, '57')
+
+    await clearWatermark('host-1')
+
+    expect(vi.mocked(AsyncStorage.removeItem).mock.calls.map((call) => call[0])).toEqual(
+      expect.arrayContaining([WATERMARK_KEY, LEGACY_KEY])
+    )
+    expect(storage.has(WATERMARK_KEY)).toBe(false)
+    expect(storage.has(LEGACY_KEY)).toBe(false)
+  })
+})

--- a/mobile/src/notifications/notification-watermark-seed-race.test.ts
+++ b/mobile/src/notifications/notification-watermark-seed-race.test.ts
@@ -2,8 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as Notifications from 'expo-notifications'
 import { subscribeToDesktopNotifications } from './mobile-notifications'
 import {
+  adoptNotificationEpoch,
   clearWatermark,
-  resetHostNotificationSessionsForTests
+  getHostNotificationSession,
+  resetHostNotificationSessionsForTests,
+  seedWatermarkFromStorage
 } from './notification-reconnect-catchup'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { RpcClient } from '../transport/rpc-client'
@@ -164,6 +167,26 @@ describe('#8591 watermark seeding races a cold open', () => {
     await flushAsync()
 
     expect(host.getMissedCalls).toEqual([])
+  })
+
+  it('a seed landing after a live epoch is adopted cannot reinstate the dead watermark', async () => {
+    // Ordering invariant on the exported pair, not a path subscribeToDesktopNotifications
+    // can currently take — 'ready' awaits watermarkSeeded before adopting, so the seed
+    // always resolves first today. Pinned anyway because the guard is load-bearing the
+    // moment any caller adopts an epoch before seeding: applying a seq 40 from a counter
+    // that no longer exists would let getMissedSince cut the new counter's 1..40, which
+    // is the original #8591 loss re-entered through the seeding path.
+    const session = getHostNotificationSession('host-1')
+    adoptNotificationEpoch(session, 'host-1', 'epoch-new')
+    await flushAsync()
+
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 40, epoch: 'epoch-old' }))
+    seedWatermarkFromStorage(session, 'host-1')
+    await session.watermarkSeeded
+    await flushAsync()
+
+    expect(session.lastDeliveredEpoch).toBe('epoch-new')
+    expect(session.lastDeliveredSeq).toBe(0)
   })
 
   it('clears the legacy seq key too, so an unpaired host cannot resurrect it', async () => {

--- a/mobile/src/transport/host-removal-lifecycle.test.ts
+++ b/mobile/src/transport/host-removal-lifecycle.test.ts
@@ -7,10 +7,15 @@ vi.mock('./host-store', () => ({
 }))
 
 import { removeHostAndCloseClient } from './host-removal-lifecycle'
+import {
+  getHostNotificationSession,
+  resetHostNotificationSessionsForTests
+} from '../notifications/notification-reconnect-catchup'
 
 describe('host removal lifecycle', () => {
   beforeEach(() => {
     removeHostMock.mockReset()
+    resetHostNotificationSessionsForTests()
   })
 
   it('closes the client only after metadata removal commits', async () => {
@@ -38,5 +43,24 @@ describe('host removal lifecycle', () => {
       'storage unavailable'
     )
     expect(closeHostClient).not.toHaveBeenCalled()
+  })
+
+  it('retires the notification session so a removed host leaves nothing behind', async () => {
+    // Round-1 review finding: the session lives at module scope (it must survive the
+    // subscription teardown a reconnect performs), so removal is the only thing that
+    // can retire it. Left behind, each remove/re-pair cycle strands a session plus up
+    // to 512 seen keys, and a re-paired host inherits a watermark it never earned.
+    removeHostMock.mockResolvedValue(undefined)
+    const session = getHostNotificationSession('host-1')
+    session.lastDeliveredSeq = 42
+    session.lastDeliveredEpoch = 'epoch-A'
+
+    await removeHostAndCloseClient('host-1', vi.fn())
+
+    // A fresh session for the same id — not the retained one.
+    const afterRemoval = getHostNotificationSession('host-1')
+    expect(afterRemoval).not.toBe(session)
+    expect(afterRemoval.lastDeliveredSeq).toBe(0)
+    expect(afterRemoval.lastDeliveredEpoch).toBeNull()
   })
 })

--- a/mobile/src/transport/host-removal-lifecycle.test.ts
+++ b/mobile/src/transport/host-removal-lifecycle.test.ts
@@ -1,6 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const removeHostMock = vi.hoisted(() => vi.fn())
+const asyncStorage = vi.hoisted(() => ({
+  getItem: vi.fn(async () => null),
+  setItem: vi.fn(async () => undefined),
+  // Why removeItem is here: clearWatermark() swallows its own failures, so a mock
+  // missing this method turns the persisted-watermark cleanup into a caught
+  // TypeError — the assertion below would pass even if the call were deleted.
+  removeItem: vi.fn(async () => undefined)
+}))
+
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: asyncStorage }))
 
 vi.mock('./host-store', () => ({
   removeHost: (hostId: string) => removeHostMock(hostId)
@@ -15,6 +25,7 @@ import {
 describe('host removal lifecycle', () => {
   beforeEach(() => {
     removeHostMock.mockReset()
+    asyncStorage.removeItem.mockClear()
     resetHostNotificationSessionsForTests()
   })
 
@@ -62,5 +73,19 @@ describe('host removal lifecycle', () => {
     expect(afterRemoval).not.toBe(session)
     expect(afterRemoval.lastDeliveredSeq).toBe(0)
     expect(afterRemoval.lastDeliveredEpoch).toBeNull()
+  })
+
+  it('erases the persisted watermark, not just the in-memory session', async () => {
+    // Why separately from the test above: the session is process-local, the
+    // watermark is not. Retiring only the session lets a re-pair of the same host
+    // read the old seq off disk and resume against a counter it never saw — the
+    // catch-up would then start above the real cut and drop everything below it.
+    removeHostMock.mockResolvedValue(undefined)
+
+    await removeHostAndCloseClient('host-1', vi.fn())
+    // clearWatermark is fire-and-forget; let its microtask land.
+    await Promise.resolve()
+
+    expect(asyncStorage.removeItem).toHaveBeenCalledWith('orca:mobileNotificationsWatermark:host-1')
   })
 })

--- a/mobile/src/transport/host-removal-lifecycle.ts
+++ b/mobile/src/transport/host-removal-lifecycle.ts
@@ -1,3 +1,7 @@
+import {
+  clearWatermark,
+  forgetHostNotificationSession
+} from '../notifications/notification-reconnect-catchup'
 import { removeHost } from './host-store'
 
 export async function removeHostAndCloseClient(
@@ -8,4 +12,9 @@ export async function removeHostAndCloseClient(
   // storage failure; closing immediately after success prevents socket leaks.
   await removeHost(hostId)
   closeHostClient(hostId)
+  // Why: the notification session outlives the socket by design (it must survive
+  // reconnects), so removal is the only thing that can retire it. Left behind, a
+  // re-pair of the same host would inherit a watermark for a counter it never saw.
+  forgetHostNotificationSession(hostId)
+  void clearWatermark(hostId)
 }

--- a/src/main/runtime/mobile-notification-replay.test.ts
+++ b/src/main/runtime/mobile-notification-replay.test.ts
@@ -102,6 +102,51 @@ describe('MobileNotificationReplayBuffer', () => {
     ])
   })
 
+  it('returns the retained buffer when the watermark came from a previous desktop run', () => {
+    // The #8591 defect: `seq` is per-process and restarts at 0 every launch, but the
+    // client's watermark is persisted. A client holding seq 57 meets a counter at 2,
+    // `57 >= 2` cuts everything, and catch-up stays dead until the new process
+    // dispatches 57 notifications. The epoch is what makes the two distinguishable.
+    const previousRun = new MobileNotificationReplayBuffer()
+    for (let i = 0; i < 57; i++) {
+      dispatch(previousRun, { notificationId: `old:${i}` })
+    }
+    const staleWatermark = 57
+    const staleEpoch = previousRun.epoch
+
+    const afterRestart = new MobileNotificationReplayBuffer()
+    dispatch(afterRestart, { notificationId: 'agent:one' })
+    dispatch(afterRestart, { notificationId: 'agent:two' })
+
+    // Seq-only (the old behaviour) still silently drops everything...
+    expect(afterRestart.getMissedSince(staleWatermark)).toEqual([])
+    // ...but a watermark tagged with the old epoch is recognised as void.
+    expect(
+      afterRestart.getMissedSince(staleWatermark, staleEpoch).map((e) => e.notificationId)
+    ).toEqual(['agent:one', 'agent:two'])
+  })
+
+  it('keeps the exact seq cut when the epoch matches the live counter', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const first = dispatch(buffer, { notificationId: 'agent:one' })
+    dispatch(buffer, { notificationId: 'agent:two' })
+
+    // Same counter: the epoch must not widen the cut into a re-push of delivered events.
+    expect(
+      buffer.getMissedSince(first.notificationSeq, buffer.epoch).map((e) => e.notificationId)
+    ).toEqual(['agent:two'])
+    expect(buffer.getMissedSince(2, buffer.epoch)).toEqual([])
+  })
+
+  it('stamps every recorded event with the buffer epoch, and epochs differ per process', () => {
+    const buffer = new MobileNotificationReplayBuffer()
+    const event = dispatch(buffer, { notificationId: 'agent:one' })
+
+    expect(event.notificationEpoch).toBe(buffer.epoch)
+    // A restart must produce a different epoch or the watermark stays ambiguous.
+    expect(new MobileNotificationReplayBuffer().epoch).not.toBe(buffer.epoch)
+  })
+
   it('evicts oldest entries once the capacity is exceeded', () => {
     const buffer = new MobileNotificationReplayBuffer(2)
     dispatch(buffer, { notificationId: 'agent:one' })

--- a/src/main/runtime/mobile-notification-replay.ts
+++ b/src/main/runtime/mobile-notification-replay.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import type { MobileNotificationEvent } from './orca-runtime'
 
 // Why: when a mobile client's socket is reaped (background/sleep, or a warm
@@ -22,6 +23,9 @@ import type { MobileNotificationEvent } from './orca-runtime'
 // single field name end-to-end is what makes live and replay interchangeable.
 export type ReplayableMobileNotification = MobileNotificationEvent & {
   notificationSeq: number
+  // The counter lifetime `notificationSeq` belongs to. Lets a client tell "seq 3
+  // is older than my watermark" from "seq 3 came from a counter I've never seen".
+  notificationEpoch: string
 }
 
 // Why: bound the buffer. 256 completes a few minutes of real agent activity and
@@ -35,9 +39,20 @@ export class MobileNotificationReplayBuffer {
   private readonly capacity: number
   private seq = 0
   private readonly buffer: ReplayableMobileNotification[] = []
+  // Why: `seq` restarts at 0 every desktop launch, but the client's watermark is
+  // persisted and monotonic. After a desktop restart a client holding seq 57 meets
+  // a counter at 3, `57 >= 3` cuts everything, and catch-up stays silently dead
+  // until the new process dispatches 57 notifications. The epoch names the counter's
+  // lifetime so both sides can tell "nothing missed" from "different counter".
+  private readonly epochId: string = randomUUID()
 
   constructor(capacity: number = DEFAULT_CAPACITY) {
     this.capacity = capacity
+  }
+
+  // Identifies this counter's lifetime. Changes on every desktop restart.
+  get epoch(): string {
+    return this.epochId
   }
 
   // Records a dispatched event and returns the monotonic seq assigned to it.
@@ -45,7 +60,7 @@ export class MobileNotificationReplayBuffer {
   // (both on the live fan-out and on explicit catch-up requests).
   record(event: MobileNotificationEvent): number {
     const seq = ++this.seq
-    this.buffer.push({ ...event, notificationSeq: seq })
+    this.buffer.push({ ...event, notificationSeq: seq, notificationEpoch: this.epochId })
     if (this.buffer.length > this.capacity) {
       // Why: insertion-order array; oldest entries sit at the front.
       this.buffer.splice(0, this.buffer.length - this.capacity)
@@ -56,7 +71,16 @@ export class MobileNotificationReplayBuffer {
   // Returns every recorded event with seq strictly greater than lastSeenSeq.
   // Because seq is monotonic and global, this is an exact, idempotent cut:
   // the same lastSeenSeq always yields the same result.
-  getMissedSince(lastSeenSeq: number): ReplayableMobileNotification[] {
+  //
+  // `epoch` is the counter lifetime the caller's watermark came from. A mismatch
+  // means the watermark indexes a counter this process no longer has, so it is
+  // meaningless here and the whole retained buffer is returned instead — every
+  // entry in it postdates the restart, so none can have reached that client.
+  // Omitting `epoch` keeps the seq-only cut, for clients that predate the field.
+  getMissedSince(lastSeenSeq: number, epoch?: string): ReplayableMobileNotification[] {
+    if (epoch !== undefined && epoch !== this.epochId) {
+      return [...this.buffer]
+    }
     if (lastSeenSeq >= this.seq) {
       return []
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2352,12 +2352,14 @@ export type MobileNotificationDispatchEvent = {
   worktreeId?: string
   notificationId?: string
   notificationSeq?: number
+  notificationEpoch?: string
 }
 
 export type MobileNotificationDismissEvent = {
   type: 'dismiss'
   notificationId: string
   notificationSeq?: number
+  notificationEpoch?: string
 }
 
 export type MobileNotificationEvent =
@@ -9991,7 +9993,12 @@ export class OrcaRuntimeService {
     // delivered and feed it back to getMissedSince on reconnect (idempotent catch-up, no dupes).
     notifyRuntimeListeners(
       this.notificationListeners,
-      (listener) => listener({ ...event, notificationSeq: seq }),
+      (listener) =>
+        listener({
+          ...event,
+          notificationSeq: seq,
+          notificationEpoch: this.mobileNotificationReplay.epoch
+        }),
       'mobile-notification'
     )
   }
@@ -9999,8 +10006,15 @@ export class OrcaRuntimeService {
   // Returns notifications dispatched after lastSeenSeq. Idempotent: the same
   // watermark always yields the same set, so a client cannot be re-pushed an
   // already-delivered event (the adversarial-review gate for #8129).
-  getMissedNotificationsSince(lastSeenSeq: number): ReplayableMobileNotification[] {
-    return this.mobileNotificationReplay.getMissedSince(lastSeenSeq)
+  getMissedNotificationsSince(lastSeenSeq: number, epoch?: string): ReplayableMobileNotification[] {
+    return this.mobileNotificationReplay.getMissedSince(lastSeenSeq, epoch)
+  }
+
+  // Why (#8591): the seq counter is per-process and restarts at 0 on every desktop
+  // launch, but the client's watermark is persisted. Clients need the epoch to tell
+  // a stale watermark from a valid one — see MobileNotificationReplayBuffer.
+  getMobileNotificationEpoch(): string {
+    return this.mobileNotificationReplay.epoch
   }
 
   dismissMobileNotification(notificationId: string): void {

--- a/src/main/runtime/rpc/methods/notifications.ts
+++ b/src/main/runtime/rpc/methods/notifications.ts
@@ -20,8 +20,13 @@ const NotificationUnsubscribeParams = z.object({
 // exact and idempotent — re-requesting with the same watermark can never
 // return an already-delivered event, so reconnects never duplicate local
 // pushes (the adversarial-review gate for #8129).
+// `epoch` names the counter lifetime lastSeenSeq came from (#8591). The desktop's
+// seq restarts at 0 on every launch while the client's watermark is persisted, so
+// without it a post-restart watermark silently cuts away everything. Optional: a
+// client that predates the field keeps the seq-only cut.
 const NotificationGetMissedSinceParams = z.object({
-  lastSeenSeq: z.number().int().min(0, 'lastSeenSeq must be a non-negative integer')
+  lastSeenSeq: z.number().int().min(0, 'lastSeenSeq must be a non-negative integer'),
+  epoch: z.string().optional()
 })
 
 // Why: notifications.subscribe streams desktop notification events to mobile
@@ -52,7 +57,9 @@ export const NOTIFICATION_METHODS: readonly RpcAnyMethod[] = [
           connectionId
         )
 
-        emit({ type: 'ready', subscriptionId })
+        // Why: the epoch rides the ready frame so a reconnecting client learns the
+        // counter lifetime BEFORE it sends its watermark to getMissedSince (#8591).
+        emit({ type: 'ready', subscriptionId, epoch: runtime.getMobileNotificationEpoch() })
       })
     }
   }),
@@ -71,8 +78,8 @@ export const NOTIFICATION_METHODS: readonly RpcAnyMethod[] = [
     // the monotonic seq, so this is the single source of truth for what the
     // client missed while its socket was reaped.
     handler: async (params, { runtime }) => {
-      const missed = runtime.getMissedNotificationsSince(params.lastSeenSeq)
-      return { notifications: missed }
+      const missed = runtime.getMissedNotificationsSince(params.lastSeenSeq, params.epoch)
+      return { notifications: missed, epoch: runtime.getMobileNotificationEpoch() }
     }
   })
 ]


### PR DESCRIPTION
Closes #8591

## What's broken

Mobile silently stops delivering notifications. The desktop dispatches them, the phone is connected, and nothing arrives — no error, no banner, nothing to see.

## ELI5

The phone keeps a bookmark: "I've shown everything up to notification #57." On reconnect it asks the desktop "anything after #57?"

The desktop's counter **restarts at 0 every launch**. So after a desktop restart, the desktop is on notification #3 while the phone still holds a bookmark saying #57. The phone asks for "anything after 57", the desktop says "nope", and notifications stay dead until the new desktop out-counts the old bookmark — potentially forever.

A bookmark is meaningless without knowing *which* counter it indexes. So the bookmark now records the counter's lifetime (an "epoch") alongside the number. Different epoch → the bookmark is void → replay everything retained.

## The fixes

1. **Epoch-tagged watermark.** A seq is stored with the counter lifetime it belongs to. A mismatch on reconnect voids it instead of trusting it.
2. **Atomic pair.** Seq and epoch live in **one** JSON value. Written as two keys, a process death between the writes leaves an epoch from one counter beside a seq from another — internally consistent, silently wrong, and therefore trusted.
3. **Survives the app's own teardown.** `app/index.tsx` tears the subscription down on every non-connected state, destroying the watermark and seen-set exactly when a reconnect needs them. They now live per-host at module scope.
4. **Cold-open catch-up** keyed on the record's *existence*, not `seq > 0` — a voided watermark reloads as seq 0 and would otherwise look like a first-ever pairing.
5. **Serialized delivery** (from review) — see trade-offs.

## Fix proof

Full mobile suite: **344 files, 2499 passed, 2 skipped.** `tsc` clean, `oxlint` clean.

Every mechanism was disabled individually against the *unchanged* suite. Each kills exactly one test — so nothing is unguarded, and nothing is redundant:

| Mechanism disabled | Result |
|---|---|
| Batch-as-one-queue-entry → per-item enqueue | ordering test fails |
| Watermark advance → moved before the await | ordering test fails |
| Seed timeout removed | wedged-read test fails |
| Live-path dedup claim removed | concurrent-dedup test fails |
| Replay-path dedup claim removed | cross-path dedup test fails |

## Trade-offs / regression risk

**Two defects found in review were pre-existing, not introduced here.** I verified this mechanically (`git show origin/main:…` shows the identical watermark advance) and fixed them anyway, because this branch is what makes the watermark load-bearing:

- **Watermark could outrun delivery.** The advance happened *before* the local notification was shown, and replay + live delivery ran concurrently. A live seq 11 handled while catch-up was still showing seq 6 persisted 11 — a process death before 7–10 were shown lost them permanently. Confirmed with a disposable probe (`expected 11 to be less than 7`) before writing any fix.
- **Unbounded seed.** Every delivery awaits the persisted read, so an AsyncStorage read that never settled disabled the host's notifications for the entire app lifetime. Now bounded at 3s; a late seed still applies when it lands. Proceeding unseeded is strictly better — the watermark stays 0, so catch-up over-fetches and the seen-set de-duplicates.

**One real behavioral trade-off:** serializing deliveries removed an overlap the duplicate-suppression relied on. `showLocalNotification` deduped two same-id events by observing the first still pending when the second arrived; serialized, the first *completes* first, so the second saw nothing pending and scheduled a second banner. The claim moved to enqueue time, where the overlap is still observable. Dismisses are deliberately **not** claimed — a dismiss is what retires the notification a show created.

**Cost:** notifications for a single host now show strictly one-at-a-time rather than concurrently. The catch-up RPC is deliberately kept *outside* the queue — `sendRequest` waits up to 30s, and holding the chain for that would stall live delivery on a slow link.

**Accepted:** delivery is at-least-once. `saveWatermark` is fire-and-forget, so a failed write leaves the stored value *below* what was delivered and a later cold start may re-show. That's the safe direction — the alternative loses notifications.

## Review loop

3 rounds (gpt-5.6-sol + fable, alternating). Final fable verdict: **CLEAN** — "mergeable from my side." The two GPT MAJORs are fixed and mutation-verified above. Residual from review: 1 MINOR (notification-burst pacing), 3 NITs.

## Cross-platform

Mobile-only (`mobile/`). Platform-independent — no path handling, no shell, no OS branching. Android and iOS both exercised by the suite.

## Perf

No polling, no new hot-path scans. The dedup set is bounded at 512 entries. The serialization chain is one promise per host.
