### PR TITLE
perf(usage): yield with setImmediate, not a clamped setTimeout(0)

### DIFF
--- a/config/scripts/claude-usage-yield-benchmark.mjs
+++ b/config/scripts/claude-usage-yield-benchmark.mjs
@@ -19,7 +19,7 @@ import { performance } from 'node:perf_hooks'
 import { readdirSync, statSync } from 'node:fs'
 
 const REPO_ROOT = new URL('../..', import.meta.url)
-const ROUNDS = 6
+const ROUNDS = Number(process.env.ORCA_YIELD_BENCH_ROUNDS ?? '10')
 
 // Why re-read the source: the claim is that the scanner yields once per batch across
 // two loops. If the batch size or the yield sites change, these numbers stop meaning
@@ -73,13 +73,12 @@ const transcriptCount = (() => {
   }
 })()
 
-// Both passes yield once per batch, minus the final batch in each.
 const FALLBACK_TRANSCRIPTS = 7500
 const effectiveTranscripts = transcriptCount > 0 ? transcriptCount : FALLBACK_TRANSCRIPTS
-const YIELDS_PER_SCAN = Math.max(
-  1,
-  Math.floor(effectiveTranscripts / FILE_SCAN_BATCH_SIZE) * YIELD_SITES
-)
+// Each pass walks ceil(files / batch) batches and yields after every batch except the
+// last, so a pass yields batchesPerPass - 1 times.
+const BATCHES_PER_PASS = Math.max(1, Math.ceil(effectiveTranscripts / FILE_SCAN_BATCH_SIZE))
+const YIELDS_PER_SCAN = Math.max(1, (BATCHES_PER_PASS - 1) * YIELD_SITES)
 
 const yieldWithTimeout = () => new Promise((resolve) => setTimeout(resolve, 0))
 const yieldWithImmediate = () => new Promise((resolve) => setImmediate(resolve))
@@ -157,19 +156,23 @@ console.log(
   `transcripts=${transcriptCount > 0 ? transcriptCount : `${FALLBACK_TRANSCRIPTS} (none found; synthetic)`} batch=${FILE_SCAN_BATCH_SIZE} sites=${YIELD_SITES} -> ~${YIELDS_PER_SCAN} yields/scan`
 )
 console.log(
-  `${pad('yields', 8)} ${pad('setTimeout(0)', 14)} ${pad('setImmediate', 13)} ${pad('speedup', 9)}`
+  `${pad('yields', 8)} ${pad('setTimeout(0)', 14)} ${pad('setImmediate', 13)} ${pad('speedup', 9)} ${pad('saved', 11)}`
 )
 
