### PR TITLE
feat: show code language selector only on hover in markdown

### DIFF
--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -859,6 +859,12 @@
   font-size: 11px;
   font-family: var(--font-mono, monospace);
   cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.rich-markdown-code-block-wrapper:hover .rich-markdown-code-block-lang {
+  opacity: 1;
 }
 
 /* Copy button inside rich-mode code blocks — sits to the left of the


### PR DESCRIPTION
## Summary

Fixes #11054

The language selector for code elements in markdown was always visible and drawn over the code content, hiding characters behind it. This change shows the selector only while the pointer is over the code block, matching the existing behavior of the copy button.

## Changes

- Set default `opacity: 0` for `.rich-markdown-code-block-lang`
- Add smooth `0.15s` opacity transition
- Show on hover via `.rich-markdown-code-block-wrapper:hover`

This follows the exact same pattern already used for the copy button in the same stylesheet, ensuring consistent UI behavior.

## Test plan

- Open a markdown file with code blocks in the rich editor
- Verify the language selector is hidden by default
- Hover over a code block and verify the selector fades in
- Move the pointer away and verify it fades out

🤖 Generated with [Claude Code](https://claude.com/claude-code)