### PR TITLE
fix(mobile): recover relay during pending direct dial

### DIFF
--- a/mobile/src/transport/mobile-direct-probe-timer.ts
+++ b/mobile/src/transport/mobile-direct-probe-timer.ts
@@ -1,0 +1,25 @@
+export class MobileDirectProbeTimer {
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  schedule(args: {
+    canSchedule: boolean
+    delayMs: number
+    setTimer: typeof setTimeout
+    onTimer: () => void
+  }): void {
+    if (!args.canSchedule || this.timer) {
+      return
+    }
+    this.timer = args.setTimer(() => {
+      this.timer = null
+      args.onTimer()
+    }, args.delayMs)
+  }
+
+  clear(clearTimer: typeof clearTimeout): void {
+    if (this.timer) {
+      clearTimer(this.timer)
+      this.timer = null
+    }
+  }
+}

--- a/mobile/src/transport/mobile-endpoint-lifecycle.ts
+++ b/mobile/src/transport/mobile-endpoint-lifecycle.ts
@@ -93,6 +93,7 @@ function createSupervisor(
     now: Date.now,
     randomBytes: ExpoCrypto.getRandomBytes,
     setTimer: setTimeout,
-    clearTimer: clearTimeout
+    clearTimer: clearTimeout,
+    onLog
   })
 }

