### PR TITLE
fix(codex): isolate Orca hooks from the system Codex home

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "react-i18next": "^17.0.8",
     "serve-sim": "^0.1.40",
     "sherpa-onnx": "1.12.37",
+    "smol-toml": "1.6.1",
     "ssh2": "^1.17.0",
     "tweetnacl": "^1.0.3",
     "ws": "^8.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       sherpa-onnx:
         specifier: 1.12.37
         version: 1.12.37
+      smol-toml:
+        specifier: 1.6.1
+        version: 1.6.1
       ssh2:
         specifier: ^1.17.0
         version: 1.17.0

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -26,6 +26,7 @@ import {
   joinTomlBlocks,
   stripRuntimeOwnedTomlSections
 } from './config-toml-runtime-owned-sections'
+import { stripInlineCodexHookSections } from './config-toml-hooks'
 
 export function syncSystemConfigIntoManagedCodexHome(
   homes: CodexSettingsPromotionHomes = {
@@ -136,7 +137,7 @@ export function resolveCodexConfigMirrorSourceDirectory(systemHomePath: string):
 
 function prepareSystemConfigForRuntimeMirror(config: string, systemConfigDir: string): string {
   return rewriteRelativePathConfigValues(
-    normalizeDeprecatedCodexHookFeatureFlag(config),
+    stripInlineCodexHookSections(normalizeDeprecatedCodexHookFeatureFlag(config)),
     systemConfigDir
   )
 }

--- a/src/main/codex/config-toml-hooks.test.ts
+++ b/src/main/codex/config-toml-hooks.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { extractInlineCodexHooks, stripInlineCodexHookSections } from './config-toml-hooks'
+
+describe('Codex inline hook config', () => {
+  it('extracts event arrays while ignoring hooks.state tables', () => {
+    const config = [
+      'model = "gpt-5"',
+      '',
+      '[[hooks.Stop]]',
+      'matcher = "*"',
+      '[[hooks.Stop.hooks]]',
+      'type = "command"',
+      'command = "user-hook"',
+      'timeout = 12',
+      '',
+      '[hooks.state."source:stop:0:0"]',
+      'enabled = true',
+      'trusted_hash = "hash"',
+      ''
+    ].join('\n')
+
+    expect(extractInlineCodexHooks(config)).toEqual({
+      Stop: [
+        {
+          matcher: '*',
+          hooks: [{ type: 'command', command: 'user-hook', timeout: 12 }]
+        }
+      ]
+    })
+  })
+
+  it('removes event array tables byte-preservingly but keeps state and lookalike strings', () => {
+    const config = [
+      'model = "gpt-5"',
+      'notes = """',
+      '[[hooks.Fake]]',
+      '"""',
+      '',
+      '[[hooks.Stop]]',
+      'matcher = "*"',
+      '[[hooks.Stop.hooks]]',
+      'type = "command"',
+      'command = "user-hook"',
+      '',
+      '[hooks.state."source:stop:0:0"]',
+      'enabled = true',
+      ''
+    ].join('\n')
+
+    expect(stripInlineCodexHookSections(config)).toBe(
+      [
+        'model = "gpt-5"',
+        'notes = """',
+        '[[hooks.Fake]]',
+        '"""',
+        '',
+        '[hooks.state."source:stop:0:0"]',
+        'enabled = true',
+        ''
+      ].join('\n')
+    )
+  })
+
+  it('removes quoted event array tables while preserving quoted state tables', () => {
+    const config = [
+      'model = "gpt-5"',
+      '',
+      '[["hooks".Stop]]',
+      'matcher = "*"',
+      '[["hooks".Stop.hooks]]',
+      'type = "command"',
+      'command = "quoted-user-hook"',
+      '',
+      '["hooks".state."source:stop:0:0"]',
+      'enabled = true',
+      ''
+    ].join('\n')
+
+    expect(extractInlineCodexHooks(config)).toEqual({
+      Stop: [
+        {
+          matcher: '*',
+          hooks: [{ type: 'command', command: 'quoted-user-hook' }]
+        }
+      ]
+    })
+    expect(stripInlineCodexHookSections(config)).toBe(
+      [
+        'model = "gpt-5"',
+        '',
+        '["hooks".state."source:stop:0:0"]',
+        'enabled = true',
+        ''
+      ].join('\n')
+    )
+  })
+
+  it('rejects semantic hook declarations that cannot be removed byte-preservingly', () => {
+    const config = [
+      '[hooks]',
+      'Stop = [{ hooks = [{ type = "command", command = "inline-user-hook" }] }]',
+      ''
+    ].join('\n')
+
+    expect(extractInlineCodexHooks(config).Stop).toHaveLength(1)
+    expect(() => stripInlineCodexHookSections(config)).toThrow(
+      'unsupported inline Codex hook representation'
+    )
+  })
+})

--- a/src/main/codex/config-toml-hooks.ts
+++ b/src/main/codex/config-toml-hooks.ts
@@ -1,0 +1,87 @@
+import { parse } from 'smol-toml'
+import { isPlainObject, type HookDefinition } from '../agent-hooks/installer-utils'
+import {
+  createTomlLineScanState,
+  getTomlTableHeader,
+  isTomlStructuralLine,
+  updateTomlLineScanState
+} from './config-toml-line-scan'
+
+export function extractInlineCodexHooks(config: string): Record<string, HookDefinition[]> {
+  const parsed = parse(config)
+  if (!isPlainObject(parsed.hooks)) {
+    return {}
+  }
+
+  const hooks: Record<string, HookDefinition[]> = {}
+  for (const [eventName, value] of Object.entries(parsed.hooks)) {
+    if (!Array.isArray(value)) {
+      continue
+    }
+    const definitions: HookDefinition[] = []
+    for (const candidate of value) {
+      if (isHookDefinition(candidate)) {
+        definitions.push(candidate)
+      }
+    }
+    if (definitions.length > 0) {
+      hooks[eventName] = definitions
+    }
+  }
+  return hooks
+}
+
+export function stripInlineCodexHookSections(config: string): string {
+  const lines = config.split('\n')
+  const keptLines: string[] = []
+  let droppingHookSection = false
+  let scanState = createTomlLineScanState()
+
+  for (const line of lines) {
+    const header = isTomlStructuralLine(scanState) ? getTomlTableHeader(line) : null
+    if (header) {
+      droppingHookSection = isInlineCodexHookHeader(header)
+    }
+    if (!droppingHookSection) {
+      keptLines.push(line)
+    }
+    scanState = updateTomlLineScanState(scanState, line)
+  }
+  const stripped = keptLines.join('\n')
+  if (Object.keys(extractInlineCodexHooks(stripped)).length > 0) {
+    throw new Error('unsupported inline Codex hook representation')
+  }
+  return stripped
+}
+
+function isHookDefinition(value: unknown): value is HookDefinition {
+  if (!isPlainObject(value)) {
+    return false
+  }
+  const handlers = value.hooks
+  return (
+    handlers === undefined ||
+    (Array.isArray(handlers) &&
+      handlers.every(
+        (handler) =>
+          isPlainObject(handler) &&
+          handler.type === 'command' &&
+          typeof handler.command === 'string'
+      ))
+  )
+}
+
+function isInlineCodexHookHeader(header: string): boolean {
+  if (!header.trimStart().startsWith('[[')) {
+    return false
+  }
+  try {
+    const parsedHeader = parse(header)
+    return (
+      isPlainObject(parsedHeader.hooks) &&
+      Object.keys(parsedHeader.hooks).some((key) => key !== 'state')
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -36,7 +36,7 @@ export type CodexEventLabel =
   | 'stop'
 
 export type CodexTrustEntry = {
-  /** Path on disk to the hooks.json that declares the hook (the "key_source"). */
+  /** Path to the config.toml or hooks.json declaration (the "key_source"). */
   sourcePath: string
   /** Codex event label (snake_case). */
   eventLabel: CodexEventLabel
@@ -44,7 +44,7 @@ export type CodexTrustEntry = {
   groupIndex: number
   /** 0-based index of the handler within the matcher group's `hooks` array. */
   handlerIndex: number
-  /** The exact `command` string written to hooks.json. */
+  /** The exact `command` string in the hook declaration. */
   command: string
   /** Effective timeout in seconds; defaults to 600 when undefined, explicit values clamped to a minimum of 1. */
   timeoutSec?: number

--- a/src/main/codex/hook-service.test.ts
+++ b/src/main/codex/hook-service.test.ts
@@ -15,12 +15,14 @@ import { join } from 'node:path'
 import { spawn } from 'node:child_process'
 import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
+import { stringify } from 'smol-toml'
 import { createManagedCommandMatcher, wrapPosixHookCommand } from '../agent-hooks/installer-utils'
 import {
   computeTrustedHash,
   getCodexExplicitHomeHookSourcePath,
   normalizeCodexHookSourcePath,
-  upsertHookTrustEntriesInContent
+  upsertHookTrustEntriesInContent,
+  type CodexTrustEntry
 } from './config-toml-trust'
 
 const { getPathMock, homedirMock } = vi.hoisted(() => ({
@@ -127,6 +129,32 @@ function localManagedCodexEvents(): string[] {
     'SubagentStop',
     'UserPromptSubmit'
   ]
+}
+
+function writeLegacyFixtureAsInline(
+  systemCodexHome: string,
+  systemHooksPath: string,
+  trustEntries: CodexTrustEntry[],
+  baseConfig = 'model = "system-model"\n'
+): string {
+  const legacy = JSON.parse(readFileSync(systemHooksPath, 'utf-8')) as {
+    hooks: Record<string, unknown>
+  }
+  const systemTomlPath = join(systemCodexHome, 'config.toml')
+  const inlineConfig = `${baseConfig.trimEnd()}\n\n${stringify({ hooks: legacy.hooks })}`
+  // Why: trust-key canonicalization uses realpath when the declaration exists.
+  // Seed the file first so fixtures under macOS /var -> /private/var match the
+  // same key spelling a running Codex process writes.
+  writeFileSync(systemTomlPath, inlineConfig, 'utf-8')
+  writeFileSync(
+    systemTomlPath,
+    upsertHookTrustEntriesInContent(
+      inlineConfig,
+      trustEntries.map((entry) => ({ ...entry, sourcePath: systemTomlPath }))
+    ),
+    'utf-8'
+  )
+  return systemTomlPath
 }
 
 describe('CodexHookService', () => {
@@ -466,23 +494,19 @@ describe('CodexHookService', () => {
       )}\n`,
       'utf-8'
     )
-    writeFileSync(
-      join(systemCodexHome, 'config.toml'),
-      upsertHookTrustEntriesInContent('model = "system-model"\n', [
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: 'stop',
-          groupIndex: 0,
-          handlerIndex: 0,
-          command: 'user-hook',
-          timeoutSec: 12,
-          async: true,
-          matcher: '*',
-          statusMessage: 'Running user hook'
-        }
-      ]),
-      'utf-8'
-    )
+    writeLegacyFixtureAsInline(systemCodexHome, systemHooksPath, [
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: 'stop',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'user-hook',
+        timeoutSec: 12,
+        async: true,
+        matcher: '*',
+        statusMessage: 'Running user hook'
+      }
+    ])
 
     expect(new CodexHookService().install().state).toBe('installed')
 
@@ -504,6 +528,57 @@ describe('CodexHookService', () => {
     expect(runtimeToml).not.toContain(hookTrustHeader(`${systemHooksPath}:stop:0:0`, true))
   })
 
+  it('mirrors inline system hooks into runtime hooks.json without keeping a second representation', () => {
+    const systemCodexHome = join(tmpHome, '.codex')
+    const systemTomlPath = join(systemCodexHome, 'config.toml')
+    mkdirSync(systemCodexHome, { recursive: true })
+    const inlineConfig = [
+      'model = "system-model"',
+      '',
+      '[[hooks.Stop]]',
+      'matcher = "*"',
+      '',
+      '[[hooks.Stop.hooks]]',
+      'type = "command"',
+      'command = "inline-user-hook"',
+      'timeout = 12',
+      'statusMessage = "Running inline hook"',
+      ''
+    ].join('\n')
+    writeFileSync(
+      systemTomlPath,
+      upsertHookTrustEntriesInContent(inlineConfig, [
+        {
+          sourcePath: systemTomlPath,
+          eventLabel: 'stop',
+          groupIndex: 0,
+          handlerIndex: 0,
+          command: 'inline-user-hook',
+          timeoutSec: 12,
+          matcher: '*',
+          statusMessage: 'Running inline hook'
+        }
+      ]),
+      'utf-8'
+    )
+
+    expect(new CodexHookService().install().state).toBe('installed')
+
+    const managedCodexHome = join(userDataDir, 'codex-runtime-home', 'home')
+    const managedHooksPath = join(managedCodexHome, 'hooks.json')
+    const runtimeHooks = JSON.parse(readFileSync(managedHooksPath, 'utf-8')) as {
+      hooks: Record<string, { matcher?: string; hooks?: { command?: string }[] }[]>
+    }
+    expect(runtimeHooks.hooks.Stop?.[1]?.matcher).toBe('*')
+    expect(runtimeHooks.hooks.Stop?.[1]?.hooks?.[0]?.command).toBe('inline-user-hook')
+
+    const runtimeToml = readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')
+    expect(runtimeToml).not.toContain('[[hooks.Stop]]')
+    expect(runtimeToml).not.toContain('[[hooks.Stop.hooks]]')
+    expect(runtimeToml).toContain(hookTrustHeader(`${managedHooksPath}:stop:1:0`))
+    expect(runtimeToml).not.toContain(hookTrustHeader(`${systemTomlPath}:stop:0:0`))
+  })
+
   it('runs managed PostToolUse status before mirrored user hooks', () => {
     const systemCodexHome = join(tmpHome, '.codex')
     const systemHooksPath = join(systemCodexHome, 'hooks.json')
@@ -517,19 +592,15 @@ describe('CodexHookService', () => {
       })}\n`,
       'utf-8'
     )
-    writeFileSync(
-      join(systemCodexHome, 'config.toml'),
-      upsertHookTrustEntriesInContent('model = "system-model"\n', [
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: 'post_tool_use',
-          groupIndex: 0,
-          handlerIndex: 0,
-          command: 'slow-user-post-tool-hook'
-        }
-      ]),
-      'utf-8'
-    )
+    writeLegacyFixtureAsInline(systemCodexHome, systemHooksPath, [
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: 'post_tool_use',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'slow-user-post-tool-hook'
+      }
+    ])
 
     expect(new CodexHookService().install().state).toBe('installed')
 
@@ -572,26 +643,22 @@ describe('CodexHookService', () => {
       )}\n`,
       'utf-8'
     )
-    writeFileSync(
-      join(systemCodexHome, 'config.toml'),
-      upsertHookTrustEntriesInContent('model = "system-model"\n', [
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: 'stop',
-          groupIndex: 0,
-          handlerIndex: 0,
-          command: 'second-stop-hook'
-        },
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: 'stop',
-          groupIndex: 1,
-          handlerIndex: 0,
-          command: 'first-stop-hook'
-        }
-      ]),
-      'utf-8'
-    )
+    writeLegacyFixtureAsInline(systemCodexHome, systemHooksPath, [
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: 'stop',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'second-stop-hook'
+      },
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: 'stop',
+        groupIndex: 1,
+        handlerIndex: 0,
+        command: 'first-stop-hook'
+      }
+    ])
 
     expect(new CodexHookService().install().state).toBe('installed')
 
@@ -640,26 +707,22 @@ describe('CodexHookService', () => {
       )}\n`,
       'utf-8'
     )
-    writeFileSync(
-      join(systemCodexHome, 'config.toml'),
-      upsertHookTrustEntriesInContent('model = "system-model"\n', [
-        ...pluginCommands.map((command, handlerIndex) => ({
-          sourcePath: systemHooksPath,
-          eventLabel: stopEventLabel,
-          groupIndex: 0,
-          handlerIndex,
-          command
-        })),
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: stopEventLabel,
-          groupIndex: 0,
-          handlerIndex: pluginCommands.length,
-          command: userCommand
-        }
-      ]),
-      'utf-8'
-    )
+    writeLegacyFixtureAsInline(systemCodexHome, systemHooksPath, [
+      ...pluginCommands.map((command, handlerIndex) => ({
+        sourcePath: systemHooksPath,
+        eventLabel: stopEventLabel,
+        groupIndex: 0,
+        handlerIndex,
+        command
+      })),
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: stopEventLabel,
+        groupIndex: 0,
+        handlerIndex: pluginCommands.length,
+        command: userCommand
+      }
+    ])
 
     expect(new CodexHookService().install().state).toBe('installed')
 
@@ -707,8 +770,7 @@ describe('CodexHookService', () => {
       )}\n`,
       'utf-8'
     )
-    const disabledPostCompactHeader = hookTrustHeader(`${systemHooksPath}:post_compact:0:0`, true)
-    const systemToml = upsertHookTrustEntriesInContent('model = "system-model"\n', [
+    const systemTomlPath = writeLegacyFixtureAsInline(systemCodexHome, systemHooksPath, [
       {
         sourcePath: systemHooksPath,
         eventLabel: 'pre_compact',
@@ -724,9 +786,16 @@ describe('CodexHookService', () => {
         command: 'post-compact-disabled'
       }
     ])
+    const disabledPostCompactHeader = hookTrustHeader(
+      `${systemTomlPath}:post_compact:0:0`,
+      true
+    )
     writeFileSync(
-      join(systemCodexHome, 'config.toml'),
-      markHookTrustDisabled(systemToml, disabledPostCompactHeader),
+      systemTomlPath,
+      markHookTrustDisabled(
+        readFileSync(systemTomlPath, 'utf-8'),
+        disabledPostCompactHeader
+      ),
       'utf-8'
     )
 
@@ -762,19 +831,15 @@ describe('CodexHookService', () => {
       })}\n`,
       'utf-8'
     )
-    writeFileSync(
-      join(systemCodexHome, 'config.toml'),
-      upsertHookTrustEntriesInContent('model = "system-model"\n', [
-        {
-          sourcePath: systemHooksPath,
-          eventLabel: 'stop',
-          groupIndex: 0,
-          handlerIndex: 0,
-          command: 'user-hook'
-        }
-      ]),
-      'utf-8'
-    )
+    writeLegacyFixtureAsInline(systemCodexHome, systemHooksPath, [
+      {
+        sourcePath: systemHooksPath,
+        eventLabel: 'stop',
+        groupIndex: 0,
+        handlerIndex: 0,
+        command: 'user-hook'
+      }
+    ])
     const service = new CodexHookService()
 
     expect(service.install().state).toBe('installed')
@@ -841,8 +906,7 @@ describe('CodexHookService', () => {
       })}\n`,
       'utf-8'
     )
-    const disabledStopHeader = hookTrustHeader(`${systemHooksPath}:stop:0:0`, true)
-    const systemToml = upsertHookTrustEntriesInContent('model = "system-model"\n', [
+    const systemTomlPath = writeLegacyFixtureAsInline(systemCodexHome, systemHooksPath, [
       {
         sourcePath: systemHooksPath,
         eventLabel: 'stop',
@@ -851,9 +915,10 @@ describe('CodexHookService', () => {
         command: 'user-stop-hook'
       }
     ])
+    const disabledStopHeader = hookTrustHeader(`${systemTomlPath}:stop:0:0`, true)
     writeFileSync(
-      join(systemCodexHome, 'config.toml'),
-      markHookTrustDisabled(systemToml, disabledStopHeader),
+      systemTomlPath,
+      markHookTrustDisabled(readFileSync(systemTomlPath, 'utf-8'), disabledStopHeader),
       'utf-8'
     )
 
@@ -1189,27 +1254,29 @@ describe('CodexHookService', () => {
       )}\n`,
       'utf-8'
     )
+    const inlineConfig = `${[
+      'model = "system-model"',
+      '',
+      '[features]',
+      'codex_hooks = true',
+      ''
+    ].join('\n')}\n${stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: userCommand }] }]
+      }
+    })}`
+    writeFileSync(systemTomlPath, inlineConfig, 'utf-8')
     writeFileSync(
       systemTomlPath,
-      upsertHookTrustEntriesInContent(
-        ['model = "system-model"', '', '[features]', 'codex_hooks = true', ''].join('\n'),
-        [
-          {
-            sourcePath: systemHooksPath,
-            eventLabel: 'stop',
-            groupIndex: 0,
-            handlerIndex: 0,
-            command: userCommand
-          },
-          {
-            sourcePath: systemHooksPath,
-            eventLabel: 'session_start',
-            groupIndex: 0,
-            handlerIndex: 0,
-            command: legacyCommand
-          }
-        ]
-      ),
+      upsertHookTrustEntriesInContent(inlineConfig, [
+        {
+          sourcePath: systemTomlPath,
+          eventLabel: 'stop',
+          groupIndex: 0,
+          handlerIndex: 0,
+          command: userCommand
+        }
+      ]),
       'utf-8'
     )
     writeFileSync(

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -81,6 +81,7 @@ import {
 } from './codex-managed-trust-reconciliation'
 import type { CodexTrustGrantLedgerHome } from './codex-trust-grant-ledger'
 import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-rebase'
+import { readSystemCodexHookAuthority } from './system-hook-authority'
 
 // Why: Pre/PostToolUse feed the live in-flight-tool readout; PermissionRequest exits with no decision so Codex still shows its approval UI while Orca flips the pane to waiting.
 const CODEX_EVENTS = [
@@ -304,18 +305,22 @@ function getRuntimeHooksWithSystemUserHooks(
     return { hooks: { ...runtimeHooks }, trustEntries: [] }
   }
 
-  const systemConfig = readHooksJson(systemConfigPath)
-  if (!systemConfig?.hooks) {
+  const authority = readSystemCodexHookAuthority(getSystemCodexHomePath(), (error) => {
+    // Why: a hand-broken system config must not prevent Orca's managed status
+    // hook from installing. Legacy hooks.json remains the compatibility source.
+    console.warn('[codex-hook-service] failed to read inline system hooks', error)
+  })
+  if (!authority) {
     return { hooks: {}, trustEntries: [] }
   }
 
   const nextHooks: Record<string, HookDefinition[]> = {}
   const trustedSystemHookSignatures = getTrustedSystemUserHookSignatures(
-    systemConfigPath,
-    systemConfig.hooks,
+    authority.sourcePath,
+    authority.hooks,
     isManagedCommand
   )
-  for (const [eventName, systemDefinitions] of Object.entries(systemConfig.hooks)) {
+  for (const [eventName, systemDefinitions] of Object.entries(authority.hooks)) {
     if (!Array.isArray(systemDefinitions)) {
       continue
     }
@@ -327,7 +332,9 @@ function getRuntimeHooksWithSystemUserHooks(
       continue
     }
 
-    // Why: rebuild from system hooks; reusing old runtime copies would keep deleted/edited ~/.codex/hooks.json entries alive for new sessions.
+    // Why: runtime hooks are derived from the user's system hooks plus Orca's
+    // managed hooks. Reusing old runtime user-hook copies would keep deleted or
+    // edited system hook entries alive for new Orca-launched sessions.
     nextHooks[eventName] = dedupeHookDefinitions(systemUserDefinitions)
   }
 

--- a/src/main/codex/hook-trust-promotion.test.ts
+++ b/src/main/codex/hook-trust-promotion.test.ts
@@ -83,12 +83,16 @@ function runtimeHomeDir(): string {
 function writeSystemUserHook(commands: string[] = [USER_HOOK_COMMAND]): void {
   mkdirSync(systemCodexDir(), { recursive: true })
   writeFileSync(
-    join(systemCodexDir(), 'hooks.json'),
-    JSON.stringify({
-      hooks: {
-        Stop: commands.map((command) => ({ hooks: [{ type: 'command', command }] }))
-      }
-    })
+    join(systemCodexDir(), 'config.toml'),
+    commands
+      .flatMap((command) => [
+        '[[hooks.Stop]]',
+        '[[hooks.Stop.hooks]]',
+        'type = "command"',
+        `command = ${JSON.stringify(command)}`,
+        ''
+      ])
+      .join('\n')
   )
 }
 
@@ -116,12 +120,16 @@ function runtimeUserStopEntry(): CodexTrustEntry {
 
 function systemUserStopEntry(groupIndex = 0): CodexTrustEntry {
   return {
-    sourcePath: join(systemCodexDir(), 'hooks.json'),
+    sourcePath: join(systemCodexDir(), 'config.toml'),
     eventLabel: 'stop',
     groupIndex,
     handlerIndex: 0,
     command: USER_HOOK_COMMAND
   }
+}
+
+function inlineSystemUserStopEntry(): CodexTrustEntry {
+  return systemUserStopEntry()
 }
 
 function readSystemToml(): string {
@@ -138,7 +146,7 @@ describe('codex hook trust write-back promotion', () => {
     const systemEntry = systemUserStopEntry()
     writeFileSync(
       join(systemCodexDir(), 'config.toml'),
-      upsertHookTrustEntriesInContent('', [systemEntry])
+      upsertHookTrustEntriesInContent(readSystemToml(), [systemEntry])
     )
 
     expect(new CodexHookService().install().state).toBe('installed')
@@ -167,7 +175,7 @@ describe('codex hook trust write-back promotion', () => {
 
     // Approval survives the relaunch instead of being wiped as stale…
     expect(readHookTrustEntries(runtimeTomlPath).get(approvalKey)?.trustedHash).toBe(approvedHash)
-    // …and is promoted into the user's real config keyed to their hooks.json.
+    // …and is promoted into the user's real config keyed to config.toml.
     const systemState = readHookTrustEntries(join(systemCodexDir(), 'config.toml')).get(
       computeTrustKey(systemUserStopEntry())
     )
@@ -180,6 +188,27 @@ describe('codex hook trust write-back promotion', () => {
     service.install()
     expect(readSystemToml()).toBe(systemTomlAfterPromotion)
     expect(readFileSync(runtimeTomlPath, 'utf-8')).toBe(runtimeTomlAfterPromotion)
+  })
+
+  it('promotes an approval to inline config.toml hooks without recreating hooks.json', () => {
+    writeSystemUserHook()
+    const service = new CodexHookService()
+    service.install()
+
+    simulateCodexApproval(runtimeUserStopEntry())
+    const approvedHash = computeTrustedHash(runtimeUserStopEntry())
+
+    service.install()
+
+    const systemTomlPath = join(systemCodexDir(), 'config.toml')
+    expect(
+      readHookTrustEntries(systemTomlPath).get(computeTrustKey(inlineSystemUserStopEntry()))
+        ?.trustedHash
+    ).toBe(approvedHash)
+    expect(existsSync(join(systemCodexDir(), 'hooks.json'))).toBe(false)
+    expect(readFileSync(join(runtimeHomeDir(), 'config.toml'), 'utf-8')).not.toContain(
+      '[[hooks.Stop]]'
+    )
   })
 
   it('never promotes trust for the Orca-managed status hook into ~/.codex', () => {
@@ -216,7 +245,10 @@ describe('codex hook trust write-back promotion', () => {
     writeSystemUserHook()
     // Pre-trust the hook in the system config, as a terminal Codex session would.
     const systemTomlPath = join(systemCodexDir(), 'config.toml')
-    writeFileSync(systemTomlPath, upsertHookTrustEntriesInContent('', [systemUserStopEntry()]))
+    writeFileSync(
+      systemTomlPath,
+      upsertHookTrustEntriesInContent(readSystemToml(), [systemUserStopEntry()])
+    )
 
     const service = new CodexHookService()
     service.install()
@@ -226,7 +258,7 @@ describe('codex hook trust write-back promotion', () => {
     expect(readHookTrustEntries(runtimeTomlPath).get(approvalKey)).toBeDefined()
 
     // User revokes in the system config; the runtime copy must not win.
-    writeFileSync(systemTomlPath, '')
+    writeSystemUserHook()
     service.install()
 
     expect(readHookTrustEntries(runtimeTomlPath).get(approvalKey)).toBeUndefined()
@@ -236,7 +268,10 @@ describe('codex hook trust write-back promotion', () => {
   it('promotes an in-Orca disable of a mirrored user hook back to the system config', () => {
     writeSystemUserHook()
     const systemTomlPath = join(systemCodexDir(), 'config.toml')
-    writeFileSync(systemTomlPath, upsertHookTrustEntriesInContent('', [systemUserStopEntry()]))
+    writeFileSync(
+      systemTomlPath,
+      upsertHookTrustEntriesInContent(readSystemToml(), [systemUserStopEntry()])
+    )
 
     const service = new CodexHookService()
     service.install()
@@ -306,7 +341,10 @@ describe('codex hook trust write-back promotion', () => {
     // sit out this launch and leave the system config byte-identical.
     writeSystemUserHook()
     const systemTomlPath = join(systemCodexDir(), 'config.toml')
-    writeFileSync(systemTomlPath, upsertHookTrustEntriesInContent('', [systemUserStopEntry()]))
+    writeFileSync(
+      systemTomlPath,
+      upsertHookTrustEntriesInContent(readSystemToml(), [systemUserStopEntry()])
+    )
     const service = new CodexHookService()
     service.install()
     rmSync(join(runtimeHomeDir(), '.orca-hook-trust-provenance.json'), { force: true })
@@ -323,11 +361,14 @@ describe('codex hook trust write-back promotion', () => {
     // build. The stale runtime mirror must not be mistaken for an approval.
     writeSystemUserHook()
     const systemTomlPath = join(systemCodexDir(), 'config.toml')
-    writeFileSync(systemTomlPath, upsertHookTrustEntriesInContent('', [systemUserStopEntry()]))
+    writeFileSync(
+      systemTomlPath,
+      upsertHookTrustEntriesInContent(readSystemToml(), [systemUserStopEntry()])
+    )
     const service = new CodexHookService()
     service.install()
     rmSync(join(runtimeHomeDir(), '.orca-hook-trust-provenance.json'), { force: true })
-    writeFileSync(systemTomlPath, '')
+    writeSystemUserHook()
 
     service.install()
 
@@ -344,13 +385,18 @@ describe('codex hook trust write-back promotion', () => {
     // enabled = false in ~/.codex/config.toml and upgraded to this build.
     writeSystemUserHook()
     const systemTomlPath = join(systemCodexDir(), 'config.toml')
-    writeFileSync(systemTomlPath, upsertHookTrustEntriesInContent('', [systemUserStopEntry()]))
+    writeFileSync(
+      systemTomlPath,
+      upsertHookTrustEntriesInContent(readSystemToml(), [systemUserStopEntry()])
+    )
     const service = new CodexHookService()
     service.install()
     rmSync(join(runtimeHomeDir(), '.orca-hook-trust-provenance.json'), { force: true })
     writeFileSync(
       systemTomlPath,
-      upsertHookTrustEntriesInContent('', [{ ...systemUserStopEntry(), enabled: false }])
+      upsertHookTrustEntriesInContent(readSystemToml(), [
+        { ...systemUserStopEntry(), enabled: false }
+      ])
     )
 
     service.install()
@@ -379,14 +425,14 @@ describe('codex hook trust write-back promotion', () => {
     expect(systemTrust.get(computeTrustKey(systemUserStopEntry(1)))?.trustedHash).toBe(approvedHash)
   })
 
-  it('skips promotion when the approved hook no longer exists in ~/.codex/hooks.json', () => {
+  it('skips promotion when the approved hook no longer exists in config.toml', () => {
     writeSystemUserHook()
     const service = new CodexHookService()
     service.install()
 
     simulateCodexApproval(runtimeUserStopEntry())
-    // User deletes the hook from their system hooks.json before relaunching.
-    writeFileSync(join(systemCodexDir(), 'hooks.json'), JSON.stringify({ hooks: {} }))
+    // User deletes the inline hook from their system config before relaunching.
+    writeFileSync(join(systemCodexDir(), 'config.toml'), 'model = "gpt-5"\n')
 
     service.install()
 

--- a/src/main/codex/hook-trust-promotion.ts
+++ b/src/main/codex/hook-trust-promotion.ts
@@ -22,6 +22,7 @@ import {
   getCodexHookTrustSignature,
   getCodexManagedScriptFileName
 } from './codex-hook-identity'
+import { readSystemCodexHookAuthority } from './system-hook-authority'
 
 // Why: ~/.codex/config.toml is the single source of truth for user-hook
 // trust, but the Codex TUI can only write approvals into the runtime
@@ -111,7 +112,7 @@ export function snapshotCodexRuntimeHookTrustProvenance(
 /**
  * Promotes hook approvals the user made inside Orca-launched Codex (written
  * by Codex into the runtime config.toml) into ~/.codex/config.toml, keyed to
- * the user's own hooks.json. Runs before the config mirror so the promoted
+ * the system hook authority. Runs before the config mirror so the promoted
  * trust is mirrored back on the same launch.
  */
 export function promoteCodexRuntimeHookApprovalsToSystem(
@@ -131,7 +132,12 @@ function promoteCodexRuntimeHookApprovalsToSystemUnsafe(runtimeHomePath: string)
   const runtimeHooksPath = join(runtimeHomePath, 'hooks.json')
   const systemHooksPath = join(systemHomePath, 'hooks.json')
   const canonicalRuntimeHooksPath = getCodexExplicitHomeHookSourcePath(runtimeHooksPath)
-  if (canonicalRuntimeHooksPath === normalizeCodexHookSourcePath(systemHooksPath)) {
+  if (
+    codexHookSourcePathsEqual(
+      canonicalRuntimeHooksPath,
+      getCodexExplicitHomeHookSourcePath(systemHooksPath)
+    )
+  ) {
     return
   }
   const runtimeTomlPath = join(runtimeHomePath, 'config.toml')
@@ -156,8 +162,17 @@ function promoteCodexRuntimeHookApprovalsToSystemUnsafe(runtimeHomePath: string)
   // against — the one still on disk from the previous launch — so it must run
   // before install() rewrites the runtime hooks.json.
   const runtimeConfig = readHooksJson(runtimeHooksPath)
-  const systemConfig = readHooksJson(systemHooksPath)
-  if (!runtimeConfig?.hooks || !systemConfig?.hooks) {
+  if (!runtimeConfig?.hooks) {
+    return
+  }
+  const systemAuthority = readSystemCodexHookAuthority(systemHomePath)
+  if (
+    !systemAuthority ||
+    codexHookSourcePathsEqual(
+      canonicalRuntimeHooksPath,
+      normalizeCodexHookSourcePath(systemAuthority.sourcePath)
+    )
+  ) {
     return
   }
   const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())
@@ -207,8 +222,8 @@ function promoteCodexRuntimeHookApprovalsToSystemUnsafe(runtimeHomePath: string)
     }
     collectSystemPromotionTargets(
       promotions,
-      systemHooksPath,
-      systemConfig.hooks,
+      systemAuthority.sourcePath,
+      systemAuthority.hooks,
       eventName,
       getCodexHookTrustSignature(runtimeEntry),
       isManagedCommand,
@@ -226,7 +241,7 @@ function promoteCodexRuntimeHookApprovalsToSystemUnsafe(runtimeHomePath: string)
 // and one runtime hook can map to several identical system entries.
 function collectSystemPromotionTargets(
   promotions: CodexTrustEntry[],
-  systemHooksPath: string,
+  systemSourcePath: string,
   systemHooks: Record<string, HookDefinition[]>,
   eventName: string,
   signature: string,
@@ -245,7 +260,7 @@ function collectSystemPromotionTargets(
         return
       }
       const systemEntry = createCodexHookTrustEntry(
-        systemHooksPath,
+        systemSourcePath,
         eventName,
         groupIndex,
         handlerIndex,

--- a/src/main/codex/system-hook-authority.test.ts
+++ b/src/main/codex/system-hook-authority.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readSystemCodexHookAuthority } from './system-hook-authority'
+
+const testHomes: string[] = []
+
+function createSystemHome(): string {
+  const homePath = mkdtempSync(join(tmpdir(), 'orca-system-hook-authority-'))
+  testHomes.push(homePath)
+  mkdirSync(homePath, { recursive: true })
+  return homePath
+}
+
+afterEach(() => {
+  for (const homePath of testHomes.splice(0)) {
+    rmSync(homePath, { recursive: true, force: true })
+  }
+})
+
+describe('system Codex hook authority', () => {
+  it('uses legacy hooks only when config.toml does not exist', () => {
+    const homePath = createSystemHome()
+    const legacyHooksPath = join(homePath, 'hooks.json')
+    writeFileSync(
+      legacyHooksPath,
+      JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'legacy-user-hook' }] }]
+        }
+      }),
+      'utf-8'
+    )
+
+    expect(readSystemCodexHookAuthority(homePath)).toEqual({
+      sourcePath: legacyHooksPath,
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'legacy-user-hook' }] }]
+      }
+    })
+  })
+
+  it('uses legacy hooks while config.toml has no executable declarations', () => {
+    const homePath = createSystemHome()
+    const systemTomlPath = join(homePath, 'config.toml')
+    writeFileSync(systemTomlPath, 'model = "gpt-5"\n', 'utf-8')
+    writeFileSync(
+      join(homePath, 'hooks.json'),
+      JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'stale-legacy-hook' }] }]
+        }
+      }),
+      'utf-8'
+    )
+
+    expect(readSystemCodexHookAuthority(homePath)).toEqual({
+      sourcePath: join(homePath, 'hooks.json'),
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'stale-legacy-hook' }] }]
+      }
+    })
+  })
+
+  it('uses legacy hooks when config.toml is malformed during migration', () => {
+    const homePath = createSystemHome()
+    const systemTomlPath = join(homePath, 'config.toml')
+    const onInlineError = vi.fn()
+    writeFileSync(systemTomlPath, 'model = "unterminated\n', 'utf-8')
+    writeFileSync(
+      join(homePath, 'hooks.json'),
+      JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: 'command', command: 'stale-legacy-hook' }] }]
+        }
+      }),
+      'utf-8'
+    )
+
+    expect(readSystemCodexHookAuthority(homePath, onInlineError)).toEqual({
+      sourcePath: join(homePath, 'hooks.json'),
+      hooks: {
+        Stop: [{ hooks: [{ type: 'command', command: 'stale-legacy-hook' }] }]
+      }
+    })
+    expect(onInlineError).toHaveBeenCalledOnce()
+  })
+
+  it('fails closed when an executable hook uses an unsupported TOML representation', () => {
+    const homePath = createSystemHome()
+    const systemTomlPath = join(homePath, 'config.toml')
+    const onInlineError = vi.fn()
+    writeFileSync(
+      systemTomlPath,
+      [
+        '[hooks]',
+        'Stop = [{ hooks = [{ type = "command", command = "unsupported-hook" }] }]',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    expect(readSystemCodexHookAuthority(homePath, onInlineError)).toEqual({
+      sourcePath: systemTomlPath,
+      hooks: {}
+    })
+    expect(onInlineError).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/codex/system-hook-authority.ts
+++ b/src/main/codex/system-hook-authority.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { readHooksJson, type HookDefinition } from '../agent-hooks/installer-utils'
+import { extractInlineCodexHooks, stripInlineCodexHookSections } from './config-toml-hooks'
+
+export type SystemCodexHookAuthority = {
+  sourcePath: string
+  hooks: Record<string, HookDefinition[]>
+}
+
+export function readSystemCodexHookAuthority(
+  systemHomePath: string,
+  onInlineError?: (error: unknown) => void
+): SystemCodexHookAuthority | null {
+  const systemTomlPath = join(systemHomePath, 'config.toml')
+  try {
+    const config = readFileSync(systemTomlPath, 'utf-8')
+    const hooks = extractInlineCodexHooks(config)
+    if (Object.keys(hooks).length > 0) {
+      try {
+        // Why: extraction and runtime-mirror removal must cover the same
+        // syntax. If a valid spelling cannot be stripped, fail closed instead
+        // of materializing the same command in two runtime authorities.
+        stripInlineCodexHookSections(config)
+      } catch (error) {
+        onInlineError?.(error)
+        return { sourcePath: systemTomlPath, hooks: {} }
+      }
+      return {
+        sourcePath: systemTomlPath,
+        hooks
+      }
+    }
+  } catch (error) {
+    if ((error as { code?: unknown })?.code !== 'ENOENT') {
+      onInlineError?.(error)
+    }
+  }
+
+  // Why: pre-migration Codex stores settings/trust in config.toml while hook
+  // declarations still live in hooks.json, so an empty or unreadable inline
+  // layer must retain that compatibility path until the authority migrates.
+  const legacyHooksPath = join(systemHomePath, 'hooks.json')
+  const legacyConfig = readHooksJson(legacyHooksPath)
+  return legacyConfig?.hooks ? { sourcePath: legacyHooksPath, hooks: legacyConfig.hooks } : null
+}


### PR DESCRIPTION
## Summary

Codex sessions launched by Orca now use an isolated `CODEX_HOME`: Orca's relay and mirrored user hooks live in the runtime `hooks.json`, while Codex launched outside Orca keeps using the system hook authority. Inline `config.toml` hook tables are parsed structurally and removed from the runtime config mirror, so a hook cannot execute once from TOML and again from JSON.

Trust approvals map back to the declaration source (`config.toml` or the pre-migration `hooks.json`). Unsupported executable TOML shapes fail closed, while installations that have not migrated to inline hooks retain legacy compatibility. The system hook files remain read-only to Orca.

Related: DKT-1300

## Validation

- `pnpm exec oxlint` on the changed Codex modules and tests
- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex`: 52 files passed; 858 tests passed; 5 skipped
- `git diff --check`
- `pnpm run typecheck:node` reaches only two unrelated existing environment errors: missing `typescript-api` imports in `agent-status-extension-source.test.ts` and `remote-runtime-shared-control-boundary.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
