### PR TITLE
fix(skills): keep a failed update run honest when nothing converged

### DIFF
--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -30,9 +30,9 @@ export function registerSkillsHandlers(store: Store): void {
   const runner = new SkillUpdateRunner({
     // Why: per-skill outcomes come from re-hashing what is actually on disk, not
     // from scraping stdout.
-    rescanOutdatedNames: async (names) => {
+    rescanOutdatedNames: async (names, commandFailed) => {
       const inventory = await scanInventory()
-      return skillUpdateFailedNames(names, inventory.installations)
+      return skillUpdateFailedNames(names, inventory.installations, commandFailed)
     },
     onState: (run: SkillUpdateRun) => {
       for (const window of BrowserWindow.getAllWindows()) {

--- a/src/main/skills/skill-update-outcome.test.ts
+++ b/src/main/skills/skill-update-outcome.test.ts
@@ -35,7 +35,9 @@ function placement(
 
 describe('skillUpdateFailedNames', () => {
   it('treats a convergent copy that is now current as landed', () => {
-    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'current')])).toEqual([])
+    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'current')], false)).toEqual(
+      []
+    )
   })
 
   // Reversed deliberately. `skills update` compares its lock against the source
@@ -44,37 +46,61 @@ describe('skillUpdateFailedNames', () => {
   // older revision that no retry converges. Blaming the run for that invented a
   // failure the CLI never reported and armed a Retry that could not succeed.
   it('does not blame the run for a copy the update command cannot converge', () => {
-    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'outdated')])).toEqual([])
+    expect(
+      skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'outdated')], false)
+    ).toEqual([])
+  })
+
+  it('still blames an outdated copy when the command itself failed', () => {
+    // An offline run exits non-zero having written nothing; forgiving the
+    // outdated copy there would read the failure as "Updated N skills".
+    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'outdated')], true)).toEqual(
+      ['orca-cli']
+    )
+  })
+
+  it('accepts current and newer copies even when the command failed', () => {
+    // A peer skill outside the request can fail the process; what landed, landed.
+    expect(
+      skillUpdateFailedNames(
+        ['orca-cli', 'orchestration'],
+        [placement('orca-cli', 'current'), placement('orchestration', 'newer-known')],
+        true
+      )
+    ).toEqual([])
   })
 
   it('reports a half-written bundle instead of reading it as success', () => {
     // The old "still eligible?" test passed here: an unrecognized copy is not
     // eligible either, so a corrupt write looked identical to a clean update.
-    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'unrecognized')])).toEqual([
-      'orca-cli'
-    ])
+    expect(
+      skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'unrecognized')], false)
+    ).toEqual(['orca-cli'])
   })
 
   it('reports an unreadable copy', () => {
-    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'inaccessible')])).toEqual([
-      'orca-cli'
-    ])
+    expect(
+      skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'inaccessible')], false)
+    ).toEqual(['orca-cli'])
   })
 
   it('reports a skill the run removed outright', () => {
-    expect(skillUpdateFailedNames(['orca-cli'], [])).toEqual(['orca-cli'])
+    expect(skillUpdateFailedNames(['orca-cli'], [], false)).toEqual(['orca-cli'])
   })
 
   it('accepts a revision newer than this build ships', () => {
     // The CLI pulls from the source repo, which runs ahead of the bundled manifest.
-    expect(skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'newer-known')])).toEqual([])
+    expect(
+      skillUpdateFailedNames(['orca-cli'], [placement('orca-cli', 'newer-known')], false)
+    ).toEqual([])
   })
 
   it('ignores placements the update command never writes to', () => {
     expect(
       skillUpdateFailedNames(
         ['orca-cli'],
-        [placement('orca-cli', 'current'), placement('orca-cli', 'outdated', 'plugin-cache')]
+        [placement('orca-cli', 'current'), placement('orca-cli', 'outdated', 'plugin-cache')],
+        false
       )
     ).toEqual([])
   })
@@ -85,7 +111,8 @@ describe('skillUpdateFailedNames', () => {
     expect(
       skillUpdateFailedNames(
         ['orca-cli'],
-        [placement('orca-cli', 'current'), placement('orca-cli', 'unrecognized', 'provider-alias')]
+        [placement('orca-cli', 'current'), placement('orca-cli', 'unrecognized', 'provider-alias')],
+        false
       )
     ).toEqual(['orca-cli'])
   })
@@ -94,7 +121,8 @@ describe('skillUpdateFailedNames', () => {
     expect(
       skillUpdateFailedNames(
         ['orca-cli'],
-        [placement('orca-cli', 'current'), placement('orca-cli', 'outdated', 'provider-alias')]
+        [placement('orca-cli', 'current'), placement('orca-cli', 'outdated', 'provider-alias')],
+        false
       )
     ).toEqual([])
   })
