### PR TITLE
fix(markdown): prevent Mermaid token leaks and recover legacy ORCA transport markers

### DIFF
--- a/src/renderer/src/components/editor/MermaidBlock.transport-recovery.test.ts
+++ b/src/renderer/src/components/editor/MermaidBlock.transport-recovery.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { decodeLeakedRichMarkdownTransport } from './MermaidBlock'
+
+describe('decodeLeakedRichMarkdownTransport', () => {
+  it('decodes leaked ORCA rich markdown tokens', () => {
+    const input =
+      'A[[ORCA_RICH_MD:a7bc3000000000000000000000000000:inline-html:%3Cbr%2F%3E]]B[[ORCA_RICH_MD:08ebb000000000000000000000000000:inline-html:%3Cbr%3E]]C'
+
+    expect(decodeLeakedRichMarkdownTransport(input)).toBe('A<br/>B<br>C')
+  })
+
+  it('keeps malformed tokens unchanged', () => {
+    const input =
+      '[[ORCA_RICH_MD:a7bc3000000000000000000000000000:inline-html:%E0%A4%A]] and plain text'
+
+    expect(decodeLeakedRichMarkdownTransport(input)).toBe(input)
+  })
+
+  it('does not modify regular mermaid text', () => {
+    const input = 'graph TD\nA[Line 1<br/>Line 2] --> B'
+
+    expect(decodeLeakedRichMarkdownTransport(input)).toBe(input)
+  })
+})

--- a/src/renderer/src/components/editor/MermaidBlock.tsx
+++ b/src/renderer/src/components/editor/MermaidBlock.tsx
@@ -6,6 +6,19 @@ import { translate } from '@/i18n/i18n'
 
 type MermaidApi = typeof mermaidNamespace
 
+const LEAKED_RICH_MARKDOWN_TOKEN_PATTERN =
+  /\[\[ORCA_RICH_MD:[a-f0-9]{32}:(?:literal|inline-html|block-html|document-link|html-superscript-link):([^\]]+)\]\]/gi
+
+export function decodeLeakedRichMarkdownTransport(content: string): string {
+  return content.replace(LEAKED_RICH_MARKDOWN_TOKEN_PATTERN, (raw, encodedValue: string) => {
+    try {
+      return decodeURIComponent(encodedValue)
+    } catch {
+      return raw
+    }
+  })
+}
+
 // Why: mermaid is ~650KB and only needed when a diagram actually renders, yet a
 // static import drags it into the eager startup chunk (it is reachable from the
 // sidebar comment-markdown path). Load it on first render and cache the promise
