### PR TITLE
feat: add 'Reload from Disk' to editor actions menu and keybindings

### DIFF
--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -3,7 +3,6 @@ import { useAppStore } from '@/store'
 import { getConnectionId } from '@/lib/connection-context'
 import { detectLanguage } from '@/lib/language-detect'
 import { openFilePreviewToSide } from '@/lib/file-preview'
-import { getEditorHeaderCopyState } from './editor-header'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 import { exportActiveMarkdownToPdf } from './export-active-markdown'
@@ -14,6 +13,8 @@ import { canUseChangesModeForFile } from './editor-panel-file-mode'
 import { getEditorPanelRenderModel } from './editor-panel-render-model'
 import { useClosedEditorTabCleanup } from './useClosedEditorTabCleanup'
 import { useEditorCmdSaveRequest } from './useEditorCmdSaveRequest'
+import { useEditorReloadShortcut } from './useEditorReloadShortcut'
+import { useEditorCopyPath } from './useEditorCopyPath'
 import { useEditorPanelContentState } from './useEditorPanelContentState'
 import { useMarkdownPreviewShortcut } from './useMarkdownPreviewShortcut'
 import { useUntitledFileRename } from './useUntitledFileRename'
@@ -24,6 +25,7 @@ import {
 } from './editor-panel-git-entry-selector'
 import { createEditorPanelDraftSelector } from './editor-panel-draft-selector'
 import { attemptEditorFileSave } from './editor-file-save-attempt'
