### PR TITLE
test(cli): lock CLI-compatible timeout parse contract

### DIFF
--- a/src/shared/timer-delay.test.ts
+++ b/src/shared/timer-delay.test.ts
@@ -33,17 +33,30 @@ describe('timer delay policy', () => {
     expect(parsePositiveSafeIntegerText(raw)).toBe(expected)
   })
 
-  it.each(['', '0', '-1', '1.5', '.1', '1e-1', '9007199254740991.1', '9007199254740992'])(
-    'rejects inexact or unsafe integer text %s',
-    (raw) => {
-      expect(parsePositiveSafeIntegerText(raw)).toBeNull()
-    }
-  )
+  it.each([
+    '',
+    '0',
+    '-1',
+    '1.5',
+    '.1',
+    '1e-1',
+    '1.0000000000000000001',
+    '+1.0000000000000000001',
+    '9007199254740991.1',
+    '9007199254740992'
+  ])('rejects inexact or unsafe integer text %s', (raw) => {
+    expect(parsePositiveSafeIntegerText(raw)).toBeNull()
+  })
 
+  // Values the CLI's own Number() coercion accepts must parse to the same
+  // budget here, or the caller's timer expires before the CLI's does.
   it.each([
     ['+1000', 1_000],
     ['1000.0', 1_000],
-    ['1e3', 1_000]
+    ['1e3', 1_000],
+    ['1.0000000000000000001', 1],
+    ['+1.0000000000000000001', 1],
+    ['600000.000000000000001', 600_000]
   ])('parses CLI-compatible positive integer text %s', (raw, expected) => {
     expect(parsePositiveSafeIntegerNumericText(raw)).toBe(expected)
   })

--- a/src/shared/timer-delay.ts
+++ b/src/shared/timer-delay.ts
@@ -19,6 +19,12 @@ export function parsePositiveSafeIntegerText(raw: string): number | null {
   return exactValue === BigInt(value) ? value : null
 }
 
+// Why: mirrors the CLI's own `Number()` coercion for generic `--timeout-ms`
+// flags (cli/flags.ts getOptionalPositiveIntegerFlag). Text that coerces to an
+// exact integer — `1000.0`, `600000.000000000000001` — is the budget the CLI
+// will actually wait on, so rejecting it here would leave the caller's timer
+// shorter than the CLI's and cut the request short. Callers that need exact
+// text (orchestration ask) use parsePositiveSafeIntegerText instead.
 export function parsePositiveSafeIntegerNumericText(raw: string): number | null {
   const value = Number(raw)
   return Number.isSafeInteger(value) && value > 0 ? value : null


### PR DESCRIPTION
Follow-up to review feedback on #10689 (already merged).

CodeRabbit flagged that `parsePositiveSafeIntegerNumericText('1.0000000000000000001')` returns `1` and suggested adding an exact-text guard. **The suggestion is not applied** — it would introduce the bug #10689 fixed.

The generic `--timeout-ms` path in the CLI (`cli/flags.ts` `getOptionalPositiveIntegerFlag`) is `Number()` + `Number.isInteger`, so the CLI *accepts* `600000.000000000000001` and waits 600000 ms. `parsePositiveSafeIntegerNumericText` deliberately mirrors that coercion so the relay request budget and SSH kill timer land at or above the CLI's own budget. Adding the exact-text guard would make those callers fall back to the base budget (5 min) while the CLI waits 10 min — cutting the request short, which is exactly the failure #10689 set out to fix.

Callers that need exact text (`orchestration ask`) already use the strict `parsePositiveSafeIntegerText`, matching the CLI's `getOptionalPositiveIntegerValueFlag`.

Changes:
- Comment on `parsePositiveSafeIntegerNumericText` recording why the lenient coercion is intentional.
- Regression cases pinning the CLI-mirroring contract (`1.0000000000000000001` -> 1, `600000.000000000000001` -> 600000) and the strict parser's rejection of the same text.

No behavior change.

Made with [Orca](https://github.com/stablyai/orca) 🐋
