### PR TITLE
feat(source-control): unstaged-only Changes diffs and toolbar refresh

### DIFF
--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -502,7 +502,8 @@ export function useEditorPanelContentState({
       return
     }
     const current = openFilesRef.current.find((f) => f.id === activeFile.id)
-    if (!current || !isReloadableSingleFileDiffTab(current)) {
+    // Why: edit-mode Changes tabs also bump this nonce on manual SC refresh.
+    if (!current || !(isReloadableSingleFileDiffTab(current) || isChangesMode)) {
       return
     }
     setDiffContents((prev) => {
@@ -514,7 +515,7 @@ export function useEditorPanelContentState({
       return next
     })
     void loadDiffContent(current, { force: true })
-  }, [activeFile?.diffContentReloadNonce, activeFile?.id, loadDiffContent])
+  }, [activeFile?.diffContentReloadNonce, activeFile?.id, isChangesMode, loadDiffContent])
 
   useEffect(() => {
     const nonce = activeFile?.fileContentReloadNonce

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -244,7 +244,9 @@ export function useEditorPanelContentState({
         const gitScope = getRuntimeGitScope(fileSettings, connectionId)
         const effectiveDiffSource: typeof file.diffSource =
           file.mode === 'edit' ? 'unstaged' : file.diffSource
-        const compareAgainstHead = file.mode === 'edit'
+        // Why: SC Changes / edit Changes view must be WT vs index (`git diff`).
+        // HEAD-vs-WT mixed already-staged hunks into remaining unstaged work (#11133).
+        const compareAgainstHead = false
         const key = inFlightDiffKey(
           { ...file, diffSource: effectiveDiffSource },
           gitScope ?? undefined,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -137,6 +137,11 @@ import {
   refreshGitStatusForWorktree,
   refreshGitStatusForWorktreeStrict
 } from './git-status-refresh'
+import { isSourceControlOpenDiffStaged } from './source-control-diff-load'
+import {
+  applyManualSourceControlDiffReload,
+  shouldStartManualSourceControlRefresh
+} from './source-control-manual-refresh'
 import { describeForkPushTarget } from './fork-push-target-label'
 import { toast } from 'sonner'
 import { SourceControlEntryContextMenu } from './source-control-entry-context-menu'
@@ -1290,6 +1295,9 @@ function SourceControlInner(): React.JSX.Element {
       console.warn('[SourceControl] post-mutation git status refresh failed', error)
     }
   }, [refreshActiveGitStatus])
+
+  const [isManualSourceControlRefreshing, setIsManualSourceControlRefreshing] = useState(false)
+  const manualSourceControlRefreshInFlightRef = useRef(false)
 
   // Why: when status is truncated, offer once per worktree to .gitignore the flooding folder; local-only since the SSH huge-folder write path isn't wired.
   useEffect(() => {
@@ -4432,10 +4440,17 @@ function SourceControlInner(): React.JSX.Element {
         setEditorViewMode(filePath, 'changes')
         return
       }
-      openDiff(activeWorktreeId, filePath, entry.path, language, entry.area === 'staged', {
-        targetGroupId,
-        preview: openAsPreview
-      })
+      openDiff(
+        activeWorktreeId,
+        filePath,
+        entry.path,
+        language,
+        isSourceControlOpenDiffStaged(entry.area),
+        {
+          targetGroupId,
+          preview: openAsPreview
+        }
+      )
     },
     [
       activeWorktreeId,
@@ -4898,6 +4913,41 @@ function SourceControlInner(): React.JSX.Element {
 
   const refreshGitHistoryRef = useRef(refreshGitHistory)
   refreshGitHistoryRef.current = refreshGitHistory
+
+  const handleManualSourceControlRefresh = useCallback(async (): Promise<void> => {
+    if (
+      !activeWorktreeId ||
+      !worktreePath ||
+      isFolder ||
+      !shouldStartManualSourceControlRefresh(manualSourceControlRefreshInFlightRef.current)
+    ) {
+      return
+    }
+
+    manualSourceControlRefreshInFlightRef.current = true
+    setIsManualSourceControlRefreshing(true)
+    try {
+      // Why: manual refresh must re-read status and force open staged/unstaged diffs to
+      // refetch even when porcelain area/status signatures are unchanged.
+      await refreshActiveGitStatus()
+      useAppStore.setState((state) => ({
+        openFiles: applyManualSourceControlDiffReload(state.openFiles, activeWorktreeId)
+      }))
+      await Promise.all([refreshBranchCompare(), refreshGitHistory()])
+    } catch (error) {
+      console.warn('[SourceControl] manual refresh failed', error)
+    } finally {
+      manualSourceControlRefreshInFlightRef.current = false
+      setIsManualSourceControlRefreshing(false)
+    }
+  }, [
+    activeWorktreeId,
+    isFolder,
+    refreshActiveGitStatus,
+    refreshBranchCompare,
+    refreshGitHistory,
+    worktreePath
+  ])
 
   useEffect(() => {
     if (!activeWorktreeId || !worktreePath || !isBranchVisible || !compareBaseRef || isFolder) {
@@ -5480,6 +5530,8 @@ function SourceControlInner(): React.JSX.Element {
           onChangeBaseRef={() => setBaseRefDialogOpen(true)}
           onRefreshBranchCompare={() => void refreshBranchCompare()}
           branchCompareRefreshDisabled={!branchSummary || branchSummary.status === 'loading'}
+          onManualRefresh={() => void handleManualSourceControlRefresh()}
+          isManualRefreshing={isManualSourceControlRefreshing}
           diffCommentCount={diffCommentCount}
           onExpandNotes={() => setDiffCommentsExpanded(true)}
           branchSummary={branchSummary}

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -4931,7 +4931,11 @@ function SourceControlInner(): React.JSX.Element {
       // refetch even when porcelain area/status signatures are unchanged.
       await refreshActiveGitStatus()
       useAppStore.setState((state) => ({
-        openFiles: applyManualSourceControlDiffReload(state.openFiles, activeWorktreeId)
+        openFiles: applyManualSourceControlDiffReload(
+          state.openFiles,
+          activeWorktreeId,
+          state.editorViewMode
+        )
       }))
       await Promise.all([refreshBranchCompare(), refreshGitHistory()])
     } catch (error) {

--- a/src/renderer/src/components/right-sidebar/source-control-diff-load.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-diff-load.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSourceControlOpenDiffStaged,
+  resolveEditChangesDiffLoadArgs,
+  resolveSourceControlDiffLoadArgs
+} from './source-control-diff-load'
+
+describe('source-control-diff-load', () => {
+  it('opens staged rows as staged diffs (index vs HEAD)', () => {
+    expect(resolveSourceControlDiffLoadArgs('staged')).toEqual({
+      staged: true,
+      compareAgainstHead: false
+    })
+    expect(isSourceControlOpenDiffStaged('staged')).toBe(true)
+  })
+
+  it('opens Changes / unstaged rows as working-tree vs index only', () => {
+    expect(resolveSourceControlDiffLoadArgs('unstaged')).toEqual({
+      staged: false,
+      compareAgainstHead: false
+    })
+    expect(isSourceControlOpenDiffStaged('unstaged')).toBe(false)
+  })
+
+  it('opens untracked rows as unstaged (not staged) without HEAD compare', () => {
+    expect(resolveSourceControlDiffLoadArgs('untracked')).toEqual({
+      staged: false,
+      compareAgainstHead: false
+    })
+    expect(isSourceControlOpenDiffStaged('untracked')).toBe(false)
+  })
+
+  it('treats missing area as unstaged-only', () => {
+    expect(resolveSourceControlDiffLoadArgs(undefined)).toEqual({
+      staged: false,
+      compareAgainstHead: false
+    })
+    expect(isSourceControlOpenDiffStaged(undefined)).toBe(false)
+  })
+
+  it('keeps editor Changes view on the index left side (not HEAD)', () => {
+    // Why: HEAD-vs-WT mixed already-staged hunks into remaining Changes work (#11133).
+    expect(resolveEditChangesDiffLoadArgs()).toEqual({
+      staged: false,
+      compareAgainstHead: false
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-diff-load.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-diff-load.ts
@@ -1,0 +1,38 @@
+import type { GitStagingArea } from '../../../../shared/git-status-types'
+
+/**
+ * Args for loading a single-file Source Control / Changes diff.
+ * Unstaged (and edit Changes view) must be working-tree vs index (`git diff`),
+ * not HEAD, so already-staged hunks stay under Staged Changes only.
+ */
+export type SourceControlDiffLoadArgs = {
+  staged: boolean
+  /** Always false for SC Changes / unstaged / edit-Changes — index is the left side. */
+  compareAgainstHead: boolean
+}
+
+/** Map a SC status row area to `git.diff` args. Staged → index vs HEAD; else WT vs index. */
+export function resolveSourceControlDiffLoadArgs(
+  area: GitStagingArea | undefined
+): SourceControlDiffLoadArgs {
+  return {
+    staged: area === 'staged',
+    compareAgainstHead: false
+  }
+}
+
+/**
+ * Editor "Changes" view on an edit tab is the remaining working-tree delta
+ * (same as SC Changes), never the mixed HEAD-vs-working-tree view.
+ */
+export function resolveEditChangesDiffLoadArgs(): SourceControlDiffLoadArgs {
+  return {
+    staged: false,
+    compareAgainstHead: false
+  }
+}
+
+/** openDiff's staged boolean from a SC row area (untracked opens as unstaged). */
+export function isSourceControlOpenDiffStaged(area: GitStagingArea | undefined): boolean {
+  return resolveSourceControlDiffLoadArgs(area).staged
+}

--- a/src/renderer/src/components/right-sidebar/source-control-header-toolbar-identity.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-header-toolbar-identity.test.tsx
@@ -57,6 +57,8 @@ function renderToolbar(options?: {
       onChangeBaseRef={vi.fn()}
       onRefreshBranchCompare={vi.fn()}
       branchCompareRefreshDisabled={false}
+      onManualRefresh={vi.fn()}
+      isManualRefreshing={false}
       diffCommentCount={0}
       onExpandNotes={vi.fn()}
       branchSummary={options?.branchSummary === undefined ? readySummary : options.branchSummary}
@@ -71,6 +73,12 @@ function renderToolbar(options?: {
 }
 
 describe('SourceControlHeaderToolbar branch identity', () => {
+  it('exposes a manual refresh control beside filter/overflow', () => {
+    const markup = renderToolbar()
+    expect(markup).toContain('data-testid="source-control-manual-refresh"')
+    expect(markup).toContain('aria-label="Refresh"')
+  })
+
   it('keeps Create PR while stacking head above base in the context row', () => {
     const markup = renderToolbar()
     const branchIndex = markup.indexOf('brennanb2025/source-control-branch-name')

--- a/src/renderer/src/components/right-sidebar/source-control-header-toolbar.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-header-toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react'
-import { GitPullRequestArrow, Loader2, Search, X } from 'lucide-react'
+import { GitPullRequestArrow, Loader2, RefreshCw, Search, X } from 'lucide-react'
 import type {
   GitBranchCompareSummary,
   GitUpstreamStatus,
@@ -34,6 +34,8 @@ type SourceControlHeaderToolbarProps = {
   onChangeBaseRef: () => void
   onRefreshBranchCompare: () => void
   branchCompareRefreshDisabled: boolean
+  onManualRefresh: () => void
+  isManualRefreshing: boolean
   diffCommentCount: number
   onExpandNotes: () => void
   branchSummary: GitBranchCompareSummary | null
@@ -140,6 +142,8 @@ export function SourceControlHeaderToolbar({
   onChangeBaseRef,
   onRefreshBranchCompare,
   branchCompareRefreshDisabled,
+  onManualRefresh,
+  isManualRefreshing,
   diffCommentCount,
   onExpandNotes,
   branchSummary,
@@ -161,6 +165,10 @@ export function SourceControlHeaderToolbar({
     diffCommentCount,
     onExpandNotes
   }
+  const refreshLabel = translate(
+    'auto.components.right.sidebar.SourceControl.manualRefresh',
+    'Refresh'
+  )
 
   const expandFilter = useCallback(() => {
     onFilterExpandedChange(true)
@@ -232,6 +240,18 @@ export function SourceControlHeaderToolbar({
               {normalizedFilter ? (
                 <span className="absolute right-1 top-1 size-1.5 rounded-full bg-foreground" />
               ) : null}
+            </button>
+            <button
+              type="button"
+              data-testid="source-control-manual-refresh"
+              className="inline-flex size-7 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-default disabled:opacity-50"
+              onClick={onManualRefresh}
+              disabled={isManualRefreshing}
+              aria-label={refreshLabel}
+              title={refreshLabel}
+              aria-busy={isManualRefreshing}
+            >
+              <RefreshCw className={cn('size-3.5', isManualRefreshing && 'animate-spin')} />
             </button>
             {renderOverflowMenu(overflowProps)}
           </>

--- a/src/renderer/src/components/right-sidebar/source-control-manual-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-refresh.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import {
+  applyManualSourceControlDiffReload,
+  isManualRefreshReloadableDiffFile,
+  shouldStartManualSourceControlRefresh
+} from './source-control-manual-refresh'
+
+function openFile(overrides: Partial<OpenFile>): OpenFile {
+  return {
+    id: overrides.id ?? 'file',
+    filePath: overrides.filePath ?? '/repo/file.ts',
+    relativePath: overrides.relativePath ?? 'file.ts',
+    worktreeId: overrides.worktreeId ?? 'wt-1',
+    language: overrides.language ?? 'typescript',
+    isDirty: overrides.isDirty ?? false,
+    mode: overrides.mode ?? 'diff',
+    ...overrides
+  }
+}
+
+describe('source-control-manual-refresh', () => {
+  it('blocks concurrent manual refreshes while one is in flight', () => {
+    expect(shouldStartManualSourceControlRefresh(false)).toBe(true)
+    expect(shouldStartManualSourceControlRefresh(true)).toBe(false)
+  })
+
+  it('reloads only staged/unstaged single-file diffs for the active worktree', () => {
+    expect(
+      isManualRefreshReloadableDiffFile(
+        openFile({ worktreeId: 'wt-1', mode: 'diff', diffSource: 'unstaged' }),
+        'wt-1'
+      )
+    ).toBe(true)
+    expect(
+      isManualRefreshReloadableDiffFile(
+        openFile({ worktreeId: 'wt-1', mode: 'diff', diffSource: 'staged' }),
+        'wt-1'
+      )
+    ).toBe(true)
+    expect(
+      isManualRefreshReloadableDiffFile(
+        openFile({ worktreeId: 'wt-2', mode: 'diff', diffSource: 'unstaged' }),
+        'wt-1'
+      )
+    ).toBe(false)
+    expect(
+      isManualRefreshReloadableDiffFile(
+        openFile({ worktreeId: 'wt-1', mode: 'diff', diffSource: 'branch' }),
+        'wt-1'
+      )
+    ).toBe(false)
+    expect(
+      isManualRefreshReloadableDiffFile(
+        openFile({ worktreeId: 'wt-1', mode: 'edit', diffSource: undefined }),
+        'wt-1'
+      )
+    ).toBe(false)
+  })
+
+  it('bumps diffContentReloadNonce only for matching open diffs', () => {
+    const files = [
+      openFile({
+        id: 'unstaged',
+        worktreeId: 'wt-1',
+        mode: 'diff',
+        diffSource: 'unstaged',
+        diffContentReloadNonce: 2
+      }),
+      openFile({
+        id: 'staged',
+        worktreeId: 'wt-1',
+        mode: 'diff',
+        diffSource: 'staged'
+      }),
+      openFile({
+        id: 'other-wt',
+        worktreeId: 'wt-2',
+        mode: 'diff',
+        diffSource: 'unstaged',
+        diffContentReloadNonce: 4
+      }),
+      openFile({
+        id: 'branch',
+        worktreeId: 'wt-1',
+        mode: 'diff',
+        diffSource: 'branch'
+      }),
+      openFile({
+        id: 'edit',
+        worktreeId: 'wt-1',
+        mode: 'edit'
+      })
+    ]
+
+    const next = applyManualSourceControlDiffReload(files, 'wt-1')
+
+    expect(next[0]?.diffContentReloadNonce).toBe(3)
+    expect(next[1]?.diffContentReloadNonce).toBe(1)
+    expect(next[2]?.diffContentReloadNonce).toBe(4)
+    expect(next[3]?.diffContentReloadNonce).toBeUndefined()
+    expect(next[4]?.diffContentReloadNonce).toBeUndefined()
+    expect(next).not.toBe(files)
+  })
+
+  it('returns the same array when no open diffs need a reload', () => {
+    const files = [
+      openFile({ id: 'edit', worktreeId: 'wt-1', mode: 'edit' }),
+      openFile({ id: 'branch', worktreeId: 'wt-1', mode: 'diff', diffSource: 'branch' })
+    ]
+    expect(applyManualSourceControlDiffReload(files, 'wt-1')).toBe(files)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-manual-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-refresh.test.ts
@@ -58,6 +58,32 @@ describe('source-control-manual-refresh', () => {
     ).toBe(false)
   })
 
+  it('reloads edit-mode tabs that are actively displaying Changes', () => {
+    const editChanges = openFile({
+      id: '/repo/readme.md',
+      worktreeId: 'wt-1',
+      mode: 'edit'
+    })
+    expect(
+      isManualRefreshReloadableDiffFile(editChanges, 'wt-1', {
+        '/repo/readme.md': 'changes'
+      })
+    ).toBe(true)
+    expect(isManualRefreshReloadableDiffFile(editChanges, 'wt-1', {})).toBe(false)
+    expect(
+      isManualRefreshReloadableDiffFile(editChanges, 'wt-1', {
+        '/repo/readme.md': 'edit'
+      })
+    ).toBe(false)
+    expect(
+      isManualRefreshReloadableDiffFile(
+        openFile({ id: '/repo/other.md', worktreeId: 'wt-1', mode: 'edit' }),
+        'wt-1',
+        { '/repo/readme.md': 'changes' }
+      )
+    ).toBe(false)
+  })
+
   it('bumps diffContentReloadNonce only for matching open diffs', () => {
     const files = [
       openFile({
@@ -90,16 +116,25 @@ describe('source-control-manual-refresh', () => {
         id: 'edit',
         worktreeId: 'wt-1',
         mode: 'edit'
+      }),
+      openFile({
+        id: '/repo/readme.md',
+        worktreeId: 'wt-1',
+        mode: 'edit',
+        diffContentReloadNonce: 1
       })
     ]
 
-    const next = applyManualSourceControlDiffReload(files, 'wt-1')
+    const next = applyManualSourceControlDiffReload(files, 'wt-1', {
+      '/repo/readme.md': 'changes'
+    })
 
     expect(next[0]?.diffContentReloadNonce).toBe(3)
     expect(next[1]?.diffContentReloadNonce).toBe(1)
     expect(next[2]?.diffContentReloadNonce).toBe(4)
     expect(next[3]?.diffContentReloadNonce).toBeUndefined()
     expect(next[4]?.diffContentReloadNonce).toBeUndefined()
+    expect(next[5]?.diffContentReloadNonce).toBe(2)
     expect(next).not.toBe(files)
   })
 
@@ -108,6 +143,6 @@ describe('source-control-manual-refresh', () => {
       openFile({ id: 'edit', worktreeId: 'wt-1', mode: 'edit' }),
       openFile({ id: 'branch', worktreeId: 'wt-1', mode: 'diff', diffSource: 'branch' })
     ]
-    expect(applyManualSourceControlDiffReload(files, 'wt-1')).toBe(files)
+    expect(applyManualSourceControlDiffReload(files, 'wt-1', { edit: 'edit' })).toBe(files)
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control-manual-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-refresh.ts
@@ -1,0 +1,46 @@
+import type { DiffSource, OpenFile } from '@/store/slices/editor'
+
+const RELOADABLE_DIFF_SOURCES: ReadonlySet<DiffSource> = new Set(['staged', 'unstaged'])
+
+/** Skip starting a second manual refresh while one is already in flight. */
+export function shouldStartManualSourceControlRefresh(isRefreshing: boolean): boolean {
+  return !isRefreshing
+}
+
+/** Single-file staged/unstaged diffs owned by this worktree that should reload on manual SC refresh. */
+export function isManualRefreshReloadableDiffFile(
+  file: Pick<OpenFile, 'worktreeId' | 'mode' | 'diffSource'>,
+  worktreeId: string
+): boolean {
+  return (
+    file.worktreeId === worktreeId &&
+    file.mode === 'diff' &&
+    file.diffSource !== undefined &&
+    RELOADABLE_DIFF_SOURCES.has(file.diffSource)
+  )
+}
+
+export function bumpDiffContentReloadNonce<T extends { diffContentReloadNonce?: number }>(
+  file: T
+): T {
+  return {
+    ...file,
+    diffContentReloadNonce: (file.diffContentReloadNonce ?? 0) + 1
+  }
+}
+
+/** Bump reload nonces for open staged/unstaged diffs so viewers refetch after a manual SC refresh. */
+export function applyManualSourceControlDiffReload(
+  openFiles: readonly OpenFile[],
+  worktreeId: string
+): OpenFile[] {
+  let changed = false
+  const next = openFiles.map((file) => {
+    if (!isManualRefreshReloadableDiffFile(file, worktreeId)) {
+      return file
+    }
+    changed = true
+    return bumpDiffContentReloadNonce(file)
+  })
+  return changed ? next : (openFiles as OpenFile[])
+}

--- a/src/renderer/src/components/right-sidebar/source-control-manual-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-refresh.ts
@@ -1,4 +1,4 @@
-import type { DiffSource, OpenFile } from '@/store/slices/editor'
+import type { DiffSource, EditorViewMode, OpenFile } from '@/store/slices/editor'
 
 const RELOADABLE_DIFF_SOURCES: ReadonlySet<DiffSource> = new Set(['staged', 'unstaged'])
 
@@ -7,17 +7,24 @@ export function shouldStartManualSourceControlRefresh(isRefreshing: boolean): bo
   return !isRefreshing
 }
 
-/** Single-file staged/unstaged diffs owned by this worktree that should reload on manual SC refresh. */
+/** Single-file staged/unstaged diffs (and edit tabs in Changes view) for this worktree. */
 export function isManualRefreshReloadableDiffFile(
-  file: Pick<OpenFile, 'worktreeId' | 'mode' | 'diffSource'>,
-  worktreeId: string
+  file: Pick<OpenFile, 'id' | 'worktreeId' | 'mode' | 'diffSource'>,
+  worktreeId: string,
+  editorViewMode?: Readonly<Record<string, EditorViewMode>>
 ): boolean {
-  return (
-    file.worktreeId === worktreeId &&
+  if (file.worktreeId !== worktreeId) {
+    return false
+  }
+  if (
     file.mode === 'diff' &&
     file.diffSource !== undefined &&
     RELOADABLE_DIFF_SOURCES.has(file.diffSource)
-  )
+  ) {
+    return true
+  }
+  // Why: SC opens unstaged Markdown as edit + Changes; manual refresh must still force that diff.
+  return file.mode === 'edit' && editorViewMode?.[file.id] === 'changes'
 }
 
 export function bumpDiffContentReloadNonce<T extends { diffContentReloadNonce?: number }>(
@@ -32,11 +39,12 @@ export function bumpDiffContentReloadNonce<T extends { diffContentReloadNonce?: 
 /** Bump reload nonces for open staged/unstaged diffs so viewers refetch after a manual SC refresh. */
 export function applyManualSourceControlDiffReload(
   openFiles: readonly OpenFile[],
-  worktreeId: string
+  worktreeId: string,
+  editorViewMode?: Readonly<Record<string, EditorViewMode>>
 ): OpenFile[] {
   let changed = false
   const next = openFiles.map((file) => {
-    if (!isManualRefreshReloadableDiffFile(file, worktreeId)) {
+    if (!isManualRefreshReloadableDiffFile(file, worktreeId, editorViewMode)) {
       return file
     }
     changed = true


### PR DESCRIPTION
## Description
Source Control **Changes** diffs now show working-tree vs index only (excluding already-staged hunks), and the SC toolbar has an explicit **Refresh** that reloads status and open diffs.

## Focused fix
- In scope: unstaged compareAgainstHead=false for Changes/edit view; pure SC open helpers; toolbar refresh (status + diff nonce + branch/history)
- Out of scope: redesign of SC layout, auto-watch policy, staged hunk partial staging UX

## Preserves
- Staged Changes still opens index vs HEAD
- Existing post-mutation refresh paths unchanged; manual refresh is additive

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts` source-control-diff-load / manual-refresh / toolbar-identity / preview-open suites → 23 passed

## User-regression-tradeoffs
- Markdown/edit “Changes” mode left pane is unstaged-only (matches VS Code mental model)

Fixes #11133