### PR TITLE
fix(panes): stop a stray mouse hijacking a touch divider drag

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-divider-drag.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider-drag.ts
@@ -77,6 +77,7 @@ export function attachDividerDrag(
   let prevInitialFlex = ''
   let nextInitialFlex = ''
   let activePointerId: number | null = null
+  let activePointerType: string | null = null
   let releasePtyResizeHold: { flush: () => void; cancel: () => void } | null = null
   let windowListenersAttached = false
   const flexScheduler = createDividerFlexFrameScheduler({
@@ -131,12 +132,14 @@ export function attachDividerDrag(
       removeWindowListeners()
       releasePointerCaptureIfHeld(activePointerId)
       activePointerId = null
+      activePointerType = null
       return
     }
 
     const pointerId = activePointerId
     dragging = false
     activePointerId = null
+    activePointerType = null
     removeWindowListeners()
 
     if (commitLayout) {
@@ -198,6 +201,7 @@ export function attachDividerDrag(
 
     divider.setPointerCapture(e.pointerId)
     activePointerId = e.pointerId
+    activePointerType = e.pointerType
     divider.classList.add('is-dragging')
     dragging = true
     didMove = false
@@ -220,12 +224,13 @@ export function attachDividerDrag(
 
   // Why: WSLg's RDP input path reports press/release as a `mouse` pointer but
   // streams motion as a `pen` pointer with a different pointerId, so a strict
-  // pointerId match drops every move. Any primary pointer continues the drag,
-  // except touch: each pointer type has its own primary, so a stray finger
-  // would otherwise hijack an in-flight mouse/pen drag. A touch-started drag
-  // still matches by pointerId.
+  // pointerId match drops every move. A foreign primary pointer may take over
+  // only when neither end is touch: each pointer type has its own primary, so
+  // otherwise a stray finger hijacks a mouse/pen drag and a stray mouse hijacks
+  // a touch drag. Either drag still matches its own pointer by pointerId.
   const isActiveDragPointer = (e: PointerEvent): boolean =>
-    e.pointerId === activePointerId || (e.isPrimary && e.pointerType !== 'touch')
+    e.pointerId === activePointerId ||
+    (e.isPrimary && e.pointerType !== 'touch' && activePointerType !== 'touch')
 
   const onPointerMove = (e: PointerEvent): void => {
     if (!dragging || !isActiveDragPointer(e) || !prevEl || !nextEl) {

--- a/src/renderer/src/lib/pane-manager/pane-divider-stray-touch.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-divider-stray-touch.test.ts
@@ -123,6 +123,17 @@ function startMouseDrag(harness: DividerDragHarness): void {
   harness.flushAnimationFrames()
 }
 
+// The mirror of STRAY_TOUCH: a mouse keeps its own primary while a finger
+// already owns the divider, and needs no contact with the divider strip.
+const TOUCH_DRAG = { pointerId: 7, pointerType: 'touch', isPrimary: true } as const
+const STRAY_MOUSE = { pointerId: 51, pointerType: 'mouse', isPrimary: true } as const
+
+function startTouchDrag(harness: DividerDragHarness): void {
+  harness.dividerListeners.get('pointerdown')?.(createPointerEvent({ ...TOUCH_DRAG, clientX: 100 }))
+  harness.windowListeners.get('pointermove')?.(createPointerEvent({ ...TOUCH_DRAG, clientX: 180 }))
+  harness.flushAnimationFrames()
+}
+
 afterEach(() => {
   vi.unstubAllGlobals()
 })
@@ -193,16 +204,68 @@ describe('divider drag pointer-type isolation', () => {
 
   it('drives a touch-started drag from its own pointerId', () => {
     const harness = createDividerDragHarness()
-    const touchDrag = { pointerId: 7, pointerType: 'touch', isPrimary: true } as const
-    harness.dividerListeners.get('pointerdown')?.(
-      createPointerEvent({ ...touchDrag, clientX: 100 })
-    )
-    harness.windowListeners.get('pointermove')?.(createPointerEvent({ ...touchDrag, clientX: 180 }))
-    harness.flushAnimationFrames()
-    harness.windowListeners.get('pointerup')?.(createPointerEvent({ ...touchDrag, clientX: 180 }))
+    startTouchDrag(harness)
+    harness.windowListeners.get('pointerup')?.(createPointerEvent({ ...TOUCH_DRAG, clientX: 180 }))
 
     expect(harness.previousPane.style.flex).toBe('180 1 0%')
     expect(harness.nextPane.style.flex).toBe('220 1 0%')
     expect(harness.onLayoutChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores stray mouse motion during an active touch drag', () => {
+    const harness = createDividerDragHarness()
+    startTouchDrag(harness)
+    expect(harness.previousPane.style.flex).toBe('180 1 0%')
+
+    harness.windowListeners.get('pointermove')?.(
+      createPointerEvent({ ...STRAY_MOUSE, clientX: 320 })
+    )
+    harness.flushAnimationFrames()
+
+    expect(harness.previousPane.style.flex).toBe('180 1 0%')
+    expect(harness.nextPane.style.flex).toBe('220 1 0%')
+  })
+
+  it('does not commit the layout when a stray mouse lifts mid touch drag', () => {
+    const harness = createDividerDragHarness()
+    startTouchDrag(harness)
+
+    harness.windowListeners.get('pointerup')?.(createPointerEvent({ ...STRAY_MOUSE, clientX: 320 }))
+
+    expect(harness.onLayoutChanged).not.toHaveBeenCalled()
+    expect(harness.divider.classList.remove).not.toHaveBeenCalledWith('is-dragging')
+    expect(harness.windowListeners.has('pointermove')).toBe(true)
+
+    harness.windowListeners.get('pointerup')?.(createPointerEvent({ ...TOUCH_DRAG, clientX: 180 }))
+
+    expect(harness.previousPane.style.flex).toBe('180 1 0%')
+    expect(harness.onLayoutChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not revert the layout when a stray mouse is cancelled mid touch drag', () => {
+    const harness = createDividerDragHarness()
+    harness.previousPane.style.flex = '2 1 0%'
+    harness.nextPane.style.flex = '3 1 0%'
+    startTouchDrag(harness)
+
+    harness.windowListeners.get('pointercancel')?.(
+      createPointerEvent({ ...STRAY_MOUSE, clientX: 320 })
+    )
+
+    expect(harness.previousPane.style.flex).toBe('180 1 0%')
+    expect(harness.windowListeners.has('pointermove')).toBe(true)
+  })
+
+  it('blocks a stray primary pen from hijacking a touch drag', () => {
+    const harness = createDividerDragHarness()
+    startTouchDrag(harness)
+
+    harness.windowListeners.get('pointermove')?.(
+      createPointerEvent({ pointerId: 52, pointerType: 'pen', isPrimary: true, clientX: 320 })
+    )
+    harness.flushAnimationFrames()
+
+    expect(harness.previousPane.style.flex).toBe('180 1 0%')
+    expect(harness.nextPane.style.flex).toBe('220 1 0%')
   })
 })


### PR DESCRIPTION
## Summary

`attachDividerDrag` records `activePointerId` at `pointerdown` but never records the pointer **type**. The ownership predicate was:

```ts
e.pointerId === activePointerId || (e.isPrimary && e.pointerType !== 'touch')
```

During a **touch-started** drag, `activePointerId` is the touch id, so any stray primary **mouse** or **pen** event:

- fails clause 1 (different `pointerId`)
- **passes** clause 2 (`isPrimary` is true, and `'mouse'`/`'pen'` is not `'touch'`)

and is accepted as the active drag pointer. The window capture-phase listeners then act on it: `pointermove` snaps the divider to the cursor, `pointerup` **commits** a pane size the user never chose, and `pointercancel` **reverts** the layout.

Each pointer type has its own primary pointer, so a mouse cursor sitting on the screen keeps `isPrimary: true` for the entire duration of a finger drag. This needs only mouse motion *anywhere on screen* — no contact with the ~10px divider strip.

### This is pre-existing, not a regression

It behaves **identically before and after #11013**. `git log -S` on the predicate confirms the lineage:

- `001a5c6846` (#9153) introduced `e.pointerId === activePointerId || e.isPrimary`
- `a72068015f` (#11013) changed it to `e.pointerId === activePointerId || (e.isPrimary && e.pointerType !== 'touch')`

A stray primary mouse during a touch drag passes `e.isPrimary` on the first form and passes `e.isPrimary && pointerType !== 'touch'` on the second. Allowed either way. #11013 closed the mouse-drag-hijacked-by-touch direction; this PR closes the mirror, and together they close both directions of the class.

### The fix

Record the pointer type alongside the id at `pointerdown`, clear it everywhere the id is cleared, and require **both ends** to be non-touch before the fallback lets a foreign pointer take over:

```ts
e.pointerId === activePointerId ||
(e.isPrimary && e.pointerType !== 'touch' && activePointerType !== 'touch')
```

| drag started by | stray event | result |
| --- | --- | --- |
| mouse | pen | **allowed** — WSLg relay preserved |
| mouse | touch | blocked (#11013, not regressed) |
| touch | mouse | **blocked — this PR** |
| touch | pen | **blocked — this PR** |
| any | its own `pointerId` | allowed via clause 1 |

The `isPrimary` fallback is deliberately preserved: WSLg's RDP input path reports press/release as a `mouse` pointer but streams motion as a `pen` pointer with a *different* `pointerId`, so a strict `pointerId` match drops every move. The check stays a **denylist** (`!== 'touch'`) rather than an allowlist — per W3C, `pointerType` MUST be `''` when the device type is undetectable and SHOULD be vendor-prefixed for novel devices, so an allowlist would drop default handling and risk re-breaking that class of relay.

## Screenshots

No visual change. The divider's rendered appearance, size, and cursor are untouched; only which pointer events are accepted as the active drag pointer changes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (full CI: 27/27 checks pass, including all 16 test shards)
- [x] `pnpm build` (covered by the `package` and `crash-survival (packaged build)` CI jobs)
- [x] Added or updated high-quality tests that would catch regressions

Tests live in `pane-divider-stray-touch.test.ts`. Note the `createPointerEvent` helper in `pane-divider.test.ts` omits `isPrimary` **and** `pointerType` entirely, so tests written through it are blind to this predicate and ride the `pointerId` clause alone; the helper in `pane-divider-stray-touch.test.ts` defaults `isPrimary: true` / `pointerType: 'mouse'`, and every new test sets both explicitly.

**Added by this PR — 4 new tests, all 4 fail without the fix (no padding):**
- touch-started drag + stray primary mouse `pointermove` does not move the divider
- touch-started drag + stray primary mouse `pointerup` does not commit
- touch-started drag + stray primary mouse `pointercancel` does not revert
- touch-started drag + stray primary pen `pointermove` does not move the divider

**Pre-existing tests that pass on both sides, retained as no-regression guards** (these are *not* added by this PR — they arrive from #11013; `drives a touch-started drag from its own pointerId` is only refactored onto the new `startTouchDrag` helper, assertions unchanged, and the WSLg test is untouched):
- `still continues a mouse drag from a primary pen pointer (WSLg relay)` — pins the row that must NOT change
- `drives a touch-started drag from its own pointerId` — pins clause 1 end to end

Revert-check, reverting only `pane-divider-drag.ts` and keeping the new tests:

```
===== AFTER (fix applied) =====
 Test Files  2 passed (2)
      Tests  19 passed (19)

===== BEFORE (source reverted, new tests kept) =====
     × ignores stray mouse motion during an active touch drag
     × does not commit the layout when a stray mouse lifts mid touch drag
     × does not revert the layout when a stray mouse is cancelled mid touch drag
     × blocks a stray primary pen from hijacking a touch drag
 Test Files  1 failed | 1 passed (2)
      Tests  4 failed | 15 passed (19)
```

The failures are value-discriminating, not merely thrown: on the reverted side `previousPane.style.flex` reads `320 1 0%` where the test expects `180 1 0%` — the stray pointer genuinely dragged the divider to the foreign cursor position.

## AI Review Report

Reviewed against four criteria: does it fix the stated issue, no regressions, no perf issues, no scope expansion. Three independent passes: a direct review plus two AI reviewer agents (one correctness-focused, one adversarial). All three independently reproduced the same `4 failed | 15 passed` revert split, and both agents returned CLEAN with no defects and no objection. The adversarial pass additionally derived the failure set and the discriminating flex value (`320 1 0%` vs `180 1 0%`) from source before observing them.

**Main risks checked:**

- **Truth table.** All five rows verified against the predicate and each backed by an executing test: mouse+pen allowed (WSLg), mouse+touch blocked (#11013 not regressed), touch+mouse blocked, touch+pen blocked, own-`pointerId` allowed.
- **Stale state — the highest risk.** `activePointerType` must be cleared at every site that nulls `activePointerId`, or the *next* drag would be gated on the *previous* drag's pointer type. Verified by grep rather than by assertion: three assignment sites each, paired in lockstep (`134/135`, `141/142`, `203/204`). Every teardown path — `onWindowBlur`, `onPointerCancel`, `disposeDividerDrag`, and the leading `finishActiveDrag(false)` in `onPointerDown` — routes through `finishActiveDrag`, which covers both branches. The two `onPointerDown` early returns (`!previousPane || !nextPane`, `measuredTotalSize <= 0`) fire *after* that clearing call, so neither can leak a type.
- **Are the clears observable?** Probed at runtime: with both `activePointerType = null` lines deleted, all 19 tests still pass *and* a purpose-built stale-leak probe still passes. Reason: `onPointerDown` unconditionally reassigns `activePointerType`, and every handler that could see a stale value is already gated by `dragging`. The clears are correct hygiene keeping the two variables in lockstep, but they are genuinely unobservable — so no non-vacuous test exists for them and none was added rather than padding the suite with a guard that passes either way.
- **Test vacuity.** A revert-check was run directly (patch method, never `git stash` — the stash ref is shared across worktrees), reproducing the 4-failed/15-passed split exactly, and independently reproduced by a second reviewer. Every test this PR adds fails on revert — 4 added, 4 failing, zero padding. The two always-passing guards are pre-existing tests from #11013, retained (not authored here) because they pin the WSLg row and the touch-own-`pointerId` row, which *should* pass on both sides by design.
- **Perf.** One extra string comparison against a closure-scoped `string | null`, only inside the existing `isActiveDragPointer` short-circuit, only while a drag is in flight. No allocation, no closure churn, no added work outside the drag, no change to the `requestAnimationFrame` flex coalescing.
- **Cross-platform (macOS / Linux / Windows).** Explicitly checked. This is a pointer**Type** distinction, not an OS one — no `navigator`, `process.platform`, or user-agent branch is introduced, and none is warranted. No keyboard shortcut, accelerator, shortcut label, or path handling is touched. Behavior is identical on all three platforms; the WSLg case is a Linux-on-Windows input-relay concern and is the row deliberately preserved. Nothing here is Electron-main or shell-dependent, so SSH-hosted and folder (non-git-worktree) workspaces are unaffected — this is pure renderer-side DOM event arbitration.
- **Scope.** Two files, one concern. Flex math, the PTY resize hold, and the double-click handler are untouched. No `max-lines` disable anywhere in the diff.

**Changed or verified as a result:** no defects found; no follow-up commits were needed.

## Security Audit

Low risk, no security-relevant surface. The change is renderer-only DOM pointer-event arbitration inside a single closure. It introduces no input parsing, no command execution, no path handling, no filesystem or network access, no IPC message or handler, no authentication or authorization logic, no secret handling, and no dependency change. The one added variable is a closure-local `string | null` holding a browser-supplied `PointerEvent.pointerType`; it is only ever compared against the literal `'touch'` and is never interpolated into a selector, path, command, or IPC payload. The net effect is *narrower* acceptance of untrusted input — foreign pointer events that were previously honored are now rejected — so the change strictly reduces the surface. No follow-up needed.

## Notes

- **The new predicate is a strict narrowing.** It is `OLD && (activePointerType !== 'touch')` — a pure conjunction, so the accepted set is a strict subset of `main`'s. No event that was rejected before is accepted now; the only possible defect class is a *lost* acceptance, which is exactly why the WSLg row is pinned by a both-sides-passing test.
- **Denylist, not allowlist — deliberate.** The check must stay `pointerType !== 'touch'`. Per W3C Pointer Events, `pointerType` MUST be the empty string when the device type cannot be detected and SHOULD be vendor-prefixed for novel device types. An allowlist of known types would drop both of those into the reject path and risks re-breaking the WSLg-class input relay that #9153 fixed. Note `pointerType === ''` satisfies `'' !== 'touch'` in *both* positions, so such devices behave identically before and after this change.
- **Pre-existing residuals, unchanged by this PR, flagged so they are not mistaken for gaps:** (1) a `pointerId` collision would defeat the arbitration in either direction, since clause 1 is type-blind and checked first — pre-existing since #9153 and near-unreachable in Chromium, where mouse is id 1 and touch ids start at 2; (2) a stray mouse `pointerdown` *on the divider strip* still aborts an in-flight touch drag via the unconditional `finishActiveDrag(false)` at the top of `onPointerDown` — identical before and after, and arguably correct, and not the scenario this PR addresses (a press elsewhere on screen never reaches that handler).
- **Hardware limitation.** Neither a real touchscreen, a real pen digitizer, a `pointerType === ''` device, nor a live WSLg/RDP session could be driven in this environment, so those paths are covered by unit tests exercising the real module against the event predicate plus W3C spec reading, not by hardware QA. The WSLg premise (press/release as `mouse`, motion as `pen` with a different `pointerId`) is inherited from #9153 and the code comment rather than re-observed. The WSLg row is protected by a test that passes on both sides of the revert, which is the strongest available guard short of a real RDP session. The `pointerType === ''` path has no test at all — the honest coverage gap, though by the strict-narrowing argument above it cannot regress.
