### PR TITLE
perf(cli): construct the runtime client only when a command needs it

### DIFF
--- a/config/scripts/cli-runtime-client-deferral-benchmark.mjs
+++ b/config/scripts/cli-runtime-client-deferral-benchmark.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// Benchmark: CLI process startup with the RuntimeClient module graph deferred.
+//
+// src/cli/index.ts used to value-import RuntimeClient at module scope, and five
+// modules that load on every invocation (args, flags, dispatch, format,
+// selectors) pulled RuntimeClientError from the ./runtime-client barrel. Either
+// edge alone drags in the whole client graph: zod (via shared/pairing ->
+// shared/mobile-relay-pairing-offer), ws + tweetnacl (via websocket-transport),
+// plus the environment store and secure-file stack.
+//
+// The fix repoints those five at ./runtime/types (zero children) and loads the
+// client through `await import()` after flag validation, so --help, `help
+// <cmd>` and every command/flag error return without ever touching it.
+//
+// Both arms are REAL tsc emits of real source: the baseline arm restores the
+// seven touched files from a git rev and compiles that. Each sample is a FRESH
+// process (module-graph cost is a once-per-process cost; timing it in-process
+// would measure a warm require cache).
+//
+// Arms alternate lead across an even number of rounds and report per-arm
+// medians. Byte-for-byte output equality is checked BEFORE timing.
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { fileURLToPath } from 'node:url'
+
+const REPO = fileURLToPath(new URL('../..', import.meta.url))
+
+const ROUNDS = Number(process.env.ORCA_CLI_DEFER_BENCH_ROUNDS ?? '30')
+const WARMUP = Number(process.env.ORCA_CLI_DEFER_BENCH_WARMUP ?? '3')
+
+for (const [name, value] of [
+  ['ORCA_CLI_DEFER_BENCH_ROUNDS', ROUNDS],
+  ['ORCA_CLI_DEFER_BENCH_WARMUP', WARMUP]
+]) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, received ${value}`)
+  }
+}
+if (ROUNDS % 2 !== 0) {
+  // Why: arms alternate which one leads; an odd count biases one arm.
+  throw new Error(`ORCA_CLI_DEFER_BENCH_ROUNDS must be even, received ${ROUNDS}`)
+}
+
+const TOUCHED = [
+  'src/cli/args.ts',
+  'src/cli/dispatch.ts',
+  'src/cli/flags.ts',
+  'src/cli/format.ts',
+  'src/cli/index.ts',
+  'src/cli/runtime/client.ts',
+  'src/cli/selectors.ts'
+]
+
+// Why: if the deferral is reverted or reshaped, both arms would compile to the
+// same thing and this would quietly report 1.00x forever. Re-read the real call
+// forms out of the source. Matching the CALL form (not a bare identifier) so a
+// comment that merely names the function cannot satisfy the check.
+function assertMarkersFresh() {
+  const checks = [
+    ['src/cli/index.ts', "await import('./runtime-client.js')"],
+    ['src/cli/index.ts', 'await loadRuntimeClientClass()'],
+    ['src/cli/index.ts', "import type { RuntimeClient } from './runtime-client'"],
+    ['src/cli/runtime/client.ts', "await import('./websocket-transport.js')"],
+    ['src/cli/runtime/client.ts', 'await loadSendWebSocketRequest()'],
+    ['src/cli/args.ts', "import { RuntimeClientError } from './runtime/types'"],
+    ['src/cli/flags.ts', "import { RuntimeClientError } from './runtime/types'"],
+    ['src/cli/dispatch.ts', "import { RuntimeClientError } from './runtime/types'"],
+    ['src/cli/selectors.ts', "import { RuntimeClientError } from './runtime/types'"],
+    ['src/cli/format.ts', "} from './runtime/types'"]
+  ]
+  for (const [file, marker] of checks) {
+    if (!readFileSync(join(REPO, file), 'utf8').includes(marker)) {
+      throw new Error(
+        `${file} no longer contains \`${marker}\` — cli-runtime-client-deferral-benchmark.mjs is stale`
+      )
+    }
+  }
+}
+
+function buildArm(label, baselineRev) {
+  // Why: a build under /tmp cannot resolve the repo's node_modules, so the
+  // output has to live inside the repo.
+  const outDir = join(REPO, `.bench-out-${label}`)
+  rmSync(outDir, { recursive: true, force: true })
+  const restore = []
+  try {
+    if (baselineRev) {
+      for (const file of TOUCHED) {
+        const path = join(REPO, file)
+        restore.push([path, readFileSync(path)])
+        writeFileSync(
+          path,
+          execFileSync('git', ['show', `${baselineRev}:${file}`], {
+            cwd: REPO,
+            maxBuffer: 64 * 1024 * 1024
+          })
+        )
+      }
+    }
+    execFileSync(
+      'npx',
+      [
+        'tsc',
+        '-p',
+        'config/tsconfig.cli.json',
+        '--outDir',
+        outDir,
+        '--composite',
+        'false',
+        '--incremental',
+        'false'
+      ],
+      { cwd: REPO, stdio: 'inherit' }
+    )
+  } finally {
+    for (const [path, contents] of restore) {
+      writeFileSync(path, contents)
+    }
+  }
+  return join(outDir, 'cli/index.js')
+}
+
+function run(entry, argv, env) {
+  const result = spawnSync(process.execPath, [entry, ...argv], {
+    cwd: REPO,
+    env: { ...process.env, ...env },
+    encoding: 'buffer'
+  })
+  if (result.error) {
+    throw result.error
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout.toString('utf8'),
+    stderr: result.stderr.toString('utf8')
+  }
+}
+
+// Counts the eager CommonJS module graph of a built entry point by hooking
+// Module._load in a child process. This is the quantity the change moves.
+function countEagerModules(entry) {
+  const probe = `
+    const Module = require('module')
+    const original = Module._load
+    const seen = new Set()
+    Module._load = function (request, parent, isMain) {
+      try { seen.add(Module._resolveFilename(request, parent, isMain)) } catch { seen.add(request) }
+      return original.apply(this, arguments)
+    }
+    require(${JSON.stringify(entry)})
+    const all = [...seen]
+    process.stdout.write(JSON.stringify({
+      total: all.length,
+      nodeModules: all.filter((p) => p.includes('node_modules')).length
+    }))
+  `
+  const result = spawnSync(process.execPath, ['-e', probe], { cwd: REPO, encoding: 'utf8' })
+  if (result.status !== 0) {
+    throw new Error(`module probe failed: ${result.stderr}`)
+  }
+  return JSON.parse(result.stdout)
+}
+
+const median = (values) => {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]
+}
+
+const baselineIndex = process.argv.indexOf('--baseline')
+const baselineRev = baselineIndex === -1 ? 'HEAD' : process.argv[baselineIndex + 1]
+
+assertMarkersFresh()
+
+const userDataPath = mkdtempSync(join(REPO, '.bench-userdata-'))
+
+try {
+  console.log(`Building eager baseline (${baselineRev}) …`)
+  const eagerEntry = buildArm('eager', baselineRev)
+  console.log('Building deferred (working tree) …')
+  const deferredEntry = buildArm('deferred', null)
+
+  const eagerGraph = countEagerModules(eagerEntry)
+  const deferredGraph = countEagerModules(deferredEntry)
+  console.log(
+    `\nEager modules at process load: ${eagerGraph.total} -> ${deferredGraph.total} ` +
+      `(node_modules ${eagerGraph.nodeModules} -> ${deferredGraph.nodeModules})`
+  )
+  if (deferredGraph.total >= eagerGraph.total) {
+    throw new Error(
+      'deferred arm loads no fewer modules — the fixture does not exercise the change'
+    )
+  }
+
+  // Each case is (label, argv, env). The runtime-dependent ones point at an
+  // empty user-data dir so both arms get the same deterministic answer.
+  const isolated = { ORCA_USER_DATA_PATH: userDataPath }
+  const cases = [
+    ['orca --help', ['--help'], {}],
+    ['orca help worktree', ['help', 'worktree'], {}],
+    ['orca (no args)', [], {}],
+    ['unknown command', ['no-such-command'], {}],
+    ['unknown flag', ['worktree', 'list', '--nope'], {}],
+    ['orca agent-context --json', ['agent-context', '--json'], {}],
+    ['orca status --json', ['status', '--json'], isolated],
+    ['orca worktree list --json', ['worktree', 'list', '--json'], isolated]
+  ]
+
+  // Why: a semantically broken arm that prints nothing would look fastest.
+  // Compare bytes and exit codes BEFORE timing anything.
+  for (const [label, argv, env] of cases) {
+    const before = run(eagerEntry, argv, env)
+    const after = run(deferredEntry, argv, env)
+    if (
+      before.status !== after.status ||
+      before.stdout !== after.stdout ||
+      before.stderr !== after.stderr
+    ) {
+      throw new Error(`arms disagree for "${label}" — refusing to report a timing`)
+    }
+    if (before.stdout.length + before.stderr.length === 0) {
+      throw new Error(`"${label}" produced no output on either arm; it proves nothing`)
+    }
+  }
+
+  const pad = (value, width) => String(value).padStart(width)
+  console.log('\nFresh process per sample, wall clock. Lower is better.')
+  console.log(`rounds=${ROUNDS} warmup=${WARMUP} (per-arm median, arms alternate lead)`)
+  console.log(`${pad('case', 26)} ${pad('eager', 10)} ${pad('deferred', 10)} ${pad('speedup', 9)}`)
+
+  // Accumulated so V8 cannot treat the spawn loop as dead code.
+  let consumed = 0
+
+  for (const [label, argv, env] of cases) {
+    for (let index = 0; index < WARMUP; index += 1) {
+      consumed += run(eagerEntry, argv, env).stdout.length
+      consumed += run(deferredEntry, argv, env).stdout.length
+    }
+    const samples = { eager: [], deferred: [] }
+    for (let round = 0; round < ROUNDS; round += 1) {
+      // Alternate which arm leads so a drifting machine load cannot be
+      // attributed to one arm.
+      const order =
+        round % 2 === 0
+          ? [
+              ['eager', eagerEntry],
+              ['deferred', deferredEntry]
+            ]
+          : [
+              ['deferred', deferredEntry],
+              ['eager', eagerEntry]
+            ]
+      for (const [arm, entry] of order) {
+        const started = performance.now()
+        const result = run(entry, argv, env)
+        samples[arm].push(performance.now() - started)
+        consumed += result.stdout.length
+      }
+    }
+    const eagerMs = median(samples.eager)
+    const deferredMs = median(samples.deferred)
+    console.log(
+      `${pad(label, 26)} ${pad(`${eagerMs.toFixed(1)} ms`, 10)} ${pad(`${deferredMs.toFixed(1)} ms`, 10)} ${pad(`${(eagerMs / deferredMs).toFixed(2)}x`, 9)}`
+    )
+  }
+
+  if (consumed === 0) {
+    throw new Error('no output consumed — the timing loop was optimised away')
+  }
+  console.log(
+    '\nThe help and error rows are the ones the change targets: they return\n' +
+      'before any client construction, so they drop the whole graph. `status` and\n' +
+      '`worktree list` still construct a client, so they only save the eager parse\n' +
+      'of the parts the local path never uses (ws/tweetnacl via websocket-transport).'
+  )
+} finally {
+  rmSync(userDataPath, { recursive: true, force: true })
+  for (const label of ['eager', 'deferred']) {
+    rmSync(join(REPO, `.bench-out-${label}`), { recursive: true, force: true })
+  }
+}

