### PR TITLE
feat(sidebar): keyboard shortcut to pin/unpin current workspace

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -182,6 +182,8 @@ import {
   type PhysicalModifierToken
 } from '../../shared/keybindings'
 import { PLUGIN_COMMAND_ALIAS_ACTION_IDS } from '../../shared/plugins/plugin-command-actions'
+import { getActiveSidebarWorkspaceId } from '../../shared/workspace-scope'
+import { resolveWorkspacePinToggleTarget } from '../../shared/workspace-pin-toggle'
 import { registerAppCommandDispatcher } from '@/lib/app-command-dispatch'
 import { executePluginCommand } from '@/lib/plugin-command-execution'
 import { findPluginCommandForKeybinding } from '@/lib/plugin-command-keybindings'
@@ -1633,6 +1635,29 @@ function App(): React.JSX.Element {
             return claim('workspace.rename', () => {
               useAppStore.getState().setSidebarOpen(true)
               requestScrollToCurrentWorkspaceRevealAndRename()
+            })
+          }
+        ],
+        [
+          'workspace.togglePin',
+          () => {
+            if (!workspaceChromeActive || floatingWorkspaceFocused) {
+              return false
+            }
+            const store = useAppStore.getState()
+            const worktreeId = getActiveSidebarWorkspaceId(
+              store.activeWorkspaceKey,
+              store.activeWorktreeId
+            )
+            const target = resolveWorkspacePinToggleTarget({
+              worktreeId,
+              isPinned: worktreeId ? store.getKnownWorktreeById(worktreeId)?.isPinned : undefined
+            })
+            if (!target) {
+              return false
+            }
+            return claim('workspace.togglePin', () => {
+              store.setWorktreesPinnedAndReveal([target.worktreeId], target.nextPinned)
             })
           }
         ],

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -84,6 +84,8 @@ import { buildSidebarHostOptions } from '@/components/sidebar/sidebar-host-optio
 import { getPaletteHostBadge, type PaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
 import { useSettingsNavigationMetadata } from '@/hooks/useSettingsNavigationMetadata'
 import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
+import { getActiveSidebarWorkspaceId } from '../../../shared/workspace-scope'
+import { resolveWorkspacePinToggleTarget } from '../../../shared/workspace-pin-toggle'
 import {
   buildCmdJActionResults,
   buildCmdJSettingsResults,
@@ -923,6 +925,22 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
     queueMicrotask(() => runWorktreeDelete(activeWorktreeId))
   }, [])
 
+  const toggleActiveWorkspacePinAction = useCallback(() => {
+    const store = useAppStore.getState()
+    const worktreeId = getActiveSidebarWorkspaceId(
+      store.activeWorkspaceKey,
+      store.activeWorktreeId
+    )
+    const target = resolveWorkspacePinToggleTarget({
+      worktreeId,
+      isPinned: worktreeId ? store.getKnownWorktreeById(worktreeId)?.isPinned : undefined
+    })
+    if (!target) {
+      return
+    }
+    store.setWorktreesPinnedAndReveal([target.worktreeId], target.nextPinned)
+  }, [])
+
   const openAddQuickCommandAction = useCallback(() => {
     openSettingsTarget({ pane: 'quick-commands', repoId: null, intent: 'add-quick-command' })
     openSettingsPage()
@@ -938,6 +956,7 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
         openNewTerminalTab: openNewTerminalTabInActiveWorkspace,
         openCreateWorkspace: openCreateWorkspaceAction,
         deleteActiveWorkspace: deleteActiveWorkspaceAction,
+        toggleActiveWorkspacePin: toggleActiveWorkspacePinAction,
         openAddQuickCommand: openAddQuickCommandAction
       }),
     [
@@ -946,7 +965,8 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
       openCreateWorkspaceAction,
       openNewBrowserTabInActiveWorkspace,
       openNewMarkdownInActiveWorkspace,
-      openNewTerminalTabInActiveWorkspace
+      openNewTerminalTabInActiveWorkspace,
+      toggleActiveWorkspacePinAction
     ]
   )
 

