### PR TITLE
fix(skills): complete the ordinary plugin cache scan and require skill evidence

### DIFF
--- a/src/main/ipc/skills.test.ts
+++ b/src/main/ipc/skills.test.ts
@@ -77,6 +77,7 @@ describe('registerSkillsHandlers', () => {
       schemaVersion: 1,
       installations: [],
       eligibleUpdateNames: [],
+      scanIssues: [],
       scannedAt: 1
     })
     getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\alice')

--- a/src/main/skills/skill-freshness-inventory.test.ts
+++ b/src/main/skills/skill-freshness-inventory.test.ts
@@ -377,4 +377,40 @@ describe('read-only skill freshness inventory', () => {
     // command does not touch, so the limit is reported without blocking the update.
     expect(inventory.eligibleUpdateNames).toEqual(['orca-cli'])
   })
+
+  it('reports incomplete plugin coverage without inventing per-skill installations', async () => {
+    const test = await fixture()
+    await test.writeSkill(join(test.homeDir, '.agents', 'skills'), test.currentMarkdown)
+    const pluginCache = join(test.homeDir, '.codex', 'plugins', 'cache')
+    await mkdir(join(pluginCache, ...Array.from({ length: 11 }, (_, index) => `level-${index}`)), {
+      recursive: true
+    })
+
+    const inventory = await inventorySkillFreshness({
+      currentAppVersion: '2.0.0',
+      homeDir: test.homeDir,
+      repos: [],
+      resourceRoot: test.resourceRoot
+    })
+
+    expect(inventory.installations).toHaveLength(1)
+    expect(inventory.installations[0]).toMatchObject({
+      name: 'orca-cli',
+      status: 'current',
+      topology: 'canonical-copy'
+    })
+    expect(inventory.installations).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ errorCategory: 'plugin-cache-scan-incomplete' })
+      ])
+    )
+    expect(inventory.scanIssues).toEqual([
+      expect.objectContaining({
+        rootId: 'codex-plugin-cache',
+        sourceLabel: 'Codex plugin cache',
+        reason: 'depth-limit',
+        errorCode: null
+      })
+    ])
+  })
 })

--- a/src/main/skills/skill-freshness-inventory.test.ts
+++ b/src/main/skills/skill-freshness-inventory.test.ts
@@ -378,6 +378,45 @@ describe('read-only skill freshness inventory', () => {
     expect(inventory.eligibleUpdateNames).toEqual(['orca-cli'])
   })
 
+  it('scans a real-shaped plugin cache completely and leaves eligibility unchanged', async () => {
+    const test = await fixture()
+    await test.writeSkill(join(test.homeDir, '.agents', 'skills'), test.oldMarkdown)
+    const packageRoot = join(
+      test.homeDir,
+      '.codex',
+      'plugins',
+      'cache',
+      'openai-bundled',
+      'orca-cli',
+      '1.0.0'
+    )
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await writeFile(join(packageRoot, '.codex-plugin', 'plugin.json'), '{"skills":"./skills/"}\n')
+    const pluginSkill = await test.writeSkill(join(packageRoot, 'skills'), test.currentMarkdown)
+    await mkdir(join(pluginSkill, 'templates', 'starter', 'examples', 'd1', 'app', 'api'), {
+      recursive: true
+    })
+
+    const inventory = await inventorySkillFreshness({
+      currentAppVersion: '2.0.0',
+      homeDir: test.homeDir,
+      repos: [],
+      resourceRoot: test.resourceRoot
+    })
+
+    // The plugin copy is real and reported at its own path — never at a joined path,
+    // and never at the same-named plugin directory two levels above it.
+    expect(inventory.scanIssues).toEqual([])
+    expect(inventory.installations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ topology: 'plugin-cache', unresolvedPath: pluginSkill })
+      ])
+    )
+    // Why: a plugin-cache copy is not convergent, so it neither grants nor withholds
+    // the update. The outdated canonical copy alone decides, exactly as before.
+    expect(inventory.eligibleUpdateNames).toEqual(['orca-cli'])
+  })
+
   it('reports incomplete plugin coverage without inventing per-skill installations', async () => {
     const test = await fixture()
     await test.writeSkill(join(test.homeDir, '.agents', 'skills'), test.currentMarkdown)

--- a/src/main/skills/skill-freshness-inventory.ts
+++ b/src/main/skills/skill-freshness-inventory.ts
@@ -123,8 +123,8 @@ export async function inventorySkillFreshness(args: {
       scan: await scanKnownPluginSkillCandidates(root.path, new Set(currentByName.keys()))
     }))
   )
-  const pluginTasks = pluginScans.flatMap(({ root, scan }) => [
-    ...scan.candidates.flatMap((candidate) => {
+  const pluginTasks = pluginScans.flatMap(({ root, scan }) =>
+    scan.candidates.flatMap((candidate) => {
       const current = currentByName.get(candidate.name)
       return current
         ? [
@@ -139,31 +139,15 @@ export async function inventorySkillFreshness(args: {
               })
           ]
         : []
-    }),
-    // Why: unreadable plugin subtrees could hide any official name. An
-    // incomplete scan must conservatively poison every name rather than imply absence.
-    ...scan.incompletePaths.flatMap((incompletePath) =>
-      artifacts.manifest.skills.map(
-        (current) => () =>
-          observeSkillFreshnessInstallation({
-            current,
-            currentAppVersion: args.currentAppVersion,
-            artifacts,
-            rootId: root.id,
-            providers: root.providers,
-            sourceKind: 'plugin',
-            sourceLabel: root.label,
-            unresolvedPath: join(incompletePath, current.name),
-            topology: {
-              topology: 'plugin-cache',
-              resolvedPath: null,
-              identity: null,
-              errorCategory: 'plugin-cache-scan-incomplete'
-            }
-          })
-      )
-    )
-  ])
+    })
+  )
+  const scanIssues = pluginScans.flatMap(({ root, scan }) =>
+    scan.issues.map((issue) => ({
+      rootId: root.id,
+      sourceLabel: root.label,
+      ...issue
+    }))
+  )
   const unsupportedInstallations = (
     await runSkillCandidateTasks([...repoTasks, ...omittedRepoTasks, ...pluginTasks])
   ).filter((installation): installation is SkillFreshnessInstallation => installation !== null)
@@ -180,6 +164,7 @@ export async function inventorySkillFreshness(args: {
     schemaVersion: 1,
     installations,
     eligibleUpdateNames: eligibleSkillUpdateNames(installations),
+    scanIssues,
     scannedAt: Date.now()
   }
 }

--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -1,10 +1,13 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { promisify } from 'node:util'
 import { afterEach, describe, expect, it } from 'vitest'
 import { scanKnownPluginSkillCandidates } from './skill-plugin-cache-scan'
 
 const temporaryDirectories: string[] = []
+const execFileAsync = promisify(execFile)
 
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((root) => rm(root, { recursive: true })))
@@ -21,10 +24,10 @@ describe('plugin skill candidate scan', () => {
     const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), 1)
 
     expect(result.candidates).toHaveLength(1)
-    expect(result.incompletePaths).toEqual([root])
+    expect(result.issues).toEqual([{ path: root, reason: 'candidate-limit', errorCode: null }])
   })
 
