### PR TITLE
fix(orchestration): reveal worker terminals reliably

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-07-26",
+  "updatedAt": "2026-07-28",
   "policy": {
     "maturityLevels": [
       "experimental",
@@ -4758,6 +4758,147 @@
         "Push-on-idle orchestration message banners remain outside this dispatch-prompt gate."
       ],
       "demotionRule": "Demote or quarantine if the live harness flakes without a product bug or harness bug filed to the terminal-input owner."
+    },
+    {
+      "id": "orchestration.worker-terminal-delivery",
+      "title": "Started workers are visible without stealing focus and retain mailbox identity",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "orchestration",
+      "layer": "cli-runtime-renderer-contract",
+      "surfaces": [
+        "Run and Dispatch mailboxes",
+        "worker-start",
+        "terminal creation",
+        "terminal tab materialization",
+        "workspace re-entry"
+      ],
+      "platforms": [
+        "macos",
+        "linux",
+        "windows"
+      ],
+      "providers": [
+        "local",
+        "daemon",
+        "ssh",
+        "wsl",
+        "remote-runtime"
+      ],
+      "coveredPlatforms": [
+        "macos"
+      ],
+      "coveredProviders": [
+        "local",
+        "daemon",
+        "ssh"
+      ],
+      "coverageNotes": "Deterministic units cover local worker presentation, reveal-failure warnings, stable-pane Run/Dispatch routing, and the SSH in-process CLI fallback. An isolated macOS Electron journey launches a fake Codex worker through the real RPC path, tolerates spawn-time handle reminting, asserts the inactive tab in the DOM before navigation, checks Run delivery by pane identity, and proves workspace re-entry keeps one worker tab by both original tab ID and visible title. SSH, WSL, remote-runtime, Linux, and Windows remain live-test gaps; federated workers retain explicit background presentation.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/pull/11107#discussion_r3663321387"
+      ],
+      "invariant": "Starting a worker in the coordinator's current workspace must materialize one inactive terminal tab before worker-start returns, preserve coordinator focus, and remain exactly once after workspace re-entry. An exact existing target workspace must receive a discoverable tab without stealing coordinator focus; if renderer reveal fails, worker-start must expose that the live worker remains background-only. Run and Dispatch checks must resolve through the caller's stable pane identity when a terminal handle is reminted, while a live handle outranks mismatched pane metadata, explicit legacy terminal inspection remains handle-scoped, and remote or headless worker presentation remains background-only.",
+      "oracle": "Drive Run create, Task create, and worker-start through a production Electron runtime with a deterministic Codex fixture. Require the worker tab to be visible in the DOM with data-active=false while the coordinator tab stays active, send ACK to the Run, read it with a deliberately stale coordinator handle plus its stable pane key, switch workspaces away and back, and require exactly one worker tab by original ID and visible title. Unit tests separately assert local worker-start omits background presentation, reveal failures return an actionable warning without discarding the worker, reminted coordinators and workers retain mailbox routing, live handles outrank mismatched pane metadata, and explicit legacy terminal checks do not inherit the caller pane key locally or through the SSH fallback.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/orchestration.test.ts src/cli/handlers/orchestration-check-identity.test.ts src/cli/handlers/orchestration-worker-cli.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/ssh/ssh-remote-orca-cli.test.ts",
+        "pnpm run test:e2e -- tests/e2e/orchestration-worker-terminal-visibility.spec.ts --workers=1"
+      ],
+      "testFiles": [
+        "src/cli/handlers/orchestration.test.ts",
+        "src/cli/handlers/orchestration-check-identity.test.ts",
+        "src/cli/handlers/orchestration-worker-cli.test.ts",
+        "src/main/runtime/rpc/methods/orchestration.test.ts",
+        "src/main/ssh/ssh-remote-orca-cli.test.ts",
+        "tests/e2e/orchestration-worker-terminal-visibility.spec.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/cli/handlers/orchestration-check-identity.test.ts",
+          "assertions": [
+            "implicit check carries the caller pane key with a potentially stale environment handle",
+            "explicit legacy terminal inspection does not inherit the caller pane key"
+          ]
+        },
+        {
+          "file": "src/cli/handlers/orchestration-worker-cli.test.ts",
+          "assertions": [
+            "worker-start prints an explicit warning when its live worker remains background-only"
+          ]
+        },
+        {
+          "file": "src/main/runtime/rpc/methods/orchestration.test.ts",
+          "assertions": [
+            "same-workspace worker creation uses visible inactive presentation",
+            "worker-start preserves and reports renderer reveal failures",
+            "Run delivery resolves through a stable coordinator pane after handle remint",
+            "Dispatch delivery resolves through a stable worker pane after handle remint",
+            "a live handle cannot be retargeted by mismatched pane metadata"
+          ]
+        },
+        {
+          "file": "src/main/ssh/ssh-remote-orca-cli.test.ts",
+          "assertions": [
+            "implicit SSH fallback checks retain stable pane identity",
+            "explicit legacy SSH inspection does not inherit the caller pane key"
+          ]
+        },
+        {
+          "file": "tests/e2e/orchestration-worker-terminal-visibility.spec.ts",
+          "assertions": [
+            "worker-start exposes one inactive worker tab before workspace navigation",
+            "the coordinator tab remains active",
+            "ACK delivery reaches a stable coordinator pane through a stale handle",
+            "workspace re-entry does not duplicate the worker tab under the same or a new tab ID"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-28",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/cli/handlers/orchestration.test.ts src/cli/handlers/orchestration-check-identity.test.ts src/cli/handlers/orchestration-worker-cli.test.ts src/main/runtime/rpc/methods/orchestration.test.ts src/main/ssh/ssh-remote-orca-cli.test.ts",
+          "result": "passed",
+          "durationSeconds": 5.27,
+          "summary": "Five focused files passed with 216 tests, covering visible inactive local worker creation, reveal-failure warnings, stable-pane mailbox routing, live-handle precedence, and SSH fallback parity."
+        },
+        {
+          "date": "2026-07-28",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm run test:e2e -- tests/e2e/orchestration-worker-terminal-visibility.spec.ts --workers=1",
+          "result": "passed",
+          "durationSeconds": 11.5,
+          "summary": "The isolated Electron journey passed with a real Run and Task, deterministic Codex PTY, immediate inactive DOM tab, ACK delivery through a stale coordinator handle, and exactly one worker tab by original ID and management title after workspace re-entry."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 45,
+        "scope": "focused CLI/runtime units plus one isolated Electron worker-start journey"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The deterministic units and isolated Electron journey pass locally; CI and soak history are not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The focused presentation and stale-handle tests failed against the pre-fix implementation, and the live incident plus Electron topology showed the worker PTY existed without an immediate tab. Saved intentional-break and CI artifacts are still needed."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Worker-start reuses the existing one-shot renderer reveal and adds no polling, provider listing, or output work. Check adds one optional pane-key field and reuses the existing Run scan or bounded active-Dispatch lookup; it adds no extra RPC, subprocess, timer, or renderer update. Federated and explicitly background terminals are unchanged."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive passes or 14 days of stable CI history on macOS, Linux, and Windows.",
+        "Add live SSH and WSL exact-workspace worker-start evidence and a paired remote-runtime control.",
+        "Attach saved intentional-break artifacts for hidden local presentation and dropped stable-pane delivery."
+      ],
+      "knownGaps": [
+        "No live Linux, Windows, SSH, WSL, or paired remote-runtime run is attached.",
+        "The Electron journey uses a deterministic fake Codex CLI rather than a real account.",
+        "The gate does not cover terminal output recovery after app restart; it covers identity, discoverability, focus, and mailbox routing."
+      ],
+      "demotionRule": "Keep experimental or demote if the Electron journey flakes without a product or harness defect, if local worker-start can return before tab materialization without an explicit reveal warning, if focus moves to the worker, if workspace re-entry duplicates the tab, or if pane-stable delivery reads the wrong mailbox."
     },
     {
       "id": "terminal-render.windows-cjk-repaint",

--- a/src/cli/handlers/orchestration-check-identity.test.ts
+++ b/src/cli/handlers/orchestration-check-identity.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.hoisted(() => vi.fn())
+const getTerminalHandleMock = vi.hoisted(() => vi.fn())
+const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
+const originalPaneKey = process.env.ORCA_PANE_KEY
+
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: getTerminalHandleMock }))
+
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+
+describe('orchestration check identity', () => {
+  beforeEach(() => {
+    callMock.mockReset().mockResolvedValue({ result: { messages: [], count: 0 } })
+    getTerminalHandleMock.mockReset()
+    delete process.env.ORCA_TERMINAL_HANDLE
+    delete process.env.ORCA_PANE_KEY
+  })
+
+  afterEach(() => {
+    if (originalTerminalHandle === undefined) {
+      delete process.env.ORCA_TERMINAL_HANDLE
+    } else {
+      process.env.ORCA_TERMINAL_HANDLE = originalTerminalHandle
+    }
+    if (originalPaneKey === undefined) {
+      delete process.env.ORCA_PANE_KEY
+    } else {
+      process.env.ORCA_PANE_KEY = originalPaneKey
+    }
+  })
+
+  const invokeCheck = (flags: Map<string, string | boolean>) =>
+    ORCHESTRATION_HANDLERS['orchestration check']({
+      flags,
+      client: { call: callMock },
+      cwd: '/tmp/repo',
+      json: true
+    } as never)
+
+  it('carries the caller pane key when the environment handle may be stale', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_coord'
+    process.env.ORCA_PANE_KEY = 'tab_coord:leaf_coord'
+    getTerminalHandleMock.mockRejectedValue(new Error('active terminal fallback is unsafe'))
+
+    await invokeCheck(new Map<string, string | boolean>([['wait', true]]))
+
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+    expect(callMock).toHaveBeenCalledWith(
+      'orchestration.check',
+      expect.objectContaining({
+        terminal: 'term_stale_coord',
+        terminalPaneKey: 'tab_coord:leaf_coord',
+        wait: true
+      })
+    )
+  })
+
+  it('keeps an explicit legacy terminal handle scoped to that handle', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_env'
+
+    await invokeCheck(new Map<string, string | boolean>([['terminal', 'term_legacy_worker']]))
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith(
+      'orchestration.check',
+      expect.objectContaining({
+        terminal: 'term_legacy_worker',
+        terminalPaneKey: undefined
+      })
+    )
+  })
+})

