### PR TITLE
fix(add-project): refresh the host that performed a nested import

### DIFF
--- a/src/renderer/src/store/slices/repos.runtime-fallback.test.ts
+++ b/src/renderer/src/store/slices/repos.runtime-fallback.test.ts
@@ -332,4 +332,75 @@ describe('repo slice runtime folder fallback', () => {
     expect(added?.kind).toBe('folder')
     expect(added?.path).toBe('/local/non-git')
   })
+
+  it('skips remote catalogs when refreshing a local-pinned nested import while a remote server is focused (#11200)', async () => {
+    const localRepo: Repo = {
+      id: 'local-folder',
+      path: '/local/plain',
+      displayName: 'plain',
+      badgeColor: '#000',
+      addedAt: 1,
+      kind: 'folder'
+    }
+    const importNested = vi.fn().mockResolvedValue({ groupId: 'g-1', repoIds: [] })
+    const listEmpty = vi.fn().mockResolvedValue([])
+    const listGroups = vi.fn().mockResolvedValue([])
+    const listRepos = vi.fn().mockResolvedValue([])
+    vi.stubGlobal('window', {
+      api: {
+        repos: { list: listRepos },
+        projectGroups: { importNested, list: listGroups },
+        folderWorkspaces: { list: listEmpty },
+        runtimeEnvironments: { call: runtimeEnvironmentTransportCall, list: listEmpty }
+      }
+    })
+    runtimeEnvironmentCall.mockImplementation((request: RuntimeEnvironmentCallRequest) => ({
+      id: `rpc-${request.method}`,
+      ok: true,
+      result: { repos: [], groups: [], folderWorkspaces: [], projects: [], setups: [] },
+      _meta: { runtimeId: 'runtime-remote' }
+    }))
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      runtimeEnvironments: [{ id: 'env-1', name: 'Remote Mac' }] as never
+    })
+
+    const localGroup = {
+      id: 'local-group',
+      name: 'plain',
+      parentPath: '/local/plain',
+      parentGroupId: null,
+      createdFrom: 'manual',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    listGroups.mockResolvedValue([localGroup])
+    listRepos.mockResolvedValue([localRepo])
+
+    await store.getState().importNestedRepos({
+      parentPath: '/local/plain',
+      groupName: 'plain',
+      projectPaths: ['/local/plain/app'],
+      mode: 'group',
+      runtimeEnvironmentId: null
+    })
+
+    // Why: the post-import refresh must show what the pinned host imported, not
+    // the focused remote's catalog (which would drop it, or stall when down).
+    expect(store.getState().projectGroups.map((group) => group.id)).toContain('local-group')
+    expect(store.getState().repos.map((repo) => repo.id)).toContain('local-folder')
+    const runtimeMethods = runtimeEnvironmentCall.mock.calls.map(
+      (call) => (call[0] as RuntimeEnvironmentCallRequest).method
+    )
+    expect(runtimeMethods).not.toContain('projectGroup.importNested')
+    // Why: the landed local import must not wait on the focused remote's
+    // catalogs, which can spend a full connect timeout when it is unreachable.
+    expect(runtimeMethods).not.toContain('repo.list')
+    expect(runtimeMethods).not.toContain('projectGroup.list')
+    expect(runtimeMethods).not.toContain('folderWorkspace.list')
+  })
 })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2444,6 +2444,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const target = getActiveRuntimeTarget(
         settingsForRuntimeOwner(get().settings, args.runtimeEnvironmentId)
       )
+      const focusedTarget = getActiveRuntimeTarget(get().settings)
       const result =
         target.kind === 'local'
           ? await window.api.projectGroups.importNested(args)
@@ -2459,15 +2460,22 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               },
               { timeoutMs: 60_000 }
             )
