### PR TITLE
fix(cmd-j): restore focus when issue match routing declines

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -1525,7 +1525,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         closeModal()
         // Why: #9939 — jumping to an already-open workspace must focus its own terminal.
         const activation = activateAndRevealWorktree(activeMatch.id)
-        queueWorkspaceActivationTerminalFocus(activeMatch.id, activation)
+        if (!queueWorkspaceActivationTerminalFocus(activeMatch.id, activation)) {
+          focusFallbackSurface()
+        }
         recordFeatureInteraction('cmd-j-workspace-open')
         return
       }
@@ -1554,7 +1556,9 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         closeModal()
         // Why: #9939 — jumping to an already-open workspace must focus its own terminal.
         const activation = activateAndRevealWorktree(activeMatch.id)
-        queueWorkspaceActivationTerminalFocus(activeMatch.id, activation)
+        if (!queueWorkspaceActivationTerminalFocus(activeMatch.id, activation)) {
+          focusFallbackSurface()
+        }
         recordFeatureInteraction('cmd-j-workspace-open')
         return
       }
@@ -1628,6 +1632,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     closeModal,
     createLookupGuard,
     createWorktreeName,
+    focusFallbackSurface,
     openModal,
     prefetchCreateWorkspaceBaseForComposer,
     recordFeatureInteraction,

--- a/src/renderer/src/components/cmd-j/palette-activation-focus-routing.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-activation-focus-routing.test.ts
@@ -45,14 +45,20 @@ describe('Cmd+J activation focus routing (#9939)', () => {
     expect(handler).not.toMatch(/focusFallbackSurface\(\)/)
   })
 
-  it('focuses the destination workspace when jumping to an already-open issue match', () => {
-    const source = paletteSource()
+  it('falls back when scoped focus declines for an already-open issue match', () => {
+    const handler = sourceBetween(
+      paletteSource(),
+      'const handleCreateWorktree = useCallback',
+      'const handleCloseAutoFocus'
+    )
     const activationCalls =
-      source.match(/const activation = activateAndRevealWorktree\(activeMatch\.id\)/g)?.length ?? 0
-    // Both issue-number match paths (PR and issue lookup) must focus the destination.
+      handler.match(/const activation = activateAndRevealWorktree\(activeMatch\.id\)/g)?.length ?? 0
+    // Both issue/PR match paths must restore focus when terminal routing declines.
     expect(activationCalls).toBe(2)
     expect(
-      source.match(/queueWorkspaceActivationTerminalFocus\(activeMatch\.id, activation\)/g)?.length
+      handler.match(
+        /if \(!queueWorkspaceActivationTerminalFocus\(activeMatch\.id, activation\)\) \{\s*focusFallbackSurface\(\)\s*\}/g
+      )?.length
     ).toBe(activationCalls)
   })
 })


### PR DESCRIPTION
## Summary

Restore fallback focus in both existing issue/PR match paths when destination-scoped terminal focus declines. This follows up on #10695 and addresses https://github.com/stablyai/orca/pull/10695#discussion_r3651923018.

## Screenshots

No visual change.

## Testing

- [ ] pnpm lint — changed files pass oxlint and React Doctor via the commit hook
- [ ] pnpm typecheck — pnpm run typecheck:web passes
- [ ] pnpm test — 10 focused focus-routing tests pass
- [ ] pnpm build — not run; no build-system or production-bundle changes
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed both existing issue/PR match branches, hook dependencies, and the false-return cases from destination-scoped terminal focus. The test now requires guarded fallback routing in both branches, preventing an unconditional fallback or a discarded return value. The change is DOM-focus-only and introduces no shortcuts, labels, paths, shell behavior, Electron platform APIs, or platform-specific differences across macOS, Linux, and Windows.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, or IPC. The change only handles an existing boolean result and schedules the existing focus fallback.

## Notes

The fallback preserves the established non-terminal behavior when scoped terminal routing declines. SSH and folder workspaces use the same renderer focus path.