### PR TITLE
refactor(shared): centralize error messages

### DIFF
--- a/src/main/ai-vault/session-scanner-values.ts
+++ b/src/main/ai-vault/session-scanner-values.ts
@@ -160,4 +160,5 @@ export {
   subtractCodexUsage,
   tokenTotal
 } from './session-scanner-token-values'
+/** Convert unknown scanner failures using the shared error-message policy. */
 export { errorMessage } from '../../shared/error-message'

--- a/src/main/ai-vault/session-scanner-values.ts
+++ b/src/main/ai-vault/session-scanner-values.ts
@@ -151,10 +151,6 @@ export function clampPositiveInteger(value: number | undefined, fallback: number
   return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : fallback
 }
 
-export function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err)
-}
-
 export {
   addCodexUsage,
   claudeUsageTotal,
@@ -164,3 +160,4 @@ export {
   subtractCodexUsage,
   tokenTotal
 } from './session-scanner-token-values'
+export { errorMessage } from '../../shared/error-message'

--- a/src/main/ai-vault/session-scanner-values.ts
+++ b/src/main/ai-vault/session-scanner-values.ts
@@ -147,6 +147,7 @@ export function normalizeAgentSessionsDir(
   return normalized
 }
 
+/** Return a positive integer or the provided fallback. */
 export function clampPositiveInteger(value: number | undefined, fallback: number): number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : fallback
 }

--- a/src/main/ipc/agent-hooks.ts
+++ b/src/main/ipc/agent-hooks.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../shared/agent-status-types'
 import type { AgentInterruptInferenceRequest } from '../../shared/agent-interrupt-intent'
 import type { AgentQuestionAnsweredInferenceRequest } from '../../shared/agent-question-answered-intent'
+import { errorMessage } from '../../shared/error-message'
 import { agentHookServer, isValidPaneKey } from '../agent-hooks/server'
 import { ampHookService } from '../amp/hook-service'
 import {
@@ -148,7 +149,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -161,7 +162,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -174,7 +175,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -187,7 +188,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -200,7 +201,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -213,7 +214,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -226,7 +227,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -239,7 +240,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -252,7 +253,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -265,7 +266,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -278,7 +279,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -291,7 +292,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -304,7 +305,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })
@@ -317,7 +318,7 @@ export function registerAgentHookHandlers(
         state: 'error',
         configPath: '',
         managedHooksPresent: false,
-        detail: err instanceof Error ? err.message : String(err)
+        detail: errorMessage(err)
       }
     }
   })

--- a/src/main/ipc/agent-hooks.ts
+++ b/src/main/ipc/agent-hooks.ts
@@ -43,6 +43,7 @@ type AgentHookHandlerDependencies = {
 // auto-installs managed hooks at app startup (see src/main/index.ts), so a
 // renderer-triggered remove would be silently reverted on the next launch
 // and mislead the user.
+/** Register main-process IPC handlers for agent-hook status and inference. */
 export function registerAgentHookHandlers(
   runtime?: AgentStatusRuntimeEnrichment,
   dependencies: AgentHookHandlerDependencies = {}

--- a/src/shared/error-message.test.ts
+++ b/src/shared/error-message.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { errorMessage } from './error-message'
+
+describe('errorMessage', () => {
+  it('returns the message from Error instances', () => {
+    expect(errorMessage(new Error('permission denied'))).toBe('permission denied')
+  })
+
+  it.each([
+    ['plain failure', 'plain failure'],
+    [404, '404'],
+    [null, 'null'],
+    [{ code: 'EFAIL' }, '[object Object]']
+  ])('stringifies non-Error values', (value, expected) => {
+    expect(errorMessage(value)).toBe(expected)
+  })
+})

--- a/src/shared/error-message.ts
+++ b/src/shared/error-message.ts
@@ -1,0 +1,4 @@
+/** Convert an unknown thrown value into the message used by existing error surfaces. */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}


### PR DESCRIPTION
## Summary

- Add a canonical `src/shared/error-message.ts` primitive for the existing `Error.message`/`String(value)` behavior.
- Re-export it from `session-scanner-values.ts` so existing AI-vault imports remain source-compatible.
- Replace 14 repeated error-message ternaries in the agent-hook status IPC handlers.
- Add focused tests for Error instances and representative non-Error values.

Addresses the high-density first migration slice of #10964. The remaining repository-wide call sites stay out of scope to keep the review focused.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted validation:

- Shared error-message, agent-hooks IPC, and session-scanner-values suites: 29 tests passed
- Node, CLI, and web TypeScript typechecks passed
- Touched-file `oxlint` and `oxfmt --check` passed
- Max-lines ratchet and `git diff --check` passed

## AI Review Report

The adversarial review checked exact behavior preservation for Error and non-Error values, shared-to-main dependency direction, circular-import risk, existing AI-vault import compatibility, and all 14 migrated handler paths. The existing `session-scanner-values` export remains available through a re-export, avoiding unrelated call-site churn.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows. This refactor does not alter shortcuts, labels, paths, shells, Electron platform behavior, SSH handling, or folder workspaces.

## Security Audit

No input handling, command execution, path handling, authentication, secrets, dependencies, or IPC contracts changed. Error text is produced with the exact previous policy, so this PR does not widen logging, telemetry, or data exposure.

## Notes

This intentionally avoids a 500-file mechanical codemod; later clusters can migrate independently to the canonical primitive.
