### PR TITLE
lint: guard the two perf bug shapes we fixed repeatedly

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -49,6 +49,23 @@
     ],
     "curly": "error",
     "no-unneeded-ternary": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@linear/sdk",
+            "allowTypeImports": true,
+            "message": "Value-importing @linear/sdk hoists its ~2.6MB CJS bundle into the eager top-level require block and defeats the lazy loader. Use `import type` plus loadLinearSdk() from src/main/linear/linear-sdk.ts."
+          },
+          {
+            "name": "qrcode",
+            "allowTypeImports": true,
+            "message": "qrcode is only reachable from mobile pairing; a static import parses it at launch for everyone. Use `import type` plus `await import('qrcode')` at the call site."
+          }
+        ]
+      }
+    ],
     "no-useless-return": "error",
     "prefer-template": "error",
     "unicorn/consistent-empty-array-spread": "error",

--- a/config/scripts/check-quadratic-buffer-concat.mjs
+++ b/config/scripts/check-quadratic-buffer-concat.mjs
@@ -1,0 +1,343 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import process from 'node:process'
+
+// TypeScript 7 is a native CLI; AST consumers still need the legacy JavaScript API.
+import ts from 'typescript-api'
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.mts', '.cts'])
+const SKIP_PATH_PARTS = new Set(['node_modules', 'dist', 'out', '.git', '__snapshots__'])
+const SCAN_ROOTS = ['src', 'config/scripts', 'tools', 'tests', 'mobile']
+
+const LOOP_KINDS = new Set([
+  ts.SyntaxKind.ForStatement,
+  ts.SyntaxKind.ForInStatement,
+  ts.SyntaxKind.ForOfStatement,
+  ts.SyntaxKind.WhileStatement,
+  ts.SyntaxKind.DoStatement
+])
+
+const ASSIGNMENT_OPERATORS = new Set([
+  ts.SyntaxKind.EqualsToken,
+  ts.SyntaxKind.PlusEqualsToken,
+  ts.SyntaxKind.QuestionQuestionEqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken
+])
+
+function normalizeReferenceText(text) {
+  return text.replaceAll(/\s+/g, '')
+}
+
+// The variable a member/call chain ultimately reads, so `carry.subarray(0, n)`
+// still resolves to `carry`. `this.x` stops at the property: the class field is
+// the accumulator.
+function rootReferenceText(node) {
+  if (ts.isIdentifier(node)) {
+    return node.text
+  }
+  if (ts.isPropertyAccessExpression(node)) {
+    return node.expression.kind === ts.SyntaxKind.ThisKeyword
+      ? normalizeReferenceText(node.getText())
+      : rootReferenceText(node.expression)
+  }
+  if (
+    ts.isElementAccessExpression(node) ||
+    ts.isCallExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node)
+  ) {
+    return rootReferenceText(node.expression)
+  }
+  return undefined
+}
+
+function isBufferConcatCall(node) {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'concat' &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'Buffer' &&
+    node.arguments.length > 0 &&
+    ts.isArrayLiteralExpression(node.arguments[0])
+  )
+}
+
+function enclosingLoop(node) {
+  for (let current = node.parent; current; current = current.parent) {
+    if (LOOP_KINDS.has(current.kind)) {
+      return current
+    }
+  }
+  return undefined
+}
+
+// A `for (let acc = ...; ;)` binding is loop-carried even though it sits inside
+// the loop node, so the initializer does not count as loop-local.
+function isDeclaredInsideLoop(declarationStart, loop) {
+  if (declarationStart < loop.getStart() || declarationStart >= loop.end) {
+    return false
+  }
+  const initializer = ts.isForStatement(loop) ? loop.initializer : undefined
+  if (!initializer) {
+    return true
+  }
+  return declarationStart < initializer.getStart() || declarationStart >= initializer.end
+}
+
+function collectBindingNames(name, into) {
+  if (ts.isIdentifier(name)) {
+    into.push(name)
+    return
+  }
+  if (ts.isObjectBindingPattern(name) || ts.isArrayBindingPattern(name)) {
+    for (const element of name.elements) {
+      if (ts.isBindingElement(element)) {
+        collectBindingNames(element.name, into)
+      }
+    }
+  }
+}
+
+function collectDeclarations(sourceFile) {
+  const declarations = new Map()
+  const record = (identifier, node) => {
+    const existing = declarations.get(identifier.text)
+    const start = node.getStart(sourceFile)
+    if (existing) {
+      existing.push(start)
+    } else {
+      declarations.set(identifier.text, [start])
+    }
+  }
+
+  const visit = (node) => {
+    if (ts.isVariableDeclaration(node) || ts.isParameter(node)) {
+      const names = []
+      collectBindingNames(node.name, names)
+      for (const identifier of names) {
+        record(identifier, node)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return declarations
+}
+
+function collectAssignedRoots(loop) {
+  const assigned = new Set()
+  const visit = (node) => {
+    if (ts.isBinaryExpression(node) && ASSIGNMENT_OPERATORS.has(node.operatorToken.kind)) {
+      const root = rootReferenceText(node.left)
+      if (root) {
+        assigned.add(root)
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(loop.statement)
+  return assigned
+}
+
+// Unwrap the wrappers a concat result passes through before it lands on the
+// left-hand side, so `acc = cond ? Buffer.concat([acc, c]) : c` still counts.
+function assignmentTargetOf(call) {
+  let node = call
+  let parent = node.parent
+  while (
+    parent &&
+    (ts.isParenthesizedExpression(parent) ||
+      ts.isAsExpression(parent) ||
+      ts.isNonNullExpression(parent) ||
+      (ts.isConditionalExpression(parent) && parent.condition !== node))
+  ) {
+    node = parent
+    parent = parent.parent
+  }
+  if (
+    parent &&
+    ts.isBinaryExpression(parent) &&
+    parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    parent.right === node
+  ) {
+    return {
+      text: normalizeReferenceText(parent.left.getText()),
+      root: rootReferenceText(parent.left)
+    }
+  }
+  return undefined
+}
+
+function concatOperands(call) {
+  return call.arguments[0].elements.map((element) => {
+    const spread = ts.isSpreadElement(element)
+    const expression = spread ? element.expression : element
+    return {
+      spread,
+      text: normalizeReferenceText(expression.getText()),
+      root: rootReferenceText(expression)
+    }
+  })
+}
+
+// A binding reset on every iteration cannot accumulate; only one that outlives
+// the iteration carries the cost forward.
+function isLoopCarried(root, loop, declarations) {
+  const starts = declarations.get(root)
+  if (!starts) {
+    return true
+  }
+  return !starts.some((start) => isDeclaredInsideLoop(start, loop))
+}
+
+function quadraticAccumulator(call, loop, declarations, assignedRoots) {
+  const operands = concatOperands(call)
+  const target = assignmentTargetOf(call)
+  // The result feeds straight back into its own input: every iteration re-copies
+  // everything accumulated so far.
+  const selfOperand = target
+    ? operands.find((operand) => operand.text === target.text || operand.root === target.root)
+    : undefined
+  if (selfOperand && target.root && isLoopCarried(target.root, loop, declarations)) {
+    return target.text
+  }
+
+  // No direct self-assignment, so look for a loop-carried operand reassigned
+  // inside the loop: the concat result reaches it by some other path. Spread
+  // operands are the sanctioned chunk-list fix, not this bug, so skip them.
+  for (const operand of operands) {
+    if (operand.spread || !operand.root || !assignedRoots.has(operand.root)) {
+      continue
+    }
+    if (isLoopCarried(operand.root, loop, declarations)) {
+      return operand.root
+    }
+  }
+  return undefined
+}
+
+export function reportQuadraticBufferConcat(filePath, sourceText) {
+  if (!sourceText.includes('Buffer.concat')) {
+    return []
+  }
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true)
+  const declarations = collectDeclarations(sourceFile)
+  const assignedRootsByLoop = new Map()
+  const reports = []
+  const seen = new Set()
+
+  const visit = (node) => {
+    if (isBufferConcatCall(node)) {
+      const loop = enclosingLoop(node)
+      if (loop) {
+        let assignedRoots = assignedRootsByLoop.get(loop)
+        if (!assignedRoots) {
+          assignedRoots = collectAssignedRoots(loop)
+          assignedRootsByLoop.set(loop, assignedRoots)
+        }
+        const accumulator = quadraticAccumulator(node, loop, declarations, assignedRoots)
+        if (accumulator) {
+          const start = node.getStart(sourceFile)
+          if (!seen.has(start)) {
+            seen.add(start)
+            const { line, character } = sourceFile.getLineAndCharacterOfPosition(start)
+            reports.push({
+              filePath,
+              line: line + 1,
+              column: character + 1,
+              accumulator,
+              text: node.getText()
+            })
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return reports
+}
+
+export function normalizePath(root, filePath) {
+  return path.relative(root, filePath).split(path.sep).join('/')
+}
+
+function isSkippedFile(root, filePath) {
+  const relative = normalizePath(root, filePath)
+  // Benchmarks keep the pre-fix shape on purpose so they can measure against it.
+  if (
+    relative.includes('.test.') ||
+    relative.includes('.spec.') ||
+    relative.includes('-benchmark.')
+  ) {
+    return true
+  }
+  return relative.split('/').some((part) => SKIP_PATH_PARTS.has(part))
+}
+
+async function collectSourceFiles(root, dir) {
+  let entries
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const files = []
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (!SKIP_PATH_PARTS.has(entry.name)) {
+        files.push(...(await collectSourceFiles(root, fullPath)))
+      }
+    } else if (
+      entry.isFile() &&
+      SOURCE_EXTENSIONS.has(path.extname(entry.name)) &&
+      !isSkippedFile(root, fullPath)
+    ) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+function formatReports(root, reports) {
+  return reports
+    .map(
+      (report) =>
+        `${normalizePath(root, report.filePath)}:${report.line}:${report.column} ${report.accumulator} — ${report.text.replaceAll(/\s+/g, ' ')}`
+    )
+    .join('\n')
+}
+
+export async function main(root = process.cwd()) {
+  const reports = []
+  for (const scanRoot of SCAN_ROOTS) {
+    const files = await collectSourceFiles(root, path.join(root, scanRoot))
+    for (const filePath of files) {
+      const sourceText = await fs.readFile(filePath, 'utf8')
+      reports.push(...reportQuadraticBufferConcat(filePath, sourceText))
+    }
+  }
+  if (reports.length === 0) {
+    return 0
+  }
+
+  console.error('Buffer.concat must not rebuild a loop-carried accumulator.')
+  console.error('Each iteration re-copies everything accumulated so far, so the loop is O(n^2).')
+  console.error('Collect the pieces in a Buffer[] and Buffer.concat(chunks) once, after the loop.')
+  console.error('')
+  console.error(formatReports(root, reports))
+  return 1
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exit(await main())
+}

--- a/config/scripts/check-quadratic-buffer-concat.test.mjs
+++ b/config/scripts/check-quadratic-buffer-concat.test.mjs
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+
+import { reportQuadraticBufferConcat } from './check-quadratic-buffer-concat.mjs'
+
+describe('check-quadratic-buffer-concat', () => {
+  it('reports an accumulator rebuilt from itself in a for-of loop', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'let acc = Buffer.alloc(0); for (const chunk of chunks) { acc = Buffer.concat([acc, chunk]) }'
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0].accumulator).toBe('acc')
+  })
+
+  it('reports the accumulator when it trails the new chunk', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'let acc = Buffer.alloc(0); for (const chunk of chunks) { acc = Buffer.concat([chunk, acc]) }'
+    )
+
+    expect(reports).toHaveLength(1)
+  })
+
+  it('reports a spread of the accumulator into its own concat', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'let acc = Buffer.alloc(0); for (const chunk of chunks) { acc = Buffer.concat([...acc, chunk]) }'
+    )
+
+    expect(reports).toHaveLength(1)
+  })
+
+  it('reports the real pre-fix ai-vault stream carry', () => {
+    const reports = reportQuadraticBufferConcat(
+      'session-scanner-parse-cache.ts',
+      `async function read(stream) {
+         let remainder = null
+         for await (const chunk of stream) {
+           const data = remainder ? Buffer.concat([remainder, chunk]) : chunk
+           remainder = Buffer.from(data.subarray(lineStart))
+         }
+       }`
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0].accumulator).toBe('remainder')
+  })
+
+  it('reports the real pre-fix transcript reader carry, which never names itself on the left', () => {
+    const reports = reportQuadraticBufferConcat(
+      'agent-hook-listener.ts',
+      `function read(fd, size) {
+         let carryBytes = Buffer.alloc(0)
+         while (bytesRead < size) {
+           const combined = Buffer.concat([buffer.subarray(0, n), carryBytes])
+           carryBytes = combined.subarray(0, firstNewline)
+         }
+       }`
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0].accumulator).toBe('carryBytes')
+  })
+
+  it('accepts the chunk-list fix that joins once after the loop', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'const parts = []; for (const chunk of chunks) { parts.push(chunk) } const out = Buffer.concat(parts)'
+    )
+
+    expect(reports).toHaveLength(0)
+  })
+
+  it('accepts spreading a carry chunk list, which is the sanctioned fix', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      `let carryChunks = []
+       while (scanEnd > 0) {
+         const region = carryChunks.length === 0 ? buffer : Buffer.concat([buffer, ...carryChunks])
+         carryChunks = [buffer.subarray(0, firstNewline)]
+       }`
+    )
+
+    expect(reports).toHaveLength(0)
+  })
+
+  it('accepts a concat whose result never outlives the iteration', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'for (const group of groups) { const frame = Buffer.concat([group.header, group.body]); send(frame) }'
+    )
+
+    expect(reports).toHaveLength(0)
+  })
+
+  it('accepts a loop-local buffer declared and rebuilt inside the same iteration', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'for (const chunk of chunks) { let framed = HEADER; framed = Buffer.concat([framed, chunk]); send(framed) }'
+    )
+
+    expect(reports).toHaveLength(0)
+  })
+
+  it('reports an accumulator declared in a classic for initializer', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'for (let acc = Buffer.alloc(0), i = 0; i < n; i++) { acc = Buffer.concat([acc, chunks[i]]) }'
+    )
+
+    expect(reports).toHaveLength(1)
+  })
+
+  it('reports a class field accumulator rebuilt inside a loop', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'class Reader { read() { while (this.open) { this.pending = Buffer.concat([this.pending, chunk]) } } }'
+    )
+
+    expect(reports).toHaveLength(1)
+    expect(reports[0].accumulator).toBe('this.pending')
+  })
+
+  it('reports an accumulator guarded by an emptiness ternary', () => {
+    const reports = reportQuadraticBufferConcat(
+      'Example.ts',
+      'let acc = Buffer.alloc(0); while (open) { acc = acc.length === 0 ? chunk : Buffer.concat([acc, chunk]) }'
+    )
+
+    expect(reports).toHaveLength(1)
+  })
+
+  it('ignores a per-event accumulator with no enclosing loop', () => {
+    const reports = reportQuadraticBufferConcat(
+      'scrcpy-stream-session.ts',
+      'class S { handleVideoChunk(chunk) { let buffer = Buffer.concat([this.pendingVideo, chunk]); this.pendingVideo = parse(buffer).pending } }'
+    )
+
+    expect(reports).toHaveLength(0)
+  })
+
+  it('ignores files with no Buffer.concat at all', () => {
+    expect(reportQuadraticBufferConcat('Example.ts', 'export const x = 1')).toHaveLength(0)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./out/main/index.js",
   "scripts": {
     "format": "oxfmt --write .",
-    "lint": "oxlint && pnpm run lint:switch-exhaustiveness && node config/scripts/check-styled-scrollbars.mjs && pnpm run check:reliability-gates && pnpm run check:max-lines-ratchet && pnpm run verify:bundled-skill-guides && pnpm run verify:skill-bundle-manifest && pnpm run verify:localization-catalog && pnpm run verify:localization-coverage",
+    "lint": "oxlint && pnpm run lint:switch-exhaustiveness && node config/scripts/check-styled-scrollbars.mjs && pnpm run check:quadratic-buffer-concat && pnpm run check:reliability-gates && pnpm run check:max-lines-ratchet && pnpm run verify:bundled-skill-guides && pnpm run verify:skill-bundle-manifest && pnpm run verify:localization-catalog && pnpm run verify:localization-coverage",
     "lint:react-doctor": "oxlint --config config/oxlint-react-doctor.json",
     "lint:react-doctor:changed": "node config/scripts/lint-react-doctor-changed.mjs",
     "lint:switch-exhaustiveness": "oxlint --type-aware --config config/oxlint-switch-exhaustiveness.json src/main src/preload src/shared src/relay src/cli src/renderer/src config tests --quiet",
@@ -19,6 +19,7 @@
     "test": "node config/scripts/ensure-native-runtime.mjs --runtime=node && vitest run --config config/vitest.config.ts",
     "test:repro:remote-agent-session": "pnpm run build:cli && pnpm run build:electron-vite && node config/scripts/remote-agent-session-authority-repro.mjs",
     "check:styled-scrollbars": "node config/scripts/check-styled-scrollbars.mjs",
+    "check:quadratic-buffer-concat": "node config/scripts/check-quadratic-buffer-concat.mjs",
     "check:reliability-gates": "node config/scripts/check-reliability-gates.mjs",
     "check:max-lines-ratchet": "node config/scripts/check-max-lines-ratchet.mjs",
     "check:feature-wall-assets": "node config/scripts/check-feature-wall-assets.mjs",


### PR DESCRIPTION
## Summary

Two performance bug shapes shipped repeatedly in this codebase — one of them **three times**. Both are invisible in code review and invisible to a passing test suite, which is exactly what makes them worth a lint rule rather than a shared helper.

**Class A — quadratic `Buffer.concat`.** `Buffer.concat` inside a loop where the accumulator being built is itself an operand, so every iteration re-copies everything accumulated so far. Fixed at three sites (#10742, #10777, #10783).

**Class B — a value import defeating a lazy loader.** `linear-sdk.ts` exists *solely* to lazily `require('@linear/sdk')` (~2.6 MB, ~19 ms of parse). One value import elsewhere defeated it for every user, because the bundler then hoists the require into the eager top-level block. Same story for `qrcode`. Fixed in #10788.

## ELI5

We fixed the same two mistakes several times over. Neither one looks wrong when you read it, and neither breaks any test — the code just quietly does far more work than it needs to.

So instead of writing a shared helper that both places could call (they're too different for that to read well), we taught the linter to recognise the *shapes*. Now the next person who writes one gets told at commit time, with a note explaining what to do instead.

## What was built, and why each choice

**Class B uses the built-in `no-restricted-imports` — no custom code at all.**

One finding worth recording: oxlint's plain `no-restricted-imports` does **not** honour `allowTypeImports` — it silently ignores the key and flags `import type` too. But the `typescript/` variant *does* exempt type-only imports, and oxlint aliases both spellings to the same underlying rule, so configuring it under the plain key with `allowTypeImports: true` behaves correctly. This was verified empirically, not read off the config schema — which doesn't even list the option.

| import form | fires? |
|---|---|
| `import { LinearClient } from '@linear/sdk'` | **yes** |
| `import QRCode from 'qrcode'` / `import * as QRCode` | **yes** |
| `export { X } from 'qrcode'` (value re-export) | **yes** |
| `import type { LinearClient } from '@linear/sdk'` | no |
| `export type { X } from 'qrcode'` | no |
| `await import('qrcode')` | no |
| `requireFromMain('@linear/sdk')` | no |

That last row is why `linear-sdk.ts` needs **no exemption** — it reaches the SDK through `createRequire`, which the rule doesn't see, so the sanctioned loader passes on its own.

**Class A needed a custom check.** No built-in covers it. The closest, `oxc/no-accumulating-spread`, fires on `acc = [...acc, item]` but **not** on `Buffer.concat([acc, chunk])` — confirmed. Every oxlint category (`correctness`, `perf`, `pedantic`, `suspicious`, `restriction`, `nursery`, `style`) was run across all plugins against a synthetic quadratic file; nothing fired. It follows the existing house pattern (`config/scripts/check-*.mjs` + `.test.mjs`, wired into `pnpm lint`).

## Proof each guard catches the real bug

A rule that doesn't catch the bug it was written for is worthless, so each was run against the **reconstructed pre-fix source** (`git show <commit>^`), not a synthetic approximation. I verified these independently of the agent that wrote them:

**Class A, ai-vault (#10783):**
```
src/main/ai-vault/session-scanner-parse-cache.ts:319:30 remainder — Buffer.concat([remainder, chunk])
PREFIX_EXIT=1        FIXED_EXIT=0
```

**Class A, Command Code transcript reader (#10742):**
```
src/shared/agent-hook-listener.ts:1318:26 carryBytes — Buffer.concat([buffer.subarray(0, n), carryBytes])
EXIT=1               clean EXIT=0
```

**This third site is the one that shaped the rule's design.** It *never names the accumulator on the left* — it does `const combined = Buffer.concat([buf, carryBytes])` and then `carryBytes = combined.subarray(...)` two lines later. A naive self-assignment matcher misses it entirely. Detection is therefore loop-carried: an operand declared outside the loop and reassigned inside it.

**Class B (#10788):**
```
src/main/ipc/mobile.ts:3:1: error eslint(no-restricted-imports): 'qrcode' import is restricted from
being used. help: qrcode is only reachable from mobile pairing; a static import parses it at launch
for everyone. Use `import type` plus `await import('qrcode')` at the call site.
```
All three pre-fix import sites fire, each with its remediation. On the current tree: **0** restricted-import errors repo-wide, and `import type` plus the real `linear-sdk.ts` loader both pass.

## Proof of zero false positives

- `pnpm exec oxlint` → 0 errors (warnings only, all pre-existing)
- `node config/scripts/check-quadratic-buffer-concat.mjs` → exit 0 over ~9,800 files
- 14 unit tests pass

## Deliberate scope limits

Honest limits beat an over-broad rule that gets disabled:

- **`scrcpy-stream-session.ts` is not flagged, and needs no suppression.** Its `Buffer.concat([this.pendingVideo, chunk])` sits in a socket `'data'` callback with no lexically enclosing loop, and the rule requires one. That's the right line: "loop-carried" is a syntactic property a linter can decide soundly, whereas "does this handler drain its accumulator every call?" needs whole-function dataflow. A regression test pins scrcpy at 0 reports so a future broadening doesn't silently start flagging it.
- **Event-handler accumulators are not linted.** The candidates (`ssh-relay-deploy-helpers.ts`, `binary-frame.ts`, `wsl-hook-relay-sentinel.ts`) all bound their buffer with an explicit byte cap and drain on frame boundaries. Flagging every `'data'` handler that concats would be mostly false positives on exactly the code that already handles this correctly.
- **Spread operands are exempt** (`Buffer.concat([buffer, ...carryChunks])`) — that *is* the sanctioned fix; flagging it would fire on all three repaired sites.
- **Benchmarks and tests are skipped** — they retain pre-fix shapes deliberately, to measure against.

## `pnpm lint`

Every step passes through `verify:localization-catalog`, including the new `check:quadratic-buffer-concat`.

**One caveat, stated plainly:** the final step, `verify:localization-coverage`, fails — but this is **pre-existing on unmodified `origin/main`** and unrelated (6 unlocalized "Ghostty" keyword strings in terminal settings search). Confirmed by stashing all four files and running that step alone on a clean tree: same failure. Not fixed here, since it's outside this PR's scope.

## Why a lint rule instead of a shared helper

The obvious response to "we fixed this three times" is to extract a helper. I looked, and the two carry sites differ on **direction** (backward vs forward), **source** (`readSync` vs stream), **what the carry holds** (bytes before vs after the newline), **join order**, **stop rule**, and **output mode**. Only ~4 lines are genuinely shared. A helper spanning all six differences would read worse than either call site.

The bug was never "we lacked a helper" — it was a *shape* that survives review. A rule closes every future site without forcing unlike code into one signature.

## AI Review Report

Reviewed for false-positive risk (the main way a lint rule fails in practice — it gets disabled), for whether a built-in could replace the custom check (yes for Class B, verified no for Class A), and for whether each rule actually fires on the historical bug rather than a lookalike.

Cross-platform: both are static analysis at lint time, no runtime or platform behaviour. The custom check uses `node:path` for traversal and normalises separators, so it reports identical paths on macOS/Linux/Windows.

## Security Audit

No runtime code changes — this PR only adds lint configuration and a build-time check script. The script reads source files from the repo and writes nothing. No new input handling, command execution, auth, secrets, or IPC surface. No dependency changes.

Made with [Orca](https://github.com/stablyai/orca) 🐋
