### PR TITLE
fix(mobile): stop folder-workspace SC selector_not_found retries

### DIFF
--- a/mobile/src/source-control/mobile-folder-workspace-selector.test.ts
+++ b/mobile/src/source-control/mobile-folder-workspace-selector.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatMobileFolderAwareBranchLabel,
+  isMobileFolderWorkspaceId,
+  isMobileFolderWorkspaceUnroutedGitMethod,
+  mobileFolderWorkspaceGitRpcGuard,
+  MOBILE_FOLDER_WORKSPACE_BRANCH_LABEL,
+  MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE,
+  shouldLoadMobileBranchCompare,
+  shouldRetryMobileStatusSelectorNotFound
+} from './mobile-folder-workspace-selector'
+
+describe('isMobileFolderWorkspaceId', () => {
+  it('detects folder: synthetic worktree ids', () => {
+    expect(isMobileFolderWorkspaceId('folder:abc')).toBe(true)
+    expect(isMobileFolderWorkspaceId('folder:')).toBe(true)
+  })
+
+  it('rejects real worktree ids and other prefixes', () => {
+    expect(isMobileFolderWorkspaceId('wt-123')).toBe(false)
+    expect(isMobileFolderWorkspaceId('id:folder:abc')).toBe(false)
+    expect(isMobileFolderWorkspaceId('')).toBe(false)
+    expect(isMobileFolderWorkspaceId('Folder:abc')).toBe(false)
+  })
+})
+
+describe('shouldRetryMobileStatusSelectorNotFound', () => {
+  it('retries for real worktrees (selector may still be registering)', () => {
+    expect(shouldRetryMobileStatusSelectorNotFound('wt-123')).toBe(true)
+  })
+
+  it('does not retry for folder workspaces (structural, never resolves)', () => {
+    expect(shouldRetryMobileStatusSelectorNotFound('folder:group-1')).toBe(false)
+  })
+})
+
+describe('shouldLoadMobileBranchCompare', () => {
+  it('loads branch compare for real worktrees', () => {
+    expect(shouldLoadMobileBranchCompare('wt-123')).toBe(true)
+  })
+
+  it('skips branch compare for folder workspaces (unrouted RPC)', () => {
+    expect(shouldLoadMobileBranchCompare('folder:group-1')).toBe(false)
+  })
+})
+
+describe('mobileFolderWorkspaceGitRpcGuard', () => {
+  it('allows all methods on real worktrees', () => {
+    for (const method of [
+      'git.status',
+      'git.diff',
+      'git.branchCompare',
+      'git.history',
+      'git.fetch',
+      'git.pull',
+      'git.push',
+      'git.upstreamStatus'
+    ]) {
+      expect(mobileFolderWorkspaceGitRpcGuard('wt-123', method)).toEqual({ allowed: true })
+    }
+  })
+
+  it('allows routed folder methods (status/diff) and blocks unrouted SC ops', () => {
+    expect(mobileFolderWorkspaceGitRpcGuard('folder:g1', 'git.status')).toEqual({
+      allowed: true
+    })
+    expect(mobileFolderWorkspaceGitRpcGuard('folder:g1', 'git.diff')).toEqual({
+      allowed: true
+    })
+    for (const method of [
+      'git.branchCompare',
+      'git.upstreamStatus',
+      'git.fetch',
+      'git.pull',
+      'git.push',
+      'git.history'
+    ]) {
+      expect(isMobileFolderWorkspaceUnroutedGitMethod(method)).toBe(true)
+      expect(mobileFolderWorkspaceGitRpcGuard('folder:g1', method)).toEqual({
+        allowed: false,
+        message: MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE
+      })
+    }
+  })
+})
+
+describe('formatMobileFolderAwareBranchLabel', () => {
+  it('formats normal branch and head labels', () => {
+    expect(formatMobileFolderAwareBranchLabel('wt-1', 'refs/heads/main', 'abc')).toBe('main')
+    expect(formatMobileFolderAwareBranchLabel('wt-1', 'feature', undefined)).toBe('feature')
+    expect(formatMobileFolderAwareBranchLabel('wt-1', undefined, 'abcdef123')).toBe('abcdef1')
+  })
+
+  it('uses No branch for real worktrees without identity', () => {
+    expect(formatMobileFolderAwareBranchLabel('wt-1', undefined, undefined)).toBe('No branch')
+  })
+
+  it('labels folder workspaces without head/branch instead of blank / No branch', () => {
+    expect(formatMobileFolderAwareBranchLabel('folder:g1', undefined, undefined)).toBe(
+      MOBILE_FOLDER_WORKSPACE_BRANCH_LABEL
+    )
+  })
+
+  it('still prefers real branch/head when folder status provides them', () => {
+    expect(formatMobileFolderAwareBranchLabel('folder:g1', 'refs/heads/dev', undefined)).toBe(
+      'dev'
+    )
+  })
+})

