### PR TITLE
fix(worktrees): resolve a two-host project by the worktree's own host (#10634)

### DIFF
--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -77,6 +77,26 @@ describe('resolveWorktreeOperationRouteResult', () => {
     ).toEqual({ kind: 'ambiguous' })
   })
 
+  it('resolves a host-stamped SSH worktree when its project also exists locally (#10634)', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          repos: [
+            { id: 'repo-1', executionHostId: 'local' },
+            { id: 'repo-1', connectionId: 'ssh-1', executionHostId: 'ssh:ssh-1' }
+          ],
+          worktreesByRepo: {
+            'repo-1': [worktree('ssh:ssh-1')]
+          }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'ssh:ssh-1', runtimeEnvironmentId: null }
+    })
+  })
+
   it('deduplicates identical projections from the same HUB', () => {
     expect(
       resolveWorktreeOperationRouteResult(

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -2,6 +2,7 @@ import type { AppState } from '@/store/types'
 import {
   getRepoExecutionHostId,
   parseExecutionHostId,
+  toSshExecutionHostId,
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
@@ -71,6 +72,31 @@ function addRoute(
   routes.set(JSON.stringify(route), route)
 }
 
+function resolveRepoRouteForSshOwner(
+  repos: WorktreeOperationRouteState['repos'],
+  owner: WorktreeOperationOwnerRecord
+): WorktreeOperationRouteResolution {
+  if (!repos || !owner.hostId) {
+    return { kind: 'missing' }
+  }
+  const routes = new Map<string, WorktreeOperationRoute>()
+  for (const repo of repos) {
+    if (repo.id !== owner.repoId) {
+      continue
+    }
+    const connectionHostId = repo.connectionId ? toSshExecutionHostId(repo.connectionId) : null
+    if (getRepoExecutionHostId(repo) !== owner.hostId && connectionHostId !== owner.hostId) {
+      continue
+    }
+    addRoute(routes, routeForOwner({ hostId: getRepoExecutionHostId(repo) }))
+  }
+  const route = routes.values().next().value
+  if (routes.size === 1 && route) {
+    return { kind: 'resolved', route }
+  }
+  return routes.size > 1 ? { kind: 'ambiguous' } : { kind: 'missing' }
+}
+
 function resolveExactWorktreeRoute(
   state: WorktreeOperationRouteState,
   owner: WorktreeOperationOwnerRecord
@@ -82,7 +108,8 @@ function resolveExactWorktreeRoute(
   if (route.runtimeEnvironmentId || parseExecutionHostId(route.executionHostId)?.kind !== 'ssh') {
     return { kind: 'resolved', route }
   }
-  const repoRoute = resolveIndexedRepoOperationRoute(state.repos, owner.repoId)
+  // Recover an optional HUB transport only from the repo setup matching the worktree's SSH host.
+  const repoRoute = resolveRepoRouteForSshOwner(state.repos, owner)
   if (repoRoute.kind === 'ambiguous') {
     return repoRoute
   }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -6058,6 +6058,70 @@ describe('worktree unread (show-until-interact)', () => {
     )
   })
 
+  it('routes multi-host project unread persistence by the worktree host (#10634)', () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo-shared::/home/user/wt',
+      repoId: 'repo-shared',
+      path: '/home/user/wt',
+      hostId: 'ssh:ssh-1'
+    })
+    store.setState({
+      repos: [
+        { id: 'repo-shared', path: '/local', displayName: 'Local', badgeColor: '#000', addedAt: 0 },
+        {
+          id: 'repo-shared',
+          path: '/home/user/repo',
+          displayName: 'SSH',
+          badgeColor: '#111',
+          addedAt: 1,
+          connectionId: 'ssh-1'
+        }
+      ],
+      worktreesByRepo: { 'repo-shared': [wt] }
+    } as Partial<AppState>)
+
+    expect(() => store.getState().markWorktreeUnread(wt.id)).not.toThrow()
+
+    expect(store.getState().worktreesByRepo['repo-shared'][0].isUnread).toBe(true)
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: wt.id,
+        updates: expect.objectContaining({ isUnread: true })
+      })
+    )
+  })
+
+  it('keeps unread state local instead of throwing for genuinely ambiguous owners (#10634)', () => {
+    const store = createTestStore()
+    const worktreeId = 'repo-shared::/same/path'
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
+      worktreesByRepo: {
+        'repo-shared': [
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-a',
+            runtimeOwnerEnvironmentId: 'hub-a'
+          }),
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-b',
+            runtimeOwnerEnvironmentId: 'hub-b'
+          })
+        ]
+      }
+    } as Partial<AppState>)
+
+    expect(() => store.getState().markWorktreeUnread(worktreeId)).not.toThrow()
+
+    expect(store.getState().worktreesByRepo['repo-shared'][0].isUnread).toBe(true)
+    expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
   it('clearWorktreeUnread clears isUnread and persists the change', async () => {
     const store = createTestStore()
     const wt = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -6122,6 +6122,76 @@ describe('worktree unread (show-until-interact)', () => {
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
 
+  it('never throws from any passive path for a genuinely ambiguous owner (#10634)', () => {
+    // Why every passive path, not just markWorktreeUnread: each one runs from a background
+    // notification, so any that still throws reproduces the uncaught renderer error.
+    const worktreeId = 'repo-shared::/same/path'
+    const ambiguousState = (): Partial<AppState> =>
+      ({
+        settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
+        worktreesByRepo: {
+          'repo-shared': [
+            makeWorktree({
+              id: worktreeId,
+              repoId: 'repo-shared',
+              hostId: 'ssh:ssh-a',
+              runtimeOwnerEnvironmentId: 'hub-a',
+              isUnread: true
+            }),
+            makeWorktree({
+              id: worktreeId,
+              repoId: 'repo-shared',
+              hostId: 'ssh:ssh-b',
+              runtimeOwnerEnvironmentId: 'hub-b',
+              isUnread: true
+            })
+          ]
+        }
+      }) as Partial<AppState>
+
+    for (const [label, run] of [
+      ['clearWorktreeUnread', (s: AppState) => s.clearWorktreeUnread(worktreeId)],
+      ['bumpWorktreeActivity', (s: AppState) => s.bumpWorktreeActivity(worktreeId)]
+    ] as const) {
+      const store = createTestStore()
+      store.setState(ambiguousState())
+      mockApi.worktrees.updateMeta.mockClear()
+
+      expect(() => run(store.getState()), `${label} threw for an ambiguous owner`).not.toThrow()
+      expect(
+        mockApi.worktrees.updateMeta,
+        `${label} persisted to a guessed host`
+      ).not.toHaveBeenCalled()
+    }
+  })
+
+  it('warns once per workspace rather than on every activity event (#10634)', () => {
+    // Why: activity bumps fire on every PTY event; an unbounded warn would flood the console.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const worktreeId = 'repo-spam::/same/path'
+      const store = createTestStore()
+      store.setState({
+        settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
+        worktreesByRepo: {
+          'repo-spam': [
+            makeWorktree({ id: worktreeId, repoId: 'repo-spam', hostId: 'ssh:ssh-a' }),
+            makeWorktree({ id: worktreeId, repoId: 'repo-spam', hostId: 'ssh:ssh-b' })
+          ]
+        }
+      } as Partial<AppState>)
+
+      const before = warn.mock.calls.length
+      for (let i = 0; i < 5; i++) {
+        store.getState().bumpWorktreeActivity(worktreeId)
+      }
+
+      expect(warn.mock.calls.length - before).toBe(1)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('clearWorktreeUnread clears isUnread and persists the change', async () => {
     const store = createTestStore()
     const wt = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -922,6 +922,18 @@ function settingsForWorktreeOwner(
   return settings
 }
 
+// Why: activity bumps fire on every PTY event, so an ambiguous workspace would warn continuously.
+// One line per workspace is enough to diagnose it (#10634).
+const ambiguousOwnerWarnedWorktreeIds = new Set<string>()
+
+function warnAmbiguousOwnerOnce(worktreeId: string, errorLabel: string): void {
+  if (ambiguousOwnerWarnedWorktreeIds.has(worktreeId)) {
+    return
+  }
+  ambiguousOwnerWarnedWorktreeIds.add(worktreeId)
+  console.warn(`Skipped ${errorLabel}: workspace identity is ambiguous across hosts`, worktreeId)
+}
+
 function persistPassiveWorktreeMetaForOwner(
   get: WorktreeSliceGet,
   worktreeId: string,
@@ -930,7 +942,7 @@ function persistPassiveWorktreeMetaForOwner(
 ): void {
   const ownerSettings = trySettingsForWorktreeOwner(get(), worktreeId)
   if (!ownerSettings) {
-    console.warn(`Skipped ${errorLabel}: workspace identity is ambiguous across hosts`, worktreeId)
+    warnAmbiguousOwnerOnce(worktreeId, errorLabel)
     return
   }
   void persistWorktreeMeta(ownerSettings, worktreeId, updates).catch((err) => {
@@ -4392,6 +4404,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
     const ownerSettings = trySettingsForWorktreeOwner(get(), worktreeId)
     if (!ownerSettings) {
+      warnAmbiguousOwnerOnce(worktreeId, 'persist worktree activity timestamp')
       return
     }
     void persistWorktreeMeta(ownerSettings, worktreeId, {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -888,7 +888,7 @@ function settingsForKnownRepoOwner(
     : ({ activeRuntimeEnvironmentId: null } as AppState['settings'])
 }
 
-function settingsForWorktreeOwner(
+function trySettingsForWorktreeOwner(
   state: Pick<
     AppState,
     | 'repos'
@@ -903,12 +903,44 @@ function settingsForWorktreeOwner(
     | 'removedRuntimeEnvironmentIds'
   >,
   worktreeId: string
-) {
+): AppState['settings'] | null {
   const route = resolveWorktreeOperationRoute(state, worktreeId)
   if (!route) {
-    throw new Error(WORKTREE_REMOVAL_AMBIGUOUS_ERROR)
+    return null
   }
   return settingsForWorktreeOperationRoute(state.settings, route)
+}
+
+function settingsForWorktreeOwner(
+  state: Parameters<typeof trySettingsForWorktreeOwner>[0],
+  worktreeId: string
+) {
+  const settings = trySettingsForWorktreeOwner(state, worktreeId)
+  if (!settings) {
+    throw new Error(WORKTREE_REMOVAL_AMBIGUOUS_ERROR)
+  }
+  return settings
+}
+
+function persistPassiveWorktreeMetaForOwner(
+  get: WorktreeSliceGet,
+  worktreeId: string,
+  updates: Partial<WorktreeMeta>,
+  errorLabel: string
+): void {
+  const ownerSettings = trySettingsForWorktreeOwner(get(), worktreeId)
+  if (!ownerSettings) {
+    console.warn(`Skipped ${errorLabel}: workspace identity is ambiguous across hosts`, worktreeId)
+    return
+  }
+  void persistWorktreeMeta(ownerSettings, worktreeId, updates).catch((err) => {
+    if (isRuntimeSelectorNotFoundError(err)) {
+      void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+      return
+    }
+    console.error(`Failed to ${errorLabel}:`, err)
+    void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
+  })
 }
 
 async function listDetectedWorktreesForRepo(
@@ -4167,17 +4199,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
 
-    void persistWorktreeMeta(settingsForWorktreeOwner(get(), worktreeId), worktreeId, {
-      isUnread: true,
-      lastActivityAt: now
-    }).catch((err) => {
-      if (isRuntimeSelectorNotFoundError(err)) {
-        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
-        return
-      }
-      console.error('Failed to persist unread worktree state:', err)
-      void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
-    })
+    persistPassiveWorktreeMetaForOwner(
+      get,
+      worktreeId,
+      { isUnread: true, lastActivityAt: now },
+      'persist unread worktree state'
+    )
   },
 
   observeTerminalGitHubPullRequestLink: (worktreeId, link) => {
@@ -4291,16 +4318,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
 
-    void persistWorktreeMeta(settingsForWorktreeOwner(get(), worktreeId), worktreeId, {
-      isUnread: false
-    }).catch((err) => {
-      if (isRuntimeSelectorNotFoundError(err)) {
-        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
-        return
-      }
-      console.error('Failed to persist cleared unread worktree state:', err)
-      void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
-    })
+    persistPassiveWorktreeMetaForOwner(
+      get,
+      worktreeId,
+      { isUnread: false },
+      'persist cleared unread worktree state'
+    )
   },
 
   bumpWorktreeActivity: (worktreeId) => {
@@ -4367,7 +4390,11 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
 
-    void persistWorktreeMeta(settingsForWorktreeOwner(get(), worktreeId), worktreeId, {
+    const ownerSettings = trySettingsForWorktreeOwner(get(), worktreeId)
+    if (!ownerSettings) {
+      return
+    }
+    void persistWorktreeMeta(ownerSettings, worktreeId, {
       lastActivityAt: now
     }).catch((err) => {
       if (isRuntimeSelectorNotFoundError(err)) {
@@ -4804,22 +4831,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         void get().updateFolderWorkspace(workspaceScope.folderWorkspaceId, { isUnread: false })
         return
       }
-      const updates: Partial<WorktreeMeta> = {
-        isUnread: false
-      }
-
-      void persistWorktreeMeta(
-        settingsForWorktreeOwner(get(), worktreeId),
+      persistPassiveWorktreeMetaForOwner(
+        get,
         worktreeId,
-        updates
-      ).catch((err) => {
-        if (isRuntimeSelectorNotFoundError(err)) {
-          void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
-          return
-        }
-        console.error('Failed to persist worktree activation state:', err)
-        void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
-      })
+        { isUnread: false },
+        'persist worktree activation state'
+      )
     }
   },
 


### PR DESCRIPTION
Fixes #10634.

## What users hit

Register the same project on two hosts — a local folder and an SSH checkout of the same repo — and **every workspace in that project breaks permanently**:

> Workspace identity is ambiguous across hosts. Refresh projects and try again.

"Refresh projects" can never fix it. Nothing is stale; both host setups are valid and intentional. It survives app restarts. And because it was thrown from a background notification path, it surfaced as an **uncaught renderer error** rather than a handled state.

## The ambiguity was manufactured

`resolveExactWorktreeRoute` starts from a worktree that **already carries exactly one `hostId`** — then discards it and asks `resolveIndexedRepoOperationRoute` which host owns the *repo*. That question genuinely has two answers once a project spans hosts.

But only the **project** spans hosts. Every individual worktree names exactly one. The information needed to answer was in hand and thrown away.

Route resolution now filters repo setups to those matching the worktree's own host (checking both `getRepoExecutionHostId` and the repo's `connectionId`) before looking for a transport. A two-host project resolves as cleanly as a one-host project. Genuine ambiguity — two setups on the *same* host — still returns `ambiguous`.

## Second half: it should never have been uncaught

Passive background paths — unread marking, cleared-unread, activity bumps — called a helper that threw. `trySettingsForWorktreeOwner` now returns `null`; those paths skip the persist and keep local state consistent. Explicit user actions (remove, force-delete) still throw and surface the error, which is correct — the user asked for something Orca can't safely do.

`bumpWorktreeActivity` warns **once per workspace**, not per event: activity bumps fire on every PTY event, so an unbounded warn would flood the console for exactly the users already hitting this bug.

## Verification

Adversarial review (4 lenses, 3 independent refuters per finding) confirmed the routing logic sound and found 3 in-scope gaps, all fixed in the second commit:
- only `markWorktreeUnread` had an ambiguous-owner test, so restoring the throw in `clearWorktreeUnread` or `bumpWorktreeActivity` would have reproduced the uncaught error with the suite green
- `bumpWorktreeActivity` skipped silently where its siblings warned
- no test pinned the warn-once contract

**Every guard mutation-tested** — reverted individually, mutation confirmed applied, specific tests confirmed failing:

| Mutation | Result |
|---|---|
| revert to `resolveIndexedRepoOperationRoute` | #10634 routing test fails |
| restore the throw in the passive path | #10634 error-handling test fails |
| restore the throw in `clearWorktreeUnread` only | new all-passive-paths test fails |
| warn on every event instead of once | warn-once test fails |

`pnpm typecheck` clean across all three projects. `oxlint` exits 0. **5,077 renderer store + lib tests pass.** max-lines ratchet and reliability gates pass.

## Scope

Renderer-only; no main-process or IPC changes. No new user-facing strings, so no locale work. No UI or layout changes — the visible difference is that a two-host project stops erroring. Folder workspaces keep their existing early path. Provider-agnostic: nothing here assumes GitHub.

Not a duplicate of #10809 — that fixes *linking* a folder to a project (#10620, main process, identity probing). This fixes *operating* on a worktree once two valid setups already exist. Zero file overlap.

## Not verified

The reporter's exact environment (a real SSH host plus a local clone of the same repo) wasn't reproduced end to end; the two-host state is driven directly in tests. The root cause was traced in current source rather than inferred.