### PR TITLE
test(worktree): lock fail-closed invariant behind the #9197 selector_not_found swallow

### DIFF
--- a/src/main/runtime/worktree-teardown.test.ts
+++ b/src/main/runtime/worktree-teardown.test.ts
@@ -729,6 +729,31 @@ describe('killAllProcessesForWorktree', () => {
     expect(result.runtimeStopped).toBe(0)
   })
 
+  it('still fails a destructive delete closed when a provider PTY refuses to stop, even though the runtime selector cannot resolve (#9197)', async () => {
+    // Why: swallowing selector_not_found (the WSL \\wsl.localhost↔\\wsl$ alias miss)
+    // relaxes ONLY the renderer-graph sweep — "no graph terminals to stop". A real
+    // provider-visible PTY that cannot be physically stopped must still block
+    // filesystem removal. Locks the invariant the swallow depends on; complements
+    // the wedged-daemon-RPC fail-closed case (#9500), which this pairing doesn't cover.
+    const worktreeId = 'repo-1::\\\\wsl.localhost\\Ubuntu\\root\\orca\\workspaces\\wt'
+    const runtime = {
+      stopTerminalsForWorktree: vi.fn().mockRejectedValue(new Error('selector_not_found'))
+    } as unknown as Parameters<typeof killAllProcessesForWorktree>[1]['runtime']
+    const localProvider = createProviderStub(async () => [
+      { id: `${worktreeId}@@live-1`, cwd: '/wsl/wt', title: 'shell' }
+    ])
+    localProvider.shutdown = vi.fn().mockRejectedValue(new Error('daemon refused kill'))
+    listRegisteredPtysMock.mockReturnValue([])
+
+    await expect(
+      killAllProcessesForWorktree(worktreeId, {
+        runtime,
+        localProvider,
+        requirePhysicalStop: true
+      })
+    ).rejects.toThrow('Failed to physically stop every PTY')
+  })
+
   it('fails destructive teardown closed when the runtime sweep rejects', async () => {
     const stopTerminalsForWorktree = vi.fn().mockRejectedValue(new Error('runtime sweep failed'))
     const runtime = {


### PR DESCRIPTION
Follow-up to #9625 (which landed the `selector_not_found` swallow for WSL worktree deletion, superseding #9601).

#9625's test covers the happy path — a swallowed `selector_not_found` means "no graph terminals to stop", so a clean delete proceeds. This adds the **pairing invariant** that swallow quietly depends on: a provider-visible PTY that genuinely cannot be physically stopped must **still fail the destructive delete closed**, even when the runtime selector can't resolve.

The swallow relaxes only the renderer-graph sweep. If it ever leaked into the provider-visible fail-closed path, a wedged PTY on a WSL `\wsl.localhost`↔`\wsl$` alias miss would let filesystem removal proceed over a live process. This test locks that boundary.

- Complements the wedged-daemon-RPC fail-closed case (#9500), which this pairing doesn't cover.
- 27/27 in `worktree-teardown.test.ts` pass on current main.

Requested by @nwparker when closing #9601 as superseded — landing the salvageable regression test separately.