### PR TITLE
fix(terminal): detach PTY strings retained from large chunks

### DIFF
--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -67,6 +67,16 @@ describe('OSC title extraction', () => {
     expect(extractAllOscTitles(data)).toEqual([extracted])
   })
 
+  it('preserves exact UTF-16 code units when detaching titles', () => {
+    const title = `A\uD800B\uDC00\uD83D\uDE00`
+    const extracted = extractLastOscTitle(`\x1b]0;${title}\x07`)
+
+    expect(extracted).toBe(title)
+    expect(Array.from(extracted ?? '', (character) => character.codePointAt(0))).toEqual(
+      Array.from(title, (character) => character.codePointAt(0))
+    )
+  })
+
   it('retains only the newest titles when one chunk contains limit +1', () => {
     const data = Array.from(
       { length: MAX_OSC_TITLES_PER_CHUNK + 1 },
@@ -78,6 +88,16 @@ describe('OSC title extraction', () => {
     expect(titles).toHaveLength(MAX_OSC_TITLES_PER_CHUNK)
     expect(titles[0]).toBe('title-1')
     expect(titles.at(-1)).toBe(`title-${MAX_OSC_TITLES_PER_CHUNK}`)
+  })
+
+  it('extracts titles unchanged from a large surrounding chunk', () => {
+    // Retention itself is covered by detached-string.test.ts; this pins the
+    // extraction values across the detaching copy.
+    const padding = 'x'.repeat(64 * 1024)
+    const data = `${padding}\x1b]0;detached-title\x07${padding}`
+
+    expect(extractAllOscTitles(data)).toEqual(['detached-title'])
+    expect(extractLastOscTitle(data)).toBe('detached-title')
   })
 })
 

--- a/src/shared/agent-status-field-normalization.ts
+++ b/src/shared/agent-status-field-normalization.ts
@@ -4,6 +4,7 @@
 // truncate without splitting surrogate pairs. Extracted from
 // agent-status-types.ts, which owns the payload shapes and per-field caps.
 
+import { detachString } from './detached-string'
 import {
   compactDispatchPromptForStatus,
   isOrcaDispatchStatusPrompt
@@ -190,7 +191,13 @@ export function normalizeInteractivePromptField(
     return undefined
   }
   const truncated = truncatePreservingSurrogates(value, maxLength)
-  return truncated.length > 0 ? truncated : undefined
+  if (truncated.length === 0) {
+    return undefined
+  }
+  // Why: this value is cached in the store, and V8 slices retain their parent.
+  // Detach unconditionally — an under-cap prompt can still arrive as a slice of
+  // a much larger hook payload, which pass-through would pin indefinitely.
+  return detachString(truncated)
 }
 
 export function normalizeOptionalField(value: unknown, maxLength: number): string | undefined {

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -241,6 +241,31 @@ Fix dispatch fallback preview for normalized status prompts`
     expect(AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH).toBe(16000)
   })
 
+  it('detaches capped interactivePrompt JSON without changing its code units', () => {
+    const promptJson = JSON.stringify({ questions: [{ question: 'Choose', options: ['a', 'b'] }] })
+    const interactivePrompt = `${promptJson}${' '.repeat(
+      AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH - promptJson.length + 500
+    )}`
+    const result = parseAgentStatusPayload(JSON.stringify({ state: 'waiting', interactivePrompt }))
+
+    expect(result!.interactivePrompt).toBe(
+      interactivePrompt.slice(0, AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH)
+    )
+    expect(result!.interactivePrompt).toHaveLength(AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH)
+    // The detaching copy must not disturb the embedded JSON clients re-parse.
+    expect(JSON.parse(result!.interactivePrompt!)).toEqual(JSON.parse(promptJson))
+  })
+
+  it('drops a cap-bound high surrogate from a detached interactivePrompt', () => {
+    const interactivePrompt = `${'x'.repeat(AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH - 1)}\u{1f680}${' '.repeat(500)}`
+    const result = parseAgentStatusPayload(JSON.stringify({ state: 'waiting', interactivePrompt }))
+
+    expect(result!.interactivePrompt).toBe(
+      'x'.repeat(AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH - 1)
+    )
+    expect(result!.interactivePrompt).toHaveLength(AGENT_STATUS_INTERACTIVE_PROMPT_MAX_LENGTH - 1)
+  })
+
   it('leaves interactivePrompt undefined when absent or non-string', () => {
     expect(parseAgentStatusPayload('{"state":"working"}')!.interactivePrompt).toBeUndefined()
     expect(

--- a/src/shared/detached-string.test.ts
+++ b/src/shared/detached-string.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { detachString } from './detached-string'
+
+describe('detachString', () => {
+  it('returns code-unit-identical strings', () => {
+    for (const value of [
+      '',
+      'a',
+      'plain title',
+      '⠋ Claude working',
+      '😀 done',
+      'x'.repeat(10_000)
+    ]) {
+      expect(detachString(value)).toBe(value)
+    }
+  })
+
+  it('preserves lone surrogates and unpaired astral halves', () => {
+    expect(detachString('\uD800')).toBe('\uD800')
+    expect(detachString('\uDC00\uD800')).toBe('\uDC00\uD800')
+    expect(detachString('A\uD800B\uDC00😀')).toBe('A\uD800B\uDC00😀')
+  })
+
+  it('handles values far past the argument-spread limit', () => {
+    const huge = 'z'.repeat(500_000)
+    expect(detachString(huge)).toBe(huge)
+  })
+
+  it('releases the source string it was copied from', () => {
+    // Why: this is the OOM. A sliced substring keeps its parent alive, so a
+    // 20-char title pins the whole multi-megabyte PTY chunk it came from.
+    const gc = (globalThis as { gc?: () => void }).gc
+    if (!gc) {
+      return
+    }
+    const megabytes = 8
+    // Why a nested frame: the source of the final iteration stays reachable from
+    // the building frame's stack slots, which would bill one chunk to the
+    // detached case regardless of correctness. Let that frame exit before we GC.
+    const build = (make: (source: string) => string, kept: string[]): void => {
+      for (let i = 0; i < 16; i += 1) {
+        const source = `${'x'.repeat(megabytes * 1024 * 1024)}retained-title-${i}`
+        kept.push(make(source))
+      }
+    }
+    const sample = (make: (source: string) => string): number => {
+      for (let i = 0; i < 4; i += 1) {
+        gc()
+      }
+      const before = process.memoryUsage().heapUsed
+      const kept: string[] = []
+      build(make, kept)
+      for (let i = 0; i < 4; i += 1) {
+        gc()
+      }
+      const retainedBytes = process.memoryUsage().heapUsed - before
+      expect(kept).toHaveLength(16)
+      return retainedBytes / (1024 * 1024)
+    }
+
+    const sliced = sample((source) => source.slice(source.lastIndexOf('retained-title-')))
+    const detached = sample((source) =>
+      detachString(source.slice(source.lastIndexOf('retained-title-')))
+    )
+    // Why: the over-cap title path detaches a prefix+suffix concatenation, which
+    // is a rope over two slices rather than a single slice.
+    const detachedRope = sample((source) =>
+      detachString(`${source.slice(0, 8)}${source.slice(source.lastIndexOf('retained-title-'))}`)
+    )
+
+    expect(sliced).toBeGreaterThan(16 * megabytes * 0.5)
+    expect(detached).toBeLessThan(1)
+    expect(detachedRope).toBeLessThan(1)
+  })
+})

--- a/src/shared/detached-string.ts
+++ b/src/shared/detached-string.ts
@@ -1,0 +1,21 @@
+// Why: `String.prototype.slice` yields a V8 sliced string that keeps its parent
+// alive. A 20-char title sliced from an 8 MiB PTY chunk therefore retains all
+// 8 MiB for as long as the title is cached, which is how a handful of idle agent
+// panes exhausted the renderer heap. Copying the code units breaks that edge.
+
+/**
+ * Copy `value` into a string that shares no backing store with its source, so
+ * the source becomes collectable. Code-unit identical to the input, including
+ * lone surrogates. Safe for any length.
+ */
+export function detachString(value: string): string {
+  if (value.length === 0) {
+    return ''
+  }
+  // Why this shape: prepending forces V8 to flatten into a freshly allocated
+  // sequential string, then slicing that owned result off by one yields a copy
+  // holding no reference to `value`. Uint16Array/fromCharCode round-trips also
+  // detach but run ~45x slower on dense PTY frames; `padEnd`/`repeat(1)` are
+  // no-ops V8 returns unchanged, so they leave the value sliced.
+  return ` ${value}`.slice(1)
+}

--- a/src/shared/osc-title-extraction.ts
+++ b/src/shared/osc-title-extraction.ts
@@ -1,3 +1,5 @@
+import { detachString } from './detached-string'
+
 const ESC_CODE_UNIT = 0x1b
 const BEL_CODE_UNIT = 0x07
 const RIGHT_BRACKET_CODE_UNIT = 0x5d
@@ -8,9 +10,14 @@ export const MAX_OSC_TITLE_CHARS = 1024
 export const MAX_OSC_TITLES_PER_CHUNK = 4096
 
 type OscTitleParseResult =
-  | { kind: 'title'; title: string; nextIndex: number }
+  | { kind: 'title'; titleStart: number; titleEnd: number; nextIndex: number }
   | { kind: 'invalid'; nextIndex: number }
   | { kind: 'incomplete' }
+
+type OscTitleBounds = {
+  titleStart: number
+  titleEnd: number
+}
 
 function isOscIntroducerAt(data: string, index: number): boolean {
   return (
@@ -36,7 +43,8 @@ function parseOscTitleAt(data: string, index: number): OscTitleParseResult {
     if (code === BEL_CODE_UNIT) {
       return {
         kind: 'title',
-        title: readBoundedOscTitle(data, titleStart, cursor),
+        titleStart,
+        titleEnd: cursor,
         nextIndex: cursor + 1
       }
     }
@@ -46,7 +54,8 @@ function parseOscTitleAt(data: string, index: number): OscTitleParseResult {
     if (data.charCodeAt(cursor + 1) === BACKSLASH_CODE_UNIT) {
       return {
         kind: 'title',
-        title: readBoundedOscTitle(data, titleStart, cursor),
+        titleStart,
+        titleEnd: cursor,
         nextIndex: cursor + 2
       }
     }
@@ -58,16 +67,17 @@ function parseOscTitleAt(data: string, index: number): OscTitleParseResult {
 
 function readBoundedOscTitle(data: string, titleStart: number, titleEnd: number): string {
   // Why: PTY output can contain pasted or remote-controlled OSC titles; keep
-  // downstream title detection bounded while preserving trailing status words.
+  // downstream title detection bounded, and detached from the raw chunk so a
+  // small retained title cannot pin a multi-megabyte PTY frame.
   const length = titleEnd - titleStart
   if (length <= MAX_OSC_TITLE_CHARS) {
-    return data.slice(titleStart, titleEnd)
+    return detachString(data.slice(titleStart, titleEnd))
   }
   const prefixLength = Math.ceil(MAX_OSC_TITLE_CHARS / 2)
   const suffixLength = MAX_OSC_TITLE_CHARS - prefixLength
-  return (
+  return detachString(
     data.slice(titleStart, titleStart + prefixLength) +
-    data.slice(titleEnd - suffixLength, titleEnd)
+      data.slice(titleEnd - suffixLength, titleEnd)
   )
 }
 
@@ -76,7 +86,7 @@ export function extractLastOscTitle(data: string): string | null {
     return null
   }
 
-  let last: string | null = null
+  let last: OscTitleBounds | null = null
   let searchStart = 0
   // Why: raw PTY chunks can include large pasted content. Parse OSC titles
   // directly instead of running a global regex over the whole chunk.
@@ -90,13 +100,13 @@ export function extractLastOscTitle(data: string): string | null {
       break
     }
     if (parsed.kind === 'title') {
-      last = parsed.title
+      last = { titleStart: parsed.titleStart, titleEnd: parsed.titleEnd }
       searchStart = parsed.nextIndex
       continue
     }
     searchStart = parsed.nextIndex
   }
-  return last
+  return last ? readBoundedOscTitle(data, last.titleStart, last.titleEnd) : null
 }
 
 export function extractAllOscTitles(data: string): string[] {
@@ -104,7 +114,7 @@ export function extractAllOscTitles(data: string): string[] {
     return []
   }
 
-  const titles: string[] = []
+  const titles: OscTitleBounds[] = []
   let oldestTitleIndex = 0
   let searchStart = 0
   while (searchStart < data.length) {
@@ -117,10 +127,11 @@ export function extractAllOscTitles(data: string): string[] {
       break
     }
     if (parsed.kind === 'title') {
+      const bounds = { titleStart: parsed.titleStart, titleEnd: parsed.titleEnd }
       if (titles.length < MAX_OSC_TITLES_PER_CHUNK) {
-        titles.push(parsed.title)
+        titles.push(bounds)
       } else {
-        titles[oldestTitleIndex] = parsed.title
+        titles[oldestTitleIndex] = bounds
         oldestTitleIndex = (oldestTitleIndex + 1) % MAX_OSC_TITLES_PER_CHUNK
       }
       searchStart = parsed.nextIndex
@@ -128,7 +139,9 @@ export function extractAllOscTitles(data: string): string[] {
     }
     searchStart = parsed.nextIndex
   }
-  return oldestTitleIndex === 0
-    ? titles
-    : [...titles.slice(oldestTitleIndex), ...titles.slice(0, oldestTitleIndex)]
+  const ordered =
+    oldestTitleIndex === 0
+      ? titles
+      : [...titles.slice(oldestTitleIndex), ...titles.slice(0, oldestTitleIndex)]
+  return ordered.map(({ titleStart, titleEnd }) => readBoundedOscTitle(data, titleStart, titleEnd))
 }


### PR DESCRIPTION
## Summary

Fix renderer OOM report `64975a31-2dcb-49d5-938d-47e4ca0e0167`. The crash is a **V8 sliced-string leak**: `String.prototype.slice` returns a string that references its parent, so a short OSC title parsed out of an 8 MiB PTY frame keeps that entire frame alive for as long as the title is cached.

Crash report: https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1785052699563809

Detaches the two values that outlive their source chunk — OSC titles and the capped `interactivePrompt` — through one shared helper.

## Evidence

Retaining 32 short titles parsed from 32 distinct 8 MiB chunks:

| | retained |
|---|---|
| sliced (before) | **256.0 MiB** |
| detached (after) | **~0 MiB** |

Five long-running agent panes re-emitting titles from large frames walks this into the 3,586 MiB heap limit. The same mechanism applies to `interactivePrompt`, which is cached in the store.

## What changed

- **`src/shared/detached-string.ts`** (new) — one `detachString` primitive.
- **`osc-title-extraction.ts`** — the parser records title *bounds* first and copies only retained titles, so a dense frame does not pay for titles the per-chunk cap discards. Every extracted title is detached.
- **`agent-status-field-normalization.ts`** — `interactivePrompt` is detached **unconditionally**. Detaching only the over-cap case would leave a short prompt sliced out of a large hook payload still pinning it.

No behavior change: same title values, same caps, same call sites. Scope is deliberately limited to the leak.

## Choice of primitive

The obvious `Uint16Array` + `fromCharCode` copy reintroduces a dense-frame regression. Benchmarked (4,096 × 1024-char detaches):

| primitive | p50 | detaches? |
|---|---|---|
| `Uint16Array` + `fromCharCode(...spread)` | 65.23 ms | yes |
| `fromCharCode.apply` | 12.81 ms | yes |
| `JSON.parse(JSON.stringify())` | 3.95 ms | yes |
| `` ` ${v}`.slice(1) `` (chosen) | **1.43 ms** | yes |
| `padEnd` / `repeat(1)` | 0.02 ms | **no** — V8 returns the input unchanged |

End-to-end parse latency, so this is not a perf trade:

| frame | before (sliced) | this PR |
|---|---|---|
| 4,096 titles @1200ch (4.7 MiB) | 3.97 ms p50 | **4.29 ms** p50 |
| 4,096 titles in 8 MiB | 0.30 ms p50 | **0.34 ms** p50 |

The `Uint16Array` version measured 85.43 ms p50 on the first row.

## Risk

The primitive encodes V8 behavior, not spec: prepending forces a flatten into a fresh sequential string, and slicing that owned result off by one yields a copy. Verified empirically, including rope-sourced input from the over-cap title path. The retention test is what protects it; `JSON.parse(JSON.stringify())` is the spec-safe swap at ~2.8× the cost.

## Testing

- **6,448 unit tests pass** across `src/shared` and `terminal-pane`
- Retention test asserts the real property under `--expose-gc`: 128 MiB sliced → <1 MiB detached, covering both slice- and rope-sourced input, plus code-unit fidelity for lone surrogates, astral pairs and 500k-char values
- `typecheck:web` / `:node`; oxlint; oxfmt

## Scope notes

Fixed in the shared parse/normalization path, so local, SSH, remote-runtime, git-worktree and folder-workspace all get it. `extractAllOscTitles` is also main's tracker path (`terminal-output-side-effects.ts`), so both sides are covered without title semantics drifting. No new IPC surface, filesystem behavior, network access, or provider-specific behavior; no visual change.

## Follow-up (not in this PR)

While measuring, I found a separate bug **already on main**, in the deferred side-effect queue added by #10625. `evictOldestPendingSideEffectsIfFull` drops evicted titles on the premise that "titles are last-wins" — but a working→idle *edge* is what mints the agent-completion notification, and evicted entries are older than what remains. Reproduced:

```
working title → completion (idle) → 512+ working titles flood in
onAgentBecameIdle calls: 0        (expected 1)
```

Also worth noting: once titles are detached, that queue costs ~0.35 MiB at 2,048 entries against a 3,586 MiB limit, so its memory rationale is weaker than it looked. Tracked separately so this leak fix can land on its own.

Co-authored with and extracted from the original C1/H2 work by @AmethystLiang.