-for (const batches of [100, 500, YIELDS_PER_SCAN]) {
+for (const yields of [100, 500, YIELDS_PER_SCAN]) {
+  // runBatchLoop yields batches - 1 times, so ask for one more batch than yields.
+  const batches = yields + 1
   const { timeoutMs, immediateMs } = await measure(batches)
+  // Why report the absolute saving too: the setImmediate arm is small enough that
+  // background load moves the RATIO a lot while the removed wall time barely budges.
   console.log(
-    `${pad(batches, 8)} ${pad(`${timeoutMs.toFixed(1)} ms`, 14)} ${pad(`${immediateMs.toFixed(1)} ms`, 13)} ${pad(`${(timeoutMs / immediateMs).toFixed(1)}x`, 9)}`
+    `${pad(yields, 8)} ${pad(`${timeoutMs.toFixed(1)} ms`, 14)} ${pad(`${immediateMs.toFixed(1)} ms`, 13)} ${pad(`${(timeoutMs / immediateMs).toFixed(1)}x`, 9)} ${pad(`${(timeoutMs - immediateMs).toFixed(0)} ms`, 11)}`
   )
 }
 
 console.log('\nResponsiveness (the reason the yield exists) at a full scan:')
-const timeoutLatency = await measureConcurrentLatency(yieldWithTimeout, YIELDS_PER_SCAN)
-const immediateLatency = await measureConcurrentLatency(yieldWithImmediate, YIELDS_PER_SCAN)
+const timeoutLatency = await measureConcurrentLatency(yieldWithTimeout, YIELDS_PER_SCAN + 1)
+const immediateLatency = await measureConcurrentLatency(yieldWithImmediate, YIELDS_PER_SCAN + 1)
 console.log(
   `  setTimeout(0): scan ${timeoutLatency.scanMs.toFixed(0)} ms, worst concurrent wait ${timeoutLatency.worstLatencyMs.toFixed(2)} ms`
 )
@@ -183,5 +186,5 @@ if (immediateLatency.worstLatencyMs > timeoutLatency.worstLatencyMs) {
 }
 
 console.log(
-  '\nThe saving is wall-clock the main process spent parked on timer clamps, not CPU\nwork removed. It is paid on every Usage-pane scan and every forced automation rescan.'
+  '\nRead the SAVED column, not the ratio. The setImmediate arm is small enough that\nbackground load swings the ratio (32x-81x observed across runs on a loaded machine)\nwhile the removed wall time stays at ~4.2-5.1 s. The saving is wall-clock the main\nprocess spent parked on timer clamps, not CPU work removed. It is paid on every\nUsage-pane scan and every forced automation rescan.'
 )

--- a/config/scripts/claude-usage-yield-benchmark.mjs
+++ b/config/scripts/claude-usage-yield-benchmark.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// Benchmark: the event-loop yield in the Claude usage scanner's batch loops.
+//
+// scanner.ts yielded with `setTimeout(resolve, 0)`, which Node clamps to ~1ms. The
+// loops yield once per FILE_SCAN_BATCH_SIZE files across two passes, so a machine with
+// thousands of transcripts spent seconds parked on timers doing no work. setImmediate
+// yields on the same tick's check phase with no clamp. The sibling scanner
+// (src/main/codex-usage/scanner.ts) already used setImmediate.
+//
+// The yield exists to keep the main process responsive during a scan, so this also
+// measures worst-case latency for a concurrent task -- a "faster" yield that starved
+// other work would be a regression, not a win.
+//
+// Run with:  node config/scripts/claude-usage-yield-benchmark.mjs
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { readdirSync, statSync } from 'node:fs'
+
+const REPO_ROOT = new URL('../..', import.meta.url)
+const ROUNDS = 6
+
+// Why re-read the source: the claim is that the scanner yields once per batch across
+// two loops. If the batch size or the yield sites change, these numbers stop meaning
+// what the header says, so fail loudly instead of reporting a stale ratio.
+const SCANNER_SOURCE = readFileSync(new URL('src/main/claude-usage/scanner.ts', REPO_ROOT), 'utf8')
+const batchMatch = SCANNER_SOURCE.match(/const FILE_SCAN_BATCH_SIZE = (\d+)/)
+if (!batchMatch) {
+  throw new Error('FILE_SCAN_BATCH_SIZE not found; this benchmark is stale')
+}
+const FILE_SCAN_BATCH_SIZE = Number(batchMatch[1])
+const YIELD_SITES = (SCANNER_SOURCE.match(/await yieldToEventLoop\(\)/g) ?? []).length
+if (YIELD_SITES === 0) {
+  throw new Error('no yieldToEventLoop call sites found; this benchmark is stale')
+}
+// Match the call, not the word: a comment mentioning setImmediate would satisfy a
+// bare substring check even after the yield reverted to setTimeout.
+if (!/setImmediate\(resolve\)/.test(SCANNER_SOURCE)) {
+  throw new Error('scanner no longer yields with setImmediate; this benchmark is stale')
+}
+
+// Real transcript count drives the yield count, so read it rather than assume one.
+function countClaudeTranscripts() {
+  const root = join(homedir(), '.claude', 'projects')
+  let count = 0
+  const stack = [root]
+  while (stack.length > 0) {
+    const dir = stack.pop()
+    let entries
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        stack.push(join(dir, entry.name))
+      } else if (entry.name.endsWith('.jsonl')) {
+        count += 1
+      }
+    }
+  }
+  return count
+}
+
+const transcriptCount = (() => {
+  try {
+    statSync(join(homedir(), '.claude', 'projects'))
+    return countClaudeTranscripts()
+  } catch {
+    return 0
+  }
+})()
+
+// Both passes yield once per batch, minus the final batch in each.
+const FALLBACK_TRANSCRIPTS = 7500
+const effectiveTranscripts = transcriptCount > 0 ? transcriptCount : FALLBACK_TRANSCRIPTS
+const YIELDS_PER_SCAN = Math.max(
+  1,
+  Math.floor(effectiveTranscripts / FILE_SCAN_BATCH_SIZE) * YIELD_SITES
+)
+
+const yieldWithTimeout = () => new Promise((resolve) => setTimeout(resolve, 0))
+const yieldWithImmediate = () => new Promise((resolve) => setImmediate(resolve))
+
+// Mirrors the scanner's shape: a little synchronous work per batch, then a yield.
+async function runBatchLoop(doYield, batches) {
+  let sink = 0
+  for (let batch = 0; batch < batches; batch += 1) {
+    for (let file = 0; file < FILE_SCAN_BATCH_SIZE; file += 1) {
+      sink += (batch * 31 + file) % 7
+    }
+    if (batch + 1 < batches) {
+      await doYield()
+    }
+  }
+  return sink
+}
+
+async function timeArm(doYield, batches) {
+  const start = performance.now()
+  const sink = await runBatchLoop(doYield, batches)
+  const elapsed = performance.now() - start
+  if (sink === -1) {
+    throw new Error('unreachable')
+  }
+  return elapsed
+}
+
+function median(samples) {
+  const sorted = [...samples].sort((a, b) => a - b)
+  const mid = sorted.length / 2
+  return (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+// Arms alternate which one leads so within-round drift cannot favour either.
+async function measure(batches) {
+  await runBatchLoop(yieldWithTimeout, Math.min(batches, 50))
+  await runBatchLoop(yieldWithImmediate, Math.min(batches, 50))
+  const timeoutSamples = []
+  const immediateSamples = []
+  for (let round = 0; round < ROUNDS; round += 1) {
+    if (round % 2 === 0) {
+      timeoutSamples.push(await timeArm(yieldWithTimeout, batches))
+      immediateSamples.push(await timeArm(yieldWithImmediate, batches))
+    } else {
+      immediateSamples.push(await timeArm(yieldWithImmediate, batches))
+      timeoutSamples.push(await timeArm(yieldWithTimeout, batches))
+    }
+  }
+  return { timeoutMs: median(timeoutSamples), immediateMs: median(immediateSamples) }
+}
+
+// The yield exists for responsiveness, so measure what a concurrent task actually sees.
+async function measureConcurrentLatency(doYield, batches) {
+  let worstLatencyMs = 0
+  let stop = false
+  const probe = (async () => {
+    while (!stop) {
+      const tick = performance.now()
+      await new Promise((resolve) => setImmediate(resolve))
+      worstLatencyMs = Math.max(worstLatencyMs, performance.now() - tick)
+    }
+  })()
+  const start = performance.now()
+  await runBatchLoop(doYield, batches)
+  const scanMs = performance.now() - start
+  stop = true
+  await probe
+  return { scanMs, worstLatencyMs }
+}
+
+const pad = (value, width) => String(value).padStart(width)
+console.log('Claude usage scanner event-loop yield. Lower is better.')
+console.log(
+  `transcripts=${transcriptCount > 0 ? transcriptCount : `${FALLBACK_TRANSCRIPTS} (none found; synthetic)`} batch=${FILE_SCAN_BATCH_SIZE} sites=${YIELD_SITES} -> ~${YIELDS_PER_SCAN} yields/scan`
+)
+console.log(
+  `${pad('yields', 8)} ${pad('setTimeout(0)', 14)} ${pad('setImmediate', 13)} ${pad('speedup', 9)}`
+)
+
+for (const batches of [100, 500, YIELDS_PER_SCAN]) {
+  const { timeoutMs, immediateMs } = await measure(batches)
+  console.log(
+    `${pad(batches, 8)} ${pad(`${timeoutMs.toFixed(1)} ms`, 14)} ${pad(`${immediateMs.toFixed(1)} ms`, 13)} ${pad(`${(timeoutMs / immediateMs).toFixed(1)}x`, 9)}`
+  )
+}
+
+console.log('\nResponsiveness (the reason the yield exists) at a full scan:')
+const timeoutLatency = await measureConcurrentLatency(yieldWithTimeout, YIELDS_PER_SCAN)
+const immediateLatency = await measureConcurrentLatency(yieldWithImmediate, YIELDS_PER_SCAN)
+console.log(
+  `  setTimeout(0): scan ${timeoutLatency.scanMs.toFixed(0)} ms, worst concurrent wait ${timeoutLatency.worstLatencyMs.toFixed(2)} ms`
+)
+console.log(
+  `  setImmediate : scan ${immediateLatency.scanMs.toFixed(0)} ms, worst concurrent wait ${immediateLatency.worstLatencyMs.toFixed(2)} ms`
+)
+if (immediateLatency.worstLatencyMs > timeoutLatency.worstLatencyMs) {
+  console.log(
+    '\n  NOTE: setImmediate showed a WORSE concurrent wait here. The yield exists for\n  responsiveness, so that would be a regression even though the scan is faster.'
+  )
+}
+
+console.log(
+  '\nThe saving is wall-clock the main process spent parked on timer clamps, not CPU\nwork removed. It is paid on every Usage-pane scan and every forced automation rescan.'
+)

--- a/src/main/claude-usage/scanner.ts
+++ b/src/main/claude-usage/scanner.ts
@@ -124,8 +124,10 @@ function getSortedWorktreeEntries(
   return sorted
 }
 
+// Why setImmediate: setTimeout(0) is clamped to ~1ms, and this yields once per
+// 4-file batch, so a 7.5k-transcript scan spent ~2s parked on timers.
 async function yieldToEventLoop(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setImmediate(resolve))
 }
 
 async function walkJsonlFiles(dirPath: string): Promise<string[]> {


### PR DESCRIPTION
## Description

The Claude usage scanner yielded to the event loop with `setTimeout(resolve, 0)`. Node clamps that to **~1ms**. Both batch loops yield once per `FILE_SCAN_BATCH_SIZE` (4) files, so a machine with 7,552 transcripts makes ~3,800 yields and spends **seconds** parked on timers doing no work.

`setImmediate` runs on the same tick's check phase with no clamp. The sibling scanner `src/main/codex-usage/scanner.ts:92` already used `setImmediate` — this was an inconsistency, not a design choice. The two functions were otherwise byte-identical.

One line changed.

## ELI5

While scanning your usage history, the app pauses between small batches so the rest of the app stays responsive.

It was using a pause that Node rounds **up to a full millisecond**. Do that ~3,800 times and you've waited ~4 seconds doing nothing. The fix uses the pause that means "right after this tick," which is what was wanted all along.

## Proof of perf improvement

`config/scripts/claude-usage-yield-benchmark.mjs` (new), arms alternated per round, per-arm medians:

| yields | `setTimeout(0)` | `setImmediate` | ratio | **saved** |
|---|---|---|---|---|
| 100 | 139.7 ms | 20.7 ms | 6.7× | 119 ms |
| 500 | 611.9 ms | 25.1 ms | 24.4× | 587 ms |
| 3,780 *(this machine's real scan)* | 4291–5270 ms | 54–164 ms | 32–81× | **4237–5107 ms** |

**Read the saved column, not the ratio.** The `setImmediate` arm is small enough that background
load lands almost entirely on it, swinging the ratio between 32× and 81× across three consecutive
runs while the removed wall time holds steady at 4.2–5.1 s. The honest headline is
**~4.3 seconds of main-process wall time removed per full scan**, not a multiple.

The yield count is **derived from real data**, not assumed: the benchmark counts `.jsonl` files under `~/.claude/projects` (7,552 here) and reads `FILE_SCAN_BATCH_SIZE` and the yield-site count out of the scanner source.

Independent confirmation of the mechanism, measured separately and in both orders: `setTimeout(0)` costs **1,138 µs** per yield versus **14.3 µs** for `setImmediate`.

**Responsiveness improves — it does not regress.** That matters, because responsiveness is the entire reason the yield exists; a "faster" yield that starved other work would be a regression even at 80×. Measured with a concurrent probe task during a full scan:

| | scan | worst concurrent wait |
|---|---|---|
| `setTimeout(0)` | 3,790 ms | 6.33 ms |
| `setImmediate` | 56 ms | **0.12 ms** |

The old version was worse on both axes because most of its wall time was the main process idle-but-blocked on timer clamps. The benchmark prints an explicit NOTE if `setImmediate` ever shows a worse concurrent wait, so a future regression here is visible rather than silent.

Scope: this is **wall-clock the process spent waiting**, not CPU work removed. The scan's own I/O and parsing are unchanged. It's paid on every Usage-pane scan and on every forced automation rescan.

## Proof of zero regression

- `src/main/claude-usage/`, `codex-usage/`, `opencode-usage/`: **11 files, 77 tests** passing. `pnpm typecheck` clean.
- **Benchmark drift guards, verified by breaking them**: renaming `FILE_SCAN_BATCH_SIZE` throws `…is stale`; reverting the scanner to `setTimeout` throws `scanner no longer yields with setImmediate`.

  The second guard initially **did not fire** — I'd written a bare `includes('setImmediate')` check, which the new *comment* mentioning `setImmediate` satisfied even after the call reverted. Now it matches the call form (`/setImmediate\(resolve\)/`). A guard that a comment can satisfy is not a guard.

- No behaviour depends on the yield's *duration*: both call sites are `if (moreWork) await yieldToEventLoop()` between pure in-memory batch steps.

**Deliberately left alone** — three other `setTimeout(resolve, 0)` sites exist in `orca-runtime.ts:14222/14249` and `pty.ts:5044`, and they look like the same bug but are not. They sit between PTY **paste chunk writes**, where the clamp acts as inter-chunk *pacing*, not merely a yield. Removing it there would change how fast bytes hit the terminal — a behaviour change, not a perf fix. `opencode-usage/scanner.ts:148` has the identical yield shape but iterates databases (2 on a real machine, ~1 yield), so it's below the bar; noted, not changed.

## Review loop count + verdict

2 loops. Round 1 verified the clamp claim independently and confirmed the yield frequency against the real transcript count rather than trusting the reported figure. Round 2 caught the comment-satisfiable drift guard.

**Verdict: ship.** One line, an in-repo sibling already proves the pattern, and the property that justifies the yield's existence measurably improves.

Made with [Orca](https://github.com/stablyai/orca) 🐋

