### PR TITLE
fix(codex): stop the restart card from parking focus on Restart

### DIFF
--- a/src/renderer/src/components/CodexRestartChip.tsx
+++ b/src/renderer/src/components/CodexRestartChip.tsx
@@ -151,10 +151,17 @@ function LoudRestartOverlay({
   const titleId = useId()
   const bodyId = useId()
   const rootRef = useRef<HTMLDivElement>(null)
-  const restartRef = useRef<HTMLButtonElement>(null)
 
-  // Why: focus Restart only when the user isn't typing elsewhere; unconditional
-  // autoFocus would steal keys from an active composer or terminal input.
+  // Why: move focus to the card only when the user isn't typing elsewhere;
+  // unconditional autoFocus would steal keys from an active composer.
+  //
+  // The target is the dialog itself, never Restart. This card is mounted per
+  // WORKTREE (a sibling of the split layout), so its focus scope is every
+  // terminal in the worktree — a notice for one pane lands while the user may
+  // be typing in a different, perfectly healthy pane. With Restart focused, the
+  // next Space/Enter of their prose queued a restart of every stale pane here
+  // and destroyed those sessions. Focus must not land on a destructive action
+  // the user never aimed at. See #10863.
   useEffect(() => {
     if (!isVisible) {
       return
@@ -165,7 +172,7 @@ function LoudRestartOverlay({
     }
     const paneScope = root.parentElement
     if (shouldFocusMobileDriverAction(document.activeElement, document.body, paneScope)) {
-      restartRef.current?.focus()
+      root.focus()
     }
   }, [isVisible, noticeKey])
 
@@ -173,10 +180,13 @@ function LoudRestartOverlay({
     <div
       ref={rootRef}
       role="dialog"
+      // Why: programmatically focusable so the card can take focus itself, but
+      // out of the Tab order — Tab from here still reaches Restart/Keep.
+      tabIndex={-1}
       aria-live="assertive"
       aria-labelledby={titleId}
       aria-describedby={bodyId}
-      className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center p-6"
+      className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center p-6 outline-none"
     >
       <div className="pointer-events-auto flex w-full max-w-[30rem] flex-col gap-3 rounded-lg border border-border bg-card p-6 pb-5 text-card-foreground shadow-xs">
         <div className="flex items-start gap-3">
@@ -207,7 +217,7 @@ function LoudRestartOverlay({
           <Button type="button" variant="outline" size="sm" onClick={onDismiss}>
             {translate('auto.components.CodexRestartChip.6133594b12', 'Keep old account')}
           </Button>
-          <Button ref={restartRef} type="button" variant="default" size="sm" onClick={onRestart}>
+          <Button type="button" variant="default" size="sm" onClick={onRestart}>
             <RefreshCw />
             {translate('auto.components.CodexRestartChip.c72a5fb234', 'Restart')}
           </Button>

--- a/src/renderer/src/components/codex-restart-chip.test.ts
+++ b/src/renderer/src/components/codex-restart-chip.test.ts
@@ -234,15 +234,13 @@ describe('CodexRestartChip helpers', () => {
       },
       ptyIdsByTabId: { 'tab-1': ['pty-1'] }
     })
-    useAppStore
-      .getState()
-      .markCodexRestartNotices([
-        {
-          ptyId: 'pty-1',
-          previousAccountLabel: 'old@example.com',
-          nextAccountLabel: 'new@example.com'
-        }
-      ])
+    useAppStore.getState().markCodexRestartNotices([
+      {
+        ptyId: 'pty-1',
+        previousAccountLabel: 'old@example.com',
+        nextAccountLabel: 'new@example.com'
+      }
+    ])
     await act(async () => {
       root.render(React.createElement(CodexRestartChip, { worktreeId: 'worktree-1' }))
     })
@@ -292,15 +290,13 @@ describe('CodexRestartChip helpers', () => {
       },
       ptyIdsByTabId: { 'tab-1': ['pty-1'] }
     })
-    useAppStore
-      .getState()
-      .markCodexRestartNotices([
-        {
-          ptyId: 'pty-1',
-          previousAccountLabel: 'old@example.com',
-          nextAccountLabel: 'new@example.com'
-        }
-      ])
+    useAppStore.getState().markCodexRestartNotices([
+      {
+        ptyId: 'pty-1',
+        previousAccountLabel: 'old@example.com',
+        nextAccountLabel: 'new@example.com'
+      }
+    ])
     await act(async () => {
       root.render(React.createElement(CodexRestartChip, { worktreeId: 'worktree-1' }))
     })
@@ -367,5 +363,84 @@ describe('CodexRestartChip helpers', () => {
     // Why: the pane still has to restart; only the prompt is answered.
     expect(useAppStore.getState().pendingCodexPaneRestartIds).toEqual({ 'pty-1': true })
     expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']?.restartRequested).toBe(true)
+  })
+})
+
+describe('CodexRestartChip focus target', () => {
+  function renderWithFocusedSiblingPane(): HTMLTextAreaElement {
+    // Mirrors Terminal.tsx, which mounts the chip as a SIBLING of the split
+    // layout — so the chip's parentElement is the whole worktree surface and
+    // its focus scope covers every pane in it, not just the stale one.
+    const splitLayout = document.createElement('div')
+    const healthyPaneInput = document.createElement('textarea')
+    healthyPaneInput.className = 'xterm-helper-textarea'
+    splitLayout.appendChild(healthyPaneInput)
+    container.appendChild(splitLayout)
+    healthyPaneInput.focus()
+
+    useAppStore.setState({
+      tabsByWorktree: {
+        'worktree-1': [
+          {
+            id: 'tab-1',
+            worktreeId: 'worktree-1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] }
+    })
+    useAppStore
+      .getState()
+      .markCodexRestartNotices([
+        {
+          ptyId: 'pty-1',
+          previousAccountLabel: 'old@example.com',
+          nextAccountLabel: 'new@example.com'
+        }
+      ])
+    return healthyPaneInput
+  }
+
+  it('never parks focus on Restart, so a stray keystroke cannot kill the session', async () => {
+    renderWithFocusedSiblingPane()
+
+    await act(async () => {
+      root.render(React.createElement(CodexRestartChip, { worktreeId: 'worktree-1' }))
+    })
+
+    // Regression (#10863): focus used to land on Restart. The card is worktree
+    // scoped, so it fires while the user is typing in a DIFFERENT, healthy pane
+    // — and the next Space/Enter of their prose restarted every stale pane here.
+    const restartButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Restart'
+    )
+    expect(restartButton).toBeDefined()
+    expect(document.activeElement).not.toBe(restartButton)
+    expect((document.activeElement as HTMLElement | null)?.getAttribute('role')).toBe('dialog')
+
+    // The keystroke that used to destroy the session now does nothing.
+    await act(async () => {
+      ;(document.activeElement as HTMLElement | null)?.click()
+    })
+    expect(useAppStore.getState().pendingCodexPaneRestartIds).toEqual({})
+  })
+
+  it('still moves focus off the terminal so the card is reachable by keyboard', async () => {
+    const healthyPaneInput = renderWithFocusedSiblingPane()
+
+    await act(async () => {
+      root.render(React.createElement(CodexRestartChip, { worktreeId: 'worktree-1' }))
+    })
+
+    // Why: the fix must not turn into "never take focus" — assistive tech and
+    // keyboard users still need to land on the dialog and Tab to its actions.
+    expect(document.activeElement).not.toBe(healthyPaneInput)
+    expect(document.activeElement).toBe(container.querySelector('[role="dialog"]'))
   })
 })


### PR DESCRIPTION
Stacked on #10770. Fixes #10863. Found while reviewing #10853 — see "Why now" below.

## The bug

When a Codex restart notice appears, `CodexRestartChip` moves keyboard focus to its default **Restart** button.

The card is mounted **per worktree**: `Terminal.tsx:2146`/`:2394` render it as a *sibling* of `TabGroupSplitLayout`. So `root.parentElement` (`CodexRestartChip.tsx:166`) is the whole worktree surface, and `shouldFocusMobileDriverAction`'s xterm branch is `focusScope.contains(active)` — which matches **any** terminal in that worktree, not just the stale pane.

Verified directly against the helper:

```
stealsFocusFromSiblingPane:   true
stealsFocusFromOtherWorktree: false
```

So a notice raised for pane A yanks focus out of pane B — a different, perfectly healthy pane whose input is *not* blocked (`isCodexPaneStale` is per-pane by design) and which the user may well be typing in.

The control that receives focus is destructive. `handleRestart` calls `queueCodexPaneRestarts(staleWorktreePtyIds)` over **every** stale pty in the worktree, so the next Space or Enter in the user's prose silently restarts those Codex sessions and loses their state — the same class of loss #10757 is about.

## Why now

This is pre-existing, but #10853 is what makes it routine. That PR widens the stale-pane sweep ladder so a notice can first appear up to **35.8s** after PTY bind instead of 5.8s. At 5.8s the pane has just appeared and nobody is typing yet; at 35.8s they plausibly are. #10853 is correct and should land — but it converts a rare race into a likely one, so this wants to land alongside it.

Filed separately rather than folded into #10853 to keep that PR to its one-line ladder change.

## The fix

Focus the `role="dialog"` root instead, with `tabIndex={-1}` so it is programmatically focusable but out of the Tab order.

- Still announced: `role="dialog"` + `aria-live="assertive"` + `aria-labelledby`/`aria-describedby`.
- Tab from the card still reaches **Restart** and **Keep old account**, so keyboard and AT discoverability are unchanged.
- The only capability removed is firing a session-killing action the user never aimed at.

`shouldFocusMobileDriverAction` is **untouched**, so `MobileDriverOverlay`'s behaviour is unchanged — that helper's worktree-wide semantics are right for a per-pane overlay whose pane is paused, just not for a worktree-wide card.

## Verification

Two new tests in `codex-restart-chip.test.ts` (happy-dom, real render), both **mutation-proved** — restoring `restartRef.current?.focus()` fails exactly these two and leaves the other 11 green:

```
× never parks focus on Restart, so a stray keystroke cannot kill the session
× still moves focus off the terminal so the card is reachable by keyboard
Tests  2 failed | 11 passed (13)
```

The second test exists so the fix cannot silently degrade into "never take focus at all".

Gates:
- `codex-restart-chip` + `mobile-driver-overlay-focus` + `mobile-driver-overlay-visibility` + `codex-restart-notice-lifecycle` — 28/28
- `npm run typecheck` — exit 0
- `npx oxlint` on both touched files — no findings
- `check:max-lines-ratchet` — OK

## Known residual, deliberately not fixed

Focus still leaves a healthy pane for the dialog, which interrupts typing. It no longer *destroys* anything, which was the severe part. Narrowing the scope to only the stale pane needs a DOM-node-to-ptyId mapping the card does not have today; that is worth doing separately, and per-pane scoping alone would not have been a fix — a correctly scoped focus steal onto a session-killing button is still a session-killing button.

Not verified: no live app run. The DOM structure claim is read from `Terminal.tsx`, and the focus-branch claim is proved against the real helper.