### PR TITLE
feat(speech): add Qwen3-ASR local speech model

### DIFF
--- a/src/main/speech/model-catalog.test.ts
+++ b/src/main/speech/model-catalog.test.ts
@@ -39,6 +39,42 @@ describe('SPEECH_MODEL_CATALOG', () => {
     expect(model?.files).toEqual(['model.int8.onnx', 'tokens.txt'])
   })
 
+  it('registers Qwen3-ASR as a non-streaming local model', () => {
+    const model = getCatalogModel('qwen3-asr-0.6b-int8')
+
+    expect(model).toBeDefined()
+    expect(model?.type).toBe('qwen3-asr')
+    expect(model?.provider).toBe('local')
+    expect(model?.language).toBe('multilingual')
+    expect(model?.streaming).toBe(false)
+    expect(model?.sampleRate).toBe(16000)
+  })
+
+  it('flattens the nested Qwen3-ASR tokenizer files into the model directory', () => {
+    const model = getCatalogModel('qwen3-asr-0.6b-int8')
+
+    expect(model?.files).toEqual([
+      'conv_frontend.onnx',
+      'encoder.int8.onnx',
+      'decoder.int8.onnx',
+      'vocab.json',
+      'merges.txt',
+      'tokenizer_config.json'
+    ])
+    expect(model?.downloadFiles?.find(({ name }) => name === 'vocab.json')?.url).toContain(
+      '/tokenizer/vocab.json'
+    )
+    expect(model?.sizeBytes).toBe(987_015_347)
+  })
+
+  it('leaves flat download URLs unchanged now that nested paths are supported', () => {
+    const model = getCatalogModel('sense-voice-zh-en-ja-ko-yue')
+
+    expect(model?.downloadFiles?.[0]?.url).toBe(
+      'https://huggingface.co/csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/resolve/2365baeacb507f821a0c8120fcee3d484dba7a07/model.int8.onnx?download=true'
+    )
+  })
+
   it('downloads only the pinned SenseVoice runtime files', () => {
     const model = getCatalogModel('sense-voice-zh-en-ja-ko-yue')
     expect(model?.sizeBytes).toBe(239_549_735)

--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -101,6 +101,18 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     streaming: false
   },
   {
+    id: 'qwen3-asr-0.6b-int8',
+    label: 'Qwen3-ASR',
+    description:
+      '30 languages with automatic language detection, including Chinese, English, Japanese, and Korean. Largest download of the local models.',
+    type: 'qwen3-asr',
+    provider: 'local',
+    language: 'multilingual',
+    ...getSpeechModelDownloadMetadata('qwen3-asr-0.6b-int8'),
+    sampleRate: 16000,
+    streaming: false
+  },
+  {
     id: 'whisper-tiny',
     label: 'Whisper Tiny',
     description: '90+ languages. Lower accuracy than Parakeet but broadest language coverage.',

--- a/src/main/speech/model-download-catalog.ts
+++ b/src/main/speech/model-download-catalog.ts
@@ -1,15 +1,26 @@
 import type { SpeechModelDownloadFile } from '../../shared/speech-types'
 
-type DownloadFileSpec = readonly [name: string, sizeBytes: number, sha256: string]
+type DownloadFileSpec = readonly [
+  name: string,
+  sizeBytes: number,
+  sha256: string,
+  // Why: some repos nest runtime files (e.g. tokenizer/vocab.json) while the
+  // downloader stores every model file flat in one directory.
+  remotePath?: string
+]
+
+function encodeRepositoryPath(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/')
+}
 
 function huggingFaceFiles(
   repository: string,
   revision: string,
   specs: DownloadFileSpec[]
 ): SpeechModelDownloadFile[] {
-  return specs.map(([name, sizeBytes, sha256]) => ({
+  return specs.map(([name, sizeBytes, sha256, remotePath]) => ({
     name,
-    url: `https://huggingface.co/${repository}/resolve/${revision}/${encodeURIComponent(name)}?download=true`,
+    url: `https://huggingface.co/${repository}/resolve/${revision}/${encodeRepositoryPath(remotePath ?? name)}?download=true`,
     sizeBytes,
     sha256
   }))
@@ -210,6 +221,45 @@ const MODEL_DOWNLOAD_FILES = {
         'c71f0ce00bec95b07744e116345e33d8cbbe08cef896382cf907bf4b51a2cd51'
       ],
       ['tokens.txt', 315_894, 'f449eb28dc567533d7fa59be34e2abca8784f771850c78a47fb731a31429a1dc']
+    ]
+  ),
+  'qwen3-asr-0.6b-int8': huggingFaceFiles(
+    'csukuangfj2/sherpa-onnx-qwen3-asr-0.6B-int8-2026-03-25',
+    '68818b2313fe77bd06f6a7c5068ff3ef59d02b8a',
+    [
+      [
+        'conv_frontend.onnx',
+        44_148_281,
+        'd22dc4423e0940e49884e903d2ea2f7e5567c14fc1aed97e4e26d6b8f208ef9e'
+      ],
+      [
+        'encoder.int8.onnx',
+        182_491_662,
+        '60748d3e6744a57c9c91e1b17424a6c2990567e8adceb0783940c03ed98fa9d9'
+      ],
+      [
+        'decoder.int8.onnx',
+        755_914_231,
+        '4f6885be5959ae26af3089d38ee7972c5fafbeeb1cf8d5e76eab6d8b61ca5771'
+      ],
+      [
+        'vocab.json',
+        2_776_833,
+        'ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910',
+        'tokenizer/vocab.json'
+      ],
+      [
+        'merges.txt',
+        1_671_853,
+        '8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5',
+        'tokenizer/merges.txt'
+      ],
+      [
+        'tokenizer_config.json',
+        12_487,
+        '4942d005604266809309cabc9f4e9cb89ce855d59b14681fdc0e1cc62ea26c4c',
+        'tokenizer/tokenizer_config.json'
+      ]
     ]
   )
 }

--- a/src/main/speech/stt-worker-model-config.test.ts
+++ b/src/main/speech/stt-worker-model-config.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { resolveFile, resolveTokens } from './stt-worker-model-config'
+import { buildRecognizerConfig, resolveFile, resolveTokens } from './stt-worker-model-config'
 
 const MODEL_DIR = join('models', 'test-model')
 
@@ -37,5 +37,68 @@ describe('resolveTokens', () => {
     const files = ['model.int8.onnx']
 
     expect(() => resolveTokens(files, MODEL_DIR)).toThrow(/No \*tokens\.txt found/)
+  })
+})
+
+describe('buildRecognizerConfig', () => {
+  const qwenFiles = [
+    'conv_frontend.onnx',
+    'encoder.int8.onnx',
+    'decoder.int8.onnx',
+    'vocab.json',
+    'merges.txt',
+    'tokenizer_config.json'
+  ]
+
+  it('points Qwen3-ASR at the model directory instead of a tokens.txt', () => {
+    const { online, config } = buildRecognizerConfig({
+      modelDir: MODEL_DIR,
+      modelType: 'qwen3-asr',
+      streaming: false,
+      sampleRate: 16000,
+      files: qwenFiles
+    })
+
+    expect(online).toBe(false)
+    const modelConfig = config.modelConfig as Record<string, Record<string, unknown>>
+    expect(modelConfig.qwen3Asr).toEqual({
+      convFrontend: join(MODEL_DIR, 'conv_frontend.onnx'),
+      encoder: join(MODEL_DIR, 'encoder.int8.onnx'),
+      decoder: join(MODEL_DIR, 'decoder.int8.onnx'),
+      tokenizer: MODEL_DIR,
+      hotwords: ''
+    })
+    expect(modelConfig.tokens).toBe('')
+  })
+
+  it('keeps streaming transducers on the online recognizer with endpoint rules', () => {
+    const { online, config } = buildRecognizerConfig({
+      modelDir: MODEL_DIR,
+      modelType: 'transducer',
+      streaming: true,
+      sampleRate: 16000,
+      files: ['encoder.onnx', 'decoder.onnx', 'joiner.onnx', 'tokens.txt']
+    })
+
+    expect(online).toBe(true)
+    expect(config.enableEndpoint).toBe(1)
+    const modelConfig = config.modelConfig as Record<string, unknown>
+    expect(modelConfig.numThreads).toBe(1)
+    expect(modelConfig.tokens).toBe(join(MODEL_DIR, 'tokens.txt'))
+  })
+
+  it('falls back to the offline transducer layout for unknown model types', () => {
+    const { online, config } = buildRecognizerConfig({
+      modelDir: MODEL_DIR,
+      modelType: 'transducer',
+      streaming: false,
+      sampleRate: 16000,
+      files: ['encoder.onnx', 'decoder.onnx', 'joiner.onnx', 'tokens.txt']
+    })
+
+    expect(online).toBe(false)
+    const modelConfig = config.modelConfig as Record<string, unknown>
+    expect(modelConfig.numThreads).toBe(2)
+    expect(modelConfig.transducer).toBeDefined()
   })
 })

--- a/src/main/speech/stt-worker-model-config.ts
+++ b/src/main/speech/stt-worker-model-config.ts
@@ -77,3 +77,142 @@ export function buildHotwordsConfig(opts: {
     modelingUnit: unit
   }
 }
+
+export type RecognizerInit = {
+  modelDir: string
+  modelType: string
+  streaming: boolean
+  sampleRate: number
+  files: string[]
+  hotwordsFilePath?: string
+  modelingUnit?: string
+}
+
+const ENDPOINT_RULES = {
+  enableEndpoint: 1,
+  rule1MinTrailingSilence: 2.4,
+  rule2MinTrailingSilence: 1.2,
+  rule3MinUtteranceLength: 20
+}
+
+// Why: each sherpa model family takes a differently shaped modelConfig, and only
+// transducer/paraformer have an online recognizer — the caller picks the API from `online`.
+export function buildRecognizerConfig(msg: RecognizerInit): {
+  online: boolean
+  config: Record<string, unknown>
+} {
+  const { modelDir, modelType, streaming, sampleRate, files } = msg
+  // Why: Qwen3-ASR carries a BPE tokenizer directory instead of a tokens.txt.
+  const tokens = modelType === 'qwen3-asr' ? '' : resolveTokens(files, modelDir)
+  const featConfig = { sampleRate, featureDim: 80 }
+  const shared = { tokens, provider: 'cpu', debug: 0 }
+
+  if (streaming && modelType === 'transducer') {
+    return {
+      online: true,
+      config: {
+        featConfig,
+        modelConfig: {
+          transducer: {
+            encoder: resolveFile(files, 'encoder', modelDir),
+            decoder: resolveFile(files, 'decoder', modelDir),
+            joiner: resolveFile(files, 'joiner', modelDir)
+          },
+          ...shared,
+          numThreads: 1
+        },
+        ...buildHotwordsConfig(msg),
+        ...ENDPOINT_RULES
+      }
+    }
+  }
+
+  if (streaming && modelType === 'paraformer') {
+    return {
+      online: true,
+      config: {
+        featConfig,
+        modelConfig: {
+          paraformer: {
+            encoder: resolveFile(files, 'encoder', modelDir),
+            decoder: resolveFile(files, 'decoder', modelDir)
+          },
+          ...shared,
+          numThreads: 1
+        },
+        decodingMethod: 'greedy_search',
+        ...ENDPOINT_RULES
+      }
+    }
+  }
+
+  const offline = (modelConfig: Record<string, unknown>, rest: Record<string, unknown>) => ({
+    online: false,
+    config: {
+      featConfig,
+      modelConfig: { ...modelConfig, ...shared, numThreads: 2 },
+      ...rest
+    }
+  })
+
+  if (modelType === 'whisper') {
+    return offline(
+      {
+        whisper: {
+          encoder: resolveFile(files, 'encoder', modelDir),
+          decoder: resolveFile(files, 'decoder', modelDir)
+        }
+      },
+      { decodingMethod: 'greedy_search' }
+    )
+  }
+
+  if (modelType === 'nemo-ctc') {
+    return offline(
+      { nemoCtc: { model: resolveFile(files, 'model', modelDir) } },
+      { decodingMethod: 'greedy_search' }
+    )
+  }
+
+  if (modelType === 'senseVoice') {
+    return offline(
+      {
+        senseVoice: {
+          model: resolveFile(files, 'model', modelDir),
+          // Empty string = auto-detect language (supports zh/en/ja/ko/yue).
+          language: '',
+          useInverseTextNormalization: 1
+        }
+      },
+      { decodingMethod: 'greedy_search' }
+    )
+  }
+
+  if (modelType === 'qwen3-asr') {
+    return offline(
+      {
+        qwen3Asr: {
+          convFrontend: resolveFile(files, 'conv_frontend', modelDir),
+          encoder: resolveFile(files, 'encoder', modelDir),
+          decoder: resolveFile(files, 'decoder', modelDir),
+          // Why: sherpa reads vocab.json/merges.txt from this directory; the
+          // download layout keeps them flat beside the ONNX files.
+          tokenizer: modelDir,
+          hotwords: ''
+        }
+      },
+      { decodingMethod: 'greedy_search' }
+    )
+  }
+
+  return offline(
+    {
+      transducer: {
+        encoder: resolveFile(files, 'encoder', modelDir),
+        decoder: resolveFile(files, 'decoder', modelDir),
+        joiner: resolveFile(files, 'joiner', modelDir)
+      }
+    },
+    buildHotwordsConfig(msg)
+  )
+}

--- a/src/main/speech/stt-worker.ts
+++ b/src/main/speech/stt-worker.ts
@@ -2,7 +2,7 @@
 import { parentPort, workerData } from 'node:worker_threads'
 import { resampleToRate } from './stt-audio-resample'
 import { OfflineAudioChunker } from './stt-offline-audio-chunker'
-import { buildHotwordsConfig, resolveFile, resolveTokens } from './stt-worker-model-config'
+import { buildRecognizerConfig } from './stt-worker-model-config'
 
 type WorkerMessage =
   | {
@@ -43,125 +43,16 @@ function handleInit(msg: Extract<WorkerMessage, { type: 'init' }>): void {
   try {
     sherpa = loadSherpa()
 
-    const { modelDir, modelType, streaming, sampleRate, files } = msg
+    const { streaming, sampleRate } = msg
     isStreaming = streaming
     offlineChunker = streaming ? null : new OfflineAudioChunker(sampleRate)
     offlineSampleRate = sampleRate
 
-    const tokens = resolveTokens(files, modelDir)
-    const hotwords = buildHotwordsConfig(msg)
-
-    if (streaming && modelType === 'transducer') {
-      const config = {
-        featConfig: { sampleRate, featureDim: 80 },
-        modelConfig: {
-          transducer: {
-            encoder: resolveFile(files, 'encoder', modelDir),
-            decoder: resolveFile(files, 'decoder', modelDir),
-            joiner: resolveFile(files, 'joiner', modelDir)
-          },
-          tokens,
-          numThreads: 1,
-          provider: 'cpu',
-          debug: 0
-        },
-        ...hotwords,
-        enableEndpoint: 1,
-        rule1MinTrailingSilence: 2.4,
-        rule2MinTrailingSilence: 1.2,
-        rule3MinUtteranceLength: 20
-      }
+    const { online, config } = buildRecognizerConfig(msg)
+    if (online) {
       recognizer = sherpa.createOnlineRecognizer(config)
       stream = sherpa.createOnlineStream(recognizer)
-    } else if (streaming && modelType === 'paraformer') {
-      const config = {
-        featConfig: { sampleRate, featureDim: 80 },
-        modelConfig: {
-          paraformer: {
-            encoder: resolveFile(files, 'encoder', modelDir),
-            decoder: resolveFile(files, 'decoder', modelDir)
-          },
-          tokens,
-          numThreads: 1,
-          provider: 'cpu',
-          debug: 0
-        },
-        decodingMethod: 'greedy_search',
-        enableEndpoint: 1,
-        rule1MinTrailingSilence: 2.4,
-        rule2MinTrailingSilence: 1.2,
-        rule3MinUtteranceLength: 20
-      }
-      recognizer = sherpa.createOnlineRecognizer(config)
-      stream = sherpa.createOnlineStream(recognizer)
-    } else if (modelType === 'whisper') {
-      const config = {
-        featConfig: { sampleRate, featureDim: 80 },
-        modelConfig: {
-          whisper: {
-            encoder: resolveFile(files, 'encoder', modelDir),
-            decoder: resolveFile(files, 'decoder', modelDir)
-          },
-          tokens,
-          numThreads: 2,
-          provider: 'cpu',
-          debug: 0
-        },
-        decodingMethod: 'greedy_search'
-      }
-      recognizer = sherpa.createOfflineRecognizer(config)
-      stream = sherpa.createOfflineStream(recognizer)
-    } else if (modelType === 'nemo-ctc') {
-      const config = {
-        featConfig: { sampleRate, featureDim: 80 },
-        modelConfig: {
-          nemoCtc: {
-            model: resolveFile(files, 'model', modelDir)
-          },
-          tokens,
-          numThreads: 2,
-          provider: 'cpu',
-          debug: 0
-        },
-        decodingMethod: 'greedy_search'
-      }
-      recognizer = sherpa.createOfflineRecognizer(config)
-      stream = sherpa.createOfflineStream(recognizer)
-    } else if (modelType === 'senseVoice') {
-      const config = {
-        featConfig: { sampleRate, featureDim: 80 },
-        modelConfig: {
-          senseVoice: {
-            model: resolveFile(files, 'model', modelDir),
-            // Empty string = auto-detect language (supports zh/en/ja/ko/yue).
-            language: '',
-            useInverseTextNormalization: 1
-          },
-          tokens,
-          numThreads: 2,
-          provider: 'cpu',
-          debug: 0
-        },
-        decodingMethod: 'greedy_search'
-      }
-      recognizer = sherpa.createOfflineRecognizer(config)
-      stream = sherpa.createOfflineStream(recognizer)
     } else {
-      const config = {
-        featConfig: { sampleRate, featureDim: 80 },
-        modelConfig: {
-          transducer: {
-            encoder: resolveFile(files, 'encoder', modelDir),
-            decoder: resolveFile(files, 'decoder', modelDir),
-            joiner: resolveFile(files, 'joiner', modelDir)
-          },
-          tokens,
-          numThreads: 2,
-          provider: 'cpu',
-          debug: 0
-        },
-        ...hotwords
-      }
       recognizer = sherpa.createOfflineRecognizer(config)
       stream = sherpa.createOfflineStream(recognizer)
     }

--- a/src/shared/speech-types.ts
+++ b/src/shared/speech-types.ts
@@ -4,6 +4,7 @@ export type SpeechModelType =
   | 'whisper'
   | 'senseVoice'
   | 'nemo-ctc'
+  | 'qwen3-asr'
   | 'openai'
 export type SpeechModelProvider = 'local' | 'openai'
 


### PR DESCRIPTION
## Summary

Adds **Qwen3-ASR (0.6B, int8)** to the local speech model catalog.

Orca already ships an engine that can run this model — `sherpa-onnx` gained a Qwen3-ASR loader in 1.12.34 and we bundle 1.12.37, so `qwen3Asr` is present in the native addon we load at runtime. What was missing was the Orca side: `stt-worker` never built a `qwen3Asr` config, so the capability was unreachable from the app.

User-visible change: a new **Qwen3-ASR** entry in the voice model list. It covers 30 languages with automatic language identification and is noticeably more accurate than the other local models on the languages I could measure.

Measured on the four Korean clips shipped with `sherpa-onnx-zipformer-korean-2024-06-24` (`test_wavs/` vs `trans.txt`), decoded through the bundled 1.12.37 addon with the same worker config path. CER is character error rate after stripping whitespace and punctuation:

| model | CER | exact sentences | avg decode |
|---|---|---|---|
| **Qwen3-ASR 0.6B int8 (this PR)** | **0.00%** | 4/4 | 618 ms |
| Zipformer Korean offline (not in catalog) | 2.63% | 3/4 | 65 ms |
| SenseVoice | 3.95% | 1/4 | 68 ms |
| Zipformer Streaming KO | 14.47% | 1/4 | 96 ms |

Caveat, stated plainly: four clean read-speech clips is a small sample, and the ranking gap comes down to one sentence. I did not measure noisy microphone input, and I only verified Korean — the multilingual claim comes from the upstream model card, not from my own runs.

Two trade-offs worth a maintainer's call:

- **Download size**: 941 MiB (987,015,347 bytes), the largest local model in the catalog — the int8 decoder alone is 721 MiB.
- **Speed**: roughly 9× slower per utterance than the Zipformer/SenseVoice models (618 ms vs ~65 ms on the clips above, M-series CPU provider). Still sub-second for normal dictation lengths, but it is not free.

### Implementation notes

- **Flat tokenizer layout.** Qwen3-ASR uses a BPE tokenizer directory instead of a `tokens.txt`. `model-manager` rejects any download filename containing `/` (path traversal guard), so rather than weakening that guard I verified sherpa resolves `vocab.json` / `merges.txt` from whatever directory is passed as `tokenizer` — the three tokenizer files download flat beside the ONNX files and `tokenizer` points at the model dir. The guard is untouched.
- **`DownloadFileSpec` gained an optional 4th element** (`remotePath`) so a flat local filename can map to a nested path in the source repo. Existing entries are unchanged: for a name with no `/`, the new `encodeRepositoryPath` is identical to the previous `encodeURIComponent`, and there is a test pinning an existing model's full URL to prove it.
- **`stt-worker.ts` refactor.** Adding the branch pushed the file past the 300-line `max-lines` limit. Since disabling that rule is forbidden, I moved recognizer-config construction into the existing `stt-worker-model-config.ts` (its stated purpose) as `buildRecognizerConfig`, which returns `{ online, config }`. Per-family settings — `numThreads` 1 online / 2 offline, endpoint rules, `decodingMethod`, hotwords placement — are preserved exactly; `stt-worker.ts` goes 306 → 221 lines.
- **Provenance.** The ONNX export is the one distributed by sherpa-onnx (`asr-models` release), converted by [Wasser1462](https://github.com/Wasser1462/Qwen3-ASR-onnx) and hosted on the maintainer's `csukuangfj2` HF account. Pinned to an immutable revision with per-file SHA-256, matching how every other catalog entry is pinned. I verified the HF copies are byte-identical to the GitHub release archive I benchmarked against.

## Screenshots

No visual change beyond one additional row in the existing voice model list, rendered by the existing list component from the catalog manifest.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 38,301 passed, 5 failed, all pre-existing (see below)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

On the five failures: none are in `src/main/speech`. Three (`relay/agent-exec-handler` ×2, `shared/posix-command-path-lookup` ×1) reproduce identically on unmodified `main` — same 3 failed / 38 passed / 1 skipped on both. The other two (`main/daemon/terminal-history-incremental-restore`) are 30-second timeouts that pass in isolation on both `main` and this branch, so they look load-dependent on my machine. Local environment note: the suite needs Node 24; on Node 20 it aborts in `ensure-native-runtime` before running anything.

New tests:
- `model-catalog.test.ts` — Qwen3-ASR manifest shape; the flattened tokenizer file list plus the nested `tokenizer/vocab.json` source URL; total size; and a regression test pinning an existing (flat) model's full download URL.
- `stt-worker-model-config.test.ts` — `buildRecognizerConfig` produces the `qwen3Asr` block with `tokenizer` set to the model dir and empty `tokens`; streaming transducers still return `online: true` with endpoint rules and `numThreads: 1`; offline transducers still fall through to `numThreads: 2`.

Beyond unit tests, I ran the real model end to end: built the config with `buildRecognizerConfig` from the actual catalog manifest, loaded it into the `sherpa-onnx` addon shipped inside the installed Orca app, and decoded the Korean clips — output matched the reference transcript exactly. That scratch test is not part of the diff since it needs a ~1 GB local model.

## AI Review Report

Reviewed with Claude Code. Focus areas and outcomes:

- **Behavior preservation in the refactor** — walked every moved branch against the original: model-family config shapes, `numThreads`, `decodingMethod`, endpoint rules, and whether hotwords spread at config or `modelConfig` level. The one intentional change is `tokens` resolution, now skipped for `qwen3-asr` because that family has no `tokens.txt`; `resolveTokens` would otherwise throw. Object key order changed in places, which the native addon does not depend on.
- **Reachability** — confirmed `manifest.type` flows unchanged from the catalog through `stt-service` into the worker, so no other dispatch site needed updating. Grepped every `SpeechModelType` consumer; only the type union, the worker branch, and the catalog reference model families.
- **Cross-platform (macOS, Linux, Windows)** — no platform-specific code added. All model paths go through `resolveFile`/`join`, never string concatenation; `tokenizer` is passed as a directory path produced by the existing `getModelDir`. Download filenames stay flat and free of separators, so Windows path handling is unaffected, and the model artifacts are platform-independent (the per-platform piece is the already-bundled sherpa addon). No shortcuts, labels, shell invocation, or Electron platform APIs are touched. I verified runtime behavior on macOS arm64 only; Linux and Windows rest on the code being platform-neutral, not on my own runs.
- **Flagged and addressed** — initial version exceeded `max-lines` (fixed by the extraction above, no suppression added); an initial description claimed "highest accuracy of the local models" on the strength of four Korean clips, which overstated the evidence, so it was rewritten to the language-coverage fact.

## Security Audit

- **Download integrity**: the six new files are pinned to an immutable HF revision with per-file SHA-256, verified by the existing downloader. No new download or extraction code; the archive path is untouched.
- **Path handling**: `model-manager`'s rejection of `/` and `\` in download filenames is unchanged, and every new filename is flat. `remotePath` affects only URL construction from repo-local constants — it never reaches the filesystem, and each segment is `encodeURIComponent`-escaped.
- **Input handling / command execution / IPC / auth / secrets**: none touched. No new dependency, no new IPC channel, no network call beyond the model download that already exists for every local model.
- **Follow-up**: none identified.

## Notes

- Supersedes #8753, which added a Korean-only Zipformer to the catalog. Qwen3-ASR beat that model on the same clips while also covering 29 other languages, so this is the better use of catalog space. I am closing #8753 in favour of this.
- The hotwords field is passed empty. sherpa supports Qwen3-ASR hotwords and a per-stream language hint; wiring either into Orca's existing hotwords flow felt out of scope here and is a clean follow-up.
- If 941 MiB is too large to sit in the default list, an alternative is gating it behind a "large models" affordance — happy to adjust.
