### PR TITLE
fix(git): use workspace agent for first-work branch rename

### DIFF
--- a/src/main/agent-hooks/branch-rename-generation-agent.test.ts
+++ b/src/main/agent-hooks/branch-rename-generation-agent.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  asSupportedBranchRenameAgent,
+  pickBranchRenameGenerationAgent
+} from './branch-rename-generation-agent'
+
+describe('asSupportedBranchRenameAgent', () => {
+  it('accepts agents with a Source Control AI generation contract', () => {
+    expect(asSupportedBranchRenameAgent('claude')).toBe('claude')
+    expect(asSupportedBranchRenameAgent('codex')).toBe('codex')
+  })
+
+  it('rejects missing, blank, and unknown agents', () => {
+    expect(asSupportedBranchRenameAgent(undefined)).toBeUndefined()
+    expect(asSupportedBranchRenameAgent(null)).toBeUndefined()
+    expect(asSupportedBranchRenameAgent('')).toBeUndefined()
+    expect(asSupportedBranchRenameAgent('not-an-agent')).toBeUndefined()
+  })
+
+  it('rejects known TUI agents without a generation contract', () => {
+    // claude-agent-teams is launchable but has no non-interactive SC AI spec.
+    expect(asSupportedBranchRenameAgent('claude-agent-teams')).toBeUndefined()
+  })
+})
+
+describe('pickBranchRenameGenerationAgent', () => {
+  it('prefers a supported workspace agent over the configured SC AI default', () => {
+    expect(pickBranchRenameGenerationAgent('codex', 'claude')).toBe('claude')
+  })
+
+  it('keeps the configured agent when the workspace agent is unsupported', () => {
+    expect(pickBranchRenameGenerationAgent('codex', 'claude-agent-teams')).toBe('codex')
+    expect(pickBranchRenameGenerationAgent('codex', undefined)).toBe('codex')
+    expect(pickBranchRenameGenerationAgent('custom', 'not-an-agent')).toBe('custom')
+  })
+
+  it('keeps a custom configured agent when workspace has no supported generation agent', () => {
+    expect(pickBranchRenameGenerationAgent('custom', undefined)).toBe('custom')
+  })
+})

--- a/src/main/agent-hooks/branch-rename-generation-agent.ts
+++ b/src/main/agent-hooks/branch-rename-generation-agent.ts
@@ -1,0 +1,24 @@
+import type { TuiAgent } from '../../shared/types'
+import { isTuiAgent } from '../../shared/tui-agent-config'
+import { getCommitMessageAgentSpec } from '../../shared/commit-message-agent-spec'
+
+/** Workspace agent when it has a non-interactive SC AI generation contract. */
+export function asSupportedBranchRenameAgent(
+  workspaceAgent: string | null | undefined
+): TuiAgent | undefined {
+  if (!workspaceAgent || !isTuiAgent(workspaceAgent)) {
+    return undefined
+  }
+  return getCommitMessageAgentSpec(workspaceAgent) ? workspaceAgent : undefined
+}
+
+/**
+ * Prefer the workspace/selected agent for first-work branch rename when it
+ * supports Source Control AI text generation; otherwise keep the configured SC AI agent.
+ */
+export function pickBranchRenameGenerationAgent(
+  configuredAgentId: TuiAgent | 'custom',
+  workspaceAgent: string | null | undefined
+): TuiAgent | 'custom' {
+  return asSupportedBranchRenameAgent(workspaceAgent) ?? configuredAgentId
+}

--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -93,10 +93,56 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
       expect.anything(),
       'local',
       'branchName',
-      expect.objectContaining({ id: REPO_ID })
+      expect.objectContaining({ id: REPO_ID }),
+      expect.objectContaining({ preferredAgentId: undefined })
     )
     expect(setDisplayName).toHaveBeenCalledWith(WORKTREE_ID, 'Fix auth')
     expect(onRenamed).toHaveBeenCalledWith(REPO_ID)
