### PR TITLE
refactor(ssh): generalize target source reconciliation

### DIFF
--- a/src/main/ssh/ssh-connection-store.ts
+++ b/src/main/ssh/ssh-connection-store.ts
@@ -6,6 +6,11 @@ import {
   buildRemovedSshTargetTombstone,
   readoptOrphanedWorkspacesForTarget
 } from './ssh-target-readoption'
+import {
+  getSshTargetSourceKey,
+  isSshTargetManagedBySource,
+  reconcileSshTargetsFromSource
+} from './ssh-target-source-reconciliation'
 
 export class SshConnectionStore {
   constructor(private store: Store) {}
@@ -91,8 +96,17 @@ export class SshConnectionStore {
     // the next ~/.ssh/config sync re-inserts it verbatim (the config entry still
     // exists on disk) and the host reappears. Manual targets need no tombstone —
     // sync never re-adds them.
-    if (target && isConfigManagedTarget(target)) {
-      const alias = target.configHost ?? target.label
+    if (
+      target &&
+      isSshTargetManagedBySource(
+        target,
+        { kind: 'ssh-config' },
+        {
+          adoptLegacySshConfigTargets: true
+        }
+      )
+    ) {
+      const alias = getSshTargetSourceKey(target)
       if (alias) {
         this.store.addDeletedSshConfigAlias(alias)
       }
@@ -116,7 +130,7 @@ export class SshConnectionStore {
   /**
    * Sync targets from ~/.ssh/config: insert new hosts, update existing
    * config-sourced ones in place (so a rotated port takes effect), never touch
-   * manual targets. Returns the inserted and updated targets.
+   * targets owned by another source. Returns the inserted and updated targets.
    */
   importFromSshConfig(options?: { reAdopt?: boolean }): SshTarget[] {
     const readoptions: SshRepoReadoption[] = []
@@ -126,85 +140,27 @@ export class SshConnectionStore {
     if (options?.reAdopt) {
       this.store.clearDeletedSshConfigAliases()
     }
-    const deletedAliases = new Set(this.store.getDeletedSshConfigAliases())
     const configHosts = loadUserSshConfig()
-    const existingTargets = this.store.getSshTargets()
-    // Map config-managed targets (and legacy targets that strongly look like
-    // prior imports) by their config alias so a repeat import reconciles instead
-    // of duplicating. Manual targets are excluded — their alias stays reserved
-    // and untouched.
-    const syncableByAlias = new Map<string, SshTarget>()
-    const manualAliases = new Set<string>()
-    for (const existing of existingTargets) {
-      const alias = existing.configHost ?? existing.label
-      if (!isConfigManagedTarget(existing)) {
-        manualAliases.add(alias)
-        continue
-      }
-      if (alias && !syncableByAlias.has(alias)) {
-        syncableByAlias.set(alias, existing)
-      }
-    }
-
     // Pass an empty exclusion set so the parser returns a candidate for every
     // config host (within-config de-duplication still applies); reconciliation
     // against existing targets happens here.
     const candidates = sshConfigHostsToTargets(configHosts, new Set())
+    const changes = reconcileSshTargetsFromSource({
+      source: { kind: 'ssh-config' },
+      existingTargets: this.store.getSshTargets(),
+      candidates,
+      deletedTargetKeys: new Set(this.store.getDeletedSshConfigAliases()),
+      adoptLegacySshConfigTargets: true
+    })
     const changed: SshTarget[] = []
-    // Guard against ever processing the same alias twice in one pass, so a
-    // duplicate candidate can never produce a duplicate target — independent of
-    // the parser's own within-config de-duplication.
-    const processedAliases = new Set<string>()
-
-    for (const candidate of candidates) {
-      const alias = candidate.configHost ?? candidate.label
-      if (manualAliases.has(alias)) {
-        // A manual target owns this alias — never clobber it.
-        continue
-      }
-      if (deletedAliases.has(alias)) {
-        // The user deleted this config host — stay deleted until they re-add it
-        // or re-adopt config explicitly.
-        continue
-      }
-      if (processedAliases.has(alias)) {
-        continue
-      }
-      processedAliases.add(alias)
-      const existing = syncableByAlias.get(alias)
-      if (existing) {
-        const nextFields = {
-          configHost: candidate.configHost,
-          host: candidate.host,
-          port: candidate.port,
-          username: candidate.username,
-          identityFile: candidate.identityFile,
-          identityAgent: candidate.identityAgent,
-          identitiesOnly: candidate.identitiesOnly,
-          gssapiAuthentication: candidate.gssapiAuthentication,
-          proxyCommand: candidate.proxyCommand,
-          jumpHost: candidate.jumpHost
-        }
-        // Skip the write (and the "synced" report) when nothing changed, so a
-        // repeat sync on every pane open is a no-op. A legacy target with no
-        // `source` is always rewritten once to stamp it as config-managed.
-        const isDirty =
-          existing.source !== 'ssh-config' ||
-          (Object.keys(nextFields) as (keyof typeof nextFields)[]).some(
-            (key) => existing[key] !== nextFields[key]
-          )
-        if (!isDirty) {
-          continue
-        }
-        const updated = this.store.updateSshTarget(existing.id, {
-          ...nextFields,
-          source: 'ssh-config'
-        })
+    for (const change of changes) {
+      if (change.kind === 'update') {
+        const updated = this.store.updateSshTarget(change.id, change.updates)
         if (updated) {
           changed.push(updated)
         }
       } else {
-        const inserted: SshTarget = { ...candidate, source: 'ssh-config' }
+        const inserted = change.target
         this.store.addSshTarget(inserted)
         // Why: a freshly-inserted config host may be one the user removed and is
         // now re-importing — re-adopt its orphaned workspaces. Updated-in-place
@@ -225,24 +181,4 @@ export function getRuntimeOwnedSshTargetId(runtimeId: string): string {
 
 export function isRuntimeOwnedSshTarget(target: SshTarget): boolean {
   return target.owner?.type === 'on-demand-runtime'
-}
-
-function isConfigManagedTarget(target: SshTarget): boolean {
-  // Why: a target is subject to config sync (and therefore needs a tombstone on
-  // delete) when it is explicitly config-sourced, or a legacy import that sync
-  // still adopts. Manual targets are excluded — sync never re-adds them.
-  return (
-    target.source === 'ssh-config' ||
-    (target.source === undefined && isLegacyConfigImportTarget(target))
-  )
-}
-
-function isLegacyConfigImportTarget(target: SshTarget): boolean {
-  const alias = target.configHost ?? target.label
-  // Why: legacy manual and imported targets both lack `source`. Only adopt the
-  // old import shape, where the SSH alias was kept as label/configHost while
-  // host stored the resolved HostName; otherwise preserve the user's target.
-  return Boolean(
-    alias && target.label === alias && target.configHost === alias && target.host !== alias
-  )
 }

--- a/src/main/ssh/ssh-target-source-reconciliation.test.ts
+++ b/src/main/ssh/ssh-target-source-reconciliation.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+import type { SshTarget } from '../../shared/ssh-types'
+import {
+  getSshTargetSourceKey,
+  isLegacySshConfigImportTarget,
+  isSshTargetManagedBySource,
+  reconcileSshTargetsFromSource
+} from './ssh-target-source-reconciliation'
+
+function target(overrides: Partial<SshTarget> & { id: string; label: string }): SshTarget {
+  return {
+    host: `${overrides.label}.example.com`,
+    port: 22,
+    username: 'dev',
+    ...overrides
+  }
+}
+
+describe('reconcileSshTargetsFromSource', () => {
+  it('plans source-owned updates and new inserts in candidate order', () => {
+    const changes = reconcileSshTargetsFromSource({
+      source: { kind: 'custom', sourceId: 'inventory-a' },
+      existingTargets: [
+        target({
+          id: 'existing',
+          label: 'alpha',
+          configHost: 'alpha',
+          port: 2200,
+          source: 'custom',
+          sourceId: 'inventory-a'
+        })
+      ],
+      candidates: [
+        target({ id: 'candidate-alpha', label: 'alpha', configHost: 'alpha', port: 2222 }),
+        target({ id: 'candidate-beta', label: 'beta', configHost: 'beta' })
+      ],
+      deletedTargetKeys: new Set()
+    })
+
+    expect(changes).toEqual([
+      expect.objectContaining({
+        kind: 'update',
+        id: 'existing',
+        updates: expect.objectContaining({
+          port: 2222,
+          source: 'custom',
+          sourceId: 'inventory-a'
+        })
+      }),
+      {
+        kind: 'insert',
+        target: expect.objectContaining({
+          id: 'candidate-beta',
+          source: 'custom',
+          sourceId: 'inventory-a'
+        })
+      }
+    ])
+  })
+
+  it('reserves keys owned by manual targets and other custom sources', () => {
+    const changes = reconcileSshTargetsFromSource({
+      source: { kind: 'custom', sourceId: 'inventory-a' },
+      existingTargets: [
+        target({ id: 'manual', label: 'alpha', configHost: 'alpha', source: 'manual' }),
+        target({
+          id: 'other-source',
+          label: 'beta',
+          configHost: 'beta',
+          source: 'custom',
+          sourceId: 'inventory-b'
+        })
+      ],
+      candidates: [
+        target({ id: 'candidate-alpha', label: 'alpha', configHost: 'alpha' }),
+        target({ id: 'candidate-beta', label: 'beta', configHost: 'beta' })
+      ],
+      deletedTargetKeys: new Set()
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it('suppresses tombstoned and duplicate candidate keys', () => {
+    const changes = reconcileSshTargetsFromSource({
+      source: { kind: 'custom', sourceId: 'inventory-a' },
+      existingTargets: [],
+      candidates: [
+        target({ id: 'deleted', label: 'alpha', configHost: 'alpha' }),
+        target({ id: 'first', label: 'beta', configHost: 'beta' }),
+        target({ id: 'duplicate', label: 'beta', configHost: 'beta' })
+      ],
+      deletedTargetKeys: new Set(['alpha'])
+    })
+
+    expect(changes).toEqual([
+      {
+        kind: 'insert',
+        target: expect.objectContaining({ id: 'first', sourceId: 'inventory-a' })
+      }
+    ])
+  })
+
+  it('adopts only the legacy shape when config reconciliation requests it', () => {
+    const imported = target({
+      id: 'legacy-import',
+      label: 'alpha',
+      configHost: 'alpha',
+      host: '10.0.0.5'
+    })
+    const manual = target({
+      id: 'legacy-manual',
+      label: 'beta',
+      configHost: 'beta',
+      host: 'beta'
+    })
+
+    expect(isLegacySshConfigImportTarget(imported)).toBe(true)
+    expect(isLegacySshConfigImportTarget(manual)).toBe(false)
+    expect(getSshTargetSourceKey(imported)).toBe('alpha')
+    expect(
+      isSshTargetManagedBySource(
+        imported,
+        { kind: 'ssh-config' },
+        {
+          adoptLegacySshConfigTargets: true
+        }
+      )
+    ).toBe(true)
+    expect(isSshTargetManagedBySource(manual, { kind: 'ssh-config' })).toBe(false)
+
+    const changes = reconcileSshTargetsFromSource({
+      source: { kind: 'ssh-config' },
+      existingTargets: [imported, manual],
+      candidates: [
+        target({ id: 'alpha-next', label: 'alpha', configHost: 'alpha', port: 2222 }),
+        target({ id: 'beta-next', label: 'beta', configHost: 'beta', port: 2222 })
+      ],
+      deletedTargetKeys: new Set(),
+      adoptLegacySshConfigTargets: true
+    })
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0]).toEqual(
+      expect.objectContaining({
+        kind: 'update',
+        id: 'legacy-import',
+        updates: expect.objectContaining({ source: 'ssh-config', port: 2222 })
+      })
+    )
+  })
+
+  it('returns no update when source-owned connection fields are unchanged', () => {
+    const existing = target({
+      id: 'existing',
+      label: 'alpha',
+      configHost: 'alpha',
+      source: 'custom',
+      sourceId: 'inventory-a'
+    })
+
+    expect(
+      reconcileSshTargetsFromSource({
+        source: { kind: 'custom', sourceId: 'inventory-a' },
+        existingTargets: [existing],
+        candidates: [{ ...existing, id: 'candidate', source: undefined, sourceId: undefined }],
+        deletedTargetKeys: new Set()
+      })
+    ).toEqual([])
+  })
+})

--- a/src/main/ssh/ssh-target-source-reconciliation.ts
+++ b/src/main/ssh/ssh-target-source-reconciliation.ts
@@ -1,0 +1,144 @@
+import type { SshTarget } from '../../shared/ssh-types'
+
+export type SshTargetManagedSource = { kind: 'ssh-config' } | { kind: 'custom'; sourceId: string }
+
+export type SshTargetSourceChange =
+  | {
+      kind: 'update'
+      id: string
+      updates: Partial<Omit<SshTarget, 'id'>>
+    }
+  | {
+      kind: 'insert'
+      target: SshTarget
+    }
+
+type ReconcileSshTargetSourceOptions = {
+  source: SshTargetManagedSource
+  existingTargets: readonly SshTarget[]
+  candidates: readonly SshTarget[]
+  deletedTargetKeys: ReadonlySet<string>
+  adoptLegacySshConfigTargets?: boolean
+}
+
+type SshTargetSourceOwnershipOptions = {
+  adoptLegacySshConfigTargets?: boolean
+}
+
+const SYNCED_CONNECTION_FIELDS = [
+  'configHost',
+  'host',
+  'port',
+  'username',
+  'identityFile',
+  'identityAgent',
+  'identitiesOnly',
+  'gssapiAuthentication',
+  'proxyCommand',
+  'jumpHost'
+] as const satisfies readonly (keyof SshTarget)[]
+
+export function reconcileSshTargetsFromSource(
+  options: ReconcileSshTargetSourceOptions
+): SshTargetSourceChange[] {
+  const managedTargets = new Map<string, SshTarget>()
+  const reservedTargetKeys = new Set<string>()
+
+  for (const target of options.existingTargets) {
+    const key = getSshTargetSourceKey(target)
+    if (
+      !isSshTargetManagedBySource(target, options.source, {
+        adoptLegacySshConfigTargets: options.adoptLegacySshConfigTargets
+      })
+    ) {
+      reservedTargetKeys.add(key)
+      continue
+    }
+    if (key && !managedTargets.has(key)) {
+      managedTargets.set(key, target)
+    }
+  }
+
+  const changes: SshTargetSourceChange[] = []
+  const processedTargetKeys = new Set<string>()
+  for (const candidate of options.candidates) {
+    const key = getSshTargetSourceKey(candidate)
+    if (
+      reservedTargetKeys.has(key) ||
+      options.deletedTargetKeys.has(key) ||
+      processedTargetKeys.has(key)
+    ) {
+      continue
+    }
+    processedTargetKeys.add(key)
+
+    const existing = managedTargets.get(key)
+    if (!existing) {
+      changes.push({ kind: 'insert', target: stampSshTargetSource(candidate, options.source) })
+      continue
+    }
+
+    const updates = getSshTargetSourceUpdates(candidate, options.source)
+    if (hasSshTargetSourceChanges(existing, updates)) {
+      changes.push({ kind: 'update', id: existing.id, updates })
+    }
+  }
+  return changes
+}
+
+export function isLegacySshConfigImportTarget(target: SshTarget): boolean {
+  const alias = getSshTargetSourceKey(target)
+  return Boolean(
+    alias && target.label === alias && target.configHost === alias && target.host !== alias
+  )
+}
+
+export function getSshTargetSourceKey(target: SshTarget): string {
+  return target.configHost ?? target.label
+}
+
+export function isSshTargetManagedBySource(
+  target: SshTarget,
+  source: SshTargetManagedSource,
+  options: SshTargetSourceOwnershipOptions = {}
+): boolean {
+  if (source.kind === 'custom') {
+    return target.source === 'custom' && target.sourceId === source.sourceId
+  }
+  return (
+    target.source === 'ssh-config' ||
+    (options.adoptLegacySshConfigTargets === true &&
+      target.source === undefined &&
+      isLegacySshConfigImportTarget(target))
+  )
+}
+
+function getSshTargetSourceUpdates(
+  candidate: SshTarget,
+  source: SshTargetManagedSource
+): Partial<Omit<SshTarget, 'id'>> {
+  const updates: Partial<Omit<SshTarget, 'id'>> = {}
+  for (const field of SYNCED_CONNECTION_FIELDS) {
+    Object.assign(updates, { [field]: candidate[field] })
+  }
+  return source.kind === 'custom'
+    ? { ...updates, source: 'custom', sourceId: source.sourceId }
+    : { ...updates, source: 'ssh-config' }
+}
+
+function stampSshTargetSource(candidate: SshTarget, source: SshTargetManagedSource): SshTarget {
+  if (source.kind === 'custom') {
+    return { ...candidate, source: 'custom', sourceId: source.sourceId }
+  }
+  const { sourceId: _sourceId, ...target } = candidate
+  return { ...target, source: 'ssh-config' }
+}
+
+function hasSshTargetSourceChanges(
+  existing: SshTarget,
+  updates: Partial<Omit<SshTarget, 'id'>>
+): boolean {
+  return (Object.keys(updates) as (keyof typeof updates)[]).some(
+    (key) => existing[key] !== updates[key]
+  )
+}


### PR DESCRIPTION
## Summary

Extracts SSH target synchronization into a source-aware, side-effect-free reconciliation planner.
The existing `~/.ssh/config` importer now applies that plan without changing its observable
behavior.

The planner:

- scopes ownership to SSH config or a specific custom `sourceId`;
- updates only fields managed by the source while preserving target IDs;
- reserves aliases owned by manual targets or other custom sources;
- suppresses deleted and duplicate source entries;
- adopts only the known legacy SSH-config import shape;
- returns ordered insert/update operations so workspace re-adoption stays deterministic.

Deletion uses the same ownership predicate as reconciliation, preventing sync and tombstone logic
from drifting apart.

## Why this is separate

The next source boundary can feed validated candidates into one reconciliation path instead of
copying the subtle SSH-config semantics. This PR is a pure refactor plus reusable custom-source
behavior; it adds no network source, UI, or persistence fields.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- focused SSH/persistence Vitest: 6 files, 519 tests
- reconciliation/store Vitest: 2 files, 36 tests
- `git diff --check`

## Stack

1. #11039 — custom source identity and downgrade-safe persistence.
2. **This PR:** source-aware reconciliation and tombstone ownership.
3. Follow-up: bounded HTTPS source configuration/fetch/parse boundary.
4. Follow-up: Add from source UI and source badges.

Made with [Orca](https://github.com/stablyai/orca) 🐋
