### PR TITLE
fix(mobile): collapse agent reasoning into a Thinking disclosure

### DIFF
--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MAX_TOOL_DETAIL_LENGTH } from '../../../src/shared/native-chat-tool-summary'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 
@@ -25,6 +25,7 @@ vi.mock('lucide-react-native', () => ({
 }))
 vi.mock('../components/MobileMarkdown', () => ({ MobileMarkdown: 'MobileMarkdown' }))
 
+import * as Clipboard from 'expo-clipboard'
 import { MobileNativeChatMessage } from './MobileNativeChatMessage'
 
 function userMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
@@ -33,6 +34,17 @@ function userMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
 
 function toolMessage(blocks: NativeChatMessage['blocks']): NativeChatMessage {
   return { id: 'a1', role: 'assistant', blocks, timestamp: null, source: 'transcript' }
+}
+
+function roleMessage(
+  role: NativeChatMessage['role'],
+  blocks: NativeChatMessage['blocks']
+): NativeChatMessage {
+  return { id: 'm1', role, blocks, timestamp: null, source: 'transcript' }
+}
+
+function reasoningMessage(text: string): NativeChatMessage {
+  return roleMessage('reasoning', [{ type: 'text', text }])
 }
 
 describe('MobileNativeChatMessage', () => {
@@ -151,5 +163,136 @@ describe('MobileNativeChatMessage', () => {
     expect(textIn(tree.root).filter((text) => text === input)).toHaveLength(1)
     expect(tree.root.findAllByType('ChevronDown' as never)).toHaveLength(1)
     expect(tree.root.findAllByType('SquareChevronRight' as never)).toHaveLength(1)
+  })
+})
+
+describe('MobileNativeChatMessage reasoning disclosure', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  function render(message: NativeChatMessage, toolsExpanded?: boolean): ReactTestRenderer {
+    const original = console.error
+    const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
+      if (typeof a[0] === 'string' && a[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      original(...a)
+    })
+    try {
+      act(() => {
+        renderer = create(createElement(MobileNativeChatMessage, { message, toolsExpanded }))
+      })
+    } finally {
+      spy.mockRestore()
+    }
+    return renderer!
+  }
+
+  function toggle(tree: ReactTestRenderer): { props: { onPress: () => void } } {
+    return tree.root.find((node) =>
+      String(node.props.accessibilityLabel ?? '').startsWith('Thinking')
+    ) as unknown as {
+      props: { onPress: () => void }
+    }
+  }
+
+  function thinkingRows(tree: ReactTestRenderer): unknown[] {
+    return tree.root.findAll((node) =>
+      String(node.props.accessibilityLabel ?? '').startsWith('Thinking')
+    )
+  }
+
+  it('hides the reasoning prose behind a collapsed disclosure', () => {
+    const tree = render(reasoningMessage('Weighing two approaches\nsecond line'))
+    expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(0)
+    const texts = tree.root
+      .findAllByType('Text' as never)
+      .map((node) => String(node.children.join('')))
+    expect(texts).toContain('Thinking')
+    expect(texts).toContain('Weighing two approaches')
+    expect(texts.some((text) => text.includes('second line'))).toBe(false)
+  })
+
+  it('reveals the prose when the disclosure is tapped', () => {
+    const tree = render(reasoningMessage('Weighing two approaches'))
+    act(() => toggle(tree).props.onPress())
+    expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(1)
+  })
+
+  it('drops the preview once expanded so the line is not shown twice', () => {
+    const tree = render(reasoningMessage('Weighing two approaches'))
+    act(() => toggle(tree).props.onPress())
+    const texts = tree.root
+      .findAllByType('Text' as never)
+      .map((node) => String(node.children.join('')))
+    expect(texts.filter((text) => text === 'Weighing two approaches')).toHaveLength(0)
+  })
+
+  it('starts expanded when the toolbar toggle is on', () => {
+    const tree = render(reasoningMessage('Weighing two approaches'), true)
+    expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(1)
+  })
+
+  it('keeps the copy control reachable while collapsed', () => {
+    const tree = render(reasoningMessage('Weighing two approaches'))
+    expect(
+      tree.root.findAll((node) => node.props.accessibilityLabel === 'Copy message')
+    ).toHaveLength(1)
+  })
+
+  it('renders no disclosure for whitespace-only reasoning', () => {
+    // Codex emits these: transcript-line-decoders-codex.ts guards on `!text`,
+    // not `!text.trim()`, so a blank thought reaches the renderer.
+    const tree = render(reasoningMessage('\n   \n'))
+    expect(thinkingRows(tree)).toHaveLength(0)
+  })
+
+  it('renders no disclosure for a reasoning turn with no blocks', () => {
+    const tree = render(roleMessage('reasoning', []))
+    expect(thinkingRows(tree)).toHaveLength(0)
+  })
+
+  it('keeps assistant prose rendered in full, not collapsed', () => {
+    const tree = render(roleMessage('assistant', [{ type: 'text', text: 'Here is the answer' }]))
+    expect(thinkingRows(tree)).toHaveLength(0)
+    const markdown = tree.root.findAllByType('MobileMarkdown' as never)
+    expect(markdown).toHaveLength(1)
+    expect(markdown[0]!.props.content).toBe('Here is the answer')
+  })
+
+  it('expands and re-collapses the reasoning body on tap', () => {
+    const tree = render(reasoningMessage('Weighing two approaches\nsecond line'))
+    act(() => toggle(tree).props.onPress())
+    expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(1)
+    act(() => toggle(tree).props.onPress())
+    expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(0)
+    // Back to the collapsed one-liner, preview and all.
+    const texts = tree.root
+      .findAllByType('Text' as never)
+      .map((node) => String(node.children.join('')))
+    expect(texts).toContain('Weighing two approaches')
+  })
+
+  it('copies the whole reasoning text while collapsed, not the preview line', () => {
+    const setStringAsync = vi.mocked(Clipboard.setStringAsync)
+    setStringAsync.mockClear()
+    const text = 'Weighing two approaches\nsecond line\nthird line\nfourth line'
+    const tree = render(reasoningMessage(text))
+    // Still collapsed: the preview is all that is on screen, but Copy must not
+    // settle for it.
+    expect(tree.root.findAllByType('MobileMarkdown' as never)).toHaveLength(0)
+    const copy = tree.root.find(
+      (node) => node.props.accessibilityLabel === 'Copy message'
+    ) as unknown as { props: { onPress: () => void } }
+    act(() => copy.props.onPress())
+    expect(setStringAsync).toHaveBeenCalledTimes(1)
+    expect(setStringAsync.mock.calls[0]![0]).toBe(text)
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -18,6 +18,8 @@ import { colors } from '../theme/mobile-theme'
 import { isRenderableImageUri } from './mobile-native-chat-image-preview'
 import { styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
 import { nativeChatMessageText } from './mobile-native-chat-message-text'
+import { MobileNativeChatReasoningRow } from './MobileNativeChatReasoningRow'
+import { reasoningPreviewLine } from './mobile-native-chat-reasoning-preview'
 
 const MAX_VISIBLE_TOOL_PAIRS = 6
 const MAX_TOOL_RUN_DIFF_ROWS = 240
@@ -337,6 +339,39 @@ function MobileNativeChatMessageImpl({
     />
   ) : null
 
+  const proseNodes = prose.map((block, index) => (
+    <Prose
+      key={index}
+      block={block}
+      invert={isUser}
+      fontScale={fontScale}
+      onOpenFile={onOpenFile}
+    />
+  ))
+
+  // Whitespace-only reasoning exists (decoders emit it), and a row that opens on
+  // nothing is worse than no row.
+  const reasoningPreview = isReasoning ? reasoningPreviewLine(prose) : ''
+  if (reasoningPreview) {
+    // Reasoning turns never carry tool blocks — folding only attaches those to assistant turns.
+    return (
+      <View style={styles.row}>
+        <View style={[styles.content, styles.reasoning, copied && styles.copied]}>
+          <MobileNativeChatReasoningRow
+            // Why: a global toggle intentionally resets all per-row overrides in
+            // one remount, avoiding an effect-driven second render.
+            key={toolsExpanded ? 'expanded' : 'collapsed'}
+            preview={reasoningPreview}
+            defaultExpanded={toolsExpanded}
+            trailing={controls}
+          >
+            {proseNodes}
+          </MobileNativeChatReasoningRow>
+        </View>
+      </View>
+    )
+  }
+
   return (
     <View style={[styles.row, isUser && styles.rowUser]}>
       <View
@@ -347,15 +382,7 @@ function MobileNativeChatMessageImpl({
           copied && styles.copied
         ]}
       >
-        {prose.map((block, index) => (
-          <Prose
-            key={index}
-            block={block}
-            invert={isUser}
-            fontScale={fontScale}
-            onOpenFile={onOpenFile}
-          />
-        ))}
+        {proseNodes}
         {tools.length > 0 ? (
           <ToolRun
             // Why: a global toggle intentionally resets all per-run/per-line

--- a/mobile/src/session/MobileNativeChatReasoningRow.tsx
+++ b/mobile/src/session/MobileNativeChatReasoningRow.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { ChevronDown, SquareChevronRight } from 'lucide-react-native'
+import { colors } from '../theme/mobile-theme'
+import { styles } from './mobile-native-chat-message-styles'
+
+/** Reasoning folds to a one-line disclosure like a tool run — thinking is
+ *  process, not answer, so it stays out of the way until asked for.
+ *  `defaultExpanded` lets the global toolbar toggle drive every row at once
+ *  while still allowing a per-row override. */
+export function MobileNativeChatReasoningRow({
+  preview,
+  defaultExpanded,
+  trailing,
+  children
+}: {
+  preview: string
+  defaultExpanded: boolean
+  trailing?: React.ReactNode
+  children: React.ReactNode
+}): React.JSX.Element {
+  const [open, setOpen] = useState(defaultExpanded)
+  return (
+    <View>
+      <View style={styles.toolRunHeader}>
+        <Pressable
+          style={styles.toolRunToggle}
+          onPress={() => setOpen((v) => !v)}
+          hitSlop={6}
+          accessibilityRole="button"
+          // Why: an explicit label replaces the children, so the preview has to
+          // be spoken here or a screen reader gets no content while collapsed.
+          accessibilityLabel={open ? 'Thinking' : `Thinking: ${preview}`}
+          accessibilityState={{ expanded: open }}
+        >
+          {open ? (
+            <ChevronDown size={15} color={colors.textMuted} strokeWidth={2} />
+          ) : (
+            <SquareChevronRight size={15} color={colors.textMuted} strokeWidth={2} />
+          )}
+          <Text style={styles.reasoningLabel}>Thinking</Text>
+          {open ? null : (
+            <Text style={styles.toolRunLabel} numberOfLines={1}>
+              {preview}
+            </Text>
+          )}
+        </Pressable>
+        {trailing}
+      </View>
+      {open ? <View style={styles.toolRunBody}>{children}</View> : null}
+    </View>
+  )
+}

--- a/mobile/src/session/mobile-native-chat-message-styles.ts
+++ b/mobile/src/session/mobile-native-chat-message-styles.ts
@@ -49,6 +49,12 @@ export const styles = StyleSheet.create({
   reasoning: {
     opacity: 0.7
   },
+  reasoningLabel: {
+    color: colors.textMuted,
+    fontFamily: typography.monoFamily,
+    fontSize: MONO_SIZE,
+    fontWeight: '700'
+  },
   toolRun: {
     marginTop: spacing.xs
   },

--- a/mobile/src/session/mobile-native-chat-reasoning-preview.test.ts
+++ b/mobile/src/session/mobile-native-chat-reasoning-preview.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { reasoningPreviewLine } from './mobile-native-chat-reasoning-preview'
+
+describe('reasoningPreviewLine', () => {
+  it('skips leading blank and whitespace-only lines', () => {
+    expect(
+      reasoningPreviewLine([{ type: 'text', text: '\n   \n\t\nLet me check the config first' }])
+    ).toBe('Let me check the config first')
+  })
+
+  it('clips to 80 characters so a long first line cannot push out the row', () => {
+    const preview = reasoningPreviewLine([{ type: 'text', text: 'x'.repeat(200) }])
+    expect(preview).toHaveLength(80)
+  })
+
+  it('reads through non-text blocks to the first text block', () => {
+    expect(
+      reasoningPreviewLine([
+        { type: 'image-ref', path: '/tmp/shot.png' },
+        { type: 'text', text: 'after the image' }
+      ])
+    ).toBe('after the image')
+  })
+
+  it('returns empty for prose that is entirely blank', () => {
+    expect(reasoningPreviewLine([{ type: 'text', text: '\n\n   \n' }])).toBe('')
+  })
+
+  it('returns empty when there are no blocks at all', () => {
+    expect(reasoningPreviewLine([])).toBe('')
+  })
+
+  it('keeps the first line only, never bleeding the second line in', () => {
+    expect(reasoningPreviewLine([{ type: 'text', text: 'first line\nsecond line' }])).toBe(
+      'first line'
+    )
+  })
+})

--- a/mobile/src/session/mobile-native-chat-reasoning-preview.ts
+++ b/mobile/src/session/mobile-native-chat-reasoning-preview.ts
@@ -1,0 +1,27 @@
+import type { NativeChatBlock } from '../../../src/shared/native-chat-types'
+import { isTextBlock } from '../../../src/shared/native-chat-types'
+
+const PREVIEW_CHARS = 80
+
+/** The collapsed reasoning disclosure's one-line label: the first line that has
+ *  content, clipped. Scans by index so a long thought never allocates a line
+ *  array just to show 80 characters. */
+export function reasoningPreviewLine(blocks: NativeChatBlock[]): string {
+  for (const block of blocks) {
+    if (!isTextBlock(block)) {
+      continue
+    }
+    const { text } = block
+    let start = 0
+    while (start < text.length) {
+      const newline = text.indexOf('\n', start)
+      const end = newline === -1 ? text.length : newline
+      const line = text.slice(start, end)
+      if (line.trim()) {
+        return line.slice(0, PREVIEW_CHARS)
+      }
+      start = end + 1
+    }
+  }
+  return ''
+}


### PR DESCRIPTION
## Summary

Mobile renders agent reasoning fully expanded. This folds it into a one-line `Thinking` disclosure that opens on tap — the same fold tool runs already have on mobile. Six files, all under `mobile/`.

**Not a duplicate of #9417.** That PR does the desktop row and the Claude decoder; its own notes say "the collapsed disclosure itself is desktop-only." This is the mobile half — zero file overlap, and the two can land in either order. Reasoning already reaches mobile today from Codex and Grok sessions, so this helps right away; once #9417 lands, Claude sessions get it too. The preview scan here walks the string by index and never allocates per line, matching the shape of `firstNonEmptyLinePreview` on that branch, so the two platforms stay consistent.

### Why

On my phone, the agent's thinking takes over the screen.

A single reasoning turn is often longer than the answer that follows it. On a desktop that's tolerable — there's room, and you can skim past it. On a phone it means scrolling through several screens of the agent talking to itself before you find the one paragraph you actually wanted. If I'm checking on a run while I'm out, that's most of what I see.

Tool calls already solved this on mobile — they fold into a single line you can tap open. Reasoning didn't. A reasoning turn now shows up as one line:

```
▸ Thinking  The user is reporting a two second delay before the worktree…
```

Tap it and the full thought opens. The toolbar's expand toggle opens them all, same as it does for tool runs. The answer is the first thing on screen again, and reasoning is there when you want it instead of by default.

## Screenshots

![Before, after collapsed, and after tapping open: a reasoning turn folded into a one-line Thinking disclosure](https://raw.githubusercontent.com/keepitmello/orca/pr-assets-mobile-reasoning/mobile-reasoning-comparison.png)

Captured on the iOS simulator against the native-chat mock server.

## Testing

- [x] `pnpm lint` — mobile lint clean; the root run stops on a pre-existing `verify:localization-coverage` failure in `src/renderer/src/components/settings/terminal-advanced-platform-search.ts` and `terminal-pane-appearance-search.ts`, both untouched here, which reproduces on a clean `origin/main` checkout — the same failure #10814 described when it merged yesterday. The root `verify` job in `pr.yml` runs `pnpm exec oxlint` rather than `pnpm lint`, and that passes.
- [x] `pnpm typecheck`
- [x] `pnpm test` — `cd mobile && pnpm test`: 347 files, 2552 passed, 2 skipped, 0 errors
- [x] `pnpm build` — passes, though nothing under `mobile/` is part of it; the gate for these files is `mobile.yml`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Everything here is under `mobile/`, so the checks that actually cover it are the ones in `.github/workflows/mobile.yml`. All five of its verification steps pass locally on macOS with Node 24 and pnpm 10.24.0: `typecheck`, `test`, the Ruby iOS release version test, `lint`, and `format:check`. I also ran the root `verify` job's lint and typecheck steps locally, since that job has no path filter and its oxlint step does cover `mobile/`. Both pass.

Sixteen tests added, all `.test.ts` so they're actually picked up — `mobile/vitest.config.ts` only includes `src/**/*.test.ts`, so a `.test.tsx` would silently never run. That's also why the preview scan lives in its own module instead of inline like the desktop version.

Six in `mobile-native-chat-reasoning-preview.test.ts` cover the one-line preview: blank leading lines get skipped, it clips at 80 characters, the second line never bleeds into the first. Ten in `MobileNativeChatMessage.test.ts` cover copy still copying the whole thought rather than the visible line, a normal assistant answer never folding, tapping twice closing it again, and empty reasoning producing no row.

## AI Review Report

I had an agent review this adversarially against #9417 and the repo's conventions, then re-review after I made the changes. It came back with one real bug and five smaller things, all fixed before this PR.

The bug: my first version folded every reasoning turn unconditionally, including ones with nothing readable in them. That's reachable today — a whitespace-only thought passes Codex's `if (!text)` (`src/main/native-chat/transcript-line-decoders-codex.ts:57`) where Grok's `!text?.trim()` (`transcript-line-decoders-grok.ts:72`) drops it, so it reaches the renderer. Before this PR it drew an invisible empty box; after, it would have drawn a tappable row that opens onto nothing. Now the preview is computed first and an empty one falls through to the old path. Two of the added tests cover it.

The rest: a conditional that became dead code once the early return existed; a new style that was byte-identical to `toolRunBody`, now deleted in favor of reusing it; an `accessibilityLabel` that replaced the row's children and left screen readers with "Thinking, button" and no content, now composed as `Thinking: <preview>` while collapsed; a three-line comment where one line did the work; and four missing tests, which are in.

It also confirmed copy still reads from the message rather than the screen, so collapsing can't truncate it, and that the preview scan stays index-based with no per-line allocation.

On cross-platform: nothing here ships in the desktop app. The Electron build doesn't compile `mobile/`, so macOS, Linux, and Windows are unaffected — no shortcut labels, no path handling, no shell behavior, no Electron-specific code in the diff. Within mobile it's React Native with no `Platform` checks; `hitSlop`, `numberOfLines`, and `accessibilityState.expanded` behave the same on iOS and Android.

On SSH and remote: this row renders text the transcript already delivered. It opens no process, reads no file, and touches no credential or network path, so it behaves identically whether the session is local, on a remote server, or in an SSH worktree. It doesn't care whether the workspace is a git worktree or a plain folder, and it never runs Git, so there's no Git version or provider surface either.

On agents and integrations: the row keys off the `reasoning` role, not the agent that produced it, so Claude, Codex, and Grok all get the same treatment with no per-agent branching. Only where that role comes from differs today, and that difference is what #9417's decoder change closes. Nothing here touches source control or a git provider, so GitHub and GitLab are unaffected.

On performance: collapsed is the cheaper state. The reasoning body isn't mounted while closed, so a long thought costs no markdown render and no layout until you tap it — on a transcript with many reasoning turns that's less work than today, not more. The preview itself scans by index and allocates one string of at most 80 characters.

## Security Audit

Nothing new here to attack. No new input parsing, no commands run, no paths handled, no auth, no secrets, no new IPC, no new dependency.

The one new function reads text that's already in the message and returns the first 80 characters of it. It walks the string by index instead of splitting it into lines, so a huge single-line thought doesn't turn into a huge allocation.

Reasoning text isn't newly exposed anywhere — it's less visible than before, which is the point. Copy is untouched and still reads from the message itself rather than what's on screen, so collapsing can't quietly truncate what someone copies.

## Notes

- No i18n change. There is no i18n layer under `mobile/src` at all: no locale files, no runtime. Modules ported from the renderer say so explicitly — `mobile/src/components/pr-sidebar/pr-comment-audience.ts:10` and `mobile/src/source-control/hosted-review-copy.ts:4` both note they are the renderer module "minus its i18n wrapper." The new `Thinking` label follows the plain-English strings already next to it.
- The preview helper is deliberately duplicated for now rather than shared. `mobile/` is a separate pnpm project and #9417 isn't in yet, so hoisting it would mean depending on an unmerged branch. Once that lands, I'm happy to follow up and collapse both into one function under `src/shared`.
- Reasoning rows follow the existing toolbar expand toggle, using the same remount trick tool runs use — the same signal #9417 feeds `NativeChatReasoningRow` on desktop. Desktop calls it `expandSignal`; mobile calls it `toolsExpanded` and labels the button `Tools` (`MobileNativeChatView.tsx:384`). Behavior matches, only the mobile name lags — happy to rename that string here or later.
- Not verified: Android and a physical device. I tested on the iOS simulator against the native-chat mock server; that leg is covered by the unit tests, and there are no `Platform` checks in the diff, so there is no Android-specific path to diverge.
- Small pre-existing thing I noticed and left alone: a blank reasoning turn still draws an empty bubble with a Copy button that does nothing, because `handleCopy` bails on empty text. Same before and after this PR. Happy to fix separately if it's worth it.

X handle: @keepitm3llo
