### PR TITLE
Add Slack-style emoji shortcode picker

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx
@@ -146,6 +146,31 @@ function renderSmartField(spies: {
   return input
 }
 
+function renderEmojiField(value: string, onValueChange: (value: string) => void): HTMLInputElement {
+  act(() => {
+    root.render(
+      <SmartWorkspaceNameField
+        repos={[]}
+        repoId="repo-1"
+        onRepoChange={vi.fn()}
+        value={value}
+        onValueChange={onValueChange}
+        onGitHubItemSelect={vi.fn()}
+        onBranchSelect={vi.fn()}
+        onLinearIssueSelect={vi.fn()}
+        selectedSource={null}
+        onClearSelectedSource={vi.fn()}
+        textOnly
+      />
+    )
+  })
+  const input = container.querySelector<HTMLInputElement>('[data-workspace-name-input="true"]')
+  if (!input) {
+    throw new Error('workspace name input not rendered')
+  }
+  return input
+}
+
 // Why: the guard must short-circuit before the `open && rows.length > 0`
 // row-select branch, so drive the field into that state — smart mode with a
 // typed value synchronously yields a highlighted "use this name" row.
@@ -233,5 +258,37 @@ describe('SmartWorkspaceNameField IME Enter guard', () => {
     // at the row-select branch, not merely inert.
     expect(onValueChange).toHaveBeenCalledWith('배포')
     expect(onPlainEnter).not.toHaveBeenCalled()
+  })
+})
+
+describe('SmartWorkspaceNameField emoji shortcodes', () => {
+  it('replaces a completed shortcode as it is typed', () => {
+    const onValueChange = vi.fn()
+    const input = renderEmojiField('Launch ', onValueChange)
+
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
+        input,
+        'Launch :wink: experiment'
+      )
+      input.setSelectionRange(13, 13)
+      input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }))
+    })
+
+    expect(onValueChange).toHaveBeenCalledWith('Launch 😉 experiment')
+  })
+
+  it('accepts the highlighted shortcode suggestion with Enter', () => {
+    const onValueChange = vi.fn()
+    const input = renderEmojiField('Launch :wink', onValueChange)
+
+    act(() => {
+      input.focus()
+      input.setSelectionRange(12, 12)
+      input.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    pressEnter(input)
+
+    expect(onValueChange).toHaveBeenCalledWith('Launch 😉')
   })
 })

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -88,6 +88,15 @@ import {
   getGitHubRuntimeRepoId,
   getGitHubSourceRuntimeTarget
 } from '@/lib/github-source-runtime-context'
+import {
+  applyWorkspaceEmojiSuggestion,
+  getActiveWorkspaceEmojiShortcode,
+  replaceCompletedWorkspaceEmojiShortcode,
+  searchWorkspaceEmojiShortcodes,
+  type WorkspaceEmojiReplacement,
+  type WorkspaceEmojiSuggestion
+} from '@/lib/workspace-emoji-shortcodes'
+import { WorkspaceEmojiSuggestionPopover } from './WorkspaceEmojiSuggestionPopover'
 
 type RepoOption = ReturnType<typeof useAppStore.getState>['repos'][number]
 const EMPTY_REPO_SEARCH_REPOS: readonly RepoOption[] = []
