### PR TITLE
fix(source-control): avoid mounting git hooks for folder workspaces

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControlGate.test.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlGate.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+
+import { act, Suspense } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo, Worktree } from '../../../../shared/types'
+
+const testState = vi.hoisted(() => ({
+  activeWorktree: null as Worktree | null,
+  repos: [] as Repo[]
+}))
+const sourceControlModuleLoad = vi.hoisted(() => vi.fn())
+const sourceControlMount = vi.hoisted(() => vi.fn(() => <div data-testid="source-control" />))
+
+vi.mock('./SourceControl', () => {
+  sourceControlModuleLoad()
+  return { default: sourceControlMount }
+})
+
+vi.mock('@/store/selectors', () => ({
+  useActiveWorktree: () => testState.activeWorktree,
+  useRepoById: (repoId: string | null) => testState.repos.find((repo) => repo.id === repoId) ?? null
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+import SourceControlGate from './SourceControlGate'
+
+let container: HTMLDivElement
+let root: Root
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/repo',
+    displayName: 'Repo',
+    badgeColor: '#fff',
+    addedAt: 1,
+    ...overrides
+  }
+}
+
+function makeWorktree(): Worktree {
+  return {
+    id: 'repo-1::/repo',
+    path: '/repo',
+    head: 'abc',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: true,
+    repoId: 'repo-1',
+    displayName: 'Repo',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+async function renderGate(): Promise<void> {
+  await act(async () => {
+    root.render(
+      <Suspense fallback={null}>
+        <SourceControlGate />
+      </Suspense>
+    )
+    await Promise.resolve()
+  })
+}
+
+describe('SourceControlGate', () => {
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    sourceControlModuleLoad.mockClear()
+    sourceControlMount.mockClear()
+    testState.activeWorktree = null
+    testState.repos = []
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  it('shows the no-selection state without loading or mounting Source Control', async () => {
+    await renderGate()
+
+    expect(sourceControlModuleLoad).not.toHaveBeenCalled()
+    expect(sourceControlMount).not.toHaveBeenCalled()
+    expect(container.textContent).toBe('Select a workspace to view changes')
+  })
+
+  it('shows the no-selection state for a missing repo without loading Source Control', async () => {
+    testState.activeWorktree = makeWorktree()
+
+    await renderGate()
+
+    expect(sourceControlModuleLoad).not.toHaveBeenCalled()
+    expect(sourceControlMount).not.toHaveBeenCalled()
+    expect(container.textContent).toBe('Select a workspace to view changes')
+  })
+
+  it('shows the folder state without loading or mounting Source Control', async () => {
+    testState.activeWorktree = makeWorktree()
+    testState.repos = [makeRepo({ kind: 'folder' })]
+
+    await renderGate()
+
+    expect(sourceControlModuleLoad).not.toHaveBeenCalled()
+    expect(sourceControlMount).not.toHaveBeenCalled()
+    expect(container.textContent).toBe('Source Control is only available for Git repositories')
+  })
+
+  it('loads and mounts Source Control for legacy git worktrees without a kind', async () => {
+    testState.activeWorktree = makeWorktree()
+    testState.repos = [makeRepo()]
+
+    await renderGate()
+
+    expect(sourceControlModuleLoad).toHaveBeenCalledOnce()
+    expect(sourceControlMount).toHaveBeenCalledOnce()
+    expect(container.querySelector('[data-testid="source-control"]')).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/SourceControlGate.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControlGate.tsx
@@ -1,0 +1,50 @@
+import { memo } from 'react'
+import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
+import { translate } from '@/i18n/i18n'
+import { useActiveWorktree, useRepoById } from '@/store/selectors'
+import { isFolderRepo } from '../../../../shared/repo-kind'
+
+const SourceControl = lazy(() => import('./SourceControl'))
+
+function SourceControlGateInner(): React.JSX.Element | null {
+  const activeWorktree = useActiveWorktree()
+  const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
+
+  if (!activeWorktree || !activeRepo || !activeWorktree.path) {
+    return (
+      <SourceControlUnavailableState>
+        {translate(
+          'auto.components.right.sidebar.SourceControl.c07b236287',
+          'Select a workspace to view changes'
+        )}
+      </SourceControlUnavailableState>
+    )
+  }
+
+  if (isFolderRepo(activeRepo)) {
+    return (
+      <SourceControlUnavailableState>
+        {translate(
+          'auto.components.right.sidebar.SourceControl.e131cd7128',
+          'Source Control is only available for Git repositories'
+        )}
+      </SourceControlUnavailableState>
+    )
+  }
+
+  return <SourceControl />
+}
+
+function SourceControlUnavailableState({
+  children
+}: {
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-center h-full text-xs text-muted-foreground px-4 text-center">
+      {children}
+    </div>
+  )
+}
+
+export default memo(SourceControlGateInner)

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -2,9 +2,9 @@ import { Suspense } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import type { ActiveRightSidebarTab } from '@/store/slices/editor'
 import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
+import SourceControlGate from './SourceControlGate'
 
 const FileExplorer = lazy(() => import('./FileExplorer'))
-const SourceControl = lazy(() => import('./SourceControl'))
 const ChecksPanel = lazy(() => import('./ChecksPanel'))
 const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
@@ -25,7 +25,7 @@ export function RightSidebarPanelContent({
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <Suspense fallback={null}>
         {effectiveTab === 'explorer' && <FileExplorer />}
-        {effectiveTab === 'source-control' && <SourceControl />}
+        {effectiveTab === 'source-control' && <SourceControlGate />}
         {effectiveTab === 'checks' && <ChecksPanel />}
         {/* Why: SSH port forwarding still depends on the raw ports.detect data,
             which the workspace-scoped status bar popover intentionally does not


### PR DESCRIPTION
## Summary

- Add a small Source Control gate that resolves the active workspace before mounting the heavy Git Source Control component.
- Preserve the existing translated no-selection and folder-workspace placeholders.
- Lazy-load only the heavy Git component; the gate itself is statically imported to avoid a second chunk waterfall and blank fallback.

Closes #10969.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted validation:

- Source Control gate, host-context boundary, and lazy-load syntax-error suites: 9 tests passed
- Touched-file `oxlint`, type-aware `oxlint`, and `oxfmt --check` passed
- `git diff --check` passed after rebasing onto current `origin/main`

The full web typecheck was attempted but the isolated worktree dependency installation was missing the existing `@tiptap/core` package. Focused type-aware lint and tests passed.

## AI Review Report

The adversarial review checked Rules of Hooks, store transitions, folder/legacy repo classification, lazy module loading, existing empty-state UI, and Suspense behavior. It caught two issues in the initial version: the placeholders disappeared, and lazy-loading both the gate and Source Control created a sequential chunk waterfall. Both were corrected and covered by tests that assert the heavy module is not loaded for folder/no-selection states.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows, including the SSH and folder-workspace requirements. No shortcuts, labels, paths, shell behavior, or Electron platform branches changed.

## Security Audit

No command execution, input parsing, path mutation, authentication, secrets, dependencies, or IPC behavior changed. The gate only reads existing renderer store selectors and repo metadata.

## Notes

Legacy repositories without an explicit `kind` retain the existing Git-repository behavior.
