### PR TITLE
feat(ssh): add custom target source identity

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -1509,6 +1509,75 @@ describe('Store', () => {
     expect(onDisk?.port).toBe(2222)
   })
 
+  it('round-trips custom SSH sources through a downgrade-safe persisted shape', async () => {
+    const store = await createStore()
+    store.addSshTarget({
+      id: 'ssh-custom-1',
+      label: 'Devbox',
+      host: 'devbox.example.com',
+      port: 22,
+      username: 'dev',
+      source: 'custom',
+      sourceId: ' internal-devboxes '
+    })
+
+    expect(store.getSshTarget('ssh-custom-1')).toMatchObject({
+      source: 'custom',
+      sourceId: 'internal-devboxes'
+    })
+
+    store.flush()
+    const persisted = readDataFile() as { sshTargets?: Record<string, unknown>[] }
+    expect(persisted.sshTargets?.[0]).toMatchObject({
+      source: 'manual',
+      sourceId: 'internal-devboxes'
+    })
+
+    const reloaded = await createStore()
+    expect(reloaded.getSshTarget('ssh-custom-1')).toMatchObject({
+      source: 'custom',
+      sourceId: 'internal-devboxes'
+    })
+  })
+
+  it('degrades malformed and future SSH sources to manual targets', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {},
+      sshTargets: [
+        {
+          id: 'ssh-missing-source-id',
+          label: 'Missing source',
+          host: 'missing.example.com',
+          port: 22,
+          username: 'dev',
+          source: 'custom'
+        },
+        {
+          id: 'ssh-future-source',
+          label: 'Future source',
+          host: 'future.example.com',
+          port: 22,
+          username: 'dev',
+          source: 'inventory-v2',
+          sourceId: 'future-source'
+        }
+      ]
+    })
+
+    const store = await createStore()
+
+    expect(store.getSshTarget('ssh-missing-source-id')?.source).toBe('manual')
+    expect(store.getSshTarget('ssh-future-source')?.source).toBe('manual')
+    expect(store.getSshTarget('ssh-missing-source-id')).not.toHaveProperty('sourceId')
+    expect(store.getSshTarget('ssh-future-source')).not.toHaveProperty('sourceId')
+  })
+
   it('persists only explicit SSH connection reuse opt-outs', async () => {
     const store = await createStore()
     store.addSshTarget({

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -89,6 +89,8 @@ import {
 import { hardenExistingSecureFile } from '../shared/secure-file'
 import {
   LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS,
+  SshTargetSourceIdSchema,
+  SshTargetSourceSchema,
   type RemovedSshTargetTombstone,
   type SshRemotePtyLease,
   type SshTarget
@@ -1108,18 +1110,23 @@ function backfillLegacyAutomationContexts(
   }
 }
 
-type LegacySshTarget = SshTarget & {
+type StoredSshTarget = Omit<SshTarget, 'source' | 'sourceId'> & {
+  source?: unknown
+  sourceId?: unknown
   remoteWorkspaceSyncEnabled?: unknown
   remoteWorkspaceSyncGracePeriodSeconds?: unknown
 }
 
 // Why: old targets predate configHost; default to label-based lookup so imported SSH aliases still resolve via ssh -G.
 function normalizeSshTarget(t: SshTarget): SshTarget {
-  const target = { ...(t as LegacySshTarget) }
+  const storedTarget = { ...(t as StoredSshTarget) }
+  const { source: storedSource, sourceId: storedSourceId, ...target } = storedTarget
   const legacySyncEnabled = target.remoteWorkspaceSyncEnabled
   const currentGracePeriodSeconds = target.relayGracePeriodSeconds
   const legacyGracePeriodSeconds = target.remoteWorkspaceSyncGracePeriodSeconds
   const systemSshConnectionReuse = target.systemSshConnectionReuse
+  const parsedSource = SshTargetSourceSchema.safeParse(storedSource)
+  const parsedSourceId = SshTargetSourceIdSchema.safeParse(storedSourceId)
   // Why: remote sync now follows the SSH relay lifecycle, so retired per-target sync/grace fields are dropped at disk load.
   delete target.remoteWorkspaceSyncEnabled
   delete target.remoteWorkspaceSyncGracePeriodSeconds
@@ -1134,6 +1141,21 @@ function normalizeSshTarget(t: SshTarget): SshTarget {
     ...target,
     configHost: target.configHost ?? target.label ?? target.host
   }
+  if (parsedSource.success) {
+    if (parsedSource.data === 'custom') {
+      normalized.source = parsedSourceId.success ? 'custom' : 'manual'
+    } else if (parsedSource.data === 'manual' && parsedSourceId.success) {
+      // Why: custom sources persist as manual so older builds cannot sync-clobber them.
+      normalized.source = 'custom'
+    } else {
+      normalized.source = parsedSource.data
+    }
+  } else if (storedSource !== undefined) {
+    normalized.source = 'manual'
+  }
+  if (normalized.source === 'custom' && parsedSourceId.success) {
+    normalized.sourceId = parsedSourceId.data
+  }
   // Why: old SSH form persisted 10800 even without a user choice; treat that legacy default as the new implicit default.
   if (
     relayGracePeriodSeconds !== undefined &&
@@ -1145,6 +1167,18 @@ function normalizeSshTarget(t: SshTarget): SshTarget {
     normalized.systemSshConnectionReuse = false
   }
   return normalized
+}
+
+function encodeSshTargetForCompatibility(target: SshTarget): SshTarget {
+  if (target.source !== 'custom') {
+    return target
+  }
+  const parsedSourceId = SshTargetSourceIdSchema.safeParse(target.sourceId)
+  if (!parsedSourceId.success) {
+    const { sourceId: _invalidSourceId, ...rest } = target
+    return { ...rest, source: 'manual' }
+  }
+  return { ...target, source: 'manual', sourceId: parsedSourceId.data }
 }
 
 // Why: strict whitelist rejects unknown/bad-typed keys; returns Partial so partial updates don't clobber valid persisted state.
@@ -3645,6 +3679,7 @@ export class Store {
     // Why: clone before encrypting secrets so in-memory this.state stays plaintext.
     const stateToSave = {
       ...this.getDurableState(),
+      sshTargets: this.state.sshTargets.map(encodeSshTargetForCompatibility),
       settings: {
         ...this.state.settings,
         opencodeSessionCookie: encryptToSentinel(this.state.settings.opencodeSessionCookie),
@@ -6240,13 +6275,24 @@ export class Store {
     if (!target) {
       return null
     }
-    const normalized = normalizeSshTarget({ ...target, ...updates })
+    const next = { ...target, ...updates }
+    if (
+      Object.hasOwn(updates, 'source') &&
+      updates.source !== 'custom' &&
+      !Object.hasOwn(updates, 'sourceId')
+    ) {
+      delete next.sourceId
+    }
+    const normalized = normalizeSshTarget(next)
     Object.assign(target, updates, normalized)
     if (!Object.hasOwn(normalized, 'relayGracePeriodSeconds')) {
       delete target.relayGracePeriodSeconds
     }
     if (!Object.hasOwn(normalized, 'systemSshConnectionReuse')) {
       delete target.systemSshConnectionReuse
+    }
+    if (!Object.hasOwn(normalized, 'sourceId')) {
+      delete target.sourceId
     }
     this.scheduleSave()
     return { ...target }

--- a/src/main/ssh/ssh-connection-store.test.ts
+++ b/src/main/ssh/ssh-connection-store.test.ts
@@ -311,6 +311,29 @@ describe('SshConnectionStore', () => {
       expect(result).toEqual([])
     })
 
+    it('never overwrites a custom-source target that owns the alias', () => {
+      mockStore.addSshTarget({
+        id: 'ssh-custom',
+        label: 'cluster',
+        configHost: 'cluster',
+        host: 'custom.example.com',
+        port: 22,
+        username: 'me',
+        source: 'custom',
+        sourceId: 'internal-devboxes'
+      })
+      loadUserSshConfigMock.mockReturnValue([{ host: 'cluster' }])
+      sshConfigHostsToTargetsMock.mockReturnValue([
+        candidate({ configHost: 'cluster', host: '10.0.0.9', port: 2222, username: 'dev' })
+      ])
+
+      const result = sshStore.importFromSshConfig()
+
+      expect(mockStore.updateSshTarget).not.toHaveBeenCalled()
+      expect(mockStore.addSshTarget).toHaveBeenCalledTimes(1)
+      expect(result).toEqual([])
+    })
+
     it('adopts a legacy unsourced target into config-sync', () => {
       mockStore.addSshTarget({
         id: 'ssh-legacy',

--- a/src/main/ssh/ssh-connection-store.ts
+++ b/src/main/ssh/ssh-connection-store.ts
@@ -137,10 +137,7 @@ export class SshConnectionStore {
     const manualAliases = new Set<string>()
     for (const existing of existingTargets) {
       const alias = existing.configHost ?? existing.label
-      if (
-        existing.source === 'manual' ||
-        (existing.source === undefined && !isLegacyConfigImportTarget(existing))
-      ) {
+      if (!isConfigManagedTarget(existing)) {
         manualAliases.add(alias)
         continue
       }

--- a/src/main/ssh/system-ssh-args.ts
+++ b/src/main/ssh/system-ssh-args.ts
@@ -167,11 +167,8 @@ function shouldUseOpenSshConfigHost(target: SshTarget): boolean {
 }
 
 export function isOpenSshConfigBackedTarget(target: SshTarget): boolean {
-  if (target.source === 'ssh-config') {
-    return true
-  }
-  if (target.source === 'manual') {
-    return false
+  if (target.source !== undefined) {
+    return target.source === 'ssh-config'
   }
   // Why: legacy imported aliases have a distinct configHost; manual targets
   // historically stored configHost=host and still need explicit -p/-i args.

--- a/src/main/ssh/vscode-ssh-authority.test.ts
+++ b/src/main/ssh/vscode-ssh-authority.test.ts
@@ -34,6 +34,19 @@ describe('resolveVsCodeSshAuthority', () => {
     ).toEqual({ ok: true, authority: 'ada@builder.example.com' })
   })
 
+  it('treats custom-source targets as explicit connection details', () => {
+    expect(
+      resolveVsCodeSshAuthority(
+        createTarget({
+          source: 'custom',
+          sourceId: 'internal-devboxes',
+          configHost: 'inventory-alias',
+          host: 'builder.example.com'
+        })
+      )
+    ).toEqual({ ok: true, authority: 'ada@builder.example.com' })
+  })
+
   it.each(['', '   '])(
     'uses a host-only authority for a manual port-22 target without a username',
     (username) => {

--- a/src/shared/ssh-types.test.ts
+++ b/src/shared/ssh-types.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import type { SshTarget, SshConnectionState, SshConnectionStatus } from './ssh-types'
+import {
+  SshTargetSourceIdSchema,
+  SshTargetSourceSchema,
+  type SshTarget,
+  type SshConnectionState,
+  type SshConnectionStatus
+} from './ssh-types'
 
 describe('SSH types', () => {
   it('SshTarget has required fields', () => {
@@ -12,6 +18,13 @@ describe('SSH types', () => {
     }
     expect(target.id).toBe('target-1')
     expect(target.host).toBe('myserver.com')
+  })
+
+  it('validates custom source identity', () => {
+    expect(SshTargetSourceSchema.parse('custom')).toBe('custom')
+    expect(SshTargetSourceIdSchema.parse(' internal-devboxes ')).toBe('internal-devboxes')
+    expect(SshTargetSourceSchema.safeParse('remote').success).toBe(false)
+    expect(SshTargetSourceIdSchema.safeParse('  ').success).toBe(false)
   })
 
   it('SshConnectionStatus covers all expected states', () => {

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod'
+
 // ─── SSH Connection Types ───────────────────────────────────────────
 
 export const MIN_SSH_RELAY_GRACE_PERIOD_SECONDS = 60
@@ -6,6 +8,10 @@ export const LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS = 3 * 60 * 60
 export const DEFAULT_BOUNDED_SSH_RELAY_GRACE_PERIOD_SECONDS = 24 * 60 * 60
 export const DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS = 0
 export const SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD = 'relay.configureGraceTime'
+export const SshTargetSourceSchema = z.enum(['ssh-config', 'manual', 'custom'])
+export const SshTargetSourceIdSchema = z.string().trim().min(1).max(256)
+
+export type SshTargetSource = z.infer<typeof SshTargetSourceSchema>
 
 export type SshTarget = {
   id: string
@@ -32,13 +38,12 @@ export type SshTarget = {
   proxyCommand?: string
   /** Jump host (ProxyJump), if any. */
   jumpHost?: string
-  /** Where this target came from. `ssh-config` targets are kept in sync with
-   *  `~/.ssh/config` on import — their config-derived fields (host, port,
-   *  username, jump host, identity, proxy) are refreshed on each import.
-   *  `manual` targets are never overwritten by import. Legacy persisted targets
-   *  predate this field (undefined) and are adopted into config-sync on next
-   *  import. */
-  source?: 'ssh-config' | 'manual'
+  /** Where this target came from. Managed sources refresh their own targets;
+   *  manual targets are never overwritten by import. Legacy persisted targets
+   *  predate this field and may be adopted into config sync. */
+  source?: SshTargetSource
+  /** Stable owner id for custom-source reconciliation. */
+  sourceId?: string
   /** Grace period in seconds before relay shuts down after disconnect.
    *  0 disables expiry. Default: 0 (until reset). Max: 604800 (7 days). */
   relayGracePeriodSeconds?: number


### PR DESCRIPTION
## Summary

Introduces the persisted identity contract required for built-in custom SSH target sources:

- adds `source: "custom"` and a validated stable `sourceId`;
- keeps custom targets isolated from `~/.ssh/config` reconciliation;
- routes custom targets through explicit host, port, user, identity, and jump-host fields;
- treats malformed or unknown source kinds as manual targets.

This is the first standalone increment from the custom-source handoff. It intentionally does not
add endpoint configuration, network fetching, UI, or plugin contributions.

## Downgrade compatibility

Current builds expose custom targets as `source: "custom"` at runtime. The durable state encodes
them as `source: "manual"` plus the unknown-to-old-builds `sourceId` metadata.

An older Orca therefore:

- treats the target as explicit connection details;
- does not resolve it through local SSH config;
- preserves the source metadata during ordinary state round trips;
- cannot adopt it into SSH-config synchronization.

Current builds restore the custom discriminator when loading that compatible representation.

## Security boundary

This change does not introduce a remote input boundary. The future importer must still strip
`proxyCommand` and cap source results before targets reach persistence. Structured `jumpHost`
remains the intended proxy mechanism for remote-supplied targets.

## Validation

- `pnpm typecheck`
- focused Vitest: 5 files, 514 tests
- `npx oxlint` on all touched TypeScript files
- `npx oxfmt --check` on all touched files
- `pnpm run check:reliability-gates`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

## Stack

1. **This PR:** custom source identity, validation, persistence, and downgrade behavior.
2. Follow-up: source-agnostic reconciliation and tombstone semantics.
3. Follow-up: bounded HTTPS source configuration/fetch/parse boundary.
4. Follow-up: Add from source UI and source badges.

Made with [Orca](https://github.com/stablyai/orca) 🐋
