### PR TITLE
test(native-chat): redirect the fixture home via USERPROFILE so these suites run on Windows

### DIFF
--- a/src/main/ipc/native-chat.test.ts
+++ b/src/main/ipc/native-chat.test.ts
@@ -44,6 +44,27 @@ function jsonLines(records: unknown[]): string {
   return records.map((record) => JSON.stringify(record)).join('\n')
 }
 
+// Points the homedir-derived Claude root at a fixture so the resolver (which
+// reads homedir() internally) finds the transcript. os.homedir() reads
+// USERPROFILE on Windows and HOME on POSIX, so both have to be overridden.
+function redirectHome(root: string): () => void {
+  const previous: Record<string, string | undefined> = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE
+  }
+  process.env.HOME = root
+  process.env.USERPROFILE = root
+  return () => {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
 async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
   const start = Date.now()
   while (!predicate()) {
@@ -104,10 +125,7 @@ describe('nativeChat:readSession handler', () => {
       ])
     )
 
-    // Point homedir-derived Claude root at our fixture via HOME so the resolver
-    // (which reads homedir() internally) finds the transcript.
-    const previousHome = process.env.HOME
-    process.env.HOME = root
+    const restoreHome = redirectHome(root)
     try {
       const result = (await invokeReadSession({ agent: 'claude', sessionId: 'sess-ipc' })) as {
         messages?: unknown[]
@@ -116,11 +134,7 @@ describe('nativeChat:readSession handler', () => {
       expect(result.error).toBeUndefined()
       expect(result.messages).toHaveLength(2)
     } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME
-      } else {
-        process.env.HOME = previousHome
-      }
+      restoreHome()
     }
   })
 
@@ -139,8 +153,7 @@ describe('nativeChat:readSession handler', () => {
     }))
     await writeFile(join(projectDir, 'sess-limit.jsonl'), jsonLines(records))
 
-    const previousHome = process.env.HOME
-    process.env.HOME = root
+    const restoreHome = redirectHome(root)
     try {
       const windowed = (await invokeReadSession({
         agent: 'claude',
@@ -156,11 +169,7 @@ describe('nativeChat:readSession handler', () => {
       })) as { messages: { id: string }[] }
       expect(wider.messages.map((m) => m.id)).toEqual(['u-2', 'u-3', 'u-4', 'u-5'])
     } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME
-      } else {
-        process.env.HOME = previousHome
-      }
+      restoreHome()
     }
   })
 
@@ -200,8 +209,7 @@ describe('nativeChat:readSession handler', () => {
       send: (channel: string, payload: unknown) => sent.push({ channel, payload })
     }
 
-    const previousHome = process.env.HOME
-    process.env.HOME = root
+    const restoreHome = redirectHome(root)
     try {
       subscribe!(
         { sender },
@@ -244,11 +252,7 @@ describe('nativeChat:readSession handler', () => {
       expect(destroyedCb).toBeDefined()
       destroyedCb!()
     } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME
-      } else {
-        process.env.HOME = previousHome
-      }
+      restoreHome()
     }
   })
 
@@ -286,8 +290,7 @@ describe('nativeChat:readSession handler', () => {
       send: vi.fn()
     }
 
-    const previousHome = process.env.HOME
-    process.env.HOME = root
+    const restoreHome = redirectHome(root)
     try {
       subscribe!(
         { sender },
@@ -305,30 +308,21 @@ describe('nativeChat:readSession handler', () => {
       await waitFor(() => _getNativeChatSenderCleanupCountForTest() === 0)
       expect(sender.send).not.toHaveBeenCalled()
     } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME
-      } else {
-        process.env.HOME = previousHome
-      }
+      restoreHome()
     }
   })
 
   it('returns an error for an unknown session without throwing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-ipc-missing-'))
     tempRoots.push(root)
-    const previousHome = process.env.HOME
-    process.env.HOME = root
+    const restoreHome = redirectHome(root)
     try {
       const result = (await invokeReadSession({ agent: 'claude', sessionId: 'nope' })) as {
         error?: string
       }
       expect(result.error).toBeTruthy()
     } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME
-      } else {
-        process.env.HOME = previousHome
-      }
+      restoreHome()
     }
   })
 })

