### PR TITLE
fix(terminal): keep worktree HISTFILE after macOS /etc/zshrc

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -147,6 +147,10 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
   expect(content).toContain('export ZDOTDIR="$_orca_home"')
+  // Why: re-apply worktree HISTFILE after macOS /etc/zshrc (#11044).
+  expect(content).toContain(
+    '[[ -n "${ORCA_HISTFILE:-}" ]] && export HISTFILE="${ORCA_HISTFILE}"'
+  )
 }
 
 describePosix('daemon shell-ready launch config', () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -799,6 +799,10 @@ export class LocalPtyProvider implements IPtyProvider {
         wslDistro: preferredWslContext?.distro ?? worktreeWslContext?.distro ?? null
       })
       logHistoryInjection(worktreeId, historyResult)
+    } else {
+      // Why: skip injectHistoryEnv — still drop inherited ORCA_HISTFILE so the
+      // zsh wrapper cannot re-export a prior worktree path over default history.
+      delete finalEnv.ORCA_HISTFILE
     }
 
     await prepareLocalPtySpawn(id)

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -340,6 +340,10 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
   expect(content).toContain('export ZDOTDIR="$_orca_home"')
+  // Why: re-apply worktree HISTFILE after macOS /etc/zshrc (#11044).
+  expect(content).toContain(
+    '[[ -n "${ORCA_HISTFILE:-}" ]] && export HISTFILE="${ORCA_HISTFILE}"'
+  )
 }
 
 describePosix('local PTY shell-ready launch config', () => {

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -169,5 +169,8 @@ esac
 # expose the same ZDOTDIR a normal zsh startup would expose.
 export ZDOTDIR="$_orca_home"
 unset _orca_home
+# Why: macOS /etc/zshrc sets HISTFILE relative to the still-wrapper ZDOTDIR
+# before this restore; re-apply the worktree-scoped path Orca injected at spawn.
+[[ -n "\${ORCA_HISTFILE:-}" ]] && export HISTFILE="\${ORCA_HISTFILE}"
 `
 }

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -158,6 +158,8 @@ describe('terminal-history', () => {
       expect(result.histFile).toContain('terminal-history')
       expect(result.histFile).toContain('zsh_history')
       expect(env.HISTFILE).toBe(result.histFile)
+      // Why: durable copy for zsh wrapper re-export after macOS /etc/zshrc (#11044).
+      expect(env.ORCA_HISTFILE).toBe(result.histFile)
     })
 
     it('injects HISTFILE for bash', () => {
@@ -169,6 +171,7 @@ describe('terminal-history', () => {
       expect(result.shell).toBe('bash')
       expect(result.histFile).toContain('bash_history')
       expect(env.HISTFILE).toBe(result.histFile)
+      expect(env.ORCA_HISTFILE).toBe(result.histFile)
     })
 
     it('produces different HISTFILE for different worktreeIds', () => {
@@ -189,6 +192,7 @@ describe('terminal-history', () => {
       const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/zsh', '/path/wt')
 
       expect(env.HISTFILE).toBe('/my/custom/histfile')
+      expect(env.ORCA_HISTFILE).toBeUndefined()
       expect(result.histFile).toBeNull()
     })
 
@@ -197,6 +201,7 @@ describe('terminal-history', () => {
       const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/tcsh', '/path/wt')
 
       expect(env.HISTFILE).toBeUndefined()
+      expect(env.ORCA_HISTFILE).toBeUndefined()
       expect(result.shell).toBe('unknown')
       expect(result.histFile).toBeNull()
     })
@@ -227,6 +232,7 @@ describe('terminal-history', () => {
       const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/zsh', '/path/wt')
 
       expect(env.HISTFILE).toBeUndefined()
+      expect(env.ORCA_HISTFILE).toBeUndefined()
       expect(result.histFile).toBeNull()
     })
   })
@@ -234,24 +240,29 @@ describe('terminal-history', () => {
   describe('updateHistFileForFallback', () => {
     it('updates HISTFILE to match fallback shell', () => {
       const env: Record<string, string> = {
-        HISTFILE: '/fake/userData/terminal-history/abc123/zsh_history'
+        HISTFILE: '/fake/userData/terminal-history/abc123/zsh_history',
+        ORCA_HISTFILE: '/fake/userData/terminal-history/abc123/zsh_history'
       }
       updateHistFileForFallback(env, '/bin/bash')
       expect(env.HISTFILE).toBe('/fake/userData/terminal-history/abc123/bash_history')
+      expect(env.ORCA_HISTFILE).toBe('/fake/userData/terminal-history/abc123/bash_history')
     })
 
     it('removes HISTFILE for unknown fallback shell', () => {
       const env: Record<string, string> = {
-        HISTFILE: '/fake/userData/terminal-history/abc123/zsh_history'
+        HISTFILE: '/fake/userData/terminal-history/abc123/zsh_history',
+        ORCA_HISTFILE: '/fake/userData/terminal-history/abc123/zsh_history'
       }
       updateHistFileForFallback(env, '/bin/sh')
       expect(env.HISTFILE).toBeUndefined()
+      expect(env.ORCA_HISTFILE).toBeUndefined()
     })
 
     it('is a no-op when HISTFILE is not set', () => {
       const env: Record<string, string> = {}
       updateHistFileForFallback(env, '/bin/bash')
       expect(env.HISTFILE).toBeUndefined()
+      expect(env.ORCA_HISTFILE).toBeUndefined()
     })
   })
 

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -196,6 +196,31 @@ describe('terminal-history', () => {
       expect(result.histFile).toBeNull()
     })
 
+    it('clears stale ORCA_HISTFILE when caller provides HISTFILE', () => {
+      // Why: inherited ORCA_HISTFILE must not win over check-before-set HISTFILE
+      // via the zsh wrapper re-export after /etc/zshrc (CodeRabbit #11146).
+      const env: Record<string, string> = {
+        HISTFILE: '/my/custom/histfile',
+        ORCA_HISTFILE: '/stale/orca/worktree/zsh_history'
+      }
+      const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/zsh', '/path/wt')
+
+      expect(env.HISTFILE).toBe('/my/custom/histfile')
+      expect(env.ORCA_HISTFILE).toBeUndefined()
+      expect(result.histFile).toBeNull()
+    })
+
+    it('clears stale ORCA_HISTFILE for unsupported shells', () => {
+      const env: Record<string, string> = {
+        ORCA_HISTFILE: '/stale/orca/worktree/zsh_history'
+      }
+      const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/usr/bin/fish', '/path/wt')
+
+      expect(env.HISTFILE).toBeUndefined()
+      expect(env.ORCA_HISTFILE).toBeUndefined()
+      expect(result.histFile).toBeNull()
+    })
+
     it('does not inject HISTFILE for unknown shells', () => {
       const env: Record<string, string> = {}
       const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/tcsh', '/path/wt')
@@ -228,7 +253,9 @@ describe('terminal-history', () => {
         throw new Error('disk full')
       })
 
-      const env: Record<string, string> = {}
+      const env: Record<string, string> = {
+        ORCA_HISTFILE: '/stale/orca/worktree/zsh_history'
+      }
       const result = injectHistoryEnv(env, 'repo-1::/path/wt', '/bin/zsh', '/path/wt')
 
       expect(env.HISTFILE).toBeUndefined()

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -168,6 +168,9 @@ export function injectHistoryEnv(
 
   // For WSL, convert the Windows path to a Linux-visible path.
   spawnEnv.HISTFILE = wslDistro ? toLinuxPath(histFilePath) : histFilePath
+  // Why: macOS /etc/zshrc reassigns HISTFILE under ZDOTDIR (the shell-ready
+  // wrapper). Keep a stable copy so the zsh wrapper can re-export after startup.
+  spawnEnv.ORCA_HISTFILE = spawnEnv.HISTFILE
 
   result.histFile = spawnEnv.HISTFILE
   return result
@@ -190,12 +193,16 @@ export function updateHistFileForFallback(
     // Fallback to an unknown shell — remove HISTFILE override entirely
     // so the shell uses its own default.
     delete spawnEnv.HISTFILE
+    delete spawnEnv.ORCA_HISTFILE
     return
   }
 
   // Replace the filename portion of the HISTFILE path.
   const dir = spawnEnv.HISTFILE.replace(/[/\\][^/\\]+$/, '')
   spawnEnv.HISTFILE = `${dir}/${newFilename}`
+  if (spawnEnv.ORCA_HISTFILE) {
+    spawnEnv.ORCA_HISTFILE = spawnEnv.HISTFILE
+  }
 }
 
 /** Log the history injection result for diagnostics. */

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -138,15 +138,24 @@ export function injectHistoryEnv(
   const shell = resolveShellKind(shellPath)
   const result: HistoryInjectionResult = { shell, histFile: null }
 
+  // Why: only set ORCA_HISTFILE when we inject HISTFILE this spawn. A stale
+  // value (inherited env, prior path) would make the zsh wrapper re-export it
+  // over a caller-provided HISTFILE or when history is not scoped (#11044 CR).
+  const clearOrcaHistFile = (): void => {
+    delete spawnEnv.ORCA_HISTFILE
+  }
+
   const filename = historyFilename(shell)
   if (!filename) {
-    // Unknown shell or Phase 2 shell (fish, pwsh, cmd) — leave unchanged.
+    // Unknown shell or Phase 2 shell (fish, pwsh, cmd) — leave HISTFILE alone.
+    clearOrcaHistFile()
     return result
   }
 
   // Check-before-set: if the caller already provided HISTFILE, preserve it.
   // This follows the pattern used by Ghostty, Kitty, and VS Code (§6).
   if (spawnEnv.HISTFILE) {
+    clearOrcaHistFile()
     return result
   }
 
@@ -159,6 +168,7 @@ export function injectHistoryEnv(
   const histDir = ensureHistoryDir(worktreeHash, wslDistro)
   if (!histDir) {
     // Directory creation failed — degrade gracefully to shared history.
+    clearOrcaHistFile()
     return result
   }
 

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -53,6 +53,10 @@ function expectZdotdirSourceContext(content: string, fileName: '.zprofile' | '.z
 function expectFinalZdotdirRestoreContext(content: string) {
   expect(content).toContain("after Orca's last wrapper file has loaded")
   expect(content).toContain('export ZDOTDIR="$_orca_home"')
+  // Why: re-apply worktree HISTFILE after macOS /etc/zshrc (#11044).
+  expect(content).toContain(
+    '[[ -n "${ORCA_HISTFILE:-}" ]] && export HISTFILE="${ORCA_HISTFILE}"'
+  )
 }
 
 describe('getRelayShellLaunchConfig', () => {


### PR DESCRIPTION
## Description
Worktree-scoped zsh history no longer lands in Orca's shell-ready sandbox on macOS after Apple's `/etc/zshrc` overwrites `HISTFILE`.

## Focused fix
- In scope: set durable `ORCA_HISTFILE` in `injectHistoryEnv`; re-export `HISTFILE` from it in the shared zsh final ZDOTDIR restore block (local/daemon/relay)
- Out of scope: bash/fish history redesign, opting into shared global history

## Preserves
- Check-before-set: caller-provided `HISTFILE` is still respected (no `ORCA_HISTFILE` then)
- Worktree history only when Orca injects; no change when history scoping is off

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/main/terminal-history.test.ts src/main/providers/local-pty-shell-ready.test.ts src/main/daemon/shell-ready.test.ts src/relay/pty-shell-launch.test.ts`
- Unit/wrapper-content assertions for `ORCA_HISTFILE` re-export green (some node-pty interactive PTY tests may need full native rebuild in CI)

## User-regression-tradeoffs
- Final HISTFILE is forced back to Orca's worktree path when `ORCA_HISTFILE` is set; intentional for the #620 worktree history feature on macOS

Fixes #11044