### PR TITLE
fix(workspace-space): bound traversal memory and serialize local disk scans

### DIFF
--- a/docs/workspace-space-scan-resource-bounds.md
+++ b/docs/workspace-space-scan-resource-bounds.md
@@ -1,0 +1,217 @@
+# Workspace Space Scan Resource Bounds
+
+## Problem
+
+Resource Manager scans every non-prunable worktree to calculate workspace disk usage. A fleet with
+hundreds of worktrees can make Orca and the host unresponsive while the scan is active.
+
+Two independent resource failures are possible:
+
+- macOS and Linux run recursive `du` processes for several worktrees at once. Competing full-tree
+  metadata walks can saturate local storage and stall unrelated applications.
+- Windows, unsupported `du` variants, timeouts, and filesystem errors use a portable recursive
+  walker. The old walker allocated a promise and retained result node for every entry without a
+  capacity limit, so a large worktree could exhaust the main or relay process heap.
+
+The July 27 incident occurred with 298 Orca worktrees. Renderer telemetry remained far below its
+heap limit, while quitting Orca immediately restored host responsiveness. The installed binary also
+contained the uncapped portable fallback.
+
+## Root Cause
+
+`src/main/workspace-space-analysis.ts` admitted up to three worktree scans per repository while
+scanning two repositories concurrently. That allowed as many as six local `du` traversals.
+
+Both the desktop portable walker and `src/relay/workspace-space-scan.ts` recursively called
+`Promise.all(entries.map(...))`. Filesystem operation limiters capped active `stat` and `readdir`
+calls, but they did not cap queued promises, retained paths, directory arrays, or aggregate result
+nodes. A failed `du` scan then repeated the same traversal through this higher-memory path.
+
+Shared fixed-worker traversal and capacity primitives already exist, but the active desktop and
+relay scanners did not use them.
+
+## Goals
+
+- Keep the host responsive while scanning hundreds of local worktrees.
+- Bound portable traversal memory before admitting filesystem entries.
+- Preserve size totals, symlink behavior, top-level compaction, partial failures, cancellation, and
+  progress reporting.
+- Apply equivalent bounds to local, folder-workspace, WSL, and SSH relay paths.
+- Preserve the current WSL-aware Git worktree listing and abort signals.
+
+## Non-Goals
+
+- Make a 298-worktree scan finish quickly.
+- Change Resource Manager UI, progress copy, deletion rules, or scan persistence.
+- Exclude `node_modules`, build output, or other directories from reported size.
+- Change Git worktree discovery or cleanup behavior.
+- Introduce polling, caching, or background automatic scans.
+
+## Design
+
+### Local disk admission
+
+Create one scan-wide limiter for local worktree traversal. Repository discovery and remote scans can
+remain concurrent, but every local worktree must acquire the single local slot before invoking
+`du` or the portable walker.
+
+The slot is global to one Resource Manager scan, not per repository. This changes the maximum local
+full-tree traversal count from six to one. Cancellation rejects queued admissions and stops the
+active child process through the existing `AbortSignal`.
+
+### Fixed-worker portable traversal
+
+Use `scanWorkspaceSpaceEntryTree` for desktop local fallback, desktop remote-provider fallback, and
+relay fallback scans. The traversal:
+
+- owns only the configured number of live entry jobs;
+- preserves source order and aggregate sizes;
+- uses iterative directory frames instead of recursive promise fanout;
+- stops on cancellation and removes its abort listener;
+- treats unreadable or disappearing entries as partial failures;
+- does not follow symlink targets.
+
+Top-level `du` result processing uses `mapWithConcurrency` so unusually wide workspace roots do not
+allocate one live operation per entry.
+
+### Capacity admission
+
+Every portable entry is admitted through `WorkspaceSpaceScanBudget` before retention:
+
+- maximum entries held at once per worktree traversal: 100,000;
+- maximum estimated live scan state per worktree traversal: 64 MiB.
+
+The retained-byte estimate includes parent path and entry name UTF-16 storage plus conservative
+per-entry object overhead. These are admission limits, not post-allocation observations.
+
+The budget measures what the traversal is holding **right now**, not what it has ever seen. A
+directory listing is charged when admitted and released once every one of its entries has been
+dispatched, so the caps bound the widest concurrent frontier rather than total tree size. This
+distinction decides real workspaces: a cumulative counter charged an ordinary 76,788-entry Orca
+worktree 61.2 MiB of its 64 MiB cap — 4% headroom, and tipping over purely because a longer branch
+name lengthens every absolute path. The same worktree peaks between 4 MiB and 8 MiB of live state.
+
+Because the estimate scales with absolute path length, a cumulative cap would make success depend on
+where a user checks out their worktrees. A live cap depends only on directory shape, so it rejects
+genuinely pathological layouts (one directory holding six figures of entries) and nothing else.
+
+Top-level directory enumeration for the `du` path uses the same budget. A capacity error must not
+fall through into the portable walker, because that would repeat an already rejected traversal.
+
+### Failure behavior
+
+- Desktop local scan: return an unavailable worktree row with the capacity error. `classifyError`
+  maps `WorkspaceSpaceScanCapacityError` to `unavailable` rather than `error`, because the workspace
+  is intact and readable, just too large to size safely. The Resource Manager renders that row as
+  "Unavailable" instead of "Failed".
+- SSH relay scan: reject the bulk scan; the desktop provider converts it to an unavailable row.
+- Generic `du` failure: use the bounded portable fallback.
+- Cancellation: propagate the scan-cancelled error rather than converting it to a row failure.
+- Missing or unreadable entries below the capacity limit: preserve existing partial-result
+  behavior.
+
+### Platform and workspace parity
+
+- macOS/Linux: one local `du` at a time; bounded Node fallback.
+- Windows: one local bounded Node traversal at a time.
+- WSL: retain `getLocalProjectWorktreeGitOptions` and its selected distro for worktree discovery;
+  UNC/native filesystem traversal uses the same local admission and capacity bounds.
+- SSH: prefer the bulk relay scan; both the relay and the request-by-request compatibility fallback
+  use the shared capacity model.
+- Folder workspaces: the synthetic main worktree passes through the same local limiter and scanner.
+
+## Data Flow
+
+1. Resource Manager starts one deduplicated scan and creates an abort controller.
+2. Repository workers list worktrees with existing host-specific Git options and the scan signal.
+3. Remote worktrees continue through provider concurrency. Local worktrees wait for the scan-wide
+   local slot.
+4. POSIX local or relay scans try `du`.
+5. Top-level entries are admitted against the scan budget and projected with bounded concurrency.
+6. If `du` fails generically, the fixed-worker portable traversal scans within the same limits.
+7. Capacity failures become unavailable rows; successful results keep existing compaction and
+   progress behavior.
+
+## Alternatives Considered
+
+### Only reduce `du` concurrency
+
+This protects local storage but leaves Windows, SSH compatibility fallback, and failed `du` scans
+capable of unbounded heap growth.
+
+### Only add traversal capacity limits
+
+This prevents OOM but still permits several recursive `du` processes to compete for local storage,
+which does not address the observed whole-host stall.
+
+### Remove the portable fallback
+
+This would fail Windows scans and POSIX environments where `du -d` is unavailable or errors during
+active filesystem churn.
+
+### Skip dependency and build directories
+
+This would make Resource Manager under-report the directories users most often want to reclaim.
+
+## Measurement and Performance Budget
+
+The deterministic regression measurements are:
+
+- peak simultaneous local `du` calls across repositories: exactly one;
+- portable traversal live entry jobs: no more than its configured worker count;
+- portable entries held at once: at most 100,000 per worktree;
+- estimated live portable state: at most 64 MiB per worktree; an ordinary 76,788-entry worktree
+  peaks between 4 MiB and 8 MiB;
+- progress and final row counts remain unchanged for scans below the limits.
+
+A follow-up diagnostic span should record strategy (`du` or portable), worktree duration, fallback
+reason, admitted entry count, estimated retained bytes, and peak local scan concurrency. It must
+record counts and identifiers rather than raw paths or directory trees.
+
+## Test Plan
+
+- Desktop integration: force the portable path over its entry budget and assert an unavailable row.
+- Relay integration: force the portable path over its entry budget and assert a capacity failure.
+- Concurrency: start local worktrees from two repositories, hold the first `du`, and assert the
+  second does not start until the first completes.
+- Shared traversal: verify worker peak, source order, exact-limit success, over-limit failure, deep
+  trees, partial failures, and cancellation cleanup.
+- Existing desktop coverage: local results, symlinks, progress, cancellation, WSL routing, SSH bulk
+  scans, disconnected SSH, `du` timeout fallback, and IPC deduplication.
+- Run `pnpm run typecheck` and `pnpm run build`.
+
+## Rollout
+
+1. Connect the shared fixed-worker traversal and capacity budget to desktop and relay scanners.
+2. Add the scan-wide single local traversal slot.
+3. Add focused capacity and concurrency regression tests.
+4. Ship without a migration or feature flag; behavior below the limits is unchanged.
+5. Monitor capacity failures and scan duration before considering a higher local concurrency.
+
+## Risks
+
+- Scanning hundreds of worktrees takes longer because local work is serialized. The feature already
+  streams progress and allows users to leave the page, and host responsiveness takes priority over
+  scan throughput.
+- A legitimate worktree above the capacity limit is reported unavailable instead of partially
+  sized. Failing closed avoids presenting an incomplete size as safe deletion evidence. With a live
+  cap this now requires a pathological directory rather than merely a large repository.
+- Because the local slot is acquired inside the per-repository worker pool, a local worktree waiting
+  on the slot still occupies one of the six in-flight scan slots. On fleets mixing local and SSH
+  repositories this can delay remote repositories behind serialized local work, even though remote
+  scans never contend for the local disk.
+- Remote hosts can still process concurrent worktrees, but each relay request has an independent
+  hard capacity and remote concurrency does not contend with the user's local disk. The desktop-side
+  request-by-request SSH fallback is not covered by the local slot, so up to six of its traversals
+  can run at once, each with an independent budget, inside the desktop main process. Live accounting
+  keeps the realistic total in the tens of MiB.
+
+## Validation
+
+- Focused tests: 36 passed across desktop analysis, IPC, relay, shared traversal, scan budget, and
+  concurrency primitives.
+- TypeScript: all node, CLI, and web projects passed.
+- Production build: relay targets, CLI, Electron, renderer, web projection, and macOS native
+  components completed successfully.
+- No live 298-worktree rescan is required for correctness validation; the concurrency and capacity
+  properties are deterministic tests.