--- a/src/main/kimi/hook-service.test.ts
+++ b/src/main/kimi/hook-service.test.ts
@@ -8,16 +8,20 @@ import { KIMI_HOOK_EVENTS } from './kimi-hook-config-toml'
 // Why: getSharedManagedScriptPath() writes the managed script under
 // homedir()/.orca, and getKimiHome() honors KIMI_CODE_HOME. Point both at a
 // temp dir so the local install/remove cycle never touches the real ~/.orca or
-// ~/.kimi-code. os.homedir() resolves $HOME on POSIX (verified at write time).
+// ~/.kimi-code. os.homedir() resolves $HOME on POSIX and %USERPROFILE% on
+// Windows, so both are pointed at the temp dir.
 let home: string
 let originalHome: string | undefined
+let originalUserProfile: string | undefined
 let originalKimiHome: string | undefined
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'orca-kimi-hook-'))
   originalHome = process.env.HOME
+  originalUserProfile = process.env.USERPROFILE
   originalKimiHome = process.env.KIMI_CODE_HOME
   process.env.HOME = home
+  process.env.USERPROFILE = home
   process.env.KIMI_CODE_HOME = join(home, '.kimi-code')
 })
 
@@ -26,6 +30,11 @@ afterEach(() => {
     delete process.env.HOME
   } else {
     process.env.HOME = originalHome
+  }
+  if (originalUserProfile === undefined) {
+    delete process.env.USERPROFILE
+  } else {
+    process.env.USERPROFILE = originalUserProfile
   }
   if (originalKimiHome === undefined) {
     delete process.env.KIMI_CODE_HOME

--- a/src/main/native-chat/transcript-read-cache.test.ts
+++ b/src/main/native-chat/transcript-read-cache.test.ts
@@ -26,6 +26,13 @@ import {
 
 let tempRoots: string[] = []
 
+// Captured at module load, before seedSession() redirects the home dir. The
+// redirect outlives each test, so it has to be undone once the fixtures are gone.
+const originalHomeEnv: Record<string, string | undefined> = {
+  HOME: process.env.HOME,
+  USERPROFILE: process.env.USERPROFILE
+}
+
 function jsonLines(records: unknown[]): string {
   return records.map((record) => JSON.stringify(record)).join('\n')
 }
@@ -43,7 +50,10 @@ async function seedSession(sessionId: string, turns: number): Promise<string> {
   }))
   const filePath = join(projectDir, `${sessionId}.jsonl`)
   await writeFile(filePath, jsonLines(records))
+  // os.homedir() reads USERPROFILE on Windows and HOME on POSIX, so the fixture
+  // home has to override both for the resolver to land inside the temp dir.
   process.env.HOME = root
+  process.env.USERPROFILE = root
   return filePath
 }
 
@@ -73,6 +83,13 @@ beforeEach(() => {
 afterEach(async () => {
   await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })))
   tempRoots = []
