### PR TITLE
fix(editor): watch folder workspaces for external file changes

### DIFF
--- a/src/renderer/src/hooks/useEditorExternalWatch-self-move.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-self-move.test.ts
@@ -30,8 +30,8 @@ import { getDiskBaselineSignature } from '@/components/editor/diff-content-signa
 
 const findTarget = (worktreePath: string, runtimeEnvironmentId: string | null = null) =>
   worktreePath === '/repo'
-    ? { worktreeId: 'wt-1', worktreePath: '/repo', connectionId: undefined, runtimeEnvironmentId }
-    : undefined
+    ? [{ worktreeId: 'wt-1', worktreePath: '/repo', connectionId: undefined, runtimeEnvironmentId }]
+    : []
 
 function payload(events: FsChangedPayload['events']): FsChangedPayload {
   return { worktreePath: '/repo', events }

--- a/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
@@ -469,6 +469,35 @@ describe('getEditorExternalWatchTargets', () => {
     ).toEqual([])
   })
 
+  it('returns the identical snapshot when folderWorkspaces is reallocated but equivalent', () => {
+    const repo = makeRepo('repo-folder-stable')
+    const worktree = makeWorktree(repo.id, 'wt-folder-stable')
+    const openFiles = [{ ...makeOpenFile('folder:fw-stable'), id: 'stable-file' }]
+    const projectGroups = [makeProjectGroup('group-1')]
+
+    const first = getEditorExternalWatchTargets(
+      makeState({
+        repo,
+        worktree,
+        openFiles,
+        folderWorkspaces: [makeFolderWorkspace('fw-stable', '/folders/stable')],
+        projectGroups
+      })
+    )
+    // Why: a fresh-but-equivalent array must not churn the snapshot, or the [targetsKey] effect re-runs and thrashes watch/unwatch IPC.
+    const second = getEditorExternalWatchTargets(
+      makeState({
+        repo,
+        worktree,
+        openFiles,
+        folderWorkspaces: [makeFolderWorkspace('fw-stable', '/folders/stable')],
+        projectGroups: [makeProjectGroup('group-1')]
+      })
+    )
+
+    expect(second).toBe(first)
+  })
+
   it('recomputes targets when folderWorkspaces changes identity', () => {
     const repo = makeRepo('repo-folder-memo')
     const worktree = makeWorktree(repo.id, 'wt-folder-memo')

--- a/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
@@ -63,10 +63,14 @@ describe('getEditorExternalWatchTargets', () => {
     rightSidebarExplorerView?: EditorExternalWatchTargetState['rightSidebarExplorerView']
     gitStatusHugeByWorktree?: EditorExternalWatchTargetState['gitStatusHugeByWorktree']
     sshConnectionStates?: EditorExternalWatchTargetState['sshConnectionStates']
+    folderWorkspaces?: EditorExternalWatchTargetState['folderWorkspaces']
+    projectGroups?: EditorExternalWatchTargetState['projectGroups']
   }): EditorExternalWatchTargetState => ({
     openFiles: args.openFiles ?? [],
     worktreesByRepo: { [args.repo.id]: [args.worktree] },
     repos: [args.repo],
+    folderWorkspaces: args.folderWorkspaces ?? [],
+    projectGroups: args.projectGroups ?? [],
     activeWorktreeId: args.activeWorktreeId ?? null,
     rightSidebarOpen: args.rightSidebarOpen ?? false,
     rightSidebarTab: args.rightSidebarTab ?? 'explorer',
@@ -336,6 +340,161 @@ describe('getEditorExternalWatchTargets', () => {
         worktreePath: '/repo-restored/worktree',
         connectionId: undefined,
         runtimeEnvironmentId: 'env-1'
+      }
+    ])
+  })
+
+  const makeFolderWorkspace = (
+    id: string,
+    folderPath: string,
+    projectGroupId = 'group-1',
+    connectionId: string | null = null
+  ): EditorExternalWatchTargetState['folderWorkspaces'][number] =>
+    ({
+      id,
+      projectGroupId,
+      name: id,
+      folderPath,
+      connectionId
+    }) as EditorExternalWatchTargetState['folderWorkspaces'][number]
+
+  const makeProjectGroup = (
+    id: string,
+    connectionId: string | null = null
+  ): EditorExternalWatchTargetState['projectGroups'][number] =>
+    ({ id, name: id, connectionId }) as EditorExternalWatchTargetState['projectGroups'][number]
+
+  it('watches a folder workspace opened from the editor even though it is not in worktreesByRepo', () => {
+    const repo = makeRepo('repo-folder-open')
+    const worktree = makeWorktree(repo.id, 'wt-folder-open')
+    const folderWorkspace = makeFolderWorkspace('fw-1', '/folders/proj')
+    const openFile = {
+      ...makeOpenFile('folder:fw-1'),
+      id: 'folder-file'
+    }
+
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({
+          repo,
+          worktree,
+          openFiles: [openFile],
+          folderWorkspaces: [folderWorkspace],
+          projectGroups: [makeProjectGroup('group-1')]
+        })
+      ).targets
+    ).toEqual([
+      {
+        worktreeId: 'folder:fw-1',
+        worktreePath: '/folders/proj',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  it('watches the active folder workspace for the Explorer sidebar', () => {
+    const repo = makeRepo('repo-folder-sidebar')
+    const worktree = makeWorktree(repo.id, 'wt-folder-sidebar')
+    const folderWorkspace = makeFolderWorkspace('fw-2', '/folders/sidebar-proj')
+
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({
+          repo,
+          worktree,
+          activeWorktreeId: 'folder:fw-2',
+          rightSidebarOpen: true,
+          rightSidebarTab: 'explorer',
+          rightSidebarExplorerView: 'files',
+          folderWorkspaces: [folderWorkspace],
+          projectGroups: [makeProjectGroup('group-1')]
+        })
+      ).targets
+    ).toEqual([
+      {
+        worktreeId: 'folder:fw-2',
+        worktreePath: '/folders/sidebar-proj',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  it('routes a remote folder workspace through its own connection, falling back to the group', () => {
+    const repo = makeRepo('repo-folder-remote')
+    const worktree = makeWorktree(repo.id, 'wt-folder-remote')
+
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({
+          repo,
+          worktree,
+          openFiles: [{ ...makeOpenFile('folder:fw-own'), id: 'own-conn-file' }],
+          folderWorkspaces: [makeFolderWorkspace('fw-own', '/folders/own', 'group-1', 'ssh-own')],
+          projectGroups: [makeProjectGroup('group-1', 'ssh-group')]
+        })
+      ).targets[0]?.connectionId
+    ).toBe('ssh-own')
+
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({
+          repo,
+          worktree,
+          openFiles: [{ ...makeOpenFile('folder:fw-inherit'), id: 'inherit-conn-file' }],
+          folderWorkspaces: [
+            makeFolderWorkspace('fw-inherit', '/folders/inherit', 'group-1', null)
+          ],
+          projectGroups: [makeProjectGroup('group-1', 'ssh-group')]
+        })
+      ).targets[0]?.connectionId
+    ).toBe('ssh-group')
+  })
+
+  it('drops a folder-workspace target whose workspace is no longer known', () => {
+    const repo = makeRepo('repo-folder-missing')
+    const worktree = makeWorktree(repo.id, 'wt-folder-missing')
+
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({
+          repo,
+          worktree,
+          openFiles: [{ ...makeOpenFile('folder:fw-gone'), id: 'gone-file' }],
+          folderWorkspaces: [],
+          projectGroups: [makeProjectGroup('group-1')]
+        })
+      ).targets
+    ).toEqual([])
+  })
+
+  it('recomputes targets when folderWorkspaces changes identity', () => {
+    const repo = makeRepo('repo-folder-memo')
+    const worktree = makeWorktree(repo.id, 'wt-folder-memo')
+    const openFiles = [{ ...makeOpenFile('folder:fw-memo'), id: 'memo-file' }]
+    const projectGroups = [makeProjectGroup('group-1')]
+
+    const before = getEditorExternalWatchTargets(
+      makeState({ repo, worktree, openFiles, folderWorkspaces: [], projectGroups })
+    )
+    expect(before.targets).toEqual([])
+
+    const after = getEditorExternalWatchTargets(
+      makeState({
+        repo,
+        worktree,
+        openFiles,
+        folderWorkspaces: [makeFolderWorkspace('fw-memo', '/folders/memo')],
+        projectGroups
+      })
+    )
+    expect(after.targets).toEqual([
+      {
+        worktreeId: 'folder:fw-memo',
+        worktreePath: '/folders/memo',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
       }
     ])
   })

--- a/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch-targets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   getEditorExternalWatchTargets,
+  sharesLocalWatchRoot,
   type EditorExternalWatchTargetState
 } from './useEditorExternalWatch'
 