--- a/src/renderer/src/components/cmd-j/quick-action-context.test.ts
+++ b/src/renderer/src/components/cmd-j/quick-action-context.test.ts
@@ -108,6 +108,7 @@ describe('Cmd+J quick action context', () => {
       openNewTerminalTab: async () => {},
       openCreateWorkspace: () => {},
       deleteActiveWorkspace: () => {},
+      toggleActiveWorkspacePin: () => {},
       openAddQuickCommand: () => {}
     } satisfies CmdJQuickActionContext
 
@@ -130,7 +131,7 @@ describe('Cmd+J quick action context', () => {
 
   it('applies the availability matrix across curated actions', () => {
     const workspaceActions = ['new-browser-tab', 'new-markdown-file', 'new-terminal-tab']
-    const currentWorkspaceActions = ['delete-workspace']
+    const currentWorkspaceActions = ['delete-workspace', 'toggle-pin-workspace']
     const workspaceAgnosticActions = ['create-workspace', 'add-quick-command']
     const actionById = new Map(getCmdJQuickActions().map((action) => [action.id, action]))
     const baseContext = {
@@ -142,6 +143,7 @@ describe('Cmd+J quick action context', () => {
       openNewTerminalTab: async () => {},
       openCreateWorkspace: () => {},
       deleteActiveWorkspace: () => {},
+      toggleActiveWorkspacePin: () => {},
       openAddQuickCommand: () => {}
     } satisfies CmdJQuickActionContext
 
@@ -222,6 +224,7 @@ describe('Cmd+J quick action context', () => {
       openNewTerminalTab: async () => {},
       openCreateWorkspace: () => {},
       deleteActiveWorkspace: () => {},
+      toggleActiveWorkspacePin: () => {},
       openAddQuickCommand: () => {}
     })
 
@@ -248,6 +251,7 @@ describe('Cmd+J quick action context', () => {
       openNewTerminalTab: async () => {},
       openCreateWorkspace: () => {},
       deleteActiveWorkspace: () => {},
+      toggleActiveWorkspacePin: () => {},
       openAddQuickCommand: () => {}
     })
 
@@ -268,6 +272,7 @@ describe('Cmd+J quick action context', () => {
       },
       openCreateWorkspace: () => {},
       deleteActiveWorkspace: () => {},
+      toggleActiveWorkspacePin: () => {},
       openAddQuickCommand: () => {}
     } satisfies CmdJQuickActionContext
 
@@ -292,10 +297,33 @@ describe('Cmd+J quick action context', () => {
       deleteActiveWorkspace: () => {
         calls.push('delete')
       },
+      toggleActiveWorkspacePin: () => {},
       openAddQuickCommand: () => {}
     } satisfies CmdJQuickActionContext
 
     await expect(action?.run(context)).resolves.toEqual({ status: 'ok' })
     expect(calls).toEqual(['delete'])
+  })
+
+  it('runtime re-check invokes the current workspace pin toggle when available', async () => {
+    const calls: string[] = []
+    const action = getCmdJQuickActions().find((entry) => entry.id === 'toggle-pin-workspace')
+    const context = {
+      ...ctx({ activeGroupId: null }),
+      activeWorktree: null,
+      runtimeMode: 'local-desktop' as const,
+      openNewBrowserTab: async () => {},
+      openNewMarkdownFile: async () => {},
+      openNewTerminalTab: async () => {},
+      openCreateWorkspace: () => {},
+      deleteActiveWorkspace: () => {},
+      toggleActiveWorkspacePin: () => {
+        calls.push('toggle-pin')
+      },
+      openAddQuickCommand: () => {}
+    } satisfies CmdJQuickActionContext
+
+    await expect(action?.run(context)).resolves.toEqual({ status: 'ok' })
+    expect(calls).toEqual(['toggle-pin'])
   })
 })

--- a/src/renderer/src/components/cmd-j/quick-action-context.ts
+++ b/src/renderer/src/components/cmd-j/quick-action-context.ts
@@ -31,6 +31,7 @@ export type CmdJQuickActionContext = {
   openNewTerminalTab: (groupId: string) => Promise<void>
   openCreateWorkspace: () => void
   deleteActiveWorkspace: () => void
+  toggleActiveWorkspacePin: () => void
   openAddQuickCommand: () => void
 }
 
@@ -133,6 +134,7 @@ export function buildCmdJQuickActionContext(args: {
   openNewTerminalTab: (groupId: string) => Promise<void>
   openCreateWorkspace: () => void
   deleteActiveWorkspace: () => void
+  toggleActiveWorkspacePin: () => void
   openAddQuickCommand: () => void
 }): CmdJQuickActionContext {
   const activeWorktreeId = args.state.activeWorktreeId
@@ -165,6 +167,7 @@ export function buildCmdJQuickActionContext(args: {
     openNewTerminalTab: args.openNewTerminalTab,
     openCreateWorkspace: args.openCreateWorkspace,
     deleteActiveWorkspace: args.deleteActiveWorkspace,
+    toggleActiveWorkspacePin: args.toggleActiveWorkspacePin,
     openAddQuickCommand: args.openAddQuickCommand
   }
 }

--- a/src/renderer/src/components/cmd-j/quick-actions.ts
+++ b/src/renderer/src/components/cmd-j/quick-actions.ts
@@ -1,4 +1,4 @@
-import { FileText, FolderPlus, Globe, Play, SquareTerminal, Trash2 } from 'lucide-react'
+import { FileText, FolderPlus, Globe, Pin, Play, SquareTerminal, Trash2 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { CmdJQuickActionAvailability, CmdJQuickActionContext } from './quick-action-context'
 import {
@@ -157,6 +157,35 @@ export const getCmdJQuickActions = createLocalizedCatalog((): CmdJQuickAction[] 
         return { status: 'unavailable', reason: availability.reason }
       }
       ctx.deleteActiveWorkspace()
+      return { status: 'ok' }
+    }
+  },
+  {
+    id: 'toggle-pin-workspace',
+    kind: 'action',
+    title: translate(
+      'auto.components.cmd.j.quick.actions.togglePinWorkspace',
+      'Toggle Pin for Current Workspace'
+    ),
+    description: translate(
+      'auto.components.cmd.j.quick.actions.togglePinWorkspaceDescription',
+      'Pin or unpin the current workspace in the sidebar.'
+    ),
+    icon: Pin,
+    verbKeywords: [
+      translate('auto.components.cmd.j.quick.actions.verbs.togglePin', 'toggle pin'),
+      translate('auto.components.cmd.j.quick.actions.verbs.pinWorkspace', 'pin workspace'),
+      translate('auto.components.cmd.j.quick.actions.verbs.unpinWorkspace', 'unpin workspace'),
+      translate('auto.components.cmd.j.quick.actions.verbs.pin', 'pin'),
+      translate('auto.components.cmd.j.quick.actions.verbs.unpin', 'unpin')
+    ],
+    isAvailable: currentWorkspaceActionAvailability,
+    run: async (ctx) => {
+      const availability = currentWorkspaceActionAvailability(ctx)
+      if (!availability.available) {
+        return { status: 'unavailable', reason: availability.reason }
+      }
+      ctx.toggleActiveWorkspacePin()
       return { status: 'ok' }
     }
   },

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -737,6 +737,35 @@ describe('keybindings', () => {
     ).toBe(true)
   })
 
+  it('keeps workspace pin toggle unassigned until users customize it', () => {
+    const binding = {
+      key: 'p',
+      code: 'KeyP',
+      control: true,
+      meta: false,
+      alt: true,
+      shift: false
+    }
+
+    expect(getEffectiveKeybindingsForAction('workspace.togglePin', 'darwin')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('workspace.togglePin', 'linux')).toEqual([])
+    expect(getEffectiveKeybindingsForAction('workspace.togglePin', 'win32')).toEqual([])
+    expect(keybindingMatchesAction('workspace.togglePin', binding, 'linux')).toBe(false)
+    expect(
+      keybindingMatchesAction('workspace.togglePin', binding, 'linux', {
+        'workspace.togglePin': ['Mod+Alt+P']
+      })
+    ).toBe(true)
+
+    const definition = getKeybindingDefinition('workspace.togglePin')
+    expect(definition?.title).toBe('Toggle Pin for Current Workspace')
+    expect(definition?.scope).toBe('global')
+    expect(definition?.allowInTerminal).toBe(true)
+    expect(definition?.searchKeywords).toEqual(
+      expect.arrayContaining(['pin', 'unpin', 'workspace', 'worktree'])
+    )
+  })
+
   it('keeps workspace board unassigned until users customize it', () => {
     const binding = {
       key: 'k',

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -36,6 +36,7 @@ export type KeybindingActionId =
   | 'workspace.create'
   | 'workspace.rename'
   | 'workspace.delete'
+  | 'workspace.togglePin'
   | 'workspace.openBoard'
   | 'workspace.selectByIndex'
   | 'voice.dictation'
@@ -292,6 +293,26 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
       'trash'
     ],
     // Why: ship now without a default chord; user overrides still win when a future default is assigned.
+    defaultBindings: platformBindings([]),
+    allowInTerminal: true
+  },
+  {
+    id: 'workspace.togglePin',
+    title: 'Toggle Pin for Current Workspace',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: [
+      'shortcut',
+      'global',
+      'workspace',
+      'current workspace',
+      'worktree',
+      'pin',
+      'unpin',
+      'toggle pin',
+      'favorite'
+    ],
+    // Why: unbound by default so users assign a chord; matches Pin/Unpin on the worktree card.
     defaultBindings: platformBindings([]),
     allowInTerminal: true
   },

--- a/src/shared/plugins/plugin-command-actions.ts
+++ b/src/shared/plugins/plugin-command-actions.ts
@@ -10,6 +10,7 @@ export const PLUGIN_COMMAND_ALIAS_ACTION_IDS = [
   'floatingWorkspace.maximize',
   'tab.rename',
   'workspace.rename',
+  'workspace.togglePin',
   'workspace.openBoard',
   'view.tasks',
   'sidebar.right.toggle',

--- a/src/shared/workspace-pin-toggle.test.ts
+++ b/src/shared/workspace-pin-toggle.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorkspacePinToggleTarget } from './workspace-pin-toggle'
+
+describe('resolveWorkspacePinToggleTarget', () => {
+  it('returns the inverted pin state for a known workspace', () => {
+    expect(
+      resolveWorkspacePinToggleTarget({ worktreeId: 'wt-1', isPinned: false })
+    ).toEqual({ worktreeId: 'wt-1', nextPinned: true })
+    expect(
+      resolveWorkspacePinToggleTarget({ worktreeId: 'wt-1', isPinned: true })
+    ).toEqual({ worktreeId: 'wt-1', nextPinned: false })
+  })
+
+  it('no-ops without an active workspace id', () => {
+    expect(resolveWorkspacePinToggleTarget({ worktreeId: null, isPinned: false })).toBeNull()
+    expect(resolveWorkspacePinToggleTarget({ worktreeId: undefined, isPinned: true })).toBeNull()
+    expect(resolveWorkspacePinToggleTarget({ worktreeId: '', isPinned: false })).toBeNull()
+  })
+
+  it('no-ops when pin state is unknown (worktree not in store)', () => {
+    expect(resolveWorkspacePinToggleTarget({ worktreeId: 'wt-1', isPinned: null })).toBeNull()
+    expect(resolveWorkspacePinToggleTarget({ worktreeId: 'wt-1', isPinned: undefined })).toBeNull()
+  })
+})

--- a/src/shared/workspace-pin-toggle.ts
+++ b/src/shared/workspace-pin-toggle.ts
@@ -1,0 +1,15 @@
+export type WorkspacePinToggleTarget = {
+  worktreeId: string
+  nextPinned: boolean
+}
+
+/** Resolve pin toggle for the focused workspace; null when there is nothing to toggle. */
+export function resolveWorkspacePinToggleTarget(input: {
+  worktreeId: string | null | undefined
+  isPinned: boolean | null | undefined
+}): WorkspacePinToggleTarget | null {
+  if (!input.worktreeId || typeof input.isPinned !== 'boolean') {
+    return null
+  }
+  return { worktreeId: input.worktreeId, nextPinned: !input.isPinned }
+}


### PR DESCRIPTION
## Description
Add a bindable global shortcut (and Cmd+J action) to pin/unpin the focused workspace, matching the existing context-menu Pin/Unpin action.

## Focused fix
- In scope: `workspace.togglePin` keybinding, pure target resolver, App/Cmd+J wiring to `setWorktreesPinnedAndReveal`
- Out of scope: project-group pin (not a product surface), default chord

## Preserves
- Existing worktree pin store API and sidebar menu
- No default binding; works only when a focused worktree exists

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/keybindings.test.ts src/shared/workspace-pin-toggle.test.ts src/renderer/src/components/cmd-j/quick-action-context.test.ts` → 87 passed

## User-regression-tradeoffs
- Unbound by default; assign in Settings → Shortcuts

Fixes #11111