### PR TITLE
fix(sidebar): restore legible selected-workspace fill in dark mode

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1164,11 +1164,11 @@
   background: color-mix(in srgb, var(--sidebar-accent) 40%, transparent);
 }
 
-/* Why: mixing into the concrete sidebar surface keeps selected contrast stable,
-   including when a custom translucent sidebar theme is active. */
+/* Why: the brighter border carries the selected state; a translucent wash keeps
+   card text legible instead of lifting the surface toward the foreground color. */
 [data-worktree-card-surface][data-worktree-card-active='primary'] {
   border-color: color-mix(in srgb, var(--worktree-sidebar-border) 40%, transparent);
-  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 8%, var(--worktree-sidebar));
+  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 8%, transparent);
   box-shadow: 0 1px 2px color-mix(in srgb, var(--worktree-sidebar-foreground) 4%, transparent);
 }
 
@@ -1178,7 +1178,7 @@
     var(--worktree-sidebar-foreground) 18%,
     var(--worktree-sidebar-border)
   );
-  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 16%, var(--worktree-sidebar));
+  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 10%, transparent);
   box-shadow: 0 1px 2px color-mix(in srgb, var(--worktree-sidebar-foreground) 3%, transparent);
 }
 

--- a/src/renderer/src/assets/worktree-card-active-style.test.ts
+++ b/src/renderer/src/assets/worktree-card-active-style.test.ts
@@ -14,7 +14,7 @@ function getCssRuleBody(selector: string): string {
 }
 
 describe('worktree card active styling', () => {
-  it('mixes the primary selection into the worktree sidebar surface', () => {
+  it('keeps the primary selection wash translucent so card text stays legible', () => {
     const primary = getCssRuleBody(
       "[data-worktree-card-surface][data-worktree-card-active='primary']"
     )
@@ -22,9 +22,12 @@ describe('worktree card active styling', () => {
       ".dark [data-worktree-card-surface][data-worktree-card-active='primary']"
     )
 
-    expect(primary).toContain('var(--worktree-sidebar-foreground) 8%')
-    expect(primary).toContain('var(--worktree-sidebar)')
-    expect(darkPrimary).toContain('var(--worktree-sidebar-foreground) 16%')
+    expect(primary).toContain(
+      'background: color-mix(in srgb, var(--worktree-sidebar-foreground) 8%, transparent)'
+    )
+    expect(darkPrimary).toContain(
+      'background: color-mix(in srgb, var(--worktree-sidebar-foreground) 10%, transparent)'
+    )
     expect(darkPrimary).toContain('var(--worktree-sidebar-border)')
   })
 


### PR DESCRIPTION
## Summary

Partially reverts the background change from #8321 — the selected workspace card's fill made its text too hard to read. **The brighter selection border from #8321 stays**; only the background wash goes back to translucent.

#8321 switched the selected-card wash from `color-mix(… , transparent)` to mixing into the opaque `--worktree-sidebar` surface, and raised dark mode from 10% → 16%. That lifted the selected card to `#4b4b4b`, pulling it toward the `#fafafa` foreground and flattening the contrast of the text sitting on it.

**This PR:**
- Dark: `16%, var(--worktree-sidebar)` → `10%, transparent` (back to pre-#8321 strength)
- Light: `8%, var(--worktree-sidebar)` → `8%, transparent` (visually identical — 8% black over `#f5f5f5` computes the same either way)
- **Kept from #8321:** the brighter border (`--worktree-sidebar-foreground` 18% into `--worktree-sidebar-border` in dark), which is what now carries the selected state
- **Kept from #8321:** the secondary-selection ring and the CSS-owns-active-state refactor in `WorktreeCard.tsx` — untouched

## Screenshots (dark mode)

Captured on the Electron dev build via CDP, same workspace (`orca`) selected in each.

### Selected card — magnified

| Before (#8321 on `main`) | After (this PR) |
|---|---|
| ![zoom-before](https://github.com/user-attachments/assets/f7ddb28e-0002-4af4-a641-b386ae2a4937) | ![zoom-after](https://github.com/user-attachments/assets/334a3b81-54ba-4e4a-8847-c9fb7a9559af) |

### Full sidebar

| Before (#8321 on `main`) | After (this PR) |
|---|---|
| ![before-cards-dark](https://github.com/user-attachments/assets/d7a3a48f-2050-4156-8069-80035583e199) | ![after-cards-dark](https://github.com/user-attachments/assets/493e1c67-cdce-431c-8d4c-9e374dc63a59) |

**Measured selected-card fill (sampled from the rendered pixels above, dark):**

| | Fill | Sidebar | `primary` badge contrast |
|---|---|---|---|
| Before | `rgb(62,62,62)` | `rgb(42,42,42)` | ≈6.0:1 |
| After | `rgb(54,54,54)` | `rgb(42,42,42)` | ≈6.6:1 |

The card still reads as clearly selected against its neighbours — that separation comes from the border #8321 added, not the fill.

### Light mode (unchanged)

![after-cards-light](https://github.com/user-attachments/assets/ee2ce5f0-1bf1-45c3-b065-a937906faa56)

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/assets/worktree-card-active-style.test.ts src/renderer/src/components/sidebar/WorktreeCard.quick-actions.test.tsx` (28 passed)
- [x] `pnpm exec oxfmt --check` on both changed files
- [x] Manual: Electron dev build, dark + light mode, selected workspace in the sidebar (screenshots above, verified via computed styles and sampled pixels)

Updated the `worktree-card-active-style.test.ts` assertion #8321 added so it now pins the translucent wash, and matches on the full `background:` declaration rather than a bare percentage substring.

## Notes

`--worktree-sidebar` is opaque in both themes today, so the "stable under a translucent sidebar theme" motivation in #8321 isn't load-bearing yet. If a translucent sidebar theme lands, the selected wash should be re-derived at a strength that keeps text legible rather than by mixing into the surface.

Made with [Orca](https://github.com/stablyai/orca) 🐋
