### PR TITLE
fix(terminals): resolve Copy Terminal ID against the owning runtime

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-handle-copy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-copy.test.ts
@@ -2,22 +2,22 @@ import { describe, expect, it, vi } from 'vitest'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const ENVIRONMENT_ID = '23306b4a-670b-4e09-a1f7-85a0a7b17fe9'
+
+function resolvedPane(handle: string): unknown {
+  return {
+    terminal: {
+      handle,
+      tabId: 'tab-1',
+      leafId: LEAF_ID,
+      ptyId: 'pty-1'
+    }
+  }
+}
 
 describe('copyTerminalHandleForPane', () => {
   it('copies the runtime terminal handle for a pane key', async () => {
-    const callRuntime = vi.fn().mockResolvedValue({
-      id: 'req-1',
-      ok: true,
-      result: {
-        terminal: {
-          handle: 'term_worker',
-          tabId: 'tab-1',
-          leafId: LEAF_ID,
-          ptyId: 'pty-1'
-        }
-      },
-      _meta: { runtimeId: 'runtime-1' }
-    })
+    const callRuntime = vi.fn().mockResolvedValue(resolvedPane('term_worker'))
     const writeClipboardText = vi.fn().mockResolvedValue(undefined)
 
     await expect(
@@ -29,22 +29,55 @@ describe('copyTerminalHandleForPane', () => {
       })
     ).resolves.toBe('term_worker')
 
-    expect(callRuntime).toHaveBeenCalledWith({
-      method: 'terminal.resolvePane',
-      params: { paneKey: `tab-1:${LEAF_ID}` }
+    expect(callRuntime).toHaveBeenCalledWith({ kind: 'local' }, 'terminal.resolvePane', {
+      paneKey: `tab-1:${LEAF_ID}`
     })
     expect(writeClipboardText).toHaveBeenCalledWith('term_worker')
   })
 
-  it('surfaces runtime lookup failures without writing the clipboard', async () => {
-    const callRuntime = vi.fn().mockResolvedValue({
-      id: 'req-1',
-      ok: false,
-      error: {
-        code: 'terminal_not_found',
-        message: 'terminal not found'
-      }
+  it('resolves against the owning runtime for a paired-environment pane', async () => {
+    const callRuntime = vi.fn().mockResolvedValue(resolvedPane('term_remote'))
+    const writeClipboardText = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      copyTerminalHandleForPane({
+        tabId: 'tab-1',
+        leafId: LEAF_ID,
+        runtimeEnvironmentId: ENVIRONMENT_ID,
+        callRuntime,
+        writeClipboardText
+      })
+    ).resolves.toBe('term_remote')
+
+    expect(callRuntime).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: ENVIRONMENT_ID },
+      'terminal.resolvePane',
+      { paneKey: `tab-1:${LEAF_ID}` }
+    )
+    expect(writeClipboardText).toHaveBeenCalledWith('term_remote')
+  })
+
+  it('treats a blank environment id as the local runtime', async () => {
+    const callRuntime = vi.fn().mockResolvedValue(resolvedPane('term_worker'))
+    const writeClipboardText = vi.fn().mockResolvedValue(undefined)
+
+    await copyTerminalHandleForPane({
+      tabId: 'tab-1',
+      leafId: LEAF_ID,
+      runtimeEnvironmentId: '   ',
+      callRuntime,
+      writeClipboardText
     })
+
+    expect(callRuntime).toHaveBeenCalledWith(
+      { kind: 'local' },
+      'terminal.resolvePane',
+      expect.anything()
+    )
+  })
+
+  it('surfaces runtime lookup failures without writing the clipboard', async () => {
+    const callRuntime = vi.fn().mockRejectedValue(new Error('terminal not found'))
     const writeClipboardText = vi.fn()
 
     await expect(
@@ -55,6 +88,22 @@ describe('copyTerminalHandleForPane', () => {
         writeClipboardText
       })
     ).rejects.toThrow('terminal not found')
+
+    expect(writeClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the runtime resolves a pane without a handle', async () => {
+    const callRuntime = vi.fn().mockResolvedValue({ terminal: { tabId: 'tab-1' } })
+    const writeClipboardText = vi.fn()
+
+    await expect(
+      copyTerminalHandleForPane({
+        tabId: 'tab-1',
+        leafId: LEAF_ID,
+        callRuntime,
+        writeClipboardText
+      })
+    ).rejects.toThrow('Terminal ID unavailable')
 
     expect(writeClipboardText).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/terminal-pane/terminal-handle-copy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-handle-copy.ts
@@ -1,31 +1,35 @@
-import type { RuntimeRpcResponse } from '../../../../shared/runtime-rpc-envelope'
+import type { RuntimeClientTarget } from '@/runtime/runtime-client-target'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 
 type CopyTerminalHandleDeps = {
   tabId: string
   leafId: string
-  callRuntime: (request: {
-    method: 'terminal.resolvePane'
+  // Why: a pane rendered from a paired runtime exists only in that runtime's
+  // pane table, so resolvePane has to be addressed to the owner. Defaulting to
+  // the local runtime made "Copy Terminal ID" fail for every remote pane.
+  runtimeEnvironmentId?: string | null
+  callRuntime: (
+    target: RuntimeClientTarget,
+    method: 'terminal.resolvePane',
     params: { paneKey: string }
-  }) => Promise<RuntimeRpcResponse<unknown>>
+  ) => Promise<unknown>
   writeClipboardText: (text: string) => Promise<void>
 }
 
 export async function copyTerminalHandleForPane({
   tabId,
   leafId,
+  runtimeEnvironmentId,
   callRuntime,
   writeClipboardText
 }: CopyTerminalHandleDeps): Promise<string> {
   const paneKey = makePaneKey(tabId, leafId)
-  const response = await callRuntime({
-    method: 'terminal.resolvePane',
-    params: { paneKey }
-  })
-  if (!response.ok) {
-    throw new Error(response.error.message)
-  }
-  const handle = readResolvedTerminalHandle(response.result)
+  const environmentId = runtimeEnvironmentId?.trim()
+  const target: RuntimeClientTarget = environmentId
+    ? { kind: 'environment', environmentId }
+    : { kind: 'local' }
+  const result = await callRuntime(target, 'terminal.resolvePane', { paneKey })
+  const handle = readResolvedTerminalHandle(result)
   if (!handle) {
     throw new Error('Terminal ID unavailable')
   }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -6,6 +6,7 @@ import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { PtyTransport } from './pty-transport'
 import { getConnectionId } from '@/lib/connection-context'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import type { PaneCwdMap } from './resolve-split-cwd'
 import type { TerminalQuickCommand } from '../../../../shared/types'
 import { isTerminalAgentQuickCommand } from '../../../../shared/terminal-quick-commands'
@@ -269,7 +270,11 @@ export function useTerminalPaneContextMenu({
       await copyTerminalHandleForPane({
         tabId,
         leafId: pane.leafId,
-        callRuntime: window.api.runtime.call,
+        runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(
+          useAppStore.getState(),
+          worktreeId
+        ),
+        callRuntime: (target, method, params) => callRuntimeRpc(target, method, params),
         writeClipboardText: window.api.ui.writeClipboardText
       })
       toast.success(


### PR DESCRIPTION
## Problem

**Copy Terminal ID** never works for a pane owned by a paired runtime. The menu item is present on those panes, but selecting it always lands in the error branch and shows *Unable to copy terminal ID*.

Reproduced on a hub setup: a client pairs with a remote runtime that owns 4 nested SSH hosts. Panes belonging to the local runtime copy fine; every pane belonging to the paired runtime fails, 100% of the time.

## Cause

`copyTerminalHandleForPane` resolved the pane through `window.api.runtime.call`, which is the **local** runtime — it takes no target argument at all:

```ts
const response = await callRuntime({ method: 'terminal.resolvePane', params: { paneKey } })
```

A pane key only exists in the pane table of the runtime that owns it, so for a remote pane the local runtime legitimately answers "not found", and the caller turns that into the failure toast.

## Fix

Thread the owning `runtimeEnvironmentId` in and build a `RuntimeClientTarget` from it, then route through `callRuntimeRpc`.

This is not a new pattern — it is the one already used next door:

- `terminal-handle-links.ts` threads `runtimeEnvironmentId` and targets `terminal.focus` the same way.
- The sibling paste path already passes the same owner id into `pasteTerminalClipboard`.
- The hook calling this code **already computes** `getRuntimeEnvironmentIdForWorktree(...)` for that paste path — the value was available at the call site and simply wasn't passed.

Going through `callRuntimeRpc` additionally picks up the runtime compatibility probe that the raw `window.api.runtime.call` path skipped.

## Why types didn't catch it

`window.api.runtime.call` and `window.api.runtimeEnvironments.call` both return `RuntimeRpcResponse<unknown>`, so choosing the wrong one compiles cleanly and fails only at runtime — and the failure is swallowed into a toast, so it is invisible on a single-runtime dev machine.

Making the target an explicit parameter means callers now have to answer *which runtime* at the call site rather than inheriting a silent local default.

## Tests

`terminal-handle-copy.test.ts` now covers:

- local target (no environment id)
- paired-environment target
- blank/whitespace environment id falling back to local
- runtime rejection leaving the clipboard untouched
- a resolved pane with no handle

```
vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/
→ 190 files, 2480 tests passed

tsc --noEmit -p config/tsconfig.tc.web.json  → clean
oxlint + oxfmt                               → clean
```

## Note

Same family as #9830 (sidebar grouping for nested SSH hosts): the UI presents entities from several runtimes, but a code path underneath assumes the local one. That one was a merge/dedupe assumption, this one is an RPC-target assumption. Flagging in case it is worth auditing other `window.api.runtime.call` sites that act on pane- or terminal-scoped state.