@@ -58,6 +71,7 @@ export default function MermaidBlock({
 
   useEffect(() => {
     let cancelled = false
+    const normalizedContent = decodeLeakedRichMarkdownTransport(content)
 
     const render = async (): Promise<void> => {
       try {
@@ -71,7 +85,7 @@ export default function MermaidBlock({
         // and render(), which would make markdown preview fall back to the
         // broken foreignObject label path again.
         mermaid.initialize(getMermaidConfig(isDark, htmlLabels))
-        const { svg } = await mermaid.render(`mermaid-${id}`, content)
+        const { svg } = await mermaid.render(`mermaid-${id}`, normalizedContent)
         if (!cancelled && containerRef.current) {
           // Why: although mermaid uses DOMPurify internally, we add an explicit
           // sanitization pass as defense-in-depth against XSS in case upstream
@@ -106,7 +120,7 @@ export default function MermaidBlock({
           {translate('auto.components.editor.MermaidBlock.dcc132e691', 'Diagram error:')} {error}
         </div>
         <pre>
-          <code>{content}</code>
+          <code>{normalizedContent}</code>
         </pre>
       </div>
     )

--- a/src/renderer/src/components/editor/markdown-reference-link-normalization.test.ts
+++ b/src/renderer/src/components/editor/markdown-reference-link-normalization.test.ts
@@ -26,6 +26,34 @@ describe('normalizeMarkdownReferenceLinks', () => {
     expect(normalizeMarkdownReferenceLinks(markdown)).toBe(markdown)
   })
 
+  it('ignores definitions in container-prefixed fenced mermaid blocks', () => {
+    const markdown = [
+      '- ```mermaid',
+      '  graph TD',
+      '  A[Line 1<br/>Line 2] --> B',
+      '  [docs]: https://example.com/docs',
+      '  ```',
+      '',
+      '[Docs]'
+    ].join('\n')
+
+    expect(normalizeMarkdownReferenceLinks(markdown)).toBe(markdown)
+  })
+
+  it('ignores definitions in nested blockquote mermaid fences', () => {
+    const markdown = [
+      '>> ```mermaid',
+      '>> graph TD',
+      '>> A[Line 1<br/>Line 2] --> B',
+      '>> [docs]: https://example.com/docs',
+      '>> ```',
+      '',
+      '[Docs]'
+    ].join('\n')
+
+    expect(normalizeMarkdownReferenceLinks(markdown)).toBe(markdown)
+  })
+
   it('scans newline-heavy documents without splitting into line arrays', () => {
     const split = vi.spyOn(String.prototype, 'split')
     const body = Array.from({ length: 5000 }, (_, index) => `line ${index + 1}`).join('\n')

--- a/src/renderer/src/components/editor/markdown-reference-link-normalization.ts
+++ b/src/renderer/src/components/editor/markdown-reference-link-normalization.ts
@@ -7,6 +7,22 @@ type ReferenceLinkDefinition = {
 const REFERENCE_DEFINITION_PATTERN =
   /^ {0,3}\[([^\]]+)\]:[ \t]*(<[^>\n]+>|[^\s]+)(?:[ \t]+(?:"([^"]*)"|'([^']*)'|\(([^)]*)\)))?[ \t]*$/
 
+// Why: fenced blocks inside list/blockquote containers still block reference
+// normalization. Without container-aware fence detection, mermaid labels like
+// `<br/>` can be transformed unexpectedly.
+const FENCE_LINE_PATTERN = /^[ \t]*(?:(?:>[ \t]*)|(?:[-+*]|\d+[.)])[ \t]+)*(`{3,}|~{3,})/
+
+function matchMarkdownFence(line: string): { char: '`' | '~'; length: number } | null {
+  const match = line.match(FENCE_LINE_PATTERN)
+  if (!match) {
+    return null
+  }
+  return {
+    char: match[1][0] as '`' | '~',
+    length: match[1].length
+  }
+}
+
 function normalizeReferenceLabel(label: string): string {
   let normalized = ''
   let pendingWhitespace = false
@@ -70,10 +86,10 @@ function splitReferenceDefinitions(content: string): {
   let markdown = ''
 
   forEachReferenceDefinitionLine(content, (line, newline) => {
-    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/)
+    const fenceMatch = matchMarkdownFence(line)
     if (fenceMatch) {
-      const fenceChar = fenceMatch[1][0] as '`' | '~'
-      const fenceLength = fenceMatch[1].length
+      const fenceChar = fenceMatch.char
+      const fenceLength = fenceMatch.length
       if (activeFence === null) {
         activeFence = fenceChar
         activeFenceLength = fenceLength
@@ -155,10 +171,10 @@ function replaceReferenceLinks(
   while (index < markdown.length) {
     if (isLineStart) {
       const lineRest = markdown.slice(index)
-      const fenceMatch = lineRest.match(/^\s*(`{3,}|~{3,})/)
+      const fenceMatch = matchMarkdownFence(lineRest)
       if (fenceMatch) {
-        const fenceChar = fenceMatch[1][0] as '`' | '~'
-        const fenceLength = fenceMatch[1].length
+        const fenceChar = fenceMatch.char
+        const fenceLength = fenceMatch.length
         if (activeFence === null) {
           activeFence = fenceChar
           activeFenceLength = fenceLength

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -110,6 +110,50 @@ describe('rich markdown round trip', () => {
     expect(roundTripMarkdown('<!-- comment -->\n')).toBe('<!-- comment -->')
   })
 
+  it('preserves mermaid line breaks in list-prefixed fenced blocks', () => {
+    const input = ['- ```mermaid', '  graph TD', '  A[Line 1<br/>Line 2] --> B', '  ```', ''].join(
+      '\n'
+    )
+    const output = roundTripMarkdown(input)
+    expect(output).toContain('```mermaid')
+    expect(output).toContain('A[Line 1<br/>Line 2] --> B')
+    expect(output).not.toContain('&lt;br/&gt;')
+  })
+
+  it('preserves mermaid line breaks in blockquote-prefixed fenced blocks', () => {
+    const input = ['> ```mermaid', '> graph TD', '> A[Line 1<br/>Line 2] --> B', '> ```', ''].join(
+      '\n'
+    )
+    const output = roundTripMarkdown(input)
+    expect(output).toContain('```mermaid')
+    expect(output).toContain('A[Line 1<br/>Line 2] --> B')
+    expect(output).not.toContain('&lt;br/&gt;')
+  })
+
+  it('preserves bare br tags in mermaid fenced blocks', () => {
+    const input = ['```mermaid', 'graph TD', 'A[Line 1<br>Line 2] --> B', '```', ''].join('\n')
+    const output = roundTripMarkdown(input)
+    expect(output).toContain('```mermaid')
+    expect(output).toContain('A[Line 1<br>Line 2] --> B')
+    expect(output).not.toContain('[[ORCA_RICH_MD:')
+    expect(output).not.toContain('&lt;br&gt;')
+  })
+
+  it('preserves mermaid line breaks in nested blockquote fenced blocks', () => {
+    const input = [
+      '>> ```mermaid',
+      '>> graph TD',
+      '>> A[Line 1<br/>Line 2] --> B',
+      '>> ```',
+      ''
+    ].join('\n')
+    const output = roundTripMarkdown(input)
+    expect(output).toContain('```mermaid')
+    expect(output).toContain('A[Line 1<br/>Line 2] --> B')
+    expect(output).not.toContain('[[ORCA_RICH_MD:')
+    expect(output).not.toContain('&lt;br/&gt;')
+  })
+
   it('preserves editable details blocks', () => {
     expect(roundTripMarkdown('<details><summary>Toggle</summary><p>Body</p></details>\n')).toBe(
       '<details class="orca-details">\n<summary>Toggle</summary>\n\nBody\n\n</details>'

--- a/src/renderer/src/components/editor/raw-markdown-html.ts
+++ b/src/renderer/src/components/editor/raw-markdown-html.ts
@@ -12,6 +12,22 @@ import { matchHtmlSuperscriptLinkSource } from './rich-markdown-html-superscript
 
 const INLINE_HTML_PATTERN = /^<!--[\s\S]*?-->|^<\/?[A-Za-z][\w.:-]*(?:\s[^<>]*?)?\/?>/
 
+// Why: fenced code blocks can appear inside list/blockquote container prefixes
+// (e.g. `- ```mermaid` or `> ```mermaid`). Detecting those keeps mermaid
+// labels like `<br/>` literal inside the fence.
+const FENCE_LINE_PATTERN = /^[ \t]*(?:(?:>[ \t]*)|(?:[-+*]|\d+[.)])[ \t]+)*(`{3,}|~{3,})/
+
+function matchMarkdownFence(lineRest: string): { char: '`' | '~'; length: number } | null {
+  const fenceMatch = lineRest.match(FENCE_LINE_PATTERN)
+  if (!fenceMatch) {
+    return null
+  }
+  return {
+    char: fenceMatch[1][0] as '`' | '~',
+    length: fenceMatch[1].length
+  }
+}
+
 function matchInlineHtml(src: string): string | null {
   const match = src.match(INLINE_HTML_PATTERN)
   return match?.[0] ?? null
@@ -72,10 +88,10 @@ export function encodeRawMarkdownHtmlForRichEditor(
       // character (one throwaway string per char) is pure waste — compute it here. On a large
       // doc this drops O(n) suffix allocations from the rich-editor open path (#7056).
       const lineRest = normalizedContent.slice(index)
-      const fenceMatch = lineRest.match(/^\s*(`{3,}|~{3,})/)
+      const fenceMatch = matchMarkdownFence(lineRest)
       if (fenceMatch) {
-        const fenceChar = fenceMatch[1][0] as '`' | '~'
-        const fenceLength = fenceMatch[1].length
+        const fenceChar = fenceMatch.char
+        const fenceLength = fenceMatch.length
         if (activeFence === null) {
           activeFence = fenceChar
           activeFenceLength = fenceLength


### PR DESCRIPTION
## Summary
- prevent HTML replacement inside Mermaid fenced blocks even when fences are prefixed by markdown containers (list/blockquote prefixes)
- align reference-link normalization fence detection with the same container-aware rules
- add Mermaid render-time recovery for legacy leaked [[ORCA_RICH_MD:...]] tokens so previously polluted diagrams still render
- add regression tests for <br/> / <br> preservation and leaked-token recovery

## Scope guard
- includes only Mermaid/Markdown editor fix files
- intentionally excludes package/pnpm workspace dependency changes

## Validation
- pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MermaidBlock.transport-recovery.test.ts src/renderer/src/components/editor/markdown-reference-link-normalization.test.ts src/renderer/src/components/editor/markdown-round-trip.test.ts
- result: 3 files passed, 51 tests passed
