### PR TITLE
feat(usage): price Claude 5 family and GPT-5.6 token usage

### DIFF
--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -343,27 +343,34 @@ describe('ClaudeUsageStore', () => {
 
   it('does not collapse Opus 4.5 or Sonnet 4.5 usage into Claude 5 pricing', async () => {
     const store = createStoreWithState({
-      dailyAggregates: [
-        {
-          day: '2026-04-09',
-          model: 'claude-sonnet-4-5-20250929',
-          projectKey: 'worktree:repo-1::/workspace/repo-a',
-          projectLabel: 'Repo A',
-          repoId: 'repo-1',
-          worktreeId: 'repo-1::/workspace/repo-a',
-          turnCount: 1,
-          zeroCacheReadTurnCount: 0,
-          inputTokens: 300_000,
-          outputTokens: 300_000,
-          cacheReadTokens: 300_000,
-          cacheWriteTokens: 300_000
-        }
-      ]
+      dailyAggregates: ['claude-sonnet-4-5-20250929', 'claude-opus-4-5-20251101'].map((model) => ({
+        day: '2026-04-09',
+        model,
+        projectKey: 'worktree:repo-1::/workspace/repo-a',
+        projectLabel: 'Repo A',
+        repoId: 'repo-1',
+        worktreeId: 'repo-1::/workspace/repo-a',
+        turnCount: 1,
+        zeroCacheReadTurnCount: 0,
+        inputTokens: 300_000,
+        outputTokens: 300_000,
+        cacheReadTokens: 300_000,
+        cacheWriteTokens: 300_000
+      }))
     })
 
-    const summary = await store.getSummary('orca', '30d')
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
 
-    expect(summary.estimatedCostUsd).toBeCloseTo(8.07)
+    // Why: the 4.5 tier premium only survives if `-4-5-` never matches the `-5`
+    // family regex, so this doubles as the digit-boundary proof for both families.
+    expect(
+      breakdown.find((row) => row.key === 'claude-sonnet-4-5-20250929')?.estimatedCostUsd
+    ).toBeCloseTo(8.07)
+    // Why: Opus 4.5 and Opus 5 share rates today, so this pins the rate rather
+    // than the routing — it fails only if the two ever diverge.
+    expect(
+      breakdown.find((row) => row.key === 'claude-opus-4-5-20251101')?.estimatedCostUsd
+    ).toBeCloseTo(11.025)
   })
 
   it('prices unknown newer Opus 4 point releases with current Opus rates', async () => {

--- a/src/main/claude-usage/store.test.ts
+++ b/src/main/claude-usage/store.test.ts
@@ -254,6 +254,118 @@ describe('ClaudeUsageStore', () => {
     ).toBeCloseTo(36.75)
   })
 
+  it('prices Claude 5 family models with current Anthropic rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'claude-opus-5',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        },
+        {
+          day: '2026-04-09',
+          model: 'anthropic/claude-fable-5',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        },
+        {
+          day: '2026-04-09',
+          model: 'claude-sonnet-5-thinking',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000
+        }
+      ]
+    })
+
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(breakdown.find((row) => row.key === 'claude-opus-5')?.estimatedCostUsd).toBeCloseTo(
+      36.75
+    )
+    expect(
+      breakdown.find((row) => row.key === 'anthropic/claude-fable-5')?.estimatedCostUsd
+    ).toBeCloseTo(73.5)
+    expect(
+      breakdown.find((row) => row.key === 'claude-sonnet-5-thinking')?.estimatedCostUsd
+    ).toBeCloseTo(22.05)
+  })
+
+  it('prices Sonnet 5 long-context usage at flat rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'claude-sonnet-5',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 300_000,
+          outputTokens: 300_000,
+          cacheReadTokens: 300_000,
+          cacheWriteTokens: 300_000
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+
+    // Why: Sonnet 4.6 and earlier bill above 200k at a premium; Sonnet 5 does not.
+    expect(summary.estimatedCostUsd).toBeCloseTo(6.615)
+  })
+
+  it('does not collapse Opus 4.5 or Sonnet 4.5 usage into Claude 5 pricing', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: [
+        {
+          day: '2026-04-09',
+          model: 'claude-sonnet-4-5-20250929',
+          projectKey: 'worktree:repo-1::/workspace/repo-a',
+          projectLabel: 'Repo A',
+          repoId: 'repo-1',
+          worktreeId: 'repo-1::/workspace/repo-a',
+          turnCount: 1,
+          zeroCacheReadTurnCount: 0,
+          inputTokens: 300_000,
+          outputTokens: 300_000,
+          cacheReadTokens: 300_000,
+          cacheWriteTokens: 300_000
+        }
+      ]
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(8.07)
+  })
+
   it('prices unknown newer Opus 4 point releases with current Opus rates', async () => {
     const store = createStoreWithState({
       dailyAggregates: [

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -59,6 +59,10 @@ const SONNET_LONG_CONTEXT_PRICING = {
 } satisfies Partial<ClaudeModelPricing>
 
 const MODEL_PRICING: Record<string, ClaudeModelPricing> = {
+  'claude-fable-5': { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
+  'claude-opus-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  // Why: Sonnet 5 bills its full 1M window at flat rates, so no long-context tier here.
+  'claude-sonnet-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-6': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
@@ -156,6 +160,12 @@ function normalizeModelForPricing(model: string | null): string | null {
   if (alias) {
     return alias
   }
+  if (hasClaudeModelVersion(lower, 'fable', '5')) {
+    return 'claude-fable-5'
+  }
+  if (hasClaudeModelVersion(lower, 'opus', '5')) {
+    return 'claude-opus-5'
+  }
   if (hasClaudeModelVersion(lower, 'opus', '4-8')) {
     return 'claude-opus-4-8'
   }
@@ -178,6 +188,9 @@ function normalizeModelForPricing(model: string | null): string | null {
     // Why: new Opus 4 point releases now share the current low Opus pricing;
     // avoid overbilling unknown future Claude Code model IDs as legacy Opus 4.
     return 'claude-opus-4-8'
+  }
+  if (hasClaudeModelVersion(lower, 'sonnet', '5')) {
+    return 'claude-sonnet-5'
   }
   if (hasClaudeModelVersion(lower, 'sonnet', '4-6')) {
     return 'claude-sonnet-4-6'

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -62,6 +62,7 @@ const MODEL_PRICING: Record<string, ClaudeModelPricing> = {
   'claude-fable-5': { input: 10, output: 50, cacheRead: 1, cacheWrite: 12.5 },
   'claude-opus-5': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   // Why: Sonnet 5 bills its full 1M window at flat rates, so no long-context tier here.
+  // Why: standard rates, not the $2/$10 introductory rate ending 2026-08-31 — no date dimension.
   'claude-sonnet-5': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   'claude-opus-4-8': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
   'claude-opus-4-7': { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },

--- a/src/main/codex-usage/store.test.ts
+++ b/src/main/codex-usage/store.test.ts
@@ -364,6 +364,67 @@ describe('CodexUsageStore', () => {
     expect(breakdown.find((row) => row.key === 'gpt-5.5')?.estimatedCostUsd).toBeCloseTo(50.424)
   })
 
+  it('prices GPT-5.6 sol, terra, and luna with current OpenAI rates', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'].map((model) => ({
+        day: '2026-04-09',
+        model,
+        projectKey: 'worktree:repo-1::/workspace/repo',
+        projectLabel: 'Repo',
+        repoId: 'repo-1',
+        worktreeId: 'repo-1::/workspace/repo',
+        eventCount: 1,
+        inputTokens: 2_000_000,
+        cachedInputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        reasoningOutputTokens: 100_000,
+        totalTokens: 3_000_000,
+        hasInferredPricing: false
+      }))
+    })
+
+    const summary = await store.getSummary('orca', '30d')
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(summary.estimatedCostUsd).toBeCloseTo(85.7208)
+    expect(breakdown.find((row) => row.key === 'gpt-5.6-sol')?.estimatedCostUsd).toBeCloseTo(50.424)
+    expect(breakdown.find((row) => row.key === 'gpt-5.6-terra')?.estimatedCostUsd).toBeCloseTo(
+      25.212
+    )
+    expect(breakdown.find((row) => row.key === 'gpt-5.6-luna')?.estimatedCostUsd).toBeCloseTo(
+      10.0848
+    )
+  })
+
+  it('normalizes GPT-5.6 reasoning suffixes before pricing', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: ['gpt-5.6-terra-high', 'gpt-5.6-luna(medium)'].map((model) => ({
+        day: '2026-04-09',
+        model,
+        projectKey: 'worktree:repo-1::/workspace/repo',
+        projectLabel: 'Repo',
+        repoId: 'repo-1',
+        worktreeId: 'repo-1::/workspace/repo',
+        eventCount: 1,
+        inputTokens: 100_000,
+        cachedInputTokens: 50_000,
+        outputTokens: 25_000,
+        reasoningOutputTokens: 5_000,
+        totalTokens: 125_000,
+        hasInferredPricing: false
+      }))
+    })
+
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(breakdown.find((row) => row.key === 'gpt-5.6-terra-high')?.estimatedCostUsd).toBeCloseTo(
+      0.5125
+    )
+    expect(
+      breakdown.find((row) => row.key === 'gpt-5.6-luna(medium)')?.estimatedCostUsd
+    ).toBeCloseTo(0.205)
+  })
+
   it('normalizes Codex model variants and reasoning suffixes before pricing', async () => {
     const store = createStoreWithState({
       dailyAggregates: [

--- a/src/main/codex-usage/store.test.ts
+++ b/src/main/codex-usage/store.test.ts
@@ -425,6 +425,31 @@ describe('CodexUsageStore', () => {
     ).toBeCloseTo(0.205)
   })
 
+  it('prices the bare gpt-5.6 alias at Sol rates without shadowing the tier IDs', async () => {
+    const store = createStoreWithState({
+      dailyAggregates: ['gpt-5.6', 'gpt-5.6-luna'].map((model) => ({
+        day: '2026-04-09',
+        model,
+        projectKey: 'worktree:repo-1::/workspace/repo',
+        projectLabel: 'Repo',
+        repoId: 'repo-1',
+        worktreeId: 'repo-1::/workspace/repo',
+        eventCount: 1,
+        inputTokens: 100_000,
+        cachedInputTokens: 50_000,
+        outputTokens: 25_000,
+        reasoningOutputTokens: 5_000,
+        totalTokens: 125_000,
+        hasInferredPricing: false
+      }))
+    })
+
+    const breakdown = await store.getBreakdown('orca', '30d', 'model')
+
+    expect(breakdown.find((row) => row.key === 'gpt-5.6')?.estimatedCostUsd).toBeCloseTo(1.025)
+    expect(breakdown.find((row) => row.key === 'gpt-5.6-luna')?.estimatedCostUsd).toBeCloseTo(0.205)
+  })
+
   it('normalizes Codex model variants and reasoning suffixes before pricing', async () => {
     const store = createStoreWithState({
       dailyAggregates: [

--- a/src/main/codex-usage/store.ts
+++ b/src/main/codex-usage/store.ts
@@ -90,6 +90,30 @@ const MODEL_PRICING: Record<string, CodexModelPricing> = {
     inputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 10 }],
     cachedInputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 1 }],
     outputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 45 }]
+  },
+  'gpt-5.6-sol': {
+    input: 5,
+    cachedInput: 0.5,
+    output: 30,
+    inputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 10 }],
+    cachedInputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 1 }],
+    outputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 45 }]
+  },
+  'gpt-5.6-terra': {
+    input: 2.5,
+    cachedInput: 0.25,
+    output: 15,
+    inputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 5 }],
+    cachedInputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 0.5 }],
+    outputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 22.5 }]
+  },
+  'gpt-5.6-luna': {
+    input: 1,
+    cachedInput: 0.1,
+    output: 6,
+    inputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 2 }],
+    cachedInputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 0.2 }],
+    outputTiers: [{ threshold: LONG_CONTEXT_THRESHOLD_TOKENS, price: 9 }]
   }
 }
 
