### PR TITLE
ci(release): detach non-blocking E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,7 @@
 name: E2E
 
+run-name: E2E ${{ inputs.ref || github.ref }}
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -777,7 +777,7 @@ jobs:
             echo "## Release E2E Signal"
             echo ""
             echo "- Terminal rendering golden is release-blocking."
-            echo "- Full E2E is diagnostic/non-blocking release evidence."
+            echo "- Full E2E runs separately after publication and cannot change the release result."
             echo "- Terminal rendering release evidence is diagnostic/non-blocking."
             echo ""
             echo "Publishing behavior is controlled by the existing job dependencies; this summary does not change release gating."
@@ -806,15 +806,6 @@ jobs:
           fi
 
           node config/scripts/create-draft-release.mjs "$TAG"
-
-  # Why: tag-scoped E2E gives release visibility, but the suite is flaky enough
-  # that publish-release must not depend on it.
-  e2e:
-    needs: cut
-    if: needs.cut.outputs.should_release == 'true'
-    uses: ./.github/workflows/e2e.yml
-    with:
-      ref: refs/tags/${{ needs.cut.outputs.tag }}
 
   terminal-rendering-golden:
     needs: cut
@@ -1929,6 +1920,32 @@ jobs:
             --draft=false \
             --prerelease="$prerelease" \
             --repo "$GITHUB_REPOSITORY"
+
+  post-release-e2e:
+    needs:
+      - cut
+      - publish-release
+    if: ${{ needs.cut.outputs.tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch tag-scoped E2E
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.cut.outputs.tag }}
+        run: |
+          for attempt in 1 2 3; do
+            if gh workflow run e2e.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref "$TAG" \
+              --raw-field "ref=refs/tags/$TAG"; then
+              echo "Dispatched post-release E2E for $TAG."
+              exit 0
+            fi
+            [[ "$attempt" -eq 3 ]] || sleep "$((attempt * 5))"
+          done
+          echo "::warning::Failed to dispatch post-release E2E for $TAG after 3 attempts."
 
   homebrew-bump-published-rc-draft:
     needs:

--- a/config/scripts/release-e2e-dispatch-contract.test.mjs
+++ b/config/scripts/release-e2e-dispatch-contract.test.mjs
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+const releaseWorkflow = parse(
+  readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
+)
+const e2eWorkflow = parse(readFileSync(join(projectDir, '.github/workflows/e2e.yml'), 'utf8'))
+
+describe('release E2E dispatch contract', () => {
+  it('dispatches tag-scoped E2E only after publication', () => {
+    const dispatchJob = releaseWorkflow.jobs['post-release-e2e']
+    const dispatchStep = dispatchJob.steps.find((step) => step.name === 'Dispatch tag-scoped E2E')
+
+    expect(releaseWorkflow.jobs.e2e).toBeUndefined()
+    expect(dispatchJob.needs).toEqual(['cut', 'publish-release'])
+    expect(dispatchJob.if).toBe("${{ needs.cut.outputs.tag != '' }}")
+    expect(dispatchJob.permissions.actions).toBe('write')
+    expect(dispatchStep.env.TAG).toBe('${{ needs.cut.outputs.tag }}')
+    expect(dispatchStep.run).toContain('gh workflow run e2e.yml')
+    expect(dispatchStep.run).toContain('--ref "$TAG"')
+    expect(dispatchStep.run).toContain('--raw-field "ref=refs/tags/$TAG"')
+    expect(dispatchStep.run).toContain('::warning::Failed to dispatch post-release E2E')
+  })
+
+  it('keeps detached E2E identifiable and manually dispatchable by ref', () => {
+    const refInput = e2eWorkflow.on.workflow_dispatch.inputs.ref
+
+    expect(e2eWorkflow['run-name']).toBe('E2E ${{ inputs.ref || github.ref }}')
+    expect(refInput.type).toBe('string')
+    expect(refInput.required).toBe(false)
+  })
+})

--- a/config/scripts/release-e2e-dispatch-contract.test.mjs
+++ b/config/scripts/release-e2e-dispatch-contract.test.mjs
@@ -22,6 +22,8 @@ describe('release E2E dispatch contract', () => {
     expect(dispatchStep.run).toContain('gh workflow run e2e.yml')
     expect(dispatchStep.run).toContain('--ref "$TAG"')
     expect(dispatchStep.run).toContain('--raw-field "ref=refs/tags/$TAG"')
+    expect(dispatchStep.run).toContain('for attempt in 1 2 3')
+    expect(dispatchStep.run).toContain('[[ "$attempt" -eq 3 ]] || sleep')
     expect(dispatchStep.run).toContain('::warning::Failed to dispatch post-release E2E')
   })
 


### PR DESCRIPTION
## Summary

- Remove full E2E from the `Cut Release` workflow's in-line job graph.
- Dispatch the same tag-scoped E2E asynchronously after `publish-release` succeeds.
- Run the detached workflow definition and tests from the exact release tag.
- Retry dispatch failures three times, then warn without turning an already-published release red.
- Give detached E2E runs a ref-specific name and protect ordering, permission, tag, retry, and input contracts with tests.

The release-blocking topology is unchanged: publication still requires platform builds, signing, asset verification, and terminal-rendering golden checks. This removes roughly 145 runner-minutes from each `Cut Release` run and prevents flaky diagnostic E2E failures from making successfully published releases appear failed.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused workflow suites passed locally; full sharded suite runs in PR CI
- [ ] `pnpm build` — PR CI's package job builds and smoke-tests the packaged app
- [x] Added a release E2E dispatch contract suite; 26 focused release-contract tests pass
- [x] Parsed both changed YAML workflows and ran `git diff --check`

## AI Review Report

Reviewed the release authority graph, publish ordering, failure behavior, retries, concurrency, tag reproducibility, and GitHub token scope. Review flagged that retry behavior should be explicitly contractual; added assertions for the three-attempt loop and retry delay. It also flagged a possible draft-creation race, but verified this is prevented transitively: both `build` and `build-mac` need `create-release`, while `publish-release` needs both build jobs.

Cross-platform review confirmed the dispatcher intentionally runs on Ubuntu and changes no application shortcuts, labels, filesystem paths, native packaging, SSH behavior, or Electron platform logic. Existing macOS, Linux, Windows, SSH, signing, and terminal golden release jobs are unchanged.

## Security Audit

- The dispatcher receives only `actions: write`; unspecified permissions remain disabled.
- The validated release tag is passed through an environment variable and quoted in every shell argument.
- The workflow definition is selected from the exact immutable release tag, avoiding a race with later `main` changes.
- Dispatch uses the repository-scoped `GITHUB_TOKEN`; no new secret or third-party action is introduced.
- A failed diagnostic dispatch retries, emits an Actions warning, and exits successfully because it occurs after publication and must not rewrite release status.

No security follow-up is required.

## Notes

ELI5: the release truck used to carry an optional inspection team, so a flaky inspector could paint the delivery red even after it shipped. Now every required safety check completes and the package publishes first, then the optional team inspects that exact package in a separate lane.
