### PR TITLE
fix(e2e): stabilize release gating

### DIFF
--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -412,7 +412,7 @@ test.describe('Activity Agent Pane Isolation', () => {
         activeTabType: 'editor',
         activeTabId: snapshot.tabId
       })
-    await expect(terminalPaneForLeaf(orcaPage, first.leafId)).toBeHidden()
+    // Editors occlude mounted terminal panes; activeTabType is the visibility contract.
 
     await clickWorkspaceCardAgentRow(orcaPage, first.prompt)
 

--- a/tests/e2e/headless-serve-desktop-activation.spec.ts
+++ b/tests/e2e/headless-serve-desktop-activation.spec.ts
@@ -7,7 +7,11 @@ import { test, expect, forwardElectronProcessLogs } from './helpers/orca-app'
 import { TEST_REPO_PATH_FILE } from './global-setup'
 import { getE2ECompletedOnboardingProfile } from './helpers/e2e-completed-onboarding-profile'
 import { getOrcaElectronLaunchArgs } from './helpers/electron-launch-args'
-import { cleanupE2EDaemons, closeElectronAppForE2E } from './helpers/electron-process-shutdown'
+import {
+  cleanupE2EDaemons,
+  closeElectronAppForE2E,
+  readE2EDaemonPids
+} from './helpers/electron-process-shutdown'
 import {
   assertElectronResolvedIsolatedHome,
   createElectronHomeIsolation,
@@ -100,6 +104,7 @@ test('promotes the headless owner without replacing its daemon terminal', async 
   const env = homeIsolation.env
   let serveApp: ElectronApplication | null = null
   let activatingProcess: ChildProcess | null = null
+  let daemonPids: number[] = []
 
   writeFileSync(
     path.join(userDataDir, 'orca-data.json'),
@@ -207,9 +212,10 @@ test('promotes the headless owner without replacing its daemon terminal', async 
       await waitForProcessExit(activatingProcess, 5_000)
     }
     if (serveApp) {
+      daemonPids = readE2EDaemonPids(userDataDir)
       await closeElectronAppForE2E(serveApp)
     }
-    await cleanupE2EDaemons(userDataDir)
+    await cleanupE2EDaemons(userDataDir, daemonPids)
     rmSync(userDataDir, { recursive: true, force: true })
   }
 })

--- a/tests/e2e/helpers/electron-process-shutdown.ts
+++ b/tests/e2e/helpers/electron-process-shutdown.ts
@@ -155,7 +155,7 @@ export async function closeElectronAppForE2E(app: ElectronApplication): Promise<
   }
 }
 
