### PR TITLE
fix(skills): stop the scan issue budget evicting a read failure

### DIFF
--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { afterEach, describe, expect, it } from 'vitest'
+import { isSkillScanIssueNeedingAttention } from '../../shared/skill-freshness'
 import {
+  MAXIMUM_PLUGIN_SCAN_ATTENTION_ISSUES,
   MAXIMUM_PLUGIN_SCAN_ISSUES,
   scanKnownPluginSkillCandidates
 } from './skill-plugin-cache-scan'
@@ -460,6 +462,73 @@ describe('plugin skill candidate scan', () => {
         errorCode: null
       })
       expect(result.issues.filter((issue) => issue.reason === 'issue-limit')).toHaveLength(1)
+    }
+  )
+
+  // Why: linking skills out of the cache is ordinary vendor packaging, so 'outside-root' is
+  // what fills the display budget on a real install — before any read failure is reached.
+  async function createCacheBehindSpentBudget(prefix: string, loopCount: number): Promise<string> {
+    const parent = await mkdtemp(join(tmpdir(), prefix))
+    temporaryDirectories.push(parent)
+    const root = join(parent, 'cache')
+    const outside = join(parent, 'outside')
+    await mkdir(outside, { recursive: true })
+    await mkdir(root, { recursive: true })
+    await Promise.all(
+      Array.from({ length: MAXIMUM_PLUGIN_SCAN_ISSUES }, (_, index) =>
+        symlink(outside, join(root, `aa-linked-${index.toString().padStart(2, '0')}`), 'dir')
+      )
+    )
+    // Sorts after the links, so these are read once the budget is already spent.
+    await Promise.all(
+      Array.from({ length: loopCount }, (_, index) => {
+        const name = `zz-loop-${index.toString().padStart(2, '0')}`
+        return symlink(name, join(root, name), 'dir')
+      })
+    )
+    return root
+  }
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps a read failure that lands after the display budget is spent',
+    async () => {
+      const root = await createCacheBehindSpentBudget('orca-plugin-attention-eviction-', 1)
+
+      const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+      // Why: a read failure is the only issue that can take the headline off "all up to
+      // date". Evicting it for display budget reports all-clear over a path that could be
+      // hiding a stale copy — the bounds that filled the budget say nothing about it.
+      expect(result.issues).toContainEqual({
+        path: join(root, 'zz-loop-00'),
+        reason: 'io-error',
+        errorCode: 'ELOOP'
+      })
+      const inventoryIssues = result.issues.map((issue) => ({
+        rootId: 'plugin-cache',
+        sourceLabel: 'Plugin cache',
+        ...issue
+      }))
+      expect(inventoryIssues.some(isSkillScanIssueNeedingAttention)).toBe(true)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'bounds how many read failures outrank the display budget',
+    async () => {
+      const root = await createCacheBehindSpentBudget(
+        'orca-plugin-attention-bound-',
+        MAXIMUM_PLUGIN_SCAN_ATTENTION_ISSUES + 4
+      )
+
+      const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+      // Why: outranking the budget is what makes this class unbounded, so a tree full of
+      // unreadable folders must not be able to pin one issue per folder in memory.
+      expect(result.issues.filter((issue) => issue.reason === 'io-error')).toHaveLength(
+        MAXIMUM_PLUGIN_SCAN_ATTENTION_ISSUES
+      )
+      expect(result.issues).toContainEqual({ path: root, reason: 'issue-limit', errorCode: null })
     }
   )
 

--- a/src/main/skills/skill-plugin-cache-scan.ts
+++ b/src/main/skills/skill-plugin-cache-scan.ts
@@ -2,6 +2,7 @@ import type { Dirent } from 'node:fs'
 import { opendir, realpath, stat } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import {
+  isSkillScanAttentionReason,
   isTruncatingSkillScanReason,
   type SkillFreshnessScanIssueReason
 } from '../../shared/skill-freshness'
@@ -19,6 +20,11 @@ const MAXIMUM_NESTED_SKILL_DEPTH = 2
 const MAXIMUM_PLUGIN_SCAN_ENTRIES = 16_384
 export const MAXIMUM_PLUGIN_SKILL_CANDIDATES = 64
 export const MAXIMUM_PLUGIN_SCAN_ISSUES = 16
