### PR TITLE
fix(macos): avoid scene deadlock on app reactivation

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -157,6 +157,7 @@ import {
   setTrayAttention,
   type SystemTrayOptions
 } from './tray/system-tray'
+import { createMacAppActivationHandler } from './window/macos-app-activation'
 import { focusExistingMainWindow } from './window/focus-existing-window'
 import { notifyMainWindowBecameVisible } from './window/main-window-visibility'
 import { CodexAccountService } from './codex-accounts/service'
@@ -557,12 +558,10 @@ function requestDesktopActivation(): void {
   desktopActivationGate.requestActivation()
 }
 
-function requestDesktopActivationForAppEvent(): void {
-  // Why: re-focusing an existing macOS 26 window can race its scene-backed Space transition.
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    requestDesktopActivation()
-  }
-}
+const handleMacAppActivation = createMacAppActivationHandler({
+  getWindow: () => mainWindow,
+  requestActivation: requestDesktopActivation
+})
 
 function getDesktopWindowStatus(): RuntimeDesktopWindowStatus {
   const state = desktopActivationGate.getState()
@@ -1850,7 +1849,7 @@ function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {
   )
 }
 
-app.whenReady().then(async () => {
+void app.whenReady().then(async () => {
   logStartupMilestone('app-ready')
   // Why: install certificate decisions before any webview or headless window issues its first TLS request.
   app.on(
@@ -2609,7 +2608,7 @@ app.whenReady().then(async () => {
   })
 
   startTerminalRuntimeStartupServices()
-  app.on('activate', requestDesktopActivationForAppEvent)
+  app.on('activate', handleMacAppActivation)
 
   if (serveOptions) {
     // Why: give managed WSL launchers a brief chance to migrate before headless PTYs go live, without slow repairs withholding all RPC readiness.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -557,6 +557,13 @@ function requestDesktopActivation(): void {
   desktopActivationGate.requestActivation()
 }
 
+function requestDesktopActivationForAppEvent(): void {
+  // Why: re-focusing an existing macOS 26 window can race its scene-backed Space transition.
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    requestDesktopActivation()
+  }
+}
+
 function getDesktopWindowStatus(): RuntimeDesktopWindowStatus {
   const state = desktopActivationGate.getState()
   return state === 'ready' ? 'openable' : state
@@ -2602,7 +2609,7 @@ app.whenReady().then(async () => {
   })
 
   startTerminalRuntimeStartupServices()
-  app.on('activate', requestDesktopActivation)
+  app.on('activate', requestDesktopActivationForAppEvent)
 
   if (serveOptions) {
     // Why: give managed WSL launchers a brief chance to migrate before headless PTYs go live, without slow repairs withholding all RPC readiness.

--- a/src/main/startup/serve-desktop-activation-wiring.test.ts
+++ b/src/main/startup/serve-desktop-activation-wiring.test.ts
@@ -8,8 +8,8 @@ describe('serve desktop activation wiring', () => {
   it('routes second-instance and windowless app activation through one safety gate', () => {
     expect(source).toContain('createServeDesktopActivationGate({')
     expect(source).toContain('acquireSingleInstanceLock(app, requestDesktopActivation)')
-    expect(source).toContain("app.on('activate', requestDesktopActivationForAppEvent)")
-    expect(source).toContain('if (!mainWindow || mainWindow.isDestroyed()) {')
+    expect(source).toContain('createMacAppActivationHandler({')
+    expect(source).toContain("app.on('activate', handleMacAppActivation)")
     expect(source).toContain('getDesktopWindowStatus: getDesktopWindowStatus')
   })
 

--- a/src/main/startup/serve-desktop-activation-wiring.test.ts
+++ b/src/main/startup/serve-desktop-activation-wiring.test.ts
@@ -5,10 +5,11 @@ import { describe, expect, it } from 'vitest'
 describe('serve desktop activation wiring', () => {
   const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
 
-  it('routes second-instance and app activation through one safety gate', () => {
+  it('routes second-instance and windowless app activation through one safety gate', () => {
     expect(source).toContain('createServeDesktopActivationGate({')
     expect(source).toContain('acquireSingleInstanceLock(app, requestDesktopActivation)')
-    expect(source).toContain("app.on('activate', requestDesktopActivation)")
+    expect(source).toContain("app.on('activate', requestDesktopActivationForAppEvent)")
+    expect(source).toContain('if (!mainWindow || mainWindow.isDestroyed()) {')
     expect(source).toContain('getDesktopWindowStatus: getDesktopWindowStatus')
   })
 

--- a/src/main/window/focus-existing-window.test.ts
+++ b/src/main/window/focus-existing-window.test.ts
@@ -110,19 +110,21 @@ describe('focusExistingMainWindow', () => {
 
   it('restores minimized windows before focusing them', () => {
     const window = makeFakeWindow({ minimized: true })
+    const timer = makeTimer()
 
     focusExistingMainWindow({
       app: makeFakeApp(),
       getWindow: () => window,
       openWindow: vi.fn(),
       platform: 'darwin',
-      setTimeout: makeTimer().setTimeout
+      setTimeout: timer.setTimeout
     })
 
     expect(window.calls.restore).toHaveBeenCalledTimes(1)
     expect(window.calls.show).toHaveBeenCalledTimes(1)
     expect(window.calls.focus).toHaveBeenCalledTimes(1)
     expect(window.calls.moveTop).not.toHaveBeenCalled()
+    expect(timer.scheduledMs()).toEqual([])
   })
 
   it('waits for normal startup when no window exists before app readiness', () => {

--- a/src/main/window/focus-existing-window.ts
+++ b/src/main/window/focus-existing-window.ts
@@ -81,8 +81,8 @@ function activateWindow(
       // Older Electron versions or destroyed windows may reject this; focus retry remains.
     }
     pulseAlwaysOnTop(window, setTimer)
+    retryFocus(window, app, setTimer)
   }
-  retryFocus(window, app, setTimer)
 }
 
 // Why: a second-instance/activate reopen can race transient startup pressure

--- a/src/main/window/macos-app-activation.test.ts
+++ b/src/main/window/macos-app-activation.test.ts
@@ -1,0 +1,38 @@
+import type { BrowserWindow } from 'electron'
+import { describe, expect, it, vi } from 'vitest'
+import { createMacAppActivationHandler } from './macos-app-activation'
+
+function makeWindow(destroyed = false): BrowserWindow {
+  return {
+    isDestroyed: vi.fn(() => destroyed)
+  } as unknown as BrowserWindow
+}
+
+describe('createMacAppActivationHandler', () => {
+  it('leaves an existing window to native macOS activation', () => {
+    const requestActivation = vi.fn()
+    const handler = createMacAppActivationHandler({
+      getWindow: () => makeWindow(),
+      requestActivation
+    })
+
+    handler()
+
+    expect(requestActivation).not.toHaveBeenCalled()
+  })
+
+  it.each([null, makeWindow(true)])(
+    'requests desktop activation for a missing or destroyed window',
+    (window) => {
+      const requestActivation = vi.fn()
+      const handler = createMacAppActivationHandler({
+        getWindow: () => window,
+        requestActivation
+      })
+
+      handler()
+
+      expect(requestActivation).toHaveBeenCalledTimes(1)
+    }
+  )
+})

--- a/src/main/window/macos-app-activation.ts
+++ b/src/main/window/macos-app-activation.ts
@@ -1,0 +1,14 @@
+import type { BrowserWindow } from 'electron'
+
+export function createMacAppActivationHandler(options: {
+  getWindow: () => BrowserWindow | null
+  requestActivation: () => void
+}): () => void {
+  return () => {
+    const window = options.getWindow()
+    // Why: re-focusing an existing macOS window can race its scene-backed Space transition.
+    if (!window || window.isDestroyed()) {
+      options.requestActivation()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- avoid calling native focus APIs when macOS activates an already-live main window
- keep windowless/headless desktop promotion routed through the existing activation gate
- scope the delayed focus retry to Windows, where it was originally introduced

## Diagnosis

On macOS 26.5.1, the browser-process main thread permanently deadlocked in AppKit/FrontBoardServices while processing a server-originated fullscreen window frame update. The observed sequence was:

1. `gh auth refresh` opened the external browser.
2. The user clicked back into fullscreen Orca.
3. `app.activate` called `app.focus()`, `window.show()`, and `window.focus()`, then repeated them 100 ms later.
4. The native focus sequence overlapped the macOS Space/scene transition.

PR #8646 began routing every app activation through the aggressive second-instance focus path. That path came from the Windows-specific foregrounding work in #4403, but its delayed retry was applied on every platform.

The underlying AppKit self-deadlock is tracked upstream in electron/electron#52437. This change removes Orca's avoidable native focus calls from the matching activation path while preserving deliberate second-instance and headless-promotion behavior.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/main/window/focus-existing-window.test.ts src/main/startup/serve-desktop-activation.test.ts src/main/startup/serve-desktop-activation-wiring.test.ts src/main/startup/single-instance-lock.test.ts`
- `pnpm exec oxlint src/main/window/focus-existing-window.ts src/main/window/focus-existing-window.test.ts src/main/index.ts src/main/startup/serve-desktop-activation-wiring.test.ts`
- `pnpm exec oxfmt --check src/main/window/focus-existing-window.ts src/main/window/focus-existing-window.test.ts src/main/index.ts src/main/startup/serve-desktop-activation-wiring.test.ts`
- `pnpm run typecheck:node`

## AI Review Report

Reviewed the macOS activation lifecycle, second-instance behavior, headless serve promotion, and Electron window calls. Windows retains its foreground reinforcement and delayed retry. Linux keeps the immediate reveal/focus behavior without the Windows-only retry. SSH and folder workspaces are unaffected because the change is limited to local Electron window activation.

## Security Audit

No new input handling, command execution, IPC, path, authentication, or secret surfaces. The change only narrows when existing Electron focus APIs are called.

## Screenshots

No visual change.
