### PR TITLE
fix(tab-bar): keep tab menu items on one line and give every item an icon

### DIFF
--- a/src/renderer/src/components/tab-bar/BrowserTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.test.tsx
@@ -60,6 +60,9 @@ vi.mock('lucide-react', () => ({
   Copy: function Copy(props: Record<string, unknown>) {
     return { type: 'Copy', props }
   },
+  CopyX: function CopyX(props: Record<string, unknown>) {
+    return { type: 'CopyX', props }
+  },
   ExternalLink: function ExternalLink(props: Record<string, unknown>) {
     return { type: 'ExternalLink', props }
   },
@@ -71,6 +74,9 @@ vi.mock('lucide-react', () => ({
   },
   PinOff: function PinOff(props: Record<string, unknown>) {
     return { type: 'PinOff', props }
+  },
+  PanelLeftClose: function PanelLeftClose(props: Record<string, unknown>) {
+    return { type: 'PanelLeftClose', props }
   },
   PanelRightClose: function PanelRightClose(props: Record<string, unknown>) {
     return { type: 'PanelRightClose', props }

--- a/src/renderer/src/components/tab-bar/BrowserTab.tsx
+++ b/src/renderer/src/components/tab-bar/BrowserTab.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
-import { Globe, X, ExternalLink, Copy, Pin, PinOff, PanelRightClose } from 'lucide-react'
+import {
+  Globe,
+  X,
+  ExternalLink,
+  Copy,
+  CopyX,
+  Pin,
+  PinOff,
+  PanelLeftClose,
+  PanelRightClose
+} from 'lucide-react'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,6 +37,8 @@ import { translate } from '@/i18n/i18n'
 import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-width-rules'
 import { TabWorkspaceLayoutMenuSection } from './TabWorkspaceLayoutMenuSection'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
+import { TAB_CONTEXT_MENU_CONTENT_CLASS } from './tab-context-menu-sizing'
+import { cn } from '@/lib/utils'
 
 function formatBrowserTabUrlLabel(url: string): string {
   if (url === ORCA_BROWSER_BLANK_URL || url === 'about:blank') {
@@ -283,7 +295,10 @@ export default function BrowserTab({
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent
-          className="min-w-[11rem] rounded-[11px] border-border/80 p-1 shadow-[0_16px_36px_rgba(0,0,0,0.24)]"
+          className={cn(
+            'rounded-[11px] border-border/80 p-1 shadow-[0_16px_36px_rgba(0,0,0,0.24)]',
+            TAB_CONTEXT_MENU_CONTENT_CLASS
+          )}
           sideOffset={0}
           align="start"
         >
@@ -309,6 +324,7 @@ export default function BrowserTab({
             {translate('auto.components.tab.bar.BrowserTab.1611a1324b', 'Close')}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onCloseOthers} disabled={tabCount <= 1}>
+            <CopyX className="size-3.5" />
             {translate('components.tab.bar.BrowserTab.closeOthers', 'Close Others')}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onCloseToRight} disabled={!hasTabsToRight}>
@@ -316,6 +332,7 @@ export default function BrowserTab({
             {translate('auto.components.tab.bar.BrowserTab.9dd880bd56', 'Close Tabs To The Right')}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={onCloseToLeft} disabled={!hasTabsToLeft}>
+            <PanelLeftClose className="size-3.5" />
             {translate('components.tab.bar.BrowserTab.closeTabsToLeft', 'Close Tabs To The Left')}
           </DropdownMenuItem>
           <DropdownMenuItem

--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -73,6 +73,12 @@ vi.mock('lucide-react', () => ({
   Columns2: function Columns2(props: Record<string, unknown>) {
     return { type: 'Columns2', props }
   },
+  CopyX: function CopyX(props: Record<string, unknown>) {
+    return { type: 'CopyX', props }
+  },
+  PanelLeftClose: function PanelLeftClose(props: Record<string, unknown>) {
+    return { type: 'PanelLeftClose', props }
+  },
   Copy: function Copy(props: Record<string, unknown>) {
     return { type: 'Copy', props }
   },

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
@@ -51,6 +51,9 @@ vi.mock('lucide-react', () => ({
   Copy: function Copy(props: Record<string, unknown>) {
     return { type: 'Copy', props }
   },
+  CopyX: function CopyX(props: Record<string, unknown>) {
+    return { type: 'CopyX', props }
+  },
   ExternalLink: function ExternalLink(props: Record<string, unknown>) {
     return { type: 'ExternalLink', props }
   },
@@ -59,6 +62,9 @@ vi.mock('lucide-react', () => ({
   },
   ListX: function ListX(props: Record<string, unknown>) {
     return { type: 'ListX', props }
+  },
+  PanelLeftClose: function PanelLeftClose(props: Record<string, unknown>) {
+    return { type: 'PanelLeftClose', props }
   },
   PanelRightClose: function PanelRightClose(props: Record<string, unknown>) {
     return { type: 'PanelRightClose', props }

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -1,8 +1,10 @@
 import {
   Copy,
+  CopyX,
   ExternalLink,
   Eye,
   ListX,
+  PanelLeftClose,
   PanelRightClose,
   Pencil,
   Pin,
@@ -24,6 +26,7 @@ import type { OpenFile } from '../../store/slices/editor'
 import { shouldBlockEditorTabLocalOpen } from './editor-tab-local-open-guard'
 import { translate } from '@/i18n/i18n'
 import { TabWorkspaceLayoutMenuSection } from './TabWorkspaceLayoutMenuSection'
+import { TAB_CONTEXT_MENU_CONTENT_CLASS } from './tab-context-menu-sizing'
 
 const isMac = navigator.userAgent.includes('Mac')
 const isLinux = navigator.userAgent.includes('Linux')
@@ -114,7 +117,7 @@ export function EditorFileTabContextMenu({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="w-48"
+        className={TAB_CONTEXT_MENU_CONTENT_CLASS}
         sideOffset={0}
         align="start"
         onCloseAutoFocus={(event) => {
@@ -156,6 +159,7 @@ export function EditorFileTabContextMenu({
           {closeShortcut ? <DropdownMenuShortcut>{closeShortcut}</DropdownMenuShortcut> : null}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onCloseOthers} disabled={tabCount <= 1}>
+          <CopyX className="size-3.5" />
           {translate('components.tab.bar.EditorFileTabContextMenu.closeOthers', 'Close Others')}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onCloseAll}>
@@ -176,6 +180,7 @@ export function EditorFileTabContextMenu({
           )}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onCloseToLeft} disabled={!hasTabsToLeft}>
+          <PanelLeftClose className="size-3.5" />
           {translate(
             'components.tab.bar.EditorFileTabContextMenu.closeTabsToLeft',
             'Close Tabs To The Left'

--- a/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
@@ -93,6 +93,9 @@ vi.mock('lucide-react', () => ({
   PanelBottomClose: function PanelBottomClose(props: Record<string, unknown>) {
     return { type: 'PanelBottomClose', props }
   },
+  PanelLeftClose: function PanelLeftClose(props: Record<string, unknown>) {
+    return { type: 'PanelLeftClose', props }
+  },
   PanelRightClose: function PanelRightClose(props: Record<string, unknown>) {
     return { type: 'PanelRightClose', props }
   },

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
@@ -58,6 +58,7 @@ vi.mock('lucide-react', () => ({
   ListX: () => null,
   MessageSquare: () => null,
   PanelBottomClose: () => null,
+  PanelLeftClose: () => null,
   PanelRightClose: () => null,
   Pencil: () => null,
   Pin: () => null,

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
@@ -1,5 +1,6 @@
 import {
   MessageSquare,
+  PanelLeftClose,
   PanelRightClose,
   Pin,
   PinOff,
@@ -21,6 +22,7 @@ import { useAppStore } from '../../store'
 import { formatShortcutLabel, useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 import { TerminalTabSplitMenuSection } from './TerminalTabSplitMenuSection'
+import { TAB_CONTEXT_MENU_CONTENT_CLASS } from './tab-context-menu-sizing'
 
 const TAB_COLORS = [
   {
@@ -156,7 +158,7 @@ export function SortableTabContextMenu({
           style={{ left: point.x, top: point.y }}
         />
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-56" sideOffset={0} align="start">
+      <DropdownMenuContent className={TAB_CONTEXT_MENU_CONTENT_CLASS} sideOffset={0} align="start">
         <TerminalTabSplitMenuSection
           unifiedTabId={unifiedTabId}
           groupId={groupId}
@@ -216,6 +218,7 @@ export function SortableTabContextMenu({
           )}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => onCloseToLeft(tab.id)} disabled={!hasTabsToLeft}>
+          <PanelLeftClose className="size-3.5" />
           {translate(
             'components.tab.bar.SortableTabContextMenu.closeTabsToLeft',
             'Close Tabs To The Left'

--- a/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
@@ -9,6 +9,7 @@ import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Columns2 } from 'lucide-reac
 import type { TabSplitDirection } from '../../store/slices/tabs'
 import { translate } from '@/i18n/i18n'
 import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import { TAB_CONTEXT_SUBMENU_CONTENT_CLASS } from './tab-context-menu-sizing'
 
 const PANE_COLUMN_DIRECTIONS: TabSplitDirection[] = ['right', 'left', 'down', 'up']
 
@@ -61,7 +62,7 @@ export function TabWorkspaceLayoutMenuSection({
             'Move Tab to Split'
           )}
         </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent>
+        <DropdownMenuSubContent className={TAB_CONTEXT_SUBMENU_CONTENT_CLASS}>
           {PANE_COLUMN_DIRECTIONS.map((direction) => (
             <DropdownMenuItem
               key={direction}

--- a/src/renderer/src/components/tab-bar/TerminalTabSplitMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/TerminalTabSplitMenuSection.tsx
@@ -10,6 +10,8 @@ import { PanelBottomClose, PanelRightClose, SquareTerminal } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import { TabWorkspaceLayoutMenuSection } from './TabWorkspaceLayoutMenuSection'
 import { requestActiveTerminalPaneSplit } from './request-active-terminal-pane-split'
+import { TAB_CONTEXT_SUBMENU_CONTENT_CLASS } from './tab-context-menu-sizing'
+import { cn } from '@/lib/utils'
 
 export function TerminalTabSplitMenuSection({
   unifiedTabId,
@@ -48,7 +50,7 @@ export function TerminalTabSplitMenuSection({
             'Split terminal'
           )}
         </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent className="min-w-[12rem]">
+        <DropdownMenuSubContent className={cn('min-w-[12rem]', TAB_CONTEXT_SUBMENU_CONTENT_CLASS)}>
           <DropdownMenuItem onSelect={() => splitActiveTerminalPane('vertical')}>
             <PanelRightClose className="size-3.5 shrink-0" />
             {translate(

--- a/src/renderer/src/components/tab-bar/tab-context-menu-consistency.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-context-menu-consistency.test.tsx
@@ -22,6 +22,18 @@ function readSource(fileName: string): string {
   return readFileSync(join(__dirname, fileName), 'utf8')
 }
 
+/** Opening tags of each menu/submenu surface, so props can be asserted directly. */
+function menuSurfaceTags(source: string): { name: string; tag: string }[] {
+  const tags: { name: string; tag: string }[] = []
+  const opening = /<(DropdownMenuContent|DropdownMenuSubContent)\b/g
+  let match: RegExpExecArray | null
+  while ((match = opening.exec(source)) !== null) {
+    const end = source.indexOf('>', match.index)
+    tags.push({ name: match[1], tag: source.slice(match.index, end === -1 ? undefined : end + 1) })
+  }
+  return tags
+}
+
 /** Item bodies, minus the color swatches which are deliberately icon-free. */
 function actionItemBodies(source: string): string[] {
   const bodies: string[] = []
@@ -50,14 +62,27 @@ describe('tab context menu consistency', () => {
     }
   })
 
-  it.each(TAB_MENU_SOURCES)('sizes menu surfaces from the shared rule in %s', (fileName) => {
+  it.each(TAB_MENU_SOURCES)('sizes every menu surface from the shared rule in %s', (fileName) => {
     const source = readSource(fileName)
-    if (!source.includes('DropdownMenuContent') && !source.includes('DropdownMenuSubContent')) {
+    const surfaces = menuSurfaceTags(source)
+    if (surfaces.length === 0) {
       return
     }
-    expect(source).toContain('tab-context-menu-sizing')
-    // Why: a fixed `w-*` reintroduces wrapping once a label or shortcut grows.
-    expect(source).not.toMatch(/className="w-\d+"/)
+
+    for (const { tag, name } of surfaces) {
+      const expected =
+        name === 'DropdownMenuSubContent'
+          ? 'TAB_CONTEXT_SUBMENU_CONTENT_CLASS'
+          : 'TAB_CONTEXT_MENU_CONTENT_CLASS'
+      expect(tag, `<${name}> in ${fileName} does not apply ${expected}:\n${tag}`).toContain(
+        expected
+      )
+      // Why: a fixed `w-*` on the surface reintroduces wrapping once a label or
+      // shortcut grows, and it survives merging with the shared rule.
+      expect(tag, `<${name}> in ${fileName} pins a fixed width:\n${tag}`).not.toMatch(
+        /(?:^|[\s'"`])w-(?:\d+|\[)/
+      )
+    }
   })
 
   it('keeps labels on one line and bounded by the viewport', () => {

--- a/src/renderer/src/components/tab-bar/tab-context-menu-consistency.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-context-menu-consistency.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Guards the two tab-context-menu invariants: every action item carries an
+ * icon, and no item can wrap onto a second line on any platform.
+ */
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  TAB_CONTEXT_MENU_CONTENT_CLASS,
+  TAB_CONTEXT_SUBMENU_CONTENT_CLASS
+} from './tab-context-menu-sizing'
+
+const TAB_MENU_SOURCES = [
+  'EditorFileTabContextMenu.tsx',
+  'SortableTabContextMenu.tsx',
+  'BrowserTab.tsx',
+  'TabWorkspaceLayoutMenuSection.tsx',
+  'TerminalTabSplitMenuSection.tsx'
+] as const
+
+function readSource(fileName: string): string {
+  return readFileSync(join(__dirname, fileName), 'utf8')
+}
+
+/** Item bodies, minus the color swatches which are deliberately icon-free. */
+function actionItemBodies(source: string): string[] {
+  const bodies: string[] = []
+  const opening = /<DropdownMenu(?:Item|SubTrigger)\b/g
+  let match: RegExpExecArray | null
+  while ((match = opening.exec(source)) !== null) {
+    const closing = source.indexOf('</DropdownMenu', match.index + 1)
+    const body = source.slice(match.index, closing === -1 ? source.length : closing)
+    if (body.includes('rounded-full')) {
+      continue
+    }
+    bodies.push(body)
+  }
+  return bodies
+}
+
+describe('tab context menu consistency', () => {
+  it.each(TAB_MENU_SOURCES)('gives every action item an icon in %s', (fileName) => {
+    const bodies = actionItemBodies(readSource(fileName))
+    expect(bodies.length).toBeGreaterThan(0)
+
+    for (const body of bodies) {
+      // Icons render as a self-closing lucide element or an icon-returning helper.
+      const hasIcon = /<[A-Z][A-Za-z0-9]*\s+className="size-3\.5/.test(body) || /Icon\(/.test(body)
+      expect(hasIcon, `menu item without an icon in ${fileName}:\n${body}`).toBe(true)
+    }
+  })
+
+  it.each(TAB_MENU_SOURCES)('sizes menu surfaces from the shared rule in %s', (fileName) => {
+    const source = readSource(fileName)
+    if (!source.includes('DropdownMenuContent') && !source.includes('DropdownMenuSubContent')) {
+      return
+    }
+    expect(source).toContain('tab-context-menu-sizing')
+    // Why: a fixed `w-*` reintroduces wrapping once a label or shortcut grows.
+    expect(source).not.toMatch(/className="w-\d+"/)
+  })
+
+  it('keeps labels on one line and bounded by the viewport', () => {
+    for (const rule of [TAB_CONTEXT_MENU_CONTENT_CLASS, TAB_CONTEXT_SUBMENU_CONTENT_CLASS]) {
+      expect(rule).toContain('whitespace-nowrap')
+      expect(rule).toContain('max-w-[calc(100vw-1rem)]')
+    }
+  })
+})

--- a/src/renderer/src/components/tab-bar/tab-context-menu-sizing.ts
+++ b/src/renderer/src/components/tab-bar/tab-context-menu-sizing.ts
@@ -1,0 +1,9 @@
+// Why: a fixed menu width wraps labels onto a second line once the label or its
+// shortcut chip grows — worst on Windows/Linux, where `Ctrl+Alt+W` is far wider
+// than `⌘⌥W`, and in locales with longer copy. Size to content instead, capped
+// so a long label still can't run off screen.
+export const TAB_CONTEXT_MENU_CONTENT_CLASS =
+  'min-w-[13rem] max-w-[calc(100vw-1rem)] whitespace-nowrap'
+
+/** Submenus portal out of the parent menu, so they can't inherit its nowrap. */
+export const TAB_CONTEXT_SUBMENU_CONTENT_CLASS = 'max-w-[calc(100vw-1rem)] whitespace-nowrap'


### PR DESCRIPTION
## Summary

Two inconsistencies in the tab context menus:

1. **"Close All Editor Tabs" wrapped onto a second line.** The editor tab menu was pinned to `w-48` (192px), which isn't wide enough for that label plus its `⌘⌥W` shortcut chip.
2. **Some items had no icon** — `Close Others` and `Close Tabs To The Left` rendered as bare text while their neighbours all had one.

The wrap is *worse* off macOS: the chip is built by `formatKeybinding`, which renders `Ctrl+Alt+W` on Windows/Linux instead of the narrower `⌘⌥W`, so a fixed width that barely fits on Mac clips harder everywhere else. Longer locales compound it (`es` renders "Cerrar todas las pestañas del editor").

**Fix:** replaced the fixed `w-48` / `w-56` widths with a shared rule in `tab-context-menu-sizing.ts` — `min-w-[13rem] max-w-[calc(100vw-1rem)] whitespace-nowrap` — so menus grow to fit content instead of wrapping, bounded by the viewport. Submenus get the same rule explicitly since they portal out and don't inherit the parent's `whitespace-nowrap`. Added `CopyX` for "Close Others" and `PanelLeftClose` for "Close Tabs To The Left".

Applied across all three tab context menus (editor, terminal, browser) — the browser menu had the same two missing icons.

## Screenshots

Captured from a dev build of this branch, CDP-attached to this worktree.

**Before** — wrapped label, two items with no icon:

![editor-menu-before.png](https://github.com/user-attachments/assets/bce56aed-9311-4f56-a9b7-7a86fd07354e)

**After** — editor tab menu:

![editor-menu-after.png](https://github.com/user-attachments/assets/17b270fd-5667-4b65-9b94-ee710c5f7c18)

**Terminal and browser tab menus** — same treatment:

![terminal-menu-after.png](https://github.com/user-attachments/assets/b1660468-4c6c-4cf6-a2e5-b5795ca134ce)
![browser-menu-after.png](https://github.com/user-attachments/assets/c3fd9470-aeb8-4565-8cb5-75814aa9f488)

Measured from the live DOM — all 12 editor items report `lines: 1` at a uniform 28px height, each with at least one svg. `Move Tab to Split` has 2 (leading icon + chevron).

## Testing

- [x] `pnpm lint` — oxlint + oxfmt clean; `verify:localization-catalog` verified parity across `es`/`ja`/`ko`/`zh`
- [x] `pnpm typecheck` — `tsc --noEmit` clean
- [x] `pnpm test` — tab-bar suite: **255 passed** (35 files)
- [ ] `pnpm build` — not run; this is a CSS-class + icon change with no build-surface impact, and CI covers it
- [x] Added `tab-context-menu-consistency.test.tsx`, asserting every action item has an icon and every menu surface applies the shared sizing rule

I verified the new test fails rather than passing vacuously, against three seeded regressions: removing an icon, `cn('w-56', SHARED)`, and an import left in place while the surface stops using it.

## AI Review Report

Reviewed for correctness, cross-platform behavior, and blast radius.

**Cross-platform** — explicitly checked, since this PR is about width:
- Shortcut chips flow through `formatKeybinding`, which emits `Ctrl+Alt+W` / `Ctrl`/`Alt`/`Shift` on Windows/Linux vs `⌘⌥⇧` glyphs on Mac. Probed against the live menu: with `Ctrl+Alt+W` the menu grows to 231px and stays single-line.
- The `Reveal in Finder` / `Open Containing Folder` / `Reveal in File Explorer` label already branches per platform and is unchanged; the longest variant stays on one line.
- No new `metaKey` hardcoding, path handling, or shell behavior — the change is CSS classes plus two icon imports.
- Longest real label measured 364px against an 884px cap at a 900px viewport.

**Flagged and addressed:** the review noted my first sizing test only checked for the module import and a literal `className="w-N"`, so it would pass on `cn('w-56', SHARED)`. Fixed in a23a523 — it now inspects each `DropdownMenuContent`/`SubContent` opening tag directly.

**Flagged and assessed as not actionable:** a concern that `whitespace-nowrap` + the viewport cap could clip long labels against the primitives' `overflow-x-hidden`. I tested this rather than assuming. Clipping requires a ~200-character label; real labels top out at 364px against an 884px cap. Every interpolation in these three menus is either a static translated string or an event handler — there is no user-controlled text in any tab menu label, so the unbounded case can't occur. Adding truncation would trade a real fixed bug for defensive code against an unreachable input. Noted as follow-up below rather than fixed here.

**Deliberately scoped out:** the `whitespace-nowrap` is on the tab menus, not the shared `DropdownMenuItem` primitive. A primitive-level change would hit ~56 usages, some with genuinely unbounded dynamic labels (browser profile names, model descriptions) — a larger cleanup than this bug warrants, and the case where truncation *would* be the right call.

## Security Audit

No security surface. The change is Tailwind class strings and two `lucide-react` icon imports. No input handling, command execution, path handling, auth, secrets, or IPC changes. No new dependencies. The existing `window.api.shell.openPath` call in the reveal item is untouched, including its `shouldBlockEditorTabLocalOpen` guard.

## Notes

- Copy is unchanged, so no new translation keys were needed.
- Follow-up worth considering separately: menu items with genuinely unbounded dynamic labels elsewhere in the app (browser profile names, model descriptions) have no truncation strategy. Out of scope here.
