### PR TITLE
ci(pr): run E2E when a PR touches tests/e2e paths (advisory)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,10 @@ name: E2E
 
 run-name: E2E ${{ inputs.ref || github.ref }}
 
+# Why: checkout + artifact upload only; callers can only further restrict.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -323,10 +323,17 @@ jobs:
       - shell_contracts
       - test
       - package
-      - e2e
     runs-on: ubuntu-latest
 
     steps:
+      # Why: e2e is deliberately absent from needs. The suite is currently red on
+      # main (every scheduled run), so gating merges on it would block any PR that
+      # touches tests/e2e/** — including the ones fixing the suite. Until it is
+      # green the job runs and reports for E2E-path PRs without blocking. To flip
+      # it on: add `e2e` to needs, add E2E to the env below, and require
+      # `"$E2E" = success || skipped` after the loop — skipped is the normal
+      # result for a path-filtered job and must keep passing, so it has to be
+      # checked outside the loop or it would excuse the jobs above.
       - name: Require successful checks
         env:
           STATIC_ANALYSIS: ${{ needs.static_analysis.result }}
@@ -335,7 +342,6 @@ jobs:
           SHELL_CONTRACTS: ${{ needs.shell_contracts.result }}
           TEST: ${{ needs.test.result }}
           PACKAGE: ${{ needs.package.result }}
-          E2E: ${{ needs.e2e.result }}
         run: |
           for result in \
             "$STATIC_ANALYSIS" \
@@ -348,10 +354,3 @@ jobs:
               exit 1
             fi
           done
-
-          # Why: E2E is path-filtered, so "skipped" is the expected result on a PR
-          # that touches no E2E files and must stay passing. Check it separately
-          # from the always-required jobs above so a skip can never satisfy those.
-          if [ "$E2E" != "success" ] && [ "$E2E" != "skipped" ]; then
-            exit 1
-          fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -294,7 +294,10 @@ jobs:
           # (pipeline status in `if` is not aborted by set -e). Merge-base limits the
           # list to files this PR introduced, not base-branch drift.
           CHANGED="$(git diff --name-only --merge-base "$BASE" "$HEAD")"
-          if printf '%s\n' "$CHANGED" | grep -E '^(tests/e2e/|playwright\.|\.github/workflows/e2e\.yml$)' >/dev/null; then
+          # Why: tests/playwright.config.ts sits beside tests/e2e/, not inside it, so
+          # it needs its own pattern — a bare `playwright.` prefix matches no tracked
+          # file and would silently skip E2E when the runner config changes.
+          if printf '%s\n' "$CHANGED" | grep -E '^(tests/e2e/|tests/playwright\.|\.github/workflows/e2e\.yml$)' >/dev/null; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "E2E path changes detected"
           else
@@ -320,6 +323,7 @@ jobs:
       - shell_contracts
       - test
       - package
+      - e2e
     runs-on: ubuntu-latest
 
     steps:
@@ -331,6 +335,7 @@ jobs:
           SHELL_CONTRACTS: ${{ needs.shell_contracts.result }}
           TEST: ${{ needs.test.result }}
           PACKAGE: ${{ needs.package.result }}
+          E2E: ${{ needs.e2e.result }}
         run: |
           for result in \
             "$STATIC_ANALYSIS" \
@@ -343,3 +348,10 @@ jobs:
               exit 1
             fi
           done
+
+          # Why: E2E is path-filtered, so "skipped" is the expected result on a PR
+          # that touches no E2E files and must stay passing. Check it separately
+          # from the always-required jobs above so a skip can never satisfy those.
+          if [ "$E2E" != "success" ] && [ "$E2E" != "skipped" ]; then
+            exit 1
+          fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -265,6 +265,52 @@ jobs:
       - name: Smoke packaged CLI
         run: node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/linux-unpacked
 
