### PR TITLE
perf(main): ignore unchanged worktree sort snapshots

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -551,18 +551,20 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('persistSortOrder only reorders existing worktrees and never mints meta for a stale id', () => {
-    const liveId = 'repo-1::/workspace/repo'
+    const liveIds = ['repo-1::/workspace/repo', 'repo-1::/workspace/feature']
     const staleId = 'removed-repo::/workspace/gone'
-    // Only the live worktree has meta; the stale id (e.g. a removed repo the
+    // Only live worktrees have meta; the stale id (e.g. a removed repo the
     // renderer still lists) has none and must be skipped, not created.
     store.getWorktreeMeta.mockImplementation((id: string) =>
-      id === liveId ? ({ instanceId: 'x' } as never) : undefined
+      liveIds.includes(id) ? ({ instanceId: 'x', sortOrder: 0 } as never) : undefined
     )
 
-    handlers['worktrees:persistSortOrder'](null, { orderedIds: [liveId, staleId] })
+    handlers['worktrees:persistSortOrder'](null, {
+      orderedIds: [liveIds[0], staleId, liveIds[1]]
+    })
 
     const orderedTargets = store.setWorktreeMeta.mock.calls.map((call) => call[0])
-    expect(orderedTargets).toContain(liveId)
+    expect(orderedTargets).toEqual(liveIds)
     expect(orderedTargets).not.toContain(staleId)
   })
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -4,6 +4,7 @@ import { ipcMain } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
+import { persistWorktreeSortOrderSnapshot } from '../worktree-sort-order-snapshot'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { readBranchRenameFailureOutputForDisplay } from '../agent-hooks/branch-rename-failure-output'
 import {
@@ -2094,19 +2095,7 @@ export function registerWorktreeHandlers(
     if (!Array.isArray(args?.orderedIds) || args.orderedIds.length === 0) {
       return
     }
-    const now = Date.now()
-    for (let i = 0; i < args.orderedIds.length; i++) {
-      // Why: a sidebar-order snapshot must only reorder worktrees that already
-      // exist — it must never create one. Without this guard a stale id the
-      // renderer still lists (e.g. a removed repo's `${repoId}::${path}`) gets a
-      // fresh worktreeMeta entry minted here, resurrecting an orphan/duplicate
-      // workspace on the next launch. setWorktreeMeta has no repo-existence check.
-      if (!store.getWorktreeMeta(args.orderedIds[i])) {
-        continue
-      }
-      // Descending timestamps: first item gets highest sortOrder so b - a sorts first-wins on cold start.
-      store.setWorktreeMeta(args.orderedIds[i], { sortOrder: now - i * 1000 })
-    }
+    persistWorktreeSortOrderSnapshot(store, args.orderedIds)
   })
 
   // Why: full failure output lives only in main memory (not worktree metadata), so the dialog pulls it on demand.

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/agent-detection'
 import { extractOscTitleScanTail } from '../../shared/osc-title-scan-tail'
 import { extractLastOsc7Uri, extractOscScanTail } from '../daemon/osc7-uri-extraction'
+import { persistWorktreeSortOrderSnapshot } from '../worktree-sort-order-snapshot'
 import { parseFileUriPathParts } from '../daemon/osc7-file-uri'
 import type { AgentStatus } from '../../shared/agent-detection'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
