### PR TITLE
fix(memory): clarify Resource Manager accounting

### DIFF
--- a/docs/reference/resource-manager-memory-metrics.md
+++ b/docs/reference/resource-manager-memory-metrics.md
@@ -1,0 +1,54 @@
+# Resource Manager memory metrics
+
+Resource Manager reports two different kinds of memory data. Process totals describe Orca and
+locally managed terminal processes; host totals describe the machine running Orca. They are not
+interchangeable.
+
+## Process memory
+
+Each snapshot declares one `processMemoryMetric`:
+
+| Platform     | Metric        | Source                                                     |
+| ------------ | ------------- | ---------------------------------------------------------- |
+| macOS, Linux | `rss`         | `ps` resident set size                                     |
+| Windows      | `working-set` | CIM `WorkingSetSize`, with a Typeperf working-set fallback |
+
+Orca walks each registered local PTY subtree and claims every PID at most once. App, session,
+worktree, history, and snapshot memory values are sums of those per-process samples.
+
+RSS and working set are not unique physical-memory measurements. Shared pages can appear in more
+than one process, and macOS can count the same resident page through multiple mappings in one
+process. A sum can therefore exceed physical RAM. Product copy and diagnostics must identify the
+metric as a sum and must not present it as a percentage of system RAM.
+
+Remote SSH and relay sessions do not receive invented local samples. They remain unavailable until
+the executing host supplies resource data. Folder workspaces use the same registered-PTY
+attribution as Git worktrees.
+
+## Host memory
+
+`HostMemory` keeps immediate free memory separate from memory available without material pressure:
+
+- `freeMemory` is Node's host free-memory value.
+- `availableMemory` is the best bounded platform value.
+- `usedMemory` is `totalMemory - availableMemory`.
+- `memoryUsagePercent` is derived from `usedMemory`.
+- `availableMemorySource` identifies how availability was measured.
+
+The sources are:
+
+| Platform | Preferred source                          | Fallback         |
+| -------- | ----------------------------------------- | ---------------- |
+| macOS    | `memory_pressure -Q` available percentage | Node free memory |
+| Linux    | `/proc/meminfo` `MemAvailable`            | Node free memory |
+| Windows  | Node free memory                          | Node free memory |
+
+This percentage describes host availability. It is not derived from the summed process metric.
+
+## Bounded collection
+
+Resource Manager polls while its popover is open, so every snapshot must remain bounded under a
+large process tree. macOS `footprint` provides a more physical process metric, but collecting it
+across dozens of processes is too expensive for this path. A future physical-footprint backend
+must use a bounded host API or helper and declare a distinct metric before product copy treats it
+as physical memory.

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3733,11 +3733,14 @@ describe('orca cli worktree awareness', () => {
         host: {
           totalMemory: 8 * 1024 * 1024,
           freeMemory: 2 * 1024 * 1024,
+          availableMemory: 2 * 1024 * 1024,
+          availableMemorySource: 'free-memory',
           usedMemory: 6 * 1024 * 1024,
           memoryUsagePercent: 75,
           cpuCoreCount: 8,
           loadAverage1m: 1.25
         },
+        processMemoryMetric: 'rss',
         totalCpu: 3.75,
         totalMemory: 2 * 1024 * 1024,
         collectedAt: 1000
@@ -3750,6 +3753,8 @@ describe('orca cli worktree awareness', () => {
     expect(callMock).toHaveBeenCalledWith('diagnostics.memory')
     const output = logSpy.mock.calls.flat().join('\n')
     expect(output).toContain('totalMemory: 2.0 MB')
+    expect(output).toContain('processMemoryMetric: summed RSS; shared or aliased pages may repeat')
+    expect(output).toContain('hostAvailable: 2.0 MB (free-memory)')
     expect(output).toContain('app: 1.0 MB')
     expect(output).toContain('- feature  1.0 MB  2.5%  1 session')
   })

--- a/src/cli/workspace-format.ts
+++ b/src/cli/workspace-format.ts
@@ -14,15 +14,19 @@ import type { MemorySnapshot, WorktreeMemory } from '../shared/types'
 
 export function formatMemorySnapshot(snapshot: MemorySnapshot): string {
   const topWorktrees = [...snapshot.worktrees].sort((a, b) => b.memory - a.memory).slice(0, 10)
+  const hostAvailable = snapshot.host.availableMemory ?? snapshot.host.freeMemory
+  const hostAvailableSource = snapshot.host.availableMemorySource ?? 'free-memory'
   const lines = [
     `collectedAt: ${new Date(snapshot.collectedAt).toISOString()}`,
     `totalMemory: ${formatByteCount(snapshot.totalMemory)}`,
+    `processMemoryMetric: ${formatProcessMemoryMetric(snapshot.processMemoryMetric)}`,
     `totalCpu: ${formatCpu(snapshot.totalCpu)}`,
     [
       `hostUsed: ${formatByteCount(snapshot.host.usedMemory)}`,
       `/ ${formatByteCount(snapshot.host.totalMemory)}`,
       `(${snapshot.host.memoryUsagePercent.toFixed(1)}%)`
     ].join(' '),
+    [`hostAvailable: ${formatByteCount(hostAvailable)}`, `(${hostAvailableSource})`].join(' '),
     [
       `app: ${formatByteCount(snapshot.app.memory)}`,
       `(main ${formatByteCount(snapshot.app.main.memory)},`,
@@ -58,6 +62,12 @@ function formatWorktreeMemoryLine(worktree: WorktreeMemory): string {
 
 function formatCpu(cpu: number): string {
   return `${cpu.toFixed(1)}%`
+}
+
+function formatProcessMemoryMetric(metric: MemorySnapshot['processMemoryMetric']): string {
+  return metric === 'working-set'
+    ? 'summed working set; shared pages may repeat'
+    : 'summed RSS; shared or aliased pages may repeat'
 }
 
 function formatByteCount(bytes: number): string {

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -27,17 +27,13 @@ import {
   iterateProcessOutputLines
 } from '../../shared/process-output-field-scanner'
 import { app } from 'electron'
-import type {
-  AppMemory,
-  MemorySnapshot,
-  HostMemory,
-  SessionMemory,
-  WorktreeMemory
-} from '../../shared/types'
+import type { AppMemory, MemorySnapshot, SessionMemory, WorktreeMemory } from '../../shared/types'
 import type { Store } from '../persistence'
 import { ORPHAN_WORKTREE_ID } from '../../shared/constants'
 import { listRegisteredPtys } from './pty-registry'
 import { enumerateWindowsProcessResources } from './windows-process-resource-collector'
+import { collectHostMemory, fallbackHostMemory } from './host-memory'
+import { getProcessMemoryMetric } from './process-memory-metric'
 
 export type MemorySnapshotStore = Pick<Store, 'getRepo' | 'getWorktreeMeta'>
 
@@ -95,26 +91,13 @@ function clampNumber(value: unknown): number {
   return Math.max(0, value)
 }
 
-function hostMetrics(): HostMemory {
-  const total = clampNumber(os.totalmem())
-  const free = clampNumber(os.freemem())
-  const used = Math.max(0, total - free)
-  return {
-    totalMemory: total,
-    freeMemory: free,
-    usedMemory: used,
-    memoryUsagePercent: total > 0 ? (used / total) * 100 : 0,
-    cpuCoreCount: Math.max(1, os.cpus().length),
-    loadAverage1m: clampNumber(os.loadavg()[0])
-  }
-}
-
 function emptySnapshot(): MemorySnapshot {
   const zero = { cpu: 0, memory: 0 }
   return {
     app: { ...zero, main: zero, renderer: zero, other: zero, history: [] },
     worktrees: [],
-    host: hostMetrics(),
+    host: fallbackHostMemory(),
+    processMemoryMetric: getProcessMemoryMetric(),
     totalCpu: 0,
     totalMemory: 0,
     collectedAt: Date.now()
@@ -352,7 +335,7 @@ function makeEmptyBucket(
 // ─── Main collection path ───────────────────────────────────────────
 
 async function runSnapshot(store: MemorySnapshotStore): Promise<MemorySnapshot> {
-  const processIndex = await enumerateProcesses()
+  const [processIndex, host] = await Promise.all([enumerateProcesses(), collectHostMemory()])
   const appBuckets = bucketElectronMetrics(processIndex)
   const ptys = listRegisteredPtys()
 
@@ -446,7 +429,8 @@ async function runSnapshot(store: MemorySnapshotStore): Promise<MemorySnapshot> 
   return {
     app: { ...appBuckets, history: readHistory(APP_HISTORY_KEY) },
     worktrees,
-    host: hostMetrics(),
+    host,
+    processMemoryMetric: getProcessMemoryMetric(),
     totalCpu: appBuckets.cpu + sessionCpuTotal,
     totalMemory: appBuckets.memory + sessionMemoryTotal,
     collectedAt: now

--- a/src/main/memory/host-memory.test.ts
+++ b/src/main/memory/host-memory.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import os from 'node:os'
+
+const { execFileMock, readFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  readFileMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: (
+    file: string,
+    args: string[],
+    options: unknown,
+    callback: (error: Error | null, stdout: string) => void
+  ) => execFileMock(file, args, options, callback)
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (file: string, encoding: string) => readFileMock(file, encoding)
+}))
+
+async function loadHostMemory() {
+  vi.resetModules()
+  return import('./host-memory')
+}
+
+describe('host memory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    execFileMock.mockReset()
+    readFileMock.mockReset()
+    vi.spyOn(os, 'totalmem').mockReturnValue(1_000)
+    vi.spyOn(os, 'freemem').mockReturnValue(100)
+    vi.spyOn(os, 'cpus').mockReturnValue([{}, {}] as ReturnType<typeof os.cpus>)
+    vi.spyOn(os, 'loadavg').mockReturnValue([1.5, 1, 0.5])
+  })
+
+  it('uses macOS memory-pressure availability instead of immediate free pages', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('darwin')
+    execFileMock.mockImplementation((_file, _args, _options, callback) =>
+      callback(null, 'System-wide memory free percentage: 79%')
+    )
+    const { collectHostMemory } = await loadHostMemory()
+
+    const host = await collectHostMemory()
+
+    expect(host).toMatchObject({
+      totalMemory: 1_000,
+      freeMemory: 100,
+      availableMemory: 790,
+      availableMemorySource: 'memory-pressure',
+      usedMemory: 210,
+      memoryUsagePercent: 21,
+      cpuCoreCount: 2,
+      loadAverage1m: 1.5
+    })
+    expect(execFileMock.mock.calls[0][0]).toBe('/usr/bin/memory_pressure')
+    expect(execFileMock.mock.calls[0][1]).toEqual(['-Q'])
+  })
+
+  it('falls back once when macOS availability cannot be read', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('darwin')
+    execFileMock.mockImplementation((_file, _args, _options, callback) =>
+      callback(new Error('unsupported'), '')
+    )
+    const { collectHostMemory } = await loadHostMemory()
+
+    const first = await collectHostMemory()
+    const second = await collectHostMemory()
+
+    expect(first).toMatchObject({
+      availableMemory: 100,
+      availableMemorySource: 'free-memory',
+      usedMemory: 900,
+      memoryUsagePercent: 90
+    })
+    expect(second.availableMemorySource).toBe('free-memory')
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses Linux MemAvailable and keeps the value within physical RAM', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('linux')
+    vi.spyOn(os, 'totalmem').mockReturnValue(4 * 1024 * 1024)
+    vi.spyOn(os, 'freemem').mockReturnValue(512 * 1024)
+    readFileMock.mockResolvedValue('MemTotal: 4096 kB\nMemAvailable: 2048 kB\n')
+    const { collectHostMemory } = await loadHostMemory()
+
+    const host = await collectHostMemory()
+
+    expect(host).toMatchObject({
+      availableMemory: 2 * 1024 * 1024,
+      availableMemorySource: 'proc-meminfo',
+      usedMemory: 2 * 1024 * 1024,
+      memoryUsagePercent: 50
+    })
+  })
+
+  it('uses the bounded Node value on Windows', async () => {
+    vi.spyOn(os, 'platform').mockReturnValue('win32')
+    const { collectHostMemory } = await loadHostMemory()
+
+    const host = await collectHostMemory()
+
+    expect(host.availableMemory).toBe(100)
+    expect(host.availableMemorySource).toBe('free-memory')
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('host availability parsers', () => {
+  it('parses bounded macOS percentages', async () => {
+    const { parseDarwinAvailableMemory } = await loadHostMemory()
+
+    expect(parseDarwinAvailableMemory('System-wide memory free percentage: 42%', 1_000)).toBe(420)
+    expect(parseDarwinAvailableMemory('System-wide memory free percentage: 101%', 1_000)).toBeNull()
+  })
+
+  it('parses Linux MemAvailable in KiB', async () => {
+    const { parseLinuxAvailableMemory } = await loadHostMemory()
+
+    expect(parseLinuxAvailableMemory('MemAvailable:    1234 kB\n')).toBe(1234 * 1024)
+    expect(parseLinuxAvailableMemory('MemFree: 1234 kB\n')).toBeNull()
+  })
+})

--- a/src/main/memory/host-memory.ts
+++ b/src/main/memory/host-memory.ts
@@ -1,0 +1,138 @@
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import type { HostAvailableMemorySource, HostMemory } from '../../shared/types'
+
+const MEMORY_PRESSURE_TIMEOUT_MS = 1_000
+const MEMORY_PRESSURE_MAX_BUFFER = 64 * 1024
+const KIB = 1024
+
+let darwinAvailabilitySupported = true
+let linuxAvailabilitySupported = true
+
+export async function collectHostMemory(): Promise<HostMemory> {
+  const total = nonNegativeNumber(os.totalmem())
+  const free = Math.min(total, nonNegativeNumber(os.freemem()))
+  const preferred = await readAvailableMemory(os.platform(), total)
+  const available = Math.min(total, Math.max(free, preferred?.bytes ?? free))
+  const used = Math.max(0, total - available)
+
+  return {
+    totalMemory: total,
+    freeMemory: free,
+    availableMemory: available,
+    availableMemorySource: preferred?.source ?? 'free-memory',
+    usedMemory: used,
+    memoryUsagePercent: total > 0 ? (used / total) * 100 : 0,
+    cpuCoreCount: Math.max(1, os.cpus().length),
+    loadAverage1m: nonNegativeNumber(os.loadavg()[0])
+  }
+}
+
+export function fallbackHostMemory(): HostMemory {
+  const total = nonNegativeNumber(os.totalmem())
+  const free = Math.min(total, nonNegativeNumber(os.freemem()))
+  const used = Math.max(0, total - free)
+  return {
+    totalMemory: total,
+    freeMemory: free,
+    availableMemory: free,
+    availableMemorySource: 'free-memory',
+    usedMemory: used,
+    memoryUsagePercent: total > 0 ? (used / total) * 100 : 0,
+    cpuCoreCount: Math.max(1, os.cpus().length),
+    loadAverage1m: nonNegativeNumber(os.loadavg()[0])
+  }
+}
+
+export function parseDarwinAvailableMemory(stdout: string, total: number): number | null {
+  const match = /System-wide memory free percentage:\s*(\d+)%/.exec(stdout)
+  const percentage = Number.parseInt(match?.[1] ?? '', 10)
+  if (!Number.isFinite(percentage) || percentage < 0 || percentage > 100 || total <= 0) {
+    return null
+  }
+  return Math.round((total * percentage) / 100)
+}
+
+export function parseLinuxAvailableMemory(meminfo: string): number | null {
+  const match = /^MemAvailable:\s*(\d+)\s+kB$/m.exec(meminfo)
+  const kib = Number.parseInt(match?.[1] ?? '', 10)
+  if (!Number.isSafeInteger(kib) || kib < 0 || kib > Number.MAX_SAFE_INTEGER / KIB) {
+    return null
+  }
+  return kib * KIB
+}
+
+async function readAvailableMemory(
+  platform: NodeJS.Platform,
+  total: number
+): Promise<{ bytes: number; source: HostAvailableMemorySource } | null> {
+  if (platform === 'darwin' && darwinAvailabilitySupported) {
+    const bytes = await readDarwinAvailableMemory(total)
+    if (bytes !== null) {
+      return { bytes, source: 'memory-pressure' }
+    }
+  }
+  if (platform === 'linux' && linuxAvailabilitySupported) {
+    const bytes = await readLinuxAvailableMemory()
+    if (bytes !== null) {
+      return { bytes, source: 'proc-meminfo' }
+    }
+  }
+  return null
+}
+
+async function readDarwinAvailableMemory(total: number): Promise<number | null> {
+  try {
+    const stdout = await execFileText('/usr/bin/memory_pressure', ['-Q'])
+    const available = parseDarwinAvailableMemory(stdout, total)
+    if (available !== null) {
+      return available
+    }
+  } catch {
+    // The built-in command is unavailable on older or restricted hosts.
+  }
+  darwinAvailabilitySupported = false
+  return null
+}
+
+async function readLinuxAvailableMemory(): Promise<number | null> {
+  try {
+    const meminfo = await readFile(path.join(path.sep, 'proc', 'meminfo'), 'utf8')
+    const available = parseLinuxAvailableMemory(meminfo)
+    if (available !== null) {
+      return available
+    }
+  } catch {
+    // Non-procfs Linux environments fall back to Node's host value.
+  }
+  linuxAvailabilitySupported = false
+  return null
+}
+
+function execFileText(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      {
+        encoding: 'utf8',
+        env: { ...process.env, LC_ALL: 'C', LANG: 'C' },
+        maxBuffer: MEMORY_PRESSURE_MAX_BUFFER,
+        timeout: MEMORY_PRESSURE_TIMEOUT_MS
+      },
+      (error, stdout) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve(String(stdout))
+      }
+    )
+  })
+}
+
+function nonNegativeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0
+}

--- a/src/main/memory/process-memory-metric.test.ts
+++ b/src/main/memory/process-memory-metric.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { getProcessMemoryMetric } from './process-memory-metric'
+
+describe('process memory metric', () => {
+  it('declares RSS for Unix process sweeps', () => {
+    expect(getProcessMemoryMetric('darwin')).toBe('rss')
+    expect(getProcessMemoryMetric('linux')).toBe('rss')
+  })
+
+  it('declares working set for Windows process sweeps', () => {
+    expect(getProcessMemoryMetric('win32')).toBe('working-set')
+  })
+})

--- a/src/main/memory/process-memory-metric.ts
+++ b/src/main/memory/process-memory-metric.ts
@@ -1,0 +1,8 @@
+import os from 'node:os'
+import type { ProcessMemoryMetric } from '../../shared/types'
+
+export function getProcessMemoryMetric(
+  platform: NodeJS.Platform = os.platform()
+): ProcessMemoryMetric {
+  return platform === 'win32' ? 'working-set' : 'rss'
+}

--- a/src/main/runtime/rpc/methods/diagnostics.test.ts
+++ b/src/main/runtime/rpc/methods/diagnostics.test.ts
@@ -23,11 +23,14 @@ describe('diagnostics RPC methods', () => {
       host: {
         totalMemory: 4096,
         freeMemory: 1024,
+        availableMemory: 1024,
+        availableMemorySource: 'free-memory',
         usedMemory: 3072,
         memoryUsagePercent: 75,
         cpuCoreCount: 8,
         loadAverage1m: 1.25
       },
+      processMemoryMetric: 'rss',
       totalCpu: 1,
       totalMemory: 1024,
       collectedAt: 123

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -66,6 +66,7 @@ import {
   getResourceManagerAriaLabel,
   getResourceManagerTooltipLines
 } from './resource-manager-terminal-copy'
+import { getResourceMemoryMetricCopy } from './resource-memory-metric-copy'
 import {
   buildResourceSessionBindingIndex,
   countUnboundDaemonSessions,
@@ -98,10 +99,6 @@ function formatMemory(bytes: number): string {
 
 function formatCpu(percent: number): string {
   return `${percent.toFixed(1)}%`
-}
-
-function formatPercent(value: number): string {
-  return `${value.toFixed(0)}%`
 }
 
 function formatMetricCpu(value: Metric): string {
@@ -962,14 +959,15 @@ export function ResourceUsageStatusSegment({
   // closed path used boundPtyIds (wake hints) and inflated the chip to 60+.
   const triggerSessionCount = sessionInventory.count
 
-  const { totalMemory, totalCpu, hostShare, memBadgeLabel } = useMemo(() => {
+  const memoryMetricCopy = getResourceMemoryMetricCopy(
+    resourceSnapshot?.processMemoryMetric ?? 'rss'
+  )
+  const { totalMemory, totalCpu, memBadgeLabel } = useMemo(() => {
     const memory = resourceSnapshot?.totalMemory ?? 0
     const cpu = resourceSnapshot?.totalCpu ?? 0
-    const hostTotal = resourceSnapshot?.host.totalMemory ?? 0
     return {
       totalMemory: memory,
       totalCpu: cpu,
-      hostShare: hostTotal > 0 ? (memory / hostTotal) * 100 : 0,
       memBadgeLabel: resourceSnapshot ? formatMemory(memory) : '—'
     }
   }, [resourceSnapshot])
@@ -979,7 +977,9 @@ export function ResourceUsageStatusSegment({
   // Why: sessions IPC can fail while snapshot IPC works; flag it so the empty session list isn't mistaken for healthy.
   const sessionsOnlyError = sessionsError && memorySnapshotError === null
   const resourceManagerTooltipLines = getResourceManagerTooltipLines({
-    memoryLabel: memBadgeLabel,
+    memoryLabel: resourceSnapshot
+      ? `${memBadgeLabel} · ${memoryMetricCopy.summaryLabel}`
+      : memBadgeLabel,
     sessionCount: triggerSessionCount,
     spaceScanReady
   })
@@ -1334,35 +1334,14 @@ export function ResourceUsageStatusSegment({
                     tabIndex={0}
                     className="font-medium text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:rounded"
                   >
-                    {formatMemory(totalMemory)}
+                    {formatMemory(totalMemory)}{' '}
+                    <span className="font-normal text-muted-foreground">
+                      {memoryMetricCopy.summaryLabel}
+                    </span>
                   </span>
                 </TooltipTrigger>
                 <TooltipContent side="top" sideOffset={6} className="z-[70] max-w-xs">
-                  {translate(
-                    'auto.components.status.bar.ResourceUsageStatusSegment.9e2525c89f',
-                    "Resident memory held by Orca plus the processes under each worktree's terminals."
-                  )}
-                </TooltipContent>
-              </Tooltip>
-              <span className="text-muted-foreground/50">·</span>
-              <Tooltip delayDuration={200}>
-                <TooltipTrigger asChild>
-                  <span
-                    tabIndex={0}
-                    className="text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:rounded"
-                  >
-                    {formatPercent(hostShare)}{' '}
-                    {translate(
-                      'auto.components.status.bar.ResourceUsageStatusSegment.e7ccce7e87',
-                      'of system RAM'
-                    )}
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top" sideOffset={6} className="z-[70] max-w-xs">
-                  {translate(
-                    'auto.components.status.bar.ResourceUsageStatusSegment.6449a95c78',
-                    "How much of this machine's physical RAM the Orca-tracked processes are sitting on."
-                  )}
+                  {memoryMetricCopy.description}
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -1439,10 +1418,7 @@ export function ResourceUsageStatusSegment({
                     )}
                     aria-pressed={sortOption === 'memory'}
                   >
-                    {translate(
-                      'auto.components.status.bar.ResourceUsageStatusSegment.1b24a32d3a',
-                      'Memory'
-                    )}
+                    {memoryMetricCopy.columnLabel}
                   </button>
                 </div>
                 {/* Why: empty trailing gutter keeps CPU/Memory header cells aligned with rows that reserve this width for the kill-X. */}

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -27,11 +27,14 @@ function makeSnapshot(worktrees: WorktreeMemory[]): MemorySnapshot {
     host: {
       totalMemory: 16e9,
       freeMemory: 8e9,
+      availableMemory: 8e9,
+      availableMemorySource: 'free-memory',
       usedMemory: 8e9,
       memoryUsagePercent: 50,
       cpuCoreCount: 8,
       loadAverage1m: 0
     },
+    processMemoryMetric: 'rss',
     totalCpu: worktrees.reduce((s, w) => s + w.cpu, 0),
     totalMemory: worktrees.reduce((s, w) => s + w.memory, 0),
     collectedAt: 0

--- a/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
+++ b/src/renderer/src/components/status-bar/resource-manager-terminal-copy.test.ts
@@ -14,12 +14,12 @@ describe('resource manager terminal copy', () => {
   it('points users from the status-bar count back to workspace terminals', () => {
     expect(
       getResourceManagerTooltipLines({
-        memoryLabel: '512 MB',
+        memoryLabel: '512 MB · Σ RSS',
         sessionCount: 2,
         spaceScanReady: false
       })
     ).toEqual([
-      'Resource Manager - 512 MB - 2 terminal sessions',
+      'Resource Manager - 512 MB · Σ RSS - 2 terminal sessions',
       'Terminal sessions are grouped by workspace.'
     ])
   })

--- a/src/renderer/src/components/status-bar/resource-memory-metric-copy.test.ts
+++ b/src/renderer/src/components/status-bar/resource-memory-metric-copy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+import { getResourceMemoryMetricCopy } from './resource-memory-metric-copy'
+
+describe('resource memory metric copy', () => {
+  it('discloses that Unix RSS sums can repeat shared and aliased pages', () => {
+    expect(getResourceMemoryMetricCopy('rss')).toEqual({
+      columnLabel: 'RSS',
+      summaryLabel: 'Σ RSS',
+      description:
+        'Summed resident set size (RSS). Shared or aliased pages can appear in more than one process.'
+    })
+  })
+
+  it('uses working-set terminology for Windows snapshots', () => {
+    expect(getResourceMemoryMetricCopy('working-set')).toEqual({
+      columnLabel: 'WS',
+      summaryLabel: 'Σ WS',
+      description: 'Summed working set (WS). Shared pages can appear in more than one process.'
+    })
+  })
+})

--- a/src/renderer/src/components/status-bar/resource-memory-metric-copy.ts
+++ b/src/renderer/src/components/status-bar/resource-memory-metric-copy.ts
@@ -1,0 +1,29 @@
+import type { ProcessMemoryMetric } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+
+export type ResourceMemoryMetricCopy = {
+  columnLabel: string
+  summaryLabel: string
+  description: string
+}
+
+export function getResourceMemoryMetricCopy(metric: ProcessMemoryMetric): ResourceMemoryMetricCopy {
+  if (metric === 'working-set') {
+    return {
+      columnLabel: 'WS',
+      summaryLabel: 'Σ WS',
+      description: translate(
+        'auto.components.status.bar.resource.memory.metric.workingSetDescription',
+        'Summed working set (WS). Shared pages can appear in more than one process.'
+      )
+    }
+  }
+  return {
+    columnLabel: 'RSS',
+    summaryLabel: 'Σ RSS',
+    description: translate(
+      'auto.components.status.bar.resource.memory.metric.rssDescription',
+      'Summed resident set size (RSS). Shared or aliased pages can appear in more than one process.'
+    )
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3359,6 +3359,14 @@
             "updatedTooltip": "Remote Orca Server updates completed",
             "failedOne": "1 server update failed",
             "updatedOne": "1 server updated"
+          },
+          "resource": {
+            "memory": {
+              "metric": {
+                "workingSetDescription": "Summed working set (WS). Shared pages can appear in more than one process.",
+                "rssDescription": "Summed resident set size (RSS). Shared or aliased pages can appear in more than one process."
+              }
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3336,6 +3336,14 @@
             "updatedTooltip": "Remote Orca Server updates completed",
             "failedOne": "1 server update failed",
             "updatedOne": "1 server updated"
+          },
+          "resource": {
+            "memory": {
+              "metric": {
+                "workingSetDescription": "Suma del conjunto de trabajo (WS). Las páginas compartidas pueden aparecer en más de un proceso.",
+                "rssDescription": "Suma del tamaño del conjunto residente (RSS). Las páginas compartidas o con alias pueden aparecer en más de un proceso."
+              }
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3336,6 +3336,14 @@
             "updatedTooltip": "Remote Orca Server updates completed",
             "failedOne": "1 server update failed",
             "updatedOne": "1 server updated"
+          },
+          "resource": {
+            "memory": {
+              "metric": {
+                "workingSetDescription": "ワーキングセット（WS）の合計です。共有ページは複数のプロセスに含まれる場合があります。",
+                "rssDescription": "常駐セットサイズ（RSS）の合計です。共有ページやエイリアスされたページは複数のプロセスに含まれる場合があります。"
+              }
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3336,6 +3336,14 @@
             "updatedTooltip": "Remote Orca Server updates completed",
             "failedOne": "1 server update failed",
             "updatedOne": "1 server updated"
+          },
+          "resource": {
+            "memory": {
+              "metric": {
+                "workingSetDescription": "작업 집합(WS)의 합계입니다. 공유 페이지가 여러 프로세스에 포함될 수 있습니다.",
+                "rssDescription": "상주 집합 크기(RSS)의 합계입니다. 공유되거나 별칭으로 매핑된 페이지가 여러 프로세스에 포함될 수 있습니다."
+              }
+            }
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3336,6 +3336,14 @@
             "updatedTooltip": "Remote Orca Server updates completed",
             "failedOne": "1 server update failed",
             "updatedOne": "1 server updated"
+          },
+          "resource": {
+            "memory": {
+              "metric": {
+                "workingSetDescription": "工作集 (WS) 的总和。共享页可能会出现在多个进程中。",
+                "rssDescription": "驻留集大小 (RSS) 的总和。共享页或别名映射页可能会出现在多个进程中。"
+              }
+            }
           }
         }
       },

--- a/src/renderer/src/store/slices/memory.test.ts
+++ b/src/renderer/src/store/slices/memory.test.ts
@@ -18,11 +18,14 @@ function makeMemorySnapshot(overrides: Partial<MemorySnapshot> = {}): MemorySnap
     host: {
       totalMemory: 8192,
       freeMemory: 4096,
+      availableMemory: 4096,
+      availableMemorySource: 'free-memory',
       usedMemory: 4096,
       memoryUsagePercent: 50,
       cpuCoreCount: 8,
       loadAverage1m: 1
     },
+    processMemoryMetric: 'rss',
     totalCpu: 1,
     totalMemory: 1024,
     collectedAt: 1,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3950,11 +3950,14 @@ function createEmptyMemorySnapshot(): MemorySnapshot {
     host: {
       totalMemory: 0,
       freeMemory: 0,
+      availableMemory: 0,
+      availableMemorySource: 'free-memory',
       usedMemory: 0,
       memoryUsagePercent: 0,
       cpuCoreCount: navigator.hardwareConcurrency || 1,
       loadAverage1m: 0
     },
+    processMemoryMetric: getBrowserPlatform() === 'win32' ? 'working-set' : 'rss',
     totalCpu: 0,
     totalMemory: 0,
     collectedAt: Date.now()

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3667,6 +3667,10 @@ export type UsageValues = {
   memory: number
 }
 
+export type ProcessMemoryMetric = 'rss' | 'working-set'
+
+export type HostAvailableMemorySource = 'memory-pressure' | 'proc-meminfo' | 'free-memory'
+
 /** The top-level cpu/memory are the sum of main + renderer + other. */
 export type AppMemory = UsageValues & {
   main: UsageValues
@@ -3695,7 +3699,12 @@ export type WorktreeMemory = UsageValues & {
 
 export type HostMemory = {
   totalMemory: number
+  /** Immediately free memory reported by Node's host API. */
   freeMemory: number
+  /** Memory available without material pressure, or freeMemory when unavailable. */
+  availableMemory: number
+  availableMemorySource: HostAvailableMemorySource
+  /** totalMemory - availableMemory. */
   usedMemory: number
   memoryUsagePercent: number
   cpuCoreCount: number
@@ -3706,9 +3715,11 @@ export type MemorySnapshot = {
   app: AppMemory
   worktrees: WorktreeMemory[]
   host: HostMemory
+  /** Per-process byte metric used by app, session, worktree, history, and totalMemory values. */
+  processMemoryMetric: ProcessMemoryMetric
   /** Sum of app + all tracked worktree sessions. Percent of a single core, so may exceed 100 on multi-core machines. */
   totalCpu: number
-  /** Sum of app + all tracked worktree sessions in bytes. NOT the same as host.totalMemory, which is physical RAM. */
+  /** Sum of per-process samples. Shared pages may repeat, so this can exceed host.totalMemory. */
   totalMemory: number
   collectedAt: number
 }


### PR DESCRIPTION
## Summary

- identify Resource Manager process totals as summed RSS on macOS/Linux and summed working set on Windows, including the UI column, summary, tooltip, CLI diagnostics, and typed snapshot contract
- calculate host usage from bounded platform availability data (`memory_pressure -Q` on macOS, `/proc/meminfo` on Linux, Node free memory on Windows/fallback) instead of treating immediately free pages as all available memory
- collect host availability concurrently with the existing process sweep and document why the bounded path does not poll `footprint` or `top`

## ELI5

Resource Manager was adding up each process's “memory pages I can see.” If several processes see the same shared page—or one macOS process maps the same page many times—that page can appear in the total more than once. It is like three roommates each listing the same sofa: adding their lists says there are three sofas, even though there is only one. The PR therefore calls the number what it is: **Σ RSS** on macOS/Linux or **Σ WS** on Windows. It is useful for finding which process tree is growing, but it is not a scale reading of unique physical RAM.

The host number had a separate problem: it treated memory that was cached or readily reclaimable as fully used. The PR asks the OS how much memory is actually available without material pressure, and keeps that host measurement separate from the process sum.

## Screenshots

Not included: the visual change is limited to compact `Σ RSS` / `Σ WS` summary text, `RSS` / `WS` column labels, and metric tooltips. The exact copy is covered by focused tests.

## Proof

### Accounting correctness

- A controlled macOS reproduction mapped one 64 MB backing file 800 times. `ps`/Orca reported about **52.5 GiB RSS**, while `vmmap` reported only about **26–28 MB physical footprint**. This proves summed RSS can exceed unique physical memory even when Orca claims each PID only once, so the former “of system RAM” presentation was invalid.
- On the review host, total RAM was `137,438,953,472` bytes and Node reported `31,499,730,944` immediately free bytes. The old `total - free` calculation reported **77.1% used**. `memory_pressure -Q` reported **79% available** (`108,576,773,243` bytes), so the new calculation reported **21.0% used**.
- The local macOS manual defines the percentage used by `memory_pressure` in terms of **available memory**. Linux uses the kernel's `MemAvailable`. Every preferred value is clamped to `[freeMemory, totalMemory]`; parse/read failure falls back to Node's value and declares `availableMemorySource: free-memory`.
- Focused metric, collector, diagnostics, renderer-copy, store, and CLI coverage passes: **9 files, 215 tests**.

### Performance budget

Resource Manager seeds one snapshot after session restore and polls every 2 seconds only while its popover is open. Renderer and main-process in-flight guards coalesce concurrent callers. The change adds one host probe per snapshot—not one per terminal, worktree, or process—and overlaps it with the existing process sweep.

Measured over 40 iterations on the review host:

| Operation | Mean | p95 | Max |
| --- | ---: | ---: | ---: |
| `memory_pressure -Q` | 1.26 ms | 1.65 ms | 1.99 ms |
| existing `ps` sweep | 30.53 ms | 33.64 ms | 33.92 ms |
| serial `ps` then host probe | 32.74 ms | 35.63 ms | 36.13 ms |
| concurrent sweep + host probe | 31.67 ms | 34.65 ms | 35.09 ms |

Concurrency limits mean added snapshot latency to about **1.14 ms** in this run. One hundred host probes consumed `0.05s` user + `0.08s` system CPU; at a 2-second open-popover cadence, that is roughly **0.065% of one core**. The command is also capped at a 1-second timeout and 64 KiB output. Unsupported preferred probes are cached so a restricted host does not retry a stable negative result every poll.

The investigation rejected per-process alternatives on this hot path: `footprint` across 50 processes took about **9.66 seconds and 103 CPU-seconds**, while `top` took about **1.2 seconds** even for a tiny target set. Those costs are unsafe during the worker-storm scenario this UI must diagnose.

### Cross-platform and workspace behavior

| Environment | Process metric | Host availability | Evidence/behavior |
| --- | --- | --- | --- |
| macOS | `ps` RSS | fixed `/usr/bin/memory_pressure -Q`, then Node fallback | real-host measurement plus parser/fallback tests |
| Linux | `ps` RSS | `/proc/meminfo` `MemAvailable`, then Node fallback | parser/clamp tests; Ubuntu native smoke passes |
| Windows | CIM/Typeperf working set | Node available/free physical memory | platform-selection/fallback tests; Windows native smoke passes |
| SSH/relay | no invented local process sample for a remote PTY | snapshot describes the host executing the collector | existing remote exclusion remains unchanged |
| folder workspace | same registered-PTY attribution as git worktrees | same executing-host snapshot | no git-worktree assumption added |

Older runtime snapshots remain readable: UI and CLI use RSS/free-memory display fallbacks when the new declarative fields are absent.

## Testing

- [ ] `pnpm lint` — reaches an existing localization-coverage failure for unchanged `terminal-advanced-platform-search.ts` and `terminal-pane-appearance-search.ts` Ghostty keywords; changed-file oxlint and all preceding repository gates pass
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 36,916 passed; 2 unrelated filesystem-watcher timing tests failed under full-suite load, then all 28 tests in `src/main/native-chat/transcript-watch.test.ts` passed in isolation
- [x] `pnpm run build:electron-vite`
- [x] Added focused host-availability parser/fallback, platform metric, UI copy, CLI diagnostics, RPC fixture, store, and web-fallback coverage (215 focused tests pass)
- [x] Changed-file `oxfmt --check`, localization catalog parity, max-lines ratchet, reliability manifest checks, and `git diff --check`
- [x] GitHub Ubuntu and Windows native-smoke jobs

## AI Review Report

No blocking correctness, performance, or cross-platform findings remain. The review traced input/authority boundaries, clamping and parser behavior, failure fallback, in-flight concurrency, polling scope, snapshot compatibility, and the lack of retained per-poll state. It also verified that the UI no longer compares a repeatable process sum with physical RAM.

Cross-platform review covered macOS RSS plus `memory_pressure`, Linux RSS plus procfs `MemAvailable`, and Windows working-set plus Node host-memory fallback. No shortcut, shell-label, or Electron platform behavior is changed. Paths use Node path primitives or a fixed macOS system binary. SSH/relay sessions still do not receive invented local process samples, and folder workspaces keep the same registered-PTY attribution as git worktrees.

The explicit fallback tradeoff is lower-fidelity host availability after a preferred probe fails: the source changes to `free-memory`, so diagnostics do not misrepresent how the value was obtained.

## Security Audit

The macOS probe uses `execFile` with a fixed absolute executable and fixed arguments, not a shell or user-controlled input, and is bounded by a 1-second timeout and 64 KiB output cap. The Linux probe reads the fixed procfs meminfo path and parses one bounded integer. No auth, secrets, dependencies, network access, or new IPC method is introduced; the existing typed diagnostics snapshot gains declarative fields only.

## Notes

This corrects the accounting semantics and host-pressure approximation while preserving the bounded process sweep. It intentionally does not label RSS/working-set sums as unique physical footprint and does not poll expensive per-process tools in the worker-storm path.

Refs #10768
