### PR TITLE
fix(memory): bound external-import traversal and speech IPC ingress

### DIFF
--- a/src/main/ipc/filesystem-external-import-limits.test.ts
+++ b/src/main/ipc/filesystem-external-import-limits.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import {
+  admitExternalImportTreeEntry,
+  assertExternalImportSourcePaths,
+  assertExternalImportTreeDepth,
+  captureRuntimeUploadRetentionCheckpoint,
+  createExternalImportTreeBudget,
+  createRuntimeUploadRetentionBudget,
+  EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES,
+  EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES,
+  EXTERNAL_IMPORT_MAX_SOURCE_PATHS,
+  EXTERNAL_IMPORT_MAX_TREE_DEPTH,
+  EXTERNAL_IMPORT_MAX_TREE_ENTRIES,
+  ExternalImportCapacityError,
+  REMOTE_IMPORT_MAX_FILE_BYTES,
+  REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES,
+  REMOTE_IMPORT_MAX_TOTAL_BYTES,
+  restoreRuntimeUploadRetentionCheckpoint,
+  retainRuntimeUploadFileBytes
+} from './filesystem-external-import-limits'
+
+describe('external filesystem import limits', () => {
+  it('accepts the exact source-count boundary and rejects the next path', () => {
+    expect(() =>
+      assertExternalImportSourcePaths(
+        Array.from({ length: EXTERNAL_IMPORT_MAX_SOURCE_PATHS }, () => '')
+      )
+    ).not.toThrow()
+    expect(() =>
+      assertExternalImportSourcePaths(
+        Array.from({ length: EXTERNAL_IMPORT_MAX_SOURCE_PATHS + 1 }, () => '')
+      )
+    ).toThrow('External import accepts at most 256 source paths')
+  })
+
+  it('accepts the exact source-path byte boundary and rejects one byte more', () => {
+    expect(() =>
+      assertExternalImportSourcePaths(['a'.repeat(EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES)])
+    ).not.toThrow()
+    expect(() =>
+      assertExternalImportSourcePaths(['a'.repeat(EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES + 1)])
+    ).toThrow('External import source paths exceed 256 KiB')
+  })
+
+  it('accepts exactly 100,000 tree entries without retaining their paths', () => {
+    const budget = createExternalImportTreeBudget()
+    for (let index = 0; index < EXTERNAL_IMPORT_MAX_TREE_ENTRIES; index += 1) {
+      admitExternalImportTreeEntry(budget, 'entry', false)
+    }
+
+    expect(budget).toEqual({
+      entries: EXTERNAL_IMPORT_MAX_TREE_ENTRIES,
+      retainedPathBytes: 0
+    })
+    expect(() => admitExternalImportTreeEntry(budget, 'overflow', false)).toThrow(
+      'External import tree exceeds 100,000 entries'
+    )
+    expect(budget.entries).toBe(EXTERNAL_IMPORT_MAX_TREE_ENTRIES)
+  })
+
+  it('accepts the exact depth and per-path boundaries', () => {
+    const budget = createExternalImportTreeBudget()
+    expect(() => assertExternalImportTreeDepth(EXTERNAL_IMPORT_MAX_TREE_DEPTH)).not.toThrow()
+    expect(() => assertExternalImportTreeDepth(EXTERNAL_IMPORT_MAX_TREE_DEPTH + 1)).toThrow(
+      'External import tree exceeds 256 nested directory levels'
+    )
+    expect(() =>
+      admitExternalImportTreeEntry(
+        budget,
+        'a'.repeat(EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES),
+        false
+      )
+    ).not.toThrow()
+    expect(() =>
+      admitExternalImportTreeEntry(
+        budget,
+        'a'.repeat(EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES + 1),
+        false
+      )
+    ).toThrow('External import relative path exceeds 64 KiB')
+  })
+
+  it('accepts the exact aggregate retained-path boundary', () => {
+    const budget = createExternalImportTreeBudget()
+    const path = 'a'.repeat(EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES)
+    const pathCount =
+      REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES / (EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES * 2)
+    for (let index = 0; index < pathCount; index += 1) {
+      admitExternalImportTreeEntry(budget, path, true)
+    }
+
+    expect(budget.retainedPathBytes).toBe(REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES)
+    expect(() => admitExternalImportTreeEntry(budget, 'b', true)).toThrow(
+      'Remote import retained paths exceed 16 MiB'
+    )
+    expect(budget.retainedPathBytes).toBe(REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES)
+  })
+
+  it('applies file and total byte limits across the full runtime-upload request', () => {
+    const budget = createRuntimeUploadRetentionBudget()
+    const exactFileCount = REMOTE_IMPORT_MAX_TOTAL_BYTES / REMOTE_IMPORT_MAX_FILE_BYTES
+    for (let index = 0; index < exactFileCount; index += 1) {
+      retainRuntimeUploadFileBytes(budget, `file-${index}`, REMOTE_IMPORT_MAX_FILE_BYTES)
+    }
+
+    expect(budget.fileBytes).toBe(REMOTE_IMPORT_MAX_TOTAL_BYTES)
+    expect(() => retainRuntimeUploadFileBytes(budget, 'overflow', 1)).toThrow(
+      'Remote import is too large'
+    )
+    expect(budget.fileBytes).toBe(REMOTE_IMPORT_MAX_TOTAL_BYTES)
+  })
+
+  it('rejects one oversized file without consuming request capacity', () => {
+    const budget = createRuntimeUploadRetentionBudget()
+
+    expect(() =>
+      retainRuntimeUploadFileBytes(budget, 'large.bin', REMOTE_IMPORT_MAX_FILE_BYTES + 1)
+    ).toThrow("'large.bin' is too large for remote import")
+    expect(budget.fileBytes).toBe(0)
+  })
+
+  it('restores capacity reserved by a failed staged source', () => {
+    const budget = createRuntimeUploadRetentionBudget()
+    const checkpoint = captureRuntimeUploadRetentionCheckpoint(budget)
+    admitExternalImportTreeEntry(budget.tree, 'partial.txt', true)
+    retainRuntimeUploadFileBytes(budget, 'partial.txt', 1024)
+
+    restoreRuntimeUploadRetentionCheckpoint(budget, checkpoint)
+
+    expect(budget).toEqual({
+      tree: { entries: 0, retainedPathBytes: 0 },
+      fileBytes: 0
+    })
+  })
+
+  it('uses a typed error for every capacity rejection', () => {
+    const budget = createExternalImportTreeBudget()
+
+    expect(() =>
+      admitExternalImportTreeEntry(
+        budget,
+        'a'.repeat(EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES + 1),
+        false
+      )
+    ).toThrow(ExternalImportCapacityError)
+  })
+})

--- a/src/main/ipc/filesystem-external-import-limits.test.ts
+++ b/src/main/ipc/filesystem-external-import-limits.test.ts
@@ -58,12 +58,19 @@ describe('external filesystem import limits', () => {
     expect(budget.entries).toBe(EXTERNAL_IMPORT_MAX_TREE_ENTRIES)
   })
 