--- a/docs/workspace-space-scan-resource-bounds.md
+++ b/docs/workspace-space-scan-resource-bounds.md
@@ -59,6 +59,15 @@ The slot is global to one Resource Manager scan, not per repository. This change
 full-tree traversal count from six to one. Cancellation rejects queued admissions and stops the
 active child process through the existing `AbortSignal`.
 
+### Remote fallback admission
+
+The desktop-side request-by-request SSH fallback runs its traversal inside the desktop main
+process, so its budget is charged against Orca's heap rather than the remote host. Repository and
+worktree concurrency alone would let six of these traversals hold six independent budgets at once.
+A second scan-wide limiter admits at most two, capping aggregate admission at 2 × 64 MiB instead of
+6 × 64 MiB. Bulk relay scans stay outside this limiter: their traversal memory lives on the remote
+host, one hard capacity per request.
+
 ### Fixed-worker portable traversal
 
 Use `scanWorkspaceSpaceEntryTree` for desktop local fallback, desktop remote-provider fallback, and
@@ -158,6 +167,7 @@ This would make Resource Manager under-report the directories users most often w
 The deterministic regression measurements are:
 
 - peak simultaneous local `du` calls across repositories: exactly one;
+- peak simultaneous desktop-side SSH fallback traversals across repositories: at most two;
 - portable traversal live entry jobs: no more than its configured worker count;
 - portable entries held at once: at most 100,000 per worktree;
 - estimated live portable state: at most 64 MiB per worktree; an ordinary 76,788-entry worktree
@@ -171,7 +181,10 @@ record counts and identifiers rather than raw paths or directory trees.
 ## Test Plan
 
 - Desktop integration: force the portable path over its entry budget and assert an unavailable row.
-- Relay integration: force the portable path over its entry budget and assert a capacity failure.
+- Relay integration: force the portable path over its entry budget and assert a capacity failure on
+  both the Windows/portable and POSIX `du` entry points.
+- Remote fallback concurrency: hold six SSH fallback traversals across two repositories and assert
+  no more than two run at once.
 - Concurrency: start local worktrees from two repositories, hold the first `du`, and assert the
   second does not start until the first completes.
 - Shared traversal: verify worker peak, source order, exact-limit success, over-limit failure, deep
@@ -201,10 +214,7 @@ record counts and identifiers rather than raw paths or directory trees.
   repositories this can delay remote repositories behind serialized local work, even though remote
   scans never contend for the local disk.
 - Remote hosts can still process concurrent worktrees, but each relay request has an independent
-  hard capacity and remote concurrency does not contend with the user's local disk. The desktop-side
-  request-by-request SSH fallback is not covered by the local slot, so up to six of its traversals
-  can run at once, each with an independent budget, inside the desktop main process. Live accounting
-  keeps the realistic total in the tens of MiB.
+  hard capacity and remote concurrency does not contend with the user's local disk.
 
 ## Validation
 

--- a/src/main/workspace-space-analysis-capacity.test.ts
+++ b/src/main/workspace-space-analysis-capacity.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as NodeProcess from 'node:process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../shared/types'
+import type * as WorkspaceSpaceScanBudgetModule from '../shared/workspace-space-scan-budget'
+import type { Store } from './persistence'
+
+const { listRepoWorktreesMock } = vi.hoisted(() => ({
+  listRepoWorktreesMock: vi.fn()
+}))
+
+vi.mock('node:process', async () => {
+  const actual = await vi.importActual<typeof NodeProcess>('node:process')
+  return { ...actual, platform: 'win32' }
+})
+
+vi.mock('../shared/workspace-space-scan-budget', async () => {
+  const actual = await vi.importActual<typeof WorkspaceSpaceScanBudgetModule>(
+    '../shared/workspace-space-scan-budget'
+  )
+  return {
+    ...actual,
+    createWorkspaceSpaceScanBudget: () => actual.createWorkspaceSpaceScanBudget({ maxEntries: 2 })
+  }
+})
+
+vi.mock('./repo-worktrees', () => ({
+  createFolderWorktree: (repo: Repo) => ({
+    path: repo.path,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: true
+  }),
+  listRepoWorktrees: listRepoWorktreesMock
+}))
+
+vi.mock('./providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn()
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: vi.fn()
+}))
+
+import { analyzeWorkspaceSpace } from './workspace-space-analysis'
+
+function createStore(repo: Repo): Store {
+  return {
+    getRepos: () => [repo],
+    getWorktreeMeta: () => undefined
+  } as unknown as Store
+}
+
+describe('analyzeWorkspaceSpace capacity', () => {
+  let tempDir: string | null = null
+
+  afterEach(async () => {
+    listRepoWorktreesMock.mockReset()
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('fails a worktree closed when the portable scan exceeds its entry budget', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-space-capacity-'))
+    const repoPath = join(tempDir, 'repo')
+    await mkdir(repoPath, { recursive: true })
+    await Promise.all(['one', 'two', 'three'].map((name) => writeFile(join(repoPath, name), name)))
+    const repo: Repo = {
+      id: 'repo-1',
+      path: repoPath,
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: repoPath,
+        head: 'a',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+
+    const result = await analyzeWorkspaceSpace(createStore(repo))
+
+    expect(result.worktrees[0]).toMatchObject({
+      status: 'unavailable',
+      sizeBytes: 0,
+      error: expect.stringContaining('Workspace is too large to scan safely')
+    })
+  })
+})

--- a/src/main/workspace-space-analysis-du-timeout.test.ts
+++ b/src/main/workspace-space-analysis-du-timeout.test.ts
@@ -114,4 +114,54 @@ describe('analyzeWorkspaceSpace local du timeout', () => {
     })
     expect(killMock).toHaveBeenCalled()
   })
+
+  it('runs one local du traversal at a time across repos', async () => {
+    const repoPaths = [join(tempDir!, 'repo-one'), join(tempDir!, 'repo-two')]
+    await Promise.all(repoPaths.map((repoPath) => mkdir(repoPath, { recursive: true })))
+    const repos: Repo[] = repoPaths.map((repoPath, index) => ({
+      id: `repo-${index}`,
+      path: repoPath,
+      displayName: `repo-${index}`,
+      badgeColor: '#000',
+      addedAt: 0
+    }))
+    listRepoWorktreesMock.mockImplementation(async (repo: Repo) => [
+      {
+        path: repo.path,
+        head: 'a',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    const completions: (() => void)[] = []
+    let active = 0
+    let peak = 0
+    execFileMock.mockImplementation(
+      (
+        _file: string,
+        args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string) => void
+      ) => {
+        const rootPath = args.at(-1)!
+        active += 1
+        peak = Math.max(peak, active)
+        completions.push(() => {
+          active -= 1
+          callback(null, `1\t${rootPath}\n`)
+        })
+        return { kill: vi.fn() }
+      }
+    )
+
+    const scan = analyzeWorkspaceSpace(createStore(repos))
+    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(1))
+    completions.shift()?.()
+    await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(2))
+    completions.shift()?.()
+
+    await expect(scan).resolves.toMatchObject({ scannedWorktreeCount: 2 })
+    expect(peak).toBe(1)
+  })
 })

--- a/src/main/workspace-space-analysis.test.ts
+++ b/src/main/workspace-space-analysis.test.ts
@@ -450,6 +450,51 @@ describe('analyzeWorkspaceSpace', () => {
     expect(result.worktrees[0]?.sizeBytes).toBe(4096)
   })
 
