### PR TITLE
fix(sidebar): stop labeling split-pane agent rows with the focused pane's title

### DIFF
--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -307,7 +307,7 @@ export function buildDashboardSnapshot(
           rowConversationName(
             row,
             generatedTitlesEnabled,
-            state.terminalLayoutsByTabId?.[tabId]?.root?.type === 'split'
+            terminalLayoutsByTabId[tabId]?.root?.type === 'split'
           )
         ),
         ...(terminalInput ? { terminalInput } : {})

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -303,7 +303,13 @@ export function buildDashboardSnapshot(
         // board and the sidebar bold/mute the same agents at the same time.
         unseen,
         askSummary: bucket === 'attention' ? (row.entry.interactivePrompt ?? undefined) : undefined,
-        conversationName: boundedLabelOrUndefined(rowConversationName(row, generatedTitlesEnabled)),
+        conversationName: boundedLabelOrUndefined(
+          rowConversationName(
+            row,
+            generatedTitlesEnabled,
+            state.terminalLayoutsByTabId?.[tabId]?.root?.type === 'split'
+          )
+        ),
         ...(terminalInput ? { terminalInput } : {})
       })
     }

--- a/src/renderer/src/components/dashboard/dashboard-card-labels.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-labels.ts
@@ -28,7 +28,8 @@ export function boundedLabelOrUndefined(value: string | undefined): string | und
  *  same agent with the same name. */
 export function rowConversationName(
   row: DashboardAgentRow,
-  generatedTitlesEnabled: boolean
+  generatedTitlesEnabled: boolean,
+  tabHasSplitPanes: boolean
 ): string | undefined {
   const parentPaneKey = row.entry.orchestration?.parentPaneKey
   // Why: a child row rendered on its parent's tab does not own that tab's name.
@@ -40,11 +41,7 @@ export function rowConversationName(
     return undefined
   }
   return (
-    getAgentRowConversationName(
-      row.tab,
-      row.agentType,
-      generatedTitlesEnabled,
-      row.entry.terminalTitle
-    ) ?? undefined
+    getAgentRowConversationName(row.tab, row.agentType, generatedTitlesEnabled, tabHasSplitPanes) ??
+    undefined
   )
 }

--- a/src/renderer/src/components/dashboard/dashboard-card-labels.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-labels.ts
@@ -39,5 +39,12 @@ export function rowConversationName(
   ) {
     return undefined
   }
-  return getAgentRowConversationName(row.tab, row.agentType, generatedTitlesEnabled) ?? undefined
+  return (
+    getAgentRowConversationName(
+      row.tab,
+      row.agentType,
+      generatedTitlesEnabled,
+      row.entry.terminalTitle
+    ) ?? undefined
+  )
 }

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
@@ -4,9 +4,10 @@ import { useAgentRowConversationName } from './use-agent-row-conversation-name'
 import type { DashboardAgentRow } from './useDashboardData'
 
 const storeState = vi.hoisted(() => ({
-  current: { settings: {}, tabsByWorktree: {} } as {
+  current: { settings: {}, tabsByWorktree: {}, terminalLayoutsByTabId: {} } as {
     settings: Record<string, unknown>
     tabsByWorktree: Record<string, unknown[]>
+    terminalLayoutsByTabId: Record<string, unknown>
   }
 }))
 
@@ -30,7 +31,7 @@ function makeAgent(overrides: Partial<DashboardAgentRow> = {}): DashboardAgentRo
 }
 
 beforeEach(() => {
-  storeState.current = { settings: {}, tabsByWorktree: {} }
+  storeState.current = { settings: {}, tabsByWorktree: {}, terminalLayoutsByTabId: {} }
 })
 
 describe('useAgentRowConversationName', () => {
@@ -39,7 +40,11 @@ describe('useAgentRowConversationName', () => {
   })
 
   it('ignores a retired stored opt-out value', () => {
-    storeState.current = { settings: { agentRowsUseConversationName: false }, tabsByWorktree: {} }
+    storeState.current = {
+      settings: { agentRowsUseConversationName: false },
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
+    }
     expect(useAgentRowConversationName(makeAgent())).toBe('Patient sync spike')
   })
 
@@ -52,7 +57,7 @@ describe('useAgentRowConversationName', () => {
         }
       }
     )
-    storeState.current = { settings: {}, tabsByWorktree }
+    storeState.current = { settings: {}, tabsByWorktree, terminalLayoutsByTabId: {} }
     expect(useAgentRowConversationName(makeAgent({ rowSource: 'subagent' }))).toBeNull()
   })
 
