### PR TITLE
fix(file-explorer): commit inline rename on outside click and stop double-click rename flicker

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -47,6 +47,10 @@ import {
   buildAddProjectFromFolderModalData,
   canShowAddAsProjectAction
 } from './file-explorer-add-project-action'
+import {
+  isRenameHotspotTarget,
+  resolveDirToggleTiming
+} from './file-explorer-dir-toggle-timing'
 import type { TreeNode } from './file-explorer-types'
 import { useFileExplorerSelection } from './useFileExplorerSelection'
 import { useFileExplorerVisibleRowProjection } from './useFileExplorerVisibleRowProjection'
@@ -489,18 +493,19 @@ function FileExplorerFiles(): React.JSX.Element {
       getNameFilterCollapsedPathsAfterExpand(current, dirPath)
     )
   }, [])
-  const { handleClick, handleDoubleClick, handleWheelCapture } = useFileExplorerHandlers({
-    activeWorktreeId,
-    runtimeEnvironmentId: activeRuntimeEnvironmentId,
-    openFile,
-    makePreviewFilePermanent,
-    toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,
-    loadDir,
-    statPath,
-    markPathAsDirectory,
-    setSelectedPath: setSingleSelectedPath,
-    scrollRef
-  })
+  const { handleClick, handleDoubleClick, handleWheelCapture, cancelPendingDirToggle } =
+    useFileExplorerHandlers({
+      activeWorktreeId,
+      runtimeEnvironmentId: activeRuntimeEnvironmentId,
+      openFile,
+      makePreviewFilePermanent,
+      toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,
+      loadDir,
+      statPath,
+      markPathAsDirectory,
+      setSelectedPath: setSingleSelectedPath,
+      scrollRef
+    })
 
   // Why: pass a stable activator so arrow-key navigation can hand the same
   // activate-toggles-folder / open-file-preview behavior the click handler
@@ -510,6 +515,15 @@ function FileExplorerFiles(): React.JSX.Element {
       void handleClick(node)
     },
     [handleClick]
