### PR TITLE
fix(github): classify blocking check conclusions

### DIFF
--- a/src/shared/pr-check-status.test.ts
+++ b/src/shared/pr-check-status.test.ts
@@ -33,4 +33,8 @@ describe('provider-neutral check status', () => {
     expect(derivePRCheckStatusFromRollup([{ state: 'PENDING' }])).toBe('pending')
     expect(derivePRCheckStatusFromRollup([{ state: 'ERROR' }])).toBe('failure')
   })
+
+  it.each(['ERROR', 'STARTUP_FAILURE'])('treats raw %s conclusions as failures', (conclusion) => {
+    expect(derivePRCheckStatusFromRollup([{ status: 'COMPLETED', conclusion }])).toBe('failure')
+  })
 })

--- a/src/shared/pr-check-status.ts
+++ b/src/shared/pr-check-status.ts
@@ -42,8 +42,10 @@ function normalizeRollupCheck(raw: RawCheckRollup, index: number): PRCheckDetail
   const state = String(raw.state ?? '').toLowerCase()
   const conclusion = String(raw.conclusion ?? '').toLowerCase()
   const normalizedConclusion =
-    conclusion ||
-    (state === 'failure' || state === 'error' ? 'failure' : state === 'success' ? 'success' : '')
+    conclusion === 'error' || conclusion === 'startup_failure'
+      ? 'failure'
+      : conclusion ||
+        (state === 'failure' || state === 'error' ? 'failure' : state === 'success' ? 'success' : '')
   const isPending =
     status === 'queued' ||
     status === 'in_progress' ||


### PR DESCRIPTION
## Summary
Supersedes stale PR #4605: raw GraphQL `ERROR` and `STARTUP_FAILURE` check conclusions now produce a failing PR status in the provider-neutral classifier used by current `main`.

## ELI5
If GitHub says a check errored or could not start, Orca now shows it as failed instead of neutral/green.

## Fix proof
Shared classifier tests cover both raw conclusions and return `failure`.

## 0 regressions / risk
YES — two constant-time comparisons in existing rollup normalization only. No IPC, SSH, folder-workspace, provider-routing, path, Git command, or platform-specific behavior changed.

## Attribution
Co-authored-by: Mubashir Rahim <mubashirrahim3431@gmail.com>, original author of #4605.

## Tests
- `pnpm exec vitest run src/shared/pr-check-status.test.ts --reporter=dot` — 5 passed
- `pnpm typecheck` — passed
- `pnpm exec oxlint src/shared/pr-check-status.ts src/shared/pr-check-status.test.ts` — passed
- `git diff origin/main...HEAD --check` — passed

## Performance
Existing O(n) normalization gains two constant-time comparisons per check; no allocation, I/O, or network work was added.

## Linked issue(s)
None supplied; supersedes standalone bug PR #4605.

## Evidence
Data mapping only; no visual surface or screenshot applies.
