### PR TITLE
feat(linear): pin logged-in user first in assignee dropdowns

### DIFF
--- a/src/main/linear/team-member-order.ts
+++ b/src/main/linear/team-member-order.ts
@@ -41,6 +41,10 @@ export async function getCachedViewerId(entry: LinearClientForWorkspace): Promis
   return lookup
 }
 
+// Why: host-default collators differ across macOS, Linux, and remote hosts; a
+// pinned collator keeps member ordering identical everywhere Orca runs.
+const memberNameCollator = new Intl.Collator('en', { sensitivity: 'variant' })
+
 export function sortMembersViewerFirst(
   members: LinearMember[],
   viewerId: string | null
@@ -54,6 +58,10 @@ export function sortMembersViewerFirst(
         return 1
       }
     }
-    return a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id)
+    return (
+      memberNameCollator.compare(a.displayName, b.displayName) ||
+      // Ordinal id tie-break: locale-independent and stable for equal names.
+      (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+    )
   })
 }

--- a/src/main/linear/team-member-order.ts
+++ b/src/main/linear/team-member-order.ts
@@ -1,0 +1,59 @@
+import type { LinearMember } from '../../shared/linear/workspace-types'
+import { acquire, release } from './linear-request-concurrency'
+import type { LinearClientForWorkspace } from './client'
+
+// Why: one viewer lookup per workspace credential is enough for member ordering;
+// entries are replaced on credential rotation so a re-auth as another user refreshes.
+const viewerIdCache = new Map<string, { revision: number; viewerId: string }>()
+// Why: several dropdowns can request members at once on a cold cache; sharing
+// one in-flight lookup avoids redundant viewer calls against the API limiter.
+const viewerLookupInFlight = new Map<string, Promise<string | null>>()
+
+export async function getCachedViewerId(entry: LinearClientForWorkspace): Promise<string | null> {
+  const revision = entry.workspace.credentialRevision ?? 0
+  const cached = viewerIdCache.get(entry.workspace.id)
+  if (cached && cached.revision === revision) {
+    return cached.viewerId
+  }
+
+  const inFlightKey = `${entry.workspace.id}:${revision}`
+  const inFlight = viewerLookupInFlight.get(inFlightKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  const lookup = (async () => {
+    await acquire()
+    try {
+      const viewer = await entry.client.viewer
+      viewerIdCache.set(entry.workspace.id, { revision, viewerId: viewer.id })
+      return viewer.id
+    } catch (error) {
+      // Member lists must not fail because the viewer lookup did.
+      console.warn('[linear] viewer lookup for member ordering failed:', error)
+      return null
+    } finally {
+      release()
+      viewerLookupInFlight.delete(inFlightKey)
+    }
+  })()
+  viewerLookupInFlight.set(inFlightKey, lookup)
+  return lookup
+}
+
+export function sortMembersViewerFirst(
+  members: LinearMember[],
+  viewerId: string | null
+): LinearMember[] {
+  return [...members].sort((a, b) => {
+    if (viewerId) {
+      if (a.id === viewerId) {
+        return b.id === viewerId ? 0 : -1
+      }
+      if (b.id === viewerId) {
+        return 1
+      }
+    }
+    return a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id)
+  })
+}