--- a/mobile/src/source-control/mobile-folder-workspace-selector.test.ts
+++ b/mobile/src/source-control/mobile-folder-workspace-selector.test.ts
@@ -60,7 +60,7 @@ describe('mobileFolderWorkspaceGitRpcGuard', () => {
     }
   })
 
-  it('allows routed folder methods (status/diff) and blocks unrouted SC ops', () => {
+  it('allows routed folder methods (status/diff) and blocks other git.* RPCs', () => {
     expect(mobileFolderWorkspaceGitRpcGuard('folder:g1', 'git.status')).toEqual({
       allowed: true
     })
@@ -73,7 +73,10 @@ describe('mobileFolderWorkspaceGitRpcGuard', () => {
       'git.fetch',
       'git.pull',
       'git.push',
-      'git.history'
+      'git.history',
+      'git.commit',
+      'git.stage',
+      'git.unknownMethod'
     ]) {
       expect(isMobileFolderWorkspaceUnroutedGitMethod(method)).toBe(true)
       expect(mobileFolderWorkspaceGitRpcGuard('folder:g1', method)).toEqual({
@@ -81,6 +84,8 @@ describe('mobileFolderWorkspaceGitRpcGuard', () => {
         message: MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE
       })
     }
+    // Non-git RPCs are not gated by this helper.
+    expect(isMobileFolderWorkspaceUnroutedGitMethod('linear.list')).toBe(false)
   })
 })
 

--- a/mobile/src/source-control/mobile-folder-workspace-selector.ts
+++ b/mobile/src/source-control/mobile-folder-workspace-selector.ts
@@ -1,0 +1,76 @@
+// Folder workspaces use synthetic worktree ids (`folder:<id>`). git.status /
+// git.diff are routed for them (#10819); other SC git RPCs are not and always
+// throw selector_not_found. Mobile must degrade instead of retrying.
+
+export const MOBILE_FOLDER_WORKSPACE_ID_PREFIX = 'folder:'
+
+export const MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE =
+  'Not available for folder workspaces'
+
+export const MOBILE_FOLDER_WORKSPACE_BRANCH_LABEL = 'Folder workspace'
+
+// Unrouted for folder selectors today — SC must not call these (or must not
+// treat their selector_not_found as transient).
+const MOBILE_FOLDER_WORKSPACE_UNROUTED_GIT_METHODS = new Set([
+  'git.branchCompare',
+  'git.upstreamStatus',
+  'git.fetch',
+  'git.pull',
+  'git.push',
+  'git.history'
+])
+
+export function isMobileFolderWorkspaceId(worktreeId: string): boolean {
+  return worktreeId.startsWith(MOBILE_FOLDER_WORKSPACE_ID_PREFIX)
+}
+
+// Real worktrees can emit selector_not_found while still being created; folder
+// ids never resolve for unrouted methods, so retries only slow the failure.
+export function shouldRetryMobileStatusSelectorNotFound(worktreeId: string): boolean {
+  return !isMobileFolderWorkspaceId(worktreeId)
+}
+
+export function shouldLoadMobileBranchCompare(worktreeId: string): boolean {
+  return !isMobileFolderWorkspaceId(worktreeId)
+}
+
+export function isMobileFolderWorkspaceUnroutedGitMethod(method: string): boolean {
+  return MOBILE_FOLDER_WORKSPACE_UNROUTED_GIT_METHODS.has(method)
+}
+
+export function mobileFolderWorkspaceGitRpcGuard(
+  worktreeId: string,
+  method: string
+): { allowed: true } | { allowed: false; message: string } {
+  if (
+    isMobileFolderWorkspaceId(worktreeId) &&
+    isMobileFolderWorkspaceUnroutedGitMethod(method)
+  ) {
+    return { allowed: false, message: MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE }
+  }
+  return { allowed: true }
+}
+
+// Folder multi-repo status intentionally leaves branch/head unset — show a
+// workspace label instead of "No branch" / blank identity. Mirrors
+// formatBranchLabel for the non-empty cases so this file stays free of UI
+// imports (lucide) that break pure unit tests.
+export function formatMobileFolderAwareBranchLabel(
+  worktreeId: string,
+  branch: string | undefined,
+  head: string | undefined
+): string {
+  if (branch?.startsWith('refs/heads/')) {
+    return branch.slice('refs/heads/'.length)
+  }
+  if (branch) {
+    return branch
+  }
+  if (head) {
+    return head.slice(0, 7)
+  }
+  if (isMobileFolderWorkspaceId(worktreeId)) {
+    return MOBILE_FOLDER_WORKSPACE_BRANCH_LABEL
+  }
+  return 'No branch'
+}

--- a/mobile/src/source-control/mobile-folder-workspace-selector.ts
+++ b/mobile/src/source-control/mobile-folder-workspace-selector.ts
@@ -9,16 +9,9 @@ export const MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE =
 
 export const MOBILE_FOLDER_WORKSPACE_BRANCH_LABEL = 'Folder workspace'
 
-// Unrouted for folder selectors today — SC must not call these (or must not
-// treat their selector_not_found as transient).
-const MOBILE_FOLDER_WORKSPACE_UNROUTED_GIT_METHODS = new Set([
-  'git.branchCompare',
-  'git.upstreamStatus',
-  'git.fetch',
-  'git.pull',
-  'git.push',
-  'git.history'
-])
+// Only git.status / git.diff are routed for folder selectors (#10819). Any other
+// git.* RPC is structurally unrouted — denylist would miss git.commit, etc.
+const MOBILE_FOLDER_WORKSPACE_ROUTED_GIT_METHODS = new Set(['git.status', 'git.diff'])
 
 export function isMobileFolderWorkspaceId(worktreeId: string): boolean {
   return worktreeId.startsWith(MOBILE_FOLDER_WORKSPACE_ID_PREFIX)
@@ -35,7 +28,7 @@ export function shouldLoadMobileBranchCompare(worktreeId: string): boolean {
 }
 
 export function isMobileFolderWorkspaceUnroutedGitMethod(method: string): boolean {
-  return MOBILE_FOLDER_WORKSPACE_UNROUTED_GIT_METHODS.has(method)
+  return method.startsWith('git.') && !MOBILE_FOLDER_WORKSPACE_ROUTED_GIT_METHODS.has(method)
 }
 
 export function mobileFolderWorkspaceGitRpcGuard(

--- a/mobile/src/source-control/mobile-git-history.test.ts
+++ b/mobile/src/source-control/mobile-git-history.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { GitHistoryItem, GitHistoryResult } from '../../../src/shared/git-history-types'
-import { formatCommitTime, mapMobileCommitRows, toMobileCommitRow } from './mobile-git-history'
+import { MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE } from './mobile-folder-workspace-selector'
+import {
+  fetchMobileGitHistory,
+  formatCommitTime,
+  mapMobileCommitRows,
+  toMobileCommitRow
+} from './mobile-git-history'
 
 const NOW = 1_000_000_000_000
 
@@ -62,5 +68,25 @@ describe('mapMobileCommitRows', () => {
   it('maps all items', () => {
     const result = { items: [item(), item({ id: 'c'.repeat(40) })] } as GitHistoryResult
     expect(mapMobileCommitRows(result, NOW)).toHaveLength(2)
+  })
+})
+
+describe('fetchMobileGitHistory', () => {
+  it('fails fast for folder workspaces without calling git.history', async () => {
+    const sendRequest = vi.fn()
+    await expect(fetchMobileGitHistory({ sendRequest }, 'folder:group-1')).rejects.toThrow(
+      MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE
+    )
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('requests history for real worktrees', async () => {
+    const result = { items: [item()] } as GitHistoryResult
+    const sendRequest = vi.fn().mockResolvedValue({ ok: true, result })
+    await expect(fetchMobileGitHistory({ sendRequest }, 'wt-123', 25)).resolves.toEqual(result)
+    expect(sendRequest).toHaveBeenCalledWith('git.history', {
+      worktree: 'id:wt-123',
+      limit: 25
+    })
   })
 })

--- a/mobile/src/source-control/mobile-git-history.ts
+++ b/mobile/src/source-control/mobile-git-history.ts
@@ -1,6 +1,10 @@
 import type { GitHistoryItem, GitHistoryResult } from '../../../src/shared/git-history-types'
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcSuccess } from '../transport/types'
+import {
+  isMobileFolderWorkspaceId,
+  MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE
+} from './mobile-folder-workspace-selector'
 
 export type MobileCommitRow = {
   id: string
@@ -60,6 +64,11 @@ export async function fetchMobileGitHistory(
   worktreeId: string,
   limit = 50
 ): Promise<GitHistoryResult> {
+  // Why: git.history is unrouted for folder: selectors; skip the RPC so the
+  // list shows a clear unsupported state instead of selector_not_found (#11153).
+  if (isMobileFolderWorkspaceId(worktreeId)) {
+    throw new Error(MOBILE_FOLDER_WORKSPACE_UNSUPPORTED_MESSAGE)
+  }
   const response = await client.sendRequest('git.history', {
     worktree: `id:${worktreeId}`,
     limit

--- a/mobile/src/source-control/use-mobile-git-requests.ts
+++ b/mobile/src/source-control/use-mobile-git-requests.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import type { ConnectionState, RpcSuccess } from '../transport/types'
 import type { RpcClient } from '../transport/rpc-client'
+import { mobileFolderWorkspaceGitRpcGuard } from './mobile-folder-workspace-selector'
 import {
   isMobileGitUnavailable,
   type MobileGitStatusResult,
@@ -21,6 +22,12 @@ export function useMobileGitRequests({ client, connState, worktreeId }: Params) 
     async <T>(method: string, params?: Record<string, unknown>): Promise<T> => {
       if (!client || connState !== 'connected') {
         throw new Error('Waiting for desktop...')
+      }
+      // Why: folder-workspace selectors never resolve unrouted git methods; fail
+      // fast with a clear message instead of a selector_not_found retry loop.
+      const folderGuard = mobileFolderWorkspaceGitRpcGuard(worktreeId, method)
+      if (!folderGuard.allowed) {
+        throw new Error(folderGuard.message)
       }
       const response = await client.sendRequest(method, {
         worktree: `id:${worktreeId}`,

--- a/mobile/src/source-control/use-mobile-source-control-loaders.ts
+++ b/mobile/src/source-control/use-mobile-source-control-loaders.ts
@@ -4,6 +4,10 @@ import type { RpcClient } from '../transport/rpc-client'
 import type { ConnectionState, RpcSuccess } from '../transport/types'
 import { resolveMobileBranchCompareBaseRef } from './mobile-branch-base-ref'
 import {
+  shouldLoadMobileBranchCompare,
+  shouldRetryMobileStatusSelectorNotFound
+} from './mobile-folder-workspace-selector'
+import {
   isMobileGitUnavailable,
   isMobileGitTransientRefreshError,
   type MobileGitStatusResult
@@ -91,6 +95,15 @@ export function useMobileSourceControlLoaders(params: Params): MobileSourceContr
         currentBranchCompareIdentityRef.current === loadKey
 
       if (!worktreeId || !client || connState !== 'connected') {
+        if (isCurrentLoad()) {
+          setBranchCompareState({ kind: 'idle' })
+        }
+        return false
+      }
+
+      // Why: git.branchCompare is unrouted for folder: selectors; skip instead of
+      // firing a guaranteed selector_not_found (issue #11153).
+      if (!shouldLoadMobileBranchCompare(worktreeId)) {
         if (isCurrentLoad()) {
           setBranchCompareState({ kind: 'idle' })
         }
@@ -221,7 +234,8 @@ export function useMobileSourceControlLoaders(params: Params): MobileSourceContr
               return false
             }
             const shouldRetry =
-              response.error?.code === 'selector_not_found' ||
+              (response.error?.code === 'selector_not_found' &&
+                shouldRetryMobileStatusSelectorNotFound(worktreeId)) ||
               isMobileGitTransientRefreshError(response.error?.code, response.error?.message)
             if (shouldRetry && attempt < SELECTOR_RETRY_COUNT) {
               await wait(SELECTOR_RETRY_DELAY_MS)

--- a/mobile/src/source-control/use-mobile-source-control-state.ts
+++ b/mobile/src/source-control/use-mobile-source-control-state.ts
@@ -26,9 +26,9 @@ import {
 } from './mobile-git-status'
 import { getMobileCommitFailureStagedEntries } from './mobile-commit-failure-recovery'
 import { useMobileSourceControlCommitFailure } from './use-mobile-source-control-commit-failure'
+import { formatMobileFolderAwareBranchLabel } from './mobile-folder-workspace-selector'
 import {
   buildMobileGitStatusEntryViews,
-  formatBranchLabel,
   type MobileBranchEntryView
 } from './mobile-source-control-screen-state'
 
@@ -160,7 +160,11 @@ export function useMobileSourceControlState(params: MobileSourceControlStatePara
     () => entries.some((entry) => entry.conflictStatus === 'unresolved'),
     [entries]
   )
-  const branchLabel = formatBranchLabel(status?.branch, status?.head)
+  const branchLabel = formatMobileFolderAwareBranchLabel(
+    worktreeId,
+    status?.branch,
+    status?.head
+  )
   const upstream = status?.upstreamStatus
   const upstreamKnown = upstream !== undefined
   const syncLabel =


### PR DESCRIPTION
## Description
On mobile Source Control for **folder workspaces** (`folder:<id>`), unrouted git RPCs (`git.branchCompare`, history, sync) throw `selector_not_found`. The loader treated that as transient and retried, so users hit a slow loop then a bare error.

## Focused fix
- Detect `folder:` worktree ids on mobile
- Do **not** retry `selector_not_found` for folder workspaces (structural, not create-race)
- Skip `git.branchCompare` for folders; fail-fast clear message for unrouted sync/history RPCs
- Branch card label falls back to “Folder workspace” when head/branch are unset
- Out of scope: main-process routing for every folder git RPC (desktop still gates SC for folders)

## Preserves
- `git.status` / routed multi-repo folder status still attempted
- Git worktree SC path unchanged (retries for real create-race still apply)
- No new desktop Source Control surface for folder workspaces

## Evidence
- Unit tests: `mobile-folder-workspace-selector.test.ts`, `mobile-git-history.test.ts` (33 related tests green)

## User-regression-tradeoffs
- Folder SC history/sync show explicit unsupported instead of hanging on retries — intentional degrade until product routes those RPCs

Closes #11153

Made with [Orca](https://github.com/stablyai/orca) 🐋