@@ -103,7 +131,8 @@ describe('skillUpdateFailedNames', () => {
     expect(
       skillUpdateFailedNames(
         ['orca-cli', 'orchestration'],
-        [placement('orca-cli', 'current'), placement('orchestration', 'unrecognized')]
+        [placement('orca-cli', 'current'), placement('orchestration', 'unrecognized')],
+        false
       )
     ).toEqual(['orchestration'])
   })

--- a/src/main/skills/skill-update-outcome.ts
+++ b/src/main/skills/skill-update-outcome.ts
@@ -23,7 +23,8 @@ import {
  */
 export function skillUpdateFailedNames(
   names: readonly string[],
-  installations: readonly SkillFreshnessInstallation[]
+  installations: readonly SkillFreshnessInstallation[],
+  commandFailed: boolean
 ): string[] {
   return names.filter((name) => {
     const convergent = installations.filter(
@@ -35,21 +36,25 @@ export function skillUpdateFailedNames(
     // `newer-known` counts as landed: the CLI pulls from the source repo, which
     // can be ahead of the revision this build ships in its manifest.
     //
-    // `outdated` is not a failed run either. `skills update` compares its lock's
-    // recorded hash against the source and never reads disk, so when the lock has
-    // advanced past the installed bytes it reports "up to date", exits 0, and
-    // writes nothing. The copy is left intact — a recognised older revision, not
-    // a broken one — and no amount of retrying converges it. Calling that an
-    // error invented a failure the CLI never reported and armed a Retry that
-    // provably could not succeed. The freshness badge still marks the copy
-    // not-current, so this only stops the run being blamed for it.
+    // `outdated` is forgiven only when the CLI reported success. `skills update`
+    // compares its lock's recorded hash against the source and never reads disk,
+    // so when the lock has advanced past the installed bytes it reports "up to
+    // date", exits 0, and writes nothing. The copy is left intact — a recognised
+    // older revision, not a broken one — and no amount of retrying converges it.
+    // Calling that an error invented a failure the CLI never reported and armed
+    // a Retry that provably could not succeed. The freshness badge still marks
+    // the copy not-current, so this only stops the run being blamed for it.
     //
-    // A genuinely botched write is still caught: a half-written bundle hashes to
-    // `unrecognized`, a wholly-degraded or removed copy leaves no convergent
-    // placement, and process-level failure surfaces through the spawn error.
+    // When the command itself failed (spawn error, non-zero exit), an outdated
+    // copy means the update never landed — forgiving it there would read an
+    // offline no-op as "Updated N skills". A genuinely botched write is still
+    // caught in both modes: a half-written bundle hashes to `unrecognized`, and
+    // a wholly-degraded or removed copy leaves no convergent placement.
     return convergent.some(
       (entry) =>
-        entry.status !== 'current' && entry.status !== 'newer-known' && entry.status !== 'outdated'
+        entry.status !== 'current' &&
+        entry.status !== 'newer-known' &&
+        (commandFailed || entry.status !== 'outdated')
     )
   })
 }

--- a/src/main/skills/skill-update-run.test.ts
+++ b/src/main/skills/skill-update-run.test.ts
@@ -12,7 +12,7 @@ class FakeChild extends EventEmitter {
 
 function makeRunner(
   overrides: {
-    rescanOutdatedNames?: (names: string[]) => Promise<string[]>
+    rescanOutdatedNames?: (names: string[], commandFailed: boolean) => Promise<string[]>
     resolveCommand?: (name: string) => string
     killTree?: (pid: number, killRoot: () => void) => Promise<void>
     buildSpawnArgs?: (command: string, args: string[]) => { spawnCmd: string; spawnArgs: string[] }
@@ -103,6 +103,35 @@ describe('SkillUpdateRunner', () => {
     child.emit('close', 1)
     await flush()
 
+    expect(runner.getState().state).toBe('success')
+  })
+
+  it('reports the failure when the command failed and nothing converged', async () => {
+    // The verdict forgives `outdated` only on a clean exit; without the flag an
+    // offline run that wrote nothing would publish "Updated N skills".
+    const rescan = vi.fn(async (names: string[], commandFailed: boolean) =>
+      commandFailed ? names : []
+    )
+    const { runner, child } = makeRunner({ rescanOutdatedNames: rescan })
+    runner.start(['orca-cli'])
+    child.emit('close', 1)
+    await flush()
+
+    expect(rescan).toHaveBeenCalledWith(['orca-cli'], true)
+    const run = runner.getState()
+    expect(run.state).toBe('error')
+    expect(run.state === 'error' && run.failedNames).toEqual(['orca-cli'])
+    expect(run.state === 'error' && run.message).toBe('skills update exited with code 1')
+  })
+
+  it('tells the verdict the command succeeded on a clean exit', async () => {
+    const rescan = vi.fn(async () => [])
+    const { runner, child } = makeRunner({ rescanOutdatedNames: rescan })
+    runner.start(['orca-cli'])
+    child.emit('close', 0)
+    await flush()
+
+    expect(rescan).toHaveBeenCalledWith(['orca-cli'], false)
     expect(runner.getState().state).toBe('success')
   })
 

--- a/src/main/skills/skill-update-run.ts
+++ b/src/main/skills/skill-update-run.ts
@@ -29,8 +29,12 @@ export const CANCEL_RELEASE_TIMEOUT_MS = 12_000
 export type SkillUpdateRunnerDeps = {
   spawnProcess?: typeof spawn
   resolveCommand?: (commandName: string) => string
-  /** Returns the subset of `names` that did not land, re-read from disk. */
-  rescanOutdatedNames?: (names: string[]) => Promise<string[]>
+  /**
+   * Returns the subset of `names` that did not land, re-read from disk.
+   * `commandFailed` relays whether the CLI itself reported failure, which
+   * decides whether a merely-outdated copy is forgiven.
+   */
+  rescanOutdatedNames?: (names: string[], commandFailed: boolean) => Promise<string[]>
   killTree?: (pid: number, killRoot: () => void) => Promise<void>
   /** Injected so the Windows cmd.exe rail is reachable off Windows. */
   buildSpawnArgs?: typeof getSpawnArgsForWindows
@@ -194,8 +198,9 @@ export class SkillUpdateRunner {
 
     // Why: when the re-scan produces a verdict it *is* the answer — it re-hashes
     // what landed on disk, which is what the user actually cares about. The exit
-    // code only decides the outcome when no verdict is available, because
-    // `skills update` reports nothing else we can trust.
+    // code decides the outcome alone only when no verdict is available, but the
+    // verdict is told whether the command failed: a copy the CLI merely left old
+    // is forgiven after a clean exit and blamed after a failed one.
     const finish = (failedNames: string[] | null): void => {
       // The re-scan is slow enough that a cancel — or a whole replacement run —
       // can land while it is still in flight; its verdict is about a run that no
@@ -222,7 +227,7 @@ export class SkillUpdateRunner {
       finish(null)
       return
     }
-    void rescan(names).then(
+    void rescan(names, spawnError !== null).then(
       (failedNames) => finish(failedNames),
       () => finish(null)
     )


### PR DESCRIPTION
## What regressed

#11105 (a8660839ee) reclassified `outdated` as not-a-failed-run so a clean-exit lock-drift no-op stops arming the red banner + Retry loop. Correct — but `finish()` in `src/main/skills/skill-update-run.ts` discards `spawnError` whenever the re-scan verdict is empty (`failedNames ?? (spawnError ? names : [])` short-circuits on `[]`). Pre-#11105 an empty verdict proved the requested skills converged; post-#11105 it also covers "left old and untouched".

**Exact false-success path:** offline / npx ENOENT / non-zero exit -> CLI writes nothing -> skills still merely `outdated` -> verdict `[]` -> run publishes green "Updated N skills" and a green status-bar check, masking the process failure.

## Fix

Thread the command's own result into the verdict (the cheap honest signal — no pre-run state, no stdout parsing):

- `skill-update-run.ts`: `rescan(names, spawnError !== null)`
- `ipc/skills.ts`: forwards the flag
- `skill-update-outcome.ts`: `outdated` is forgiven only when the CLI reported success; `current`/`newer-known` still count as landed even on a failed exit (a peer skill can fail the process — preserves the tested behavior)

The #11105 core fix survives: exit 0 + outdated -> success, no banner, no Retry.

## Test evidence

- `pnpm vitest run` outcome + run + ipc/skills tests: **38/38 pass**
- Mutation 1 — forgive `outdated` unconditionally: `still blames an outdated copy when the command itself failed` **fails** (1/12)
- Mutation 2 — runner always passes `commandFailed=false`: `reports the failure when the command failed and nothing converged` **fails** (1/20)
- Peer-skill pin (`treats a clean re-scan as success even though the exit code is non-zero`) and both #11105 reversal pins still pass
- `rm -f config/*.tsbuildinfo && pnpm run tc`: clean