### PR TITLE
fix(browser): keep the address bar editable in a narrow toolbar

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -1,12 +1,14 @@
 /* oxlint-disable react-doctor/no-adjust-state-on-prop-change -- Why: dropdown visibility depends on DOM focus plus browser-history suggestions, so the close path is an imperative popover sync. */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Globe, Search } from 'lucide-react'
+import { Globe } from 'lucide-react'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command'
+import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { DEFAULT_SEARCH_ENGINE, type SearchEngine } from '../../../../shared/browser-url'
 import { buildBrowserAddressBarSuggestions } from './browser-address-bar-suggestions'
+import { shouldOverlayBrowserAddressBar } from './browser-address-bar-expansion'
+import BrowserAddressBarSuggestionList from './BrowserAddressBarSuggestionList'
 
 type BrowserAddressBarProps = {
   value: string
@@ -38,6 +40,24 @@ export default function BrowserAddressBar({
   const openedAtRef = useRef(0)
   const blurCloseTimerRef = useRef<number | null>(null)
   const closingResetTimerRef = useRef<number | null>(null)
+  const slotRef = useRef<HTMLDivElement | null>(null)
+  const [inlineWidth, setInlineWidth] = useState<number | null>(null)
+
+  // Why: the slot keeps its flex width even while the bar overlays the toolbar,
+  // so measuring it here (not the form) cannot oscillate with the overlay.
+  useEffect(() => {
+    const slot = slotRef.current
+    if (!slot || typeof ResizeObserver === 'undefined') {
+      return
+    }
+    const syncWidth = (): void => setInlineWidth(slot.getBoundingClientRect().width)
+    syncWidth()
+    const observer = new ResizeObserver(syncWidth)
+    observer.observe(slot)
+    return () => observer.disconnect()
+  }, [])
+
+  const overlay = shouldOverlayBrowserAddressBar({ inlineWidth, focused: open })
 
   const clearAddressBarTimers = useCallback((): void => {
     if (blurCloseTimerRef.current !== null) {
@@ -338,111 +358,102 @@ export default function BrowserAddressBar({
   }, [dismissSuggestions, dismissSuggestionsRef])
 
   return (
-    <Popover
-      modal={false}
-      open={open}
-      onOpenChange={(next) => {
-        // Why: Radix fires onOpenChange(false) when it detects an outside
-        // interaction, but during the focus-retry loop the input may still
-        // hold focus. Only allow programmatic closes (setOpen(false) from
-        // our handlers) or genuine outside dismissals.
-        if (!next && inputRef.current && document.activeElement === inputRef.current) {
-          return
-        }
-        if (!next) {
-          restoreTypedQuery()
-        }
-        setOpen(next)
-      }}
-    >
-      <PopoverTrigger asChild>
-        <form
-          ref={setAddressBarFormRef}
-          className="flex min-w-0 flex-1 items-center gap-2 rounded-xl border border-border bg-background px-3 py-1 shadow-sm"
-          onSubmit={(event) => {
-            event.preventDefault()
-            setOpen(false)
-            clearSuggestionPreview()
-            setAutocompleteQuery(value)
-            onSubmit()
-          }}
-        >
-          <Globe className="size-4 shrink-0 text-muted-foreground" />
-          <Input
-            ref={inputRef}
-            value={value}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            onKeyDown={handleKeyDown}
-            data-orca-browser-address-bar="true"
-            className="h-auto border-0 bg-transparent px-0 text-sm shadow-none focus-visible:ring-0"
-            spellCheck={false}
-            autoCapitalize="none"
-            autoCorrect="off"
-            onChange={(event) => {
-              const nextValue = event.target.value
-              // Why: typing creates a new suggestion list, so keyboard selection
-              // should return to the derived top match instead of a stale row.
-              // Clearing preview state here also prevents stale hover/selection
-              // from repopulating the input after Cmd+A → Delete.
-              prePreviewValueRef.current = null
-              setSelectedValueOverride(null)
-              setAutocompleteQuery(nextValue)
-              onChange(nextValue)
+    // Why: min-w-11 keeps the leading globe a real hit target once the toolbar
+    // squeezes the bar away — without it neighbouring buttons overlap the only
+    // affordance for reopening the URL field.
+    <div ref={slotRef} className="flex min-w-11 flex-1 items-center">
+      <Popover
+        modal={false}
+        open={open}
+        onOpenChange={(next) => {
+          // Why: Radix fires onOpenChange(false) when it detects an outside
+          // interaction, but during the focus-retry loop the input may still
+          // hold focus. Only allow programmatic closes (setOpen(false) from
+          // our handlers) or genuine outside dismissals.
+          if (!next && inputRef.current && document.activeElement === inputRef.current) {
+            return
+          }
+          if (!next) {
+            restoreTypedQuery()
+          }
+          setOpen(next)
+        }}
+      >
+        <PopoverTrigger asChild>
+          <form
+            ref={setAddressBarFormRef}
+            data-orca-browser-address-bar-overlay={overlay ? 'true' : undefined}
+            className={cn(
+              'flex items-center gap-2 rounded-xl border border-border bg-background px-3 py-1 shadow-sm',
+              // Why: the toolbar row is the positioned ancestor, so the overlay
+              // spans it edge to edge (matching its px-3) instead of the few
+              // pixels the squeezed slot has left.
+              overlay
+                ? 'absolute inset-x-3 top-1/2 z-30 -translate-y-1/2 shadow-md'
+                : 'min-w-0 flex-1'
+            )}
+            // Why: when squeezed the input is zero-width, so clicks land on the
+            // form padding — forward them to the input so it expands and edits.
+            onClick={() => inputRef.current?.focus()}
+            onSubmit={(event) => {
+              event.preventDefault()
+              setOpen(false)
+              clearSuggestionPreview()
+              setAutocompleteQuery(value)
+              onSubmit()
             }}
-            role="combobox"
-            aria-expanded={open}
-            aria-controls="browser-history-listbox"
-            aria-autocomplete="list"
-          />
-        </form>
-      </PopoverTrigger>
-      {suggestions.length > 0 && (
-        <PopoverContent
-          align="start"
-          sideOffset={4}
-          className="w-[var(--radix-popover-trigger-width)] p-0"
-          onOpenAutoFocus={(e) => {
-            // Why: prevent the popover from stealing focus away from the
-            // address bar input. The user is still typing; the popover is
-            // an overlay of suggestions, not a focus target.
-            e.preventDefault()
-          }}
-        >
-          <Command
-            shouldFilter={false}
-            value={selectedValue}
-            onValueChange={setSelectedValueOverride}
           >
-            <CommandList id="browser-history-listbox" role="listbox">
-              <CommandGroup>
-                {suggestions.map((entry) => (
-                  <CommandItem
-                    key={entry.url}
-                    value={entry.url}
-                    onSelect={() => handleSelect(entry.url)}
-                    className="flex items-center gap-2 px-3 py-2"
-                  >
-                    {entry.isSearch ? (
-                      <Search className="size-3.5 shrink-0 text-muted-foreground" />
-                    ) : (
-                      <Globe className="size-3.5 shrink-0 text-muted-foreground" />
-                    )}
-                    <div className="flex min-w-0 flex-1 flex-col">
-                      <span className="truncate text-sm">{entry.title}</span>
-                      {entry.subtitle ? (
-                        <span className="truncate text-xs text-muted-foreground">
-                          {entry.subtitle}
-                        </span>
-                      ) : null}
-                    </div>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      )}
-    </Popover>
+            <Globe className="size-4 shrink-0 text-muted-foreground" />
+            <Input
+              ref={inputRef}
+              value={value}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              onKeyDown={handleKeyDown}
+              data-orca-browser-address-bar="true"
+              className="h-auto border-0 bg-transparent px-0 text-sm shadow-none focus-visible:ring-0"
+              spellCheck={false}
+              autoCapitalize="none"
+              autoCorrect="off"
+              onChange={(event) => {
+                const nextValue = event.target.value
+                // Why: typing creates a new suggestion list, so keyboard selection
+                // should return to the derived top match instead of a stale row.
+                // Clearing preview state here also prevents stale hover/selection
+                // from repopulating the input after Cmd+A → Delete.
+                prePreviewValueRef.current = null
+                setSelectedValueOverride(null)
+                setAutocompleteQuery(nextValue)
+                onChange(nextValue)
+              }}
+              role="combobox"
+              aria-expanded={open}
+              aria-controls="browser-history-listbox"
+              aria-autocomplete="list"
+            />
+          </form>
+        </PopoverTrigger>
+        {suggestions.length > 0 && (
+          <PopoverContent
+            align="start"
+            sideOffset={4}
+            className="w-[var(--radix-popover-trigger-width)] p-0"
+            onOpenAutoFocus={(e) => {
+              // Why: prevent the popover from stealing focus away from the
+              // address bar input. The user is still typing; the popover is
+              // an overlay of suggestions, not a focus target.
+              e.preventDefault()
+            }}
+          >
+            <BrowserAddressBarSuggestionList
+              suggestions={suggestions}
+              selectedValue={selectedValue}
+              onSelectedValueChange={setSelectedValueOverride}
+              onSelect={handleSelect}
+            />
+          </PopoverContent>
+        )}
+      </Popover>
+    </div>
   )
 }

--- a/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBar.tsx
@@ -389,7 +389,7 @@ export default function BrowserAddressBar({
               // spans it edge to edge (matching its px-3) instead of the few
               // pixels the squeezed slot has left.
               overlay
-                ? 'absolute inset-x-3 top-1/2 z-30 -translate-y-1/2 shadow-md'
+                ? 'absolute inset-x-3 top-1/2 z-30 -translate-y-1/2 shadow-[0_10px_24px_rgba(0,0,0,0.18)]'
                 : 'min-w-0 flex-1'
             )}
             // Why: when squeezed the input is zero-width, so clicks land on the

--- a/src/renderer/src/components/browser-pane/BrowserAddressBarSuggestionList.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserAddressBarSuggestionList.tsx
@@ -1,0 +1,46 @@
+import { Globe, Search } from 'lucide-react'
+import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command'
+import type { BrowserAddressBarSuggestion } from './browser-address-bar-suggestions'
+
+type BrowserAddressBarSuggestionListProps = {
+  suggestions: BrowserAddressBarSuggestion[]
+  selectedValue: string
+  onSelectedValueChange: (value: string) => void
+  onSelect: (url: string) => void
+}
+
+export default function BrowserAddressBarSuggestionList({
+  suggestions,
+  selectedValue,
+  onSelectedValueChange,
+  onSelect
+}: BrowserAddressBarSuggestionListProps): React.ReactElement {
+  return (
+    <Command shouldFilter={false} value={selectedValue} onValueChange={onSelectedValueChange}>
+      <CommandList id="browser-history-listbox" role="listbox">
+        <CommandGroup>
+          {suggestions.map((entry) => (
+            <CommandItem
+              key={entry.url}
+              value={entry.url}
+              onSelect={() => onSelect(entry.url)}
+              className="flex items-center gap-2 px-3 py-2"
+            >
+              {entry.isSearch ? (
+                <Search className="size-3.5 shrink-0 text-muted-foreground" />
+              ) : (
+                <Globe className="size-3.5 shrink-0 text-muted-foreground" />
+              )}
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-sm">{entry.title}</span>
+                {entry.subtitle ? (
+                  <span className="truncate text-xs text-muted-foreground">{entry.subtitle}</span>
+                ) : null}
+              </div>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  )
+}

--- a/src/renderer/src/components/browser-pane/browser-address-bar-expansion.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-address-bar-expansion.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH,
+  isBrowserAddressBarCollapsed,
+  shouldOverlayBrowserAddressBar
+} from './browser-address-bar-expansion'
+
+describe('isBrowserAddressBarCollapsed', () => {
+  it('treats an unmeasured slot as roomy so the bar never overlays before layout', () => {
+    expect(isBrowserAddressBarCollapsed(null)).toBe(false)
+  })
+
+  it('collapses below the minimum inline width', () => {
+    expect(isBrowserAddressBarCollapsed(BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH - 1)).toBe(true)
+    expect(isBrowserAddressBarCollapsed(48)).toBe(true)
+  })
+
+  it('stays inline at or above the minimum width', () => {
+    expect(isBrowserAddressBarCollapsed(BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH)).toBe(false)
+    expect(isBrowserAddressBarCollapsed(640)).toBe(false)
+  })
+})
+
+describe('shouldOverlayBrowserAddressBar', () => {
+  it('overlays only while a collapsed bar is focused', () => {
+    expect(shouldOverlayBrowserAddressBar({ inlineWidth: 48, focused: true })).toBe(true)
+    expect(shouldOverlayBrowserAddressBar({ inlineWidth: 48, focused: false })).toBe(false)
+  })
+
+  it('never overlays a bar that already fits', () => {
+    expect(shouldOverlayBrowserAddressBar({ inlineWidth: 640, focused: true })).toBe(false)
+  })
+})

--- a/src/renderer/src/components/browser-pane/browser-address-bar-expansion.ts
+++ b/src/renderer/src/components/browser-pane/browser-address-bar-expansion.ts
@@ -1,0 +1,19 @@
+// Every other browser toolbar control is shrink-0, so the address bar absorbs
+// all of the squeeze when the pane narrows and ends up as the leading globe
+// icon with a zero-width input. Below this slot width the bar overlays the
+// toolbar while focused instead, keeping the URL editable (issue #11090).
+export const BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH = 220
+
+export function isBrowserAddressBarCollapsed(inlineWidth: number | null): boolean {
+  return inlineWidth !== null && inlineWidth < BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH
+}
+
+export function shouldOverlayBrowserAddressBar({
+  inlineWidth,
+  focused
+}: {
+  inlineWidth: number | null
+  focused: boolean
+}): boolean {
+  return focused && isBrowserAddressBarCollapsed(inlineWidth)
+}

--- a/tests/e2e/browser-address-bar-narrow-toolbar.spec.ts
+++ b/tests/e2e/browser-address-bar-narrow-toolbar.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * E2E regression for issue #11090: in a narrow browser pane every toolbar
+ * button stays shrink-0, so the address bar absorbed the whole squeeze and
+ * became an unusable globe icon with a zero-width input. Focusing it must now
+ * overlay the toolbar with a typable field that navigates on Enter.
+ */
+
+import { createServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { expect, test } from './helpers/orca-app'
+import type { ElectronApplication, Locator, Page } from '@stablyai/playwright-test'
+import {
+  ensureTerminalVisible,
+  getActiveTabType,
+  getActiveWorktreeId,
+  getBrowserTabs,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import { BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH } from '../../src/renderer/src/components/browser-pane/browser-address-bar-expansion'
+
+// Why: the left sidebar keeps its default 280px, so this leaves the browser
+// pane around 420px — narrow enough to squeeze the address bar away, wide
+// enough that the toolbar itself still renders its buttons.
+const NARROW_WINDOW_WIDTH = 700
+const NARROW_WINDOW_HEIGHT = 800
+
+async function startDestinationServer(): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+    response.end(
+      '<!doctype html><html><head><title>Typed destination</title></head><body>ok</body></html>'
+    )
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  return {
+    url: `http://127.0.0.1:${(server.address() as AddressInfo).port}/typed`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      )
+  }
+}
+
+async function createBlankBrowserTab(page: Page, worktreeId: string): Promise<void> {
+  await page.evaluate((targetWorktreeId) => {
+    window.__store?.getState().createBrowserTab(targetWorktreeId, 'about:blank', {
+      title: 'Narrow toolbar tab',
+      activate: true
+    })
+  }, worktreeId)
+  await expect.poll(async () => getActiveTabType(page), { timeout: 10_000 }).toBe('browser')
+}
+
+async function closeRightSidebar(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    window.__store?.getState().setRightSidebarOpen(false)
+  })
+}
+
+async function resizeWindow(electronApp: ElectronApplication): Promise<void> {
+  await electronApp.evaluate(
+    ({ BrowserWindow }, { width, height }) => {
+      const window = BrowserWindow.getAllWindows()[0]
+      if (!window) {
+        throw new Error('No Electron window')
+      }
+      window.setSize(width, height)
+    },
+    { width: NARROW_WINDOW_WIDTH, height: NARROW_WINDOW_HEIGHT }
+  )
+}
+
+function addressBarInput(page: Page): Locator {
+  return page.locator('[data-orca-browser-address-bar="true"]')
+}
+
+async function blurAddressBar(page: Page): Promise<void> {
+  await addressBarInput(page).evaluate((node) => node.blur())
+}
+
+async function addressBarInputWidth(page: Page): Promise<number> {
+  return addressBarInput(page).evaluate((node) => node.getBoundingClientRect().width)
+}
+
+test.describe('Browser address bar in a narrow toolbar', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+  })
+
+  test('focusing the squeezed address bar expands a typable field that navigates', async ({
+    orcaPage,
+    electronApp
+  }) => {
+    const destination = await startDestinationServer()
+    try {
+      const worktreeId = (await getActiveWorktreeId(orcaPage))!
+      await createBlankBrowserTab(orcaPage, worktreeId)
+      await closeRightSidebar(orcaPage)
+      await resizeWindow(electronApp)
+
+      // Why: a fresh blank tab auto-focuses the address bar, which already
+      // expands it. Blur first to observe the squeezed resting state.
+      await blurAddressBar(orcaPage)
+
+      const overlay = orcaPage.locator('[data-orca-browser-address-bar-overlay="true"]')
+      await expect(overlay).toHaveCount(0)
+      // The bug: the inline field is squeezed away entirely.
+      await expect.poll(() => addressBarInputWidth(orcaPage), { timeout: 10_000 }).toBeLessThan(40)
+
+      await orcaPage.locator('form:has(> [data-orca-browser-address-bar="true"])').click()
+
+      await expect(overlay).toBeVisible()
+      await expect
+        .poll(() => addressBarInputWidth(orcaPage), { timeout: 5_000 })
+        .toBeGreaterThan(BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH / 2)
+
+      await addressBarInput(orcaPage).fill(destination.url)
+      await addressBarInput(orcaPage).press('Enter')
+
+      await expect
+        .poll(async () => (await getBrowserTabs(orcaPage, worktreeId)).at(-1)?.url ?? null, {
+          timeout: 15_000
+        })
+        .toContain('/typed')
+    } finally {
+      await destination.close()
+    }
+  })
+})

--- a/tests/e2e/browser-address-bar-narrow-toolbar.spec.ts
+++ b/tests/e2e/browser-address-bar-narrow-toolbar.spec.ts
@@ -19,10 +19,13 @@ import {
 } from './helpers/store'
 import { BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH } from '../../src/renderer/src/components/browser-pane/browser-address-bar-expansion'
 
-// Why: the left sidebar keeps its default 280px, so this leaves the browser
-// pane around 420px — narrow enough to squeeze the address bar away, wide
-// enough that the toolbar itself still renders its buttons.
-const NARROW_WINDOW_WIDTH = 700
+// Why: the toolbar must land in a band — squeezed enough that the inline field
+// collapses, roomy enough that the overlay itself has somewhere to go. Target
+// the middle of that band rather than a fixed window width, because how much
+// chrome flanks the pane (left sidebar, and a right sidebar that other startup
+// paths may re-open) varies between runs.
+const TARGET_TOOLBAR_WIDTH = 420
+const MIN_USABLE_TOOLBAR_WIDTH = BROWSER_ADDRESS_BAR_MIN_INLINE_WIDTH + 100
 const NARROW_WINDOW_HEIGHT = 800
 
 async function startDestinationServer(): Promise<{ url: string; close: () => Promise<void> }> {
@@ -52,35 +55,77 @@ async function createBlankBrowserTab(page: Page, worktreeId: string): Promise<vo
   await expect.poll(async () => getActiveTabType(page), { timeout: 10_000 }).toBe('browser')
 }
 
-async function closeRightSidebar(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    window.__store?.getState().setRightSidebarOpen(false)
-  })
-}
-
-async function resizeWindow(electronApp: ElectronApplication): Promise<void> {
+async function setWindowWidth(electronApp: ElectronApplication, width: number): Promise<void> {
   await electronApp.evaluate(
-    ({ BrowserWindow }, { width, height }) => {
+    ({ BrowserWindow }, size) => {
       const window = BrowserWindow.getAllWindows()[0]
       if (!window) {
         throw new Error('No Electron window')
       }
-      window.setSize(width, height)
+      window.setSize(size.width, size.height)
     },
-    { width: NARROW_WINDOW_WIDTH, height: NARROW_WINDOW_HEIGHT }
+    { width: Math.round(width), height: NARROW_WINDOW_HEIGHT }
   )
+}
+
+function browserToolbar(page: Page): Locator {
+  return page.locator('[data-contextual-tour-target="browser-toolbar"]').first()
+}
+
+async function toolbarWidth(page: Page): Promise<number> {
+  return browserToolbar(page).evaluate((node) => Math.round(node.getBoundingClientRect().width))
 }
 
 function addressBarInput(page: Page): Locator {
   return page.locator('[data-orca-browser-address-bar="true"]')
 }
 
-async function blurAddressBar(page: Page): Promise<void> {
-  await addressBarInput(page).evaluate((node) => node.blur())
+function addressBarOverlay(page: Page): Locator {
+  return page.locator('[data-orca-browser-address-bar-overlay="true"]')
 }
 
 async function addressBarInputWidth(page: Page): Promise<number> {
   return addressBarInput(page).evaluate((node) => node.getBoundingClientRect().width)
+}
+
+/**
+ * Drive the app to the resting state this spec is about: a squeezed-but-usable
+ * toolbar whose address bar is collapsed and unfocused.
+ *
+ * Why one loop rather than three: both preconditions are actively fought by the
+ * app. Startup paths re-open the right sidebar (which alone leaves the pane
+ * ~70px, too narrow for the overlay to have anywhere to go), and BrowserPane
+ * re-focuses a blank tab's address bar across several animation frames plus the
+ * blank-url did-finish-load handler. Settling them separately just lets whichever
+ * settled first drift back while the next one runs, so re-assert all of them
+ * together until they hold at the same time. The interval must clear the 200ms
+ * blur-close timer in BrowserAddressBar for the collapse to register.
+ */
+async function settleToSqueezedRestingState(
+  page: Page,
+  electronApp: ElectronApplication
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        await page.evaluate(() => {
+          window.__store?.getState().setRightSidebarOpen(false)
+        })
+        const [innerWidth, toolbar] = await Promise.all([
+          page.evaluate(() => window.innerWidth),
+          toolbarWidth(page)
+        ])
+        // Chrome flanking the pane is everything the toolbar didn't get.
+        await setWindowWidth(electronApp, innerWidth - toolbar + TARGET_TOOLBAR_WIDTH)
+        await addressBarInput(page).evaluate((node) => node.blur())
+        return {
+          toolbar: (await toolbarWidth(page)) > MIN_USABLE_TOOLBAR_WIDTH,
+          collapsed: (await addressBarOverlay(page).count()) === 0
+        }
+      },
+      { timeout: 30_000, intervals: [300, 300, 300, 500, 500, 1000] }
+    )
+    .toEqual({ toolbar: true, collapsed: true })
 }
 
 test.describe('Browser address bar in a narrow toolbar', () => {
@@ -98,15 +143,9 @@ test.describe('Browser address bar in a narrow toolbar', () => {
     try {
       const worktreeId = (await getActiveWorktreeId(orcaPage))!
       await createBlankBrowserTab(orcaPage, worktreeId)
-      await closeRightSidebar(orcaPage)
-      await resizeWindow(electronApp)
+      await settleToSqueezedRestingState(orcaPage, electronApp)
 
-      // Why: a fresh blank tab auto-focuses the address bar, which already
-      // expands it. Blur first to observe the squeezed resting state.
-      await blurAddressBar(orcaPage)
-
-      const overlay = orcaPage.locator('[data-orca-browser-address-bar-overlay="true"]')
-      await expect(overlay).toHaveCount(0)
+      const overlay = addressBarOverlay(orcaPage)
       // The bug: the inline field is squeezed away entirely.
       await expect.poll(() => addressBarInputWidth(orcaPage), { timeout: 10_000 }).toBeLessThan(40)
 


### PR DESCRIPTION
## Summary

Fixes #11090 — in a narrow browser pane the address bar became impossible to use.

Every other control in the browser toolbar is `shrink-0`, so the address bar form (`min-w-0 flex-1`) was the only flexible item and absorbed the entire squeeze. Below roughly 420px of pane width it collapsed to just the leading globe icon with a zero-width input. Clicking it only opened the history/suggestion dropdown, which is sized with `w-[var(--radix-popover-trigger-width)]` and therefore also rendered at icon width — which is why the reported symptom was "clicking the globe pops up another globe". There was no collapsed mode to fix; the bar was simply being squeezed out of existence, leaving the tab navigable only through links already on the page.

Focusing a squeezed address bar now lifts the form out of the toolbar flow and overlays the row edge to edge, giving a full-width editable field that navigates on Enter. Because the form is still the Radix popover trigger, the suggestion list picks up the expanded width for free. When there is room, nothing changes: the bar stays inline exactly as before.

Details:

- `browser-address-bar-expansion.ts` holds the threshold and the pure predicate (`shouldOverlayBrowserAddressBar`), unit-tested separately.
- The measured element is a new in-flow slot `div`, not the form. The form leaves the flow while overlaid, so measuring the form itself would oscillate between the two states.
- The slot keeps a `min-w-11`, so the globe stays a real hit target. Without it the neighbouring toolbar buttons overlap the only affordance for reopening the field (Playwright's click was genuinely intercepted by the Import button before this was added).
- `BrowserAddressBarSuggestionList.tsx` is the previous inline dropdown JSX extracted verbatim — needed to stay under the 400-line `max-lines` budget for `.tsx` without a suppression.

Both the local and the remote-runtime toolbars render `BrowserAddressBar` inside the same `relative … px-3` row, so both get the fix.

## Screenshots

Browser pane narrowed to ~420px.

Squeezed resting state — the address bar is a globe pill:

![collapsed](https://raw.githubusercontent.com/yoyoys/orca/pr-assets-11090/collapsed.png)

After clicking it — full-width editable field, Enter navigates:

![expanded](https://raw.githubusercontent.com/yoyoys/orca/pr-assets-11090/expanded.png)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 38721 passed. 2 pre-existing failures in `src/relay/agent-exec-handler.test.ts` (they reproduce identically on an unmodified checkout of this branch point; they depend on a `codex` binary in the environment) plus some load-dependent flakes in `src/relay/subprocess.test.ts`, `src/main/plugins/plugin-worker-supervision.integration.test.ts` and `src/main/ssh/ssh-system-transport.integration.test.ts` that pass in isolation. None touch the renderer.
- [x] `pnpm build`
- [x] Added tests:
  - `browser-address-bar-expansion.test.ts` — unit coverage for the threshold predicate.
  - `tests/e2e/browser-address-bar-narrow-toolbar.spec.ts` — real Electron regression: narrows the window with the right sidebar closed, asserts the inline field is squeezed below 40px and no overlay is present, clicks the globe, asserts the overlay appears with a usable field, then types a URL and asserts the tab actually navigates. Verified this spec fails (`overlay … element(s) not found`) when the fix is disabled, so it is not vacuous.

## AI Review Report

This PR was written and reviewed by Claude (Claude Code). Root cause was established by reading the layout code before any change: the toolbar row, every button's `shrink-0` from the shared `buttonVariants`, `Input`'s `w-full min-w-0`, and the popover's trigger-width sizing — not by guessing from the screenshot in the issue. The issue's own hypothesis (an overflow container rendering a collapsed variant) was checked and rejected; there is no overflow container and no collapsed variant in this code path.

Risks checked:

- **Measurement feedback loop** — the overlay removes the form from flow. Addressed by measuring a separate in-flow slot; covered implicitly by the e2e, which would flap if the state oscillated.
- **Focus handling** — `BrowserPane.focusAddressBarNow()` focuses `addressBarInputRef`, and several call sites compare `document.activeElement` against it. The input is never unmounted or duplicated by this change, so Cmd+L and the blank-tab auto-focus keep working; the e2e exercises the auto-focus path directly (it had to blur first to observe the resting state).
- **Popover dismissal** — the existing window-blur / webview-focusin / Escape handlers are untouched; overlay state is derived from the same `open` flag they already control, so dismissal collapses the bar.
- **Cross-platform** — no keyboard shortcuts, accelerators, shortcut labels, paths, shell invocations or Electron platform branches are touched. The change is CSS classes plus a `ResizeObserver`, with a `typeof ResizeObserver === 'undefined'` guard for the non-DOM/web runtime. macOS/Linux/Windows behave identically; verified on macOS.
- **SSH / remote runtime and folder workspaces** — the remote-runtime toolbar shares the same component and the same `relative … px-3` row, so it is fixed too; nothing here assumes a git worktree or local execution.
- **Agent and integration compatibility** — none. This path is the embedded browser's chrome; it does not touch CLI agents, integrations, or git providers, and contains no provider-specific naming or branching.
- **Performance** — one `ResizeObserver` on one element per browser pane, already the same pattern this file uses for the chrome inset and viewport sync. It sets state only when the slot width changes, and the collapsed/expanded decision is a pure comparison, so nothing runs in a hot path. No new subscriptions, timers, or listeners.
- **UI quality / STYLEGUIDE** — the overlay reuses the address bar's existing surface (`rounded-xl`, `border-border`, `bg-background`) and only changes position. The review caught that my first version used `shadow-md`, which is a fourth elevation level that `docs/STYLEGUIDE.md` explicitly forbids; the follow-up commit switches it to the documented floating shadow (`0 10px 24px rgba(0,0,0,0.18)`) already used by the other floating surfaces in this pane. No new colors, radii, font sizes, or tokens. Both light and dark mode inherit from existing tokens.
- **`max-lines`** — no suppression added; the file was split instead, and the ratchet reports no new bypasses.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency or IPC surface. The change is presentational (Tailwind classes on an existing form) plus a `ResizeObserver` on an element this component already owns. URL parsing, normalization and navigation continue to flow through the untouched `submitAddressBar` / `navigateToUrl` path in `BrowserPane`, and through `shared/browser-url`. No new dependencies. The added e2e spec binds a throwaway HTTP server on `127.0.0.1:0` and closes it in a `finally`. No follow-up needed.

## Notes

- The threshold (220px of slot width) is the point below which the inline field stops being usefully typable; it is a single exported constant if you would prefer a different value.
- No X handle to share — I'm not on X, so there's nothing to shout out. Everything else in CONTRIBUTING's PR checklist is covered above.
- Branch name is `yoyoys/fix-narrow-addressbar-overlay`. CONTRIBUTING asks for a clear, descriptive name and lists `fix/...` as an example; I tried renaming to `fix/narrow-browser-address-bar` and GitHub auto-closed this PR because branch renames don't carry across a fork boundary, so I restored the original name. Say the word if you want the prefix anyway and I'll open a fresh PR from a renamed branch.
- This only rescues the address bar. At very narrow widths the toolbar row still overflows horizontally and the trailing buttons are clipped — the pre-existing behaviour, and the broader "collapse secondary actions into the `…` menu" idea from the issue. Happy to take that on in a follow-up if you want it, but it is a bigger change and orthogonal to making the URL editable again.

https://claude.ai/code/session_01Mx53f7erbtw5NraS8HdXKE
