### PR TITLE
fix(agent-status): clear session on reclassification

### DIFF
--- a/config/localization-coverage-allowlist.json
+++ b/config/localization-coverage-allowlist.json
@@ -40,5 +40,33 @@
     "text": "Idioma",
     "dynamic": false,
     "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/terminal-advanced-platform-search.ts",
+    "kind": "object-property:keywords",
+    "text": "Ghostty",
+    "dynamic": false,
+    "count": 2
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/terminal-advanced-platform-search.ts",
+    "kind": "object-property:keywords",
+    "text": "ghostty",
+    "dynamic": false,
+    "count": 2
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/terminal-pane-appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "Ghostty",
+    "dynamic": false,
+    "count": 1
+  },
+  {
+    "filePath": "src/renderer/src/components/settings/terminal-pane-appearance-search.ts",
+    "kind": "object-property:keywords",
+    "text": "ghostty",
+    "dynamic": false,
+    "count": 1
   }
 ]

--- a/src/main/agent-hooks/agent-status-reclassification-provider-session.test.ts
+++ b/src/main/agent-hooks/agent-status-reclassification-provider-session.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { AgentHookServer } from './server'
+
+const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('agent status reclassification provider session', () => {
+  it('drops the incoming provider session when the pane keeps another agent identity', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const server = new AgentHookServer()
+
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        providerSession: { key: 'session_id', id: 'codex-session' },
+        payload: { state: 'working', prompt: 'parent task', agentType: 'codex' }
+      },
+      'connection-1'
+    )
+
+    vi.setSystemTime(1_001)
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        providerSession: {
+          key: 'session_id',
+          id: 'claude-session',
+          transcriptPath: '/home/user/.claude/projects/repo/claude-session.jsonl'
+        },
+        payload: { state: 'working', prompt: 'nested task', agentType: 'claude' }
+      },
+      'connection-1'
+    )
+
+    const status = server.getStatusSnapshot()[0]
+    expect(status).toMatchObject({ paneKey: PANE_KEY, agentType: 'codex' })
+    expect(status).not.toHaveProperty('providerSession')
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -955,6 +955,8 @@ export class AgentHookServer {
         ? rootContextPreservingPayload
         : {
             ...rootContextPreservingPayload,
+            // Why: provider session provenance belongs to the incoming agent, not the pane identity that replaced it.
+            providerSession: undefined,
             payload: {
               ...rootContextPreservingPayload.payload,
               agentType: identity.agentType


### PR DESCRIPTION
## Summary

Fixes #10792.

- Clear an incoming `providerSession` when `AgentHookServer` resolves the event to a different pane agent identity.
- Prevent cross-agent resume records such as a Codex pane paired with a Claude session id and transcript path.
- Add a regression test for the exact Codex/Claude reclassification sequence.
- Allowlist the intentionally untranslated `Ghostty` search keywords so localization coverage remains green.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` - full suite ran: 37,063 passed, 60 skipped, and 4 high-concurrency deadline tests failed. A grouped single-worker rerun of the three files passed 49/49. When the four failed cases were then run individually, the relay case and both Codex cases passed; the system SSH case still timed out during native dependency installation.
- [x] `pnpm build`
- [x] Added a regression test that fails on the prior cross-agent `providerSession` behavior.
- [x] Localization coverage passed with the reviewed `Ghostty` brand-name exclusions.

## AI Review Report

Reviewed the identity-resolution path, provider-session persistence, renderer fallback behavior, and cold-resume record construction. The main risk was clearing valid same-agent session metadata; the fix is restricted to the branch where resolved and incoming agent identities differ. Existing same-agent provider-session tests remain green.

Cross-platform compatibility was checked for macOS, Linux, and Windows. This change contains no platform-specific paths, shell commands, keyboard behavior, UI labels, or Electron platform branches. Local, folder-workspace, SSH, and relay inputs all converge on the same `AgentHookServer` normalization path, so the invariant applies consistently without changing routing.

## Security Audit

Reviewed the relay trust boundary and session metadata flow. The change only removes untrusted cross-agent session metadata after canonical payload normalization; it does not add input handling, command execution, filesystem access, authentication, secrets, dependencies, or IPC surface area. Clearing the mismatched metadata prevents an invalid session id from reaching a later resume command.

## Notes

- Individual reruns passed for `uses configured grace after a detached relay has accepted a socket client` (1.61s), `kills a hung server at the session deadline` (511ms), and `bounds a callback that stalls between RPC requests` (513ms).
- `deploys and speaks relay RPC over a system ssh process for ProxyUseFdpass targets` timed out at 20s while running the fixture's native dependency installation, before its RPC assertion.
- Build completed with a non-blocking local permission warning while attempting to link `/usr/local/bin/orca-dev`.
- No UI or provider-specific resume syntax changed.
- X handle: not provided in the contributor GitHub profile.
