### PR TITLE
fix(remote): recover and report remote panes whose host PTY has no output pipeline

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2639,6 +2639,8 @@ export class OrcaRuntimeService {
   // iterates them all. Listeners are cleaned up via subscriptionCleanups.
   private notificationListeners = new Set<(event: MobileNotificationEvent) => void>()
   private ptysById = new Map<string, RuntimePtyWorktreeRecord>()
+  // Why: single-flight per PTY so repeated subscribes to a never-observed pane don't spam mount requests.
+  private unobservedPtyAttachRequests = new Set<string>()
   private wslDistroByPtyId = new Map<string, string>()
   private titleObservationSequence = 0
   private headlessTerminals = new Map<string, RuntimeHeadlessTerminal>()
@@ -7772,6 +7774,8 @@ export class OrcaRuntimeService {
       pty.connected = true
       pty.disconnectedAt = null
       pty.lastOutputAt = at
+      // The output pipeline is proven; a later subscribe may request a fresh attach if it breaks again.
+      this.unobservedPtyAttachRequests.delete(ptyId)
       const normalized = normalizeTerminalChunk(data, pty.tailPendingAnsi)
       pty.tailPendingAnsi = normalized.pendingAnsi
       const nextTail = appendNormalizedToTailBuffer(
@@ -11169,6 +11173,7 @@ export class OrcaRuntimeService {
     this.remoteDesktopHostReclaimTargets.delete(ptyId)
     this.remoteDesktopViewerRevisions.delete(ptyId)
     this.disposeHeadlessTerminal(ptyId)
+    this.unobservedPtyAttachRequests.delete(ptyId)
     this.agentDetector?.onExit(ptyId)
     if (pty) {
       pty.connected = false
@@ -23432,6 +23437,32 @@ export class OrcaRuntimeService {
       this.graphSyncCallbacks.push(check)
       check()
     })
+  }
+
+  // Why: the daemon outlives the app, so after a host restart a session can be alive with its
+  // shell running while nothing is attached — output goes only to the daemon and every remote
+  // keystroke lands in a terminal no one can see. Mounting the owning tab rebuilds that pipeline.
+  requestHostPaneAttachForUnobservedPty(handle: string, ptyId: string): boolean {
+    const pty = this.ptysById.get(ptyId)
+    if (!pty || pty.lastOutputAt !== null) {
+      return false
+    }
+    if (this.ptyController?.hasRendererSerializer?.(ptyId) === true) {
+      return false
+    }
+    if (this.hasHeadlessTerminalState(ptyId)) {
+      return false
+    }
+    if (this.unobservedPtyAttachRequests.has(ptyId)) {
+      return false
+    }
+    this.unobservedPtyAttachRequests.add(ptyId)
+    const requested = this.requestRendererTerminalTabMount(handle)
+    if (!requested) {
+      // Headless host has no window to mount into; let a later subscribe retry.
+      this.unobservedPtyAttachRequests.delete(ptyId)
+    }
+    return requested
   }
 
   // Why: never-mounted tabs have no PTY or snapshot; synthetic handles need the ptyId to mount the exact owning tab.

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1557,6 +1557,10 @@ const RECENT_PTY_PATH_CANDIDATE_LIMIT = 1024
 const RECENT_PTY_PATH_CANDIDATE_MAX_BYTES = 4 * 1024
 const RECENT_PTY_PATH_CANDIDATE_TOTAL_BYTES = 64 * 1024
 const SSH_PANE_RECOVERY_GRACE_MS = 30_000
+// Why: the renderer resolves the mount against its own graph and can legitimately find nothing to
+// mount, which it reports by doing nothing. Retry after this long so a later subscribe gets another
+// attempt, while still coalescing the burst of subscribes a single reconnect produces.
+const UNOBSERVED_PTY_ATTACH_RETRY_MS = 10_000
 
 function isClientDisconnectedError(error: unknown): boolean {
   return error instanceof Error && error.message === 'client_disconnected'
@@ -2639,8 +2643,10 @@ export class OrcaRuntimeService {
   // iterates them all. Listeners are cleaned up via subscriptionCleanups.
   private notificationListeners = new Set<(event: MobileNotificationEvent) => void>()
   private ptysById = new Map<string, RuntimePtyWorktreeRecord>()
-  // Why: single-flight per PTY so repeated subscribes to a never-observed pane don't spam mount requests.
-  private unobservedPtyAttachRequests = new Set<string>()
+  // Why: single-flight per PTY so repeated subscribes to a never-observed pane don't spam mount
+  // requests. Holds the request time, not just the id — the renderer can drop the mount silently,
+  // and a permanent latch would leave the pane in exactly the state this attach exists to repair.
+  private unobservedPtyAttachRequests = new Map<string, number>()
   private wslDistroByPtyId = new Map<string, string>()
   private titleObservationSequence = 0
   private headlessTerminals = new Map<string, RuntimeHeadlessTerminal>()
@@ -23453,10 +23459,12 @@ export class OrcaRuntimeService {
     if (this.hasHeadlessTerminalState(ptyId)) {
       return false
     }
-    if (this.unobservedPtyAttachRequests.has(ptyId)) {
+    const requestedAt = this.unobservedPtyAttachRequests.get(ptyId)
+    const now = Date.now()
+    if (requestedAt !== undefined && now - requestedAt < UNOBSERVED_PTY_ATTACH_RETRY_MS) {
       return false
     }
-    this.unobservedPtyAttachRequests.add(ptyId)
+    this.unobservedPtyAttachRequests.set(ptyId, now)
     const requested = this.requestRendererTerminalTabMount(handle)
     if (!requested) {
       // Headless host has no window to mount into; let a later subscribe retry.

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -15,7 +15,8 @@ import {
   encodeTerminalStreamFrame,
   encodeTerminalStreamJson,
   encodeTerminalStreamText,
-  type TerminalStreamFrame
+  type TerminalStreamFrame,
+  type TerminalStreamWriteUnavailableReason
 } from '../../../../shared/terminal-stream-protocol'
 import {
   iterateTerminalOutputFrameChunks,
@@ -115,6 +116,7 @@ type TerminalMultiplexStream = {
   ackInFlightBytes: number
   ackWindowBytes: number
   supportsDesktopViewportClaims: boolean
+  supportsWriteUnavailable: boolean
   desktopClaimTail: Promise<boolean>
   // Whether THIS stream registered the width driver, so detach won't release a peer stream's floor.
   registeredRemoteDesktopDriver: boolean
@@ -273,6 +275,14 @@ function resolveMobileFloorClientId(
   return null
 }
 
+/** Why an outcome: a swallowed send left the client typing into a void with no way to learn its input never landed. */
+type TerminalStreamInputOutcome = 'delivered' | 'rejected' | 'failed'
+
+function isTerminalStreamInputRejection(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes('terminal_not_writable') || message.includes('terminal_handle_stale')
+}
+
 async function sendTerminalStreamInput(
   runtime: OrcaRuntimeService,
   args: {
@@ -281,14 +291,14 @@ async function sendTerminalStreamInput(
     client: TerminalViewportClient | undefined
     isMobile: boolean
   }
-): Promise<void> {
+): Promise<TerminalStreamInputOutcome> {
   const action = { text: args.text, enter: false, interrupt: false }
   const clientId = args.isMobile ? args.client?.id : undefined
   const floorClaim: MobileInputFloorClaimHolder = { current: null }
   try {
     if (!clientId) {
-      await runtime.sendTerminal(args.terminal, action)
-      return
+      const result = await runtime.sendTerminal(args.terminal, action)
+      return result.accepted ? 'delivered' : 'rejected'
     }
     const result = await runtime.sendTerminal(args.terminal, action, {
       reserveWrite: (writePtyId) => {
@@ -302,9 +312,12 @@ async function sendTerminalStreamInput(
     })
     if (!result.accepted) {
       floorClaim.current?.rollback()
+      return 'rejected'
     }
-  } catch {
+    return 'delivered'
+  } catch (error) {
     floorClaim.current?.rollback()
+    return isTerminalStreamInputRejection(error) ? 'rejected' : 'failed'
   }
 }
 
@@ -934,7 +947,8 @@ const TerminalSubscribe = TerminalHandle.extend({
     .object({
       terminalBinaryStream: z.literal(1).optional(),
       desktopViewportClaims: z.literal(1).optional(),
-      mobileInputLeaseOnly: z.literal(1).optional()
+      mobileInputLeaseOnly: z.literal(1).optional(),
+      writeUnavailable: z.literal(1).optional()
     })
     .optional()
 })
@@ -953,7 +967,8 @@ const TerminalMultiplexSubscribeFrame = TerminalHandle.extend({
   capabilities: z
     .object({
       ackOutput: z.literal(1).optional(),
-      desktopViewportClaims: z.literal(1).optional()
+      desktopViewportClaims: z.literal(1).optional(),
+      writeUnavailable: z.literal(1).optional()
     })
     .optional()
 })
@@ -1554,6 +1569,22 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         sendFrame(streamId, TerminalStreamOpcode.Error, encodeTerminalStreamText(message))
         emit({ type: 'error', streamId, message })
       }
+      // Why gated on the declared capability: older clients kill the whole connection on an unknown opcode.
+      const notifyStreamWriteUnavailable = (
+        stream: TerminalMultiplexStream,
+        outcome: TerminalStreamInputOutcome
+      ): void => {
+        if (outcome !== 'rejected' || !stream.supportsWriteUnavailable) {
+          return
+        }
+        sendFrame(
+          stream.streamId,
+          TerminalStreamOpcode.WriteUnavailable,
+          encodeTerminalStreamJson({
+            reason: 'not_writable' satisfies TerminalStreamWriteUnavailableReason
+          })
+        )
+      }
       const sendResizedFrame = (
         stream: TerminalMultiplexStream,
         event: { cols: number; rows: number; displayMode: string; reason: string; seq?: number }
@@ -1845,16 +1876,17 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           }
           // Mobile already has the higher-priority floor, so a rejected desktop claim must not suppress later phone input.
           const inputClaimTail = stream.isMobile ? Promise.resolve(true) : stream.desktopClaimTail
-          void inputClaimTail.then((claimed) => {
+          void inputClaimTail.then(async (claimed) => {
             if (!claimed || isTerminalInputLockedForClient(runtime, stream.ptyId, stream.client)) {
               return
             }
-            return sendTerminalStreamInput(runtime, {
+            const outcome = await sendTerminalStreamInput(runtime, {
               terminal: stream.terminal,
               text,
               client: stream.client,
               isMobile: stream.isMobile
             })
+            notifyStreamWriteUnavailable(stream, outcome)
           })
           return
         }
@@ -2140,6 +2172,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         detachStream(request.streamId, false)
 
         const ptyId = leaf.ptyId
+        // Why not awaited: the stream already listens on the runtime emitter, so replay and live
+        // output flow in as soon as the host attach lands.
+        runtime.requestHostPaneAttachForUnobservedPty?.(request.terminal, ptyId)
         const stream: TerminalMultiplexStream = {
           streamId: request.streamId,
           terminal: request.terminal,
@@ -2150,6 +2185,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           ackInFlightBytes: 0,
           ackWindowBytes: TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES,
           supportsDesktopViewportClaims: request.capabilities?.desktopViewportClaims === 1,
+          supportsWriteUnavailable: request.capabilities?.writeUnavailable === 1,
           desktopClaimTail: Promise.resolve(true),
           registeredRemoteDesktopDriver: false,
           // Why: streamId is client-local, so key the width floor by connectionId or two connections sharing stream 1 for one PTY clobber each other's floor.
@@ -2508,6 +2544,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
       }
 
       const ptyId = leaf.ptyId
+      // Why not awaited: the subscription below feeds off the runtime emitter, which the attach fills.
+      runtime.requestHostPaneAttachForUnobservedPty?.(params.terminal, ptyId)
       const clientId = params.client?.id
       const mobileInputLeaseOnly =
         isMobile && params.capabilities?.mobileInputLeaseOnly === 1 && Boolean(clientId)
@@ -2521,6 +2559,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           : runtime.getRendererTerminalSerializerGeneration(ptyId)
         : 0
       const supportsDesktopViewportClaims = params.capabilities?.desktopViewportClaims === 1
+      const supportsWriteUnavailable = params.capabilities?.writeUnavailable === 1
       if (mobileInputLeaseOnly && clientId) {
         let closed = false
         let resolveStream = (): void => {}
@@ -2766,12 +2805,21 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               if (!claimed || isTerminalInputLockedForClient(runtime, ptyId, params.client)) {
                 return
               }
-              await sendTerminalStreamInput(runtime, {
+              const outcome = await sendTerminalStreamInput(runtime, {
                 terminal: params.terminal,
                 text,
                 client: params.client,
                 isMobile
               })
+              // Why gated on the declared capability: older clients kill the stream on an unknown opcode.
+              if (outcome === 'rejected' && supportsWriteUnavailable) {
+                sendFrame(
+                  TerminalStreamOpcode.WriteUnavailable,
+                  encodeTerminalStreamJson({
+                    reason: 'not_writable' satisfies TerminalStreamWriteUnavailableReason
+                  })
+                )
+              }
             })
             return
           }

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -1574,7 +1574,13 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         stream: TerminalMultiplexStream,
         outcome: TerminalStreamInputOutcome
       ): void => {
-        if (outcome !== 'rejected' || !stream.supportsWriteUnavailable) {
+        // Why the identity check: the write is awaited, so this streamId may already be detached and re-subscribed to another pane.
+        if (
+          closed ||
+          streams.get(stream.streamId) !== stream ||
+          outcome !== 'rejected' ||
+          !stream.supportsWriteUnavailable
+        ) {
           return
         }
         sendFrame(

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -226,6 +226,49 @@ describe('terminal multiplex write-unavailable signalling', () => {
     expect(writeUnavailableFrames(harness)).toEqual([])
   })
 
+  // Why (regression): the write is awaited, so an Unsubscribe can land first and the client can
+  // hand the same streamId to a different pane. Reporting the dead pane's rejection on that id
+  // would recover a terminal that is writing fine.
+  it('stays silent when the stream detached before the rejected write resolved', async () => {
+    let releaseSend: (result: unknown) => void = () => {}
+    const sendTerminal = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        releaseSend = resolve
+      })
+    )
+    const harness = await sendInputAfterSubscribe({
+      capabilities: { ackOutput: 1, desktopViewportClaims: 1, writeUnavailable: 1 },
+      sendTerminal: sendTerminal as unknown as OrcaRuntimeService['sendTerminal']
+    })
+    await vi.waitFor(() => expect(sendTerminal).toHaveBeenCalled())
+
+    harness.handlers.get(7)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Unsubscribe,
+          streamId: 7,
+          seq: 2,
+          payload: new Uint8Array()
+        })
+      )!
+    )
+    // The replacement pane now owns streamId 7.
+    sendDesktopMultiplexSubscribe(harness.handlers, {
+      ackOutput: 1,
+      desktopViewportClaims: 1,
+      writeUnavailable: 1
+    })
+    await vi.waitFor(() =>
+      expect(
+        harness.messages.filter((msg) => JSON.parse(msg).result?.type === 'subscribed')
+      ).toHaveLength(2)
+    )
+
+    releaseSend({ handle: 'terminal-1', accepted: false, bytesWritten: 0 })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(writeUnavailableFrames(harness)).toEqual([])
+  })
+
   // Why: a phone holding the input floor is a healthy pane, not an undeliverable one (docs/mobile-presence-lock.md).
   it('stays silent when the mobile presence lock owns the pane', async () => {
     const sendTerminal = vi

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -117,7 +117,8 @@ function startDesktopMultiplexSubscribe(
 }
 
 function sendDesktopMultiplexSubscribe(
-  handlers: Map<number, (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void>
+  handlers: Map<number, (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void>,
+  capabilities: Record<string, 1> = { ackOutput: 1, desktopViewportClaims: 1 }
 ) {
   handlers.get(0)?.(
     decodeTerminalStreamFrame(
@@ -129,13 +130,118 @@ function sendDesktopMultiplexSubscribe(
           streamId: 7,
           terminal: 'terminal-1',
           client: { id: 'desktop-1', type: 'desktop' },
-          capabilities: { ackOutput: 1, desktopViewportClaims: 1 },
+          capabilities,
           viewport: { cols: 120, rows: 40 }
         })
       })
     )!
   )
 }
+
+describe('terminal multiplex write-unavailable signalling', () => {
+  async function sendInputAfterSubscribe(options: {
+    capabilities?: Record<string, 1>
+    sendTerminal: OrcaRuntimeService['sendTerminal']
+    driver?: { kind: 'idle' } | { kind: 'mobile'; clientId: string }
+  }) {
+    const harness = startDesktopMultiplexSubscribe({
+      sendTerminal: options.sendTerminal,
+      getDriver: vi.fn().mockReturnValue(options.driver ?? { kind: 'idle' })
+    })
+    await vi.waitFor(() =>
+      expect(harness.messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+    )
+    sendDesktopMultiplexSubscribe(harness.handlers, options.capabilities)
+    await vi.waitFor(() =>
+      expect(harness.messages.some((msg) => JSON.parse(msg).result?.type === 'subscribed')).toBe(
+        true
+      )
+    )
+    harness.binaryFrames.splice(0)
+    harness.handlers.get(7)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Input,
+          streamId: 7,
+          seq: 1,
+          payload: encodeTerminalStreamText('hello')
+        })
+      )!
+    )
+    return harness
+  }
+
+  const writeUnavailableFrames = (harness: {
+    binaryFrames: Uint8Array<ArrayBufferLike>[]
+  }): NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>[] =>
+    harness.binaryFrames
+      .map((bytes) => decodeTerminalStreamFrame(bytes))
+      .filter((frame) => frame?.opcode === TerminalStreamOpcode.WriteUnavailable)
+      .map((frame) => frame!)
+
+  it('tells a capable client its input never reached the PTY', async () => {
+    const harness = await sendInputAfterSubscribe({
+      capabilities: { ackOutput: 1, desktopViewportClaims: 1, writeUnavailable: 1 },
+      sendTerminal: vi
+        .fn()
+        .mockResolvedValue({ handle: 'terminal-1', accepted: false, bytesWritten: 0 })
+    })
+
+    await vi.waitFor(() => expect(writeUnavailableFrames(harness)).toHaveLength(1))
+    expect(decodeTerminalStreamJson(writeUnavailableFrames(harness)[0].payload)).toEqual({
+      reason: 'not_writable'
+    })
+  })
+
+  it('reports a thrown terminal_not_writable the same way', async () => {
+    const harness = await sendInputAfterSubscribe({
+      capabilities: { ackOutput: 1, desktopViewportClaims: 1, writeUnavailable: 1 },
+      sendTerminal: vi.fn().mockRejectedValue(new Error('terminal_not_writable'))
+    })
+
+    await vi.waitFor(() => expect(writeUnavailableFrames(harness)).toHaveLength(1))
+  })
+
+  // Why: an unknown opcode fails decode and kills the whole multiplexed connection on older clients.
+  it('stays silent for a client that never declared the capability', async () => {
+    const harness = await sendInputAfterSubscribe({
+      sendTerminal: vi
+        .fn()
+        .mockResolvedValue({ handle: 'terminal-1', accepted: false, bytesWritten: 0 })
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(writeUnavailableFrames(harness)).toEqual([])
+  })
+
+  it('stays silent when the send succeeded', async () => {
+    const harness = await sendInputAfterSubscribe({
+      capabilities: { ackOutput: 1, desktopViewportClaims: 1, writeUnavailable: 1 },
+      sendTerminal: vi
+        .fn()
+        .mockResolvedValue({ handle: 'terminal-1', accepted: true, bytesWritten: 5 })
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(writeUnavailableFrames(harness)).toEqual([])
+  })
+
+  // Why: a phone holding the input floor is a healthy pane, not an undeliverable one (docs/mobile-presence-lock.md).
+  it('stays silent when the mobile presence lock owns the pane', async () => {
+    const sendTerminal = vi
+      .fn()
+      .mockResolvedValue({ handle: 'terminal-1', accepted: false, bytesWritten: 0 })
+    const harness = await sendInputAfterSubscribe({
+      capabilities: { ackOutput: 1, desktopViewportClaims: 1, writeUnavailable: 1 },
+      sendTerminal,
+      driver: { kind: 'mobile', clientId: 'phone-1' }
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(sendTerminal).not.toHaveBeenCalled()
+    expect(writeUnavailableFrames(harness)).toEqual([])
+  })
+})
 
 describe('terminal multiplex RPC', () => {
   it.each(['refuses', 'throws'] as const)(

--- a/src/main/runtime/unobserved-pty-host-attach.test.ts
+++ b/src/main/runtime/unobserved-pty-host-attach.test.ts
@@ -96,6 +96,31 @@ describe('host attach for unobserved PTYs', () => {
     expect(send).not.toHaveBeenCalled()
   })
 
+  // Why (regression): the renderer resolves the mount against its own graph and reports "nothing to
+  // mount" by doing nothing — a stale tab record, or a tab it already considers mounted. The host
+  // only knows webContents.send() succeeded, so a permanent latch would strand the pane in exactly
+  // the silent-input state this attach exists to repair, with no later subscribe able to retry.
+  it('retries the mount when the renderer silently dropped the earlier request', () => {
+    vi.useFakeTimers()
+    try {
+      const { runtime, send } = seedRuntime()
+
+      expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(true)
+      expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(false)
+
+      // Still coalescing the burst of subscribes one reconnect produces.
+      vi.advanceTimersByTime(9_000)
+      expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(false)
+      expect(send).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(1_500)
+      expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(true)
+      expect(send).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   // Why: a headless host has no window to mount into, so the request must stay retryable.
   it('does not consume the single-flight when no window can take the mount', () => {
     const { runtime, internals } = seedRuntime({ withWindow: false })

--- a/src/main/runtime/unobserved-pty-host-attach.test.ts
+++ b/src/main/runtime/unobserved-pty-host-attach.test.ts
@@ -1,0 +1,110 @@
+/** A daemon session can outlive the host app with its shell alive but nothing attached: output reaches
+ *  only the daemon and remote keystrokes land in a terminal no client can see. Subscribe must re-attach. */
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+
+type RuntimeInternals = {
+  handles: Map<string, unknown>
+  ptysById: Map<string, { ptyId: string; lastOutputAt: number | null }>
+  headlessTerminals: Map<string, unknown>
+  getAuthoritativeWindow: () => {
+    webContents: { send: (channel: string, payload: unknown) => void }
+  }
+}
+
+function seedRuntime(options: { lastOutputAt?: number | null; withWindow?: boolean } = {}): {
+  runtime: OrcaRuntimeService
+  send: ReturnType<typeof vi.fn>
+  internals: RuntimeInternals
+} {
+  const runtime = new OrcaRuntimeService()
+  const internals = runtime as unknown as RuntimeInternals
+  internals.handles.set('term_1', {
+    handle: 'term_1',
+    worktreeId: 'wt-1',
+    tabId: 'tab-1',
+    leafId: 'leaf-1',
+    ptyId: 'pty-1',
+    ptyGeneration: 1,
+    runtimeId: 'rt-test',
+    rendererGraphEpoch: 1
+  })
+  internals.ptysById.set('pty-1', {
+    ptyId: 'pty-1',
+    lastOutputAt: options.lastOutputAt ?? null
+  })
+  const send = vi.fn()
+  internals.getAuthoritativeWindow =
+    options.withWindow === false
+      ? () => {
+          throw new Error('no authoritative window')
+        }
+      : () => ({ webContents: { send } })
+  return { runtime, send, internals }
+}
+
+describe('host attach for unobserved PTYs', () => {
+  it('requests a host pane mount when the runtime has never seen output', () => {
+    const { runtime, send } = seedRuntime()
+
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(true)
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('terminal:requestTabMount', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      ptyId: 'pty-1'
+    })
+  })
+
+  it('requests the mount only once while the attach is still pending', () => {
+    const { runtime, send } = seedRuntime()
+
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(true)
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(false)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves a pane alone once its output pipeline has proven itself', () => {
+    const { runtime, send } = seedRuntime({ lastOutputAt: Date.now() })
+
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(false)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('leaves a pane alone when main already holds headless terminal state', () => {
+    const { runtime, send, internals } = seedRuntime()
+    internals.headlessTerminals.set('pty-1', {})
+
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(false)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('leaves a pane alone when a renderer serializer is already attached', () => {
+    const { runtime, send } = seedRuntime()
+    runtime.setPtyController({
+      hasRendererSerializer: () => true
+    } as unknown as Parameters<OrcaRuntimeService['setPtyController']>[0])
+
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(false)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('ignores an unknown PTY record', () => {
+    const { runtime, send } = seedRuntime()
+
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-missing')).toBe(false)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  // Why: a headless host has no window to mount into, so the request must stay retryable.
+  it('does not consume the single-flight when no window can take the mount', () => {
+    const { runtime, internals } = seedRuntime({ withWindow: false })
+
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(false)
+
+    const send = vi.fn()
+    internals.getAuthoritativeWindow = () => ({ webContents: { send } })
+    expect(runtime.requestHostPaneAttachForUnobservedPty('term_1', 'pty-1')).toBe(true)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -225,7 +225,8 @@ describe('createRemoteRuntimePtyTransport', () => {
     await vi.waitFor(() =>
       expect(latestSubscribePayload().capabilities).toEqual({
         ackOutput: 1,
-        desktopViewportClaims: 1
+        desktopViewportClaims: 1,
+        writeUnavailable: 1
       })
     )
     expect(runtimeSubscribe).toHaveBeenCalledWith(
@@ -242,6 +243,39 @@ describe('createRemoteRuntimePtyTransport', () => {
       client: { id: expect.stringMatching(/^desktop:tab-1:pane:1:/), type: 'desktop' },
       viewport: { cols: 120, rows: 40 }
     })
+  })
+
+  it('reports undeliverable input when the host says the stream write went nowhere', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onError = vi.fn()
+    const onWriteUnavailable = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    transport.attach({
+      existingPtyId: 'remote:terminal-1',
+      cols: 120,
+      rows: 40,
+      callbacks: { onError, onWriteUnavailable }
+    })
+
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    const streamId = latestSubscribePayload().streamId
+    subscriptionCallbacks?.onBinary?.(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.WriteUnavailable,
+        streamId,
+        seq: 1,
+        payload: encodeTerminalStreamJson({ reason: 'not_writable' })
+      })
+    )
+
+    await vi.waitFor(() => expect(onWriteUnavailable).toHaveBeenCalledTimes(1))
+    // Why: recovery owns this, not the fatal red banner.
+    expect(onError).not.toHaveBeenCalled()
   })
 
   it('does not report attachment health until the authoritative PTY snapshot arrives', async () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -1923,6 +1923,69 @@ describe('createRemoteRuntimePtyTransport', () => {
     }
   })
 
+  // Why (regression): the fallback send is awaited, so recovery can rebind the pane to a new
+  // handle before it resolves. Recovering on the dead handle's rejection would remount the
+  // healthy replacement — the pane's response to onWriteUnavailable is a remount.
+  it('does not recover the replacement pane when a superseded handle reports a rejected send', async () => {
+    vi.useFakeTimers()
+    runtimeSubscribe.mockImplementation(
+      async (_args: unknown, callbacks: typeof subscriptionCallbacks) => {
+        subscriptionCallbacks = callbacks
+        return { unsubscribe: vi.fn(), sendBinary: subscriptionSendBinary }
+      }
+    )
+    try {
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const onWriteUnavailable = vi.fn()
+      const transport = createRemoteRuntimePtyTransport('env-1', {
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: 'pane:1'
+      })
+
+      resolvedPaneHandle = 'terminal-old'
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-old',
+        cols: 80,
+        rows: 24,
+        callbacks: { onWriteUnavailable }
+      })
+      await vi.waitFor(() => expect(transport.getPtyId()).toBe('remote:env-1@@terminal-old'))
+
+      let rejectSend: (response: unknown) => void = () => {}
+      // Why: only terminal.send is held open; everything else must keep the default
+      // behaviour or the second attach can never resolve to the replacement handle.
+      const defaultRuntimeCall = runtimeCall.getMockImplementation()
+      runtimeCall.mockImplementation((args: { method: string }) => {
+        if (args.method === 'terminal.send') {
+          return new Promise((resolve) => {
+            rejectSend = resolve
+          })
+        }
+        return defaultRuntimeCall?.(args)
+      })
+
+      expect(transport.sendInput('typed-into-old')).toBe(true)
+      await vi.advanceTimersByTimeAsync(10)
+
+      resolvedPaneHandle = 'terminal-new'
+      transport.attach({
+        existingPtyId: 'remote:env-1@@terminal-new',
+        cols: 80,
+        rows: 24,
+        callbacks: { onWriteUnavailable }
+      })
+      await vi.waitFor(() => expect(transport.getPtyId()).toBe('remote:env-1@@terminal-new'))
+
+      rejectSend({ ok: true, result: { send: { accepted: false, bytesWritten: 0 } } })
+      await vi.advanceTimersByTimeAsync(10)
+
+      expect(onWriteUnavailable).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('ignores stale attach subscription rejection after reattaching a newer remote terminal', async () => {
     const oldSubscription = {
       reject: null as ((error: Error) => void) | null

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -981,15 +981,30 @@ export function createRemoteRuntimePtyTransport(
       pendingClaimInput += text
       return
     }
-    void callRuntime('terminal.send', {
+    void callRuntime<{ send: RuntimeTerminalSend }>('terminal.send', {
       terminal: targetHandle,
       text,
       client: { id: clientId, type: 'desktop' },
       ...(desiredViewport ? { viewport: desiredViewport, claimViewport: true as const } : {})
-    }).catch((error) => {
-      handleRemoteTerminalError(error)
     })
+      .then((result) => {
+        // Why: a rejected send is silent by protocol — without this the keystrokes just vanish.
+        if (result.send.accepted !== true) {
+          notifyWriteUnavailable()
+        }
+      })
+      .catch((error) => {
+        handleRemoteTerminalError(error)
+      })
   })
+
+  // Why: the pane turns this into remount-based recovery, the same response local PTYs get from `pty:writeUnavailable`.
+  function notifyWriteUnavailable(): void {
+    if (destroyed) {
+      return
+    }
+    storedCallbacks.onWriteUnavailable?.()
+  }
 
   function sendViewportUpdate(cols: number, rows: number, claim = false): void {
     const targetHandle = handle
@@ -1151,6 +1166,11 @@ export function createRemoteRuntimePtyTransport(
     if (isRecoverableRemoteRuntimeConnectionError(toRemoteRuntimeClientErrorLike(error))) {
       // Why: a partition is attachment state, not a terminal failure; keep the red error surface for actionable fatal errors.
       scheduleResubscribeAfterTransportClose()
+      return
+    }
+    if (message.includes('terminal_not_writable')) {
+      // Why: the pane is mirroring a PTY that cannot accept input; remount recovery can rebind it, a red banner cannot.
+      notifyWriteUnavailable()
       return
     }
     connecting = false
@@ -1409,6 +1429,11 @@ export function createRemoteRuntimePtyTransport(
         onDriverChanged: (driver) => {
           if (isCurrentSubscription() && subscribedPtyId) {
             setDriverForPty(subscribedPtyId, driver)
+          }
+        },
+        onWriteUnavailable: () => {
+          if (isCurrentSubscription()) {
+            notifyWriteUnavailable()
           }
         },
         onTransportClose: ({ recoverable }) => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -989,7 +989,9 @@ export function createRemoteRuntimePtyTransport(
     })
       .then((result) => {
         // Why: a rejected send is silent by protocol — without this the keystrokes just vanish.
-        if (result.send.accepted !== true) {
+        // Why the handle re-check: recovery can rebind `handle` while this RPC is in flight, and
+        // recovering the replacement pane over a dead pane's rejection would remount the wrong terminal.
+        if (connected && handle === targetHandle && result.send.accepted !== true) {
           notifyWriteUnavailable()
         }
       })

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -57,6 +57,8 @@ export type RemoteRuntimeMultiplexedTerminalCallbacks = {
   onDriverChanged?: (
     driver: { kind: 'idle' } | { kind: 'desktop' } | { kind: 'mobile'; clientId: string }
   ) => void
+  /** Host proved this stream's input never reached a PTY; the pane owns recovery. */
+  onWriteUnavailable?: () => void
   onTransportClose?: (event: { recoverable: boolean }) => void
 }
 
@@ -324,7 +326,9 @@ class RemoteRuntimeTerminalMultiplexer {
           client: args.client,
           viewport: args.viewport,
           capabilities:
-            args.client.type === 'desktop' ? { ackOutput: 1, desktopViewportClaims: 1 } : undefined
+            args.client.type === 'desktop'
+              ? { ackOutput: 1, desktopViewportClaims: 1, writeUnavailable: 1 }
+              : undefined
         })
       )
       if (!sent) {
@@ -690,6 +694,10 @@ class RemoteRuntimeTerminalMultiplexer {
       } else {
         this.sendDeferredResyncSnapshot(stream)
       }
+      return
+    }
+    if (frame.opcode === TerminalStreamOpcode.WriteUnavailable) {
+      stream.callbacks.onWriteUnavailable?.()
       return
     }
     if (frame.opcode === TerminalStreamOpcode.Error) {

--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -102,12 +102,13 @@ describe('remote runtime terminal data subscriptions', () => {
       subscribeFrame &&
       decodeTerminalStreamJson<{
         streamId: number
-        capabilities?: { ackOutput?: 1; desktopViewportClaims?: 1 }
+        capabilities?: { ackOutput?: 1; desktopViewportClaims?: 1; writeUnavailable?: 1 }
       }>(subscribeFrame.payload)
     expect(subscribePayload?.streamId).toEqual(expect.any(Number))
     expect(subscribePayload?.capabilities).toEqual({
       ackOutput: 1,
-      desktopViewportClaims: 1
+      desktopViewportClaims: 1,
+      writeUnavailable: 1
     })
 
     callbacks?.onBinary?.(

--- a/src/shared/terminal-stream-protocol.ts
+++ b/src/shared/terminal-stream-protocol.ts
@@ -28,8 +28,14 @@ export enum TerminalStreamOpcode {
   // Why 14: Ack already occupies 13 on current clients; older runtimes ignore
   // this opcode and still receive the compatibility Resize frame behind it.
   ClaimViewport = 14,
-  OutputSpan = 15
+  OutputSpan = 15,
+  // Why gated: an unknown opcode fails decode and kills the whole multiplexed
+  // connection, so only send this to streams that declared writeUnavailable.
+  WriteUnavailable = 16
 }
+
+/** Why only this reason: unexpected send errors stay silent so a transient failure can't loop the client through remount recovery. */
+export type TerminalStreamWriteUnavailableReason = 'not_writable'
 
 export type TerminalStreamFrame = {
   opcode: TerminalStreamOpcode
@@ -116,6 +122,7 @@ function isTerminalStreamOpcode(value: number): value is TerminalStreamOpcode {
     value === TerminalStreamOpcode.Metadata ||
     value === TerminalStreamOpcode.Ack ||
     value === TerminalStreamOpcode.ClaimViewport ||
-    value === TerminalStreamOpcode.OutputSpan
+    value === TerminalStreamOpcode.OutputSpan ||
+    value === TerminalStreamOpcode.WriteUnavailable
   )
 }


### PR DESCRIPTION
Fixes #11124

## Summary

A paired client could type into a remote terminal pane forever and have nothing happen — no error, no banner, no recovery. The pane reported `connected: true` / `writable: true`, `terminal.read` said `status: "running"`, and `terminal.send` answered `{ accepted: true }`. Because only *some* projects were affected, it read to users as "this project is broken" rather than as a connection problem.

The host state behind it: the PTY daemon deliberately outlives the app, so after a host-app restart `reconcileOnStartup` re-lists daemon sessions but never attaches to them. For projects the host user has not opened since that restart, the shell is alive and `Session.emitSubprocessOutput` broadcasts only to `attachedClients` — so output goes to the daemon's headless emulator and nowhere else. A remote subscribe did not repair this: the mount-request fallback only ran when the leaf had **no ptyId at all**, so a record with a present-but-unattached ptyId subscribed to a black hole. Writes were genuinely delivered — to a terminal nobody could see.

This makes the pane recover, and tells the truth when it can't:

1. **Attach-on-subscribe.** Both subscribe paths now call `requestHostPaneAttachForUnobservedPty`, which asks the host to mount the owning tab when the runtime has never observed output for that PTY *and* neither a renderer serializer nor headless state holds it. That reuses the existing mount → `pty.spawn(sessionId)` → daemon `createOrAttach` machinery, so the output pipeline is rebuilt and the pane comes fully alive. Single-flight per PTY, cleared on first output or exit, and it never consumes the flight when no authoritative window exists (headless hosts stay retryable).
2. **Stream input stops swallowing failures.** `sendTerminalStreamInput` returns `'delivered' | 'rejected' | 'failed'` instead of `void`, keeping the mobile input-floor claim/rollback behavior verbatim.
3. **New `WriteUnavailable` stream frame (opcode 16), capability-gated per stream.** Emitted when stream input is rejected. Gating is not optional: an unknown opcode fails `decodeTerminalStreamFrame` and kills the *whole* multiplexed connection on older clients, so the frame only goes to streams that declared `writeUnavailable: 1` in their Subscribe frame.
4. **Client surfaces and recovers.** The desktop multiplexer declares the capability and routes the frame to a new `onWriteUnavailable` callback; the transport wires that — plus a `terminal.send` fallback that came back `accepted: false`, plus a `terminal_not_writable` RPC error — into the `onWriteUnavailable` → `requestRecoveryForUndeliverableInput` path that local PTYs have always had. `terminal_not_writable` no longer dead-ends in the fatal red banner.

### Compatibility

- **Old host + new client**: zod strips the unknown `writeUnavailable` capability key; behavior is exactly as today.
- **New host + old client**: capability absent, frame never sent.
- **Mobile**: does not declare the capability, so zero wire change. Mobile does benefit from (1), which reuses the mount request it already relies on.
- No `RUNTIME_PROTOCOL_VERSION` bump: additive optional field plus a gated opcode, negotiated per stream, degrading to current behavior when absent. No new runtime capability constant either — negotiation happens in the Subscribe frame, so a client never has to decide anything before acting.

### Deliberately not in this PR

The second host state that can produce the same symptom — a *dead* daemon session whose runtime record stays `connected: true` forever, because every renderer graph sync force-marks persisted-layout ptyIds connected with no verification and the liveness sweep refuses to disconnect a record any graph leaf references — is left for a follow-up. Fixing it means changing `syncWindowGraph`, a hot path with a real renderer-spawn race, and it deserves its own change and soak. It is written up in #11124 and now tracked separately in #11312, since this PR closes #11124.

Also out of scope: end-to-end write acks through the daemon wire protocol. They would not have caught this bug — in the diagnosed state the write really is delivered; it is the output path that is broken.

## Screenshots

No visual change. The user-visible effect is that a previously dead pane starts working again, and an unrecoverable one now triggers the existing recovery path instead of silently dropping keystrokes.

## Testing

- [ ] `pnpm lint` — pnpm is not available in this environment. Ran the underlying checks directly: `oxlint` over every changed file and over `src/main/runtime`, `src/renderer/src/runtime`, `src/renderer/src/components/terminal-pane`, `src/shared/terminal-stream-protocol.ts` — clean; `oxfmt --write` over the changed files — no diff.
- [x] `pnpm typecheck` — `tsc --noEmit` for the node, web, and cli projects, all clean.
- [x] `pnpm test` — full `vitest run`: 38802 passed, 43 failed across 8 files. Those 8 files (`sidebar/LinearAgentSkillSetupPrompt.reminder-toast`, `right-sidebar/pr-comments-list-selection`, `right-sidebar/use-persisted-ai-vault-view-options`, `right-sidebar/pr-comment-presentation`, `browser-pane/markup/use-markup-draw-hint`, `sidebar/mobile-sidebar-onboarding-badge`, `sidebar/SidebarToolbar`, `relay/agent-exec-handler`) fail identically — same 43 tests — on a clean checkout of the base commit with none of these changes applied, so they are pre-existing in my environment and unrelated to this PR. Nothing in the areas this PR touches fails.
- [ ] `pnpm build` — not run (needs pnpm).
- [x] Added tests that would catch the regression.

New/updated tests:

- `src/main/runtime/unobserved-pty-host-attach.test.ts` (new) — mount requested exactly once for a never-observed PTY; not requested when output was already observed, when headless state exists, when a renderer serializer is attached, or for an unknown record; the single-flight is not consumed when no window can take the mount.
- `src/main/runtime/rpc/terminal-multiplex.test.ts` — `WriteUnavailable` emitted on `accepted: false` and on a thrown `terminal_not_writable`; **not** emitted for a client that never declared the capability, nor on success, nor when the mobile presence lock owns the pane (that path must not even call `sendTerminal`).
- `src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts` — the frame reaches `onWriteUnavailable` without firing the fatal `onError`; capability is declared in the Subscribe payload.
- `src/renderer/src/runtime/runtime-terminal-stream.test.ts` — Subscribe capability assertion updated.

## AI Review Report

Reviewed with Claude (analysis/design pass and implementation pass run as separate agents). Risks checked:

- **Version skew** — the review's main finding: an unknown opcode is fatal to the whole multiplexed connection on existing clients (`remote-runtime-terminal-multiplexer` drops the connection on decode failure), so the frame had to be negotiated per stream rather than advertised as a runtime capability. Both the multiplex and legacy `terminal.subscribe` binary paths are gated independently, and there is a test asserting silence for an undeclared client.
- **Mobile presence lock** (`docs/mobile-presence-lock.md`) — a locked pane is healthy, not undeliverable. Input suppressed by the lock must not emit the frame or it would fight the "Take back" affordance; covered by a test. The input-floor claim/rollback logic is unchanged.
- **Recovery loops** — only a `rejected` outcome emits. Unexpected errors deliberately stay silent so a transient failure cannot loop the client through remount recovery; this is documented on the reason type.
- **Focus stealing** — the mount request is the one already used for mobile subscribe, which attaches the exact tab without activating the worktree.
- **Cross-platform (macOS / Linux / Windows)** — no platform-dependent code touched: no shortcuts, labels, paths, shell invocation, or Electron platform APIs. The daemon/attach machinery reused here is already platform-guarded upstream of these call sites.
- **SSH and folder workspaces** — the attach predicate is workspace-kind agnostic and keys only off "has the runtime ever seen a byte from this PTY". No SSH-specific liveness or reattach logic changed; the SSH-expired-pane path (`recoverExpiredHostPane`) is untouched.
- **Stub-based test harnesses** — the new runtime method is invoked optionally (`?.`), matching how this file already calls `hasHeadlessTerminalState?.()` etc., so existing stub runtimes keep working.

## Security Audit

- **Input handling**: the new frame payload is JSON-decoded through the existing `decodeTerminalStreamJson`, which already enforces the 8 MiB cap and JSON structure limits. The client ignores the payload contents entirely and reacts only to the opcode, so a malformed or hostile payload cannot influence behavior.
- **Direction of trust**: the frame is host→client only and carries no terminal content, path, or identifier — it cannot leak data. It is emitted solely on a stream the client itself subscribed to.
- **Authorization**: no change to auth, pairing, or the existing per-stream gating. `requestHostPaneAttachForUnobservedPty` mounts only the tab the caller's own handle already resolves to, and returns false for any handle without a worktree — it cannot be used to mount an arbitrary tab.
- **Command execution / path handling / secrets / dependencies**: none touched. No new dependencies.
- **IPC**: reuses the existing `terminal:requestTabMount` channel with the same payload shape.
- Follow-up: none identified.

### Verifying the regression tests are not vacuous

Each guard added in review has a test that fails against the previous implementation. Fastest way to confirm without reading the whole diff — revert one guard, run its test, restore:

| Guard | Revert | Test |
|---|---|---|
| stream identity (`terminal.ts`) | drop `closed \|\| streams.get(stream.streamId) !== stream \|\|` | `-t "detached before the rejected write"` |
| handle identity (`remote-runtime-pty-transport.ts`) | drop `connected && handle === targetHandle &&` | `-t "superseded handle"` |
| attach retry (`orca-runtime.ts`) | restore the `Set`/`has` latch | `-t "silently dropped"` |

All three were confirmed failing pre-fix, not assumed.

## Notes

- No X handle to share — I'm not on X, so there's nothing to shout out. Every other item in CONTRIBUTING's PR checklist is covered above.
- The two subscribe paths (multiplex and legacy `terminal.subscribe`) are gated separately on purpose — they negotiate capabilities in different frames.
- The follow-up described above (graph-sync minting unverified `connected: true`) is the remaining way a pane can still report healthy while being dead. With this PR such a pane at least routes into recovery once a write is rejected; without the follow-up, a pane in that state can still report `accepted: true` and stay silent.


