### PR TITLE
fix(tasks): share GitHub task query semantics with mobile

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -147,7 +147,8 @@ import {
   githubProjectHost,
   githubProjectIdentityKey as githubProjectKey
 } from '../../../../src/shared/github-project-identity'
-import { getTaskPresetQuery, scopeGitHubTaskSearch } from '../../../../src/shared/task-query'
+import { getTaskPresetQuery, scopeGitHubTaskSearch } from '../../../../src/shared/github-task-query'
+import { resolveMobileGitHubTaskKind } from '../../../src/tasks/mobile-github-task-kind'
 
 type RepoSummary = {
   id: string
@@ -901,18 +902,6 @@ function normalizeLinearFilter(value: unknown): LinearFilter {
   return value === 'assigned' || value === 'created' || value === 'completed' || value === 'all'
     ? value
     : 'all'
-}
-
-function githubKindFromQuery(query: string, fallbackPreset: GitHubPreset): GitHubTaskKind {
-  if (/\bis:(?:pr|pull-request)\b/i.test(query)) {
-    return 'prs'
-  }
-  if (/\bis:issue\b/i.test(query)) {
-    return 'issues'
-  }
-  return fallbackPreset === 'prs' || fallbackPreset === 'my-prs' || fallbackPreset === 'review'
-    ? 'prs'
-    : 'issues'
 }
 
 function projectRowType(row: GitHubProjectRow): 'issue' | 'pr' | null {
@@ -3029,7 +3018,7 @@ export default function MobileTasksScreen() {
         nextProvider === 'github' ? githubQuery : nextProvider === 'linear' ? nextLinearQuery : ''
       const nextAppliedQuery =
         nextProvider === 'github'
-          ? scopeGitHubTaskSearch(githubQuery, githubKindFromQuery(githubQuery, preset))
+          ? scopeGitHubTaskSearch(githubQuery, resolveMobileGitHubTaskKind(githubQuery, preset))
           : nextQuery
 
       setVisibleProviders(nextVisibleProviders)
@@ -3037,7 +3026,7 @@ export default function MobileTasksScreen() {
       setGithubMode(resume.githubMode === 'project' ? 'project' : 'items')
       setDefaultGitHubPreset(defaultPreset)
       setGithubPreset(preset)
-      setGithubKind(githubKindFromQuery(githubQuery, preset))
+      setGithubKind(resolveMobileGitHubTaskKind(githubQuery, preset))
       setLinearFilter(nextLinearFilter)
       setGithubProjectSettings(settings.githubProjects ?? EMPTY_GITHUB_PROJECT_SETTINGS)
       setQuery(nextQuery)
@@ -9789,7 +9778,7 @@ export default function MobileTasksScreen() {
               resume.githubItemsPreset === null
                 ? (resume.githubItemsQuery ?? '')
                 : getTaskPresetQuery(preset)
-            const nextKind = githubKindFromQuery(nextQuery, preset)
+            const nextKind = resolveMobileGitHubTaskKind(nextQuery, preset)
             setGithubPreset(preset)
             setGithubKind(nextKind)
             setQuery(nextQuery)

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -147,6 +147,7 @@ import {
   githubProjectHost,
   githubProjectIdentityKey as githubProjectKey
 } from '../../../../src/shared/github-project-identity'
+import { getTaskPresetQuery, scopeGitHubTaskSearch } from '../../../../src/shared/task-query'
 
 type RepoSummary = {
   id: string
@@ -882,22 +883,6 @@ function formatUpdatedAt(value: string): string {
   return `${Math.floor(hours / 24)}d`
 }
 
-function getTaskPresetQuery(preset: GitHubPreset): string {
-  switch (preset) {
-    case 'my-issues':
-      return 'assignee:@me is:issue is:open'
-    case 'prs':
-      return 'is:pr is:open'
-    case 'my-prs':
-      return 'author:@me is:pr is:open'
-    case 'review':
-      return 'review-requested:@me is:pr is:open'
-    case 'issues':
-    default:
-      return 'is:issue is:open'
-  }
-}
-
 function isTaskProvider(value: unknown): value is TaskProvider {
   return value === 'github' || value === 'gitlab' || value === 'linear'
 }
@@ -919,7 +904,7 @@ function normalizeLinearFilter(value: unknown): LinearFilter {
 }
 
 function githubKindFromQuery(query: string, fallbackPreset: GitHubPreset): GitHubTaskKind {
-  if (/\bis:pr\b/i.test(query)) {
+  if (/\bis:(?:pr|pull-request)\b/i.test(query)) {
     return 'prs'
   }
   if (/\bis:issue\b/i.test(query)) {
@@ -997,17 +982,6 @@ function projectRowStatusLabel(row: GitHubProjectRow): string {
     return 'Closed'
   }
   return 'Open'
-}
-
-function scopeGitHubTaskSearch(query: string, kind: GitHubTaskKind): string {
-  const trimmed = query.trim()
-  if (!trimmed) {
-    return getTaskPresetQuery(kind === 'prs' ? 'prs' : 'issues')
-  }
-  if (/\bis:(?:issue|pr)\b/i.test(trimmed)) {
-    return trimmed
-  }
-  return `${kind === 'prs' ? 'is:pr' : 'is:issue'} ${trimmed}`
 }
 
 function gitHubStatusLabel(item: GitHubWorkItem): string {

--- a/mobile/src/tasks/mobile-github-task-kind.ts
+++ b/mobile/src/tasks/mobile-github-task-kind.ts
@@ -1,0 +1,28 @@
+import type { TaskViewPresetId } from '../../../src/shared/types'
+import { getExplicitTaskQueryScope, parseTaskQuery } from '../../../src/shared/task-query'
+
+export type MobileGitHubTaskKind = 'issues' | 'prs'
+
+/** Resolve the mobile GitHub tab from explicit, unquoted scope tokens or its saved preset. */
+export function resolveMobileGitHubTaskKind(
+  query: string,
+  fallbackPreset: TaskViewPresetId
+): MobileGitHubTaskKind {
+  const explicitScope = getExplicitTaskQueryScope(query)
+  if (explicitScope === 'pr') {
+    return 'prs'
+  }
+  if (explicitScope === 'issue') {
+    return 'issues'
+  }
+  const parsed = parseTaskQuery(query)
+  if (parsed.scope === 'pr') {
+    return 'prs'
+  }
+  if (parsed.scope === 'issue') {
+    return 'issues'
+  }
+  return fallbackPreset === 'prs' || fallbackPreset === 'my-prs' || fallbackPreset === 'review'
+    ? 'prs'
+    : 'issues'
+}

--- a/mobile/src/tasks/mobile-github-task-query.test.ts
+++ b/mobile/src/tasks/mobile-github-task-query.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { getTaskPresetQuery, scopeGitHubTaskSearch } from '../../../src/shared/task-query'
+
+describe('mobile GitHub task query parity', () => {
+  it.each([
+    ['issues', 'is:issue is:open'],
+    ['my-issues', 'assignee:@me is:issue is:open'],
+    ['prs', 'is:pr is:open'],
+    ['my-prs', 'author:@me is:pr is:open'],
+    ['review', 'review-requested:@me is:pr is:open']
+  ] as const)('keeps the %s preset aligned with desktop', (preset, expected) => {
+    expect(getTaskPresetQuery(preset)).toBe(expected)
+  })
+
+  it.each([
+    ['is:issue bug', 'prs'],
+    ['is:pr bug', 'issues'],
+    ['is:pull-request bug', 'issues']
+  ] as const)('preserves the %s scope alias', (query, kind) => {
+    expect(scopeGitHubTaskSearch(query, kind)).toBe(query)
+  })
+})

--- a/mobile/src/tasks/mobile-github-task-query.test.ts
+++ b/mobile/src/tasks/mobile-github-task-query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { getTaskPresetQuery, scopeGitHubTaskSearch } from '../../../src/shared/task-query'
+import { getTaskPresetQuery, scopeGitHubTaskSearch } from '../../../src/shared/github-task-query'
+import { resolveMobileGitHubTaskKind } from './mobile-github-task-kind'
 
 describe('mobile GitHub task query parity', () => {
   it.each([
@@ -13,10 +14,17 @@ describe('mobile GitHub task query parity', () => {
   })
 
   it.each([
-    ['is:issue bug', 'prs'],
-    ['is:pr bug', 'issues'],
-    ['is:pull-request bug', 'issues']
-  ] as const)('preserves the %s scope alias', (query, kind) => {
-    expect(scopeGitHubTaskSearch(query, kind)).toBe(query)
+    ['is:issue bug', 'prs', 'issues'],
+    ['is:pr bug', 'issues', 'prs'],
+    ['is:pull-request bug', 'issues', 'prs'],
+    ['review-requested:@me', 'issues', 'prs'],
+    ['"is:pull-request"', 'issues', 'issues'],
+    ['label:"is:issue"', 'prs', 'prs']
+  ] as const)('resolves %s from the mobile parser', (query, fallback, expected) => {
+    expect(resolveMobileGitHubTaskKind(query, fallback)).toBe(expected)
+  })
+
+  it('preserves explicit aliases when scoping the mobile query', () => {
+    expect(scopeGitHubTaskSearch('is:pull-request bug', 'issues')).toBe('is:pull-request bug')
   })
 })

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -124,12 +124,8 @@ import {
   getLinearStateMarkerStyle,
   getLinearStatePillStyle
 } from '@/components/linear-state-pill-style'
-import {
-  parseTaskQuery,
-  scopeGitHubTaskSearch,
-  stripRepoQualifiers,
-  withQualifier
-} from '../../../shared/task-query'
+import { scopeGitHubTaskSearch } from '../../../shared/github-task-query'
+import { parseTaskQuery, stripRepoQualifiers, withQualifier } from '../../../shared/task-query'
 import { githubProjectHost } from '../../../shared/github-project-identity'
 import {
   buildLinearTeamUrl,

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -124,7 +124,12 @@ import {
   getLinearStateMarkerStyle,
   getLinearStatePillStyle
 } from '@/components/linear-state-pill-style'
-import { parseTaskQuery, stripRepoQualifiers, withQualifier } from '../../../shared/task-query'
+import {
+  parseTaskQuery,
+  scopeGitHubTaskSearch,
+  stripRepoQualifiers,
+  withQualifier
+} from '../../../shared/task-query'
 import { githubProjectHost } from '../../../shared/github-project-identity'
 import {
   buildLinearTeamUrl,
@@ -556,19 +561,6 @@ function getGitHubTaskKind(preset: TaskViewPresetId | null, query: string): GitH
 
 function getDefaultPresetForGitHubTaskKind(kind: GitHubTaskKind): TaskViewPresetId {
   return kind === 'prs' ? 'prs' : 'issues'
-}
-
-function scopeGitHubTaskSearch(query: string, kind: GitHubTaskKind): string {
-  const trimmed = query.trim()
-  if (!trimmed) {
-    return getTaskPresetQuery(getDefaultPresetForGitHubTaskKind(kind))
-  }
-  if (/\bis:(?:issue|pr|pull-request)\b/i.test(trimmed)) {
-    return trimmed
-  }
-  const parsed = parseTaskQuery(trimmed)
-  const inferredKind = parsed.scope === 'pr' ? 'prs' : parsed.scope === 'issue' ? 'issues' : kind
-  return `${inferredKind === 'prs' ? 'is:pr' : 'is:issue'} ${trimmed}`
 }
 
 // Why: Intl.RelativeTimeFormat allocation is non-trivial; hoist to module scope so all rows share one instance instead of allocating per render.

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -20,7 +20,7 @@ import { createBrowserUuid } from '@/lib/browser-uuid'
 export { getLinkedWorkItemSuggestedName } from '../../../shared/workspace-name'
 export { getLinkedWorkItemWorkspaceName } from '../../../shared/workspace-name'
 export { getWorkspaceIntentName } from '../../../shared/workspace-name'
-export { getTaskPresetQuery } from '../../../shared/task-query'
+export { getTaskPresetQuery } from '../../../shared/github-task-query'
 export { PER_REPO_FETCH_LIMIT, CROSS_REPO_DISPLAY_LIMIT } from '../../../shared/work-items'
 
 export const CLIENT_PLATFORM: NodeJS.Platform = navigator.userAgent.includes('Windows')

--- a/src/renderer/src/lib/new-workspace.ts
+++ b/src/renderer/src/lib/new-workspace.ts
@@ -13,39 +13,15 @@ import {
   queuePendingAgentStartupDelivery,
   resolveAgentStartupTabId
 } from '@/lib/agent-startup-delayed-delivery'
-import type { FolderWorkspaceLinkedTask, OrcaHooks, TaskViewPresetId } from '../../../shared/types'
+import type { FolderWorkspaceLinkedTask, OrcaHooks } from '../../../shared/types'
 import { resolveHookCommandSourcePolicy } from '../../../shared/hook-command-source-policy'
 import { slugifyForWorkspaceName } from '../../../shared/workspace-name'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 export { getLinkedWorkItemSuggestedName } from '../../../shared/workspace-name'
 export { getLinkedWorkItemWorkspaceName } from '../../../shared/workspace-name'
 export { getWorkspaceIntentName } from '../../../shared/workspace-name'
-
-/**
- * Why: the TaskPage's preset buttons and the openTaskPage prefetcher both need
- * to compute the same GitHub query string for a given preset id. Keep the
- * mapping here so the prefetch warms exactly the cache key the page will look
- * up on mount.
- */
+export { getTaskPresetQuery } from '../../../shared/task-query'
 export { PER_REPO_FETCH_LIMIT, CROSS_REPO_DISPLAY_LIMIT } from '../../../shared/work-items'
-
-export function getTaskPresetQuery(presetId: TaskViewPresetId | null): string {
-  switch (presetId) {
-    case 'all':
-    case 'issues':
-      return 'is:issue is:open'
-    case 'my-issues':
-      return 'assignee:@me is:issue is:open'
-    case 'prs':
-      return 'is:pr is:open'
-    case 'my-prs':
-      return 'author:@me is:pr is:open'
-    case 'review':
-      return 'review-requested:@me is:pr is:open'
-    case null:
-      return 'is:issue is:open'
-  }
-}
 
 export const CLIENT_PLATFORM: NodeJS.Platform = navigator.userAgent.includes('Windows')
   ? 'win32'

--- a/src/shared/github-task-query.ts
+++ b/src/shared/github-task-query.ts
@@ -1,0 +1,35 @@
+import type { TaskViewPresetId } from './types'
+import { getExplicitTaskQueryScope, parseTaskQuery, type GitHubTaskKind } from './task-query'
+
+/** Map a saved task-view preset to the GitHub search query used by every client. */
+export function getTaskPresetQuery(presetId: TaskViewPresetId | null): string {
+  switch (presetId) {
+    case 'all':
+    case 'issues':
+      return 'is:issue is:open'
+    case 'my-issues':
+      return 'assignee:@me is:issue is:open'
+    case 'prs':
+      return 'is:pr is:open'
+    case 'my-prs':
+      return 'author:@me is:pr is:open'
+    case 'review':
+      return 'review-requested:@me is:pr is:open'
+    case null:
+      return 'is:issue is:open'
+  }
+}
+
+/** Add a GitHub issue or pull-request scope unless the query already has one. */
+export function scopeGitHubTaskSearch(query: string, kind: GitHubTaskKind): string {
+  const trimmed = query.trim()
+  if (!trimmed) {
+    return getTaskPresetQuery(kind === 'prs' ? 'prs' : 'issues')
+  }
+  if (getExplicitTaskQueryScope(trimmed) !== null) {
+    return trimmed
+  }
+  const parsed = parseTaskQuery(trimmed)
+  const inferredKind = parsed.scope === 'pr' ? 'prs' : parsed.scope === 'issue' ? 'issues' : kind
+  return `${inferredKind === 'prs' ? 'is:pr' : 'is:issue'} ${trimmed}`
+}

--- a/src/shared/task-query.test.ts
+++ b/src/shared/task-query.test.ts
@@ -1,11 +1,41 @@
 import { describe, expect, it } from 'vitest'
 import {
+  getTaskPresetQuery,
   parseTaskQuery,
   serializeTaskQuery,
+  scopeGitHubTaskSearch,
   stripRepoQualifiers,
   tokenizeSearchQuery,
   withQualifier
 } from './task-query'
+
+describe('GitHub task queries', () => {
+  it.each([
+    ['all', 'is:issue is:open'],
+    ['issues', 'is:issue is:open'],
+    ['my-issues', 'assignee:@me is:issue is:open'],
+    ['prs', 'is:pr is:open'],
+    ['my-prs', 'author:@me is:pr is:open'],
+    ['review', 'review-requested:@me is:pr is:open'],
+    [null, 'is:issue is:open']
+  ] as const)('maps %s to its preset query', (preset, expected) => {
+    expect(getTaskPresetQuery(preset)).toBe(expected)
+  })
+
+  it.each([
+    ['is:issue bug', 'prs'],
+    ['is:pr bug', 'issues'],
+    ['is:pull-request bug', 'issues']
+  ] as const)('preserves the %s scope alias', (query, kind) => {
+    expect(scopeGitHubTaskSearch(query, kind)).toBe(query)
+  })
+
+  it('infers pull requests from PR-only qualifiers', () => {
+    expect(scopeGitHubTaskSearch('review-requested:@me', 'issues')).toBe(
+      'is:pr review-requested:@me'
+    )
+  })
+})
 
 describe('tokenizeSearchQuery', () => {
   it('splits on whitespace', () => {

--- a/src/shared/task-query.test.ts
+++ b/src/shared/task-query.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { getTaskPresetQuery, scopeGitHubTaskSearch } from './github-task-query'
 import {
-  getTaskPresetQuery,
   parseTaskQuery,
   serializeTaskQuery,
-  scopeGitHubTaskSearch,
   stripRepoQualifiers,
   tokenizeSearchQuery,
   withQualifier
@@ -29,6 +28,17 @@ describe('GitHub task queries', () => {
   ] as const)('preserves the %s scope alias', (query, kind) => {
     expect(scopeGitHubTaskSearch(query, kind)).toBe(query)
   })
+
+  it.each([
+    ['"is:issue"', 'prs', 'is:pr "is:issue"'],
+    ['label:"is:issue"', 'prs', 'is:pr label:"is:issue"'],
+    ["'is:pull-request'", 'issues', "is:issue 'is:pull-request'"]
+  ] as const)(
+    'does not treat quoted scope text in %s as an explicit scope',
+    (query, kind, expected) => {
+      expect(scopeGitHubTaskSearch(query, kind)).toBe(expected)
+    }
+  )
 
   it('infers pull requests from PR-only qualifiers', () => {
     expect(scopeGitHubTaskSearch('review-requested:@me', 'issues')).toBe(
@@ -85,6 +95,13 @@ describe('parseTaskQuery', () => {
     const parsed = parseTaskQuery('is:pull-request is:open')
     expect(parsed.scope).toBe('pr')
     expect(parsed.state).toBe('open')
+  })
+
+  it('keeps quoted scope text out of the parsed scope', () => {
+    const parsed = parseTaskQuery('"is:issue" label:"is:pr"')
+    expect(parsed.scope).toBe('all')
+    expect(parsed.labels).toEqual(['is:pr'])
+    expect(parsed.freeText).toBe('"is:issue"')
   })
 
   it('widens scope to all when both is:issue and is:pr are present', () => {

--- a/src/shared/task-query.ts
+++ b/src/shared/task-query.ts
@@ -1,3 +1,7 @@
+import type { TaskViewPresetId } from './types'
+
+export type GitHubTaskKind = 'issues' | 'prs'
+
 export type ParsedTaskQuery = {
   scope: 'all' | 'issue' | 'pr'
   state: 'open' | 'closed' | 'all' | 'merged' | null
@@ -160,6 +164,37 @@ export function parseTaskQuery(rawQuery: string): ParsedTaskQuery {
   }
   query.freeText = freeTextTokens.join(' ').trim()
   return query
+}
+
+export function getTaskPresetQuery(presetId: TaskViewPresetId | null): string {
+  switch (presetId) {
+    case 'all':
+    case 'issues':
+      return 'is:issue is:open'
+    case 'my-issues':
+      return 'assignee:@me is:issue is:open'
+    case 'prs':
+      return 'is:pr is:open'
+    case 'my-prs':
+      return 'author:@me is:pr is:open'
+    case 'review':
+      return 'review-requested:@me is:pr is:open'
+    case null:
+      return 'is:issue is:open'
+  }
+}
+
+export function scopeGitHubTaskSearch(query: string, kind: GitHubTaskKind): string {
+  const trimmed = query.trim()
+  if (!trimmed) {
+    return getTaskPresetQuery(kind === 'prs' ? 'prs' : 'issues')
+  }
+  if (/\bis:(?:issue|pr|pull-request)\b/i.test(trimmed)) {
+    return trimmed
+  }
+  const parsed = parseTaskQuery(trimmed)
+  const inferredKind = parsed.scope === 'pr' ? 'prs' : parsed.scope === 'issue' ? 'issues' : kind
+  return `${inferredKind === 'prs' ? 'is:pr' : 'is:issue'} ${trimmed}`
 }
 
 function quoteIfNeeded(value: string): string {

--- a/src/shared/task-query.ts
+++ b/src/shared/task-query.ts
@@ -1,5 +1,3 @@
-import type { TaskViewPresetId } from './types'
-
 export type GitHubTaskKind = 'issues' | 'prs'
 
 export type ParsedTaskQuery = {
@@ -76,12 +74,13 @@ export function parseTaskQuery(rawQuery: string): ParsedTaskQuery {
   let sawPRScope = false
   for (const { value: token, raw } of tokenizeSearchQueryWithRaw(rawQuery.trim())) {
     const normalized = token.toLowerCase()
-    if (normalized === 'is:issue') {
+    const isBareToken = raw === token
+    if (isBareToken && normalized === 'is:issue') {
       sawIssueScope = true
       query.scope = sawPRScope ? 'all' : 'issue'
       continue
     }
-    if (normalized === 'is:pr' || normalized === 'is:pull-request') {
+    if (isBareToken && (normalized === 'is:pr' || normalized === 'is:pull-request')) {
       sawPRScope = true
       query.scope = sawIssueScope ? 'all' : 'pr'
       continue
@@ -166,35 +165,22 @@ export function parseTaskQuery(rawQuery: string): ParsedTaskQuery {
   return query
 }
 
-export function getTaskPresetQuery(presetId: TaskViewPresetId | null): string {
-  switch (presetId) {
-    case 'all':
-    case 'issues':
-      return 'is:issue is:open'
-    case 'my-issues':
-      return 'assignee:@me is:issue is:open'
-    case 'prs':
-      return 'is:pr is:open'
-    case 'my-prs':
-      return 'author:@me is:pr is:open'
-    case 'review':
-      return 'review-requested:@me is:pr is:open'
-    case null:
-      return 'is:issue is:open'
+/** Return the explicit, unquoted GitHub work-item scope in a task query. */
+export function getExplicitTaskQueryScope(rawQuery: string): ParsedTaskQuery['scope'] | null {
+  let sawIssueScope = false
+  let sawPRScope = false
+  for (const { value, raw } of tokenizeSearchQueryWithRaw(rawQuery.trim())) {
+    if (raw !== value) {
+      continue
+    }
+    const normalized = value.toLowerCase()
+    sawIssueScope ||= normalized === 'is:issue'
+    sawPRScope ||= normalized === 'is:pr' || normalized === 'is:pull-request'
   }
-}
-
-export function scopeGitHubTaskSearch(query: string, kind: GitHubTaskKind): string {
-  const trimmed = query.trim()
-  if (!trimmed) {
-    return getTaskPresetQuery(kind === 'prs' ? 'prs' : 'issues')
+  if (sawIssueScope && sawPRScope) {
+    return 'all'
   }
-  if (/\bis:(?:issue|pr|pull-request)\b/i.test(trimmed)) {
-    return trimmed
-  }
-  const parsed = parseTaskQuery(trimmed)
-  const inferredKind = parsed.scope === 'pr' ? 'prs' : parsed.scope === 'issue' ? 'issues' : kind
-  return `${inferredKind === 'prs' ? 'is:pr' : 'is:issue'} ${trimmed}`
+  return sawIssueScope ? 'issue' : sawPRScope ? 'pr' : null
 }
 
 function quoteIfNeeded(value: string): string {


### PR DESCRIPTION
## Summary

- Share GitHub task preset and scoping logic between desktop and mobile.
- Make mobile recognize the existing `is:pull-request` alias and PR-only qualifiers consistently with desktop.
- Use token-aware scope detection so quoted text and qualifier values are not mistaken for explicit issue/PR scopes.
- Keep the removed legacy `all` view normalized to `issues` in mobile state while retaining exhaustive query mapping for persisted settings.

Addresses the task-query parity portion of #10950. Mobile Jira/provider availability remains intentionally out of scope.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted validation:

- Shared task-query suite: 48 tests passed
- Mobile GitHub task-query suite: 12 tests passed
- Root web and mobile TypeScript typechecks passed
- Touched-file root/mobile `oxlint` and `oxfmt --check` passed
- `git diff --check` passed after rebasing onto current `origin/main`

## AI Review Report

The adversarial review compared desktop/mobile query behavior, persisted preset handling, provider boundaries, quoted search text, and the mobile picker options. It caught that an initial version could resurrect the removed `all` view in mobile state despite no matching picker option. CodeRabbit later identified raw-regex scope detection that could misclassify quoted text; the final version uses one token-aware detector across shared and mobile code and directly tests the mobile kind resolver.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows. This change only transforms GitHub search strings and does not alter shortcuts, labels, paths, shells, or Electron-specific platform behavior.

## Security Audit

No command execution, filesystem paths, authentication, secrets, dependencies, or IPC contracts changed. User-entered search text is still passed through the existing GitHub query path; the shared function only adds or preserves recognized scope qualifiers.

## Notes

This PR does not add Jira to mobile and does not remove `mobile-task-providers.ts`.
