### PR TITLE
fix(shell): preserve exit status across OSC 133 hooks

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -98,7 +98,14 @@ async function runInteractiveZshRc(args: {
   return output
 }
 
-function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): string {
+function runInteractiveBashRcfile(
+  rcfileContent: string,
+  tempDir: string,
+  // Why: attribution shells launch with the marker off, and the trailing marker
+  // test used to be the precmd's last command — only marker='0' exposes the
+  // phantom-error direction of #10940.
+  readyMarker: '0' | '1' = '1'
+): string {
   const rcfile = join(tempDir, 'bash-osc133-rcfile')
   writeFileSync(rcfile, rcfileContent)
 
@@ -111,7 +118,7 @@ function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): strin
       env: {
         ...process.env,
         HOME: tempDir,
-        ORCA_SHELL_READY_MARKER: '1',
+        ORCA_SHELL_READY_MARKER: readyMarker,
         TERM: process.env.TERM || 'xterm'
       },
       timeout: 5000
@@ -500,7 +507,9 @@ describePosix('daemon shell-ready launch config', () => {
     )
     expect(zshrc).toContain('printf "\\033]133;D;%s\\007"')
     expect(zshrc).toContain('printf "\\033]133;C\\007"')
-    expect(zshrc).toContain('return "$exit_code"')
+    // Why: zsh restores $? per precmd hook, so a return here would only double
+    // the ERR-trap fires for a failed command (#10940 review).
+    expect(zshrc).not.toContain('return "$exit_code"')
   })
 
   itWithBash(
@@ -529,11 +538,41 @@ describePosix('daemon shell-ready launch config', () => {
       const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
 
       expect(output).toContain('PROMPT_HOOK')
-      expect(output).toContain('PROMPT_STATUS:1')
+      // Why: #10940 — pre-fix the precmd returned its own printf status, so the
+      // downstream hook saw 0,0,0 and a real failure looked like success.
+      expect([...output.matchAll(/PROMPT_STATUS:(\d+)/g)].map((match) => match[1])).toEqual([
+        '0',
+        '0',
+        '1'
+      ])
       expect(output).toContain('USER_DEBUG_AFTER')
       expectBashOsc133Lifecycle(output)
     }
   )
+
+  // Why: #10940's headline symptom. With the marker off (attribution shells) the
+  // precmd's last command used to be a failing `[[ ... ]]` test, so a successful
+  // command reached prompt frameworks as status 1 — a phantom error on every
+  // prompt. Guards both directions from one run.
+  itWithBash('reports the real command status to prompt hooks with the marker off', async () => {
+    const { getDaemonBashShellReadyRcfileContent } = await importFreshShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      'PROMPT_COMMAND=\'printf "PROMPT_STATUS:%s\\n" "$?"; printf "LATER_HOOK\\n"\''
+    )
+
+    const output = runInteractiveBashRcfile(
+      getDaemonBashShellReadyRcfileContent(),
+      userDataPath,
+      '0'
+    )
+
+    const statuses = [...output.matchAll(/PROMPT_STATUS:(\d+)/g)].map((match) => match[1])
+    // First prompt + `true` report 0; `false` reports 1. Pre-fix this was 1,1,1.
+    expect(statuses).toEqual(['0', '0', '1'])
+    // Why: a non-zero precmd return must not abort the rest of the chain.
+    expect([...output.matchAll(/LATER_HOOK/g)]).toHaveLength(3)
+  })
 
   itWithBash(
     'still emits 133;C when bash-preexec re-arms the DEBUG trap at first prompt',

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -489,6 +489,7 @@ describePosix('daemon shell-ready launch config', () => {
 
     expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(bashRc).toContain('printf "\\033]133;C\\007"')
+    expect(bashRc).toContain('return "$exit_code"')
     // precmd is prepended (captures $? first), epilogue appended last, so a framework needing last position stays between them.
     expect(bashRc).toContain(
       'PROMPT_COMMAND="__orca_osc133_precmd${PROMPT_COMMAND:+;${PROMPT_COMMAND}};__orca_osc133_epilogue"'
@@ -499,6 +500,7 @@ describePosix('daemon shell-ready launch config', () => {
     )
     expect(zshrc).toContain('printf "\\033]133;D;%s\\007"')
     expect(zshrc).toContain('printf "\\033]133;C\\007"')
+    expect(zshrc).toContain('return "$exit_code"')
   })
 
   itWithBash(
@@ -519,7 +521,7 @@ describePosix('daemon shell-ready launch config', () => {
       writeFileSync(
         join(userDataPath, '.bash_profile'),
         [
-          'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
+          'PROMPT_COMMAND=\'printf "PROMPT_STATUS:%s\\n" "$?"; AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
           'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
         ].join('\n')
       )
@@ -527,6 +529,7 @@ describePosix('daemon shell-ready launch config', () => {
       const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath)
 
       expect(output).toContain('PROMPT_HOOK')
+      expect(output).toContain('PROMPT_STATUS:1')
       expect(output).toContain('USER_DEBUG_AFTER')
       expectBashOsc133Lifecycle(output)
     }

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -139,6 +139,8 @@ __orca_osc133_precmd() {
   # so a framework that must be last in PROMPT_COMMAND — bash-preexec — is not
   # displaced by one of Orca's own hooks.
   [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]] && printf "${SHELL_READY_MARKER}"
+  # Why: downstream prompt hooks must observe the foreground command's status.
+  return "$exit_code"
 }
 __orca_run_user_debug_trap() {
   if [[ -n "\${__orca_user_debug_trap:-}" ]]; then
@@ -251,6 +253,8 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
+  # Why: downstream prompt hooks must observe the foreground command's status.
+  return "$exit_code"
 }
 __orca_osc133_preexec() {
   printf "\\033]133;C\\007"

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -253,13 +253,14 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
-  # Why: downstream prompt hooks must observe the foreground command's status.
-  return "$exit_code"
 }
 __orca_osc133_preexec() {
   printf "\\033]133;C\\007"
   __orca_in_command=1
 }
+# Why: no exit-status return here — unlike bash's PROMPT_COMMAND chain, zsh
+# resets $? to the foreground command's status before each precmd hook, so a
+# return would only add a second spurious ERR-trap fire per failed command.
 # Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
 precmd_functions=(__orca_osc133_precmd \${precmd_functions[@]})
 preexec_functions=(__orca_osc133_preexec \${preexec_functions[@]})

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -545,7 +545,9 @@ describePosix('local PTY shell-ready launch config', () => {
     // Sanity: zsh wrapper emits the same markers — both branches must stay in sync.
     expect(zshRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(zshRc).toContain('printf "\\033]133;C\\007"')
-    expect(zshRc).toContain('return "$exit_code"')
+    // Why: zsh restores $? per precmd hook, so a return here would only double
+    // the ERR-trap fires for a failed command (#10940 review).
+    expect(zshRc).not.toContain('return "$exit_code"')
   })
 
   itWithBash('runs the bash wrapper without fake C/D markers before the first prompt', async () => {
@@ -571,7 +573,13 @@ describePosix('local PTY shell-ready launch config', () => {
       const output = runInteractiveBashRcfile(getBashShellReadyRcfileContent(), userDataPath)
 
       expect(output).toContain('PROMPT_HOOK')
-      expect(output).toContain('PROMPT_STATUS:1')
+      // Why: #10940 — pre-fix the precmd returned its own printf status, so the
+      // downstream hook saw 0,0,0 and a real failure looked like success.
+      expect([...output.matchAll(/PROMPT_STATUS:(\d+)/g)].map((match) => match[1])).toEqual([
+        '0',
+        '0',
+        '1'
+      ])
       expect(output).toContain('USER_DEBUG_AFTER')
       expectBashOsc133Lifecycle(output)
     }

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -535,6 +535,7 @@ describePosix('local PTY shell-ready launch config', () => {
     // The exact escape sequences terminal-command-lifecycle parses (133;D = finished, 133;C = start).
     expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(bashRc).toContain('printf "\\033]133;C\\007"')
+    expect(bashRc).toContain('return "$exit_code"')
     expect(bashRc).toContain(
       'PROMPT_COMMAND="__orca_osc133_precmd${PROMPT_COMMAND:+;${PROMPT_COMMAND}}"'
     )
@@ -544,6 +545,7 @@ describePosix('local PTY shell-ready launch config', () => {
     // Sanity: zsh wrapper emits the same markers — both branches must stay in sync.
     expect(zshRc).toContain('printf "\\033]133;D;%s\\007"')
     expect(zshRc).toContain('printf "\\033]133;C\\007"')
+    expect(zshRc).toContain('return "$exit_code"')
   })
 
   itWithBash('runs the bash wrapper without fake C/D markers before the first prompt', async () => {
@@ -561,7 +563,7 @@ describePosix('local PTY shell-ready launch config', () => {
       writeFileSync(
         join(userDataPath, '.bash_profile'),
         [
-          'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
+          'PROMPT_COMMAND=\'printf "PROMPT_STATUS:%s\\n" "$?"; AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
           'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
         ].join('\n')
       )
@@ -569,6 +571,7 @@ describePosix('local PTY shell-ready launch config', () => {
       const output = runInteractiveBashRcfile(getBashShellReadyRcfileContent(), userDataPath)
 
       expect(output).toContain('PROMPT_HOOK')
+      expect(output).toContain('PROMPT_STATUS:1')
       expect(output).toContain('USER_DEBUG_AFTER')
       expectBashOsc133Lifecycle(output)
     }

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -143,6 +143,8 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
+  # Why: downstream prompt hooks must observe the foreground command's status.
+  return "$exit_code"
 }
 __orca_osc133_prompt_done() {
   unset __orca_in_prompt_command
@@ -254,6 +256,8 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
+  # Why: downstream prompt hooks must observe the foreground command's status.
+  return "$exit_code"
 }
 __orca_osc133_preexec() {
   printf "\\033]133;C\\007"

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -256,13 +256,14 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
-  # Why: downstream prompt hooks must observe the foreground command's status.
-  return "$exit_code"
 }
 __orca_osc133_preexec() {
   printf "\\033]133;C\\007"
   __orca_in_command=1
 }
+# Why: no exit-status return here — unlike bash's PROMPT_COMMAND chain, zsh
+# resets $? to the foreground command's status before each precmd hook, so a
+# return would only add a second spurious ERR-trap fire per failed command.
 # Why: prepend so Orca captures $? before user prompt hooks can overwrite it.
 precmd_functions=(__orca_osc133_precmd \${precmd_functions[@]})
 preexec_functions=(__orca_osc133_preexec \${preexec_functions[@]})

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -220,7 +220,13 @@ describe('getRelayShellLaunchConfig', () => {
     const output = runInteractiveBashRcfile(config.args[1] as string, homeDir)
 
     expect(output).toContain('PROMPT_HOOK')
-    expect(output).toContain('PROMPT_STATUS:1')
+    // Why: #10940 — pre-fix the precmd returned its own printf status, so the
+    // downstream hook saw 0,0,0 and a real failure looked like success.
+    expect([...output.matchAll(/PROMPT_STATUS:(\d+)/g)].map((match) => match[1])).toEqual([
+      '0',
+      '0',
+      '1'
+    ])
     expect(output).toContain('USER_DEBUG_AFTER')
     expectBashOsc133Lifecycle(output)
   })

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -166,6 +166,7 @@ describe('getRelayShellLaunchConfig', () => {
       expect(config.env).toEqual({})
       expect(bashRc).toContain('printf "\\033]133;D;%s\\007"')
       expect(bashRc).toContain('printf "\\033]133;C\\007"')
+      expect(bashRc).toContain('return "$exit_code"')
     }
   )
 
@@ -211,7 +212,7 @@ describe('getRelayShellLaunchConfig', () => {
     writeFileSync(
       join(homeDir, '.bash_profile'),
       [
-        'PROMPT_COMMAND=\'AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
+        'PROMPT_COMMAND=\'printf "PROMPT_STATUS:%s\\n" "$?"; AFTER_FIRST_PROMPT=1; printf "PROMPT_HOOK\\n"\'',
         'trap \'if [[ -n "${AFTER_FIRST_PROMPT:-}" ]]; then\n  printf "USER_DEBUG_AFTER\\n"\nfi\' DEBUG'
       ].join('\n')
     )
@@ -219,6 +220,7 @@ describe('getRelayShellLaunchConfig', () => {
     const output = runInteractiveBashRcfile(config.args[1] as string, homeDir)
 
     expect(output).toContain('PROMPT_HOOK')
+    expect(output).toContain('PROMPT_STATUS:1')
     expect(output).toContain('USER_DEBUG_AFTER')
     expectBashOsc133Lifecycle(output)
   })

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -161,6 +161,8 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
+  # Why: downstream prompt hooks must observe the foreground command's status.
+  return "$exit_code"
 }
 __orca_osc133_prompt_done() {
   unset __orca_in_prompt_command


### PR DESCRIPTION
## Summary

- return the captured foreground-command status from OSC 133 precmd hooks
- preserve the status seen by downstream prompt framework hooks in daemon, local PTY, and SSH relay sessions
- add regression coverage proving Bash prompt hooks still observe a failing command and keep Bash/Zsh wrapper generation in sync

## Validation

- `pnpm run typecheck`
- `npx oxlint src/main/daemon/shell-ready.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.ts src/main/providers/local-pty-shell-ready.test.ts src/relay/pty-shell-launch.ts src/relay/pty-shell-launch.test.ts`
- `npx vitest run --config config/vitest.config.ts src/main/daemon/shell-ready.test.ts src/main/providers/local-pty-shell-ready.test.ts src/relay/pty-shell-launch.test.ts`
- `pnpm run build:electron-vite`
- `pnpm run build:web`

Closes #10940