### PR TITLE
fix(ai-vault): resume a bridged Codex session under the selected account's home

### DIFF
--- a/mobile/src/agent-history/MobileAgentSessionHistoryPanel.tsx
+++ b/mobile/src/agent-history/MobileAgentSessionHistoryPanel.tsx
@@ -10,15 +10,17 @@ import type { RpcClient } from '../transport/rpc-client'
 import { getWorktreeLabel } from '../session/worktree-label'
 import {
   buildMobileAiVaultResumeLaunch,
-  prepareMobileAiVaultSessionResume,
   createMobileAiVaultResumeMutationRegistry,
   readMobileRuntimeHostPlatform,
   readMobileRuntimeTerminalWindowsShell,
   resolveMobileAiVaultResumePlatform,
   resumeAiVaultSessionInTerminal,
-  RESUME_RPC_TIMEOUT_MS,
   type MobileAiVaultResumeSettings
 } from '../session/ai-vault-resume-launch'
+import {
+  prepareMobileAiVaultSessionResume,
+  RESUME_RPC_TIMEOUT_MS
+} from '../session/ai-vault-resume-preparation'
 import { triggerError, triggerSuccess } from '../platform/haptics'
 import type { AiVaultScope, AiVaultSession } from '../../../src/shared/ai-vault-types'
 import type { Worktree } from '../worktree/workspace-list-types'

--- a/mobile/src/session/ai-vault-resume-launch.test.ts
+++ b/mobile/src/session/ai-vault-resume-launch.test.ts
@@ -8,9 +8,9 @@ import {
   readMobileRuntimeHostPlatform,
   readMobileRuntimeTerminalWindowsShell,
   resolveMobileAiVaultResumePlatform,
-  resumeAiVaultSessionInTerminal,
-  RESUME_RPC_TIMEOUT_MS
+  resumeAiVaultSessionInTerminal
 } from './ai-vault-resume-launch'
+import { RESUME_RPC_TIMEOUT_MS } from './ai-vault-resume-preparation'
 
 function session(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
   return {

--- a/mobile/src/session/ai-vault-resume-launch.ts
+++ b/mobile/src/session/ai-vault-resume-launch.ts
@@ -4,10 +4,7 @@ import {
   buildAiVaultResumeShellCommand,
   realHomeCodexResumeEnvDeletion
 } from '../../../src/shared/ai-vault-types'
-import {
-  isAiVaultPrepareSessionResumeUnavailableError,
-  isLegacySharedCodexHome
-} from '../../../src/shared/ai-vault-resume-preparation'
+import { RESUME_RPC_TIMEOUT_MS } from './ai-vault-resume-preparation'
 import { isResumableTuiAgent } from '../../../src/shared/agent-session-resume'
 import type { SleepingAgentLaunchConfig } from '../../../src/shared/agent-session-resume'
 import { buildAgentResumeStartupPlan } from '../../../src/shared/tui-agent-startup'
@@ -165,43 +162,6 @@ function normalizeMobileAiVaultResumeCommandOverrides(
     }
   }
   return normalized
-}
-
-// Why: without an explicit timeout, a socket drop mid-resume parks the request
-// on the reconnect waiter for the full reconnect budget, pinning the spinner.
-export const RESUME_RPC_TIMEOUT_MS = 30_000
-
-export async function prepareMobileAiVaultSessionResume(
-  client: Pick<RpcClient, 'sendRequest'>,
-  session: AiVaultSession
-): Promise<AiVaultSession> {
-  if (session.agent !== 'codex' || !isLegacySharedCodexHome(session.codexHome)) {
-    return session
-  }
-  const response = await client.sendRequest(
-    'aiVault.prepareSessionResume',
-    {
-      agent: session.agent,
-      filePath: session.filePath,
-      codexHome: session.codexHome,
-      executionHostId: session.executionHostId
-    },
-    { timeoutMs: RESUME_RPC_TIMEOUT_MS }
-  )
-  if (!response.ok) {
-    if (isAiVaultPrepareSessionResumeUnavailableError(response.error)) {
-      // Why: older hosts cannot prepare, but their shared home still supports the legacy resume path.
-      return session
-    }
-    throw new Error(
-      response.error?.message || 'Could not prepare this legacy Codex session. Retry resume.'
-    )
-  }
-  const result = response.result as { useRealCodexHome?: unknown } | null
-  if (result?.useRealCodexHome !== true) {
-    return session
-  }
-  return { ...session, codexHome: null }
 }
 
 export async function resumeAiVaultSessionInTerminal(

--- a/mobile/src/session/ai-vault-resume-preparation.test.ts
+++ b/mobile/src/session/ai-vault-resume-preparation.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AiVaultSession } from '../../../src/shared/ai-vault-types'
 import {
   buildMobileAiVaultResumeLaunch,
-  prepareMobileAiVaultSessionResume,
-  resumeAiVaultSessionInTerminal,
-  RESUME_RPC_TIMEOUT_MS
+  resumeAiVaultSessionInTerminal
 } from './ai-vault-resume-launch'
+import {
+  prepareMobileAiVaultSessionResume,
+  RESUME_RPC_TIMEOUT_MS
+} from './ai-vault-resume-preparation'
 
 const LEGACY_CODEX_HOME = '/Users/ada/Library/Application Support/orca/codex-runtime-home/home'