--- a/mobile/src/transport/mobile-endpoint-supervisor-contract.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-contract.ts
@@ -3,7 +3,7 @@ import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bund
 import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
 import type { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
 import type { RpcClient } from './rpc-client'
-import type { HostProfile } from './types'
+import type { ConnectionLogSink, HostProfile } from './types'
 
 export type MobileEndpointSupervisorDependencies = {
   openDirect: (endpoint: string) => RpcClient
@@ -20,4 +20,5 @@ export type MobileEndpointSupervisorDependencies = {
   randomBytes: (length: number) => Uint8Array
   setTimer: typeof setTimeout
   clearTimer: typeof clearTimeout
+  onLog: ConnectionLogSink
 }

--- a/mobile/src/transport/mobile-endpoint-supervisor-support.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-support.ts
@@ -1,6 +1,7 @@
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
-import type { HostProfile } from './types'
+import type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-supervisor-contract'
+import type { ConnectionState, HostProfile } from './types'
 import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
 
 export function isDirectorResolutionFailure(error: Error): boolean {
@@ -41,4 +42,32 @@ export function encodeBase64Url(value: Uint8Array): string {
 
 export function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error))
+}
+
+export function logRelayLifecycle(
+  dependencies: Pick<MobileEndpointSupervisorDependencies, 'onLog' | 'now' | 'randomBytes'>,
+  event: 'start' | 'success' | 'cancel',
+  state?: ConnectionState
+): void {
+  const id = `relay-${event}-${dependencies.randomBytes(8).join('')}`
+  const ts = dependencies.now()
+  if (event === 'start') {
+    dependencies.onLog({
+      id,
+      ts,
+      level: 'info',
+      message: 'Recovering via Relay',
+      detail: `Direct connection is ${state}`
+    })
+  } else if (event === 'success') {
+    dependencies.onLog({ id, ts, level: 'success', message: 'Connected via Relay' })
+  } else {
+    dependencies.onLog({
+      id,
+      ts,
+      level: 'warn',
+      message: 'Relay migration cancelled',
+      detail: 'Direct connection became active'
+    })
+  }
 }

--- a/mobile/src/transport/mobile-endpoint-supervisor-test-setup.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-test-setup.ts
@@ -1,0 +1,198 @@
+import { vi } from 'vitest'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
+import type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-supervisor'
+import type { RpcClient } from './rpc-client'
+import type { MobileConnectionPath, StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { ConnectionState, HostProfile, RpcResponse } from './types'
+
+export class FakeSession implements RpcClient {
+  readonly sendRequest = vi.fn(
+    async (_method: string, _params?: unknown): Promise<RpcResponse> => ({
+      id: 'rpc-1',
+      ok: true,
+      result: {},
+      _meta: { runtimeId: 'runtime-1' }
+    })
+  )
+  readonly subscribe = vi.fn(() => () => {})
+  readonly updateTerminalSubscriptionViewport = vi.fn()
+  readonly notifyForeground = vi.fn()
+  readonly close = vi.fn()
+  private readonly listeners = new Set<(state: ConnectionState) => void>()
+
+  constructor(private state: ConnectionState) {}
+
+  getState = () => this.state
+  getReconnectAttempt = () => 0
+  getLastConnectedAt = () => null
+  onStateChange = (listener: (state: ConnectionState) => void) => {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  publishState(state: ConnectionState): void {
+    this.state = state
+    for (const listener of this.listeners) {
+      listener(state)
+    }
+  }
+}
+
+export class FakeRelaySession extends FakeSession implements MobileRelayRpcSession {
+  constructor(
+    state: ConnectionState,
+    private readonly failure: Error | null = null,
+    private readonly lease = Date.now() + 120_000
+  ) {
+    super(state)
+  }
+  getLeaseExpiresAt = () => this.lease
+  getResumeConfirmation = () => ({
+    v: 1 as const,
+    reqId: 'confirm-1',
+    currentVersion: 2,
+    acceptedAs: 'current' as const,
+    renewed: true,
+    resumeExpiresAt: Date.now() + 300_000
+  })
+  getFailure = () => this.failure
+}
+
+export class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
+  private path: MobileConnectionPath
+  private generation = 1
+  private migrateDelay = false
+
+  constructor(state: ConnectionState, path: MobileConnectionPath) {
+    super(state)
+    this.path = path
+  }
+
+  setMigrateDelay(): void {
+    this.migrateDelay = true
+  }
+
+  migrateTo = vi.fn(async (session: RpcClient, path: MobileConnectionPath) => {
+    const wasConnected = this.getState() === 'connected'
+    if (this.migrateDelay && session.getState() !== 'connected') {
+      await new Promise<void>((resolve, reject) => {
+        if (session.getState() === 'connected') {
+          resolve()
+          return
+        }
+        const unsub = session.onStateChange((state) => {
+          if (state === 'connected') {
+            unsub()
+            resolve()
+          } else if (state === 'auth-failed' || state === 'disconnected') {
+            unsub()
+            reject(new Error(`replacement session ${state}`))
+          }
+        })
+      })
+    } else if (session.getState() !== 'connected') {
+      session.close()
+      throw new Error(`replacement session ${session.getState()}`)
+    }
+    if (
+      !wasConnected &&
+      this.getState() === 'connected' &&
+      this.path !== 'relay' &&
+      path === 'relay'
+    ) {
+      session.close()
+      throw new Error('session migration cancelled: active path already connected')
+    }
+    this.path = path
+    this.generation += 1
+    this.publishState('connected')
+  })
+  suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
+  getActivePath = () => this.path
+  getGeneration = () => this.generation
+}
+
+export const relay = {
+  v: 1 as const,
+  directorUrl: 'https://relay.onorca.dev',
+  cellUrl: 'https://relay-c1.onorca.dev',
+  assignmentEpoch: 7,
+  relayHostId: 'AbCdEf0123_-xyZ9',
+  e2eeFraming: 2 as const
+}
+
+export const host: HostProfile = {
+  id: 'host-1',
+  name: 'Blue Whale',
+  endpoint: 'ws://192.168.1.10:6768',
+  deviceToken: 'device-token',
+  publicKeyB64: 'A'.repeat(44),
+  lastConnected: 1,
+  endpoints: [
+    { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.10:6768' },
+    { id: 'relay-primary', kind: 'relay', url: 'wss://relay-c1.onorca.dev/v1/connect/id' }
+  ],
+  relayHostId: relay.relayHostId,
+  relay
+}
+
+export const bundle: MobileRelayCredentialBundle = {
+  v: 1,
+  hostId: host.id,
+  deviceToken: host.deviceToken,
+  current: {
+    token: 'A'.repeat(43),
+    hash: 'B'.repeat(43),
+    version: 2,
+    expiresAt: Number.MAX_SAFE_INTEGER
+  }
+}
+
+export function dependencies(
+  overrides: Partial<MobileEndpointSupervisorDependencies> = {}
+): MobileEndpointSupervisorDependencies {
+  return {
+    openDirect: vi.fn(() => new FakeSession('connected')),
+    openRelay: vi.fn(() => new FakeRelaySession('connected')),
+    resolveRelay: vi.fn(async ({ relay }) => relay),
+    readBundle: vi.fn(async () => bundle),
+    writeBundle: vi.fn(async () => {}),
+    saveHost: vi.fn(async () => {}),
+    now: Date.now,
+    randomBytes: (length) => new Uint8Array(length).fill(1),
+    setTimer: setTimeout,
+    clearTimer: clearTimeout,
+    ...overrides
+  }
+}
+
+export function mockCredentialRotation(logical: FakeLogicalClient): void {
+  let installResult: Record<string, unknown> | null = null
+  logical.sendRequest.mockImplementation(async (method, params) => {
+    const request = params as { installReqId?: string; reqId?: string }
+    if (method === 'pairing.provisionRelay') {
+      installResult = {
+        v: 1,
+        reqId: request.reqId,
+        authorizationMode: 'authenticated-direct',
+        currentVersion: 3,
+        resumeExpiresAt: Date.now() + 300_000,
+        graceExpiresAt: Date.now() + 60_000
+      }
+      return { id: 'rpc-2', ok: true, result: installResult, _meta: { runtimeId: 'runtime-1' } }
+    }
+    return {
+      id: 'rpc-1',
+      ok: true,
+      result: {
+        v: 1,
+        relay,
+        installStatus: installResult
+          ? { v: 1, reqId: request.installReqId, state: 'committed', result: installResult }
+          : { v: 1, reqId: request.installReqId, state: 'not-found' }
+      },
+      _meta: { runtimeId: 'runtime-1' }
+    }
+  })
+}

--- a/mobile/src/transport/mobile-endpoint-supervisor-test-setup.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-test-setup.ts
@@ -24,6 +24,12 @@ export class FakeSession implements RpcClient {
   constructor(private state: ConnectionState) {}
 
   getState = () => this.state
+  setState = (state: ConnectionState) => {
+    this.state = state
+    for (const listener of this.listeners) {
+      listener(state)
+    }
+  }
   getReconnectAttempt = () => 0
   getLastConnectedAt = () => null
   onStateChange = (listener: (state: ConnectionState) => void) => {
@@ -163,6 +169,7 @@ export function dependencies(
     randomBytes: (length) => new Uint8Array(length).fill(1),
     setTimer: setTimeout,
     clearTimer: clearTimeout,
+    onLog: vi.fn(),
     ...overrides
   }
 }

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -782,4 +782,69 @@ describe('mobile endpoint supervisor', () => {
     expect(logical.getActivePath()).toBe('relay')
     supervisor.stop()
   })
+
+  describe('observability', () => {
+    it('logs when relay recovery begins from pending', async () => {
+      const logical = new FakeLogicalClient('connecting', 'direct')
+      const deps = dependencies()
+      const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+      await supervisor.start()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(deps.onLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'info',
+          message: 'Recovering via Relay',
+          detail: 'Direct connection is connecting'
+        })
+      )
+
+      const logText = JSON.stringify(deps.onLog.mock.calls)
+      expect(logText).not.toContain(host.endpoint)
+      expect(logText).not.toContain(host.deviceToken)
+      expect(logText).not.toContain(host.publicKeyB64)
+      expect(logText).not.toContain(host.relay!.relayHostId)
+    })
+
+    it('logs when relay migration succeeds', async () => {
+      const logical = new FakeLogicalClient('connecting', 'direct')
+      const deps = dependencies()
+      const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+      await supervisor.start()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(deps.onLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'success',
+          message: 'Connected via Relay'
+        })
+      )
+    })
+
+    it('logs when relay migration is cancelled by direct', async () => {
+      const logical = new FakeLogicalClient('connecting', 'direct')
+      logical.setMigrateDelay()
+      const relaySession = new FakeRelaySession('connecting')
+      const deps = dependencies({
+        openRelay: vi.fn(() => relaySession)
+      })
+      const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+      const startPromise = supervisor.start()
+      await vi.advanceTimersByTimeAsync(0)
+
+      logical.publishState('connected')
+      relaySession.publishState('connected')
+
+      await startPromise
+
+      expect(deps.onLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          level: 'warn',
+          message: 'Relay migration cancelled',
+          detail: 'Direct connection became active'
+        })
+      )
+    })
+  })
 })

