### PR TITLE
fix(browser): restore host focus after synthetic mouse presses

### DIFF
--- a/src/main/browser/cdp-bridge-integration.test.ts
+++ b/src/main/browser/cdp-bridge-integration.test.ts
@@ -11,7 +11,9 @@ const { webContentsFromIdMock } = vi.hoisted(() => ({
 }))
 
 vi.mock('electron', () => ({
-  webContents: { fromId: webContentsFromIdMock },
+  // Why: cdp-bridge's host focus guard (#8139) reads the focused contents around
+  // synthetic mouse presses; the integration mock needs the same surface.
+  webContents: { fromId: webContentsFromIdMock, getFocusedWebContents: vi.fn(() => null) },
   shell: { openExternal: vi.fn() },
   ipcMain: { handle: vi.fn(), removeHandler: vi.fn(), on: vi.fn() },
   app: { getPath: vi.fn(() => '/tmp'), isPackaged: false }

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -182,27 +182,28 @@ export class CdpBridge {
       const { cx, cy } = await this.getPageCoordinates(guest, node, localCenter.cx, localCenter.cy)
 
       // Why: the synthetic press hands native focus to the guest, so remember who
-      // owned it and give it back (#8139).
+      // owned it and give it back even if a dispatch rejects (#8139).
       const hostFocus = captureHostFocus(guest.id)
-
-      // Why: mouseMoved fires mouseenter/mouseover so sites reveal hover-dependent menus/targets before the click lands.
-      await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x: cx, y: cy })
-      await sender('Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: cx,
-        y: cy,
-        button: 'left',
-        clickCount: 1
-      })
-      await sender('Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: cx,
-        y: cy,
-        button: 'left',
-        clickCount: 1
-      })
-
-      restoreHostFocus(hostFocus)
+      try {
+        // Why: mouseMoved fires mouseenter/mouseover so sites reveal hover-dependent menus/targets before the click lands.
+        await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x: cx, y: cy })
+        await sender('Input.dispatchMouseEvent', {
+          type: 'mousePressed',
+          x: cx,
+          y: cy,
+          button: 'left',
+          clickCount: 1
+        })
+        await sender('Input.dispatchMouseEvent', {
+          type: 'mouseReleased',
+          x: cx,
+          y: cy,
+          button: 'left',
+          clickCount: 1
+        })
+      } finally {
+        restoreHostFocus(hostFocus)
+      }
 
       return { clicked: element }
     })
@@ -244,34 +245,35 @@ export class CdpBridge {
       const to = await this.getPageCoordinates(guest, toNode, toLocal.cx, toLocal.cy)
 
       // Why: the synthetic press hands native focus to the guest, so remember who
-      // owned it and give it back (#8139).
+      // owned it and give it back even if a dispatch rejects (#8139).
       const hostFocus = captureHostFocus(guest.id)
+      try {
+        // Why: interpolate the drag so intermediate elements fire dragenter/dragover, which many drag-and-drop libs require.
+        await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x: from.cx, y: from.cy })
+        await sender('Input.dispatchMouseEvent', {
+          type: 'mousePressed',
+          x: from.cx,
+          y: from.cy,
+          button: 'left'
+        })
 
-      // Why: interpolate the drag so intermediate elements fire dragenter/dragover, which many drag-and-drop libs require.
-      await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x: from.cx, y: from.cy })
-      await sender('Input.dispatchMouseEvent', {
-        type: 'mousePressed',
-        x: from.cx,
-        y: from.cy,
-        button: 'left'
-      })
+        const steps = 10
+        for (let i = 1; i <= steps; i++) {
+          const x = from.cx + ((to.cx - from.cx) * i) / steps
+          const y = from.cy + ((to.cy - from.cy) * i) / steps
+          await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, buttons: 1 })
+          await new Promise((r) => setTimeout(r, 10))
+        }
 
-      const steps = 10
-      for (let i = 1; i <= steps; i++) {
-        const x = from.cx + ((to.cx - from.cx) * i) / steps
-        const y = from.cy + ((to.cy - from.cy) * i) / steps
-        await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x, y, buttons: 1 })
-        await new Promise((r) => setTimeout(r, 10))
+        await sender('Input.dispatchMouseEvent', {
+          type: 'mouseReleased',
+          x: to.cx,
+          y: to.cy,
+          button: 'left'
+        })
+      } finally {
+        restoreHostFocus(hostFocus)
       }