-      const catalogOptions =
-        'runtimeEnvironmentId' in args
-          ? { runtimeEnvironmentId: args.runtimeEnvironmentId }
-          : undefined
-      await get().fetchProjectGroups(catalogOptions)
-      await get().fetchFolderWorkspaces(catalogOptions)
-      await (args.runtimeEnvironmentId
-        ? get().fetchRuntimeEnvironmentRepos(args.runtimeEnvironmentId)
-        : get().fetchRepos(catalogOptions))
+      if (args.runtimeEnvironmentId) {
+        const catalogOptions = { runtimeEnvironmentId: args.runtimeEnvironmentId }
+        await get().fetchProjectGroups(catalogOptions)
+        await get().fetchFolderWorkspaces(catalogOptions)
+        await get().fetchRuntimeEnvironmentRepos(args.runtimeEnvironmentId)
+      } else if (getRuntimeTargetHostId(target) === getRuntimeTargetHostId(focusedTarget)) {
+        await get().fetchProjectGroups()
+        await get().fetchFolderWorkspaces()
+        await get().fetchRepos()
+      } else {
+        // Why: focused-host fetches replace the catalogs wholesale, so an import
+        // routed off the focused host would be refreshed away; merge every host.
+        await get().fetchProjectGroupsForAllHosts()
+        await get().fetchFolderWorkspacesForAllHosts()
+        await get().fetchReposForAllHosts()
+      }
       set({ folderWorkspacePathStatuses: {} })
       return result
     } catch (err) {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2469,6 +2469,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         await get().fetchProjectGroups()
         await get().fetchFolderWorkspaces()
         await get().fetchRepos()
+      } else if (target.kind === 'local') {
+        // Why: merge instead of replacing the focused host's catalogs, and skip
+        // remotes so a landed local import never waits on an unreachable one.
+        await get().fetchProjectGroupsForAllHosts({ remoteHosts: 'skip' })
+        await get().fetchFolderWorkspacesForAllHosts({ remoteHosts: 'skip' })
+        await get().fetchReposForAllHosts({ remoteHosts: 'skip' })
       } else {
         // Why: focused-host fetches replace the catalogs wholesale, so an import
         // routed off the focused host would be refreshed away; merge every host.


### PR DESCRIPTION
## Summary

Follow-up to #11200 — narrowed after rebasing onto current `main`.

This PR originally pinned local folder scan/add/import routing to the local host explicitly (`runtimeEnvironmentId: null`), because the add flow validated against the dialog's host but executed through the global `activeRuntimeEnvironmentId`.

While this PR sat unrebased, #11346 landed upstream and independently introduced `nestedRuntimeEnvironmentId`: the nested-review flow now captures the routing owner at scan time and threads that captured value through to import, instead of re-reading the live global setting. For a local-originated scan, that captured value is already `null` (the local picker/drop flow refuses to even start a scan while a remote environment is active), so the routing-mismatch part of #11200 is now handled by that mechanism and the explicit-pin commit from this PR became redundant. It has been dropped from this branch.

What's left, and still reachable today: a user can open a local folder, let it scan (captured owner = local), then switch the Active Server in Settings while the nested-review dialog is still open, and confirm the import. `importNestedRepos` correctly routes the import itself to local (using the captured owner), but the post-import catalog refresh read the *focused* host (now the remote one) — so the just-imported local project group/repos didn't show up, and could stall waiting on an unreachable remote.

This PR:
- Refreshes the host that actually performed the import instead of the focused host when they differ (merges every host's catalog rather than replacing it wholesale, so the import isn't refreshed away).
- Skips remote hosts entirely when the import that was performed is local-only, so a landed local import never waits on an unreachable Active Server.

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm test` — full `store/slices` (2207 tests) + `sidebar` (1829 tests) suites, all passing
- [x] `oxlint` on the two touched files (`repos.ts`, `repos.runtime-fallback.test.ts`)
- [ ] `pnpm lint` (full) — the localization-extraction step fails locally with `Cannot find module '.../i18next-cli/dist/esm/cli.js'`, unrelated to this change (stale local `node_modules` after rebasing across 340+ upstream commits); every prior lint stage (oxlint, type-aware code quality, reliability gates, max-lines ratchet, localization catalog coverage) passed. Deferring to CI for this step.
- [ ] `pnpm build` — not run locally; no build-affecting changes (pure renderer store logic)
- [x] Added a regression test (`repos.runtime-fallback.test.ts`) covering the still-reachable scenario: a local-pinned import while a remote server is focused must not call any remote RPC and must still surface the imported group/repo in state.

## AI Review Report

Reviewed the rebase/conflict-resolution work by hand rather than a full agent pass, given this PR's diff is now small and isolated to `repos.ts`'s `importNestedRepos` catalog-refresh branch:

- **Cross-platform (macOS/Linux/Windows)**: no platform-specific code touched — pure host-routing/catalog-merge logic.
- **SSH/remote/local compatibility**: verified the explicit-runtime-environment-selected import path (`args.runtimeEnvironmentId` truthy, upstream's own `fetchRuntimeEnvironmentRepos` mechanism from #11346) is preserved unchanged and takes priority over the new same-host/all-hosts branching.
- **Regression risk**: confirmed via the full `store/slices` + `sidebar` suites (4036 tests) that #11346's routing/refresh mechanisms are untouched by this change.
- **Performance**: no new RPC calls added; the local-pinned branch actively *reduces* RPC calls by skipping unreachable remotes.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface changes. Pure client-side catalog refresh branching.

## Notes

- This branch was rebased from a very stale base (343 commits behind `main`) onto current `main`. The original routing-pin commit was dropped as redundant with #11346's independent `nestedRuntimeEnvironmentId` capture mechanism — see summary above for the reasoning and the still-reachable scenario this PR now covers.
- `cancelNestedRepoScan` still routes by the global setting (it early-returns for non-local targets), so canceling a pinned-local scan while a remote Active Server is set is a no-op; the scan completes and its results are discarded. Left as-is to keep this PR focused.
