### PR TITLE
fix(editor): keep the PDF find counter in sync while stepping matches

### DIFF
--- a/src/renderer/src/components/editor/PdfFind.match-counter.test.tsx
+++ b/src/renderer/src/components/editor/PdfFind.match-counter.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EventBus } from 'pdfjs-dist/web/pdf_viewer.mjs'
+import PdfFind from './PdfFind'
+
+type MatchesCount = { current: number; total: number }
+type Listener = (evt: { matchesCount: MatchesCount }) => void
+
+// Why: the real EventBus lives in pdf_viewer.mjs, which pulls in the whole
+// viewer (canvas, workers). PdfFind only needs on/off/dispatch.
+function createEventBusStub(): {
+  bus: InstanceType<typeof EventBus>
+  emit: (name: string, matchesCount: MatchesCount) => void
+  listenerCount: (name: string) => number
+} {
+  const listeners = new Map<string, Set<Listener>>()
+  const bus = {
+    on: (name: string, listener: Listener) => {
+      if (!listeners.has(name)) {
+        listeners.set(name, new Set())
+      }
+      listeners.get(name)?.add(listener)
+    },
+    off: (name: string, listener: Listener) => {
+      listeners.get(name)?.delete(listener)
+    },
+    dispatch: vi.fn()
+  }
+  return {
+    bus: bus as unknown as InstanceType<typeof EventBus>,
+    emit: (name, matchesCount) => {
+      act(() => {
+        for (const listener of listeners.get(name) ?? []) {
+          listener({ matchesCount })
+        }
+      })
+    },
+    listenerCount: (name) => listeners.get(name)?.size ?? 0
+  }
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => {
+    root.unmount()
+  })
+  document.body.innerHTML = ''
+})
+
+function renderFind(bus: InstanceType<typeof EventBus>): { input: HTMLInputElement } {
+  const eventBusRef = { current: bus }
+  act(() => {
+    root.render(<PdfFind isOpen onClose={vi.fn()} eventBusRef={eventBusRef} />)
+  })
+  const input = container.querySelector('input')
+  if (!input) {
+    throw new Error('find input not rendered')
+  }
+  return { input }
+}
+
+function typeQuery(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  act(() => {
+    setter?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+function counterText(): string {
+  return container.querySelector('span')?.textContent?.trim() ?? ''
+}
+
+describe('PdfFind match counter', () => {
+  it('advances the counter when pdf.js reports a new selection', () => {
+    const { bus, emit } = createEventBusStub()
+    const { input } = renderFind(bus)
+    typeQuery(input, 'orca')
+
+    // The initial scan reports the totals through updatefindmatchescount.
+    emit('updatefindmatchescount', { current: 1, total: 5 })
+    expect(counterText()).toBe('1 of 5')
+
+    // Why: stepping to the next match does not rescan any page, so pdf.js
+    // reports the new position through updatefindcontrolstate only.
+    emit('updatefindcontrolstate', { current: 2, total: 5 })
+    expect(counterText()).toBe('2 of 5')
+
+    emit('updatefindcontrolstate', { current: 3, total: 5 })
+    expect(counterText()).toBe('3 of 5')
+  })
+
+  it('keeps following the totals reported while pages are still being scanned', () => {
+    const { bus, emit } = createEventBusStub()
+    const { input } = renderFind(bus)
+    typeQuery(input, 'orca')
+
+    emit('updatefindmatchescount', { current: 1, total: 2 })
+    expect(counterText()).toBe('1 of 2')
+
+    emit('updatefindmatchescount', { current: 1, total: 7 })
+    expect(counterText()).toBe('1 of 7')
+  })
+
+  it('clears a stale count when the next query finds nothing', () => {
+    const { bus, emit } = createEventBusStub()
+    const { input } = renderFind(bus)
+    typeQuery(input, 'orca')
+    emit('updatefindmatchescount', { current: 1, total: 5 })
+
+    // Why: a query with no hits never re-enters the page-scan path, so its only
+    // signal is the NOT_FOUND control state. Without it the bar keeps showing
+    // the previous query's count.
+    typeQuery(input, 'zzzz')
+    emit('updatefindcontrolstate', { current: 0, total: 0 })
+
+    expect(counterText()).toBe('No matches')
+  })
+
+  it('unregisters both listeners on unmount', () => {
+    const { bus, listenerCount } = createEventBusStub()
+    renderFind(bus)
+    expect(listenerCount('updatefindmatchescount')).toBe(1)
+    expect(listenerCount('updatefindcontrolstate')).toBe(1)
+
+    act(() => {
+      root.unmount()
+    })
+
+    expect(listenerCount('updatefindmatchescount')).toBe(0)
+    expect(listenerCount('updatefindcontrolstate')).toBe(0)
+  })
+})

--- a/src/renderer/src/components/editor/PdfFind.match-counter.test.tsx
+++ b/src/renderer/src/components/editor/PdfFind.match-counter.test.tsx
@@ -78,10 +78,6 @@ function typeQuery(input: HTMLInputElement, value: string): void {
   })
 }
 
-function counterText(): string {
-  return container.querySelector('span')?.textContent?.trim() ?? ''
-}
-
 describe('PdfFind match counter', () => {
   it('advances the counter when pdf.js reports a new selection', () => {
     const { bus, emit } = createEventBusStub()
@@ -90,15 +86,16 @@ describe('PdfFind match counter', () => {
 
     // The initial scan reports the totals through updatefindmatchescount.
     emit('updatefindmatchescount', { current: 1, total: 5 })
-    expect(counterText()).toBe('1 of 5')
+    expect(container.textContent).toContain('1 of 5')
 
     // Why: stepping to the next match does not rescan any page, so pdf.js
     // reports the new position through updatefindcontrolstate only.
     emit('updatefindcontrolstate', { current: 2, total: 5 })
-    expect(counterText()).toBe('2 of 5')
+    expect(container.textContent).toContain('2 of 5')
+    expect(container.textContent).not.toContain('1 of 5')
 
     emit('updatefindcontrolstate', { current: 3, total: 5 })
-    expect(counterText()).toBe('3 of 5')
+    expect(container.textContent).toContain('3 of 5')
   })
 
   it('keeps following the totals reported while pages are still being scanned', () => {
@@ -107,10 +104,11 @@ describe('PdfFind match counter', () => {
     typeQuery(input, 'orca')
 
     emit('updatefindmatchescount', { current: 1, total: 2 })
-    expect(counterText()).toBe('1 of 2')
+    expect(container.textContent).toContain('1 of 2')
 
     emit('updatefindmatchescount', { current: 1, total: 7 })
-    expect(counterText()).toBe('1 of 7')
+    expect(container.textContent).toContain('1 of 7')
+    expect(container.textContent).not.toContain('1 of 2')
   })
 
   it('clears a stale count when the next query finds nothing', () => {
@@ -125,7 +123,8 @@ describe('PdfFind match counter', () => {
     typeQuery(input, 'zzzz')
     emit('updatefindcontrolstate', { current: 0, total: 0 })
 
-    expect(counterText()).toBe('No matches')
+    expect(container.textContent).toContain('No matches')
+    expect(container.textContent).not.toContain('1 of 5')
   })
 
   it('unregisters both listeners on unmount', () => {

--- a/src/renderer/src/components/editor/PdfFind.tsx
+++ b/src/renderer/src/components/editor/PdfFind.tsx
@@ -85,10 +85,8 @@ export default function PdfFind({
       setActiveMatch(evt.matchesCount.current)
       setTotalMatches(evt.matchesCount.total)
     }
-    // Why: pdf.js only emits 'updatefindmatchescount' while it scans pages for
-    // matches. Stepping to the next/previous hit rescans nothing, so the new
-    // position arrives on 'updatefindcontrolstate' — without it the counter
-    // freezes at whatever the initial scan reported (#11049).
+    // Why: 'updatefindmatchescount' only fires while pages are scanned; stepping
+    // between matches reports the new position on 'updatefindcontrolstate' (#11049).
     eventBus.on('updatefindmatchescount', handleMatchesCount)
     eventBus.on('updatefindcontrolstate', handleMatchesCount)
     return () => {

--- a/src/renderer/src/components/editor/PdfFind.tsx
+++ b/src/renderer/src/components/editor/PdfFind.tsx
@@ -85,9 +85,15 @@ export default function PdfFind({
       setActiveMatch(evt.matchesCount.current)
       setTotalMatches(evt.matchesCount.total)
     }
+    // Why: pdf.js only emits 'updatefindmatchescount' while it scans pages for
+    // matches. Stepping to the next/previous hit rescans nothing, so the new
+    // position arrives on 'updatefindcontrolstate' — without it the counter
+    // freezes at whatever the initial scan reported (#11049).
     eventBus.on('updatefindmatchescount', handleMatchesCount)
+    eventBus.on('updatefindcontrolstate', handleMatchesCount)
     return () => {
       eventBus.off('updatefindmatchescount', handleMatchesCount)
+      eventBus.off('updatefindcontrolstate', handleMatchesCount)
     }
   }, [eventBusRef, isOpen])
 


### PR DESCRIPTION
## Summary

Fixes #11049 — in-PDF search moved the highlight and scrolled to the next hit, but the `N of M` counter stayed frozen.

`PdfFind` subscribed to `updatefindmatchescount` only. pdf.js emits that event from `#updateUIResultsCount()`, which runs while it scans pages for matches. Stepping to the next or previous hit takes the `again` path, which rescans nothing — the new selection is reported on `updatefindcontrolstate` instead (`#updateUIState()` in `PDFFindController`). With only the first event wired up, the counter kept showing whatever the initial scan reported while the selection moved underneath it.

Subscribing to both is how the upstream viewer wires its own find bar: `web/app.js` binds `onUpdateFindMatchesCount` → `findBar.updateResultsCount(matchesCount)` and `onUpdateFindControlState` → `findBar.updateUIState(state, previous, matchesCount)`, which calls `updateResultsCount` in turn. Both events carry the same `#requestMatchesCount()` payload, so no reconciliation is needed.

This also clears a stale count. A query with no hits never re-enters the page-scan path, so `updatefindmatchescount` never fires for it and the bar kept showing the *previous* query's total. It now falls back to `No matches` through the NOT_FOUND control state.

## Screenshots

No layout change — the counter is the same element and only the value it renders updates. The behaviour change (counter advancing in step with the selection) is covered by the tests below rather than a recording.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added `PdfFind.match-counter.test.tsx` (4 cases). The first case fails on `main` — it asserts the counter advances when pdf.js reports a new selection, which is exactly the reported bug. The others cover totals arriving mid-scan, the stale-count-to-`No matches` transition, and that both listeners are unregistered on unmount so reopening a PDF cannot retain a dead component.

Pre-existing failures on this machine, unrelated to this PR and reproduced on an unmodified `main`: `release-rc-history`, `publish-complete-draft-releases`, `plugin-install`, and `orchestration-cli-subprocess` all fail locally because the machine has `tag.gpgsign` / `commit.gpgsign` enabled globally.

## AI Review Report

Reviewed with Claude Code. Checks and findings:

- **Root cause verified against the dependency, not guessed:** traced `#updateUIResultsCount()` vs `#updateUIState()` in the bundled `pdfjs-dist@5.7` and confirmed `#calculateMatch()` is the only caller of the former, so the `again` path cannot emit it.
- **Upstream parity:** confirmed mozilla/pdf.js `web/app.js` subscribes to both events for its own find bar, so this does not invent a new contract.
- **Regression risk — PENDING states:** `#updateUIState(FindState.PENDING)` now reaches the handler too. Its payload is the same `#requestMatchesCount()` result, and the upstream find bar updates its count on PENDING as well. Before this change the bar showed the previous query's count until the scan finished, so this is not a new class of transient.
- **Listener lifecycle:** the added subscription is unregistered in the same cleanup as the existing one. `PdfViewer` reuses one `EventBus` per document and pdf.js retains callbacks by event name, so a missed `off()` would leak a stale component across PDF opens — asserted in a test.
- **Cross-platform (macOS/Linux/Windows):** renderer-only, no platform branch, no shortcut/label/path/shell behaviour touched.
- **SSH / remote / folder workspaces:** none involved; the find bar operates on an already-loaded document in the renderer.
- **Performance:** one extra EventBus listener; both events are low-frequency and the handler only calls two setState.

## Security Audit

No new input parsing, command execution, path handling, auth, secret, dependency, or IPC surface. The change adds a listener for an event the app already receives from a library it already loads, and the payload only reaches two numeric state values rendered as text.

## Notes

Reproducing needs a PDF with several occurrences of a word: open the find bar, type it, then press Enter or the next-match arrow repeatedly. Before this change the highlight advanced but the counter did not.
