### PR TITLE
fix(native-chat): keep known sessions loading until flush

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-live-status.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-status.ts
@@ -36,7 +36,7 @@ export type NativeChatLiveMergeInput = {
  * provider lifecycle records reconcile a dropped final hook.
  *
  * Precedence:
- *   - errors win outright; live work wins over transcript loading.
+ *   - errors win outright; known sessions stay loading until transcript content resolves.
  *   - hook 'working' stays authoritative until the hook exits that state OR an
  *     explicit terminal marker for this turn lands.
  *   - design is hook-first: lifecycle is a terminal suppressor for dropped
@@ -65,7 +65,7 @@ export function mergeNativeChatLiveSession(input: NativeChatLiveMergeInput): Nat
     transcriptLifecycle,
     hookHasWorkingSubagents ?? false
   )
-  if (loading && status !== 'working') {
+  if (loading && (sessionId !== null || status !== 'working')) {
     return assembleNativeChatSession({ sources, sessionId, agent, status: 'loading' })
   }
   return assembleNativeChatSession({

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -256,6 +256,15 @@ describe('mergeNativeChatLiveSession', () => {
         loading: true
       }).status
     ).toBe('working')
+    expect(
+      mergeNativeChatLiveSession({
+        sources: { transcript: [] },
+        sessionId: 'sess',
+        agent: 'claude',
+        hookState: 'working',
+        loading: true
+      }).status
+    ).toBe('loading')
 
     const errored = mergeNativeChatLiveSession({
       sources: { transcript: [] },


### PR DESCRIPTION
## Summary

- keep a known provider session loading until its first transcript snapshot resolves
- preserve the existing pre-session behavior where live hook work can render before a provider session id exists
- cover both precedence paths in the live-session merge tests

## ELI5

Orca knew the Claude chat existed before Claude wrote the first line of its transcript. During that short gap, Orca incorrectly showed “start a new chat.” It now shows “Loading conversation…” until the first transcript arrives.

## Root cause

`mergeNativeChatLiveSession` let a live `working` hook override transcript loading for every session. When Claude had already reported a provider session id but had not flushed the JSONL transcript yet, the view received zero messages with `working` status and rendered the empty state.

## Proof of fix

The focused Electron reproduction holds the first transcript flush. A known session now remains in the loading state with no false empty/error UI:

![Known Claude session remains loading before its first transcript flush](https://github.com/user-attachments/assets/4a7c785a-e84f-459c-bd64-6be57aaae794)

After the delayed snapshot resolves, the same view hydrates with the conversation:

![Claude conversation hydrates after the transcript snapshot resolves](https://github.com/user-attachments/assets/a8000367-78a4-4dc3-91ed-3a343da4b363)

- Focused Vitest: 38/38 passed.
- `native-chat-first-flush-race.spec.ts`: 1/1 passed with one Electron worker.

## Proof of no regression

- The pre-session live-working path remains explicitly tested, so hook-driven work can still render before a provider session id exists.
- Tests cover both the known-session loading precedence and the pre-session live precedence.
- `electron-vite build --mode e2e`, targeted oxlint, and `git diff --check` passed.
- Current GitHub CI: 23/23 non-skipped checks passed, with no failures or pending checks.

## CI evidence

This fixes the native-chat first-flush failure reproduced in Cut Release runs 30316035485 and 30314906938.
