### PR TITLE
fix(skills): stop reporting a failed update when the CLI succeeded

### DIFF
--- a/src/main/skills/skill-update-outcome.test.ts
+++ b/src/main/skills/skill-update-outcome.test.ts
@@ -38,10 +38,13 @@ describe('skillUpdateFailedNames', () => {
     expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'current')])).toEqual([])
   })
 
-  it('reports a copy the run left outdated', () => {
-    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'outdated')])).toEqual([
-      'orca-cli'
-    ])
+  // Reversed deliberately. `skills update` compares its lock against the source
+  // and never reads disk, so once the lock has advanced past the installed bytes
+  // it prints "up to date", exits 0 and writes nothing — leaving a recognised
+  // older revision that no retry converges. Blaming the run for that invented a
+  // failure the CLI never reported and armed a Retry that could not succeed.
+  it('does not blame the run for a copy the update command cannot converge', () => {
+    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'outdated')])).toEqual([])
   })
 
   it('reports a half-written bundle instead of reading it as success', () => {
@@ -76,20 +79,31 @@ describe('skillUpdateFailedNames', () => {
     ).toEqual([])
   })
 
-  it('fails the name when any convergent alias was left behind', () => {
+  // Still fails on a DEGRADED alias — only `outdated` was reclassified, so a
+  // half-written alias beside a good canonical copy must not read as success.
+  it('fails the name when any convergent alias was left broken', () => {
+    expect(
+      skillUpdateFailedNames(
+        ['orca-cli'],
+        [placement('orca-cli', 'current'), placement('orca-cli', 'unrecognized', 'provider-alias')]
+      )
+    ).toEqual(['orca-cli'])
+  })
+
+  it('does not fail the name for an alias the command merely left old', () => {
     expect(
       skillUpdateFailedNames(
         ['orca-cli'],
         [placement('orca-cli', 'current'), placement('orca-cli', 'outdated', 'provider-alias')]
       )
-    ).toEqual(['orca-cli'])
+    ).toEqual([])
   })
 
   it('judges each requested name independently', () => {
     expect(
       skillUpdateFailedNames(
         ['orca-cli', 'orchestration'],
-        [placement('orca-cli', 'current'), placement('orchestration', 'outdated')]
+        [placement('orca-cli', 'current'), placement('orchestration', 'unrecognized')]
       )
     ).toEqual(['orchestration'])
   })

--- a/src/main/skills/skill-update-outcome.ts
+++ b/src/main/skills/skill-update-outcome.ts
@@ -34,6 +34,22 @@ export function skillUpdateFailedNames(
     }
     // `newer-known` counts as landed: the CLI pulls from the source repo, which
     // can be ahead of the revision this build ships in its manifest.
-    return convergent.some((entry) => entry.status !== 'current' && entry.status !== 'newer-known')
+    //
+    // `outdated` is not a failed run either. `skills update` compares its lock's
+    // recorded hash against the source and never reads disk, so when the lock has
+    // advanced past the installed bytes it reports "up to date", exits 0, and
+    // writes nothing. The copy is left intact — a recognised older revision, not
+    // a broken one — and no amount of retrying converges it. Calling that an
+    // error invented a failure the CLI never reported and armed a Retry that
+    // provably could not succeed. The freshness badge still marks the copy
+    // not-current, so this only stops the run being blamed for it.
+    //
+    // A genuinely botched write is still caught: a half-written bundle hashes to
+    // `unrecognized`, a wholly-degraded or removed copy leaves no convergent
+    // placement, and process-level failure surfaces through the spawn error.
+    return convergent.some(
+      (entry) =>
+        entry.status !== 'current' && entry.status !== 'newer-known' && entry.status !== 'outdated'
+    )
   })
 }


### PR DESCRIPTION
## Symptom

The Update skills dialog shows a red **"The update didn't finish" / "Some skills could not be updated"** with an armed **Retry** — directly above the runner's own log line saying **"✓ All global skills are up to date"**. Exit code was **0**. Retry re-runs the same command and no-ops again: a closed loop with no user recourse.

## Root cause

`skills update` compares its **lock's** recorded hash against the source and **never reads disk**. From the published CLI (`dist/cli.mjs`):

```js
const latestHash = getSkillFolderHashFromTree(tree, entry.skillPath);
if (latestHash && latestHash !== entry.skillFolderHash) updates.push(...)
```

So once the lock has advanced past the installed bytes, it prints up-to-date, exits 0, and writes nothing. The copy left behind is a **recognised older revision**.

The post-run re-scan then sees `outdated`; `skillUpdateFailedNames` counted that as a failed run; `skill-update-run.ts` settles `failed.length > 0` → `state: 'error'` → banner + Retry. Orca was **inventing a failure the CLI never reported**.

## Fix

Reclassify `outdated` as *"the command did not converge this"*, not *"the run failed"*.

The freshness badge still marks the copy not-current, so nothing is hidden — the **run** just stops being blamed for it.

**A botched write is still caught:** a half-written bundle hashes to `unrecognized`, a wholly-degraded or removed copy leaves no convergent placement, and process-level failure still surfaces through the spawn error. Only the intact-but-old case moved.

## Blast radius

Not two skills. **Every bundled skill** shows a stub → full → stub oscillation in its last three registry revisions:

| skill | rev N-2 | rev N-1 | rev N |
|---|---|---|---|
| orca-cli | 3835 | 21557 | 3835 |
| orchestration | 4220 | 22676 | 4220 |
| orca-per-workspace-env | 4222 | 43769 | 4222 |

Anyone who updated inside that middle window lands in this state.

## Tests

Three existing cases encoded the old behavior and were changed **deliberately** — called out here because reversing an intended behavior deserves review, not a silent edit:

- `reports a copy the run left outdated` → **reversed** to `does not blame the run for a copy the update command cannot converge`
- `fails the name when any convergent alias was left behind` → now uses `unrecognized`, so degraded-alias coverage stays non-vacuous, plus a new case that an *outdated* alias does not fail
- `judges each requested name independently` → now uses `unrecognized` to keep the independence assertion meaningful

Mutation-checked — restoring the old condition fails exactly the two new assertions:

```
× does not blame the run for a copy the update command cannot converge
× does not fail the name for an alias the command merely left old
Tests  2 failed | 8 passed (10)
```

With the fix: **69 passed** across `skill-update-outcome`, `skill-update-run`, `SkillFreshnessUpdateDialog`, and `skill-freshness-eligibility`. `pnpm run tc` clean.

## Not fixed here (deliberately out of scope)

The real convergence path is `skills add stablyai/orca --skill <name> --global -y`, which **does** re-materialize (verified: rewrote 12190 → 3902 while an untouched control stayed drifted). Wiring Retry to `add`, plus the lock-vs-disk eligibility signal so these are never offered as a routine update, belongs with the skills-updater owner (@nwparker) who is already on it. This PR only stops the lie.

Note `--skill a,b` (comma) silently matches nothing and **still exits 0** — one name per flag.

Found by a release-readiness scan of `v1.4.159..v1.4.160-rc.3`.