### PR TITLE
fix(notifications): stop Codex banner spam on non-turn-end Stop hooks

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -6623,6 +6623,47 @@ describe('Last-status persistence', () => {
     }
   })
 
+  it('strips leadStopWithLiveSubagents on hydrate even if the file already carries it', async () => {
+    // Why: the write-side strip only covers bytes this build wrote. A file from an older
+    // build, a restored backup, or a hand edit would otherwise rehydrate the flag on a
+    // `done` entry — the one state it survives normalization — and re-suppress a real
+    // completion after restart. Enforce the invariant against arbitrary bytes (#4375).
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    writeFileSync(
+      lastStatusPath(),
+      JSON.stringify({
+        version: 2,
+        entries: {
+          [PANE]: {
+            paneKey: PANE,
+            tabId: 'tab-1',
+            worktreeId: 'wt-1',
+            receivedAt: recentTs(),
+            stateStartedAt: recentTs(-1000),
+            payload: {
+              state: 'done',
+              prompt: 'injected',
+              agentType: 'codex',
+              leadStopWithLiveSubagents: true
+            }
+          }
+        }
+      }),
+      'utf8'
+    )
+
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      const hydrated = server.getStatusSnapshot()[0]
+      // The entry must hydrate (otherwise this asserts nothing about the flag).
+      expect(hydrated?.state).toBe('done')
+      expect(hydrated).not.toHaveProperty('leadStopWithLiveSubagents')
+    } finally {
+      server.stop()
+    }
+  })
+
   it('treats a corrupt file as empty hydration without throwing', async () => {
     mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
     writeFileSync(lastStatusPath(), 'not-json{{', 'utf8')

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -6597,6 +6597,32 @@ describe('Last-status persistence', () => {
     }
   })
 
+  it('never persists leadStopWithLiveSubagents, so a restart cannot re-suppress a completion', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      await postHookEvent(server, buildBody({ hook_event_name: 'SessionStart' }), '/hook/codex')
+      await postHookEvent(
+        server,
+        buildBody({
+          hook_event_name: 'SubagentStart',
+          agent_id: '11111111-2222-4333-8444-555555555555',
+          agent_type: 'explore'
+        }),
+        '/hook/codex'
+      )
+      await postHookEvent(server, buildBody({ hook_event_name: 'Stop' }), '/hook/codex')
+      server.flushStatusPersistSync()
+      const persisted = JSON.parse(readFileSync(lastStatusPath(), 'utf8'))
+      // Why: the flag describes one live hook delivery. Rehydrating it would make the
+      // notification gate suppress the first real completion after every restart (#4375).
+      expect(persisted.entries[PANE].payload.state).toBe('done')
+      expect(persisted.entries[PANE].payload).not.toHaveProperty('leadStopWithLiveSubagents')
+    } finally {
+      server.stop()
+    }
+  })
+
   it('treats a corrupt file as empty hydration without throwing', async () => {
     mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
     writeFileSync(lastStatusPath(), 'not-json{{', 'utf8')

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -234,6 +234,12 @@ function sanitizeHydratedEntry(
   if (!payload) {
     return null
   }
+  // Why: the write side already strips this, but the state gate in normalizeAgentStatusPayload
+  // preserves it on `done` — the only state it is ever set on. Enforce here too so the invariant
+  // holds against any bytes on disk, not just the ones this process wrote (#4375).
+  if (payload.leadStopWithLiveSubagents) {
+    delete payload.leadStopWithLiveSubagents
+  }
   const providerSession = normalizeAgentProviderSession(record.providerSession) ?? undefined
   const providerSessionOnly = record.providerSessionOnly === true
   if (providerSessionOnly && !isValidPiProviderSessionOnly(providerSession, payload.agentType)) {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1927,6 +1927,12 @@ export class AgentHookServer {
         continue
       }
       const { promptInteractionKey: _promptInteractionKey, ...persistedPayload } = payload
+      // Why: leadStopWithLiveSubagents describes one live hook delivery, not restorable pane
+      // state — a rehydrated one would re-suppress the first completion after restart (#4375).
+      if (persistedPayload.payload?.leadStopWithLiveSubagents) {
+        const { leadStopWithLiveSubagents: _live, ...inner } = persistedPayload.payload
+        persistedPayload.payload = inner
+      }
       entries[paneKey] = persistedPayload as EnrichedAgentHookEventPayload
     }
     const file: LastStatusFile = { version: LAST_STATUS_FILE_VERSION, entries }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -811,6 +811,13 @@ export function createAgentCompletionCoordinator(
       return
     }
     if (isCompletionHookState(payload.state)) {
+      if (payload.leadStopWithLiveSubagents) {
+        // Why: a Codex lead Stop raised while its children still run ends no turn (#4375).
+        // It stays `done` for the sidebar, but notifying here is the reported spam. Cancel any
+        // provisional done too — the lead can Stop inside a quiet window opened by an earlier one.
+        clearPendingHookDone()
+        return
+      }
       // Why: the turn is ending, so a debounced attention from an earlier pause must not fire after completion.
       clearPendingCodexAttention()
       if (isRecognizedAgentType(payload.agentType)) {

--- a/src/renderer/src/components/terminal-pane/codex-lead-stop-subagent-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-lead-stop-subagent-gate.test.ts
@@ -242,6 +242,43 @@ describe('issue #4375 — non-turn-end notification spam', () => {
     expect(restarted?.payload.state).toBe('working')
   })
 
+  it('gates notification without downgrading the reported state of a lead Stop', () => {
+    // Why: an earlier cut of this fix gated by rewriting `state` to 'working', which silently
+    // broke the sidebar/persistence contract that a root Stop retires child rows and reports
+    // 'done' (server.test.ts). The suppression signal must ride alongside `done`, not replace it.
+    const listenerState: HookListenerState = createHookListenerState()
+    const send = (
+      ev: string,
+      p?: Record<string, unknown>
+    ): ReturnType<typeof normalizeHookPayload> =>
+      normalizeHookPayload(
+        listenerState,
+        'codex',
+        {
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: WORKTREE_ID,
+          hook_event_name: ev,
+          payload: { hook_event_name: ev, ...p }
+        },
+        'test-env'
+      )
+
+    send('UserPromptSubmit', { prompt: 'go' })
+    send('SubagentStart', { agent_id: 'child-1', agent_type: 'reviewer' })
+
+    const leadStop = send('Stop')
+    expect(leadStop?.payload.state).toBe('done')
+    expect(leadStop?.payload.subagents).toBeUndefined()
+    expect(leadStop?.payload.leadStopWithLiveSubagents).toBe(true)
+
+    // The child's own Stop is a real turn end: same shape, but no suppression flag.
+    send('PreToolUse', { agent_id: 'child-1', tool_name: 'Bash', tool_input: { command: 'y' } })
+    const childStop = send('SubagentStop', { agent_id: 'child-1' })
+    expect(childStop?.payload.state).toBe('done')
+    expect(childStop?.payload.leadStopWithLiveSubagents).toBeUndefined()
+  })
+
   // KNOWN-OPEN residual, deliberately out of scope for the roster fix. A bare mid-turn
   // Stop (no subagent) that resumes AFTER the 1.5s quiet window still notifies. There is
   // no principled bound to widen the window to, and widening it delays every real Codex

--- a/src/renderer/src/components/terminal-pane/codex-lead-stop-subagent-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-lead-stop-subagent-gate.test.ts
@@ -7,6 +7,7 @@ import { dispatchTerminalNotification } from './use-notification-dispatch'
 import {
   createHookListenerState,
   normalizeHookPayload,
+  reconcileRemoteCodexState,
   type HookListenerState
 } from '../../../../shared/agent-hook-listener'
 import type { AgentHookSource } from '../../../../shared/agent-hook-relay'
@@ -277,6 +278,33 @@ describe('issue #4375 — non-turn-end notification spam', () => {
     const childStop = send('SubagentStop', { agent_id: 'child-1' })
     expect(childStop?.payload.state).toBe('done')
     expect(childStop?.payload.leadStopWithLiveSubagents).toBeUndefined()
+  })
+
+  it('gates a lead Stop arriving over SSH/relay, which reconciles on a separate path', () => {
+    // Why: remote panes never reach normalizeHookPayload's codex branch — the main process
+    // re-derives their roster in reconcileRemoteCodexState, which does its own reap. Without the
+    // same pre-reap capture there, the fix would cover local Codex only.
+    const listenerState: HookListenerState = createHookListenerState()
+    const remote = (
+      ev: string,
+      agentId: string | undefined,
+      payload: Parameters<typeof reconcileRemoteCodexState>[4],
+      previous?: Parameters<typeof reconcileRemoteCodexState>[5]
+    ): ReturnType<typeof reconcileRemoteCodexState> =>
+      reconcileRemoteCodexState(listenerState, PANE_KEY, ev, agentId, payload, previous)
+
+    const working = { state: 'working', prompt: 'go', agentType: 'codex' } as const
+    remote('UserPromptSubmit', undefined, { ...working })
+    // The relay reports the live child roster alongside the lead's own state.
+    remote('SubagentStart', 'child-1', {
+      ...working,
+      subagents: [{ id: 'child-1', state: 'working', agentType: 'reviewer', startedAt: Date.now() }]
+    })
+
+    const leadStop = remote('Stop', undefined, { state: 'done', prompt: 'go', agentType: 'codex' })
+    expect(leadStop.state).toBe('done')
+    expect(leadStop.subagents).toBeUndefined()
+    expect(leadStop.leadStopWithLiveSubagents).toBe(true)
   })
 
   // KNOWN-OPEN residual, deliberately out of scope for the roster fix. A bare mid-turn

--- a/src/renderer/src/components/terminal-pane/codex-lead-stop-subagent-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-lead-stop-subagent-gate.test.ts
@@ -307,11 +307,13 @@ describe('issue #4375 — non-turn-end notification spam', () => {
     expect(leadStop.leadStopWithLiveSubagents).toBe(true)
   })
 
-  // KNOWN-OPEN residual, deliberately out of scope for the roster fix. A bare mid-turn
-  // Stop (no subagent) that resumes AFTER the 1.5s quiet window still notifies. There is
-  // no principled bound to widen the window to, and widening it delays every real Codex
-  // completion; the correct fix is retracting the banner via notifications:dismiss on the
-  // resuming 'working' hook. Pinned here so that change flips this test.
+  // KNOWN-OPEN residual, deliberately out of scope for the roster fix, and the reason this PR
+  // does NOT close #4375: a bare mid-turn Stop (no subagent) that resumes AFTER the 1.5s quiet
+  // window still notifies, which is the "notification after tool calls or reasoning" the issue
+  // reports. There is no principled bound to widen the window to, and widening it delays every
+  // real Codex completion; the correct fix is retracting the banner via notifications:dismiss on
+  // the resuming 'working' hook, which needs a notification id plumbed back through
+  // dispatchCompletion (currently `=> void`). Pinned here so that change flips this test.
   it('KNOWN-OPEN: a bare mid-turn Stop resuming after the quiet window still notifies', () => {
     const calls = drive('codex', [
       { ev: 'UserPromptSubmit', p: { prompt: 'run tests' } },

--- a/src/renderer/src/components/terminal-pane/codex-lead-stop-subagent-gate.test.ts
+++ b/src/renderer/src/components/terminal-pane/codex-lead-stop-subagent-gate.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createAgentCompletionCoordinator,
+  resetAgentCompletionCoordinatorIdentitiesForTest
+} from './agent-completion-coordinator'
+import { dispatchTerminalNotification } from './use-notification-dispatch'
+import {
+  createHookListenerState,
+  normalizeHookPayload,
+  type HookListenerState
+} from '../../../../shared/agent-hook-listener'
+import type { AgentHookSource } from '../../../../shared/agent-hook-relay'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { AgentCompletionStatusSnapshot } from './agent-completion-coordinator-types'
+import type { NotificationDispatchRequest } from '../../../../shared/types'
+
+const LEAF = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = `tab-1:${LEAF}`
+const WORKTREE_ID = 'wt-primary'
+
+type MockState = Record<string, unknown>
+let mockState: MockState
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => mockState, subscribe: () => () => {} }
+}))
+vi.mock('@/lib/desktop-notification-sound', () => ({ playDesktopNotificationSound: vi.fn() }))
+
+function baseState(): MockState {
+  return {
+    activeWorktreeId: 'wt-other',
+    activeTabId: 'tab-1',
+    tabsByWorktree: { [WORKTREE_ID]: [{ id: 'tab-1', ptyId: 'pty-1' }] },
+    ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+    suppressedPtyExitIds: {},
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: { type: 'leaf', leafId: LEAF },
+        activeLeafId: LEAF,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF]: 'pty-1' }
+      }
+    },
+    browserTabsByWorktree: {},
+    retainedAgentsByPaneKey: {},
+    agentStatusByPaneKey: {} as Record<string, AgentStatusEntry>,
+    worktreesByRepo: {
+      repo1: [{ id: WORKTREE_ID, repoId: 'repo1', displayName: 'main', branch: 'main' }],
+      repo2: [{ id: 'wt-other', repoId: 'repo2', displayName: 'other', branch: 'other' }]
+    },
+    repos: [
+      { id: 'repo1', displayName: 'danmaku_monitor', connectionId: null },
+      { id: 'repo2', displayName: 'second_repo', connectionId: null }
+    ],
+    settings: {
+      experimentalTerminalAttention: false,
+      notifications: { enabled: true, agentTaskComplete: true }
+    },
+    markWorktreeUnread: vi.fn(),
+    markTerminalTabUnread: vi.fn(),
+    markTerminalPaneUnread: vi.fn(),
+    markAgentCompletionPaneUnread: vi.fn()
+  }
+}
+
+function applyStatusToStore(payload: AgentCompletionStatusSnapshot, now: number): void {
+  const store = mockState.agentStatusByPaneKey as Record<string, AgentStatusEntry>
+  const previous = store[PANE_KEY]
+  const stateStartedAt =
+    previous && previous.state === payload.state ? previous.stateStartedAt : now
+  store[PANE_KEY] = {
+    ...previous,
+    state: payload.state,
+    prompt: payload.prompt,
+    agentType: payload.agentType,
+    toolName: payload.toolName,
+    toolInput: payload.toolInput,
+    lastAssistantMessage: payload.lastAssistantMessage,
+    interrupted: payload.interrupted,
+    subagents: payload.subagents,
+    updatedAt: now,
+    stateStartedAt,
+    paneKey: PANE_KEY,
+    terminalTitle: payload.agentType ?? 'agent',
+    stateHistory: []
+  } as AgentStatusEntry
+}
+
+function dispatchCalls(): NotificationDispatchRequest[] {
+  const d = window.api.notifications.dispatch as unknown as ReturnType<typeof vi.fn>
+  return d.mock.calls.map((c) => c[0] as NotificationDispatchRequest)
+}
+
+function makeCoordinator(): ReturnType<typeof createAgentCompletionCoordinator> {
+  return createAgentCompletionCoordinator({
+    paneKey: PANE_KEY,
+    getPtyId: () => 'pty-1',
+    getSettings: () => null,
+    inspectProcess: async () => ({ foregroundProcess: null, hasChildProcesses: false }),
+    dispatchCompletion: (title, meta) => {
+      dispatchTerminalNotification(WORKTREE_ID, {
+        source: 'agent-task-complete',
+        terminalTitle: title,
+        paneKey: PANE_KEY,
+        ...(meta?.agentStatus ? { agentStatusSnapshot: meta.agentStatus } : {})
+      })
+    },
+    dispatchAttention: (title, meta) => {
+      dispatchTerminalNotification(WORKTREE_ID, {
+        source: 'agent-task-complete',
+        terminalTitle: title,
+        paneKey: PANE_KEY,
+        agentStatusSnapshot: meta.agentStatus
+      })
+    },
+    isLive: () => true
+  })
+}
+
+type Step = { ev: string; p?: Record<string, unknown>; waitMs?: number }
+
+/** Drives real hook normalization -> store mirror -> coordinator -> dispatcher. */
+function drive(source: AgentHookSource, steps: Step[]): NotificationDispatchRequest[] {
+  const listenerState: HookListenerState = createHookListenerState()
+  const coordinator = makeCoordinator()
+  for (const step of steps) {
+    const event = normalizeHookPayload(
+      listenerState,
+      source,
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: WORKTREE_ID,
+        hook_event_name: step.ev,
+        payload: { hook_event_name: step.ev, ...step.p }
+      },
+      'test-env'
+    )
+    if (event) {
+      const now = Date.now()
+      applyStatusToStore(event.payload, now)
+      const stored = (mockState.agentStatusByPaneKey as Record<string, AgentStatusEntry>)[PANE_KEY]
+      coordinator.observeHookStatus({ ...event.payload, stateStartedAt: stored.stateStartedAt })
+    }
+    vi.advanceTimersByTime(step.waitMs ?? 100)
+  }
+  vi.advanceTimersByTime(6_000)
+  coordinator.dispose()
+  return dispatchCalls()
+}
+
+const BASH_1 = { tool_name: 'Bash', tool_input: { command: 'npm run test:submit' } }
+const BASH_2 = {
+  tool_name: 'Bash',
+  tool_input: { command: 'node scripts/check-hook-registry.js' }
+}
+
+describe('issue #4375 — non-turn-end notification spam', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-25T12:00:00Z'))
+    vi.stubGlobal('document', { visibilityState: 'hidden', hasFocus: () => false })
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' })
+    vi.stubGlobal('window', {
+      api: { notifications: { dispatch: vi.fn().mockResolvedValue({ delivered: true }) } }
+    })
+    mockState = baseState()
+    // Why: completion identities are module-scoped and keyed by paneKey, so they leak between tests.
+    resetAgentCompletionCoordinatorIdentitiesForTest()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('control: a real turn end notifies once', () => {
+    const calls = drive('codex', [
+      { ev: 'UserPromptSubmit', p: { prompt: 'run tests' } },
+      { ev: 'PreToolUse', p: BASH_1 },
+      { ev: 'PostToolUse', p: BASH_1 },
+      { ev: 'Stop' }
+    ])
+    expect(calls).toHaveLength(1)
+    expect(calls[0].agentState).toBe('done')
+  })
+
+  it('REPRO: a Codex lead Stop notifies while a subagent is still working', () => {
+    const calls = drive('codex', [
+      { ev: 'UserPromptSubmit', p: { prompt: 'run tests' } },
+      { ev: 'SubagentStart', p: { agent_id: 'child-1', agent_type: 'reviewer' } },
+      { ev: 'PreToolUse', p: BASH_1 },
+      // Lead finishes; the child keeps working well past the 1.5s quiet window.
+      { ev: 'Stop', waitMs: 5_000 },
+      { ev: 'PreToolUse', p: { ...BASH_2, agent_id: 'child-1' } }
+    ])
+
+    if (calls.length > 0) {
+      throw new Error(
+        `Spurious completion while subagent child-1 is still working: ` +
+          `state=${calls[0].agentState} tool=${calls[0].agentToolInput}`
+      )
+    }
+    expect(calls).toHaveLength(0)
+  })
+
+  it('cancels a mid-turn Stop when work resumes inside the quiet window', () => {
+    const calls = drive('codex', [
+      { ev: 'UserPromptSubmit', p: { prompt: 'run tests' } },
+      { ev: 'PreToolUse', p: BASH_1 },
+      // Resumes at 1s — inside HOOK_DONE_QUIET_MS, so the provisional done is cancelled.
+      { ev: 'Stop', waitMs: 1_000 },
+      { ev: 'PreToolUse', p: BASH_2 }
+    ])
+    expect(calls).toHaveLength(0)
+  })
+
+  it('a new session is not gated by the roster the previous Codex process left behind', () => {
+    const listenerState: HookListenerState = createHookListenerState()
+    const send = (
+      ev: string,
+      p?: Record<string, unknown>
+    ): ReturnType<typeof normalizeHookPayload> =>
+      normalizeHookPayload(
+        listenerState,
+        'codex',
+        {
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: WORKTREE_ID,
+          hook_event_name: ev,
+          payload: { hook_event_name: ev, ...p }
+        },
+        'test-env'
+      )
+
+    // A child parks in 'waiting', then the Codex process dies without a child Stop hook.
+    send('UserPromptSubmit', { prompt: 'first' })
+    send('PermissionRequest', { agent_id: 'child-1', agent_type: 'reviewer' })
+
+    // Why: SessionStart retires the stale roster, so it must not also be gated by it.
+    const restarted = send('SessionStart')
+    expect(restarted?.payload.state).toBe('working')
+  })
+
+  // KNOWN-OPEN residual, deliberately out of scope for the roster fix. A bare mid-turn
+  // Stop (no subagent) that resumes AFTER the 1.5s quiet window still notifies. There is
+  // no principled bound to widen the window to, and widening it delays every real Codex
+  // completion; the correct fix is retracting the banner via notifications:dismiss on the
+  // resuming 'working' hook. Pinned here so that change flips this test.
+  it('KNOWN-OPEN: a bare mid-turn Stop resuming after the quiet window still notifies', () => {
+    const calls = drive('codex', [
+      { ev: 'UserPromptSubmit', p: { prompt: 'run tests' } },
+      { ev: 'PreToolUse', p: BASH_1 },
+      { ev: 'Stop', waitMs: 2_000 },
+      { ev: 'PreToolUse', p: BASH_2 }
+    ])
+
+    const finalRow = (mockState.agentStatusByPaneKey as Record<string, AgentStatusEntry>)[PANE_KEY]
+    expect(finalRow.state).toBe('working')
+    expect(calls).toHaveLength(1)
+    // The banner carries the *previous* tool, matching the report in #4375.
+    expect(calls[0].agentToolInput).toBe('npm run test:submit')
+  })
+})

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -4715,6 +4715,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     toolInput?: string
     lastAssistantMessage?: string
     interrupted?: boolean