--- a/config/scripts/cli-runtime-client-deferral-equivalence.mjs
+++ b/config/scripts/cli-runtime-client-deferral-equivalence.mjs
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+// Equivalence check for deferring the RuntimeClient module graph in the CLI.
+//
+// Builds the CLI twice with the REAL tsc emit — once from the working tree and
+// once with the seven touched files restored from git HEAD~ (the pre-deferral
+// implementation) — then compares stdout, stderr and exit code BYTE FOR BYTE
+// across a matrix of invocations.
+//
+// Why a script and not a vitest case: this compiles two full CLI trees. It is
+// the artifact that proves the refactor is behaviour-preserving; the fast
+// invariants (class identity, no eager barrel import) live in
+// src/cli/runtime-client-deferral.test.ts and run in the normal suite.
+//
+// Usage: node config/scripts/cli-runtime-client-deferral-equivalence.mjs [--baseline <rev>]
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO = fileURLToPath(new URL('../..', import.meta.url))
+
+// The files this change touches. Restoring exactly these from the baseline rev
+// reconstructs the old implementation without disturbing anything else.
+const TOUCHED = [
+  'src/cli/args.ts',
+  'src/cli/dispatch.ts',
+  'src/cli/flags.ts',
+  'src/cli/format.ts',
+  'src/cli/index.ts',
+  'src/cli/runtime/client.ts',
+  'src/cli/selectors.ts'
+]
+
+// Why: if the deferral is ever reverted or reshaped, the "old" arm would
+// silently become identical to the new one and every case would pass
+// vacuously. Re-read the real call form out of the source and fail loudly.
+function assertMarkersFresh() {
+  const index = readFileSync(join(REPO, 'src/cli/index.ts'), 'utf8')
+  const client = readFileSync(join(REPO, 'src/cli/runtime/client.ts'), 'utf8')
+  const checks = [
+    ['src/cli/index.ts', index, 'await loadRuntimeClientClass()'],
+    ['src/cli/index.ts', index, "await import('./runtime-client.js')"],
+    ['src/cli/index.ts', index, "import type { RuntimeClient } from './runtime-client'"],
+    ['src/cli/runtime/client.ts', client, 'await loadSendWebSocketRequest()'],
+    ['src/cli/runtime/client.ts', client, "await import('./websocket-transport.js')"]
+  ]
+  for (const [file, source, marker] of checks) {
+    // Match the call form, not a bare word: a comment naming the function must
+    // not satisfy the check.
+    if (!source.includes(marker)) {
+      throw new Error(
+        `${file} no longer contains \`${marker}\` — cli-runtime-client-deferral-equivalence.mjs is stale`
+      )
+    }
+  }
+  const repointed = ['src/cli/args.ts', 'src/cli/flags.ts', 'src/cli/dispatch.ts']
+  for (const file of repointed) {
+    const source = readFileSync(join(REPO, file), 'utf8')
+    if (!source.includes("import { RuntimeClientError } from './runtime/types'")) {
+      throw new Error(`${file} no longer repoints RuntimeClientError at ./runtime/types — stale`)
+    }
+  }
+}
+
+function buildTree(label, baselineRev) {
+  // Why: builds under /tmp cannot resolve the repo's node_modules, so the
+  // output dir has to live inside the repo.
+  const outDir = join(REPO, `.equiv-out-${label}`)
+  rmSync(outDir, { recursive: true, force: true })
+  const restored = []
+  try {
+    if (baselineRev) {
+      for (const file of TOUCHED) {
+        const path = join(REPO, file)
+        restored.push([path, readFileSync(path)])
+        const old = execFileSync('git', ['show', `${baselineRev}:${file}`], {
+          cwd: REPO,
+          maxBuffer: 64 * 1024 * 1024
+        })
+        writeFileSync(path, old)
+      }
+    }
+    execFileSync(
+      'npx',
+      [
+        'tsc',
+        '-p',
+        'config/tsconfig.cli.json',
+        '--outDir',
+        outDir,
+        '--composite',
+        'false',
+        '--incremental',
+        'false'
+      ],
+      { cwd: REPO, stdio: 'inherit' }
+    )
+  } finally {
+    for (const [path, contents] of restored) {
+      writeFileSync(path, contents)
+    }
+  }
+  return join(outDir, 'cli/index.js')
+}
+
+// Why: every case is a one-shot CLI invocation that must exit on its own. An
+// unbounded spawnSync turns "this argv reached a blocking command" into an
+// indefinite stall — a guard that can hang instead of failing is not a guard.
+const RUN_TIMEOUT_MS = 30_000
+
+function run(entry, argv, env) {
+  const result = spawnSync(process.execPath, [entry, ...argv], {
+    cwd: REPO,
+    env: { ...process.env, ...env },
+    encoding: 'buffer',
+    timeout: RUN_TIMEOUT_MS,
+    killSignal: 'SIGKILL'
+  })
+  if (result.error) {
+    if (result.error.code === 'ETIMEDOUT') {
+      throw new Error(
+        `orca ${argv.join(' ')} did not exit within ${RUN_TIMEOUT_MS} ms — it reached a blocking command`
+      )
+    }
+    throw result.error
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout.toString('utf8'),
+    stderr: result.stderr.toString('utf8')
+  }
+}
+
+// Every case must produce identical bytes on both arms. The runtime-dependent
+// ones (status/worktree list) are pointed at an empty user-data dir so the
+// answer is deterministic "not running" rather than whatever the dev machine
+// happens to be doing.
+function buildCases(isolatedUserData) {
+  const isolated = { ORCA_USER_DATA_PATH: isolatedUserData }
+  const cases = [
+    // Paths that must never load the runtime client at all.
+    [[], {}],
+    [['--help'], {}],
+    [['help'], {}],
+    [['help', 'worktree'], {}],
+    [['help', 'browser'], {}],
+    [['worktree', '--help'], {}],
+    [['help', 'no-such-command'], {}],
+    [['no-such-command'], {}],
+    [['no-such-command'], { ORCA_PAIRING_CODE: 'garbage' }],
+    [['wrktree', 'list'], {}],
+    [['agent-context'], {}],
+    [['agent-context', '--json'], {}],
+    // Flag validation must still fire before any runtime lookup.
+    [['worktree', 'list', '--nonexistent-flag'], {}],
+    [['worktree', 'list', '--nonexistent-flag', '--json'], {}],
+    [['browser', 'snapshot', '--nonexistent-flag'], {}],
+    // resolveRemotePairing throws from the RuntimeClient CONSTRUCTOR.
+    [['status', '--pairing-code', 'x', '--environment', 'y'], isolated],
+    [['status', '--pairing-code', 'x', '--environment', 'y', '--json'], isolated],
+    [['status', '--pairing-code', 'not-a-pairing-code'], isolated],
+    [['status', '--pairing-code', 'not-a-pairing-code', '--json'], isolated],
+    [['status', '--pairing-code', 'orca://pair?code=zzzz'], isolated],
+    [['status', '--environment', 'no-such-environment'], isolated],
+    [['status', '--environment', 'no-such-environment', '--json'], isolated],
+    [['worktree', 'list', '--environment', 'no-such-environment', '--json'], isolated],
+    // The env-var fallback must stay live for non-suppressed commands...
+    [['status', '--json'], { ...isolated, ORCA_PAIRING_CODE: 'not-a-pairing-code' }],
+    [['status', '--json'], { ...isolated, ORCA_REMOTE_PAIRING: 'not-a-pairing-code' }],
+    [['status', '--json'], { ...isolated, ORCA_ENVIRONMENT: 'no-such-environment' }],
+    // ...and must stay suppressed for the local-only command groups.
+    //
+    // NOTE: the only commands that both live in a suppressed group AND touch
+    // ctx.client are `agent hooks on|off`, which rewrite the user's real agent
+    // hook configuration in ~/.claude and friends — far outside
+    // ORCA_USER_DATA_PATH. They are deliberately NOT invoked here. The
+    // null-vs-undefined suppression they would exercise is covered
+    // side-effect-free by the constructor-argument assertions in
+    // src/cli/runtime-client-deferral.test.ts instead.
+    [['environment', 'list', '--json'], { ...isolated, ORCA_ENVIRONMENT: 'no-such-environment' }],
+    [['environment', 'list', '--json'], { ...isolated, ORCA_PAIRING_CODE: 'not-a-pairing-code' }],
+    [['agent-context', '--json'], { ...isolated, ORCA_PAIRING_CODE: 'not-a-pairing-code' }],
+    // Runtime-unavailable reporting (RuntimeClientError formatting).
+    [['status'], isolated],
+    [['status', '--json'], isolated],
+    [['worktree', 'list', '--json'], isolated],
+    [['terminal', 'list', '--json'], isolated]
+  ]
+  // Fuzz: random argv drawn from real command tokens, flags and hostile
+  // strings. Seeded so a failure is reproducible. Every token here must be
+  // safe to actually execute — see UNSAFE_TOKENS, which is cross-checked
+  // against this list before a single case runs.
+  const tokens = [
+    'worktree',
+    'list',
+    'status',
+    'browser',
+    'snapshot',
+    'terminal',
+    'environment',
+    'agent',
+    'agent-context',
+    'vm',
+    '--json',
+    '--help',
+    '--pairing-code',
+    '--environment',
+    '--worktree',
+    'orca://pair?code=!!!',
+    '',
+    '-',
+    '--',
+    '--=',
+    'a'.repeat(300),
+    'näme-ünicode',
+    '💥',
+    '../..',
+    'x\ty'
+  ]
+  let seed = 0x9e3779b9
+  const next = () => {
+    seed ^= seed << 13
+    seed ^= seed >>> 17
+    seed ^= seed << 5
+    return (seed >>> 0) / 0x100000000
+  }
+  // Why: check the draw POOL, not just the 400 cases it happens to produce.
+  // `serve` sat in this array for the whole review because the per-case scan
+  // never named it, and the cases that drew it only survived by accident.
+  assertTokensSafe(tokens, 'fuzz token pool')
+  assertFuzzPoolDeclaredReadOnly(tokens)
+  for (let index = 0; index < 400; index += 1) {
+    const length = 1 + Math.floor(next() * 4)
+    const argv = []
+    for (let part = 0; part < length; part += 1) {
+      argv.push(tokens[Math.floor(next() * tokens.length)])
+    }
+    cases.push([argv, isolated])
+  }
+  for (const [argv] of cases) {
+    assertTokensSafe(argv, `argv ${JSON.stringify(argv)}`)
+  }
+  return cases
+}
+
+// Why: this script shells out to the REAL CLI with the developer's own HOME and
+// PATH, so an argv that reaches the wrong verb does real damage. Two classes:
+//
+//   1. FOREGROUND — `orca serve` runs Orca until Ctrl+C and `orca open` /
+//      `claude-teams` spawn processes that outlive the case. A blocking case
+//      does not fail the run, it stalls it, which is worse than a mismatch.
+//   2. MUTATING — writes outside ORCA_USER_DATA_PATH (`agent hooks off` parks
+//      the real ~/.claude hooks) or drives real browser/desktop input.
+//
+// Group tokens whose subcommands split read/write (`capture`, `intercept`,
+// `label`, `relation`) are denied wholesale: the fuzzer cannot tell them apart.
+const FOREGROUND_TOKENS = ['serve', 'open', 'claude-teams', 'exec', 'eval', 'launch', 'attach']
+const MUTATING_TOKENS = [
+  // persistent config and registry state
+  'on',
+  'off',
+  'hooks',
+  'create',
+  'remove',
+  'rm',
+  'delete',
+  'add',
+  'edit',
+  'set',
+  'set-value',
+  'set-base-ref',
+  'setup-clone',
+  'setup-create',
+  'setup-update',
+  'setup-delete',
+  'setup-existing-folder',
+  'install',
+  'uninstall',
+  'reinstall',
+  'update',
+  'clone',
+  'apply',
+  'write',
+  'reset',
+  'clear',
+  'enable',
+  'disable',
+  'use-default',
+  'permissions',
+  // process and pane lifecycle
+  'run',
+  'run-stop',
+  'start',
+  'stop',
+  'kill',
+  'shutdown',
+  'close',
+  'split',
+  'switch',
+  'rename',
+  'focus',
+  // orchestration writes
+  'send',
+  'reply',
+  'dispatch',
+  'task-create',
+  'task-update',
+  'gate-create',
+  'gate-resolve',
+  // issue-tracker writes
+  'save-issue',
+  'comment',
+  'label',
+  'relation',
+  'assignee',
+  'priority',
+  'estimate',
+  'due-date',
+  // browser / computer / emulator input and navigation
+  'goto',
+  'back',
+  'forward',
+  'reload',
+  'click',
+  'dblclick',
+  'hover',
+  'fill',
+  'type',
+  'type-text',
+  'select',
+  'select-all',
+  'uncheck',
+  'keypress',
+  'press-key',
+  'inserttext',
+  'hotkey',
+  'paste-text',
+  'perform-secondary-action',
+  'drag',
+  'scroll',
+  'scrollintoview',
+  'wheel',
+  'move',
+  'up',
+  'down',
+  'tap',
+  'gesture',
+  'button',
+  'rotate',
+  'upload',
+  'download',
+  'dismiss',
+  'accept',
+  'highlight',
+  'viewport',
+  'geolocation',
+  'headers',
+  'credentials',
+  'offline',
+  'media',
+  'device',
+  'capture',
+  'intercept'
+]
+
+const UNSAFE_TOKENS = new Map([
+  ...FOREGROUND_TOKENS.map((token) => [token, 'runs in the foreground or spawns a process']),
+  ...MUTATING_TOKENS.map((token) => [token, 'can write outside ORCA_USER_DATA_PATH'])
+])
+
+// Why: the deny list only catches verbs someone already thought of — `serve`
+// sat in the fuzz pool for the whole review because nobody added it. The pool
+// is therefore ALSO checked against this allowlist, so a token added to the
+// pool fails closed until it is consciously declared read-only here.
+const READ_ONLY_FUZZ_TOKENS = new Set([
+  // command tokens: every path they can form is a list/show or a parse error
+  'agent',
+  'agent-context',
+  'browser',
+  'environment',
+  'list',
+  'snapshot',
+  'status',
+  'terminal',
+  'vm',
+  'worktree',
+  // global flags and hostile strings, which reach no handler at all
+  '--json',
+  '--help',
+  '--pairing-code',
+  '--environment',
+  '--worktree',
+  'orca://pair?code=!!!',
+  '',
+  '-',
+  '--',
+  '--=',
+  'a'.repeat(300),
+  'näme-ünicode',
+  '💥',
+  '../..',
+  'x\ty'
+])
+
+function assertTokensSafe(tokens, context) {
+  for (const token of tokens) {
+    const reason = UNSAFE_TOKENS.get(token)
+    if (reason) {
+      throw new Error(`Refusing to run ${context}: "${token}" ${reason}`)
+    }
+  }
+}
+
+// Why: a token on neither list (or, worse, on both) means the two lists have
+// drifted apart. Fail before any case runs rather than sampling and hoping.
+function assertFuzzPoolDeclaredReadOnly(tokens) {
+  for (const token of tokens) {
+    if (!READ_ONLY_FUZZ_TOKENS.has(token)) {
+      throw new Error(
+        `Fuzz token ${JSON.stringify(token)} is not declared in READ_ONLY_FUZZ_TOKENS — declare it read-only or drop it`
+      )
+    }
+  }
+  for (const token of READ_ONLY_FUZZ_TOKENS) {
+    if (UNSAFE_TOKENS.has(token)) {
+      throw new Error(
+        `Token ${JSON.stringify(token)} is declared both read-only and unsafe — the two lists disagree`
+      )
+    }
+  }
+}
+
+const baselineIndex = process.argv.indexOf('--baseline')
+const baselineRev = baselineIndex === -1 ? 'HEAD' : process.argv[baselineIndex + 1]
+
+assertMarkersFresh()
+
+const isolatedUserData = mkdtempSync(join(REPO, '.equiv-userdata-'))
+mkdirSync(join(isolatedUserData, 'empty'), { recursive: true })
+
+let oldEntry
+let newEntry
+try {
+  // Why: build the case list (and run its safety guards) BEFORE the two tsc
+  // compiles, so an unsafe token fails in a second instead of two minutes in.
+  const cases = buildCases(isolatedUserData)
+
+  console.log(`Building baseline (${baselineRev}) …`)
+  oldEntry = buildTree('old', baselineRev)
+  console.log('Building working tree …')
+  newEntry = buildTree('new', null)
+
+  console.log(`Comparing ${cases.length} invocations byte for byte …`)
+  let mismatches = 0
+  for (const [argv, env] of cases) {
+    const before = run(oldEntry, argv, env)
+    const after = run(newEntry, argv, env)
+    if (
+      before.status !== after.status ||
+      before.stdout !== after.stdout ||
+      before.stderr !== after.stderr
+    ) {
+      mismatches += 1
+      console.error(`\nMISMATCH argv=${JSON.stringify(argv)} env=${JSON.stringify(env)}`)
+      console.error(`  exit   before=${before.status} after=${after.status}`)
+      if (before.stdout !== after.stdout) {
+        console.error(`  stdout before=${JSON.stringify(before.stdout.slice(0, 400))}`)
+        console.error(`         after =${JSON.stringify(after.stdout.slice(0, 400))}`)
+      }
+      if (before.stderr !== after.stderr) {
+        console.error(`  stderr before=${JSON.stringify(before.stderr.slice(0, 400))}`)
+        console.error(`         after =${JSON.stringify(after.stderr.slice(0, 400))}`)
+      }
+    }
+  }
+  if (mismatches > 0) {
+    throw new Error(`${mismatches} of ${cases.length} invocations differ`)
+  }
+  console.log(`\nAll ${cases.length} invocations byte-identical (stdout, stderr, exit code).`)
+} finally {
+  rmSync(isolatedUserData, { recursive: true, force: true })
+  for (const label of ['old', 'new']) {
+    rmSync(resolve(REPO, `.equiv-out-${label}`), { recursive: true, force: true })
+  }
+}

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,4 +1,4 @@
-import { RuntimeClientError } from './runtime-client'
+import { RuntimeClientError } from './runtime/types'
 import { unknownCommandData, unknownFlagData } from './command-suggestion'
 
 export type ParsedArgs = {

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,5 +1,5 @@
 import type { RuntimeClient } from './runtime-client'
-import { RuntimeClientError } from './runtime-client'
+import { RuntimeClientError } from './runtime/types'
 import { HANDLER_GROUPS, type HandlerGroup } from './handler-group-manifest'
 
 export type HandlerContext = {

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -1,4 +1,4 @@
-import { RuntimeClientError } from './runtime-client'
+import { RuntimeClientError } from './runtime/types'
 import { REPEATED_FLAG_SEPARATOR } from './args'
 
 export function getRequiredStringFlag(flags: Map<string, string | boolean>, name: string): string {

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -2,7 +2,7 @@ import type { CliStatusResult } from '../shared/runtime-types'
 import { computerUseErrorRecoveryData } from '../shared/computer-use-error-recovery'
 import { prepareComputerCliJsonResult } from './computer-format'
 import type { RuntimeRpcFailure, RuntimeRpcSuccess } from './runtime-client'
-import { RuntimeClientError, RuntimeRpcFailureError } from './runtime-client'
+import { RuntimeClientError, RuntimeRpcFailureError } from './runtime/types'
 
 export {
   formatBrowserProfileList,

--- a/src/cli/handlers/computer-action-validation.test.ts
+++ b/src/cli/handlers/computer-action-validation.test.ts
@@ -2,36 +2,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const callMock = vi.fn()
 
-vi.mock('../runtime-client', () => {
+vi.mock('../runtime-client', async () => {
   class RuntimeClient {
     call = callMock
     getCliStatus = vi.fn()
     openOrca = vi.fn()
   }
 
-  class RuntimeClientError extends Error {
-    readonly code: string
-
-    constructor(code: string, message: string) {
-      super(message)
-      this.code = code
-    }
-  }
-
-  class RuntimeRpcFailureError extends RuntimeClientError {
-    readonly response: unknown
-
-    constructor(response: unknown) {
-      super('runtime_error', 'runtime_error')
-      this.response = response
-    }
-  }
-
-  return {
-    RuntimeClient,
-    RuntimeClientError,
-    RuntimeRpcFailureError
-  }
+  // Why: re-export the REAL error classes rather than redefining them. format.ts
+  // narrows with `instanceof` against ./runtime/types, so a look-alike class
+  // here would make every CLI error fall through to the generic `runtime_error`
+  // shape — mirroring the barrel keeps the mock faithful to production.
+  const { RuntimeClientError, RuntimeRpcFailureError } = await import('../runtime/types.js')
+  return { RuntimeClient, RuntimeClientError, RuntimeRpcFailureError }
 })
 
 import { main } from '../index'

--- a/src/cli/handlers/computer.test.ts
+++ b/src/cli/handlers/computer.test.ts
@@ -2,36 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const callMock = vi.fn()
 
-vi.mock('../runtime-client', () => {
+vi.mock('../runtime-client', async () => {
   class RuntimeClient {
     call = callMock
     getCliStatus = vi.fn()
     openOrca = vi.fn()
   }
 
-  class RuntimeClientError extends Error {
-    readonly code: string
-
-    constructor(code: string, message: string) {
-      super(message)
-      this.code = code
-    }
-  }
-
-  class RuntimeRpcFailureError extends RuntimeClientError {
-    readonly response: unknown
-
-    constructor(response: unknown) {
-      super('runtime_error', 'runtime_error')
-      this.response = response
-    }
-  }
-
-  return {
-    RuntimeClient,
-    RuntimeClientError,
-    RuntimeRpcFailureError
-  }
+  // Why: re-export the REAL error classes; format.ts narrows with `instanceof`
+  // against ./runtime/types, so a look-alike would collapse every CLI error
+  // code into the generic `runtime_error` shape.
+  const { RuntimeClientError, RuntimeRpcFailureError } = await import('../runtime/types.js')
+  return { RuntimeClient, RuntimeClientError, RuntimeRpcFailureError }
 })
 
 import { main } from '../index'

--- a/src/cli/handlers/emulator.test.ts
+++ b/src/cli/handlers/emulator.test.ts
@@ -6,7 +6,7 @@ const { callMock, remoteMock } = vi.hoisted(() => ({
   remoteMock: vi.fn(() => false)
 }))
 
-vi.mock('../runtime-client', () => {
+vi.mock('../runtime-client', async () => {
   class RuntimeClient {
     readonly isRemote: boolean
     call = callMock
@@ -18,29 +18,11 @@ vi.mock('../runtime-client', () => {
     }
   }
 
-  class RuntimeClientError extends Error {
-    readonly code: string
-
-    constructor(code: string, message: string) {
-      super(message)
-      this.code = code
-    }
-  }
-
-  class RuntimeRpcFailureError extends RuntimeClientError {
-    readonly response: unknown
-
-    constructor(response: unknown) {
-      super('runtime_error', 'runtime_error')
-      this.response = response
-    }
-  }
-
-  return {
-    RuntimeClient,
-    RuntimeClientError,
-    RuntimeRpcFailureError
-  }
+  // Why: re-export the REAL error classes; format.ts narrows with `instanceof`
+  // against ./runtime/types, so a look-alike would collapse every CLI error
+  // code into the generic `runtime_error` shape.
+  const { RuntimeClientError, RuntimeRpcFailureError } = await import('../runtime/types.js')
+  return { RuntimeClient, RuntimeClientError, RuntimeRpcFailureError }
 })
 
 import { main } from '../index'

--- a/src/cli/handlers/linear.test.ts
+++ b/src/cli/handlers/linear.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const callMock = vi.fn()
 
-vi.mock('../runtime-client', () => {
+vi.mock('../runtime-client', async () => {
   class RuntimeClient {
     readonly isRemote: boolean
     call = callMock
@@ -19,23 +19,10 @@ vi.mock('../runtime-client', () => {
     }
   }
 
-  class RuntimeClientError extends Error {
-    readonly code: string
-
-    constructor(code: string, message: string) {
-      super(message)
-      this.code = code
-    }
-  }
-
-  class RuntimeRpcFailureError extends RuntimeClientError {
-    readonly response: unknown
-
-    constructor(response: unknown) {
-      super('runtime_error', 'runtime_error')
-      this.response = response
-    }
-  }
+  // Why: re-export the REAL error classes; format.ts narrows with `instanceof`
+  // against ./runtime/types, so a look-alike would collapse every CLI error
+  // code into the generic `runtime_error` shape.
+  const { RuntimeClientError, RuntimeRpcFailureError } = await import('../runtime/types.js')
 
   return {
     RuntimeClient,

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -22,7 +22,13 @@ const {
   spawnMock: vi.fn()
 }))
 
-vi.mock('./runtime-client', () => {
+vi.mock('./runtime-client', async () => {
+  // Why: re-export the REAL error classes rather than redefining them. format.ts
+  // narrows with `instanceof` against ./runtime/types, so a look-alike class
+  // here would make every CLI error fall through to the generic `runtime_error`
+  // shape — mirroring the barrel keeps the mock faithful to production.
+  const { RuntimeClientError, RuntimeRpcFailureError } = await import('./runtime/types.js')
+
   class RuntimeClient {
     readonly isRemote: boolean
     call = callMock
@@ -49,26 +55,6 @@ vi.mock('./runtime-client', () => {
         )
       }
       this.isRemote = Boolean(effectivePairingCode || effectiveEnvironment)
-    }
-  }
-
-  class RuntimeClientError extends Error {
-    readonly code: string
-    readonly data?: unknown
-
-    constructor(code: string, message: string, data?: unknown) {
-      super(message)
-      this.code = code
-      this.data = data
-    }
-  }
-
-  class RuntimeRpcFailureError extends RuntimeClientError {
-    readonly response: unknown
-
-    constructor(response: unknown) {
-      super('runtime_error', 'runtime_error')
-      this.response = response
     }
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,7 @@ import {
 import { dispatch } from './dispatch'
 import { reportCliError } from './format'
 import { printHelp } from './help'
-import { RuntimeClient } from './runtime-client'
+import type { RuntimeClient } from './runtime-client'
 import { COMMAND_SPECS } from './specs'
 
 export { COMMAND_SPECS } from './specs'
@@ -27,6 +27,15 @@ function shouldIgnoreRemoteSelection(commandPath: string[]): boolean {
     commandPath[0] === 'vm' ||
     commandPath[0] === 'agent-context'
   )
+}
+
+// Why: the RuntimeClient graph is 153 of the CLI's 199 eager modules (zod via
+// shared/pairing, ws + tweetnacl via websocket-transport). Loading it here
+// rather than at module scope means --help, `help <cmd>`, and command/flag
+// errors — which all return before this call — never pay for it. Awaited
+// before dispatch so `ctx.client` stays a synchronous getter.
+async function loadRuntimeClientClass(): Promise<typeof RuntimeClient> {
+  return (await import('./runtime-client.js')).RuntimeClient
 }
 
 // Why: the SSH relay bridge executes this CLI on the Orca host while the
@@ -74,6 +83,7 @@ export async function main(
     // lookup so users do not get misleading "Orca is not running" failures for
     // simple command typos or unsupported flags.
     validateCommandAndFlags(COMMAND_SPECS, parsed)
+    const RuntimeClientClass = await loadRuntimeClientClass()
     const ignoreRemoteSelection = shouldIgnoreRemoteSelection(parsed.commandPath)
     const pairingCode = ignoreRemoteSelection ? null : parsed.flags.get('pairing-code')
     const environmentSelector = ignoreRemoteSelection ? null : parsed.flags.get('environment')
@@ -86,7 +96,7 @@ export async function main(
       flags: parsed.flags,
       // Why: local-only handlers must not resolve runtime metadata just to dispatch.
       get client() {
-        client ??= new RuntimeClient(
+        client ??= new RuntimeClientClass(
           undefined,
           undefined,
           typeof pairingCode === 'string' ? pairingCode : ignoreRemoteSelection ? null : undefined,
@@ -111,7 +121,7 @@ async function runClaudeTeams(argv: string[], cwd: string): Promise<void> {
   try {
     // Why: everything after `orca claude-teams` belongs to Claude Code, not
     // Orca's own flag parser, so new Claude flags work without Orca changes.
-    const client = new RuntimeClient(undefined, undefined, null, null)
+    const client = new (await loadRuntimeClientClass())(undefined, undefined, null, null)
     await dispatch(['claude-teams'], {
       flags: new Map(),
       client,
@@ -127,7 +137,7 @@ async function runClaudeTeams(argv: string[], cwd: string): Promise<void> {
 
 async function runAgentTeamsTmuxShim(argv: string[]): Promise<void> {
   try {
-    const client = new RuntimeClient(undefined, 10_000)
+    const client = new (await loadRuntimeClientClass())(undefined, 10_000)
     const response = await client.call<{
       tmux: { stdout: string; stderr: string; exitCode: number }
     }>(

--- a/src/cli/runtime-client-deferral.test.ts
+++ b/src/cli/runtime-client-deferral.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const { constructorArgsMock, callMock, getCliStatusMock } = vi.hoisted(() => ({
+  constructorArgsMock: vi.fn(),
+  callMock: vi.fn(),
+  getCliStatusMock: vi.fn()
+}))
+
+// Why: `main` reaches RuntimeClient through `await import('./runtime-client.js')`
+// now. Mocking the same specifier the eager import used proves the dynamic
+// import still resolves to the module the 10 existing vi.mock suites target.
+vi.mock('./runtime-client', () => {
+  class RuntimeClient {
+    call = callMock
+    getCliStatus = getCliStatusMock
+    openOrca = vi.fn()
+
+    constructor(...args: unknown[]) {
+      constructorArgsMock(...args)
+    }
+  }
+  return { RuntimeClient }
+})
+
+import { main } from './index'
+import * as dispatchModule from './dispatch'
+
+const CLI_DIR = __dirname
+
+describe('RuntimeClient module-graph deferral', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    constructorArgsMock.mockClear()
+    callMock.mockReset()
+    getCliStatusMock.mockReset()
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    errorSpy.mockRestore()
+    vi.unstubAllEnvs()
+    process.exitCode = 0
+  })
+
+  // Why: the whole point of the change. These five modules load on EVERY
+  // invocation, so a value-import of the barrel from any of them drags the
+  // RuntimeClient graph (zod, ws, tweetnacl) back onto the --help path.
+  it.each(['args.ts', 'flags.ts', 'dispatch.ts', 'format.ts', 'selectors.ts'])(
+    '%s imports error classes from ./runtime/types, not the barrel',
+    (file) => {
+      const source = readFileSync(join(CLI_DIR, file), 'utf8')
+      const valueImports = source
+        .split('\n')
+        .filter((line) => line.startsWith('import ') && line.includes("'./runtime-client'"))
+      for (const line of valueImports) {
+        expect(line, `${file}: "${line}" must be type-only`).toMatch(/^import type /)
+      }
+      expect(source).toContain("} from './runtime/types'")
+    }
+  )
+
+  it('index.ts has no eager value-import of the runtime client', () => {
+    const source = readFileSync(join(CLI_DIR, 'index.ts'), 'utf8')
+    expect(source).toContain("import type { RuntimeClient } from './runtime-client'")
+    expect(source).not.toMatch(/^import \{[^}]*RuntimeClient[^}]*\} from '\.\/runtime-client'/m)
+    expect(source).toContain("await import('./runtime-client.js')")
+  })
+
+  it('constructs no client for --help', async () => {
+    await main(['--help'], '/tmp/repo')
+    expect(constructorArgsMock).not.toHaveBeenCalled()
+  })
+
+  it('constructs no client for an unknown flag', async () => {
+    await main(['worktree', 'list', '--nope'], '/tmp/repo')
+    expect(process.exitCode).toBe(1)
+    expect(constructorArgsMock).not.toHaveBeenCalled()
+  })
+
+  // Why: `agent hooks on|off` are the only commands that both sit in a
+  // suppressed group and touch ctx.client, and they rewrite the real ~/.claude
+  // hook config — so the byte-for-byte equivalence script cannot invoke them.
+  // Assert the constructor arguments directly instead: `null` (not `undefined`)
+  // is what stops the ORCA_* env fallback re-activating for local-only groups.
+  //
+  // `constructs` is declared per case and asserted BEFORE the args, because
+  // only `agent hooks off` reads ctx.client. Looping over `mock.calls` alone
+  // would pass vacuously for the other four, and would keep passing if the one
+  // case that carries the null-vs-undefined coverage stopped constructing at
+  // all. The zero rows are not filler: they assert the deferral itself — a
+  // local-only group must reach its handler without building a client.
+  const SUPPRESSED_GROUPS: [name: string, argv: string[], constructs: number][] = [
+    ['agent', ['agent', 'hooks', 'off'], 1],
+    ['environment', ['environment', 'list'], 0],
+    ['serve', ['serve'], 0],
+    ['vm', ['vm', 'recipe', 'doctor'], 0],
+    ['agent-context', ['agent-context'], 0]
+  ]
+
+  it.each(SUPPRESSED_GROUPS)(
+    'constructs exactly %s expected clients, with null remote selection',
+    async (_name, argv, constructs) => {
+      vi.stubEnv('ORCA_PAIRING_CODE', 'pairing-code')
+      vi.stubEnv('ORCA_ENVIRONMENT', 'some-environment')
+      getCliStatusMock.mockResolvedValue({ result: { runtime: { reachable: false } } })
+
+      await main(argv, '/tmp/repo')
+
+      const calls = constructorArgsMock.mock.calls
+      expect(calls.length, `${argv.join(' ')} client constructions`).toBe(constructs)
+      for (const call of calls) {
+        expect(call[2], `${argv.join(' ')} pairing code`).toBeNull()
+        expect(call[3], `${argv.join(' ')} environment`).toBeNull()
+      }
+    }
+  )
+
+  // Why: four of the five groups above never read ctx.client, so they can only
+  // assert that no client is built — not that suppression forwards `null`.
+  // Stub dispatch and read the getter directly so every group asserts the
+  // constructor arguments unconditionally, exactly once.
+  it.each(SUPPRESSED_GROUPS.map(([name, argv]) => [name, argv] as const))(
+    'forwards null remote selection to the client %s would build',
+    async (_name, argv) => {
+      vi.stubEnv('ORCA_PAIRING_CODE', 'pairing-code')
+      vi.stubEnv('ORCA_ENVIRONMENT', 'some-environment')
+      const dispatchSpy = vi.spyOn(dispatchModule, 'dispatch').mockResolvedValue(undefined)
+      try {
+        await main(argv, '/tmp/repo')
+
+        const ctx = dispatchSpy.mock.calls.at(-1)?.[1]
+        expect(dispatchSpy, `${argv.join(' ')} reached dispatch`).toHaveBeenCalledTimes(1)
+        void ctx?.client
+        expect(constructorArgsMock, `${argv.join(' ')} constructions`).toHaveBeenCalledTimes(1)
+        const [, , pairingCode, environment] = constructorArgsMock.mock.calls[0]
+        expect(pairingCode, `${argv.join(' ')} pairing code`).toBeNull()
+        expect(environment, `${argv.join(' ')} environment`).toBeNull()
+      } finally {
+        dispatchSpy.mockRestore()
+      }
+    }
+  )
+
+  // Why: the mirror — the same stubbed-dispatch probe must show `undefined`
+  // (not `null`) for a non-suppressed group, or the assertion above would pass
+  // for a build that suppressed EVERY command's env fallback.
+  it('forwards undefined remote selection for a non-suppressed group', async () => {
+    vi.stubEnv('ORCA_PAIRING_CODE', 'pairing-code')
+    const dispatchSpy = vi.spyOn(dispatchModule, 'dispatch').mockResolvedValue(undefined)
+    try {
+      await main(['worktree', 'list'], '/tmp/repo')
+
+      void dispatchSpy.mock.calls.at(-1)?.[1]?.client
+      expect(constructorArgsMock).toHaveBeenCalledTimes(1)
+      const [, , pairingCode, environment] = constructorArgsMock.mock.calls[0]
+      expect(pairingCode).toBeUndefined()
+      expect(environment).toBeUndefined()
+    } finally {
+      dispatchSpy.mockRestore()
+    }
+  })
+
+  // Why: the mirror of the above — for every other command the env fallback
+  // MUST stay live, which the RuntimeClient default parameters implement. That
+  // only works if `undefined` is forwarded.
+  it('forwards undefined for non-suppressed commands so the env fallback applies', async () => {
+    callMock.mockResolvedValue({ result: { worktrees: [] } })
+
+    await main(['worktree', 'list', '--json'], '/tmp/repo')
+
+    expect(constructorArgsMock).toHaveBeenCalled()
+    const [, , pairingCode, environment] = constructorArgsMock.mock.calls[0]
+    expect(pairingCode).toBeUndefined()
+    expect(environment).toBeUndefined()
+  })
+
+  it('forwards explicit --pairing-code and --environment values verbatim', async () => {
+    callMock.mockResolvedValue({ result: { worktrees: [] } })
+
+    await main(['worktree', 'list', '--pairing-code', 'code-1', '--json'], '/tmp/repo')
+    expect(constructorArgsMock.mock.calls[0][2]).toBe('code-1')
+    expect(constructorArgsMock.mock.calls[0][3]).toBeUndefined()
+
+    constructorArgsMock.mockClear()
+    await main(['worktree', 'list', '--environment', 'env-1', '--json'], '/tmp/repo')
+    expect(constructorArgsMock.mock.calls[0][2]).toBeUndefined()
+    expect(constructorArgsMock.mock.calls[0][3]).toBe('env-1')
+  })
+
+  // Why: the getter is memoised; a dynamic import inside it would have made it
+  // async and changed every handler signature.
+  it('reuses one client instance across repeated ctx.client reads', async () => {
+    callMock.mockResolvedValue({ result: { worktrees: [] } })
+
+    await main(['worktree', 'list', '--json'], '/tmp/repo')
+
+    expect(constructorArgsMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/cli/runtime/client.ts
+++ b/src/cli/runtime/client.ts
@@ -11,7 +11,7 @@ import { getDefaultUserDataPath, readMetadata } from './metadata'
 import { getCliStatus, resolveDesktopWindowStatus } from './status'
 import { sendRequest } from './transport'
 import { RuntimeClientError, RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
-import { sendWebSocketRequest } from './websocket-transport'
+import type { sendWebSocketRequest } from './websocket-transport'
 import { markEnvironmentUsed, resolveEnvironmentPairingOffer } from './environments'
 import { describeRuntimeCompatBlock, evaluateRuntimeCompat } from '../../shared/protocol-compat'
 import {
@@ -28,6 +28,13 @@ import {
 // emit its terminal frame. The 10 s grace absorbs round-trip + one final
 // keepalive window. See design doc §3.1.
 const LONG_POLL_CLIENT_GRACE_MS = 10_000
+
+// Why: ws + tweetnacl + the remote-runtime frame stack only matter once a
+// request actually goes over a pairing offer, which local CLI calls never do.
+// Both call sites already await this, so deferring the load changes no ordering.
+async function loadSendWebSocketRequest(): Promise<typeof sendWebSocketRequest> {
+  return (await import('./websocket-transport.js')).sendWebSocketRequest
+}
 
 export class RuntimeClient {
   private readonly userDataPath: string
@@ -80,6 +87,7 @@ export class RuntimeClient {
       if (method !== 'status.get') {
         await this.ensureRemoteRuntimeCompatible(effectiveTimeoutMs)
       }
+      const sendWebSocketRequest = await loadSendWebSocketRequest()
       let response
       try {
         response = await sendWebSocketRequest<TResult>(
@@ -179,6 +187,7 @@ export class RuntimeClient {
     if (!this.remotePairing || this.remoteCompatChecked) {
       return
     }
+    const sendWebSocketRequest = await loadSendWebSocketRequest()
     const response = await sendWebSocketRequest<RuntimeStatus>(
       this.remotePairing,
       'status.get',

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -6,7 +6,7 @@ import type {
 } from '../shared/runtime-types'
 import { isPathInsideOrEqual } from '../shared/cross-platform-path'
 import type { RuntimeClient } from './runtime-client'
-import { RuntimeClientError } from './runtime-client'
+import { RuntimeClientError } from './runtime/types'
 import { getOptionalStringFlag, getRequiredStringFlag } from './flags'
 
 export type BrowserCliTarget = {


### PR DESCRIPTION
## Description

`src/cli/index.ts` was the **only eager value-import of `RuntimeClient`** in the tree. Five other eager modules (`args`, `flags`, `dispatch`, `format`, `selectors`) imported just `RuntimeClientError` / `RuntimeRpcFailureError` from the `runtime-client` barrel — and that re-export dragged in `client → pairing → zod → ws → e2ee` on **every** invocation, including `orca --help`.

Those error classes live in `src/cli/runtime/types.ts`, which has **zero children**. The five imports now point there, and the client loads through the existing `ctx.client` getter — already lazy by design; its comment even says *"local-only handlers must not resolve runtime metadata just to dispatch."* The getter stays synchronous, so no handler signature changes.

## ELI5

Typing `orca --help` used to load the entire networking stack — websockets, encryption, schema validation — before printing a help page it was always going to print without touching the network.

Now it loads that only when a command actually needs to talk to something. Help is about twice as fast.

## Proof of perf improvement

`config/scripts/cli-runtime-client-deferral-benchmark.mjs` (new). Both arms are **real `tsc` emits of real source** — the baseline arm restores the touched files from a git rev and compiles that. Fresh process per sample; arms alternate lead across 30 rounds; per-arm medians.

| case | eager | deferred | speedup |
|---|---|---|---|
| `orca --help` | 59.6 ms | 29.2 ms | **2.04×** |
| `orca help worktree` | 60.1 ms | 29.5 ms | **2.04×** |
| `orca` (no args) | 59.7 ms | 28.9 ms | **2.06×** |
| unknown command | 60.6 ms | 29.4 ms | **2.06×** |
| unknown flag | 67.3 ms | 35.7 ms | **1.88×** |
| `orca agent-context --json` | 67.8 ms | 61.8 ms | 1.10× |
| `orca status --json` | 61.3 ms | 55.9 ms | 1.10× |
| `orca worktree list --json` | 62.9 ms | 56.3 ms | 1.12× |

Eager modules **199 → 46**, with `node_modules` dropping **94 → 0**.

Scope, stated plainly: the 2× rows are help and error paths, which return before constructing a client. Commands that *do* construct one gain 1.10–1.12× — only from not eagerly parsing the transport the local path never uses. Most invocations are the latter.

**A correction to a figure I previously recorded:** `websocket-transport` alone is ~24 modules / ~8 ms, **not** the "107 modules / 28 ms" I noted earlier. That number wrongly charged it for zod (79 modules, ~21 ms), which enters via a *different* edge — `runtime/client → shared/pairing → shared/mobile-relay-pairing-offer → zod`. Isolated cost overcounts; marginal cost is the shippable number. Same trap that inflated #10788.

## Proof of zero regression

- **433 invocations byte-identical** (stdout, stderr, exit code) between eager and deferred builds.
- `instanceof` identity preserved — `require('./runtime/types').RuntimeClientError === require('./runtime-client').RuntimeClientError` is `true` (the barrel re-exports, it doesn't copy).
- Constructor-thrown errors still fire at the same point: `resolveRemotePairing` throws from the `RuntimeClient` **constructor** for `--pairing-code` + `--environment` together, malformed codes, and unknown environments. All three compared byte-for-byte.
- `src/cli/`: **42 files, 561 tests** passing. Both `tsconfig.node` and `tsconfig.tc.cli` typecheck clean; oxfmt/oxlint clean.

### Two verification defects found and fixed by adversarial review

**1. The safety guard could hang instead of failing.** `assertNoStateMutatingCases()` existed specifically to prevent an `orca agent hooks off` incident — but `serve` was in the fuzz pool and *absent* from the blocklist. Replaying the fixed seed: **15 of 400 cases lead with `serve`**, which spawns Orca in the foreground and blocks, and `spawnSync` had no `timeout`. It passed only by luck, because `resolveForegroundOrcaExecutable()` happened to throw first on this machine.

Both halves fixed, and the design changed rather than just patched: a deny list only catches verbs someone thought of, which is precisely how `serve` survived review. There is now a **fail-closed `READ_ONLY_FUZZ_TOKENS` allowlist** — every token in the pool must be explicitly declared read-only. I verified this by reintroducing the exact original defect (`serve` back in the pool, removed from the foreground list) and confirming it still fails: `Fuzz token "serve" is not declared in READ_ONLY_FUZZ_TOKENS`. `run()` also takes a 30 s timeout, so a hang is now a named failure.

Critically, **the guard was not masking a real difference** — that was proven, not assumed, since it would have changed the verdict: `serve` compared across 66 cases and `agent hooks on|off|status` across 27 (in a throwaway `HOME`, diffing the resulting `settings.json` as well as output), **0 mismatches**.

**2. A test was 4/5 vacuous.** The `it.each` asserting constructor args looped over `mock.calls`, so the four cases constructing *nothing* passed on an empty loop body — instrumentation confirmed counts of `agent=1, environment=0, serve=0, vm=0, agent-context=0`. Restructured to assert the expected construction count **first**, unconditionally. Verified by mutation: making `ctx.client` return a stub for a group that must construct one now fails **10 tests**; under the original test it was silently green.

**Still unverified, stated rather than glossed:** the `serve` and `agent-hooks` comparisons ran through throwaway harnesses (the committed script still deliberately excludes those paths), macOS/Node 24 only, and the `serve` comparison used a stub executable — the real Electron foreground path was never spawned.

## Review loop count + verdict

3 loops. Round 1 implemented and measured. Round 2 (adversarial) reproduced the speedup independently but returned FIX_FIRST on the two verification defects above. Round 3 fixed both, replaced the deny list with a fail-closed allowlist, and re-proved the excluded paths were equivalent.

**Verdict: ship.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