-  it('marks depth-truncated subtrees incomplete so hidden skills poison eligibility', async () => {
+  it('reports a depth-truncated subtree as scan coverage instead of a skill candidate', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-plugin-skill-depth-'))
     temporaryDirectories.push(root)
     const segments = Array.from({ length: 11 }, (_, index) => `level-${index}`)
@@ -34,7 +37,328 @@ describe('plugin skill candidate scan', () => {
     const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
 
     expect(result.candidates).toEqual([])
-    expect(result.incompletePaths).toHaveLength(1)
-    expect(hiddenSkill.startsWith(result.incompletePaths[0] ?? '')).toBe(true)
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0]).toMatchObject({ reason: 'depth-limit', errorCode: null })
+    expect(hiddenSkill.startsWith(result.issues[0]?.path ?? '')).toBe(true)
   })
+
+  it('does not scan dependency packages for plugin skill entrypoints', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-dependencies-'))
+    temporaryDirectories.push(root)
+    await mkdir(
+      join(
+        root,
+        'vendor',
+        'plugin',
+        'scripts',
+        'node_modules',
+        ...Array.from({ length: 12 }, (_, index) => `level-${index}`)
+      ),
+      { recursive: true }
+    )
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({ candidates: [], issues: [] })
+  })
+
+  it('scans only declared Codex plugin skill roots', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-manifest-roots-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    const candidate = join(packageRoot, 'custom-skills', 'group', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await mkdir(candidate, { recursive: true })
+    await mkdir(
+      join(packageRoot, 'payload', ...Array.from({ length: 12 }, (_, index) => `level-${index}`)),
+      { recursive: true }
+    )
+    await writeFile(
+      join(packageRoot, '.codex-plugin', 'plugin.json'),
+      '{"skills":["./custom-skills","./skills"]}\n'
+    )
+    await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [{ name: 'orca-cli', path: candidate }],
+      issues: []
+    })
+  })
+
+  it('uses the default skills root for compatible manifests without a skills field', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-default-root-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    const candidate = join(packageRoot, 'skills', 'nested', 'orca-cli')
+    await mkdir(join(packageRoot, '.claude-plugin'), { recursive: true })
+    await mkdir(candidate, { recursive: true })
+    await writeFile(join(packageRoot, '.claude-plugin', 'plugin.json'), '{"name":"plugin"}\n')
+    await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [{ name: 'orca-cli', path: candidate }],
+      issues: []
+    })
+  })
+
+  it('discovers nested skill packages recursively within declared roots', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-skill-boundary-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    const skillRoot = join(packageRoot, 'skills', 'sites-building')
+    await mkdir(join(packageRoot, '.cursor-plugin'), { recursive: true })
+    await mkdir(join(skillRoot, 'templates', 'orca-cli'), { recursive: true })
+    await writeFile(join(packageRoot, '.cursor-plugin', 'plugin.json'), '{"skills":"./skills"}\n')
+    await writeFile(join(skillRoot, 'SKILL.md'), '# Sites building\n')
+    await writeFile(join(skillRoot, 'templates', 'orca-cli', 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [{ name: 'orca-cli', path: join(skillRoot, 'templates', 'orca-cli') }],
+      issues: []
+    })
+  })
+
+  it('rejects Windows parent traversal and falls back to the default skills root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-windows-parent-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    const candidate = join(packageRoot, 'skills', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await mkdir(candidate, { recursive: true })
+    await writeFile(
+      join(packageRoot, '.codex-plugin', 'plugin.json'),
+      '{"skills":"./..\\\\outside"}\n'
+    )
+    await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [{ name: 'orca-cli', path: candidate }],
+      issues: []
+    })
+  })
+
+  it('falls through empty manifest directories to the first manifest file', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-manifest-precedence-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    const candidate = join(packageRoot, 'custom-skills', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await mkdir(join(packageRoot, '.claude-plugin'), { recursive: true })
+    await mkdir(candidate, { recursive: true })
+    await mkdir(
+      join(packageRoot, 'payload', ...Array.from({ length: 12 }, (_, index) => `level-${index}`)),
+      { recursive: true }
+    )
+    await writeFile(
+      join(packageRoot, '.claude-plugin', 'plugin.json'),
+      '{"skills":"./custom-skills"}\n'
+    )
+    await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [{ name: 'orca-cli', path: candidate }],
+      issues: []
+    })
+  })
+
+  it('counts declared skill roots against the scan entry budget', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-manifest-budget-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await writeFile(
+      join(packageRoot, '.codex-plugin', 'plugin.json'),
+      JSON.stringify({
+        skills: Array.from({ length: 4_097 }, (_, index) => `./missing-${index}`)
+      })
+    )
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result.candidates).toEqual([])
+    expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
+  })
+
+  it('falls back to the default root when a skills array contains an invalid value', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-invalid-root-array-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    const candidate = join(packageRoot, 'skills', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await mkdir(candidate, { recursive: true })
+    await mkdir(join(packageRoot, 'custom-skills', 'orca-cli'), { recursive: true })
+    await writeFile(
+      join(packageRoot, '.codex-plugin', 'plugin.json'),
+      '{"skills":["./custom-skills",7]}\n'
+    )
+    await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+    await writeFile(join(packageRoot, 'custom-skills', 'orca-cli', 'SKILL.md'), '# Wrong root\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [{ name: 'orca-cli', path: candidate }],
+      issues: []
+    })
+  })
+
+  it('does not reset the depth budget across nested plugin manifests', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-nested-manifests-'))
+    temporaryDirectories.push(root)
+    let pluginRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    for (let index = 0; index < 8; index += 1) {
+      await mkdir(join(pluginRoot, '.codex-plugin'), { recursive: true })
+      await writeFile(join(pluginRoot, '.codex-plugin', 'plugin.json'), '{"skills":"./skills"}\n')
+      pluginRoot = join(pluginRoot, 'skills', `nested-${index}`)
+    }
+    const hiddenCandidate = join(pluginRoot, 'orca-cli')
+    await mkdir(hiddenCandidate, { recursive: true })
+    await writeFile(join(hiddenCandidate, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result.candidates).toEqual([])
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ reason: 'depth-limit', errorCode: null })
+    )
+  })
+
+  it('ignores non-directory manifest markers when selecting precedence', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-manifest-marker-file-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    const candidate = join(packageRoot, 'custom-skills', 'orca-cli')
+    await mkdir(packageRoot, { recursive: true })
+    await mkdir(join(packageRoot, '.claude-plugin'), { recursive: true })
+    await mkdir(candidate, { recursive: true })
+    await mkdir(
+      join(packageRoot, 'payload', ...Array.from({ length: 12 }, (_, index) => `level-${index}`)),
+      { recursive: true }
+    )
+    await writeFile(join(packageRoot, '.codex-plugin'), 'not a directory\n')
+    await writeFile(
+      join(packageRoot, '.claude-plugin', 'plugin.json'),
+      '{"skills":"./custom-skills"}\n'
+    )
+    await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [{ name: 'orca-cli', path: candidate }],
+      issues: []
+    })
+  })
+
+  it('reports manifests that exceed the bounded read limit', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-large-manifest-'))
+    temporaryDirectories.push(root)
+    const manifestPath = join(root, 'vendor', 'plugin', '.codex-plugin', 'plugin.json')
+    await mkdir(join(root, 'vendor', 'plugin', '.codex-plugin'), { recursive: true })
+    await writeFile(manifestPath, ' '.repeat(256 * 1024 + 1))
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result.issues).toContainEqual({
+      path: manifestPath,
+      reason: 'manifest-limit',
+      errorCode: null
+    })
+  })
+
+  it('reports a symlink target that cannot be inspected', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-symlink-error-'))
+    temporaryDirectories.push(root)
+    const linkPath = join(root, 'loop')
+    await symlink('loop', linkPath, 'dir')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result.issues).toContainEqual({
+      path: linkPath,
+      reason: 'io-error',
+      errorCode: 'ELOOP'
+    })
+  })
+
+  it('keeps a dangling known-name symlink from a declared skill root as a candidate', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-declared-dangling-symlink-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin')
+    const candidate = join(packageRoot, 'skills', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await mkdir(join(packageRoot, 'skills'), { recursive: true })
+    await writeFile(join(packageRoot, '.codex-plugin', 'plugin.json'), '{"skills":"./skills"}\n')
+    await symlink('missing-target', candidate, 'dir')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [{ name: 'orca-cli', path: candidate }],
+      issues: []
+    })
+  })
+
+  it('does not follow directory symlinks outside the plugin cache', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'orca-plugin-symlink-outside-'))
+    temporaryDirectories.push(parent)
+    const root = join(parent, 'cache')
+    const outside = join(parent, 'outside')
+    const linkPath = join(root, 'vendor')
+    await mkdir(join(outside, 'orca-cli'), { recursive: true })
+    await mkdir(root, { recursive: true })
+    await writeFile(join(outside, 'orca-cli', 'SKILL.md'), '# Orca CLI\n')
+    await symlink(outside, linkPath, 'dir')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [],
+      issues: [{ path: linkPath, reason: 'outside-root', errorCode: null }]
+    })
+  })
+
+  it('does not read manifest symlinks outside the plugin cache', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'orca-plugin-manifest-outside-'))
+    temporaryDirectories.push(parent)
+    const root = join(parent, 'cache')
+    const outsideManifest = join(parent, 'plugin.json')
+    const manifestPath = join(root, '.codex-plugin', 'plugin.json')
+    await mkdir(join(root, '.codex-plugin'), { recursive: true })
+    await writeFile(outsideManifest, '{"skills":"./outside"}\n')
+    await symlink(outsideManifest, manifestPath, 'file')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({
+      candidates: [],
+      issues: [{ path: manifestPath, reason: 'outside-root', errorCode: null }]
+    })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'does not block on a manifest FIFO',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-plugin-manifest-fifo-'))
+      temporaryDirectories.push(root)
+      const manifestPath = join(root, '.codex-plugin', 'plugin.json')
+      await mkdir(join(root, '.codex-plugin'), { recursive: true })
+      await execFileAsync('mkfifo', [manifestPath])
+
+      const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+      expect(result).toEqual({ candidates: [], issues: [] })
+    },
+    1_000
+  )
 })

--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -189,25 +189,26 @@ describe('plugin skill candidate scan', () => {
     expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
   })
 
-  it('falls back to the default root when a skills array contains an invalid value', async () => {
+  it('keeps valid roots when a skills array contains an invalid value', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-plugin-invalid-root-array-'))
     temporaryDirectories.push(root)
     const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
-    const candidate = join(packageRoot, 'skills', 'orca-cli')
+    const defaultCandidate = join(packageRoot, 'skills', 'orca-cli')
+    const declaredCandidate = join(packageRoot, 'custom-skills', 'orca-cli')
     await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
-    await mkdir(candidate, { recursive: true })
-    await mkdir(join(packageRoot, 'custom-skills', 'orca-cli'), { recursive: true })
+    await mkdir(defaultCandidate, { recursive: true })
+    await mkdir(declaredCandidate, { recursive: true })
     await writeFile(
       join(packageRoot, '.codex-plugin', 'plugin.json'),
       '{"skills":["./custom-skills",7]}\n'
     )
-    await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
-    await writeFile(join(packageRoot, 'custom-skills', 'orca-cli', 'SKILL.md'), '# Wrong root\n')
+    await writeFile(join(defaultCandidate, 'SKILL.md'), '# Wrong root\n')
+    await writeFile(join(declaredCandidate, 'SKILL.md'), '# Orca CLI\n')
 
     const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
 
     expect(result).toEqual({
-      candidates: [{ name: 'orca-cli', path: candidate }],
+      candidates: [{ name: 'orca-cli', path: declaredCandidate }],
       issues: []
     })
   })

--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -18,13 +18,81 @@ describe('plugin skill candidate scan', () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-plugin-skill-scan-'))
     temporaryDirectories.push(root)
     await Promise.all(
-      ['one', 'two'].map((vendor) => mkdir(join(root, vendor, 'orca-cli'), { recursive: true }))
+      ['one', 'two'].map(async (vendor) => {
+        await mkdir(join(root, vendor, 'orca-cli'), { recursive: true })
+        await writeFile(join(root, vendor, 'orca-cli', 'SKILL.md'), '# Orca CLI\n')
+      })
     )
 
     const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), 1)
 
     expect(result.candidates).toHaveLength(1)
     expect(result.issues).toEqual([{ path: root, reason: 'candidate-limit', errorCode: null }])
