### PR TITLE
fix(updater): resume background checks after a local build session ends

### DIFF
--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -177,6 +177,9 @@ vi.mock('./local-builds/local-build-feed-server', () => ({
   startLocalBuildFeed: startLocalBuildFeedMock
 }))
 
+/** Mirrors AUTO_UPDATE_CHECK_INTERVAL_MS in updater.ts. */
+const AUTO_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+
 describe('updater', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -399,6 +402,179 @@ describe('updater', () => {
       })
     }
   )
+
+  it.runIf(process.platform === 'darwin')(
+    'keeps the automatic check chain alive across a local build session',
+    async () => {
+      vi.useFakeTimers()
+      chooseLocalBuildMock.mockResolvedValue({
+        version: '0.9.0-local.1',
+        manifestContent: 'version: 0.9.0-local.1',
+        artifacts: new Map()
+      })
+      autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+        autoUpdaterMock.emit('checking-for-update')
+        autoUpdaterMock.emit('update-available', { version: '0.9.0-local.1' })
+        return Promise.resolve(undefined)
+      })
+      autoUpdaterMock.downloadUpdate.mockRejectedValue(new Error('local download failed'))
+      const send = vi.fn()
+      const { setupAutoUpdater, checkForUpdatesFromMenu, downloadUpdate } =
+        await import('./updater')
+      setupAutoUpdater({ webContents: { send } } as never, {
+        getLastUpdateCheckAt: () => Date.now()
+      })
+
+      checkForUpdatesFromMenu({ localBuild: true })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(send).toHaveBeenCalledWith(
+        'updater:status',
+        expect.objectContaining({ state: 'available', source: 'local' })
+      )
+
+      // Why: assert through this window rather than the shared updater mock — a status only lands here
+      // when this module instance owns the check attempt, so sibling tests' timers can't fake a pass.
+      autoUpdaterMock.checkForUpdates.mockReset().mockImplementation(() => {
+        autoUpdaterMock.emit('checking-for-update')
+        autoUpdaterMock.emit('update-not-available')
+        return Promise.resolve(undefined)
+      })
+
+      // The scheduled release check fires while the local session still owns the feed, so it defers.
+      send.mockClear()
+      await vi.advanceTimersByTimeAsync(AUTO_UPDATE_CHECK_INTERVAL_MS)
+      expect(send).not.toHaveBeenCalledWith('updater:status', { state: 'not-available' })
+
+      // A failed local download ends the session and restores the release source.
+      downloadUpdate()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(autoUpdaterMock.allowDowngrade).toBe(false)
+
+      send.mockClear()
+      await vi.advanceTimersByTimeAsync(AUTO_UPDATE_CHECK_INTERVAL_MS)
+      expect(send).toHaveBeenCalledWith('updater:status', { state: 'not-available' })
+      expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+        provider: 'generic',
+        url: 'https://github.com/stablyai/orca/releases/latest/download'
+      })
+    }
+  )
+
+  it.runIf(process.platform === 'darwin')(
+    'restores release checks when an offered local build is dismissed',
+    async () => {
+      chooseLocalBuildMock.mockResolvedValue({
+        version: '0.9.0-local.1',
+        manifestContent: 'version: 0.9.0-local.1',
+        artifacts: new Map()
+      })
+      autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+        autoUpdaterMock.emit('checking-for-update')
+        autoUpdaterMock.emit('update-available', { version: '0.9.0-local.1' })
+        return Promise.resolve(undefined)
+      })
+      const send = vi.fn()
+      const { setupAutoUpdater, checkForUpdates, checkForUpdatesFromMenu, dismissAvailableUpdate } =
+        await import('./updater')
+      setupAutoUpdater({ webContents: { send } } as never, {
+        getLastUpdateCheckAt: () => Date.now()
+      })
+
+      checkForUpdatesFromMenu({ localBuild: true })
+      await vi.waitFor(() => {
+        expect(send).toHaveBeenCalledWith(
+          'updater:status',
+          expect.objectContaining({ state: 'available', source: 'local' })
+        )
+      })
+
+      dismissAvailableUpdate()
+      expect(closeLocalBuildFeedMock).toHaveBeenCalledTimes(1)
+      expect(autoUpdaterMock.allowDowngrade).toBe(false)
+      expect(autoUpdaterMock.disableDifferentialDownload).toBe(false)
+      expect(send).toHaveBeenCalledWith('updater:status', { state: 'idle' })
+
+      autoUpdaterMock.checkForUpdates.mockReset().mockResolvedValue(undefined)
+      checkForUpdates()
+      await vi.waitFor(() => {
+        expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(1)
+      })
+      expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+        provider: 'generic',
+        url: 'https://github.com/stablyai/orca/releases/latest/download'
+      })
+    }
+  )
+
+  it.runIf(process.platform === 'darwin')(
+    'keeps the local feed in force when a dismiss lands during a local build download',
+    async () => {
+      chooseLocalBuildMock.mockResolvedValue({
+        version: '0.9.0-local.1',
+        manifestContent: 'version: 0.9.0-local.1',
+        artifacts: new Map()
+      })
+      autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+        autoUpdaterMock.emit('checking-for-update')
+        autoUpdaterMock.emit('update-available', { version: '0.9.0-local.1' })
+        return Promise.resolve(undefined)
+      })
+      autoUpdaterMock.downloadUpdate.mockResolvedValue(undefined)
+      const send = vi.fn()
+      const { setupAutoUpdater, checkForUpdatesFromMenu, dismissAvailableUpdate, downloadUpdate } =
+        await import('./updater')
+      setupAutoUpdater({ webContents: { send } } as never, {
+        getLastUpdateCheckAt: () => Date.now()
+      })
+
+      checkForUpdatesFromMenu({ localBuild: true })
+      await vi.waitFor(() => {
+        expect(send).toHaveBeenCalledWith(
+          'updater:status',
+          expect.objectContaining({ state: 'available', source: 'local' })
+        )
+      })
+
+      downloadUpdate()
+      dismissAvailableUpdate()
+
+      expect(closeLocalBuildFeedMock).not.toHaveBeenCalled()
+      expect(autoUpdaterMock.allowDowngrade).toBe(true)
+      expect(autoUpdaterMock.disableDifferentialDownload).toBe(true)
+      expect(autoUpdaterMock.setFeedURL).toHaveBeenLastCalledWith({
+        provider: 'generic',
+        url: 'http://127.0.0.1:1234/token/'
+      })
+    }
+  )
+
+  it('leaves a dismissed release update on the release source', async () => {
+    autoUpdaterMock.checkForUpdates.mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      autoUpdaterMock.emit('update-available', { version: '2.0.0' })
+      return Promise.resolve(undefined)
+    })
+    const send = vi.fn()
+    const { setupAutoUpdater, checkForUpdatesFromMenu, dismissAvailableUpdate } =
+      await import('./updater')
+    setupAutoUpdater({ webContents: { send } } as never, {
+      getLastUpdateCheckAt: () => Date.now()
+    })
+
+    checkForUpdatesFromMenu()
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledWith(
+        'updater:status',
+        expect.objectContaining({ state: 'available', version: '2.0.0' })
+      )
+    })
+
+    dismissAvailableUpdate()
+
+    // Why: a release dismissal is renderer-only state; main must not clear the offer it can still install.
+    expect(closeLocalBuildFeedMock).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalledWith('updater:status', { state: 'idle' })
+  })
 
   it('deduplicates identical check errors from the event and rejected promise', async () => {
     autoUpdaterMock.checkForUpdates.mockImplementation(() => {

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -978,7 +978,10 @@ function scheduleAutomaticUpdateCheck(delayMs: number): void {
   }
   autoUpdateCheckTimer = setTimeout(() => {
     // Why: Orca runs for days, so keep the next background check scheduled in the main process rather than tying it to relaunches or renderer lifetime.
-    runBackgroundUpdateCheck()
+    if (!runBackgroundUpdateCheck()) {
+      // Why: a deferred check reaches no outcome handler, so re-arm here or one deferral ends automatic checks for the process lifetime.
+      scheduleAutomaticUpdateCheck(AUTO_UPDATE_CHECK_INTERVAL_MS)
+    }
   }, effectiveDelayMs)
 }
 
@@ -1212,18 +1215,19 @@ function retryPrereleaseFallbackAfterMissingManifest(
   return true
 }
 
+/** Returns false when the check was deferred instead of launched, so timer-driven callers can re-arm. */
 function runBackgroundUpdateCheck(
   nudgeId: string | null = getPersistedPendingUpdateNudgeId()
-): void {
+): boolean {
   if (activeUpdateSource === 'local' || localBuildSelectionInProgress) {
-    return
+    return false
   }
   if (backgroundCheckLaunchPending || currentStatus.state === 'checking') {
-    return
+    return false
   }
   if (!app.isPackaged || is.dev) {
     sendStatus({ state: 'not-available' })
-    return
+    return false
   }
   // Why: set the nudge marker before any events arrive so later checks can't inherit a stale campaign id; persisted id keeps a nudge card dismissable after relaunch.
   activeUpdateNudgeId = nudgeId
@@ -1255,6 +1259,7 @@ function runBackgroundUpdateCheck(
       }
       void sendCheckFailureStatus(String(err?.message ?? err), wasUserInitiated, 'promise', err)
     })
+  return true
 }
 
 export function checkForUpdates(): void {
@@ -1507,6 +1512,24 @@ export function dismissNudge(): void {
     _setDismissedUpdateNudgeId?.(pendingId)
     clearPendingUpdateNudge()
   }
+}
+
+/**
+ * The user closed an offered update without taking it. For a local build that ends the session:
+ * nothing will consume the local feed now, so release checks must stop being deferred.
+ */
+export function dismissAvailableUpdate(): void {
+  if (activeUpdateSource !== 'local' || localBuildSelectionInProgress) {
+    return
+  }
+  // Why: only an un-acted 'available' card is abandoned — 'downloading'/'downloaded' still need the local feed and allowDowngrade.
+  if (currentStatus.state !== 'available') {
+    return
+  }
+  clearAvailableUpdateContext()
+  restoreReleaseUpdateSource()
+  // Why: leaving the card's 'available' status behind would let a retry download the local version off the restored release feed.
+  sendStatus({ state: 'idle' })
 }
 
 export function setupAutoUpdater(

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -30,6 +30,7 @@ import {
   getUpdateStatus,
   quitAndInstall,
   setupAutoUpdater,
+  dismissAvailableUpdate,
   dismissNudge,
   type UpdateInstallMode
 } from '../updater'
@@ -426,6 +427,7 @@ export function registerUpdaterHandlers(_store: Store): void {
   ipcMain.removeHandler('updater:download')
   ipcMain.removeHandler('updater:quitAndInstall')
   ipcMain.removeHandler('updater:dismissNudge')
+  ipcMain.removeHandler('updater:dismissAvailableUpdate')
 
   ipcMain.handle('updater:getStatus', () => getUpdateStatus())
   ipcMain.handle('updater:getVersion', () => app.getVersion())
@@ -436,4 +438,5 @@ export function registerUpdaterHandlers(_store: Store): void {
   ipcMain.handle('updater:download', () => downloadUpdate())
   ipcMain.handle('updater:quitAndInstall', () => quitAndInstall())
   ipcMain.handle('updater:dismissNudge', () => dismissNudge())
+  ipcMain.handle('updater:dismissAvailableUpdate', () => dismissAvailableUpdate())
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2640,6 +2640,7 @@ export type PreloadApi = {
     download: () => Promise<void>
     quitAndInstall: () => Promise<void>
     dismissNudge: () => Promise<void>
+    dismissAvailableUpdate: () => Promise<void>
     onStatus: (callback: (status: UpdateStatus) => void) => () => void
     onClearDismissal: (callback: () => void) => () => void
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2903,6 +2903,7 @@ const api = {
     check: (options) => ipcRenderer.invoke('updater:check', options),
     download: () => ipcRenderer.invoke('updater:download'),
     dismissNudge: () => ipcRenderer.invoke('updater:dismissNudge'),
+    dismissAvailableUpdate: () => ipcRenderer.invoke('updater:dismissAvailableUpdate'),
     quitAndInstall: async (): Promise<void> => {
       await prepareRendererForAppRestart(window, {
         startedEventName: ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT,

--- a/src/renderer/src/components/UpdateCard.error-card.test.tsx
+++ b/src/renderer/src/components/UpdateCard.error-card.test.tsx
@@ -38,6 +38,7 @@ beforeEach(() => {
       updater: {
         check,
         dismissNudge: vi.fn(),
+        dismissAvailableUpdate: vi.fn().mockResolvedValue(undefined),
         download,
         quitAndInstall: vi.fn().mockResolvedValue(undefined)
       }

--- a/src/renderer/src/components/UpdateCard.test.ts
+++ b/src/renderer/src/components/UpdateCard.test.ts
@@ -41,7 +41,8 @@ beforeEach(() => {
       updater: {
         download: vi.fn().mockResolvedValue(undefined),
         quitAndInstall: vi.fn().mockResolvedValue(undefined),
-        dismissNudge: vi.fn().mockResolvedValue(undefined)
+        dismissNudge: vi.fn().mockResolvedValue(undefined),
+        dismissAvailableUpdate: vi.fn().mockResolvedValue(undefined)
       }
     },
     matchMedia: vi.fn().mockReturnValue({

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -2585,6 +2585,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         'activeNudgeId' in s.updateStatus ? (s.updateStatus.activeNudgeId ?? null) : null
       // Why: persist dismissal so relaunch doesn't immediately re-show the same card until a newer release.
       void window.api.ui.set({ dismissedUpdateVersion }).catch(console.error)
+      // Why: main can't otherwise tell an offered update was abandoned, which keeps a local-build session pinned and stalls background checks.
+      void window.api.updater.dismissAvailableUpdate().catch(console.error)
       // Why: only consume the nudge campaign for cards from a nudge cycle, not ordinary dismissals.
       if (activeNudgeId) {
         void window.api.updater.dismissNudge().catch(console.error)

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2919,6 +2919,7 @@ function createUpdaterApi(): NonNullable<Partial<PreloadApi>['updater']> {
     download: () => Promise.resolve(),
     quitAndInstall: () => Promise.resolve(),
     dismissNudge: () => Promise.resolve(),
+    dismissAvailableUpdate: () => Promise.resolve(),
     onStatus: () => noopUnsubscribe,
     onClearDismissal: () => noopUnsubscribe
   }


### PR DESCRIPTION
## The bug

A local-build check (macOS only: Option+click **Check for Updates**, pick a valid `latest-mac.yml`) sets `activeUpdateSource = 'local'` and pins the updater to a local feed server with `allowDowngrade = true`.

`restoreReleaseUpdateSource()` runs on only four paths — local selection error, a manual menu check, `update-not-available`, and the updater `error` handler. The **`update-available` success path has no restore.** Combined with the unconditional early return added at the top of `runBackgroundUpdateCheck`:

```ts
if (activeUpdateSource === 'local' || localBuildSelectionInProgress) { return }
```

...once a local build check reaches `available`, every wake-from-sleep check, window-focus daily check and 30-minute nudge poll returns at that guard for the rest of the process. Dismissing the card is not required to get into this state. A user in this state never learns about a release, including a security release.

There is a second, compounding effect. The automatic check timer is one-shot; the chain is re-armed by each check's *outcome* handler. A deferred check reaches no outcome handler, so the timer that fired during the local session was the last one — the scheduling chain died and `lastUpdateCheckAt` froze.

### Severity bounds

Two mitigations, stated so reviewers can judge scope:

- **A manual menu check fully recovers.** `checkForUpdatesFromMenu` restores unconditionally; its guard only blocks during `checking`/`downloading`, not `available`.
- **Relaunching resets it.** The state is process-lifetime only.
- The trigger is macOS-only and requires the deliberate Option+click local-build flow.

## The fix, and why not the obvious version

**Not** restoring when `update-available` fires. The local flow is still live at that moment — the pending download needs `activeLocalBuildFeed` and `allowDowngrade`. Restoring there closes the feed server and would break the very flow the user just started, trading a background-check freeze for a broken local install.

Tracing the lifecycle, the local session has no terminal event on the success path: `error` and `not-available` already restore, `quitAndInstall` exits the process, and everything else leaves the session pinned indefinitely. The one real abandonment point — the user closing the offered card — was **renderer-only state**; `dismissUpdate` persisted `dismissedUpdateVersion` and main never learned about it.

So this adds that missing signal (`updater:dismissAvailableUpdate`) and restores there.

**Why it cannot fire mid-download:** the restore is gated on `currentStatus.state === 'available'`. `downloadUpdate()` calls `sendStatus({ state: 'downloading' })` **synchronously**, before it calls into electron-updater — so by the time any download is under way the status is no longer `available` and the hook is inert. It is gated the same way against `downloaded`, where Squirrel.Mac may still be staging. The gate lives in main, so it holds regardless of what the renderer does: `UpdateCard` in fact routes `downloading`/`downloaded`/`error` to *collapse*, not dismiss, and a dismiss during a nudge-driven download still lands harmlessly.

After restoring, main sends `idle`. Without that, the stale `available` status would still satisfy `downloadUpdate()`'s `canStart` check and let a retry try to pull the local version off the now-restored release feed.

Separately, the automatic timer now re-arms when a check is **deferred rather than launched**, so a single deferral can no longer end automatic checks for the process lifetime.

### On `updater-events.ts:200`

I did **not** change it. That `if (!isLocalBuildCheck())` correctly skips `recordCompletedUpdateCheck()` for a local check — a local build check is not evidence the release channel was checked, and recording it would suppress the next release check for 24h. The severed chain traces to the early return in `runBackgroundUpdateCheck`, not to this line, and it is fixed there.

## Tests

Fail-first, verified red on `origin/main` (70c81c4b32) with only the test file applied:

| Test | Result on main |
|---|---|
| `keeps the automatic check chain alive across a local build session` | **RED** — `expected "vi.fn()" to be called with [ 'updater:status', {state:'not-available'} ] / Number of calls: 0` |
| `restores release checks when an offered local build is dismissed` | **RED** |
| `keeps the local feed in force when a dismiss lands during a local build download` | **RED** |
| `leaves a dismissed release update on the release source` | **RED** |

The first is the behavioral proof: a local build reaches `available`, the scheduled release check fires and defers, the local download then **fails** (an existing restore path — no new API involved), and the next automatic tick must actually run a release check. On main it never does, because the chain died at the deferral.

The two regression guards cover the trap: while a local download is genuinely pending, the local feed URL, `allowDowngrade` and `disableDifferentialDownload` must all still be in force; and a normal release-channel dismissal must leave the offer untouched.

> **Note on assertion style:** the chain test asserts through its own `webContents.send` mock rather than the shared `autoUpdaterMock.checkForUpdates` counter. The shared counter made it pass in a full-file run while failing in isolation — sibling tests' real timers call into the shared mock. A status only reaches this window when *this* module instance owns the check attempt, so the send-based assertion cannot be faked by another test. Verified red in isolation and in the full file, green in both after the fix.

No existing updater test was weakened.

## Verification

- `vitest src/main/updater.test.ts` — 89 passed
- All other updater + local-build suites — 12 files, 96 passed
- `UpdateCard.test.ts` + `UpdateCard.error-card.test.tsx` — 46 passed
- `pnpm typecheck` (after clearing `tsbuildinfo`) — clean
- `pnpm lint` — clean, including max-lines ratchet
- `pnpm check:code-quality:changed` — 0 new findings across 9 files

Cross-platform: the trigger is macOS-gated (`checkForLocalBuildFromMenu` rejects other platforms), but nothing added here is platform-conditional — the dismiss hook and timer re-arm behave identically on Windows and Linux, where `activeUpdateSource` is always `'release'` and the hook is a no-op.
