### PR TITLE
fix(new-workspace): center agent selection in create dialog

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -1421,7 +1421,7 @@ export default function NewWorkspaceComposerCard({
           </div>
         </div>
 
-        <div className="space-y-1" data-contextual-tour-target="workspace-creation-agent">
+        <div className="min-w-0 space-y-1" data-contextual-tour-target="workspace-creation-agent">
           <div className="flex items-center justify-between gap-2">
             <label className="text-xs font-medium text-muted-foreground">
               {translate('auto.components.NewWorkspaceComposerCard.01d1e8f601', 'Agent')}
@@ -1459,7 +1459,9 @@ export default function NewWorkspaceComposerCard({
             onOpenManageAgents={onOpenAgentSettings}
             defaultAgent={defaultTuiAgent}
             onSetDefault={handleSetDefaultAgent}
-            triggerClassName="h-9 w-full border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+            // Why: match Project/Run-on — full-width form row, no 260px min that can overflow the dialog column.
+            allowNarrowTrigger
+            triggerClassName="h-9 w-full min-w-0 border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
             onTriggerEnter={createDisabled ? undefined : onCreate}
           />
         </div>

--- a/src/renderer/src/components/agent/AgentCombobox.test.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.test.tsx
@@ -36,12 +36,13 @@ describe('AgentCombobox', () => {
     expect(markup).not.toContain('!min-w-[260px]')
     expect(markup).toContain('min-w-0 w-full')
     expect(markup).toContain('leading-none')
-    expect(markup).toContain('size-3.5 -translate-y-px shrink-0')
+    expect(markup).toContain('size-3.5 shrink-0')
+    expect(markup).not.toContain('translate-y')
     // Why: React HTML-escapes `[`/`&` in class strings during static markup.
     expect(markup).toContain('size-3.5!')
   })
 
-  it('uses the same 14px optical alignment for every agent mark', () => {
+  it('uses the same centered 14px layout for every agent mark', () => {
     for (const agent of AGENT_CATALOG) {
       const markup = renderToStaticMarkup(
         <AgentCombobox
@@ -53,7 +54,8 @@ describe('AgentCombobox', () => {
       )
 
       expect(markup).toContain(agent.label)
-      expect(markup).toContain('size-3.5 -translate-y-px shrink-0')
+      expect(markup).toContain('size-3.5 shrink-0')
+      expect(markup).not.toContain('translate-y')
       expect(markup).toContain('width="14"')
       expect(markup).toContain('height="14"')
     }

--- a/src/renderer/src/components/agent/AgentCombobox.test.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.test.tsx
@@ -21,6 +21,26 @@ describe('AgentCombobox', () => {
     expect(markup).toContain('flex-1')
   })
 
+  it('centers the selected agent mark and label inside a full-width form trigger', () => {
+    const markup = renderToStaticMarkup(
+      <AgentCombobox
+        agents={AGENT_CATALOG}
+        value="codex"
+        onValueChange={vi.fn()}
+        allowNarrowTrigger
+        triggerClassName="h-9 w-full min-w-0"
+      />
+    )
+
+    expect(markup).toContain('Codex')
+    expect(markup).not.toContain('!min-w-[260px]')
+    expect(markup).toContain('min-w-0 w-full')
+    expect(markup).toContain('leading-none')
+    expect(markup).toContain('size-3.5 shrink-0')
+    // Why: React HTML-escapes `[`/`&` in class strings during static markup.
+    expect(markup).toContain('size-3.5!')
+  })
+
   it('supports an Agent-only empty state without presenting a blank terminal', () => {
     const markup = renderToStaticMarkup(
       <AgentCombobox

--- a/src/renderer/src/components/agent/AgentCombobox.test.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.test.tsx
@@ -36,9 +36,27 @@ describe('AgentCombobox', () => {
     expect(markup).not.toContain('!min-w-[260px]')
     expect(markup).toContain('min-w-0 w-full')
     expect(markup).toContain('leading-none')
-    expect(markup).toContain('size-3.5 shrink-0')
+    expect(markup).toContain('size-3.5 -translate-y-px shrink-0')
     // Why: React HTML-escapes `[`/`&` in class strings during static markup.
     expect(markup).toContain('size-3.5!')
+  })
+
+  it('uses the same 14px optical alignment for every agent mark', () => {
+    for (const agent of AGENT_CATALOG) {
+      const markup = renderToStaticMarkup(
+        <AgentCombobox
+          agents={AGENT_CATALOG}
+          value={agent.id}
+          onValueChange={vi.fn()}
+          allowNarrowTrigger
+        />
+      )
+
+      expect(markup).toContain(agent.label)
+      expect(markup).toContain('size-3.5 -translate-y-px shrink-0')
+      expect(markup).toContain('width="14"')
+      expect(markup).toContain('height="14"')
+    }
   })
 
   it('supports an Agent-only empty state without presenting a blank terminal', () => {

--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -86,10 +86,14 @@ function renderItem({
       onSelect={onSelect}
       className="items-center gap-2 px-3 py-1.5"
     >
-      <Check className={cn('size-4 text-foreground', isChecked ? 'opacity-100' : 'opacity-0')} />
+      <Check
+        className={cn('size-4 shrink-0 text-foreground', isChecked ? 'opacity-100' : 'opacity-0')}
+      />
       <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-        {icon}
-        <span className="truncate">{label}</span>
+        <span className="inline-flex size-3.5 shrink-0 items-center justify-center [&_img]:size-3.5 [&_svg]:size-3.5!">
+          {icon}
+        </span>
+        <span className="truncate leading-none">{label}</span>
       </span>
     </CommandItem>
   )
@@ -268,7 +272,9 @@ export default function AgentCombobox({
   )
 
   return (
-    <div className="flex w-full items-center">
+    // Why: min-w-0 lets full-width form rows shrink; plain flex+items-center left the
+    // trigger free to overflow its dialog column and look misaligned with Project/Name.
+    <div className="min-w-0 w-full">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <Button
@@ -281,7 +287,8 @@ export default function AgentCombobox({
             className={cn(
               // Why: callers sometimes pass `min-w-0` for grid layouts, but
               // the compact trigger still needs room for "GitHub Copilot".
-              'h-8 justify-between px-3 text-xs font-normal',
+              // py-0 clears the default size's py-2 so icon+label center in h-8/h-9.
+              'h-8 justify-between px-3 py-0 text-xs font-normal',
               triggerClassName,
               !allowNarrowTrigger && TRIGGER_MIN_WIDTH_CLASS
             )}
@@ -289,19 +296,22 @@ export default function AgentCombobox({
           >
             {selectedAgent ? (
               <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                <AgentIcon agent={selectedAgent.id} />
-                <span className="truncate">{selectedAgent.label}</span>
+                {/* Why: pin a 14px box so Button's [&_svg]:size-4 cannot inflate agent marks. */}
+                <span className="inline-flex size-3.5 shrink-0 items-center justify-center [&_img]:size-3.5 [&_svg]:size-3.5!">
+                  <AgentIcon agent={selectedAgent.id} size={14} />
+                </span>
+                <span className="truncate leading-none">{selectedAgent.label}</span>
               </span>
             ) : (
               <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                <Terminal className="size-3.5" />
-                <span className="truncate">
+                <Terminal className="size-3.5 shrink-0" />
+                <span className="truncate leading-none">
                   {emptyLabel ??
                     translate('auto.components.agent.AgentCombobox.986f946354', 'Blank Terminal')}
                 </span>
               </span>
             )}
-            <ChevronsUpDown className="size-3.5 opacity-50" />
+            <ChevronsUpDown className="size-3.5 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
         <PopoverContent

--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -78,8 +78,7 @@ function AgentIconLabel({
 }): React.JSX.Element {
   return (
     <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-      {/* Why: Geist's visible glyphs sit high in their line box, so lift marks to their optical center. */}
-      <span className="inline-flex size-3.5 -translate-y-px shrink-0 items-center justify-center [&_img]:size-3.5 [&_svg]:size-3.5!">
+      <span className="inline-flex size-3.5 shrink-0 items-center justify-center [&_img]:size-3.5 [&_svg]:size-3.5!">
         {icon}
       </span>
       <span className="truncate leading-none">{label}</span>
@@ -105,10 +104,7 @@ function renderItem({
       className="items-center gap-2 px-3 py-1.5"
     >
       <Check
-        className={cn(
-          'size-4 -translate-y-px shrink-0 text-foreground',
-          isChecked ? 'opacity-100' : 'opacity-0'
-        )}
+        className={cn('size-4 shrink-0 text-foreground', isChecked ? 'opacity-100' : 'opacity-0')}
       />
       <AgentIconLabel icon={icon} label={label} />
     </CommandItem>
@@ -324,7 +320,7 @@ export default function AgentCombobox({
                 }
               />
             )}
-            <ChevronsUpDown className="size-3.5 -translate-y-px shrink-0 opacity-50" />
+            <ChevronsUpDown className="size-3.5 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
         <PopoverContent

--- a/src/renderer/src/components/agent/AgentCombobox.tsx
+++ b/src/renderer/src/components/agent/AgentCombobox.tsx
@@ -69,6 +69,24 @@ type ItemRenderArgs = {
   label: string
 }
 
+function AgentIconLabel({
+  icon,
+  label
+}: {
+  icon: React.ReactNode
+  label: string
+}): React.JSX.Element {
+  return (
+    <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+      {/* Why: Geist's visible glyphs sit high in their line box, so lift marks to their optical center. */}
+      <span className="inline-flex size-3.5 -translate-y-px shrink-0 items-center justify-center [&_img]:size-3.5 [&_svg]:size-3.5!">
+        {icon}
+      </span>
+      <span className="truncate leading-none">{label}</span>
+    </span>
+  )
+}
+
 function renderItem({
   key,
   itemValue,
@@ -87,14 +105,12 @@ function renderItem({
       className="items-center gap-2 px-3 py-1.5"
     >
       <Check
-        className={cn('size-4 shrink-0 text-foreground', isChecked ? 'opacity-100' : 'opacity-0')}
+        className={cn(
+          'size-4 -translate-y-px shrink-0 text-foreground',
+          isChecked ? 'opacity-100' : 'opacity-0'
+        )}
       />
-      <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-        <span className="inline-flex size-3.5 shrink-0 items-center justify-center [&_img]:size-3.5 [&_svg]:size-3.5!">
-          {icon}
-        </span>
-        <span className="truncate leading-none">{label}</span>
-      </span>
+      <AgentIconLabel icon={icon} label={label} />
     </CommandItem>
   )
   if (!onSetDefault) {
@@ -295,23 +311,20 @@ export default function AgentCombobox({
             data-agent-combobox-root="true"
           >
             {selectedAgent ? (
-              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                {/* Why: pin a 14px box so Button's [&_svg]:size-4 cannot inflate agent marks. */}
-                <span className="inline-flex size-3.5 shrink-0 items-center justify-center [&_img]:size-3.5 [&_svg]:size-3.5!">
-                  <AgentIcon agent={selectedAgent.id} size={14} />
-                </span>
-                <span className="truncate leading-none">{selectedAgent.label}</span>
-              </span>
+              <AgentIconLabel
+                icon={<AgentIcon agent={selectedAgent.id} size={14} />}
+                label={selectedAgent.label}
+              />
             ) : (
-              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                <Terminal className="size-3.5 shrink-0" />
-                <span className="truncate leading-none">
-                  {emptyLabel ??
-                    translate('auto.components.agent.AgentCombobox.986f946354', 'Blank Terminal')}
-                </span>
-              </span>
+              <AgentIconLabel
+                icon={<Terminal className="size-3.5" />}
+                label={
+                  emptyLabel ??
+                  translate('auto.components.agent.AgentCombobox.986f946354', 'Blank Terminal')
+                }
+              />
             )}
-            <ChevronsUpDown className="size-3.5 shrink-0 opacity-50" />
+            <ChevronsUpDown className="size-3.5 -translate-y-px shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
         <PopoverContent


### PR DESCRIPTION
## Summary
- Fix vertical alignment of the Agent combobox icon + label in the new worktree dialog
- Pin agent marks to 14px so Button/CommandItem `size-4` rules cannot inflate Codex/Claude SVGs past the chevron and text
- Use a full-width `min-w-0` form trigger (`allowNarrowTrigger`) so the row lines up with Project/Name

## Before / After

### Before
Agent icon rendered oversized and optically high relative to the “Codex” label inside the select.

![before.png](https://github.com/user-attachments/assets/79686381-4c53-4ebb-a4c6-f11b37137942)

### After
Icon, label, and chevron share one midline at 14px with even vertical padding.

![after.jpg](https://github.com/user-attachments/assets/2f5f8c30-f810-4a35-a7b2-3aa266a0a05b)

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/agent/AgentCombobox.test.tsx`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/NewWorkspaceComposerCard.test.tsx`
- [ ] Open **New worktree** dialog → Agent field shows Codex/Claude with icon + label vertically centered
- [ ] Confirm Agent control is full-width and left/right edges match Project and Name fields
- [ ] Open agent picker list — row icons stay 14px and aligned with labels
- [ ] Settings gear next to Agent label still opens agent settings