@@ -20232,17 +20233,9 @@ export class OrcaRuntimeService {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
-    const now = Date.now()
-    let updated = 0
-    for (let i = 0; i < orderedIds.length; i++) {
-      // Why: a sort-order snapshot must only reorder existing worktrees, never
-      // mint new meta — a stale id would otherwise resurrect an orphan workspace
-      // (setWorktreeMeta has no repo-existence check).
-      if (!this.store.getWorktreeMeta(orderedIds[i])) {
-        continue
-      }
-      this.store.setWorktreeMeta(orderedIds[i], { sortOrder: now - i * 1000 })
-      updated++
+    const updated = persistWorktreeSortOrderSnapshot(this.store, orderedIds)
+    if (updated === 0) {
+      return { updated }
     }
     this.invalidateResolvedWorktreeCache()
     this.notifyReposChanged()

--- a/src/main/worktree-sort-order-snapshot.test.ts
+++ b/src/main/worktree-sort-order-snapshot.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { persistWorktreeSortOrderSnapshot } from './worktree-sort-order-snapshot'
+
+function createStore(sortOrders: Record<string, number | undefined>) {
+  return {
+    getWorktreeMeta: vi.fn((id: string) =>
+      Object.hasOwn(sortOrders, id) ? { sortOrder: sortOrders[id] } : undefined
+    ),
+    setWorktreeMeta: vi.fn()
+  }
+}
+
+describe('persistWorktreeSortOrderSnapshot', () => {
+  it('skips writes when the persisted relative order already matches', () => {
+    const store = createStore({ first: 3_000, second: 2_000, third: 1_000 })
+
+    expect(persistWorktreeSortOrderSnapshot(store, ['first', 'second', 'third'], 10_000)).toBe(0)
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('writes a new strictly ordered snapshot when the relative order changes', () => {
+    const store = createStore({ first: 1_000, second: 2_000, third: 3_000 })
+
+    expect(persistWorktreeSortOrderSnapshot(store, ['first', 'second', 'third'], 10_000)).toBe(3)
+    expect(store.setWorktreeMeta.mock.calls).toEqual([
+      ['first', { sortOrder: 10_000 }],
+      ['second', { sortOrder: 9_000 }],
+      ['third', { sortOrder: 8_000 }]
+    ])
+  })
+
+  it('writes tied legacy values once so the requested order is durable', () => {
+    const store = createStore({ first: 0, second: 0 })
+
+    expect(persistWorktreeSortOrderSnapshot(store, ['first', 'second'], 10_000)).toBe(2)
+  })
+
+  it('ignores stale ids without creating metadata', () => {
+    const store = createStore({ first: 2_000, second: 1_000 })
+
+    expect(persistWorktreeSortOrderSnapshot(store, ['first', 'stale', 'second'], 10_000)).toBe(0)
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/worktree-sort-order-snapshot.ts
+++ b/src/main/worktree-sort-order-snapshot.ts
@@ -1,0 +1,36 @@
+type WorktreeSortOrderStore = {
+  getWorktreeMeta: (worktreeId: string) => { sortOrder?: number } | undefined
+  setWorktreeMeta: (worktreeId: string, updates: { sortOrder: number }) => unknown
+}
+
+type PersistedSortOrderEntry = {
+  id: string
+  sortOrder: number | undefined
+}
+
+function alreadyPersistsOrder(entries: readonly PersistedSortOrderEntry[]): boolean {
+  if (entries.length < 2) {
+    return true
+  }
+  return entries.every(
+    (entry, index) => index === 0 || entries[index - 1]!.sortOrder! > entry.sortOrder!
+  )
+}
+
+export function persistWorktreeSortOrderSnapshot(
+  store: WorktreeSortOrderStore,
+  orderedIds: readonly string[],
+  now = Date.now()
+): number {
+  const entries = orderedIds.flatMap((id): PersistedSortOrderEntry[] => {
+    const meta = store.getWorktreeMeta(id)
+    return meta ? [{ id, sortOrder: meta.sortOrder }] : []
+  })
+  if (alreadyPersistsOrder(entries)) {
+    return 0
+  }
+  for (let index = 0; index < entries.length; index++) {
+    store.setWorktreeMeta(entries[index]!.id, { sortOrder: now - index * 1000 })
+  }
+  return entries.length
+}


### PR DESCRIPTION
## Summary

- skip worktree sort-order writes when the persisted relative order already matches the requested snapshot
- share the same idempotent snapshot logic between desktop IPC and managed runtime RPC
- avoid runtime cache invalidation and `reposChanged` broadcasts for no-op snapshots
- preserve stale-worktree filtering and normalize tied legacy values once

## Why

Smart-sort snapshots can be submitted repeatedly, including by another or older connected client. Previously every request rewrote every worktree's `sortOrder`; the runtime path then invalidated caches and broadcast `reposChanged`, even though the visible order had not changed.

On Windows this appeared as a brief whole-renderer stall during unrelated interactions such as Chinese IME composition, scrolling, and terminal text selection. During reproduction, all persisted sort timestamps advanced together every 5–11 seconds while their relative order stayed unchanged. After enforcing idempotency at the authoritative persistence boundary, a 55-second live check showed an identical sort-order snapshot and the stalls stopped.



## Tests

- `pnpm exec vitest run src/main/worktree-sort-order-snapshot.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.test.ts` (1092 passed)
- `pnpm run typecheck`
- `pnpm exec oxlint src/main/worktree-sort-order-snapshot.ts src/main/worktree-sort-order-snapshot.test.ts src/main/ipc/worktrees.ts src/main/ipc/worktrees.test.ts src/main/runtime/orca-runtime.ts`