@@ -15,6 +16,13 @@ vi.mock('@/components/editor/editor-autosave', () => ({
 }))
 
 describe('getEditorExternalWatchTargets', () => {
+  // Why: the memo guard compares identities, so shared defaults must be stable across calls or every guard conjunct is untestable.
+  const EMPTY_GIT_STATUS_HUGE: EditorExternalWatchTargetState['gitStatusHugeByWorktree'] = {}
+  const EMPTY_SSH_STATES: EditorExternalWatchTargetState['sshConnectionStates'] = new Map()
+  const EMPTY_RESTORED_HOST_IDS: EditorExternalWatchTargetState['restoredRuntimeHostIdByWorkspaceSessionKey'] =
+    {}
+  const EMPTY_RUNTIME_ENVS: EditorExternalWatchTargetState['runtimeEnvironments'] = []
+
   const makeRepo = (
     id: string,
     connectionId: string | null = null,
@@ -65,18 +73,23 @@ describe('getEditorExternalWatchTargets', () => {
     sshConnectionStates?: EditorExternalWatchTargetState['sshConnectionStates']
     folderWorkspaces?: EditorExternalWatchTargetState['folderWorkspaces']
     projectGroups?: EditorExternalWatchTargetState['projectGroups']
+    worktreesByRepo?: EditorExternalWatchTargetState['worktreesByRepo']
+    repos?: EditorExternalWatchTargetState['repos']
   }): EditorExternalWatchTargetState => ({
     openFiles: args.openFiles ?? [],
-    worktreesByRepo: { [args.repo.id]: [args.worktree] },
-    repos: [args.repo],
+    // Why: callers can pass stable identities; the default literals otherwise miss the memo guard on every call, making guard conjuncts untestable.
+    worktreesByRepo: args.worktreesByRepo ?? { [args.repo.id]: [args.worktree] },
+    repos: args.repos ?? [args.repo],
     folderWorkspaces: args.folderWorkspaces ?? [],
     projectGroups: args.projectGroups ?? [],
     activeWorktreeId: args.activeWorktreeId ?? null,
     rightSidebarOpen: args.rightSidebarOpen ?? false,
     rightSidebarTab: args.rightSidebarTab ?? 'explorer',
     rightSidebarExplorerView: args.rightSidebarExplorerView ?? 'files',
-    gitStatusHugeByWorktree: args.gitStatusHugeByWorktree ?? {},
-    sshConnectionStates: args.sshConnectionStates ?? new Map(),
+    gitStatusHugeByWorktree: args.gitStatusHugeByWorktree ?? EMPTY_GIT_STATUS_HUGE,
+    sshConnectionStates: args.sshConnectionStates ?? EMPTY_SSH_STATES,
+    restoredRuntimeHostIdByWorkspaceSessionKey: EMPTY_RESTORED_HOST_IDS,
+    runtimeEnvironments: EMPTY_RUNTIME_ENVS,
     settings:
       args.runtimeEnvironmentId === undefined
         ? null
@@ -452,21 +465,109 @@ describe('getEditorExternalWatchTargets', () => {
     ).toBe('ssh-group')
   })
 
-  it('drops a folder-workspace target whose workspace is no longer known', () => {
+  it('drops only the unknown folder workspace and still emits the known one', () => {
     const repo = makeRepo('repo-folder-missing')
     const worktree = makeWorktree(repo.id, 'wt-folder-missing')
+
+    // Why: asserting [] alone passes even with the folder branch deleted; pairing a known workspace with an unknown one makes the assertion mutation-sensitive.
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({
+          repo,
+          worktree,
+          openFiles: [
+            { ...makeOpenFile('folder:fw-known'), id: 'known-file' },
+            { ...makeOpenFile('folder:fw-gone'), id: 'gone-file' }
+          ],
+          folderWorkspaces: [makeFolderWorkspace('fw-known', '/folders/known')],
+          projectGroups: [makeProjectGroup('group-1')]
+        })
+      ).targets
+    ).toEqual([
+      {
+        worktreeId: 'folder:fw-known',
+        worktreePath: '/folders/known',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  it('emits a folder workspace and a git worktree together, sorted by worktree id', () => {
+    const repo = makeRepo('repo-coexist')
+    const worktree = makeWorktree(repo.id, 'wt-coexist')
 
     expect(
       getEditorExternalWatchTargets(
         makeState({
           repo,
           worktree,
-          openFiles: [{ ...makeOpenFile('folder:fw-gone'), id: 'gone-file' }],
-          folderWorkspaces: [],
+          openFiles: [
+            { ...makeOpenFile(worktree.id), id: 'git-file' },
+            { ...makeOpenFile('folder:fw-coexist'), id: 'folder-file' }
+          ],
+          folderWorkspaces: [makeFolderWorkspace('fw-coexist', '/folders/coexist')],
           projectGroups: [makeProjectGroup('group-1')]
         })
       ).targets
-    ).toEqual([])
+    ).toEqual([
+      {
+        worktreeId: 'folder:fw-coexist',
+        worktreePath: '/folders/coexist',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      },
+      {
+        worktreeId: 'wt-coexist',
+        worktreePath: '/repo-coexist/worktree',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  it('reuses the cached snapshot only while every guarded input keeps its identity', () => {
+    const repo = makeRepo('repo-guard')
+    const worktree = makeWorktree(repo.id, 'wt-guard')
+    // Why: identities are hoisted so the guard can actually be reached; rebuilding them per call misses it every time and leaves every conjunct untested.
+    const worktreesByRepo = { [repo.id]: [worktree] }
+    const repos = [repo]
+    const openFiles = [{ ...makeOpenFile('folder:fw-guard'), id: 'guard-file' }]
+    const folderWorkspaces = [makeFolderWorkspace('fw-guard', '/folders/guard')]
+    const projectGroups = [makeProjectGroup('group-1')]
+    const shared = { repo, worktree, worktreesByRepo, repos, openFiles, projectGroups }
+
+    const first = getEditorExternalWatchTargets(makeState({ ...shared, folderWorkspaces }))
+    expect(first.targets).toEqual([
+      {
+        worktreeId: 'folder:fw-guard',
+        worktreePath: '/folders/guard',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+
+    // Same identities everywhere: the guard must short-circuit.
+    expect(getEditorExternalWatchTargets(makeState({ ...shared, folderWorkspaces }))).toBe(first)
+
+    // folderWorkspaces identity changes to a workspace at a NEW path: the guard must NOT short-circuit.
+    const moved = getEditorExternalWatchTargets(
+      makeState({
+        ...shared,
+        folderWorkspaces: [makeFolderWorkspace('fw-guard', '/folders/moved')]
+      })
+    )
+    expect(moved.targets[0]?.worktreePath).toBe('/folders/moved')
+
+    // projectGroups identity changes in a way that changes the resolved connection: the guard must NOT short-circuit.
+    const rerouted = getEditorExternalWatchTargets(
+      makeState({
+        ...shared,
+        folderWorkspaces: [makeFolderWorkspace('fw-guard', '/folders/moved', 'group-1', null)],
+        projectGroups: [makeProjectGroup('group-1', 'ssh-rerouted')]
+      })
+    )
+    expect(rerouted.targets[0]?.connectionId).toBe('ssh-rerouted')
   })
 
   it('returns the identical snapshot when folderWorkspaces is reallocated but equivalent', () => {
@@ -526,5 +627,90 @@ describe('getEditorExternalWatchTargets', () => {
         runtimeEnvironmentId: null
       }
     ])
+  })
+
+  it('emits both folder workspaces that share one folder path (the default in a folder-backed group)', () => {
+    const repo = makeRepo('repo-shared-path')
+    const worktree = makeWorktree(repo.id, 'wt-shared-path')
+
+    // Why: createFolderWorkspace defaults folderPath to the group's parentPath and enforces no uniqueness, so siblings in one group normally share a path.
+    expect(
+      getEditorExternalWatchTargets(
+        makeState({
+          repo,
+          worktree,
+          openFiles: [
+            { ...makeOpenFile('folder:fw-a'), id: 'a-file' },
+            { ...makeOpenFile('folder:fw-b'), id: 'b-file' }
+          ],
+          folderWorkspaces: [
+            makeFolderWorkspace('fw-a', '/group/parent'),
+            makeFolderWorkspace('fw-b', '/group/parent')
+          ],
+          projectGroups: [makeProjectGroup('group-1')]
+        })
+      ).targets
+    ).toEqual([
+      {
+        worktreeId: 'folder:fw-a',
+        worktreePath: '/group/parent',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      },
+      {
+        worktreeId: 'folder:fw-b',
+        worktreePath: '/group/parent',
+        connectionId: undefined,
+        runtimeEnvironmentId: null
+      }
+    ])
+  })
+
+  describe('sharesLocalWatchRoot', () => {
+    const target = (
+      worktreeId: string,
+      worktreePath: string,
+      connectionId?: string,
+      runtimeEnvironmentId: string | null = null
+    ): Parameters<typeof sharesLocalWatchRoot>[0] => ({
+      worktreeId,
+      worktreePath,
+      connectionId,
+      runtimeEnvironmentId
+    })
+
+    it('treats sibling folder workspaces on one path as one local watch root', () => {
+      expect(
+        sharesLocalWatchRoot(
+          target('folder:a', '/group/parent'),
+          target('folder:b', '/group/parent')
+        )
+      ).toBe(true)
+    })
+
+    it('treats a folder workspace colliding with a git worktree path as one local watch root', () => {
+      expect(
+        sharesLocalWatchRoot(target('folder:c', '/repo-1/wt'), target('wt-1', '/repo-1/wt'))
+      ).toBe(true)
+    })
+
+    it('does not merge different paths, different connections, or runtime-owned targets', () => {
+      expect(sharesLocalWatchRoot(target('folder:a', '/one'), target('folder:b', '/two'))).toBe(
+        false
+      )
+      expect(
+        sharesLocalWatchRoot(
+          target('folder:a', '/same', 'ssh-1'),
+          target('folder:b', '/same', undefined)
+        )
+      ).toBe(false)
+      // Runtime-owned targets unsubscribe through their own handle, not the path-keyed local watcher.
+      expect(
+        sharesLocalWatchRoot(
+          target('folder:a', '/same', undefined, 'env-1'),
+          target('folder:b', '/same', undefined, 'env-1')
+        )
+      ).toBe(false)
+    })
   })
 })

--- a/src/renderer/src/hooks/useEditorExternalWatch.test.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.test.ts
@@ -186,22 +186,22 @@ describe('createExternalWatchEventHandler tombstone coalescing', () => {
   const findTarget = (
     worktreePath: string,
     runtimeEnvironmentId: string | null = null
-  ):
-    | {
-        worktreeId: string
-        worktreePath: string
-        connectionId: string | undefined
-        runtimeEnvironmentId: string | null
-      }
-    | undefined =>
+  ): {
+    worktreeId: string
+    worktreePath: string
+    connectionId: string | undefined
+    runtimeEnvironmentId: string | null
+  }[] =>
     worktreePath === '/repo'
-      ? {
-          worktreeId: 'wt-1',
-          worktreePath: '/repo',
-          connectionId: undefined,
-          runtimeEnvironmentId
-        }
-      : undefined
+      ? [
+          {
+            worktreeId: 'wt-1',
+            worktreePath: '/repo',
+            connectionId: undefined,
+            runtimeEnvironmentId
+          }
+        ]
+      : []
 
   const fileNotes = {
     id: 'file-notes',
@@ -294,12 +294,14 @@ describe('createExternalWatchEventHandler tombstone coalescing', () => {
       setExternalMutation
     } as never)
     vi.mocked(getOpenFilesForExternalFileChange).mockReturnValue([file] as never)
-    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => ({
-      worktreeId: 'wt-win',
-      worktreePath: 'C:\\Repo',
-      connectionId: undefined,
-      runtimeEnvironmentId: 'env-1'
-    }))
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => [
+      {
+        worktreeId: 'wt-win',
+        worktreePath: 'C:\\Repo',
+        connectionId: undefined,
+        runtimeEnvironmentId: 'env-1'
+      }
+    ])
 
     handleFsChanged({
       worktreePath: 'c:\\repo',
@@ -331,12 +333,14 @@ describe('createExternalWatchEventHandler tombstone coalescing', () => {
       setExternalMutation
     } as never)
     vi.mocked(getOpenFilesForExternalFileChange).mockReturnValue([file] as never)
-    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => ({
-      worktreeId: 'wt-unc',
-      worktreePath: '//Server/Share/Repo',
-      connectionId: undefined,
-      runtimeEnvironmentId: 'env-1'
-    }))
+    const { handleFsChanged, dispose } = createExternalWatchEventHandler(() => [
+      {
+        worktreeId: 'wt-unc',
+        worktreePath: '//Server/Share/Repo',
+        connectionId: undefined,
+        runtimeEnvironmentId: 'env-1'
+      }
+    ])
 
     handleFsChanged({
       worktreePath: '//server/share/repo',

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -98,6 +98,8 @@ export type EditorExternalWatchTargetState = Pick<
   | 'sshConnectionStates'
   | 'folderWorkspaces'
   | 'projectGroups'
+  | 'restoredRuntimeHostIdByWorkspaceSessionKey'
+  | 'runtimeEnvironments'
 >
 
 let cachedOpenFiles: AppState['openFiles'] | null = null
@@ -112,7 +114,21 @@ let cachedGitStatusHugeByWorktree: AppState['gitStatusHugeByWorktree'] | null = 
 let cachedSshConnectionStates: AppState['sshConnectionStates'] | null = null
 let cachedFolderWorkspaces: AppState['folderWorkspaces'] | null = null
 let cachedProjectGroups: AppState['projectGroups'] | null = null
+let cachedRestoredRuntimeHostIds: AppState['restoredRuntimeHostIdByWorkspaceSessionKey'] | null =
+  null
+let cachedRuntimeEnvironments: AppState['runtimeEnvironments'] | null = null
 let cachedWatchedTargetsSnapshot: WatchedTargetsSnapshot = { targets: [], targetsKey: '' }
+
+// Why: main keys local watchers by path alone (one listener entry per renderer, not a refcount), so two targets on the same root share one subscription.
+export function sharesLocalWatchRoot(left: WatchedTarget, right: WatchedTarget): boolean {
+  return (
+    !left.runtimeEnvironmentId &&
+    !right.runtimeEnvironmentId &&
+    left.connectionId === right.connectionId &&
+    normalizeRuntimePathForComparison(left.worktreePath) ===
+      normalizeRuntimePathForComparison(right.worktreePath)
+  )
+}
 
 export function getWatchedTargetKey(target: WatchedTarget): string {
   // Why: include connectionId so a local placeholder watch is replaced by the real SSH watch once an SSH worktree's provider metadata hydrates.
@@ -169,7 +185,9 @@ export function getEditorExternalWatchTargets(
     cachedGitStatusHugeByWorktree === state.gitStatusHugeByWorktree &&
     cachedSshConnectionStates === state.sshConnectionStates &&
     cachedFolderWorkspaces === state.folderWorkspaces &&
-    cachedProjectGroups === state.projectGroups
+    cachedProjectGroups === state.projectGroups &&
+    cachedRestoredRuntimeHostIds === state.restoredRuntimeHostIdByWorkspaceSessionKey &&
+    cachedRuntimeEnvironments === state.runtimeEnvironments
   ) {
     return cachedWatchedTargetsSnapshot
   }
@@ -251,6 +269,8 @@ export function getEditorExternalWatchTargets(
   cachedSshConnectionStates = state.sshConnectionStates
   cachedFolderWorkspaces = state.folderWorkspaces
   cachedProjectGroups = state.projectGroups
+  cachedRestoredRuntimeHostIds = state.restoredRuntimeHostIdByWorkspaceSessionKey
+  cachedRuntimeEnvironments = state.runtimeEnvironments
 
   if (targetsKey === cachedWatchedTargetsSnapshot.targetsKey) {
     return cachedWatchedTargetsSnapshot
@@ -301,7 +321,8 @@ export function useEditorExternalWatch(): void {
       if (remoteUnsubscribe) {
         remoteUnsubscribe()
         remoteWatchUnsubsRef.current.delete(key)
-      } else {
+      } else if (!nextTargets.some((t) => sharesLocalWatchRoot(t, target))) {
+        // Why: the local watcher is keyed by path with no per-target refcount, so unwatching a removed target would kill delivery for a surviving target on the same root.
         void window.api.fs.unwatchWorktree({
           worktreePath: target.worktreePath,
           connectionId: target.connectionId
@@ -364,7 +385,7 @@ export function useEditorExternalWatch(): void {
     const remoteWatchUnsubs = remoteWatchUnsubsRef.current
     const { handleFsChanged, dispose } = createExternalWatchEventHandler(
       (worktreePath, runtimeEnvironmentId) =>
-        targetsRef.current.find(
+        targetsRef.current.filter(
           (t) =>
             normalizeRuntimePathForComparison(t.worktreePath) ===
               normalizeRuntimePathForComparison(worktreePath) &&
@@ -404,10 +425,7 @@ export function useEditorExternalWatch(): void {
  * without mounting the hook.
  */
 export function createExternalWatchEventHandler(
-  findTarget: (
-    worktreePath: string,
-    runtimeEnvironmentId: string | null
-  ) => WatchedTarget | undefined
+  findTargets: (worktreePath: string, runtimeEnvironmentId: string | null) => WatchedTarget[]
 ): {
   handleFsChanged: (payload: FsChangedPayload, runtimeEnvironmentId?: string | null) => void
   dispose: () => void
@@ -424,10 +442,13 @@ export function createExternalWatchEventHandler(
     payload: FsChangedPayload,
     runtimeEnvironmentId: string | null = null
   ): void => {
-    const target = findTarget(payload.worktreePath, runtimeEnvironmentId)
-    if (!target) {
-      return
+    // Why: folder workspaces can share a path with each other or with a git worktree, so one payload may own several targets; dispatching only the first silently stops reloading the others' tabs.
+    for (const target of findTargets(payload.worktreePath, runtimeEnvironmentId)) {
+      dispatchToTarget(payload, target)
     }
+  }
+
+  const dispatchToTarget = (payload: FsChangedPayload, target: WatchedTarget): void => {
     // Why: this app-level hook owns watcher subscriptions; other consumers listen here so they don't fight over watch/unwatch ownership.
     if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
       window.dispatchEvent(

--- a/src/renderer/src/hooks/useEditorExternalWatch.ts
+++ b/src/renderer/src/hooks/useEditorExternalWatch.ts
@@ -22,6 +22,7 @@ import {
 } from '@/components/editor/editor-path-move-inflight'
 import type { FsChangedPayload } from '../../../shared/types'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import type { OpenFile } from '@/store/slices/editor'
 import { readRuntimeFileContent, subscribeRuntimeFileChanges } from '@/runtime/runtime-file-client'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -95,6 +96,8 @@ export type EditorExternalWatchTargetState = Pick<
   | 'rightSidebarExplorerView'
   | 'gitStatusHugeByWorktree'
   | 'sshConnectionStates'
+  | 'folderWorkspaces'
+  | 'projectGroups'
 >
 
 let cachedOpenFiles: AppState['openFiles'] | null = null
@@ -107,6 +110,8 @@ let cachedRightSidebarTab: AppState['rightSidebarTab'] | null = null
 let cachedRightSidebarExplorerView: AppState['rightSidebarExplorerView'] | null = null
 let cachedGitStatusHugeByWorktree: AppState['gitStatusHugeByWorktree'] | null = null
 let cachedSshConnectionStates: AppState['sshConnectionStates'] | null = null
+let cachedFolderWorkspaces: AppState['folderWorkspaces'] | null = null
+let cachedProjectGroups: AppState['projectGroups'] | null = null
 let cachedWatchedTargetsSnapshot: WatchedTargetsSnapshot = { targets: [], targetsKey: '' }
 
 export function getWatchedTargetKey(target: WatchedTarget): string {
@@ -116,6 +121,36 @@ export function getWatchedTargetKey(target: WatchedTarget): string {
 
 function openFileRuntimeOwner(file: Pick<OpenFile, 'runtimeEnvironmentId'>): string | null {
   return file.runtimeEnvironmentId?.trim() || null
+}
+
+// Why: folder workspaces live in state.folderWorkspaces, not worktreesByRepo, so a worktreesByRepo-only lookup silently drops every folder-workspace watch target (issue #7868).
+function resolveWatchLocation(
+  state: EditorExternalWatchTargetState,
+  worktreeId: string
+): { path: string; connectionId: string | undefined } | null {
+  const workspaceScope = parseWorkspaceKey(worktreeId)
+  if (workspaceScope?.type === 'folder') {
+    const folderWorkspace = state.folderWorkspaces.find(
+      (workspace) => workspace.id === workspaceScope.folderWorkspaceId
+    )
+    if (!folderWorkspace) {
+      return null
+    }
+    const projectGroup = state.projectGroups.find(
+      (group) => group.id === folderWorkspace.projectGroupId
+    )
+    return {
+      path: folderWorkspace.folderPath,
+      connectionId:
+        folderWorkspace.connectionId?.trim() || projectGroup?.connectionId?.trim() || undefined
+    }
+  }
+  const worktree = findWorktreeById(state.worktreesByRepo, worktreeId)
+  if (!worktree) {
+    return null
+  }
+  const repo = state.repos.find((r) => r.id === worktree.repoId)
+  return { path: worktree.path, connectionId: repo?.connectionId ?? undefined }
 }
 
 export function getEditorExternalWatchTargets(
@@ -132,7 +167,9 @@ export function getEditorExternalWatchTargets(
     cachedRightSidebarTab === state.rightSidebarTab &&
     cachedRightSidebarExplorerView === state.rightSidebarExplorerView &&
     cachedGitStatusHugeByWorktree === state.gitStatusHugeByWorktree &&
-    cachedSshConnectionStates === state.sshConnectionStates
+    cachedSshConnectionStates === state.sshConnectionStates &&
+    cachedFolderWorkspaces === state.folderWorkspaces &&
+    cachedProjectGroups === state.projectGroups
   ) {
     return cachedWatchedTargetsSnapshot
   }
@@ -182,19 +219,18 @@ export function getEditorExternalWatchTargets(
   const parts: string[] = []
   const sortedWorktreeIds = Array.from(targetOwnersByWorktreeId.keys()).sort()
   for (const id of sortedWorktreeIds) {
-    const wt = findWorktreeById(state.worktreesByRepo, id)
-    if (!wt) {
+    const location = resolveWatchLocation(state, id)
+    if (!location) {
       continue
     }
-    const repo = state.repos.find((r) => r.id === wt.repoId)
     const owners = Array.from(targetOwnersByWorktreeId.get(id) ?? []).sort((a, b) =>
       (a ?? '').localeCompare(b ?? '')
     )
     for (const owner of owners) {
       const target = {
         worktreeId: id,
-        worktreePath: wt.path,
-        connectionId: repo?.connectionId ?? undefined,
+        worktreePath: location.path,
+        connectionId: location.connectionId,
         runtimeEnvironmentId: owner
       }
       nextTargets.push(target)
@@ -213,6 +249,8 @@ export function getEditorExternalWatchTargets(
   cachedRightSidebarExplorerView = state.rightSidebarExplorerView
   cachedGitStatusHugeByWorktree = state.gitStatusHugeByWorktree
   cachedSshConnectionStates = state.sshConnectionStates
+  cachedFolderWorkspaces = state.folderWorkspaces
+  cachedProjectGroups = state.projectGroups
 
   if (targetsKey === cachedWatchedTargetsSnapshot.targetsKey) {
     return cachedWatchedTargetsSnapshot

--- a/src/renderer/src/lib/execute-open-editor-path-move.test.ts
+++ b/src/renderer/src/lib/execute-open-editor-path-move.test.ts
@@ -133,13 +133,15 @@ describe('executeOpenEditorPathMove', () => {
     // The delayed destination create/update event finally arrives.
     const { handleFsChanged, dispose } = createExternalWatchEventHandler((worktreePath) =>
       worktreePath === '/repo'
-        ? {
-            worktreeId: 'wt-1',
-            worktreePath: '/repo',
-            connectionId: undefined,
-            runtimeEnvironmentId: null
-          }
-        : undefined
+        ? [
+            {
+              worktreeId: 'wt-1',
+              worktreePath: '/repo',
+              connectionId: undefined,
+              runtimeEnvironmentId: null
+            }
+          ]
+        : []
     )
     handleFsChanged({
       worktreePath: '/repo',


### PR DESCRIPTION
## What's broken

Folder workspaces get **no filesystem watcher at all**. Not a slow one — none.

`useEditorExternalWatch.ts` is the only caller of `window.api.fs.watchWorktree` in the entire renderer; everything else merely listens to `fs:changed`. Its target builder resolved each watched workspace with `findWorktreeById(state.worktreesByRepo, id)`, which scans **only** `worktreesByRepo`. Folder workspaces live in `state.folderWorkspaces` (ids shaped `folder:<uuid>`) and are never in `worktreesByRepo`, so every folder-workspace target hit `continue` — no target, no `watchWorktree` call, no watcher. Both the editor's external-reload path and the Explorer tree then stay stale until a remount.

The store's own `findKnownWorktreeById` already handles the folder case. The watch hook was using the wrong lookup.

Fixes #7868.

### Scope correction worth knowing

This is **not** "all non-git folders". A non-git folder **project** (repo `kind: 'folder'`) *is* in `worktreesByRepo` and watches correctly — I used one as a live control. Only folder **workspaces** are affected. The original report's "non-git folder workspaces" framing was broader than the actual defect.

## Fix

`resolveWatchLocation(state, worktreeId)`:
- folder-scoped ids → the workspace's `folderPath`, and a `connectionId` of `workspace.connectionId ?? group.connectionId` (the precedence already used in `folder-workspace-runtime-owner.ts`)
- everything else → delegates to the existing `findWorktreeById` path, unchanged

`folderWorkspaces` and `projectGroups` are also threaded into `EditorExternalWatchTargetState` **and** into the module-level memo guard and its writeback. That second part is load-bearing: without it the cached snapshot is returned unchanged and the fix silently no-ops on the first folder-workspace mount.

## Evidence

Live, in a real Orca dev build over CDP, with an isolated user-data profile. Rig: a folder workspace at `/tmp/orca-fwgroup/proj`, plus a non-git folder **project** at `/tmp/orca-fw-test` as a same-instance control. `window.api` is frozen, so instead of stubbing I subscribed to the real `fs:changed` bus and counted deliveries.

Five interleaved write rounds to each path, same instant, same app:

| | control (folder project) | folder workspace |
|---|---|---|
| **Before** | 5 events | **0 events** |
| **After** | — | **5 events** |

Single-file creates after the fix deliver 1 event each. Before the fix the Explorer for `proj` listed only `a.md` while 7 files existed on disk.

Tests: **23 pass** in this file, **62** across all four affected files. Mutation-verified in both directions rather than assumed —
- neutering the folder branch → the folder tests fail
- breaking the identity-preserving return → the referential-stability test fails
- reverting the memo guard to its pre-fix input set → the guard test fails (it did **not** before the test helper was given stable identities; see Reviews)

`pnpm typecheck`, oxlint, react-doctor and oxfmt all clean.

## ELI5

Orca only re-reads a file when something is *watching* the folder it lives in. It sets up those watchers by looking each workspace up in a list — but folder workspaces were never in that list, so they were skipped, and no watcher was ever created for them. The file changed on disk and nothing told the editor. Closing and reopening the tab forced a fresh read, which is why that "fixed" it.

This teaches the lookup where folder workspaces actually live, so they get a watcher like every other workspace.

## Trade-offs and known limitations

Not "none" — three, stated plainly:

1. **Large or network-mounted roots.** Folder workspaces are arbitrary user directories (`~`, Dropbox/iCloud, an SMB/NFS mount), unlike git worktrees. The ignore machinery still applies, but its list is nine well-known *code* directories, which buys nothing for those paths, and there is no size or network-mount guard. Note the asymmetry: the `gitStatusHugeByWorktree` bail-out covers neither the open-tab nor the Explorer branch, and folder workspaces are non-git so it can never fire for them. Before this change such a folder was watched by nobody; now it is watched unconditionally. That is inherent to fixing the bug, but it is a real new cost.

2. **Same-path targets now share one local watcher, handled explicitly.** Sibling folder workspaces in one group share `group.parentPath` by default, so this is the normal case rather than an exotic one. The local watcher is keyed by path with a single listener entry per renderer, so `2b2666fae7` fans the dispatch out to every match and skips `unwatchWorktree` while another target still shares the root. `sharesLocalWatchRoot` deliberately excludes runtime-owned targets, which unsubscribe through their own handle. The remaining soft spot is that there is no hook-effect test for the watch/unwatch IPC diffing anywhere in the file, so that half is pinned by unit tests on the predicate rather than end to end.

3. **Connection resolution is inlined and ignores `executionHostId`.** `resolveWatchLocation` derives the host from the workspace's own `connectionId` falling back to the group's, and does not consult `projectGroup.executionHostId` — the highest-precedence host signal elsewhere. On legacy or migrated state that can mean a local watch on a remote path, whose consequence is one `console.warn` and a degrade back to today's "no watch" behaviour. Left for a follow-up with its own verification; see Reviews.

No user-facing regression is expected for git worktrees: that branch is byte-for-byte the previous logic.

## Reviews

**Adversarial — 1 round, NOT CLEAN, findings addressed in `2b2666fae7`.** Two independent reviewers converged on the same HIGH finding, and the second one escalated it in a way that matters: the same-path collision is **the default configuration, not an edge case**. `createFolderWorkspace` defaults `folderPath` to `group.parentPath` and enforces no uniqueness, and the sidebar composer — the primary creation path — sends no `folderPath` at all. So every workspace in one folder-backed group shares a path, connection and owner. Against a path-keyed watcher with one listener entry per renderer, that meant the first commit could tear down a live sibling's watcher and dispatch events to only one of them: the STA-1519 bug, re-inflicted between siblings.

Fixed here, both halves as recommended — dispatch fans out to every path+owner match, and unwatch is skipped while another target still shares the local root.

Also fixed from that round:
- **Memo guard was incomplete**: the folder sidebar-owner lookup reads `restoredRuntimeHostIdByWorkspaceSessionKey` and `runtimeEnvironments`, neither of which was guarded. Added.
- **The guard shipped untested, provably.** A reviewer mutation reverting the guard to its pre-fix input set still passed 17/17, because the test helper rebuilt `worktreesByRepo`, `repos`, `sshConnectionStates` and `gitStatusHugeByWorktree` on every call and so missed the guard every time — no conjunct, old or new, was reachable. The helper now takes stable identities; that same mutation now fails. This is why the earlier "the guard is load-bearing" claim was not actually being verified.

Both reviewers independently cleared the git-worktree regression question (`parseWorkspaceKey` returns null for every real worktree id, so the fall-through is byte-identical) and the remote/SSH path (the runtime resolves `folder:` keys explicitly and derives its own connection, and failed subscribes warn once rather than looping).

**Still open, deliberately not fixed here** — `resolveWatchLocation` ignores `projectGroup.executionHostId`, which is the highest-precedence host signal. Both reviewers flagged it; they disagreed on the remedy (one favours resolving through the execution host, the other through `getFolderWorkspaceConnectionId`), and they agreed the consequence is one `console.warn` and a degrade back to "no watch" on legacy or migrated state. I would rather leave that to a change with its own verification than pick a side under time pressure.

**Test gaps a reviewer named that remain**: no hook-effect test exists anywhere for the watch/unwatch IPC diffing (so the teardown half is pinned only by the `sharesLocalWatchRoot` unit tests, not end to end), and runtime-owner fanout is uncovered for folder workspaces.

**Performance — SHIP WITH NOTE.** Benched rather than asserted: the new folder path costs ~10µs per target against the pre-existing git branch's ~34µs, i.e. roughly 3× cheaper than the code beside it; explicit "do not Map-ify". Guard widening is negligible — `projectGroups` writes co-occur with `repos` (already guarded) and `folderWorkspaces` churns only on PTY spawn/exit, not on terminal output or agent status ticks. Referential stability confirmed, so the `[targetsKey]` effect doesn't churn watch/unwatch IPC.

## Not fixed here

The Explorer **tree** still does not add a newly created file even though the event now arrives — `useFileExplorerWatch` gates refreshes on `parent in cache`. That is a second layer downstream of this fix and wants its own change.

I also could not verify the editor's visual reload end-to-end: the workbench errored in my rig, but that was **my rig's fault**, not a product bug — I called `openFile()` programmatically without `relativePath`, so `normalizeRelativePath` received `undefined`. So this PR is proven at the watch-subscription layer, and not proven end-to-end at the user-visible layer.
