### PR TITLE
fix(mobile): stop deleted worktrees from reappearing in the workspace list

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -598,8 +598,13 @@ export function HostScreen({
           setLastKnownWorktrees(updater)
         },
         refresh: () => void fetchWorktrees(),
-        // Why: a silently restored row is indistinguishable from "delete does nothing".
-        onFailure: (message) => Alert.alert('Could not delete workspace', message)
+        // Why: a silently restored row is indistinguishable from "delete does nothing", and
+        // a slow delete can fail after the user has moved on, so name the workspace.
+        onFailure: (message) =>
+          Alert.alert(
+            'Could not delete workspace',
+            `"${item.displayName || item.repo}": ${message}`
+          )
       })
     },
     [client, fetchWorktrees, worktreeRemoval]

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -95,6 +95,10 @@ import { useWorkspaceSections } from '../../../src/worktree/use-workspace-sectio
 import { getMobileWorkspaceLineageGroupKey } from '../../../src/worktree/mobile-workspace-lineage'
 import { areWorktreeListsEqual } from '../../../src/worktree/worktree-list-snapshot'
 import {
+  canDeleteWorktreeFromMobile,
+  MAIN_WORKTREE_DELETE_HINT
+} from '../../../src/worktree/worktree-delete-availability'
+import {
   getWorktreeRemovalTracker,
   STALE_SNAPSHOT_GENERATION
 } from '../../../src/worktree/worktree-removal'
