### PR TITLE
fix(lint): restore nested config discovery in changed-code gate

### DIFF
--- a/config/scripts/check-changed-code-quality.mjs
+++ b/config/scripts/check-changed-code-quality.mjs
@@ -6,10 +6,12 @@ import { pathToFileURL } from 'node:url'
 import { resolvePullRequestDiffBase } from './git-pull-request-diff-base.mjs'
 
 const SOURCE_FILE_PATTERN = /\.(?:[cm]?[jt]sx?)$/
-const OXLINT_SCANS = [
+export const OXLINT_SCANS = [
   {
+    // Why: no --config, so Oxlint keeps discovering nested configs. Pinning the root
+    // config would apply root rules to mobile/, whose .oxlintrc.json turns them off.
     label: 'code quality',
-    args: ['--config', '.oxlintrc.json', '--report-unused-disable-directives-severity', 'warn']
+    args: ['--report-unused-disable-directives-severity', 'warn']
   },
   {
     label: 'type-aware code quality',

--- a/config/scripts/check-changed-code-quality.test.mjs
+++ b/config/scripts/check-changed-code-quality.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  OXLINT_SCANS,
   diagnosticTouchesAddedLines,
   overlapsAddedLines,
   parseAddedLineRanges
@@ -40,5 +41,14 @@ describe('changed-code quality line matching', () => {
     expect(
       diagnosticTouchesAddedLines(diagnostic, new Map([[file, [{ start: 24, end: 24 }]]]), root)
     ).toBe(true)
+  })
+
+  // Why: pinning --config disables nested-config discovery, so root rules that
+  // mobile/.oxlintrc.json turns off would fail the gate on mobile files.
+  it('lets the untyped scan discover nested configs instead of pinning the root config', () => {
+    const scan = OXLINT_SCANS.find((candidate) => candidate.label === 'code quality')
+
+    expect(scan.args).not.toContain('--config')
+    expect(scan.args).not.toContain('--disable-nested-config')
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to #11117. That PR repointed the changed-code quality gate's untyped scan from `config/oxlint-code-quality.json` to the root `.oxlintrc.json`:

```diff
-    args: ['--config', 'config/oxlint-code-quality.json', ...]
+    args: ['--config', '.oxlintrc.json', '--report-unused-disable-directives-severity', 'warn']
```

Passing `--config` **disables Oxlint's nested-config discovery**. Since `mobile/` has its own `mobile/.oxlintrc.json` that extends the root and turns several root rules *off*, the gate began applying root rules to `mobile/` files that mobile deliberately exempts.

This only affects the changed-code gate. `pnpm lint` and CI's `Lint` step invoke `oxlint` with no `--config`, so they still honor `mobile/.oxlintrc.json` — which is why full-repo lint stayed green and the regression is invisible until someone touches a `mobile/` file.

## Repro (on `main`)

```ts
// mobile/src/probe.ts
export type ProbeShape = { items: Array<{ id: string }> }
```

```
$ node config/scripts/check-changed-code-quality.mjs
mobile/src/probe.ts:2 typescript(array-type): Array type using 'Array<T>' is forbidden.
Changed-code quality gate failed with 1 finding(s).
```

`mobile/.oxlintrc.json` sets `"typescript/array-type": "off"`. On a real file such as `mobile/app/h/[hostId]/tasks.tsx`, the pinned config yields 27 diagnostics (`array-type`, `no-unescaped-entities`, `prefer-at`, `exhaustive-deps`, and a `max-lines` hit against the root 400-line budget rather than mobile's grandfathered one) where nested discovery yields 0.

## Fix

Drop `--config` from that scan so Oxlint resolves the root config for repo files and `mobile/.oxlintrc.json` for mobile files — matching how `pnpm lint` already behaves. #11117's actual goal (running the consolidated custom plugins over changed code) is preserved: the root config is still what Oxlint auto-discovers for non-mobile paths.

Verified equivalent outside mobile: `src config tests tools` produces **76 diagnostics both with and without** the flag, and `mobile/.oxlintrc.json` is the only nested config in the repo. The consolidated plugins still fire on changed code (confirmed `quadratic-buffer-concat/no-loop-carried-concat` on a probe under `src/main`).

## Testing

- [x] pnpm lint (full suite, green)
- [x] `vitest run config/scripts/` — 71 files, 531 passed
- [x] Repro above now passes the gate
- [x] Added a test that would catch a regression

The new test asserts the untyped scan carries neither `--config` nor `--disable-nested-config`. Confirmed it **fails against the pre-fix args** and passes after.

## Screenshots

No visual change.

## Notes

No `max-lines` disable or per-file budget bump. Lint/CI infrastructure only — no production runtime, IPC, auth, or dependency changes, so the SSH, folder-workspace, and Git-compatibility surfaces are untouched. The one-line `OXLINT_SCANS` export is test-only.

Made with [Orca](https://github.com/stablyai/orca) 🐋
