### PR TITLE
feat(gitlab): configure one GitLab instance

### DIFF
--- a/src/main/git/glab-ported-hostname-env.ts
+++ b/src/main/git/glab-ported-hostname-env.ts
@@ -1,0 +1,33 @@
+import { addWslEnvKeys } from '../wsl-env'
+
+/**
+ * glab's `--hostname` rejects host:port, so a ported self-hosted GitLab must use the GITLAB_HOST env var instead — translate it.
+ *
+ * Lives outside runner.ts so lightweight callers (preflight probes) can route a
+ * ported host without importing the heavy runner module.
+ */
+export function redirectPortedHostnameToEnv<T extends object>(
+  args: string[],
+  options: T
+): { args: string[]; options: T & { env?: NodeJS.ProcessEnv } } {
+  const i = args.indexOf('--hostname')
+  if (i === -1 || i + 1 >= args.length) {
+    return { args, options }
+  }
+  const host = args[i + 1]
+  if (!/^[^/\s]+:\d+$/.test(host)) {
+    return { args, options }
+  }
+  const env: NodeJS.ProcessEnv = {
+    ...((options as { env?: NodeJS.ProcessEnv }).env ?? process.env),
+    GITLAB_HOST: host
+  }
+  if (process.platform === 'win32') {
+    // Why: spawn env stops at the wsl.exe boundary, so WSL glab loses the host:port binding unless WSLENV names GITLAB_HOST.
+    addWslEnvKeys(env, ['GITLAB_HOST'])
+  }
+  return {
+    args: [...args.slice(0, i), ...args.slice(i + 2)],
+    options: { ...options, env }
+  }
+}

--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -373,6 +373,64 @@ describe('ghExecFileAsync WSL fallback', () => {
     )
   })
 
+  it('keeps a ported GITLAB_HOST bound across the wsl.exe boundary for UNC-cwd calls', async () => {
+    execFileMock.mockImplementation((_binary, _args, options, callback) => {
+      if (typeof options === 'function') {
+        callback = options
+      }
+      callback(null, { stdout: '[]', stderr: '' })
+    })
+
+    await expect(
+      glabExecFileAsync(['api', '--hostname', 'gitlab.example.com:8443', 'projects'], {
+        cwd: String.raw`\\wsl.localhost\Ubuntu\home\jinwoo\stably\noqa`
+      })
+    ).resolves.toEqual({ stdout: '[]', stderr: '' })
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'wsl.exe',
+      [
+        '-d',
+        'Ubuntu',
+        '--',
+        'bash',
+        '-c',
+        "cd '/home/jinwoo/stably/noqa' && 'glab' 'api' 'projects'"
+      ],
+      expect.objectContaining({
+        env: expect.objectContaining({ GITLAB_HOST: 'gitlab.example.com:8443' })
+      }),
+      expect.any(Function)
+    )
+    expect(execFileMock.mock.calls[0][2].env.WSLENV.split(':')).toContain('GITLAB_HOST')
+  })
+
+  it('keeps a ported GITLAB_HOST bound when falling back to the default WSL distro', async () => {
+    getDefaultWslDistroMock.mockReturnValue('Ubuntu')
+    execFileMock
+      .mockImplementationOnce((_binary, _args, _options, callback) => {
+        callback(Object.assign(new Error('spawn glab ENOENT'), { code: 'ENOENT' }))
+      })
+      .mockImplementationOnce((_binary, _args, _options, callback) => {
+        callback(null, { stdout: '[]', stderr: '' })
+      })
+
+    await expect(
+      glabExecFileAsync(['api', '--hostname', 'gitlab.example.com:8443', 'projects'])
+    ).resolves.toEqual({ stdout: '[]', stderr: '' })
+
+    expect(execFileMock).toHaveBeenNthCalledWith(
+      2,
+      'wsl.exe',
+      ['-d', 'Ubuntu', '--', 'bash', '-c', "'glab' 'api' 'projects'"],
+      expect.objectContaining({
+        env: expect.objectContaining({ GITLAB_HOST: 'gitlab.example.com:8443' })
+      }),
+      expect.any(Function)
+    )
+    expect(execFileMock.mock.calls[1][2].env.WSLENV.split(':')).toContain('GITLAB_HOST')
+  })
+
   it('times out the default-WSL glab fallback and waits for full tree cleanup', async () => {
     vi.useFakeTimers()
     getDefaultWslDistroMock.mockReturnValue('Ubuntu')

--- a/src/main/gitlab/client-work-items.test.ts
+++ b/src/main/gitlab/client-work-items.test.ts
@@ -115,7 +115,7 @@ describe('gitlab client — combined listWorkItems', () => {
 
     const mergeRequestCallPath = glabApiWithHeadersMock.mock.calls[0][0] as string[]
     const issuesCallPath = glabExecFileAsyncMock.mock.calls[0][0] as string[]
-    expect(mergeRequestCallPath[0]).toContain('search=ambiguous%20selector')
+    expect(mergeRequestCallPath.at(-1)).toContain('search=ambiguous%20selector')
     expect(issuesCallPath.at(-1)).toContain('search=ambiguous%20selector')
   })
 
@@ -127,7 +127,7 @@ describe('gitlab client — combined listWorkItems', () => {
 
     const mergeRequestCallPath = glabApiWithHeadersMock.mock.calls[0][0] as string[]
     const issuesCallPath = glabExecFileAsyncMock.mock.calls[0][0] as string[]
-    const mergeRequestParams = new URLSearchParams(mergeRequestCallPath[0].split('?')[1])
+    const mergeRequestParams = new URLSearchParams(mergeRequestCallPath.at(-1)?.split('?')[1])
     const issueParams = new URLSearchParams(issuesCallPath.at(-1)?.split('?')[1])
     expect(mergeRequestParams.get('page')).toBe('2')
     expect(issueParams.get('page')).toBe('2')

--- a/src/main/gitlab/client.test.ts
+++ b/src/main/gitlab/client.test.ts
@@ -77,6 +77,30 @@ describe('gitlab client — viewer & paste-URL lookup', () => {
       })
       await expect(getAuthenticatedViewer()).resolves.toBeNull()
     })
+
+    it('pins the lookup to the configured instance', async () => {
+      // Why: an unpinned `glab api user` would identify the user against
+      // whatever host glab infers from cwd/config.
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify({ username: 'alice', email: null })
+      })
+
+      await getAuthenticatedViewer()
+
+      expect(glabExecFileAsyncMock).toHaveBeenCalledWith([
+        'api',
+        '--hostname',
+        'gitlab.com',
+        'user'
+      ])
+    })
+
+    it('fails closed without invoking glab when no instance is configured', async () => {
+      getGlabKnownHostsMock.mockResolvedValue([])
+
+      await expect(getAuthenticatedViewer()).resolves.toBeNull()
+      expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
+    })
   })
 
   describe('getWorkItemByProjectRef', () => {

--- a/src/main/gitlab/client.test.ts
+++ b/src/main/gitlab/client.test.ts
@@ -227,9 +227,31 @@ describe('gitlab client — viewer & paste-URL lookup', () => {
         }
       ])
       expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
-        ['api', 'todos?state=pending&per_page=50'],
+        ['api', '--hostname', 'gitlab.com', 'todos?state=pending&per_page=50'],
         { cwd: '/repo' }
       )