@@ -1356,6 +1360,12 @@ export function HostScreen({
                     {
                       label: 'Delete',
                       destructive: true,
+                      // Why: git refuses to remove the primary checkout, so offering it is a
+                      // dead button. Desktop routes these to project removal instead.
+                      disabled: !canDeleteWorktreeFromMobile(actionTarget),
+                      ...(canDeleteWorktreeFromMobile(actionTarget)
+                        ? {}
+                        : { hint: MAIN_WORKTREE_DELETE_HINT }),
                       onPress: () => setConfirmDelete(actionTarget)
                     }
                   ]

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -94,6 +94,7 @@ import {
 import { useWorkspaceSections } from '../../../src/worktree/use-workspace-sections'
 import { getMobileWorkspaceLineageGroupKey } from '../../../src/worktree/mobile-workspace-lineage'
 import { areWorktreeListsEqual } from '../../../src/worktree/worktree-list-snapshot'
+import { createWorktreeRemovalTracker } from '../../../src/worktree/worktree-removal'
 import { repoColor } from '../../../src/worktree/repo-color'
 import {
   WORKSPACE_GROUP_OPTIONS as GROUP_OPTIONS,
@@ -146,6 +147,7 @@ export function HostScreen({
   const repoMetadataFetchedAtRef = useRef(0)
   const newWorktreeModalRef = useRef<{ open: () => void }>(null)
   const newWorktreeModalVisibleRef = useRef(false)
+  const worktreeRemovalRef = useRef(createWorktreeRemovalTracker())
   const closeHostClient = useCloseHost()
   const forceReconnectHost = useForceReconnect()
   const [worktrees, setWorktrees] = useState<Worktree[]>(initialCache ?? [])
@@ -433,23 +435,21 @@ export function HostScreen({
         }
         if (response.ok) {
           const result = (response as RpcSuccess).result as { worktrees: Worktree[] }
+          // Why: a poll in flight when a delete lands still lists the deleted worktree; without this the row comes back.
+          const snapshot = worktreeRemovalRef.current.reconcile(result.worktrees)
           // Why: reuse the existing array on identical snapshots to keep SectionList/sort rebuilds off the tap path.
-          setWorktrees((current) =>
-            areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
-          )
+          setWorktrees((current) => (areWorktreeListsEqual(current, snapshot) ? current : snapshot))
           setLastKnownWorktrees((current) =>
-            areWorktreeListsEqual(current, result.worktrees) ? current : result.worktrees
+            areWorktreeListsEqual(current, snapshot) ? current : snapshot
           )
           setWorktreesLoaded(true)
           // Why (#8498): overwrite the home-written cache with the confirmed snapshot so a reconnect/remount can't serve a stale list.
           if (hostId) {
-            setCachedWorktrees(hostId, result.worktrees)
+            setCachedWorktrees(hostId, snapshot)
           }
           // Drop the optimistic active override once the host reports it active, so later desktop changes win.
           setOptimisticActiveWorktreeId((pending) =>
-            pending && result.worktrees.some((w) => w.worktreeId === pending && w.isActive)
-              ? null
-              : pending
+            pending && snapshot.some((w) => w.worktreeId === pending && w.isActive) ? null : pending
           )
 
           // Clear optimistic sleep overrides once the server confirms inactive (liveTerminalCount === 0).
@@ -459,7 +459,7 @@ export function HostScreen({
             }
             const still = new Set<string>()
             for (const id of prev) {
-              const wt = result.worktrees.find((w) => w.worktreeId === id)
+              const wt = snapshot.find((w) => w.worktreeId === id)
               if (wt && wt.liveTerminalCount > 0) {
                 still.add(id)
               }
@@ -468,9 +468,7 @@ export function HostScreen({
           })
 
           // Sync pin state from server so desktop-initiated pins reflect without relying on stale AsyncStorage.
-          const serverPinned = new Set(
-            result.worktrees.filter((w) => w.isPinned).map((w) => w.worktreeId)
-          )
+          const serverPinned = new Set(snapshot.filter((w) => w.isPinned).map((w) => w.worktreeId))
           setPinnedIds((prev) => {
             if (serverPinned.size === prev.size && [...serverPinned].every((id) => prev.has(id))) {
               return prev
@@ -581,26 +579,17 @@ export function HostScreen({
       if (!client) {
         return
       }
-
-      const removeFromList = (list: Worktree[]) =>
-        list.filter((w) => w.worktreeId !== item.worktreeId)
-      setWorktrees(removeFromList)
-      setLastKnownWorktrees(removeFromList)
-
-      try {
-        const response = await client.sendRequest('worktree.rm', {
-          worktree: `id:${item.worktreeId}`,
-          force: true
-        })
-        if (!response.ok) {
-          setWorktrees((prev) => [...prev, item])
-          setLastKnownWorktrees((prev) => [...prev, item])
-        }
-        void fetchWorktrees()
-      } catch {
-        setWorktrees((prev) => [...prev, item])
-        setLastKnownWorktrees((prev) => [...prev, item])
-      }
+      await worktreeRemovalRef.current.remove({
+        worktree: item,
+        client,
+        updateWorktreeLists: (updater) => {
+          setWorktrees(updater)
+          setLastKnownWorktrees(updater)
+        },
+        refresh: () => void fetchWorktrees(),
+        // Why: a silently restored row is indistinguishable from "delete does nothing".
+        onFailure: (message) => Alert.alert('Could not delete workspace', message)
+      })
     },
     [client, fetchWorktrees]
   )

--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -94,7 +94,10 @@ import {
 import { useWorkspaceSections } from '../../../src/worktree/use-workspace-sections'
 import { getMobileWorkspaceLineageGroupKey } from '../../../src/worktree/mobile-workspace-lineage'
 import { areWorktreeListsEqual } from '../../../src/worktree/worktree-list-snapshot'
-import { createWorktreeRemovalTracker } from '../../../src/worktree/worktree-removal'
+import {
+  getWorktreeRemovalTracker,
+  STALE_SNAPSHOT_GENERATION
+} from '../../../src/worktree/worktree-removal'
 import { repoColor } from '../../../src/worktree/repo-color'
 import {
   WORKSPACE_GROUP_OPTIONS as GROUP_OPTIONS,
@@ -147,7 +150,7 @@ export function HostScreen({
   const repoMetadataFetchedAtRef = useRef(0)
   const newWorktreeModalRef = useRef<{ open: () => void }>(null)
   const newWorktreeModalVisibleRef = useRef(false)
-  const worktreeRemovalRef = useRef(createWorktreeRemovalTracker())
+  const worktreeRemoval = getWorktreeRemovalTracker(hostId ?? '')
   const closeHostClient = useCloseHost()
   const forceReconnectHost = useForceReconnect()
   const [worktrees, setWorktrees] = useState<Worktree[]>(initialCache ?? [])
@@ -325,8 +328,10 @@ export function HostScreen({
     // Why: useState initializer runs only on first mount, so re-seed the cache when Expo Router reuses this screen for a new hostId.
     const freshCache = hostId ? (getCachedWorktrees(hostId) as Worktree[] | null) : null
     if (freshCache) {
-      setWorktrees(freshCache)
-      setLastKnownWorktrees(freshCache)
+      // A replayed cache proves nothing about a pending delete, so it never settles one.
+      const seeded = worktreeRemoval.reconcile(freshCache, STALE_SNAPSHOT_GENERATION)
+      setWorktrees(seeded)
+      setLastKnownWorktrees(seeded)
       setWorktreesLoaded(true)
     } else {
       setWorktreesLoaded(false)
@@ -423,6 +428,7 @@ export function HostScreen({
       fetchWorktreesInFlightRef.current = true
       const requestClient = client
       const requestHostId = hostId
+      const generation = worktreeRemoval.beginSnapshot()
 
       try {
         // Why: worktree.ps silently truncates at 200; use a high cap so large hosts don't drop workspaces.
@@ -435,8 +441,9 @@ export function HostScreen({
         }
         if (response.ok) {
           const result = (response as RpcSuccess).result as { worktrees: Worktree[] }
-          // Why: a poll in flight when a delete lands still lists the deleted worktree; without this the row comes back.
-          const snapshot = worktreeRemovalRef.current.reconcile(result.worktrees)
+          // Why: the host keeps reporting a worktree until its removal finishes, so a read
+          // issued before the delete landed would otherwise resurrect the row.
+          const snapshot = worktreeRemoval.reconcile(result.worktrees, generation)
           // Why: reuse the existing array on identical snapshots to keep SectionList/sort rebuilds off the tap path.
           setWorktrees((current) => (areWorktreeListsEqual(current, snapshot) ? current : snapshot))
           setLastKnownWorktrees((current) =>
@@ -485,7 +492,7 @@ export function HostScreen({
         fetchWorktreesInFlightRef.current = false
       }
     },
-    [client, connState, hostId]
+    [client, connState, hostId, worktreeRemoval]
   )
 
   useFocusEffect(
@@ -579,10 +586,14 @@ export function HostScreen({
       if (!client) {
         return
       }
-      await worktreeRemovalRef.current.remove({
+      await worktreeRemoval.remove({
         worktree: item,
         client,
         updateWorktreeLists: (updater) => {
+          // Why: this screen is reused across hostIds, so a late rollback must not edit another host's list.
+          if (clientRef.current !== client) {
+            return
+          }
           setWorktrees(updater)
           setLastKnownWorktrees(updater)
         },
@@ -591,7 +602,7 @@ export function HostScreen({
         onFailure: (message) => Alert.alert('Could not delete workspace', message)
       })
     },
-    [client, fetchWorktrees]
+    [client, fetchWorktrees, worktreeRemoval]
   )
 
   const handleRemoveHost = useCallback(async () => {

--- a/mobile/src/worktree/worktree-delete-availability.test.ts
+++ b/mobile/src/worktree/worktree-delete-availability.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { canDeleteWorktreeFromMobile } from './worktree-delete-availability'
+
+describe('canDeleteWorktreeFromMobile', () => {
+  it('refuses the primary checkout, which git will not remove', () => {
+    // Why (regression): the main worktree sorts first in every repo group and is shown by
+    // default, so mobile offered a Delete that the runtime rejects with "Refusing to delete
+    // protected worktree path" — a dead button on the most prominent row in the list.
+    expect(canDeleteWorktreeFromMobile({ isMainWorktree: true })).toBe(false)
+  })
+
+  it('allows an ordinary worktree', () => {
+    expect(canDeleteWorktreeFromMobile({ isMainWorktree: false })).toBe(true)
+  })
+
+  it('defers to the runtime when the host does not report isMainWorktree', () => {
+    // Older hosts omit the field; guessing from the branch name would block deleting a
+    // perfectly deletable worktree that merely sits on main.
+    expect(canDeleteWorktreeFromMobile({})).toBe(true)
+  })
+})

--- a/mobile/src/worktree/worktree-delete-availability.ts
+++ b/mobile/src/worktree/worktree-delete-availability.ts
@@ -1,0 +1,15 @@
+import type { Worktree } from './workspace-list-types'
+
+// Why: mobile has no project-removal flow, so point at the one place that does.
+export const MAIN_WORKTREE_DELETE_HINT = 'Remove the project from Orca on desktop instead'
+
+/**
+ * Git refuses to remove a repo's primary checkout, and the runtime refuses to remove a
+ * folder project's root workspace — both arrive here as `isMainWorktree`. Desktop never
+ * offers the action for them; mobile must not either, or the row is a dead button.
+ */
+export function canDeleteWorktreeFromMobile(worktree: Pick<Worktree, 'isMainWorktree'>): boolean {
+  // Hosts predating isMainWorktree in worktree.ps report nothing here; let the runtime
+  // answer rather than guessing from the branch name and blocking a deletable worktree.
+  return worktree.isMainWorktree !== true
+}

--- a/mobile/src/worktree/worktree-removal.test.ts
+++ b/mobile/src/worktree/worktree-removal.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest'
+import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
+import type { RpcResponse } from '../transport/types'
+import type { Worktree } from './workspace-list-types'
+import {
+  WORKTREE_REMOVAL_TOMBSTONE_TTL_MS,
+  WORKTREE_REMOVE_TIMEOUT_MS,
+  createWorktreeRemovalTracker
+} from './worktree-removal'
+
+function worktree(worktreeId: string): Worktree {
+  return {
+    worktreeId,
+    repoId: 'repo-1',
+    repo: 'orca',
+    branch: `feature/${worktreeId}`,
+    displayName: worktreeId,
+    path: `/tmp/orca/worktrees/${worktreeId}`,
+    liveTerminalCount: 0,
+    hasAttachedPty: false,
+    preview: '',
+    unread: false,
+    isPinned: false,
+    linkedPR: null
+  }
+}
+
+function success(result: unknown = { removed: true }): RpcResponse {
+  return { id: '1', ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+}
+
+function failure(message: string): RpcResponse {
+  return {
+    id: '1',
+    ok: false,
+    error: { code: 'internal', message },
+    _meta: { runtimeId: 'runtime-1' }
+  }
+}
+
+function listHarness(initial: Worktree[]) {
+  let list = initial
+  return {
+    get current(): Worktree[] {
+      return list
+    },
+    update: (updater: (value: Worktree[]) => Worktree[]) => {
+      list = updater(list)
+    }
+  }
+}
+
+describe('createWorktreeRemovalTracker', () => {
+  it('sends worktree.rm with the desktop-sized timeout and keeps the row hidden', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1'), worktree('wt-2')])
+    const sendRequest = vi.fn().mockResolvedValue(success())
+    const refresh = vi.fn()
+    const onFailure = vi.fn()
+
+    await tracker.remove({
+      worktree: worktree('wt-1'),
+      client: { sendRequest },
+      updateWorktreeLists: lists.update,
+      refresh,
+      onFailure
+    })
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'worktree.rm',
+      { worktree: 'id:wt-1', force: true },
+      { timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS }
+    )
+    expect(lists.current.map((entry) => entry.worktreeId)).toEqual(['wt-2'])
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(onFailure).not.toHaveBeenCalled()
+  })
+
+  it('drops a deleted worktree from a snapshot the host took before the delete landed', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1'), worktree('wt-2')])
+
+    await tracker.remove({
+      worktree: worktree('wt-1'),
+      client: { sendRequest: vi.fn().mockResolvedValue(success()) },
+      updateWorktreeLists: lists.update,
+      refresh: () => {},
+      onFailure: () => {},
+      now: () => 1000
+    })
+
+    const stale = [worktree('wt-1'), worktree('wt-2')]
+    expect(tracker.reconcile(stale, 1500).map((entry) => entry.worktreeId)).toEqual(['wt-2'])
+  })
+
+  it('stops hiding a worktree once the host confirms it is gone', async () => {
+    const tracker = createWorktreeRemovalTracker()
+
+    await tracker.remove({
+      worktree: worktree('wt-1'),
+      client: { sendRequest: vi.fn().mockResolvedValue(success()) },
+      updateWorktreeLists: () => {},
+      refresh: () => {},
+      onFailure: () => {},
+      now: () => 1000
+    })
+
+    expect(tracker.reconcile([worktree('wt-2')], 1500)).toHaveLength(1)
+    // The worktree id is untracked again, so a same-id workspace recreated later shows up.
+    const recreated = [worktree('wt-1'), worktree('wt-2')]
+    expect(tracker.reconcile(recreated, 1600)).toBe(recreated)
+  })
+
+  it('stops hiding a worktree the host keeps reporting past the tombstone TTL', async () => {
+    const tracker = createWorktreeRemovalTracker()
+
+    await tracker.remove({
+      worktree: worktree('wt-1'),
+      client: { sendRequest: vi.fn().mockResolvedValue(success()) },
+      updateWorktreeLists: () => {},
+      refresh: () => {},
+      onFailure: () => {},
+      now: () => 1000
+    })
+
+    const stubborn = [worktree('wt-1')]
+    expect(tracker.reconcile(stubborn, 1000 + WORKTREE_REMOVAL_TOMBSTONE_TTL_MS - 1)).toHaveLength(
+      0
+    )
+    expect(tracker.reconcile(stubborn, 1000 + WORKTREE_REMOVAL_TOMBSTONE_TTL_MS)).toBe(stubborn)
+  })
+
+  it('restores the row and reports the host error when the delete is rejected', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1')])
+    const onFailure = vi.fn()
+
+    await tracker.remove({
+      worktree: worktree('wt-1'),
+      client: { sendRequest: vi.fn().mockResolvedValue(failure('worktree is locked')) },
+      updateWorktreeLists: lists.update,
+      refresh: () => {},
+      onFailure
+    })
+
+    expect(lists.current.map((entry) => entry.worktreeId)).toEqual(['wt-1'])
+    expect(onFailure).toHaveBeenCalledWith('worktree is locked')
+    expect(tracker.reconcile([worktree('wt-1')])).toHaveLength(1)
+  })
+
+  it('restores the row and reports the message when the request throws', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1')])
+    const onFailure = vi.fn()
+
+    await tracker.remove({
+      worktree: worktree('wt-1'),
+      client: { sendRequest: vi.fn().mockRejectedValue(new Error('repo_not_found')) },
+      updateWorktreeLists: lists.update,
+      refresh: () => {},
+      onFailure
+    })
+
+    expect(lists.current).toHaveLength(1)
+    expect(onFailure).toHaveBeenCalledWith('repo_not_found')
+  })
+
+  it('keeps the row hidden when delivery is unknown, since the host may still be deleting', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1')])
+    const onFailure = vi.fn()
+
+    await tracker.remove({
+      worktree: worktree('wt-1'),
+      client: {
+        sendRequest: vi
+          .fn()
+          .mockRejectedValue(markRpcDeliveryUnknown(new Error('Request timed out: worktree.rm')))
+      },
+      updateWorktreeLists: lists.update,
+      refresh: () => {},
+      onFailure,
+      now: () => 1000
+    })
+
+    expect(lists.current).toHaveLength(0)
+    expect(onFailure).not.toHaveBeenCalled()
+    expect(tracker.reconcile([worktree('wt-1')], 1500)).toHaveLength(0)
+  })
+
+  it('refreshes after both outcomes so a rolled-back list re-sorts from the host', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const refresh = vi.fn()
+
+    await tracker.remove({
+      worktree: worktree('wt-1'),
+      client: { sendRequest: vi.fn().mockRejectedValue(new Error('boom')) },
+      updateWorktreeLists: () => {},
+      refresh,
+      onFailure: () => {}
+    })
+
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves untouched snapshots referentially stable', () => {
+    const tracker = createWorktreeRemovalTracker()
+    const snapshot = [worktree('wt-1')]
+
+    expect(tracker.reconcile(snapshot)).toBe(snapshot)
+  })
+})

--- a/mobile/src/worktree/worktree-removal.test.ts
+++ b/mobile/src/worktree/worktree-removal.test.ts
@@ -3,9 +3,12 @@ import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
 import type { RpcResponse } from '../transport/types'
 import type { Worktree } from './workspace-list-types'
 import {
-  WORKTREE_REMOVAL_TOMBSTONE_TTL_MS,
+  STALE_SNAPSHOT_GENERATION,
+  WORKTREE_REMOVAL_AMBIGUOUS_GRACE_MS,
   WORKTREE_REMOVE_TIMEOUT_MS,
-  createWorktreeRemovalTracker
+  createWorktreeRemovalTracker,
+  getWorktreeRemovalTracker,
+  type RemoveWorktreeArgs
 } from './worktree-removal'
 
 function worktree(worktreeId: string): Worktree {
@@ -25,8 +28,8 @@ function worktree(worktreeId: string): Worktree {
   }
 }
 
-function success(result: unknown = { removed: true }): RpcResponse {
-  return { id: '1', ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+function success(): RpcResponse {
+  return { id: '1', ok: true, result: { removed: true }, _meta: { runtimeId: 'runtime-1' } }
 }
 
 function failure(message: string): RpcResponse {
@@ -38,11 +41,15 @@ function failure(message: string): RpcResponse {
   }
 }
 
+function timeout(): Error {
+  return markRpcDeliveryUnknown(new Error('Request timed out: worktree.rm'))
+}
+
 function listHarness(initial: Worktree[]) {
   let list = initial
   return {
-    get current(): Worktree[] {
-      return list
+    get ids(): string[] {
+      return list.map((entry) => entry.worktreeId)
     },
     update: (updater: (value: Worktree[]) => Worktree[]) => {
       list = updater(list)
@@ -50,84 +57,159 @@ function listHarness(initial: Worktree[]) {
   }
 }
 
-describe('createWorktreeRemovalTracker', () => {
-  it('sends worktree.rm with the desktop-sized timeout and keeps the row hidden', async () => {
+type RemoveOverrides = Partial<RemoveWorktreeArgs> & { response?: RpcResponse; rejectWith?: Error }
+
+function removeArgs(worktreeId: string, overrides: RemoveOverrides = {}): RemoveWorktreeArgs {
+  const { response, rejectWith, ...rest } = overrides
+  const sendRequest = rejectWith
+    ? vi.fn().mockRejectedValue(rejectWith)
+    : vi.fn().mockResolvedValue(response ?? success())
+  return {
+    worktree: worktree(worktreeId),
+    client: { sendRequest },
+    updateWorktreeLists: () => {},
+    refresh: () => {},
+    onFailure: () => {},
+    ...rest
+  }
+}
+
+describe('worktree removal tracker', () => {
+  it('sends worktree.rm with the desktop-sized timeout and drops the row', async () => {
     const tracker = createWorktreeRemovalTracker()
     const lists = listHarness([worktree('wt-1'), worktree('wt-2')])
     const sendRequest = vi.fn().mockResolvedValue(success())
-    const refresh = vi.fn()
     const onFailure = vi.fn()
+    const refresh = vi.fn()
 
-    await tracker.remove({
-      worktree: worktree('wt-1'),
-      client: { sendRequest },
-      updateWorktreeLists: lists.update,
-      refresh,
-      onFailure
-    })
+    await tracker.remove(
+      removeArgs('wt-1', {
+        client: { sendRequest },
+        updateWorktreeLists: lists.update,
+        onFailure,
+        refresh
+      })
+    )
 
     expect(sendRequest).toHaveBeenCalledWith(
       'worktree.rm',
       { worktree: 'id:wt-1', force: true },
       { timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS }
     )
-    expect(lists.current.map((entry) => entry.worktreeId)).toEqual(['wt-2'])
-    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(lists.ids).toEqual(['wt-2'])
     expect(onFailure).not.toHaveBeenCalled()
+    expect(refresh).toHaveBeenCalledTimes(1)
   })
 
-  it('drops a deleted worktree from a snapshot the host took before the delete landed', async () => {
+  it('hides the worktree in a read issued before the delete landed', async () => {
     const tracker = createWorktreeRemovalTracker()
-    const lists = listHarness([worktree('wt-1'), worktree('wt-2')])
+    // The poll that was already in flight when the user confirmed the delete.
+    const inFlight = tracker.beginSnapshot()
 
-    await tracker.remove({
-      worktree: worktree('wt-1'),
-      client: { sendRequest: vi.fn().mockResolvedValue(success()) },
-      updateWorktreeLists: lists.update,
-      refresh: () => {},
-      onFailure: () => {},
-      now: () => 1000
-    })
+    await tracker.remove(removeArgs('wt-1'))
 
     const stale = [worktree('wt-1'), worktree('wt-2')]
-    expect(tracker.reconcile(stale, 1500).map((entry) => entry.worktreeId)).toEqual(['wt-2'])
+    expect(tracker.reconcile(stale, inFlight).map((entry) => entry.worktreeId)).toEqual(['wt-2'])
   })
 
-  it('stops hiding a worktree once the host confirms it is gone', async () => {
+  it('hides the worktree for the whole delete, not just one poll', async () => {
     const tracker = createWorktreeRemovalTracker()
+    let settle = (_: RpcResponse) => {}
+    const sendRequest = vi.fn().mockReturnValue(
+      new Promise<RpcResponse>((resolve) => {
+        settle = resolve
+      })
+    )
+    const removal = tracker.remove(removeArgs('wt-1', { client: { sendRequest } }))
 
-    await tracker.remove({
-      worktree: worktree('wt-1'),
-      client: { sendRequest: vi.fn().mockResolvedValue(success()) },
-      updateWorktreeLists: () => {},
-      refresh: () => {},
-      onFailure: () => {},
-      now: () => 1000
-    })
+    // The host truthfully keeps reporting the worktree until the removal finishes.
+    for (let poll = 0; poll < 5; poll += 1) {
+      const snapshot = [worktree('wt-1')]
+      expect(tracker.reconcile(snapshot, tracker.beginSnapshot())).toHaveLength(0)
+    }
 
-    expect(tracker.reconcile([worktree('wt-2')], 1500)).toHaveLength(1)
-    // The worktree id is untracked again, so a same-id workspace recreated later shows up.
-    const recreated = [worktree('wt-1'), worktree('wt-2')]
-    expect(tracker.reconcile(recreated, 1600)).toBe(recreated)
+    settle(success())
+    await removal
   })
 
-  it('stops hiding a worktree the host keeps reporting past the tombstone TTL', async () => {
+  it('stops hiding a worktree recreated at the same path after the delete', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    // Why (regression): ids are path-derived and reused. Clearing only when the host stops
+    // reporting the id hid a freshly recreated workspace until the grace period lapsed.
+    await tracker.remove(removeArgs('wt-1'))
+
+    const recreated = [worktree('wt-1')]
+    expect(tracker.reconcile(recreated, tracker.beginSnapshot())).toBe(recreated)
+  })
+
+  it('keeps hiding a confirmed delete across reads issued before it resolved', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const stale = tracker.beginSnapshot()
+
+    await tracker.remove(removeArgs('wt-1'))
+
+    expect(tracker.reconcile([worktree('wt-1')], stale)).toHaveLength(0)
+  })
+
+  it('never lets a replayed cache settle a pending delete', async () => {
     const tracker = createWorktreeRemovalTracker()
 
-    await tracker.remove({
-      worktree: worktree('wt-1'),
-      client: { sendRequest: vi.fn().mockResolvedValue(success()) },
-      updateWorktreeLists: () => {},
-      refresh: () => {},
-      onFailure: () => {},
-      now: () => 1000
+    await tracker.remove(removeArgs('wt-1'))
+
+    const cached = [worktree('wt-1')]
+    expect(tracker.reconcile(cached, STALE_SNAPSHOT_GENERATION)).toHaveLength(0)
+  })
+
+  it('keeps the row hidden for the grace period after an rm times out', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1')])
+    const onFailure = vi.fn()
+    // Why (regression): the timeout fires a full WORKTREE_REMOVE_TIMEOUT_MS after the
+    // request starts. A grace period measured from the request would already be spent,
+    // so the row reappeared the instant the delete timed out.
+    let clock = 1000
+    const sendRequest = vi.fn().mockImplementation(() => {
+      clock += WORKTREE_REMOVE_TIMEOUT_MS
+      return Promise.reject(timeout())
     })
+
+    await tracker.remove(
+      removeArgs('wt-1', {
+        client: { sendRequest },
+        updateWorktreeLists: lists.update,
+        onFailure,
+        now: () => clock
+      })
+    )
 
     const stubborn = [worktree('wt-1')]
-    expect(tracker.reconcile(stubborn, 1000 + WORKTREE_REMOVAL_TOMBSTONE_TTL_MS - 1)).toHaveLength(
-      0
-    )
-    expect(tracker.reconcile(stubborn, 1000 + WORKTREE_REMOVAL_TOMBSTONE_TTL_MS)).toBe(stubborn)
+    expect(lists.ids).toEqual([])
+    expect(onFailure).not.toHaveBeenCalled()
+    expect(tracker.reconcile(stubborn, tracker.beginSnapshot(), clock)).toHaveLength(0)
+    expect(
+      tracker.reconcile(
+        stubborn,
+        tracker.beginSnapshot(),
+        clock + WORKTREE_REMOVAL_AMBIGUOUS_GRACE_MS - 1
+      )
+    ).toHaveLength(0)
+    expect(
+      tracker.reconcile(
+        stubborn,
+        tracker.beginSnapshot(),
+        clock + WORKTREE_REMOVAL_AMBIGUOUS_GRACE_MS
+      )
+    ).toBe(stubborn)
+  })
+
+  it('leaves an ambiguous delete gone once the host confirms it', async () => {
+    const tracker = createWorktreeRemovalTracker()
+
+    await tracker.remove(removeArgs('wt-1', { rejectWith: timeout(), now: () => 1000 }))
+
+    expect(tracker.reconcile([worktree('wt-2')], tracker.beginSnapshot(), 1500)).toHaveLength(1)
+    const recreated = [worktree('wt-1')]
+    expect(tracker.reconcile(recreated, tracker.beginSnapshot(), 1600)).toBe(recreated)
   })
 
   it('restores the row and reports the host error when the delete is rejected', async () => {
@@ -135,17 +217,37 @@ describe('createWorktreeRemovalTracker', () => {
     const lists = listHarness([worktree('wt-1')])
     const onFailure = vi.fn()
 
-    await tracker.remove({
-      worktree: worktree('wt-1'),
-      client: { sendRequest: vi.fn().mockResolvedValue(failure('worktree is locked')) },
-      updateWorktreeLists: lists.update,
-      refresh: () => {},
-      onFailure
-    })
+    await tracker.remove(
+      removeArgs('wt-1', {
+        response: failure('worktree is locked'),
+        updateWorktreeLists: lists.update,
+        onFailure
+      })
+    )
 
-    expect(lists.current.map((entry) => entry.worktreeId)).toEqual(['wt-1'])
+    expect(lists.ids).toEqual(['wt-1'])
     expect(onFailure).toHaveBeenCalledWith('worktree is locked')
-    expect(tracker.reconcile([worktree('wt-1')])).toHaveLength(1)
+    expect(tracker.reconcile([worktree('wt-1')], tracker.beginSnapshot())).toHaveLength(1)
+  })
+
+  it('restores the row once, even if a poll already put it back', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1')])
+
+    await tracker.remove(
+      removeArgs('wt-1', {
+        response: failure('worktree is locked'),
+        updateWorktreeLists: (updater) => {
+          lists.update(updater)
+          // A poll resolving between the optimistic drop and the rollback.
+          lists.update((list) =>
+            list.some((entry) => entry.worktreeId === 'wt-1') ? list : [...list, worktree('wt-1')]
+          )
+        }
+      })
+    )
+
+    expect(lists.ids).toEqual(['wt-1'])
   })
 
   it('restores the row and reports the message when the request throws', async () => {
@@ -153,52 +255,23 @@ describe('createWorktreeRemovalTracker', () => {
     const lists = listHarness([worktree('wt-1')])
     const onFailure = vi.fn()
 
-    await tracker.remove({
-      worktree: worktree('wt-1'),
-      client: { sendRequest: vi.fn().mockRejectedValue(new Error('repo_not_found')) },
-      updateWorktreeLists: lists.update,
-      refresh: () => {},
-      onFailure
-    })
+    await tracker.remove(
+      removeArgs('wt-1', {
+        rejectWith: new Error('repo_not_found'),
+        updateWorktreeLists: lists.update,
+        onFailure
+      })
+    )
 
-    expect(lists.current).toHaveLength(1)
+    expect(lists.ids).toEqual(['wt-1'])
     expect(onFailure).toHaveBeenCalledWith('repo_not_found')
   })
 
-  it('keeps the row hidden when delivery is unknown, since the host may still be deleting', async () => {
-    const tracker = createWorktreeRemovalTracker()
-    const lists = listHarness([worktree('wt-1')])
-    const onFailure = vi.fn()
-
-    await tracker.remove({
-      worktree: worktree('wt-1'),
-      client: {
-        sendRequest: vi
-          .fn()
-          .mockRejectedValue(markRpcDeliveryUnknown(new Error('Request timed out: worktree.rm')))
-      },
-      updateWorktreeLists: lists.update,
-      refresh: () => {},
-      onFailure,
-      now: () => 1000
-    })
-
-    expect(lists.current).toHaveLength(0)
-    expect(onFailure).not.toHaveBeenCalled()
-    expect(tracker.reconcile([worktree('wt-1')], 1500)).toHaveLength(0)
-  })
-
-  it('refreshes after both outcomes so a rolled-back list re-sorts from the host', async () => {
+  it('refreshes after every outcome so the list re-sorts from the host', async () => {
     const tracker = createWorktreeRemovalTracker()
     const refresh = vi.fn()
 
-    await tracker.remove({
-      worktree: worktree('wt-1'),
-      client: { sendRequest: vi.fn().mockRejectedValue(new Error('boom')) },
-      updateWorktreeLists: () => {},
-      refresh,
-      onFailure: () => {}
-    })
+    await tracker.remove(removeArgs('wt-1', { rejectWith: new Error('boom'), refresh }))
 
     expect(refresh).toHaveBeenCalledTimes(1)
   })
@@ -207,6 +280,22 @@ describe('createWorktreeRemovalTracker', () => {
     const tracker = createWorktreeRemovalTracker()
     const snapshot = [worktree('wt-1')]
 
-    expect(tracker.reconcile(snapshot)).toBe(snapshot)
+    expect(tracker.reconcile(snapshot, tracker.beginSnapshot())).toBe(snapshot)
+  })
+
+  it('keeps one host cached tracker per hostId so a remount remembers a pending delete', async () => {
+    // Why: worktree ids are only unique per host, and the list screen unmounts on
+    // navigation and is reused across hostIds.
+    const removal = getWorktreeRemovalTracker('host-a').remove(removeArgs('wt-1'))
+    await removal
+
+    const remounted = getWorktreeRemovalTracker('host-a')
+    expect(remounted).toBe(getWorktreeRemovalTracker('host-a'))
+    expect(remounted.reconcile([worktree('wt-1')], STALE_SNAPSHOT_GENERATION)).toHaveLength(0)
+
+    const otherHost = [worktree('wt-1')]
+    expect(
+      getWorktreeRemovalTracker('host-b').reconcile(otherHost, STALE_SNAPSHOT_GENERATION)
+    ).toBe(otherHost)
   })
 })

--- a/mobile/src/worktree/worktree-removal.test.ts
+++ b/mobile/src/worktree/worktree-removal.test.ts
@@ -160,6 +160,32 @@ describe('worktree removal tracker', () => {
     expect(tracker.reconcile(cached, STALE_SNAPSHOT_GENERATION)).toHaveLength(0)
   })
 
+  it('does not let a cache written during the delete settle it', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    let settle = (_: RpcResponse) => {}
+    const sendRequest = vi.fn().mockReturnValue(
+      new Promise<RpcResponse>((resolve) => {
+        settle = resolve
+      })
+    )
+    const removal = tracker.remove(removeArgs('wt-1', { client: { sendRequest } }))
+
+    // Why (regression): the screen caches the *reconciled* list, so remounting mid-delete
+    // replays a cache the row is already missing from. Treating that absence as the host
+    // confirming the delete dropped the pending state, and the next poll — with the host
+    // still mid-removal and still reporting the worktree — put the row back.
+    const cachedDuringDelete = [worktree('wt-2')]
+    tracker.reconcile(cachedDuringDelete, STALE_SNAPSHOT_GENERATION)
+
+    const stillRemoving = [worktree('wt-1'), worktree('wt-2')]
+    expect(
+      tracker.reconcile(stillRemoving, tracker.beginSnapshot()).map((entry) => entry.worktreeId)
+    ).toEqual(['wt-2'])
+
+    settle(success())
+    await removal
+  })
+
   it('keeps the row hidden for the grace period after an rm times out', async () => {
     const tracker = createWorktreeRemovalTracker()
     const lists = listHarness([worktree('wt-1')])
@@ -228,6 +254,51 @@ describe('worktree removal tracker', () => {
     expect(lists.ids).toEqual(['wt-1'])
     expect(onFailure).toHaveBeenCalledWith('worktree is locked')
     expect(tracker.reconcile([worktree('wt-1')], tracker.beginSnapshot())).toHaveLength(1)
+  })
+
+  it('coalesces a double-fired delete into one request', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1')])
+    const onFailure = vi.fn()
+    let settle = (_: RpcResponse) => {}
+    const sendRequest = vi.fn().mockReturnValue(
+      new Promise<RpcResponse>((resolve) => {
+        settle = resolve
+      })
+    )
+    const args = removeArgs('wt-1', {
+      client: { sendRequest },
+      updateWorktreeLists: lists.update,
+      onFailure
+    })
+
+    // Why (regression): the confirm button can fire twice before the sheet unmounts. The
+    // loser's rollback would otherwise re-add the row and drop the winner's pending state.
+    const first = tracker.remove(args)
+    const second = tracker.remove(args)
+    expect(second).toBe(first)
+
+    settle(failure('worktree is locked'))
+    await Promise.all([first, second])
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(onFailure).toHaveBeenCalledTimes(1)
+    expect(lists.ids).toEqual(['wt-1'])
+  })
+
+  it('accepts a fresh delete once the previous attempt settled', async () => {
+    const tracker = createWorktreeRemovalTracker()
+    const lists = listHarness([worktree('wt-1')])
+
+    await tracker.remove(
+      removeArgs('wt-1', {
+        response: failure('worktree is locked'),
+        updateWorktreeLists: lists.update
+      })
+    )
+    await tracker.remove(removeArgs('wt-1', { updateWorktreeLists: lists.update }))
+
+    expect(lists.ids).toEqual([])
   })
 
   it('restores the row once, even if a poll already put it back', async () => {

--- a/mobile/src/worktree/worktree-removal.ts
+++ b/mobile/src/worktree/worktree-removal.ts
@@ -1,0 +1,99 @@
+import type { RpcClient } from '../transport/rpc-client'
+import { isRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
+import type { Worktree } from './workspace-list-types'
+
+// Why: matches the desktop worktree.rm budget — SSH teardown, archive hooks and
+// large node_modules deletes routinely outrun the generic 30s mobile RPC timeout.
+export const WORKTREE_REMOVE_TIMEOUT_MS = 60_000
+
+// Why: a removed worktree stays hidden only until worktree.ps stops reporting it;
+// the TTL keeps a half-removed workspace from being invisible forever.
+export const WORKTREE_REMOVAL_TOMBSTONE_TTL_MS = 60_000
+
+const WORKTREE_REMOVE_FAILURE_FALLBACK = 'The host could not delete this workspace.'
+
+export type WorktreeListUpdate = (updater: (list: Worktree[]) => Worktree[]) => void
+
+export type RemoveWorktreeArgs = {
+  worktree: Worktree
+  client: Pick<RpcClient, 'sendRequest'>
+  /** Applies the same edit to every list mirroring the host snapshot. */
+  updateWorktreeLists: WorktreeListUpdate
+  refresh: () => void
+  onFailure: (message: string) => void
+  now?: () => number
+}
+
+export type WorktreeRemovalTracker = {
+  /** Drops rows this client already deleted from a host snapshot taken before the delete landed. */
+  reconcile: (snapshot: Worktree[], now?: number) => Worktree[]
+  remove: (args: RemoveWorktreeArgs) => Promise<void>
+}
+
+/**
+ * Tracks worktrees this client asked the host to delete. `worktree.ps` polls every
+ * 3s, so a snapshot requested before the delete resolves still lists the worktree and
+ * would otherwise resurrect the row the user just removed.
+ */
+export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
+  const removedAtById = new Map<string, number>()
+
+  function reconcile(snapshot: Worktree[], now = Date.now()): Worktree[] {
+    if (removedAtById.size === 0) {
+      return snapshot
+    }
+    const reported = new Set(snapshot.map((entry) => entry.worktreeId))
+    // Deleting the current entry mid-iteration is safe for a Map.
+    for (const [worktreeId, removedAt] of removedAtById) {
+      if (!reported.has(worktreeId) || now - removedAt >= WORKTREE_REMOVAL_TOMBSTONE_TTL_MS) {
+        removedAtById.delete(worktreeId)
+      }
+    }
+    if (removedAtById.size === 0) {
+      return snapshot
+    }
+    return snapshot.filter((entry) => !removedAtById.has(entry.worktreeId))
+  }
+
+  async function remove({
+    worktree,
+    client,
+    updateWorktreeLists,
+    refresh,
+    onFailure,
+    now = Date.now
+  }: RemoveWorktreeArgs): Promise<void> {
+    const { worktreeId } = worktree
+    removedAtById.set(worktreeId, now())
+    updateWorktreeLists((list) => list.filter((entry) => entry.worktreeId !== worktreeId))
+
+    const restore = (message: string): void => {
+      removedAtById.delete(worktreeId)
+      updateWorktreeLists((list) =>
+        list.some((entry) => entry.worktreeId === worktreeId) ? list : [...list, worktree]
+      )
+      onFailure(message)
+    }
+
+    try {
+      const response = await client.sendRequest(
+        'worktree.rm',
+        { worktree: `id:${worktreeId}`, force: true },
+        { timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS }
+      )
+      if (!response.ok) {
+        restore(response.error.message || WORKTREE_REMOVE_FAILURE_FALLBACK)
+      }
+    } catch (error) {
+      // Why: a timed-out or socket-dropped rm may still be running on the host, so
+      // keep the row hidden and let the next snapshot (or the TTL) settle it.
+      if (!isRpcDeliveryUnknown(error)) {
+        restore(error instanceof Error ? error.message : WORKTREE_REMOVE_FAILURE_FALLBACK)
+      }
+    } finally {
+      refresh()
+    }
+  }
+
+  return { reconcile, remove }
+}

--- a/mobile/src/worktree/worktree-removal.ts
+++ b/mobile/src/worktree/worktree-removal.ts
@@ -6,11 +6,23 @@ import type { Worktree } from './workspace-list-types'
 // large node_modules deletes routinely outrun the generic 30s mobile RPC timeout.
 export const WORKTREE_REMOVE_TIMEOUT_MS = 60_000
 
-// Why: a removed worktree stays hidden only until worktree.ps stops reporting it;
-// the TTL keeps a half-removed workspace from being invisible forever.
-export const WORKTREE_REMOVAL_TOMBSTONE_TTL_MS = 60_000
+// Why: a timed-out or socket-dropped rm may still be running on the host. Hide the row
+// this long past the failure, then let the host's own answer stand. Measured from the
+// failure, not the request, or the delete timeout would consume the whole window.
+export const WORKTREE_REMOVAL_AMBIGUOUS_GRACE_MS = 60_000
+
+// Snapshots that cannot settle a removal: replayed caches, not a fresh worktree.ps read.
+export const STALE_SNAPSHOT_GENERATION = 0
 
 const WORKTREE_REMOVE_FAILURE_FALLBACK = 'The host could not delete this workspace.'
+
+type PendingRemoval = {
+  // Snapshot generation past which the host's answer is authoritative. Null while the rm
+  // is in flight and for ambiguous outcomes, where no snapshot can settle the question.
+  authoritativeAfter: number | null
+  // Deadline for an ambiguous outcome; null when the outcome is known.
+  revealAt: number | null
+}
 
 export type WorktreeListUpdate = (updater: (list: Worktree[]) => Worktree[]) => void
 
@@ -25,34 +37,46 @@ export type RemoveWorktreeArgs = {
 }
 
 export type WorktreeRemovalTracker = {
-  /** Drops rows this client already deleted from a host snapshot taken before the delete landed. */
-  reconcile: (snapshot: Worktree[], now?: number) => Worktree[]
+  /** Stamps a worktree.ps read so reconcile can tell pre-delete snapshots from post-delete ones. */
+  beginSnapshot: () => number
+  /** Drops rows this client already deleted from a snapshot that predates the delete. */
+  reconcile: (snapshot: Worktree[], generation: number, now?: number) => Worktree[]
   remove: (args: RemoveWorktreeArgs) => Promise<void>
 }
 
 /**
- * Tracks worktrees this client asked the host to delete. `worktree.ps` polls every
- * 3s, so a snapshot requested before the delete resolves still lists the worktree and
- * would otherwise resurrect the row the user just removed.
+ * Tracks worktrees this client asked the host to delete. `worktree.ps` polls every 3s and
+ * the host keeps reporting a worktree until the removal finishes, so without this a poll
+ * issued before the delete landed resurrects the row the user just removed.
  */
 export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
-  const removedAtById = new Map<string, number>()
+  const pending = new Map<string, PendingRemoval>()
+  let snapshotGeneration = STALE_SNAPSHOT_GENERATION
 
-  function reconcile(snapshot: Worktree[], now = Date.now()): Worktree[] {
-    if (removedAtById.size === 0) {
+  function beginSnapshot(): number {
+    snapshotGeneration += 1
+    return snapshotGeneration
+  }
+
+  function reconcile(snapshot: Worktree[], generation: number, now = Date.now()): Worktree[] {
+    if (pending.size === 0) {
       return snapshot
     }
     const reported = new Set(snapshot.map((entry) => entry.worktreeId))
     // Deleting the current entry mid-iteration is safe for a Map.
-    for (const [worktreeId, removedAt] of removedAtById) {
-      if (!reported.has(worktreeId) || now - removedAt >= WORKTREE_REMOVAL_TOMBSTONE_TTL_MS) {
-        removedAtById.delete(worktreeId)
+    for (const [worktreeId, removal] of pending) {
+      const settled =
+        !reported.has(worktreeId) ||
+        (removal.authoritativeAfter !== null && generation > removal.authoritativeAfter) ||
+        (removal.revealAt !== null && now >= removal.revealAt)
+      if (settled) {
+        pending.delete(worktreeId)
       }
     }
-    if (removedAtById.size === 0) {
+    if (pending.size === 0) {
       return snapshot
     }
-    return snapshot.filter((entry) => !removedAtById.has(entry.worktreeId))
+    return snapshot.filter((entry) => !pending.has(entry.worktreeId))
   }
 
   async function remove({
@@ -64,11 +88,11 @@ export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
     now = Date.now
   }: RemoveWorktreeArgs): Promise<void> {
     const { worktreeId } = worktree
-    removedAtById.set(worktreeId, now())
+    pending.set(worktreeId, { authoritativeAfter: null, revealAt: null })
     updateWorktreeLists((list) => list.filter((entry) => entry.worktreeId !== worktreeId))
 
     const restore = (message: string): void => {
-      removedAtById.delete(worktreeId)
+      pending.delete(worktreeId)
       updateWorktreeLists((list) =>
         list.some((entry) => entry.worktreeId === worktreeId) ? list : [...list, worktree]
       )
@@ -81,13 +105,21 @@ export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
         { worktree: `id:${worktreeId}`, force: true },
         { timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS }
       )
-      if (!response.ok) {
+      if (response.ok) {
+        // Why: worktree ids are path-derived and get reused, so stop hiding as soon as a
+        // read issued after the delete answers — otherwise a workspace recreated at the
+        // same path stays invisible.
+        pending.set(worktreeId, { authoritativeAfter: snapshotGeneration, revealAt: null })
+      } else {
         restore(response.error.message || WORKTREE_REMOVE_FAILURE_FALLBACK)
       }
     } catch (error) {
-      // Why: a timed-out or socket-dropped rm may still be running on the host, so
-      // keep the row hidden and let the next snapshot (or the TTL) settle it.
-      if (!isRpcDeliveryUnknown(error)) {
+      if (isRpcDeliveryUnknown(error)) {
+        pending.set(worktreeId, {
+          authoritativeAfter: null,
+          revealAt: now() + WORKTREE_REMOVAL_AMBIGUOUS_GRACE_MS
+        })
+      } else {
         restore(error instanceof Error ? error.message : WORKTREE_REMOVE_FAILURE_FALLBACK)
       }
     } finally {
@@ -95,5 +127,20 @@ export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
     }
   }
 
-  return { reconcile, remove }
+  return { beginSnapshot, reconcile, remove }
+}
+
+// Why: the list screen unmounts on navigation and is reused across hostIds, so per-mount
+// state would forget an in-flight delete — and leak one host's ids onto another's list,
+// since worktree ids are only unique per host.
+const trackersByHostId = new Map<string, WorktreeRemovalTracker>()
+
+export function getWorktreeRemovalTracker(hostId: string): WorktreeRemovalTracker {
+  const existing = trackersByHostId.get(hostId)
+  if (existing) {
+    return existing
+  }
+  const tracker = createWorktreeRemovalTracker()
+  trackersByHostId.set(hostId, tracker)
+  return tracker
 }

--- a/mobile/src/worktree/worktree-removal.ts
+++ b/mobile/src/worktree/worktree-removal.ts
@@ -51,6 +51,7 @@ export type WorktreeRemovalTracker = {
  */
 export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
   const pending = new Map<string, PendingRemoval>()
+  const inFlight = new Map<string, Promise<void>>()
   let snapshotGeneration = STALE_SNAPSHOT_GENERATION
 
   function beginSnapshot(): number {
@@ -62,11 +63,14 @@ export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
     if (pending.size === 0) {
       return snapshot
     }
+    const fresh = generation !== STALE_SNAPSHOT_GENERATION
     const reported = new Set(snapshot.map((entry) => entry.worktreeId))
     // Deleting the current entry mid-iteration is safe for a Map.
     for (const [worktreeId, removal] of pending) {
       const settled =
-        !reported.has(worktreeId) ||
+        // Why: the screen caches the reconciled list, so a replayed cache is missing the row
+        // it is being asked about — only a real read proves the host stopped reporting it.
+        (fresh && !reported.has(worktreeId)) ||
         (removal.authoritativeAfter !== null && generation > removal.authoritativeAfter) ||
         (removal.revealAt !== null && now >= removal.revealAt)
       if (settled) {
@@ -79,7 +83,7 @@ export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
     return snapshot.filter((entry) => !pending.has(entry.worktreeId))
   }
 
-  async function remove({
+  async function runRemoval({
     worktree,
     client,
     updateWorktreeLists,
@@ -125,6 +129,22 @@ export function createWorktreeRemovalTracker(): WorktreeRemovalTracker {
     } finally {
       refresh()
     }
+  }
+
+  // Why: the confirm button can double-fire before the sheet unmounts. Two rm's for one
+  // worktree let the loser's rollback undo the winner's delete, so share one attempt —
+  // the same coalescing the runtime does host-side.
+  function remove(args: RemoveWorktreeArgs): Promise<void> {
+    const { worktreeId } = args.worktree
+    const existing = inFlight.get(worktreeId)
+    if (existing) {
+      return existing
+    }
+    const attempt = runRemoval(args).finally(() => {
+      inFlight.delete(worktreeId)
+    })
+    inFlight.set(worktreeId, attempt)
+    return attempt
   }
 
   return { beginSnapshot, reconcile, remove }


### PR DESCRIPTION
## Summary

Deleting a workspace from the mobile app often didn't stick: the row vanished, then reappeared seconds later, and nothing told you why.

Four defects, all in the mobile workspace list (`mobile/app/h/[hostId]/index.tsx`):

0. **The most prominent row in the list offered a Delete that can never succeed.** `hideDefaultBranch` starts `false` and `orderMainWorktreeFirst` puts the main worktree at the top of every repo group, so the first row of every repo had a Delete action. The runtime refuses it — `findRegisteredDeletableWorktree` throws `Refusing to delete protected worktree path` for `isMainWorktree`, and a folder project's root workspace is refused the same way. Combined with defect 3 below, tapping it did nothing visible and said nothing: the row disappeared, came back, and gave no reason. Desktop never offers the action there — `runWorktreeDelete` intercepts `isMainWorktree` and opens project removal instead, and `DeleteWorktreeDialogFooter` drops its destructive button entirely. Mobile now disables the entry and points at where the real action lives.

1. **Polling resurrects the deleted row for the whole duration of the delete.** `handleDeleteWorktree` optimistically dropped the row, then `fetchWorktrees` re-applied whatever `worktree.ps` returned next — with no notion that this client had just deleted something. The host keeps reporting a worktree until its removal actually finishes, so the first 3s poll (`WORKTREE_REFRESH_MS`) after the tap truthfully lists it and undoes the optimistic hide. For an SSH host or a large `node_modules`, that is tens of seconds of "delete does nothing". A poll already in flight at delete time does the same thing with a stale snapshot; the corrective `void fetchWorktrees()` after `worktree.rm` resolves is additionally dropped whenever a poll is in flight (`fetchWorktreesInFlightRef` returns early), extending the window by another cycle. That last part is a ~3s aggravation, not the cause — mobile already subscribes to `worktreesChanged` (`mobile/src/worktree/host-worktree-refresh.ts:73`), so a *completed* delete does converge. The failure is the window *during* the delete.
2. **Half the timeout budget of desktop.** Mobile sent `worktree.rm` on the generic 30s RPC timeout. Desktop budgets the same call at 60s (`src/renderer/src/store/slices/worktrees.ts`) because SSH teardown, archive hooks, and large `node_modules` deletes routinely outrun 30s. On timeout, mobile rolled the row back even though the host was still deleting it — and rolled it back on *any* dropped socket, where the delete may well have succeeded.
3. **Silent failure.** Neither `!response.ok` nor a thrown error surfaced anything. A host-side rejection (locked worktree, `repo_not_found`, orphaned-directory guard) was indistinguishable from a dead button. Desktop shows a failure toast.

The fix adds a removal tracker (`mobile/src/worktree/worktree-removal.ts`) keyed by hostId at module scope, which:

- hides ids this client asked the host to remove from incoming `worktree.ps` snapshots, so neither an in-flight poll nor the host's truthful mid-delete reporting can undo the delete. Only a real read can settle a pending removal — a replayed cache settles nothing, since the screen caches the *reconciled* list and is therefore already missing the row it would be asked about;
- coalesces concurrent removals of one worktree into a single attempt, mirroring the runtime's own `removeManagedWorktreeInFlight`, so a double-fired confirm button can't have the loser's rollback undo the winner's delete;
- **settles by snapshot generation, not by elapsed time.** Every `worktree.ps` read is stamped, and a confirmed removal is cleared by the first read *issued after it resolved* — whatever that read says. Gone means gone; still-there means the workspace was recreated at the same path (ids are path-derived and reused) and must become visible again. Reads issued earlier cannot resurrect the row, and a replayed cache never settles anything;
- sends `worktree.rm` with the 60s desktop-sized budget;
- rolls the row back **and** shows the host's error message on a real failure, but keeps it hidden for a 60s grace measured **from the failure** when delivery is unknown (`isRpcDeliveryUnknown` — timeout / dropped socket), since the host may still be completing the delete.

Living at module scope rather than in a `useRef` matters: this screen is used both as the phone route and as the wide-layout sidebar (`mobile/app/h/_layout.tsx`) and is reused across hostIds, so per-mount state would forget an in-flight delete on remount and leak one host's ids onto another's list.

Incidental fix: the old failure path appended `[...prev, item]` unconditionally, so if a poll had already resurrected the row the rollback produced a **duplicate row with the same `worktreeId`** in a keyed list. The restore now dedupes.

Defect 0 is fixed by a single predicate (`mobile/src/worktree/worktree-delete-availability.ts`) gating the action-sheet entry. Hosts predating `isMainWorktree` in `worktree.ps` report nothing, so those still fall through to the runtime — which now surfaces its reason in the alert instead of failing silently. Guessing from the branch name instead would block deleting an ordinary worktree that merely sits on `main`.

No RPC or host-side change: `worktree.rm` was already used by mobile and already in `MOBILE_RPC_METHOD_ALLOWLIST`.

## Screenshots

No visual change to the list or the delete confirmation. In the long-press action sheet, `Delete` is now greyed out with a hint when the target is a main worktree or a folder project's root workspace:

```
  Delete
  Remove the project from Orca on desktop instead
```

The other new UI is a native `Alert` on delete failure, which previously showed nothing:

```
Could not delete workspace
<host error message, e.g. "worktree is locked">
                                        [ OK ]
```

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 3658 files pass. 8 files / 43 tests fail identically on unmodified `main` in this local environment (DOM-env failures in `use-markup-draw-hint`, `pr-comments-list-selection`, `SidebarToolbar`, `agent-exec-handler`, etc.), plus `native-chat/transcript-watch.test.ts` which fails only under full-suite load and passes in isolation. None are in this change's blast radius, which is `mobile/` only.
- [x] `pnpm build`
- [x] `mobile`: `oxlint`, `tsc --noEmit`, `oxfmt --check`, and the full mobile vitest suite (351 files / 2576 tests) pass.
- [x] Added or updated high-quality tests that would catch regressions

17 tests in `mobile/src/worktree/worktree-removal.test.ts` cover the regressions rather than the happy path: hiding across repeated polls for the whole duration of a delete, a read issued before the delete landed, a workspace recreated at the same path becoming visible again, neither a replayed cache that still lists the row nor one written mid-delete settling it, the ambiguous-outcome grace boundary in both directions, a coalesced double-fired delete, a fresh delete after a settled attempt, rollback + host message on `!ok` and on a thrown error, rollback not duplicating a row a poll already restored, and per-host tracker isolation. The request assertion pins method, selector, and the 60s timeout.

Four of these were written against defects found while reviewing this branch (commits 2 and 3) and were each confirmed to **fail** against the preceding implementation before the fix landed.

Also re-ran the desktop-side guards that cover mobile RPC wiring — `src/main/runtime/mobile-rpc-allowlist.test.ts` and `src/main/runtime/rpc/methods/worktree.test.ts` — since the `sendRequest('worktree.rm', …)` literal moved into a new file that the allowlist scraper must still see. Both pass.

## AI Review Report

Reviewed with Claude Code. Risks checked:

- **Cross-platform (macOS / Linux / Windows):** the change is pure TypeScript state logic plus `Alert.alert`, which is cross-platform React Native. No keyboard shortcuts, no shortcut labels, no `metaKey`/`ctrlKey`, no path construction, no shell invocation, no Electron-specific code, no new native module. Nothing platform-dependent was introduced. The mobile client itself runs on iOS and Android against hosts on all three desktop platforms; the host-side delete path is untouched.
- **SSH and remote hosts:** this is the case the change most improves. The 30s→60s budget and the delivery-unknown handling exist precisely because SSH worktree teardown is slow; previously a slow SSH delete rolled the row back and looked like a failure.
- **Folder workspaces:** a folder project's *root* workspace is `isMainWorktree: true`, so the new predicate covers it for free if folder workspaces ever gain an action sheet. Mobile still wires `onLongPress` to `undefined` for `workspaceKind === 'folder-workspace'`, so they have no action sheet at all today — pre-existing, called out under Notes rather than changed here.
- **Git providers:** no provider-specific code; nothing GitHub- or GitLab-named.
- **Git binary compatibility:** no new or changed Git commands.
- **State correctness:** the `updateWorktreeLists` callbacks are pure and idempotent (a filter, and an append guarded by an existence check), so React invoking an updater twice under StrictMode is safe. The tracker's map is per-hostId, only grows on an explicit user delete, and prunes itself on every reconcile.
- Flagged and fixed during review: `reconcile` originally spread the Map to iterate it (`unicorn/no-useless-spread`); deleting the current entry mid-iteration is well-defined for a `Map`, so the copy was dropped.
- Flagged and accepted: the post-delete `fetchWorktrees()` can still be swallowed by the in-flight guard. With generation-stamped reads that is now harmless — an earlier read cannot settle or resurrect anything, and the next 3s poll (or the `worktreesChanged` runtime event) converges — so the guard was left alone to keep the diff scoped.
- The branch was then re-reviewed twice by a second, independent model specifically tasked with breaking it. The first pass found the two defects fixed in commit 2 (the dead delivery-unknown branch, and same-path id reuse) plus the per-mount/per-host state issues. The second pass, adjudicating CodeRabbit's review, found a further resurrection bug CodeRabbit missed — a cache replayed mid-delete settling the pending removal, fixed in commit 3. Every one is covered by a test that fails against the pre-fix behavior.

## Security Audit

Basic audit via Claude Code:

- **Input handling:** the only new untrusted input reaching the UI is the host's RPC error message, rendered as text in a native `Alert`. It arrives over the existing E2EE paired-host channel — the same trust boundary as every other RPC result — and is not interpolated into a shell command, a path, HTML, or a WebView.
- **Command execution / path handling:** none added. The worktree selector is still `id:${worktreeId}`, unchanged from the previous code.
- **Auth / IPC / RPC surface:** no new method and no allowlist change. `worktree.rm` was already reachable by mobile-scoped device tokens; enforcement in `runtime-rpc.ts` is untouched.
- **Secrets:** none read, stored, or logged. Nothing is written to `AsyncStorage`; pending-removal state is in-memory only and dies with the process.
- **Resource use:** the per-host tracker map is bounded by the hosts paired in a session; each tracker's pending map is bounded by user delete actions and self-prunes on every reconcile, so neither grows without bound.
- **Dependencies:** none added.
- No follow-up security work identified.

## Review feedback

CodeRabbit raised three issues, all addressed (replies on the threads):

1. *Scope removal state and callbacks to the initiating host* — fixed in commit 2 by moving the tracker to module scope keyed by hostId, plus a client guard on the list update. `onFailure` is deliberately left ungated: the user initiated the delete and must learn it failed. The alert now names its workspace so a cross-screen failure reads correctly.
2. *Deduplicate concurrent removals for one worktree* — implemented in commit 3 via a per-id in-flight promise. I'd rate it Minor rather than Major: the row is hidden synchronously and no reconcile can reveal an in-flight removal, so a second attempt needs the confirm button to double-fire within ~1 frame, and the runtime already coalesces matching concurrent rm's. Worth fixing regardless.
3. *Restart the tombstone TTL when the request settles* — fixed in commit 2, but by replacing the time-based rule for definite outcomes with snapshot-generation settling rather than re-stamping the TTL. A pure re-stamp would still hide a workspace recreated at the same path for a full 60s.

## Notes

- No X handle to share — I'm not on X, so there's nothing to shout out. Every other item in CONTRIBUTING's PR checklist is covered above.
- **Considered and rejected:** desktop solves this differently — it never removes optimistically, it marks rows `isDeleting` and keeps them visible (`markWorktreesDeleting` in `src/renderer/src/components/sidebar/delete-worktree-flow.ts`). That eliminates resurrection by construction and gives progress feedback during a 30-60s delete, which this change does not. I kept the mobile idiom (row disappears on confirm) because changing it is a UI redesign rather than a bug fix, but if you'd rather have mobile mirror desktop's in-place `isDeleting` row, say so and I'll do that instead — it is the more idiomatic mechanism for this codebase.
- The one behavior change a reviewer should weigh: on a **delivery-unknown** failure (RPC timeout or dropped socket) the row stays hidden instead of being restored, with no error shown. That is deliberate — the host may still be completing the delete — and it is bounded by the 60s grace, after which the host's answer stands. The downside is a silent reappearance on a flaky network; happy to add a non-blocking notice for that case.
- Out of scope, noticed while investigating, worth separate issues:
  - Folder workspaces can't be deleted from mobile at all (no long-press → no action sheet), even though non-root folder workspaces are deletable on the host and from desktop. They also lose Sleep, Pin, Source Control, and Agent History for the same reason. Giving them an action sheet means deciding which of those entries make sense for a non-git workspace, which is why it isn't in this PR.
  - Mobile has no project-removal flow at all, which is why defect 0's hint has to send the user to desktop.
  - Mobile hardcodes `force: true` and never sets `runHooks`, so mobile deletes skip `orca.yaml` archive hooks and surface none of the dirty-changes / preserved-branch / lineage warnings the desktop dialog shows.
  - There is no delete entry point on the session screen — long-pressing a row in the workspace list is the only way to reach it.

