### PR TITLE
fix(worktree): give the physical-stop recheck a budget it can actually use

### DIFF
--- a/src/main/runtime/worktree-teardown.test.ts
+++ b/src/main/runtime/worktree-teardown.test.ts
@@ -8,7 +8,11 @@ vi.mock('../memory/pty-registry', () => ({
   listRegisteredPtys: listRegisteredPtysMock
 }))
 
-import { killAllProcessesForWorktree, WORKTREE_PROCESS_SWEEP_TIMEOUT_MS } from './worktree-teardown'
+import {
+  killAllProcessesForWorktree,
+  WORKTREE_PROCESS_SWEEP_TIMEOUT_MS,
+  WORKTREE_TEARDOWN_RPC_MARGIN_MS
+} from './worktree-teardown'
 import type { IPtyProvider, PtyProcessInfo } from '../providers/types'
 import { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
 
@@ -601,6 +605,55 @@ describe('killAllProcessesForWorktree', () => {
 
       await failure
       expect(localProvider.shutdown).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why (#10484 fallout, measured on native Windows): the daemon's agent-kill path
+  // runs a whole-process-table identity query (0.7-3.6s observed) plus a forced
+  // tree kill (0.7-3.0s observed) per teardown burst, so the kill RPC can exhaust
+  // its bound after the PTY has already died. The recheck that exists to absolve
+  // that PTY (#10106) then inherits only the leftover margin, and a daemon
+  // round-trip that outlives it is scored as "still running" — failing a delete
+  // whose processes are all gone.
+  it('does not fail destructive teardown when the physical-exit recheck outlives the reserved RPC margin', async () => {
+    vi.useFakeTimers()
+    try {
+      const sessionId = 'w1@@abcd1234'
+      // The daemon really did kill the PTY; only its acknowledgement was late.
+      let ptyAlive = true
+      const RECHECK_RPC_MS = WORKTREE_TEARDOWN_RPC_MARGIN_MS + 400
+
+      const localProvider = createProviderStub(async () => {
+        await new Promise((resolve) => setTimeout(resolve, RECHECK_RPC_MS))
+        return ptyAlive ? [{ id: sessionId, cwd: '/tmp/w1', title: 'shell' }] : []
+      })
+      ;(localProvider.shutdown as ReturnType<typeof vi.fn>).mockImplementation(
+        async (_id: string, opts: { deadlineMs?: number }) => {
+          // Model the adapter's bounded kill RPC: it rejects exactly at the RPC
+          // deadline, having already terminated the process.
+          await new Promise((resolve) =>
+            setTimeout(resolve, Math.max(1, (opts?.deadlineMs ?? 0) - Date.now()))
+          )
+          ptyAlive = false
+          throw new Error('Request kill timed out')
+        }
+      )
+      listRegisteredPtysMock.mockReturnValue([])
+
+      const teardown = killAllProcessesForWorktree('w1', {
+        localProvider,
+        requirePhysicalStop: true,
+        timeoutMs: WORKTREE_PROCESS_SWEEP_TIMEOUT_MS
+      })
+
+      await vi.advanceTimersByTimeAsync(WORKTREE_PROCESS_SWEEP_TIMEOUT_MS + RECHECK_RPC_MS * 3)
+
+      // The PTY is provably gone, so the sweep must not report a stop failure.
+      await expect(teardown).resolves.toMatchObject({ providerStopped: 0 })
+      // The recheck must actually have asked, not been cut off before it could.
+      expect(localProvider.listProcesses).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -30,6 +30,16 @@ export const WORKTREE_PROCESS_SWEEP_TIMEOUT_MS = 10_000
 // failure actually left a live PTY before the outer sweep deadline.
 export const WORKTREE_TEARDOWN_RPC_MARGIN_MS = 500
 
+// Why: the recheck below is a provider round-trip, and scoping it to whatever is
+// left of the sweep deadline starves it exactly when it is needed. A Windows
+// agent kill spends seconds in the root-identity process query plus the tree
+// kill (0.7-3.6s and 0.7-3.0s measured on a loaded host), so the stop RPC can
+// exhaust its bound after the process already died — leaving the recheck less
+// than one round-trip, resolving it "cannot tell", and failing a delete whose
+// PTYs are all gone. Give it a window of its own, still hard-bounded so
+// destructive removal cannot hang (#9516).
+export const WORKTREE_TEARDOWN_VERIFY_BUDGET_MS = 3_000
+
 // Absolute deadline (epoch ms) threaded into provider RPCs on the destructive
 // path; each RPC leaf converts it to the remaining time when it actually issues,
 // so sequential RPCs share one budget without any relative-timeout bookkeeping.
@@ -152,8 +162,7 @@ export async function killAllProcessesForWorktree(
     )
     const failedPtyIds = stopResults.filter(([, stopped]) => !stopped).map(([ptyId]) => ptyId)
     const failedPtysExited =
-      failedPtyIds.length === 0 ||
-      (await verifyFailedPtysExited(failedPtyIds, deps.localProvider, deadline))
+      failedPtyIds.length === 0 || (await verifyFailedPtysExited(failedPtyIds, deps.localProvider))
     if (!failedPtysExited) {
       throw new Error(`Failed to physically stop every PTY for worktree: ${worktreeId}`)
     }
@@ -167,13 +176,15 @@ export async function killAllProcessesForWorktree(
 
 async function verifyFailedPtysExited(
   failedPtyIds: readonly string[],
-  provider: IPtyProvider,
-  deadline: number
+  provider: IPtyProvider
 ): Promise<boolean> {
+  // Why: measured from here, not from the sweep deadline the stop phase just
+  // consumed — a recheck with no budget left cannot absolve an already-dead PTY.
+  const verifyDeadline = Date.now() + WORKTREE_TEARDOWN_VERIFY_BUDGET_MS
   const sessions = await settleBeforeDeadline(
-    () => provider.listProcesses({ deadlineMs: deadline }),
+    () => provider.listProcesses({ deadlineMs: verifyDeadline }),
     null,
-    deadline
+    verifyDeadline
   ).catch(() => null)
   if (!sessions) {
     return false


### PR DESCRIPTION
## Problem

Deleting a worktree that holds an idle agent fails on Windows with:

```
Failed to delete workspace test
Error: Failed to physically stop every PTY for worktree: a4affed8-...::C:/Users/neil/orca/workspaces/orca/test
```

Every PTY named in that error was already dead.

## Root cause (measured, not inferred)

I instrumented a dev build on native Windows and captured five worktree deletes with idle Claude Code agents. Findings:

**The executing path is the terminal daemon**, not the in-process local provider — `src/main/daemon/terminal-session-teardown.ts` (`daemon-agent`). `local-pty-provider.ts` never ran during any delete. Anything fixed only there would not engage.

**Per-teardown cost on Windows** (each burst, measured):

| stage | observed range |
|---|---|
| root-identity process query | 0.73s – 3.62s |
| forced tree kill | 0.69s – 3.01s |
| whole sweep | 1.96s – 6.56s (budget 10s) |

The identity query hit its own 3s timeout in 2 of 5 runs and resolved `unknown`. `unknown` takes the same branch as `own` — the tree kill still runs — so on timeout that query costs up to 3.6s and changes nothing.

**The actual defect** is downstream. When a stop RPC exhausts its bound *after* the process already died, the PTY lands in `failedPtyIds`, and `verifyFailedPtysExited` (added in #10106) is supposed to absolve it. But that recheck was scoped to the same sweep deadline the stop phase had just spent, so it started with less time than one provider round-trip. `settleBeforeDeadline` returned its `null` fallback **without ever issuing `listProcesses`**, and `null` is read as "still running":

```ts
const sessions = await settleBeforeDeadline(
  () => provider.listProcesses({ deadlineMs: deadline }),
  null,
  deadline            // ← already spent by the stop phase
).catch(() => null)
if (!sessions) {
  return false        // ← "cannot tell" scored as "still alive"
}
```

So the recheck failed closed in exactly the situation it was written to rescue. That is why #10106 did not hold.

## Fix

One concern: give the recheck a bounded window measured from when the stop phase ends, so it can ask before it answers. Still hard-bounded, so destructive removal cannot hang (#9516). When a PTY genuinely is alive, `listProcesses` still lists it and the sweep still fails closed — the safety property is unchanged.

## Test

`does not fail destructive teardown when the physical-exit recheck outlives the reserved RPC margin` models the real shape: a bounded kill RPC that rejects at its deadline having already terminated the process, and a recheck round-trip slightly longer than the reserved margin.

Revert-verified — with `worktree-teardown.ts` reverted the test fails with the exact production string at the exact throw site:

```
AssertionError: promise rejected "Error: Failed to physically stop every PT…" instead of resolving
Caused by: Error: Failed to physically stop every PTY for worktree: w1
```

With the fix: 27/27 in the file, 87/87 across the teardown suites.

## Live verification

Instrumented dev build on native Windows, 4 idle Claude Code agents in a real worktree with UI tabs, under emulated steady-state process-scan load: delete succeeded in 9.5s, all stops OK, worktree directory gone, zero surviving processes.

## Scope notes

- Not local-worktree-specific: the change is in the provider-agnostic sweep, so SSH and folder-workspace removal get the same corrected recheck. No path assumptions added.
- Renderer respawn / silent-toast behaviour deliberately untouched — owned separately.

## Follow-ups (deliberately not in this PR)

1. **The identity query may not be worth its cost.** Comparable terminal implementations either fire the forced tree kill unconditionally and let the OS no-op a dead PID, or hold a real process handle (which cannot be recycled) instead of a bare PID. Orca gates on a whole-machine process-table scan, which is the most expensive of the three and returns `unknown` under load. Worth revisiting whether a narrower console-scoped enumeration or a retained handle would be both cheaper and stronger.
2. **`stopTerminalsForWorktree` stops PTYs in a sequential `for await` loop** while the provider/registry sweeps use `mapWithConcurrency(32)`. It contributed nothing in my runs (the worktree had already left the runtime graph, so it exited early every time), but it is a latency cliff if it ever does own the PTYs.

## Honest limitation

I could not make the delete fail live on the dev build — my runs peaked at 6.6s against a 10s budget, short of the cliff. The failure is reproduced deterministically in the unit test, which throws the identical error from the identical line. The live measurements establish the cost model that gets a loaded machine to that cliff; they do not themselves cross it.
