### PR TITLE
fix(git-history): stop reading the option marker as the resolved ref name

### DIFF
--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -201,4 +201,16 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
       expect(supports(2, 31)).toBe(false)
     }
   })
+
+  // Why pin this: --verify swallows --end-of-options but --symbolic-full-name echoes
+  // it deliberately, on every version tested (2.25 through 2.49). git-history.ts skips
+  // that line; if a future git stopped emitting it, the skip stays correct, but if this
+  // assertion ever flips the reason for the skip is worth re-reading.
+  it('echoes the option marker from rev-parse --symbolic-full-name', async () => {
+    const result = await runGit(['rev-parse', '--symbolic-full-name', '--end-of-options', 'HEAD'])
+    const lines = result.stdout.trim().split(/\r?\n/).filter(Boolean)
+
+    expect(lines[0]).toBe('--end-of-options')
+    expect(lines.find((line) => line !== '--end-of-options')).toMatch(/^refs\//)
+  })
 })

--- a/src/shared/git-history.test.ts
+++ b/src/shared/git-history.test.ts
@@ -263,3 +263,65 @@ describe('git history loader', () => {
     expect(executor).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('symbolic full-name resolution', () => {
+  // Why: `rev-parse --verify` swallows --end-of-options, but --symbolic-full-name
+  // deliberately echoes it. Taking the first line made every branch and tag fall
+  // through gitHistoryRefFromFullName's prefix checks into the "commits" category.
+  function executorEmitting(symbolicStdout: string): GitHistoryExecutor {
+    return vi.fn(async (args: string[]) => {
+      if (args[0] === 'rev-parse' && args.includes('--symbolic-full-name')) {
+        return { stdout: symbolicStdout }
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: `${HEAD_OID}\n` }
+      }
+      if (args[0] === 'symbolic-ref') {
+        return { stdout: 'main\n' }
+      }
+      if (args[0] === 'for-each-ref' || args[0] === 'merge-base') {
+        return { stdout: '' }
+      }
+      if (args[0] === 'log') {
+        return { stdout: logRecord({ hash: HEAD_OID, message: 'only' }) }
+      }
+      return { stdout: '' }
+    }) as unknown as GitHistoryExecutor
+  }
+
+  it('categorizes a branch when git echoes the option marker', async () => {
+    const executor = executorEmitting('--end-of-options\nrefs/heads/feature\n')
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', { baseRef: 'feature' })
+
+    expect(result.baseRef).toMatchObject({
+      id: 'refs/heads/feature',
+      name: 'feature',
+      category: 'branches'
+    })
+  })
+
+  it('categorizes a tag when git echoes the option marker', async () => {
+    const executor = executorEmitting('--end-of-options\nrefs/tags/v1.0.0\n')
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', { baseRef: 'v1.0.0' })
+
+    expect(result.baseRef).toMatchObject({ id: 'refs/tags/v1.0.0', category: 'tags' })
+  })
+
+  it('still resolves when git does not echo the marker', async () => {
+    const executor = executorEmitting('refs/heads/feature\n')
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', { baseRef: 'feature' })
+
+    expect(result.baseRef).toMatchObject({ id: 'refs/heads/feature', category: 'branches' })
+  })
+
+  it('falls back to the commits category for a bare revision', async () => {
+    const executor = executorEmitting('--end-of-options\n')
+
+    const result = await loadGitHistoryFromExecutor(executor, '/repo', { baseRef: 'some-rev' })
+
+    expect(result.baseRef).toMatchObject({ category: 'commits' })
+  })
+})

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -76,7 +76,16 @@ async function resolveSymbolicFullName(
       ['rev-parse', '--symbolic-full-name', '--end-of-options', ref],
       cwd
     )
-    return stdout.trim().split(/\r?\n/).find(Boolean) ?? null
+    // Why skip the marker: --verify swallows --end-of-options, but
+    // --symbolic-full-name deliberately echoes it, so the first line is the marker
+    // rather than the ref. Taking it made every branch and tag fall through
+    // gitHistoryRefFromFullName's prefix checks into the "commits" category.
+    return (
+      stdout
+        .trim()
+        .split(/\r?\n/)
+        .find((line) => line && line !== '--end-of-options') ?? null
+    )
   } catch {
     return null
   }


