### PR TITLE
test(e2e): harden release latch and teardown coverage

### DIFF
--- a/tests/e2e/resource-manager-unbound-session-safety.spec.ts
+++ b/tests/e2e/resource-manager-unbound-session-safety.spec.ts
@@ -179,6 +179,7 @@ test.describe('Resource Manager unbound-session safety', () => {
       if (secondApp) {
         await session.close(secondApp).catch(() => {})
       }
+      await session.dispose()
     }
   })
 })

--- a/tests/e2e/terminal-opencode-altscreen-reveal-artifacts.spec.ts
+++ b/tests/e2e/terminal-opencode-altscreen-reveal-artifacts.spec.ts
@@ -542,6 +542,60 @@ async function readSynchronizedOutputLatch(page: Page, tabId: string): Promise<b
   }, tabId)
 }
 
+async function freezeMidFrameAndSwitchWorktree(
+  page: Page,
+  setup: StreamingTabSetup
+): Promise<string | null> {
+  return page.evaluate(
+    ({ currentWorktreeId, ptyId, tabId }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is unavailable')
+      }
+      const otherWorktree = Object.values(store.getState().worktreesByRepo)
+        .flat()
+        .find((worktree) => worktree.id !== currentWorktreeId)
+      if (!otherWorktree) {
+        return null
+      }
+
+      window.api.pty.write(ptyId, 'ORCA_FREEZE_MID_FRAME')
+      return new Promise<string>((resolve, reject) => {
+        const deadline = performance.now() + 5_000
+        const switchWhenLatched = (): void => {
+          const manager = window.__paneManagers?.get(tabId)
+          const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+          const synchronizedOutput = (
+            pane?.terminal as unknown as
+              | {
+                  _core?: {
+                    coreService?: { decPrivateModes?: { synchronizedOutput?: boolean } }
+                  }
+                }
+              | undefined
+          )?._core?.coreService?.decPrivateModes?.synchronizedOutput
+          if (synchronizedOutput === true) {
+            store.getState().setActiveWorktree(otherWorktree.id)
+            resolve(otherWorktree.id)
+            return
+          }
+          if (performance.now() >= deadline) {
+            reject(new Error('fixture did not leave a synchronized-output frame open'))
+            return
+          }
+          setTimeout(switchWhenLatched, 0)
+        }
+        switchWhenLatched()
+      })
+    },
+    {
+      currentWorktreeId: setup.worktreeId,
+      ptyId: setup.ptyId,
+      tabId: setup.tabId
+    }
+  )
+}
+
 async function streamWhileHidden(setup: StreamingTabSetup, minFrames: number): Promise<void> {
   const heartbeatBefore = heartbeatFrame(setup.heartbeatPath)
   await expect
@@ -739,25 +793,10 @@ test.describe('OpenCode alt-screen reveal artifacts (STA-2694)', () => {
     test.setTimeout(180_000)
     const setup = await startStreamingAltScreenTui(orcaPage, testInfo)
     try {
-      // Stop the TUI mid-bracket, then hide — the exact field sequence.
-      await sendToTerminal(orcaPage, setup.ptyId, 'ORCA_FREEZE_MID_FRAME').catch(() => {})
-      // Why poll instead of a fixed wait: xterm arms a 1s safety timeout that
-      // clears the latch on its own, so a longer sleep would sample after the
-      // watchdog fired and miss the very state under test.
-      await expect
-        .poll(() => readSynchronizedOutputLatch(orcaPage, setup.tabId), {
-          timeout: 5_000,
-          intervals: [50],
-          message: 'fixture did not leave a synchronized-output frame open'
-        })
-        .toBe(true)
-
-      const otherWorktreeId = await switchToOtherWorktree(orcaPage, setup.worktreeId)
+      // Switch in the renderer task that observes the latch; CI round trips can
+      // otherwise outlast xterm's one-second safety watchdog.
+      const otherWorktreeId = await freezeMidFrameAndSwitchWorktree(orcaPage, setup)
       test.skip(!otherWorktreeId, 'test session has a single worktree; cannot surface-hide')
-      // Why re-check here: the pane was still VISIBLE between the freeze and this
-      // switch, so refreshes reached bufferRows and armed xterm's 1s watchdog. If
-      // it fired before the hide, the pane is now unlatched and the final
-      // assertion would pass without the defect ever existing.
       expect(
         await readSynchronizedOutputLatch(orcaPage, setup.tabId),
         'the watchdog cleared the latch before the hide, so this run proves nothing'


### PR DESCRIPTION
## Summary

- switch worktrees in the renderer task that observes xterm's synchronized-output latch
- preserve the post-hide latch assertion and final user-visible repaint assertion
- dispose the restart session owned by the Resource Manager warm-reattach spec

## ELI5

- **Latch race:** The test needed to hide the terminal during a one-second window, but the round trip through CI sometimes took longer than the window. It now observes the latch and performs the real worktree switch together, so it cannot miss the moment it is meant to test.
- **Teardown leak:** The test checked out but forgot to turn off its detached terminal daemon. `session.dispose()` now owns that cleanup.

## Root causes

### Synchronized-output race

The test opened xterm's DEC 2026 latch, returned through Playwright, and then switched worktrees. xterm clears that latch with a one-second safety watchdog; Linux CI could complete the round trip too late, leaving the test without proof that the pane hid mid-frame.

### Worker teardown timeout

`resource-manager-unbound-session-safety.spec.ts` created a `RestartSession` but omitted `session.dispose()`. Both failing Cut Release jobs ended by killing exactly one orphan `electron` process and one orphan `bash` process after Playwright's 120-second worker teardown timeout.

## Proof of fix

### Synchronized-output latch

- Fresh exact-branch Electron build and focused E2E: 1/1 passed.
- Stress repeat: 3/3 passed.
- The test proves the latch exists after the hide, then proves it is cleared on reveal before checking the final rendered pixels.
- The screenshot below was captured after the no-repair pixel assertion and shows the alternate-screen terminal visibly repainted in the full Orca window.

![Revealed alternate-screen terminal fully painted after the synchronized-output latch clears](https://github.com/user-attachments/assets/33ba5111-fa63-4179-b23c-ca933fcb6e72)

### Worker teardown

- Resource Manager teardown regression: 1/1 passed under `CI=1`; the worker exited normally.
- Two consecutive stress repeats also exited normally.
- Process-lifecycle evidence is stronger than a screenshot for this non-visual fix: the old failure left one orphan Electron process and one orphan bash process, while the fixed run returned normally after disposing the owned session/profile.
- A third exploratory stress repeat hit the suite's unrelated global temp-repo pointer collision, not the teardown path.

## Proof of no regression

- The post-hide latch assertion remains, so the test cannot pass without reproducing the intended mid-frame state.
- The final visible repaint and no-manual-repair pixel assertions remain.
- Both Electron apps close and the owned session/profile dispose in `finally`.
- `electron-vite build --mode e2e`, `pnpm run typecheck:node`, targeted oxlint/oxfmt, the max-lines ratchet, and `git diff --check` passed.
- Current GitHub CI: 23/23 non-skipped checks passed, with no failures or pending checks.

## CI evidence

This covers the remaining harness failures in Cut Release runs 30316035485 and 30314906938. Plugin failures from those runs were already fixed by #11024.
