### PR TITLE
feat(jira): add saved JQL filters

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -8,6 +8,12 @@ import {
   MAX_QUICK_COMMAND_TERMINAL_TEXT_LENGTH
 } from '../../../../shared/terminal-quick-commands'
 import type { PersistedUIState } from '../../../../shared/types'
+import {
+  MAX_JIRA_SAVED_FILTERS,
+  MAX_JIRA_SAVED_FILTER_ID_LENGTH,
+  MAX_JIRA_SAVED_FILTER_JQL_LENGTH,
+  MAX_JIRA_SAVED_FILTER_NAME_LENGTH
+} from '../../../../shared/jira-saved-filters'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { RpcRequest } from '../core'
 import { RpcDispatcher } from '../dispatcher'
@@ -446,7 +452,9 @@ describe('client UI RPC methods', () => {
           model: 'project'
         },
         jiraPreset: 'assigned',
-        jiraQuery: 'ENG'
+        jiraQuery: 'ENG',
+        jiraSavedFilters: [{ id: 'filter-1', name: 'My work', jql: 'project = ENG' }],
+        jiraActiveSavedFilterId: 'filter-1'
       },
       workspaceCleanup: {
         dismissals: {
@@ -497,7 +505,9 @@ describe('client UI RPC methods', () => {
           model: 'project'
         },
         jiraPreset: 'assigned',
-        jiraQuery: 'ENG'
+        jiraQuery: 'ENG',
+        jiraSavedFilters: [{ id: 'filter-1', name: 'My work', jql: 'project = ENG' }],
+        jiraActiveSavedFilterId: 'filter-1'
       },
       workspaceCleanup: {
         dismissals: {
@@ -544,6 +554,18 @@ describe('client UI RPC methods', () => {
     ],
     ['taskResumeState.jiraPreset', { taskResumeState: { jiraPreset: 'assigned' } }],
     ['taskResumeState.jiraQuery', { taskResumeState: { jiraQuery: 'ENG' } }],
+    [
+      'taskResumeState.jiraSavedFilters',
+      {
+        taskResumeState: {
+          jiraSavedFilters: [{ id: 'filter-1', name: 'My work', jql: 'project = ENG' }]
+        }
+      }
+    ],
+    [
+      'taskResumeState.jiraActiveSavedFilterId',
+      { taskResumeState: { jiraActiveSavedFilterId: null } }
+    ],
     ['activeView', { activeView: 'tasks' }],
     ['showDotfilesByWorktree', { showDotfilesByWorktree: { 'repo::/worktree': true } }],
     ['setupGuideSidebarDismissed', { setupGuideSidebarDismissed: true }],
@@ -630,6 +652,64 @@ describe('client UI RPC methods', () => {
 
     const response = await dispatcher.dispatch(
       makeRequest('ui.set', { showActiveOnly: 'yes', unknownField: true })
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+    expect(runtime.updateUIState).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [
+      'too many saved filters',
+      Array.from({ length: MAX_JIRA_SAVED_FILTERS + 1 }, (_, index) => ({
+        id: `filter-${index}`,
+        name: `Filter ${index}`,
+        jql: `project = P${index}`
+      }))
+    ],
+    [
+      'an oversized id',
+      [
+        {
+          id: 'x'.repeat(MAX_JIRA_SAVED_FILTER_ID_LENGTH + 1),
+          name: 'My work',
+          jql: 'project = ENG'
+        }
+      ]
+    ],
+    [
+      'an oversized name',
+      [
+        {
+          id: 'filter-1',
+          name: 'x'.repeat(MAX_JIRA_SAVED_FILTER_NAME_LENGTH + 1),
+          jql: 'project = ENG'
+        }
+      ]
+    ],
+    [
+      'oversized JQL',
+      [
+        {
+          id: 'filter-1',
+          name: 'My work',
+          jql: 'x'.repeat(MAX_JIRA_SAVED_FILTER_JQL_LENGTH + 1)
+        }
+      ]
+    ],
+    [
+      'an unknown nested field',
+      [{ id: 'filter-1', name: 'My work', jql: 'project = ENG', unknown: true }]
+    ]
+  ])('rejects Jira saved filters with %s', async (_label, jiraSavedFilters) => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateUIState: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('ui.set', { taskResumeState: { jiraSavedFilters } })
     )
 
     expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })

--- a/src/main/runtime/rpc/methods/task-resume-state-schema.ts
+++ b/src/main/runtime/rpc/methods/task-resume-state-schema.ts
@@ -1,6 +1,20 @@
 import { z } from 'zod'
 import type { TaskResumeState as TaskResumeStateType } from '../../../../shared/types'
 import type { AssertNoMissingKeys } from './ui-state-schema-parity'
+import {
+  MAX_JIRA_SAVED_FILTERS,
+  MAX_JIRA_SAVED_FILTER_ID_LENGTH,
+  MAX_JIRA_SAVED_FILTER_JQL_LENGTH,
+  MAX_JIRA_SAVED_FILTER_NAME_LENGTH
+} from '../../../../shared/jira-saved-filters'
+
+const JiraSavedFilter = z
+  .object({
+    id: z.string().trim().min(1).max(MAX_JIRA_SAVED_FILTER_ID_LENGTH),
+    name: z.string().trim().min(1).max(MAX_JIRA_SAVED_FILTER_NAME_LENGTH),
+    jql: z.string().trim().min(1).max(MAX_JIRA_SAVED_FILTER_JQL_LENGTH)
+  })
+  .strict()
 
 /** Tasks page-position state persisted through `ui.set`; mirrors `TaskResumeState`. */
 export const TaskResumeState = z
@@ -22,7 +36,15 @@ export const TaskResumeState = z
       .strict()
       .optional(),
     jiraPreset: z.enum(['assigned', 'reported', 'all', 'done']).optional(),
-    jiraQuery: z.string().optional()
+    jiraQuery: z.string().optional(),
+    jiraSavedFilters: z.array(JiraSavedFilter).max(MAX_JIRA_SAVED_FILTERS).optional(),
+    jiraActiveSavedFilterId: z
+      .string()
+      .trim()
+      .min(1)
+      .max(MAX_JIRA_SAVED_FILTER_ID_LENGTH)
+      .nullable()
+      .optional()
   })
   .strict()
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -160,6 +160,7 @@ import {
 } from '@/components/linear-project-view-surfaces'
 import JiraIssueWorkspace from '@/components/JiraIssueWorkspace'
 import { TaskPageJiraIssueList } from '@/components/task-page-jira-issue-list'
+import { TaskPageJiraSavedFilters } from '@/components/TaskPageJiraSavedFilters'
 import {
   getSingleJiraProjectScope,
   getTaskPageJiraStatusOrderScopeKey,
@@ -167,6 +168,12 @@ import {
 } from '@/components/task-page-jira-status-order'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { cn } from '@/lib/utils'
+import { createBrowserUuid } from '@/lib/browser-uuid'
+import {
+  MAX_JIRA_SAVED_FILTERS,
+  normalizeJiraSavedFilters,
+  type JiraSavedFilter
+} from '../../../shared/jira-saved-filters'
 import {
   getLinkedWorkItemSuggestedName,
   getLinkedWorkItemWorkspaceName,
@@ -383,6 +390,7 @@ function isGitLabIssueFilter(
 const TASK_SEARCH_DEBOUNCE_MS = 300
 const LINEAR_ITEM_LIMIT = 36
 const JIRA_ITEM_LIMIT = 50
+const EMPTY_JIRA_SAVED_FILTERS: JiraSavedFilter[] = []
 const PR_CHECKS_EAGER_PREFETCH_LIMIT = 20
 
 const GITHUB_TASK_GRID_CLASS =
@@ -4527,7 +4535,9 @@ export default function TaskPage(): React.JSX.Element {
   const [jiraSearchInput, setJiraSearchInput] = useState('')
   const [appliedJiraSearch, setAppliedJiraSearch] = useState('')
   const [activeJiraPreset, setActiveJiraPreset] = useState<JiraPresetId>('assigned')
+  const [activeJiraSavedFilterId, setActiveJiraSavedFilterId] = useState<string | null>(null)
   const [jiraRefreshNonce, setJiraRefreshNonce] = useState(0)
+  const jiraSavedFilters = taskResumeState?.jiraSavedFilters ?? EMPTY_JIRA_SAVED_FILTERS
   const [jiraProjectStatusOrder, setJiraProjectStatusOrder] = useState<{
     order: JiraProjectStatusOrder
     scopeKey: string
@@ -4631,6 +4641,7 @@ export default function TaskPage(): React.JSX.Element {
     const jiraPreset = taskResumeState?.jiraPreset ?? 'assigned'
     const jiraQuery = taskResumeState?.jiraQuery ?? ''
     setActiveJiraPreset(jiraPreset)
+    setActiveJiraSavedFilterId(taskResumeState?.jiraActiveSavedFilterId ?? null)
     setJiraSearchInput(jiraQuery)
     setAppliedJiraSearch(jiraQuery)
 
@@ -7678,6 +7689,85 @@ export default function TaskPage(): React.JSX.Element {
     taskSource
   ])
 
+  const applyJiraSavedFilter = useCallback(
+    (filter: JiraSavedFilter) => {
+      setActiveJiraSavedFilterId(filter.id)
+      setJiraSearchInput(filter.jql)
+      setAppliedJiraSearch(filter.jql)
+      setTaskResumeState({
+        jiraSavedFilters,
+        jiraActiveSavedFilterId: filter.id,
+        jiraQuery: filter.jql
+      })
+      setJiraRefreshNonce((nonce) => nonce + 1)
+    },
+    [jiraSavedFilters, setTaskResumeState]
+  )
+
+  const createJiraSavedFilter = useCallback(
+    (draft: { name: string; jql: string }) => {
+      if (jiraSavedFilters.length >= MAX_JIRA_SAVED_FILTERS) {
+        return
+      }
+      const id = createBrowserUuid()
+      const filter = { id, name: draft.name, jql: draft.jql }
+      const nextFilters = normalizeJiraSavedFilters([...jiraSavedFilters, filter])
+      if (!nextFilters.some((candidate) => candidate.id === id)) {
+        return
+      }
+      setActiveJiraSavedFilterId(id)
+      setJiraSearchInput(filter.jql)
+      setAppliedJiraSearch(filter.jql)
+      setTaskResumeState({
+        jiraSavedFilters: nextFilters,
+        jiraActiveSavedFilterId: id,
+        jiraQuery: filter.jql
+      })
+      setJiraRefreshNonce((nonce) => nonce + 1)
+    },
+    [jiraSavedFilters, setTaskResumeState]
+  )
+
+  const updateJiraSavedFilter = useCallback(
+    (id: string, draft: { name: string; jql: string }) => {
+      const nextFilters = normalizeJiraSavedFilters(
+        jiraSavedFilters.map((filter) => (filter.id === id ? { ...filter, ...draft } : filter))
+      )
+      if (nextFilters.length !== jiraSavedFilters.length) {
+        return
+      }
+      const updated = nextFilters.find((filter) => filter.id === id)
+      if (!updated) {
+        return
+      }
+      if (activeJiraSavedFilterId === id) {
+        setJiraSearchInput(updated.jql)
+        setAppliedJiraSearch(updated.jql)
+        setTaskResumeState({ jiraSavedFilters: nextFilters, jiraQuery: updated.jql })
+        setJiraRefreshNonce((nonce) => nonce + 1)
+        return
+      }
+      setTaskResumeState({ jiraSavedFilters: nextFilters })
+    },
+    [activeJiraSavedFilterId, jiraSavedFilters, setTaskResumeState]
+  )
+
+  const deleteJiraSavedFilter = useCallback(
+    (id: string) => {
+      const nextFilters = jiraSavedFilters.filter((filter) => filter.id !== id)
+      if (activeJiraSavedFilterId === id) {
+        setActiveJiraSavedFilterId(null)
+        setTaskResumeState({
+          jiraSavedFilters: nextFilters,
+          jiraActiveSavedFilterId: null
+        })
+        return
+      }
+      setTaskResumeState({ jiraSavedFilters: nextFilters })
+    },
+    [activeJiraSavedFilterId, jiraSavedFilters, setTaskResumeState]
+  )
+
   useEffect(() => {
     if (!taskResumeApplied) {
       return
@@ -8716,7 +8806,10 @@ export default function TaskPage(): React.JSX.Element {
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div className="flex flex-wrap gap-2">
                         {jiraPresets.map((preset) => {
-                          const active = !jiraSearchInput && activeJiraPreset === preset.id
+                          const active =
+                            !jiraSearchInput &&
+                            activeJiraSavedFilterId === null &&
+                            activeJiraPreset === preset.id
                           return (
                             <button
                               key={preset.id}
@@ -8725,7 +8818,12 @@ export default function TaskPage(): React.JSX.Element {
                                 setJiraSearchInput('')
                                 setAppliedJiraSearch('')
                                 setActiveJiraPreset(preset.id)
-                                setTaskResumeState({ jiraPreset: preset.id, jiraQuery: '' })
+                                setActiveJiraSavedFilterId(null)
+                                setTaskResumeState({
+                                  jiraPreset: preset.id,
+                                  jiraQuery: '',
+                                  jiraActiveSavedFilterId: null
+                                })
                                 setJiraRefreshNonce((n) => n + 1)
                               }}
                               className={cn(
@@ -8739,6 +8837,15 @@ export default function TaskPage(): React.JSX.Element {
                             </button>
                           )
                         })}
+                        <TaskPageJiraSavedFilters
+                          filters={jiraSavedFilters}
+                          activeFilterId={activeJiraSavedFilterId}
+                          currentJql={jiraSearchInput}
+                          onApply={applyJiraSavedFilter}
+                          onCreate={createJiraSavedFilter}
+                          onUpdate={updateJiraSavedFilter}
+                          onDelete={deleteJiraSavedFilter}
+                        />
                       </div>
                       <div className="flex shrink-0 items-center gap-2">
                         <Tooltip>
@@ -8813,7 +8920,14 @@ export default function TaskPage(): React.JSX.Element {
                         <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
                         <Input
                           value={jiraSearchInput}
-                          onChange={(e) => setJiraSearchInput(e.target.value)}
+                          onChange={(e) => {
+                            const query = e.target.value
+                            setJiraSearchInput(query)
+                            if (!query.trim() && activeJiraSavedFilterId !== null) {
+                              setActiveJiraSavedFilterId(null)
+                              setTaskResumeState({ jiraActiveSavedFilterId: null })
+                            }
+                          }}
                           onKeyDown={(e) => {
                             if (e.key === 'Enter') {
                               if (
@@ -8848,7 +8962,11 @@ export default function TaskPage(): React.JSX.Element {
                             onClick={() => {
                               setJiraSearchInput('')
                               setAppliedJiraSearch('')
-                              setTaskResumeState({ jiraQuery: '' })
+                              setActiveJiraSavedFilterId(null)
+                              setTaskResumeState({
+                                jiraQuery: '',
+                                jiraActiveSavedFilterId: null
+                              })
                               setJiraRefreshNonce((n) => n + 1)
                             }}
                             className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition hover:text-foreground"

--- a/src/renderer/src/components/TaskPageJiraSavedFilters.test.tsx
+++ b/src/renderer/src/components/TaskPageJiraSavedFilters.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_JIRA_SAVED_FILTER_JQL_LENGTH,
+  MAX_JIRA_SAVED_FILTER_NAME_LENGTH,
+  MAX_JIRA_SAVED_FILTERS
+} from '../../../shared/jira-saved-filters'
+import { TaskPageJiraSavedFilters } from './TaskPageJiraSavedFilters'
+
+const FILTERS = [
+  { id: 'mine', name: 'My open work', jql: 'assignee = currentUser() AND statusCategory != Done' },
+  { id: 'bugs', name: 'Team bugs', jql: 'project = ORCA AND type = Bug' }
+]
+
+afterEach(cleanup)
+
+function renderSavedFilters(
+  overrides: Partial<React.ComponentProps<typeof TaskPageJiraSavedFilters>> = {}
+) {
+  const props: React.ComponentProps<typeof TaskPageJiraSavedFilters> = {
+    filters: FILTERS,
+    activeFilterId: 'mine',
+    currentJql: 'project = ORCA',
+    onApply: vi.fn(),
+    onCreate: vi.fn(),
+    onUpdate: vi.fn(),
+    onDelete: vi.fn(),
+    ...overrides
+  }
+  return { user: userEvent.setup(), props, ...render(<TaskPageJiraSavedFilters {...props} />) }
+}
+
+describe('TaskPageJiraSavedFilters', () => {
+  it('저장된 필터를 한 번의 클릭으로 적용하고 활성 필터를 표시한다', async () => {
+    // Given
+    const { user, props } = renderSavedFilters()
+
+    // When
+    await user.click(screen.getByRole('button', { name: 'Saved filters' }))
+
+    // Then
+    const activeFilter = screen.getByRole('button', { name: 'My open work' })
+    expect(activeFilter.getAttribute('aria-current')).toBe('true')
+    expect(activeFilter.getAttribute('data-current')).toBe('true')
+
+    // When
+    await user.click(screen.getByRole('button', { name: 'Team bugs' }))
+
+    // Then
+    expect(props.onApply).toHaveBeenCalledOnce()
+    expect(props.onApply).toHaveBeenCalledWith(FILTERS[1])
+  })
+
+  it('현재 JQL을 새 이름으로 저장하고 필수값과 중복 이름을 검증한다', async () => {
+    // Given
+    const { user, props, rerender } = renderSavedFilters({ currentJql: '' })
+    await user.click(screen.getByRole('button', { name: 'Saved filters' }))
+    expect(
+      (screen.getByRole('button', { name: 'Save current filter' }) as HTMLButtonElement).disabled
+    ).toBe(true)
+
+    // When
+    rerender(<TaskPageJiraSavedFilters {...props} currentJql="project = ORCA" />)
+    await user.click(screen.getByRole('button', { name: 'Save current filter' }))
+
+    // Then
+    const nameInput = screen.getByRole('textbox', { name: 'Name' })
+    const jqlInput = screen.getByRole('textbox', { name: 'JQL' })
+    expect((jqlInput as HTMLTextAreaElement).value).toBe('project = ORCA')
+    expect((nameInput as HTMLInputElement).maxLength).toBe(MAX_JIRA_SAVED_FILTER_NAME_LENGTH)
+    expect((jqlInput as HTMLTextAreaElement).maxLength).toBe(MAX_JIRA_SAVED_FILTER_JQL_LENGTH)
+    expect(
+      (screen.getByRole('button', { name: 'Save filter' }) as HTMLButtonElement).disabled
+    ).toBe(true)
+
+    // When
+    await user.type(nameInput, '  team BUGS  ')
+
+    // Then
+    expect(screen.getByText('A saved filter with this name already exists.')).toBeTruthy()
+    expect(
+      (screen.getByRole('button', { name: 'Save filter' }) as HTMLButtonElement).disabled
+    ).toBe(true)
+
+    // When
+    await user.clear(nameInput)
+    await user.type(nameInput, '  Current sprint  ')
+    await user.click(screen.getByRole('button', { name: 'Save filter' }))
+
+    // Then
+    expect(props.onCreate).toHaveBeenCalledWith({
+      name: 'Current sprint',
+      jql: 'project = ORCA'
+    })
+  })
+
+  it('활성 필터 편집 Dialog에 현재 JQL을 seed하고 명시적으로 update한다', async () => {
+    // Given
+    const { user, props } = renderSavedFilters()
+    await user.click(screen.getByRole('button', { name: 'Saved filters' }))
+
+    // When
+    await user.click(screen.getByRole('button', { name: 'Edit My open work' }))
+
+    // Then
+    expect((screen.getByRole('textbox', { name: 'Name' }) as HTMLInputElement).value).toBe(
+      'My open work'
+    )
+    expect((screen.getByRole('textbox', { name: 'JQL' }) as HTMLTextAreaElement).value).toBe(
+      'project = ORCA'
+    )
+
+    // When
+    await user.clear(screen.getByRole('textbox', { name: 'Name' }))
+    await user.type(screen.getByRole('textbox', { name: 'Name' }), 'My active work')
+    await user.click(screen.getByRole('button', { name: 'Update filter' }))
+
+    // Then
+    expect(props.onUpdate).toHaveBeenCalledWith('mine', {
+      name: 'My active work',
+      jql: 'project = ORCA'
+    })
+  })
+
+  it('편집 Dialog에서 destructive Delete action을 제공한다', async () => {
+    // Given
+    const { user, props } = renderSavedFilters()
+    await user.click(screen.getByRole('button', { name: 'Saved filters' }))
+    await user.click(screen.getByRole('button', { name: 'Edit Team bugs' }))
+
+    // When
+    const deleteButton = screen.getByRole('button', { name: 'Delete filter' })
+
+    // Then
+    expect(deleteButton.getAttribute('data-variant')).toBe('destructive')
+
+    // When
+    await user.click(deleteButton)
+
+    // Then
+    expect(props.onDelete).toHaveBeenCalledWith('bugs')
+  })
+
+  it('저장 한도에 도달하면 새 필터 저장을 막고 제한을 안내한다', async () => {
+    // Given
+    const filters = Array.from({ length: MAX_JIRA_SAVED_FILTERS }, (_, index) => ({
+      id: `filter-${index}`,
+      name: `Filter ${index}`,
+      jql: `project = ORCA AND rank = ${index}`
+    }))
+    const { user } = renderSavedFilters({ filters })
+
+    // When
+    await user.click(screen.getByRole('button', { name: 'Saved filters' }))
+
+    // Then
+    expect(
+      (screen.getByRole('button', { name: 'Save current filter' }) as HTMLButtonElement).disabled
+    ).toBe(true)
+    expect(screen.getByText('You can save up to 50 filters.')).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/TaskPageJiraSavedFilters.tsx
+++ b/src/renderer/src/components/TaskPageJiraSavedFilters.tsx
@@ -1,0 +1,310 @@
+import { useState } from 'react'
+import { Check, ListFilter, Pencil, Plus, Trash2 } from 'lucide-react'
+import {
+  MAX_JIRA_SAVED_FILTER_JQL_LENGTH,
+  MAX_JIRA_SAVED_FILTER_NAME_LENGTH,
+  MAX_JIRA_SAVED_FILTERS,
+  type JiraSavedFilter
+} from '../../../shared/jira-saved-filters'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+
+type SavedFilterDraft = {
+  mode: 'create' | 'edit'
+  id: string | null
+  name: string
+  jql: string
+}
+
+type TaskPageJiraSavedFiltersProps = {
+  filters: readonly JiraSavedFilter[]
+  activeFilterId: string | null
+  currentJql: string
+  onApply: (filter: JiraSavedFilter) => void
+  onCreate: (filter: { name: string; jql: string }) => void
+  onUpdate: (id: string, filter: { name: string; jql: string }) => void
+  onDelete: (id: string) => void
+}
+
+function normalizedName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+export function TaskPageJiraSavedFilters({
+  filters,
+  activeFilterId,
+  currentJql,
+  onApply,
+  onCreate,
+  onUpdate,
+  onDelete
+}: TaskPageJiraSavedFiltersProps): React.JSX.Element {
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  const [draft, setDraft] = useState<SavedFilterDraft | null>(null)
+  const filterLimitReached = filters.length >= MAX_JIRA_SAVED_FILTERS
+  const duplicateName = draft
+    ? filters.some(
+        (filter) =>
+          filter.id !== draft.id && normalizedName(filter.name) === normalizedName(draft.name)
+      )
+    : false
+  const canSubmit = Boolean(
+    draft?.name.trim() &&
+    draft.name.length <= MAX_JIRA_SAVED_FILTER_NAME_LENGTH &&
+    draft.jql.trim() &&
+    draft.jql.length <= MAX_JIRA_SAVED_FILTER_JQL_LENGTH &&
+    !duplicateName
+  )
+
+  const openCreateDialog = (): void => {
+    setPopoverOpen(false)
+    setDraft({ mode: 'create', id: null, name: '', jql: currentJql.trim() })
+  }
+
+  const openEditDialog = (filter: JiraSavedFilter): void => {
+    setPopoverOpen(false)
+    setDraft({
+      mode: 'edit',
+      id: filter.id,
+      name: filter.name,
+      jql: filter.id === activeFilterId ? currentJql.trim() : filter.jql
+    })
+  }
+
+  const saveDraft = (): void => {
+    if (!draft || !canSubmit) {
+      return
+    }
+    const value = { name: draft.name.trim(), jql: draft.jql.trim() }
+    if (draft.mode === 'edit' && draft.id) {
+      onUpdate(draft.id, value)
+    } else {
+      onCreate(value)
+    }
+    setDraft(null)
+  }
+
+  return (
+    <>
+      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+        <PopoverTrigger asChild>
+          <Button type="button" variant="outline" size="xs">
+            <ListFilter />
+            {translate('auto.components.TaskPageJiraSavedFilters.6c381858a1', 'Saved filters')}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" sideOffset={6} className="w-72 p-0">
+          <div className="border-b border-border/50 px-3 py-2">
+            <p className="text-xs font-medium">
+              {translate('auto.components.TaskPageJiraSavedFilters.6c381858a1', 'Saved filters')}
+            </p>
+          </div>
+          <div className="max-h-72 overflow-y-auto p-1 scrollbar-sleek">
+            {filters.length === 0 ? (
+              <p className="px-2 py-4 text-center text-xs text-muted-foreground">
+                {translate(
+                  'auto.components.TaskPageJiraSavedFilters.d14121662d',
+                  'No saved filters yet.'
+                )}
+              </p>
+            ) : (
+              filters.map((filter) => {
+                const active = filter.id === activeFilterId
+                return (
+                  <div key={filter.id} className="group flex items-center gap-1 rounded-md">
+                    <button
+                      type="button"
+                      aria-current={active ? 'true' : undefined}
+                      data-current={active ? 'true' : undefined}
+                      onClick={() => {
+                        setPopoverOpen(false)
+                        onApply(filter)
+                      }}
+                      className={cn(
+                        'flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                        active && 'bg-accent text-accent-foreground'
+                      )}
+                    >
+                      <Check
+                        aria-hidden
+                        className={active ? 'size-3.5 shrink-0' : 'size-3.5 shrink-0 opacity-0'}
+                      />
+                      <span className="truncate">{filter.name}</span>
+                    </button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      aria-label={translate(
+                        'auto.components.TaskPageJiraSavedFilters.af0dd8c528',
+                        'Edit {{value0}}',
+                        { value0: filter.name }
+                      )}
+                      onClick={() => openEditDialog(filter)}
+                      className="text-muted-foreground can-hover:opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                    >
+                      <Pencil />
+                    </Button>
+                  </div>
+                )
+              })
+            )}
+          </div>
+          <div className="border-t border-border/50 p-1">
+            {filterLimitReached ? (
+              <p className="px-2 py-1 text-[11px] text-muted-foreground">
+                {translate(
+                  'auto.components.TaskPageJiraSavedFilters.bae9bd87bf',
+                  'You can save up to {{value0}} filters.',
+                  { value0: MAX_JIRA_SAVED_FILTERS }
+                )}
+              </p>
+            ) : null}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="w-full justify-start text-xs"
+              disabled={!currentJql.trim() || filterLimitReached}
+              onClick={openCreateDialog}
+            >
+              <Plus />
+              {translate(
+                'auto.components.TaskPageJiraSavedFilters.85506127a5',
+                'Save current filter'
+              )}
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <Dialog open={draft !== null} onOpenChange={(open) => !open && setDraft(null)}>
+        <DialogContent showCloseButton={false} className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-sm">
+              {draft?.mode === 'edit'
+                ? translate(
+                    'auto.components.TaskPageJiraSavedFilters.7aef259c28',
+                    'Edit Jira filter'
+                  )
+                : translate(
+                    'auto.components.TaskPageJiraSavedFilters.4f0e55d2e5',
+                    'Save Jira filter'
+                  )}
+            </DialogTitle>
+            <DialogDescription className="text-xs">
+              {translate(
+                'auto.components.TaskPageJiraSavedFilters.466c1b12ce',
+                'Give this JQL query a name for quick access.'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault()
+              saveDraft()
+            }}
+          >
+            <div className="space-y-2">
+              <Label htmlFor="jira-saved-filter-name">
+                {translate('auto.components.TaskPageJiraSavedFilters.e4c2f52972', 'Name')}
+              </Label>
+              <Input
+                id="jira-saved-filter-name"
+                autoFocus
+                required
+                maxLength={MAX_JIRA_SAVED_FILTER_NAME_LENGTH}
+                value={draft?.name ?? ''}
+                aria-invalid={duplicateName || undefined}
+                onChange={(event) =>
+                  setDraft((current) =>
+                    current ? { ...current, name: event.target.value } : current
+                  )
+                }
+              />
+              {duplicateName ? (
+                <p role="alert" className="text-xs text-destructive">
+                  {translate(
+                    'auto.components.TaskPageJiraSavedFilters.0ab71bb840',
+                    'A saved filter with this name already exists.'
+                  )}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="jira-saved-filter-jql">
+                {translate('auto.components.TaskPageJiraSavedFilters.42ce360813', 'JQL')}
+              </Label>
+              <textarea
+                id="jira-saved-filter-jql"
+                required
+                rows={5}
+                maxLength={MAX_JIRA_SAVED_FILTER_JQL_LENGTH}
+                value={draft?.jql ?? ''}
+                onChange={(event) =>
+                  setDraft((current) =>
+                    current ? { ...current, jql: event.target.value } : current
+                  )
+                }
+                className="w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-xs outline-none placeholder:text-muted-foreground/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30"
+              />
+            </div>
+
+            <DialogFooter className={draft?.mode === 'edit' ? 'sm:justify-between' : undefined}>
+              {draft?.mode === 'edit' ? (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => {
+                    if (draft.id) {
+                      onDelete(draft.id)
+                    }
+                    setDraft(null)
+                  }}
+                >
+                  <Trash2 />
+                  {translate(
+                    'auto.components.TaskPageJiraSavedFilters.7b21c59a26',
+                    'Delete filter'
+                  )}
+                </Button>
+              ) : null}
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="ghost" size="sm" onClick={() => setDraft(null)}>
+                  {translate('auto.components.TaskPageJiraSavedFilters.a62f9db53d', 'Cancel')}
+                </Button>
+                <Button type="submit" size="sm" disabled={!canSubmit}>
+                  {draft?.mode === 'edit'
+                    ? translate(
+                        'auto.components.TaskPageJiraSavedFilters.c77189bc0c',
+                        'Update filter'
+                      )
+                    : translate(
+                        'auto.components.TaskPageJiraSavedFilters.19af906d12',
+                        'Save filter'
+                      )}
+                </Button>
+              </div>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14031,6 +14031,23 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "TaskPageJiraSavedFilters": {
+        "6c381858a1": "Saved filters",
+        "d14121662d": "No saved filters yet.",
+        "af0dd8c528": "Edit {{value0}}",
+        "bae9bd87bf": "You can save up to {{value0}} filters.",
+        "85506127a5": "Save current filter",
+        "7aef259c28": "Edit Jira filter",
+        "4f0e55d2e5": "Save Jira filter",
+        "466c1b12ce": "Give this JQL query a name for quick access.",
+        "e4c2f52972": "Name",
+        "0ab71bb840": "A saved filter with this name already exists.",
+        "42ce360813": "JQL",
+        "7b21c59a26": "Delete filter",
+        "a62f9db53d": "Cancel",
+        "c77189bc0c": "Update filter",
+        "19af906d12": "Save filter"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14008,6 +14008,23 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "TaskPageJiraSavedFilters": {
+        "6c381858a1": "Saved filters",
+        "d14121662d": "No saved filters yet.",
+        "af0dd8c528": "Edit {{value0}}",
+        "bae9bd87bf": "You can save up to {{value0}} filters.",
+        "85506127a5": "Save current filter",
+        "7aef259c28": "Edit Jira filter",
+        "4f0e55d2e5": "Save Jira filter",
+        "466c1b12ce": "Give this JQL query a name for quick access.",
+        "e4c2f52972": "Name",
+        "0ab71bb840": "A saved filter with this name already exists.",
+        "42ce360813": "JQL",
+        "7b21c59a26": "Delete filter",
+        "a62f9db53d": "Cancel",
+        "c77189bc0c": "Update filter",
+        "19af906d12": "Save filter"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14008,6 +14008,23 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "TaskPageJiraSavedFilters": {
+        "6c381858a1": "Saved filters",
+        "d14121662d": "No saved filters yet.",
+        "af0dd8c528": "Edit {{value0}}",
+        "bae9bd87bf": "You can save up to {{value0}} filters.",
+        "85506127a5": "Save current filter",
+        "7aef259c28": "Edit Jira filter",
+        "4f0e55d2e5": "Save Jira filter",
+        "466c1b12ce": "Give this JQL query a name for quick access.",
+        "e4c2f52972": "Name",
+        "0ab71bb840": "A saved filter with this name already exists.",
+        "42ce360813": "JQL",
+        "7b21c59a26": "Delete filter",
+        "a62f9db53d": "Cancel",
+        "c77189bc0c": "Update filter",
+        "19af906d12": "Save filter"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14008,6 +14008,23 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "TaskPageJiraSavedFilters": {
+        "6c381858a1": "Saved filters",
+        "d14121662d": "No saved filters yet.",
+        "af0dd8c528": "Edit {{value0}}",
+        "bae9bd87bf": "You can save up to {{value0}} filters.",
+        "85506127a5": "Save current filter",
+        "7aef259c28": "Edit Jira filter",
+        "4f0e55d2e5": "Save Jira filter",
+        "466c1b12ce": "Give this JQL query a name for quick access.",
+        "e4c2f52972": "Name",
+        "0ab71bb840": "A saved filter with this name already exists.",
+        "42ce360813": "JQL",
+        "7b21c59a26": "Delete filter",
+        "a62f9db53d": "Cancel",
+        "c77189bc0c": "Update filter",
+        "19af906d12": "Save filter"
       }
     },
     "i18n": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14008,6 +14008,23 @@
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }
+      },
+      "TaskPageJiraSavedFilters": {
+        "6c381858a1": "Saved filters",
+        "d14121662d": "No saved filters yet.",
+        "af0dd8c528": "Edit {{value0}}",
+        "bae9bd87bf": "You can save up to {{value0}} filters.",
+        "85506127a5": "Save current filter",
+        "7aef259c28": "Edit Jira filter",
+        "4f0e55d2e5": "Save Jira filter",
+        "466c1b12ce": "Give this JQL query a name for quick access.",
+        "e4c2f52972": "Name",
+        "0ab71bb840": "A saved filter with this name already exists.",
+        "42ce360813": "JQL",
+        "7b21c59a26": "Delete filter",
+        "a62f9db53d": "Cancel",
+        "c77189bc0c": "Update filter",
+        "19af906d12": "Save filter"
       }
     },
     "i18n": {

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1617,7 +1617,14 @@ describe('createUISlice hydratePersistedUI', () => {
           linearPreset: 'completed',
           linearQuery: 'label:bug',
           jiraPreset: 'reported',
-          jiraQuery: 99
+          jiraQuery: 'project = KEEP',
+          jiraSavedFilters: [
+            { id: 'filter-1', name: 'My work', jql: 'assignee = currentUser()' },
+            { id: 'filter-1', name: 'Duplicate id', jql: 'project = DUPLICATE' },
+            { id: 'filter-2', name: 'my WORK', jql: 'project = DUPLICATE_NAME' },
+            { id: '', name: 'Invalid', jql: 'project = INVALID' }
+          ],
+          jiraActiveSavedFilterId: 'missing'
         } as unknown as PersistedUIState['taskResumeState']
       })
     )
@@ -1626,7 +1633,30 @@ describe('createUISlice hydratePersistedUI', () => {
       githubMode: 'project',
       linearPreset: 'completed',
       linearQuery: 'label:bug',
-      jiraPreset: 'reported'
+      jiraPreset: 'reported',
+      jiraQuery: 'project = KEEP',
+      jiraSavedFilters: [{ id: 'filter-1', name: 'My work', jql: 'assignee = currentUser()' }]
+    })
+  })
+
+  it.each([
+    ['matching id', 'filter-1', 'filter-1'],
+    ['explicit null', null, null]
+  ])('hydrates saved Jira filters with %s active selection', (_label, activeId, expected) => {
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        taskResumeState: {
+          jiraSavedFilters: [{ id: ' filter-1 ', name: ' My work ', jql: ' project = ENG ' }],
+          jiraActiveSavedFilterId: activeId
+        }
+      })
+    )
+
+    expect(store.getState().taskResumeState).toEqual({
+      jiraSavedFilters: [{ id: 'filter-1', name: 'My work', jql: 'project = ENG' }],
+      jiraActiveSavedFilterId: expected
     })
   })
 
@@ -1812,9 +1842,19 @@ describe('createUISlice hydratePersistedUI', () => {
     const store = createUIStore()
 
     store.setState({ taskResumeState: { githubMode: 'project', linearPreset: 'all' } })
-    store.getState().setTaskResumeState({ githubItemsPreset: 'my-prs' })
+    store.getState().setTaskResumeState({
+      githubItemsPreset: 'my-prs',
+      jiraSavedFilters: [{ id: 'filter-1', name: 'My work', jql: 'project = ENG' }],
+      jiraActiveSavedFilterId: 'filter-1'
+    })
 
-    const expected = { githubMode: 'project', linearPreset: 'all', githubItemsPreset: 'my-prs' }
+    const expected = {
+      githubMode: 'project',
+      linearPreset: 'all',
+      githubItemsPreset: 'my-prs',
+      jiraSavedFilters: [{ id: 'filter-1', name: 'My work', jql: 'project = ENG' }],
+      jiraActiveSavedFilterId: 'filter-1'
+    }
     expect(store.getState().taskResumeState).toEqual(expected)
     expect(setUI).toHaveBeenCalledWith({ taskResumeState: expected })
   })

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -35,6 +35,10 @@ import {
   applyManualRepoOrder,
   normalizeManualRepoOrder
 } from '../../../../shared/manual-repo-order'
+import {
+  MAX_JIRA_SAVED_FILTER_ID_LENGTH,
+  normalizeJiraSavedFilters
+} from '../../../../shared/jira-saved-filters'
 import { isTopLevelView } from '../../../../shared/top-level-view'
 import type { UsagePercentageDisplay } from '../../../../shared/usage-percentage-display'
 import {
@@ -578,6 +582,22 @@ function sanitizeTaskResumeState(value: unknown): TaskResumeState | undefined {
   }
   if (typeof input.jiraQuery === 'string') {
     next.jiraQuery = input.jiraQuery
+  }
+  const jiraSavedFilters = normalizeJiraSavedFilters(input.jiraSavedFilters)
+  if (Array.isArray(input.jiraSavedFilters)) {
+    next.jiraSavedFilters = jiraSavedFilters
+  }
+  if (input.jiraActiveSavedFilterId === null) {
+    next.jiraActiveSavedFilterId = null
+  } else if (typeof input.jiraActiveSavedFilterId === 'string') {
+    const activeId = input.jiraActiveSavedFilterId.trim()
+    if (
+      activeId.length > 0 &&
+      activeId.length <= MAX_JIRA_SAVED_FILTER_ID_LENGTH &&
+      jiraSavedFilters.some((filter) => filter.id === activeId)
+    ) {
+      next.jiraActiveSavedFilterId = activeId
+    }
   }
 
   return Object.keys(next).length > 0 ? next : undefined

--- a/src/shared/jira-saved-filters.test.ts
+++ b/src/shared/jira-saved-filters.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_JIRA_SAVED_FILTERS,
+  MAX_JIRA_SAVED_FILTER_ID_LENGTH,
+  MAX_JIRA_SAVED_FILTER_JQL_LENGTH,
+  MAX_JIRA_SAVED_FILTER_NAME_LENGTH,
+  normalizeJiraSavedFilters
+} from './jira-saved-filters'
+
+describe('normalizeJiraSavedFilters', () => {
+  it('defines bounded persisted filter limits', () => {
+    expect(MAX_JIRA_SAVED_FILTERS).toBe(50)
+    expect(MAX_JIRA_SAVED_FILTER_ID_LENGTH).toBe(128)
+    expect(MAX_JIRA_SAVED_FILTER_NAME_LENGTH).toBe(80)
+    expect(MAX_JIRA_SAVED_FILTER_JQL_LENGTH).toBe(10_000)
+  })
+
+  it('trims valid persisted filters', () => {
+    expect(
+      normalizeJiraSavedFilters([
+        { id: ' filter-1 ', name: ' My open work ', jql: ' assignee = currentUser() ' }
+      ])
+    ).toEqual([{ id: 'filter-1', name: 'My open work', jql: 'assignee = currentUser()' }])
+  })
+
+  it('drops malformed and out-of-bounds entries', () => {
+    expect(
+      normalizeJiraSavedFilters([
+        null,
+        [],
+        { id: '', name: 'Empty id', jql: 'project = ENG' },
+        { id: 'id', name: '', jql: 'project = ENG' },
+        { id: 'jql', name: 'Empty JQL', jql: ' ' },
+        { id: 'x'.repeat(MAX_JIRA_SAVED_FILTER_ID_LENGTH + 1), name: 'Long id', jql: 'x' },
+        { id: 'name', name: 'x'.repeat(MAX_JIRA_SAVED_FILTER_NAME_LENGTH + 1), jql: 'x' },
+        { id: 'jql-long', name: 'Long JQL', jql: 'x'.repeat(MAX_JIRA_SAVED_FILTER_JQL_LENGTH + 1) },
+        { id: 'valid', name: 'Valid', jql: 'project = ENG' }
+      ])
+    ).toEqual([{ id: 'valid', name: 'Valid', jql: 'project = ENG' }])
+    expect(normalizeJiraSavedFilters({})).toEqual([])
+  })
+
+  it('keeps the first filter for duplicate ids and case-insensitive names', () => {
+    expect(
+      normalizeJiraSavedFilters([
+        { id: 'one', name: 'My Bugs', jql: 'one' },
+        { id: 'one', name: 'Different', jql: 'duplicate id' },
+        { id: 'two', name: ' my bugs ', jql: 'duplicate name' },
+        { id: 'three', name: 'Done', jql: 'three' }
+      ])
+    ).toEqual([
+      { id: 'one', name: 'My Bugs', jql: 'one' },
+      { id: 'three', name: 'Done', jql: 'three' }
+    ])
+  })
+
+  it('caps the normalized list after filtering invalid entries', () => {
+    const persisted = [
+      { id: '', name: 'invalid', jql: 'invalid' },
+      ...Array.from({ length: MAX_JIRA_SAVED_FILTERS + 5 }, (_, index) => ({
+        id: `filter-${index}`,
+        name: `Filter ${index}`,
+        jql: `project = P${index}`
+      }))
+    ]
+
+    const normalized = normalizeJiraSavedFilters(persisted)
+
+    expect(normalized).toHaveLength(MAX_JIRA_SAVED_FILTERS)
+    expect(normalized.at(-1)?.id).toBe(`filter-${MAX_JIRA_SAVED_FILTERS - 1}`)
+  })
+})

--- a/src/shared/jira-saved-filters.ts
+++ b/src/shared/jira-saved-filters.ts
@@ -1,0 +1,58 @@
+export const MAX_JIRA_SAVED_FILTERS = 50
+export const MAX_JIRA_SAVED_FILTER_ID_LENGTH = 128
+export const MAX_JIRA_SAVED_FILTER_NAME_LENGTH = 80
+export const MAX_JIRA_SAVED_FILTER_JQL_LENGTH = 10_000
+
+export type JiraSavedFilter = {
+  id: string
+  name: string
+  jql: string
+}
+
+function normalizeBoundedString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const normalized = value.trim()
+  if (normalized.length === 0 || normalized.length > maxLength) {
+    return null
+  }
+  return normalized
+}
+
+export function normalizeJiraSavedFilters(value: unknown): JiraSavedFilter[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const normalized: JiraSavedFilter[] = []
+  const ids = new Set<string>()
+  const names = new Set<string>()
+
+  for (const candidate of value) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+      continue
+    }
+    const input = candidate as Record<string, unknown>
+    const id = normalizeBoundedString(input.id, MAX_JIRA_SAVED_FILTER_ID_LENGTH)
+    const name = normalizeBoundedString(input.name, MAX_JIRA_SAVED_FILTER_NAME_LENGTH)
+    const jql = normalizeBoundedString(input.jql, MAX_JIRA_SAVED_FILTER_JQL_LENGTH)
+    if (!id || !name || !jql) {
+      continue
+    }
+
+    const normalizedName = name.toLowerCase()
+    if (ids.has(id) || names.has(normalizedName)) {
+      continue
+    }
+
+    normalized.push({ id, name, jql })
+    ids.add(id)
+    names.add(normalizedName)
+    if (normalized.length === MAX_JIRA_SAVED_FILTERS) {
+      break
+    }
+  }
+
+  return normalized
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -44,11 +44,13 @@ import type { UsagePercentageDisplay } from './usage-percentage-display'
 import type { StatusBarUsageMode } from './status-bar-usage-mode'
 import type { PersistedNativeChatSessionOptions } from './native-chat-session-options'
 import type { CodexResetCreditAttemptLedger } from './codex-reset-credit-attempt-ledger'
+import type { JiraSavedFilter } from './jira-saved-filters'
 
 // Re-exported for backward compat with renderer call sites that import
 // `WorkspaceCreateTelemetrySource` from '../../../shared/types'.
 export type { WorkspaceSource as WorkspaceCreateTelemetrySource } from './workspace-source'
 export type { TaskProvider } from './task-providers'
+export type { JiraSavedFilter } from './jira-saved-filters'
 export type {
   GitBranchChangeStatus,
   GitConflictKind,
@@ -3223,6 +3225,8 @@ export type TaskResumeState = {
   }
   jiraPreset?: 'assigned' | 'reported' | 'all' | 'done'
   jiraQuery?: string
+  jiraSavedFilters?: JiraSavedFilter[]
+  jiraActiveSavedFilterId?: string | null
 }
 
 export type RightSidebarTab =


### PR DESCRIPTION
## Summary

- add a **Saved filters** control to the Jira task header
- let users save, apply, rename, explicitly update, and delete named JQL filters
- persist the saved-filter list and active selection through local and remote/SSH UI-state paths
- validate and bound persisted filter data while preserving the existing Jira presets and manual JQL flow

Closes #11114

## Screenshots

Not included yet — this is a draft PR. The new UI behavior is covered by component interaction tests.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 38,824 passed, 62 skipped
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

Reviewed the saved-filter CRUD flow, active-filter/manual-JQL transitions, existing preset behavior, persistence hydration, strict remote RPC validation, and localization catalog parity.

The review specifically checked that editing an active query does not silently overwrite its saved filter, invalid or duplicate persisted entries are dropped safely, active selections cannot reference missing filters, and the existing selected Jira site scope remains unchanged.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows. This change uses shared renderer and UI-state data only and introduces no platform-specific shortcuts, labels, filesystem paths, shell behavior, or Electron-native differences.

## Security Audit

Saved-filter input is treated as data and continues through the existing Jira query flow. Persisted and remote UI state is bounded by strict limits for filter count, IDs, names, and JQL length; malformed entries, duplicate IDs, and case-insensitive duplicate names are rejected or normalized.

No new command execution, filesystem paths, authentication flows, secrets, dependencies, or privileged IPC methods were introduced.

## Notes

- The local environment used Node v23.11.0 and emitted the repository's Node 24 engine warning; all listed checks still completed successfully.
- A screenshot or recording should be added before marking this PR ready for review.
