### PR TITLE
fix(release): accept lowered telemetry declarations

### DIFF
--- a/config/scripts/telemetry-bundle-constant-patterns.mjs
+++ b/config/scripts/telemetry-bundle-constant-patterns.mjs
@@ -1,0 +1,2 @@
+export const BUILD_IDENTITY_RE = /\b(?:const|let|var)\s+BUILD_IDENTITY\s*=\s*"(rc|stable)"/
+export const WRITE_KEY_RE = /\b(?:const|let|var)\s+WRITE_KEY\s*=\s*"(phc_[A-Za-z0-9_-]+)"/

--- a/config/scripts/telemetry-bundle-constant-patterns.test.mjs
+++ b/config/scripts/telemetry-bundle-constant-patterns.test.mjs
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { BUILD_IDENTITY_RE, WRITE_KEY_RE } from './telemetry-bundle-constant-patterns.mjs'
+
+describe('telemetry bundle constant patterns', () => {
+  it.each(['const', 'let', 'var'])('accepts %s declarations', (declaration) => {
+    expect(`${declaration} BUILD_IDENTITY = "rc"`).toMatch(BUILD_IDENTITY_RE)
+    expect(`${declaration} WRITE_KEY = "phc_example-key_123"`).toMatch(WRITE_KEY_RE)
+  })
+
+  it('rejects assignments and invalid values', () => {
+    expect('BUILD_IDENTITY = "rc"').not.toMatch(BUILD_IDENTITY_RE)
+    expect('const BUILD_IDENTITY = "dev"').not.toMatch(BUILD_IDENTITY_RE)
+    expect('const WRITE_KEY = null').not.toMatch(WRITE_KEY_RE)
+    expect('const WRITE_KEY = "example-key"').not.toMatch(WRITE_KEY_RE)
+  })
+})

--- a/config/scripts/verify-telemetry-constants.mjs
+++ b/config/scripts/verify-telemetry-constants.mjs
@@ -38,6 +38,7 @@ import { join, resolve } from 'node:path'
 // `node_modules`). If electron-builder ever drops it, promote this to a
 // direct devDependency in package.json.
 import { extractFile, listPackage } from '@electron/asar'
+import { BUILD_IDENTITY_RE, WRITE_KEY_RE } from './telemetry-bundle-constant-patterns.mjs'
 
 // Why resolve from import.meta.url instead of cwd: a release runner (or a
 // developer debugging locally) may invoke this script from a non-root cwd.
@@ -118,20 +119,8 @@ for (const m of asarMatches) {
 // Why these regexes: electron-vite's `define` block substitutes the bare
 // identifiers `ORCA_BUILD_IDENTITY` and `ORCA_POSTHOG_WRITE_KEY` with their
 // JSON-stringified values at build time. `src/main/telemetry/client.ts`
-// then assigns those into module-local consts named `BUILD_IDENTITY` and
-// `WRITE_KEY`. electron-vite's main config is not minified (Vite default for
-// Electron main builds), so Rollup emits the substituted constants verbatim
-// as `const BUILD_IDENTITY = "stable";`. Match that exact emitted shape so a
-// regression — e.g. the env var unset and the substitution falling back to
-// literal `null` — fails the grep instead of slipping through as a falsy-
-// but-stringy value. NOTE: if `build.minify` is ever enabled on the main
-// bundle, esbuild/terser will rename top-level consts and this regex must
-// be revisited (or replaced with a value-based assertion).
-//
-// WRITE_KEY char class includes `_` and `-` because PostHog project API
-// keys use URL-safe base64 alphabet beyond `phc_`.
-const BUILD_IDENTITY_RE = /const\s+BUILD_IDENTITY\s*=\s*"(rc|stable)"/
-const WRITE_KEY_RE = /const\s+WRITE_KEY\s*=\s*"(phc_[A-Za-z0-9_-]+)"/
+// then assigns those into module-local declarations named `BUILD_IDENTITY`
+// and `WRITE_KEY`. Rollup may preserve `const` or lower it to `var`.
 
 function verifyAsar(asarPath) {
   console.log(`Verifying ${asarPath}`)


### PR DESCRIPTION
## Summary
- accept Rollup-lowered `var` and `let` telemetry declarations in packaged app verification
- retain strict release identity and PostHog key value checks
- cover all supported declaration forms with a regression test

## Verification
- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/telemetry-bundle-constant-patterns.test.mjs`
- `pnpm exec oxlint config/scripts/verify-telemetry-constants.mjs config/scripts/telemetry-bundle-constant-patterns.mjs config/scripts/telemetry-bundle-constant-patterns.test.mjs`
- `pnpm exec oxfmt --check config/scripts/verify-telemetry-constants.mjs config/scripts/telemetry-bundle-constant-patterns.mjs config/scripts/telemetry-bundle-constant-patterns.test.mjs`
- release-style build with `ORCA_BUILD_IDENTITY=rc` and a test PostHog key
- packed generated `out/main` into app.asar and passed `verify-telemetry-constants.mjs`