### PR TITLE
fix(runtime): surface desktop RPC startup failures

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,6 +57,10 @@ import { callRuntimeEnvironment } from './ipc/runtime-environment-transport-rout
 import { resolveEnvironment } from '../shared/runtime-environment-store'
 import { getPreferredPairingOffer } from '../shared/runtime-environments'
 import { OrcaRuntimeRpcServer } from './runtime/runtime-rpc'
+import {
+  recordRuntimeRpcStartFailure,
+  showRuntimeRpcStartupFailureDialog
+} from './runtime/runtime-rpc-startup-failure'
 import { resolveAdvertisedPairingEndpoint } from './runtime/pairing-endpoint'
 import { ServeReadinessPublisher } from './server/serve-readiness'
 import { reserveServeStdoutForReadiness } from './server/serve-stdout-boundary'
@@ -2682,12 +2686,19 @@ void app.whenReady().then(async () => {
   }
 
   // Why: window and RPC startup run in parallel; registerPtyHandlers gates PTY spawns so RPC binds without racing the daemon provider swap.
-  const [win] = await Promise.all([
+  const [win, runtimeRpcStartResult] = await Promise.all([
     Promise.resolve(openMainWindow()),
-    runtimeRpc.start().catch((error) => {
-      console.error('[runtime] Failed to start local RPC transport:', error)
-    })
+    runtimeRpc.start().then(
+      () => ({ ok: true as const }),
+      (error: unknown) => {
+        recordRuntimeRpcStartFailure(error)
+        return { ok: false as const, error }
+      }
+    )
   ])
+  if (!runtimeRpcStartResult.ok) {
+    void showRuntimeRpcStartupFailureDialog(win, runtimeRpcStartResult.error)
+  }
 
   const cloudAuth = getOrcaCloudAuthConfig()
   if (cloudAuth.configured) {

--- a/src/main/runtime/runtime-rpc-startup-failure.test.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.test.ts
@@ -71,6 +71,21 @@ describe('runtime RPC startup failure reporting', () => {
     consoleError.mockRestore()
   })
 
+  it('does not let telemetry failure escape the startup failure handler', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const telemetryError = new Error('telemetry unavailable')
+    trackMock.mockImplementationOnce(() => {
+      throw telemetryError
+    })
+
+    expect(() => recordRuntimeRpcStartFailure(new Error('RPC failed'))).not.toThrow()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[runtime] Failed to record RPC startup failure telemetry:',
+      telemetryError
+    )
+    consoleError.mockRestore()
+  })
+
   it('shows the CLI impact and local cause', async () => {
     const parentWindow = createParentWindow()
     const error = new Error('metadata write failed')

--- a/src/main/runtime/runtime-rpc-startup-failure.test.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.test.ts
@@ -39,7 +39,11 @@ import {
 type FakeParentWindow = Electron.BrowserWindow & EventEmitter
 
 function createParentWindow(visible = true, destroyed = false): FakeParentWindow {
+  const webContents = Object.assign(new EventEmitter(), {
+    isDestroyed: () => destroyed
+  })
   return Object.assign(new EventEmitter(), {
+    webContents,
     isDestroyed: () => destroyed,
     isVisible: () => visible
   }) as unknown as FakeParentWindow
@@ -198,7 +202,7 @@ describe('runtime RPC startup failure reporting', () => {
 
     expect(showMessageBoxMock).toHaveBeenCalledOnce()
     expect(parentWindow.listenerCount('show')).toBe(0)
-    expect(parentWindow.listenerCount('closed')).toBe(0)
+    expect(parentWindow.webContents.listenerCount('destroyed')).toBe(0)
   })
 
   it('never shows a dialog against an already destroyed window', async () => {
@@ -217,12 +221,15 @@ describe('runtime RPC startup failure reporting', () => {
       new Error('metadata write failed')
     )
 
-    parentWindow.emit('closed')
+    await flushMicrotasks()
+    expect(parentWindow.listenerCount('closed')).toBe(0)
+    expect(parentWindow.webContents.listenerCount('destroyed')).toBe(1)
+    parentWindow.webContents.emit('destroyed')
     await reporting
 
     expect(showMessageBoxMock).not.toHaveBeenCalled()
     expect(parentWindow.listenerCount('show')).toBe(0)
-    expect(parentWindow.listenerCount('closed')).toBe(0)
+    expect(parentWindow.webContents.listenerCount('destroyed')).toBe(0)
   })
 
   it('logs instead of rejecting if Electron cannot show the dialog', async () => {

--- a/src/main/runtime/runtime-rpc-startup-failure.test.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.test.ts
@@ -1,0 +1,120 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { showMessageBoxMock, trackMock } = vi.hoisted(() => ({
+  showMessageBoxMock: vi.fn(),
+  trackMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  dialog: {
+    showMessageBox: showMessageBoxMock
+  }
+}))
+
+vi.mock('../i18n/main-i18n', () => ({
+  translateMain: (
+    _key: string,
+    fallback: string,
+    options?: Readonly<Record<string, string>>
+  ): string => fallback.replace('{{cause}}', options?.cause ?? '')
+}))
+
+vi.mock('../telemetry/client', () => ({
+  track: trackMock
+}))
+
+import {
+  classifyRuntimeRpcStartFailure,
+  recordRuntimeRpcStartFailure,
+  showRuntimeRpcStartupFailureDialog
+} from './runtime-rpc-startup-failure'
+
+function createParentWindow(visible = true): Electron.BrowserWindow {
+  return Object.assign(new EventEmitter(), {
+    isDestroyed: () => false,
+    isVisible: () => visible
+  }) as unknown as Electron.BrowserWindow
+}
+
+describe('runtime RPC startup failure reporting', () => {
+  beforeEach(() => {
+    showMessageBoxMock.mockReset().mockResolvedValue({ response: 0 })
+    trackMock.mockReset()
+  })
+
+  it.each([
+    ['EACCES', 'permission_denied'],
+    ['EPERM', 'permission_denied'],
+    ['EADDRINUSE', 'address_in_use'],
+    ['ENOSPC', 'storage_unavailable'],
+    ['EROFS', 'storage_unavailable'],
+    ['ENOENT', 'invalid_path'],
+    ['ENAMETOOLONG', 'invalid_path'],
+    ['unexpected', 'unknown']
+  ] as const)('classifies %s without exposing the raw error', (code, expected) => {
+    const error = Object.assign(new Error('/Users/private/orca-runtime.json'), { code })
+
+    expect(classifyRuntimeRpcStartFailure(error)).toBe(expected)
+  })
+
+  it('records a privacy-safe telemetry event', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const error = Object.assign(new Error('/Users/private/orca-runtime.json'), { code: 'EACCES' })
+
+    recordRuntimeRpcStartFailure(error)
+
+    expect(trackMock).toHaveBeenCalledWith('runtime_rpc_start_failed', {
+      error_class: 'permission_denied'
+    })
+    expect(trackMock.mock.calls[0]).not.toContainEqual(expect.stringContaining('/Users/private'))
+    consoleError.mockRestore()
+  })
+
+  it('shows the CLI impact and local cause', async () => {
+    const parentWindow = createParentWindow()
+    const error = new Error('metadata write failed')
+
+    await showRuntimeRpcStartupFailureDialog(parentWindow, error)
+
+    expect(showMessageBoxMock).toHaveBeenCalledWith(
+      parentWindow,
+      expect.objectContaining({
+        type: 'error',
+        title: 'Orca CLI unavailable',
+        message: "Orca couldn't start its local command transport.",
+        detail: expect.stringMatching(
+          /orca status.*orca terminal.*orchestration.*Cause: metadata write failed/s
+        )
+      })
+    )
+  })
+
+  it('waits until the app window is visible', async () => {
+    const parentWindow = createParentWindow(false)
+    const reporting = showRuntimeRpcStartupFailureDialog(
+      parentWindow,
+      new Error('metadata write failed')
+    )
+
+    expect(showMessageBoxMock).not.toHaveBeenCalled()
+    parentWindow.emit('show')
+    await reporting
+
+    expect(showMessageBoxMock).toHaveBeenCalledOnce()
+  })
+
+  it('logs instead of rejecting if Electron cannot show the dialog', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    showMessageBoxMock.mockRejectedValueOnce(new Error('window closed'))
+
+    await expect(
+      showRuntimeRpcStartupFailureDialog(createParentWindow(), new Error('failed'))
+    ).resolves.toBeUndefined()
+    expect(consoleError).toHaveBeenCalledWith(
+      '[runtime] Failed to show RPC startup failure dialog:',
+      expect.any(Error)
+    )
+    consoleError.mockRestore()
+  })
+})

--- a/src/main/runtime/runtime-rpc-startup-failure.test.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.test.ts
@@ -38,15 +38,27 @@ import {
 
 type FakeParentWindow = Electron.BrowserWindow & EventEmitter
 
-function createParentWindow(visible = true, destroyed = false): FakeParentWindow {
+function createParentWindow(
+  visible = true,
+  destroyed = false,
+  webContentsDestroyed = destroyed
+): FakeParentWindow {
   const webContents = Object.assign(new EventEmitter(), {
-    isDestroyed: () => destroyed
+    isDestroyed: () => webContentsDestroyed
   })
-  return Object.assign(new EventEmitter(), {
-    webContents,
+  const parentWindow = Object.assign(new EventEmitter(), {
     isDestroyed: () => destroyed,
     isVisible: () => visible
   }) as unknown as FakeParentWindow
+  Object.defineProperty(parentWindow, 'webContents', {
+    get: () => {
+      if (destroyed) {
+        throw new Error('Object has been destroyed')
+      }
+      return webContents
+    }
+  })
+  return parentWindow
 }
 
 // Why: the dialog is deferred behind an await, so a synchronous "not called yet" assertion
@@ -212,6 +224,16 @@ describe('runtime RPC startup failure reporting', () => {
 
     expect(showMessageBoxMock).not.toHaveBeenCalled()
     expect(parentWindow.listenerCount('show')).toBe(0)
+  })
+
+  it('never waits on already destroyed web contents', async () => {
+    const parentWindow = createParentWindow(false, false, true)
+
+    await showRuntimeRpcStartupFailureDialog(parentWindow, new Error('metadata write failed'))
+
+    expect(showMessageBoxMock).not.toHaveBeenCalled()
+    expect(parentWindow.listenerCount('show')).toBe(0)
+    expect(parentWindow.webContents.listenerCount('destroyed')).toBe(0)
   })
 
   it('drops the pending dialog and its listeners when the window closes first', async () => {

--- a/src/main/runtime/runtime-rpc-startup-failure.test.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.test.ts
@@ -30,11 +30,21 @@ import {
   showRuntimeRpcStartupFailureDialog
 } from './runtime-rpc-startup-failure'
 
-function createParentWindow(visible = true): Electron.BrowserWindow {
+type FakeParentWindow = Electron.BrowserWindow & EventEmitter
+
+function createParentWindow(visible = true, destroyed = false): FakeParentWindow {
   return Object.assign(new EventEmitter(), {
-    isDestroyed: () => false,
+    isDestroyed: () => destroyed,
     isVisible: () => visible
-  }) as unknown as Electron.BrowserWindow
+  }) as unknown as FakeParentWindow
+}
+
+// Why: the dialog is deferred behind an await, so a synchronous "not called yet" assertion
+// would pass even if the deferral were deleted; drain the microtask queue first.
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve)
+  })
 }
 
 describe('runtime RPC startup failure reporting', () => {
@@ -58,6 +68,21 @@ describe('runtime RPC startup failure reporting', () => {
     expect(classifyRuntimeRpcStartFailure(error)).toBe(expected)
   })
 
+  it('classifies a code carried on a wrapped cause', () => {
+    const error = new Error('failed to publish orca-runtime.json', {
+      cause: Object.assign(new Error('read-only volume'), { code: 'EROFS' })
+    })
+
+    expect(classifyRuntimeRpcStartFailure(error)).toBe('storage_unavailable')
+  })
+
+  it('survives a self-referential cause chain', () => {
+    const error: Error & { cause?: unknown } = new Error('cyclic')
+    error.cause = error
+
+    expect(classifyRuntimeRpcStartFailure(error)).toBe('unknown')
+  })
+
   it('records a privacy-safe telemetry event', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const error = Object.assign(new Error('/Users/private/orca-runtime.json'), { code: 'EACCES' })
@@ -67,7 +92,7 @@ describe('runtime RPC startup failure reporting', () => {
     expect(trackMock).toHaveBeenCalledWith('runtime_rpc_start_failed', {
       error_class: 'permission_denied'
     })
-    expect(trackMock.mock.calls[0]).not.toContainEqual(expect.stringContaining('/Users/private'))
+    expect(JSON.stringify(trackMock.mock.calls)).not.toContain('/Users/private')
     consoleError.mockRestore()
   })
 
@@ -105,6 +130,15 @@ describe('runtime RPC startup failure reporting', () => {
     )
   })
 
+  it('truncates a runaway cause instead of pasting it whole into the dialog', async () => {
+    await showRuntimeRpcStartupFailureDialog(createParentWindow(), new Error('x'.repeat(900)))
+
+    const detail = showMessageBoxMock.mock.calls[0]?.[1]?.detail as string
+    const cause = detail.slice(detail.indexOf('Cause: ') + 'Cause: '.length)
+    expect(cause).toHaveLength(500)
+    expect(cause.endsWith('…')).toBe(true)
+  })
+
   it('waits until the app window is visible', async () => {
     const parentWindow = createParentWindow(false)
     const reporting = showRuntimeRpcStartupFailureDialog(
@@ -112,11 +146,38 @@ describe('runtime RPC startup failure reporting', () => {
       new Error('metadata write failed')
     )
 
+    await flushMicrotasks()
     expect(showMessageBoxMock).not.toHaveBeenCalled()
     parentWindow.emit('show')
     await reporting
 
     expect(showMessageBoxMock).toHaveBeenCalledOnce()
+    expect(parentWindow.listenerCount('show')).toBe(0)
+    expect(parentWindow.listenerCount('closed')).toBe(0)
+  })
+
+  it('never shows a dialog against an already destroyed window', async () => {
+    const parentWindow = createParentWindow(false, true)
+
+    await showRuntimeRpcStartupFailureDialog(parentWindow, new Error('metadata write failed'))
+
+    expect(showMessageBoxMock).not.toHaveBeenCalled()
+    expect(parentWindow.listenerCount('show')).toBe(0)
+  })
+
+  it('drops the pending dialog and its listeners when the window closes first', async () => {
+    const parentWindow = createParentWindow(false)
+    const reporting = showRuntimeRpcStartupFailureDialog(
+      parentWindow,
+      new Error('metadata write failed')
+    )
+
+    parentWindow.emit('closed')
+    await reporting
+
+    expect(showMessageBoxMock).not.toHaveBeenCalled()
+    expect(parentWindow.listenerCount('show')).toBe(0)
+    expect(parentWindow.listenerCount('closed')).toBe(0)
   })
 
   it('logs instead of rejecting if Electron cannot show the dialog', async () => {

--- a/src/main/runtime/runtime-rpc-startup-failure.test.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.test.ts
@@ -76,6 +76,15 @@ describe('runtime RPC startup failure reporting', () => {
     expect(classifyRuntimeRpcStartFailure(error)).toBe('storage_unavailable')
   })
 
+  it('walks past an unmapped wrapper code to the mapped cause', () => {
+    const error = Object.assign(new Error('failed to publish orca-runtime.json'), {
+      code: 'ERR_PUBLISH_FAILED',
+      cause: Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    })
+
+    expect(classifyRuntimeRpcStartFailure(error)).toBe('permission_denied')
+  })
+
   it('survives a self-referential cause chain', () => {
     const error: Error & { cause?: unknown } = new Error('cyclic')
     error.cause = error

--- a/src/main/runtime/runtime-rpc-startup-failure.test.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.test.ts
@@ -13,11 +13,17 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('../i18n/main-i18n', () => ({
+  // Why: substitute every supplied placeholder, not just {{cause}} — a mock that ignores one
+  // would leave a literal {{...}} in the detail and hide it from every assertion below.
   translateMain: (
     _key: string,
     fallback: string,
     options?: Readonly<Record<string, string>>
-  ): string => fallback.replace('{{cause}}', options?.cause ?? '')
+  ): string =>
+    Object.entries(options ?? {}).reduce(
+      (text, [name, value]) => text.replaceAll(`{{${name}}}`, value),
+      fallback
+    )
 }))
 
 vi.mock('../telemetry/client', () => ({
@@ -137,6 +143,33 @@ describe('runtime RPC startup failure reporting', () => {
         )
       })
     )
+  })
+
+  // Why: a bare "restart" is only true for address_in_use — the other classes need the user to
+  // change something, so each must reach the dialog with its own remediation.
+  it.each([
+    ['EACCES', "Check permissions on Orca's data folder"],
+    ['EPERM', "Check permissions on Orca's data folder"],
+    ['ENOSPC', 'Your disk may be full or read-only'],
+    ['EROFS', 'Your disk may be full or read-only'],
+    ['ENOENT', "Orca's data folder may be missing or moved"],
+    ['EADDRINUSE', 'Another process may be holding the port']
+  ] as const)('guides the user on how to fix %s', async (code, guidance) => {
+    const error = Object.assign(new Error('metadata write failed'), { code })
+
+    await showRuntimeRpcStartupFailureDialog(createParentWindow(), error)
+
+    const detail = showMessageBoxMock.mock.calls[0]?.[1]?.detail as string
+    expect(detail).toContain(guidance)
+    expect(detail).not.toContain('{{')
+  })
+
+  it('falls back to a plain restart when the cause is unrecognised', async () => {
+    await showRuntimeRpcStartupFailureDialog(createParentWindow(), new Error('mystery'))
+
+    const detail = showMessageBoxMock.mock.calls[0]?.[1]?.detail as string
+    expect(detail).toContain('Restart Orca to try again.')
+    expect(detail).not.toContain("Check permissions on Orca's data folder")
   })
 
   it('truncates a runaway cause instead of pasting it whole into the dialog', async () => {

--- a/src/main/runtime/runtime-rpc-startup-failure.test.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.test.ts
@@ -65,6 +65,7 @@ describe('runtime RPC startup failure reporting', () => {
     ['EADDRINUSE', 'address_in_use'],
     ['ENOSPC', 'storage_unavailable'],
     ['EROFS', 'storage_unavailable'],
+    ['EINVAL', 'invalid_path'],
     ['ENOENT', 'invalid_path'],
     ['ENAMETOOLONG', 'invalid_path'],
     ['unexpected', 'unknown']
@@ -152,7 +153,9 @@ describe('runtime RPC startup failure reporting', () => {
     ['EPERM', "Check permissions on Orca's data folder"],
     ['ENOSPC', 'Your disk may be full or read-only'],
     ['EROFS', 'Your disk may be full or read-only'],
-    ['ENOENT', "Orca's data folder may be missing or moved"],
+    ['EINVAL', 'at a path that is too long'],
+    ['ENAMETOOLONG', 'at a path that is too long'],
+    ['ENOENT', "Orca's data folder may be missing"],
     ['EADDRINUSE', 'Another process may be holding the port']
   ] as const)('guides the user on how to fix %s', async (code, guidance) => {
     const error = Object.assign(new Error('metadata write failed'), { code })

--- a/src/main/runtime/runtime-rpc-startup-failure.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.ts
@@ -125,8 +125,11 @@ export function recordRuntimeRpcStartFailure(error: unknown): void {
 }
 
 function waitForWindowToShow(parentWindow: BrowserWindow): Promise<boolean> {
+  if (parentWindow.isDestroyed()) {
+    return Promise.resolve(false)
+  }
   const parentWebContents = parentWindow.webContents
-  if (parentWindow.isDestroyed() || parentWebContents.isDestroyed()) {
+  if (parentWebContents.isDestroyed()) {
     return Promise.resolve(false)
   }
   if (parentWindow.isVisible()) {

--- a/src/main/runtime/runtime-rpc-startup-failure.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.ts
@@ -25,9 +25,13 @@ function getErrorCode(error: unknown, seen = new Set<object>()): string | null {
     return null
   }
   seen.add(error)
+  // Why: only a mapped code ends the walk — an unmapped wrapper code would otherwise mask a nested EACCES/ENOSPC.
   const code = 'code' in error ? error.code : undefined
   if (typeof code === 'string') {
-    return code.toUpperCase()
+    const normalizedCode = code.toUpperCase()
+    if (ERROR_CLASS_BY_CODE[normalizedCode]) {
+      return normalizedCode
+    }
   }
   return 'cause' in error ? getErrorCode(error.cause, seen) : null
 }

--- a/src/main/runtime/runtime-rpc-startup-failure.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.ts
@@ -1,0 +1,121 @@
+import { dialog, type BrowserWindow, type MessageBoxOptions } from 'electron'
+
+import type { RuntimeRpcStartErrorClass } from '../../shared/telemetry-events'
+import { translateMain } from '../i18n/main-i18n'
+import { track } from '../telemetry/client'
+
+const MAX_VISIBLE_CAUSE_LENGTH = 500
+
+const ERROR_CLASS_BY_CODE: Readonly<Record<string, RuntimeRpcStartErrorClass>> = {
+  EACCES: 'permission_denied',
+  EPERM: 'permission_denied',
+  EADDRINUSE: 'address_in_use',
+  EDQUOT: 'storage_unavailable',
+  EIO: 'storage_unavailable',
+  ENOSPC: 'storage_unavailable',
+  EROFS: 'storage_unavailable',
+  EINVAL: 'invalid_path',
+  ENAMETOOLONG: 'invalid_path',
+  ENOENT: 'invalid_path',
+  ENOTDIR: 'invalid_path'
+}
+
+function getErrorCode(error: unknown, seen = new Set<object>()): string | null {
+  if (typeof error !== 'object' || error === null || seen.has(error)) {
+    return null
+  }
+  seen.add(error)
+  const code = 'code' in error ? error.code : undefined
+  if (typeof code === 'string') {
+    return code.toUpperCase()
+  }
+  return 'cause' in error ? getErrorCode(error.cause, seen) : null
+}
+
+export function classifyRuntimeRpcStartFailure(error: unknown): RuntimeRpcStartErrorClass {
+  const code = getErrorCode(error)
+  return (code && ERROR_CLASS_BY_CODE[code]) || 'unknown'
+}
+
+function describeRuntimeRpcStartFailure(error: unknown): string {
+  const raw =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : translateMain(
+            'runtimeRpc.startupFailure.unknownCause',
+            'No additional error details were available.'
+          )
+  const normalized =
+    raw.trim() ||
+    translateMain(
+      'runtimeRpc.startupFailure.unknownCause',
+      'No additional error details were available.'
+    )
+  return normalized.length <= MAX_VISIBLE_CAUSE_LENGTH
+    ? normalized
+    : `${normalized.slice(0, MAX_VISIBLE_CAUSE_LENGTH - 1)}…`
+}
+
+function createRuntimeRpcStartupFailureDialogOptions(error: unknown): MessageBoxOptions {
+  const cause = describeRuntimeRpcStartFailure(error)
+  return {
+    type: 'error',
+    buttons: [translateMain('runtimeRpc.startupFailure.continueButton', 'Continue without CLI')],
+    defaultId: 0,
+    cancelId: 0,
+    noLink: true,
+    title: translateMain('runtimeRpc.startupFailure.title', 'Orca CLI unavailable'),
+    message: translateMain(
+      'runtimeRpc.startupFailure.message',
+      "Orca couldn't start its local command transport."
+    ),
+    detail: translateMain(
+      'runtimeRpc.startupFailure.detail',
+      'Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}',
+      { cause }
+    )
+  }
+}
+
+export function recordRuntimeRpcStartFailure(error: unknown): void {
+  console.error('[runtime] Failed to start local RPC transport:', error)
+  track('runtime_rpc_start_failed', {
+    error_class: classifyRuntimeRpcStartFailure(error)
+  })
+}
+
+function waitForWindowToShow(parentWindow: BrowserWindow): Promise<boolean> {
+  if (parentWindow.isDestroyed()) {
+    return Promise.resolve(false)
+  }
+  if (parentWindow.isVisible()) {
+    return Promise.resolve(true)
+  }
+  return new Promise((resolve) => {
+    const settle = (visible: boolean): void => {
+      parentWindow.removeListener('show', onShow)
+      parentWindow.removeListener('closed', onClosed)
+      resolve(visible)
+    }
+    const onShow = (): void => settle(!parentWindow.isDestroyed())
+    const onClosed = (): void => settle(false)
+    parentWindow.once('show', onShow)
+    parentWindow.once('closed', onClosed)
+  })
+}
+
+export async function showRuntimeRpcStartupFailureDialog(
+  parentWindow: BrowserWindow,
+  error: unknown
+): Promise<void> {
+  if (!(await waitForWindowToShow(parentWindow))) {
+    return
+  }
+  try {
+    await dialog.showMessageBox(parentWindow, createRuntimeRpcStartupFailureDialogOptions(error))
+  } catch (dialogError) {
+    console.error('[runtime] Failed to show RPC startup failure dialog:', dialogError)
+  }
+}

--- a/src/main/runtime/runtime-rpc-startup-failure.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.ts
@@ -62,8 +62,37 @@ function describeRuntimeRpcStartFailure(error: unknown): string {
     : `${normalized.slice(0, MAX_VISIBLE_CAUSE_LENGTH - 1)}…`
 }
 
+// Why: a bare "restart" is wrong for every class but address_in_use — perms, full disks and missing
+// dirs all survive a relaunch, so each class names the thing the user actually has to change.
+const GUIDANCE_BY_ERROR_CLASS: Readonly<
+  Record<RuntimeRpcStartErrorClass, { key: string; fallback: string }>
+> = {
+  permission_denied: {
+    key: 'runtimeRpc.startupFailure.guidance.permissionDenied',
+    fallback:
+      "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart."
+  },
+  storage_unavailable: {
+    key: 'runtimeRpc.startupFailure.guidance.storageUnavailable',
+    fallback: 'Your disk may be full or read-only. Free up space, then restart Orca.'
+  },
+  invalid_path: {
+    key: 'runtimeRpc.startupFailure.guidance.invalidPath',
+    fallback: "Orca's data folder may be missing or moved. Restart Orca to recreate it."
+  },
+  address_in_use: {
+    key: 'runtimeRpc.startupFailure.guidance.addressInUse',
+    fallback: 'Another process may be holding the port. Restart Orca to try again.'
+  },
+  unknown: {
+    key: 'runtimeRpc.startupFailure.guidance.unknown',
+    fallback: 'Restart Orca to try again.'
+  }
+}
+
 function createRuntimeRpcStartupFailureDialogOptions(error: unknown): MessageBoxOptions {
   const cause = describeRuntimeRpcStartFailure(error)
+  const { key, fallback } = GUIDANCE_BY_ERROR_CLASS[classifyRuntimeRpcStartFailure(error)]
   return {
     type: 'error',
     buttons: [translateMain('runtimeRpc.startupFailure.continueButton', 'Continue without CLI')],
@@ -77,8 +106,8 @@ function createRuntimeRpcStartupFailureDialogOptions(error: unknown): MessageBox
     ),
     detail: translateMain(
       'runtimeRpc.startupFailure.detail',
-      'Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}',
-      { cause }
+      'Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session.\n\n{{guidance}}\n\nCause: {{cause}}',
+      { cause, guidance: translateMain(key, fallback) }
     )
   }
 }

--- a/src/main/runtime/runtime-rpc-startup-failure.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.ts
@@ -81,9 +81,13 @@ function createRuntimeRpcStartupFailureDialogOptions(error: unknown): MessageBox
 
 export function recordRuntimeRpcStartFailure(error: unknown): void {
   console.error('[runtime] Failed to start local RPC transport:', error)
-  track('runtime_rpc_start_failed', {
-    error_class: classifyRuntimeRpcStartFailure(error)
-  })
+  try {
+    track('runtime_rpc_start_failed', {
+      error_class: classifyRuntimeRpcStartFailure(error)
+    })
+  } catch (telemetryError) {
+    console.error('[runtime] Failed to record RPC startup failure telemetry:', telemetryError)
+  }
 }
 
 function waitForWindowToShow(parentWindow: BrowserWindow): Promise<boolean> {

--- a/src/main/runtime/runtime-rpc-startup-failure.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.ts
@@ -125,7 +125,8 @@ export function recordRuntimeRpcStartFailure(error: unknown): void {
 }
 
 function waitForWindowToShow(parentWindow: BrowserWindow): Promise<boolean> {
-  if (parentWindow.isDestroyed()) {
+  const parentWebContents = parentWindow.webContents
+  if (parentWindow.isDestroyed() || parentWebContents.isDestroyed()) {
     return Promise.resolve(false)
   }
   if (parentWindow.isVisible()) {
@@ -134,13 +135,15 @@ function waitForWindowToShow(parentWindow: BrowserWindow): Promise<boolean> {
   return new Promise((resolve) => {
     const settle = (visible: boolean): void => {
       parentWindow.removeListener('show', onShow)
-      parentWindow.removeListener('closed', onClosed)
+      parentWebContents.removeListener('destroyed', onDestroyed)
       resolve(visible)
     }
-    const onShow = (): void => settle(!parentWindow.isDestroyed())
-    const onClosed = (): void => settle(false)
+    const onShow = (): void =>
+      settle(!parentWindow.isDestroyed() && !parentWebContents.isDestroyed())
+    const onDestroyed = (): void => settle(false)
     parentWindow.once('show', onShow)
-    parentWindow.once('closed', onClosed)
+    // Why: keep this failure-only waiter off the crowded BrowserWindow `closed` event.
+    parentWebContents.once('destroyed', onDestroyed)
   })
 }
 

--- a/src/main/runtime/runtime-rpc-startup-failure.ts
+++ b/src/main/runtime/runtime-rpc-startup-failure.ts
@@ -78,7 +78,8 @@ const GUIDANCE_BY_ERROR_CLASS: Readonly<
   },
   invalid_path: {
     key: 'runtimeRpc.startupFailure.guidance.invalidPath',
-    fallback: "Orca's data folder may be missing or moved. Restart Orca to recreate it."
+    fallback:
+      "Orca's data folder may be missing, moved, or at a path that is too long. Restore it or use a shorter path, then restart Orca."
   },
   address_in_use: {
     key: 'runtimeRpc.startupFailure.guidance.addressInUse',

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -62,7 +62,9 @@ describe('startup ordering', () => {
     expect(reconciliationStart).toBeGreaterThanOrEqual(0)
     expect(serveStart).toBeGreaterThan(reconciliationStart)
     expect(serveEnd).toBeGreaterThan(serveStart)
-    expect(desktopWindowStart).toBeGreaterThan(reconciliationStart)
+    // Why: bound against serveEnd, not reconciliationStart — an earlier openMainWindow() call
+    // would steal this anchor, collapse desktopStartup to '', and pass the negative check below.
+    expect(desktopWindowStart).toBeGreaterThan(serveEnd)
     expect(serveStartup).toContain('await managedWslCliStartupBarrierReady')
     expect(serveStartup).not.toContain('await managedWslCliReconciliationReady')
     expect(serveStartup.indexOf('await managedWslCliStartupBarrierReady')).toBeLessThan(
@@ -81,6 +83,11 @@ describe('startup ordering', () => {
     const readyStart = source.indexOf('await serveReadinessPublisher.publish(')
     const readyEnd = source.indexOf('pairing: pairing.available', readyStart)
     const readyPayload = source.slice(readyStart, readyEnd)
+
+    // Why: unbounded, a renamed pairing key slices to EOF and the status only has to survive
+    // somewhere later in the file — not in the serve-ready payload this test is about.
+    expect(readyStart).toBeGreaterThanOrEqual(0)
+    expect(readyEnd).toBeGreaterThan(readyStart)
     expect(readyPayload).toContain('managedWslCliReconciliation: managedWslCliReconciliationStatus')
 
     expect(source).toContain("managedWslCliReconciliationStatus = 'pending'")

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -8,7 +8,7 @@ describe('startup ordering', () => {
     const attachStart = source.indexOf('attachMainWindowServices(')
     const attachEnd = source.indexOf('rateLimits.attach(window)', attachStart)
     const attachBlock = source.slice(attachStart, attachEnd)
-    const desktopStart = source.indexOf('const [win] = await Promise.all([')
+    const desktopStart = source.indexOf('const [win, runtimeRpcStartResult] = await Promise.all([')
     const desktopEnd = source.indexOf('// Why: the macOS notification permission dialog')
     const desktopStartup = source.slice(desktopStart, desktopEnd)
 
@@ -25,6 +25,13 @@ describe('startup ordering', () => {
 
     expect(windowIndex).toBeGreaterThanOrEqual(0)
     expect(Math.max(rpcStartIndex, legacyRpcStartIndex)).toBeGreaterThanOrEqual(0)
+    expect(desktopStartup).toContain('recordRuntimeRpcStartFailure(error)')
+    expect(desktopStartup).toContain(
+      'void showRuntimeRpcStartupFailureDialog(win, runtimeRpcStartResult.error)'
+    )
+    expect(desktopStartup).not.toContain(
+      "console.error('[runtime] Failed to start local RPC transport:'"
+    )
   })
 
   it('bounds WSL reconciliation before serve RPC while leaving desktop startup independent', () => {

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -8,7 +8,9 @@ describe('startup ordering', () => {
     const attachStart = source.indexOf('attachMainWindowServices(')
     const attachEnd = source.indexOf('rateLimits.attach(window)', attachStart)
     const attachBlock = source.slice(attachStart, attachEnd)
-    const desktopStart = source.indexOf('const [win, runtimeRpcStartResult] = await Promise.all([')
+    // Why: anchor on the destructure head only — the settled-result variable's name is not the
+    // contract, and pinning it turns a rename into a cryptic `expected -1` failure here.
+    const desktopStart = source.indexOf('const [win')
     const desktopEnd = source.indexOf('// Why: the macOS notification permission dialog')
     const desktopStartup = source.slice(desktopStart, desktopEnd)
 
@@ -25,10 +27,10 @@ describe('startup ordering', () => {
 
     expect(windowIndex).toBeGreaterThanOrEqual(0)
     expect(Math.max(rpcStartIndex, legacyRpcStartIndex)).toBeGreaterThanOrEqual(0)
-    expect(desktopStartup).toContain('recordRuntimeRpcStartFailure(error)')
-    expect(desktopStartup).toContain(
-      'void showRuntimeRpcStartupFailureDialog(win, runtimeRpcStartResult.error)'
-    )
+    expect(desktopStartup).toContain('recordRuntimeRpcStartFailure(')
+    // Why: `void`, not `await` — awaiting the dialog would park the rest of startup behind a modal.
+    expect(desktopStartup).toMatch(/void showRuntimeRpcStartupFailureDialog\(\s*win,/)
+    // Why (#11025): a bare console.error here is exactly what left the CLI dead but the app healthy.
     expect(desktopStartup).not.toContain(
       "console.error('[runtime] Failed to start local RPC transport:'"
     )

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -11,8 +11,13 @@ describe('startup ordering', () => {
     // Why: anchor on the destructure head only — the settled-result variable's name is not the
     // contract, and pinning it turns a rename into a cryptic `expected -1` failure here.
     const desktopStart = source.indexOf('const [win')
-    const desktopEnd = source.indexOf('// Why: the macOS notification permission dialog')
+    // Why: anchor on code, not a comment — the previous comment anchor was silently reworded, so
+    // this was -1 and sliced to EOF, letting the assertions below pass against never-run code.
+    const desktopEnd = source.indexOf("win.once('show'", desktopStart)
     const desktopStartup = source.slice(desktopStart, desktopEnd)
+
+    expect(desktopStart).toBeGreaterThanOrEqual(0)
+    expect(desktopEnd).toBeGreaterThan(desktopStart)
 
     expect(attachBlock).toContain('awaitLocalPtyStartup: () => localPtyStartupReady')
     expect(attachBlock).toContain(

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -16,6 +16,9 @@ describe('startup ordering', () => {
     const desktopEnd = source.indexOf("win.once('show'", desktopStart)
     const desktopStartup = source.slice(desktopStart, desktopEnd)
 
+    // Why: bound every anchor, not just the desktop pair — an unresolved one slices to EOF.
+    expect(attachStart).toBeGreaterThanOrEqual(0)
+    expect(attachEnd).toBeGreaterThan(attachStart)
     expect(desktopStart).toBeGreaterThanOrEqual(0)
     expect(desktopEnd).toBeGreaterThan(desktopStart)
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14278,5 +14278,14 @@
     "sidebar": {
       "label": "Agent Dashboard"
     }
+  },
+  "runtimeRpc": {
+    "startupFailure": {
+      "unknownCause": "No additional error details were available.",
+      "continueButton": "Continue without CLI",
+      "title": "Orca CLI unavailable",
+      "message": "Orca couldn't start its local command transport.",
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14285,7 +14285,14 @@
       "continueButton": "Continue without CLI",
       "title": "Orca CLI unavailable",
       "message": "Orca couldn't start its local command transport.",
-      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session.\n\n{{guidance}}\n\nCause: {{cause}}",
+      "guidance": {
+        "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
+        "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
+        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
+        "unknown": "Restart Orca to try again."
+      }
     }
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14289,7 +14289,7 @@
       "guidance": {
         "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
         "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
-        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "invalidPath": "Orca's data folder may be missing, moved, or at a path that is too long. Restore it or use a shorter path, then restart Orca.",
         "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
         "unknown": "Restart Orca to try again."
       }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14285,7 +14285,14 @@
       "continueButton": "Continue without CLI",
       "title": "Orca CLI unavailable",
       "message": "Orca couldn't start its local command transport.",
-      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session.\n\n{{guidance}}\n\nCause: {{cause}}",
+      "guidance": {
+        "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
+        "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
+        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
+        "unknown": "Restart Orca to try again."
+      }
     }
   }
 }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14289,7 +14289,7 @@
       "guidance": {
         "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
         "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
-        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "invalidPath": "Orca's data folder may be missing, moved, or at a path that is too long. Restore it or use a shorter path, then restart Orca.",
         "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
         "unknown": "Restart Orca to try again."
       }

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14278,5 +14278,14 @@
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
     }
+  },
+  "runtimeRpc": {
+    "startupFailure": {
+      "unknownCause": "No additional error details were available.",
+      "continueButton": "Continue without CLI",
+      "title": "Orca CLI unavailable",
+      "message": "Orca couldn't start its local command transport.",
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14285,7 +14285,14 @@
       "continueButton": "Continue without CLI",
       "title": "Orca CLI unavailable",
       "message": "Orca couldn't start its local command transport.",
-      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session.\n\n{{guidance}}\n\nCause: {{cause}}",
+      "guidance": {
+        "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
+        "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
+        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
+        "unknown": "Restart Orca to try again."
+      }
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14289,7 +14289,7 @@
       "guidance": {
         "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
         "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
-        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "invalidPath": "Orca's data folder may be missing, moved, or at a path that is too long. Restore it or use a shorter path, then restart Orca.",
         "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
         "unknown": "Restart Orca to try again."
       }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14278,5 +14278,14 @@
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
     }
+  },
+  "runtimeRpc": {
+    "startupFailure": {
+      "unknownCause": "No additional error details were available.",
+      "continueButton": "Continue without CLI",
+      "title": "Orca CLI unavailable",
+      "message": "Orca couldn't start its local command transport.",
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14285,7 +14285,14 @@
       "continueButton": "Continue without CLI",
       "title": "Orca CLI unavailable",
       "message": "Orca couldn't start its local command transport.",
-      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session.\n\n{{guidance}}\n\nCause: {{cause}}",
+      "guidance": {
+        "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
+        "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
+        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
+        "unknown": "Restart Orca to try again."
+      }
     }
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14289,7 +14289,7 @@
       "guidance": {
         "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
         "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
-        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "invalidPath": "Orca's data folder may be missing, moved, or at a path that is too long. Restore it or use a shorter path, then restart Orca.",
         "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
         "unknown": "Restart Orca to try again."
       }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14278,5 +14278,14 @@
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
     }
+  },
+  "runtimeRpc": {
+    "startupFailure": {
+      "unknownCause": "No additional error details were available.",
+      "continueButton": "Continue without CLI",
+      "title": "Orca CLI unavailable",
+      "message": "Orca couldn't start its local command transport.",
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14285,7 +14285,14 @@
       "continueButton": "Continue without CLI",
       "title": "Orca CLI unavailable",
       "message": "Orca couldn't start its local command transport.",
-      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session.\n\n{{guidance}}\n\nCause: {{cause}}",
+      "guidance": {
+        "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
+        "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
+        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
+        "unknown": "Restart Orca to try again."
+      }
     }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14289,7 +14289,7 @@
       "guidance": {
         "permissionDenied": "Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart.",
         "storageUnavailable": "Your disk may be full or read-only. Free up space, then restart Orca.",
-        "invalidPath": "Orca's data folder may be missing or moved. Restart Orca to recreate it.",
+        "invalidPath": "Orca's data folder may be missing, moved, or at a path that is too long. Restore it or use a shorter path, then restart Orca.",
         "addressInUse": "Another process may be holding the port. Restart Orca to try again.",
         "unknown": "Restart Orca to try again."
       }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14278,5 +14278,14 @@
       "certificateChallengeUnavailable": "This certificate request is no longer available. Retry the page to request a new one.",
       "certificateProceedFailed": "Orca could not approve this certificate request. Retry the page and try again."
     }
+  },
+  "runtimeRpc": {
+    "startupFailure": {
+      "unknownCause": "No additional error details were available.",
+      "continueButton": "Continue without CLI",
+      "title": "Orca CLI unavailable",
+      "message": "Orca couldn't start its local command transport.",
+      "detail": "Orca will continue to work, but commands such as orca status, orca terminal, and orchestration are unavailable for this session. Restart Orca to try again.\n\nCause: {{cause}}"
+    }
   }
 }

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -371,6 +371,20 @@ const agentErrorSchema = z
 // Why: daemon start-failure signal (fleet-wide outage like v1.4.129-rc.1); enum-only so raw stderr never reaches the wire.
 const daemonStartFailedSchema = z.object({ error_class: errorClassSchema }).strict()
 
+export const runtimeRpcStartErrorClassSchema = z.enum([
+  'permission_denied',
+  'address_in_use',
+  'storage_unavailable',
+  'invalid_path',
+  'unknown'
+])
+export type RuntimeRpcStartErrorClass = z.infer<typeof runtimeRpcStartErrorClassSchema>
+
+// Why: runtime discovery failures can contain user paths; keep telemetry to closed filesystem/socket categories.
+const runtimeRpcStartFailedSchema = z
+  .object({ error_class: runtimeRpcStartErrorClassSchema })
+  .strict()
+
 // Why: daemon replace/retire lifecycle signal — issue #7936 was undiagnosable without asking a user for daemon.log.
 // Enum-only + bucketed session count so no paths, raw versions, or exact counts reach the wire.
 // The union keeps each reason pinned to its transition, so a death can't be reported as a replace.
@@ -1328,6 +1342,7 @@ export const eventSchemas = {
 
   daemon_start_failed: daemonStartFailedSchema,
   daemon_lifecycle: daemonLifecycleSchema,
+  runtime_rpc_start_failed: runtimeRpcStartFailedSchema,
 
   codex_trust_grant: codexTrustGrantSchema,
 


### PR DESCRIPTION
## Summary

- report desktop runtime RPC startup failures with privacy-safe telemetry categories
- show a localized native dialog after the main window becomes visible, naming the CLI impact, the local cause,
  and cause-specific guidance on what to fix
- preserve parallel, non-blocking desktop startup and add regression coverage for reporting and startup wiring

## Live QA

Reproduced the real failure end to end on macOS against an isolated dev profile, with **no product code modified**. The injection makes `orca-runtime.json` immutable (`chflags uchg`), so `writeSecureFile()`'s `renameSync` fails with `EPERM` — the exact "single failed write to `orca-runtime.json`" the issue describes:

```
[runtime] Failed to start local RPC transport: Error: EPERM: operation not permitted, rename '.../orca-runtime.json.<pid>.<ts>.tmp' -> '.../orca-runtime.json'
    at OrcaRuntimeRpcServer.writeMetadata (...)
    at OrcaRuntimeRpcServer.start (...)
    at async Promise.all (index 1)
```

**The failure is total, and silent without this PR.** `orca-runtime.json` was never published, and the CLI is dead against a live, healthy-looking app — the same symptom as #7848:

```json
{ "app": { "running": false }, "runtime": { "state": "stale_bootstrap", "reachable": false } }
```

**1. Dialog over the main window** — appears only after the window is visible, so it is never orphaned behind a hidden window.

![01-orca-window-with-dialog.png](https://github.com/user-attachments/assets/50df3ffa-946b-424e-a7bd-387214578700)

**2. Close-up** — i18n resolves (real copy, not raw keys), and both `{{cause}}` and `{{guidance}}` interpolate rather than printing placeholders. The guidance line is chosen from the same `error_class` the telemetry reports, so advice and telemetry cannot drift.

![02-dialog-closeup.png](https://github.com/user-attachments/assets/6f8b14d9-8f61-4dba-813a-186c05f5150a)

**3. After "Continue without CLI"** — the app stays fully usable, matching the copy's promise.

![03-app-continues-after-dismiss.png](https://github.com/user-attachments/assets/19f4543f-73ca-468b-8ebc-5b7f225a1860)

### Guidance copy

A bare "Restart Orca to try again" is only correct for `address_in_use` — permissions, a full or read-only disk, and a missing data folder all survive a relaunch. Each class now names the thing the user has to change:

| `error_class` | guidance |
| --- | --- |
| `permission_denied` | Orca couldn't write its runtime file. Check permissions on Orca's data folder, then restart. |
| `storage_unavailable` | Your disk may be full or read-only. Free up space, then restart Orca. |
| `invalid_path` | Orca's data folder may be missing, moved, or at a path that is too long. Restore it or use a shorter path, then restart Orca. |
| `address_in_use` | Another process may be holding the port. Restart Orca to try again. |
| `unknown` | Restart Orca to try again. |

Mutation-checked: forcing every class to the generic line fails 6 tests, dropping the `{{guidance}}` substitution fails 7, and swapping one class's copy for another's fails 2 — so the per-class mapping is pinned, not just "some guidance is present".

Also confirmed: `recordRuntimeRpcStartFailure` ran (`EPERM` → `permission_denied`), with zero dialog-show and zero telemetry-record errors logged.

Note: macOS ignores `title` on message boxes, so the "Orca CLI unavailable" headline does not render there — `message` + `detail` carry the impact and cause, so nothing essential is lost.

Not covered: Windows/Linux were not exercised (both additionally have the 10s `initialRevealFallbackTimer`, so reveal is at least as likely there).


## Final Electron validation

Re-ran the real immutable-`orca-runtime.json` failure in this exact worktree through Electron/CDP and the native macOS accessibility surface. The captures below show the full product context rather than a recreated fixture.

**Native dialog over the usable app** — the CLI impact, permission-specific remediation, raw local cause, and “Continue without CLI” action all render without clipping or overlap.

![Final Electron validation — native RPC startup failure dialog](https://github.com/user-attachments/assets/acb7489a-9bcf-455f-92c0-5b81a6a41912)

**After “Continue without CLI”** — the native sheet closes and the app remains interactive; Settings navigation was exercised immediately afterward.

![Final Electron validation — app remains usable after dismissing dialog](https://github.com/user-attachments/assets/2a6b0f9a-01d1-431e-a0d3-dba6d981e02a)

The Electron run also exposed and then verified the fixes for a false `MaxListenersExceededWarning` on the failure path and destroyed-window access ordering. At final head `932556687b`, the same real failure showed the dialog with no listener warning or unhandled rejection.

## Verification

- `vitest run src/main/runtime/runtime-rpc-startup-failure.test.ts src/main/startup/desktop-startup-ordering.test.ts` — 36 tests passed
- both suites mutation-checked: relocating the dialog call off the startup path, and reverting to the bare `console.error`, each fail the startup-ordering test
- `pnpm run typecheck:node`
- `pnpm run lint`
- `node config/scripts/check-changed-code-quality.mjs -- origin/main`

Closes #11025

