### PR TITLE
feat(editor): bindable shortcut for editor/diff viewer toggle

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -33,6 +33,10 @@ import {
   type EditorRequestFileCloseDetail,
   requestEditorSaveQuiesce
 } from './editor/editor-autosave'
+import {
+  canUseChangesModeForFile,
+  toggleEditorDiffViewMode
+} from './editor/editor-panel-file-mode'
 import { isIntentionalAppRestartInProgress } from '@/lib/updater-beforeunload'
 import { preventUnloadAndScheduleShutdownCheckpointReset } from '@/lib/shutdown-checkpoint-guard'
 import EditorAutosaveController from './editor/EditorAutosaveController'
@@ -1786,6 +1790,27 @@ function Terminal(): React.JSX.Element | null {
             void state.updateSettings({ editorWordWrap: !wrapOn })
           }
           return
+        }
+      }
+
+      // Why: Settings → Shortcuts entry for the Edit/Changes toolbar toggle (#11095).
+      if (!e.repeat && matchShortcut('editor.toggleDiffViewer')) {
+        const state = useAppStore.getState()
+        if (state.activeTabType === 'editor' && state.activeFileId) {
+          const activeFile = state.openFiles.find((file) => file.id === state.activeFileId)
+          const nextMode = activeFile
+            ? toggleEditorDiffViewMode(
+                state.editorViewMode[activeFile.id],
+                canUseChangesModeForFile(activeFile)
+              )
+            : null
+          // Why: only consume when changes mode applies (same gate as the toolbar).
+          if (activeFile && nextMode) {
+            e.preventDefault()
+            notifyTerminalCapture('editor.toggleDiffViewer')
+            state.setEditorViewMode(activeFile.id, nextMode)
+            return
+          }
         }
       }
 

--- a/src/renderer/src/components/editor/editor-panel-file-mode.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-file-mode.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import {
+  canUseChangesModeForFile,
+  isAbsolutePathLike,
+  toggleEditorDiffViewMode
+} from './editor-panel-file-mode'
+
+function openFile(overrides: Partial<OpenFile> = {}): OpenFile {
+  return {
+    id: '/repo/src/app.ts',
+    filePath: '/repo/src/app.ts',
+    relativePath: 'src/app.ts',
+    worktreeId: 'wt-1',
+    language: 'typescript',
+    isDirty: false,
+    mode: 'edit',
+    ...overrides
+  }
+}
+
+describe('isAbsolutePathLike', () => {
+  it('detects posix, windows, and unc-style paths', () => {
+    expect(isAbsolutePathLike('/repo/file.ts')).toBe(true)
+    expect(isAbsolutePathLike('C:\\repo\\file.ts')).toBe(true)
+    expect(isAbsolutePathLike('\\\\server\\share\\file.ts')).toBe(true)
+    expect(isAbsolutePathLike('src/app.ts')).toBe(false)
+  })
+})
+
+describe('canUseChangesModeForFile', () => {
+  it('allows worktree-relative edit files', () => {
+    expect(canUseChangesModeForFile(openFile())).toBe(true)
+  })
+
+  it('rejects untitled, diff-mode, and absolute relativePath files', () => {
+    expect(canUseChangesModeForFile(openFile({ isUntitled: true }))).toBe(false)
+    expect(canUseChangesModeForFile(openFile({ mode: 'diff' }))).toBe(false)
+    expect(
+      canUseChangesModeForFile(
+        openFile({
+          relativePath: '/repo/src/app.ts',
+          filePath: '/repo/src/app.ts'
+        })
+      )
+    ).toBe(false)
+  })
+})
+
+describe('toggleEditorDiffViewMode', () => {
+  it('returns null when changes mode is unavailable', () => {
+    expect(toggleEditorDiffViewMode(undefined, false)).toBeNull()
+    expect(toggleEditorDiffViewMode('changes', false)).toBeNull()
+    expect(toggleEditorDiffViewMode('edit', false)).toBeNull()
+  })
+
+  it('toggles edit ↔ changes when changes mode is available', () => {
+    expect(toggleEditorDiffViewMode(undefined, true)).toBe('changes')
+    expect(toggleEditorDiffViewMode('edit', true)).toBe('changes')
+    expect(toggleEditorDiffViewMode('changes', true)).toBe('edit')
+  })
+})

