### PR TITLE
feat(source-control): dock committed branch changes

### DIFF
--- a/src/renderer/src/components/right-sidebar/CommittedBranchChangesPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/CommittedBranchChangesPanel.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+
+export function CommittedBranchChangesPanel({
+  count,
+  collapsed,
+  onToggle,
+  onViewAll,
+  children
+}: {
+  count: number
+  collapsed: boolean
+  onToggle: () => void
+  onViewAll: () => void
+  children: (scrollElement: HTMLDivElement | null) => React.ReactNode
+}): React.JSX.Element {
+  const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null)
+
+  return (
+    <div data-testid="committed-branch-changes-panel" className="relative border-t border-border">
+      <div className="h-7 pl-1 pr-3">
+        <div className="flex h-full items-stretch rounded-md pr-1">
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 items-center gap-1 px-0.5 text-left text-[11px] font-semibold uppercase tracking-wider text-foreground/70"
+            aria-expanded={!collapsed}
+            onClick={onToggle}
+          >
+            <ChevronDown
+              className={cn('size-3 shrink-0 transition-transform', collapsed && '-rotate-90')}
+            />
+            <span>
+              {translate(
+                'auto.components.right.sidebar.SourceControl.d7ae61269b',
+                'Committed on Branch'
+              )}
+            </span>
+            <span className="text-[10px] font-medium tabular-nums">{count}</span>
+          </button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="my-auto h-auto px-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground"
+            onClick={onViewAll}
+          >
+            {translate('auto.components.right.sidebar.SourceControl.48db37cca9', 'View all')}
+          </Button>
+        </div>
+      </div>
+      {!collapsed && (
+        <div
+          ref={setScrollElement}
+          data-testid="committed-branch-changes-body"
+          className="max-h-[33vh] overflow-y-auto scrollbar-sleek"
+        >
+          {children(scrollElement)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx
@@ -264,6 +264,14 @@ function doubleClickUncommitted(path: string): void {
 }
 
 function clickBranchRow(init: MouseEventInit = {}): void {
+  const toggle = container.querySelector<HTMLButtonElement>(
+    '[data-testid="committed-branch-changes-panel"] button[aria-expanded]'
+  )
+  expect(toggle?.getAttribute('aria-expanded')).toBe('false')
+  act(() => {
+    toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+
   const label = [...container.querySelectorAll('span')].find(
     (candidate) => candidate.textContent === 'branch.ts'
   )

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -194,6 +194,7 @@ import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
 import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullRequestDialogFields'
 import { resolveCreateReviewDraftTitle } from './create-review-draft-title'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
+import { CommittedBranchChangesPanel } from './CommittedBranchChangesPanel'
 import { useGitHistoryCommitActions } from './useGitHistoryCommitActions'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
 import {
@@ -536,7 +537,7 @@ const SOURCE_CONTROL_TREE_DIRECTORY_PADDING_PX = 8
 const SOURCE_CONTROL_TREE_FILE_PADDING_PX = 20
 const CAPPED_STATUS_RETRY_TIMEOUT_MS = 15_000
 const EMPTY_GIT_HISTORY_STATE: GitHistoryPanelState = { status: 'idle' }
-const DEFAULT_COLLAPSED_SECTIONS = ['history'] as const
+const DEFAULT_COLLAPSED_SECTIONS = ['branch', 'history'] as const
 const SUBMODULE_WORKTREE_ONLY_LABEL = 'Stage inside submodule'
 const SUBMODULE_WORKTREE_ONLY_TOOLTIP =
   'The parent repo (including Stage All) cannot stage file changes inside a submodule'
@@ -6079,108 +6080,96 @@ function SourceControlInner(): React.JSX.Element {
               onRetry={() => void refreshBranchCompare()}
             />
           ) : null}
+        </div>
 
-          {branchSummary?.status === 'ready' && hasFilteredBranchEntries && (
-            <div>
-              <SectionHeader
-                label={translate(
-                  'auto.components.right.sidebar.SourceControl.d7ae61269b',
-                  'Committed on Branch'
-                )}
+        {(branchSummary?.status === 'ready' && hasFilteredBranchEntries) || isGitHistoryVisible ? (
+          <div
+            data-testid="source-control-docked-panels"
+            className="z-10 shrink-0 bg-sidebar/95 backdrop-blur-sm"
+          >
+            {branchSummary?.status === 'ready' && hasFilteredBranchEntries && (
+              <CommittedBranchChangesPanel
                 count={filteredBranchEntries.length}
-                isCollapsed={collapsedSections.has('branch')}
+                collapsed={collapsedSections.has('branch')}
                 onToggle={() => toggleSection('branch')}
-                actions={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-auto px-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      if (activeWorktreeId && worktreePath && branchSummary) {
-                        openBranchAllDiffs(activeWorktreeId, worktreePath, branchSummary)
-                      }
-                    }}
-                  >
-                    {translate(
-                      'auto.components.right.sidebar.SourceControl.48db37cca9',
-                      'View all'
-                    )}
-                  </Button>
-                }
-              />
-              {!collapsedSections.has('branch') &&
-                (sourceControlViewMode === 'tree' ? (
-                  <SourceControlVirtualFileList
-                    rows={visibleBranchTreeRows}
-                    scrollElement={fileListScrollElement}
-                    getRowKey={(node) => node.key}
-                    renderRow={(node) => {
-                      if (node.type === 'directory') {
+                onViewAll={() => {
+                  if (activeWorktreeId && worktreePath) {
+                    openBranchAllDiffs(activeWorktreeId, worktreePath, branchSummary)
+                  }
+                }}
+              >
+                {(branchListScrollElement) =>
+                  sourceControlViewMode === 'tree' ? (
+                    <SourceControlVirtualFileList
+                      rows={visibleBranchTreeRows}
+                      scrollElement={branchListScrollElement}
+                      getRowKey={(node) => node.key}
+                      renderRow={(node) => {
+                        if (node.type === 'directory') {
+                          return (
+                            <SourceControlBranchTreeDirectoryRow
+                              key={node.key}
+                              node={node}
+                              isCollapsed={collapsedTreeDirs.has(node.key)}
+                              onToggle={() => toggleTreeDir(node.key)}
+                            />
+                          )
+                        }
                         return (
-                          <SourceControlBranchTreeDirectoryRow
+                          <BranchEntryRow
                             key={node.key}
-                            node={node}
-                            isCollapsed={collapsedTreeDirs.has(node.key)}
-                            onToggle={() => toggleTreeDir(node.key)}
+                            entry={node.entry}
+                            currentWorktreeId={currentWorktreeId}
+                            worktreePath={worktreePath}
+                            depth={node.depth}
+                            onRevealInExplorer={revealInExplorer}
+                            connectionId={activeConnectionId}
+                            onOpen={(event) => openCommittedDiff(node.entry, event)}
+                            commentCount={diffCommentCountByPath.get(node.entry.path) ?? 0}
+                            showPathHint={false}
                           />
                         )
-                      }
-                      return (
+                      }}
+                    />
+                  ) : (
+                    <SourceControlVirtualFileList
+                      rows={filteredBranchEntries}
+                      scrollElement={branchListScrollElement}
+                      getRowKey={(entry) => `branch:${entry.path}`}
+                      renderRow={(entry) => (
                         <BranchEntryRow
-                          key={node.key}
-                          entry={node.entry}
+                          key={`branch:${entry.path}`}
+                          entry={entry}
                           currentWorktreeId={currentWorktreeId}
                           worktreePath={worktreePath}
-                          depth={node.depth}
                           onRevealInExplorer={revealInExplorer}
                           connectionId={activeConnectionId}
-                          onOpen={(event) => openCommittedDiff(node.entry, event)}
-                          commentCount={diffCommentCountByPath.get(node.entry.path) ?? 0}
-                          showPathHint={false}
+                          onOpen={(event) => openCommittedDiff(entry, event)}
+                          commentCount={diffCommentCountByPath.get(entry.path) ?? 0}
                         />
-                      )
-                    }}
-                  />
-                ) : (
-                  <SourceControlVirtualFileList
-                    rows={filteredBranchEntries}
-                    scrollElement={fileListScrollElement}
-                    getRowKey={(entry) => `branch:${entry.path}`}
-                    renderRow={(entry) => (
-                      <BranchEntryRow
-                        key={`branch:${entry.path}`}
-                        entry={entry}
-                        currentWorktreeId={currentWorktreeId}
-                        worktreePath={worktreePath}
-                        onRevealInExplorer={revealInExplorer}
-                        connectionId={activeConnectionId}
-                        onOpen={(event) => openCommittedDiff(entry, event)}
-                        commentCount={diffCommentCountByPath.get(entry.path) ?? 0}
-                      />
-                    )}
-                  />
-                ))}
-            </div>
-          )}
+                      )}
+                    />
+                  )
+                }
+              </CommittedBranchChangesPanel>
+            )}
 
-          {isGitHistoryVisible && (
-            // Why: the graph is reference context, so keep it docked at the bottom as the pane scrolls.
-            <div className="sticky bottom-0 z-10 mt-auto shrink-0 border-t border-border bg-sidebar/95 backdrop-blur-sm">
-              <GitHistoryPanel
-                state={gitHistoryState}
-                collapsed={collapsedSections.has('history')}
-                onToggle={() => toggleSection('history')}
-                onRefresh={() => void refreshGitHistory()}
-                onOpenCommit={(item) => void openHistoryCommitDiff(item)}
-                onLoadCommitFiles={loadCommitFiles}
-                onOpenCommitFile={openCommitFile}
-                onCommitAction={handleCommitAction}
-              />
-            </div>
-          )}
-        </div>
+            {isGitHistoryVisible && (
+              <div className="border-t border-border">
+                <GitHistoryPanel
+                  state={gitHistoryState}
+                  collapsed={collapsedSections.has('history')}
+                  onToggle={() => toggleSection('history')}
+                  onRefresh={() => void refreshGitHistory()}
+                  onOpenCommit={(item) => void openHistoryCommitDiff(item)}
+                  onLoadCommitFiles={loadCommitFiles}
+                  onOpenCommitFile={openCommitFile}
+                  onCommitAction={handleCommitAction}
+                />
+              </div>
+            )}
+          </div>
+        ) : null}
 
         {selectedKeys.size > 0 && (
           <BulkActionBar

--- a/src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx
@@ -4,7 +4,11 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '@/components/ui/tooltip'
-import type { GitStatusEntry } from '../../../../shared/types'
+import type {
+  GitBranchChangeEntry,
+  GitBranchCompareSummary,
+  GitStatusEntry
+} from '../../../../shared/types'
 import SourceControl from './SourceControl'
 import {
   SOURCE_CONTROL_FILE_ROW_HEIGHT_PX,
@@ -97,6 +101,22 @@ function manyEntries(count: number): GitStatusEntry[] {
   return Array.from({ length: count }, (_, index) =>
     gitEntry({ path: `src/file-${String(index).padStart(3, '0')}.ts` })
   )
+}
+
+function branchEntry(path: string): GitBranchChangeEntry {
+  return { path, status: 'modified', added: 1, removed: 0 }
+}
+
+function readyBranchSummary(changedFiles: number): GitBranchCompareSummary {
+  return {
+    baseRef: 'origin/main',
+    baseOid: 'base-oid',
+    compareRef: 'HEAD',
+    headOid: 'head-oid',
+    mergeBase: 'base-oid',
+    changedFiles,
+    status: 'ready'
+  }
 }
 
 function noopAsync(value: unknown = undefined): () => Promise<unknown> {
@@ -288,6 +308,36 @@ function virtualList(): HTMLDivElement | null {
 }
 
 describe('SourceControl virtualized changed-files list', () => {
+  it('docks committed branch changes above commits and expands them on demand', () => {
+    const entries = [branchEntry('src/committed.ts')]
+    resetState({
+      gitBranchChangesByWorktree: { [mocks.activeWorktree.id]: entries },
+      gitBranchCompareSummaryByWorktree: {
+        [mocks.activeWorktree.id]: readyBranchSummary(entries.length)
+      }
+    })
+    renderSourceControl()
+
+    const dock = container.querySelector('[data-testid="source-control-docked-panels"]')
+    const panel = container.querySelector('[data-testid="committed-branch-changes-panel"]')
+    const toggle = panel?.querySelector<HTMLButtonElement>('button[aria-expanded]')
+
+    expect(dock).toBeTruthy()
+    expect(panel?.parentElement).toBe(dock)
+    expect(scroller().contains(panel)).toBe(false)
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('[data-testid="committed-branch-changes-body"]')).toBeNull()
+    expect(dock?.lastElementChild?.textContent).toContain('Commits')
+
+    act(() => {
+      toggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[data-testid="committed-branch-changes-body"]')).toBeTruthy()
+    expect(panel?.textContent).toContain('committed.ts')
+  })
+
   it('bounds mounted rows by viewport + overscan with 500 entries', () => {
     resetState({
       gitStatusByWorktree: { [mocks.activeWorktree.id]: manyEntries(500) }


### PR DESCRIPTION
## Summary

The **Committed on Branch** section currently lives inside the changed-files scroller, so long staged, unstaged, or untracked lists push it away from the bottom of the Source Control sidebar. The adjacent **Commits** panel is docked separately, which makes the two related branch-reference sections behave inconsistently.

This change:

- docks **Committed on Branch** at the bottom of the Source Control sidebar, directly above **Commits**
- collapses the section by default and renders its file list only after the user expands it
- gives the expanded branch list its own bounded, virtualized scroll container
- preserves the existing tree/list modes, diff opening, comment counts, reveal actions, and **View all** behavior
- adds regression coverage for docking, default collapsed state, expansion, and committed-file preview behavior

## Screenshots

### Before

The section follows the changed/untracked files and can be pushed away from the bottom.

<img src="https://raw.githubusercontent.com/fabiojansenbr/orca/pr-assets-10994/.github/pr-assets/10994/before.png" alt="Before: Committed on Branch follows the untracked files" width="576">

### After

The collapsed section stays docked immediately above **Commits** and expands on demand.

<img src="https://raw.githubusercontent.com/fabiojansenbr/orca/pr-assets-10994/.github/pr-assets/10994/after.png" alt="After: Committed on Branch is docked above Commits" width="1200">

## Testing

- [ ] `pnpm lint` — the command reaches the repository artifact checks, then fails because `resources/skills/current-manifest.json`, `snapshot-registry.json`, and `release-mapping.json` are already stale on `origin/main`; this PR does not modify those files
- [x] `pnpm typecheck`
- [ ] `pnpm test` — attempted twice locally; the full suite exceeded the 10-minute runner limit without reporting an assertion failure
- [x] `pnpm build`
- [x] Added high-quality regression coverage

Focused validation:

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/right-sidebar/SourceControl.virtual-file-list.test.tsx \
  src/renderer/src/components/right-sidebar/SourceControl.preview-open.test.tsx

Test Files  2 passed (2)
Tests       17 passed (17)
```

Additional checks:

- `oxlint` on all four changed files
- `oxfmt --check` on all four changed files
- `git diff --check`
- manual Electron validation on Windows in an isolated development profile

## AI Review Report

The review checked the layout boundary, collapsed/expanded state, list virtualization, existing diff and **View all** actions, accessibility state, and regression coverage.

It explicitly reviewed compatibility across macOS, Linux, and Windows. This renderer-only change adds no shortcuts, shortcut labels, paths, shell behavior, Git commands, native modules, or Electron platform branches. It also leaves local worktrees, folder workspaces, SSH/remote repositories, Git providers, agents, and integrations unchanged because it only reorganizes already-fetched Source Control presentation state.

The main risk identified was accidentally weakening the existing `worktreePath` guard for **View all** while moving the callback. The guard was restored before publication. The expanded list retains virtualization and is capped at one-third of the viewport, avoiding unbounded DOM or sidebar growth.

## Security Audit

This is a renderer-only layout and disclosure-state change. It introduces no new user input parsing, command execution, file/path handling, authentication, secrets, dependencies, network requests, IPC channels, preload APIs, or persisted data. Existing committed-diff and reveal actions continue to use their established handlers.

No security follow-up is required.

## Notes

- Manually verified on Windows in dark mode.
- The behavior is platform-neutral CSS/React layout; no platform-specific code was added.
- CI should provide the authoritative full-suite result because the local full test command exceeded the runner limit.
- X handle: not provided on the contributor's GitHub profile.