+// Why: an attention issue outranks the display budget, so nothing else bounds how many a
+// pathological tree can pin in memory. One is all the badge needs to be truthful; a few
+// more give the dialog enough distinct paths to read as a pattern, and 'issue-limit' still
+// says there are others.
+export const MAXIMUM_PLUGIN_SCAN_ATTENTION_ISSUES = 4
 const SKILL_FILE_NAME = 'SKILL.md'
 
 export type KnownPluginSkillCandidate = {
@@ -52,6 +58,7 @@ export async function scanKnownPluginSkillCandidates(
   const issues: KnownPluginSkillScanIssue[] = []
   const issueKeys = new Set<string>()
   const visited = new Set<string>()
+  let attentionIssueCount = 0
   let resolvedRoot: string | null = null
   let entryCount = 0
   let limitReached = false
@@ -70,9 +77,15 @@ export async function scanKnownPluginSkillCandidates(
     if (issueKeys.has(key)) {
       return
     }
+    // Why: an attention issue is the only thing that can turn the headline off "all up to
+    // date", so evicting one for display budget makes Orca report all-clear over a read
+    // failure. Reserving a few keeps that unbounded on a tree full of unreadable folders.
+    const attention =
+      isSkillScanAttentionReason(reason) &&
+      attentionIssueCount < MAXIMUM_PLUGIN_SCAN_ATTENTION_ISSUES
     // Why: the bound that ended the walk is the one issue the dialog cannot do without
     // — dropping it for display budget is what lets a truncated scan report all-clear.
-    const required = explainsCandidate || isTruncatingSkillScanReason(reason)
+    const required = explainsCandidate || attention || isTruncatingSkillScanReason(reason)
     // Why: this budget bounds what the dialog lists, not how far the scan reaches.
     // Ending the walk here would truncate coverage over a display limit — and since
     // Orca's own bounds no longer raise attention, it would do so silently.
@@ -87,6 +100,9 @@ export async function scanKnownPluginSkillCandidates(
       return
     }
     issueKeys.add(key)
+    if (isSkillScanAttentionReason(reason)) {
+      attentionIssueCount += 1
+    }
     issues.push({ path, reason, errorCode: code })
   }
 

--- a/src/shared/skill-freshness.ts
+++ b/src/shared/skill-freshness.ts
@@ -112,8 +112,12 @@ export type SkillFreshnessScanIssue = {
 // every installed skill. It is still listed in Details, like the other bounds.
 const SKILL_SCAN_ATTENTION_REASONS = new Set<SkillFreshnessScanIssueReason>(['io-error'])
 
+export function isSkillScanAttentionReason(reason: SkillFreshnessScanIssueReason): boolean {
+  return SKILL_SCAN_ATTENTION_REASONS.has(reason)
+}
+
 export function isSkillScanIssueNeedingAttention(issue: SkillFreshnessScanIssue): boolean {
-  return SKILL_SCAN_ATTENTION_REASONS.has(issue.reason)
+  return isSkillScanAttentionReason(issue.reason)
 }
 
 // Why: these are the bounds that end the walk rather than skip one folder. They are


### PR DESCRIPTION
## The wrong banner

`scanKnownPluginSkillCandidates` bounds how many issues one scan reports. An issue survives that bound only when it is `required`:

```ts
const required = explainsCandidate || isTruncatingSkillScanReason(reason)
```

Neither set intersects the attention set. In `src/shared/skill-freshness.ts`, `SKILL_SCAN_ATTENTION_REASONS` is `['io-error']` and `SKILL_SCAN_TRUNCATING_REASONS` is `['entry-limit', 'candidate-limit']`. So `io-error` — the **sole** reason a plugin-cache scan can raise "Needs attention" — was droppable.

Once 16 non-required issues fill the budget, a later read failure is evicted and replaced by a generic `issue-limit` row, which raises neither attention nor truncation. The freshness dialog then reports **"All installed Orca skills are up to date"** over a path Orca could not read — a path that could be hiding a stale copy of any bundled skill.

This is not a contrived shape. `outside-root` is what fills the budget on an ordinary install: the scan's own comments document vendors linking skills out of the cache as normal packaging, and directory entries are walked in alphabetical order, so a read failure that sorts late is exactly the one that gets evicted.

## The fix

Attention issues now outrank the display budget, reusing the existing shared reason set rather than a second copy of the predicate. `isSkillScanIssueNeedingAttention` is refactored into a reason-level `isSkillScanAttentionReason` (mirroring the existing `isTruncatingSkillScanReason` / `isSkillScanIssueTruncatingScan` pair) so the main-process scan and the renderer badge stay driven by one set.

### The bound

`explainsCandidate` charging is bounded by the candidate cap; unconditional attention charging would not be. A tree with hundreds of unreadable directories would pin one issue per directory in memory, so this trades a wrong banner for unbounded growth.

`MAXIMUM_PLUGIN_SCAN_ATTENTION_ISSUES = 4` caps the reserve. One kept issue is all the badge needs to be truthful; a few more give the dialog enough distinct paths to read as a pattern, and the existing `issue-limit` row still says there are others. Worst case per root is 16 listed + 4 reserved.

## Tests

- **`keeps a read failure that lands after the display budget is spent`** — 16 `outside-root` links, then an `ELOOP` link sorting later. Verified **red on `origin/main`** (`70c81c4b32`): the scan returned 16 `outside-root` rows plus `issue-limit`, with the `io-error` absent.
- **`bounds how many read failures outrank the display budget`** — pins the reserve. Verified it kills the mutation that drops the cap (8 kept vs 4 expected).

No existing test was weakened.

## Scope

Only the scan issue budget. The update verdict, convergence gate, and updater are untouched.

## Checks

`pnpm typecheck` (after clearing `tsbuildinfo`), `oxlint`, both code-quality audits, max-lines ratchet, and 209 skills tests across 22 files — all green.