+  })
+
+  it('prefers the workspace agent over the configured Source Control AI default', async () => {
+    // Issue #11009: Codex is the SC AI default (out of usage) but Claude was selected
+    // for the new workspace — rename must generate with Claude, not Codex.
+    resolveTextGenerationParamsMock.mockReturnValue({
+      ok: true,
+      params: { agentId: 'claude', model: 'sonnet' }
+    })
+    const { deps } = makeDeps()
+    await maybeAutoRenameBranchOnFirstWork(workingEvent({ agentType: 'claude' }), deps)
+    expect(resolveTextGenerationParamsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'local',
+      'branchName',
+      expect.objectContaining({ id: REPO_ID }),
+      { preferredAgentId: 'claude' }
+    )
+    expect(generateBranchNameMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { agentId: 'claude', model: 'sonnet' },
+      expect.anything()
+    )
+  })
+
+  it('falls back to the configured agent when the workspace agent is unsupported', async () => {
+    resolveTextGenerationParamsMock.mockReturnValue({
+      ok: true,
+      params: { agentId: 'codex', model: 'gpt-5.5' }
+    })
+    const { deps } = makeDeps()
+    // claude-agent-teams is launchable but has no non-interactive generation contract.
+    await maybeAutoRenameBranchOnFirstWork(workingEvent({ agentType: 'claude-agent-teams' }), deps)
+    expect(resolveTextGenerationParamsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'local',
+      'branchName',
+      expect.objectContaining({ id: REPO_ID }),
+      { preferredAgentId: undefined }
+    )
+    expect(generateBranchNameMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { agentId: 'codex', model: 'gpt-5.5' },
+      expect.anything()
+    )
   })
 
   it('asks to align the on-disk folder with the generated slug after renaming', async () => {
@@ -226,10 +272,38 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
       expect.anything(),
       'local',
       'branchName',
-      null
+      null,
+      expect.objectContaining({ preferredAgentId: undefined })
     )
     expect(setDisplayName).toHaveBeenCalledWith(FOLDER_WORKTREE_ID, 'Fix auth')
     expect(onRenamed).toHaveBeenCalledWith(FOLDER_WORKTREE_ID)
+  })
+
+  it('prefers the workspace agent when renaming a folder workspace title', async () => {
+    resolveTextGenerationParamsMock.mockReturnValue({
+      ok: true,
+      params: { agentId: 'claude', model: 'sonnet' }
+    })
+    const { deps, setDisplayName } = makeDeps({
+      resolveWorktreeIdForTab: () => FOLDER_WORKTREE_ID,
+      getFolderWorkspacePath: () => '/workspace/platform',
+      isPendingFirstAgentMessageRename: () => true,
+      getCurrentDisplayName: () => 'Platform workspace'
+    })
+
+    await maybeAutoRenameBranchOnFirstWork(
+      workingEvent({ prompt: 'Fix auth from note #1', agentType: 'claude' }),
+      deps
+    )
+
+    expect(resolveTextGenerationParamsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'local',
+      'branchName',
+      null,
+      { preferredAgentId: 'claude' }
+    )
+    expect(setDisplayName).toHaveBeenCalledWith(FOLDER_WORKTREE_ID, 'Fix auth')
   })
 
   it('does not rename folder workspace titles without the pending marker', async () => {

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -25,6 +25,7 @@ import {
 } from '../text-generation/commit-message-text-generation'
 import type { CommitMessageAgentEnvironmentResolvers } from '../text-generation/commit-message-agent-environment'
 import type { AgentGenerationFailureOutput } from '../text-generation/agent-failure-output'
+import { asSupportedBranchRenameAgent } from './branch-rename-generation-agent'
 import { resolveGenerationTarget } from './first-work-generation-target'
 import { runFolderWorkspaceTitleAutoRename } from './first-work-workspace-title-rename'
 
@@ -37,6 +38,8 @@ export type FirstWorkBranchRenameEvent = {
   prompt: string | undefined
   assistantMessage: string | undefined
   isReplay: boolean | undefined
+  /** Agent that did the first work (status hook); preferred for rename generation. */
+  agentType?: string
 }
 
 export type FirstWorkBranchRenameDeps = {
@@ -119,7 +122,13 @@ export async function maybeAutoRenameBranchOnFirstWork(
   inFlightWorktreeIds.add(worktreeId)
   try {
     // settled = definitive verdict (renamed/ineligible); false = transient bail to retry later.
-    const settled = await runAutoRename(worktreeId, prompt, event.assistantMessage, deps)
+    const settled = await runAutoRename(
+      worktreeId,
+      prompt,
+      event.assistantMessage,
+      deps,
+      event.agentType
+    )
     if (settled) {
       rememberSettledWorktreeId(worktreeId)
     }
@@ -136,7 +145,8 @@ async function runAutoRename(
   worktreeId: string,
   prompt: string,
   assistantMessage: string | undefined,
-  deps: FirstWorkBranchRenameDeps
+  deps: FirstWorkBranchRenameDeps,
+  workspaceAgentType: string | undefined
 ): Promise<boolean> {
   // `stop` = permanent skip (logs which gate bailed); `retry` = transient; `clearError` drops a stale "rename failed" badge on a benign final state.
   const stop = (reason: string, clearError = false): true => {
@@ -159,7 +169,8 @@ async function runAutoRename(
       assistantMessage,
       deps,
       stop,
-      retry
+      retry,
+      workspaceAgentType
     )
   }
 
@@ -208,7 +219,11 @@ async function runAutoRename(
 
   const settings = deps.getSettings()
   const hostKey = getCommitMessageModelDiscoveryHostKey(repo.connectionId ?? null)
-  const resolvedParams = resolveTextGenerationParams(settings, hostKey, 'branchName', repo)
+  // Prefer the agent that actually did first work over the global SC AI default.
+  const preferredAgentId = asSupportedBranchRenameAgent(workspaceAgentType)
+  const resolvedParams = resolveTextGenerationParams(settings, hostKey, 'branchName', repo, {
+    preferredAgentId
+  })
   if (!resolvedParams.ok) {
     // Why: a generation-step failure (vs a benign skip) is user-actionable, so surface it on the card.
     deps.setRenameError(worktreeId, resolvedParams.error)

--- a/src/main/agent-hooks/first-work-workspace-title-rename.ts
+++ b/src/main/agent-hooks/first-work-workspace-title-rename.ts
@@ -3,6 +3,7 @@ import {
   generateBranchNameFromContext,
   resolveTextGenerationParams
 } from '../text-generation/commit-message-text-generation'
+import { asSupportedBranchRenameAgent } from './branch-rename-generation-agent'
 import { resolveGenerationTarget } from './first-work-generation-target'
 import type { FirstWorkBranchRenameDeps } from './first-work-branch-rename'
 
@@ -17,7 +18,8 @@ export async function runFolderWorkspaceTitleAutoRename(
   assistantMessage: string | undefined,
   deps: FirstWorkBranchRenameDeps,
   stop: (reason: string, clearError?: boolean) => true,
-  retry: (reason: string) => false
+  retry: (reason: string) => false,
+  workspaceAgentType?: string
 ): Promise<boolean> {
   if (deps.isPendingFirstAgentMessageRename?.(worktreeId) !== true) {
     return stop('folder workspace is not pending title rename', true)
@@ -28,7 +30,10 @@ export async function runFolderWorkspaceTitleAutoRename(
   }
 
   const settings = deps.getSettings()
-  const resolvedParams = resolveTextGenerationParams(settings, 'local', 'branchName', null)
+  const preferredAgentId = asSupportedBranchRenameAgent(workspaceAgentType)
+  const resolvedParams = resolveTextGenerationParams(settings, 'local', 'branchName', null, {
+    preferredAgentId
+  })
   if (!resolvedParams.ok) {
     deps.setRenameError(worktreeId, resolvedParams.error)
     return stop(`no generation agent: ${resolvedParams.error}`)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -377,7 +377,12 @@ function maybeAutoRenameBranchOnFirstWorkFromHook(event: {
   paneKey: string
   tabId: string | undefined
   worktreeId: string | undefined
-  payload: { state: string; prompt?: string; lastAssistantMessage?: string }
+  payload: {
+    state: string
+    prompt?: string
+    lastAssistantMessage?: string
+    agentType?: string
+  }
   isReplay: boolean | undefined
 }): void {
   const currentStore = store
@@ -393,7 +398,8 @@ function maybeAutoRenameBranchOnFirstWorkFromHook(event: {
       state: event.payload.state,
       prompt: event.payload.prompt,
       assistantMessage: event.payload.lastAssistantMessage,
-      isReplay: event.isReplay
+      isReplay: event.isReplay,
+      agentType: event.payload.agentType
     },
     {
       getSettings: () => currentStore.getSettings(),

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -131,17 +131,28 @@ export function trimGeneratedCommitMessage(message: string): string {
   return message.replace(/\s+$/, '')
 }
 
+export type ResolveTextGenerationOptions = {
+  /**
+   * Prefer this agent when it supports non-interactive SC AI generation.
+   * Used by first-work branch rename so the workspace-selected agent wins over
+   * the global Source Control AI default.
+   */
+  preferredAgentId?: TuiAgent | null
+}
+
 export function resolveCommitMessageSettings(
   settings: GlobalSettings,
   discoveryHostKey = LOCAL_COMMIT_MESSAGE_HOST_KEY,
   operation: SourceControlAiOperation = 'commitMessage',
-  repo?: Pick<Repo, 'sourceControlAi'> | null
+  repo?: Pick<Repo, 'sourceControlAi'> | null,
+  options?: ResolveTextGenerationOptions
 ): ResolveCommitMessageSettingsResult {
   const resolved = resolveSourceControlAiForOperation({
     settings,
     repo,
     operation,
-    discoveryHostKey
+    discoveryHostKey,
+    ...(options?.preferredAgentId ? { preferredAgentId: options.preferredAgentId } : {})
   })
   return resolved.ok ? { ok: true, params: resolved.value.params } : resolved
 }
@@ -150,9 +161,10 @@ export function resolveTextGenerationParams(
   settings: GlobalSettings,
   discoveryHostKey = LOCAL_COMMIT_MESSAGE_HOST_KEY,
   operation: SourceControlAiOperation = 'commitMessage',
-  repo?: Pick<Repo, 'sourceControlAi'> | null
+  repo?: Pick<Repo, 'sourceControlAi'> | null,
+  options?: ResolveTextGenerationOptions
 ): ResolveCommitMessageSettingsResult {
-  return resolveCommitMessageSettings(settings, discoveryHostKey, operation, repo)
+  return resolveCommitMessageSettings(settings, discoveryHostKey, operation, repo, options)
 }
 
 function formatAgentCliFailureMessage(

--- a/src/shared/source-control-ai.test.ts
+++ b/src/shared/source-control-ai.test.ts
@@ -66,6 +66,38 @@ describe('source-control AI resolution', () => {
     expect(resolve('branchName').params.model).toBe('gpt-5.5')
   })
 
+  it('prefers a supported preferredAgentId over the configured SC AI agent', () => {
+    // First-work branch rename: workspace selected Claude while SC AI default is Codex.
+    const result = resolveSourceControlAiForOperation({
+      settings: settings(),
+      repo: null,
+      operation: 'branchName',
+      discoveryHostKey: 'local',
+      preferredAgentId: 'claude'
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      throw new Error(result.error)
+    }
+    expect(result.value.params.agentId).toBe('claude')
+    expect(result.value.params.model).toBeTruthy()
+  })
+
+  it('ignores preferredAgentId when the agent lacks a generation contract', () => {
+    const result = resolveSourceControlAiForOperation({
+      settings: settings(),
+      repo: null,
+      operation: 'branchName',
+      discoveryHostKey: 'local',
+      preferredAgentId: 'claude-agent-teams'
+    })
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      throw new Error(result.error)
+    }
+    expect(result.value.params.agentId).toBe('codex')
+  })
+
   it('resolves generation config and PR defaults when Source Control AI actions are hidden', () => {
     const base = settings()
     base.sourceControlAi = {

--- a/src/shared/source-control-ai.ts
+++ b/src/shared/source-control-ai.ts
@@ -76,6 +76,12 @@ type ResolveSourceControlAiInput = {
   operation: SourceControlAiOperation
   discoveryHostKey?: string
   prCreationProductDefaults?: SourceControlAiPrCreationDefaults
+  /**
+   * When set and the agent has a non-interactive SC AI contract, prefer it over
+   * the configured Source Control AI agent for this resolve only (e.g. first-work
+   * branch rename should use the workspace-selected agent).
+   */
+  preferredAgentId?: TuiAgent | null
 }
 
 export type ResolveSourceControlAiPrCreationDefaultsInput = {
@@ -1214,7 +1220,16 @@ export function resolveSourceControlAiForOperation(
   }
   // Why: action recipes own the new customization model. The legacy global
   // agent remains a fallback so existing users migrate without losing intent.
-  const preferredAgent = hasActionAgentRecipe(actionRecipe) ? actionRecipe.agentId : source.agentId
+  // Callers (first-work branch rename) may prefer the workspace-selected agent
+  // when it supports non-interactive generation so rename doesn't burn a
+  // default agent the user already exhausted.
+  const usePreferredWorkspaceAgent =
+    !!input.preferredAgentId && !!getCommitMessageAgentSpec(input.preferredAgentId)
+  const preferredAgent = usePreferredWorkspaceAgent
+    ? input.preferredAgentId
+    : hasActionAgentRecipe(actionRecipe)
+      ? actionRecipe.agentId
+      : source.agentId
   const agentChoice = resolveCommitMessageAgentChoice(
     preferredAgent,
     input.settings.defaultTuiAgent,
@@ -1259,7 +1274,9 @@ export function resolveSourceControlAiForOperation(
   }
 
   const agentId = agentChoice
-  const actionAgentId = actionRecipe.agentId ?? agentId
+  // Why: a workspace preferred agent must not be re-overridden by a branchName
+  // action recipe that still points at the exhausted default agent.
+  const actionAgentId = usePreferredWorkspaceAgent ? agentId : (actionRecipe.agentId ?? agentId)
   const resolvedActionAgentId =
     actionAgentId === agentId
       ? agentId


### PR DESCRIPTION
## Description
First-work auto branch rename prefers the workspace/selected agent (hook `agentType`) over the global Source Control AI default, so rename no longer fails against a default agent without remaining usage.

## Focused fix
- In scope: preferred-agent override for `branchName` generation; pure picker; wire from status hook; same for folder title rename
- Out of scope: changing commit-message / PR-title generation defaults when no preferred agent is provided

## Preserves
- Unsupported workspace agents fall back to configured SC AI
- Commit-message and other SC AI operations unchanged unless `preferredAgentId` is passed

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/first-work-branch-rename.test.ts src/main/agent-hooks/branch-rename-generation-agent.test.ts src/shared/source-control-ai.test.ts` → 68 passed

## User-regression-tradeoffs
- When both workspace agent and SC AI default are set, workspace agent wins for rename slug generation (matches user expectation from Create Workspace agent picker)

Fixes #11009