### PR TITLE
test(daemon): use a named-pipe socket path so the preflight suite runs on Windows

### DIFF
--- a/src/main/daemon/daemon-preflight-client-replacement.test.ts
+++ b/src/main/daemon/daemon-preflight-client-replacement.test.ts
@@ -3,6 +3,7 @@ import { connect, type Socket } from 'node:net'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { relayTestSocketPath } from '../../relay/relay-test-socket-path'
 import { DaemonClient } from './client'
 import { DaemonServer } from './daemon-server'
 import { encodeNdjson } from './ndjson'
@@ -71,7 +72,7 @@ describe('daemon preflight client replacement', () => {
     })
     const preparePtySpawn = vi.fn(() => preparation)
     const spawnSubprocess = vi.fn(() => createMockSubprocess())
-    const socketPath = join(dir, 'daemon.sock')
+    const socketPath = relayTestSocketPath(dir, 'daemon.sock')
     const tokenPath = join(dir, 'daemon.token')
     server = new DaemonServer({ socketPath, tokenPath, preparePtySpawn, spawnSubprocess })
     await server.start()
@@ -110,7 +111,7 @@ describe('daemon preflight client replacement', () => {
     })
     const preparePtySpawn = vi.fn(() => preparation)
     const spawnSubprocess = vi.fn(() => createMockSubprocess())
-    const socketPath = join(dir, 'daemon.sock')
+    const socketPath = relayTestSocketPath(dir, 'daemon.sock')
     const tokenPath = join(dir, 'daemon.token')
     server = new DaemonServer({ socketPath, tokenPath, preparePtySpawn, spawnSubprocess })
     await server.start()


### PR DESCRIPTION
## Summary

No user-visible change. `daemon-preflight-client-replacement.test.ts` builds its endpoint with `join(dir, 'daemon.sock')` and hands it to `DaemonServer`, which passes it straight to `net.Server.listen()` (`src/main/daemon/daemon-server.ts:214`). Windows IPC endpoints have to be named pipes, so both tests in the file fail with `listen EACCES` on a clean Windows checkout of `main`.

The repo already solves this. `relayTestSocketPath()` (`src/relay/relay-test-socket-path.ts`) returns `join(dir, name)` on POSIX and a `\\.\pipe\...` endpoint on win32, and its comment states the constraint outright:

> Node's net server requires Windows IPC endpoints to be named pipes; filesystem-style .sock paths fail with EACCES on Windows hosts.

`src/relay/subprocess.test.ts` and `src/relay/relay-handshake-roundtrip.test.ts` already use it. This suite was the only one still passing a filesystem path, so it now uses the helper too.

No coverage is lost and POSIX behavior is identical: on darwin and linux the helper returns the same `join(dir, 'daemon.sock')` string the test built before.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - every step passes except the last, `verify:skill-bundle-manifest` ("Generated skill artifacts are stale"). Pre-existing and Windows-specific: it fails identically on a clean checkout of the base commit `badf911`, this PR touches nothing under `resources/skills/`, and CI is green on `ubuntu-latest`. Passing steps: `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `lint:switch-exhaustiveness`, `check-styled-scrollbars`, `check:quadratic-buffer-concat`, `check:reliability-gates` (51 gates), `check:max-lines-ratchet` (no new bypasses), `verify:bundled-skill-guides`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` - the full suite exits non-zero on this host because of pre-existing Windows failures unrelated to this PR.

  Scoped to the suite this PR touches:

  | | passed | failed |
  |---|---|---|
  | clean `main` at `badf911` | 0 | 2 |
  | this branch | 2 | 0 |

  Both baseline failures are the same `listen EACCES: permission denied ...\daemon.sock` raised from `daemon-server.ts:214`.

- [x] `pnpm build`
- [x] No new tests were needed: this fixes how an existing suite builds its endpoint and does not change behavior. The two tests it already contains now execute on Windows instead of failing at `server.start()`, which is the regression coverage this restores.

Host: Windows 11 (26200), Node v24.11.1, base commit `badf911`.

## AI Review Report

Reviewed with Claude Code. Risks checked and findings:

- **Cross-platform** - the main risk, and it is bounded by the helper itself. `relayTestSocketPath()` branches on `process.platform !== 'win32'` and returns `join(dir, name)` unchanged, so darwin and linux receive the exact string the test used before. Only win32 sees a different value, and that path is verified locally (2 passed). The unchanged path is left to CI, since this host is Windows-only.
- **Daemon / IPC** - no production code is touched. `DaemonServer` and `DaemonClient` both receive the same `socketPath` value they always did; only its shape changes on Windows, which is what `net` requires there. The token file path stays a real filesystem path, since it is read with `readFileSync` rather than bound.
- **Test isolation** - the helper derives its pipe name from `process.pid`, the temp dir, and the name, so parallel vitest workers cannot collide on a shared endpoint.
- **Agents / integrations / git providers / UI** - untouched.
- **Performance** - no runtime code changes.
- **Security** - see below.

Considered and rejected: skipping the suite on Windows, the way three Linux-only suites are skipped in #11080. That is wrong here. The daemon runs on Windows, `daemon-server.ts` has no platform gate, and the suite covers real reconnect and stream-loss handling. Skipping would hide coverage that Windows users depend on, whereas the endpoint shape is purely a test-fixture concern.

## Security Audit

No input handling, authentication, secret, dependency, or command execution code is modified. The diff is one import and two call sites in a single test file. The helper it calls is already in the repo and already used by two other suites. The named pipe it produces is process-scoped and lives only for the duration of the test.

## Notes

- Windows-specific by construction. macOS and Linux resolve to the identical path string as before.
- Context on why this went unnoticed: no CI job runs the full unit suite on Windows. `.github/workflows/pr.yml` pins the `verify` job to `ubuntu-latest`, and the Windows vitest lane in `computer-e2e.yml` runs a hand-listed allowlist that this file is not in.
- X handle: `gyujinkim00`
