### PR TITLE
fix(notifications): suppress stale completion alerts after compaction

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -2996,6 +2996,25 @@ describe('AgentHookServer listener replay', () => {
           })
         })
       )
+
+      const completedSnapshot = server.getStatusSnapshot()[0]
+      const completedEventCount = listener.mock.calls.length
+      await postCodexHook({
+        hook_event_name: 'SessionStart',
+        source: 'compact'
+      })
+      expect(listener).toHaveBeenCalledTimes(completedEventCount)
+      expect(server.getStatusSnapshot()[0]).toEqual(completedSnapshot)
+
+      await postCodexHook({
+        hook_event_name: 'Stop',
+        last_assistant_message: 'compacted'
+      })
+      expect(server.getStatusSnapshot()[0]).toMatchObject({
+        state: 'done',
+        prompt: 'ship codex hook status',
+        stateStartedAt: completedSnapshot.stateStartedAt
+      })
     } finally {
       server.stop()
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -18121,6 +18121,56 @@ describe('connectPanePty', () => {
     )
   })
 
+  it.each([
+    ['Claude', 'claude', '✳ Compacted'],
+    ['Codex', 'codex', '* Codex done']
+  ] as const)(
+    'ignores %s compact title completion while hook state remains on the previous turn',
+    async (_label, agentType, idleTitle) => {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport(`pty-${agentType}`)
+      transportFactoryQueue.push(transport)
+      vi.useFakeTimers()
+      const paneKey = makePaneKey('tab-1', LEAF_1)
+      mockStoreState.agentStatusByPaneKey[paneKey] = {
+        state: 'done',
+        prompt: 'previous task',
+        updatedAt: Date.now(),
+        stateStartedAt: Date.now(),
+        agentType,
+        paneKey,
+        stateHistory: [],
+        lastAssistantMessage: 'Previous task completed.'
+      }
+
+      const pane = createPane(1)
+      const manager = createManager(1)
+      const deps = createDeps()
+
+      connectPanePty(pane as never, manager as never, deps as never)
+
+      const workingHandler = createdTransportOptions[0]?.onAgentBecameWorking as
+        | (() => void)
+        | undefined
+      const idleHandler = createdTransportOptions[0]?.onAgentBecameIdle as
+        | ((title: string) => void)
+        | undefined
+      if (!workingHandler || !idleHandler) {
+        throw new Error('Expected working and idle handlers to be registered')
+      }
+
+      vi.advanceTimersByTime(1)
+      workingHandler()
+      vi.advanceTimersByTime(1_000)
+      idleHandler(idleTitle)
+      vi.advanceTimersByTime(AGENT_TASK_COMPLETE_NOTIFICATION_MAX_WAIT_MS)
+
+      expect(deps.dispatchNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'agent-task-complete' })
+      )
+    }
+  )
+
   it('ignores title-only idle while fresh hook status is still working', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -18122,11 +18122,12 @@ describe('connectPanePty', () => {
   })
 
   it.each([
-    ['Claude', 'claude', '✳ Compacted'],
-    ['Codex', 'codex', '* Codex done']
+    ['Claude', 'claude', '✳ Compacted', 1],
+    ['Codex', 'codex', '* Codex done', 1],
+    ['Claude with equal hook/title timestamps', 'claude', '✳ Compacted', 0]
   ] as const)(
     'ignores %s compact title completion while hook state remains on the previous turn',
-    async (_label, agentType, idleTitle) => {
+    async (_label, agentType, idleTitle, titleWorkingDelayMs) => {
       const { connectPanePty } = await import('./pty-connection')
       const transport = createMockTransport(`pty-${agentType}`)
       transportFactoryQueue.push(transport)
@@ -18159,7 +18160,7 @@ describe('connectPanePty', () => {
         throw new Error('Expected working and idle handlers to be registered')
       }
 
-      vi.advanceTimersByTime(1)
+      vi.advanceTimersByTime(titleWorkingDelayMs)
       workingHandler()
       vi.advanceTimersByTime(1_000)
       idleHandler(idleTitle)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1435,6 +1435,28 @@ export function connectPanePty(
       activeHookAgentForTitle !== explicitTitleAgentType
     return !titleNamesDifferentKnownAgent
   }
+  const shouldSuppressTitleCompletionWithoutNewHookTurn = (
+    title: string,
+    hookStatus: AgentStatusEntry | undefined,
+    titleWorkingStartedAt: number | null
+  ): boolean => {
+    // Why: compaction toggles native titles without opening a hook turn, so a prior `done` row cannot prove completion.
+    if (
+      titleWorkingStartedAt === null ||
+      hookStatus?.state !== 'done' ||
+      hookStatus.updatedAt >= titleWorkingStartedAt ||
+      (hookStatus.agentType !== 'claude' && hookStatus.agentType !== 'codex')
+    ) {
+      return false
+    }
+    const explicitTitleAgentType = resolveCommittedTitleAgentType(title)
+    return (
+      explicitTitleAgentType === null ||
+      resolveCompatibleAgentTypeForOwner(hookStatus.agentType, explicitTitleAgentType) ===
+        explicitTitleAgentType
+    )
+  }
+  let titleWorkingStartedAt: number | null = null
   let pendingSuppressedTitleSideEffects: {
     title: string
     agentType: AgentType | undefined
@@ -3105,11 +3127,18 @@ export function connectPanePty(
     // that renderer timer throttling previously damped. Clear session-tied
     // state only; never schedule completion attention from it.
     if (meta?.staleWorkingTitleClear) {
+      titleWorkingStartedAt = null
       deps.setCacheTimerStartedAt(cacheKey, null)
       return
     }
     const currentState = useAppStore.getState()
     const activeHookStatus = currentState.agentStatusByPaneKey[cacheKey]
+    const suppressCompletionWithoutNewHookTurn = shouldSuppressTitleCompletionWithoutNewHookTurn(
+      title,
+      activeHookStatus,
+      titleWorkingStartedAt
+    )
+    titleWorkingStartedAt = null
     if (shouldSuppressTitleCompletionForFreshHook(title, activeHookStatus)) {
       // Why: agent CLIs can briefly publish an idle title while hook status
       // still says the same agent turn is active (e.g. during tool output).
@@ -3135,7 +3164,7 @@ export function connectPanePty(
     if (detectAgentStatusFromTitle(title) === 'idle') {
       setFocusReportSuppressionForAgentCompletion(title, activeHookStatus?.agentType)
     }
-    if (syncAgentTaskCompleteTrackingEnabled()) {
+    if (syncAgentTaskCompleteTrackingEnabled() && !suppressCompletionWithoutNewHookTurn) {
       agentCompletionCoordinator.observeClassifiedTitleCompletion(title)
     }
     // Why: some agent TUIs leave xterm renderer modes active after a turn.
@@ -3143,6 +3172,7 @@ export function connectPanePty(
     queueAgentIdleTerminalModeReset()
   }
   const onAgentBecameWorking = (): void => {
+    titleWorkingStartedAt = Date.now()
     suppressNativeWindowsIdleCodexFocusReports = false
     clearSuppressedTitleSideEffects()
     if (syncAgentTaskCompleteTrackingEnabled()) {
@@ -3158,6 +3188,7 @@ export function connectPanePty(
     }
   }
   const onAgentExited = (): void => {
+    titleWorkingStartedAt = null
     // Why: eligibility can disappear transiently during reconnect, but a
     // confirmed shell-title transition is authoritative for native-chat exit.
     deps.onAgentExitedRef.current(pane.leafId)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1444,7 +1444,7 @@ export function connectPanePty(
     if (
       titleWorkingStartedAt === null ||
       hookStatus?.state !== 'done' ||
-      hookStatus.updatedAt >= titleWorkingStartedAt ||
+      hookStatus.updatedAt > titleWorkingStartedAt ||
       (hookStatus.agentType !== 'claude' && hookStatus.agentType !== 'codex')
     ) {
       return false

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -2595,6 +2595,49 @@ describe('shared agent-hook-listener', () => {
     expect(working?.payload.interactivePrompt).toBeUndefined()
   })
 
+  it('keeps Codex compaction inside the current turn', () => {
+    normalizeHookPayload(
+      state,
+      'codex',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'UserPromptSubmit',
+          prompt: 'finish the current task'
+        }
+      },
+      'production'
+    )
+    const compacted = normalizeHookPayload(
+      state,
+      'codex',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'SessionStart',
+          source: 'compact'
+        }
+      },
+      'production'
+    )
+    const stopped = normalizeHookPayload(
+      state,
+      'codex',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'Stop' }
+      },
+      'production'
+    )
+
+    expect(compacted).toBeNull()
+    expect(stopped?.payload).toMatchObject({
+      state: 'done',
+      prompt: 'finish the current task',
+      agentType: 'codex'
+    })
+  })
+
   it('clears stale Droid tool input when a same-tool update has explicit unpreviewable input', () => {
     normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -3234,6 +3234,10 @@ function normalizeCodexEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
+  // Why: Codex emits SessionStart after compaction, but it continues the current turn.
+  if (eventName === 'SessionStart' && readString(hookPayload, 'source') === 'compact') {
+    return null
+  }
   if (eventName === 'SubagentStart' || eventName === 'SubagentStop') {
     return normalizeCodexSubagentLifecycleEvent(state, eventName, paneKey, hookPayload)
   }


### PR DESCRIPTION
## Summary

- Prevent Codex `SessionStart` events with `source: compact` from creating a synthetic new turn.
- Ignore Claude and Codex title-based completion transitions when no new hook turn has started.
- Prevent compaction from showing an Agent Task Complete notification containing the previous task's prompt or assistant response.
- Preserve normal completion notifications when the current turn has fresh hook activity.

Related but distinct from #9333 / #9507: those defer intermediate Codex `Stop` notifications while output continues. This PR prevents compaction-only lifecycle/title transitions from replaying a previous turn's completion notification, including the Claude Code title-based path.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
  - Run on Node v24.18.0; all stages passed except localization coverage, which reports six unrelated Ghostty search keywords in untouched settings files.
  - Changed-file `oxlint` and formatting checks passed; max-lines ratchet passed.
- [x] `pnpm typecheck`
  - Full command passed on Node v24.18.0.
- [ ] `pnpm test`
  - Targeted hook server, hook normalizer, and PTY connection suites passed on Node v24.18.0: 838 tests.
- [ ] `pnpm build`
  - Not run.
- [x] Added high-quality regression tests covering both Claude Code and Codex compaction title transitions.

## AI Review Report

The initial review found that the Codex compact hook could create an incorrect turn boundary. Review based on a real Claude Code reproduction found a second path: Claude's native terminal title can transition from working to idle during compaction even though Orca receives no new Claude hook turn. That title-only completion reused the previous `done` hook snapshot.

The implementation now requires fresh hook activity after title-based work begins before a Claude or Codex title transition can complete that turn.

Reviewed risks:

- Normal Claude and Codex task completions still notify when their current-turn hook status is updated.
- Explicit titles belonging to another agent are not suppressed.
- Other supported agents retain their existing title fallback behavior.
- The check adds only constant-time timestamp and identity comparisons on title transitions.
- macOS, Linux, Windows, local, remote, and SSH behavior were reviewed. The change uses renderer timestamps and existing agent identity resolution and introduces no platform-specific paths, shortcuts, labels, shell behavior, or Electron APIs.
- No UI layout, styling, or interaction surface changes.

## Security Audit

No new command execution, filesystem access, path handling, authentication, dependency, secret, or IPC behavior was added.

Terminal titles are only compared through existing agent identity resolution and are not executed or interpolated into commands. Hook payload handling remains bounded by the existing normalizer.

Follow-up needed: none.

## Notes

- The issue was reproduced with Claude Code as well as identified in the Codex lifecycle path.
- Other agent integrations are unchanged.
- Local verification used Node v24.18.0, matching the repository engine.
- X handle: N/A

## ELI5

After Orca compacted (summarized) a long agent chat, you could still get a fake "task complete" notification with the old task's text. This stops compaction from looking like a new turn, so only real finishes ring the bell.