@@ -227,6 +251,15 @@ function normalizeModelForPricing(model: string | null): string | null {
   }
   if (normalized === 'gpt-5.5' || normalized.startsWith('gpt-5.5-')) {
     return 'gpt-5.5'
+  }
+  if (normalized === 'gpt-5.6-sol' || normalized.startsWith('gpt-5.6-sol-')) {
+    return 'gpt-5.6-sol'
+  }
+  if (normalized === 'gpt-5.6-terra' || normalized.startsWith('gpt-5.6-terra-')) {
+    return 'gpt-5.6-terra'
+  }
+  if (normalized === 'gpt-5.6-luna' || normalized.startsWith('gpt-5.6-luna-')) {
+    return 'gpt-5.6-luna'
   }
   return null
 }

--- a/src/main/codex-usage/store.ts
+++ b/src/main/codex-usage/store.ts
@@ -261,6 +261,12 @@ function normalizeModelForPricing(model: string | null): string | null {
   if (normalized === 'gpt-5.6-luna' || normalized.startsWith('gpt-5.6-luna-')) {
     return 'gpt-5.6-luna'
   }
+  // Why: OpenAI routes the bare `gpt-5.6` alias to Sol. Match it exactly — a
+  // `gpt-5.6-` prefix match would swallow the tier IDs above and any future
+  // cheaper variant.
+  if (normalized === 'gpt-5.6') {
+    return 'gpt-5.6-sol'
+  }
   return null
 }
 