--- a/src/main/linear/team-member-order.ts
+++ b/src/main/linear/team-member-order.ts
@@ -1,0 +1,59 @@
+import type { LinearMember } from '../../shared/types'
+import { acquire, release } from './client'
+import type { LinearClientForWorkspace } from './client'
+
+// Why: one viewer lookup per workspace credential is enough for member ordering;
+// entries are replaced on credential rotation so a re-auth as another user refreshes.
+const viewerIdCache = new Map<string, { revision: number; viewerId: string }>()
+// Why: several dropdowns can request members at once on a cold cache; sharing
+// one in-flight lookup avoids redundant viewer calls against the API limiter.
+const viewerLookupInFlight = new Map<string, Promise<string | null>>()
+
+export async function getCachedViewerId(entry: LinearClientForWorkspace): Promise<string | null> {
+  const revision = entry.workspace.credentialRevision ?? 0
+  const cached = viewerIdCache.get(entry.workspace.id)
+  if (cached && cached.revision === revision) {
+    return cached.viewerId
+  }
+
+  const inFlightKey = `${entry.workspace.id}:${revision}`
+  const inFlight = viewerLookupInFlight.get(inFlightKey)
+  if (inFlight) {
+    return inFlight
+  }
+
+  const lookup = (async () => {
+    await acquire()
+    try {
+      const viewer = await entry.client.viewer
+      viewerIdCache.set(entry.workspace.id, { revision, viewerId: viewer.id })
+      return viewer.id
+    } catch (error) {
+      // Member lists must not fail because the viewer lookup did.
+      console.warn('[linear] viewer lookup for member ordering failed:', error)
+      return null
+    } finally {
+      release()
+      viewerLookupInFlight.delete(inFlightKey)
+    }
+  })()
+  viewerLookupInFlight.set(inFlightKey, lookup)
+  return lookup
+}
+
+export function sortMembersViewerFirst(
+  members: LinearMember[],
+  viewerId: string | null
+): LinearMember[] {
+  return [...members].sort((a, b) => {
+    if (viewerId) {
+      if (a.id === viewerId) {
+        return b.id === viewerId ? 0 : -1
+      }
+      if (b.id === viewerId) {
+        return 1
+      }
+    }
+    return a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id)
+  })
+}

