### PR TITLE
fix(workspaces): hide false repo error for remote servers

### DIFF
--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -140,6 +140,7 @@ import { useFolderWorkspaceComposerPathStatus } from '@/components/sidebar/folde
 import { submitFolderWorkspaceCreate } from '@/components/sidebar/folder-workspace-composer-submit'
 import { buildExecutionHostRegistry } from '../../../shared/execution-host-registry'
 import {
+  getRepoExecutionHostId,
   normalizeExecutionHostId,
   parseExecutionHostId,
   type ExecutionHostId
@@ -826,6 +827,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
     repoId: selectedRecipeRepoId,
     repoIsGit: selectedRepoIsGit,
     repoConnectionId: selectedRecipeRepoConnectionId,
+    repoExecutionHostId: selectedRepo ? getRepoExecutionHostId(selectedRepo) : null,
     projectGroupTarget: isProjectGroupTarget,
     initialRecipeId: initialEphemeralVmRecipeId
   })

--- a/src/renderer/src/hooks/useEphemeralVmRecipeOptions.test.tsx
+++ b/src/renderer/src/hooks/useEphemeralVmRecipeOptions.test.tsx
@@ -59,17 +59,20 @@ function installApi(listRecipes: ReturnType<typeof vi.fn>): {
 function Harness({
   repoId,
   initialRecipeId,
-  enabled = true
+  enabled = true,
+  repoExecutionHostId = 'local'
 }: {
   repoId: string
   initialRecipeId?: string
   enabled?: boolean
+  repoExecutionHostId?: 'local' | `runtime:${string}`
 }): React.JSX.Element {
   const state = useEphemeralVmRecipeOptions({
     enabled,
     repoId,
     repoIsGit: true,
     repoConnectionId: null,
+    repoExecutionHostId,
     projectGroupTarget: false,
     initialRecipeId
   })
@@ -78,6 +81,7 @@ function Harness({
       <span data-testid="repo">{repoId}</span>
       <span data-testid="recipes">{state.recipes.map((recipe) => recipe.id).join(',')}</span>
       <span data-testid="selected">{state.selectedRecipeId ?? 'none'}</span>
+      <span data-testid="error">{state.error ?? 'none'}</span>
     </div>
   )
 }
@@ -144,5 +148,23 @@ describe('useEphemeralVmRecipeOptions', () => {
     await render(<Harness repoId="repo-1" enabled={false} />)
 
     expect(listRecipes).not.toHaveBeenCalled()
+  })
+
+  it('does not send a paired-runtime repo id to local recipe discovery', async () => {
+    const listRecipes = vi.fn().mockResolvedValue({
+      status: 'error',
+      repoPath: null,
+      diagnostics: [],
+      recipes: [],
+      message: 'Repo not found: repo-runtime'
+    })
+    installApi(listRecipes)
+
+    const { container } = await render(
+      <Harness repoId="repo-runtime" repoExecutionHostId="runtime:windows-2" />
+    )
+
+    expect(listRecipes).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-testid="error"]')?.textContent).toBe('none')
   })
 })

--- a/src/renderer/src/hooks/useEphemeralVmRecipeOptions.ts
+++ b/src/renderer/src/hooks/useEphemeralVmRecipeOptions.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../shared/execution-host'
 import type { OrcaVmRecipe } from '../../../shared/types'
 
 type EphemeralVmRecipeOptionsArgs = {
@@ -6,6 +7,7 @@ type EphemeralVmRecipeOptionsArgs = {
   repoId: string | null
   repoIsGit: boolean
   repoConnectionId: string | null
+  repoExecutionHostId: ExecutionHostId | null
   projectGroupTarget: boolean
   initialRecipeId?: string
 }
@@ -25,6 +27,7 @@ export function useEphemeralVmRecipeOptions(args: EphemeralVmRecipeOptionsArgs):
     Boolean(args.repoId) &&
     args.repoIsGit &&
     !args.repoConnectionId &&
+    args.repoExecutionHostId === LOCAL_EXECUTION_HOST_ID &&
     !args.projectGroupTarget
 
   const load = useCallback(


### PR DESCRIPTION
## Summary

- stop the workspace composer from sending an attached remote Orca server's repo ID to viewer-local recipe discovery
- remove the false `Repo not found` message without changing remote workspace creation
- add regression coverage proving a paired-runtime repo does not call local recipe IPC or surface an error

## Regression cause

This occurs with a normal attached Orca server; the server itself is not an ephemeral VM.

When the experimental environment feature is enabled, the composer probes every eligible Git repo for optional environment recipes, even when the user is simply selecting a normal run host. PR #6320 excluded SSH repos using `connectionId`, but repos published by an attached Orca server are identified by `executionHostId: runtime:...` and have no connection ID. The Windows repo ID was therefore sent to the Mac viewer's local repo store, which returned `Repo not found`.

Remote workspace creation uses the proper runtime route and was never broken, explaining why creation still succeeded despite the message.

## Fix

Limit viewer-local recipe discovery to repos owned by the viewer's local execution host. Attached remote Orca servers continue through the existing remote workspace creation route.

## Validation

- regression test red before / green after
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useEphemeralVmRecipeOptions.test.tsx src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts src/main/ipc/ephemeral-vm.test.ts` (50 passed)
- `pnpm run typecheck:web`
- focused oxlint
- changed-code quality gate
- max-lines ratchet
