### PR TITLE
fix: stop notification loss, credentialed cache reuse, and clipboard clobber

### DIFF
--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -161,7 +161,7 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
       // Why quarantine rather than retry: the range this catch-up abandoned stays
       // unrecovered until SOME later one succeeds, and a live seq persisting past it
       // meanwhile would make the desktop cut it forever.
-      quarantineCatchUpWatermark(session, askFrom)
+      quarantineCatchUpWatermark(session, hostId, askFrom)
       return
     }
     // Why the whole batch is ONE queue entry (#8591): awaiting per event returns to
@@ -190,7 +190,7 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
         if (drained) {
           resolveCatchUpQuarantine(session, hostId)
         } else {
-          quarantineCatchUpWatermark(session, contiguousSeq)
+          quarantineCatchUpWatermark(session, hostId, contiguousSeq)
         }
       }
     })

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -15,9 +15,12 @@ import {
 } from './local-notification-scheduling'
 import {
   adoptNotificationEpoch,
+  catchUpWatermarkSeq,
   enqueueHostDelivery,
   getHostNotificationSession,
+  quarantineCatchUpWatermark,
   releaseQueuedShowNotificationId,
+  resolveCatchUpQuarantine,
   saveWatermark,
   seedWatermarkFromStorage,
   seenKeyForEvent,
@@ -92,11 +95,41 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     // desktop for seq greater than one the user never saw.
     if (event.notificationSeq != null && event.notificationSeq > session.lastDeliveredSeq) {
       session.lastDeliveredSeq = event.notificationSeq
-      // Persisted as a pair: a seq is only trustworthy alongside the epoch it indexes.
+      // Why clamped: while a failed catch-up's range is still unrecovered, persisting
+      // the live seq would let the next catch-up ask from above the gap and the desktop
+      // would cut it. resolveCatchUpQuarantine writes the held-back value on success.
       void saveWatermark(hostId, {
-        seq: session.lastDeliveredSeq,
+        seq: catchUpWatermarkSeq(session),
         epoch: session.lastDeliveredEpoch
       })
+    }
+  }
+
+  // Claimed inline rather than via queueDelivery: the batch is already one queue
+  // entry, and re-enqueueing per item is what let a live event cut in.
+  async function deliverMissedEvent(
+    event: NotificationEvent | DismissNotificationEvent
+  ): Promise<void> {
+    const key = seenKeyForEvent(event)
+    if (key && session.seen.has(key)) {
+      return
+    }
+    if (key) {
+      session.seen.add(key)
+    }
+    if (event.type === 'notification') {
+      if (!shouldQueueShowForNotificationId(session, event.notificationId)) {
+        return
+      }
+      try {
+        await deliverLive('notification', event)
+      } finally {
+        releaseQueuedShowNotificationId(session, event.notificationId)
+      }
+      return
+    }
+    if (event.type === 'dismiss') {
+      await deliverLive('dismiss', event)
     }
   }
 
@@ -105,55 +138,59 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     if (disposed) {
       return
     }
+    // Captured before the request: everything at or below it is known delivered, so
+    // it is the floor the watermark falls back to if this catch-up never completes.
+    const askFrom = catchUpWatermarkSeq(session)
     const missed = await client
       .sendRequest('notifications.getMissedSince', {
-        lastSeenSeq: session.lastDeliveredSeq,
+        lastSeenSeq: askFrom,
         // Why: sending the epoch lets the desktop reject a watermark from a counter
         // it no longer has and return the whole retained buffer instead of nothing.
         ...(session.lastDeliveredEpoch != null ? { epoch: session.lastDeliveredEpoch } : {})
       })
       .then((response) => {
         if (!response.ok) {
-          return []
+          return null
         }
         const result = response.result as { notifications?: unknown[]; epoch?: string } | undefined
         adoptNotificationEpoch(session, hostId, result?.epoch)
         return Array.isArray(result?.notifications) ? result.notifications : []
       })
-      .catch(() => [])
+      .catch(() => null)
+    if (missed == null) {
+      // Why quarantine rather than retry: the range this catch-up abandoned stays
+      // unrecovered until SOME later one succeeds, and a live seq persisting past it
+      // meanwhile would make the desktop cut it forever.
+      quarantineCatchUpWatermark(session, askFrom)
+      return
+    }
     // Why the whole batch is ONE queue entry (#8591): awaiting per event returns to
     // the event loop between replays, so a live seq 11 slots into the chain between
     // seq 6 and 7 and persists a watermark past a notification still unshown. Why the
     // request stays OUTSIDE the queue: sendRequest waits up to 30s, and holding the
     // chain for that would stall live delivery on a slow link.
     await enqueueHostDelivery(session, async () => {
-      for (const raw of missed) {
-        // Re-checked per event: the batch can start before a teardown and still be
-        // draining after it, and a torn-down host must stop pushing.
-        if (disposed) {
-          return
-        }
-        const event = raw as NotificationEvent | DismissNotificationEvent
-        const key = seenKeyForEvent(event)
-        if (key && session.seen.has(key)) {
-          continue
-        }
-        if (key) {
-          session.seen.add(key)
-        }
-        // Claimed inline rather than via queueDelivery: the batch is already one
-        // queue entry, and re-enqueueing per item is what let a live event cut in.
-        if (event.type === 'notification') {
-          if (!shouldQueueShowForNotificationId(session, event.notificationId)) {
-            continue
+      // Advances only past events this batch settled, so a teardown or a failing show
+      // quarantines the true contiguous point instead of the range it never reached.
+      let contiguousSeq = askFrom
+      let drained = false
+      try {
+        for (const raw of missed) {
+          // Re-checked per event: the batch can start before a teardown and still be
+          // draining after it, and a torn-down host must stop pushing.
+          if (disposed) {
+            return
           }
-          try {
-            await deliverLive('notification', event)
-          } finally {
-            releaseQueuedShowNotificationId(session, event.notificationId)
-          }
-        } else if (event.type === 'dismiss') {
-          await deliverLive('dismiss', event)
+          const event = raw as NotificationEvent | DismissNotificationEvent
+          await deliverMissedEvent(event)
+          contiguousSeq = event.notificationSeq ?? contiguousSeq
+        }
+        drained = true
+      } finally {
+        if (drained) {
+          resolveCatchUpQuarantine(session, hostId)
+        } else {
+          quarantineCatchUpWatermark(session, contiguousSeq)
         }
       }
     })

--- a/mobile/src/notifications/mobile-notifications.ts
+++ b/mobile/src/notifications/mobile-notifications.ts
@@ -71,7 +71,10 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
           releaseQueuedShowNotificationId(session, event.notificationId)
         }
       }
-    })
+      // Why swallowed: the caller is an un-awaited handler, so a rejected show would
+      // surface as an unhandled rejection (a RN redbox) instead of being retried by
+      // the next catch-up — which is now possible, since `seen` is marked after the show.
+    }).catch(() => {})
   }
 
   async function deliverLive(
@@ -79,15 +82,20 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
     event: NotificationEvent | DismissNotificationEvent
   ): Promise<void> {
     adoptNotificationEpoch(session, hostId, event.notificationEpoch)
-    // Why (#8129): mark seen on the live path too, so a later replay of an already-pushed id dedups instead of double-pushing.
-    const key = seenKeyForEvent(event)
-    if (key) {
-      session.seen.add(key)
-    }
+    const epochAtDelivery = session.lastDeliveredEpoch
     if (type === 'notification') {
       await showLocalNotification(event as NotificationEvent, hostId)
     } else {
       await dismissLocalNotification(event as DismissNotificationEvent, hostId)
+    }
+    // Why after the await, exactly like the watermark below: `seen` asserts this event
+    // reached the user (#8129). Marked before, a rejected show leaves the key behind and
+    // every later replay is dropped as a duplicate — loss the quarantine cannot recover,
+    // since the first event to drain a batch lifts it past the one never shown.
+    const key = seenKeyForEvent(event)
+    // A mid-flight epoch adoption already cleared the counter lifetime this key indexes.
+    if (key && session.lastDeliveredEpoch === epochAtDelivery) {
+      session.seen.add(key)
     }
     // Why after the await (#8591): the watermark is a promise that everything up
     // to this seq has been shown. Advancing it before the local notification lands
@@ -110,12 +118,10 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
   async function deliverMissedEvent(
     event: NotificationEvent | DismissNotificationEvent
   ): Promise<void> {
+    // No pre-marking here either: deliverLive marks the key once the show lands.
     const key = seenKeyForEvent(event)
     if (key && session.seen.has(key)) {
       return
-    }
-    if (key) {
-      session.seen.add(key)
     }
     if (event.type === 'notification') {
       if (!shouldQueueShowForNotificationId(session, event.notificationId)) {
@@ -193,7 +199,10 @@ export function subscribeToDesktopNotifications(client: RpcClient, hostId: strin
           quarantineCatchUpWatermark(session, hostId, contiguousSeq)
         }
       }
-    })
+      // Why swallowed here: the `finally` above already recorded the contiguous point,
+      // and the only caller is an un-awaited 'ready' continuation — letting a failed
+      // show escape turns every one into an unhandled rejection (a RN redbox).
+    }).catch(() => {})
   }
 
   seedWatermarkFromStorage(session, hostId)

