### PR TITLE
fix(browser): give CDP-attached guests an opaque base background

### DIFF
--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -308,7 +308,7 @@ export class BrowserManager {
           // white fallback. An opaque base lets Blink pick the canvas color per document scheme.
           .then(() =>
             guest.debugger.sendCommand('Emulation.setDefaultBackgroundColorOverride', {
-              color: { r: 255, g: 255, b: 255, a: 255 }
+              color: { r: 255, g: 255, b: 255, a: 1 }
             })
           )
           .catch(() => {})

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -303,6 +303,14 @@ export class BrowserManager {
               source: ANTI_DETECTION_SCRIPT
             })
           )
+          // Why: webview guests default to a transparent base background, so dark-color-scheme
+          // documents (e.g. Chromium's application/json viewer) render light text over the pane's
+          // white fallback. An opaque base lets Blink pick the canvas color per document scheme.
+          .then(() =>
+            guest.debugger.sendCommand('Emulation.setDefaultBackgroundColorOverride', {
+              color: { r: 255, g: 255, b: 255, a: 255 }
+            })
+          )
           .catch(() => {})
       } catch {
         /* best-effort — debugger may be unavailable */

--- a/src/main/browser/cdp-bridge-integration.test.ts
+++ b/src/main/browser/cdp-bridge-integration.test.ts
@@ -175,8 +175,14 @@ function createMockGuest(
         return {}
       case 'Page.addScriptToEvaluateOnNewDocument':
         return { identifier: 'mock-script-id' }
-      case 'Emulation.setDefaultBackgroundColorOverride':
+      case 'Emulation.setDefaultBackgroundColorOverride': {
+        // Why: CDP RGBA alpha is a float in [0, 1]; reject out-of-range payloads like real Chromium may.
+        const color = params?.color as { r: number; g: number; b: number; a?: number } | undefined
+        if (color && color.a !== undefined && (color.a < 0 || color.a > 1)) {
+          throw new Error(`RGBA alpha out of range [0, 1]: ${color.a}`)
+        }
         return {}
+      }
       case 'Runtime.enable':
         return {}
       default:

--- a/src/main/browser/cdp-bridge-integration.test.ts
+++ b/src/main/browser/cdp-bridge-integration.test.ts
@@ -175,6 +175,8 @@ function createMockGuest(
         return {}
       case 'Page.addScriptToEvaluateOnNewDocument':
         return { identifier: 'mock-script-id' }
+      case 'Emulation.setDefaultBackgroundColorOverride':
+        return {}
       case 'Runtime.enable':
         return {}
       default:

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -1164,7 +1164,7 @@ export class CdpBridge {
 
     // Why: keep the opaque base background across bridge takeovers so dark-color-scheme documents stay readable.
     await sender('Emulation.setDefaultBackgroundColorOverride', {
-      color: { r: 255, g: 255, b: 255, a: 255 }
+      color: { r: 255, g: 255, b: 255, a: 1 }
     })
 
     // Why: only remove this bridge's listeners; screencast/proxy sessions share the debugger and own their teardown.

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -1162,6 +1162,11 @@ export class CdpBridge {
       source: ANTI_DETECTION_SCRIPT
     })
 
+    // Why: keep the opaque base background across bridge takeovers so dark-color-scheme documents stay readable.
+    await sender('Emulation.setDefaultBackgroundColorOverride', {
+      color: { r: 255, g: 255, b: 255, a: 255 }
+    })
+
     // Why: only remove this bridge's listeners; screencast/proxy sessions share the debugger and own their teardown.
     this.removeDebuggerListeners(guest, state)
 

--- a/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
+++ b/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
@@ -53,6 +53,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setDefaultBackgroundColorOverride', expect.any(Object)],
       ['DOM.focus', { backendNodeId: 99 }],
       ['DOM.focus', { backendNodeId: 99 }],
       ['Input.insertText', { text: 'hello' }]
@@ -81,6 +82,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setDefaultBackgroundColorOverride', expect.any(Object)],
       ['DOM.focus', { backendNodeId: 123 }, 'oopif-session-123'],
       ['DOM.focus', { backendNodeId: 123 }, 'oopif-session-123'],
       ['Input.insertText', { text: 'frame text' }, 'oopif-session-123']
@@ -113,6 +115,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setDefaultBackgroundColorOverride', expect.any(Object)],
       ['DOM.focus', { backendNodeId: 44 }],
       ['Runtime.callFunctionOn', { functionDeclaration: '() => document.activeElement?.id' }],
       ['Input.insertText', { text: 'after eval' }]
@@ -156,6 +159,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setDefaultBackgroundColorOverride', expect.any(Object)],
       ['DOM.focus', { backendNodeId: 55 }],
       ['Input.insertText', { text: 'fallback' }]
     ])
@@ -198,6 +202,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setDefaultBackgroundColorOverride', expect.any(Object)],
       ['DOM.focus', { backendNodeId: 77 }],
       ['DOM.focus', { backendNodeId: 77 }]
     ])