@@ -65,7 +70,7 @@ describe('useAgentRowConversationName', () => {
         }
       }
     )
-    storeState.current = { settings: {}, tabsByWorktree }
+    storeState.current = { settings: {}, tabsByWorktree, terminalLayoutsByTabId: {} }
     expect(
       useAgentRowConversationName(
         makeAgent({
@@ -112,7 +117,8 @@ describe('useAgentRowConversationName', () => {
     )
     storeState.current = {
       settings: {},
-      tabsByWorktree: { 'wt-1': tabs }
+      tabsByWorktree: { 'wt-1': tabs },
+      terminalLayoutsByTabId: {}
     }
 
     expect(useAgentRowConversationName(makeAgent())).toBe('First name')
@@ -136,59 +142,61 @@ describe('useAgentRowConversationName', () => {
       // snapshot; a rename landing after that must still surface.
       tabsByWorktree: {
         'wt-1': [{ id: 'tab-1', worktreeId: 'wt-1', customTitle: 'Renamed later', title: '' }]
-      }
+      },
+      terminalLayoutsByTabId: {}
     }
     expect(useAgentRowConversationName(makeAgent())).toBe('Renamed later')
   })
 
-  it('names split-pane rows from their own pane title, not the focused tab title', () => {
+  it('gives split-pane rows no shared name, so each keeps its own per-pane label', () => {
+    const splitTab = { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Redis cache' }
     storeState.current = {
       settings: {},
-      // Why: tab.title only tracks the focused pane, so both rows would otherwise
-      // relabel to whichever split was clicked last.
-      tabsByWorktree: {
-        'wt-1': [{ id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Redis cache' }]
+      tabsByWorktree: { 'wt-1': [splitTab] },
+      // Why: a split root means tab.title is only the focused pane's title.
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf-1' },
+            second: { type: 'leaf', leafId: 'leaf-2' },
+            ratio: 0.5
+          }
+        }
       }
     }
-    const paneA = makeAgent({
-      tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Redis cache' },
-      entry: { prompt: 'p', terminalTitle: '✳ Linear work log' }
-    } as Partial<DashboardAgentRow>)
+    const paneA = makeAgent({ tab: splitTab } as Partial<DashboardAgentRow>)
     const paneB = makeAgent({
       paneKey: 'tab-1:leaf-2',
-      tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Redis cache' },
-      entry: { prompt: 'p', terminalTitle: '✳ Redis cache' }
+      tab: splitTab
     } as Partial<DashboardAgentRow>)
-    expect(useAgentRowConversationName(paneA)).toBe('Linear work log')
-    expect(useAgentRowConversationName(paneB)).toBe('Redis cache')
+    expect(useAgentRowConversationName(paneA)).toBeNull()
+    expect(useAgentRowConversationName(paneB)).toBeNull()
   })
 
-  it('yields no name until an agent sets a real title, so fresh rows keep their own prompt', () => {
-    // Why: before the first turn both panes carry the identity echo, which is
-    // rejected — rows fall back to their per-pane prompt and look correct. The
-    // shared-name symptom only appears once a real title reaches the tab.
+  it('keeps the live title on a single-pane tab', () => {
+    const tab = { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Redis cache' }
     storeState.current = {
       settings: {},
-      tabsByWorktree: {
-        'wt-1': [{ id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Claude Code' }]
-      }
+      tabsByWorktree: { 'wt-1': [tab] },
+      terminalLayoutsByTabId: { 'tab-1': { root: { type: 'leaf', leafId: 'leaf-1' } } }
     }
-    const freshPane = makeAgent({
-      tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Claude Code' },
-      entry: { prompt: 'p', terminalTitle: '✳ Claude Code' }
-    } as Partial<DashboardAgentRow>)
-    expect(useAgentRowConversationName(freshPane)).toBeNull()
+    expect(useAgentRowConversationName(makeAgent({ tab } as Partial<DashboardAgentRow>))).toBe(
+      'Redis cache'
+    )
   })
 
   it('honors the generated-titles setting for generated names', () => {
     const agent = makeAgent({
       tab: { customTitle: null, title: '', generatedTitle: 'Fix intake flow' }
     } as Partial<DashboardAgentRow>)
-    storeState.current = { settings: {}, tabsByWorktree: {} }
+    storeState.current = { settings: {}, tabsByWorktree: {}, terminalLayoutsByTabId: {} }
     expect(useAgentRowConversationName(agent)).toBeNull()
     storeState.current = {
       settings: { tabAutoGenerateTitle: true },
-      tabsByWorktree: {}
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {}
     }
     expect(useAgentRowConversationName(agent)).toBe('Fix intake flow')
   })

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
@@ -141,6 +141,28 @@ describe('useAgentRowConversationName', () => {
     expect(useAgentRowConversationName(makeAgent())).toBe('Renamed later')
   })
 
+  it('names split-pane rows from their own pane title, not the focused tab title', () => {
+    storeState.current = {
+      settings: {},
+      // Why: tab.title only tracks the focused pane, so both rows would otherwise
+      // relabel to whichever split was clicked last.
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Redis cache' }]
+      }
+    }
+    const paneA = makeAgent({
+      tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Redis cache' },
+      entry: { prompt: 'p', terminalTitle: '✳ Linear work log' }
+    } as Partial<DashboardAgentRow>)
+    const paneB = makeAgent({
+      paneKey: 'tab-1:leaf-2',
+      tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Redis cache' },
+      entry: { prompt: 'p', terminalTitle: '✳ Redis cache' }
+    } as Partial<DashboardAgentRow>)
+    expect(useAgentRowConversationName(paneA)).toBe('Linear work log')
+    expect(useAgentRowConversationName(paneB)).toBe('Redis cache')
+  })
+
   it('honors the generated-titles setting for generated names', () => {
     const agent = makeAgent({
       tab: { customTitle: null, title: '', generatedTitle: 'Fix intake flow' }

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
@@ -163,6 +163,23 @@ describe('useAgentRowConversationName', () => {
     expect(useAgentRowConversationName(paneB)).toBe('Redis cache')
   })
 
+  it('yields no name until an agent sets a real title, so fresh rows keep their own prompt', () => {
+    // Why: before the first turn both panes carry the identity echo, which is
+    // rejected — rows fall back to their per-pane prompt and look correct. The
+    // shared-name symptom only appears once a real title reaches the tab.
+    storeState.current = {
+      settings: {},
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Claude Code' }]
+      }
+    }
+    const freshPane = makeAgent({
+      tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: '✳ Claude Code' },
+      entry: { prompt: 'p', terminalTitle: '✳ Claude Code' }
+    } as Partial<DashboardAgentRow>)
+    expect(useAgentRowConversationName(freshPane)).toBeNull()
+  })
+
   it('honors the generated-titles setting for generated names', () => {
     const agent = makeAgent({
       tab: { customTitle: null, title: '', generatedTitle: 'Fix intake flow' }

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
@@ -44,5 +44,10 @@ export function useAgentRowConversationName(agent: DashboardAgentRow): string | 
     return null
   }
   // Why: retained row snapshots need a fallback after their live tab disappears.
-  return getAgentRowConversationName(liveTab ?? agent.tab, agent.agentType, generatedTitlesEnabled)
+  return getAgentRowConversationName(
+    liveTab ?? agent.tab,
+    agent.agentType,
+    generatedTitlesEnabled,
+    agent.entry.terminalTitle
+  )
 }

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
@@ -39,6 +39,12 @@ export function useAgentRowConversationName(agent: DashboardAgentRow): string | 
       ? undefined
       : getIndexedTab(s.tabsByWorktree[agent.tab.worktreeId], agent.tab.id)
   )
+  // Why: a split root means the tab holds more than one pane, so its live title
+  // belongs to whichever pane has focus. Selecting the boolean (not the layout)
+  // keeps this row subscribed to splits, not to every title frame.
+  const tabHasSplitPanes = useAppStore(
+    (s) => !cannotOwnTabName && s.terminalLayoutsByTabId[agent.tab.id]?.root?.type === 'split'
+  )
   // Why: synthetic and same-tab child rows do not own the parent tab's name.
   if (cannotOwnTabName) {
     return null
@@ -48,6 +54,6 @@ export function useAgentRowConversationName(agent: DashboardAgentRow): string | 
     liveTab ?? agent.tab,
     agent.agentType,
     generatedTitlesEnabled,
-    agent.entry.terminalTitle
+    tabHasSplitPanes
   )
 }

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -37,23 +37,41 @@ describe('getAgentRowConversationName', () => {
     expect(getAgentRowConversationName(tab, 'claude', false)).toBe('Investigate replay bug')
   })
 
-  it('prefers the row pane title over the focused-pane tab title', () => {
-    const tab = makeTab({ title: '✳ Redis cache strategy' })
-    expect(getAgentRowConversationName(tab, 'claude', false, '✳ Linear work log')).toBe(
-      'Linear work log'
-    )
-    // Empty/status-only pane titles fall back to the tab so single-pane rows are unchanged.
-    expect(getAgentRowConversationName(tab, 'claude', false, '  ')).toBe('Redis cache strategy')
-    expect(getAgentRowConversationName(tab, 'claude', false, undefined)).toBe(
-      'Redis cache strategy'
-    )
+  it('drops the live title in a split tab, where it names only the focused pane', () => {
+    const tab = makeTab({ title: '✳ Investigate replay bug' })
+    expect(getAgentRowConversationName(tab, 'claude', false)).toBe('Investigate replay bug')
+    expect(getAgentRowConversationName(tab, 'claude', false, true)).toBeNull()
+    // OpenCode semantic titles are live titles too, so they go with it.
+    const openCodeTab = makeTab({ title: 'OC | build the release pipeline' })
+    expect(getAgentRowConversationName(openCodeTab, 'opencode', false, true)).toBeNull()
   })
 
-  it('keeps tab-owned names ahead of the pane title', () => {
-    const tab = makeTab({ customTitle: 'Patient sync spike', title: '✳ Redis cache strategy' })
-    expect(getAgentRowConversationName(tab, 'claude', false, '✳ Linear work log')).toBe(
-      'Patient sync spike'
-    )
+  it('keeps tab-owned names in a split tab', () => {
+    // Why: the user gave these to the whole tab, so every pane in it may show them.
+    expect(
+      getAgentRowConversationName(
+        makeTab({ customTitle: 'Patient sync spike' }),
+        'claude',
+        false,
+        true
+      )
+    ).toBe('Patient sync spike')
+    expect(
+      getAgentRowConversationName(
+        makeTab({ quickCommandLabel: 'Run tests' }),
+        'claude',
+        false,
+        true
+      )
+    ).toBe('Run tests')
+    expect(
+      getAgentRowConversationName(
+        makeTab({ generatedTitle: 'Fix intake flow' }),
+        'claude',
+        true,
+        true
+      )
+    ).toBe('Fix intake flow')
   })
 
   it('strips leading status decoration from agent-set titles', () => {

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -37,6 +37,25 @@ describe('getAgentRowConversationName', () => {
     expect(getAgentRowConversationName(tab, 'claude', false)).toBe('Investigate replay bug')
   })
 
+  it('prefers the row pane title over the focused-pane tab title', () => {
+    const tab = makeTab({ title: '✳ Redis cache strategy' })
+    expect(getAgentRowConversationName(tab, 'claude', false, '✳ Linear work log')).toBe(
+      'Linear work log'
+    )
+    // Empty/status-only pane titles fall back to the tab so single-pane rows are unchanged.
+    expect(getAgentRowConversationName(tab, 'claude', false, '  ')).toBe('Redis cache strategy')
+    expect(getAgentRowConversationName(tab, 'claude', false, undefined)).toBe(
+      'Redis cache strategy'
+    )
+  })
+
+  it('keeps tab-owned names ahead of the pane title', () => {
+    const tab = makeTab({ customTitle: 'Patient sync spike', title: '✳ Redis cache strategy' })
+    expect(getAgentRowConversationName(tab, 'claude', false, '✳ Linear work log')).toBe(
+      'Patient sync spike'
+    )
+  })
+
   it('strips leading status decoration from agent-set titles', () => {
     expect(
       getAgentRowConversationName(makeTab({ title: '✳ Fix patient intake flow' }), 'claude', false)

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -124,11 +124,8 @@ export function getAgentRowConversationName(
   if (quickCommandLabel) {
     return quickCommandLabel
   }
-  // Why: `tab.title` carries only the focused pane's live title (pty-connection
-  // keeps it that way so split agents don't make the tab flicker). In a split
-  // tab it names one pane and mislabels its siblings, and it flips as focus
-  // moves — so drop it there and let each row keep its own per-pane label. The
-  // tab-owned names above stay: the user gave those to the whole tab.
+  // Why: pty-connection only propagates the focused pane's title to the tab
+  // (deliberately, to stop split agents flickering), so in a split it mislabels siblings.
   const liveTitle = tabHasSplitPanes ? '' : (tab.title?.trim() ?? '')
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -113,7 +113,8 @@ function conversationNameFromLiveTitle(
 export function getAgentRowConversationName(
   tab: ConversationNameTab,
   agentType: AgentType | null | undefined,
-  generatedTitlesEnabled: boolean
+  generatedTitlesEnabled: boolean,
+  paneTitle?: string | null
 ): string | null {
   const customTitle = tab.customTitle?.trim()
   if (customTitle) {
@@ -123,7 +124,10 @@ export function getAgentRowConversationName(
   if (quickCommandLabel) {
     return quickCommandLabel
   }
-  const liveTitle = tab.title?.trim() ?? ''
+  // Why: split panes share one tab, and `tab.title` deliberately tracks only the
+  // focused pane (pty-connection.ts) — without the row's own pane title every
+  // split row would show, and re-show on each click, the last-focused pane's name.
+  const liveTitle = paneTitle?.trim() || (tab.title?.trim() ?? '')
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
   }

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -114,7 +114,7 @@ export function getAgentRowConversationName(
   tab: ConversationNameTab,
   agentType: AgentType | null | undefined,
   generatedTitlesEnabled: boolean,
-  paneTitle?: string | null
+  tabHasSplitPanes = false
 ): string | null {
   const customTitle = tab.customTitle?.trim()
   if (customTitle) {
@@ -124,10 +124,12 @@ export function getAgentRowConversationName(
   if (quickCommandLabel) {
     return quickCommandLabel
   }
-  // Why: split panes share one tab, and `tab.title` deliberately tracks only the
-  // focused pane (pty-connection.ts) — without the row's own pane title every
-  // split row would show, and re-show on each click, the last-focused pane's name.
-  const liveTitle = paneTitle?.trim() || (tab.title?.trim() ?? '')
+  // Why: `tab.title` carries only the focused pane's live title (pty-connection
+  // keeps it that way so split agents don't make the tab flicker). In a split
+  // tab it names one pane and mislabels its siblings, and it flips as focus
+  // moves — so drop it there and let each row keep its own per-pane label. The
+  // tab-owned names above stay: the user gave those to the whole tab.
+  const liveTitle = tabHasSplitPanes ? '' : (tab.title?.trim() ?? '')
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
   }


### PR DESCRIPTION
Fixes #11069

## Summary

**AS-IS** — Sidebar and dashboard agent rows are rendered per pane, but they take their name from `tab.title`. That field carries only the **focused pane's** live title — `pty-connection.ts` keeps it that way on purpose, so two agents in splits don't make the tab title flicker, and `use-terminal-pane-lifecycle.ts` re-syncs it on every focus change. In a split tab that title names one pane and mislabels its siblings, so **every row in the tab showed the same name, and all of them changed when the user clicked another split**.

**TO-BE** — A tab with more than one pane no longer lends its live title to any row. Each row keeps its own per-pane label instead, so split rows stop reading as duplicates and stop flipping.

```
before:  click pane A → both rows "Linear work log"
         click pane B → both rows "Redis cache strategy"

after:   each row shows its own per-pane label; clicking a split changes nothing
```

Introduced by #9989, whose design note reads *"There is no additional preference: row identity consistently follows tab identity"*. Split panes are the case where one tab holds several independent sessions, and they were not considered.

### What changed

`getAgentRowConversationName` gains a `tabHasSplitPanes` flag that suppresses the live-title source:

```ts
const liveTitle = tabHasSplitPanes ? '' : (tab.title?.trim() ?? '')
```

That covers both live-title branches — the OpenCode semantic `OC | …` title and the general `conversationNameFromLiveTitle` path.

**Tab-owned names deliberately still apply to every row in the tab**: `customTitle`, `quickCommandLabel`, and `generatedTitle` are names the user (or Orca) gave the whole tab, not one pane, and none of them flip on focus. Only the live title is pane-specific by nature, and only it is dropped.

When a row has no conversation name it falls back to `getAgentRowPrimaryText(entry)` — the pane's own prompt, keyed by `paneKey`. That is the same per-pane labeling users already see before an agent's first turn, when the identity-echo title (`✳ Claude Code`) is rejected and no conversation name exists.

The split test is `layout.root.type === 'split'`, which is true exactly when the tab holds more than one leaf. The hook selects the **boolean**, not the layout, so a row re-renders on splits rather than on every title frame.

Both surfaces are updated — `use-agent-row-conversation-name.ts` (sidebar worktree-card rows and dashboard rows) and `build-dashboard-snapshot.ts` (the pop-out board, which mirrors the hook and had the same defect).

**Single-pane tabs — the case #9989 was written for — are untouched.**

### Side effects, both on the pop-out board

Every consumer of `conversationName` was traced. Four are pure display fallbacks or optional-field checks that behave identically; two are worth stating.

**1. The kanban card heading.** The card falls back differently from the sidebar row. The sidebar drops to the pane's own prompt; `AgentKanbanCard` uses `card.conversationName ?? card.worktreeName`, and `worktreeInFooter` is keyed off the same value. So for split panes the heading now reads the worktree name and the worktree leaves the footer.

That heading is still shared between the two cards — but it is now a **stable, true** shared value (they really are in one worktree) instead of one pane's title shown on both and flipping on focus. The per-pane distinction stays visible in the card body, which renders each pane's own `lastUserMessage` / `lastAgentMessage`. Verified deliberately rather than assumed, because the two surfaces do not share a fallback.

**2. Board search (#11042).** `conversationName` is one of the ten fields in `cardSearchText`, so it is a search key, not only a label. Today a split tab puts the focused pane's title into **both** cards' search text:

```
panes: A "Linear work log" | B "Redis cache strategy",  focus on A

before:  query "linear" → matches A and B     (B is a Redis pane; false positive)
         focus moves to B → query "linear" now matches nothing at all
after:   query "linear" → matches A only, via its own task / lastUserMessage
```

So the term this PR removes from the haystack is the *wrong* one, and the per-pane keys (`task`, `lastUserMessage`, `lastAgentMessage`) stay. Search stops depending on which split has focus. `cardSearchText` runs `.filter(Boolean)`, so an absent value is skipped rather than stringified.

### Known limits, deliberately not fixed here

- **Split rows show a label, not a title.** Orca has no per-pane live title the sidebar can read: the only live per-pane map (`runtimePaneTitlesByTabId`) is keyed by ephemeral numeric pane ids, while rows are keyed by `tabId:leafId`. Giving split rows real titles means adding a leaf-keyed live-title channel — worth doing, but it is infrastructure, not this bug fix. Showing this pane's prompt beats showing another pane's title.
- **Hook-less split agents** (title-derived rows) now fall back to their agent label rather than the focused pane's title. Both read as duplicates; neither is more wrong than the other. Same follow-up unblocks it.
- **User-assigned pane names** (`layout.titlesByLeafId`, set via the pane rename shortcut) are still not surfaced on agent rows. Same root cause as this bug, separate symptom; noted on #11069.
- **A `root: null` snapshot reverts to today's behavior.** `persistLayoutSnapshot` writes unconditionally, so a snapshot taken while the container is being torn down can store a null root. The split test then reads false and the rows fall back to the pre-fix shared title — a transient reversion to the status quo, never a new wrong name, so it is not worth a guard.

## Screenshots

No visual change — no layout, spacing, color, typography, or component change. The only difference is which text an already-existing row resolves, shown in the before/after above and pinned by the added tests.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — re-run after the rebase: 39,607 / 39,609 passing (3,747 of 3,748 files). The 2 failures are pre-existing and environmental — both in `src/relay/agent-exec-handler.test.ts`, which fails identically on a clean `main` checkout because an exported `GIT_ASKPASS` in the local shell flows through `process.env` into the credential guard's expected spawn env. Nothing in `src/relay` imports anything this PR touches. The suites that own every file this PR does touch (dashboard, dashboard-popout, sidebar, shared resolver) pass 1790/1790.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Added tests:

- `src/shared/agent-row-conversation-name.test.ts` — a split tab drops the live title (including the OpenCode semantic form) while the same tab keeps it when unsplit; `customTitle` / `quickCommandLabel` / `generatedTitle` still resolve in a split tab.
- `src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts` — two rows on one tab with a split layout root both resolve to `null` (each row then keeps its own label); the same tab with a leaf root still resolves the live title. The split test fails on `main`.

## AI Review Report

Reviewed with Claude Opus 5 in Claude Code, including an adversarial pass on an earlier version of this PR that the review **rejected** — that version routed rows through `entry.terminalTitle` on the assumption it was the pane's live OSC title. It is not: on the local path `entry.terminalTitle` resolves to `layout.titlesByLeafId[leafId] ?? tab.title`, where `titlesByLeafId` holds *user-assigned* pane names (`src/shared/types.ts`), so for an ordinary split it collapses to `tab.title` and the fix was a no-op. It was reverted in this branch rather than shipped. What follows is the review of the change that remains.

**Correctness**
- **Data source verified this time.** `layout.root.type === 'split'` is structural: the layout root is a split node exactly when the tab has ≥2 leaves. No heuristic, no ephemeral id, no cross-map lookup.
- **Fallback is genuinely per-pane** — traced `getCompactAgentPrimary` → `getAgentRowPrimaryText(agent.entry)` → `entry.prompt`, which is stored per `paneKey` in `agentStatusByPaneKey`.
- **Both callers covered** — grepped every caller of `getAgentRowConversationName`; exactly two production call sites exist and both pass the flag. `mobile/` does not use this resolver.
- **Rebased onto current `main`** — one conflict, one line: `main` had wrapped the same expression in `boundedLabelOrUndefined` (label bounding). Resolved by composing both rather than choosing, and the consumer sweep was re-run against the new base, which is where the board-search consumer above surfaced.
- **Precedence** — the flag feeds only the `liveTitle` local; the three tab-owned short-circuits sit upstream of it and are pinned by a test.
- **Default is safe** — the parameter defaults to `false`, so any future caller behaves as it does today.
- **Split collapse** — `removeLeafFromTree` promotes the surviving sibling, so closing one pane of a two-way split leaves a leaf root. No orphaned single-leaf split can strip a now-single-pane tab of its title.
- **Expanded pane (`Cmd+Shift+Enter`)** — the case most likely to silently undo this fix, and it does not: expand only sets `display: none` / `flex` inline styles, and `getLayoutChildNodes` filters by class rather than visibility, so the hidden sibling still serializes and the root stays `split`.
- **No tab-id divergence** — the snapshot builder looks the layout up by the routing pane key's tab while naming from `row.tab`. `activationPaneKey` is set only for subagent child rows, which the builder skips and the hook nulls out, so the two ids agree on every path that reaches the resolver.
- **Hook order** — all three `useAppStore` calls precede the `cannotOwnTabName` early return, so no hook is called conditionally.
- **Stale layouts** — if a split root ever outlived a closed pane, the row would drop its live title and show its own prompt. Degraded, never mislabeled.

**Cross-platform (macOS / Linux / Windows)** — explicitly checked. No shortcuts, accelerators, modifier keys, shortcut labels, path construction, shell invocation, or Electron platform APIs are touched; the change is a boolean and a string. The resolver's existing Windows and UNC path-rejection cases pass unchanged.

**SSH / remote / local** — no Git commands, no process or credential assumptions, no local-only paths. Identical for local, remote-server, and SSH worktrees, and for folder workspaces as well as git worktrees. Worth calling out: the earlier rejected approach behaved *differently* on local versus remote panes (main owns agent status locally, the renderer owns it for remote runtimes), which is what made it wrong. The layout root is the same on every host.

**Agent, integration, and git-provider compatibility** — provider-neutral. Claude, Codex, Gemini, Cursor, OpenCode and the rest all reach the same branch; OpenCode's semantic title is a live title and is suppressed with the others in a split tab, which is intentional and tested. No git-provider surface (GitHub, GitLab, others) is involved.

**Performance** — one added store selector per row returning a boolean primitive, so it cannot churn on identity and does not subscribe rows to title frames. The WeakMap-backed per-tab-array index from #9989 is untouched and its "one index build per immutable tab array" test still passes. The snapshot builder reuses the worktree-scoped layout map already in scope rather than re-reading the store.

**UI quality** — no token, primitive, or style change, so `docs/STYLEGUIDE.md` is not engaged and light/dark rendering is unaffected. Split rows go from "two identical names that swap on click" to two distinct per-pane labels. Under SSH latency the rows no longer depend on focus-driven title propagation at all.

**Security** — no security-relevant surface. No new string reaches the UI; one existing source is suppressed. No command execution, path handling, auth, secrets, IPC channel, dependency, persisted state, or schema change. No follow-up needed.

## Notes

- Fixes the reported symptom on every platform, for local and remote panes alike, and after an Orca restart (`tab.title` is persisted, so before this change both rows started out sharing whichever pane was focused at quit).
- No platform-specific, SSH-specific, agent-specific, integration-specific, or git-provider-specific behavior is introduced.
- Follow-ups are listed under "Known limits" above and on #11069; the leaf-keyed live-title channel is the one that unblocks the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
