### PR TITLE
refactor(daemon): consolidate listener fanout

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -3176,5 +3176,59 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(aExits).toEqual([{ id: 'sess-a', code: -1 }])
       expect(bExits).toEqual([{ id: 'sess-a', code: -1 }])
     })
+
+    it('keeps listeners already snapshotted when another listener unsubscribes them', () => {
+      const calls: string[] = []
+      let unsubscribeSecond = () => {}
+      adapter.onExit(() => {
+        calls.push('first')
+        unsubscribeSecond()
+      })
+      unsubscribeSecond = adapter.onExit(() => calls.push('second'))
+
+      const internals = adapter as unknown as { activeSessionIds: Set<string> }
+      internals.activeSessionIds.add('sess-a')
+      adapter.fanoutSyntheticExits(-1)
+
+      internals.activeSessionIds.add('sess-b')
+      adapter.fanoutSyntheticExits(-1)
+
+      expect(calls).toEqual(['first', 'second', 'first'])
+    })
+
+    it('isolates each listener from synthetic exit payload mutations', () => {
+      const secondListenerPayloads: { id: string; code: number }[] = []
+      adapter.onExit((payload) => {
+        payload.id = 'mutated'
+        payload.code = 99
+      })
+      adapter.onExit((payload) => secondListenerPayloads.push(payload))
+
+      const internals = adapter as unknown as { activeSessionIds: Set<string> }
+      internals.activeSessionIds.add('sess-a')
+      adapter.fanoutSyntheticExits(-1)
+
+      expect(secondListenerPayloads).toEqual([{ id: 'sess-a', code: -1 }])
+    })
+
+    it('emits matching synthetic and daemon exit payloads with incarnation IDs', async () => {
+      const exits: { id: string; code: number; incarnationId?: string }[] = []
+      adapter.onExit((payload) => exits.push(payload))
+      const { id } = await adapter.spawn({ sessionId: 'payload-parity', cols: 80, rows: 24 })
+
+      lastSubprocess._simulateExit(-1)
+      await waitFor(() => exits.length === 1)
+      const daemonExit = exits[0]!
+
+      const internals = adapter as unknown as {
+        activeSessionIds: Set<string>
+        sessionIncarnations: Map<string, string>
+      }
+      internals.activeSessionIds.add(id)
+      internals.sessionIncarnations.set(id, daemonExit.incarnationId!)
+      adapter.fanoutSyntheticExits(-1)
+
+      expect(exits).toEqual([daemonExit, daemonExit])
+    })
   })
 })

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -64,6 +64,29 @@ type HistoryRecoveryContext = {
   identityChanged: boolean
 }
 
+type PtyExitListenerPayload = {
+  id: string
+  code: number
+  incarnationId?: PtyIncarnationId
+}
+
+function fanoutListenerSnapshot<TPayload>(
+  listeners: readonly ((payload: TPayload) => void)[],
+  createPayload: () => TPayload
+): void {
+  for (const listener of listeners.slice()) {
+    listener(createPayload())
+  }
+}
+
+function createPtyExitListenerPayload(
+  id: string,
+  code: number,
+  incarnationId?: PtyIncarnationId
+): PtyExitListenerPayload {
+  return { id, code, ...(incarnationId ? { incarnationId } : {}) }
+}
+
 // Why take-and-clear together: every consuming branch must reset the field, so pairing them stops one from forgetting.
 function takeRecoveryFreeze(
   historyRecovery: HistoryRecoveryContext,
@@ -143,11 +166,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     transformed?: boolean
     seq?: number
   }) => void)[] = []
-  private exitListeners: ((payload: {
-    id: string
-    code: number
-    incarnationId?: PtyIncarnationId
-  }) => void)[] = []
+  private exitListeners: ((payload: PtyExitListenerPayload) => void)[] = []
   private backgroundStreamListeners: ((payload: PtyBackgroundStreamEvent) => void)[] = []
   // Why: lets main fan a dead-endpoint signal to every affected pane, not just the written one (STA-2373 sibling-freeze).
   private writeUnavailableListeners: ((payload: { id: string }) => void)[] = []
@@ -1268,16 +1287,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
     for (const id of ids) {
       this.coldRestoreCache.delete(id)
       // Why: don't catch listener throws — matches the natural onExit fanout so synthetic exits keep the same error semantics.
-      // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
-      for (const listener of [...this.exitListeners]) {
-        listener({
-          id,
-          code,
-          ...(this.sessionIncarnations.get(id)
-            ? { incarnationId: this.sessionIncarnations.get(id) }
-            : {})
-        })
-      }
+      fanoutListenerSnapshot(this.exitListeners, () =>
+        createPtyExitListenerPayload(id, code, this.sessionIncarnations.get(id))
+      )
       this.sessionIncarnations.delete(id)
     }
   }