-function readDaemonPidFiles(userDataDir: string): number[] {
+export function readE2EDaemonPids(userDataDir: string): number[] {
   const daemonDir = path.join(userDataDir, 'daemon')
   if (!existsSync(daemonDir)) {
     return []
@@ -182,11 +182,15 @@ function readDaemonPidFiles(userDataDir: string): number[] {
   return pids
 }
 
-export async function cleanupE2EDaemons(userDataDir: string): Promise<void> {
+export async function cleanupE2EDaemons(
+  userDataDir: string,
+  capturedPids: readonly number[] = []
+): Promise<void> {
   // Why: app quit intentionally leaves daemon PTYs alive for warm reattach.
   // E2E temp profiles are deleted after each test, so their detached daemons
   // must be stopped explicitly or CI accumulates orphan Electron/shell trees.
-  for (const pid of readDaemonPidFiles(userDataDir)) {
+  const pids = new Set([...capturedPids, ...readE2EDaemonPids(userDataDir)])
+  for (const pid of pids) {
     await forceKillPidTree(pid)
   }
 }

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -25,7 +25,11 @@ import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync
 import os from 'node:os'
 import path from 'node:path'
 import { TEST_REPO_PATH_FILE } from '../global-setup'
-import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
+import {
+  cleanupE2EDaemons,
+  closeElectronAppForE2E,
+  readE2EDaemonPids
+} from './electron-process-shutdown'
 import { getOrcaElectronLaunchArgs } from './electron-launch-args'
 import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
 import {
@@ -261,8 +265,9 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
       const resolvedHome = await app.evaluate(({ app }) => app.getPath('home'))
       assertElectronResolvedIsolatedHome(resolvedHome, homeIsolation)
     } catch (error) {
+      const daemonPids = readE2EDaemonPids(userDataDir)
       await closeElectronAppForE2E(app)
-      await cleanupE2EDaemons(userDataDir)
+      await cleanupE2EDaemons(userDataDir, daemonPids)
       await removeUserDataDirAfterShutdown(userDataDir)
       throw error
     }
@@ -270,8 +275,11 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     await provideFixture(app)
     // Why: the Playwright close promise can settle before all Electron and PTY
     // descendants are gone in CI; worker teardown then hangs on open handles.
+    // Capture first because daemon shutdown unlinks its PID record before
+    // waiting on PTYs, which can otherwise leave an undiscoverable test orphan.
+    const daemonPids = readE2EDaemonPids(userDataDir)
     await closeElectronAppForE2E(app)
-    await cleanupE2EDaemons(userDataDir)
+    await cleanupE2EDaemons(userDataDir, daemonPids)
     await removeUserDataDirAfterShutdown(userDataDir)
   },
 

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -22,7 +22,11 @@ import os from 'node:os'
 import path from 'node:path'
 import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
 import { getOrcaElectronLaunchArgs } from './electron-launch-args'
-import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
+import {
+  cleanupE2EDaemons,
+  closeElectronAppForE2E,
+  readE2EDaemonPids
+} from './electron-process-shutdown'
 import {
   assertElectronResolvedIsolatedHome,
   createElectronHomeIsolation,
@@ -140,6 +144,13 @@ export function createRestartSession(
   const headful = shouldLaunchHeadful(testInfo)
   const homeIsolation = createRestartLaunchIsolation(userDataDir, headful, extraEnv)
   let runtimeWsPort: number | null = null
+  const daemonPids = new Set<number>()
+
+  const captureDaemonPids = (): void => {
+    for (const pid of readE2EDaemonPids(userDataDir)) {
+      daemonPids.add(pid)
+    }
+  }
 
   // Why: this helper bypasses the shared `electronApp` fixture, so it must
   // seed the same completed onboarding profile or first-run overlays cover
@@ -169,6 +180,7 @@ export function createRestartSession(
       const resolvedHome = await app.evaluate(({ app }) => app.getPath('home'))
       assertElectronResolvedIsolatedHome(resolvedHome, homeIsolation)
     } catch (error) {
+      captureDaemonPids()
       await closeElectronAppForE2E(app)
       throw error
     }
@@ -179,11 +191,12 @@ export function createRestartSession(
   }
 
   const close = async (app: ElectronApplication): Promise<void> => {
+    captureDaemonPids()
     await closeElectronAppForE2E(app)
   }
 
   const dispose = async (): Promise<void> => {
-    await cleanupE2EDaemons(userDataDir)
+    await cleanupE2EDaemons(userDataDir, daemonPids)
     if (process.env.ORCA_E2E_PRESERVE_RESTART_PROFILE === '1') {
       console.log(`[e2e] Preserved restart profile at ${userDataDir}`)
       return

--- a/tests/e2e/helpers/paired-electron-client.ts
+++ b/tests/e2e/helpers/paired-electron-client.ts
@@ -11,7 +11,11 @@ import {
 
 import { getE2ECompletedOnboardingProfile } from './e2e-completed-onboarding-profile'
 import { getOrcaElectronLaunchArgs } from './electron-launch-args'
-import { cleanupE2EDaemons, closeElectronAppForE2E } from './electron-process-shutdown'
+import {
+  cleanupE2EDaemons,
+  closeElectronAppForE2E,
+  readE2EDaemonPids
+} from './electron-process-shutdown'
 import {
   assertElectronResolvedIsolatedHome,
   createElectronHomeIsolation
@@ -222,8 +226,9 @@ export async function launchPairedElectronClient(
       environmentId,
       captureDirectSshAttempts,
       dispose: async () => {
+        const daemonPids = readE2EDaemonPids(userDataDir)
         await closeElectronAppForE2E(app)
-        await cleanupE2EDaemons(userDataDir)
+        await cleanupE2EDaemons(userDataDir, daemonPids)
         await removeProfile(userDataDir)
       },
       getDirectSshAttemptTargetIds: async () => {
@@ -235,8 +240,9 @@ export async function launchPairedElectronClient(
       replacePairingInPlace
     }
   } catch (error) {
+    const daemonPids = readE2EDaemonPids(userDataDir)
     await closeElectronAppForE2E(app)
-    await cleanupE2EDaemons(userDataDir)
+    await cleanupE2EDaemons(userDataDir, daemonPids)
     await removeProfile(userDataDir)
     throw error
   }

--- a/tests/e2e/native-chat-first-flush-race.spec.ts
+++ b/tests/e2e/native-chat-first-flush-race.spec.ts
@@ -8,7 +8,7 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './helpers/terminal'
 import type { GlobalSettings } from '../../src/shared/types'
 
-const LOADING_TITLE = 'Loading conversation…'
+const EMPTY_TITLE = 'Start a chat with Claude'
 const ERROR_TITLE = 'Could not load conversation'
 
 async function enableNativeChatSetting(page: Page): Promise<void> {
@@ -93,7 +93,7 @@ function claudeTranscriptLines(args: {
 }
 
 test.describe('Native chat first-flush transcript race (#8401)', () => {
-  test('stays in loading (never errors) until a not-yet-flushed transcript appears, then hydrates live', async ({
+  test('never errors while a not-yet-flushed transcript is missing, then hydrates live', async ({
     orcaPage
   }, testInfo) => {
     await waitForSessionReady(orcaPage)
@@ -135,10 +135,12 @@ test.describe('Native chat first-flush transcript race (#8401)', () => {
       await expect(orcaPage.locator('[data-native-chat-root="true"]')).toBeVisible({
         timeout: 15_000
       })
-      await expect(orcaPage.getByText(LOADING_TITLE)).toBeVisible({ timeout: 10_000 })
+      // A live working hook intentionally wins over transcript loading and
+      // renders the empty composer until the first turn reaches disk.
+      await expect(orcaPage.getByText(EMPTY_TITLE)).toBeVisible({ timeout: 10_000 })
       await expect(orcaPage.getByText(ERROR_TITLE)).toHaveCount(0)
       await orcaPage.screenshot({
-        path: path.join(screenshotDir, '01-loading-no-error.png')
+        path: path.join(screenshotDir, '01-empty-no-error.png')
       })
 
       // Why: a short real delay proves the first readSession attempt already

--- a/tests/e2e/terminal-opencode-altscreen-reveal-artifacts.spec.ts
+++ b/tests/e2e/terminal-opencode-altscreen-reveal-artifacts.spec.ts
@@ -542,6 +542,38 @@ async function readSynchronizedOutputLatch(page: Page, tabId: string): Promise<b
   }, tabId)
 }
 
+async function hideLatchedPaneInOtherWorktree(
+  page: Page,
+  tabId: string,
+  currentWorktreeId: string
+): Promise<{ latchWasOpen: boolean | null; otherWorktreeId: string | null }> {
+  return page.evaluate(
+    ({ tabId, currentWorktreeId }) => {
+      const store = window.__store
+      const manager = window.__paneManagers?.get(tabId)
+      if (!store || !manager) {
+        return { latchWasOpen: null, otherWorktreeId: null }
+      }
+      const pane = manager.getActivePane?.() ?? manager.getPanes?.()[0] ?? null
+      const modes = (
+        pane?.terminal as unknown as
+          | { _core?: { coreService?: { decPrivateModes?: { synchronizedOutput?: boolean } } } }
+          | undefined
+      )?._core?.coreService?.decPrivateModes
+      const latchWasOpen = modes ? modes.synchronizedOutput === true : null
+      const state = store.getState()
+      const other = Object.values(state.worktreesByRepo)
+        .flat()
+        .find((worktree) => worktree.id !== currentWorktreeId)
+      if (latchWasOpen && other) {
+        state.setActiveWorktree(other.id)
+      }
+      return { latchWasOpen, otherWorktreeId: other?.id ?? null }
+    },
+    { tabId, currentWorktreeId }
+  )
+}
+
 async function streamWhileHidden(setup: StreamingTabSetup, minFrames: number): Promise<void> {
   const heartbeatBefore = heartbeatFrame(setup.heartbeatPath)
   await expect
@@ -752,14 +784,12 @@ test.describe('OpenCode alt-screen reveal artifacts (STA-2694)', () => {
         })
         .toBe(true)
 
-      const otherWorktreeId = await switchToOtherWorktree(orcaPage, setup.worktreeId)
-      test.skip(!otherWorktreeId, 'test session has a single worktree; cannot surface-hide')
-      // Why re-check here: the pane was still VISIBLE between the freeze and this
-      // switch, so refreshes reached bufferRows and armed xterm's 1s watchdog. If
-      // it fired before the hide, the pane is now unlatched and the final
-      // assertion would pass without the defect ever existing.
+      // Observe the latch and hide synchronously so xterm's 1s watchdog cannot
+      // clear it between Playwright round trips.
+      const hidden = await hideLatchedPaneInOtherWorktree(orcaPage, setup.tabId, setup.worktreeId)
+      test.skip(!hidden.otherWorktreeId, 'test session has a single worktree; cannot surface-hide')
       expect(
-        await readSynchronizedOutputLatch(orcaPage, setup.tabId),
+        hidden.latchWasOpen,
         'the watchdog cleared the latch before the hide, so this run proves nothing'
       ).toBe(true)
       await orcaPage.waitForTimeout(2_500)


### PR DESCRIPTION
## Summary
- keep the native-chat first-flush test aligned with the intentional working-hook empty state while preserving no-error and live-hydration coverage
- make the synchronized-output latch observation and worktree hide atomic, and remove an invalid occlusion-blind terminal visibility assertion
- capture E2E daemon PIDs before Electron shutdown can unlink their records, preventing detached daemon/PTY trees from hanging worker teardown

## Validation
- `pnpm run typecheck`
- `pnpm run check:max-lines-ratchet`
- targeted `oxlint` and `oxfmt --check`
- the three previously failing E2Es pass together after rebasing on main
- exact shard 4-of-10 completed without its prior 120s worker teardown timeout
- restart cleanup leaves no daemon process behind after both pass and failure paths
- localization coverage check passes