### PR TITLE
feat(git): route git clone through configured HTTP/SOCKS5 proxy

### DIFF
--- a/src/main/git/git-clone-proxy-env.test.ts
+++ b/src/main/git/git-clone-proxy-env.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { gitCloneEnvWithProxy } from './git-clone-proxy-env'
+
+describe('gitCloneEnvWithProxy', () => {
+  it('merges an http proxy into the git env', () => {
+    const env = gitCloneEnvWithProxy(
+      { PATH: '/usr/bin' },
+      { httpProxyUrl: 'http://proxy.example:8080' },
+      'linux'
+    )
+    expect(env.HTTP_PROXY).toBe('http://proxy.example:8080')
+    expect(env.HTTPS_PROXY).toBe('http://proxy.example:8080')
+    expect(env.ALL_PROXY).toBe('http://proxy.example:8080')
+    expect(env.http_proxy).toBe('http://proxy.example:8080')
+    expect(env.https_proxy).toBe('http://proxy.example:8080')
+    expect(env.all_proxy).toBe('http://proxy.example:8080')
+    // Original keys are preserved.
+    expect(env.PATH).toBe('/usr/bin')
+  })
+
+  it('merges a socks5 proxy so libcurl-backed git routes through it', () => {
+    const env = gitCloneEnvWithProxy({}, { httpProxyUrl: 'socks5://127.0.0.1:1080' }, 'linux')
+    expect(env.ALL_PROXY).toBe('socks5://127.0.0.1:1080')
+    expect(env.HTTPS_PROXY).toBe('socks5://127.0.0.1:1080')
+  })
+
+  it('applies bypass rules as NO_PROXY', () => {
+    const env = gitCloneEnvWithProxy(
+      {},
+      { httpProxyUrl: 'http://proxy.example:8080', httpProxyBypassRules: 'localhost;*.internal' },
+      'linux'
+    )
+    expect(env.NO_PROXY).toBe('localhost,*.internal')
+    expect(env.no_proxy).toBe('localhost,*.internal')
+  })
+
+  it('returns the env unchanged when no proxy is configured', () => {
+    const original = { PATH: '/usr/bin' }
+    expect(gitCloneEnvWithProxy(original, undefined, 'linux')).toBe(original)
+    expect(gitCloneEnvWithProxy(original, {}, 'linux')).toBe(original)
+    expect(gitCloneEnvWithProxy(original, { httpProxyUrl: '' }, 'linux')).toBe(original)
+  })
+
+  it('does not mutate WSLENV off win32', () => {
+    const env = gitCloneEnvWithProxy({}, { httpProxyUrl: 'http://proxy.example:8080' }, 'darwin')
+    expect(env.WSLENV).toBeUndefined()
+  })
+
+  it('forwards proxy keys into WSLENV on win32 so a WSL-routed clone receives them', () => {
+    const env = gitCloneEnvWithProxy(
+      {},
+      { httpProxyUrl: 'http://proxy.example:8080', httpProxyBypassRules: 'localhost' },
+      'win32'
+    )
+    const forwarded = new Set((env.WSLENV ?? '').split(':').filter(Boolean))
+    for (const key of ['HTTP_PROXY', 'HTTPS_PROXY', 'ALL_PROXY', 'NO_PROXY', 'no_proxy']) {
+      expect(forwarded.has(key)).toBe(true)
+    }
+  })
+
+  it('leaves the env untouched on win32 when no proxy is set (no empty WSLENV)', () => {
+    const original = {}
+    const env = gitCloneEnvWithProxy(original, undefined, 'win32')
+    expect(env).toBe(original)
+    expect(env.WSLENV).toBeUndefined()
+  })
+})

