### PR TITLE
fix(codex): re-confirm spurious shell readings before skipping the restart card

### DIFF
--- a/src/renderer/src/lib/codex-session-restart-shell-flap.test.ts
+++ b/src/renderer/src/lib/codex-session-restart-shell-flap.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import {
+  markLiveCodexSessionsForRestart,
+  markRestoredStaleCodexSessionsForRestart
+} from './codex-session-restart'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '@/runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '@/runtime/runtime-rpc-client'
+
+const ACCOUNT_A = 'account-a@example.com'
+const ACCOUNT_B = 'account-b@example.com'
+
+/**
+ * The cached inspection can flap to the pane's shell for a live Codex session
+ * (#11064), and the switch path has no retry — one spurious reading silently
+ * loses the restart card forever. These pin the fresh-scan re-confirmation.
+ */
+describe('spurious shell readings on Codex-launched panes', () => {
+  const originalWindow = (globalThis as { window?: typeof window }).window
+  const runtimeEnvironmentCall = vi.fn()
+  const runtimeEnvironmentTransportCall = vi.fn()
+
+  function seedPane(args: { ptyId?: string; launchAgent?: 'codex' } = {}): void {
+    const ptyId = args.ptyId ?? 'pty-1'
+    useAppStore.setState({
+      settings: null as never,
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab-1',
+            ptyId,
+            worktreeId: 'wt1',
+            title: 'orca-1',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ...(args.launchAgent ? { launchAgent: args.launchAgent } : {})
+          }
+        ]
+      },
+      ptyIdsByTabId: { 'tab-1': [ptyId] },
+      pendingCodexPaneRestartIds: {},
+      codexRestartNoticeByPtyId: {}
+    })
+  }
+
+  beforeEach(() => {
+    clearRuntimeCompatibilityCacheForTests()
+    runtimeEnvironmentCall.mockReset()
+    runtimeEnvironmentTransportCall.mockReset()
+    runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+    })
+    seedPane({ launchAgent: 'codex' })
+    ;(globalThis as { window: typeof window }).window = {
+      ...originalWindow,
+      api: {
+        ...originalWindow?.api,
+        pty: {
+          ...originalWindow?.api?.pty,
+          inspectProcess: vi
+            .fn()
+            .mockResolvedValue({ foregroundProcess: 'zsh', hasChildProcesses: false }),
+          confirmForegroundProcess: vi.fn().mockResolvedValue(null)
+        },
+        codexAccounts: {
+          ...originalWindow?.api?.codexAccounts,
+          list: vi.fn().mockResolvedValue({
+            accounts: [
+              { id: 'account-a', email: ACCOUNT_A },
+              { id: 'account-b', email: ACCOUNT_B }
+            ],
+            activeAccountId: 'account-b'
+          }),
+          listStalePanes: vi.fn().mockResolvedValue([])
+        },
+        runtimeEnvironments: {
+          ...originalWindow?.api?.runtimeEnvironments,
+          call: runtimeEnvironmentTransportCall
+        }
+      }
+    } as unknown as typeof window
+  })
+
+  afterEach(() => {
+    useAppStore.setState({ settings: null as never })
+    if (originalWindow) {
+      ;(globalThis as { window: typeof window }).window = originalWindow
+    } else {
+      delete (globalThis as { window?: typeof window }).window
+    }
+  })
+
+  it('re-confirms with the fresh scan and cards the pane when codex still owns it', async () => {
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('codex-aarch64-ap')
+
+    await markLiveCodexSessionsForRestart({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+
+    expect(window.api.pty.confirmForegroundProcess).toHaveBeenCalledWith('pty-1')
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+  })
+
+  it('keeps the pane uncarded when the fresh scan confirms the shell (user exited Codex)', async () => {
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('zsh')
+
+    await markLiveCodexSessionsForRestart({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+  })
+
+  it('treats a rejected confirmation as no new evidence', async () => {
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockRejectedValue(new Error('daemon busy'))
+
+    await markLiveCodexSessionsForRestart({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+  })
+
+  it('survives a preload without confirmForegroundProcess', async () => {
+    ;(
+      window.api.pty as unknown as { confirmForegroundProcess?: unknown }
+    ).confirmForegroundProcess = undefined
+
+    await markLiveCodexSessionsForRestart({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+  })
+
+  it('never spends the fresh scan on a pane Orca did not launch Codex in', async () => {
+    seedPane()
+
+    await markLiveCodexSessionsForRestart({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+
+    expect(window.api.pty.confirmForegroundProcess).not.toHaveBeenCalled()
+    expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+  })
+
+  it('never spends the fresh scan when the cached reading already answers', async () => {
+    vi.mocked(window.api.pty.inspectProcess).mockResolvedValue({
+      foregroundProcess: 'codex',
+      hasChildProcesses: true
+    })
+
+    await markLiveCodexSessionsForRestart({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toBeDefined()
+    expect(window.api.pty.confirmForegroundProcess).not.toHaveBeenCalled()
+  })
+
+  it('never routes a remote runtime pane through the local confirm bridge', async () => {
+    seedPane({ ptyId: 'remote:term-1', launchAgent: 'codex' })
+    useAppStore.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: { process: { foregroundProcess: 'zsh', hasChildProcesses: false } },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+
+    await markLiveCodexSessionsForRestart({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+
+    // Why: a fresh local scan can know nothing about env-1's PTY, and a
+    // cross-lane answer must never card (or spare) a remote pane.
+    expect(window.api.pty.confirmForegroundProcess).not.toHaveBeenCalled()
+    expect(useAppStore.getState().codexRestartNoticeByPtyId).toEqual({})
+  })
+
+  it('heals a spurious shell reading before the restored-pane stale lookup', async () => {
+    vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('codex')
+    vi.mocked(window.api.codexAccounts.listStalePanes).mockResolvedValue([
+      { ptyId: 'pty-1', launchAccountId: 'account-a', activeAccountId: 'account-b' }
+    ])
+
+    await markRestoredStaleCodexSessionsForRestart()
+
+    expect(useAppStore.getState().codexRestartNoticeByPtyId['pty-1']).toEqual({
+      previousAccountLabel: ACCOUNT_A,
+      nextAccountLabel: ACCOUNT_B
+    })
+  })
+})

--- a/src/renderer/src/lib/codex-session-restart.test.ts
+++ b/src/renderer/src/lib/codex-session-restart.test.ts
@@ -48,6 +48,9 @@ describe('markLiveCodexSessionsForRestart', () => {
       return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
     })
     useAppStore.setState({
+      // Why: a prior test's remote-runtime selection must not silently move
+      // every later local pane out of the switch's lane.
+      settings: null as never,
       tabsByWorktree: {
         wt1: [
           {
@@ -78,7 +81,8 @@ describe('markLiveCodexSessionsForRestart', () => {
           ...originalWindow?.api?.pty,
           getForegroundProcess: vi.fn(),
           hasChildProcesses: vi.fn().mockResolvedValue(false),
-          inspectProcess: vi.fn()
+          inspectProcess: vi.fn(),
+          confirmForegroundProcess: vi.fn().mockResolvedValue(null)
         },
         codexAccounts: {
           ...originalWindow?.api?.codexAccounts,
@@ -760,7 +764,8 @@ describe('markRestoredStaleCodexSessionsForRestart', () => {
           hasChildProcesses: vi.fn().mockResolvedValue(false),
           inspectProcess: vi
             .fn()
-            .mockResolvedValue({ foregroundProcess: 'codex', hasChildProcesses: false })
+            .mockResolvedValue({ foregroundProcess: 'codex', hasChildProcesses: false }),
+          confirmForegroundProcess: vi.fn().mockResolvedValue(null)
         },
         codexAccounts: {
           ...originalWindow?.api?.codexAccounts,

--- a/src/renderer/src/lib/codex-session-restart.ts
+++ b/src/renderer/src/lib/codex-session-restart.ts
@@ -1,8 +1,16 @@
 import type { AppState } from '@/store'
 import { useAppStore } from '@/store'
-import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
+import {
+  confirmRuntimeTerminalForegroundProcess,
+  inspectRuntimeTerminalProcess,
+  type RuntimeTerminalProcessInspection
+} from '@/runtime/runtime-terminal-inspection'
 import { translate } from '@/i18n/i18n'
-import { isCodexRestartEligiblePane } from './codex-pane-restart-eligibility'
+import { isShellProcess } from '../../../shared/shell-process-detection'
+import {
+  isCodexForegroundProcess,
+  isCodexRestartEligiblePane
+} from './codex-pane-restart-eligibility'
 import {
   getCodexAccountSwitchLaneMatcher,
   isForeignMachineCodexPtyId,
@@ -10,6 +18,7 @@ import {
   resolveCodexPaneSelectionLane
 } from './codex-pane-selection-lane'
 import type { CodexAccountSelectionTarget } from '../../../shared/codex-selection-lane'
+import type { TuiAgent } from '../../../shared/types'
 
 // Why: prompt integrations such as Starship can outlast the daemon's 300ms
 // Codex fast-path timeout; account restarts must wait until the shell accepts input.
@@ -57,6 +66,36 @@ async function readRecordedCodexPaneLanes(
     return {}
   }
   return await listRecordedPaneLanes({ ptyIds: localPtyIds }).catch(() => ({}))
+}
+
+/**
+ * Re-checks a shell reading with a fresh, uncached scan before trusting it.
+ *
+ * Why: the cached foreground read can flap to the pane's shell for a live Codex
+ * session (#11064), and a spurious shell here silently skips the restart card —
+ * no error, no retry. Mirrors main's terminalHasShellForegroundProcess, which
+ * already refuses to conclude "agent done" from an unconfirmed shell reading.
+ * Gated to Orca-launched Codex panes so an account switch never spends the
+ * expensive fresh scan on ordinary shell terminals, and only an affirmative
+ * codex answer flips the decision: a confirmed shell (user exited Codex) and a
+ * null (scan failed or unsupported) both keep today's ineligible outcome.
+ */
+async function isConfirmedCodexForegroundDespiteShellReading(
+  state: AppState,
+  ptyId: string,
+  launchAgent: TuiAgent | undefined,
+  inspection: RuntimeTerminalProcessInspection
+): Promise<boolean> {
+  if (
+    launchAgent !== 'codex' ||
+    inspection.unavailable === true ||
+    inspection.foregroundProcess === null ||
+    !isShellProcess(inspection.foregroundProcess)
+  ) {
+    return false
+  }
+  const confirmed = await confirmRuntimeTerminalForegroundProcess(state.settings, ptyId)
+  return isCodexForegroundProcess(confirmed)
 }
 
 /**
@@ -114,11 +153,18 @@ async function scanCodexPanes(
         // Why: one stale remote pane must not hide restart notices for other confirmed Codex panes.
         () => null
       )
+      const eligible =
+        inspection !== null &&
+        (isCodexRestartEligiblePane({ inspection, launchAgent: tab.launchAgent }) ||
+          (await isConfirmedCodexForegroundDespiteShellReading(
+            state,
+            ptyId,
+            tab.launchAgent,
+            inspection
+          )))
       return {
         ptyId,
-        eligible:
-          inspection !== null &&
-          isCodexRestartEligiblePane({ inspection, launchAgent: tab.launchAgent }),
+        eligible,
         inconclusive: inspection === null || inspection.unavailable === true,
         launchedCodex: tab.launchAgent === 'codex',
         notified: false,

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -96,6 +96,32 @@ export async function inspectRuntimeTerminalProcess(
   }
 }
 
+/**
+ * Forces a fresh, uncached foreground scan for a pane whose cached inspection
+ * is suspect (issue #11064: the cached read can flap to the shell for a live
+ * agent). Local/daemon panes only — runtime environments expose no fresh-scan
+ * RPC, and an SSH provider without confirm support answers null, which callers
+ * must read as "no new evidence", never as a shell confirmation.
+ */
+export async function confirmRuntimeTerminalForegroundProcess(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  ptyId: string
+): Promise<string | null> {
+  const ownerEnvironmentId = getRemoteRuntimePtyEnvironmentId(ptyId)
+  const target = ownerEnvironmentId
+    ? ({ kind: 'environment', environmentId: ownerEnvironmentId } as const)
+    : getActiveRuntimeTarget(settings)
+  if (target.kind === 'environment' && getRemoteRuntimeTerminalHandle(ptyId)) {
+    return null
+  }
+  const confirmForegroundProcess = window.api.pty.confirmForegroundProcess
+  // Why the shape check: a preload older than this handler has no such method.
+  if (typeof confirmForegroundProcess !== 'function') {
+    return null
+  }
+  return confirmForegroundProcess(ptyId).catch(() => null)
+}
+
 export function sendRuntimePtyInput(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   ptyId: string,


### PR DESCRIPTION
Fixes #11064

A Codex account switch decides pane eligibility from a **single cached** `inspectProcess` read with no retry. When that read spuriously reports the pane's shell, the pane silently loses its restart card. This PR re-checks shell readings on Orca-launched Codex panes with the existing fresh-scan `confirmForegroundProcess` before trusting them.

## The measurement (done first, per the issue)

The issue flagged an unresolved contradiction: a ~1-in-5 read flake cannot produce a 4-in-6 switch miss rate. I instrumented before fixing. Everything below ran on the same macOS arm64 machine as the original QA.

**Harness runs (driving the real `createPtySubprocess` daemon code + a raw node-pty control):**

| Run | Conditions | Reads | Shell readings |
|---|---|---|---|
| v2 | native codex, login screen (temp CODEX_HOME), idle | 238 rapid + 238 raw + 30 slow + 15 cold | **0** |
| v3 | native codex, logged-in idle TUI (real CODEX_HOME) | 238 rapid + 30 slow + 15 cold | **0** |
| v3 | same, under 8-way CPU load | 20 slow + 20 raw + 4 cold | **0** |

(v1 is excluded as invalid: its startup command was never delivered, so the pane really was a bare shell — its 239/239 "zsh" readings were correct, not flake.)

**Production probe (read-only, replicating node-pty's exact mechanism):** node-pty's macOS `.process` is `p_comm` of `tcgetpgrp(fd)` — the foreground-pgroup *leader* — and **any lookup failure silently falls back to the shell's file name** (`pty_getproc` → NULL → `this._file`). I sampled leader liveness on every live codex tty on the machine (67 Orca-daemon panes + 11 others) every 300 ms for 3 minutes: **6786 probes, leader alive 100%, zero dead-leader windows.**

**Net: I could NOT reproduce the ~1-in-5 flake or the 4-in-6 miss under any at-rest condition, in 592 daemon reads + 6786 production probes.** The one QA condition I could not replicate is an *actively working* session (the QA pane's tree was native `codex → codex`, mid-task; reproducing that requires driving real agent turns). Flake candidates that remain require activity: transient foreground-pgroup churn during codex's own job/pty manipulation, which the `pty_getproc` fallback converts into exactly the observed `{foregroundProcess:"zsh", hasChildProcesses:false}` pair (the daemon derives `hasChildProcesses` from the same single read, which is why both fields flip together).

## Verdict on (a) worse/clustered vs (b) second mechanism vs (c) mis-measurement

**Primarily (a) as a structural asymmetry, with (c) unresolvable for the specific 4-in-6 figure.**

- **(a)** The two QA numbers measure different things and the gap has a mechanical explanation. The characterization loop (~1 s cadence) is protected by the daemon's 1 s foreground cache and its refresh machinery, so it *underestimates* the raw flake. An account switch performs one **cold** read on an at-rest pane: the cache (TTL 1 s) is expired, so a single bad underlying read is a guaranteed, unretried miss. Whatever the raw rate is during an active session, the switch path always eats it undiluted while the characterization loop mostly doesn't. The restore sweep even has a 5-rung retry ladder for exactly these readings (`codex-stale-pane-sweep.ts`) — the switch path was the only consumer with zero tolerance.
- **(b)** I audited the merged #10757 batch (#10770/#10802/#10803/#10804/#10853/#10870/#10992) for a second pane-dropping mechanism. The lane filter is deterministic given stable state (and its fallbacks are pinned by tests); the `previousActiveAccountId !== nextActiveAccountId` gate at both call sites would drop *all* panes, not one local pane 4-of-6 times. Nothing in the batch is implicated as an intermittent dropper; the pre-existing verdict from the issue stands. Caveat: that verdict rests on the original QA's n=6, which is thin.
- **(c)** The 4-in-6 figure itself may simply be overstated (n=6; with the cold-read asymmetry above, even a modest raw flake makes 4/6 unremarkable). I could not re-measure it without reproducing an active session.

**Honestly stated: this fix is validated as correct hardening of a read the codebase itself documents as untrustworthy — not against a reproduced 4-in-6 failure.**

## The fix

When the inspection reports a **shell** foreground for a pane whose `launchAgent === 'codex'`, re-confirm via the fresh, uncached scan (`window.api.pty.confirmForegroundProcess`, already plumbed end-to-end) before deciding the pane is ineligible. Mirrors `terminalHasShellForegroundProcess` (`orca-runtime.ts`), which already refuses to conclude "agent done" from an unconfirmed shell reading.

- **Only an affirmative codex answer flips the decision.** A confirmed shell (user exited Codex — the correct-ineligible case the issue insists must survive) stays uncarded; `null` (scan failed, SSH provider without confirm support, old preload, web client) keeps today's outcome.
- **Cost-gated:** never runs for non-Codex-launched panes, never when the cached reading already answers, and never for remote-runtime panes (no cross-lane RPC; a local fresh scan knows nothing about a remote PTY). It lives in `scanCodexPanes`, so it covers the switch path and the bounded restore-sweep ladder — the background pane poller (`pane-foreground-agent-tracker`) is a different code path and is untouched.

**Live validation of the confirm tool at the daemon level** (both launch shapes, real codex):

| State | Cached read | Fresh confirm |
|---|---|---|
| Live codex, native own-pgroup leader | `codex` 8/8 | `codex` **8/8** |
| Live codex behind the npm `node` shim leader | flaps `node`/`codex` | `codex` **8/8** |
| Codex exited, genuine shell at prompt | `zsh` | `zsh` **20/20** (true negative preserved) |

## Mutation proofs

Each mutation applied to production code, test run, then reverted:

| Mutation | Killed by |
|---|---|
| Neuter the whole retry (`if (true \|\| …) return false`) | `re-confirms with the fresh scan and cards the pane…` + `heals a spurious shell reading before the restored-pane stale lookup` |
| Remove the `launchAgent === 'codex'` cost gate | `never spends the fresh scan on a pane Orca did not launch Codex in` |
| Accept any non-null confirmation (`confirmed !== null`) | `keeps the pane uncarded when the fresh scan confirms the shell` |
| Remove the remote-runtime guard in `confirmRuntimeTerminalForegroundProcess` | `never routes a remote runtime pane through the local confirm bridge` |

Also fixed en passant: the first `markLiveCodexSessionsForRestart` describe leaked `settings.activeRuntimeEnvironmentId = 'env-1'` from its remote test into later tests (order-dependent lane filtering); `beforeEach` now resets `settings`.

## What I could NOT verify

- The original ~1-in-5 / 4-in-6 rates: not reproducible at rest; requires an actively-working codex session to re-measure, which means driving real agent turns. If someone hits the miss again post-merge, the confirm retry either rescues it (flake) or the pane genuinely wasn't running codex — the two now behave differently, which is itself diagnostic.
- Windows: the confirm path uses `forceProcessScan` + conpty console membership there, but I validated live on macOS only. The renderer change is platform-agnostic and affirmative-only, so a failed Windows scan degrades to today's behavior.
- Whether the QA pane's `codex → codex` tree (no `node` shim) launched via a PATH that bypasses the npm shim — not currently reproducible on this machine; all 78 live panes run behind the shim.

## Gates

- `tsc` ×3 (node / tc.web / tc.cli) clean after `rm -f config/*.tsbuildinfo`
- oxlint clean on changed files; max-lines ratchet OK (new tests extracted to `codex-session-restart-shell-flap.test.ts` instead of bumping the 800-line cap)
- 613 tests pass across the codex + runtime suites; formatted with oxfmt
