### PR TITLE
fix(clipboard): fit oversized paste images under size limits

### DIFF
--- a/src/main/window/clipboard-image-fit.test.ts
+++ b/src/main/window/clipboard-image-fit.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CLIPBOARD_IMAGE_MAX_PIXELS,
+  CLIPBOARD_IMAGE_MAX_SOURCE_BYTES,
+  CLIPBOARD_IMAGE_TOO_LARGE_ERROR
+} from '../../shared/clipboard-image'
+import {
+  encodeClipboardImageWithinLimits,
+  type FitClipboardImageSource
+} from './clipboard-image-fit'
+
+function makeImage(options: {
+  width: number
+  height: number
+  pngBytes?: number
+  resizePngBytes?: number
+}): FitClipboardImageSource {
+  let width = options.width
+  let height = options.height
+  const pngBytes = options.pngBytes ?? 16
+  const resizePngBytes =
+    options.resizePngBytes ?? Math.min(pngBytes, CLIPBOARD_IMAGE_MAX_SOURCE_BYTES)
+
+  const image: FitClipboardImageSource = {
+    isEmpty: () => false,
+    getSize: () => ({ width, height }),
+    toPNG: () => Buffer.alloc(pngBytes),
+    resize: vi.fn(({ width: nextWidth, height: nextHeight }) => {
+      width = nextWidth
+      height = nextHeight
+      return {
+        isEmpty: () => false,
+        getSize: () => ({ width, height }),
+        toPNG: () => Buffer.alloc(resizePngBytes),
+        resize: image.resize
+      }
+    })
+  }
+  return image
+}
+
+describe('encodeClipboardImageWithinLimits', () => {
+  it('returns the original PNG when already within limits', () => {
+    const png = Buffer.from([1, 2, 3, 4])
+    const image: FitClipboardImageSource = {
+      isEmpty: () => false,
+      getSize: () => ({ width: 10, height: 10 }),
+      toPNG: () => png,
+      resize: vi.fn()
+    }
+
+    expect(encodeClipboardImageWithinLimits(image)).toBe(png)
+    expect(image.resize).not.toHaveBeenCalled()
+  })
+
+  it('downscales images over the pixel cap so paste can succeed', () => {
+    const image = makeImage({
+      width: CLIPBOARD_IMAGE_MAX_PIXELS + 1,
+      height: 1,
+      pngBytes: CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1,
+      resizePngBytes: 64
+    })
+
+    const encoded = encodeClipboardImageWithinLimits(image)
+    expect(encoded.byteLength).toBe(64)
+    expect(image.resize).toHaveBeenCalled()
+    const firstTarget = vi.mocked(image.resize).mock.calls[0]?.[0]
+    expect(firstTarget).toBeDefined()
+    expect((firstTarget?.width ?? 0) * (firstTarget?.height ?? 0)).toBeLessThanOrEqual(
+      CLIPBOARD_IMAGE_MAX_PIXELS
+    )
+  })
+
+  it('retries encoded-size downscale when PNG bytes exceed the byte cap', () => {
+    let encodeCount = 0
+    let width = 4000
+    let height = 3000
+    const resize = vi.fn(({ width: nextWidth, height: nextHeight }) => {
+      width = nextWidth
+      height = nextHeight
+      return image
+    })
+    const image: FitClipboardImageSource = {
+      isEmpty: () => false,
+      getSize: () => ({ width, height }),
+      toPNG: () => {
+        encodeCount += 1
+        // First encode is over the cap; subsequent encodes fit after resize.
+        return Buffer.alloc(encodeCount === 1 ? CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1024 : 128)
+      },
+      resize
+    }
+
+    const encoded = encodeClipboardImageWithinLimits(image)
+    expect(encoded.byteLength).toBe(128)
+    expect(resize).toHaveBeenCalled()
+  })
+
+  it('still rejects when downscale cannot bring the payload under the cap', () => {
+    const image = makeImage({
+      width: 1,
+      height: 1,
+      pngBytes: CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1,
+      resizePngBytes: CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1
+    })
+
+    expect(() => encodeClipboardImageWithinLimits(image)).toThrow(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
+  })
+
+  it('rejects empty or invalid dimensions', () => {
+    expect(() =>
+      encodeClipboardImageWithinLimits({
+        isEmpty: () => true,
+        getSize: () => ({ width: 1, height: 1 }),
+        toPNG: () => Buffer.alloc(1),
+        resize: vi.fn()
+      })
+    ).toThrow(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
+
+    expect(() =>
+      encodeClipboardImageWithinLimits({
+        isEmpty: () => false,
+        getSize: () => ({ width: 0, height: 10 }),
+        toPNG: () => Buffer.alloc(1),
+        resize: vi.fn()
+      })
+    ).toThrow(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
+  })
+})

--- a/src/main/window/clipboard-image-fit.ts
+++ b/src/main/window/clipboard-image-fit.ts
@@ -1,0 +1,61 @@
+import type { NativeImage } from 'electron'
+import {
+  CLIPBOARD_IMAGE_MAX_DOWNSCALE_ATTEMPTS,
+  CLIPBOARD_IMAGE_MAX_PIXELS,
+  CLIPBOARD_IMAGE_MAX_SOURCE_BYTES,
+  CLIPBOARD_IMAGE_TOO_LARGE_ERROR,
+  assertClipboardImageByteLengthWithinLimit,
+  assertClipboardImageDimensionsWithinLimit,
+  computeClipboardImageEncodedSizeDownscale,
+  computeClipboardImagePixelDownscale
+} from '../../shared/clipboard-image'
+
+/** Minimal NativeImage surface so tests can inject fakes without Electron. */
+export type FitClipboardImageSource = Pick<NativeImage, 'getSize' | 'isEmpty' | 'resize' | 'toPNG'>
+
+/**
+ * Encode a clipboard NativeImage as PNG under hard size caps.
+ * Downscales when pixel count or PNG bytes would otherwise reject the paste.
+ */
+export function encodeClipboardImageWithinLimits(image: FitClipboardImageSource): Buffer {
+  if (image.isEmpty()) {
+    throw new Error(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
+  }
+
+  let current = image
+  let { width, height } = current.getSize()
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    throw new Error(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
+  }
+
+  const pixelTarget = computeClipboardImagePixelDownscale(width, height, CLIPBOARD_IMAGE_MAX_PIXELS)
+  if (pixelTarget) {
+    current = current.resize(pixelTarget)
+    ;({ width, height } = current.getSize())
+  }
+
+  let png = current.toPNG()
+  for (
+    let attempt = 0;
+    attempt < CLIPBOARD_IMAGE_MAX_DOWNSCALE_ATTEMPTS &&
+    png.byteLength > CLIPBOARD_IMAGE_MAX_SOURCE_BYTES;
+    attempt += 1
+  ) {
+    const target = computeClipboardImageEncodedSizeDownscale(
+      png.byteLength,
+      width,
+      height,
+      CLIPBOARD_IMAGE_MAX_SOURCE_BYTES
+    )
+    if (!target) {
+      break
+    }
+    current = current.resize(target)
+    ;({ width, height } = current.getSize())
+    png = current.toPNG()
+  }
+
+  assertClipboardImageDimensionsWithinLimit({ width, height })
+  assertClipboardImageByteLengthWithinLimit(png.byteLength)
+  return png
+}

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -817,37 +817,16 @@ describe('registerClipboardHandlers', () => {
     )
   })
 
-  it('rejects oversized clipboard image dimensions before PNG conversion', async () => {
-    const toPNG = vi.fn(() => Buffer.from([0, 1, 2, 3]))
-    clipboardReadImageMock.mockReturnValue({
-      getSize: () => ({ height: 1, width: CLIPBOARD_IMAGE_MAX_PIXELS + 1 }),
-      isEmpty: () => false,
-      toPNG
-    })
-
-    registerClipboardHandlers({} as never)
-
-    const handlers = getRegisteredHandlers()
-    await expect(
-      handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), undefined)
-    ).rejects.toThrow('Clipboard image is too large')
-    expect(toPNG).not.toHaveBeenCalled()
-    expect(fsWriteFileMock).not.toHaveBeenCalled()
-    expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
-  })
-
-  it('rejects oversized clipboard PNG bytes before SSH provider lookup', async () => {
+  it('rejects clipboard PNG bytes that remain over the cap after downscale', async () => {
     clipboardReadImageMock.mockReturnValue({
       getSize: () => ({ height: 1, width: 1 }),
       isEmpty: () => false,
-      toPNG: () => Buffer.alloc(CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1)
+      toPNG: () => Buffer.alloc(CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1),
+      resize: vi.fn()
     })
-
     registerClipboardHandlers({} as never)
-
-    const handlers = getRegisteredHandlers()
     await expect(
-      handlers.get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
+      getRegisteredHandlers().get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
         connectionId: 'ssh-secret'
       })
     ).rejects.toThrow('Clipboard image is too large')

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -818,18 +818,21 @@ describe('registerClipboardHandlers', () => {
   })
 
   it('rejects clipboard PNG bytes that remain over the cap after downscale', async () => {
-    clipboardReadImageMock.mockReturnValue({
-      getSize: () => ({ height: 1, width: 1 }),
+    // 2×2 can shrink (1×1 cannot), so resize must run before we still reject.
+    const image = {
+      getSize: () => ({ height: 2, width: 2 }),
       isEmpty: () => false,
       toPNG: () => Buffer.alloc(CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1),
-      resize: vi.fn()
-    })
+      resize: vi.fn(() => image)
+    }
+    clipboardReadImageMock.mockReturnValue(image)
     registerClipboardHandlers({} as never)
     await expect(
       getRegisteredHandlers().get('clipboard:saveImageAsTempFile')?.(makeClipboardEvent(), {
         connectionId: 'ssh-secret'
       })
     ).rejects.toThrow('Clipboard image is too large')
+    expect(image.resize).toHaveBeenCalled()
     expect(getSshFilesystemProviderMock).not.toHaveBeenCalled()
     expect(fsWriteFileMock).not.toHaveBeenCalled()
   })

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -19,6 +19,7 @@ import {
   saveClipboardImageBufferAsTempFile,
   type SaveClipboardImageAsTempFileArgs
 } from './clipboard-image-temp-file'
+import { encodeClipboardImageWithinLimits } from './clipboard-image-fit'
 import {
   assertClipboardImageBase64LengthWithinLimit,
   assertClipboardImageByteLengthWithinLimit,
@@ -119,8 +120,9 @@ export function registerClipboardHandlers(store: Store): void {
         )
         return copiedFilePng ? saveClipboardImageBufferForTarget(copiedFilePng, args) : null
       }
-      assertClipboardImageDimensionsWithinLimit(image.getSize())
-      return saveClipboardImageBufferForTarget(image.toPNG(), args)
+      // Why: large screenshots (OpenCode paste) often exceed pixel/byte caps as raw PNG;
+      // downscale to fit so paste succeeds instead of hard-failing under the safety limit.
+      return saveClipboardImageBufferForTarget(encodeClipboardImageWithinLimits(image), args)
     }
   )
   // Why: copy the actual file to the OS clipboard so pasting in Finder/Explorer

--- a/src/shared/clipboard-image.test.ts
+++ b/src/shared/clipboard-image.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
+  CLIPBOARD_IMAGE_DOWNSCALE_SAFETY,
   CLIPBOARD_IMAGE_MAX_BASE64_CHARS,
   CLIPBOARD_IMAGE_MAX_PIXELS,
   CLIPBOARD_IMAGE_MAX_SOURCE_BYTES,
   assertClipboardImageBase64LengthWithinLimit,
   assertClipboardImageByteLengthWithinLimit,
-  assertClipboardImageDimensionsWithinLimit
+  assertClipboardImageDimensionsWithinLimit,
+  computeClipboardImageEncodedSizeDownscale,
+  computeClipboardImagePixelDownscale
 } from './clipboard-image'
 
 describe('clipboard image limits', () => {
@@ -41,5 +44,38 @@ describe('clipboard image limits', () => {
     expect(() =>
       assertClipboardImageDimensionsWithinLimit({ height: Number.POSITIVE_INFINITY, width: 1 })
     ).toThrow('Clipboard image is too large')
+  })
+})
+
+describe('clipboard image downscale targets', () => {
+  it('does not propose a pixel downscale when already within budget', () => {
+    expect(computeClipboardImagePixelDownscale(100, 100)).toBeNull()
+  })
+
+  it('shrinks both edges so pixel count lands under the max with safety margin', () => {
+    // 4x over budget → scale sqrt(0.25)*0.85 = 0.425 → 40*0.425=17, 20*0.425=8.5→8
+    const overWidth = 40
+    const overHeight = 20
+    const maxPixels = (overWidth * overHeight) / 4
+    expect(computeClipboardImagePixelDownscale(overWidth, overHeight, maxPixels)).toEqual({
+      width: 17,
+      height: 8
+    })
+    expect(17 * 8).toBeLessThanOrEqual(maxPixels)
+  })
+
+  it('shrinks encoded-size overflow using sqrt(budget/actual)*safety', () => {
+    // 400 bytes vs 100 budget → scale sqrt(0.25)*0.85 = 0.425
+    expect(computeClipboardImageEncodedSizeDownscale(400, 40, 20, 100)).toEqual({
+      width: 17,
+      height: 8
+    })
+    expect(CLIPBOARD_IMAGE_DOWNSCALE_SAFETY).toBe(0.85)
+  })
+
+  it('returns null when encoded size already fits or dimensions cannot shrink', () => {
+    expect(computeClipboardImageEncodedSizeDownscale(50, 100, 100, 100)).toBeNull()
+    expect(computeClipboardImageEncodedSizeDownscale(400, 1, 1, 100)).toBeNull()
+    expect(computeClipboardImagePixelDownscale(0, 20)).toBeNull()
   })
 })