@@ -308,6 +317,8 @@ export default function SmartWorkspaceNameField({
   const [branchesLoading, setBranchesLoading] = useState(false)
   const [linearLoading, setLinearLoading] = useState(false)
   const [commandValue, setCommandValue] = useState('')
+  const [emojiCommandValue, setEmojiCommandValue] = useState('')
+  const [emojiCursor, setEmojiCursor] = useState<number | null>(null)
   const localInputRef = useRef<HTMLInputElement | null>(null)
   const focusedSelectedSourceKeyRef = useRef<string | null>(null)
   const tabsListRef = useRef<HTMLDivElement | null>(null)
@@ -1104,6 +1115,33 @@ export default function SmartWorkspaceNameField({
     isQueryStale,
     sourceIntent
   })
+  const activeEmojiShortcode = useMemo(
+    () => getActiveWorkspaceEmojiShortcode(value, emojiCursor),
+    [emojiCursor, value]
+  )
+  const emojiSuggestions = useMemo(
+    () =>
+      activeEmojiShortcode
+        ? searchWorkspaceEmojiShortcodes(activeEmojiShortcode.query)
+        : ([] as WorkspaceEmojiSuggestion[]),
+    [activeEmojiShortcode]
+  )
+  const emojiMenuOpen =
+    !disabled &&
+    selectedSource === null &&
+    activeEmojiShortcode !== null &&
+    emojiSuggestions.length > 0
+  const resolvedEmojiCommandValue = emojiSuggestions.some(
+    (suggestion) => `emoji:${suggestion.shortcode}` === emojiCommandValue
+  )
+    ? emojiCommandValue
+    : emojiSuggestions[0]
+      ? `emoji:${emojiSuggestions[0].shortcode}`
+      : ''
+  const selectedEmojiSuggestion =
+    emojiSuggestions.find(
+      (suggestion) => `emoji:${suggestion.shortcode}` === resolvedEmojiCommandValue
+    ) ?? null
 
   const loading = githubLoading || gitlabLoading || branchesLoading || linearLoading
   const ActiveInputIcon = mode === 'text' ? CaseSensitive : loading ? LoaderCircle : Search
@@ -1126,6 +1164,30 @@ export default function SmartWorkspaceNameField({
       setOpen(false)
     },
     [onBranchSelect, onGitHubItemSelect, onGitLabItemSelect, onLinearIssueSelect, onValueChange]
+  )
+
+  const applyEmojiReplacement = useCallback(
+    (replacement: WorkspaceEmojiReplacement): void => {
+      onValueChange(replacement.value)
+      setEmojiCursor(null)
+      cancelLocalInputFocusFrame()
+      localInputFocusFrameRef.current = requestAnimationFrame(() => {
+        localInputFocusFrameRef.current = null
+        localInputRef.current?.focus({ preventScroll: true })
+        localInputRef.current?.setSelectionRange(replacement.cursor, replacement.cursor)
+      })
+    },
+    [cancelLocalInputFocusFrame, onValueChange]
+  )
+
+  const handleEmojiSelect = useCallback(
+    (suggestion: WorkspaceEmojiSuggestion): void => {
+      if (!activeEmojiShortcode) {
+        return
+      }
+      applyEmojiReplacement(applyWorkspaceEmojiSuggestion(value, activeEmojiShortcode, suggestion))
+    },
+    [activeEmojiShortcode, applyEmojiReplacement, value]
   )
 
   const acceptGitHubLink = useCallback(
@@ -1450,8 +1512,20 @@ export default function SmartWorkspaceNameField({
                         setOpen(true)
                       }
                     }}
+                    onClick={(event) => setEmojiCursor(event.currentTarget.selectionStart)}
                     onChange={(event) => {
-                      onValueChange(event.target.value)
+                      const nextValue = event.target.value
+                      const nextCursor = event.target.selectionStart
+                      const completedEmoji = replaceCompletedWorkspaceEmojiShortcode(
+                        nextValue,
+                        nextCursor
+                      )
+                      if (completedEmoji) {
+                        applyEmojiReplacement(completedEmoji)
+                        return
+                      }
+                      onValueChange(nextValue)
+                      setEmojiCursor(nextCursor)
                       if (!disabled && mode !== 'text') {
                         markSourcePopoverUserEngaged()
                         setOpen(true)
@@ -1460,8 +1534,10 @@ export default function SmartWorkspaceNameField({
                     onFocus={(event) => {
                       // Why: only open on focus from another composer control (Tab); dialog autofocus from outside stays suppressed.
                       if (!isComposerFieldToFieldFocus(event)) {
+                        setEmojiCursor(event.currentTarget.selectionStart)
                         return
                       }
+                      setEmojiCursor(event.currentTarget.selectionStart)
                       markSourcePopoverUserEngaged()
                       tryOpenSourcePopover()
                     }}
@@ -1475,6 +1551,20 @@ export default function SmartWorkspaceNameField({
                           activeTrigger.focus()
                           return
                         }
+                      }
+                      if (emojiMenuOpen && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        const selectedIndex = emojiSuggestions.findIndex(
+                          (suggestion) =>
+                            `emoji:${suggestion.shortcode}` === resolvedEmojiCommandValue
+                        )
+                        const direction = event.key === 'ArrowDown' ? 1 : -1
+                        const nextIndex =
+                          (selectedIndex + direction + emojiSuggestions.length) %
+                          emojiSuggestions.length
+                        setEmojiCommandValue(`emoji:${emojiSuggestions[nextIndex].shortcode}`)
+                        return
                       }
                       if (
                         event.key === 'Enter' &&
@@ -1490,6 +1580,12 @@ export default function SmartWorkspaceNameField({
                         if (isImeCompositionKeyDown(event)) {
                           return
                         }
+                        if (emojiMenuOpen && selectedEmojiSuggestion) {
+                          event.preventDefault()
+                          event.stopPropagation()
+                          handleEmojiSelect(selectedEmojiSuggestion)
+                          return
+                        }
                         if (open && rows.length > 0) {
                           const row = rows.find((entry) => entry.value === resolvedCommandValue)
                           if (row) {
@@ -1500,6 +1596,22 @@ export default function SmartWorkspaceNameField({
                           // No highlighted row (e.g. cleared stale GitHub/Linear results); fall through to onPlainEnter so the keypress isn't inert.
                         }
                         onPlainEnter?.()
+                      }
+                      if (
+                        event.key === 'Tab' &&
+                        !event.shiftKey &&
+                        emojiMenuOpen &&
+                        selectedEmojiSuggestion
+                      ) {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        handleEmojiSelect(selectedEmojiSuggestion)
+                        return
+                      }
+                      if (event.key === 'Escape' && emojiMenuOpen) {
+                        event.stopPropagation()
+                        setEmojiCursor(null)
+                        return
                       }
                       if (event.key === 'Escape' && open) {
                         event.stopPropagation()
@@ -1517,8 +1629,11 @@ export default function SmartWorkspaceNameField({
             </div>
           </PopoverAnchor>
           <PopoverContent
+            data-workspace-source-suggestions="true"
             align="start"
+            side="bottom"
             sideOffset={4}
+            avoidCollisions={false}
             className="popover-scroll-content flex w-[var(--radix-popover-trigger-width)] flex-col p-0"
             // Why: capped height so the result list can't cover the create-workspace dialog's submit footer while typing.
             style={{ maxHeight: 'min(var(--radix-popover-content-available-height,7rem),7rem)' }}
@@ -1614,6 +1729,20 @@ export default function SmartWorkspaceNameField({
           </PopoverContent>
         </Command>
       </Popover>
+      <WorkspaceEmojiSuggestionPopover
+        anchorRef={localInputRef}
+        open={emojiMenuOpen}
+        commandValue={resolvedEmojiCommandValue}
+        heading={translate('auto.components.new.workspace.SmartWorkspaceNameField.emoji', 'Emoji')}
+        suggestions={emojiSuggestions}
+        onCommandValueChange={setEmojiCommandValue}
+        onSelect={handleEmojiSelect}
+        onOpenChange={(next) => {
+          if (!next) {
+            setEmojiCursor(null)
+          }
+        }}
+      />
       <Dialog
         open={crossRepoPrompt !== null}
         onOpenChange={(next) => !next && dismissCrossRepoPrompt()}

--- a/src/renderer/src/components/new-workspace/WorkspaceEmojiSuggestionPopover.tsx
+++ b/src/renderer/src/components/new-workspace/WorkspaceEmojiSuggestionPopover.tsx
@@ -1,0 +1,78 @@
+import type { RefObject } from 'react'
+import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import type { WorkspaceEmojiSuggestion } from '@/lib/workspace-emoji-shortcodes'
+
+type WorkspaceEmojiSuggestionPopoverProps = {
+  anchorRef: RefObject<HTMLInputElement | null>
+  commandValue: string
+  heading: string
+  onCommandValueChange: (value: string) => void
+  onOpenChange: (open: boolean) => void
+  onSelect: (suggestion: WorkspaceEmojiSuggestion) => void
+  open: boolean
+  suggestions: readonly WorkspaceEmojiSuggestion[]
+}
+
+export function WorkspaceEmojiSuggestionPopover({
+  anchorRef,
+  commandValue,
+  heading,
+  onCommandValueChange,
+  onOpenChange,
+  onSelect,
+  open,
+  suggestions
+}: WorkspaceEmojiSuggestionPopoverProps): React.JSX.Element {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverAnchor virtualRef={anchorRef as RefObject<HTMLInputElement>} />
+      <PopoverContent
+        data-workspace-emoji-suggestions="true"
+        align="start"
+        side="top"
+        sideOffset={4}
+        avoidCollisions={false}
+        className="popover-scroll-content flex max-h-56 w-[var(--radix-popover-trigger-width)] flex-col p-0"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onPointerDownOutside={(event) => {
+          if (anchorRef.current?.contains(event.target as Node)) {
+            event.preventDefault()
+          }
+        }}
+        onFocusOutside={(event) => {
+          if (anchorRef.current?.contains(event.target as Node)) {
+            event.preventDefault()
+          }
+        }}
+      >
+        <Command
+          value={commandValue}
+          onValueChange={onCommandValueChange}
+          shouldFilter={false}
+          className="bg-transparent"
+        >
+          <CommandList className="!max-h-none min-h-0 flex-1 scrollbar-sleek">
+            <CommandGroup heading={heading} className="p-1">
+              {suggestions.map((suggestion) => (
+                <CommandItem
+                  key={suggestion.shortcode}
+                  value={`emoji:${suggestion.shortcode}`}
+                  onSelect={() => onSelect(suggestion)}
+                  className="gap-2 px-3 py-2 text-xs"
+                >
+                  <span className="w-5 shrink-0 text-center text-base leading-none">
+                    {suggestion.emoji}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate font-mono text-foreground">
+                    :{suggestion.shortcode}:
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11404,7 +11404,8 @@
             "searchGitLab": "Search GitLab MRs and issues",
             "searchBranches": "Search branches",
             "searchLinear": "Search Linear issues",
-            "workspaceName": "Workspace name"
+            "workspaceName": "Workspace name",
+            "emoji": "Emoji"
           },
           "ProjectHostSetupCombobox": {
             "empty": "No hosts are ready for this project.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -11381,7 +11381,8 @@
             "searchGitLab": "Buscar MRs e issues de GitLab",
             "searchBranches": "Buscar ramas",
             "searchLinear": "Buscar issues de Linear",
-            "workspaceName": "Nombre del espacio de trabajo"
+            "workspaceName": "Nombre del espacio de trabajo",
+            "emoji": "Emoji"
           },
           "ProjectHostSetupCombobox": {
             "empty": "No hay hosts listos para este proyecto.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -11381,7 +11381,8 @@
             "searchGitLab": "GitLab MR と Issue を検索",
             "searchBranches": "ブランチを検索",
             "searchLinear": "Linear Issue を検索",
-            "workspaceName": "ワークスペース名"
+            "workspaceName": "ワークスペース名",
+            "emoji": "Emoji"
           },
           "ProjectHostSetupCombobox": {
             "empty": "No hosts are ready for this project.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -11381,7 +11381,8 @@
             "searchGitLab": "GitLab MR 및 이슈 검색",
             "searchBranches": "브랜치 검색",
             "searchLinear": "Linear 이슈 검색",
-            "workspaceName": "워크스페이스 이름"
+            "workspaceName": "워크스페이스 이름",
+            "emoji": "Emoji"
           },
           "ProjectHostSetupCombobox": {
             "empty": "이 프로젝트에 준비된 호스트가 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11381,7 +11381,8 @@
             "searchGitLab": "搜索 GitLab MR 和议题",
             "searchBranches": "搜索分支",
             "searchLinear": "搜索 Linear 议题",
-            "workspaceName": "工作区名称"
+            "workspaceName": "工作区名称",
+            "emoji": "Emoji"
           },
           "ProjectHostSetupCombobox": {
             "empty": "此项目没有已就绪的主机。",

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyWorkspaceEmojiSuggestion,
+  getActiveWorkspaceEmojiShortcode,
+  replaceCompletedWorkspaceEmojiShortcode,
+  searchWorkspaceEmojiShortcodes
+} from './workspace-emoji-shortcodes'
+
+describe('workspace emoji shortcodes', () => {
+  it('finds standard emoji by Slack-style shortcode', () => {
+    expect(searchWorkspaceEmojiShortcodes('wink', 1)).toEqual([{ emoji: '😉', shortcode: 'wink' }])
+  })
+
+  it('ranks an exact shortcode before longer aliases', () => {
+    expect(searchWorkspaceEmojiShortcodes('heart', 3)[0]).toMatchObject({
+      shortcode: 'heart'
+    })
+  })
+
+  it('deduplicates aliases that resolve to the same emoji', () => {
+    const suggestions = searchWorkspaceEmojiShortcodes('wink')
+    expect(new Set(suggestions.map((suggestion) => suggestion.emoji)).size).toBe(suggestions.length)
+  })
+
+  it('detects a shortcode at the caret without matching URLs or mid-word colons', () => {
+    expect(getActiveWorkspaceEmojiShortcode('Ship :win', 9)).toEqual({
+      start: 5,
+      end: 9,
+      query: 'win'
+    })
+    expect(getActiveWorkspaceEmojiShortcode('https://example.com', 19)).toBeNull()
+    expect(getActiveWorkspaceEmojiShortcode('fix:win', 7)).toBeNull()
+  })
+
+  it('replaces a completed shortcode and preserves text after the caret', () => {
+    expect(replaceCompletedWorkspaceEmojiShortcode('Ship :wink: today', 11)).toEqual({
+      value: 'Ship 😉 today',
+      cursor: 7
+    })
+  })
+
+  it('leaves unknown completed shortcodes unchanged', () => {
+    expect(replaceCompletedWorkspaceEmojiShortcode(':orca_custom:', 13)).toBeNull()
+  })
+
+  it('applies a selected suggestion to the active shortcode range', () => {
+    expect(
+      applyWorkspaceEmojiSuggestion(
+        'Ship :win today',
+        { start: 5, end: 9, query: 'win' },
+        { emoji: '😉', shortcode: 'wink' }
+      )
+    ).toEqual({
+      value: 'Ship 😉 today',
+      cursor: 7
+    })
+  })
+})

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.ts
@@ -1,0 +1,112 @@
+import {
+  STANDARD_EMOJI_SHORTCODE_ENTRIES,
+  type StandardEmojiShortcodeEntry
+} from '../../../shared/emoji-shortcode-catalog'
+
+export type WorkspaceEmojiSuggestion = StandardEmojiShortcodeEntry
+
+export type ActiveWorkspaceEmojiShortcode = {
+  end: number
+  query: string
+  start: number
+}
+
+export type WorkspaceEmojiReplacement = {
+  cursor: number
+  value: string
+}
+
+const SHORTCODE_ENTRIES = STANDARD_EMOJI_SHORTCODE_ENTRIES
+
+const EXACT_SHORTCODE = new Map(
+  SHORTCODE_ENTRIES.map(({ emoji, shortcode }) => [shortcode, { emoji, shortcode }])
+)
+
+export function searchWorkspaceEmojiShortcodes(
+  query: string,
+  limit = 8
+): WorkspaceEmojiSuggestion[] {
+  const normalizedQuery = query.trim().toLowerCase()
+  if (!normalizedQuery || limit <= 0) {
+    return []
+  }
+
+  const matches = SHORTCODE_ENTRIES.filter(({ shortcode }) =>
+    shortcode.startsWith(normalizedQuery)
+  ).sort(
+    (left, right) =>
+      Number(right.shortcode === normalizedQuery) - Number(left.shortcode === normalizedQuery) ||
+      left.shortcode.length - right.shortcode.length ||
+      left.shortcode.localeCompare(right.shortcode)
+  )
+  const seenEmoji = new Set<string>()
+  const suggestions: WorkspaceEmojiSuggestion[] = []
+  for (const { emoji, shortcode } of matches) {
+    if (seenEmoji.has(emoji)) {
+      continue
+    }
+    seenEmoji.add(emoji)
+    suggestions.push({ emoji, shortcode })
+    if (suggestions.length === limit) {
+      break
+    }
+  }
+  return suggestions
+}
+
+export function getActiveWorkspaceEmojiShortcode(
+  value: string,
+  cursor: number | null
+): ActiveWorkspaceEmojiShortcode | null {
+  if (cursor === null || cursor < 0 || cursor > value.length) {
+    return null
+  }
+  const match = value.slice(0, cursor).match(/(^|\s):([a-z0-9_+-]{1,40})$/i)
+  if (!match) {
+    return null
+  }
+  return {
+    start: cursor - match[2].length - 1,
+    end: cursor,
+    query: match[2].toLowerCase()
+  }
+}
+
+export function replaceCompletedWorkspaceEmojiShortcode(
+  value: string,
+  cursor: number | null
+): WorkspaceEmojiReplacement | null {
+  if (cursor === null || cursor < 0 || cursor > value.length) {
+    return null
+  }
+  const match = value.slice(0, cursor).match(/(^|\s):([a-z0-9_+-]{1,40}):$/i)
+  if (!match) {
+    return null
+  }
+  const suggestion = EXACT_SHORTCODE.get(match[2].toLowerCase())
+  if (!suggestion) {
+    return null
+  }
+  const start = cursor - match[2].length - 2
+  return replaceWorkspaceEmojiRange(value, start, cursor, suggestion.emoji)
+}
+
+export function applyWorkspaceEmojiSuggestion(
+  value: string,
+  active: ActiveWorkspaceEmojiShortcode,
+  suggestion: WorkspaceEmojiSuggestion
+): WorkspaceEmojiReplacement {
+  return replaceWorkspaceEmojiRange(value, active.start, active.end, suggestion.emoji)
+}
+
+function replaceWorkspaceEmojiRange(
+  value: string,
+  start: number,
+  end: number,
+  emoji: string
+): WorkspaceEmojiReplacement {
+  return {
+    value: `${value.slice(0, start)}${emoji}${value.slice(end)}`,
+    cursor: start + emoji.length
+  }
+}

--- a/tests/e2e/worktree.spec.ts
+++ b/tests/e2e/worktree.spec.ts
@@ -190,6 +190,43 @@ test.describe('Create Workspace', () => {
     }
   })
 
+  test('enters emoji with Slack-style shortcode suggestions', async ({ orcaPage }) => {
+    try {
+      await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
+
+      const dialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+      const nameInput = dialog.getByPlaceholder(/Type a name/i)
+      await expect(nameInput).toBeVisible()
+
+      await nameInput.pressSequentially('Launch :wink', { delay: 100 })
+      const emojiSuggestions = orcaPage.locator('[data-workspace-emoji-suggestions="true"]')
+      const sourceSuggestions = orcaPage.locator('[data-workspace-source-suggestions="true"]')
+      await expect(emojiSuggestions).toBeVisible()
+      await expect(emojiSuggestions.getByRole('option', { name: ':wink:' })).toBeVisible()
+      await expect(emojiSuggestions).toHaveAttribute('data-side', 'top')
+      await expect(sourceSuggestions).toBeVisible()
+      await expect(sourceSuggestions).toHaveAttribute('data-side', 'bottom')
+      // Keep both independently positioned suggestion surfaces visible in proof recordings.
+      await orcaPage.waitForTimeout(750)
+
+      await nameInput.pressSequentially(':')
+      await expect(nameInput).toHaveValue('Launch 😉')
+      await expect(orcaPage.getByRole('option', { name: /:wink:/i })).toHaveCount(0)
+      await nameInput.pressSequentially(' experiment')
+      await expect(nameInput).toHaveValue('Launch 😉 experiment')
+      // Keep the asserted result visible in retained proof recordings.
+      await orcaPage.waitForTimeout(750)
+    } finally {
+      await orcaPage
+        .evaluate(() => {
+          window.__store?.getState().closeModal()
+        })
+        .catch(() => {
+          /* page may already be torn down */
+        })
+    }
+  })
+
   test('shows a failed workspace entry when worktree creation fails', async ({ orcaPage }) => {
     await orcaPage.evaluate(() => {
       const store = window.__store


### PR DESCRIPTION
## Summary

- add an offline, standard-Unicode emoji shortcode picker while naming a workspace
- render emoji suggestions in a separate popover above the input while existing source autocomplete remains below; both can be visible together
- replace completed shortcodes anywhere in longer names, for example `Launch :wink: experiment` → `Launch 😉 experiment`
- support Enter, Tab, and Escape without limiting completion to a single-emoji name
- exclude custom emoji and reuse the shared emoji catalog from #11057
- depends on #11057

## Visual proof

https://github.com/user-attachments/assets/ff8b685e-04b2-43ac-bc98-6508d43136ba

The recording shows the emoji picker above the input, source suggestions below it, and `Launch 😉 experiment` after insertion.

## Test plan

- `pnpm run typecheck`
- 318 focused tests passed
- `pnpm run lint`
- localization catalog, coverage, and max-lines checks
- production Electron build
- Electron E2E verifies simultaneous top/bottom popovers and longer-name insertion
- `git diff --check`