--- a/src/main/git/git-clone-proxy-env.ts
+++ b/src/main/git/git-clone-proxy-env.ts
@@ -1,0 +1,30 @@
+import { buildConfiguredProxyEnv, type NetworkProxySettings } from '../../shared/network-proxy'
+import { addWslEnvKeys } from '../wsl-env'
+
+/**
+ * Merge the app's configured proxy (http/https/socks/socks4/socks5) into a git
+ * clone env so clones honor the same proxy Orca uses for its other network
+ * children. Git routes transports through libcurl, which reads the standard
+ * ALL_PROXY/HTTP(S)_PROXY (+ NO_PROXY) vars buildConfiguredProxyEnv emits — so a
+ * socks5:// URL works without any git-config flags.
+ *
+ * On win32 the keys are added to WSLENV so a WSL-routed clone actually receives
+ * them (env does not cross the wsl.exe boundary otherwise). Returns `env`
+ * unchanged when no proxy is configured.
+ */
+export function gitCloneEnvWithProxy(
+  env: NodeJS.ProcessEnv,
+  proxySettings: NetworkProxySettings | null | undefined,
+  platform: NodeJS.Platform = process.platform
+): NodeJS.ProcessEnv {
+  const proxyEnv = buildConfiguredProxyEnv(proxySettings)
+  const proxyKeys = Object.keys(proxyEnv)
+  if (proxyKeys.length === 0) {
+    return env
+  }
+  const next = { ...env, ...proxyEnv }
+  if (platform === 'win32') {
+    addWslEnvKeys(next, proxyKeys)
+  }
+  return next
+}

