### PR TITLE
fix(mobile): unblock iOS releases and prepare 0.0.36

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.32",
+    "version": "0.0.36",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 8
+      "versionCode": 9
     },
     "plugins": [
       "expo-router",

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -36,8 +36,15 @@ DEFAULT_TESTFLIGHT_CHANGELOG = "Latest Orca Mobile updates and fixes.".freeze
 # closed"). Only approved/released/removed states qualify: a version that is
 # merely IN_REVIEW / WAITING_FOR_REVIEW / PROCESSING_FOR_APP_STORE still accepts
 # TestFlight builds, so bumping on those would break normal beta iteration.
+#
+# Covers both vocabularies: `appStoreState` is deprecated as of App Store
+# Connect API 3.3 in favor of `appVersionState`, which renames the shipped state
+# (READY_FOR_SALE -> READY_FOR_DISTRIBUTION) and drops the removed-from-sale
+# ones. Reading whichever field Apple populates keeps the guard working through
+# the transition instead of silently finding zero closed versions.
 CLOSED_APP_STORE_STATES = %w[
   READY_FOR_SALE
+  READY_FOR_DISTRIBUTION
   PENDING_DEVELOPER_RELEASE
   PENDING_APPLE_RELEASE
   REPLACED_WITH_NEW_VERSION
@@ -67,22 +74,42 @@ def current_mobile_version(config)
   config.fetch("expo").fetch("version")
 end
 
-# Returns true when `version`'s App Store train is closed to new build uploads.
-# `app` is a Spaceship::ConnectAPI::App the caller looks up (nil if lookup
-# failed). On a nil app or any API error, degrade to "open": we then proceed as
-# before this check existed — the upload either succeeds or fails with the same
-# 90186 we have always seen, never worse than today's behavior.
-def version_train_closed?(app, version)
-  return false unless app
+# True when either state field reports a terminally closed train. `respond_to?`
+# guards the newer field, which older spaceship versions do not define.
+def closed_state?(app_store_version)
+  states = [app_store_version.app_store_state]
+  states << app_store_version.app_version_state if app_store_version.respond_to?(:app_version_state)
 
-  app
-    .get_app_store_versions(filter: { versionString: version })
-    .any? { |app_store_version| CLOSED_APP_STORE_STATES.include?(app_store_version.app_store_state) }
+  states.compact.any? { |state| CLOSED_APP_STORE_STATES.include?(state) }
+end
+
+# Highest version whose App Store record is in a terminally closed state, or nil
+# when none is (or the lookup fails). Fetched once because the answer is a
+# property of the app, not of any single candidate version.
+#
+# Why the whole list rather than a per-version lookup: a version only gets an
+# App Store record once someone submits it. 0.0.34 was uploaded to TestFlight
+# but never submitted, so it had no record and a filtered lookup found nothing
+# closed — while 0.0.35 shipped, which closes 0.0.34 too (Apple: 90062 requires
+# a *higher* version than the last approved one).
+#
+# On a nil app or any API error, degrade to "open": we then proceed as before
+# this check existed — the upload either succeeds or fails with the same 90186
+# we have always seen, never worse than today's behavior.
+def highest_closed_app_store_version(app)
+  return nil unless app
+
+  closed = app
+    .get_app_store_versions
+    .select { |app_store_version| closed_state?(app_store_version) }
+    .map(&:version_string)
+
+  IosReleaseVersion.max_version(closed)
 rescue StandardError => error
   # Loud, not silent: a swallowed error here un-fixes the 90186 guard, so the
   # degraded run must be visible rather than buried.
-  UI.error("Could not determine App Store state for #{version} (#{error.message}); assuming open and proceeding.")
-  false
+  UI.error("Could not determine closed App Store versions (#{error.message}); assuming open and proceeding.")
+  nil
 end
 
 def testflight_changelog
@@ -103,13 +130,16 @@ platform :ios do
         UI.error("Could not look up App Store app #{BUNDLE_ID} (#{error.message}); skipping closed-train check.")
         nil
       end
+    highest_closed = highest_closed_app_store_version(app)
+    UI.message("Highest closed App Store version: #{highest_closed || 'none'}")
+
     version =
       begin
         IosReleaseVersion.resolve(
           requested: options[:version],
           bump_patch: options[:bump_patch],
           current_version: current_mobile_version(config),
-          train_closed: ->(candidate) { version_train_closed?(app, candidate) },
+          train_closed: ->(candidate) { IosReleaseVersion.closed_train?(candidate, highest_closed) },
         )
       rescue ArgumentError => error
         UI.user_error!(error.message)
@@ -117,7 +147,7 @@ platform :ios do
 
     # Explicit and checked-in versions still fail fast when closed. Patch bumps
     # skip closed trains above because workflow-only releases can outpace Git.
-    if version_train_closed?(app, version)
+    if IosReleaseVersion.closed_train?(version, highest_closed)
       retry_guidance =
         if IosReleaseVersion.truthy?(options[:bump_patch])
           "Use a higher release_version or land a \"Prepare mobile <version>\" commit."
@@ -126,8 +156,8 @@ platform :ios do
             "or land a \"Prepare mobile <version>\" commit."
         end
       UI.user_error!(
-        "iOS version #{version} is already submitted/released on the App Store and cannot accept " \
-        "new builds. #{retry_guidance}",
+        "iOS version #{version} is not higher than #{highest_closed}, which is already " \
+        "submitted/released on the App Store, so Apple will reject the upload. #{retry_guidance}",
       )
     end
 

--- a/mobile/fastlane/ios_release_version.rb
+++ b/mobile/fastlane/ios_release_version.rb
@@ -1,15 +1,47 @@
 module IosReleaseVersion
   module_function
 
+  SEMVER_PATTERN = /\A(\d+)\.(\d+)\.(\d+)\z/.freeze
+
   def truthy?(value)
     %w[1 true yes on].include?(value.to_s.strip.downcase)
   end
 
-  def bump_patch(version)
-    match = version.match(/\A(\d+)\.(\d+)\.(\d+)\z/)
-    raise ArgumentError, "Cannot bump non-semver mobile version '#{version}'" unless match
+  # [major, minor, patch] for semver comparison, or nil for anything else.
+  def parse(version)
+    match = version.to_s.strip.match(SEMVER_PATTERN)
+    return nil unless match
 
-    "#{match[1]}.#{match[2]}.#{match[3].to_i + 1}"
+    [match[1].to_i, match[2].to_i, match[3].to_i]
+  end
+
+  def bump_patch(version)
+    parts = parse(version)
+    raise ArgumentError, "Cannot bump non-semver mobile version '#{version}'" unless parts
+
+    "#{parts[0]}.#{parts[1]}.#{parts[2] + 1}"
+  end
+
+  # Highest semver in `versions`, skipping entries App Store Connect reports in
+  # a non-semver shape. Compares numerically: "0.0.10" beats "0.0.9", which a
+  # string sort gets backwards.
+  def max_version(versions)
+    Array(versions)
+      .map { |version| version.to_s.strip }
+      .select { |version| parse(version) }
+      .max_by { |version| parse(version) }
+  end
+
+  # Apple rejects an upload whose CFBundleShortVersionString is not higher than
+  # the last approved version (90062) and reports that version's train as closed
+  # (90186). So every version at or below `highest_closed` is unusable, not just
+  # the ones whose own App Store record sits in a closed state.
+  def closed_train?(version, highest_closed)
+    candidate = parse(version)
+    ceiling = parse(highest_closed)
+    return false unless candidate && ceiling
+
+    (candidate <=> ceiling) <= 0
   end
 
   def resolve(requested:, bump_patch:, current_version:, train_closed:)

--- a/mobile/fastlane/ios_release_version_test.rb
+++ b/mobile/fastlane/ios_release_version_test.rb
@@ -45,4 +45,51 @@ class IosReleaseVersionTest < Minitest::Test
 
     assert_equal("Cannot bump non-semver mobile version '0.0'", error.message)
   end
+
+  # The 0.0.34 regression: 0.0.35 shipped, so every version at or below it is
+  # closed even though 0.0.34 itself never got an App Store record.
+  def test_versions_at_or_below_the_highest_closed_version_are_closed
+    assert(IosReleaseVersion.closed_train?("0.0.34", "0.0.35"))
+    assert(IosReleaseVersion.closed_train?("0.0.35", "0.0.35"))
+    refute(IosReleaseVersion.closed_train?("0.0.36", "0.0.35"))
+  end
+
+  def test_nothing_is_closed_without_a_known_closed_version
+    refute(IosReleaseVersion.closed_train?("0.0.1", nil))
+    refute(IosReleaseVersion.closed_train?("0.0.1", ""))
+  end
+
+  def test_non_semver_candidates_are_treated_as_open
+    refute(IosReleaseVersion.closed_train?("0.0", "0.0.35"))
+  end
+
+  def test_resolve_skips_past_the_highest_closed_version
+    version = IosReleaseVersion.resolve(
+      requested: "",
+      bump_patch: true,
+      current_version: "0.0.32",
+      train_closed: ->(candidate) { IosReleaseVersion.closed_train?(candidate, "0.0.35") },
+    )
+
+    assert_equal("0.0.36", version)
+  end
+
+  def test_max_version_compares_numerically_not_lexically
+    assert_equal("0.0.10", IosReleaseVersion.max_version(%w[0.0.9 0.0.10 0.0.2]))
+    assert_equal("0.2.0", IosReleaseVersion.max_version(%w[0.1.99 0.2.0]))
+    assert_equal("1.0.0", IosReleaseVersion.max_version(%w[0.9.9 1.0.0]))
+  end
+
+  def test_max_version_ignores_non_semver_entries
+    assert_equal("0.0.35", IosReleaseVersion.max_version(["0.0.35", "1.0", "", nil]))
+    assert_nil(IosReleaseVersion.max_version([]))
+    assert_nil(IosReleaseVersion.max_version(nil))
+  end
+
+  # Minor/major releases must close stale patch trains beneath them.
+  def test_closed_train_compares_across_minor_and_major
+    assert(IosReleaseVersion.closed_train?("0.0.99", "0.1.0"))
+    assert(IosReleaseVersion.closed_train?("0.9.9", "1.0.0"))
+    refute(IosReleaseVersion.closed_train?("1.0.1", "1.0.0"))
+  end
 end


### PR DESCRIPTION
## Why

[Run 30238959540](https://github.com/stablyai/orca/actions/runs/30238959540/job/89892061596) built an .ipa for ~24 minutes, then Apple rejected the upload:

- `90186` — train `0.0.34` is closed for new build submissions
- `90062` — `CFBundleShortVersionString [0.0.34]` must be higher than the previously approved version `0.0.35`

The closed-train guard was supposed to prevent exactly this, but it asked the wrong question. It looked up each candidate's own App Store record:

```ruby
app.get_app_store_versions(filter: { versionString: version })
```

A version only *gets* a record once it is submitted for review. `0.0.34` reached TestFlight but was never submitted — no record, so nothing looked closed and the patch-bump walk stopped there. Meanwhile `0.0.35` shipped, which closes `0.0.34` retroactively: Apple requires a version *higher* than the last approved one, not merely one that isn't itself released. The guard checked version-by-version; the real constraint is a floor across the whole app.

The same root cause failed run 30169107429 two days earlier, identically.

## What changed

**`fix(mobile): block iOS uploads below the last shipped App Store version`**

- `highest_closed_app_store_version` fetches all versions and takes the highest in a closed state — one call, no per-version filter, so unsubmitted versions no longer create blind spots.
- `closed_train?` treats anything `<= highest_closed` as closed, comparing `[major, minor, patch]` numerically. A string sort ranks `0.0.9 > 0.0.10`, which would break at the next double-digit patch.
- The guard now reads `appVersionState` alongside `appStoreState`. CI runs fastlane 2.237.0, where `appStoreState` is deprecated as of App Store Connect API 3.3 and the shipped state is renamed `READY_FOR_SALE` → `READY_FOR_DISTRIBUTION`. Reading only the old field would silently find zero closed versions once Apple stops populating it — re-breaking this bug in a way that looks like success. `respond_to?`-guarded, since older spaceship lacks the new field.

The API-error path still degrades to "open" and proceeds, as before — never worse than current behavior.

**`chore(mobile): prepare 0.0.36`**

`app.json` sat at `0.0.32` while `0.0.35` had shipped — four versions of drift, because release versions are resolved on the runner and never committed back. This closes the gap so the checked-in version matches reality, and the iOS release no longer *depends* on the closed-train walk to find an open version (the walk remains as the safety net).

Android `versionCode` goes 8 → 9 in the same commit. The version string is shared between platforms, and shipping `0.0.36` with the code that already shipped for `0.0.32` produces an APK that cannot install over the released build. Git history shows this being missed and patched after the fact twice (`20ebe858af`, `d1cc78d5c5`), so it is bundled here rather than left as a follow-up.

## Testing

- 11 tests pass via `ruby fastlane/ios_release_version_test.rb`, already wired into `mobile.yml` CI. New cases cover the 0.0.34 regression, numeric-vs-lexical ordering, minor/major boundaries, and non-semver input.
- Simulated the failing run against real App Store shape: resolves **0.0.36** instead of 0.0.34. Verified the `closed_state?` helper across both field vocabularies (old-gem, new-field-only, and both-nil).
- `node scripts/prepare-android-release.mjs` accepts the new state: `Prepared Orca Mobile Android 0.0.36 (9)`.
- Stale explicit versions now fail fast in the ~1-minute resolve step rather than after a 24-minute build. Normal beta iteration on an unshipped version is unaffected.

## Follow-up (not in this PR)

Nothing commits the resolved version back after a release, so `app.json` will start drifting again from the next release onward. Worth a durable fix — this PR resets the counter but does not change that mechanism.