+  })
+
+  it('completes a real-shaped Codex cache without reporting coverage issues', async () => {
+    // Mirrors ~/.codex/plugins/cache: <vendor>/<plugin>/<version>/.codex-plugin, with the
+    // skill's own payload nesting well past the raw traversal depth (issue #10659).
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-real-shape-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'openai-bundled', 'sites', '0.1.31')
+    const skill = join(packageRoot, 'skills', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await mkdir(
+      join(skill, 'templates', 'vinext-starter', 'examples', 'd1', 'app', 'api', 'deep'),
+      { recursive: true }
+    )
+    await writeFile(join(packageRoot, '.codex-plugin', 'plugin.json'), '{"skills":"./skills/"}\n')
+    await writeFile(join(skill, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({ candidates: [{ name: 'orca-cli', path: skill }], issues: [] })
+  })
+
+  it('does not emit a plugin directory that only shares a skill name', async () => {
+    // The cached plugin is itself called orca-cli. Only the SKILL.md below it is a skill.
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-name-collision-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'openai-bundled', 'orca-cli', '1.0.0')
+    const skill = join(packageRoot, 'skills', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await mkdir(skill, { recursive: true })
+    await writeFile(join(packageRoot, '.codex-plugin', 'plugin.json'), '{"skills":"./skills/"}\n')
+    await writeFile(join(skill, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({ candidates: [{ name: 'orca-cli', path: skill }], issues: [] })
+  })
+
+  it('does not emit a bare known-name directory that carries no SKILL.md', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-bare-name-'))
+    temporaryDirectories.push(root)
+    await mkdir(join(root, 'vendor', 'orca-cli', 'assets'), { recursive: true })
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    expect(result).toEqual({ candidates: [], issues: [] })
+  })
+
+  it('stops descending once a skill package payload exceeds the nested skill budget', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-payload-prune-'))
+    temporaryDirectories.push(root)
+    const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+    const skill = join(packageRoot, 'skills', 'sites-building')
+    const buried = join(skill, 'templates', 'starter', 'examples', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+    await mkdir(buried, { recursive: true })
+    await writeFile(join(packageRoot, '.codex-plugin', 'plugin.json'), '{"skills":"./skills"}\n')
+    await writeFile(join(skill, 'SKILL.md'), '# Sites building\n')
+    await writeFile(join(buried, 'SKILL.md'), '# Orca CLI\n')
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+    // Why: pruning payload is a topology decision, so it must stay silent rather than
+    // surface as a coverage issue the user is asked to act on.
+    expect(result).toEqual({ candidates: [], issues: [] })
   })
 
   it('reports a depth-truncated subtree as scan coverage instead of a skill candidate', async () => {
@@ -179,7 +247,7 @@ describe('plugin skill candidate scan', () => {
     await writeFile(
       join(packageRoot, '.codex-plugin', 'plugin.json'),
       JSON.stringify({
-        skills: Array.from({ length: 4_097 }, (_, index) => `./missing-${index}`)
+        skills: Array.from({ length: 16_385 }, (_, index) => `./m${index}`)
       })
     )
 

--- a/src/main/skills/skill-plugin-cache-scan.ts
+++ b/src/main/skills/skill-plugin-cache-scan.ts
@@ -6,9 +6,17 @@ import { declaredPluginSkillRoots, isWithinRoot } from './skill-plugin-manifest-
 
 const MAXIMUM_PLUGIN_SCAN_DEPTH = 9
 const MAXIMUM_DECLARED_SKILL_SCAN_DEPTH = 6
-const MAXIMUM_PLUGIN_SCAN_ENTRIES = 4_096
+// Why: a skill package's own payload (templates, fixtures, sample apps) is not a skill
+// tree, and it is what drives ordinary caches past the depth and entry bounds. Descend
+// far enough to still find a skill grouped under a package, then stop.
+const MAXIMUM_NESTED_SKILL_DEPTH = 2
+// Why: sized against a real multi-vendor cache, which reads ~7k entries once payload is
+// pruned. The bound still exists to stop a hostile or runaway tree; it is not a budget
+// ordinary installs are meant to exhaust.
+const MAXIMUM_PLUGIN_SCAN_ENTRIES = 16_384
 export const MAXIMUM_PLUGIN_SKILL_CANDIDATES = 64
 const MAXIMUM_PLUGIN_SCAN_ISSUES = 16
+const SKILL_FILE_NAME = 'SKILL.md'
 
 export type KnownPluginSkillCandidate = {
   name: string
@@ -76,10 +84,32 @@ export async function scanKnownPluginSkillCandidates(
     candidates.push({ name, path })
   }
 
+  // Why: a directory only proves it is a skill by carrying SKILL.md. Matching a known
+  // name alone would promote any same-named plugin or vendor folder into an installation
+  // Orca never verified.
+  async function hasSkillFile(directory: string, entries: readonly Dirent[]): Promise<boolean> {
+    const skillFile = entries.find((entry) => entry.name === SKILL_FILE_NAME)
+    if (!skillFile) {
+      return false
+    }
+    if (!skillFile.isSymbolicLink()) {
+      return skillFile.isFile()
+    }
+    try {
+      return (await stat(join(directory, skillFile.name))).isFile()
+    } catch (error) {
+      if (errorCode(error) !== 'ENOENT') {
+        recordIssue(join(directory, skillFile.name), 'io-error', errorCode(error))
+      }
+      return false
+    }
+  }
+
   async function visit(
     directory: string,
     depth: number,
-    withinDeclaredSkillRoot = false
+    withinDeclaredSkillRoot = false,
+    payloadDepth: number | null = null
   ): Promise<void> {
     if (limitReached) {
       return
@@ -139,25 +169,19 @@ export async function scanKnownPluginSkillCandidates(
       await handle.close().catch(() => undefined)
     }
 
-    const skillFile = entries.find((entry) => entry.name === 'SKILL.md')
-    if (withinDeclaredSkillRoot && skillFile) {
-      let isSkillFile = skillFile.isFile()
-      if (skillFile.isSymbolicLink()) {
-        try {
-          isSkillFile = (await stat(join(directory, skillFile.name))).isFile()
-        } catch (error) {
-          if (errorCode(error) !== 'ENOENT') {
-            recordIssue(join(directory, skillFile.name), 'io-error', errorCode(error))
-          }
-          isSkillFile = false
-        }
+    const isSkillPackage = await hasSkillFile(directory, entries)
+    if (isSkillPackage) {
+      const name = basename(directory)
+      if (knownNames.has(name)) {
+        recordCandidate(name, directory)
       }
-      if (isSkillFile) {
-        const name = basename(directory)
-        if (knownNames.has(name)) {
-          recordCandidate(name, directory)
-        }
-      }
+    }
+
+    // Why: pruning payload is a topology decision, not a coverage failure, so it stays
+    // silent — recording it would put Orca's own traversal rules in the user's dialog.
+    const nextPayloadDepth = isSkillPackage ? 0 : payloadDepth === null ? null : payloadDepth + 1
+    if (nextPayloadDepth !== null && nextPayloadDepth > MAXIMUM_NESTED_SKILL_DEPTH) {
+      return
     }
 
     const skillRoots = await declaredPluginSkillRoots(directory, entries, resolvedRoot, recordIssue)
@@ -202,7 +226,10 @@ export async function scanKnownPluginSkillCandidates(
           if (errorCode(error) !== 'ENOENT') {
             recordIssue(entryPath, 'io-error', errorCode(error))
           }
-          if (knownNames.has(entry.name)) {
+          // Why: inside a declared skill root the plugin itself claims this name is a
+          // skill, so an uninspectable link stays fail-closed. Outside one there is no
+          // such claim and no SKILL.md to read, so inventing a copy would be a guess.
+          if (withinDeclaredSkillRoot && knownNames.has(entry.name)) {
             recordCandidate(entry.name, entryPath)
           }
           continue
@@ -211,11 +238,7 @@ export async function scanKnownPluginSkillCandidates(
       if (!directoryEntry) {
         continue
       }
-      if (!withinDeclaredSkillRoot && knownNames.has(entry.name)) {
-        recordCandidate(entry.name, entryPath)
-        continue
-      }
-      await visit(entryPath, depth + 1, withinDeclaredSkillRoot)
+      await visit(entryPath, depth + 1, withinDeclaredSkillRoot, nextPayloadDepth)
     }
   }
 

--- a/src/main/skills/skill-plugin-cache-scan.ts
+++ b/src/main/skills/skill-plugin-cache-scan.ts
@@ -1,20 +1,29 @@
 import type { Dirent } from 'node:fs'
 import { opendir, realpath, stat } from 'node:fs/promises'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
+import type { SkillFreshnessScanIssueReason } from '../../shared/skill-freshness'
+import { declaredPluginSkillRoots, isWithinRoot } from './skill-plugin-manifest-roots'
 
 const MAXIMUM_PLUGIN_SCAN_DEPTH = 9
+const MAXIMUM_DECLARED_SKILL_SCAN_DEPTH = 6
 const MAXIMUM_PLUGIN_SCAN_ENTRIES = 4_096
 export const MAXIMUM_PLUGIN_SKILL_CANDIDATES = 64
-const MAXIMUM_PLUGIN_INCOMPLETE_PATHS = 16
+const MAXIMUM_PLUGIN_SCAN_ISSUES = 16
 
 export type KnownPluginSkillCandidate = {
   name: string
   path: string
 }
 
+export type KnownPluginSkillScanIssue = {
+  path: string
+  reason: SkillFreshnessScanIssueReason
+  errorCode: string | null
+}
+
 export type KnownPluginSkillScan = {
   candidates: KnownPluginSkillCandidate[]
-  incompletePaths: string[]
+  issues: KnownPluginSkillScanIssue[]
 }
 
 function errorCode(error: unknown): string | null {
@@ -29,32 +38,57 @@ export async function scanKnownPluginSkillCandidates(
   maximumCandidates = MAXIMUM_PLUGIN_SKILL_CANDIDATES
 ): Promise<KnownPluginSkillScan> {
   const candidates: KnownPluginSkillCandidate[] = []
-  const incompletePaths = new Set<string>()
+  const issues: KnownPluginSkillScanIssue[] = []
+  const issueKeys = new Set<string>()
   const visited = new Set<string>()
+  let resolvedRoot: string | null = null
   let entryCount = 0
   let limitReached = false
 
-  function recordIncomplete(path: string): void {
-    if (incompletePaths.has(path)) {
+  function recordIssue(
+    path: string,
+    reason: KnownPluginSkillScanIssue['reason'],
+    code: string | null = null
+  ): void {
+    const key = `${path}\0${reason}\0${code ?? ''}`
+    if (issueKeys.has(key)) {
       return
     }
-    if (incompletePaths.size >= MAXIMUM_PLUGIN_INCOMPLETE_PATHS) {
-      // Why: each incomplete path expands to one conservative row per official
-      // skill. Collapse a hostile cache into one poison sentinel before IPC/render fanout.
-      incompletePaths.clear()
-      incompletePaths.add(rootPath)
+    if (issues.length >= MAXIMUM_PLUGIN_SCAN_ISSUES) {
+      issues.splice(0, issues.length, {
+        path: rootPath,
+        reason: 'issue-limit',
+        errorCode: null
+      })
       limitReached = true
       return
     }
-    incompletePaths.add(path)
+    issueKeys.add(key)
+    issues.push({ path, reason, errorCode: code })
   }
 
-  async function visit(directory: string, depth: number): Promise<void> {
+  function recordCandidate(name: string, path: string): void {
+    if (candidates.length >= maximumCandidates) {
+      limitReached = true
+      recordIssue(rootPath, 'candidate-limit')
+      return
+    }
+    candidates.push({ name, path })
+  }
+
+  async function visit(
+    directory: string,
+    depth: number,
+    withinDeclaredSkillRoot = false
+  ): Promise<void> {
     if (limitReached) {
       return
     }
-    if (depth > MAXIMUM_PLUGIN_SCAN_DEPTH) {
-      recordIncomplete(directory)
+    const maximumDepth = withinDeclaredSkillRoot
+      ? MAXIMUM_DECLARED_SKILL_SCAN_DEPTH
+      : MAXIMUM_PLUGIN_SCAN_DEPTH
+    if (depth > maximumDepth) {
+      recordIssue(directory, 'depth-limit')
       return
     }
     let resolved: string
@@ -62,8 +96,14 @@ export async function scanKnownPluginSkillCandidates(
       resolved = await realpath(directory)
     } catch (error) {
       if (errorCode(error) !== 'ENOENT') {
-        recordIncomplete(directory)
+        recordIssue(directory, 'io-error', errorCode(error))
       }
+      return
+    }
+    if (resolvedRoot === null) {
+      resolvedRoot = resolved
+    } else if (!isWithinRoot(resolvedRoot, resolved)) {
+      recordIssue(directory, 'outside-root')
       return
     }
     if (visited.has(resolved)) {
@@ -73,9 +113,9 @@ export async function scanKnownPluginSkillCandidates(
 
     let handle: Awaited<ReturnType<typeof opendir>>
     try {
-      handle = await opendir(directory)
-    } catch {
-      recordIncomplete(directory)
+      handle = await opendir(resolved)
+    } catch (error) {
+      recordIssue(directory, 'io-error', errorCode(error))
       return
     }
     const entries: Dirent[] = []
@@ -88,15 +128,54 @@ export async function scanKnownPluginSkillCandidates(
         entryCount += 1
         if (entryCount > MAXIMUM_PLUGIN_SCAN_ENTRIES) {
           limitReached = true
-          recordIncomplete(rootPath)
+          recordIssue(rootPath, 'entry-limit')
           break
         }
         entries.push(entry)
       }
-    } catch {
-      recordIncomplete(directory)
+    } catch (error) {
+      recordIssue(directory, 'io-error', errorCode(error))
     } finally {
       await handle.close().catch(() => undefined)
+    }
+
+    const skillFile = entries.find((entry) => entry.name === 'SKILL.md')
+    if (withinDeclaredSkillRoot && skillFile) {
+      let isSkillFile = skillFile.isFile()
+      if (skillFile.isSymbolicLink()) {
+        try {
+          isSkillFile = (await stat(join(directory, skillFile.name))).isFile()
+        } catch (error) {
+          if (errorCode(error) !== 'ENOENT') {
+            recordIssue(join(directory, skillFile.name), 'io-error', errorCode(error))
+          }
+          isSkillFile = false
+        }
+      }
+      if (isSkillFile) {
+        const name = basename(directory)
+        if (knownNames.has(name)) {
+          recordCandidate(name, directory)
+        }
+      }
+    }
+
+    const skillRoots = await declaredPluginSkillRoots(directory, entries, resolvedRoot, recordIssue)
+    if (limitReached) {
+      return
+    }
+    if (skillRoots) {
+      const skillRootDepth = withinDeclaredSkillRoot ? depth + 1 : 0
+      for (const skillRoot of skillRoots.sort()) {
+        entryCount += 1
+        if (entryCount > MAXIMUM_PLUGIN_SCAN_ENTRIES) {
+          limitReached = true
+          recordIssue(rootPath, 'entry-limit')
+          return
+        }
+        await visit(skillRoot, skillRootDepth, true)
+      }
+      return
     }
 
     entries.sort((left, right) => (left.name === right.name ? 0 : left.name < right.name ? -1 : 1))
@@ -104,19 +183,27 @@ export async function scanKnownPluginSkillCandidates(
       if (limitReached) {
         return
       }
+      if (entry.name === 'node_modules') {
+        continue
+      }
       const entryPath = join(directory, entry.name)
       let directoryEntry = entry.isDirectory()
       if (entry.isSymbolicLink()) {
         try {
           directoryEntry = (await stat(entryPath)).isDirectory()
-        } catch {
-          if (knownNames.has(entry.name)) {
-            if (candidates.length >= maximumCandidates) {
-              limitReached = true
-              recordIncomplete(rootPath)
-              return
+          if (directoryEntry) {
+            const resolvedEntry = await realpath(entryPath)
+            if (resolvedRoot !== null && !isWithinRoot(resolvedRoot, resolvedEntry)) {
+              recordIssue(entryPath, 'outside-root')
+              continue
             }
-            candidates.push({ name: entry.name, path: entryPath })
+          }
+        } catch (error) {
+          if (errorCode(error) !== 'ENOENT') {
+            recordIssue(entryPath, 'io-error', errorCode(error))
+          }
+          if (knownNames.has(entry.name)) {
+            recordCandidate(entry.name, entryPath)
           }
           continue
         }
@@ -124,19 +211,14 @@ export async function scanKnownPluginSkillCandidates(
       if (!directoryEntry) {
         continue
       }
-      if (knownNames.has(entry.name)) {
-        if (candidates.length >= maximumCandidates) {
-          limitReached = true
-          recordIncomplete(rootPath)
-          return
-        }
-        candidates.push({ name: entry.name, path: entryPath })
+      if (!withinDeclaredSkillRoot && knownNames.has(entry.name)) {
+        recordCandidate(entry.name, entryPath)
         continue
       }
-      await visit(entryPath, depth + 1)
+      await visit(entryPath, depth + 1, withinDeclaredSkillRoot)
     }
   }
 
   await visit(rootPath, 0)
-  return { candidates, incompletePaths: [...incompletePaths] }
+  return { candidates, issues }
 }

--- a/src/main/skills/skill-plugin-manifest-roots.ts
+++ b/src/main/skills/skill-plugin-manifest-roots.ts
@@ -101,10 +101,10 @@ export async function declaredPluginSkillRoots(
       }
       const skills = (parsed as Record<string, unknown>).skills
       const values = Array.isArray(skills) ? skills : [skills]
-      const roots = values.map((value) => resolveManifestSkillPath(directory, value))
-      return roots.length > 0 && roots.every((value): value is string => value !== null)
-        ? [...new Set(roots)]
-        : [join(directory, 'skills')]
+      const roots = values
+        .map((value) => resolveManifestSkillPath(directory, value))
+        .filter((value): value is string => value !== null)
+      return roots.length > 0 ? [...new Set(roots)] : [join(directory, 'skills')]
     } catch (error) {
       if (!(error instanceof SyntaxError)) {
         recordIssue(manifestPath, 'io-error', errorCode(error))

--- a/src/main/skills/skill-plugin-manifest-roots.ts
+++ b/src/main/skills/skill-plugin-manifest-roots.ts
@@ -1,0 +1,118 @@
+import { constants, type Dirent } from 'node:fs'
+import { open, realpath } from 'node:fs/promises'
+import { isAbsolute, join, relative, sep } from 'node:path'
+import type { SkillFreshnessScanIssueReason } from '../../shared/skill-freshness'
+
+const MAXIMUM_PLUGIN_MANIFEST_BYTES = 256 * 1024
+const PLUGIN_MANIFEST_DIRECTORIES = ['.codex-plugin', '.claude-plugin', '.cursor-plugin'] as const
+const MANIFEST_OPEN_FLAGS =
+  constants.O_RDONLY |
+  (process.platform === 'win32' ? 0 : constants.O_NONBLOCK | constants.O_NOFOLLOW)
+
+function errorCode(error: unknown): string | null {
+  return error && typeof error === 'object' && 'code' in error && typeof error.code === 'string'
+    ? error.code
+    : null
+}
+
+export function isWithinRoot(root: string, path: string): boolean {
+  const relativePath = relative(root, path)
+  return !isAbsolute(relativePath) && relativePath.split(sep)[0] !== '..'
+}
+
+function resolveManifestSkillPath(directory: string, value: unknown): string | null {
+  if (typeof value !== 'string' || !value.startsWith('./')) {
+    return null
+  }
+  const relativePath = value.slice(2)
+  if (!relativePath || relativePath.split(/[\\/]/).includes('..')) {
+    return null
+  }
+  return join(directory, relativePath)
+}
+
+export async function declaredPluginSkillRoots(
+  directory: string,
+  entries: readonly Dirent[],
+  resolvedRoot: string,
+  recordIssue: (path: string, reason: SkillFreshnessScanIssueReason, code?: string | null) => void
+): Promise<string[] | null> {
+  for (const manifestDirectory of PLUGIN_MANIFEST_DIRECTORIES) {
+    if (!entries.some((entry) => entry.name === manifestDirectory)) {
+      continue
+    }
+    const manifestPath = join(directory, manifestDirectory, 'plugin.json')
+    let resolvedManifestPath: string
+    try {
+      resolvedManifestPath = await realpath(manifestPath)
+    } catch (error) {
+      const code = errorCode(error)
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        continue
+      }
+      recordIssue(manifestPath, 'io-error', code)
+      return null
+    }
+    if (!isWithinRoot(resolvedRoot, resolvedManifestPath)) {
+      recordIssue(manifestPath, 'outside-root')
+      return null
+    }
+    let manifestFile: Awaited<ReturnType<typeof open>>
+    try {
+      manifestFile = await open(resolvedManifestPath, MANIFEST_OPEN_FLAGS)
+    } catch (error) {
+      const code = errorCode(error)
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        continue
+      }
+      recordIssue(manifestPath, 'io-error', code)
+      return null
+    }
+    try {
+      const manifestStat = await manifestFile.stat()
+      if (!manifestStat.isFile()) {
+        continue
+      }
+      if (manifestStat.size > MAXIMUM_PLUGIN_MANIFEST_BYTES) {
+        recordIssue(manifestPath, 'manifest-limit')
+        return null
+      }
+      const content = Buffer.alloc(MAXIMUM_PLUGIN_MANIFEST_BYTES + 1)
+      let contentLength = 0
+      while (contentLength < content.length) {
+        const { bytesRead } = await manifestFile.read(
+          content,
+          contentLength,
+          content.length - contentLength,
+          contentLength
+        )
+        if (bytesRead === 0) {
+          break
+        }
+        contentLength += bytesRead
+      }
+      if (contentLength > MAXIMUM_PLUGIN_MANIFEST_BYTES) {
+        recordIssue(manifestPath, 'manifest-limit')
+        return null
+      }
+      const parsed: unknown = JSON.parse(content.toString('utf8', 0, contentLength))
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return null
+      }
+      const skills = (parsed as Record<string, unknown>).skills
+      const values = Array.isArray(skills) ? skills : [skills]
+      const roots = values.map((value) => resolveManifestSkillPath(directory, value))
+      return roots.length > 0 && roots.every((value): value is string => value !== null)
+        ? [...new Set(roots)]
+        : [join(directory, 'skills')]
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) {
+        recordIssue(manifestPath, 'io-error', errorCode(error))
+      }
+      return null
+    } finally {
+      await manifestFile.close().catch(() => undefined)
+    }
+  }
+  return null
+}

--- a/src/renderer/src/components/skills/SkillFreshnessNudge.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessNudge.test.tsx
@@ -51,6 +51,7 @@ function eligibleInventory(): SkillFreshnessInventory {
     schemaVersion: 1,
     installations: [placement()],
     eligibleUpdateNames: ['orca-cli'],
+    scanIssues: [],
     scannedAt: 1
   }
 }
@@ -154,6 +155,7 @@ describe('SkillFreshnessNudge', () => {
       schemaVersion: 1,
       installations: [placement({ status: 'current', observedPackageDigest: 'current' })],
       eligibleUpdateNames: [],
+      scanIssues: [],
       scannedAt: 2
     }
     await rerenderNudge()
@@ -212,6 +214,7 @@ describe('SkillFreshnessNudge', () => {
       schemaVersion: 1,
       installations: [placement(), placement({ id: 'repo-copy', topology: 'repo-scope' })],
       eligibleUpdateNames: [],
+      scanIssues: [],
       scannedAt: 1
     }
 

--- a/src/renderer/src/components/skills/SkillFreshnessStatusPill.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessStatusPill.test.tsx
@@ -55,6 +55,7 @@ function inventory(
       errorCategory: null
     })),
     eligibleUpdateNames,
+    scanIssues: [],
     scannedAt: 1
   }
 }

--- a/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
@@ -121,6 +121,7 @@ function eligibleInventory(): SkillFreshnessInventory {
     schemaVersion: 1,
     installations: [placement('orca-cli')],
     eligibleUpdateNames: ['orca-cli'],
+    scanIssues: [],
     scannedAt: 1
   }
 }
@@ -222,6 +223,7 @@ describe('SkillFreshnessUpdateDialog', () => {
         placement('orca-cli', { status: 'current', observedPackageDigest: 'current' })
       ],
       eligibleUpdateNames: [],
+      scanIssues: [],
       scannedAt: 2
     }
     await rerender()
@@ -229,6 +231,37 @@ describe('SkillFreshnessUpdateDialog', () => {
     expect(mocks.terminalCommits).toContainEqual(['npx skills update orca-cli --global', true])
     expect(container?.textContent).toContain('All installed Orca skills are up to date.')
     expect(container?.querySelector('[data-testid="update-terminal"]')).toBeNull()
+  })
+
+  it('shows incomplete plugin coverage without presenting a fabricated skill copy', async () => {
+    mocks.inventory = {
+      schemaVersion: 1,
+      installations: [
+        placement('orca-cli', { status: 'current', observedPackageDigest: 'current' })
+      ],
+      eligibleUpdateNames: [],
+      scanIssues: [
+        {
+          rootId: 'codex-plugin-cache',
+          sourceLabel: 'Codex plugin cache',
+          path: '/home/.codex/plugins/cache/vendor/deep',
+          reason: 'depth-limit',
+          errorCode: null
+        }
+      ],
+      scannedAt: 2
+    }
+    await renderDialog()
+    await openViaRequest()
+
+    expect(container?.textContent).toContain(
+      'Orca could not finish checking plugin-managed skills.'
+    )
+    expect(container?.textContent).toContain('/home/.codex/plugins/cache/vendor/deep')
+    expect(container?.textContent).toContain('scan depth limit')
+    expect(container?.textContent).not.toContain('All installed Orca skills are up to date.')
+    expect(container?.textContent).not.toContain('/home/.codex/plugins/cache/vendor/deep/orca-cli')
+    expect(container?.querySelector('[data-collapsible-open="true"]')).not.toBeNull()
   })
 
   it('auto-expands Details when a rescan changes the result to blocked', async () => {
@@ -240,6 +273,7 @@ describe('SkillFreshnessUpdateDialog', () => {
       schemaVersion: 1,
       installations: [placement('orca-cli', { topology: 'read-only' })],
       eligibleUpdateNames: [],
+      scanIssues: [],
       scannedAt: 2
     }
     await rerender()
@@ -268,6 +302,7 @@ describe('SkillFreshnessUpdateDialog', () => {
         placement('orca-cli', { status: 'current', observedPackageDigest: 'current' })
       ],
       eligibleUpdateNames: [],
+      scanIssues: [],
       scannedAt: 2
     }
     mocks.loading = false
@@ -368,6 +403,7 @@ describe('SkillFreshnessUpdateDialog', () => {
         })
       ],
       eligibleUpdateNames: [],
+      scanIssues: [],
       scannedAt: 1
     }
     await renderDialog()
@@ -385,6 +421,7 @@ describe('SkillFreshnessUpdateDialog', () => {
       schemaVersion: 1,
       installations: [placement('orca-cli', { topology: 'read-only' })],
       eligibleUpdateNames: [],
+      scanIssues: [],
       scannedAt: 1
     }
     await renderDialog()

--- a/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.tsx
@@ -25,13 +25,20 @@ import { OnboardingInlineCommandTerminal } from '@/components/onboarding/Onboard
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { groupSkillFreshness } from './skill-freshness-grouping'
 import { SkillFreshnessGroup } from './skill-freshness-group'
+import { SkillFreshnessScanIssues } from './skill-freshness-scan-issues'
 import {
   consumeSkillFreshnessUpdateDialogRequest,
   getSkillFreshnessUpdateDialogRequest,
   subscribeSkillFreshnessUpdateDialog
 } from './skill-freshness-update-dialog'
 
-type FreshnessSummaryKind = 'loading' | 'empty' | 'eligible' | 'current' | 'attention'
+type FreshnessSummaryKind =
+  | 'loading'
+  | 'empty'
+  | 'eligible'
+  | 'current'
+  | 'attention'
+  | 'scan-incomplete'
 
 function summarizeInventory(
   inventory: SkillFreshnessInventory | null,
@@ -40,11 +47,14 @@ function summarizeInventory(
   if (!inventory) {
     return 'loading'
   }
-  if (inventory.installations.length === 0) {
-    return 'empty'
-  }
   if (inventory.eligibleUpdateNames.length > 0) {
     return 'eligible'
+  }
+  if (inventory.scanIssues.length > 0) {
+    return 'scan-incomplete'
+  }
+  if (inventory.installations.length === 0) {
+    return 'empty'
   }
   // Why: with nothing eligible, the modal is either genuinely all-clear or has
   // out-of-date skills it can't safely update; the group filter already dropped
@@ -88,6 +98,25 @@ function SummaryHeadline({
           'auto.components.skills.SkillFreshnessUpdateDialog.success',
           'All installed Orca skills are up to date.'
         )}
+      </div>
+    )
+  }
+  if (kind === 'scan-incomplete') {
+    return (
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+          <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
+          {translate(
+            'auto.components.skills.SkillFreshnessUpdateDialog.scanIncomplete',
+            'Orca could not finish checking plugin-managed skills.'
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.skills.SkillFreshnessUpdateDialog.scanIncompleteDescription',
+            'Open Update details to see which plugin folders were skipped.'
+          )}
+        </p>
       </div>
     )
   }
@@ -144,12 +173,14 @@ export function SkillFreshnessUpdateDialog(): React.JSX.Element {
   const inventoryAtTerminalExitRef = useRef<SkillFreshnessInventory | null>(null)
   const inventory = state.inventory
   const eligibleNames = useMemo(() => inventory?.eligibleUpdateNames ?? [], [inventory])
+  const scanIssues = inventory?.scanIssues ?? []
   const groups = useMemo(
     () =>
       inventory ? groupSkillFreshness(inventory.installations, inventory.eligibleUpdateNames) : [],
     [inventory]
   )
-  const hasBlockedGroup = groups.some((group) => group.status === 'cannot-update')
+  const hasBlockedGroup =
+    scanIssues.length > 0 || groups.some((group) => group.status === 'cannot-update')
   const updateCommand = buildTargetedSkillUpdateCommand(eligibleNames)
   const summaryKind = summarizeInventory(inventory, hasBlockedGroup)
   const terminalAuthorizationPending =
@@ -252,7 +283,7 @@ export function SkillFreshnessUpdateDialog(): React.JSX.Element {
     notifyInstalledAgentSkillsChanged()
   }
 
-  const hasVisibleGroups = groups.length > 0
+  const hasVisibleGroups = scanIssues.length > 0 || groups.length > 0
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -338,6 +369,7 @@ export function SkillFreshnessUpdateDialog(): React.JSX.Element {
             </CollapsibleTrigger>
             <CollapsibleContent className="mt-1 divide-y divide-border/40 rounded-md border border-border/60 p-3">
               <TooltipProvider>
+                <SkillFreshnessScanIssues issues={scanIssues} />
                 {groups.map((group) => (
                   <SkillFreshnessGroup key={group.name} group={group} />
                 ))}

--- a/src/renderer/src/components/skills/skill-freshness-scan-issues.tsx
+++ b/src/renderer/src/components/skills/skill-freshness-scan-issues.tsx
@@ -1,0 +1,74 @@
+import type { SkillFreshnessScanIssue } from '../../../../shared/skill-freshness'
+import { translate } from '@/i18n/i18n'
+
+function issueDescription(issue: SkillFreshnessScanIssue): string {
+  switch (issue.reason) {
+    case 'depth-limit':
+      return translate(
+        'auto.components.skills.SkillFreshnessUpdateDialog.scanDepthLimit',
+        'Orca reached its plugin scan depth limit before checking this folder.'
+      )
+    case 'entry-limit':
+      return translate(
+        'auto.components.skills.SkillFreshnessUpdateDialog.scanEntryLimit',
+        'Orca reached its plugin scan entry limit before checking the rest of this cache.'
+      )
+    case 'candidate-limit':
+      return translate(
+        'auto.components.skills.SkillFreshnessUpdateDialog.scanCandidateLimit',
+        'Orca found more same-named skill folders than it can safely inspect.'
+      )
+    case 'manifest-limit':
+      return translate(
+        'auto.components.skills.SkillFreshnessUpdateDialog.scanManifestLimit',
+        'Orca skipped this plugin manifest because it exceeded the safe read limit.'
+      )
+    case 'outside-root':
+      return translate(
+        'auto.components.skills.SkillFreshnessUpdateDialog.scanOutsideRoot',
+        'Orca skipped this plugin path because it points outside the plugin cache.'
+      )
+    case 'io-error':
+      return issue.errorCode
+        ? translate(
+            'auto.components.skills.SkillFreshnessUpdateDialog.scanIoErrorWithCode',
+            'Orca could not read this plugin path ({{value0}}).',
+            { value0: issue.errorCode }
+          )
+        : translate(
+            'auto.components.skills.SkillFreshnessUpdateDialog.scanIoError',
+            'Orca could not read this plugin path.'
+          )
+    case 'issue-limit':
+      return translate(
+        'auto.components.skills.SkillFreshnessUpdateDialog.scanIssueLimit',
+        'Orca found too many skipped plugin folders to list individually.'
+      )
+  }
+}
+
+export function SkillFreshnessScanIssues({
+  issues
+}: {
+  issues: readonly SkillFreshnessScanIssue[]
+}): React.JSX.Element {
+  return (
+    <>
+      {issues.map((issue) => (
+        <div
+          key={`${issue.rootId}\0${issue.path}\0${issue.reason}`}
+          className="space-y-1.5 py-3 first:pt-0 last:pb-0"
+        >
+          <p className="text-sm font-medium text-foreground">{issue.sourceLabel}</p>
+          <p className="text-xs leading-5 text-muted-foreground">{issueDescription(issue)}</p>
+          <span
+            className="block truncate font-mono text-[11px] text-muted-foreground"
+            title={issue.path}
+          >
+            {issue.path}
+          </span>
+        </div>
+      ))}
+    </>
+  )
+}

--- a/src/renderer/src/hooks/useSkillFreshness.test.tsx
+++ b/src/renderer/src/hooks/useSkillFreshness.test.tsx
@@ -25,7 +25,7 @@ function deferred<T>(): {
 }
 
 function inventory(scannedAt: number, eligibleUpdateNames: string[] = []): SkillFreshnessInventory {
-  return { schemaVersion: 1, installations: [], eligibleUpdateNames, scannedAt }
+  return { schemaVersion: 1, installations: [], eligibleUpdateNames, scanIssues: [], scannedAt }
 }
 
 let root: Root | null = null

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3783,7 +3783,17 @@
           "terminalDescription": "Review the pre-filled command, then press Enter to run it.",
           "terminalAria": "Orca skill update terminal",
           "checkNow": "Re-check",
-          "close": "Close"
+          "close": "Close",
+          "scanIncomplete": "Orca could not finish checking plugin-managed skills.",
+          "scanIncompleteDescription": "Open Update details to see which plugin folders were skipped.",
+          "scanDepthLimit": "Orca reached its plugin scan depth limit before checking this folder.",
+          "scanEntryLimit": "Orca reached its plugin scan entry limit before checking the rest of this cache.",
+          "scanCandidateLimit": "Orca found more same-named skill folders than it can safely inspect.",
+          "scanManifestLimit": "Orca skipped this plugin manifest because it exceeded the safe read limit.",
+          "scanOutsideRoot": "Orca skipped this plugin path because it points outside the plugin cache.",
+          "scanIoErrorWithCode": "Orca could not read this plugin path ({{value0}}).",
+          "scanIoError": "Orca could not read this plugin path.",
+          "scanIssueLimit": "Orca found too many skipped plugin folders to list individually."
         },
         "SkillFreshnessStatusPill": {
           "updateAvailable": "Update available",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3760,7 +3760,17 @@
           "terminalDescription": "Revisa el comando pre-rellenado y pulsa Intro para ejecutarlo.",
           "terminalAria": "Terminal de actualización de skills de Orca",
           "checkNow": "Comprobar ahora",
-          "close": "Cerrar"
+          "close": "Cerrar",
+          "scanIncomplete": "Orca no pudo terminar de comprobar los skills gestionados por plugins.",
+          "scanIncompleteDescription": "Abre los detalles de la actualización para ver qué carpetas de plugins se omitieron.",
+          "scanDepthLimit": "Orca alcanzó el límite de profundidad del análisis antes de comprobar esta carpeta.",
+          "scanEntryLimit": "Orca alcanzó el límite de entradas del análisis antes de comprobar el resto de esta caché.",
+          "scanCandidateLimit": "Orca encontró más carpetas de skills con el mismo nombre de las que puede inspeccionar de forma segura.",
+          "scanManifestLimit": "Orca omitió este manifiesto del plugin porque superaba el límite de lectura segura.",
+          "scanOutsideRoot": "Orca omitió esta ruta del plugin porque apunta fuera de la caché de plugins.",
+          "scanIoErrorWithCode": "Orca no pudo leer esta ruta del plugin ({{value0}}).",
+          "scanIoError": "Orca no pudo leer esta ruta del plugin.",
+          "scanIssueLimit": "Orca encontró demasiadas carpetas de plugins omitidas para mostrarlas por separado."
         },
         "SkillFreshnessStatusPill": {
           "updateAvailable": "Actualización disponible",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3760,7 +3760,17 @@
           "terminalDescription": "入力済みのコマンドを確認し、Enter キーを押して実行してください。",
           "terminalAria": "Orca スキル更新ターミナル",
           "checkNow": "今すぐ確認",
-          "close": "閉じる"
+          "close": "閉じる",
+          "scanIncomplete": "Orca はプラグインで管理されるスキルの確認を完了できませんでした。",
+          "scanIncompleteDescription": "更新の詳細を開くと、スキップされたプラグインフォルダーを確認できます。",
+          "scanDepthLimit": "このフォルダーを確認する前に、プラグインスキャンの深度上限に達しました。",
+          "scanEntryLimit": "キャッシュの残りを確認する前に、プラグインスキャンのエントリ数上限に達しました。",
+          "scanCandidateLimit": "安全に確認できる数を超える同名のスキルフォルダーが見つかりました。",
+          "scanManifestLimit": "安全な読み取り上限を超えたため、このプラグインマニフェストをスキップしました。",
+          "scanOutsideRoot": "プラグインキャッシュの外部を指しているため、このプラグインパスをスキップしました。",
+          "scanIoErrorWithCode": "このプラグインパスを読み取れませんでした（{{value0}}）。",
+          "scanIoError": "このプラグインパスを読み取れませんでした。",
+          "scanIssueLimit": "スキップされたプラグインフォルダーが多すぎるため、個別に表示できません。"
         },
         "SkillFreshnessStatusPill": {
           "updateAvailable": "更新があります",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3760,7 +3760,17 @@
           "terminalDescription": "미리 입력된 명령을 검토한 후 Enter 키를 눌러 실행하세요.",
           "terminalAria": "Orca 스킬 업데이트 터미널",
           "checkNow": "지금 확인",
-          "close": "닫기"
+          "close": "닫기",
+          "scanIncomplete": "Orca가 플러그인으로 관리되는 스킬 확인을 완료하지 못했습니다.",
+          "scanIncompleteDescription": "업데이트 세부 정보를 열어 건너뛴 플러그인 폴더를 확인하세요.",
+          "scanDepthLimit": "이 폴더를 확인하기 전에 플러그인 검사 깊이 제한에 도달했습니다.",
+          "scanEntryLimit": "이 캐시의 나머지 항목을 확인하기 전에 플러그인 검사 항목 수 제한에 도달했습니다.",
+          "scanCandidateLimit": "안전하게 검사할 수 있는 수보다 많은 동명 스킬 폴더가 발견되었습니다.",
+          "scanManifestLimit": "안전한 읽기 제한을 초과한 플러그인 매니페스트를 건너뛰었습니다.",
+          "scanOutsideRoot": "플러그인 캐시 외부를 가리키는 플러그인 경로를 건너뛰었습니다.",
+          "scanIoErrorWithCode": "이 플러그인 경로를 읽지 못했습니다({{value0}}).",
+          "scanIoError": "이 플러그인 경로를 읽지 못했습니다.",
+          "scanIssueLimit": "건너뛴 플러그인 폴더가 너무 많아 개별적으로 표시할 수 없습니다."
         },
         "SkillFreshnessStatusPill": {
           "updateAvailable": "업데이트 가능",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3760,7 +3760,17 @@
           "terminalDescription": "检查预填的命令，然后按 Enter 键运行。",
           "terminalAria": "Orca 技能更新终端",
           "checkNow": "立即检查",
-          "close": "关闭"
+          "close": "关闭",
+          "scanIncomplete": "Orca 无法完成对插件管理技能的检查。",
+          "scanIncompleteDescription": "打开更新详情，查看哪些插件文件夹被跳过。",
+          "scanDepthLimit": "在检查此文件夹之前，Orca 已达到插件扫描深度上限。",
+          "scanEntryLimit": "在检查此缓存的其余内容之前，Orca 已达到插件扫描条目数上限。",
+          "scanCandidateLimit": "Orca 发现的同名技能文件夹数量超过了可安全检查的上限。",
+          "scanManifestLimit": "此插件清单超出安全读取限制，Orca 已将其跳过。",
+          "scanOutsideRoot": "此插件路径指向插件缓存之外，Orca 已将其跳过。",
+          "scanIoErrorWithCode": "Orca 无法读取此插件路径（{{value0}}）。",
+          "scanIoError": "Orca 无法读取此插件路径。",
+          "scanIssueLimit": "被跳过的插件文件夹过多，Orca 无法逐一列出。"
         },
         "SkillFreshnessStatusPill": {
           "updateAvailable": "有可用更新",

--- a/src/renderer/src/lib/agent-skill-nav-install-status.test.ts
+++ b/src/renderer/src/lib/agent-skill-nav-install-status.test.ts
@@ -57,7 +57,7 @@ function inventory(
   installations: SkillFreshnessInstallation[],
   eligibleUpdateNames: string[] = []
 ): SkillFreshnessInventory {
-  return { schemaVersion: 1, installations, eligibleUpdateNames, scannedAt: 1 }
+  return { schemaVersion: 1, installations, eligibleUpdateNames, scanIssues: [], scannedAt: 1 }
 }
 
 describe('getAgentSkillNavInstallStatus', () => {

--- a/src/renderer/src/lib/skill-freshness-display-status.test.ts
+++ b/src/renderer/src/lib/skill-freshness-display-status.test.ts
@@ -2,11 +2,27 @@ import { describe, expect, it } from 'vitest'
 import type {
   SkillFreshnessInstallation,
   SkillFreshnessInventory,
+  SkillFreshnessScanIssueReason,
   SkillFreshnessStatus
 } from '../../../shared/skill-freshness'
-import { getSkillFreshnessDisplayStatus } from './skill-freshness-display-status'
+import {
+  getSkillFreshnessDisplayStatus,
+  hasSkillCopyNeedingAttention
+} from './skill-freshness-display-status'
 
 const SKILL_NAME = 'orca-cli'
+
+function scanIssue(
+  reason: SkillFreshnessScanIssueReason
+): SkillFreshnessInventory['scanIssues'][number] {
+  return {
+    rootId: 'codex-plugin-cache',
+    sourceLabel: 'Codex plugin cache',
+    path: '/home/.codex/plugins/cache',
+    reason,
+    errorCode: reason === 'io-error' ? 'EACCES' : null
+  }
+}
 
 function placement(status: SkillFreshnessStatus, index = 0): SkillFreshnessInstallation {
   return {
@@ -77,24 +93,49 @@ describe('getSkillFreshnessDisplayStatus', () => {
     expect(getSkillFreshnessDisplayStatus(value, SKILL_NAME)).toBe('needs-attention')
   })
 
-  it('reports needs attention when plugin scan coverage is incomplete', () => {
+  it.each([
+    ['depth-limit'],
+    ['entry-limit'],
+    ['candidate-limit'],
+    ['manifest-limit'],
+    ['issue-limit']
+  ] as const)('does not report attention for the %s traversal bound', (reason) => {
+    // Why: these are Orca's own bounds. A large but healthy plugin cache would
+    // otherwise pin every skill amber with nothing the user could do about it.
     expect(
       getSkillFreshnessDisplayStatus(
-        inventory(
-          [placement('current')],
-          [],
-          [
-            {
-              rootId: 'codex-plugin-cache',
-              sourceLabel: 'Codex plugin cache',
-              path: '/home/.codex/plugins/cache',
-              reason: 'entry-limit',
-              errorCode: null
-            }
-          ]
-        ),
+        inventory([placement('current')], [], [scanIssue(reason)]),
         SKILL_NAME
       )
-    ).toBe('needs-attention')
+    ).toBe('up-to-date')
+  })
+
+  it.each([['outside-root'], ['io-error']] as const)(
+    'reports needs attention for the %s scan fault',
+    (reason) => {
+      expect(
+        getSkillFreshnessDisplayStatus(
+          inventory([placement('current')], [], [scanIssue(reason)]),
+          SKILL_NAME
+        )
+      ).toBe('needs-attention')
+    }
+  )
+})
+
+describe('hasSkillCopyNeedingAttention', () => {
+  it('ignores a traversal bound but keeps a real scan fault', () => {
+    expect(
+      hasSkillCopyNeedingAttention(
+        inventory([placement('current')], [], [scanIssue('entry-limit')]),
+        SKILL_NAME
+      )
+    ).toBe(false)
+    expect(
+      hasSkillCopyNeedingAttention(
+        inventory([placement('current')], [], [scanIssue('io-error')]),
+        SKILL_NAME
+      )
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/lib/skill-freshness-display-status.test.ts
+++ b/src/renderer/src/lib/skill-freshness-display-status.test.ts
@@ -33,9 +33,10 @@ function placement(status: SkillFreshnessStatus, index = 0): SkillFreshnessInsta
 
 function inventory(
   installations: SkillFreshnessInstallation[],
-  eligibleUpdateNames: string[] = []
+  eligibleUpdateNames: string[] = [],
+  scanIssues: SkillFreshnessInventory['scanIssues'] = []
 ): SkillFreshnessInventory {
-  return { schemaVersion: 1, installations, eligibleUpdateNames, scannedAt: 1 }
+  return { schemaVersion: 1, installations, eligibleUpdateNames, scanIssues, scannedAt: 1 }
 }
 
 describe('getSkillFreshnessDisplayStatus', () => {
@@ -74,5 +75,26 @@ describe('getSkillFreshnessDisplayStatus', () => {
     // Why: no eligible update is not proof a copy is fine. Green here would read as
     // all-clear over drift the update command cannot reach and the user cannot see.
     expect(getSkillFreshnessDisplayStatus(value, SKILL_NAME)).toBe('needs-attention')
+  })
+
+  it('reports needs attention when plugin scan coverage is incomplete', () => {
+    expect(
+      getSkillFreshnessDisplayStatus(
+        inventory(
+          [placement('current')],
+          [],
+          [
+            {
+              rootId: 'codex-plugin-cache',
+              sourceLabel: 'Codex plugin cache',
+              path: '/home/.codex/plugins/cache',
+              reason: 'entry-limit',
+              errorCode: null
+            }
+          ]
+        ),
+        SKILL_NAME
+      )
+    ).toBe('needs-attention')
   })
 })

--- a/src/renderer/src/lib/skill-freshness-display-status.ts
+++ b/src/renderer/src/lib/skill-freshness-display-status.ts
@@ -16,6 +16,9 @@ export function getSkillFreshnessDisplayStatus(
   if (inventory?.eligibleUpdateNames.includes(skillName)) {
     return 'update-available'
   }
+  if (inventory?.scanIssues.length) {
+    return 'needs-attention'
+  }
 
   let hasPlacement = false
   let hasBlockedCopy = false
@@ -48,14 +51,17 @@ export function hasSkillCopyNeedingAttention(
   inventory: SkillFreshnessInventory | null,
   skillName: string
 ): boolean {
-  return (inventory?.installations ?? []).some(
-    (installation) =>
-      installation.name === skillName &&
-      installation.status !== 'current' &&
-      // Why: an out-of-date copy the command converges is ordinary work, not a problem.
-      !(
-        SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(installation.topology) &&
-        installation.status === 'outdated'
-      )
+  return (
+    Boolean(inventory?.scanIssues.length) ||
+    (inventory?.installations ?? []).some(
+      (installation) =>
+        installation.name === skillName &&
+        installation.status !== 'current' &&
+        // Why: an out-of-date copy the command converges is ordinary work, not a problem.
+        !(
+          SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(installation.topology) &&
+          installation.status === 'outdated'
+        )
+    )
   )
 }

--- a/src/renderer/src/lib/skill-freshness-display-status.ts
+++ b/src/renderer/src/lib/skill-freshness-display-status.ts
@@ -1,4 +1,5 @@
 import {
+  isSkillScanIssueNeedingAttention,
   SUPPORTED_GLOBAL_SKILL_TOPOLOGIES,
   type SkillFreshnessInventory
 } from '../../../shared/skill-freshness'
@@ -16,7 +17,7 @@ export function getSkillFreshnessDisplayStatus(
   if (inventory?.eligibleUpdateNames.includes(skillName)) {
     return 'update-available'
   }
-  if (inventory?.scanIssues.length) {
+  if (inventory?.scanIssues.some(isSkillScanIssueNeedingAttention)) {
     return 'needs-attention'
   }
 
@@ -52,7 +53,7 @@ export function hasSkillCopyNeedingAttention(
   skillName: string
 ): boolean {
   return (
-    Boolean(inventory?.scanIssues.length) ||
+    Boolean(inventory?.scanIssues.some(isSkillScanIssueNeedingAttention)) ||
     (inventory?.installations ?? []).some(
       (installation) =>
         installation.name === skillName &&

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2790,6 +2790,7 @@ function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
         schemaVersion: 1,
         installations: [],
         eligibleUpdateNames: [],
+        scanIssues: [],
         scannedAt: Date.now()
       })
   }

--- a/src/shared/skill-freshness.ts
+++ b/src/shared/skill-freshness.ts
@@ -101,6 +101,18 @@ export type SkillFreshnessScanIssue = {
   errorCode: string | null
 }
 
+// Why: a real read failure or an escaping path is a fact about the user's disk and
+// stays actionable. Orca's own traversal bounds are not — reporting them as attention
+// turns an ordinary large plugin cache into a permanent amber pill on every skill.
+const SKILL_SCAN_ATTENTION_REASONS = new Set<SkillFreshnessScanIssueReason>([
+  'outside-root',
+  'io-error'
+])
+
+export function isSkillScanIssueNeedingAttention(issue: SkillFreshnessScanIssue): boolean {
+  return SKILL_SCAN_ATTENTION_REASONS.has(issue.reason)
+}
+
 export type SkillFreshnessInventory = {
   schemaVersion: 1
   installations: SkillFreshnessInstallation[]

--- a/src/shared/skill-freshness.ts
+++ b/src/shared/skill-freshness.ts
@@ -84,10 +84,28 @@ export type SkillFreshnessInstallation = {
   errorCategory: string | null
 }
 
+export type SkillFreshnessScanIssueReason =
+  | 'depth-limit'
+  | 'entry-limit'
+  | 'candidate-limit'
+  | 'manifest-limit'
+  | 'outside-root'
+  | 'io-error'
+  | 'issue-limit'
+
+export type SkillFreshnessScanIssue = {
+  rootId: string
+  sourceLabel: string
+  path: string
+  reason: SkillFreshnessScanIssueReason
+  errorCode: string | null
+}
+
 export type SkillFreshnessInventory = {
   schemaVersion: 1
   installations: SkillFreshnessInstallation[]
   eligibleUpdateNames: string[]
+  scanIssues: SkillFreshnessScanIssue[]
   scannedAt: number
 }
 


### PR DESCRIPTION
Repair pass on top of #10865 (`agent/fix-plugin-scan-coverage`). That PR stopped the scanner from fabricating per-skill `Inaccessible` placements, but two blocking problems survived, both reproducible against a real `~/.codex/plugins/cache`. `#10877` and `#10635` are untouched.

## 1. The ordinary scan did not finish, and its bounds became the same symptom

A skill package's own payload — templates, sample apps, vendored fixtures — was walked as if it were a skill tree. Ordinary OpenAI-bundled plugins therefore pushed past the depth and entry bounds, and the resulting diagnostics set **every** skill to `Needs attention` via `getSkillFreshnessDisplayStatus`, which returned `needs-attention` for any non-empty `scanIssues`. That is the symptom #10659 asked to remove, reintroduced one layer up. The entry bound also set `limitReached`, aborting the rest of the walk.

Traversal is now topology-aware. A directory carrying `SKILL.md` is a skill package; Orca descends a bounded `MAXIMUM_NESTED_SKILL_DEPTH` (2) below it so a skill grouped inside a package is still found — the existing nested-skill contract — then stops. Pruning payload is a topology decision, not a coverage failure, so it is silent.

Limits are kept, not removed:
- `MAXIMUM_PLUGIN_SCAN_ENTRIES` 4096 → 16384, sized against a measured real cache (~7.1k entries read once payload is pruned; ~2.3x headroom).
- Depth, candidate, manifest, and issue bounds unchanged.

Orca's own bounds no longer drive the attention pill. `isSkillScanIssueNeedingAttention` (shared, so main and renderer agree) keeps `io-error` and `outside-root` actionable — those are facts about the user's disk — and treats `depth-limit`, `entry-limit`, `candidate-limit`, `manifest-limit`, and `issue-limit` as coverage facts. The Details dialog still lists **every** skipped path and still reports `scan-incomplete`, so no information is lost; it simply stops being escalated to a per-skill badge the user cannot act on.

## 2. Live false-positive candidate rule

Outside a declared skill root, any directory whose bare name matched a known Orca skill was emitted as a candidate with no evidence, and the match `continue`d — so it also **masked** the genuine skill beneath it.

On this machine that produced `…/cache/openai-bundled/computer-use` and `…/cache/openai-primary-runtime/presentations`. Neither contains a `SKILL.md`; both are plugin directories. The real skills sit at `…/computer-use/1.0.1000502/skills/computer-use` and `…/presentations/26.723.12215/skills/presentations` and were never reached.

A candidate now requires a real `SKILL.md` (regular file, or a symlink resolving to one). Inside a declared skill root an uninspectable link still records a candidate — there the plugin manifest itself claims the name is a skill, so fail-closed is warranted; outside one there is no such claim and no file to read, so inventing a copy would be a guess.

## Preserved separations

Symlink handling (`outside-root` refusal, `ELOOP` as `io-error`), the dangling-known-name-symlink-in-a-declared-root candidate, non-blocking manifest inspection (FIFO), and the no-fabricated-installations guarantee from #10865 are all unchanged and still covered.

## Real cache: before → after

| | before | after |
| -- | -- | -- |
| candidates | 3 — 2 fabricated, 1 of them masking a real skill | 3, all with a verified `SKILL.md` at their true path |
| issues | `depth-limit`, `entry-limit` | none |
| pill | `Needs attention` on every skill | driven only by real placements/faults |

## Tests

Added: real-shaped Codex cache completes with no coverage issues; a plugin directory sharing a skill name is not emitted; a bare known-name directory with no `SKILL.md` is not emitted; payload pruning beyond the nested budget stays silent; eligibility unchanged when a genuine plugin-cache copy is present; per-reason diagnostic behavior for both `getSkillFreshnessDisplayStatus` and `hasSkillCopyNeedingAttention`.

Updated: the candidate-budget fixture now carries `SKILL.md` (the rule it asserted changed); the entry-budget fixture is resized to the new bound.

## Validation

- focused suites — 21 files, 157 tests, all passing (`src/main/skills`, `src/main/ipc/skills.test.ts`, `src/renderer/src/components/skills`, display-status, nav-install-status, `useSkillFreshness`)
- `pnpm typecheck` — clean
- changed-file `oxlint` + `oxfmt`, `pnpm run lint:switch-exhaustiveness`, `check:max-lines-ratchet`, `check:reliability-gates` — clean
- real `~/.codex/plugins/cache` scan, asserted `issues` is empty

Refs #10659

Made with [Orca](https://github.com/stablyai/orca) 🐋
