### PR TITLE
feat(editor): support syntax highlighting for JSP (.jsp) files (#9795)

### DIFF
--- a/config/localization-coverage-allowlist.json
+++ b/config/localization-coverage-allowlist.json
@@ -40,33 +40,5 @@
     "text": "Idioma",
     "dynamic": false,
     "count": 1
-  },
-  {
-    "filePath": "src/renderer/src/components/settings/terminal-advanced-platform-search.ts",
-    "kind": "object-property:keywords",
-    "text": "Ghostty",
-    "dynamic": false,
-    "count": 2
-  },
-  {
-    "filePath": "src/renderer/src/components/settings/terminal-advanced-platform-search.ts",
-    "kind": "object-property:keywords",
-    "text": "ghostty",
-    "dynamic": false,
-    "count": 2
-  },
-  {
-    "filePath": "src/renderer/src/components/settings/terminal-pane-appearance-search.ts",
-    "kind": "object-property:keywords",
-    "text": "Ghostty",
-    "dynamic": false,
-    "count": 1
-  },
-  {
-    "filePath": "src/renderer/src/components/settings/terminal-pane-appearance-search.ts",
-    "kind": "object-property:keywords",
-    "text": "ghostty",
-    "dynamic": false,
-    "count": 1
   }
 ]

--- a/config/localization-coverage-allowlist.json
+++ b/config/localization-coverage-allowlist.json
@@ -40,5 +40,33 @@
     "text": "Idioma",
     "dynamic": false,
     "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/terminal-advanced-platform-search.ts",
+    "kind": "object-property:keywords",
+    "text": "Ghostty",
+    "dynamic": false,
+    "count": 2
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/terminal-advanced-platform-search.ts",
+    "kind": "object-property:keywords",
+    "text": "ghostty",
+    "dynamic": false,
+    "count": 2
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/terminal-pane-appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "Ghostty",
+    "dynamic": false,
+    "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/terminal-pane-appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "ghostty",
+    "dynamic": false,
+    "count": 1
   }
 ]

--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -20,6 +20,11 @@ describe('detectLanguage', () => {
     expect(detectLanguage('packages/app.nimble')).toBe('nim')
   })
 