+const PER_ACCOUNT_HOME = '/Users/ada/Library/Application Support/orca/codex-accounts/a/home'
 
 function legacySession(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
   return {
@@ -121,15 +124,61 @@ describe('prepareMobileAiVaultSessionResume', () => {
     { agent: 'codex' as const, codexHome: '/Users/ada/.config/codex' },
     {
       agent: 'codex' as const,
-      codexHome: '/Users/ada/Library/Application Support/orca/codex-accounts/a/home'
+      codexHome: PER_ACCOUNT_HOME,
+      executionHostId: 'ssh:server-1' as AiVaultSession['executionHostId']
     },
     { agent: 'codex' as const, codexHome: '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex' }
-  ])('does not prepare non-legacy session $agent at $codexHome', async (overrides) => {
+  ])('does not prepare unrepinnable session $agent at $codexHome', async (overrides) => {
     const current = legacySession(overrides)
     const sendRequest = vi.fn()
 
     await expect(prepareMobileAiVaultSessionResume({ sendRequest }, current)).resolves.toBe(current)
     expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('repins a per-account session to the home the host substitutes', async () => {
+    const substituteHome = '/Users/ada/Library/Application Support/orca/codex-accounts/b/home'
+    const current = legacySession({ codexHome: PER_ACCOUNT_HOME })
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { useRealCodexHome: false, substituteCodexHome: substituteHome }
+    })
+
+    const prepared = await prepareMobileAiVaultSessionResume({ sendRequest }, current)
+    const launch = buildMobileAiVaultResumeLaunch({ session: prepared, hostPlatform: 'darwin' })
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'aiVault.prepareSessionResume',
+      {
+        agent: 'codex',
+        filePath: current.filePath,
+        codexHome: PER_ACCOUNT_HOME,
+        executionHostId: 'local'
+      },
+      { timeoutMs: RESUME_RPC_TIMEOUT_MS }
+    )
+    expect(prepared.codexHome).toBe(substituteHome)
+    expect(launch.command).toContain(`CODEX_HOME='${substituteHome}'`)
+  })
+
+  it('keeps a per-account session home when an older host sends no repin', async () => {
+    const current = legacySession({ codexHome: PER_ACCOUNT_HOME })
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { useRealCodexHome: false }
+    })
+
+    await expect(prepareMobileAiVaultSessionResume({ sendRequest }, current)).resolves.toBe(current)
+  })
+
+  it('keeps a per-account session usable when the host cannot prepare at all', async () => {
+    const current = legacySession({ codexHome: PER_ACCOUNT_HOME })
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: false,
+      error: { code: 'method_not_found', message: 'Unknown method' }
+    })
+
+    await expect(prepareMobileAiVaultSessionResume({ sendRequest }, current)).resolves.toBe(current)
   })
 
   it.each([

--- a/mobile/src/session/ai-vault-resume-preparation.ts
+++ b/mobile/src/session/ai-vault-resume-preparation.ts
@@ -1,0 +1,60 @@
+import type { AiVaultSession } from '../../../src/shared/ai-vault-types'
+import {
+  isAiVaultPrepareSessionResumeUnavailableError,
+  isLegacySharedCodexHome,
+  isPerAccountManagedCodexHome
+} from '../../../src/shared/ai-vault-resume-preparation'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../src/shared/execution-host'
+import type { RpcClient } from '../transport/rpc-client'
+
+// Why: without an explicit timeout, a socket drop mid-resume parks the request
+// on the reconnect waiter for the full reconnect budget, pinning the spinner.
+export const RESUME_RPC_TIMEOUT_MS = 30_000
+
+export async function prepareMobileAiVaultSessionResume(
+  client: Pick<RpcClient, 'sendRequest'>,
+  session: AiVaultSession
+): Promise<AiVaultSession> {
+  // Why: per-account repinning runs on the serving host, whose account
+  // selection only applies to that host's own ("local") sessions.
+  const needsAccountRepin =
+    isPerAccountManagedCodexHome(session.codexHome) &&
+    (!session.executionHostId || session.executionHostId === LOCAL_EXECUTION_HOST_ID)
+  if (
+    session.agent !== 'codex' ||
+    (!isLegacySharedCodexHome(session.codexHome) && !needsAccountRepin)
+  ) {
+    return session
+  }
+  const response = await client.sendRequest(
+    'aiVault.prepareSessionResume',
+    {
+      agent: session.agent,
+      filePath: session.filePath,
+      codexHome: session.codexHome,
+      executionHostId: session.executionHostId
+    },
+    { timeoutMs: RESUME_RPC_TIMEOUT_MS }
+  )
+  if (!response.ok) {
+    if (isAiVaultPrepareSessionResumeUnavailableError(response.error)) {
+      // Why: older hosts cannot prepare, but their shared home still supports the legacy resume path.
+      return session
+    }
+    throw new Error(
+      response.error?.message || 'Could not prepare this legacy Codex session. Retry resume.'
+    )
+  }
+  const result = response.result as {
+    useRealCodexHome?: unknown
+    substituteCodexHome?: unknown
+  } | null
+  if (result?.useRealCodexHome === true) {
+    return { ...session, codexHome: null }
+  }
+  // Why: older hosts never send a repin home, so absence keeps the session's own home.
+  if (typeof result?.substituteCodexHome === 'string' && result.substituteCodexHome) {
+    return { ...session, codexHome: result.substituteCodexHome }
+  }
+  return session
+}

--- a/src/main/ai-vault/runtime-session-scanner.test.ts
+++ b/src/main/ai-vault/runtime-session-scanner.test.ts
@@ -135,6 +135,28 @@ describe('runtime AI Vault session scanner', () => {
     )
   })
 
+  it('keeps a repinned account home instead of stripping it', async () => {
+    mocks.callRuntimeEnvironment.mockResolvedValueOnce({
+      ok: true,
+      result: {
+        useRealCodexHome: false,
+        substituteCodexHome: '/data/orca/codex-accounts/account-2/home'
+      }
+    })
+
+    await expect(
+      prepareRuntimeAiVaultSessionResume('/user-data', 'env-1', {
+        agent: 'codex',
+        filePath: '/managed/sessions/2026/07/20/rollout-a.jsonl',
+        codexHome: '/managed',
+        executionHostId: 'runtime:env-1'
+      })
+    ).resolves.toEqual({
+      useRealCodexHome: false,
+      substituteCodexHome: '/data/orca/codex-accounts/account-2/home'
+    })
+  })
+
   it('fails retryably when runtime preparation returns an invalid result', async () => {
     mocks.callRuntimeEnvironment.mockResolvedValueOnce({ ok: true, result: {} })
 

--- a/src/main/ai-vault/runtime-session-scanner.ts
+++ b/src/main/ai-vault/runtime-session-scanner.ts
@@ -105,7 +105,12 @@ const aiVaultListResultSchema = z.object({
   scannedAt: z.string()
 })
 
-const aiVaultPrepareSessionResumeResultSchema = z.object({ useRealCodexHome: z.boolean() })
+// Why: zod strips unknown keys, so the repin home must be declared or the
+// parent would silently drop it and resume under the wrong account's home.
+const aiVaultPrepareSessionResumeResultSchema = z.object({
+  useRealCodexHome: z.boolean(),
+  substituteCodexHome: z.string().optional()
+})
 
 export function getSavedRuntimeAiVaultHostInfos(
   userDataPath: string

--- a/src/main/codex/codex-legacy-session-resume.test.ts
+++ b/src/main/codex/codex-legacy-session-resume.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   existsSync,
+  linkSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -9,7 +10,11 @@ import {
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { basename, join } from 'node:path'
+import { basename, dirname, join } from 'node:path'
+import {
+  codexRolloutHardlinkIdentity,
+  dedupeCodexRolloutFileAliases
+} from '../ai-vault/codex-session-root-dedup'
 import { prepareLegacySharedCodexSessionResume } from './codex-legacy-session-resume'
 
 describe('prepareLegacySharedCodexSessionResume', () => {
@@ -117,6 +122,15 @@ describe('prepareLegacySharedCodexSessionResume', () => {
     }
   )
 
+  it('still materializes a legacy resume when an account selection exists', async () => {
+    const result = await prepareLegacySharedCodexSessionResume(legacyArgs(), {
+      ...options(),
+      getSelectedHostAccountCodexHomePath: () => join(root, 'codex-accounts', 'account-1', 'home')
+    })
+
+    expect(result).toEqual({ useRealCodexHome: true })
+  })
+
   function prepare() {
     return prepareLegacySharedCodexSessionResume(legacyArgs(), options())
   }
@@ -142,6 +156,174 @@ describe('prepareLegacySharedCodexSessionResume', () => {
     return join(systemHome, 'sessions', '2026', '07', '20', basename(rolloutPath))
   }
 })
+
+// Why: the session bridge hardlinks each rollout into every per-account home
+// and vault dedup keeps the lexicographically-smallest alias, so a session
+// recorded by the selected account can surface under a peer account's home.
+describe('per-account resume repin', () => {
+  let root: string
+  // Deliberately ordered so the SELECTED account loses the path tie-break.
+  let peerHome: string
+  let selectedHome: string
+  let recordedRolloutPath: string
+  let bridgedRolloutPath: string
+
+  const rolloutRelativePath = join(
+    'sessions',
+    '2026',
+    '07',
+    '20',
+    'rollout-2026-07-20T10-00-00-abcdef00-1234-4321-9999-cafecafecafe.jsonl'
+  )
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-codex-account-repin-'))
+    peerHome = join(root, 'codex-accounts', '11111111-aaaa-4aaa-8aaa-111111111111', 'home')
+    selectedHome = join(root, 'codex-accounts', '99999999-bbbb-4bbb-8bbb-999999999999', 'home')
+    recordedRolloutPath = join(selectedHome, rolloutRelativePath)
+    bridgedRolloutPath = join(peerHome, rolloutRelativePath)
+    mkdirSync(dirname(recordedRolloutPath), { recursive: true })
+    writeFileSync(recordedRolloutPath, '{"type":"session_meta"}\n', 'utf-8')
+    mkdirSync(dirname(bridgedRolloutPath), { recursive: true })
+    linkSync(recordedRolloutPath, bridgedRolloutPath)
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it.each([['recorded rollout first'], ['bridged alias first']])(
+    'repins the surviving vault row to the selected account, discovered %s',
+    async (order) => {
+      const recorded = rolloutCandidate(recordedRolloutPath, selectedHome)
+      const bridged = rolloutCandidate(bridgedRolloutPath, peerHome)
+      const survivors = dedupeCodexRolloutFileAliases(
+        order === 'recorded rollout first' ? [recorded, bridged] : [bridged, recorded],
+        rolloutCandidateAccessors
+      )
+
+      // The dedup pick is order-independent: the peer's alias wins the tie-break.
+      expect(survivors).toEqual([bridged])
+
+      const result = await prepareLegacySharedCodexSessionResume(
+        {
+          agent: 'codex',
+          filePath: bridged.filePath,
+          codexHome: peerHome,
+          executionHostId: 'local'
+        },
+        repinOptions()
+      )
+
+      expect(result).toEqual({ useRealCodexHome: false, substituteCodexHome: selectedHome })
+    }
+  )
+
+  it('keeps the home of a row that already names the selected account', async () => {
+    const result = await prepareLegacySharedCodexSessionResume(
+      {
+        agent: 'codex',
+        filePath: recordedRolloutPath,
+        codexHome: selectedHome,
+        executionHostId: 'local'
+      },
+      repinOptions()
+    )
+
+    expect(result).toEqual({ useRealCodexHome: false })
+  })
+
+  it('declines while the system default is selected', async () => {
+    const result = await prepareLegacySharedCodexSessionResume(
+      {
+        agent: 'codex',
+        filePath: bridgedRolloutPath,
+        codexHome: peerHome,
+        executionHostId: 'local'
+      },
+      { ...repinOptions(), getSelectedHostAccountCodexHomePath: () => null }
+    )
+
+    expect(result).toEqual({ useRealCodexHome: false })
+  })
+
+  it('declines while the bridge has not yet linked the rollout into the selected home', async () => {
+    const unbridgedSelectedHome = join(
+      root,
+      'codex-accounts',
+      'ffffffff-cccc-4ccc-8ccc-ffffffffffff',
+      'home'
+    )
+    mkdirSync(unbridgedSelectedHome, { recursive: true })
+
+    const result = await prepareLegacySharedCodexSessionResume(
+      {
+        agent: 'codex',
+        filePath: bridgedRolloutPath,
+        codexHome: peerHome,
+        executionHostId: 'local'
+      },
+      { ...repinOptions(), getSelectedHostAccountCodexHomePath: () => unbridgedSelectedHome }
+    )
+
+    expect(result).toEqual({ useRealCodexHome: false })
+  })
+
+  it('declines a session owned by another host', async () => {
+    const result = await prepareLegacySharedCodexSessionResume(
+      {
+        agent: 'codex',
+        filePath: bridgedRolloutPath,
+        codexHome: peerHome,
+        executionHostId: 'ssh:server-1' as 'local'
+      },
+      repinOptions()
+    )
+
+    expect(result).toEqual({ useRealCodexHome: false })
+  })
+
+  it('declines a transcript outside the dated rollout layout', async () => {
+    const straySessionPath = join(peerHome, 'sessions', 'stray.jsonl')
+    writeFileSync(straySessionPath, '{"type":"session_meta"}\n', 'utf-8')
+
+    const result = await prepareLegacySharedCodexSessionResume(
+      {
+        agent: 'codex',
+        filePath: straySessionPath,
+        codexHome: peerHome,
+        executionHostId: 'local'
+      },
+      repinOptions()
+    )
+
+    expect(result).toEqual({ useRealCodexHome: false })
+  })
+
+  function repinOptions() {
+    return {
+      isHostSystemDefaultRealHome: () => false,
+      getSelectedHostAccountCodexHomePath: () => selectedHome
+    }
+  }
+
+  function rolloutCandidate(filePath: string, codexHome: string) {
+    const stat = statSync(filePath)
+    return {
+      filePath,
+      codexHome,
+      file: { dev: stat.dev, ino: stat.ino, nlink: stat.nlink }
+    }
+  }
+})
+
+const rolloutCandidateAccessors = {
+  isCodex: () => true,
+  getFilePath: (candidate: { filePath: string }) => candidate.filePath,
+  getCodexHome: (candidate: { codexHome: string }) => candidate.codexHome,
+  getHardlinkIdentity: (candidate: { file: { dev: number; ino: number; nlink: number } }) =>
+    codexRolloutHardlinkIdentity(candidate.file)
+}
 
 function rootPlaceholder(): string {
   return '__ROOT__'

--- a/src/main/codex/codex-legacy-session-resume.ts
+++ b/src/main/codex/codex-legacy-session-resume.ts
@@ -6,6 +6,7 @@ import type {
   AiVaultPrepareSessionResumeArgs,
   AiVaultPrepareSessionResumeResult
 } from '../../shared/ai-vault-resume-preparation'
+import { isPerAccountManagedCodexHome } from '../../shared/ai-vault-resume-preparation'
 import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import {
@@ -27,10 +28,15 @@ export async function prepareLegacySharedCodexSessionResume(
   args: AiVaultPrepareSessionResumeArgs,
   options: {
     isHostSystemDefaultRealHome: () => boolean
+    getSelectedHostAccountCodexHomePath?: () => string | null
     legacyCodexHomePath?: string
     systemCodexHomePath?: string
   }
 ): Promise<AiVaultPrepareSessionResumeResult> {
+  const substituteCodexHome = await resolveSelectedAccountCodexHomeForResume(args, options)
+  if (substituteCodexHome) {
+    return { useRealCodexHome: false, substituteCodexHome }
+  }
   const paths = resolveCodexSessionBackfillPaths(options.systemCodexHomePath)
   const legacyCodexHomePath = options.legacyCodexHomePath ?? dirname(paths.managedSessionsRoot)
   const managedSessionsRoot = join(legacyCodexHomePath, 'sessions')
@@ -46,7 +52,7 @@ export async function prepareLegacySharedCodexSessionResume(
 
   const sourcePath = resolve(args.filePath)
   const relativePath = relative(resolve(managedSessionsRoot), sourcePath)
-  if (!isLegacyRolloutRelativePath(relativePath)) {
+  if (!isDatedRolloutRelativePath(relativePath)) {
     throw new Error(RETRYABLE_RESUME_ERROR)
   }
   const targetPath = join(paths.systemSessionsRoot, relativePath)
@@ -76,6 +82,47 @@ export async function prepareLegacySharedCodexSessionResume(
     throw new Error(RETRYABLE_RESUME_ERROR, { cause: error })
   }
   return { useRealCodexHome: true }
+}
+
+/**
+ * Repins a per-account resume to the selected account's home, or null to keep
+ * the session's own home.
+ *
+ * Why: the session bridge hardlinks each rollout into every per-account home,
+ * and vault dedup keeps the lexicographically-smallest alias — which names an
+ * arbitrary account. When the selected account's home holds the same rollout
+ * at the same sessions-relative path, resume must run under that account's
+ * credentials. Every uncertain branch (no selection, unbridged rollout, odd
+ * layout) declines, so resume degrades to today's behavior instead of failing.
+ */
+async function resolveSelectedAccountCodexHomeForResume(
+  args: AiVaultPrepareSessionResumeArgs,
+  options: { getSelectedHostAccountCodexHomePath?: () => string | null }
+): Promise<string | null> {
+  if (
+    args.agent !== 'codex' ||
+    args.executionHostId !== LOCAL_EXECUTION_HOST_ID ||
+    !args.codexHome ||
+    !isPerAccountManagedCodexHome(args.codexHome)
+  ) {
+    return null
+  }
+  const selectedCodexHome = options.getSelectedHostAccountCodexHomePath?.() ?? null
+  if (!selectedCodexHome || sameRuntimePath(selectedCodexHome, args.codexHome)) {
+    return null
+  }
+  const relativePath = relative(resolve(join(args.codexHome, 'sessions')), resolve(args.filePath))
+  if (!isDatedRolloutRelativePath(relativePath)) {
+    return null
+  }
+  const candidatePath = join(selectedCodexHome, 'sessions', relativePath)
+  try {
+    const candidateStat = await lstat(candidatePath)
+    // Why: the bridge is async, so an unbridged rollout is a real state — decline rather than pin a home codex cannot resume from.
+    return candidateStat.isFile() && !candidateStat.isSymbolicLink() ? selectedCodexHome : null
+  } catch {
+    return null
+  }
 }
 
 async function materializeLegacyRollout(
@@ -152,7 +199,7 @@ async function fileDigest(filePath: string): Promise<string> {
   return hash.digest('hex')
 }
 
-function isLegacyRolloutRelativePath(relativePath: string): boolean {
+function isDatedRolloutRelativePath(relativePath: string): boolean {
   if (!relativePath || relativePath.startsWith('..') || resolve(relativePath) === relativePath) {
     return false
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1200,6 +1200,8 @@ function openMainWindow(): BrowserWindow {
         prepareLegacySharedCodexSessionResume(args, {
           isHostSystemDefaultRealHome: () =>
             codexRuntimeHome?.isHostSystemDefaultRealHome() === true,
+          getSelectedHostAccountCodexHomePath: () =>
+            codexRuntimeHome?.getSelectedHostAccountCodexHomePath() ?? null,
           systemCodexHomePath: resolveHostCodexSessionSourceHome(store!.getSettings())
         }),
       onBeforeRelaunch: async () => {
@@ -2178,6 +2180,8 @@ void app.whenReady().then(async () => {
     prepareAiVaultSessionResume: (args) =>
       prepareLegacySharedCodexSessionResume(args, {
         isHostSystemDefaultRealHome: () => codexRuntimeHome?.isHostSystemDefaultRealHome() === true,
+        getSelectedHostAccountCodexHomePath: () =>
+          codexRuntimeHome?.getSelectedHostAccountCodexHomePath() ?? null,
         systemCodexHomePath: resolveHostCodexSessionSourceHome(store!.getSettings())
       }),
     buildAgentHookPtyEnv: () =>

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -104,7 +104,9 @@ export function VaultSessionRow({
         sessionFilePath: session.filePath,
         sessionExecutionHostId: session.executionHostId,
         codexHome: session.codexHome,
-        ...(session.cwd ? { sessionCwd: session.cwd } : {}),
+        // Why: always sent (null when absent) so drop targets can tell "no cwd"
+        // from "payload predates the repin field".
+        sessionCwd: session.cwd ?? null,
         ...(resumeStartup.env ? { env: resumeStartup.env } : {}),
         ...(resumeStartup.envToDelete ? { envToDelete: resumeStartup.envToDelete } : {}),
         ...(resumeStartup.launchConfig ? { launchConfig: resumeStartup.launchConfig } : {}),

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -104,6 +104,7 @@ export function VaultSessionRow({
         sessionFilePath: session.filePath,
         sessionExecutionHostId: session.executionHostId,
         codexHome: session.codexHome,
+        ...(session.cwd ? { sessionCwd: session.cwd } : {}),
         ...(resumeStartup.env ? { env: resumeStartup.env } : {}),
         ...(resumeStartup.envToDelete ? { envToDelete: resumeStartup.envToDelete } : {}),
         ...(resumeStartup.launchConfig ? { launchConfig: resumeStartup.launchConfig } : {}),

--- a/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
@@ -10,15 +10,21 @@ import {
   AI_VAULT_SESSION_DRAG_START_EVENT,
   clearAiVaultSessionDragData,
   hasAiVaultSessionDragData,
-  readAiVaultSessionDragData
+  readAiVaultSessionDragData,
+  type AiVaultSessionDragPayload
 } from '@/lib/ai-vault-session-drag'
-import { getAiVaultAgentProviderSession } from '@/lib/ai-vault-resume-command'
+import {
+  buildAiVaultResumeStartupForWorktree,
+  getAiVaultAgentProviderSession,
+  type AiVaultResumeStartup
+} from '@/lib/ai-vault-resume-command'
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
+import { aiVaultSessionNeedsResumePreparation } from '@/lib/ai-vault-session-resume-preparation'
 import { useAppStore } from '@/store'
 import { resolveDropZone } from './tab-drop-zone'
 import type { TabDropZone } from './useTabDragSplit'
 import { translate } from '@/i18n/i18n'
-import { isLegacySharedCodexHome } from '../../../../shared/ai-vault-resume-preparation'
+import type { AiVaultPrepareSessionResumeResult } from '../../../../shared/ai-vault-resume-preparation'
 
 type PaneDropTarget = {
   groupId: string
@@ -48,6 +54,30 @@ function getZoneOverlayStyle(rect: DOMRect, layerRect: DOMRect, zone: TabDropZon
 
 function containsPoint(rect: DOMRect, x: number, y: number): boolean {
   return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
+}
+
+function buildRepinnedDropStartup(
+  payload: AiVaultSessionDragPayload,
+  substituteCodexHome: string,
+  worktreeId: string
+): AiVaultResumeStartup | null {
+  if (!payload.sessionCwd || !payload.sessionFilePath) {
+    return null
+  }
+  const state = useAppStore.getState()
+  return buildAiVaultResumeStartupForWorktree({
+    state,
+    worktreeId,
+    session: {
+      agent: payload.agent,
+      sessionId: payload.sessionId,
+      cwd: payload.sessionCwd,
+      codexHome: substituteCodexHome,
+      executionHostId: payload.sessionExecutionHostId,
+      filePath: payload.sessionFilePath
+    },
+    commandOverride: state.settings?.agentCmdOverrides?.[payload.agent]
+  })
 }
 
 function resolvePaneDropTarget(
@@ -210,21 +240,32 @@ export default function AiVaultSessionDropLayer({
         )
       }
       const preparation =
-        payload.agent === 'codex' &&
-        isLegacySharedCodexHome(payload.codexHome ?? null) &&
         payload.sessionFilePath &&
         payload.sessionExecutionHostId &&
-        payload.codexHome !== undefined
+        payload.codexHome !== undefined &&
+        aiVaultSessionNeedsResumePreparation({
+          agent: payload.agent,
+          codexHome: payload.codexHome,
+          executionHostId: payload.sessionExecutionHostId
+        })
           ? window.api.aiVault.prepareSessionResume({
               agent: payload.agent,
               filePath: payload.sessionFilePath,
               executionHostId: payload.sessionExecutionHostId,
               codexHome: payload.codexHome
             })
-          : Promise.resolve({ useRealCodexHome: false })
+          : Promise.resolve<AiVaultPrepareSessionResumeResult>({ useRealCodexHome: false })
       void preparation
         .then((result) => {
-          const startup = result.useRealCodexHome ? payload.realHomeStartup : payload
+          const startup = result.useRealCodexHome
+            ? payload.realHomeStartup
+            : result.substituteCodexHome
+              ? // Why: the drag payload's command pins the recorded home, so a
+                // repin must rebuild; without a payload cwd the prebuilt
+                // command still resumes, just without the repin.
+                (buildRepinnedDropStartup(payload, result.substituteCodexHome, worktreeId) ??
+                payload)
+              : payload
           if (!startup) {
             throw new Error('Orca could not prepare this legacy Codex session. Retry resume.')
           }

--- a/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
@@ -10,13 +10,11 @@ import {
   AI_VAULT_SESSION_DRAG_START_EVENT,
   clearAiVaultSessionDragData,
   hasAiVaultSessionDragData,
-  readAiVaultSessionDragData,
-  type AiVaultSessionDragPayload
+  readAiVaultSessionDragData
 } from '@/lib/ai-vault-session-drag'
 import {
-  buildAiVaultResumeStartupForWorktree,
-  getAiVaultAgentProviderSession,
-  type AiVaultResumeStartup
+  buildAiVaultDropRepinStartup,
+  getAiVaultAgentProviderSession
 } from '@/lib/ai-vault-resume-command'
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
 import { aiVaultSessionNeedsResumePreparation } from '@/lib/ai-vault-session-resume-preparation'
@@ -54,30 +52,6 @@ function getZoneOverlayStyle(rect: DOMRect, layerRect: DOMRect, zone: TabDropZon
 
 function containsPoint(rect: DOMRect, x: number, y: number): boolean {
   return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
-}
-
-function buildRepinnedDropStartup(
-  payload: AiVaultSessionDragPayload,
-  substituteCodexHome: string,
-  worktreeId: string
-): AiVaultResumeStartup | null {
-  if (!payload.sessionCwd || !payload.sessionFilePath) {
-    return null
-  }
-  const state = useAppStore.getState()
-  return buildAiVaultResumeStartupForWorktree({
-    state,
-    worktreeId,
-    session: {
-      agent: payload.agent,
-      sessionId: payload.sessionId,
-      cwd: payload.sessionCwd,
-      codexHome: substituteCodexHome,
-      executionHostId: payload.sessionExecutionHostId,
-      filePath: payload.sessionFilePath
-    },
-    commandOverride: state.settings?.agentCmdOverrides?.[payload.agent]
-  })
 }
 
 function resolvePaneDropTarget(
@@ -260,14 +234,22 @@ export default function AiVaultSessionDropLayer({
           const startup = result.useRealCodexHome
             ? payload.realHomeStartup
             : result.substituteCodexHome
-              ? // Why: the drag payload's command pins the recorded home, so a
-                // repin must rebuild; without a payload cwd the prebuilt
-                // command still resumes, just without the repin.
-                (buildRepinnedDropStartup(payload, result.substituteCodexHome, worktreeId) ??
-                payload)
+              ? buildAiVaultDropRepinStartup({
+                  state: useAppStore.getState(),
+                  payload,
+                  substituteCodexHome: result.substituteCodexHome,
+                  worktreeId
+                })
               : payload
           if (!startup) {
-            throw new Error('Orca could not prepare this legacy Codex session. Retry resume.')
+            // Why: the host just proved the prebuilt command pins another
+            // account's home, so an unrepinnable payload (older serializer)
+            // must fail loudly rather than silently resume under it.
+            throw new Error(
+              result.substituteCodexHome
+                ? 'This session was dragged from an older Orca window, so Orca cannot retarget it to the selected Codex account. Resume it from the Session History panel instead.'
+                : 'Orca could not prepare this legacy Codex session. Retry resume.'
+            )
           }
           const providerSession = getAiVaultAgentProviderSession({
             agent: payload.agent,

--- a/src/renderer/src/lib/ai-vault-resume-command.drop-repin.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.drop-repin.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import { buildAiVaultDropRepinStartup } from './ai-vault-resume-command'
+
+vi.mock('@/lib/new-workspace', () => ({
+  CLIENT_PLATFORM: 'darwin'
+}))
+
+const RECORDED_HOME = '/tmp/orca/codex-accounts/aaaa/home'
+const SELECTED_HOME = '/tmp/orca/codex-accounts/bbbb/home'
+
+type DropRepinState = Pick<
+  AppState,
+  | 'activeRepoId'
+  | 'activeWorktreeId'
+  | 'folderWorkspaces'
+  | 'projectGroups'
+  | 'projects'
+  | 'repos'
+  | 'settings'
+  | 'worktreesByRepo'
+>
+
+function makeState(): DropRepinState {
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: 'repo-1::worktree-1',
+    folderWorkspaces: [],
+    projectGroups: [],
+    repos: [{ id: 'repo-1', path: '/Users/ada/repo' }],
+    projects: [{ id: 'repo-1', sourceRepoIds: ['repo-1'] }],
+    settings: {
+      agentDefaultArgs: { claude: '', codex: '' },
+      agentDefaultEnv: { claude: {}, codex: {} }
+    },
+    worktreesByRepo: {
+      'repo-1': [{ id: 'repo-1::worktree-1', repoId: 'repo-1', path: '/Users/ada/repo' }]
+    }
+  } as unknown as DropRepinState
+}
+
+function payload(overrides: {
+  sessionCwd?: string | null
+  sessionFilePath?: string
+}): Parameters<typeof buildAiVaultDropRepinStartup>[0]['payload'] {
+  return {
+    agent: 'codex',
+    sessionId: 'session-1',
+    sessionExecutionHostId: 'local',
+    sessionFilePath: `${RECORDED_HOME}/sessions/2026/07/20/rollout-x.jsonl`,
+    ...overrides
+  }
+}
+
+describe('buildAiVaultDropRepinStartup', () => {
+  it('repins a payload with a cwd to the substituted home', () => {
+    const startup = buildAiVaultDropRepinStartup({
+      state: makeState(),
+      payload: payload({ sessionCwd: '/Users/ada/repo' }),
+      substituteCodexHome: SELECTED_HOME,
+      worktreeId: 'repo-1::worktree-1'
+    })
+
+    expect(startup).not.toBeNull()
+    expect(startup?.command).toContain(`CODEX_HOME='${SELECTED_HOME}'`)
+    expect(startup?.command).not.toContain(RECORDED_HOME)
+    expect(startup?.command).toContain("cd '/Users/ada/repo' && ")
+  })
+
+  it('repins a payload whose session has no cwd instead of keeping the wrong-account command', () => {
+    const startup = buildAiVaultDropRepinStartup({
+      state: makeState(),
+      payload: payload({ sessionCwd: null }),
+      substituteCodexHome: SELECTED_HOME,
+      worktreeId: 'repo-1::worktree-1'
+    })
+
+    expect(startup).not.toBeNull()
+    expect(startup?.command).toContain(`CODEX_HOME='${SELECTED_HOME}'`)
+    expect(startup?.command).not.toContain(RECORDED_HOME)
+    expect(startup?.command).not.toContain('cd ')
+  })
+
+  it('declines a payload from an older serializer that never carried sessionCwd', () => {
+    const startup = buildAiVaultDropRepinStartup({
+      state: makeState(),
+      payload: payload({}),
+      substituteCodexHome: SELECTED_HOME,
+      worktreeId: 'repo-1::worktree-1'
+    })
+
+    expect(startup).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -23,6 +23,7 @@ import {
   resolveStartupShell
 } from '../../../shared/tui-agent-startup-shell'
 import type { AppState } from '@/store/types'
+import type { AiVaultSessionDragPayload } from '@/lib/ai-vault-session-drag'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
@@ -80,6 +81,43 @@ export function buildAiVaultResumeStartupForWorktree(
   args: AiVaultResumeWorktreeArgs
 ): AiVaultResumeStartup {
   return buildAiVaultResumeForWorktree(args)
+}
+
+/**
+ * Rebuilds a drag-drop resume startup under the account home the host
+ * substituted, or null when the payload cannot be repinned.
+ *
+ * Why: the drag payload's prebuilt command pins the session's recorded home,
+ * which the substitution just proved belongs to the wrong account. A null
+ * sessionCwd is a real value (session has no cwd; rebuild without a cd
+ * prefix); only an ABSENT sessionCwd — a payload from an older serializer —
+ * declines, because the original cwd is unrecoverable.
+ */
+export function buildAiVaultDropRepinStartup(args: {
+  state: AiVaultResumeWorktreeArgs['state']
+  payload: Pick<
+    AiVaultSessionDragPayload,
+    'agent' | 'sessionId' | 'sessionCwd' | 'sessionExecutionHostId' | 'sessionFilePath'
+  >
+  substituteCodexHome: string
+  worktreeId: string
+}): AiVaultResumeStartup | null {
+  if (args.payload.sessionCwd === undefined || !args.payload.sessionFilePath) {
+    return null
+  }
+  return buildAiVaultResumeStartupForWorktree({
+    state: args.state,
+    worktreeId: args.worktreeId,
+    session: {
+      agent: args.payload.agent,
+      sessionId: args.payload.sessionId,
+      cwd: args.payload.sessionCwd,
+      codexHome: args.substituteCodexHome,
+      executionHostId: args.payload.sessionExecutionHostId,
+      filePath: args.payload.sessionFilePath
+    },
+    commandOverride: args.state.settings?.agentCmdOverrides?.[args.payload.agent]
+  })
 }
 
 function buildAiVaultResumeForWorktree(args: AiVaultResumeWorktreeArgs): AiVaultResumeStartup {

--- a/src/renderer/src/lib/ai-vault-session-drag.test.ts
+++ b/src/renderer/src/lib/ai-vault-session-drag.test.ts
@@ -71,6 +71,45 @@ describe('Session History session drag data', () => {
     expect(readAiVaultSessionDragData(transfer)).toEqual(payload)
   })
 
+  it('preserves an explicit null sessionCwd across the serialized round-trip', () => {
+    const transfer = createTransfer()
+    const payload: AiVaultSessionDragPayload = {
+      agent: 'codex',
+      sessionId: 'session-3',
+      title: 'Session without a recorded cwd',
+      command: 'codex resume session-3',
+      sessionFilePath: '/tmp/orca/codex-accounts/a/home/sessions/2026/07/20/rollout-x.jsonl',
+      codexHome: '/tmp/orca/codex-accounts/a/home',
+      sessionCwd: null
+    }
+
+    writeAiVaultSessionDragData(transfer, payload)
+
+    const read = readAiVaultSessionDragData(transfer)
+    expect(read).toEqual(payload)
+    // Explicit null (no cwd) must stay distinguishable from an absent key (old serializer).
+    expect(read && 'sessionCwd' in read).toBe(true)
+  })
+
+  it('keeps sessionCwd absent when an older serializer omitted it', () => {
+    const transfer = createTransfer()
+    transfer.setData(
+      AI_VAULT_SESSION_DRAG_TYPE,
+      JSON.stringify({
+        kind: 'ai-vault-session',
+        version: 1,
+        agent: 'codex',
+        sessionId: 'session-4',
+        title: 'Old-window payload',
+        command: 'codex resume session-4'
+      })
+    )
+
+    const read = readAiVaultSessionDragData(transfer)
+    expect(read).not.toBeNull()
+    expect(read && 'sessionCwd' in read).toBe(false)
+  })
+
   it('rejects blank session file paths', () => {
     const transfer = createTransfer()
     transfer.setData(

--- a/src/renderer/src/lib/ai-vault-session-drag.test.ts
+++ b/src/renderer/src/lib/ai-vault-session-drag.test.ts
@@ -50,6 +50,7 @@ describe('Session History session drag data', () => {
       command: "cd '/repo' && claude --resume session-1",
       sessionFilePath: '/Users/ada/.claude/projects/-repo/session-1.jsonl',
       codexHome: '/Users/ada/Library/Application Support/orca/codex-runtime-home/home',
+      sessionCwd: '/repo',
       env: { ANTHROPIC_BASE_URL: 'https://claude.example.test' },
       envToDelete: ['CODEX_HOME', 'ORCA_CODEX_HOME'],
       launchConfig: {

--- a/src/renderer/src/lib/ai-vault-session-drag.ts
+++ b/src/renderer/src/lib/ai-vault-session-drag.ts
@@ -18,6 +18,9 @@ export type AiVaultSessionDragPayload = {
   sessionFilePath?: string
   sessionExecutionHostId?: ExecutionHostId
   codexHome?: string | null
+  // Why: a per-account repin at drop time rebuilds the startup, which needs the
+  // session cwd; absent (older payloads) the drop falls back to the prebuilt command.
+  sessionCwd?: string
   // Why: drag/drop resume must preserve planned env mutations/default args, not just the command.
   env?: Record<string, string>
   envToDelete?: string[]
@@ -91,6 +94,7 @@ function isSerializedPayload(value: unknown): value is SerializedAiVaultSessionD
     (payload.codexHome === undefined ||
       payload.codexHome === null ||
       isNonEmptyString(payload.codexHome)) &&
+    (payload.sessionCwd === undefined || isNonEmptyString(payload.sessionCwd)) &&
     (payload.env === undefined || isStringRecord(payload.env)) &&
     (payload.envToDelete === undefined || isEnvDeletionList(payload.envToDelete)) &&
     (payload.launchConfig === undefined || isLaunchConfig(payload.launchConfig)) &&
@@ -163,6 +167,7 @@ export function readAiVaultSessionDragData(
       sessionFilePath,
       sessionExecutionHostId,
       codexHome,
+      sessionCwd,
       env,
       envToDelete,
       launchConfig,
@@ -176,6 +181,7 @@ export function readAiVaultSessionDragData(
       ...(sessionFilePath ? { sessionFilePath } : {}),
       ...(sessionExecutionHostId ? { sessionExecutionHostId } : {}),
       ...(codexHome !== undefined ? { codexHome } : {}),
+      ...(sessionCwd ? { sessionCwd } : {}),
       ...(env ? { env } : {}),
       ...(envToDelete ? { envToDelete } : {}),
       ...(launchConfig ? { launchConfig } : {}),

--- a/src/renderer/src/lib/ai-vault-session-drag.ts
+++ b/src/renderer/src/lib/ai-vault-session-drag.ts
@@ -18,9 +18,10 @@ export type AiVaultSessionDragPayload = {
   sessionFilePath?: string
   sessionExecutionHostId?: ExecutionHostId
   codexHome?: string | null
-  // Why: a per-account repin at drop time rebuilds the startup, which needs the
-  // session cwd; absent (older payloads) the drop falls back to the prebuilt command.
-  sessionCwd?: string
+  // Why: a per-account repin at drop time rebuilds the startup from the session
+  // cwd. Explicit null means the session genuinely has no cwd (rebuild without a
+  // cd prefix); an ABSENT key means an older serializer built the payload.
+  sessionCwd?: string | null
   // Why: drag/drop resume must preserve planned env mutations/default args, not just the command.
   env?: Record<string, string>
   envToDelete?: string[]
@@ -94,7 +95,9 @@ function isSerializedPayload(value: unknown): value is SerializedAiVaultSessionD
     (payload.codexHome === undefined ||
       payload.codexHome === null ||
       isNonEmptyString(payload.codexHome)) &&
-    (payload.sessionCwd === undefined || isNonEmptyString(payload.sessionCwd)) &&
+    (payload.sessionCwd === undefined ||
+      payload.sessionCwd === null ||
+      isNonEmptyString(payload.sessionCwd)) &&
     (payload.env === undefined || isStringRecord(payload.env)) &&
     (payload.envToDelete === undefined || isEnvDeletionList(payload.envToDelete)) &&
     (payload.launchConfig === undefined || isLaunchConfig(payload.launchConfig)) &&
@@ -181,7 +184,7 @@ export function readAiVaultSessionDragData(
       ...(sessionFilePath ? { sessionFilePath } : {}),
       ...(sessionExecutionHostId ? { sessionExecutionHostId } : {}),
       ...(codexHome !== undefined ? { codexHome } : {}),
-      ...(sessionCwd ? { sessionCwd } : {}),
+      ...(sessionCwd !== undefined ? { sessionCwd } : {}),
       ...(env ? { env } : {}),
       ...(envToDelete ? { envToDelete } : {}),
       ...(launchConfig ? { launchConfig } : {}),

--- a/src/renderer/src/lib/ai-vault-session-resume-preparation.test.ts
+++ b/src/renderer/src/lib/ai-vault-session-resume-preparation.test.ts
@@ -33,17 +33,52 @@ describe('prepareAiVaultSessionForResume', () => {
     ).rejects.toThrow('Retry resume.')
   })
 
-  it.each(['/custom/codex', '/tmp/orca/codex-accounts/account-1/home'])(
-    'preserves a non-legacy home without materialization: %s',
-    async (codexHome) => {
-      const prepareSessionResume = vi.fn()
-      stubPreparation(prepareSessionResume)
-      const current = session({ codexHome })
+  it('preserves a custom home without materialization', async () => {
+    const prepareSessionResume = vi.fn()
+    stubPreparation(prepareSessionResume)
+    const current = session({ codexHome: '/custom/codex' })
 
-      await expect(prepareAiVaultSessionForResume(current)).resolves.toBe(current)
-      expect(prepareSessionResume).not.toHaveBeenCalled()
-    }
-  )
+    await expect(prepareAiVaultSessionForResume(current)).resolves.toBe(current)
+    expect(prepareSessionResume).not.toHaveBeenCalled()
+  })
+
+  it('repins a per-account session to the home the host substitutes', async () => {
+    const prepareSessionResume = vi.fn().mockResolvedValue({
+      useRealCodexHome: false,
+      substituteCodexHome: '/tmp/orca/codex-accounts/account-2/home'
+    })
+    stubPreparation(prepareSessionResume)
+    const current = session({ codexHome: '/tmp/orca/codex-accounts/account-1/home' })
+
+    const prepared = await prepareAiVaultSessionForResume(current)
+
+    expect(prepared.codexHome).toBe('/tmp/orca/codex-accounts/account-2/home')
+    expect(prepareSessionResume).toHaveBeenCalledWith({
+      agent: 'codex',
+      filePath: current.filePath,
+      codexHome: current.codexHome,
+      executionHostId: 'local'
+    })
+  })
+
+  it('keeps a per-account session unchanged when the host declines to repin', async () => {
+    stubPreparation(vi.fn().mockResolvedValue({ useRealCodexHome: false }))
+    const current = session({ codexHome: '/tmp/orca/codex-accounts/account-1/home' })
+
+    await expect(prepareAiVaultSessionForResume(current)).resolves.toBe(current)
+  })
+
+  it('does not ask a remote host to repin a per-account session', async () => {
+    const prepareSessionResume = vi.fn()
+    stubPreparation(prepareSessionResume)
+    const current = session({
+      codexHome: '/home/user/.orca/codex-accounts/account-1/home',
+      executionHostId: 'ssh:server-1' as AiVaultSession['executionHostId']
+    })
+
+    await expect(prepareAiVaultSessionForResume(current)).resolves.toBe(current)
+    expect(prepareSessionResume).not.toHaveBeenCalled()
+  })
 })
 
 function stubPreparation(prepareSessionResume: ReturnType<typeof vi.fn>): void {

--- a/src/renderer/src/lib/ai-vault-session-resume-preparation.ts
+++ b/src/renderer/src/lib/ai-vault-session-resume-preparation.ts
@@ -1,10 +1,14 @@
 import type { AiVaultSession } from '../../../shared/ai-vault-types'
-import { isLegacySharedCodexHome } from '../../../shared/ai-vault-resume-preparation'
+import {
+  isLegacySharedCodexHome,
+  isPerAccountManagedCodexHome
+} from '../../../shared/ai-vault-resume-preparation'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 
 export async function prepareAiVaultSessionForResume(
   session: AiVaultSession
 ): Promise<AiVaultSession> {
-  if (session.agent !== 'codex' || !isLegacySharedCodexHome(session.codexHome)) {
+  if (!aiVaultSessionNeedsResumePreparation(session)) {
     return session
   }
   const result = await window.api.aiVault.prepareSessionResume({
@@ -13,5 +17,28 @@ export async function prepareAiVaultSessionForResume(
     codexHome: session.codexHome,
     executionHostId: session.executionHostId
   })
-  return result.useRealCodexHome ? { ...session, codexHome: null } : session
+  if (result.useRealCodexHome) {
+    return { ...session, codexHome: null }
+  }
+  if (result.substituteCodexHome) {
+    return { ...session, codexHome: result.substituteCodexHome }
+  }
+  return session
+}
+
+export function aiVaultSessionNeedsResumePreparation(
+  session: Pick<AiVaultSession, 'agent' | 'codexHome' | 'executionHostId'>
+): boolean {
+  if (session.agent !== 'codex') {
+    return false
+  }
+  if (isLegacySharedCodexHome(session.codexHome)) {
+    return true
+  }
+  // Why: per-account repinning reads the LOCAL account selection, so only
+  // local sessions ask; remote sessions keep their recorded home untouched.
+  return (
+    isPerAccountManagedCodexHome(session.codexHome) &&
+    (!session.executionHostId || session.executionHostId === LOCAL_EXECUTION_HOST_ID)
+  )
 }

--- a/src/shared/ai-vault-resume-preparation.ts
+++ b/src/shared/ai-vault-resume-preparation.ts
@@ -7,6 +7,10 @@ export type AiVaultPrepareSessionResumeArgs = Pick<
 
 export type AiVaultPrepareSessionResumeResult = {
   useRealCodexHome: boolean
+  // Why: cross-account hardlinking lists one rollout under several per-account
+  // homes, so the owning host repins resume to the selected account's home.
+  // Absent (older hosts included) means resume keeps the session's own home.
+  substituteCodexHome?: string
 }
 
 export type AiVaultSessionResumePreparation = (
@@ -32,4 +36,13 @@ export function isLegacySharedCodexHome(codexHome: string | null): boolean {
   }
   const segments = codexHome.split(/[\\/]/).filter(Boolean)
   return segments.at(-2) === 'codex-runtime-home' && segments.at(-1) === 'home'
+}
+
+/** Matches the managed `codex-accounts/<id>/home` layout, mirroring the AI Vault scan-root shape check. */
+export function isPerAccountManagedCodexHome(codexHome: string | null): boolean {
+  if (!codexHome) {
+    return false
+  }
+  const segments = codexHome.split(/[\\/]/).filter(Boolean)
+  return segments.at(-3) === 'codex-accounts' && segments.at(-1) === 'home'
 }


### PR DESCRIPTION
## Problem

The Codex account session bridge (#10770) hardlinks every rollout into each per-account `CODEX_HOME` at the identical relative path, so the AI Vault sees the same physical rollout under several `codex-accounts/<uuid>/home` roots. Pre-parse dedup collapses those aliases by hardlink identity and — with both roots ranked equally — keeps the **lexicographically smallest path** (`codex-session-root-dedup.ts:103`). The surviving row's `codexHome` becomes an inline `CODEX_HOME='…'` prefix on the resume command, which overrides the pane's correctly-resolved env.

Net effect: with two or more managed accounts, **Resume / Copy resume command / drag-drop resume can run a session under a peer account's `auth.json` and quota**, decided by UUID sort order, silently. Nothing on the resume path corrected it — the existing preparation only covered the legacy shared home.

## Fix (resume-time repin, no dedup changes)

At resume time, the owning host substitutes the **selected** account's home when it verifiably holds the same rollout at the same sessions-relative path (`resolveSelectedAccountCodexHomeForResume` in `codex-legacy-session-resume.ts`). Selected-account-over-path-order is the same product decision `rankTrustedCodexHomesForRescan` already documents for the pane-restore path — once a rollout sits in several homes, the path no longer names an account, and the selected account is what the user asked for.

Every uncertain branch declines and resume behaves exactly as today:
- no account selected (system default), or selection equals the row's home
- rollout not yet bridged into the selected home (the bridge is async)
- transcript outside the dated rollout layout
- non-local session (`executionHostId` gate on both requester and host)
- older host (result field absent → clients no-op)

The result contract grows an **optional** `substituteCodexHome`; the runtime-RPC zod schema is extended so it is not silently stripped (zod drops unknown keys).

## Surfaces

- **Copy resume command / Resume in tab**: already awaited preparation; now apply the substitute home.
- **Drag & drop**: the drag payload's prebuilt command pins the recorded home, so the drop layer now rebuilds the startup from a new optional `sessionCwd` payload field; payloads without it (older windows) fall back to the prebuilt command.
- **Mobile**: gets the repin — the RPC executes on the serving desktop, which owns the account selection. Old desktops degrade cleanly (absent field / method-unavailable). `prepareMobileAiVaultSessionResume` moved to `mobile/src/session/ai-vault-resume-preparation.ts` (the launch file crossed the max-lines limit, which must not be bumped).
- **Out of scope, unchanged**: dedup ranking and `codexSessionRootRank`; the pane-restore `resolveVerifiedResumeHome` path; runtime-hosted and SSH sessions.

## Tests

Fail-first (verified red on origin/main `70c81c4b32`, green here): two per-account homes with controlled UUIDs, a real rollout recorded under the larger UUID, a **real hardlink** bridged into the smaller at the identical relative path, run through the **real** `dedupeCodexRolloutFileAliases` in **both discovery orders** — the dedup pick is asserted (peer alias wins), then prepare must repin to the selected home:

```
× repins the surviving vault row to the selected account, discovered recorded rollout first
× repins the surviving vault row to the selected account, discovered bridged alias first
AssertionError: expected { useRealCodexHome: false } to deeply equal { useRealCodexHome: false, …(1) }
-   "substituteCodexHome": ".../codex-accounts/99999999-…/home"
```

Regression guards: selected == row home (single-account), system-default selection, unbridged rollout, non-local host, stray transcript layout, legacy materialization with a selection present, zod strip-catcher for the runtime result, renderer local/remote gating, drag payload round-trip, and 5 mobile preparation cases.

`typecheck` (fresh, tsbuildinfo removed), `oxlint` + both code-quality configs, max-lines ratchet, reliability gates: all green. ai-vault + codex suites: 1155 passed (3 unrelated load flakes — a benchmark budget and two app-server deadline tests — pass clean at `--maxWorkers=2`, no overlap with this change). Mobile suite (own vitest config): 34 passed.