### PR TITLE
test(agent-hooks): guard the Windows direct-spawn hook launcher contract

### DIFF
--- a/src/main/agent-hooks/windows-direct-spawn-launcher.test.ts
+++ b/src/main/agent-hooks/windows-direct-spawn-launcher.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import type * as Os from 'node:os'
+import { join } from 'node:path'
+import type * as InstallerUtils from './installer-utils'
+
+const { getPathMock, homedirMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn<(name: string) => string>(),
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({ app: { getPath: getPathMock } }))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof Os>()
+  return { ...actual, homedir: homedirMock }
+})
+
+// Why: stubbing only the path source keeps the real wrappers in play (so a wrapper swap still
+// shows up) and pins a Windows path, letting this assert win32 behavior on ubuntu CI.
+const WINDOWS_HOOK_DIR = 'C:\\Users\\alice\\.orca\\agent-hooks'
+
+vi.mock('./installer-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof InstallerUtils>()
+  return {
+    ...actual,
+    getSharedManagedScriptPath: (scriptFileName: string) =>
+      `${WINDOWS_HOOK_DIR}\\${scriptFileName}`,
+    writeManagedScript: vi.fn()
+  }
+})
+
+import { AntigravityHookService } from '../antigravity/hook-service'
+import { cursorHookService } from '../cursor/hook-service'
+import { getCodexManagedHookInstallMaterial } from '../codex/hook-service'
+import { getDevinManagedCommand, getDevinManagedScriptPath } from '../devin/hook-settings'
+
+const BARE_WINDOWS_CMD_LAUNCHER = /^C:\\Users\\alice\\\.orca\\agent-hooks\\[A-Za-z0-9._-]+\.cmd$/
+const ENCODED_POWERSHELL_LAUNCHER =
+  /powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand \S+$/
+
+function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return run()
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  }
+}
+
+// Why: these agents hand the command to CreateProcess as argv[0], not to cmd.exe, so anything
+// but a single token naming a real .cmd is unspawnable and exits every hook 1 (#8430).
+function expectDirectlySpawnable(command: string, label: string): void {
+  expect(command, `${label}: launcher must be the bare managed .cmd path`).toMatch(
+    BARE_WINDOWS_CMD_LAUNCHER
+  )
+  expect(command.split(' '), `${label}: launcher must be a single argv[0] token`).toHaveLength(1)
+  expect(command, `${label}: launcher must not be a shell launcher`).not.toMatch(/powershell/i)
+}
+
+function readCursorCommand(homeDir: string): string {
+  const config = JSON.parse(readFileSync(join(homeDir, '.cursor', 'hooks.json'), 'utf8')) as {
+    hooks: Record<string, { command?: string }[]>
+  }
+  return config.hooks.stop?.[0]?.command ?? ''
+}
+
+function readAntigravityCommands(homeDir: string): string[] {
+  const config = JSON.parse(
+    readFileSync(join(homeDir, '.gemini', 'config', 'hooks.json'), 'utf8')
+  ) as {
+    'orca-status': Record<string, { command?: string; hooks?: { command?: string }[] }[]>
+  }
+  return Object.values(config['orca-status']).flatMap((definitions) =>
+    definitions.map((definition) => definition.command ?? definition.hooks?.[0]?.command ?? '')
+  )
+}
+
+describe('Windows direct-spawn hook launcher contract', () => {
+  let homeDir: string
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), 'orca-direct-spawn-home-'))
+    homedirMock.mockReturnValue(homeDir)
+    getPathMock.mockReturnValue(homeDir)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    rmSync(homeDir, { recursive: true, force: true })
+  })
+
+  it('keeps the Codex managed command directly spawnable', () => {
+    const { command } = withPlatform('win32', () => getCodexManagedHookInstallMaterial())
+    expectDirectlySpawnable(command, 'codex')
+  })
+
+  it('keeps the Devin managed command directly spawnable', () => {
+    const command = withPlatform('win32', () => getDevinManagedCommand(getDevinManagedScriptPath()))
+    expectDirectlySpawnable(command, 'devin')
+  })
+
+  it('keeps every Antigravity managed command directly spawnable', () => {
+    withPlatform('win32', () => new AntigravityHookService().install())
+    const commands = readAntigravityCommands(homeDir)
+    expect(commands.length).toBeGreaterThan(0)
+    for (const command of commands) {
+      expectDirectlySpawnable(command, 'antigravity')
+    }
+  })
+
+  // Why: pins the split — Cursor's runner goes through a shell, so it must keep the encoded
+  // launcher. Without this, "make every agent spawnable" would look like a valid refactor.
+  it('keeps a shell-launched agent on the encoded PowerShell launcher', () => {
+    withPlatform('win32', () => cursorHookService.install())
+    const command = readCursorCommand(homeDir)
+    expect(command).toMatch(ENCODED_POWERSHELL_LAUNCHER)
+    expect(command).not.toMatch(BARE_WINDOWS_CMD_LAUNCHER)
+  })
+})