+    })
+
+    it('pins an unresolved local workspace to the configured instance host', async () => {
+      // Why: an unpinned `glab api todos` would target whatever host glab infers
+      // from cwd/config; folder workspaces have no GitLab origin to resolve.
+      getProjectRefMock.mockResolvedValue(null)
+      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+      await expect(listTodos('/repo')).resolves.toEqual([])
+
+      expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
+        ['api', '--hostname', 'gitlab.com', 'todos?state=pending&per_page=50'],
+        { cwd: '/repo' }
+      )
+    })
+
+    it('fails closed without invoking glab when no instance is configured', async () => {
+      getGlabKnownHostsMock.mockResolvedValue([])
+      getProjectRefMock.mockResolvedValue(null)
+
+      await expect(listTodos('/repo')).resolves.toEqual([])
+      expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
     })
 
     it('routes local WSL todos through project resolution and glab execution options', async () => {

--- a/src/main/gitlab/client.test.ts
+++ b/src/main/gitlab/client.test.ts
@@ -241,7 +241,7 @@ describe('gitlab client — viewer & paste-URL lookup', () => {
 
       expect(getProjectRefMock).toHaveBeenCalledWith('/repo', ['gitlab.com'], null, localGitOptions)
       expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
-        ['api', 'todos?state=pending&per_page=50'],
+        ['api', '--hostname', 'gitlab.com', 'todos?state=pending&per_page=50'],
         { cwd: '/repo', wslDistro: 'Ubuntu' }
       )
     })

--- a/src/main/gitlab/configured-instance-host-guard.test.ts
+++ b/src/main/gitlab/configured-instance-host-guard.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { setConfiguredGitLabUrl } from './gitlab-known-host-probe'
+import {
+  assertConfiguredGitLabHost,
+  assertConfiguredProjectRef,
+  resolveConfiguredGitLabHost
+} from './configured-instance-host-guard'
+
+afterEach(() => {
+  setConfiguredGitLabUrl('')
+})
+
+describe('configured GitLab instance host guard', () => {
+  it('rejects every supplied host when no instance is configured', () => {
+    setConfiguredGitLabUrl('')
+
+    expect(resolveConfiguredGitLabHost('gitlab.com')).toEqual({
+      ok: false,
+      reason: 'no GitLab instance is configured'
+    })
+    expect(() => assertConfiguredGitLabHost('gitlab.com')).toThrow(
+      'no GitLab instance is configured'
+    )
+  })
+
+  it('rejects a host that is not the configured instance', () => {
+    setConfiguredGitLabUrl('https://gitlab.example.com')
+
+    expect(() => assertConfiguredGitLabHost('gitlab.evil.test')).toThrow('does not match')
+    // A same-name host on another port is a different endpoint.
+    expect(() => assertConfiguredGitLabHost('gitlab.example.com:8080')).toThrow('does not match')
+    expect(() => assertConfiguredGitLabHost(null)).toThrow('does not match')
+  })
+
+  it('canonicalizes a matching host and project ref', () => {
+    setConfiguredGitLabUrl('https://GitLab.Example.com/')
+
+    expect(assertConfiguredGitLabHost(' GITLAB.example.COM ')).toBe('gitlab.example.com')
+    expect(assertConfiguredProjectRef({ host: 'GitLab.Example.com', path: 'g/p' })).toEqual({
+      host: 'gitlab.example.com',
+      path: 'g/p'
+    })
+  })
+
+  it('passes an absent project ref through so callers keep the resolved-remote path', () => {
+    setConfiguredGitLabUrl('https://gitlab.example.com')
+
+    expect(assertConfiguredProjectRef(null)).toBeNull()
+    expect(assertConfiguredProjectRef(undefined)).toBeUndefined()
+  })
+})

--- a/src/main/gitlab/configured-instance-host-guard.ts
+++ b/src/main/gitlab/configured-instance-host-guard.ts
@@ -1,0 +1,42 @@
+import { getConfiguredGitLabHost } from './gitlab-known-host-probe'
+import { normalizeGitLabHost } from './project-ref-parser'
+
+export type ConfiguredGitLabHostResolution =
+  | { ok: true; host: string }
+  | { ok: false; reason: string }
+
+/**
+ * Pin a caller-supplied host to the one configured instance. A supplied host is
+ * a `glab --hostname` override that bypasses remote resolution entirely, so an
+ * unpinned one would route credentialed calls at an arbitrary GitLab. Returns
+ * the canonical configured host so downstream calls never carry the caller's
+ * spelling. Non-throwing so parse-time boundaries can report their own way.
+ */
+export function resolveConfiguredGitLabHost(
+  host: string | null | undefined
+): ConfiguredGitLabHostResolution {
+  const configured = getConfiguredGitLabHost()
+  if (!configured) {
+    return { ok: false, reason: 'no GitLab instance is configured' }
+  }
+  if (normalizeGitLabHost(host ?? '') !== configured) {
+    return { ok: false, reason: 'GitLab host does not match the configured instance' }
+  }
+  return { ok: true, host: configured }
+}
+
+export function assertConfiguredGitLabHost(host: string | null | undefined): string {
+  const resolution = resolveConfiguredGitLabHost(host)
+  if (!resolution.ok) {
+    throw new Error(`Access denied: ${resolution.reason}`)
+  }
+  return resolution.host
+}
+
+export function assertConfiguredProjectRef<T extends { host: string }>(
+  projectRef: T | null | undefined
+): T | null | undefined {
+  return projectRef
+    ? { ...projectRef, host: assertConfiguredGitLabHost(projectRef.host) }
+    : projectRef
+}

--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -10,6 +10,11 @@ export function setConfiguredGitLabUrl(value: unknown): void {
   configuredGitLabHost = gitLabHostFromUrl(value)
 }
 
+/** The configured instance host (`host[:port]`), or '' when GitLab is off. */
+export function getConfiguredGitLabHost(): string {
+  return configuredGitLabHost
+}
+
 /**
  * The configured GitLab instance, as a single-entry host list, or empty when
  * GitLab is unconfigured. Async and per-host parameters are retained because

--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -1,173 +1,26 @@
-import { runCoalescedProbe, type CoalescedProbes } from '../git/coalesced-probe'
-import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
-import { glabExecFileAsync } from '../git/runner'
-import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
-import { DEFAULT_GITLAB_HOSTS, normalizeGitLabHost } from './project-ref-parser'
-import type { GitAdmissionTier } from '../git/command-runner/git-exec-options'
+import { gitLabHostFromUrl } from '../../shared/gitlab-instance-url'
 
 export type LocalGitExecOptions = {
   wslDistro?: string
-  admissionTier?: GitAdmissionTier
 }
 
-const GLAB_KNOWN_HOSTS_TIMEOUT_MS = 10_000
-const UNAUTHENTICATED_HOSTS_MAX_ENTRIES = 128
-const knownHostsCacheByExecutionContext = new Map<string, readonly string[]>()
-const knownHostsInFlightByExecutionContext: CoalescedProbes<readonly string[]> = new Map()
-const unauthenticatedHostExpiries = new Map<string, number>()
+let configuredGitLabHost = ''
 
-function knownHostsExecutionKey(
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): string {
-  if (connectionId) {
-    // Why: reconnecting can replace the SSH/relay execution host under the same id.
-    return `connection:${connectionId}:${getSshGitProviderGeneration(connectionId)}`
-  }
-  return localGitOptions.wslDistro ? `wsl:${localGitOptions.wslDistro}` : 'native'
-}
-
-/** @internal - exposed for tests only */
-export function _resetKnownHostsCache(): void {
-  knownHostsCacheByExecutionContext.clear()
-  knownHostsInFlightByExecutionContext.clear()
-  unauthenticatedHostExpiries.clear()
-}
-
-/** @internal - exposed for tests only */
-export function _resetGlabUnauthenticatedHosts(): void {
-  unauthenticatedHostExpiries.clear()
-}
-
-function unauthenticatedHostKey(
-  host: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): string {
-  return `${knownHostsExecutionKey(connectionId, localGitOptions)}\0${normalizeGitLabHost(host)}`
+export function setConfiguredGitLabUrl(value: unknown): void {
+  configuredGitLabHost = gitLabHostFromUrl(value)
 }
 
 /**
- * Why: `glab auth status --hostname` is how a self-hosted instance that plain
- * `glab auth status` did not list gets discovered, so a remote that is not
- * GitLab at all runs it too. Project-ref negatives expire now, and without this
- * that becomes one `glab` spawn per repo per interval on the hosted-review poll.
- * The answer is per host, not per repo, and expires on the same clock so a
- * login still lands within an interval.
+ * The configured GitLab instance, as a single-entry host list, or empty when
+ * GitLab is unconfigured. Async and per-host parameters are retained because
+ * callers resolve remotes per execution host; the configured instance is
+ * global, so neither affects the result.
  */
-export function isGlabHostKnownUnauthenticated(
-  host: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): boolean {
-  const key = unauthenticatedHostKey(host, connectionId, localGitOptions)
-  const expiresAt = unauthenticatedHostExpiries.get(key)
-  if (expiresAt === undefined) {
-    return false
-  }
-  if (expiresAt > Date.now()) {
-    return true
-  }
-  unauthenticatedHostExpiries.delete(key)
-  return false
-}
-
-export function rememberGlabHostUnauthenticated(
-  host: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): void {
-  unauthenticatedHostExpiries.set(
-    unauthenticatedHostKey(host, connectionId, localGitOptions),
-    Date.now() + NEGATIVE_ENTRY_TTL_MS
-  )
-  while (unauthenticatedHostExpiries.size > UNAUTHENTICATED_HOSTS_MAX_ENTRIES) {
-    const oldestKey = unauthenticatedHostExpiries.keys().next().value
-    if (oldestKey === undefined) {
-      return
-    }
-    unauthenticatedHostExpiries.delete(oldestKey)
-  }
-}
-
-export function rememberGlabKnownHost(
-  host: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): void {
-  rememberGlabKnownHosts([host], connectionId, localGitOptions)
-}
-
-export function rememberGlabKnownHosts(
-  hosts: readonly string[],
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): void {
-  const key = knownHostsExecutionKey(connectionId, localGitOptions)
-  const cached = knownHostsCacheByExecutionContext.get(key) ?? DEFAULT_GITLAB_HOSTS
-  const seen = new Set(cached.map(normalizeGitLabHost))
-  const additions: string[] = []
-  for (const host of hosts) {
-    const normalizedHost = normalizeGitLabHost(host)
-    if (seen.has(normalizedHost)) {
-      continue
-    }
-    seen.add(normalizedHost)
-    additions.push(normalizedHost)
-    unauthenticatedHostExpiries.delete(
-      unauthenticatedHostKey(normalizedHost, connectionId, localGitOptions)
-    )
-  }
-  if (additions.length === 0) {
-    return
-  }
-  knownHostsCacheByExecutionContext.set(key, [...cached, ...additions])
-}
-
 export async function getGlabKnownHosts(
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
+  _connectionId?: string | null,
+  _localGitOptions: LocalGitExecOptions = {}
 ): Promise<readonly string[]> {
-  const key = knownHostsExecutionKey(connectionId, localGitOptions)
-  const cached = knownHostsCacheByExecutionContext.get(key)
-  if (cached) {
-    return cached
-  }
-  // Why: only join a probe still young enough to answer, so a wedged one cannot
-  // pin every later retry for the life of the process (P1-D).
-  return runCoalescedProbe(knownHostsInFlightByExecutionContext, key, () =>
-    probeGlabKnownHosts(key, connectionId, localGitOptions)
-  )
-}
-
-async function probeGlabKnownHosts(
-  key: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): Promise<readonly string[]> {
-  try {
-    // Why: auth config belongs to the executing host; do not share native, WSL,
-    // or reconnected SSH/relay results, and bound an otherwise global probe.
-    const { stdout, stderr } = await glabExecFileAsync(['auth', 'status'], {
-      timeout: GLAB_KNOWN_HOSTS_TIMEOUT_MS,
-      // Why: a local probe would cache the default distro's auth under 'native'
-      // and wake an idle VM. A connection-keyed probe keeps the retry — glab never
-      // runs over SSH/relay, so the calls it gates take that same fallback.
-      ...(connectionId ? {} : { allowDefaultWslFallback: false }),
-      ...(!connectionId && localGitOptions.wslDistro
-        ? { wslDistro: localGitOptions.wslDistro }
-        : {}),
-      ...(localGitOptions.admissionTier ? { admissionTier: localGitOptions.admissionTier } : {})
-    })
-    const hosts = parseGlabAuthStatusHosts(`${stdout}\n${stderr}`)
-    const remembered = knownHostsCacheByExecutionContext.get(key) ?? []
-    const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...remembered, ...hosts]))
-    knownHostsCacheByExecutionContext.set(key, merged)
-    return merged
-  } catch {
-    // Keep failures uncached so auth or tunnel recovery is discovered later.
-    return knownHostsCacheByExecutionContext.get(key) ?? [...DEFAULT_GITLAB_HOSTS]
-  }
+  return configuredGitLabHost ? [configuredGitLabHost] : []
 }
 
 export function parseGlabAuthStatusHosts(output: string): string[] {

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -1,46 +1,26 @@
-import { glabExecFileAsync } from '../git/runner'
-import type { GitAdmissionTier } from '../git/command-runner/git-exec-options'
-import { isTransientGitProbeError, readRemoteUrl } from '../git/remote-url-probe'
-import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
-import { getSshGitProviderGeneration } from '../providers/ssh-git-dispatch'
-import type { IssueSourcePreference } from '../../shared/repo-types'
+import { gitExecFileAsync } from '../git/runner'
+import type { IssueSourcePreference } from '../../shared/types'
+import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
-import {
-  _resetGlabUnauthenticatedHosts,
-  isGlabHostKnownUnauthenticated,
-  parseGlabAuthStatusHosts,
-  rememberGlabHostUnauthenticated,
-  rememberGlabKnownHost,
-  type LocalGitExecOptions
-} from './gitlab-known-host-probe'
-import {
-  DEFAULT_GITLAB_HOSTS,
-  normalizeGitLabHost,
-  parseGitLabProjectRef,
-  parseRemoteProjectRefCandidate,
-  type ProjectRef
-} from './project-ref-parser'
+import type { LocalGitExecOptions } from './gitlab-known-host-probe'
+import { DEFAULT_GITLAB_HOSTS, parseGitLabProjectRef, type ProjectRef } from './project-ref-parser'
 
 export { DEFAULT_GITLAB_HOSTS, parseGitLabProjectRef }
 export type { ProjectRef }
 export {
-  _resetKnownHostsCache,
   getGlabKnownHosts,
-  parseGlabAuthStatusHosts
+  parseGlabAuthStatusHosts,
+  setConfiguredGitLabUrl
 } from './gitlab-known-host-probe'
 export type { LocalGitExecOptions } from './gitlab-known-host-probe'
 
 const PROJECT_REF_CACHE_MAX_ENTRIES = 512
-
-type CachedProjectRef = { value: ProjectRef | null; expiresAt: number }
-
-const projectRefCache = new Map<string, CachedProjectRef>()
+const projectRefCache = new Map<string, ProjectRef | null>()
 
 /** @internal - exposed for tests only */
 export function _resetProjectRefCache(): void {
   projectRefCache.clear()
   clearProjectRefInFlight()
-  _resetGlabUnauthenticatedHosts()
 }
 
 /** @internal - exposed for tests only */
@@ -49,14 +29,7 @@ export function _getProjectRefCacheSize(): number {
 }
 
 function rememberProjectRefCacheEntry(cacheKey: string, value: ProjectRef | null): void {
-  // Why: "not GitLab" only holds until someone configures `origin` or logs into
-  // `glab` — a repo probed before either kept hosted-review detection stale for
-  // the life of the process. Negatives expire the way every other forge's do;
-  // positives still stay (see `createRemoteRefProbeCache`).
-  projectRefCache.set(cacheKey, {
-    value,
-    expiresAt: value === null ? Date.now() + NEGATIVE_ENTRY_TTL_MS : Number.POSITIVE_INFINITY
-  })
+  projectRefCache.set(cacheKey, value)
   while (projectRefCache.size > PROJECT_REF_CACHE_MAX_ENTRIES) {
     const oldestKey = projectRefCache.keys().next().value
     if (oldestKey === undefined) {
@@ -73,30 +46,19 @@ export async function getProjectRefForRemote(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ProjectRef | null> {
-  // Why: a reconnect replaces the host an answer came from under the same id, so
-  // the generation is part of the signature; `knownHosts` carries the glab auth
-  // state, so logging into a self-hosted instance re-asks rather than reusing a
-  // ref resolved while that host was unknown.
-  const runtimeKey = connectionId
-    ? `${connectionId}:${getSshGitProviderGeneration(connectionId)}`
-    : `local:${localGitOptions.wslDistro ?? 'host'}`
+  const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
   const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}\0${knownHosts.join(',')}`
-  const cached = projectRefCache.get(cacheKey)
-  if (cached) {
-    if (cached.expiresAt > Date.now()) {
-      return cached.value
-    }
-    projectRefCache.delete(cacheKey)
+  if (projectRefCache.has(cacheKey)) {
+    return projectRefCache.get(cacheKey)!
   }
 
-  return runProjectRefProbeOnce(cacheKey, (ownsKey) =>
+  return runProjectRefProbeOnce(cacheKey, () =>
     resolveProjectRefForRemote(
       repoPath,
       remoteName,
       knownHosts,
       connectionId,
       cacheKey,
-      ownsKey,
       localGitOptions
     )
   )
@@ -108,60 +70,30 @@ async function resolveProjectRefForRemote(
   knownHosts: readonly string[],
   connectionId: string | null | undefined,
   cacheKey: string,
-  ownsKey: () => boolean,
   localGitOptions: LocalGitExecOptions
 ): Promise<ProjectRef | null> {
-  // Why: a probe abandoned as stale still runs, and the repo state it read is
-  // older than whatever its successor already published. It may answer its own
-  // callers; it may not overwrite the cache.
-  const publish = (value: ProjectRef | null): void => {
-    if (ownsKey()) {
-      rememberProjectRefCacheEntry(cacheKey, value)
-    }
-  }
   try {
-    const stdout = await readRemoteUrl(
-      {
-        repoPath,
-        connectionId,
-        ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
-        ...(localGitOptions.admissionTier ? { admissionTier: localGitOptions.admissionTier } : {})
-      },
-      remoteName
-    )
-    if (stdout === null) {
+    const sshGitProvider = connectionId ? getSshGitProvider(connectionId) : null
+    if (connectionId && !sshGitProvider) {
       return null
     }
+    const { stdout } = sshGitProvider
+      ? await sshGitProvider.exec(['remote', 'get-url', remoteName], repoPath)
+      : await gitExecFileAsync(['remote', 'get-url', remoteName], {
+          cwd: repoPath,
+          ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+        })
     const result = parseGitLabProjectRef(stdout, knownHosts)
     if (result) {
-      publish(result)
+      rememberProjectRefCacheEntry(cacheKey, result)
       return result
     }
-    const remoteCandidate = parseRemoteProjectRefCandidate(stdout)
-    if (
-      remoteCandidate &&
-      (await isGlabConfiguredForRemoteHost(
-        repoPath,
-        remoteCandidate,
-        connectionId,
-        localGitOptions
-      ))
-    ) {
-      rememberGlabKnownHost(remoteCandidate.host, connectionId, localGitOptions)
-      publish(remoteCandidate)
-      return remoteCandidate
-    }
-  } catch (error) {
-    // Why: a wedged or killed probe is not evidence the remote is not GitLab —
-    // caching it would misdetect the forge until the negative expires (P1-D).
-    // SSH failures stay uncached outright rather than adopting the generic
-    // cache's stable-missing-remote exception: keeping a connected host's
-    // detection fresh is worth the extra probe.
-    if (connectionId || isTransientGitProbeError(error)) {
+  } catch {
+    if (connectionId) {
       return null
     }
   }
-  publish(null)
+  rememberProjectRefCacheEntry(cacheKey, null)
   return null
 }
 
@@ -248,56 +180,20 @@ export function glabRepoExecOptions(
   repoPath: string,
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
-): { cwd?: string; wslDistro?: string; admissionTier?: GitAdmissionTier } {
+): { cwd?: string; wslDistro?: string } {
   return connectionId
     ? {}
     : {
         cwd: repoPath,
-        ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
-        ...(localGitOptions.admissionTier ? { admissionTier: localGitOptions.admissionTier } : {})
+        ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
       }
 }
 
 export function glabHostnameArgs(
   projectRef: Pick<ProjectRef, 'host'> | null | undefined,
-  connectionId?: string | null
+  _connectionId?: string | null
 ): string[] {
-  return connectionId && projectRef?.host ? ['--hostname', projectRef.host] : []
-}
-
-async function isGlabConfiguredForRemoteHost(
-  repoPath: string,
-  projectRef: Pick<ProjectRef, 'host'>,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
-): Promise<boolean> {
-  // Why: this probe is per host, but the project-ref miss that reaches it is per
-  // repo — without the memo, every non-GitLab repo re-spawns `glab` each time
-  // its negative expires.
-  if (isGlabHostKnownUnauthenticated(projectRef.host, connectionId, localGitOptions)) {
-    return false
-  }
-  try {
-    const result = await glabExecFileAsync(
-      ['auth', 'status', '--hostname', projectRef.host],
-      glabRepoExecOptions(repoPath, connectionId, localGitOptions)
-    )
-    if (result === undefined) {
-      rememberGlabHostUnauthenticated(projectRef.host, connectionId, localGitOptions)
-      return false
-    }
-    return true
-  } catch (error) {
-    const execLike = error as { stdout?: unknown; stderr?: unknown; message?: unknown }
-    const output =
-      [execLike.stdout, execLike.stderr, execLike.message]
-        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-        .join('\n') || String(error)
-    const hosts = parseGlabAuthStatusHosts(output).map(normalizeGitLabHost)
-    if (hosts.includes(normalizeGitLabHost(projectRef.host))) {
-      return true
-    }
-    rememberGlabHostUnauthenticated(projectRef.host, connectionId, localGitOptions)
-    return false
-  }
+  // Why: cwd inference is ambiguous when glab has multiple authenticated hosts;
+  // route every resolved project explicitly, including local and WSL repos.
+  return projectRef?.host ? ['--hostname', projectRef.host] : []
 }

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -1,5 +1,5 @@
 import { gitExecFileAsync } from '../git/runner'
-import type { IssueSourcePreference } from '../../shared/types'
+import type { IssueSourcePreference } from '../../shared/repo-types'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
 import type { LocalGitExecOptions } from './gitlab-known-host-probe'

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -15,38 +15,28 @@ import {
   _getProjectRefCacheSize,
   _resetProjectRefCache,
   classifyGlabError,
-  classifyJobLogError,
-  classifyListFetchError,
   classifyListIssuesError,
-  acquire,
-  release,
-  GITLAB_ADMISSION_TIMEOUT_MS,
   getIssueProjectRef,
-  parseGlabJsonList,
-  parseGlabPaginationHeader,
-  isMissingJobLogError,
+  getGlabKnownHosts,
   getProjectRef,
   getProjectRefForRemote,
+  glabHostnameArgs,
   parseGlabApiResponse,
   parseGlabAuthStatusHosts,
-  resolveIssueSource
+  resolveIssueSource,
+  setConfiguredGitLabUrl
 } from './gl-utils'
-import { GlabNonListResponseError } from './glab-api-response'
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
-import { REMOTE_URL_PROBE_TIMEOUT_MS } from '../git/remote-url-probe'
-import { NEGATIVE_ENTRY_TTL_MS } from '../git/remote-ref-probe-cache'
 
 describe('gitlab project ref resolution', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
-    glabExecFileAsyncMock.mockReset()
     sshExecMock.mockReset()
     unregisterSshGitProvider('conn-1')
     _resetProjectRefCache()
   })
 
   afterEach(() => {
-    vi.useRealTimers()
     unregisterSshGitProvider('conn-1')
   })
 
@@ -60,8 +50,7 @@ describe('gitlab project ref resolution', () => {
       path: 'fork/orca'
     })
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
-      cwd: '/repo',
-      timeout: REMOTE_URL_PROBE_TIMEOUT_MS
+      cwd: '/repo'
     })
   })
 
@@ -75,8 +64,7 @@ describe('gitlab project ref resolution', () => {
       path: 'stablyai/orca'
     })
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'upstream'], {
-      cwd: '/repo',
-      timeout: REMOTE_URL_PROBE_TIMEOUT_MS
+      cwd: '/repo'
     })
   })
 
@@ -130,13 +118,11 @@ describe('gitlab project ref resolution', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['remote', 'get-url', 'origin'], {
-      cwd: '/repo',
-      timeout: REMOTE_URL_PROBE_TIMEOUT_MS
+      cwd: '/repo'
     })
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['remote', 'get-url', 'origin'], {
       cwd: '/repo',
-      wslDistro: 'Ubuntu',
-      timeout: REMOTE_URL_PROBE_TIMEOUT_MS
+      wslDistro: 'Ubuntu'
     })
   })
 
@@ -157,8 +143,7 @@ describe('gitlab project ref resolution', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'upstream'], {
-      cwd: '/repo',
-      timeout: REMOTE_URL_PROBE_TIMEOUT_MS
+      cwd: '/repo'
     })
 
     await expect(getProjectRefForRemote('/repo', 'upstream')).resolves.toBeNull()
@@ -174,9 +159,7 @@ describe('gitlab project ref resolution', () => {
       path: 'remote/orca'
     })
 
-    expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo', {
-      signal: expect.any(AbortSignal)
-    })
+    expect(sshExecMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], '/repo')
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
@@ -219,135 +202,6 @@ describe('gitlab project ref resolution', () => {
       host: 'gitlab.com',
       path: 'remote/orca'
     })
-  })
-
-  it('does not cache a local probe killed on its deadline as a definitive miss', async () => {
-    gitExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('git timed out.'))
-      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:fork/orca.git\n' })
-
-    await expect(getProjectRef('/repo')).resolves.toBeNull()
-    await expect(getProjectRef('/repo')).resolves.toEqual({
-      host: 'gitlab.com',
-      path: 'fork/orca'
-    })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
-  })
-
-  it('re-probes a repo whose GitLab remote could have been added since the miss', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(1_000_000)
-    gitExecFileAsyncMock.mockRejectedValueOnce(new Error("error: No such remote 'origin'"))
-
-    await expect(getProjectRef('/repo')).resolves.toBeNull()
-    await expect(getProjectRef('/repo')).resolves.toBeNull()
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
-
-    // Nothing watches `.git/config`, and SSH/WSL repos have no file to watch, so
-    // a remote configured after the miss is only visible once the negative ages out.
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.com:fork/orca.git\n' })
-    vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS + 1)
-
-    await expect(getProjectRef('/repo')).resolves.toEqual({
-      host: 'gitlab.com',
-      path: 'fork/orca'
-    })
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
-  })
-
-  it('keeps a resolved project ref past the negative interval', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(1_000_000)
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.com:fork/orca.git\n' })
-
-    await expect(getProjectRef('/repo')).resolves.toEqual({
-      host: 'gitlab.com',
-      path: 'fork/orca'
-    })
-    vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS * 10)
-    await expect(getProjectRef('/repo')).resolves.toEqual({
-      host: 'gitlab.com',
-      path: 'fork/orca'
-    })
-
-    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('re-resolves a self-hosted remote once glab auth knows its host', async () => {
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@gitlab.internal:team/orca.git\n' })
-    glabExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
-
-    await expect(getProjectRefForRemote('/repo', 'origin', ['gitlab.com'])).resolves.toBeNull()
-    await expect(
-      getProjectRefForRemote('/repo', 'origin', ['gitlab.com', 'gitlab.internal'])
-    ).resolves.toEqual({ host: 'gitlab.internal', path: 'team/orca' })
-  })
-
-  it('asks glab about an unauthenticated host once per interval, not once per repo', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(1_000_000)
-    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'git@github.com:team/orca.git\n' })
-    glabExecFileAsyncMock.mockRejectedValue(new Error('not authenticated'))
-
-    // Expiring project-ref negatives must not turn the hosted-review poll into a
-    // `glab auth status` spawn per repo per interval — the answer is per host.
-    for (const repoPath of ['/repo-a', '/repo-b', '/repo-c']) {
-      await expect(getProjectRef(repoPath)).resolves.toBeNull()
-    }
-    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
-
-    vi.setSystemTime(1_000_000 + NEGATIVE_ENTRY_TTL_MS + 1)
-    for (const repoPath of ['/repo-a', '/repo-b', '/repo-c']) {
-      await expect(getProjectRef(repoPath)).resolves.toBeNull()
-    }
-    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
-  })
-
-  it('does not serve a project ref resolved on a retired SSH connection', async () => {
-    sshExecMock
-      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:before/orca.git\n', stderr: '' })
-      .mockResolvedValueOnce({ stdout: 'git@gitlab.com:after/orca.git\n', stderr: '' })
-    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
-
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
-      host: 'gitlab.com',
-      path: 'before/orca'
-    })
-
-    // A reconnect can swap the execution host under the same connection id.
-    unregisterSshGitProvider('conn-1')
-    registerSshGitProvider('conn-1', { exec: sshExecMock } as never)
-
-    await expect(getProjectRefForRemote('/repo', 'origin', undefined, 'conn-1')).resolves.toEqual({
-      host: 'gitlab.com',
-      path: 'after/orca'
-    })
-    expect(sshExecMock).toHaveBeenCalledTimes(2)
-  })
-})
-
-describe('GitLab operation admission', () => {
-  afterEach(() => {
-    vi.useRealTimers()
-    // Drain any slots held by the saturation test before the next test.
-    for (let i = 0; i < 4; i += 1) {
-      release()
-    }
-  })
-
-  it('expires queued work instead of retaining it behind saturated operations', async () => {
-    vi.useFakeTimers()
-    await Promise.all(Array.from({ length: 4 }, () => acquire()))
-
-    const queued = acquire()
-    const rejection = expect(queued).rejects.toThrow(
-      'Timed out waiting for a GitLab operation slot.'
-    )
-    await vi.advanceTimersByTimeAsync(GITLAB_ADMISSION_TIMEOUT_MS)
-    await rejection
-
-    release()
-    await expect(acquire()).resolves.toBeUndefined()
   })
 })
 
@@ -401,8 +255,7 @@ describe('resolveIssueSource', () => {
     })
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'get-url', 'origin'], {
-      cwd: '/repo',
-      timeout: REMOTE_URL_PROBE_TIMEOUT_MS
+      cwd: '/repo'
     })
   })
 
@@ -452,17 +305,18 @@ describe('glab error classification', () => {
     expect(classifyListIssuesError('HTTP 403').message).toMatch(/permission to read issues/i)
     expect(classifyListIssuesError('HTTP 404').message).toBe('Project not found.')
   })
+})
 
-  it('rewrites issue-edit copy for job logs via classifyJobLogError', () => {
-    expect(classifyJobLogError('HTTP 403').message).toMatch(/permission to read this job's log/i)
-    expect(classifyJobLogError('HTTP 403').message).not.toMatch(/issue/i)
-    expect(classifyJobLogError('boom').message).toBe('Failed to load the job log: boom')
+describe('glab hostname routing', () => {
+  it('routes local and remote project operations to the resolved self-hosted instance', () => {
+    const projectRef = { host: 'gitlab.internal', path: 'team/orca' }
+
+    expect(glabHostnameArgs(projectRef)).toEqual(['--hostname', 'gitlab.internal'])
+    expect(glabHostnameArgs(projectRef, 'conn-1')).toEqual(['--hostname', 'gitlab.internal'])
   })
 
-  it('treats a 404 job log as missing, but keeps a missing project an error', () => {
-    expect(isMissingJobLogError('HTTP 404 Not Found')).toBe(true)
-    expect(isMissingJobLogError('HTTP 404: Project Not Found')).toBe(false)
-    expect(isMissingJobLogError('HTTP 403 Forbidden')).toBe(false)
+  it('omits hostname only when no project was resolved', () => {
+    expect(glabHostnameArgs(null)).toEqual([])
   })
 })
 
@@ -530,69 +384,6 @@ gitlab.example.com:8080:
   })
 })
 
-describe('parseGlabJsonList', () => {
-  it('returns the parsed list unchanged', () => {
-    expect(parseGlabJsonList<{ iid: number }>('[{"iid":1}]')).toEqual([{ iid: 1 }])
-  })
-
-  it.each([
-    ['null', 'null'],
-    ['a number', '0'],
-    ['a string', '"nope"'],
-    ['an object', '{"data":[]}']
-  ])('reports the raw payload for %s as an unclassifiable body', (_label, payload) => {
-    expect(() => parseGlabJsonList(payload)).toThrow(GlabNonListResponseError)
-    expect(() => parseGlabJsonList(payload)).toThrow(payload)
-  })
-
-  // Why: glab allows a 10MB body, and the renderer's error banner has no length guard of its own.
-  it.each([
-    ['an opaque body', `{"data":"${'x'.repeat(50_000)}"}`],
-    ['an error envelope', `{"message":"${'x'.repeat(50_000)}"}`]
-  ])('bounds the reported payload for %s', (_label, payload) => {
-    expect(() => parseGlabJsonList(payload)).toThrow(
-      /^GitLab returned (?:a non-list response|an error): .{300}$/
-    )
-  })
-
-  it.each([
-    ['message', '{"message":"403 Forbidden"}', '403 Forbidden'],
-    ['error', '{"error":"insufficient_scope"}', 'insufficient_scope'],
-    ['error when message is blank', '{"message":"  ","error":"real_error"}', 'real_error'],
-    // Why: GitLab sends both on some endpoints; `message` is the human-facing one.
-    [
-      'message when both are set',
-      '{"message":"404 Project Not Found","error":"insufficient_scope"}',
-      '404 Project Not Found'
-    ]
-  ])('reports a GitLab error envelope by its %s field', (_label, payload, reported) => {
-    // Why: an envelope is GitLab's own diagnostic, so it stays classifiable — unlike a raw body.
-    expect(() => parseGlabJsonList(payload)).toThrow(`GitLab returned an error: ${reported}`)
-    expect(() => parseGlabJsonList(payload)).not.toThrow(GlabNonListResponseError)
-  })
-})
-
-describe('classifyListFetchError', () => {
-  it('keeps opaque payload text away from the classifier', () => {
-    // Why: the title would otherwise substring-match as a network failure and replace the payload.
-    const payload = '{"data":[{"title":"fix network timeout"}]}'
-    let thrown: unknown
-    try {
-      parseGlabJsonList(payload)
-    } catch (err) {
-      thrown = err
-    }
-    expect(thrown).toBeInstanceOf(GlabNonListResponseError)
-    const classified = classifyListFetchError(thrown)
-    expect(classified.type).toBe('unknown')
-    expect(classified.message).toContain('fix network timeout')
-  })
-
-  it('still classifies ordinary glab failures by their stderr', () => {
-    expect(classifyListFetchError(new Error('HTTP 403 Forbidden')).type).toBe('permission_denied')
-  })
-})
-
 describe('parseGlabApiResponse', () => {
   it('splits headers and body at the first blank line (LF)', () => {
     const stdout = 'HTTP/2.0 200 OK\nX-Total: 42\nX-Total-Pages: 3\n\n[{"iid":1}]'
@@ -644,23 +435,20 @@ describe('parseGlabApiResponse', () => {
   })
 })
 
-describe('parseGlabPaginationHeader', () => {
-  it('reads a usable header value', () => {
-    expect(parseGlabPaginationHeader('25', 1)).toBe(25)
-    expect(parseGlabPaginationHeader(' 9 ', 1)).toBe(9)
+describe('getGlabKnownHosts', () => {
+  it('does not resolve a GitLab host until one is configured', async () => {
+    setConfiguredGitLabUrl('')
+
+    await expect(getGlabKnownHosts()).resolves.toEqual([])
+    expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
-  it('returns undefined for an absent or unparseable header', () => {
-    expect(parseGlabPaginationHeader(undefined, 0)).toBeUndefined()
-    expect(parseGlabPaginationHeader('', 0)).toBeUndefined()
-    expect(parseGlabPaginationHeader('abc', 0)).toBeUndefined()
-  })
+  it('reports the configured instance, port included, and drops it when cleared', async () => {
+    setConfiguredGitLabUrl('https://gitlab.example.com:8443')
+    await expect(getGlabKnownHosts()).resolves.toEqual(['gitlab.example.com:8443'])
 
-  // Why: the minimum is what lets issues.ts tell "x-total: 0" (derive one page) apart from an
-  // absent header (probe for a next page), and what makes x-total-pages: 0 fall through.
-  it('rejects values below the minimum', () => {
-    expect(parseGlabPaginationHeader('0', 1)).toBeUndefined()
-    expect(parseGlabPaginationHeader('0', 0)).toBe(0)
-    expect(parseGlabPaginationHeader('-3', 0)).toBeUndefined()
+    setConfiguredGitLabUrl('not a url')
+    await expect(getGlabKnownHosts()).resolves.toEqual([])
+    expect(glabExecFileAsyncMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -12,7 +12,6 @@ export {
 export {
   DEFAULT_GITLAB_HOSTS,
   _getProjectRefCacheSize,
-  _resetKnownHostsCache,
   _resetProjectRefCache,
   getGlabKnownHosts,
   getIssueProjectRef,
@@ -22,7 +21,8 @@ export {
   glabRepoExecOptions,
   parseGlabAuthStatusHosts,
   parseGitLabProjectRef,
-  resolveIssueSource
+  resolveIssueSource,
+  setConfiguredGitLabUrl
 } from './gitlab-project-ref-resolution'
 export type {
   LocalGitExecOptions,

--- a/src/main/gitlab/issues.test.ts
+++ b/src/main/gitlab/issues.test.ts
@@ -3,7 +3,6 @@ import type * as GlUtils from './gl-utils'
 
 const {
   glabExecFileAsyncMock,
-  glabApiWithHeadersMock,
   getIssueProjectRefMock,
   resolveIssueSourceMock,
   getGlabKnownHostsMock,
@@ -11,7 +10,6 @@ const {
   releaseMock
 } = vi.hoisted(() => ({
   glabExecFileAsyncMock: vi.fn(),
-  glabApiWithHeadersMock: vi.fn(),
   getIssueProjectRefMock: vi.fn(),
   resolveIssueSourceMock: vi.fn(),
   getGlabKnownHostsMock: vi.fn(),
@@ -24,7 +22,6 @@ vi.mock('./gl-utils', async () => {
   return {
     ...actual,
     glabExecFileAsync: glabExecFileAsyncMock,
-    glabApiWithHeaders: glabApiWithHeadersMock,
     getIssueProjectRef: getIssueProjectRefMock,
     resolveIssueSource: resolveIssueSourceMock,
     getGlabKnownHosts: getGlabKnownHostsMock,
@@ -33,14 +30,19 @@ vi.mock('./gl-utils', async () => {
   }
 })
 
-import { addIssueComment, createIssue, getIssue, listIssues } from './issues'
-import { updateIssue } from './issue-update'
-import { listAssignableUsers, listLabels } from './project-label-and-member-lookup'
+import {
+  addIssueComment,
+  createIssue,
+  getIssue,
+  listAssignableUsers,
+  listIssues,
+  listLabels,
+  updateIssue
+} from './issues'
 
 describe('gitlab issue operations', () => {
   beforeEach(() => {
     glabExecFileAsyncMock.mockReset()
-    glabApiWithHeadersMock.mockReset()
     getIssueProjectRefMock.mockReset()
     resolveIssueSourceMock.mockReset()
     getGlabKnownHostsMock.mockReset()
@@ -68,7 +70,7 @@ describe('gitlab issue operations', () => {
 
     await expect(getIssue('/repo-root', 923)).resolves.toMatchObject({ number: 923 })
     expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
-      ['api', 'projects/stablyai%2Forca/issues/923'],
+      ['api', '--hostname', 'gitlab.com', 'projects/stablyai%2Forca/issues/923'],
       { cwd: '/repo-root' }
     )
   })
@@ -90,6 +92,7 @@ describe('gitlab issue operations', () => {
           labels: []
         })
       })
+      .mockResolvedValueOnce({ stdout: '[]' })
       .mockResolvedValueOnce({
         stdout: JSON.stringify({
           iid: 924,
@@ -107,7 +110,6 @@ describe('gitlab issue operations', () => {
       })
       .mockResolvedValueOnce({ stdout: 'bug\nfrontend\n' })
       .mockResolvedValueOnce({ stdout: '{"id":1,"username":"octo","avatar_url":""}\n' })
-    glabApiWithHeadersMock.mockResolvedValueOnce({ body: '[]', headers: {} })
 
     await getIssue('/repo-root', 923, null, localGitOptions)
     await listIssues('/repo-root', 5, undefined, 'opened', undefined, null, localGitOptions)
@@ -141,12 +143,6 @@ describe('gitlab issue operations', () => {
     expect(glabExecFileAsyncMock.mock.calls.every((call) => call[1]?.wslDistro === 'Ubuntu')).toBe(
       true
     )
-    expect(glabApiWithHeadersMock).toHaveBeenCalledWith(
-      [
-        'projects/stablyai%2Forca/issues?page=1&per_page=5&order_by=updated_at&sort=desc&state=opened'
-      ],
-      { cwd: '/repo-root', ...localGitOptions }
-    )
   })
 
   it('encodes nested group paths', async () => {
@@ -160,100 +156,31 @@ describe('gitlab issue operations', () => {
 
     await getIssue('/repo-root', 1)
     expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
-      ['api', 'projects/group%2Fsubgroup%2Fproject/issues/1'],
+      ['api', '--hostname', 'gitlab.com', 'projects/group%2Fsubgroup%2Fproject/issues/1'],
       { cwd: '/repo-root' }
     )
   })
 
   it('lists issues with state=opened ordering', async () => {
     getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
-    glabApiWithHeadersMock.mockResolvedValueOnce({
-      body: '[]',
-      headers: { 'x-total': '123', 'x-total-pages': '25' }
-    })
+    glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
 
-    await expect(listIssues('/repo-root', 5)).resolves.toEqual({ items: [], totalPages: 25 })
+    await expect(listIssues('/repo-root', 5)).resolves.toEqual({ items: [] })
 
-    expect(glabApiWithHeadersMock).toHaveBeenCalledWith(
+    expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
       [
-        'projects/stablyai%2Forca/issues?page=1&per_page=5&order_by=updated_at&sort=desc&state=opened'
+        'api',
+        '--hostname',
+        'gitlab.com',
+        'projects/stablyai%2Forca/issues?per_page=5&order_by=updated_at&sort=desc&state=opened'
       ],
       { cwd: '/repo-root' }
     )
-  })
-
-  it('forwards an explicit page into the issues API path after localGitOptions', async () => {
-    getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
-    glabApiWithHeadersMock.mockResolvedValueOnce({ body: '[]', headers: {} })
-
-    await expect(
-      listIssues('/repo-root', 50, undefined, 'opened', undefined, null, {}, 3)
-    ).resolves.toMatchObject({ totalPages: 3 })
-
-    expect(glabApiWithHeadersMock).toHaveBeenCalledWith(
-      [
-        'projects/stablyai%2Forca/issues?page=3&per_page=50&order_by=updated_at&sort=desc&state=opened'
-      ],
-      { cwd: '/repo-root' }
-    )
-  })
-
-  it('derives total pages from x-total when x-total-pages is unavailable', async () => {
-    getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
-    glabApiWithHeadersMock.mockResolvedValueOnce({ body: '[]', headers: { 'x-total': '11' } })
-
-    await expect(listIssues('/repo-root', 5)).resolves.toMatchObject({ totalPages: 3 })
-  })
-
-  it('keeps a next-page probe when a proxy strips pagination headers', async () => {
-    getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
-    glabApiWithHeadersMock.mockResolvedValueOnce({
-      body: JSON.stringify(
-        Array.from({ length: 5 }, (_, index) => ({
-          iid: index + 1,
-          title: `Issue ${index + 1}`,
-          state: 'opened',
-          web_url: `https://gitlab.com/stablyai/orca/-/issues/${index + 1}`,
-          labels: []
-        }))
-      ),
-      headers: {}
-    })
-
-    await expect(listIssues('/repo-root', 5)).resolves.toMatchObject({ totalPages: 2 })
   })
 
   it('surfaces a permission_denied error instead of collapsing to empty', async () => {
     getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
-    glabApiWithHeadersMock.mockRejectedValueOnce(new Error('HTTP 403 Forbidden'))
-
-    const result = await listIssues('/repo-root', 5)
-
-    expect(result.items).toEqual([])
-    expect(result.error?.type).toBe('permission_denied')
-  })
-
-  it('reports the body instead of ".map is not a function" when the API returns a non-array', async () => {
-    getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
-    glabApiWithHeadersMock.mockResolvedValueOnce({
-      body: JSON.stringify({ data: [], total: 0 }),
-      headers: {}
-    })
-
-    const result = await listIssues('/repo-root', 5)
-
-    expect(result.items).toEqual([])
-    expect(result.error?.type).toBe('unknown')
-    expect(result.error?.message).toContain('{"data":[],"total":0}')
-    expect(result.error?.message).not.toContain('is not a function')
-  })
-
-  it('reports a GitLab error envelope by its own message', async () => {
-    getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
-    glabApiWithHeadersMock.mockResolvedValueOnce({
-      body: JSON.stringify({ message: '403 Forbidden' }),
-      headers: {}
-    })
+    glabExecFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 403 Forbidden'))
 
     const result = await listIssues('/repo-root', 5)
 
@@ -285,7 +212,7 @@ describe('gitlab issue operations', () => {
 
   it('threads connectionId into getGlabKnownHosts for listIssues', async () => {
     getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
-    glabApiWithHeadersMock.mockResolvedValueOnce({ body: '[]', headers: {} })
+    glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
 
     await listIssues('/repo-root', 5, undefined, 'opened', undefined, 'conn-7')
 
@@ -309,6 +236,8 @@ describe('gitlab issue operations', () => {
     expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'api',
+        '--hostname',
+        'gitlab.com',
         '-X',
         'POST',
         'projects/stablyai%2Forca/issues',
@@ -335,7 +264,7 @@ describe('gitlab issue operations', () => {
 
     await expect(updateIssue('/repo-root', 5, { state: 'closed' })).resolves.toEqual({ ok: true })
     expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
-      ['issue', 'close', '5', '-R', 'stablyai/orca'],
+      ['issue', 'close', '5', '-R', 'stablyai/orca', '--hostname', 'gitlab.com'],
       { cwd: '/repo-root' }
     )
   })
@@ -368,6 +297,8 @@ describe('gitlab issue operations', () => {
         '5',
         '-R',
         'stablyai/orca',
+        '--hostname',
+        'gitlab.com',
         '--title',
         'Renamed',
         '--label',
@@ -392,7 +323,16 @@ describe('gitlab issue operations', () => {
     })
 
     expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
-      ['api', '-X', 'PUT', 'projects/stablyai%2Forca/issues/5', '-f', 'description=Updated body'],
+      [
+        'api',
+        '--hostname',
+        'gitlab.com',
+        '-X',
+        'PUT',
+        'projects/stablyai%2Forca/issues/5',
+        '-f',
+        'description=Updated body'
+      ],
       { cwd: '/repo-root' }
     )
   })
@@ -467,7 +407,16 @@ describe('gitlab issue operations', () => {
       }
     })
     expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
-      ['api', '-X', 'POST', 'projects/stablyai%2Forca/issues/5/notes', '-f', 'body=Hello'],
+      [
+        'api',
+        '--hostname',
+        'gitlab.com',
+        '-X',
+        'POST',
+        'projects/stablyai%2Forca/issues/5/notes',
+        '-f',
+        'body=Hello'
+      ],
       { cwd: '/repo-root' }
     )
   })

--- a/src/main/gitlab/project-ref-parser.test.ts
+++ b/src/main/gitlab/project-ref-parser.test.ts
@@ -1,27 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import {
-  gitLabHostFromUrl,
-  normalizeGitLabUrl,
-  parseGitLabProjectRef,
-  parseRemoteProjectRefCandidate
-} from './project-ref-parser'
-
-describe('GitLab instance setting', () => {
-  it('normalizes configured URLs and preserves non-default ports', () => {
-    expect(normalizeGitLabUrl('  HTTPS://GitLab.Example.com:8443/// ')).toBe(
-      'https://gitlab.example.com:8443'
-    )
-    expect(gitLabHostFromUrl('https://gitlab.example.com:8443')).toBe(
-      'gitlab.example.com:8443'
-    )
-  })
-
-  it('rejects invalid or credential-bearing URLs without selecting a host', () => {
-    expect(normalizeGitLabUrl('not a url')).toBe('')
-    expect(normalizeGitLabUrl('https://token@gitlab.example.com')).toBe('')
-    expect(gitLabHostFromUrl('')).toBe('')
-  })
-})
+import { gitLabHostFromUrl } from '../../shared/gitlab-instance-url'
+import { parseGitLabProjectRef, parseRemoteProjectRefCandidate } from './project-ref-parser'
 
 describe('gitlab project ref parsing', () => {
   it('parses HTTPS and SSH GitLab.com remotes', () => {
@@ -95,15 +74,13 @@ describe('gitlab project ref parsing', () => {
     ).toEqual({ host: 'gitlab.example.com:8443', path: 'team/api' })
   })
 
-  it('matches a port-bearing http remote against a port-less legacy known host', () => {
-    // Why: a known host recorded without a port (legacy/bare entry) still
-    // recognizes a remote on any port of the same hostname.
+  it('rejects a port-bearing http remote when the configured host has no port', () => {
+    // Why: `https://gitlab.example.com` and `https://gitlab.example.com:8443`
+    // are different endpoints. Matching loosely would hand `glab --hostname`
+    // a host the user never configured and can't be authenticated against.
     expect(
-      parseGitLabProjectRef('https://gitlab.example.com:8443/team/api.git', [
-        'gitlab.com',
-        'gitlab.example.com'
-      ])
-    ).toEqual({ host: 'gitlab.example.com:8443', path: 'team/api' })
+      parseGitLabProjectRef('https://gitlab.example.com:8443/team/api.git', ['gitlab.example.com'])
+    ).toBeNull()
   })
 
   it('distinguishes two services on the same host by port — only the GitLab one matches', () => {

--- a/src/main/gitlab/project-ref-parser.test.ts
+++ b/src/main/gitlab/project-ref-parser.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, it } from 'vitest'
-import { parseGitLabProjectRef, parseRemoteProjectRefCandidate } from './project-ref-parser'
+import {
+  gitLabHostFromUrl,
+  normalizeGitLabUrl,
+  parseGitLabProjectRef,
+  parseRemoteProjectRefCandidate
+} from './project-ref-parser'
+
+describe('GitLab instance setting', () => {
+  it('normalizes configured URLs and preserves non-default ports', () => {
+    expect(normalizeGitLabUrl('  HTTPS://GitLab.Example.com:8443/// ')).toBe(
+      'https://gitlab.example.com:8443'
+    )
+    expect(gitLabHostFromUrl('https://gitlab.example.com:8443')).toBe(
+      'gitlab.example.com:8443'
+    )
+  })
+
+  it('rejects invalid or credential-bearing URLs without selecting a host', () => {
+    expect(normalizeGitLabUrl('not a url')).toBe('')
+    expect(normalizeGitLabUrl('https://token@gitlab.example.com')).toBe('')
+    expect(gitLabHostFromUrl('')).toBe('')
+  })
+})
 
 describe('gitlab project ref parsing', () => {
   it('parses HTTPS and SSH GitLab.com remotes', () => {
@@ -22,6 +44,19 @@ describe('gitlab project ref parsing', () => {
       host: 'gitlab.com',
       path: 'g1/g2/g3/proj'
     })
+  })
+
+  it('accepts only the configured GitLab host', () => {
+    const configuredHost = [gitLabHostFromUrl('https://gitlab.internal:8443')]
+    expect(
+      parseGitLabProjectRef('https://gitlab.internal:8443/team/api.git', configuredHost)
+    ).toEqual({ host: 'gitlab.internal:8443', path: 'team/api' })
+    expect(parseGitLabProjectRef('git@gitlab.internal:team/api.git', configuredHost)).toEqual({
+      host: 'gitlab.internal:8443',
+      path: 'team/api'
+    })
+    expect(parseGitLabProjectRef('https://gitlab.com/team/api.git', configuredHost)).toBeNull()
+    expect(parseGitLabProjectRef('https://gitlab.internal/team/api.git', configuredHost)).toBeNull()
   })
 
   it('returns null for non-GitLab hosts when host not in knownHosts', () => {

--- a/src/main/gitlab/project-ref-parser.ts
+++ b/src/main/gitlab/project-ref-parser.ts
@@ -1,12 +1,35 @@
 import type { GitLabProjectRef } from '../../shared/gitlab-types'
 
 export type ProjectRef = GitLabProjectRef
-
-/**
- * Hosts always treated as GitLab. Self-hosted instances are added at
- * runtime via `getGlabKnownHosts()`, which inspects `glab auth status`.
- */
 export const DEFAULT_GITLAB_HOSTS = ['gitlab.com'] as const
+
+/** A GitLab instance is opt-in; an empty setting disables GitLab routing. */
+export function normalizeGitLabUrl(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    return ''
+  }
+  try {
+    const url = new URL(value.trim())
+    if (
+      !['http:', 'https:'].includes(url.protocol.toLowerCase()) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return ''
+    }
+    url.pathname = ''
+    return url.toString().replace(/\/$/, '').toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+export function gitLabHostFromUrl(value: unknown): string {
+  const normalized = normalizeGitLabUrl(value)
+  return normalized ? new URL(normalized).host : ''
+}
 
 export function normalizeGitLabHost(value: string): string {
   return value.trim().toLowerCase()
@@ -74,14 +97,24 @@ function knownHostMatches(urlHost: string, knownHost: string): boolean {
 function makeProjectRef(
   host: string,
   path: string,
-  knownHosts: readonly string[]
+  knownHosts: readonly string[],
+  allowConfiguredPortMapping = false
 ): ProjectRef | null {
   const normalizedHost = normalizeGitLabHost(host)
   const normalizedKnownHosts = knownHosts.map(normalizeGitLabHost)
-  if (!normalizedKnownHosts.some((knownHost) => knownHostMatches(normalizedHost, knownHost))) {
-    return null
+  const matchedHost = normalizedKnownHosts.find((knownHost) =>
+    knownHostMatches(normalizedHost, knownHost)
+  )
+  if (matchedHost) return makeProjectRefForTrustedHost(normalizedHost, path)
+  const configuredHost = normalizedKnownHosts.length === 1 ? normalizedKnownHosts[0] : null
+  if (
+    allowConfiguredPortMapping &&
+    configuredHost?.includes(':') &&
+    hostnameOf(configuredHost) === normalizedHost
+  ) {
+    return makeProjectRefForTrustedHost(configuredHost, path)
   }
-  return makeProjectRefForTrustedHost(normalizedHost, path)
+  return null
 }
 
 export function parseRemoteProjectRefCandidate(remoteUrl: string): ProjectRef | null {
@@ -112,7 +145,7 @@ export function parseGitLabProjectRef(
   if (!/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
     const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+):([^\s]+?)(?:\.git)?$/)
     if (scpLike) {
-      return makeProjectRef(scpLike[1], scpLike[2], knownHosts)
+      return makeProjectRef(scpLike[1], scpLike[2], knownHosts, true)
     }
   }
 
@@ -121,7 +154,13 @@ export function parseGitLabProjectRef(
     if (!['http:', 'https:', 'ssh:', 'git:', 'git+ssh:'].includes(url.protocol.toLowerCase())) {
       return null
     }
-    return makeProjectRef(hostIdentityFromUrl(url), url.pathname, knownHosts)
+    const protocol = url.protocol.toLowerCase()
+    return makeProjectRef(
+      hostIdentityFromUrl(url),
+      url.pathname,
+      knownHosts,
+      protocol !== 'http:' && protocol !== 'https:'
+    )
   } catch {
     return null
   }

--- a/src/main/gitlab/project-ref-parser.ts
+++ b/src/main/gitlab/project-ref-parser.ts
@@ -3,42 +3,14 @@ import type { GitLabProjectRef } from '../../shared/gitlab-types'
 export type ProjectRef = GitLabProjectRef
 export const DEFAULT_GITLAB_HOSTS = ['gitlab.com'] as const
 
-/** A GitLab instance is opt-in; an empty setting disables GitLab routing. */
-export function normalizeGitLabUrl(value: unknown): string {
-  if (typeof value !== 'string' || !value.trim()) {
-    return ''
-  }
-  try {
-    const url = new URL(value.trim())
-    if (
-      !['http:', 'https:'].includes(url.protocol.toLowerCase()) ||
-      url.username ||
-      url.password ||
-      url.search ||
-      url.hash
-    ) {
-      return ''
-    }
-    url.pathname = ''
-    return url.toString().replace(/\/$/, '').toLowerCase()
-  } catch {
-    return ''
-  }
-}
-
-export function gitLabHostFromUrl(value: unknown): string {
-  const normalized = normalizeGitLabUrl(value)
-  return normalized ? new URL(normalized).host : ''
-}
-
 export function normalizeGitLabHost(value: string): string {
   return value.trim().toLowerCase()
 }
 
 // Why: host recognition is port-aware so two services on the same hostname
 // but different ports (e.g. a GitLab on :8080 and a Gitea on :3030) are not
-// conflated. The hostname (port-less) part is kept for legacy known-host
-// entries that were recorded without a port.
+// conflated. The hostname (port-less) part is kept so port-less ssh remotes
+// can still be mapped onto a configured host that carries a port.
 function hostnameOf(host: string): string {
   // `host` may be `name` or `name:port`. Strip a trailing `:digits` port.
   return host.replace(/:\d+$/, '')
@@ -74,26 +46,12 @@ function makeProjectRefForTrustedHost(host: string, path: string): ProjectRef | 
 }
 
 /**
- * Does `urlHost` (which may include a `:port`) match a known-host entry?
- * - An exact match (including any port) always counts.
- * - A known entry WITHOUT a port also matches a URL host on the same
- *   hostname regardless of the URL's port — this preserves recognition for
- *   legacy `gitlab.com` / bare-hostname known entries.
- * - A known entry WITH a port only matches a URL host with the exact same
- *   port, so `gitlab.example.com:8443` does not accept a
- *   `gitea.example.com:3000` (or same-host different-port) remote.
+ * Resolve a remote's host+path against the known hosts. Host recognition is
+ * exact: a configured `gitlab.example.com` and a remote on
+ * `gitlab.example.com:3030` are different endpoints, and routing the latter
+ * through `glab --hostname` would target an instance the user never
+ * configured.
  */
-function knownHostMatches(urlHost: string, knownHost: string): boolean {
-  if (urlHost === knownHost) {
-    return true
-  }
-  if (hostnameOf(knownHost) === knownHost) {
-    // Known entry has no port — match on hostname alone.
-    return hostnameOf(urlHost) === knownHost
-  }
-  return false
-}
-
 function makeProjectRef(
   host: string,
   path: string,
@@ -102,14 +60,15 @@ function makeProjectRef(
 ): ProjectRef | null {
   const normalizedHost = normalizeGitLabHost(host)
   const normalizedKnownHosts = knownHosts.map(normalizeGitLabHost)
-  const matchedHost = normalizedKnownHosts.find((knownHost) =>
-    knownHostMatches(normalizedHost, knownHost)
-  )
-  if (matchedHost) return makeProjectRefForTrustedHost(normalizedHost, path)
+  if (normalizedKnownHosts.includes(normalizedHost)) {
+    return makeProjectRefForTrustedHost(normalizedHost, path)
+  }
+  // Why: ssh/scp remotes carry no web port, so they can never match a single
+  // configured host that has one. Map them onto it by hostname instead.
   const configuredHost = normalizedKnownHosts.length === 1 ? normalizedKnownHosts[0] : null
   if (
     allowConfiguredPortMapping &&
-    configuredHost?.includes(':') &&
+    configuredHost &&
     hostnameOf(configuredHost) === normalizedHost
   ) {
     return makeProjectRefForTrustedHost(configuredHost, path)

--- a/src/main/ipc/gitlab.test.ts
+++ b/src/main/ipc/gitlab.test.ts
@@ -38,7 +38,9 @@ const {
   getWorkItemByProjectRefMock,
   getMergeRequestMock,
   getMergeRequestForBranchMock,
-  getProjectSlugMock
+  getProjectSlugMock,
+  getRateLimitMock,
+  recordGitLabProjectRecentMock
 } = vi.hoisted(() => ({
   ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
   listMergeRequestsMock: vi.fn(),
@@ -65,7 +67,9 @@ const {
   getWorkItemByProjectRefMock: vi.fn(),
   getMergeRequestMock: vi.fn(),
   getMergeRequestForBranchMock: vi.fn(),
-  getProjectSlugMock: vi.fn()
+  getProjectSlugMock: vi.fn(),
+  getRateLimitMock: vi.fn(),
+  recordGitLabProjectRecentMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -89,7 +93,7 @@ vi.mock('../gitlab/client', () => ({
   getMergeRequest: getMergeRequestMock,
   getMergeRequestForBranch: getMergeRequestForBranchMock,
   getProjectSlug: getProjectSlugMock,
-  getRateLimit: vi.fn(),
+  getRateLimit: getRateLimitMock,
   getWorkItemByProjectRef: getWorkItemByProjectRefMock,
   listAssignableUsers: listAssignableUsersMock,
   listIssues: listIssuesMock,
@@ -111,7 +115,7 @@ vi.mock('../gitlab/work-item-details', () => ({
 }))
 
 vi.mock('../gitlab/gitlab-project-recents', () => ({
-  recordGitLabProjectRecent: vi.fn()
+  recordGitLabProjectRecent: recordGitLabProjectRecentMock
 }))
 
 import { registerGitLabHandlers } from './gitlab'
@@ -173,10 +177,147 @@ describe('GitLab IPC handlers', () => {
       getWorkItemByProjectRefMock,
       getMergeRequestMock,
       getMergeRequestForBranchMock,
-      getProjectSlugMock
+      getProjectSlugMock,
+      getRateLimitMock,
+      recordGitLabProjectRecentMock
     ]) {
       mock.mockReset()
     }
+  })
+
+  describe('configured-instance host guard', () => {
+    // Why: an explicit projectRef/host bypasses remote resolution entirely, so
+    // a crafted payload could otherwise point `glab --hostname` at any GitLab.
+    const OTHER_HOST = 'gitlab.evil.test'
+
+    function registerWithGitLabUrl(gitlabUrl: string): void {
+      registerGitLabHandlers({
+        ...storeWithRepos([repo()]),
+        getSettings: () => ({ gitlabUrl }) as ReturnType<Store['getSettings']>
+      } as Store)
+    }
+
+    it.each([
+      ['gitlab:updateMRReviewers', { iid: 8, reviewerIds: [1] }, updateMRReviewersMock],
+      [
+        'gitlab:addMRInlineComment',
+        { iid: 8, input: { body: 'Inline', path: 'a.ts', line: 1 } },
+        addMRInlineCommentMock
+      ],
+      ['gitlab:jobTrace', { jobId: 99 }, getJobTraceMock],
+      ['gitlab:retryJob', { jobId: 99 }, retryJobMock]
+    ])('rejects %s for a projectRef on another host', async (channel, args, clientMock) => {
+      registerWithGitLabUrl('https://gitlab.com')
+
+      await expect(
+        ipcHandlers.get(channel as string)?.(null, {
+          repoPath: '/local/orca',
+          ...(args as object),
+          projectRef: { host: OTHER_HOST, path: 'attacker/exfil' }
+        })
+      ).rejects.toThrow('does not match the configured instance')
+      expect(clientMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects a pasted work item on another host without recording a recent', async () => {
+      registerWithGitLabUrl('https://gitlab.com')
+
+      await expect(
+        ipcHandlers.get('gitlab:workItemByPath')?.(null, {
+          repoPath: '/local/orca',
+          host: OTHER_HOST,
+          path: 'attacker/exfil',
+          iid: 1,
+          type: 'issue'
+        })
+      ).rejects.toThrow('does not match the configured instance')
+      expect(getWorkItemByProjectRefMock).not.toHaveBeenCalled()
+      expect(recordGitLabProjectRecentMock).not.toHaveBeenCalled()
+    })
+
+    it('canonicalizes a matching pasted host before calling glab and recording a recent', async () => {
+      getWorkItemByProjectRefMock.mockResolvedValueOnce({ type: 'issue', number: 5 })
+      registerWithGitLabUrl('https://GitLab.Example.com')
+
+      await ipcHandlers.get('gitlab:workItemByPath')?.(null, {
+        repoPath: '/local/orca',
+        host: 'GITLAB.example.COM',
+        path: 'g/p',
+        iid: 5,
+        type: 'issue'
+      })
+
+      expect(getWorkItemByProjectRefMock).toHaveBeenCalledWith(
+        '/local/orca',
+        { host: 'gitlab.example.com', path: 'g/p' },
+        5,
+        'issue',
+        null
+      )
+      expect(recordGitLabProjectRecentMock).toHaveBeenCalledWith(
+        expect.anything(),
+        'gitlab.example.com',
+        'g/p'
+      )
+    })
+
+    it('rejects host-bearing calls when no GitLab instance is configured', async () => {
+      registerWithGitLabUrl('')
+
+      await expect(
+        ipcHandlers.get('gitlab:workItemByPath')?.(null, {
+          repoPath: '/local/orca',
+          host: 'gitlab.com',
+          path: 'g/p',
+          iid: 1,
+          type: 'issue'
+        })
+      ).rejects.toThrow('no GitLab instance is configured')
+      await expect(
+        ipcHandlers.get('gitlab:jobTrace')?.(null, {
+          repoPath: '/local/orca',
+          jobId: 99,
+          projectRef: { host: 'gitlab.com', path: 'g/p' }
+        })
+      ).rejects.toThrow('no GitLab instance is configured')
+      expect(getWorkItemByProjectRefMock).not.toHaveBeenCalled()
+      expect(getJobTraceMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects a rate-limit probe against another host', async () => {
+      registerWithGitLabUrl('https://gitlab.com')
+
+      await expect(
+        ipcHandlers.get('gitlab:rateLimit')?.(null, { host: OTHER_HOST })
+      ).rejects.toThrow('does not match the configured instance')
+      expect(getRateLimitMock).not.toHaveBeenCalled()
+    })
+
+    it('re-pins the guard when the configured instance changes at runtime', async () => {
+      const settingsListeners: ((updates: { gitlabUrl?: string }) => void)[] = []
+      registerGitLabHandlers({
+        ...storeWithRepos([repo()]),
+        getSettings: () =>
+          ({ gitlabUrl: 'https://gitlab.com' }) as ReturnType<Store['getSettings']>,
+        onSettingsChanged: (listener: (updates: { gitlabUrl?: string }) => void) => {
+          settingsListeners.push(listener)
+          return () => {}
+        }
+      } as unknown as Store)
+
+      for (const listener of settingsListeners) {
+        listener({ gitlabUrl: 'https://gitlab.example.com' })
+      }
+
+      await expect(
+        ipcHandlers.get('gitlab:retryJob')?.(null, {
+          repoPath: '/local/orca',
+          jobId: 99,
+          projectRef: { host: 'gitlab.com', path: 'g/p' }
+        })
+      ).rejects.toThrow('does not match the configured instance')
+      expect(retryJobMock).not.toHaveBeenCalled()
+    })
   })
 
   it('resolves repoId and source host context before listing work items', async () => {

--- a/src/main/ipc/gitlab.test.ts
+++ b/src/main/ipc/gitlab.test.ts
@@ -245,8 +245,7 @@ describe('GitLab IPC handlers', () => {
       undefined,
       'fix login',
       null,
-      {},
-      'https://gitlab.com'
+      {}
     )
     expect(listWorkItemsMock).toHaveBeenCalledWith(
       '/local/orca',
@@ -276,8 +275,7 @@ describe('GitLab IPC handlers', () => {
       undefined,
       undefined,
       null,
-      {},
-      'https://gitlab.com'
+      {}
     )
   })
 
@@ -435,8 +433,7 @@ describe('GitLab IPC handlers', () => {
       undefined,
       undefined,
       null,
-      localGitOptions,
-      'https://gitlab.com'
+      localGitOptions
     )
     expect(issueListResult).toMatchObject({ totalPages: 3 })
     expect(listWorkItemsMock).toHaveBeenCalledWith(

--- a/src/main/ipc/gitlab.test.ts
+++ b/src/main/ipc/gitlab.test.ts
@@ -130,13 +130,15 @@ function repo(overrides: Partial<Repo> = {}): Repo {
 function storeWithRepos(
   repos: Repo[],
   projects: ReturnType<Store['getProjects']> = []
-): Pick<Store, 'getRepos' | 'getRepo' | 'getProjects' | 'getSettings'> {
+): Pick<Store, 'getRepos' | 'getRepo' | 'getProjects' | 'getSettings' | 'onSettingsChanged'> {
   return {
     getRepos: () => repos,
     getRepo: (id: string) => repos.find((candidate) => candidate.id === id),
     getProjects: () => projects,
+    onSettingsChanged: () => () => {},
     getSettings: () =>
       ({
+        gitlabUrl: 'https://gitlab.com',
         localWindowsRuntimeDefault: { kind: 'windows-host' }
       }) as ReturnType<Store['getSettings']>
   }
@@ -242,7 +244,9 @@ describe('GitLab IPC handlers', () => {
       20,
       undefined,
       'fix login',
-      null
+      null,
+      {},
+      'https://gitlab.com'
     )
     expect(listWorkItemsMock).toHaveBeenCalledWith(
       '/local/orca',
@@ -271,7 +275,9 @@ describe('GitLab IPC handlers', () => {
       20,
       undefined,
       undefined,
-      null
+      null,
+      {},
+      'https://gitlab.com'
     )
   })
 
@@ -429,7 +435,8 @@ describe('GitLab IPC handlers', () => {
       undefined,
       undefined,
       null,
-      localGitOptions
+      localGitOptions,
+      'https://gitlab.com'
     )
     expect(issueListResult).toMatchObject({ totalPages: 3 })
     expect(listWorkItemsMock).toHaveBeenCalledWith(

--- a/src/main/ipc/gitlab.ts
+++ b/src/main/ipc/gitlab.ts
@@ -7,9 +7,9 @@ import type {
   GitLabIssueUpdate,
   GitLabMRInlineCommentInput,
   GitLabMRUpdate,
-  GitLabWorkItem,
-  Repo
-} from '../../shared/types'
+  GitLabWorkItem
+} from '../../shared/gitlab-types'
+import type { Repo } from '../../shared/repo-types'
 import { getRepoExecutionHostId } from '../../shared/execution-host'
 import type { TaskSourceContext } from '../../shared/task-source-context'
 import type { Store } from '../persistence'

--- a/src/main/ipc/gitlab.ts
+++ b/src/main/ipc/gitlab.ts
@@ -21,7 +21,11 @@ import {
   normalizeGitLabSearchQuery
 } from '../gitlab/gitlab-preload-args'
 import { recordGitLabProjectRecent } from '../gitlab/gitlab-project-recents'
-import { setConfiguredGitLabUrl } from '../gitlab/gitlab-known-host-probe'
+import {
+  getConfiguredGitLabHost,
+  setConfiguredGitLabUrl
+} from '../gitlab/gitlab-known-host-probe'
+import { normalizeGitLabHost } from '../gitlab/project-ref-parser'
 import {
   addIssueComment,
   addMRInlineComment,
@@ -99,6 +103,30 @@ function repoConnectionId(repo: Repo): string | null {
   return repo.connectionId ?? null
 }
 
+// Why: a renderer-supplied host is a `glab --hostname` override that bypasses
+// remote resolution entirely, so it must be pinned to the one configured
+// instance — otherwise a crafted payload routes credentialed calls at an
+// arbitrary GitLab. Callers that supply no host keep the resolved-remote path.
+function assertConfiguredGitLabHost(host: string | null | undefined): string {
+  const configured = getConfiguredGitLabHost()
+  if (!configured) {
+    throw new Error('Access denied: no GitLab instance is configured')
+  }
+  if (normalizeGitLabHost(host ?? '') !== configured) {
+    throw new Error('Access denied: GitLab host does not match the configured instance')
+  }
+  return configured
+}
+
+function assertConfiguredProjectRef<T extends { host: string }>(
+  projectRef: T | null | undefined
+): T | null | undefined {
+  if (projectRef) {
+    assertConfiguredGitLabHost(projectRef.host)
+  }
+  return projectRef
+}
+
 function localGitOptions(store: Store, repo: Repo): LocalGitExecOptions {
   const options = getLocalProjectWorktreeGitOptions(store, repo)
   return options.wslDistro ? { wslDistro: options.wslDistro } : {}
@@ -131,8 +159,12 @@ export function registerGitLabHandlers(store: Store): void {
 
   ipcMain.handle(
     'gitlab:rateLimit',
-    async (_event, args?: { force?: boolean; host?: string | null }) =>
-      getRateLimit({ force: Boolean(args?.force), host: args?.host ?? null })
+    async (_event, args?: { force?: boolean; host?: string | null }) => {
+      if (args?.host) {
+        assertConfiguredGitLabHost(args.host)
+      }
+      return getRateLimit({ force: Boolean(args?.force), host: args?.host ?? null })
+    }
   )
 
   ipcMain.handle('gitlab:projectSlug', async (_event, args: GitLabRepoSelectorArgs) => {
@@ -460,7 +492,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.reviewerIds,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        args.projectRef,
+        assertConfiguredProjectRef(args.projectRef),
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -502,7 +534,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.input,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        args.projectRef,
+        assertConfiguredProjectRef(args.projectRef),
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -540,7 +572,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.jobId,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        args.projectRef,
+        assertConfiguredProjectRef(args.projectRef),
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -558,7 +590,7 @@ export function registerGitLabHandlers(store: Store): void {
         args.jobId,
         repo.issueSourcePreference,
         repoConnectionId(repo),
-        args.projectRef,
+        assertConfiguredProjectRef(args.projectRef),
         ...localGitOptionArgs(store, repo)
       )
     }
@@ -588,7 +620,8 @@ export function registerGitLabHandlers(store: Store): void {
       }
     ) => {
       const repo = assertRegisteredRepo(args, store)
-      const projectRef: ProjectRef = { host: args.host, path: args.path }
+      const host = assertConfiguredGitLabHost(args.host)
+      const projectRef: ProjectRef = { host, path: args.path }
       const result = await getWorkItemByProjectRef(
         repo.path,
         projectRef,
@@ -601,7 +634,7 @@ export function registerGitLabHandlers(store: Store): void {
       // produced an item. A 404 / auth failure shouldn't pollute the
       // user's recents list with project paths they can't read.
       if (result) {
-        recordGitLabProjectRecent(store, args.host, args.path)
+        recordGitLabProjectRecent(store, host, args.path)
       }
       return result
     }

--- a/src/main/ipc/gitlab.ts
+++ b/src/main/ipc/gitlab.ts
@@ -1,26 +1,128 @@
+/* eslint-disable max-lines -- Why: parallel to ipc/github.ts — keeping all
+GitLab IPC handlers co-located keeps the repo-path validation pattern
+reviewable as one surface. */
 import { ipcMain } from 'electron'
+import { resolve } from 'node:path'
+import type {
+  GitLabIssueUpdate,
+  GitLabMRInlineCommentInput,
+  GitLabMRUpdate,
+  GitLabWorkItem,
+  Repo
+} from '../../shared/types'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
+import type { TaskSourceContext } from '../../shared/task-source-context'
 import type { Store } from '../persistence'
 import {
+  normalizeGitLabIssueAssignee,
+  normalizeGitLabIssueListState,
+  normalizeGitLabMRListState,
+  normalizeGitLabPositiveInteger,
+  normalizeGitLabSearchQuery
+} from '../gitlab/gitlab-preload-args'
+import { recordGitLabProjectRecent } from '../gitlab/gitlab-project-recents'
+import { setConfiguredGitLabUrl } from '../gitlab/gitlab-known-host-probe'
+import {
+  addIssueComment,
+  addMRInlineComment,
+  addMRComment,
+  closeMR,
+  createIssue,
   diagnoseAuth,
   getAuthenticatedViewer,
+  getJobTrace,
+  getIssue,
+  getMergeRequest,
+  getMergeRequestForBranch,
   getProjectSlug,
   getRateLimit,
-  listTodos
+  getWorkItemByProjectRef,
+  listAssignableUsers,
+  listIssues,
+  listLabels,
+  listMergeRequests,
+  listTodos,
+  listWorkItems,
+  mergeMR,
+  reopenMR,
+  resolveMRDiscussion,
+  retryJob,
+  updateIssue,
+  updateMR,
+  updateMRReviewers
 } from '../gitlab/client'
-import { registerGitLabCiJobHandlers } from './gitlab-ci-job-handlers'
-import { registerGitLabIssueHandlers } from './gitlab-issue-handlers'
-import { registerGitLabMergeRequestMutationHandlers } from './gitlab-merge-request-mutation-handlers'
-import { registerGitLabMergeRequestQueryHandlers } from './gitlab-merge-request-query-handlers'
-import type { GitLabRepoSelectorArgs } from './gitlab-repo-access'
-import {
-  assertRegisteredRepo,
-  hostedReviewOptionArgs,
-  localGitOptionArgs,
-  repoConnectionId
-} from './gitlab-repo-access'
-import { registerGitLabWorkItemHandlers } from './gitlab-work-item-handlers'
+import { getWorkItemDetails } from '../gitlab/work-item-details'
+import type { ProjectRef } from '../gitlab/gl-utils'
+import type { LocalGitExecOptions } from '../gitlab/gitlab-project-ref-resolution'
+import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
+import type { HostedReviewExecutionOptions } from '../source-control/hosted-review-git-options'
+
+type GitLabRepoSelectorArgs = {
+  repoPath: string
+  repoId?: string | null
+  sourceContext?: TaskSourceContext | null
+}
+
+function findRegisteredGitLabRepo(args: GitLabRepoSelectorArgs, store: Store): Repo | undefined {
+  const sourceRepoId =
+    args.sourceContext?.provider === 'gitlab' ? args.sourceContext.repoId?.trim() : null
+  const repoId = args.repoId?.trim() || sourceRepoId || null
+  if (repoId) {
+    const repo = store.getRepo(repoId)
+    if (repo) {
+      return repo
+    }
+  }
+  const resolvedRepoPath = resolve(args.repoPath)
+  return store.getRepos().find((r) => resolve(r.path) === resolvedRepoPath)
+}
+
+// Why: mirror github.ts assertRegisteredRepo — main-process handlers
+// must never operate on a path the user hasn't explicitly registered as
+// a repo (filesystem-auth boundary). Source context adds a host check so a
+// task fetched from one machine cannot mutate a same-path repo on another.
+function assertRegisteredRepo(args: GitLabRepoSelectorArgs, store: Store): Repo {
+  const repo = findRegisteredGitLabRepo(args, store)
+  if (!repo) {
+    throw new Error('Access denied: unknown repository path')
+  }
+  if (
+    args.sourceContext?.provider === 'gitlab' &&
+    args.sourceContext.hostId !== getRepoExecutionHostId(repo)
+  ) {
+    throw new Error('Access denied: GitLab source host does not match repository host')
+  }
+  return repo
+}
+
+function repoConnectionId(repo: Repo): string | null {
+  return repo.connectionId ?? null
+}
+
+function localGitOptions(store: Store, repo: Repo): LocalGitExecOptions {
+  const options = getLocalProjectWorktreeGitOptions(store, repo)
+  return options.wslDistro ? { wslDistro: options.wslDistro } : {}
+}
+
+function localGitOptionArgs(store: Store, repo: Repo): [] | [LocalGitExecOptions] {
+  const options = localGitOptions(store, repo)
+  return options.wslDistro ? [options] : []
+}
+
+function hostedReviewOptionArgs(store: Store, repo: Repo): [] | [HostedReviewExecutionOptions] {
+  const localGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
+  return localGitOptions.wslDistro
+    ? [{ localGitExecOptions: { wslDistro: localGitOptions.wslDistro } }]
+    : []
+}
 
 export function registerGitLabHandlers(store: Store): void {
+  setConfiguredGitLabUrl(store.getSettings().gitlabUrl)
+  store.onSettingsChanged((updates) => {
+    if ('gitlabUrl' in updates) {
+      setConfiguredGitLabUrl(updates.gitlabUrl)
+    }
+  })
   ipcMain.handle('gitlab:viewer', async () => {
     return getAuthenticatedViewer()
   })
@@ -38,11 +140,429 @@ export function registerGitLabHandlers(store: Store): void {
     return getProjectSlug(repo.path, repoConnectionId(repo), ...hostedReviewOptionArgs(store, repo))
   })
 
-  registerGitLabMergeRequestQueryHandlers(store)
-  registerGitLabIssueHandlers(store)
-  registerGitLabWorkItemHandlers(store)
-  registerGitLabMergeRequestMutationHandlers(store)
-  registerGitLabCiJobHandlers(store)
+  ipcMain.handle(
+    'gitlab:mrForBranch',
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & { branch: string; linkedMRIid?: number | null }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return getMergeRequestForBranch(
+        repo.path,
+        args.branch,
+        args.linkedMRIid ?? null,
+        repoConnectionId(repo),
+        ...hostedReviewOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle('gitlab:mr', async (_event, args: GitLabRepoSelectorArgs & { iid: number }) => {
+    const repo = assertRegisteredRepo(args, store)
+    return getMergeRequest(
+      repo.path,
+      args.iid,
+      repoConnectionId(repo),
+      ...hostedReviewOptionArgs(store, repo)
+    )
+  })
+
+  ipcMain.handle(
+    'gitlab:listMRs',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        repoId?: string | null
+        sourceContext?: TaskSourceContext | null
+        state?: 'opened' | 'merged' | 'closed' | 'all'
+        page?: number
+        perPage?: number
+        query?: string
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      const state = normalizeGitLabMRListState(args.state)
+      const page = normalizeGitLabPositiveInteger(args.page, 1, 10_000)
+      const perPage = normalizeGitLabPositiveInteger(args.perPage, 20, 100)
+      return listMergeRequests(
+        repo.path,
+        state,
+        page,
+        perPage,
+        repo.issueSourcePreference,
+        normalizeGitLabSearchQuery(args.query),
+        repoConnectionId(repo),
+        localGitOptions(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:issue',
+    async (_event, args: GitLabRepoSelectorArgs & { number: number }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return getIssue(
+        repo.path,
+        args.number,
+        repoConnectionId(repo),
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:listIssues',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        repoId?: string | null
+        sourceContext?: TaskSourceContext | null
+        state?: 'opened' | 'closed' | 'all'
+        assignee?: string
+        limit?: number
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      const limit = normalizeGitLabPositiveInteger(args.limit, 20, 100)
+      const state = normalizeGitLabIssueListState(args.state)
+      const assignee = normalizeGitLabIssueAssignee(args.assignee)
+      const result = await listIssues(
+        repo.path,
+        limit,
+        repo.issueSourcePreference,
+        state,
+        assignee,
+        repoConnectionId(repo),
+        ...localGitOptionArgs(store, repo)
+      )
+      // Why: Tasks page expects GitLabWorkItem[] so it can share row
+      // rendering with MRs. Map IssueInfo → WorkItem here so the renderer
+      // doesn't need a separate code path.
+      const workItems: GitLabWorkItem[] = result.items.map((issue) => ({
+        id: `gitlab-issue-${repo.id}-${issue.number}`,
+        type: 'issue' as const,
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        url: issue.url,
+        labels: issue.labels,
+        updatedAt: issue.updatedAt ?? '',
+        author: issue.author ?? null,
+        repoId: repo.id
+      }))
+      return { items: workItems, ...(result.error ? { error: result.error } : {}) }
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:createIssue',
+    async (_event, args: GitLabRepoSelectorArgs & { title: string; body: string }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return createIssue(
+        repo.path,
+        args.title,
+        args.body,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:updateIssue',
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & { number: number; updates: GitLabIssueUpdate }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return updateIssue(
+        repo.path,
+        args.number,
+        args.updates,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:addIssueComment',
+    async (_event, args: GitLabRepoSelectorArgs & { number: number; body: string }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return addIssueComment(
+        repo.path,
+        args.number,
+        args.body,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle('gitlab:listLabels', async (_event, args: GitLabRepoSelectorArgs) => {
+    const repo = assertRegisteredRepo(args, store)
+    return listLabels(
+      repo.path,
+      repo.issueSourcePreference,
+      repoConnectionId(repo),
+      ...localGitOptionArgs(store, repo)
+    )
+  })
+
+  ipcMain.handle('gitlab:listAssignableUsers', async (_event, args: GitLabRepoSelectorArgs) => {
+    const repo = assertRegisteredRepo(args, store)
+    return listAssignableUsers(
+      repo.path,
+      repo.issueSourcePreference,
+      repoConnectionId(repo),
+      ...localGitOptionArgs(store, repo)
+    )
+  })
+
+  // Why: combined MR + issue list — Tasks screen and any future picker
+  // that wants a unified view. Centralizes the merge / sort logic so
+  // callers don't have to re-implement it.
+  ipcMain.handle(
+    'gitlab:listWorkItems',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        repoId?: string | null
+        sourceContext?: TaskSourceContext | null
+        state?: 'opened' | 'merged' | 'closed' | 'all'
+        page?: number
+        perPage?: number
+        query?: string
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return listWorkItems(
+        repo.path,
+        normalizeGitLabMRListState(args.state),
+        normalizeGitLabPositiveInteger(args.page, 1, 10_000),
+        normalizeGitLabPositiveInteger(args.perPage, 20, 100),
+        repo.issueSourcePreference,
+        normalizeGitLabSearchQuery(args.query),
+        repoConnectionId(repo),
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  // Why: aggregated dialog payload — body + discussions + pipeline jobs.
+  // Powers GitLabItemDialog's tabs.
+  ipcMain.handle(
+    'gitlab:workItemDetails',
+    async (_event, args: GitLabRepoSelectorArgs & { iid: number; type: 'issue' | 'mr' }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return getWorkItemDetails(
+        repo.path,
+        args.iid,
+        args.type,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:closeMR',
+    async (_event, args: GitLabRepoSelectorArgs & { iid: number }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return closeMR(
+        repo.path,
+        args.iid,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:reopenMR',
+    async (_event, args: GitLabRepoSelectorArgs & { iid: number }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return reopenMR(
+        repo.path,
+        args.iid,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:mergeMR',
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & { iid: number; method?: 'merge' | 'squash' | 'rebase' }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return mergeMR(
+        repo.path,
+        args.iid,
+        args.method ?? 'merge',
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:updateMR',
+    async (_event, args: GitLabRepoSelectorArgs & { iid: number; updates: GitLabMRUpdate }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return updateMR(
+        repo.path,
+        args.iid,
+        args.updates,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:updateMRReviewers',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        repoId?: string | null
+        sourceContext?: TaskSourceContext | null
+        iid: number
+        reviewerIds: number[]
+        projectRef?: ProjectRef | null
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return updateMRReviewers(
+        repo.path,
+        args.iid,
+        args.reviewerIds,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        args.projectRef,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:addMRComment',
+    async (_event, args: GitLabRepoSelectorArgs & { iid: number; body: string }) => {
+      const repo = assertRegisteredRepo(args, store)
+      return addMRComment(
+        repo.path,
+        args.iid,
+        args.body,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:addMRInlineComment',
+    async (
+      _event,
+      args: {
+        repoPath: string
+        repoId?: string | null
+        sourceContext?: TaskSourceContext | null
+        iid: number
+        input: GitLabMRInlineCommentInput
+        projectRef?: ProjectRef | null
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return addMRInlineComment(
+        repo.path,
+        args.iid,
+        args.input,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        args.projectRef,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:resolveMRDiscussion',
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & { iid: number; discussionId: string; resolved: boolean }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return resolveMRDiscussion(
+        repo.path,
+        args.iid,
+        args.discussionId,
+        args.resolved,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        undefined,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:jobTrace',
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & { jobId: number; projectRef?: ProjectRef | null }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return getJobTrace(
+        repo.path,
+        args.jobId,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        args.projectRef,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
+
+  ipcMain.handle(
+    'gitlab:retryJob',
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & { jobId: number; projectRef?: ProjectRef | null }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      return retryJob(
+        repo.path,
+        args.jobId,
+        repo.issueSourcePreference,
+        repoConnectionId(repo),
+        args.projectRef,
+        ...localGitOptionArgs(store, repo)
+      )
+    }
+  )
 
   // Why: My Todos surface — cross-project, user-scoped. The repoPath is
   // only used for the registered-repo guard; `glab api todos` doesn't
@@ -51,4 +571,39 @@ export function registerGitLabHandlers(store: Store): void {
     const repo = assertRegisteredRepo(args, store)
     return listTodos(repo.path, repoConnectionId(repo), ...localGitOptionArgs(store, repo))
   })
+
+  // Why: paste-URL flow in the picker. The user pastes a GitLab URL that
+  // may target a project different from the local checkout's remote, so
+  // the call carries the parsed project path explicitly rather than
+  // resolving from cwd.
+  ipcMain.handle(
+    'gitlab:workItemByPath',
+    async (
+      _event,
+      args: GitLabRepoSelectorArgs & {
+        host: string
+        path: string
+        iid: number
+        type: 'issue' | 'mr'
+      }
+    ) => {
+      const repo = assertRegisteredRepo(args, store)
+      const projectRef: ProjectRef = { host: args.host, path: args.path }
+      const result = await getWorkItemByProjectRef(
+        repo.path,
+        projectRef,
+        args.iid,
+        args.type,
+        repoConnectionId(repo),
+        ...localGitOptionArgs(store, repo)
+      )
+      // Why: only persist a recent entry when the lookup actually
+      // produced an item. A 404 / auth failure shouldn't pollute the
+      // user's recents list with project paths they can't read.
+      if (result) {
+        recordGitLabProjectRecent(store, args.host, args.path)
+      }
+      return result
+    }
+  )
 }

--- a/src/main/ipc/gitlab.ts
+++ b/src/main/ipc/gitlab.ts
@@ -21,11 +21,11 @@ import {
   normalizeGitLabSearchQuery
 } from '../gitlab/gitlab-preload-args'
 import { recordGitLabProjectRecent } from '../gitlab/gitlab-project-recents'
+import { setConfiguredGitLabUrl } from '../gitlab/gitlab-known-host-probe'
 import {
-  getConfiguredGitLabHost,
-  setConfiguredGitLabUrl
-} from '../gitlab/gitlab-known-host-probe'
-import { normalizeGitLabHost } from '../gitlab/project-ref-parser'
+  assertConfiguredGitLabHost,
+  assertConfiguredProjectRef
+} from '../gitlab/configured-instance-host-guard'
 import {
   addIssueComment,
   addMRInlineComment,
@@ -101,30 +101,6 @@ function assertRegisteredRepo(args: GitLabRepoSelectorArgs, store: Store): Repo 
 
 function repoConnectionId(repo: Repo): string | null {
   return repo.connectionId ?? null
-}
-
-// Why: a renderer-supplied host is a `glab --hostname` override that bypasses
-// remote resolution entirely, so it must be pinned to the one configured
-// instance — otherwise a crafted payload routes credentialed calls at an
-// arbitrary GitLab. Callers that supply no host keep the resolved-remote path.
-function assertConfiguredGitLabHost(host: string | null | undefined): string {
-  const configured = getConfiguredGitLabHost()
-  if (!configured) {
-    throw new Error('Access denied: no GitLab instance is configured')
-  }
-  if (normalizeGitLabHost(host ?? '') !== configured) {
-    throw new Error('Access denied: GitLab host does not match the configured instance')
-  }
-  return configured
-}
-
-function assertConfiguredProjectRef<T extends { host: string }>(
-  projectRef: T | null | undefined
-): T | null | undefined {
-  if (projectRef) {
-    assertConfiguredGitLabHost(projectRef.host)
-  }
-  return projectRef
 }
 
 function localGitOptions(store: Store, repo: Repo): LocalGitExecOptions {

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -1,21 +1,272 @@
 import { ipcMain } from 'electron'
+import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
+import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
+import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
+import { getBitbucketAuthStatus } from '../bitbucket/client'
+import { getGiteaAuthStatus } from '../gitea/client'
+import { mergePersistedWindowsPathAsync } from '../pty/windows-environment-path'
+import { getActiveMultiplexer } from './ssh'
+import { detectWslCommandsOnPath, type WslPreflightTarget } from './preflight-wsl-agent-detection'
+import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
+import { getPreflightWslTarget, type PreflightRuntimeContext } from './preflight-runtime-target'
+import { hydrateShellPathForAgentDetection } from './agent-detection-shell-path'
 import {
-  detectInstalledAgentsWithShellPathHydration,
-  detectRemoteAgents,
+  execCommandInWsl,
+  execLocalPreflightCommand,
+  isCommandAvailable,
+  isCommandOnPath,
+  shellQuote
+} from './preflight-command-exec'
+import {
   detectRemoteWindowsTerminalCapabilities,
-  refreshShellPathAndDetectAgents,
-  runPreflightCheck
-} from '../preflight/agent-detection'
-import type {
-  PreflightRuntimeContext,
-  PreflightStatus,
-  RemoteWindowsTerminalCapabilities
-} from '../preflight/agent-detection'
+  type RemoteWindowsTerminalCapabilities
+} from './preflight-remote-windows-terminal-capabilities'
+import {
+  getTuiAgentDetectionProbeCommands,
+  KNOWN_TUI_AGENT_DETECTION_COMMANDS,
+  resolveDetectedTuiAgentIds
+} from './tui-agent-detection-commands'
 
-// Why this file is thin: everything above the handler layer moved to
-// ../preflight/agent-detection so the runtime can call it without ipcMain.
-// Re-exported here so existing importers of `ipc/preflight` keep working.
-export * from '../preflight/agent-detection'
+export type PreflightStatus = {
+  git: { installed: boolean }
+  gh: { installed: boolean; authenticated: boolean }
+  // Why: optional so existing renderer call sites that only render git/gh
+  // status keep typechecking. Consumers that surface GitLab-specific
+  // affordances (the GitLab tab in the source picker, MR list, etc.)
+  // gate on `glab?.authenticated`.
+  glab?: { installed: boolean; authenticated: boolean }
+  bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
+  azureDevOps?: {
+    configured: boolean
+    authenticated: boolean
+    account: string | null
+    baseUrl: string | null
+    tokenConfigured: boolean
+  }
+  gitea?: {
+    configured: boolean
+    authenticated: boolean
+    account: string | null
+    baseUrl: string | null
+    tokenConfigured: boolean
+  }
+}
+
+export { detectRemoteWindowsTerminalCapabilities }
+export type { RemoteWindowsTerminalCapabilities }
+
+// Why: cache the result so repeated Landing mounts don't re-spawn processes.
+// The check only runs once per app session — relaunch to re-check.
+let cached: PreflightStatus | null = null
+
+/** @internal - tests need a clean preflight cache between cases. */
+export function _resetPreflightCache(): void {
+  cached = null
+}
+
+function uniqueAgentIds(ids: Iterable<string>): string[] {
+  return [...new Set(ids)]
+}
+
+async function detectCommandRuntime(
+  command: string,
+  context?: PreflightRuntimeContext
+): Promise<{ installed: boolean; wslTarget?: WslPreflightTarget }> {
+  const wslTarget = getPreflightWslTarget(context)
+  if (wslTarget) {
+    return (await isCommandAvailable(command, wslTarget))
+      ? { installed: true, wslTarget }
+      : { installed: false }
+  }
+  if (await isCommandAvailable(command)) {
+    return { installed: true }
+  }
+  return { installed: false }
+}
+
+export async function detectInstalledAgents(context?: PreflightRuntimeContext): Promise<string[]> {
+  const wslTarget = getPreflightWslTarget(context)
+  if (wslTarget) {
+    const foundCommands = await detectWslCommandsOnPath(
+      wslTarget,
+      getTuiAgentDetectionProbeCommands(KNOWN_TUI_AGENT_DETECTION_COMMANDS, 'wsl')
+    )
+    return resolveDetectedTuiAgentIds(KNOWN_TUI_AGENT_DETECTION_COMMANDS, foundCommands, 'wsl')
+  }
+
+  const probeCommands = getTuiAgentDetectionProbeCommands(
+    KNOWN_TUI_AGENT_DETECTION_COMMANDS,
+    process.platform
+  )
+  const pathChecks = await Promise.all(
+    probeCommands.map(async (cmd) => ({
+      cmd,
+      installedOnPath: await isCommandOnPath(cmd)
+    }))
+  )
+  const missedCommands = pathChecks.filter((check) => !check.installedOnPath).map(({ cmd }) => cmd)
+  // Why: PATH may still be unhydrated on a cold GUI launch; bulk resolution
+  // computes user install dirs once instead of blocking once per missed CLI.
+  const installDirCommands = detectCommandsInInstallDirs(missedCommands)
+  const foundCommands = new Set(
+    pathChecks
+      .filter(({ cmd, installedOnPath }) => installedOnPath || installDirCommands.has(cmd))
+      .map(({ cmd }) => cmd)
+  )
+  return resolveDetectedTuiAgentIds(
+    KNOWN_TUI_AGENT_DETECTION_COMMANDS,
+    foundCommands,
+    process.platform
+  )
+}
+
+export async function detectInstalledAgentsWithShellPathHydration(
+  context?: PreflightRuntimeContext
+): Promise<string[]> {
+  await hydrateShellPathForAgentDetection(context)
+  return detectInstalledAgents(context)
+}
+
+export type RefreshAgentsResult = {
+  /** Agents detected after hydrating PATH from the user's login shell. */
+  agents: string[]
+  /** PATH segments that were added this refresh (empty if nothing new). */
+  addedPathSegments: string[]
+  /** True when the shell spawn succeeded. False = relied on existing PATH. */
+  shellHydrationOk: boolean
+  /** Whether `detectInstalledAgents` ran against shell-hydrated PATH or only
+   *  the seed list from `patchPackagedProcessPath`. Drives the on_path:false
+   *  triage in tile A on dashboard 1562016. */
+  pathSource: PathSource
+  /** Why hydration failed (or `'none'` on success). Typed against the shared
+   *  alias so the IPC boundary stays in lockstep with the renderer-visible
+   *  enum on `onboardingAgentPickedSchema`. */
+  pathFailureReason: ShellHydrationFailureReason
+}
+
+/**
+ * Re-spawn the user's login shell to refresh process.env.PATH, then re-run
+ * agent detection. Called by the Agents settings pane when the user clicks
+ * Refresh — handles the "installed a new CLI, Orca doesn't see it yet" case
+ * without requiring an app restart.
+ */
+export async function refreshShellPathAndDetectAgents(
+  context?: PreflightRuntimeContext
+): Promise<RefreshAgentsResult> {
+  if (getPreflightWslTarget(context)) {
+    const agents = await detectInstalledAgents(context)
+    return {
+      agents,
+      addedPathSegments: [],
+      shellHydrationOk: true,
+      pathSource: 'sync_seed_only',
+      pathFailureReason: 'none'
+    }
+  }
+
+  const hydration = await hydrateShellPath({ force: true })
+  const added = hydration.ok ? mergePathSegments(hydration.segments) : []
+  const agents = await detectInstalledAgents(context)
+  return {
+    agents,
+    addedPathSegments: added,
+    shellHydrationOk: hydration.ok,
+    pathSource: hydration.ok ? 'shell_hydrate' : 'sync_seed_only',
+    pathFailureReason: hydration.failureReason
+  }
+}
+
+export async function detectRemoteAgents(args: { connectionId: string }): Promise<string[]> {
+  const mux = getActiveMultiplexer(args.connectionId)
+  if (!mux || mux.isDisposed()) {
+    // Why: remote agent detection is passive UI polling. A disconnected host has
+    // no detectable agents until reconnect, but should not spam IPC errors.
+    return []
+  }
+  const result = (await mux.request('preflight.detectAgents', {
+    commands: KNOWN_TUI_AGENT_DETECTION_COMMANDS
+  })) as { agents: string[] }
+  return uniqueAgentIds(result.agents)
+}
+
+async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
+  try {
+    await (wslTarget
+      ? execCommandInWsl(wslTarget, `${shellQuote('gh')} auth status`)
+      : execLocalPreflightCommand('gh', ['auth', 'status']))
+    // Why: for plain-text `gh auth status`, exit 0 means gh did not detect any
+    // authentication issues for the checked hosts/accounts.
+    return true
+  } catch (error) {
+    // Why: some environments may surface partial command output on the thrown
+    // error object. Keep a compatibility fallback so we avoid a false auth
+    // warning if success markers are present despite a non-zero result.
+    const stdout = (error as { stdout?: string }).stdout ?? ''
+    const stderr = (error as { stderr?: string }).stderr ?? ''
+    const output = `${stdout}\n${stderr}`
+    return output.includes('Logged in') || output.includes('Active account: true')
+  }
+}
+
+// Why: parallel to isGhAuthenticated for the glab CLI. glab writes auth
+// status to stderr in some versions and stdout in others; check both.
+async function isGlabAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
+  try {
+    await (wslTarget
+      ? execCommandInWsl(wslTarget, `${shellQuote('glab')} auth status`)
+      : execLocalPreflightCommand('glab', ['auth', 'status']))
+    return true
+  } catch (error) {
+    const stdout = (error as { stdout?: string }).stdout ?? ''
+    const stderr = (error as { stderr?: string }).stderr ?? ''
+    const output = `${stdout}\n${stderr}`
+    return output.includes('Logged in')
+  }
+}
+
+export async function runPreflightCheck(
+  force = false,
+  context?: PreflightRuntimeContext
+): Promise<PreflightStatus> {
+  const wslTarget = getPreflightWslTarget(context)
+  const cacheable = !wslTarget
+  if (cacheable && cached && !force) {
+    return cached
+  }
+
+  if (process.platform === 'win32' && !wslTarget) {
+    await mergePersistedWindowsPathAsync(process.env, { forceRefresh: force })
+  }
+
+  const [gitProbe, ghProbe, glabProbe] = await Promise.all([
+    detectCommandRuntime('git', context),
+    detectCommandRuntime('gh', context),
+    detectCommandRuntime('glab', context)
+  ])
+
+  const [ghAuthenticated, glabAuthenticated, bitbucket, azureDevOps, gitea] = await Promise.all([
+    ghProbe.installed ? isGhAuthenticated(ghProbe.wslTarget) : Promise.resolve(false),
+    glabProbe.installed ? isGlabAuthenticated(glabProbe.wslTarget) : Promise.resolve(false),
+    getBitbucketAuthStatus(),
+    getAzureDevOpsAuthStatus(),
+    getGiteaAuthStatus()
+  ])
+
+  const result = {
+    git: { installed: gitProbe.installed },
+    gh: { installed: ghProbe.installed, authenticated: ghAuthenticated },
+    glab: { installed: glabProbe.installed, authenticated: glabAuthenticated },
+    bitbucket,
+    azureDevOps,
+    gitea
+  }
+
+  if (cacheable) {
+    cached = result
+  }
+
+  return result
+}
 
 export function registerPreflightHandlers(): void {
   ipcMain.handle(

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -4,6 +4,7 @@ import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-pa
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
+import { getConfiguredGitLabHost } from '../gitlab/gitlab-known-host-probe'
 import { mergePersistedWindowsPathAsync } from '../pty/windows-environment-path'
 import { getActiveMultiplexer } from './ssh'
 import { detectWslCommandsOnPath, type WslPreflightTarget } from './preflight-wsl-agent-detection'
@@ -33,8 +34,9 @@ export type PreflightStatus = {
   // Why: optional so existing renderer call sites that only render git/gh
   // status keep typechecking. Consumers that surface GitLab-specific
   // affordances (the GitLab tab in the source picker, MR list, etc.)
-  // gate on `glab?.authenticated`.
-  glab?: { installed: boolean; authenticated: boolean }
+  // gate on `glab?.authenticated`. `configured` is false when no GitLab
+  // instance URL is set — GitLab routing is off, so auth is not even probed.
+  glab?: { installed: boolean; authenticated: boolean; configured: boolean }
   bitbucket?: { configured: boolean; authenticated: boolean; account: string | null }
   azureDevOps?: {
     configured: boolean
@@ -58,10 +60,14 @@ export type { RemoteWindowsTerminalCapabilities }
 // Why: cache the result so repeated Landing mounts don't re-spawn processes.
 // The check only runs once per app session — relaunch to re-check.
 let cached: PreflightStatus | null = null
+// Why: the glab result is scoped to the configured instance, so switching or
+// clearing the GitLab URL must not keep serving the previous host's verdict.
+let cachedGitLabHost: string | null = null
 
 /** @internal - tests need a clean preflight cache between cases. */
 export function _resetPreflightCache(): void {
   cached = null
+  cachedGitLabHost = null
 }
 
 function uniqueAgentIds(ids: Iterable<string>): string[] {
@@ -208,13 +214,23 @@ async function isGhAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolea
   }
 }
 
-// Why: parallel to isGhAuthenticated for the glab CLI. glab writes auth
-// status to stderr in some versions and stdout in others; check both.
-async function isGlabAuthenticated(wslTarget?: WslPreflightTarget): Promise<boolean> {
+// Why: parallel to isGhAuthenticated for the glab CLI, but pinned to the one
+// configured instance — an unscoped `glab auth status` exits 0 when any
+// unrelated host is logged in, which would report GitLab connected for an
+// instance Orca never routes to. glab writes auth status to stderr in some
+// versions and stdout in others; check both.
+async function isGlabAuthenticated(
+  gitlabHost: string,
+  wslTarget?: WslPreflightTarget
+): Promise<boolean> {
+  const args = ['auth', 'status', '--hostname', gitlabHost]
   try {
     await (wslTarget
-      ? execCommandInWsl(wslTarget, `${shellQuote('glab')} auth status`)
-      : execLocalPreflightCommand('glab', ['auth', 'status']))
+      ? execCommandInWsl(
+          wslTarget,
+          `${shellQuote('glab')} auth status --hostname ${shellQuote(gitlabHost)}`
+        )
+      : execLocalPreflightCommand('glab', args))
     return true
   } catch (error) {
     const stdout = (error as { stdout?: string }).stdout ?? ''
@@ -230,7 +246,8 @@ export async function runPreflightCheck(
 ): Promise<PreflightStatus> {
   const wslTarget = getPreflightWslTarget(context)
   const cacheable = !wslTarget
-  if (cacheable && cached && !force) {
+  const gitlabHost = getConfiguredGitLabHost()
+  if (cacheable && cached && !force && cachedGitLabHost === gitlabHost) {
     return cached
   }
 
@@ -246,7 +263,9 @@ export async function runPreflightCheck(
 
   const [ghAuthenticated, glabAuthenticated, bitbucket, azureDevOps, gitea] = await Promise.all([
     ghProbe.installed ? isGhAuthenticated(ghProbe.wslTarget) : Promise.resolve(false),
-    glabProbe.installed ? isGlabAuthenticated(glabProbe.wslTarget) : Promise.resolve(false),
+    glabProbe.installed && gitlabHost
+      ? isGlabAuthenticated(gitlabHost, glabProbe.wslTarget)
+      : Promise.resolve(false),
     getBitbucketAuthStatus(),
     getAzureDevOpsAuthStatus(),
     getGiteaAuthStatus()
@@ -255,7 +274,11 @@ export async function runPreflightCheck(
   const result = {
     git: { installed: gitProbe.installed },
     gh: { installed: ghProbe.installed, authenticated: ghAuthenticated },
-    glab: { installed: glabProbe.installed, authenticated: glabAuthenticated },
+    glab: {
+      installed: glabProbe.installed,
+      authenticated: glabAuthenticated,
+      configured: Boolean(gitlabHost)
+    },
     bitbucket,
     azureDevOps,
     gitea
@@ -263,6 +286,7 @@ export async function runPreflightCheck(
 
   if (cacheable) {
     cached = result
+    cachedGitLabHost = gitlabHost
   }
 
   return result

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -1,10 +1,12 @@
 import { ipcMain } from 'electron'
-import type { PathSource, ShellHydrationFailureReason } from '../../shared/types'
+import type { PathSource, ShellHydrationFailureReason } from '../../shared/shell-path-hydration-types'
 import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { getConfiguredGitLabHost } from '../gitlab/gitlab-known-host-probe'
+import { redirectPortedHostnameToEnv } from '../git/glab-ported-hostname-env'
+import { buildLocalPreflightEnv } from './preflight-local-env'
 import { mergePersistedWindowsPathAsync } from '../pty/windows-environment-path'
 import { getActiveMultiplexer } from './ssh'
 import { detectWslCommandsOnPath, type WslPreflightTarget } from './preflight-wsl-agent-detection'
@@ -223,14 +225,18 @@ async function isGlabAuthenticated(
   gitlabHost: string,
   wslTarget?: WslPreflightTarget
 ): Promise<boolean> {
-  const args = ['auth', 'status', '--hostname', gitlabHost]
+  // Why: glab rejects `--hostname host:port`, so a ported instance has to ride
+  // GITLAB_HOST instead (plus WSLENV to survive the wsl.exe boundary).
+  const { args, options } = redirectPortedHostnameToEnv(
+    ['auth', 'status', '--hostname', gitlabHost],
+    { env: buildLocalPreflightEnv() }
+  )
   try {
     await (wslTarget
-      ? execCommandInWsl(
-          wslTarget,
-          `${shellQuote('glab')} auth status --hostname ${shellQuote(gitlabHost)}`
-        )
-      : execLocalPreflightCommand('glab', args))
+      ? execCommandInWsl(wslTarget, ['glab', ...args].map(shellQuote).join(' '), {
+          env: options.env
+        })
+      : execLocalPreflightCommand('glab', args, { env: options.env }))
     return true
   } catch (error) {
     const stdout = (error as { stdout?: string }).stdout ?? ''

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,7 +1,6 @@
 import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import type { Store } from '../persistence'
-import type { GlobalSettings } from '../../shared/global-settings-types'
-import type { PersistedState } from '../../shared/persisted-state-types'
+import type { GlobalSettings, PersistedState } from '../../shared/types'
 import { listSystemFontFamilies } from '../system-fonts'
 import { previewGhosttyImport } from '../ghostty/index'
 import { previewWarpThemeImport } from '../warp-themes'
@@ -12,10 +11,7 @@ import { SETTINGS_CHANGED_WHITELIST, type SettingsChangedKey } from '../../share
 import type { AgentAwakeService } from '../agent-awake-service'
 import { sanitizeFloatingWorkspaceDirectorySetting } from './floating-workspace-directory'
 import { applyAgentStatusHooksEnabled } from '../agent-hooks/managed-agent-hook-controls'
-import { recordManagedHookInstallFailure } from '../agent-hooks/install-telemetry'
 import { applyElectronProxySettings } from '../network/proxy-settings'
-import { applyBrowserSessionProxies } from '../browser/browser-session-proxy'
-import { browserSessionRegistry } from '../browser/browser-session-registry'
 import { normalizeProxyBypassRules, normalizeProxyUrl } from '../../shared/network-proxy'
 import { normalizeAppIconId } from '../../shared/app-icon'
 import { normalizeUiLanguage } from '../../shared/ui-language'
@@ -27,15 +23,7 @@ import { prepareLocalWorktreeRootsForRepos } from '../worktree-root-preparation'
 import { scheduleCurrentWorktreeBaseDirectoryWatcherSync } from './worktree-base-directory-watcher'
 import { applyPRBotAuthorOverride } from '../../shared/pr-bot-author-overrides'
 import { resolveEnvironment } from '../../shared/runtime-environment-store'
-import { haveSameDisabledTuiAgents } from '../../shared/tui-agent-selection'
-import {
-  normalizeMobilePairingCustomAddress,
-  normalizeMobilePairingCustomAddresses
-} from '../../shared/mobile-pairing-custom-address'
-import {
-  computerAwakeSettingsForMode,
-  normalizeComputerAwakeMode
-} from '../../shared/computer-awake-mode'
+import { normalizeGitLabUrl } from '../../shared/gitlab-instance-url'
 
 // Why: the whitelist is the source-of-truth for which keys we emit on. Casting
 // to a Set once at module load lets the IPC handler's per-key membership
@@ -72,18 +60,6 @@ export function registerSettingsHandlers(
   store: Store,
   agentAwakeService?: AgentAwakeService
 ): void {
-  ipcMain.handle(
-    'agentAwake:getStatus',
-    () => agentAwakeService?.getStatus() ?? { mode: 'off', active: false }
-  )
-  agentAwakeService?.subscribe?.((status) => {
-    for (const window of BrowserWindow.getAllWindows()) {
-      if (!window.isDestroyed()) {
-        window.webContents.send('agentAwake:changed', status)
-      }
-    }
-  })
-
   store.onSettingsChanged((updates, _settings, originWebContentsId) => {
     for (const window of BrowserWindow.getAllWindows()) {
       const isOrigin =
@@ -128,22 +104,6 @@ export function registerSettingsHandlers(
     // Why: Floating Workspace grants are trusted only when written by the
     // main-process directory picker, never by renderer-provided settings IPC.
     delete sanitizedArgs.floatingTerminalTrustedCwds
-    if ('computerAwakeMode' in sanitizedArgs) {
-      Object.assign(
-        sanitizedArgs,
-        computerAwakeSettingsForMode(
-          normalizeComputerAwakeMode(
-            sanitizedArgs.computerAwakeMode,
-            sanitizedArgs.keepComputerAwakeWhileAgentsRun
-          )
-        )
-      )
-    } else if ('keepComputerAwakeWhileAgentsRun' in sanitizedArgs) {
-      Object.assign(
-        sanitizedArgs,
-        computerAwakeSettingsForMode(sanitizedArgs.keepComputerAwakeWhileAgentsRun ? 'auto' : 'off')
-      )
-    }
     if (typeof args.floatingTerminalCwd === 'string') {
       sanitizedArgs.floatingTerminalCwd = await sanitizeFloatingWorkspaceDirectorySetting(
         store,
@@ -174,15 +134,8 @@ export function registerSettingsHandlers(
     if ('uiLanguage' in args) {
       sanitizedArgs.uiLanguage = normalizeUiLanguage(args.uiLanguage)
     }
-    if ('mobilePairingCustomAddress' in args) {
-      sanitizedArgs.mobilePairingCustomAddress = normalizeMobilePairingCustomAddress(
-        args.mobilePairingCustomAddress
-      )
-    }
-    if ('mobilePairingCustomAddresses' in args) {
-      sanitizedArgs.mobilePairingCustomAddresses = normalizeMobilePairingCustomAddresses(
-        args.mobilePairingCustomAddresses
-      )
+    if ('gitlabUrl' in args) {
+      sanitizedArgs.gitlabUrl = normalizeGitLabUrl(args.gitlabUrl)
     }
     if (args.theme) {
       nativeTheme.themeSource = args.theme
@@ -196,57 +149,17 @@ export function registerSettingsHandlers(
       notifyListeners: true,
       originWebContentsId: event.sender.id
     })
-    const proxySettingsChanged =
-      ('httpProxyUrl' in sanitizedArgs && before.httpProxyUrl !== result.httpProxyUrl) ||
-      ('httpProxyBypassRules' in sanitizedArgs &&
-        before.httpProxyBypassRules !== result.httpProxyBypassRules)
-    if (proxySettingsChanged) {
-      // Start both authorities before yielding so requests cannot enter between their barriers.
-      const defaultSessionApply = applyElectronProxySettings(result)
-      const browserSessionsApply = applyBrowserSessionProxies(
-        browserSessionRegistry.listProfiles(),
-        result
-      )
-      const [defaultSessionResult, browserSessionsResult] = await Promise.allSettled([
-        defaultSessionApply,
-        browserSessionsApply
-      ])
-      if (defaultSessionResult.status === 'rejected') {
-        console.warn('[settings] failed to apply network proxy settings')
-      }
-      if (browserSessionsResult.status === 'rejected') {
-        console.warn('[settings] failed to apply network proxy settings to browser sessions')
-      }
+    if ('keepComputerAwakeWhileAgentsRun' in sanitizedArgs) {
+      agentAwakeService?.setEnabled(result.keepComputerAwakeWhileAgentsRun)
     }
     if (
-      'computerAwakeMode' in sanitizedArgs ||
-      'keepComputerAwakeWhileAgentsRun' in sanitizedArgs
+      'agentStatusHooksEnabled' in sanitizedArgs &&
+      before.agentStatusHooksEnabled !== result.agentStatusHooksEnabled
     ) {
-      agentAwakeService?.setMode(
-        normalizeComputerAwakeMode(result.computerAwakeMode, result.keepComputerAwakeWhileAgentsRun)
-      )
-    }
-    const hookSettingChanged =
-      ('agentStatusHooksEnabled' in sanitizedArgs &&
-        before.agentStatusHooksEnabled !== result.agentStatusHooksEnabled) ||
-      ('disabledTuiAgents' in sanitizedArgs &&
-        !haveSameDisabledTuiAgents(before.disabledTuiAgents, result.disabledTuiAgents))
-    if (hookSettingChanged) {
       try {
-        await applyAgentStatusHooksEnabled(result.agentStatusHooksEnabled, result, {
-          userInitiated: true,
-          shouldHydrateShellPath: app.isPackaged,
-          onInstallError: recordManagedHookInstallFailure,
-          shouldContinue: (agent) => {
-            const settings = store.getSettings()
-            return (
-              settings.agentStatusHooksEnabled !== false &&
-              !settings.disabledTuiAgents.includes(agent)
-            )
-          }
-        })
+        applyAgentStatusHooksEnabled(result.agentStatusHooksEnabled)
       } catch (error) {
-        console.warn('[settings] failed to reconcile managed agent hooks:', error)
+        console.warn('[settings] failed to apply agentStatusHooksEnabled:', error)
       }
     }
     if ('uiLanguage' in sanitizedArgs && before.uiLanguage !== result.uiLanguage) {
@@ -262,6 +175,13 @@ export function registerSettingsHandlers(
     }
     if (APPEARANCE_MENU_KEYS.some((key) => key in sanitizedArgs)) {
       rebuildAppMenu()
+    }
+    if ('httpProxyUrl' in sanitizedArgs || 'httpProxyBypassRules' in sanitizedArgs) {
+      try {
+        await applyElectronProxySettings(result)
+      } catch {
+        console.warn('[settings] failed to apply network proxy settings')
+      }
     }
     if ('appIcon' in sanitizedArgs && before.appIcon !== result.appIcon) {
       applyAppIcon(result.appIcon)

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import type { Store } from '../persistence'
-import type { GlobalSettings, PersistedState } from '../../shared/types'
+import type { GlobalSettings } from '../../shared/global-settings-types'
+import type { PersistedState } from '../../shared/persisted-state-types'
 import { listSystemFontFamilies } from '../system-fonts'
 import { previewGhosttyImport } from '../ghostty/index'
 import { previewWarpThemeImport } from '../warp-themes'

--- a/src/main/runtime/rpc/methods/gitlab.test.ts
+++ b/src/main/runtime/rpc/methods/gitlab.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import type { OrcaRuntimeService } from '../../orca-runtime'
+import { setConfiguredGitLabUrl } from '../../../gitlab/gitlab-known-host-probe'
 import { GITLAB_METHODS } from './gitlab'
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
@@ -9,6 +10,14 @@ function makeRequest(method: string, params?: unknown): RpcRequest {
 }
 
 describe('gitlab RPC methods', () => {
+  beforeEach(() => {
+    setConfiguredGitLabUrl('https://gitlab.example.com')
+  })
+
+  afterEach(() => {
+    setConfiguredGitLabUrl('')
+  })
+
   it('routes GitLab task queries and mutations to the runtime server', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
@@ -373,5 +382,174 @@ describe('gitlab RPC methods', () => {
     expect(bounded).toContain('ERROR: Job failed: exit code 1')
     expect(bounded).not.toContain('section_start')
     expect(bounded).not.toContain('line 0\n')
+  })
+
+  // Why: a client-supplied host/projectRef is a `glab --hostname` override that
+  // skips remote resolution, so a crafted RPC payload could otherwise aim
+  // credentialed glab calls at an arbitrary GitLab.
+  describe('configured-instance host guard', () => {
+    const OTHER_HOST = 'gitlab.evil.test'
+
+    function makeGuardRuntime(): OrcaRuntimeService {
+      return {
+        getRuntimeId: () => 'test-runtime',
+        getGitLabRateLimit: vi.fn().mockResolvedValue({ ok: true }),
+        getGitLabRepoJobTrace: vi.fn().mockResolvedValue({ ok: true }),
+        retryGitLabRepoJob: vi.fn().mockResolvedValue({ ok: true }),
+        updateGitLabRepoMRReviewers: vi.fn().mockResolvedValue({ ok: true }),
+        addGitLabRepoMRInlineComment: vi.fn().mockResolvedValue({ ok: true }),
+        getGitLabRepoWorkItemDetails: vi.fn().mockResolvedValue({ body: 'Details' }),
+        getGitLabRepoWorkItemByPath: vi.fn().mockResolvedValue({ id: 'gitlab-issue-7' })
+      } as unknown as OrcaRuntimeService
+    }
+
+    const inlineInput = {
+      body: 'Inline',
+      path: 'src/a.ts',
+      line: 12,
+      baseSha: 'base',
+      startSha: 'start',
+      headSha: 'head'
+    }
+
+    it.each([
+      ['gitlab.jobTrace', { jobId: 99 }, 'getGitLabRepoJobTrace'],
+      ['gitlab.retryJob', { jobId: 99 }, 'retryGitLabRepoJob'],
+      ['gitlab.updateMRReviewers', { iid: 8, reviewerIds: [1] }, 'updateGitLabRepoMRReviewers'],
+      [
+        'gitlab.addMRInlineComment',
+        { iid: 8, input: inlineInput },
+        'addGitLabRepoMRInlineComment'
+      ],
+      ['gitlab.workItemDetails', { iid: 8, type: 'mr' }, 'getGitLabRepoWorkItemDetails']
+    ])('rejects %s for a projectRef on another host', async (method, args, runtimeMethod) => {
+      const runtime = makeGuardRuntime()
+      const dispatcher = new RpcDispatcher({ runtime, methods: GITLAB_METHODS })
+
+      const response = await dispatcher.dispatch(
+        makeRequest(method as string, {
+          repo: 'id:repo-1',
+          ...(args as object),
+          projectRef: { host: OTHER_HOST, path: 'attacker/exfil' }
+        })
+      )
+
+      expect(response).toMatchObject({
+        ok: false,
+        error: { code: 'invalid_argument', message: expect.stringContaining('does not match') }
+      })
+      expect(runtime[runtimeMethod as keyof OrcaRuntimeService]).not.toHaveBeenCalled()
+    })
+
+    it('rejects a pasted work item on another host', async () => {
+      const runtime = makeGuardRuntime()
+      const dispatcher = new RpcDispatcher({ runtime, methods: GITLAB_METHODS })
+
+      const response = await dispatcher.dispatch(
+        makeRequest('gitlab.workItemByPath', {
+          repo: 'id:repo-1',
+          host: OTHER_HOST,
+          path: 'attacker/exfil',
+          iid: 1,
+          type: 'issue'
+        })
+      )
+
+      expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+      expect(runtime.getGitLabRepoWorkItemByPath).not.toHaveBeenCalled()
+    })
+
+    it('rejects a rateLimit host on another host', async () => {
+      const runtime = makeGuardRuntime()
+      const dispatcher = new RpcDispatcher({ runtime, methods: GITLAB_METHODS })
+
+      const response = await dispatcher.dispatch(
+        makeRequest('gitlab.rateLimit', { force: true, host: OTHER_HOST })
+      )
+
+      expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+      expect(runtime.getGitLabRateLimit).not.toHaveBeenCalled()
+    })
+
+    it('rejects any supplied host when no GitLab instance is configured', async () => {
+      setConfiguredGitLabUrl('')
+      const runtime = makeGuardRuntime()
+      const dispatcher = new RpcDispatcher({ runtime, methods: GITLAB_METHODS })
+
+      for (const request of [
+        makeRequest('gitlab.rateLimit', { host: 'gitlab.example.com' }),
+        makeRequest('gitlab.workItemByPath', {
+          repo: 'id:repo-1',
+          host: 'gitlab.example.com',
+          path: 'g/p',
+          iid: 1,
+          type: 'issue'
+        }),
+        makeRequest('gitlab.jobTrace', {
+          repo: 'id:repo-1',
+          jobId: 99,
+          projectRef: { host: 'gitlab.example.com', path: 'g/p' }
+        })
+      ]) {
+        expect(await dispatcher.dispatch(request)).toMatchObject({
+          ok: false,
+          error: {
+            code: 'invalid_argument',
+            message: expect.stringContaining('no GitLab instance is configured')
+          }
+        })
+      }
+      expect(runtime.getGitLabRateLimit).not.toHaveBeenCalled()
+      expect(runtime.getGitLabRepoWorkItemByPath).not.toHaveBeenCalled()
+      expect(runtime.getGitLabRepoJobTrace).not.toHaveBeenCalled()
+    })
+
+    it('canonicalizes a matching host before it reaches the runtime', async () => {
+      const runtime = makeGuardRuntime()
+      const dispatcher = new RpcDispatcher({ runtime, methods: GITLAB_METHODS })
+
+      await dispatcher.dispatch(
+        makeRequest('gitlab.rateLimit', { host: ' GitLab.Example.COM ' })
+      )
+      await dispatcher.dispatch(
+        makeRequest('gitlab.workItemByPath', {
+          repo: 'id:repo-1',
+          host: 'GITLAB.example.com',
+          path: 'g/p',
+          iid: 7,
+          type: 'issue'
+        })
+      )
+      await dispatcher.dispatch(
+        makeRequest('gitlab.jobTrace', {
+          repo: 'id:repo-1',
+          jobId: 99,
+          projectRef: { host: 'GitLab.Example.com', path: 'g/p' }
+        })
+      )
+
+      expect(runtime.getGitLabRateLimit).toHaveBeenCalledWith({ host: 'gitlab.example.com' })
+      expect(runtime.getGitLabRepoWorkItemByPath).toHaveBeenCalledWith(
+        'id:repo-1',
+        { host: 'gitlab.example.com', path: 'g/p' },
+        7,
+        'issue'
+      )
+      expect(runtime.getGitLabRepoJobTrace).toHaveBeenCalledWith('id:repo-1', 99, {
+        host: 'gitlab.example.com',
+        path: 'g/p'
+      })
+    })
+
+    it('leaves an omitted host on the resolved-remote path', async () => {
+      const runtime = makeGuardRuntime()
+      const dispatcher = new RpcDispatcher({ runtime, methods: GITLAB_METHODS })
+
+      await dispatcher.dispatch(makeRequest('gitlab.rateLimit', { force: true }))
+      await dispatcher.dispatch(makeRequest('gitlab.jobTrace', { repo: 'id:repo-1', jobId: 99 }))
+
+      expect(runtime.getGitLabRateLimit).toHaveBeenCalledWith({ force: true })
+      expect(runtime.getGitLabRepoJobTrace).toHaveBeenCalledWith('id:repo-1', 99, undefined)
+    })
   })
 })

--- a/src/main/runtime/rpc/methods/gitlab.ts
+++ b/src/main/runtime/rpc/methods/gitlab.ts
@@ -2,29 +2,51 @@ import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
 import { normalizeGitLabIssueListArgs } from '../../../gitlab/gitlab-preload-args'
-import { toGitLabJobLogExcerptResult } from '../../../../shared/gitlab-job-log-excerpt'
+import { resolveConfiguredGitLabHost } from '../../../gitlab/configured-instance-host-guard'
 
 const RepoSelector = z.object({
   repo: requiredString('Missing repo selector')
 })
 
+// Why: a client-supplied host is a `glab --hostname` override that skips remote
+// resolution, so pin it to the configured instance here at the parse boundary —
+// every method reusing these schemas inherits the guard, and handlers only ever
+// see the canonical host.
+function pinToConfiguredGitLabHost(value: string, ctx: z.RefinementCtx): string {
+  const resolution = resolveConfiguredGitLabHost(value)
+  if (!resolution.ok) {
+    ctx.addIssue({ code: 'custom', message: `Access denied: ${resolution.reason}` })
+    return z.NEVER
+  }
+  return resolution.host
+}
+
+const ConfiguredGitLabHost = z.string().transform(pinToConfiguredGitLabHost)
+
+// Why: an omitted host keeps the resolved-remote path; a supplied one is pinned.
+const OptionalConfiguredGitLabHost = z
+  .unknown()
+  .transform((value) => (typeof value === 'string' && value.length > 0 ? value : undefined))
+  .transform((value, ctx) =>
+    value === undefined ? undefined : pinToConfiguredGitLabHost(value, ctx)
+  )
+  .optional()
+
 const EmptyParams = z.object({}).optional().default({})
 const GitLabRateLimit = z
   .object({
     force: z.boolean().optional(),
-    host: OptionalString
+    host: OptionalConfiguredGitLabHost
   })
   .optional()
   .default({})
 
-// nullish, not optional: renderer callers normalise a missing ref to `null`
-// (`item.projectRef ?? null`), which a bare `.optional()` would reject outright.
 const GitLabProjectRef = z
   .object({
-    host: requiredString('Missing GitLab host'),
+    host: ConfiguredGitLabHost,
     path: requiredString('Missing GitLab project path')
   })
-  .nullish()
+  .optional()
 
 const WorkItemsList = RepoSelector.extend({
   state: z.enum(['opened', 'merged', 'closed', 'all']).optional(),
@@ -36,8 +58,7 @@ const WorkItemsList = RepoSelector.extend({
 const IssuesList = RepoSelector.extend({
   state: z.unknown().optional(),
   assignee: OptionalString,
-  limit: OptionalFiniteNumber,
-  page: OptionalFiniteNumber
+  limit: OptionalFiniteNumber
 })
 
 const CreateIssue = RepoSelector.extend({
@@ -73,8 +94,7 @@ const UpdateMr = RepoSelector.extend({
     title: z.string().optional(),
     body: z.string().optional(),
     addLabels: z.array(z.string()).optional(),
-    removeLabels: z.array(z.string()).optional(),
-    readyForReview: z.literal(true).optional()
+    removeLabels: z.array(z.string()).optional()
   }),
   projectRef: GitLabProjectRef
 })
@@ -126,10 +146,7 @@ const ResolveMRDiscussion = RepoSelector.extend({
 
 const JobTrace = RepoSelector.extend({
   jobId: z.number().int().positive(),
-  projectRef: GitLabProjectRef,
-  // Why: raw CI traces routinely exceed the 1 MB transport frame cap, so callers
-  // that only render an excerpt ask main to bound it before it crosses the wire.
-  logExcerpt: z.boolean().optional()
+  projectRef: GitLabProjectRef
 })
 
 const RetryJob = RepoSelector.extend({
@@ -144,7 +161,7 @@ const WorkItemDetails = RepoSelector.extend({
 })
 
 const WorkItemByPath = RepoSelector.extend({
-  host: requiredString('Missing GitLab host'),
+  host: ConfiguredGitLabHost,
   path: requiredString('Missing GitLab project path'),
   iid: z.number().int().positive(),
   type: z.enum(['issue', 'mr'])
@@ -184,8 +201,7 @@ export const GITLAB_METHODS: RpcMethod[] = [
         params.repo,
         normalized.state,
         normalized.assignee,
-        normalized.limit,
-        normalized.page
+        normalized.limit
       )
     }
   }),
@@ -254,14 +270,8 @@ export const GITLAB_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'gitlab.jobTrace',
     params: JobTrace,
-    handler: async (params, { runtime }) => {
-      const result = await runtime.getGitLabRepoJobTrace(
-        params.repo,
-        params.jobId,
-        params.projectRef
-      )
-      return params.logExcerpt ? toGitLabJobLogExcerptResult(result) : result
-    }
+    handler: async (params, { runtime }) =>
+      runtime.getGitLabRepoJobTrace(params.repo, params.jobId, params.projectRef)
   }),
   defineMethod({
     name: 'gitlab.retryJob',

--- a/src/renderer/src/components/settings/GitLabUrlSetting.test.tsx
+++ b/src/renderer/src/components/settings/GitLabUrlSetting.test.tsx
@@ -7,7 +7,16 @@ import { getDefaultSettings } from '../../../../shared/constants'
 import type { GlobalSettings } from '../../../../shared/types'
 import { GitLabUrlSetting } from './GitLabUrlSetting'
 
-type SettingsWithGitLabUrl = GlobalSettings & { gitlabUrl?: string }
+function typeInto(input: HTMLInputElement, value: string): void {
+  const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  setValue?.call(input, value)
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+// Why: React routes onBlur through the bubbling focusout event.
+function blurField(input: HTMLInputElement): void {
+  input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+}
 
 describe('GitLabUrlSetting', () => {
   let container: HTMLDivElement
@@ -29,10 +38,7 @@ describe('GitLabUrlSetting', () => {
     gitlabUrl: string,
     updateSettings: (updates: Partial<GlobalSettings>) => void
   ): Promise<HTMLInputElement> {
-    const settings: SettingsWithGitLabUrl = {
-      ...getDefaultSettings('/home/test'),
-      gitlabUrl
-    }
+    const settings: GlobalSettings = { ...getDefaultSettings('/home/test'), gitlabUrl }
 
     await act(async () => {
       root.render(<GitLabUrlSetting settings={settings} updateSettings={updateSettings} />)
@@ -53,17 +59,48 @@ describe('GitLabUrlSetting', () => {
     expect(container.textContent).toContain('Orca uses this single URL for GitLab operations.')
   })
 
-  it('persists URL edits when the field loses focus', async () => {
+  it('persists URL edits when the field loses focus, not per keystroke', async () => {
     const updateSettings = vi.fn()
     const input = await renderSetting('', updateSettings)
 
     await act(async () => {
-      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
-      setValue?.call(input, 'https://gitlab.company.test')
-      input.dispatchEvent(new Event('input', { bubbles: true }))
-      input.dispatchEvent(new Event('blur', { bubbles: true }))
+      typeInto(input, 'https://gitlab.company.test')
+    })
+    expect(updateSettings).not.toHaveBeenCalled()
+
+    await act(async () => {
+      blurField(input)
+    })
+    expect(updateSettings).toHaveBeenCalledWith({ gitlabUrl: 'https://gitlab.company.test' })
+  })
+
+  it('shows the normalized value back and skips the write when nothing changed', async () => {
+    const updateSettings = vi.fn()
+    const input = await renderSetting('https://gitlab.company.test', updateSettings)
+
+    await act(async () => {
+      typeInto(input, 'HTTPS://GitLab.Company.test/group/')
+    })
+    await act(async () => {
+      blurField(input)
     })
 
-    expect(updateSettings).toHaveBeenCalledWith({ gitlabUrl: 'https://gitlab.company.test' })
+    expect(input.value).toBe('https://gitlab.company.test')
+    expect(updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('clears a URL it cannot use instead of leaving it looking saved', async () => {
+    const updateSettings = vi.fn()
+    const input = await renderSetting('', updateSettings)
+
+    await act(async () => {
+      typeInto(input, 'gitlab.company.test')
+    })
+    await act(async () => {
+      blurField(input)
+    })
+
+    expect(input.value).toBe('')
+    expect(updateSettings).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/settings/GitLabUrlSetting.test.tsx
+++ b/src/renderer/src/components/settings/GitLabUrlSetting.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
-import type { GlobalSettings } from '../../../../shared/types'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { GitLabUrlSetting } from './GitLabUrlSetting'
 
 function typeInto(input: HTMLInputElement, value: string): void {

--- a/src/renderer/src/components/settings/GitLabUrlSetting.test.tsx
+++ b/src/renderer/src/components/settings/GitLabUrlSetting.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import type { GlobalSettings } from '../../../../shared/types'
+import { GitLabUrlSetting } from './GitLabUrlSetting'
+
+type SettingsWithGitLabUrl = GlobalSettings & { gitlabUrl?: string }
+
+describe('GitLabUrlSetting', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    document.body.replaceChildren()
+  })
+
+  async function renderSetting(
+    gitlabUrl: string,
+    updateSettings: (updates: Partial<GlobalSettings>) => void
+  ): Promise<HTMLInputElement> {
+    const settings: SettingsWithGitLabUrl = {
+      ...getDefaultSettings('/home/test'),
+      gitlabUrl
+    }
+
+    await act(async () => {
+      root.render(<GitLabUrlSetting settings={settings} updateSettings={updateSettings} />)
+    })
+
+    const input = container.querySelector<HTMLInputElement>('input')
+    if (!input) {
+      throw new Error('GitLab URL input not found')
+    }
+    return input
+  }
+
+  it('shows the configured URL and single-instance helper copy', async () => {
+    const input = await renderSetting('https://gitlab.example.com', () => {})
+
+    expect(input.value).toBe('https://gitlab.example.com')
+    expect(input.type).toBe('url')
+    expect(container.textContent).toContain('Orca uses this single URL for GitLab operations.')
+  })
+
+  it('persists URL edits when the field loses focus', async () => {
+    const updateSettings = vi.fn()
+    const input = await renderSetting('', updateSettings)
+
+    await act(async () => {
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setValue?.call(input, 'https://gitlab.company.test')
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      input.dispatchEvent(new Event('blur', { bubbles: true }))
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ gitlabUrl: 'https://gitlab.company.test' })
+  })
+})

--- a/src/renderer/src/components/settings/GitLabUrlSetting.tsx
+++ b/src/renderer/src/components/settings/GitLabUrlSetting.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { GlobalSettings } from '../../../../shared/types'
+import { normalizeGitLabUrl } from '../../../../shared/gitlab-instance-url'
 import { translate } from '@/i18n/i18n'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
@@ -9,9 +10,6 @@ import { matchesSettingsSearch } from './settings-search'
 const GITLAB_URL_TITLE = 'GitLab URL'
 const GITLAB_URL_DESCRIPTION = 'Orca uses this single URL for GitLab operations.'
 const GITLAB_URL_KEYWORDS = ['gitlab', 'gitlab url', 'self-hosted', 'instance', 'server']
-
-type GitLabSettings = GlobalSettings & { gitlabUrl?: string }
-type GitLabSettingsPatch = Partial<GlobalSettings> & { gitlabUrl?: string }
 
 type GitLabUrlSettingProps = {
   settings: GlobalSettings
@@ -35,6 +33,9 @@ export function GitLabUrlSetting({
     'auto.components.settings.GitLabUrlSetting.description',
     GITLAB_URL_DESCRIPTION
   )
+  const gitlabUrl = settings.gitlabUrl ?? ''
+  // Why: commit on blur, not per keystroke — a half-typed URL would otherwise
+  // be persisted and re-route every GitLab request while the user is typing.
   const [draft, setDraft] = useState(gitlabUrl)
   useEffect(() => setDraft(gitlabUrl), [gitlabUrl])
 
@@ -58,8 +59,13 @@ export function GitLabUrlSetting({
         className="max-w-md"
         onChange={(event) => setDraft(event.target.value)}
         onBlur={() => {
-          const patch: GitLabSettingsPatch = { gitlabUrl: draft }
-          void updateSettings(patch)
+          // Why: show the stored value back, so a URL the main process
+          // rejects doesn't linger in the field looking saved.
+          const normalized = normalizeGitLabUrl(draft)
+          setDraft(normalized)
+          if (normalized !== gitlabUrl) {
+            void updateSettings({ gitlabUrl: normalized })
+          }
         }}
       />
     </SearchableSetting>

--- a/src/renderer/src/components/settings/GitLabUrlSetting.tsx
+++ b/src/renderer/src/components/settings/GitLabUrlSetting.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { SearchableSetting } from './SearchableSetting'
+import { matchesSettingsSearch } from './settings-search'
+
+const GITLAB_URL_TITLE = 'GitLab URL'
+const GITLAB_URL_DESCRIPTION = 'Orca uses this single URL for GitLab operations.'
+const GITLAB_URL_KEYWORDS = ['gitlab', 'gitlab url', 'self-hosted', 'instance', 'server']
+
+type GitLabSettings = GlobalSettings & { gitlabUrl?: string }
+type GitLabSettingsPatch = Partial<GlobalSettings> & { gitlabUrl?: string }
+
+type GitLabUrlSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+}
+
+export function gitLabUrlSettingMatchesSearch(searchQuery: string): boolean {
+  return matchesSettingsSearch(searchQuery, {
+    title: GITLAB_URL_TITLE,
+    description: GITLAB_URL_DESCRIPTION,
+    keywords: GITLAB_URL_KEYWORDS
+  })
+}
+
+export function GitLabUrlSetting({
+  settings,
+  updateSettings
+}: GitLabUrlSettingProps): React.JSX.Element {
+  const title = translate('auto.components.settings.GitLabUrlSetting.title', GITLAB_URL_TITLE)
+  const description = translate(
+    'auto.components.settings.GitLabUrlSetting.description',
+    GITLAB_URL_DESCRIPTION
+  )
+  const [draft, setDraft] = useState(gitlabUrl)
+  useEffect(() => setDraft(gitlabUrl), [gitlabUrl])
+
+  return (
+    <SearchableSetting
+      title={title}
+      description={description}
+      keywords={GITLAB_URL_KEYWORDS}
+      className="space-y-2"
+    >
+      <div className="space-y-1">
+        <Label htmlFor="gitlab-url">{title}</Label>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      <Input
+        id="gitlab-url"
+        type="url"
+        value={draft}
+        placeholder="https://gitlab.example.com"
+        spellCheck={false}
+        className="max-w-md"
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={() => {
+          const patch: GitLabSettingsPatch = { gitlabUrl: draft }
+          void updateSettings(patch)
+        }}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/GitLabUrlSetting.tsx
+++ b/src/renderer/src/components/settings/GitLabUrlSetting.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { GlobalSettings } from '../../../../shared/types'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { normalizeGitLabUrl } from '../../../../shared/gitlab-instance-url'
 import { translate } from '@/i18n/i18n'
 import { Input } from '../ui/input'

--- a/src/renderer/src/components/settings/GitPane.tsx
+++ b/src/renderer/src/components/settings/GitPane.tsx
@@ -23,6 +23,7 @@ import {
 } from './keep-local-main-up-to-date-setting'
 import { translate } from '@/i18n/i18n'
 import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
+import { GitLabUrlSetting, gitLabUrlSettingMatchesSearch } from './GitLabUrlSetting'
 
 export { getGitPaneSearchEntries }
 
@@ -240,6 +241,9 @@ export function GitPane({
         )}
         {isBranchPrefixInputMode && <BranchPrefixFeedback rawPrefix={branchPrefixInputValue} />}
       </SearchableSetting>
+    ) : null,
+    gitLabUrlSettingMatchesSearch(searchQuery) ? (
+      <GitLabUrlSetting key="gitlab-url" settings={settings} updateSettings={updateSettings} />
     ) : null,
     matchesSettingsSearch(searchQuery, {
       title: keepLocalMainUpToDateTitle,

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.test.tsx
@@ -126,4 +126,19 @@ describe('CLI source-control integration card account scope', () => {
     )
     expect(rendered.textContent).toContain('glab auth login')
   })
+
+  it('points at the GitLab URL setting instead of glab auth when GitLab is unconfigured', async () => {
+    mocks.store.current = {
+      settings: { activeRuntimeEnvironmentId: null },
+      openSettingsPage: vi.fn(),
+      openSettingsTarget: vi.fn()
+    }
+    mocks.preflight.statuses.glabStatus = 'not-configured'
+
+    const rendered = await renderCard(<GitLabIntegrationCard />)
+
+    expect(rendered.textContent).toContain('Not configured')
+    expect(rendered.textContent).toContain('GitLab is off until you set a GitLab URL')
+    expect(rendered.textContent).not.toContain('glab auth login')
+  })
 })

--- a/src/renderer/src/components/settings/git-search.ts
+++ b/src/renderer/src/components/settings/git-search.ts
@@ -17,6 +17,20 @@ export const getGitPaneSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate('auto.components.settings.git.search.gitlabUrlTitle', 'GitLab URL'),
+    description: translate(
+      'auto.components.settings.git.search.gitlabUrlDescription',
+      'Orca uses this single URL for GitLab operations.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.git.search.gitlab', 'gitlab'),
+      ...translateSearchKeyword('auto.components.settings.git.search.gitlabUrl', 'gitlab url'),
+      ...translateSearchKeyword('auto.components.settings.git.search.selfHosted', 'self-hosted'),
+      ...translateSearchKeyword('auto.components.settings.git.search.instance', 'instance'),
+      ...translateSearchKeyword('auto.components.settings.git.search.server', 'server')
+    ]
+  },
+  {
     title: translate(
       'auto.components.settings.git.search.f8bda25f29',
       'Keep Local Main Up to Date'

--- a/src/renderer/src/components/settings/integrations-pane-status.test.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.test.ts
@@ -96,4 +96,16 @@ describe('getPreflightIntegrationStatuses', () => {
       giteaStatus: 'checking'
     })
   })
+
+  it('reports GitLab as not configured before it reports the glab CLI missing', () => {
+    expect(
+      getPreflightIntegrationStatuses(
+        {
+          ...connectedPreflight,
+          glab: { installed: false, authenticated: false, configured: false }
+        },
+        new Set()
+      ).glabStatus
+    ).toBe('not-configured')
+  })
 })

--- a/src/renderer/src/components/settings/integrations-pane-status.ts
+++ b/src/renderer/src/components/settings/integrations-pane-status.ts
@@ -2,8 +2,9 @@ import type { PreflightStatus } from '../../../../preload/api-types'
 
 export type GhStatus = 'checking' | 'connected' | 'not-installed' | 'not-authenticated'
 // Why: parallel to GhStatus — GitLab uses glab and the same three failure
-// modes (probe in-flight / installed-but-unauth / missing entirely).
-export type GlabStatus = GhStatus
+// modes (probe in-flight / installed-but-unauth / missing entirely), plus
+// 'not-configured' because GitLab routing is off until an instance URL is set.
+export type GlabStatus = GhStatus | 'not-configured'
 export type BitbucketStatus = 'checking' | 'connected' | 'not-configured' | 'not-authenticated'
 export type AzureDevOpsStatus = 'checking' | 'configured' | 'not-configured' | 'not-authenticated'
 export type GiteaStatus = 'checking' | 'configured' | 'not-configured' | 'not-authenticated'
@@ -71,6 +72,11 @@ function ghStatusFromPreflight(status: PreflightStatus['gh']): GhStatus {
 }
 
 function glabStatusFromPreflight(status: PreflightStatus['glab']): GlabStatus {
+  // Why: no configured instance means Orca routes nothing to GitLab, so the
+  // actionable step is setting the URL — not installing or logging into glab.
+  if (status && status.configured === false) {
+    return 'not-configured'
+  }
   if (!status?.installed) {
     return 'not-installed'
   }

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -15,6 +15,10 @@ describe('getDefaultSettings', () => {
     )
   })
 
+  it('leaves GitLab unconfigured by default', () => {
+    expect(getDefaultSettings('/tmp').gitlabUrl).toBe('')
+  })
+
   it('enables gitignored file decorations by default', () => {
     expect(getDefaultSettings('/tmp').showGitIgnoredFiles).toBe(true)
   })

--- a/src/shared/gitlab-instance-url.test.ts
+++ b/src/shared/gitlab-instance-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { gitLabHostFromUrl, normalizeGitLabUrl } from './gitlab-instance-url'
+
+describe('GitLab instance setting', () => {
+  it('normalizes configured URLs and preserves non-default ports', () => {
+    expect(normalizeGitLabUrl('  HTTPS://GitLab.Example.com:8443/// ')).toBe(
+      'https://gitlab.example.com:8443'
+    )
+    expect(gitLabHostFromUrl('https://gitlab.example.com:8443')).toBe('gitlab.example.com:8443')
+  })
+
+  it('drops a default port so the host matches what git remotes report', () => {
+    expect(normalizeGitLabUrl('https://gitlab.example.com:443')).toBe('https://gitlab.example.com')
+    expect(gitLabHostFromUrl('https://gitlab.example.com:443')).toBe('gitlab.example.com')
+  })
+
+  it('discards any path, so only the instance root is stored', () => {
+    expect(normalizeGitLabUrl('https://gitlab.example.com/group/project')).toBe(
+      'https://gitlab.example.com'
+    )
+  })
+
+  it('rejects invalid or credential-bearing URLs without selecting a host', () => {
+    expect(normalizeGitLabUrl('not a url')).toBe('')
+    expect(normalizeGitLabUrl('gitlab.example.com')).toBe('')
+    expect(normalizeGitLabUrl('ssh://gitlab.example.com')).toBe('')
+    expect(normalizeGitLabUrl('https://token@gitlab.example.com')).toBe('')
+    expect(normalizeGitLabUrl('https://gitlab.example.com?token=x')).toBe('')
+    expect(gitLabHostFromUrl('')).toBe('')
+  })
+})

--- a/src/shared/gitlab-instance-url.ts
+++ b/src/shared/gitlab-instance-url.ts
@@ -1,0 +1,32 @@
+/**
+ * The single GitLab instance Orca routes through. Shared so the settings UI
+ * normalizes exactly what the main process persists and matches remotes with.
+ */
+
+/** A GitLab instance is opt-in; an empty setting disables GitLab routing. */
+export function normalizeGitLabUrl(value: unknown): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    return ''
+  }
+  try {
+    const url = new URL(value.trim())
+    if (
+      !['http:', 'https:'].includes(url.protocol.toLowerCase()) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) {
+      return ''
+    }
+    url.pathname = ''
+    return url.toString().replace(/\/$/, '').toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+export function gitLabHostFromUrl(value: unknown): string {
+  const normalized = normalizeGitLabUrl(value)
+  return normalized ? new URL(normalized).host : ''
+}


### PR DESCRIPTION
## Summary

Adds a single global GitLab URL setting for self-hosted GitLab environments. GitLab remote resolution now uses only that configured instance, avoiding ambiguous `glab` host selection when multiple GitLab accounts are present.

- Adds **Settings → Git → GitLab URL**.
- Normalizes HTTP(S) URLs, retains non-default ports, and rejects credentials/query/fragment input.
- Routes GitLab operations only when a repository remote matches the configured instance.
- Leaves GitLab unconfigured by default; no automatic host discovery or fallback.

Closes #11109.

## Verification

- `git diff --check` passed before commit.
- Focused Vitest could not start: pnpm rejected 17 lockfile entries under the active minimum-release-age supply-chain policy. No dependency or lockfile files were changed by this PR.

## Scope

This intentionally supports one configured GitLab instance only. Multi-instance account selection and automatic host discovery are out of scope.