--- a/mobile/src/notifications/notification-catchup-failure-quarantine.test.ts
+++ b/mobile/src/notifications/notification-catchup-failure-quarantine.test.ts
@@ -160,7 +160,9 @@ describe('#8591 catch-up failure quarantines the watermark', () => {
     const titles = vi
       .mocked(Notifications.scheduleNotificationAsync)
       .mock.calls.map((call) => (call[0] as { content: { title: string } }).content.title)
-    expect(titles).toEqual(expect.arrayContaining(['m6', 'm7']))
+    // Exact, not arrayContaining: a duplicate here is the double-push `seen` prevents.
+    // m11/m12 are the live events that kept flowing while the gap stayed open.
+    expect(titles).toEqual(['m11', 'm12', 'm6', 'm7'])
 
     // Only now may the watermark move past the recovered range.
     expect(persistedSeq()).toBe(12)
@@ -233,6 +235,82 @@ describe('#8591 catch-up failure quarantines the watermark', () => {
     await flushAsync()
 
     expect(host2.askedFrom).toEqual([6])
+    expect(
+      vi
+        .mocked(Notifications.scheduleNotificationAsync)
+        .mock.calls.map((call) => (call[0] as { content: { title: string } }).content.title)
+    ).toEqual(['m6', 'm20', 'm7', 'm8'])
     expect(persistedSeq()).toBe(20)
+  })
+
+  it('re-shows a replay whose show threw, instead of dropping it as already seen', async () => {
+    // The quarantine only holds the RANGE. If the failing event is also marked seen,
+    // the next catch-up re-fetches it and the dedup guard drops it — the banner is
+    // never shown, and the first later event to drain the batch lifts the quarantine
+    // past it. Silent loss with the watermark looking healthy.
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 5, epoch: 'epoch-1' }))
+    const host = makeHostClient()
+    host.setOutcome({ kind: 'ok', notifications: [notification(6), notification(7)] })
+
+    let failNext = true
+    vi.mocked(Notifications.scheduleNotificationAsync).mockImplementation(async (request) => {
+      const title = (request as { content: { title: string } }).content.title
+      if (title === 'm6' && failNext) {
+        failNext = false
+        throw new Error('scheduling rejected')
+      }
+      return 'sched-1'
+    })
+
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+    expect(persistedSeq()).toBe(5)
+
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+
+    const titles = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map((call) => (call[0] as { content: { title: string } }).content.title)
+    expect(titles).toEqual(['m6', 'm6', 'm7'])
+    expect(host.askedFrom).toEqual([5, 5])
+    expect(persistedSeq()).toBe(7)
+  })
+
+  it('re-shows a live event whose show threw, instead of dropping it as already seen', async () => {
+    // The same hole without any catch-up failing: the live path marks seen before the
+    // show, so a rejected show leaves the key behind while the watermark stays put.
+    // The next catch-up dutifully re-fetches the seq and the guard eats it.
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 5, epoch: 'epoch-1' }))
+    const host = makeHostClient()
+    host.setOutcome({ kind: 'ok', notifications: [] })
+
+    let failNext = true
+    vi.mocked(Notifications.scheduleNotificationAsync).mockImplementation(async () => {
+      if (failNext) {
+        failNext = false
+        throw new Error('scheduling rejected')
+      }
+      return 'sched-1'
+    })
+
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+
+    host.onData?.({ ...notification(6), notificationEpoch: 'epoch-1' })
+    await flushAsync()
+    expect(persistedSeq()).toBe(5)
+
+    host.setOutcome({ kind: 'ok', notifications: [notification(6)] })
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+
+    const titles = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map((call) => (call[0] as { content: { title: string } }).content.title)
+    expect(titles).toEqual(['m6', 'm6'])
+    expect(persistedSeq()).toBe(6)
   })
 })

--- a/mobile/src/notifications/notification-catchup-failure-quarantine.test.ts
+++ b/mobile/src/notifications/notification-catchup-failure-quarantine.test.ts
@@ -48,11 +48,14 @@ type MissedOutcome =
   | { kind: 'reject' }
   | { kind: 'notOk' }
   | { kind: 'ok'; notifications: unknown[] }