### PR DESCRIPTION
## Description

`git rev-parse --verify` swallows `--end-of-options`, but `--symbolic-full-name` **deliberately echoes it**. From the commit that added the flag to `rev-parse` (Jeff King, `3a1f91cfd9`): *"We'll leave `--end-of-options` in the output."*

```
$ git rev-parse --symbolic-full-name --end-of-options feature
--end-of-options
refs/heads/feature
```

`resolveSymbolicFullName` took the first non-empty line — so it returned the literal string `"--end-of-options"` instead of the ref. That value flows into `gitHistoryRefFromFullName`, matches none of the `refs/heads/`, `refs/remotes/`, or `refs/tags/` prefixes, and falls through to the catch-all: **every named branch and tag in git history was silently categorized as a plain commit, with `"--end-of-options"` as its id.**

This is version-independent — reproduced on 2.25.1, 2.38.1, 2.44.0, and 2.49.1. No test covered it.

## ELI5

When asking git "what's the full name of this branch?", the app passed a safety marker meaning *"everything after this is a ref name, not an option."*

For this particular question, git politely repeats the marker back before the answer. The app read the first line it got — the marker — and used *that* as the branch name. So every branch and tag showed up in history as an anonymous commit.

## How this was found

Not by looking for it. A reviewer on [#10895](https://github.com/stablyai/orca/pull/10895) flagged `--end-of-options` as requiring Git 2.30 and therefore breaking the repo's Git 2.25 baseline. Verifying that claim turned up something different in both directions:

- **The 2.30 version number is correct** — `rev-parse` has its own argument loop and didn't get the flag until `3a1f91cfd9` (v2.30.0), separately from the general parse-options support in v2.24.0 that covers `git show` / `log` / `rev-list`.
- **The stated consequence is wrong.** `git rev-parse` silently ignores unrecognized `--`-prefixed arguments, so on 2.25 the flag is *inert*, not an error. Verified empirically against real binaries (Ubuntu 20.04 → git 2.25.1, alpine 2.24.4 / 2.26.3 / 2.30.6, 2.38.1, 2.49.1): `rev-parse --verify --end-of-options HEAD` exits 0 and prints the OID on every one. There is no unsupported-option failure to catch and no `GitCapabilityCache` fallback warranted.

So there was **no latent baseline bug of the kind described** — but chasing it down surfaced this real one, which is worse: it's silent, and it affects current git too.

Also worth stating plainly: `--end-of-options` on `rev-parse` is a **no-op on 2.25–2.29**. It's accepted and ignored, so it provides no protection there. That's pre-existing on `main` and out of scope here; every such call site either pre-validates its input (`assertFullGitObjectId`, or `ref.startsWith('-')` guards) or catches, so it's harmless — but it's not doing the job its presence implies.

## Proof of zero regression

- **4 new tests** in `git-history.test.ts` covering a branch, a tag, the no-marker case (in case a future git stops echoing), and the bare-revision fallback.
- **The tests fail on the unfixed code**: reverting to `.find(Boolean)` gives `2 failed | 8 passed`. They pass on the fix. A test that doesn't fail on the bug it describes isn't evidence.
- **1 new assertion in the real-binary compatibility suite** pinning git's echo behaviour directly, so the reason for the skip gets re-read rather than quietly rotting if git ever changes. Verified locally: `ORCA_GIT_COMPAT_BINARY=$(which git) ORCA_GIT_COMPAT_VERSION=2.44.0` → **5 tests pass**. CI runs this against real 2.25.5, 2.38.1, and newer.
- `src/shared/git-history*`: **3 files, 23 tests** passing. `pnpm typecheck` clean.

The fix is a one-line filter — skip the marker line rather than removing the flag, since removing it would silently change what the other version-dependent behaviour does.

## Review loop count + verdict

2 loops. Round 1 established the actual version boundary and disproved the reported failure mode before touching anything. Round 2 confirmed the new tests actually fail on the old code, after the first draft asserted against the wrong result field and passed vacuously.

**Verdict: ship.** This is a correctness fix rather than a perf change; the behaviour is pinned both against a mocked executor and against a real git binary.

Made with [Orca](https://github.com/stablyai/orca) 🐋
