### PR TITLE
fix(pdf): update match counter during navigation

### DIFF
--- a/src/renderer/src/components/editor/PdfFind.test.tsx
+++ b/src/renderer/src/components/editor/PdfFind.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import type { EventBus } from 'pdfjs-dist/web/pdf_viewer.mjs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import PdfFind from './PdfFind'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (
+    _key: string,
+    fallback: string,
+    values?: { value0?: number; value1?: number }
+  ): string =>
+    fallback
+      .replace('{{value0}}', String(values?.value0 ?? ''))
+      .replace('{{value1}}', String(values?.value1 ?? ''))
+}))
+
+afterEach(cleanup)
+
+type FindListener = (event: { matchesCount: { current: number; total: number } }) => void
+
+class FindEventBus {
+  private readonly listeners = new Map<string, Set<FindListener>>()
+
+  on(name: string, listener: FindListener): void {
+    const listeners = this.listeners.get(name) ?? new Set<FindListener>()
+    listeners.add(listener)
+    this.listeners.set(name, listeners)
+  }
+
+  off(name: string, listener: FindListener): void {
+    this.listeners.get(name)?.delete(listener)
+  }
+
+  dispatch(name: string, current: number, total: number): void {
+    for (const listener of this.listeners.get(name) ?? []) {
+      listener({ matchesCount: { current, total } })
+    }
+  }
+}
+
+describe('PdfFind match counter', () => {
+  it('tracks the selected match while navigating results', async () => {
+    const eventBus = new FindEventBus()
+    const view = render(
+      <PdfFind
+        isOpen
+        onClose={vi.fn()}
+        eventBusRef={{ current: eventBus as unknown as InstanceType<typeof EventBus> }}
+      />
+    )
+    fireEvent.change(view.getByPlaceholderText('Find in page...'), {
+      target: { value: 'needle' }
+    })
+
+    eventBus.dispatch('updatefindmatchescount', 1, 3)
+    await waitFor(() => expect(view.getByText('1 of 3')).toBeTruthy())
+
+    eventBus.dispatch('updatefindcontrolstate', 2, 3)
+    await waitFor(() => expect(view.getByText('2 of 3')).toBeTruthy())
+  })
+})

--- a/src/renderer/src/components/editor/PdfFind.tsx
+++ b/src/renderer/src/components/editor/PdfFind.tsx
@@ -79,15 +79,17 @@ export default function PdfFind({
     if (!eventBus || !isOpen) {
       return
     }
-    const handleMatchesCount = (evt: {
+    const updateMatchesCount = (evt: {
       matchesCount: { current: number; total: number }
     }): void => {
       setActiveMatch(evt.matchesCount.current)
       setTotalMatches(evt.matchesCount.total)
     }
-    eventBus.on('updatefindmatchescount', handleMatchesCount)
+    eventBus.on('updatefindmatchescount', updateMatchesCount)
+    eventBus.on('updatefindcontrolstate', updateMatchesCount)
     return () => {
-      eventBus.off('updatefindmatchescount', handleMatchesCount)
+      eventBus.off('updatefindmatchescount', updateMatchesCount)
+      eventBus.off('updatefindcontrolstate', updateMatchesCount)
     }
   }, [eventBusRef, isOpen])
 


### PR DESCRIPTION
Closes #11049

## Summary

Keep the in-PDF search counter synchronized with the highlighted result while users navigate with the arrow buttons or Enter/Shift+Enter.

pdf.js publishes initial/progressive totals through `updatefindmatchescount`, but publishes navigation state (including the current match) through `updatefindcontrolstate`. `PdfFind` now consumes both events with one listener and unregisters both on cleanup.

Upstream contract checked against pdf.js 5.7.284:
https://github.com/mozilla/pdf.js/blob/v5.7.284/web/app.js

## Screenshots

No visual layout change. The reporter's recording in #11049 shows the before state; the regression test verifies the counter changes from `1 of 3` to `2 of 3` on the navigation event.

## Testing

- [ ] `pnpm lint` (full repository)
- [ ] `pnpm typecheck` (full repository)
- [ ] `pnpm test` (full repository)
- [ ] `pnpm build` (full repository)
- [x] Added a high-quality regression test
- [x] `vitest run src/renderer/src/components/editor/PdfFind.test.tsx --config config/vitest.config.ts` — 1 passed
- [x] Targeted `oxfmt --check`
- [x] Targeted `oxlint`
- [x] `git diff --check`

The full lanes were left to draft CI. This sparse checkout's dependency install fetched the test toolchain but its native `cpu-features` build could not detect a Windows compiler, and the sparse tree omitted the repository postinstall script.

## AI Review Report

AI-assisted with OpenAI Codex. Review traced the event contract in the exact locked pdf.js version and checked subscription cleanup, performance, and compatibility. The change is renderer-only and event-driven: no keyboard labels, paths, shell behavior, Electron platform branch, agent integration, git provider, or local/SSH transport behavior changes. It is platform-neutral on macOS, Linux, and Windows.

## Security Audit

No command execution, IPC, filesystem paths, authentication, secrets, dependencies, or new input parsing are introduced. The additional event consumes the same numeric `matchesCount` shape already handled by the component and is removed during effect cleanup.

## Notes

- X handle: not provided.
- AI assistance disclosed; I reviewed the implementation and test.