+    leadStopWithLiveSubagents?: boolean
     terminalHandle?: string
     launchToken?: string
     providerSession?: { key: 'session_id'; id: string }
@@ -5596,6 +5597,85 @@ describe('useIpcEvents agent status snapshot integration', () => {
     )
     expect(updateTabTitle).toHaveBeenCalledWith('tab-future', 'Codex - action required')
     expect(observeAgentHookCompletionForNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards leadStopWithLiveSubagents to completion tracking (#4375)', async () => {
+    const setAgentStatus = vi.fn()
+    const updateTabTitle = vi.fn()
+    const observeAgentHookCompletionForNotification = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      updateTabTitle,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: true, agentTaskComplete: true } },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Codex' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    vi.doMock('./agent-hook-completion-notifications', () => ({
+      observeAgentHookCompletionForNotification,
+      resetAgentHookCompletionNotificationCoordinators: vi.fn(),
+      syncAgentHookCompletionNotificationsForStoreUpdate: vi.fn()
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      tabId: 'tab-future',
+      worktreeId: 'wt-1',
+      state: 'done',
+      prompt: 'lead stop while children run',
+      agentType: 'codex',
+      leadStopWithLiveSubagents: true,
+      receivedAt: 1_700_000_000_600,
+      stateStartedAt: 1_699_999_999_600
+    })
+
+    // Why: local Codex hooks reach the coordinator only through this path, and the payload is
+    // rebuilt field-by-field on the way. The gate's own tests call observeHookStatus directly,
+    // so they stay green even when the flag is dropped here and the fix is dead in the app.
+    expect(observeAgentHookCompletionForNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ leadStopWithLiveSubagents: true })
+      })
+    )
   })
 
   it('does not send an out-of-order hook event to completion lifecycle tracking', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -2995,7 +2995,10 @@ export function useIpcEvents(): void {
         lastAssistantMessage: data.lastAssistantMessage,
         interrupted: data.interrupted,
         // Why: same trap as interactivePrompt — this rebuild is a field whitelist, so subagent child rows vanish if omitted.
-        subagents: data.subagents
+        subagents: data.subagents,
+        // Why: local Codex hooks reach the coordinator only through this rebuild; dropping it here
+        // silently disables the #4375 lead-Stop gate in the app while unit tests still pass.
+        leadStopWithLiveSubagents: data.leadStopWithLiveSubagents
       })
       if (!payload) {
         return 'dropped'

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -3133,12 +3133,17 @@ export function reconcileRemoteCodexState(
   if (payload.subagents) {
     seedCodexSubagentRoster(roster, payload.subagents)
   }
+  let leadStopWithLiveSubagents = false
   if (agentId) {
     if (eventName === 'SubagentStop') {
       finishCodexSubagent(roster, agentId)
     }
   } else {
     const leadState = codexLeadStateForHookEvent(eventName)
+    // Why: same pre-reap capture as the local path — SSH/relay panes reach the notification
+    // coordinator through here, so without it remote Codex leads keep spamming (#4375).
+    leadStopWithLiveSubagents =
+      eventName === 'Stop' && codexRosterEffectiveState(roster, 'done') !== 'done'
     if (eventName === 'SessionStart' || eventName === 'Stop') {
       roster.clear()
     }
@@ -3159,7 +3164,8 @@ export function reconcileRemoteCodexState(
     ...payload,
     state: codexRosterEffectiveState(roster, lead.state),
     model: lead.model ?? payload.model,
-    subagents: codexRosterToSnapshots(roster)
+    subagents: codexRosterToSnapshots(roster),
+    ...(leadStopWithLiveSubagents ? { leadStopWithLiveSubagents: true } : {})
   }
 }
 

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -3283,6 +3283,12 @@ function normalizeCodexEvent(
     return buildCodexChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
   }
 
+  // Why: a lead Stop isn't "done" while children still run, so the roster must gate it before
+  // being retired. SessionStart is exempt — its roster belongs to the process that just exited.
+  const effectiveState =
+    eventName === 'SessionStart'
+      ? stateName
+      : codexRosterEffectiveState(state.codexSubagentRosterByPaneKey.get(paneKey), stateName)
   if (eventName === 'SessionStart') {
     // Why: a pane can host a new Codex process after the old one exited without child Stop hooks.
     state.codexSubagentRosterByPaneKey.delete(paneKey)
@@ -3297,10 +3303,6 @@ function normalizeCodexEvent(
       normalizeOptionalField(hookPayload['model'], AGENT_MODEL_MAX_LENGTH) ??
       (eventName === 'SessionStart' ? undefined : previousLead?.model)
   })
-  const effectiveState = codexRosterEffectiveState(
-    state.codexSubagentRosterByPaneKey.get(paneKey),
-    stateName
-  )
   return buildCodexStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,
     updateLead: true

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -3316,8 +3316,15 @@ function normalizeCodexEvent(
       normalizeOptionalField(hookPayload['model'], AGENT_MODEL_MAX_LENGTH) ??
       (eventName === 'SessionStart' ? undefined : previousLead?.model)
   })
+  // Why: read the roster AFTER the reap. A blocked child must still hold the pane at `waiting` on
+  // non-Stop lead events, but on Stop the roster is already empty so this stays `done` — the root
+  // Stop contract in agent-hooks/server.ts depends on that.
+  const effectiveState = codexRosterEffectiveState(
+    state.codexSubagentRosterByPaneKey.get(paneKey),
+    stateName
+  )
   return buildCodexStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
-    stateName,
+    stateName: effectiveState,
     updateLead: true,
     leadStopWithLiveSubagents
   })

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -3169,7 +3169,11 @@ function buildCodexStatusPayload(
   promptText: string,
   paneKey: string,
   hookPayload: Record<string, unknown>,
-  options: { stateName: 'working' | 'waiting' | 'done'; updateLead: boolean }
+  options: {
+    stateName: 'working' | 'waiting' | 'done'
+    updateLead: boolean
+    leadStopWithLiveSubagents?: boolean
+  }
 ): ParsedAgentStatusPayload | null {
   const snapshot = options.updateLead
     ? resolveToolState(state, paneKey, extractToolFields('codex', eventName, hookPayload), {
@@ -3189,7 +3193,8 @@ function buildCodexStatusPayload(
     toolInput: snapshot.toolInput,
     interactivePrompt: snapshot.interactivePrompt,
     lastAssistantMessage: snapshot.lastAssistantMessage,
-    subagents: codexRosterToSnapshots(state.codexSubagentRosterByPaneKey.get(paneKey))
+    subagents: codexRosterToSnapshots(state.codexSubagentRosterByPaneKey.get(paneKey)),
+    leadStopWithLiveSubagents: options.leadStopWithLiveSubagents
   })
 }
 
@@ -3283,12 +3288,14 @@ function normalizeCodexEvent(
     return buildCodexChildDrivenStatusPayload(state, eventName, paneKey, hookPayload)
   }
 
-  // Why: a lead Stop isn't "done" while children still run, so the roster must gate it before
-  // being retired. SessionStart is exempt — its roster belongs to the process that just exited.
-  const effectiveState =
-    eventName === 'SessionStart'
-      ? stateName
-      : codexRosterEffectiveState(state.codexSubagentRosterByPaneKey.get(paneKey), stateName)
+  // Why: the roster is retired below, which makes a lead Stop indistinguishable from the final
+  // SubagentStop (both `done` with no children). Capture whether children were still live BEFORE
+  // the reap so notification can tell a real turn end from a mid-turn one (#4375). SessionStart is
+  // exempt — its roster belongs to the process that just exited.
+  const leadStopWithLiveSubagents =
+    eventName === 'Stop' &&
+    codexRosterEffectiveState(state.codexSubagentRosterByPaneKey.get(paneKey), stateName) !==
+      stateName
   if (eventName === 'SessionStart') {
     // Why: a pane can host a new Codex process after the old one exited without child Stop hooks.
     state.codexSubagentRosterByPaneKey.delete(paneKey)
@@ -3304,8 +3311,9 @@ function normalizeCodexEvent(
       (eventName === 'SessionStart' ? undefined : previousLead?.model)
   })
   return buildCodexStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
-    stateName: effectiveState,
-    updateLead: true
+    stateName,
+    updateLead: true,
+    leadStopWithLiveSubagents
   })
 }
 

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -165,6 +165,11 @@ export type AgentStatusPayload = {
   interrupted?: boolean
   /** Live in-process children of the reporting session. See AgentStatusEntry. */
   subagents?: AgentSubagentSnapshot[]
+  /** Live-only: this `done` is a Codex lead Stop raised while subagents were still
+   *  running, so it ends no turn. Set before the roster is retired, which is what
+   *  otherwise makes it identical to the final SubagentStop (#4375). Notification-only —
+   *  `state` stays `done` so sidebar/persistence behavior is unchanged. */
+  leadStopWithLiveSubagents?: boolean
 }
 
 /**
@@ -361,7 +366,10 @@ function normalizeAgentStatusObject(parsed: unknown): ParsedAgentStatusPayload |
     ),
     // Why: only meaningful on `done`; coerce to undefined elsewhere so it can't leak stale truth across transitions.
     interrupted: obj.interrupted === true && state === 'done' ? true : undefined,
-    subagents: normalizeSubagentsField(obj.subagents)
+    subagents: normalizeSubagentsField(obj.subagents),
+    // Why: like `interrupted`, only meaningful on `done`; anywhere else it would be stale truth.
+    leadStopWithLiveSubagents:
+      obj.leadStopWithLiveSubagents === true && state === 'done' ? true : undefined
   }
 }
 

--- a/src/shared/codex-lead-state-vs-subagent-roster.test.ts
+++ b/src/shared/codex-lead-state-vs-subagent-roster.test.ts
@@ -22,13 +22,17 @@ describe('Codex lead state vs. a live subagent roster', () => {
     state = createHookListenerState()
   })
 
-  it('holds the pane at waiting on a non-Stop lead event while a child is blocked', () => {
+  // Every lead event that normalizes to `working` must yield to a blocked child, not just the
+  // PostToolUse this originally regressed on.
+  it.each([
+    ['PostToolUse', { hook_event_name: 'PostToolUse', tool_name: 'read' }],
+    ['PreToolUse', { hook_event_name: 'PreToolUse', tool_name: 'read' }],
+    ['UserPromptSubmit', { hook_event_name: 'UserPromptSubmit', prompt: 'keep going' }]
+  ])('holds the pane at waiting on a lead %s while a child is blocked', (_name, event) => {
     withBlockedChild()
     // Read pre-reap: a lead that keeps working must not paper over a child's permission prompt,
     // or the pane looks busy and the user never sees what it is blocked on.
-    expect(codexEvent({ hook_event_name: 'PostToolUse', tool_name: 'read' })?.payload.state).toBe(
-      'waiting'
-    )
+    expect(codexEvent(event)?.payload.state).toBe('waiting')
   })
 
   it('still reports done on a lead Stop, flagging that children were live', () => {
@@ -47,5 +51,34 @@ describe('Codex lead state vs. a live subagent roster', () => {
     const stopped = codexEvent({ hook_event_name: 'Stop' })
     expect(stopped?.payload.state).toBe('done')
     expect(stopped?.payload.leadStopWithLiveSubagents).toBeUndefined()
+  })
+
+  // The gate suppresses on roster membership, so a child whose Stop hook never arrives (Codex
+  // 0.144 drops them) costs a real completion. These two pin how far that can go: the Stop reap
+  // empties the roster, so the cost is exactly ONE turn and the next turn notifies unaided.
+  // That measured bound is why there is no aging/liveness timer here — any release window short
+  // enough to salvage the dropped-hook turn is shorter than a legitimately long-running child,
+  // and would re-fire the very spam #4375 reports.
+  it('flags only the turn a dropped child Stop spans, not the next one', () => {
+    codexEvent({ hook_event_name: 'SessionStart' })
+    codexEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'turn one' })
+    codexEvent({ hook_event_name: 'SubagentStart', agent_id: 'child-1', agent_type: 'explore' })
+    // child-1's SubagentStop is dropped by the CLI and never arrives.
+    expect(codexEvent({ hook_event_name: 'Stop' })?.payload.leadStopWithLiveSubagents).toBe(true)
+
+    codexEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'turn two' })
+    const turnTwo = codexEvent({ hook_event_name: 'Stop' })
+    expect(turnTwo?.payload.state).toBe('done')
+    expect(turnTwo?.payload.leadStopWithLiveSubagents).toBeUndefined()
+  })
+
+  it('clears the flag as soon as the child does report, so nothing is stranded', () => {
+    codexEvent({ hook_event_name: 'SessionStart' })
+    codexEvent({ hook_event_name: 'SubagentStart', agent_id: 'child-1', agent_type: 'explore' })
+    expect(codexEvent({ hook_event_name: 'Stop' })?.payload.leadStopWithLiveSubagents).toBe(true)
+    // The child's own Stop carries the turn end the gated lead Stop withheld: deferred, not lost.
+    const childStop = codexEvent({ hook_event_name: 'SubagentStop', agent_id: 'child-1' })
+    expect(childStop?.payload.state).toBe('done')
+    expect(childStop?.payload.leadStopWithLiveSubagents).toBeUndefined()
   })
 })

--- a/src/shared/codex-lead-state-vs-subagent-roster.test.ts
+++ b/src/shared/codex-lead-state-vs-subagent-roster.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createHookListenerState, normalizeHookPayload } from './agent-hook-listener'
+import { makePaneKey } from './stable-pane-id'
+
+const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+let state: ReturnType<typeof createHookListenerState>
+
+function codexEvent(payload: Record<string, unknown>) {
+  return normalizeHookPayload(state, 'codex', { paneKey: PANE_KEY, payload }, 'production')
+}
+
+function withBlockedChild() {
+  codexEvent({ hook_event_name: 'SessionStart' })
+  codexEvent({ hook_event_name: 'SubagentStart', agent_id: 'child-1', agent_type: 'explore' })
+  codexEvent({ hook_event_name: 'PermissionRequest', agent_id: 'child-1' })
+}
+
+// Why: the roster reap and the effective-state read must stay in this order. Swapping them
+// breaks one of the two contracts below, and each was a shipped bug at some point (#4375).
+describe('Codex lead state vs. a live subagent roster', () => {
+  beforeEach(() => {
+    state = createHookListenerState()
+  })
+
+  it('holds the pane at waiting on a non-Stop lead event while a child is blocked', () => {
+    withBlockedChild()
+    // Read pre-reap: a lead that keeps working must not paper over a child's permission prompt,
+    // or the pane looks busy and the user never sees what it is blocked on.
+    expect(codexEvent({ hook_event_name: 'PostToolUse', tool_name: 'read' })?.payload.state).toBe(
+      'waiting'
+    )
+  })
+
+  it('still reports done on a lead Stop, flagging that children were live', () => {
+    withBlockedChild()
+    const stopped = codexEvent({ hook_event_name: 'Stop' })
+    // Read post-reap: agent-hooks/server.ts retires child rows on a root Stop and reports 'done'.
+    // The pre-reap flag carries the "children were live" signal instead of downgrading the state.
+    expect(stopped?.payload.state).toBe('done')
+    expect(stopped?.payload.leadStopWithLiveSubagents).toBe(true)
+  })
+
+  it('omits the flag on a lead Stop with no live children', () => {
+    codexEvent({ hook_event_name: 'SessionStart' })
+    codexEvent({ hook_event_name: 'SubagentStart', agent_id: 'child-1', agent_type: 'explore' })
+    codexEvent({ hook_event_name: 'SubagentStop', agent_id: 'child-1' })
+    const stopped = codexEvent({ hook_event_name: 'Stop' })
+    expect(stopped?.payload.state).toBe('done')
+    expect(stopped?.payload.leadStopWithLiveSubagents).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Partially addresses #4375 — **deliberately does not close it.** See [Scope](#scope-what-this-does-not-fix).

## What's broken

Codex fires a desktop notification on **non-turn-end** events. As the reporter put it: "after tool calls or reasoning, I will get a notification" — enough noise that they turned the feature off.

This PR fixes **one** of the two ways that happens: a lead `Stop` raised while sub-agents are still running. The other — a bare mid-turn `Stop` with no sub-agent at all — is still open and pinned by a test below.

## ELI5

Codex's lead agent emits a `Stop` hook when *it* finishes — but its sub-agents may still be running, so the turn isn't over. Orca treated that `Stop` as "task complete" and popped a banner. This teaches it to check whether any children are still alive first.

## Fix proof

**Repro test** (`codex-lead-stop-subagent-gate.test.ts`), driving real hook normalization → store → coordinator → dispatcher:

```
UserPromptSubmit → SubagentStart(child-1) → PreToolUse → Stop → [child keeps working]
```

Before: 1 spurious notification. After: 0. A **control test** in the same file proves a genuine turn end still notifies exactly once — the gate suppresses spam, not completions.

## The interesting part: why this can't be fixed in `state`

My first cut gated by rewriting the lead `Stop`'s `state` from `done` to `working`. That broke two **pre-existing** tests in `src/main/agent-hooks/server.test.ts` (`:4447`, `:6587`), which pin the opposite contract: a root `Stop` retires child rows and reports `done`. Both contracts are real; they can't both live in `state`.

Worse, the reap is what *destroys* the signal. Probing the payload stream showed the lead `Stop` and the final `SubagentStop` are byte-identical after it:

```
Stop(lead):          state=done  subs=undefined   ← must NOT notify
SubagentStop(child): state=done  subs=undefined   ← MUST notify
```

No downstream heuristic can separate those. So the flag is captured **before** the reap and carried as a live-only field; `state` is untouched, and only the notification layer reads it.

## Proof of no regressions

- `server.test.ts` + gate suite: **250 passed**. The two tests my first cut broke are green again, and a new test pins that contract so it can't silently regress.
- Affected areas (`src/shared/`, `agent-hooks/`, `terminal-pane/`, `hooks/`, `relay/`): **7275 passed**.
- Full suite: **36428 passed**. The 8 failures (IME/editor/packaging) reproduce **identically on a clean `origin/main`** in this worktree — stale `node_modules`, unrelated to this diff. Verified by reverting all four source files and re-running.
- `oxlint` clean; `tsc` clean (the one `@sanity/diff-match-patch` error is the same pre-existing missing-dep).

**Mutation testing** — every mechanism is load-bearing, and each kills a *different* test (no redundancy):

| Mutation | Test killed |
|---|---|
| Coordinator gate → `if (false)` | REPRO |
| Drop pre-reap capture (local) | REPRO |
| Don't pass flag to payload builder | REPRO + contract test |
| Drop pre-reap capture (remote) | SSH/relay test |

## Review loop

2 rounds. Round 1 (fable / gpt-5.6-sol) split: fable **CLEAN "ship it"**, gpt **CHANGES_REQUIRED**. I verified gpt's claim directly — the two `server.test.ts` failures were real and mine — and sided with the stricter verdict. Both of gpt's substantive findings are now fixed; round 2 verdicts are in the thread.

## Cross-platform

Pure hook-listener/notification logic in `src/shared/` and the renderer — no paths, no shell, no platform APIs. The `Stop`-gating path is identical on macOS, Linux, and Windows.

**Both transports are covered.** A reviewer caught that SSH/relay panes never reach `normalizeHookPayload`'s codex branch — the main process re-derives their roster in `reconcileRemoteCodexState`, which does its own reap. Without the same capture there, this would have been a local-only fix. The second commit closes that, with its own test.

## Perf

No new hot-path work: one boolean computed from an in-memory roster already being read on that line, on `Stop` events only. No added allocation, I/O, or polling.

## Trade-offs / known-open

- **A bare mid-turn `Stop` with no subagents** that resumes after the 1.5s quiet window still notifies. Out of scope here: there's no principled bound to widen the window to, and widening it delays *every* real Codex completion. The right fix is retracting the banner via `notifications:dismiss` on the resuming `working` hook. Pinned by a test explicitly named `KNOWN-OPEN` (green, asserting today's behavior) so that change flips it — it documents the gap rather than hiding it.
- The flag is **stripped on persist**, so a rehydrated row can't re-suppress the first real completion after a restart.

---

## Update: a regression was reported against this PR — confirmed and fixed (`a6a5076`)

A reviewer reported that this branch flipped a blocked child's pane from `waiting` to `working`. **They were right, and my first check was wrong.** I probed only lead `Stop` (where this branch and `origin/main` agree on `done`) and concluded there was no regression. Re-probing a **non-`Stop`** lead event showed the real divergence:

| lead event, child blocked on a permission prompt | `origin/main` | this branch, before `a6a5076` |
| --- | --- | --- |
| `PostToolUse` | `waiting` | **`working`** ← regression |
| `Stop` | `done` | `done` + flag |

**Cause.** The revert in `84880f2711` removed the `codexRosterEffectiveState` call from the *entire* local lead path, not just the `Stop` case. Collateral damage: a child blocked on a permission prompt stopped holding the pane, so the pane read `working` and the user never saw what it was blocked on.

**Fix.** Restore the call, placed **after** the roster reap:

```ts
// Why: read the roster AFTER the reap. A blocked child must still hold the pane at `waiting` on
// non-Stop lead events, but on Stop the roster is already empty so this stays `done` — the root
// Stop contract in agent-hooks/server.ts depends on that.
const effectiveState = codexRosterEffectiveState(
  state.codexSubagentRosterByPaneKey.get(paneKey),
  stateName
)
```

Both contracts now hold at once, and the branch matches `origin/main` on both paths. The pre-reap flag described above is untouched.

### Ordering is the load-bearing detail — both directions are pinned

New `src/shared/codex-lead-state-vs-subagent-roster.test.ts`:

| mutation | result |
| --- | --- |
| drop the read (the reported regression) | ❌ `holds the pane at waiting on a non-Stop lead event while a child is blocked` fails |
| move the read *before* the reap (what `84880f2711` reverted) | ❌ `still reports done on a lead Stop, flagging that children were live` fails |
| unmutated | ✅ 3/3 |

Each mutation kills exactly the contract it violates — neither test is redundant.

### No regressions from the fix

`src/shared/` + `src/main/agent-hooks/` + gate suite: **3531 passed | 9 skipped | 0 failed** (366 files), including the two `server.ts` root-`Stop` tests whose failure forced the original revert.

Also verified `SessionStart` under the new ordering: a stale blocked child from a dead process is cleared, the restart reports `working`, and the next event does not resurrect it.

### Known bound, measured not assumed

Codex CLI 0.144 can omit a child `SubagentStop`, leaving a stale roster entry that suppresses one genuine completion. I measured the blast radius: **exactly one notification** — the `Stop` reap clears the roster, so the next turn notifies normally. Strictly better than the bug it replaces (a banner on every mid-turn lead `Stop`, indefinitely), and self-correcting.

## Scope: what this does **not** fix

Review correctly caught that the original auto-close link on this PR was overclaiming, so it is now "partially addresses" — merging this must not close the issue.

`#4375` reports notifications "after tool calls or reasoning". There are two distinct paths that produce that symptom:

| path | status |
| --- | --- |
| lead `Stop` while a sub-agent is still working | ✅ fixed here |
| bare mid-turn `Stop`, no sub-agent, resuming after the 1.5s quiet window | ❌ **still open** |

The second is pinned by a deliberately-passing test, `KNOWN-OPEN: a bare mid-turn Stop resuming after the quiet window still notifies`, which asserts today's wrong behaviour so that a real fix flips it. It even asserts the banner carries the *previous* tool name, matching the report.

Why it isn't fixed here: the quiet window has no principled bound to widen to, and widening it delays every genuine Codex completion. The correct fix is retracting the banner via `notifications:dismiss` on the resuming `working` hook — which needs a notification id plumbed back through `dispatchCompletion` (today typed `=> void`, `agent-completion-coordinator-types.ts:30`). That's a separate change with its own blast radius, not a line to sneak into this one.

## Review response: the suppression bound, measured

Review raised that gating on roster membership means a dropped child `Stop` hook (Codex 0.144 can omit them) suppresses a *genuine* completion, and asked for "a bounded/provisional suppression that eventually releases."

I probed the real payload stream rather than reasoning about it. The suppression is **already bounded** — by the `Stop` reap, not by a timer:

| scenario | notifications delivered |
| --- | --- |
| child finishes normally after a gated lead `Stop` | **1** — the child's own `SubagentStop` carries the turn end. Deferred, not lost. |
| child `Stop` hook dropped by the CLI | **0** for that turn — one real completion lost |
| dropped child `Stop`, then a second turn | **1** — self-heals, no user action needed |

So the worst case is one missed notification on one turn, self-correcting. Both rows are now pinned as tests (`flags only the turn a dropped child Stop spans`, `clears the flag as soon as the child does report`).

**Why no aging/liveness timer was added anyway:** a Codex sub-agent can legitimately run for many minutes. Any release window short enough to salvage the dropped-hook turn is shorter than a real long-running child — so it would re-fire the exact spam this gate exists to suppress. A timer would trade a rare, self-healing missed notification for a common, permanent false one. I took the measured bound over the redesign; happy to revisit if you disagree with that trade.

Also folded in the review's MINOR: the blocked-child contract now runs parameterized over `PreToolUse`, `PostToolUse`, and `UserPromptSubmit`, since every lead event normalizing to `working` must yield to a blocked child.

### Test totals after the review response

`src/shared/` + `src/renderer/src/components/terminal-pane/` + `src/renderer/src/hooks/`: **5950 passed | 6 skipped**, plus 257 in the three directly-affected suites. `tsc -p config/tsconfig.node.json` and `oxlint` clean.

⚠️ One pre-existing failure set, **not from this branch**: 5 tests in `terminal-ime-xterm-composition-deduplication.test.ts`. I verified these reproduce identically on the untouched merge base `c67aadbc18` — this branch touches no IME code (6 files changed, all notification/hook paths).
