### PR TITLE
feat(appearance): add IDE Font Weight setting

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -638,6 +638,22 @@ describe('Store', () => {
     expect(persisted.localAccountRuntimeDefaultedToAutoForAllUsers).toBe(true)
   })
 
+  it('backfills appFontWeight for settings files saved before it existed', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        appFontFamily: 'Inter'
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().appFontWeight).toBe(400)
+    expect(store.getSettings().appFontFamily).toBe('Inter')
+  })
+
   it('preserves an explicit WSL account-runtime pin through the migration', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -680,6 +680,7 @@ describe('Store', () => {
     expect(settings.theme).toBe('system')
     expect(settings.appIcon).toBe('classic')
     expect(settings.appFontFamily).toBe('Geist')
+    expect(settings.appFontWeight).toBe(400)
     expect(settings.editorAutoSave).toBe(false)
     expect(settings.editorAutoSaveDelayMs).toBe(1000)
     expect(settings.terminalFontSize).toBe(14)
@@ -5113,6 +5114,7 @@ describe('Store', () => {
       editorAutoSave: true,
       editorAutoSaveDelayMs: 1500,
       appFontFamily: 'Inter',
+      appFontWeight: 350,
       terminalFontSize: 16,
       terminalFontWeight: 600
     })
@@ -5120,6 +5122,7 @@ describe('Store', () => {
     expect(updated.editorAutoSave).toBe(true)
     expect(updated.editorAutoSaveDelayMs).toBe(1500)
     expect(updated.appFontFamily).toBe('Inter')
+    expect(updated.appFontWeight).toBe(350)
     expect(updated.terminalFontSize).toBe(16)
     expect(updated.terminalFontWeight).toBe(600)
     // Other fields preserved

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -32,6 +32,7 @@ import {
 import { resolveLeftTitlebarChromeLayout } from '@/lib/titlebar-left-chrome'
 import { shouldShowWorktreeCreationSurface } from '@/lib/worktree-creation-surface'
 import { buildAppFontFamily } from '@/lib/app-font-family'
+import { normalizeAppFontWeight } from '../../shared/app-fonts'
 import { toast } from 'sonner'
 import { Toaster } from '@/components/ui/sonner'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -1427,7 +1428,11 @@ function App(): React.JSX.Element {
       '--app-font-family',
       buildAppFontFamily(settings?.appFontFamily)
     )
-  }, [settings?.appFontFamily])
+    document.documentElement.style.setProperty(
+      '--app-font-weight',
+      String(normalizeAppFontWeight(settings?.appFontWeight))
+    )
+  }, [settings?.appFontFamily, settings?.appFontWeight])
 
   // Refresh GitHub data (PR/issue status) when window regains focus
   useEffect(() => {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -125,6 +125,7 @@
 
 :root {
   --app-font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --app-font-weight: 400;
   --font-sans: var(--app-font-family);
   --font-mono:
     'SF Mono', SFMono-Regular, ui-monospace, 'Cascadia Code', Menlo, Consolas, 'Liberation Mono',
@@ -463,6 +464,7 @@
       'Segoe UI',
       sans-serif
     );
+    font-weight: var(--app-font-weight, 400);
     letter-spacing: 0.01em;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -221,7 +221,7 @@ export function AppearanceInterfaceSection({
           min={APP_FONT_WEIGHT_MIN}
           max={APP_FONT_WEIGHT_MAX}
           step={APP_FONT_WEIGHT_STEP}
-          suffix="100-900"
+          suffix={`${APP_FONT_WEIGHT_MIN}-${APP_FONT_WEIGHT_MAX}`}
           onChange={(value) => updateSettings({ appFontWeight: normalizeAppFontWeight(value) })}
         />
       </SearchableSetting>

--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -10,11 +10,19 @@ import { useShortcutKeyComboDetails } from '@/hooks/useShortcutLabel'
 import { ShortcutHintList } from './AppearanceShortcutHintList'
 import {
   FontAutocomplete,
+  NumberField,
   SettingsRow,
   SettingsSegmentedControl,
   SettingsSwitchRow
 } from './SettingsFormControls'
 import { DEFAULT_APP_FONT_FAMILY } from '../../../../shared/constants'
+import {
+  APP_FONT_WEIGHT_MAX,
+  APP_FONT_WEIGHT_MIN,
+  APP_FONT_WEIGHT_STEP,
+  DEFAULT_APP_FONT_WEIGHT,
+  normalizeAppFontWeight
+} from '../../../../shared/app-fonts'
 import {
   getLanguageEntries,
   getMenuBarIconEntries,
@@ -67,6 +75,7 @@ export function AppearanceInterfaceSection({
   const themeLabel = translate('auto.components.settings.AppearancePane.932ff1fbff', 'Theme')
   const titlebarEntry = getTitlebarEntries()[0]
   const typographyEntry = getTypographyEntries()[0]
+  const typographyWeightEntry = getTypographyEntries()[1]
   const zoomEntry = getZoomEntries()[0]
   const advancedEntries = [
     ...getTitlebarEntries(),
@@ -192,6 +201,28 @@ export function AppearanceInterfaceSection({
               }
             />
           }
+        />
+      </SearchableSetting>
+
+      <SearchableSetting
+        title={translate('auto.components.settings.AppearancePane.bff865af14', 'IDE Font Weight')}
+        description={typographyWeightEntry?.description}
+        keywords={typographyWeightEntry?.keywords ?? ['font', 'weight', 'typography']}
+        forceVisible={forceVisiblePrimary}
+      >
+        <NumberField
+          label={translate('auto.components.settings.AppearancePane.bff865af14', 'IDE Font Weight')}
+          description={translate(
+            'auto.components.settings.AppearancePane.bec3447ccd',
+            'Adjust the base weight of interface text.'
+          )}
+          value={normalizeAppFontWeight(settings.appFontWeight)}
+          defaultValue={DEFAULT_APP_FONT_WEIGHT}
+          min={APP_FONT_WEIGHT_MIN}
+          max={APP_FONT_WEIGHT_MAX}
+          step={APP_FONT_WEIGHT_STEP}
+          suffix="100-900"
+          onChange={(value) => updateSettings({ appFontWeight: normalizeAppFontWeight(value) })}
         />
       </SearchableSetting>
 

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -304,6 +304,52 @@ describe('AppearancePane', () => {
     expect(updateSettings).toHaveBeenCalledWith({ uiLanguage: 'zh' })
   })
 
+  it('commits a normalized app font weight from the interface typography setting', async () => {
+    mocks.state.settingsSearchQuery = 'IDE Font Weight'
+    const updateSettings = vi.fn()
+
+    const container = await renderAppearancePane(getDefaultSettings('/tmp'), updateSettings)
+    const weightInput = container.querySelector<HTMLInputElement>('input[type="number"]')
+    if (!weightInput) {
+      throw new Error('IDE Font Weight input was not rendered')
+    }
+    expect(weightInput.value).toBe('400')
+
+    await act(async () => {
+      // Why: React reads controlled-input changes through the native value setter.
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setValue?.call(weightInput, '350')
+      weightInput.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      weightInput.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ appFontWeight: 350 })
+  })
+
+  it('clamps out-of-range app font weights before persisting', async () => {
+    mocks.state.settingsSearchQuery = 'IDE Font Weight'
+    const updateSettings = vi.fn()
+
+    const container = await renderAppearancePane(getDefaultSettings('/tmp'), updateSettings)
+    const weightInput = container.querySelector<HTMLInputElement>('input[type="number"]')
+    if (!weightInput) {
+      throw new Error('IDE Font Weight input was not rendered')
+    }
+
+    await act(async () => {
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setValue?.call(weightInput, '1200')
+      weightInput.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => {
+      weightInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ appFontWeight: 900 })
+  })
+
   it('includes the selected language in the collapsed Interface summary', async () => {
     mocks.state.settingsSearchQuery = ''
     const settings = {

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -112,6 +112,25 @@ export const getTypographyEntries = createLocalizedCatalog((): SettingsSearchEnt
       ...translateSearchKeyword('auto.components.settings.appearance.search.36e006efc1', 'app'),
       ...translateSearchKeyword('auto.components.settings.appearance.search.2f12e1aa3a', 'ui')
     ]
+  },
+  {
+    title: translate('auto.components.settings.appearance.search.bff865af14', 'IDE Font Weight'),
+    description: translate(
+      'auto.components.settings.appearance.search.bec3447ccd',
+      'Adjust the base weight of interface text.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.appearance.search.24094af355', 'font'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.0844df8fee', 'weight'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.1a0dc227b5', 'thin'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.e0007a5bca', 'bold'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.8b36fb3f64',
+        'typography'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.fab91464dd', 'ide'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.2f12e1aa3a', 'ui')
+    ]
   }
 ])
 

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -4,6 +4,7 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   terminalFontSize: 'Font Size',
   terminalFontFamily: 'Font Family',
   editorFontFamily: 'Editor Font Family',
+  appFontWeight: 'IDE Font Weight',
   terminalFontWeight: 'Font Weight',
   terminalLineHeight: 'Line Height',
   terminalScrollSensitivity: 'Normal Scroll Speed',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5265,7 +5265,9 @@
           "showPinnedWorktreesInGroups": {
             "title": "Also show pinned worktrees in their original lists",
             "description": "Pinned worktrees stay in Pinned and also appear in All, Project, Status, and PR."
-          }
+          },
+          "bff865af14": "IDE Font Weight",
+          "bec3447ccd": "Adjust the base weight of interface text."
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -7556,7 +7558,12 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
-            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
+            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "0844df8fee": "weight",
+            "1a0dc227b5": "thin",
+            "e0007a5bca": "bold",
+            "bff865af14": "IDE Font Weight",
+            "bec3447ccd": "Adjust the base weight of interface text."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5242,7 +5242,9 @@
           "showPinnedWorktreesInGroups": {
             "title": "Mostrar también los worktrees fijados en sus listas originales",
             "description": "Los worktrees fijados permanecen en Fijados y también aparecen en Todos, Proyecto, Estado y PR."
-          }
+          },
+          "bff865af14": "Grosor de fuente del IDE",
+          "bec3447ccd": "Ajusta el grosor base del texto de la interfaz."
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -7496,7 +7498,12 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Porcentajes de uso",
-            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante."
+            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante.",
+            "0844df8fee": "grosor",
+            "1a0dc227b5": "fino",
+            "e0007a5bca": "negrita",
+            "bff865af14": "Grosor de fuente del IDE",
+            "bec3447ccd": "Ajusta el grosor base del texto de la interfaz."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5227,7 +5227,9 @@
           "showPinnedWorktreesInGroups": {
             "title": "ピン留めしたワークツリーを元のリストにも表示",
             "description": "ピン留めしたワークツリーを Pinned に残したまま、すべて、プロジェクト、ステータス、PR にも表示します。"
-          }
+          },
+          "bff865af14": "IDE フォントの太さ",
+          "bec3447ccd": "インターフェイステキストの基本の太さを調整します。"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -7518,7 +7520,12 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "使用率",
-            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。"
+            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。",
+            "0844df8fee": "太さ",
+            "1a0dc227b5": "細い",
+            "e0007a5bca": "太い",
+            "bff865af14": "IDE フォントの太さ",
+            "bec3447ccd": "インターフェイステキストの基本の太さを調整します。"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5227,7 +5227,9 @@
           "showPinnedWorktreesInGroups": {
             "title": "고정된 워크트리를 원래 목록에도 표시",
             "description": "고정된 워크트리는 Pinned에 유지하면서 전체, 프로젝트, 상태 및 PR에도 표시합니다."
-          }
+          },
+          "bff865af14": "IDE 글꼴 두께",
+          "bec3447ccd": "인터페이스 텍스트의 기본 두께를 조정합니다."
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -7481,7 +7483,12 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "사용량 백분율",
-            "usagePercentageDisplayDescription": "공급자 한도를 사용한 비율 또는 남은 비율로 표시할지 선택합니다."
+            "usagePercentageDisplayDescription": "공급자 한도를 사용한 비율 또는 남은 비율로 표시할지 선택합니다.",
+            "0844df8fee": "두께",
+            "1a0dc227b5": "얇게",
+            "e0007a5bca": "굵게",
+            "bff865af14": "IDE 글꼴 두께",
+            "bec3447ccd": "인터페이스 텍스트의 기본 두께를 조정합니다."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5227,7 +5227,9 @@
           "showPinnedWorktreesInGroups": {
             "title": "也在原来的列表中显示已固定的工作树",
             "description": "已固定的工作树会保留在 Pinned 中，同时也显示在全部、项目、状态和 PR 中。"
-          }
+          },
+          "bff865af14": "IDE 字体粗细",
+          "bec3447ccd": "调整界面文本的基础粗细。"
         },
         "AutoRenameBranchFromWorkSetting": {
           "1626524572": "Nautilus",
@@ -7481,7 +7483,12 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "用量百分比",
-            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。"
+            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。",
+            "0844df8fee": "粗细",
+            "1a0dc227b5": "细",
+            "e0007a5bca": "粗",
+            "bff865af14": "IDE 字体粗细",
+            "bec3447ccd": "调整界面文本的基础粗细。"
           }
         },
         "auto": {

--- a/src/renderer/src/popout.tsx
+++ b/src/renderer/src/popout.tsx
@@ -11,6 +11,7 @@ import {
 } from './lib/crash-diagnostics'
 import { applyDocumentTheme } from './lib/document-theme'
 import { buildAppFontFamily } from './lib/app-font-family'
+import { normalizeAppFontWeight } from '../../shared/app-fonts'
 import { I18nProvider } from './i18n/I18nProvider'
 import { translate } from './i18n/i18n'
 import { useAppStore } from './store'
@@ -28,6 +29,10 @@ function applyPopoutAppearance(settings: GlobalSettings | null): void {
   document.documentElement.style.setProperty(
     '--app-font-family',
     buildAppFontFamily(settings?.appFontFamily)
+  )
+  document.documentElement.style.setProperty(
+    '--app-font-weight',
+    String(normalizeAppFontWeight(settings?.appFontWeight))
   )
 }
 

--- a/src/shared/app-fonts.test.ts
+++ b/src/shared/app-fonts.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_APP_FONT_WEIGHT, normalizeAppFontWeight } from './app-fonts'
+
+describe('normalizeAppFontWeight', () => {
+  it('falls back to the default weight when the value is missing', () => {
+    expect(normalizeAppFontWeight(undefined)).toBe(DEFAULT_APP_FONT_WEIGHT)
+    expect(normalizeAppFontWeight(null)).toBe(DEFAULT_APP_FONT_WEIGHT)
+    expect(normalizeAppFontWeight(Number.NaN)).toBe(DEFAULT_APP_FONT_WEIGHT)
+  })
+
+  it('clamps weights to the CSS font-weight range', () => {
+    expect(normalizeAppFontWeight(10)).toBe(100)
+    expect(normalizeAppFontWeight(1200)).toBe(900)
+  })
+
+  it('rounds fractional weights from hand-edited profiles', () => {
+    expect(normalizeAppFontWeight(437.4)).toBe(437)
+    expect(normalizeAppFontWeight(350)).toBe(350)
+  })
+})

--- a/src/shared/app-fonts.ts
+++ b/src/shared/app-fonts.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_APP_FONT_WEIGHT = 400
+export const APP_FONT_WEIGHT_MIN = 100
+export const APP_FONT_WEIGHT_MAX = 900
+export const APP_FONT_WEIGHT_STEP = 50
+
+/** Clamp persisted or IPC-provided app font weights into the CSS `font-weight` range. */
+export function normalizeAppFontWeight(fontWeight: number | null | undefined): number {
+  const numericFontWeight = typeof fontWeight === 'number' ? fontWeight : Number.NaN
+
+  if (!Number.isFinite(numericFontWeight)) {
+    return DEFAULT_APP_FONT_WEIGHT
+  }
+
+  return Math.min(APP_FONT_WEIGHT_MAX, Math.max(APP_FONT_WEIGHT_MIN, Math.round(numericFontWeight)))
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -13,6 +13,7 @@ import type {
 import { EMPTY_CODEX_RESET_CREDIT_ATTEMPT_LEDGER } from './codex-reset-credit-attempt-ledger'
 import { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 import { DEFAULT_TERMINAL_FONT_WEIGHT } from './terminal-fonts'
+import { DEFAULT_APP_FONT_WEIGHT } from './app-fonts'
 import { getDefaultTerminalQuickCommands } from './terminal-quick-commands'
 import type { VoiceSettings } from './speech-types'
 import { cloneDefaultWorkspaceStatuses } from './workspace-statuses'
@@ -189,6 +190,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     uiLanguage: UI_LANGUAGE_SYSTEM,
     appIcon: DEFAULT_APP_ICON_ID,
     appFontFamily: DEFAULT_APP_FONT_FAMILY,
+    appFontWeight: DEFAULT_APP_FONT_WEIGHT,
     editorAutoSave: false,
     editorAutoSaveDelayMs: DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
     editorMinimapEnabled: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2649,6 +2649,8 @@ export type GlobalSettings = {
   uiLanguage: UiLanguage
   appIcon: AppIconId
   appFontFamily: string
+  /** Base weight for interface text; optional for profiles saved before it existed. */
+  appFontWeight?: number
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number
   editorMinimapEnabled: boolean


### PR DESCRIPTION
## Summary

Adds an **IDE Font Weight** setting under **Settings → Appearance → Interface**, directly below **IDE Font**, so users can lighten or strengthen the base weight of interface text.

- New optional `appFontWeight` setting (default `400`), clamped to the CSS `font-weight` range `100–900` by a shared normalizer (`src/shared/app-fonts.ts`, mirroring `terminal-fonts.ts`).
- Applied as a `--app-font-weight` CSS variable from the same effect that owns `--app-font-family`, in both the main window (`App.tsx`) and the dashboard pop-out (`popout.tsx`); consumed by the `body` base style in `main.css`.
- Elements with explicit weights (headings, `font-medium`/`font-semibold` UI) keep their hierarchy — only default-weight text follows the setting.
- The bundled Geist is a variable font (100–900), so every step renders a true weight; custom IDE fonts resolve through normal CSS weight matching.
- Old profiles backfill to `400` via the persisted-settings defaults, so the UI is unchanged until a user opts in.

## Screenshots

| Default (400) | Lighter (300) | Heavier (700) |
| --- | --- | --- |
| ![weight 400](https://raw.githubusercontent.com/chan1103/orca/assets-app-font-weight/weight-400.png) | ![weight 300](https://raw.githubusercontent.com/chan1103/orca/assets-app-font-weight/weight-300.png) | ![weight 700](https://raw.githubusercontent.com/chan1103/orca/assets-app-font-weight/weight-700.png) |

## Testing

- [x] `pnpm lint` — every gate passes with this diff except `verify:localization-coverage`, which fails identically on unchanged current `main` in my environment (pre-existing `"Ghostty"` keyword findings in `terminal-advanced-platform-search.ts` / `terminal-pane-appearance-search.ts`, files untouched by this PR)
- [x] `pnpm typecheck`
- [x] `pnpm test` — 37,522 passed; the only 4 failures (GPU-flag, git-prompt, and socket-timing suites) reproduce identically on clean `main` in this environment and are unrelated to this change
- [x] `pnpm build`
- [x] Added or updated high-quality tests: normalization unit tests (`src/shared/app-fonts.test.ts`), AppearancePane commit + clamp component tests, and persistence default-backfill/update-merge coverage

## AI Review Report

Implemented and reviewed with an AI coding agent. The review explicitly checked:

- **Cross-platform (macOS/Linux/Windows):** no platform branches, shortcuts, shortcut labels, paths, shell behavior, or Electron platform differences are touched — the change is a numeric setting plus a CSS variable, identical on all three platforms.
- **Local/SSH/remote:** renderer presentation state only; no host, process, or filesystem assumption. The pop-out window applies the same variable so both windows stay consistent.
- **Lifecycle:** live-applies through the existing settings→effect path. Verified in a live dev run: committing `300`/`700` updates `getComputedStyle(document.body).fontWeight` immediately, and an accidental `400300` entry clamps to `900`.
- **Compatibility:** `appFontWeight` is optional in `GlobalSettings`, so existing fixtures and persisted profiles need no migration; missing values normalize to `400` at every read site (settings UI, main window, pop-out).
- **i18n:** label, description, and search-keyword strings added for en/es/ja/ko/zh; `verify:localization-catalog` passes.

## Security Audit

- No command execution, filesystem path handling, auth, secrets, dependency, or IPC-surface changes.
- The existing settings channel carries one additional optional numeric field, clamped at every consumer before use; the CSS variable receives a stringified clamped number, so no injection surface.

## Notes

- Visual change is limited to default-weight interface text; no layout shifts observed at 300/400/700 in the live run.
- No platform-specific, remote-specific, agent-specific, or git-provider-specific behavior.