+  )
+  // Why: a rename can start while a name click is still holding back its
+  // directory toggle; drop it so the tree doesn't shift under the input.
+  const handleStartRename = useCallback(
+    (node: TreeNode) => {
+      cancelPendingDirToggle()
+      startRename(node)
+    },
+    [cancelPendingDirToggle, startRename]
   )
   const scrollToIndex = useCallback(
     (index: number) => {
@@ -529,7 +543,7 @@ function FileExplorerFiles(): React.JSX.Element {
     activateNode,
     moveSelection,
     toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,
-    startRename,
+    startRename: handleStartRename,
     requestDelete,
     requestDeleteAll,
     scrollToIndex,
@@ -552,8 +566,13 @@ function FileExplorerFiles(): React.JSX.Element {
 
   const handleDuplicate = useFileDuplicate({ activeWorktreeId, worktreePath, refreshDir })
   const handleRowClick = useCallback(
-    (node: TreeNode, event: React.MouseEvent<HTMLButtonElement>) =>
-      selectRowWithModifiers(node, event, handleClick),
+    (node: TreeNode, event: React.MouseEvent<HTMLButtonElement>) => {
+      const dirToggle = resolveDirToggleTiming({
+        fromRenameHotspot: isRenameHotspotTarget(event.target),
+        clickCount: event.detail
+      })
+      selectRowWithModifiers(node, event, (target) => handleClick(target, dirToggle))
+    },
     [handleClick, selectRowWithModifiers]
   )
   const handleCollapseFolderSubtree = useCallback(
@@ -762,7 +781,7 @@ function FileExplorerFiles(): React.JSX.Element {
                 onContextMenuSelect={preserveSelectionForContextMenu}
                 onCopyPaths={copyPathsForNode}
                 onStartNew={startNew}
-                onStartRename={startRename}
+                onStartRename={handleStartRename}
                 onDuplicate={handleDuplicate}
                 onAddFolderAsProject={handleAddFolderAsProject}
                 canAddFolderAsProject={(node) => canShowAddAsProjectAction(node, activeRepo)}

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -229,21 +229,12 @@ export function InlineInputRow({
         }}
         onFocus={clearBlurTimeout}
         onBlur={(e) => {
-          // When a Radix menu (context or dropdown) closes, it restores focus
-          // to its trigger button, which steals focus from this input before
-          // the user can type. Detect this by checking relatedTarget — if focus
-          // moved to any menu trigger, it's Radix cleanup, not a user action.
-          if (
-            e.relatedTarget instanceof HTMLElement &&
-            (e.relatedTarget.closest('[data-slot="context-menu-trigger"]') ||
-              e.relatedTarget.closest('[data-slot="dropdown-menu-trigger"]'))
-          ) {
-            scheduleInputRefocus()
-            return
-          }
           // During the grace period after mount, menu close focus management
-          // may shift focus away (often relatedTarget is null). Re-focus
-          // instead of dismissing the still-empty input.
+          // may shift focus away before the user can type. Re-focus instead of
+          // dismissing the still-empty input. Past that window a blur is the
+          // user leaving, so commit like Finder does rather than clinging to
+          // the edit state — every row is itself a context-menu trigger, so
+          // relatedTarget can't tell an ordinary row click from Radix cleanup.
           if (!focusSettled.current) {
             scheduleInputRefocus()
             return

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -45,6 +45,7 @@ import {
 } from '@/lib/workspace-file-drag'
 import type { GitFileStatus } from '../../../../shared/types'
 import { STATUS_LABELS } from './status-display'
+import { RENAME_HOTSPOT_ATTR } from './file-explorer-dir-toggle-timing'
 import type { TreeNode } from './file-explorer-types'
 import { useFileExplorerRowDrag } from './useFileExplorerRowDrag'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
@@ -626,6 +627,9 @@ export function FileExplorerRow({
             </>
           )}
           <span
+            // Why: marks the rename hotspot so the row's click handler can hold
+            // back the directory toggle until the double-click window closes.
+            {...{ [RENAME_HOTSPOT_ATTR]: '' }}
             className={cn(
               'truncate',
               isSelected && !nodeStatus && !isIgnored && 'text-accent-foreground',
@@ -642,10 +646,8 @@ export function FileExplorerRow({
                   : undefined
             }
             onDoubleClick={(e) => {
-              // Why: the row itself swallows double-click for "pin preview" /
-              // directory toggle. Scope rename to the filename text only so
-              // those behaviors stay intact on the icon and empty row area,
-              // matching VS Code's rename hotspot.
+              // Why: scope rename to the filename text so "pin preview" and the
+              // directory toggle stay reachable on the icon and empty row area.
               e.stopPropagation()
               onStartRename(node)
             }}

--- a/src/renderer/src/components/right-sidebar/file-explorer-deferred-dir-toggle.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-deferred-dir-toggle.test.ts
@@ -15,6 +15,14 @@ const directoryNode: TreeNode = {
   depth: 1
 }
 
+const siblingDirectoryNode: TreeNode = {
+  name: 'lib',
+  path: '/repo/src/lib',
+  relativePath: 'src/lib',
+  isDirectory: true,
+  depth: 1
+}
+
 function renderHandlers(toggleDir: (worktreeId: string, dirPath: string) => void) {
   return renderHook(() =>
     useFileExplorerHandlers({
@@ -100,6 +108,28 @@ describe('deferred directory toggle', () => {
 
     await flush(DIR_TOGGLE_DOUBLE_CLICK_MS * 2)
     expect(toggleDir).not.toHaveBeenCalled()
+  })
+
+  it('flushes a pending toggle when the next click lands on a different row', async () => {
+    const toggleDir = vi.fn()
+    const { result } = renderHandlers(toggleDir)
+
+    await act(async () => {
+      result.current.handleClick(directoryNode, 'deferred')
+      await Promise.resolve()
+    })
+    // Why: clicking another folder must not silently discard the first folder's
+    // expand — only that row's own second click (the rename) may retract it.
+    await act(async () => {
+      result.current.handleClick(siblingDirectoryNode, 'deferred')
+      await Promise.resolve()
+    })
+
+    expect(toggleDir).toHaveBeenCalledWith('wt-1', directoryNode.path)
+
+    await flush(DIR_TOGGLE_DOUBLE_CLICK_MS)
+    expect(toggleDir).toHaveBeenCalledWith('wt-1', siblingDirectoryNode.path)
+    expect(toggleDir).toHaveBeenCalledTimes(2)
   })
 
   it('drops a pending toggle when the explorer unmounts', async () => {

--- a/src/renderer/src/components/right-sidebar/file-explorer-deferred-dir-toggle.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-deferred-dir-toggle.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { createRef } from 'react'
+import { useFileExplorerHandlers } from './useFileExplorerHandlers'
+import { DIR_TOGGLE_DOUBLE_CLICK_MS } from './file-explorer-dir-toggle-timing'
+import type { TreeNode } from './file-explorer-types'
+
+const directoryNode: TreeNode = {
+  name: 'components',
+  path: '/repo/src/components',
+  relativePath: 'src/components',
+  isDirectory: true,
+  depth: 1
+}
+
+function renderHandlers(toggleDir: (worktreeId: string, dirPath: string) => void) {
+  return renderHook(() =>
+    useFileExplorerHandlers({
+      activeWorktreeId: 'wt-1',
+      openFile: vi.fn(),
+      makePreviewFilePermanent: vi.fn(),
+      toggleDir,
+      loadDir: vi.fn().mockResolvedValue(true),
+      statPath: vi.fn().mockResolvedValue({ isDirectory: true }),
+      markPathAsDirectory: vi.fn(),
+      setSelectedPath: vi.fn(),
+      scrollRef: createRef<HTMLDivElement>()
+    })
+  )
+}
+
+async function flush(ms: number): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(ms)
+    await Promise.resolve()
+  })
+}
+
+describe('deferred directory toggle', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('toggles immediately when the click missed the rename hotspot', async () => {
+    const toggleDir = vi.fn()
+    const { result } = renderHandlers(toggleDir)
+
+    await act(async () => {
+      result.current.handleClick(directoryNode, 'immediate')
+      await Promise.resolve()
+    })
+
+    expect(toggleDir).toHaveBeenCalledWith('wt-1', directoryNode.path)
+  })
+
+  it('holds a filename click back until the double-click window closes', async () => {
+    const toggleDir = vi.fn()
+    const { result } = renderHandlers(toggleDir)
+
+    await act(async () => {
+      result.current.handleClick(directoryNode, 'deferred')
+      await Promise.resolve()
+    })
+    expect(toggleDir).not.toHaveBeenCalled()
+
+    await flush(DIR_TOGGLE_DOUBLE_CLICK_MS)
+    expect(toggleDir).toHaveBeenCalledWith('wt-1', directoryNode.path)
+  })
+
+  it('never toggles when a second click turns the gesture into a rename', async () => {
+    const toggleDir = vi.fn()
+    const { result } = renderHandlers(toggleDir)
+
+    await act(async () => {
+      result.current.handleClick(directoryNode, 'deferred')
+      await Promise.resolve()
+    })
+    await act(async () => {
+      result.current.handleClick(directoryNode, 'skip')
+      await Promise.resolve()
+    })
+
+    await flush(DIR_TOGGLE_DOUBLE_CLICK_MS * 2)
+    expect(toggleDir).not.toHaveBeenCalled()
+  })
+
+  it('drops a pending toggle when a rename starts', async () => {
+    const toggleDir = vi.fn()
+    const { result } = renderHandlers(toggleDir)
+
+    await act(async () => {
+      result.current.handleClick(directoryNode, 'deferred')
+      await Promise.resolve()
+    })
+    act(() => result.current.cancelPendingDirToggle())
+
+    await flush(DIR_TOGGLE_DOUBLE_CLICK_MS * 2)
+    expect(toggleDir).not.toHaveBeenCalled()
+  })
+
+  it('drops a pending toggle when the explorer unmounts', async () => {
+    const toggleDir = vi.fn()
+    const { result, unmount } = renderHandlers(toggleDir)
+
+    await act(async () => {
+      result.current.handleClick(directoryNode, 'deferred')
+      await Promise.resolve()
+    })
+    unmount()
+
+    await flush(DIR_TOGGLE_DOUBLE_CLICK_MS * 2)
+    expect(toggleDir).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/file-explorer-dir-toggle-timing.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-dir-toggle-timing.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import {
+  RENAME_HOTSPOT_ATTR,
+  isRenameHotspotTarget,
+  resolveDirToggleTiming
+} from './file-explorer-dir-toggle-timing'
+
+describe('resolveDirToggleTiming', () => {
+  it('toggles immediately when the click misses the rename hotspot', () => {
+    expect(resolveDirToggleTiming({ fromRenameHotspot: false, clickCount: 1 })).toBe('immediate')
+    // Why: the chevron and empty row area must stay instant even on a fast double click.
+    expect(resolveDirToggleTiming({ fromRenameHotspot: false, clickCount: 2 })).toBe('immediate')
+  })
+
+  it('defers the first click on the filename so a double click can cancel it', () => {
+    expect(resolveDirToggleTiming({ fromRenameHotspot: true, clickCount: 1 })).toBe('deferred')
+  })
+
+  it('drops the toggle on the second click, which belongs to the rename', () => {
+    expect(resolveDirToggleTiming({ fromRenameHotspot: true, clickCount: 2 })).toBe('skip')
+    expect(resolveDirToggleTiming({ fromRenameHotspot: true, clickCount: 3 })).toBe('skip')
+  })
+})
+
+describe('isRenameHotspotTarget', () => {
+  it('matches the filename element and its descendants', () => {
+    const row = document.createElement('button')
+    const name = document.createElement('span')
+    name.setAttribute(RENAME_HOTSPOT_ATTR, '')
+    const inner = document.createElement('em')
+    name.appendChild(inner)
+    row.appendChild(name)
+
+    expect(isRenameHotspotTarget(name)).toBe(true)
+    expect(isRenameHotspotTarget(inner)).toBe(true)
+  })
+
+  it('rejects the row chrome and non-element targets', () => {
+    const row = document.createElement('button')
+    const icon = document.createElement('svg')
+    row.appendChild(icon)
+
+    expect(isRenameHotspotTarget(icon)).toBe(false)
+    expect(isRenameHotspotTarget(row)).toBe(false)
+    expect(isRenameHotspotTarget(null)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/file-explorer-dir-toggle-timing.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-dir-toggle-timing.ts
@@ -1,0 +1,30 @@
+/** Marks the filename text, which doubles as the double-click-to-rename hotspot. */
+export const RENAME_HOTSPOT_ATTR = 'data-file-explorer-row-name'
+
+/** Roughly the platform double-click threshold; long enough to catch the second click. */
+export const DIR_TOGGLE_DOUBLE_CLICK_MS = 250
+
+export type DirToggleTiming = 'immediate' | 'deferred' | 'skip'
+
+export function isRenameHotspotTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(`[${RENAME_HOTSPOT_ATTR}]`) !== null
+}
+
+/**
+ * Why: a double-click on the filename toggles the directory twice before the
+ * rename starts, so the row visibly collapses and re-expands. Clicks on the
+ * rename hotspot wait out the double-click window; the second click drops the
+ * toggle entirely and lets the rename take over.
+ */
+export function resolveDirToggleTiming({
+  fromRenameHotspot,
+  clickCount
+}: {
+  fromRenameHotspot: boolean
+  clickCount: number
+}): DirToggleTiming {
+  if (!fromRenameHotspot) {
+    return 'immediate'
+  }
+  return clickCount > 1 ? 'skip' : 'deferred'
+}

--- a/src/renderer/src/components/right-sidebar/file-explorer-dir-toggle-timing.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-dir-toggle-timing.ts
@@ -1,8 +1,12 @@
 /** Marks the filename text, which doubles as the double-click-to-rename hotspot. */
 export const RENAME_HOTSPOT_ATTR = 'data-file-explorer-row-name'
 
-/** Roughly the platform double-click threshold; long enough to catch the second click. */
-export const DIR_TOGGLE_DOUBLE_CLICK_MS = 250
+/**
+ * Matches Chromium/Electron's double-click window (`kDoubleClickTimeMS`), so a
+ * deferred toggle can't fire before the second click of a slow double-click
+ * arrives and turns the gesture into a rename.
+ */
+export const DIR_TOGGLE_DOUBLE_CLICK_MS = 500
 
 export type DirToggleTiming = 'immediate' | 'deferred' | 'skip'
 

--- a/src/renderer/src/components/right-sidebar/file-explorer-inline-input-outside-click.test.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-inline-input-outside-click.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { InlineInputRow } from './FileExplorerRow'
+import type { InlineInput } from './FileExplorerRow'
+
+const renameInput: InlineInput = {
+  parentPath: '/repo/src',
+  type: 'rename',
+  depth: 1,
+  existingName: 'components',
+  existingPath: '/repo/src/components'
+}
+
+const BLUR_COMMIT_MS = 200
+
+// Why: the input focuses itself a frame after mount, then arms blur-commits once
+// the 200ms menu-close grace period has elapsed.
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(ms)
+    await Promise.resolve()
+  })
+}
+
+async function settleInlineInput(): Promise<void> {
+  await advance(0)
+  await advance(250)
+}
+
+function renderRenameRow(): {
+  input: HTMLInputElement
+  row: HTMLButtonElement
+  onSubmit: ReturnType<typeof vi.fn>
+} {
+  const onSubmit = vi.fn()
+  const view = render(
+    <div>
+      <InlineInputRow
+        depth={1}
+        inlineInput={renameInput}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />
+      {/* Rows are Radix context-menu triggers, so a genuine click on a neighbour
+          used to be indistinguishable from Radix restoring focus after a close. */}
+      <button type="button" data-slot="context-menu-trigger">
+        another-file.ts
+      </button>
+    </div>
+  )
+  return {
+    input: view.container.querySelector('input') as HTMLInputElement,
+    row: view.container.querySelector('button') as HTMLButtonElement,
+    onSubmit
+  }
+}
+
+describe('file explorer inline rename input', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('commits when the user clicks another file explorer row', async () => {
+    const { input, row, onSubmit } = renderRenameRow()
+    await settleInlineInput()
+
+    fireEvent.change(input, { target: { value: 'renamed' } })
+    fireEvent.blur(input, { relatedTarget: row })
+    await advance(BLUR_COMMIT_MS)
+
+    expect(onSubmit).toHaveBeenCalledWith('renamed')
+  })
+
+  it('commits when the user tabs to another row without any pointer input', async () => {
+    const { input, row, onSubmit } = renderRenameRow()
+    await settleInlineInput()
+
+    fireEvent.change(input, { target: { value: 'renamed' } })
+    row.focus()
+    fireEvent.blur(input, { relatedTarget: row })
+    await advance(BLUR_COMMIT_MS)
+
+    expect(onSubmit).toHaveBeenCalledWith('renamed')
+  })
+
+  it('commits when focus moves to an unrelated element', async () => {
+    const { input, onSubmit } = renderRenameRow()
+    await settleInlineInput()
+
+    fireEvent.change(input, { target: { value: 'renamed' } })
+    fireEvent.blur(input, { relatedTarget: null })
+    await advance(BLUR_COMMIT_MS)
+
+    expect(onSubmit).toHaveBeenCalledWith('renamed')
+  })
+
+  it('refocuses instead of committing when a menu close steals focus on mount', async () => {
+    const { input, row, onSubmit } = renderRenameRow()
+    // Only let the mount focus frame run — stay inside the grace period.
+    await advance(0)
+
+    fireEvent.blur(input, { relatedTarget: row })
+    await advance(BLUR_COMMIT_MS)
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/file-explorer-inline-rename-flow.test.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-inline-rename-flow.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { useRef } from 'react'
+import { InlineInputRow } from './FileExplorerRow'
+import { createFileExplorerRowProjection } from './file-explorer-row-projection'
+import type { TreeNode } from './file-explorer-types'
+import { useFileExplorerInlineInput } from './useFileExplorerInlineInput'
+
+const mocks = vi.hoisted(() => ({
+  openFile: vi.fn(),
+  refreshDir: vi.fn().mockResolvedValue(undefined),
+  renameFileOnDisk: vi.fn().mockResolvedValue(undefined),
+  toggleDir: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ openFile: mocks.openFile, toggleDir: mocks.toggleDir })
+}))
+
+vi.mock('@/lib/rename-file', () => ({
+  extractIpcErrorMessage: vi.fn(),
+  renameFileOnDisk: mocks.renameFileOnDisk
+}))
+
+const node: TreeNode = {
+  name: 'components',
+  path: '/repo/src/components',
+  relativePath: 'src/components',
+  isDirectory: true,
+  depth: 1
+}
+const rowProjection = createFileExplorerRowProjection([node])
+
+function RenameHarness(): React.JSX.Element {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const { inlineInput, startRename, dismissInlineInput, handleInlineSubmit } =
+    useFileExplorerInlineInput({
+      activeWorktreeId: 'wt-1',
+      worktreePath: '/repo',
+      expanded: new Set(),
+      rowProjection,
+      scrollRef,
+      refreshDir: mocks.refreshDir
+    })
+
+  return (
+    <div ref={scrollRef} tabIndex={-1}>
+      <button type="button" onClick={() => startRename(node)}>
+        Rename
+      </button>
+      {inlineInput ? (
+        <InlineInputRow
+          depth={inlineInput.depth}
+          inlineInput={inlineInput}
+          onSubmit={handleInlineSubmit}
+          onCancel={dismissInlineInput}
+        />
+      ) : null}
+      <button type="button">Another row</button>
+    </div>
+  )
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(ms)
+    await Promise.resolve()
+  })
+}
+
+async function startSettledRename(): Promise<{
+  input: HTMLInputElement
+  outsideRow: HTMLButtonElement
+}> {
+  const view = render(<RenameHarness />)
+  fireEvent.click(view.getByRole('button', { name: 'Rename' }))
+  await advance(0)
+  await advance(250)
+  return {
+    input: view.getByRole('textbox') as HTMLInputElement,
+    outsideRow: view.getByRole('button', { name: 'Another row' }) as HTMLButtonElement
+  }
+}
+
+describe('file explorer inline rename flow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+  })
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('renames on disk when focus leaves the input', async () => {
+    const { input, outsideRow } = await startSettledRename()
+
+    fireEvent.change(input, { target: { value: 'renamed-components' } })
+    fireEvent.blur(input, { relatedTarget: outsideRow })
+    await advance(150)
+
+    expect(mocks.renameFileOnDisk).toHaveBeenCalledWith({
+      oldPath: node.path,
+      newName: 'renamed-components',
+      worktreeId: 'wt-1',
+      worktreePath: '/repo',
+      operationOwner: undefined,
+      refreshDir: mocks.refreshDir
+    })
+  })
+
+  it('discards the rename on Escape without touching disk', async () => {
+    const { input } = await startSettledRename()
+
+    fireEvent.change(input, { target: { value: 'renamed-components' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    await advance(200)
+
+    expect(mocks.renameFileOnDisk).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -1,10 +1,12 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import type React from 'react'
 import type { RefObject } from 'react'
 import { detectLanguage } from '@/lib/language-detect'
 import { toast } from 'sonner'
 import type { TreeNode } from './file-explorer-types'
 import { FILE_EXPLORER_DRAGGABLE_SELECTOR } from './file-explorer-drag-scroll-marker'
+import { DIR_TOGGLE_DOUBLE_CLICK_MS } from './file-explorer-dir-toggle-timing'
+import type { DirToggleTiming } from './file-explorer-dir-toggle-timing'
 import { translate } from '@/i18n/i18n'
 import {
   getFileExplorerOwnerUnresolvedMessage,
@@ -44,9 +46,10 @@ type UseFileExplorerHandlersParams = {
 }
 
 type UseFileExplorerHandlersReturn = {
-  handleClick: (node: TreeNode) => void
+  handleClick: (node: TreeNode, dirToggle?: DirToggleTiming) => void
   handleDoubleClick: (node: TreeNode) => void
   handleWheelCapture: (e: React.WheelEvent<HTMLDivElement>) => void
+  cancelPendingDirToggle: () => void
 }
 
 type OpenFileParams = Parameters<UseFileExplorerHandlersParams['openFile']>[0]
@@ -164,14 +167,40 @@ export function useFileExplorerHandlers({
   setSelectedPath,
   scrollRef
 }: UseFileExplorerHandlersParams): UseFileExplorerHandlersReturn {
+  const pendingDirToggle = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cancelPendingDirToggle = useCallback((): void => {
+    if (pendingDirToggle.current === null) {
+      return
+    }
+    clearTimeout(pendingDirToggle.current)
+    pendingDirToggle.current = null
+  }, [])
+
+  useEffect(() => cancelPendingDirToggle, [cancelPendingDirToggle])
+
   const handleClick = useCallback(
-    (node: TreeNode) => {
+    (node: TreeNode, dirToggle: DirToggleTiming = 'immediate') => {
+      cancelPendingDirToggle()
+      if (dirToggle === 'skip' && node.isDirectory) {
+        // Why: the rename about to start owns this gesture; selection still applies.
+        setSelectedPath(node.path)
+        return
+      }
       void activateFileExplorerNode({
         node,
         activeWorktreeId,
         runtimeEnvironmentId,
         openFile,
-        toggleDir,
+        toggleDir:
+          dirToggle === 'deferred'
+            ? (worktreeId, dirPath) => {
+                pendingDirToggle.current = setTimeout(() => {
+                  pendingDirToggle.current = null
+                  toggleDir(worktreeId, dirPath)
+                }, DIR_TOGGLE_DOUBLE_CLICK_MS)
+              }
+            : toggleDir,
         canToggleDirectories,
         loadDir,
         statPath,
@@ -183,6 +212,7 @@ export function useFileExplorerHandlers({
       activeWorktreeId,
       runtimeEnvironmentId,
       canToggleDirectories,
+      cancelPendingDirToggle,
       loadDir,
       markPathAsDirectory,
       openFile,
@@ -221,5 +251,5 @@ export function useFileExplorerHandlers({
     [scrollRef]
   )
 
-  return { handleClick, handleDoubleClick, handleWheelCapture }
+  return { handleClick, handleDoubleClick, handleWheelCapture, cancelPendingDirToggle }
 }

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -167,21 +167,40 @@ export function useFileExplorerHandlers({
   setSelectedPath,
   scrollRef
 }: UseFileExplorerHandlersParams): UseFileExplorerHandlersReturn {
-  const pendingDirToggle = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingDirToggle = useRef<{
+    timer: ReturnType<typeof setTimeout>
+    dirPath: string
+    run: () => void
+  } | null>(null)
 
   const cancelPendingDirToggle = useCallback((): void => {
     if (pendingDirToggle.current === null) {
       return
     }
-    clearTimeout(pendingDirToggle.current)
+    clearTimeout(pendingDirToggle.current.timer)
     pendingDirToggle.current = null
+  }, [])
+
+  // Why: only the row that armed the deferral can retract it (its own second
+  // click becomes a rename). Any other gesture leaves that click's intent
+  // standing, so run it now instead of dropping the folder the user opened.
+  const settlePendingDirToggle = useCallback((retractingDirPath: string | null): void => {
+    const pending = pendingDirToggle.current
+    if (pending === null) {
+      return
+    }
+    clearTimeout(pending.timer)
+    pendingDirToggle.current = null
+    if (pending.dirPath !== retractingDirPath) {
+      pending.run()
+    }
   }, [])
 
   useEffect(() => cancelPendingDirToggle, [cancelPendingDirToggle])
 
   const handleClick = useCallback(
     (node: TreeNode, dirToggle: DirToggleTiming = 'immediate') => {
-      cancelPendingDirToggle()
+      settlePendingDirToggle(node.path)
       if (dirToggle === 'skip' && node.isDirectory) {
         // Why: the rename about to start owns this gesture; selection still applies.
         setSelectedPath(node.path)
@@ -195,10 +214,15 @@ export function useFileExplorerHandlers({
         toggleDir:
           dirToggle === 'deferred'
             ? (worktreeId, dirPath) => {
-                pendingDirToggle.current = setTimeout(() => {
-                  pendingDirToggle.current = null
-                  toggleDir(worktreeId, dirPath)
-                }, DIR_TOGGLE_DOUBLE_CLICK_MS)
+                const run = (): void => toggleDir(worktreeId, dirPath)
+                pendingDirToggle.current = {
+                  dirPath,
+                  run,
+                  timer: setTimeout(() => {
+                    pendingDirToggle.current = null
+                    run()
+                  }, DIR_TOGGLE_DOUBLE_CLICK_MS)
+                }
               }
             : toggleDir,
         canToggleDirectories,
@@ -212,7 +236,7 @@ export function useFileExplorerHandlers({
       activeWorktreeId,
       runtimeEnvironmentId,
       canToggleDirectories,
-      cancelPendingDirToggle,
+      settlePendingDirToggle,
       loadDir,
       markPathAsDirectory,
       openFile,


### PR DESCRIPTION
## Summary

Two fixes for the File Explorer's inline rename, both matching how Finder / VS Code behave.

**1. Commit an inline rename when focus leaves the input.** Every explorer row is a Radix `ContextMenuTrigger` (a native `<button>` carrying `data-slot="context-menu-trigger"`). The rename input's `onBlur` treated *any* `relatedTarget` inside such a trigger as "Radix restoring focus after a menu close" and refocused itself — so clicking another row never committed the rename; only Enter/Esc worked. The guard could never even match the case it was written for: on rename the input *replaces* the row, unmounting that row's own trigger, and both context menus already set `onCloseAutoFocus={(e) => e.preventDefault()}`. The guard is removed; the existing mount grace period still covers the menu-close focus race. Leaving the input now commits, by click or by keyboard (Tab).

**2. Stop the collapse/expand flicker on double-click rename.** Double-clicking a folder name fired two bubbling `click`s (collapse, then re-expand) before the `dblclick` started the rename, so the row visibly flickered — the row's `stopPropagation` only covered `dblclick`, never the clicks the toggle actually runs on. The directory toggle is now held back for the double-click window, but only when the click lands on the filename (the rename hotspot); the chevron, icon, and empty row area still toggle instantly. A second click cancels the pending toggle and lets the rename take over, and starting a rename drops any pending toggle so the tree can't shift under the input. Selection stays immediate throughout.

## Screenshots

Screen recording of the fixed behavior (double-click rename no longer flickers; clicking elsewhere commits the rename without needing Esc)

https://github.com/user-attachments/assets/2ca20e8a-32e4-4b0a-9bb8-ce0506a2a578


## Testing

- [x] `pnpm lint` — every gate passes (oxlint, switch-exhaustiveness, styled-scrollbars, reliability-gates, max-lines-ratchet, skill guides, localization-catalog) except the final `localization-coverage` step, which flags 6 pre-existing "Ghostty" keyword strings in `terminal-advanced-platform-search.ts` / `terminal-pane-appearance-search.ts` — files this PR does not touch and that fail identically on clean `main`
- [x] `pnpm typecheck` (full — node, cli, and web projects all clean)
- [x] `pnpm test` — new tests pass; full `right-sidebar` suite passes except 3 files (`pr-comment-presentation`, `pr-comments-list-selection`, `use-persisted-ai-vault-view-options`) that fail identically on `main` (local happy-dom `localStorage` env), unrelated to this change
- [x] `pnpm build` — full desktop + native build passes (exit 0): typecheck, relay, cli, electron-vite, web, and native (relay/cli binaries, notification-status + computer-use macOS helpers)
- [x] Added tests: `file-explorer-inline-input-outside-click.test.tsx` (commit-on-blur, keyboard-tab, unrelated-target, mount-grace refocus), `file-explorer-dir-toggle-timing.test.ts` (pure timing decision), `file-explorer-deferred-dir-toggle.test.ts` (immediate/deferred/skip, rename-cancel, unmount-cleanup). Both fixes verified to fail their new tests when reverted.

Manually verified in a dev build (isolated `orca-dev` profile): double-click folder rename no longer flickers, single click on chevron/icon still toggles instantly, single click on the name toggles after the double-click window, and clicking another row / pressing Tab commits the rename without Esc.

## AI Review Report

Reviewed both fixes for correctness, focus-timing, and event-ordering races, with cross-platform in mind (no `metaKey`/path/shell/accelerator assumptions were introduced; the double-click window keys off `MouseEvent.detail` and the rename hotspot off a `data-*` attribute, both platform-neutral).

Checked and cleared:
- Removing the `relatedTarget` guard does not reintroduce the empty-input-dismissed-on-menu-close bug — the input replaces the triggering row on rename and both menus prevent close-auto-focus, so the mount grace period is the only guard that was ever doing real work.
- Deferred toggle: single-timer semantics (clicking A's name then B's name drops A's toggle → only B expands) are acceptable; `skip` early-returns only for directories so file double-click-rename keeps prior open-preview behavior; pending timer is cleared on unmount (tested) and when a rename starts.

One residual, out-of-scope edge noted: a symlink-to-directory toggles *after* an `await`, so a rapid double-click rename on such a symlink could still race the deferral — this path was already racy before the change and the interaction is extremely rare.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. Changes are renderer-only UI event-timing and focus management; the new module is a pure decision function plus a DOM `closest()` check. No security-relevant risk.

## Notes

- The deferred directory toggle adds a 500ms delay before a folder expands **when the folder name itself is single-clicked** — this matches Chromium/Electron's double-click window (`kDoubleClickTimeMS`) so a slow double-click can't flip the folder before the rename-starting second click arrives. Clicking the chevron/icon/empty row area is unaffected and stays instant. This tradeoff was chosen deliberately over changing the click-to-expand hotspot.
- No GitHub/GitLab, SSH, or folder-vs-worktree specific behavior is touched.