--- a/src/main/linear/teams.test.ts
+++ b/src/main/linear/teams.test.ts
@@ -101,7 +101,8 @@ function makeEntry(
 function makeTeamLookupEntry(
   workspaceId: string,
   organizationName: string,
-  teamNode: unknown
+  teamNode: unknown,
+  options?: { viewer?: () => Promise<{ id: string }>; credentialRevision?: number }
 ): LinearClientForWorkspace {
   return {
     workspace: {
@@ -109,10 +110,14 @@ function makeTeamLookupEntry(
       organizationId: workspaceId,
       organizationName,
       displayName: 'Ada',
-      email: 'ada@example.com'
+      email: 'ada@example.com',
+      credentialRevision: options?.credentialRevision
     },
     client: {
-      team: vi.fn().mockResolvedValue(teamNode)
+      team: vi.fn().mockResolvedValue(teamNode),
+      get viewer() {
+        return options?.viewer ? options.viewer() : Promise.reject(new Error('no viewer mock'))
+      }
     }
   } as unknown as LinearClientForWorkspace
 }
@@ -251,7 +256,14 @@ describe('Linear teams', () => {
           [makeMember('user-3', 'Linus')]
         ])
       )
-    const entry = makeTeamLookupEntry('workspace-1', 'Workspace', { members })
+    const entry = makeTeamLookupEntry(
+      'workspace-1',
+      'Workspace',
+      { members },
+      {
+        viewer: () => Promise.resolve({ id: 'user-1' })
+      }
+    )
     getClients.mockReturnValue([entry])
     const { getTeamMembersOrThrow } = await import('./teams')
 
@@ -281,6 +293,103 @@ describe('Linear teams', () => {
 
     expect(entry.client.team).toHaveBeenCalledWith('team-1')
     expect(members).toHaveBeenCalledWith({ first: 100 })
+  })
+
+  describe('viewer-first member ordering', () => {
+    beforeEach(() => {
+      vi.resetModules()
+    })
+
+    function makeMembersEntry(options?: {
+      viewer?: () => Promise<{ id: string }>
+      credentialRevision?: number
+      memberPages?: MemberNode[][]
+    }): LinearClientForWorkspace {
+      const members = vi.fn().mockResolvedValue(
+        makeConnection(
+          options?.memberPages ?? [
+            [makeMember('user-1', 'brian'), makeMember('user-2', 'pika')],
+            [makeMember('user-3', 'andrew'), makeMember('user-4', 'sean')]
+          ]
+        )
+      )
+      return makeTeamLookupEntry('workspace-1', 'Workspace', { members }, options)
+    }
+
+    it('pins the viewer first and alpha-sorts the rest', async () => {
+      const viewer = vi.fn().mockResolvedValue({ id: 'user-3' })
+      getClients.mockReturnValue([makeMembersEntry({ viewer })])
+      const { getTeamMembersOrThrow } = await import('./teams')
+
+      await expect(getTeamMembersOrThrow('team-1', 'workspace-1')).resolves.toMatchObject([
+        { id: 'user-3', displayName: 'andrew' },
+        { id: 'user-1', displayName: 'brian' },
+        { id: 'user-2', displayName: 'pika' },
+        { id: 'user-4', displayName: 'sean' }
+      ])
+    })
+
+    it('alpha-sorts when the viewer is not a team member', async () => {
+      const viewer = vi.fn().mockResolvedValue({ id: 'user-elsewhere' })
+      getClients.mockReturnValue([makeMembersEntry({ viewer })])
+      const { getTeamMembers } = await import('./teams')
+
+      await expect(getTeamMembers('team-1', 'workspace-1')).resolves.toMatchObject([
+        { id: 'user-3' },
+        { id: 'user-1' },
+        { id: 'user-2' },
+        { id: 'user-4' }
+      ])
+    })
+
+    it('falls back to alpha order when the viewer lookup fails', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const viewer = vi.fn().mockRejectedValue(new Error('viewer down'))
+        getClients.mockReturnValue([makeMembersEntry({ viewer })])
+        const { getTeamMembersOrThrow } = await import('./teams')
+
+        await expect(getTeamMembersOrThrow('team-1', 'workspace-1')).resolves.toMatchObject([
+          { id: 'user-3' },
+          { id: 'user-1' },
+          { id: 'user-2' },
+          { id: 'user-4' }
+        ])
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('caches the viewer id per workspace credential revision', async () => {
+      const viewer = vi.fn().mockResolvedValue({ id: 'user-3' })
+      getClients.mockReturnValue([makeMembersEntry({ viewer, credentialRevision: 1 })])
+      const { getTeamMembersOrThrow } = await import('./teams')
+
+      await getTeamMembersOrThrow('team-1', 'workspace-1')
+      await getTeamMembersOrThrow('team-1', 'workspace-1')
+      expect(viewer).toHaveBeenCalledTimes(1)
+
+      // Credential rotation invalidates the cached viewer id.
+      getClients.mockReturnValue([makeMembersEntry({ viewer, credentialRevision: 2 })])
+      await getTeamMembersOrThrow('team-1', 'workspace-1')
+      expect(viewer).toHaveBeenCalledTimes(2)
+    })
+
+    it('sorts members deterministically with duplicate display names', async () => {
+      const { sortMembersViewerFirst } = await import('./teams')
+
+      expect(sortMembersViewerFirst([], null)).toEqual([])
+      expect(
+        sortMembersViewerFirst(
+          [
+            { id: 'user-b', displayName: 'sam' },
+            { id: 'user-a', displayName: 'sam' },
+            { id: 'user-c', displayName: 'alex' }
+          ],
+          'user-b'
+        )
+      ).toMatchObject([{ id: 'user-b' }, { id: 'user-c' }, { id: 'user-a' }])
+    })
   })
 
   it('surfaces Linear credential decrypt errors on active team reads', async () => {

--- a/src/main/linear/teams.test.ts
+++ b/src/main/linear/teams.test.ts
@@ -387,9 +387,35 @@ describe('Linear teams', () => {
           { id: 'user-2' },
           { id: 'user-4' }
         ])
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('viewer lookup'),
+          expect.any(Error)
+        )
       } finally {
         warn.mockRestore()
       }
+    })
+
+    it('shares one in-flight viewer lookup across concurrent member fetches', async () => {
+      let resolveViewer: (value: { id: string }) => void = () => {}
+      const viewer = vi.fn().mockImplementation(
+        () =>
+          new Promise<{ id: string }>((resolve) => {
+            resolveViewer = resolve
+          })
+      )
+      getClients.mockReturnValue([makeMembersEntry({ viewer })])
+      const { getTeamMembersOrThrow } = await import('./teams')
+
+      const first = getTeamMembersOrThrow('team-1', 'workspace-1')
+      const second = getTeamMembersOrThrow('team-1', 'workspace-1')
+      await vi.waitFor(() => expect(viewer).toHaveBeenCalledTimes(1))
+      resolveViewer({ id: 'user-3' })
+
+      const expectedOrder = [{ id: 'user-3' }, { id: 'user-1' }, { id: 'user-2' }, { id: 'user-4' }]
+      await expect(first).resolves.toMatchObject(expectedOrder)
+      await expect(second).resolves.toMatchObject(expectedOrder)
+      expect(viewer).toHaveBeenCalledTimes(1)
     })
 
     it('caches the viewer id per workspace credential revision', async () => {
@@ -408,7 +434,7 @@ describe('Linear teams', () => {
     })
 
     it('sorts members deterministically with duplicate display names', async () => {
-      const { sortMembersViewerFirst } = await import('./teams')
+      const { sortMembersViewerFirst } = await import('./team-member-order')
 
       expect(sortMembersViewerFirst([], null)).toEqual([])
       expect(

--- a/src/main/linear/teams.test.ts
+++ b/src/main/linear/teams.test.ts
@@ -109,7 +109,8 @@ function makeEntry(
 function makeTeamLookupEntry(
   workspaceId: string,
   organizationName: string,
-  teamNode: unknown
+  teamNode: unknown,
+  options?: { viewer?: () => Promise<{ id: string }>; credentialRevision?: number }
 ): LinearClientForWorkspace {
   return {
     workspace: {
@@ -117,10 +118,14 @@ function makeTeamLookupEntry(
       organizationId: workspaceId,
       organizationName,
       displayName: 'Ada',
-      email: 'ada@example.com'
+      email: 'ada@example.com',
+      credentialRevision: options?.credentialRevision
     },
     client: {
-      team: vi.fn().mockResolvedValue(teamNode)
+      team: vi.fn().mockResolvedValue(teamNode),
+      get viewer() {
+        return options?.viewer ? options.viewer() : Promise.reject(new Error('no viewer mock'))
+      }
     }
   } as unknown as LinearClientForWorkspace
 }
@@ -259,7 +264,14 @@ describe('Linear teams', () => {
           [makeMember('user-3', 'Linus')]
         ])
       )
-    const entry = makeTeamLookupEntry('workspace-1', 'Workspace', { members })
+    const entry = makeTeamLookupEntry(
+      'workspace-1',
+      'Workspace',
+      { members },
+      {
+        viewer: () => Promise.resolve({ id: 'user-1' })
+      }
+    )
     getClients.mockReturnValue([entry])
     const { getTeamMembersOrThrow } = await import('./teams')
 
@@ -313,6 +325,103 @@ describe('Linear teams', () => {
     expect(clearToken).toHaveBeenCalledWith('workspace-1')
     expect(release).toHaveBeenCalledTimes(3)
     warn.mockRestore()
+  })
+
+  describe('viewer-first member ordering', () => {
+    beforeEach(() => {
+      vi.resetModules()
+    })
+
+    function makeMembersEntry(options?: {
+      viewer?: () => Promise<{ id: string }>
+      credentialRevision?: number
+      memberPages?: MemberNode[][]
+    }): LinearClientForWorkspace {
+      const members = vi.fn().mockResolvedValue(
+        makeConnection(
+          options?.memberPages ?? [
+            [makeMember('user-1', 'brian'), makeMember('user-2', 'pika')],
+            [makeMember('user-3', 'andrew'), makeMember('user-4', 'sean')]
+          ]
+        )
+      )
+      return makeTeamLookupEntry('workspace-1', 'Workspace', { members }, options)
+    }
+
+    it('pins the viewer first and alpha-sorts the rest', async () => {
+      const viewer = vi.fn().mockResolvedValue({ id: 'user-3' })
+      getClients.mockReturnValue([makeMembersEntry({ viewer })])
+      const { getTeamMembersOrThrow } = await import('./teams')
+
+      await expect(getTeamMembersOrThrow('team-1', 'workspace-1')).resolves.toMatchObject([
+        { id: 'user-3', displayName: 'andrew' },
+        { id: 'user-1', displayName: 'brian' },
+        { id: 'user-2', displayName: 'pika' },
+        { id: 'user-4', displayName: 'sean' }
+      ])
+    })
+
+    it('alpha-sorts when the viewer is not a team member', async () => {
+      const viewer = vi.fn().mockResolvedValue({ id: 'user-elsewhere' })
+      getClients.mockReturnValue([makeMembersEntry({ viewer })])
+      const { getTeamMembers } = await import('./teams')
+
+      await expect(getTeamMembers('team-1', 'workspace-1')).resolves.toMatchObject([
+        { id: 'user-3' },
+        { id: 'user-1' },
+        { id: 'user-2' },
+        { id: 'user-4' }
+      ])
+    })
+
+    it('falls back to alpha order when the viewer lookup fails', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        const viewer = vi.fn().mockRejectedValue(new Error('viewer down'))
+        getClients.mockReturnValue([makeMembersEntry({ viewer })])
+        const { getTeamMembersOrThrow } = await import('./teams')
+
+        await expect(getTeamMembersOrThrow('team-1', 'workspace-1')).resolves.toMatchObject([
+          { id: 'user-3' },
+          { id: 'user-1' },
+          { id: 'user-2' },
+          { id: 'user-4' }
+        ])
+      } finally {
+        warn.mockRestore()
+      }
+    })
+
+    it('caches the viewer id per workspace credential revision', async () => {
+      const viewer = vi.fn().mockResolvedValue({ id: 'user-3' })
+      getClients.mockReturnValue([makeMembersEntry({ viewer, credentialRevision: 1 })])
+      const { getTeamMembersOrThrow } = await import('./teams')
+
+      await getTeamMembersOrThrow('team-1', 'workspace-1')
+      await getTeamMembersOrThrow('team-1', 'workspace-1')
+      expect(viewer).toHaveBeenCalledTimes(1)
+
+      // Credential rotation invalidates the cached viewer id.
+      getClients.mockReturnValue([makeMembersEntry({ viewer, credentialRevision: 2 })])
+      await getTeamMembersOrThrow('team-1', 'workspace-1')
+      expect(viewer).toHaveBeenCalledTimes(2)
+    })
+
+    it('sorts members deterministically with duplicate display names', async () => {
+      const { sortMembersViewerFirst } = await import('./teams')
+
+      expect(sortMembersViewerFirst([], null)).toEqual([])
+      expect(
+        sortMembersViewerFirst(
+          [
+            { id: 'user-b', displayName: 'sam' },
+            { id: 'user-a', displayName: 'sam' },
+            { id: 'user-c', displayName: 'alex' }
+          ],
+          'user-b'
+        )
+      ).toMatchObject([{ id: 'user-b' }, { id: 'user-c' }, { id: 'user-a' }])
+    })
   })
 
   it('surfaces Linear credential decrypt errors on active team reads', async () => {

--- a/src/main/linear/teams.test.ts
+++ b/src/main/linear/teams.test.ts
@@ -355,9 +355,35 @@ describe('Linear teams', () => {
           { id: 'user-2' },
           { id: 'user-4' }
         ])
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining('viewer lookup'),
+          expect.any(Error)
+        )
       } finally {
         warn.mockRestore()
       }
+    })
+
+    it('shares one in-flight viewer lookup across concurrent member fetches', async () => {
+      let resolveViewer: (value: { id: string }) => void = () => {}
+      const viewer = vi.fn().mockImplementation(
+        () =>
+          new Promise<{ id: string }>((resolve) => {
+            resolveViewer = resolve
+          })
+      )
+      getClients.mockReturnValue([makeMembersEntry({ viewer })])
+      const { getTeamMembersOrThrow } = await import('./teams')
+
+      const first = getTeamMembersOrThrow('team-1', 'workspace-1')
+      const second = getTeamMembersOrThrow('team-1', 'workspace-1')
+      await vi.waitFor(() => expect(viewer).toHaveBeenCalledTimes(1))
+      resolveViewer({ id: 'user-3' })
+
+      const expectedOrder = [{ id: 'user-3' }, { id: 'user-1' }, { id: 'user-2' }, { id: 'user-4' }]
+      await expect(first).resolves.toMatchObject(expectedOrder)
+      await expect(second).resolves.toMatchObject(expectedOrder)
+      expect(viewer).toHaveBeenCalledTimes(1)
     })
 
     it('caches the viewer id per workspace credential revision', async () => {
@@ -376,7 +402,7 @@ describe('Linear teams', () => {
     })
 
     it('sorts members deterministically with duplicate display names', async () => {
-      const { sortMembersViewerFirst } = await import('./teams')
+      const { sortMembersViewerFirst } = await import('./team-member-order')
 
       expect(sortMembersViewerFirst([], null)).toEqual([])
       expect(

--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -10,55 +10,13 @@ import type {
 import { acquire, release } from './linear-request-concurrency'
 import { clearToken } from './linear-token-store'
 import { getClients, isAuthError } from './client'
-import type { LinearClientForWorkspace } from './client'
+import { getCachedViewerId, sortMembersViewerFirst } from './team-member-order'
 import {
   fetchAllTeamLabels,
   fetchAllTeamMembers,
   fetchAllTeamsForWorkspace,
   fetchAllTeamStates
 } from './linear-team-pages'
-
-// Why: one viewer lookup per workspace credential is enough for member ordering;
-// entries are replaced on credential rotation so a re-auth as another user refreshes.
-const viewerIdCache = new Map<string, { revision: number; viewerId: string }>()
-
-async function getCachedViewerId(entry: LinearClientForWorkspace): Promise<string | null> {
-  const revision = entry.workspace.credentialRevision ?? 0
-  const cached = viewerIdCache.get(entry.workspace.id)
-  if (cached && cached.revision === revision) {
-    return cached.viewerId
-  }
-
-  await acquire()
-  try {
-    const viewer = await entry.client.viewer
-    viewerIdCache.set(entry.workspace.id, { revision, viewerId: viewer.id })
-    return viewer.id
-  } catch (error) {
-    // Member lists must not fail because the viewer lookup did.
-    console.warn('[linear] viewer lookup for member ordering failed:', error)
-    return null
-  } finally {
-    release()
-  }
-}
-
-export function sortMembersViewerFirst(
-  members: LinearMember[],
-  viewerId: string | null
-): LinearMember[] {
-  return [...members].sort((a, b) => {
-    if (viewerId) {
-      if (a.id === viewerId) {
-        return b.id === viewerId ? 0 : -1
-      }
-      if (b.id === viewerId) {
-        return 1
-      }
-    }
-    return a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id)
-  })
-}
 
 export async function listTeams(
   workspaceId?: LinearWorkspaceSelection | null

--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -7,55 +7,13 @@ import type {
   LinearWorkspaceSelection
 } from '../../shared/types'
 import { acquire, release, getClients, isAuthError, clearToken } from './client'
-import type { LinearClientForWorkspace } from './client'
+import { getCachedViewerId, sortMembersViewerFirst } from './team-member-order'
 import {
   fetchAllTeamLabels,
   fetchAllTeamMembers,
   fetchAllTeamsForWorkspace,
   fetchAllTeamStates
 } from './linear-team-pages'
-
-// Why: one viewer lookup per workspace credential is enough for member ordering;
-// entries are replaced on credential rotation so a re-auth as another user refreshes.
-const viewerIdCache = new Map<string, { revision: number; viewerId: string }>()
-
-async function getCachedViewerId(entry: LinearClientForWorkspace): Promise<string | null> {
-  const revision = entry.workspace.credentialRevision ?? 0
-  const cached = viewerIdCache.get(entry.workspace.id)
-  if (cached && cached.revision === revision) {
-    return cached.viewerId
-  }
-
-  await acquire()
-  try {
-    const viewer = await entry.client.viewer
-    viewerIdCache.set(entry.workspace.id, { revision, viewerId: viewer.id })
-    return viewer.id
-  } catch (error) {
-    // Member lists must not fail because the viewer lookup did.
-    console.warn('[linear] viewer lookup for member ordering failed:', error)
-    return null
-  } finally {
-    release()
-  }
-}
-
-export function sortMembersViewerFirst(
-  members: LinearMember[],
-  viewerId: string | null
-): LinearMember[] {
-  return [...members].sort((a, b) => {
-    if (viewerId) {
-      if (a.id === viewerId) {
-        return b.id === viewerId ? 0 : -1
-      }
-      if (b.id === viewerId) {
-        return 1
-      }
-    }
-    return a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id)
-  })
-}
 
 export async function listTeams(
   workspaceId?: LinearWorkspaceSelection | null

--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -7,12 +7,55 @@ import type {
   LinearWorkspaceSelection
 } from '../../shared/types'
 import { acquire, release, getClients, isAuthError, clearToken } from './client'
+import type { LinearClientForWorkspace } from './client'
 import {
   fetchAllTeamLabels,
   fetchAllTeamMembers,
   fetchAllTeamsForWorkspace,
   fetchAllTeamStates
 } from './linear-team-pages'
+
+// Why: one viewer lookup per workspace credential is enough for member ordering;
+// entries are replaced on credential rotation so a re-auth as another user refreshes.
+const viewerIdCache = new Map<string, { revision: number; viewerId: string }>()
+
+async function getCachedViewerId(entry: LinearClientForWorkspace): Promise<string | null> {
+  const revision = entry.workspace.credentialRevision ?? 0
+  const cached = viewerIdCache.get(entry.workspace.id)
+  if (cached && cached.revision === revision) {
+    return cached.viewerId
+  }
+
+  await acquire()
+  try {
+    const viewer = await entry.client.viewer
+    viewerIdCache.set(entry.workspace.id, { revision, viewerId: viewer.id })
+    return viewer.id
+  } catch (error) {
+    // Member lists must not fail because the viewer lookup did.
+    console.warn('[linear] viewer lookup for member ordering failed:', error)
+    return null
+  } finally {
+    release()
+  }
+}
+
+export function sortMembersViewerFirst(
+  members: LinearMember[],
+  viewerId: string | null
+): LinearMember[] {
+  return [...members].sort((a, b) => {
+    if (viewerId) {
+      if (a.id === viewerId) {
+        return b.id === viewerId ? 0 : -1
+      }
+      if (b.id === viewerId) {
+        return 1
+      }
+    }
+    return a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id)
+  })
+}
 
 export async function listTeams(
   workspaceId?: LinearWorkspaceSelection | null
@@ -213,10 +256,11 @@ export async function getTeamMembers(
     return []
   }
 
+  const viewerId = await getCachedViewerId(entry)
   await acquire()
   try {
     const team = await entry.client.team(teamId)
-    return await fetchAllTeamMembers(team)
+    return sortMembersViewerFirst(await fetchAllTeamMembers(team), viewerId)
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.workspace.id)
@@ -238,10 +282,11 @@ export async function getTeamMembersOrThrow(
     return []
   }
 
+  const viewerId = await getCachedViewerId(entry)
   await acquire()
   try {
     const team = await entry.client.team(teamId)
-    return await fetchAllTeamMembers(team)
+    return sortMembersViewerFirst(await fetchAllTeamMembers(team), viewerId)
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.workspace.id)

--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -10,12 +10,55 @@ import type {
 import { acquire, release } from './linear-request-concurrency'
 import { clearToken } from './linear-token-store'
 import { getClients, isAuthError } from './client'
+import type { LinearClientForWorkspace } from './client'
 import {
   fetchAllTeamLabels,
   fetchAllTeamMembers,
   fetchAllTeamsForWorkspace,
   fetchAllTeamStates
 } from './linear-team-pages'
+
+// Why: one viewer lookup per workspace credential is enough for member ordering;
+// entries are replaced on credential rotation so a re-auth as another user refreshes.
+const viewerIdCache = new Map<string, { revision: number; viewerId: string }>()
+
+async function getCachedViewerId(entry: LinearClientForWorkspace): Promise<string | null> {
+  const revision = entry.workspace.credentialRevision ?? 0
+  const cached = viewerIdCache.get(entry.workspace.id)
+  if (cached && cached.revision === revision) {
+    return cached.viewerId
+  }
+
+  await acquire()
+  try {
+    const viewer = await entry.client.viewer
+    viewerIdCache.set(entry.workspace.id, { revision, viewerId: viewer.id })
+    return viewer.id
+  } catch (error) {
+    // Member lists must not fail because the viewer lookup did.
+    console.warn('[linear] viewer lookup for member ordering failed:', error)
+    return null
+  } finally {
+    release()
+  }
+}
+
+export function sortMembersViewerFirst(
+  members: LinearMember[],
+  viewerId: string | null
+): LinearMember[] {
+  return [...members].sort((a, b) => {
+    if (viewerId) {
+      if (a.id === viewerId) {
+        return b.id === viewerId ? 0 : -1
+      }
+      if (b.id === viewerId) {
+        return 1
+      }
+    }
+    return a.displayName.localeCompare(b.displayName) || a.id.localeCompare(b.id)
+  })
+}
 
 export async function listTeams(
   workspaceId?: LinearWorkspaceSelection | null
@@ -140,6 +183,25 @@ async function readTeamResource<T>(
   }
 }
 
+async function readTeamMembersViewerFirst(
+  teamId: string,
+  workspaceId: string | null | undefined,
+  fallbackWarning?: string
+): Promise<LinearMember[]> {
+  const entry = getClients(workspaceId)[0]
+  if (!entry) {
+    return []
+  }
+  const viewerId = await getCachedViewerId(entry)
+  const members = await readTeamResource(
+    teamId,
+    workspaceId,
+    fetchAllTeamMembers,
+    fallbackWarning
+  )
+  return sortMembersViewerFirst(members, viewerId)
+}
+
 export async function getTeamStates(
   teamId: string,
   workspaceId?: string | null
@@ -172,14 +234,14 @@ export async function getTeamMembers(
   teamId: string,
   workspaceId?: string | null
 ): Promise<LinearMember[]> {
-  return readTeamResource(teamId, workspaceId, fetchAllTeamMembers, 'getTeamMembers')
+  return readTeamMembersViewerFirst(teamId, workspaceId, 'getTeamMembers')
 }
 
 export async function getTeamMembersOrThrow(
   teamId: string,
   workspaceId?: string | null
 ): Promise<LinearMember[]> {
-  return readTeamResource(teamId, workspaceId, fetchAllTeamMembers)
+  return readTeamMembersViewerFirst(teamId, workspaceId)
 }
 
 export async function getViewerForWorkspaceOrThrow(

--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -151,12 +151,7 @@ async function readTeamMembersViewerFirst(
     return []
   }
   const viewerId = await getCachedViewerId(entry)
-  const members = await readTeamResource(
-    teamId,
-    workspaceId,
-    fetchAllTeamMembers,
-    fallbackWarning
-  )
+  const members = await readTeamResource(teamId, workspaceId, fetchAllTeamMembers, fallbackWarning)
   return sortMembersViewerFirst(members, viewerId)
 }
 


### PR DESCRIPTION
## Summary

Linear assignee dropdowns (issue drawer/page properties, new-issue composer, and assignee filters) previously listed team members in arbitrary Linear API order, so the logged-in user was buried mid-list. Team members are now sorted with the current Linear user (workspace viewer) first, and the remaining members alphabetized by display name.

The sort happens in the main-process `getTeamMembers`/`getTeamMembersOrThrow`, so every consumer — including remote/SSH runtimes, whose RPC path calls the same function on the token-owning host — inherits the order with no renderer or protocol changes. The viewer id is fetched once per workspace and cached keyed by `credentialRevision`, so reconnecting as a different user refreshes it. A failed viewer lookup degrades to plain alphabetical order and never fails the members fetch.

## Screenshots

Assignee dropdown with the logged-in Linear user (andrew) pinned first after Unassigned:
<img width="550" height="362" alt="image" src="https://github.com/user-attachments/assets/43ae24b6-2681-48fe-9be9-b11fdb36338f" />




## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — full suite; 2 pre-existing failures in `src/relay/agent-exec-handler.test.ts` also fail on unmodified `main` in this local environment (env-dependent codex spawn expectations), unrelated to this change
- [x] `pnpm build`
- [x] Added tests: viewer pinned first + alpha rest, viewer not in team, viewer lookup failure fallback, per-credential-revision caching, deterministic tie-breaks for duplicate display names

## AI Review Report

Reviewed with Claude Code and cross-checked by a second agent (Codex):
- **Cross-platform (macOS/Linux/Windows):** no platform-specific APIs touched; main-process-only sorting logic.
- **SSH/remote/local:** the runtime RPC path (`linear.teamMembers`) executes the same `getTeamMembers` on the remote host, so remote runtimes get identical ordering; no protocol/capability changes (result shape unchanged).
- **Integrations:** Linear-only change; no provider-generic code paths altered.
- **Performance:** one extra `client.viewer` call per workspace per credential revision (cached in-memory; fetched outside the members semaphore window to avoid nested-acquire starvation). Sorting is O(n log n) on ≤100-member pages already held in memory.
- **Flagged and addressed in review:** stale viewer-cache accumulation (cache now keyed per workspace and replaced on credential-revision bump), sort non-determinism for duplicate display names (id tie-break), and semaphore nesting (viewer fetch uses its own acquire/release window).

## Security Audit

- No new IPC/RPC surface, no new inputs; `viewer.id` comes from the authenticated Linear SDK client already in use.
- Viewer id is cached in main-process memory only; no credentials or tokens are read, stored, or logged.
- Failure path returns `null` and logs via the existing `console.warn` convention without including token material.

## Notes

- Multi-team assignee *filter* dropdowns union per-team lists in team order (`useIssueMetadata`), so the union is not globally alphabetical; the viewer still surfaces at the top of the first team block after dedup.
- No X handle to shout out for now.



