### PR TITLE
fix(native-chat): make the launch-draft mirror reachable

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -297,6 +297,7 @@ async function spawnLocalStartupAndSetupTerminals(args: {
       env: sequencedStartup.env,
       ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
       ...(isTuiAgent(createdWithAgent) ? { launchAgent: createdWithAgent } : {}),
+      ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
       startupCommandDelivery: sequencedStartup.startupCommandDelivery,
       telemetry: sequencedStartup.telemetry,
       activate: true

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1134,6 +1134,7 @@ describe('registerWorktreeHandlers', () => {
       startup: {
         command: 'claude --prefill test',
         env: { ORCA_AGENT_MODE: 'direct' },
+        viewMode: 'chat',
         telemetry: {
           agent_kind: 'claude',
           launch_source: 'new_workspace_composer',
@@ -1154,6 +1155,7 @@ describe('registerWorktreeHandlers', () => {
         command: 'claude --prefill test',
         env: { ORCA_AGENT_MODE: 'direct' },
         launchAgent: 'claude',
+        viewMode: 'chat',
         startupCommandDelivery: undefined,
         telemetry: {
           agent_kind: 'claude',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -3752,16 +3752,34 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
       getLocalProvider: () => localProvider as never
     })
+    runtime.setPtyController({
+      spawn: vi.fn(),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const createTerminal = vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
+      handle: 'term_folder_startup',
+      tabId: 'tab-folder-startup',
+      worktreeId: '',
+      title: null,
+      surface: 'background'
+    })
     const notifier = { worktreesChanged: vi.fn() }
     runtime.setNotifier(notifier as never)
 
     const result = await runtime.createManagedWorktree({
       repoSelector: 'id:folder-repo',
       name: 'folder-session',
-      createdWithAgent: 'codex'
+      createdWithAgent: 'codex',
+      startup: { command: 'codex', viewMode: 'chat' }
     })
 
     expect(addWorktreeMock).not.toHaveBeenCalled()
+    expect(createTerminal).toHaveBeenCalledWith(
+      `id:${result.worktree.id}`,
+      expect.objectContaining({ command: 'codex', viewMode: 'chat' })
+    )
     expect(result.worktree).toEqual(
       expect.objectContaining({
         id: expect.stringMatching(/^folder-repo::\/workspace\/folder::workspace:[0-9a-f-]{36}$/),
@@ -5411,16 +5429,21 @@ describe('OrcaRuntimeService', () => {
     })
     runtime.attachWindow(1)
 
+    const createTerminal = vi.spyOn(runtime, 'createTerminal')
     try {
       const result = await runtime.createManagedWorktree({
         repoSelector: TEST_REPO_ID,
         name: 'mobile-setup',
         setupDecision: 'run',
-        startup: { command: 'claude' }
+        startup: { command: 'claude', viewMode: 'chat' }
       })
 
       // Why: runtime provisions setup itself (fire-and-forget) and omits it from the RPC result so the caller doesn't double-spawn.
       expect(result.setup).toBeUndefined()
+      expect(createTerminal).toHaveBeenCalledWith(
+        `path:${result.worktree.path}`,
+        expect.objectContaining({ viewMode: 'chat' })
+      )
       await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2))
       expect(spawn).toHaveBeenNthCalledWith(
         1,
@@ -33053,6 +33076,7 @@ describe('OrcaRuntimeService', () => {
       getRepo: (id: string) => (id === 'repo-1' ? waitRepo : undefined)
     }
     const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const createTerminal = vi.spyOn(runtime, 'createTerminal')
     const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-headless-startup' })
     const spawn = vi
       .fn()
@@ -33109,11 +33133,15 @@ describe('OrcaRuntimeService', () => {
       repoSelector: 'id:repo-1',
       name: 'runtime-headless-startup-setup',
       setupDecision: 'run',
-      startup: { command: 'claude' }
+      startup: { command: 'claude', viewMode: 'chat' }
     })
 
     expect(createSetupRunnerScript).toHaveBeenCalled()
     expect(runHook).not.toHaveBeenCalled()
+    expect(createTerminal).toHaveBeenCalledWith(
+      `id:${result.worktree.id}`,
+      expect.objectContaining({ viewMode: 'chat' })
+    )
     // Why: setup is provisioned fire-and-forget; the wait-for-setup guarantee comes from the shell nonce/marker, not JS spawn ordering.
     await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2))
     const startupCommand = (spawn.mock.calls[0]![0] as { command: string }).command

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18821,6 +18821,7 @@ export class OrcaRuntimeService {
               ? { launchConfig: effectiveStartup.launchConfig }
               : {}),
             ...(effectiveCreatedWithAgent ? { launchAgent: effectiveCreatedWithAgent } : {}),
+            ...(effectiveStartup.viewMode ? { viewMode: effectiveStartup.viewMode } : {}),
             startupCommandDelivery: effectiveStartup.startupCommandDelivery,
             telemetry: effectiveStartup.telemetry
           })
@@ -19546,6 +19547,7 @@ export class OrcaRuntimeService {
           env: sequencedStartup.env,
           ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
           ...(effectiveCreatedWithAgent ? { launchAgent: effectiveCreatedWithAgent } : {}),
+          ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
           startupCommandDelivery: sequencedStartup.startupCommandDelivery,
           telemetry: sequencedStartup.telemetry
         })
@@ -19888,6 +19890,7 @@ export class OrcaRuntimeService {
           env: sequencedStartup.env,
           ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
           ...(args.createdWithAgent ? { launchAgent: args.createdWithAgent } : {}),
+          ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
           startupCommandDelivery: sequencedStartup.startupCommandDelivery,
           telemetry: sequencedStartup.telemetry
         })

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
@@ -10,9 +10,12 @@ const mocks = vi.hoisted(() => ({
   ensureAgentStartupInTerminal: vi.fn()
 }))
 
-vi.mock('@/lib/worktree-activation', () => ({
-  activateAndRevealFolderWorkspace: mocks.activateAndRevealFolderWorkspace
-}))
+// Why: importOriginal keeps the real resolveStartupLaunchDraftText, so the
+// invariant test below exercises the shipped gate instead of a copy of it.
+vi.mock('@/lib/worktree-activation', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, activateAndRevealFolderWorkspace: mocks.activateAndRevealFolderWorkspace }
+})
 
 vi.mock('@/lib/new-workspace', async (importOriginal) => {
   const actual = await importOriginal<typeof NewWorkspaceModule>()
@@ -23,6 +26,8 @@ vi.mock('@/lib/new-workspace', async (importOriginal) => {
 })
 
 import { useAppStore } from '@/store'
+import { decideInitialAgentTabViewMode } from '@/lib/native-chat-initial-view-mode'
+import { resolveStartupLaunchDraftText } from '@/lib/worktree-activation'
 import {
   buildFolderWorkspaceLinkedStartupPlan,
   getFolderWorkspaceAgentLaunchPlatform,
@@ -771,5 +776,74 @@ describe('submitFolderWorkspaceCreate native-chat launch draft', () => {
     })
 
     expect(seededDraftFor('tab-1')).toBeUndefined()
+  })
+})
+
+describe('folder-workspace draft: seeded set == chat-opening set', () => {
+  const ISSUE_URL = 'https://github.com/stablyai/orca/issues/42'
+  const linkedIssue = {
+    provider: 'github' as const,
+    type: 'issue' as const,
+    number: 42,
+    title: 'Restore linked quick-create',
+    url: ISSUE_URL,
+    repoId: 'repo-1'
+  }
+
+  beforeEach(() => {
+    mocks.activateAndRevealFolderWorkspace.mockReturnValue({ primaryTabId: 'tab-1' })
+    useAppStore.setState({ nativeChatLaunchDraftByTabId: {} })
+    Object.assign(window, {
+      api: { agentTrust: { markTrusted: vi.fn().mockResolvedValue(undefined) } }
+    })
+  })
+
+  afterEach(() => {
+    mocks.activateAndRevealFolderWorkspace.mockReset()
+    mocks.ensureAgentStartupInTerminal.mockReset()
+    useAppStore.setState({ nativeChatLaunchDraftByTabId: {} })
+    Reflect.deleteProperty(window, 'api')
+    vi.restoreAllMocks()
+  })
+
+  // Why: `claude` takes its draft on argv, so `startupPlan.draftPrompt` stays
+  // undefined; `codex` gets a startup paste and sets it. Both must reach the
+  // view-mode gate, and both must agree with what the composer actually holds.
+  it.each([
+    ['argv-prefill', 'claude' as const, '', true],
+    ['argv-prefill multi-line', 'claude' as const, 'Reproduce on Windows first', false],
+    ['startup-paste', 'codex' as const, '', true],
+    ['startup-paste multi-line', 'codex' as const, 'Reproduce on Windows first', false]
+  ])('%s', async (_label, quickAgent, note, expectMirrored) => {
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem: linkedIssue,
+      note,
+      quickAgent,
+      autoRenameBranchFromWork: false,
+      agentCmdOverrides: {},
+      createFolderWorkspace: vi.fn(async () => makeFolderWorkspace()),
+      onOpenChange: vi.fn()
+    })
+
+    const startup = mocks.activateAndRevealFolderWorkspace.mock.calls[0]?.[1]?.startup
+    const seeded = useAppStore.getState().nativeChatLaunchDraftByTabId['tab-1'] != null
+    const draftText = resolveStartupLaunchDraftText(startup)
+    const opensInChat =
+      decideInitialAgentTabViewMode({
+        experimentalNativeChat: true,
+        openAgentTabsInChatByDefault: true,
+        agent: quickAgent,
+        ...(draftText != null
+          ? { promptDelivery: 'draft' as const, launchDraftText: draftText }
+          : {})
+      }) === 'chat'
+
+    // The draft always reaches the TUI, whichever way it is delivered.
+    expect(`${startup?.command ?? ''}${startup?.draftPrompt ?? ''}`).toContain(ISSUE_URL)
+    expect(seeded).toBe(expectMirrored)
+    expect(opensInChat).toBe(expectMirrored)
   })
 })

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/lib/new-workspace', async (importOriginal) => {
   }
 })
 