+  it('bounds concurrent SSH fallback traversals in the main process', async () => {
+    // Why: each fallback traversal holds its own admission budget, so repo ×
+    // worktree concurrency alone would stack six of them on the desktop heap.
+    const repos: Repo[] = ['ssh-1', 'ssh-2'].map((connectionId) => ({
+      id: `repo-${connectionId}`,
+      path: `/remote/${connectionId}`,
+      displayName: connectionId,
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId
+    }))
+    getSshGitProviderMock.mockReturnValue({
+      listWorktrees: vi.fn(async (repoPath: string) =>
+        [0, 1, 2].map((index) => ({
+          path: `${repoPath}/worktree-${index}`,
+          head: 'c',
+          branch: `refs/heads/worktree-${index}`,
+          isBare: false,
+          isMainWorktree: false
+        }))
+      )
+    })
+
+    const releases: (() => void)[] = []
+    let active = 0
+    let peak = 0
+    const stat = vi.fn(async () => {
+      active += 1
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => releases.push(resolve))
+      active -= 1
+      return { size: 0, type: 'directory' as const, mtime: 0 }
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ readDir: vi.fn(async () => []), stat })
+
+    const scan = analyzeWorkspaceSpace(createStore(repos))
+    for (let index = 0; index < 6; index += 1) {
+      await vi.waitFor(() => expect(releases.length).toBeGreaterThan(index))
+      releases[index]!()
+    }
+
+    await expect(scan).resolves.toMatchObject({ scannedWorktreeCount: 6 })
+    expect(peak).toBe(2)
+  })
+
   it('reports disconnected SSH repos without failing the whole analysis', async () => {
     const repo: Repo = {
       id: 'repo-remote',

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -35,14 +35,24 @@ import { createFolderWorktree, listRepoWorktrees } from './repo-worktrees'
 import { mergeWorktree } from './ipc/worktree-logic'
 import { getLocalProjectWorktreeGitOptions } from './project-runtime-git-options'
 
+const REPO_SCAN_CONCURRENCY = 2
 const WORKTREE_SCAN_CONCURRENCY = 3
 const LOCAL_WORKTREE_SCAN_CONCURRENCY = 1
+// Why: the SSH compatibility walker traverses inside the desktop main process
+// and each traversal carries its own admission budget, so repo × worktree
+// concurrency would otherwise stack six independent budgets on this heap.
+const REMOTE_FALLBACK_SCAN_CONCURRENCY = 2
 const LOCAL_FS_CONCURRENCY = 48
 const REMOTE_FS_CONCURRENCY = 10
 const DU_TIMEOUT_MS = 120_000
 const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
 type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
+
+type WorkspaceSpaceScanLimiters = {
+  localWorktree: AsyncLimiter
+  remoteFallbackTraversal: AsyncLimiter
+}
 
 type ScanStats = WorkspaceSpaceEntryScan
 
@@ -598,6 +608,7 @@ async function scanRemoteWorktree(
   worktree: Worktree,
   scannedAt: number,
   provider: IFilesystemProvider,
+  fallbackTraversalLimit: AsyncLimiter,
   signal?: AbortSignal
 ): Promise<WorkspaceSpaceWorktree> {
   try {
@@ -618,11 +629,8 @@ async function scanRemoteWorktree(
       }
     }
 
-    const root = await scanRemoteEntry(
-      worktree.path,
-      basenameFilesystemPath(worktree.path),
-      provider,
-      signal
+    const root = await fallbackTraversalLimit(() =>
+      scanRemoteEntry(worktree.path, basenameFilesystemPath(worktree.path), provider, signal)
     )
     const compact = compactWorkspaceSpaceItems((root.children ?? []).map(toWorkspaceSpaceItem))
     return createScannedWorktreeRow(repo, worktree, scannedAt, {
@@ -701,7 +709,7 @@ async function scanRepo(
   repo: Repo,
   scannedAt: number,
   store: Store,
-  localWorktreeLimit: AsyncLimiter,
+  limiters: WorkspaceSpaceScanLimiters,
   progress: WorkspaceSpaceProgressState,
   options: WorkspaceSpaceAnalyzeOptions
 ): Promise<RepoScanResult> {
@@ -762,7 +770,14 @@ async function scanRepo(
     )
     const row: WorkspaceSpaceWorktree = repo.connectionId
       ? remoteProvider
-        ? await scanRemoteWorktree(repo, worktree, scannedAt, remoteProvider, options.signal)
+        ? await scanRemoteWorktree(
+            repo,
+            worktree,
+            scannedAt,
+            remoteProvider,
+            limiters.remoteFallbackTraversal,
+            options.signal
+          )
         : createUnavailableWorktreeRow(
             repo,
             worktree,
@@ -770,7 +785,9 @@ async function scanRepo(
             'unavailable',
             `SSH filesystem for "${repo.connectionId}" is not connected.`
           )
-      : await localWorktreeLimit(() => scanLocalWorktree(repo, worktree, scannedAt, options.signal))
+      : await limiters.localWorktree(() =>
+          scanLocalWorktree(repo, worktree, scannedAt, options.signal)
+        )
     reportProgress(
       progress,
       { scannedWorktreeCount: progress.scannedWorktreeCount + 1 },
@@ -825,9 +842,12 @@ export async function analyzeWorkspaceSpace(
     currentWorktreeDisplayName: null
   }
   options.onProgress?.({ ...progress })
-  const localWorktreeLimit = createAsyncLimiter(LOCAL_WORKTREE_SCAN_CONCURRENCY, options.signal)
-  const repoResults = await mapWithConcurrency(reposToScan, 2, (repo) =>
-    scanRepo(repo, scannedAt, store, localWorktreeLimit, progress, options)
+  const limiters: WorkspaceSpaceScanLimiters = {
+    localWorktree: createAsyncLimiter(LOCAL_WORKTREE_SCAN_CONCURRENCY, options.signal),
+    remoteFallbackTraversal: createAsyncLimiter(REMOTE_FALLBACK_SCAN_CONCURRENCY, options.signal)
+  }
+  const repoResults = await mapWithConcurrency(reposToScan, REPO_SCAN_CONCURRENCY, (repo) =>
+    scanRepo(repo, scannedAt, store, limiters, progress, options)
   )
   throwIfAborted(options.signal)
   const repos = repoResults.map((result) => result.summary)

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -1,24 +1,33 @@
 /* eslint-disable max-lines -- Why: this module keeps local and SSH directory-walk
    semantics paired so reclaimable-byte, symlink, and partial-failure behavior cannot drift. */
-import { lstat, readdir } from 'node:fs/promises'
+import { lstat, opendir } from 'node:fs/promises'
 import { execFile } from 'node:child_process'
 import { posix, win32 } from 'node:path'
 import { platform } from 'node:process'
 import type { Dirent } from 'node:fs'
 import type { Store } from './persistence'
 import { isFolderRepo } from '../shared/repo-kind'
-import type { GitWorktreeInfo, Repo, Worktree } from '../shared/types'
+import type { DirEntry, GitWorktreeInfo, Repo, Worktree } from '../shared/types'
 import type {
   WorkspaceSpaceAnalysis,
   WorkspaceSpaceDirectoryScanResult,
   WorkspaceSpaceItem,
-  WorkspaceSpaceItemKind,
   WorkspaceSpaceRepoSummary,
   WorkspaceSpaceScanProgress,
   WorkspaceSpaceScanStatus,
   WorkspaceSpaceWorktree
 } from '../shared/workspace-space-types'
 import { compactWorkspaceSpaceItems } from '../shared/workspace-space-compaction'
+import { mapWithConcurrency } from '../shared/map-with-concurrency'
+import {
+  scanWorkspaceSpaceEntryTree,
+  type WorkspaceSpaceEntryScan
+} from '../shared/workspace-space-entry-traversal'
+import {
+  collectWorkspaceSpaceDirectoryEntries,
+  createWorkspaceSpaceScanBudget,
+  WorkspaceSpaceScanCapacityError
+} from '../shared/workspace-space-scan-budget'
 import type { IFilesystemProvider } from './providers/types'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
@@ -27,6 +36,7 @@ import { mergeWorktree } from './ipc/worktree-logic'
 import { getLocalProjectWorktreeGitOptions } from './project-runtime-git-options'
 
 const WORKTREE_SCAN_CONCURRENCY = 3
+const LOCAL_WORKTREE_SCAN_CONCURRENCY = 1
 const LOCAL_FS_CONCURRENCY = 48
 const REMOTE_FS_CONCURRENCY = 10
 const DU_TIMEOUT_MS = 120_000
@@ -34,14 +44,7 @@ const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
 type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
 
-type ScanStats = {
-  name: string
-  path: string
-  kind: WorkspaceSpaceItemKind
-  sizeBytes: number
-  skippedEntryCount: number
-  children?: ScanStats[]
-}
+type ScanStats = WorkspaceSpaceEntryScan
 
 type WorktreeListResult =
   | { ok: true; worktrees: GitWorktreeInfo[] }
@@ -137,15 +140,6 @@ function createAsyncLimiter(maxConcurrent: number, signal?: AbortSignal): AsyncL
       next?.resolve()
     }
   }
-}
-
-async function mapLimit<T, R>(
-  items: readonly T[],
-  maxConcurrent: number,
-  mapper: (item: T) => Promise<R>
-): Promise<R[]> {
-  const limit = createAsyncLimiter(maxConcurrent)
-  return Promise.all(items.map((item) => limit(() => mapper(item))))
 }
 
 function looksLikeWindowsPath(pathValue: string): boolean {
@@ -263,6 +257,11 @@ function classifyError(error: unknown): {
       : ''
   const message = error instanceof Error ? error.message : String(error)
 
+  // Why: a workspace over the scan budget is intact and readable, just too big
+  // to size safely, so it reads as unavailable rather than a filesystem error.
+  if (error instanceof WorkspaceSpaceScanCapacityError) {
+    return { status: 'unavailable', message }
+  }
   if (code === 'ENOENT' || code === 'ENOTDIR') {
     return { status: 'missing', message }
   }
@@ -356,195 +355,73 @@ function createScannedWorktreeRow(
 async function scanLocalEntry(
   entryPath: string,
   name: string,
-  limit: AsyncLimiter,
   signal?: AbortSignal
 ): Promise<ScanStats> {
-  throwIfAborted(signal)
-  const stats = await limit(() => lstat(entryPath))
-  throwIfAborted(signal)
-
-  if (stats.isSymbolicLink()) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'symlink',
-      // Why: symlink targets may be shared outside the worktree. Counting the
-      // link itself reflects what deleting this worktree can actually reclaim.
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  if (!stats.isDirectory()) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'file',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  let entries: Dirent[]
-  try {
-    entries = await limit(() => readdir(entryPath, { withFileTypes: true }))
-  } catch {
-    return {
-      name,
-      path: entryPath,
-      kind: 'directory',
-      sizeBytes: stats.size,
-      skippedEntryCount: 1
-    }
-  }
-
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
-      try {
-        return await scanLocalEntry(
-          joinFilesystemPath(entryPath, entry.name),
-          entry.name,
-          limit,
-          signal
-        )
-      } catch (error) {
-        if (error instanceof WorkspaceSpaceScanCancelledError) {
-          throw error
-        }
-        return null
+  return scanWorkspaceSpaceEntryTree<Dirent>({
+    rootPath: entryPath,
+    rootName: name,
+    concurrency: LOCAL_FS_CONCURRENCY,
+    signal,
+    entryName: (entry) => entry.name,
+    joinPath: joinFilesystemPath,
+    classifyEntry: async (path) => {
+      const stats = await lstat(path)
+      throwIfAborted(signal)
+      if (stats.isSymbolicLink()) {
+        return { kind: 'symlink', sizeBytes: stats.size }
       }
-    })
-  )
-
-  let sizeBytes = stats.size
-  let skippedEntryCount = 0
-  for (const child of childStats) {
-    if (!child) {
-      skippedEntryCount += 1
-      continue
-    }
-    sizeBytes += child.sizeBytes
-    skippedEntryCount += child.skippedEntryCount
-  }
-
-  return {
-    name,
-    path: entryPath,
-    kind: 'directory',
-    sizeBytes,
-    skippedEntryCount,
-    children: childStats.filter((child): child is ScanStats => child !== null)
-  }
+      return stats.isDirectory()
+        ? { kind: 'directory', sizeBytes: stats.size }
+        : { kind: 'file', sizeBytes: stats.size }
+    },
+    readDirectory: (path) => opendir(path),
+    checkCancelled: () => throwIfAborted(signal),
+    createCancellationError: () => new WorkspaceSpaceScanCancelledError(),
+    isCancellationError: (error) => error instanceof WorkspaceSpaceScanCancelledError
+  })
 }
 
 async function scanRemoteEntry(
   entryPath: string,
   name: string,
   provider: IFilesystemProvider,
-  limit: AsyncLimiter,
-  signal?: AbortSignal,
-  knownSymlink = false
+  signal?: AbortSignal
 ): Promise<ScanStats> {
-  throwIfAborted(signal)
-  if (knownSymlink) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'symlink',
-      sizeBytes: 0,
-      skippedEntryCount: 0
-    }
-  }
-
-  const stats = await limit(() => provider.stat(entryPath))
-  throwIfAborted(signal)
-  if (stats.type === 'symlink') {
-    return {
-      name,
-      path: entryPath,
-      kind: 'symlink',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  if (stats.type !== 'directory') {
-    return {
-      name,
-      path: entryPath,
-      kind: 'file',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  let entries
-  try {
-    entries = await limit(() => provider.readDir(entryPath))
-    throwIfAborted(signal)
-  } catch (error) {
-    if (error instanceof WorkspaceSpaceScanCancelledError) {
-      throw error
-    }
-    return {
-      name,
-      path: entryPath,
-      kind: 'directory',
-      sizeBytes: stats.size,
-      skippedEntryCount: 1
-    }
-  }
-
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
-      try {
-        return await scanRemoteEntry(
-          joinFilesystemPath(entryPath, entry.name),
-          entry.name,
-          provider,
-          limit,
-          signal,
-          entry.isSymlink
-        )
-      } catch (error) {
-        if (error instanceof WorkspaceSpaceScanCancelledError) {
-          throw error
-        }
-        return null
+  return scanWorkspaceSpaceEntryTree<DirEntry>({
+    rootPath: entryPath,
+    rootName: name,
+    concurrency: REMOTE_FS_CONCURRENCY,
+    signal,
+    entryName: (entry) => entry.name,
+    joinPath: joinFilesystemPath,
+    classifyEntry: async (path, sourceEntry) => {
+      if (sourceEntry?.isSymlink) {
+        return { kind: 'symlink', sizeBytes: 0 }
       }
-    })
-  )
-
-  let sizeBytes = stats.size
-  let skippedEntryCount = 0
-  for (const child of childStats) {
-    if (!child) {
-      skippedEntryCount += 1
-      continue
-    }
-    sizeBytes += child.sizeBytes
-    skippedEntryCount += child.skippedEntryCount
-  }
-
-  return {
-    name,
-    path: entryPath,
-    kind: 'directory',
-    sizeBytes,
-    skippedEntryCount,
-    children: childStats.filter((child): child is ScanStats => child !== null)
-  }
+      const stats = await provider.stat(path)
+      throwIfAborted(signal)
+      if (stats.type === 'symlink') {
+        return { kind: 'symlink', sizeBytes: stats.size }
+      }
+      return stats.type === 'directory'
+        ? { kind: 'directory', sizeBytes: stats.size }
+        : { kind: 'file', sizeBytes: stats.size }
+    },
+    readDirectory: (path) => provider.readDir(path),
+    checkCancelled: () => throwIfAborted(signal),
+    createCancellationError: () => new WorkspaceSpaceScanCancelledError(),
+    isCancellationError: (error) => error instanceof WorkspaceSpaceScanCancelledError
+  })
 }
 
 async function scanLocalTopLevelEntry(
   entryPath: string,
   name: string,
   duSizes: Map<string, number>,
-  limit: AsyncLimiter,
   signal?: AbortSignal
 ): Promise<ScanStats> {
   throwIfAborted(signal)
-  const stats = await limit(() => lstat(entryPath))
+  const stats = await lstat(entryPath)
   throwIfAborted(signal)
 
   if (stats.isSymbolicLink()) {
@@ -585,13 +462,7 @@ async function scanLocalWorktreeWithDu(
   throwIfAborted(signal)
   const rootStats = await lstat(worktree.path)
   if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) {
-    const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY, signal)
-    const root = await scanLocalEntry(
-      worktree.path,
-      basenameFilesystemPath(worktree.path),
-      limit,
-      signal
-    )
+    const root = await scanLocalEntry(worktree.path, basenameFilesystemPath(worktree.path), signal)
     const compact = compactWorkspaceSpaceItems((root.children ?? []).map(toWorkspaceSpaceItem))
     return {
       ...createBaseWorktreeRow(repo, worktree, scannedAt),
@@ -605,19 +476,28 @@ async function scanLocalWorktreeWithDu(
   }
 
   const [entries, duSizes] = await Promise.all([
-    readdir(worktree.path, { withFileTypes: true }),
+    opendir(worktree.path).then(async (directory) => {
+      const admission = await collectWorkspaceSpaceDirectoryEntries(
+        directory,
+        worktree.path,
+        (entry) => entry.name,
+        createWorkspaceSpaceScanBudget(),
+        () => throwIfAborted(signal)
+      )
+      return admission.entries
+    }),
     readLocalDuDepthOne(worktree.path, signal)
   ])
   throwIfAborted(signal)
-  const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY, signal)
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
+  const childStats = await mapWithConcurrency(
+    entries,
+    LOCAL_FS_CONCURRENCY,
+    async (entry): Promise<ScanStats | null> => {
       try {
         return await scanLocalTopLevelEntry(
           joinFilesystemPath(worktree.path, entry.name),
           entry.name,
           duSizes,
-          limit,
           signal
         )
       } catch (error) {
@@ -626,7 +506,7 @@ async function scanLocalWorktreeWithDu(
         }
         return null
       }
-    })
+    }
   )
   const children = childStats.filter((child): child is ScanStats => child !== null)
   const skippedEntryCount = childStats.length - children.length
@@ -653,13 +533,7 @@ async function scanLocalWorktreeWithNode(
   signal?: AbortSignal
 ): Promise<WorkspaceSpaceWorktree> {
   try {
-    const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY, signal)
-    const root = await scanLocalEntry(
-      worktree.path,
-      basenameFilesystemPath(worktree.path),
-      limit,
-      signal
-    )
+    const root = await scanLocalEntry(worktree.path, basenameFilesystemPath(worktree.path), signal)
     const compact = compactWorkspaceSpaceItems((root.children ?? []).map(toWorkspaceSpaceItem))
     return {
       ...createBaseWorktreeRow(repo, worktree, scannedAt),
@@ -702,6 +576,16 @@ async function scanLocalWorktree(
       if (error instanceof WorkspaceSpaceScanCancelledError) {
         throw error
       }
+      if (error instanceof WorkspaceSpaceScanCapacityError) {
+        const classified = classifyError(error)
+        return createUnavailableWorktreeRow(
+          repo,
+          worktree,
+          scannedAt,
+          classified.status,
+          classified.message
+        )
+      }
       // Fall through to the portable scanner so unsupported du variants or
       // permission edge cases still produce partial rows instead of failing.
     }
@@ -734,12 +618,10 @@ async function scanRemoteWorktree(
       }
     }
 
-    const limit = createAsyncLimiter(REMOTE_FS_CONCURRENCY, signal)
     const root = await scanRemoteEntry(
       worktree.path,
       basenameFilesystemPath(worktree.path),
       provider,
-      limit,
       signal
     )
     const compact = compactWorkspaceSpaceItems((root.children ?? []).map(toWorkspaceSpaceItem))
@@ -819,6 +701,7 @@ async function scanRepo(
   repo: Repo,
   scannedAt: number,
   store: Store,
+  localWorktreeLimit: AsyncLimiter,
   progress: WorkspaceSpaceProgressState,
   options: WorkspaceSpaceAnalyzeOptions
 ): Promise<RepoScanResult> {
@@ -867,7 +750,7 @@ async function scanRepo(
     options.onProgress
   )
   const remoteProvider = repo.connectionId ? getSshFilesystemProvider(repo.connectionId) : undefined
-  const rows = await mapLimit(worktrees, WORKTREE_SCAN_CONCURRENCY, async (worktree) => {
+  const rows = await mapWithConcurrency(worktrees, WORKTREE_SCAN_CONCURRENCY, async (worktree) => {
     throwIfAborted(options.signal)
     reportProgress(
       progress,
@@ -887,7 +770,7 @@ async function scanRepo(
             'unavailable',
             `SSH filesystem for "${repo.connectionId}" is not connected.`
           )
-      : await scanLocalWorktree(repo, worktree, scannedAt, options.signal)
+      : await localWorktreeLimit(() => scanLocalWorktree(repo, worktree, scannedAt, options.signal))
     reportProgress(
       progress,
       { scannedWorktreeCount: progress.scannedWorktreeCount + 1 },
@@ -942,8 +825,9 @@ export async function analyzeWorkspaceSpace(
     currentWorktreeDisplayName: null
   }
   options.onProgress?.({ ...progress })
-  const repoResults = await mapLimit(reposToScan, 2, (repo) =>
-    scanRepo(repo, scannedAt, store, progress, options)
+  const localWorktreeLimit = createAsyncLimiter(LOCAL_WORKTREE_SCAN_CONCURRENCY, options.signal)
+  const repoResults = await mapWithConcurrency(reposToScan, 2, (repo) =>
+    scanRepo(repo, scannedAt, store, localWorktreeLimit, progress, options)
   )
   throwIfAborted(options.signal)
   const repos = repoResults.map((result) => result.summary)

--- a/src/relay/workspace-space-scan-du-capacity.test.ts
+++ b/src/relay/workspace-space-scan-du-capacity.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as NodeProcess from 'node:process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as WorkspaceSpaceScanBudgetModule from '../shared/workspace-space-scan-budget'
+import type { RequestContext } from './dispatcher'
+
+const { execFileMock, budgetState } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  budgetState: { created: 0 }
+}))
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+
+vi.mock('node:process', async () => {
+  const actual = await vi.importActual<typeof NodeProcess>('node:process')
+  return { ...actual, platform: 'linux' }
+})
+
+vi.mock('../shared/workspace-space-scan-budget', async () => {
+  const actual = await vi.importActual<typeof WorkspaceSpaceScanBudgetModule>(
+    '../shared/workspace-space-scan-budget'
+  )
+  return {
+    ...actual,
+    // Why: only the du path's top-level listing is capped, so a swallowed
+    // capacity error would let the portable retry succeed and fail this test.
+    createWorkspaceSpaceScanBudget: () => {
+      budgetState.created += 1
+      return actual.createWorkspaceSpaceScanBudget(
+        budgetState.created === 1 ? { maxEntries: 2 } : undefined
+      )
+    }
+  }
+})
+
+import { WorkspaceSpaceScanCapacityError } from '../shared/workspace-space-scan-budget'
+import { scanWorkspaceSpaceDirectory } from './workspace-space-scan'
+
+const context: RequestContext = {
+  clientId: 1,
+  isStale: () => false
+}
+
+describe('relay workspace space scan du path', () => {
+  let tempDir: string | null = null
+
+  afterEach(async () => {
+    execFileMock.mockReset()
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('fails closed instead of repeating the traversal through the portable walker', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-relay-du-capacity-'))
+    const rootPath = join(tempDir, 'repo')
+    await mkdir(rootPath, { recursive: true })
+    await Promise.all(['one', 'two', 'three'].map((name) => writeFile(join(rootPath, name), name)))
+    execFileMock.mockImplementation(
+      (
+        _file: string,
+        args: string[],
+        _options: unknown,
+        callback: (error: Error | null, output: { stdout: string; stderr: string }) => void
+      ) => {
+        callback(null, { stdout: `1\t${args.at(-1)}\n`, stderr: '' })
+        return { kill: vi.fn() }
+      }
+    )
+
+    await expect(scanWorkspaceSpaceDirectory(rootPath, context)).rejects.toBeInstanceOf(
+      WorkspaceSpaceScanCapacityError
+    )
+    expect(execFileMock).toHaveBeenCalledWith(
+      'du',
+      ['-k', '-d', '1', rootPath],
+      expect.any(Object),
+      expect.any(Function)
+    )
+  })
+})

--- a/src/relay/workspace-space-scan.test.ts
+++ b/src/relay/workspace-space-scan.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as NodeProcess from 'node:process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as WorkspaceSpaceScanBudgetModule from '../shared/workspace-space-scan-budget'
+import type { RequestContext } from './dispatcher'
+
+vi.mock('node:process', async () => {
+  const actual = await vi.importActual<typeof NodeProcess>('node:process')
+  return { ...actual, platform: 'win32' }
+})
+
+vi.mock('../shared/workspace-space-scan-budget', async () => {
+  const actual = await vi.importActual<typeof WorkspaceSpaceScanBudgetModule>(
+    '../shared/workspace-space-scan-budget'
+  )
+  return {
+    ...actual,
+    createWorkspaceSpaceScanBudget: () => actual.createWorkspaceSpaceScanBudget({ maxEntries: 2 })
+  }
+})
+
+import { WorkspaceSpaceScanCapacityError } from '../shared/workspace-space-scan-budget'
+import { scanWorkspaceSpaceDirectory } from './workspace-space-scan'
+
+const context: RequestContext = {
+  clientId: 1,
+  isStale: () => false
+}
+
+describe('relay workspace space scan', () => {
+  let tempDir: string | null = null
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('fails closed when the portable scan exceeds its entry budget', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-relay-space-capacity-'))
+    const rootPath = join(tempDir, 'repo')
+    await mkdir(rootPath, { recursive: true })
+    await Promise.all(['one', 'two', 'three'].map((name) => writeFile(join(rootPath, name), name)))
+
+    await expect(scanWorkspaceSpaceDirectory(rootPath, context)).rejects.toBeInstanceOf(
+      WorkspaceSpaceScanCapacityError
+    )
+  })
+})

--- a/src/relay/workspace-space-scan.ts
+++ b/src/relay/workspace-space-scan.ts
@@ -2,16 +2,25 @@
    cancellation, symlink, and top-level compaction semantics in one scanner. */
 import { execFile } from 'node:child_process'
 import type { Dirent } from 'node:fs'
-import { lstat, readdir } from 'node:fs/promises'
+import { lstat, opendir } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import { platform } from 'node:process'
 import { promisify } from 'node:util'
 import type {
   WorkspaceSpaceDirectoryScanResult,
-  WorkspaceSpaceItem,
-  WorkspaceSpaceItemKind
+  WorkspaceSpaceItem
 } from '../shared/workspace-space-types'
 import { compactWorkspaceSpaceItems } from '../shared/workspace-space-compaction'
+import { mapWithConcurrency } from '../shared/map-with-concurrency'
+import {
+  scanWorkspaceSpaceEntryTree,
+  type WorkspaceSpaceEntryScan
+} from '../shared/workspace-space-entry-traversal'
+import {
+  collectWorkspaceSpaceDirectoryEntries,
+  createWorkspaceSpaceScanBudget,
+  WorkspaceSpaceScanCapacityError
+} from '../shared/workspace-space-scan-budget'
 import type { RequestContext } from './dispatcher'
 
 const RELAY_FS_CONCURRENCY = 48
@@ -19,15 +28,7 @@ const DU_TIMEOUT_MS = 120_000
 const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 const execFileAsync = promisify(execFile)
 
-type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
-
-type ScanStats = {
-  name: string
-  path: string
-  kind: WorkspaceSpaceItemKind
-  sizeBytes: number
-  skippedEntryCount: number
-}
+type ScanStats = WorkspaceSpaceEntryScan
 
 class RelayWorkspaceSpaceScanCancelledError extends Error {
   constructor() {
@@ -39,57 +40,6 @@ class RelayWorkspaceSpaceScanCancelledError extends Error {
 function throwIfCancelled(context: RequestContext): void {
   if (context.isStale() || context.signal?.aborted) {
     throw new RelayWorkspaceSpaceScanCancelledError()
-  }
-}
-
-function createAsyncLimiter(maxConcurrent: number, context: RequestContext): AsyncLimiter {
-  let active = 0
-  const queue: { resolve: () => void }[] = []
-
-  const acquire = async (): Promise<void> => {
-    throwIfCancelled(context)
-    if (active < maxConcurrent) {
-      active += 1
-      return
-    }
-    await new Promise<void>((resolve, reject) => {
-      let onAbort: (() => void) | null = null
-      const waiter = {
-        resolve: () => {
-          if (onAbort) {
-            context.signal?.removeEventListener('abort', onAbort)
-          }
-          resolve()
-        }
-      }
-      onAbort = () => {
-        const index = queue.indexOf(waiter)
-        if (index !== -1) {
-          queue.splice(index, 1)
-        }
-        reject(new RelayWorkspaceSpaceScanCancelledError())
-      }
-      queue.push(waiter)
-      if (context.signal) {
-        context.signal.addEventListener('abort', onAbort, { once: true })
-        if (context.signal.aborted) {
-          onAbort()
-        }
-      }
-    })
-    throwIfCancelled(context)
-    active += 1
-  }
-
-  return async <T>(task: () => Promise<T>): Promise<T> => {
-    await acquire()
-    try {
-      return await task()
-    } finally {
-      active -= 1
-      const next = queue.shift()
-      next?.resolve()
-    }
   }
 }
 
@@ -142,11 +92,10 @@ async function scanTopLevelEntryWithDu(
   entryPath: string,
   name: string,
   duSizes: Map<string, number>,
-  limit: AsyncLimiter,
   context: RequestContext
 ): Promise<ScanStats> {
   throwIfCancelled(context)
-  const stats = await limit(() => lstat(entryPath))
+  const stats = await lstat(entryPath)
   throwIfCancelled(context)
 
   if (stats.isSymbolicLink()) {
@@ -181,77 +130,30 @@ async function scanTopLevelEntryWithDu(
 async function scanEntryAggregate(
   entryPath: string,
   name: string,
-  limit: AsyncLimiter,
   context: RequestContext
 ): Promise<ScanStats> {
-  throwIfCancelled(context)
-  const stats = await limit(() => lstat(entryPath))
-  throwIfCancelled(context)
-
-  if (stats.isSymbolicLink()) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'symlink',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  if (!stats.isDirectory()) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'file',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  let entries: Dirent[]
-  try {
-    entries = await limit(() => readdir(entryPath, { withFileTypes: true }))
-  } catch {
-    return {
-      name,
-      path: entryPath,
-      kind: 'directory',
-      sizeBytes: stats.size,
-      skippedEntryCount: 1
-    }
-  }
-
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
-      try {
-        return await scanEntryAggregate(join(entryPath, entry.name), entry.name, limit, context)
-      } catch (error) {
-        if (error instanceof RelayWorkspaceSpaceScanCancelledError) {
-          throw error
-        }
-        return null
+  return scanWorkspaceSpaceEntryTree<Dirent>({
+    rootPath: entryPath,
+    rootName: name,
+    concurrency: RELAY_FS_CONCURRENCY,
+    signal: context.signal,
+    entryName: (entry) => entry.name,
+    joinPath: join,
+    classifyEntry: async (path) => {
+      const stats = await lstat(path)
+      throwIfCancelled(context)
+      if (stats.isSymbolicLink()) {
+        return { kind: 'symlink', sizeBytes: stats.size }
       }
-    })
-  )
-
-  let sizeBytes = stats.size
-  let skippedEntryCount = 0
-  for (const child of childStats) {
-    if (!child) {
-      skippedEntryCount += 1
-      continue
-    }
-    sizeBytes += child.sizeBytes
-    skippedEntryCount += child.skippedEntryCount
-  }
-
-  return {
-    name,
-    path: entryPath,
-    kind: 'directory',
-    sizeBytes,
-    skippedEntryCount
-  }
+      return stats.isDirectory()
+        ? { kind: 'directory', sizeBytes: stats.size }
+        : { kind: 'file', sizeBytes: stats.size }
+    },
+    readDirectory: (path) => opendir(path),
+    checkCancelled: () => throwIfCancelled(context),
+    createCancellationError: () => new RelayWorkspaceSpaceScanCancelledError(),
+    isCancellationError: (error) => error instanceof RelayWorkspaceSpaceScanCancelledError
+  })
 }
 
 async function scanDirectoryWithDu(
@@ -266,19 +168,28 @@ async function scanDirectoryWithDu(
   }
 
   const [entries, duSizes] = await Promise.all([
-    readdir(rootPath, { withFileTypes: true }),
+    opendir(rootPath).then(async (directory) => {
+      const admission = await collectWorkspaceSpaceDirectoryEntries(
+        directory,
+        rootPath,
+        (entry) => entry.name,
+        createWorkspaceSpaceScanBudget(),
+        () => throwIfCancelled(context)
+      )
+      return admission.entries
+    }),
     readDuDepthOne(rootPath, context)
   ])
   throwIfCancelled(context)
-  const limit = createAsyncLimiter(RELAY_FS_CONCURRENCY, context)
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
+  const childStats = await mapWithConcurrency(
+    entries,
+    RELAY_FS_CONCURRENCY,
+    async (entry): Promise<ScanStats | null> => {
       try {
         return await scanTopLevelEntryWithDu(
           join(rootPath, entry.name),
           entry.name,
           duSizes,
-          limit,
           context
         )
       } catch (error) {
@@ -287,7 +198,7 @@ async function scanDirectoryWithDu(
         }
         return null
       }
-    })
+    }
   )
   const children = childStats.filter((child): child is ScanStats => child !== null)
   const compact = compactWorkspaceSpaceItems(children.map(toWorkspaceSpaceItem))
@@ -305,55 +216,13 @@ async function scanDirectoryWithNode(
   rootPath: string,
   context: RequestContext
 ): Promise<WorkspaceSpaceDirectoryScanResult> {
-  throwIfCancelled(context)
-  const limit = createAsyncLimiter(RELAY_FS_CONCURRENCY, context)
-  const rootStats = await lstat(rootPath)
-  throwIfCancelled(context)
-  if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) {
-    const root = await scanEntryAggregate(rootPath, basename(rootPath), limit, context)
-    return {
-      sizeBytes: root.sizeBytes,
-      skippedEntryCount: root.skippedEntryCount,
-      topLevelItems: [],
-      omittedTopLevelItemCount: 0,
-      omittedTopLevelSizeBytes: 0
-    }
-  }
-
-  let entries: Dirent[]
-  try {
-    entries = await readdir(rootPath, { withFileTypes: true })
-  } catch {
-    return {
-      sizeBytes: rootStats.size,
-      skippedEntryCount: 1,
-      topLevelItems: [],
-      omittedTopLevelItemCount: 0,
-      omittedTopLevelSizeBytes: 0
-    }
-  }
-
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
-      try {
-        return await scanEntryAggregate(join(rootPath, entry.name), entry.name, limit, context)
-      } catch (error) {
-        if (error instanceof RelayWorkspaceSpaceScanCancelledError) {
-          throw error
-        }
-        return null
-      }
-    })
-  )
-  const children = childStats.filter((child): child is ScanStats => child !== null)
+  const root = await scanEntryAggregate(rootPath, basename(rootPath), context)
+  const children = root.children ?? []
   const compact = compactWorkspaceSpaceItems(children.map(toWorkspaceSpaceItem))
 
   return {
-    sizeBytes: rootStats.size + children.reduce((sum, child) => sum + child.sizeBytes, 0),
-    skippedEntryCount:
-      children.reduce((sum, child) => sum + child.skippedEntryCount, 0) +
-      childStats.length -
-      children.length,
+    sizeBytes: root.sizeBytes,
+    skippedEntryCount: root.skippedEntryCount,
     ...compact
   }
 }
@@ -366,7 +235,10 @@ export async function scanWorkspaceSpaceDirectory(
     try {
       return await scanDirectoryWithDu(rootPath, context)
     } catch (error) {
-      if (error instanceof RelayWorkspaceSpaceScanCancelledError) {
+      if (
+        error instanceof RelayWorkspaceSpaceScanCancelledError ||
+        error instanceof WorkspaceSpaceScanCapacityError
+      ) {
         throw error
       }
     }

--- a/src/shared/workspace-space-directory-frame.ts
+++ b/src/shared/workspace-space-directory-frame.ts
@@ -1,0 +1,61 @@
+import type { WorkspaceSpaceItemKind } from './workspace-space-types'
+
+type ScannableWorkspaceSpaceItemKind = Exclude<WorkspaceSpaceItemKind, 'other'>
+
+export type WorkspaceSpaceEntryScan = {
+  name: string
+  path: string
+  kind: ScannableWorkspaceSpaceItemKind
+  sizeBytes: number
+  skippedEntryCount: number
+  children?: WorkspaceSpaceEntryScan[]
+}
+
+export type WorkspaceSpaceEntryIdentity = {
+  kind: ScannableWorkspaceSpaceItemKind
+  sizeBytes: number
+}
+
+export type ParentSlot<TEntry> = {
+  frame: DirectoryFrame<TEntry>
+  index: number
+}
+
+/**
+ * One directory the walk has opened but not finished. `entries` is the admitted
+ * listing; `childResults` is only allocated for the root, because callers read
+ * top-level items and aggregate totals rather than the whole tree.
+ */
+export type DirectoryFrame<TEntry> = {
+  result: WorkspaceSpaceEntryScan
+  entries: readonly TEntry[]
+  /** Budget charge held for `entries`, returned once the listing is dispatched. */
+  retainedBytes: number
+  retired: boolean
+  nextIndex: number
+  remainingChildren: number
+  childResults?: (WorkspaceSpaceEntryScan | null | undefined)[]
+  parentSlot?: ParentSlot<TEntry>
+}
+
+export type EntryJob<TEntry> = {
+  frame: DirectoryFrame<TEntry>
+  index: number
+  entry: TEntry
+  name: string
+  path: string
+}
+
+export function createEntryScan(
+  path: string,
+  name: string,
+  identity: WorkspaceSpaceEntryIdentity
+): WorkspaceSpaceEntryScan {
+  return {
+    name,
+    path,
+    kind: identity.kind,
+    sizeBytes: identity.sizeBytes,
+    skippedEntryCount: 0
+  }
+}

--- a/src/shared/workspace-space-entry-traversal.test.ts
+++ b/src/shared/workspace-space-entry-traversal.test.ts
@@ -157,19 +157,35 @@ describe('scanWorkspaceSpaceEntryTree', () => {
     ])
   })
 
-  it('fails closed when a deep chain crosses the cumulative entry cap', async () => {
+  // Why: the cap bounds entries held at once. A deep walk retires each listing
+  // as it descends, so total tree size must not decide the outcome.
+  it('scans a chain far longer than the cap because listings are released', async () => {
+    const depth = 50
     const directories = new Map<string, readonly Entry[]>()
     let path = '/root'
-    for (let index = 0; index < 5; index += 1) {
+    for (let index = 0; index < depth; index += 1) {
       const name = `directory-${index}`
       directories.set(path, [{ name }])
       path = `${path}/${name}`
     }
     directories.set(path, [])
 
-    const scan = makeTraversal(directories, async () => ({ kind: 'directory', sizeBytes: 1 }), {
-      maxEntries: 4
-    })
+    const result = await makeTraversal(
+      directories,
+      async () => ({ kind: 'directory', sizeBytes: 1 }),
+      { maxEntries: 4 }
+    )
+
+    expect(result.sizeBytes).toBe(depth + 1)
+  })
+
+  it('still fails closed when one directory holds more entries than the cap', async () => {
+    const entries = Array.from({ length: 12 }, (_, index) => ({ name: `entry-${index}` }))
+    const scan = makeTraversal(
+      new Map([['/root', entries]]),
+      async (path) => ({ kind: path === '/root' ? 'directory' : 'file', sizeBytes: 1 }),
+      { maxEntries: 4 }
+    )
 
     await expect(scan).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
   })

--- a/src/shared/workspace-space-entry-traversal.ts
+++ b/src/shared/workspace-space-entry-traversal.ts
@@ -1,27 +1,21 @@
-import type { WorkspaceSpaceItemKind } from './workspace-space-types'
+import {
+  createEntryScan,
+  type DirectoryFrame,
+  type EntryJob,
+  type WorkspaceSpaceEntryIdentity,
+  type WorkspaceSpaceEntryScan
+} from './workspace-space-directory-frame'
 import {
   collectWorkspaceSpaceDirectoryEntries,
   createWorkspaceSpaceScanBudget,
+  releaseWorkspaceSpaceScanEntries,
   WorkspaceSpaceScanCapacityError,
+  type WorkspaceSpaceDirectoryAdmission,
   type WorkspaceSpaceScanBudget,
   type WorkspaceSpaceScanLimits
 } from './workspace-space-scan-budget'
 
-type ScannableWorkspaceSpaceItemKind = Exclude<WorkspaceSpaceItemKind, 'other'>
-
-export type WorkspaceSpaceEntryScan = {
-  name: string
-  path: string
-  kind: ScannableWorkspaceSpaceItemKind
-  sizeBytes: number
-  skippedEntryCount: number
-  children?: WorkspaceSpaceEntryScan[]
-}
-
-type WorkspaceSpaceEntryIdentity = {
-  kind: ScannableWorkspaceSpaceItemKind
-  sizeBytes: number
-}
+export type { WorkspaceSpaceEntryScan } from './workspace-space-directory-frame'
 
 type WorkspaceSpaceEntryTraversalOptions<TEntry> = {
   rootPath: string
@@ -38,50 +32,14 @@ type WorkspaceSpaceEntryTraversalOptions<TEntry> = {
   limits?: Partial<WorkspaceSpaceScanLimits>
 }
 
-type ParentSlot<TEntry> = {
-  frame: DirectoryFrame<TEntry>
-  index: number
-}
-
-type DirectoryFrame<TEntry> = {
-  result: WorkspaceSpaceEntryScan
-  entries: readonly TEntry[]
-  nextIndex: number
-  remainingChildren: number
-  childResults?: (WorkspaceSpaceEntryScan | null | undefined)[]
-  parentSlot?: ParentSlot<TEntry>
-}
-
-type EntryJob<TEntry> = {
-  frame: DirectoryFrame<TEntry>
-  index: number
-  entry: TEntry
-  name: string
-  path: string
-}
-
-function createEntryScan(
-  path: string,
-  name: string,
-  identity: WorkspaceSpaceEntryIdentity
-): WorkspaceSpaceEntryScan {
-  return {
-    name,
-    path,
-    kind: identity.kind,
-    sizeBytes: identity.sizeBytes,
-    skippedEntryCount: 0
-  }
-}
-
 async function readDirectoryOrNull<TEntry>(
   path: string,
   options: WorkspaceSpaceEntryTraversalOptions<TEntry>,
   budget: WorkspaceSpaceScanBudget
-): Promise<readonly TEntry[] | null> {
+): Promise<WorkspaceSpaceDirectoryAdmission<TEntry> | null> {
   try {
     const directory = await options.readDirectory(path)
-    const entries = await collectWorkspaceSpaceDirectoryEntries(
+    const admission = await collectWorkspaceSpaceDirectoryEntries(
       directory,
       path,
       options.entryName,
@@ -89,7 +47,7 @@ async function readDirectoryOrNull<TEntry>(
       options.checkCancelled
     )
     options.checkCancelled()
-    return entries
+    return admission
   } catch (error) {
     if (options.isCancellationError(error) || error instanceof WorkspaceSpaceScanCapacityError) {
       throw error
@@ -115,11 +73,12 @@ export async function scanWorkspaceSpaceEntryTree<TEntry>(
     return root
   }
 
-  const rootEntries = await readDirectoryOrNull(options.rootPath, options, budget)
-  if (rootEntries === null) {
+  const rootAdmission = await readDirectoryOrNull(options.rootPath, options, budget)
+  if (rootAdmission === null) {
     root.skippedEntryCount = 1
     return root
   }
+  const rootEntries = rootAdmission.entries
   if (rootEntries.length === 0) {
     root.children = []
     return root
@@ -128,6 +87,8 @@ export async function scanWorkspaceSpaceEntryTree<TEntry>(
   const rootFrame: DirectoryFrame<TEntry> = {
     result: root,
     entries: rootEntries,
+    retainedBytes: rootAdmission.retainedBytes,
+    retired: false,
     nextIndex: 0,
     remainingChildren: rootEntries.length,
     childResults: Array.from({ length: rootEntries.length }, () => undefined)
@@ -152,27 +113,36 @@ export async function scanWorkspaceSpaceEntryTree<TEntry>(
     onAbort()
   }
 
+  // Why: once every entry is dispatched the listing is dead weight, so drop it
+  // and hand its charge back before the walk descends any further.
+  const retireFrame = (frame: DirectoryFrame<TEntry>): void => {
+    if (frame.retired) {
+      return
+    }
+    frame.retired = true
+    releaseWorkspaceSpaceScanEntries(budget, frame.entries.length, frame.retainedBytes)
+    frame.entries = []
+    frame.retainedBytes = 0
+  }
+
   const takeAvailableJob = (): EntryJob<TEntry> | null => {
     while (availableFrames.length > 0) {
       const frame = availableFrames.at(-1)!
       if (frame.nextIndex >= frame.entries.length) {
         availableFrames.pop()
+        retireFrame(frame)
         continue
       }
       const index = frame.nextIndex
       frame.nextIndex += 1
-      if (frame.nextIndex >= frame.entries.length) {
-        availableFrames.pop()
-      }
       const entry = frame.entries[index]
       const name = options.entryName(entry)
-      return {
-        frame,
-        index,
-        entry,
-        name,
-        path: options.joinPath(frame.result.path, name)
+      const path = options.joinPath(frame.result.path, name)
+      if (frame.nextIndex >= frame.entries.length) {
+        availableFrames.pop()
+        retireFrame(frame)
       }
+      return { frame, index, entry, name, path }
     }
     return null
   }
@@ -239,8 +209,9 @@ export async function scanWorkspaceSpaceEntryTree<TEntry>(
   const expandDirectory = (
     job: EntryJob<TEntry>,
     result: WorkspaceSpaceEntryScan,
-    entries: readonly TEntry[]
+    admission: WorkspaceSpaceDirectoryAdmission<TEntry>
   ): void => {
+    const entries = admission.entries
     if (entries.length === 0) {
       completeChild(job.frame, job.index, result)
       return
@@ -249,6 +220,8 @@ export async function scanWorkspaceSpaceEntryTree<TEntry>(
     availableFrames.push({
       result,
       entries,
+      retainedBytes: admission.retainedBytes,
+      retired: false,
       nextIndex: 0,
       remainingChildren: entries.length,
       parentSlot: { frame: job.frame, index: job.index }
@@ -274,13 +247,13 @@ export async function scanWorkspaceSpaceEntryTree<TEntry>(
       completeChild(job.frame, job.index, result)
       return
     }
-    const entries = await readDirectoryOrNull(job.path, options, budget)
-    if (entries === null) {
+    const admission = await readDirectoryOrNull(job.path, options, budget)
+    if (admission === null) {
       result.skippedEntryCount = 1
       completeChild(job.frame, job.index, result)
       return
     }
-    expandDirectory(job, result, entries)
+    expandDirectory(job, result, admission)
   }
 
   const worker = async (): Promise<void> => {

--- a/src/shared/workspace-space-scan-budget.test.ts
+++ b/src/shared/workspace-space-scan-budget.test.ts
@@ -98,4 +98,16 @@ describe('workspace space scan budget', () => {
     ).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
     expect(closed).toBe(true)
   })
+
+  it('reports the configured cap rather than the default limits', async () => {
+    await expect(
+      collectWorkspaceSpaceDirectoryEntries(
+        [{ name: 'first' }, { name: 'second' }],
+        '/workspace',
+        (entry) => entry.name,
+        createWorkspaceSpaceScanBudget({ maxEntries: 1, maxRetainedBytes: 4 * 1024 * 1024 }),
+        () => undefined
+      )
+    ).rejects.toThrow('limit: 1 entries or 4 MiB of live scan state')
+  })
 })

--- a/src/shared/workspace-space-scan-budget.test.ts
+++ b/src/shared/workspace-space-scan-budget.test.ts
@@ -3,6 +3,7 @@ import {
   collectWorkspaceSpaceDirectoryEntries,
   createWorkspaceSpaceScanBudget,
   estimateWorkspaceSpaceEntryRetainedBytes,
+  releaseWorkspaceSpaceScanEntries,
   WorkspaceSpaceScanCapacityError
 } from './workspace-space-scan-budget'
 
@@ -23,7 +24,56 @@ describe('workspace space scan budget', () => {
         createWorkspaceSpaceScanBudget({ maxRetainedBytes: exactBytes }),
         () => undefined
       )
-    ).resolves.toEqual(entries)
+    ).resolves.toEqual({ entries, retainedBytes: exactBytes })
+  })
+
+  it('returns a failed listing’s charge so it cannot leak across directories', async () => {
+    const budget = createWorkspaceSpaceScanBudget()
+    async function* directory() {
+      yield { name: 'accepted' }
+      throw new Error('readdir exploded')
+    }
+
+    await expect(
+      collectWorkspaceSpaceDirectoryEntries(
+        directory(),
+        '/workspace',
+        (entry) => entry.name,
+        budget,
+        () => undefined
+      )
+    ).rejects.toThrow('readdir exploded')
+    expect(budget).toMatchObject({ entries: 0, retainedBytes: 0 })
+  })
+
+  it('frees capacity for later directories once a listing is released', async () => {
+    const parentPath = '/workspace'
+    const entries = [{ name: 'first' }, { name: 'second' }]
+    const exactBytes = entries.reduce(
+      (total, entry) => total + estimateWorkspaceSpaceEntryRetainedBytes(parentPath, entry.name),
+      0
+    )
+    const budget = createWorkspaceSpaceScanBudget({ maxRetainedBytes: exactBytes })
+
+    const first = await collectWorkspaceSpaceDirectoryEntries(
+      entries,
+      parentPath,
+      (entry) => entry.name,
+      budget,
+      () => undefined
+    )
+    // Why: a cumulative counter would reject the identical second listing here.
+    releaseWorkspaceSpaceScanEntries(budget, first.entries.length, first.retainedBytes)
+
+    await expect(
+      collectWorkspaceSpaceDirectoryEntries(
+        entries,
+        parentPath,
+        (entry) => entry.name,
+        budget,
+        () => undefined
+      )
+    ).resolves.toMatchObject({ retainedBytes: exactBytes })
   })
 
   it('closes an async directory iterator when the next entry exceeds the budget', async () => {

--- a/src/shared/workspace-space-scan-budget.ts
+++ b/src/shared/workspace-space-scan-budget.ts
@@ -8,6 +8,11 @@ export type WorkspaceSpaceScanLimits = {
   maxRetainedBytes: number
 }
 
+/**
+ * Tracks entries the traversal is holding right now, not entries it has ever
+ * seen. Counters fall again as directory listings are dispatched and dropped,
+ * so the caps bound live heap rather than total tree size.
+ */
 export type WorkspaceSpaceScanBudget = {
   entries: number
   retainedBytes: number
@@ -17,7 +22,7 @@ export type WorkspaceSpaceScanBudget = {
 export class WorkspaceSpaceScanCapacityError extends Error {
   constructor() {
     super(
-      'Workspace is too large to scan safely (limit: 100,000 entries or 64 MiB retained scan state)'
+      'Workspace is too large to scan safely (limit: 100,000 entries or 64 MiB of live scan state)'
     )
     this.name = 'WorkspaceSpaceScanCapacityError'
   }
@@ -63,20 +68,47 @@ export function retainWorkspaceSpaceScanEntry(
   budget.retainedBytes = retainedBytes
 }
 
+// Why: callers must return a listing's charge once they drop it, so the caps
+// track live retention instead of accumulating across the whole traversal.
+export function releaseWorkspaceSpaceScanEntries(
+  budget: WorkspaceSpaceScanBudget,
+  entryCount: number,
+  retainedBytes: number
+): void {
+  budget.entries = Math.max(0, budget.entries - entryCount)
+  budget.retainedBytes = Math.max(0, budget.retainedBytes - retainedBytes)
+}
+
+export type WorkspaceSpaceDirectoryAdmission<TEntry> = {
+  entries: TEntry[]
+  /** Charge held against the budget until the caller releases this listing. */
+  retainedBytes: number
+}
+
 export async function collectWorkspaceSpaceDirectoryEntries<TEntry>(
   directory: AsyncIterable<TEntry> | Iterable<TEntry>,
   parentPath: string,
   entryName: (entry: TEntry) => string,
   budget: WorkspaceSpaceScanBudget,
   checkCancelled: () => void
-): Promise<TEntry[]> {
+): Promise<WorkspaceSpaceDirectoryAdmission<TEntry>> {
   const entries: TEntry[] = []
-  for await (const entry of directory) {
-    checkCancelled()
-    retainWorkspaceSpaceScanEntry(budget, parentPath, entryName(entry))
-    entries.push(entry)
+  let retainedBytes = 0
+  try {
+    for await (const entry of directory) {
+      checkCancelled()
+      const name = entryName(entry)
+      retainWorkspaceSpaceScanEntry(budget, parentPath, name)
+      retainedBytes += estimateWorkspaceSpaceEntryRetainedBytes(parentPath, name)
+      entries.push(entry)
+    }
+  } catch (error) {
+    // Why: a rejected or cancelled listing is never handed to the caller, so
+    // nothing would otherwise return the charge already taken for it.
+    releaseWorkspaceSpaceScanEntries(budget, entries.length, retainedBytes)
+    throw error
   }
-  return entries
+  return { entries, retainedBytes }
 }
 
 function clampLimit(value: number | undefined, maximum: number): number {

--- a/src/shared/workspace-space-scan-budget.ts
+++ b/src/shared/workspace-space-scan-budget.ts
@@ -19,10 +19,17 @@ export type WorkspaceSpaceScanBudget = {
   limits: WorkspaceSpaceScanLimits
 }
 
+function formatLiveStateLimit(bytes: number): string {
+  const mebibytes = bytes / (1024 * 1024)
+  return mebibytes >= 1
+    ? `${Math.round(mebibytes * 10) / 10} MiB`
+    : `${bytes.toLocaleString('en-US')} bytes`
+}
+
 export class WorkspaceSpaceScanCapacityError extends Error {
-  constructor() {
+  constructor(limits: WorkspaceSpaceScanLimits) {
     super(
-      'Workspace is too large to scan safely (limit: 100,000 entries or 64 MiB of live scan state)'
+      `Workspace is too large to scan safely (limit: ${limits.maxEntries.toLocaleString('en-US')} entries or ${formatLiveStateLimit(limits.maxRetainedBytes)} of live scan state)`
     )
     this.name = 'WorkspaceSpaceScanCapacityError'
   }
@@ -62,7 +69,7 @@ export function retainWorkspaceSpaceScanEntry(
     budget.entries >= budget.limits.maxEntries ||
     retainedBytes > budget.limits.maxRetainedBytes
   ) {
-    throw new WorkspaceSpaceScanCapacityError()
+    throw new WorkspaceSpaceScanCapacityError(budget.limits)
   }
   budget.entries += 1
   budget.retainedBytes = retainedBytes


### PR DESCRIPTION
## Problem

Resource Manager scans worktrees to calculate workspace disk usage. The July 27 incident with 298 Orca worktrees demonstrated two independent resource failures:

- **macOS/Linux**: Up to six concurrent `du` processes competed for local storage, saturating disk I/O and stalling unrelated applications.
- **Windows/fallback**: The portable recursive scanner allocated promises and result nodes without limits, allowing large worktrees to exhaust heap (desktop or relay).

## Solution

### Local disk serialization
Introduce a scan-wide limiter that reduces maximum concurrent local traversals from six to one. This preserves host responsiveness while scanning hundreds of worktrees.

### Fixed-worker portable traversal
Replace recursive promise fanout with iterative `DirectoryFrame` stack and fixed-worker concurrency. Use shared `scanWorkspaceSpaceEntryTree` for desktop local fallback, desktop remote-provider fallback, and relay fallback scans.

### Capacity admission
Every portable entry is admitted through `WorkspaceSpaceScanBudget` before retention:
- Maximum entries held at once per worktree: 100,000
- Maximum estimated live state per worktree: 64 MiB

Budget measures what the traversal holds right now, not cumulative tree size. Directory listings are charged on admission and released once all entries are dispatched, bounding the widest concurrent frontier rather than total tree size. This distinction preserves success for ordinary large worktrees (76,788-entry Orca worktree peaks between 4–8 MiB live state).

### Failure mode
Capacity errors become unavailable rows rather than crashes, since the workspace is intact and readable, just too large to size safely.

## Testing

- Focused capacity and concurrency regression tests added across desktop, relay, and shared traversal modules.
- TypeScript and production build validation passed.
- 36 tests across analysis, IPC, relay, and budget modules.
- Existing desktop coverage (local results, symlinks, progress, cancellation, WSL routing, SSH bulk scans, du timeout fallback) preserved.

## Platform parity

- **macOS/Linux**: One local `du` at a time; bounded Node fallback on failure.
- **Windows**: One local bounded Node traversal at a time.
- **WSL**: Retains `getLocalProjectWorktreeGitOptions` distro selection; same admission and capacity bounds.
- **SSH**: Relay and request-by-request fallback use shared capacity model.
- **Folder workspaces**: Synthetic main worktree passes through same limiter and scanner.