### PR TITLE
feat(terminal): detect agents inside tmux

### DIFF
--- a/src/main/providers/agent-foreground-process-tmux.test.ts
+++ b/src/main/providers/agent-foreground-process-tmux.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+type ExecCallback = (error: unknown, result: { stdout: string; stderr: string }) => void
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+
+import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot'
+import { resolveAgentForegroundProcess } from './agent-foreground-process'
+
+describe('agent foreground process through tmux', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetProcessTableSnapshotForTests()
+  })
+
+  it('resolves the agent outside the tmux client process tree', async () => {
+    execFileMock.mockImplementation(
+      (command: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+        const stdout =
+          command === 'ps'
+            ? [
+                '100 99 Ss   zsh',
+                '101 100 S+   tmux attach-session -t work',
+                '500 400 Ss   zsh',
+                '501 500 S+   claude'
+              ].join('\n')
+            : '101\t500\tclaude\n'
+        callback(null, { stdout, stderr: '' })
+      }
+    )
+
+    await expect(resolveAgentForegroundProcess(100, 'tmux')).resolves.toBe('claude')
+  })
+})

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -6,6 +6,10 @@ import {
   type ProcessTableRow
 } from '../../shared/process-table-snapshot'
 import {
+  isTmuxProcessCommand,
+  resolveTmuxPaneForegroundProcess
+} from '../../shared/tmux-pane-process'
+import {
   resolveWindowsAgentForegroundProcessWithAvailability,
   shouldInspectWindowsAgentForeground,
   type AgentForegroundResolutionOptions
@@ -99,7 +103,7 @@ export async function resolveAgentForegroundProcessWithAvailability(
     }
     return {
       available: true,
-      processName: resolveAgentForegroundProcessFromPs(rows, shellPid) ?? fallbackProcess
+      processName: (await resolveAgentForegroundProcessFromPs(rows, shellPid)) ?? fallbackProcess
     }
   } catch {
     // Why: a failed scan cannot prove fallback ownership; callers retain the last recognized agent.
@@ -107,10 +111,10 @@ export async function resolveAgentForegroundProcessWithAvailability(
   }
 }
 
