### PR TITLE
fix(mobile): heal a stale input line before sending diff-review notes

### DIFF
--- a/mobile/src/session/use-mobile-diff-review-send-actions.test.ts
+++ b/mobile/src/session/use-mobile-diff-review-send-actions.test.ts
@@ -1,0 +1,221 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DiffComment } from '../../../src/shared/types'
+import type { RpcClient } from '../transport/rpc-client'
+import type { ReviewScreenState } from './mobile-diff-review-screen-model'
+import {
+  isMobileNativeChatInputStale,
+  markMobileNativeChatInputStale,
+  resetMobileNativeChatStaleInputForTests
+} from './mobile-native-chat-stale-input'
+import { useMobileDiffReviewSendActions } from './use-mobile-diff-review-send-actions'
+
+type SendActions = ReturnType<typeof useMobileDiffReviewSendActions>
+
+vi.mock('../platform/haptics', () => ({ triggerSuccess: vi.fn() }))
+vi.mock('expo-clipboard', () => ({ setStringAsync: vi.fn().mockResolvedValue(undefined) }))
+
+function sendResponse(accepted: boolean) {
+  return {
+    id: 'send',
+    ok: true as const,
+    result: { send: { accepted } },
+    _meta: { runtimeId: 'runtime' }
+  }
+}
+
+const COMMENT: DiffComment = {
+  id: 'comment-1',
+  worktreeId: 'wt-1',
+  filePath: 'src/a.ts',
+  lineNumber: 3,
+  body: 'rename this',
+  createdAt: 1,
+  side: 'modified'
+}
+
+const READY: ReviewScreenState = {
+  kind: 'ready',
+  status: { entries: [], conflictOperation: 'none' },
+  branchCompare: null,
+  comments: [COMMENT],
+  reviewState: { version: 1, files: {} }
+}
+
+describe('useMobileDiffReviewSendActions', () => {
+  let renderer: ReactTestRenderer | null = null
+  let actions: SendActions | null = null
+  let mountedClient: RpcClient | null = null
+  let setActionError: ReturnType<typeof vi.fn>
+  let setSendSheet: ReturnType<typeof vi.fn>
+  let saveCommentsAndReviewState: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    resetMobileNativeChatStaleInputForTests()
+    setActionError = vi.fn()
+    setSendSheet = vi.fn()
+    saveCommentsAndReviewState = vi.fn().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    actions = null
+    mountedClient = null
+  })
+
+  function Harness(): null {
+    actions = useMobileDiffReviewSendActions({
+      client: mountedClient,
+      connState: 'connected',
+      worktreeId: 'wt-1',
+      screenState: READY,
+      setActionError,
+      setSendSheet,
+      saveCommentsAndReviewState
+    })
+    return null
+  }
+
+  async function mount(client: RpcClient): Promise<void> {
+    mountedClient = client
+    const original = console.error
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      original(...args)
+    })
+    try {
+      await act(async () => {
+        renderer = create(createElement(Harness))
+      })
+    } finally {
+      consoleSpy.mockRestore()
+    }
+  }
+
+  it('heals a marked terminal BEFORE submitting the notes', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(sendResponse(true))
+    await mount({ sendRequest } as unknown as RpcClient)
+    markMobileNativeChatInputStale('terminal-1')
+
+    await act(async () => {
+      await actions?.sendPromptToTerminal('terminal-1', [COMMENT])
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(2)
+    // Order matters: the Ctrl+U clear must land before the enter-carrying write,
+    // or the orphaned paste is submitted with the notes.
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({
+      terminal: 'terminal-1',
+      text: '\x15',
+      enter: false
+    })
+    expect(sendRequest.mock.calls[1]?.[1]).toMatchObject({ terminal: 'terminal-1', enter: true })
+    expect(sendRequest.mock.calls[1]?.[1]).not.toMatchObject({ text: '\x15' })
+    expect(isMobileNativeChatInputStale('terminal-1')).toBe(false)
+    expect(setActionError).toHaveBeenCalledWith('Review notes sent')
+  })
+
+  it('does not submit when the heal reports the line is not safe', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(sendResponse(false))
+    await mount({ sendRequest } as unknown as RpcClient)
+    markMobileNativeChatInputStale('terminal-1')
+
+    let error: unknown
+    await act(async () => {
+      error = await actions?.sendPromptToTerminal('terminal-1', [COMMENT]).catch((err) => err)
+    })
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('Failed to send notes')
+    // Only the failed clear — never the notes.
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '\x15', enter: false })
+    expect(saveCommentsAndReviewState).not.toHaveBeenCalled()
+    expect(setActionError).not.toHaveBeenCalled()
+    expect(setSendSheet).not.toHaveBeenCalled()
+    // Marker survives for the next attempt.
+    expect(isMobileNativeChatInputStale('terminal-1')).toBe(true)
+  })
+
+  it('keeps the marker and skips the notes when the clear throws', async () => {
+    const sendRequest = vi.fn().mockRejectedValue(new Error('offline'))
+    await mount({ sendRequest } as unknown as RpcClient)
+    markMobileNativeChatInputStale('terminal-1')
+
+    let error: unknown
+    await act(async () => {
+      error = await actions?.sendPromptToTerminal('terminal-1', [COMMENT]).catch((err) => err)
+    })
+
+    expect((error as Error).message).toBe('Failed to send notes')
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(saveCommentsAndReviewState).not.toHaveBeenCalled()
+    expect(isMobileNativeChatInputStale('terminal-1')).toBe(true)
+  })
+
+  it('sends an unmarked terminal with no extra RPC', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(sendResponse(true))
+    await mount({ sendRequest } as unknown as RpcClient)
+
+    await act(async () => {
+      await actions?.sendPromptToTerminal('terminal-1', [COMMENT])
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest.mock.calls[0]?.[0]).toBe('terminal.send')
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ terminal: 'terminal-1', enter: true })
+    expect(saveCommentsAndReviewState).toHaveBeenCalledTimes(1)
+    expect(setActionError).toHaveBeenCalledWith('Review notes sent')
+    expect(setSendSheet).toHaveBeenCalledWith(null)
+  })
+
+  it('only heals the terminal that was marked', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(sendResponse(true))
+    await mount({ sendRequest } as unknown as RpcClient)
+    markMobileNativeChatInputStale('terminal-other')
+
+    await act(async () => {
+      await actions?.sendPromptToTerminal('terminal-1', [COMMENT])
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(isMobileNativeChatInputStale('terminal-other')).toBe(true)
+  })
+
+  it('still reports a rejected terminal.send after a successful heal', async () => {
+    const sendRequest = vi
+      .fn()
+      .mockResolvedValueOnce(sendResponse(true))
+      .mockResolvedValueOnce(sendResponse(false))
+    await mount({ sendRequest } as unknown as RpcClient)
+    markMobileNativeChatInputStale('terminal-1')
+
+    let error: unknown
+    await act(async () => {
+      error = await actions?.sendPromptToTerminal('terminal-1', [COMMENT]).catch((err) => err)
+    })
+
+    expect((error as Error).message).toBe('Terminal input is locked')
+    expect(saveCommentsAndReviewState).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed terminal.send response', async () => {
+    const sendRequest = vi
+      .fn()
+      .mockResolvedValue({ id: 'send', ok: false, error: { message: 'pane gone' } })
+    await mount({ sendRequest } as unknown as RpcClient)
+
+    let error: unknown
+    await act(async () => {
+      error = await actions?.sendPromptToTerminal('terminal-1', [COMMENT]).catch((err) => err)
+    })
+
+    expect((error as Error).message).toBe('pane gone')
+    expect(saveCommentsAndReviewState).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/session/use-mobile-diff-review-send-actions.test.ts
+++ b/mobile/src/session/use-mobile-diff-review-send-actions.test.ts
@@ -115,7 +115,8 @@ describe('useMobileDiffReviewSendActions', () => {
       enter: false
     })
     expect(sendRequest.mock.calls[1]?.[1]).toMatchObject({ terminal: 'terminal-1', enter: true })
-    expect(sendRequest.mock.calls[1]?.[1]).not.toMatchObject({ text: '\x15' })
+    // The second call is the notes themselves, not another clear.
+    expect(String(sendRequest.mock.calls[1]?.[1]?.text)).toContain('rename this')
     expect(isMobileNativeChatInputStale('terminal-1')).toBe(false)
     expect(setActionError).toHaveBeenCalledWith('Review notes sent')
   })

--- a/mobile/src/session/use-mobile-diff-review-send-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-send-actions.ts
@@ -11,6 +11,7 @@ import {
   readMobileReviewTerminalSendAccepted,
   readMobileReviewTerminalTabs
 } from './mobile-diff-review-rpc'
+import { healMobileNativeChatStaleInput } from './mobile-native-chat-stale-input'
 import type { ReviewScreenState, SendSheetState } from './mobile-diff-review-screen-model'
 
 type SendActionsInput = {
@@ -73,6 +74,13 @@ export function useMobileDiffReviewSendActions(input: SendActionsInput) {
     async (terminal: string, comments: readonly DiffComment[]) => {
       if (!client || connState !== 'connected') {
         throw new Error('Waiting for desktop...')
+      }
+      // The stale marker is keyed by terminal handle, not by surface, so an image
+      // paste orphaned on this terminal by native chat would be submitted along
+      // with these notes (#10228). No device token is threaded here — this send
+      // carries none either.
+      if (!(await healMobileNativeChatStaleInput({ client, terminal, deviceToken: null }))) {
+        throw new Error('Failed to send notes')
       }
       const response = await client.sendRequest('terminal.send', {
         terminal,

--- a/mobile/src/session/use-mobile-diff-review-send-actions.ts
+++ b/mobile/src/session/use-mobile-diff-review-send-actions.ts
@@ -75,10 +75,8 @@ export function useMobileDiffReviewSendActions(input: SendActionsInput) {
       if (!client || connState !== 'connected') {
         throw new Error('Waiting for desktop...')
       }
-      // The stale marker is keyed by terminal handle, not by surface, so an image
-      // paste orphaned on this terminal by native chat would be submitted along
-      // with these notes (#10228). No device token is threaded here — this send
-      // carries none either.
+      // Marked by terminal handle, not by surface, so a paste orphaned here by native
+      // chat would ride along with these notes (#10228). Diff review carries no device token.
       if (!(await healMobileNativeChatStaleInput({ client, terminal, deviceToken: null }))) {
         throw new Error('Failed to send notes')
       }


### PR DESCRIPTION
## Summary

`useMobileDiffReviewSendActions.sendPromptToTerminal` submitted review notes with `enter: true` without first healing a stale agent input line. It now gates the send on `healMobileNativeChatStaleInput`, exactly as `use-mobile-native-chat-answer-send.ts:186` already does.

This completes a follow-up **deliberately deferred by #10480**.

**Why the two surfaces connect.** The stale marker is keyed by **terminal handle** (`staleInputTerminals: Set<string>`), not by surface. A marker set by the native-chat image-paste path is still set when the user then sends diff-review notes to that same terminal — so those notes were submitted on top of the orphaned paste (#10228).

When the heal reports the line is not safe, the send is skipped: no `terminal.send` for the notes, `markNotesSent` / `triggerSuccess` / `setSendSheet(null)` are all skipped, and the marker stays set so the next attempt retries. The notes are neither lost nor marked sent. The existing `!response.ok` and `readMobileReviewTerminalSendAccepted` handling is unchanged and still runs after the heal.

## Screenshots

Emulator QA — **PARTIAL**, see the Testing section for exactly what this does and does not prove.

![app loaded](https://github.com/user-attachments/assets/a99ea3cc-3fac-455c-bdad-c7820a4938e9)

![hosts unpaired](https://github.com/user-attachments/assets/bf8d4a88-2dec-423e-8973-2960a08e8286)

## Testing

- [x] `pnpm lint` — oxlint exit 0
- [x] `pnpm typecheck` — `tsc --noEmit` exit 0
- [x] `pnpm test` — mobile suite 350 files / 2563 passed; all 16 CI test shards green
- [x] `pnpm build` — CI `package` + `verify` green
- [x] Added or updated high-quality tests that would catch regressions

**Unit tests — 7 added** (new file `use-mobile-diff-review-send-actions.test.ts`; count from `git diff <parent> <head>`, so no inherited tests are credited here). This hook had no test file before.

Revert-check via the patch method (revert the source fix only, keep the tests):

```
 × heals a marked terminal BEFORE submitting the notes
 × does not submit when the heal reports the line is not safe
 × keeps the marker and skips the notes when the clear throws
 × still reports a rejected terminal.send after a successful heal
 Test Files  1 failed (1)
      Tests  4 failed | 3 passed (7)
```

With the fix restored: `Tests 7 passed (7)`.

- **4 tests encode NEW behavior** and fail on revert (call ordering, not-safe → no send, clear-throws → no send, post-heal rejection still reported).
- **3 tests are regression guards** that pass on both sides (unmarked terminal sends with exactly one RPC, only the marked terminal is healed, a failed `terminal.send` response still surfaces).

The ordering assertion was proven to discriminate, not merely to observe: moving the heal to *after* `terminal.send` in the source fails 4 tests. `calls[0]` must be `{text: '\x15', enter: false}` and `calls[1]` must be `enter: true` **and** contain the note body, so a swapped or duplicated-clear implementation cannot pass.

Note for anyone re-running these: mobile uses its own `mobile/vitest.config.ts`, not the root `config/vitest.config.ts`.

**NOT verified on the emulator:** the diff-review note send end-to-end, and the stale precondition. The simulator has no live desktop pairing — all 13 saved pairings are on networks this machine has left (`10.0.0.4`, `172.16.101.141`; the Mac is on `192.168.0.x`). Re-pairing requires the desktop Settings > Mobile UI and has no CLI path, and the only workaround would have been a second runtime, which risks the known singleton-lock / runtime-metadata clobber against a live primary instance. What the screenshots prove is only that the app loads and runs this branch's bundle. The ordering, the not-safe-→-no-send behavior, and the no-regression claim rest on the unit tests above, **not** on live emulator evidence.

## AI Review Report

Reviewed with two independent Opus subagent lanes (correctness/vacuity, and scope/CodeRabbit adjudication) plus a lead pass. Risks checked: test vacuity, call ordering, the silent-drop path, marker lifecycle, regressions on untouched branches, perf on the common path, and scope.

- **Vacuity** — confirmed non-vacuous by actually reverting the source and re-running (output above).
- **`deviceToken: null`** — settled against the desktop handler, not assumed. `src/main/runtime/rpc/methods/terminal.ts:246-249` treats a clientless send as legacy mobile and **unlocked**, and `sendTerminalStreamInput` skips `beginMobileInputFloor` when there is no client id. The notes send this heal precedes is itself clientless, so the clear is authorized identically to the write it guards. A null token cannot make the heal fail where the send would have succeeded.
- **Marker lifecycle** — the marker is consumed only after the host accepts the clear; both the `catch` and the `!cleared` branch return false with the marker intact. Two tests assert it survives a failed heal.
- **Perf** — the common (unmarked) path is a `Set.has` early-return with zero added RPCs, asserted by an exact call count. The `useCallback` dep array is unchanged, so no new identity churn.
- **Cross-platform (macOS / Linux / Windows)** — explicitly checked and **N/A**. No path handling, no shortcuts or shortcut labels, no Electron platform branches in the diff. The only literal is `\x15` (Ctrl+U), a PTY control byte written into a stream, not a key event, and platform-independent at the mobile end. The desktop code that interprets it is untouched.
- **SSH hosts** — exercised but not at risk: the heal writes via `terminal.send` keyed by an opaque handle, and the desktop routes to whichever host owns the pane. Ctrl+U is readline/TUI-level and travels the PTY identically.
- **Folder workspaces** — N/A; the heal keys on terminal handle only, with no worktree or repo assumption.
- **Non-GitHub providers** — N/A; diff comments are local records formatted into a prompt, nothing provider-specific.

## Security Audit

No new attack surface. No command execution, no path handling, no auth or secrets, no dependency change. The one new outbound write is a `terminal.send` RPC carrying a fixed control byte (`\x15`) to a terminal handle the caller already holds and is already authorized to write to on the next line — it grants no capability the existing send did not. Input handling is unchanged: note bodies still flow through `formatMobileDiffReviewPrompt`. The clientless-send authorization path is pre-existing and documented above. No IPC surface added.

## Notes

Two follow-ups, deliberately **not** done here to keep this PR to one concern:

1. **Errors from this hook are not surfaced to the user.** `sendPromptToTerminal` throws, but `MobileDiffReviewDrawers.tsx:76` calls it as `void controller.sendPromptToTerminal(...)` and `ActionSheetModal.tsx:74` invokes `action.onPress()` with no catch — and there is no unhandled-rejection handler under `mobile/`. So on a failed heal the user sees nothing and the sheet stays open (`skipAutoClose: true`). **This is pre-existing**: all four existing throws in this hook (`'Waiting for desktop...'`, `!response.ok`, `'Terminal input is locked'`, `'Failed to create terminal'`) die the same way, and this change adds a fifth to an already-broken channel. It is not a data-loss path — the notes stay unsent and unmarked, so a retry is correct and safe. Fixing it properly means exposing `setActionError` through the controller and changing four paths this PR never touches, which is a second concern. The sibling `useMobileDiffReviewGitActions.runGitMutation` already catches internally and is the pattern to follow.

2. **The three diff-review send RPCs are unbounded.** `terminal.send`, `session.tabs.createTerminal`, and `session.tabs.list` in this file pass no `timeoutMs`, so per `rpc-client.ts:1003` they wait for reconnect indefinitely. Worth bounding, but it needs a UX decision about what the review screen shows on timeout and applies to all three equally.

3. `mobile-native-chat-stale-input.ts` is now used from diff review too, so its `native-chat` name is cross-domain. Renaming it would touch 4+ modules and swamp an 8-line fix, so it is deliberately left alone.
