### PR TITLE
fix(runtime): drain pending session-tabs notify before a new subscriber joins

### DIFF
--- a/src/main/runtime/graph-sync-mobile-snapshot-gating.test.ts
+++ b/src/main/runtime/graph-sync-mobile-snapshot-gating.test.ts
@@ -325,6 +325,28 @@ describe('graph-sync mobile snapshot gating', () => {
     expect(events).toHaveLength(0)
   })
 
+  it('drains a pending notify to existing subscribers instead of replaying it to a new one', () => {
+    const { runtime, events, sync } = createRuntime(makeSession())
+
+    sync([makeRendererSnapshot({ version: 1 })])
+    // Mid-window: the notify is armed but has not fired.
+    vi.advanceTimersByTime(20)
+    expect(events).toHaveLength(0)
+
+    const lateEvents: RuntimeMobileSessionTabsResult[] = []
+    runtime.onMobileSessionTabsChanged((snapshot) => lateEvents.push(snapshot))
+    const drainedOnSubscribe = events.length
+
+    vi.advanceTimersByTime(500)
+    // The new subscriber's initial snapshot already folded that state in, so it
+    // must never see the armed notify — otherwise the timer lands as a stale
+    // `updated` frame carrying pre-subscribe state.
+    expect(lateEvents).toEqual([])
+    // Drained on subscribe, not cancelled: no existing subscriber loses it.
+    expect(drainedOnSubscribe).toBe(1)
+    expect(events).toHaveLength(1)
+  })
+
   it('forces an emit by the starvation cap under sustained sync churn', () => {
     const { events, sync } = createRuntime(makeSession())
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -7402,6 +7402,11 @@ export class OrcaRuntimeService {
     listener: (snapshot: RuntimeMobileSessionTabsResult) => void,
     clientNavigationId?: string
   ): () => void {
+    // Why: a notify coalesced before this subscriber existed is already folded
+    // into the initial snapshot it was just sent. Draining it here — before the
+    // listener joins — keeps that pending timer from landing as a redundant
+    // `updated` frame carrying pre-subscribe state. Mirrors the unsubscribe flush.
+    this.mobileSessionTabsNotifyCoalescer.flushAll()
     const subscription = { listener, clientNavigationId }
     this.mobileSessionTabListeners.add(subscription)
     return () => {


### PR DESCRIPTION
## The flake

`src/main/runtime/multi-client-navigation-isolation.integration.test.ts` → **"routes explicit host and paired-client follow intent without changing the default"** fails intermittently on CI for unrelated PRs. It is not caused by any particular PR — clean `main` fails it on its own.

## Mechanism

A race between the 50ms session-tabs notify coalescer and listener registration.

- A notify is armed by `seedSessionTabs` → `syncWindowGraph` (`orca-runtime.ts`), on the 50ms trailing-edge window in `mobile-session-tabs-notify-coalescer.ts`.
- `session.tabs.subscribe` reads its initial snapshot, emits it, then registers a listener via `onMobileSessionTabsChanged`.
- If the pending timer fires **after** that listener registers but **before** the next mutation (`session.tabs.activate`) is handled, it delivers a stale `{ type: 'updated', activeTabId: 'host-tab' }` — state the subscriber's initial snapshot had already folded in.

The test consumes that frame at `multi-client-navigation-isolation.integration.test.ts:515`, producing the CI assertion:

```
AssertionError: expected 'host-tab' to be 'client-a-tab'
```

Instrumented trace on a failing run, showing the ~2ms margin:

```
[TRACE 23412] coalescer.schedule repo-1::/tmp/session
[TRACE 23460] onMobileSessionTabsChanged REGISTER 1f1129ff-…
[TRACE 23461] onMobileSessionTabsChanged REGISTER 5070bfc2-…
[TRACE 23462] coalescer.fire repo-1::/tmp/session      <-- lands between subscribe and activate
```

## The fix

One line: `flushAll()` the coalescer at the top of `onMobileSessionTabsChanged`, **before** the listener joins the set — mirroring the `flushAll()` its own unsubscribe closure already performs.

Draining rather than cancelling matters: a `cancel`/`dispose` would silence the stale frame but drop the update for subscribers that were already listening. `flushAll` delivers it to them and simply excludes the newcomer, whose initial snapshot already covers it.

## Measurement

Reproduced and verified by sweeping the coalescer flush window across the race boundary (12 delays × 2 reps, single test):

| | delays 45–56ms × 2 reps |
|---|---|
| clean `main` (6943638053) | **5 / 24 failed** |
| with this fix | **0 / 24 failed** |

Both observed failure modes were the same stale frame, one step apart:
- `expected 'host-tab' to be 'client-a-tab'`
- `expected [ 'client-a-tab', 'host-tab' ] to deeply equal [ 'client-b-tab', 'client-b-tab' ]`

Full file at the real 50ms default: 5/5 pass.

## Regression test

`graph-sync-mobile-snapshot-gating.test.ts` — deterministic, on **fake timers**, no wall-clock dependency. It arms a notify, advances 20ms into the window, subscribes late, then runs the clock out.

It is two-sided, and I verified both directions:
- without the fix → fails on the primary assertion (`expected [ {…} ] to deeply equal []` — the late subscriber got the stale frame)
- with the flush swapped for a `dispose`/cancel → fails on `expected +0 to be 1` (an existing subscriber lost the update)

## Verification

- `src/main/runtime` full suite: **2885 passed, 5 skipped, 0 failed** (181 files)
- `tsc --noEmit` × 3 (node / cli / web, `--composite false`, tsbuildinfo cleared first): clean
- `oxlint`: exit 0, no warnings in either touched file
- `check:max-lines-ratchet`: OK, no new bypasses
- `oxfmt`: no changes

Scope is this race only — the coalescer and the session-tabs RPC are untouched, and the failing test was not weakened, skipped, retried, or deleted.