### PR TITLE
fix(git): honor commit message cancellation before spawn

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -1897,10 +1897,14 @@ describe('registerFilesystemHandlers', () => {
     ).resolves.toEqual({ success: true, message: 'Update README' })
 
     expect(getStagedCommitContextMock).toHaveBeenCalledWith(WORKTREE_FEATURE_PATH, {})
-    expect(generateCommitMessageFromContextMock).toHaveBeenCalledWith(context, params, {
-      kind: 'local',
-      cwd: WORKTREE_FEATURE_PATH
-    })
+    expect(generateCommitMessageFromContextMock).toHaveBeenCalledWith(
+      context,
+      params,
+      expect.objectContaining({
+        kind: 'local',
+        cwd: WORKTREE_FEATURE_PATH
+      })
+    )
   })
 
   it('uses one-shot resolved params for local commit message generation', async () => {
@@ -1934,10 +1938,10 @@ describe('registerFilesystemHandlers', () => {
     expect(generateCommitMessageFromContextMock).toHaveBeenCalledWith(
       context,
       sourceControlAiResolvedParams,
-      {
+      expect.objectContaining({
         kind: 'local',
         cwd: WORKTREE_FEATURE_PATH
-      }
+      })
     )
   })
 
@@ -2620,6 +2624,96 @@ describe('registerFilesystemHandlers', () => {
       })
     ).resolves.toEqual({ success: false, error: 'Failed to read staged changes.' })
 
+    expect(generateCommitMessageFromContextMock).not.toHaveBeenCalled()
+  })
+
+  it('cancels local commit-message generation while staged context is still loading', async () => {
+    resolveCommitMessageSettingsMock.mockReturnValue({
+      ok: true,
+      params: { agentId: 'codex', model: 'gpt-5.4-mini' }
+    })
+    let resolveContext:
+      | ((context: { branch: string; stagedSummary: string; stagedPatch: string }) => void)
+      | undefined
+    getStagedCommitContextMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveContext = resolve
+        })
+    )
+
+    registerFilesystemHandlers(store as never)
+
+    const pending = handlers.get('git:generateCommitMessage')!(null, {
+      worktreePath: WORKTREE_FEATURE_PATH
+    })
+    await vi.waitFor(() => expect(resolveContext).toBeTypeOf('function'))
+
+    await handlers.get('git:cancelGenerateCommitMessage')!(null, {
+      worktreePath: WORKTREE_FEATURE_PATH
+    })
+
+    await expect(pending).resolves.toEqual({
+      success: false,
+      error: 'Generation canceled.',
+      canceled: true
+    })
+    expect(generateCommitMessageFromContextMock).not.toHaveBeenCalled()
+
+    resolveContext?.({
+      branch: 'main',
+      stagedSummary: 'M\tREADME.md',
+      stagedPatch: '+hello'
+    })
+    await vi.waitFor(() => expect(getStagedCommitContextMock).toHaveResolved())
+    expect(generateCommitMessageFromContextMock).not.toHaveBeenCalled()
+  })
+
+  it('cancels SSH commit-message generation while staged context is still loading', async () => {
+    resolveCommitMessageSettingsMock.mockReturnValue({
+      ok: true,
+      params: { agentId: 'codex', model: 'gpt-5.4-mini' }
+    })
+    let resolveContext:
+      | ((context: { branch: string; stagedSummary: string; stagedPatch: string }) => void)
+      | undefined
+    const cancelGenerateCommitMessage = vi.fn().mockResolvedValue(undefined)
+    getSshGitProviderMock.mockReturnValue({
+      cancelGenerateCommitMessage,
+      getStagedCommitContext: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveContext = resolve
+          })
+      )
+    })
+
+    registerFilesystemHandlers(store as never)
+
+    const pending = handlers.get('git:generateCommitMessage')!(null, {
+      worktreePath: '/remote/repo',
+      connectionId: 'connection-1'
+    })
+    await vi.waitFor(() => expect(resolveContext).toBeTypeOf('function'))
+
+    await handlers.get('git:cancelGenerateCommitMessage')!(null, {
+      worktreePath: '/remote/repo',
+      connectionId: 'connection-1'
+    })
+
+    await expect(pending).resolves.toEqual({
+      success: false,
+      error: 'Generation canceled.',
+      canceled: true
+    })
+    expect(cancelGenerateCommitMessage).toHaveBeenCalledWith('/remote/repo', 'commit-message')
+
+    resolveContext?.({
+      branch: 'main',
+      stagedSummary: 'M\tREADME.md',
+      stagedPatch: '+hello'
+    })
+    await Promise.resolve()
     expect(generateCommitMessageFromContextMock).not.toHaveBeenCalled()
   })
 

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -61,7 +61,6 @@ import {
 } from '../git/status'
 import { getHistory } from '../git/history'
 import {
-  cancelGenerateCommitMessageLocal,
   cancelGeneratePullRequestFieldsLocal,
   discoverCommitMessageModelsLocal,
   discoverCommitMessageModelsRemote,
@@ -78,7 +77,8 @@ import {
   cancelTextGeneration,
   localTextGenerationLane,
   runCancelableTextGenerationRequest,
-  sshTextGenerationLane
+  sshTextGenerationLane,
+  TEXT_GENERATION_CANCELED_RESULT
 } from '../text-generation/text-generation-cancellation'
 import { getUpstreamStatus } from '../git/upstream'
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
@@ -1383,7 +1383,7 @@ export function registerFilesystemHandlers(
       return runCancelableTextGenerationRequest(
         'commit-message',
         cancellationLane,
-        { success: false, error: 'Generation canceled.', canceled: true },
+        TEXT_GENERATION_CANCELED_RESULT,
         async (cancellation) => {
           const discoveryHostKey = getCommitMessageModelDiscoveryHostKey(args.connectionId ?? null)
           const baseSettings = store.getSettings()
@@ -1405,7 +1405,7 @@ export function registerFilesystemHandlers(
                 await getRepoForSourceControlAi(store, args)
               )
           if (cancellation.isCanceled()) {
-            return { success: false, error: 'Generation canceled.', canceled: true }
+            return TEXT_GENERATION_CANCELED_RESULT
           }
           if (!resolvedSettings.ok) {
             return { success: false, error: resolvedSettings.error }
@@ -1423,7 +1423,7 @@ export function registerFilesystemHandlers(
               context = await provider.getStagedCommitContext(args.worktreePath)
             } catch (error) {
               if (cancellation.isCanceled()) {
-                return { success: false, error: 'Generation canceled.', canceled: true }
+                return TEXT_GENERATION_CANCELED_RESULT
               }
               console.error('[filesystem] Failed to read remote staged commit context:', error)
               return {
@@ -1432,7 +1432,7 @@ export function registerFilesystemHandlers(
               }
             }
             if (cancellation.isCanceled()) {
-              return { success: false, error: 'Generation canceled.', canceled: true }
+              return TEXT_GENERATION_CANCELED_RESULT
             }
             if (!context) {
               return { success: false, error: 'No staged changes to summarize.' }
@@ -1461,7 +1461,7 @@ export function registerFilesystemHandlers(
             context = await getStagedCommitContext(worktreePath, gitOptions)
           } catch (error) {
             if (cancellation.isCanceled()) {
-              return { success: false, error: 'Generation canceled.', canceled: true }
+              return TEXT_GENERATION_CANCELED_RESULT
             }
             console.error('[filesystem] Failed to read staged commit context:', error)
             return {
@@ -1470,7 +1470,7 @@ export function registerFilesystemHandlers(
             }
           }
           if (cancellation.isCanceled()) {
-            return { success: false, error: 'Generation canceled.', canceled: true }
+            return TEXT_GENERATION_CANCELED_RESULT
           }
           if (!context) {
             return { success: false, error: 'No staged changes to summarize.' }
@@ -1485,7 +1485,7 @@ export function registerFilesystemHandlers(
             getLocalAgentRuntimeTarget(gitOptions)
           )
           if (cancellation.isCanceled()) {
-            return { success: false, error: 'Generation canceled.', canceled: true }
+            return TEXT_GENERATION_CANCELED_RESULT
           }
           if (!localEnv.ok) {
             return { success: false, error: localEnv.error }
@@ -1512,10 +1512,7 @@ export function registerFilesystemHandlers(
           return
         }
         await provider.cancelGenerateCommitMessage(args.worktreePath, 'commit-message')
-        return
       }
-      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
-      cancelGenerateCommitMessageLocal(worktreePath)
     }
   )
 

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -74,6 +74,12 @@ import {
   type GeneratePullRequestFieldsResult
 } from '../text-generation/commit-message-text-generation'
 import { getPullRequestDraftContext } from '../text-generation/pull-request-context'
+import {
+  cancelTextGeneration,
+  localTextGenerationLane,
+  runCancelableTextGenerationRequest,
+  sshTextGenerationLane
+} from '../text-generation/text-generation-cancellation'
 import { getUpstreamStatus } from '../git/upstream'
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from '../git/remote'
 import { gitSyncForkDefaultBranch } from '../git/fork-sync'
@@ -1371,94 +1377,124 @@ export function registerFilesystemHandlers(
         agentCmdOverrides?: GlobalSettings['agentCmdOverrides']
       }
     ): Promise<GenerateCommitMessageResult> => {
-      const discoveryHostKey = getCommitMessageModelDiscoveryHostKey(args.connectionId ?? null)
-      const baseSettings = store.getSettings()
-      const requestSettings = {
-        ...baseSettings,
-        ...(args.sourceControlAi !== undefined ? { sourceControlAi: args.sourceControlAi } : {}),
-        ...(args.agentCmdOverrides !== undefined
-          ? { agentCmdOverrides: args.agentCmdOverrides }
-          : {})
-      }
-      const resolvedSettings = args.sourceControlAiResolvedParams
-        ? { ok: true as const, params: args.sourceControlAiResolvedParams }
-        : resolveCommitMessageSettings(
-            requestSettings,
-            discoveryHostKey,
-            'commitMessage',
-            await getRepoForSourceControlAi(store, args)
+      const cancellationLane = args.connectionId
+        ? sshTextGenerationLane(args.connectionId, args.worktreePath)
+        : localTextGenerationLane(args.worktreePath)
+      return runCancelableTextGenerationRequest(
+        'commit-message',
+        cancellationLane,
+        { success: false, error: 'Generation canceled.', canceled: true },
+        async (cancellation) => {
+          const discoveryHostKey = getCommitMessageModelDiscoveryHostKey(args.connectionId ?? null)
+          const baseSettings = store.getSettings()
+          const requestSettings = {
+            ...baseSettings,
+            ...(args.sourceControlAi !== undefined
+              ? { sourceControlAi: args.sourceControlAi }
+              : {}),
+            ...(args.agentCmdOverrides !== undefined
+              ? { agentCmdOverrides: args.agentCmdOverrides }
+              : {})
+          }
+          const resolvedSettings = args.sourceControlAiResolvedParams
+            ? { ok: true as const, params: args.sourceControlAiResolvedParams }
+            : resolveCommitMessageSettings(
+                requestSettings,
+                discoveryHostKey,
+                'commitMessage',
+                await getRepoForSourceControlAi(store, args)
+              )
+          if (cancellation.isCanceled()) {
+            return { success: false, error: 'Generation canceled.', canceled: true }
+          }
+          if (!resolvedSettings.ok) {
+            return { success: false, error: resolvedSettings.error }
+          }
+          if (args.connectionId) {
+            const provider = getSshGitProvider(args.connectionId)
+            if (!provider) {
+              return {
+                success: false,
+                error: SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
+              }
+            }
+            let context
+            try {
+              context = await provider.getStagedCommitContext(args.worktreePath)
+            } catch (error) {
+              if (cancellation.isCanceled()) {
+                return { success: false, error: 'Generation canceled.', canceled: true }
+              }
+              console.error('[filesystem] Failed to read remote staged commit context:', error)
+              return {
+                success: false,
+                error: 'Failed to read staged changes.'
+              }
+            }
+            if (cancellation.isCanceled()) {
+              return { success: false, error: 'Generation canceled.', canceled: true }
+            }
+            if (!context) {
+              return { success: false, error: 'No staged changes to summarize.' }
+            }
+            context = withLinkedIssueDraftContext(
+              context,
+              resolveSourceControlAiLinkedIssue(store, args)
+            )
+            return generateCommitMessageFromContext(context, resolvedSettings.params, {
+              kind: 'remote',
+              cwd: args.worktreePath,
+              execute: (plan, cwd, timeoutMs, operation) =>
+                provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
+              missingBinaryLocation: 'remote PATH',
+              cancellation
+            })
+          }
+          const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+          const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+            store,
+            args.worktreePath,
+            worktreePath
           )
-      if (!resolvedSettings.ok) {
-        return { success: false, error: resolvedSettings.error }
-      }
-      if (args.connectionId) {
-        const provider = getSshGitProvider(args.connectionId)
-        if (!provider) {
-          return {
-            success: false,
-            error: SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
+          let context
+          try {
+            context = await getStagedCommitContext(worktreePath, gitOptions)
+          } catch (error) {
+            if (cancellation.isCanceled()) {
+              return { success: false, error: 'Generation canceled.', canceled: true }
+            }
+            console.error('[filesystem] Failed to read staged commit context:', error)
+            return {
+              success: false,
+              error: 'Failed to read staged changes.'
+            }
           }
-        }
-        let context
-        try {
-          context = await provider.getStagedCommitContext(args.worktreePath)
-        } catch (error) {
-          console.error('[filesystem] Failed to read remote staged commit context:', error)
-          return {
-            success: false,
-            error: 'Failed to read staged changes.'
+          if (cancellation.isCanceled()) {
+            return { success: false, error: 'Generation canceled.', canceled: true }
           }
+          if (!context) {
+            return { success: false, error: 'No staged changes to summarize.' }
+          }
+          context = withLinkedIssueDraftContext(
+            context,
+            resolveSourceControlAiLinkedIssue(store, args, worktreePath)
+          )
+          const localEnv = await prepareLocalCommitMessageAgentEnv(
+            resolvedSettings.params.agentId,
+            commitMessageAgentEnv,
+            getLocalAgentRuntimeTarget(gitOptions)
+          )
+          if (cancellation.isCanceled()) {
+            return { success: false, error: 'Generation canceled.', canceled: true }
+          }
+          if (!localEnv.ok) {
+            return { success: false, error: localEnv.error }
+          }
+          return generateCommitMessageFromContext(context, resolvedSettings.params, {
+            ...getLocalTextGenerationTarget(worktreePath, gitOptions, localEnv.env),
+            cancellation
+          })
         }
-        if (!context) {
-          return { success: false, error: 'No staged changes to summarize.' }
-        }
-        context = withLinkedIssueDraftContext(
-          context,
-          resolveSourceControlAiLinkedIssue(store, args)
-        )
-        return generateCommitMessageFromContext(context, resolvedSettings.params, {
-          kind: 'remote',
-          cwd: args.worktreePath,
-          execute: (plan, cwd, timeoutMs, operation) =>
-            provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
-          missingBinaryLocation: 'remote PATH'
-        })
-      }
-      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
-      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
-        store,
-        args.worktreePath,
-        worktreePath
-      )
-      let context
-      try {
-        context = await getStagedCommitContext(worktreePath, gitOptions)
-      } catch (error) {
-        console.error('[filesystem] Failed to read staged commit context:', error)
-        return {
-          success: false,
-          error: 'Failed to read staged changes.'
-        }
-      }
-      if (!context) {
-        return { success: false, error: 'No staged changes to summarize.' }
-      }
-      context = withLinkedIssueDraftContext(
-        context,
-        resolveSourceControlAiLinkedIssue(store, args, worktreePath)
-      )
-      const localEnv = await prepareLocalCommitMessageAgentEnv(
-        resolvedSettings.params.agentId,
-        commitMessageAgentEnv,
-        getLocalAgentRuntimeTarget(gitOptions)
-      )
-      if (!localEnv.ok) {
-        return { success: false, error: localEnv.error }
-      }
-      return generateCommitMessageFromContext(
-        context,
-        resolvedSettings.params,
-        getLocalTextGenerationTarget(worktreePath, gitOptions, localEnv.env)
       )
     }
   )
@@ -1466,6 +1502,10 @@ export function registerFilesystemHandlers(
   ipcMain.handle(
     'git:cancelGenerateCommitMessage',
     async (_event, args: { worktreePath: string; connectionId?: string }): Promise<void> => {
+      const cancellationLane = args.connectionId
+        ? sshTextGenerationLane(args.connectionId, args.worktreePath)
+        : localTextGenerationLane(args.worktreePath)
+      cancelTextGeneration('commit-message', cancellationLane)
       if (args.connectionId) {
         const provider = getSshGitProvider(args.connectionId)
         if (!provider) {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -59,7 +59,6 @@ import {
 } from '../providers/ssh-git-dispatch'
 import { checkIgnoredPaths } from '../git/check-ignored-paths'
 import {
-  cancelGenerateCommitMessageLocal,
   cancelGeneratePullRequestFieldsLocal,
   discoverCommitMessageModelsLocal,
   discoverCommitMessageModelsRemote,
@@ -80,7 +79,8 @@ import {
   cancelTextGeneration,
   localTextGenerationLane,
   runCancelableTextGenerationRequest,
-  sshTextGenerationLane
+  sshTextGenerationLane,
+  TEXT_GENERATION_CANCELED_RESULT
 } from '../text-generation/text-generation-cancellation'
 import { getPullRequestDraftContext } from '../text-generation/pull-request-context'
 import { normalizeRuntimeRelativePath } from './runtime-relative-paths'
@@ -606,7 +606,7 @@ export class RuntimeGitCommands {
     return runCancelableTextGenerationRequest(
       'commit-message',
       cancellationLane,
-      { success: false, error: 'Generation canceled.', canceled: true },
+      TEXT_GENERATION_CANCELED_RESULT,
       async (cancellation) => {
         const discoveryHostKey =
           settingsOverride?.commitMessageDiscoveryHostKey ??
@@ -624,7 +624,7 @@ export class RuntimeGitCommands {
               target.repo ?? null
             )
         if (cancellation.isCanceled()) {
-          return { success: false, error: 'Generation canceled.', canceled: true }
+          return TEXT_GENERATION_CANCELED_RESULT
         }
         if (!resolvedSettings.ok) {
           return { success: false, error: resolvedSettings.error }
@@ -643,13 +643,13 @@ export class RuntimeGitCommands {
             context = await provider.getStagedCommitContext(target.worktree.path)
           } catch (error) {
             if (cancellation.isCanceled()) {
-              return { success: false, error: 'Generation canceled.', canceled: true }
+              return TEXT_GENERATION_CANCELED_RESULT
             }
             console.error('[runtime-git] Failed to read remote staged commit context:', error)
             return { success: false, error: 'Failed to read staged changes.' }
           }
           if (cancellation.isCanceled()) {
-            return { success: false, error: 'Generation canceled.', canceled: true }
+            return TEXT_GENERATION_CANCELED_RESULT
           }
           if (!context) {
             return { success: false, error: 'No staged changes to summarize.' }
@@ -673,13 +673,13 @@ export class RuntimeGitCommands {
           )
         } catch (error) {
           if (cancellation.isCanceled()) {
-            return { success: false, error: 'Generation canceled.', canceled: true }
+            return TEXT_GENERATION_CANCELED_RESULT
           }
           console.error('[runtime-git] Failed to read staged commit context:', error)
           return { success: false, error: 'Failed to read staged changes.' }
         }
         if (cancellation.isCanceled()) {
-          return { success: false, error: 'Generation canceled.', canceled: true }
+          return TEXT_GENERATION_CANCELED_RESULT
         }
         if (!context) {
           return { success: false, error: 'No staged changes to summarize.' }
@@ -691,7 +691,7 @@ export class RuntimeGitCommands {
           localAgentRuntimeTargetForTarget(target)
         )
         if (cancellation.isCanceled()) {
-          return { success: false, error: 'Generation canceled.', canceled: true }
+          return TEXT_GENERATION_CANCELED_RESULT
         }
         if (!localEnv.ok) {
           return { success: false, error: localEnv.error }
@@ -715,7 +715,6 @@ export class RuntimeGitCommands {
       await provider?.cancelGenerateCommitMessage(target.worktree.path, 'commit-message')
       return { ok: true }
     }
-    cancelGenerateCommitMessageLocal(target.worktree.path)
     return { ok: true }
   }
 

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -76,6 +76,12 @@ import type {
   CommitMessageAgentRuntimeTarget
 } from '../text-generation/commit-message-agent-environment'
 import { prepareLocalCommitMessageAgentEnv } from '../text-generation/commit-message-agent-environment'
+import {
+  cancelTextGeneration,
+  localTextGenerationLane,
+  runCancelableTextGenerationRequest,
+  sshTextGenerationLane
+} from '../text-generation/text-generation-cancellation'
 import { getPullRequestDraftContext } from '../text-generation/pull-request-context'
 import { normalizeRuntimeRelativePath } from './runtime-relative-paths'
 import { gitExecFileAsync } from '../git/runner'
@@ -594,81 +600,116 @@ export class RuntimeGitCommands {
     settingsOverride?: RuntimeCommitMessageSettingsOverride
   ): Promise<GenerateCommitMessageResult> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
-    const discoveryHostKey =
-      settingsOverride?.commitMessageDiscoveryHostKey ??
-      getCommitMessageModelDiscoveryHostKey(target.connectionId ?? null)
-    const resolvedSettings = settingsOverride?.sourceControlAiResolvedParams
-      ? { ok: true as const, params: settingsOverride.sourceControlAiResolvedParams }
-      : resolveCommitMessageSettings(
-          getRuntimeGitGenerationSettings(
-            this.host.getRuntimeSettings(),
-            settingsOverride,
-            'commitMessage'
-          ),
-          discoveryHostKey,
-          'commitMessage',
-          target.repo ?? null
-        )
-    if (!resolvedSettings.ok) {
-      return { success: false, error: resolvedSettings.error }
-    }
-
-    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
-    if (target.connectionId) {
-      if (!provider) {
-        return {
-          success: false,
-          error: SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
+    const cancellationLane = target.connectionId
+      ? sshTextGenerationLane(target.connectionId, target.worktree.path)
+      : localTextGenerationLane(target.worktree.path)
+    return runCancelableTextGenerationRequest(
+      'commit-message',
+      cancellationLane,
+      { success: false, error: 'Generation canceled.', canceled: true },
+      async (cancellation) => {
+        const discoveryHostKey =
+          settingsOverride?.commitMessageDiscoveryHostKey ??
+          getCommitMessageModelDiscoveryHostKey(target.connectionId ?? null)
+        const resolvedSettings = settingsOverride?.sourceControlAiResolvedParams
+          ? { ok: true as const, params: settingsOverride.sourceControlAiResolvedParams }
+          : resolveCommitMessageSettings(
+              getRuntimeGitGenerationSettings(
+                this.host.getRuntimeSettings(),
+                settingsOverride,
+                'commitMessage'
+              ),
+              discoveryHostKey,
+              'commitMessage',
+              target.repo ?? null
+            )
+        if (cancellation.isCanceled()) {
+          return { success: false, error: 'Generation canceled.', canceled: true }
         }
-      }
-      let context: CommitMessageDraftContext | null
-      try {
-        context = await provider.getStagedCommitContext(target.worktree.path)
-      } catch (error) {
-        console.error('[runtime-git] Failed to read remote staged commit context:', error)
-        return { success: false, error: 'Failed to read staged changes.' }
-      }
-      if (!context) {
-        return { success: false, error: 'No staged changes to summarize.' }
-      }
-      context = withLinkedIssueDraftContext(context, this.linkedIssueForTarget(target))
-      return generateCommitMessageFromContext(context, resolvedSettings.params, {
-        kind: 'remote',
-        cwd: target.worktree.path,
-        execute: (plan, cwd, timeoutMs, operation) =>
-          provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
-        missingBinaryLocation: 'remote PATH'
-      })
-    }
+        if (!resolvedSettings.ok) {
+          return { success: false, error: resolvedSettings.error }
+        }
 
-    let context: CommitMessageDraftContext | null
-    try {
-      context = await getStagedCommitContext(target.worktree.path, localGitOptionsForTarget(target))
-    } catch (error) {
-      console.error('[runtime-git] Failed to read staged commit context:', error)
-      return { success: false, error: 'Failed to read staged changes.' }
-    }
-    if (!context) {
-      return { success: false, error: 'No staged changes to summarize.' }
-    }
-    context = withLinkedIssueDraftContext(context, this.linkedIssueForTarget(target))
-    const localEnv = await prepareLocalCommitMessageAgentEnv(
-      resolvedSettings.params.agentId,
-      this.host.getCommitMessageAgentEnvironment?.(),
-      localAgentRuntimeTargetForTarget(target)
-    )
-    if (!localEnv.ok) {
-      return { success: false, error: localEnv.error }
-    }
-    return generateCommitMessageFromContext(
-      context,
-      resolvedSettings.params,
-      localTextGenerationTargetForTarget(target, localEnv.env)
+        const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+        if (target.connectionId) {
+          if (!provider) {
+            return {
+              success: false,
+              error: SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
+            }
+          }
+          let context: CommitMessageDraftContext | null
+          try {
+            context = await provider.getStagedCommitContext(target.worktree.path)
+          } catch (error) {
+            if (cancellation.isCanceled()) {
+              return { success: false, error: 'Generation canceled.', canceled: true }
+            }
+            console.error('[runtime-git] Failed to read remote staged commit context:', error)
+            return { success: false, error: 'Failed to read staged changes.' }
+          }
+          if (cancellation.isCanceled()) {
+            return { success: false, error: 'Generation canceled.', canceled: true }
+          }
+          if (!context) {
+            return { success: false, error: 'No staged changes to summarize.' }
+          }
+          context = withLinkedIssueDraftContext(context, this.linkedIssueForTarget(target))
+          return generateCommitMessageFromContext(context, resolvedSettings.params, {
+            kind: 'remote',
+            cwd: target.worktree.path,
+            execute: (plan, cwd, timeoutMs, operation) =>
+              provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
+            missingBinaryLocation: 'remote PATH',
+            cancellation
+          })
+        }
+
+        let context: CommitMessageDraftContext | null
+        try {
+          context = await getStagedCommitContext(
+            target.worktree.path,
+            localGitOptionsForTarget(target)
+          )
+        } catch (error) {
+          if (cancellation.isCanceled()) {
+            return { success: false, error: 'Generation canceled.', canceled: true }
+          }
+          console.error('[runtime-git] Failed to read staged commit context:', error)
+          return { success: false, error: 'Failed to read staged changes.' }
+        }
+        if (cancellation.isCanceled()) {
+          return { success: false, error: 'Generation canceled.', canceled: true }
+        }
+        if (!context) {
+          return { success: false, error: 'No staged changes to summarize.' }
+        }
+        context = withLinkedIssueDraftContext(context, this.linkedIssueForTarget(target))
+        const localEnv = await prepareLocalCommitMessageAgentEnv(
+          resolvedSettings.params.agentId,
+          this.host.getCommitMessageAgentEnvironment?.(),
+          localAgentRuntimeTargetForTarget(target)
+        )
+        if (cancellation.isCanceled()) {
+          return { success: false, error: 'Generation canceled.', canceled: true }
+        }
+        if (!localEnv.ok) {
+          return { success: false, error: localEnv.error }
+        }
+        return generateCommitMessageFromContext(context, resolvedSettings.params, {
+          ...localTextGenerationTargetForTarget(target, localEnv.env),
+          cancellation
+        })
+      }
     )
   }
 
   async cancelRuntimeGenerateCommitMessage(worktreeSelector: string): Promise<{ ok: true }> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const cancellationLane = target.connectionId
+      ? sshTextGenerationLane(target.connectionId, target.worktree.path)
+      : localTextGenerationLane(target.worktree.path)
+    cancelTextGeneration('commit-message', cancellationLane)
     const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
     if (target.connectionId) {
       await provider?.cancelGenerateCommitMessage(target.worktree.path, 'commit-message')

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -40,6 +40,13 @@ import {
 } from '../../shared/commit-message-plan'
 import { LOCAL_COMMIT_MESSAGE_HOST_KEY } from '../../shared/commit-message-host-key'
 import {
+  beginTextGenerationCancellation,
+  cancelTextGeneration,
+  localTextGenerationLane,
+  type TextGenerationCancellation,
+  type TextGenerationOperation
+} from './text-generation-cancellation'
+import {
   resolveSourceControlAiForOperation,
   type ResolvedSourceControlAiGenerationParams
 } from '../../shared/source-control-ai'
@@ -91,10 +98,14 @@ export type RemoteCommitMessageExecResult = {
   spawnError?: string
 }
 
-export type TextGenerationOperation = 'commit-message' | 'pull-request-fields' | 'branch-name'
-
 export type CommitMessageGenerationTarget =
-  | { kind: 'local'; cwd: string; env?: NodeJS.ProcessEnv; wslDistro?: string }
+  | {
+      kind: 'local'
+      cwd: string
+      env?: NodeJS.ProcessEnv
+      wslDistro?: string
+      cancellation?: TextGenerationCancellation
+    }
   | {
       kind: 'remote'
       cwd: string
@@ -105,6 +116,7 @@ export type CommitMessageGenerationTarget =
         operation: TextGenerationOperation
       ) => Promise<RemoteCommitMessageExecResult>
       missingBinaryLocation: string
+      cancellation?: TextGenerationCancellation
     }
 
 type ResolveCommitMessageSettingsResult =
@@ -512,9 +524,6 @@ function killProcessTree(child: ChildProcess): void {
   }
 }
 
-// Keying by operation plus `local:${cwd}` keeps local cancellation independent
-// from SSH worktrees and from other generation features in the same worktree.
-const cancelTokensByLane = new Map<string, () => void>()
 const WSL_LAUNCHER_ENV_KEYS = [
   'ComSpec',
   'COMSPEC',
@@ -527,12 +536,8 @@ const WSL_LAUNCHER_ENV_KEYS = [
   'WINDIR'
 ] as const
 
-function localLaneKey(operation: TextGenerationOperation, cwd: string): string {
-  return `${operation}:local:${cwd}`
-}
-
 export function cancelGenerateCommitMessageLocal(cwd: string): void {
-  cancelTokensByLane.get(localLaneKey('commit-message', cwd))?.()
+  cancelTextGeneration('commit-message', localTextGenerationLane(cwd))
 }
 
 function buildWslLauncherEnv(explicitEnv: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
@@ -557,10 +562,19 @@ async function runLocalPlan(
   env: NodeJS.ProcessEnv | undefined,
   emptyResultName = 'message',
   operation: TextGenerationOperation = 'commit-message',
-  wslDistro?: string
+  wslDistro?: string,
+  requestCancellation?: TextGenerationCancellation
 ): Promise<InternalTextGenerationResult> {
   const { binary, args, stdinPayload, label } = plan
   return new Promise((resolve) => {
+    const cancellation =
+      requestCancellation ??
+      beginTextGenerationCancellation(operation, localTextGenerationLane(cwd))
+    if (cancellation.isCanceled()) {
+      cancellation.finish()
+      resolve({ success: false, error: 'Generation canceled.', canceled: true })
+      return
+    }
     let child: ChildProcess
     try {
       const spawnEnv = env ?? process.env
@@ -587,6 +601,7 @@ async function runLocalPlan(
         })
       }
     } catch (error) {
+      cancellation.finish()
       if (error instanceof UnsafeWindowsBatchArgumentsError) {
         resolve({
           success: false,
@@ -609,8 +624,7 @@ async function runLocalPlan(
     let outputLimitExceeded = false
     let settled = false
     let canceledByUser = false
-    const laneKey = localLaneKey(operation, cwd)
-    let cancelToken: (() => void) | null = null
+    let detachCancellation = (): void => {}
     let timer: ReturnType<typeof setTimeout> | null = null
     let detachChildListeners = (): void => {}
     const finalize = (result: InternalTextGenerationResult): void => {
@@ -623,20 +637,19 @@ async function runLocalPlan(
         timer = null
       }
       detachChildListeners()
-      if (cancelToken && cancelTokensByLane.get(laneKey) === cancelToken) {
-        cancelTokensByLane.delete(laneKey)
-      }
+      detachCancellation()
+      cancellation.finish()
       resolve(result)
     }
 
-    cancelToken = () => {
+    const cancelToken = () => {
       canceledByUser = true
       killProcessTree(child)
       // Why: cancellation is a user-visible UI command; do not wait for a
       // wedged agent CLI to emit `close` before the request leaves loading.
       finalize({ success: false, error: 'Generation canceled.', canceled: true })
     }
-    cancelTokensByLane.set(laneKey, cancelToken)
+    detachCancellation = cancellation.attach(cancelToken)
 
     timer = setTimeout(() => {
       killProcessTree(child)
@@ -790,15 +803,27 @@ async function runRemotePlan(
   operation: TextGenerationOperation = 'commit-message'
 ): Promise<InternalTextGenerationResult> {
   const { binary, label } = plan
+  if (target.cancellation?.isCanceled()) {
+    target.cancellation.finish()
+    return { success: false, error: 'Generation canceled.', canceled: true }
+  }
   let result: RemoteCommitMessageExecResult
   try {
     result = await target.execute(plan, target.cwd, GENERATION_TIMEOUT_MS, operation)
   } catch (error) {
+    if (target.cancellation?.isCanceled()) {
+      target.cancellation.finish()
+      return { success: false, error: 'Generation canceled.', canceled: true }
+    }
     console.error('[commit-message] Remote generator request failed:', error)
     return {
       success: false,
       error: `${label} could not be reached on the ${target.missingBinaryLocation}. Try again after the SSH connection recovers.`
     }
+  }
+  if (target.cancellation?.isCanceled()) {
+    target.cancellation.finish()
+    return { success: false, error: 'Generation canceled.', canceled: true }
   }
   if (result.spawnError) {
     if (result.spawnError === WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR) {
@@ -896,13 +921,14 @@ export async function generateCommitMessageFromContext(
           target.env,
           'message',
           'commit-message',
-          target.wslDistro
+          target.wslDistro,
+          target.cancellation
         )
   return formatCommitMessageGenerationResult(internalResult)
 }
 
 export function cancelGeneratePullRequestFieldsLocal(cwd: string): void {
-  cancelTokensByLane.get(localLaneKey('pull-request-fields', cwd))?.()
+  cancelTextGeneration('pull-request-fields', localTextGenerationLane(cwd))
 }
 
 function formatPullRequestFieldsGenerationResult(

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -43,6 +43,7 @@ import {
   beginTextGenerationCancellation,
   cancelTextGeneration,
   localTextGenerationLane,
+  TEXT_GENERATION_CANCELED_RESULT,
   type TextGenerationCancellation,
   type TextGenerationOperation
 } from './text-generation-cancellation'
@@ -567,12 +568,14 @@ async function runLocalPlan(
 ): Promise<InternalTextGenerationResult> {
   const { binary, args, stdinPayload, label } = plan
   return new Promise((resolve) => {
-    const cancellation =
-      requestCancellation ??
-      beginTextGenerationCancellation(operation, localTextGenerationLane(cwd))
+    const ownedCancellation = requestCancellation
+      ? null
+      : beginTextGenerationCancellation(operation, localTextGenerationLane(cwd))
+    const cancellation = requestCancellation ?? ownedCancellation!
+    const finishOwnedCancellation = (): void => ownedCancellation?.finish()
     if (cancellation.isCanceled()) {
-      cancellation.finish()
-      resolve({ success: false, error: 'Generation canceled.', canceled: true })
+      finishOwnedCancellation()
+      resolve(TEXT_GENERATION_CANCELED_RESULT)
       return
     }
     let child: ChildProcess
@@ -601,7 +604,7 @@ async function runLocalPlan(
         })
       }
     } catch (error) {
-      cancellation.finish()
+      finishOwnedCancellation()
       if (error instanceof UnsafeWindowsBatchArgumentsError) {
         resolve({
           success: false,
@@ -638,7 +641,7 @@ async function runLocalPlan(
       }
       detachChildListeners()
       detachCancellation()
-      cancellation.finish()
+      finishOwnedCancellation()
       resolve(result)
     }
 
@@ -647,7 +650,7 @@ async function runLocalPlan(
       killProcessTree(child)
       // Why: cancellation is a user-visible UI command; do not wait for a
       // wedged agent CLI to emit `close` before the request leaves loading.
-      finalize({ success: false, error: 'Generation canceled.', canceled: true })
+      finalize(TEXT_GENERATION_CANCELED_RESULT)
     }
     detachCancellation = cancellation.attach(cancelToken)
 
@@ -694,7 +697,7 @@ async function runLocalPlan(
     }
     const onClose = (code: number | null): void => {
       if (canceledByUser) {
-        finalize({ success: false, error: 'Generation canceled.', canceled: true })
+        finalize(TEXT_GENERATION_CANCELED_RESULT)
         return
       }
       if (outputLimitExceeded) {
@@ -804,16 +807,14 @@ async function runRemotePlan(
 ): Promise<InternalTextGenerationResult> {
   const { binary, label } = plan
   if (target.cancellation?.isCanceled()) {
-    target.cancellation.finish()
-    return { success: false, error: 'Generation canceled.', canceled: true }
+    return TEXT_GENERATION_CANCELED_RESULT
   }
   let result: RemoteCommitMessageExecResult
   try {
     result = await target.execute(plan, target.cwd, GENERATION_TIMEOUT_MS, operation)
   } catch (error) {
     if (target.cancellation?.isCanceled()) {
-      target.cancellation.finish()
-      return { success: false, error: 'Generation canceled.', canceled: true }
+      return TEXT_GENERATION_CANCELED_RESULT
     }
     console.error('[commit-message] Remote generator request failed:', error)
     return {
@@ -822,8 +823,7 @@ async function runRemotePlan(
     }
   }
   if (target.cancellation?.isCanceled()) {
-    target.cancellation.finish()
-    return { success: false, error: 'Generation canceled.', canceled: true }
+    return TEXT_GENERATION_CANCELED_RESULT
   }
   if (result.spawnError) {
     if (result.spawnError === WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR) {
@@ -845,7 +845,7 @@ async function runRemotePlan(
     }
   }
   if (result.canceled) {
-    return { success: false, error: 'Generation canceled.', canceled: true }
+    return TEXT_GENERATION_CANCELED_RESULT
   }
   if (result.timedOut) {
     return {

--- a/src/main/text-generation/text-generation-cancellation.test.ts
+++ b/src/main/text-generation/text-generation-cancellation.test.ts
@@ -1,0 +1,80 @@
+import { expect, it, vi } from 'vitest'
+import {
+  beginTextGenerationCancellation,
+  cancelTextGeneration,
+  localTextGenerationLane,
+  runCancelableTextGenerationRequest,
+  sshTextGenerationLane
+} from './text-generation-cancellation'
+
+it('settles a request immediately while pre-spawn work remains pending', async () => {
+  let releaseWork = (): void => {}
+  const work = new Promise<void>((resolve) => {
+    releaseWork = resolve
+  })
+  const reachedAfterWork = vi.fn()
+
+  const pending = runCancelableTextGenerationRequest(
+    'commit-message',
+    localTextGenerationLane('/repo'),
+    'canceled',
+    async (cancellation) => {
+      await work
+      if (!cancellation.isCanceled()) {
+        reachedAfterWork()
+      }
+      return 'completed'
+    }
+  )
+
+  cancelTextGeneration('commit-message', localTextGenerationLane('/repo'))
+
+  await expect(pending).resolves.toBe('canceled')
+  expect(reachedAfterWork).not.toHaveBeenCalled()
+
+  releaseWork()
+  await work
+  await Promise.resolve()
+  expect(reachedAfterWork).not.toHaveBeenCalled()
+})
+
+it('does not let an older request clear a newer request in the same lane', () => {
+  const lane = localTextGenerationLane('/repo')
+  const older = beginTextGenerationCancellation('commit-message', lane)
+  const newer = beginTextGenerationCancellation('commit-message', lane)
+
+  older.finish()
+  cancelTextGeneration('commit-message', lane)
+
+  expect(older.isCanceled()).toBe(false)
+  expect(newer.isCanceled()).toBe(true)
+  newer.finish()
+})
+
+it('runs an attached cancellation action only once', () => {
+  const lane = localTextGenerationLane('/repo')
+  const cancellation = beginTextGenerationCancellation('commit-message', lane)
+  const action = vi.fn()
+  cancellation.attach(action)
+
+  cancelTextGeneration('commit-message', lane)
+  cancelTextGeneration('commit-message', lane)
+
+  expect(action).toHaveBeenCalledTimes(1)
+  cancellation.finish()
+})
+
+it('isolates identical paths across local and SSH hosts', () => {
+  const local = beginTextGenerationCancellation('commit-message', localTextGenerationLane('/repo'))
+  const remote = beginTextGenerationCancellation(
+    'commit-message',
+    sshTextGenerationLane('connection-1', '/repo')
+  )
+
+  cancelTextGeneration('commit-message', sshTextGenerationLane('connection-1', '/repo'))
+
+  expect(local.isCanceled()).toBe(false)
+  expect(remote.isCanceled()).toBe(true)
+  local.finish()
+  remote.finish()
+})

--- a/src/main/text-generation/text-generation-cancellation.ts
+++ b/src/main/text-generation/text-generation-cancellation.ts
@@ -1,5 +1,11 @@
 export type TextGenerationOperation = 'commit-message' | 'pull-request-fields' | 'branch-name'
 
+export const TEXT_GENERATION_CANCELED_RESULT = {
+  success: false,
+  error: 'Generation canceled.',
+  canceled: true
+} as const
+
 export type TextGenerationCancellation = {
   isCanceled: () => boolean
   attach: (action: () => void) => () => void
@@ -7,69 +13,89 @@ export type TextGenerationCancellation = {
   whenCanceled: Promise<void>
 }
 
-const activeCancellations = new Map<string, () => void>()
+const activeCancellations = new Map<string, TextGenerationCancellationController>()
 
+class TextGenerationCancellationController implements TextGenerationCancellation {
+  private canceled = false
+  private action: (() => void) | null = null
+  private resolveCanceled: () => void = () => {}
+  readonly whenCanceled = new Promise<void>((resolve) => {
+    this.resolveCanceled = resolve
+  })
+
+  constructor(private readonly key: string) {}
+
+  /** Reports whether the user has canceled this request. */
+  isCanceled(): boolean {
+    return this.canceled
+  }
+
+  /** Connects cancellation to a process action once the child exists. */
+  attach(action: () => void): () => void {
+    this.action = action
+    if (this.canceled) {
+      action()
+    }
+
+    /** Detaches only the action installed by this caller. */
+    return () => {
+      if (this.action === action) {
+        this.action = null
+      }
+    }
+  }
+
+  /** Cancels once and resolves both pre-spawn and post-spawn observers. */
+  cancel(): void {
+    if (this.canceled) {
+      return
+    }
+    this.canceled = true
+    this.resolveCanceled()
+    this.action?.()
+  }
+
+  /** Releases this controller without clearing a newer request in the lane. */
+  finish(): void {
+    if (activeCancellations.get(this.key) === this) {
+      activeCancellations.delete(this.key)
+    }
+    this.action = null
+  }
+}
+
+/** Builds an unambiguous registry key for one operation lane. */
 function cancellationKey(operation: TextGenerationOperation, lane: string): string {
   return JSON.stringify([operation, lane])
 }
 
+/** Identifies a text-generation lane on the native or selected WSL host. */
 export function localTextGenerationLane(cwd: string): string {
   return `local:${cwd}`
 }
 
+/** Identifies a text-generation lane on one SSH connection. */
 export function sshTextGenerationLane(connectionId: string, cwd: string): string {
   return `ssh:${connectionId}:${cwd}`
 }
 
+/** Registers a cancelable request before its pre-spawn work begins. */
 export function beginTextGenerationCancellation(
   operation: TextGenerationOperation,
   lane: string
 ): TextGenerationCancellation {
   const key = cancellationKey(operation, lane)
-  let canceled = false
-  let action: (() => void) | null = null
-  let resolveCanceled = (): void => {}
-  const whenCanceled = new Promise<void>((resolve) => {
-    resolveCanceled = resolve
-  })
-  const cancel = (): void => {
-    if (canceled) {
-      return
-    }
-    canceled = true
-    resolveCanceled()
-    action?.()
-  }
-  activeCancellations.set(key, cancel)
-
-  return {
-    isCanceled: () => canceled,
-    attach: (nextAction) => {
-      action = nextAction
-      if (canceled) {
-        nextAction()
-      }
-      return () => {
-        if (action === nextAction) {
-          action = null
-        }
-      }
-    },
-    whenCanceled,
-    finish: () => {
-      // Why: an older request may finish after a newer request has claimed the same lane.
-      if (activeCancellations.get(key) === cancel) {
-        activeCancellations.delete(key)
-      }
-      action = null
-    }
-  }
+  const cancellation = new TextGenerationCancellationController(key)
+  activeCancellations.set(key, cancellation)
+  return cancellation
 }
 
+/** Cancels the active request for an operation lane, when present. */
 export function cancelTextGeneration(operation: TextGenerationOperation, lane: string): void {
-  activeCancellations.get(cancellationKey(operation, lane))?.()
+  activeCancellations.get(cancellationKey(operation, lane))?.cancel()
 }
 
+/** Settles a request immediately on cancellation while its guarded work unwinds. */
 export async function runCancelableTextGenerationRequest<T>(
   operation: TextGenerationOperation,
   lane: string,

--- a/src/main/text-generation/text-generation-cancellation.ts
+++ b/src/main/text-generation/text-generation-cancellation.ts
@@ -1,0 +1,86 @@
+export type TextGenerationOperation = 'commit-message' | 'pull-request-fields' | 'branch-name'
+
+export type TextGenerationCancellation = {
+  isCanceled: () => boolean
+  attach: (action: () => void) => () => void
+  finish: () => void
+  whenCanceled: Promise<void>
+}
+
+const activeCancellations = new Map<string, () => void>()
+
+function cancellationKey(operation: TextGenerationOperation, lane: string): string {
+  return JSON.stringify([operation, lane])
+}
+
+export function localTextGenerationLane(cwd: string): string {
+  return `local:${cwd}`
+}
+
+export function sshTextGenerationLane(connectionId: string, cwd: string): string {
+  return `ssh:${connectionId}:${cwd}`
+}
+
+export function beginTextGenerationCancellation(
+  operation: TextGenerationOperation,
+  lane: string
+): TextGenerationCancellation {
+  const key = cancellationKey(operation, lane)
+  let canceled = false
+  let action: (() => void) | null = null
+  let resolveCanceled = (): void => {}
+  const whenCanceled = new Promise<void>((resolve) => {
+    resolveCanceled = resolve
+  })
+  const cancel = (): void => {
+    if (canceled) {
+      return
+    }
+    canceled = true
+    resolveCanceled()
+    action?.()
+  }
+  activeCancellations.set(key, cancel)
+
+  return {
+    isCanceled: () => canceled,
+    attach: (nextAction) => {
+      action = nextAction
+      if (canceled) {
+        nextAction()
+      }
+      return () => {
+        if (action === nextAction) {
+          action = null
+        }
+      }
+    },
+    whenCanceled,
+    finish: () => {
+      // Why: an older request may finish after a newer request has claimed the same lane.
+      if (activeCancellations.get(key) === cancel) {
+        activeCancellations.delete(key)
+      }
+      action = null
+    }
+  }
+}
+
+export function cancelTextGeneration(operation: TextGenerationOperation, lane: string): void {
+  activeCancellations.get(cancellationKey(operation, lane))?.()
+}
+
+export async function runCancelableTextGenerationRequest<T>(
+  operation: TextGenerationOperation,
+  lane: string,
+  canceledResult: T,
+  run: (cancellation: TextGenerationCancellation) => Promise<T>
+): Promise<T> {
+  const cancellation = beginTextGenerationCancellation(operation, lane)
+  const generation = run(cancellation)
+  try {
+    return await Promise.race([generation, cancellation.whenCanceled.then(() => canceledResult)])
+  } finally {
+    cancellation.finish()
+  }
+}


### PR DESCRIPTION
Closes #10855.

## Summary

Canceling commit-message generation now settles immediately, including while staged-context or agent-environment preparation is still pending. Pending pre-spawn work cannot launch an agent after cancellation, while cancellation after spawn still terminates the process tree.

Cancellation lanes are isolated by operation, host, and path across local, WSL, and SSH targets.

## Screenshots

No visual change.

## Testing

- [x] `pnpm run typecheck`
- [x] `npx oxlint src/main/text-generation/text-generation-cancellation.ts src/main/text-generation/text-generation-cancellation.test.ts src/main/text-generation/commit-message-text-generation.ts src/main/ipc/filesystem.ts src/main/ipc/filesystem.test.ts src/main/runtime/orca-runtime-git.ts`
- [x] `npx vitest run --config config/vitest.config.ts src/main/text-generation/text-generation-cancellation.test.ts src/main/ipc/filesystem.test.ts src/main/text-generation/commit-message-text-generation.test.ts src/main/runtime/orca-runtime-git.test.ts` (199 passed, 1 skipped)
- [x] `pnpm run build:electron-vite`
- [x] `pnpm run build:web`
- [x] Added regression coverage for cancellation before spawn, immediate request settlement, local/SSH isolation, same-lane request ordering, idempotent cancellation, and child processes that do not close after termination.

## Review Report

Reviewed cancellation ownership, request ordering, duplicate cancellation paths, cleanup of timers/listeners/actions, and the race between pre-spawn work and process creation. The review found and corrected premature cleanup of caller-owned cancellation state and redundant local cancellation calls.

Cross-platform behavior was checked for macOS, Linux, Windows, WSL, and SSH. The change introduces no shortcuts, labels, shell commands, or path parsing; host identity is explicit in cancellation lane keys.

## Security Audit

No new command construction, executable resolution, filesystem authorization, credentials, dependencies, or renderer-controlled IPC parameters were added. Existing worktree authorization and SSH provider routing remain unchanged. Cancellation keys are internal JSON-encoded tuples, and cancellation cannot cross local or SSH host boundaries.

## Notes

Pre-spawn operations that do not expose an abort signal may finish internally after the request settles, but cancellation guards prevent them from spawning an agent or returning a generated message.