--- a/src/cli/handlers/orchestration-worker-cli.test.ts
+++ b/src/cli/handlers/orchestration-worker-cli.test.ts
@@ -7,10 +7,12 @@ vi.mock('../format', () => ({ printResult: vi.fn() }))
 vi.mock('../selectors', () => ({ getTerminalHandle: vi.fn() }))
 
 import { ORCHESTRATION_HANDLERS } from './orchestration'
+import { printResult } from '../format'
 
 describe('orchestration worker-start CLI contract', () => {
   beforeEach(() => {
     callMock.mockReset()
+    vi.mocked(printResult).mockReset()
     process.exitCode = undefined
   })
 
@@ -102,6 +104,47 @@ describe('orchestration worker-start CLI contract', () => {
     )
 
     expect(process.exitCode).toBe(1)
+  })
+
+  it('prints a reveal warning for a live background worker', async () => {
+    callMock.mockResolvedValue({
+      result: {
+        taskId: 'task_1',
+        dispatchId: 'ctx_1',
+        state: 'ready',
+        warning: 'Terminal term_worker is running but could not be revealed.',
+        effects: [],
+        residualResources: []
+      }
+    })
+
+    await ORCHESTRATION_HANDLERS['orchestration worker-start']({
+      flags: new Map<string, string | boolean>([
+        ['task', 'task_1'],
+        ['agent', 'codex'],
+        ['from', 'term_coord']
+      ]),
+      client: { call: callMock },
+      cwd: '/tmp/repo',
+      json: false
+    } as never)
+
+    const formatter = vi.mocked(printResult).mock.calls[0]?.[2] as
+      | ((result: {
+          taskId: string
+          dispatchId: string
+          state: string
+          warning?: string
+        }) => string)
+      | undefined
+    expect(
+      formatter?.({
+        taskId: 'task_1',
+        dispatchId: 'ctx_1',
+        state: 'ready',
+        warning: 'Terminal term_worker is running but could not be revealed.'
+      })
+    ).toContain('Warning: Terminal term_worker is running but could not be revealed.')
   })
 
   it('allows the initial zero cursor when paging worker output', async () => {

--- a/src/cli/handlers/orchestration.test.ts
+++ b/src/cli/handlers/orchestration.test.ts
@@ -686,6 +686,7 @@ describe('orchestration timeout flag validation', () => {
     // the non-consuming all mode instead of the destructive mark-read default.
     expect(callMock).toHaveBeenCalledWith('orchestration.check', {
       terminal: 'term_worker',
+      terminalPaneKey: undefined,
       unread: false,
       peek: true,
       all: undefined,

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -582,6 +582,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       )
     }
     const timeoutMs = getOptionalPositiveIntegerValueFlag(flags, 'timeout-ms')
+    const explicitTerminal = getOptionalStringFlag(flags, 'terminal')
     const terminal = await resolveOrchestrationTerminalHandle(flags, cwd, client, 'terminal')
 
     // Why: Claude Code auto-backgrounds subprocesses silent ~2 min; emit JSON keepalives to stderr (stdout stays one payload). See §3.4.
@@ -600,6 +601,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     try {
       result = await callMutation<CheckResult>(client, flags, 'orchestration.check', {
         terminal,
+        terminalPaneKey: explicitTerminal ? undefined : process.env.ORCA_PANE_KEY || undefined,
         // Why: peek also sends unread:false so pre-peek runtimes degrade to non-consuming all mode instead of destructive mark-read.
         unread: flags.has('unread') ? true : peek ? false : undefined,
         peek: peek ? true : undefined,
@@ -822,6 +824,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       state: string
       failedStage?: string
       lastError?: string
+      warning?: string
       effects: unknown[]
       residualResources: unknown[]
     }>(client, flags, 'orchestration.workerStart', {
@@ -847,9 +850,10 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     }
     printResult(result, json, (worker) => {
       const base = `Worker ${worker.dispatchId} [${worker.state}] for ${worker.taskId}`
-      return worker.lastError
-        ? `${base}\n${worker.failedStage ?? 'start'}: ${worker.lastError}`
-        : base
+      if (worker.lastError) {
+        return `${base}\n${worker.failedStage ?? 'start'}: ${worker.lastError}`
+      }
+      return worker.warning ? `${base}\nWarning: ${worker.warning}` : base
     })
   },
 

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -16,6 +16,8 @@ export type WorkerEffect = {
   hookFound?: boolean
   startupPolicy?: string
   terminalId?: string
+  surface?: 'visible' | 'background'
+  warning?: string
 }
 
 export type WorkerSetupReceipt = {
@@ -32,6 +34,28 @@ export type WorkerSetupReceipt = {
     | 'not_configured'
     | 'spawn_failed'
     | 'not_applicable'
+}
+
+export async function createExistingWorktreeWorkerTerminal(args: {
+  runtime: OrcaRuntimeService
+  worktreeId: string
+  agent: TuiAgent
+  taskId: string
+  effects: WorkerEffect[]
+}): Promise<{ handle: string; warning?: string }> {
+  const terminal = await args.runtime.createTerminal(`id:${args.worktreeId}`, {
+    command: args.agent,
+    title: `worker-${args.taskId}`
+  })
+  args.effects.push({
+    kind: 'terminal',
+    role: 'agent',
+    action: 'created',
+    id: terminal.handle,
+    surface: terminal.surface,
+    warning: terminal.warning
+  })
+  return { handle: terminal.handle, warning: terminal.warning }
 }
 
 export function applyWaitForSetupOutcome(

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -7,6 +7,7 @@ import { startFederatedWorker } from './orchestration-federated-worker-start'
 import { assertOrchestrationWorktreeCreationSupported } from './orchestration-folder-worktree-placement'
 import { WorkerStartParams } from './orchestration-worker-start-schema'
 import {
+  createExistingWorktreeWorkerTerminal,
   createWorkerWorktree,
   monitorWorkerSetup,
   type WorkerEffect,
@@ -151,6 +152,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         )
       }
       let terminalHandle = params.terminal
+      let terminalRevealWarning: string | undefined
       let failedStage = 'terminal_create'
       let setupReceipt: WorkerSetupReceipt = {
         requested: 'not_applicable',
@@ -183,18 +185,15 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             worktreeId: resolvedWorktree!.id,
             effects
           })
-          const terminal = await runtime.createTerminal(`id:${resolvedWorktree!.id}`, {
-            command: agent,
-            title: `worker-${task.id}`,
-            presentation: 'background'
+          const terminal = await createExistingWorktreeWorkerTerminal({
+            runtime,
+            worktreeId: resolvedWorktree!.id,
+            agent: agent as TuiAgent,
+            taskId: task.id,
+            effects
           })
           terminalHandle = terminal.handle
-          effects.push({
-            kind: 'terminal',
-            role: 'agent',
-            action: 'created',
-            id: terminal.handle
-          })
+          terminalRevealWarning = terminal.warning
         } else {
           effects.push({
             kind: 'terminal',
@@ -287,7 +286,8 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           setup: setupReceipt,
           timeoutMs: params.timeoutMs ?? 60_000,
           effects,
-          residualResources: []
+          residualResources: [],
+          ...(terminalRevealWarning ? { warning: terminalRevealWarning } : {})
         }
       } catch (error) {
         return failWorkerStartWithReceipt({

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -322,6 +322,32 @@ describe('orchestration RPC methods', () => {
       })
     })
 
+    it('routes Dispatch mail by stable pane identity after worker handle remint', async () => {
+      setup()
+      const task = db.createTask({ spec: 'controlled worker after restart' })
+      const dispatch = db.createDispatchContext(
+        task.id,
+        'term_worker_before',
+        'tab_worker:leaf_worker'
+      )
+      db.insertMessage({
+        from: 'term_coord',
+        to: `dispatch:${dispatch.id}`,
+        subject: 'Continue after restart',
+        runId: activeRunId
+      })
+
+      const workerCheck = (await call('orchestration.check', {
+        terminal: 'term_worker_after',
+        terminalPaneKey: 'tab_worker:leaf_worker'
+      })) as { dispatchId: string; messages: { subject: string }[] }
+
+      expect(workerCheck).toMatchObject({
+        dispatchId: dispatch.id,
+        messages: [{ subject: 'Continue after restart' }]
+      })
+    })
+
     it('rejects hidden task-recipient retargeting', async () => {
       setup()
       await expect(
@@ -1041,6 +1067,56 @@ describe('orchestration RPC methods', () => {
       }
       expect(inboxA.messages.map((message) => message.subject)).toEqual(['A only'])
       expect(inboxB.messages.map((message) => message.subject)).toEqual(['B only'])
+    })
+
+    it('uses the stable pane identity when the coordinator handle was reminted', async () => {
+      setup()
+      db.insertMessage({
+        from: 'term_worker',
+        to: `run:${activeRunId}`,
+        subject: 'Completed after restart',
+        runId: activeRunId
+      })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_stale_coord',
+        terminalPaneKey: coordinatorPaneKey
+      })) as { runId: string; messages: { subject: string }[] }
+
+      expect(result).toMatchObject({
+        runId: activeRunId,
+        messages: [{ subject: 'Completed after restart' }]
+      })
+    })
+
+    it('keeps a live handle authoritative over mismatched pane metadata', async () => {
+      setup()
+      const foreignRun = db.createRun({
+        objective: 'Foreign run',
+        coordinatorHandle: 'term_foreign',
+        coordinatorPaneKey: 'tab_foreign:leaf_foreign'
+      })
+      db.insertMessage({
+        from: 'term_worker',
+        to: `run:${activeRunId}`,
+        subject: 'Coordinator only',
+        runId: activeRunId
+      })
+      db.insertMessage({
+        from: 'term_foreign_worker',
+        to: `run:${foreignRun.id}`,
+        subject: 'Foreign only',
+        runId: foreignRun.id
+      })
+
+      const result = (await call('orchestration.check', {
+        terminal: 'term_coord',
+        terminalPaneKey: 'tab_foreign:leaf_foreign',
+        all: true
+      })) as { runId: string; messages: { subject: string }[] }
+
+      expect(result.runId).toBe(activeRunId)
+      expect(result.messages.map((message) => message.subject)).toEqual(['Coordinator only'])
     })
 
     it('returns formatted output with --format', async () => {
@@ -2071,10 +2147,50 @@ describe('orchestration RPC methods', () => {
       )
       expect(db.getTask(task.id)?.status).toBe('dispatched')
       expect(db.getWorkerDispatch(result.dispatchId)?.state).toBe('ready')
+      expect(runtime.createTerminal).toHaveBeenCalledWith('id:repo::worktree', {
+        command: 'codex',
+        title: `worker-${task.id}`
+      })
       expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledWith(
         'term_worker',
         expect.stringContaining('--dispatch-capability dcap_')
       )
+    })
+
+    it('surfaces a worker terminal reveal failure without discarding the live worker', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.createTerminal).mockResolvedValue({
+        handle: 'term_worker',
+        worktreeId: 'repo::worktree',
+        title: 'worker',
+        surface: 'background',
+        warning: 'Terminal term_worker is running but could not be revealed.'
+      })
+      const task = db.createTask({ spec: 'keep working if reveal fails' })
+
+      const result = (await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })) as {
+        state: string
+        warning?: string
+        effects: { kind: string; surface?: string; warning?: string }[]
+      }
+
+      expect(result).toMatchObject({
+        state: 'ready',
+        warning: 'Terminal term_worker is running but could not be revealed.'
+      })
+      expect(result.effects).toContainEqual(
+        expect.objectContaining({
+          kind: 'terminal',
+          surface: 'background',
+          warning: 'Terminal term_worker is running but could not be revealed.'
+        })
+      )
+      expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalled()
     })
 
     it('starts a fresh agent in an exact existing worktree without replaying setup', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -97,6 +97,7 @@ const SendParams = z
 const CheckParams = z
   .object({
     terminal: OptionalString,
+    terminalPaneKey: OptionalString,
     unread: OptionalBoolean,
     peek: OptionalBoolean,
     // Why: `all` surfaces every message and skips mark-read; legacy encoding was the `{unread: false}` trick (design doc §3.2/§3.3).
@@ -238,6 +239,7 @@ function resolveRunScope(
   params: {
     runId?: string
     callerTerminalHandle?: string
+    callerPaneKey?: string
     requireCurrentConsumer: boolean
   }
 ): RunRow {
@@ -257,7 +259,7 @@ function resolveRunScope(
       orchestrationSkillRecoveryData()
     )
   }
-  const paneKey = runtime.getTerminalPaneKey(params.callerTerminalHandle)
+  const paneKey = params.callerPaneKey ?? runtime.getTerminalPaneKey(params.callerTerminalHandle)
   if (!paneKey) {
     throw new OrchestrationError(
       'stable_pane_required',
@@ -636,12 +638,14 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       const handle = params.terminal ?? 'unknown'
       const typeFilter = parseMessageTypes(params.types)
 
-      const paneKey = runtime.getTerminalPaneKey(handle)
+      // Why: a live runtime handle is authoritative; pane metadata is only the restart fallback.
+      const paneKey = runtime.getTerminalPaneKey(handle) ?? params.terminalPaneKey
       const boundRun = paneKey ? db.getCurrentRunForPane(paneKey) : undefined
       if (params.run || boundRun) {
         const run = resolveRunScope(runtime, {
           runId: params.run,
           callerTerminalHandle: handle,
+          callerPaneKey: paneKey ?? undefined,
           requireCurrentConsumer: true
         })
         const generation = run.consumer_generation
@@ -780,7 +784,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         remoteAttachment &&
         !db.isRemoteAttachmentProcessCurrent({
           dispatchId: remoteAttachment.dispatch_id,
-          paneKey,
+          paneKey: paneKey ?? null,
           processIncarnation: runtime.getTerminalProcessIncarnation(handle)
         })
       ) {

--- a/src/main/ssh/ssh-remote-orca-cli.test.ts
+++ b/src/main/ssh/ssh-remote-orca-cli.test.ts
@@ -80,7 +80,9 @@ describe('runRemoteOrcaCli', () => {
           }
         }
       }),
-      getActiveDispatchForIdentity: vi.fn(() => undefined)
+      getActiveDispatchForIdentity: vi.fn(() => undefined),
+      getCurrentRunForPane: vi.fn(() => undefined),
+      findActiveRemoteAttachmentForPane: vi.fn(() => undefined)
     }
     const runtime = {
       getRuntimeId: () => 'runtime-test',
@@ -478,6 +480,51 @@ describe('runRemoteOrcaCli', () => {
     expect(payload.ok).toBe(true)
     expect(payload.result.count).toBe(1)
     expect(payload.result.messages[0]?.subject).toBe('pong')
+  })
+
+  it('carries the remote pane key for an implicit orchestration check', async () => {
+    const { runtime, db } = createRuntime()
+
+    const result = await runRemoteOrcaCli(
+      runtime,
+      {
+        argv: ['orchestration', 'check', '--all', '--json'],
+        cwd: '/home/alice/repo',
+        env: {
+          ORCA_TERMINAL_HANDLE: 'term_stale_ssh',
+          ORCA_PANE_KEY: 'tab_ssh:leaf_ssh'
+        }
+      },
+      LEGACY_FALLBACK_OPTIONS
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(db.getCurrentRunForPane).toHaveBeenCalledWith('tab_ssh:leaf_ssh')
+    expect(db.getActiveDispatchForIdentity).toHaveBeenCalledWith(
+      'term_stale_ssh',
+      'tab_ssh:leaf_ssh'
+    )
+  })
+
+  it('does not inherit a remote pane key for explicit legacy inspection', async () => {
+    const { runtime, db } = createRuntime()
+
+    const result = await runRemoteOrcaCli(
+      runtime,
+      {
+        argv: ['orchestration', 'check', '--terminal', 'term_legacy_worker', '--all', '--json'],
+        cwd: '/home/alice/repo',
+        env: {
+          ORCA_TERMINAL_HANDLE: 'term_stale_ssh',
+          ORCA_PANE_KEY: 'tab_ssh:leaf_ssh'
+        }
+      },
+      LEGACY_FALLBACK_OPTIONS
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(db.getCurrentRunForPane).not.toHaveBeenCalled()
+    expect(db.getActiveDispatchForIdentity).toHaveBeenCalledWith('term_legacy_worker', undefined)
   })
 
   it('routes previously-unsupported commands through the full host CLI', async () => {

--- a/src/main/ssh/ssh-remote-orca-cli.ts
+++ b/src/main/ssh/ssh-remote-orca-cli.ts
@@ -195,6 +195,7 @@ async function dispatchRemoteCli(
     case 'orchestration check':
       return await call(dispatcher, 'orchestration.check', {
         terminal: resolveRemoteCliHandle(parsed.flags, env, 'terminal'),
+        terminalPaneKey: parsed.flags.has('terminal') ? undefined : env.ORCA_PANE_KEY || undefined,
         unread: parsed.flags.has('unread') ? true : undefined,
         all: parsed.flags.has('all') ? true : undefined,
         types: optionalRemoteCliString(parsed.flags, 'types'),

--- a/tests/e2e/orchestration-worker-terminal-visibility.spec.ts
+++ b/tests/e2e/orchestration-worker-terminal-visibility.spec.ts
@@ -1,0 +1,158 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test as base, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getActiveTabId,
+  switchToOtherWorktree,
+  switchToWorktree,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import { waitForActivePaneHookDescriptor } from './helpers/terminal'
+import { RuntimeClient } from '../../src/cli/runtime-client'
+import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/shared/runtime-types'
+
+const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-orchestration-worker-'))
+const fakeCodexSource = `
+if (process.argv.slice(2).includes('app-server')) {
+  process.stderr.write("error: unrecognized subcommand 'app-server'\\n")
+  process.exit(2)
+}
+process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
+let acknowledged = false
+process.stdin.on('data', (chunk) => {
+  if (!acknowledged && chunk.toString().includes('\\r')) {
+    acknowledged = true
+    process.stdout.write('ACK\\n')
+  }
+})
+process.stdin.resume()
+setInterval(() => {}, 60_000)
+`
+
+if (process.platform === 'win32') {
+  writeFileSync(path.join(fakeCliDir, 'fake-codex.js'), fakeCodexSource)
+  writeFileSync(
+    path.join(fakeCliDir, 'codex.cmd'),
+    '@echo off\r\nnode "%~dp0\\fake-codex.js" %*\r\n'
+  )
+} else {
+  const executable = path.join(fakeCliDir, 'codex')
+  writeFileSync(executable, `#!/usr/bin/env node\n${fakeCodexSource}`)
+  chmodSync(executable, 0o755)
+}
+
+const test = base.extend({
+  launchEnv: [
+    {
+      PATH: `${fakeCliDir}${path.delimiter}${process.env.PATH ?? ''}`
+    },
+    { option: true }
+  ]
+})
+
+test.afterAll(() => {
+  rmSync(fakeCliDir, { recursive: true, force: true })
+})
+
+test('worker-start materializes one inactive terminal tab before workspace re-entry', async ({
+  orcaPage,
+  electronApp
+}) => {
+  await waitForSessionReady(orcaPage)
+  const worktreeId = await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  const coordinatorTabId = await getActiveTabId(orcaPage)
+  expect(coordinatorTabId).toBeTruthy()
+  const coordinatorPane = await waitForActivePaneHookDescriptor(orcaPage)
+  const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+  const client = new RuntimeClient(userDataDir, 30_000, null, null)
+  const coordinator = await client.call<{ terminal: { handle: string } }>('terminal.resolvePane', {
+    paneKey: coordinatorPane.paneKey
+  })
+  const run = await client.call<{ run: { id: string } }>('orchestration.runCreate', {
+    objective: 'Verify worker terminal visibility',
+    from: coordinator.result.terminal.handle
+  })
+  const task = await client.call<{ task: { id: string } }>('orchestration.taskCreate', {
+    spec: 'Respond ACK and remain idle',
+    run: run.result.run.id,
+    callerTerminalHandle: coordinator.result.terminal.handle
+  })
+  const coordinatorTerminal = await client.call<{ terminal: { worktreeId: string } }>(
+    'terminal.show',
+    { terminal: coordinator.result.terminal.handle }
+  )
+  await expect
+    .poll(async () => {
+      const listed = await client.call<{ worktrees: { id: string }[] }>('worktree.list', {})
+      return listed.result.worktrees.some(
+        (worktree) => worktree.id === coordinatorTerminal.result.terminal.worktreeId
+      )
+    })
+    .toBe(true)
+
+  const started = await client.call<{
+    effects: { kind: string; role?: string; id?: string }[]
+  }>('orchestration.workerStart', {
+    task: task.result.task.id,
+    from: coordinator.result.terminal.handle,
+    agent: 'codex',
+    timeoutMs: 15_000
+  })
+  const workerHandle = started.result.effects.find(
+    (effect) => effect.kind === 'terminal' && effect.role === 'agent'
+  )?.id
+  expect(workerHandle).toBeTruthy()
+  const workerTabTitle = `worker-${task.result.task.id}`
+
+  const terminals = await client.call<RuntimeTerminalListResult>('terminal.list')
+  const workerTerminal = terminals.result.terminals.find(
+    (terminal) => terminal.title === 'Codex Ready'
+  )
+  expect(workerTerminal?.tabId).toBeTruthy()
+  expect(workerTerminal?.leafId).toBeTruthy()
+  await expect
+    .poll(async () => {
+      const read = await client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
+        terminal: workerTerminal!.handle,
+        limit: 200
+      })
+      return read.result.terminal.tail.join('\n')
+    })
+    .toContain('ACK')
+  const workerTab = orcaPage.locator(
+    `[data-testid="sortable-tab"][data-tab-id="${workerTerminal!.tabId}"]`
+  )
+  await expect(workerTab).toBeVisible()
+  await expect(workerTab).toHaveAttribute('data-active', 'false')
+  await expect(
+    orcaPage.locator(`[data-testid="sortable-tab"][data-tab-id="${coordinatorTabId}"]`)
+  ).toHaveAttribute('data-active', 'true')
+
+  await client.call('orchestration.send', {
+    from: workerHandle,
+    to: `run:${run.result.run.id}`,
+    subject: 'ACK'
+  })
+  const checked = await client.call<{ messages: { subject: string }[] }>('orchestration.check', {
+    terminal: 'term_stale_coordinator',
+    terminalPaneKey: coordinatorPane.paneKey
+  })
+  expect(checked.result.messages).toEqual([expect.objectContaining({ subject: 'ACK' })])
+
+  const otherWorktreeId = await switchToOtherWorktree(orcaPage, worktreeId)
+  expect(otherWorktreeId).toBeTruthy()
+  await expect(workerTab).not.toBeVisible()
+  await switchToWorktree(orcaPage, worktreeId)
+
+  await expect(workerTab).toBeVisible()
+  await expect(
+    orcaPage.locator(`[data-testid="sortable-tab"][data-tab-id="${workerTerminal!.tabId}"]`)
+  ).toHaveCount(1)
+  await expect(
+    orcaPage.locator(`[data-testid="sortable-tab"][data-tab-title="${workerTabTitle}"]`)
+  ).toHaveCount(1)
+})


### PR DESCRIPTION
## Summary
- materialize same-workspace worker terminals as visible inactive tabs without stealing coordinator focus
- route checks through stable pane identity across handle remints while keeping live handles authoritative and explicit legacy inspection handle-scoped, including the SSH fallback
- surface renderer reveal failures without discarding the live worker, and register a focused reliability gate

## Verification
- 216 focused CLI/runtime/SSH tests
- node and CLI typechecks
- reliability, max-lines, and changed-code quality gates
- fresh production Electron E2E: fake Codex receives the dispatch, prints ACK, the worker tab appears immediately, coordinator focus stays put, stale-handle Run delivery succeeds, and workspace re-entry leaves exactly one worker tab
- internal-review-until-clean: final adversarial correctness and quality rounds clean

Motivated by the blocking workspace-switch reproduction and https://github.com/stablyai/orca/pull/11107#discussion_r3663321387.