### PR TITLE
fix(session): preserve client tab-group split ratios on remote snapshots

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1784,6 +1784,156 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.layoutByWorktree).toBeUndefined()
   })
 
+  it('preserves client terminal|browser split ratio when host omits tabGroupLayout (#11162)', () => {
+    // Why: Browser-tab-host=this-computer composites are client-owned. Host publishes a
+    // terminal-only group with no layout; rebuilding via appendTabGroupLayout would drop the ratio.
+    const terminalId = toWebTerminalSurfaceTabId('host-terminal')
+    const localBrowserWorkspace: BrowserWorkspace = {
+      id: 'local-browser-workspace',
+      worktreeId: WT,
+      label: undefined,
+      sessionProfileId: null,
+      activePageId: 'local-browser-page',
+      pageIds: ['local-browser-page'],
+      url: 'https://example.com/',
+      title: 'Example',
+      loading: false,
+      faviconUrl: null,
+      canGoBack: false,
+      canGoForward: false,
+      loadError: null,
+      createdAt: NOW + 1
+    }
+    const localBrowserPage: BrowserPage = {
+      id: 'local-browser-page',
+      workspaceId: localBrowserWorkspace.id,
+      worktreeId: WT,
+      url: 'https://example.com/',
+      title: 'Example',
+      loading: false,
+      faviconUrl: null,
+      canGoBack: false,
+      canGoForward: false,
+      loadError: null,
+      createdAt: NOW + 1,
+      browserRuntimeEnvironmentId: null,
+      viewportPresetId: null
+    }
+    const terminalTab: Tab = {
+      id: terminalId,
+      entityId: terminalId,
+      groupId: 'host-group-1',
+      worktreeId: WT,
+      contentType: 'terminal',
+      label: 'host shell',
+      customLabel: null,
+      color: null,
+      sortOrder: 0,
+      createdAt: NOW,
+      isPreview: false,
+      isPinned: false
+    }
+    const browserTab: Tab = {
+      id: 'local-browser-tab',
+      entityId: localBrowserWorkspace.id,
+      groupId: 'local-browser-group',
+      worktreeId: WT,
+      contentType: 'browser',
+      label: 'Example',
+      customLabel: null,
+      color: null,
+      sortOrder: 1,
+      createdAt: NOW + 1,
+      isPreview: false,
+      isPinned: false
+    }
+    const currentLayout = {
+      type: 'split' as const,
+      direction: 'horizontal' as const,
+      ratio: 0.3,
+      first: { type: 'leaf' as const, groupId: 'host-group-1' },
+      second: { type: 'leaf' as const, groupId: 'local-browser-group' }
+    }
+
+    const patch = applyWebSessionTabsSnapshot(
+      makeState({
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: terminalId,
+              ptyId: 'remote:web-env-1@@terminal-1',
+              worktreeId: WT,
+              title: 'host shell',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: NOW
+            }
+          ]
+        },
+        browserTabsByWorktree: { [WT]: [localBrowserWorkspace] },
+        browserPagesByWorkspace: { [localBrowserWorkspace.id]: [localBrowserPage] },
+        unifiedTabsByWorktree: { [WT]: [terminalTab, browserTab] },
+        tabBarOrderByWorktree: { [WT]: [terminalId, browserTab.id] },
+        groupsByWorktree: {
+          [WT]: [
+            {
+              id: 'host-group-1',
+              worktreeId: WT,
+              activeTabId: terminalId,
+              tabOrder: [terminalId],
+              recentTabIds: [terminalId]
+            },
+            {
+              id: 'local-browser-group',
+              worktreeId: WT,
+              activeTabId: browserTab.id,
+              tabOrder: [browserTab.id],
+              recentTabIds: [browserTab.id]
+            }
+          ]
+        },
+        layoutByWorktree: { [WT]: currentLayout }
+      }),
+      makeSnapshot(
+        [
+          {
+            type: 'terminal',
+            id: `host-terminal::${LEAF_ID}`,
+            title: 'host shell',
+            parentTabId: 'host-terminal',
+            leafId: LEAF_ID,
+            isActive: true,
+            status: 'ready',
+            terminal: 'terminal-1'
+          }
+        ],
+        {
+          activeGroupId: 'host-group-1',
+          activeTabId: `host-terminal::${LEAF_ID}`,
+          activeTabType: 'terminal',
+          tabGroups: [
+            { id: 'host-group-1', activeTabId: 'host-terminal', tabOrder: ['host-terminal'] }
+          ]
+          // no tabGroupLayout — host does not publish client composite layout
+        }
+      ),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    // Unchanged layout yields no patch entry; if a patch is emitted it must keep the ratio.
+    const layout = patch.layoutByWorktree?.[WT] ?? currentLayout
+    expect(layout).toEqual({
+      type: 'split',
+      direction: 'horizontal',
+      ratio: 0.3,
+      first: { type: 'leaf', groupId: 'host-group-1' },
+      second: { type: 'leaf', groupId: 'local-browser-group' }
+    })
+    expect(patch.layoutByWorktree).toBeUndefined()
+  })
+
   it('preserves host pane titles without synthesizing them from tab titles', () => {
     const patch = applyWebSessionTabsSnapshot(
       makeState(),

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1108,6 +1108,76 @@ function appendTabGroupLayout(
   }
 }
 
+function layoutCoversAllGroupIds(
+  layout: TabGroupLayoutNode | null,
+  groupIds: ReadonlySet<string>
+): boolean {
+  if (!layout || groupIds.size === 0) {
+    return false
+  }
+  const present = collectLayoutGroupIds(layout)
+  for (const groupId of groupIds) {
+    if (!present.has(groupId)) {
+      return false
+    }
+  }
+  return true
+}
+
+function tabGroupLayoutTopologyEqual(
+  a: TabGroupLayoutNode | null | undefined,
+  b: TabGroupLayoutNode | null | undefined
+): boolean {
+  if (!a || !b) {
+    return !a && !b
+  }
+  if (a.type !== b.type) {
+    return false
+  }
+  if (a.type === 'leaf') {
+    return b.type === 'leaf' && a.groupId === b.groupId
+  }
+  return (
+    b.type === 'split' &&
+    a.direction === b.direction &&
+    tabGroupLayoutTopologyEqual(a.first, b.first) &&
+    tabGroupLayoutTopologyEqual(a.second, b.second)
+  )
+}
+
+/** Copy split ratios from source onto target when topology matches and target omits ratio. */
+function preserveTabGroupLayoutRatios(
+  target: TabGroupLayoutNode,
+  source: TabGroupLayoutNode | null | undefined
+): TabGroupLayoutNode {
+  if (!source || !tabGroupLayoutTopologyEqual(target, source)) {
+    return target
+  }
+  return copyMissingLayoutRatios(target, source)
+}
+
+function copyMissingLayoutRatios(
+  target: TabGroupLayoutNode,
+  source: TabGroupLayoutNode
+): TabGroupLayoutNode {
+  if (target.type === 'leaf' || source.type === 'leaf') {
+    return target
+  }
+  const first = copyMissingLayoutRatios(target.first, source.first)
+  const second = copyMissingLayoutRatios(target.second, source.second)
+  const ratio = target.ratio ?? source.ratio
+  if (first === target.first && second === target.second && ratio === target.ratio) {
+    return target
+  }
+  return {
+    type: 'split',
+    direction: target.direction,
+    first,
+    second,
+    ...(ratio !== undefined ? { ratio } : {})
+  }
+}
+
 function tabGroupLayoutEqual(
   a: TabGroupLayoutNode | null | undefined,
   b: TabGroupLayoutNode | null | undefined
@@ -2373,8 +2443,20 @@ export function applyWebSessionTabsSnapshot(
       return state.layoutByWorktree
     }
     const validGroupIds = new Set(nextGroups.map((group) => group.id))
+    const localLayout = pruneTabGroupLayout(state.layoutByWorktree[worktreeId], validGroupIds)
     const hostLayout = pruneTabGroupLayout(snapshot.tabGroupLayout, validGroupIds)
     const defaultLeafLayout = { type: 'leaf' as const, groupId: nextActiveGroupId ?? targetGroupId }
+    // Why: Browser-tab-host=this-computer composites are client-owned; host often omits tabGroupLayout.
+    // Prefer the existing local tree (incl. drag ratio) when it still covers every live group.
+    if (!hostLayout && localLayout && layoutCoversAllGroupIds(localLayout, validGroupIds)) {
+      if (tabGroupLayoutEqual(state.layoutByWorktree[worktreeId], localLayout)) {
+        return state.layoutByWorktree
+      }
+      return {
+        ...state.layoutByWorktree,
+        [worktreeId]: localLayout
+      }
+    }
     const hostLayoutGroupIds = collectLayoutGroupIds(hostLayout ?? undefined)
     const hostGroupIds = new Set(snapshot.tabGroups?.map((group) => group.id) ?? [])
     const extraGroupIds = new Set(
@@ -2391,16 +2473,18 @@ export function applyWebSessionTabsSnapshot(
     const localExtraLayout = pruneTabGroupLayout(state.layoutByWorktree[worktreeId], extraGroupIds)
     const hostBaseLayout =
       hostLayout ?? (snapshot.tabGroups && snapshot.tabGroups.length > 0 ? defaultLeafLayout : null)
-    const fallbackLayout =
+    const mergedLayout =
       appendTabGroupLayout(hostBaseLayout, localExtraLayout) ??
       (snapshot.tabGroups && snapshot.tabGroups.length > 0
         ? defaultLeafLayout
         : state.layoutByWorktree[worktreeId]
           ? null
           : defaultLeafLayout)
-    if (!fallbackLayout) {
+    if (!mergedLayout) {
       return state.layoutByWorktree
     }
+    // Why: host/merged split nodes may omit ratio; keep the client's ratio when topology matches.
+    const fallbackLayout = preserveTabGroupLayoutRatios(mergedLayout, localLayout)
     if (tabGroupLayoutEqual(state.layoutByWorktree[worktreeId], fallbackLayout)) {
       return state.layoutByWorktree
     }


### PR DESCRIPTION
## Description
Dragging the outer tab-group divider on a remote workspace snaps back to ~50/50 after the next `session.tabs` snapshot. With **Browser tab host = This computer**, the terminal|browser composite layout is client-owned; the host often publishes no `tabGroupLayout`. Snapshot merge rebuilt the layout via `appendTabGroupLayout` without the client ratio.

## Focused fix
- When the host omits a usable `tabGroupLayout`, keep the pruned local layout if it still covers every live group
- When topologies match and a host/merged split omits `ratio`, preserve the local ratio
- Out of scope: new host RPC to persist outer divider ratios; inner terminal-pane resize path

## Preserves
- Host-published `tabGroupLayout` topology stays authoritative when present
- Tab moves / group membership still follow the snapshot
- Local-only workspaces unchanged

## Evidence
- `web-session-tabs-sync.test.ts` regression: local ratio `0.3` survives host terminal-only snapshot without layout (63 tests green)

## User-regression-tradeoffs
- Client-owned composites keep the user’s divider position across routine remote updates; host-driven topology changes still apply when the host publishes layout

Closes #11162

Made with [Orca](https://github.com/stablyai/orca) 🐋