### PR TITLE
fix(skills): require updater registration

### DIFF
--- a/src/main/skills/skill-freshness-eligibility.test.ts
+++ b/src/main/skills/skill-freshness-eligibility.test.ts
@@ -5,6 +5,12 @@ import {
 } from '../../shared/skill-freshness'
 import { eligibleSkillUpdateNames } from './skill-freshness-eligibility'
 
+const globallyUpdatableNames = new Set(['computer-use', 'orca-cli', 'orchestration'])
+
+function eligible(installations: SkillFreshnessInstallation[]): string[] {
+  return eligibleSkillUpdateNames(installations, globallyUpdatableNames)
+}
+
 function placement(
   name: string,
   overrides: Partial<SkillFreshnessInstallation> = {}
@@ -35,7 +41,7 @@ function placement(
 describe('skill freshness name-scoped update eligibility', () => {
   it('offers a name when at least one supported placement is outdated and all are official', () => {
     expect(
-      eligibleSkillUpdateNames([
+      eligible([
         placement('orca-cli'),
         placement('orca-cli', {
           id: 'orca-cli-claude',
@@ -62,7 +68,7 @@ describe('skill freshness name-scoped update eligibility', () => {
       // update over one refuses work the command could do to a copy that is never at
       // stake. The canonical copy converges and the outlier is reported separately.
       expect(
-        eligibleSkillUpdateNames([
+        eligible([
           placement('orca-cli'),
           placement('orca-cli', { id: `outlier-${status}-${topology}`, status, topology })
         ])
@@ -76,7 +82,7 @@ describe('skill freshness name-scoped update eligibility', () => {
       // Why: this is the placement the command writes to, so overwriting it is the
       // real data-loss case the rail exists to avoid.
       expect(
-        eligibleSkillUpdateNames([
+        eligible([
           placement('orca-cli', { id: 'blocked-canonical', status }),
           placement('orca-cli', {
             id: 'orca-cli-claude',
@@ -93,7 +99,7 @@ describe('skill freshness name-scoped update eligibility', () => {
     // Why: a duplicate no longer omits the whole name — the canonical copy converges
     // and the duplicate row is flagged as maybe-not-reached rather than blocking.
     expect(
-      eligibleSkillUpdateNames([
+      eligible([
         placement('orca-cli'),
         placement('orca-cli', {
           id: 'orca-cli-gemini',
@@ -112,7 +118,7 @@ describe('skill freshness name-scoped update eligibility', () => {
     // name here advertises an update the command reports as already up to date, so the
     // badge could never clear; the dialog explains the duplicate as skipped instead.
     expect(
-      eligibleSkillUpdateNames([
+      eligible([
         placement('orchestration', { status: 'current' }),
         placement('orchestration', {
           id: 'orchestration-factory',
@@ -131,7 +137,7 @@ describe('skill freshness name-scoped update eligibility', () => {
     // Why: with no canonical or alias to anchor `--global`, the command has no
     // reliable target, so a duplicate-only skill stays unoffered.
     expect(
-      eligibleSkillUpdateNames([
+      eligible([
         placement('orca-cli', {
           rootId: 'home-gemini',
           unresolvedPath: '/home/.gemini/skills/orca-cli',
@@ -147,7 +153,7 @@ describe('skill freshness name-scoped update eligibility', () => {
     // Why: a project copy is never written by `--global`, so it does not speak for
     // the global one — while a name whose convergent copy is current stays unoffered.
     expect(
-      eligibleSkillUpdateNames([
+      eligible([
         placement('computer-use', { status: 'current' }),
         placement('orchestration'),
         placement('orchestration', {
@@ -157,6 +163,10 @@ describe('skill freshness name-scoped update eligibility', () => {
         })
       ])
     ).toEqual(['orchestration'])
+  })
+
+  it('does not offer an official canonical copy missing from the updater lock (#10791)', () => {
+    expect(eligibleSkillUpdateNames([placement('orca-cli')], new Set())).toEqual([])
   })
 
   it('builds only an explicit, deterministic global command', () => {

--- a/src/main/skills/skill-freshness-eligibility.ts
+++ b/src/main/skills/skill-freshness-eligibility.ts
@@ -13,9 +13,12 @@ import {
  * do, or refuse work it could, over a copy that is never at stake either way. A
  * blocked *convergent* copy still withholds it, because that is the placement the
  * command would write to and overwriting it is the real data-loss case.
+ * `globallyUpdatableNames` comes from the updater's lock; an unregistered copied
+ * bundle is installed but `skills update` cannot identify its source.
  */
 export function eligibleSkillUpdateNames(
-  installations: readonly SkillFreshnessInstallation[]
+  installations: readonly SkillFreshnessInstallation[],
+  globallyUpdatableNames: ReadonlySet<string>
 ): string[] {
   const byName = new Map<string, SkillFreshnessInstallation[]>()
   for (const installation of installations) {
@@ -26,6 +29,9 @@ export function eligibleSkillUpdateNames(
 
   const eligible: string[] = []
   for (const [, entries] of byName) {
+    if (!globallyUpdatableNames.has(entries[0].name)) {
+      continue
+    }
     const convergent = entries.filter((entry) =>
       SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(entry.topology)
     )

--- a/src/main/skills/skill-freshness-inventory.test.ts
+++ b/src/main/skills/skill-freshness-inventory.test.ts
@@ -58,6 +58,21 @@ async function fixture() {
     ...snapshots[1]
   }
   await Promise.all([
+    mkdir(join(homeDir, '.agents'), { recursive: true }).then(() =>
+      writeFile(
+        join(homeDir, '.agents', '.skill-lock.json'),
+        `${JSON.stringify({
+          version: 3,
+          skills: {
+            'orca-cli': {
+              skillFolderHash: 'tracked-old-hash',
+              skillPath: 'skills/orca-cli/SKILL.md',
+              source: 'stablyai/orca'
+            }
+          }
+        })}\n`
+      )
+    ),
     writeFile(
       join(skillResourceRoot, 'current-manifest.json'),
       `${JSON.stringify({ schemaVersion: 2, skills: [current] }, null, 2)}\n`
@@ -119,6 +134,26 @@ describe('read-only skill freshness inventory', () => {
     expect(inventory.installations.map((entry) => entry.status)).toEqual(['outdated'])
     expect(inventory.installations[0]?.installedAppVersion).toBe('1.0.0')
     expect(inventory.eligibleUpdateNames).toEqual(['orca-cli'])
+  })
+
+  it('does not offer an older copied bundle the external updater has never registered (#10791)', async () => {
+    const test = await fixture()
+    await test.writeSkill(join(test.homeDir, '.agents', 'skills'), test.oldMarkdown)
+    await rm(join(test.homeDir, '.agents', '.skill-lock.json'))
+
+    const inventory = await inventorySkillFreshness({
+      currentAppVersion: '2.0.0',
+      homeDir: test.homeDir,
+      repos: [],
+      resourceRoot: test.resourceRoot,
+      stateHome: null
+    })
+
+    expect(inventory.installations[0]).toMatchObject({
+      topology: 'canonical-copy',
+      status: 'outdated'
+    })
+    expect(inventory.eligibleUpdateNames).toEqual([])
   })
 
   it('labels newer known and unrecognized bytes honestly without calling them modified', async () => {

--- a/src/main/skills/skill-freshness-inventory.ts
+++ b/src/main/skills/skill-freshness-inventory.ts
@@ -17,6 +17,7 @@ import {
   type CandidateLstat
 } from './skill-freshness-placement-observation'
 import { scanKnownPluginSkillCandidates } from './skill-plugin-cache-scan'
+import { readGloballyUpdatableSkillNames } from './skill-update-registration'
 
 export const MAXIMUM_REPOSITORY_SKILL_ROOTS = 128
 
@@ -39,8 +40,12 @@ export async function inventorySkillFreshness(args: {
   repos?: Repo[]
   resourceRoot?: string
   candidateLstat?: CandidateLstat
+  stateHome?: string | null
 }): Promise<SkillFreshnessInventory> {
-  const artifacts = await loadSkillBundleArtifacts(args.resourceRoot)
+  const [artifacts, globallyUpdatableNames] = await Promise.all([
+    loadSkillBundleArtifacts(args.resourceRoot),
+    readGloballyUpdatableSkillNames({ homeDir: args.homeDir, stateHome: args.stateHome })
+  ])
   const currentByName = new Map(artifacts.manifest.skills.map((skill) => [skill.name, skill]))
   const discoveryArgs = {
     homeDir: args.homeDir,
@@ -163,7 +168,7 @@ export async function inventorySkillFreshness(args: {
   return {
     schemaVersion: 1,
     installations,
-    eligibleUpdateNames: eligibleSkillUpdateNames(installations),
+    eligibleUpdateNames: eligibleSkillUpdateNames(installations, globallyUpdatableNames),
     scanIssues,
     scannedAt: Date.now()
   }

--- a/src/main/skills/skill-update-registration.test.ts
+++ b/src/main/skills/skill-update-registration.test.ts
@@ -1,0 +1,65 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { readGloballyUpdatableSkillNames } from './skill-update-registration'
+
+const temporaryDirectories: string[] = []
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-skill-registration-'))
+  temporaryDirectories.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((root) => rm(root, { recursive: true })))
+})
+
+describe('global skill update registration', () => {
+  it('reads only updateable entries from the external updater lock', async () => {
+    const homeDir = await temporaryRoot()
+    await mkdir(join(homeDir, '.agents'), { recursive: true })
+    await writeFile(
+      join(homeDir, '.agents', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          orchestration: {
+            skillFolderHash: 'hash',
+            skillPath: 'skills/orchestration/SKILL.md',
+            source: 'stablyai/orca'
+          },
+          copied: {}
+        }
+      })
+    )
+
+    await expect(readGloballyUpdatableSkillNames({ homeDir, stateHome: null })).resolves.toEqual(
+      new Set(['orchestration'])
+    )
+  })
+
+  it('uses the XDG state lock when configured', async () => {
+    const root = await temporaryRoot()
+    const stateHome = join(root, 'state')
+    await mkdir(join(stateHome, 'skills'), { recursive: true })
+    await writeFile(
+      join(stateHome, 'skills', '.skill-lock.json'),
+      JSON.stringify({
+        version: 3,
+        skills: {
+          'orca-cli': {
+            skillFolderHash: 'hash',
+            skillPath: 'skills/orca-cli/SKILL.md',
+            source: 'stablyai/orca'
+          }
+        }
+      })
+    )
+
+    await expect(readGloballyUpdatableSkillNames({ homeDir: root, stateHome })).resolves.toEqual(
+      new Set(['orca-cli'])
+    )
+  })
+})

--- a/src/main/skills/skill-update-registration.test.ts
+++ b/src/main/skills/skill-update-registration.test.ts
@@ -30,7 +30,17 @@ describe('global skill update registration', () => {
             skillPath: 'skills/orchestration/SKILL.md',
             source: 'stablyai/orca'
           },
-          copied: {}
+          copied: {},
+          emptyHash: {
+            skillFolderHash: '',
+            skillPath: 'skills/empty-hash/SKILL.md',
+            source: 'stablyai/orca'
+          },
+          emptyPath: {
+            skillFolderHash: 'hash',
+            skillPath: '',
+            source: 'stablyai/orca'
+          }
         }
       })
     )

--- a/src/main/skills/skill-update-registration.ts
+++ b/src/main/skills/skill-update-registration.ts
@@ -1,0 +1,65 @@
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+const GLOBAL_SKILL_LOCK_SCHEMA_VERSION = 3
+
+type SkillUpdateRegistrationArgs = {
+  homeDir?: string
+  stateHome?: string | null
+}
+
+function globalSkillLockPath(args: SkillUpdateRegistrationArgs): string {
+  const stateHome =
+    args.stateHome === undefined
+      ? args.homeDir === undefined
+        ? (process.env.XDG_STATE_HOME ?? null)
+        : null
+      : args.stateHome
+  return stateHome
+    ? join(stateHome, 'skills', '.skill-lock.json')
+    : join(args.homeDir ?? homedir(), '.agents', '.skill-lock.json')
+}
+
+export async function readGloballyUpdatableSkillNames(
+  args: SkillUpdateRegistrationArgs = {}
+): Promise<ReadonlySet<string>> {
+  try {
+    const parsed = JSON.parse(await readFile(globalSkillLockPath(args), 'utf8')) as {
+      version?: unknown
+      skills?: unknown
+    }
+    if (
+      typeof parsed.version !== 'number' ||
+      parsed.version < GLOBAL_SKILL_LOCK_SCHEMA_VERSION ||
+      !parsed.skills ||
+      typeof parsed.skills !== 'object' ||
+      Array.isArray(parsed.skills)
+    ) {
+      return new Set()
+    }
+
+    return new Set(
+      Object.entries(parsed.skills)
+        .filter(([, value]) => {
+          if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            return false
+          }
+          const entry = value as {
+            skillFolderHash?: unknown
+            skillPath?: unknown
+            source?: unknown
+          }
+          return (
+            typeof entry.skillFolderHash === 'string' &&
+            typeof entry.skillPath === 'string' &&
+            typeof entry.source === 'string' &&
+            entry.source.length > 0
+          )
+        })
+        .map(([name]) => name)
+    )
+  } catch {
+    return new Set()
+  }
+}

--- a/src/main/skills/skill-update-registration.ts
+++ b/src/main/skills/skill-update-registration.ts
@@ -52,7 +52,9 @@ export async function readGloballyUpdatableSkillNames(
           }
           return (
             typeof entry.skillFolderHash === 'string' &&
+            entry.skillFolderHash.length > 0 &&
             typeof entry.skillPath === 'string' &&
+            entry.skillPath.length > 0 &&
             typeof entry.source === 'string' &&
             entry.source.length > 0
           )


### PR DESCRIPTION
## Summary

- read the external skills updater lock from `XDG_STATE_HOME/skills/.skill-lock.json` or `~/.agents/.skill-lock.json`
- treat only schema 3+ entries with a folder hash, skill path, and non-empty source as globally updateable
- require updater registration before bundled canonical skill copies appear in the update inventory
- preserve the plugin-cache scan completeness and scan-issue reporting merged in #10865

## Reproduction

A copied canonical bundle could be offered as updateable even though it was absent from the updater lock. Running `npx skills update orchestration --global -y` then printed `No installed skills found matching: orchestration` and exited 0. The inventory now advertises only registrations the external updater can actually resolve.

## Validation

- 39 focused skill freshness and updater-registration tests
- `pnpm typecheck:node`
- `pnpm check:max-lines-ratchet`
- `git diff origin/main...HEAD --check`

Closes #10791