-
-      await sender('Input.dispatchMouseEvent', {
-        type: 'mouseReleased',
-        x: to.cx,
-        y: to.cy,
-        button: 'left'
-      })
-
-      restoreHostFocus(hostFocus)
 
       return { dragged: { from: fromElement, to: toElement } }
     })
@@ -474,31 +476,33 @@ export class CdpBridge {
         // owned it and give it back (#8139).
         const hostFocus = captureHostFocus(guest.id)
 
-        await this.scrollIntoView(refSender, node.backendDOMNodeId)
-        const localCenter = await this.getElementCenter(refSender, node.backendDOMNodeId)
-        const { cx, cy } = await this.getPageCoordinates(
-          guest,
-          node,
-          localCenter.cx,
-          localCenter.cy
-        )
-        await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x: cx, y: cy })
-        await sender('Input.dispatchMouseEvent', {
-          type: 'mousePressed',
-          x: cx,
-          y: cy,
-          button: 'left',
-          clickCount: 1
-        })
-        await sender('Input.dispatchMouseEvent', {
-          type: 'mouseReleased',
-          x: cx,
-          y: cy,
-          button: 'left',
-          clickCount: 1
-        })
-
-        restoreHostFocus(hostFocus)
+        try {
+          await this.scrollIntoView(refSender, node.backendDOMNodeId)
+          const localCenter = await this.getElementCenter(refSender, node.backendDOMNodeId)
+          const { cx, cy } = await this.getPageCoordinates(
+            guest,
+            node,
+            localCenter.cx,
+            localCenter.cy
+          )
+          await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x: cx, y: cy })
+          await sender('Input.dispatchMouseEvent', {
+            type: 'mousePressed',
+            x: cx,
+            y: cy,
+            button: 'left',
+            clickCount: 1
+          })
+          await sender('Input.dispatchMouseEvent', {
+            type: 'mouseReleased',
+            x: cx,
+            y: cy,
+            button: 'left',
+            clickCount: 1
+          })
+        } finally {
+          restoreHostFocus(hostFocus)
+        }
 
         // Why: custom checkboxes may not toggle from a coordinate click; verify state and fall back to programmatic .click().
         try {

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: the CDP bridge owns debugger lifecycle, ref map management, command serialization, and all browser interaction logic in one module so the browser automation boundary stays coherent. */
 import { webContents } from 'electron'
+import { captureHostFocus, restoreHostFocus } from './host-focus-guard'
 import type {
   BrowserCaptureStartResult,
   BrowserCaptureStopResult,
@@ -180,6 +181,10 @@ export class CdpBridge {
       const localCenter = await this.getElementCenter(refSender, node.backendDOMNodeId)
       const { cx, cy } = await this.getPageCoordinates(guest, node, localCenter.cx, localCenter.cy)
 
+      // Why: the synthetic press hands native focus to the guest, so remember who
+      // owned it and give it back (#8139).
+      const hostFocus = captureHostFocus(guest.id)
+
       // Why: mouseMoved fires mouseenter/mouseover so sites reveal hover-dependent menus/targets before the click lands.
       await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x: cx, y: cy })
       await sender('Input.dispatchMouseEvent', {
@@ -196,6 +201,8 @@ export class CdpBridge {
         button: 'left',
         clickCount: 1
       })
+
+      restoreHostFocus(hostFocus)
 
       return { clicked: element }
     })
@@ -236,6 +243,10 @@ export class CdpBridge {
       const toLocal = await this.getElementCenter(toSender, toNode.backendDOMNodeId)
       const to = await this.getPageCoordinates(guest, toNode, toLocal.cx, toLocal.cy)
 
+      // Why: the synthetic press hands native focus to the guest, so remember who
+      // owned it and give it back (#8139).
+      const hostFocus = captureHostFocus(guest.id)
+
       // Why: interpolate the drag so intermediate elements fire dragenter/dragover, which many drag-and-drop libs require.
       await sender('Input.dispatchMouseEvent', { type: 'mouseMoved', x: from.cx, y: from.cy })
       await sender('Input.dispatchMouseEvent', {
@@ -259,6 +270,8 @@ export class CdpBridge {
         y: to.cy,
         button: 'left'
       })
+
+      restoreHostFocus(hostFocus)
 
       return { dragged: { from: fromElement, to: toElement } }
     })
