### PR TITLE
test(windows): skip POSIX exec-bit suites that can never pass on NTFS

### DIFF
--- a/src/main/cli/linux-bare-orca-dispatcher.test.ts
+++ b/src/main/cli/linux-bare-orca-dispatcher.test.ts
@@ -25,7 +25,8 @@ afterEach(async () => {
   await Promise.all(created.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
-describe('installLinuxBareOrcaDispatcher', () => {
+// Why: the dispatcher is only installed on Linux (index.ts), and NTFS has no POSIX exec bit, so the mode assertions can never hold on Windows.
+describe.skipIf(process.platform === 'win32')('installLinuxBareOrcaDispatcher', () => {
   it('writes an executable bare-orca dispatcher that execs the bundled orca-ide launcher', async () => {
     const { homePath, resourcesPath } = await makeFixture()
 

--- a/src/main/cli/linux-terminal-orca-cli-shim.test.ts
+++ b/src/main/cli/linux-terminal-orca-cli-shim.test.ts
@@ -26,7 +26,8 @@ afterEach(async () => {
   await Promise.all(created.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
-describe('ensureLinuxTerminalOrcaCliShimDir', () => {
+// Why: the shim is only installed on Linux (ipc/pty.ts), and NTFS has no POSIX exec bit, so the mode assertions can never hold on Windows.
+describe.skipIf(process.platform === 'win32')('ensureLinuxTerminalOrcaCliShimDir', () => {
   it('writes an executable bare-orca shim that execs the bundled orca-ide launcher', async () => {
     const { userDataPath, resourcesPath } = await makeFixture()
 

--- a/tests/e2e/helpers/nested-runtime-proxy-jump-fixture.unit.test.ts
+++ b/tests/e2e/helpers/nested-runtime-proxy-jump-fixture.unit.test.ts
@@ -5,7 +5,8 @@ import {
   type NestedRuntimeProxyJumpFixture
 } from './nested-runtime-proxy-jump-fixture'
 
-describe('nested runtime ProxyJump fixture', () => {
+// Why: the fixture writes a /bin/sh ssh wrapper and asserts its exec bit, neither of which exists on Windows.
+describe.skipIf(process.platform === 'win32')('nested runtime ProxyJump fixture', () => {
   let fixture: NestedRuntimeProxyJumpFixture | null = null
 
   afterEach(() => fixture?.dispose())


### PR DESCRIPTION
## Summary

No user-visible change. Three test suites assert the POSIX executable bit (`mode & 0o111`) on files they create. NTFS has no exec bit, so `chmod` is a no-op there and those assertions can never pass — 4 failures across 3 files on a clean Windows checkout of `main`.

All three cover code that only runs on Linux, so they are now gated with `describe.skipIf(process.platform === 'win32')`, the pattern this repo already uses in ~30 places (`src/cli/index.test.ts`, `src/relay/git-handler.test.ts`, `src/main/agent-hooks/*`).

- `ensureLinuxTerminalOrcaCliShimDir` is only called under `process.platform === 'linux'` — `src/main/ipc/pty.ts:1154`
- `installLinuxBareOrcaDispatcher` is only called under `process.platform === 'linux'` — `src/main/index.ts:2635`
- `nested-runtime-proxy-jump-fixture` writes a `#!/bin/sh` wrapper around `/usr/bin/ssh`

No coverage is lost: on Windows these suites were failing, not passing. On Linux and macOS `skipIf(false)` leaves them exactly as they were.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — every step passes except the last, `verify:skill-bundle-manifest` ("Generated skill artifacts are stale"). Pre-existing: stashing the three files and rerunning on a clean tree at the same commit fails identically, and CI is green on `ubuntu-latest`, so it appears Windows-specific and outside this change. Passing steps: `oxlint`, `lint:switch-exhaustiveness`, `check-styled-scrollbars`, `check:quadratic-buffer-concat`, `check:reliability-gates` (51 gates), `check:max-lines-ratchet` (no new bypasses), `verify:bundled-skill-guides`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — runs, but exits non-zero on this host because of pre-existing Windows failures unrelated to this PR.

  Scoped to the three suites this PR touches:

  | | result |
  |---|---|
  | before | 4 failed, 7 passed |
  | after | 11 skipped, 0 failed |

  Full suite, for context — `main` at the same commit already fails on Windows:

  | | failed | files |
  |---|---|---|
  | clean `main` | 142 | 48 |
  | this branch | 136 | 43 |

  Comparing the two failing-file sets: no file regressed, no shared file changed its failure count, and exactly five files left the set. Three are this PR's (4 failures). The other two are environment, not code — `windows-user-path-registry.test.ts` now loads its native registry addon because VS Build Tools were installed between the runs, and `wsl-login-shell-command.test.ts` is load-dependent (it shells out to a real WSL distro and passes under `--maxWorkers=1`).

- [x] `pnpm build`
- [x] No new tests: this changes only test gating, not behavior. The Linux and macOS paths are untouched, and CI's `verify` job (`ubuntu-latest`) exercises them unchanged.

Host: Windows 11 (26200), Node v24.11.1, commit `94009f6`.

## AI Review Report

Reviewed with Claude Code. Risks checked and findings:

- **Cross-platform** — the main risk. `describe.skipIf(process.platform === 'win32')` is `skipIf(false)` on darwin and linux, so both keep running the suites unchanged; only win32 is affected. The win32 side is verified locally (11 skipped, 0 failed); the unchanged path is left to CI, since this host is Windows-only. Each suite's subject was confirmed Linux-only by reading the production call sites above, so this does not hide a real Windows defect — the code under test never executes there. No shortcuts, labels, or Electron platform APIs are touched.
- **SSH / remote / local** — `nested-runtime-proxy-jump-fixture.unit.test.ts` is SSH-adjacent. The fixture builds a POSIX `ssh` wrapper for e2e specs, and those specs run on macOS and Linux, where this unit test still runs. No relay, provider, or remote code path changes.
- **Agents / integrations / git providers** — untouched.
- **Performance** — no runtime code changes. Marginally fewer tests execute on Windows.
- **UI** — no UI surface touched.
- **Security** — see below.

Considered and rejected: guarding only the individual `mode & 0o111` assertions instead of the whole suite. That keeps the surrounding assertions running on Windows, but it exercises Linux-only production code on a platform where it never runs, and the existing convention here is suite- or test-level `skipIf` rather than assertion-level branching.

## Security Audit

No input handling, command execution, authentication, secret, dependency, or IPC code is modified — the diff is three `describe(` call sites in test files plus three comments. Path handling is unchanged. The skipped suites do not gate any security-relevant assertion on Linux or macOS, where they continue to run. No new dependencies.

## Notes

- Windows-specific by construction; macOS and Linux behavior is unchanged.
- Context on why these went unnoticed: no CI job runs the full unit suite on Windows. `.github/workflows/pr.yml` pins the `verify` job to `ubuntu-latest`, and the Windows vitest lane in `computer-e2e.yml` runs a hand-listed file allowlist behind a computer-use path filter that these files are not in. I have a fuller picture of what a Windows run currently looks like on a dev host and am happy to open an issue with the breakdown if that would be useful.
- X handle: `gyujinkim00`
