### PR TITLE
fix(ui): prevent IME Enter from submitting rename and notes fields

### DIFF
--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.ime-enter.test.tsx
@@ -11,8 +11,7 @@ const { commitRename, cancelRename } = vi.hoisted(() => ({
   cancelRename: vi.fn()
 }))
 
-// Why: the rename field only mounts while the hook reports isRenaming, so the
-// hook is stubbed into that state instead of driving the whole rename flow.
+// Why: stub the hook state so this test isolates the mounted rename field.
 vi.mock('./editor-header-file-rename', () => ({
   useEditorHeaderFileRename: () => ({
     canRename: true,
@@ -79,12 +78,13 @@ function renderHeaderPath(): HTMLInputElement {
   return input
 }
 
-function pressEnter(
+function pressKey(
   input: HTMLInputElement,
+  key: string,
   init?: KeyboardEventInit & { keyCode?: number }
 ): void {
   const event = new KeyboardEvent('keydown', {
-    key: 'Enter',
+    key,
     bubbles: true,
     cancelable: true,
     ...init
@@ -101,7 +101,7 @@ describe('EditorPanelHeaderPath IME Enter guard', () => {
   it('does not commit the rename on an IME-composition Enter', () => {
     const input = renderHeaderPath()
 
-    pressEnter(input, { isComposing: true })
+    pressKey(input, 'Enter', { isComposing: true })
 
     expect(commitRename).not.toHaveBeenCalled()
   })
@@ -109,7 +109,7 @@ describe('EditorPanelHeaderPath IME Enter guard', () => {
   it('does not commit it for IMEs that report keyCode 229 without isComposing', () => {
     const input = renderHeaderPath()
 
-    pressEnter(input, { keyCode: 229 })
+    pressKey(input, 'Enter', { keyCode: 229 })
 
     expect(commitRename).not.toHaveBeenCalled()
   })
@@ -117,7 +117,34 @@ describe('EditorPanelHeaderPath IME Enter guard', () => {
   it('still commits the rename on a plain Enter', () => {
     const input = renderHeaderPath()
 
-    pressEnter(input)
+    pressKey(input, 'Enter')
+
+    expect(commitRename).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cancel the rename on an IME-composition Escape', () => {
+    const input = renderHeaderPath()
+
+    pressKey(input, 'Escape', { isComposing: true })
+
+    expect(cancelRename).not.toHaveBeenCalled()
+  })
+
+  it('still cancels the rename on a plain Escape', () => {
+    const input = renderHeaderPath()
+
+    pressKey(input, 'Escape')
+
+    expect(cancelRename).toHaveBeenCalledTimes(1)
+  })
+
+  it('still commits the rename on blur', () => {
+    const input = renderHeaderPath()
+
+    act(() => {
+      input.focus()
+      input.blur()
+    })
 
     expect(commitRename).toHaveBeenCalledTimes(1)
   })

--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.ime-enter.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import { EditorPanelHeaderPath } from './EditorPanelHeaderPath'
+
+const { commitRename, cancelRename } = vi.hoisted(() => ({
+  commitRename: vi.fn(),
+  cancelRename: vi.fn()
+}))
+
+// Why: the rename field only mounts while the hook reports isRenaming, so the
+// hook is stubbed into that state instead of driving the whole rename flow.
+vi.mock('./editor-header-file-rename', () => ({
+  useEditorHeaderFileRename: () => ({
+    canRename: true,
+    currentFileName: '議事録.md',
+    isRenaming: true,
+    renameInputRef: { current: null },
+    openRenameInput: vi.fn(),
+    commitRename,
+    cancelRename
+  })
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutLabel: () => '⌘⇧M'
+}))
+
+const activeFile: OpenFile = {
+  id: 'edit:/repo/議事録.md',
+  filePath: '/repo/議事録.md',
+  relativePath: '議事録.md',
+  worktreeId: 'repo::/repo',
+  language: 'markdown',
+  isDirty: false,
+  mode: 'edit'
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  commitRename.mockClear()
+  cancelRename.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderHeaderPath(): HTMLInputElement {
+  act(() => {
+    root.render(
+      <EditorPanelHeaderPath
+        activeFile={activeFile}
+        copiedPathVisible={false}
+        canShowMarkdownPreview={false}
+        onCopyPath={vi.fn()}
+        onOpenMarkdownPreview={vi.fn()}
+        onOpenContainingFolder={vi.fn()}
+      />
+    )
+  })
+  const input = document.body.querySelector<HTMLInputElement>(
+    '[data-editor-header-rename-input="true"]'
+  )
+  if (!input) {
+    throw new Error('rename input not rendered')
+  }
+  return input
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('EditorPanelHeaderPath IME Enter guard', () => {
+  it('does not commit the rename on an IME-composition Enter', () => {
+    const input = renderHeaderPath()
+
+    pressEnter(input, { isComposing: true })
+
+    expect(commitRename).not.toHaveBeenCalled()
+  })
+
+  it('does not commit it for IMEs that report keyCode 229 without isComposing', () => {
+    const input = renderHeaderPath()
+
+    pressEnter(input, { keyCode: 229 })
+
+    expect(commitRename).not.toHaveBeenCalled()
+  })
+
+  it('still commits the rename on a plain Enter', () => {
+    const input = renderHeaderPath()
+
+    pressEnter(input)
+
+    expect(commitRename).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeaderPath.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Input } from '@/components/ui/input'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { translate } from '@/i18n/i18n'
 import type { OpenFile } from '@/store/slices/editor'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from '../tab-bar/SortableTab'
@@ -96,6 +97,9 @@ export function EditorPanelHeaderPath({
             onClick={(event) => event.stopPropagation()}
             onDoubleClick={(event) => event.stopPropagation()}
             onKeyDown={(event) => {
+              if (isImeCompositionKeyDown(event)) {
+                return
+              }
               if (event.key === 'Enter') {
                 event.preventDefault()
                 event.stopPropagation()

--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.ime-enter.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UntitledFileRenameDialog } from './UntitledFileRenameDialog'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderDialog(onConfirm: (relativePath: string) => void): {
+  nameInput: HTMLInputElement
+  folderInput: HTMLInputElement
+} {
+  act(() => {
+    root.render(
+      <UntitledFileRenameDialog
+        open={true}
+        currentName="議事録"
+        worktreePath="/repo"
+        disableBrowse
+        onClose={vi.fn()}
+        onConfirm={onConfirm}
+      />
+    )
+  })
+  const inputs = Array.from(document.body.querySelectorAll('input'))
+  if (inputs.length < 2) {
+    throw new Error('rename dialog inputs not rendered')
+  }
+  return { nameInput: inputs[0], folderInput: inputs[1] }
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('UntitledFileRenameDialog IME Enter guard', () => {
+  it('does not save the file on an IME-composition Enter in the name field', () => {
+    const onConfirm = vi.fn()
+    const { nameInput } = renderDialog(onConfirm)
+
+    pressEnter(nameInput, { isComposing: true })
+
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('does not save it for IMEs that report keyCode 229 without isComposing', () => {
+    const onConfirm = vi.fn()
+    const { nameInput } = renderDialog(onConfirm)
+
+    pressEnter(nameInput, { keyCode: 229 })
+
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('does not save the file on an IME-composition Enter in the folder field', () => {
+    const onConfirm = vi.fn()
+    const { folderInput } = renderDialog(onConfirm)
+
+    pressEnter(folderInput, { isComposing: true })
+
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('still saves on a plain Enter', () => {
+    const onConfirm = vi.fn()
+    const { nameInput } = renderDialog(onConfirm)
+
+    pressEnter(nameInput)
+
+    expect(onConfirm).toHaveBeenCalledWith('議事録.md')
+  })
+})

--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.ime-enter.test.tsx
@@ -21,7 +21,10 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-function renderDialog(onConfirm: (relativePath: string) => void): {
+function renderDialog(
+  onConfirm: (relativePath: string) => void,
+  onClose: () => void = vi.fn()
+): {
   nameInput: HTMLInputElement
   folderInput: HTMLInputElement
 } {
@@ -32,7 +35,7 @@ function renderDialog(onConfirm: (relativePath: string) => void): {
         currentName="議事録"
         worktreePath="/repo"
         disableBrowse
-        onClose={vi.fn()}
+        onClose={onClose}
         onConfirm={onConfirm}
       />
     )
@@ -59,6 +62,14 @@ function pressEnter(
   }
   act(() => {
     input.dispatchEvent(event)
+  })
+}
+
+function changeValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  act(() => {
+    setter?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
   })
 }
 
@@ -93,9 +104,27 @@ describe('UntitledFileRenameDialog IME Enter guard', () => {
   it('still saves on a plain Enter', () => {
     const onConfirm = vi.fn()
     const { nameInput } = renderDialog(onConfirm)
+    changeValue(nameInput, '最終版')
 
     pressEnter(nameInput)
 
-    expect(onConfirm).toHaveBeenCalledWith('議事録.md')
+    expect(onConfirm).toHaveBeenCalledWith('最終版.md')
+  })
+
+  it('keeps the dialog open when composition Escape uses keyCode 229', () => {
+    const onClose = vi.fn()
+    const { nameInput } = renderDialog(vi.fn(), onClose)
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true
+    })
+    Object.defineProperty(event, 'keyCode', { value: 229 })
+
+    act(() => {
+      nameInput.dispatchEvent(event)
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
+++ b/src/renderer/src/components/editor/UntitledFileRenameDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { getRelativePathInsideRoot } from '@/lib/path'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
 
@@ -157,6 +158,9 @@ export function UntitledFileRenameDialog({
                   setError(null)
                 }}
                 onKeyDown={(e) => {
+                  if (isImeCompositionKeyDown(e)) {
+                    return
+                  }
                   if (e.key === 'Enter') {
                     e.preventDefault()
                     handleSubmit()
@@ -186,6 +190,9 @@ export function UntitledFileRenameDialog({
                   setError(null)
                 }}
                 onKeyDown={(e) => {
+                  if (isImeCompositionKeyDown(e)) {
+                    return
+                  }
                   if (e.key === 'Enter') {
                     e.preventDefault()
                     handleSubmit()

--- a/src/renderer/src/components/sidebar/HostRenameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/HostRenameDialog.ime-enter.test.tsx
@@ -95,4 +95,22 @@ describe('HostRenameDialog IME Enter guard', () => {
     expect(updateSettings).toHaveBeenCalledTimes(1)
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
+
+  it('keeps the dialog open on an IME-composition Escape', () => {
+    const onOpenChange = vi.fn()
+    const input = renderDialog(onOpenChange)
+
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          isComposing: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/sidebar/HostRenameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/HostRenameDialog.ime-enter.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HostRenameDialog } from './HostRenameDialog'
+
+const { updateSettings } = vi.hoisted(() => ({ updateSettings: vi.fn() }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ settings: {}, updateSettings })
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  updateSettings.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderDialog(onOpenChange: (open: boolean) => void): HTMLInputElement {
+  act(() => {
+    root.render(
+      <HostRenameDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        hostId="local"
+        derivedLabel="This Mac"
+      />
+    )
+  })
+  const input = document.body.querySelector<HTMLInputElement>('#host-rename-input')
+  if (!input) {
+    throw new Error('host rename input not rendered')
+  }
+  return input
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+describe('HostRenameDialog IME Enter guard', () => {
+  it('does not commit the rename on an IME-composition Enter', () => {
+    const onOpenChange = vi.fn()
+    const input = renderDialog(onOpenChange)
+
+    pressEnter(input, { isComposing: true })
+
+    expect(updateSettings).not.toHaveBeenCalled()
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('does not commit it for IMEs that report keyCode 229 without isComposing', () => {
+    const onOpenChange = vi.fn()
+    const input = renderDialog(onOpenChange)
+
+    pressEnter(input, { keyCode: 229 })
+
+    expect(updateSettings).not.toHaveBeenCalled()
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('still commits the rename on a plain Enter', () => {
+    const onOpenChange = vi.fn()
+    const input = renderDialog(onOpenChange)
+
+    pressEnter(input)
+
+    expect(updateSettings).toHaveBeenCalledTimes(1)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/HostRenameDialog.tsx
+++ b/src/renderer/src/components/sidebar/HostRenameDialog.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useAppStore } from '@/store'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { translate } from '@/i18n/i18n'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { applyHostRename, getHostDisplayLabelOverride } from './host-rename-remove'
@@ -78,6 +79,9 @@ export function HostRenameDialog({
             placeholder={derivedLabel}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
+              if (isImeCompositionKeyDown(e)) {
+                return
+              }
               if (e.key === 'Enter') {
                 e.preventDefault()
                 submit()

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.ime-enter.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderDialog(onSubmit: () => void): HTMLInputElement {
+  act(() => {
+    root.render(
+      <ProjectGroupNameDialog
+        open={true}
+        title="Rename Project Group"
+        description="Name this group."
+        initialName="グループ"
+        confirmLabel="Save"
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+  })
+  const input = document.body.querySelector('input')
+  if (!input) {
+    throw new Error('group name input not rendered')
+  }
+  return input
+}
+
+function pressEnter(
+  input: HTMLInputElement,
+  init?: KeyboardEventInit & { keyCode?: number }
+): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    input.dispatchEvent(event)
+  })
+  return event
+}
+
+describe('ProjectGroupNameDialog IME Enter guard', () => {
+  it('cancels the implicit form submit on an IME-composition Enter (isComposing)', () => {
+    const onSubmit = vi.fn()
+    const input = renderDialog(onSubmit)
+
+    const event = pressEnter(input, { isComposing: true })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('cancels it for IMEs that report keyCode 229 without isComposing', () => {
+    const onSubmit = vi.fn()
+    const input = renderDialog(onSubmit)
+
+    const event = pressEnter(input, { keyCode: 229 })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('leaves a plain Enter alone so the form still submits', () => {
+    const onSubmit = vi.fn()
+    const input = renderDialog(onSubmit)
+
+    const event = pressEnter(input)
+
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  it('still saves the trimmed name when the form submits', () => {
+    const onSubmit = vi.fn()
+    renderDialog(onSubmit)
+    const form = document.body.querySelector('form')
+    if (!form) {
+      throw new Error('form not rendered')
+    }
+
+    act(() => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+    })
+
+    expect(onSubmit).toHaveBeenCalledWith('グループ')
+  })
+})

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.ime-enter.test.tsx
@@ -21,7 +21,10 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-function renderDialog(onSubmit: () => void): HTMLInputElement {
+function renderDialog(
+  onSubmit: () => void,
+  onOpenChange: (open: boolean) => void = vi.fn()
+): HTMLInputElement {
   act(() => {
     root.render(
       <ProjectGroupNameDialog
@@ -30,7 +33,7 @@ function renderDialog(onSubmit: () => void): HTMLInputElement {
         description="Name this group."
         initialName="グループ"
         confirmLabel="Save"
-        onOpenChange={vi.fn()}
+        onOpenChange={onOpenChange}
         onSubmit={onSubmit}
       />
     )
@@ -59,6 +62,14 @@ function pressEnter(
     input.dispatchEvent(event)
   })
   return event
+}
+
+function changeValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  act(() => {
+    setter?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
 }
 
 describe('ProjectGroupNameDialog IME Enter guard', () => {
@@ -93,7 +104,8 @@ describe('ProjectGroupNameDialog IME Enter guard', () => {
 
   it('still saves the trimmed name when the form submits', () => {
     const onSubmit = vi.fn()
-    renderDialog(onSubmit)
+    const input = renderDialog(onSubmit)
+    changeValue(input, '  新しいグループ  ')
     const form = document.body.querySelector('form')
     if (!form) {
       throw new Error('form not rendered')
@@ -103,6 +115,24 @@ describe('ProjectGroupNameDialog IME Enter guard', () => {
       form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
     })
 
-    expect(onSubmit).toHaveBeenCalledWith('グループ')
+    expect(onSubmit).toHaveBeenCalledWith('新しいグループ')
+  })
+
+  it('keeps the dialog open when composition Escape uses keyCode 229', () => {
+    const onOpenChange = vi.fn()
+    const input = renderDialog(vi.fn(), onOpenChange)
+    const event = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true
+    })
+    Object.defineProperty(event, 'keyCode', { value: 229 })
+
+    act(() => {
+      input.dispatchEvent(event)
+    })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(onOpenChange).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { translate } from '@/i18n/i18n'
 
 type ProjectGroupNameDialogProps = {
@@ -102,6 +103,13 @@ export function ProjectGroupNameDialog({
               ref={inputRef}
               value={name}
               onChange={(event) => setName(event.target.value)}
+              onKeyDown={(event) => {
+                // Why: the form submits implicitly on Enter, and a CJK IME fires one
+                // for the conversion candidate — that must not save a half-typed name.
+                if (event.key === 'Enter' && isImeCompositionKeyDown(event)) {
+                  event.preventDefault()
+                }
+              }}
               className="h-8 text-xs"
             />
           </div>

--- a/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
+++ b/src/renderer/src/components/sidebar/ProjectGroupNameDialog.tsx
@@ -104,8 +104,7 @@ export function ProjectGroupNameDialog({
               value={name}
               onChange={(event) => setName(event.target.value)}
               onKeyDown={(event) => {
-                // Why: the form submits implicitly on Enter, and a CJK IME fires one
-                // for the conversion candidate — that must not save a half-typed name.
+                // Why: implicit form submission must not save an IME conversion candidate.
                 if (event.key === 'Enter' && isImeCompositionKeyDown(event)) {
                   event.preventDefault()
                 }

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.ime-enter.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import WorktreeMetaDialog from './WorktreeMetaDialog'
+
+const { closeModal, updateWorktreeMeta } = vi.hoisted(() => ({
+  closeModal: vi.fn(),
+  updateWorktreeMeta: vi.fn(async () => undefined)
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      activeModal: 'edit-meta',
+      modalData: { worktreeId: 'repo::/repo', currentDisplayName: '', focus: 'comment' },
+      closeModal,
+      updateWorktreeMeta,
+      fetchIssue: vi.fn(),
+      worktreesByRepo: {}
+    })
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  updateWorktreeMeta.mockClear()
+  closeModal.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderDialog(): { displayNameInput: HTMLInputElement; comment: HTMLTextAreaElement } {
+  act(() => {
+    root.render(<WorktreeMetaDialog />)
+  })
+  const displayNameInput = document.body.querySelector('input')
+  const comment = document.body.querySelector('textarea')
+  if (!displayNameInput || !comment) {
+    throw new Error('worktree meta fields not rendered')
+  }
+  return { displayNameInput, comment }
+}
+
+function pressEnter(element: HTMLElement, init?: KeyboardEventInit & { keyCode?: number }): void {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  if (init?.keyCode !== undefined) {
+    Object.defineProperty(event, 'keyCode', { value: init.keyCode })
+  }
+  act(() => {
+    element.dispatchEvent(event)
+  })
+}
+
+describe('WorktreeMetaDialog IME Enter guard', () => {
+  it('does not save the note on the Enter that commits an IME composition', () => {
+    const { comment } = renderDialog()
+
+    pressEnter(comment, { isComposing: true })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('does not save it for IMEs that report keyCode 229 without isComposing', () => {
+    const { comment } = renderDialog()
+
+    pressEnter(comment, { keyCode: 229 })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('does not save the display name on an IME-composition Enter', () => {
+    const { displayNameInput } = renderDialog()
+
+    pressEnter(displayNameInput, { isComposing: true })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('still saves on a plain Enter', () => {
+    const { comment } = renderDialog()
+
+    pressEnter(comment)
+
+    expect(updateWorktreeMeta).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.ime-enter.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.ime-enter.test.tsx
@@ -46,16 +46,26 @@ afterEach(() => {
   document.body.innerHTML = ''
 })
 
-function renderDialog(): { displayNameInput: HTMLInputElement; comment: HTMLTextAreaElement } {
+function renderDialog(): {
+  displayNameInput: HTMLInputElement
+  issueInput: HTMLInputElement
+  prInput: HTMLInputElement
+  comment: HTMLTextAreaElement
+} {
   act(() => {
     root.render(<WorktreeMetaDialog />)
   })
-  const displayNameInput = document.body.querySelector('input')
+  const inputs = Array.from(document.body.querySelectorAll('input'))
   const comment = document.body.querySelector('textarea')
-  if (!displayNameInput || !comment) {
+  if (inputs.length !== 3 || !comment) {
     throw new Error('worktree meta fields not rendered')
   }
-  return { displayNameInput, comment }
+  return {
+    displayNameInput: inputs[0],
+    issueInput: inputs[1],
+    prInput: inputs[2],
+    comment
+  }
 }
 
 function pressEnter(element: HTMLElement, init?: KeyboardEventInit & { keyCode?: number }): void {
@@ -70,6 +80,14 @@ function pressEnter(element: HTMLElement, init?: KeyboardEventInit & { keyCode?:
   }
   act(() => {
     element.dispatchEvent(event)
+  })
+}
+
+function changeValue(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  act(() => {
+    setter?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
   })
 }
 
@@ -96,6 +114,64 @@ describe('WorktreeMetaDialog IME Enter guard', () => {
     pressEnter(displayNameInput, { isComposing: true })
 
     expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it.each(['issueInput', 'prInput'] as const)(
+    'does not save the %s on keyCode 229 Enter',
+    (field) => {
+      const inputs = renderDialog()
+
+      pressEnter(inputs[field], { keyCode: 229 })
+
+      expect(updateWorktreeMeta).not.toHaveBeenCalled()
+    }
+  )
+
+  it('does not save a composition Enter with the platform submit modifier', () => {
+    const { comment } = renderDialog()
+    const modifier = navigator.userAgent.includes('Mac') ? { metaKey: true } : { ctrlKey: true }
+
+    pressEnter(comment, { isComposing: true, ...modifier })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('keeps Shift+Enter available for a note newline', () => {
+    const { comment } = renderDialog()
+
+    pressEnter(comment, { shiftKey: true })
+
+    expect(updateWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('saves with the platform submit modifier', () => {
+    const { displayNameInput, comment } = renderDialog()
+    const modifier = navigator.userAgent.includes('Mac') ? { metaKey: true } : { ctrlKey: true }
+    changeValue(displayNameInput, '最新の名前')
+
+    pressEnter(comment, modifier)
+
+    expect(updateWorktreeMeta).toHaveBeenCalledWith(
+      'repo::/repo',
+      expect.objectContaining({ displayName: '最新の名前' })
+    )
+  })
+
+  it('keeps the dialog open on an IME-composition Escape', () => {
+    const { comment } = renderDialog()
+
+    act(() => {
+      comment.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          isComposing: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+
+    expect(closeModal).not.toHaveBeenCalled()
   })
 
   it('still saves on a plain Enter', () => {

--- a/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeMetaDialog.tsx
@@ -18,6 +18,7 @@ import {
 } from './worktree-meta-updates'
 import { useWorktreeIssueLink } from './use-worktree-issue-link'
 import { getScreenSubmitShortcutLabel, isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { ExternalLink, LoaderCircle } from 'lucide-react'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
@@ -158,6 +159,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
 
   const handleCommentKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (isImeCompositionKeyDown(e)) {
+        return
+      }
       const isPlainEnter = e.key === 'Enter' && !e.shiftKey && !e.altKey && !e.metaKey && !e.ctrlKey
       if (isPlainEnter || isScreenSubmitShortcut(e)) {
         e.preventDefault()
@@ -170,6 +174,9 @@ const WorktreeMetaDialog = React.memo(function WorktreeMetaDialog() {
 
   const handleIssueKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (isImeCompositionKeyDown(e)) {
+        return
+      }
       if (e.key === 'Enter') {
         e.preventDefault()
         handleSave()

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -7,6 +7,7 @@ import { Dialog as DialogPrimitive } from 'radix-ui'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
+import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
@@ -48,6 +49,7 @@ function DialogContent({
   children,
   overlayClassName,
   showCloseButton = true,
+  onEscapeKeyDown,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   overlayClassName?: string
@@ -67,6 +69,13 @@ function DialogContent({
           'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-black/14 bg-background/96 p-6 text-foreground shadow-[0_20px_60px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl duration-200 outline-none dark:border-white/14 dark:bg-[rgba(23,23,23,0.96)] dark:shadow-[0_24px_72px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.06)] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           className
         )}
+        onEscapeKeyDown={(event) => {
+          if (isImeCompositionKeyDown(event)) {
+            event.preventDefault()
+            return
+          }
+          onEscapeKeyDown?.(event)
+        }}
         {...props}
       >
         {children}

--- a/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.test.ts
@@ -23,4 +23,10 @@ describe('isImeCompositionKeyDown', () => {
   it('is false for a plain Enter outside of composition', () => {
     expect(isImeCompositionKeyDown(keyEvent({ isComposing: false, keyCode: 13 }))).toBe(false)
   })
+
+  it('accepts the native keyboard event Radix provides for Escape', () => {
+    const event = { isComposing: true, keyCode: 27 } as KeyboardEvent
+
+    expect(isImeCompositionKeyDown(event)).toBe(true)
+  })
 })

--- a/src/renderer/src/lib/ime-composition-keyboard-event.ts
+++ b/src/renderer/src/lib/ime-composition-keyboard-event.ts
@@ -1,13 +1,9 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
 
-/**
- * Why: CJK IMEs (Japanese/Chinese/Korean) fire a keydown for the Enter that
- * only confirms a conversion candidate. Rename/title inputs that commit on
- * `Enter` must ignore that keydown, otherwise they submit mid-composition with a
- * half-converted value. `isComposing` covers most browsers; `keyCode === 229` is
- * a defensive fallback for IMEs that don't set `isComposing` on keydown.
- */
-export function isImeCompositionKeyDown(event: ReactKeyboardEvent): boolean {
-  const nativeEvent = event.nativeEvent
+type ImeKeyboardEvent = KeyboardEvent | ReactKeyboardEvent
+
+/** Detects IME-owned keydowns, including engines that only report keyCode 229. */
+export function isImeCompositionKeyDown(event: ImeKeyboardEvent): boolean {
+  const nativeEvent = 'nativeEvent' in event ? event.nativeEvent : event
   return nativeEvent.isComposing || nativeEvent.keyCode === 229
 }


### PR DESCRIPTION
## Description

Supersedes #10711 while preserving the original contributor commit and attribution. Prevents the Enter key used by CJK IMEs to confirm a conversion candidate from submitting project-group, host, file, worktree-name, issue, and notes inputs.

## ELI5

When an IME turns typed phonetic text into a character, it first uses Enter to choose the character. Orca now waits for the next normal Enter before saving the form.

## Fix proof

- Added focused tests for `isComposing`, legacy `keyCode === 229`, and ordinary Enter in each affected surface.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/EditorPanelHeaderPath.ime-enter.test.tsx src/renderer/src/components/editor/UntitledFileRenameDialog.ime-enter.test.tsx src/renderer/src/components/sidebar/HostRenameDialog.ime-enter.test.tsx src/renderer/src/components/sidebar/ProjectGroupNameDialog.ime-enter.test.tsx src/renderer/src/components/sidebar/WorktreeMetaDialog.ime-enter.test.tsx` — 18 tests passed locally.

## No-regression proof / trade-offs

Plain Enter remains covered and submits normally. The existing Cmd/Ctrl-aware screen-submit shortcut remains after the shared IME guard; native CJK IME behavior still needs manual desktop verification on macOS, Linux, and Windows.

## Review

One independent native review loop: **clean**. It confirmed the guard precedes each explicit submit, the project-group form prevents implicit submit during composition, and no shortcut ordering conflict was found; reviewer target run reported 21/21 passing.

## Performance and compatibility

The guard is a constant-time keydown predicate with no polling, I/O, or allocation-heavy path. It uses browser keyboard event state only; there are no SSH, folder-workspace, Git provider, or path behavior changes.

## Evidence

No Electron screenshot was captured: the behavior is native IME interaction and the automated component tests are the available deterministic proof.

## Links

Supersedes and credits #10711 (@makoto-developer). Related category issue: #10711.

0 regressions / risk: **UNKNOWN** — targeted automated regressions are green, but native IME confirmation remains to be exercised on all desktop platforms.
