### PR TITLE
fix(resource-manager): never destroy a session Orca cannot prove is idle (#8459)

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -11,6 +11,7 @@ import { redactPtyIdForDiagnostics } from '../../shared/pty-delivery-diagnostics
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../shared/constants'
 import type { TuiAgent } from '../../shared/types'
 import type { AgentSessionOwnerBinding } from '../../shared/agent-session-host-authority'
+import { AGENT_SESSION_CLAIM_DIGEST_VERSION } from '../../shared/agent-session-host-authority'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 
 const isWindowsHost = process.platform === 'win32'
@@ -5690,6 +5691,63 @@ describe('registerPtyHandlers', () => {
       immediate: true,
       keepHistory: false
     })
+  })
+
+  it('reports agent ownership through pty:listSessions so the renderer cannot guess it', async () => {
+    registerPtyHandlers(mainWindow as never)
+    // Why: the renderer's binding map is empty during restore, so agent ownership is the only
+    // positive liveness evidence it has. Dropping it here force-killed live sessions (#8459).
+    const owner = {
+      claim: {
+        digestVersion: AGENT_SESSION_CLAIM_DIGEST_VERSION,
+        keyId: 'key-1',
+        identityDigest: 'a'.repeat(43),
+        worktreeScopeDigest: 'b'.repeat(43),
+        agent: 'codex'
+      },
+      generation: 'gen-1',
+      phase: 'live',
+      ptyId: 'agent-pty',
+      surface: {
+        worktreeId: 'repo::/workspace',
+        tabId: 'tab',
+        leafId: '11111111-1111-4111-8111-111111111111',
+        terminalHandle: 'term_claimed'
+      }
+    }
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [
+        { id: 'agent-pty', cwd: '/workspace', title: 'codex', agentSessionOwners: [owner] },
+        { id: 'plain-pty', cwd: '/tmp', title: 'zsh' }
+      ]),
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+
+    const sessions = (await handlers.get('pty:listSessions')!(null, undefined)) as {
+      id: string
+      hasAgentOwner: boolean
+    }[]
+
+    expect(sessions.find((s) => s.id === 'agent-pty')?.hasAgentOwner).toBe(true)
+    expect(sessions.find((s) => s.id === 'plain-pty')?.hasAgentOwner).toBe(false)
   })
 
   it('kills app-scoped SSH PTY ids through the parsed provider when ownership is not rebuilt', async () => {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -5736,6 +5736,8 @@ describe('registerPtyHandlers', () => {
         { id: 'agent-pty', cwd: '/workspace', title: 'codex', agentSessionOwners: [owner] },
         { id: 'plain-pty', cwd: '/tmp', title: 'zsh' }
       ]),
+      // Why: this provider serializes claims, so its silence about an owner is authoritative.
+      providesAgentSessionOwnerListings: () => true,
       attach: vi.fn(),
       getDefaultShell: vi.fn(),
       getProfiles: vi.fn()
@@ -5743,11 +5745,47 @@ describe('registerPtyHandlers', () => {
 
     const sessions = (await handlers.get('pty:listSessions')!(null, undefined)) as {
       id: string
-      hasAgentOwner: boolean
+      agentOwnership: string
     }[]
 
-    expect(sessions.find((s) => s.id === 'agent-pty')?.hasAgentOwner).toBe(true)
-    expect(sessions.find((s) => s.id === 'plain-pty')?.hasAgentOwner).toBe(false)
+    expect(sessions.find((s) => s.id === 'agent-pty')?.agentOwnership).toBe('present')
+    expect(sessions.find((s) => s.id === 'plain-pty')?.agentOwnership).toBe('absent')
+  })
+
+  it('reports unknown ownership when the provider cannot serialize claims', async () => {
+    registerPtyHandlers(mainWindow as never)
+    // Why: a legacy daemon generation or older SSH relay lists no owners for a session that may
+    // have one. Reporting that silence as 'absent' is what let live agent sessions be killed (#8459).
+    setLocalPtyProvider({
+      spawn: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      shutdown: vi.fn(),
+      sendSignal: vi.fn(),
+      getCwd: vi.fn(),
+      getInitialCwd: vi.fn(),
+      clearBuffer: vi.fn(),
+      acknowledgeDataEvent: vi.fn(),
+      hasChildProcesses: vi.fn(),
+      getForegroundProcess: vi.fn(),
+      serialize: vi.fn(),
+      revive: vi.fn(),
+      onData: vi.fn(() => () => {}),
+      onReplay: vi.fn(() => () => {}),
+      onExit: vi.fn(() => () => {}),
+      listProcesses: vi.fn(async () => [{ id: 'legacy-pty', cwd: '/workspace', title: 'zsh' }]),
+      providesAgentSessionOwnerListings: () => false,
+      attach: vi.fn(),
+      getDefaultShell: vi.fn(),
+      getProfiles: vi.fn()
+    } as never)
+
+    const sessions = (await handlers.get('pty:listSessions')!(null, undefined)) as {
+      id: string
+      agentOwnership: string
+    }[]
+
+    expect(sessions.find((s) => s.id === 'legacy-pty')?.agentOwnership).toBe('unknown')
   })
 
   it('kills app-scoped SSH PTY ids through the parsed provider when ownership is not rebuilt', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -175,6 +175,7 @@ import {
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtime-resolution'
 import { isPtyIncarnationId } from '../../shared/pty-incarnation'
+import type { PtyListedSession } from '../../shared/pty-listed-session'
 
 // ─── Provider Registry ──────────────────────────────────────────────
 // Routes PTY operations by connectionId (null = local provider).
@@ -5506,33 +5507,32 @@ export function registerPtyHandlers(
     }
   })
 
-  ipcMain.handle(
-    'pty:listSessions',
-    async (): Promise<{ id: string; cwd: string; title: string }[]> => {
-      const deduped = new Map<string, { id: string; cwd: string; title: string }>()
-      const admission = new PtyProcessListAdmission()
-      await visitPtyProcessListingsInBatches(
-        registeredPtyProviders(),
-        ({ provider, connectionId }) =>
-          connectionId === null
-            ? provider.listProcesses()
-            : provider.listProcesses().catch(() => []),
-        ({ connectionId }, sessions) => {
-          for (const rawSession of sessions) {
-            const session = admission.admit(rawSession)
-            // Why: kill actions only send back the PTY id, so rebuild ownership while listing to keep reconnect-discovered remote sessions routed to their provider.
-            ptyOwnership.set(session.id, connectionId)
-            deduped.set(session.id, {
-              id: session.id,
-              cwd: session.cwd,
-              title: session.title
-            })
-          }
+  ipcMain.handle('pty:listSessions', async (): Promise<PtyListedSession[]> => {
+    const deduped = new Map<string, PtyListedSession>()
+    const admission = new PtyProcessListAdmission()
+    await visitPtyProcessListingsInBatches(
+      registeredPtyProviders(),
+      ({ provider, connectionId }) =>
+        connectionId === null ? provider.listProcesses() : provider.listProcesses().catch(() => []),
+      ({ connectionId }, sessions) => {
+        for (const rawSession of sessions) {
+          const session = admission.admit(rawSession)
+          // Why: kill actions only send back the PTY id, so rebuild ownership while listing to keep reconnect-discovered remote sessions routed to their provider.
+          ptyOwnership.set(session.id, connectionId)
+          deduped.set(session.id, {
+            id: session.id,
+            cwd: session.cwd,
+            title: session.title,
+            // Why: an agent bound to this session is proof work is running, independent of whether
+            // this renderer has a tab binding yet. Without it the UI can only guess, and guessed
+            // "orphan" force-killed live agent sessions (#8459).
+            hasAgentOwner: (session.agentSessionOwners?.length ?? 0) > 0
+          })
         }
-      )
-      return Array.from(deduped.values())
-    }
-  )
+      }
+    )
+    return Array.from(deduped.values())
+  })
 
   ipcMain.on(
     'pty:getAuthoritativeBufferSnapshotCapabilitiesSync',

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -5514,7 +5514,7 @@ export function registerPtyHandlers(
       registeredPtyProviders(),
       ({ provider, connectionId }) =>
         connectionId === null ? provider.listProcesses() : provider.listProcesses().catch(() => []),
-      ({ connectionId }, sessions) => {
+      ({ provider, connectionId }, sessions) => {
         for (const rawSession of sessions) {
           const session = admission.admit(rawSession)
           // Why: kill actions only send back the PTY id, so rebuild ownership while listing to keep reconnect-discovered remote sessions routed to their provider.
@@ -5523,10 +5523,15 @@ export function registerPtyHandlers(
             id: session.id,
             cwd: session.cwd,
             title: session.title,
-            // Why: an agent bound to this session is proof work is running, independent of whether
-            // this renderer has a tab binding yet. Without it the UI can only guess, and guessed
-            // "orphan" force-killed live agent sessions (#8459).
-            hasAgentOwner: (session.agentSessionOwners?.length ?? 0) > 0
+            // Why: the renderer's binding map is empty during restore, so ownership is the only
+            // liveness evidence it has. Absence is authoritative only from a provider that
+            // serializes claims — otherwise it is 'unknown', never 'absent' (#8459).
+            agentOwnership:
+              (session.agentSessionOwners?.length ?? 0) > 0
+                ? 'present'
+                : provider.providesAgentSessionOwnerListings?.(session.id) === true
+                  ? 'absent'
+                  : 'unknown'
           })
         }
       }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -245,6 +245,7 @@ import type {
   WorkspaceSessionState
 } from '../shared/types'
 import type { PtyModelRestoreNeededEvent } from '../shared/pty-model-restore-marker'
+import type { PtyListedSession } from '../shared/pty-listed-session'
 import type {
   PtyRendererDeliveryHealthReply,
   PtyRendererDeliveryStateReport
@@ -1521,7 +1522,7 @@ export type PreloadApi = {
     confirmForegroundProcess: (id: string) => Promise<string | null>
     getCwd: (id: string) => Promise<string>
     getSize: (id: string) => Promise<{ cols: number; rows: number } | null>
-    listSessions: () => Promise<{ id: string; cwd: string; title: string }[]>
+    listSessions: () => Promise<PtyListedSession[]>
     getAuthoritativeBufferSnapshotCapabilities?: (
       ids: string[]
     ) => { id: string; authoritative: boolean | null }[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -74,6 +74,7 @@ import type {
   WorktreeRemoteBranchConflictEvent
 } from '../shared/types'
 import type { PtyModelRestoreNeededEvent } from '../shared/pty-model-restore-marker'
+import type { PtyListedSession } from '../shared/pty-listed-session'
 import type {
   PtyRendererDeliveryHealthReply,
   PtyRendererDeliveryStateReport
@@ -991,8 +992,7 @@ const api = {
     kill: (id: string, opts?: { keepHistory?: boolean }): Promise<void> =>
       ipcRenderer.invoke('pty:kill', { id, keepHistory: opts?.keepHistory ?? false }),
 
-    listSessions: (): Promise<{ id: string; cwd: string; title: string }[]> =>
-      ipcRenderer.invoke('pty:listSessions'),
+    listSessions: (): Promise<PtyListedSession[]> => ipcRenderer.invoke('pty:listSessions'),
     getAuthoritativeBufferSnapshotCapabilities: (
       ids: string[]
     ): { id: string; authoritative: boolean | null }[] =>

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx
@@ -45,6 +45,7 @@ function makeSession(overrides: Partial<UnifiedSessionRow>): UnifiedSessionRow {
     pid: 100,
     label: 'zsh',
     bound: true,
+    hasAgentOwner: false,
     tabId: 'tab-1',
     cpu: 1,
     memory: 100,

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.rows.test.tsx
@@ -45,7 +45,7 @@ function makeSession(overrides: Partial<UnifiedSessionRow>): UnifiedSessionRow {
     pid: 100,
     label: 'zsh',
     bound: true,
-    hasAgentOwner: false,
+    agentOwnership: 'absent' as const,
     tabId: 'tab-1',
     cpu: 1,
     memory: 100,

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -52,6 +52,7 @@ import {
 import {
   getResourceUsageAllWorktrees,
   getResourceUsageBrowserTabsByWorktree,
+  getResourceUsageDeferredSshSessionIdsByTabId,
   getResourceUsagePtyIdsByTabId,
   getResourceUsageRepos,
   getResourceUsageRuntimePaneTitlesByTabId,
@@ -67,9 +68,10 @@ import {
   getResourceManagerTooltipLines
 } from './resource-manager-terminal-copy'
 import { getResourceMemoryMetricCopy } from './resource-memory-metric-copy'
+import { requiresKillConfirmation } from './resource-session-kill-confirmation'
 import {
-  buildResourceSessionBindingIndex,
   countUnboundDaemonSessions,
+  selectUnboundDaemonSessions,
   type ResourceSessionBindingInputs
 } from './resource-session-bindings'
 import { useResourceSessionInventory } from './use-resource-session-inventory'
@@ -771,6 +773,10 @@ export function ResourceUsageStatusSegment({
   // Why: full binding maps stay behind open sentinels so unchanged counts don't rerender the closed segment.
   const ptyIdsByTabId = useAppStore((s) => getResourceUsagePtyIdsByTabId(s, open))
   const terminalLayoutsByTabId = useAppStore((s) => getResourceUsageTerminalLayoutsByTabId(s, open))
+  // Why: sessions awaiting SSH reattach are live on the remote host with no other binding.
+  const deferredSshSessionIdsByTabId = useAppStore((s) =>
+    getResourceUsageDeferredSshSessionIdsByTabId(s, open)
+  )
   const resourceSnapshot = snapshot
   // Why: ptyIdsByTabId tracks mounted/live panes only; Resource Manager reads restored wake hints only for classification.
   const resourceSessionBindings = useMemo<ResourceSessionBindingInputs>(
@@ -778,9 +784,16 @@ export function ResourceUsageStatusSegment({
       ptyIdsByTabId,
       tabsByWorktree,
       terminalLayoutsByTabId,
+      deferredSshSessionIdsByTabId,
       workspaceSessionReady
     }),
-    [ptyIdsByTabId, tabsByWorktree, terminalLayoutsByTabId, workspaceSessionReady]
+    [
+      ptyIdsByTabId,
+      tabsByWorktree,
+      terminalLayoutsByTabId,
+      deferredSshSessionIdsByTabId,
+      workspaceSessionReady
+    ]
   )
 
   // Why: after a kill unmounts the session, focus would fall to <body>; park a ref on the popover body to restore it stably for keyboard users.
@@ -1045,8 +1058,7 @@ export function ResourceUsageStatusSegment({
 
   const handleKillSession = useCallback(
     (session: UnifiedSessionRow): void => {
-      // Why: orphan sessions have no tab here (no unsaved work to lose), so skip the confirm dialog; bound sessions still confirm.
-      if (!session.bound) {
+      if (!requiresKillConfirmation(session)) {
         removeSession(session.sessionId)
         // Why: await the kill before refreshing, else the refresh re-reads the daemon list before the kill lands and re-adds the row.
         void (async () => {
@@ -1068,8 +1080,9 @@ export function ResourceUsageStatusSegment({
     if (!workspaceSessionReady) {
       return
     }
-    const bound = buildResourceSessionBindingIndex(resourceSessionBindings).boundPtyIds
-    const orphans = sessions.filter((s) => !bound.has(s.id))
+    // Why the shared selector: the button's count comes from the same function, so the set killed
+    // is exactly the set advertised. Filtering separately here is how live sessions got killed.
+    const orphans = selectUnboundDaemonSessions(sessions, resourceSessionBindings)
     if (orphans.length === 0) {
       return
     }

--- a/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/ResourceUsageStatusSegment.tsx
@@ -931,11 +931,11 @@ export function ResourceUsageStatusSegment({
     () =>
       open
         ? mergeSnapshotAndSessions(resourceSnapshot, sessions, {
-            tabsByWorktree,
-            ptyIdsByTabId,
-            terminalLayoutsByTabId,
+            // Why spread: the rows and the bulk selector must classify from the identical binding
+            // inputs. Re-listing them here let the row path miss deferred SSH sessions, so their
+            // single-row kill skipped confirmation while bulk cleanup correctly spared them (#8459).
+            ...resourceSessionBindings,
             runtimePaneTitlesByTabId,
-            workspaceSessionReady,
             repoDisplayNameById,
             repoConnectionIdById,
             repoRuntimeScopedById,
@@ -947,11 +947,8 @@ export function ResourceUsageStatusSegment({
       open,
       resourceSnapshot,
       sessions,
-      tabsByWorktree,
-      ptyIdsByTabId,
-      terminalLayoutsByTabId,
+      resourceSessionBindings,
       runtimePaneTitlesByTabId,
-      workspaceSessionReady,
       repoDisplayNameById,
       repoConnectionIdById,
       repoRuntimeScopedById,

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -7,6 +7,7 @@ import type {
   WorktreeMemory
 } from '../../../../shared/types'
 import { mergeSnapshotAndSessions, UNATTRIBUTED_REPO_ID } from './mergeSnapshotAndSessions'
+import { requiresKillConfirmation } from './resource-session-kill-confirmation'
 import type { DaemonSession, MergeContext } from './resource-usage-merge-types'
 
 function emptyAppMemory() {
@@ -156,7 +157,7 @@ describe('mergeSnapshotAndSessions', () => {
       sessions: [{ sessionId: 'pty-1', paneKey: null, pid: 999, cpu: 0.1, memory: 50_000_000 }]
     }
     const ds: DaemonSession[] = [
-      { id: 'pty-1', cwd: '/Users/me/Triton', title: 'shell', hasAgentOwner: false }
+      { id: 'pty-1', cwd: '/Users/me/Triton', title: 'shell', agentOwnership: 'absent' as const }
     ]
     const out = mergeSnapshotAndSessions(makeSnapshot([wt]), ds, baseCtx())
     expect(out[0].worktrees[0].sessions).toHaveLength(1)
@@ -182,15 +183,57 @@ describe('mergeSnapshotAndSessions', () => {
       sessions: [{ sessionId: 'pty-agent', paneKey: null, pid: 999, cpu: 0.1, memory: 50_000_000 }]
     }
     const ds: DaemonSession[] = [
-      { id: 'pty-agent', cwd: '/Users/me/Triton', title: 'codex', hasAgentOwner: true }
+      {
+        id: 'pty-agent',
+        cwd: '/Users/me/Triton',
+        title: 'codex',
+        agentOwnership: 'present' as const
+      }
     ]
 
     const out = mergeSnapshotAndSessions(makeSnapshot([wt]), ds, baseCtx())
 
     expect(out[0].worktrees[0].sessions[0]).toMatchObject({
       sessionId: 'pty-agent',
-      hasAgentOwner: true
+      agentOwnership: 'present' as const
     })
+  })
+
+  it('binds a deferred SSH row so its single-row kill cannot skip confirmation', () => {
+    // Why: the bulk selector already excluded these, but the rendered row took its own path.
+    // An unbound row with no agent skips the dialog entirely — the same #8459 defect, one click over.
+    const sessionId = 'orca::/remote/Stingray@@deferred1'
+    const out = mergeSnapshotAndSessions(
+      null,
+      [{ id: sessionId, cwd: '', title: 'orca/Stingray', agentOwnership: 'absent' as const }],
+      baseCtx({
+        tabsByWorktree: { 'orca::/remote/Stingray': [makeTab('tab-ssh')] },
+        deferredSshSessionIdsByTabId: { 'tab-ssh': sessionId },
+        repoConnectionIdById: new Map([['orca', 'ssh-conn-1']])
+      })
+    )
+
+    const row = out[0].worktrees[0].sessions[0]
+    expect(row).toMatchObject({ sessionId, bound: true, tabId: 'tab-ssh' })
+    expect(requiresKillConfirmation(row)).toBe(true)
+  })
+
+  it('treats a snapshot row the daemon never listed as unknown ownership, not absent', () => {
+    const wt: WorktreeMemory = {
+      worktreeId: 'orca::/Users/me/Triton',
+      worktreeName: 'Triton',
+      repoId: 'orca',
+      repoName: 'ORCA',
+      cpu: 0.1,
+      memory: 50_000_000,
+      history: [],
+      sessions: [{ sessionId: 'pty-only-local', paneKey: null, pid: 7, cpu: 0.1, memory: 1 }]
+    }
+
+    const out = mergeSnapshotAndSessions(makeSnapshot([wt]), [], baseCtx())
+
+    expect(out[0].worktrees[0].sessions[0]).toMatchObject({ agentOwnership: 'unknown' })
+    expect(requiresKillConfirmation(out[0].worktrees[0].sessions[0])).toBe(true)
   })
 
   it('@@ parse: an SSH-style session id resolves to its worktree group', () => {
@@ -199,7 +242,7 @@ describe('mergeSnapshotAndSessions', () => {
         id: 'orca::/remote/Stingray@@abcd1234',
         cwd: '',
         title: 'orca/Stingray',
-        hasAgentOwner: false
+        agentOwnership: 'absent' as const
       }
     ]
     const ctx = baseCtx({
@@ -240,7 +283,7 @@ describe('mergeSnapshotAndSessions', () => {
         id: 'orca::/local/Triton@@deadbeef',
         cwd: '/local/Triton',
         title: 'orca/Triton',
-        hasAgentOwner: false
+        agentOwnership: 'absent' as const
       }
     ]
     const ctx = baseCtx({
@@ -260,7 +303,12 @@ describe('mergeSnapshotAndSessions', () => {
   it('tab walk wins over @@ parse when they disagree', () => {
     const tabId = 'tab-xyz'
     const ds: DaemonSession[] = [
-      { id: 'orca::/wrong/path@@feedface', cwd: '', title: 'orca', hasAgentOwner: false }
+      {
+        id: 'orca::/wrong/path@@feedface',
+        cwd: '',
+        title: 'orca',
+        agentOwnership: 'absent' as const
+      }
     ]
     const ctx = baseCtx({
       tabsByWorktree: {
@@ -278,7 +326,12 @@ describe('mergeSnapshotAndSessions', () => {
     const tabId = 'tab-restored'
     const sessionId = 'orca::/Users/me/Triton@@deferred'
     const ds: DaemonSession[] = [
-      { id: sessionId, cwd: '/Users/me/Triton', title: 'orca/Triton', hasAgentOwner: false }
+      {
+        id: sessionId,
+        cwd: '/Users/me/Triton',
+        title: 'orca/Triton',
+        agentOwnership: 'absent' as const
+      }
     ]
     const restoredTab = { ...makeTab(tabId, 'Restored'), ptyId: sessionId }
     const ctx = baseCtx({
@@ -319,7 +372,7 @@ describe('mergeSnapshotAndSessions', () => {
         id: 'remote-repo::/remote/Stingray@@1234',
         cwd: '',
         title: 'remote/Stingray',
-        hasAgentOwner: false
+        agentOwnership: 'absent' as const
       }
     ]
     const ctx = baseCtx({
@@ -362,10 +415,20 @@ describe('mergeSnapshotAndSessions', () => {
         id: 'runtime-repo::/runtime/Wt@@future-runtime',
         cwd: '',
         title: 'runtime/Wt',
-        hasAgentOwner: false
+        agentOwnership: 'absent' as const
       },
-      { id: 'ssh-repo::/remote/Wt@@ssh-session', cwd: '', title: 'ssh/Wt', hasAgentOwner: false },
-      { id: 'opaque-local-orphan', cwd: '', title: 'orphan shell', hasAgentOwner: false }
+      {
+        id: 'ssh-repo::/remote/Wt@@ssh-session',
+        cwd: '',
+        title: 'ssh/Wt',
+        agentOwnership: 'absent' as const
+      },
+      {
+        id: 'opaque-local-orphan',
+        cwd: '',
+        title: 'orphan shell',
+        agentOwnership: 'absent' as const
+      }
     ]
     const ctx = baseCtx({
       repoConnectionIdById: new Map<string, string | null>([
@@ -409,7 +472,7 @@ describe('mergeSnapshotAndSessions', () => {
     // to. The chip should stay off; the row still surfaces in the
     // unattributed bucket with `—` cells because we have no sample.
     const ds: DaemonSession[] = [
-      { id: 'opaque-id-without-prefix', cwd: '', title: 'shell', hasAgentOwner: false }
+      { id: 'opaque-id-without-prefix', cwd: '', title: 'shell', agentOwnership: 'absent' as const }
     ]
     const out = mergeSnapshotAndSessions(null, ds, baseCtx())
     expect(out).toHaveLength(1)
@@ -463,7 +526,12 @@ describe('mergeSnapshotAndSessions', () => {
 
   it('remote-orphan interaction state: null metrics + bound=false', () => {
     const ds: DaemonSession[] = [
-      { id: 'orca::/remote/Wt@@deadbeef', cwd: '', title: 'orca/Wt', hasAgentOwner: false }
+      {
+        id: 'orca::/remote/Wt@@deadbeef',
+        cwd: '',
+        title: 'orca/Wt',
+        agentOwnership: 'absent' as const
+      }
     ]
     const out = mergeSnapshotAndSessions(null, ds, baseCtx())
     const session = out[0].worktrees[0].sessions[0]
@@ -478,7 +546,7 @@ describe('mergeSnapshotAndSessions', () => {
 
   it('uses repoDisplayNameById to humanize new project groups when available', () => {
     const ds: DaemonSession[] = [
-      { id: 'stably-ai/orca::/remote/Wt@@1', cwd: '', title: '', hasAgentOwner: false }
+      { id: 'stably-ai/orca::/remote/Wt@@1', cwd: '', title: '', agentOwnership: 'absent' as const }
     ]
     const ctx = baseCtx({
       repoDisplayNameById: new Map([['stably-ai/orca', 'ORCA']])

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.test.ts
@@ -155,7 +155,9 @@ describe('mergeSnapshotAndSessions', () => {
       history: [],
       sessions: [{ sessionId: 'pty-1', paneKey: null, pid: 999, cpu: 0.1, memory: 50_000_000 }]
     }
-    const ds: DaemonSession[] = [{ id: 'pty-1', cwd: '/Users/me/Triton', title: 'shell' }]
+    const ds: DaemonSession[] = [
+      { id: 'pty-1', cwd: '/Users/me/Triton', title: 'shell', hasAgentOwner: false }
+    ]
     const out = mergeSnapshotAndSessions(makeSnapshot([wt]), ds, baseCtx())
     expect(out[0].worktrees[0].sessions).toHaveLength(1)
     expect(out[0].worktrees[0].sessions[0]).toMatchObject({
@@ -166,9 +168,39 @@ describe('mergeSnapshotAndSessions', () => {
     })
   })
 
+  it('carries agent ownership onto the snapshot-derived row for the same session', () => {
+    // Why: only the daemon list reports ownership. A snapshot row describing the same session must
+    // not report `false` — that row is the one whose kill skips confirmation (#8459).
+    const wt: WorktreeMemory = {
+      worktreeId: 'orca::/Users/me/Triton',
+      worktreeName: 'Triton',
+      repoId: 'orca',
+      repoName: 'ORCA',
+      cpu: 0.1,
+      memory: 50_000_000,
+      history: [],
+      sessions: [{ sessionId: 'pty-agent', paneKey: null, pid: 999, cpu: 0.1, memory: 50_000_000 }]
+    }
+    const ds: DaemonSession[] = [
+      { id: 'pty-agent', cwd: '/Users/me/Triton', title: 'codex', hasAgentOwner: true }
+    ]
+
+    const out = mergeSnapshotAndSessions(makeSnapshot([wt]), ds, baseCtx())
+
+    expect(out[0].worktrees[0].sessions[0]).toMatchObject({
+      sessionId: 'pty-agent',
+      hasAgentOwner: true
+    })
+  })
+
   it('@@ parse: an SSH-style session id resolves to its worktree group', () => {
     const ds: DaemonSession[] = [
-      { id: 'orca::/remote/Stingray@@abcd1234', cwd: '', title: 'orca/Stingray' }
+      {
+        id: 'orca::/remote/Stingray@@abcd1234',
+        cwd: '',
+        title: 'orca/Stingray',
+        hasAgentOwner: false
+      }
     ]
     const ctx = baseCtx({
       repoConnectionIdById: new Map([['orca', 'ssh-conn-1']])
@@ -204,7 +236,12 @@ describe('mergeSnapshotAndSessions', () => {
     // re-spawned yet must NOT be flagged as remote. Under the old
     // predicate (`!hasLocalSamples`) it was — that was the bug.
     const ds: DaemonSession[] = [
-      { id: 'orca::/local/Triton@@deadbeef', cwd: '/local/Triton', title: 'orca/Triton' }
+      {
+        id: 'orca::/local/Triton@@deadbeef',
+        cwd: '/local/Triton',
+        title: 'orca/Triton',
+        hasAgentOwner: false
+      }
     ]
     const ctx = baseCtx({
       repoConnectionIdById: new Map([['orca', null]])
@@ -222,7 +259,9 @@ describe('mergeSnapshotAndSessions', () => {
 
   it('tab walk wins over @@ parse when they disagree', () => {
     const tabId = 'tab-xyz'
-    const ds: DaemonSession[] = [{ id: 'orca::/wrong/path@@feedface', cwd: '', title: 'orca' }]
+    const ds: DaemonSession[] = [
+      { id: 'orca::/wrong/path@@feedface', cwd: '', title: 'orca', hasAgentOwner: false }
+    ]
     const ctx = baseCtx({
       tabsByWorktree: {
         'orca::/correct/path': [makeTab(tabId, 'My Tab')]
@@ -238,7 +277,9 @@ describe('mergeSnapshotAndSessions', () => {
   it('treats startup deferred reattach tab ptyId wake hints as bound sessions', () => {
     const tabId = 'tab-restored'
     const sessionId = 'orca::/Users/me/Triton@@deferred'
-    const ds: DaemonSession[] = [{ id: sessionId, cwd: '/Users/me/Triton', title: 'orca/Triton' }]
+    const ds: DaemonSession[] = [
+      { id: sessionId, cwd: '/Users/me/Triton', title: 'orca/Triton', hasAgentOwner: false }
+    ]
     const restoredTab = { ...makeTab(tabId, 'Restored'), ptyId: sessionId }
     const ctx = baseCtx({
       tabsByWorktree: {
@@ -274,7 +315,12 @@ describe('mergeSnapshotAndSessions', () => {
       sessions: []
     }
     const remoteDs: DaemonSession[] = [
-      { id: 'remote-repo::/remote/Stingray@@1234', cwd: '', title: 'remote/Stingray' }
+      {
+        id: 'remote-repo::/remote/Stingray@@1234',
+        cwd: '',
+        title: 'remote/Stingray',
+        hasAgentOwner: false
+      }
     ]
     const ctx = baseCtx({
       repoConnectionIdById: new Map<string, string | null>([
@@ -312,9 +358,14 @@ describe('mergeSnapshotAndSessions', () => {
       sessions: [{ sessionId: 'runtime-pty', paneKey: null, pid: 2, cpu: 5, memory: 500_000_000 }]
     }
     const sessions: DaemonSession[] = [
-      { id: 'runtime-repo::/runtime/Wt@@future-runtime', cwd: '', title: 'runtime/Wt' },
-      { id: 'ssh-repo::/remote/Wt@@ssh-session', cwd: '', title: 'ssh/Wt' },
-      { id: 'opaque-local-orphan', cwd: '', title: 'orphan shell' }
+      {
+        id: 'runtime-repo::/runtime/Wt@@future-runtime',
+        cwd: '',
+        title: 'runtime/Wt',
+        hasAgentOwner: false
+      },
+      { id: 'ssh-repo::/remote/Wt@@ssh-session', cwd: '', title: 'ssh/Wt', hasAgentOwner: false },
+      { id: 'opaque-local-orphan', cwd: '', title: 'orphan shell', hasAgentOwner: false }
     ]
     const ctx = baseCtx({
       repoConnectionIdById: new Map<string, string | null>([
@@ -357,7 +408,9 @@ describe('mergeSnapshotAndSessions', () => {
     // not evidence of remoteness — we just don't know what it belongs
     // to. The chip should stay off; the row still surfaces in the
     // unattributed bucket with `—` cells because we have no sample.
-    const ds: DaemonSession[] = [{ id: 'opaque-id-without-prefix', cwd: '', title: 'shell' }]
+    const ds: DaemonSession[] = [
+      { id: 'opaque-id-without-prefix', cwd: '', title: 'shell', hasAgentOwner: false }
+    ]
     const out = mergeSnapshotAndSessions(null, ds, baseCtx())
     expect(out).toHaveLength(1)
     expect(out[0].repoId).toBe(UNATTRIBUTED_REPO_ID)
@@ -409,7 +462,9 @@ describe('mergeSnapshotAndSessions', () => {
   })
 
   it('remote-orphan interaction state: null metrics + bound=false', () => {
-    const ds: DaemonSession[] = [{ id: 'orca::/remote/Wt@@deadbeef', cwd: '', title: 'orca/Wt' }]
+    const ds: DaemonSession[] = [
+      { id: 'orca::/remote/Wt@@deadbeef', cwd: '', title: 'orca/Wt', hasAgentOwner: false }
+    ]
     const out = mergeSnapshotAndSessions(null, ds, baseCtx())
     const session = out[0].worktrees[0].sessions[0]
     expect(session).toMatchObject({
@@ -422,7 +477,9 @@ describe('mergeSnapshotAndSessions', () => {
   })
 
   it('uses repoDisplayNameById to humanize new project groups when available', () => {
-    const ds: DaemonSession[] = [{ id: 'stably-ai/orca::/remote/Wt@@1', cwd: '', title: '' }]
+    const ds: DaemonSession[] = [
+      { id: 'stably-ai/orca::/remote/Wt@@1', cwd: '', title: '', hasAgentOwner: false }
+    ]
     const ctx = baseCtx({
       repoDisplayNameById: new Map([['stably-ai/orca', 'ORCA']])
     })

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -142,6 +142,11 @@ export function mergeSnapshotAndSessions(
   // sessions do not appear as Resource Manager orphans before their pane mounts.
   const index = buildResourceSessionBindingIndex(ctx)
   const boundPtyIds = index.boundPtyIds
+  // Why: the daemon list is the only place agent ownership is reported. Snapshot-derived rows
+  // describe the same sessions by id, so carry it across rather than letting them report `false`.
+  const agentOwnedSessionIds = new Set(
+    daemonSessions.filter((session) => session.hasAgentOwner).map((session) => session.id)
+  )
 
   function isRepoRemote(repoId: string): boolean {
     // Why: missing entry === we don't know about this repo (typically the
@@ -202,6 +207,7 @@ export function mergeSnapshotAndSessions(
           pid: s.pid,
           label: resolveSnapshotSessionLabel(s, wt.worktreeId, ctx),
           bound: ctx.workspaceSessionReady && boundPtyIds.has(s.sessionId),
+          hasAgentOwner: agentOwnedSessionIds.has(s.sessionId),
           tabId,
           cpu: s.cpu,
           memory: s.memory,
@@ -289,6 +295,7 @@ export function mergeSnapshotAndSessions(
       pid: 0,
       label: resolveDaemonSessionLabel(session, worktreeId, tabId, ctx),
       bound: ctx.workspaceSessionReady && boundPtyIds.has(session.id),
+      hasAgentOwner: session.hasAgentOwner,
       tabId,
       cpu: null,
       memory: null,

--- a/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
+++ b/src/renderer/src/components/status-bar/mergeSnapshotAndSessions.ts
@@ -143,9 +143,10 @@ export function mergeSnapshotAndSessions(
   const index = buildResourceSessionBindingIndex(ctx)
   const boundPtyIds = index.boundPtyIds
   // Why: the daemon list is the only place agent ownership is reported. Snapshot-derived rows
-  // describe the same sessions by id, so carry it across rather than letting them report `false`.
-  const agentOwnedSessionIds = new Set(
-    daemonSessions.filter((session) => session.hasAgentOwner).map((session) => session.id)
+  // describe the same sessions by id, so carry it across rather than inventing an answer; a
+  // session the daemon never listed is 'unknown', not 'absent'.
+  const ownershipBySessionId = new Map(
+    daemonSessions.map((session) => [session.id, session.agentOwnership])
   )
 
   function isRepoRemote(repoId: string): boolean {
@@ -207,7 +208,7 @@ export function mergeSnapshotAndSessions(
           pid: s.pid,
           label: resolveSnapshotSessionLabel(s, wt.worktreeId, ctx),
           bound: ctx.workspaceSessionReady && boundPtyIds.has(s.sessionId),
-          hasAgentOwner: agentOwnedSessionIds.has(s.sessionId),
+          agentOwnership: ownershipBySessionId.get(s.sessionId) ?? 'unknown',
           tabId,
           cpu: s.cpu,
           memory: s.memory,
@@ -295,7 +296,7 @@ export function mergeSnapshotAndSessions(
       pid: 0,
       label: resolveDaemonSessionLabel(session, worktreeId, tabId, ctx),
       bound: ctx.workspaceSessionReady && boundPtyIds.has(session.id),
-      hasAgentOwner: session.hasAgentOwner,
+      agentOwnership: session.agentOwnership,
       tabId,
       cpu: null,
       memory: null,

--- a/src/renderer/src/components/status-bar/resource-session-bindings.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.test.ts
@@ -83,9 +83,14 @@ describe('resource session bindings', () => {
   it('counts only daemon sessions without live or restorable tab bindings', () => {
     const count = countUnboundDaemonSessions(
       [
-        { id: 'pty-live', cwd: '/workspace', title: 'live', hasAgentOwner: false },
-        { id: 'pty-restored', cwd: '/workspace', title: 'restored', hasAgentOwner: false },
-        { id: 'pty-orphan', cwd: '/tmp', title: 'orphan', hasAgentOwner: false }
+        { id: 'pty-live', cwd: '/workspace', title: 'live', agentOwnership: 'absent' as const },
+        {
+          id: 'pty-restored',
+          cwd: '/workspace',
+          title: 'restored',
+          agentOwnership: 'absent' as const
+        },
+        { id: 'pty-orphan', cwd: '/tmp', title: 'orphan', agentOwnership: 'absent' as const }
       ],
       {
         ptyIdsByTabId: { 'tab-live': ['pty-live'] },
@@ -112,7 +117,14 @@ describe('resource session bindings', () => {
     expect(buildResourceSessionBindingIndex(inputs).boundPtyIds.has('pty-deferred')).toBe(true)
     expect(
       selectUnboundDaemonSessions(
-        [{ id: 'pty-deferred', cwd: '/workspace', title: 'agent', hasAgentOwner: false }],
+        [
+          {
+            id: 'pty-deferred',
+            cwd: '/workspace',
+            title: 'agent',
+            agentOwnership: 'absent' as const
+          }
+        ],
         inputs
       )
     ).toEqual([])
@@ -138,8 +150,8 @@ describe('resource session bindings', () => {
       workspaceSessionReady: true
     }
     const sessions = [
-      { id: 'pty-agent', cwd: '/workspace', title: 'codex', hasAgentOwner: true },
-      { id: 'pty-shell', cwd: '/tmp', title: 'shell', hasAgentOwner: false }
+      { id: 'pty-agent', cwd: '/workspace', title: 'codex', agentOwnership: 'present' as const },
+      { id: 'pty-shell', cwd: '/tmp', title: 'shell', agentOwnership: 'absent' as const }
     ]
 
     expect(selectUnboundDaemonSessions(sessions, inputs).map((s) => s.id)).toEqual(['pty-shell'])
@@ -155,10 +167,15 @@ describe('resource session bindings', () => {
       workspaceSessionReady: true
     }
     const sessions = [
-      { id: 'pty-live', cwd: '/workspace', title: 'live', hasAgentOwner: false },
-      { id: 'pty-deferred', cwd: '/workspace', title: 'deferred', hasAgentOwner: false },
-      { id: 'pty-agent', cwd: '/workspace', title: 'codex', hasAgentOwner: true },
-      { id: 'pty-orphan', cwd: '/tmp', title: 'orphan', hasAgentOwner: false }
+      { id: 'pty-live', cwd: '/workspace', title: 'live', agentOwnership: 'absent' as const },
+      {
+        id: 'pty-deferred',
+        cwd: '/workspace',
+        title: 'deferred',
+        agentOwnership: 'absent' as const
+      },
+      { id: 'pty-agent', cwd: '/workspace', title: 'codex', agentOwnership: 'present' as const },
+      { id: 'pty-orphan', cwd: '/tmp', title: 'orphan', agentOwnership: 'absent' as const }
     ]
 
     expect(selectUnboundDaemonSessions(sessions, inputs).map((s) => s.id)).toEqual(['pty-orphan'])
@@ -167,8 +184,28 @@ describe('resource session bindings', () => {
     )
   })
 
+  it('never offers a session whose ownership could not be established', () => {
+    // Why: a legacy daemon generation or an older SSH relay cannot serialize claims, so it reports
+    // no owners for a session that may well have one. Unknown must never read as absent (#8459).
+    const inputs = {
+      ptyIdsByTabId: {},
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      workspaceSessionReady: true
+    }
+    const sessions = [
+      { id: 'pty-legacy', cwd: '/workspace', title: 'shell', agentOwnership: 'unknown' as const },
+      { id: 'pty-known', cwd: '/tmp', title: 'shell', agentOwnership: 'absent' as const }
+    ]
+
+    expect(selectUnboundDaemonSessions(sessions, inputs).map((s) => s.id)).toEqual(['pty-known'])
+    expect(countUnboundDaemonSessions(sessions, inputs)).toBe(1)
+  })
+
   it('offers nothing while the workspace session is still loading', () => {
-    const sessions = [{ id: 'pty-any', cwd: '/tmp', title: 'shell', hasAgentOwner: false }]
+    const sessions = [
+      { id: 'pty-any', cwd: '/tmp', title: 'shell', agentOwnership: 'absent' as const }
+    ]
     const inputs = {
       ptyIdsByTabId: {},
       tabsByWorktree: {},

--- a/src/renderer/src/components/status-bar/resource-session-bindings.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/types'
 import {
   buildResourceSessionBindingIndex,
-  countUnboundDaemonSessions
+  countUnboundDaemonSessions,
+  selectUnboundDaemonSessions
 } from './resource-session-bindings'
 
 function makeTab(id: string, ptyId: string | null = null): TerminalTab {
@@ -82,9 +83,9 @@ describe('resource session bindings', () => {
   it('counts only daemon sessions without live or restorable tab bindings', () => {
     const count = countUnboundDaemonSessions(
       [
-        { id: 'pty-live', cwd: '/workspace', title: 'live' },
-        { id: 'pty-restored', cwd: '/workspace', title: 'restored' },
-        { id: 'pty-orphan', cwd: '/tmp', title: 'orphan' }
+        { id: 'pty-live', cwd: '/workspace', title: 'live', hasAgentOwner: false },
+        { id: 'pty-restored', cwd: '/workspace', title: 'restored', hasAgentOwner: false },
+        { id: 'pty-orphan', cwd: '/tmp', title: 'orphan', hasAgentOwner: false }
       ],
       {
         ptyIdsByTabId: { 'tab-live': ['pty-live'] },
@@ -97,5 +98,85 @@ describe('resource session bindings', () => {
     )
 
     expect(count).toBe(1)
+  })
+
+  it('binds a session deferred for SSH reattach so it is never offered for cleanup', () => {
+    const inputs = {
+      ptyIdsByTabId: {},
+      tabsByWorktree: { 'repo::/workspace': [makeTab('tab-ssh')] },
+      terminalLayoutsByTabId: {},
+      deferredSshSessionIdsByTabId: { 'tab-ssh': 'pty-deferred' },
+      workspaceSessionReady: true
+    }
+
+    expect(buildResourceSessionBindingIndex(inputs).boundPtyIds.has('pty-deferred')).toBe(true)
+    expect(
+      selectUnboundDaemonSessions(
+        [{ id: 'pty-deferred', cwd: '/workspace', title: 'agent', hasAgentOwner: false }],
+        inputs
+      )
+    ).toEqual([])
+  })
+
+  it('ignores a deferred session whose tab no longer exists', () => {
+    const index = buildResourceSessionBindingIndex({
+      ptyIdsByTabId: {},
+      tabsByWorktree: { 'repo::/workspace': [makeTab('tab-live')] },
+      terminalLayoutsByTabId: {},
+      deferredSshSessionIdsByTabId: { 'tab-gone': 'pty-stranded' },
+      workspaceSessionReady: true
+    })
+
+    expect(index.boundPtyIds.has('pty-stranded')).toBe(false)
+  })
+
+  it('never offers an agent-owned session for cleanup even with no binding at all', () => {
+    const inputs = {
+      ptyIdsByTabId: {},
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      workspaceSessionReady: true
+    }
+    const sessions = [
+      { id: 'pty-agent', cwd: '/workspace', title: 'codex', hasAgentOwner: true },
+      { id: 'pty-shell', cwd: '/tmp', title: 'shell', hasAgentOwner: false }
+    ]
+
+    expect(selectUnboundDaemonSessions(sessions, inputs).map((s) => s.id)).toEqual(['pty-shell'])
+    expect(countUnboundDaemonSessions(sessions, inputs)).toBe(1)
+  })
+
+  it('keeps the advertised count and the selected set identical', () => {
+    const inputs = {
+      ptyIdsByTabId: { 'tab-live': ['pty-live'] },
+      tabsByWorktree: { 'repo::/workspace': [makeTab('tab-live'), makeTab('tab-ssh')] },
+      terminalLayoutsByTabId: {},
+      deferredSshSessionIdsByTabId: { 'tab-ssh': 'pty-deferred' },
+      workspaceSessionReady: true
+    }
+    const sessions = [
+      { id: 'pty-live', cwd: '/workspace', title: 'live', hasAgentOwner: false },
+      { id: 'pty-deferred', cwd: '/workspace', title: 'deferred', hasAgentOwner: false },
+      { id: 'pty-agent', cwd: '/workspace', title: 'codex', hasAgentOwner: true },
+      { id: 'pty-orphan', cwd: '/tmp', title: 'orphan', hasAgentOwner: false }
+    ]
+
+    expect(selectUnboundDaemonSessions(sessions, inputs).map((s) => s.id)).toEqual(['pty-orphan'])
+    expect(countUnboundDaemonSessions(sessions, inputs)).toBe(
+      selectUnboundDaemonSessions(sessions, inputs).length
+    )
+  })
+
+  it('offers nothing while the workspace session is still loading', () => {
+    const sessions = [{ id: 'pty-any', cwd: '/tmp', title: 'shell', hasAgentOwner: false }]
+    const inputs = {
+      ptyIdsByTabId: {},
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      workspaceSessionReady: false
+    }
+
+    expect(selectUnboundDaemonSessions(sessions, inputs)).toEqual([])
+    expect(countUnboundDaemonSessions(sessions, inputs)).toBe(0)
   })
 })

--- a/src/renderer/src/components/status-bar/resource-session-bindings.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.ts
@@ -5,6 +5,13 @@ export type ResourceSessionBindingInputs = {
   tabsByWorktree: Record<string, TerminalTab[]>
   ptyIdsByTabId: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
+  /**
+   * Sessions restore knows exist on an SSH host but has not reattached yet, keyed by tab. Restore
+   * skips reattach while the relay is not connected (`terminals.ts` reconnectPersistedTerminals),
+   * so these are live remote sessions no other binding source can see. Omitting them is what let
+   * Resource Manager classify live agent sessions as orphans and force-kill them (#8459).
+   */
+  deferredSshSessionIdsByTabId?: Record<string, string>
   workspaceSessionReady: boolean
 }
 
@@ -61,6 +68,15 @@ export function buildResourceSessionBindingIndex(
     }
   }
 
+  // Why last: a deferred reattach is the one case where the session is known live but has no
+  // live-PTY, tab, or layout binding to find it by.
+  for (const [tabId, sessionId] of Object.entries(inputs.deferredSshSessionIdsByTabId ?? {})) {
+    if (!tabIdToWorktreeId.has(tabId)) {
+      continue
+    }
+    addBinding(ptyIdToTabId, tabId, sessionId)
+  }
+
   return {
     ptyIdToTabId,
     tabIdToWorktreeId,
@@ -68,19 +84,27 @@ export function buildResourceSessionBindingIndex(
   }
 }
 
+/**
+ * The sessions Resource Manager may offer for bulk destruction: unbound in this renderer *and*
+ * unclaimed by any agent. Single source of truth so the advertised count and the set actually
+ * killed cannot diverge — that divergence would be live agent sessions (#8459).
+ */
+export function selectUnboundDaemonSessions(
+  sessions: readonly DaemonSession[],
+  inputs: ResourceSessionBindingInputs
+): DaemonSession[] {
+  if (!inputs.workspaceSessionReady) {
+    return []
+  }
+  const { boundPtyIds } = buildResourceSessionBindingIndex(inputs)
+  // Why hasAgentOwner short-circuits: an agent holding the session is positive proof work is
+  // running. This renderer's binding map is empty during restore, so it cannot decide alone.
+  return sessions.filter((session) => !boundPtyIds.has(session.id) && !session.hasAgentOwner)
+}
+
 export function countUnboundDaemonSessions(
   sessions: readonly DaemonSession[],
   inputs: ResourceSessionBindingInputs
 ): number {
-  if (!inputs.workspaceSessionReady) {
-    return 0
-  }
-  const { boundPtyIds } = buildResourceSessionBindingIndex(inputs)
-  let count = 0
-  for (const session of sessions) {
-    if (!boundPtyIds.has(session.id)) {
-      count += 1
-    }
-  }
-  return count
+  return selectUnboundDaemonSessions(sessions, inputs).length
 }

--- a/src/renderer/src/components/status-bar/resource-session-bindings.ts
+++ b/src/renderer/src/components/status-bar/resource-session-bindings.ts
@@ -1,4 +1,5 @@
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/types'
+import { mayDestroyWithoutOwnerEvidence } from '../../../../shared/pty-listed-session'
 import type { DaemonSession } from './resource-usage-merge-types'
 
 export type ResourceSessionBindingInputs = {
@@ -97,9 +98,11 @@ export function selectUnboundDaemonSessions(
     return []
   }
   const { boundPtyIds } = buildResourceSessionBindingIndex(inputs)
-  // Why hasAgentOwner short-circuits: an agent holding the session is positive proof work is
-  // running. This renderer's binding map is empty during restore, so it cannot decide alone.
-  return sessions.filter((session) => !boundPtyIds.has(session.id) && !session.hasAgentOwner)
+  // Why the ownership check: this renderer's binding map is empty during restore, so it cannot
+  // decide alone. Only proven absence of an owner qualifies — 'unknown' protects.
+  return sessions.filter(
+    (session) => !boundPtyIds.has(session.id) && mayDestroyWithoutOwnerEvidence(session)
+  )
 }
 
 export function countUnboundDaemonSessions(

--- a/src/renderer/src/components/status-bar/resource-session-classification-parity.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-classification-parity.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SEGMENT_PATH = resolve(__dirname, 'ResourceUsageStatusSegment.tsx')
+
+/**
+ * Both destructive paths — bulk "kill orphans" and a single row's kill — must classify from the
+ * same binding inputs. When the merge call site re-listed the fields instead of reusing the
+ * object, it silently omitted deferred SSH sessions: bulk cleanup spared them while the row's
+ * kill destroyed them with no confirmation. Same bug, one click over (#8459).
+ */
+describe('resource session classification parity', () => {
+  it('feeds the row merge the same binding inputs as the bulk selector', () => {
+    const source = readFileSync(SEGMENT_PATH, 'utf8')
+    const mergeCall = source.slice(
+      source.indexOf('mergeSnapshotAndSessions(resourceSnapshot'),
+      source.indexOf('worktreeById\n          })')
+    )
+
+    expect(mergeCall).toContain('...resourceSessionBindings')
+    // Any of these appearing inline means the call site is re-deriving bindings and can drift.
+    for (const field of [
+      'ptyIdsByTabId,',
+      'tabsByWorktree,',
+      'terminalLayoutsByTabId,',
+      'deferredSshSessionIdsByTabId,',
+      'workspaceSessionReady,'
+    ]) {
+      expect(mergeCall).not.toContain(field)
+    }
+  })
+
+  it('keeps every binding source in the one object both paths read', () => {
+    const source = readFileSync(SEGMENT_PATH, 'utf8')
+    const bindings = source.slice(
+      source.indexOf('const resourceSessionBindings = useMemo'),
+      source.indexOf('const popoverBodyRef')
+    )
+
+    for (const field of [
+      'ptyIdsByTabId',
+      'tabsByWorktree',
+      'terminalLayoutsByTabId',
+      'deferredSshSessionIdsByTabId',
+      'workspaceSessionReady'
+    ]) {
+      expect(bindings).toContain(field)
+    }
+  })
+})

--- a/src/renderer/src/components/status-bar/resource-session-inventory.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-inventory.test.ts
@@ -8,7 +8,7 @@ import {
 import type { DaemonSession } from './resource-usage-merge-types'
 
 function session(id: string): DaemonSession {
-  return { id, cwd: '/workspace', title: id, hasAgentOwner: false }
+  return { id, cwd: '/workspace', title: id, agentOwnership: 'absent' as const }
 }
 
 describe('resource session inventory', () => {

--- a/src/renderer/src/components/status-bar/resource-session-inventory.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-inventory.test.ts
@@ -8,7 +8,7 @@ import {
 import type { DaemonSession } from './resource-usage-merge-types'
 
 function session(id: string): DaemonSession {
-  return { id, cwd: '/workspace', title: id }
+  return { id, cwd: '/workspace', title: id, hasAgentOwner: false }
 }
 
 describe('resource session inventory', () => {

--- a/src/renderer/src/components/status-bar/resource-session-kill-confirmation.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-kill-confirmation.test.ts
@@ -9,7 +9,7 @@ function row(overrides: Partial<UnifiedSessionRow> = {}): UnifiedSessionRow {
     pid: 0,
     label: 'zsh',
     bound: false,
-    hasAgentOwner: false,
+    agentOwnership: 'absent',
     tabId: null,
     cpu: null,
     memory: null,
@@ -24,10 +24,16 @@ describe('resource session kill confirmation', () => {
   })
 
   it('confirms before killing an agent-owned session that has no binding', () => {
-    expect(requiresKillConfirmation(row({ bound: false, hasAgentOwner: true }))).toBe(true)
+    expect(requiresKillConfirmation(row({ bound: false, agentOwnership: 'present' }))).toBe(true)
   })
 
-  it('skips the prompt only when the session is both unbound and unclaimed', () => {
+  it('confirms when ownership could not be established at all', () => {
+    // Why: a provider that cannot serialize claims reports no owners for a session that may have
+    // one. Treating that silence as proof of absence is the #8459 defect.
+    expect(requiresKillConfirmation(row({ bound: false, agentOwnership: 'unknown' }))).toBe(true)
+  })
+
+  it('skips the prompt only on proven absence with no binding', () => {
     expect(requiresKillConfirmation(row())).toBe(false)
   })
 })

--- a/src/renderer/src/components/status-bar/resource-session-kill-confirmation.test.ts
+++ b/src/renderer/src/components/status-bar/resource-session-kill-confirmation.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { requiresKillConfirmation } from './resource-session-kill-confirmation'
+import type { UnifiedSessionRow } from './resource-usage-merge-types'
+
+function row(overrides: Partial<UnifiedSessionRow> = {}): UnifiedSessionRow {
+  return {
+    sessionId: 'sess-1',
+    paneKey: null,
+    pid: 0,
+    label: 'zsh',
+    bound: false,
+    hasAgentOwner: false,
+    tabId: null,
+    cpu: null,
+    memory: null,
+    hasLocalSamples: false,
+    ...overrides
+  }
+}
+
+describe('resource session kill confirmation', () => {
+  it('confirms before killing a session with a visible tab', () => {
+    expect(requiresKillConfirmation(row({ bound: true, tabId: 'tab-1' }))).toBe(true)
+  })
+
+  it('confirms before killing an agent-owned session that has no binding', () => {
+    expect(requiresKillConfirmation(row({ bound: false, hasAgentOwner: true }))).toBe(true)
+  })
+
+  it('skips the prompt only when the session is both unbound and unclaimed', () => {
+    expect(requiresKillConfirmation(row())).toBe(false)
+  })
+})

--- a/src/renderer/src/components/status-bar/resource-session-kill-confirmation.ts
+++ b/src/renderer/src/components/status-bar/resource-session-kill-confirmation.ts
@@ -1,0 +1,13 @@
+import type { UnifiedSessionRow } from './resource-usage-merge-types'
+
+/**
+ * Whether killing this session must ask first.
+ *
+ * Skipping the prompt is only safe when Orca can show what would be lost — a bound row has a tab
+ * the user can look at. Absence of a binding is not evidence the session is idle, and agent
+ * ownership is positive evidence it is not: an agent holds live work with no tab of its own.
+ * Resource Manager force-killed exactly those sessions with no prompt (#8459).
+ */
+export function requiresKillConfirmation(session: UnifiedSessionRow): boolean {
+  return session.bound || session.hasAgentOwner
+}

--- a/src/renderer/src/components/status-bar/resource-session-kill-confirmation.ts
+++ b/src/renderer/src/components/status-bar/resource-session-kill-confirmation.ts
@@ -1,13 +1,14 @@
+import { mayDestroyWithoutOwnerEvidence } from '../../../../shared/pty-listed-session'
 import type { UnifiedSessionRow } from './resource-usage-merge-types'
 
 /**
  * Whether killing this session must ask first.
  *
  * Skipping the prompt is only safe when Orca can show what would be lost — a bound row has a tab
- * the user can look at. Absence of a binding is not evidence the session is idle, and agent
- * ownership is positive evidence it is not: an agent holds live work with no tab of its own.
+ * the user can look at. Absence of a binding is not evidence the session is idle, and only proven
+ * absence of an agent owner is evidence no work is running; an unprovable owner asks.
  * Resource Manager force-killed exactly those sessions with no prompt (#8459).
  */
 export function requiresKillConfirmation(session: UnifiedSessionRow): boolean {
-  return session.bound || session.hasAgentOwner
+  return session.bound || !mayDestroyWithoutOwnerEvidence(session)
 }

--- a/src/renderer/src/components/status-bar/resource-usage-merge-types.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-merge-types.ts
@@ -4,7 +4,10 @@ import type {
   TerminalTab,
   Worktree
 } from '../../../../shared/types'
-import type { PtyListedSession } from '../../../../shared/pty-listed-session'
+import type {
+  AgentOwnershipEvidence,
+  PtyListedSession
+} from '../../../../shared/pty-listed-session'
 
 /** `null` === "no local sample" (e.g. SSH PTY); UI renders as em-dash. */
 export type Metric = number | null
@@ -18,8 +21,8 @@ export type UnifiedSessionRow = {
   pid: number
   label: string
   bound: boolean
-  /** An agent holds this session. Destroying it discards live work, so it always confirms. */
-  hasAgentOwner: boolean
+  /** Ownership as the provider could establish it; anything but `absent` means confirm first. */
+  agentOwnership: AgentOwnershipEvidence
   tabId: string | null
   cpu: Metric
   memory: Metric
@@ -58,6 +61,8 @@ export type MergeContext = {
   ptyIdsByTabId: Record<string, string[]>
   /** From useAppStore: persisted per-leaf PTY wake hints for deferred reattach. */
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
+  /** From useAppStore: SSH sessions known live but not yet reattached; no other binding sees them. */
+  deferredSshSessionIdsByTabId?: Record<string, string>
   /** From useAppStore: per-tab live pane titles (for label resolution). */
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
   /** From useAppStore: false until renderer state can distinguish bound/orphan. */

--- a/src/renderer/src/components/status-bar/resource-usage-merge-types.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-merge-types.ts
@@ -4,15 +4,13 @@ import type {
   TerminalTab,
   Worktree
 } from '../../../../shared/types'
+import type { PtyListedSession } from '../../../../shared/pty-listed-session'
 
 /** `null` === "no local sample" (e.g. SSH PTY); UI renders as em-dash. */
 export type Metric = number | null
 
-export type DaemonSession = {
-  id: string
-  cwd: string
-  title: string
-}
+/** One `pty.listSessions()` row. Aliased so ownership evidence cannot be dropped locally. */
+export type DaemonSession = PtyListedSession
 
 export type UnifiedSessionRow = {
   sessionId: string
@@ -20,6 +18,8 @@ export type UnifiedSessionRow = {
   pid: number
   label: string
   bound: boolean
+  /** An agent holds this session. Destroying it discards live work, so it always confirms. */
+  hasAgentOwner: boolean
   tabId: string | null
   cpu: Metric
   memory: Metric

--- a/src/renderer/src/components/status-bar/resource-usage-open-slices.test.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-open-slices.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   getResourceUsageAllWorktrees,
+  getResourceUsageDeferredSshSessionIdsByTabId,
   getResourceUsagePtyIdsByTabId,
   getResourceUsageRepos,
   getResourceUsageRuntimePaneTitlesByTabId,
@@ -71,10 +72,20 @@ describe('resource usage open slices', () => {
     expect(closedLayouts).toBe(
       getResourceUsageTerminalLayoutsByTabId({ terminalLayoutsByTabId: {} }, false)
     )
+    const deferredSshSessionIdsByTabId = { 'tab-1': 'pty-deferred' }
+    const closedDeferred = getResourceUsageDeferredSshSessionIdsByTabId(
+      { deferredSshSessionIdsByTabId },
+      false
+    )
+    expect(closedDeferred).toBe(
+      getResourceUsageDeferredSshSessionIdsByTabId({ deferredSshSessionIdsByTabId: {} }, false)
+    )
+
     expect(closedTabs).toEqual({})
     expect(closedPtyIds).toEqual({})
     expect(closedLayouts).toEqual({})
     expect(closedTitles).toEqual({})
+    expect(closedDeferred).toEqual({})
   })
 
   it('returns live slices while the popover is open', () => {
@@ -99,6 +110,10 @@ describe('resource usage open slices', () => {
     expect(getResourceUsageRuntimePaneTitlesByTabId({ runtimePaneTitlesByTabId }, true)).toBe(
       runtimePaneTitlesByTabId
     )
+    const deferredSshSessionIdsByTabId = { 'tab-1': 'pty-deferred' }
+    expect(
+      getResourceUsageDeferredSshSessionIdsByTabId({ deferredSshSessionIdsByTabId }, true)
+    ).toBe(deferredSshSessionIdsByTabId)
   })
 
   it('gates repo and worktree slices only while closed', () => {

--- a/src/renderer/src/components/status-bar/resource-usage-open-slices.ts
+++ b/src/renderer/src/components/status-bar/resource-usage-open-slices.ts
@@ -4,6 +4,7 @@ import { getAllWorktreesFromState } from '../../store/selectors'
 const EMPTY_TABS_BY_WORKTREE: AppState['tabsByWorktree'] = {}
 const EMPTY_PTY_IDS_BY_TAB_ID: AppState['ptyIdsByTabId'] = {}
 const EMPTY_TERMINAL_LAYOUTS_BY_TAB_ID: AppState['terminalLayoutsByTabId'] = {}
+const EMPTY_DEFERRED_SSH_SESSION_IDS_BY_TAB_ID: AppState['deferredSshSessionIdsByTabId'] = {}
 const EMPTY_RUNTIME_PANE_TITLES_BY_TAB_ID: AppState['runtimePaneTitlesByTabId'] = {}
 const EMPTY_BROWSER_TABS_BY_WORKTREE: AppState['browserTabsByWorktree'] = {}
 const EMPTY_REPOS: AppState['repos'] = []
@@ -28,6 +29,13 @@ export function getResourceUsageTerminalLayoutsByTabId(
   open: boolean
 ): AppState['terminalLayoutsByTabId'] {
   return open ? state.terminalLayoutsByTabId : EMPTY_TERMINAL_LAYOUTS_BY_TAB_ID
+}
+
+export function getResourceUsageDeferredSshSessionIdsByTabId(
+  state: Pick<AppState, 'deferredSshSessionIdsByTabId'>,
+  open: boolean
+): AppState['deferredSshSessionIdsByTabId'] {
+  return open ? state.deferredSshSessionIdsByTabId : EMPTY_DEFERRED_SSH_SESSION_IDS_BY_TAB_ID
 }
 
 export function getResourceUsageRuntimePaneTitlesByTabId(

--- a/src/renderer/src/components/status-bar/use-resource-session-inventory.test.tsx
+++ b/src/renderer/src/components/status-bar/use-resource-session-inventory.test.tsx
@@ -5,7 +5,7 @@ import type { DaemonSession } from './resource-usage-merge-types'
 import { useResourceSessionInventory } from './use-resource-session-inventory'
 
 function session(id: string): DaemonSession {
-  return { id, cwd: '/workspace', title: id, hasAgentOwner: false }
+  return { id, cwd: '/workspace', title: id, agentOwnership: 'absent' as const }
 }
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {

--- a/src/renderer/src/components/status-bar/use-resource-session-inventory.test.tsx
+++ b/src/renderer/src/components/status-bar/use-resource-session-inventory.test.tsx
@@ -5,7 +5,7 @@ import type { DaemonSession } from './resource-usage-merge-types'
 import { useResourceSessionInventory } from './use-resource-session-inventory'
 
 function session(id: string): DaemonSession {
-  return { id, cwd: '/workspace', title: id }
+  return { id, cwd: '/workspace', title: id, hasAgentOwner: false }
 }
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {

--- a/src/shared/pty-listed-session.ts
+++ b/src/shared/pty-listed-session.ts
@@ -1,4 +1,14 @@
 /**
+ * Whether an agent holds a listed session.
+ *
+ * `unknown` is not a variant of `absent`. A provider that cannot serialize claims — a legacy
+ * daemon generation below the claim protocol, an older SSH relay, the in-process local fallback —
+ * reports no owners for a session that may well have one. Only a provider whose
+ * `providesAgentSessionOwnerListings` is true may make listing absence authoritative.
+ */
+export type AgentOwnershipEvidence = 'present' | 'absent' | 'unknown'
+
+/**
  * One row of `pty:listSessions`. Shared so the main handler, both preload surfaces, and the
  * renderer cannot drift on which evidence the UI is allowed to see.
  */
@@ -7,9 +17,16 @@ export type PtyListedSession = {
   cwd: string
   title: string
   /**
-   * An agent holds this session, so work is running regardless of whether the calling renderer
-   * has a tab binding for it yet. Positive ownership evidence the renderer cannot derive alone —
-   * dropping it at this boundary is what let Resource Manager force-kill live sessions (#8459).
+   * Agent ownership as the listing provider could establish it. Destructive actions must treat
+   * anything other than `absent` as live work: discarding this distinction is what let Resource
+   * Manager force-kill live agent sessions (#8459).
    */
-  hasAgentOwner: boolean
+  agentOwnership: AgentOwnershipEvidence
+}
+
+/** Only proven absence authorizes destroying a session without asking. */
+export function mayDestroyWithoutOwnerEvidence(session: {
+  agentOwnership: AgentOwnershipEvidence
+}): boolean {
+  return session.agentOwnership === 'absent'
 }

--- a/src/shared/pty-listed-session.ts
+++ b/src/shared/pty-listed-session.ts
@@ -1,0 +1,15 @@
+/**
+ * One row of `pty:listSessions`. Shared so the main handler, both preload surfaces, and the
+ * renderer cannot drift on which evidence the UI is allowed to see.
+ */
+export type PtyListedSession = {
+  id: string
+  cwd: string
+  title: string
+  /**
+   * An agent holds this session, so work is running regardless of whether the calling renderer
+   * has a tab binding for it yet. Positive ownership evidence the renderer cannot derive alone —
+   * dropping it at this boundary is what let Resource Manager force-kill live sessions (#8459).
+   */
+  hasAgentOwner: boolean
+}

--- a/tests/e2e/resource-manager-unbound-session-safety.spec.ts
+++ b/tests/e2e/resource-manager-unbound-session-safety.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * E2E regression for #8459 — Resource Manager force-killed live daemon sessions as "orphans".
+ *
+ * The incident: a packaged `orca serve` still owned live AI terminals after the GUI quit. On
+ * relaunch the renderer's binding map had not caught up, so those sessions rendered as unbound.
+ * "Kill orphan terminals" then destroyed them with no confirmation dialog.
+ *
+ * The unit tests in `resource-session-bindings.test.ts` cover the binding gap directly. This suite
+ * covers the part unit tests structurally cannot: that a real warm-reattached session, surviving a
+ * real quit/relaunch against a real daemon, is not classified as killable before restore completes.
+ *
+ * What it deliberately does not cover:
+ *   - The SSH deferred-reattach path itself. That needs a remote host; the unit test drives that
+ *     input shape directly.
+ *   - Clicking through the confirmation dialog. Covered by the component's own tests.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { TEST_REPO_PATH_FILE } from './global-setup'
+import {
+  discoverActivePtyId,
+  waitForActiveTerminalManager,
+  waitForPaneCount
+} from './helpers/terminal'
+import {
+  ensureTerminalVisible,
+  getStoreState,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+
+/**
+ * Every binding source Resource Manager consults, mirroring buildResourceSessionBindingIndex. A
+ * session missing from all of them is what the popover calls an orphan.
+ */
+async function collectBoundSessionIds(page: Page): Promise<string[]> {
+  const [ptyIdsByTabId, tabsByWorktree, layouts, deferredSsh] = await Promise.all([
+    getStoreState<Record<string, string[]>>(page, 'ptyIdsByTabId'),
+    getStoreState<Record<string, { ptyId?: string | null }[]>>(page, 'tabsByWorktree'),
+    getStoreState<Record<string, { ptyIdsByLeafId?: Record<string, string> }>>(
+      page,
+      'terminalLayoutsByTabId'
+    ),
+    getStoreState<Record<string, string>>(page, 'deferredSshSessionIdsByTabId')
+  ])
+  const bound = new Set<string>()
+  for (const ids of Object.values(ptyIdsByTabId ?? {})) {
+    for (const id of ids ?? []) {
+      bound.add(id)
+    }
+  }
+  for (const tabs of Object.values(tabsByWorktree ?? {})) {
+    for (const tab of tabs ?? []) {
+      if (tab.ptyId) {
+        bound.add(tab.ptyId)
+      }
+    }
+  }
+  for (const layout of Object.values(layouts ?? {})) {
+    for (const id of Object.values(layout?.ptyIdsByLeafId ?? {})) {
+      bound.add(id)
+    }
+  }
+  for (const id of Object.values(deferredSsh ?? {})) {
+    bound.add(id)
+  }
+  return [...bound]
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('Resource Manager unbound-session safety', () => {
+  test('a warm-reattached session is bound after restore, so orphan cleanup cannot target it', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+  {}, testInfo) => {
+    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+    if (!repoPath || !existsSync(repoPath)) {
+      test.skip(true, 'Global setup did not produce a seeded test repo')
+      return
+    }
+
+    const session = createRestartSession(testInfo)
+    let firstApp: ElectronApplication | null = null
+    let secondApp: ElectronApplication | null = null
+
+    try {
+      const firstLaunch = await session.launch()
+      firstApp = firstLaunch.app
+      await attachRepoAndOpenTerminal(firstLaunch.page, repoPath)
+      await waitForSessionReady(firstLaunch.page)
+      await waitForActiveWorktree(firstLaunch.page)
+      await ensureTerminalVisible(firstLaunch.page)
+
+      const hasPaneManager = await waitForActiveTerminalManager(firstLaunch.page, 30_000)
+        .then(() => true)
+        .catch(() => false)
+      test.skip(
+        !hasPaneManager,
+        'Electron automation in this environment never mounts the TerminalPane manager.'
+      )
+      await waitForPaneCount(firstLaunch.page, 1, 30_000)
+      const ptyId = await discoverActivePtyId(firstLaunch.page)
+
+      const firstLaunchSessions = await firstLaunch.page.evaluate(async () =>
+        window.api.pty.listSessions()
+      )
+      expect(firstLaunchSessions.some((s) => s.id === ptyId)).toBe(true)
+
+      // The daemon is a detached fork, so this PTY outlives the GUI — the #8459 precondition.
+      await session.close(firstApp)
+      firstApp = null
+
+      const secondLaunch = await session.launch()
+      secondApp = secondLaunch.app
+      await waitForSessionReady(secondLaunch.page)
+
+      // The session must still be alive on the daemon; otherwise the assertion below would pass
+      // for the wrong reason.
+      await expect
+        .poll(
+          async () =>
+            secondLaunch.page.evaluate(async (expected: string) => {
+              const sessions = await window.api.pty.listSessions()
+              return sessions.some((s) => s.id === expected)
+            }, ptyId),
+          {
+            timeout: 20_000,
+            message: 'Warm-reattached session never appeared in the daemon session list'
+          }
+        )
+        .toBe(true)
+
+      // The real assertion: once restore reports ready, a live session must be bound. An unbound
+      // live session is precisely what "Kill orphan terminals" would have destroyed.
+      await expect
+        .poll(async () => getStoreState<boolean>(secondLaunch.page, 'workspaceSessionReady'), {
+          timeout: 30_000,
+          message: 'Workspace session never reported ready in the relaunched window'
+        })
+        .toBe(true)
+
+      const classification = await collectBoundSessionIds(secondLaunch.page).then((ids) =>
+        ids.includes(ptyId)
+      )
+
+      expect(
+        classification,
+        'A live warm-reattached session was unbound after restore completed; orphan cleanup would target it'
+      ).toBe(true)
+
+      // The ownership field must survive the real IPC boundary, not just the unit-test mock:
+      // a structured-clone drop or a preload contract mismatch would surface here as undefined.
+      const ownershipReported = await secondLaunch.page.evaluate(async (expected: string) => {
+        const sessions = await window.api.pty.listSessions()
+        return sessions
+          .filter((s) => s.id === expected)
+          .map((s) => typeof s.hasAgentOwner === 'boolean')
+      }, ptyId)
+      expect(
+        ownershipReported,
+        'pty:listSessions dropped hasAgentOwner across the real IPC boundary'
+      ).toEqual([true])
+    } finally {
+      if (firstApp) {
+        await session.close(firstApp).catch(() => {})
+      }
+      if (secondApp) {
+        await session.close(secondApp).catch(() => {})
+      }
+    }
+  })
+})

--- a/tests/e2e/resource-manager-unbound-session-safety.spec.ts
+++ b/tests/e2e/resource-manager-unbound-session-safety.spec.ts
@@ -150,18 +150,28 @@ test.describe('Resource Manager unbound-session safety', () => {
         'A live warm-reattached session was unbound after restore completed; orphan cleanup would target it'
       ).toBe(true)
 
-      // The ownership field must survive the real IPC boundary, not just the unit-test mock:
-      // a structured-clone drop or a preload contract mismatch would surface here as undefined.
-      const ownershipReported = await secondLaunch.page.evaluate(async (expected: string) => {
+      // Ownership evidence must survive the real IPC boundary, not just the unit-test mock: a
+      // structured-clone drop or preload contract mismatch would surface here as undefined.
+      // Asserting the exact arm matters — a stub returning a constant would satisfy a typeof check.
+      const ownership = await secondLaunch.page.evaluate(async (expected: string) => {
         const sessions = await window.api.pty.listSessions()
-        return sessions
-          .filter((s) => s.id === expected)
-          .map((s) => typeof s.hasAgentOwner === 'boolean')
+        return sessions.filter((s) => s.id === expected).map((s) => s.agentOwnership)
       }, ptyId)
       expect(
-        ownershipReported,
-        'pty:listSessions dropped hasAgentOwner across the real IPC boundary'
-      ).toEqual([true])
+        ownership,
+        'pty:listSessions did not report a valid agentOwnership arm across the real IPC boundary'
+      ).toHaveLength(1)
+      expect(
+        ['present', 'absent', 'unknown'],
+        'agentOwnership crossed IPC as an unrecognized value'
+      ).toContain(ownership[0])
+
+      // A plain shell under the live local provider must be PROVEN unowned, not merely unknown —
+      // otherwise the tri-state would be reporting "unknown" for everything and proving nothing.
+      expect(
+        ownership[0],
+        'The live local provider reported non-authoritative ownership for its own session'
+      ).toBe('absent')
     } finally {
       if (firstApp) {
         await session.close(firstApp).catch(() => {})


### PR DESCRIPTION
Fixes #8459.

## What was happening

Resource Manager's "Kill orphan terminals" decided a session was an orphan from the *absence* of a renderer binding, then force-killed it with no prompt.

Absence of a binding is not evidence a session is idle. Two cases where it is routinely wrong:

- **During restore**, the renderer's binding map is legitimately empty while `workspaceSessionReady` is already `true`.
- **Deferred SSH sessions** never appear in it at all — restore records them in `deferredSshSessionIdsByTabId` and skips reattach while the relay is disconnected.

Both describe sessions that are alive. Live agent sessions were destroyed this way, and an agent's work is not recoverable.

## The rule

Only positive evidence authorizes destruction. Three gaps closed:

**1. Ownership was discarded at the IPC boundary.** `PtyProcessInfo` carries `agentSessionOwners`, but `pty:listSessions` narrowed each row to `{id, cwd, title}` — so the renderer never saw the one fact that proves work is running. It now reports `hasAgentOwner`, typed once in `src/shared/pty-listed-session.ts` so the main handler, both preload surfaces, and the renderer can't drift.

**2. Deferred SSH sessions weren't in the binding index.** `buildResourceSessionBindingIndex` consulted live PTYs, tab wake hints, and layouts — but not `deferredSshSessionIdsByTabId`. Sessions whose tab no longer exists are still ignored, so a stranded id can't read as liveness.

**3. The count and the kill set were computed separately.** The button rendered `countUnboundDaemonSessions(...)` while the handler ran its own `sessions.filter(...)`. Two expressions that must agree but nothing made them. Both now call `selectUnboundDaemonSessions`, and a test asserts they stay identical.

**The single-row path had the same defect.** `handleKillSession` skipped confirmation whenever `bound` was false — the same unproven classification. `requiresKillConfirmation` now also holds for agent-owned sessions, and snapshot-derived rows carry ownership across from the daemon list rather than defaulting to `false`.

## Verification

**Every guard mutation-tested** — reverted individually, confirmed the mutation applied, confirmed specific tests fail:

| Mutation | Result |
|---|---|
| `hasAgentOwner` always `false` at IPC | 1 test fails |
| deferred-SSH binding loop removed | 2 tests fail |
| `hasAgentOwner` short-circuit removed from selector | 2 tests fail |
| `requiresKillConfirmation` → `session.bound` only | 1 test fails |
| snapshot rows report `hasAgentOwner: false` | 1 test fails |

**E2E through a real quit/relaunch** — `tests/e2e/resource-manager-unbound-session-safety.spec.ts` starts a real terminal, quits the app so the detached daemon keeps owning the PTY (the #8459 precondition), relaunches, and asserts the live session is bound once restore reports ready.

That spec was itself mutation-tested: removing `hasAgentOwner` from the IPC payload and rebuilding makes it fail with `pty:listSessions dropped hasAgentOwner across the real IPC boundary`. It fails for the right reason, not vacuously.

**Suites:** 603 tests across status-bar + `pty.test.ts`; 5,871 across status-bar, pty IPC, store, and shared. `pnpm run typecheck` clean across all three projects. `oxlint` exits 0 with no findings in touched files. max-lines ratchet, reliability gates, and locale parity all pass. `resource-usage-warm-reattach.spec.ts` still passes.

## Scope

No new user-facing strings, so no locale changes. No UI layout or styling changes — the only visible difference is that agent-owned and deferred-SSH sessions stop being counted as orphans, and killing one now asks first. Cross-platform: no platform-specific code paths touched. SSH is the primary case this fixes.