### PR TITLE
fix(terminal): clear retained overlay for editor tabs

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.test.ts
@@ -48,6 +48,17 @@ describe('useColdParkedTerminalPresentation', () => {
     expect(presentedTargetId(hook.result)).toBe('b')
   })
 
+  it('clears the terminal presentation when the group activates non-terminal content', () => {
+    const hook = renderPresentationHook({
+      desiredTargetId: 'a',
+      coldParkedTargetIds: new Set()
+    })
+
+    hook.rerender({ desiredTargetId: null, coldParkedTargetIds: new Set() })
+
+    expect(presentedTargetId(hook.result)).toBeNull()
+  })
+
   it('retains the prior target until a cold target settles', () => {
     const hook = renderPresentationHook({
       desiredTargetId: 'a',

--- a/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.ts
+++ b/src/renderer/src/components/terminal-pane/use-cold-parked-terminal-presentation.ts
@@ -56,7 +56,7 @@ export function resolveColdParkedPresentation(
       presentedTargetId: null,
       pendingTargetId: null
     }
-    if (entry.pendingTargetId === desiredTargetId) {
+    if (entry.pendingTargetId !== null && entry.pendingTargetId === desiredTargetId) {
       next.set(scopeId, entry)
       continue
     }


### PR DESCRIPTION
## Summary

- clear the retained terminal presentation when a tab group activates non-terminal content
- retain the existing cold-parked handoff behavior only when a real pending terminal target exists
- add regression coverage for switching from a terminal to editor content

## ELI5

The editor and terminal are like two sheets stacked in the same spot. Orca accidentally read “no pending terminal equals no desired terminal” as “keep the old terminal sheet,” so it stayed over the editor. The guard now keeps a terminal only when there is an actual pending terminal to show.

## Root cause

`resolveColdParkedPresentation` treated `pendingTargetId === desiredTargetId` as a pending handoff even when both values were `null`. That retained the previously presented terminal after the editor tab became active.

## Proof of fix

- Launched the exact PR branch in an isolated Electron profile; the app reported `Orca: nwparker/fix-terminal-editor-overlay`.
- Opened a real terminal, then clicked `README.md` through Orca's rendered Explorer.
- Post-click state was `activeTabType: "editor"`, `visibleTerminalPanes: 0`, and `editorVisible: true`.

![Editor visible with the previously active terminal cleared](https://github.com/user-attachments/assets/24f47895-8f9b-4ef9-abde-76577f700431)

## Proof of no regression

- Focused Vitest: 5/5 passed, including preservation of the real pending-terminal handoff.
- Focused `activity-agent-pane-isolation.spec.ts` regression passed with one Electron worker.
- `electron-vite build --mode e2e`, targeted oxlint, and `git diff --check` passed.
- Current GitHub CI: 25/25 non-skipped checks passed, with no failures or pending checks.

## CI evidence

This fixes the editor-tab/terminal-overlay failure reproduced in Cut Release runs 30316035485 and 30314906938.
