### PR TITLE
fix(agents): track Qwen Code in workspace agent list via title identity

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -69,6 +69,29 @@ describe('buildTitleDerivedAgentRows', () => {
     ])
   })
 
+  // Why: Qwen Code has no agent hooks; workspace list tracking is title-derived only.
+  it('adds title-derived rows for hook-less Qwen Code panes', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: 'Qwen Code',
+          2: '⠋ Qwen Code'
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-left', 'pty-right'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.lastAssistantMessage])).toEqual([
+      ['qwen-code', 'idle', 'Idle'],
+      ['qwen-code', 'working', 'Running']
+    ])
+  })
+
   it('normalizes Pi-compatible title-derived rows to the launched OMP owner', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent: 'omp' })],

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -34,6 +34,7 @@ const TITLE_AGENT_LABEL_TO_TYPE: Record<string, AgentType> = {
   Devin: 'devin',
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
+  'Qwen Code': 'qwen-code',
   Aider: 'aider',
   Cursor: 'cursor',
   Droid: 'droid',

--- a/src/renderer/src/lib/agent-status.test.ts
+++ b/src/renderer/src/lib/agent-status.test.ts
@@ -467,6 +467,9 @@ describe('getAgentLabel', () => {
     expect(getAgentLabel('Hermes ready')).toBe('Hermes')
     expect(getAgentLabel('⠋ Devin')).toBe('Devin')
     expect(getAgentLabel('Devin ready')).toBe('Devin')
+    expect(getAgentLabel('Qwen Code')).toBe('Qwen Code')
+    expect(getAgentLabel('⠋ Qwen Code')).toBe('Qwen Code')
+    expect(getAgentLabel('qwen ready')).toBe('Qwen Code')
   })
 
   it('does not label the Claude agents management title', () => {
@@ -854,6 +857,10 @@ describe('formatAgentTypeLabel', () => {
 
   it("maps 'command-code' to 'Command Code'", () => {
     expect(formatAgentTypeLabel('command-code')).toBe('Command Code')
+  })
+
+  it("maps 'qwen-code' to 'Qwen Code'", () => {
+    expect(formatAgentTypeLabel('qwen-code')).toBe('Qwen Code')
   })
 
   it("maps 'ante' to 'Ante'", () => {

--- a/src/shared/agent-detection.test.ts
+++ b/src/shared/agent-detection.test.ts
@@ -101,6 +101,26 @@ describe('MiMo title detection', () => {
   )
 })
 
+describe('Qwen Code title detection', () => {
+  it.each([
+    ['Qwen Code', 'idle'],
+    ['qwen ready', 'idle'],
+    ['qwen working', 'working'],
+    ['\u280b Qwen Code', 'working']
+  ] as const)('classifies %s', (title, expectedStatus) => {
+    expect(getAgentLabel(title)).toBe('Qwen Code')
+    expect(detectAgentStatusFromTitle(title)).toBe(expectedStatus)
+  })
+
+  it.each(['~/qwen/working', 'qwen-code-fixtures ready'])(
+    'does not classify path or hyphen false positive %s',
+    (title) => {
+      expect(getAgentLabel(title)).toBeNull()
+      expect(detectAgentStatusFromTitle(title)).toBeNull()
+    }
+  )
+})
+
 describe('Pi-compatible title detection', () => {
   it.each([
     ['\u280b OMP', 'OMP', 'working'],

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -26,7 +26,10 @@ export const AGENT_NAMES = [
   'openclaw',
   'aider',
   'grok',
-  'devin'
+  'devin',
+  // Why: Qwen Code installs as `qwen`; token-match is safe (uncommon in cwd names)
+  // and keeps the hook-less title-derived sidebar path aligned with process recognition.
+  'qwen'
 ]
 
 // Why: Windows agent titles can surface launcher process names such as

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -99,9 +99,6 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'mimo')) {
     return 'MiMo Code'
   }
-  if (titleHasAgentName(title, 'qwen')) {
-    return 'Qwen Code'
-  }
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
@@ -115,6 +112,11 @@ export function getAgentLabel(title: string): string | null {
   }
   if (HERMES_AGENT_NAME_RE.test(title)) {
     return 'Hermes'
+  }
+  // Why: after other named agents so mixed titles like "Aider: compare qwen output"
+  // keep the owner identity; still before Claude's braille fallback.
+  if (titleHasAgentName(title, 'qwen')) {
+    return 'Qwen Code'
   }
   if (isClaudeAgent(title)) {
     return 'Claude Code'

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -99,6 +99,9 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'mimo')) {
     return 'MiMo Code'
   }
+  if (titleHasAgentName(title, 'qwen')) {
+    return 'Qwen Code'
+  }
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }

--- a/src/shared/agent-type-label.ts
+++ b/src/shared/agent-type-label.ts
@@ -12,6 +12,7 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   copilot: 'GitHub Copilot',
   opencode: 'OpenCode',
   'mimo-code': 'MiMo Code',
+  'qwen-code': 'Qwen Code',
   cursor: 'Cursor',
   aider: 'Aider',
   pi: 'Pi',

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -132,6 +132,12 @@ describe('resolveTerminalTitleAgentType', () => {
     expect(resolveTerminalTitleAgentType('Qwen Code')).toBe('qwen-code')
     expect(resolveTerminalTitleAgentType('⠋ Qwen Code')).toBe('qwen-code')
     expect(resolveTerminalTitleAgentType('qwen ready')).toBe('qwen-code')
+  })
+
+  it('does not let a qwen mention reclassify another named agent title', () => {
+    expect(resolveTerminalTitleAgentType('Aider: compare qwen output')).toBe('aider')
+    expect(resolveTerminalTitleAgentType('⠋ Aider: compare qwen output')).toBe('aider')
+    expect(getSharedAgentLabel('Aider: compare qwen output')).toBe('Aider')
     expect(getSharedAgentLabel('Qwen Code')).toBe('Qwen Code')
     expect(getSharedAgentLabel('⠋ Qwen Code')).toBe('Qwen Code')
   })

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -42,6 +42,8 @@ describe('resolveExplicitTerminalTitleAgentType', () => {
     expect(resolveExplicitTerminalTitleAgentType('⠋ Codex')).toBe('codex')
     expect(resolveExplicitTerminalTitleAgentType('✦ Gemini CLI')).toBe('gemini')
     expect(resolveExplicitTerminalTitleAgentType('MiMo Code')).toBe('mimo-code')
+    expect(resolveExplicitTerminalTitleAgentType('Qwen Code')).toBe('qwen-code')
+    expect(resolveExplicitTerminalTitleAgentType('⠋ Qwen Code')).toBe('qwen-code')
     expect(resolveExplicitTerminalTitleAgentType('⠋ OpenClaude')).toBe('openclaude')
     expect(resolveExplicitTerminalTitleAgentType('OMP')).toBe('omp')
   })
@@ -122,6 +124,16 @@ describe('resolveTerminalTitleAgentType', () => {
       'claude'
     )
     expect(resolveTerminalTitleAgentType('⠋ Codex: fix cursor offsets')).toBe('codex')
+  })
+
+  // Why: Qwen Code is hook-less; sidebar tracking depends on title identity resolving
+  // to qwen-code before Claude's braille-spinner heuristic claims the frame.
+  it('maps Qwen Code product titles to qwen-code', () => {
+    expect(resolveTerminalTitleAgentType('Qwen Code')).toBe('qwen-code')
+    expect(resolveTerminalTitleAgentType('⠋ Qwen Code')).toBe('qwen-code')
+    expect(resolveTerminalTitleAgentType('qwen ready')).toBe('qwen-code')
+    expect(getSharedAgentLabel('Qwen Code')).toBe('Qwen Code')
+    expect(getSharedAgentLabel('⠋ Qwen Code')).toBe('Qwen Code')
   })
 })
 

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -183,12 +183,6 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'mimo')) {
     return 'MiMo Code'
   }
-  // Why: Qwen Code can use braille spinner prefixes while working; match the
-  // name token before Claude's generic spinner heuristic (keep in sync with
-  // agent-title-identity.ts).
-  if (titleHasAgentName(title, 'qwen')) {
-    return 'Qwen Code'
-  }
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
@@ -206,6 +200,11 @@ export function getAgentLabel(title: string): string | null {
   // Claude's generic braille-spinner heuristic.
   if (HERMES_AGENT_NAME_RE.test(title)) {
     return 'Hermes'
+  }
+  // Why: after other named agents so mixed titles keep the owner; still before
+  // Claude's braille fallback (keep in sync with agent-title-identity.ts).
+  if (titleHasAgentName(title, 'qwen')) {
+    return 'Qwen Code'
   }
   if (isClaudeAgent(title)) {
     return 'Claude Code'

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -183,6 +183,12 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'mimo')) {
     return 'MiMo Code'
   }
+  // Why: Qwen Code can use braille spinner prefixes while working; match the
+  // name token before Claude's generic spinner heuristic (keep in sync with
+  // agent-title-identity.ts).
+  if (titleHasAgentName(title, 'qwen')) {
+    return 'Qwen Code'
+  }
   if (titleHasAgentName(title, 'aider')) {
     return 'Aider'
   }
@@ -223,6 +229,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
   'MiMo Code': 'mimo-code',
+  'Qwen Code': 'qwen-code',
   Aider: 'aider',
   Cursor: 'cursor',
   Droid: 'droid',


### PR DESCRIPTION
## Description
Qwen Code launches and runs in a terminal, but sessions did not appear in the workspace agent list. Process recognition already mapped `qwen` → `qwen-code`; the hook-less **title identity** path (sidebar title-derived rows) did not know Qwen.

## Focused fix
- Token-match `qwen` in agent name detection
- `getAgentLabel` → `Qwen Code`; map label → `qwen-code` for title-derived rows and terminal title agent type
- `formatAgentTypeLabel('qwen-code')` → `Qwen Code`
- Out of scope: full managed agent hooks installer for Qwen (no `AGENT_HOOK_TARGETS` entry)

## Preserves
- Existing process recognition for the `qwen` binary
- Hook-based agents and other title labels unchanged
- No synthetic title rewrite for Qwen (native titles only)

## Evidence
- `agent-detection`, `terminal-title-agent-type`, `agent-status`, `worktree-title-derived-agent-rows`, `agent-process-recognition` — 234 related tests green

## User-regression-tradeoffs
- List tracking works when the title names Qwen (or braille+launchAgent path). Full status hooks (permission/done granularity) still need a future Qwen hook installer

Closes #11148

Made with [Orca](https://github.com/stablyai/orca) 🐋