@@ -243,6 +248,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setDefaultBackgroundColorOverride',
       'DOM.focus',
       'DOM.focus',
       'Input.insertText'
@@ -273,6 +279,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setDefaultBackgroundColorOverride',
       'DOM.focus',
       'Input.insertText'
     ])
@@ -299,6 +306,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setDefaultBackgroundColorOverride',
       'DOM.focus',
       'Page.captureScreenshot',
       'Input.insertText'
@@ -325,6 +333,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setDefaultBackgroundColorOverride',
       'DOM.focus',
       'Input.insertText'
     ])

--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -403,6 +403,7 @@ describe('CdpWsProxy', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setDefaultBackgroundColorOverride',
       'Input.insertText'
     ])
     client.close()
@@ -422,6 +423,7 @@ describe('CdpWsProxy', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setDefaultBackgroundColorOverride',
       'Network.enable',
       'Page.enable',
       'Page.setLifecycleEventsEnabled',
@@ -443,6 +445,7 @@ describe('CdpWsProxy', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setDefaultBackgroundColorOverride',
       'Network.enable',
       'Page.enable',
       'Page.setLifecycleEventsEnabled'
@@ -462,7 +465,7 @@ describe('CdpWsProxy', () => {
       sessionId: 'iframe-session-123'
     })
 
-    expect(getSendCommandCalls(mock).slice(2)).toEqual([
+    expect(getSendCommandCalls(mock).slice(3)).toEqual([
       ['Network.enable', {}, 'iframe-session-123'],
       ['Page.enable', {}, 'iframe-session-123'],
       ['Page.setLifecycleEventsEnabled', { enabled: true }, 'iframe-session-123'],
@@ -481,7 +484,7 @@ describe('CdpWsProxy', () => {
       sessionId: 'iframe-session-123'
     })
 
-    expect(getSendCommandCalls(mock).slice(2)).toEqual([
+    expect(getSendCommandCalls(mock).slice(3)).toEqual([
       ['Network.enable', {}, 'iframe-session-123'],
       ['Page.enable', {}, 'iframe-session-123'],
       ['Page.setLifecycleEventsEnabled', { enabled: true }, 'iframe-session-123'],
@@ -565,6 +568,7 @@ describe('CdpWsProxy', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setDefaultBackgroundColorOverride',
       'Runtime.evaluate'
     ])
     client.close()

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -229,6 +229,10 @@ export class CdpWsProxy {
       await this.webContents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
         source: ANTI_DETECTION_SCRIPT
       })
+      // Why: keep the opaque base background across proxy takeovers so dark-color-scheme documents stay readable.
+      await this.webContents.debugger.sendCommand('Emulation.setDefaultBackgroundColorOverride', {
+        color: { r: 255, g: 255, b: 255, a: 255 }
+      })
     } catch {
       /* best-effort — page domain may not be ready yet */
     }

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -231,7 +231,7 @@ export class CdpWsProxy {
       })
       // Why: keep the opaque base background across proxy takeovers so dark-color-scheme documents stay readable.
       await this.webContents.debugger.sendCommand('Emulation.setDefaultBackgroundColorOverride', {
-        color: { r: 255, g: 255, b: 255, a: 255 }
+        color: { r: 255, g: 255, b: 255, a: 1 }
       })
     } catch {
       /* best-effort — page domain may not be ready yet */

--- a/src/renderer/src/components/browser-pane/browser-page-webview.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-webview.ts
@@ -56,8 +56,9 @@ export function ensureBrowserPageWebview({
   webview.style.height = '100%'
   webview.style.border = 'none'
   webview.style.pointerEvents = inputLocked ? 'none' : 'auto'
-  // Why: some pages never paint a background, and a white viewport matches
-  // normal browser behavior instead of leaking Orca chrome through the guest.
+  // Why: fallback for guests without a CDP debugger (e.g. DevTools open) so Orca chrome
+  // never leaks through; attached guests get an opaque base via
+  // Emulation.setDefaultBackgroundColorOverride, which Blink flips per document color scheme.
   webview.style.background = '#ffffff'
   registerPersistentWebview(browserTabId, webview)
   activeContainer.appendChild(webview)


### PR DESCRIPTION
Fixes #11190.

## Summary

`application/json` responses rendered as a blank white page in the embedded browser with the dark theme. Chromium's JSON viewer document declares `color-scheme: light dark`, so its text goes white in dark mode, but it paints no background. Webview guests have a transparent base background and the pane forces a white CSS fallback, so the page came out white-on-white. Details and repro in the issue.

This adds `Emulation.setDefaultBackgroundColorOverride` (opaque white) where the guest debugger gets bootstrapped: `injectAntiDetection` in browser-manager, plus cdp-bridge and cdp-ws-proxy so the override survives takeovers, same way `ANTI_DETECTION_SCRIPT` is kept alive. With an opaque base Blink picks the canvas color per document color scheme: JSON pages get a dark canvas in dark mode, CSS-less pages keep the white one. The white CSS fallback on the `<webview>` element stays for guests where `debugger.attach` fails (DevTools open).

## Screenshots

Before/after screenshots are in #11190: the blank white page vs a dark canvas with readable JSON, plus a CSS-less page that keeps its white background with the fix applied.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — ran the affected suite `vitest run src/main/browser/`: 526 passed. Updated command-sequence expectations in `cdp-ws-proxy.test.ts` / `cdp-ws-proxy-focus-replay.test.ts`; the `cdp-bridge-integration.test.ts` mock now handles the new command and rejects an out-of-range RGBA alpha so it can't regress
- [ ] `pnpm build`
- [x] Behavior check in a standalone Electron 43.1.0 repro: JSON page → dark canvas + white text; plain no-CSS page → white canvas + black text

## AI Review Report

Ran an AI-assisted review of the change. Risks checked: regressions for pages that paint no background (the case the white CSS fallback was originally added for) — verified a CSS-less page still renders white with black text; override survival across bridge/proxy debugger takeovers — the override is installed at all three bootstrap sites, mirroring how `ANTI_DETECTION_SCRIPT` is kept alive; behavior when no debugger can attach (DevTools open) — the CSS fallback keeps today's behavior for that guest. The review also flagged an out-of-spec RGBA alpha (`a: 255` instead of the 0–1 float the protocol defines), fixed to `a: 1`. Cross-platform: the change is a CDP command with a constant payload — no shortcuts, labels, paths, or shell behavior involved; the call sites are shared (not platform-gated) code, so macOS/Linux/Windows behave the same, and headless `orca serve` gets the same override through cdp-bridge / cdp-ws-proxy.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or dependency changes. The added CDP command sends a constant color payload to already-attached debugger sessions over the existing internal channel; no page- or user-controlled data flows into it. IPC surfaces are unchanged.

## Notes

- The override only applies while a debugger is attached. If `debugger.attach` fails (e.g. DevTools open on the tab), the white CSS fallback preserves the current behavior for that guest.
- `pnpm build` was not run locally; the change is main-process/renderer TypeScript only, no build-config or asset changes.
