### PR TITLE
fix(codex): scope System Default status hooks without dual-file collision

### DIFF
--- a/src/main/codex/codex-real-home-hook-install.test.ts
+++ b/src/main/codex/codex-real-home-hook-install.test.ts
@@ -45,9 +45,12 @@ import {
 import { getCodexManagedHookInstallMaterial } from './hook-service'
 import { _internals as rebaseInternals } from './codex-user-hook-trust-rebase'
 
+const HOOK_SCOPE_ENV = 'ORCA_CODEX_SYSTEM_DEFAULT_HOOK_SCOPE'
+
 let fakeHomeDir: string
 let userDataDir: string
 let previousUserDataPath: string | undefined
+let previousHookScope: string | undefined
 
 function getRealHooksJsonPath(): string {
   return join(fakeHomeDir, '.codex', 'hooks.json')
@@ -75,12 +78,21 @@ function grantUnavailable(): void {
   grantMock.mockReturnValue({ lane: 'fallback', reason: 'unsupported' })
 }
 
+/** Real-home enrollment tests pin the opt-in all-sessions scope. */
+function useAllSessionsScope(): void {
+  process.env[HOOK_SCOPE_ENV] = 'all-sessions'
+}
+
 beforeEach(() => {
   grantMock.mockReset()
   fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-real-home-hooks-home-'))
   userDataDir = mkdtempSync(join(tmpdir(), 'orca-real-home-hooks-user-data-'))
   previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  previousHookScope = process.env[HOOK_SCOPE_ENV]
   process.env.ORCA_USER_DATA_PATH = userDataDir
+  // Why: install-path suites cover all-sessions enrollment; scope-default
+  // suites clear this env and assert the safer orca-sessions product default.
+  useAllSessionsScope()
   homedirMock.mockReturnValue(fakeHomeDir)
   mkdirSync(join(fakeHomeDir, '.codex'), { recursive: true })
   _internals.setLaneForTesting('pending')
@@ -95,6 +107,11 @@ afterEach(() => {
     delete process.env.ORCA_USER_DATA_PATH
   } else {
     process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  if (previousHookScope === undefined) {
+    delete process.env[HOOK_SCOPE_ENV]
+  } else {
+    process.env[HOOK_SCOPE_ENV] = previousHookScope
   }
   vi.clearAllMocks()
 })
@@ -537,5 +554,77 @@ describe('ensureRealHomeCodexHookState (opt-out sweep)', () => {
     const trust = readHookTrustEntries(getRealConfigTomlPath())
     expect(trust.has(computeTrustKey(entries[0]!))).toBe(true)
     expect(trust.has(computeTrustKey(entries[1]!))).toBe(false)
+  })
+})
+
+describe('ensureRealHomeCodexHookState (orca-sessions scope default)', () => {
+  beforeEach(() => {
+    delete process.env[HOOK_SCOPE_ENV]
+  })
+
+  it('does not write hooks.json and reports the orca-sessions lane', () => {
+    grantSucceeds()
+
+    const lane = ensureRealHomeCodexHookState({ hooksEnabled: true, userDataPath: userDataDir })
+
+    expect(lane).toBe('orca-sessions')
+    expect(getRealHomeCodexHookLane()).toBe('orca-sessions')
+    expect(existsSync(getRealHooksJsonPath())).toBe(false)
+    expect(grantMock).not.toHaveBeenCalled()
+  })
+
+  it('sweeps a prior real-home Orca install when scope prefers managed', () => {
+    useAllSessionsScope()
+    grantSucceeds()
+    ensureRealHomeCodexHookState({ hooksEnabled: true, userDataPath: userDataDir })
+    expect(existsSync(getRealHooksJsonPath())).toBe(true)
+    const userStop = {
+      matcher: 'deploy-*',
+      hooks: [{ type: 'command', command: 'my-stop-hook.sh' }]
+    }
+    const installed = readRealHooksJson()
+    installed.hooks = {
+      ...installed.hooks,
+      Stop: [userStop, ...(installed.hooks?.Stop ?? [])]
+    }
+    writeFileSync(getRealHooksJsonPath(), `${JSON.stringify(installed, null, 2)}\n`, 'utf-8')
+
+    delete process.env[HOOK_SCOPE_ENV]
+    _internals.setLaneForTesting('pending')
+
+    expect(ensureRealHomeCodexHookState({ hooksEnabled: true, userDataPath: userDataDir })).toBe(
+      'orca-sessions'
+    )
+
+    expect(readRealHooksJson().hooks?.Stop).toEqual([userStop])
+    const material = getCodexManagedHookInstallMaterial()
+    for (const eventName of material.events) {
+      if (eventName === 'Stop') {
+        continue
+      }
+      expect(readRealHooksJson().hooks?.[eventName]).toBeUndefined()
+    }
+  })
+
+  it('keeps the real home free when config.toml already declares user hooks', () => {
+    useAllSessionsScope()
+    grantSucceeds()
+    writeFileSync(
+      getRealConfigTomlPath(),
+      [
+        '[[hooks.Stop]]',
+        '[[hooks.Stop.hooks]]',
+        'type = "command"',
+        'command = "mine.sh"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    const lane = ensureRealHomeCodexHookState({ hooksEnabled: true, userDataPath: userDataDir })
+
+    expect(lane).toBe('unavailable')
+    expect(existsSync(getRealHooksJsonPath())).toBe(false)
+    expect(grantMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/codex/codex-real-home-hook-install.ts
+++ b/src/main/codex/codex-real-home-hook-install.ts
@@ -87,12 +87,28 @@ function reconcileRealHomeCodexHookState(args: {
   userDataPath: string
 }): RealHomeCodexHookLane {
   const scope = resolveCodexSystemDefaultHookScope()
-  const configTomlPath = getRealHomeConfigTomlPath()
-  const configToml = existsSync(configTomlPath) ? readFileSync(configTomlPath, 'utf-8') : ''
+  // Why: orca-sessions never consults config.toml (plan ignores dual-rep for that
+  // scope). Skip the sync read on the default path so EACCES/ENOENT races cannot
+  // mark the lane unavailable for a decision that does not need the file.
+  let configTomlHasUserHookDefinitions = false
+  if (scope === 'all-sessions') {
+    const configTomlPath = getRealHomeConfigTomlPath()
+    try {
+      const configToml = existsSync(configTomlPath) ? readFileSync(configTomlPath, 'utf-8') : ''
+      configTomlHasUserHookDefinitions = configTomlHasUserLayerHookDefinitions(configToml)
+    } catch (error) {
+      // Why: fail closed — prefer managed when we cannot prove config.toml is clean.
+      console.warn(
+        '[codex-real-home-hooks] config.toml read failed; treating as dual-representation risk:',
+        error
+      )
+      configTomlHasUserHookDefinitions = true
+    }
+  }
   const plan = planSystemDefaultHookInstall({
     scope,
     hooksEnabled: args.hooksEnabled,
-    configTomlHasUserHookDefinitions: configTomlHasUserLayerHookDefinitions(configToml)
+    configTomlHasUserHookDefinitions
   })
 
   if (plan.action === 'sweep-real-home') {

--- a/src/main/codex/codex-real-home-hook-install.ts
+++ b/src/main/codex/codex-real-home-hook-install.ts
@@ -1,30 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { writeFileAtomically } from '../codex-accounts/fs-utils'
-import {
-  buildManagedCommandHook,
-  createManagedCommandMatcher,
-  MANAGED_HOOK_TIMEOUT_SECONDS,
-  readHooksJsonWithRaw,
-  removeManagedCommands,
-  writeHooksJson,
-  writeManagedScript,
-  type HookDefinition,
-  type HooksConfig
-} from '../agent-hooks/installer-utils'
-import { resolveHooksJsonWritePath } from '../agent-hooks/hook-config-write-path'
-import { getCodexManagedScriptFileName } from './codex-hook-identity'
-import {
-  CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS,
-  grantManagedCodexHookTrust,
-  type CodexTrustGrantFallbackReason
-} from './codex-hook-trust-grant'
-import { removeCodexManagedHookTrustEntries } from './codex-managed-trust-reconciliation'
-import { getCodexManagedHookInstallMaterial } from './hook-service'
+import { CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS } from './codex-hook-trust-grant'
 import { getSystemCodexHomePath } from './codex-home-paths'
-import type { CodexTrustEntry } from './config-toml-trust'
-import { restoreCodexTrustConfig } from './codex-trust-config-rollback'
-import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-rebase'
+import { installRealHomeCodexHooks, sweepRealHomeCodexHooks } from './codex-real-home-hook-mutation'
+import {
+  configTomlHasUserLayerHookDefinitions,
+  planSystemDefaultHookInstall,
+  resolveCodexSystemDefaultHookScope
+} from './codex-system-default-hook-scope'
 
 /**
  * Real-home Codex hook lane for the system-default selection (flag ON).
@@ -32,13 +15,21 @@ import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-
  * - 'pending': no attempt yet this process; routing may optimistically use the
  *   real home (reads are hook-free and the install runs before pane spawns).
  * - 'installed': entry appended LAST in ~/.codex/hooks.json and trusted by
- *   codex itself through the app-server grant client.
+ *   codex itself through the app-server grant client (`all-sessions` scope).
+ * - 'orca-sessions': safer default scope — real home is not enrolled; Orca
+ *   launches use the managed CODEX_HOME where status hooks live.
  * - 'unavailable': the grant lane could not trust the entry (old binary,
- *   unsupported RPC, verify failure). The entry is rolled back and the host
- *   stays on the managed-home lane.
+ *   unsupported RPC, verify failure) or dual-representation would collide
+ *   with user config.toml hooks. The entry is rolled back / never written and
+ *   the host stays on the managed-home lane.
  * - 'removed': hooks are opted out; Orca entries are swept from the real home.
  */
-export type RealHomeCodexHookLane = 'pending' | 'installed' | 'unavailable' | 'removed'
+export type RealHomeCodexHookLane =
+  | 'pending'
+  | 'installed'
+  | 'orca-sessions'
+  | 'unavailable'
+  | 'removed'
 
 let currentLane: RealHomeCodexHookLane = 'pending'
 let installRetryAfterMs = 0
@@ -48,46 +39,24 @@ export function getRealHomeCodexHookLane(): RealHomeCodexHookLane {
 }
 
 /**
- * Routing gate consumed by CodexRuntimeHomeService. Both a failed install and
- * a failed opt-out cleanup use the managed lane so no half-mutated hook state
- * can diverge from PTY, rate-limit, or commit-message routing.
+ * Routing gate consumed by CodexRuntimeHomeService. Failed installs, dual-
+ * representation fallback, and the orca-sessions scope all keep the host on
+ * the managed lane so PTY / rate-limit / commit-message routing stay aligned.
  */
 export function isRealHomeCodexHookLaneUsable(): boolean {
-  return currentLane !== 'unavailable'
-}
-
-function getRealHomeHooksJsonPath(): string {
-  return join(getSystemCodexHomePath(), 'hooks.json')
+  return currentLane !== 'unavailable' && currentLane !== 'orca-sessions'
 }
 
 function getRealHomeConfigTomlPath(): string {
   return join(getSystemCodexHomePath(), 'config.toml')
 }
 
-/** Orca-side state dir; nothing extra is ever written into the user's ~/.codex. */
-function getRealHomeHookStateDir(userDataPath: string): string {
-  return join(userDataPath, 'codex-real-home-hooks')
-}
-
-function assertHooksJsonGeneration(
-  hooksJsonPath: string,
-  hooksWritePath: string,
-  expectedRaw: string | null
-): void {
-  const currentRaw = existsSync(hooksJsonPath) ? readFileSync(hooksJsonPath, 'utf-8') : null
-  if (currentRaw !== expectedRaw || resolveHooksJsonWritePath(hooksJsonPath) !== hooksWritePath) {
-    // Why: the pre-mutation RPC can overlap a user's editor save. Abort rather
-    // than atomically replacing a newer file with the stale parsed snapshot.
-    throw new Error('Codex hooks.json changed while Orca prepared its trust repair')
-  }
-}
-
 /**
- * Ensures the real-home hook state matches the settings: installs and trusts
- * the Orca status hook when enabled, sweeps it when opted out. Idempotent and
- * synchronous (launch prep); repeat calls are cheap — an unchanged hooks.json
- * write no-ops and a valid grant ledger skips the RPC session entirely.
- * Never throws: any failure logs and leaves the host on the managed lane.
+ * Ensures the real-home hook state matches the settings and scope: installs
+ * and trusts the Orca status hook when `all-sessions` is selected, otherwise
+ * sweeps the real home and keeps status on the managed CODEX_HOME. Idempotent
+ * and synchronous (launch prep). Never throws: any failure logs and leaves
+ * the host on the managed lane.
  */
 export function ensureRealHomeCodexHookState(args: {
   hooksEnabled: boolean
@@ -99,10 +68,8 @@ export function ensureRealHomeCodexHookState(args: {
     return currentLane
   }
   try {
-    currentLane = args.hooksEnabled
-      ? installRealHomeCodexHook(args.userDataPath)
-      : sweepRealHomeCodexHook()
-    if (!args.hooksEnabled || currentLane === 'installed') {
+    currentLane = reconcileRealHomeCodexHookState(args)
+    if (!args.hooksEnabled || currentLane === 'installed' || currentLane === 'orca-sessions') {
       installRetryAfterMs = 0
     }
   } catch (error) {
@@ -115,261 +82,45 @@ export function ensureRealHomeCodexHookState(args: {
   return currentLane
 }
 
-function installRealHomeCodexHook(userDataPath: string): RealHomeCodexHookLane {
-  const material = getCodexManagedHookInstallMaterial()
-  const hooksJsonPath = getRealHomeHooksJsonPath()
-  const hooksWritePath = resolveHooksJsonWritePath(hooksJsonPath)
-  // Why: the generation guard compares against these bytes before writing; a
-  // separate later read would let a concurrent save land between parse and
-  // snapshot and be silently overwritten by the stale parse.
-  const { raw: previousRaw, config } = readHooksJsonWithRaw(hooksJsonPath)
-  if (!config) {
-    // Why: an unparseable user file must never be clobbered; without a hook
-    // entry the managed lane keeps status working for this host.
-    console.warn('[codex-real-home-hooks] could not parse', hooksJsonPath, '- managed lane kept')
-    installRetryAfterMs = Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS
-    return 'unavailable'
-  }
-  if (Object.keys(config).some((key) => key !== 'hooks')) {
-    // Why: Codex rejects unknown root keys instead of ignoring them. Avoid a
-    // transient rewrite of a user-owned file that the trust RPC cannot load.
-    installRetryAfterMs = Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS
-    return 'unavailable'
-  }
-
-  // Why: the same script the managed lane maintains; deploying here too keeps
-  // host-connect ordering independent of the managed installer loop.
-  writeManagedScript(material.scriptPath, material.script)
-
-  const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())
-  const nextHooks: Record<string, HookDefinition[]> = { ...config.hooks }
-  const managedEntries: CodexTrustEntry[] = []
-  for (const eventName of material.events) {
-    const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
-    const reconciled = reconcileManagedHookDefinition(current, isManagedCommand, material.command)
-    nextHooks[eventName] = reconciled.definitions
-    managedEntries.push({
-      sourcePath: hooksJsonPath,
-      eventLabel: material.eventLabel[eventName],
-      groupIndex: reconciled.groupIndex,
-      handlerIndex: reconciled.handlerIndex,
-      command: material.command,
-      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
-    })
-  }
-  // Why: sweep stale Orca entries out of events the managed lane no longer
-  // subscribes to, mirroring the managed installer's upgrade behavior.
-  for (const [eventName, definitions] of Object.entries(nextHooks)) {
-    if ((material.events as readonly string[]).includes(eventName) || !Array.isArray(definitions)) {
-      continue
-    }
-    const cleaned = removeManagedCommands(definitions, isManagedCommand)
-    if (cleaned.length === 0) {
-      delete nextHooks[eventName]
-    } else {
-      nextHooks[eventName] = cleaned
-    }
-  }
-
-  const previousMode = previousRaw === null ? undefined : statSync(hooksWritePath).mode
-  backupRealHomeHooksJsonOnce(userDataPath, previousRaw)
-  // Why: unknown top-level fields belong to the user (other managers'
-  // metadata); unlike the managed-home writer, preserve them verbatim.
-  const trustConfigSnapshot = mutateRealHomeHooksPreservingUserTrust({
-    sourcePath: hooksJsonPath,
-    runtimeHomePath: getSystemCodexHomePath(),
-    tomlPath: getRealHomeConfigTomlPath(),
-    beforeHooks: config.hooks ?? {},
-    afterHooks: nextHooks,
-    writeHooks: () => {
-      assertHooksJsonGeneration(hooksJsonPath, hooksWritePath, previousRaw)
-      writeHooksJson(hooksWritePath, { ...config, hooks: nextHooks } as HooksConfig, {
-        preserveMode: true
-      })
-    },
-    restoreHooks: () => restoreRealHomeHooksJson(hooksWritePath, previousRaw, previousMode)
+function reconcileRealHomeCodexHookState(args: {
+  hooksEnabled: boolean
+  userDataPath: string
+}): RealHomeCodexHookLane {
+  const scope = resolveCodexSystemDefaultHookScope()
+  const configTomlPath = getRealHomeConfigTomlPath()
+  const configToml = existsSync(configTomlPath) ? readFileSync(configTomlPath, 'utf-8') : ''
+  const plan = planSystemDefaultHookInstall({
+    scope,
+    hooksEnabled: args.hooksEnabled,
+    configTomlHasUserHookDefinitions: configTomlHasUserLayerHookDefinitions(configToml)
   })
 
-  const grant = grantManagedCodexHookTrust({
-    runtimeHomePath: getSystemCodexHomePath(),
-    tomlPath: getRealHomeConfigTomlPath(),
-    managedCommand: material.command,
-    managedEntries,
-    host: { kind: 'native' },
-    telemetryLane: 'real-home',
-    useDefaultCodexHome: true
-  })
-  if (grant.lane === 'rpc') {
-    return 'installed'
-  }
-
-  // Why: never leave an untrusted Orca entry in the user's real home — it
-  // would surface as "Hooks need review". Roll the file back to its prior
-  // bytes and keep this host on the managed-home lane; the grant client
-  // already logged the fallback reason.
-  try {
-    restoreRealHomeHooksJson(hooksWritePath, previousRaw, previousMode)
-  } finally {
-    // Why: a user-trust rebase may have succeeded before the managed grant
-    // failed. Roll both files back to the same pre-mutation generation.
-    if (trustConfigSnapshot) {
-      restoreCodexTrustConfig(getRealHomeConfigTomlPath(), trustConfigSnapshot)
-    }
-  }
-  installRetryAfterMs = getInstallRetryAfterMs(grant.reason)
-  console.warn(
-    `[codex-real-home-hooks] trust grant unavailable (${grant.reason}); entry rolled back, managed lane kept`
-  )
-  return 'unavailable'
-}
-
-function reconcileManagedHookDefinition(
-  current: HookDefinition[],
-  isManagedCommand: (command: string | undefined) => boolean,
-  command: string
-): { definitions: HookDefinition[]; groupIndex: number; handlerIndex: number } {
-  const directCommandKeys = ['command', 'bash', 'powershell'] as const
-  const hasManagedDirectCommand = current.some((definition) =>
-    directCommandKeys.some((key) => isManagedCommand(definition[key]))
-  )
-  const nestedLocations = current.flatMap((definition, groupIndex) =>
-    Array.isArray(definition.hooks)
-      ? definition.hooks.flatMap((hook, handlerIndex) =>
-          isManagedCommand(hook.command) ? [{ groupIndex, handlerIndex }] : []
-        )
-      : []
-  )
-  if (!hasManagedDirectCommand && nestedLocations.length === 1) {
-    const { groupIndex, handlerIndex } = nestedLocations[0]!
-    const definition = current[groupIndex]!
-    const hasDirectCommand = directCommandKeys.some((key) => typeof definition[key] === 'string')
-    if (definition.matcher === undefined && !hasDirectCommand) {
-      const definitions = [...current]
-      // Why: users can append groups or handlers after Orca's first install.
-      // Reusing the exact slot preserves all later positional trust keys.
-      const hooks = [...definition.hooks!]
-      hooks[handlerIndex] = buildManagedCommandHook(command)
-      definitions[groupIndex] = { ...definition, hooks }
-      return { definitions, groupIndex, handlerIndex }
-    }
-  }
-
-  const cleaned = removeManagedCommands(current, isManagedCommand)
-  // Why: first install appends LAST so no existing user trust position shifts.
-  return {
-    definitions: [...cleaned, { hooks: [buildManagedCommandHook(command)] }],
-    groupIndex: cleaned.length,
-    handlerIndex: 0
-  }
-}
-
-function getInstallRetryAfterMs(reason: CodexTrustGrantFallbackReason): number {
-  return reason === 'unsupported' || reason === 'unsupported-cached' || reason === 'disabled'
-    ? Number.POSITIVE_INFINITY
-    : Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS
-}
-
-function sweepRealHomeCodexHook(): RealHomeCodexHookLane {
-  const hooksJsonPath = getRealHomeHooksJsonPath()
-  // Why: single read — the pre-write generation guard must compare against
-  // the exact bytes this sweep's parse came from.
-  const { raw: previousRaw, config } = readHooksJsonWithRaw(hooksJsonPath)
-  if (!config?.hooks || previousRaw === null) {
+  if (plan.action === 'sweep-real-home') {
+    sweepRealHomeCodexHooks()
     return 'removed'
   }
-  const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())
-  const material = getCodexManagedHookInstallMaterial()
-  const nextHooks: Record<string, HookDefinition[]> = { ...config.hooks }
-  let removedAny = false
-  for (const [eventName, definitions] of Object.entries(nextHooks)) {
-    if (!Array.isArray(definitions)) {
-      continue
-    }
-    const cleaned = removeManagedCommands(definitions, isManagedCommand)
-    if (
-      cleaned.length !== definitions.length ||
-      cleaned.some((definition, index) => definition !== definitions[index])
-    ) {
-      removedAny = true
-    }
-    if (cleaned.length === 0) {
-      delete nextHooks[eventName]
-    } else {
-      nextHooks[eventName] = cleaned
-    }
-  }
-  if (removedAny) {
-    const hooksWritePath = resolveHooksJsonWritePath(hooksJsonPath)
-    const previousMode = statSync(hooksWritePath).mode
-    mutateRealHomeHooksPreservingUserTrust({
-      sourcePath: hooksJsonPath,
-      runtimeHomePath: getSystemCodexHomePath(),
-      tomlPath: getRealHomeConfigTomlPath(),
-      beforeHooks: config.hooks,
-      afterHooks: nextHooks,
-      writeHooks: () => {
-        assertHooksJsonGeneration(hooksJsonPath, hooksWritePath, previousRaw)
-        writeHooksJson(
-          hooksWritePath,
-          {
-            ...config,
-            hooks: nextHooks
-          } as HooksConfig,
-          { preserveMode: true }
-        )
-      },
-      restoreHooks: () => restoreRealHomeHooksJson(hooksWritePath, previousRaw, previousMode)
-    })
-    // Why: dead [hooks.state] blocks for a removed hook are Orca-owned records;
-    // dropping them keeps the user's config.toml from accumulating orphans.
-    // Verify ownership by the expected hash or grant ledger: stale/mixed hook
-    // groups must never make Orca delete a user's trust record at the same key.
-    try {
-      removeCodexManagedHookTrustEntries({
-        tomlPath: getRealHomeConfigTomlPath(),
-        runtimeHomePath: getSystemCodexHomePath(),
-        sourcePath: hooksJsonPath,
-        command: material.command,
-        managedEventLabels: new Set(Object.values(material.eventLabel)),
-        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
-      })
-    } catch (error) {
-      console.warn('[codex-real-home-hooks] failed to drop Orca trust entries:', error)
-    }
-  }
-  return 'removed'
-}
 
-/** One-time pristine copy of the user's file, kept under Orca's userData. */
-function backupRealHomeHooksJsonOnce(userDataPath: string, previousRaw: string | null): void {
-  if (previousRaw === null) {
-    return
-  }
-  const backupDir = getRealHomeHookStateDir(userDataPath)
-  const backupPath = join(backupDir, 'hooks.json.pre-orca')
-  if (existsSync(backupPath)) {
-    return
-  }
-  // Why: this lane mutates the user's real Codex home. If the required
-  // pristine recovery copy cannot be created, keep the managed lane intact.
-  mkdirSync(backupDir, { recursive: true })
-  writeFileAtomically(backupPath, previousRaw, { mode: 0o600 })
-}
-
-function restoreRealHomeHooksJson(
-  hooksJsonPath: string,
-  previousRaw: string | null,
-  previousMode?: number
-): void {
-  if (previousRaw === null) {
-    if (existsSync(hooksJsonPath)) {
-      unlinkSync(hooksJsonPath)
+  if (plan.action === 'prefer-managed') {
+    // Why: leave ~/.codex free of Orca status hooks for orca-sessions scope
+    // and dual-representation avoidance. Managed CODEX_HOME keeps Orca-launched
+    // status reporting working without enrolling external Codex sessions.
+    sweepRealHomeCodexHooks()
+    if (plan.reason === 'dual-hook-representation') {
+      console.warn(
+        '[codex-real-home-hooks] config.toml already declares user-layer hooks; ' +
+          'skipping real-home hooks.json to avoid dual representation — managed lane kept'
+      )
+      installRetryAfterMs = Number.POSITIVE_INFINITY
+      return 'unavailable'
     }
-    return
+    return 'orca-sessions'
   }
-  // Why: rollback is part of the safety boundary. Use the shared atomic
-  // writer so Windows file-lock retries and failed-temp cleanup are covered.
-  writeFileAtomically(hooksJsonPath, previousRaw, { mode: previousMode })
+
+  const outcome = installRealHomeCodexHooks(args.userDataPath)
+  if (outcome.kind === 'unavailable') {
+    installRetryAfterMs = outcome.retryAfterMs
+  }
+  return outcome.kind
 }
 
 export const _internals = {

--- a/src/main/codex/codex-real-home-hook-mutation.ts
+++ b/src/main/codex/codex-real-home-hook-mutation.ts
@@ -138,12 +138,19 @@ export function installRealHomeCodexHooks(userDataPath: string): RealHomeHookMut
     return { kind: 'installed' }
   }
 
-  // Why: never leave an untrusted Orca entry in the user's real home.
+  // Why: never leave an untrusted Orca entry in the user's real home. Catch each
+  // restore so a secondary throw cannot mask grant.reason for the retry timer.
   try {
     restoreRealHomeHooksJson(hooksWritePath, previousRaw, previousMode)
+  } catch (error) {
+    console.error('[codex-real-home-hooks] rollback of hooks.json failed:', error)
   } finally {
     if (trustConfigSnapshot) {
-      restoreCodexTrustConfig(getRealHomeConfigTomlPath(), trustConfigSnapshot)
+      try {
+        restoreCodexTrustConfig(getRealHomeConfigTomlPath(), trustConfigSnapshot)
+      } catch (error) {
+        console.error('[codex-real-home-hooks] rollback of config.toml trust failed:', error)
+      }
     }
   }
   console.warn(
@@ -156,6 +163,16 @@ export function installRealHomeCodexHooks(userDataPath: string): RealHomeHookMut
 export function sweepRealHomeCodexHooks(): RealHomeHookMutationOutcome {
   const hooksJsonPath = getRealHomeHooksJsonPath()
   const { raw: previousRaw, config } = readHooksJsonWithRaw(hooksJsonPath)
+  if (previousRaw !== null && !config) {
+    // Why: unreadable/unparseable hooks.json is not "clean" — log residue so ops
+    // can diagnose a leftover Orca entry the sweep could not rewrite.
+    console.warn(
+      '[codex-real-home-hooks] could not parse',
+      hooksJsonPath,
+      '- sweep skipped'
+    )
+    return { kind: 'removed' }
+  }
   if (!config?.hooks || previousRaw === null) {
     return { kind: 'removed' }
   }

--- a/src/main/codex/codex-real-home-hook-mutation.ts
+++ b/src/main/codex/codex-real-home-hook-mutation.ts
@@ -1,0 +1,290 @@
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { writeFileAtomically } from '../codex-accounts/fs-utils'
+import {
+  buildManagedCommandHook,
+  createManagedCommandMatcher,
+  MANAGED_HOOK_TIMEOUT_SECONDS,
+  readHooksJsonWithRaw,
+  removeManagedCommands,
+  writeHooksJson,
+  writeManagedScript,
+  type HookDefinition,
+  type HooksConfig
+} from '../agent-hooks/installer-utils'
+import { resolveHooksJsonWritePath } from '../agent-hooks/hook-config-write-path'
+import { getCodexManagedScriptFileName } from './codex-hook-identity'
+import {
+  CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS,
+  grantManagedCodexHookTrust,
+  type CodexTrustGrantFallbackReason
+} from './codex-hook-trust-grant'
+import { removeCodexManagedHookTrustEntries } from './codex-managed-trust-reconciliation'
+import { getCodexManagedHookInstallMaterial } from './hook-service'
+import { getSystemCodexHomePath } from './codex-home-paths'
+import type { CodexTrustEntry } from './config-toml-trust'
+import { restoreCodexTrustConfig } from './codex-trust-config-rollback'
+import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-rebase'
+
+export type RealHomeHookMutationOutcome =
+  | { kind: 'installed' }
+  | { kind: 'removed' }
+  | { kind: 'unavailable'; retryAfterMs: number }
+
+function getRealHomeHooksJsonPath(): string {
+  return join(getSystemCodexHomePath(), 'hooks.json')
+}
+
+function getRealHomeConfigTomlPath(): string {
+  return join(getSystemCodexHomePath(), 'config.toml')
+}
+
+function getRealHomeHookStateDir(userDataPath: string): string {
+  return join(userDataPath, 'codex-real-home-hooks')
+}
+
+function assertHooksJsonGeneration(
+  hooksJsonPath: string,
+  hooksWritePath: string,
+  expectedRaw: string | null
+): void {
+  const currentRaw = existsSync(hooksJsonPath) ? readFileSync(hooksJsonPath, 'utf-8') : null
+  if (currentRaw !== expectedRaw || resolveHooksJsonWritePath(hooksJsonPath) !== hooksWritePath) {
+    // Why: the pre-mutation RPC can overlap a user's editor save. Abort rather
+    // than atomically replacing a newer file with the stale parsed snapshot.
+    throw new Error('Codex hooks.json changed while Orca prepared its trust repair')
+  }
+}
+
+/** Append + trust Orca status hooks in the real ~/.codex home (all-sessions). */
+export function installRealHomeCodexHooks(userDataPath: string): RealHomeHookMutationOutcome {
+  const material = getCodexManagedHookInstallMaterial()
+  const hooksJsonPath = getRealHomeHooksJsonPath()
+  const hooksWritePath = resolveHooksJsonWritePath(hooksJsonPath)
+  // Why: generation guard must compare against the same bytes this parse used.
+  const { raw: previousRaw, config } = readHooksJsonWithRaw(hooksJsonPath)
+  if (!config) {
+    console.warn('[codex-real-home-hooks] could not parse', hooksJsonPath, '- managed lane kept')
+    return {
+      kind: 'unavailable',
+      retryAfterMs: Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS
+    }
+  }
+  if (Object.keys(config).some((key) => key !== 'hooks')) {
+    // Why: Codex rejects unknown root keys; avoid rewriting a file RPC can't load.
+    return {
+      kind: 'unavailable',
+      retryAfterMs: Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS
+    }
+  }
+
+  writeManagedScript(material.scriptPath, material.script)
+
+  const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())
+  const nextHooks: Record<string, HookDefinition[]> = { ...config.hooks }
+  const managedEntries: CodexTrustEntry[] = []
+  for (const eventName of material.events) {
+    const current = Array.isArray(nextHooks[eventName]) ? nextHooks[eventName] : []
+    const reconciled = reconcileManagedHookDefinition(current, isManagedCommand, material.command)
+    nextHooks[eventName] = reconciled.definitions
+    managedEntries.push({
+      sourcePath: hooksJsonPath,
+      eventLabel: material.eventLabel[eventName],
+      groupIndex: reconciled.groupIndex,
+      handlerIndex: reconciled.handlerIndex,
+      command: material.command,
+      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+    })
+  }
+  for (const [eventName, definitions] of Object.entries(nextHooks)) {
+    if ((material.events as readonly string[]).includes(eventName) || !Array.isArray(definitions)) {
+      continue
+    }
+    const cleaned = removeManagedCommands(definitions, isManagedCommand)
+    if (cleaned.length === 0) {
+      delete nextHooks[eventName]
+    } else {
+      nextHooks[eventName] = cleaned
+    }
+  }
+
+  const previousMode = previousRaw === null ? undefined : statSync(hooksWritePath).mode
+  backupRealHomeHooksJsonOnce(userDataPath, previousRaw)
+  const trustConfigSnapshot = mutateRealHomeHooksPreservingUserTrust({
+    sourcePath: hooksJsonPath,
+    runtimeHomePath: getSystemCodexHomePath(),
+    tomlPath: getRealHomeConfigTomlPath(),
+    beforeHooks: config.hooks ?? {},
+    afterHooks: nextHooks,
+    writeHooks: () => {
+      assertHooksJsonGeneration(hooksJsonPath, hooksWritePath, previousRaw)
+      writeHooksJson(hooksWritePath, { ...config, hooks: nextHooks } as HooksConfig, {
+        preserveMode: true
+      })
+    },
+    restoreHooks: () => restoreRealHomeHooksJson(hooksWritePath, previousRaw, previousMode)
+  })
+
+  const grant = grantManagedCodexHookTrust({
+    runtimeHomePath: getSystemCodexHomePath(),
+    tomlPath: getRealHomeConfigTomlPath(),
+    managedCommand: material.command,
+    managedEntries,
+    host: { kind: 'native' },
+    telemetryLane: 'real-home',
+    useDefaultCodexHome: true
+  })
+  if (grant.lane === 'rpc') {
+    return { kind: 'installed' }
+  }
+
+  // Why: never leave an untrusted Orca entry in the user's real home.
+  try {
+    restoreRealHomeHooksJson(hooksWritePath, previousRaw, previousMode)
+  } finally {
+    if (trustConfigSnapshot) {
+      restoreCodexTrustConfig(getRealHomeConfigTomlPath(), trustConfigSnapshot)
+    }
+  }
+  console.warn(
+    `[codex-real-home-hooks] trust grant unavailable (${grant.reason}); entry rolled back, managed lane kept`
+  )
+  return { kind: 'unavailable', retryAfterMs: getInstallRetryAfterMs(grant.reason) }
+}
+
+/** Remove only Orca-owned entries from the real ~/.codex hooks layer. */
+export function sweepRealHomeCodexHooks(): RealHomeHookMutationOutcome {
+  const hooksJsonPath = getRealHomeHooksJsonPath()
+  const { raw: previousRaw, config } = readHooksJsonWithRaw(hooksJsonPath)
+  if (!config?.hooks || previousRaw === null) {
+    return { kind: 'removed' }
+  }
+  const isManagedCommand = createManagedCommandMatcher(getCodexManagedScriptFileName())
+  const material = getCodexManagedHookInstallMaterial()
+  const nextHooks: Record<string, HookDefinition[]> = { ...config.hooks }
+  let removedAny = false
+  for (const [eventName, definitions] of Object.entries(nextHooks)) {
+    if (!Array.isArray(definitions)) {
+      continue
+    }
+    const cleaned = removeManagedCommands(definitions, isManagedCommand)
+    if (
+      cleaned.length !== definitions.length ||
+      cleaned.some((definition, index) => definition !== definitions[index])
+    ) {
+      removedAny = true
+    }
+    if (cleaned.length === 0) {
+      delete nextHooks[eventName]
+    } else {
+      nextHooks[eventName] = cleaned
+    }
+  }
+  if (removedAny) {
+    const hooksWritePath = resolveHooksJsonWritePath(hooksJsonPath)
+    const previousMode = statSync(hooksWritePath).mode
+    mutateRealHomeHooksPreservingUserTrust({
+      sourcePath: hooksJsonPath,
+      runtimeHomePath: getSystemCodexHomePath(),
+      tomlPath: getRealHomeConfigTomlPath(),
+      beforeHooks: config.hooks,
+      afterHooks: nextHooks,
+      writeHooks: () => {
+        assertHooksJsonGeneration(hooksJsonPath, hooksWritePath, previousRaw)
+        writeHooksJson(
+          hooksWritePath,
+          {
+            ...config,
+            hooks: nextHooks
+          } as HooksConfig,
+          { preserveMode: true }
+        )
+      },
+      restoreHooks: () => restoreRealHomeHooksJson(hooksWritePath, previousRaw, previousMode)
+    })
+    try {
+      removeCodexManagedHookTrustEntries({
+        tomlPath: getRealHomeConfigTomlPath(),
+        runtimeHomePath: getSystemCodexHomePath(),
+        sourcePath: hooksJsonPath,
+        command: material.command,
+        managedEventLabels: new Set(Object.values(material.eventLabel)),
+        timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+      })
+    } catch (error) {
+      console.warn('[codex-real-home-hooks] failed to drop Orca trust entries:', error)
+    }
+  }
+  return { kind: 'removed' }
+}
+
+function reconcileManagedHookDefinition(
+  current: HookDefinition[],
+  isManagedCommand: (command: string | undefined) => boolean,
+  command: string
+): { definitions: HookDefinition[]; groupIndex: number; handlerIndex: number } {
+  const directCommandKeys = ['command', 'bash', 'powershell'] as const
+  const hasManagedDirectCommand = current.some((definition) =>
+    directCommandKeys.some((key) => isManagedCommand(definition[key]))
+  )
+  const nestedLocations = current.flatMap((definition, groupIndex) =>
+    Array.isArray(definition.hooks)
+      ? definition.hooks.flatMap((hook, handlerIndex) =>
+          isManagedCommand(hook.command) ? [{ groupIndex, handlerIndex }] : []
+        )
+      : []
+  )
+  if (!hasManagedDirectCommand && nestedLocations.length === 1) {
+    const { groupIndex, handlerIndex } = nestedLocations[0]!
+    const definition = current[groupIndex]!
+    const hasDirectCommand = directCommandKeys.some((key) => typeof definition[key] === 'string')
+    if (definition.matcher === undefined && !hasDirectCommand) {
+      const definitions = [...current]
+      // Why: reuse the exact slot so later positional trust keys stay stable.
+      const hooks = [...definition.hooks!]
+      hooks[handlerIndex] = buildManagedCommandHook(command)
+      definitions[groupIndex] = { ...definition, hooks }
+      return { definitions, groupIndex, handlerIndex }
+    }
+  }
+
+  const cleaned = removeManagedCommands(current, isManagedCommand)
+  return {
+    definitions: [...cleaned, { hooks: [buildManagedCommandHook(command)] }],
+    groupIndex: cleaned.length,
+    handlerIndex: 0
+  }
+}
+
+function getInstallRetryAfterMs(reason: CodexTrustGrantFallbackReason): number {
+  return reason === 'unsupported' || reason === 'unsupported-cached' || reason === 'disabled'
+    ? Number.POSITIVE_INFINITY
+    : Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS
+}
+
+function backupRealHomeHooksJsonOnce(userDataPath: string, previousRaw: string | null): void {
+  if (previousRaw === null) {
+    return
+  }
+  const backupDir = getRealHomeHookStateDir(userDataPath)
+  const backupPath = join(backupDir, 'hooks.json.pre-orca')
+  if (existsSync(backupPath)) {
+    return
+  }
+  mkdirSync(backupDir, { recursive: true })
+  writeFileAtomically(backupPath, previousRaw, { mode: 0o600 })
+}
+
+function restoreRealHomeHooksJson(
+  hooksJsonPath: string,
+  previousRaw: string | null,
+  previousMode?: number
+): void {
+  if (previousRaw === null) {
+    if (existsSync(hooksJsonPath)) {
+      unlinkSync(hooksJsonPath)
+    }
+    return
+  }
+  writeFileAtomically(hooksJsonPath, previousRaw, { mode: previousMode })
+}

--- a/src/main/codex/codex-system-default-hook-scope.test.ts
+++ b/src/main/codex/codex-system-default-hook-scope.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  configTomlHasUserLayerHookDefinitions,
+  getDefaultCodexSystemDefaultHookScope,
+  planSystemDefaultHookInstall,
+  resolveCodexSystemDefaultHookScope
+} from './codex-system-default-hook-scope'
+
+const SCOPE_ENV = 'ORCA_CODEX_SYSTEM_DEFAULT_HOOK_SCOPE'
+let previousScope: string | undefined
+
+beforeEach(() => {
+  previousScope = process.env[SCOPE_ENV]
+  delete process.env[SCOPE_ENV]
+})
+
+afterEach(() => {
+  if (previousScope === undefined) {
+    delete process.env[SCOPE_ENV]
+  } else {
+    process.env[SCOPE_ENV] = previousScope
+  }
+})
+
+describe('resolveCodexSystemDefaultHookScope', () => {
+  it('defaults to the safer orca-sessions scope', () => {
+    expect(getDefaultCodexSystemDefaultHookScope()).toBe('orca-sessions')
+    expect(resolveCodexSystemDefaultHookScope({})).toBe('orca-sessions')
+  })
+
+  it('accepts all-sessions env aliases', () => {
+    for (const raw of ['all-sessions', 'all', 'system-default', 'real-home', ' ALL ']) {
+      expect(resolveCodexSystemDefaultHookScope({ [SCOPE_ENV]: raw })).toBe('all-sessions')
+    }
+  })
+
+  it('accepts orca-sessions env aliases', () => {
+    for (const raw of ['orca-sessions', 'orca', 'orca-only', 'managed']) {
+      expect(resolveCodexSystemDefaultHookScope({ [SCOPE_ENV]: raw })).toBe('orca-sessions')
+    }
+  })
+
+  it('ignores unrecognized values and stays on the safer default', () => {
+    expect(resolveCodexSystemDefaultHookScope({ [SCOPE_ENV]: 'maybe' })).toBe('orca-sessions')
+  })
+})
+
+describe('planSystemDefaultHookInstall', () => {
+  it('sweeps the real home when status hooks are disabled', () => {
+    expect(
+      planSystemDefaultHookInstall({
+        scope: 'all-sessions',
+        hooksEnabled: false,
+        configTomlHasUserHookDefinitions: false
+      })
+    ).toEqual({ action: 'sweep-real-home' })
+  })
+
+  it('prefers managed CODEX_HOME for the orca-sessions scope', () => {
+    expect(
+      planSystemDefaultHookInstall({
+        scope: 'orca-sessions',
+        hooksEnabled: true,
+        configTomlHasUserHookDefinitions: false
+      })
+    ).toEqual({ action: 'prefer-managed', reason: 'orca-sessions-scope' })
+  })
+
+  it('installs into the real home only for all-sessions without dual representation', () => {
+    expect(
+      planSystemDefaultHookInstall({
+        scope: 'all-sessions',
+        hooksEnabled: true,
+        configTomlHasUserHookDefinitions: false
+      })
+    ).toEqual({ action: 'install-real-home' })
+  })
+
+  it('refuses real-home install when config.toml already defines user hooks', () => {
+    expect(
+      planSystemDefaultHookInstall({
+        scope: 'all-sessions',
+        hooksEnabled: true,
+        configTomlHasUserHookDefinitions: true
+      })
+    ).toEqual({ action: 'prefer-managed', reason: 'dual-hook-representation' })
+  })
+})
+
+describe('configTomlHasUserLayerHookDefinitions', () => {
+  it('detects array-of-tables hook definitions', () => {
+    expect(
+      configTomlHasUserLayerHookDefinitions(
+        [
+          'model = "gpt"',
+          '',
+          '[[hooks.Stop]]',
+          '[[hooks.Stop.hooks]]',
+          'type = "command"',
+          ''
+        ].join('\n')
+      )
+    ).toBe(true)
+  })
+
+  it('ignores hooks.state trust tables Orca writes next to hooks.json', () => {
+    expect(
+      configTomlHasUserLayerHookDefinitions(
+        [
+          '[features]',
+          'hooks = true',
+          '',
+          '[hooks.state."/home/u/.codex/hooks.json:stop:0:0"]',
+          'trusted_hash = "sha256:abc"',
+          ''
+        ].join('\n')
+      )
+    ).toBe(false)
+  })
+
+  it('ignores hook-looking headers inside multiline strings', () => {
+    expect(
+      configTomlHasUserLayerHookDefinitions(
+        ['notes = """', '[[hooks.Stop]]', 'is documentation only', '"""', ''].join('\n')
+      )
+    ).toBe(false)
+  })
+
+  it('treats a bare [hooks] table as a user-layer definition container', () => {
+    expect(configTomlHasUserLayerHookDefinitions('[hooks]\n')).toBe(true)
+  })
+})

--- a/src/main/codex/codex-system-default-hook-scope.ts
+++ b/src/main/codex/codex-system-default-hook-scope.ts
@@ -1,0 +1,103 @@
+import {
+  createTomlLineScanState,
+  getTomlTableHeader,
+  isTomlStructuralLine,
+  updateTomlLineScanState
+} from './config-toml-line-scan'
+
+/**
+ * Scope of Orca status-hook enrollment for the System Default Codex home.
+ *
+ * - `orca-sessions`: install only into Orca-managed CODEX_HOME for launches
+ *   from Orca. Never mutate the shared `~/.codex` hook layer. Safer default.
+ * - `all-sessions`: enroll the real system home so every Codex process using
+ *   that home (including outside Orca) loads the status relay.
+ */
+export type CodexSystemDefaultHookScope = 'orca-sessions' | 'all-sessions'
+
+export type SystemDefaultHookInstallPlan =
+  | { action: 'install-real-home' }
+  | { action: 'prefer-managed'; reason: 'orca-sessions-scope' | 'dual-hook-representation' }
+  | { action: 'sweep-real-home' }
+
+const SCOPE_ENV = 'ORCA_CODEX_SYSTEM_DEFAULT_HOOK_SCOPE'
+
+/** Safer product default: do not enroll the shared System Default home. */
+export function getDefaultCodexSystemDefaultHookScope(): CodexSystemDefaultHookScope {
+  return 'orca-sessions'
+}
+
+/**
+ * Resolves the effective scope. Env override is test/power-user only — no UI
+ * setting yet; production default stays `orca-sessions`.
+ */
+export function resolveCodexSystemDefaultHookScope(
+  env: NodeJS.ProcessEnv = process.env
+): CodexSystemDefaultHookScope {
+  const raw = env[SCOPE_ENV]?.trim().toLowerCase()
+  if (raw === 'all-sessions' || raw === 'all' || raw === 'system-default' || raw === 'real-home') {
+    return 'all-sessions'
+  }
+  if (raw === 'orca-sessions' || raw === 'orca' || raw === 'orca-only' || raw === 'managed') {
+    return 'orca-sessions'
+  }
+  return getDefaultCodexSystemDefaultHookScope()
+}
+
+/**
+ * Pure install-target decision for System Default status hooks.
+ * Dual-representation always wins over `all-sessions`: never create hooks.json
+ * when config.toml already carries user-layer hook definitions.
+ */
+export function planSystemDefaultHookInstall(args: {
+  scope: CodexSystemDefaultHookScope
+  hooksEnabled: boolean
+  configTomlHasUserHookDefinitions: boolean
+}): SystemDefaultHookInstallPlan {
+  if (!args.hooksEnabled) {
+    return { action: 'sweep-real-home' }
+  }
+  if (args.scope === 'orca-sessions') {
+    return { action: 'prefer-managed', reason: 'orca-sessions-scope' }
+  }
+  if (args.configTomlHasUserHookDefinitions) {
+    return { action: 'prefer-managed', reason: 'dual-hook-representation' }
+  }
+  return { action: 'install-real-home' }
+}
+
+/**
+ * True when config.toml declares executable hook definitions (array-of-tables
+ * or tables under `hooks.*` other than `hooks.state`). Trust-only `[hooks.state.*]`
+ * does not count — Orca writes those alongside hooks.json intentionally.
+ */
+export function configTomlHasUserLayerHookDefinitions(toml: string): boolean {
+  const lines = toml.split('\n')
+  let scanState = createTomlLineScanState()
+  for (const line of lines) {
+    if (isTomlStructuralLine(scanState)) {
+      const header = getTomlTableHeader(line)
+      if (header && isUserLayerHookDefinitionHeader(header)) {
+        return true
+      }
+    }
+    scanState = updateTomlLineScanState(scanState, line)
+  }
+  return false
+}
+
+function isUserLayerHookDefinitionHeader(header: string): boolean {
+  const trimmed = header.trim()
+  // [[hooks.Stop]] / [hooks.Stop] / [[hooks.Stop.hooks]] — not [hooks.state.*]
+  const match = /^\[\[?\s*hooks(?:\.(.+))?\s*\]\]?$/.exec(trimmed)
+  if (!match) {
+    return false
+  }
+  const rest = match[1]
+  if (rest === undefined || rest === '') {
+    // Bare [hooks] / [[hooks]] is a hook-definition container, not trust state.
+    return true
+  }
+  const firstSegment = rest.split('.')[0]?.trim().toLowerCase()
+  return firstSegment !== 'state'
+}


### PR DESCRIPTION
## Description
System Default Codex status hooks default to **Orca sessions only**: do not write Orca hooks into the user’s real `~/.codex/hooks.json` (avoids dual hooks.json + config.toml representation and unexpected outside-Orca reporting). Orca-managed launches keep status via managed CODEX_HOME.

## Focused fix
- In scope: default `orca-sessions` scope, leftover real-home sweep, dual-rep guard for opt-in `all-sessions`, pure plan helpers + tests
- Out of scope: full settings UI (env opt-in `ORCA_CODEX_SYSTEM_DEFAULT_HOOK_SCOPE=all-sessions` only)

## Preserves
- Orca-launched Codex status hooks still work (managed home)
- User’s real-home hooks/trust entries
- Opt-in all-sessions path for users who want shared-home reporting

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-system-default-hook-scope.test.ts src/main/codex/codex-real-home-hook-install.test.ts` → 36 passed

## User-regression-tradeoffs
- Default is safer (no real-home enrollment). Users who relied on external Codex reporting to Orca must set the all-sessions env (or future UI).

Fixes #10947