--- a/src/main/ipc/repos/remote-repo-clone.ts
+++ b/src/main/ipc/repos/remote-repo-clone.ts
@@ -84,12 +84,18 @@ export async function cloneRemoteRepo(
     // Why: match local clone by creating the parent first, or a fresh remote parent surfaces as spawn ENOENT.
     await fsProvider.createDir(trimmedDestination)
     // Why: the SSH relay runs git argv, not a shell; use the repo folder name so git creates it under the chosen parent.
+    const settings = store.getSettings()
     await gitProvider.clone(
       ['clone', '--progress', '--', args.url.trim(), repoName],
       trimmedDestination,
       {
         signal: controller.signal,
         timeoutMs: 10 * 60_000,
+        // Why: forward the configured proxy so the remote clone routes through it (the relay can't see the desktop's proxy env).
+        ...(settings.httpProxyUrl?.trim() ? { proxyUrl: settings.httpProxyUrl.trim() } : {}),
+        ...(settings.httpProxyBypassRules?.trim()
+          ? { proxyBypassRules: settings.httpProxyBypassRules.trim() }
+          : {}),
         onProgress: (progress) => {
           if (!mainWindow.isDestroyed()) {
             mainWindow.webContents.send('repos:clone-progress', progress)

--- a/src/main/ipc/repos/remote-repo-clone.ts
+++ b/src/main/ipc/repos/remote-repo-clone.ts
@@ -26,6 +26,11 @@ type ActiveRemoteCloneMetadata = {
 let activeRemoteClone: ActiveRemoteCloneMetadata | null = null
 const remoteCloneInFlightByPath = new Set<string>()
 
+/**
+ * Clone a repo onto an SSH host via the relay, forwarding the app's configured
+ * proxy so the remote clone routes through it (the relay rebuilds git env from
+ * the remote host and cannot see the desktop's proxy).
+ */
 export async function cloneRemoteRepo(
   store: Store,
   mainWindow: BrowserWindow,

--- a/src/main/ipc/repos/repo-clone-lifecycle.ts
+++ b/src/main/ipc/repos/repo-clone-lifecycle.ts
@@ -9,6 +9,7 @@ import { isFolderRepo } from '../../../shared/repo-kind'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../../shared/constants'
 import { getGitCloneFailureMessage } from '../../../shared/git-clone-failure-message'
 import { gitSpawnAfterWindowsEnvironmentReady, nonInteractiveGitEnv } from '../../git/runner'
+import { gitCloneEnvWithProxy } from '../../git/git-clone-proxy-env'
 import { getRepoName } from '../../git/repo'
 import type { ClaimedCloneTarget } from '../../git/repo-clone-path'
 import {
@@ -148,7 +149,8 @@ export function registerRepoCloneHandlers(mainWindow: BrowserWindow, store: Stor
               cwd: args.destination,
               admissionTier: 'interactive',
               // Why: without this, an auth-needing clone pops Git Credential Manager's OAuth window on Windows, unclosable in a restricted env (issue #7652).
-              env: nonInteractiveGitEnv(),
+              // Why: honor the app's configured proxy so clones route through it like other Orca network children.
+              env: gitCloneEnvWithProxy(nonInteractiveGitEnv(), store.getSettings()),
               signal: pendingController.signal,
               stdio: ['ignore', 'ignore', 'pipe']
             }

--- a/src/main/providers/ssh-git-provider-exec.test.ts
+++ b/src/main/providers/ssh-git-provider-exec.test.ts
@@ -69,6 +69,36 @@ describe('SshGitProvider', () => {
     )
   })
 
+  it('forwards a configured proxy to the git.clone request', async () => {
+    mux.onNotificationByMethod.mockReturnValue(vi.fn())
+    mux.request.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await provider.clone(['clone', '--progress', '--', 'url', 'repo'], '/home/user', {
+      proxyUrl: 'socks5://127.0.0.1:1080',
+      proxyBypassRules: 'localhost;*.internal'
+    })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.clone',
+      expect.objectContaining({
+        proxyUrl: 'socks5://127.0.0.1:1080',
+        proxyBypassRules: 'localhost;*.internal'
+      }),
+      expect.anything()
+    )
+  })
+
+  it('omits proxy fields from git.clone when none is configured', async () => {
+    mux.onNotificationByMethod.mockReturnValue(vi.fn())
+    mux.request.mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await provider.clone(['clone', '--progress', '--', 'url', 'repo'], '/home/user')
+
+    const params = mux.request.mock.calls[0][1]
+    expect(params).not.toHaveProperty('proxyUrl')
+    expect(params).not.toHaveProperty('proxyBypassRules')
+  })
+
   it('execNonInteractive delegates fixed binary commands to the relay', async () => {
     const execResult = {
       stdout: '10.0.0\n',

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -68,6 +68,8 @@ export class SshGitProvider extends SshGitWorktreeProvider implements IGitProvid
       signal?: AbortSignal
       timeoutMs?: number
       onProgress?: (progress: { phase: string; percent: number }) => void
+      proxyUrl?: string
+      proxyBypassRules?: string
     }
   ): Promise<{ stdout: string; stderr: string }> {
     return this.runWithGitReadInvalidation(async () => {
@@ -87,7 +89,15 @@ export class SshGitProvider extends SshGitWorktreeProvider implements IGitProvid
       try {
         const result = await this.mux.request(
           'git.clone',
-          { args, cwd, progressId },
+          {
+            args,
+            cwd,
+            progressId,
+            // Why: the relay rebuilds git env from the remote host, so a locally
+            // configured proxy only reaches the clone when forwarded explicitly.
+            ...(options?.proxyUrl ? { proxyUrl: options.proxyUrl } : {}),
+            ...(options?.proxyBypassRules ? { proxyBypassRules: options.proxyBypassRules } : {})
+          },
           { signal: options?.signal, timeoutMs: options?.timeoutMs }
         )
         return result as { stdout: string; stderr: string }

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -61,6 +61,12 @@ export class SshGitProvider extends SshGitWorktreeProvider implements IGitProvid
     return result as { stdout: string; stderr: string }
   }
 
+  /**
+   * Clone a repo over the relay. `options.proxyUrl` / `options.proxyBypassRules`
+   * are forwarded to the remote `git.clone` so the clone routes through the
+   * desktop's configured proxy (the relay rebuilds env from the remote host and
+   * cannot otherwise see it). Omitted when no proxy is configured.
+   */
   async clone(
     args: string[],
     cwd: string,

--- a/src/main/runtime/runtime-repository-clone-controller.ts
+++ b/src/main/runtime/runtime-repository-clone-controller.ts
@@ -11,6 +11,7 @@ import {
   getClonePathComparisonKey
 } from '../git/repo-clone-path'
 import { gitSpawnAfterWindowsEnvironmentReady, nonInteractiveGitEnv } from '../git/runner'
+import { gitCloneEnvWithProxy } from '../git/git-clone-proxy-env'
 import { runWithGitReadCacheInvalidation } from '../git/status'
 import { invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
 import { isFolderRepo } from '../../shared/repo-kind'
@@ -106,7 +107,8 @@ export class RuntimeRepositoryCloneController {
         {
           cwd: trimmedDestination,
           admissionTier: 'interactive',
-          env: nonInteractiveGitEnv(),
+          // Why: honor the app's configured proxy so clones route through it like other Orca network children.
+          env: gitCloneEnvWithProxy(nonInteractiveGitEnv(), store.getSettings()),
           stdio: ['ignore', 'ignore', 'pipe']
         }
       )

--- a/src/main/runtime/runtime-store-contract.ts
+++ b/src/main/runtime/runtime-store-contract.ts
@@ -115,6 +115,9 @@ export type RuntimeStore = {
     terminalMainSideEffectAuthority?: GlobalSettings['terminalMainSideEffectAuthority']
     terminalHiddenDeliveryGate?: GlobalSettings['terminalHiddenDeliveryGate']
     terminalModelQueryAuthority?: GlobalSettings['terminalModelQueryAuthority']
+    // Why: git clone honors the app's configured proxy (see gitCloneEnvWithProxy).
+    httpProxyUrl?: GlobalSettings['httpProxyUrl']
+    httpProxyBypassRules?: GlobalSettings['httpProxyBypassRules']
     worktreeVisibilityDefaults?: GlobalSettings['worktreeVisibilityDefaults']
     hostSettingOverrides?: GlobalSettings['hostSettingOverrides']
     agentSkillSharingEnabled?: GlobalSettings['agentSkillSharingEnabled']

--- a/src/relay/git-handler-exec-operations.ts
+++ b/src/relay/git-handler-exec-operations.ts
@@ -18,6 +18,13 @@ export class GitHandlerExecOperations extends GitHandlerOperationContext {
     return this.maybeStreamResponse({ stdout, stderr }, params, context)
   }
 
+  /**
+   * Handle a `git.clone` RPC: validate the clone argv, then spawn git with the
+   * caller's forwarded proxy (`params.proxyUrl` / `params.proxyBypassRules`)
+   * applied as env only. Values are string-guarded here and re-derived through
+   * buildConfiguredProxyEnv, so a malformed value yields no proxy env rather
+   * than reaching git as an arbitrary string.
+   */
   async clone(params: Record<string, unknown>, context?: RequestContext) {
     const args = params.args as string[]
     const cwd = params.cwd as string

--- a/src/relay/git-handler-exec-operations.ts
+++ b/src/relay/git-handler-exec-operations.ts
@@ -29,8 +29,14 @@ export class GitHandlerExecOperations extends GitHandlerOperationContext {
     if (args[0] !== 'clone') {
       throw new Error('git.clone only supports clone commands.')
     }
+    // Why: normalizeProxyUrl already validated the scheme desktop-side; still
+    // build env via buildConfiguredProxyEnv so a malformed value simply yields
+    // no proxy keys rather than reaching git as an arbitrary string.
+    const proxyUrl = typeof params.proxyUrl === 'string' ? params.proxyUrl : undefined
+    const proxyBypassRules =
+      typeof params.proxyBypassRules === 'string' ? params.proxyBypassRules : undefined
     return await this.runWithGitReadCacheClear(() =>
-      this.spawnClone(args, cwd, progressId, context)
+      this.spawnClone(args, cwd, progressId, { proxyUrl, proxyBypassRules }, context)
     )
   }
 

--- a/src/relay/git-handler-operation-context.ts
+++ b/src/relay/git-handler-operation-context.ts
@@ -18,6 +18,7 @@ export type GitHandlerCommandOptions = {
 
 export type GitHandlerCommandResult = { stdout: string; stderr: string }
 export type GitHandlerWatcherRegistry = Pick<RelayFilesystemWatchRegistry, 'runWithRemovalFence'>
+export type GitCloneProxyOptions = { proxyUrl?: string; proxyBypassRules?: string }
 
 export type GitHandlerOperationHost = {
   readonly gitDiffReadDedupe: InFlightPromiseDedupe<unknown>
@@ -34,6 +35,7 @@ export type GitHandlerOperationHost = {
     args: string[],
     cwd: string,
     progressId: string,
+    proxy?: GitCloneProxyOptions,
     context?: RequestContext
   ): Promise<GitHandlerCommandResult>
   clearGitMutationReadCaches(): void
@@ -80,9 +82,10 @@ export abstract class GitHandlerOperationContext {
     args: string[],
     cwd: string,
     progressId: string,
+    proxy?: GitCloneProxyOptions,
     context?: RequestContext
   ): Promise<GitHandlerCommandResult> {
-    return this.host.spawnClone(args, cwd, progressId, context)
+    return this.host.spawnClone(args, cwd, progressId, proxy, context)
   }
 
   protected clearGitMutationReadCaches(): void {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -199,6 +199,11 @@ export class GitHandler {
     return stdout
   }
 
+  /**
+   * Spawn `git clone` on the relay host, merging the forwarded proxy into the
+   * unattended git env (env only — never argv), and stream progress back over
+   * `git.cloneProgress`.
+   */
   private async spawnClone(
     args: string[],
     cwd: string,

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -15,10 +15,12 @@ import { clearGitStatusLineStatsCache } from '../shared/git-status-line-stats-ca
 import { invalidateGitBranchLineTotalInFlight } from '../shared/git-branch-line-total'
 import { buildRelayGitEnv, buildRelayUnattendedGitEnv } from './relay-command-env'
 import { getGitCloneFailureMessage } from '../shared/git-clone-failure-message'
+import { buildConfiguredProxyEnv } from '../shared/network-proxy'
 import type {
   GitHandlerCommandOptions,
   GitHandlerCommandResult,
-  GitHandlerWatcherRegistry
+  GitHandlerWatcherRegistry,
+  GitCloneProxyOptions
 } from './git-handler-operation-context'
 import { createGitHandlerOperationSet } from './git-handler-operation-set'
 import { registerGitHandlers } from './git-handler-registration'
@@ -90,8 +92,8 @@ export class GitHandler {
       git: (args, cwd, opts) =>
         opts === undefined ? this.git(args, cwd) : this.git(args, cwd, opts),
       gitBuffer: (args, cwd) => this.gitBuffer(args, cwd),
-      spawnClone: (args, cwd, progressId, context) =>
-        this.spawnClone(args, cwd, progressId, context),
+      spawnClone: (args, cwd, progressId, proxy, context) =>
+        this.spawnClone(args, cwd, progressId, proxy, context),
       clearGitMutationReadCaches: () => this.clearGitMutationReadCaches(),
       runWithGitReadCacheClear: (run) => this.runWithGitReadCacheClear(run),
       maybeStreamResponse: (result, params, context) =>
@@ -201,12 +203,17 @@ export class GitHandler {
     args: string[],
     cwd: string,
     progressId: string,
+    proxy: GitCloneProxyOptions | undefined,
     context?: RequestContext
   ): Promise<{ stdout: string; stderr: string }> {
+    const proxyEnv = buildConfiguredProxyEnv({
+      httpProxyUrl: proxy?.proxyUrl,
+      httpProxyBypassRules: proxy?.proxyBypassRules
+    })
     return await new Promise((resolve, reject) => {
       const child = spawn('git', args, {
         cwd: expandTilde(cwd),
-        env: buildRelayUnattendedGitEnv(),
+        env: { ...buildRelayUnattendedGitEnv(), ...proxyEnv },
         stdio: ['ignore', 'pipe', 'pipe']
       })
       let stdout = ''

--- a/src/renderer/src/components/settings/AdvancedNetworkSettingsSection.tsx
+++ b/src/renderer/src/components/settings/AdvancedNetworkSettingsSection.tsx
@@ -215,7 +215,9 @@ export function AdvancedNetworkSettingsSection({
         'no_proxy',
         'network',
         'bypass',
-        'localhost'
+        'localhost',
+        'git',
+        'clone'
       ]}
       className="space-y-3"
     >

--- a/src/renderer/src/components/settings/advanced-network-search.ts
+++ b/src/renderer/src/components/settings/advanced-network-search.ts
@@ -23,7 +23,10 @@ export const getAdvancedNetworkSearchEntries = createLocalizedCatalog((): Settin
       ...translateSearchKeyword('auto.components.settings.general.search.91a46caafc', 'no_proxy'),
       ...translateSearchKeyword('auto.components.settings.general.search.3a73054565', 'bypass'),
       ...translateSearchKeyword('auto.components.settings.general.search.3566fce83f', 'localhost'),
-      ...translateSearchKeyword('auto.components.settings.general.search.c56cb6f1c2', 'network')
+      ...translateSearchKeyword('auto.components.settings.general.search.c56cb6f1c2', 'network'),
+      // English-only aliases: the configured proxy also applies to git clone.
+      ...translateSearchKeyword('', 'git', { englishOnly: true }),
+      ...translateSearchKeyword('', 'clone', { englishOnly: true })
     ]
   }
 ])

--- a/src/shared/network-proxy.test.ts
+++ b/src/shared/network-proxy.test.ts
@@ -63,6 +63,19 @@ describe('network proxy settings', () => {
     expect(buildConfiguredProxyEnv({ httpProxyUrl: '' })).toEqual({})
   })
 
+  it('builds socks5 proxy env so libcurl-backed git clone can route through it', () => {
+    expect(buildConfiguredProxyEnv({ httpProxyUrl: 'socks5://127.0.0.1:1080' })).toEqual({
+      HTTP_PROXY: 'socks5://127.0.0.1:1080',
+      HTTPS_PROXY: 'socks5://127.0.0.1:1080',
+      ALL_PROXY: 'socks5://127.0.0.1:1080',
+      http_proxy: 'socks5://127.0.0.1:1080',
+      https_proxy: 'socks5://127.0.0.1:1080',
+      all_proxy: 'socks5://127.0.0.1:1080',
+      NO_PROXY: '',
+      no_proxy: ''
+    })
+  })
+
   it('redacts credentials for diagnostics', () => {
     expect(redactProxyUrl('http://user:pass@proxy.example:8080')).toBe(
       'http://***:***@proxy.example:8080'


### PR DESCRIPTION
## Summary

Git clone previously ignored Orca's app-wide proxy setting (`settings.httpProxyUrl` / `settings.httpProxyBypassRules`), so users behind an HTTP or SOCKS5 proxy could not clone repositories. This PR wires that existing — already validated, persisted, encrypted, and socks5-capable — setting into all three clone transports.

The mechanism is the standard proxy **environment variables** (`ALL_PROXY` / `HTTP_PROXY` / `HTTPS_PROXY` + lowercase, plus `NO_PROXY`) that Git's libcurl backend honors. Because `ALL_PROXY` is respected, a `socks5://` URL works with no git-config flags — so the relay's strict clone-argv validator does not need to be touched.

Covered transports:

- **Local clone** (`src/main/ipc/repos.ts`) and **runtime clone** (`src/main/runtime/orca-runtime.ts`) — a new `gitCloneEnvWithProxy` helper merges the configured proxy into the non-interactive git env, and on Windows also forwards the keys to `WSLENV` so a WSL-routed clone actually receives them.
- **SSH / relay clone** — `proxyUrl` / `proxyBypassRules` are forwarded over the `git.clone` RPC (the relay rebuilds git env from the remote host and can't see the desktop's proxy). The relay re-derives env via `buildConfiguredProxyEnv`, so a forwarded value can only ever become an env-var value, never argv.

Also adds `git` / `clone` search aliases to the **Advanced Network** settings section so the proxy field is discoverable when searching for "git clone".

## Screenshots

`No visual change` — the proxy field already exists in Advanced Network settings; this PR only makes clone honor it and adds English search aliases.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`pnpm lint` and `pnpm typecheck` pass. `pnpm test` was not run in full — the affected suites (`network-proxy`, `git-clone-proxy-env`, `ssh-git-provider`, 99 tests) pass via targeted `vitest` runs. `pnpm build` was not run locally.

New/updated tests:
- `src/main/git/git-clone-proxy-env.test.ts` — http & socks5 merge, `NO_PROXY` bypass rules, unchanged-env (same ref) when no proxy, WSLENV forwarding only on win32-with-proxy, no empty WSLENV.
- `src/main/providers/ssh-git-provider.test.ts` — forwards proxy to the `git.clone` request; omits the fields when none configured.
- `src/shared/network-proxy.test.ts` — socks5 env emits all six proxy keys.

## AI Review Report

Ran an adversarial security + correctness review of the full diff with an AI agent. Main risks checked and results:

- **Command/argument injection** — traced `params.proxyUrl` / `proxyBypassRules` from the relay RPC boundary through `buildConfiguredProxyEnv` into `spawn('git', args, { env })` (argv array, no `shell: true`). Confirmed they only ever become **env-var values**, never argv, and a value failing the `normalizeProxyUrl` scheme allowlist (`http/https/socks/socks4/socks5`) yields no env keys. **Safe.**
- **Relay validator** — `src/relay/git-exec-validator.ts` is unchanged; clone argv stays restricted and global git flags stay blocked. **Intact.**
- **Credential leakage** — proxy URLs may contain `user:pass`; verified clone failure messages route through `stripCredentialsFromMessage`, and neither the relay dispatcher/multiplexer nor `spawnClone` logs the env. **No leak.**
- **Cross-platform (macOS / Linux / Windows)** — explicitly reviewed. Local callers default to `process.platform`; WSLENV forwarding is gated to `win32` **and** proxy-present, reads the already-populated `WSLENV` before the global fallback, and never emits an empty `WSLENV`. Paths use the existing env plumbing (no hardcoded separators). No keyboard-shortcut/label surface touched.
- **SSH + folder-workspace use cases** — SSH clone forwards the proxy over RPC explicitly; folder-workspace clone flows through the same local path. Both verified.

The review found **no blockers and no should-fix issues**.

## Security Audit

- **Input handling** — proxy URL is validated by `normalizeProxyUrl` (URL parse + scheme allowlist + length cap); bypass rules normalized/length-capped. Relay re-validates via `buildConfiguredProxyEnv` so a malformed value degrades to "no proxy" rather than reaching git.
- **Command execution** — no shell; `spawn` with an argv array. Proxy values influence only the child `env`, never the command line. The relay's clone-argv allowlist is unchanged.
- **IPC / relay** — new `git.clone` RPC fields are type-guarded (`typeof === 'string'`) at the boundary and optional.
- **Secrets** — proxy credentials are never logged; existing credential-stripping on failure messages covers this path. `redactProxyUrl` remains available for diagnostics.
- **Dependencies** — none added.

No follow-up required.

## Notes

- Windows/WSL: proxy keys are forwarded into `WSLENV` so clones that shell out through `wsl.exe` inherit them.
- The relay path is intentionally env-only (no `git -c http.proxy=`), keeping the strict clone-argv validator and its global-flag block untouched.
- Bypass-rules-without-a-proxy-URL is a no-op on both local and relay paths (consistent behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