@@ -1332,9 +1344,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return () => {}
   }
 
-  onExit(
-    callback: (payload: { id: string; code: number; incarnationId?: PtyIncarnationId }) => void
-  ): () => void {
+  onExit(callback: (payload: PtyExitListenerPayload) => void): () => void {
     this.exitListeners.push(callback)
     return () => {
       const idx = this.exitListeners.indexOf(callback)
@@ -1355,10 +1365,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   private emitWriteUnavailable(id: string): void {
-    // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
-    for (const listener of [...this.writeUnavailableListeners]) {
-      listener({ id })
-    }
+    fanoutListenerSnapshot(this.writeUnavailableListeners, () => ({ id }))
   }
 
   dispose(): void {
@@ -1870,10 +1877,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   private emitBackgroundStreamEvent(payload: PtyBackgroundStreamEvent): void {
-    // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
-    for (const listener of [...this.backgroundStreamListeners]) {
-      listener(payload)
-    }
+    fanoutListenerSnapshot(this.backgroundStreamListeners, () => payload)
   }
 
   private async doRespawn(
@@ -1912,18 +1916,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
       if (event.event === 'data') {
         this.markSessionDirty(event.sessionId)
-        // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
-        for (const listener of [...this.dataListeners]) {
-          listener({
-            id: event.sessionId,
-            data: event.payload.data,
-            ...((event.payload.rawLength ?? event.payload.sequenceChars) === undefined
-              ? {}
-              : { sequenceChars: event.payload.rawLength ?? event.payload.sequenceChars }),
-            ...(event.payload.transformed ? { transformed: true } : {}),
-            ...(event.payload.seq === undefined ? {} : { seq: event.payload.seq })
-          })
-        }
+        fanoutListenerSnapshot(this.dataListeners, () => ({
+          id: event.sessionId,
+          data: event.payload.data,
+          ...((event.payload.rawLength ?? event.payload.sequenceChars) === undefined
+            ? {}
+            : { sequenceChars: event.payload.rawLength ?? event.payload.sequenceChars }),
+          ...(event.payload.transformed ? { transformed: true } : {}),
+          ...(event.payload.seq === undefined ? {} : { seq: event.payload.seq })
+        }))
       } else if (event.event === 'sessionBackgroundMarker') {
         this.emitBackgroundStreamEvent({
           id: event.sessionId,
@@ -2010,14 +2011,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.initialCwds.delete(event.sessionId)
         this.wslDistrosBySessionId.delete(event.sessionId)
         this.sessionIncarnations.delete(event.sessionId)
-        // oxlint-disable-next-line unicorn/no-useless-spread -- copy-safe: listeners may unsubscribe during iteration
-        for (const listener of [...this.exitListeners]) {
-          listener({
-            id: event.sessionId,
-            code: event.payload.code,
-            ...(event.payload.incarnationId ? { incarnationId: event.payload.incarnationId } : {})
-          })
-        }
+        fanoutListenerSnapshot(this.exitListeners, () =>
+          createPtyExitListenerPayload(
+            event.sessionId,
+            event.payload.code,
+            event.payload.incarnationId
+          )
+        )
       }
     })
   }


### PR DESCRIPTION
## Summary

- Centralize snapshot-safe listener fanout in `DaemonPtyAdapter`.
- Reuse one exit-payload constructor for synthetic and daemon exit paths.
- Preserve the original payload identity semantics: data, exit, and write-unavailable listeners receive independent payload objects, while background-stream listeners retain their existing shared payload.

Closes #10984.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted validation:

- `daemon-pty-adapter.test.ts`: 138 tests passed
- Touched-file `oxlint` and `oxfmt --check` passed
- `git diff --check` passed after rebasing onto current `origin/main`

The full Node typecheck was attempted but the isolated worktree environment was missing unrelated existing `esbuild` modules referenced by plugin/relay test files.

## AI Review Report

The adversarial review checked listener mutation, unsubscribe-during-emission behavior, payload parity, and exception semantics. It caught that an initial abstraction shared one mutable payload across listeners where the old loops created one per listener. The implementation now accepts a payload factory, and a regression test proves one listener cannot mutate the next listener's payload.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows. This change does not alter shortcuts, labels, paths, shells, Electron platform branches, or host-specific behavior.

## Security Audit

No input parsing, command execution, path handling, authentication, secrets, dependencies, or IPC contracts changed. Listener exceptions still propagate with the same semantics, and fanout still snapshots before callbacks can unsubscribe.

## Notes

Current main contains five listener-fanout sites in this adapter; all five now use the common primitive.