### PR DESCRIPTION
## Summary

Locks the invariant behind #8430/#8737: **Codex, Antigravity and Devin hand the managed hook `command` to CreateProcess as `argv[0]`** — not to `cmd.exe` — so it must stay a single spawnable token naming a real `.cmd`. Anything else is unspawnable and fails every lifecycle hook with `exit 1`.

Test-only. No production code changes.

## The gap

Nothing currently guards *which wrapper each service picks*:

- `installer-utils.test.ts` tests `wrapWindowsCmdHookCommand` **directly**, so it stays green no matter which wrapper a service calls.
- The Codex-side check that would catch it is `it.skipIf(process.platform !== 'win32')`, and `pr.yml` runs unit tests on `ubuntu-latest` only — so **it never executes in PR CI**.

Net effect: a service switching from `wrapWindowsCmdHookCommand` to `wrapWindowsHookCommand` reintroduces #8430 with fully green CI.

This surfaced while evaluating #8665, which proposed exactly that swap for Codex to fix #8645. #8645 was already fixed by #8737 via the bare-path form (user-confirmed on Orca 1.4.141), so that swap would have been a pure regression.

## Approach

Rather than skipping on non-Windows, this mocks the **managed script path** (and the disk write) while leaving the **real wrappers** in play. The platform-sensitive input is the only thing stubbed, so the win32 launcher contract is asserted deterministically on Linux CI.

Per agent, the command is taken from the narrowest available seam — `getCodexManagedHookInstallMaterial()`, `getDevinManagedCommand()`, and Antigravity's installed `hooks.json`.

Each direct-spawn agent asserts the command is the bare managed `.cmd` path, is a single `argv[0]` token, and is not a shell launcher. A shell-launched control (Cursor) asserts the complement, so the split is pinned in both directions and "make every agent spawnable" can't pass as a valid refactor.

## Verification

Each assertion was proven non-vacuous by swapping wrappers locally (reverted, not committed):

| Change simulated | Result |
| --- | --- |
| Codex → `wrapWindowsHookCommand` (the #8665 change) | FAILS |
| Antigravity → `wrapWindowsHookCommand` | FAILS |
| Devin → `wrapWindowsHookCommand` | FAILS |
| Cursor → `wrapWindowsCmdHookCommand` (reverse) | FAILS |
| unmodified `main` | 4 passed |

Also confirmed empirically on Windows via `System.Diagnostics.Process` with `UseShellExecute=false` (CreateProcess, no shell): the bare `.cmd` path spawns and exits 0, while the encoded PowerShell launcher fails to spawn with "The system cannot find the file specified". Note that a Node-based `spawnSync` check is misleading here — Node refuses `.cmd` with `shell:false` since the CVE-2024-24576 guard, so it errors for *both* forms.

- `pnpm typecheck` — clean
- `oxlint` on the new file — clean
- `npx vitest run src/main/agent-hooks/windows-direct-spawn-launcher.test.ts` — 4 passed
- Affected suites (`agent-hooks/`, codex, antigravity, devin, cursor): 5 failures, all **pre-existing** — an identical control run on unmodified `origin/main` with this file removed produced the same 5 (Windows-local symlink-permission and POSIX-script assertions; they pass on Linux CI).

Linux execution is confirmed by this PR's own CI rather than assumed: shard `tests 4/16` (ubuntu) logs `✓ src/main/agent-hooks/windows-direct-spawn-launcher.test.ts (4 tests)`, so all four assertions really execute instead of skipping.

## Notes

Issue #8645 is still open even though #8737 fixed it and a user confirmed the fix on 1.4.141 — worth closing separately.