+import { useAppStore } from '@/store'
 import {
   buildFolderWorkspaceLinkedStartupPlan,
   getFolderWorkspaceAgentLaunchPlatform,
@@ -656,5 +657,119 @@ describe('buildFolderWorkspaceLinkedStartupPlan', () => {
     })
 
     expect(plan?.launchCommand).toBe('hermes --tui "--provider" "value with space"')
+  })
+})
+
+describe('submitFolderWorkspaceCreate native-chat launch draft', () => {
+  const ISSUE_URL = 'https://github.com/stablyai/orca/issues/42'
+  const linkedIssue = {
+    provider: 'github' as const,
+    type: 'issue' as const,
+    number: 42,
+    title: 'Restore linked quick-create',
+    url: ISSUE_URL,
+    repoId: 'repo-1'
+  }
+
+  function seededDraftFor(tabId: string): { text: string } | undefined {
+    return useAppStore.getState().nativeChatLaunchDraftByTabId[tabId]
+  }
+
+  beforeEach(() => {
+    mocks.activateAndRevealFolderWorkspace.mockReturnValue({ primaryTabId: 'tab-1' })
+    useAppStore.setState({ nativeChatLaunchDraftByTabId: {} })
+    Object.assign(window, {
+      api: { agentTrust: { markTrusted: vi.fn().mockResolvedValue(undefined) } }
+    })
+  })
+
+  afterEach(() => {
+    mocks.activateAndRevealFolderWorkspace.mockReset()
+    mocks.ensureAgentStartupInTerminal.mockReset()
+    useAppStore.setState({ nativeChatLaunchDraftByTabId: {} })
+    Reflect.deleteProperty(window, 'api')
+    vi.restoreAllMocks()
+  })
+
+  it('mirrors a startup-paste draft into the chat composer', async () => {
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem: linkedIssue,
+      note: '',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: false,
+      agentCmdOverrides: {},
+      createFolderWorkspace: vi.fn(async () => makeFolderWorkspace()),
+      onOpenChange: vi.fn()
+    })
+
+    expect(seededDraftFor('tab-1')?.text).toBe(ISSUE_URL)
+  })
+
+  it('mirrors an argv-prefill draft, which never lands in startupPlan.draftPrompt', async () => {
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem: linkedIssue,
+      note: '',
+      quickAgent: 'claude',
+      autoRenameBranchFromWork: false,
+      agentCmdOverrides: {},
+      createFolderWorkspace: vi.fn(async () => makeFolderWorkspace()),
+      onOpenChange: vi.fn()
+    })
+
+    // The draft rides in on `--prefill`, so the plan carries no draftPrompt at
+    // all — keying the mirror off it would silently drop this whole branch.
+    const startup = mocks.activateAndRevealFolderWorkspace.mock.calls[0]?.[1]?.startup
+    expect(startup?.draftPrompt).toBeUndefined()
+    expect(startup?.command).toContain(ISSUE_URL)
+    expect(seededDraftFor('tab-1')?.text).toBe(ISSUE_URL)
+  })
+
+  it('leaves a multi-line draft in the terminal only', async () => {
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem: linkedIssue,
+      note: 'Reproduce on Windows first',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: false,
+      agentCmdOverrides: {},
+      createFolderWorkspace: vi.fn(async () => makeFolderWorkspace()),
+      onOpenChange: vi.fn()
+    })
+
+    // Terminal still gets it; the chat mirror is withheld until multi-line send
+    // is safe, and decideInitialAgentTabViewMode keeps this launch in terminal.
+    expect(mocks.ensureAgentStartupInTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startup: expect.objectContaining({
+          draftPrompt: `Reproduce on Windows first\n\n${ISSUE_URL}`
+        })
+      })
+    )
+    expect(seededDraftFor('tab-1')).toBeUndefined()
+  })
+
+  it('does not mirror an unlinked note, which is submitted rather than drafted', async () => {
+    await submitFolderWorkspaceCreate({
+      projectGroup: makeProjectGroup(),
+      name: '',
+      lastAutoName: '',
+      linkedWorkItem: null,
+      note: 'Fix the flaky checkout flow',
+      quickAgent: 'codex',
+      autoRenameBranchFromWork: false,
+      agentCmdOverrides: {},
+      createFolderWorkspace: vi.fn(async () => makeFolderWorkspace()),
+      onOpenChange: vi.fn()
+    })
+
+    expect(seededDraftFor('tab-1')).toBeUndefined()
   })
 })

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -4,6 +4,7 @@ import {
   type LinkedWorkItemSummary
 } from '@/lib/new-workspace'
 import { resolveQuickCreateLinkedWorkItemPrompt } from '@/lib/linked-work-item-context'
