### PR TITLE
fix(dashboard): stop the agent icon shrinking on long card titles

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -86,7 +86,10 @@ export const AgentKanbanCard = memo(
         )}
       >
         <div className="flex items-center gap-1.5">
-          <AgentIcon agent={agentTypeToIconAgent(card.agentType)} size={14} />
+          {/* Why: a bare <svg> flex item shrinks with the row — long worktree names squashed the icon. */}
+          <span className="inline-flex shrink-0">
+            <AgentIcon agent={agentTypeToIconAgent(card.agentType)} size={14} />
+          </span>
           <span
             // Why: same unvisited treatment as the sidebar's DashboardAgentRow —
             // bold+bright until acked, normal+muted after — so both surfaces

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -79,7 +79,9 @@ export function AgentTerminalDialog({
           }}
         >
           <div className="flex items-center gap-1.5 px-2.5 py-2">
-            <AgentIcon agent={agentTypeToIconAgent(card.agentType)} size={13} />
+            <span className="inline-flex shrink-0">
+              <AgentIcon agent={agentTypeToIconAgent(card.agentType)} size={13} />
+            </span>
             <DialogTitle className="text-[12px] leading-normal font-semibold">
               {card.worktreeName}
             </DialogTitle>


### PR DESCRIPTION
## Problem

In the agent dashboard, one card's Claude icon renders noticeably smaller (and washed out) than the rest:

| | |
|---|---|
| normal | long title |
| 14px | ~9px |

It looked like a status or agent-type difference. It isn't — it's flexbox.

## Cause

`AgentKanbanCard` rendered the icon as a bare `<svg>` flex item:

```tsx
<div className="flex items-center gap-1.5">
  <AgentIcon ... size={14} />   // default flex-shrink: 1
  <span className="truncate">{card.worktreeName}</span>
```

An `<svg>` with the default `flex-shrink: 1` shrinks along with its row. Cards whose worktree name fits are unaffected; the moment the title overflows and truncates, the browser distributes the shrink proportionally to flex-basis and the 14px icon loses ~5px. The dimmer color is just antialiasing on the downscaled glyph.

`AgentTerminalDialog` had the same bare call site, so a long worktree name in the dialog header squeezed its 13px icon too.

Every other surface already guards against this — `DashboardAgentRow`, `worktree-card-compact-agent-row`, and `ActivityPrototypePage` all wrap `AgentIcon` in `<span className="inline-flex shrink-0">`, and `AgentStateDot` bakes `shrink-0` into its own wrapper. These two popout call sites were the outliers.

## Fix

Wrap both in the same `inline-flex shrink-0` span the rest of the app uses. No layout change for cards that already fit.

## Testing

- `AgentKanbanCard.test.tsx` — 4/4 pass.
- `oxfmt --check` clean; lint-staged (oxlint + react-doctor) clean on commit.

Note: the existing tests mock `AgentIcon`, so they don't cover sizing. Verification here is the CSS reasoning plus parity with the surfaces that already carry the guard.

## Follow-up (not in this PR)

The durable fix is moving `shrink-0` inside `AgentIcon` so no call site can omit it, but that needs a `className` pass-through on ~10 icon components — out of scope for a one-line rendering bug.
