### PR TITLE
Make cross-machine pairing recoverable when the host advertises loopback

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -68,6 +68,7 @@
     "../src/main/kimi/kimi-hook-config-toml.ts",
     "../src/main/openclaude/hook-service.ts",
     "../src/main/rolling-file-backup.ts",
+    "../src/main/runtime/pairing-endpoint.ts",
     "../src/main/runtime/runtime-metadata.ts",
     "../src/main/win32-utils.ts"
   ],

--- a/src/cli/handlers/environment.ts
+++ b/src/cli/handlers/environment.ts
@@ -17,10 +17,12 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
   'environment add': async ({ flags, json }) => {
     const name = getRequiredStringFlag(flags, 'name')
     const pairingCode = getRequiredStringFlag(flags, 'pairing-code')
+    const endpointAddress = getOptionalStringFlag(flags, 'endpoint')
     const environment = redactRuntimeEnvironment(
       addEnvironmentFromPairingCode(getDefaultUserDataPath(), {
         name,
-        pairingCode
+        pairingCode,
+        ...(endpointAddress ? { endpointAddress } : {})
       })
     )
     printResult(
@@ -53,6 +55,17 @@ export const ENVIRONMENT_HANDLERS: Record<string, CommandHandler> = {
         `Removed environment ${result.removed.name} (${result.removed.id}).`
     )
   }
+}
+
+function getOptionalStringFlag(flags: Map<string, string | boolean>, name: string): string | null {
+  const value = flags.get(name)
+  if (value === undefined) {
+    return null
+  }
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new RuntimeClientError('invalid_argument', `--${name} requires a value`)
+  }
+  return value
 }
 
 function getRequiredStringFlag(flags: Map<string, string | boolean>, name: string): string {

--- a/src/cli/handlers/environment.ts
+++ b/src/cli/handlers/environment.ts
@@ -62,7 +62,7 @@ function getOptionalStringFlag(flags: Map<string, string | boolean>, name: strin
   if (value === undefined) {
     return null
   }
-  if (typeof value !== 'string' || value.length === 0) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
     throw new RuntimeClientError('invalid_argument', `--${name} requires a value`)
   }
   return value

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -212,7 +212,7 @@ Common Commands:
   orca status [--json]
   orca diagnostics memory [--json]
   orca agent-context [--json]
-  orca environment add --name <name> --pairing-code <code> [--json]
+  orca environment add --name <name> --pairing-code <code> [--endpoint <host>] [--json]
   orca environment list [--json]
   orca environment show --environment <selector> [--json]
   orca environment rm --environment <selector> [--json]
@@ -505,6 +505,8 @@ export function formatFlagHelp(flag: string): string {
     'display-name': '--display-name <name>  Override the Orca display name',
     'element-index': '--element-index <n>   Element index from get-app-state',
     title: '--title <text>         Custom title for the terminal tab (omit to reset)',
+    endpoint:
+      '--endpoint <host>      Reachable host, host:port, or ws(s):// URL replacing the address advertised by the pairing code',
     enter: '--enter                Append Enter after sending text',
     force: '--force                Force worktree removal when supported',
     focus: '--focus                Reveal the created terminal session in Orca',

--- a/src/cli/runtime/environments.test.ts
+++ b/src/cli/runtime/environments.test.ts
@@ -117,6 +117,16 @@ describe('CLI runtime environments', () => {
       expect(() => addWithEndpoint('0.0.0.0')).toThrow(/Invalid --endpoint "0\.0\.0\.0"/)
     })
 
+    // Why: the endpoint resolver reads a blank advertised address as "none given"
+    // and falls back to loopback, so a blank override would quietly do the exact
+    // damage this flag exists to undo.
+    it.each(['', ' ', '\t'])(
+      'rejects a blank override rather than falling back to loopback',
+      (blank) => {
+        expect(() => addWithEndpoint(blank, 'ws://10.0.0.5:6768')).toThrow(/Invalid --endpoint/)
+      }
+    )
+
     it('leaves the advertised endpoint alone when omitted', () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-env-store-'))
       addEnvironmentFromPairingCode(userDataPath, {

--- a/src/cli/runtime/environments.test.ts
+++ b/src/cli/runtime/environments.test.ts
@@ -81,4 +81,52 @@ describe('CLI runtime environments', () => {
     )
     expect(listEnvironments(userDataPath)[0]?.id).toBe(first.id)
   })
+
+  describe('endpointAddress override', () => {
+    function addWithEndpoint(endpointAddress: string, offerEndpoint = 'ws://127.0.0.1:6768') {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-env-store-'))
+      addEnvironmentFromPairingCode(userDataPath, {
+        name: 'workstation',
+        pairingCode: pairingCode(offerEndpoint),
+        endpointAddress,
+        now: 100
+      })
+      return resolveEnvironmentPairingOffer(userDataPath, 'workstation')
+    }
+
+    it('keeps the port from the pairing code for a bare host', () => {
+      expect(addWithEndpoint('100.64.0.2').endpoint).toBe('ws://100.64.0.2:6768')
+    })
+
+    it('accepts host:port and full ws(s):// forms', () => {
+      expect(addWithEndpoint('desktop.tailnet.ts.net:7000').endpoint).toBe(
+        'ws://desktop.tailnet.ts.net:7000'
+      )
+      expect(addWithEndpoint('wss://desktop.example.com/runtime').endpoint).toBe(
+        'wss://desktop.example.com/runtime'
+      )
+    })
+
+    it('preserves the credentials the host issued', () => {
+      const offer = addWithEndpoint('100.64.0.2')
+      expect(offer.deviceToken).toBe('device-token')
+      expect(offer.publicKeyB64).toBe(Buffer.from(new Uint8Array(32).fill(1)).toString('base64'))
+    })
+
+    it('rejects an unreachable wildcard bind address', () => {
+      expect(() => addWithEndpoint('0.0.0.0')).toThrow(/Invalid --endpoint "0\.0\.0\.0"/)
+    })
+
+    it('leaves the advertised endpoint alone when omitted', () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-env-store-'))
+      addEnvironmentFromPairingCode(userDataPath, {
+        name: 'workstation',
+        pairingCode: pairingCode('ws://10.0.0.5:6768'),
+        now: 100
+      })
+      expect(resolveEnvironmentPairingOffer(userDataPath, 'workstation').endpoint).toBe(
+        'ws://10.0.0.5:6768'
+      )
+    })
+  })
 })

--- a/src/cli/runtime/environments.ts
+++ b/src/cli/runtime/environments.ts
@@ -14,7 +14,10 @@ import type {
   PublicKnownRuntimeEnvironment
 } from '../../shared/runtime-environments'
 import { parsePairingCode, type PairingOffer } from '../../shared/pairing'
-import { resolveAdvertisedPairingEndpoint } from '../../main/runtime/pairing-endpoint'
+import {
+  INVALID_PAIRING_ENDPOINT_GUIDANCE,
+  resolveAdvertisedPairingEndpoint
+} from '../../main/runtime/pairing-endpoint'
 import { RuntimeClientError } from './types'
 
 export type EnvironmentAddResult = {
@@ -36,9 +39,12 @@ export function addEnvironmentFromPairingCode(
   args: { name: string; pairingCode: string; now?: number; endpointAddress?: string }
 ): KnownRuntimeEnvironment {
   const { endpointAddress, ...rest } = args
-  const endpoint = endpointAddress
-    ? resolveEndpointOverride(args.pairingCode, endpointAddress)
-    : null
+  // Why: test provided-ness, not truthiness — an empty override must be rejected
+  // as invalid, never silently treated as "no override".
+  const endpoint =
+    endpointAddress === undefined
+      ? null
+      : resolveEndpointOverride(args.pairingCode, endpointAddress)
   return translateStoreError(() =>
     addEnvironmentFromPairingCodeInStore(userDataPath, {
       ...rest,
@@ -50,6 +56,14 @@ export function addEnvironmentFromPairingCode(
 // Why: reuse the host's advertise grammar so --endpoint accepts the same hosts,
 // host:port, and ws(s):// forms the "Share this Orca server" address field does.
 function resolveEndpointOverride(pairingCode: string, address: string): string {
+  // Why: the resolver reads a blank advertised address as "none given" and falls
+  // back to loopback, which would silently downgrade a reachable offer here.
+  if (address.trim().length === 0) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Invalid --endpoint "${address}". ${INVALID_PAIRING_ENDPOINT_GUIDANCE}`
+    )
+  }
   const offer = parsePairingCode(pairingCode)
   if (!offer) {
     throw new RuntimeClientError(

--- a/src/cli/runtime/environments.ts
+++ b/src/cli/runtime/environments.ts
@@ -13,7 +13,8 @@ import type {
   KnownRuntimeEnvironment,
   PublicKnownRuntimeEnvironment
 } from '../../shared/runtime-environments'
-import type { PairingOffer } from '../../shared/pairing'
+import { parsePairingCode, type PairingOffer } from '../../shared/pairing'
+import { resolveAdvertisedPairingEndpoint } from '../../main/runtime/pairing-endpoint'
 import { RuntimeClientError } from './types'
 
 export type EnvironmentAddResult = {
@@ -32,9 +33,38 @@ export { getEnvironmentStorePath, listEnvironments }
 
 export function addEnvironmentFromPairingCode(
   userDataPath: string,
-  args: { name: string; pairingCode: string; now?: number }
+  args: { name: string; pairingCode: string; now?: number; endpointAddress?: string }
 ): KnownRuntimeEnvironment {
-  return translateStoreError(() => addEnvironmentFromPairingCodeInStore(userDataPath, args))
+  const { endpointAddress, ...rest } = args
+  const endpoint = endpointAddress
+    ? resolveEndpointOverride(args.pairingCode, endpointAddress)
+    : null
+  return translateStoreError(() =>
+    addEnvironmentFromPairingCodeInStore(userDataPath, {
+      ...rest,
+      ...(endpoint ? { endpoint } : {})
+    })
+  )
+}
+
+// Why: reuse the host's advertise grammar so --endpoint accepts the same hosts,
+// host:port, and ws(s):// forms the "Share this Orca server" address field does.
+function resolveEndpointOverride(pairingCode: string, address: string): string {
+  const offer = parsePairingCode(pairingCode)
+  if (!offer) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Invalid pairing code. Expected an orca://pair?... URL or bare pairing payload.'
+    )
+  }
+  const resolved = resolveAdvertisedPairingEndpoint(offer.endpoint, address)
+  if (!resolved.ok) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Invalid --endpoint "${address}". ${resolved.guidance}`
+    )
+  }
+  return resolved.endpoint
 }
 
 export function removeEnvironment(userDataPath: string, selector: string): KnownRuntimeEnvironment {

--- a/src/cli/specs/environment.test.ts
+++ b/src/cli/specs/environment.test.ts
@@ -20,6 +20,15 @@ describe('environment command specs', () => {
     expect(parsed.flags.get('endpoint')).toBe('100.64.0.2')
   })
 
+  // Why: only GLOBAL_VALUE_FLAGS get the parse-time "requires a value" guard, so
+  // an empty --endpoint reaches the handler; rejection is asserted there instead.
+  it('parses an empty --endpoint= into an empty value rather than dropping the flag', () => {
+    const parsed = parseArgs(['environment', 'add', '--endpoint='])
+
+    expect(() => validateCommandAndFlags(ENVIRONMENT_COMMAND_SPECS, parsed)).not.toThrow()
+    expect(parsed.flags.get('endpoint')).toBe('')
+  })
+
   it('rejects --endpoint on commands that do not resolve an address', () => {
     for (const path of [
       ['environment', 'list'],

--- a/src/cli/specs/environment.test.ts
+++ b/src/cli/specs/environment.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseArgs, validateCommandAndFlags } from '../args'
+import { ENVIRONMENT_COMMAND_SPECS } from './environment'
+
+describe('environment command specs', () => {
+  it('accepts --endpoint on environment add and carries its value through', () => {
+    const parsed = parseArgs([
+      'environment',
+      'add',
+      '--name',
+      'work-laptop',
+      '--pairing-code',
+      'orca://pair?code=abc',
+      '--endpoint',
+      '100.64.0.2'
+    ])
+
+    expect(() => validateCommandAndFlags(ENVIRONMENT_COMMAND_SPECS, parsed)).not.toThrow()
+    expect(parsed.flags.get('endpoint')).toBe('100.64.0.2')
+  })
+
+  it('rejects --endpoint on commands that do not resolve an address', () => {
+    for (const path of [
+      ['environment', 'list'],
+      ['environment', 'show', '--environment', 'work-laptop'],
+      ['environment', 'rm', '--environment', 'work-laptop']
+    ]) {
+      const parsed = parseArgs([...path, '--endpoint', '100.64.0.2'])
+      expect(() => validateCommandAndFlags(ENVIRONMENT_COMMAND_SPECS, parsed)).toThrow(
+        /Unknown flag --endpoint/
+      )
+    }
+  })
+})

--- a/src/cli/specs/environment.ts
+++ b/src/cli/specs/environment.ts
@@ -5,9 +5,15 @@ export const ENVIRONMENT_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['environment', 'add'],
     summary: 'Save a remote Orca runtime environment from a pairing code',
-    usage: 'orca environment add --name <name> --pairing-code <code> [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'name'],
-    examples: ['orca environment add --name work-laptop --pairing-code orca://pair?code=...']
+    usage: 'orca environment add --name <name> --pairing-code <code> [--endpoint <host>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'name', 'endpoint'],
+    examples: [
+      'orca environment add --name work-laptop --pairing-code orca://pair?code=...',
+      'orca environment add --name work-laptop --pairing-code orca://pair?code=... --endpoint 100.64.0.2'
+    ],
+    notes: [
+      'Use --endpoint when the host advertised an address this machine cannot reach (for example a 127.0.0.1 link generated for a LAN or Tailscale peer). It accepts a host, host:port, or ws(s):// URL and keeps the port from the pairing code when omitted.'
+    ]
   },
   {
     path: ['environment', 'list'],

--- a/src/renderer/src/components/settings/RuntimePairingGeneratorForm.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingGeneratorForm.tsx
@@ -189,7 +189,9 @@ export function RuntimePairingGeneratorForm({
         </div>
       </div>
 
-      {generatedForLoopback && (webClientUrl || runtimePairingUrl) ? (
+      {/* Why: when the picker still sits on the address the link was minted for,
+          the hint above already carries this warning — don't stack a second one. */}
+      {generatedForLoopback && !selectionIsLoopback && (webClientUrl || runtimePairingUrl) ? (
         <p className="flex items-start gap-1.5 text-xs text-foreground">
           <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
           {translate(

--- a/src/renderer/src/components/settings/RuntimePairingGeneratorForm.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingGeneratorForm.tsx
@@ -1,9 +1,12 @@
-import { Loader2, RefreshCw } from 'lucide-react'
+import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { AddressPicker, type AddressOption } from '../network/AddressPicker'
-import { parseServerShareAddress } from '../../../../shared/network/server-share-address'
+import {
+  isLoopbackShareAddress,
+  parseServerShareAddress
+} from '../../../../shared/network/server-share-address'
 import { GeneratedUrlRow, UnavailableUrlRow } from './RuntimePairingGeneratedUrlRows'
 import { translate } from '@/i18n/i18n'
 
@@ -15,6 +18,7 @@ type RuntimePairingGeneratorFormProps = {
   isGeneratingPairing: boolean
   webClientUrl: string | null
   runtimePairingUrl: string | null
+  generatedAddress: string | null
   copiedTarget: 'web' | 'pairing' | null
   onSelectedAddressChange: (address: string) => void
   onRefreshNetworkInterfaces: () => void
@@ -30,12 +34,15 @@ export function RuntimePairingGeneratorForm({
   isGeneratingPairing,
   webClientUrl,
   runtimePairingUrl,
+  generatedAddress,
   copiedTarget,
   onSelectedAddressChange,
   onRefreshNetworkInterfaces,
   onGenerate,
   onCopy
 }: RuntimePairingGeneratorFormProps): React.JSX.Element {
+  const selectionIsLoopback = isLoopbackShareAddress(selectedAddress)
+  const generatedForLoopback = generatedAddress !== null && isLoopbackShareAddress(generatedAddress)
   const options: AddressOption[] = [
     {
       value: loopbackAddress,
@@ -147,12 +154,23 @@ export function RuntimePairingGeneratorForm({
             </Tooltip>
           </div>
         </div>
-        <p className="text-xs text-muted-foreground">
-          {translate(
-            'auto.components.settings.RuntimePairingUrlGenerator.279e0dcb57',
-            '127.0.0.1 only works on this computer. Use a LAN, Tailscale, or custom address for another device.'
-          )}
-        </p>
+        {selectionIsLoopback ? (
+          <p className="flex items-start gap-1.5 text-xs text-foreground">
+            <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+            {translate(
+              'auto.components.settings.RuntimePairingUrlGenerator.279e0dcb57',
+              '127.0.0.1 only works on this computer. Use a LAN, Tailscale, or custom address for another device.'
+            )}
+          </p>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.RuntimePairingUrlGenerator.reachable-address-hint',
+              'The other device must be able to reach {{address}}.',
+              { address: selectedAddress }
+            )}
+          </p>
+        )}
         <div className="flex justify-end">
           <Button
             type="button"
@@ -170,6 +188,17 @@ export function RuntimePairingGeneratorForm({
           </Button>
         </div>
       </div>
+
+      {generatedForLoopback && (webClientUrl || runtimePairingUrl) ? (
+        <p className="flex items-start gap-1.5 text-xs text-foreground">
+          <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+          {translate(
+            'auto.components.settings.RuntimePairingUrlGenerator.generated-loopback-warning',
+            'These links were generated for {{address}}, so only this computer can open them. Pick a reachable address above and generate again to pair another device.',
+            { address: generatedAddress ?? '' }
+          )}
+        </p>
+      ) : null}
 
       {webClientUrl ? (
         <GeneratedUrlRow

--- a/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
+++ b/src/renderer/src/components/settings/RuntimePairingUrlGenerator.tsx
@@ -16,11 +16,15 @@ const runtimePairingUrlCache: {
   runtimePairingUrl: string | null
   webClientUrl: string | null
   runtimePairingDeviceId: string | null
+  generatedAddress: string | null
 } = {
   selectedAddress: LOOPBACK_ADDRESS,
   runtimePairingUrl: null,
   webClientUrl: null,
-  runtimePairingDeviceId: null
+  runtimePairingDeviceId: null,
+  // Why: the picker can move after generating, so the link warning tracks the
+  // address the displayed link was actually minted for.
+  generatedAddress: null
 }
 
 type RuntimePairingUrlGeneratorProps = {
@@ -46,6 +50,9 @@ export function RuntimePairingUrlGenerator({
   )
   const [runtimePairingDeviceId, setRuntimePairingDeviceId] = useState<string | null>(
     runtimePairingUrlCache.runtimePairingDeviceId
+  )
+  const [generatedAddress, setGeneratedAddress] = useState<string | null>(
+    runtimePairingUrlCache.generatedAddress
   )
   const [runtimeAccessGrants, setRuntimeAccessGrants] = useState<RuntimeAccessGrant[]>([])
   const [isLoadingAccessGrants, setIsLoadingAccessGrants] = useState(false)
@@ -165,10 +172,12 @@ export function RuntimePairingUrlGenerator({
     runtimePairingUrlCache.runtimePairingUrl = null
     runtimePairingUrlCache.webClientUrl = null
     runtimePairingUrlCache.runtimePairingDeviceId = null
+    runtimePairingUrlCache.generatedAddress = null
     if (mountedRef.current) {
       setRuntimePairingUrl(null)
       setWebClientUrl(null)
       setRuntimePairingDeviceId(null)
+      setGeneratedAddress(null)
     }
   }
 
@@ -194,10 +203,12 @@ export function RuntimePairingUrlGenerator({
       runtimePairingUrlCache.runtimePairingUrl = result.pairingUrl
       runtimePairingUrlCache.webClientUrl = result.webClientUrl
       runtimePairingUrlCache.runtimePairingDeviceId = result.deviceId
+      runtimePairingUrlCache.generatedAddress = selectedAddress
       if (mountedRef.current) {
         setRuntimePairingUrl(result.pairingUrl)
         setWebClientUrl(result.webClientUrl)
         setRuntimePairingDeviceId(result.deviceId)
+        setGeneratedAddress(selectedAddress)
       }
       await loadRuntimeAccessGrants()
       if (mountedRef.current) {
@@ -356,6 +367,7 @@ export function RuntimePairingUrlGenerator({
           isGeneratingPairing={isGeneratingPairing}
           webClientUrl={webClientUrl}
           runtimePairingUrl={runtimePairingUrl}
+          generatedAddress={generatedAddress}
           copiedTarget={copiedTarget}
           onSelectedAddressChange={updateSelectedAddress}
           onRefreshNetworkInterfaces={() => void loadNetworkInterfaces({ showToastOnError: true })}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6718,7 +6718,9 @@
           "custom-description": "Advertise an address another device can reach — a LAN or Tailscale host, or a full ws(s):// URL.",
           "custom-hint": "Enter a host, host:port, or a ws(s):// URL.",
           "custom-cancel": "Cancel",
-          "custom-use": "Use address"
+          "custom-use": "Use address",
+          "reachable-address-hint": "The other device must be able to reach {{address}}.",
+          "generated-loopback-warning": "These links were generated for {{address}}, so only this computer can open them. Pick a reachable address above and generate again to pair another device."
         },
         "Settings": {
           "3bf149e873": "Project Settings > {{value0}}",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -6658,7 +6658,9 @@
           "custom-description": "Anuncia una dirección que otro dispositivo pueda alcanzar: un host de LAN o Tailscale, o una URL ws(s):// completa.",
           "custom-hint": "Introduce un host, host:puerto o una URL ws(s)://.",
           "custom-cancel": "Cancelar",
-          "custom-use": "Usar dirección"
+          "custom-use": "Usar dirección",
+          "reachable-address-hint": "The other device must be able to reach {{address}}.",
+          "generated-loopback-warning": "These links were generated for {{address}}, so only this computer can open them. Pick a reachable address above and generate again to pair another device."
         },
         "Settings": {
           "3bf149e873": "Configuración del proyecto > {{value0}}",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -6680,7 +6680,9 @@
           "custom-description": "他のデバイスから到達できるアドレスを指定します。LAN や Tailscale のホスト、または完全な ws(s):// URL です。",
           "custom-hint": "ホスト、host:port、または ws(s):// URL を入力してください。",
           "custom-cancel": "キャンセル",
-          "custom-use": "アドレスを使用"
+          "custom-use": "アドレスを使用",
+          "reachable-address-hint": "The other device must be able to reach {{address}}.",
+          "generated-loopback-warning": "These links were generated for {{address}}, so only this computer can open them. Pick a reachable address above and generate again to pair another device."
         },
         "Settings": {
           "3bf149e873": "プロジェクト設定 > {{value0}}",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -6643,7 +6643,9 @@
           "custom-description": "다른 기기가 연결할 수 있는 주소를 알립니다. LAN 또는 Tailscale 호스트, 또는 전체 ws(s):// URL입니다.",
           "custom-hint": "호스트, host:port 또는 ws(s):// URL을 입력하세요.",
           "custom-cancel": "취소",
-          "custom-use": "주소 사용"
+          "custom-use": "주소 사용",
+          "reachable-address-hint": "The other device must be able to reach {{address}}.",
+          "generated-loopback-warning": "These links were generated for {{address}}, so only this computer can open them. Pick a reachable address above and generate again to pair another device."
         },
         "Settings": {
           "3bf149e873": "프로젝트 설정 > {{value0}}",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -6643,7 +6643,9 @@
           "custom-description": "公布其他设备可以访问的地址：LAN 或 Tailscale 主机，或完整的 ws(s):// URL。",
           "custom-hint": "请输入主机、host:port 或 ws(s):// URL。",
           "custom-cancel": "取消",
-          "custom-use": "使用地址"
+          "custom-use": "使用地址",
+          "reachable-address-hint": "The other device must be able to reach {{address}}.",
+          "generated-loopback-warning": "These links were generated for {{address}}, so only this computer can open them. Pick a reachable address above and generate again to pair another device."
         },
         "Settings": {
           "3bf149e873": "项目设置 > {{value0}}",

--- a/src/shared/network/server-share-address.test.ts
+++ b/src/shared/network/server-share-address.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseServerShareAddress } from './server-share-address'
+import { isLoopbackShareAddress, parseServerShareAddress } from './server-share-address'
 
 describe('parseServerShareAddress', () => {
   it('accepts a bare hostname or IP', () => {
@@ -33,5 +33,38 @@ describe('parseServerShareAddress', () => {
 
   it('rejects an out-of-range port', () => {
     expect(parseServerShareAddress('my-host:70000').ok).toBe(false)
+  })
+})
+
+describe('isLoopbackShareAddress', () => {
+  it('detects loopback hosts in every accepted address form', () => {
+    for (const address of [
+      '127.0.0.1',
+      '127.1.2.3',
+      '127.0.0.1:6768',
+      'localhost',
+      'LocalHost:6768',
+      '::1',
+      '[::1]',
+      'ws://127.0.0.1:6768',
+      'wss://localhost/runtime'
+    ]) {
+      expect(isLoopbackShareAddress(address), address).toBe(true)
+    }
+  })
+
+  it('leaves routable LAN, tailnet, and public addresses alone', () => {
+    for (const address of [
+      '192.168.1.50',
+      '100.64.0.2',
+      '10.0.0.5:6768',
+      'my-mac.tail-abcd.ts.net',
+      'ws://100.64.0.2:6768',
+      '128.0.0.1',
+      '27.0.0.1',
+      ''
+    ]) {
+      expect(isLoopbackShareAddress(address), address).toBe(false)
+    }
   })
 })

--- a/src/shared/network/server-share-address.ts
+++ b/src/shared/network/server-share-address.ts
@@ -40,3 +40,31 @@ export function parseServerShareAddress(input: string): ParseServerShareAddressR
   }
   return { ok: true, value: trimmed }
 }
+
+// Why: a shared address that resolves to loopback produces a pairing link only
+// this computer can dial, so both the picker and the generated link warn on it.
+export function isLoopbackShareAddress(input: string): boolean {
+  const trimmed = input.trim()
+  if (trimmed === '') {
+    return false
+  }
+
+  let host = trimmed
+  if (/^[a-z]+:\/\//i.test(trimmed)) {
+    try {
+      host = new URL(trimmed).hostname
+    } catch {
+      return false
+    }
+  } else if (HOST_OR_HOST_PORT.test(trimmed) && trimmed.includes(':')) {
+    host = trimmed.slice(0, trimmed.lastIndexOf(':'))
+  }
+
+  const normalized = host.replace(/^\[|\]$/g, '').toLowerCase()
+  return (
+    normalized === 'localhost' ||
+    normalized === '::1' ||
+    normalized === '0:0:0:0:0:0:0:1' ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(normalized)
+  )
+}

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -41,15 +41,25 @@ export function listEnvironments(userDataPath: string): KnownRuntimeEnvironment[
 
 export function addEnvironmentFromPairingCode(
   userDataPath: string,
-  args: { name: string; pairingCode: string; now?: number; source?: RuntimeEnvironmentSource }
+  args: {
+    name: string
+    pairingCode: string
+    now?: number
+    source?: RuntimeEnvironmentSource
+    /** Already-resolved ws(s):// URL replacing the offer's advertised endpoint. */
+    endpoint?: string
+  }
 ): KnownRuntimeEnvironment {
-  const offer = parsePairingCode(args.pairingCode)
-  if (!offer) {
+  const parsed = parsePairingCode(args.pairingCode)
+  if (!parsed) {
     throw new RuntimeEnvironmentStoreError(
       'invalid_argument',
       'Invalid pairing code. Expected an orca://pair?... URL or bare pairing payload.'
     )
   }
+  // Why: a host that advertised loopback mints an offer no other device can dial;
+  // the token stays valid, so let the caller redirect it instead of re-pairing.
+  const offer = args.endpoint ? { ...parsed, endpoint: args.endpoint } : parsed
   const store = readEnvironmentStore(userDataPath)
   const now = args.now ?? Date.now()
   const existing = store.environments.find((entry) => entry.name === args.name)


### PR DESCRIPTION
## Summary

Pairing a second machine goes through **Settings → Runtime Environments → Share this Orca server**. Its address picker defaults to `127.0.0.1`, and the hint below it renders as static muted copy that reads identically whichever address is selected. Nothing marks the one selection that produces a link no other device can open.

The result is a link whose credentials are correct but whose endpoint points at the receiving machine's own loopback. Recovering from it meant base64-decoding the offer, rewriting `endpoint`, and re-encoding by hand — `environment add` accepted only `--name` and `--pairing-code`.

Two commits: one makes the mistake recoverable, one makes it less likely.

### `environment add --endpoint <host>`

Redirects a pairing offer to a reachable address while keeping the `deviceToken` and pinned public key the host issued.

```
$ orca environment add --name peer --pairing-code "$CODE" --json
    "endpoint": "ws://127.0.0.1:6768"          # unchanged without the flag

$ orca environment add --name peer --pairing-code "$CODE" --endpoint 100.64.0.2 --json
    "endpoint": "ws://100.64.0.2:6768"         # port inherited from the offer

$ orca environment add --name peer --pairing-code "$CODE" --endpoint wss://desk.example.com/runtime --json
    "endpoint": "wss://desk.example.com/runtime"

$ orca environment add --name peer --pairing-code "$CODE" --endpoint 0.0.0.0 --json
    "message": "Invalid --endpoint \"0.0.0.0\". Use a reachable hostname, host:port, IPv4/IPv6 literal, or ws(s):// URL. ..."
```

Resolution reuses `resolveAdvertisedPairingEndpoint`, so the flag accepts exactly the forms the "Share this Orca server" address field accepts, and rejects wildcard bind addresses no client can dial. No second address grammar was introduced.

`src/cli` reaching into `src/main` follows the existing pattern (`handlers/agent-hooks.ts` → `main/agent-hooks/…`); the module is added to the explicit allowlist in `config/tsconfig.cli.json`.

### Selection-aware loopback warning

- The picker hint now tracks the selection — loopback gets warning emphasis, any other address states which host the peer must reach.
- Generated links carry their own warning, keyed to the address the link was **minted for** rather than the current picker value, so moving the picker afterwards cannot make the warning lie.
- `isLoopbackShareAddress()` lives in `shared/network` so the picker and the link row agree: `127.x`, `localhost`, `::1`, `[::1]`, and `ws(s)://` forms.

## Screenshots

No screenshot attached. The visual change is confined to the hint line under the address picker in Settings → Runtime Environments → Share this Orca server, and one conditional warning line above the generated link rows:

- Loopback selected → existing copy, now rendered at `text-foreground` with an `AlertTriangle` icon instead of muted body text.
- Any other address selected → `The other device must be able to reach {{address}}.`
- Link minted for loopback while the picker has since moved elsewhere → an additional warning naming the minted address.

The warning uses typography and an icon rather than a new color. A loopback address is a valid choice, not an error, and STYLEGUIDE reserves color for selection, destructive, and git decorations — there is no warning token to reach for.

## Testing

- [x] `pnpm typecheck` — node / cli / web, clean
- [x] `pnpm test` — `vitest` across `src/cli`, `src/shared/network`, `src/shared/runtime-environment-store`, `src/renderer/src/components/settings`: **1438 passed / 170 files**
- [x] Added or updated high-quality tests that would catch regressions
- [x] `oxlint` on changed files — clean; `oxfmt --check` — clean
- [x] `verify-localization-catalog` + `audit-localization-coverage` — pass (2 new keys synced across all 5 locales)
- [x] `check-max-lines-ratchet` — pass
- [x] Built CLI exercised end-to-end against a throwaway `ORCA_USER_DATA_PATH` (the four cases above, plus blank-`--endpoint` rejection)
- [ ] `pnpm build` — not run; no main-process or packaging surface is touched
- [ ] `lint:react-doctor:changed` — **could not run.** In my checkout `oxlint-plugin-react-doctor` resolves to 0.2.10 while `package.json` pins 0.9.1, so `config/oxlint-react-doctor.json` fails to parse — identically on files this PR does not touch. Unrelated to these changes, but flagging it since the pre-commit hook depends on it.

16 tests: endpoint override (port inheritance, `host:port` / `ws(s)://` forms, credential preservation, wildcard rejection, blank rejection, no-op when omitted), loopback detection, and command-spec coverage asserting `--endpoint` is accepted on `add` and rejected on `list`/`show`/`rm`.

## AI Review Report

CodeRabbit reviewed both commits. Two actionable items, both addressed in `f16062fad`:

1. **Blank `--endpoint` was not rejected** (`src/cli/handlers/environment.ts`) — a real bug, and the impact was worse than "fails to reject": the blank value was silently applied, downgrading a reachable `ws://10.0.0.5:6768` offer to `ws://127.0.0.1:6768` — exactly the failure the flag exists to repair, because `resolveAdvertisedPairingEndpoint` reads a blank advertised address as "none given" and falls back to loopback. Guarded at both layers — a trimmed check in the flag reader, and provided-ness rather than truthiness in `addEnvironmentFromPairingCode` — so direct API callers are covered too.
2. **Redundant stacked loopback warning** (`RuntimePairingGeneratorForm.tsx`) — took the suggested `!selectionIsLoopback` guard. On the common path (pick "This computer" → Generate) the picker hint already carries the message; two near-identical warnings in one card read as two separate problems.

One correction to my own test in that round: I first asserted `--endpoint=` is rejected at parse time. It isn't — only `GLOBAL_VALUE_FLAGS` (`pairing-code`, `environment`) get that guard, so an empty value reaches the handler. The test now asserts what actually holds (parses to `''`, rejected downstream) rather than what I assumed.

**Cross-platform:** reviewed for macOS, Linux, and Windows. No new keyboard shortcuts, accelerators, or shortcut labels. No filesystem path construction is added — the store path continues through `getDefaultUserDataPath()`. No shell invocation. Address parsing is pure string/URL work with no platform-dependent branches, and the CLI cases were exercised on macOS with a throwaway `ORCA_USER_DATA_PATH`. The renderer change is icon + typography only, with no platform-conditional rendering.

## Security Audit

The security-relevant surface here is that `--endpoint` **deliberately redirects where a pairing offer connects**, so the audit focused on whether that redirect can weaken host authentication.

- **Credential integrity** — the override rewrites only `endpoint`. `deviceToken` and the pinned `publicKeyB64` are carried through from the host-issued offer untouched, so a redirected environment still pins the original host key and a wrong or hostile `--endpoint` fails the pinned-key check rather than silently trusting a new peer. Asserted directly in `environments.test.ts` ("preserves the credentials the host issued").
- **Input handling** — the override is parsed by the existing `resolveAdvertisedPairingEndpoint` grammar rather than a new parser, so it inherits scheme validation and wildcard-bind rejection (`0.0.0.0`). Blank/whitespace input is rejected at two layers instead of degrading to loopback. Invalid pairing codes are rejected before the override is applied.
- **Downgrade check** — the flag cannot upgrade or downgrade the transport silently in a way the user did not type: `ws://` vs `wss://` comes from what the operator passes, and when only a bare host is given the scheme and port are inherited from the offer, not defaulted.
- **Secrets** — no new logging of tokens or codes; CLI output continues through `redactRuntimeEnvironment`.
- **Not touched** — no IPC surface, no command execution, no filesystem path handling, no new dependencies, no change to the RPC allowlist.

**Follow-up:** none required for this PR. Separately, minting an offer at all still requires renderer/GUI access on the host — tracked in #11084, which this PR explicitly does not solve.

## Notes

- No X handle to share — I'm not on X, so there's nothing to shout out. Every other item in CONTRIBUTING's PR checklist is covered above.
- This makes an already-issued offer redirectable; it does **not** remove the need for GUI access to issue one. That gap is #11084 (addressed by #11180).
- The `lint:react-doctor:changed` breakage noted under Testing is pre-existing and environment-local, but it blocks the pre-commit hook for anyone whose install resolves the older plugin version — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