### PR DESCRIPTION
Closes STA-2684.

## Problem

Usage analytics scanned turns for Claude Opus 5 / Sonnet 5 / Fable 5 and Codex `gpt-5.6-*`, aggregated their tokens, and then reported **no cost** for them — those model IDs were missing from both pricing tables, so `estimateCostUsd` returned `null` and the spend silently vanished from the totals.

On my own machine that was ~$14.5k of Claude and ~$30.5k of Codex API-equivalent spend not showing up.

## Change

`src/main/claude-usage/store.ts` — added `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, plus family matchers ahead of the existing Opus 4 / Sonnet 4 branches.

`src/main/codex-usage/store.ts` — added `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` with their long-context tiers, plus normalization (reasoning suffixes like `-xhigh` / `(medium)` already strip before lookup).

Rates from [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing) and [OpenAI pricing](https://developers.openai.com/api/docs/pricing).

| Model | Input | Output | Cache read | Cache write |
|---|---|---|---|---|
| `claude-fable-5` | $10 | $50 | $1 | $12.50 |
| `claude-opus-5` | $5 | $25 | $0.50 | $6.25 |
| `claude-sonnet-5` | $3 | $15 | $0.30 | $3.75 |

| Model | Input | Cached input | Output | (long ctx >272k) |
|---|---|---|---|---|
| `gpt-5.6-sol` | $5 | $0.50 | $30 | $10 / $1 / $45 |
| `gpt-5.6-terra` | $2.50 | $0.25 | $15 | $5 / $0.50 / $22.50 |
| `gpt-5.6-luna` | $1 | $0.10 | $6 | $2 / $0.20 / $9 |

### Two judgement calls worth reviewing

1. **Sonnet 5 gets no long-context tier.** Sonnet 4/4.5/4.6 carry a >200k premium in our table, but Anthropic's pricing page now states Claude 4.6 and later bill the full 1M window at standard rates. So Sonnet 5 is flat.
2. **Sonnet 5 uses the standard $3/$15, not the $2/$10 introductory rate** in effect through 2026-08-31. The pricing table has no date dimension, and standard is the durable value — this slightly overstates Sonnet 5 cost until Sept 1.

## Verification

Unit tests (`pnpm vitest run src/main/claude-usage/store.test.ts src/main/codex-usage/store.test.ts`) — 25 pass, including a guard that Sonnet 4.5 still gets tiered pricing while Sonnet 5 does not.

Live in the app against real on-disk logs (dev build, isolated profile, both providers enabled through the settings UI). Arithmetic checked exactly against the rendered totals:

- `claude-opus-5` → $2809.165289, matches `(99618×5 + 14699089×25 + 3181270073×0.5 + 136088790×6.25)/1e6` exactly
- `claude-sonnet-5` → $29.4146736, exact
- `gpt-5.6-luna` → $1.2864912, exact (`gpt-5.6-sol` differs from a whole-total calc by $0.01 because cost is summed per daily row, so each row tiers independently — pre-existing behavior)

![orca-2684-models.png](https://github.com/user-attachments/assets/f9fe28d0-c42c-4728-9ba3-5cee1d6d31ee)

![orca-2684-codex-models.png](https://github.com/user-attachments/assets/d8c32903-781f-42c3-ae50-91b07360911a)

## Not in scope

- **`claude-sonnet-4-6` may now be mispriced above 200k.** Its long-context tier predates the flat-rate 1M policy, so we likely overcharge Sonnet 4.6 usage past 200k tokens. Left alone to keep this PR on one thing — happy to file a follow-up.
- `claude-mythos-5` (Project Glasswing, invitation-only) is not in the model picker, so it's not added.
- The "Unknown model — inferred pricing" row in the Codex screenshot is pre-existing (sessions with no model recorded), unrelated to this change.
