### PR TITLE
fix(editor): save floating workspace markdown files

### DIFF
--- a/src/renderer/src/lib/editor-file-operation-owner.test.ts
+++ b/src/renderer/src/lib/editor-file-operation-owner.test.ts
@@ -5,6 +5,7 @@ import {
   captureEditorFileOperationProvenance,
   getEditorFileOperationContext
 } from './editor-file-operation-owner'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 
 const worktreeId = 'repo::/remote/repo'
 
@@ -37,6 +38,31 @@ beforeEach(() => {
 })
 
 describe('editor file operation owner', () => {
+  it('round-trips the synthetic local owner for floating workspace files', () => {
+    const provenance = captureEditorFileOperationProvenance(
+      useAppStore.getState(),
+      FLOATING_TERMINAL_WORKTREE_ID,
+      null,
+      true
+    )
+
+    expect(
+      getEditorFileOperationContext(
+        useAppStore.getState(),
+        {
+          worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+          runtimeEnvironmentId: null,
+          operationProvenance: provenance
+        },
+        '/tmp/orca/floating-workspace'
+      )
+    ).toMatchObject({
+      worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      worktreePath: '/tmp/orca/floating-workspace',
+      expectedExecutionHostId: 'local'
+    })
+  })
+
   it('uses the explicit worktree owner instead of global runtime focus', () => {
     useAppStore.setState({
       worktreesByRepo: {

--- a/src/renderer/src/lib/editor-file-operation-owner.ts
+++ b/src/renderer/src/lib/editor-file-operation-owner.ts
@@ -102,6 +102,9 @@ function resolveCurrentEditorRoute(
   worktreeId: string,
   provenance: EditorFileOperationProvenance
 ): WorktreeOperationRoute | null {
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return { executionHostId: 'local', runtimeEnvironmentId: null }
+  }
   const explicitResolution = resolveExplicitWorktreeOperationRouteResult(state, worktreeId)
   if (explicitResolution.kind === 'resolved') {
     return explicitResolution.route


### PR DESCRIPTION
## Summary

- preserve the synthetic local owner while revalidating floating workspace file mutations
- restore Save As renames for newly created floating markdown notes
- add focused regression coverage for the floating owner round trip

## Root cause

Opening a floating markdown note captured explicit local ownership provenance. Save As then revalidated that provenance through repo-backed owner catalogs, where the synthetic floating workspace ID cannot exist, and rejected before the filesystem rename.

## Test plan

- 258 focused editor and ownership-routing tests
- renderer typecheck
- targeted oxlint and formatting checks
- max-lines ratchet check