--- a/src/shared/clipboard-image.ts
+++ b/src/shared/clipboard-image.ts
@@ -4,6 +4,9 @@ export const CLIPBOARD_IMAGE_MAX_SOURCE_BYTES = Math.floor(
 )
 export const CLIPBOARD_IMAGE_MAX_PIXELS = 32 * 1024 * 1024
 export const CLIPBOARD_IMAGE_TOO_LARGE_ERROR = 'Clipboard image is too large'
+// Why: PNG bytes don't scale exactly with pixel area, so undershoot and retry.
+export const CLIPBOARD_IMAGE_DOWNSCALE_SAFETY = 0.85
+export const CLIPBOARD_IMAGE_MAX_DOWNSCALE_ATTEMPTS = 3
 
 export type ClipboardImageDimensions = {
   height: number
@@ -35,4 +38,69 @@ export function assertClipboardImageDimensionsWithinLimit({
   ) {
     throw new Error(CLIPBOARD_IMAGE_TOO_LARGE_ERROR)
   }
+}
+
+function scaleClipboardImageDimensions(
+  width: number,
+  height: number,
+  scale: number
+): ClipboardImageDimensions | null {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null
+  }
+  if (!Number.isFinite(scale) || scale <= 0) {
+    return null
+  }
+  const nextWidth = Math.max(1, Math.floor(width * scale))
+  const nextHeight = Math.max(1, Math.floor(height * scale))
+  // Guard against a no-op shrink (already 1px) so retry loops can't spin forever.
+  if (nextWidth >= width && nextHeight >= height) {
+    return null
+  }
+  return { width: nextWidth, height: nextHeight }
+}
+
+/** Target size so width*height fits under maxPixels, or null when already within budget. */
+export function computeClipboardImagePixelDownscale(
+  width: number,
+  height: number,
+  maxPixels: number = CLIPBOARD_IMAGE_MAX_PIXELS
+): ClipboardImageDimensions | null {
+  const pixelCount = width * height
+  if (!Number.isFinite(pixelCount) || width <= 0 || height <= 0 || pixelCount <= maxPixels) {
+    return null
+  }
+  if (!Number.isFinite(maxPixels) || maxPixels <= 0) {
+    return null
+  }
+  return scaleClipboardImageDimensions(
+    width,
+    height,
+    Math.sqrt(maxPixels / pixelCount) * CLIPBOARD_IMAGE_DOWNSCALE_SAFETY
+  )
+}
+
+/**
+ * Target size so an encoded payload (PNG bytes or base64 length) fits under maxEncodedSize.
+ * Returns null when already within budget or dimensions cannot shrink further.
+ */
+export function computeClipboardImageEncodedSizeDownscale(
+  encodedSize: number,
+  width: number,
+  height: number,
+  maxEncodedSize: number
+): ClipboardImageDimensions | null {
+  if (
+    !Number.isFinite(encodedSize) ||
+    !Number.isFinite(maxEncodedSize) ||
+    encodedSize <= maxEncodedSize ||
+    maxEncodedSize <= 0
+  ) {
+    return null
+  }
+  return scaleClipboardImageDimensions(
+    width,
+    height,
+    Math.sqrt(maxEncodedSize / encodedSize) * CLIPBOARD_IMAGE_DOWNSCALE_SAFETY
+  )
 }


### PR DESCRIPTION
## Description
Oversized clipboard image pastes (e.g. OpenCode screenshots) are auto-downscaled to fit existing hard size caps instead of hard-failing with “Clipboard image is too large”.

## Focused fix
- In scope: `encodeClipboardImageWithinLimits` on desktop `saveImageAsTempFile` paste path; pure downscale helpers; regression tests
- Out of scope: RPC upload wire caps, Windows FileNameW metadata bomb path redesign, JPEG re-encode

## Preserves
- Same hard caps (24MB base64 / ~18MB source / 32MP pixels) as security/memory bounds
- Error still thrown when an image cannot be fit (e.g. 1×1 over byte cap)

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/shared/clipboard-image.test.ts src/main/window/clipboard-image-fit.test.ts src/main/window/clipboard-ipc-handlers.test.ts` (+ related clipboard suites green)

## User-regression-tradeoffs
- Very large pastes may be slightly downscaled visually so attach succeeds within limits

Fixes #11000