-  it('accepts the exact depth and per-path boundaries', () => {
-    const budget = createExternalImportTreeBudget()
-    expect(() => assertExternalImportTreeDepth(EXTERNAL_IMPORT_MAX_TREE_DEPTH)).not.toThrow()
-    expect(() => assertExternalImportTreeDepth(EXTERNAL_IMPORT_MAX_TREE_DEPTH + 1)).toThrow(
+  // Why the literal 256 rather than the constant: seeding the assertion from
+  // EXTERNAL_IMPORT_MAX_TREE_DEPTH makes `MAX + 1` throw at any value, so the test passes
+  // even when the constant is raised to MAX_SAFE_INTEGER — i.e. when it is no bound at all.
+  it('rejects the 257th nested directory level', () => {
+    expect(EXTERNAL_IMPORT_MAX_TREE_DEPTH).toBe(256)
+    expect(() => assertExternalImportTreeDepth(256)).not.toThrow()
+    expect(() => assertExternalImportTreeDepth(257)).toThrow(
       'External import tree exceeds 256 nested directory levels'
     )
+  })
+
+  it('accepts the exact depth and per-path boundaries', () => {
+    const budget = createExternalImportTreeBudget()
     expect(() =>
       admitExternalImportTreeEntry(
         budget,

--- a/src/main/ipc/filesystem-external-import-limits.ts
+++ b/src/main/ipc/filesystem-external-import-limits.ts
@@ -1,0 +1,157 @@
+import {
+  NATIVE_FILE_DROP_MAX_PATH_BYTES,
+  NATIVE_FILE_DROP_MAX_PATHS
+} from '../../shared/native-file-drop'
+
+export const EXTERNAL_IMPORT_MAX_SOURCE_PATHS = NATIVE_FILE_DROP_MAX_PATHS
+export const EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES = NATIVE_FILE_DROP_MAX_PATH_BYTES
+export const EXTERNAL_IMPORT_MAX_TREE_ENTRIES = 100_000
+export const EXTERNAL_IMPORT_MAX_TREE_DEPTH = 256
+export const EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES = 64 * 1024
+export const REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES = 16 * 1024 * 1024
+export const REMOTE_IMPORT_MAX_FILE_BYTES = 25 * 1024 * 1024
+export const REMOTE_IMPORT_MAX_TOTAL_BYTES = 100 * 1024 * 1024
+
+export const EXTERNAL_IMPORT_TREE_ENTRY_LIMIT_MESSAGE =
+  'External import tree exceeds 100,000 entries'
+export const EXTERNAL_IMPORT_TREE_DEPTH_LIMIT_MESSAGE =
+  'External import tree exceeds 256 nested directory levels'
+export const EXTERNAL_IMPORT_RELATIVE_PATH_LIMIT_MESSAGE =
+  'External import relative path exceeds 64 KiB'
+export const REMOTE_IMPORT_RETAINED_PATH_LIMIT_MESSAGE =
+  'Remote import retained paths exceed 16 MiB'
+
+export type ExternalImportTreeBudget = {
+  entries: number
+  retainedPathBytes: number
+}
+
+export type RuntimeUploadRetentionBudget = {
+  tree: ExternalImportTreeBudget
+  fileBytes: number
+}
+
+export type RuntimeUploadRetentionCheckpoint = {
+  entries: number
+  retainedPathBytes: number
+  fileBytes: number
+}
+
+export class ExternalImportCapacityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ExternalImportCapacityError'
+  }
+}
+
+export function assertExternalImportSourcePaths(
+  sourcePaths: unknown
+): asserts sourcePaths is readonly string[] {
+  if (!Array.isArray(sourcePaths)) {
+    throw new TypeError('External import source paths must be an array')
+  }
+  if (sourcePaths.length > EXTERNAL_IMPORT_MAX_SOURCE_PATHS) {
+    throw new ExternalImportCapacityError(
+      `External import accepts at most ${EXTERNAL_IMPORT_MAX_SOURCE_PATHS} source paths`
+    )
+  }
+
+  let pathBytes = 0
+  for (const sourcePath of sourcePaths) {
+    if (typeof sourcePath !== 'string') {
+      throw new TypeError('External import source paths must be strings')
+    }
+    pathBytes += Buffer.byteLength(sourcePath, 'utf8')
+    if (pathBytes > EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES) {
+      throw new ExternalImportCapacityError('External import source paths exceed 256 KiB')
+    }
+  }
+}
+
+export function createExternalImportTreeBudget(): ExternalImportTreeBudget {
+  return { entries: 0, retainedPathBytes: 0 }
+}
+
+export function assertExternalImportTreeDepth(depth: number): void {
+  if (depth > EXTERNAL_IMPORT_MAX_TREE_DEPTH) {
+    throw new ExternalImportCapacityError(EXTERNAL_IMPORT_TREE_DEPTH_LIMIT_MESSAGE)
+  }
+}
+
+export function admitExternalImportTreeEntry(
+  budget: ExternalImportTreeBudget,
+  relativePath: string,
+  retainPath: boolean
+): void {
+  if (budget.entries >= EXTERNAL_IMPORT_MAX_TREE_ENTRIES) {
+    throw new ExternalImportCapacityError(EXTERNAL_IMPORT_TREE_ENTRY_LIMIT_MESSAGE)
+  }
+
+  const pathBytes = Buffer.byteLength(relativePath, 'utf8')
+  if (pathBytes > EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES) {
+    throw new ExternalImportCapacityError(EXTERNAL_IMPORT_RELATIVE_PATH_LIMIT_MESSAGE)
+  }
+  const retainedPathBytes = relativePath.length * 2
+  if (
+    retainPath &&
+    retainedPathBytes > REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES - budget.retainedPathBytes
+  ) {
+    throw new ExternalImportCapacityError(REMOTE_IMPORT_RETAINED_PATH_LIMIT_MESSAGE)
+  }
+
+  budget.entries += 1
+  if (retainPath) {
+    budget.retainedPathBytes += retainedPathBytes
+  }
+}
+
+export function createRuntimeUploadRetentionBudget(): RuntimeUploadRetentionBudget {
+  return {
+    tree: createExternalImportTreeBudget(),
+    fileBytes: 0
+  }
+}
+
+export function captureRuntimeUploadRetentionCheckpoint(
+  budget: RuntimeUploadRetentionBudget
+): RuntimeUploadRetentionCheckpoint {
+  return {
+    entries: budget.tree.entries,
+    retainedPathBytes: budget.tree.retainedPathBytes,
+    fileBytes: budget.fileBytes
+  }
+}
+
+export function restoreRuntimeUploadRetentionCheckpoint(
+  budget: RuntimeUploadRetentionBudget,
+  checkpoint: RuntimeUploadRetentionCheckpoint
+): void {
+  budget.tree.entries = checkpoint.entries
+  budget.tree.retainedPathBytes = checkpoint.retainedPathBytes
+  budget.fileBytes = checkpoint.fileBytes
+}
+
+export function assertRuntimeUploadFileFits(
+  budget: RuntimeUploadRetentionBudget,
+  relativePath: string,
+  fileBytes: number
+): void {
+  if (!Number.isSafeInteger(fileBytes) || fileBytes < 0) {
+    throw new Error(`Could not safely measure '${relativePath}' for remote import`)
+  }
+  if (fileBytes > REMOTE_IMPORT_MAX_FILE_BYTES) {
+    throw new ExternalImportCapacityError(`'${relativePath}' is too large for remote import`)
+  }
+  if (fileBytes > REMOTE_IMPORT_MAX_TOTAL_BYTES - budget.fileBytes) {
+    throw new ExternalImportCapacityError('Remote import is too large')
+  }
+}
+
+export function retainRuntimeUploadFileBytes(
+  budget: RuntimeUploadRetentionBudget,
+  relativePath: string,
+  fileBytes: number
+): void {
+  assertRuntimeUploadFileFits(budget, relativePath, fileBytes)
+  budget.fileBytes += fileBytes
+}

--- a/src/main/ipc/filesystem-import-ssh-directory.ts
+++ b/src/main/ipc/filesystem-import-ssh-directory.ts
@@ -1,7 +1,13 @@
-import { lstat, readdir, realpath } from 'node:fs/promises'
+import { lstat, opendir, realpath } from 'node:fs/promises'
 import { isAbsolute, join, relative, sep } from 'node:path'
 import type { FileUploadSession, IFilesystemProvider } from '../providers/types'
 import { assertSafeRemotePathSegment, type RemotePathFlavor } from '../ssh/ssh-remote-platform'
+import {
+  admitExternalImportTreeEntry,
+  assertExternalImportTreeDepth,
+  createExternalImportTreeBudget,
+  type ExternalImportTreeBudget
+} from './filesystem-external-import-limits'
 
 export async function captureLocalUploadRoot(
   sourcePath: string,
@@ -23,18 +29,47 @@ export async function preScanSshImportDirectory(
   dirPath: string,
   remotePathFlavor: RemotePathFlavor
 ): Promise<boolean> {
-  const entries = await readdir(dirPath, { withFileTypes: true })
-  for (const entry of entries) {
-    assertSafeRemotePathSegment(entry.name, remotePathFlavor)
-    if (entry.isSymbolicLink()) {
-      return true
-    }
-    if (entry.isDirectory()) {
-      const childPath = join(dirPath, entry.name)
-      if (await preScanSshImportDirectory(childPath, remotePathFlavor)) {
+  return preScanSshImportDirectoryWithinBudget(
+    dirPath,
+    remotePathFlavor,
+    createExternalImportTreeBudget(),
+    '',
+    0
+  )
+}
+
+async function preScanSshImportDirectoryWithinBudget(
+  dirPath: string,
+  remotePathFlavor: RemotePathFlavor,
+  budget: ExternalImportTreeBudget,
+  relativeDir: string,
+  depth: number
+): Promise<boolean> {
+  assertExternalImportTreeDepth(depth)
+  const directory = await opendir(dirPath)
+  try {
+    for await (const entry of directory) {
+      assertSafeRemotePathSegment(entry.name, remotePathFlavor)
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name
+      admitExternalImportTreeEntry(budget, relativePath, false)
+      if (entry.isSymbolicLink()) {
+        return true
+      }
+      if (
+        entry.isDirectory() &&
+        (await preScanSshImportDirectoryWithinBudget(
+          join(dirPath, entry.name),
+          remotePathFlavor,
+          budget,
+          relativePath,
+          depth + 1
+        ))
+      ) {
         return true
       }
     }
+  } finally {
+    await directory.close().catch(() => undefined)
   }
   return false
 }
@@ -48,37 +83,72 @@ export async function uploadSshImportDirectory(
   remotePathFlavor: RemotePathFlavor,
   assertCurrent?: () => void
 ): Promise<void> {
+  await uploadSshImportDirectoryWithinBudget(
+    provider,
+    uploadSession,
+    localDir,
+    remoteDir,
+    rootRealPath,
+    remotePathFlavor,
+    createExternalImportTreeBudget(),
+    '',
+    0,
+    assertCurrent
+  )
+}
+
+async function uploadSshImportDirectoryWithinBudget(
+  provider: IFilesystemProvider,
+  uploadSession: FileUploadSession,
+  localDir: string,
+  remoteDir: string,
+  rootRealPath: string,
+  remotePathFlavor: RemotePathFlavor,
+  budget: ExternalImportTreeBudget,
+  relativeDir: string,
+  depth: number,
+  assertCurrent?: () => void
+): Promise<void> {
+  assertExternalImportTreeDepth(depth)
   await assertLocalUploadPathInsideRoot(rootRealPath, localDir)
-  const entries = await readdir(localDir, { withFileTypes: true })
-  for (const entry of entries) {
-    assertSafeRemotePathSegment(entry.name, remotePathFlavor)
-    const localPath = join(localDir, entry.name)
-    const remotePath = `${remoteDir}/${entry.name}`
-    await assertLocalUploadPathInsideRoot(rootRealPath, localPath)
-    const statResult = await lstat(localPath)
+  const directory = await opendir(localDir)
+  try {
+    for await (const entry of directory) {
+      assertSafeRemotePathSegment(entry.name, remotePathFlavor)
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name
+      admitExternalImportTreeEntry(budget, relativePath, false)
+      const localPath = join(localDir, entry.name)
+      const remotePath = `${remoteDir}/${entry.name}`
+      await assertLocalUploadPathInsideRoot(rootRealPath, localPath)
+      const statResult = await lstat(localPath)
 
-    // Why: skip symlinks and special files even after the up-front pre-scan;
-    // this closes the TOCTOU gap if one is created during upload.
-    if (statResult.isSymbolicLink() || (!statResult.isFile() && !statResult.isDirectory())) {
-      continue
-    }
+      // Why: the up-front scan cannot prevent a source swap during upload.
+      if (statResult.isSymbolicLink() || (!statResult.isFile() && !statResult.isDirectory())) {
+        continue
+      }
 
-    if (statResult.isDirectory()) {
+      if (statResult.isDirectory()) {
+        assertCurrent?.()
+        await provider.createDirNoClobber(remotePath)
+        await uploadSshImportDirectoryWithinBudget(
+          provider,
+          uploadSession,
+          localPath,
+          remotePath,
+          rootRealPath,
+          remotePathFlavor,
+          budget,
+          relativePath,
+          depth + 1,
+          assertCurrent
+        )
+        continue
+      }
       assertCurrent?.()
-      await provider.createDirNoClobber(remotePath)
-      await uploadSshImportDirectory(
-        provider,
-        uploadSession,
-        localPath,
-        remotePath,
-        rootRealPath,
-        remotePathFlavor,
-        assertCurrent
-      )
-      continue
+      await uploadSession.uploadFile(localPath, remotePath, { exclusive: true })
     }
-    assertCurrent?.()
-    await uploadSession.uploadFile(localPath, remotePath, { exclusive: true })
+  } finally {
+    await directory.close().catch(() => undefined)
   }
 }
 

--- a/src/main/ipc/filesystem-import-ssh-ops.test.ts
+++ b/src/main/ipc/filesystem-import-ssh-ops.test.ts
@@ -9,6 +9,7 @@ const {
   mkdirMock,
   realpathMock,
   copyFileMock,
+  opendirMock,
   readdirMock,
   getConnMgrMock
 } = vi.hoisted(() => ({
@@ -17,6 +18,7 @@ const {
   mkdirMock: vi.fn(),
   realpathMock: vi.fn(),
   copyFileMock: vi.fn(),
+  opendirMock: vi.fn(),
   readdirMock: vi.fn(),
   getConnMgrMock: vi.fn()
 }))
@@ -29,14 +31,15 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
   realpath: realpathMock,
   copyFile: copyFileMock,
-  readdir: readdirMock
+  opendir: opendirMock
 }))
 vi.mock('./ssh', () => ({ getSshConnectionManager: getConnMgrMock }))
 
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
 import {
   advanceSshConnectionGeneration,
-  resetSshConnectionGenerations
+  resetSshConnectionGenerations,
+  setSshConnectionGeneration
 } from '../ssh/ssh-connection-generation'
 import {
   registerSshFilesystemProvider,
@@ -82,6 +85,7 @@ function createProvider(uploadSession: FileUploadSession): IFilesystemProvider {
 }
 
 describe('fs:importExternalPaths — SSH operations', () => {
+  const sessionCounterStride = 2 ** 13
   const destDir = '/home/user/project/src'
   const connId = 'ssh-conn-1'
   let provider: IFilesystemProvider
@@ -130,12 +134,15 @@ describe('fs:importExternalPaths — SSH operations', () => {
 
   beforeEach(() => {
     handlers.clear()
+    resetSshConnectionGenerations()
+    setSshConnectionGeneration(connId, 0)
     ;[
       handleMock,
       lstatMock,
       mkdirMock,
       realpathMock,
       copyFileMock,
+      opendirMock,
       readdirMock,
       getConnMgrMock
     ].forEach((m) => m.mockReset())
@@ -145,6 +152,12 @@ describe('fs:importExternalPaths — SSH operations', () => {
     realpathMock.mockImplementation(async (p: string) => p)
     lstatMock.mockRejectedValue(enoent())
     readdirMock.mockResolvedValue([])
+    opendirMock.mockImplementation(async (directoryPath: string) => ({
+      async *[Symbol.asyncIterator]() {
+        yield* await readdirMock(directoryPath, { withFileTypes: true })
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    }))
     getConnMgrMock.mockReturnValue({ getConnection: () => makeConn() })
     uploadSession = {
       uploadFile: vi.fn().mockResolvedValue(undefined),
@@ -162,6 +175,7 @@ describe('fs:importExternalPaths — SSH operations', () => {
 
   it('rejects a staged upload when a restarted HUB reaches the same target counter', async () => {
     resetSshConnectionGenerations(71)
+    setSshConnectionGeneration(connId, 71 * sessionCounterStride)
     const stagedGeneration = advanceSshConnectionGeneration(connId)
     const sourcePath = path.resolve('/tmp/dropped/restart.txt')
     lstatMock.mockImplementation(async (candidate: string) => {
@@ -169,6 +183,7 @@ describe('fs:importExternalPaths — SSH operations', () => {
         throw enoent()
       }
       resetSshConnectionGenerations(72)
+      setSshConnectionGeneration(connId, 72 * sessionCounterStride)
       advanceSshConnectionGeneration(connId)
       return {
         size: 12,

--- a/src/main/ipc/filesystem-import-ssh-path-safety.test.ts
+++ b/src/main/ipc/filesystem-import-ssh-path-safety.test.ts
@@ -2,17 +2,19 @@ import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FileUploadSession, IFilesystemProvider } from '../providers/types'
 
-const { getConnMgrMock, lstatMock, providerMock, readdirMock, realpathMock } = vi.hoisted(() => ({
-  getConnMgrMock: vi.fn(),
-  lstatMock: vi.fn(),
-  providerMock: vi.fn(),
-  readdirMock: vi.fn(),
-  realpathMock: vi.fn()
-}))
+const { getConnMgrMock, lstatMock, opendirMock, providerMock, readdirMock, realpathMock } =
+  vi.hoisted(() => ({
+    getConnMgrMock: vi.fn(),
+    lstatMock: vi.fn(),
+    opendirMock: vi.fn(),
+    providerMock: vi.fn(),
+    readdirMock: vi.fn(),
+    realpathMock: vi.fn()
+  }))
 
 vi.mock('node:fs/promises', () => ({
   lstat: lstatMock,
-  readdir: readdirMock,
+  opendir: opendirMock,
   realpath: realpathMock
 }))
 vi.mock('./filesystem-auth', () => ({
@@ -25,6 +27,7 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 }))
 
 import { importExternalPathsSsh } from './filesystem-import-ssh'
+import { EXTERNAL_IMPORT_MAX_TREE_ENTRIES } from './filesystem-external-import-limits'
 
 function createProvider(uploadSession: FileUploadSession): IFilesystemProvider {
   const missing = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
@@ -54,6 +57,12 @@ describe('SSH import remote path safety', () => {
     provider = createProvider(uploadSession)
     providerMock.mockReturnValue(provider)
     readdirMock.mockResolvedValue([])
+    opendirMock.mockImplementation(async (directoryPath: string) => ({
+      async *[Symbol.asyncIterator]() {
+        yield* await readdirMock(directoryPath, { withFileTypes: true })
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    }))
     realpathMock.mockImplementation(async (value: string) => value)
   })
 
@@ -187,6 +196,47 @@ describe('SSH import remote path safety', () => {
         { exclusive: true }
       )
     }
+  })
+
+  it('rejects an oversized directory before creating the remote root', async () => {
+    const sourcePath = path.resolve('/tmp/generated')
+    let yieldedEntries = 0
+    let iteratorClosed = false
+    lstatMock.mockResolvedValue({
+      isFile: () => false,
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    })
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (yieldedEntries <= EXTERNAL_IMPORT_MAX_TREE_ENTRIES) {
+            const index = yieldedEntries
+            yieldedEntries += 1
+            yield {
+              name: `entry-${index}`,
+              isFile: () => true,
+              isDirectory: () => false,
+              isSymbolicLink: () => false
+            }
+          }
+        } finally {
+          iteratorClosed = true
+        }
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    })
+
+    const { results } = await importExternalPathsSsh([sourcePath], destDir, connectionId)
+
+    expect(results[0]).toMatchObject({
+      status: 'failed',
+      reason: 'External import tree exceeds 100,000 entries'
+    })
+    expect(yieldedEntries).toBe(EXTERNAL_IMPORT_MAX_TREE_ENTRIES + 1)
+    expect(iteratorClosed).toBe(true)
+    expect(provider.createDirNoClobber).not.toHaveBeenCalled()
+    expect(uploadSession.uploadFile).not.toHaveBeenCalled()
   })
 
   it('skips special entries without failing the directory import', async () => {

--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -11,7 +11,7 @@ const {
   realpathMock,
   copyFileMock,
   openMock,
-  readFileMock,
+  opendirMock,
   readdirMock,
   rmMock,
   unlinkMock
@@ -22,7 +22,7 @@ const {
   realpathMock: vi.fn(),
   copyFileMock: vi.fn(),
   openMock: vi.fn(),
-  readFileMock: vi.fn(),
+  opendirMock: vi.fn(),
   readdirMock: vi.fn(),
   rmMock: vi.fn(),
   unlinkMock: vi.fn()
@@ -40,13 +40,17 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
   realpath: realpathMock,
   copyFile: copyFileMock,
-  readFile: readFileMock,
-  readdir: readdirMock,
+  opendir: opendirMock,
   rm: rmMock,
   unlink: unlinkMock
 }))
 
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
+import {
+  EXTERNAL_IMPORT_MAX_SOURCE_PATHS,
+  EXTERNAL_IMPORT_MAX_TREE_ENTRIES,
+  REMOTE_IMPORT_MAX_FILE_BYTES
+} from './filesystem-external-import-limits'
 
 const REPO_PATH = path.resolve('/workspace/repo')
 const WORKSPACE_DIR = path.resolve('/workspace')
@@ -60,6 +64,24 @@ const store = {
 
 function enoent(): Error {
   return Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+}
+
+function streamDirectoryEntries(entries: unknown[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* entries
+    }
+  }
+}
+
+function createFileHandleRead(content: Buffer) {
+  return vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
+    const bytesRead = Math.min(length, Math.max(0, content.byteLength - position))
+    if (bytesRead > 0) {
+      content.copy(buffer, offset, position, position + bytesRead)
+    }
+    return { buffer, bytesRead }
+  })
 }
 
 describe('fs:importExternalPaths', () => {
@@ -158,7 +180,7 @@ describe('fs:importExternalPaths', () => {
     realpathMock.mockReset()
     copyFileMock.mockReset()
     openMock.mockReset()
-    readFileMock.mockReset()
+    opendirMock.mockReset()
     readdirMock.mockReset()
     rmMock.mockReset()
     unlinkMock.mockReset()
@@ -172,8 +194,10 @@ describe('fs:importExternalPaths', () => {
     mkdirMock.mockResolvedValue(undefined)
     copyFileMock.mockResolvedValue(undefined)
     mockLocalCopyOpenSuccess()
-    readFileMock.mockResolvedValue(Buffer.from('file-content'))
     readdirMock.mockResolvedValue([])
+    opendirMock.mockImplementation(async (dirPath: string) =>
+      streamDirectoryEntries(await readdirMock(dirPath))
+    )
     rmMock.mockResolvedValue(undefined)
     unlinkMock.mockResolvedValue(undefined)
 
@@ -384,6 +408,67 @@ describe('fs:importExternalPaths', () => {
     expect(copyFileMock).not.toHaveBeenCalled()
   })
 
+  it('stops streaming an oversized local tree before creating its destination', async () => {
+    const sourcePath = '/tmp/dropped/generated'
+    const resolvedSource = path.resolve(sourcePath)
+    let iteratorClosed = false
+    let yieldedEntries = 0
+    lstatMock.mockImplementation(async (candidatePath: string) => {
+      if (candidatePath === resolvedSource) {
+        return {
+          isFile: () => false,
+          isDirectory: () => true,
+          isSymbolicLink: () => false
+        }
+      }
+      throw enoent()
+    })
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (yieldedEntries <= EXTERNAL_IMPORT_MAX_TREE_ENTRIES) {
+            const index = yieldedEntries
+            yieldedEntries += 1
+            yield {
+              name: `entry-${index}`,
+              isDirectory: () => false,
+              isSymbolicLink: () => false,
+              isFile: () => true
+            }
+          }
+        } finally {
+          iteratorClosed = true
+        }
+      }
+    })
+
+    const result = (await handlers.get('fs:importExternalPaths')!(null, {
+      sourcePaths: [sourcePath],
+      destDir
+    })) as { results: { status: string; reason?: string }[] }
+
+    expect(result.results[0]).toMatchObject({
+      status: 'failed',
+      reason: 'External import tree exceeds 100,000 entries'
+    })
+    expect(yieldedEntries).toBe(EXTERNAL_IMPORT_MAX_TREE_ENTRIES + 1)
+    expect(iteratorClosed).toBe(true)
+    expect(mkdirMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized source batches before touching the filesystem', async () => {
+    const sourcePaths = Array.from(
+      { length: EXTERNAL_IMPORT_MAX_SOURCE_PATHS + 1 },
+      (_, index) => `/tmp/dropped/${index}`
+    )
+
+    await expect(
+      handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, { sourcePaths })
+    ).rejects.toThrow('External import accepts at most 256 source paths')
+    expect(lstatMock).not.toHaveBeenCalled()
+    expect(openMock).not.toHaveBeenCalled()
+  })
+
   it('fails and removes output if a local directory entry becomes a symlink after pre-scan', async () => {
     const sourcePath = '/tmp/dropped/mixeddir'
     const resolvedSource = path.resolve(sourcePath)
@@ -481,7 +566,7 @@ describe('fs:importExternalPaths', () => {
     lstatMock.mockImplementation(async (p: string) => {
       if (p === resolvedPath) {
         return {
-          size: 4,
+          size: 3,
           ino: 1,
           dev: 1,
           isFile: () => true,
@@ -492,15 +577,15 @@ describe('fs:importExternalPaths', () => {
       throw enoent()
     })
     const closeMock = vi.fn().mockResolvedValue(undefined)
-    const readFileHandleMock = vi.fn().mockResolvedValue(Buffer.from('png'))
+    const readFileHandleMock = createFileHandleRead(Buffer.from('png'))
     openMock.mockResolvedValue({
       stat: vi.fn().mockResolvedValue({
-        size: 4,
+        size: 3,
         ino: 1,
         dev: 1,
         isFile: () => true
       }),
-      readFile: readFileHandleMock,
+      read: readFileHandleMock,
       close: closeMock
     })
 
@@ -580,7 +665,7 @@ describe('fs:importExternalPaths', () => {
         dev: 1,
         isFile: () => true
       }),
-      readFile: vi.fn().mockResolvedValue(Buffer.from('icon')),
+      read: createFileHandleRead(Buffer.from('icon')),
       close: vi.fn().mockResolvedValue(undefined)
     })
 
@@ -637,16 +722,10 @@ describe('fs:importExternalPaths', () => {
     expect(openMock).not.toHaveBeenCalled()
   })
 
-  it('checks runtime upload directory byte budget before reading a file that exceeds the total cap', async () => {
+  it('checks the runtime upload file budget before opening an oversized entry', async () => {
     const sourcePath = '/tmp/dropped/project'
     const resolvedPath = path.resolve(sourcePath)
-    const filePaths = ['one.bin', 'two.bin', 'three.bin', 'four.bin', 'overflow.bin'].map((name) =>
-      path.join(resolvedPath, name)
-    )
-    const mib = 1024 * 1024
-    const regularSize = 25 * mib
-    const overflowSize = 1 * mib
-    const readFileMock = vi.fn().mockResolvedValue(Buffer.from('chunk'))
+    const oversizedPath = path.join(resolvedPath, 'oversized.bin')
 
     lstatMock.mockImplementation(async (p: string) => {
       if (p === resolvedPath) {
@@ -659,12 +738,10 @@ describe('fs:importExternalPaths', () => {
           isSymbolicLink: () => false
         }
       }
-      const fileIndex = filePaths.indexOf(p)
-      if (fileIndex !== -1) {
-        const size = fileIndex === filePaths.length - 1 ? overflowSize : regularSize
+      if (p === oversizedPath) {
         return {
-          size,
-          ino: fileIndex + 2,
+          size: REMOTE_IMPORT_MAX_FILE_BYTES + 1,
+          ino: 2,
           dev: 1,
           isFile: () => true,
           isDirectory: () => false,
@@ -673,30 +750,14 @@ describe('fs:importExternalPaths', () => {
       }
       throw enoent()
     })
-    readdirMock.mockResolvedValue(
-      filePaths.map((filePath) => ({
-        name: path.basename(filePath),
+    readdirMock.mockResolvedValue([
+      {
+        name: path.basename(oversizedPath),
         isDirectory: () => false,
         isSymbolicLink: () => false,
         isFile: () => true
-      }))
-    )
-    openMock.mockImplementation(async (p: string) => {
-      const fileIndex = filePaths.indexOf(p)
-      if (fileIndex >= 0 && fileIndex < filePaths.length - 1) {
-        return {
-          stat: vi.fn().mockResolvedValue({
-            size: regularSize,
-            ino: fileIndex + 2,
-            dev: 1,
-            isFile: () => true
-          }),
-          readFile: readFileMock,
-          close: vi.fn().mockResolvedValue(undefined)
-        }
       }
-      throw new Error(`unexpected open: ${p}`)
-    })
+    ])
 
     const result = (await handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, {
       sourcePaths: [sourcePath]
@@ -704,10 +765,9 @@ describe('fs:importExternalPaths', () => {
 
     expect(result.sources[0]).toMatchObject({
       status: 'failed',
-      reason: 'Remote import is too large'
+      reason: "'oversized.bin' is too large for remote import"
     })
-    expect(readFileMock).toHaveBeenCalledTimes(4)
-    expect(openMock).not.toHaveBeenCalledWith(filePaths.at(-1), expect.anything())
+    expect(openMock).not.toHaveBeenCalled()
   })
 
   it('fails runtime upload staging when a file changes between lstat and open', async () => {
@@ -726,7 +786,7 @@ describe('fs:importExternalPaths', () => {
       }
       throw enoent()
     })
-    const readFileHandleMock = vi.fn().mockResolvedValue(Buffer.from('png'))
+    const readFileHandleMock = createFileHandleRead(Buffer.from('png'))
     openMock.mockResolvedValue({
       stat: vi.fn().mockResolvedValue({
         size: 4,
@@ -734,7 +794,7 @@ describe('fs:importExternalPaths', () => {
         dev: 1,
         isFile: () => true
       }),
-      readFile: readFileHandleMock,
+      read: readFileHandleMock,
       close: vi.fn().mockResolvedValue(undefined)
     })
 

--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -48,6 +48,7 @@ vi.mock('fs/promises', () => ({
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
 import {
   EXTERNAL_IMPORT_MAX_SOURCE_PATHS,
+  EXTERNAL_IMPORT_MAX_TREE_DEPTH,
   EXTERNAL_IMPORT_MAX_TREE_ENTRIES,
   REMOTE_IMPORT_MAX_FILE_BYTES
 } from './filesystem-external-import-limits'
@@ -686,6 +687,45 @@ describe('fs:importExternalPaths', () => {
         ]
       }
     ])
+  })
+
+  // Why: the depth constant can be pinned by a unit test while the walker never consults it.
+  // Deleting assertExternalImportTreeDepth from the traversal keeps those tests green, so a
+  // deeply nested drop would recurse until the stack overflows. This drives the real walker.
+  it('fails a runtime upload staging whose tree is nested past the depth limit', async () => {
+    const sourcePath = '/tmp/dropped/deep'
+    const resolvedPath = path.resolve(sourcePath)
+    const overLimitDepth = EXTERNAL_IMPORT_MAX_TREE_DEPTH + 1
+    lstatMock.mockImplementation(async () => ({
+      size: 0,
+      ino: 1,
+      dev: 1,
+      isFile: () => false,
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    }))
+    // Every level holds one directory, so the walk only terminates at the depth ceiling.
+    readdirMock.mockImplementation(async (p: string) =>
+      path.relative(resolvedPath, p).split(path.sep).filter(Boolean).length < overLimitDepth
+        ? [
+            {
+              name: 'nested',
+              isDirectory: () => true,
+              isSymbolicLink: () => false,
+              isFile: () => false
+            }
+          ]
+        : []
+    )
+
+    const result = (await handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, {
+      sourcePaths: [sourcePath]
+    })) as { sources: { status: string; reason?: string }[] }
+
+    expect(result.sources[0]).toMatchObject({
+      status: 'failed',
+      reason: 'External import tree exceeds 256 nested directory levels'
+    })
   })
 
   it('skips runtime upload directories with nested symlinks during the staging traversal', async () => {

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -7,7 +7,7 @@ import {
   lstat,
   mkdir,
   open,
-  readdir,
+  opendir,
   realpath,
   rename,
   rm,
@@ -24,6 +24,19 @@ import { importExternalPathsSsh } from './filesystem-import-ssh'
 import { assertNoClobberRenameDestinationAvailable } from '../../shared/filesystem-rename-collision'
 import type { SshMutationExpectation } from '../../shared/ssh-types'
 import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
+import { readStableRuntimeUploadFile } from './filesystem-runtime-upload-file-reader'
+import {
+  admitExternalImportTreeEntry,
+  assertExternalImportSourcePaths,
+  assertExternalImportTreeDepth,
+  assertRuntimeUploadFileFits,
+  captureRuntimeUploadRetentionCheckpoint,
+  createExternalImportTreeBudget,
+  createRuntimeUploadRetentionBudget,
+  restoreRuntimeUploadRetentionCheckpoint,
+  retainRuntimeUploadFileBytes,
+  type RuntimeUploadRetentionBudget
+} from './filesystem-external-import-limits'
 
 /**
  * Re-throw filesystem errors with user-friendly messages.
@@ -201,6 +214,7 @@ export function registerFilesystemMutationHandlers(store: Store): void {
         args.expectedSshConnectionGeneration,
         args.expectedExecutionHostId
       )
+      assertExternalImportSourcePaths(args.sourcePaths)
       if (args.connectionId) {
         return importExternalPathsSsh(args.sourcePaths, args.destDir, args.connectionId, {
           ensureDir: args.ensureDir,
@@ -242,8 +256,10 @@ export function registerFilesystemMutationHandlers(store: Store): void {
       args: { sourcePaths: string[] }
     ): Promise<{ sources: StagedExternalImportSource[] }> => {
       const sources: StagedExternalImportSource[] = []
+      assertExternalImportSourcePaths(args.sourcePaths)
+      const retentionBudget = createRuntimeUploadRetentionBudget()
       for (const sourcePath of args.sourcePaths) {
-        sources.push(await stageOneSourceForRuntimeUpload(sourcePath))
+        sources.push(await stageOneSourceForRuntimeUpload(sourcePath, retentionBudget))
       }
       return { sources }
     }
@@ -271,6 +287,7 @@ export function registerFilesystemMutationHandlers(store: Store): void {
         args.expectedSshConnectionGeneration,
         args.expectedExecutionHostId
       )
+      assertExternalImportSourcePaths(args.paths)
       // Why: `== null` (not `!args.connectionId`) so an empty string is
       // treated as a renderer error, not silently routed to the local branch.
       if (args.connectionId == null) {
@@ -362,9 +379,6 @@ export type StagedExternalImportEntry =
   | { relativePath: string; kind: 'directory' }
   | { relativePath: string; kind: 'file'; contentBase64: string }
 
-const REMOTE_IMPORT_MAX_FILE_BYTES = 25 * 1024 * 1024
-const REMOTE_IMPORT_MAX_TOTAL_BYTES = 100 * 1024 * 1024
-
 class RuntimeUploadSymlinkError extends Error {}
 
 // ─── External Import Implementation ─────────────────────────────────
@@ -425,9 +439,17 @@ async function importOneSource(
   // creating any destination files. This prevents partially imported
   // trees when a symlink is discovered halfway through recursive copy.
   if (isDir) {
-    const hasSymlink = await preScanForSymlinks(resolvedSource)
-    if (hasSymlink) {
-      return { sourcePath, status: 'skipped', reason: 'symlink' }
+    try {
+      const hasSymlink = await preScanForSymlinks(resolvedSource)
+      if (hasSymlink) {
+        return { sourcePath, status: 'skipped', reason: 'symlink' }
+      }
+    } catch (error) {
+      return {
+        sourcePath,
+        status: 'failed',
+        reason: error instanceof Error ? error.message : String(error)
+      }
     }
   }
 
@@ -462,7 +484,8 @@ async function importOneSource(
 }
 
 async function stageOneSourceForRuntimeUpload(
-  sourcePath: string
+  sourcePath: string,
+  retentionBudget: RuntimeUploadRetentionBudget
 ): Promise<StagedExternalImportSource> {
   const resolvedSource = resolve(sourcePath)
 
@@ -498,10 +521,15 @@ async function stageOneSourceForRuntimeUpload(
   if (!sourceStat.isFile() && !sourceStat.isDirectory()) {
     return { sourcePath, status: 'skipped', reason: 'unsupported' }
   }
+  const checkpoint = captureRuntimeUploadRetentionCheckpoint(retentionBudget)
   try {
-    const entries = sourceStat.isDirectory()
-      ? await stageDirectoryEntries(resolvedSource)
-      : [(await stageFileEntry(resolvedSource, '')).entry]
+    let entries: StagedExternalImportEntry[]
+    if (sourceStat.isDirectory()) {
+      entries = await stageDirectoryEntries(resolvedSource, retentionBudget)
+    } else {
+      admitExternalImportTreeEntry(retentionBudget.tree, '', true)
+      entries = [await stageFileEntry(resolvedSource, '', { retentionBudget })]
+    }
     return {
       sourcePath,
       status: 'staged',
@@ -510,6 +538,7 @@ async function stageOneSourceForRuntimeUpload(
       entries
     }
   } catch (error) {
+    restoreRuntimeUploadRetentionCheckpoint(retentionBudget, checkpoint)
     if (error instanceof RuntimeUploadSymlinkError) {
       return { sourcePath, status: 'skipped', reason: 'symlink' }
     }
@@ -521,61 +550,61 @@ async function stageOneSourceForRuntimeUpload(
   }
 }
 
-async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalImportEntry[]> {
+async function stageDirectoryEntries(
+  rootPath: string,
+  retentionBudget: RuntimeUploadRetentionBudget
+): Promise<StagedExternalImportEntry[]> {
+  admitExternalImportTreeEntry(retentionBudget.tree, '', true)
   const entries: StagedExternalImportEntry[] = [{ relativePath: '', kind: 'directory' }]
-  let totalBytes = 0
   const rootRealPath = await realpath(rootPath)
 
-  async function visit(dirPath: string): Promise<void> {
+  async function visit(dirPath: string, depth: number): Promise<void> {
+    assertExternalImportTreeDepth(depth)
     const dirStat = await lstat(dirPath)
+    const dirRelativePath = normalizeRelativeUploadPath(relative(rootPath, dirPath))
     if (dirStat.isSymbolicLink()) {
-      throw new RuntimeUploadSymlinkError(
-        `Symlink not allowed in '${normalizeRelativeUploadPath(relative(rootPath, dirPath))}'`
-      )
+      throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${dirRelativePath}'`)
     }
     if (!dirStat.isDirectory()) {
-      throw new Error(
-        `Unsupported file type in '${normalizeRelativeUploadPath(relative(rootPath, dirPath))}'`
-      )
+      throw new Error(`Unsupported file type in '${dirRelativePath}'`)
     }
-    await assertRealPathInsideRoot(
-      rootRealPath,
-      dirPath,
-      normalizeRelativeUploadPath(relative(rootPath, dirPath))
-    )
-    const dirEntries = await readdir(dirPath, { withFileTypes: true })
-    for (const entry of dirEntries) {
+    await assertRealPathInsideRoot(rootRealPath, dirPath, dirRelativePath)
+    const directory = await opendir(dirPath)
+    for await (const entry of directory) {
       const childPath = join(dirPath, entry.name)
       const childRelativePath = normalizeRelativeUploadPath(relative(rootPath, childPath))
       if (entry.isSymbolicLink()) {
         throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${childRelativePath}'`)
       }
       if (entry.isDirectory()) {
+        assertExternalImportTreeDepth(depth + 1)
+        admitExternalImportTreeEntry(retentionBudget.tree, childRelativePath, true)
         entries.push({ relativePath: childRelativePath, kind: 'directory' })
-        await visit(childPath)
+        await visit(childPath, depth + 1)
         continue
       }
       if (!entry.isFile()) {
         throw new Error(`Unsupported file type in '${childRelativePath}'`)
       }
-      const stagedFile = await stageFileEntry(childPath, childRelativePath, {
-        rootRealPath,
-        totalBytesBefore: totalBytes
-      })
-      totalBytes += stagedFile.byteLength
-      entries.push(stagedFile.entry)
+      admitExternalImportTreeEntry(retentionBudget.tree, childRelativePath, true)
+      entries.push(
+        await stageFileEntry(childPath, childRelativePath, {
+          rootRealPath,
+          retentionBudget
+        })
+      )
     }
   }
 
-  await visit(rootPath)
+  await visit(rootPath, 0)
   return entries
 }
 
 async function stageFileEntry(
   filePath: string,
   relativePath: string,
-  options?: { rootRealPath?: string; totalBytesBefore?: number }
-): Promise<{ entry: StagedExternalImportEntry; byteLength: number }> {
+  options: { retentionBudget: RuntimeUploadRetentionBudget; rootRealPath?: string }
+): Promise<StagedExternalImportEntry> {
   const statResult = await lstat(filePath)
   const displayPath = normalizeRelativeUploadPath(relativePath)
   if (statResult.isSymbolicLink()) {
@@ -587,11 +616,7 @@ async function stageFileEntry(
   if (options?.rootRealPath) {
     await assertRealPathInsideRoot(options.rootRealPath, filePath, displayPath)
   }
-  const initialTotalBytes =
-    options?.totalBytesBefore === undefined
-      ? statResult.size
-      : options.totalBytesBefore + statResult.size
-  assertRemoteUploadBudget(relativePath, statResult.size, initialTotalBytes)
+  assertRuntimeUploadFileFits(options.retentionBudget, displayPath, statResult.size)
   const fileHandle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
   try {
     const openedStat = await fileHandle.stat()
@@ -605,23 +630,17 @@ async function stageFileEntry(
     ) {
       throw new Error(`File changed during upload staging: '${displayPath}'`)
     }
-    const totalBytes =
-      options?.totalBytesBefore === undefined
-        ? openedStat.size
-        : options.totalBytesBefore + openedStat.size
-    assertRemoteUploadBudget(relativePath, openedStat.size, totalBytes)
-    const buffer = await fileHandle.readFile()
+    assertRuntimeUploadFileFits(options.retentionBudget, displayPath, openedStat.size)
+    const buffer = await readStableRuntimeUploadFile(fileHandle, openedStat.size, displayPath)
     const afterReadStat = await fileHandle.stat()
     if (afterReadStat.size !== openedStat.size) {
       throw new Error(`File changed during upload staging: '${displayPath}'`)
     }
+    retainRuntimeUploadFileBytes(options.retentionBudget, displayPath, buffer.byteLength)
     return {
-      entry: {
-        relativePath: displayPath,
-        kind: 'file',
-        contentBase64: buffer.toString('base64')
-      },
-      byteLength: openedStat.size
+      relativePath: displayPath,
+      kind: 'file',
+      contentBase64: buffer.toString('base64')
     }
   } finally {
     await fileHandle.close()
@@ -644,19 +663,6 @@ async function assertRealPathInsideRoot(
   }
 }
 
-function assertRemoteUploadBudget(
-  relativePath: string,
-  fileBytes: number,
-  totalBytes: number
-): void {
-  if (fileBytes > REMOTE_IMPORT_MAX_FILE_BYTES) {
-    throw new Error(`'${relativePath}' is too large for remote import`)
-  }
-  if (totalBytes > REMOTE_IMPORT_MAX_TOTAL_BYTES) {
-    throw new Error('Remote import is too large')
-  }
-}
-
 function normalizeRelativeUploadPath(path: string): string {
   return path.replace(/[\\/]+/g, '/').replace(/^\/+/, '')
 }
@@ -666,19 +672,40 @@ function normalizeRelativeUploadPath(path: string): string {
  * is found anywhere in the subtree.
  */
 async function preScanForSymlinks(dirPath: string): Promise<boolean> {
-  const entries = await readdir(dirPath, { withFileTypes: true })
-  for (const entry of entries) {
-    if (entry.isSymbolicLink()) {
+  const budget = createExternalImportTreeBudget()
+
+  async function visit(
+    currentDirPath: string,
+    relativeDirPath: string,
+    depth: number
+  ): Promise<boolean> {
+    assertExternalImportTreeDepth(depth)
+    const currentStat = await lstat(currentDirPath)
+    if (currentStat.isSymbolicLink()) {
       return true
     }
-    if (entry.isDirectory()) {
-      const childPath = join(dirPath, entry.name)
-      if (await preScanForSymlinks(childPath)) {
+    if (!currentStat.isDirectory()) {
+      throw new Error(`Unsupported file type in '${relativeDirPath}'`)
+    }
+
+    const directory = await opendir(currentDirPath)
+    for await (const entry of directory) {
+      const childRelativePath = join(relativeDirPath, entry.name)
+      admitExternalImportTreeEntry(budget, childRelativePath, false)
+      if (entry.isSymbolicLink()) {
         return true
       }
+      if (entry.isDirectory()) {
+        assertExternalImportTreeDepth(depth + 1)
+        if (await visit(join(currentDirPath, entry.name), childRelativePath, depth + 1)) {
+          return true
+        }
+      }
     }
+    return false
   }
-  return false
+
+  return visit(dirPath, '', 0)
 }
 
 /**
@@ -687,24 +714,47 @@ async function preScanForSymlinks(dirPath: string): Promise<boolean> {
  * buffering entire files into memory.
  */
 async function recursiveCopyDir(srcDir: string, destDir: string): Promise<void> {
-  await mkdir(destDir, { recursive: false })
-  const entries = await readdir(srcDir, { withFileTypes: true })
-  for (const entry of entries) {
-    const srcPath = join(srcDir, entry.name)
-    const dstPath = join(destDir, entry.name)
-    const statResult = await lstat(srcPath)
-    if (statResult.isSymbolicLink()) {
-      throw new Error(`Symlink not allowed in '${entry.name}'`)
+  const budget = createExternalImportTreeBudget()
+
+  async function copyDirectory(
+    currentSrcDir: string,
+    currentDestDir: string,
+    relativeDirPath: string,
+    depth: number
+  ): Promise<void> {
+    assertExternalImportTreeDepth(depth)
+    const dirStat = await lstat(currentSrcDir)
+    if (dirStat.isSymbolicLink()) {
+      throw new Error(`Symlink not allowed in '${relativeDirPath}'`)
     }
-    if (statResult.isDirectory()) {
-      await recursiveCopyDir(srcPath, dstPath)
-      continue
+    if (!dirStat.isDirectory()) {
+      throw new Error(`Unsupported file type in '${relativeDirPath}'`)
     }
-    if (!statResult.isFile()) {
-      throw new Error(`Unsupported file type in '${entry.name}'`)
+    await mkdir(currentDestDir, { recursive: false })
+
+    const directory = await opendir(currentSrcDir)
+    for await (const entry of directory) {
+      const srcPath = join(currentSrcDir, entry.name)
+      const dstPath = join(currentDestDir, entry.name)
+      const childRelativePath = join(relativeDirPath, entry.name)
+      admitExternalImportTreeEntry(budget, childRelativePath, false)
+      const statResult = await lstat(srcPath)
+      if (statResult.isSymbolicLink()) {
+        throw new Error(`Symlink not allowed in '${childRelativePath}'`)
+      }
+      if (statResult.isDirectory()) {
+        assertExternalImportTreeDepth(depth + 1)
+        await copyDirectory(srcPath, dstPath, childRelativePath, depth + 1)
+        continue
+      }
+      if (!statResult.isFile()) {
+        throw new Error(`Unsupported file type in '${childRelativePath}'`)
+      }
+      await copyLocalFileNoFollow(srcPath, dstPath, statResult)
     }
-    await copyLocalFileNoFollow(srcPath, dstPath, statResult)
   }
+
+  await copyDirectory(srcDir, destDir, '', 0)
 }
 
 async function copyLocalFileNoFollow(

--- a/src/main/ipc/filesystem-runtime-upload-file-reader.test.ts
+++ b/src/main/ipc/filesystem-runtime-upload-file-reader.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readStableRuntimeUploadFile } from './filesystem-runtime-upload-file-reader'
+
+function createRead(content: Buffer, maxBytesPerRead = content.byteLength) {
+  return vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
+    const bytesRead = Math.min(length, maxBytesPerRead, Math.max(0, content.byteLength - position))
+    if (bytesRead > 0) {
+      content.copy(buffer, offset, position, position + bytesRead)
+    }
+    return { buffer, bytesRead }
+  })
+}
+
+describe('runtime upload file reader', () => {
+  it('preserves an exact-size file across partial reads', async () => {
+    const content = Buffer.from('bounded-content')
+    const read = createRead(content, 3)
+
+    await expect(
+      readStableRuntimeUploadFile({ read }, content.byteLength, 'asset.bin')
+    ).resolves.toEqual(content)
+    expect(read).toHaveBeenLastCalledWith(expect.any(Buffer), 0, 1, content.byteLength)
+  })
+
+  it('rejects a file that becomes shorter without exposing uninitialized bytes', async () => {
+    const content = Buffer.from('short')
+
+    await expect(
+      readStableRuntimeUploadFile({ read: createRead(content) }, content.byteLength + 1, '')
+    ).rejects.toThrow("File changed during upload staging: ''")
+  })
+
+  it('uses a one-byte probe and rejects growth beyond the admitted size', async () => {
+    const content = Buffer.from('growth')
+    const admittedBytes = content.byteLength - 1
+    const read = createRead(content)
+
+    await expect(
+      readStableRuntimeUploadFile({ read }, admittedBytes, 'growth.bin')
+    ).rejects.toThrow("File changed during upload staging: 'growth.bin'")
+    expect(read).toHaveBeenNthCalledWith(1, expect.any(Buffer), 0, admittedBytes, 0)
+    expect(read).toHaveBeenNthCalledWith(2, expect.any(Buffer), 0, 1, admittedBytes)
+  })
+})

--- a/src/main/ipc/filesystem-runtime-upload-file-reader.ts
+++ b/src/main/ipc/filesystem-runtime-upload-file-reader.ts
@@ -1,0 +1,33 @@
+type RuntimeUploadFileHandle = {
+  read(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number
+  ): Promise<{ bytesRead: number }>
+}
+
+export async function readStableRuntimeUploadFile(
+  fileHandle: RuntimeUploadFileHandle,
+  expectedBytes: number,
+  displayPath: string
+): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(expectedBytes)
+  let offset = 0
+  while (offset < expectedBytes) {
+    const { bytesRead } = await fileHandle.read(buffer, offset, expectedBytes - offset, offset)
+    if (bytesRead === 0) {
+      throw fileChangedError(displayPath)
+    }
+    offset += bytesRead
+  }
+  const probe = Buffer.allocUnsafe(1)
+  if ((await fileHandle.read(probe, 0, 1, offset)).bytesRead !== 0) {
+    throw fileChangedError(displayPath)
+  }
+  return buffer
+}
+
+function fileChangedError(displayPath: string): Error {
+  return new Error(`File changed during upload staging: '${displayPath}'`)
+}

--- a/src/main/ipc/speech-ipc-admission.ts
+++ b/src/main/ipc/speech-ipc-admission.ts
@@ -1,0 +1,152 @@
+import { measureUtf8ByteLength } from '../../shared/memory-safety/utf8-byte-limits'
+
+export const MAX_SPEECH_AUDIO_CHUNK_BYTES = 1024 * 1024
+export const MAX_SPEECH_HOTWORDS = 256
+export const MAX_SPEECH_HOTWORD_BYTES = 4 * 1024
+export const MAX_SPEECH_HOTWORDS_TOTAL_BYTES = 256 * 1024
+export const MAX_SPEECH_SESSION_ID_BYTES = 1024
+export const MAX_SPEECH_MODEL_ID_BYTES = 1024
+export const MAX_SPEECH_OPENAI_API_KEY_BYTES = 64 * 1024
+export const MAX_PENDING_DESKTOP_DICTATION_STARTS = 16
+export const MAX_ACTIVE_DESKTOP_DICTATION_LISTENERS = 16
+
+const MIN_SPEECH_SAMPLE_RATE = 8_000
+const MAX_SPEECH_SAMPLE_RATE = 384_000
+const HOTWORD_LINE_SUFFIX = ' :2.0\n'
+
+export type DesktopDictationListener = { release: () => void }
+
+function requireBoundedString(
+  value: unknown,
+  name: string,
+  maxBytes: number,
+  options: { allowEmpty?: boolean } = {}
+): string {
+  if (
+    typeof value !== 'string' ||
+    (!options.allowEmpty && value.length === 0) ||
+    measureUtf8ByteLength(value, { stopAfterBytes: maxBytes }).exceededLimit
+  ) {
+    throw new Error(`Invalid ${name}`)
+  }
+  return value
+}
+
+export function validateSpeechSessionId(value: unknown): string {
+  return requireBoundedString(
+    value === undefined ? 'desktop' : value,
+    'speech session id',
+    MAX_SPEECH_SESSION_ID_BYTES
+  )
+}
+
+export function validateSpeechModelId(value: unknown): string {
+  return requireBoundedString(value, 'speech model id', MAX_SPEECH_MODEL_ID_BYTES)
+}
+
+export function validateOpenAiSpeechApiKey(value: unknown): string {
+  return requireBoundedString(value, 'OpenAI speech API key', MAX_SPEECH_OPENAI_API_KEY_BYTES)
+}
+
+export function buildSpeechHotwordsContent(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  if (!Array.isArray(value) || value.length > MAX_SPEECH_HOTWORDS) {
+    throw new Error('Invalid speech hotwords')
+  }
+  const lines: string[] = []
+  let retainedBytes = 0
+  for (const hotword of value) {
+    const text = requireBoundedString(hotword, 'speech hotword', MAX_SPEECH_HOTWORD_BYTES, {
+      allowEmpty: true
+    })
+    const lineBytes = measureUtf8ByteLength(text).byteLength + HOTWORD_LINE_SUFFIX.length
+    if (lineBytes > MAX_SPEECH_HOTWORDS_TOTAL_BYTES - retainedBytes) {
+      throw new Error('Speech hotwords are too large')
+    }
+    retainedBytes += lineBytes
+    lines.push(`${text}${HOTWORD_LINE_SUFFIX}`)
+  }
+  return lines.length > 0 ? lines.join('') : undefined
+}
+
+export function decodeSpeechAudioChunk(
+  value: unknown,
+  sampleRate: unknown
+): { samples: Float32Array; sampleRate: number } {
+  if (
+    !(value instanceof Uint8Array) ||
+    value.byteLength === 0 ||
+    value.byteLength > MAX_SPEECH_AUDIO_CHUNK_BYTES ||
+    value.byteLength % Float32Array.BYTES_PER_ELEMENT !== 0
+  ) {
+    throw new Error('Invalid speech audio chunk')
+  }
+  if (
+    typeof sampleRate !== 'number' ||
+    !Number.isFinite(sampleRate) ||
+    sampleRate < MIN_SPEECH_SAMPLE_RATE ||
+    sampleRate > MAX_SPEECH_SAMPLE_RATE
+  ) {
+    throw new Error('Invalid speech sample rate')
+  }
+  // Why: worker transfer moves the whole backing buffer; own only the admitted view.
+  const ownedBytes = new Uint8Array(value.byteLength)
+  ownedBytes.set(value)
+  return { samples: new Float32Array(ownedBytes.buffer), sampleRate }
+}
+
+export class SpeechIpcAdmission {
+  private readonly pendingStarts = new Set<string>()
+  private readonly activeListeners = new Map<string, DesktopDictationListener>()
+
+  claimStart(owner: string): void {
+    if (
+      this.pendingStarts.has(owner) ||
+      this.pendingStarts.size >= MAX_PENDING_DESKTOP_DICTATION_STARTS
+    ) {
+      throw new Error('Too many pending speech dictation starts')
+    }
+    this.pendingStarts.add(owner)
+  }
+
+  releaseStart(owner: string): void {
+    this.pendingStarts.delete(owner)
+  }
+
+  commitListener(owner: string, listener: DesktopDictationListener): void {
+    const previous = this.activeListeners.get(owner)
+    if (!previous && this.activeListeners.size >= MAX_ACTIVE_DESKTOP_DICTATION_LISTENERS) {
+      this.activeListeners.values().next().value?.release()
+    }
+    this.activeListeners.set(owner, listener)
+    previous?.release()
+  }
+
+  deleteListenerIfCurrent(owner: string, listener: DesktopDictationListener): void {
+    if (this.activeListeners.get(owner) === listener) {
+      this.activeListeners.delete(owner)
+    }
+  }
+
+  releaseListener(owner: string): void {
+    this.activeListeners.get(owner)?.release()
+  }
+
+  reset(): void {
+    this.pendingStarts.clear()
+    for (const listener of Array.from(this.activeListeners.values())) {
+      listener.release()
+    }
+    this.activeListeners.clear()
+  }
+
+  get pendingStartCount(): number {
+    return this.pendingStarts.size
+  }
+
+  get activeListenerCount(): number {
+    return this.activeListeners.size
+  }
+}

--- a/src/main/ipc/speech-ipc-admission.ts
+++ b/src/main/ipc/speech-ipc-admission.ts
@@ -14,7 +14,11 @@ const MIN_SPEECH_SAMPLE_RATE = 8_000
 const MAX_SPEECH_SAMPLE_RATE = 384_000
 const HOTWORD_LINE_SUFFIX = ' :2.0\n'
 
-export type DesktopDictationListener = { release: () => void }
+/**
+ * `release` detaches bookkeeping for a session that is already finished. `evict` must also
+ * stop the underlying dictation, because the cap can reclaim a session that is still running.
+ */
+export type DesktopDictationListener = { release: () => void; evict: () => void }
 
 function requireBoundedString(
   value: unknown,
@@ -118,9 +122,24 @@ export class SpeechIpcAdmission {
   commitListener(owner: string, listener: DesktopDictationListener): void {
     const previous = this.activeListeners.get(owner)
     if (!previous && this.activeListeners.size >= MAX_ACTIVE_DESKTOP_DICTATION_LISTENERS) {
-      this.activeListeners.values().next().value?.release()
+      // Why: the evicted session's microphone is still live. Dropping only the map entry
+      // would leave it recording with nothing left that can stop it, and no 'stopped'
+      // event — the renderer would wait on a transcript that never arrives.
+      const [evictedOwner, evicted] = this.activeListeners.entries().next().value ?? []
+      if (typeof evictedOwner === 'string') {
+        this.activeListeners.delete(evictedOwner)
+        // Why: a failed stop must not block admitting the session that displaced it,
+        // or one wedged session would deny dictation to everyone behind it.
+        try {
+          evicted?.evict()
+        } catch {
+          // Best effort: the entry is gone, so the cap is honored regardless.
+        }
+      }
     }
     this.activeListeners.set(owner, listener)
+    // Not `evict`: a same-owner replacement shares the dictation the new listener just
+    // committed, so stopping it here would stop the session that is replacing it.
     previous?.release()
   }
 
@@ -136,10 +155,17 @@ export class SpeechIpcAdmission {
 
   reset(): void {
     this.pendingStarts.clear()
-    for (const listener of Array.from(this.activeListeners.values())) {
-      listener.release()
-    }
+    const listeners = Array.from(this.activeListeners.values())
     this.activeListeners.clear()
+    for (const listener of listeners) {
+      // Why: reset runs during teardown, when the speech service may already be gone.
+      // One session failing to stop must not strand the sessions after it in the list.
+      try {
+        listener.evict()
+      } catch {
+        // Best effort: the map is already cleared, so nothing is retained either way.
+      }
+    }
   }
 
   get pendingStartCount(): number {

--- a/src/main/ipc/speech.test.ts
+++ b/src/main/ipc/speech.test.ts
@@ -43,17 +43,45 @@ vi.mock('../speech/speech-model-deletion', () => ({
   deleteLocalSpeechModel: deleteLocalSpeechModelMock
 }))
 
-import { registerSpeechHandlers } from './speech'
+import {
+  clearSpeechIpcAdmissionForTests,
+  getActiveDesktopDictationListenerCountForTest,
+  getPendingDesktopDictationStartCountForTest,
+  registerSpeechHandlers
+} from './speech'
+import {
+  MAX_PENDING_DESKTOP_DICTATION_STARTS,
+  MAX_SPEECH_AUDIO_CHUNK_BYTES,
+  MAX_SPEECH_HOTWORD_BYTES,
+  MAX_SPEECH_HOTWORDS,
+  MAX_SPEECH_SESSION_ID_BYTES
+} from './speech-ipc-admission'
 
 type SpeechDownloadHandler = (event: { sender: { id: number } }, modelId: string) => Promise<void>
 
-function getHandler(channel: string): SpeechDownloadHandler {
+function getHandler<T = SpeechDownloadHandler>(channel: string): T {
   const call = handleMock.mock.calls.find((entry) => entry[0] === channel)
   if (!call) {
     throw new Error(`${channel} handler not registered`)
   }
-  return call[1] as SpeechDownloadHandler
+  return call[1] as T
 }
+
+type SpeechFeedHandler = (
+  event: { sender: { id: number } },
+  buffer: Uint8Array,
+  sampleRate: number,
+  sessionId?: string
+) => Promise<void>
+
+type SpeechStartHandler = (
+  event: { sender: { id: number } },
+  modelId: string,
+  hotwords?: string[],
+  sessionId?: string
+) => Promise<void>
+
+type SpeechStopHandler = (event: { sender: { id: number } }, sessionId?: string) => Promise<void>
 
 describe('registerSpeechHandlers', () => {
   beforeEach(() => {
@@ -62,6 +90,7 @@ describe('registerSpeechHandlers', () => {
     getSpeechModelManagerMock.mockReset()
     getSpeechSttServiceMock.mockReset()
     deleteLocalSpeechModelMock.mockReset()
+    clearSpeechIpcAdmissionForTests()
   })
 
   it('clears the model download progress callback after completion', async () => {
@@ -155,5 +184,152 @@ describe('registerSpeechHandlers', () => {
       sttService,
       modelId: 'model-1'
     })
+  })
+
+  it('rejects oversized or malformed audio chunks before reaching the STT service', async () => {
+    const feedAudio = vi.fn()
+    getSpeechSttServiceMock.mockReturnValue({ feedAudio })
+    registerSpeechHandlers({} as never)
+    const handler = getHandler<SpeechFeedHandler>('speech:feedAudio')
+
+    await expect(
+      handler(
+        { sender: { id: 7 } },
+        new Uint8Array(MAX_SPEECH_AUDIO_CHUNK_BYTES + 4),
+        48_000,
+        'session'
+      )
+    ).rejects.toThrow('Invalid speech audio chunk')
+    await expect(
+      handler({ sender: { id: 7 } }, new Uint8Array(3), 48_000, 'session')
+    ).rejects.toThrow('Invalid speech audio chunk')
+    expect(feedAudio).not.toHaveBeenCalled()
+  })
+
+  it('copies an admitted audio view into an exact-size transferable buffer', async () => {
+    const feedAudio = vi.fn()
+    getSpeechSttServiceMock.mockReturnValue({ feedAudio })
+    registerSpeechHandlers({} as never)
+    const handler = getHandler<SpeechFeedHandler>('speech:feedAudio')
+    const oversizedBacking = new Uint8Array(MAX_SPEECH_AUDIO_CHUNK_BYTES + 128)
+    const admittedView = oversizedBacking.subarray(64, 64 + MAX_SPEECH_AUDIO_CHUNK_BYTES)
+
+    await handler({ sender: { id: 8 } }, admittedView, 48_000, 'session')
+
+    const samples = feedAudio.mock.calls[0]?.[0] as Float32Array
+    expect(samples.byteLength).toBe(MAX_SPEECH_AUDIO_CHUNK_BYTES)
+    expect(samples.buffer.byteLength).toBe(MAX_SPEECH_AUDIO_CHUNK_BYTES)
+    expect(feedAudio).toHaveBeenCalledWith(samples, 48_000, 'desktop:8:session')
+  })
+
+  it.each([
+    ['count', Array.from({ length: MAX_SPEECH_HOTWORDS + 1 }, () => 'word')],
+    ['per-word bytes', ['😀'.repeat(Math.floor(MAX_SPEECH_HOTWORD_BYTES / 4) + 1)]],
+    ['aggregate bytes', Array.from({ length: 64 }, () => 'x'.repeat(MAX_SPEECH_HOTWORD_BYTES))]
+  ])('rejects hotword %s overflow before window or service retention', async (_label, hotwords) => {
+    registerSpeechHandlers({} as never)
+    const handler = getHandler<SpeechStartHandler>('speech:startDictation')
+
+    await expect(handler({ sender: { id: 9 } }, 'model-1', hotwords, 'session')).rejects.toThrow(
+      /hotword/i
+    )
+    expect(fromWebContentsMock).not.toHaveBeenCalled()
+    expect(getSpeechSttServiceMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized session ids for start, feed, and stop before service work', async () => {
+    registerSpeechHandlers({} as never)
+    const oversizedSession = '😀'.repeat(Math.floor(MAX_SPEECH_SESSION_ID_BYTES / 4) + 1)
+
+    await expect(
+      getHandler<SpeechStartHandler>('speech:startDictation')(
+        { sender: { id: 10 } },
+        'model-1',
+        undefined,
+        oversizedSession
+      )
+    ).rejects.toThrow('Invalid speech session id')
+    await expect(
+      getHandler<SpeechFeedHandler>('speech:feedAudio')(
+        { sender: { id: 10 } },
+        new Uint8Array(4),
+        16_000,
+        oversizedSession
+      )
+    ).rejects.toThrow('Invalid speech session id')
+    await expect(
+      getHandler<SpeechStopHandler>('speech:stopDictation')(
+        { sender: { id: 10 } },
+        oversizedSession
+      )
+    ).rejects.toThrow('Invalid speech session id')
+    expect(getSpeechSttServiceMock).not.toHaveBeenCalled()
+  })
+
+  it('caps concurrent desktop dictation starts and releases admission after settlement', async () => {
+    let resolveStarts = (): void => {}
+    const startGate = new Promise<void>((resolve) => {
+      resolveStarts = resolve
+    })
+    const startDictation = vi.fn(() => startGate)
+    getSpeechSttServiceMock.mockReturnValue({ startDictation, stopDictation: vi.fn() })
+    fromWebContentsMock.mockImplementation((sender: { id: number }) => ({
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
+      once: vi.fn(),
+      off: vi.fn(),
+      sender
+    }))
+    registerSpeechHandlers({} as never)
+    const handler = getHandler<SpeechStartHandler>('speech:startDictation')
+    const starts = Array.from({ length: MAX_PENDING_DESKTOP_DICTATION_STARTS }, (_, index) =>
+      handler({ sender: { id: 100 + index } }, 'model-1', undefined, 'session')
+    )
+
+    await vi.waitFor(() =>
+      expect(getPendingDesktopDictationStartCountForTest()).toBe(
+        MAX_PENDING_DESKTOP_DICTATION_STARTS
+      )
+    )
+    await expect(handler({ sender: { id: 999 } }, 'model-1', undefined, 'session')).rejects.toThrow(
+      'Too many pending speech dictation starts'
+    )
+    resolveStarts()
+    await Promise.all(starts)
+
+    expect(startDictation).toHaveBeenCalledTimes(MAX_PENDING_DESKTOP_DICTATION_STARTS)
+    expect(getPendingDesktopDictationStartCountForTest()).toBe(0)
+  })
+
+  it('replaces the retained window listener for a sequential same-owner restart', async () => {
+    const stopDictation = vi.fn().mockResolvedValue(undefined)
+    getSpeechSttServiceMock.mockReturnValue({
+      startDictation: vi.fn().mockResolvedValue(undefined),
+      stopDictation
+    })
+    const firstWindow = {
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
+      once: vi.fn(),
+      off: vi.fn()
+    }
+    const secondWindow = {
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
+      once: vi.fn(),
+      off: vi.fn()
+    }
+    fromWebContentsMock.mockReturnValueOnce(firstWindow).mockReturnValueOnce(secondWindow)
+    registerSpeechHandlers({} as never)
+    const start = getHandler<SpeechStartHandler>('speech:startDictation')
+
+    await start({ sender: { id: 200 } }, 'model-1', undefined, 'session')
+    await start({ sender: { id: 200 } }, 'model-1', undefined, 'session')
+
+    expect(getActiveDesktopDictationListenerCountForTest()).toBe(1)
+    expect(firstWindow.off).toHaveBeenCalledWith('closed', expect.any(Function))
+    await getHandler<SpeechStopHandler>('speech:stopDictation')({ sender: { id: 200 } }, 'session')
+    expect(secondWindow.off).toHaveBeenCalledWith('closed', expect.any(Function))
+    expect(getActiveDesktopDictationListenerCountForTest()).toBe(0)
   })
 })

--- a/src/main/ipc/speech.test.ts
+++ b/src/main/ipc/speech.test.ts
@@ -50,6 +50,7 @@ import {
   registerSpeechHandlers
 } from './speech'
 import {
+  MAX_ACTIVE_DESKTOP_DICTATION_LISTENERS,
   MAX_PENDING_DESKTOP_DICTATION_STARTS,
   MAX_SPEECH_AUDIO_CHUNK_BYTES,
   MAX_SPEECH_HOTWORD_BYTES,
@@ -330,6 +331,87 @@ describe('registerSpeechHandlers', () => {
     expect(firstWindow.off).toHaveBeenCalledWith('closed', expect.any(Function))
     await getHandler<SpeechStopHandler>('speech:stopDictation')({ sender: { id: 200 } }, 'session')
     expect(secondWindow.off).toHaveBeenCalledWith('closed', expect.any(Function))
+    expect(getActiveDesktopDictationListenerCountForTest()).toBe(0)
+  })
+
+  // Why: a same-owner restart shares the dictation the new listener just committed. Stopping
+  // it here would stop the session that replaced it, muting a mic the user just re-opened.
+  it('does not stop the dictation a same-owner restart just committed', async () => {
+    const stopDictation = vi.fn().mockResolvedValue(undefined)
+    getSpeechSttServiceMock.mockReturnValue({
+      startDictation: vi.fn().mockResolvedValue(undefined),
+      stopDictation
+    })
+    fromWebContentsMock.mockImplementation(() => ({
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
+      once: vi.fn(),
+      off: vi.fn()
+    }))
+    registerSpeechHandlers({} as never)
+    const start = getHandler<SpeechStartHandler>('speech:startDictation')
+
+    await start({ sender: { id: 300 } }, 'model-1', undefined, 'session')
+    await start({ sender: { id: 300 } }, 'model-1', undefined, 'session')
+
+    expect(stopDictation).not.toHaveBeenCalled()
+  })
+
+  // Why: this is the regression. Reaching the listener cap used to drop only the map entry,
+  // leaving the evicted session's microphone recording with nothing able to stop it — and no
+  // 'stopped' event, so the renderer waits forever on a transcript that never arrives.
+  it('stops the dictation it evicts when the active-listener cap is reached', async () => {
+    const stopDictation = vi.fn().mockResolvedValue(undefined)
+    getSpeechSttServiceMock.mockReturnValue({
+      startDictation: vi.fn().mockResolvedValue(undefined),
+      stopDictation
+    })
+    fromWebContentsMock.mockImplementation(() => ({
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
+      once: vi.fn(),
+      off: vi.fn()
+    }))
+    registerSpeechHandlers({} as never)
+    const start = getHandler<SpeechStartHandler>('speech:startDictation')
+
+    for (let index = 0; index < MAX_ACTIVE_DESKTOP_DICTATION_LISTENERS; index += 1) {
+      await start({ sender: { id: 400 + index } }, 'model-1', undefined, 'session')
+    }
+    expect(stopDictation).not.toHaveBeenCalled()
+
+    await start({ sender: { id: 999 } }, 'model-1', undefined, 'session')
+
+    // The oldest owner, not an arbitrary one: eviction order has to match insertion order.
+    expect(stopDictation).toHaveBeenCalledWith('desktop:400:session')
+    expect(getActiveDesktopDictationListenerCountForTest()).toBe(
+      MAX_ACTIVE_DESKTOP_DICTATION_LISTENERS
+    )
+  })
+
+  // Why: reset() runs on teardown. Leaving a live dictation behind keeps the microphone
+  // open past the point the process believes every session is gone.
+  it('stops every retained dictation when admission is reset', async () => {
+    const stopDictation = vi.fn().mockResolvedValue(undefined)
+    getSpeechSttServiceMock.mockReturnValue({
+      startDictation: vi.fn().mockResolvedValue(undefined),
+      stopDictation
+    })
+    fromWebContentsMock.mockImplementation(() => ({
+      isDestroyed: vi.fn(() => false),
+      webContents: { send: vi.fn() },
+      once: vi.fn(),
+      off: vi.fn()
+    }))
+    registerSpeechHandlers({} as never)
+    const start = getHandler<SpeechStartHandler>('speech:startDictation')
+    await start({ sender: { id: 500 } }, 'model-1', undefined, 'session')
+    await start({ sender: { id: 501 } }, 'model-1', undefined, 'session')
+
+    clearSpeechIpcAdmissionForTests()
+
+    expect(stopDictation).toHaveBeenCalledWith('desktop:500:session')
+    expect(stopDictation).toHaveBeenCalledWith('desktop:501:session')
     expect(getActiveDesktopDictationListenerCountForTest()).toBe(0)
   })
 })

--- a/src/main/ipc/speech.ts
+++ b/src/main/ipc/speech.ts
@@ -11,6 +11,28 @@ import {
   saveOpenAiSpeechApiKey
 } from '../speech/openai-api-key-store'
 import type { Store } from '../persistence'
+import {
+  buildSpeechHotwordsContent,
+  decodeSpeechAudioChunk,
+  SpeechIpcAdmission,
+  validateOpenAiSpeechApiKey,
+  validateSpeechModelId,
+  validateSpeechSessionId
+} from './speech-ipc-admission'
+
+const speechAdmission = new SpeechIpcAdmission()
+
+export function clearSpeechIpcAdmissionForTests(): void {
+  speechAdmission.reset()
+}
+
+export function getPendingDesktopDictationStartCountForTest(): number {
+  return speechAdmission.pendingStartCount
+}
+
+export function getActiveDesktopDictationListenerCountForTest(): number {
+  return speechAdmission.activeListenerCount
+}
 
 export function registerSpeechHandlers(store: Store): void {
   ipcMain.handle('speech:getCatalog', () => {
@@ -26,7 +48,7 @@ export function registerSpeechHandlers(store: Store): void {
   })
 
   ipcMain.handle('speech:saveOpenAiApiKey', async (_event, apiKey: string) => {
-    saveOpenAiSpeechApiKey(apiKey)
+    saveOpenAiSpeechApiKey(validateOpenAiSpeechApiKey(apiKey))
     return { configured: true }
   })
 
@@ -36,6 +58,7 @@ export function registerSpeechHandlers(store: Store): void {
   })
 
   ipcMain.handle('speech:downloadModel', async (event, modelId: string) => {
+    const validatedModelId = validateSpeechModelId(modelId)
     const manager = getSpeechModelManager(store)
     const window = BrowserWindow.fromWebContents(event.sender)
     if (!window) {
@@ -59,22 +82,23 @@ export function registerSpeechHandlers(store: Store): void {
     }
     window.once('closed', cleanupProgressCallback)
     try {
-      await manager.downloadModel(modelId)
+      await manager.downloadModel(validatedModelId)
     } finally {
       cleanupProgressCallback()
     }
   })
 
   ipcMain.handle('speech:cancelDownload', async (_event, modelId: string) => {
-    getSpeechModelManager(store).cancelDownload(modelId)
+    getSpeechModelManager(store).cancelDownload(validateSpeechModelId(modelId))
   })
 
   ipcMain.handle('speech:deleteModel', async (_event, modelId: string) => {
+    const validatedModelId = validateSpeechModelId(modelId)
     await deleteLocalSpeechModel({
       store,
       modelManager: getSpeechModelManager(store),
       sttService: getSpeechSttService(store),
-      modelId
+      modelId: validatedModelId
     })
   })
 
@@ -91,15 +115,21 @@ export function registerSpeechHandlers(store: Store): void {
   ipcMain.handle(
     'speech:startDictation',
     async (event, modelId: string, hotwords?: string[], sessionId = 'desktop') => {
+      const validatedModelId = validateSpeechModelId(modelId)
+      const validatedSessionId = validateSpeechSessionId(sessionId)
+      const hotwordsContent = buildSpeechHotwordsContent(hotwords)
       const window = BrowserWindow.fromWebContents(event.sender)
       if (!window) {
         return
       }
       let resolvedHotwordsPath: string | undefined
       let windowClosed = false
-      const owner = getDesktopOwner(event.sender.id, sessionId)
+      let sessionListenerReleased = false
+      const owner = getDesktopOwner(event.sender.id, validatedSessionId)
+      speechAdmission.claimStart(owner)
       const cleanupOnWindowClosed = (): void => {
         windowClosed = true
+        cleanupSessionListener()
         void getSpeechSttService(store)
           .stopDictation(owner)
           .finally(() => {
@@ -110,8 +140,14 @@ export function registerSpeechHandlers(store: Store): void {
           .catch(() => {})
       }
       const cleanupSessionListener = (): void => {
+        if (sessionListenerReleased) {
+          return
+        }
+        sessionListenerReleased = true
         window.off('closed', cleanupOnWindowClosed)
+        speechAdmission.deleteListenerIfCurrent(owner, sessionListener)
       }
+      const sessionListener = { release: cleanupSessionListener }
       window.once('closed', cleanupOnWindowClosed)
 
       try {
@@ -133,10 +169,9 @@ export function registerSpeechHandlers(store: Store): void {
           }
         }
 
-        if (hotwords && hotwords.length > 0) {
-          const content = `${hotwords.map((w) => `${w} :2.0`).join('\n')}\n`
-          const hotwordsFilePath = getHotwordsFilePath(content)
-          await writeFile(hotwordsFilePath, content, 'utf-8')
+        if (hotwordsContent) {
+          const hotwordsFilePath = getHotwordsFilePath(hotwordsContent)
+          await writeFile(hotwordsFilePath, hotwordsContent, 'utf-8')
           resolvedHotwordsPath = hotwordsFilePath
         }
 
@@ -149,27 +184,36 @@ export function registerSpeechHandlers(store: Store): void {
         }
 
         await getSpeechSttService(store).startDictation(
-          modelId,
+          validatedModelId,
           (msg) => {
             if (window.isDestroyed()) {
               return
             }
             switch (msg.type) {
               case 'ready':
-                window.webContents.send('speech:ready', { sessionId })
+                window.webContents.send('speech:ready', { sessionId: validatedSessionId })
                 break
               case 'partial':
-                window.webContents.send('speech:partial', { text: msg.text ?? '', sessionId })
+                window.webContents.send('speech:partial', {
+                  text: msg.text ?? '',
+                  sessionId: validatedSessionId
+                })
                 break
               case 'final':
-                window.webContents.send('speech:final', { text: msg.text ?? '', sessionId })
+                window.webContents.send('speech:final', {
+                  text: msg.text ?? '',
+                  sessionId: validatedSessionId
+                })
                 break
               case 'stopped':
                 cleanupSessionListener()
-                window.webContents.send('speech:stopped', { sessionId })
+                window.webContents.send('speech:stopped', { sessionId: validatedSessionId })
                 break
               case 'error':
-                window.webContents.send('speech:error', { error: msg.error ?? '', sessionId })
+                window.webContents.send('speech:error', {
+                  error: msg.error ?? '',
+                  sessionId: validatedSessionId
+                })
                 void getSpeechSttService(store)
                   .stopDictation(owner)
                   .catch(() => undefined)
@@ -180,6 +224,14 @@ export function registerSpeechHandlers(store: Store): void {
           resolvedHotwordsPath,
           owner
         )
+        if (windowClosed || window.isDestroyed() || sessionListenerReleased) {
+          cleanupSessionListener()
+          if (resolvedHotwordsPath) {
+            unlink(resolvedHotwordsPath).catch(() => {})
+          }
+          return
+        }
+        speechAdmission.commitListener(owner, sessionListener)
         if (resolvedHotwordsPath) {
           unlink(resolvedHotwordsPath).catch(() => {})
         }
@@ -189,25 +241,33 @@ export function registerSpeechHandlers(store: Store): void {
           unlink(resolvedHotwordsPath).catch(() => {})
         }
         throw err
+      } finally {
+        speechAdmission.releaseStart(owner)
       }
     }
   )
 
   ipcMain.handle(
     'speech:feedAudio',
-    async (_event, buffer: Buffer, sampleRate: number, sessionId = 'desktop') => {
+    async (_event, buffer: Uint8Array, sampleRate: number, sessionId = 'desktop') => {
       // Why: the preload sends audio as a Buffer to avoid Float32Array data
       // being zeroed out during contextBridge + IPC serialization.
-      const samples = new Float32Array(buffer.buffer, buffer.byteOffset, buffer.byteLength / 4)
+      const audio = decodeSpeechAudioChunk(buffer, sampleRate)
+      const validatedSessionId = validateSpeechSessionId(sessionId)
       getSpeechSttService(store).feedAudio(
-        samples,
-        sampleRate,
-        getDesktopOwner(_event.sender.id, sessionId)
+        audio.samples,
+        audio.sampleRate,
+        getDesktopOwner(_event.sender.id, validatedSessionId)
       )
     }
   )
 
   ipcMain.handle('speech:stopDictation', async (_event, sessionId = 'desktop') => {
-    await getSpeechSttService(store).stopDictation(getDesktopOwner(_event.sender.id, sessionId))
+    const owner = getDesktopOwner(_event.sender.id, validateSpeechSessionId(sessionId))
+    try {
+      await getSpeechSttService(store).stopDictation(owner)
+    } finally {
+      speechAdmission.releaseListener(owner)
+    }
   })
 }

--- a/src/main/ipc/speech.ts
+++ b/src/main/ipc/speech.ts
@@ -147,7 +147,18 @@ export function registerSpeechHandlers(store: Store): void {
         window.off('closed', cleanupOnWindowClosed)
         speechAdmission.deleteListenerIfCurrent(owner, sessionListener)
       }
-      const sessionListener = { release: cleanupSessionListener }
+      // Why: the listener cap can reclaim this session while its microphone is still open.
+      // Stop the dictation on the way out so the service emits 'stopped' and the renderer's
+      // pending transcript resolves, instead of waiting on a session nothing will finish.
+      const sessionListener = {
+        release: cleanupSessionListener,
+        evict: (): void => {
+          cleanupSessionListener()
+          void getSpeechSttService(store)
+            .stopDictation(owner)
+            .catch(() => undefined)
+        }
+      }
       window.once('closed', cleanupOnWindowClosed)
 
       try {


### PR DESCRIPTION
Slice 12 of the re-landed OOM work. Base is `oom-slice-11-relay-protocol` (#11061) — review only the top two commits.

## ELI5

Two ways the main process could be handed more data than it could hold.

**Dragging files in.** When you drop a folder onto the file tree, Orca walks it. It used `readdir`, which builds the *entire* listing of a directory in memory before looking at the first entry, and it recursed with no depth limit. A folder with a million files, or one nested a few thousand levels deep, had nothing standing between it and the heap. The upload size tally was an ad-hoc running total threaded through function arguments, which is easy to get wrong and easy to bypass.

Now the walk streams one entry at a time with `opendir`, and every drop runs against a typed budget: entries, depth, retained path bytes, per-file bytes, total bytes. Peak retention is the cap, not the size of what you dropped.

**Dictation.** `speech:feedAudio` took whatever the renderer sent and reinterpreted the bytes as audio samples. No size check, no sample-rate check, no check that the length was even a multiple of the sample size. Hotwords, session ids, model ids and the OpenAI key were likewise unvalidated. And every `startDictation` retained a window listener with nothing bounding the set.

Now all of it is validated at the IPC boundary, and the retained sets are capped.

The second commit fixes a bug in that last cap — it's the interesting part of this PR, so it's described in full below.

## What changed

**External import budget** (`filesystem-external-import-limits.ts`, new)
- Ceilings on source paths (256), source-path bytes (256 KiB), tree entries (100,000), tree depth (256), per-path bytes (64 KiB), retained path bytes (16 MiB), per-file bytes (25 MiB), total upload bytes (100 MiB).
- The budget is a value threaded through the walk, with a checkpoint/restore pair so a source that fails midway returns the capacity it reserved instead of leaking it against the rest of the request.

**Streaming traversal** (`filesystem-mutations.ts`, `filesystem-import-ssh-directory.ts`)
- `readdir` → `opendir` in all three walkers. The directory handle closes on every exit path.
- Depth is tracked explicitly rather than left to the stack.

**Speech IPC admission** (`speech-ipc-admission.ts`, new)
- Audio chunks: 1 MiB cap, non-empty, length a multiple of `Float32Array.BYTES_PER_ELEMENT`, sample rate within 8 kHz–384 kHz.
- The admitted view is copied into an owned buffer before transfer, because worker transfer moves the whole backing buffer and the renderer's view may be a slice of something larger.
- Hotwords: 256 entries, 4 KiB each, 256 KiB total. Session/model ids 1 KiB, API key 64 KiB.
- Pending starts capped at 16; active window listeners capped at 16.

## The bug the second commit fixes

**What went wrong.** The active-listener cap reclaims the oldest entry once 16 dictations are retained — but it only deleted the map entry. The evicted session's microphone stayed open. Worse, the owner key was gone, so no later `speech:stopDictation` could reach it: nothing left in the process could stop that recording.

The renderer waits for a `speech:stopped` event before finishing a session, and that event is emitted by the STT service on stop. An eviction that never stops the service leaves the renderer waiting on a transcript that cannot arrive, with the mic live.

That is the OOM fix trading a crash for a stuck open microphone — a strictly worse failure, because it is silent and it is a privacy issue.

**Confirmed introduced by this slice, not pre-existing.** At the merge base (`f10b6de2c7`) `speech-ipc-admission.ts` does not exist and `speech.ts` has no listener retention at all — no cap, therefore no eviction, therefore no way to reach this state.

**The fix.** `DesktopDictationListener` now distinguishes two operations:

- `release` — detach bookkeeping for a session that already finished.
- `evict` — also stop the underlying dictation, so the service emits `stopped` and the renderer's pending wait resolves.

Details worth a reviewer's attention:

- **A same-owner replacement uses `release`, not `evict`.** It shares the dictation the *new* listener just committed, so stopping it there would kill the session doing the replacing — muting a mic the user had just re-opened. A test pins this.
- **Eviction order is insertion order.** The test asserts the *oldest* owner is the one stopped, not merely that something was.
- **`evict` failures are caught.** A wedged session must not block admitting the session that displaced it, or one bad session denies dictation to everyone behind it. On `reset` the same guard keeps one failure from stranding the sessions after it in the list.
- **The map entry is deleted before `evict` runs**, so the cap holds even if the stop throws.

## Proof the OOM fix works

Every bound was mutation-tested — removed or raised to `MAX_SAFE_INTEGER`, then the suite re-run.

| Removed bound | Result |
|---|---|
| `EXTERNAL_IMPORT_MAX_SOURCE_PATHS` | 2 tests fail |
| `EXTERNAL_IMPORT_MAX_TREE_ENTRIES` | **suite hangs** — see below |
| `EXTERNAL_IMPORT_MAX_TREE_DEPTH` | 2 tests fail *(after the fix below)* |
| `EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES` | 3 tests fail |
| `REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES` | 1 test fails |
| `REMOTE_IMPORT_MAX_FILE_BYTES` | 2 tests fail |
| `REMOTE_IMPORT_MAX_TOTAL_BYTES` | 1 test fails |
| Depth guard deleted from the walker | 1 test fails *(after the fix below)* |

**The entry cap is load-bearing beyond memory.** Removing it doesn't fail a test, it hangs — the traversal test has nothing left to terminate it. Killed at 10 minutes.

**Two coverage gaps this found**, both fixed in the second commit:

1. `EXTERNAL_IMPORT_MAX_TREE_DEPTH` could be raised to `MAX_SAFE_INTEGER` with the suite green. The assertion was seeded *from the constant* (`MAX + 1` throws), so it held at any value — including one that is no bound at all. Replaced with a test asserting the literal 256.
2. The depth guard could be deleted from **both** tree walkers with the suite green — nothing drove a tree deep enough to reach it. A staging test now walks a real 257-level tree through the IPC handler, so deleting the call site fails rather than passing silently.

**The speech fix is mutation-tested too, 4 mutations, all fail:**

| Mutation | Tests failing |
|---|---|
| Eviction drops the entry without stopping (the original defect) | 1 |
| `evict` cleans bookkeeping but does not stop the dictation | 2 |
| `reset` uses `release` instead of `evict` | 1 |
| Same-owner replacement uses `evict` (would kill the new session) | 1 |

And the direct proof: checking out the **first** commit's `speech.ts` / `speech-ipc-admission.ts` under the **second** commit's tests fails exactly the two regression tests, and passes with the fix applied.

## Proof of zero regressions

- **Full suite: 3,697 files / 38,963 tests pass.** 8 failures, all pre-existing on `origin/main`:
  - 2 in `src/relay/agent-exec-handler.test.ts`
  - 6 in `src/renderer/src/components/terminal-search-decoration-leak.test.ts`

  Both verified by running the same files on a clean `origin/main` checkout: same tests, same failures. Neither file is touched by this slice, which changes only `src/main/ipc/`.
- **`src/main/ipc` alone: 150 files / 2,342 tests pass.**
- Typecheck clean on `tsconfig.node`. Lint 0 warnings / 0 errors.
- No conflicts against `origin/main`.

## User-facing behavior changes

1. **A dropped folder deeper than 256 levels, or with more than 100,000 entries, fails that source with a reason** instead of being imported. The file-explorer import flow already surfaces per-source failures as a toast, so this is visible rather than silent. Ordinary drops are nowhere near either ceiling.

2. **A single file over 25 MiB, or a request over 100 MiB, is rejected for remote import** with the offending path named.

3. **Malformed audio chunks are now rejected** rather than reinterpreted. Previously a chunk whose length was not a multiple of 4 would construct a `Float32Array` over a mis-aligned buffer.

4. **A 17th concurrent dictation now stops the oldest one** rather than leaving it recording. Reaching this requires 16 simultaneous dictation sessions in one process.

Made with [Orca](https://github.com/stablyai/orca) 🐋