-function resolveAgentForegroundProcessFromPs(
+async function resolveAgentForegroundProcessFromPs(
   rows: ProcessTableRow[],
   shellPid: number
-): string | null {
+): Promise<string | null> {
   const shellRow = rows.find((row) => row.pid === shellPid)
   const candidates = collectDescendants(rows, shellPid).sort(
     (a, b) => candidateScore(b) - candidateScore(a)
@@ -124,6 +128,12 @@ function resolveAgentForegroundProcessFromPs(
   for (const candidate of candidates) {
     if (foregroundIsKnown && !candidate.stat.includes('+')) {
       continue
+    }
+    if (isTmuxProcessCommand(candidate.command)) {
+      const tmuxForeground = await resolveTmuxPaneForegroundProcess(rows, candidate)
+      if (tmuxForeground) {
+        return tmuxForeground
+      }
     }
     const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
     if (recognized) {

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -304,6 +304,30 @@ describe('getForegroundProcessName', () => {
     })
   })
 
+  it('recognizes an agent in the active tmux pane on an SSH relay', async () => {
+    await withProcessPlatform('linux', async () => {
+      mockExecFile((command, args) => {
+        if (command === 'ps' && args[0] === '-axo') {
+          return {
+            stdout: [
+              '100 99 Ss   bash -l',
+              '101 100 S+   tmux -L work attach',
+              '500 400 Ss   zsh',
+              '501 500 S+   node /home/dev/.local/bin/codex'
+            ].join('\n')
+          }
+        }
+        if (command === 'tmux') {
+          expect(args.slice(0, 2)).toEqual(['-L', 'work'])
+          return { stdout: '101\t500\tcodex\n' }
+        }
+        return new Error('unexpected command')
+      })
+
+      await expect(getForegroundProcessName(100, 'tmux')).resolves.toBe('codex')
+    })
+  })
+
   it('recognizes Windows SSH relay shell-rooted agent descendants', async () => {
     await withProcessPlatform('win32', async () => {
       mockExecFile((command) => {

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -11,6 +11,7 @@ import {
 } from '../shared/agent-process-recognition'
 import { getFirstCommandToken } from '../shared/command-token-scanner'
 import { getProcessTableSnapshot, type ProcessTableRow } from '../shared/process-table-snapshot'
+import { isTmuxProcessCommand, resolveTmuxPaneForegroundProcess } from '../shared/tmux-pane-process'
 import {
   resolveOuterWrapperForegroundProcess,
   shouldInspectOuterWrapperForegroundProcess
@@ -224,13 +225,6 @@ function processCommandToken(command: string): string {
   return getFirstCommandToken(command)
 }
 
-function candidateMatchesFallbackWrapper(
-  candidate: ProcessTableRow,
-  fallbackProcess: string
-): boolean {
-  return isExpectedAgentProcess(processCommandToken(candidate.command), fallbackProcess)
-}
-
 async function getRecognizedForegroundDescendant(
   pid: number,
   fallbackProcess?: string | null
@@ -249,20 +243,21 @@ async function getRecognizedForegroundDescendant(
     const foregroundCandidates = foregroundIsKnown
       ? candidates.filter((candidate) => candidate.stat.includes('+'))
       : candidates
-    const inspectionCandidates =
-      fallbackProcess && isAgentForegroundWrapperProcess(fallbackProcess)
-        ? foregroundCandidates.filter((candidate) =>
-            candidateMatchesFallbackWrapper(candidate, fallbackProcess)
-          )
-        : foregroundCandidates
-    if (
-      fallbackProcess &&
-      isAgentForegroundWrapperProcess(fallbackProcess) &&
-      inspectionCandidates.length !== 1
-    ) {
+    const fallbackIsWrapper =
+      typeof fallbackProcess === 'string' && isAgentForegroundWrapperProcess(fallbackProcess)
+    const inspectionCandidates = fallbackIsWrapper
+      ? foregroundCandidates.filter((candidate) =>
+          isExpectedAgentProcess(processCommandToken(candidate.command), fallbackProcess)
+        )
+      : foregroundCandidates
+    if (fallbackIsWrapper && inspectionCandidates.length !== 1) {
       return null
     }
     for (const candidate of inspectionCandidates) {
+      const tmuxForeground = await resolveTmuxPaneForegroundProcess(rows, candidate)
+      if (tmuxForeground) {
+        return tmuxForeground
+      }
       const recognized = recognizeAgentProcessFromCommandLine(candidate.command)
       if (recognized) {
         // Why: return the outer wrapper (omp) rather than the deeper wrapped child
@@ -310,7 +305,11 @@ export async function getForegroundProcessName(
         (await resolveWindowsAgentForegroundProcess(pid, fallbackProcess, {})) ?? fallbackProcess
       )
     }
-    if (!isShellProcess(fallbackProcess) && !isAgentForegroundWrapperProcess(fallbackProcess)) {
+    const inspectFallback =
+      isShellProcess(fallbackProcess) ||
+      isAgentForegroundWrapperProcess(fallbackProcess) ||
+      isTmuxProcessCommand(fallbackProcess)
+    if (!inspectFallback) {
       return fallbackProcess
     }
   }

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
@@ -206,6 +206,18 @@ describe('createPaneForegroundAgentTracker', () => {
     expect(publish).toHaveBeenLastCalledWith({ agent: 'codex', shellForeground: false })
   })
 
+  it('retries a restored visible tmux client until its pane agent resolves', async () => {
+    readForegroundProcess.mockResolvedValueOnce('tmux').mockResolvedValueOnce('claude')
+    const tracker = makeTracker()
+
+    tracker.onVisiblePtyBound()
+    await flushSettleRead(VISIBLE_PTY_SETTLE_MS)
+    expect(publish).not.toHaveBeenCalled()
+
+    await flushSettleRead(WRAPPER_RESOLVE_RETRY_MS)
+    expect(publish).toHaveBeenLastCalledWith({ agent: 'claude', shellForeground: false })
+  })
+
   it('re-reads on a bounded ladder while the read still sees an interpreter wrapper', async () => {
     // Why: daemon shell/helper→agent ancestry resolution has been observed to
     // take >1.5s for real node-wrapped CLIs, so the ladder gets two re-reads.
@@ -226,6 +238,18 @@ describe('createPaneForegroundAgentTracker', () => {
     await flushSettleRead(SECOND_WRAPPER_RETRY_MS)
     expect(readForegroundProcess).toHaveBeenCalledTimes(3)
     expect(publish).toHaveBeenLastCalledWith({ agent: 'claude', shellForeground: false })
+  })
+
+  it('keeps sampling a tmux start until its active pane agent is visible', async () => {
+    readForegroundProcess.mockResolvedValueOnce('tmux').mockResolvedValueOnce('codex')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    await flushSettleRead(COMMAND_SETTLE_MS)
+    expect(publish).toHaveBeenLastCalledWith({ agent: null, shellForeground: false })
+
+    await flushSettleRead(WRAPPER_RESOLVE_RETRY_MS)
+    expect(publish).toHaveBeenLastCalledWith({ agent: 'codex', shellForeground: false })
   })
 
   it('stops after the ladder and publishes no identity for a persistent unknown process', async () => {

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
@@ -3,6 +3,7 @@ import {
   recognizeAgentProcess
 } from '../../../../shared/agent-process-recognition'
 import { isShellProcess } from '../../../../shared/shell-process-detection'
+import { isTmuxProcessCommand } from '../../../../shared/tmux-pane-process'
 import type { TuiAgent } from '../../../../shared/types'
 import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 
@@ -12,6 +13,7 @@ const COMMAND_SETTLE_MS = 350
 const VISIBLE_PTY_SETTLE_MS = 350
 const WRAPPER_RESOLVE_RETRY_DELAYS_MS = [1200, 6000] as const
 type ForegroundReadReason = 'command' | 'visible-pty' | 'command-finished'
+type ForegroundAgentCommandExpectation = TuiAgent | 'tmux'
 
 type PaneForegroundAgentTrackerDeps = {
   getPtyId: () => string | null
@@ -44,7 +46,7 @@ type PaneForegroundAgentTrackerDeps = {
  */
 export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTrackerDeps): {
   onVisiblePtyBound: (expectsAgent?: boolean) => boolean
-  onCommandStarted: (expectedAgent?: TuiAgent | null) => void
+  onCommandStarted: (expectedAgent?: ForegroundAgentCommandExpectation | null) => void
   /** True when pane identity must remain visible until an async shell confirmation. */
   onCommandFinished: () => boolean
   dispose: () => void
@@ -151,7 +153,9 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
       retryDelay !== undefined &&
       (shouldRetryExpectedIdentity ||
         (processName !== null &&
-          (reason === 'command' || isAgentForegroundWrapperProcess(processName))))
+          (reason === 'command' ||
+            isAgentForegroundWrapperProcess(processName) ||
+            isTmuxProcessCommand(processName))))
     if (shouldRetry) {
       // Why: provisional PowerShell may hide a live agent; the bounded ladder
       // spans PowerShell-to-WMIC enrichment without becoming a polling loop.

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -5531,6 +5531,42 @@ describe('connectPanePty', () => {
     expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
   })
 
+  it('remembers a typed tmux attach command until its pane agent is visible', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    vi.mocked(window.api.pty.confirmForegroundProcess)
+      .mockResolvedValueOnce('tmux')
+      .mockResolvedValue('codex')
+    const pane = createPane(1)
+    const ptyId = 'pty-manual-tmux-no-osc'
+    const tabId = 'tab-manual-tmux-no-osc'
+    const paneKey = makePaneKey(tabId, LEAF_1)
+    transportFactoryQueue.push(createMockTransport(ptyId))
+
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({ tabId, isVisibleRef: { current: false } }) as never
+    )
+    await vi.advanceTimersByTimeAsync(20)
+    await flushAsyncTicks()
+
+    sendTerminalInputThroughPane(pane, 'tmux -L work attach-session -t agent\r')
+    await vi.advanceTimersByTimeAsync(350)
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: null,
+      shellForeground: false
+    })
+
+    await vi.advanceTimersByTimeAsync(1200)
+    expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledTimes(2)
+    expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
+      agent: 'codex',
+      routingTrusted: true,
+      shellForeground: false
+    })
+  })
+
   it('confirms an Orca-launched Droid fresh spawn in a no-OSC shell (Git Bash)', async () => {
     // Why: no-OSC shells (Git Bash/cmd) emit no command boundary, so without a fresh-spawn sample the pane never earns routing trust and Shift+Enter regresses to Esc+CR (#7620).
     vi.useFakeTimers()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -266,6 +266,7 @@ import {
   isExpectedAgentProcess,
   recognizeAgentProcessFromCommandLine
 } from '../../../../shared/agent-process-recognition'
+import { isTmuxSessionCommand } from '../../../../shared/tmux-pane-process'
 import type { SetupSplitDirection, TuiAgent } from '../../../../shared/types'
 import { isWslUncPath } from '../../../../shared/wsl-paths'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
@@ -1265,11 +1266,12 @@ export function connectPanePty(
   // shadowing the shell's current command line, for generic terminals where no
   // launch metadata exists. Consumed by getAuthoritativePaneAgent below.
   let commandInferredPaneAgent: TuiAgent | null = null
+  let commandInferredTmuxSessionCommand: string | null = null
   let pendingShellCommandLine = ''
   let pendingShellCommandCursor = 0
   let commandInferredPaneAgentGeneration = 0
   let shellCommandInferenceSuspendedUntilCommandEnd = false
-  let startAcceptedInferredCommand = (_agent: TuiAgent): void => {}
+  let startAcceptedInferredCommand = (_expectation: TuiAgent | 'tmux'): void => {}
   let requestKnownDroidReconfirmation = (): void => {}
   const resetPendingShellCommandLine = (): void => {
     pendingShellCommandLine = ''
@@ -1281,6 +1283,7 @@ export function connectPanePty(
     const candidateAgent = commandLine
       ? (recognizeAgentProcessFromCommandLine(commandLine)?.agent ?? null)
       : null
+    const candidateTmuxCommand = isTmuxSessionCommand(commandLine) ? commandLine : null
     const state = useAppStore.getState()
     const registeredLaunchAgent = state.agentLaunchConfigByPaneKey[cacheKey]?.identity.agentType
     // Why: input inside a live TUI can spell another agent command; process or
@@ -1289,14 +1292,22 @@ export function connectPanePty(
       state.paneForegroundAgentByPaneKey[cacheKey]?.agent || isTuiAgent(registeredLaunchAgent)
         ? null
         : candidateAgent
+    const nextTmuxCommand =
+      nextAgent === null &&
+      !state.paneForegroundAgentByPaneKey[cacheKey]?.agent &&
+      !isTuiAgent(registeredLaunchAgent)
+        ? candidateTmuxCommand
+        : null
     commandInferredPaneAgent = nextAgent
+    commandInferredTmuxSessionCommand = nextTmuxCommand
     commandInferredPaneAgentGeneration += 1
-    if (nextAgent) {
-      startAcceptedInferredCommand(nextAgent)
+    if (nextAgent || nextTmuxCommand) {
+      startAcceptedInferredCommand(nextAgent ?? 'tmux')
     }
   }
   const clearCommandInferredPaneAgent = (): void => {
     commandInferredPaneAgent = null
+    commandInferredTmuxSessionCommand = null
     resetPendingShellCommandLine()
     commandInferredPaneAgentGeneration += 1
   }
@@ -1522,7 +1533,7 @@ export function connectPanePty(
       // submit or interrupt revokes only stale Droid routing and confirms once.
       requestKnownDroidReconfirmation()
     }
-    if (commandInferredPaneAgent) {
+    if (commandInferredPaneAgent || commandInferredTmuxSessionCommand) {
       return
     }
     // Why: bytes typed inside a live agent TUI are prompt text, not shell
@@ -2121,7 +2132,9 @@ export function connectPanePty(
       visibleForegroundSampleSettled = false
       // Why: typed commands can be aliases, so they only widen the bounded
       // process-confirmation window; they never become routing evidence.
-      paneForegroundAgentTracker.onCommandStarted(commandInferredPaneAgent)
+      paneForegroundAgentTracker.onCommandStarted(
+        commandInferredPaneAgent ?? (commandInferredTmuxSessionCommand ? 'tmux' : null)
+      )
     },
     onCommandFinished: handleCommandFinished
   })

--- a/src/shared/agent-process-recognition.ts
+++ b/src/shared/agent-process-recognition.ts
@@ -101,7 +101,7 @@ function recognizedAgentForProcess(normalized: string): RecognizedAgentProcess |
   return agent ? { agent, processName: normalized } : null
 }
 
-function tokenizeCommandLine(commandLine: string): string[] {
+export function tokenizeProcessCommandLine(commandLine: string): string[] {
   const tokens: string[] = []
   let current = ''
   let quote: '"' | "'" | null = null
@@ -287,7 +287,7 @@ export function recognizeAgentProcessFromCommandLine(
     return null
   }
   const keep = options?.includeHeadlessOneShot === true
-  const tokens = tokenizeCommandLine(commandLine)
+  const tokens = tokenizeProcessCommandLine(commandLine)
   const firstNormalized = normalizeProcessName(tokens[0])
   let direct = recognizeAgentProcess(tokens[0])
   // Why: the generic Orca CLI is not an agent; only this subcommand launches its TUI mode.

--- a/src/shared/tmux-pane-process.test.ts
+++ b/src/shared/tmux-pane-process.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+type ExecCallback = (error: unknown, result: { stdout: string; stderr: string }) => void
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+
+import type { ProcessTableRow } from './process-table-snapshot'
+import { isTmuxSessionCommand, resolveTmuxPaneForegroundProcess } from './tmux-pane-process'
+
+function row(pid: number, ppid: number, stat: string, command: string): ProcessTableRow {
+  return { pid, ppid, stat, command }
+}
+
+describe('tmux pane process resolution', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+  })
+
+  it('maps a tmux client using its socket and reports the active pane agent', async () => {
+    execFileMock.mockImplementation(
+      (cmd: string, args: string[], _opts: unknown, callback: ExecCallback) => {
+        expect(cmd).toBe('/usr/bin/tmux')
+        expect(args).toEqual([
+          '-S',
+          '/tmp/orca.sock',
+          'list-clients',
+          '-F',
+          '#{client_pid}\t#{pane_pid}\t#{pane_current_command}'
+        ])
+        callback(null, { stdout: '101\t500\tcodex\n', stderr: '' })
+      }
+    )
+    const rows = [
+      row(101, 100, 'S+', '/usr/bin/tmux -S /tmp/orca.sock attach-session -t work'),
+      row(500, 400, 'Ss', 'zsh'),
+      row(501, 500, 'S+', 'node /Users/dev/.nvm/versions/node/bin/codex')
+    ]
+
+    await expect(resolveTmuxPaneForegroundProcess(rows, rows[0])).resolves.toBe('codex')
+  })
+
+  it('reports the pane shell after its agent exits', async () => {
+    execFileMock.mockImplementation(
+      (_cmd: string, _args: string[], _opts: unknown, callback: ExecCallback) => {
+        callback(null, { stdout: '101\t500\tbash\n', stderr: '' })
+      }
+    )
+    const rows = [row(101, 100, 'S+', 'tmux attach'), row(500, 400, 'Ss+', '/bin/bash')]
+
+    await expect(resolveTmuxPaneForegroundProcess(rows, rows[0])).resolves.toBe('bash')
+  })
+
+  it('recognizes session creation and attach commands without matching control commands', () => {
+    expect(isTmuxSessionCommand('tmux')).toBe(true)
+    expect(isTmuxSessionCommand('tmux new-session -s work')).toBe(true)
+    expect(isTmuxSessionCommand('tmux -S /tmp/work.sock attach -t work')).toBe(true)
+    expect(isTmuxSessionCommand('tmux list-sessions')).toBe(false)
+    expect(isTmuxSessionCommand('tmux kill-server')).toBe(false)
+  })
+})

--- a/src/shared/tmux-pane-process.ts
+++ b/src/shared/tmux-pane-process.ts
@@ -1,0 +1,168 @@
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import {
+  recognizeAgentProcessFromCommandLine,
+  tokenizeProcessCommandLine
+} from './agent-process-recognition'
+import { getFirstCommandToken } from './command-token-scanner'
+import type { ProcessTableRow } from './process-table-snapshot'
+
+const execFile = promisify(execFileCb)
+const TMUX_QUERY_TIMEOUT_MS = 2_000
+const TMUX_CLIENT_FORMAT = '#{client_pid}\t#{pane_pid}\t#{pane_current_command}'
+const TMUX_COMMANDS = new Set(['tmux'])
+const TMUX_SESSION_COMMANDS = new Set(['attach', 'attach-session', 'a', 'new', 'new-session'])
+
+type TmuxServerInvocation = {
+  executable: string
+  serverArgs: string[]
+  subcommand: string | null
+}
+
+export type TmuxPaneProcess = {
+  panePid: number
+  currentCommand: string
+}
+
+function normalizedCommandName(token: string | undefined): string {
+  const basename =
+    (token ?? '')
+      .trim()
+      .replace(/^["']|["']$/g, '')
+      .split(/[\\/]/)
+      .pop() ?? ''
+  return basename.toLowerCase().replace(/\.exe$/, '')
+}
+
+function tmuxServerInvocation(commandLine: string): TmuxServerInvocation | null {
+  const tokens = tokenizeProcessCommandLine(commandLine)
+  if (!TMUX_COMMANDS.has(normalizedCommandName(tokens[0]))) {
+    return null
+  }
+  const serverArgs: string[] = []
+  let subcommand: string | null = null
+  for (let index = 1; index < tokens.length; index += 1) {
+    const token = tokens[index]
+    if (token === '-L' || token === '-S') {
+      const value = tokens[index + 1]
+      if (!value) {
+        return null
+      }
+      serverArgs.push(token, value)
+      index += 1
+      continue
+    }
+    if (token.startsWith('-L') || token.startsWith('-S')) {
+      serverArgs.push(token)
+      continue
+    }
+    if (token === '-c' || token === '-f' || token === '-T') {
+      index += 1
+      continue
+    }
+    if (!token.startsWith('-')) {
+      subcommand = token.toLowerCase()
+      break
+    }
+  }
+  return { executable: tokens[0], serverArgs, subcommand }
+}
+
+export function isTmuxProcessCommand(commandLine: string | null | undefined): boolean {
+  return typeof commandLine === 'string' && tmuxServerInvocation(commandLine) !== null
+}
+
+export function isTmuxSessionCommand(commandLine: string | null | undefined): boolean {
+  if (!commandLine) {
+    return false
+  }
+  const invocation = tmuxServerInvocation(commandLine)
+  return (
+    invocation !== null &&
+    (invocation.subcommand === null || TMUX_SESSION_COMMANDS.has(invocation.subcommand))
+  )
+}
+
+function parseTmuxPaneProcess(stdout: string, clientPid: number): TmuxPaneProcess | null {
+  for (const line of stdout.split(/\r?\n/)) {
+    const [clientPidText, panePidText, ...commandParts] = line.split('\t')
+    if (Number(clientPidText) !== clientPid) {
+      continue
+    }
+    const panePid = Number(panePidText)
+    if (!Number.isSafeInteger(panePid) || panePid <= 0) {
+      return null
+    }
+    return { panePid, currentCommand: commandParts.join('\t').trim() }
+  }
+  return null
+}
+
+export async function readTmuxClientPane(
+  clientCommandLine: string,
+  clientPid: number
+): Promise<TmuxPaneProcess | null> {
+  const invocation = tmuxServerInvocation(clientCommandLine)
+  if (!invocation) {
+    return null
+  }
+  try {
+    const { stdout } = await execFile(
+      invocation.executable,
+      [...invocation.serverArgs, 'list-clients', '-F', TMUX_CLIENT_FORMAT],
+      { encoding: 'utf8', timeout: TMUX_QUERY_TIMEOUT_MS }
+    )
+    return parseTmuxPaneProcess(stdout, clientPid)
+  } catch {
+    return null
+  }
+}
+
+function collectPaneProcesses(rows: ProcessTableRow[], rootPid: number): ProcessTableRow[] {
+  const childrenByParent = new Map<number, ProcessTableRow[]>()
+  for (const row of rows) {
+    const children = childrenByParent.get(row.ppid) ?? []
+    children.push(row)
+    childrenByParent.set(row.ppid, children)
+  }
+  const processes: ProcessTableRow[] = []
+  const stack = [rootPid]
+  const visited = new Set<number>()
+  while (stack.length > 0) {
+    const pid = stack.pop()!
+    if (visited.has(pid)) {
+      continue
+    }
+    visited.add(pid)
+    const row = rows.find((candidate) => candidate.pid === pid)
+    if (row) {
+      processes.push(row)
+    }
+    for (const child of childrenByParent.get(pid) ?? []) {
+      stack.push(child.pid)
+    }
+  }
+  return processes
+}
+
+export async function resolveTmuxPaneForegroundProcess(
+  rows: ProcessTableRow[],
+  client: ProcessTableRow
+): Promise<string | null> {
+  const pane = await readTmuxClientPane(client.command, client.pid)
+  if (!pane) {
+    return null
+  }
+  const processes = collectPaneProcesses(rows, pane.panePid)
+  const foregroundKnown = processes.some((row) => row.stat.includes('+'))
+  for (const row of processes) {
+    if (foregroundKnown && !row.stat.includes('+')) {
+      continue
+    }
+    const recognized = recognizeAgentProcessFromCommandLine(row.command)
+    if (recognized) {
+      return recognized.processName
+    }
+  }
+  return pane.currentCommand || getFirstCommandToken(processes[0]?.command ?? '') || null
+}


### PR DESCRIPTION
## Summary

This change teaches Orca to follow agent processes through tmux instead of treating the tmux client itself as the terminal foreground application.

- Recognize manually entered tmux session start and attach commands as an agent-hosting command expectation.
- Remember the accepted tmux command for the lifetime of the shell command, including shells that do not emit OSC 133 command boundaries.
- Resolve a tmux client to its currently active pane by querying `client_pid`, `pane_pid`, and `pane_current_command`.
- Inspect the active pane's process tree with Orca's existing agent recognition rules, so Claude, Codex, and other supported agents behave like directly launched agents.
- Re-evaluate the active pane as users switch panes or as the inner agent exits back to a shell.
- Apply the same resolution in local/daemon-backed terminals and SSH relay terminals.

## Problem

Orca's foreground-agent detection normally walks descendants of the shell process that owns the Orca PTY. That works for agents launched directly from the shell, but not for tmux.

The tmux process attached to the Orca PTY is only a client. Pane shells and their child processes are owned by the separate tmux server, so they are not descendants of the Orca shell or the attached tmux client. As a result, the existing process-tree scan could only see `tmux`, not the Claude or Codex process running in the active pane. This prevented the normal agent identity, interaction, completion, and summary behavior from activating.

## Implementation

### Active pane resolution

A new shared tmux process resolver:

1. Parses the observed tmux client command line.
2. Preserves custom tmux server selectors supplied through `-L` or `-S`.
3. Runs a bounded `tmux list-clients` query using:
   - `#{client_pid}`
   - `#{pane_pid}`
   - `#{pane_current_command}`
4. Selects the row whose client PID matches the tmux process attached to the Orca PTY.
5. Walks the process tree rooted at the active pane PID.
6. Uses the existing foreground marker and agent command-line recognition logic to return the real inner agent.
7. Falls back to the pane's current command when no supported agent is active, allowing Orca to observe the transition back to `bash`, `zsh`, or another foreground program.

The query is best-effort and has a two-second timeout. Failure to query tmux falls back to the existing foreground behavior rather than affecting PTY health.

### Command lifecycle

The renderer now recognizes `tmux`, `tmux new-session`, `tmux new`, `tmux attach-session`, `tmux attach`, and `tmux a` as session commands.

The exact accepted command is retained while the command owns the shell. This seeds the same bounded process-confirmation ladder used for direct agent launches. It is especially important for shells without OSC 133 support, where there would otherwise be no later command-start event to trigger agent discovery.

Restored visible terminals also retry while the foreground still reports `tmux`, covering sessions that were already attached before the renderer mounted.

### Local and remote execution

The resolver is integrated into:

- the main-process POSIX foreground resolver used by local and daemon-backed PTYs;
- the relay foreground resolver used on SSH hosts.

This keeps the tmux query on the host where tmux and its socket actually exist. Custom socket names and paths therefore work on both local and remote hosts without assuming that the workspace is a Git worktree.

## User impact

When a user starts or attaches to tmux and runs a supported agent in the active pane, Orca can now:

- identify the inner agent;
- activate the same pane interaction and routing behavior used for directly launched agents;
- keep tracking through delayed tmux startup and restored sessions;
- detect when the agent exits back to the pane shell;
- feed the existing completion and summary pipeline with the correct agent identity.

## Validation

- `pnpm run typecheck`
- Focused Vitest suite covering tmux parsing, local foreground resolution, SSH relay resolution, renderer retry behavior, command memory without OSC 133, and the full PTY connection suite: **588 tests passed**
- `pnpm run build:relay`
  - Linux x64 and arm64
  - macOS x64 and arm64
  - Windows x64 and arm64
  - WSL hook relay
- `pnpm run check:max-lines-ratchet`
- `git diff --check`
- Commit-time `oxlint`, React Doctor lint, and formatting hooks

The repository-wide `pnpm run lint` proceeds through lint, switch exhaustiveness, reliability gates, max-lines, skill verification, and localization catalog verification, then currently fails the localization coverage audit on pre-existing `Ghostty` search keywords in unrelated settings files. This PR does not modify those files or add localization strings.
