### PR TITLE
feat(workspace): allow selecting empty workspaces without auto-terminal

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1449,8 +1449,7 @@ function Terminal(): React.JSX.Element | null {
   ])
   // Why: on host unmount no reconciliation effect runs again, so dispose every remaining parked watcher.
   useEffect(() => () => disposeAllParkedTerminalWatchers(), [])
-  // Why: do not auto-create a terminal here — reselect of an emptied workspace must stay empty
-  // (#11108). First activation / create-flow seeding lives in activateAndRevealWorktree.
+  // Empty reselection stays terminal-less; activation flows own first-terminal seeding (#11108).
 
   const startupResumeWorktreeIdsRef = useRef(new Set<string>())
   useEffect(() => {

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -81,7 +81,6 @@ import {
 } from '../hooks/ipc-tab-switch'
 import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 import AiVaultSessionDropLayer from './tab-group/AiVaultSessionDropLayer'
-import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
 import { useActiveTerminalRepair } from './terminal/use-active-terminal-repair'
 import { scheduleBackgroundTerminalWorktreeMeasure } from './terminal/background-terminal-worktree-visibility'
 import {
@@ -382,7 +381,6 @@ function Terminal(): React.JSX.Element | null {
   const layoutByWorktree = useAppStore((s) => s.layoutByWorktree)
   const activeGroupIdByWorktree = useAppStore((s) => s.activeGroupIdByWorktree)
   const ensureWorktreeRootGroup = useAppStore((s) => s.ensureWorktreeRootGroup)
-  const reconcileWorktreeTabModel = useAppStore((s) => s.reconcileWorktreeTabModel)
 
   const markFileDirty = useAppStore((s) => s.markFileDirty)
   const setTabBarOrder = useAppStore((s) => s.setTabBarOrder)
@@ -1451,27 +1449,8 @@ function Terminal(): React.JSX.Element | null {
   ])
   // Why: on host unmount no reconciliation effect runs again, so dispose every remaining parked watcher.
   useEffect(() => () => disposeAllParkedTerminalWatchers(), [])
-  // Auto-create first tab when worktree activates
-  useEffect(() => {
-    if (!workspaceSessionReady) {
-      return
-    }
-    if (!activeWorktreeId) {
-      return
-    }
-    // Why: host session-tabs are authoritative in the paired web client; a local fallback races the host's initial terminal and duplicates tabs.
-    if (isWebRuntimeSessionActive(getActiveWorktreeRuntimeEnvironmentId(activeWorktreeId))) {
-      return
-    }
-
-    // Why: give a newly activated worktree a focusable surface when nothing renders, without recreating one after the user closes the last visible tab.
-    const { renderableTabCount } = reconcileWorktreeTabModel(activeWorktreeId)
-    if (!shouldAutoCreateInitialTerminal(renderableTabCount)) {
-      return
-    }
-    // Why: tag this never-visited-worktree tab so its PTY spawn doesn't count as activity and reshuffle the sidebar (explicit New Tab still bumps).
-    createTab(activeWorktreeId, undefined, undefined, { pendingActivationSpawn: true })
-  }, [workspaceSessionReady, activeWorktreeId, createTab, reconcileWorktreeTabModel])
+  // Why: do not auto-create a terminal here — reselect of an emptied workspace must stay empty
+  // (#11108). First activation / create-flow seeding lives in activateAndRevealWorktree.
 
   const startupResumeWorktreeIdsRef = useRef(new Set<string>())
   useEffect(() => {

--- a/src/renderer/src/lib/worktree-activation-created-agent.test.ts
+++ b/src/renderer/src/lib/worktree-activation-created-agent.test.ts
@@ -86,17 +86,16 @@ describe('activateAndRevealWorktree', () => {
     expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
   })
 
-  it('does not relaunch on repeated activate/close cycles', () => {
+  it('keeps later activate/close cycles empty after the first activation', () => {
     const worktree = makeWorktree()
     seedEmptyActivatableWorktree(worktree)
 
-    for (let cycle = 0; cycle < 3; cycle += 1) {
-      activateAndExpectNoRelaunch(worktree.id)
+    activateAndExpectNoRelaunch(worktree.id)
+    useAppStore.setState({ tabsByWorktree: {}, activeTabIdByWorktree: {} })
 
-      // Return to zero tabs, the state that used to re-arm the relaunch. Sets state
-      // directly rather than via closeTab — the sleeping-record purge is covered in
-      // worktree-reactivation-tab-forkbomb.test.ts.
-      useAppStore.setState({ tabsByWorktree: {}, activeTabIdByWorktree: {} })
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      expect(activateAndRevealWorktree(worktree.id)).toEqual({ primaryTabId: null })
+      expect(useAppStore.getState().tabsByWorktree[worktree.id] ?? []).toEqual([])
     }
   })
 

--- a/src/renderer/src/lib/worktree-activation-empty-reselect.test.ts
+++ b/src/renderer/src/lib/worktree-activation-empty-reselect.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { activateAndRevealWorktree } from './worktree-activation'
+import { makeCreatedAgentWorktree as makeWorktree } from '@/lib/worktree-activation-created-agent-test-state'
+
+const initialAppStoreState = useAppStore.getState()
+
+afterEach(() => {
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function seedEmptyPreviouslyActivatedWorktree(
+  worktree: ReturnType<typeof makeWorktree>,
+  overrides: Partial<ReturnType<typeof useAppStore.getState>> = {}
+): { revealWorktreeInSidebar: ReturnType<typeof vi.fn> } {
+  const revealWorktreeInSidebar = vi.fn()
+  useAppStore.setState({
+    repos: [
+      {
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000000',
+        addedAt: 0
+      }
+    ],
+    worktreesByRepo: { 'repo-1': [worktree] },
+    activeRepoId: 'repo-1',
+    activeWorktreeId: null,
+    activeView: 'terminal',
+    tabsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    activeGroupIdByWorktree: {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    activeFileIdByWorktree: {},
+    activeBrowserTabIdByWorktree: {},
+    activeTabTypeByWorktree: {},
+    activeTabIdByWorktree: {},
+    tabBarOrderByWorktree: {},
+    pendingStartupByTabId: {},
+    everActivatedWorktreeIds: new Set([worktree.id]),
+    settings: {
+      agentCmdOverrides: {},
+      setupScriptLaunchMode: 'new-tab'
+    } as unknown as ReturnType<typeof useAppStore.getState>['settings'],
+    markWorktreeVisited: vi.fn(),
+    recordWorktreeVisit: vi.fn(),
+    refreshGitHubForWorktreeIfStale: vi.fn(),
+    revealWorktreeInSidebar,
+    ...overrides
+  })
+  return { revealWorktreeInSidebar }
+}
+
+describe('activateAndRevealWorktree empty reselect (#11108)', () => {
+  it('does not auto-create a terminal or relaunch the creation agent when reselecting an emptied workspace', () => {
+    const worktree = makeWorktree()
+    const createTab = vi.fn(() => ({ id: 'should-not-create' }))
+    const { revealWorktreeInSidebar } = seedEmptyPreviouslyActivatedWorktree(worktree, {
+      createTab
+    } as never)
+
+    const result = activateAndRevealWorktree(worktree.id)
+    const state = useAppStore.getState()
+
+    expect(result).toEqual({ primaryTabId: null })
+    expect(createTab).not.toHaveBeenCalled()
+    expect(state.tabsByWorktree[worktree.id] ?? []).toEqual([])
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(state.activeWorktreeId).toBe(worktree.id)
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
+  })
+
+  it('still seeds a terminal for explicit create-flow startup when reselecting an emptied workspace', () => {
+    const worktree = makeWorktree()
+    const { revealWorktreeInSidebar } = seedEmptyPreviouslyActivatedWorktree(worktree)
+
+    const result = activateAndRevealWorktree(worktree.id, {
+      startup: {
+        command: 'echo create-flow',
+        launchAgent: 'codex',
+        telemetry: {
+          agent_kind: 'codex',
+          launch_source: 'composer',
+          request_kind: 'new'
+        }
+      }
+    })
+    const state = useAppStore.getState()
+    const seededTab = state.tabsByWorktree[worktree.id]?.[0]
+
+    expect(result).toEqual({ primaryTabId: seededTab?.id })
+    expect(seededTab).toBeDefined()
+    expect(state.pendingStartupByTabId[seededTab!.id]?.command).toBe('echo create-flow')
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
+  })
+})

--- a/src/renderer/src/lib/worktree-activation-empty-reselect.test.ts
+++ b/src/renderer/src/lib/worktree-activation-empty-reselect.test.ts
@@ -1,12 +1,27 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '@/store'
-import { activateAndRevealWorktree } from './worktree-activation'
+import type { FolderWorkspace, ProjectGroup } from '../../../shared/types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import { makeCreatedAgentWorktree as makeWorktree } from '@/lib/worktree-activation-created-agent-test-state'
+
+const resumeSleepingMock = vi.hoisted(() => vi.fn(() => 0))
+
+vi.mock('@/lib/resume-sleeping-agent-session', () => ({
+  resumeSleepingAgentSessionsForWorktree: resumeSleepingMock
+}))
+
+const { activateAndRevealFolderWorkspace, activateAndRevealWorktree } =
+  await import('./worktree-activation')
 
 const initialAppStoreState = useAppStore.getState()
 
 afterEach(() => {
   useAppStore.setState(initialAppStoreState, true)
+  resumeSleepingMock.mockClear()
+})
+
+beforeEach(() => {
+  resumeSleepingMock.mockClear()
 })
 
 function seedEmptyPreviouslyActivatedWorktree(
@@ -55,7 +70,85 @@ function seedEmptyPreviouslyActivatedWorktree(
   return { revealWorktreeInSidebar }
 }
 
-describe('activateAndRevealWorktree empty reselect (#11108)', () => {
+const projectGroup: ProjectGroup = {
+  id: 'group-1',
+  name: 'Platform',
+  parentPath: null,
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const folderWorkspace: FolderWorkspace = {
+  id: 'folder-workspace-1',
+  projectGroupId: projectGroup.id,
+  name: 'Notes folder',
+  folderPath: '/workspace/notes',
+  linkedTask: null,
+  comment: '',
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 1,
+  lastActivityAt: 0,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+function seedEmptyPreviouslyActivatedFolderWorkspace(
+  overrides: Partial<ReturnType<typeof useAppStore.getState>> = {}
+): {
+  revealWorktreeInSidebar: ReturnType<typeof vi.fn>
+  workspaceKey: string
+} {
+  const revealWorktreeInSidebar = vi.fn()
+  const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
+  useAppStore.setState({
+    projectGroups: [projectGroup],
+    folderWorkspaces: [folderWorkspace],
+    activeWorktreeId: null,
+    activeWorkspaceKey: null,
+    activeView: 'terminal',
+    tabsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    groupsByWorktree: {},
+    layoutByWorktree: {},
+    activeGroupIdByWorktree: {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    activeFileIdByWorktree: {},
+    activeBrowserTabIdByWorktree: {},
+    activeTabTypeByWorktree: {},
+    activeTabIdByWorktree: {},
+    tabBarOrderByWorktree: {},
+    pendingStartupByTabId: {},
+    // Why: previously activated + empty tabs is the empty-reselect policy under test.
+    everActivatedWorktreeIds: new Set([workspaceKey]),
+    settings: {
+      agentCmdOverrides: {},
+      setupScriptLaunchMode: 'new-tab'
+    } as unknown as ReturnType<typeof useAppStore.getState>['settings'],
+    markWorktreeVisited: vi.fn(),
+    recordWorktreeVisit: vi.fn(),
+    // Why: null does not block activation (only confirmed stale / ambiguous).
+    getFreshFolderWorkspacePathStatus: vi.fn(() => null),
+    setActiveFolderWorkspace: vi.fn((id: string) => {
+      useAppStore.setState({
+        activeWorkspaceKey: folderWorkspaceKey(id),
+        activeWorktreeId: null
+      })
+    }),
+    revealWorktreeInSidebar,
+    ...overrides
+  })
+  return { revealWorktreeInSidebar, workspaceKey }
+}
+
+describe('activateAndRevealWorktree empty reselect (#11108 / #11159)', () => {
   it('does not auto-create a terminal or relaunch the creation agent when reselecting an emptied workspace', () => {
     const worktree = makeWorktree()
     const createTab = vi.fn(() => ({ id: 'should-not-create' }))
@@ -72,6 +165,8 @@ describe('activateAndRevealWorktree empty reselect (#11108)', () => {
     expect(state.pendingStartupByTabId).toEqual({})
     expect(state.activeWorktreeId).toBe(worktree.id)
     expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
+    // Why: empty reselect must not wake sleeping agents into a terminal-less workspace.
+    expect(resumeSleepingMock).not.toHaveBeenCalled()
   })
 
   it('still seeds a terminal for explicit create-flow startup when reselecting an emptied workspace', () => {
@@ -84,7 +179,7 @@ describe('activateAndRevealWorktree empty reselect (#11108)', () => {
         launchAgent: 'codex',
         telemetry: {
           agent_kind: 'codex',
-          launch_source: 'composer',
+          launch_source: 'new_workspace_composer',
           request_kind: 'new'
         }
       }
@@ -96,5 +191,64 @@ describe('activateAndRevealWorktree empty reselect (#11108)', () => {
     expect(seededTab).toBeDefined()
     expect(state.pendingStartupByTabId[seededTab!.id]?.command).toBe('echo create-flow')
     expect(revealWorktreeInSidebar).toHaveBeenCalledWith(worktree.id)
+    expect(resumeSleepingMock).toHaveBeenCalledWith(worktree.id)
+  })
+})
+
+describe('activateAndRevealFolderWorkspace empty reselect (#11159)', () => {
+  it('does not seed a terminal or resume sleeping agents when reselecting an emptied folder workspace', () => {
+    const createTab = vi.fn(() => ({ id: 'should-not-create' }))
+    const { revealWorktreeInSidebar, workspaceKey } = seedEmptyPreviouslyActivatedFolderWorkspace({
+      createTab
+    } as never)
+
+    const result = activateAndRevealFolderWorkspace(folderWorkspace.id)
+    const state = useAppStore.getState()
+
+    expect(result).toEqual({ primaryTabId: null })
+    expect(createTab).not.toHaveBeenCalled()
+    expect(state.tabsByWorktree[workspaceKey] ?? []).toEqual([])
+    expect(state.pendingStartupByTabId).toEqual({})
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(workspaceKey)
+    expect(resumeSleepingMock).not.toHaveBeenCalled()
+  })
+
+  it('still seeds a terminal and may resume sleeping agents when startup is explicit', () => {
+    const { revealWorktreeInSidebar, workspaceKey } = seedEmptyPreviouslyActivatedFolderWorkspace()
+
+    const result = activateAndRevealFolderWorkspace(folderWorkspace.id, {
+      startup: {
+        command: 'echo folder-create-flow',
+        launchAgent: 'codex',
+        telemetry: {
+          agent_kind: 'codex',
+          launch_source: 'new_workspace_composer',
+          request_kind: 'new'
+        }
+      }
+    })
+    const state = useAppStore.getState()
+    const seededTab = state.tabsByWorktree[workspaceKey]?.[0]
+
+    expect(result).toEqual({ primaryTabId: seededTab?.id })
+    expect(seededTab).toBeDefined()
+    expect(state.pendingStartupByTabId[seededTab!.id]?.command).toBe('echo folder-create-flow')
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(workspaceKey)
+    expect(resumeSleepingMock).toHaveBeenCalledWith(workspaceKey)
+  })
+
+  it('seeds on first folder activation when never activated before', () => {
+    const { revealWorktreeInSidebar, workspaceKey } = seedEmptyPreviouslyActivatedFolderWorkspace({
+      everActivatedWorktreeIds: new Set()
+    })
+
+    const result = activateAndRevealFolderWorkspace(folderWorkspace.id)
+    const state = useAppStore.getState()
+    const seededTab = state.tabsByWorktree[workspaceKey]?.[0]
+
+    expect(result).toEqual({ primaryTabId: seededTab?.id })
+    expect(seededTab).toBeDefined()
+    expect(revealWorktreeInSidebar).toHaveBeenCalledWith(workspaceKey)
+    expect(resumeSleepingMock).toHaveBeenCalledWith(workspaceKey)
   })
 })

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -241,15 +241,25 @@ export function activateAndRevealFolderWorkspace(
     state.setActiveView('terminal')
   }
 
+  const workspaceKey = folderWorkspaceKey(folderWorkspaceId)
+  // Why: same empty-reselect policy as git worktrees (#11108) — seed only on first open or explicit startup.
+  const shouldSeedInitialTerminal =
+    Boolean(opts?.startup) || !state.everActivatedWorktreeIds.has(workspaceKey)
+
   state.setActiveFolderWorkspace(folderWorkspaceId, opts?.executionHostId)
 
-  const workspaceKey = folderWorkspaceKey(folderWorkspaceId)
   state.markWorktreeVisited(workspaceKey)
   if (!state.isNavigatingHistory) {
     state.recordWorktreeVisit(workspaceKey)
   }
-  resumeSleepingAgentSessionsForWorktree(workspaceKey)
-  const primaryTabId = ensureFolderWorkspaceInitialTerminal(folderWorkspace, opts?.startup)
+  // Why: empty reselect must not wake sleeping agents into a workspace the user
+  // deliberately left terminal-less (#11108 / CodeRabbit on #11159).
+  if (shouldSeedInitialTerminal) {
+    resumeSleepingAgentSessionsForWorktree(workspaceKey)
+  }
+  const primaryTabId = shouldSeedInitialTerminal
+    ? ensureFolderWorkspaceInitialTerminal(folderWorkspace, opts?.startup)
+    : null
 
   if (opts?.sidebarRevealBehavior) {
     state.revealWorktreeInSidebar(workspaceKey, { behavior: opts.sidebarRevealBehavior })
@@ -282,9 +292,15 @@ export function activateAndRevealWorktree(
   const hasActivationWork = Boolean(
     opts?.startup || opts?.setup || opts?.defaultTabs || opts?.issueCommand
   )
+  // Why: check before setActiveWorktree marks everActivated — reselect of a previously
+  // emptied workspace must stay empty (#11108); first open and create-flow still seed.
+  const isFirstActivation = !state.everActivatedWorktreeIds.has(worktreeId)
+  const shouldSeedInitialTerminal =
+    hasActivationWork || Boolean(opts?.initialCwd) || isFirstActivation
   // Why: a plain reselect should still reveal the sidebar row but must not restamp focus recency or wake persistence.
   const isPlainAlreadyActiveTerminal =
     !hasActivationWork &&
+    !opts?.initialCwd &&
     state.activeRepoId === wt.repoId &&
     state.activeWorktreeId === worktreeId &&
     state.activeWorkspaceExecutionHostId === (opts?.executionHostId ?? null) &&
@@ -322,18 +338,25 @@ export function activateAndRevealWorktree(
     state.recordWorktreeVisit(worktreeId)
   }
 
-  // Why: sleeping destroys the local PTY but preserves the provider session id, so waking should restore those CLI sessions automatically.
-  resumeSleepingAgentSessionsForWorktree(worktreeId)
+  // Why: sleeping destroys the local PTY but preserves the provider session id,
+  // so waking should restore those CLI sessions — but not when reselecting an
+  // empty workspace that must stay empty (#11108).
+  if (shouldSeedInitialTerminal) {
+    resumeSleepingAgentSessionsForWorktree(worktreeId)
+  }
 
-  // 4. Ensure a focusable surface exists for externally-created worktrees
-  const primaryTabId = ensureWorktreeHasInitialTerminal(
-    useAppStore.getState(),
-    worktreeId,
-    opts?.startup,
-    opts?.setup,
-    opts?.issueCommand,
-    opts?.defaultTabs
-  )
+  // 4. Seed a terminal only on first activation or explicit create/launch work — not on
+  // reselect after the user closed every tab (#11108).
+  const primaryTabId = shouldSeedInitialTerminal
+    ? ensureWorktreeHasInitialTerminal(
+        useAppStore.getState(),
+        worktreeId,
+        opts?.startup,
+        opts?.setup,
+        opts?.issueCommand,
+        opts?.defaultTabs
+      )
+    : null
   if (primaryTabId && opts?.initialCwd) {
     useAppStore.getState().queueTabInitialCwd(primaryTabId, opts.initialCwd)
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -526,9 +526,9 @@ export type Worktree = {
    *  grant newly-created worktrees a short grace window at the top of Recent,
    *  immune to ambient PTY-bump reordering in other worktrees. */
   createdAt?: number
-  /** Agent selected when Orca originally created the worktree. Used only to
-   *  seed a replacement terminal if the user later reopens the worktree after
-   *  closing every visible surface. */
+  /** Agent selected when Orca originally created the worktree. Used to seed the
+   *  first activation terminal after create; plain reselect of an emptied
+   *  workspace no longer auto-relaunches (#11108). */
   createdWithAgent?: TuiAgent
   /** True while an auto-named workspace is waiting for the first agent message
    *  to drive the branch/title rename. */


### PR DESCRIPTION
## Description
Re-selecting a workspace after all tabs were closed no longer auto-creates a blank terminal or relaunches the creation agent. The workspace can stay empty until the user explicitly opens a tab.

## Focused fix
- In scope: gate `ensureWorktreeHasInitialTerminal` on first-activation / explicit create work; remove Terminal.tsx auto-create-on-activate effect; regression tests
- Out of scope: new Settings toggle (not required for minimal fix), dedicated empty-state redesign

## Preserves
- First activation this session still seeds a terminal (and creation agent when configured)
- Explicit create/launch paths with startup/setup/defaultTabs still seed as before
- Folder workspaces follow the same reselect policy

## Evidence
- worktree-activation* + empty-reselect + related store tests green (see suite run in worktree)

## User-regression-tradeoffs
- After restart, first activation of a previously emptied workspace may still seed a terminal (`everActivated` is session-scoped). Same-session empty reselect is fixed.

Fixes #11108