### PR TITLE
fix(sidebar): close the shortcut-opened workspace rename editor

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.editor-lifecycle.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.editor-lifecycle.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WorktreeTitleInlineRename } from './WorktreeTitleInlineRename'
+
+afterEach(cleanup)
+
+function getRenameInput(container: HTMLElement): HTMLInputElement | null {
+  return container.querySelector<HTMLInputElement>('[data-worktree-title-rename-input="true"]')
+}
+
+describe('WorktreeTitleInlineRename editor lifecycle', () => {
+  it('closes the editor after the shortcut-opened rename commits', async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined)
+    const onEditingChange = vi.fn()
+    const onBeginEditingConsumed = vi.fn()
+
+    const { container, rerender } = render(
+      <WorktreeTitleInlineRename
+        displayName="old name"
+        beginEditing={true}
+        onBeginEditingConsumed={onBeginEditingConsumed}
+        onEditingChange={onEditingChange}
+        onRename={onRename}
+      />
+    )
+    // the parent clears its trigger once the request is consumed
+    rerender(
+      <WorktreeTitleInlineRename
+        displayName="old name"
+        beginEditing={false}
+        onBeginEditingConsumed={onBeginEditingConsumed}
+        onEditingChange={onEditingChange}
+        onRename={onRename}
+      />
+    )
+
+    const input = getRenameInput(container)
+    expect(input).not.toBeNull()
+    // Why: the card disables drag while renaming, so the shortcut path must report it too.
+    expect(onEditingChange).toHaveBeenCalledWith(true)
+
+    fireEvent.change(input!, { target: { value: 'new name' } })
+    fireEvent.keyDown(input!, { key: 'Enter' })
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith('new name'))
+
+    rerender(
+      <WorktreeTitleInlineRename
+        displayName="new name"
+        beginEditing={false}
+        onBeginEditingConsumed={onBeginEditingConsumed}
+        onEditingChange={onEditingChange}
+        onRename={onRename}
+      />
+    )
+
+    expect(getRenameInput(container)).toBeNull()
+    expect(onEditingChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('closes the editor when the shortcut-opened rename is cancelled with Escape', () => {
+    const onBeginEditingConsumed = vi.fn()
+
+    const { container, rerender } = render(
+      <WorktreeTitleInlineRename
+        displayName="old name"
+        beginEditing={true}
+        onBeginEditingConsumed={onBeginEditingConsumed}
+        onRename={vi.fn()}
+      />
+    )
+    rerender(
+      <WorktreeTitleInlineRename
+        displayName="old name"
+        beginEditing={false}
+        onBeginEditingConsumed={onBeginEditingConsumed}
+        onRename={vi.fn()}
+      />
+    )
+
+    const input = getRenameInput(container)
+    expect(input).not.toBeNull()
+    fireEvent.keyDown(input!, { key: 'Escape' })
+
+    rerender(
+      <WorktreeTitleInlineRename
+        displayName="old name"
+        beginEditing={false}
+        onBeginEditingConsumed={onBeginEditingConsumed}
+        onRename={vi.fn()}
+      />
+    )
+
+    expect(getRenameInput(container)).toBeNull()
+  })
+
+  it('closes the editor after a double-click rename commits', async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined)
+
+    const { container, rerender } = render(
+      <WorktreeTitleInlineRename displayName="old name" onRename={onRename} />
+    )
+
+    fireEvent.doubleClick(container.querySelector('[data-worktree-title-inline-rename=""]')!)
+    const input = getRenameInput(container)
+    expect(input).not.toBeNull()
+
+    fireEvent.change(input!, { target: { value: 'new name' } })
+    fireEvent.keyDown(input!, { key: 'Enter' })
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith('new name'))
+
+    rerender(<WorktreeTitleInlineRename displayName="new name" onRename={onRename} />)
+
+    expect(getRenameInput(container)).toBeNull()
+  })
+
+  it('keeps the open editor untouched when the row flips to unread', () => {
+    const { container, rerender } = render(
+      <WorktreeTitleInlineRename
+        displayName="old name"
+        showUnreadEmphasis={false}
+        onRename={vi.fn()}
+      />
+    )
+
+    fireEvent.doubleClick(container.querySelector('[data-worktree-title-inline-rename=""]')!)
+    const input = getRenameInput(container)
+    expect(input).not.toBeNull()
+    // the user is mid-edit with the caret placed inside the title
+    input!.setSelectionRange(3, 3)
+
+    // an agent-completion notification marks this workspace unread mid-edit
+    rerender(
+      <WorktreeTitleInlineRename
+        displayName="old name"
+        showUnreadEmphasis={true}
+        onRename={vi.fn()}
+      />
+    )
+
+    // Why: remounting the editor would reselect the whole title, so the next keystroke replaces it.
+    expect(getRenameInput(container)).toBe(input)
+    expect(input!.selectionStart).toBe(3)
+    expect(input!.selectionEnd).toBe(3)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeTitleInlineRename.tsx
@@ -161,8 +161,8 @@ export function WorktreeTitleInlineRename({
       return
     }
     setValue(displayName)
-    setEditing(true)
-  }, [beginEditing, disabled, editing, displayName, onBeginEditingConsumed])
+    setEditingMode(true)
+  }, [beginEditing, disabled, editing, displayName, onBeginEditingConsumed, setEditingMode])
 
   const stopCardEvent = useCallback((event: React.SyntheticEvent) => {
     event.stopPropagation()
@@ -245,7 +245,8 @@ export function WorktreeTitleInlineRename({
   if (editing) {
     return (
       <span
-        key={`editing:${titleElementKey}`}
+        // Why: a title/unread change must not remount the open editor — the input ref would refocus and reselect mid-edit.
+        key="editing"
         ref={handleRootRef}
         className={cn(
           'relative grid min-w-0 truncate leading-tight text-foreground',


### PR DESCRIPTION
## Summary

Follow-up: #11099 removes the structure that made this bug possible (behavior-preserving refactor, stacked on this PR).

Renaming a workspace from the keyboard leaves the sidebar title stuck in an edit box that will not close. Enter, Escape and clicking away all fail. The box is borderless, so it looks like an ordinary title — until an agent finishes and the notification for that row pulls focus back in and selects the whole name. The next key you press replaces the title you already finished typing.

This PR:

- closes the editor on the `workspace.rename` shortcut path, so Enter commits, Escape cancels, and clicking away commits — matching the double-click path
- keeps an open editor in place when the row's title or unread flag changes, so a notification no longer steals the caret
- reports editing state to the parent card on the shortcut path, so card drag stays disabled while a rename is in progress

## ELI5

The code that opens the rename box and the code that closes it were checking two different switches. Opening flipped only one of them, so closing looked at the other, concluded "we were never editing," and did nothing. Separately, any update to that row — a new title, an unread dot — rebuilt the box from scratch, and a fresh box always grabs focus and highlights its contents. That is fine when you just double-clicked to rename; it is not fine when a background notification triggers it.

## Root cause

Two independent defects in `WorktreeTitleInlineRename`. Either one alone is a papercut; together they produce the symptom above.

**1. The shortcut path never set `editingRef`.** The `beginEditing` Effect opened the editor with `setEditing(true)` rather than `setEditingMode(true)`:

```ts
setValue(displayName)
setEditing(true)          // editingRef stays false
```

`setEditingMode` starts with `if (editingRef.current === nextEditing) return`. With `editingRef` still `false`, every later `setEditingMode(false)` — from `commitRename`, from `cancelRename`, from the input's `onBlur` — returned early and left `editing` state `true`. The editor could not be closed by Enter, Escape, or clicking away. `onEditingChange` was never fired either, so `WorktreeCard` never learned a rename was in progress. The double-click path was unaffected because `startRename` calls `setEditingMode(true)`.

**2. The open editor remounted on unrelated row updates.** The editing branch keyed its root on `titleElementKey`, which is derived from `displayName` and `showUnreadEmphasis`:

```ts
const titleElementKey = `${displayName}:${showUnreadEmphasis ? 'unread' : 'read'}`
```

`use-notification-dispatch` calls `markWorktreeUnread` on `agent-task-complete`, `WorktreeCard` turns that into `showUnreadEmphasis`, the key changes, and React discards the subtree. The freshly mounted input hits the ref callback, which runs `input.focus()` and `input.select()` — correct on a genuine double-click open, wrong on a remount. Committing a rename triggered the same thing through the `displayName` half of the key.

Defect 1 leaves the editor open forever, which gives defect 2 something to remount on every later notification for that row. The sidebar renders the borderless `editingPresentation="text"` variant, so nothing on screen says an editor is still there — which is why this reads as the title randomly grabbing the cursor.

## Fix

- open through `setEditingMode(true)` so `editingRef` and `onEditingChange` stay in sync with `editing`
- give the editing branch a stable key so title/unread churn cannot remount a live editor

## Proof of fix

Ran the PR branch as a dev instance (`pnpm dev`, isolated `orca-dev` profile) against a throwaway repo, and drove the real UI through the renderer's CDP endpoint. The rename shortcut is `Mod+Alt+R` on macOS.

Before the fix — Escape leaves the editor open, and a notification mid-edit remounts it, refocuses it and reselects the whole title (caret was at 3,3):

```
after shortcut : input present, focused, sel [0,12]
after Escape   : input STILL present, still focused
markWorktreeUnread(active) -> remounted: true, focused: true, sel [0,16]
```

<img src="https://raw.githubusercontent.com/socar-jian/orca/assets/rename-editor-lifecycle/.tmp-assets/before-fix.png" width="900" alt="Sidebar workspace title rendered as a fully selected text block after a notification" />

After the fix — Escape closes it, Enter saves and closes it, and the same notification leaves the caret untouched:

```
after shortcut : input present, focused, sel [0,12]
after Escape   : no input
rename + Enter : title becomes "renamed-by-probe", no input
markWorktreeUnread(active) while editing -> remounted: false, focused: true, sel [3,3]
```

<img src="https://raw.githubusercontent.com/socar-jian/orca/assets/rename-editor-lifecycle/.tmp-assets/after-fix.png" width="900" alt="Same row with the notification bell, title no longer selected" />

## Proof of no regression

- New `WorktreeTitleInlineRename.editor-lifecycle.test.tsx` covers shortcut-Enter, shortcut-Escape, a double-click control case, and an unread flip during an open edit. Reverting the source change fails 3 of the 4 and leaves only the double-click control passing, so the suite actually catches this regression.
- `pnpm lint`, `pnpm typecheck`, `pnpm build`: pass.
- `pnpm test`: 38,734 tests. The only failures were `src/main` / `src/relay` git, ssh, pty and plugin integration files; re-running those 9 files in isolation passed 8, and the remaining one (`src/main/repo-icon-autodetect.test.ts` → "uses the resolved fork upstream for both metadata and the GitHub avatar") fails identically on an unmodified tree. Nothing under `src/renderer` failed.
- react-doctor reports the same two pre-existing warnings on this file before and after the change; no new ones.

## AI Review Report

Reviewed with Claude Code, focused on the risks this repo asks about:

- **Cross-platform**: renderer-only React state and key handling — no platform branches, path handling, or accelerator strings. `workspace.rename` ships a default binding on macOS only (`Mod+Alt+R`), so elsewhere the path is reached through a user-defined binding; the fix itself is platform-neutral.
- **SSH / remote / local**: no main-process, git, IPC, or transport code is touched. Rename still flows through the existing `onRename` prop, so local, SSH and folder workspaces behave identically.
- **Agents / integrations / git providers**: none referenced. The notification link is one-way — `markWorktreeUnread` is unchanged and this component only reads the resulting flag.
- **Performance**: strictly fewer renders. The stable editing key removes a full subtree unmount/remount per title or unread change while an editor is open; nothing new runs on any hot path.
- **UI quality**: both call sites were checked — the sidebar row (`editingPresentation="text"`) and the hovercard identity header (`editingPresentation="field"`). Only lifecycle behavior changes; no visual or layout change in either. The non-editing title keeps its original key, so tooltip truncation re-measurement on title/unread changes is preserved.
- **Flagged and verified**: adding `setEditingMode` to the Effect deps could re-run it, so I checked the guard order — the Effect returns immediately unless `beginEditing` is true, and the parent clears its trigger in `onBeginEditingConsumed`, so the open request still fires once.

## Security Audit

No input parsing, command execution, path handling, auth, secrets, IPC surface, or dependency changes. The edit is confined to React state transitions and a React key inside one presentational component; the rename value itself still travels the pre-existing `onRename` path with unchanged trimming and validation in `getWorktreeTitleRenameCommit`. No new attack surface, no follow-up needed.

## Notes

- Verified on macOS. Reproducing on Linux or Windows needs a user-defined binding for this shortcut, since neither ships one by default.
- The screenshots live on a separate `assets/rename-editor-lifecycle` branch of my fork, so no binaries land in this PR's diff. Happy to re-upload them as GitHub attachments if you prefer.
- The two react-doctor warnings on this file (`effect-needs-cleanup` on the ResizeObserver, `no-adjust-state-on-prop-change` on the begin-editing Effect) predate this change and are left alone to keep the diff focused.
- X handle, per the contributor guide: [@hgijeon](https://x.com/hgijeon)