+  # Why: regression specs under tests/e2e/** used to merge green without ever
+  # running — e2e.yml only fired on schedule/release (#10518). Path-filter so
+  # ordinary PRs stay light; any E2E suite change still gets a full shard run.
+  e2e-paths:
+    name: detect e2e path changes
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+    # Why: detector only needs to read the checkout; do not inherit repo defaults.
+    permissions:
+      contents: read
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Filter E2E-relevant paths
+        id: filter
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          # Why: capture first so a failed git diff does not look like "no matches"
+          # (pipeline status in `if` is not aborted by set -e). Merge-base limits the
+          # list to files this PR introduced, not base-branch drift.
+          CHANGED="$(git diff --name-only --merge-base "$BASE" "$HEAD")"
+          if printf '%s\n' "$CHANGED" | grep -E '^(tests/e2e/|playwright\.|\.github/workflows/e2e\.yml$)' >/dev/null; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "E2E path changes detected"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No E2E path changes"
+          fi
+
+  e2e:
+    name: e2e
+    needs: e2e-paths
+    if: needs.e2e-paths.outputs.should_run == 'true'
+    # Why: reusable e2e.yml only checkouts, builds, and uploads artifacts.
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e.yml
+
   verify:
     if: always()
     needs:

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -14,12 +14,15 @@ const verifyStep = prWorkflow.jobs.verify.steps.find(
 )
 
 describe('PR E2E gate contract', () => {
-  it('blocks the merge gate on E2E instead of only displaying it', () => {
-    // Why: an e2e job that verify does not depend on reproduces the bug this
-    // gate exists to fix — a red spec still merges because verify stays green.
-    expect(prWorkflow.jobs.verify.needs).toContain('e2e')
-    expect(verifyStep.env.E2E).toBe('${{ needs.e2e.result }}')
-    expect(verifyStep.run).toContain('"$E2E" != "success"')
+  it('keeps E2E advisory while the suite is red on main', () => {
+    // Why: pin the deliberate choice so it reads as intentional rather than as
+    // the "forgot to wire the gate" bug this file originally caught. Gating on a
+    // suite that fails every scheduled run would block the PRs that fix it.
+    // Flipping to blocking means updating this expectation too — see the comment
+    // on verify's Require-successful-checks step for the exact wiring.
+    expect(prWorkflow.jobs.verify.needs).not.toContain('e2e')
+    expect(verifyStep.env.E2E).toBeUndefined()
+    expect(verifyStep.run).not.toContain('$E2E')
   })
 
   it('runs E2E only when the detector says the PR touches E2E paths', () => {
@@ -33,25 +36,17 @@ describe('PR E2E gate contract', () => {
     )
   })
 
-  it('treats a path-filtered skip as passing without excusing the other jobs', () => {
-    // Why: E2E is skipped on PRs touching no E2E files, so 'skipped' must pass.
-    // The always-required jobs are checked in their own loop so that allowance
-    // cannot leak to them.
-    expect(verifyStep.run).toContain('"$E2E" != "skipped"')
-
+  it('enforces every job verify depends on', () => {
     // Why: derive from verify.needs rather than hardcoding, so adding a required
     // job without adding it to the strict loop fails here instead of silently
-    // leaving that job unenforced.
+    // leaving that job unenforced. This is what caught GIT_COMPATIBILITY and
+    // SHELL_CONTRACTS being absent from an earlier hardcoded list.
     const strictLoop = verifyStep.run.slice(0, verifyStep.run.indexOf('done'))
     for (const job of prWorkflow.jobs.verify.needs) {
-      if (job === 'e2e') {
-        continue
-      }
       const envVar = job.toUpperCase()
       expect(verifyStep.env[envVar]).toBe(`\${{ needs.${job}.result }}`)
       expect(strictLoop).toContain(`"$${envVar}"`)
     }
-    expect(strictLoop).not.toContain('$E2E')
   })
 
   it('matches the Playwright config where it actually lives', () => {

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -22,15 +22,34 @@ describe('PR E2E gate contract', () => {
     expect(verifyStep.run).toContain('"$E2E" != "success"')
   })
 
+  it('runs E2E only when the detector says the PR touches E2E paths', () => {
+    // Why: without this the job could lose its filter and run on every PR — the
+    // cost the path filter exists to avoid — while the gate assertions above
+    // stay green.
+    expect(prWorkflow.jobs.e2e.needs).toBe('e2e-paths')
+    expect(prWorkflow.jobs.e2e.if).toBe("needs.e2e-paths.outputs.should_run == 'true'")
+    expect(prWorkflow.jobs['e2e-paths'].outputs.should_run).toBe(
+      '${{ steps.filter.outputs.should_run }}'
+    )
+  })
+
   it('treats a path-filtered skip as passing without excusing the other jobs', () => {
     // Why: E2E is skipped on PRs touching no E2E files, so 'skipped' must pass.
     // The always-required jobs are checked in their own loop so that allowance
     // cannot leak to them.
     expect(verifyStep.run).toContain('"$E2E" != "skipped"')
 
+    // Why: derive from verify.needs rather than hardcoding, so adding a required
+    // job without adding it to the strict loop fails here instead of silently
+    // leaving that job unenforced.
     const strictLoop = verifyStep.run.slice(0, verifyStep.run.indexOf('done'))
-    for (const required of ['STATIC_ANALYSIS', 'TYPECHECK', 'TEST', 'PACKAGE']) {
-      expect(strictLoop).toContain(`"$${required}"`)
+    for (const job of prWorkflow.jobs.verify.needs) {
+      if (job === 'e2e') {
+        continue
+      }
+      const envVar = job.toUpperCase()
+      expect(verifyStep.env[envVar]).toBe(`\${{ needs.${job}.result }}`)
+      expect(strictLoop).toContain(`"$${envVar}"`)
     }
     expect(strictLoop).not.toContain('$E2E')
   })

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+const prWorkflow = parse(readFileSync(join(projectDir, '.github/workflows/pr.yml'), 'utf8'))
+
+const filterStep = prWorkflow.jobs['e2e-paths'].steps.find(
+  (step) => step.name === 'Filter E2E-relevant paths'
+)
+const verifyStep = prWorkflow.jobs.verify.steps.find(
+  (step) => step.name === 'Require successful checks'
+)
+
+describe('PR E2E gate contract', () => {
+  it('blocks the merge gate on E2E instead of only displaying it', () => {
+    // Why: an e2e job that verify does not depend on reproduces the bug this
+    // gate exists to fix — a red spec still merges because verify stays green.
+    expect(prWorkflow.jobs.verify.needs).toContain('e2e')
+    expect(verifyStep.env.E2E).toBe('${{ needs.e2e.result }}')
+    expect(verifyStep.run).toContain('"$E2E" != "success"')
+  })
+
+  it('treats a path-filtered skip as passing without excusing the other jobs', () => {
+    // Why: E2E is skipped on PRs touching no E2E files, so 'skipped' must pass.
+    // The always-required jobs are checked in their own loop so that allowance
+    // cannot leak to them.
+    expect(verifyStep.run).toContain('"$E2E" != "skipped"')
+
+    const strictLoop = verifyStep.run.slice(0, verifyStep.run.indexOf('done'))
+    for (const required of ['STATIC_ANALYSIS', 'TYPECHECK', 'TEST', 'PACKAGE']) {
+      expect(strictLoop).toContain(`"$${required}"`)
+    }
+    expect(strictLoop).not.toContain('$E2E')
+  })
+
+  it('matches the Playwright config where it actually lives', () => {
+    // Why: the config is tests/playwright.config.ts, beside tests/e2e/ rather
+    // than inside it. A bare `playwright.` prefix matches no tracked file, so
+    // editing the runner config would silently skip E2E.
+    expect(filterStep.run).toContain('tests/playwright\\.')
+    expect(filterStep.run).not.toMatch(/\(\^?\|\|]tests\/e2e\/\|playwright\\\./)
+  })
+
+  it('scopes detection to the PR range so base drift cannot false-trigger', () => {
+    expect(filterStep.run).toContain('git diff --name-only --merge-base "$BASE" "$HEAD"')
+    expect(filterStep.run).toContain('set -euo pipefail')
+  })
+})

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -165,10 +165,7 @@ describe('PR workflow parallelism', () => {
       'git_compatibility',
       'shell_contracts',
       'test',
-      'package',
-      // Why: path-filtered, so it reports 'skipped' on most PRs. verify allows
-      // that specific result; see pr-e2e-gate-contract.test.mjs.
-      'e2e'
+      'package'
     ])
   })
 })

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -165,7 +165,10 @@ describe('PR workflow parallelism', () => {
       'git_compatibility',
       'shell_contracts',
       'test',
-      'package'
+      'package',
+      // Why: path-filtered, so it reports 'skipped' on most PRs. verify allows
+      // that specific result; see pr-e2e-gate-contract.test.mjs.
+      'e2e'
     ])
   })
 })


### PR DESCRIPTION
Supersedes #10600 by @innocarpe — their two commits are preserved as the base of this branch, rebased onto current `main` (the original was 185 commits behind and `pr.yml` was restructured underneath it). My changes are the second commit, so the delta is reviewable on its own.

Closes #10518.

## Why this exists

E2E has not run on PRs since #2098 (May 16) removed the `pr.yml` trigger. As of #11031 (yesterday) the release path dispatches it *after* publication, where it cannot block. So a regression spec under `tests/e2e/` currently has no gate at all — not on the PR, not on the release cut.

This is not hypothetical: #11098 shipped an e2e spec that failed deterministically on its own branch. It looked green because nothing ran it.

## What @innocarpe wrote (commit 1)

Path-filtered `e2e-paths` detector + `e2e` job that `workflow_call`s the existing suite, so ordinary PRs stay light but any E2E-relevant change gets a full shard run. Plus merge-base diffing so base drift can't false-trigger, and least-privilege `contents: read` on the detector and on `e2e.yml`.

## What I fixed (commit 2)

**1. The gate did not gate.** `verify` is the required check and enumerates its dependencies explicitly. `e2e` was in neither `needs` nor the result list, so a failing shard left `verify` green — reproducing the exact hole this job closes, just with a red box further down the page.

Since the job is path-filtered, `skipped` is the normal result and has to keep passing. That allowance is checked *after* the strict loop, never inside it, so it cannot leak to the six always-required jobs:

```
E2E=success   -> PASS
E2E=skipped   -> PASS
E2E=failure   -> FAIL
E2E=cancelled -> FAIL
PACKAGE=failure + E2E=skipped -> FAIL   (skip can't mask a real failure)
```

**2. The `playwright.` pattern matched nothing.** The config is `tests/playwright.config.ts` — beside `tests/e2e/`, not inside it — so no tracked file starts with `playwright.`, and editing the runner config would silently skip E2E. Anchored at `tests/playwright.`.

## Testing

- New `config/scripts/pr-e2e-gate-contract.test.mjs`, alongside the existing release-E2E contract test. Verified non-vacuous: reverting either fix independently fails it.
- Updated `pr-workflow-parallelism.test.mjs`, which pins `verify.needs` exactly and correctly caught my change.
- `config/scripts` suite: 534 passed. `pnpm lint` clean.

## One decision for you

This makes E2E **blocking** on PRs that touch E2E paths. Given you moved release E2E to non-blocking yesterday because the suite is flaky, you may not want that on the PR path — and fork PRs need per-run maintainer approval, so this adds approval toil on community PRs touching specs.

If you'd rather keep it advisory, drop the `- e2e` line from `verify.needs` and the `$E2E` check; fix 2 and the detector still stand on their own. Happy to make that change instead — flagging it rather than assuming.

Made with [Orca](https://github.com/stablyai/orca) 🐋
