### PR TITLE
fix(terminal): honor key-binding remaps of the Korean ₩ key

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-native-text-candidates.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-native-text-candidates.ts
@@ -41,6 +41,9 @@ const CJK_DIRECT_PUNCTUATION_KEYS = new Set<string>([
   '『',
   '』',
   '￥',
+  // Korean sources put ₩ on Backquote; its committed text can differ from
+  // `key` when DefaultKeyBinding.dict rewrites it (typically back to `).
+  '₩',
   '～',
   '·',
   '…'

--- a/src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.test.ts
@@ -68,6 +68,18 @@ describe('isImeNativeTextKeydownCandidate', () => {
     ).toBe(true)
   })
 
+  // Why: macOS Korean sources emit ₩ from Backquote, and a DefaultKeyBinding.dict
+  // entry can rewrite it to ` — but only in the keypress/input events.
+  it('accepts the Korean won-sign key even when the input source probe is stale', () => {
+    expect(
+      isImeNativeTextKeydownCandidate(
+        keyEvent({ key: '₩', code: 'Backquote', keyCode: 192 }),
+        false,
+        DISABLED_FEATURES
+      )
+    ).toBe(true)
+  })
+
   it('accepts Vietnamese short replacement keys without enabling punctuation', () => {
     expect(
       isImeNativeTextKeydownCandidate(
@@ -262,6 +274,40 @@ describe('installTerminalImeNativeTextForwarder', () => {
     dispatchInsertText(textarea, '。')
 
     expect(sendInput).toHaveBeenCalledExactlyOnceWith('。')
+  })
+
+  it('forwards the key binding substitution for the Korean won-sign key', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImeNativeTextForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput,
+      getInputSourceFeatures: () => CJK_FEATURES
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: '₩', code: 'Backquote', keyCode: 192 }))).toBe(
+      true
+    )
+    dispatchInsertText(textarea, '`')
+
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith('`')
+  })
+
+  it('forwards the won sign unchanged when no key binding remaps it', () => {
+    const sendInput = vi.fn()
+    const forwarder = installTerminalImeNativeTextForwarder({
+      terminalElement: element,
+      isComposing: () => false,
+      sendInput,
+      getInputSourceFeatures: () => CJK_FEATURES
+    })
+
+    expect(forwarder.claimKeyEvent(keyEvent({ key: '₩', code: 'Backquote', keyCode: 192 }))).toBe(
+      true
+    )
+    dispatchInsertText(textarea, '₩')
+
+    expect(sendInput).toHaveBeenCalledExactlyOnceWith('₩')
   })
 
   it('forwards a plain ASCII symbol unchanged when the IME does not convert it', () => {


### PR DESCRIPTION
## Summary

Fixes #11170.

macOS Korean input sources put `₩` (U+20A9) on the Backquote key, so a backtick is unreachable without switching input source. The standard workaround is a `~/Library/KeyBindings/DefaultKeyBinding.dict` remap:

```json
{ "₩" = ("insertText:", "`"); }
```

That remap works in every other app — including Orca's own text inputs — but not in the Orca terminal, which sends the raw `₩` to the PTY.

**Why:** AppKit applies the substitution in the text input path, and Chromium surfaces the result only on the keypress/input events. Probe capture with a Korean input source active:

```
keydown   key="₩" U+20A9  code=Backquote  keyCode=192  isComposing=false
keypress  key="₩" U+20A9  charCode=96          <- 96 = `
input     data="`" U+0060 inputType=insertText <- committed text
```

xterm derives the PTY payload from `keydown.key` and calls `preventDefault()`, which makes Chromium suppress the following Char event — so the keypress and input carrying `` ` `` never fire and only the raw layout character survives.

`₩` fell through all three existing guards: `CJK_DIRECT_PUNCTUATION_KEYS` carries `￥` (U+FFE5) but not `₩` (U+20A9); the non-ASCII bypass in `xterm-bypass-policy.ts` is scoped to `event.shiftKey`; and `terminal-jis-yen-input.ts` is scoped to `code === 'IntlYen'` behind an opt-in setting.

**Change:** add `₩` to `CJK_DIRECT_PUNCTUATION_KEYS` so `installTerminalImeNativeTextForwarder` claims the keydown, routes it around xterm, and forwards the committed glyph from the `input` event — the mechanism this file already provides for "committed text differs from `keydown.key`". Users without the dict are unaffected: the forwarder passes through whatever text actually commits, which is `₩`.

Considered and rejected: dropping the `shiftKey` condition from the non-ASCII bypass. It would cover any dict-remapped non-ASCII key, but it changes the code path for every keystroke on all non-Latin layouts (Cyrillic, Greek, Thai, …) and silently drops keys that emit no keypress. Too broad for this defect.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Three regression tests in `terminal-ime-native-text-forwarder.test.ts`, written failing first and confirmed failing before the fix:

1. `₩` keydown is a native-text candidate even when the input-source probe is stale.
2. The dict substitution (`` ` ``) is forwarded from the input event.
3. **`₩` is forwarded unchanged when no dict remap exists** — pins the behavior for users who do not remap.

`terminal-pane` suite: 193 files / 2522 tests pass. Full suite: 8 files / 43 tests fail, all pre-existing — verified identical failure counts on `upstream/main` without this change (`window.localStorage` is not implemented under Node 25.x, plus one flaky timing assertion). `oxlint` findings on this machine came only from untracked local worktree copies under `.orca/` and `.claude/`; scoped to `src config tests mobile` it is clean.

## AI Review Report

Reviewed with systematic root-cause debugging rather than symptom patching: captured real key-event evidence before proposing a fix, confirmed the xterm payload rule in the shipped bundle (`keyCode >= 48 && key.length === 1 → result.key = ev.key`), and verified `_keyPress` reads `e.charCode` and stays reachable because `_keyDownHandled` remains false when a custom handler bypasses the keydown.

Risks checked:

- **Blast radius.** `isImeNativeTextKeydownCandidate` has exactly one consumer, `terminal-ime-native-text-forwarder.ts`, which `use-terminal-pane-lifecycle.ts` installs only when `isMac`; on Windows and Linux `claimKeyEvent` is a constant `false`, so this is a no-op there. No shortcut, accelerator, label, or path handling is touched, and nothing here assumes local execution, so SSH sessions and folder workspaces behave identically.
- **Regression for non-remapping users.** Covered by test 3 above: the forwarder sends the actual committed text, so an unremapped `₩` still arrives as `₩`.
- **Modifier chords.** Unchanged — `isImeNativeTextKeydownCandidate` still rejects Ctrl/Alt/Meta, so `Option+₩` continues to fall through to `terminalMacOptionAsAlt` as before.
- **Composition safety.** Unchanged — composing keystrokes and active compositions are still rejected before the candidate check, so Hangul composition is untouched.
- **Dropped input.** If no `input` event followed a claimed keydown the glyph would be lost; the existing 100 ms disarm timer and keyup handling already cover that, and the probe shows the input event always fires for this key.

## Security Audit

No new IPC, command execution, path handling, auth, secrets, or dependency surface. The only data flow added is an existing one widened by one character: text from a focused terminal element's `InputEvent.data` is passed to `pane.terminal.input()` — the same path every typed character already takes, subject to the same PTY input guards. Input is a single committed glyph from the OS text input system, not attacker-controlled content, and it is neither parsed nor interpolated into a command. No follow-up needed.

## Notes

- macOS-only in effect, though the constant is platform-neutral.
- Reproduces only while a Korean input source is active; with ABC selected `keydown.key` is already `` ` ``.
- Likely affects any xterm.js-based terminal, so this is less an Orca-specific defect than a gap in guards Orca already ships.
- Out of scope: the companion `"~₩" = ("insertText:", "₩")` dict rule (Option + the key). Modifier chords are deliberately excluded from the native-text claim, and `terminalMacOptionAsAlt` consumes Option first. Left unchanged rather than widening the claim to modifier chords.