--- a/src/renderer/src/components/editor/editor-panel-file-mode.ts
+++ b/src/renderer/src/components/editor/editor-panel-file-mode.ts
@@ -1,4 +1,4 @@
-import type { OpenFile } from '@/store/slices/editor'
+import type { EditorViewMode, OpenFile } from '@/store/slices/editor'
 
 export function isAbsolutePathLike(value: string): boolean {
   return value.startsWith('/') || value.startsWith('\\\\') || /^[A-Za-z]:[\\/]/.test(value)
@@ -11,4 +11,15 @@ export function canUseChangesModeForFile(file: OpenFile): boolean {
     file.relativePath !== file.filePath &&
     !isAbsolutePathLike(file.relativePath)
   )
+}
+
+/** Next edit↔changes mode for the toolbar toggle; null when changes mode is unavailable. */
+export function toggleEditorDiffViewMode(
+  currentMode: EditorViewMode | undefined,
+  canUseChanges: boolean
+): EditorViewMode | null {
+  if (!canUseChanges) {
+    return null
+  }
+  return currentMode === 'changes' ? 'edit' : 'changes'
 }

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -231,6 +231,28 @@ describe('keybindings', () => {
     }
   )
 
+  it('registers unbound Toggle Diff Viewer under Editors', () => {
+    const definition = getKeybindingDefinition('editor.toggleDiffViewer')
+    expect(definition).toMatchObject({
+      id: 'editor.toggleDiffViewer',
+      title: 'Toggle Diff Viewer',
+      group: 'Editors',
+      scope: 'editor'
+    })
+    expect(definition?.searchKeywords).toEqual(
+      expect.arrayContaining(['diff', 'viewer', 'changes', 'edit', 'toggle'])
+    )
+    expect(getEffectiveKeybindingsForAction('editor.toggleDiffViewer', 'darwin')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('editor.toggleDiffViewer', 'linux')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('editor.toggleDiffViewer', 'win32')).toEqual([])
+    // Why: users can bind any free chord; custom override must match.
+    expect(
+      getEffectiveKeybindingsForAction('editor.toggleDiffViewer', 'darwin', {
+        'editor.toggleDiffViewer': ['Mod+Shift+D']
+      })
+    ).toEqual(['Mod+Shift+D'])
+  })
+
   it('matches macOS Option+Z through its composed key', () => {
     expect(
       keybindingMatchesAction(

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -89,6 +89,7 @@ export type KeybindingActionId =
   | 'editor.save'
   | 'editor.markdownPreview'
   | 'editor.toggleWordWrap'
+  | 'editor.toggleDiffViewer'
   | 'editor.copyContext'
   | 'editor.previousChange'
   | 'editor.nextChange'
@@ -815,6 +816,23 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     searchKeywords: ['shortcut', 'editor', 'word wrap', 'wrap', 'long lines', 'soft wrap'],
     // Why: Alt+Z matches VS Code; bare Alt+letter is not AltGr, so it stays cross-platform (#9974).
     defaultBindings: platformBindings(['Alt+Z'])
+  },
+  {
+    id: 'editor.toggleDiffViewer',
+    title: 'Toggle Diff Viewer',
+    group: 'Editors',
+    scope: 'editor',
+    searchKeywords: [
+      'shortcut',
+      'editor',
+      'diff',
+      'viewer',
+      'changes',
+      'edit',
+      'toggle'
+    ],
+    // Why: unbound by default so users opt in; avoids colliding with existing editor chords (#11095).
+    defaultBindings: platformBindings([])
   },
   {
     id: 'editor.copyContext',


### PR DESCRIPTION
## Description
Users can assign a keyboard shortcut for the toolbar **Edit ↔ Diff (Changes)** toggle so review workflows stay keyboard-first.

## Focused fix
- In scope: register `editor.toggleDiffViewer`, wire global capture to existing `setEditorViewMode` edit/changes path, pure toggle helper + tests
- Out of scope: changing diff semantics, default chord, markdown-only modes

## Preserves
- Existing toolbar `EditorViewToggle` behavior and `canUseChangesModeForFile` gates (virtual/check-details no-op)
- No default binding — user assigns in Settings → Shortcuts

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/keybindings.test.ts src/renderer/src/components/editor/editor-panel-file-mode.test.ts` → 79 passed

## User-regression-tradeoffs
- Unbound by default to avoid stealing chords; discoverability via Shortcuts list

Fixes #11095