+import { seedNativeChatLaunchDraftForAgentTab } from '@/lib/agent-launch-prompt-delivery'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import {
   buildAgentDraftLaunchPlan,
@@ -66,6 +67,19 @@ export function getFolderWorkspaceAgentLaunchPlatform(
   return parentPath && isWslUncPath(parentPath) ? 'linux' : CLIENT_PLATFORM
 }
 
+/**
+ * The launch context a linked folder-workspace agent starts with in its TUI
+ * input but never submits — delivered as argv prefill or a startup paste
+ * depending on the agent.
+ */
+export function resolveFolderWorkspaceLaunchDraft(
+  linkedWorkItem: LinkedWorkItemSummary,
+  note: string
+): string | null {
+  const { prompt, draftPrompt } = resolveQuickCreateLinkedWorkItemPrompt(linkedWorkItem, note)
+  return (draftPrompt ?? prompt.trim()) || null
+}
+
 export function buildFolderWorkspaceLinkedStartupPlan(args: {
   agent: TuiAgent
   linkedWorkItem: LinkedWorkItemSummary
@@ -78,11 +92,7 @@ export function buildFolderWorkspaceLinkedStartupPlan(args: {
   shell?: AgentStartupShell
   isRemote: boolean
 }): AgentStartupPlan | null {
-  const { prompt, draftPrompt } = resolveQuickCreateLinkedWorkItemPrompt(
-    args.linkedWorkItem,
-    args.note
-  )
-  const linkedDraftPrompt = (draftPrompt ?? prompt.trim()) || null
+  const linkedDraftPrompt = resolveFolderWorkspaceLaunchDraft(args.linkedWorkItem, args.note)
   const draftLaunchPlan = linkedDraftPrompt
     ? buildAgentDraftLaunchPlan({
         agent: args.agent,
@@ -215,6 +225,10 @@ export async function submitFolderWorkspaceCreate({
             allowEmptyPromptLaunch: true
           })
         : null
+  // Why: the argv-prefill plan carries the draft inside `launchCommand`, so
+  // `startupPlan.draftPrompt` alone can't tell whether this launch has one.
+  const launchDraftPrompt =
+    quickAgent && linkedWorkItem ? resolveFolderWorkspaceLaunchDraft(linkedWorkItem, note) : null
   // Why: the pending badge should only appear when the submitted prompt can
   // actually produce the first agent message that names the workspace.
   const pendingFirstAgentMessageRename =
@@ -274,6 +288,21 @@ export async function submitFolderWorkspaceCreate({
       ...(startup ? { startup } : {}),
       runtimeEnvironmentId
     })
+    if (
+      quickAgent &&
+      startupPlan &&
+      launchDraftPrompt &&
+      activation !== false &&
+      activation.primaryTabId
+    ) {
+      // Why: draft launch context reaches only the TUI input; seed the
+      // chat-composer copy so it isn't invisible in the chat view.
+      seedNativeChatLaunchDraftForAgentTab({
+        tabId: activation.primaryTabId,
+        agent: quickAgent,
+        text: launchDraftPrompt
+      })
+    }
     if (
       startupPlan &&
       (startupPlan.followupPrompt || startupPlan.draftPrompt) &&

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -272,6 +272,9 @@ export async function submitFolderWorkspaceCreate({
           launchAgent: quickAgent,
           ...(startupPlan.sessionOptions ? { sessionOptions: startupPlan.sessionOptions } : {}),
           ...(startupPlan.draftPrompt ? { draftPrompt: startupPlan.draftPrompt } : {}),
+          // Why: view-mode only. The argv-prefill plan sets no draftPrompt, so
+          // without this the tab opens in chat with nothing mirrored into it.
+          ...(launchDraftPrompt ? { launchDraftText: launchDraftPrompt } : {}),
           ...(startupPlan.startupCommandDelivery
             ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
             : {}),

--- a/src/renderer/src/lib/agent-launch-prompt-delivery.ts
+++ b/src/renderer/src/lib/agent-launch-prompt-delivery.ts
@@ -1,25 +1,20 @@
 import { agentDeliversDraftViaNativePrefill } from '@/lib/agent-native-draft-prefill'
 import { pasteDraftWhenAgentReady } from '@/lib/agent-paste-draft'
+import { canMirrorLaunchDraftToNativeChat } from '@/lib/native-chat-launch-draft-mirrorability'
 import { isNativeChatSupportedAgent } from '@/lib/native-chat-supported-agent'
 import { useAppStore } from '@/store'
 import type { TuiAgent } from '../../../shared/types'
 
 /** Seed the chat-composer copy of launch context that reaches only the TUI
- *  input (argv prefill or startup paste). No-op for empty text or agents
- *  without a native-chat renderer. */
+ *  input (argv prefill or startup paste). No-op for agents without a
+ *  native-chat renderer, or for text `canMirrorLaunchDraftToNativeChat`
+ *  rejects — the same predicate that decides whether the tab opens in chat. */
 export function seedNativeChatLaunchDraftForAgentTab(args: {
   tabId: string
   agent: TuiAgent
   text: string
 }): void {
-  // Single-line only: the chat send pre-clears the TUI with Ctrl+U
-  // (kill-to-start-of-LINE), so a multi-line prefill (e.g. a Linear issue block)
-  // would leave earlier lines to glue onto the next message.
-  if (
-    args.text.trim().length === 0 ||
-    args.text.includes('\n') ||
-    !isNativeChatSupportedAgent(args.agent)
-  ) {
+  if (!canMirrorLaunchDraftToNativeChat(args.text) || !isNativeChatSupportedAgent(args.agent)) {
     return
   }
   useAppStore.getState().seedNativeChatLaunchDraft({

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -117,10 +117,13 @@ vi.mock('@/lib/telemetry', () => ({
 }))
 
 const mockCreateWebRuntimeSessionTerminal = vi.fn()
+const mockCreateWebRuntimeAgentSessionTerminalWithLaunchDraft = vi.fn()
 const mockIsWebRuntimeSessionActive = vi.fn(() => false)
 
 vi.mock('@/runtime/web-runtime-session', () => ({
   createWebRuntimeSessionTerminal: mockCreateWebRuntimeSessionTerminal,
+  createWebRuntimeAgentSessionTerminalWithLaunchDraft:
+    mockCreateWebRuntimeAgentSessionTerminalWithLaunchDraft,
   isWebRuntimeSessionActive: mockIsWebRuntimeSessionActive,
   isWebTerminalSurfaceTabId: vi.fn(() => false)
 }))
@@ -130,6 +133,7 @@ describe('launchAgentInNewTab', () => {
     vi.clearAllMocks()
     mockIsWebRuntimeSessionActive.mockReturnValue(false)
     mockCreateWebRuntimeSessionTerminal.mockResolvedValue({ status: 'created' })
+    mockCreateWebRuntimeAgentSessionTerminalWithLaunchDraft.mockResolvedValue({ status: 'created' })
     store.activeRepoId = 'repo-1'
     store.activeWorktreeId = 'wt-1'
     store.settings = {
@@ -268,6 +272,71 @@ describe('launchAgentInNewTab', () => {
     })
   })
 
+  it('mirrors an argv-prefill draft into chat and opens the tab there', async () => {
+    store.settings = {
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {},
+      activeRuntimeEnvironmentId: null,
+      experimentalNativeChat: true,
+      openAgentTabsInChatByDefault: true
+    }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      prompt: 'https://github.com/o/r/issues/12',
+      promptDelivery: 'draft'
+    })
+
+    // Claude takes the draft on --prefill, so no paste runs and
+    // deliverLaunchPromptToAgentTab never fires — this is the only seed.
+    expect(result?.pasteDraftAfterLaunch).toBe(false)
+    expect(mockSeedNativeChatLaunchDraft).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabId: 'tab-1',
+        agent: 'claude',
+        text: 'https://github.com/o/r/issues/12'
+      })
+    )
+    expect(mockCreateTab).toHaveBeenCalledWith(
+      'wt-1',
+      undefined,
+      undefined,
+      expect.objectContaining({ viewMode: 'chat' })
+    )
+  })
+
+  it('keeps a multi-line draft out of chat entirely', async () => {
+    store.settings = {
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {},
+      activeRuntimeEnvironmentId: null,
+      experimentalNativeChat: true,
+      openAgentTabsInChatByDefault: true
+    }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      prompt: 'Reproduce first\n\nhttps://github.com/o/r/issues/12',
+      promptDelivery: 'draft'
+    })
+
+    // Unseedable and un-opened must move together: a chat view here would be
+    // an empty composer beside a filled TUI input.
+    expect(mockSeedNativeChatLaunchDraft).not.toHaveBeenCalled()
+    expect(mockCreateTab).toHaveBeenCalledWith(
+      'wt-1',
+      undefined,
+      undefined,
+      expect.not.objectContaining({ viewMode: 'chat' })
+    )
+  })
+
   it('passes quick command labels only to locally-created agent tabs', async () => {
     const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
@@ -308,15 +377,20 @@ describe('launchAgentInNewTab', () => {
     })
 
     expect(result).toEqual(expect.objectContaining({ tabId: null, pasteDraftAfterLaunch: false }))
-    expect(mockCreateWebRuntimeSessionTerminal).toHaveBeenCalledWith(
+    // The draft rides in on the launch command, so this host-class launch also
+    // carries the text that seeds the mirrored tab's chat composer.
+    expect(mockCreateWebRuntimeAgentSessionTerminalWithLaunchDraft).toHaveBeenCalledWith(
       expect.objectContaining({
         launchAgent: 'claude',
         prompt: 'review before sending',
         promptDelivery: 'draft',
         agentArgs: '--permission-mode plan',
-        launchPreferences: { model: 'opus', effort: 'high' }
+        launchPreferences: { model: 'opus', effort: 'high' },
+        agent: 'claude',
+        launchDraft: 'review before sending'
       })
     )
+    expect(mockCreateWebRuntimeSessionTerminal).not.toHaveBeenCalled()
     expect(mockCreateTab).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -1,15 +1,15 @@
-import { toast } from 'sonner'
 import { useAppStore } from '@/store'
-import {
-  buildAgentDraftLaunchPlan,
-  buildAgentStartupPlan,
-  type AgentStartupPlan
-} from '@/lib/tui-agent-startup'
+import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+import { planLaunchAgentStartupPrompt } from '@/lib/launch-agent-startup-prompt-plan'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { getAgentLaunchPlatformForRepo } from '@/lib/agent-launch-platform'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
-import { track, tuiAgentToAgentKind } from '@/lib/telemetry'
-import { deliverLaunchPromptToAgentTab } from '@/lib/agent-launch-prompt-delivery'
+import { tuiAgentToAgentKind } from '@/lib/telemetry'
+import { createPasteReadinessTimeoutNotice } from '@/lib/launch-agent-paste-timeout-notice'
+import {
+  deliverLaunchPromptToAgentTab,
+  seedNativeChatLaunchDraftForAgentTab
+} from '@/lib/agent-launch-prompt-delivery'
 import { initialAgentTabViewModeProps } from '@/lib/native-chat-initial-view-mode'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -26,7 +26,6 @@ import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-status-seed'
 import type { TuiAgent } from '../../../shared/types'
 import type { LaunchSource } from '../../../shared/telemetry-events'
-import { translate } from '@/i18n/i18n'
 import { getConnectionIdFromState } from '@/lib/connection-context'
 import { resolveNativeChatSessionOptionDefaults } from '../../../shared/native-chat-session-option-defaults'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
@@ -124,63 +123,13 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   const trimmedPrompt = prompt?.trim() ?? ''
   const hasPrompt = trimmedPrompt.length > 0
   const isFollowupPath = TUI_AGENT_CONFIG[agent].promptInjectionMode === 'stdin-after-start'
-  // argv/flag agents fold the prompt into the launch command; followup/generated launches deliver it via post-launch paste.
-  let startupPlan: AgentStartupPlan | null = null
-  let pasteDraftAfterLaunch: string | null = null
-  let submitPastedPrompt = false
+  const { startupPlan, pasteDraftAfterLaunch, submitPastedPrompt } = planLaunchAgentStartupPrompt({
+    base: startupPlanBase,
+    prompt: trimmedPrompt,
+    promptDelivery,
+    isFollowupPath
+  })
   let promptDeliveryResult: Promise<{ delivered: boolean; failureNotified: boolean }> | undefined
-
-  if (hasPrompt && promptDelivery === 'submit-after-ready') {
-    // Why: multi-line generated prompts are too large for a shell argv, so launch clean then paste+submit in the TUI.
-    startupPlan = buildAgentStartupPlan({
-      ...startupPlanBase,
-      prompt: '',
-      allowEmptyPromptLaunch: true
-    })
-    pasteDraftAfterLaunch = trimmedPrompt
-    submitPastedPrompt = true
-  } else if (hasPrompt && promptDelivery === 'draft') {
-    const draftLaunchPlan = buildAgentDraftLaunchPlan({
-      ...startupPlanBase,
-      draft: trimmedPrompt
-    })
-    if (draftLaunchPlan) {
-      startupPlan = {
-        agent: draftLaunchPlan.agent,
-        launchCommand: draftLaunchPlan.launchCommand,
-        expectedProcess: draftLaunchPlan.expectedProcess,
-        followupPrompt: null,
-        launchConfig: draftLaunchPlan.launchConfig,
-        ...(draftLaunchPlan.sessionOptions
-          ? { sessionOptions: draftLaunchPlan.sessionOptions }
-          : {}),
-        ...(draftLaunchPlan.startupCommandDelivery
-          ? { startupCommandDelivery: draftLaunchPlan.startupCommandDelivery }
-          : {}),
-        ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
-      }
-    } else {
-      startupPlan = buildAgentStartupPlan({
-        ...startupPlanBase,
-        prompt: '',
-        allowEmptyPromptLaunch: true
-      })
-      pasteDraftAfterLaunch = trimmedPrompt
-    }
-  } else if (hasPrompt && isFollowupPath) {
-    startupPlan = buildAgentStartupPlan({
-      ...startupPlanBase,
-      prompt: '',
-      allowEmptyPromptLaunch: true
-    })
-    pasteDraftAfterLaunch = trimmedPrompt
-  } else {
-    startupPlan = buildAgentStartupPlan({
-      ...startupPlanBase,
-      prompt: hasPrompt ? trimmedPrompt : '',
-      allowEmptyPromptLaunch: !hasPrompt
-    })
-  }
 
   if (!startupPlan) {
     return null
@@ -192,6 +141,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   const initialViewModeProps = initialAgentTabViewModeProps(store.settings, {
     agent,
     promptDelivery: viewModePromptDelivery,
+    launchDraftText: trimmedPrompt,
     nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(
       getConnectionIdFromState(store, worktreeId)
     )
@@ -259,41 +209,25 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   })
   // Why: fire-and-forget the paste-after-ready delivery so callers keep the synchronous { tabId, startupPlan } signature.
   // Why: safe to call unconditionally — the helper short-circuits (no paste) for native-prefill agents already holding the draft.
+  if (hasPrompt && promptDelivery === 'draft' && pasteDraftAfterLaunch === null) {
+    // Why: the draft rode in on argv (Claude --prefill etc.), so no paste runs
+    // and deliverLaunchPromptToAgentTab never seeds. Mirror it into chat here.
+    seedNativeChatLaunchDraftForAgentTab({ tabId: tab.id, agent, text: trimmedPrompt })
+  }
   if (pasteDraftAfterLaunch !== null) {
-    // Why: onTimeout surfaces silent paste failures — a stalled readiness wait would otherwise drop notes silently.
-    let failureNotified = false
+    const timeoutNotice = createPasteReadinessTimeoutNotice({
+      worktreeId,
+      tabId: tab.id,
+      agent,
+      submitted: submitPastedPrompt
+    })
     const deliveryPromise = deliverLaunchPromptToAgentTab({
       tabId: tab.id,
       content: pasteDraftAfterLaunch,
       agent,
       submit: submitPastedPrompt,
       forcePaste: promptDelivery === 'submit-after-ready',
-      onTimeout: () => {
-        const state = useAppStore.getState()
-        const tabsForWorktree = state.tabsByWorktree[worktreeId] ?? []
-        const currentTab = tabsForWorktree.find((t) => t.id === tab.id)
-        if (currentTab?.ptyId === null) {
-          // Why: PTY never spawned = genuine launch failure; stay silent so the caller emits the sole notice.
-          return
-        }
-        if (!currentTab || state.activeWorktreeId !== worktreeId) {
-          // Why: user cancelled (closed tab / switched worktrees); mark notified so the deferred caller suppresses its toast too.
-          failureNotified = true
-          return
-        }
-        toast.message(
-          translate(
-            'auto.lib.launch.agent.in.new.tab.a5a1f7033f',
-            "Your {{value0}} wasn't sent — paste it once the agent is ready.",
-            { value0: submitPastedPrompt ? 'prompt' : 'notes' }
-          )
-        )
-        failureNotified = true
-        track('agent_error', {
-          error_class: 'paste_readiness_timeout',
-          agent_kind: tuiAgentToAgentKind(agent)
-        })
-      }
+      onTimeout: timeoutNotice.onTimeout
     }).then((delivered) => {
       if (delivered) {
         if (agent === 'command-code' && submitPastedPrompt) {
@@ -303,7 +237,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
         }
         onPromptDelivered?.()
       }
-      return { delivered, failureNotified: !delivered && failureNotified }
+      return { delivered, failureNotified: !delivered && timeoutNotice.wasNotified() }
     })
     if (promptDelivery === 'submit-after-ready') {
       promptDeliveryResult = deliveryPromise

--- a/src/renderer/src/lib/launch-agent-paste-timeout-notice.ts
+++ b/src/renderer/src/lib/launch-agent-paste-timeout-notice.ts
@@ -1,0 +1,51 @@
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { track, tuiAgentToAgentKind } from '@/lib/telemetry'
+import { translate } from '@/i18n/i18n'
+import type { TuiAgent } from '../../../shared/types'
+
+/**
+ * Notice for a post-launch paste that never landed — a stalled readiness wait
+ * would otherwise drop the user's text silently.
+ *
+ * `wasNotified()` reports whether the user already heard about it, so a
+ * deferred caller can suppress a duplicate toast.
+ */
+export function createPasteReadinessTimeoutNotice(args: {
+  worktreeId: string
+  tabId: string
+  agent: TuiAgent
+  submitted: boolean
+}): { onTimeout: () => void; wasNotified: () => boolean } {
+  let notified = false
+  return {
+    wasNotified: () => notified,
+    onTimeout: () => {
+      const state = useAppStore.getState()
+      const currentTab = (state.tabsByWorktree[args.worktreeId] ?? []).find(
+        (tab) => tab.id === args.tabId
+      )
+      if (currentTab?.ptyId === null) {
+        // Why: PTY never spawned = genuine launch failure; stay silent so the caller emits the sole notice.
+        return
+      }
+      if (!currentTab || state.activeWorktreeId !== args.worktreeId) {
+        // Why: user cancelled (closed tab / switched worktrees); mark notified so the deferred caller suppresses its toast too.
+        notified = true
+        return
+      }
+      toast.message(
+        translate(
+          'auto.lib.launch.agent.in.new.tab.a5a1f7033f',
+          "Your {{value0}} wasn't sent — paste it once the agent is ready.",
+          { value0: args.submitted ? 'prompt' : 'notes' }
+        )
+      )
+      notified = true
+      track('agent_error', {
+        error_class: 'paste_readiness_timeout',
+        agent_kind: tuiAgentToAgentKind(args.agent)
+      })
+    }
+  }
+}

--- a/src/renderer/src/lib/launch-agent-startup-prompt-plan.ts
+++ b/src/renderer/src/lib/launch-agent-startup-prompt-plan.ts
@@ -1,0 +1,81 @@
+import {
+  buildAgentDraftLaunchPlan,
+  buildAgentStartupPlan,
+  type AgentStartupPlan
+} from '@/lib/tui-agent-startup'
+
+type StartupPlanBase = Omit<
+  Parameters<typeof buildAgentStartupPlan>[0],
+  'prompt' | 'allowEmptyPromptLaunch'
+>
+
+export type LaunchAgentStartupPromptPlan = {
+  startupPlan: AgentStartupPlan | null
+  /** Text to paste once the TUI is ready; null when the launch command already carries it. */
+  pasteDraftAfterLaunch: string | null
+  submitPastedPrompt: boolean
+}
+
+/**
+ * Decide how a new-tab launch delivers its prompt: argv/flag agents fold it
+ * into the launch command, while followup and generated launches start clean
+ * and paste after the TUI is ready.
+ */
+export function planLaunchAgentStartupPrompt(args: {
+  base: StartupPlanBase
+  /** Already trimmed. */
+  prompt: string
+  promptDelivery: 'auto-submit' | 'draft' | 'submit-after-ready'
+  isFollowupPath: boolean
+}): LaunchAgentStartupPromptPlan {
+  const { base, prompt, promptDelivery, isFollowupPath } = args
+  const hasPrompt = prompt.length > 0
+  const launchEmpty = (): AgentStartupPlan | null =>
+    buildAgentStartupPlan({ ...base, prompt: '', allowEmptyPromptLaunch: true })
+  const pasteAfterReady = (submit: boolean): LaunchAgentStartupPromptPlan => ({
+    startupPlan: launchEmpty(),
+    pasteDraftAfterLaunch: prompt,
+    submitPastedPrompt: submit
+  })
+
+  if (hasPrompt && promptDelivery === 'submit-after-ready') {
+    // Why: multi-line generated prompts are too large for a shell argv, so launch clean then paste+submit in the TUI.
+    return pasteAfterReady(true)
+  }
+  if (hasPrompt && promptDelivery === 'draft') {
+    const draftLaunchPlan = buildAgentDraftLaunchPlan({ ...base, draft: prompt })
+    if (!draftLaunchPlan) {
+      return pasteAfterReady(false)
+    }
+    return {
+      startupPlan: {
+        agent: draftLaunchPlan.agent,
+        launchCommand: draftLaunchPlan.launchCommand,
+        expectedProcess: draftLaunchPlan.expectedProcess,
+        followupPrompt: null,
+        launchConfig: draftLaunchPlan.launchConfig,
+        ...(draftLaunchPlan.sessionOptions
+          ? { sessionOptions: draftLaunchPlan.sessionOptions }
+          : {}),
+        ...(draftLaunchPlan.startupCommandDelivery
+          ? { startupCommandDelivery: draftLaunchPlan.startupCommandDelivery }
+          : {}),
+        ...(draftLaunchPlan.env ? { env: draftLaunchPlan.env } : {})
+      },
+      pasteDraftAfterLaunch: null,
+      submitPastedPrompt: false
+    }
+  }
+  if (hasPrompt && isFollowupPath) {
+    return pasteAfterReady(false)
+  }
+  return {
+    startupPlan: buildAgentStartupPlan({
+      ...base,
+      prompt: hasPrompt ? prompt : '',
+      allowEmptyPromptLaunch: !hasPrompt
+    }),
+    pasteDraftAfterLaunch: null,
+    submitPastedPrompt: false
+  }
+}

--- a/src/renderer/src/lib/launch-agent-web-host-tab.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.ts
@@ -2,6 +2,7 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import {
   createWebRuntimeAgentSessionTerminal,
+  createWebRuntimeAgentSessionTerminalWithLaunchDraft,
   createWebRuntimeSessionTerminal,
   isWebTerminalSurfaceTabId
 } from '@/runtime/web-runtime-session'
@@ -128,6 +129,15 @@ export function launchAgentInWebHostTab(args: {
       submitPrompt: submitPastedPrompt,
       forcePromptPaste: promptDelivery === 'submit-after-ready'
     }).then(handleCreation)
+  }
+  if (hasPrompt && promptDelivery === 'draft') {
+    // Why: the draft rode in on the launch command, so no paste runs and
+    // nothing else seeds the chat-composer copy for this host class.
+    return createWebRuntimeAgentSessionTerminalWithLaunchDraft({
+      ...launch,
+      agent,
+      launchDraft: prompt
+    }).then((outcome) => handleCreation({ outcome, promptDelivered: outcome.status === 'created' }))
   }
   return createWebRuntimeSessionTerminal(launch).then((outcome) =>
     handleCreation({ outcome, promptDelivered: outcome.status === 'created' && hasPrompt })

--- a/src/renderer/src/lib/launch-work-item-direct-agent.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.test.ts
@@ -36,4 +36,26 @@ describe('buildDirectWorkItemStartupOpts', () => {
       }
     })
   })
+
+  it('carries launchDraftText for a natively-prefilled draft launch', () => {
+    // Why: the draft is already inside launchCommand, so draftPrompt stays unset
+    // and launchDraftText is the only signal the view-mode gate can read.
+    const plan: AgentStartupPlan = {
+      agent: 'claude',
+      launchCommand: "claude --prefill 'https://github.com/o/r/issues/12'",
+      expectedProcess: 'claude',
+      followupPrompt: null,
+      launchConfig: { agentArgs: '', agentEnv: {} }
+    }
+
+    const opts = buildDirectWorkItemStartupOpts(
+      'claude',
+      plan,
+      'task_page',
+      'https://github.com/o/r/issues/12'
+    )
+
+    expect(opts.startup?.draftPrompt).toBeUndefined()
+    expect(opts.startup?.launchDraftText).toBe('https://github.com/o/r/issues/12')
+  })
 })

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -114,7 +114,10 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
 export function buildDirectWorkItemStartupOpts(
   agent: TuiAgent | null,
   plan: AgentStartupPlan | null,
-  launchSource: LaunchSource
+  launchSource: LaunchSource,
+  /** Unsent launch context, for the view-mode decision only. Set it for every
+   *  draft launch — a natively-prefilled plan carries no `draftPrompt`. */
+  launchDraftText?: string
 ): {
   startup?: {
     command: string
@@ -122,6 +125,7 @@ export function buildDirectWorkItemStartupOpts(
     launchConfig?: SleepingAgentLaunchConfig
     launchAgent?: TuiAgent
     draftPrompt?: string
+    launchDraftText?: string
     sessionOptions?: AgentStartupPlan['sessionOptions']
     startupCommandDelivery?: StartupCommandDelivery
     telemetry?: AgentStartedTelemetry
@@ -142,6 +146,7 @@ export function buildDirectWorkItemStartupOpts(
       ...(plan.sessionOptions ? { sessionOptions: plan.sessionOptions } : {}),
       ...(agent ? { launchAgent: agent } : {}),
       ...(plan.draftPrompt ? { draftPrompt: plan.draftPrompt } : {}),
+      ...(launchDraftText ? { launchDraftText } : {}),
       ...(plan.startupCommandDelivery
         ? { startupCommandDelivery: plan.startupCommandDelivery }
         : {}),

--- a/src/renderer/src/lib/launch-work-item-direct.test.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.test.ts
@@ -459,6 +459,12 @@ describe('launchWorkItemDirect', () => {
       createdAt: expect.any(Number)
     })
     expect(mocks.seedNativeChatLaunchPrompt).not.toHaveBeenCalled()
+    // Why: the draft is inside `--prefill`, so the plan sets no draftPrompt.
+    // launchDraftText is the only thing that lets the view-mode gate see a
+    // draft here — without it this tab opens in chat unconditionally.
+    const startup = mocks.activateAndRevealWorktree.mock.calls.at(-1)?.[1]?.startup
+    expect(startup?.draftPrompt).toBeUndefined()
+    expect(startup?.launchDraftText).toBe('https://github.com/acme/repo/issues/12')
   })
 
   it('withholds the chat-composer launch draft for a multi-line Linear draft launch', async () => {

--- a/src/renderer/src/lib/launch-work-item-direct.ts
+++ b/src/renderer/src/lib/launch-work-item-direct.ts
@@ -286,7 +286,12 @@ export async function launchWorkItemDirect(args: LaunchWorkItemDirectArgs): Prom
       sidebarRevealBehavior: 'auto',
       setup: result.setup,
       defaultTabs: result.defaultTabs,
-      ...buildDirectWorkItemStartupOpts(effectiveAgent, startupPlan, launchSource)
+      ...buildDirectWorkItemStartupOpts(
+        effectiveAgent,
+        startupPlan,
+        launchSource,
+        promptDelivery === 'draft' ? draftContent : undefined
+      )
     })
     if (!activation) {
       // Worktree vanished between create and activate — extremely unlikely but

--- a/src/renderer/src/lib/native-chat-initial-view-mode.test.ts
+++ b/src/renderer/src/lib/native-chat-initial-view-mode.test.ts
@@ -90,13 +90,31 @@ describe('decideInitialAgentTabViewMode', () => {
     ).toEqual({})
   })
 
-  it('returns undefined for draft delivery', () => {
+  it('opens a mirrorable draft launch in chat', () => {
     expect(
       decideInitialAgentTabViewMode({
         experimentalNativeChat: true,
         openAgentTabsInChatByDefault: true,
         agent: 'claude',
-        promptDelivery: 'draft'
+        promptDelivery: 'draft',
+        launchDraftText: 'https://github.com/o/r/issues/12'
+      })
+    ).toBe('chat')
+  })
+
+  it.each([
+    ['multi-line', 'Reproduce first\n\nhttps://github.com/o/r/issues/12'],
+    ['trailing-newline', 'https://github.com/o/r/issues/12\n'],
+    ['blank', '   '],
+    ['absent', undefined]
+  ])('keeps a %s draft in the terminal, where its text actually is', (_label, launchDraftText) => {
+    expect(
+      decideInitialAgentTabViewMode({
+        experimentalNativeChat: true,
+        openAgentTabsInChatByDefault: true,
+        agent: 'claude',
+        promptDelivery: 'draft',
+        ...(launchDraftText === undefined ? {} : { launchDraftText })
       })
     ).toBeUndefined()
   })

--- a/src/renderer/src/lib/native-chat-initial-view-mode.ts
+++ b/src/renderer/src/lib/native-chat-initial-view-mode.ts
@@ -1,4 +1,5 @@
 import type { GlobalSettings, Tab, TuiAgent } from '../../../shared/types'
+import { canMirrorLaunchDraftToNativeChat } from '@/lib/native-chat-launch-draft-mirrorability'
 import { isNativeChatSupportedAgent } from '@/lib/native-chat-supported-agent'
 
 export type NativeChatLaunchPromptDelivery = 'auto-submit' | 'draft' | 'submit-after-ready'
@@ -8,14 +9,17 @@ export type NativeChatLaunchPromptDelivery = 'auto-submit' | 'draft' | 'submit-a
  * opt-in `openAgentTabsInChatByDefault` setting.
  *
  * Returns `'chat'` only when the setting is explicitly on and the launched
- * agent has a native-chat renderer. Draft launches stay in the terminal because
- * their prompt exists only in the TUI input buffer.
+ * agent has a native-chat renderer. A draft launch opens in chat only when its
+ * unsent context can be mirrored into the composer — gated on the same
+ * predicate as seeding so the view never opens empty beside a filled TUI input.
  */
 export function decideInitialAgentTabViewMode(args: {
   experimentalNativeChat?: boolean
   openAgentTabsInChatByDefault?: boolean
   agent?: TuiAgent | null
   promptDelivery?: NativeChatLaunchPromptDelivery
+  /** The unsent launch context, when `promptDelivery` is `'draft'`. */
+  launchDraftText?: string
   nativeChatTranscriptIsLocalReadable?: boolean
 }): Tab['viewMode'] {
   if (args.experimentalNativeChat !== true || args.openAgentTabsInChatByDefault !== true) {
@@ -27,7 +31,10 @@ export function decideInitialAgentTabViewMode(args: {
   if (args.agent === 'grok' && args.nativeChatTranscriptIsLocalReadable !== true) {
     return undefined
   }
-  if (args.promptDelivery === 'draft') {
+  if (
+    args.promptDelivery === 'draft' &&
+    !canMirrorLaunchDraftToNativeChat(args.launchDraftText ?? '')
+  ) {
     return undefined
   }
   return 'chat'
@@ -41,6 +48,7 @@ export function initialAgentTabViewModeProps(
   options: {
     agent?: TuiAgent | null
     promptDelivery?: NativeChatLaunchPromptDelivery
+    launchDraftText?: string
     nativeChatTranscriptIsLocalReadable?: boolean
   } = {}
 ): { viewMode?: Tab['viewMode'] } {
@@ -49,6 +57,7 @@ export function initialAgentTabViewModeProps(
     openAgentTabsInChatByDefault: settings?.openAgentTabsInChatByDefault,
     agent: options.agent,
     promptDelivery: options.promptDelivery,
+    launchDraftText: options.launchDraftText,
     nativeChatTranscriptIsLocalReadable: options.nativeChatTranscriptIsLocalReadable
   })
   return viewMode ? { viewMode } : {}

--- a/src/renderer/src/lib/native-chat-launch-draft-mirrorability.test.ts
+++ b/src/renderer/src/lib/native-chat-launch-draft-mirrorability.test.ts
@@ -22,6 +22,9 @@ import { decideInitialAgentTabViewMode } from './native-chat-initial-view-mode'
 const DRAFT_TEXTS = [
   'https://github.com/o/r/issues/12',
   'Reproduce on Windows first\n\nhttps://github.com/o/r/issues/12',
+  'Reproduce on Windows first\rhttps://github.com/o/r/issues/12',
+  'Reproduce first\u2028https://github.com/o/r/issues/12',
+  'Reproduce first\u2029https://github.com/o/r/issues/12',
   'ORC-123: Restore linked quick-create\nhttps://linear.app/o/issue/ORC-123',
   'ORC-123 https://linear.app/o/issue/ORC-123\n',
   '  spaced but single line  ',
@@ -68,9 +71,12 @@ describe('launch draft mirrorability', () => {
 
   // The only test that pins the rule itself; the agreement tests above adapt on
   // their own. Multi-line send work updates the predicate body and this test.
-  it('accepts single-line text and rejects anything with a newline', () => {
+  it('accepts single-line text and rejects any line separator', () => {
     expect(canMirrorLaunchDraftToNativeChat('https://github.com/o/r/issues/12')).toBe(true)
     expect(canMirrorLaunchDraftToNativeChat('one\ntwo')).toBe(false)
+    expect(canMirrorLaunchDraftToNativeChat('one\rtwo')).toBe(false)
+    expect(canMirrorLaunchDraftToNativeChat('one\u2028two')).toBe(false)
+    expect(canMirrorLaunchDraftToNativeChat('one\u2029two')).toBe(false)
     expect(canMirrorLaunchDraftToNativeChat('trailing\n')).toBe(false)
     expect(canMirrorLaunchDraftToNativeChat('   ')).toBe(false)
   })

--- a/src/renderer/src/lib/native-chat-launch-draft-mirrorability.test.ts
+++ b/src/renderer/src/lib/native-chat-launch-draft-mirrorability.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  seedNativeChatLaunchDraft: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({ seedNativeChatLaunchDraft: mocks.seedNativeChatLaunchDraft })
+  }
+}))
+
+import { seedNativeChatLaunchDraftForAgentTab } from './agent-launch-prompt-delivery'
+import { canMirrorLaunchDraftToNativeChat } from './native-chat-launch-draft-mirrorability'
+import { decideInitialAgentTabViewMode } from './native-chat-initial-view-mode'
+
+/**
+ * Every shape a launch draft takes today. `formatDraftContextBlock` appends a
+ * trailing newline and note+URL joins with a blank line, so the multi-line
+ * cases are the majority of real draft launches, not edge cases.
+ */
+const DRAFT_TEXTS = [
+  'https://github.com/o/r/issues/12',
+  'Reproduce on Windows first\n\nhttps://github.com/o/r/issues/12',
+  'ORC-123: Restore linked quick-create\nhttps://linear.app/o/issue/ORC-123',
+  'ORC-123 https://linear.app/o/issue/ORC-123\n',
+  '  spaced but single line  ',
+  '',
+  '   ',
+  '\n'
+]
+
+function opensInChat(text: string): boolean {
+  return (
+    decideInitialAgentTabViewMode({
+      experimentalNativeChat: true,
+      openAgentTabsInChatByDefault: true,
+      agent: 'claude',
+      promptDelivery: 'draft',
+      launchDraftText: text
+    }) === 'chat'
+  )
+}
+
+function seedsTheComposer(text: string): boolean {
+  mocks.seedNativeChatLaunchDraft.mockClear()
+  seedNativeChatLaunchDraftForAgentTab({ tabId: 'tab-1', agent: 'claude', text })
+  return mocks.seedNativeChatLaunchDraft.mock.calls.length > 0
+}
+
+describe('launch draft mirrorability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // Why: the whole point of the shared predicate. If either side ever grows its
+  // own inline rule, a draft launch opens in chat with an empty composer beside
+  // a filled TUI input (or stays in the terminal with a mirror nobody sees).
+  it.each(DRAFT_TEXTS)('opens in chat exactly when it seeds: %j', (text) => {
+    expect(opensInChat(text)).toBe(seedsTheComposer(text))
+  })
+
+  it.each(DRAFT_TEXTS)('both sides follow the predicate: %j', (text) => {
+    const expected = canMirrorLaunchDraftToNativeChat(text)
+    expect(seedsTheComposer(text)).toBe(expected)
+    expect(opensInChat(text)).toBe(expected)
+  })
+
+  // The only test that pins the rule itself; the agreement tests above adapt on
+  // their own. Multi-line send work updates the predicate body and this test.
+  it('accepts single-line text and rejects anything with a newline', () => {
+    expect(canMirrorLaunchDraftToNativeChat('https://github.com/o/r/issues/12')).toBe(true)
+    expect(canMirrorLaunchDraftToNativeChat('one\ntwo')).toBe(false)
+    expect(canMirrorLaunchDraftToNativeChat('trailing\n')).toBe(false)
+    expect(canMirrorLaunchDraftToNativeChat('   ')).toBe(false)
+  })
+
+  it('withholds the mirror from agents without a native-chat renderer', () => {
+    // The view mode already returns undefined for these, so the sets still
+    // agree — but only the seeding side enforces it.
+    expect(seedsTheComposer('https://github.com/o/r/issues/12')).toBe(true)
+    mocks.seedNativeChatLaunchDraft.mockClear()
+    seedNativeChatLaunchDraftForAgentTab({
+      tabId: 'tab-1',
+      agent: 'gemini',
+      text: 'https://github.com/o/r/issues/12'
+    })
+    expect(mocks.seedNativeChatLaunchDraft).not.toHaveBeenCalled()
+    expect(
+      decideInitialAgentTabViewMode({
+        experimentalNativeChat: true,
+        openAgentTabsInChatByDefault: true,
+        agent: 'gemini',
+        promptDelivery: 'draft',
+        launchDraftText: 'https://github.com/o/r/issues/12'
+      })
+    ).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/native-chat-launch-draft-mirrorability.ts
+++ b/src/renderer/src/lib/native-chat-launch-draft-mirrorability.ts
@@ -14,5 +14,5 @@
  * predicate to accept multi-line flips seeding and view mode together.
  */
 export function canMirrorLaunchDraftToNativeChat(text: string): boolean {
-  return text.trim().length > 0 && !text.includes('\n')
+  return text.trim().length > 0 && !/[\r\n\u2028\u2029]/.test(text)
 }

--- a/src/renderer/src/lib/native-chat-launch-draft-mirrorability.ts
+++ b/src/renderer/src/lib/native-chat-launch-draft-mirrorability.ts
@@ -1,0 +1,18 @@
+/**
+ * Single source of truth for whether unsent launch context can be mirrored from
+ * the agent's TUI input into the native-chat composer.
+ *
+ * Both the seeding path (`seedNativeChatLaunchDraftForAgentTab`) and the
+ * initial-view-mode decision (`decideInitialAgentTabViewMode`) gate on this one
+ * predicate, so a draft launch can never open in chat with a composer that
+ * chat then refuses to fill.
+ *
+ * Multi-line is rejected because the chat send pre-clears the TUI input with
+ * Ctrl+U (\x15) — kill-to-start-of-LINE, not of the whole buffer — so earlier
+ * lines of a multi-line mirror would survive and concatenate onto the message
+ * being sent. Relaxing that rule belongs here and nowhere else: teaching this
+ * predicate to accept multi-line flips seeding and view mode together.
+ */
+export function canMirrorLaunchDraftToNativeChat(text: string): boolean {
+  return text.trim().length > 0 && !text.includes('\n')
+}

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -533,6 +533,42 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     })
   })
 
+  // An argv-prefill launch carries the draft inside `command` and sets NO
+  // draftPrompt, so gating on draftPrompt alone lets it open in chat with
+  // nothing mirrored — an empty composer beside a filled TUI input.
+  it.each([
+    ['mirrorable', 'https://github.com/o/r/issues/12', { viewMode: 'chat' }],
+    ['multi-line', 'Review this\n\nhttps://github.com/o/r/issues/12', {}]
+  ])(
+    'gates a %s argv-prefill draft on launchDraftText alone',
+    (_label, launchDraftText, expectedViewMode) => {
+      const store = createMockStore({
+        settings: {
+          experimentalNativeChat: true,
+          openAgentTabsInChatByDefault: true
+        }
+      })
+
+      ensureWorktreeHasInitialTerminal(
+        store,
+        'wt-1',
+        {
+          command: `claude --prefill '${launchDraftText}'`,
+          launchAgent: 'claude',
+          launchDraftText
+        },
+        undefined,
+        undefined
+      )
+
+      expect(store.createTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
+        pendingActivationSpawn: true,
+        launchAgent: 'claude',
+        ...expectedViewMode
+      })
+    }
+  )
+
   it('opens the startup default tab in native chat when configured', () => {
     let createdIndex = 0
     const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -501,7 +501,12 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     })
   })
 
-  it('keeps draft startup payloads in terminal mode even when native chat is configured', () => {
+  // A draft opens in chat only when the composer can actually show it; the
+  // multi-line case would otherwise be an empty composer beside a filled TUI.
+  it.each([
+    ['mirrorable', 'https://github.com/o/r/issues/12', { viewMode: 'chat' }],
+    ['multi-line', 'Review this\n\nhttps://github.com/o/r/issues/12', {}]
+  ])('opens a %s draft startup payload accordingly', (_label, draftPrompt, expectedViewMode) => {
     const store = createMockStore({
       settings: {
         experimentalNativeChat: true,
@@ -515,7 +520,7 @@ describe('ensureWorktreeHasInitialTerminal', () => {
       {
         command: 'claude',
         launchAgent: 'claude',
-        draftPrompt: 'Review before sending'
+        draftPrompt
       },
       undefined,
       undefined
@@ -523,7 +528,8 @@ describe('ensureWorktreeHasInitialTerminal', () => {
 
     expect(store.createTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
       pendingActivationSpawn: true,
-      launchAgent: 'claude'
+      launchAgent: 'claude',
+      ...expectedViewMode
     })
   })
 
@@ -555,32 +561,39 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     })
   })
 
-  it('keeps a draft startup default tab in terminal mode even when native chat is configured', () => {
-    let createdIndex = 0
-    const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
-    const store = createMockStore({
-      createTab,
-      settings: {
-        experimentalNativeChat: true,
-        openAgentTabsInChatByDefault: true
-      }
-    })
+  it.each([
+    ['mirrorable', 'https://github.com/o/r/issues/12', { viewMode: 'chat' }],
+    ['multi-line', 'Review this\n\nhttps://github.com/o/r/issues/12', {}]
+  ])(
+    'opens a %s draft startup default tab accordingly',
+    (_label, draftPrompt, expectedViewMode) => {
+      let createdIndex = 0
+      const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
+      const store = createMockStore({
+        createTab,
+        settings: {
+          experimentalNativeChat: true,
+          openAgentTabsInChatByDefault: true
+        }
+      })
 
-    ensureWorktreeHasInitialTerminal(
-      store,
-      'wt-1',
-      { command: 'claude', launchAgent: 'claude', draftPrompt: 'Review before sending' },
-      undefined,
-      undefined,
-      { runCommands: true, tabs: [{ title: 'Claude', command: 'claude' }] }
-    )
+      ensureWorktreeHasInitialTerminal(
+        store,
+        'wt-1',
+        { command: 'claude', launchAgent: 'claude', draftPrompt },
+        undefined,
+        undefined,
+        { runCommands: true, tabs: [{ title: 'Claude', command: 'claude' }] }
+      )
 
-    expect(createTab).toHaveBeenNthCalledWith(1, 'wt-1', undefined, undefined, {
-      pendingActivationSpawn: true,
-      recordInteraction: false,
-      launchAgent: 'claude'
-    })
-  })
+      expect(createTab).toHaveBeenNthCalledWith(1, 'wt-1', undefined, undefined, {
+        pendingActivationSpawn: true,
+        recordInteraction: false,
+        launchAgent: 'claude',
+        ...expectedViewMode
+      })
+    }
+  )
 
   it('gates startup behind setup completion when both are provided in new-tab mode', () => {
     setSetupScriptLaunchMode('new-tab')

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -552,6 +552,9 @@ export function ensureWorktreeHasInitialTerminal(
           ...initialAgentTabViewModeProps(store.settings ?? null, {
             agent: launchAgent,
             promptDelivery: sequencedStartup?.draftPrompt != null ? 'draft' : undefined,
+            ...(sequencedStartup?.draftPrompt != null
+              ? { launchDraftText: sequencedStartup.draftPrompt }
+              : {}),
             nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(
               getConnectionId(worktreeId)
             )
@@ -624,6 +627,9 @@ function applyDefaultTerminalTabs(
             ...initialAgentTabViewModeProps(store.settings ?? null, {
               agent: launchAgent,
               promptDelivery: isStartupTab && startup?.draftPrompt != null ? 'draft' : undefined,
+              ...(isStartupTab && startup?.draftPrompt != null
+                ? { launchDraftText: startup.draftPrompt }
+                : {}),
               nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(
                 getConnectionId(worktreeId)
               )

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -83,10 +83,39 @@ export type WorktreeStartupPayload = {
   launchToken?: string
   launchAgent?: TuiAgent
   draftPrompt?: string
+  /**
+   * The unsent launch context, for the initial view-mode decision ONLY.
+   *
+   * Deliberately separate from `draftPrompt`, which drives the bracketed paste
+   * in pty-connection: an argv-prefill launch already carries the draft inside
+   * `command`, so reusing `draftPrompt` here would paste it a second time.
+   * Set this on every draft launch; set `draftPrompt` only for paste delivery.
+   */
+  launchDraftText?: string
   startupCommandDelivery?: StartupCommandDelivery
   initialAgentStatus?: { agent: TuiAgent; prompt: string }
   sessionOptions?: Record<string, SessionOptionValue>
   telemetry?: AgentStartedTelemetry
+}
+
+/**
+ * The unsent launch context a startup payload carries, whichever way the agent
+ * receives it: argv prefill sets only `launchDraftText`, post-ready paste sets
+ * `draftPrompt`. Gating on `draftPrompt` alone silently misses every
+ * argv-prefill launch.
+ */
+export function resolveStartupLaunchDraftText(
+  startup: Pick<WorktreeStartupPayload, 'draftPrompt' | 'launchDraftText'> | undefined
+): string | undefined {
+  return startup?.draftPrompt ?? startup?.launchDraftText
+}
+
+/** Shared by both tab-creation sites so the draft gate can't drift between them. */
+function draftViewModeProps(draftText: string | undefined): {
+  promptDelivery?: 'draft'
+  launchDraftText?: string
+} {
+  return draftText == null ? {} : { promptDelivery: 'draft', launchDraftText: draftText }
 }
 
 // Why: accept either a main-generated runner script or a plain TaskPage command string, so callers needn't synthesize a runner file.
@@ -551,10 +580,9 @@ export function ensureWorktreeHasInitialTerminal(
           launchAgent,
           ...initialAgentTabViewModeProps(store.settings ?? null, {
             agent: launchAgent,
-            promptDelivery: sequencedStartup?.draftPrompt != null ? 'draft' : undefined,
-            ...(sequencedStartup?.draftPrompt != null
-              ? { launchDraftText: sequencedStartup.draftPrompt }
-              : {}),
+            // Why: argv-prefill launches carry the draft in `command` and set no
+            // draftPrompt, so gating on draftPrompt alone misses them entirely.
+            ...draftViewModeProps(resolveStartupLaunchDraftText(sequencedStartup)),
             nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(
               getConnectionId(worktreeId)
             )
@@ -626,10 +654,9 @@ function applyDefaultTerminalTabs(
             launchAgent,
             ...initialAgentTabViewModeProps(store.settings ?? null, {
               agent: launchAgent,
-              promptDelivery: isStartupTab && startup?.draftPrompt != null ? 'draft' : undefined,
-              ...(isStartupTab && startup?.draftPrompt != null
-                ? { launchDraftText: startup.draftPrompt }
-                : {}),
+              ...draftViewModeProps(
+                isStartupTab ? resolveStartupLaunchDraftText(startup) : undefined
+              ),
               nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(
                 getConnectionId(worktreeId)
               )

--- a/src/renderer/src/lib/worktree-creation-agent-seeds.test.ts
+++ b/src/renderer/src/lib/worktree-creation-agent-seeds.test.ts
@@ -5,7 +5,8 @@ import { seedAgentTabStateAfterWorktreeCreate } from './worktree-creation-agent-
 
 const mocks = vi.hoisted(() => ({
   seedNativeChatAppliedSessionOptions: vi.fn(),
-  seedNativeChatLaunchDraftForAgentTab: vi.fn()
+  seedNativeChatLaunchDraftForAgentTab: vi.fn(),
+  setWebRuntimeTabProps: vi.fn()
 }))
 
 vi.mock('@/components/native-chat/native-chat-session-option-cache', () => ({
@@ -14,11 +15,18 @@ vi.mock('@/components/native-chat/native-chat-session-option-cache', () => ({
 vi.mock('@/lib/agent-launch-prompt-delivery', () => ({
   seedNativeChatLaunchDraftForAgentTab: mocks.seedNativeChatLaunchDraftForAgentTab
 }))
+vi.mock('@/runtime/web-runtime-session', () => ({
+  setWebRuntimeTabProps: mocks.setWebRuntimeTabProps
+}))
 
 type AppState = ReturnType<typeof useAppStore.getState>
 
 const initialTabsByWorktree = useAppStore.getState().tabsByWorktree
+const initialUnifiedTabsByWorktree = useAppStore.getState().unifiedTabsByWorktree
 const initialGetKnownWorktreeById = useAppStore.getState().getKnownWorktreeById
+const initialSettings = useAppStore.getState().settings!
+const initialWorktreesByRepo = useAppStore.getState().worktreesByRepo
+const initialRepos = useAppStore.getState().repos
 
 const DRAFT = 'https://github.com/o/r/issues/12'
 
@@ -28,9 +36,40 @@ const request = {
   launchDraftPrompt: DRAFT
 }
 
-function setTabs(tabs: { id: string; launchAgent?: string }[]): void {
+function setTabs(
+  tabs: { id: string; launchAgent?: string; viewMode?: 'terminal' | 'chat' }[],
+  runtimeOwnerEnvironmentId?: string
+): void {
   useAppStore.setState({
     tabsByWorktree: { 'wt-1': tabs },
+    worktreesByRepo: {
+      'repo-1': [
+        {
+          id: 'wt-1',
+          repoId: 'repo-1',
+          path: '/repo/wt-1',
+          ...(runtimeOwnerEnvironmentId ? { runtimeOwnerEnvironmentId } : {})
+        }
+      ]
+    },
+    repos: [{ id: 'repo-1', path: '/repo', connectionId: null }],
+    unifiedTabsByWorktree: {
+      'wt-1': tabs.map((tab, index) => ({
+        id: tab.id,
+        entityId: tab.id,
+        groupId: 'group-1',
+        worktreeId: 'wt-1',
+        contentType: 'terminal' as const,
+        label: `Terminal ${index + 1}`,
+        customLabel: null,
+        color: null,
+        sortOrder: index,
+        createdAt: index,
+        isPreview: false,
+        isPinned: false,
+        ...(tab.viewMode ? { viewMode: tab.viewMode } : {})
+      }))
+    },
     getKnownWorktreeById: ((id: string) =>
       id === 'wt-1' ? { id } : undefined) as unknown as AppState['getKnownWorktreeById']
   } as unknown as Partial<AppState>)
@@ -40,15 +79,31 @@ function seededTabIds(): string[] {
   return mocks.seedNativeChatLaunchDraftForAgentTab.mock.calls.map((call) => call[0].tabId)
 }
 
+function tabViewMode(tabId: string): 'terminal' | 'chat' | undefined {
+  return useAppStore.getState().unifiedTabsByWorktree['wt-1']?.find((tab) => tab.id === tabId)
+    ?.viewMode
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
+  useAppStore.setState({
+    settings: {
+      ...initialSettings,
+      experimentalNativeChat: true,
+      openAgentTabsInChatByDefault: true
+    }
+  })
 })
 
 afterEach(() => {
   resetHookCommandDelayedDeliveryForTests()
   useAppStore.setState({
     tabsByWorktree: initialTabsByWorktree,
-    getKnownWorktreeById: initialGetKnownWorktreeById
+    unifiedTabsByWorktree: initialUnifiedTabsByWorktree,
+    getKnownWorktreeById: initialGetKnownWorktreeById,
+    settings: initialSettings,
+    worktreesByRepo: initialWorktreesByRepo,
+    repos: initialRepos
   } as Partial<AppState>)
 })
 
@@ -72,6 +127,60 @@ describe('seedAgentTabStateAfterWorktreeCreate', () => {
       'claude',
       undefined
     )
+  })
+
+  it('moves a backend-spawned non-mirrorable draft out of an inherited chat view', () => {
+    setTabs([{ id: 'agent-tab', launchAgent: 'claude', viewMode: 'chat' }])
+
+    seedAgentTabStateAfterWorktreeCreate({
+      request: { ...request, launchDraftPrompt: 'note\rhttps://github.com/o/r/issues/12' },
+      worktreeId: 'wt-1',
+      primaryTabId: 'agent-tab',
+      startupTerminalTabId: 'agent-tab',
+      backendSpawned: true
+    })
+
+    expect(tabViewMode('agent-tab')).toBe('terminal')
+  })
+
+  it('opens a backend-spawned mirrorable draft in chat after host reconciliation', () => {
+    setTabs([{ id: 'agent-tab', launchAgent: 'claude', viewMode: 'terminal' }])
+
+    seedAgentTabStateAfterWorktreeCreate({
+      request,
+      worktreeId: 'wt-1',
+      primaryTabId: 'agent-tab',
+      startupTerminalTabId: 'agent-tab',
+      backendSpawned: true
+    })
+
+    expect(tabViewMode('agent-tab')).toBe('chat')
+  })
+
+  it('keys a raw backend tab id and updates the host before its tab mirror lands', async () => {
+    setTabs([], 'runtime-1')
+
+    seedAgentTabStateAfterWorktreeCreate({
+      request,
+      worktreeId: 'wt-1',
+      primaryTabId: null,
+      startupTerminalTabId: 'host-agent-tab',
+      backendSpawned: true
+    })
+
+    expect(seededTabIds()).toEqual(['web-terminal-host-agent-tab'])
+    await vi.waitFor(() =>
+      expect(mocks.setWebRuntimeTabProps).toHaveBeenCalledWith({
+        worktreeId: 'wt-1',
+        tabId: 'web-terminal-host-agent-tab',
+        viewMode: 'chat'
+      })
+    )
+    setTabs(
+      [{ id: 'web-terminal-host-agent-tab', launchAgent: 'claude', viewMode: 'chat' }],
+      'runtime-1'
+    )
+    expect(seededTabIds()).toEqual(['web-terminal-host-agent-tab'])
   })
 
   it('seeds the launchAgent-stamped tab when the renderer owns startup', () => {

--- a/src/renderer/src/lib/worktree-creation-agent-seeds.ts
+++ b/src/renderer/src/lib/worktree-creation-agent-seeds.ts
@@ -2,6 +2,11 @@ import { useAppStore } from '@/store'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 import { seedNativeChatLaunchDraftForAgentTab } from '@/lib/agent-launch-prompt-delivery'
 import { queueHookCommandsForFirstWorktreeTab } from '@/lib/hook-command-delayed-delivery'
+import { decideInitialAgentTabViewMode } from '@/lib/native-chat-initial-view-mode'
+import { getConnectionIdFromState } from '@/lib/connection-context'
+import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { toWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
 import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
 import type { TuiAgent } from '../../../shared/types'
 
@@ -26,18 +31,69 @@ function resolveLaunchAgentTabId(
     backendSpawned: boolean
   }
 ): string | null {
+  const worktreeTabs = state.tabsByWorktree[args.worktreeId] ?? []
   // Main spawned the agent itself, so its startup tab is authoritative.
   if (args.backendSpawned && args.startupTerminalTabId) {
-    return args.startupTerminalTabId
+    return getRuntimeEnvironmentIdForWorktree(state, args.worktreeId)
+      ? toWebTerminalSurfaceTabId(args.startupTerminalTabId)
+      : args.startupTerminalTabId
   }
-  const worktreeTabs = state.tabsByWorktree[args.worktreeId] ?? []
   const stamped = worktreeTabs.find((tab) => tab.launchAgent === args.agent)?.id
   // Why: when the renderer owns startup, `ensureAgentStartupInTerminal` queues it
   // on primaryTabId, so that tab is the agent's tab by construction.
   return stamped ?? args.primaryTabId ?? args.startupTerminalTabId ?? null
 }
 
-function applyAgentTabSeeds(request: SeedRequest, agent: TuiAgent, tabId: string): void {
+function applyBackendSpawnedDraftViewMode(args: {
+  state: AppStoreSnapshot
+  request: SeedRequest
+  agent: TuiAgent
+  tabId: string
+  worktreeId: string
+  backendSpawned: boolean
+}): void {
+  const { state, request, agent, tabId, worktreeId, backendSpawned } = args
+  if (!backendSpawned || !request.launchDraftPrompt) {
+    return
+  }
+  const desiredViewMode =
+    decideInitialAgentTabViewMode({
+      experimentalNativeChat: state.settings?.experimentalNativeChat,
+      openAgentTabsInChatByDefault: state.settings?.openAgentTabsInChatByDefault,
+      agent,
+      promptDelivery: 'draft',
+      launchDraftText: request.launchDraftPrompt,
+      ...(agent === 'grok'
+        ? {
+            nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(
+              getConnectionIdFromState(state, worktreeId)
+            )
+          }
+        : {})
+    }) ?? 'terminal'
+  const tab = state.unifiedTabsByWorktree?.[worktreeId]?.find((tab) => tab.id === tabId)
+  if (!tab && getRuntimeEnvironmentIdForWorktree(state, worktreeId)) {
+    void import('@/runtime/web-runtime-session').then(({ setWebRuntimeTabProps }) =>
+      setWebRuntimeTabProps({ worktreeId, tabId, viewMode: desiredViewMode })
+    )
+    return
+  }
+  const currentViewMode = tab?.viewMode ?? 'terminal'
+  if (currentViewMode !== desiredViewMode) {
+    state.setTabViewMode(tabId, desiredViewMode)
+  }
+}
+
+function applyAgentTabSeeds(args: {
+  state: AppStoreSnapshot
+  request: SeedRequest
+  agent: TuiAgent
+  tabId: string
+  worktreeId: string
+  backendSpawned: boolean
+}): void {
+  const { request, agent, tabId } = args
+  applyBackendSpawnedDraftViewMode(args)
   seedNativeChatAppliedSessionOptions(tabId, agent, request.startupPlan?.sessionOptions)
   // Why: draft launch context reaches only the TUI input; seed the
   // chat-composer copy so it isn't invisible in the chat view.
@@ -57,7 +113,7 @@ export function seedAgentTabStateAfterWorktreeCreate(args: {
   startupTerminalTabId: string | null | undefined
   backendSpawned: boolean
 }): void {
-  const { request, worktreeId } = args
+  const { request, worktreeId, backendSpawned } = args
   const agent = request.agent
   if (!request.startupPlan || !agent) {
     return
@@ -65,7 +121,7 @@ export function seedAgentTabStateAfterWorktreeCreate(args: {
   const state = useAppStore.getState()
   const tabId = resolveLaunchAgentTabId(state, { ...args, agent })
   if (tabId) {
-    applyAgentTabSeeds(request, agent, tabId)
+    applyAgentTabSeeds({ state, request, agent, tabId, worktreeId, backendSpawned })
     return
   }
   if ((state.tabsByWorktree[worktreeId] ?? []).length > 0) {
@@ -81,7 +137,14 @@ export function seedAgentTabStateAfterWorktreeCreate(args: {
     deliver: (state, firstTerminalTabId) => {
       const mirroredTabId = resolveLaunchAgentTabId(state, { ...args, agent })
       if (mirroredTabId) {
-        applyAgentTabSeeds(request, agent, mirroredTabId)
+        applyAgentTabSeeds({
+          state,
+          request,
+          agent,
+          tabId: mirroredTabId,
+          worktreeId,
+          backendSpawned
+        })
         return
       }
       // Why: same invariant as the synchronous branch — never seed a tab that
@@ -89,7 +152,14 @@ export function seedAgentTabStateAfterWorktreeCreate(args: {
       // so accept the first mirrored tab only when it is the worktree's only
       // one and therefore unambiguously the agent's.
       if ((state.tabsByWorktree[worktreeId] ?? []).length === 1) {
-        applyAgentTabSeeds(request, agent, firstTerminalTabId)
+        applyAgentTabSeeds({
+          state,
+          request,
+          agent,
+          tabId: firstTerminalTabId,
+          worktreeId,
+          backendSpawned
+        })
       }
     }
   })

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -13,7 +13,11 @@ const { prepareEphemeralVmWorkspaceTargetMock } = vi.hoisted(() => ({
 type TestActiveView = 'terminal' | 'tasks'
 
 const store = {
-  settings: { activeRuntimeEnvironmentId: null as string | null },
+  settings: {
+    activeRuntimeEnvironmentId: null as string | null,
+    experimentalNativeChat: undefined as boolean | undefined,
+    openAgentTabsInChatByDefault: undefined as boolean | undefined
+  },
   activeView: 'terminal' as TestActiveView,
   activePendingCreationId: 'creation-1' as string | null,
   repos: [{ id: 'repo-runtime', connectionId: null }],
@@ -41,7 +45,9 @@ const store = {
   setupProjectExistingFolder: vi.fn(),
   refreshRuntimeEnvironmentStatus: vi.fn(),
   seedNativeChatLaunchDraft: vi.fn(),
-  tabsByWorktree: {} as Record<string, { id: string; launchAgent?: string }[]>
+  setTabViewMode: vi.fn(),
+  tabsByWorktree: {} as Record<string, { id: string; launchAgent?: string }[]>,
+  unifiedTabsByWorktree: {}
 }
 
 vi.mock('@/store', () => ({
@@ -94,12 +100,15 @@ const FLOW_SOURCE = readFileSync(join(__dirname, 'worktree-creation-flow.ts'), '
 beforeEach(() => {
   vi.clearAllMocks()
   store.settings.activeRuntimeEnvironmentId = null
+  store.settings.experimentalNativeChat = undefined
+  store.settings.openAgentTabsInChatByDefault = undefined
   store.activeView = 'terminal'
   store.activePendingCreationId = 'creation-1'
   store.repos = []
   store.pendingWorktreeCreations = { 'creation-1': makePendingCreation(makeRequest()) }
   store.createWorktree.mockImplementation(() => new Promise(() => {}))
   store.tabsByWorktree = {}
+  store.unifiedTabsByWorktree = {}
   vi.mocked(ensureWorktreeHasInitialTerminal).mockReturnValue('tab-1')
 })
 
@@ -695,6 +704,38 @@ describe('staged background worktree creation', () => {
     expect(store.seedNativeChatLaunchDraft).toHaveBeenCalledWith(
       expect.objectContaining({ tabId: 'agent-tab' })
     )
+  })
+
+  it.each([
+    ['mirrorable local Grok', 'grok', 'https://github.com/o/r/issues/12', 'chat'],
+    ['multi-line Claude', 'claude', 'note\nhttps://github.com/o/r/issues/12', 'terminal']
+  ] as const)('passes %s draft mode to backend startup', async (_label, agent, draft, viewMode) => {
+    store.settings.experimentalNativeChat = true
+    store.settings.openAgentTabsInChatByDefault = true
+    store.repos = [{ id: 'repo-1', connectionId: null }]
+    continueBackgroundWorktreeCreation(
+      'creation-1',
+      makeRequest({
+        agent,
+        startup: { command: `${agent} --prefill x`, launchAgent: agent },
+        startupPlan: {
+          agent,
+          launchCommand: `${agent} --prefill x`,
+          expectedProcess: agent,
+          followupPrompt: null,
+          launchConfig: { agentArgs: '', agentEnv: {} }
+        },
+        launchDraftPrompt: draft
+      })
+    )
+
+    await vi.waitFor(() => expect(store.createWorktree).toHaveBeenCalled())
+    const createCall = store.createWorktree.mock.calls[0] as unknown[] | undefined
+    expect(createCall?.[16]).toEqual({
+      command: `${agent} --prefill x`,
+      launchAgent: agent,
+      viewMode
+    })
   })
 
   it('carries launchDraftText into activation for an argv-prefill launch', async () => {

--- a/src/renderer/src/lib/worktree-creation-flow.test.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.test.ts
@@ -697,6 +697,38 @@ describe('staged background worktree creation', () => {
     )
   })
 
+  it('carries launchDraftText into activation for an argv-prefill launch', async () => {
+    // Why: the draft rides inside `launchCommand` here, so the plan sets no
+    // draftPrompt — without launchDraftText the initial view-mode decision
+    // never sees a draft and opens chat on an unmirrorable one.
+    store.activeView = 'terminal'
+    store.activePendingCreationId = 'creation-1'
+    store.createWorktree.mockResolvedValueOnce({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/repo/wt-1' }
+    })
+    vi.mocked(activateAndRevealWorktree).mockReturnValueOnce({ primaryTabId: 'tab-1' })
+
+    continueBackgroundWorktreeCreation(
+      'creation-1',
+      makeRequest({
+        agent: 'claude',
+        startupPlan: {
+          agent: 'claude',
+          launchCommand: "claude --prefill 'https://github.com/o/r/issues/12'",
+          expectedProcess: 'claude',
+          followupPrompt: null,
+          launchConfig: { agentArgs: '', agentEnv: {} }
+        },
+        launchDraftPrompt: 'https://github.com/o/r/issues/12'
+      })
+    )
+
+    await vi.waitFor(() => expect(activateAndRevealWorktree).toHaveBeenCalled())
+    const startup = vi.mocked(activateAndRevealWorktree).mock.calls[0]?.[1]?.startup
+    expect(startup?.draftPrompt).toBeUndefined()
+    expect(startup?.launchDraftText).toBe('https://github.com/o/r/issues/12')
+  })
+
   it('does not seed a launch draft without draft launch context', async () => {
     store.activeView = 'terminal'
     store.activePendingCreationId = 'creation-1'

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -26,6 +26,7 @@ import type {
 } from '@/lib/pending-worktree-creation'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { seedAgentTabStateAfterWorktreeCreate } from '@/lib/worktree-creation-agent-seeds'
+import { resolveBackendDraftStartup } from '@/lib/worktree-draft-startup-view-mode'
 
 type ContinueBackgroundWorktreeCreationOptions = {
   revealCreationSurface?: boolean
@@ -141,6 +142,7 @@ async function executeWorktreeCreation(
 
   let result: CreateWorktreeResult
   try {
+    const backendStartup = resolveBackendDraftStartup(preparedRequest)
     result = await useAppStore
       .getState()
       .createWorktree(
@@ -160,7 +162,7 @@ async function executeWorktreeCreation(
         preparedRequest.workspaceStatus,
         preparedRequest.linkedGitLabMR,
         preparedRequest.linkedGitLabIssue,
-        preparedRequest.startup,
+        backendStartup,
         preparedRequest.pendingFirstAgentMessageRename,
         creationId,
         preparedRequest.linkedLinearIssueWorkspaceId,

--- a/src/renderer/src/lib/worktree-creation-flow.ts
+++ b/src/renderer/src/lib/worktree-creation-flow.ts
@@ -48,6 +48,9 @@ function buildStartupOpt(
     ...(plan.launchToken ? { launchToken: plan.launchToken } : {}),
     ...(request.agent ? { launchAgent: request.agent } : {}),
     ...(plan.draftPrompt ? { draftPrompt: plan.draftPrompt } : {}),
+    // Why: view-mode only. An argv-prefill plan sets no draftPrompt, so this is
+    // the sole signal that this launch starts with unsent context in the TUI.
+    ...(request.launchDraftPrompt ? { launchDraftText: request.launchDraftPrompt } : {}),
     ...(plan.startupCommandDelivery ? { startupCommandDelivery: plan.startupCommandDelivery } : {}),
     // Why: command-code shows its prompt in the tab status before the first
     // hook fires, so the prompt is threaded through here.

--- a/src/renderer/src/lib/worktree-draft-startup-view-mode.ts
+++ b/src/renderer/src/lib/worktree-draft-startup-view-mode.ts
@@ -1,0 +1,29 @@
+import { useAppStore } from '@/store'
+import { decideInitialAgentTabViewMode } from '@/lib/native-chat-initial-view-mode'
+import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
+import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
+
+export function resolveBackendDraftStartup(
+  request: WorktreeCreationRequest
+): WorktreeCreationRequest['startup'] {
+  if (!request.startup || !request.agent || !request.launchDraftPrompt) {
+    return request.startup
+  }
+  const state = useAppStore.getState()
+  const repo = state.repos.find((entry) => entry.id === request.repoId)
+  const connectionId = repo ? (repo.connectionId ?? null) : undefined
+  const viewMode =
+    decideInitialAgentTabViewMode({
+      experimentalNativeChat: state.settings?.experimentalNativeChat,
+      openAgentTabsInChatByDefault: state.settings?.openAgentTabsInChatByDefault,
+      agent: request.agent,
+      promptDelivery: 'draft',
+      launchDraftText: request.launchDraftPrompt,
+      ...(request.agent === 'grok'
+        ? {
+            nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(connectionId)
+          }
+        : {})
+    }) ?? 'terminal'
+  return { ...request.startup, viewMode }
+}

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -9,6 +9,7 @@ import {
   consumePendingWebRuntimeSplitMirrorTelemetry,
   createWebRuntimeSessionBrowserTab,
   createWebRuntimeAgentSessionTerminal,
+  createWebRuntimeAgentSessionTerminalWithLaunchDraft,
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive,
   moveWebRuntimeSessionTab,
@@ -45,6 +46,7 @@ const mocks = vi.hoisted(() => ({
   resolveHostSessionTabIdForWebSessionTab: vi.fn(),
   trackTerminalPaneSplit: vi.fn(),
   deliverLaunchPromptToAgentTab: vi.fn(),
+  seedNativeChatLaunchDraftForAgentTab: vi.fn(),
   getRuntimeEnvironmentIdForWorktree: vi.fn()
 }))
 
@@ -72,7 +74,8 @@ vi.mock('@/lib/worktree-runtime-owner', () => ({
 }))
 
 vi.mock('@/lib/agent-launch-prompt-delivery', () => ({
-  deliverLaunchPromptToAgentTab: mocks.deliverLaunchPromptToAgentTab
+  deliverLaunchPromptToAgentTab: mocks.deliverLaunchPromptToAgentTab,
+  seedNativeChatLaunchDraftForAgentTab: mocks.seedNativeChatLaunchDraftForAgentTab
 }))
 
 const ENVIRONMENT_ID = 'web-env-1'
@@ -1248,6 +1251,62 @@ describe('createWebRuntimeSessionTerminal', () => {
       agent: 'claude',
       submit: true,
       forcePaste: true
+    })
+  })
+
+  it('seeds the chat composer for a draft that rode in on the launch command', async () => {
+    const runtimeCall = vi.fn(async (request: { method: string; params?: unknown }) => {
+      if (request.method === 'status.get') {
+        return {
+          id: 'status',
+          ok: true,
+          result: {
+            runtimeId: 'runtime-1',
+            graphStatus: 'ready',
+            runtimeProtocolVersion: 3,
+            minCompatibleRuntimeClientVersion: 2,
+            capabilities: ['agent-session.host-authority.v1']
+          }
+        }
+      }
+      if (request.method === 'terminal.createAgentSession') {
+        return {
+          id: 'create',
+          ok: true,
+          result: {
+            terminal: {
+              handle: 'term_created',
+              worktreeId: WORKTREE_ID,
+              tabId: 'host-tab-2',
+              paneKey: `host-tab-2:${FOCUS_LEAF_ID}`
+            },
+            disposition: 'created'
+          }
+        }
+      }
+      return { id: 'list', ok: true, result: makeSnapshot() }
+    })
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+
+    await expect(
+      createWebRuntimeAgentSessionTerminalWithLaunchDraft({
+        worktreeId: WORKTREE_ID,
+        agentSessionKind: 'fresh',
+        agent: 'claude',
+        command: "claude --prefill 'https://github.com/o/r/issues/12'",
+        launchDraft: 'https://github.com/o/r/issues/12'
+      })
+    ).resolves.toEqual({ status: 'created' })
+
+    // No paste runs for an argv-prefill draft, so this is the only thing that
+    // fills the mirrored tab's composer on this host class.
+    expect(mocks.deliverLaunchPromptToAgentTab).not.toHaveBeenCalled()
+    expect(mocks.seedNativeChatLaunchDraftForAgentTab).toHaveBeenCalledWith({
+      tabId: 'web-terminal-host-tab-2',
+      agent: 'claude',
+      text: 'https://github.com/o/r/issues/12'
     })
   })
 })

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -48,7 +48,10 @@ import {
   toHostSessionTabId,
   toWebTerminalSurfaceTabId
 } from './web-terminal-surface-id'
-import { deliverLaunchPromptToAgentTab } from '../lib/agent-launch-prompt-delivery'
+import {
+  deliverLaunchPromptToAgentTab,
+  seedNativeChatLaunchDraftForAgentTab
+} from '../lib/agent-launch-prompt-delivery'
 import {
   listRemoteRuntimeSessionTabsAfterCurrentInFlight,
   listRemoteRuntimeSessionTabsDeduped
@@ -180,6 +183,28 @@ export async function createWebRuntimeAgentSessionTerminal(
     forcePaste: args.forcePromptPaste
   })
   return { outcome: created.outcome, promptDelivered }
+}
+
+/**
+ * Launch a web-host agent terminal whose draft already rode in on the launch
+ * command (argv prefill). No post-ready paste runs for that delivery, so seed
+ * the chat-composer copy here once the mirrored host tab id is known.
+ */
+export async function createWebRuntimeAgentSessionTerminalWithLaunchDraft(
+  args: CreateWebRuntimeSessionTerminalArgs & {
+    agent: TuiAgent
+    launchDraft: string
+  }
+): Promise<WebRuntimeTerminalCreateOutcome> {
+  const created = await createWebRuntimeSessionTerminalResult(args)
+  if (created.outcome.status !== 'failed' && created.hostTabId) {
+    seedNativeChatLaunchDraftForAgentTab({
+      tabId: toWebTerminalSurfaceTabId(created.hostTabId),
+      agent: args.agent,
+      text: args.launchDraft
+    })
+  }
+  return created.outcome
 }
 
 async function createWebRuntimeSessionTerminalResult(

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2148,6 +2148,7 @@ export type WorktreeStartupLaunch = {
   launchConfig?: SleepingAgentLaunchConfig
   launchToken?: string
   launchAgent?: TuiAgent
+  viewMode?: 'terminal' | 'chat'
   startupCommandDelivery?: StartupCommandDelivery
   telemetry?: { agent_kind: AgentKind; launch_source: LaunchSource; request_kind: RequestKind }
 }


### PR DESCRIPTION
Follow-up to #9802. That PR added the native-chat mirror of unsent launch context; this one makes it actually reachable.

## Behavior change — draft launches now open in chat

With **"open agent tabs in chat by default"** on, a draft launch used to be forced into terminal view. It now opens in chat **when the draft can be mirrored** (see the predicate below). This changes the default view for every mirrorable draft launch.

## The gaps

Six originating paths deliver a draft to the agent's TUI. Two problems, both concentrated on the **argv-prefill** branch (Claude `--prefill` etc.), where the draft rides inside `launchCommand` and the plan sets **no `draftPrompt`**:

**1. Three paths never seeded the chat composer at all.** Paste-based branches were already fine — they route through `deliverLaunchPromptToAgentTab`, which seeds. Only argv prefill fell through, because no paste runs.

| Path | Was it visible? |
|---|---|
| `folder-workspace-composer-submit.ts` | Broken today — already opened in chat with an empty composer |
| `launch-agent-in-new-tab.ts` (local) | Hidden by the terminal-view guard |
| `launch-agent-web-host-tab.ts` (web runtime) | Hidden by the terminal-view guard |

**2. The view-mode gate itself missed argv prefill on four paths.** `worktree-activation.ts` derived the gate from `startup.draftPrompt != null`, which only paste delivery sets. So argv-prefill launches were never classified as drafts and opened in chat unconditionally — including multi-line drafts that are correctly *not* seeded, producing exactly the empty-composer-beside-filled-TUI failure the predicate exists to prevent. Affected: `folder-workspace-composer-submit.ts`, `launch-work-item-direct.ts`, and both `worktree-creation-flow.ts` producers (`useComposerState.submitQuick`, `github-work-item-background-request.ts`).

Fix: a `launchDraftText` field on the activation startup payload, carrying the resolved draft text for the **view-mode decision only**. It is deliberately distinct from `draftPrompt`, which drives the bracketed paste in `pty-connection` — reusing it would deliver the draft a second time on top of the argv prefill. `resolveStartupLaunchDraftText` reads either field, and both tab-creation sites share one `draftViewModeProps` helper so they cannot drift.

## Seeded set == chat-opening set, by construction

Lifting the guard outright would have regressed the majority case. `seedNativeChatLaunchDraftForAgentTab` rejects multi-line text, and multi-line is the common shape:

- `formatDraftContextBlock` appends a trailing newline to every Linear block
- `buildLinearLaunchContextBlock` joins identifier and URL with a newline
- note + URL joins with a blank line

A bare issue URL with no note is essentially the only single-line draft. So instead of deleting the guard, both sides gate on one shared predicate, `canMirrorLaunchDraftToNativeChat` in `native-chat-launch-draft-mirrorability.ts`.

## Draft paths that still do not mirror — by design

**Multi-line drafts still open in terminal view**, and today that is the majority of draft launches. That is deliberate: the chat send pre-clears the TUI with Ctrl+U, which is kill-to-start-of-**line**, so a multi-line mirror could concatenate onto the message being sent. The send-protocol work on `brennanb2025/native-chat-multiline-send` is what flips them.

### Note for that worktree — measured, not estimated

The **production** change stays a one-line edit to the predicate body. The **test** fallout is larger than I first claimed. Measured by mutating the predicate to accept multi-line and diffing the full `src/renderer` failure set against baseline: **13 tests across 7 files** go red.

- `worktree-activation.test.ts` (3), `folder-workspace-composer-submit.test.ts` (3), `native-chat-initial-view-mode.test.ts` (2), `native-chat-launch-draft-mirrorability.test.ts` (1), `launch-agent-in-new-tab.test.ts` (1)
- Plus 2 that predate this PR: `agent-launch-prompt-delivery.test.ts`, `launch-work-item-direct.test.ts`

Of these, only `native-chat-launch-draft-mirrorability.test.ts` pins the rule directly; the rest assert multi-line stays in the terminal and flip as a consequence. The consistency suite's 16 agreement assertions stay green throughout — they follow the predicate rather than restating it.

## Tests

Every added test was mutation-checked — production line reverted, test confirmed RED, restored.

Gate and all four producers, each mutated independently:

| Mutation | Result |
|---|---|
| Gate reverted to `draftPrompt`-only (the shipped bug) | 2 RED |
| Folder producer stops emitting `launchDraftText` | 1 RED |
| `worktree-creation-flow` producer dropped | 1 RED |
| `launch-work-item-direct-agent` producer dropped | 1 RED |
| `launch-work-item-direct` caller stops passing `draftContent` | 1 RED |

Seeding, from the first round:

| Mutation | Result |
|---|---|
| Folder seeding disabled | 2 RED |
| Naive `startupPlan.draftPrompt`-keyed implementation | 1 RED |
| Local argv-prefill seed removed | 1 RED |
| Web-host seed disabled / draft branch removed | 1 RED each |
| View-mode grows its own inline rule | **8 RED** — 6 in the consistency suite (3 discriminating texts × 2 assertions) + 2 in the view-mode suite |
| Guard deleted outright (the literal original brief) | 16 RED |

The end-to-end invariant test in `folder-workspace-composer-submit.test.ts` runs the real `submitFolderWorkspaceCreate` and the real view-mode decision over all four delivery/shape combinations and asserts `seeded === opensInChat`. Its module mock uses `importOriginal` so it exercises the shipped `resolveStartupLaunchDraftText` rather than a copy — without that it silently tested a reimplementation.

## Note on the original target

The brief named `useComposerState.ts`'s `submit`. That branch is dead: `NewWorkspaceComposerModal` is the only consumer of `useComposerState` and uses `submitQuick` only (it also overrides `cardProps.onCreate`), and `submit` builds its plan with `buildAgentStartupPlan`, which never sets `draftPrompt`. Seeding it would have been inert with an unfalsifiable test.

## Also here

`launch-agent-in-new-tab.ts` crossed the 300-line `max-lines` cap. Per `AGENTS.md` I split rather than bump it: `launch-agent-startup-prompt-plan.ts` (how a launch delivers its prompt) and `launch-agent-paste-timeout-notice.ts` (the dropped-paste notice). Both are pure moves.

## Verification

- `npm run typecheck` clean (after `rm -f config/*.tsbuildinfo`)
- `npm run lint` clean, including the native and type-aware quality audits
- Changed-code quality gate: **0 new findings** across 22 changed files (react-compiler + react-doctor)
- All 203 tests across the 10 affected suites pass
- Full vitest suite: remaining failures are **pre-existing** — identical set on `b41e813cb5` with the same command, and they survive `--maxWorkers=2`, so they are not load flakes
- **The mobile suite was NOT run in this worktree.** `expo` is not installed here, so all 351 mobile files fail to parse (`TSConfckParseError: failed to resolve "extends":"expo/tsconfig.base.json"`). No mobile files are changed, but CI green does not represent local mobile coverage.
- No live QA on this branch; evidence is unit-level plus a static call-graph trace.
