### PR TITLE
fix(codex): widen the stale-pane sweep retry ladder past the Windows worst case

### DIFF
--- a/src/renderer/src/lib/codex-stale-pane-sweep.test.ts
+++ b/src/renderer/src/lib/codex-stale-pane-sweep.test.ts
@@ -148,6 +148,10 @@ describe('notifyCodexPaneBoundForStaleSweep', () => {
     await vi.advanceTimersByTimeAsync(120_000)
 
     expect(window.api.pty.inspectProcess).toHaveBeenCalledTimes(5)
+    // Why: the count alone only bounds the first two minutes — a rung past the
+    // window would still read as 5. An empty queue is what proves the ladder
+    // ended rather than merely moved out of view.
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('still sweeps a pane whose reattach outlives the first three rungs', async () => {

--- a/src/renderer/src/lib/codex-stale-pane-sweep.test.ts
+++ b/src/renderer/src/lib/codex-stale-pane-sweep.test.ts
@@ -144,16 +144,44 @@ describe('notifyCodexPaneBoundForStaleSweep', () => {
     vi.mocked(window.api.pty.inspectProcess).mockRejectedValue(new Error('terminal_gone'))
 
     notifyCodexPaneBoundForStaleSweep('pty-1')
-    await vi.advanceTimersByTimeAsync(60_000)
+    // Well past the last rung (35.8s), so this pins the ceiling, not the clock.
+    await vi.advanceTimersByTimeAsync(120_000)
 
-    expect(window.api.pty.inspectProcess).toHaveBeenCalledTimes(3)
+    expect(window.api.pty.inspectProcess).toHaveBeenCalledTimes(5)
+  })
+
+  it('still sweeps a pane whose reattach outlives the first three rungs', async () => {
+    // Regression: live Windows 11 runs raised the notice on the third rung
+    // (5.8s) in all three samples, i.e. the ladder ended exactly where the
+    // slowest measured box landed. A colder reattach falls past it, and the
+    // failure is silent — no card, so the pane keeps running the old account.
+    vi.mocked(window.api.codexAccounts.listStalePanes).mockResolvedValue([STALE_PANE])
+    vi.mocked(window.api.pty.inspectProcess)
+      .mockRejectedValueOnce(new Error('terminal_gone'))
+      .mockRejectedValueOnce(new Error('terminal_gone'))
+      .mockRejectedValueOnce(new Error('terminal_gone'))
+
+    notifyCodexPaneBoundForStaleSweep('pty-1')
+    // t = 5800: rungs 1-3 are spent and nothing has been raised.
+    await vi.advanceTimersByTimeAsync(5_800)
+    expect(inspectCallCountFor('pty-1')).toBe(3)
+    expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+
+    // t = 15800: the fourth rung is the one that catches this pane.
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+    expect(inspectCallCountFor('pty-1')).toBe(4)
   })
 
   it('spends a pane its full retry ladder even when another pane binds later', async () => {
     // Regression: one shared timer used to drain every queued PTY, so a pane
     // already waiting on its 1500ms rung had the next rung consumed by the newer
-    // pane's shorter delay — exhausting its 3 attempts ~2.5s early and dropping
-    // a Windows daemon reattach that had not settled yet.
+    // pane's shorter delay — burning through its ladder early and dropping a
+    // Windows daemon reattach that had not settled yet.
     useAppStore.setState({ ptyIdsByTabId: { 'tab-1': ['pty-1', 'pty-2'] } })
     vi.mocked(window.api.pty.inspectProcess).mockRejectedValue(new Error('terminal_gone'))
 

--- a/src/renderer/src/lib/codex-stale-pane-sweep.ts
+++ b/src/renderer/src/lib/codex-stale-pane-sweep.ts
@@ -5,10 +5,14 @@ import {
 
 // Why: the first delay coalesces the startup burst of binds and lets
 // updateTabPtyId (written just after the layout binding) land, since the scan
-// walks tabs. The later two cover a reattached daemon shell that answers
-// `inspectProcess` with terminal_gone for a beat. Bounded on purpose — this is
-// a hint, and a pane that never resolves must not become a polling loop.
-const SWEEP_ATTEMPT_DELAYS_MS = [300, 1500, 4000] as const
+// walks tabs. The rest cover a reattached daemon shell that answers
+// `inspectProcess` with terminal_gone for a beat. The tail is sized off live
+// Windows 11 runs, where the 5.8s rung is what raised the notice in all three
+// (macOS resolved on the first): the ladder used to end exactly where the
+// slowest measured box landed, so a colder reattach fell off it and the pane
+// stayed silently stale. Bounded on purpose — this is a hint, and a pane that
+// never resolves must not become a polling loop.
+const SWEEP_ATTEMPT_DELAYS_MS = [300, 1500, 4000, 10_000, 20_000] as const
 
 // Why: each PTY owns its rung, so the queue has to carry a per-PTY due time. One
 // shared timer coalesces the startup burst, but it must always target the


### PR DESCRIPTION
Stacked on #10770. **Ladder only** — no change to the bind signal, the eligibility predicate, or the queue mechanics.

## The problem

Live Windows 11 validation of #10770 measured store-visible PTY bind → notice raised:

| run | bind → notice |
| --- | --- |
| 1 | 5,140 ms |
| 2 | 3,959 ms |
| 3 | 4,064 ms |

The ladder was `SWEEP_ATTEMPT_DELAYS_MS = [300, 1500, 4000]`, i.e. attempts at **300ms / 1800ms / 5800ms** from bind. On Windows the **final** rung is what produced the card in all three runs — rungs 1 and 2 never won. macOS by comparison resolved on the first rung in ~0.66s, leaving ~3.3s of ladder unused.

So Windows consumes the entire ladder with essentially zero margin. A slower box, more panes, or a colder daemon reattach and the last attempt also misses — at which point there is no further rung, `queueNextRung` drops the pane, and **the card never appears**. The user stays on the old account unaware, which is precisely the bug #10770 exists to fix. The failure mode when the ladder exhausts is "no card", never a dead keyboard, so this is a coverage problem, not a safety one.

## The change

```
- const SWEEP_ATTEMPT_DELAYS_MS = [300, 1500, 4000] as const
+ const SWEEP_ATTEMPT_DELAYS_MS = [300, 1500, 4000, 10_000, 20_000] as const
```

Cumulative attempt times from bind:

| rung | old | new |
| --- | --- | --- |
| 1 | 300 ms | 300 ms |
| 2 | 1.8 s | 1.8 s |
| 3 | 5.8 s | 5.8 s |
| 4 | — | 15.8 s |
| 5 | — | 35.8 s |

Justification against the measurements:

- **Early rungs untouched**, so macOS still resolves in <1s and the startup-burst coalescing is unchanged. This is a pure tail extension — no existing behaviour moves.
- **The tail clears the observed worst case by a wide margin.** The winning rung on Windows was 5.8s; the new rungs sit at ~2.7× and ~6.2× that. Two extra rungs is enough because the growth is geometric — matching the existing ~2.5× shape — so a large time window costs few attempts and therefore few IPC round-trips.
- **Still bounded.** Five attempts, then `queueNextRung` finds `undefined` and deletes the pane's attempt state. It is not interval-based and cannot become a polling loop, which the constant's comment calls out explicitly.
- **A late card is strictly better than no card.** The pane is still stale at t=35s, and the notice is dismissible.

Per-PTY rungs stay per-PTY: `queue`/`takeDuePtyIds` are untouched, so the rung-collapse fix from the earlier review round is not regressed. The sweep still stops for a notified pane (`notifiedPtyIds`) and for a dismissed one (`forgetStaleCodexPanes` drops the launch record, so `listStalePanes` stops reporting it) — a longer tail cannot resurrect either.

## Verification

**Mutation-proof of the new tail.** Reverting the constant to `[300, 1500, 4000]` with the tests unchanged fails exactly the two tests that assert the tail:

```
FAIL  'still sweeps a pane whose reattach outlives the first three rungs'
      → codexRestartNoticeByPtyId['pty-1'] is undefined; inspect count 3, expected 4
FAIL  'gives up after a bounded ladder instead of polling forever'
      → expected inspectProcess called 5 times, got 3
Tests  2 failed | 13 passed
```

The new test drives a pane inconclusive through the first three rungs and asserts the notice is still raised on the fourth — the exact silent-failure scenario the Windows data points at. The bounded-ladder test now advances 120s (well past the 35.8s ceiling) so it pins the ceiling rather than the clock.

**Per-PTY independence test passes unchanged** — `spends a pane its full retry ladder even when another pane binds later` still asserts 2 then 3 inspects for `pty-1` at t=3310/6310, which the longer ladder does not perturb. Only its stale "its 3 attempts" comment was reworded.

Gates, all green on this branch:

- `npm run typecheck` (node + tc.cli + tc.web) — exit 0, 0 errors
- `npx oxlint` — exit 0, no findings in touched files
- `check:max-lines-ratchet` — OK, no new bypasses
- `codex-stale-pane-sweep.test.ts` + `codex-session-restart.test.ts` — 33/33
- `pty-connection.test.ts` (the sweep's only caller) — 484/484

Known-noise on the validation box, unrelated to this change: Node 26 vs the repo-pinned 24 fails ~41 renderer tests (browser-pane/markup, right-sidebar, sidebar) on clean checkouts, and `verify:localization-coverage` exits 1 on 6 pre-existing Ghostty strings.