### PR TITLE
test(status-bar): cover weekly-only Grok usage bar

### DIFF
--- a/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
@@ -43,7 +43,38 @@ function grokMonthlyLimits(status: ProviderRateLimits['status']): ProviderRateLi
   }
 }
 
-describe('ProviderSegment monthly window', () => {
+function grokWeeklyLimits(): ProviderRateLimits {
+  return {
+    provider: 'grok',
+    session: null,
+    weekly: windowOf(27, 10080),
+    monthly: null,
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok'
+  }
+}
+
+describe('ProviderSegment usage windows', () => {
+  it('renders a usage bar for weekly-only Grok in detailed mode (#9366)', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={grokWeeklyLimits()} compact={false} display="used" mode="verbose" />
+    )
+    expect(markup).toContain('data-usage-bar')
+    expect(markup).toContain('27% used')
+    expect(markup).toContain('width:27%')
+  })
+
+  it('renders the weekly-only Grok label in compact mode', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={grokWeeklyLimits()} compact={false} display="used" mode="compact" />
+    )
+    expect(markup).toContain('27% used wk')
+    expect(markup).not.toContain('data-usage-bar')
+  })
+
   it('renders a monthly-only snapshot in the chip instead of a bare icon', async () => {
     const { ProviderSegment } = await import('./StatusBar')
 


### PR DESCRIPTION
Supersedes conflicting contributor attempt #9367 and credits its diagnosis.

## Why

Weekly-only Grok accounts were missing the small status-bar usage bar (#9366). While this PR was waiting, #11376 centralized the detailed-mode bar on `getTightestUsageSection`, which now covers weekly-only Grok. After rebasing onto `main`, this PR keeps focused regression coverage and avoids duplicating the meter-selection logic.

## Before / after

Captured from the same Electron app instance, viewport, isolated profile, and controlled store state. The fixture holds Codex at 72% session / 45% weekly and Grok at `session: null` / 41% weekly. Both screenshots use detailed mode and the “used” display.

### Before — Grok has no bar

The former session-only condition was restored for this capture. Codex shows its 72% meter; Grok shows `41% used wk` with no meter after its icon.

![Before: Codex has a session meter while weekly-only Grok has no meter](https://github.com/user-attachments/assets/6af6cbe8-6189-4cde-bed8-282b351eba53)

### After — Grok has a 41% bar

The current implementation was restored through hot reload without changing the store state or viewport. Codex is unchanged; Grok now shows a 41% meter between its icon and `41% used wk` label.

![After: weekly-only Grok has a 41 percent usage meter](https://github.com/user-attachments/assets/9da21ae3-b8aa-4bc8-828d-75b2b619b400)

## Automated proof

The detailed-mode fixture uses `session: null` and a weekly window at 27%, then asserts `data-usage-bar`, `27% used`, and `width:27%`. A companion compact-mode case asserts `27% used wk` and confirms that mode intentionally omits the detailed usage bar.

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx` — 11 passed
- `pnpm run check:code-quality:changed` — passed, 0 new findings
- `pnpm run typecheck` — passed
- `pnpm exec oxfmt --check src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx` — passed

## AI Review Report

- Traced the render authority from `ProviderSegment` through `getTightestUsageSection`; weekly-only Grok reaches the existing detailed bar without a second selection path.
- Checked the successful, compact, stale/error, and missing-window neighboring branches for regression risk; production code is unchanged.
- Greptile reviewed the test-only diff at 4/5 confidence. Its two P2 suggestions were addressed by clarifying the detailed-mode test name and adding compact-mode coverage.
- macOS visible behavior was exercised in Electron. The changed static renderer tests are platform-neutral; Linux, Windows, SSH, and folder-workspace behavior is unchanged because the PR adds no production path or platform condition.

## Security Audit

- Test-only change: no authority, validation, persistence, cleanup, network, authentication, IPC, or dependency behavior changes.
- The fixture contains synthetic percentages only. Uploaded screenshots contain no credentials or account identifiers.
- No new external input, executable command, secret handling, or provider-specific privilege boundary is introduced.

## Risk

Test-only after rebase; production behavior from #11376 is unchanged. No persistence, SSH, folder-workspace, Git, or platform-specific paths are touched.

Fixes #9366.