+import { reloadTabContentFromDisk } from './ExternalFileChangeBanner'
 
 function EditorPanelInner({
   activeFileId: activeFileIdProp,
@@ -69,30 +71,10 @@ function EditorPanelInner({
   const setEditorDraft = useAppStore((s) => s.setEditorDraft)
   const settings = useAppStore((s) => s.settings)
   const panelRef = useRef<HTMLDivElement>(null)
-  const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
-    null
-  )
-  const copiedPathToastResetTimerRef = useRef<number | null>(null)
-  // Why: clipboard IPC can resolve after the editor panel unmounts; skip path
-  // toast feedback instead of starting a reset timer on a stale panel.
-  const pathCopyMountedRef = useRef(false)
-  const clearCopiedPathToastResetTimer = useCallback((): void => {
-    if (copiedPathToastResetTimerRef.current === null) {
-      return
-    }
-    window.clearTimeout(copiedPathToastResetTimerRef.current)
-    copiedPathToastResetTimerRef.current = null
+  const { copiedPathToast, handleCopyPath } = useEditorCopyPath(activeFile)
+  const setPanelRef = useCallback((node: HTMLDivElement | null) => {
+    panelRef.current = node
   }, [])
-  const setPanelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      panelRef.current = node
-      pathCopyMountedRef.current = node !== null
-      if (!node) {
-        clearCopiedPathToastResetTimer()
-      }
-    },
-    [clearCopiedPathToastResetTimer]
-  )
   const [sideBySide, setSideBySide] = useState(settings?.diffDefaultView === 'side-by-side')
   const [prevDiffView, setPrevDiffView] = useState(settings?.diffDefaultView)
 
@@ -203,34 +185,20 @@ function EditorPanelInner({
   )
   useEditorCmdSaveRequest({ activeFile, openFiles, fileContents, handleSave })
 
-  const handleCopyPath = useCallback(async (): Promise<void> => {
-    if (!activeFile) {
+  // Why: only editable file tabs can reload; exclude diff views and read-only tabs.
+  const canReloadFromDisk =
+    activeFile?.mode === 'edit' &&
+    !activeFile.isUntitled &&
+    !fileContents[activeFile.id]?.isBinary
+
+  const handleReloadFromDisk = useCallback((): void => {
+    if (!activeFile || !canReloadFromDisk) {
       return
     }
-    const copyState = getEditorHeaderCopyState(activeFile)
-    if (!copyState.copyText) {
-      return
-    }
-    try {
-      await window.api.ui.writeClipboardText(copyState.copyText)
-      if (!pathCopyMountedRef.current) {
-        return
-      }
-      clearCopiedPathToastResetTimer()
-      const nextToast = { fileId: activeFile.id, token: Date.now() }
-      setCopiedPathToast(nextToast)
-      copiedPathToastResetTimerRef.current = window.setTimeout(() => {
-        copiedPathToastResetTimerRef.current = null
-        setCopiedPathToast((current) => (current?.token === nextToast.token ? null : current))
-      }, 1500)
-    } catch {
-      if (!pathCopyMountedRef.current) {
-        return
-      }
-      clearCopiedPathToastResetTimer()
-      setCopiedPathToast(null)
-    }
-  }, [activeFile, clearCopiedPathToastResetTimer])
+    reloadTabContentFromDisk(activeFile, reloadContent)
+  }, [activeFile, canReloadFromDisk, reloadContent])
+
+  useEditorReloadShortcut({ activeFile, canReloadFromDisk, handleReloadFromDisk })
 
   if (!activeFile) {
     return null
@@ -361,6 +329,7 @@ function EditorPanelInner({
         showMarkdownTableOfContents={isMarkdownTableOfContentsVisible}
         canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={isMarkdownFrontmatterVisible}
+        canReloadFromDisk={canReloadFromDisk}
         sideBySide={sideBySide}
         openFiles={openFiles}
         fileContents={fileContents}
@@ -389,6 +358,7 @@ function EditorPanelInner({
         onExportMarkdownToPdf={() =>
           void exportActiveMarkdownToPdf({ fileId: activeFile.id, root: panelRef.current })
         }
+        onReloadFromDisk={handleReloadFromDisk}
         onContentChange={handleContentChange}
         onContentChangeForFile={handleContentChangeForFile}
         onDirtyStateHint={handleDirtyStateHint}

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -38,6 +38,7 @@ type EditorPanelHeaderProps = {
   showMarkdownTableOfContents: boolean
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
+  canReloadFromDisk: boolean
   sideBySide: boolean
   openFileState: EditorHeaderOpenFileState
   onCopyPath: () => void
@@ -50,6 +51,7 @@ type EditorPanelHeaderProps = {
   onToggleMarkdownTableOfContents: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
+  onReloadFromDisk: () => void
 }
 
 export function EditorPanelHeader({
@@ -72,6 +74,7 @@ export function EditorPanelHeader({
   showMarkdownTableOfContents,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
+  canReloadFromDisk,
   sideBySide,
   openFileState,
   onCopyPath,
@@ -83,7 +86,8 @@ export function EditorPanelHeader({
   onEditorToggleChange,
   onToggleMarkdownTableOfContents,
   onToggleMarkdownFrontmatter,
-  onExportMarkdownToPdf
+  onExportMarkdownToPdf,
+  onReloadFromDisk
 }: EditorPanelHeaderProps): React.JSX.Element {
   const diffComments = useAppStore((s) =>
     selectWorktreeDiffCommentsOrEmpty(s, activeFile.worktreeId)
@@ -320,10 +324,12 @@ export function EditorPanelHeader({
         canExportMarkdownToPdf={canExportMarkdownToPdf}
         canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={markdownFrontmatterVisible}
+        canReloadFromDisk={canReloadFromDisk}
         onToggleDiffWordWrap={() => void updateSettings({ diffWordWrap: !diffWordWrap })}
         onToggleEditorWordWrap={() => void updateSettings({ editorWordWrap: !editorWordWrap })}
         onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
         onExportMarkdownToPdf={onExportMarkdownToPdf}
+        onReloadFromDisk={onReloadFromDisk}
       />
     </div>
   )

--- a/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
@@ -21,10 +21,12 @@ type EditorPanelMarkdownActionsMenuProps = {
   canExportMarkdownToPdf: boolean
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
+  canReloadFromDisk: boolean
   onToggleDiffWordWrap: () => void
   onToggleEditorWordWrap: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
+  onReloadFromDisk: () => void
 }
 
 export function EditorPanelMarkdownActionsMenu({
@@ -36,10 +38,12 @@ export function EditorPanelMarkdownActionsMenu({
   canExportMarkdownToPdf,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
+  canReloadFromDisk,
   onToggleDiffWordWrap,
   onToggleEditorWordWrap,
   onToggleMarkdownFrontmatter,
-  onExportMarkdownToPdf
+  onExportMarkdownToPdf,
+  onReloadFromDisk
 }: EditorPanelMarkdownActionsMenuProps): React.JSX.Element | null {
   const hasMarkdownActions =
     isMarkdown && (shouldShowMarkdownExportAction || canShowMarkdownFrontmatterToggle)
@@ -72,6 +76,17 @@ export function EditorPanelMarkdownActionsMenu({
             'Word Wrap'
           )}
         </DropdownMenuCheckboxItem>
+        {canReloadFromDisk ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onReloadFromDisk}>
+              {translate(
+                'auto.components.editor.EditorPanelMarkdownActionsMenu.3fa2b8d417',
+                'Reload from Disk'
+              )}
+            </DropdownMenuItem>
+          </>
+        ) : null}
         {hasMarkdownActions ? <DropdownMenuSeparator /> : null}
         {canShowMarkdownFrontmatterToggle ? (
           <>

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -22,6 +22,7 @@ type EditorPanelShellProps = {
   showMarkdownTableOfContents: boolean
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
+  canReloadFromDisk: boolean
   sideBySide: boolean
   openFiles: OpenFile[]
   fileContents: Record<string, FileContent>
@@ -41,6 +42,7 @@ type EditorPanelShellProps = {
   onToggleMarkdownTableOfContents: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
+  onReloadFromDisk: () => void
   onContentChange: (content: string) => void
   onContentChangeForFile: (file: OpenFile, content: string) => void
   onDirtyStateHint: (dirty: boolean) => void
@@ -62,6 +64,7 @@ export function EditorPanelShell({
   showMarkdownTableOfContents,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
+  canReloadFromDisk,
   sideBySide,
   openFiles,
   fileContents,
@@ -81,6 +84,7 @@ export function EditorPanelShell({
   onToggleMarkdownTableOfContents,
   onToggleMarkdownFrontmatter,
   onExportMarkdownToPdf,
+  onReloadFromDisk,
   onContentChange,
   onContentChangeForFile,
   onDirtyStateHint,
@@ -115,6 +119,7 @@ export function EditorPanelShell({
           showMarkdownTableOfContents={showMarkdownTableOfContents}
           canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
           markdownFrontmatterVisible={markdownFrontmatterVisible}
+          canReloadFromDisk={canReloadFromDisk}
           sideBySide={sideBySide}
           openFileState={model.openFileState}
           onCopyPath={onCopyPath}
@@ -127,6 +132,7 @@ export function EditorPanelShell({
           onToggleMarkdownTableOfContents={onToggleMarkdownTableOfContents}
           onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
           onExportMarkdownToPdf={onExportMarkdownToPdf}
+          onReloadFromDisk={onReloadFromDisk}
         />
       )}
       <Suspense fallback={<EditorLoadingFallback />}>

--- a/src/renderer/src/components/editor/useEditorCopyPath.ts
+++ b/src/renderer/src/components/editor/useEditorCopyPath.ts
@@ -1,0 +1,54 @@
+import { useCallback, useRef, useState } from 'react'
+import type { OpenFile } from '@/store/slices/editor'
+import { getEditorHeaderCopyState } from './editor-header-copy-state'
+
+type UseEditorCopyPathResult = {
+  copiedPathToast: { fileId: string; token: number } | null
+  handleCopyPath: () => Promise<void>
+}
+
+export function useEditorCopyPath(activeFile: OpenFile | null): UseEditorCopyPathResult {
+  const [copiedPathToast, setCopiedPathToast] = useState<{ fileId: string; token: number } | null>(
+    null
+  )
+  const copiedPathToastResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pathCopyMountedRef = useRef(true)
+
+  const clearCopiedPathToastResetTimer = useCallback(() => {
+    if (copiedPathToastResetTimerRef.current !== null) {
+      clearTimeout(copiedPathToastResetTimerRef.current)
+      copiedPathToastResetTimerRef.current = null
+    }
+  }, [])
+
+  const handleCopyPath = useCallback(async (): Promise<void> => {
+    if (!activeFile) {
+      return
+    }
+    const copyState = getEditorHeaderCopyState(activeFile)
+    if (!copyState.copyText) {
+      return
+    }
+    try {
+      await window.api.ui.writeClipboardText(copyState.copyText)
+      if (!pathCopyMountedRef.current) {
+        return
+      }
+      clearCopiedPathToastResetTimer()
+      const nextToast = { fileId: activeFile.id, token: Date.now() }
+      setCopiedPathToast(nextToast)
+      copiedPathToastResetTimerRef.current = window.setTimeout(() => {
+        copiedPathToastResetTimerRef.current = null
+        setCopiedPathToast((current) => (current?.token === nextToast.token ? null : current))
+      }, 1500)
+    } catch {
+      if (!pathCopyMountedRef.current) {
+        return
+      }
+      clearCopiedPathToastResetTimer()
+      setCopiedPathToast(null)
+    }
+  }, [activeFile, clearCopiedPathToastResetTimer])
+
+  return { copiedPathToast, handleCopyPath }
+}

--- a/src/renderer/src/components/editor/useEditorReloadShortcut.ts
+++ b/src/renderer/src/components/editor/useEditorReloadShortcut.ts
@@ -1,0 +1,34 @@
+import { useEffect } from 'react'
+import type { OpenFile } from '@/store/slices/editor'
+import { editorShortcutMatches } from './editor-shortcuts'
+
+type UseEditorReloadShortcutParams = {
+  activeFile: OpenFile | null
+  canReloadFromDisk: boolean
+  handleReloadFromDisk: () => void
+}
+
+export function useEditorReloadShortcut({
+  activeFile,
+  canReloadFromDisk,
+  handleReloadFromDisk
+}: UseEditorReloadShortcutParams): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (!activeFile || !canReloadFromDisk) {
+        return
+      }
+      if (!editorShortcutMatches('editor.reloadFromDisk', event)) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      if (!event.repeat) {
+        handleReloadFromDisk()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown, true)
+    return () => window.removeEventListener('keydown', handleKeyDown, true)
+  }, [activeFile, canReloadFromDisk, handleReloadFromDisk])
+}

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -87,6 +87,7 @@ export type KeybindingActionId =
   | 'editor.find'
   | 'editor.replace'
   | 'editor.save'
+  | 'editor.reloadFromDisk'
   | 'editor.markdownPreview'
   | 'editor.toggleWordWrap'
   | 'editor.copyContext'
@@ -798,6 +799,14 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'editor',
     searchKeywords: ['shortcut', 'editor', 'save'],
     defaultBindings: platformBindings(['Mod+S'])
+  },
+  {
+    id: 'editor.reloadFromDisk',
+    title: 'Reload from Disk',
+    group: 'Editors',
+    scope: 'editor',
+    searchKeywords: ['shortcut', 'editor', 'reload', 'revert', 'disk'],
+    defaultBindings: platformBindings([])
   },
   {
     id: 'editor.markdownPreview',


### PR DESCRIPTION
## Summary

Fixes #11085

Exposes the existing `reloadTabContentFromDisk` action through the two surfaces editor features already use, mirroring how Word Wrap works today (#10086). Previously this action had exactly one entry point — the `ExternalFileChangeBanner` — which is a one-way door once dismissed.

## Changes

1. **Keybinding** — Added `editor.reloadFromDisk` action (`group: 'Editors'`, `scope: 'editor'`), **unbound by default**. `Ctrl+R` / `Ctrl+Shift+R` are already taken on Windows/Linux, so this follows the assign-it-yourself pattern from #6169.
2. **Menu item** — Added a "Reload from Disk" item to `EditorPanelMarkdownActionsMenu` (the `…` menu), alongside Export as PDF.
3. **Shared predicate** — Both surfaces are gated on editable file tabs only. Diff surfaces are excluded because the reload rotates the Monaco model and drops its undo stack; read-only live-tail tabs already follow the file on their own.

Both call the already-exported `reloadTabContentFromDisk(file, reloadContent)`, so behavior is identical to the banner action, including the "Reloaded from disk" toast with Undo. No new reload logic.

### Implementation notes

- New `useEditorReloadShortcut` hook handles the keyboard shortcut
- Extracted `useEditorCopyPath` hook to keep `EditorPanel.tsx` under the max-lines limit (no `max-lines` disable added)

## Test plan

- Open an editable file, modify on disk externally, and verify "Reload from Disk" in the `…` menu loads disk content with an Undo toast
- Assign a shortcut to `editor.reloadFromDisk` in settings and verify it triggers the same action
- Verify the item/shortcut is disabled for diff views and read-only tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)