### PR TITLE
feat(pet): scale animation speed with CPU usage

### DIFF
--- a/src/main/ipc/pet.test.ts
+++ b/src/main/ipc/pet.test.ts
@@ -8,6 +8,7 @@ const {
   browserWindowFromWebContentsMock,
   browserWindowGetFocusedWindowMock,
   handleMock,
+  samplePetSystemCpuUsageMock,
   nativeImageCreateFromBufferMock,
   showOpenDialogMock
 } = vi.hoisted(() => ({
@@ -15,8 +16,13 @@ const {
   browserWindowFromWebContentsMock: vi.fn(),
   browserWindowGetFocusedWindowMock: vi.fn(),
   handleMock: vi.fn(),
+  samplePetSystemCpuUsageMock: vi.fn(),
   nativeImageCreateFromBufferMock: vi.fn(),
   showOpenDialogMock: vi.fn()
+}))
+
+vi.mock('../pet-system-cpu-usage', () => ({
+  samplePetSystemCpuUsage: samplePetSystemCpuUsageMock
 }))
 
 vi.mock('electron', () => ({
@@ -54,6 +60,7 @@ describe('registerPetHandlers', () => {
     browserWindowFromWebContentsMock.mockReset()
     browserWindowGetFocusedWindowMock.mockReset()
     handleMock.mockReset()
+    samplePetSystemCpuUsageMock.mockReset()
     nativeImageCreateFromBufferMock.mockReset()
     showOpenDialogMock.mockReset()
 
@@ -81,6 +88,13 @@ describe('registerPetHandlers', () => {
     }
     return handler
   }
+
+  it('returns sampled system CPU usage over pet IPC', async () => {
+    samplePetSystemCpuUsageMock.mockReturnValue(0.42)
+
+    expect(await getHandler('pet:getSystemCpuUsage')({})).toBe(0.42)
+    expect(samplePetSystemCpuUsageMock).toHaveBeenCalledOnce()
+  })
 
   it('imports a pet bundle whose manifest uses Windows separators', async () => {
     const bundleDir = join(tempDir, 'windows-export.codex-pet')

--- a/src/main/ipc/pet.ts
+++ b/src/main/ipc/pet.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'node:crypto'
 import { basename, dirname, extname, isAbsolute, join, normalize, resolve, sep } from 'node:path'
 import { z } from 'zod'
 import type { CustomPet } from '../../shared/types'
+import { samplePetSystemCpuUsage } from '../pet-system-cpu-usage'
 import {
   applyCodexPetDefaults,
   readWebpDimensionsFromBuffer,
@@ -167,6 +168,11 @@ async function isSymlink(path: string): Promise<boolean> {
 }
 
 export function registerPetHandlers(): void {
+  ipcMain.handle(
+    'pet:getSystemCpuUsage',
+    async (): Promise<number | null> => samplePetSystemCpuUsage()
+  )
+
   ipcMain.handle('pet:import', async (event): Promise<CustomPet | null> => {
     const senderWindow =
       BrowserWindow.fromWebContents(event.sender) ?? BrowserWindow.getFocusedWindow()

--- a/src/main/pet-system-cpu-usage.test.ts
+++ b/src/main/pet-system-cpu-usage.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { cpus } from 'node:os'
+import { createPetSystemCpuUsageSampler } from './pet-system-cpu-usage'
+
+type CpuInfo = ReturnType<typeof cpus>[number]
+
+function cpu(times: CpuInfo['times']): CpuInfo {
+  return {
+    model: 'test',
+    speed: 1,
+    times
+  }
+}
+
+describe('createPetSystemCpuUsageSampler', () => {
+  it('returns null for the first sample', () => {
+    const sampler = createPetSystemCpuUsageSampler(() => [
+      cpu({ user: 10, nice: 0, sys: 10, idle: 80, irq: 0 })
+    ])
+
+    expect(sampler()).toBeNull()
+  })
+
+  it('returns host-wide busy time from aggregate CPU tick deltas', () => {
+    const samples = [
+      [
+        cpu({ user: 30, nice: 0, sys: 20, idle: 50, irq: 0 }),
+        cpu({ user: 60, nice: 0, sys: 40, idle: 100, irq: 0 })
+      ],
+      [
+        cpu({ user: 100, nice: 0, sys: 25, idle: 75, irq: 0 }),
+        cpu({ user: 130, nice: 0, sys: 45, idle: 125, irq: 0 })
+      ]
+    ]
+    const sampler = createPetSystemCpuUsageSampler(() => samples.shift() ?? [])
+
+    expect(sampler()).toBeNull()
+    expect(sampler()).toBe(0.75)
+  })
+
+  it('returns null when counters reset', () => {
+    const samples = [
+      [cpu({ user: 30, nice: 0, sys: 20, idle: 50, irq: 0 })],
+      [cpu({ user: 20, nice: 0, sys: 20, idle: 40, irq: 0 })]
+    ]
+    const sampler = createPetSystemCpuUsageSampler(() => samples.shift() ?? [])
+
+    expect(sampler()).toBeNull()
+    expect(sampler()).toBeNull()
+  })
+
+  it('returns null when no ticks elapsed', () => {
+    const sample = [cpu({ user: 30, nice: 0, sys: 20, idle: 50, irq: 0 })]
+    const sampler = createPetSystemCpuUsageSampler(() => sample)
+
+    expect(sampler()).toBeNull()
+    expect(sampler()).toBeNull()
+  })
+
+  it('clamps invalid idle deltas to the usage range', () => {
+    const samples = [
+      [cpu({ user: 100, nice: 0, sys: 0, idle: 0, irq: 0 })],
+      [cpu({ user: 50, nice: 0, sys: 0, idle: 100, irq: 0 })]
+    ]
+    const sampler = createPetSystemCpuUsageSampler(() => samples.shift() ?? [])
+
+    expect(sampler()).toBeNull()
+    expect(sampler()).toBe(0)
+  })
+})

--- a/src/main/pet-system-cpu-usage.ts
+++ b/src/main/pet-system-cpu-usage.ts
@@ -1,0 +1,47 @@
+import { cpus } from 'node:os'
+
+type CpuSnapshot = {
+  idle: number
+  total: number
+}
+
+type ReadCpuInfo = typeof cpus
+
+function readSnapshot(readCpuInfo: ReadCpuInfo): CpuSnapshot {
+  let idle = 0
+  let total = 0
+
+  for (const cpu of readCpuInfo()) {
+    const times = cpu.times
+    idle += times.idle
+    total += times.user + times.nice + times.sys + times.idle + times.irq
+  }
+
+  return { idle, total }
+}
+
+export function createPetSystemCpuUsageSampler(
+  readCpuInfo: ReadCpuInfo = cpus
+): () => number | null {
+  let previous: CpuSnapshot | null = null
+
+  return () => {
+    const current = readSnapshot(readCpuInfo)
+    const prior = previous
+    previous = current
+
+    if (!prior || current.idle < prior.idle || current.total < prior.total) {
+      return null
+    }
+
+    const idleDelta = current.idle - prior.idle
+    const totalDelta = current.total - prior.total
+    if (totalDelta === 0) {
+      return null
+    }
+
+    return Math.min(1, Math.max(0, 1 - idleDelta / totalDelta))
+  }
+}
+
+export const samplePetSystemCpuUsage = createPetSystemCpuUsageSampler()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2479,6 +2479,7 @@ export type PreloadApi = {
     onUpdateRun: (callback: (run: SkillUpdateRun) => void) => () => void
   }
   pet: {
+    getSystemCpuUsage: () => Promise<number | null>
     import: () => Promise<CustomPet | null>
     importPetBundle: () => Promise<CustomPet | null>
     read: (id: string, fileName: string, kind?: 'image' | 'bundle') => Promise<ArrayBuffer | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2348,6 +2348,7 @@ const api = {
   },
 
   pet: {
+    getSystemCpuUsage: (): Promise<number | null> => ipcRenderer.invoke('pet:getSystemCpuUsage'),
     import: (): Promise<CustomPet | null> => ipcRenderer.invoke('pet:import'),
     importPetBundle: (): Promise<CustomPet | null> => ipcRenderer.invoke('pet:importPetBundle'),
     read: (id: string, fileName: string, kind?: 'image' | 'bundle'): Promise<ArrayBuffer | null> =>

--- a/src/renderer/src/components/pet/PetOverlay.detected-speed.test.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.detected-speed.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const storeState = vi.hoisted(() => ({
+  agentStatusByPaneKey: {},
+  agentStatusEpoch: 0,
+  retainedAgentsByPaneKey: {},
+  petSize: 180
+}))
+
+const cpuSpeedMocks = vi.hoisted(() => ({
+  useSpeed: vi.fn((_active: boolean) => 1.5)
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(
+    <T,>(selector: (state: typeof storeState) => T): T => selector(storeState),
+    { getState: () => storeState }
+  )
+}))
+
+vi.mock('@/hooks/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => false
+}))
+
+vi.mock('./pet-cpu-animation-speed', () => ({
+  usePetCpuAnimationSpeed: (active: boolean) => cpuSpeedMocks.useSpeed(active),
+  getPetFrameIntervalMs: (fps: number, speedMultiplier: number) => 1000 / (fps * speedMultiplier)
+}))
+
+vi.mock('./usePetUrl', () => ({
+  usePetUrl: () => ({
+    url: 'blob:detected-pet',
+    ready: true,
+    sprite: null,
+    detected: {
+      frames: [
+        { x: 0, y: 0, w: 32, h: 32 },
+        { x: 32, y: 0, w: 32, h: 32 }
+      ],
+      bitmaps: [{}, {}] as ImageBitmap[],
+      fps: 8
+    }
+  })
+}))
+
+import { PetOverlay } from './PetOverlay'
+
+describe('PetOverlay detected sprite CPU speed', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+  let rafCallbacks: FrameRequestCallback[] = []
+  const drawImage = vi.fn()
+
+  beforeEach(() => {
+    rafCallbacks = []
+    drawImage.mockClear()
+    cpuSpeedMocks.useSpeed.mockClear()
+    vi.spyOn(performance, 'now').mockReturnValue(0)
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        rafCallbacks.push(callback)
+        return rafCallbacks.length
+      })
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      clearRect: vi.fn(),
+      drawImage,
+      imageSmoothingEnabled: false
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    container?.remove()
+    root = null
+    container = null
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('detected sprite의 rAF threshold에 CPU 속도 배수를 적용한다', () => {
+    // Given
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    // When
+    act(() => root?.render(<PetOverlay />))
+
+    // Then
+    expect(cpuSpeedMocks.useSpeed).toHaveBeenCalledWith(true)
+    expect(drawImage).toHaveBeenCalledTimes(1)
+
+    // When: 8fps at 1.5x advances after 83.33ms, not before it.
+    act(() => rafCallbacks.shift()?.(80))
+    expect(drawImage).toHaveBeenCalledTimes(1)
+    act(() => rafCallbacks.shift()?.(84))
+
+    // Then
+    expect(drawImage).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/components/pet/PetOverlay.frame-durations.test.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.frame-durations.test.tsx
@@ -44,6 +44,11 @@ vi.mock('./usePetUrl', () => ({
   })
 }))
 
+vi.mock('./pet-cpu-animation-speed', () => ({
+  usePetCpuAnimationSpeed: () => 1.5,
+  getPetFrameIntervalMs: (fps: number, speedMultiplier: number) => 1000 / (fps * speedMultiplier)
+}))
+
 import { PetOverlay } from './PetOverlay'
 
 function renderPetOverlay(): { container: HTMLDivElement; root: Root } {
@@ -105,7 +110,7 @@ describe('PetOverlay per-frame sprite durations', () => {
     const spriteDiv = Array.from(container.querySelectorAll('div')).find(
       (div) => div.style.backgroundImage !== ''
     )
-    expect(spriteDiv?.style.animation).toContain('6.6s')
+    expect(spriteDiv?.style.animation).toContain('4.4s')
     expect(spriteDiv?.style.animation).toContain('step-end')
     expect(spriteDiv?.style.animation).toContain('infinite')
   })

--- a/src/renderer/src/components/pet/PetOverlay.tsx
+++ b/src/renderer/src/components/pet/PetOverlay.tsx
@@ -12,6 +12,7 @@ import {
 } from './pet-agent-state'
 import { usePetPointerInteraction } from './usePetPointerInteraction'
 import { buildSpriteAnimationCss } from './sprite-animation-css'
+import { getPetFrameIntervalMs, usePetCpuAnimationSpeed } from './pet-cpu-animation-speed'
 
 type Sprite = NonNullable<CustomPet['sprite']>
 
@@ -50,13 +51,15 @@ function SpriteFrame({
   animate,
   maxSize,
   animationName,
-  restartKey
+  restartKey,
+  speedMultiplier
 }: {
   url: string
   sprite: Sprite
   animate: boolean
   maxSize: number
   animationName: PetAnimationName
+  speedMultiplier: number
   // Why: folded into the keyframes name, so bumping it mints a fresh animation
   // that restarts from frame 0 even when the state row is unchanged.
   restartKey: number
@@ -91,7 +94,8 @@ function SpriteFrame({
     frameWidth: sprite.frameWidth,
     scale,
     rowOffsetY: startY,
-    frameDurationsMs: anim?.frameDurationsMs
+    frameDurationsMs: anim?.frameDurationsMs,
+    speedMultiplier
   })
   return (
     <>
@@ -121,15 +125,21 @@ function SpriteFrame({
 function DetectedSpriteFrame({
   detected,
   animate,
-  maxSize
+  maxSize,
+  speedMultiplier
 }: {
   detected: DetectedSpriteCacheEntry
   animate: boolean
   maxSize: number
+  speedMultiplier: number
 }): React.JSX.Element {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const frameIndexRef = useRef(0)
   const lastTimeRef = useRef(0)
+  const speedMultiplierRef = useRef(speedMultiplier)
+  useEffect(() => {
+    speedMultiplierRef.current = speedMultiplier
+  }, [speedMultiplier])
   // Why: honor manifest fps captured at import time so bundles play at their
   // intended speed; default to 8 only when the manifest didn't declare one.
   const fps = detected.fps > 0 ? detected.fps : 8
@@ -185,7 +195,7 @@ function DetectedSpriteFrame({
     }
     const tick = (now: number): void => {
       const dt = now - lastTimeRef.current
-      if (dt >= 1000 / fps) {
+      if (dt >= getPetFrameIntervalMs(fps, speedMultiplierRef.current)) {
         lastTimeRef.current = now
         frameIndexRef.current = (frameIndexRef.current + 1) % detected.frames.length
         draw()
@@ -372,6 +382,7 @@ export function PetOverlay(): React.JSX.Element {
   }, [dragging, position])
 
   const motionAllowed = documentVisible && !reducedMotion
+  const speedMultiplier = usePetCpuAnimationSpeed(motionAllowed)
   // Why: a still/vertical grab freezes on frame 0 (Codex grab-and-hold); a
   // horizontal drag keeps animating so the running rows show. Bob always pauses.
   const spriteAnimate = motionAllowed && (!dragging || dragAnimation !== null)
@@ -419,9 +430,15 @@ export function PetOverlay(): React.JSX.Element {
               maxSize={size}
               animationName={animationName}
               restartKey={dragGeneration}
+              speedMultiplier={speedMultiplier}
             />
           ) : detected ? (
-            <DetectedSpriteFrame detected={detected} animate={spriteAnimate} maxSize={size} />
+            <DetectedSpriteFrame
+              detected={detected}
+              animate={spriteAnimate}
+              maxSize={size}
+              speedMultiplier={speedMultiplier}
+            />
           ) : (
             // Why: cap explicitly at the pet size — the w-fit/h-fit wrapper is
             // fit-content, so max-w/h-full has no fixed box to resolve against

--- a/src/renderer/src/components/pet/pet-cpu-animation-speed.test.tsx
+++ b/src/renderer/src/components/pet/pet-cpu-animation-speed.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  PET_CPU_POLL_MS,
+  applyPetCpuEma,
+  getPetAnimationSpeed,
+  getPetFrameIntervalMs,
+  usePetCpuAnimationSpeed
+} from './pet-cpu-animation-speed'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('pet CPU animation speed', () => {
+  it('CPU 사용량을 1.0x에서 1.5x 사이의 속도로 변환한다', () => {
+    // Given / When / Then
+    expect(getPetAnimationSpeed(null)).toBe(1)
+    expect(getPetAnimationSpeed(-0.1)).toBe(1)
+    expect(getPetAnimationSpeed(0.5)).toBe(1.25)
+    expect(getPetAnimationSpeed(1)).toBe(1.5)
+    expect(getPetAnimationSpeed(2.5)).toBe(1.5)
+  })
+
+  it('새 CPU 샘플에 EMA 평활화를 적용한다', () => {
+    // Given / When / Then
+    expect(applyPetCpuEma(null, 0.8)).toBe(0.8)
+    expect(applyPetCpuEma(0.2, 1)).toBe(0.4)
+    expect(applyPetCpuEma(0.4, Number.NaN)).toBe(0.4)
+  })
+
+  it('detected sprite 프레임 간격에 속도 배수를 적용한다', () => {
+    // Given / When / Then
+    expect(getPetFrameIntervalMs(8, 1)).toBe(125)
+    expect(getPetFrameIntervalMs(8, 1.25)).toBe(100)
+    expect(getPetFrameIntervalMs(8, 1.5)).toBeCloseTo(83.333, 3)
+  })
+
+  it('활성 상태에서 즉시 조회하고 2초마다 다시 조회한다', async () => {
+    // Given
+    vi.useFakeTimers()
+    const getSystemCpuUsage = vi.fn().mockResolvedValueOnce(0.2).mockResolvedValueOnce(1)
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { pet: { getSystemCpuUsage } }
+    })
+
+    // When
+    const { result } = renderHook(() => usePetCpuAnimationSpeed(true))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Then
+    expect(getSystemCpuUsage).toHaveBeenCalledTimes(1)
+    expect(result.current).toBe(1.1)
+
+    // When
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PET_CPU_POLL_MS)
+    })
+
+    // Then
+    expect(getSystemCpuUsage).toHaveBeenCalledTimes(2)
+    expect(result.current).toBe(1.2)
+  })
+
+  it('비활성 상태에서는 조회하지 않고 기본 속도를 반환한다', async () => {
+    // Given
+    vi.useFakeTimers()
+    const getSystemCpuUsage = vi.fn().mockResolvedValue(1)
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { pet: { getSystemCpuUsage } }
+    })
+
+    // When
+    const { result } = renderHook(() => usePetCpuAnimationSpeed(false))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PET_CPU_POLL_MS * 2)
+    })
+
+    // Then
+    expect(getSystemCpuUsage).not.toHaveBeenCalled()
+    expect(result.current).toBe(1)
+  })
+
+  it('활성 상태에서 비활성 상태로 바뀌면 polling을 중단하고 기본 속도로 복귀한다', async () => {
+    // Given
+    vi.useFakeTimers()
+    const getSystemCpuUsage = vi.fn().mockResolvedValue(0.8)
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { pet: { getSystemCpuUsage } }
+    })
+    const { result, rerender } = renderHook(({ active }) => usePetCpuAnimationSpeed(active), {
+      initialProps: { active: true }
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current).toBe(1.4)
+
+    // When
+    rerender({ active: false })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PET_CPU_POLL_MS * 2)
+    })
+
+    // Then
+    expect(getSystemCpuUsage).toHaveBeenCalledTimes(1)
+    expect(result.current).toBe(1)
+  })
+})

--- a/src/renderer/src/components/pet/pet-cpu-animation-speed.ts
+++ b/src/renderer/src/components/pet/pet-cpu-animation-speed.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react'
+
+export const PET_CPU_POLL_MS = 2_000
+export const PET_CPU_EMA_ALPHA = 0.25
+
+const PET_ANIMATION_SPEED_MIN = 1
+const PET_ANIMATION_SPEED_MAX = 1.5
+const CPU_USAGE_MAX = 1
+
+function clampCpuUsage(value: number): number {
+  return Math.min(CPU_USAGE_MAX, Math.max(0, value))
+}
+
+function safeSpeedMultiplier(value: number): number {
+  if (!Number.isFinite(value)) {
+    return PET_ANIMATION_SPEED_MIN
+  }
+  return Math.min(PET_ANIMATION_SPEED_MAX, Math.max(PET_ANIMATION_SPEED_MIN, value))
+}
+
+export function applyPetCpuEma(previous: number | null, next: number): number {
+  if (!Number.isFinite(next)) {
+    return previous ?? 0
+  }
+  const sample = clampCpuUsage(next)
+  return previous === null
+    ? sample
+    : previous + PET_CPU_EMA_ALPHA * (sample - clampCpuUsage(previous))
+}
+
+export function getPetAnimationSpeed(cpuUsage: number | null): number {
+  if (cpuUsage === null || !Number.isFinite(cpuUsage)) {
+    return PET_ANIMATION_SPEED_MIN
+  }
+  const normalized = clampCpuUsage(cpuUsage) / CPU_USAGE_MAX
+  return PET_ANIMATION_SPEED_MIN + normalized * (PET_ANIMATION_SPEED_MAX - PET_ANIMATION_SPEED_MIN)
+}
+
+export function getPetFrameIntervalMs(fps: number, speedMultiplier: number): number {
+  const safeFps = Number.isFinite(fps) && fps > 0 ? fps : 8
+  return 1000 / (safeFps * safeSpeedMultiplier(speedMultiplier))
+}
+
+export function usePetCpuAnimationSpeed(active: boolean): number {
+  const [smoothedCpu, setSmoothedCpu] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!active) {
+      return
+    }
+
+    let cancelled = false
+    let inFlight = false
+    const getSystemCpuUsage = (window.api as Partial<typeof window.api> | undefined)?.pet
+      ?.getSystemCpuUsage
+    if (!getSystemCpuUsage) {
+      return
+    }
+
+    const poll = async (): Promise<void> => {
+      if (inFlight) {
+        return
+      }
+      inFlight = true
+      try {
+        const usage = await getSystemCpuUsage()
+        if (!cancelled && typeof usage === 'number' && Number.isFinite(usage)) {
+          setSmoothedCpu((previous) => applyPetCpuEma(previous, usage))
+        }
+      } catch {
+        // CPU sampling is advisory; keep the last stable speed on transient IPC failures.
+      } finally {
+        inFlight = false
+      }
+    }
+
+    void poll()
+    const timer = window.setInterval(() => void poll(), PET_CPU_POLL_MS)
+    return () => {
+      cancelled = true
+      window.clearInterval(timer)
+    }
+  }, [active])
+
+  return active ? getPetAnimationSpeed(smoothedCpu) : PET_ANIMATION_SPEED_MIN
+}

--- a/src/renderer/src/components/pet/sprite-animation-css.test.ts
+++ b/src/renderer/src/components/pet/sprite-animation-css.test.ts
@@ -5,7 +5,8 @@ const BASE = {
   keyframesId: 'kf',
   frameWidth: 100,
   scale: 1,
-  rowOffsetY: -200
+  rowOffsetY: -200,
+  speedMultiplier: 1
 }
 
 describe('buildSpriteAnimationCss', () => {
@@ -82,5 +83,27 @@ describe('buildSpriteAnimationCss', () => {
     })
     expect(keyframesCss).toContain('0% { background-position: 0px -200px; }')
     expect(keyframesCss).toContain('1% { background-position: -100px -200px; }')
+  })
+
+  it('속도 배수만큼 uniform 및 uneven animation duration을 줄인다', () => {
+    // Given / When
+    const uniform = buildSpriteAnimationCss({
+      ...BASE,
+      frames: 6,
+      fps: 6,
+      frameDurationsMs: undefined,
+      speedMultiplier: 1.25
+    })
+    const uneven = buildSpriteAnimationCss({
+      ...BASE,
+      frames: 2,
+      fps: 8,
+      frameDurationsMs: [1000, 2000],
+      speedMultiplier: 1.5
+    })
+
+    // Then
+    expect(uniform.animationCss).toBe('pet-kf 0.8s steps(6) infinite')
+    expect(uneven.animationCss).toBe('pet-kf 2s step-end infinite')
   })
 })

--- a/src/renderer/src/components/pet/sprite-animation-css.ts
+++ b/src/renderer/src/components/pet/sprite-animation-css.ts
@@ -21,6 +21,8 @@ export type SpriteAnimationCssInput = {
   rowOffsetY: number
   // Per-frame holds in ms; uneven pacing renders when they pass validation.
   frameDurationsMs: number[] | undefined
+  // Live playback multiplier. The pet CPU hook constrains this to 1x-1.5x.
+  speedMultiplier: number
 }
 
 // Why: sprite keyframes are runtime CSS, not user-visible copy; translated CSS
@@ -32,9 +34,11 @@ export function buildSpriteAnimationCss({
   frameWidth,
   scale,
   rowOffsetY,
-  frameDurationsMs
+  frameDurationsMs,
+  speedMultiplier
 }: SpriteAnimationCssInput): SpriteAnimationCss {
   const name = `pet-${keyframesId}`
+  const speed = Number.isFinite(speedMultiplier) && speedMultiplier > 0 ? speedMultiplier : 1
   const durations = validFrameDurations(frameDurationsMs, frames)
   if (durations) {
     const totalMs = durations.reduce((sum, ms) => sum + ms, 0)
@@ -44,12 +48,12 @@ export function buildSpriteAnimationCss({
     if (stops) {
       return {
         keyframesCss: `@keyframes ${name} { ${stops.join(' ')} }`,
-        animationCss: `${name} ${totalMs / 1000}s step-end infinite`
+        animationCss: `${name} ${Number((totalMs / 1000 / speed).toFixed(4))}s step-end infinite`
       }
     }
   }
   // Uniform sheet fps: one steps() run across the row.
-  const duration = Math.max(0.1, frames / Math.max(0.1, fps))
+  const duration = Math.max(0.1, frames / Math.max(0.1, fps) / speed)
   const endX = -(frames * frameWidth * scale)
   return {
     keyframesCss: `@keyframes ${name} { from { background-position: 0px ${rowOffsetY}px; } to { background-position: ${endX}px ${rowOffsetY}px; } }`,


### PR DESCRIPTION
## Summary

- sample host-wide CPU usage in the main process from aggregate `os.cpus()` tick deltas
- smooth the normalized load and map it to a 1.0x–1.5x pet animation multiplier
- apply the multiplier to both manifest CSS sprites and auto-detected canvas sprites without changing animation track selection
- stop CPU polling while the document is hidden, reduced motion is enabled, or the pet overlay is unmounted

Closes #11079

## Screenshots

No recording yet. This is a timing-only visual change driven by live host CPU usage; the draft includes deterministic CSS and canvas timing tests.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 38,615 passed and 7 unrelated tests failed on the current upstream snapshot: 1 remote-runtime WebSocket connection test and 6 terminal-search decoration cleanup tests. The remote-runtime test passed when rerun alone; the 6 terminal-search tests reproduce alone and do not touch pet code.
- [x] `pnpm build` — desktop build passed; the native Swift step also passed when rerun outside the sandbox after its cache path was initially blocked.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification: 17 test files and 62 tests passed across the CPU sampler, pet IPC, and all renderer pet tests.

## AI Review Report

The review checked the CPU sampling contract, smoothing and clamping boundaries, polling cleanup, in-flight IPC behavior, CSS duration updates, canvas frame thresholds, and accidental animation restarts. It caught and fixed an initial 0–100 vs. 0–1 CPU-unit mismatch and removed a synchronous state update from the polling effect.

Cross-platform review covered macOS, Linux, and Windows. The implementation uses Node's platform-neutral `os.cpus()` data and does not add paths, shell commands, shortcuts, labels, or platform-specific Electron behavior. Counter resets, zero tick deltas, and invalid values fall back safely without changing animation tracks.

## Security Audit

The new IPC endpoint is read-only, accepts no renderer input, exposes only a clamped aggregate CPU ratio, and does not access commands, paths, auth state, secrets, or dependencies. CPU sampling remains in the main process; no raw system details cross the preload boundary. No follow-up security work is required.

## Notes

- CPU polling runs immediately and then every two seconds only while pet motion is allowed.
- EMA smoothing uses alpha 0.25; the resulting playback multiplier is capped at 1.5x and never slows pets below their authored speed.
- Local verification used Node 23.11.0, while the repository currently requests Node 24; commands emitted an engine warning.
- X handle: N/A
