### PR TITLE
fix(editor): translate mirrored editor-tab owners into the receiver frame

### DIFF
--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -6,6 +6,7 @@ import {
   getRuntimeEnvironmentIdForWorktree,
   getRuntimeSessionMirrorEnvironmentIds,
   getSettingsForWorktreeRuntimeOwner,
+  translateMirroredEditorRuntimeEnvironmentId,
   type WorktreeRuntimeOwnerState
 } from './worktree-runtime-owner'
 
@@ -141,6 +142,18 @@ describe('getSettingsForWorktreeRuntimeOwner', () => {
 })
 
 describe('getExplicitRuntimeEnvironmentIdForWorktree', () => {
+  it('translates only concrete receiver records and preserves peer-only ownership', () => {
+    expect(
+      translateMirroredEditorRuntimeEnvironmentId(state, 'local-repo::wt-a', 'peer-env')
+    ).toBeNull()
+    expect(
+      translateMirroredEditorRuntimeEnvironmentId(state, 'runtime-repo::wt-b', 'peer-env')
+    ).toBe('owner-env')
+    expect(translateMirroredEditorRuntimeEnvironmentId(state, 'peer-only::wt', 'peer-env')).toBe(
+      'peer-env'
+    )
+  })
+
   it('keeps SSH execution on its paired HUB transport owner', () => {
     const nestedState: WorktreeRuntimeOwnerState = {
       settings: { activeRuntimeEnvironmentId: 'different-hub' },

--- a/src/renderer/src/lib/worktree-runtime-owner.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.ts
@@ -14,7 +14,8 @@ import { getSingleFocusedRuntimeEnvironmentId } from './single-runtime-legacy-ow
 import {
   getExecutionHostIdForFolderWorkspace,
   getExplicitRuntimeEnvironmentIdForFolderWorkspace,
-  getRuntimeEnvironmentIdForFolderWorkspace
+  getRuntimeEnvironmentIdForFolderWorkspace,
+  findFolderWorkspaceOwner
 } from './folder-workspace-runtime-owner'
 import {
   resolveExplicitWorktreeOperationRouteResult,
@@ -139,6 +140,25 @@ export function getExplicitRuntimeEnvironmentIdForWorktree(
   // Why: session mirroring is expensive; a merely focused runtime must not make
   // legacy/local worktrees look remote-owned.
   return getExplicitRuntimeEnvironmentIdFromHost(getRepoExecutionHostId(repo))
+}
+
+export function translateMirroredEditorRuntimeEnvironmentId(
+  state: WorktreeRuntimeOwnerState,
+  worktreeId: string,
+  incomingRuntimeEnvironmentId: string | null | undefined
+): string | null | undefined {
+  const workspaceScope = parseWorkspaceKey(worktreeId)
+  const hasDetectedOwner = Object.values(state.detectedWorktreesByRepo ?? {}).some((result) =>
+    result.worktrees.some((worktree) => worktree.id === worktreeId)
+  )
+  const hasConcreteRecord =
+    workspaceScope?.type === 'folder'
+      ? Boolean(findFolderWorkspaceOwner(state, workspaceScope.folderWorkspaceId))
+      : Boolean(findWorktreeRecord(state.worktreesByRepo, worktreeId) || hasDetectedOwner)
+
+  return hasConcreteRecord
+    ? getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    : incomingRuntimeEnvironmentId
 }
 
 export function getExecutionHostIdForWorktree(

--- a/src/renderer/src/runtime/close-mirrored-editor-tab.test.ts
+++ b/src/renderer/src/runtime/close-mirrored-editor-tab.test.ts
@@ -71,6 +71,30 @@ describe('notifyHostOfMirroredEditorClose', () => {
     })
   })
 
+  it('uses mirror-host provenance when route ownership was translated locally', async () => {
+    const handled = notifyHostOfMirroredEditorClose(
+      buildState({
+        openFiles: [
+          {
+            id: 'file-1',
+            worktreeId: 'wt-1',
+            mirroredFromRuntimeSession: true,
+            mirroredFromRuntimeEnvironmentId: 'host-env'
+          }
+        ] as unknown as MirroredEditorCloseState['openFiles']
+      }),
+      'wt-1',
+      'file-1'
+    )
+
+    expect(handled).toBe(true)
+    await vi.waitFor(() => expect(closeWebRuntimeSessionTabMock).toHaveBeenCalled())
+    expect(closeWebRuntimeSessionTabMock).toHaveBeenCalledWith(
+      expect.objectContaining({ environmentId: 'host-env' })
+    )
+    expect(getRuntimeEnvironmentIdForWorktreeMock).not.toHaveBeenCalled()
+  })
+
   it('does not route locally-opened (non-mirrored) files to the host', () => {
     const state = buildState({
       openFiles: [

--- a/src/renderer/src/runtime/close-mirrored-editor-tab.ts
+++ b/src/renderer/src/runtime/close-mirrored-editor-tab.ts
@@ -27,7 +27,9 @@ export function notifyHostOfMirroredEditorClose(
   if (!file?.mirroredFromRuntimeSession) {
     return false
   }
-  const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+  const runtimeEnvironmentId =
+    file.mirroredFromRuntimeEnvironmentId?.trim() ||
+    getRuntimeEnvironmentIdForWorktree(state, worktreeId)
   if (!runtimeEnvironmentId?.trim()) {
     return false
   }

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -21,7 +21,7 @@ import {
   resetWebSessionReorderIntentForTests
 } from './web-session-reorder-intent'
 import type { BrowserPage, BrowserWorkspace, Tab, TerminalTab } from '../../../shared/types'
-import type { OpenFile } from '../store/slices/editor'
+import { buildOwnedEditorFileId, type OpenFile } from '../store/slices/editor'
 import {
   confirmWebAgentSessionHandoffAfterCreate,
   recordWebAgentSessionHandoff,
@@ -52,6 +52,7 @@ vi.mock('../store', () => ({
 
 const WT = 'repo::/worktree'
 const ENV = 'web-env-1'
+const ENV_2 = 'web-env-2'
 const NOW = 1_700_000_000_000
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 const SECOND_LEAF_ID = '22222222-2222-4222-8222-222222222222'
@@ -3233,7 +3234,7 @@ describe('applyWebSessionTabsSnapshot', () => {
     const terminalId = patch.tabsByWorktree?.[WT]?.[0]?.id
     expect(patch.openFiles).toMatchObject([
       {
-        id: '/repo/README.md',
+        id: buildOwnedEditorFileId('/repo/README.md', WT, ENV),
         filePath: '/repo/README.md',
         relativePath: 'README.md',
         worktreeId: WT,
@@ -3247,7 +3248,7 @@ describe('applyWebSessionTabsSnapshot', () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: 'host-readme-unified',
-          entityId: '/repo/README.md',
+          entityId: buildOwnedEditorFileId('/repo/README.md', WT, ENV),
           contentType: 'editor',
           label: 'README.md',
           color: '#16a34a',
@@ -3259,8 +3260,10 @@ describe('applyWebSessionTabsSnapshot', () => {
       activeTabId: 'host-readme-unified',
       tabOrder: [terminalId, 'host-readme-unified']
     })
-    expect(patch.activeFileId).toBe('/repo/README.md')
-    expect(patch.activeFileIdByWorktree?.[WT]).toBe('/repo/README.md')
+    expect(patch.activeFileId).toBe(buildOwnedEditorFileId('/repo/README.md', WT, ENV))
+    expect(patch.activeFileIdByWorktree?.[WT]).toBe(
+      buildOwnedEditorFileId('/repo/README.md', WT, ENV)
+    )
     expect(patch.activeTabType).toBe('editor')
     expect(patch.activeTabTypeByWorktree?.[WT]).toBe('editor')
   })
@@ -3445,7 +3448,7 @@ describe('applyWebSessionTabsSnapshot', () => {
 
     expect(patch.openFiles).toMatchObject([
       {
-        id: 'markdown-preview::/repo/README.md',
+        id: buildOwnedEditorFileId('markdown-preview::/repo/README.md', WT, ENV),
         filePath: '/repo/README.md',
         markdownPreviewSourceFileId: '/repo/README.md',
         mode: 'markdown-preview'
@@ -3454,11 +3457,13 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.unifiedTabsByWorktree?.[WT]).toMatchObject([
       {
         id: 'host-preview-unified',
-        entityId: 'markdown-preview::/repo/README.md',
+        entityId: buildOwnedEditorFileId('markdown-preview::/repo/README.md', WT, ENV),
         contentType: 'editor'
       }
     ])
-    expect(patch.activeFileId).toBe('markdown-preview::/repo/README.md')
+    expect(patch.activeFileId).toBe(
+      buildOwnedEditorFileId('markdown-preview::/repo/README.md', WT, ENV)
+    )
   })
 
   it('removes mirrored editor tabs when the host closes the file', () => {
@@ -3490,12 +3495,12 @@ describe('applyWebSessionTabsSnapshot', () => {
     const hydratedState = { ...makeState(), ...hydratedPatch } as WebSessionTabsSyncState
 
     expect(hydratedState.openFiles[0]).toMatchObject({
-      id: '/repo/README.md',
+      id: buildOwnedEditorFileId('/repo/README.md', WT, ENV),
       mirroredFromRuntimeSession: true
     })
     expect(hydratedState.unifiedTabsByWorktree[WT]?.[0]).toMatchObject({
       id: 'host-readme-unified',
-      entityId: '/repo/README.md'
+      entityId: buildOwnedEditorFileId('/repo/README.md', WT, ENV)
     })
 
     const patch = applyWebSessionTabsSnapshot(
@@ -3665,5 +3670,151 @@ describe('applyWebSessionTabsSnapshot', () => {
     })
     expect(patch.activeTabId).toBe(mirroredId)
     expect(patch.activeTabIdByWorktree?.[WT]).toBe(mirroredId)
+  })
+
+  it('translates mirrored editor ownership and culls by mirror host provenance', () => {
+    const state = makeState({
+      openFiles: [
+        {
+          id: 'stale-editor',
+          filePath: '/repo/README.md',
+          relativePath: 'README.md',
+          worktreeId: WT,
+          language: 'markdown',
+          isDirty: false,
+          runtimeEnvironmentId: null,
+          mirroredFromRuntimeSession: true,
+          mirroredFromRuntimeEnvironmentId: ENV,
+          mode: 'edit'
+        }
+      ]
+    })
+    Object.assign(state, {
+      repos: [{ id: 'repo-1', executionHostId: 'local' }],
+      worktreesByRepo: { 'repo-1': [{ id: WT, repoId: 'repo-1' }] }
+    })
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([
+        {
+          type: 'file',
+          id: 'host-editor-1',
+          title: 'README.md',
+          filePath: '/repo/README.md',
+          relativePath: 'README.md',
+          language: 'markdown',
+          isDirty: false,
+          isActive: true
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.openFiles).toHaveLength(1)
+    expect(patch.openFiles?.[0]).toMatchObject({
+      runtimeEnvironmentId: null,
+      mirroredFromRuntimeEnvironmentId: ENV,
+      mirroredFromRuntimeSession: true
+    })
+  })
+
+  it('replaces an earlier mirror-host copy when a second host publishes the same translated editor id', () => {
+    const mirroredId = buildOwnedEditorFileId('/repo/README.md', WT, null)
+    const state = makeState({
+      openFiles: [
+        {
+          id: mirroredId,
+          filePath: '/repo/README.md',
+          relativePath: 'README.md',
+          worktreeId: WT,
+          language: 'markdown',
+          isDirty: false,
+          runtimeEnvironmentId: null,
+          mirroredFromRuntimeSession: true,
+          mirroredFromRuntimeEnvironmentId: ENV,
+          mode: 'edit'
+        }
+      ]
+    })
+    Object.assign(state, {
+      repos: [{ id: 'repo-1', executionHostId: 'local' }],
+      worktreesByRepo: { 'repo-1': [{ id: WT, repoId: 'repo-1' }] }
+    })
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([
+        {
+          type: 'file',
+          id: 'host-editor-2',
+          title: 'README.md',
+          filePath: '/repo/README.md',
+          relativePath: 'README.md',
+          language: 'markdown',
+          isDirty: false,
+          isActive: true
+        }
+      ]),
+      ENV_2,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.openFiles).toHaveLength(1)
+    expect(patch.openFiles?.[0]).toMatchObject({
+      id: mirroredId,
+      runtimeEnvironmentId: null,
+      mirroredFromRuntimeEnvironmentId: ENV_2,
+      mirroredFromRuntimeSession: true
+    })
+  })
+
+  it('replaces a preexisting local entry when a mirrored snapshot publishes the same translated editor id', () => {
+    const mirroredId = buildOwnedEditorFileId('/repo/README.md', WT, null)
+    const state = makeState({
+      openFiles: [
+        {
+          id: mirroredId,
+          filePath: '/repo/README.md',
+          relativePath: 'README.md',
+          worktreeId: WT,
+          language: 'markdown',
+          isDirty: false,
+          runtimeEnvironmentId: null,
+          mirroredFromRuntimeSession: false,
+          mode: 'edit'
+        }
+      ]
+    })
+    Object.assign(state, {
+      repos: [{ id: 'repo-1', executionHostId: 'local' }],
+      worktreesByRepo: { 'repo-1': [{ id: WT, repoId: 'repo-1' }] }
+    })
+
+    const patch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([
+        {
+          type: 'file',
+          id: 'host-editor-3',
+          title: 'README.md',
+          filePath: '/repo/README.md',
+          relativePath: 'README.md',
+          language: 'markdown',
+          isDirty: false,
+          isActive: true
+        }
+      ]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(patch.openFiles).toHaveLength(1)
+    expect(patch.openFiles?.[0]).toMatchObject({
+      id: mirroredId,
+      runtimeEnvironmentId: null,
+      mirroredFromRuntimeEnvironmentId: ENV,
+      mirroredFromRuntimeSession: true
+    })
   })
 })

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -27,14 +27,16 @@ import type {
   TerminalPaneLayoutNode,
   TerminalTab
 } from '../../../shared/types'
-import type { OpenFile } from '../store/slices/editor'
+import { buildOwnedEditorFileId, type OpenFile } from '../store/slices/editor'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { getRemoteRuntimePtyEnvironmentId, toRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-title-sanitization'
 import {
   getExplicitRuntimeEnvironmentIdForWorktree,
-  getRuntimeSessionMirrorEnvironmentIds
+  getRuntimeSessionMirrorEnvironmentIds,
+  translateMirroredEditorRuntimeEnvironmentId
 } from '@/lib/worktree-runtime-owner'
+import type { WorktreeRuntimeOwnerState } from '@/lib/worktree-runtime-owner'
 import {
   createWebRuntimeSessionTerminal,
   HOST_TERMINAL_SURFACE_SEPARATOR,
@@ -440,11 +442,16 @@ function isReadyEditorTab(
   return tab.type === 'markdown' || tab.type === 'file'
 }
 
-function localEditorFileId(tab: ReadyEditorSurface): string {
-  if (tab.type === 'markdown' && tab.mode === 'markdown-preview') {
-    return `markdown-preview::${tab.sourceFilePath}`
-  }
-  return tab.filePath
+function localEditorFileId(
+  tab: ReadyEditorSurface,
+  worktreeId: string,
+  runtimeEnvironmentId: string | null | undefined
+): string {
+  const filePath =
+    tab.type === 'markdown' && tab.mode === 'markdown-preview'
+      ? `markdown-preview::${tab.sourceFilePath}`
+      : tab.filePath
+  return buildOwnedEditorFileId(filePath, worktreeId, runtimeEnvironmentId)
 }
 
 function editorSourceFileId(tab: ReadyEditorSurface): string | undefined {
@@ -873,7 +880,12 @@ function buildMirroredEditorTabs(
   now: number
 ): MirroredEditorTab[] {
   return snapshot.tabs.filter(isReadyEditorTab).map((tab, index) => {
-    const fileId = localEditorFileId(tab)
+    const runtimeEnvironmentId = translateMirroredEditorRuntimeEnvironmentId(
+      state as unknown as WorktreeRuntimeOwnerState,
+      snapshot.worktree,
+      environmentId
+    )
+    const fileId = localEditorFileId(tab, snapshot.worktree, runtimeEnvironmentId)
     const existingFile = state.openFiles.find(
       (file) => file.worktreeId === snapshot.worktree && file.id === fileId
     )
@@ -893,11 +905,12 @@ function buildMirroredEditorTabs(
       worktreeId: snapshot.worktree,
       language: tab.language,
       isDirty: tab.isDirty,
-      runtimeEnvironmentId: environmentId,
+      runtimeEnvironmentId,
       mode: tab.type === 'markdown' ? tab.mode : 'edit',
       markdownPreviewSourceFileId: sourceFileId,
       // Why: marks this tab host-owned so a later snapshot that omits it can cull it; locally opened tabs lack this flag and survive.
-      mirroredFromRuntimeSession: true
+      mirroredFromRuntimeSession: true,
+      mirroredFromRuntimeEnvironmentId: environmentId
     }
     return {
       file,
@@ -1594,6 +1607,7 @@ function openFileEqual(a: OpenFile, b: OpenFile): boolean {
     a.language === b.language &&
     a.isDirty === b.isDirty &&
     a.runtimeEnvironmentId === b.runtimeEnvironmentId &&
+    a.mirroredFromRuntimeEnvironmentId === b.mirroredFromRuntimeEnvironmentId &&
     a.markdownPreviewSourceFileId === b.markdownPreviewSourceFileId &&
     a.markdownPreviewAnchor === b.markdownPreviewAnchor &&
     a.isPreview === b.isPreview &&
@@ -1893,7 +1907,7 @@ export function applyWebSessionTabsSnapshot(
       .filter(
         (file) =>
           file.worktreeId === worktreeId &&
-          file.runtimeEnvironmentId === environmentId &&
+          file.mirroredFromRuntimeEnvironmentId === environmentId &&
           (file.mode === 'edit' || file.mode === 'markdown-preview') &&
           // Why: only cull host-mirrored tabs; locally opened files have no host counterpart, so their omission isn't a close signal.
           file.mirroredFromRuntimeSession === true &&
@@ -1906,7 +1920,7 @@ export function applyWebSessionTabsSnapshot(
       (file) =>
         !(
           file.worktreeId === worktreeId &&
-          file.runtimeEnvironmentId === environmentId &&
+          (file.mode === 'edit' || file.mode === 'markdown-preview') &&
           (removedEditorFileIds.has(file.id) || mirroredEditorFileIds.has(file.id))
         )
     )

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -106,6 +106,65 @@ function mirroredEditorUnifiedTab(id: string, entityId: string, worktreeId: stri
 }
 
 describe('createEditorSlice right sidebar state', () => {
+  it('re-owns mirrored hydration in the receiver frame', () => {
+    const store = createEditorStore()
+    store.setState({ unifiedTabsByWorktree: {} })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'focused-env' } as AppState['settings']
+    })
+
+    store.getState().hydrateEditorSession({
+      openFilesByWorktree: {
+        'wt-1': [
+          {
+            filePath: '/repo/README.md',
+            relativePath: 'README.md',
+            worktreeId: 'wt-1',
+            language: 'markdown',
+            runtimeEnvironmentId: 'peer-env'
+          }
+        ]
+      }
+    } as never)
+
+    expect(store.getState().openFiles[0]).toMatchObject({
+      id: ownedEditorFileId('/repo/README.md', 'wt-1', null),
+      runtimeEnvironmentId: null
+    })
+  })
+
+  it('uses an owned id when hydration translates a local snapshot into explicit remote ownership', () => {
+    const store = createEditorStore()
+    store.setState({
+      unifiedTabsByWorktree: {},
+      repos: [
+        { id: 'repo-1', executionHostId: 'runtime:owner-env' }
+      ] as unknown as AppState['repos'],
+      worktreesByRepo: {
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1' }]
+      } as unknown as AppState['worktreesByRepo']
+    })
+
+    store.getState().hydrateEditorSession({
+      openFilesByWorktree: {
+        'wt-1': [
+          {
+            filePath: '/repo/README.md',
+            relativePath: 'README.md',
+            worktreeId: 'wt-1',
+            language: 'markdown',
+            runtimeEnvironmentId: null
+          }
+        ]
+      }
+    } as never)
+
+    expect(store.getState().openFiles[0]).toMatchObject({
+      id: ownedEditorFileId('/repo/README.md', 'wt-1', 'owner-env'),
+      runtimeEnvironmentId: 'owner-env'
+    })
+  })
+
   it('queues and safely consumes explicit editor focus requests', () => {
     const store = createEditorStore()
 
@@ -1564,6 +1623,7 @@ describe('createEditorSlice recently closed editor tabs', () => {
         language: 'markdown',
         runtimeEnvironmentId: 'env-1',
         mirroredFromRuntimeSession: true,
+        mirroredFromRuntimeEnvironmentId: 'host-env',
         mode: 'edit'
       },
       { preview }
@@ -1579,10 +1639,12 @@ describe('createEditorSlice recently closed editor tabs', () => {
     const recent = store.getState().recentlyClosedEditorTabsByWorktree['wt-1']?.[0]
     expect(recent).toMatchObject({ filePath: '/repo/notes.md' })
     expect(recent).not.toHaveProperty('mirroredFromRuntimeSession')
+    expect(recent).not.toHaveProperty('mirroredFromRuntimeEnvironmentId')
 
     expect(store.getState().reopenClosedEditorTab('wt-1')).toBe(true)
     expect(store.getState().openFiles[0]).toMatchObject({ filePath: '/repo/notes.md' })
     expect(store.getState().openFiles[0]).not.toHaveProperty('mirroredFromRuntimeSession')
+    expect(store.getState().openFiles[0]).not.toHaveProperty('mirroredFromRuntimeEnvironmentId')
   })
 
   it('reopens close-all mirrored editor tabs as local tabs', () => {

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -64,7 +64,10 @@ import {
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { notifyHostOfMirroredEditorClose } from '@/runtime/close-mirrored-editor-tab'
 import { findWorktreeById, getRepoIdFromWorktreeId } from './worktree-helpers'
-import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import {
+  getExplicitRuntimeEnvironmentIdForWorktree,
+  translateMirroredEditorRuntimeEnvironmentId
+} from '@/lib/worktree-runtime-owner'
 import {
   addAdditionalValidWorkspaceKeys,
   type WorkspaceSessionHydrationOptions
@@ -258,6 +261,8 @@ export type OpenFile = {
   checkRunDetails?: OpenCheckRunDetailsState
   /** Why: web-client tab mirrored from the host snapshot; only mirrored tabs may be culled when they vanish, locally-opened tabs must survive. */
   mirroredFromRuntimeSession?: boolean
+  /** Runtime-only sender provenance; route ownership remains receiver-relative in runtimeEnvironmentId. */
+  mirroredFromRuntimeEnvironmentId?: string | null
   /** Why: orthogonal to `mode` — an edit-mode tab that must never accept edits/autosave/rename (AI Vault View Log). Persisted only when true. */
   readOnly?: boolean
   /** Why: explicit live tail, only meaningful for a read-only local log. */
@@ -276,7 +281,7 @@ export type EditorViewMode = 'edit' | 'changes'
 // Why: omit mirroredFromRuntimeSession so a user-reopened tab isn't treated as host-owned and culled by the next web session sync.
 export type ClosedEditorTabSnapshot = Omit<
   OpenFile,
-  'id' | 'isDirty' | 'mirroredFromRuntimeSession'
+  'id' | 'isDirty' | 'mirroredFromRuntimeSession' | 'mirroredFromRuntimeEnvironmentId'
 >
 
 const MAX_RECENT_CLOSED_EDITOR_TABS = 10
@@ -1111,6 +1116,15 @@ function shouldHydrateWithOwnedEditorFileId(
   )
 }
 
+function didHydratedEditorOwnerChange(
+  persistedRuntimeEnvironmentId: string | null | undefined,
+  hydratedRuntimeEnvironmentId: string | null | undefined
+): boolean {
+  return (
+    runtimeOwnerKey(persistedRuntimeEnvironmentId) !== runtimeOwnerKey(hydratedRuntimeEnvironmentId)
+  )
+}
+
 function addEditorFileIdMigration(
   migrationsByWorktree: Record<string, Map<string, string>>,
   worktreeId: string,
@@ -1777,6 +1791,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
               id: _rid,
               isDirty: _rdirty,
               mirroredFromRuntimeSession: _rmirrored,
+              mirroredFromRuntimeEnvironmentId: _rsourceEnvironment,
               ...snap
             } = replacedPreview
             const stack = s.recentlyClosedEditorTabsByWorktree[worktreeId] ?? []
@@ -2166,6 +2181,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
           id: _id,
           isDirty: _dirty,
           mirroredFromRuntimeSession: _mirrored,
+          mirroredFromRuntimeEnvironmentId: _sourceEnvironment,
           ...snap
         } = closedFile
         const stack = s.recentlyClosedEditorTabsByWorktree[wtRecent] ?? []
@@ -2355,7 +2371,13 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         ) {
           continue
         }
-        const { id: _id, isDirty: _dirty, mirroredFromRuntimeSession: _mirrored, ...snap } = f
+        const {
+          id: _id,
+          isDirty: _dirty,
+          mirroredFromRuntimeSession: _mirrored,
+          mirroredFromRuntimeEnvironmentId: _sourceEnvironment,
+          ...snap
+        } = f
         nextRecentClosed = [snap as ClosedEditorTabSnapshot, ...nextRecentClosed].slice(
           0,
           MAX_RECENT_CLOSED_EDITOR_TABS
@@ -4495,9 +4517,15 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             worktreeId
           )
           // Why: floating/runtime-owned files need IDs that survive peers disappearing between restarts; collision-based IDs drift when the path is no longer open elsewhere.
-          const ownedId = buildOwnedEditorFileId(pf.filePath, worktreeId, pf.runtimeEnvironmentId)
+          const runtimeEnvironmentId = translateMirroredEditorRuntimeEnvironmentId(
+            s,
+            worktreeId,
+            pf.runtimeEnvironmentId
+          )
+          const ownedId = buildOwnedEditorFileId(pf.filePath, worktreeId, runtimeEnvironmentId)
           const id =
-            shouldHydrateWithOwnedEditorFileId(worktreeId, pf.runtimeEnvironmentId) ||
+            shouldHydrateWithOwnedEditorFileId(worktreeId, runtimeEnvironmentId) ||
+            didHydratedEditorOwnerChange(pf.runtimeEnvironmentId, runtimeEnvironmentId) ||
             usedOpenFileIds.has(pf.filePath)
               ? ownedId
               : pf.filePath
@@ -4508,7 +4536,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             id: legacyId,
             filePath: pf.filePath,
             worktreeId,
-            runtimeEnvironmentId: pf.runtimeEnvironmentId
+            runtimeEnvironmentId
           })
           // Why: read-only tabs (AI Vault View Log) must restore clean — ignore any persisted dirty draft/baseline so they can't come back writable.
           const isReadOnly = pf.readOnly === true
@@ -4524,7 +4552,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
             language: detectLanguage(pf.relativePath || pf.filePath),
             isDirty: !isReadOnly && pf.dirtyDraftContent !== undefined,
             isPreview: pf.isPreview,
-            runtimeEnvironmentId: pf.runtimeEnvironmentId,
+            runtimeEnvironmentId,
             externalSshTargetId: pf.externalSshTargetId,
             ...(isReadOnly ? { readOnly: true } : {}),
             ...(isReadOnly && pf.liveTail === true ? { liveTail: true } : {}),


### PR DESCRIPTION
## Summary

Fixes #10859. Mirrored editor tabs were carrying the sender's perspective-relative `runtimeEnvironmentId` across paired Orca instances unchanged. When the receiver owned that worktree locally, Orca still routed local editor reads and diffs back to the peer, which had never heard of the worktree. The same overloaded field also drove close and cull behavior, so mirrored tabs could reappear or multiply after sync.

This change splits those meanings and keeps the fix renderer-local:

- `runtimeEnvironmentId` becomes the receiver-frame routing owner for the file.
- New runtime-only `mirroredFromRuntimeEnvironmentId` records which remote runtime mirrored the tab to this receiver.
- Hydration and live mirror ingest translate incoming owners only when the receiver has concrete ownership for that worktree.
- Live mirror dedupe keys off the translated owner, while cull and close use the mirror-host provenance.

The result is that paired machines still mirror editor tabs, but a machine that owns the worktree routes its own file operations locally and can close mirrored tabs authoritatively across the link.

Closes #10859.

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/worktree-runtime-owner.test.ts src/renderer/src/store/slices/editor.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/runtime/close-mirrored-editor-tab.test.ts`
- [x] `pnpm run typecheck:web`
- [x] `pnpm exec oxlint` on changed files
- [x] `pnpm exec oxfmt --check` on changed files

Focused coverage:

- Hydration re-owns mirrored local-worktree tabs into the receiver frame.
- The shared owner-translation helper preserves peer-only and explicit-remote worktrees.
- Live mirror sync dedupes by translated owner and culls by mirror-host provenance.
- Mirrored close routes to the mirror host, with a fallback for pre-fix mirrored rows.

## AI Review Report

Adversarial review found three P1s, all fixed on the final branch and revalidated locally:

- Hydration initially decided whether to use an owned file ID from the persisted owner, not the translated receiver-frame owner. That could diverge from live sync when a local snapshot translated into an explicit remote owner. The final branch now forces the owned ID whenever translation changes ownership.
- Live sync initially retained an earlier mirror-host copy when a second host published the same translated editor ID. The final branch now replaces any preexisting mirrored file with the same translated ID before appending the new host copy.
- Live sync still let a receiver-local tab with the same translated owned ID survive beside the mirrored replacement. The final branch now coalesces canonical-ID collisions against local entries too, so the mirrored copy becomes the single authoritative tab and carries the host provenance for close and cull.

Final local revalidation after those fixes:

- Focused Vitest: `4 passed, 283 tests`
- `pnpm run typecheck:web`
- changed-file `oxlint`
- changed-file `oxfmt --check`

Review focus covered the explicit-owner boundary, shared owned-ID construction across hydration and live sync, mirror-host keyed cull/close, and stripping runtime-only mirror provenance from persisted or reopened tabs.

## Security Audit

No new RPC, IPC, or cross-process trust boundary. The fix tightens routing by keeping receiver-owned local file operations on the receiver instead of sending them to a peer runtime that does not own the worktree. Owner translation is guarded by concrete receiver-side records, and peer-only worktrees remain peer-owned.

## Notes

- The issue comment at https://github.com/stablyai/orca/issues/10859#issuecomment-5087991543 is the design anchor for this slice. Cross-machine editing is intended behavior; only the untranslated owner semantics are wrong.
- The field-reported tab growth, memory churn, and close-loop behavior are downstream effects of the same overloaded owner field. This PR proves the routing, dedupe, cull, and close mechanism in focused renderer tests.
