### PR TITLE
fix(renderer): clear terminal overlay when editor becomes active

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.test.ts
@@ -48,6 +48,17 @@ describe('useColdParkedTerminalPresentation', () => {
     expect(presentedTargetId(hook.result)).toBe('b')
   })
 
+  it('clears the terminal presentation when an editor becomes active', () => {
+    const hook = renderPresentationHook({
+      desiredTargetId: 'a',
+      coldParkedTargetIds: new Set()
+    })
+
+    hook.rerender({ desiredTargetId: null, coldParkedTargetIds: new Set() })
+
+    expect(presentedTargetId(hook.result)).toBeNull()
+  })
+
   it('retains the prior target until a cold target settles', () => {
     const hook = renderPresentationHook({
       desiredTargetId: 'a',

--- a/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.ts
+++ b/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.ts
@@ -56,7 +56,7 @@ export function resolveColdParkedPresentation(
       presentedTargetId: null,
       pendingTargetId: null
     }
-    if (entry.pendingTargetId === desiredTargetId) {
+    if (entry.pendingTargetId !== null && entry.pendingTargetId === desiredTargetId) {
       next.set(scopeId, entry)
       continue
     }


### PR DESCRIPTION
## Summary

- clear a previously presented terminal when a tab group switches to an editor
- retain the fast path only while a non-null cold terminal target is pending
- add a regression test for the terminal-to-editor transition

## Root cause

The cold-parked presentation fast path treated `pendingTargetId === desiredTargetId` as settled. When an editor became active, both values were `null` while `presentedTargetId` still referenced the terminal, so the terminal overlay remained visible above the editor.

This is a regression in the presentation state introduced with #10871.

## Test plan

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.test.ts`
- 5 tests passed