### PR TITLE
Improve Monaco editor caret accessibility on macOS

### DIFF
--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -118,6 +118,7 @@ export default function MonacoEditor({
 }: MonacoEditorProps): React.JSX.Element {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
   const editorContainerRef = useRef<HTMLDivElement | null>(null)
+  const caretAccessibilityAnchorRef = useRef<HTMLDivElement | null>(null)
   const [mountedEditor, setMountedEditor] = useState<editor.IStandaloneCodeEditor | null>(null)
   const [autoHeightContentHeight, setAutoHeightContentHeight] = useState<number | null>(null)
   const modelKeyRef = useRef<string | null>(null)
@@ -140,6 +141,19 @@ export default function MonacoEditor({
   readOnlyRef.current = readOnly
   const contentSyncModeRef = useRef<MonacoContentSyncMode>('undoable')
   contentSyncModeRef.current = readOnly && liveTail ? 'read-only-live-tail' : 'undoable'
+  const caretAccessibilityAnchorId = useMemo(() => {
+    const stableId = [viewStateId, viewStateKey, fileId]
+      .filter(Boolean)
+      .join('-')
+      .replace(/[^A-Za-z0-9_-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '')
+    return `orca-monaco-caret-anchor-${stableId || 'editor'}`
+  }, [fileId, viewStateId, viewStateKey])
+  const caretAccessibilityLabel = translate(
+    'auto.components.editor.MonacoEditor.caretAccessibilityLabel',
+    'Editor caret'
+  )
 
   const settings = useAppStore((s) => s.settings)
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
@@ -403,6 +417,45 @@ export default function MonacoEditor({
         propsRef.current.onSave(value)
       })
       const cleanupFindShortcut = installMonacoEditorFindShortcut(editorInstance)
+      let caretAccessibilityFrame: number | null = null
+      const updateCaretAccessibilityAnchor = (): void => {
+        if (caretAccessibilityFrame !== null) {
+          return
+        }
+        caretAccessibilityFrame = window.requestAnimationFrame(() => {
+          caretAccessibilityFrame = null
+          const anchor = caretAccessibilityAnchorRef.current
+          const position = editorInstance.getPosition()
+          if (!anchor || !position) {
+            return
+          }
+
+          const visiblePosition = editorInstance.getScrolledVisiblePosition(position)
+          if (!visiblePosition) {
+            anchor.style.display = 'none'
+            anchor.classList.remove('orca-monaco-caret-anchor-active')
+            return
+          }
+
+          anchor.style.display = 'block'
+          anchor.classList.toggle('orca-monaco-caret-anchor-active', editorInstance.hasTextFocus())
+          anchor.style.transform = `translate(${Math.round(visiblePosition.left)}px, ${Math.round(visiblePosition.top)}px)`
+          anchor.style.height = `${Math.max(1, Math.round(visiblePosition.height))}px`
+          anchor.dataset.line = String(position.lineNumber)
+          anchor.dataset.column = String(position.column)
+          anchor.setAttribute(
+            'aria-label',
+            translate(
+              'auto.components.editor.MonacoEditor.caretAccessibilityPositionLabel',
+              'Editor caret at line {{line}}, column {{column}}',
+              {
+                line: position.lineNumber,
+                column: position.column
+              }
+            )
+          )
+        })
+      }
       // Opens the same composer as the selection "+" button.
       const cleanupAddReviewNoteShortcut = installEditorAddReviewNoteShortcut(editorDomNode, () => {
         // Why: keep an open draft instead of remounting, to avoid same-tick chord races before the composer guard runs.
@@ -478,16 +531,22 @@ export default function MonacoEditor({
       if (pos) {
         setEditorCursorLine(filePath, pos.lineNumber)
       }
+      updateCaretAccessibilityAnchor()
       const cursorPositionSub = editorInstance.onDidChangeCursorPosition((e) => {
         setEditorCursorLine(filePath, e.position.lineNumber)
         setWithLRU(cursorPositionCache, viewStateKey, {
           lineNumber: e.position.lineNumber,
           column: e.position.column
         })
+        updateCaretAccessibilityAnchor()
       })
+      const layoutSub = editorInstance.onDidLayoutChange(updateCaretAccessibilityAnchor)
+      const focusSub = editorInstance.onDidFocusEditorText(updateCaretAccessibilityAnchor)
+      const blurSub = editorInstance.onDidBlurEditorText(updateCaretAccessibilityAnchor)
 
       // Why: only the resting scroll position matters, so trailing-throttle writes (~150ms) instead of writing every 60fps frame.
       const scrollStateSub = editorInstance.onDidScrollChange((e) => {
+        updateCaretAccessibilityAnchor()
         if (scrollThrottleTimerRef.current !== null) {
           clearTimeout(scrollThrottleTimerRef.current)
         }
@@ -515,6 +574,9 @@ export default function MonacoEditor({
 
       editorInstance.onDidDispose(() => {
         cursorPositionSub.dispose()
+        layoutSub.dispose()
+        focusSub.dispose()
+        blurSub.dispose()
         scrollStateSub.dispose()
         gutterMouseDownSub.dispose()
         cleanupSaveShortcut()
@@ -526,6 +588,10 @@ export default function MonacoEditor({
         if (autoHeightFrame !== null) {
           window.cancelAnimationFrame(autoHeightFrame)
           autoHeightFrame = null
+        }
+        if (caretAccessibilityFrame !== null) {
+          window.cancelAnimationFrame(caretAccessibilityFrame)
+          caretAccessibilityFrame = null
         }
         conflictDecorationsRef.current?.clear()
         conflictDecorationsRef.current = null
@@ -835,6 +901,14 @@ export default function MonacoEditor({
           <Plus className="size-3" />
         </button>
       ) : null}
+      <div
+        ref={caretAccessibilityAnchorRef}
+        id={caretAccessibilityAnchorId}
+        className="orca-monaco-caret-anchor pointer-events-none absolute left-0 top-0 z-0 w-px"
+        role="note"
+        aria-label={caretAccessibilityLabel}
+        style={{ display: 'none', opacity: 0 }}
+      />
       <Editor
         height={renderedEditorHeight === null ? '100%' : `${renderedEditorHeight}px`}
         language={language}


### PR DESCRIPTION
## Summary

- Add a non-visual DOM anchor that tracks the Monaco editor caret position.
- Update the anchor on cursor, scroll, and layout changes using Monaco's `getScrolledVisiblePosition`.
- Expose line/column metadata without exposing editor text content.
- Localize the caret accessibility labels and use a unique anchor id per editor instance, with shared/active classes for assistive clients that need to resolve the focused editor.

## Screenshots

No visual change. The anchor is visually hidden and non-interactive.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Validation run locally:

- `pnpm exec oxfmt --write src/renderer/src/components/editor/MonacoEditor.tsx`
- `pnpm exec oxlint src/renderer/src/components/editor/MonacoEditor.tsx`
- `pnpm run typecheck:web`

Targeted validation is sufficient for this one-file renderer accessibility hook because it does not change editor content handling, persistence, IPC, commands, or visual UI. Full repo-wide lint/typecheck/test/build were not run locally due to the scope of the change.

Note: local validation ran with Node v26.0.0, while the repo declares Node 24; pnpm emitted an unsupported-engine warning, but the checks completed successfully.

## AI Review Report

AI review checked the Monaco editor lifecycle, cursor/scroll/layout update subscriptions, cleanup on disposal, localization consistency, duplicate DOM id risk in split panes, and cross-platform impact.

Findings addressed:

- The original fixed `orca-monaco-caret-anchor` id could be duplicated when multiple Monaco editors are mounted. The PR now generates a stable per-editor id.
- The static and dynamic ARIA labels bypassed the local translation helper. Both labels now use `translate()`.
- A shared `orca-monaco-caret-anchor` class and focus-dependent `orca-monaco-caret-anchor-active` class were added so accessibility clients can find the focused editor without relying on a fixed id.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows. The change is DOM/ARIA metadata inside the renderer only; it does not alter shortcuts, filesystem paths, shell behavior, native modules, or Electron IPC. macOS benefits from the accessibility anchor, while Linux/Windows should see no behavioral change beyond inert DOM metadata.

## Security Audit

This change does not add command execution, IPC, network access, file/path handling, auth, secrets, dependencies, or clipboard access.

The anchor exposes only caret line/column metadata and a localized label. It intentionally does not expose editor text content. The element is pointer-events disabled, visually hidden, and non-interactive, so it should not affect user input or create an injection surface.

No security follow-up is currently needed.

## Notes

This is primarily a macOS accessibility compatibility improvement for Monaco-backed source editors, where external accessibility clients can otherwise receive only a full line box instead of a precise insertion-point rectangle. Rich Markdown editing surfaces already expose a more accurate caret rect through the accessibility tree.
