### PR TITLE
fix(skills): tell the user how to fix a skill the updater cannot converge

### DIFF
--- a/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
@@ -423,6 +423,25 @@ describe('SkillFreshnessUpdateDialog', () => {
     )
   })
 
+  it('names the skill in the stale-record remedy so the command is runnable as-is', async () => {
+    // Why: the reinstall advice only fires when the row hands its group name through
+    // to skippedReason — dropping that argument silently degrades every stale-record
+    // row to the generic sentence with no command to run.
+    mocks.inventory = {
+      schemaVersion: 1,
+      installations: [placement('orchestration')],
+      eligibleUpdateNames: [],
+      scanIssues: [],
+      scannedAt: 3
+    }
+    await renderDialog()
+    await openViaRequest()
+
+    expect(container?.textContent).toContain(
+      'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+    )
+  })
+
   it('stays coherent while an idle re-scan is in flight', async () => {
     await renderDialog()
     await openViaRequest()

--- a/src/renderer/src/components/skills/SkillUpdateRow.tsx
+++ b/src/renderer/src/components/skills/SkillUpdateRow.tsx
@@ -118,7 +118,7 @@ export function SkillUpdateRow({
           nor on a mount-time `defaultOpen` that a re-scan can't re-fire. */}
       {state === 'blocked' ? (
         <p className="px-1.5 pb-1.5 text-xs leading-5 text-muted-foreground">
-          {skippedReason(group.locations)}
+          {skippedReason(group.locations, group.name)}
         </p>
       ) : null}
 

--- a/src/renderer/src/components/skills/skill-freshness-grouping.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-grouping.test.ts
@@ -164,6 +164,9 @@ describe('groupSkillFreshness', () => {
     expect(chipFor(at('g', { topology: 'repo-scope' }))).toBe('in-a-repo')
     expect(chipFor(at('h', { topology: 'plugin-cache' }))).toBe('plugin-cache')
     expect(chipFor(at('i', { status: 'current', topology: 'provider-alias' }))).toBe('current')
+    // Why: a bare chip is what the reason copy reads as "behind, and a reinstall fixes
+    // it". A copy that is ahead must be told apart, or that advice rolls it back.
+    expect(chipFor(at('k', { status: 'newer-known', topology: 'canonical-copy' }))).toBe('newer')
     expect(chipFor(at('j', { status: 'unrecognized', topology: 'plugin-cache' }))).toBe(
       'plugin-cache'
     )

--- a/src/renderer/src/components/skills/skill-freshness-grouping.ts
+++ b/src/renderer/src/components/skills/skill-freshness-grouping.ts
@@ -7,6 +7,7 @@ export type SkillGroupStatus = 'update-available' | 'cannot-update'
 
 export type SkillLocationChip =
   | 'current'
+  | 'newer'
   | 'unrecognized'
   | 'inaccessible'
   | 'duplicate'
@@ -53,9 +54,14 @@ export function locationChip(installation: SkillFreshnessInstallation): SkillLoc
       return 'plugin-cache'
     case 'canonical-copy':
     case 'provider-alias':
-      // Why: a supported location only needs a chip when it's already up to date,
-      // to explain why the update won't touch it; the out-of-date main copy is bare.
-      return installation.status === 'current' ? 'current' : null
+      // Why: a supported location only needs a chip when the update won't touch it —
+      // already current, or ahead of what this build knows. The out-of-date main copy
+      // is bare, and 'newer' is what keeps a bare chip meaning "behind, and fixable":
+      // reinstalling a copy that is ahead would quietly roll the user back.
+      if (installation.status === 'current') {
+        return 'current'
+      }
+      return installation.status === 'newer-known' ? 'newer' : null
   }
 }
 

--- a/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
@@ -25,7 +25,31 @@ describe('skippedReason', () => {
     expect(skippedReason([row('duplicate'), row('read-only')])).toContain('read-only location')
   })
 
-  it('falls back to the generic sentence when nothing is blocking', () => {
+  it('hands over the reinstall command when no location is at fault', () => {
+    // Why: the only way to reach this with a bare out-of-date copy is the updater's own
+    // record, which `skills update` can never converge — so the sentence has to give the
+    // one command that does, not report a skip the user cannot act on.
+    const reason = skippedReason([row(null)], 'orchestration')
+    expect(reason).toContain('reports the skill as already up to date')
+    expect(reason).toContain(
+      'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+    )
+  })
+
+  it('never offers the reinstall for a copy that is ahead of this build', () => {
+    // Why: reinstalling a newer copy rolls the user back to what this build ships.
+    const reason = skippedReason([row('newer')], 'orchestration')
+    expect(reason).toContain('later version')
+    expect(reason).not.toContain('skills add')
+  })
+
+  it('keeps a placement blocker ahead of the record advice', () => {
+    expect(skippedReason([row(null), row('unrecognized')], 'orchestration')).toContain(
+      'doesn’t match the official version'
+    )
+  })
+
+  it('falls back to the generic sentence when no skill name is available', () => {
     expect(skippedReason([row('current')])).toContain('left this skill out of the update')
     expect(skippedReason([])).toContain('left this skill out of the update')
   })

--- a/src/renderer/src/components/skills/skill-freshness-skipped-reason.ts
+++ b/src/renderer/src/components/skills/skill-freshness-skipped-reason.ts
@@ -1,3 +1,4 @@
+import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import type { SkillLocationChip, SkillLocationRow } from './skill-freshness-grouping'
 import { translate } from '@/i18n/i18n'
 
@@ -8,6 +9,9 @@ const SKIPPED_REASON_PRIORITY: SkillLocationChip[] = [
   'unrecognized',
   'read-only',
   'inaccessible',
+  // Why: above the placement chips — a copy that is ahead of this build must never
+  // fall through to the reinstall advice below, which would roll it back.
+  'newer',
   'in-a-repo',
   'plugin-cache',
   'external-link',
@@ -29,10 +33,18 @@ function blockingChip(locations: readonly SkillLocationRow[]): SkillLocationChip
  * The wording is deictic ("this copy") on purpose: it is only ever rendered beside the
  * location rows it describes, which is why the setup rails link into the dialog rather
  * than repeating a sentence that would have nothing to point at.
+ *
+ * `skillName` is only used for the no-chip case, where the fault is not a placement at
+ * all but the updater's own record of this skill, and the remedy has to name it.
  */
-export function skippedReason(locations: readonly SkillLocationRow[]): string {
+export function skippedReason(locations: readonly SkillLocationRow[], skillName?: string): string {
   const chip = blockingChip(locations)
   switch (chip) {
+    case 'newer':
+      return translate(
+        'auto.components.skills.SkillFreshnessRow.skippedReasonNewer',
+        'This copy is a later version than the one this build of Orca ships, so Orca left it alone rather than roll it back. Updating Orca will bring the two back in line.'
+      )
     case 'unrecognized':
       return translate(
         'auto.components.skills.SkillFreshnessRow.skippedReasonUnrecognized',
@@ -75,9 +87,22 @@ export function skippedReason(locations: readonly SkillLocationRow[]): string {
       )
     case 'current':
     case undefined:
-      return translate(
-        'auto.components.skills.SkillFreshnessRow.cantUpdateReason',
-        'Orca left this skill out of the update command.'
-      )
+      // Why: no location is at fault here — the copy is an ordinary out-of-date one the
+      // update would happily write. What is wrong is the updater's own record of it:
+      // `skills update` decides what to do by comparing that record against the source
+      // and never reads disk, so when the record is missing or already names the version
+      // it was meant to fetch, the command reports "up to date" and writes nothing. No
+      // retry converges it; only a reinstall rewrites the record, which is why the
+      // sentence has to hand over the command rather than say the update was skipped.
+      return skillName
+        ? translate(
+            'auto.components.skills.SkillFreshnessRow.skippedReasonStaleRecord',
+            'The skills updater has no usable record of this copy, so it reports the skill as already up to date and changes nothing. Reinstall it to bring the record back in line: {{value0}}',
+            { value0: buildAgentFeatureSkillInstallCommand([skillName]) }
+          )
+        : translate(
+            'auto.components.skills.SkillFreshnessRow.cantUpdateReason',
+            'Orca left this skill out of the update command.'
+          )
   }
 }

--- a/src/renderer/src/components/skills/skill-location-chip-copy.ts
+++ b/src/renderer/src/components/skills/skill-location-chip-copy.ts
@@ -5,6 +5,8 @@ export function chipLabel(chip: SkillLocationChip): string {
   switch (chip) {
     case 'current':
       return translate('auto.components.skills.SkillFreshnessRow.chipCurrent', 'Current')
+    case 'newer':
+      return translate('auto.components.skills.SkillFreshnessRow.chipNewer', 'Newer')
     case 'unrecognized':
       return translate('auto.components.skills.SkillFreshnessRow.chipUnrecognized', 'Unrecognized')
     case 'inaccessible':
@@ -32,6 +34,11 @@ export function chipTooltip(chip: SkillLocationChip): string {
       return translate(
         'auto.components.skills.SkillFreshnessRow.tipCurrent',
         'This copy matches the current official version.'
+      )
+    case 'newer':
+      return translate(
+        'auto.components.skills.SkillFreshnessRow.tipNewer',
+        'This copy is a later version than the one this build of Orca ships.'
       )
     case 'unrecognized':
       return translate(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3820,7 +3820,11 @@
           "tipReadOnly": "This copy is in a read-only location.",
           "tipInRepo": "This copy lives inside a project, not your global skills.",
           "tipPluginCache": "This copy is managed by a plugin.",
-          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one."
+          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one.",
+          "skippedReasonNewer": "This copy is a later version than the one this build of Orca ships, so Orca left it alone rather than roll it back. Updating Orca will bring the two back in line.",
+          "skippedReasonStaleRecord": "The skills updater has no usable record of this copy, so it reports the skill as already up to date and changes nothing. Reinstall it to bring the record back in line: {{value0}}",
+          "chipNewer": "Newer",
+          "tipNewer": "This copy is a later version than the one this build of Orca ships."
         },
         "SkillFreshnessUpdateDialog": {
           "title": "Update skills",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3797,7 +3797,11 @@
           "skippedReasonPluginCache": "A plugin manages this skill, so Orca left it out of the update — update the plugin instead.",
           "skippedReasonExternalLink": "This copy is a shortcut pointing outside Orca’s skill folders, so Orca left it out of the update.",
           "skippedReasonBrokenLink": "This copy is a shortcut to something that no longer exists, so Orca left it out — you can safely delete it.",
-          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one."
+          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one.",
+          "skippedReasonNewer": "This copy is a later version than the one this build of Orca ships, so Orca left it alone rather than roll it back. Updating Orca will bring the two back in line.",
+          "skippedReasonStaleRecord": "The skills updater has no usable record of this copy, so it reports the skill as already up to date and changes nothing. Reinstall it to bring the record back in line: {{value0}}",
+          "chipNewer": "Newer",
+          "tipNewer": "This copy is a later version than the one this build of Orca ships."
         },
         "SkillFreshnessUpdateDialog": {
           "title": "Actualizar skills",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3797,7 +3797,11 @@
           "skippedReasonPluginCache": "A plugin manages this skill, so Orca left it out of the update — update the plugin instead.",
           "skippedReasonExternalLink": "This copy is a shortcut pointing outside Orca’s skill folders, so Orca left it out of the update.",
           "skippedReasonBrokenLink": "This copy is a shortcut to something that no longer exists, so Orca left it out — you can safely delete it.",
-          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one."
+          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one.",
+          "skippedReasonNewer": "This copy is a later version than the one this build of Orca ships, so Orca left it alone rather than roll it back. Updating Orca will bring the two back in line.",
+          "skippedReasonStaleRecord": "The skills updater has no usable record of this copy, so it reports the skill as already up to date and changes nothing. Reinstall it to bring the record back in line: {{value0}}",
+          "chipNewer": "Newer",
+          "tipNewer": "This copy is a later version than the one this build of Orca ships."
         },
         "SkillFreshnessUpdateDialog": {
           "title": "スキルを更新",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3797,7 +3797,11 @@
           "skippedReasonPluginCache": "A plugin manages this skill, so Orca left it out of the update — update the plugin instead.",
           "skippedReasonExternalLink": "This copy is a shortcut pointing outside Orca’s skill folders, so Orca left it out of the update.",
           "skippedReasonBrokenLink": "This copy is a shortcut to something that no longer exists, so Orca left it out — you can safely delete it.",
-          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one."
+          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one.",
+          "skippedReasonNewer": "This copy is a later version than the one this build of Orca ships, so Orca left it alone rather than roll it back. Updating Orca will bring the two back in line.",
+          "skippedReasonStaleRecord": "The skills updater has no usable record of this copy, so it reports the skill as already up to date and changes nothing. Reinstall it to bring the record back in line: {{value0}}",
+          "chipNewer": "Newer",
+          "tipNewer": "This copy is a later version than the one this build of Orca ships."
         },
         "SkillFreshnessUpdateDialog": {
           "title": "스킬 업데이트",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3797,7 +3797,11 @@
           "skippedReasonPluginCache": "A plugin manages this skill, so Orca left it out of the update — update the plugin instead.",
           "skippedReasonExternalLink": "This copy is a shortcut pointing outside Orca’s skill folders, so Orca left it out of the update.",
           "skippedReasonBrokenLink": "This copy is a shortcut to something that no longer exists, so Orca left it out — you can safely delete it.",
-          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one."
+          "skippedReasonDuplicate": "This is a separate copy, so the update won’t reach it — the command only refreshes the main copy. Remove this copy, then reinstall the skill so this location follows the main one.",
+          "skippedReasonNewer": "This copy is a later version than the one this build of Orca ships, so Orca left it alone rather than roll it back. Updating Orca will bring the two back in line.",
+          "skippedReasonStaleRecord": "The skills updater has no usable record of this copy, so it reports the skill as already up to date and changes nothing. Reinstall it to bring the record back in line: {{value0}}",
+          "chipNewer": "Newer",
+          "tipNewer": "This copy is a later version than the one this build of Orca ships."
         },
         "SkillFreshnessUpdateDialog": {
           "title": "更新技能",


### PR DESCRIPTION
> Stacked on #11128 (same files). Review that one first.

## Problem

A skill the update command provably cannot move shows one sentence:

> Orca left this skill out of the update command.

No cause, no remedy, nothing to do. It is the message for **the only state #11110 exists to create** — and #11110's whole point is that no retry converges it.

## Cause

That sentence is the `undefined` fallback in `skippedReason`, reached when no location carries a chip. Working through it exhaustively, a chip-less blocked row means every placement is a `canonical-copy`/`provider-alias` that is `outdated` — the ordinary case the update *would* happily write. So the skill is ineligible for exactly one family of reasons, none of which is a placement:

- the lock's recorded hash names a different revision than the one on disk (#11110), or
- the skill has no lock entry (#11051), or the lock file is absent or unreadable.

`skills update` decides what to do by comparing that record against the source and **never reads disk**. A record that is missing, or that already names the version it was meant to fetch, makes the command print "up to date", exit 0 and write nothing. Only a reinstall rewrites it.

## Fix

The fallback now names the cause and hands over the command that actually fixes it, built from the existing `buildAgentFeatureSkillInstallCommand` — no new command form, no new source-of-truth:

> The skills updater has no usable record of this copy, so it reports the skill as already up to date and changes nothing. Reinstall it to bring the record back in line: `npx skills add https://github.com/stablyai/orca --skill orchestration --global`

**One state had to be carved out first.** A copy that is *ahead* of what this build ships (`newer-known`) also reached the bare chip-less row, where that advice would quietly roll the user back. It now gets its own `Newer` chip and its own sentence ("Updating Orca will bring the two back in line"), ranked above the record advice.

`newer-known` is currently unreachable — `generate-skill-bundle-manifest.mjs` always sets the manifest revision to the newest registry revision. This is guarding the type system's reachable set rather than an observed bug, and it is what makes the reinstall advice provably correct instead of correct-by-invariant.

## Verification

Live Electron against the exact #11110 repro (`~/.agents/skills/orca-linear` at revision 7 with the lock naming revision 8's tree, same for `orchestration`): both rows now carry the cause and their own `npx skills add … --skill <name> --global`.

New keys added via `pnpm run sync:localization-catalog`; present in all 5 catalogs, `verify:localization-catalog` and `verify:localization-coverage` both 0.

`pnpm run tc` 0 · `oxlint` 0 · 6729 tests pass.

## Mutation testing

| Mutation | Result |
|---|---|
| fallback reverts to the generic sentence | `hands over the reinstall command…` fails |
| `newer-known` falls through to a bare chip | `maps every topology to a chip` fails |
| `newer` dropped from the reason priority list | `never offers the reinstall for a copy that is ahead` fails |

## Follow-up (not in this PR)

The command is selectable text but not copyable in one click. A per-row Copy button would be the natural next step; the dialog already has one in its error block.