### PR TITLE
perf(terminal): measure stream byte length natively above a code-unit floor

### DIFF
--- a/config/scripts/terminal-stream-byte-length-benchmark.mjs
+++ b/config/scripts/terminal-stream-byte-length-benchmark.mjs
@@ -1,11 +1,36 @@
 #!/usr/bin/env node
-// Mirrors the production terminal byte-measurement paths at their real budgets: the output
-// batcher push and the snapshot budget scan. Every scenario
-// asserts which BRANCH of the new arm ran, so a fixture cannot silently stop testing anything.
+// Benchmarks the production terminal byte-measurement exports at their real budgets: the output
+// batcher push and the snapshot budget scan. Every scenario asserts whether production invoked
+// Buffer.byteLength, so implementation drift cannot preserve stale speedup claims.
+import { spawnSync } from 'node:child_process'
 import { performance } from 'node:perf_hooks'
 import fs from 'node:fs'
+import nodeModule from 'node:module'
 import path from 'node:path'
 import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+if (!process.execArgv.includes('--experimental-transform-types')) {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-transform-types', '--no-warnings', import.meta.filename],
+    { stdio: 'inherit' }
+  )
+  process.exit(result.status ?? 1)
+}
+
+// The app's TS sources import siblings without an extension; Node's ESM resolver needs it.
+nodeModule.registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('.') && !/\.[cm]?[jt]s$/.test(specifier) && context.parentURL) {
+      const candidate = new URL(`${specifier}.ts`, context.parentURL)
+      if (fs.existsSync(fileURLToPath(candidate))) {
+        return { url: candidate.href, shortCircuit: true }
+      }
+    }
+    return nextResolve(specifier, context)
+  }
+})
 
 const ROOT = path.resolve(import.meta.dirname, '../..')
 const ITERATIONS = Number(process.env.ORCA_BYTE_LENGTH_BENCH_ITERATIONS ?? '61')
@@ -20,24 +45,7 @@ function readSource(relative) {
   return fs.readFileSync(path.join(ROOT, relative), 'utf8')
 }
 
-// Re-read the production constants and CALL FORMS so this benchmark fails loudly if the
-// code it claims to mirror drifts. Matching call shapes, not bare words.
-const FLOW_CONTROL_SOURCE = readSource('src/shared/terminal-multiplex-flow-control.ts')
 const TERMINAL_SOURCE = readSource('src/main/runtime/rpc/methods/terminal.ts')
