### PR TITLE
Improve bug report template for desktop, remote, and mobile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,23 +11,57 @@ body:
         Use this form for Orca bugs. Include enough detail for someone else to reproduce the issue.
 
   - type: dropdown
+    id: where
+    attributes:
+      label: Where were you using Orca?
+      description: Pick the closest match. For mobile/web, this is the app you were in — mention the paired host in Details if it matters.
+      options:
+        - Desktop (this computer)
+        - Desktop + SSH
+        - Desktop + Orca remote server
+        - Desktop + WSL
+        - Mobile (iOS)
+        - Mobile (Android)
+        - Web / browser
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
     id: os
     attributes:
       label: Operating system
+      description: OS of the machine or phone where you hit the bug (your local desktop or mobile device).
       options:
         - macOS
         - Windows
         - Linux
+        - iOS
+        - Android
         - Other
     validations:
       required: true
+
+  - type: dropdown
+    id: remote_os
+    attributes:
+      label: Remote host operating system
+      description: Only if you selected Desktop + SSH or Desktop + Orca remote server. Leave blank otherwise.
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Other
+        - Not sure
+    validations:
+      required: false
 
   - type: input
     id: orca_version
     attributes:
       label: Orca version
-      description: Include the exact Orca version if you can. You can find it in `Orca > About Orca`.
-      placeholder: v0.14.2
+      description: Desktop/web — `Orca > About Orca`. Mobile — app version from Settings or the store listing.
+      placeholder: v0.14.2 / mobile 0.0.32
     validations:
       required: false
 

--- a/.github/workflows/issue-os-labeler.yaml
+++ b/.github/workflows/issue-os-labeler.yaml
@@ -22,7 +22,10 @@ jobs:
           script: |
             const issue = context.payload.issue;
             const body = issue.body || "";
-            const osMatch = body.match(/^### Operating system\s+(.+)$/m);
+            // Prefer the current form field; keep older headings for open issues.
+            const osMatch =
+              body.match(/^### Operating system\s+(.+)$/m) ||
+              body.match(/^### Host operating system\s+(.+)$/m);
 
             if (!osMatch) {
               core.info("No operating system field found. Skipping.");
@@ -34,6 +37,8 @@ jobs:
               macos: "os:macos",
               windows: "os:Windows",
               linux: "os:linux",
+              ios: "os:mobile",
+              android: "os:mobile",
             };
 
             const desiredLabel = osLabelMap[selectedOs];
@@ -51,11 +56,20 @@ jobs:
             );
             const nextLabels = [...new Set([...labelsToKeep, desiredLabel])];
 
+            // Apply the plain "mobile" label for mobile clients (current + older forms).
+            const whereMatch =
+              body.match(/^### Where were you using Orca\?\s+(.+)$/m) ||
+              body.match(/^### Client\s+(.+)$/m);
+            const where = whereMatch?.[1]?.trim().toLowerCase() ?? "";
+            if (where.startsWith("mobile")) {
+              nextLabels.push("mobile");
+            }
+
             await github.rest.issues.setLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-              labels: nextLabels,
+              labels: [...new Set(nextLabels)],
             });
 
             core.info(`Applied label ${desiredLabel} to issue #${issue.number}.`);


### PR DESCRIPTION
## Summary
- Redesign the bug report form with a single **Where were you using Orca?** field covering desktop (local/SSH/remote/WSL), mobile (iOS/Android), and web.
- Add optional **Remote host operating system** for SSH / Orca remote server cases.
- Expand OS choices with iOS/Android; update the OS labeler to tag `os:mobile` and `mobile` for mobile reports.

## Test plan
- [ ] Open **New issue → Bug report** and confirm required fields: Where + Operating system
- [ ] Confirm remote OS is optional and can be skipped for local desktop
- [ ] File a sample mobile issue and confirm `mobile` / `os:mobile` labels apply via the labeler