@@ -457,6 +470,10 @@ export class CdpBridge {
       })) as { result: { value: boolean } }
 
       if (currentState.value !== checked) {
+        // Why: the synthetic press hands native focus to the guest, so remember who
+        // owned it and give it back (#8139).
+        const hostFocus = captureHostFocus(guest.id)
+
         await this.scrollIntoView(refSender, node.backendDOMNodeId)
         const localCenter = await this.getElementCenter(refSender, node.backendDOMNodeId)
         const { cx, cy } = await this.getPageCoordinates(
@@ -480,6 +497,8 @@ export class CdpBridge {
           button: 'left',
           clickCount: 1
         })
+
+        restoreHostFocus(hostFocus)
 
         // Why: custom checkboxes may not toggle from a coordinate click; verify state and fall back to programmatic .click().
         try {

--- a/src/main/browser/host-focus-guard.test.ts
+++ b/src/main/browser/host-focus-guard.test.ts
@@ -89,6 +89,27 @@ describe('host focus guard', () => {
       expect(focusedMock).not.toHaveBeenCalled()
     })
 
+    it('still restores when the dispatch that stole focus rejected', async () => {
+      const host = makeContents(1)
+      const guest = makeContents(42)
+      focusedMock.mockReturnValue(asWebContents(guest))
+
+      // Why: callers wrap the mouse dispatch in try/finally so a rejected or
+      // timed-out press cannot strand focus on the guest (#8139).
+      const captured = asWebContents(host)
+      await expect(
+        (async () => {
+          try {
+            throw new Error('Input.dispatchMouseEvent timed out')
+          } finally {
+            restoreHostFocus(captured)
+          }
+        })()
+      ).rejects.toThrow('timed out')
+
+      expect(host.focus).toHaveBeenCalledTimes(1)
+    })
+
     it('restores when focus landed on some third view', () => {
       const host = makeContents(1)
       focusedMock.mockReturnValue(asWebContents(makeContents(7)))

--- a/src/main/browser/host-focus-guard.test.ts
+++ b/src/main/browser/host-focus-guard.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { webContents } from 'electron'
+import { captureHostFocus, restoreHostFocus } from './host-focus-guard'
+
+vi.mock('electron', () => ({
+  webContents: { getFocusedWebContents: vi.fn() }
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const asWebContents = (value: unknown): any => value
+
+function makeContents(id: number, destroyed = false) {
+  return {
+    id,
+    isDestroyed: () => destroyed,
+    focus: vi.fn()
+  }
+}
+
+const focusedMock = vi.mocked(webContents.getFocusedWebContents)
+
+// Why: a synthetic mousePressed into an automation guest hands native focus to
+// that guest, pulling the caret out of whatever pane the user was typing in
+// (#8139). These tests pin the capture/restore contract that hands it back.
+describe('host focus guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('captureHostFocus', () => {
+    it('returns the focused host contents when a different view owns focus', () => {
+      const host = makeContents(1)
+      focusedMock.mockReturnValue(asWebContents(host))
+
+      expect(captureHostFocus(42)).toBe(host)
+    })
+
+    it('returns null when the guest already owns focus', () => {
+      const guest = makeContents(42)
+      focusedMock.mockReturnValue(asWebContents(guest))
+
+      expect(captureHostFocus(42)).toBeNull()
+    })
+
+    it('returns null when nothing is focused', () => {
+      focusedMock.mockReturnValue(asWebContents(null))
+
+      expect(captureHostFocus(42)).toBeNull()
+    })
+
+    it('returns null when the focused contents is already destroyed', () => {
+      focusedMock.mockReturnValue(asWebContents(makeContents(1, true)))
+
+      expect(captureHostFocus(42)).toBeNull()
+    })
+  })
+
+  describe('restoreHostFocus', () => {
+    it('re-focuses the host after the guest stole focus', () => {
+      const host = makeContents(1)
+      const guest = makeContents(42)
+      focusedMock.mockReturnValue(asWebContents(guest))
+
+      restoreHostFocus(asWebContents(host))
+
+      expect(host.focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not re-focus when the host never lost focus', () => {
+      const host = makeContents(1)
+      focusedMock.mockReturnValue(asWebContents(host))
+
+      restoreHostFocus(asWebContents(host))
+
+      expect(host.focus).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when nothing was captured', () => {
+      expect(() => restoreHostFocus(null)).not.toThrow()
+      expect(focusedMock).not.toHaveBeenCalled()
+    })
+
+    it('does not touch a host that was destroyed while the click ran', () => {
+      const host = makeContents(1, true)
+
+      restoreHostFocus(asWebContents(host))
+
+      expect(host.focus).not.toHaveBeenCalled()
+      expect(focusedMock).not.toHaveBeenCalled()
+    })
+
+    it('restores when focus landed on some third view', () => {
+      const host = makeContents(1)
+      focusedMock.mockReturnValue(asWebContents(makeContents(7)))
+
+      restoreHostFocus(asWebContents(host))
+
+      expect(host.focus).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/main/browser/host-focus-guard.ts
+++ b/src/main/browser/host-focus-guard.ts
@@ -1,0 +1,40 @@
+import { webContents, type WebContents } from 'electron'
+
+/**
+ * Keeps background browser automation from stealing the host's keyboard focus.
+ *
+ * Why: `Input.dispatchMouseEvent` with `mousePressed` makes Chromium hand native
+ * focus to the guest view that received the press. Unlike `Input.insertText`
+ * (#7041 DOM.focus replay) and `Runtime.evaluate` (deliberately not focused),
+ * the synthetic mouse path had no compensation, so an agent clicking in a
+ * background tab pulled the caret out of whatever pane the user was typing in.
+ *
+ * DOM focus still follows the click — only the OS/app-level focus owner is
+ * handed back, so subsequent automation that relies on `document.activeElement`
+ * is unaffected.
+ */
+export function captureHostFocus(guestId: number): WebContents | null {
+  const focused = webContents.getFocusedWebContents()
+  if (!focused || focused.isDestroyed()) {
+    return null
+  }
+  // Why: the guest already owning focus means the user is driving that view, so
+  // restoring afterwards would be a no-op at best and a focus fight at worst.
+  if (focused.id === guestId) {
+    return null
+  }
+  return focused
+}
+
+export function restoreHostFocus(prior: WebContents | null): void {
+  if (!prior || prior.isDestroyed()) {
+    return
+  }
+  const current = webContents.getFocusedWebContents()
+  // Why: only restore when the press actually moved focus; re-focusing an
+  // already-focused WebContents can churn selection in some editors.
+  if (current && current.id === prior.id) {
+    return
+  }
+  prior.focus()
+}

--- a/src/main/browser/host-focus-guard.ts
+++ b/src/main/browser/host-focus-guard.ts
@@ -1,25 +1,14 @@
 import { webContents, type WebContents } from 'electron'
 
-/**
- * Keeps background browser automation from stealing the host's keyboard focus.
- *
- * Why: `Input.dispatchMouseEvent` with `mousePressed` makes Chromium hand native
- * focus to the guest view that received the press. Unlike `Input.insertText`
- * (#7041 DOM.focus replay) and `Runtime.evaluate` (deliberately not focused),
- * the synthetic mouse path had no compensation, so an agent clicking in a
- * background tab pulled the caret out of whatever pane the user was typing in.
- *
- * DOM focus still follows the click — only the OS/app-level focus owner is
- * handed back, so subsequent automation that relies on `document.activeElement`
- * is unaffected.
- */
+// Why: a synthetic mousePressed hands native focus to the guest that received it,
+// pulling the caret out of the pane the user was typing in (#8139). DOM focus still
+// follows the click — only the OS-level focus owner is handed back.
 export function captureHostFocus(guestId: number): WebContents | null {
   const focused = webContents.getFocusedWebContents()
   if (!focused || focused.isDestroyed()) {
     return null
   }
-  // Why: the guest already owning focus means the user is driving that view, so
-  // restoring afterwards would be a no-op at best and a focus fight at worst.
+  // Why: the guest already owning focus means the user is driving that view.
   if (focused.id === guestId) {
     return null
   }
@@ -31,8 +20,7 @@ export function restoreHostFocus(prior: WebContents | null): void {
     return
   }
   const current = webContents.getFocusedWebContents()
-  // Why: only restore when the press actually moved focus; re-focusing an
-  // already-focused WebContents can churn selection in some editors.
+  // Why: re-focusing an already-focused WebContents can churn selection.
   if (current && current.id === prior.id) {
     return
   }


### PR DESCRIPTION
## Summary

Background browser automation stole the host's keyboard focus on every click, pulling the caret out of whatever pane the user was typing in.

`Input.dispatchMouseEvent` with `mousePressed` makes Chromium hand native focus to the guest view that received the press. The two neighbouring input paths already compensate for this — the synthetic mouse path did not:

| CDP path | orca command | Compensation today |
|---|---|---|
| `Input.insertText` | `fill`, `type` | `DOM.focus` replay (#7041) + `webContents.focus()` |
| `Runtime.evaluate` | `eval` | Deliberately excluded from auto-focus |
| **`Input.dispatchMouseEvent`** | **`click`, `drag`, `check`** | **none** |

The exclusion for `Runtime.evaluate` already states the intent in `cdp-ws-proxy.ts`:

> Do not auto-focus generic `Runtime.evaluate`/`callFunctionOn` traffic: wait polling and read-only JS probes use those methods heavily, and **focusing on every eval steals the user's foreground window while background automation is running**.

This PR completes that intent for the remaining path.

New `host-focus-guard.ts` captures the focused host `WebContents` before dispatching synthetic mouse events and hands focus back afterwards, in a `finally` so a rejected or timed-out dispatch cannot strand focus on the guest. Applied to `click`, `drag`, `check`.

**DOM focus still follows the click** — only the OS/app-level focus owner is restored, so automation that relies on `document.activeElement` (e.g. `click` then `fill`) is unaffected.

Guarded edge cases: guest already owns focus → no restore (the user is driving that view); captured contents destroyed mid-click → no-op; focus never moved → no re-focus (re-focusing an already-focused `WebContents` can churn selection).

## Screenshots

`No visual change` — main-process focus routing only, no UI surface touched.

## Testing

- [ ] `pnpm lint` — fails on `main` too, in files this PR does not touch. `verify:localization-coverage` rejects untranslated `"Ghostty"` keywords in `terminal-advanced-platform-search.ts` / `terminal-pane-appearance-search.ts` (last touched by #10628). Deliberately **not** silenced via `config/localization-coverage-allowlist.json` here, since those strings belong to another change. `oxlint` reports 0 findings on the four files changed in this PR.
- [x] `pnpm typecheck` — exit 0
- [ ] `pnpm test` — 3462 passed / 8 files failed, **all from my local Node version, not from the repo or this PR.** The repo pins `engines.node: 24`; I ran on v25.8.1, where the global `localStorage` shadows the jsdom one. Every one of the 43 failures is `window.localStorage.clear/getItem/removeItem is not a function` in `src/relay/` and `src/renderer/` — none in `src/main/browser/`, and they reproduce identically on unmodified `origin/main` (verified in a detached worktree). CI runs Node 24, so it is authoritative here.
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/` — **29 files, 526 passed**, the module this PR changes
- [ ] `pnpm build` — not run
- [x] Added tests: `host-focus-guard.test.ts` covers capture/restore, guest-already-focused, destroyed contents, no-op restoration, third-view focus change, and the rejection path (dispatch throws → restore still runs)

## AI Review Report

Reviewed with Claude (Sonnet 4.5) plus an independent Codex pass used adversarially against my own conclusions.

**Risks checked and what changed as a result**

- **Rejection path** — flagged by CodeRabbit and fixed in `96f4b64d`: the first revision restored focus after the awaits, so a rejected or timed-out dispatch skipped restoration and left focus on the guest — the exact failure mode the guard exists to prevent. Now wrapped in `try/finally` at all three call sites, with a test asserting restoration on throw.
- **Over-restoring** — re-focusing an already-focused `WebContents` can churn selection in some editors, and restoring when the guest legitimately owns focus would start a focus fight. Both guarded, both tested.
- **Scope of the claim** — Codex pushed back on inferring "eval is safe" from a single measurement window. Rule-of-three on the sample gives roughly a 1.8% per-command upper bound, so the finding is stated as "`click` is the trigger" rather than "the other paths are proven risk-free"; `type`/`inserttext` are explicitly left out of scope below.
- **Instrument validity** — `document.hasFocus()` never returns true for these guest views (consistent with #10375/#10376 and Electron 43+ tracking `WebContentsView` focus more strictly), so it was discarded as a measurement tool and the finding rests on order-reversed observation instead.

**Cross-platform**: reviewed explicitly. The change uses only `webContents.getFocusedWebContents()`, `isDestroyed()` and `focus()` — no platform branches, no paths, no shell, no shortcuts or labels. `focus()` semantics differ per platform in *how* the OS raises a view, but the guard only restores whatever owned focus beforehand, so it cannot introduce a platform-specific ordering that did not already exist. The measurements were taken on macOS; the logic is platform-neutral but has not been exercised on Linux or Windows.

## Security Audit

- **Input handling** — no user input parsed; the only inputs are an integer `guestId` and a `WebContents` handle obtained from Electron.
- **Command execution / path handling** — none introduced.
- **Auth / secrets** — none touched. No credentials, tokens or storage read or written.
- **IPC** — no new IPC surface. The guard runs inside existing main-process CDP command handlers.
- **Privilege / cross-view exposure** — the restore target is captured from `getFocusedWebContents()` immediately before dispatch and is only ever handed focus back to itself; the guard cannot move focus to a view that did not already hold it. It never reads or writes guest content.
- **Denial of service** — `restoreHostFocus` is a bounded, non-recursive call with no retry loop; the `finally` placement means it runs exactly once per operation.
- **Follow-up** — none identified.

## Notes

**Repro** — related to #8139, which was blocked at `cannot_repro`:

> Needs an isolated computer-use automation that asserts keyboard focus ownership during agent typing. Not reproduced here.

It did not reproduce because **the trigger is not in the typing path**. Measured on 1.4.158 (macOS), driving a scratch `file://` tab while a human typed continuously in a terminal pane in the same window:

| Command | Commands issued | Caret in user's pane |
|---|---|---|
| `snapshot` / `get` / `is` / `network` | 32 | held |
| `eval` (DOM `.click()` + value set) | 224 @ 1.5/s | held |
| **`fill`** | 37 + 38, both orders | **held** |
| **`click`** | 39 + 38, both orders | **lost** |

Order-reversed crossover, excluding a warm-up or time-of-day confound:

| Run | Order | click segment | fill segment |
|---|---|---|---|
| 1 | click → fill | caret lost | caret held |
| 2 | fill → click | caret lost | caret held |

Each segment carried execution evidence (a page-side click counter and the final input value) so a silently-skipped command could not be mistaken for a clean run.

**Scope / what this does not cover**

- Only `Input.dispatchMouseEvent` is changed. `Input.insertText` (`type`, `inserttext`) and `Page.bringToFront` (`tab switch --focus`) still call `webContents.focus()` by design; `type`/`inserttext` were not measured.
- Marked **Related to** rather than **Fixes** #8139 for that reason — the reporter described typing, and I only have evidence for the mouse path. Happy to retarget if a maintainer confirms the remaining paths are in scope.
- Interaction with #10376 (`Emulation.setFocusEmulationEnabled`) is untested. That PR touches `cdp-bridge.ts` and `cdp-ws-proxy.ts` and changes what `document.hasFocus()` reports; this change is orthogonal (OS-level focus owner, not page-level focus emulation) but the two are worth verifying together. GitHub currently reports this branch as mergeable against `main`.
- Verified on macOS only.

**Test-side change**: `cdp-bridge-integration.test.ts` needed `getFocusedWebContents` added to its `electron` mock; that is the only non-source edit.

## ELI5

When an agent clicked something in a browser tab in the background, your computer decided the browser was now the thing you were typing into — so your cursor vanished out of the terminal mid-sentence. Typing and running scripts already knew not to do that. Clicking didn't. Now it puts your cursor back where it was.
