### PR TITLE
fix(terminal): avoid flash while restoring parked terminals

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -84,6 +84,7 @@ import {
   type TerminalWorktreeColdParkCandidate
 } from './terminal-pane/terminal-hidden-view-parking'
 import { getTerminalParkingPolicyOverrides } from './terminal-pane/terminal-parking-e2e-overrides'
+import { useColdParkedTerminalPresentation } from './terminal-pane/use-cold-parked-terminal-presentation'
 import {
   canWatcherCoverParkedTerminalTab,
   disposeAllParkedTerminalWatchers,
@@ -1042,6 +1043,32 @@ function Terminal(): React.JSX.Element | null {
     groupsByWorktree,
     activeGroupIdByWorktree
   )
+  const desiredPresentedWorktree = useMemo(
+    () =>
+      new Map([['terminal-worktree', activeView === 'terminal' ? renderedActiveWorktreeId : null]]),
+    [activeView, renderedActiveWorktreeId]
+  )
+  const availablePresentedWorktreeIds = useMemo(
+    () => new Set(workspaceSurfaces.map((workspace) => workspace.id)),
+    [workspaceSurfaces]
+  )
+  const coldWorktreePresentationTargets = useMemo(
+    () =>
+      activeView === 'terminal' && activeTabType === 'terminal'
+        ? parkedTerminalWorktreeIds
+        : new Set<string>(),
+    [activeTabType, activeView, parkedTerminalWorktreeIds]
+  )
+  const {
+    presentationByScope: worktreePresentationByScope,
+    settleTarget: settleWorktreePresentation
+  } = useColdParkedTerminalPresentation({
+    desiredTargetByScope: desiredPresentedWorktree,
+    coldParkedTargetIds: coldWorktreePresentationTargets,
+    availableTargetIds: availablePresentedWorktreeIds
+  })
+  const presentedWorktreeId =
+    worktreePresentationByScope.get('terminal-worktree')?.presentedTargetId ?? null
   // Why: legacy (non-split) host owns watcher reconciliation; split mode's overlay layers own theirs, so only dispose worktrees with no overlay layer.
   useEffect(() => {
     pruneParkedTerminalWatchers(new Set(workspaceSurfaces.map((workspace) => workspace.id)))
@@ -2076,6 +2103,7 @@ function Terminal(): React.JSX.Element | null {
               // Why: strict '=== terminal' (not !== settings) so the terminal/browser surface hides on the tasks page too.
               const isVisible =
                 activeView === 'terminal' && workspace.id === renderedActiveWorktreeId
+              const isPresented = workspace.id === presentedWorktreeId
               const shouldMeasureHiddenWorktree =
                 !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspace.id)
               const shouldColdParkTerminalPanes =
@@ -2090,6 +2118,7 @@ function Terminal(): React.JSX.Element | null {
                   layout={layout}
                   focusedGroupId={activeGroupIdByWorktree[workspace.id]}
                   isVisible={isVisible}
+                  isPresented={isPresented}
                   shouldMeasureHiddenWorktree={shouldMeasureHiddenWorktree}
                   shouldColdParkTerminalPanes={shouldColdParkTerminalPanes}
                   activityTerminalPortals={activityTerminalPortals}
@@ -2099,6 +2128,7 @@ function Terminal(): React.JSX.Element | null {
                   activationDeferredMountTabIds={
                     activationDeferredMountTabIdsByWorktreeRef.current.get(workspace.id) ?? null
                   }
+                  onInitialTerminalRenderSettled={() => settleWorktreePresentation(workspace.id)}
                 />
               )
             })}
@@ -2125,6 +2155,7 @@ function Terminal(): React.JSX.Element | null {
                 // Why: strict '=== terminal' (not !== settings) so the terminal/browser surface hides on the tasks page too.
                 const isVisible =
                   activeView === 'terminal' && workspace.id === renderedActiveWorktreeId
+                const isPresented = workspace.id === presentedWorktreeId
                 const shouldMeasureHiddenWorktree =
                   !isVisible && measurableBackgroundWorktreeIdsRef.current.has(workspace.id)
                 const shouldColdParkTerminalPanes =
@@ -2135,15 +2166,16 @@ function Terminal(): React.JSX.Element | null {
                   <div
                     key={workspace.id}
                     className={
-                      isVisible
+                      isPresented
                         ? 'absolute inset-0'
-                        : shouldMeasureHiddenWorktree
+                        : isVisible || shouldMeasureHiddenWorktree
                           ? 'absolute inset-0 opacity-0 pointer-events-none'
                           : 'absolute inset-0 hidden'
                     }
-                    aria-hidden={!isVisible}
+                    inert={!isPresented}
+                    aria-hidden={!isPresented}
                   >
-                    <CodexRestartChip isVisible={isVisible} worktreeId={workspace.id} />
+                    <CodexRestartChip isVisible={isPresented} worktreeId={workspace.id} />
                     {(tabsByWorktree[workspace.id] ?? [])
                       .filter((tab) =>
                         shouldMountBackgroundWorktreeTab(
@@ -2159,6 +2191,9 @@ function Terminal(): React.JSX.Element | null {
                         const isActivityPortalTab = activityTerminalPortal !== null
                         const isActiveTerminalTab =
                           isVisible && tab.id === activeTabId && activeTabType === 'terminal'
+                        const isPresentedTerminalTab =
+                          isPresented &&
+                          (isActiveTerminalTab || tab.id === activeTabIdByWorktree[workspace.id])
                         // Why: parking unmounts the view but keeps the PTY; an Activity portal stays mounted as a visible consumer.
                         if (shouldColdParkTerminalPanes && !isActivityPortalTab) {
                           return null
@@ -2170,16 +2205,22 @@ function Terminal(): React.JSX.Element | null {
                             worktreeId={workspace.id}
                             cwd={tab.startupCwd ?? workspace.path}
                             isActive={
-                              isActiveTerminalTab || activityTerminalPortal?.active === true
+                              (isActiveTerminalTab && isPresented) ||
+                              activityTerminalPortal?.active === true
                             }
                             // Why: keep isVisible true for the portaled tab so xterm fits/streams while the workspace surface stays hidden.
-                            isVisible={isActiveTerminalTab || isActivityPortalTab}
+                            isVisible={isPresentedTerminalTab || isActivityPortalTab}
                             // Why: inactive tabs here are tab-hidden (not worktree-hidden), so they need the same light resume path as split-group overlays.
-                            isWorktreeActive={isVisible || isActivityPortalTab}
+                            isWorktreeActive={isVisible || isPresented || isActivityPortalTab}
                             // Why: isolate the portaled Activity leaf so split siblings stay hidden; workspace renders pass null.
                             isolatedPaneKey={activityTerminalPortal?.paneKey ?? null}
                             onPtyExit={(ptyId) => handlePtyExit(tab.id, ptyId)}
                             onCloseTab={() => handleCloseTab(tab.id)}
+                            onInitialRenderSettled={
+                              isActiveTerminalTab
+                                ? () => settleWorktreePresentation(workspace.id)
+                                : undefined
+                            }
                           />
                         )
                         if (activityTerminalPortal) {
@@ -2349,22 +2390,26 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   layout,
   focusedGroupId,
   isVisible,
+  isPresented,
   shouldMeasureHiddenWorktree,
   shouldColdParkTerminalPanes,
   activityTerminalPortals,
   backgroundMountTabIds,
-  activationDeferredMountTabIds
+  activationDeferredMountTabIds,
+  onInitialTerminalRenderSettled
 }: {
   worktreeId: string
   worktreePath: string
   layout: TabGroupLayoutNode
   focusedGroupId?: string
   isVisible: boolean
+  isPresented: boolean
   shouldMeasureHiddenWorktree: boolean
   shouldColdParkTerminalPanes: boolean
   activityTerminalPortals: ActivityTerminalPortalTarget[]
   backgroundMountTabIds: ReadonlySet<string> | null
   activationDeferredMountTabIds: ReadonlySet<string> | null
+  onInitialTerminalRenderSettled: (tabId: string) => void
 }): React.JSX.Element {
   const browserPageIds = useAppStore(
     useShallow((state) =>
@@ -2381,37 +2426,45 @@ const WorktreeSplitSurface = React.memo(function WorktreeSplitSurface({
   return (
     <div
       className={
-        isVisible
+        isPresented
           ? 'absolute inset-0 flex'
-          : shouldKeepPaintable
+          : isVisible || shouldKeepPaintable
             ? 'absolute inset-0 flex opacity-0 pointer-events-none'
             : 'absolute inset-0 hidden'
       }
       // Why: paintable-but-hidden webviews must be inert so they stay unreachable by Tab / assistive tech.
-      inert={!isVisible}
-      aria-hidden={!isVisible}
+      inert={!isPresented}
+      aria-hidden={!isPresented}
     >
-      <CodexRestartChip isVisible={isVisible} worktreeId={worktreeId} />
+      <CodexRestartChip isVisible={isPresented} worktreeId={worktreeId} />
       <TabGroupSplitLayout
         layout={layout}
         worktreeId={worktreeId}
         focusedGroupId={focusedGroupId}
-        isWorktreeActive={isVisible}
+        isWorktreeActive={isVisible || isPresented}
       />
       <TerminalPaneOverlayLayer
         worktreeId={worktreeId}
         worktreePath={worktreePath}
         isWorktreeActive={isVisible}
+        isWorktreePresented={isPresented}
         coldParkTerminalPanes={shouldColdParkTerminalPanes}
         shouldMeasureHiddenWorktree={shouldMeasureHiddenWorktree}
         activityTerminalPortals={activityTerminalPortals}
         backgroundMountTabIds={backgroundMountTabIds}
         activationDeferredMountTabIds={activationDeferredMountTabIds}
+        onInitialTerminalRenderSettled={onInitialTerminalRenderSettled}
       />
       {isVisible || backgroundMountTabIds === null ? (
         <>
-          <BrowserPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
-          <EmulatorPaneOverlayLayer worktreeId={worktreeId} isWorktreeActive={isVisible} />
+          <BrowserPaneOverlayLayer
+            worktreeId={worktreeId}
+            isWorktreeActive={isVisible || isPresented}
+          />
+          <EmulatorPaneOverlayLayer
+            worktreeId={worktreeId}
+            isWorktreeActive={isVisible || isPresented}
+          />
         </>
       ) : null}
       <AiVaultSessionDropLayer worktreeId={worktreeId} enabled={isVisible} />

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -240,6 +240,7 @@ type TerminalPaneProps = {
   showSplitButton?: boolean
   onPtyExit: (ptyId: string) => void
   onCloseTab: () => void
+  onInitialRenderSettled?: () => void
 }
 
 type TerminalQuickCommandEditorDialogProps = {
@@ -282,7 +283,8 @@ export default function TerminalPane({
   isolatedPaneKey = null,
   showSplitButton = true,
   onPtyExit,
-  onCloseTab
+  onCloseTab,
+  onInitialRenderSettled
 }: TerminalPaneProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
   const managerRef = useRef<PaneManager | null>(null)
@@ -311,6 +313,8 @@ export default function TerminalPane({
   const isRendererVisible = isVisible && isWorktreeActive
   const isVisibleRef = useRef(isRendererVisible)
   isVisibleRef.current = isRendererVisible
+  const onInitialRenderSettledRef = useRef(onInitialRenderSettled)
+  onInitialRenderSettledRef.current = onInitialRenderSettled
   const sshReconnectTargetId = useAppStore((store) => {
     const connectionId = getConnectionIdFromState(store, worktreeId)
     // Why: runtime-owned SSH targets are internal plumbing users can't connect to, so a reconnect prompt would mislead.
@@ -1447,7 +1451,8 @@ export default function TerminalPane({
     setPaneCount,
     setPaneLayoutRevision,
     resolveExternalPaneDropTarget,
-    onExternalPaneDrop: handleExternalPaneDrop
+    onExternalPaneDrop: handleExternalPaneDrop,
+    onInitialRenderSettledRef
   })
 
   useEffect(() => {

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.react185.test.tsx
@@ -72,7 +72,9 @@ function renderSlot(): void {
         startupCwd={undefined}
         groupId={GROUP_ID}
         isWorktreeActive
+        isWorktreePresented
         isVisible
+        isPresented
         isActive
         activityTerminalPortal={null}
         onFocusOwningGroup={vi.fn()}

--- a/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneOverlayLayer.tsx
@@ -15,32 +15,19 @@ import { shouldMountBackgroundWorktreeTab } from '../terminal/background-termina
 import { useNativeChatToggleShortcut } from '../native-chat/use-native-chat-toggle-shortcut'
 import { shouldDeferParkedPtyExitTabClose } from './terminal-parked-tab-watchers'
 import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
-
-type TerminalOverlayAssignment = {
-  unifiedTabId: string
-  groupId: string
-  isActiveInGroup: boolean
-}
+import { useTerminalOverlayPresentation } from './use-terminal-overlay-presentation'
+import { buildTerminalOverlayAssignments } from './terminal-overlay-assignments'
+import {
+  FALLBACK_RECT_MIN_CHANGE_PX,
+  MIN_OVERLAY_FIT_HEIGHT_PX,
+  MIN_OVERLAY_FIT_WIDTH_PX,
+  shouldUseCssAnchorPositioning
+} from './terminal-overlay-positioning'
 
 const EMPTY_TERMINAL_TABS: readonly TerminalTab[] = []
 const EMPTY_UNIFIED_TABS: readonly Tab[] = []
 const EMPTY_GROUPS: readonly TabGroup[] = []
 const EMPTY_ACTIVITY_PORTALS: ActivityTerminalPortalTarget[] = []
-const HAS_CSS_ANCHOR_POSITIONING =
-  typeof CSS !== 'undefined' &&
-  CSS.supports('position-anchor', '--orca-terminal-overlay-probe') &&
-  CSS.supports('top', 'anchor(--orca-terminal-overlay-probe top)') &&
-  CSS.supports('width', 'anchor-size(--orca-terminal-overlay-probe width)')
-const MIN_OVERLAY_FIT_WIDTH_PX = 48
-const MIN_OVERLAY_FIT_HEIGHT_PX = 24
-const FALLBACK_RECT_MIN_CHANGE_PX = 1
-
-function shouldUseCssAnchorPositioning(): boolean {
-  return (
-    HAS_CSS_ANCHOR_POSITIONING &&
-    (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
-  )
-}
 
 type MeasuredFallbackRect = {
   top: number
@@ -57,12 +44,15 @@ type TerminalOverlaySlotProps = {
   startupCwd: string | undefined
   groupId: string | undefined
   isWorktreeActive: boolean
+  isWorktreePresented: boolean
   isVisible: boolean
+  isPresented: boolean
   isActive: boolean
   activityTerminalPortal: ActivityTerminalPortalTarget | null
   onFocusOwningGroup: ((groupId: string) => void) | undefined
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   leaveWorktreeIfEmpty: () => void
+  onInitialRenderSettled?: () => void
 }
 
 export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
@@ -73,12 +63,15 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
   startupCwd,
   groupId,
   isWorktreeActive,
+  isWorktreePresented,
   isVisible,
+  isPresented,
   isActive,
   activityTerminalPortal,
   onFocusOwningGroup,
   consumeSuppressedPtyExit,
-  leaveWorktreeIfEmpty
+  leaveWorktreeIfEmpty,
+  onInitialRenderSettled
 }: TerminalOverlaySlotProps): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
   const overlayRef = useRef<HTMLDivElement | null>(null)
@@ -187,6 +180,8 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
     }
   }, [anchorName, isVisible, measuredFallbackRect])
 
+  const showPresentedTerminal = isPresented && (isWorktreeActive || isWorktreePresented)
+  const isInteractive = isVisible && isPresented && isWorktreePresented
   const style: React.CSSProperties = useMemo(
     () =>
       anchorName && shouldUseCssAnchorPositioning()
@@ -197,9 +192,10 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
             left: `anchor(${anchorName} left)`,
             width: `anchor-size(${anchorName} width)`,
             height: `anchor-size(${anchorName} height)`,
-            display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
-            opacity: isVisible ? 1 : 0,
-            pointerEvents: isVisible ? 'auto' : 'none'
+            display:
+              isVisible || showPresentedTerminal || shouldMeasureHiddenStartup ? 'flex' : 'none',
+            opacity: showPresentedTerminal ? 1 : 0,
+            pointerEvents: isInteractive ? 'auto' : 'none'
           }
         : anchorName
           ? {
@@ -211,9 +207,10 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
               left: measuredFallbackRect?.left ?? 0,
               width: measuredFallbackRect?.width ?? '100%',
               height: measuredFallbackRect?.height ?? 'calc(100% - 32px)',
-              display: isVisible || shouldMeasureHiddenStartup ? 'flex' : 'none',
-              opacity: isVisible ? 1 : 0,
-              pointerEvents: isVisible ? 'auto' : 'none'
+              display:
+                isVisible || showPresentedTerminal || shouldMeasureHiddenStartup ? 'flex' : 'none',
+              opacity: showPresentedTerminal ? 1 : 0,
+              pointerEvents: isInteractive ? 'auto' : 'none'
             }
           : {
               position: 'absolute',
@@ -224,7 +221,14 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
               display: 'none',
               pointerEvents: 'none'
             },
-    [anchorName, isVisible, measuredFallbackRect, shouldMeasureHiddenStartup]
+    [
+      anchorName,
+      isInteractive,
+      isVisible,
+      measuredFallbackRect,
+      shouldMeasureHiddenStartup,
+      showPresentedTerminal
+    ]
   )
   const focusGroup = useCallback(() => {
     if (groupId !== undefined && onFocusOwningGroup) {
@@ -238,12 +242,14 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       tabId={terminalTabId}
       worktreeId={worktreeId}
       cwd={startupCwd ?? worktreePath}
-      isActive={isActive || activityTerminalPortal?.active === true}
+      isActive={
+        (isActive && isPresented && isWorktreePresented) || activityTerminalPortal?.active === true
+      }
       // Why: split-group changes reparent TabGroupPanel subtrees. Keeping the
       // TerminalPane mounted here preserves alt-screen TUI state while this
       // flag still lets hidden tabs throttle rendering.
-      isVisible={isVisible || activityTerminalPortal !== null}
-      isWorktreeActive={isWorktreeActive || activityTerminalPortal !== null}
+      isVisible={isVisible || showPresentedTerminal || activityTerminalPortal !== null}
+      isWorktreeActive={isWorktreeActive || isWorktreePresented || activityTerminalPortal !== null}
       isolatedPaneKey={activityTerminalPortal?.paneKey ?? null}
       onPtyExit={(ptyId) => {
         if (consumeSuppressedPtyExit(ptyId)) {
@@ -267,6 +273,7 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
         // store.closeTab was the path that closed pinned terminals silently.
         closeTerminalTab(terminalTabId, { onClosed: leaveWorktreeIfEmpty })
       }}
+      onInitialRenderSettled={onInitialRenderSettled}
     />
   )
 
@@ -283,6 +290,9 @@ export const TerminalOverlaySlot = memo(function TerminalOverlaySlot({
       ref={overlayRef}
       style={style}
       data-terminal-overlay-tab-id={terminalTabId}
+      data-terminal-overlay-presented={showPresentedTerminal ? 'true' : 'false'}
+      inert={!isInteractive}
+      aria-hidden={!isInteractive}
       onPointerDown={focusGroup}
       onFocusCapture={focusGroup}
     >
@@ -298,15 +308,18 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   worktreeId,
   worktreePath,
   isWorktreeActive,
+  isWorktreePresented = isWorktreeActive,
   coldParkTerminalPanes = false,
   shouldMeasureHiddenWorktree = false,
   activityTerminalPortals = EMPTY_ACTIVITY_PORTALS,
   backgroundMountTabIds = null,
-  activationDeferredMountTabIds = null
+  activationDeferredMountTabIds = null,
+  onInitialTerminalRenderSettled
 }: {
   worktreeId: string
   worktreePath: string
   isWorktreeActive: boolean
+  isWorktreePresented?: boolean
   coldParkTerminalPanes?: boolean
   shouldMeasureHiddenWorktree?: boolean
   activityTerminalPortals?: ActivityTerminalPortalTarget[]
@@ -316,6 +329,7 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
   /** Only cold-activation deferred tabs receive immediate parked watcher
    *  coverage; targeted mounts keep their existing delayed parking policy. */
   activationDeferredMountTabIds?: ReadonlySet<string> | null
+  onInitialTerminalRenderSettled?: (tabId: string) => void
 }): React.JSX.Element | null {
   const { terminalTabs, unifiedTabs, groups, activeGroupId } = useAppStore(
     useShallow((state) => ({
@@ -353,30 +367,12 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
     [focusGroup, worktreeId]
   )
 
-  const groupActiveTabById = useMemo(() => {
-    const lookup: Record<string, string | null | undefined> = {}
-    for (const group of groups) {
-      lookup[group.id] = group.activeTabId
-    }
-    return lookup
-  }, [groups])
+  const assignments = useMemo(
+    () => buildTerminalOverlayAssignments(groups, unifiedTabs),
+    [groups, unifiedTabs]
+  )
 
-  const assignments = useMemo(() => {
-    const entries = new Map<string, TerminalOverlayAssignment>()
-    for (const tab of unifiedTabs) {
-      if (tab.contentType !== 'terminal') {
-        continue
-      }
-      entries.set(tab.entityId, {
-        unifiedTabId: tab.id,
-        groupId: tab.groupId,
-        isActiveInGroup: groupActiveTabById[tab.groupId] === tab.id
-      })
-    }
-    return entries
-  }, [groupActiveTabById, unifiedTabs])
-
-  const parkedTerminalTabIds = useTerminalTabColdParking({
+  const { parkedTerminalTabIds, coldParkedTerminalTabIds } = useTerminalTabColdParking({
     worktreeId,
     terminalTabs,
     assignments,
@@ -386,6 +382,16 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
     activityTerminalPortals,
     activationDeferredMountTabIds
   })
+  const { presentedTerminalTabIdByGroup: presentationByScope, handleInitialRenderSettled } =
+    useTerminalOverlayPresentation({
+      groups,
+      terminalTabs,
+      assignments,
+      coldParkedTerminalTabIds,
+      isWorktreeActive,
+      activeGroupId,
+      onInitialTerminalRenderSettled
+    })
 
   if (!worktreePath) {
     return null
@@ -401,6 +407,9 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
           const assignment = assignments.get(terminalTab.id)
           const isVisible = Boolean(isWorktreeActive && assignment && assignment.isActiveInGroup)
           const isActive = Boolean(isVisible && assignment && assignment.groupId === activeGroupId)
+          const isPresented = Boolean(
+            assignment && presentationByScope.get(assignment.groupId) === terminalTab.id
+          )
           const activityTerminalPortal = findActivityTerminalPortal(activityTerminalPortals, {
             worktreeId,
             tabId: terminalTab.id
@@ -420,12 +429,15 @@ const TerminalPaneOverlayLayer = memo(function TerminalPaneOverlayLayer({
               startupCwd={terminalTab.startupCwd}
               groupId={assignment?.groupId}
               isWorktreeActive={isWorktreeActive}
+              isWorktreePresented={isWorktreePresented}
               isVisible={isVisible}
+              isPresented={isPresented}
               isActive={isActive}
               activityTerminalPortal={activityTerminalPortal}
               onFocusOwningGroup={focusOwningGroup}
               consumeSuppressedPtyExit={consumeSuppressedPtyExit}
               leaveWorktreeIfEmpty={leaveWorktreeIfEmpty}
+              onInitialRenderSettled={() => handleInitialRenderSettled(terminalTab.id)}
             />
           )
         })}

--- a/src/renderer/src/components/terminal-pane/terminal-initial-render-settle.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-initial-render-settle.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { scheduleTerminalInitialRenderSettled } from './terminal-initial-render-settle'
+
+vi.mock('@/lib/pane-manager/pane-terminal-output-scheduler', () => ({
+  waitForTerminalOutputParsed: vi.fn(() => Promise.resolve())
+}))
+
+describe('scheduleTerminalInitialRenderSettled', () => {
+  const frames: FrameRequestCallback[] = []
+
+  beforeEach(() => {
+    frames.length = 0
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('waits for replay and content before two frames paint', async () => {
+    let replaySettled = false
+    let contentReady = false
+    const onSettled = vi.fn()
+    scheduleTerminalInitialRenderSettled({
+      manager: { getPanes: () => [] },
+      isCurrent: () => true,
+      isReplaySettled: () => replaySettled,
+      isContentReady: () => contentReady,
+      onSettled
+    })
+    await Promise.resolve()
+
+    frames.shift()?.(0)
+    replaySettled = true
+    frames.shift()?.(16)
+    contentReady = true
+    frames.shift()?.(32)
+    expect(onSettled).not.toHaveBeenCalled()
+
+    frames.shift()?.(48)
+    expect(onSettled).toHaveBeenCalledOnce()
+  })
+
+  it('ignores queued work after cancellation', async () => {
+    const onSettled = vi.fn()
+    const cancel = scheduleTerminalInitialRenderSettled({
+      manager: { getPanes: () => [] },
+      isCurrent: () => true,
+      isReplaySettled: () => true,
+      isContentReady: () => true,
+      onSettled
+    })
+    await Promise.resolve()
+    cancel()
+
+    frames.shift()?.(0)
+    expect(onSettled).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-initial-render-settle.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-initial-render-settle.ts
@@ -1,0 +1,51 @@
+import type { Terminal } from '@xterm/xterm'
+import { waitForTerminalOutputParsed } from '@/lib/pane-manager/pane-terminal-output-scheduler'
+
+type InitialRenderPaneManager = {
+  getPanes(): { terminal: Terminal }[]
+}
+
+export function scheduleTerminalInitialRenderSettled(args: {
+  manager: InitialRenderPaneManager
+  isCurrent: () => boolean
+  isReplaySettled: () => boolean
+  isContentReady: () => boolean
+  onSettled: () => void
+}): () => void {
+  let cancelled = false
+  let frameId: number | null = null
+  let replaySettledFrameObserved = false
+  const scheduleFrame = (): void => {
+    frameId = requestAnimationFrame(() => {
+      frameId = null
+      if (cancelled || !args.isCurrent()) {
+        return
+      }
+      if (!args.isReplaySettled() || !args.isContentReady()) {
+        replaySettledFrameObserved = false
+        scheduleFrame()
+        return
+      }
+      if (!replaySettledFrameObserved) {
+        replaySettledFrameObserved = true
+        scheduleFrame()
+        return
+      }
+      args.onSettled()
+    })
+  }
+  void Promise.all(
+    args.manager.getPanes().map((pane) => waitForTerminalOutputParsed(pane.terminal))
+  ).then(() => {
+    if (cancelled || !args.isCurrent()) {
+      return
+    }
+    scheduleFrame()
+  })
+  return () => {
+    cancelled = true
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-overlay-assignments.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-overlay-assignments.ts
@@ -1,0 +1,23 @@
+import type { Tab, TabGroup } from '../../../../shared/types'
+
+export type TerminalOverlayAssignment = {
+  groupId: string
+  isActiveInGroup: boolean
+}
+
+export function buildTerminalOverlayAssignments(
+  groups: readonly TabGroup[],
+  unifiedTabs: readonly Tab[]
+): Map<string, TerminalOverlayAssignment> {
+  const activeTabByGroupId = new Map(groups.map((group) => [group.id, group.activeTabId]))
+  const assignments = new Map<string, TerminalOverlayAssignment>()
+  for (const tab of unifiedTabs) {
+    if (tab.contentType === 'terminal') {
+      assignments.set(tab.entityId, {
+        groupId: tab.groupId,
+        isActiveInGroup: activeTabByGroupId.get(tab.groupId) === tab.id
+      })
+    }
+  }
+  return assignments
+}

--- a/src/renderer/src/components/terminal-pane/terminal-overlay-positioning.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-overlay-positioning.ts
@@ -1,0 +1,16 @@
+const HAS_CSS_ANCHOR_POSITIONING =
+  typeof CSS !== 'undefined' &&
+  CSS.supports('position-anchor', '--orca-terminal-overlay-probe') &&
+  CSS.supports('top', 'anchor(--orca-terminal-overlay-probe top)') &&
+  CSS.supports('width', 'anchor-size(--orca-terminal-overlay-probe width)')
+
+export const MIN_OVERLAY_FIT_WIDTH_PX = 48
+export const MIN_OVERLAY_FIT_HEIGHT_PX = 24
+export const FALLBACK_RECT_MIN_CHANGE_PX = 1
+
+export function shouldUseCssAnchorPositioning(): boolean {
+  return (
+    HAS_CSS_ANCHOR_POSITIONING &&
+    (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ !== true
+  )
+}

--- a/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  COLD_PARKED_PRESENTATION_FALLBACK_MS,
+  useColdParkedTerminalPresentation
+} from './use-cold-parked-terminal-presentation'
+
+type HookProps = {
+  desiredTargetId: string | null
+  coldParkedTargetIds: ReadonlySet<string>
+}
+
+const availableTargetIds = new Set(['a', 'b', 'c'])
+
+function renderPresentationHook(initialProps: HookProps) {
+  return renderHook(
+    ({ desiredTargetId, coldParkedTargetIds }: HookProps) =>
+      useColdParkedTerminalPresentation({
+        desiredTargetByScope: new Map([['scope', desiredTargetId]]),
+        coldParkedTargetIds,
+        availableTargetIds
+      }),
+    { initialProps }
+  )
+}
+
+function presentedTargetId(
+  result: ReturnType<typeof renderPresentationHook>['result']
+): string | null | undefined {
+  return result.current.presentationByScope.get('scope')?.presentedTargetId
+}
+
+describe('useColdParkedTerminalPresentation', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('presents a warm target immediately', () => {
+    const hook = renderPresentationHook({
+      desiredTargetId: 'a',
+      coldParkedTargetIds: new Set()
+    })
+
+    hook.rerender({ desiredTargetId: 'b', coldParkedTargetIds: new Set() })
+
+    expect(presentedTargetId(hook.result)).toBe('b')
+  })
+
+  it('retains the prior target until a cold target settles', () => {
+    const hook = renderPresentationHook({
+      desiredTargetId: 'a',
+      coldParkedTargetIds: new Set()
+    })
+
+    hook.rerender({ desiredTargetId: 'b', coldParkedTargetIds: new Set(['b']) })
+    hook.rerender({ desiredTargetId: 'b', coldParkedTargetIds: new Set() })
+
+    expect(presentedTargetId(hook.result)).toBe('a')
+    act(() => hook.result.current.settleTarget('b'))
+    expect(presentedTargetId(hook.result)).toBe('b')
+  })
+
+  it('ignores a stale settle after another switch', () => {
+    const hook = renderPresentationHook({
+      desiredTargetId: 'a',
+      coldParkedTargetIds: new Set()
+    })
+
+    hook.rerender({ desiredTargetId: 'b', coldParkedTargetIds: new Set(['b']) })
+    hook.rerender({ desiredTargetId: 'c', coldParkedTargetIds: new Set() })
+    act(() => hook.result.current.settleTarget('b'))
+
+    expect(presentedTargetId(hook.result)).toBe('c')
+  })
+
+  it('falls back when a cold target never settles', () => {
+    vi.useFakeTimers()
+    const hook = renderPresentationHook({
+      desiredTargetId: 'a',
+      coldParkedTargetIds: new Set()
+    })
+
+    hook.rerender({ desiredTargetId: 'b', coldParkedTargetIds: new Set(['b']) })
+    act(() => vi.advanceTimersByTime(COLD_PARKED_PRESENTATION_FALLBACK_MS))
+
+    expect(presentedTargetId(hook.result)).toBe('b')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.ts
+++ b/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+export const COLD_PARKED_PRESENTATION_FALLBACK_MS = 1_000
+
+type PresentationEntry = {
+  presentedTargetId: string | null
+  pendingTargetId: string | null
+}
+
+export type ColdParkedPresentationState = ReadonlyMap<string, PresentationEntry>
+
+type PresentationInputs = {
+  desiredTargetByScope: ReadonlyMap<string, string | null>
+  coldParkedTargetIds: ReadonlySet<string>
+  availableTargetIds: ReadonlySet<string>
+}
+
+function haveSameEntries(
+  left: ColdParkedPresentationState,
+  right: ColdParkedPresentationState
+): boolean {
+  if (left.size !== right.size) {
+    return false
+  }
+  for (const [scopeId, entry] of left) {
+    const other = right.get(scopeId)
+    if (
+      !other ||
+      entry.presentedTargetId !== other.presentedTargetId ||
+      entry.pendingTargetId !== other.pendingTargetId
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+export function createColdParkedPresentationState(
+  desiredTargetByScope: ReadonlyMap<string, string | null>
+): ColdParkedPresentationState {
+  return new Map(
+    Array.from(desiredTargetByScope, ([scopeId, targetId]) => [
+      scopeId,
+      { presentedTargetId: targetId, pendingTargetId: null }
+    ])
+  )
+}
+
+export function resolveColdParkedPresentation(
+  current: ColdParkedPresentationState,
+  inputs: PresentationInputs
+): ColdParkedPresentationState {
+  const next = new Map<string, PresentationEntry>()
+  for (const [scopeId, desiredTargetId] of inputs.desiredTargetByScope) {
+    const entry = current.get(scopeId) ?? {
+      presentedTargetId: null,
+      pendingTargetId: null
+    }
+    if (entry.pendingTargetId === desiredTargetId) {
+      next.set(scopeId, entry)
+      continue
+    }
+    const canRetainPresentedTarget =
+      entry.presentedTargetId !== null && inputs.availableTargetIds.has(entry.presentedTargetId)
+    const shouldWait =
+      desiredTargetId !== null &&
+      desiredTargetId !== entry.presentedTargetId &&
+      canRetainPresentedTarget &&
+      inputs.coldParkedTargetIds.has(desiredTargetId)
+    next.set(
+      scopeId,
+      shouldWait
+        ? { presentedTargetId: entry.presentedTargetId, pendingTargetId: desiredTargetId }
+        : { presentedTargetId: desiredTargetId, pendingTargetId: null }
+    )
+  }
+  return haveSameEntries(current, next) ? current : next
+}
+
+function settlePresentationTarget(
+  current: ColdParkedPresentationState,
+  desiredTargetByScope: ReadonlyMap<string, string | null>,
+  targetId: string
+): ColdParkedPresentationState {
+  let changed = false
+  const next = new Map(current)
+  for (const [scopeId, entry] of current) {
+    if (entry.pendingTargetId !== targetId || desiredTargetByScope.get(scopeId) !== targetId) {
+      continue
+    }
+    next.set(scopeId, { presentedTargetId: targetId, pendingTargetId: null })
+    changed = true
+  }
+  return changed ? next : current
+}
+
+export function useColdParkedTerminalPresentation(
+  inputs: PresentationInputs,
+  fallbackMs = COLD_PARKED_PRESENTATION_FALLBACK_MS
+): {
+  presentationByScope: ColdParkedPresentationState
+  settleTarget: (targetId: string) => void
+} {
+  const [committed, setCommitted] = useState<ColdParkedPresentationState>(() =>
+    createColdParkedPresentationState(inputs.desiredTargetByScope)
+  )
+  const latestInputsRef = useRef(inputs)
+  latestInputsRef.current = inputs
+  const presentationByScope = resolveColdParkedPresentation(committed, inputs)
+
+  useLayoutEffect(() => {
+    setCommitted((current) => resolveColdParkedPresentation(current, latestInputsRef.current))
+  }, [presentationByScope])
+
+  const settleTarget = useCallback((targetId: string) => {
+    setCommitted((current) => {
+      const latest = latestInputsRef.current
+      const resolved = resolveColdParkedPresentation(current, latest)
+      return settlePresentationTarget(resolved, latest.desiredTargetByScope, targetId)
+    })
+  }, [])
+
+  useEffect(() => {
+    const timers = new Set<number>()
+    const pendingTargetIds = new Set(
+      Array.from(presentationByScope.values(), (entry) => entry.pendingTargetId).filter(
+        (targetId): targetId is string => targetId !== null
+      )
+    )
+    for (const targetId of pendingTargetIds) {
+      timers.add(window.setTimeout(() => settleTarget(targetId), fallbackMs))
+    }
+    return () => {
+      for (const timer of timers) {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [fallbackMs, presentationByScope, settleTarget])
+
+  return { presentationByScope, settleTarget }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-overlay-presentation.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-overlay-presentation.ts
@@ -1,0 +1,75 @@
+import { useCallback, useMemo } from 'react'
+import type { TabGroup, TerminalTab } from '../../../../shared/types'
+import { useColdParkedTerminalPresentation } from './use-cold-parked-terminal-presentation'
+
+type TerminalOverlayAssignment = {
+  groupId: string
+  isActiveInGroup: boolean
+}
+
+export function useTerminalOverlayPresentation(args: {
+  groups: readonly TabGroup[]
+  terminalTabs: readonly TerminalTab[]
+  assignments: ReadonlyMap<string, TerminalOverlayAssignment>
+  coldParkedTerminalTabIds: ReadonlySet<string>
+  isWorktreeActive: boolean
+  activeGroupId: string | undefined
+  onInitialTerminalRenderSettled?: (tabId: string) => void
+}): {
+  presentedTerminalTabIdByGroup: ReadonlyMap<string, string | null>
+  handleInitialRenderSettled: (tabId: string) => void
+} {
+  const {
+    groups,
+    terminalTabs,
+    assignments,
+    coldParkedTerminalTabIds,
+    isWorktreeActive,
+    activeGroupId,
+    onInitialTerminalRenderSettled
+  } = args
+  const desiredTerminalTabByGroup = useMemo(() => {
+    const desired = new Map<string, string | null>()
+    for (const group of groups) {
+      desired.set(group.id, null)
+    }
+    for (const terminalTab of terminalTabs) {
+      const assignment = assignments.get(terminalTab.id)
+      if (assignment?.isActiveInGroup) {
+        desired.set(assignment.groupId, terminalTab.id)
+      }
+    }
+    return desired
+  }, [assignments, groups, terminalTabs])
+  const availableTerminalTabIds = useMemo(
+    () => new Set(terminalTabs.map((terminalTab) => terminalTab.id)),
+    [terminalTabs]
+  )
+  const { presentationByScope, settleTarget } = useColdParkedTerminalPresentation({
+    desiredTargetByScope: desiredTerminalTabByGroup,
+    coldParkedTargetIds: coldParkedTerminalTabIds,
+    availableTargetIds: availableTerminalTabIds
+  })
+  const presentedTerminalTabIdByGroup = useMemo(
+    () =>
+      new Map(
+        Array.from(presentationByScope, ([groupId, entry]) => [groupId, entry.presentedTargetId])
+      ),
+    [presentationByScope]
+  )
+  const handleInitialRenderSettled = useCallback(
+    (tabId: string) => {
+      settleTarget(tabId)
+      const assignment = assignments.get(tabId)
+      if (isWorktreeActive && assignment?.isActiveInGroup && assignment.groupId === activeGroupId) {
+        onInitialTerminalRenderSettled?.(tabId)
+      }
+    },
+    [activeGroupId, assignments, isWorktreeActive, onInitialTerminalRenderSettled, settleTarget]
+  )
+
+  return {
+    presentedTerminalTabIdByGroup,
+    handleInitialRenderSettled
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -62,6 +62,7 @@ import {
   replayTerminalLayout,
   restoreScrollbackBuffers
 } from './layout-serialization'
+import { scheduleTerminalInitialRenderSettled } from './terminal-initial-render-settle'
 import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
@@ -306,6 +307,7 @@ type UseTerminalPaneLifecycleDeps = {
   setPaneLayoutRevision: React.Dispatch<React.SetStateAction<number>>
   resolveExternalPaneDropTarget?: PaneExternalDropResolver
   onExternalPaneDrop?: PaneExternalDropHandler
+  onInitialRenderSettledRef: React.RefObject<(() => void) | undefined>
 }
 
 export function suppressIntentionalPaneCloseExit(
@@ -554,7 +556,8 @@ export function useTerminalPaneLifecycle({
   setPaneCount,
   setPaneLayoutRevision,
   resolveExternalPaneDropTarget,
-  onExternalPaneDrop
+  onExternalPaneDrop,
+  onInitialRenderSettledRef
 }: UseTerminalPaneLifecycleDeps): void {
   const terminalScrollbackRows = normalizeDesktopTerminalScrollbackRows(
     settings?.terminalScrollbackRows
@@ -718,6 +721,7 @@ export function useTerminalPaneLifecycle({
       initialLayoutRef.current = hydratedInitialScrollback.layout
     }
     let shouldPersistLayout = false
+    let cancelInitialRenderSettle: (() => void) | null = null
     const startupWithSetupSplitWait =
       startup && setupSplit
         ? { ...startup, waitForSetupSplitDirection: setupSplit.direction }
@@ -1517,6 +1521,28 @@ export function useTerminalPaneLifecycle({
     queueResizeAll(isActive)
     persistLayoutSnapshot()
     scheduleRuntimeGraphSync()
+    if (onInitialRenderSettledRef.current) {
+      cancelInitialRenderSettle = scheduleTerminalInitialRenderSettled({
+        manager,
+        isCurrent: () => managerRef.current === manager,
+        isReplaySettled: () => replayingPanesRef.current.size === 0,
+        isContentReady: () => {
+          const terminal = (manager.getActivePane() ?? manager.getPanes()[0])?.terminal
+          if (!terminal) {
+            return false
+          }
+          const buffer = terminal.buffer.active
+          const viewportEnd = Math.min(buffer.length, buffer.viewportY + terminal.rows)
+          for (let row = buffer.viewportY; row < viewportEnd; row += 1) {
+            if (buffer.getLine(row)?.translateToString(true).trim()) {
+              return true
+            }
+          }
+          return false
+        },
+        onSettled: () => onInitialRenderSettledRef.current?.()
+      })
+    }
 
     // Why: deliver the startup command via the PTY connection path (waits for shell readiness), not terminal.paste() which can lose input before the shell reads stdin.
     function onCliSplitPane(event: Event): void {
@@ -1587,6 +1613,7 @@ export function useTerminalPaneLifecycle({
     window.addEventListener(CLOSE_TERMINAL_PANE_EVENT, onCliClosePane)
 
     return () => {
+      cancelInitialRenderSettle?.()
       window.removeEventListener(SPLIT_TERMINAL_PANE_EVENT, onCliSplitPane)
       window.removeEventListener(CLOSE_TERMINAL_PANE_EVENT, onCliClosePane)
       const currentWorktreeTabs = useAppStore.getState().tabsByWorktree[worktreeId]

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -60,7 +60,10 @@ export function useTerminalTabColdParking(args: {
   /** Tabs cold activation keeps unmounted — parked-equivalent for watcher
    *  purposes. Targeted background restrictions intentionally stay bounded. */
   activationDeferredMountTabIds?: ReadonlySet<string> | null
-}): ReadonlySet<string> {
+}): {
+  parkedTerminalTabIds: ReadonlySet<string>
+  coldParkedTerminalTabIds: ReadonlySet<string>
+} {
   const {
     worktreeId,
     terminalTabs,
@@ -276,5 +279,5 @@ export function useTerminalTabColdParking(args: {
 
   useEffect(() => () => disposeParkedTerminalWatchersForWorktree(worktreeId), [worktreeId])
 
-  return parkedTerminalTabIds
+  return { parkedTerminalTabIds, coldParkedTerminalTabIds }
 }

--- a/tests/e2e/terminal-hidden-view-parking.spec.ts
+++ b/tests/e2e/terminal-hidden-view-parking.spec.ts
@@ -181,6 +181,87 @@ async function activateTerminalTab(page: Page, tabId: string): Promise<void> {
     .toBe(tabId)
 }
 
+type TerminalPresentationFrame = {
+  previousPresented: boolean
+  targetPresented: boolean
+  targetBufferContainsMarker: boolean
+}
+
+async function startTerminalPresentationObservation(
+  page: Page,
+  previousTabId: string,
+  targetTabId: string,
+  targetMarker: string
+): Promise<void> {
+  await page.evaluate(
+    ({ previousTabId, targetTabId, targetMarker }) => {
+      const observedWindow = window as Window & {
+        __terminalPresentationFrames?: TerminalPresentationFrame[]
+        __terminalPresentationObservationDone?: boolean
+      }
+      const frames: TerminalPresentationFrame[] = []
+      observedWindow.__terminalPresentationFrames = frames
+      observedWindow.__terminalPresentationObservationDone = false
+      const findOverlay = (tabId: string): HTMLElement | null =>
+        document.querySelector<HTMLElement>(`[data-terminal-overlay-tab-id="${CSS.escape(tabId)}"]`)
+      const isPresented = (tabId: string): boolean => {
+        const overlay = findOverlay(tabId)
+        return (
+          overlay?.dataset.terminalOverlayPresented === 'true' &&
+          getComputedStyle(overlay).display !== 'none' &&
+          getComputedStyle(overlay).opacity !== '0'
+        )
+      }
+      const sample = (): void => {
+        const targetPane =
+          window.__paneManagers?.get(targetTabId)?.getActivePane?.() ??
+          window.__paneManagers?.get(targetTabId)?.getPanes?.()[0]
+        const frame = {
+          previousPresented: isPresented(previousTabId),
+          targetPresented: isPresented(targetTabId),
+          targetBufferContainsMarker:
+            targetPane?.serializeAddon?.serialize?.().includes(targetMarker) === true
+        }
+        frames.push(frame)
+        if (frame.targetPresented) {
+          observedWindow.__terminalPresentationObservationDone = true
+          return
+        }
+        requestAnimationFrame(sample)
+      }
+      sample()
+    },
+    { previousTabId, targetTabId, targetMarker }
+  )
+}
+
+async function readTerminalPresentationObservation(
+  page: Page
+): Promise<TerminalPresentationFrame[]> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            (
+              window as Window & {
+                __terminalPresentationObservationDone?: boolean
+              }
+            ).__terminalPresentationObservationDone === true
+        ),
+      { timeout: 5_000, message: 'terminal presentation handoff did not settle' }
+    )
+    .toBe(true)
+  return page.evaluate(
+    () =>
+      (
+        window as Window & {
+          __terminalPresentationFrames?: TerminalPresentationFrame[]
+        }
+      ).__terminalPresentationFrames ?? []
+  )
+}
+
 async function createActiveTerminalTab(page: Page, worktreeId: string): Promise<string> {
   const tabId = await page.evaluate((worktreeId) => {
     const store = window.__store
@@ -311,6 +392,16 @@ test.describe('Terminal hidden view parking', () => {
       expect(tabBState.hasManager).toBe(true)
       expect(tabBState.paneCount).toBeGreaterThan(0)
 
+      const previouslyPresentedTabId = await getActiveTabId(orcaPage)
+      if (!previouslyPresentedTabId) {
+        throw new Error('parking reveal had no previously presented terminal tab')
+      }
+      await startTerminalPresentationObservation(
+        orcaPage,
+        previouslyPresentedTabId,
+        tabAId,
+        finalMarker
+      )
       await activateTerminalTab(orcaPage, tabAId)
       await waitForActiveTerminalManager(orcaPage, 30_000)
       const revealedSnapshot = await waitForPaneIdentitySnapshot(orcaPage, 1)
@@ -325,6 +416,20 @@ test.describe('Terminal hidden view parking', () => {
           message: 'parked rich TUI frame did not restore when the tab was revealed'
         })
         .toContain(finalMarker)
+
+      const presentationFrames = await readTerminalPresentationObservation(orcaPage)
+      const firstTargetFrame = presentationFrames.findIndex((frame) => frame.targetPresented)
+      expect(firstTargetFrame).toBeGreaterThan(0)
+      expect(
+        presentationFrames[firstTargetFrame]?.targetBufferContainsMarker,
+        JSON.stringify(presentationFrames)
+      ).toBe(true)
+      expect(
+        presentationFrames
+          .slice(0, firstTargetFrame)
+          .every((frame) => frame.previousPresented && !frame.targetPresented),
+        JSON.stringify(presentationFrames)
+      ).toBe(true)
 
       const content = await getTerminalContent(orcaPage, 12_000)
       expect(content).toContain(`Frame ${String(PARKED_FRAME_COUNT - 1).padStart(3, '0')}`)


### PR DESCRIPTION
## ELI5

When Orca parked a terminal to save resources, switching back was like changing a TV input: we briefly showed the empty new screen before its picture finished loading. The terminal contents were still safe, but that blank frame looked like a flash.

This keeps the old picture on screen (but non-interactive) until the restored terminal has content and has actually painted. Then it swaps in one step.

## Root cause

#10692 fixed the bold/WebGL behavior, but cold parking still fully unmounted xterm. On reveal, logical activation and visual presentation happened together, so React could expose an empty terminal container before saved-buffer replay and renderer paint completed.

## Fix

- Separate logical activation from visual presentation at both worktree and terminal-tab levels.
- Keep the previously presented terminal visible but inert while the cold target restores offscreen.
- Handoff only after xterm parsing settles, replay drains, visible viewport content exists, and two animation frames paint.
- Ignore stale settle callbacks and retain a 1-second escape hatch so a failed renderer cannot pin the old surface forever.
- Apply the behavior to split-pane overlays and the legacy worktree surface.

## Visual proof

![terminal-handoff-proof.gif](https://github.com/user-attachments/assets/a1a117cc-70cf-4f7e-9b0f-c7919923f819)

The regression test samples every animation frame across the switch. It proves that:

1. every frame before takeover still presents the previous terminal;
2. the restoring target is never presented early; and
3. the first frame that presents the target already contains the restored rich-TUI marker.

The recorded Electron regression passed **3/3 consecutive runs**:

```bash
SKIP_BUILD=1 ORCA_E2E_RECORD_VIDEO=1 node_modules/.bin/playwright test \
  tests/e2e/terminal-hidden-view-parking.spec.ts \
  --config tests/playwright.config.ts \
  --project electron-headless \
  --workers=1 \
  --repeat-each=3 \
  --grep 'parks a hidden terminal tab and restores rich TUI output on reveal'
```

## Verification

- 109 focused unit tests across 7 files
- Node, CLI, and web typechecks
- full `oxlint --quiet`
- max-lines ratchet (no new bypasses)
- E2E-mode Electron build
- recorded frame-by-frame regression: 3/3 passed