--- a/mobile/src/transport/mobile-endpoint-supervisor.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.test.ts
@@ -2,176 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
 import { hashMobileRelayCredential } from './mobile-relay-credential-hash'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
-import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
+import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
 import {
-  MobileEndpointSupervisor,
-  type MobileEndpointSupervisorDependencies
-} from './mobile-endpoint-supervisor'
-import type { RpcClient } from './rpc-client'
-import type { MobileConnectionPath, StableLogicalRpcClient } from './stable-logical-rpc-client'
-import type { ConnectionState, HostProfile, RpcResponse } from './types'
+  FakeSession,
+  FakeRelaySession,
+  FakeLogicalClient,
+  host,
+  relay,
+  bundle,
+  dependencies,
+  mockCredentialRotation
+} from './mobile-endpoint-supervisor-test-setup'
 
 vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
 vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
 vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
-
-class FakeSession implements RpcClient {
-  readonly sendRequest = vi.fn(
-    async (_method: string, _params?: unknown): Promise<RpcResponse> => ({
-      id: 'rpc-1',
-      ok: true,
-      result: {},
-      _meta: { runtimeId: 'runtime-1' }
-    })
-  )
-  readonly subscribe = vi.fn(() => () => {})
-  readonly updateTerminalSubscriptionViewport = vi.fn()
-  readonly notifyForeground = vi.fn()
-  readonly close = vi.fn()
-  private readonly listeners = new Set<(state: ConnectionState) => void>()
-
-  constructor(private state: ConnectionState) {}
-
-  getState = () => this.state
-  getReconnectAttempt = () => 0
-  getLastConnectedAt = () => null
-  onStateChange = (listener: (state: ConnectionState) => void) => {
-    this.listeners.add(listener)
-    return () => this.listeners.delete(listener)
-  }
-
-  publishState(state: ConnectionState): void {
-    this.state = state
-    for (const listener of this.listeners) {
-      listener(state)
-    }
-  }
-}
-
-class FakeRelaySession extends FakeSession implements MobileRelayRpcSession {
-  constructor(
-    state: ConnectionState,
-    private readonly failure: Error | null = null,
-    private readonly lease = Date.now() + 120_000
-  ) {
-    super(state)
-  }
-  getLeaseExpiresAt = () => this.lease
-  getResumeConfirmation = () => ({
-    v: 1 as const,
-    reqId: 'confirm-1',
-    currentVersion: 2,
-    acceptedAs: 'current' as const,
-    renewed: true,
-    resumeExpiresAt: Date.now() + 300_000
-  })
-  getFailure = () => this.failure
-}
-
-class FakeLogicalClient extends FakeSession implements StableLogicalRpcClient {
-  private path: MobileConnectionPath
-  private generation = 1
-
-  constructor(state: ConnectionState, path: MobileConnectionPath) {
-    super(state)
-    this.path = path
-  }
-
-  migrateTo = vi.fn(async (session: RpcClient, path: MobileConnectionPath) => {
-    if (session.getState() !== 'connected') {
-      session.close()
-      throw new Error(`replacement session ${session.getState()}`)
-    }
-    this.path = path
-    this.generation += 1
-    this.publishState('connected')
-  })
-  suspendActiveSession = vi.fn(() => this.publishState('disconnected'))
-  getActivePath = () => this.path
-  getGeneration = () => this.generation
-}
-
-const relay = {
-  v: 1 as const,
-  directorUrl: 'https://relay.onorca.dev',
-  cellUrl: 'https://relay-c1.onorca.dev',
-  assignmentEpoch: 7,
-  relayHostId: 'AbCdEf0123_-xyZ9',
-  e2eeFraming: 2 as const
-}
-const host: HostProfile = {
-  id: 'host-1',
-  name: 'Blue Whale',
-  endpoint: 'ws://192.168.1.10:6768',
-  deviceToken: 'device-token',
-  publicKeyB64: 'A'.repeat(44),
-  lastConnected: 1,
-  endpoints: [
-    { id: 'direct-primary', kind: 'lan', url: 'ws://192.168.1.10:6768' },
-    { id: 'relay-primary', kind: 'relay', url: 'wss://relay-c1.onorca.dev/v1/connect/id' }
-  ],
-  relayHostId: relay.relayHostId,
-  relay
-}
-const bundle: MobileRelayCredentialBundle = {
-  v: 1,
-  hostId: host.id,
-  deviceToken: host.deviceToken,
-  current: {
-    token: 'A'.repeat(43),
-    hash: 'B'.repeat(43),
-    version: 2,
-    expiresAt: Number.MAX_SAFE_INTEGER
-  }
-}
-
-function dependencies(
-  overrides: Partial<MobileEndpointSupervisorDependencies> = {}
-): MobileEndpointSupervisorDependencies {
-  return {
-    openDirect: vi.fn(() => new FakeSession('connected')),
-    openRelay: vi.fn(() => new FakeRelaySession('connected')),
-    resolveRelay: vi.fn(async ({ relay }) => relay),
-    readBundle: vi.fn(async () => bundle),
-    writeBundle: vi.fn(async () => {}),
-    saveHost: vi.fn(async () => {}),
-    now: Date.now,
-    randomBytes: (length) => new Uint8Array(length).fill(1),
-    setTimer: setTimeout,
-    clearTimer: clearTimeout,
-    ...overrides
-  }
-}
-
-function mockCredentialRotation(logical: FakeLogicalClient): void {
-  let installResult: Record<string, unknown> | null = null
-  logical.sendRequest.mockImplementation(async (method, params) => {
-    const request = params as { installReqId?: string; reqId?: string }
-    if (method === 'pairing.provisionRelay') {
-      installResult = {
-        v: 1,
-        reqId: request.reqId,
-        authorizationMode: 'authenticated-direct',
-        currentVersion: 3,
-        resumeExpiresAt: Date.now() + 300_000,
-        graceExpiresAt: Date.now() + 60_000
-      }
-      return { id: 'rpc-2', ok: true, result: installResult, _meta: { runtimeId: 'runtime-1' } }
-    }
-    return {
-      id: 'rpc-1',
-      ok: true,
-      result: {
-        v: 1,
-        relay,
-        installStatus: installResult
-          ? { v: 1, reqId: request.installReqId, state: 'committed', result: installResult }
-          : { v: 1, reqId: request.installReqId, state: 'not-found' }
-      },
-      _meta: { runtimeId: 'runtime-1' }
-    }
-  })
-}
 
 describe('mobile endpoint supervisor', () => {
   beforeEach(() => {
@@ -198,21 +43,47 @@ describe('mobile endpoint supervisor', () => {
     supervisor.stop()
   })
 
-  it('fails over when the direct retry loop publishes reconnecting', async () => {
+  it('does not replace an authenticated direct connection with Relay', async () => {
+    const logical = new FakeLogicalClient('connected', 'lan')
+    const deps = dependencies()
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+
+    expect(deps.openRelay).not.toHaveBeenCalled()
+    supervisor.stop()
+  })
+
+  it('keeps direct when it authenticates before relay migration completes during startup', async () => {
+    const logical = new FakeLogicalClient('connecting', 'lan')
+    logical.setMigrateDelay()
+    const relaySession = new FakeRelaySession('connecting')
+    const openRelay = vi.fn(() => relaySession)
+    const deps = dependencies({ openRelay })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    const startPromise = supervisor.start()
+
+    // Wait for relay dial before progressing the race
+    await vi.waitFor(() => expect(openRelay).toHaveBeenCalledOnce())
+
+    // Direct connects while relay authentication is in-flight
+    logical.publishState('connected')
+
+    // Relay authentication completes
+    relaySession.publishState('connected')
+
+    await startPromise
+
+    expect(logical.getActivePath()).toBe('lan')
+    supervisor.stop()
+  })
+
+  it('fails over immediately when the initial LAN dial remains pending', async () => {
     const logical = new FakeLogicalClient('connecting', 'lan')
     const deps = dependencies()
     const supervisor = new MobileEndpointSupervisor(logical, host, deps)
     await supervisor.start()
 
-    logical.publishState('handshaking')
-    await vi.advanceTimersByTimeAsync(0)
-    expect(deps.openRelay).not.toHaveBeenCalled()
-
-    supervisor.setForeground(true)
-    await vi.advanceTimersByTimeAsync(0)
-    expect(deps.openRelay).not.toHaveBeenCalled()
-
-    logical.publishState('reconnecting')
     await vi.waitFor(() => expect(logical.getActivePath()).toBe('relay'))
 
     expect(logical.migrateTo).toHaveBeenCalledWith(expect.any(FakeRelaySession), 'relay')

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -5,7 +5,7 @@ import { RelayLeaseRotationTimer } from './mobile-relay-lease-rotation-timer'
 import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
 import { MobileDirectProbeTimer } from './mobile-direct-probe-timer'
 import { canRecoverMobileRelay } from './mobile-relay-recovery-eligibility'
-import { encodeBase64Url, toError } from './mobile-endpoint-supervisor-support'
+import { encodeBase64Url, logRelayLifecycle, toError } from './mobile-endpoint-supervisor-support'
 import { applyResumeConfirmation } from './mobile-relay-credential-rotation'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
 import { refreshMobileRelayCredentialIfNeeded } from './mobile-relay-credential-refresh'
@@ -120,6 +120,9 @@ export class MobileEndpointSupervisor {
     if (!bundle) {
       return
     }
+
+    logRelayLifecycle(this.dependencies, 'start', this.logical.getState())
+
     this.operationInFlight = true
     let lastError: Error | null = null
     let retryAfterOperation = false
@@ -139,10 +142,17 @@ export class MobileEndpointSupervisor {
           }
         })
         if (result.ok) {
+          logRelayLifecycle(this.dependencies, 'success')
           retryAfterOperation = this.logical.getState() !== 'connected'
           return
         }
         lastError = result.error
+
+        if (this.logical.getState() === 'connected' && this.logical.getActivePath() !== 'relay') {
+          logRelayLifecycle(this.dependencies, 'cancel')
+          break
+        }
+
         if (this.relayReconnect.shouldTryGraceAfterRelayFailure(result.error)) {
           this.relayReconnect.recordRejectedCredential(credential.version)
         } else {

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -3,18 +3,13 @@ import type { MobileEndpointSupervisorDependencies } from './mobile-endpoint-sup
 import { RelayReconnectController } from './mobile-relay-reconnect-controller'
 import { RelayLeaseRotationTimer } from './mobile-relay-lease-rotation-timer'
 import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
-import {
-  encodeBase64Url,
-  isDirectorResolutionFailure,
-  persistRelayHost,
-  toError
-} from './mobile-endpoint-supervisor-support'
-import {
-  applyResumeConfirmation,
-  mobileRelayCredentialNeedsRotation,
-  rotateMobileRelayCredential
-} from './mobile-relay-credential-rotation'
+import { MobileDirectProbeTimer } from './mobile-direct-probe-timer'
+import { canRecoverMobileRelay } from './mobile-relay-recovery-eligibility'
+import { encodeBase64Url, toError } from './mobile-endpoint-supervisor-support'
+import { applyResumeConfirmation } from './mobile-relay-credential-rotation'
 import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { refreshMobileRelayCredentialIfNeeded } from './mobile-relay-credential-refresh'
+import { tryRelayCredential } from './mobile-relay-credential-trial'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import type { HostProfile } from './types'
 
@@ -32,7 +27,7 @@ export class MobileEndpointSupervisor {
   private operationInFlight = false
   private credentialRotationInFlight = false
   private relayRotationPending = false
-  private probeTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly directProbeTimer = new MobileDirectProbeTimer()
   private unsubscribeState: (() => void) | null = null
   private readonly hysteresis: MobileEndpointHysteresis
   private readonly relayReconnect: RelayReconnectController
@@ -68,15 +63,11 @@ export class MobileEndpointSupervisor {
         }
         this.scheduleDirectProbe()
       } else {
-        // Why: the direct client enters reconnecting after its first failed
-        // dial and may never publish disconnected while its retry loop lives.
         this.relayReconnect.handleStateFailure(this.logical, state)
       }
     })
-    if (this.relayReconnect.needsRecovery(this.logical.getState())) {
-      // Why: the first direct dial can fail while encrypted relay credentials
-      // are still loading, before the supervisor subscribes to state changes.
-      await this.recoverRelay()
+    if (this.logical.getState() !== 'connected') {
+      await this.recoverRelay(false, !this.relayReconnect.needsRecovery(this.logical.getState()))
     } else {
       this.scheduleDirectProbe()
     }
@@ -106,83 +97,75 @@ export class MobileEndpointSupervisor {
     this.leaseRotation.clear()
   }
 
-  private async recoverRelay(forceReplacement = false): Promise<void> {
-    // Why: connecting/handshaking is live direct progress; a relay dial would race it.
+  private async recoverRelay(forceReplacement = false, allowDirectRace = false): Promise<void> {
     if (
-      this.stopped ||
-      !this.foreground ||
-      this.operationInFlight ||
-      !this.bundle ||
-      !this.host.relay ||
-      (!forceReplacement && !this.relayReconnect.needsRecovery(this.logical.getState()))
+      !canRecoverMobileRelay({
+        stopped: this.stopped,
+        foreground: this.foreground,
+        operationInFlight: this.operationInFlight,
+        hasBundle: this.bundle !== null,
+        hasRelay: this.host.relay !== undefined,
+        forceReplacement,
+        allowDirectRace,
+        state: this.logical.getState(),
+        needsRecovery: this.relayReconnect.needsRecovery.bind(this.relayReconnect)
+      })
     ) {
       return
     }
-    // Why: revival and lease timers can overlap resume failures; one shared cooldown
-    // prevents PEER_DROPPED/LIMIT_EXCEEDED reconnect churn.
     if (this.relayReconnect.shouldDefer()) {
+      return
+    }
+    const bundle = this.bundle
+    if (!bundle) {
       return
     }
     this.operationInFlight = true
     let lastError: Error | null = null
     let retryAfterOperation = false
     try {
-      const credentials = this.relayReconnect.eligibleCredentials(
-        this.bundle.current,
-        this.bundle.grace
-      )
+      const credentials = this.relayReconnect.eligibleCredentials(bundle.current, bundle.grace)
       for (const credential of credentials) {
-        const result = await this.tryRelayCredential(credential)
+        const result = await tryRelayCredential({
+          credential,
+          host: this.host,
+          logicalState: () => this.logical.getState(),
+          logicalActivePath: () => this.logical.getActivePath(),
+          openAndMigrateRelay: (c) => this.openAndMigrateRelay(c),
+          resolveRelay: (a) => this.dependencies.resolveRelay(a),
+          saveHost: this.dependencies.saveHost,
+          updateHost: (host) => {
+            this.host = host
+          }
+        })
         if (result.ok) {
           retryAfterOperation = this.logical.getState() !== 'connected'
           return
         }
         lastError = result.error
         if (this.relayReconnect.shouldTryGraceAfterRelayFailure(result.error)) {
-          // Why: a rejected version stays invalid; retry only the grace credential.
           this.relayReconnect.recordRejectedCredential(credential.version)
         } else {
           break
         }
       }
       if (credentials.length > 0) {
-        // Why: cleanup may happen while a relay dial is awaiting the network;
-        // record its outcome without recreating a foreground retry timer.
-        const scheduleRetry = !forceReplacement && this.foreground && !this.stopped
-        this.relayReconnect.registerFailure(lastError, scheduleRetry)
+        this.relayReconnect.registerFailure(
+          lastError,
+          !forceReplacement &&
+            this.foreground &&
+            !this.stopped &&
+            this.relayReconnect.needsRecovery(this.logical.getState())
+        )
       }
     } finally {
       this.operationInFlight = false
       if (forceReplacement && this.relayRotationPending && !this.stopped && this.foreground) {
         this.leaseRotation.armRetry(this.relayReconnect.retryDelayMs(5000))
       }
-      // Why: the active relay can drop while migration follow-up still owns the mutex.
-      if (retryAfterOperation && !this.stopped && this.foreground) {
+      if (retryAfterOperation) {
         void this.recoverRelay()
       }
-    }
-  }
-
-  private async tryRelayCredential(credential: {
-    token: string
-    version: number
-  }): Promise<{ ok: true } | { ok: false; error: Error }> {
-    const first = await this.openAndMigrateRelay(credential)
-    if (first.ok) {
-      return first
-    }
-    if (!isDirectorResolutionFailure(first.error) || !this.host.relay) {
-      return first
-    }
-    try {
-      const resolved = await this.dependencies.resolveRelay({
-        relay: this.host.relay,
-        resumeToken: credential.token
-      })
-      this.host = await persistRelayHost(this.host, resolved, this.dependencies.saveHost)
-      return await this.openAndMigrateRelay(credential)
-    } catch (error) {
-      return { ok: false, error: toError(error) }
     }
   }
 
@@ -190,7 +173,6 @@ export class MobileEndpointSupervisor {
     token: string
     version: number
   }): Promise<{ ok: true } | { ok: false; error: Error }> {
-    // Why: director resolution and grace fallback can finish after background/stop.
     if (this.stopped || !this.foreground || !this.host.relay || !this.bundle) {
       return { ok: false, error: new Error('relay state missing') }
     }
@@ -210,11 +192,8 @@ export class MobileEndpointSupervisor {
       const confirmation = session.getResumeConfirmation()
       if (confirmation) {
         this.bundle = applyResumeConfirmation(this.bundle, credential.version, confirmation)
-        // Why: the relay is already authenticated; a SecureStore failure must
-        // not open another socket or count against transport recovery backoff.
         await this.dependencies.writeBundle(this.bundle).catch(() => {})
       }
-      // Why: async persistence can finish after stop/background; never recreate a stale timer.
       this.leaseRotation.scheduleFromLease(
         this.stopped || !this.foreground ? null : session.getLeaseExpiresAt()
       )
@@ -226,18 +205,12 @@ export class MobileEndpointSupervisor {
   }
 
   private scheduleDirectProbe(delayMs = DIRECT_PROBE_INTERVAL_MS): void {
-    if (
-      this.stopped ||
-      !this.foreground ||
-      this.logical.getActivePath() !== 'relay' ||
-      this.probeTimer
-    ) {
-      return
-    }
-    this.probeTimer = this.dependencies.setTimer(() => {
-      this.probeTimer = null
-      void this.probeDirect()
-    }, delayMs)
+    this.directProbeTimer.schedule({
+      canSchedule: !this.stopped && this.foreground && this.logical.getActivePath() === 'relay',
+      delayMs,
+      setTimer: this.dependencies.setTimer,
+      onTimer: () => void this.probeDirect()
+    })
   }
 
   private async probeDirect(): Promise<void> {
@@ -272,7 +245,6 @@ export class MobileEndpointSupervisor {
     } finally {
       successful?.client.close()
       this.operationInFlight = false
-      // Why: a relay drop or backoff timer can arrive while the direct probe owns the mutex.
       if (this.relayRotationPending || this.logical.getState() !== 'connected') {
         void this.recoverRelay(this.relayRotationPending)
       }
@@ -281,35 +253,32 @@ export class MobileEndpointSupervisor {
   }
 
   private async rotateCredentialIfNeeded(force = false): Promise<void> {
-    if (
-      this.stopped ||
-      this.credentialRotationInFlight ||
-      !this.bundle ||
-      this.logical.getActivePath() === 'relay' ||
-      (!force && !mobileRelayCredentialNeedsRotation(this.bundle, this.dependencies.now()))
-    ) {
+    if (this.credentialRotationInFlight) {
       return
     }
     this.credentialRotationInFlight = true
     let credentialRefreshed = false
     try {
-      const result = await rotateMobileRelayCredential({
+      const result = await refreshMobileRelayCredentialIfNeeded({
+        force,
+        stopped: this.stopped,
+        activePath: this.logical.getActivePath(),
+        now: this.dependencies.now(),
         client: this.logical,
         bundle: this.bundle,
         writeBundle: this.dependencies.writeBundle,
-        randomBytes: this.dependencies.randomBytes
+        randomBytes: this.dependencies.randomBytes,
+        host: this.host,
+        saveHost: this.dependencies.saveHost
       })
-      this.bundle = result.bundle
-      // Why: a scheduled rotation can finish after the old credential enters the rejection gate.
-      credentialRefreshed = true
-      this.host = await persistRelayHost(this.host, result.relay, this.dependencies.saveHost)
-    } catch {
-      // Why: pending material remains durable; the next authenticated direct
-      // opportunity must reconcile it before creating another install key.
-    } finally {
-      if (credentialRefreshed) {
-        this.relayReconnect.completeCredentialRefresh()
+      if (!result) {
+        return
       }
+      this.bundle = result.bundle
+      this.host = result.host
+      this.relayReconnect.completeCredentialRefresh()
+      credentialRefreshed = true
+    } finally {
       this.credentialRotationInFlight = false
       if (
         credentialRefreshed &&
@@ -323,9 +292,6 @@ export class MobileEndpointSupervisor {
   }
 
   private clearDirectProbeTimer(): void {
-    if (this.probeTimer) {
-      this.dependencies.clearTimer(this.probeTimer)
-      this.probeTimer = null
-    }
+    this.directProbeTimer.clear(this.dependencies.clearTimer)
   }
 }

--- a/mobile/src/transport/mobile-relay-credential-refresh.ts
+++ b/mobile/src/transport/mobile-relay-credential-refresh.ts
@@ -1,0 +1,47 @@
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import {
+  mobileRelayCredentialNeedsRotation,
+  rotateMobileRelayCredential
+} from './mobile-relay-credential-rotation'
+import { persistRelayHost } from './mobile-endpoint-supervisor-support'
+import type { MobileConnectionPath, StableLogicalRpcClient } from './stable-logical-rpc-client'
+import type { HostProfile } from './types'
+
+export async function refreshMobileRelayCredentialIfNeeded(args: {
+  force: boolean
+  stopped: boolean
+  activePath: MobileConnectionPath
+  now: number
+  client: StableLogicalRpcClient
+  bundle: MobileRelayCredentialBundle | null
+  host: HostProfile
+  writeBundle: (bundle: MobileRelayCredentialBundle) => Promise<void>
+  saveHost: (host: HostProfile) => Promise<void>
+  randomBytes: (length: number) => Uint8Array
+}): Promise<{ bundle: MobileRelayCredentialBundle; host: HostProfile } | null> {
+  if (
+    args.stopped ||
+    !args.bundle ||
+    args.activePath === 'relay' ||
+    (!args.force && !mobileRelayCredentialNeedsRotation(args.bundle, args.now))
+  ) {
+    return null
+  }
+  try {
+    const result = await rotateMobileRelayCredential({
+      client: args.client,
+      bundle: args.bundle,
+      writeBundle: args.writeBundle,
+      randomBytes: args.randomBytes
+    })
+    return {
+      bundle: result.bundle,
+      host: await persistRelayHost(args.host, result.relay, args.saveHost)
+    }
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error
+    }
+    return null
+  }
+}

--- a/mobile/src/transport/mobile-relay-credential-trial.ts
+++ b/mobile/src/transport/mobile-relay-credential-trial.ts
@@ -1,0 +1,50 @@
+import {
+  isDirectorResolutionFailure,
+  persistRelayHost,
+  toError
+} from './mobile-endpoint-supervisor-support'
+import type { HostProfile } from './types'
+import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
+
+export type TryRelayCredentialResult = { ok: true } | { ok: false; error: Error }
+
+export async function tryRelayCredential(args: {
+  credential: { token: string; version: number }
+  host: HostProfile
+  logicalState: () => string
+  logicalActivePath: () => string
+  openAndMigrateRelay: (credential: {
+    token: string
+    version: number
+  }) => Promise<{ ok: true } | { ok: false; error: Error }>
+  resolveRelay: (args: {
+    relay: MobileRelayEndpoint
+    resumeToken: string
+  }) => Promise<MobileRelayEndpoint>
+  saveHost: (host: HostProfile) => Promise<void>
+  updateHost: (host: HostProfile) => void
+}): Promise<TryRelayCredentialResult> {
+  const first = await args.openAndMigrateRelay(args.credential)
+  if (first.ok) {
+    return first
+  }
+  // Why: if the active session connected on a non-relay path during the
+  // first attempt, the director resolution retry would also race — skip it.
+  if (args.logicalState() === 'connected' && args.logicalActivePath() !== 'relay') {
+    return first
+  }
+  if (!isDirectorResolutionFailure(first.error) || !args.host.relay) {
+    return first
+  }
+  try {
+    const resolved = await args.resolveRelay({
+      relay: args.host.relay,
+      resumeToken: args.credential.token
+    })
+    const host = await persistRelayHost(args.host, resolved, args.saveHost)
+    args.updateHost(host)
+    return await args.openAndMigrateRelay(args.credential)
+  } catch (error) {
+    return { ok: false, error: toError(error) }
+  }
+}

--- a/mobile/src/transport/mobile-relay-recovery-eligibility.ts
+++ b/mobile/src/transport/mobile-relay-recovery-eligibility.ts
@@ -1,0 +1,22 @@
+import type { ConnectionState } from './types'
+
+export function canRecoverMobileRelay(args: {
+  stopped: boolean
+  foreground: boolean
+  operationInFlight: boolean
+  hasBundle: boolean
+  hasRelay: boolean
+  forceReplacement: boolean
+  allowDirectRace: boolean
+  state: ConnectionState
+  needsRecovery: (state: ConnectionState) => boolean
+}): boolean {
+  return (
+    !args.stopped &&
+    args.foreground &&
+    !args.operationInFlight &&
+    args.hasBundle &&
+    args.hasRelay &&
+    (args.forceReplacement || args.allowDirectRace || args.needsRecovery(args.state))
+  )
+}

--- a/mobile/src/transport/stable-logical-rpc-client.test.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.test.ts
@@ -197,4 +197,22 @@ describe('stable logical RPC client', () => {
     expect(client.getActivePath()).toBe('lan')
     expect(client.getGeneration()).toBe(1)
   })
+
+  it('preserves direct path if it connects while relay replacement authenticates', async () => {
+    const lanSession = new FakeSession('connecting')
+    const relaySession = new FakeSession('connecting')
+    const client = createStableLogicalRpcClient(lanSession, 'lan')
+    const migrating = client.migrateTo(relaySession, 'relay')
+
+    lanSession.setState('connected')
+    relaySession.setState('connected')
+
+    await expect(migrating).rejects.toThrow(
+      'session migration cancelled: active path already connected'
+    )
+    expect(relaySession.close).toHaveBeenCalledOnce()
+    expect(lanSession.close).not.toHaveBeenCalled()
+    expect(client.getActivePath()).toBe('lan')
+    expect(client.getGeneration()).toBe(1)
+  })
 })

--- a/mobile/src/transport/stable-logical-rpc-client.ts
+++ b/mobile/src/transport/stable-logical-rpc-client.ts
@@ -184,6 +184,9 @@ export function createStableLogicalRpcClient(
         nextSession.close()
         throw new Error('Client closed')
       }
+      // Why: snapshot before wait so the post-wait guard can detect a
+      // transition that happened during the replacement's authentication.
+      const wasConnected = state === 'connected'
       try {
         await waitForAuthenticated(nextSession, timeoutMs)
       } catch (error) {
@@ -193,6 +196,12 @@ export function createStableLogicalRpcClient(
       if (closed) {
         nextSession.close()
         throw new Error('Client closed')
+      }
+      // Why: if the active session connected on a non-relay path while the
+      // replacement was authenticating, the active route is already viable.
+      if (!wasConnected && state === 'connected' && activePath !== 'relay' && path === 'relay') {
+        nextSession.close()
+        throw new Error('session migration cancelled: active path already connected')
       }
       const previous = activeSession
       const previousStateUnsubscribe = activeStateUnsubscribe


### PR DESCRIPTION
## Summary
- start Relay recovery while the initial direct LAN dial is still pending
- preserve an authenticated direct path if it wins while a Relay session is authenticating
- record safe, endpoint-free Relay lifecycle diagnostics: recovery begins, Relay connects, or direct wins the race

## Validation
- focused mobile supervisor and stable-client tests: 42 passed
- full mobile test suite: 341 files passed, 2,485 tests passed, 2 skipped
- mobile TypeScript check, lint, and format check passed
- root TypeScript check passed
- root lint ran but failed on existing localization findings in three untouched Settings search files
- root build passed after exposing `pnpm` to nested package scripts; the non-fatal global `orca-dev` symlink permission warning remains environment-specific
- root full test run completed with 3,448 files passing and 4 files / 5 tests failing in untouched startup, Command Code, SSH integration, and renderer project-view tests; it also hit worker startup timeouts. It is not claimed as passing

## Compatibility And Review Summary
- no visual change; no screenshots are applicable
- cross-platform: TypeScript-only mobile transport logic; no platform-specific API, shortcut, filesystem, or native-module changes
- local, remote, and SSH: Relay recovery operates through the existing host profile and logical RPC client; it does not assume a local desktop process or local filesystem path
- agents, integrations, and Git providers: no agent, integration, or provider-specific behavior changed
- performance: diagnostics emit only on recovery lifecycle transitions and reuse the existing bounded per-host log store
- security: logs contain fixed lifecycle text and a direct connection-state enum only; no endpoint, host/relay identifier, token, cryptographic value, credential, or raw error is recorded
- Tailscale/direct reachability is outside this Relay fallback change

## Evidence And Limits
- pairing-offer construction and schemas were inspected; Relay credentials remain distinct from the direct endpoint and are not logged
- physical iOS/Relay verification was not possible here: no iOS simulator/device harness or reachable Relay environment
- upstream pull-request workflows require maintainer approval for this fork PR
- this PR remains a draft
- X/Twitter: not provided by contributor; maintainer waiver requested
