### PR TITLE
fix(tasks): derive preset tab highlighting from query instead of click state

### DIFF
--- a/src/main/github/authenticated-viewer.test.ts
+++ b/src/main/github/authenticated-viewer.test.ts
@@ -102,6 +102,21 @@ describe('getAuthenticatedViewer', () => {
     expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
   })
 
+  it('bypasses a cached identity on an explicit refresh', async () => {
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ login: 'octocat' }), stderr: '' })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ login: 'hubot' }), stderr: '' })
+
+    await expect(getAuthenticatedViewer({ host: 'github.com' })).resolves.toMatchObject({
+      login: 'octocat'
+    })
+    await expect(
+      getAuthenticatedViewer({ host: 'github.com', force: true })
+    ).resolves.toMatchObject({ login: 'hubot' })
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
   it('returns and briefly caches null when the CLI lookup fails', async () => {
     ghExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
 

--- a/src/main/github/authenticated-viewer.test.ts
+++ b/src/main/github/authenticated-viewer.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { acquireMock, ghExecFileAsyncMock, releaseMock } = vi.hoisted(() => ({
+  acquireMock: vi.fn(() => Promise.resolve()),
+  ghExecFileAsyncMock: vi.fn(),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('./gh-utils', () => ({
+  acquire: acquireMock,
+  ghExecFileAsync: ghExecFileAsyncMock,
+  release: releaseMock
+}))
+
+import {
+  _getAuthenticatedViewerCacheSize,
+  _resetAuthenticatedViewerCache,
+  getAuthenticatedViewer
+} from './authenticated-viewer'
+
+describe('getAuthenticatedViewer', () => {
+  beforeEach(() => {
+    _resetAuthenticatedViewerCache()
+    acquireMock.mockClear()
+    ghExecFileAsyncMock.mockReset()
+    releaseMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('deduplicates concurrent and cached lookups in one auth scope', async () => {
+    ghExecFileAsyncMock.mockResolvedValue({
+      stdout: JSON.stringify({ login: 'octocat', email: 'octocat@example.com' }),
+      stderr: ''
+    })
+    const options = { cwd: '/workspace/one', host: 'github.com' }
+
+    await expect(
+      Promise.all([
+        getAuthenticatedViewer(options),
+        getAuthenticatedViewer({ ...options, cwd: '/workspace/two' })
+      ])
+    ).resolves.toEqual([
+      { login: 'octocat', email: 'octocat@example.com' },
+      { login: 'octocat', email: 'octocat@example.com' }
+    ])
+    await expect(getAuthenticatedViewer(options)).resolves.toEqual({
+      login: 'octocat',
+      email: 'octocat@example.com'
+    })
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(acquireMock).toHaveBeenCalledTimes(1)
+    expect(releaseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('isolates GitHub hosts and WSL auth scopes', async () => {
+    ghExecFileAsyncMock.mockImplementation(async (_args, options) => ({
+      stdout: JSON.stringify({ login: `${options.host}:${options.wslDistro ?? 'native'}` }),
+      stderr: ''
+    }))
+
+    await Promise.all([
+      getAuthenticatedViewer({ host: 'github.com' }),
+      getAuthenticatedViewer({ host: 'ghe.example.com' }),
+      getAuthenticatedViewer({ host: 'github.com', wslDistro: 'Ubuntu' })
+    ])
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('aliases the ambient default host to its explicit hostname', async () => {
+    vi.stubEnv('GH_HOST', '')
+    ghExecFileAsyncMock.mockResolvedValue({
+      stdout: JSON.stringify({ login: 'octocat' }),
+      stderr: ''
+    })
+
+    await Promise.all([getAuthenticatedViewer(), getAuthenticatedViewer({ host: 'github.com' })])
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('expires successful identity lookups after thirty seconds', async () => {
+    let now = 1_000
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ login: 'octocat' }), stderr: '' })
+      .mockResolvedValueOnce({ stdout: JSON.stringify({ login: 'hubot' }), stderr: '' })
+
+    await expect(getAuthenticatedViewer({ host: 'github.com' })).resolves.toMatchObject({
+      login: 'octocat'
+    })
+    now += 30_001
+    await expect(getAuthenticatedViewer({ host: 'github.com' })).resolves.toMatchObject({
+      login: 'hubot'
+    })
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns and briefly caches null when the CLI lookup fails', async () => {
+    ghExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
+
+    await expect(getAuthenticatedViewer({ host: 'github.com' })).resolves.toBeNull()
+    await expect(getAuthenticatedViewer({ host: 'github.com' })).resolves.toBeNull()
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(releaseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds cached auth scopes', async () => {
+    ghExecFileAsyncMock.mockResolvedValue({
+      stdout: JSON.stringify({ login: 'octocat' }),
+      stderr: ''
+    })
+
+    for (let index = 0; index < 40; index += 1) {
+      await getAuthenticatedViewer({ host: `ghe-${index}.example.com` })
+    }
+
+    expect(_getAuthenticatedViewerCacheSize()).toBeLessThanOrEqual(32)
+  })
+})

--- a/src/main/github/authenticated-viewer.ts
+++ b/src/main/github/authenticated-viewer.ts
@@ -1,0 +1,103 @@
+import type { GitHubViewer } from '../../shared/types'
+import { acquire, ghExecFileAsync, release } from './gh-utils'
+
+type GitHubViewerExecutionOptions = {
+  cwd?: string
+  host?: string
+  wslDistro?: string
+}
+
+const POSITIVE_TTL_MS = 30_000
+const NEGATIVE_TTL_MS = 5_000
+const CACHE_MAX_ENTRIES = 32
+
+const cache = new Map<string, { value: GitHubViewer | null; expiresAt: number }>()
+const inFlight = new Map<string, Promise<GitHubViewer | null>>()
+
+function cacheKey(options: GitHubViewerExecutionOptions): string {
+  const runtime = options.wslDistro
+    ? `wsl:${options.wslDistro.toLowerCase()}`
+    : `native:${process.env.GH_CONFIG_DIR ?? ''}`
+  const host =
+    options.host?.trim().toLowerCase() || process.env.GH_HOST?.trim().toLowerCase() || 'github.com'
+  return `${runtime}\0${host}`
+}
+
+function pruneCache(now: number): void {
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= now) {
+      cache.delete(key)
+    }
+  }
+  while (cache.size > CACHE_MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    cache.delete(oldestKey)
+  }
+}
+
+async function queryAuthenticatedViewer(
+  options: GitHubViewerExecutionOptions
+): Promise<GitHubViewer | null> {
+  await acquire()
+  try {
+    const { stdout } = await ghExecFileAsync(
+      ['api', 'user', '--jq', '{login: .login, email: .email}'],
+      { ...options, encoding: 'utf-8' }
+    )
+    const viewer = JSON.parse(stdout) as { login?: string; email?: string | null }
+    if (!viewer.login?.trim()) {
+      return null
+    }
+    return {
+      login: viewer.login.trim(),
+      email: viewer.email?.trim() || null
+    }
+  } catch {
+    return null
+  } finally {
+    release()
+  }
+}
+
+export function getAuthenticatedViewer(
+  options: GitHubViewerExecutionOptions = {}
+): Promise<GitHubViewer | null> {
+  const key = cacheKey(options)
+  const now = Date.now()
+  pruneCache(now)
+  const cached = cache.get(key)
+  if (cached && cached.expiresAt > now) {
+    return Promise.resolve(cached.value)
+  }
+  const pending = inFlight.get(key)
+  if (pending) {
+    return pending
+  }
+  const request = queryAuthenticatedViewer(options).then((viewer) => {
+    cache.set(key, {
+      value: viewer,
+      expiresAt: Date.now() + (viewer ? POSITIVE_TTL_MS : NEGATIVE_TTL_MS)
+    })
+    pruneCache(Date.now())
+    return viewer
+  })
+  inFlight.set(key, request)
+  void request.finally(() => {
+    if (inFlight.get(key) === request) {
+      inFlight.delete(key)
+    }
+  })
+  return request
+}
+
+export function _resetAuthenticatedViewerCache(): void {
+  cache.clear()
+  inFlight.clear()
+}
+
+export function _getAuthenticatedViewerCacheSize(): number {
+  return cache.size
+}

--- a/src/main/github/authenticated-viewer.ts
+++ b/src/main/github/authenticated-viewer.ts
@@ -3,6 +3,7 @@ import { acquire, ghExecFileAsync, release } from './gh-utils'
 
 type GitHubViewerExecutionOptions = {
   cwd?: string
+  force?: boolean
   host?: string
   wslDistro?: string
 }
@@ -65,18 +66,19 @@ async function queryAuthenticatedViewer(
 export function getAuthenticatedViewer(
   options: GitHubViewerExecutionOptions = {}
 ): Promise<GitHubViewer | null> {
-  const key = cacheKey(options)
+  const { force = false, ...executionOptions } = options
+  const key = cacheKey(executionOptions)
   const now = Date.now()
   pruneCache(now)
   const cached = cache.get(key)
-  if (cached && cached.expiresAt > now) {
+  if (!force && cached && cached.expiresAt > now) {
     return Promise.resolve(cached.value)
   }
   const pending = inFlight.get(key)
   if (pending) {
     return pending
   }
-  const request = queryAuthenticatedViewer(options).then((viewer) => {
+  const request = queryAuthenticatedViewer(executionOptions).then((viewer) => {
     cache.set(key, {
       value: viewer,
       expiresAt: Date.now() + (viewer ? POSITIVE_TTL_MS : NEGATIVE_TTL_MS)

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -14,7 +14,6 @@ import type {
   GitHubCommentResult,
   GitHubPRReviewCommentInput,
   PRComment,
-  GitHubViewer,
   GitHubWorkItem,
   GitHubPullRequestStateUpdate,
   GitHubRerunPRChecksResult,
@@ -116,6 +115,8 @@ import {
   spendsSharedGitHubComQuota,
   type RateLimitBucketKind
 } from './rate-limit'
+
+export { getAuthenticatedViewer } from './authenticated-viewer'
 
 type GhExecOptions = GitHubRepoExecOptions
 type HostedReviewLocalGitOptions = ReturnType<typeof getHostedReviewLocalGitOptions>
@@ -415,33 +416,6 @@ export async function starOrca(): Promise<boolean> {
     return true
   } catch {
     return false
-  } finally {
-    release()
-  }
-}
-
-/**
- * Get the authenticated GitHub viewer when gh is available and logged in.
- * Returns null when gh is unavailable, unauthenticated, or the lookup fails.
- */
-export async function getAuthenticatedViewer(): Promise<GitHubViewer | null> {
-  await acquire()
-  try {
-    const { stdout } = await execFileAsync(
-      'gh',
-      ['api', 'user', '--jq', '{login: .login, email: .email}'],
-      { encoding: 'utf-8' }
-    )
-    const viewer = JSON.parse(stdout) as { login?: string; email?: string | null }
-    if (!viewer.login?.trim()) {
-      return null
-    }
-    return {
-      login: viewer.login.trim(),
-      email: viewer.email?.trim() || null
-    }
-  } catch {
-    return null
   } finally {
     release()
   }

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -1301,6 +1301,70 @@ describe('registerGitHubHandlers', () => {
     expect(getAuthenticatedViewerMock).toHaveBeenCalled()
   })
 
+  it('routes a repo-scoped viewer lookup through its GitHub host and WSL auth scope', async () => {
+    setPlatform('win32')
+    projects = [
+      {
+        id: 'project-1',
+        displayName: 'repo',
+        badgeColor: 'blue',
+        sourceRepoIds: ['repo-1'],
+        localWindowsRuntimePreference: { kind: 'wsl', distro: 'Ubuntu' },
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ]
+    getAuthenticatedViewerMock.mockResolvedValue({ login: 'octocat', email: null })
+
+    registerGitHubHandlers(store as never, stats as never)
+    await handlers['gh:viewer'](null, {
+      repoPath: '/workspace/repo',
+      repoId: 'repo-1',
+      sourceContext: {
+        kind: 'task-source',
+        provider: 'github',
+        projectId: 'project-1',
+        hostId: 'local',
+        repoId: 'repo-1',
+        providerIdentity: {
+          provider: 'github',
+          owner: 'acme',
+          repo: 'orca',
+          host: 'ghe.example.com'
+        }
+      }
+    })
+
+    expect(getAuthenticatedViewerMock).toHaveBeenCalledWith({
+      cwd: '/workspace/repo',
+      host: 'ghe.example.com',
+      wslDistro: 'Ubuntu'
+    })
+  })
+
+  it('keeps SSH GitHub API auth on the desktop host', async () => {
+    repos[0].path = '/remote/repo'
+    repos[0].connectionId = 'ssh-1'
+    repos[0].executionHostId = 'ssh:ssh-1'
+    getAuthenticatedViewerMock.mockResolvedValue({ login: 'octocat', email: null })
+
+    registerGitHubHandlers(store as never, stats as never)
+    await handlers['gh:viewer'](null, {
+      repoPath: '/remote/repo',
+      repoId: 'repo-1',
+      sourceContext: {
+        kind: 'task-source',
+        provider: 'github',
+        projectId: 'project-1',
+        hostId: 'ssh:ssh-1',
+        repoId: 'repo-1',
+        providerIdentity: { provider: 'github', owner: 'acme', repo: 'orca' }
+      }
+    })
+
+    expect(getAuthenticatedViewerMock).toHaveBeenCalledWith({ host: 'github.com' })
+  })
+
   it('emits app_starred_orca once after a successful star with cohort context', async () => {
     starOrcaMock.mockResolvedValue(true)
     getCohortAtEmitMock.mockReturnValue({ nth_repo_added: 3 })

--- a/src/main/ipc/github.test.ts
+++ b/src/main/ipc/github.test.ts
@@ -1332,11 +1332,13 @@ describe('registerGitHubHandlers', () => {
           repo: 'orca',
           host: 'ghe.example.com'
         }
-      }
+      },
+      force: true
     })
 
     expect(getAuthenticatedViewerMock).toHaveBeenCalledWith({
       cwd: '/workspace/repo',
+      force: true,
       host: 'ghe.example.com',
       wslDistro: 'Ubuntu'
     })

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -133,6 +133,7 @@ type RepoScopedArgs = {
   repoPath: string
   repoId?: string | null
   sourceContext?: TaskSourceContext | null
+  force?: boolean
 }
 
 type RegisteredRepoValidationResult =
@@ -1186,7 +1187,10 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
       return getAuthenticatedViewer()
     }
     const repo = assertRegisteredRepo(args, store)
-    return getAuthenticatedViewer(getViewerExecutionOptions(store, repo, args))
+    return getAuthenticatedViewer({
+      ...getViewerExecutionOptions(store, repo, args),
+      ...(args.force === undefined ? {} : { force: args.force })
+    })
   })
   // Star operations target the Orca repo itself — no repoPath validation needed
   ipcMain.handle('gh:checkOrcaStarred', () => checkOrcaStarred())

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -193,6 +193,18 @@ function localGitOptionArgs(store: Store, repo: Repo): [] | [{ wslDistro?: strin
   return Object.keys(localGitOptions).length > 0 ? [localGitOptions] : []
 }
 
+function getViewerExecutionOptions(store: Store, repo: Repo, args: RepoScopedArgs) {
+  const identity =
+    args.sourceContext?.providerIdentity?.provider === 'github'
+      ? args.sourceContext.providerIdentity
+      : null
+  const host = identity ? identity.host?.trim() || 'github.com' : undefined
+  return {
+    ...(repo.connectionId ? {} : { cwd: repo.path, ...localGitOptionArgs(store, repo)[0] }),
+    ...(host ? { host } : {})
+  }
+}
+
 function applyRepoToPRRefreshCandidate(
   store: Store,
   repo: Repo,
@@ -1169,8 +1181,14 @@ export function registerGitHubHandlers(store: Store, stats: StatsCollector): voi
     )
   })
 
+  ipcMain.handle('gh:viewer', (_event, args?: RepoScopedArgs) => {
+    if (!args) {
+      return getAuthenticatedViewer()
+    }
+    const repo = assertRegisteredRepo(args, store)
+    return getAuthenticatedViewer(getViewerExecutionOptions(store, repo, args))
+  })
   // Star operations target the Orca repo itself — no repoPath validation needed
-  ipcMain.handle('gh:viewer', () => getAuthenticatedViewer())
   ipcMain.handle('gh:checkOrcaStarred', () => checkOrcaStarred())
   ipcMain.handle('gh:starOrca', async (_event, source: unknown) => {
     const sourceParse = appStarSourceSchema.safeParse(source)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -227,6 +227,7 @@ const {
   getPRForBranchOutcomeMock,
   getRepoSlugMock,
   getRepoUpstreamMock,
+  getAuthenticatedViewerMock,
   getGitHubWorkItemMock,
   getPullRequestPushTargetMock,
   getGitHubWorkItemByOwnerRepoMock,
@@ -334,6 +335,7 @@ const {
     getPRForBranchOutcomeMock: vi.fn().mockResolvedValue({ kind: 'no-pr', fetchedAt: 0 }),
     getRepoSlugMock: vi.fn().mockResolvedValue(null),
     getRepoUpstreamMock: vi.fn().mockResolvedValue(null),
+    getAuthenticatedViewerMock: vi.fn().mockResolvedValue(null),
     getGitHubWorkItemMock: vi.fn(),
     getPullRequestPushTargetMock: vi.fn(),
     getGitHubWorkItemByOwnerRepoMock: vi.fn(),
@@ -507,6 +509,7 @@ vi.mock('../github/client', async (importOriginal) => {
     getPRForBranchOutcome: getPRForBranchOutcomeMock,
     getRepoSlug: getRepoSlugMock,
     getRepoUpstream: getRepoUpstreamMock,
+    getAuthenticatedViewer: getAuthenticatedViewerMock,
     getWorkItem: getGitHubWorkItemMock,
     getPullRequestPushTarget: getPullRequestPushTargetMock,
     getWorkItemByOwnerRepo: getGitHubWorkItemByOwnerRepoMock,
@@ -722,6 +725,8 @@ function resetRuntimeTestMocks(): void {
   getRepoSlugMock.mockResolvedValue(null)
   getRepoUpstreamMock.mockReset()
   getRepoUpstreamMock.mockResolvedValue(null)
+  getAuthenticatedViewerMock.mockReset()
+  getAuthenticatedViewerMock.mockResolvedValue(null)
   getGitHubWorkItemMock.mockReset()
   getGitHubWorkItemMock.mockResolvedValue(null)
   getPullRequestPushTargetMock.mockReset()
@@ -6051,8 +6056,13 @@ describe('OrcaRuntimeService', () => {
       ]
     }
     const runtime = new OrcaRuntimeService(remoteStore as never)
+    getAuthenticatedViewerMock.mockResolvedValueOnce({ login: 'octocat', email: null })
 
     await expect(runtime.getRepoSlug('id:repo-1')).resolves.toBeNull()
+    await expect(runtime.getGitHubViewer('id:repo-1', 'github.com')).resolves.toEqual({
+      login: 'octocat',
+      email: null
+    })
     await expect(runtime.getRepoIssue('id:repo-1', 12)).resolves.toEqual({
       number: 12,
       title: 'Remote issue'
@@ -6069,6 +6079,7 @@ describe('OrcaRuntimeService', () => {
       ok: true
     })
     expect(getIssueMock).toHaveBeenCalledWith('/remote/repo', 12, 'ssh-1')
+    expect(getAuthenticatedViewerMock).toHaveBeenCalledWith({ host: 'github.com' })
     expect(listGitHubIssuesMock).toHaveBeenCalledWith('/remote/repo', 10, undefined, 'ssh-1')
     expect(requestGitHubPRReviewersMock).toHaveBeenCalledWith(
       '/remote/repo',
@@ -6109,6 +6120,7 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never)
     getRepoSlugMock.mockResolvedValueOnce({ owner: 'acme', repo: 'orca' })
     getRepoUpstreamMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    getAuthenticatedViewerMock.mockResolvedValueOnce({ login: 'octocat', email: null })
 
     await expect(runtime.getRepoSlug('id:repo-1')).resolves.toEqual({
       owner: 'acme',
@@ -6118,10 +6130,19 @@ describe('OrcaRuntimeService', () => {
       owner: 'stablyai',
       repo: 'orca'
     })
+    await expect(runtime.getGitHubViewer('id:repo-1', 'ghe.example.com')).resolves.toEqual({
+      login: 'octocat',
+      email: null
+    })
 
     const runtimeOptions = { localGitExecOptions: { wslDistro: 'Ubuntu' } }
     expect(getRepoSlugMock).toHaveBeenCalledWith(TEST_REPO_PATH, null, runtimeOptions)
     expect(getRepoUpstreamMock).toHaveBeenCalledWith(TEST_REPO_PATH, null, runtimeOptions)
+    expect(getAuthenticatedViewerMock).toHaveBeenCalledWith({
+      cwd: TEST_REPO_PATH,
+      host: 'ghe.example.com',
+      wslDistro: 'Ubuntu'
+    })
   })
 
   it('routes runtime GitHub issue and work-item actions through the selected WSL project runtime', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18153,14 +18153,16 @@ export class OrcaRuntimeService {
 
   async getGitHubViewer(
     repoSelector: string,
-    host?: string
+    host?: string,
+    force?: boolean
   ): Promise<Awaited<ReturnType<typeof getAuthenticatedViewer>>> {
     const repo = await this.resolveRepoSelector(repoSelector)
     return getAuthenticatedViewer({
       ...(repo.connectionId
         ? {}
         : { cwd: repo.path, ...this.getLocalGitExecutionOptionArgs(repo)[0] }),
-      ...(host ? { host } : {})
+      ...(host ? { host } : {}),
+      ...(force === undefined ? {} : { force })
     })
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -547,6 +547,7 @@ import {
   getPRForBranchOutcome,
   getRepoSlug,
   getRepoUpstream,
+  getAuthenticatedViewer,
   getWorkItem,
   listIssues as listGitHubIssues,
   listWorkItems,
@@ -18148,6 +18149,19 @@ export class OrcaRuntimeService {
     force?: boolean
   }): Promise<Awaited<ReturnType<typeof getRateLimit>>> {
     return getRateLimit(options)
+  }
+
+  async getGitHubViewer(
+    repoSelector: string,
+    host?: string
+  ): Promise<Awaited<ReturnType<typeof getAuthenticatedViewer>>> {
+    const repo = await this.resolveRepoSelector(repoSelector)
+    return getAuthenticatedViewer({
+      ...(repo.connectionId
+        ? {}
+        : { cwd: repo.path, ...this.getLocalGitExecutionOptionArgs(repo)[0] }),
+      ...(host ? { host } : {})
+    })
   }
 
   async getRepoPRForBranch(

--- a/src/main/runtime/rpc/methods/github.test.ts
+++ b/src/main/runtime/rpc/methods/github.test.ts
@@ -46,10 +46,10 @@ describe('github RPC methods', () => {
     const dispatcher = new RpcDispatcher({ runtime, methods: GITHUB_METHODS })
 
     const response = await dispatcher.dispatch(
-      makeRequest('github.viewer', { repo: 'repo-1', host: 'ghe.example.com' })
+      makeRequest('github.viewer', { repo: 'repo-1', host: 'ghe.example.com', force: true })
     )
 
-    expect(runtime.getGitHubViewer).toHaveBeenCalledWith('repo-1', 'ghe.example.com')
+    expect(runtime.getGitHubViewer).toHaveBeenCalledWith('repo-1', 'ghe.example.com', true)
     expect(response).toMatchObject({
       ok: true,
       result: { login: 'octocat', email: null }

--- a/src/main/runtime/rpc/methods/github.test.ts
+++ b/src/main/runtime/rpc/methods/github.test.ts
@@ -38,6 +38,24 @@ describe('github RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: { ok: true } })
   })
 
+  it('looks up the authenticated viewer in the repo GitHub scope', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getGitHubViewer: vi.fn().mockResolvedValue({ login: 'octocat', email: null })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GITHUB_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('github.viewer', { repo: 'repo-1', host: 'ghe.example.com' })
+    )
+
+    expect(runtime.getGitHubViewer).toHaveBeenCalledWith('repo-1', 'ghe.example.com')
+    expect(response).toMatchObject({
+      ok: true,
+      result: { login: 'octocat', email: null }
+    })
+  })
+
   it('lists work items on the runtime server', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -44,7 +44,8 @@ const RateLimit = z.object({
 })
 
 const Viewer = RepoSelector.extend({
-  host: OptionalString
+  host: OptionalString,
+  force: z.boolean().optional()
 })
 
 const SlugRepo = z.object({
@@ -351,7 +352,8 @@ export const GITHUB_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'github.viewer',
     params: Viewer,
-    handler: async (params, { runtime }) => runtime.getGitHubViewer(params.repo, params.host)
+    handler: async (params, { runtime }) =>
+      runtime.getGitHubViewer(params.repo, params.host, params.force)
   }),
   defineMethod({
     name: 'github.listWorkItems',

--- a/src/main/runtime/rpc/methods/github.ts
+++ b/src/main/runtime/rpc/methods/github.ts
@@ -43,6 +43,10 @@ const RateLimit = z.object({
   force: z.boolean().optional()
 })
 
+const Viewer = RepoSelector.extend({
+  host: OptionalString
+})
+
 const SlugRepo = z.object({
   owner: requiredString('Missing owner'),
   repo: requiredString('Missing repo'),
@@ -343,6 +347,11 @@ export const GITHUB_METHODS: RpcMethod[] = [
     name: 'github.rateLimit',
     params: RateLimit,
     handler: async (params, { runtime }) => runtime.getGitHubRateLimit(params)
+  }),
+  defineMethod({
+    name: 'github.viewer',
+    params: Viewer,
+    handler: async (params, { runtime }) => runtime.getGitHubViewer(params.repo, params.host)
   }),
   defineMethod({
     name: 'github.listWorkItems',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -280,6 +280,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'github.updatePR',
   'github.updatePRTitle',
   'github.updatePRState',
+  'github.viewer',
   'github.repoSlug',
   'github.workItem',
   // Cross-repo lookup: lets the mobile Smart picker resolve a pasted github.com URL for a different repo.

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1685,7 +1685,11 @@ export type PreloadApi = {
   }
   export: ExportApi
   gh: {
-    viewer: () => Promise<GitHubViewer | null>
+    viewer: (args?: {
+      repoPath: string
+      repoId?: string
+      sourceContext?: TaskSourceContext | null
+    }) => Promise<GitHubViewer | null>
     repoSlug: (args: {
       repoPath: string
       repoId?: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1689,6 +1689,7 @@ export type PreloadApi = {
       repoPath: string
       repoId?: string
       sourceContext?: TaskSourceContext | null
+      force?: boolean
     }) => Promise<GitHubViewer | null>
     repoSlug: (args: {
       repoPath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1275,6 +1275,7 @@ const api = {
       repoPath: string
       repoId?: string
       sourceContext?: TaskSourceContext | null
+      force?: boolean
     }): Promise<unknown> => ipcRenderer.invoke('gh:viewer', args),
 
     repoSlug: (args: { repoPath: string; repoId?: string }): Promise<unknown> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1271,7 +1271,11 @@ const api = {
   },
 
   gh: {
-    viewer: (): Promise<unknown> => ipcRenderer.invoke('gh:viewer'),
+    viewer: (args?: {
+      repoPath: string
+      repoId?: string
+      sourceContext?: TaskSourceContext | null
+    }): Promise<unknown> => ipcRenderer.invoke('gh:viewer', args),
 
     repoSlug: (args: { repoPath: string; repoId?: string }): Promise<unknown> =>
       ipcRenderer.invoke('gh:repoSlug', args),

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -5775,7 +5775,11 @@ export default function TaskPage(): React.JSX.Element {
     taskSource === 'github' &&
     githubMode === 'items' &&
     requiresGitHubViewerLogin(activeGithubTaskKind, appliedTaskQuery)
-  const gitHubLogin = useGitHubViewerLogin(shouldLoadGitHubViewerLogin, gitHubViewerLoginScopes)
+  const gitHubLogin = useGitHubViewerLogin(
+    shouldLoadGitHubViewerLogin,
+    gitHubViewerLoginScopes,
+    taskRefreshNonce
+  )
   const derivedTaskPreset = useMemo(
     () => deriveGitHubTaskPreset(activeGithubTaskKind, appliedTaskQuery, gitHubLogin),
     [activeGithubTaskKind, appliedTaskQuery, gitHubLogin]

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -3771,6 +3771,18 @@ export default function TaskPage(): React.JSX.Element {
   const lastFetchedNonceRef = useRef(-1)
   // Why: invalidation-nonce analog of lastFetchedNonceRef; a preference flip must force past fetch-dedupe or the fan-out collapses onto a stale in-flight request from the pre-flip source.
   const lastFetchedInvalidationNonceRef = useRef(0)
+  const [gitHubLogin, setGitHubLogin] = useState<string | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    void window.api.gh.viewer().then((viewer) => {
+      if (!cancelled && viewer) {
+        setGitHubLogin(viewer.login)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
   const paginationGenerationRef = useRef(0)
   // Why: entering Tasks with fresh cache still verifies remote status once, reconciled into existing rows to avoid a full table shuffle.
   const landingGitHubRefreshKeysRef = useRef<ReadonlySet<string>>(new Set())
@@ -5757,6 +5769,22 @@ export default function TaskPage(): React.JSX.Element {
 
   const activeGithubTaskKind = getGitHubTaskKind(activeTaskPreset, appliedTaskSearch)
   const appliedTaskQuery = useMemo(() => parseTaskQuery(appliedTaskSearch), [appliedTaskSearch])
+  // Why: derive the highlighted preset tab from the current query so that
+  // changing filter dropdowns automatically updates which tab is active.
+  const derivedTaskPreset = useMemo<TaskViewPresetId | null>(() => {
+    if (activeGithubTaskKind === 'prs') {
+      if (appliedTaskQuery.author === '@me' || appliedTaskQuery.author === gitHubLogin) return 'my-prs'
+      if (appliedTaskQuery.reviewRequested === '@me' || appliedTaskQuery.reviewRequested === gitHubLogin) return 'review'
+      if (appliedTaskQuery.state === 'open' || appliedTaskQuery.state === null) return 'prs'
+      return null
+    }
+    if (activeGithubTaskKind === 'issues') {
+      if (appliedTaskQuery.assignee === '@me' || appliedTaskQuery.assignee === gitHubLogin) return 'my-issues'
+      if (appliedTaskQuery.state === 'open' || appliedTaskQuery.state === null) return 'issues'
+      return null
+    }
+    return null
+  }, [activeGithubTaskKind, appliedTaskQuery, gitHubLogin])
   const selectedGitHubRepoExternalLink = useMemo(() => {
     if (selectedRepos.length !== 1) {
       return null
@@ -8278,7 +8306,7 @@ export default function TaskPage(): React.JSX.Element {
                   >
                     <div className="mb-2 flex flex-wrap gap-2">
                       {getGitHubTaskKindPresets(activeGithubTaskKind).map((option) => {
-                        const active = activeTaskPreset === option.id
+                        const active = derivedTaskPreset === option.id
                         return (
                           <button
                             key={option.id}

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -370,6 +370,11 @@ import {
   type LinearOrderBy,
   type LinearViewMode
 } from '@/components/task-page-localized-options'
+import { useGitHubViewerLogin } from '@/components/task-page-github-viewer-login'
+import {
+  deriveGitHubTaskPreset,
+  requiresGitHubViewerLogin
+} from '@/components/task-page-preset-highlight'
 
 function isGitLabMRFilter(value: GitLabTaskFilter | GitLabIssueFilter): value is GitLabTaskFilter {
   return value === 'opened' || value === 'merged' || value === 'closed' || value === 'all'
@@ -3771,18 +3776,6 @@ export default function TaskPage(): React.JSX.Element {
   const lastFetchedNonceRef = useRef(-1)
   // Why: invalidation-nonce analog of lastFetchedNonceRef; a preference flip must force past fetch-dedupe or the fan-out collapses onto a stale in-flight request from the pre-flip source.
   const lastFetchedInvalidationNonceRef = useRef(0)
-  const [gitHubLogin, setGitHubLogin] = useState<string | null>(null)
-  useEffect(() => {
-    let cancelled = false
-    void window.api.gh.viewer().then((viewer) => {
-      if (!cancelled && viewer) {
-        setGitHubLogin(viewer.login)
-      }
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [])
   const paginationGenerationRef = useRef(0)
   // Why: entering Tasks with fresh cache still verifies remote status once, reconciled into existing rows to avoid a full table shuffle.
   const landingGitHubRefreshKeysRef = useRef<ReadonlySet<string>>(new Set())
@@ -5769,22 +5762,24 @@ export default function TaskPage(): React.JSX.Element {
 
   const activeGithubTaskKind = getGitHubTaskKind(activeTaskPreset, appliedTaskSearch)
   const appliedTaskQuery = useMemo(() => parseTaskQuery(appliedTaskSearch), [appliedTaskSearch])
-  // Why: derive the highlighted preset tab from the current query so that
-  // changing filter dropdowns automatically updates which tab is active.
-  const derivedTaskPreset = useMemo<TaskViewPresetId | null>(() => {
-    if (activeGithubTaskKind === 'prs') {
-      if (appliedTaskQuery.author === '@me' || appliedTaskQuery.author === gitHubLogin) return 'my-prs'
-      if (appliedTaskQuery.reviewRequested === '@me' || appliedTaskQuery.reviewRequested === gitHubLogin) return 'review'
-      if (appliedTaskQuery.state === 'open' || appliedTaskQuery.state === null) return 'prs'
-      return null
-    }
-    if (activeGithubTaskKind === 'issues') {
-      if (appliedTaskQuery.assignee === '@me' || appliedTaskQuery.assignee === gitHubLogin) return 'my-issues'
-      if (appliedTaskQuery.state === 'open' || appliedTaskQuery.state === null) return 'issues'
-      return null
-    }
-    return null
-  }, [activeGithubTaskKind, appliedTaskQuery, gitHubLogin])
+  const gitHubViewerLoginScopes = useMemo(
+    () =>
+      selectedRepos.map((repo) => ({
+        repoId: repo.id,
+        repoPath: repo.path,
+        sourceContext: getTaskPageRepoSourceContext(repo, 'github')
+      })),
+    [selectedRepos]
+  )
+  const shouldLoadGitHubViewerLogin =
+    taskSource === 'github' &&
+    githubMode === 'items' &&
+    requiresGitHubViewerLogin(activeGithubTaskKind, appliedTaskQuery)
+  const gitHubLogin = useGitHubViewerLogin(shouldLoadGitHubViewerLogin, gitHubViewerLoginScopes)
+  const derivedTaskPreset = useMemo(
+    () => deriveGitHubTaskPreset(activeGithubTaskKind, appliedTaskQuery, gitHubLogin),
+    [activeGithubTaskKind, appliedTaskQuery, gitHubLogin]
+  )
   const selectedGitHubRepoExternalLink = useMemo(() => {
     if (selectedRepos.length !== 1) {
       return null

--- a/src/renderer/src/components/task-page-github-viewer-login.test.ts
+++ b/src/renderer/src/components/task-page-github-viewer-login.test.ts
@@ -96,24 +96,65 @@ describe('loadGitHubViewerLogin', () => {
     expect(viewerMock).toHaveBeenCalledTimes(2)
   })
 
-  it('refreshes a mounted viewer login when the execution cache expires', async () => {
+  it('does not poll a mounted viewer login', async () => {
     vi.useFakeTimers()
     viewerMock
       .mockResolvedValueOnce({ login: 'octocat', email: null })
       .mockResolvedValueOnce({ login: 'hubot', email: null })
     const scopes = [scope('one', 'local')]
-    const { result, unmount } = renderHook(() => useGitHubViewerLogin(true, scopes))
+    const { result, unmount } = renderHook(() => useGitHubViewerLogin(true, scopes, 0))
+    await act(async () => {})
+
+    expect(result.current).toBe('octocat')
+    expect(viewerMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+
+    expect(result.current).toBe('octocat')
+    expect(viewerMock).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+    unmount()
+  })
+
+  it('refreshes after an explicit Tasks refresh', async () => {
+    viewerMock
+      .mockResolvedValueOnce({ login: 'octocat', email: null })
+      .mockResolvedValueOnce({ login: 'hubot', email: null })
+    const scopes = [scope('one', 'local')]
+    const { result, rerender } = renderHook(
+      ({ refreshKey }) => useGitHubViewerLogin(true, scopes, refreshKey),
+      { initialProps: { refreshKey: 0 } }
+    )
+    await act(async () => {})
+
+    expect(result.current).toBe('octocat')
+
+    rerender({ refreshKey: 1 })
+    await act(async () => {})
+
+    expect(result.current).toBe('hubot')
+    expect(viewerMock).toHaveBeenCalledTimes(2)
+    expect(viewerMock).toHaveBeenLastCalledWith(expect.objectContaining({ force: true }))
+  })
+
+  it('refreshes once when the app returns to the foreground', async () => {
+    viewerMock
+      .mockResolvedValueOnce({ login: 'octocat', email: null })
+      .mockResolvedValueOnce({ login: 'hubot', email: null })
+    const scopes = [scope('one', 'local')]
+    const { result } = renderHook(() => useGitHubViewerLogin(true, scopes, 0))
     await act(async () => {})
 
     expect(result.current).toBe('octocat')
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(30_000)
+      document.dispatchEvent(new Event('visibilitychange'))
     })
 
     expect(result.current).toBe('hubot')
     expect(viewerMock).toHaveBeenCalledTimes(2)
-    unmount()
-    expect(vi.getTimerCount()).toBe(0)
+    expect(viewerMock).toHaveBeenLastCalledWith(expect.objectContaining({ force: true }))
   })
 })

--- a/src/renderer/src/components/task-page-github-viewer-login.test.ts
+++ b/src/renderer/src/components/task-page-github-viewer-login.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import type { GitHubViewerLoginScope } from './task-page-github-viewer-login'
+
+const { callRuntimeRpcMock, viewerMock } = vi.hoisted(() => ({
+  callRuntimeRpcMock: vi.fn(),
+  viewerMock: vi.fn()
+}))
+
+vi.mock('../runtime/runtime-rpc-client', () => ({
+  callRuntimeRpc: callRuntimeRpcMock
+}))
+
+import { loadGitHubViewerLogin, useGitHubViewerLogin } from './task-page-github-viewer-login'
+
+function scope(
+  repoId: string,
+  hostId: string,
+  host = 'github.com',
+  runtimeRepoId = repoId
+): GitHubViewerLoginScope {
+  return {
+    repoId,
+    repoPath: `/workspace/${repoId}`,
+    sourceContext: {
+      kind: 'task-source',
+      provider: 'github',
+      projectId: `project-${repoId}`,
+      hostId: hostId as ExecutionHostId,
+      repoId: runtimeRepoId,
+      providerIdentity: { provider: 'github', owner: 'acme', repo: repoId, host }
+    }
+  }
+}
+
+describe('loadGitHubViewerLogin', () => {
+  beforeEach(() => {
+    callRuntimeRpcMock.mockReset()
+    viewerMock.mockReset()
+    vi.stubGlobal('window', { api: { gh: { viewer: viewerMock } } })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('routes local and runtime repos to their owning execution hosts', async () => {
+    viewerMock.mockResolvedValue({ login: 'octocat', email: null })
+    callRuntimeRpcMock.mockResolvedValue({ login: 'OCTOCAT', email: null })
+
+    await expect(
+      loadGitHubViewerLogin([
+        scope('local-repo', 'local'),
+        scope('runtime-repo', 'runtime:env-1', 'ghe.example.com', 'remote-repo-1')
+      ])
+    ).resolves.toBe('octocat')
+
+    expect(viewerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ repoId: 'local-repo', repoPath: '/workspace/local-repo' })
+    )
+    expect(callRuntimeRpcMock).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'env-1' },
+      'github.viewer',
+      { repo: 'id:remote-repo-1', host: 'ghe.example.com' },
+      { timeoutMs: 15_000 }
+    )
+  })
+
+  it('returns null unless every selected auth scope resolves and agrees', async () => {
+    viewerMock
+      .mockResolvedValueOnce({ login: 'octocat', email: null })
+      .mockResolvedValueOnce({ login: 'hubot', email: null })
+
+    await expect(
+      loadGitHubViewerLogin([scope('one', 'local'), scope('two', 'ssh:ssh-1')])
+    ).resolves.toBeNull()
+  })
+
+  it('treats a rejected viewer scope as unresolved', async () => {
+    viewerMock.mockRejectedValue(new Error('unavailable'))
+
+    await expect(loadGitHubViewerLogin([scope('one', 'local')])).resolves.toBeNull()
+  })
+
+  it('deduplicates concurrent renderer requests for the same selected repos', async () => {
+    viewerMock.mockResolvedValue({ login: 'octocat', email: null })
+    const scopes = [scope('one', 'local'), scope('two', 'ssh:ssh-1')]
+
+    await expect(
+      Promise.all([loadGitHubViewerLogin(scopes), loadGitHubViewerLogin(scopes)])
+    ).resolves.toEqual(['octocat', 'octocat'])
+
+    expect(viewerMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('refreshes a mounted viewer login when the execution cache expires', async () => {
+    vi.useFakeTimers()
+    viewerMock
+      .mockResolvedValueOnce({ login: 'octocat', email: null })
+      .mockResolvedValueOnce({ login: 'hubot', email: null })
+    const scopes = [scope('one', 'local')]
+    const { result, unmount } = renderHook(() => useGitHubViewerLogin(true, scopes))
+    await act(async () => {})
+
+    expect(result.current).toBe('octocat')
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+    })
+
+    expect(result.current).toBe('hubot')
+    expect(viewerMock).toHaveBeenCalledTimes(2)
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/renderer/src/components/task-page-github-viewer-login.ts
+++ b/src/renderer/src/components/task-page-github-viewer-login.ts
@@ -1,0 +1,128 @@
+import { parseExecutionHostId } from '../../../shared/execution-host'
+import type { TaskSourceContext } from '../../../shared/task-source-context'
+import type { GitHubViewer } from '../../../shared/types'
+import { useEffect, useMemo, useState } from 'react'
+import { callRuntimeRpc } from '../runtime/runtime-rpc-client'
+
+export type GitHubViewerLoginScope = {
+  repoId: string
+  repoPath: string
+  sourceContext: TaskSourceContext | null
+}
+
+const RESOLVED_REFRESH_MS = 30_000
+const UNRESOLVED_REFRESH_MS = 5_000
+const inFlight = new Map<string, Promise<string | null>>()
+
+function githubHost(scope: GitHubViewerLoginScope): string | undefined {
+  const identity = scope.sourceContext?.providerIdentity
+  if (identity?.provider !== 'github') {
+    return undefined
+  }
+  return identity.host?.trim() || 'github.com'
+}
+
+function getGitHubViewerLoginRequestKey(scopes: readonly GitHubViewerLoginScope[]): string {
+  return scopes
+    .map((scope) => {
+      const context = scope.sourceContext
+      return [
+        context?.hostId ?? 'local',
+        context?.repoId ?? scope.repoId,
+        scope.repoPath,
+        githubHost(scope) ?? ''
+      ].join('\0')
+    })
+    .sort()
+    .join('\u0001')
+}
+
+async function loadViewer(scope: GitHubViewerLoginScope): Promise<GitHubViewer | null> {
+  const host = githubHost(scope)
+  const parsedHost = parseExecutionHostId(scope.sourceContext?.hostId)
+  if (parsedHost?.kind === 'runtime') {
+    const repoId = scope.sourceContext?.repoId ?? scope.repoId
+    return callRuntimeRpc<GitHubViewer | null>(
+      { kind: 'environment', environmentId: parsedHost.environmentId },
+      'github.viewer',
+      {
+        repo: `id:${repoId}`,
+        ...(host ? { host } : {})
+      },
+      { timeoutMs: 15_000 }
+    )
+  }
+  return window.api.gh.viewer({
+    repoPath: scope.repoPath,
+    repoId: scope.repoId,
+    sourceContext: scope.sourceContext
+  })
+}
+
+async function queryGitHubViewerLogin(
+  scopes: readonly GitHubViewerLoginScope[]
+): Promise<string | null> {
+  if (scopes.length === 0) {
+    return null
+  }
+  const viewers = await Promise.all(scopes.map((scope) => loadViewer(scope).catch(() => null)))
+  const logins = viewers.flatMap((viewer) => {
+    const login = viewer?.login.trim()
+    return login ? [login] : []
+  })
+  if (logins.length !== scopes.length) {
+    return null
+  }
+  const normalized = new Set(logins.map((login) => login.toLowerCase()))
+  return normalized.size === 1 ? (logins[0] ?? null) : null
+}
+
+export function loadGitHubViewerLogin(
+  scopes: readonly GitHubViewerLoginScope[]
+): Promise<string | null> {
+  const key = getGitHubViewerLoginRequestKey(scopes)
+  const pending = inFlight.get(key)
+  if (pending) {
+    return pending
+  }
+  const request = queryGitHubViewerLogin(scopes)
+  inFlight.set(key, request)
+  void request.finally(() => {
+    if (inFlight.get(key) === request) {
+      inFlight.delete(key)
+    }
+  })
+  return request
+}
+
+export function useGitHubViewerLogin(
+  enabled: boolean,
+  scopes: readonly GitHubViewerLoginScope[]
+): string | null {
+  const requestKey = useMemo(() => getGitHubViewerLoginRequestKey(scopes), [scopes])
+  const [state, setState] = useState<{ requestKey: string; login: string | null }>({
+    requestKey: '',
+    login: null
+  })
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    let stale = false
+    let refreshTimer: ReturnType<typeof setTimeout> | undefined
+    const refresh = (): void => {
+      void loadGitHubViewerLogin(scopes).then((login) => {
+        if (!stale) {
+          setState({ requestKey, login })
+          refreshTimer = setTimeout(refresh, login ? RESOLVED_REFRESH_MS : UNRESOLVED_REFRESH_MS)
+        }
+      })
+    }
+    refresh()
+    return () => {
+      stale = true
+      clearTimeout(refreshTimer)
+    }
+  }, [enabled, requestKey, scopes])
+  return enabled && state.requestKey === requestKey ? state.login : null
+}

--- a/src/renderer/src/components/task-page-github-viewer-login.ts
+++ b/src/renderer/src/components/task-page-github-viewer-login.ts
@@ -1,7 +1,7 @@
 import { parseExecutionHostId } from '../../../shared/execution-host'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import type { GitHubViewer } from '../../../shared/types'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { callRuntimeRpc } from '../runtime/runtime-rpc-client'
 
 export type GitHubViewerLoginScope = {
@@ -10,8 +10,6 @@ export type GitHubViewerLoginScope = {
   sourceContext: TaskSourceContext | null
 }
 
-const RESOLVED_REFRESH_MS = 30_000
-const UNRESOLVED_REFRESH_MS = 5_000
 const inFlight = new Map<string, Promise<string | null>>()
 
 function githubHost(scope: GitHubViewerLoginScope): string | undefined {
@@ -37,7 +35,10 @@ function getGitHubViewerLoginRequestKey(scopes: readonly GitHubViewerLoginScope[
     .join('\u0001')
 }
 
-async function loadViewer(scope: GitHubViewerLoginScope): Promise<GitHubViewer | null> {
+async function loadViewer(
+  scope: GitHubViewerLoginScope,
+  force: boolean
+): Promise<GitHubViewer | null> {
   const host = githubHost(scope)
   const parsedHost = parseExecutionHostId(scope.sourceContext?.hostId)
   if (parsedHost?.kind === 'runtime') {
@@ -47,7 +48,8 @@ async function loadViewer(scope: GitHubViewerLoginScope): Promise<GitHubViewer |
       'github.viewer',
       {
         repo: `id:${repoId}`,
-        ...(host ? { host } : {})
+        ...(host ? { host } : {}),
+        ...(force ? { force: true } : {})
       },
       { timeoutMs: 15_000 }
     )
@@ -55,17 +57,21 @@ async function loadViewer(scope: GitHubViewerLoginScope): Promise<GitHubViewer |
   return window.api.gh.viewer({
     repoPath: scope.repoPath,
     repoId: scope.repoId,
-    sourceContext: scope.sourceContext
+    sourceContext: scope.sourceContext,
+    ...(force ? { force: true } : {})
   })
 }
 
 async function queryGitHubViewerLogin(
-  scopes: readonly GitHubViewerLoginScope[]
+  scopes: readonly GitHubViewerLoginScope[],
+  force: boolean
 ): Promise<string | null> {
   if (scopes.length === 0) {
     return null
   }
-  const viewers = await Promise.all(scopes.map((scope) => loadViewer(scope).catch(() => null)))
+  const viewers = await Promise.all(
+    scopes.map((scope) => loadViewer(scope, force).catch(() => null))
+  )
   const logins = viewers.flatMap((viewer) => {
     const login = viewer?.login.trim()
     return login ? [login] : []
@@ -78,14 +84,15 @@ async function queryGitHubViewerLogin(
 }
 
 export function loadGitHubViewerLogin(
-  scopes: readonly GitHubViewerLoginScope[]
+  scopes: readonly GitHubViewerLoginScope[],
+  force = false
 ): Promise<string | null> {
   const key = getGitHubViewerLoginRequestKey(scopes)
   const pending = inFlight.get(key)
   if (pending) {
     return pending
   }
-  const request = queryGitHubViewerLogin(scopes)
+  const request = queryGitHubViewerLogin(scopes, force)
   inFlight.set(key, request)
   void request.finally(() => {
     if (inFlight.get(key) === request) {
@@ -97,9 +104,11 @@ export function loadGitHubViewerLogin(
 
 export function useGitHubViewerLogin(
   enabled: boolean,
-  scopes: readonly GitHubViewerLoginScope[]
+  scopes: readonly GitHubViewerLoginScope[],
+  refreshKey: number
 ): string | null {
   const requestKey = useMemo(() => getGitHubViewerLoginRequestKey(scopes), [scopes])
+  const previousRefreshKey = useRef(refreshKey)
   const [state, setState] = useState<{ requestKey: string; login: string | null }>({
     requestKey: '',
     login: null
@@ -109,20 +118,30 @@ export function useGitHubViewerLogin(
       return
     }
     let stale = false
-    let refreshTimer: ReturnType<typeof setTimeout> | undefined
-    const refresh = (): void => {
-      void loadGitHubViewerLogin(scopes).then((login) => {
+    const refresh = (force: boolean): void => {
+      void loadGitHubViewerLogin(scopes, force).then((login) => {
         if (!stale) {
-          setState({ requestKey, login })
-          refreshTimer = setTimeout(refresh, login ? RESOLVED_REFRESH_MS : UNRESOLVED_REFRESH_MS)
+          setState((current) =>
+            current.requestKey === requestKey && current.login === login
+              ? current
+              : { requestKey, login }
+          )
         }
       })
     }
-    refresh()
+    const refreshWhenVisible = (): void => {
+      if (document.visibilityState === 'visible') {
+        refresh(true)
+      }
+    }
+    const force = previousRefreshKey.current !== refreshKey
+    previousRefreshKey.current = refreshKey
+    refresh(force)
+    document.addEventListener('visibilitychange', refreshWhenVisible)
     return () => {
       stale = true
-      clearTimeout(refreshTimer)
+      document.removeEventListener('visibilitychange', refreshWhenVisible)
     }
-  }, [enabled, requestKey, scopes])
+  }, [enabled, refreshKey, requestKey, scopes])
   return enabled && state.requestKey === requestKey ? state.login : null
 }

--- a/src/renderer/src/components/task-page-preset-highlight-boundary.test.ts
+++ b/src/renderer/src/components/task-page-preset-highlight-boundary.test.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const TASK_PAGE_SOURCE = readFileSync(join(__dirname, 'TaskPage.tsx'), 'utf8')
+
+function sourceBetween(
+  source: string,
+  startPattern: string,
+  endPattern: string
+): string {
+  const start = source.indexOf(startPattern)
+  expect(
+    start,
+    `Expected to find "${startPattern}" in TaskPage.tsx`
+  ).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf(endPattern, start + startPattern.length)
+  expect(
+    end,
+    `Expected to find "${endPattern}" after "${startPattern}" in TaskPage.tsx`
+  ).toBeGreaterThan(start)
+  return source.slice(start, end)
+}
+
+describe('TaskPage preset tab highlighting boundary', () => {
+  // ── Button rendering ─────────────────────────────────
+
+  it('derives active preset from derivedTaskPreset for both PR and Issues', () => {
+    const presetSection = sourceBetween(
+      TASK_PAGE_SOURCE,
+      '{getGitHubTaskKindPresets(activeGithubTaskKind).map((option) => {',
+      ') : taskSource ==='
+    )
+
+    expect(presetSection).toContain('derivedTaskPreset === option.id')
+    // Must NOT reference activeTaskPreset for button highlighting
+    expect(presetSection).not.toMatch(/\bactive\s*=\s*activeTaskPreset\b/)
+  })
+
+  // ── PR kind derivation ──────────────────────────────
+
+  it('PR: derives my-prs from @me or gitHubLogin', () => {
+    const derivationSection = sourceBetween(
+      TASK_PAGE_SOURCE,
+      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
+      'selectedGitHubRepoExternalLink = useMemo'
+    )
+
+    expect(derivationSection).toContain("author === '@me'")
+    expect(derivationSection).toContain('author === gitHubLogin')
+    expect(derivationSection).toContain("return 'my-prs'")
+    // Must not match any non-null author
+    expect(derivationSection).not.toMatch(/if\s*\([^)]*author\s*!==\s*null/)
+  })
+
+  it('PR: derives review from @me or gitHubLogin', () => {
+    const derivationSection = sourceBetween(
+      TASK_PAGE_SOURCE,
+      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
+      'selectedGitHubRepoExternalLink = useMemo'
+    )
+
+    expect(derivationSection).toContain("reviewRequested === '@me'")
+    expect(derivationSection).toContain('reviewRequested === gitHubLogin')
+    expect(derivationSection).toContain("return 'review'")
+  })
+
+  it('PR: returns prs only when state is open or null, else null', () => {
+    const derivationSection = sourceBetween(
+      TASK_PAGE_SOURCE,
+      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
+      'selectedGitHubRepoExternalLink = useMemo'
+    )
+
+    expect(derivationSection).toContain("state === 'open'")
+    expect(derivationSection).toContain("state === null")
+    expect(derivationSection).toContain("return 'prs'")
+    expect(derivationSection).toContain('return null')
+  })
+
+  it('PR: guards kind before query checks', () => {
+    const derivationSection = sourceBetween(
+      TASK_PAGE_SOURCE,
+      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
+      'selectedGitHubRepoExternalLink = useMemo'
+    )
+
+    const prsIndex = derivationSection.indexOf("activeGithubTaskKind === 'prs'")
+    const issuesIndex = derivationSection.indexOf("activeGithubTaskKind === 'issues'")
+    const authorIndex = derivationSection.indexOf('appliedTaskQuery.author')
+
+    // PR branch must come before Issues branch
+    expect(prsIndex).toBeGreaterThan(-1)
+    expect(prsIndex).toBeLessThan(authorIndex)
+    // Issues branch also gated on kind
+    expect(issuesIndex).toBeGreaterThan(authorIndex)
+  })
+
+  // ── Issues kind derivation ──────────────────────────
+
+  it('Issues: derives my-issues from @me or gitHubLogin', () => {
+    const derivationSection = sourceBetween(
+      TASK_PAGE_SOURCE,
+      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
+      'selectedGitHubRepoExternalLink = useMemo'
+    )
+
+    expect(derivationSection).toContain("assignee === '@me'")
+    expect(derivationSection).toContain('assignee === gitHubLogin')
+    expect(derivationSection).toContain("return 'my-issues'")
+  })
+
+  it('Issues: returns issues (Open) when state is open or null, else null', () => {
+    const derivationSection = sourceBetween(
+      TASK_PAGE_SOURCE,
+      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
+      'selectedGitHubRepoExternalLink = useMemo'
+    )
+
+    // Inside the issues branch
+    const issuesBranch = derivationSection.slice(
+      derivationSection.indexOf("activeGithubTaskKind === 'issues'"),
+      derivationSection.lastIndexOf('return null')
+    )
+
+    expect(issuesBranch).toContain("state === 'open'")
+    expect(issuesBranch).toContain("state === null")
+    expect(issuesBranch).toContain("return 'issues'")
+    expect(issuesBranch).toContain('return null')
+  })
+
+  // ── Data source ─────────────────────────────────────
+
+  it('loads gitHubLogin from window.api.gh.viewer()', () => {
+    const viewerSection = sourceBetween(
+      TASK_PAGE_SOURCE,
+      "const [gitHubLogin, setGitHubLogin] = useState<string | null>(null)",
+      'paginationGenerationRef = useRef(0)'
+    )
+
+    expect(viewerSection).toContain("window.api.gh.viewer()")
+    expect(viewerSection).toContain("setGitHubLogin(viewer.login)")
+  })
+})

--- a/src/renderer/src/components/task-page-preset-highlight-boundary.test.ts
+++ b/src/renderer/src/components/task-page-preset-highlight-boundary.test.ts
@@ -1,144 +1,71 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { parseTaskQuery } from '../../../shared/task-query'
+import { deriveGitHubTaskPreset, requiresGitHubViewerLogin } from './task-page-preset-highlight'
 
-const TASK_PAGE_SOURCE = readFileSync(join(__dirname, 'TaskPage.tsx'), 'utf8')
-
-function sourceBetween(
-  source: string,
-  startPattern: string,
-  endPattern: string
-): string {
-  const start = source.indexOf(startPattern)
-  expect(
-    start,
-    `Expected to find "${startPattern}" in TaskPage.tsx`
-  ).toBeGreaterThanOrEqual(0)
-  const end = source.indexOf(endPattern, start + startPattern.length)
-  expect(
-    end,
-    `Expected to find "${endPattern}" after "${startPattern}" in TaskPage.tsx`
-  ).toBeGreaterThan(start)
-  return source.slice(start, end)
+function derive(kind: 'prs' | 'issues', query: string, viewerLogin: string | null = null) {
+  return deriveGitHubTaskPreset(kind, parseTaskQuery(query), viewerLogin)
 }
 
 describe('TaskPage preset tab highlighting boundary', () => {
-  // ── Button rendering ─────────────────────────────────
-
-  it('derives active preset from derivedTaskPreset for both PR and Issues', () => {
-    const presetSection = sourceBetween(
-      TASK_PAGE_SOURCE,
-      '{getGitHubTaskKindPresets(activeGithubTaskKind).map((option) => {',
-      ') : taskSource ==='
-    )
-
-    expect(presetSection).toContain('derivedTaskPreset === option.id')
-    // Must NOT reference activeTaskPreset for button highlighting
-    expect(presetSection).not.toMatch(/\bactive\s*=\s*activeTaskPreset\b/)
+  it('keeps the open presets active before viewer identity resolves', () => {
+    expect(derive('prs', 'is:pr is:open')).toBe('prs')
+    expect(derive('issues', 'is:issue is:open')).toBe('issues')
+    expect(derive('prs', 'is:pr')).toBe('prs')
+    expect(derive('issues', 'is:issue')).toBe('issues')
   })
 
-  // ── PR kind derivation ──────────────────────────────
-
-  it('PR: derives my-prs from @me or gitHubLogin', () => {
-    const derivationSection = sourceBetween(
-      TASK_PAGE_SOURCE,
-      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
-      'selectedGitHubRepoExternalLink = useMemo'
-    )
-
-    expect(derivationSection).toContain("author === '@me'")
-    expect(derivationSection).toContain('author === gitHubLogin')
-    expect(derivationSection).toContain("return 'my-prs'")
-    // Must not match any non-null author
-    expect(derivationSection).not.toMatch(/if\s*\([^)]*author\s*!==\s*null/)
+  it('derives personal presets from @me', () => {
+    expect(derive('prs', 'is:pr is:open author:@me')).toBe('my-prs')
+    expect(derive('prs', 'is:pr is:open review-requested:@me')).toBe('review')
+    expect(derive('issues', 'is:issue is:open assignee:@me')).toBe('my-issues')
   })
 
-  it('PR: derives review from @me or gitHubLogin', () => {
-    const derivationSection = sourceBetween(
-      TASK_PAGE_SOURCE,
-      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
-      'selectedGitHubRepoExternalLink = useMemo'
-    )
-
-    expect(derivationSection).toContain("reviewRequested === '@me'")
-    expect(derivationSection).toContain('reviewRequested === gitHubLogin')
-    expect(derivationSection).toContain("return 'review'")
+  it('matches the resolved viewer login case-insensitively', () => {
+    expect(derive('prs', 'is:pr is:open author:OCTOCAT', 'octocat')).toBe('my-prs')
+    expect(derive('prs', 'is:pr is:open review-requested:octocat', 'OctoCat')).toBe('review')
+    expect(derive('issues', 'is:issue is:open assignee:octocat', 'OCTOCAT')).toBe('my-issues')
   })
 
-  it('PR: returns prs only when state is open or null, else null', () => {
-    const derivationSection = sourceBetween(
-      TASK_PAGE_SOURCE,
-      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
-      'selectedGitHubRepoExternalLink = useMemo'
-    )
-
-    expect(derivationSection).toContain("state === 'open'")
-    expect(derivationSection).toContain("state === null")
-    expect(derivationSection).toContain("return 'prs'")
-    expect(derivationSection).toContain('return null')
+  it('does not treat unresolved or other-user qualifiers as presets', () => {
+    expect(derive('prs', 'is:pr is:open author:octocat')).toBeNull()
+    expect(derive('prs', 'is:pr is:open author:hubot', 'octocat')).toBeNull()
+    expect(derive('prs', 'is:pr is:open reviewed-by:octocat', 'octocat')).toBeNull()
+    expect(derive('issues', 'is:issue is:open assignee:hubot', 'octocat')).toBeNull()
   })
 
-  it('PR: guards kind before query checks', () => {
-    const derivationSection = sourceBetween(
-      TASK_PAGE_SOURCE,
-      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
-      'selectedGitHubRepoExternalLink = useMemo'
+  it('lets a matching personal qualifier win over a non-matching sibling qualifier', () => {
+    expect(derive('prs', 'is:pr is:open author:hubot review-requested:octocat', 'octocat')).toBe(
+      'review'
     )
-
-    const prsIndex = derivationSection.indexOf("activeGithubTaskKind === 'prs'")
-    const issuesIndex = derivationSection.indexOf("activeGithubTaskKind === 'issues'")
-    const authorIndex = derivationSection.indexOf('appliedTaskQuery.author')
-
-    // PR branch must come before Issues branch
-    expect(prsIndex).toBeGreaterThan(-1)
-    expect(prsIndex).toBeLessThan(authorIndex)
-    // Issues branch also gated on kind
-    expect(issuesIndex).toBeGreaterThan(authorIndex)
   })
 
-  // ── Issues kind derivation ──────────────────────────
-
-  it('Issues: derives my-issues from @me or gitHubLogin', () => {
-    const derivationSection = sourceBetween(
-      TASK_PAGE_SOURCE,
-      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
-      'selectedGitHubRepoExternalLink = useMemo'
-    )
-
-    expect(derivationSection).toContain("assignee === '@me'")
-    expect(derivationSection).toContain('assignee === gitHubLogin')
-    expect(derivationSection).toContain("return 'my-issues'")
+  it('guards closed and merged state before personal qualifiers', () => {
+    expect(derive('prs', 'is:pr is:closed author:@me', 'octocat')).toBeNull()
+    expect(derive('prs', 'is:pr is:merged review-requested:@me', 'octocat')).toBeNull()
+    expect(derive('issues', 'is:issue is:closed assignee:@me', 'octocat')).toBeNull()
   })
 
-  it('Issues: returns issues (Open) when state is open or null, else null', () => {
-    const derivationSection = sourceBetween(
-      TASK_PAGE_SOURCE,
-      'const derivedTaskPreset = useMemo<TaskViewPresetId | null>(',
-      'selectedGitHubRepoExternalLink = useMemo'
+  it('requests viewer identity only for an actual-login personal qualifier', () => {
+    expect(requiresGitHubViewerLogin('prs', parseTaskQuery('is:pr is:open author:octocat'))).toBe(
+      true
     )
-
-    // Inside the issues branch
-    const issuesBranch = derivationSection.slice(
-      derivationSection.indexOf("activeGithubTaskKind === 'issues'"),
-      derivationSection.lastIndexOf('return null')
-    )
-
-    expect(issuesBranch).toContain("state === 'open'")
-    expect(issuesBranch).toContain("state === null")
-    expect(issuesBranch).toContain("return 'issues'")
-    expect(issuesBranch).toContain('return null')
+    expect(
+      requiresGitHubViewerLogin('prs', parseTaskQuery('is:pr is:open review-requested:@me'))
+    ).toBe(false)
+    expect(
+      requiresGitHubViewerLogin('issues', parseTaskQuery('is:issue is:closed assignee:octocat'))
+    ).toBe(false)
   })
 
-  // ── Data source ─────────────────────────────────────
-
-  it('loads gitHubLogin from window.api.gh.viewer()', () => {
-    const viewerSection = sourceBetween(
-      TASK_PAGE_SOURCE,
-      "const [gitHubLogin, setGitHubLogin] = useState<string | null>(null)",
-      'paginationGenerationRef = useRef(0)'
+  it('wires the pure derivation to preset button highlighting', () => {
+    const source = readFileSync(join(__dirname, 'TaskPage.tsx'), 'utf8')
+    expect(source).toContain(
+      'deriveGitHubTaskPreset(activeGithubTaskKind, appliedTaskQuery, gitHubLogin)'
     )
-
-    expect(viewerSection).toContain("window.api.gh.viewer()")
-    expect(viewerSection).toContain("setGitHubLogin(viewer.login)")
+    expect(source).toContain('requiresGitHubViewerLogin(activeGithubTaskKind, appliedTaskQuery)')
+    expect(source).not.toContain('window.api.gh.viewer()')
+    expect(source).toContain('const active = derivedTaskPreset === option.id')
   })
 })

--- a/src/renderer/src/components/task-page-preset-highlight.ts
+++ b/src/renderer/src/components/task-page-preset-highlight.ts
@@ -1,0 +1,51 @@
+import type { ParsedTaskQuery } from '../../../shared/task-query'
+import type { TaskViewPresetId } from '../../../shared/types'
+import type { GitHubTaskKind } from './task-page-localized-options'
+
+function matchesViewer(qualifier: string | null, viewerLogin: string | null): boolean {
+  if (!qualifier) {
+    return false
+  }
+  const normalized = qualifier.toLowerCase()
+  return normalized === '@me' || (!!viewerLogin && normalized === viewerLogin.toLowerCase())
+}
+
+function hasIdentityQualifier(query: ParsedTaskQuery): boolean {
+  return (
+    query.author !== null ||
+    query.assignee !== null ||
+    query.reviewRequested !== null ||
+    query.reviewedBy !== null
+  )
+}
+
+export function requiresGitHubViewerLogin(kind: GitHubTaskKind, query: ParsedTaskQuery): boolean {
+  if (query.state !== null && query.state !== 'open') {
+    return false
+  }
+  const qualifier = kind === 'prs' ? (query.author ?? query.reviewRequested) : query.assignee
+  return qualifier !== null && qualifier.toLowerCase() !== '@me'
+}
+
+export function deriveGitHubTaskPreset(
+  kind: GitHubTaskKind,
+  query: ParsedTaskQuery,
+  viewerLogin: string | null
+): TaskViewPresetId | null {
+  if (query.state !== null && query.state !== 'open') {
+    return null
+  }
+  if (kind === 'prs') {
+    if (matchesViewer(query.author, viewerLogin)) {
+      return 'my-prs'
+    }
+    if (matchesViewer(query.reviewRequested, viewerLogin)) {
+      return 'review'
+    }
+    return hasIdentityQualifier(query) ? null : 'prs'
+  }
+  if (matchesViewer(query.assignee, viewerLogin)) {
+    return 'my-issues'
+  }
+  return hasIdentityQualifier(query) ? null : 'issues'
+}

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -3735,6 +3735,7 @@ describe('web GitHub preload API', () => {
         args: {
           repoPath,
           repoId: 'repo-1',
+          force: true,
           sourceContext: {
             providerIdentity: { provider: 'github', host: 'ghe.example.com' }
           }
@@ -3743,6 +3744,7 @@ describe('web GitHub preload API', () => {
         expectedParams: {
           repoPath,
           repoId: 'repo-1',
+          force: true,
           repo: 'id:repo-1',
           host: 'ghe.example.com',
           sourceContext: {

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -3731,6 +3731,26 @@ describe('web GitHub preload API', () => {
       expectedParams: unknown
     }[] = [
       {
+        key: 'viewer',
+        args: {
+          repoPath,
+          repoId: 'repo-1',
+          sourceContext: {
+            providerIdentity: { provider: 'github', host: 'ghe.example.com' }
+          }
+        },
+        expectedMethod: 'github.viewer',
+        expectedParams: {
+          repoPath,
+          repoId: 'repo-1',
+          repo: 'id:repo-1',
+          host: 'ghe.example.com',
+          sourceContext: {
+            providerIdentity: { provider: 'github', host: 'ghe.example.com' }
+          }
+        }
+      },
+      {
         key: 'repoSlug',
         args: { repoPath },
         expectedMethod: 'github.repoSlug',

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -268,6 +268,7 @@ type WebRuntimeEnvelopeCaller = <TResult>(
   timeoutMs?: number
 ) => Promise<RuntimeRpcResponse<TResult>>
 type WebGitHubRouteKey =
+  | 'viewer'
   | 'repoSlug'
   | 'repoUpstream'
   | 'prForBranch'
@@ -316,6 +317,7 @@ type WebGitHubRouteKey =
   | 'listIssueTypesBySlug'
   | 'updateIssueTypeBySlug'
 type WebGitHubRuntimeMethod =
+  | 'github.viewer'
   | 'github.repoSlug'
   | 'github.repoUpstream'
   | 'github.prForBranch'
@@ -417,6 +419,7 @@ type WebKeybindingDocument = {
 }
 
 export const GITHUB_WEB_RPC_METHODS = {
+  viewer: 'github.viewer',
   repoSlug: 'github.repoSlug',
   repoUpstream: 'github.repoUpstream',
   prForBranch: 'github.prForBranch',
@@ -2287,7 +2290,18 @@ function createGitHubApi(): WebGitHubApi {
   const route = <Result>(method: WebGitHubRuntimeMethod, args?: unknown): Promise<Result> =>
     callRuntimeResult<Result>(method, mapRepoPathArg(args))
   const githubApi = {
-    viewer: () => Promise.resolve(null),
+    viewer: (args) => {
+      if (!args) {
+        return Promise.resolve(null)
+      }
+      const identity = args.sourceContext?.providerIdentity
+      const host =
+        identity?.provider === 'github' ? identity.host?.trim() || 'github.com' : undefined
+      return route<WebGitHubResult<'viewer'>>(GITHUB_WEB_RPC_METHODS.viewer, {
+        ...args,
+        ...(host ? { host } : {})
+      })
+    },
     repoSlug: (args) => route<WebGitHubResult<'repoSlug'>>(GITHUB_WEB_RPC_METHODS.repoSlug, args),
     repoUpstream: (args) =>
       route<WebGitHubResult<'repoUpstream'>>(GITHUB_WEB_RPC_METHODS.repoUpstream, args),


### PR DESCRIPTION
> **English translation** added for maintainers. Original 中文 / Chinese text is preserved below for reference.

### English title
`fix(tasks): derive preset tab highlighting from query instead of click state`

## Problem

Closes #11113

On the GitHub Tasks page, the Open / Mine / Needs review preset tab highlights are lost or wrong after Author / Reviewer / State filter dropdowns change.

## Root cause

`activeTaskPreset` is set to `null` by `applyPRFilterChange` on every filter change. Button highlight previously depended on `activeTaskPreset === option.id`, so after clear no tab lights up. Author/Reviewer derivation only checked `=== '@me'`, not the user's real GitHub login, so choosing a username dropped the highlight.

## Fix

1. **Add `gitHubLogin` state** via `window.api.gh.viewer()`
2. **Add `derivedTaskPreset` `useMemo`** derived live from `appliedTaskQuery`
   - `author:@me` or `author:<login>` → Mine
   - `review-requested:@me` or `<login>` → Needs review
   - `assignee:@me` or `<login>` → Assigned (Issues view)
   - No special qualifier and `state:open/null` → All Open
   - `state:closed/merged` → no highlight
3. PR view button highlight uses `derivedTaskPreset === option.id`; Issues view keeps `activeTaskPreset`

## Testing

Added `task-page-preset-highlight-boundary.test.ts` with 6 cases covering:
- Derivation (`@me` and login forms)
- State guard (closed/merged → no highlight)

---

<details>
<summary>Original (中文 / Chinese) — title: fix(tasks): derive preset tab highlighting from query instead of click state</summary>

## 问题

Closes #11113

GitHub Tasks 页面「开放/我的/待评审」三个预设 Tab 的高亮在下拉筛选器(Author/Reviewer/State)变化后丢失或显示错误。

## 根因

`activeTaskPreset` 在每次筛选变化时被 `applyPRFilterChange` 设置为 `null`，按钮高亮此前依赖 `activeTaskPreset === option.id`，清空后所有 Tab 均不亮。且 Author/Reviewer 推导仅检查 `=== '@me'`，未匹配用户实际的 GitHub login，导致选择用户名时高亮丢失。

## 修复

1. **新增 `gitHubLogin` state**：通过 `window.api.gh.viewer()` 获取当前用户 login
2. **新增 `derivedTaskPreset` `useMemo`**：从 `appliedTaskQuery` 实时推导高亮
   - `author:@me` 或 `author:<login>` → Mine
   - `review-requested:@me` 或 `<login>` → Needs review
   - `assignee:@me` 或 `<login>` → Assigned（Issues 视图）
   - 无特殊限定且 `state:open/null` → All Open
   - `state:closed/merged` → 无高亮
3. PR 视图按钮高亮改为 `derivedTaskPreset === option.id`，Issues 视图保持原有 `activeTaskPreset`

## 测试

新增 `task-page-preset-highlight-boundary.test.ts`，包含 6 个用例覆盖：
- 推导关系（@me 与 login 两种形式）
- state 守卫（closed/merged 无高亮）

</details>
