### PR TITLE
fix(worktree): ignore shared-dir symlinks so git add -A cannot stage them

### DIFF
--- a/src/main/ipc/worktree-symlink-git-exclude.test.ts
+++ b/src/main/ipc/worktree-symlink-git-exclude.test.ts
@@ -11,7 +11,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { createWorktreeLinkedPaths } from './worktree-symlinks'
+import { createWorktreeSharedPaths } from './worktree-symlinks'
 import {
   ensureWorktreeSharedSymlinkExclude,
   resolveWorktreeGitCommonDir,
@@ -134,6 +134,23 @@ describe('ensureWorktreeSharedSymlinkExclude', () => {
     expect(readFileSync(excludePath, 'utf8')).toBe('/node_modules\n')
   })
 
+  posixIt('still appends bare rule when only a directory-only pattern exists', async () => {
+    const primary = join(root, 'primary')
+    initRepoWithCommit(primary)
+    const worktree = join(root, 'worktree-dir-only')
+    git(primary, ['worktree', 'add', '--quiet', '-b', 'feature-dir', worktree])
+    symlinkSync(join(primary, '.gitignore'), join(worktree, 'node_modules'))
+
+    const commonDir = (await resolveWorktreeGitCommonDir(worktree))!
+    const excludePath = join(commonDir, 'info', 'exclude')
+    // Directory-only form does not cover symlinks — must still write /node_modules.
+    writeFileSync(excludePath, 'node_modules/\n')
+
+    await ensureWorktreeSharedSymlinkExclude(worktree, ['node_modules'])
+    expect(readFileSync(excludePath, 'utf8')).toContain('/node_modules\n')
+    git(worktree, ['check-ignore', '-q', 'node_modules'])
+  })
+
   posixIt('skips real directories that already match directory-only ignore', async () => {
     const primary = join(root, 'primary')
     initRepoWithCommit(primary)
@@ -153,7 +170,7 @@ describe('ensureWorktreeSharedSymlinkExclude', () => {
   })
 
   posixIt(
-    'materialize path writes exclude so git add -A cannot stage the absolute-path symlink',
+    'shared-path materialize writes exclude so git add -A cannot stage the absolute-path symlink',
     async () => {
       const primary = join(root, 'primary')
       initRepoWithCommit(primary)
@@ -163,7 +180,9 @@ describe('ensureWorktreeSharedSymlinkExclude', () => {
       mkdirSync(join(primary, 'node_modules'))
       writeFileSync(join(primary, 'node_modules', 'pkg.js'), 'secret')
 
-      await createWorktreeLinkedPaths(primary, worktree, ['node_modules'], {
+      // Why: exclude widening is scoped to sharedDirectories (createWorktreeSharedPaths),
+      // not every generic linked path.
+      await createWorktreeSharedPaths(primary, worktree, ['node_modules'], {
         platform: 'linux'
       })
 

--- a/src/main/ipc/worktree-symlink-git-exclude.test.ts
+++ b/src/main/ipc/worktree-symlink-git-exclude.test.ts
@@ -1,0 +1,155 @@
+import { execFileSync } from 'node:child_process'
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createWorktreeLinkedPaths } from './worktree-symlinks'
+import {
+  ensureWorktreeSharedSymlinkExclude,
+  resolveWorktreeGitCommonDir,
+  sharedSymlinkExcludePattern
+} from './worktree-symlink-git-exclude'
+
+const posixIt = process.platform === 'win32' ? it.skip : it
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe']
+  })
+}
+
+function initRepoWithCommit(repoRoot: string): void {
+  mkdirSync(repoRoot, { recursive: true })
+  git(repoRoot, ['init', '--quiet'])
+  git(repoRoot, ['config', 'user.email', 'test@orca.test'])
+  git(repoRoot, ['config', 'user.name', 'Orca Test'])
+  // Why: directory-only ignore is the common spelling that misses symlinks.
+  writeFileSync(join(repoRoot, '.gitignore'), 'node_modules/\n')
+  writeFileSync(join(repoRoot, 'README.md'), 'seed\n')
+  git(repoRoot, ['add', 'README.md', '.gitignore'])
+  git(repoRoot, ['commit', '--quiet', '-m', 'seed'])
+}
+
+describe('sharedSymlinkExcludePattern', () => {
+  it('anchors at the repo root without a trailing slash', () => {
+    expect(sharedSymlinkExcludePattern('node_modules')).toBe('/node_modules')
+    expect(sharedSymlinkExcludePattern('node_modules/')).toBe('/node_modules')
+    expect(sharedSymlinkExcludePattern('/apps/web/node_modules')).toBe('/apps/web/node_modules')
+  })
+
+  it('normalizes backslashes and rejects traversal or injection', () => {
+    expect(sharedSymlinkExcludePattern('apps\\web\\node_modules')).toBe('/apps/web/node_modules')
+    expect(sharedSymlinkExcludePattern('../escape')).toBeNull()
+    expect(sharedSymlinkExcludePattern('node_modules\n/etc/passwd')).toBeNull()
+    expect(sharedSymlinkExcludePattern('')).toBeNull()
+  })
+})
+
+describe('ensureWorktreeSharedSymlinkExclude', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-symlink-exclude-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  posixIt('appends a bare symlink rule to info/exclude for linked worktrees', async () => {
+    const primary = join(root, 'primary')
+    initRepoWithCommit(primary)
+    const worktree = join(root, 'worktree')
+    git(primary, ['worktree', 'add', '--quiet', '-b', 'feature', worktree])
+
+    mkdirSync(join(primary, 'node_modules'))
+    writeFileSync(join(primary, 'node_modules', 'pkg.js'), 'x')
+    symlinkSync(join(primary, 'node_modules'), join(worktree, 'node_modules'))
+
+    // Baseline: directory-only ignore does not match the symlink.
+    expect(() => git(worktree, ['check-ignore', '-q', 'node_modules'])).toThrow()
+
+    await ensureWorktreeSharedSymlinkExclude(worktree, ['node_modules'])
+
+    const commonDir = await resolveWorktreeGitCommonDir(worktree)
+    expect(commonDir).toBeTruthy()
+    const exclude = readFileSync(join(commonDir!, 'info', 'exclude'), 'utf8')
+    expect(exclude).toContain('/node_modules\n')
+
+    // check-ignore exits 0 when ignored.
+    git(worktree, ['check-ignore', '-q', 'node_modules'])
+  })
+
+  posixIt('is a no-op when the pattern is already listed', async () => {
+    const primary = join(root, 'primary')
+    initRepoWithCommit(primary)
+    const worktree = join(root, 'worktree')
+    git(primary, ['worktree', 'add', '--quiet', '-b', 'feature', worktree])
+    symlinkSync(join(primary, '.gitignore'), join(worktree, 'node_modules'))
+
+    const commonDir = (await resolveWorktreeGitCommonDir(worktree))!
+    const excludePath = join(commonDir, 'info', 'exclude')
+    writeFileSync(excludePath, '/node_modules\n')
+
+    await ensureWorktreeSharedSymlinkExclude(worktree, ['node_modules'])
+    expect(readFileSync(excludePath, 'utf8')).toBe('/node_modules\n')
+  })
+
+  posixIt('skips real directories that already match directory-only ignore', async () => {
+    const primary = join(root, 'primary')
+    initRepoWithCommit(primary)
+    mkdirSync(join(primary, 'node_modules'))
+
+    await ensureWorktreeSharedSymlinkExclude(primary, ['node_modules'])
+
+    const commonDir = (await resolveWorktreeGitCommonDir(primary))!
+    // Why: no symlink → no exclude write; git's default exclude may still exist empty/commented.
+    let exclude = ''
+    try {
+      exclude = readFileSync(join(commonDir, 'info', 'exclude'), 'utf8')
+    } catch {
+      // absent is fine
+    }
+    expect(exclude).not.toContain('node_modules')
+  })
+
+  posixIt(
+    'materialize path writes exclude so git add -A cannot stage the absolute-path symlink',
+    async () => {
+      const primary = join(root, 'primary')
+      initRepoWithCommit(primary)
+      const worktree = join(root, 'worktree')
+      git(primary, ['worktree', 'add', '--quiet', '-b', 'feature', worktree])
+
+      mkdirSync(join(primary, 'node_modules'))
+      writeFileSync(join(primary, 'node_modules', 'pkg.js'), 'secret')
+
+      await createWorktreeLinkedPaths(primary, worktree, ['node_modules'], {
+        platform: 'linux'
+      })
+
+      expect(lstatSync(join(worktree, 'node_modules')).isSymbolicLink()).toBe(true)
+      git(worktree, ['check-ignore', '-q', 'node_modules'])
+
+      git(worktree, ['add', '-A'])
+      const porcelain = git(worktree, ['status', '--porcelain'])
+      expect(porcelain).not.toMatch(/(^|\n)A\s+node_modules(\n|$)/)
+      expect(porcelain).not.toMatch(/(^|\n)\?\?\s+node_modules(\n|$)/)
+
+      // Why: the staged-index path must not hold a mode-120000 absolute blob.
+      expect(() => git(worktree, ['ls-files', '-s', '--', 'node_modules'])).not.toThrow()
+      const lsFiles = git(worktree, ['ls-files', '-s', '--', 'node_modules']).trim()
+      expect(lsFiles).toBe('')
+    }
+  )
+})

--- a/src/main/ipc/worktree-symlink-git-exclude.test.ts
+++ b/src/main/ipc/worktree-symlink-git-exclude.test.ts
@@ -53,6 +53,14 @@ describe('sharedSymlinkExcludePattern', () => {
     expect(sharedSymlinkExcludePattern('node_modules\n/etc/passwd')).toBeNull()
     expect(sharedSymlinkExcludePattern('')).toBeNull()
   })
+
+  it('escapes gitignore metacharacters and spaces as literal names', () => {
+    expect(sharedSymlinkExcludePattern('cache*')).toBe('/cache\\*')
+    expect(sharedSymlinkExcludePattern('foo?bar')).toBe('/foo\\?bar')
+    expect(sharedSymlinkExcludePattern('br[ack]ets')).toBe('/br\\[ack\\]ets')
+    expect(sharedSymlinkExcludePattern('has space')).toBe('/has\\ space')
+    expect(sharedSymlinkExcludePattern('trailing  ')).toBe('/trailing\\ \\ ')
+  })
 })
 
 describe('ensureWorktreeSharedSymlinkExclude', () => {
@@ -88,6 +96,27 @@ describe('ensureWorktreeSharedSymlinkExclude', () => {
 
     // check-ignore exits 0 when ignored.
     git(worktree, ['check-ignore', '-q', 'node_modules'])
+  })
+
+  posixIt('excludes a symlink whose basename has gitignore metacharacters', async () => {
+    const primary = join(root, 'primary')
+    initRepoWithCommit(primary)
+    const worktree = join(root, 'worktree-meta')
+    git(primary, ['worktree', 'add', '--quiet', '-b', 'feature-meta', worktree])
+
+    const sharedName = 'cache*'
+    mkdirSync(join(primary, sharedName))
+    writeFileSync(join(primary, sharedName, 'pkg.js'), 'x')
+    symlinkSync(join(primary, sharedName), join(worktree, sharedName))
+
+    expect(() => git(worktree, ['check-ignore', '-q', sharedName])).toThrow()
+
+    await ensureWorktreeSharedSymlinkExclude(worktree, [sharedName])
+
+    const commonDir = await resolveWorktreeGitCommonDir(worktree)
+    const exclude = readFileSync(join(commonDir!, 'info', 'exclude'), 'utf8')
+    expect(exclude).toContain('/cache\\*\n')
+    git(worktree, ['check-ignore', '-q', sharedName])
   })
 
   posixIt('is a no-op when the pattern is already listed', async () => {

--- a/src/main/ipc/worktree-symlink-git-exclude.ts
+++ b/src/main/ipc/worktree-symlink-git-exclude.ts
@@ -1,13 +1,6 @@
 import { appendFile, lstat, mkdir, readFile, stat } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
 
-/**
- * Root-anchored pattern with no trailing slash.
- *
- * Why: directory-only rules (`node_modules/`) match real directories but not the
- * worktree shared-dir symlink Git treats as a file, so `git add -A` can stage a
- * mode-120000 blob whose content is the absolute primary path (issue #11077).
- */
 /** Normalize a worktree-relative shared path for filesystem lookup. */
 function normalizeSharedRelativePath(relativePath: string): string | null {
   // Why: do not trim trailing spaces — they can be part of a real basename.
@@ -36,6 +29,13 @@ function escapeGitignoreLiteralSegment(segment: string): string {
     .replace(/ /g, '\\ ')
 }
 
+/**
+ * Root-anchored pattern with no trailing slash.
+ *
+ * Why: directory-only rules (`node_modules/`) match real directories but not the
+ * worktree shared-dir symlink Git treats as a file, so `git add -A` can stage a
+ * mode-120000 blob whose content is the absolute primary path (issue #11077).
+ */
 export function sharedSymlinkExcludePattern(relativePath: string): string | null {
   const rel = normalizeSharedRelativePath(relativePath)
   if (!rel) {
@@ -45,8 +45,10 @@ export function sharedSymlinkExcludePattern(relativePath: string): string | null
 }
 
 function excludePatternAlreadyListed(content: string, pattern: string): boolean {
+  // Why: only exact bare/`/`-anchored forms cover symlinks. Directory-only
+  // `name/` must NOT count as already listed — that is the bug this PR fixes.
   const bare = pattern.startsWith('/') ? pattern.slice(1) : pattern
-  const candidates = new Set([pattern, `${pattern}/`, bare, `${bare}/`])
+  const candidates = new Set([pattern, bare])
   return content
     .split(/\r?\n/)
     .map((line) => line.trim())

--- a/src/main/ipc/worktree-symlink-git-exclude.ts
+++ b/src/main/ipc/worktree-symlink-git-exclude.ts
@@ -1,0 +1,138 @@
+import { appendFile, lstat, mkdir, readFile, stat } from 'node:fs/promises'
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
+
+/**
+ * Root-anchored pattern with no trailing slash.
+ *
+ * Why: directory-only rules (`node_modules/`) match real directories but not the
+ * worktree shared-dir symlink Git treats as a file, so `git add -A` can stage a
+ * mode-120000 blob whose content is the absolute primary path (issue #11077).
+ */
+export function sharedSymlinkExcludePattern(relativePath: string): string | null {
+  const rel = relativePath.trim().replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '')
+  if (
+    !rel ||
+    isAbsolute(rel) ||
+    rel.split('/').includes('..') ||
+    rel.includes('\r') ||
+    rel.includes('\n') ||
+    rel.includes('\u0000')
+  ) {
+    return null
+  }
+  return `/${rel}`
+}
+
+function excludePatternAlreadyListed(content: string, pattern: string): boolean {
+  const bare = pattern.startsWith('/') ? pattern.slice(1) : pattern
+  const candidates = new Set([pattern, `${pattern}/`, bare, `${bare}/`])
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .some((line) => candidates.has(line))
+}
+
+/** Resolve the shared git common dir (where `info/exclude` lives) for a worktree. */
+export async function resolveWorktreeGitCommonDir(worktreePath: string): Promise<string | null> {
+  const dotGitPath = join(worktreePath, '.git')
+  try {
+    const dotGitStat = await stat(dotGitPath)
+    if (dotGitStat.isDirectory()) {
+      return dotGitPath
+    }
+    if (!dotGitStat.isFile()) {
+      return null
+    }
+    const content = await readFile(dotGitPath, 'utf8')
+    const gitDirMatch = content.match(/^gitdir:\s*(.+)\s*$/m)
+    if (!gitDirMatch) {
+      return null
+    }
+    const gitDirRaw = gitDirMatch[1].trim()
+    const gitDir = isAbsolute(gitDirRaw) ? gitDirRaw : resolve(worktreePath, gitDirRaw)
+    try {
+      const commonRaw = (await readFile(join(gitDir, 'commondir'), 'utf8')).trim()
+      if (commonRaw.length > 0) {
+        return isAbsolute(commonRaw) ? commonRaw : resolve(gitDir, commonRaw)
+      }
+    } catch {
+      // Why: older layouts may omit commondir; fall through to path heuristic.
+    }
+    // Why: linked worktree gitdirs live at <common>/worktrees/<name>.
+    if (basename(dirname(gitDir)) === 'worktrees') {
+      return dirname(dirname(gitDir))
+    }
+    return gitDir
+  } catch {
+    return null
+  }
+}
+
+async function collectSymlinkExcludePatterns(
+  worktreePath: string,
+  relativePaths: readonly string[]
+): Promise<string[]> {
+  const patterns: string[] = []
+  const seen = new Set<string>()
+  for (const rawPath of relativePaths) {
+    const pattern = sharedSymlinkExcludePattern(rawPath)
+    if (!pattern || seen.has(pattern)) {
+      continue
+    }
+    const target = resolve(worktreePath, pattern.slice(1))
+    try {
+      // Why: only positively identified shared symlinks need exclude widening;
+      // APFS clones / real dirs already match directory-only ignore rules.
+      if (!(await lstat(target)).isSymbolicLink()) {
+        continue
+      }
+    } catch {
+      continue
+    }
+    seen.add(pattern)
+    patterns.push(pattern)
+  }
+  return patterns
+}
+
+/**
+ * Idempotently append root-anchored ignore rules for shared-directory symlinks
+ * to the repo's `info/exclude` so agents' `git add -A` cannot stage them.
+ *
+ * Failures are swallowed by the caller — exclude maintenance must never block
+ * worktree creation. Scope is repo-wide (common dir), matching Git's exclude
+ * resolution from linked worktrees.
+ */
+export async function ensureWorktreeSharedSymlinkExclude(
+  worktreePath: string,
+  relativePaths: readonly string[]
+): Promise<void> {
+  if (relativePaths.length === 0) {
+    return
+  }
+  const patterns = await collectSymlinkExcludePatterns(worktreePath, relativePaths)
+  if (patterns.length === 0) {
+    return
+  }
+  const commonDir = await resolveWorktreeGitCommonDir(worktreePath)
+  if (!commonDir) {
+    return
+  }
+  const excludePath = join(commonDir, 'info', 'exclude')
+  let existingContent = ''
+  try {
+    existingContent = await readFile(excludePath, 'utf8')
+  } catch {
+    // info/exclude may be absent until we create it.
+  }
+  const missing = patterns.filter(
+    (pattern) => !excludePatternAlreadyListed(existingContent, pattern)
+  )
+  if (missing.length === 0) {
+    return
+  }
+  await mkdir(dirname(excludePath), { recursive: true })
+  const needsLeadingNewline = existingContent.length > 0 && !existingContent.endsWith('\n')
+  const body = `${missing.join('\n')}\n`
+  await appendFile(excludePath, `${needsLeadingNewline ? '\n' : ''}${body}`, 'utf8')
+}

--- a/src/main/ipc/worktree-symlink-git-exclude.ts
+++ b/src/main/ipc/worktree-symlink-git-exclude.ts
@@ -8,8 +8,10 @@ import { basename, dirname, isAbsolute, join, resolve } from 'node:path'
  * worktree shared-dir symlink Git treats as a file, so `git add -A` can stage a
  * mode-120000 blob whose content is the absolute primary path (issue #11077).
  */
-export function sharedSymlinkExcludePattern(relativePath: string): string | null {
-  const rel = relativePath.trim().replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/+$/, '')
+/** Normalize a worktree-relative shared path for filesystem lookup. */
+function normalizeSharedRelativePath(relativePath: string): string | null {
+  // Why: do not trim trailing spaces — they can be part of a real basename.
+  const rel = relativePath.replace(/\\/g, '/').replace(/^[\s/]+/, '').replace(/\/+$/, '')
   if (
     !rel ||
     isAbsolute(rel) ||
@@ -20,7 +22,26 @@ export function sharedSymlinkExcludePattern(relativePath: string): string | null
   ) {
     return null
   }
-  return `/${rel}`
+  return rel
+}
+
+/** Escape one path segment so Git treats it as a literal exclude entry. */
+function escapeGitignoreLiteralSegment(segment: string): string {
+  // Why: gitignore strips unescaped trailing spaces and treats *,?,[] as globs.
+  // Shared symlink basenames can contain those characters; exclude must match
+  // the literal filesystem name only.
+  return segment
+    .replace(/\\/g, '\\\\')
+    .replace(/([*?[\]])/g, '\\$1')
+    .replace(/ /g, '\\ ')
+}
+
+export function sharedSymlinkExcludePattern(relativePath: string): string | null {
+  const rel = normalizeSharedRelativePath(relativePath)
+  if (!rel) {
+    return null
+  }
+  return `/${rel.split('/').map(escapeGitignoreLiteralSegment).join('/')}`
 }
 
 function excludePatternAlreadyListed(content: string, pattern: string): boolean {
@@ -75,11 +96,14 @@ async function collectSymlinkExcludePatterns(
   const patterns: string[] = []
   const seen = new Set<string>()
   for (const rawPath of relativePaths) {
+    const rel = normalizeSharedRelativePath(rawPath)
     const pattern = sharedSymlinkExcludePattern(rawPath)
-    if (!pattern || seen.has(pattern)) {
+    if (!rel || !pattern || seen.has(pattern)) {
       continue
     }
-    const target = resolve(worktreePath, pattern.slice(1))
+    // Why: exclude patterns escape git metacharacters; filesystem resolve must
+    // use the unescaped relative path or `cache*` becomes `cache\*`.
+    const target = resolve(worktreePath, rel)
     try {
       // Why: only positively identified shared symlinks need exclude widening;
       // APFS clones / real dirs already match directory-only ignore rules.

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -314,16 +314,6 @@ export async function createWorktreeLinkedPaths(
   options: WorktreeLinkedPathOptions = {}
 ): Promise<void> {
   await materializeWorktreePaths(primaryPath, worktreePath, paths, 'link', options)
-  // Why: directory-only ignore misses shared-dir symlinks; cover them in
-  // info/exclude so `git add -A` cannot stage absolute-path mode-120000 blobs.
-  try {
-    await ensureWorktreeSharedSymlinkExclude(worktreePath, paths)
-  } catch (error) {
-    console.warn(
-      `[worktree-symlinks] Failed to ignore shared-directory symlinks against git add -A:`,
-      error
-    )
-  }
 }
 
 /** Copy `.worktreeinclude`-resolved paths from the primary checkout into a
@@ -354,6 +344,17 @@ export async function createWorktreeSharedPaths(
   options: WorktreeLinkedPathOptions = {}
 ): Promise<void> {
   await materializeWorktreePaths(primaryPath, worktreePath, paths, 'share', options)
+  // Why: only sharedDirectories need the exclude widen — generic linked paths
+  // (e.g. .worktreeinclude) must not all land in info/exclude. Directory-only
+  // ignore misses shared-dir symlinks so git add -A can stage mode-120000 blobs.
+  try {
+    await ensureWorktreeSharedSymlinkExclude(worktreePath, paths)
+  } catch (error) {
+    console.warn(
+      `[worktree-symlinks] Failed to ignore shared-directory symlinks against git add -A:`,
+      error
+    )
+  }
 }
 
 /** Create filesystem symlinks from the primary checkout into a freshly-created

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -18,6 +18,7 @@ import {
   findExistingWorktreeSymlinkPaths,
   getSafeRelativePath
 } from '../git/worktree-symlink-detection'
+import { ensureWorktreeSharedSymlinkExclude } from './worktree-symlink-git-exclude'
 
 type WorktreeLinkedPathOptions = {
   platform?: NodeJS.Platform
@@ -313,6 +314,16 @@ export async function createWorktreeLinkedPaths(
   options: WorktreeLinkedPathOptions = {}
 ): Promise<void> {
   await materializeWorktreePaths(primaryPath, worktreePath, paths, 'link', options)
+  // Why: directory-only ignore misses shared-dir symlinks; cover them in
+  // info/exclude so `git add -A` cannot stage absolute-path mode-120000 blobs.
+  try {
+    await ensureWorktreeSharedSymlinkExclude(worktreePath, paths)
+  } catch (error) {
+    console.warn(
+      `[worktree-symlinks] Failed to ignore shared-directory symlinks against git add -A:`,
+      error
+    )
+  }
 }
 
 /** Copy `.worktreeinclude`-resolved paths from the primary checkout into a


### PR DESCRIPTION
## Description
After materializing worktree shared-directory symlinks, Orca appends root-anchored exclude rules so `git add -A` no longer stages mode-120000 absolute-path blobs for paths like `node_modules`.

## Focused fix
- In scope: common-dir `info/exclude` ensure for symlink shared paths; unit + real-Git hermetic regression
- Out of scope: replacing #10459 UI filters (complementary residual for raw terminal git)

## Preserves
- Worktree create still succeeds if exclude write fails (warn-only)
- Real directories (non-symlinks) are not unnecessarily exclude-written
- Git 2.25-compatible (filesystem + standard worktree layout only)

## Evidence
- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktree-symlink-git-exclude.test.ts src/main/ipc/worktree-symlinks.test.ts` → 44 passed (incl. git add -A does not stage symlink)

## User-regression-tradeoffs
- Exclude is repo common-dir scoped (Git limitation for linked worktrees) — shared path names become ignored repo-wide

Fixes #11077