+  // Rejects only once `settle()` is called, so a live event can land mid-request.
+  | { kind: 'heldReject' }
 
 function makeHostClient() {
   let onData: ((data: unknown) => void) | null = null
   const askedFrom: number[] = []
   let outcome: MissedOutcome = { kind: 'ok', notifications: [] }
+  let releaseHeld: (() => void) | null = null
   const client = {
     subscribe: vi.fn((_m: string, _p: unknown, cb: (data: unknown) => void) => {
       onData = cb
@@ -66,6 +69,12 @@ function makeHostClient() {
         return { ok: true, result: undefined } as never
       }
       askedFrom.push((params as { lastSeenSeq: number }).lastSeenSeq)
+      if (outcome.kind === 'heldReject') {
+        await new Promise<void>((resolve) => {
+          releaseHeld = resolve
+        })
+        throw new Error('socket closed')
+      }
       if (outcome.kind === 'reject') {
         throw new Error('socket closed')
       }
@@ -83,6 +92,9 @@ function makeHostClient() {
     askedFrom,
     setOutcome(next: MissedOutcome) {
       outcome = next
+    },
+    settleHeld() {
+      releaseHeld?.()
     }
   }
 }
@@ -155,6 +167,28 @@ describe('#8591 catch-up failure quarantines the watermark', () => {
     host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
     await flushAsync()
     expect(host.askedFrom).toEqual([5, 5, 5, 12])
+  })
+
+  it('rolls back a watermark a live event stored while the catch-up was in flight', async () => {
+    // getMissedSince waits up to 30s, so live traffic routinely persists during it.
+    // Clamping only writes made AFTER the failure leaves that higher seq on disk, and
+    // the next launch reads it back and resumes past the range this catch-up abandoned.
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 5, epoch: 'epoch-1' }))
+    const host = makeHostClient()
+    host.setOutcome({ kind: 'heldReject' })
+
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+    expect(host.askedFrom).toEqual([5])
+
+    host.onData?.({ ...notification(11), notificationEpoch: 'epoch-1' })
+    await flushAsync()
+    expect(persistedSeq()).toBe(11)
+
+    host.settleHeld()
+    await flushAsync()
+    expect(persistedSeq()).toBe(5)
   })
 
   it('quarantines at the last replayed seq when a teardown cuts the batch short', async () => {

--- a/mobile/src/notifications/notification-catchup-failure-quarantine.test.ts
+++ b/mobile/src/notifications/notification-catchup-failure-quarantine.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import * as Notifications from 'expo-notifications'
+import { subscribeToDesktopNotifications } from './mobile-notifications'
+import { resetHostNotificationSessionsForTests } from './notification-reconnect-catchup'
+import type { RpcClient } from '../transport/rpc-client'
+import { loadPushNotificationsEnabled } from '../storage/preferences'
+
+vi.mock('expo-notifications', () => ({
+  AndroidImportance: { HIGH: 'high' },
+  setNotificationChannelAsync: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  scheduleNotificationAsync: vi.fn(),
+  dismissNotificationAsync: vi.fn()
+}))
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios', Version: 18 }
+}))
+
+const WATERMARK_KEY = 'orca:mobileNotificationsWatermark:host-1'
+const storage = new Map<string, string>()
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: {
+    getItem: vi.fn(async (key: string) => storage.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      storage.set(key, value)
+    })
+  }
+}))
+
+vi.mock('../storage/preferences', () => ({
+  loadPushNotificationsEnabled: vi.fn()
+}))
+
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 10)
+  })
+}
+
+function persistedSeq(): number {
+  return (JSON.parse(storage.get(WATERMARK_KEY) ?? '{}') as { seq?: number }).seq ?? 0
+}
+
+type MissedOutcome =
+  | { kind: 'reject' }
+  | { kind: 'notOk' }
+  | { kind: 'ok'; notifications: unknown[] }
+
+function makeHostClient() {
+  let onData: ((data: unknown) => void) | null = null
+  const askedFrom: number[] = []
+  let outcome: MissedOutcome = { kind: 'ok', notifications: [] }
+  const client = {
+    subscribe: vi.fn((_m: string, _p: unknown, cb: (data: unknown) => void) => {
+      onData = cb
+      return vi.fn(() => {
+        onData = null
+      })
+    }),
+    getState: vi.fn(() => 'connected'),
+    sendRequest: vi.fn(async (method: string, params: unknown = {}) => {
+      if (method !== 'notifications.getMissedSince') {
+        return { ok: true, result: undefined } as never
+      }
+      askedFrom.push((params as { lastSeenSeq: number }).lastSeenSeq)
+      if (outcome.kind === 'reject') {
+        throw new Error('socket closed')
+      }
+      if (outcome.kind === 'notOk') {
+        return { ok: false, error: { message: 'timeout' } } as never
+      }
+      return { ok: true, result: { notifications: outcome.notifications } } as never
+    })
+  }
+  return {
+    client: client as unknown as RpcClient,
+    get onData() {
+      return onData
+    },
+    askedFrom,
+    setOutcome(next: MissedOutcome) {
+      outcome = next
+    }
+  }
+}
+
+function notification(seq: number) {
+  return {
+    type: 'notification',
+    title: `m${seq}`,
+    body: 'b',
+    notificationId: `agent:${seq}`,
+    notificationSeq: seq
+  }
+}
+
+describe('#8591 catch-up failure quarantines the watermark', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storage.clear()
+    resetHostNotificationSessionsForTests()
+    vi.mocked(loadPushNotificationsEnabled).mockResolvedValue(true)
+    vi.mocked(Notifications.getPermissionsAsync).mockResolvedValue({
+      status: 'granted',
+      canAskAgain: true
+    } as never)
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('sched-1')
+    vi.mocked(Notifications.dismissNotificationAsync).mockResolvedValue(undefined)
+  })
+
+  it('keeps asking from the abandoned range until a catch-up actually succeeds', async () => {
+    // The phone was offline while seqs 6-7 dispatched. The catch-up that would have
+    // replayed them dies (socket close / timeout / ok:false), and live traffic keeps
+    // flowing. If a live seq is allowed to persist past 6-7, the desktop cuts by
+    // `seq > lastSeenSeq` on the next catch-up and they are gone for good — and the
+    // window stays open until some catch-up succeeds, not for one round trip.
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 5, epoch: 'epoch-1' }))
+    const host = makeHostClient()
+    host.setOutcome({ kind: 'reject' })
+
+    subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+    expect(host.askedFrom).toEqual([5])
+
+    host.onData?.({ ...notification(11), notificationEpoch: 'epoch-1' })
+    await flushAsync()
+    expect(persistedSeq()).toBe(5)
+
+    // Second catch-up also fails; the gap is still open.
+    host.setOutcome({ kind: 'notOk' })
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+    host.onData?.({ ...notification(12), notificationEpoch: 'epoch-1' })
+    await flushAsync()
+    expect(host.askedFrom).toEqual([5, 5])
+    expect(persistedSeq()).toBe(5)
+
+    // Third succeeds and replays the abandoned range.
+    host.setOutcome({ kind: 'ok', notifications: [notification(6), notification(7)] })
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+
+    expect(host.askedFrom).toEqual([5, 5, 5])
+    const titles = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map((call) => (call[0] as { content: { title: string } }).content.title)
+    expect(titles).toEqual(expect.arrayContaining(['m6', 'm7']))
+
+    // Only now may the watermark move past the recovered range.
+    expect(persistedSeq()).toBe(12)
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+    expect(host.askedFrom).toEqual([5, 5, 5, 12])
+  })
+
+  it('quarantines at the last replayed seq when a teardown cuts the batch short', async () => {
+    // The batch can start before a teardown and still be draining after it, so the
+    // events past the interruption were never shown. A live seq arriving on the next
+    // connection must not persist over them.
+    storage.set(WATERMARK_KEY, JSON.stringify({ seq: 5, epoch: 'epoch-1' }))
+    const host = makeHostClient()
+    host.setOutcome({
+      kind: 'ok',
+      notifications: [notification(6), notification(7), notification(8)]
+    })
+
+    let unsubscribe: (() => void) | null = null
+    vi.mocked(Notifications.scheduleNotificationAsync).mockImplementation(async (request) => {
+      if ((request as { content: { title: string } }).content.title === 'm6') {
+        unsubscribe?.()
+      }
+      return 'sched-1'
+    })
+
+    unsubscribe = subscribeToDesktopNotifications(host.client, 'host-1')
+    host.onData?.({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1' })
+    await flushAsync()
+
+    const titles = vi
+      .mocked(Notifications.scheduleNotificationAsync)
+      .mock.calls.map((call) => (call[0] as { content: { title: string } }).content.title)
+    expect(titles).toEqual(['m6'])
+
+    // A fresh subscription on the same module-scope session takes a live seq 20 before
+    // its own catch-up, then resumes from 6 rather than from 20.
+    vi.mocked(Notifications.scheduleNotificationAsync).mockResolvedValue('sched-1')
+    const host2 = makeHostClient()
+    host2.setOutcome({ kind: 'ok', notifications: [notification(7), notification(8)] })
+    subscribeToDesktopNotifications(host2.client, 'host-1')
+    host2.onData?.({ ...notification(20), notificationEpoch: 'epoch-1' })
+    await flushAsync()
+    expect(persistedSeq()).toBe(6)
+
+    host2.onData?.({ type: 'ready', subscriptionId: 'sub-2', epoch: 'epoch-1' })
+    await flushAsync()
+
+    expect(host2.askedFrom).toEqual([6])
+    expect(persistedSeq()).toBe(20)
+  })
+})

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -135,6 +135,9 @@ export type HostNotificationSession = {
   // Counter lifetime lastDeliveredSeq belongs to; null until one is known. A
   // mismatch on reconnect means the desktop restarted and the watermark is void.
   lastDeliveredEpoch: string | null
+  // Highest seq known delivered CONTIGUOUSLY, frozen here while a catch-up is
+  // outstanding; null when none has failed. See quarantineCatchUpWatermark.
+  catchUpQuarantineSeq: number | null
   seen: ReturnType<typeof createSeenNotificationGuard>
   // False only until the host's first subscription reaches 'ready' — a true cold open.
   connectedBefore: boolean
@@ -161,6 +164,7 @@ export function getHostNotificationSession(hostId: string): HostNotificationSess
     session = {
       lastDeliveredSeq: 0,
       lastDeliveredEpoch: null,
+      catchUpQuarantineSeq: null,
       seen: createSeenNotificationGuard(),
       connectedBefore: false,
       hadStoredWatermark: false,
@@ -239,6 +243,47 @@ export function resetHostNotificationSessionsForTests(): void {
   sessionsByHost.clear()
 }
 
+/**
+ * Freeze the catch-up watermark at the last seq known delivered contiguously,
+ * after a catch-up that did not complete.
+ *
+ * Why: live delivery advances lastDeliveredSeq unconditionally, so an abandoned
+ * catch-up otherwise lets the NEXT one ask from above the range it gave up on —
+ * the desktop cuts by seq, so those notifications are never replayed and are
+ * gone. Lowest wins: an earlier failure's gap is still open.
+ */
+export function quarantineCatchUpWatermark(
+  session: HostNotificationSession,
+  contiguousSeq: number
+): void {
+  session.catchUpQuarantineSeq =
+    session.catchUpQuarantineSeq == null
+      ? contiguousSeq
+      : Math.min(session.catchUpQuarantineSeq, contiguousSeq)
+}
+
+/** Lift the quarantine once a catch-up completes, persisting what it held back. */
+export function resolveCatchUpQuarantine(session: HostNotificationSession, hostId: string): void {
+  if (session.catchUpQuarantineSeq == null) {
+    return
+  }
+  session.catchUpQuarantineSeq = null
+  void saveWatermark(hostId, {
+    seq: session.lastDeliveredSeq,
+    epoch: session.lastDeliveredEpoch
+  })
+}
+
+/**
+ * The seq a catch-up may ask from and the highest seq safe to persist — the live
+ * watermark, clamped to any open gap.
+ */
+export function catchUpWatermarkSeq(session: HostNotificationSession): number {
+  return session.catchUpQuarantineSeq == null
+    ? session.lastDeliveredSeq
+    : Math.min(session.catchUpQuarantineSeq, session.lastDeliveredSeq)
+}
+
 // Why (#8591): the desktop's seq counter restarts at 0 every launch, so a watermark
 // from a previous lifetime indexes a counter that no longer exists. Comparing it
 // against the fresh counter makes `lastSeenSeq >= seq` true for everything and
@@ -262,6 +307,8 @@ export function adoptNotificationEpoch(
   // counter re-issues those same low seqs, so a stale `seq:1` would silently drop
   // the new counter's first bell. The dedup window belongs to one counter lifetime.
   session.seen.clear()
+  // The quarantined gap indexed the dead counter; the watermark it guarded is gone too.
+  session.catchUpQuarantineSeq = null
   session.lastDeliveredEpoch = epoch
   void saveWatermark(hostId, { seq: 0, epoch })
 }

--- a/mobile/src/notifications/notification-reconnect-catchup.ts
+++ b/mobile/src/notifications/notification-reconnect-catchup.ts
@@ -254,12 +254,20 @@ export function resetHostNotificationSessionsForTests(): void {
  */
 export function quarantineCatchUpWatermark(
   session: HostNotificationSession,
+  hostId: string,
   contiguousSeq: number
 ): void {
   session.catchUpQuarantineSeq =
     session.catchUpQuarantineSeq == null
       ? contiguousSeq
       : Math.min(session.catchUpQuarantineSeq, contiguousSeq)
+  // Why re-persist: a live event delivered while the catch-up was still in flight
+  // already stored a seq above the gap. Clamping only later writes would leave that
+  // value on disk, so a restart still resumes past the abandoned range.
+  void saveWatermark(hostId, {
+    seq: catchUpWatermarkSeq(session),
+    epoch: session.lastDeliveredEpoch
+  })
 }
 
 /** Lift the quarantine once a catch-up completes, persisting what it held back. */

--- a/src/main/jira/attachment-image-cache.test.ts
+++ b/src/main/jira/attachment-image-cache.test.ts
@@ -58,4 +58,43 @@ describe('attachment image cache', () => {
     expect(await p3).toBe('data:image/png;base64,OK==')
     expect(_getAttachmentImageCacheSize()).toBe(1)
   })
+
+  it('does not repopulate after "disconnect all" when the site was cleared before', async () => {
+    // Summed epochs collide: a site at per-site 1 reads the same value before a
+    // global clear (1 + 0) and after it (0 + 1), so the mid-flight guard passes and
+    // the download re-inserts credentialed bytes the logout just purged. Reached by
+    // any prior per-site clear (401 → clearToken, or disconnect(siteId)).
+    clearAttachmentImagesForSite('site-a')
+
+    let resolveLoad: (value: { dataUrl: string; byteSize: number } | null) => void = () => {}
+    const inFlight = loadAttachmentDataUrlWithCache({
+      siteId: 'site-a',
+      attachmentId: '1',
+      load: () =>
+        new Promise<{ dataUrl: string; byteSize: number } | null>((resolve) => {
+          resolveLoad = resolve
+        })
+    })
+
+    clearAttachmentImagesForSite()
+    resolveLoad({ dataUrl: 'data:image/png;base64,SECRET==', byteSize: 4 })
+
+    // The waiter still gets its bytes; nothing survives in the cache.
+    expect(await inFlight).toBe('data:image/png;base64,SECRET==')
+    expect(getCachedAttachmentDataUrl('site-a', '1')).toBeNull()
+    expect(_getAttachmentImageCacheSize()).toBe(0)
+  })
+
+  it('still caches a load that spans no clear at all', async () => {
+    clearAttachmentImagesForSite('site-a')
+
+    const dataUrl = await loadAttachmentDataUrlWithCache({
+      siteId: 'site-a',
+      attachmentId: '1',
+      load: async () => ({ dataUrl: 'data:image/png;base64,OK==', byteSize: 2 })
+    })
+
+    expect(dataUrl).toBe('data:image/png;base64,OK==')
+    expect(getCachedAttachmentDataUrl('site-a', '1')).toBe('data:image/png;base64,OK==')
+  })
 })

--- a/src/main/jira/attachment-image-cache.test.ts
+++ b/src/main/jira/attachment-image-cache.test.ts
@@ -60,10 +60,7 @@ describe('attachment image cache', () => {
   })
 
   it('does not repopulate after "disconnect all" when the site was cleared before', async () => {
-    // Summed epochs collide: a site at per-site 1 reads the same value before a
-    // global clear (1 + 0) and after it (0 + 1), so the mid-flight guard passes and
-    // the download re-inserts credentialed bytes the logout just purged. Reached by
-    // any prior per-site clear (401 → clearToken, or disconnect(siteId)).
+    // Summed epochs read the same before a global clear (1 + 0) and after it (0 + 1).
     clearAttachmentImagesForSite('site-a')
 
     let resolveLoad: (value: { dataUrl: string; byteSize: number } | null) => void = () => {}

--- a/src/main/jira/attachment-image-cache.ts
+++ b/src/main/jira/attachment-image-cache.ts
@@ -15,15 +15,24 @@ type CacheEntry = {
 const cache = new Map<string, CacheEntry>()
 const inFlight = new Map<string, Promise<string | null>>()
 // Why: mid-flight downloads must not repopulate cache after disconnect/clearToken.
-let cacheEpoch = 0
+// Why ONE ticker for both scopes: summing independent per-site and global counters
+// makes distinct clear states collide (site at 1 before a global clear reads the
+// same 1 after it), so the guard passes and re-inserts credentialed bytes.
+let epochTicker = 0
+let globalEpoch = 0
 const siteEpoch = new Map<string, number>()
 
 function cacheKey(siteId: string, attachmentId: string): string {
   return `${siteId}::${attachmentId}`
 }
 
+function nextEpoch(): number {
+  epochTicker += 1
+  return epochTicker
+}
+
 function currentEpoch(siteId: string): number {
-  return (siteEpoch.get(siteId) ?? 0) + cacheEpoch
+  return Math.max(globalEpoch, siteEpoch.get(siteId) ?? 0)
 }
 
 function pruneExpired(now = Date.now()): void {
@@ -137,11 +146,11 @@ export function clearAttachmentImagesForSite(siteId?: string): void {
   if (siteId == null || siteId === '') {
     cache.clear()
     inFlight.clear()
-    cacheEpoch += 1
+    globalEpoch = nextEpoch()
     siteEpoch.clear()
     return
   }
-  siteEpoch.set(siteId, (siteEpoch.get(siteId) ?? 0) + 1)
+  siteEpoch.set(siteId, nextEpoch())
   const prefix = `${siteId}::`
   for (const key of cache.keys()) {
     if (key.startsWith(prefix)) {
@@ -159,7 +168,8 @@ export function clearAttachmentImagesForSite(siteId?: string): void {
 export function _resetAttachmentImageCache(): void {
   cache.clear()
   inFlight.clear()
-  cacheEpoch = 0
+  epochTicker = 0
+  globalEpoch = 0
   siteEpoch.clear()
 }
 

--- a/src/main/jira/attachment-image-cache.ts
+++ b/src/main/jira/attachment-image-cache.ts
@@ -15,9 +15,8 @@ type CacheEntry = {
 const cache = new Map<string, CacheEntry>()
 const inFlight = new Map<string, Promise<string | null>>()
 // Why: mid-flight downloads must not repopulate cache after disconnect/clearToken.
-// Why ONE ticker for both scopes: summing independent per-site and global counters
-// makes distinct clear states collide (site at 1 before a global clear reads the
-// same 1 after it), so the guard passes and re-inserts credentialed bytes.
+// Why ONE ticker across both scopes: summing separate counters lets distinct clear
+// states collide, passing the guard and re-inserting credentialed bytes.
 let epochTicker = 0
 let globalEpoch = 0
 const siteEpoch = new Map<string, number>()

--- a/src/renderer/src/web/web-clipboard-copy-fallback.test.ts
+++ b/src/renderer/src/web/web-clipboard-copy-fallback.test.ts
@@ -11,6 +11,7 @@ type FakeDocOptions = {
 function createFakeDocument(options?: FakeDocOptions) {
   const listeners: ((event: unknown) => void)[] = []
   const clipboardData = { setData: vi.fn() }
+  const stopImmediatePropagation = vi.fn()
   const createElement = vi.fn()
   const appendChild = vi.fn()
   const execCommand = vi.fn((command: string) => {
@@ -24,7 +25,8 @@ function createFakeDocument(options?: FakeDocOptions) {
       for (const listener of listeners.slice()) {
         listener({
           clipboardData: (options?.withClipboardData ?? true) ? clipboardData : undefined,
-          preventDefault: vi.fn()
+          preventDefault: vi.fn(),
+          stopImmediatePropagation
         })
       }
     }
@@ -50,7 +52,15 @@ function createFakeDocument(options?: FakeDocOptions) {
     body: { appendChild }
   } as unknown as Document
 
-  return { doc, clipboardData, createElement, appendChild, execCommand, listeners }
+  return {
+    doc,
+    clipboardData,
+    stopImmediatePropagation,
+    createElement,
+    appendChild,
+    execCommand,
+    listeners
+  }
 }
 
 describe('copyClipboardTextViaExecCommand', () => {

--- a/src/renderer/src/web/web-clipboard-copy-fallback.ts
+++ b/src/renderer/src/web/web-clipboard-copy-fallback.ts
@@ -11,17 +11,21 @@ export function copyClipboardTextViaExecCommand(text: string, doc: Document = do
       return
     }
     event.clipboardData.setData('text/plain', text)
+    // Why: xterm's own copy listener sits on terminal.element and overwrites
+    // text/plain with the terminal selection. Capture ran before it and lost;
+    // bubbling to the document runs after it, and this keeps any later
+    // document-level listener from clobbering us in turn.
+    event.stopImmediatePropagation()
     event.preventDefault()
     served = true
   }
-  // Why capture: run before any app-level copy handler so the terminal text wins.
-  doc.addEventListener('copy', onCopy, true)
+  doc.addEventListener('copy', onCopy)
   try {
     // Chromium can return true even when no handler supplied clipboard data.
     return doc.execCommand('copy') === true && served
   } catch {
     return false
   } finally {
-    doc.removeEventListener('copy', onCopy, true)
+    doc.removeEventListener('copy', onCopy)
   }
 }

--- a/src/renderer/src/web/web-clipboard-copy-fallback.ts
+++ b/src/renderer/src/web/web-clipboard-copy-fallback.ts
@@ -11,10 +11,8 @@ export function copyClipboardTextViaExecCommand(text: string, doc: Document = do
       return
     }
     event.clipboardData.setData('text/plain', text)
-    // Why: xterm's own copy listener sits on terminal.element and overwrites
-    // text/plain with the terminal selection. Capture ran before it and lost;
-    // bubbling to the document runs after it, and this keeps any later
-    // document-level listener from clobbering us in turn.
+    // Why bubble + stop: xterm's listener on terminal.element overwrites text/plain,
+    // and preventDefault alone does not stop it or any later window-level handler.
     event.stopImmediatePropagation()
     event.preventDefault()
     served = true

--- a/src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts
+++ b/src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts
@@ -74,17 +74,24 @@ describe('web copy fallback vs. the terminal selection', () => {
     expect(clipboardData.getData('text/plain')).toBe('/Users/me/repo/src/index.ts')
   })
 
-  it('wins over a document-level copy handler registered after it', () => {
+  it('wins over a copy handler that still runs after the document', () => {
+    // Bubbling reaches the document before the window, so phase order alone does not
+    // protect against a window-level listener — only stopImmediatePropagation does.
     const source = document.createElement('div')
     document.body.appendChild(source)
     const clipboardData = createClipboardDataStub()
     stubExecCommand(source, clipboardData)
-    document.addEventListener('copy', (event) => {
+    const clobber = (event: Event): void => {
       const data = (event as unknown as { clipboardData?: ClipboardDataStub }).clipboardData
-      data?.setData('text/plain', 'late document handler')
-    })
+      data?.setData('text/plain', 'later window handler')
+    }
+    window.addEventListener('copy', clobber)
 
-    expect(copyClipboardTextViaExecCommand('pane-42', document)).toBe(true)
-    expect(clipboardData.getData('text/plain')).toBe('pane-42')
+    try {
+      expect(copyClipboardTextViaExecCommand('pane-42', document)).toBe(true)
+      expect(clipboardData.getData('text/plain')).toBe('pane-42')
+    } finally {
+      window.removeEventListener('copy', clobber)
+    }
   })
 })

--- a/src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts
+++ b/src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import { copyClipboardTextViaExecCommand } from './web-clipboard-copy-fallback'
+
+// Why a real DOM: the bug is purely about listener phase ordering, which only a
+// DOM with genuine capture/bubble propagation can reproduce.
+
+type ClipboardDataStub = {
+  setData: (format: string, value: string) => void
+  getData: (format: string) => string
+}
+
+function createClipboardDataStub(): ClipboardDataStub {
+  const store = new Map<string, string>()
+  return {
+    setData(format, value) {
+      store.set(format, value)
+    },
+    getData(format) {
+      return store.get(format) ?? ''
+    }
+  }
+}
+
+/**
+ * Stands in for xterm: a bubble-phase 'copy' listener on terminal.element that
+ * overwrites text/plain with the terminal selection (xterm's copyHandler).
+ */
+function mountTerminalWithSelection(selectionText: string): HTMLElement {
+  const terminalElement = document.createElement('div')
+  document.body.appendChild(terminalElement)
+  terminalElement.addEventListener('copy', (event) => {
+    const clipboardData = (event as unknown as { clipboardData?: ClipboardDataStub }).clipboardData
+    clipboardData?.setData('text/plain', selectionText)
+    event.preventDefault()
+  })
+  return terminalElement
+}
+
+/**
+ * Stands in for the browser's execCommand('copy'): dispatches one bubbling,
+ * cancelable copy event from the element the DOM selection anchors to.
+ */
+function stubExecCommand(source: HTMLElement, clipboardData: ClipboardDataStub): void {
+  ;(document as unknown as { execCommand: (command: string) => boolean }).execCommand = (
+    command
+  ) => {
+    if (command !== 'copy') {
+      return false
+    }
+    const event = new Event('copy', { bubbles: true, cancelable: true })
+    Object.defineProperty(event, 'clipboardData', { value: clipboardData })
+    source.dispatchEvent(event)
+    return true
+  }
+}
+
+describe('web copy fallback vs. the terminal selection', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('copies the requested text even when the selection anchor is inside a terminal', () => {
+    // Every Orca copy affordance (Copy Pane ID, Copy Path, commit SHA, PR URL) leaves
+    // the DOM selection inside the terminal, so execCommand('copy') dispatches from
+    // there. A capture-phase handler sets text/plain FIRST and xterm's bubble handler
+    // then overwrites it — and preventDefault does not stop propagation, so the copy
+    // reports success while the clipboard holds the terminal selection.
+    const terminalElement = mountTerminalWithSelection('rm -rf ./secret-dir')
+    const clipboardData = createClipboardDataStub()
+    stubExecCommand(terminalElement, clipboardData)
+
+    expect(copyClipboardTextViaExecCommand('/Users/me/repo/src/index.ts', document)).toBe(true)
+    expect(clipboardData.getData('text/plain')).toBe('/Users/me/repo/src/index.ts')
+  })
+
+  it('wins over a document-level copy handler registered after it', () => {
+    const source = document.createElement('div')
+    document.body.appendChild(source)
+    const clipboardData = createClipboardDataStub()
+    stubExecCommand(source, clipboardData)
+    document.addEventListener('copy', (event) => {
+      const data = (event as unknown as { clipboardData?: ClipboardDataStub }).clipboardData
+      data?.setData('text/plain', 'late document handler')
+    })
+
+    expect(copyClipboardTextViaExecCommand('pane-42', document)).toBe(true)
+    expect(clipboardData.getData('text/plain')).toBe('pane-42')
+  })
+})

--- a/src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts
+++ b/src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts
@@ -2,8 +2,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { copyClipboardTextViaExecCommand } from './web-clipboard-copy-fallback'
 
-// Why a real DOM: the bug is purely about listener phase ordering, which only a
-// DOM with genuine capture/bubble propagation can reproduce.
+// Why a real DOM: only genuine capture/bubble propagation reproduces the ordering bug.
 
 type ClipboardDataStub = {
   setData: (format: string, value: string) => void
@@ -22,10 +21,7 @@ function createClipboardDataStub(): ClipboardDataStub {
   }
 }
 
-/**
- * Stands in for xterm: a bubble-phase 'copy' listener on terminal.element that
- * overwrites text/plain with the terminal selection (xterm's copyHandler).
- */
+/** Stands in for xterm's copyHandler: bubble-phase, overwrites text/plain. */
 function mountTerminalWithSelection(selectionText: string): HTMLElement {
   const terminalElement = document.createElement('div')
   document.body.appendChild(terminalElement)
@@ -37,10 +33,7 @@ function mountTerminalWithSelection(selectionText: string): HTMLElement {
   return terminalElement
 }
 
-/**
- * Stands in for the browser's execCommand('copy'): dispatches one bubbling,
- * cancelable copy event from the element the DOM selection anchors to.
- */
+/** Stands in for execCommand('copy'): dispatches from the DOM selection's anchor. */
 function stubExecCommand(source: HTMLElement, clipboardData: ClipboardDataStub): void {
   ;(document as unknown as { execCommand: (command: string) => boolean }).execCommand = (
     command
@@ -61,11 +54,8 @@ describe('web copy fallback vs. the terminal selection', () => {
   })
 
   it('copies the requested text even when the selection anchor is inside a terminal', () => {
-    // Every Orca copy affordance (Copy Pane ID, Copy Path, commit SHA, PR URL) leaves
-    // the DOM selection inside the terminal, so execCommand('copy') dispatches from
-    // there. A capture-phase handler sets text/plain FIRST and xterm's bubble handler
-    // then overwrites it — and preventDefault does not stop propagation, so the copy
-    // reports success while the clipboard holds the terminal selection.
+    // Copy Path / Copy Pane ID leave the selection in the terminal, so the copy event
+    // dispatches from there and a capture-phase write loses to xterm's bubble handler.
     const terminalElement = mountTerminalWithSelection('rm -rf ./secret-dir')
     const clipboardData = createClipboardDataStub()
     stubExecCommand(terminalElement, clipboardData)
@@ -75,8 +65,8 @@ describe('web copy fallback vs. the terminal selection', () => {
   })
 
   it('wins over a copy handler that still runs after the document', () => {
-    // Bubbling reaches the document before the window, so phase order alone does not
-    // protect against a window-level listener — only stopImmediatePropagation does.
+    // Bubbling hits the document before the window, so only stopImmediatePropagation
+    // protects against a window-level listener.
     const source = document.createElement('div')
     document.body.appendChild(source)
     const clipboardData = createClipboardDataStub()

--- a/src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts
+++ b/src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts
@@ -34,13 +34,19 @@ function mountTerminalWithSelection(selectionText: string): HTMLElement {
 }
 
 /** Stands in for execCommand('copy'): dispatches from the DOM selection's anchor. */
-function stubExecCommand(source: HTMLElement, clipboardData: ClipboardDataStub): void {
+function stubExecCommand(
+  source: HTMLElement,
+  clipboardData: ClipboardDataStub,
+  // Runs once the fallback has registered, so a handler added here is ordered after it.
+  beforeDispatch?: () => void
+): void {
   ;(document as unknown as { execCommand: (command: string) => boolean }).execCommand = (
     command
   ) => {
     if (command !== 'copy') {
       return false
     }
+    beforeDispatch?.()
     const event = new Event('copy', { bubbles: true, cancelable: true })
     Object.defineProperty(event, 'clipboardData', { value: clipboardData })
     source.dispatchEvent(event)
@@ -62,6 +68,26 @@ describe('web copy fallback vs. the terminal selection', () => {
 
     expect(copyClipboardTextViaExecCommand('/Users/me/repo/src/index.ts', document)).toBe(true)
     expect(clipboardData.getData('text/plain')).toBe('/Users/me/repo/src/index.ts')
+  })
+
+  it('wins over a later document-level copy handler', () => {
+    // Same target as the fallback's own listener, so only stopImmediatePropagation
+    // suppresses it — stopPropagation would still let it run and clobber text/plain.
+    const source = document.createElement('div')
+    document.body.appendChild(source)
+    const clipboardData = createClipboardDataStub()
+    const clobber = (event: Event): void => {
+      const data = (event as unknown as { clipboardData?: ClipboardDataStub }).clipboardData
+      data?.setData('text/plain', 'later document handler')
+    }
+    stubExecCommand(source, clipboardData, () => document.addEventListener('copy', clobber))
+
+    try {
+      expect(copyClipboardTextViaExecCommand('pane-42', document)).toBe(true)
+      expect(clipboardData.getData('text/plain')).toBe('pane-42')
+    } finally {
+      document.removeEventListener('copy', clobber)
+    }
   })
 
   it('wins over a copy handler that still runs after the document', () => {

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -70,7 +70,11 @@ function installExecCommandClipboardDocument(execCommandResult = true): {
   const execCommand = vi.fn((command: string) => {
     if (command === 'copy') {
       for (const listener of listeners.slice()) {
-        listener({ clipboardData: { setData }, preventDefault: vi.fn() })
+        listener({
+          clipboardData: { setData },
+          preventDefault: vi.fn(),
+          stopImmediatePropagation: vi.fn()
+        })
       }
     }
     return execCommandResult


### PR DESCRIPTION
## What

Three independent data-loss/data-leak defects, each in code added by an earlier fix:

1. **Mobile notification loss on a failed catch-up** (`mobile/src/notifications/mobile-notifications.ts:123` on `main`, from #10816). `fetchMissed` collapsed an RPC failure into an empty batch (`.catch(() => [])`), so an abandoned catch-up looked identical to "nothing missed". Live delivery kept advancing and persisting `lastDeliveredSeq`, and because the desktop cuts by `seq > lastSeenSeq`, the next catch-up asked from above the abandoned range — those notifications were never replayed. A per-session quarantine now freezes the persisted watermark at the seq the failed catch-up asked from until some later catch-up actually drains. Review then surfaced a second half of the same loss: `seen` was marked *before* delivery, so a rejected `showLocalNotification` left the key behind and every later replay of that event was dropped as a duplicate — the quarantine held the range, but the notification inside it could never be re-shown. `seen` is now marked after the show lands, on the same rule as the watermark.
2. **Jira attachment cache repopulated with credentialed bytes after a disconnect** (`src/main/jira/attachment-image-cache.ts:26` on `main`, from #8938). The staleness guard compared `siteEpoch + cacheEpoch`, so distinct clear states could sum to the same number (site at 1 before a global clear equals global 1 after it). An in-flight download that spanned a per-site clear followed by "Disconnect all" passed the guard and re-inserted image bytes fetched with a now-revoked token. Replaced with one monotonic ticker read via `Math.max`, so distinct clear states can never be equal.
3. **Web-client copy pasting the terminal selection instead of the requested text** (`src/renderer/src/web/web-clipboard-copy-fallback.ts:18` on `main`, from #10534). The `execCommand` fallback registered its `copy` listener in the capture phase; xterm's own handler is bubble-phase on `terminal.element` and overwrote `text/plain` with the terminal selection afterwards (`preventDefault` does not stop propagation). Switched to bubble phase plus `stopImmediatePropagation()`.

## ELI5

Three separate things could quietly hand you the wrong data. On your phone, if the app lost its connection at the exact moment it was asking the desktop "what did I miss?", it would give up on that batch but still move its bookmark forward — so those notifications were skipped for good and you never learned about them. In the Jira panel, an image that was still downloading when you disconnected your account could land in the cache anyway, meaning pictures fetched with credentials you had just revoked stayed in memory and could be shown again. And in the browser version of Orca, clicking something like "Copy Path" while text was highlighted in a terminal would copy the highlighted terminal text instead — the app said "Copied!", but pasting gave you whatever was selected in the terminal. There was also a subtler version of the phone problem: the app ticked a notification off its "already handled" list the instant it *started* showing it, so if showing it then failed, the app spent forever re-asking for a notification it would keep throwing away as a repeat. Now the phone keeps asking from the point it actually stopped at until it truly catches up, only ticks a notification off once it has really appeared, the disconnected account's images are dropped, and copy copies what you asked for.

## Proof of fix

### 1. Mobile notification loss (`mobile/`, vitest)

Source files reverted to `origin/main`, new test kept at HEAD:

```
$ git checkout origin/main -- mobile/src/notifications/mobile-notifications.ts \
    mobile/src/notifications/notification-reconnect-catchup.ts
$ cd mobile && npx vitest run --reporter=verbose \
    src/notifications/notification-catchup-failure-quarantine.test.ts

 FAIL  ... > keeps asking from the abandoned range until a catch-up actually succeeds
AssertionError: expected 11 to be 5 // Object.is equality
 ❯ src/notifications/notification-catchup-failure-quarantine.test.ts:143:28

 FAIL  ... > rolls back a watermark a live event stored while the catch-up was in flight
AssertionError: expected 11 to be 5 // Object.is equality
 ❯ src/notifications/notification-catchup-failure-quarantine.test.ts:191:28

 FAIL  ... > quarantines at the last replayed seq when a teardown cuts the batch short
AssertionError: expected 20 to be 6 // Object.is equality

 FAIL  ... > re-shows a replay whose show threw, instead of dropping it as already seen
AssertionError: expected [ 'm6', 'm7' ] to deeply equal [ 'm6', 'm6', 'm7' ]

 FAIL  ... > re-shows a live event whose show threw, instead of dropping it as already seen
AssertionError: expected [ 'm6' ] to deeply equal [ 'm6', 'm6' ]

 Test Files  1 failed (1)
      Tests  5 failed (5)
     Errors  2 errors
```

The two `Errors` are the unhandled rejections the escaping show produced (vitest exits 1 on them);
both queue boundaries now contain it.

With the fix:

```
 ✓ ... > keeps asking from the abandoned range until a catch-up actually succeeds 68ms
 ✓ ... > rolls back a watermark a live event stored while the catch-up was in flight 33ms
 ✓ ... > quarantines at the last replayed seq when a teardown cuts the batch short 33ms
 ✓ ... > re-shows a replay whose show threw, instead of dropping it as already seen 23ms
 ✓ ... > re-shows a live event whose show threw, instead of dropping it as already seen 34ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

### 2 & 3. Jira cache and web clipboard (desktop vitest)

Source files reverted to `origin/main`, new tests kept at HEAD:

```
$ git checkout origin/main -- src/main/jira/attachment-image-cache.ts \
    src/renderer/src/web/web-clipboard-copy-fallback.ts
$ npx vitest run --config config/vitest.config.ts --reporter=verbose \
    src/main/jira/attachment-image-cache.test.ts \
    src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts

 FAIL  src/main/jira/attachment-image-cache.test.ts > attachment image cache >
       does not repopulate after "disconnect all" when the site was cleared before
AssertionError: expected 'data:image/png;base64,SECRET==' to be null
 ❯ src/main/jira/attachment-image-cache.test.ts:84:55

 FAIL  src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts >
       copies the requested text even when the selection anchor is inside a terminal
AssertionError: expected 'rm -rf ./secret-dir' to be '/Users/me/repo/src/index.ts'
 ❯ src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts:74:49

 FAIL  src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts >
       wins over a copy handler that still runs after the document
AssertionError: expected 'later window handler' to be 'pane-42'
 ❯ src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts:92:51

 Test Files  2 failed (2)
      Tests  3 failed | 3 passed (6)
```

With the fix:

```
 Test Files  2 passed (2)
      Tests  6 passed (6)
```

### Clipboard: visual before/after

![before — clipboard holds the terminal selection](https://github.com/user-attachments/assets/f094f2dc-95e4-411f-95c1-be89a4fa7d74)

![after — clipboard holds the requested path](https://github.com/user-attachments/assets/1587c6c6-ff15-4b26-b11a-08ca57695bdb)

**Read these two shots with the caveat below.** They are real captures, but of a purpose-built page, not the shipped Orca web client. What is genuine: real Chromium driven by Playwright, real `@xterm/xterm` from this repo's `node_modules`, a genuinely insecure origin (served over plain HTTP on a LAN IP, with `navigator.clipboard === undefined` rendered on the page — `127.0.0.1` would be a secure context and would not exercise this path), a real mouse-drag selection via CDP, the unmodified `copyClipboardTextViaExecCommand` imported from `src/`, and a real `execCommand('copy')` followed by a real paste. The two runs differ only by `git stash` / `git stash pop` of `web-clipboard-copy-fallback.ts`: same viewport, same URL, same drag coordinates, same click sequence, one shared capture script. The diagnostics block is identical in both shots (`xterm hasSelection: true`, `dom selection anchor: xterm-helpers`, `dom selection inside terminal: true`, `copy reported: true`), so the only delta is the pasted text. The harness was deleted before committing and is not in this diff.

## Proof of no regression

**New regression tests**

- `mobile/src/notifications/notification-catchup-failure-quarantine.test.ts` — 5 cases. Fails on parent (5 failed + 2 unhandled rejections), passes with the fix (5 passed, 0 errors); output above. The last two are the review finding: one drives a rejecting show inside a replay batch, the other a rejecting show on the pure live path with no catch-up failure at all. It drives the real `subscribeToDesktopNotifications` across two subscription lifetimes (matching the `app/index.tsx` teardown/resubscribe cycle) with a mocked `RpcClient` and AsyncStorage, and asserts the persisted watermark directly.
- `src/main/jira/attachment-image-cache.test.ts` — added `does not repopulate after "disconnect all" when the site was cleared before` (the defect) plus `still caches a load that spans no clear at all`, which guards against the degenerate "never cache anything" fix.
- `src/renderer/src/web/web-clipboard-copy-terminal-selection.test.ts` — 3 cases. **Corrected at the merge gate:** the original 2 cases did not pin either half of the fix as this section previously claimed. Re-measured against all four phase/stop combinations, both passed with the listener still in the **capture** phase, and both passed with plain `stopPropagation` — the window-level clobber sits on a different target, which `stopPropagation` also suppresses. Added `wins over a later document-level copy handler`, which registers the clobber on the **same** target (`document`) ordered after the fallback's own listener: it fails with `stopPropagation` (`expected 'later document handler' to be 'pane-42'`) and passes only with `stopImmediatePropagation`. All 3 fail against the unfixed `origin/main` source. The bubble-phase change itself remains unpinned by any test — it is load-bearing in the real DOM (xterm's handler is on `terminal.element`, a descendant the capture phase reaches *before*), but the happy-dom harness dispatches from that same element, so capture and bubble are indistinguishable there. Stated rather than claimed as covered.

**Existing tests over the touched area** (real commands, real results, at HEAD):

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/web/ src/main/jira
 Test Files  15 passed | 1 skipped (16)
      Tests  232 passed | 3 skipped (235)

$ cd mobile && npx vitest run src/notifications src/transport
 Test Files  62 passed (62)
      Tests  376 passed | 2 skipped (378)
```

`src/transport` is included because `host-removal-lifecycle.test.ts` asserts on `HostNotificationSession.lastDeliveredSeq`.

**Typecheck and lint**

```
$ pnpm run typecheck:node   # exit 0
$ pnpm run typecheck:web    # exit 0
$ cd mobile && npx tsc --noEmit   # exit 0
$ pnpm run check:code-quality:changed
code quality: 0 new finding(s) across 9 changed file(s).
type-aware code quality: 0 new finding(s) across 9 changed file(s).
React Doctor: 0 new finding(s) across 9 changed file(s).
Changed-code quality gate passed since 747b241145cf.
```

**Deliberately not changed**

- `pruneExpired` in the Jira cache still has no TTL sweep timer, so entries only expire when Jira activity touches the cache. That is why the leak was permanent, but it is not the defect this PR fixes; adding a timer is a separate change. The "no TTL sweep without activity" property is unchanged.
- The catch-up RPC stays **outside** `enqueueHostDelivery`. Moving it in would serialize a request that waits up to 30s ahead of live delivery, and it would not fix the watermark problem — the bug is which seq gets persisted, not ordering.
- `session.lastDeliveredSeq` still advances on live delivery; only the *persisted* value is clamped. The quarantine changes what reaches AsyncStorage, not in-memory dedup.
- **Mark-after-success, not rollback-on-failure**, for the `seen` key. Rollback needs a "did I add this key or was it already here" distinction to avoid deleting a key an earlier successful delivery owns, and it leaves the key present during the await — the exact window a concurrent replay of the same id consults. Marking after the await gives one rule that already governs the watermark two lines below: both advance only once the event reached the user. In-batch pre-marking is not needed, since the batch is a single queue entry and no second replay of a key can interleave within it.
- The dismiss path needed no separate treatment: it flows through the same `deliverLive` tail. `dismissLocalNotification` swallows its own OS error, so a rejecting dismiss is not reachable through a path a test can drive — that branch is fixed by construction rather than by a dedicated case.
- Two pre-existing hand-rolled fake copy events (in `web-clipboard-copy-fallback.test.ts` and the shared document helper in `web-preload-api.test.ts`) gained a `stopImmediatePropagation` stub — a property every real `ClipboardEvent` has. No original assertion was removed or weakened.

**Known gaps, stated plainly**

- **No device-level proof for the notification fix.** No paired phone, no real desktop host, no real socket drop. Evidence is the unit test above, not an end-to-end offline/reconnect run.
- **Restart while a quarantine is open re-fetches.** Because the persisted watermark is rolled back to the quarantined seq, a process death during an open gap resumes from the lower seq and may re-show notifications already delivered once the in-memory seen-set is gone. That is the at-least-once trade-off the existing `saveWatermark` comment already documents, and it is preferred over silent loss — but it is a real behavior change and there is **no test pinning that duplicate-on-restart case**.
- **One notification edge left unchased.** `contiguousSeq` advances after each replayed event returns, including events skipped as already-seen or already-queued. If a skipped event preceded a later failing one in the same batch, the quarantine point could sit above it. Now that `seen` is only marked after a show lands, an already-seen skip provably means the event reached the user — but the already-*queued* skip still rests on the claim being released only after its own delivery settles, and that composition is not pinned by a test.
- **A retry needs a later catch-up to arrive.** Marking `seen` after the show makes the failed event re-deliverable, but nothing re-fetches on its own — recovery still waits for the next `ready`. On a stable connection that may be a long time. Reducing that latency (an explicit retry) is deliberately out of scope.
- **No UI proof for the Jira cache fix, and none is possible** — the defect is retained bytes in the main process, not anything rendered. Staging it also needs two real Jira sites; it was reproduced only at the unit level.
- **Third-party copy listeners were not exhaustively audited.** All app-level `copy` listeners in `src/` were checked (there are none besides this one), and Monaco's sole copy listener is scoped to its own textarea and does not stop propagation. Libraries beyond xterm and Monaco were not swept for document-level copy listeners that `stopImmediatePropagation` might now pre-empt.
- Review note: the notification fix initially clamped only watermark writes made *after* the failure, leaving an already-too-high value in storage that a restart would read back — loss reached through a restart instead of a reconnect. That was caught in review and fixed in `ab2e89be3c`; the `rolls back a watermark a live event stored while the catch-up was in flight` test covers it.
- Review note: CodeRabbit's final comment asked for a same-target clobber regression, since the existing case only installed the later handler on `window` and would also pass under `stopPropagation`. It landed after the previous head commit; verified correct and addressed in `c075397c47`.
- Review note: CodeRabbit then found that the quarantine held the *range* but not the *event* — `seen` was marked before delivery, so a rejected show could never be re-shown. Confirmed and fixed in `5b33a6cd1c`. The suggested diff (drop the pre-mark in `deliverMissedEvent`) was not sufficient on its own: `deliverLive` marked the key itself before its await, so the identical hole existed on the live path with no catch-up involved. Both are now covered. The same commit contains the escaping rejection at **both** queue boundaries — the catch-up batch CodeRabbit flagged out-of-band, and `queueDelivery`, where the live-path rejection escapes identically (pre-existing on `main`).

**Rebase note**

Rebased onto `747b241145` (was branched at `b41e813cb5`). No conflicts, and **no hunk was dropped**: `git log b41e813cb5..origin/main --` over `mobile/src/notifications/`, `src/main/jira/attachment-image-cache.ts` and `src/renderer/src/web/web-clipboard-copy-fallback.ts` is empty, so no upstream commit in that range touches any file this PR changes and none of these three defects was fixed independently.

Made with [Orca](https://github.com/stablyai/orca) 🐋