### PR TITLE
fix(terminal): restore link hover after mouseleave

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -145,6 +145,7 @@ export function createPaneDOM(
     compositionHandler: null,
     focusClassSyncCleanup: null,
     terminalScrollIntentDisposable: null,
+    linkifierMouseLeaveResetDisposable: null,
     arabicShapingJoinerCleanup: null,
     pendingSplitScrollState: null,
     pendingSplitScrollRafIds: [],

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -623,6 +623,19 @@ describe('openTerminal — addon and provider wiring', () => {
     expect(pane.linkifierHoverResetDisposable).toBeNull()
   })
 
+  it('installs the mouseleave linkifier hover reset and disposes it', () => {
+    const { pane } = createOpenTerminalHarness()
+
+    openTerminal(pane)
+    const disposable = pane.linkifierMouseLeaveResetDisposable
+    expect(disposable?.dispose).toBeTypeOf('function')
+
+    const disposeSpy = vi.spyOn(disposable!, 'dispose')
+    disposePane(pane, new Map([[pane.id, pane]]))
+    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(pane.linkifierMouseLeaveResetDisposable).toBeNull()
+  })
+
   // Why: the DOM renderer misrenders joined spans (per-character
   // letter-spacing blowout), so the joiner must only join while this pane's
   // WebGL addon is live — locked here against the real openTerminal wiring.

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -637,7 +637,10 @@ describe('openTerminal — addon and provider wiring', () => {
     const disposable = pane.linkifierMouseLeaveResetDisposable
     expect(disposable?.dispose).toBeTypeOf('function')
     expect(addEventListener).toHaveBeenCalledWith('mouseleave', expect.any(Function))
-    const mouseLeaveHandler = addEventListener.mock.calls[0][1]
+    const mouseLeaveHandler = addEventListener.mock.calls.find(
+      ([eventName]) => eventName === 'mouseleave'
+    )?.[1]
+    expect(mouseLeaveHandler).toBeTypeOf('function')
 
     disposePane(pane, new Map([[pane.id, pane]]))
     expect(removeEventListener).toHaveBeenCalledWith('mouseleave', mouseLeaveHandler)

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -625,14 +625,22 @@ describe('openTerminal — addon and provider wiring', () => {
 
   it('installs the mouseleave linkifier hover reset and disposes it', () => {
     const { pane } = createOpenTerminalHarness()
+    const addEventListener = vi.fn()
+    const removeEventListener = vi.fn()
+    const screen = {
+      addEventListener,
+      removeEventListener
+    } as unknown as HTMLElement
+    vi.mocked(pane.terminal.element!.querySelector).mockReturnValueOnce(screen)
 
     openTerminal(pane)
     const disposable = pane.linkifierMouseLeaveResetDisposable
     expect(disposable?.dispose).toBeTypeOf('function')
+    expect(addEventListener).toHaveBeenCalledWith('mouseleave', expect.any(Function))
+    const mouseLeaveHandler = addEventListener.mock.calls[0][1]
 
-    const disposeSpy = vi.spyOn(disposable!, 'dispose')
     disposePane(pane, new Map([[pane.id, pane]]))
-    expect(disposeSpy).toHaveBeenCalledTimes(1)
+    expect(removeEventListener).toHaveBeenCalledWith('mouseleave', mouseLeaveHandler)
     expect(pane.linkifierMouseLeaveResetDisposable).toBeNull()
   })
 

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -9,6 +9,7 @@ import { cancelDeferredScrollRestore } from './pane-scroll'
 import { activateOrcaTerminalUnicodeProvider } from '../../../../shared/terminal-unicode-provider'
 import { attachTerminalMouseWheelMultiplier } from './pane-terminal-mouse-wheel'
 import { attachTerminalScrollIntentTracking } from './terminal-scroll-intent-dom-tracking'
+import { installTerminalLinkifierHoverResetOnMouseLeave } from './terminal-linkifier-hover-reset-on-mouseleave'
 import { installTerminalLinkifierHoverResetOnWrite } from './terminal-linkifier-hover-reset-on-write'
 import { attachDomRendererFocusClassSync } from './pane-dom-focus-class-sync'
 import { attachWebgl, cancelPendingWebglRefresh, disposeWebgl } from './pane-webgl-renderer'
@@ -62,6 +63,7 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   // line; invalidate the linkifier hover cache when output lands so the next
   // pointer move re-linkifies it.
   pane.linkifierHoverResetDisposable = installTerminalLinkifierHoverResetOnWrite(terminal)
+  pane.linkifierMouseLeaveResetDisposable = installTerminalLinkifierHoverResetOnMouseLeave(terminal)
 
   // Activate Orca's Unicode 11 width shim *before* any caller-driven write. CJK / emoji /
   // ZWJ codepoints get baked into the buffer at the active unicode version on
@@ -236,6 +238,8 @@ export function disposePane(
   pane.terminalScrollIntentDisposable = null
   pane.linkifierHoverResetDisposable?.dispose()
   pane.linkifierHoverResetDisposable = null
+  pane.linkifierMouseLeaveResetDisposable?.dispose()
+  pane.linkifierMouseLeaveResetDisposable = null
   // Deregister the RTL shaping joiner: terminal.dispose() below does not.
   try {
     pane.arabicShapingJoinerCleanup?.()

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -169,6 +169,8 @@ export type ManagedPaneInternal = {
   // Stored so disposePane() can detach the streamed-output hover-cache reset
   // that keeps freshly printed links linkifiable without a scroll.
   linkifierHoverResetDisposable?: IDisposable | null
+  // Stored because mouseleave does not bubble from xterm's screen.
+  linkifierMouseLeaveResetDisposable?: IDisposable | null
   // Stored so disposePane() can deregister the joiner; terminal.dispose()
   // does not remove registered character joiners.
   arabicShapingJoinerCleanup?: (() => void) | null

--- a/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.test.ts
@@ -1,0 +1,78 @@
+import type { Terminal } from '@xterm/xterm'
+import { describe, expect, it, vi } from 'vitest'
+import { installTerminalLinkifierHoverResetOnMouseLeave } from './terminal-linkifier-hover-reset-on-mouseleave'
+
+type FakeLinkifier = { _lastBufferCell?: unknown; _activeLine?: number }
+
+function createHarness(hasScreen = true): {
+  terminal: Terminal
+  linkifier: FakeLinkifier
+  dispatchMouseLeave: () => void
+} {
+  let mouseLeaveHandler: (() => void) | null = null
+  const screen = {
+    addEventListener: vi.fn((_event: string, handler: () => void) => {
+      mouseLeaveHandler = handler
+    }),
+    removeEventListener: vi.fn((_event: string, handler: () => void) => {
+      if (mouseLeaveHandler === handler) {
+        mouseLeaveHandler = null
+      }
+    })
+  }
+  const linkifier: FakeLinkifier = {
+    _lastBufferCell: { x: 2, y: 3 },
+    _activeLine: 3
+  }
+  const terminal = {
+    element: {
+      querySelector: vi.fn(() => (hasScreen ? screen : null))
+    },
+    _core: { linkifier }
+  } as unknown as Terminal
+  return {
+    terminal,
+    linkifier,
+    dispatchMouseLeave: () => mouseLeaveHandler?.()
+  }
+}
+
+describe('installTerminalLinkifierHoverResetOnMouseLeave', () => {
+  it('resets the hover cache when the terminal surface loses the pointer', () => {
+    const harness = createHarness()
+    installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal)
+
+    harness.dispatchMouseLeave()
+
+    expect(harness.linkifier._lastBufferCell).toBeUndefined()
+    expect(harness.linkifier._activeLine).toBe(-1)
+  })
+
+  it('removes the listener on dispose', () => {
+    const harness = createHarness()
+    const disposable = installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal)
+
+    disposable.dispose()
+    harness.dispatchMouseLeave()
+
+    expect(harness.linkifier._lastBufferCell).toEqual({ x: 2, y: 3 })
+    expect(harness.linkifier._activeLine).toBe(3)
+  })
+
+  it('degrades to a no-op when the screen is unavailable', () => {
+    const harness = createHarness(false)
+
+    expect(() =>
+      installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal).dispose()
+    ).not.toThrow()
+  })
+
+  it('does not throw when xterm linkifier internals are unavailable', () => {
+    const harness = createHarness()
+    const terminal = harness.terminal as unknown as { _core?: unknown }
+    terminal._core = undefined
+    installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal)
+
+    expect(harness.dispatchMouseLeave).not.toThrow()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.test.ts
@@ -4,35 +4,32 @@ import { installTerminalLinkifierHoverResetOnMouseLeave } from './terminal-linki
 
 type FakeLinkifier = { _lastBufferCell?: unknown; _activeLine?: number }
 
-function createHarness(hasScreen = true): {
-  terminal: Terminal
-  linkifier: FakeLinkifier
-  dispatchMouseLeave: () => void
-} {
+function createHarness(hasScreen = true) {
   let mouseLeaveHandler: (() => void) | null = null
-  const screen = {
-    addEventListener: vi.fn((_event: string, handler: () => void) => {
-      mouseLeaveHandler = handler
-    }),
-    removeEventListener: vi.fn((_event: string, handler: () => void) => {
-      if (mouseLeaveHandler === handler) {
-        mouseLeaveHandler = null
-      }
-    })
-  }
+  const addEventListener = vi.fn((_event: string, handler: () => void) => {
+    mouseLeaveHandler = handler
+  })
+  const removeEventListener = vi.fn((_event: string, handler: () => void) => {
+    if (mouseLeaveHandler === handler) {
+      mouseLeaveHandler = null
+    }
+  })
+  const screen = { addEventListener, removeEventListener }
+  const querySelector = vi.fn(() => (hasScreen ? screen : null))
   const linkifier: FakeLinkifier = {
     _lastBufferCell: { x: 2, y: 3 },
     _activeLine: 3
   }
   const terminal = {
-    element: {
-      querySelector: vi.fn(() => (hasScreen ? screen : null))
-    },
+    element: { querySelector },
     _core: { linkifier }
   } as unknown as Terminal
   return {
     terminal,
     linkifier,
+    querySelector,
+    addEventListener,
+    removeEventListener,
     dispatchMouseLeave: () => mouseLeaveHandler?.()
   }
 }
@@ -42,6 +39,8 @@ describe('installTerminalLinkifierHoverResetOnMouseLeave', () => {
     const harness = createHarness()
     installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal)
 
+    expect(harness.querySelector).toHaveBeenCalledWith('.xterm-screen')
+    expect(harness.addEventListener).toHaveBeenCalledWith('mouseleave', expect.any(Function))
     harness.dispatchMouseLeave()
 
     expect(harness.linkifier._lastBufferCell).toBeUndefined()
@@ -51,8 +50,13 @@ describe('installTerminalLinkifierHoverResetOnMouseLeave', () => {
   it('removes the listener on dispose', () => {
     const harness = createHarness()
     const disposable = installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal)
+    const mouseLeaveHandler = harness.addEventListener.mock.calls.find(
+      ([eventName]) => eventName === 'mouseleave'
+    )?.[1]
+    expect(mouseLeaveHandler).toBeTypeOf('function')
 
     disposable.dispose()
+    expect(harness.removeEventListener).toHaveBeenCalledWith('mouseleave', mouseLeaveHandler)
     harness.dispatchMouseLeave()
 
     expect(harness.linkifier._lastBufferCell).toEqual({ x: 2, y: 3 })

--- a/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.ts
@@ -1,0 +1,16 @@
+import type { IDisposable, Terminal } from '@xterm/xterm'
+import { resetTerminalLinkifierHoverState } from './terminal-linkifier-hover-reset'
+
+export function installTerminalLinkifierHoverResetOnMouseLeave(terminal: Terminal): IDisposable {
+  const screen = terminal.element?.querySelector<HTMLElement>('.xterm-screen')
+  if (!screen) {
+    return { dispose: () => undefined }
+  }
+
+  const resetHover = (): void => resetTerminalLinkifierHoverState(terminal)
+  // Why: xterm clears its active link but keeps the cell cache on mouseleave.
+  screen.addEventListener('mouseleave', resetHover)
+  return {
+    dispose: () => screen.removeEventListener('mouseleave', resetHover)
+  }
+}

--- a/tests/e2e/terminal-link-hover-after-worktree-return.spec.ts
+++ b/tests/e2e/terminal-link-hover-after-worktree-return.spec.ts
@@ -98,14 +98,21 @@ async function hoverAndReadActiveLinkText(page: Page, probe: HoverProbe): Promis
       new MouseEvent('mousemove', { bubbles: true, cancelable: true, clientX, clientY })
     )
   }, probe)
-  return page.evaluate(({ tabId }) => {
-    const manager = window.__paneManagers?.get(tabId)
-    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
-    const core = pane?.terminal as unknown as
-      | { _core?: { linkifier?: { currentLink?: { link?: { text?: string } } } } }
-      | undefined
-    return core?._core?.linkifier?.currentLink?.link?.text ?? null
-  }, probe)
+  return readActiveLinkText(page, probe.tabId)
+}
+
+async function readActiveLinkText(page: Page, tabId: string): Promise<string | null> {
+  return page.evaluate(
+    ({ tabId }) => {
+      const manager = window.__paneManagers?.get(tabId)
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      const core = pane?.terminal as unknown as
+        | { _core?: { linkifier?: { currentLink?: { link?: { text?: string } } } } }
+        | undefined
+      return core?._core?.linkifier?.currentLink?.link?.text ?? null
+    },
+    { tabId }
+  )
 }
 
 async function readTerminalCursor(page: Page, tabId: string): Promise<string | null> {
@@ -239,6 +246,47 @@ async function assertLinkRecoversAfterReturn(
 test.describe('Terminal link hover after worktree return', () => {
   test.beforeEach(async ({ orcaPage }) => {
     await waitForSessionReady(orcaPage)
+  })
+
+  test('re-establishes a URL link on hover after the pointer leaves the terminal', async ({
+    orcaPage
+  }) => {
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    await waitForPtyShellEcho(orcaPage, ptyId, 15_000)
+
+    const url = `https://example.com/orca-link-${randomUUID()}`
+    await sendToTerminal(orcaPage, ptyId, `echo ${url}\r`)
+    await expect
+      .poll(() => getTerminalContent(orcaPage, 4000), {
+        timeout: 10_000,
+        message: 'URL fixture did not reach the terminal buffer'
+      })
+      .toContain(url)
+
+    // Let the streamed-output reset finish before creating the hover cache
+    // state this mouseleave regression targets.
+    await orcaPage.waitForTimeout(300)
+    const probe = await locateHoverProbe(orcaPage, url)
+    await expect
+      .poll(() => hoverAndReadActiveLinkText(orcaPage, probe), {
+        timeout: 5_000,
+        message: 'baseline hover never established the URL link'
+      })
+      .toContain(url)
+
+    await dispatchScreenMouseLeave(orcaPage, probe.tabId)
+    await expect.poll(() => readActiveLinkText(orcaPage, probe.tabId)).toBeNull()
+    await expect.poll(() => readTerminalCursor(orcaPage, probe.tabId)).not.toBe('pointer')
+
+    await expect
+      .poll(() => hoverAndReadActiveLinkText(orcaPage, probe), {
+        timeout: 5_000,
+        message: 'URL link did not re-establish after terminal mouseleave'
+      })
+      .toContain(url)
+    await expect.poll(() => readTerminalCursor(orcaPage, probe.tabId)).toBe('pointer')
   })
 
   test('re-establishes a file-path link on hover after switching worktrees and back', async ({


### PR DESCRIPTION
## Summary

- Reproduces the intermittent Claude Code case where a colored URL remains non-clickable after the pointer leaves and returns to the same terminal cell.
- Resets xterm's stale linkifier hover cache on the non-bubbling terminal-screen `mouseleave` event and disposes the listener with its pane.
- Adds focused unit coverage plus URL and file-path E2E regressions.

## Screenshots

After the pointer leaves the terminal and returns to the same Claude Code URL cell, the URL hover strip and pointer affordance now recover immediately without clicking, selecting, scrolling, or changing worktrees.

![issue-001-fixed-first-hover.png](https://github.com/user-attachments/assets/f07f675f-0e85-4135-a784-2f4d2cd9e32a)

## Testing

- [ ] `pnpm lint` (targeted Oxlint and formatting checks passed)
- [ ] `pnpm typecheck` (`pnpm run typecheck:web` passed)
- [ ] `pnpm test` (63 focused tests passed)
- [ ] `pnpm build` (E2E-mode Electron build passed)
- [x] Added or updated high-quality tests that would catch regressions

Focused verification:

- `pnpm exec vitest run src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.test.ts src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset.test.ts src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-write.test.ts src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts --config config/vitest.config.ts` — 63 passed
- `pnpm run typecheck:web`
- `pnpm run check:max-lines-ratchet`
- `pnpm exec electron-vite build --mode e2e --logLevel error`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/terminal-link-hover-after-worktree-return.spec.ts --reporter=line` — 3 passed
- Manual Electron verification against Claude Code output confirmed first-hover recovery after leaving and returning to the same URL cell.

## Performance Audit

The handler is an O(1) pair of terminal-local cache assignments and runs only on `.xterm-screen` `mouseleave`, not terminal output, typing, render, resize, polling, or visibility hot paths. A local stress measurement completed 1,000,000 handler calls in 2.3 ms and 100,000 install/dispose pairs in 29.4 ms; every one of 100,001 installed listeners was removed and zero listeners remained. The lifecycle regression now asserts the exact listener added during `openTerminal` is removed by `disposePane`.

## AI Review Report

No findings remained. The review traced listener ownership from terminal creation through pane disposal, verified no-op behavior when the xterm screen or private linkifier fields are unavailable, checked synchronous stale-state recovery and event ordering, and confirmed the E2E test targets the same cell without a visibility transition or scroll. A review nit that the lifecycle test initially exercised a no-op disposable was fixed by supplying a real screen-capable harness and asserting the exact add/remove listener pairing. Cross-platform review found no macOS-, Linux-, Windows-, WSL-, SSH-, or folder-workspace-specific assumptions: the change is renderer-local DOM behavior and introduces no shortcuts, labels, filesystem paths, shell commands, or provider-specific logic.

## Security Audit

No new IPC, network, authentication, secret, command-execution, filesystem-path, dependency, or untrusted-input surface is introduced. The handler only invalidates terminal-local xterm hover-cache fields, those private accesses remain guarded, and the DOM listener is explicitly removed during pane disposal.

## Notes

The reset continues to rely on guarded xterm linkifier internals because xterm exposes no public hover-cache invalidation API. If those fields change in a future xterm release, the behavior safely degrades to the prior cell-change recovery path rather than throwing.