+  for (const [key, value] of Object.entries(originalHomeEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
 })
 
 describe('readNativeChatTranscriptCached', () => {


### PR DESCRIPTION
## Summary

No user-visible change. Three suites redirect the home directory at a temp fixture by setting `process.env.HOME`, so that production code reading `os.homedir()` resolves inside the fixture. That works on POSIX only. On Windows `os.homedir()` reads `USERPROFILE`, so the redirect is ignored and the resolver walks the real user home instead. 7 failures across 3 files on a clean Windows checkout of `main`.

The fix sets both variables wherever the fixture home is installed, and restores both afterwards.

| file | what it redirects for |
|---|---|
| `src/main/ipc/native-chat.test.ts` | `session-file-resolver.ts:19` joins `homedir()` with `.claude/projects` |
| `src/main/native-chat/transcript-read-cache.test.ts` | same resolver, reached through the cache |
| `src/main/kimi/hook-service.test.ts` | `getSharedManagedScriptPath()` writes under `homedir()/.orca` |

Two things worth flagging beyond the failure count:

- `native-chat.test.ts` installed the redirect five times with the same six-line save/restore block. Those are now one `redirectHome(root)` call returning its own restore, which is why the diff removes more lines than it adds.
- **Two of those five sites were passing for the wrong reason.** One asserts `expect(sender.send).not.toHaveBeenCalled()` and the other asserts `expect(result.error).toBeTruthy()`. When the redirect silently fails, no transcript is found, so both assertions hold and the tests pass without exercising anything. They are not in the 7-failure count, and they now assert against the fixture as intended.
- `transcript-read-cache.test.ts` set `HOME` inside `seedSession()` and never restored it, so the redirect outlived the test that installed it. That was harmless while only `HOME` was set, because Windows ignores it. Setting `USERPROFILE` without restoring would have leaked a deleted temp dir as the home directory to every later suite in the same worker, so the restore is now done in `afterEach`.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - every step passes except the last, `verify:skill-bundle-manifest` ("Generated skill artifacts are stale"). Pre-existing and Windows-specific: it fails identically on a clean checkout of the base commit `badf911`, this PR touches nothing under `resources/skills/`, and CI is green on `ubuntu-latest`. Passing steps: `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `lint:switch-exhaustiveness`, `check-styled-scrollbars`, `check:quadratic-buffer-concat`, `check:reliability-gates` (51 gates), `check:max-lines-ratchet` (no new bypasses), `verify:bundled-skill-guides`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` - the full suite exits non-zero on this host because of pre-existing Windows failures unrelated to this PR.

  Scoped to the three suites this PR touches:

  | | passed | failed |
  |---|---|---|
  | clean `main` at `badf911` | 11 | 7 |
  | this branch | 18 | 0 |

  Checked for regressions in the adjacent suites that share these directories (`src/main/native-chat`, `src/main/kimi`, `src/main/ipc/native-chat.test.ts`), since the restore changes what later tests in the same worker inherit:

  | | failing files | failing tests |
  |---|---|---|
  | clean `main` at `badf911` | 4 | 9 |
  | this branch | 1 | 2 |

  The file that still fails is `transcript-watch-error.test.ts`, with the same 2 failures and the same assertion diff before and after. It is unrelated to home resolution and is left alone.

- [x] `pnpm build`
- [x] No new tests were needed: this fixes how existing suites install their fixture home and does not change behavior. Seven tests that could not pass on Windows now run, and two more that were passing without exercising their fixture now do. On POSIX the added `USERPROFILE` assignment is inert, since `os.homedir()` there reads `HOME`.

Host: Windows 11 (26200), Node v24.11.1, base commit `badf911`.

## AI Review Report

Reviewed with Claude Code. Risks checked and findings:

- **Cross-platform** - the main risk. On POSIX `os.homedir()` reads `HOME`, so setting `USERPROFILE` alongside it changes nothing there; the suites keep running exactly as before. Verified directly on this host that `os.homedir()` returns the `USERPROFILE` value when both are set. The win32 side is verified locally (18 passed, 0 failed); the unchanged path is left to CI, since this host is Windows-only.
- **Environment leakage** - the reason the restore was added rather than just the assignment. `native-chat.test.ts` already restored in a `finally`, and now restores both variables through one returned closure. `hook-service.test.ts` restores in `afterEach` next to its existing `HOME` and `KIMI_CODE_HOME` handling. `transcript-read-cache.test.ts` had no restore at all; it captures both values at module load and restores them after the fixtures are removed. Each restore deletes the variable when it was previously unset rather than writing an empty string.
- **Test isolation** - every redirect still points at a per-test `mkdtemp` directory, so nothing is shared between tests or workers.
- **Production code** - untouched. `session-file-resolver.ts` already exposes a `claudeProjectsDir` override, but it is not threaded through `readNativeChatTranscriptCached()`, and widening that signature to serve tests would be a larger and more invasive change than fixing the fixture.
- **Agents / integrations / git providers / UI / performance** - untouched.
- **Security** - see below.

Considered and rejected: skipping these suites on Windows. The code under test is not platform-gated. `session-file-resolver.ts` and the Kimi hook installer both run on Windows, so skipping would drop real coverage rather than remove a false failure.

## Security Audit

No input handling, authentication, secret, dependency, or command execution code is modified. The diff touches three test files: it adds `USERPROFILE` next to existing `HOME` assignments and restores both. It narrows rather than widens process state leakage, since one suite previously left a fixture path in the environment permanently. No new dependencies.

## Notes

- Windows-specific by construction. macOS and Linux behavior is unchanged.
- `transcript-watch-error.test.ts` in the same directory fails on Windows for an unrelated reason (an error argument not reaching `onInitialSnapshot`). It is out of scope here and unchanged by this PR.
- Context on why this went unnoticed: no CI job runs the full unit suite on Windows. `.github/workflows/pr.yml` pins the `verify` job to `ubuntu-latest`, and the Windows vitest lane in `computer-e2e.yml` runs a hand-listed allowlist that these files are not in.
- X handle: `gyujinkim00`