-const BYTE_LENGTH_SOURCE = readSource('src/main/runtime/rpc/terminal-stream-byte-length.ts')
-const CLIPBOARD_SOURCE = readSource('src/shared/clipboard-text.ts')
-
-function requireConstant(source, name, label) {
-  const match = new RegExp(`export const ${name} = ([^\\n]+)`).exec(source)
-  if (!match) {
-    throw new Error(`${label} is stale: ${name} is no longer exported`)
-  }
-  const value = Number(new Function(`return (${match[1].trim()})`)())
-  if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`${label} is stale: ${name} is not a positive integer`)
-  }
-  return value
-}
 
 function requireCallForm(source, needle, label) {
   if (!source.includes(needle)) {
@@ -45,21 +53,20 @@ function requireCallForm(source, needle, label) {
   }
 }
 
-const TERMINAL_OUTPUT_BATCH_MAX_BYTES = requireConstant(
-  FLOW_CONTROL_SOURCE,
-  'TERMINAL_OUTPUT_BATCH_MAX_BYTES',
-  'terminal-multiplex-flow-control'
+const { TERMINAL_OUTPUT_BATCH_MAX_BYTES, TERMINAL_STREAM_CHUNK_BYTES } = await import(
+  new URL('../../src/shared/terminal-multiplex-flow-control.ts', import.meta.url).href
 )
-const TERMINAL_STREAM_CHUNK_BYTES = requireConstant(
-  FLOW_CONTROL_SOURCE,
-  'TERMINAL_STREAM_CHUNK_BYTES',
-  'terminal-multiplex-flow-control'
+const { measureClipboardTextByteLength } = await import(
+  new URL('../../src/shared/clipboard-text.ts', import.meta.url).href
 )
-const MIN_NATIVE_BYTE_LENGTH_CODE_UNITS = requireConstant(
-  BYTE_LENGTH_SOURCE,
-  'MIN_NATIVE_BYTE_LENGTH_CODE_UNITS',
-  'terminal-stream-byte-length'
+const {
+  MIN_NATIVE_BYTE_LENGTH_CODE_UNITS,
+  measureTerminalStreamByteLength,
+  terminalStreamByteLengthExceeds
+} = await import(
+  new URL('../../src/main/runtime/rpc/terminal-stream-byte-length.ts', import.meta.url).href
 )
+
 const REQUESTED_SNAPSHOT_BYTE_BUDGET = (() => {
   const match = /const REQUESTED_SNAPSHOT_BYTE_BUDGET = ([^\n]+)/.exec(TERMINAL_SOURCE)
   if (!match) {
@@ -68,116 +75,32 @@ const REQUESTED_SNAPSHOT_BYTE_BUDGET = (() => {
   return Number(new Function(`return (${match[1].trim()})`)())
 })()
 
-// The batcher push still measures against a remaining-budget stopAfterBytes.
 requireCallForm(TERMINAL_SOURCE, 'measureTerminalStreamByteLength(data, {', 'terminal.ts')
 requireCallForm(TERMINAL_SOURCE, 'stopAfterBytes: remainingBudget', 'terminal.ts')
-// The snapshot scans still go through the boolean-only exceeds gate.
 requireCallForm(
   TERMINAL_SOURCE,
   'terminalStreamByteLengthExceeds(data, REQUESTED_SNAPSHOT_BYTE_BUDGET)',
   'terminal.ts'
 )
-// The new module still routes the over-limit case back through the legacy partial scan.
-requireCallForm(
-  BYTE_LENGTH_SOURCE,
-  'return measureClipboardTextByteLength(data, options)',
-  'terminal-stream-byte-length.ts'
-)
-requireCallForm(
-  BYTE_LENGTH_SOURCE,
-  'data.length * MAX_UTF8_BYTES_PER_CODE_UNIT <= (stopAfterBytes as number)',
-  'terminal-stream-byte-length.ts'
-)
-requireCallForm(
-  BYTE_LENGTH_SOURCE,
-  'data.length >= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS &&',
-  'terminal-stream-byte-length.ts'
-)
-requireCallForm(
-  CLIPBOARD_SOURCE,
-  'export function measureClipboardTextByteLength(',
-  'shared/clipboard-text.ts'
-)
 
-// ---- OLD ARM: byte-for-byte copy of shared/clipboard-text.ts measureClipboardTextByteLength,
-// which is exactly what terminal.ts called on every one of these paths before the change.
-function legacyUtf8ByteLengthForCodePoint(codePoint) {
-  if (codePoint <= 0x7f) {
-    return 1
+const nativeByteLength = Buffer.byteLength
+function runWithNativeCallCount(fn) {
+  let calls = 0
+  Buffer.byteLength = (...args) => {
+    calls += 1
+    return Reflect.apply(nativeByteLength, Buffer, args)
   }
-  if (codePoint <= 0x7ff) {
-    return 2
+  try {
+    return { output: fn(), calls }
+  } finally {
+    Buffer.byteLength = nativeByteLength
   }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
 }
 
-function legacyMeasure(text, options = {}) {
-  const stopAfterBytes = options.stopAfterBytes
-  let byteLength = 0
-  for (let index = 0; index < text.length; index += 1) {
-    const codePoint = text.codePointAt(index) ?? 0
-    byteLength += legacyUtf8ByteLengthForCodePoint(codePoint)
-    if (Number.isFinite(stopAfterBytes) && byteLength > (stopAfterBytes ?? 0)) {
-      return { byteLength, exceededLimit: true }
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return { byteLength, exceededLimit: false }
-}
-
-// ---- NEW ARM: mirrors src/main/runtime/rpc/terminal-stream-byte-length.ts, with a branch
-// counter so `assertExercised` can prove which path ran instead of guessing from the input.
-const MAX_UTF8_BYTES_PER_CODE_UNIT = (() => {
-  const match = /const MAX_UTF8_BYTES_PER_CODE_UNIT = (\d+)/.exec(BYTE_LENGTH_SOURCE)
-  if (!match) {
-    throw new Error('terminal-stream-byte-length.ts is stale: MAX_UTF8_BYTES_PER_CODE_UNIT is gone')
-  }
-  return Number(match[1])
-})()
-
-const BRANCH = { nativeFastPath: 0, scanFallback: 0, lengthShortCircuit: 0 }
-
-function newMeasure(data, options = {}) {
-  const stopAfterBytes = options.stopAfterBytes
-  if (!Number.isFinite(stopAfterBytes)) {
-    BRANCH.nativeFastPath += 1
-    return { byteLength: Buffer.byteLength(data, 'utf8'), exceededLimit: false }
-  }
-  if (
-    data.length >= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS &&
-    data.length * MAX_UTF8_BYTES_PER_CODE_UNIT <= stopAfterBytes
-  ) {
-    BRANCH.nativeFastPath += 1
-    return { byteLength: Buffer.byteLength(data, 'utf8'), exceededLimit: false }
-  }
-  BRANCH.scanFallback += 1
-  return legacyMeasure(data, options)
-}
-
-function newExceeds(data, maxBytes) {
-  if (data.length === 0 || !Number.isFinite(maxBytes)) {
-    return false
-  }
-  if (data.length > maxBytes) {
-    BRANCH.lengthShortCircuit += 1
-    return true
-  }
-  if (data.length < MIN_NATIVE_BYTE_LENGTH_CODE_UNITS) {
-    BRANCH.scanFallback += 1
-    return legacyMeasure(data, { stopAfterBytes: maxBytes }).exceededLimit
-  }
-  BRANCH.nativeFastPath += 1
-  return Buffer.byteLength(data, 'utf8') > maxBytes
-}
-
-function legacyExceeds(data, maxBytes) {
-  return legacyMeasure(data, { stopAfterBytes: maxBytes }).exceededLimit
-}
+// ---- OLD ARM: the production implementation terminal.ts called before this change.
+const legacyMeasure = measureClipboardTextByteLength
+const legacyExceeds = (data, maxBytes) =>
+  measureClipboardTextByteLength(data, { stopAfterBytes: maxBytes }).exceededLimit
 
 // ---- Fixtures. Deterministic, seeded, and varied per sample so V8 cannot hoist.
 function mulberry32(seed) {
@@ -233,7 +156,7 @@ function makeTerminalTextUnderBytes(byteBudget, sampleId) {
 // cannot short-circuit, but pack 3-byte BMP scalars so the legacy scan bails out after only a
 // THIRD of the string while Buffer.byteLength still walks all of it.
 function makeEarlyTripText(byteBudget, sampleId) {
-  const tripUnits = Math.ceil((byteBudget + 1) / MAX_UTF8_BYTES_PER_CODE_UNIT)
+  const tripUnits = Math.ceil((byteBudget + 1) / 3)
   const marker = String.fromCharCode(0x4e00 + (sampleId % 4096))
   const prefix = `${marker}${'走'.repeat(tripUnits - 1)}`
   return `${prefix}${'a'.repeat(byteBudget - tripUnits)}`
@@ -272,22 +195,21 @@ function runScenario(scenario) {
       for (let repeat = 0; repeat < repeats; repeat += 1) {
         inputs.push(scenario.make(batch * repeats + repeat))
       }
-      for (const input of inputs) {
-        const legacyOutput = scenario.legacy(input)
-        const branchBefore = { ...BRANCH }
-        const nextOutput = scenario.next(input)
+      const legacyOutputs = inputs.map(scenario.legacy)
+      const observed = runWithNativeCallCount(() => inputs.map(scenario.next))
+      for (let inputIndex = 0; inputIndex < inputs.length; inputIndex += 1) {
+        const input = inputs[inputIndex]
+        const legacyOutput = legacyOutputs[inputIndex]
+        const nextOutput = observed.output[inputIndex]
         if (!scenario.equal(legacyOutput, nextOutput)) {
           throw new Error(
             `${scenario.label}: arms disagree on ${JSON.stringify(input.slice(0, 40))}`
           )
         }
-        scenario.assertExercised(legacyOutput, input, {
-          nativeFastPath: BRANCH.nativeFastPath - branchBefore.nativeFastPath,
-          scanFallback: BRANCH.scanFallback - branchBefore.scanFallback,
-          lengthShortCircuit: BRANCH.lengthShortCircuit - branchBefore.lengthShortCircuit
-        })
+        scenario.assertResult(legacyOutput, input)
         validatedPairs += 1
       }
+      scenario.assertNativeCalls(inputs.length, observed.calls)
       let legacyResult
       let nextResult
       if (legacyFirst) {
@@ -311,14 +233,14 @@ const measurementEqual = (a, b) =>
 const measurementChecksum = (m) => m.byteLength + (m.exceededLimit ? 1 : 0)
 const booleanChecksum = (value) => (value ? 1 : 0)
 
-// Every scenario must state which branch it is testing. `expectBranch` is checked on EVERY
-// sample against a live counter inside the new arm, so a fixture that stops reaching the
-// branch it claims to exercise fails the benchmark instead of quietly reporting 1.00x.
+// Every scenario states which production branch it expects. Native fixtures require exactly one
+// Buffer.byteLength call per input; fallback fixtures require none.
 function requireBranch(expected) {
-  return (counts) => {
-    if (counts[expected] !== 1) {
+  return (inputCount, calls) => {
+    const expectedCalls = expected === 'nativeFastPath' ? inputCount : 0
+    if (calls !== expectedCalls) {
       throw new Error(
-        `expected the ${expected} branch to run exactly once, got ${JSON.stringify(counts)}`
+        `expected the production ${expected} branch (${expectedCalls} Buffer.byteLength calls), got ${calls}`
       )
     }
   }
@@ -329,13 +251,14 @@ const batchScenario = (label, make, options = {}) => ({
   make,
   repeats: options.repeats,
   legacy: (input) => legacyMeasure(input, { stopAfterBytes: TERMINAL_OUTPUT_BATCH_MAX_BYTES }),
-  next: (input) => newMeasure(input, { stopAfterBytes: TERMINAL_OUTPUT_BATCH_MAX_BYTES }),
+  next: (input) =>
+    measureTerminalStreamByteLength(input, {
+      stopAfterBytes: TERMINAL_OUTPUT_BATCH_MAX_BYTES
+    }),
   equal: measurementEqual,
   checksum: measurementChecksum,
-  assertExercised: (out, input, counts) => {
-    options.assert?.(out, input)
-    requireBranch(options.branch)(counts)
-  }
+  assertResult: (out, input) => options.assert?.(out, input),
+  assertNativeCalls: requireBranch(options.branch)
 })
 
 const gateScenario = (label, budget, make, options = {}) => ({
@@ -343,13 +266,11 @@ const gateScenario = (label, budget, make, options = {}) => ({
   make,
   repeats: options.repeats,
   legacy: (input) => legacyExceeds(input, budget),
-  next: (input) => newExceeds(input, budget),
+  next: (input) => terminalStreamByteLengthExceeds(input, budget),
   equal: (a, b) => a === b,
   checksum: booleanChecksum,
-  assertExercised: (out, input, counts) => {
-    options.assert?.(out, input)
-    requireBranch(options.branch)(counts)
-  }
+  assertResult: (out, input) => options.assert?.(out, input),
+  assertNativeCalls: requireBranch(options.branch)
 })
 
 const scenarios = [
@@ -477,20 +398,19 @@ for (const scenario of scenarios) {
     `${pad('bytes', 10)} ${pad('legacy', 12)} ${pad('new', 12)} ${pad('speedup', 9)}  branch`
   )
   for (const codeUnits of [4, 8, 16, 64, 256, 1024, 4096]) {
-    const before = { ...BRANCH }
+    const expectedBranch =
+      codeUnits >= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS ? 'nativeFastPath' : 'scanFallback'
     const { legacy, next } = runScenario(
       batchScenario(`sweep ${codeUnits}`, (sampleId) => makeInteractiveText(codeUnits, sampleId), {
-        branch: codeUnits >= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS ? 'nativeFastPath' : 'scanFallback',
+        branch: expectedBranch,
         repeats: Math.max(64, Math.min(4096, Math.ceil(2 ** 18 / codeUnits)))
       })
     )
-    const branch = BRANCH.nativeFastPath > before.nativeFastPath ? 'native' : 'scan (unchanged)'
+    const branch = expectedBranch === 'nativeFastPath' ? 'native' : 'scan (unchanged)'
     console.log(
       `${pad(`${codeUnits} B`, 10)} ${pad(formatTime(legacy), 12)} ${pad(formatTime(next), 12)} ${pad(`${(legacy / next).toFixed(2)}x`, 9)}  ${branch}`
     )
   }
 }
 
-console.log(
-  `\nvalidated=${validatedPairs} measured pairs, branches=${JSON.stringify(BRANCH)}, result checksum=${resultChecksum >>> 0}`
-)
+console.log(`\nvalidated=${validatedPairs} measured pairs, result checksum=${resultChecksum >>> 0}`)

--- a/config/scripts/terminal-stream-byte-length-benchmark.mjs
+++ b/config/scripts/terminal-stream-byte-length-benchmark.mjs
@@ -1,0 +1,496 @@
+#!/usr/bin/env node
+// Mirrors the production terminal byte-measurement paths at their real budgets: the output
+// batcher push and the snapshot budget scan. Every scenario
+// asserts which BRANCH of the new arm ran, so a fixture cannot silently stop testing anything.
+import { performance } from 'node:perf_hooks'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+const ROOT = path.resolve(import.meta.dirname, '../..')
+const ITERATIONS = Number(process.env.ORCA_BYTE_LENGTH_BENCH_ITERATIONS ?? '61')
+let resultChecksum = 0
+let validatedPairs = 0
+
+if (!Number.isSafeInteger(ITERATIONS) || ITERATIONS <= 0) {
+  throw new Error(`ORCA_BYTE_LENGTH_BENCH_ITERATIONS must be a positive integer, got ${ITERATIONS}`)
+}
+
+function readSource(relative) {
+  return fs.readFileSync(path.join(ROOT, relative), 'utf8')
+}
+
+// Re-read the production constants and CALL FORMS so this benchmark fails loudly if the
+// code it claims to mirror drifts. Matching call shapes, not bare words.
+const FLOW_CONTROL_SOURCE = readSource('src/shared/terminal-multiplex-flow-control.ts')
+const TERMINAL_SOURCE = readSource('src/main/runtime/rpc/methods/terminal.ts')
+const BYTE_LENGTH_SOURCE = readSource('src/main/runtime/rpc/terminal-stream-byte-length.ts')
+const CLIPBOARD_SOURCE = readSource('src/shared/clipboard-text.ts')
+
+function requireConstant(source, name, label) {
+  const match = new RegExp(`export const ${name} = ([^\\n]+)`).exec(source)
+  if (!match) {
+    throw new Error(`${label} is stale: ${name} is no longer exported`)
+  }
+  const value = Number(new Function(`return (${match[1].trim()})`)())
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} is stale: ${name} is not a positive integer`)
+  }
+  return value
+}
+
+function requireCallForm(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`${label} is stale: expected call form \`${needle}\` was not found`)
+  }
+}
+
+const TERMINAL_OUTPUT_BATCH_MAX_BYTES = requireConstant(
+  FLOW_CONTROL_SOURCE,
+  'TERMINAL_OUTPUT_BATCH_MAX_BYTES',
+  'terminal-multiplex-flow-control'
+)
+const TERMINAL_STREAM_CHUNK_BYTES = requireConstant(
+  FLOW_CONTROL_SOURCE,
+  'TERMINAL_STREAM_CHUNK_BYTES',
+  'terminal-multiplex-flow-control'
+)
+const MIN_NATIVE_BYTE_LENGTH_CODE_UNITS = requireConstant(
+  BYTE_LENGTH_SOURCE,
+  'MIN_NATIVE_BYTE_LENGTH_CODE_UNITS',
+  'terminal-stream-byte-length'
+)
+const REQUESTED_SNAPSHOT_BYTE_BUDGET = (() => {
+  const match = /const REQUESTED_SNAPSHOT_BYTE_BUDGET = ([^\n]+)/.exec(TERMINAL_SOURCE)
+  if (!match) {
+    throw new Error('terminal.ts is stale: REQUESTED_SNAPSHOT_BYTE_BUDGET is gone')
+  }
+  return Number(new Function(`return (${match[1].trim()})`)())
+})()
+
+// The batcher push still measures against a remaining-budget stopAfterBytes.
+requireCallForm(TERMINAL_SOURCE, 'measureTerminalStreamByteLength(data, {', 'terminal.ts')
+requireCallForm(TERMINAL_SOURCE, 'stopAfterBytes: remainingBudget', 'terminal.ts')
+// The snapshot scans still go through the boolean-only exceeds gate.
+requireCallForm(
+  TERMINAL_SOURCE,
+  'terminalStreamByteLengthExceeds(data, REQUESTED_SNAPSHOT_BYTE_BUDGET)',
+  'terminal.ts'
+)
+// The new module still routes the over-limit case back through the legacy partial scan.
+requireCallForm(
+  BYTE_LENGTH_SOURCE,
+  'return measureClipboardTextByteLength(data, options)',
+  'terminal-stream-byte-length.ts'
+)
+requireCallForm(
+  BYTE_LENGTH_SOURCE,
+  'data.length * MAX_UTF8_BYTES_PER_CODE_UNIT <= (stopAfterBytes as number)',
+  'terminal-stream-byte-length.ts'
+)
+requireCallForm(
+  BYTE_LENGTH_SOURCE,
+  'data.length >= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS &&',
+  'terminal-stream-byte-length.ts'
+)
+requireCallForm(
+  CLIPBOARD_SOURCE,
+  'export function measureClipboardTextByteLength(',
+  'shared/clipboard-text.ts'
+)
+
+// ---- OLD ARM: byte-for-byte copy of shared/clipboard-text.ts measureClipboardTextByteLength,
+// which is exactly what terminal.ts called on every one of these paths before the change.
+function legacyUtf8ByteLengthForCodePoint(codePoint) {
+  if (codePoint <= 0x7f) {
+    return 1
+  }
+  if (codePoint <= 0x7ff) {
+    return 2
+  }
+  if (codePoint <= 0xffff) {
+    return 3
+  }
+  return 4
+}
+
+function legacyMeasure(text, options = {}) {
+  const stopAfterBytes = options.stopAfterBytes
+  let byteLength = 0
+  for (let index = 0; index < text.length; index += 1) {
+    const codePoint = text.codePointAt(index) ?? 0
+    byteLength += legacyUtf8ByteLengthForCodePoint(codePoint)
+    if (Number.isFinite(stopAfterBytes) && byteLength > (stopAfterBytes ?? 0)) {
+      return { byteLength, exceededLimit: true }
+    }
+    if (codePoint > 0xffff) {
+      index += 1
+    }
+  }
+  return { byteLength, exceededLimit: false }
+}
+
+// ---- NEW ARM: mirrors src/main/runtime/rpc/terminal-stream-byte-length.ts, with a branch
+// counter so `assertExercised` can prove which path ran instead of guessing from the input.
+const MAX_UTF8_BYTES_PER_CODE_UNIT = (() => {
+  const match = /const MAX_UTF8_BYTES_PER_CODE_UNIT = (\d+)/.exec(BYTE_LENGTH_SOURCE)
+  if (!match) {
+    throw new Error('terminal-stream-byte-length.ts is stale: MAX_UTF8_BYTES_PER_CODE_UNIT is gone')
+  }
+  return Number(match[1])
+})()
+
+const BRANCH = { nativeFastPath: 0, scanFallback: 0, lengthShortCircuit: 0 }
+
+function newMeasure(data, options = {}) {
+  const stopAfterBytes = options.stopAfterBytes
+  if (!Number.isFinite(stopAfterBytes)) {
+    BRANCH.nativeFastPath += 1
+    return { byteLength: Buffer.byteLength(data, 'utf8'), exceededLimit: false }
+  }
+  if (
+    data.length >= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS &&
+    data.length * MAX_UTF8_BYTES_PER_CODE_UNIT <= stopAfterBytes
+  ) {
+    BRANCH.nativeFastPath += 1
+    return { byteLength: Buffer.byteLength(data, 'utf8'), exceededLimit: false }
+  }
+  BRANCH.scanFallback += 1
+  return legacyMeasure(data, options)
+}
+
+function newExceeds(data, maxBytes) {
+  if (data.length === 0 || !Number.isFinite(maxBytes)) {
+    return false
+  }
+  if (data.length > maxBytes) {
+    BRANCH.lengthShortCircuit += 1
+    return true
+  }
+  if (data.length < MIN_NATIVE_BYTE_LENGTH_CODE_UNITS) {
+    BRANCH.scanFallback += 1
+    return legacyMeasure(data, { stopAfterBytes: maxBytes }).exceededLimit
+  }
+  BRANCH.nativeFastPath += 1
+  return Buffer.byteLength(data, 'utf8') > maxBytes
+}
+
+function legacyExceeds(data, maxBytes) {
+  return legacyMeasure(data, { stopAfterBytes: maxBytes }).exceededLimit
+}
+
+// ---- Fixtures. Deterministic, seeded, and varied per sample so V8 cannot hoist.
+function mulberry32(seed) {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+// Realistic agent-TUI output: mostly ASCII with SGR runs, box drawing, and emoji status
+// glyphs, plus a per-sample marker so no two measured strings are identical.
+function makeTerminalText(codeUnits, sampleId) {
+  const random = mulberry32(sampleId * 2654435761)
+  const lines = [
+    '[35m✻ Thinking…[0m\r\n',
+    '  ⏺ Running tests… 42 passed, 0 failed\r\n',
+    '│ src/main/runtime/rpc/methods/terminal.ts  │\r\n',
+    '  ✅ build succeeded in 12.4s — café naïve\r\n',
+    '[32m+ added line[0m\r\n'
+  ]
+  let text = `sample:${sampleId}\r\n`
+  while (text.length < codeUnits) {
+    text += lines[Math.floor(random() * lines.length)]
+  }
+  return text.slice(0, codeUnits)
+}
+
+// Keystroke echo and tiny interactive writes: the shapes a PTY emits between key presses.
+function makeInteractiveText(codeUnits, sampleId) {
+  const random = mulberry32(sampleId * 40503)
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789 ./-_'
+  let text = ''
+  while (text.length < codeUnits) {
+    text += alphabet[Math.floor(random() * alphabet.length)]
+  }
+  return text.slice(0, codeUnits)
+}
+
+// Trim to just under a BYTE budget so the legacy arm runs its full scan without tripping the limit.
+function makeTerminalTextUnderBytes(byteBudget, sampleId) {
+  let text = makeTerminalText(byteBudget, sampleId)
+  while (Buffer.byteLength(text, 'utf8') > byteBudget) {
+    text = text.slice(0, Math.floor(text.length * (byteBudget / Buffer.byteLength(text, 'utf8'))))
+  }
+  return text
+}
+
+// The TRUE adversary for the exceeds gate: stay at the code-unit cap so `length > maxBytes`
+// cannot short-circuit, but pack 3-byte BMP scalars so the legacy scan bails out after only a
+// THIRD of the string while Buffer.byteLength still walks all of it.
+function makeEarlyTripText(byteBudget, sampleId) {
+  const tripUnits = Math.ceil((byteBudget + 1) / MAX_UTF8_BYTES_PER_CODE_UNIT)
+  const marker = String.fromCharCode(0x4e00 + (sampleId % 4096))
+  const prefix = `${marker}${'走'.repeat(tripUnits - 1)}`
+  return `${prefix}${'a'.repeat(byteBudget - tripUnits)}`
+}
+
+function median(samples) {
+  const sorted = [...samples].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
+}
+
+function consume(value) {
+  resultChecksum = Math.imul(resultChecksum ^ (value | 0), 16777619) >>> 0
+}
+
+// Small inputs are far below timer resolution, so batch them: build `repeats` distinct
+// samples, time the whole loop, and report per-call cost. Consuming the running total
+// inside the timed region keeps V8 from hoisting the calls out.
+function runScenario(scenario) {
+  const repeats = scenario.repeats ?? 1
+  const samples = { legacy: [], next: [] }
+  const runArm = (fn, inputs) => {
+    const start = performance.now()
+    let total = 0
+    for (const input of inputs) {
+      total += scenario.checksum(fn(input))
+    }
+    const elapsed = performance.now() - start
+    return { elapsed, total }
+  }
+  for (let index = 0; index < ITERATIONS; index += 1) {
+    // Alternate which arm leads on every iteration so cache/JIT warmup is shared evenly.
+    for (const legacyFirst of index % 2 === 0 ? [true, false] : [false, true]) {
+      const batch = index * 2 + (legacyFirst ? 0 : 1)
+      const inputs = []
+      for (let repeat = 0; repeat < repeats; repeat += 1) {
+        inputs.push(scenario.make(batch * repeats + repeat))
+      }
+      for (const input of inputs) {
+        const legacyOutput = scenario.legacy(input)
+        const branchBefore = { ...BRANCH }
+        const nextOutput = scenario.next(input)
+        if (!scenario.equal(legacyOutput, nextOutput)) {
+          throw new Error(
+            `${scenario.label}: arms disagree on ${JSON.stringify(input.slice(0, 40))}`
+          )
+        }
+        scenario.assertExercised(legacyOutput, input, {
+          nativeFastPath: BRANCH.nativeFastPath - branchBefore.nativeFastPath,
+          scanFallback: BRANCH.scanFallback - branchBefore.scanFallback,
+          lengthShortCircuit: BRANCH.lengthShortCircuit - branchBefore.lengthShortCircuit
+        })
+        validatedPairs += 1
+      }
+      let legacyResult
+      let nextResult
+      if (legacyFirst) {
+        legacyResult = runArm(scenario.legacy, inputs)
+        nextResult = runArm(scenario.next, inputs)
+      } else {
+        nextResult = runArm(scenario.next, inputs)
+        legacyResult = runArm(scenario.legacy, inputs)
+      }
+      consume(legacyResult.total)
+      consume(nextResult.total)
+      samples.legacy.push(legacyResult.elapsed / repeats)
+      samples.next.push(nextResult.elapsed / repeats)
+    }
+  }
+  return { legacy: median(samples.legacy), next: median(samples.next) }
+}
+
+const measurementEqual = (a, b) =>
+  a.byteLength === b.byteLength && a.exceededLimit === b.exceededLimit
+const measurementChecksum = (m) => m.byteLength + (m.exceededLimit ? 1 : 0)
+const booleanChecksum = (value) => (value ? 1 : 0)
+
+// Every scenario must state which branch it is testing. `expectBranch` is checked on EVERY
+// sample against a live counter inside the new arm, so a fixture that stops reaching the
+// branch it claims to exercise fails the benchmark instead of quietly reporting 1.00x.
+function requireBranch(expected) {
+  return (counts) => {
+    if (counts[expected] !== 1) {
+      throw new Error(
+        `expected the ${expected} branch to run exactly once, got ${JSON.stringify(counts)}`
+      )
+    }
+  }
+}
+
+const batchScenario = (label, make, options = {}) => ({
+  label,
+  make,
+  repeats: options.repeats,
+  legacy: (input) => legacyMeasure(input, { stopAfterBytes: TERMINAL_OUTPUT_BATCH_MAX_BYTES }),
+  next: (input) => newMeasure(input, { stopAfterBytes: TERMINAL_OUTPUT_BATCH_MAX_BYTES }),
+  equal: measurementEqual,
+  checksum: measurementChecksum,
+  assertExercised: (out, input, counts) => {
+    options.assert?.(out, input)
+    requireBranch(options.branch)(counts)
+  }
+})
+
+const gateScenario = (label, budget, make, options = {}) => ({
+  label,
+  make,
+  repeats: options.repeats,
+  legacy: (input) => legacyExceeds(input, budget),
+  next: (input) => newExceeds(input, budget),
+  equal: (a, b) => a === b,
+  checksum: booleanChecksum,
+  assertExercised: (out, input, counts) => {
+    options.assert?.(out, input)
+    requireBranch(options.branch)(counts)
+  }
+})
+
+const scenarios = [
+  batchScenario('batcher push 8KiB', (sampleId) => makeTerminalText(8 * 1024, sampleId), {
+    branch: 'nativeFastPath',
+    assert: (out) => {
+      if (out.exceededLimit) {
+        throw new Error('batcher push 8KiB should stay under the batch budget')
+      }
+    }
+  }),
+  batchScenario(
+    'batcher push over budget',
+    // Oversized on purpose: this is the case where the arms MUST both return the partial count.
+    (sampleId) => makeTerminalText(3 * TERMINAL_OUTPUT_BATCH_MAX_BYTES, sampleId),
+    {
+      branch: 'scanFallback',
+      assert: (out) => {
+        if (!out.exceededLimit) {
+          throw new Error('over-budget fixture never exceeded the limit')
+        }
+      }
+    }
+  ),
+  // TRUE WORST CASE for the batcher push. The guard only takes the native count when
+  // length*3 <= stopAfterBytes, which PROVES the limit cannot trip, so the fast path can never
+  // pay for both a Buffer.byteLength and a scan. What is left is the shape where the native
+  // call replaces the fewest scan iterations: a chunk sitting just above the code-unit floor.
+  batchScenario(
+    `batcher push ${MIN_NATIVE_BYTE_LENGTH_CODE_UNITS}B (floor)`,
+    (sampleId) => makeInteractiveText(MIN_NATIVE_BYTE_LENGTH_CODE_UNITS, sampleId),
+    { branch: 'nativeFastPath', repeats: 4096 }
+  ),
+  // Below the floor the new arm deliberately keeps the scan, so it is the legacy code exactly.
+  batchScenario('batcher push 4B keystroke', (sampleId) => makeInteractiveText(4, sampleId), {
+    branch: 'scanFallback',
+    repeats: 4096
+  }),
+  gateScenario(
+    `snapshot scan ${(REQUESTED_SNAPSHOT_BYTE_BUDGET / (1024 * 1024)).toFixed(0)}MiB`,
+    REQUESTED_SNAPSHOT_BYTE_BUDGET,
+    (sampleId) => makeTerminalTextUnderBytes(REQUESTED_SNAPSHOT_BYTE_BUDGET, sampleId),
+    {
+      branch: 'nativeFastPath',
+      assert: (out) => {
+        if (out) {
+          throw new Error('snapshot fixture should sit under the budget so the full scan runs')
+        }
+      }
+    }
+  ),
+  // TRUE WORST CASE for the boolean gate: at the code-unit cap so `length > maxBytes` cannot
+  // short-circuit, but 3-byte scalars let the legacy scan bail out a THIRD of the way in while
+  // Buffer.byteLength still walks the whole string. This is where the new arm can actually lose.
+  gateScenario(
+    'snapshot gate early-trip',
+    REQUESTED_SNAPSHOT_BYTE_BUDGET,
+    (sampleId) => makeEarlyTripText(REQUESTED_SNAPSHOT_BYTE_BUDGET, sampleId),
+    {
+      branch: 'nativeFastPath',
+      assert: (out, input) => {
+        if (!out) {
+          throw new Error('early-trip gate fixture must exceed the budget')
+        }
+        if (input.length > REQUESTED_SNAPSHOT_BYTE_BUDGET) {
+          throw new Error('early-trip fixture must not hit the code-unit short circuit')
+        }
+      }
+    }
+  ),
+  gateScenario(
+    'chunk gate early-trip',
+    TERMINAL_STREAM_CHUNK_BYTES,
+    (sampleId) => makeEarlyTripText(TERMINAL_STREAM_CHUNK_BYTES, sampleId),
+    {
+      branch: 'nativeFastPath',
+      assert: (out, input) => {
+        if (!out) {
+          throw new Error('early-trip chunk fixture must exceed the budget')
+        }
+        if (input.length > TERMINAL_STREAM_CHUNK_BYTES) {
+          throw new Error('early-trip fixture must not hit the code-unit short circuit')
+        }
+      }
+    }
+  ),
+  gateScenario(
+    `chunk gate ${TERMINAL_STREAM_CHUNK_BYTES / 1024}KiB`,
+    TERMINAL_STREAM_CHUNK_BYTES,
+    (sampleId) => makeTerminalTextUnderBytes(TERMINAL_STREAM_CHUNK_BYTES, sampleId),
+    {
+      branch: 'nativeFastPath',
+      assert: (out) => {
+        if (out) {
+          throw new Error('chunk gate fixture should sit under the chunk budget')
+        }
+      }
+    }
+  )
+]
+
+const pad = (value, width) => String(value).padStart(width)
+const formatTime = (ms) =>
+  ms >= 0.001 ? `${(ms * 1000).toFixed(1)} us` : `${(ms * 1e6).toFixed(1)} ns`
+console.log('Production terminal byte-measurement paths. Lower is better.')
+console.log(
+  `iterations=${ITERATIONS} (${ITERATIONS * 2} counterbalanced batches/scenario, per-arm medians)`
+)
+console.log(`${pad('scenario', 30)} ${pad('legacy', 12)} ${pad('new', 12)} ${pad('speedup', 9)}`)
+for (const scenario of scenarios) {
+  const { legacy, next } = runScenario(scenario)
+  console.log(
+    `${pad(scenario.label, 30)} ${pad(formatTime(legacy), 12)} ${pad(formatTime(next), 12)} ${pad(`${(legacy / next).toFixed(2)}x`, 9)}`
+  )
+}
+
+// Small-chunk sweep across real interactive PTY write sizes. The floor makes everything below
+// MIN_NATIVE_BYTE_LENGTH_CODE_UNITS byte-identical to the legacy scan, so those rows must land
+// at ~1.00x; anything materially below that is a regression the change would be shipping.
+{
+  console.log(
+    `\nbatcher push small-chunk sweep (stopAfterBytes=${TERMINAL_OUTPUT_BATCH_MAX_BYTES}):`
+  )
+  console.log(
+    `${pad('bytes', 10)} ${pad('legacy', 12)} ${pad('new', 12)} ${pad('speedup', 9)}  branch`
+  )
+  for (const codeUnits of [4, 8, 16, 64, 256, 1024, 4096]) {
+    const before = { ...BRANCH }
+    const { legacy, next } = runScenario(
+      batchScenario(`sweep ${codeUnits}`, (sampleId) => makeInteractiveText(codeUnits, sampleId), {
+        branch: codeUnits >= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS ? 'nativeFastPath' : 'scanFallback',
+        repeats: Math.max(64, Math.min(4096, Math.ceil(2 ** 18 / codeUnits)))
+      })
+    )
+    const branch = BRANCH.nativeFastPath > before.nativeFastPath ? 'native' : 'scan (unchanged)'
+    console.log(
+      `${pad(`${codeUnits} B`, 10)} ${pad(formatTime(legacy), 12)} ${pad(formatTime(next), 12)} ${pad(`${(legacy / next).toFixed(2)}x`, 9)}  ${branch}`
+    )
+  }
+}
+
+console.log(
+  `\nvalidated=${validatedPairs} measured pairs, branches=${JSON.stringify(BRANCH)}, result checksum=${resultChecksum >>> 0}`
+)

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -29,7 +29,11 @@ import {
   TERMINAL_INPUT_TOO_LARGE_ERROR,
   isTerminalInputTooLargeWithYield
 } from '../../../../shared/terminal-input'
-import { measureClipboardTextByteLength } from '../../../../shared/clipboard-text'
+import {
+  measureTerminalStreamByteLength,
+  terminalStreamByteLength,
+  terminalStreamByteLengthExceeds
+} from '../terminal-stream-byte-length'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import { isTerminalQueryReply } from '../../../../shared/terminal-query-reply'
 import {
@@ -456,13 +460,6 @@ function trimPendingOutputToBudget(
   return { bytes: pendingOutputBytes, overflowed: omittedChunkCount > 0 }
 }
 
-function measureTerminalStreamByteLength(
-  data: string,
-  options: { stopAfterBytes?: number } = {}
-): { byteLength: number; exceededLimit: boolean } {
-  return measureClipboardTextByteLength(data, options)
-}
-
 function trimPendingOutputCoveredBySnapshot(
   pendingOutput: TerminalOutputChunk[],
   snapshotSeq: number | undefined
@@ -498,14 +495,6 @@ function trimPendingOutputCoveredBySnapshot(
     bytes += slicedBytes
   }
   return { chunks, bytes }
-}
-
-function terminalStreamByteLength(data: string): number {
-  return measureTerminalStreamByteLength(data).byteLength
-}
-
-function terminalStreamByteLengthExceeds(data: string, maxBytes: number): boolean {
-  return measureTerminalStreamByteLength(data, { stopAfterBytes: maxBytes }).exceededLimit
 }
 
 function* iterateTerminalStreamTextPayloads(data: string): Generator<Uint8Array<ArrayBufferLike>> {

--- a/src/main/runtime/rpc/terminal-stream-byte-length.test.ts
+++ b/src/main/runtime/rpc/terminal-stream-byte-length.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MIN_NATIVE_BYTE_LENGTH_CODE_UNITS,
+  measureTerminalStreamByteLength,
+  terminalStreamByteLength,
+  terminalStreamByteLengthExceeds
+} from './terminal-stream-byte-length'
+import { TERMINAL_OUTPUT_BATCH_MAX_BYTES } from '../../../shared/terminal-multiplex-flow-control'
+
+// Byte-for-byte copy of the pre-change implementation (shared/clipboard-text.ts
+// measureClipboardTextByteLength), kept here so equivalence is checked against the
+// ACTUAL old code path rather than a paraphrase of it.
+function legacyUtf8ByteLengthForCodePoint(codePoint: number): number {
+  if (codePoint <= 0x7f) {
+    return 1
+  }
+  if (codePoint <= 0x7ff) {
+    return 2
+  }
+  if (codePoint <= 0xffff) {
+    return 3
+  }
+  return 4
+}
+
+function legacyMeasure(
+  text: string,
+  options: { stopAfterBytes?: number } = {}
+): { byteLength: number; exceededLimit: boolean } {
+  const stopAfterBytes = options.stopAfterBytes
+  let byteLength = 0
+  for (let index = 0; index < text.length; index += 1) {
+    const codePoint = text.codePointAt(index) ?? 0
+    byteLength += legacyUtf8ByteLengthForCodePoint(codePoint)
+    if (Number.isFinite(stopAfterBytes) && byteLength > (stopAfterBytes ?? 0)) {
+      return { byteLength, exceededLimit: true }
+    }
+    if (codePoint > 0xffff) {
+      index += 1
+    }
+  }
+  return { byteLength, exceededLimit: false }
+}
+
+function legacyByteLength(data: string): number {
+  return legacyMeasure(data).byteLength
+}
+
+function legacyExceeds(data: string, maxBytes: number): boolean {
+  return legacyMeasure(data, { stopAfterBytes: maxBytes }).exceededLimit
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = state
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+// Mixed generator: ASCII, 2-byte, 3-byte, astral pairs, and LONE surrogates, so the
+// fixtures exercise every branch of the legacy code-point scan.
+function randomUnit(random: () => number): string {
+  const roll = random()
+  if (roll < 0.4) {
+    return String.fromCharCode(Math.floor(random() * 0x80))
+  }
+  if (roll < 0.55) {
+    return String.fromCharCode(0x80 + Math.floor(random() * 0x780))
+  }
+  if (roll < 0.72) {
+    return String.fromCharCode(0x800 + Math.floor(random() * 0xd000))
+  }
+  if (roll < 0.88) {
+    return String.fromCodePoint(0x10000 + Math.floor(random() * 0x100000))
+  }
+  return String.fromCharCode(0xd800 + Math.floor(random() * 0x800))
+}
+
+function randomString(random: () => number, maxUnits: number): string {
+  const count = Math.floor(random() * maxUnits)
+  let text = ''
+  for (let index = 0; index < count; index += 1) {
+    text += randomUnit(random)
+  }
+  return text
+}
+
+// Raw UTF-16 with no code-point discipline at all: catches anything that assumes
+// well-formedness (unpaired high after high, low before high, etc).
+function rawUtf16(random: () => number, maxUnits: number): string {
+  const count = Math.floor(random() * maxUnits)
+  let text = ''
+  for (let index = 0; index < count; index += 1) {
+    text += String.fromCharCode(Math.floor(random() * 0x11000))
+  }
+  return text
+}
+
+const EDGE_STRINGS = [
+  '',
+  'a',
+  '\u0000',
+  '\u007f',
+  '',
+  '߿',
+  'ࠀ',
+  '￿',
+  '�',
+  '\u{10000}',
+  '\u{10ffff}',
+  '\ud800',
+  '\udfff',
+  '\ud800\ud800',
+  '\udc00\ud800',
+  '😀',
+  '😀\ud800',
+  '\ud800😀',
+  'a\ud800b',
+  '\r\n\u001b[0m',
+  'é́',
+  '\u{1f469}‍\u{1f4bb}',
+  'x'.repeat(1000),
+  '\u{1f600}'.repeat(300),
+  `${'é'.repeat(500)}\ud800`
+]
+
+describe('terminal stream byte length equivalence with the legacy code-point scan', () => {
+  it('matches the legacy total byte length on edge strings', () => {
+    for (const text of EDGE_STRINGS) {
+      expect(terminalStreamByteLength(text)).toBe(legacyByteLength(text))
+    }
+  })
+
+  it('matches the legacy total byte length over every Unicode code point', () => {
+    for (let codePoint = 0; codePoint <= 0x10ffff; codePoint += 1) {
+      const text = String.fromCodePoint(codePoint)
+      if (terminalStreamByteLength(text) !== legacyByteLength(text)) {
+        throw new Error(`byte length diverged at code point U+${codePoint.toString(16)}`)
+      }
+    }
+    expect(terminalStreamByteLength('\u{10ffff}')).toBe(4)
+  })
+
+  it('matches the legacy total byte length over every lone surrogate', () => {
+    for (let unit = 0xd800; unit <= 0xdfff; unit += 1) {
+      const text = `a${String.fromCharCode(unit)}b`
+      expect(terminalStreamByteLength(text)).toBe(legacyByteLength(text))
+    }
+  })
+
+  it('matches the legacy total byte length over fuzzed mixed and raw UTF-16 input', () => {
+    const random = mulberry32(0x5eed01)
+    for (let iteration = 0; iteration < 20000; iteration += 1) {
+      const text = iteration % 2 === 0 ? randomString(random, 24) : rawUtf16(random, 24)
+      if (terminalStreamByteLength(text) !== legacyByteLength(text)) {
+        throw new Error(`byte length diverged for ${JSON.stringify(text)}`)
+      }
+    }
+    expect(true).toBe(true)
+  })
+
+  it('matches the legacy exceededLimit decision across a dense (string, limit) sweep', () => {
+    const random = mulberry32(0xc0ffee)
+    let compared = 0
+    for (let iteration = 0; iteration < 10000; iteration += 1) {
+      const text = iteration % 2 === 0 ? randomString(random, 16) : rawUtf16(random, 16)
+      const total = legacyByteLength(text)
+      // Sweep every limit from below zero to past the true total so the boundary is hit exactly.
+      for (let limit = -2; limit <= total + 2; limit += 1) {
+        if (terminalStreamByteLengthExceeds(text, limit) !== legacyExceeds(text, limit)) {
+          throw new Error(`exceededLimit diverged for ${JSON.stringify(text)} at limit ${limit}`)
+        }
+        compared += 1
+      }
+    }
+    expect(compared).toBeGreaterThan(100000)
+  })
+
+  it('matches the legacy exceededLimit decision for non-finite and fractional limits', () => {
+    const random = mulberry32(0xfeed42)
+    for (const limit of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      0.5,
+      2.5,
+      -0.5,
+      Number.MAX_SAFE_INTEGER
+    ]) {
+      for (let iteration = 0; iteration < 400; iteration += 1) {
+        const text = rawUtf16(random, 12)
+        expect(terminalStreamByteLengthExceeds(text, limit)).toBe(legacyExceeds(text, limit))
+      }
+      for (const text of EDGE_STRINGS) {
+        expect(terminalStreamByteLengthExceeds(text, limit)).toBe(legacyExceeds(text, limit))
+      }
+    }
+  })
+
+  it('matches the legacy measurement pair, byteLength included, across a stopAfterBytes sweep', () => {
+    const random = mulberry32(0xa11ce)
+    for (let iteration = 0; iteration < 3000; iteration += 1) {
+      const text = iteration % 2 === 0 ? randomString(random, 20) : rawUtf16(random, 20)
+      const total = legacyByteLength(text)
+      for (let stopAfterBytes = -1; stopAfterBytes <= total + 2; stopAfterBytes += 1) {
+        const actual = measureTerminalStreamByteLength(text, { stopAfterBytes })
+        const expected = legacyMeasure(text, { stopAfterBytes })
+        if (
+          actual.byteLength !== expected.byteLength ||
+          actual.exceededLimit !== expected.exceededLimit
+        ) {
+          throw new Error(
+            `measurement diverged for ${JSON.stringify(text)} at stopAfterBytes ${stopAfterBytes}`
+          )
+        }
+      }
+    }
+    expect(
+      measureTerminalStreamByteLength('\u{1f600}\u{1f600}\u{1f600}', { stopAfterBytes: 5 })
+    ).toEqual(legacyMeasure('\u{1f600}\u{1f600}\u{1f600}', { stopAfterBytes: 5 }))
+  })
+
+  it('keeps the partial byteLength the legacy scan returned when the limit is exceeded', () => {
+    // A drop-in Buffer.byteLength would report 12 here; the legacy scan stops at 8.
+    const measurement = measureTerminalStreamByteLength('\u{1f600}\u{1f600}\u{1f600}', {
+      stopAfterBytes: 5
+    })
+    expect(measurement).toEqual({ byteLength: 8, exceededLimit: true })
+  })
+
+  it('matches the legacy measurement with no stopAfterBytes and with an undefined option bag', () => {
+    const random = mulberry32(0xb0b)
+    for (let iteration = 0; iteration < 2000; iteration += 1) {
+      const text = rawUtf16(random, 32)
+      expect(measureTerminalStreamByteLength(text)).toEqual(legacyMeasure(text))
+      expect(measureTerminalStreamByteLength(text, {})).toEqual(legacyMeasure(text, {}))
+      expect(measureTerminalStreamByteLength(text, { stopAfterBytes: undefined })).toEqual(
+        legacyMeasure(text, { stopAfterBytes: undefined })
+      )
+    }
+  })
+
+  // The code-unit floor routes short inputs back through the scan. Both sides of that
+  // boundary must stay legacy-identical, so sweep it exhaustively rather than by sampling.
+  it('matches the legacy result on both sides of the native-call floor', () => {
+    const random = mulberry32(0xf100a)
+    for (let units = 0; units <= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS * 2; units += 1) {
+      for (let iteration = 0; iteration < 60; iteration += 1) {
+        let text = ''
+        while (text.length < units) {
+          text +=
+            iteration % 2 === 0
+              ? randomUnit(random)
+              : String.fromCharCode(Math.floor(random() * 0x11000))
+        }
+        text = text.slice(0, units)
+        const total = legacyByteLength(text)
+        expect(terminalStreamByteLength(text)).toBe(total)
+        for (let limit = -1; limit <= total + 2; limit += 1) {
+          if (terminalStreamByteLengthExceeds(text, limit) !== legacyExceeds(text, limit)) {
+            throw new Error(`exceeds diverged at ${units} units, limit ${limit}`)
+          }
+          const actual = measureTerminalStreamByteLength(text, { stopAfterBytes: limit })
+          const expected = legacyMeasure(text, { stopAfterBytes: limit })
+          if (
+            actual.byteLength !== expected.byteLength ||
+            actual.exceededLimit !== expected.exceededLimit
+          ) {
+            throw new Error(`measurement diverged at ${units} units, limit ${limit}`)
+          }
+        }
+      }
+    }
+    expect(MIN_NATIVE_BYTE_LENGTH_CODE_UNITS).toBeGreaterThan(0)
+  })
+})
+
+// Reproduces createTerminalOutputBatcher's byte accounting exactly, under both the
+// legacy scan and the new measurement, and asserts IDENTICAL flush boundaries. This is
+// what makes the partial-count behaviour provably unobservable at that call site.
+function simulateBatcherFlushes(
+  chunks: string[],
+  measure: (
+    data: string,
+    options: { stopAfterBytes?: number }
+  ) => { byteLength: number; exceededLimit: boolean }
+): string[] {
+  const flushes: string[] = []
+  let pending: string[] = []
+  let bytes = 0
+  const flush = (): void => {
+    if (pending.length === 0) {
+      return
+    }
+    flushes.push(pending.join(''))
+    pending = []
+    bytes = 0
+  }
+  for (const data of chunks) {
+    if (!data) {
+      continue
+    }
+    pending.push(data)
+    const remainingBudget = Math.max(1, TERMINAL_OUTPUT_BATCH_MAX_BYTES - bytes)
+    const measurement = measure(data, { stopAfterBytes: remainingBudget })
+    bytes += measurement.byteLength
+    if (measurement.exceededLimit || bytes >= TERMINAL_OUTPUT_BATCH_MAX_BYTES) {
+      flush()
+    }
+  }
+  flush()
+  return flushes
+}
+
+describe('terminal output batcher flush boundaries are unchanged', () => {
+  it(
+    'produces identical flush boundaries over randomized multi-chunk runs',
+    { timeout: 60000 },
+    () => {
+      const random = mulberry32(0x1337)
+      for (let run = 0; run < 300; run += 1) {
+        const chunks: string[] = []
+        const chunkCount = 1 + Math.floor(random() * 40)
+        for (let index = 0; index < chunkCount; index += 1) {
+          // Sizes straddle the 64KiB batch cap so single chunks both fit and blow the budget.
+          // Sizes straddle the native-call floor too, so runs mix scan-branch and
+          // native-branch measurements inside one batcher's byte accounting.
+          const scale = random()
+          const maxUnits =
+            scale < 0.25
+              ? MIN_NATIVE_BYTE_LENGTH_CODE_UNITS * 2
+              : scale < 0.5
+                ? 64
+                : scale < 0.85
+                  ? 20000
+                  : 90000
+          chunks.push(random() < 0.5 ? randomString(random, maxUnits) : rawUtf16(random, maxUnits))
+        }
+        const legacyFlushes = simulateBatcherFlushes(chunks, legacyMeasure)
+        const actualFlushes = simulateBatcherFlushes(chunks, measureTerminalStreamByteLength)
+        if (legacyFlushes.length !== actualFlushes.length) {
+          throw new Error(`flush count diverged on run ${run}`)
+        }
+        for (let index = 0; index < legacyFlushes.length; index += 1) {
+          if (legacyFlushes[index] !== actualFlushes[index]) {
+            throw new Error(`flush ${index} diverged on run ${run}`)
+          }
+        }
+      }
+      expect(true).toBe(true)
+    }
+  )
+
+  it('exercises runs that actually cross the batch budget', () => {
+    const oversized = '\u{1f600}'.repeat(TERMINAL_OUTPUT_BATCH_MAX_BYTES)
+    const chunks = ['a'.repeat(10), oversized, 'b'.repeat(10), oversized, 'c']
+    const legacyFlushes = simulateBatcherFlushes(chunks, legacyMeasure)
+    expect(legacyFlushes.length).toBeGreaterThan(1)
+    expect(simulateBatcherFlushes(chunks, measureTerminalStreamByteLength)).toEqual(legacyFlushes)
+  })
+})
+
+// trimPendingOutputCoveredBySnapshot re-measures a sliced chunk with terminalStreamByteLength.
+// The RPC suites never reach that slice branch (a `data.length` mutant there survives on
+// unmodified HEAD too), so pin the byte accounting the branch depends on here.
+describe('resync trim byte accounting for a snapshot-sliced chunk', () => {
+  it('re-measures a sliced chunk in UTF-8 bytes, not UTF-16 code units', () => {
+    const data = '\u{1f600}é走a'
+    const sliced = data.slice(2)
+    expect(terminalStreamByteLength(sliced)).toBe(legacyByteLength(sliced))
+    // Guards the mutant: code-unit length would be 4 here, UTF-8 is 6.
+    expect(terminalStreamByteLength(sliced)).toBe(6)
+    expect(terminalStreamByteLength(sliced)).not.toBe(sliced.length)
+  })
+
+  it('matches the legacy byte length for every suffix slice of multi-byte terminal text', () => {
+    const random = mulberry32(0x51ced)
+    for (let iteration = 0; iteration < 2000; iteration += 1) {
+      const data = iteration % 2 === 0 ? randomString(random, 24) : rawUtf16(random, 24)
+      for (let offset = 0; offset <= data.length; offset += 1) {
+        const sliced = data.slice(offset)
+        if (terminalStreamByteLength(sliced) !== legacyByteLength(sliced)) {
+          throw new Error(`sliced byte length diverged for ${JSON.stringify(data)} at ${offset}`)
+        }
+      }
+    }
+    expect(true).toBe(true)
+  })
+})

--- a/src/main/runtime/rpc/terminal-stream-byte-length.ts
+++ b/src/main/runtime/rpc/terminal-stream-byte-length.ts
@@ -1,0 +1,56 @@
+import { measureClipboardTextByteLength } from '../../../shared/clipboard-text'
+
+export type TerminalStreamByteLengthMeasurement = {
+  byteLength: number
+  exceededLimit: boolean
+}
+
+// UTF-8 encodes a UTF-16 code unit in at most 3 bytes (BMP scalar, or U+FFFD for a lone
+// surrogate; a surrogate pair is 4 bytes across 2 units), and never in fewer than 1. So
+// `length <= byteLength <= 3 * length` bounds the byte count without touching the string.
+const MAX_UTF8_BYTES_PER_CODE_UNIT = 3
+
+// Buffer.byteLength's fixed call cost (~14ns) buys nothing until it replaces enough scan
+// iterations (~1.5ns each) to pay for itself; measured crossover is 8-12 code units. Below
+// this the native call is a REGRESSION on interactive keystroke-echo chunks, so keep the scan.
+export const MIN_NATIVE_BYTE_LENGTH_CODE_UNITS = 16
+
+export function terminalStreamByteLength(data: string): number {
+  if (data.length < MIN_NATIVE_BYTE_LENGTH_CODE_UNITS) {
+    return measureClipboardTextByteLength(data).byteLength
+  }
+  return Buffer.byteLength(data, 'utf8')
+}
+
+export function terminalStreamByteLengthExceeds(data: string, maxBytes: number): boolean {
+  if (data.length === 0 || !Number.isFinite(maxBytes)) {
+    return false
+  }
+  // Sound: UTF-8 is never shorter than UTF-16 code-unit count, so this needs no scan at all.
+  if (data.length > maxBytes) {
+    return true
+  }
+  if (data.length < MIN_NATIVE_BYTE_LENGTH_CODE_UNITS) {
+    return measureClipboardTextByteLength(data, { stopAfterBytes: maxBytes }).exceededLimit
+  }
+  return Buffer.byteLength(data, 'utf8') > maxBytes
+}
+
+export function measureTerminalStreamByteLength(
+  data: string,
+  options: { stopAfterBytes?: number } = {}
+): TerminalStreamByteLengthMeasurement {
+  const stopAfterBytes = options.stopAfterBytes
+  if (!Number.isFinite(stopAfterBytes)) {
+    return { byteLength: terminalStreamByteLength(data), exceededLimit: false }
+  }
+  // Why: over the limit the callers keep the scan's TRUNCATED running total, so only take the
+  // native count when the upper bound proves it can't trip the limit — otherwise both would run.
+  if (
+    data.length >= MIN_NATIVE_BYTE_LENGTH_CODE_UNITS &&
+    data.length * MAX_UTF8_BYTES_PER_CODE_UNIT <= (stopAfterBytes as number)
+  ) {
+    return { byteLength: Buffer.byteLength(data, 'utf8'), exceededLimit: false }
+  }
+  return measureClipboardTextByteLength(data, options)
+}


### PR DESCRIPTION
> **Stacked on [#10915](https://github.com/stablyai/orca/pull/10915)** — review that one first; this branch contains both commits.

## Description

The terminal RPC path counted UTF-8 bytes with a hand-rolled per-code-point scan. `Buffer.byteLength` does the same job natively, roughly an order of magnitude faster per byte.

The change goes through a small dedicated module rather than swapping the shared `measureClipboardTextByteLength`, which has ~50 renderer call sites and a **partial-count contract** on the over-limit path that must not change.

## ELI5

To decide when a terminal message is too big to send in one piece, the app counted its bytes by hand, one character at a time. Node can count them natively, far faster.

The catch: making that native call has a small fixed cost. For a 1-character keystroke echo, paying it costs *more* than just counting by hand. So short inputs keep the old counting loop and only larger ones go native.

## Proof of perf improvement

`config/scripts/terminal-stream-byte-length-benchmark.mjs` (new). Arms interleaved with alternating lead over 122 counterbalanced batches, per-arm medians, results consumed inside the timed region, outputs compared for equality before timing:

| scenario | legacy | new | speedup |
|---|---|---|---|
| batcher push 8 KiB | 19.3 µs | 4.4 µs | **4.41×** |
| batcher push over budget | 155.2 µs | 155.3 µs | 1.00× |
| batcher push 16 B (at floor) | 41.7 ns | 23.5 ns | **1.77×** |
| batcher push 4 B keystroke | 11.7 ns | 10.5 ns | 1.12× |
| snapshot scan 2 MiB | 4019.7 µs | 966.6 µs | **4.16×** |
| snapshot gate early-trip | 1410.4 µs | 1060.1 µs | **1.33×** |
| chunk gate early-trip | 32.9 µs | 26.2 µs | **1.26×** |
| chunk gate 48 KiB | 94.4 µs | 23.7 µs | **3.98×** |

Small-chunk sweep: 4 B **1.07×**, 8 B 1.09×, 16 B 1.59×, 64 B 4.26×, 256 B 9.34×, 1 KiB 12.11×, 4 KiB 13.86×. **No row below 1.0.**

## The floor is load-bearing, and finding out why is the story here

The first version of this change had **no floor** and a benchmark scenario labelled *"WORST CASE for the new arm — if the new arm ever loses, it loses here"*, reporting a reassuring 1.00×.

That scenario was **vacuous**. Its fixture was 32,776 code units against a 65,536-byte limit, so the guard `length * 3 <= stopAfterBytes` (98,328 ≤ 65,536) was false and the fast path never ran. Both arms executed byte-identical code. The 1.00× was a tautology — and it had *replaced* a previously-measured real 0.78× regression, which it appeared to explain away.

Digging in produced two findings:

1. **The claimed "double work" regression is unreachable by construction.** The guard is a *proof* that the limit cannot trip, so `measure` can never pay for both a native call and a fallback scan. No fixture could have measured it.
2. **The real regression was elsewhere and much worse.** At 1–4 code units the unfloored version ran at **0.20–0.62× — a 5× slowdown on keystroke echo**, the most latency-sensitive PTY shape there is. `Buffer.byteLength`'s ~14 ns fixed call cost against a scan that finishes in ~3 ns.

I verified the crossover independently rather than trusting the reported number — interleaved, alternating lead, across a size sweep:

| code units | native ÷ scan |
|---|---|
| 1 | **4.24× slower** |
| 4 | 2.51× slower |
| 8 | 1.43× slower |
| 12 | 1.11× slower |
| 16 | 0.65× (native wins) |
| 64 | 0.21× |

`MIN_NATIVE_BYTE_LENGTH_CODE_UNITS = 16` sits above the measured 8–12 crossover with deliberate margin. Below it both functions keep the legacy scan **verbatim**, so those rows are byte-identical code and ~1.0× is the correct result, not a win.

Caveat worth recording: the constant is tuned on Apple M4 Max / Node 24. The crossover is call-overhead-dominated, so it should hold in shape but not exact value on other hosts — which is why 16 carries margin rather than sitting at 12.

## Proof of zero regression

- **`exceededLimit` semantics preserved.** The over-limit path returns the scan's *truncated* running total; the native count is taken only when the `length * 3 <= stopAfterBytes` bound proves the limit cannot trip, so the truncated total is never replaced. A randomized 300-run multi-chunk test shows identical flush boundaries, with sizes straddling the floor so both branches mix within one batcher.
- **I verified equivalence independently** rather than relying on the supplied tests: `byteLength`, `exceededLimit`, and both fields of `measure` compared against the legacy scan across 6 alphabets (ASCII, 2-byte, 3-byte, astral, both lone-surrogate extremes) × 10 lengths × 6 limits. All match.
- **The `assertExercised` guard is now a live branch counter** asserted on every sample, not an input-size check. Re-injecting the old vacuous fixture makes it fail with `expected the nativeFastPath branch to run exactly once, got {"nativeFastPath":0,"scanFallback":1}`. The run reports `branches={"nativeFastPath":3327428,"scanFallback":2998516}` — both paths demonstrably executed.
- **Mutation testing**: all 4 correctness-load-bearing mutants die (drop the `*3` bound → 2 failures; naive native full-count → 3; `>` → `>=` → 2; code-units-for-bytes → 5). The two floor branches are pure perf and correctly survive — they're unobservable by design, and I'm not counting them as kills.
- `src/main/runtime/rpc/`: **81 files, 802 tests** passing. `pnpm typecheck` clean, oxfmt/oxlint clean.

Because #10915 removed the per-code-point frame loop, `terminalStreamCodePointByteLength` and its benchmark arm became dead on this stacked branch and are deleted rather than shipped unused. The benchmark's staleness guard caught that itself — it failed with `expected call form terminalStreamCodePointByteLength(part) was not found`, which is the guard doing its job.

## Review loop count + verdict

3 loops. Round 1 shipped without a floor and with the vacuous worst-case scenario. Round 2 (adversarial) identified the vacuity. Round 3 found the real 5× keystroke regression it was masking, added the floor, and rebuilt the guard as a branch counter.

**Verdict: ship.** Every production shape measures ≥1.0×, the adversarial shapes are wins, and the one shape that would have regressed is now byte-identical to before.

Made with [Orca](https://github.com/stablyai/orca) 🐋
