### PR TITLE
fix(droid): stop rendering Orca hook runs in the Droid TUI

### DIFF
--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -266,13 +266,24 @@ describe('Windows managed hook stdin structure', () => {
         expect(script, `${fileName} pane guard`).toContain(
           'if "%ORCA_PANE_KEY%"=="" goto :orca_agent_hook_drain_stdin'
         )
-        expect(script, `${fileName} drain epilogue`).toContain(
-          [
-            ':orca_agent_hook_drain_stdin',
-            '"%SystemRoot%\\System32\\more.com" >nul 2>nul',
-            'exit /b 0'
-          ].join('\r\n')
-        )
+        // Why: droid inserts Factory suppressOutput echo before exit (#11122);
+        // other agents keep the shared drain → exit epilogue byte-identical.
+        if (fileName === 'droid-hook.cmd') {
+          expect(script, `${fileName} drain label`).toContain(':orca_agent_hook_drain_stdin')
+          expect(script, `${fileName} drain reader`).toContain(
+            '"%SystemRoot%\\System32\\more.com" >nul 2>nul'
+          )
+          expect(script, `${fileName} suppressOutput`).toContain('{"suppressOutput":true}')
+          expect(script, `${fileName} exit`).toContain('exit /b 0')
+        } else {
+          expect(script, `${fileName} drain epilogue`).toContain(
+            [
+              ':orca_agent_hook_drain_stdin',
+              '"%SystemRoot%\\System32\\more.com" >nul 2>nul',
+              'exit /b 0'
+            ].join('\r\n')
+          )
+        }
       }
 
       const copilot = readFileSync(join(hooksDir, 'copilot-hook.ps1'), 'utf8')

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -269,12 +269,16 @@ describe('Windows managed hook stdin structure', () => {
         // Why: droid inserts Factory suppressOutput echo before exit (#11122);
         // other agents keep the shared drain → exit epilogue byte-identical.
         if (fileName === 'droid-hook.cmd') {
-          expect(script, `${fileName} drain label`).toContain(':orca_agent_hook_drain_stdin')
-          expect(script, `${fileName} drain reader`).toContain(
-            '"%SystemRoot%\\System32\\more.com" >nul 2>nul'
+          // Why: contiguous order matters — echo before more.com would leak
+          // suppressOutput before stdin is drained (#11122 / Greptile).
+          expect(script, `${fileName} drain epilogue`).toContain(
+            [
+              ':orca_agent_hook_drain_stdin',
+              '"%SystemRoot%\\System32\\more.com" >nul 2>nul',
+              'echo {"suppressOutput":true}',
+              'exit /b 0'
+            ].join('\r\n')
           )
-          expect(script, `${fileName} suppressOutput`).toContain('{"suppressOutput":true}')
-          expect(script, `${fileName} exit`).toContain('exit /b 0')
         } else {
           expect(script, `${fileName} drain epilogue`).toContain(
             [

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -775,6 +775,10 @@ describe('remote hook service installers', () => {
     const script = fs.files.get('/home/dev/.orca/agent-hooks/droid-hook.sh')
     expect(script).toContain('#!/bin/sh')
     expect(script).toContain('/hook/droid')
+    // Why: #11122 — remote install must ship the same suppressOutput contract
+    // as local so SSH Droid sessions do not paint Hooks event noise either.
+    expect(script).toContain('{"suppressOutput":true}')
+    expect(script).toMatch(/trap .*suppressOutput.*EXIT/)
     expect(fs.modes.get('/home/dev/.orca/agent-hooks/droid-hook.sh')).toBe(0o755)
   })
 

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -80,6 +81,47 @@ describe('DroidHookService', () => {
       expect(config.hooks.PreToolUse[0].hooks[0].command).toContain(join(homeDir, '.orca'))
     }
     expect(config.hooks.PreToolUse[0].hooks[0].command).not.toContain(userDataDir)
+  })
+
+  // Why: Factory paints a "Hooks <Event>" chat block for every exit-0 command
+  // hook unless stdout is suppressOutput JSON (#11122). Status posts still run.
+  it('emits Factory suppressOutput JSON so Orca status hooks stay out of the Droid TUI', () => {
+    expect(new DroidHookService().install().state).toBe('installed')
+
+    const scriptFileName = process.platform === 'win32' ? 'droid-hook.cmd' : 'droid-hook.sh'
+    const scriptPath = join(homeDir, '.orca', 'agent-hooks', scriptFileName)
+    const script = readFileSync(scriptPath, 'utf8')
+    expect(script).toContain('{"suppressOutput":true}')
+    if (process.platform === 'win32') {
+      expect(script).toMatch(/echo \{"suppressOutput":true\}[\s\S]*exit \/b 0/)
+      expect(script).toContain(':orca_agent_hook_drain_stdin')
+      return
+    }
+
+    expect(script).toMatch(/trap .*suppressOutput.*EXIT/)
+    // Why: execute early-exit and happy-path branches so a broken trap quote
+    // cannot ship even if the source still contains the JSON literal.
+    for (const [label, env, input] of [
+      ['empty-payload', {}, ''],
+      ['missing-env', {}, '{"hook_event_name":"Stop"}'],
+      [
+        'full-env',
+        {
+          ORCA_AGENT_HOOK_PORT: '1',
+          ORCA_AGENT_HOOK_TOKEN: 't',
+          ORCA_PANE_KEY: 'p'
+        },
+        '{"hook_event_name":"Stop"}'
+      ]
+    ] as const) {
+      const result = spawnSync('/bin/sh', [scriptPath], {
+        input,
+        encoding: 'utf8',
+        env: { ...process.env, ...env }
+      })
+      expect(result.status, label).toBe(0)
+      expect(result.stdout.trim(), label).toBe('{"suppressOutput":true}')
+    }
   })
 
   // Why: #6078 — a Windows user profile path with a space used to be written

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -117,7 +117,16 @@ describe('DroidHookService', () => {
       const result = spawnSync('/bin/sh', [scriptPath], {
         input,
         encoding: 'utf8',
-        env: { ...process.env, ...env }
+        // Why: clear inherited hook env so missing-env cases cannot pick up a
+        // parent ORCA_* endpoint and skip the early-exit branch (CodeRabbit).
+        env: {
+          ...process.env,
+          ORCA_AGENT_HOOK_ENDPOINT: '',
+          ORCA_AGENT_HOOK_PORT: '',
+          ORCA_AGENT_HOOK_TOKEN: '',
+          ORCA_PANE_KEY: '',
+          ...env
+        }
       })
       expect(result.status, label).toBe(0)
       expect(result.stdout.trim(), label).toBe('{"suppressOutput":true}')

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -24,7 +24,8 @@ import {
 import {
   buildPosixHookPayloadCapture,
   buildWindowsHookEnvironmentGuardLines,
-  buildWindowsHookStdinDrainEpilogue
+  WINDOWS_HOOK_STDIN_DRAIN_COMMAND,
+  WINDOWS_HOOK_STDIN_DRAIN_LABEL
 } from '../agent-hooks/hook-stdin-contract'
 
 // Why: SessionStart is installed (not just listened for) so that resuming a
@@ -76,6 +77,11 @@ function getManagedCommand(scriptPath: string): string {
     : wrapPosixHookCommand(scriptPath)
 }
 
+// Why: Factory's chat view renders a "Hooks <Event>" block for every command
+// hook that exits 0 without this JSON. suppressOutput hides the block from the
+// conversation while still posting status to Orca (#11122).
+const DROID_HOOK_SUPPRESS_OUTPUT_JSON = '{"suppressOutput":true}'
+
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
@@ -84,14 +90,23 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       ...buildWindowsHookEnvironmentGuardLines(),
       buildWindowsAgentHookPostCommand('droid'),
+      `echo ${DROID_HOOK_SUPPRESS_OUTPUT_JSON}`,
       'exit /b 0',
-      ...buildWindowsHookStdinDrainEpilogue(),
+      // Why: drain path also needs suppressOutput — missing env still exits 0
+      // and Factory would otherwise paint a Hooks block for the empty run.
+      `:${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
+      WINDOWS_HOOK_STDIN_DRAIN_COMMAND,
+      `echo ${DROID_HOOK_SUPPRESS_OUTPUT_JSON}`,
+      'exit /b 0',
       ''
     ].join('\r\n')
   }
 
   return [
     '#!/bin/sh',
+    // Why: cover empty-payload and missing-env early exits without duplicating
+    // the printf on every branch; EXIT fires for every successful path.
+    `trap 'printf '\\''%s\\n'\\'' '\\''${DROID_HOOK_SUPPRESS_OUTPUT_JSON}'\\''' EXIT`,
     ...buildPosixHookPayloadCapture(),
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',


### PR DESCRIPTION
## Description
Factory Droid no longer floods the conversation with “Hooks …” lines for Orca status hooks. Managed hook scripts emit Factory’s `suppressOutput: true` so exit-0 hooks stay out of the main chat.

## Focused fix
- In scope: POSIX/Windows droid-hook script stdout contract; local + remote install tests
- Out of scope: removing lifecycle events, changing status POST payload, Factory settings schema migration

## Preserves
- Full DROID_EVENTS set (SessionStart, UserPromptSubmit, Pre/PostToolUse, Stop, …)
- Status reporting via `/hook/droid` curl path

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/main/droid/hook-service.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts src/main/agent-hooks/managed-hook-timeout.test.ts` → 39 passed, 2 skipped

## User-regression-tradeoffs
- Hook runs may still appear in Factory’s detailed transcript; main chat stays clean. Existing sessions need hook reinstall/restart to pick up the new script.

Fixes #11122