### PR TITLE
fix(ci): stabilize flaky terminal and SFTP tests

### DIFF
--- a/src/main/daemon/terminal-history-incremental-restore.test.ts
+++ b/src/main/daemon/terminal-history-incremental-restore.test.ts
@@ -278,14 +278,16 @@ describe('incremental terminal history restore', () => {
     const firstReplay = reader.detectColdRestore(SESSION_ID)
     const secondReplay = reader.detectColdRestore(secondSessionId)
     try {
+      // Drain by yield because awaiting the session that loses the replay-slot race deadlocks.
       await vi.waitFor(() => expect(pendingYields).toHaveLength(1))
-
       pendingYields.shift()!()
-      expect((await firstReplay)?.scrollbackAnsi).toContain('😀second')
+
       await vi.waitFor(() => expect(pendingYields).toHaveLength(1))
-
       pendingYields.shift()!()
-      expect((await secondReplay)?.scrollbackAnsi).toContain('😀second')
+
+      for (const restore of await Promise.all([firstReplay, secondReplay])) {
+        expect(restore?.scrollbackAnsi).toContain('😀second')
+      }
       expect(pendingYields).toHaveLength(0)
     } finally {
       for (const resume of pendingYields.splice(0)) {

--- a/src/main/ssh/ssh-connection-sftp-wire.test.ts
+++ b/src/main/ssh/ssh-connection-sftp-wire.test.ts
@@ -160,7 +160,8 @@ function installSftpHandlers(sftp: SFTPWrapper, backingRoot: string, operations:
 async function startSftpWireServer(backingRoot: string): Promise<SftpWireServer> {
   const operations: string[] = []
   const connections = new Set<Connection>()
-  const hostKey = utils.generateKeyPairSync('ed25519').private
+  // Ed25519 keygen can produce an invalid 31-byte key; ECDSA points always start with 0x04.
+  const hostKey = utils.generateKeyPairSync('ecdsa', { bits: 256 }).private
   const server = new Ssh2Server({ hostKeys: [hostKey] }, (connection) => {
     connections.add(connection)
     connection.on('error', () => {})


### PR DESCRIPTION
## Summary

- Drain scheduled terminal-history replay yields before awaiting either session, removing an async ordering deadlock from the test.
- Use an ECDSA host key in the SFTP wire test to avoid `ssh2` occasionally generating an invalid 31-byte Ed25519 public key.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed:

- `pnpm run typecheck:node`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/terminal-history-incremental-restore.test.ts src/main/ssh/ssh-connection-sftp-wire.test.ts` (18 tests)
- Targeted oxlint and oxfmt checks through the commit hook

The full test suite was not completed locally: this checkout is running unsupported Node 26 instead of the required Node 24, and unrelated suites failed before the run was canceled.

## AI Review Report

Reviewed the replay race, promise settlement, cleanup behavior, and `ssh2` host-key compatibility. The changes remain test-only and preserve coverage of both concurrent restores and the SFTP wire path.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This PR does not touch shortcuts, labels, paths, shell behavior, or Electron platform branches; ECDSA P-256 generation uses the existing cross-platform `ssh2`/Node crypto API, and no production SSH behavior changes.

## Security Audit

These are test-only changes with no production input handling, command execution, path handling, authentication, dependency, or IPC changes. The generated private host key remains ephemeral and in memory; no credentials or secrets are persisted.

## Notes

CI reliability only; no production or platform-specific behavior changes.
