### PR TITLE
Reject legacy orchestration mail acknowledgment

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-migration-behavior.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-migration-behavior.test.ts
@@ -71,6 +71,25 @@ describe('orchestration migration behavior', () => {
     expect(db.getMessageById(message.id)?.read).toBe(0)
   })
 
+  it('rejects acknowledgment of legacy mail without effects', async () => {
+    const { db, runtime } = createRuntime()
+    const message = db.insertMessage({
+      from: 'term_worker',
+      to: 'term_coord',
+      subject: 'still working'
+    })
+    const check = ORCHESTRATION_METHODS.find((method) => method.name === 'orchestration.check')!
+
+    await expect(
+      check.handler(check.params!.parse({ terminal: 'term_coord' }), { runtime })
+    ).rejects.toMatchObject({
+      code: 'legacy_read_only',
+      data: { effectsApplied: false }
+    })
+    expect(db.getMessageById(message.id)?.read).toBe(0)
+    expect(db.getInbox(100)).toHaveLength(1)
+  })
+
   it('rejects replies to legacy mail without marking or inserting rows', async () => {
     const { db, runtime } = createRuntime()
     const message = db.insertMessage({

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -40,9 +40,12 @@ describe('orchestration RPC methods', () => {
         coordinatorHandle: 'term_coord',
         coordinatorPaneKey
       }).id
+      // Why: default direct fixtures to current-contract state; legacy behavior has dedicated tests.
       const createTask = db.createTask.bind(db)
-      // Why: legacy tests exercise the RPC behavior under test; default their direct fixture rows to the bound Run.
       db.createTask = (task) => createTask({ ...task, runId: task.runId ?? activeRunId })
+      const insertMessage = db.insertMessage.bind(db)
+      db.insertMessage = (message) =>
+        insertMessage({ ...message, runId: message.runId ?? activeRunId })
     } else {
       activeRunId = undefined
     }
@@ -1548,22 +1551,23 @@ describe('orchestration RPC methods', () => {
       expect(db.getUnreadMessages('b')).toHaveLength(1)
     })
 
-    it('keeps waiting for requested types when an unrelated heartbeat arrives', async () => {
+    it('keeps waiting for requested types when an unrelated status arrives', async () => {
       setup()
 
       const waitPromise = call('orchestration.check', {
         terminal: 'coord',
         wait: true,
         timeoutMs: 5000,
-        types: 'worker_done,escalation'
+        types: 'escalation,question'
       }) as Promise<{ count: number; messages: { type: string }[] }>
       await Promise.resolve()
 
       await call('orchestration.send', {
         from: 'worker',
         to: 'coord',
-        subject: 'alive',
-        type: 'heartbeat'
+        subject: 'still working',
+        type: 'status',
+        run: activeRunId
       })
 
       const early = await Promise.race([
@@ -1575,13 +1579,14 @@ describe('orchestration RPC methods', () => {
       await call('orchestration.send', {
         from: 'worker',
         to: 'coord',
-        subject: 'done',
-        type: 'worker_done'
+        subject: 'needs attention',
+        type: 'escalation',
+        run: activeRunId
       })
 
       const result = await waitPromise
       expect(result.count).toBe(1)
-      expect(result.messages[0].type).toBe('worker_done')
+      expect(result.messages[0].type).toBe('escalation')
     })
 
     it('does not mark existing messages read when the check starts aborted', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -856,6 +856,17 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           ? db.getAllMessagesForHandle(handle, undefined, typeFilter)
           : db.getUnreadMessages(handle, typeFilter)
 
+        if (
+          consumeUnread &&
+          messages.some((message) => message.run_id === ORCHESTRATION_LEGACY_RUN_ID)
+        ) {
+          throw new OrchestrationError(
+            'legacy_read_only',
+            'Legacy orchestration messages are inspect-only; use --peek or --all. No acknowledgment was applied.',
+            { effectsApplied: false }
+          )
+        }
+
         let visibleMessages = messages
         if (consumeUnread && messages.length > 0) {
           // Why: unread check is an authoritative read path for worker_done/heartbeat, so reconcile lifecycle messages here too.


### PR DESCRIPTION
## Summary

- reject consuming checks when unread legacy orchestration mail is present, before lifecycle reconciliation or read-state mutation
- return `legacy_read_only` with `effectsApplied: false` and direct callers to `--peek` / `--all`
- keep generic RPC fixtures in the current Run namespace so legacy behavior stays isolated in migration tests

## Scope

PR #11107 already updated the authoritative version-matched guide to preserve valid legacy assignments and filesystem work, require read-only observation to a stable handoff, and forbid concurrent replacement editors. It also made runtime/CLI legacy rows unmistakably read-only, removed generated Reply commands, rejected replies, and confirmed there is no separate renderer reply UI at this boundary. This follow-up closes the remaining implicit acknowledgment path without duplicating that work.

## Tests

- 7 focused migration/runtime/CLI/formatter/contract/guide files: 232 tests
- `pnpm run typecheck:node`
- `pnpm run typecheck:cli`
- focused `oxlint` and `oxfmt --check`
- `pnpm run verify:bundled-skill-guides`
- `pnpm run check:max-lines-ratchet`