+  it('maps JSP files to the jsp language id', () => {
+    expect(detectLanguage('src/main/webapp/index.jsp')).toBe('jsp')
+    expect(detectLanguage('src/main/webapp/header.jspf')).toBe('jsp')
+  })
+
   it('maps exact filenames from Windows paths', () => {
     expect(detectLanguage('C:\\Users\\alice\\repo\\Dockerfile')).toBe('dockerfile')
     expect(detectLanguage('C:\\Users\\alice\\repo\\CMakeLists.txt')).toBe('cmake')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -91,6 +91,8 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.nim': 'nim',
   '.nims': 'nim',
   '.nimble': 'nim',
+  '.jsp': 'jsp',
+  '.jspf': 'jsp',
   '.tf': 'hcl',
   '.hcl': 'hcl',
   '.prisma': 'graphql',

--- a/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
@@ -65,6 +65,43 @@ function matchLengthFor(state: string, source: string): number | undefined {
   return regexp.exec(source)?.[0].length
 }
 
+function endingStateFor(source: string): string {
+  const states = ['root']
+  let remaining = source
+
+  while (remaining) {
+    const state = states.at(-1)
+    if (!state) {
+      throw new Error('Tokenizer state stack is empty')
+    }
+    const rule = findRule(state, remaining)
+    if (!rule) {
+      remaining = remaining.slice(1)
+      continue
+    }
+
+    const [, action, shortcut] = rule
+    const next = (
+      typeof action === 'object' ? (action.next ?? action.switchTo) : shortcut
+    )?.replace(/^@/, '')
+    const matchLength = matchLengthFor(state, remaining)
+    if (!matchLength) {
+      throw new Error(`Tokenizer rule made no progress in ${state}`)
+    }
+    remaining = remaining.slice(matchLength)
+
+    if (next === 'popall') {
+      states.splice(1)
+    } else if (next === 'pop') {
+      states.pop()
+    } else if (next) {
+      states.push(next)
+    }
+  }
+
+  return states.at(-1) ?? 'root'
+}
+
 describe('registerJspLanguage', () => {
   it('registers the jsp language and attaches the HTML language service once', () => {
     const languages: { id: string }[] = [{ id: 'html' }]
@@ -171,6 +208,15 @@ describe('registerJspLanguage', () => {
     // finds the closing delimiter first, so the comment must stop there.
     expect(matchLengthFor('jspScriptlet', '// done %>')).toBe(8)
     expect(matchLengthFor('javaBlockComment', ' note %> */')).toBe(6)
+    expect(nextStateFor('javaBlockComment', '%> */')).toBe('popall')
+    expect(endingStateFor('<% /* comment %> */')).toBe('root')
+  })
+
+  it('does not let Java literals swallow the scriptlet terminator', () => {
+    // JSP closes before Java can parse a literal.
+    expect(matchLengthFor('jspScriptlet', '"%>"; %>')).toBe(1)
+    expect(matchLengthFor('jspScriptlet', "'%>'; %>")).toBe(1)
+    expect(matchLengthFor('jspScriptlet', '"%\\>"')).toBe(5)
   })
 
   it('keeps scriptlet-looking text inert inside a JSP comment', () => {
@@ -192,6 +238,39 @@ describe('registerJspLanguage', () => {
     expect(tokenFor('jspScriptlet', 'IF (x)')).toBe('identifier')
     expect(nextStateFor('root', '<SCRIPT type="text/javascript">')).toBe('scriptOpen')
     expect(nextStateFor('root', '<STYLE>')).toBe('styleOpen')
+  })
+
+  it('recognizes common Java collection, utility and boxed types', () => {
+    const commonTypes = [
+      'ArrayList',
+      'LinkedList',
+      'HashMap',
+      'LinkedHashMap',
+      'HashSet',
+      'LinkedHashSet',
+      'TreeMap',
+      'TreeSet',
+      'Set',
+      'Iterator',
+      'Optional',
+      'StringBuilder',
+      'BigDecimal',
+      'BigInteger',
+      'Integer',
+      'Long',
+      'Double',
+      'Boolean',
+      'Short',
+      'Byte',
+      'Float',
+      'Character',
+      'Void'
+    ]
+
+    commonTypes.forEach((type) => {
+      expect(tokenFor('jspScriptlet', `${type} value`)).toBe('type')
+    })
+    expect(tokenFor('jspScriptlet', 'arrayList = null')).toBe('identifier')
   })
 
   it('pops the embedded language when the script or style block closes', () => {

--- a/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest'
+import { jspLanguageConfiguration, jspMonarchLanguage, registerJspLanguage } from './register-jsp'
+
+type RuleEntry = [RegExp, string | object, string?] | { include: string }
+
+function findMatchingRule(
+  stateName: string,
+  text: string
+): { rule: RuleEntry; match: RegExpExecArray } | null {
+  const rules = jspMonarchLanguage.tokenizer[stateName] as RuleEntry[]
+  if (!rules) {
+    return null
+  }
+
+  for (const rule of rules) {
+    if ('include' in rule) {
+      continue
+    }
+    const [regex] = rule
+    const match = regex.exec(text)
+    if (match && match.index === 0) {
+      return { rule, match }
+    }
+  }
+  return null
+}
+
+describe('registerJspLanguage', () => {
+  describe('registration', () => {
+    it('registers the jsp language, Monarch tokenizer, and configuration once', () => {
+      const languages: { id: string }[] = [{ id: 'html' }]
+      const register = vi.fn((entry: { id: string }) => {
+        languages.push({ id: entry.id })
+      })
+      const setMonarchTokensProvider = vi.fn()
+      const setLanguageConfiguration = vi.fn()
+      const getLanguages = vi.fn(() => languages)
+      const monacoMock = {
+        languages: {
+          register,
+          setMonarchTokensProvider,
+          setLanguageConfiguration,
+          getLanguages
+        }
+      }
+
+      registerJspLanguage(monacoMock as never)
+      registerJspLanguage(monacoMock as never)
+
+      expect(register).toHaveBeenCalledTimes(1)
+      expect(register).toHaveBeenCalledWith({
+        id: 'jsp',
+        extensions: ['.jsp', '.jspf'],
+        aliases: ['JSP', 'jsp', 'JavaServer Pages']
+      })
+      expect(setMonarchTokensProvider).toHaveBeenCalledTimes(1)
+      expect(setMonarchTokensProvider).toHaveBeenCalledWith('jsp', jspMonarchLanguage)
+      expect(setLanguageConfiguration).toHaveBeenCalledTimes(1)
+      expect(setLanguageConfiguration).toHaveBeenCalledWith('jsp', jspLanguageConfiguration)
+    })
+  })
+
+  describe('bracket and auto-closing configuration', () => {
+    it('excludes angle brackets (<, >) from brackets, autoClosingPairs, and surroundingPairs', () => {
+      expect(jspLanguageConfiguration.brackets).toEqual([
+        ['{', '}'],
+        ['[', ']'],
+        ['(', ')']
+      ])
+      expect(jspMonarchLanguage.brackets).toEqual([
+        { open: '{', close: '}', token: 'delimiter.curly' },
+        { open: '[', close: ']', token: 'delimiter.square' },
+        { open: '(', close: ')', token: 'delimiter.parenthesis' }
+      ])
+
+      const autoClosingOpenChars = jspLanguageConfiguration.autoClosingPairs?.map(
+        (pair) => pair.open
+      )
+      expect(autoClosingOpenChars).not.toContain('<')
+
+      const surroundingOpenChars = jspLanguageConfiguration.surroundingPairs?.map(
+        (pair) => pair.open
+      )
+      expect(surroundingOpenChars).not.toContain('<')
+    })
+  })
+
+  describe('tokenizer rules and token actions', () => {
+    it('matches JSTL / Custom tags like <c:if> and </c:if> with tag.custom token', () => {
+      const openResult = findMatchingRule('root', '<c:if')
+      expect(openResult).not.toBeNull()
+      expect(openResult?.rule[1]).toBe('tag.custom')
+      expect(openResult?.rule[2]).toBe('@tagCustom')
+
+      const closeResult = findMatchingRule('root', '</c:if>')
+      expect(closeResult).not.toBeNull()
+      expect(closeResult?.rule[1]).toBe('tag.custom')
+      expect(closeResult?.rule[2]).toBe('@tagCustomClose')
+    })
+
+    it('tokenizes comparison operators (<, >, <=, >=, ==, !=) in jspScriptletOpen as operator', () => {
+      const scriptletRules = ['<', '>', '<=', '>=', '==', '!=', '&&', '||']
+      for (const op of scriptletRules) {
+        const result = findMatchingRule('jspScriptletOpen', op)
+        expect(result).not.toBeNull()
+        expect(result?.rule[1]).toBe('operator')
+      }
+    })
+
+    it('tokenizes comparison and logical operators in elExpression as keyword.operator', () => {
+      const elOps = ['<=', '>=', '==', '!=', '&&', '||', '<', '>']
+      for (const op of elOps) {
+        const result = findMatchingRule('elExpression', op)
+        expect(result).not.toBeNull()
+        expect(result?.rule[1]).toBe('keyword.operator')
+      }
+
+      const elKeywords = [
+        'and',
+        'or',
+        'not',
+        'eq',
+        'ne',
+        'gt',
+        'lt',
+        'ge',
+        'le',
+        'empty',
+        'instanceof'
+      ]
+      for (const kw of elKeywords) {
+        const result = findMatchingRule('elExpression', kw)
+        expect(result).not.toBeNull()
+        expect(result?.rule[1]).toBe('keyword.operator')
+      }
+    })
+
+    it('configures embedded javascript for <script> and css for <style> tags', () => {
+      const scriptOpenResult = findMatchingRule('root', '<script>')
+      expect(scriptOpenResult).not.toBeNull()
+      expect(scriptOpenResult?.rule[1]).toBe('tag')
+      expect(scriptOpenResult?.rule[2]).toBe('@scriptOpen')
+
+      const scriptBodyResult = findMatchingRule('scriptBody', '</script>')
+      expect(scriptBodyResult).not.toBeNull()
+      expect(scriptBodyResult?.rule[1]).toEqual({
+        token: 'tag',
+        next: '@pop',
+        nextEmbedded: '@pop'
+      })
+
+      const styleOpenResult = findMatchingRule('root', '<style>')
+      expect(styleOpenResult).not.toBeNull()
+      expect(styleOpenResult?.rule[1]).toBe('tag')
+      expect(styleOpenResult?.rule[2]).toBe('@styleOpen')
+
+      const styleBodyResult = findMatchingRule('styleBody', '</style>')
+      expect(styleBodyResult).not.toBeNull()
+      expect(styleBodyResult?.rule[1]).toEqual({
+        token: 'tag',
+        next: '@pop',
+        nextEmbedded: '@pop'
+      })
+    })
+
+    it('matches JSP comments <%-- --%> and HTML comments <!-- -->', () => {
+      const jspCommentOpen = findMatchingRule('root', '<%--')
+      expect(jspCommentOpen).not.toBeNull()
+      expect(jspCommentOpen?.rule[1]).toBe('comment')
+      expect(jspCommentOpen?.rule[2]).toBe('@jspComment')
+
+      const htmlCommentOpen = findMatchingRule('root', '<!--')
+      expect(htmlCommentOpen).not.toBeNull()
+      expect(htmlCommentOpen?.rule[1]).toBe('comment')
+      expect(htmlCommentOpen?.rule[2]).toBe('@htmlComment')
+    })
+
+    it('tokenizes tag attributes, string values, and embedded EL in double/single quotes', () => {
+      const attrName = findMatchingRule('tagAttributes', 'test')
+      expect(attrName?.rule[1]).toBe('attribute.name')
+
+      const doubleQuoteOpen = findMatchingRule('tagAttributes', '"')
+      expect(doubleQuoteOpen?.rule[1]).toBe('attribute.value')
+      expect(doubleQuoteOpen?.rule[2]).toBe('@stringDouble')
+
+      const elInString = findMatchingRule('stringDouble', '${')
+      expect(elInString?.rule[1]).toBe('delimiter.curly')
+      expect(elInString?.rule[2]).toBe('@elExpression')
+    })
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
@@ -1,191 +1,271 @@
 import { describe, expect, it, vi } from 'vitest'
-import { jspLanguageConfiguration, jspMonarchLanguage, registerJspLanguage } from './register-jsp'
+import {
+  jspHtmlModeConfiguration,
+  jspLanguageConfiguration,
+  jspMonarchLanguage,
+  registerJspLanguage
+} from './register-jsp'
 
-type RuleEntry = [RegExp, string | object, string?] | { include: string }
+type MonarchAction = {
+  token?: string
+  next?: string
+  nextEmbedded?: string
+  switchTo?: string
+}
+type MonarchRule = [RegExp, string | MonarchAction, string?] | { include: string }
 
-function findMatchingRule(
-  stateName: string,
-  text: string
-): { rule: RuleEntry; match: RegExpExecArray } | null {
-  const rules = jspMonarchLanguage.tokenizer[stateName] as RuleEntry[]
-  if (!rules) {
-    return null
+function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction, string?] {
+  return Array.isArray(rule)
+}
+
+function rulesFor(state: string): [RegExp, string | MonarchAction, string?][] {
+  const tokenizer = jspMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  return tokenizer[state].flatMap((rule) =>
+    isRuleEntry(rule) ? [rule] : rulesFor(rule.include.replace(/^@/, ''))
+  )
+}
+
+function findRule(
+  state: string,
+  source: string
+): [RegExp, string | MonarchAction, string?] | undefined {
+  return rulesFor(state).find(([regexp]) => {
+    regexp.lastIndex = 0
+    const match = regexp.exec(source)
+    return match !== null && match.index === 0
+  })
+}
+
+function tokenFor(state: string, source: string): string | undefined {
+  const rule = findRule(state, source)
+  if (!rule) {
+    return undefined
   }
+  const [, action] = rule
+  return typeof action === 'string' ? action : action.token
+}
 
-  for (const rule of rules) {
-    if ('include' in rule) {
-      continue
-    }
-    const [regex] = rule
-    const match = regex.exec(text)
-    if (match && match.index === 0) {
-      return { rule, match }
-    }
+function nextStateFor(state: string, source: string): string | undefined {
+  const rule = findRule(state, source)
+  if (!rule) {
+    return undefined
   }
-  return null
+  const [, action, shortcut] = rule
+  const next = typeof action === 'object' ? (action.next ?? action.switchTo) : shortcut
+  return next?.replace(/^@/, '')
+}
+
+function matchLengthFor(state: string, source: string): number | undefined {
+  const rule = findRule(state, source)
+  if (!rule) {
+    return undefined
+  }
+  const [regexp] = rule
+  regexp.lastIndex = 0
+  return regexp.exec(source)?.[0].length
 }
 
 describe('registerJspLanguage', () => {
-  describe('registration', () => {
-    it('registers the jsp language, Monarch tokenizer, and configuration once', () => {
-      const languages: { id: string }[] = [{ id: 'html' }]
-      const register = vi.fn((entry: { id: string }) => {
-        languages.push({ id: entry.id })
-      })
-      const setMonarchTokensProvider = vi.fn()
-      const setLanguageConfiguration = vi.fn()
-      const getLanguages = vi.fn(() => languages)
-      const monacoMock = {
-        languages: {
-          register,
-          setMonarchTokensProvider,
-          setLanguageConfiguration,
-          getLanguages
+  it('registers the jsp language and attaches the HTML language service once', () => {
+    const languages: { id: string }[] = [{ id: 'html' }]
+    const register = vi.fn((entry: { id: string }) => {
+      languages.push({ id: entry.id })
+    })
+    const setMonarchTokensProvider = vi.fn()
+    const setLanguageConfiguration = vi.fn()
+    const getLanguages = vi.fn(() => languages)
+    const registerHTMLLanguageService = vi.fn()
+    const monacoMock = {
+      languages: {
+        register,
+        setMonarchTokensProvider,
+        setLanguageConfiguration,
+        getLanguages
+      },
+      html: { registerHTMLLanguageService }
+    }
+
+    registerJspLanguage(monacoMock as never)
+    registerJspLanguage(monacoMock as never)
+
+    expect(register).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalledWith({
+      id: 'jsp',
+      extensions: ['.jsp', '.jspf'],
+      aliases: ['JSP', 'JavaServer Pages']
+    })
+    expect(setMonarchTokensProvider).toHaveBeenCalledWith('jsp', jspMonarchLanguage)
+    expect(setLanguageConfiguration).toHaveBeenCalledWith('jsp', jspLanguageConfiguration)
+    // A second registration would create another worker and provider set.
+    expect(registerHTMLLanguageService).toHaveBeenCalledTimes(1)
+    expect(registerHTMLLanguageService).toHaveBeenCalledWith(
+      'jsp',
+      undefined,
+      jspHtmlModeConfiguration
+    )
+  })
+
+  it('keeps buffer-editing HTML features off and read-only ones on', () => {
+    expect(jspHtmlModeConfiguration.rename).toBe(false)
+    expect(jspHtmlModeConfiguration.documentFormattingEdits).toBe(false)
+    expect(jspHtmlModeConfiguration.documentRangeFormattingEdits).toBe(false)
+    expect(jspHtmlModeConfiguration.completionItems).toBe(true)
+    expect(jspHtmlModeConfiguration.hovers).toBe(true)
+    expect(jspHtmlModeConfiguration.foldingRanges).toBe(true)
+  })
+
+  it('enters dedicated states for directives, scriptlets, comments and EL', () => {
+    expect(nextStateFor('root', '<%@ page contentType="text/html" %>')).toBe('jspDirective')
+    expect(nextStateFor('root', '<% int total = 0; %>')).toBe('jspScriptlet')
+    expect(nextStateFor('root', '<%= user.getName() %>')).toBe('jspScriptlet')
+    expect(nextStateFor('root', '<%-- hidden from output --%>')).toBe('jspComment')
+    expect(nextStateFor('root', '${user.name}')).toBe('elExpression')
+    expect(nextStateFor('root', '#{bean.value}')).toBe('elExpression')
+    expect(nextStateFor('root', '<!-- sent to the browser -->')).toBe('htmlComment')
+  })
+
+  it('consumes the whole opening delimiter for each JSP construct', () => {
+    expect(matchLengthFor('root', '<%-- hidden --%>')).toBe(4)
+    expect(matchLengthFor('root', '<%@ page %>')).toBe(3)
+    expect(matchLengthFor('root', '<%= user.getName() %>')).toBe(3)
+    expect(matchLengthFor('root', '<%! int counter = 0; %>')).toBe(3)
+    expect(matchLengthFor('root', '<% int total = 0; %>')).toBe(2)
+  })
+
+  it('matches namespaced tag names in full, not just the prefix', () => {
+    // The generic tag rule would stop at `<c`, so match length is what
+    // distinguishes the JSTL rule from it.
+    expect(matchLengthFor('root', '<c:if test="${ok}">')).toBe(5)
+    expect(matchLengthFor('root', '</c:forEach>')).toBe(11)
+    expect(matchLengthFor('root', '<div class="row">')).toBe(4)
+  })
+
+  it('leaves every nested state through its closing delimiter', () => {
+    expect(nextStateFor('jspDirective', '%>')).toBe('pop')
+    expect(nextStateFor('jspScriptlet', '%>')).toBe('pop')
+    expect(nextStateFor('jspComment', '--%>')).toBe('pop')
+    expect(nextStateFor('htmlComment', '-->')).toBe('pop')
+    expect(nextStateFor('javaBlockComment', '*/')).toBe('pop')
+    expect(nextStateFor('elExpression', '}')).toBe('pop')
+    expect(nextStateFor('attributeValueDouble', '" />')).toBe('pop')
+    expect(nextStateFor('attributeValueSingle', "' />")).toBe('pop')
+    expect(nextStateFor('tagRest', '>')).toBe('pop')
+    expect(nextStateFor('tagRest', '/>')).toBe('pop')
+  })
+
+  it('treats a JSP comment inside a tag as a comment, not a scriptlet', () => {
+    // Without this rule the `--%>` terminator is swallowed by the operator run
+    // and Java tokenization leaks to end of file.
+    expect(nextStateFor('tagRest', '<%-- escapeXml="false" --%> />')).toBe('jspComment')
+    expect(nextStateFor('attributeValueDouble', '<%-- x --%>"')).toBe('jspComment')
+    expect(nextStateFor('attributeValueSingle', "<%-- x --%>'")).toBe('jspComment')
+  })
+
+  it('does not let an operator run swallow the scriptlet terminator', () => {
+    expect(matchLengthFor('jspScriptlet', '++%>')).toBe(2)
+    expect(tokenFor('jspScriptlet', '% 2')).toBe('keyword.operator')
+  })
+
+  it('does not let a comment swallow the scriptlet terminator', () => {
+    // A line comment before the terminator is valid JSP: the container
+    // finds the closing delimiter first, so the comment must stop there.
+    expect(matchLengthFor('jspScriptlet', '// done %>')).toBe(8)
+    expect(matchLengthFor('javaBlockComment', ' note %> */')).toBe(6)
+  })
+
+  it('keeps scriptlet-looking text inert inside a JSP comment', () => {
+    expect(tokenFor('jspComment', '<% still a comment --%>')).toBe('comment')
+    expect(nextStateFor('jspComment', '<% still a comment --%>')).toBeUndefined()
+  })
+
+  it('does not close a tag on a `>` inside an attribute value', () => {
+    expect(tokenFor('attributeValueDouble', '> b">')).toBe('attribute.value')
+    expect(nextStateFor('attributeValueDouble', '> b">')).toBeUndefined()
+    expect(tokenFor('elExpression', "> b ? 'x' : 'y'}")).toBe('keyword.operator')
+  })
+
+  it('is case-sensitive for Java tokens but not for script and style tags', () => {
+    expect(jspMonarchLanguage.ignoreCase).toBeUndefined()
+    // `List list` must not colour the variable as a type.
+    expect(tokenFor('jspScriptlet', 'List list')).toBe('type')
+    expect(tokenFor('jspScriptlet', 'list = null')).toBe('identifier')
+    expect(tokenFor('jspScriptlet', 'IF (x)')).toBe('identifier')
+    expect(nextStateFor('root', '<SCRIPT type="text/javascript">')).toBe('scriptOpen')
+    expect(nextStateFor('root', '<STYLE>')).toBe('styleOpen')
+  })
+
+  it('pops the embedded language when the script or style block closes', () => {
+    const scriptRule = rulesFor('scriptBody')[0]
+    const styleRule = rulesFor('styleBody')[0]
+    const scriptAction = scriptRule[1] as MonarchAction
+    const styleAction = styleRule[1] as MonarchAction
+
+    // Monarch throws 'no rule containing nextEmbedded: "@pop"' without these.
+    expect(scriptAction.nextEmbedded).toBe('@pop')
+    expect(scriptAction.next).toBe('@pop')
+    expect(styleAction.nextEmbedded).toBe('@pop')
+    expect(styleAction.next).toBe('@pop')
+
+    expect(scriptRule[0].test('</SCRIPT >')).toBe(true)
+    expect(styleRule[0].test('</STYLE>')).toBe(true)
+  })
+
+  it('embeds javascript and css when the opening tag closes', () => {
+    const scriptOpen = rulesFor('scriptOpen').find(
+      (rule) => typeof rule[1] === 'object' && rule[1].nextEmbedded === 'javascript'
+    )
+    const styleOpen = rulesFor('styleOpen').find(
+      (rule) => typeof rule[1] === 'object' && rule[1].nextEmbedded === 'css'
+    )
+
+    expect(scriptOpen).toBeDefined()
+    expect(styleOpen).toBeDefined()
+    expect((scriptOpen?.[1] as MonarchAction | undefined)?.switchTo).toBe('@scriptBody')
+    expect((styleOpen?.[1] as MonarchAction | undefined)?.switchTo).toBe('@styleBody')
+  })
+
+  it('uses theme-backed token names for operators', () => {
+    // vs-dark defines operator.scss/sql/swift but no plain `operator`, so a
+    // bare 'operator' token would render unstyled.
+    expect(tokenFor('jspScriptlet', '>= 10')).toBe('keyword.operator')
+    expect(tokenFor('elExpression', 'ne 0')).toBe('keyword.operator')
+    expect(JSON.stringify(jspMonarchLanguage.tokenizer)).not.toContain('"operator"')
+  })
+
+  it('only references tokenizer states that exist', () => {
+    const tokenizer = jspMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+    const declared = new Set(Object.keys(tokenizer))
+
+    Object.values(tokenizer).forEach((rules) => {
+      rules.forEach((rule) => {
+        if (!isRuleEntry(rule)) {
+          expect(declared).toContain(rule.include.replace(/^@/, ''))
+          return
         }
-      }
-
-      registerJspLanguage(monacoMock as never)
-      registerJspLanguage(monacoMock as never)
-
-      expect(register).toHaveBeenCalledTimes(1)
-      expect(register).toHaveBeenCalledWith({
-        id: 'jsp',
-        extensions: ['.jsp', '.jspf'],
-        aliases: ['JSP', 'jsp', 'JavaServer Pages']
+        const [, action, shortcut] = rule
+        const targets = [
+          shortcut,
+          typeof action === 'object' ? action.next : undefined,
+          typeof action === 'object' ? action.switchTo : undefined
+        ]
+        targets.forEach((target) => {
+          if (target && target !== '@pop' && target !== '@popall') {
+            expect(declared).toContain(target.replace(/^@/, ''))
+          }
+        })
       })
-      expect(setMonarchTokensProvider).toHaveBeenCalledTimes(1)
-      expect(setMonarchTokensProvider).toHaveBeenCalledWith('jsp', jspMonarchLanguage)
-      expect(setLanguageConfiguration).toHaveBeenCalledTimes(1)
-      expect(setLanguageConfiguration).toHaveBeenCalledWith('jsp', jspLanguageConfiguration)
     })
   })
 
-  describe('bracket and auto-closing configuration', () => {
-    it('excludes angle brackets (<, >) from brackets, autoClosingPairs, and surroundingPairs', () => {
-      expect(jspLanguageConfiguration.brackets).toEqual([
-        ['{', '}'],
-        ['[', ']'],
-        ['(', ')']
-      ])
-      expect(jspMonarchLanguage.brackets).toEqual([
-        { open: '{', close: '}', token: 'delimiter.curly' },
-        { open: '[', close: ']', token: 'delimiter.square' },
-        { open: '(', close: ')', token: 'delimiter.parenthesis' }
-      ])
-
-      const autoClosingOpenChars = jspLanguageConfiguration.autoClosingPairs?.map(
-        (pair) => pair.open
+  it('excludes angle brackets from bracket pairs so comparisons do not mismatch', () => {
+    const bracketChars = [
+      ...(jspLanguageConfiguration.brackets ?? []).flat(),
+      ...(jspLanguageConfiguration.autoClosingPairs ?? []).flatMap((pair) =>
+        'open' in pair ? [pair.open, pair.close] : []
       )
-      expect(autoClosingOpenChars).not.toContain('<')
+    ]
 
-      const surroundingOpenChars = jspLanguageConfiguration.surroundingPairs?.map(
-        (pair) => pair.open
-      )
-      expect(surroundingOpenChars).not.toContain('<')
-    })
-  })
-
-  describe('tokenizer rules and token actions', () => {
-    it('matches JSTL / Custom tags like <c:if> and </c:if> with tag.custom token', () => {
-      const openResult = findMatchingRule('root', '<c:if')
-      expect(openResult).not.toBeNull()
-      expect(openResult?.rule[1]).toBe('tag.custom')
-      expect(openResult?.rule[2]).toBe('@tagCustom')
-
-      const closeResult = findMatchingRule('root', '</c:if>')
-      expect(closeResult).not.toBeNull()
-      expect(closeResult?.rule[1]).toBe('tag.custom')
-      expect(closeResult?.rule[2]).toBe('@tagCustomClose')
-    })
-
-    it('tokenizes comparison operators (<, >, <=, >=, ==, !=) in jspScriptletOpen as operator', () => {
-      const scriptletRules = ['<', '>', '<=', '>=', '==', '!=', '&&', '||']
-      for (const op of scriptletRules) {
-        const result = findMatchingRule('jspScriptletOpen', op)
-        expect(result).not.toBeNull()
-        expect(result?.rule[1]).toBe('operator')
-      }
-    })
-
-    it('tokenizes comparison and logical operators in elExpression as keyword.operator', () => {
-      const elOps = ['<=', '>=', '==', '!=', '&&', '||', '<', '>']
-      for (const op of elOps) {
-        const result = findMatchingRule('elExpression', op)
-        expect(result).not.toBeNull()
-        expect(result?.rule[1]).toBe('keyword.operator')
-      }
-
-      const elKeywords = [
-        'and',
-        'or',
-        'not',
-        'eq',
-        'ne',
-        'gt',
-        'lt',
-        'ge',
-        'le',
-        'empty',
-        'instanceof'
-      ]
-      for (const kw of elKeywords) {
-        const result = findMatchingRule('elExpression', kw)
-        expect(result).not.toBeNull()
-        expect(result?.rule[1]).toBe('keyword.operator')
-      }
-    })
-
-    it('configures embedded javascript for <script> and css for <style> tags', () => {
-      const scriptOpenResult = findMatchingRule('root', '<script>')
-      expect(scriptOpenResult).not.toBeNull()
-      expect(scriptOpenResult?.rule[1]).toBe('tag')
-      expect(scriptOpenResult?.rule[2]).toBe('@scriptOpen')
-
-      const scriptBodyResult = findMatchingRule('scriptBody', '</script>')
-      expect(scriptBodyResult).not.toBeNull()
-      expect(scriptBodyResult?.rule[1]).toEqual({
-        token: 'tag',
-        next: '@pop',
-        nextEmbedded: '@pop'
-      })
-
-      const styleOpenResult = findMatchingRule('root', '<style>')
-      expect(styleOpenResult).not.toBeNull()
-      expect(styleOpenResult?.rule[1]).toBe('tag')
-      expect(styleOpenResult?.rule[2]).toBe('@styleOpen')
-
-      const styleBodyResult = findMatchingRule('styleBody', '</style>')
-      expect(styleBodyResult).not.toBeNull()
-      expect(styleBodyResult?.rule[1]).toEqual({
-        token: 'tag',
-        next: '@pop',
-        nextEmbedded: '@pop'
-      })
-    })
-
-    it('matches JSP comments <%-- --%> and HTML comments <!-- -->', () => {
-      const jspCommentOpen = findMatchingRule('root', '<%--')
-      expect(jspCommentOpen).not.toBeNull()
-      expect(jspCommentOpen?.rule[1]).toBe('comment')
-      expect(jspCommentOpen?.rule[2]).toBe('@jspComment')
-
-      const htmlCommentOpen = findMatchingRule('root', '<!--')
-      expect(htmlCommentOpen).not.toBeNull()
-      expect(htmlCommentOpen?.rule[1]).toBe('comment')
-      expect(htmlCommentOpen?.rule[2]).toBe('@htmlComment')
-    })
-
-    it('tokenizes tag attributes, string values, and embedded EL in double/single quotes', () => {
-      const attrName = findMatchingRule('tagAttributes', 'test')
-      expect(attrName?.rule[1]).toBe('attribute.name')
-
-      const doubleQuoteOpen = findMatchingRule('tagAttributes', '"')
-      expect(doubleQuoteOpen?.rule[1]).toBe('attribute.value')
-      expect(doubleQuoteOpen?.rule[2]).toBe('@stringDouble')
-
-      const elInString = findMatchingRule('stringDouble', '${')
-      expect(elInString?.rule[1]).toBe('delimiter.curly')
-      expect(elInString?.rule[2]).toBe('@elExpression')
-    })
+    expect(bracketChars).not.toContain('<')
+    expect(bracketChars).not.toContain('>')
   })
 })

--- a/src/renderer/src/lib/monaco-languages/register-jsp.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.ts
@@ -2,10 +2,16 @@ import type * as Monaco from 'monaco-editor'
 
 type MonacoModule = typeof Monaco
 
+// Why: `ignoreCase` is off because scriptlets are Java, which is case-sensitive
+// — with it on, `List list` colours the variable as a type. Monarch has no
+// per-rule casing, so the four HTML tags that genuinely need it spell it out.
+//
+// Token names must exist in the built-in themes: vs-dark defines
+// operator.scss/sql/swift but no plain `operator`, so operators use
+// `keyword.operator`, which falls back to `keyword`.
 export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
   defaultToken: '',
   tokenPostfix: '.jsp',
-  ignoreCase: true,
   brackets: [
     { open: '{', close: '}', token: 'delimiter.curly' },
     { open: '[', close: ']', token: 'delimiter.square' },
@@ -14,150 +20,178 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
   tokenizer: {
     root: [
       [/<%--/, 'comment', '@jspComment'],
-      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
-      [/<script(?=\s|>)/, 'tag', '@scriptOpen'],
-      [/<style(?=\s|>)/, 'tag', '@styleOpen'],
-      [/<\/([a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+)/, 'tag.custom', '@tagCustomClose'],
-      [/<([a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+)/, 'tag.custom', '@tagCustom'],
-      [/<\/([a-zA-Z][a-zA-Z0-9_-]*)/, 'tag', '@tagClose'],
-      [/<([a-zA-Z][a-zA-Z0-9_-]*)/, 'tag', '@tagOpen'],
+      [/<%@/, 'metatag', '@jspDirective'],
+      [/<%[=!]?/, 'metatag', '@jspScriptlet'],
+      [/[$#]\{/, 'delimiter.curly', '@elExpression'],
+      [/<[sS][cC][rR][iI][pP][tT](?=[\s>])/, 'tag', '@scriptOpen'],
+      [/<[sS][tT][yY][lL][eE](?=[\s>])/, 'tag', '@styleOpen'],
       [/<!--/, 'comment', '@htmlComment'],
-      [/[^<%$]+/, '']
+      [/<\/?[a-zA-Z][\w.-]*:[\w.-]+/, 'tag', '@tagRest'],
+      [/<\/?[a-zA-Z][\w-]*/, 'tag', '@tagRest'],
+      [/[^<$#]+/, '']
     ],
+
     htmlComment: [
       [/-->/, 'comment', '@pop'],
       [/[^-]+/, 'comment'],
       [/./, 'comment']
     ],
+
     jspComment: [
       [/--%>/, 'comment', '@pop'],
       [/[^-]+/, 'comment'],
       [/./, 'comment']
     ],
-    tagCustom: [
-      [/\/>/, 'tag.custom', '@pop'],
-      [/>/, 'tag.custom', '@pop'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
-      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
-      { include: '@tagAttributes' }
-    ],
-    tagCustomClose: [
-      [/>/, 'tag.custom', '@pop'],
-      [/\s+/, 'white']
-    ],
-    tagOpen: [
-      [/\/>/, 'tag', '@pop'],
-      [/>/, 'tag', '@pop'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
-      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
-      { include: '@tagAttributes' }
-    ],
-    tagClose: [
-      [/>/, 'tag', '@pop'],
-      [/\s+/, 'white']
-    ],
-    tagAttributes: [
-      [/[a-zA-Z0-9_-]+/, 'attribute.name'],
+
+    // `<%@ page contentType="..." %>` reads as markup, not as Java.
+    jspDirective: [
+      [/%>/, 'metatag', '@pop'],
+      [/[a-zA-Z_][\w.-]*(?=\s*=)/, 'attribute.name'],
+      [/[a-zA-Z_][\w.-]*/, 'keyword'],
       [/=/, 'delimiter'],
-      [/"/, 'attribute.value', '@stringDouble'],
-      [/'/, 'attribute.value', '@stringSingle'],
+      [/"[^"]*"/, 'attribute.value'],
+      [/'[^']*'/, 'attribute.value'],
       [/\s+/, 'white']
     ],
-    stringDouble: [
-      [/"/, 'attribute.value', '@pop'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
-      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
-      [/[^"\\$%]+/, 'attribute.value'],
-      [/[$%]/, 'attribute.value']
-    ],
-    stringSingle: [
-      [/'/, 'attribute.value', '@pop'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
-      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
-      [/[^'\\$%]+/, 'attribute.value'],
-      [/[$%]/, 'attribute.value']
-    ],
-    jspScriptletOpen: [
-      [/%>/, 'keyword', '@pop'],
-      [/\/\/.*/, 'comment'],
-      [/\/\*/, 'comment', '@javaComment'],
+
+    // Covers `<% %>`, `<%= %>` and `<%! %>`; all three need the same Java tokens.
+    jspScriptlet: [
+      [/%>/, 'metatag', '@pop'],
+      [/\/\/(?:(?!%>)[^\n])*/, 'comment'],
+      [/\/\*/, 'comment', '@javaBlockComment'],
       [/"([^"\\]|\\.)*"/, 'string'],
       [/'([^'\\]|\\.)*'/, 'string'],
-      [/\b(true|false|null)\b/, 'constant.language'],
+      [/\b(?:true|false|null)\b/, 'constant'],
       [
-        /\b(if|else|for|while|do|switch|case|default|break|continue|return|try|catch|finally|throw|new|import|package)\b/,
+        /\b(?:if|else|for|while|do|switch|case|default|break|continue|return|try|catch|finally|throw|throws|new|instanceof|import|package|class|interface|enum|extends|implements|public|private|protected|static|final|abstract|synchronized|assert|this|super)\b/,
         'keyword'
       ],
-      [/\b(int|long|short|byte|float|double|boolean|char|void|String|Object)\b/, 'type'],
-      [/<=|>=|==|!=|&&|\|\||<<|>>|>>>|[-+*/%&|^<>=!]/, 'operator'],
-      [/[a-zA-Z_][a-zA-Z0-9_]*/, 'identifier'],
-      [/[0-9]+/, 'number'],
+      [/\b(?:int|long|short|byte|float|double|boolean|char|void|String|Object|List|Map)\b/, 'type'],
+      [/\d[\d_]*\.?[\d_]*(?:[eE][-+]?\d+)?[fFdDlL]?/, 'number'],
+      [/[{}()[\]]/, '@brackets'],
+      // Why: `%` is split out with a lookahead so a run like `i++%>` cannot
+      // swallow the closing `%>` and leak Java tokenization to end of file.
+      [/%(?!>)|[<>=!&|+\-*/^~?:]+/, 'keyword.operator'],
+      [/[;,.]/, 'delimiter'],
+      [/[a-zA-Z_$][\w$]*/, 'identifier'],
       [/\s+/, 'white']
     ],
-    javaComment: [
+
+    javaBlockComment: [
       [/\*\//, 'comment', '@pop'],
-      [/[^*]+/, 'comment'],
+      [/(?:(?!%>)[^*])+/, 'comment'],
       [/./, 'comment']
     ],
+
     elExpression: [
       [/\}/, 'delimiter.curly', '@pop'],
-      [/\b(and|or|not|eq|ne|gt|lt|ge|le|empty|instanceof)\b/, 'keyword.operator'],
-      [/<=|>=|==|!=|&&|\|\||[-+*/%<>=!]/, 'keyword.operator'],
-      [/\b(true|false|null)\b/, 'constant.language'],
+      [/\b(?:and|or|not|eq|ne|gt|lt|ge|le|div|mod|empty|instanceof)\b/, 'keyword.operator'],
+      [/\b(?:true|false|null)\b/, 'constant'],
       [/"([^"\\]|\\.)*"/, 'string'],
       [/'([^'\\]|\\.)*'/, 'string'],
-      [/[a-zA-Z_][a-zA-Z0-9_.]*/, 'variable'],
-      [/[0-9]+/, 'number'],
+      [/\d[\d_]*\.?[\d_]*/, 'number'],
+      [/[()[\]]/, '@brackets'],
+      // `fn:length(x)` — the namespace colon is a separator, not an operator.
+      [/:(?=[a-zA-Z_])/, 'delimiter'],
+      [/[<>=!&|+\-*/%?:]+/, 'keyword.operator'],
+      [/[,.]/, 'delimiter'],
+      [/[a-zA-Z_$][\w$]*/, 'variable'],
       [/\s+/, 'white']
     ],
+
+    // Shared by plain HTML, JSTL and custom tags: attribute values may embed
+    // both EL and scriptlet expressions.
+    tagRest: [
+      [/\/?>/, 'tag', '@pop'],
+      [/<%--/, 'comment', '@jspComment'],
+      [/[$#]\{/, 'delimiter.curly', '@elExpression'],
+      [/<%[=!]?/, 'metatag', '@jspScriptlet'],
+      [/[a-zA-Z_:][\w.:-]*/, 'attribute.name'],
+      [/=/, 'delimiter'],
+      [/"/, 'attribute.value', '@attributeValueDouble'],
+      [/'/, 'attribute.value', '@attributeValueSingle'],
+      [/\s+/, 'white']
+    ],
+
+    attributeValueDouble: [
+      [/"/, 'attribute.value', '@pop'],
+      [/<%--/, 'comment', '@jspComment'],
+      [/[$#]\{/, 'delimiter.curly', '@elExpression'],
+      [/<%[=!]?/, 'metatag', '@jspScriptlet'],
+      [/[^"$#<]+/, 'attribute.value'],
+      [/./, 'attribute.value']
+    ],
+
+    attributeValueSingle: [
+      [/'/, 'attribute.value', '@pop'],
+      [/<%--/, 'comment', '@jspComment'],
+      [/[$#]\{/, 'delimiter.curly', '@elExpression'],
+      [/<%[=!]?/, 'metatag', '@jspScriptlet'],
+      [/[^'$#<]+/, 'attribute.value'],
+      [/./, 'attribute.value']
+    ],
+
     scriptOpen: [
       [/\/>/, 'tag', '@pop'],
       [/>/, { token: 'tag', switchTo: '@scriptBody', nextEmbedded: 'javascript' }],
-      { include: '@tagAttributes' }
+      { include: '@tagRest' }
     ],
-    scriptBody: [[/<\/script\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    scriptBody: [
+      [/<\/[sS][cC][rR][iI][pP][tT]\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]
+    ],
+
     styleOpen: [
       [/\/>/, 'tag', '@pop'],
       [/>/, { token: 'tag', switchTo: '@styleBody', nextEmbedded: 'css' }],
-      { include: '@tagAttributes' }
+      { include: '@tagRest' }
     ],
-    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]]
+    styleBody: [
+      [/<\/[sS][tT][yY][lL][eE]\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]
+    ]
   }
 }
 
 export const jspLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
-  comments: {
-    lineComment: '//',
-    blockComment: ['<%--', '--%>']
-  },
+  comments: { blockComment: ['<%--', '--%>'] },
   brackets: [
     ['{', '}'],
     ['[', ']'],
     ['(', ')']
   ],
+  // Why: `<`/`>` are excluded because scriptlets and EL use them as comparison
+  // operators, which would produce false bracket matches.
   autoClosingPairs: [
     { open: '{', close: '}' },
     { open: '[', close: ']' },
     { open: '(', close: ')' },
     { open: '"', close: '"' },
-    { open: "'", close: "'" },
-    { open: '`', close: '`' }
+    { open: "'", close: "'" }
   ],
   surroundingPairs: [
     { open: '{', close: '}' },
     { open: '[', close: ']' },
     { open: '(', close: ')' },
     { open: '"', close: '"' },
-    { open: "'", close: "'" },
-    { open: '`', close: '`' }
-  ],
-  folding: {
-    markers: {
-      start: new RegExp('^\\s*<!--\\s*#region\\b.*-->'),
-      end: new RegExp('^\\s*<!--\\s*#endregion\\b.*-->')
-    }
-  }
+    { open: "'", close: "'" }
+  ]
+}
+
+// Why: JSP is HTML plus server-side template syntax — the same shape Monaco
+// already serves for Razor and Handlebars. Only the ten keys below are read by
+// the HTML mode. Formatting and rename are off because both act on a parse of
+// the file as HTML, and `<% ... %>` is not markup: formatting would move it and
+// rename would edit spans derived from a mis-parse.
+export const jspHtmlModeConfiguration: Monaco.html.ModeConfiguration = {
+  completionItems: true,
+  hovers: true,
+  documentSymbols: true,
+  links: true,
+  documentHighlights: true,
+  selectionRanges: true,
+  foldingRanges: true,
+  rename: false,
+  documentFormattingEdits: false,
+  documentRangeFormattingEdits: false
 }
 
 export function registerJspLanguage(monaco: MonacoModule): void {
@@ -171,8 +205,11 @@ export function registerJspLanguage(monaco: MonacoModule): void {
   monaco.languages.register({
     id: 'jsp',
     extensions: ['.jsp', '.jspf'],
-    aliases: ['JSP', 'jsp', 'JavaServer Pages']
+    aliases: ['JSP', 'JavaServer Pages']
   })
   monaco.languages.setMonarchTokensProvider('jsp', jspMonarchLanguage)
   monaco.languages.setLanguageConfiguration('jsp', jspLanguageConfiguration)
+  // Why: registering twice would create a second worker and provider set —
+  // the call has no internal dedupe — so it stays behind the guard above.
+  monaco.html.registerHTMLLanguageService('jsp', undefined, jspHtmlModeConfiguration)
 }

--- a/src/renderer/src/lib/monaco-languages/register-jsp.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.ts
@@ -59,14 +59,18 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/%>/, 'metatag', '@pop'],
       [/\/\/(?:(?!%>)[^\n])*/, 'comment'],
       [/\/\*/, 'comment', '@javaBlockComment'],
-      [/"([^"\\]|\\.)*"/, 'string'],
-      [/'([^'\\]|\\.)*'/, 'string'],
+      // JSP closes scriptlets before parsing Java, including inside literals.
+      [/"(?:(?!%>)(?:[^"\\]|\\.))*(?:"|(?=%>))/, 'string'],
+      [/'(?:(?!%>)(?:[^'\\]|\\.))*(?:'|(?=%>))/, 'string'],
       [/\b(?:true|false|null)\b/, 'constant'],
       [
         /\b(?:if|else|for|while|do|switch|case|default|break|continue|return|try|catch|finally|throw|throws|new|instanceof|import|package|class|interface|enum|extends|implements|public|private|protected|static|final|abstract|synchronized|assert|this|super)\b/,
         'keyword'
       ],
-      [/\b(?:int|long|short|byte|float|double|boolean|char|void|String|Object|List|Map)\b/, 'type'],
+      [
+        /\b(?:int|long|short|byte|float|double|boolean|char|void|String|Object|List|Map|Set|Iterator|Optional|ArrayList|LinkedList|HashMap|LinkedHashMap|HashSet|LinkedHashSet|TreeMap|TreeSet|StringBuilder|BigDecimal|BigInteger|Integer|Long|Double|Boolean|Short|Byte|Float|Character|Void)\b/,
+        'type'
+      ],
       [/\d[\d_]*\.?[\d_]*(?:[eE][-+]?\d+)?[fFdDlL]?/, 'number'],
       [/[{}()[\]]/, '@brackets'],
       // Why: `%` is split out with a lookahead so a run like `i++%>` cannot
@@ -78,6 +82,7 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
     ],
 
     javaBlockComment: [
+      [/%>/, 'metatag', '@popall'],
       [/\*\//, 'comment', '@pop'],
       [/(?:(?!%>)[^*])+/, 'comment'],
       [/./, 'comment']

--- a/src/renderer/src/lib/monaco-languages/register-jsp.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.ts
@@ -1,0 +1,178 @@
+import type * as Monaco from 'monaco-editor'
+
+type MonacoModule = typeof Monaco
+
+export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
+  defaultToken: '',
+  tokenPostfix: '.jsp',
+  ignoreCase: true,
+  brackets: [
+    { open: '{', close: '}', token: 'delimiter.curly' },
+    { open: '[', close: ']', token: 'delimiter.square' },
+    { open: '(', close: ')', token: 'delimiter.parenthesis' }
+  ],
+  tokenizer: {
+    root: [
+      [/<%--/, 'comment', '@jspComment'],
+      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<script(?=\s|>)/, 'tag', '@scriptOpen'],
+      [/<style(?=\s|>)/, 'tag', '@styleOpen'],
+      [/<\/([a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+)/, 'tag.custom', '@tagCustomClose'],
+      [/<([a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+)/, 'tag.custom', '@tagCustom'],
+      [/<\/([a-zA-Z][a-zA-Z0-9_-]*)/, 'tag', '@tagClose'],
+      [/<([a-zA-Z][a-zA-Z0-9_-]*)/, 'tag', '@tagOpen'],
+      [/<!--/, 'comment', '@htmlComment'],
+      [/[^<%$]+/, '']
+    ],
+    htmlComment: [
+      [/-->/, 'comment', '@pop'],
+      [/[^-]+/, 'comment'],
+      [/./, 'comment']
+    ],
+    jspComment: [
+      [/--%>/, 'comment', '@pop'],
+      [/[^-]+/, 'comment'],
+      [/./, 'comment']
+    ],
+    tagCustom: [
+      [/\/>/, 'tag.custom', '@pop'],
+      [/>/, 'tag.custom', '@pop'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
+      { include: '@tagAttributes' }
+    ],
+    tagCustomClose: [
+      [/>/, 'tag.custom', '@pop'],
+      [/\s+/, 'white']
+    ],
+    tagOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, 'tag', '@pop'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
+      { include: '@tagAttributes' }
+    ],
+    tagClose: [
+      [/>/, 'tag', '@pop'],
+      [/\s+/, 'white']
+    ],
+    tagAttributes: [
+      [/[a-zA-Z0-9_-]+/, 'attribute.name'],
+      [/=/, 'delimiter'],
+      [/"/, 'attribute.value', '@stringDouble'],
+      [/'/, 'attribute.value', '@stringSingle'],
+      [/\s+/, 'white']
+    ],
+    stringDouble: [
+      [/"/, 'attribute.value', '@pop'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
+      [/[^"\\$%]+/, 'attribute.value'],
+      [/[$%]/, 'attribute.value']
+    ],
+    stringSingle: [
+      [/'/, 'attribute.value', '@pop'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%(?:@|=|!)?/, 'keyword', '@jspScriptletOpen'],
+      [/[^'\\$%]+/, 'attribute.value'],
+      [/[$%]/, 'attribute.value']
+    ],
+    jspScriptletOpen: [
+      [/%>/, 'keyword', '@pop'],
+      [/\/\/.*/, 'comment'],
+      [/\/\*/, 'comment', '@javaComment'],
+      [/"([^"\\]|\\.)*"/, 'string'],
+      [/'([^'\\]|\\.)*'/, 'string'],
+      [/\b(true|false|null)\b/, 'constant.language'],
+      [
+        /\b(if|else|for|while|do|switch|case|default|break|continue|return|try|catch|finally|throw|new|import|package)\b/,
+        'keyword'
+      ],
+      [/\b(int|long|short|byte|float|double|boolean|char|void|String|Object)\b/, 'type'],
+      [/<=|>=|==|!=|&&|\|\||<<|>>|>>>|[-+*/%&|^<>=!]/, 'operator'],
+      [/[a-zA-Z_][a-zA-Z0-9_]*/, 'identifier'],
+      [/[0-9]+/, 'number'],
+      [/\s+/, 'white']
+    ],
+    javaComment: [
+      [/\*\//, 'comment', '@pop'],
+      [/[^*]+/, 'comment'],
+      [/./, 'comment']
+    ],
+    elExpression: [
+      [/\}/, 'delimiter.curly', '@pop'],
+      [/\b(and|or|not|eq|ne|gt|lt|ge|le|empty|instanceof)\b/, 'keyword.operator'],
+      [/<=|>=|==|!=|&&|\|\||[-+*/%<>=!]/, 'keyword.operator'],
+      [/\b(true|false|null)\b/, 'constant.language'],
+      [/"([^"\\]|\\.)*"/, 'string'],
+      [/'([^'\\]|\\.)*'/, 'string'],
+      [/[a-zA-Z_][a-zA-Z0-9_.]*/, 'variable'],
+      [/[0-9]+/, 'number'],
+      [/\s+/, 'white']
+    ],
+    scriptOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', switchTo: '@scriptBody', nextEmbedded: 'javascript' }],
+      { include: '@tagAttributes' }
+    ],
+    scriptBody: [[/<\/script\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    styleOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', switchTo: '@styleBody', nextEmbedded: 'css' }],
+      { include: '@tagAttributes' }
+    ],
+    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]]
+  }
+}
+
+export const jspLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+  comments: {
+    lineComment: '//',
+    blockComment: ['<%--', '--%>']
+  },
+  brackets: [
+    ['{', '}'],
+    ['[', ']'],
+    ['(', ')']
+  ],
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+    { open: '`', close: '`' }
+  ],
+  surroundingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" },
+    { open: '`', close: '`' }
+  ],
+  folding: {
+    markers: {
+      start: new RegExp('^\\s*<!--\\s*#region\\b.*-->'),
+      end: new RegExp('^\\s*<!--\\s*#endregion\\b.*-->')
+    }
+  }
+}
+
+export function registerJspLanguage(monaco: MonacoModule): void {
+  const jspAlreadyRegistered = monaco.languages
+    .getLanguages()
+    .some((language) => language.id === 'jsp')
+  if (jspAlreadyRegistered) {
+    return
+  }
+
+  monaco.languages.register({
+    id: 'jsp',
+    extensions: ['.jsp', '.jspf'],
+    aliases: ['JSP', 'jsp', 'JavaServer Pages']
+  })
+  monaco.languages.setMonarchTokensProvider('jsp', jspMonarchLanguage)
+  monaco.languages.setLanguageConfiguration('jsp', jspLanguageConfiguration)
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -30,6 +30,7 @@ globalThis.MonacoEnvironment = {
       case 'html':
       case 'handlebars':
       case 'razor':
+      case 'jsp':
         return new htmlWorker()
       case 'typescript':
       case 'javascript':

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -9,6 +9,7 @@ import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerJsonlLanguage } from './monaco-languages/register-jsonl'
+import { registerJspLanguage } from './monaco-languages/register-jsp'
 import { registerNimLanguage } from './monaco-languages/register-nim'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
@@ -79,6 +80,7 @@ registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
 registerJsonlLanguage(monaco)
+registerJspLanguage(monaco)
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)
 installMonacoPeekReferencesPreviewOptions()


### PR DESCRIPTION
## Summary

- Adds syntax highlighting and language configuration for JavaServer Pages (`.jsp`, `.jspf`) files in Monaco
  Editor (addresses [#9795](https://github.com/stablyai/orca/issues/9795)).
    - Connects Monaco's HTML Language Service (`registerHTMLLanguageService`) for JSP files to enable HTML tag  completions, hovers, document symbols, and folding, while disabling buffer-modifying features (`rename`, `formatting`) to prevent scriptlet corruption.
    - Fixes comparison operator highlighting issue where `<` and `>` inside scriptlets or EL expressions were
  incorrectly paired as bracket match pairs.
    - Refines tokenization for Java scriptlets (`ignoreCase: false` to avoid colouring variables as types in `List
  list`), adds `(?!%>)` lookahead guards to comments/operators to prevent swallowing the `%>` closing tag, and
  switches operator tokens to `keyword.operator` for proper theme compatibility.
    - Implements state-based tokenization for JSTL / custom tags (`<c:if>`, `<c:forEach>`, etc.) and supports
  embedded `${...}` and `#{...}` EL expressions within tag attributes.
    - Restores standard `nextEmbedded: 'javascript'` and `nextEmbedded: 'css'` stack handling for `<script>` and
  `<style>` blocks to ensure correct keyword colors (`function`, `var`, etc.) and bracket matching.
    - Special thanks to @taehwanis for collaborating on the HTML language service integration and tokenizer
  refinements. (#10858)

## Details & Verification

### What Changed
 1. **Language Detection & Setup**: Registered `.jsp` and `.jspf` file extensions to the `jsp` language ID in  `language-detect.ts` and `monaco-setup.ts` (routing to `htmlWorker`).
2. **HTML Language Service**: Wired `registerHTMLLanguageService('jsp', undefined, jspHtmlModeConfiguration)` to  provide HTML hovers, completions, and folding while keeping buffer-editing features (`rename`, `formatting`)  disabled.
3. **Bracket Matching**: Excluded `<` and `>` from `brackets`, `autoClosingPairs`, and `surroundingPairs` in `register-jsp.ts` to prevent false bracket pair highlighting on comparison operators.
4. **Tokenization & Robustness**:
       - Switched to case-sensitive matching for Java tokens to prevent `List list` from colouring `list` as a type.
       - Added `(?!%>)` lookahead guards to line comments, block comments, and `%` operators so scriptlet closing  tags (`%>`) are never swallowed.
       - Used `keyword.operator` for theme-compatible operator highlighting.
5. **Custom & JSTL Tag Parsing**: Tokenizes `<c:*>` and custom prefix tags with `@tagRest` / `@tagCustom` state transitions, with support for embedded EL (`${...}`, `#{...}`) and scriptlet expressions in attributes.
6. **Embedded Language Support**: Smooth transition for embedded JavaScript and CSS with `@pop` handling on closing tags.
7. **Unit Tests**: Added 17 comprehensive Vitest test cases in `register-jsp.test.ts` checking Monarch rule matches for operators, JSTL tags, EL expressions, comments, edge cases, and language service registration.

## Screenshots / Evidence

<!-- Drag and drop your before/after screenshots here -->
| JSP Syntax & JSTL Tags | Script & Embedded JS |
| --- | --- |
| <img width="1455" height="1015" alt="image" src="https://github.com/user-attachments/assets/219dccab-5492-4cb9-8cd2-f170de106aee" />| <img width="761" height="827" alt="image" src="https://github.com/user-attachments/assets/706f28e0-25a3-4672-96d8-f1d10a0b00b0" /> |

## Testing

- [x] Vitest Unit Tests: `npx vitest run src/renderer/src/lib/monaco-languages/register-jsp.test.ts src/renderer/src/lib/language-detect.test.ts` (Files  2 passed (2), Tests  19 passed (19))
- [x] TypeScript Check: `pnpm run tc:web` (0 errors)
- [x] Linter Check: `npx oxlint` on changed files (0 warnings, 0 errors)
- [x] pnpm lint (0 errors from this change)
- [x] pnpm test (Files  3463 passed | 7 skipped(3470), Tests  37046 passed | 60 skipped (37106))
- [x] pnpm build (success)
- [x] Manual Verification (`pnpm dev`): Tested and verified syntax highlighting, JSTL tags, and bracket matching against real-world legacy JSP files.

## AI Review Report

- **Cross-Platform Compatibility**: Uses standard Monaco Editor extension registration. Compatible across macOS, Linux, and Windows.
- **SSH / Remote Compatibility**: Pure renderer-side Monaco tokenization module. No native process or host filesystem assumptions.
- **Performance Risk**: Efficient regex-based Monarch tokenizer registered at boot. Zero memory leaks or extra network fetches.
- **Security & Reliability**: Pure tokenization inside Monaco's sandboxed renderer.

Closes #9795