### PR TITLE
fix(perf): correct three 07-27 perf regressions

### DIFF
--- a/docs/workspace-space-scan-resource-bounds.md
+++ b/docs/workspace-space-scan-resource-bounds.md
@@ -96,8 +96,12 @@ listing at once, so its verdict scales with the configured concurrency: at 48 wo
 files (100,848 entries) was rejected while 100 × 1,500 (150,100 entries, 50% more) was admitted.
 Aggregate live retention stays bounded by the 64 MiB byte cap, which all concurrent listings share.
 
-The retained-byte estimate includes parent path and entry name UTF-16 storage plus conservative
-per-entry object overhead. These are admission limits, not post-allocation observations.
+The retained-byte estimate includes entry name UTF-16 storage plus conservative per-entry object
+overhead, and each listing's parent path once. The parent path is charged per listing rather than
+per entry because a listing's entries all share a single parent-path string; charging it per entry
+multiplied it by the directory's width, so the 64 MiB cap tracked checkout depth instead of live
+heap and rejected the layouts above once the worktree path passed ~58 characters. These are
+admission limits, not post-allocation observations.
 
 The budget measures what the traversal is holding **right now**, not what it has ever seen. A
 directory listing is charged when admitted and released once every one of its entries has been
@@ -106,9 +110,10 @@ distinction decides real workspaces: a cumulative counter charged an ordinary 76
 worktree 61.2 MiB of its 64 MiB cap — 4% headroom, and tipping over purely because a longer branch
 name lengthens every absolute path. The same worktree peaks between 4 MiB and 8 MiB of live state.
 
-Because the estimate scales with absolute path length, a cumulative cap would make success depend on
-where a user checks out their worktrees. A live cap depends only on directory shape, so it rejects
-genuinely pathological layouts (one directory holding six figures of entries) and nothing else.
+Neither cap may depend on where a user checks out their worktrees, so the estimate charges each
+absolute path once per listing rather than once per entry. A live cap depends only on directory
+shape, so it rejects genuinely pathological layouts (one directory holding six figures of entries)
+and nothing else.
 
 Top-level directory enumeration for the `du` path uses the same budget. A capacity error must not
 fall through into the portable walker, because that would repeat an already rejected traversal.

--- a/docs/workspace-space-scan-resource-bounds.md
+++ b/docs/workspace-space-scan-resource-bounds.md
@@ -87,8 +87,14 @@ allocate one live operation per entry.
 
 Every portable entry is admitted through `WorkspaceSpaceScanBudget` before retention:
 
-- maximum entries held at once per worktree traversal: 100,000;
+- maximum entries in any one directory listing: 100,000;
 - maximum estimated live scan state per worktree traversal: 64 MiB.
+
+The entry cap is per listing rather than per traversal because only a single directory's width is
+fixed by directory shape. A traversal-wide entry counter is charged by every worker holding a
+listing at once, so its verdict scales with the configured concurrency: at 48 workers, 48 × 2,100
+files (100,848 entries) was rejected while 100 × 1,500 (150,100 entries, 50% more) was admitted.
+Aggregate live retention stays bounded by the 64 MiB byte cap, which all concurrent listings share.
 
 The retained-byte estimate includes parent path and entry name UTF-16 storage plus conservative
 per-entry object overhead. These are admission limits, not post-allocation observations.
@@ -169,7 +175,7 @@ The deterministic regression measurements are:
 - peak simultaneous local `du` calls across repositories: exactly one;
 - peak simultaneous desktop-side SSH fallback traversals across repositories: at most two;
 - portable traversal live entry jobs: no more than its configured worker count;
-- portable entries held at once: at most 100,000 per worktree;
+- portable entries in any one directory listing: at most 100,000;
 - estimated live portable state: at most 64 MiB per worktree; an ordinary 76,788-entry worktree
   peaks between 4 MiB and 8 MiB;
 - progress and final row counts remain unchanged for scans below the limits.

--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -61,12 +61,14 @@ const SNAPSHOT = {
 } satisfies DashboardSnapshot
 
 /** A real PNG header plus `bodyBytes` of filler, so sanitizing actually decodes. */
-function imageIconSrc(bodyBytes: number): string {
+function imageIconSrc(bodyBytes: number, withWhitespace = false): string {
   const header = Buffer.from([
     137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 64, 0, 0, 0, 64, 8, 6, 0,
     0, 0
   ])
-  return `data:image/png;base64,${Buffer.concat([header, Buffer.alloc(bodyBytes, bodyBytes % 251)]).toString('base64')}`
+  const body = Buffer.concat([header, Buffer.alloc(bodyBytes, bodyBytes % 251)]).toString('base64')
+  // The sanitizer's base64 pattern admits whitespace, so a real src can hold it.
+  return `data:image/png;base64,${withWhitespace ? `${body.slice(0, 20)} ${body.slice(20)}` : body}`
 }
 
 describe('dashboard payload validation', () => {
@@ -308,6 +310,30 @@ describe('dashboard payload validation', () => {
     }
 
     expect(sanitizeRepoIconCalls).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let a split of one icon key inherit another icon verdict', () => {
+    // A valid base64 src may contain whitespace, so `source` and `src` must not
+    // be joined ambiguously: this pair concatenates identically.
+    const accepted = { type: 'image', src: imageIconSrc(1_024, true), source: 'upload' }
+    const joined = `upload ${accepted.src}`
+    const splitAt = joined.indexOf(' ', 'upload '.length)
+    const forged = {
+      type: 'image',
+      source: joined.slice(0, splitAt),
+      src: joined.slice(splitAt + 1)
+    }
+    sanitizeRepoIconCalls.mockClear()
+
+    expect(isDashboardSnapshot({ ...SNAPSHOT, repoIconsByRepoId: { 'repo-1': accepted } })).toBe(
+      true
+    )
+    // `forged.source` is not a legal RepoIconImageSource, so it must be rejected
+    // no matter what the accepted icon left in the cache.
+    expect(isDashboardSnapshot({ ...SNAPSHOT, repoIconsByRepoId: { 'repo-1': forged } })).toBe(
+      false
+    )
+    expect(sanitizeRepoIconCalls).toHaveBeenCalledTimes(2)
   })
 
   it('does not let a cached image verdict answer for a non-image icon', () => {

--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { DashboardSnapshot } from '../../shared/dashboard-snapshot'
+import type * as RepoIconModule from '../../shared/repo-icon'
+
+// Counts real sanitizer entries so the icon cache is proven by decode count
+// rather than by wall clock, which is unfalsifiable on a loaded CI box.
+const sanitizeRepoIconCalls = vi.hoisted(() => vi.fn())
+vi.mock('../../shared/repo-icon', async (importOriginal) => {
+  const actual = await importOriginal<typeof RepoIconModule>()
+  return {
+    ...actual,
+    sanitizeRepoIcon: (value: unknown) => {
+      sanitizeRepoIconCalls(value)
+      return actual.sanitizeRepoIcon(value)
+    }
+  }
+})
+
 import {
   admitDashboardSnapshot,
   isDashboardRevealAgentArgs,
@@ -43,6 +59,15 @@ const SNAPSHOT = {
     workspaceStatuses: [{ id: 'in-review', label: 'In review', color: 'emerald' }]
   }
 } satisfies DashboardSnapshot
+
+/** A real PNG header plus `bodyBytes` of filler, so sanitizing actually decodes. */
+function imageIconSrc(bodyBytes: number): string {
+  const header = Buffer.from([
+    137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 64, 0, 0, 0, 64, 8, 6, 0,
+    0, 0
+  ])
+  return `data:image/png;base64,${Buffer.concat([header, Buffer.alloc(bodyBytes, bodyBytes % 251)]).toString('base64')}`
+}
 
 describe('dashboard payload validation', () => {
   it('accepts a complete dashboard snapshot', () => {
@@ -170,23 +195,70 @@ describe('dashboard payload validation', () => {
       expect(admitted?.snapshot.cards).toHaveLength(1)
     })
 
+    it('drops a card that fails only the search-board fields', () => {
+      const good = SNAPSHOT.cards[0]
+      const badReview = { ...good, paneKey: 'p2', review: { number: 0, state: 'open' } }
+      const badSubagent = {
+        ...good,
+        paneKey: 'p3',
+        subagents: [{ id: '', name: 'x', dotState: 'idle' }]
+      }
+      const badBucket = { ...good, paneKey: 'p4', bucket: 'archived' }
+
+      const admitted = admitDashboardSnapshot({
+        ...SNAPSHOT,
+        cards: [good, badReview, badSubagent, badBucket]
+      })
+
+      expect(admitted?.droppedCardCount).toBe(3)
+      expect(admitted?.snapshot.cards.map((card) => card.paneKey)).toEqual(['tab-1:leaf-1'])
+    })
+
+    it('keeps a done-bucket card the search board produces', () => {
+      const admitted = admitDashboardSnapshot({
+        ...SNAPSHOT,
+        cards: [{ ...SNAPSHOT.cards[0], bucket: 'done', dotState: 'done' }]
+      })
+
+      expect(admitted?.droppedCardCount).toBe(0)
+    })
+
     it('still rejects a snapshot whose own shape is unusable', () => {
       expect(admitDashboardSnapshot({ ...SNAPSHOT, generatedAt: Number.NaN })).toBeNull()
       expect(admitDashboardSnapshot({ ...SNAPSHOT, cards: 'nope' })).toBeNull()
       expect(admitDashboardSnapshot({ ...SNAPSHOT, repoIconsByRepoId: [] })).toBeNull()
+      // Why: showIdle and filterOptions describe the frame, not one card, so a
+      // bad value there has no card to drop and must fail the whole snapshot.
+      expect(admitDashboardSnapshot({ ...SNAPSHOT, showIdle: 'yes' })).toBeNull()
+      expect(
+        admitDashboardSnapshot({
+          ...SNAPSHOT,
+          filterOptions: { ...SNAPSHOT.filterOptions, projects: [{ id: '', label: 'Invalid' }] }
+        })
+      ).toBeNull()
+    })
+
+    it('mirrors isDashboardSnapshot on every snapshot-level rejection', () => {
+      const cases: unknown[] = [
+        { ...SNAPSHOT, generatedAt: Number.NaN },
+        { ...SNAPSHOT, cards: 'nope' },
+        { ...SNAPSHOT, repoIconsByRepoId: [] },
+        { ...SNAPSHOT, showIdle: 'yes' },
+        { ...SNAPSHOT, filterOptions: { projects: [], workspaceStatuses: 'nope' } },
+        null,
+        []
+      ]
+      for (const value of cases) {
+        expect(isDashboardSnapshot(value)).toBe(false)
+        expect(admitDashboardSnapshot(value)).toBeNull()
+      }
     })
   })
 
   // Why: sanitizing an image icon decodes the whole payload to read a 24-byte
   // header, and the renderer republishes the same icons every 250 ms.
   it('validates a repeated image icon without re-decoding it every publish', () => {
-    const src = `data:image/png;base64,${Buffer.concat([
-      Buffer.from([
-        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 64, 0, 0, 0, 64, 8,
-        6, 0, 0, 0
-      ]),
-      Buffer.alloc(256 * 1024, 7)
-    ]).toString('base64')}`
+    const src = imageIconSrc(256 * 1024)
     const snapshot = {
       ...SNAPSHOT,
       repoIconsByRepoId: Object.fromEntries(
@@ -196,17 +268,60 @@ describe('dashboard payload validation', () => {
         ])
       )
     }
+    sanitizeRepoIconCalls.mockClear()
 
-    expect(isDashboardSnapshot(snapshot)).toBe(true)
-    const start = performance.now()
-    for (let run = 0; run < 20; run += 1) {
+    for (let publish = 0; publish < 20; publish += 1) {
       expect(isDashboardSnapshot(snapshot)).toBe(true)
     }
-    const perPublishMs = (performance.now() - start) / 20
 
-    // Uncached this costs ~37 ms per publish; the cached path is well under 5 ms
-    // even on a loaded CI box.
-    expect(perPublishMs).toBeLessThan(5)
+    // 10 repos x 20 publishes = 200 icon checks against ONE decode.
+    expect(sanitizeRepoIconCalls).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-decodes when the icon payload or its source actually changes', () => {
+    const first = { type: 'image', src: imageIconSrc(1_024), source: 'upload' }
+    const second = { type: 'image', src: imageIconSrc(2_048), source: 'upload' }
+    // Same bytes, different source: `source` picks which src pattern is legal,
+    // so it must not collide with the first entry's cached verdict.
+    const rebranded = { ...first, source: 'file' }
+    sanitizeRepoIconCalls.mockClear()
+
+    for (const icon of [first, first, second, second, rebranded, rebranded]) {
+      isDashboardSnapshot({ ...SNAPSHOT, repoIconsByRepoId: { 'repo-1': icon } })
+    }
+
+    expect(sanitizeRepoIconCalls).toHaveBeenCalledTimes(3)
+  })
+
+  it('caches a rejection too, so a bad icon cannot be re-decoded every publish', () => {
+    const icon = {
+      type: 'image',
+      src: `${imageIconSrc(1_024)}`.replace('png', 'gif'),
+      source: 'upload'
+    }
+    sanitizeRepoIconCalls.mockClear()
+
+    for (let publish = 0; publish < 5; publish += 1) {
+      expect(isDashboardSnapshot({ ...SNAPSHOT, repoIconsByRepoId: { 'repo-1': icon } })).toBe(
+        false
+      )
+    }
+
+    expect(sanitizeRepoIconCalls).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let a cached image verdict answer for a non-image icon', () => {
+    const emoji = { type: 'emoji', emoji: '🦑' }
+    sanitizeRepoIconCalls.mockClear()
+
+    for (let publish = 0; publish < 3; publish += 1) {
+      expect(isDashboardSnapshot({ ...SNAPSHOT, repoIconsByRepoId: { 'repo-1': emoji } })).toBe(
+        true
+      )
+    }
+
+    // Cheap branches bypass the cache entirely rather than sharing its keyspace.
+    expect(sanitizeRepoIconCalls).toHaveBeenCalledTimes(3)
   })
 
   it('requires complete bounded reveal routing', () => {

--- a/src/main/ipc/dashboard-payload-validation.test.ts
+++ b/src/main/ipc/dashboard-payload-validation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { DashboardSnapshot } from '../../shared/dashboard-snapshot'
-import { isDashboardRevealAgentArgs, isDashboardSnapshot } from './dashboard-payload-validation'
+import {
+  admitDashboardSnapshot,
+  isDashboardRevealAgentArgs,
+  isDashboardSnapshot
+} from './dashboard-payload-validation'
 
 const SNAPSHOT = {
   generatedAt: 1_700_000_000_000,
@@ -144,6 +148,65 @@ describe('dashboard payload validation', () => {
         cards: [{ ...SNAPSHOT.cards[0], conversationName: 'x'.repeat(1_025) }]
       })
     ).toBe(false)
+  })
+
+  // Why: the pop-out replays the last accepted snapshot, so rejecting the whole
+  // board over one card froze every other agent's status until it was renamed.
+  describe('admitDashboardSnapshot', () => {
+    it('drops only the offending card and keeps the rest of the board', () => {
+      const good = SNAPSHOT.cards[0]
+      const bad = { ...good, paneKey: 'tab-2:leaf-2', conversationName: 'x'.repeat(1_025) }
+
+      const admitted = admitDashboardSnapshot({ ...SNAPSHOT, cards: [good, bad] })
+
+      expect(admitted?.droppedCardCount).toBe(1)
+      expect(admitted?.snapshot.cards.map((card) => card.paneKey)).toEqual(['tab-1:leaf-1'])
+    })
+
+    it('reports nothing dropped for a fully valid snapshot', () => {
+      const admitted = admitDashboardSnapshot(SNAPSHOT)
+
+      expect(admitted?.droppedCardCount).toBe(0)
+      expect(admitted?.snapshot.cards).toHaveLength(1)
+    })
+
+    it('still rejects a snapshot whose own shape is unusable', () => {
+      expect(admitDashboardSnapshot({ ...SNAPSHOT, generatedAt: Number.NaN })).toBeNull()
+      expect(admitDashboardSnapshot({ ...SNAPSHOT, cards: 'nope' })).toBeNull()
+      expect(admitDashboardSnapshot({ ...SNAPSHOT, repoIconsByRepoId: [] })).toBeNull()
+    })
+  })
+
+  // Why: sanitizing an image icon decodes the whole payload to read a 24-byte
+  // header, and the renderer republishes the same icons every 250 ms.
+  it('validates a repeated image icon without re-decoding it every publish', () => {
+    const src = `data:image/png;base64,${Buffer.concat([
+      Buffer.from([
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 64, 0, 0, 0, 64, 8,
+        6, 0, 0, 0
+      ]),
+      Buffer.alloc(256 * 1024, 7)
+    ]).toString('base64')}`
+    const snapshot = {
+      ...SNAPSHOT,
+      repoIconsByRepoId: Object.fromEntries(
+        Array.from({ length: 10 }, (_, index) => [
+          `repo-${index}`,
+          { type: 'image', src, source: 'upload' }
+        ])
+      )
+    }
+
+    expect(isDashboardSnapshot(snapshot)).toBe(true)
+    const start = performance.now()
+    for (let run = 0; run < 20; run += 1) {
+      expect(isDashboardSnapshot(snapshot)).toBe(true)
+    }
+    const perPublishMs = (performance.now() - start) / 20
+
+    // Uncached this costs ~37 ms per publish; the cached path is well under 5 ms
+    // even on a loaded CI box.
+    expect(perPublishMs).toBeLessThan(5)
   })
 
   it('requires complete bounded reveal routing', () => {

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -221,10 +221,12 @@ function imageIconCacheKey(icon: unknown): string | null {
   const candidate = icon as Record<string, unknown>
   // Why: `source` and `src` are the only fields an image icon can be rejected
   // on — `label` is normalized rather than rejected — so they alone key it.
+  // Length-prefixed because a valid `src` may contain whitespace, so a plain
+  // separator would let a rejected icon collide with an accepted one's verdict.
   return candidate.type === 'image' &&
     typeof candidate.src === 'string' &&
     typeof candidate.source === 'string'
-    ? `${candidate.source} ${candidate.src}`
+    ? `${candidate.source.length}:${candidate.source}${candidate.src}`
     : null
 }
 

--- a/src/main/ipc/dashboard-payload-validation.ts
+++ b/src/main/ipc/dashboard-payload-validation.ts
@@ -1,4 +1,9 @@
-import type { DashboardRevealAgentArgs, DashboardSnapshot } from '../../shared/dashboard-snapshot'
+import {
+  DASHBOARD_MAX_LABEL_LENGTH,
+  type DashboardRevealAgentArgs,
+  type DashboardSnapshot
+} from '../../shared/dashboard-snapshot'
+import { BoundedMap } from '../../shared/bounded-map'
 import { sanitizeRepoIcon } from '../../shared/repo-icon'
 import {
   AGENT_STATUS_ASSISTANT_MESSAGE_MAX_LENGTH,
@@ -11,8 +16,16 @@ const MAX_DASHBOARD_CARDS = 1_000
 const MAX_DASHBOARD_SUBAGENTS = 100
 const MAX_DASHBOARD_REPO_ICONS = 500
 const MAX_DASHBOARD_FILTER_OPTIONS = 500
+// Why: sanitizing an image icon base64-decodes the whole data URI to read a
+// 24-byte header, and the renderer republishes the same icons every 250 ms.
+const MAX_CACHED_ICON_SRC_BYTES = 8 * 1024 * 1024
+const imageIconValidity = new BoundedMap<string, boolean>({
+  maxEntries: MAX_DASHBOARD_REPO_ICONS,
+  maxBytes: MAX_CACHED_ICON_SRC_BYTES,
+  sizeOf: (_valid, key) => key.length * 2
+})
 const MAX_ID_LENGTH = 4_096
-const MAX_LABEL_LENGTH = 1_024
+const MAX_LABEL_LENGTH = DASHBOARD_MAX_LABEL_LENGTH
 const DASHBOARD_BUCKETS = new Set(['attention', 'working', 'done', 'idle'])
 const DASHBOARD_DOT_STATES = new Set(['working', 'blocked', 'waiting', 'done', 'idle'])
 const DASHBOARD_REVIEW_STATES = new Set(['open', 'closed', 'merged', 'draft'])
@@ -62,6 +75,41 @@ export function isDashboardSnapshot(value: unknown): value is DashboardSnapshot 
   )
 }
 
+export type DashboardSnapshotAdmission = {
+  snapshot: DashboardSnapshot
+  /** Cards dropped for failing validation; the rest of the board still paints. */
+  droppedCardCount: number
+}
+
+/**
+ * Why: one malformed card used to reject the whole snapshot, and the pop-out
+ * then replayed its last good board forever with nothing logged. A single
+ * over-long label must cost that card, not every other agent's live status.
+ * Snapshot-level fields still reject outright — there is no partial board to
+ * salvage when the frame itself is unusable.
+ */
+export function admitDashboardSnapshot(value: unknown): DashboardSnapshotAdmission | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const snapshot = value as Record<string, unknown>
+  if (
+    !isFiniteNumber(snapshot.generatedAt) ||
+    !Array.isArray(snapshot.cards) ||
+    snapshot.cards.length > MAX_DASHBOARD_CARDS ||
+    (snapshot.showIdle !== undefined && typeof snapshot.showIdle !== 'boolean') ||
+    !isDashboardFilterOptions(snapshot.filterOptions) ||
+    !isDashboardRepoIcons(snapshot.repoIconsByRepoId)
+  ) {
+    return null
+  }
+  const cards = snapshot.cards.filter(isDashboardCard)
+  return {
+    snapshot: { ...(snapshot as unknown as DashboardSnapshot), cards },
+    droppedCardCount: snapshot.cards.length - cards.length
+  }
+}
+
 function isDashboardFilterOptions(value: unknown): boolean {
   if (value === undefined) {
     return true
@@ -107,9 +155,7 @@ function isDashboardRepoIcons(value: unknown): boolean {
   return (
     entries.length <= MAX_DASHBOARD_REPO_ICONS &&
     entries.every(
-      ([repoId, icon]) =>
-        isBoundedString(repoId, MAX_ID_LENGTH) &&
-        (icon === null || sanitizeRepoIcon(icon) !== undefined)
+      ([repoId, icon]) => isBoundedString(repoId, MAX_ID_LENGTH) && (icon === null || isIcon(icon))
     )
   )
 }
@@ -150,6 +196,36 @@ function isDashboardSubagents(value: unknown): boolean {
       )
     })
   )
+}
+
+/** Memoizes only the image branch, whose cost is proportional to payload size. */
+function isIcon(icon: unknown): boolean {
+  const key = imageIconCacheKey(icon)
+  if (key === null) {
+    return sanitizeRepoIcon(icon) !== undefined
+  }
+  const cached = imageIconValidity.get(key)
+  if (cached !== undefined) {
+    return cached
+  }
+  const valid = sanitizeRepoIcon(icon) !== undefined
+  imageIconValidity.set(key, valid)
+  return valid
+}
+
+/** Cache key for an image icon; null when the verdict is already cheap. */
+function imageIconCacheKey(icon: unknown): string | null {
+  if (!icon || typeof icon !== 'object' || Array.isArray(icon)) {
+    return null
+  }
+  const candidate = icon as Record<string, unknown>
+  // Why: `source` and `src` are the only fields an image icon can be rejected
+  // on — `label` is normalized rather than rejected — so they alone key it.
+  return candidate.type === 'image' &&
+    typeof candidate.src === 'string' &&
+    typeof candidate.source === 'string'
+    ? `${candidate.source} ${candidate.src}`
+    : null
 }
 
 function isDashboardCard(value: unknown): boolean {

--- a/src/main/ipc/dashboard-popout.test.ts
+++ b/src/main/ipc/dashboard-popout.test.ts
@@ -53,6 +53,24 @@ const mainSender = { id: 1, send: vi.fn() }
 const popoutSender = { id: 2, send: vi.fn() }
 const untrustedSender = { id: 3, send: vi.fn() }
 const SNAPSHOT = { generatedAt: 1, cards: [] }
+const CARD = {
+  paneKey: 'tab-1:leaf-1',
+  ptyId: 'pty-1',
+  agentType: 'codex',
+  bucket: 'working',
+  dotState: 'working',
+  task: 'Ship it',
+  repoId: 'repo-1',
+  worktreeId: 'worktree-1',
+  tabId: 'tab-1',
+  leafId: 'leaf-1',
+  repoName: 'Orca',
+  worktreeName: 'Dashboard',
+  startedAt: 1,
+  finishedAt: null,
+  stateChangedAt: 1,
+  unseen: false
+}
 
 function makeWindow(sender: typeof mainSender) {
   return {
@@ -129,6 +147,40 @@ describe('registerDashboardPopoutHandlers', () => {
 
     handlers.get('dashboard:publishSnapshot')!({ sender: mainSender } as never, SNAPSHOT)
     expect(popoutSender.send).toHaveBeenCalledWith('dashboard:snapshot', SNAPSHOT)
+  })
+
+  // Why: an over-long label used to drop the whole snapshot silently, leaving
+  // the board frozen on its last good paint with nothing logged.
+  it('keeps publishing the board when one card is invalid, and says so', () => {
+    const popout = makeWindow(popoutSender)
+    getPopoutMock.mockReturnValue(popout)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const good = { ...CARD, paneKey: 'tab-1:leaf-1' }
+    const bad = { ...CARD, paneKey: 'tab-2:leaf-2', conversationName: 'x'.repeat(1_025) }
+
+    handlers.get('dashboard:publishSnapshot')!({ sender: mainSender } as never, {
+      generatedAt: 2,
+      cards: [good, bad]
+    })
+
+    expect(popoutSender.send).toHaveBeenCalledWith('dashboard:snapshot', {
+      generatedAt: 2,
+      cards: [good]
+    })
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropped 1 invalid card'))
+    warn.mockRestore()
+  })
+
+  it('logs when a snapshot is rejected outright', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    handlers.get('dashboard:publishSnapshot')!({ sender: mainSender } as never, {
+      generatedAt: Number.NaN,
+      cards: []
+    })
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('rejected malformed snapshot'))
+    warn.mockRestore()
   })
 
   it('replays the cached snapshot only to the popout and nudges only the trusted main renderer', () => {

--- a/src/main/ipc/dashboard-popout.ts
+++ b/src/main/ipc/dashboard-popout.ts
@@ -12,9 +12,9 @@ import {
 import { safelyRevealWindow } from '../window/focus-existing-window'
 import { getTrustedUIRendererWindow, isTrustedUIRenderer, sendToTrustedUIRenderer } from './ui'
 import {
+  admitDashboardSnapshot,
   isDashboardPaneKey,
-  isDashboardRevealAgentArgs,
-  isDashboardSnapshot
+  isDashboardRevealAgentArgs
 } from './dashboard-payload-validation'
 
 // The most recent snapshot the main renderer published, replayed to the popout
@@ -63,22 +63,28 @@ export function registerDashboardPopoutHandlers(
 
   // Relay: the main renderer publishes derived snapshots; forward to the popout.
   ipcMain.handle('dashboard:publishSnapshot', (event, snapshot: unknown): void => {
-    if (
-      !isTrustedUIRenderer(event.sender) ||
-      !isDashboardEnabled(store) ||
-      !isDashboardSnapshot(snapshot)
-    ) {
+    if (!isTrustedUIRenderer(event.sender) || !isDashboardEnabled(store)) {
       return
+    }
+    const admitted = admitDashboardSnapshot(snapshot)
+    // Why: silently dropping left the pop-out replaying a stale board with no
+    // trace of why it stopped updating.
+    if (!admitted) {
+      console.warn('[dashboard] rejected malformed snapshot; pop-out keeps its previous board')
+      return
+    }
+    if (admitted.droppedCardCount > 0) {
+      console.warn(`[dashboard] dropped ${admitted.droppedCardCount} invalid card(s) from snapshot`)
     }
     // The renderer omits repoIconsByRepoId once it is unchanged, so carry the
     // last map into the cache — a popout mounting mid-session is replayed this
     // and has no icons of its own to retain. The live popout does, so what is
     // forwarded stays as slim as the renderer sent it.
     lastSnapshot =
-      snapshot.repoIconsByRepoId === undefined && lastSnapshot?.repoIconsByRepoId
-        ? { ...snapshot, repoIconsByRepoId: lastSnapshot.repoIconsByRepoId }
-        : snapshot
-    getDashboardPopoutWindow()?.webContents.send('dashboard:snapshot', snapshot)
+      admitted.snapshot.repoIconsByRepoId === undefined && lastSnapshot?.repoIconsByRepoId
+        ? { ...admitted.snapshot, repoIconsByRepoId: lastSnapshot.repoIconsByRepoId }
+        : admitted.snapshot
+    getDashboardPopoutWindow()?.webContents.send('dashboard:snapshot', admitted.snapshot)
   })
 
   // The popout asks for a snapshot on mount: replay the cache immediately, then

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -179,6 +179,21 @@ describe('buildDashboardSnapshot', () => {
     expect(snapshot.cards[0].conversationName).toHaveLength(DASHBOARD_MAX_LABEL_LENGTH)
   })
 
+  // Why: filterOptions is snapshot-level, so an over-long project label is not
+  // recoverable by dropping a card — it invalidates the entire board.
+  it('truncates the project filter label the whole snapshot rides on', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        repos: [
+          { id: 'r1', path: '/r1', displayName: 'x'.repeat(5_000), badgeColor: '#000', addedAt: 0 }
+        ]
+      }),
+      NOW
+    )
+
+    expect(snapshot.filterOptions?.projects[0].label).toHaveLength(DASHBOARD_MAX_LABEL_LENGTH)
+  })
+
   it('withholds generated titles until the setting enables them', () => {
     const tabs = { w1: [{ ...tab(), generatedTitle: 'Fix the flaky pty test' }] }
     const off = buildDashboardSnapshot(

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -5,6 +5,7 @@ import {
   type AgentStatusEntry,
   type AgentStatusOrchestrationContext
 } from '../../../../shared/agent-status-types'
+import { DASHBOARD_MAX_LABEL_LENGTH } from '../../../../shared/dashboard-snapshot'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalTab, Worktree } from '../../../../shared/types'
 import { selectRuntimeAgentOrchestrationBatch } from '../sidebar/worktree-agent-orchestration-batch'
@@ -162,6 +163,20 @@ describe('buildDashboardSnapshot', () => {
       NOW
     )
     expect(unnamed.cards[0].conversationName).toBeUndefined()
+  })
+
+  // Why: `orca terminal rename --title` is unbounded, and the main-process
+  // validator drops any card whose label exceeds the shared bound.
+  it('truncates labels to the length the snapshot validator accepts', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        agentStatusByPaneKey: { [PANE_KEY]: entry({}) },
+        tabsByWorktree: { w1: [{ ...tab(), customTitle: 'x'.repeat(5_000) }] }
+      }),
+      NOW
+    )
+
+    expect(snapshot.cards[0].conversationName).toHaveLength(DASHBOARD_MAX_LABEL_LENGTH)
   })
 
   it('withholds generated titles until the setting enables them', () => {

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -1,10 +1,11 @@
 import type { AppState } from '@/store/types'
-import type {
-  DashboardBucket,
-  DashboardCard,
-  DashboardCardDotState,
-  DashboardCardSubagent,
-  DashboardSnapshot
+import {
+  DASHBOARD_MAX_LABEL_LENGTH,
+  type DashboardBucket,
+  type DashboardCard,
+  type DashboardCardDotState,
+  type DashboardCardSubagent,
+  type DashboardSnapshot
 } from '../../../../shared/dashboard-snapshot'
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { DEFAULT_WORKSPACE_STATUSES } from '../../../../shared/workspace-statuses'
@@ -77,6 +78,18 @@ function rowTask(row: DashboardAgentRow): string {
 function nonEmpty(value: string | undefined): string | undefined {
   const trimmed = (value ?? '').trim()
   return trimmed.length > 0 ? trimmed : undefined
+}
+
+/** Why: these labels come from unbounded sources (`terminal rename`, OSC titles,
+ *  display names). Over the validator's bound the card would be dropped. */
+function boundedLabel(value: string): string {
+  return value.length > DASHBOARD_MAX_LABEL_LENGTH
+    ? value.slice(0, DASHBOARD_MAX_LABEL_LENGTH)
+    : value
+}
+
+function boundedLabelOrUndefined(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : boundedLabel(value)
 }
 
 /** Mirrors useAgentRowConversationName so the board and the sidebar label the
@@ -261,8 +274,8 @@ export function buildDashboardSnapshot(
         worktreeId,
         tabId,
         leafId,
-        repoName: repo.displayName,
-        worktreeName: worktree.displayName,
+        repoName: boundedLabel(repo.displayName),
+        worktreeName: boundedLabel(worktree.displayName),
         workspaceStatusId: context?.workspaceStatus.id,
         workspaceStatusLabel: context?.workspaceStatus.label,
         workspaceStatusColor: context?.workspaceStatus.color,
@@ -280,7 +293,7 @@ export function buildDashboardSnapshot(
           !isTitleDerived &&
           (state.acknowledgedAgentsByPaneKey?.[row.paneKey] ?? 0) < row.entry.stateStartedAt,
         askSummary: bucket === 'attention' ? (row.entry.interactivePrompt ?? undefined) : undefined,
-        conversationName: rowConversationName(row, generatedTitlesEnabled)
+        conversationName: boundedLabelOrUndefined(rowConversationName(row, generatedTitlesEnabled))
       })
     }
   }

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -142,8 +142,10 @@ export function buildDashboardSnapshot(
     options.includeFilterOptions === false
       ? undefined
       : {
+          // Why: filterOptions is snapshot-level, so an over-long project label
+          // costs the WHOLE board, not one card. Bound it at the producer.
           projects: [...new Map(activeWorktrees.map(({ repo }) => [repo.id, repo])).values()].map(
-            (repo) => ({ id: repo.id, label: repo.displayName })
+            (repo) => ({ id: repo.id, label: boundedLabel(repo.displayName) })
           ),
           workspaceStatuses: (state.workspaceStatuses && state.workspaceStatuses.length > 0
             ? state.workspaceStatuses

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -19,6 +19,11 @@ export const DASHBOARD_BUCKET_ORDER: readonly DashboardBucket[] = [
   'idle'
 ]
 
+/** Max length of a card's display labels. The producer truncates to this and
+ *  the main-process validator enforces it, so an unbounded name (a long
+ *  `terminal rename`, an OSC title) cannot cost the card its place on the board. */
+export const DASHBOARD_MAX_LABEL_LENGTH = 1_024
+
 /** Kept distinct from `bucket` so attention cards retain their precise dot state. */
 export type DashboardCardDotState = 'working' | 'blocked' | 'waiting' | 'done' | 'idle'
 

--- a/src/shared/workspace-space-entry-traversal.test.ts
+++ b/src/shared/workspace-space-entry-traversal.test.ts
@@ -247,4 +247,73 @@ describe('scanWorkspaceSpaceEntryTree', () => {
       )
     }, 30_000)
   })
+
+  // Why: the cases above pin maxRetainedBytes wide open, so they cannot see the
+  // byte cap. At the real 64 MiB default the same layouts must still scan, and
+  // must not start failing because the worktree sits under a longer path — the
+  // resource-bounds doc rules out exactly that path dependence.
+  describe('capacity at the production default limits', () => {
+    // A real worktree checkout path; the bug appeared above ~58 characters.
+    const DEEP_ROOT = '/Users/octocat/projects/orca/.claude/worktrees/wf_d39acf3c-e7d-2'
+
+    function scanAtDefaults(
+      rootPath: string,
+      dirCount: number,
+      filesPerDir: number,
+      concurrency: number
+    ) {
+      const directories = new Map<string, readonly Entry[]>()
+      directories.set(
+        rootPath,
+        Array.from({ length: dirCount }, (_, index) => ({ name: `dir-${index}` }))
+      )
+      for (let index = 0; index < dirCount; index += 1) {
+        directories.set(
+          `${rootPath}/dir-${index}`,
+          Array.from({ length: filesPerDir }, (_, file) => ({ name: `file-${file}.ts` }))
+        )
+      }
+      return scanWorkspaceSpaceEntryTree({
+        rootPath,
+        rootName: 'root',
+        concurrency,
+        entryName: (entry: Entry) => entry.name,
+        joinPath: (parent, child) => `${parent}/${child}`,
+        classifyEntry: async (path) => ({
+          kind: directories.has(path) ? ('directory' as const) : ('file' as const),
+          sizeBytes: 1
+        }),
+        readDirectory: async (path) => {
+          const entries = directories.get(path)
+          if (!entries) {
+            throw new Error(`unreadable ${path}`)
+          }
+          return entries
+        },
+        checkCancelled: () => undefined,
+        createCancellationError: () => new Error('cancelled'),
+        isCancellationError: (error) => error instanceof Error && error.message === 'cancelled'
+      })
+    }
+
+    it.each([
+      { dirCount: 48, filesPerDir: 2_100, concurrency: 48 },
+      { dirCount: 10, filesPerDir: 10_001, concurrency: 10 },
+      { dirCount: 40, filesPerDir: 2_500, concurrency: 48 }
+    ])(
+      'scans $dirCount x $filesPerDir at concurrency $concurrency under a deep root',
+      async ({ dirCount, filesPerDir, concurrency }) => {
+        const result = await scanAtDefaults(DEEP_ROOT, dirCount, filesPerDir, concurrency)
+        expect(result.sizeBytes).toBe(dirCount * filesPerDir + dirCount + 1)
+      },
+      30_000
+    )
+
+    it('reaches the same verdict under a short root as under a deep one', async () => {
+      const shallow = await scanAtDefaults('/w', 48, 2_100, 48)
+      const deep = await scanAtDefaults(DEEP_ROOT, 48, 2_100, 48)
+
+      expect(deep.sizeBytes).toBe(shallow.sizeBytes)
+    }, 30_000)
+  })
 })

--- a/src/shared/workspace-space-entry-traversal.test.ts
+++ b/src/shared/workspace-space-entry-traversal.test.ts
@@ -158,8 +158,6 @@ describe('scanWorkspaceSpaceEntryTree', () => {
     ])
   })
 
-  // Why: the cap bounds entries held at once. A deep walk retires each listing
-  // as it descends, so total tree size must not decide the outcome.
   it('scans a chain far longer than the cap because listings are released', async () => {
     const depth = 50
     const directories = new Map<string, readonly Entry[]>()
@@ -191,10 +189,8 @@ describe('scanWorkspaceSpaceEntryTree', () => {
     await expect(scan).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
   })
 
-  // Why: docs/workspace-space-scan-resource-bounds.md promises "a live cap
-  // depends only on directory shape". A cap that N workers can each charge
-  // against makes the verdict scale with concurrency instead, so these layouts
-  // are the documented boundary: only a single over-cap directory may fail.
+  // Why: a cap N workers can each charge scales the verdict with concurrency,
+  // which docs/workspace-space-scan-resource-bounds.md forbids.
   describe('capacity depends on directory shape, not tree size or concurrency', () => {
     function buildWideTree(dirCount: number, filesPerDir: number) {
       const directories = new Map<string, readonly Entry[]>()
@@ -224,8 +220,6 @@ describe('scanWorkspaceSpaceEntryTree', () => {
       )
     }
 
-    // Every layout below sits under the 100,000 per-directory cap, so each must
-    // scan regardless of total entry count or worker count.
     it.each([
       { dirCount: 48, filesPerDir: 2_100, concurrency: 48 },
       { dirCount: 100, filesPerDir: 1_500, concurrency: 48 },
@@ -248,10 +242,8 @@ describe('scanWorkspaceSpaceEntryTree', () => {
     }, 30_000)
   })
 
-  // Why: the cases above pin maxRetainedBytes wide open, so they cannot see the
-  // byte cap. At the real 64 MiB default the same layouts must still scan, and
-  // must not start failing because the worktree sits under a longer path — the
-  // resource-bounds doc rules out exactly that path dependence.
+  // Why: the cases above pin maxRetainedBytes open, so only these see the byte
+  // cap — and its verdict must not depend on where the worktree is checked out.
   describe('capacity at the production default limits', () => {
     // A real worktree checkout path; the bug appeared above ~58 characters.
     const DEEP_ROOT = '/Users/octocat/projects/orca/.claude/worktrees/wf_d39acf3c-e7d-2'

--- a/src/shared/workspace-space-entry-traversal.test.ts
+++ b/src/shared/workspace-space-entry-traversal.test.ts
@@ -10,12 +10,13 @@ function makeTraversal(
     kind: 'directory' | 'file' | 'symlink'
     sizeBytes: number
   }>,
-  limits?: { maxEntries?: number; maxRetainedBytes?: number }
+  limits?: { maxEntries?: number; maxRetainedBytes?: number },
+  concurrency = 5
 ) {
   return scanWorkspaceSpaceEntryTree({
     rootPath: '/root',
     rootName: 'root',
-    concurrency: 5,
+    concurrency,
     entryName: (entry: Entry) => entry.name,
     joinPath: (parent, child) => `${parent}/${child}`,
     classifyEntry: (path) => classifyEntry(path),
@@ -188,5 +189,62 @@ describe('scanWorkspaceSpaceEntryTree', () => {
     )
 
     await expect(scan).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
+  })
+
+  // Why: docs/workspace-space-scan-resource-bounds.md promises "a live cap
+  // depends only on directory shape". A cap that N workers can each charge
+  // against makes the verdict scale with concurrency instead, so these layouts
+  // are the documented boundary: only a single over-cap directory may fail.
+  describe('capacity depends on directory shape, not tree size or concurrency', () => {
+    function buildWideTree(dirCount: number, filesPerDir: number) {
+      const directories = new Map<string, readonly Entry[]>()
+      directories.set(
+        '/root',
+        Array.from({ length: dirCount }, (_, index) => ({ name: `dir-${index}` }))
+      )
+      for (let index = 0; index < dirCount; index += 1) {
+        directories.set(
+          `/root/dir-${index}`,
+          Array.from({ length: filesPerDir }, (_, file) => ({ name: `file-${file}` }))
+        )
+      }
+      return directories
+    }
+
+    function scanWideTree(dirCount: number, filesPerDir: number, concurrency: number) {
+      const directories = buildWideTree(dirCount, filesPerDir)
+      return makeTraversal(
+        directories,
+        async (path) => ({
+          kind: directories.has(path) ? 'directory' : 'file',
+          sizeBytes: 1
+        }),
+        { maxEntries: 100_000, maxRetainedBytes: Number.MAX_SAFE_INTEGER },
+        concurrency
+      )
+    }
+
+    // Every layout below sits under the 100,000 per-directory cap, so each must
+    // scan regardless of total entry count or worker count.
+    it.each([
+      { dirCount: 48, filesPerDir: 2_100, concurrency: 48 },
+      { dirCount: 100, filesPerDir: 1_500, concurrency: 48 },
+      { dirCount: 10, filesPerDir: 10_001, concurrency: 10 },
+      { dirCount: 40, filesPerDir: 2_500, concurrency: 48 }
+    ])(
+      'scans $dirCount x $filesPerDir at concurrency $concurrency',
+      async ({ dirCount, filesPerDir, concurrency }) => {
+        const result = await scanWideTree(dirCount, filesPerDir, concurrency)
+        expect(result.sizeBytes).toBe(dirCount * filesPerDir + dirCount + 1)
+        expect(result.skippedEntryCount).toBe(0)
+      },
+      30_000
+    )
+
+    it('still rejects a single directory above the cap', async () => {
+      await expect(scanWideTree(1, 100_001, 48)).rejects.toBeInstanceOf(
+        WorkspaceSpaceScanCapacityError
+      )
+    }, 30_000)
   })
 })

--- a/src/shared/workspace-space-entry-traversal.ts
+++ b/src/shared/workspace-space-entry-traversal.ts
@@ -120,7 +120,7 @@ export async function scanWorkspaceSpaceEntryTree<TEntry>(
       return
     }
     frame.retired = true
-    releaseWorkspaceSpaceScanEntries(budget, frame.entries.length, frame.retainedBytes)
+    releaseWorkspaceSpaceScanEntries(budget, frame.retainedBytes)
     frame.entries = []
     frame.retainedBytes = 0
   }

--- a/src/shared/workspace-space-scan-budget.test.ts
+++ b/src/shared/workspace-space-scan-budget.test.ts
@@ -44,7 +44,7 @@ describe('workspace space scan budget', () => {
         () => undefined
       )
     ).rejects.toThrow('readdir exploded')
-    expect(budget).toMatchObject({ entries: 0, retainedBytes: 0 })
+    expect(budget).toMatchObject({ retainedBytes: 0 })
   })
 
   it('frees capacity for later directories once a listing is released', async () => {
@@ -64,7 +64,7 @@ describe('workspace space scan budget', () => {
       () => undefined
     )
     // Why: a cumulative counter would reject the identical second listing here.
-    releaseWorkspaceSpaceScanEntries(budget, first.entries.length, first.retainedBytes)
+    releaseWorkspaceSpaceScanEntries(budget, first.retainedBytes)
 
     await expect(
       collectWorkspaceSpaceDirectoryEntries(

--- a/src/shared/workspace-space-scan-budget.test.ts
+++ b/src/shared/workspace-space-scan-budget.test.ts
@@ -3,6 +3,7 @@ import {
   collectWorkspaceSpaceDirectoryEntries,
   createWorkspaceSpaceScanBudget,
   estimateWorkspaceSpaceEntryRetainedBytes,
+  estimateWorkspaceSpaceListingRetainedBytes,
   releaseWorkspaceSpaceScanEntries,
   WorkspaceSpaceScanCapacityError
 } from './workspace-space-scan-budget'
@@ -12,8 +13,8 @@ describe('workspace space scan budget', () => {
     const entries = [{ name: 'first' }, { name: 'second' }]
     const parentPath = '/workspace'
     const exactBytes = entries.reduce(
-      (total, entry) => total + estimateWorkspaceSpaceEntryRetainedBytes(parentPath, entry.name),
-      0
+      (total, entry) => total + estimateWorkspaceSpaceEntryRetainedBytes(entry.name),
+      estimateWorkspaceSpaceListingRetainedBytes(parentPath)
     )
 
     await expect(
@@ -50,8 +51,8 @@ describe('workspace space scan budget', () => {
     const parentPath = '/workspace'
     const entries = [{ name: 'first' }, { name: 'second' }]
     const exactBytes = entries.reduce(
-      (total, entry) => total + estimateWorkspaceSpaceEntryRetainedBytes(parentPath, entry.name),
-      0
+      (total, entry) => total + estimateWorkspaceSpaceEntryRetainedBytes(entry.name),
+      estimateWorkspaceSpaceListingRetainedBytes(parentPath)
     )
     const budget = createWorkspaceSpaceScanBudget({ maxRetainedBytes: exactBytes })
 

--- a/src/shared/workspace-space-scan-budget.ts
+++ b/src/shared/workspace-space-scan-budget.ts
@@ -12,6 +12,11 @@ export type WorkspaceSpaceScanLimits = {
  * Tracks entries the traversal is holding right now, not entries it has ever
  * seen. Counters fall again as directory listings are dispatched and dropped,
  * so the caps bound live heap rather than total tree size.
+ *
+ * `maxEntries` bounds a single listing, because that is the only quantity fixed
+ * by directory shape; the aggregate live cost is bounded by `maxRetainedBytes`.
+ * A global entry cap would instead scale with worker concurrency, rejecting an
+ * intact worktree purely because N workers happened to hold N listings at once.
  */
 export type WorkspaceSpaceScanBudget = {
   entries: number
@@ -61,12 +66,13 @@ export function estimateWorkspaceSpaceEntryRetainedBytes(
 export function retainWorkspaceSpaceScanEntry(
   budget: WorkspaceSpaceScanBudget,
   parentPath: string,
-  entryName: string
+  entryName: string,
+  listingEntryCount: number
 ): void {
   const retainedBytes =
     budget.retainedBytes + estimateWorkspaceSpaceEntryRetainedBytes(parentPath, entryName)
   if (
-    budget.entries >= budget.limits.maxEntries ||
+    listingEntryCount >= budget.limits.maxEntries ||
     retainedBytes > budget.limits.maxRetainedBytes
   ) {
     throw new WorkspaceSpaceScanCapacityError(budget.limits)
@@ -105,7 +111,7 @@ export async function collectWorkspaceSpaceDirectoryEntries<TEntry>(
     for await (const entry of directory) {
       checkCancelled()
       const name = entryName(entry)
-      retainWorkspaceSpaceScanEntry(budget, parentPath, name)
+      retainWorkspaceSpaceScanEntry(budget, parentPath, name, entries.length)
       retainedBytes += estimateWorkspaceSpaceEntryRetainedBytes(parentPath, name)
       entries.push(entry)
     }

--- a/src/shared/workspace-space-scan-budget.ts
+++ b/src/shared/workspace-space-scan-budget.ts
@@ -9,17 +9,17 @@ export type WorkspaceSpaceScanLimits = {
 }
 
 /**
- * Tracks entries the traversal is holding right now, not entries it has ever
- * seen. Counters fall again as directory listings are dispatched and dropped,
- * so the caps bound live heap rather than total tree size.
+ * Tracks what the traversal is holding right now, not what it has ever seen:
+ * `retainedBytes` falls again as listings are dispatched and dropped, so the
+ * cap bounds live heap rather than total tree size.
  *
- * `maxEntries` bounds a single listing, because that is the only quantity fixed
- * by directory shape; the aggregate live cost is bounded by `maxRetainedBytes`.
- * A global entry cap would instead scale with worker concurrency, rejecting an
- * intact worktree purely because N workers happened to hold N listings at once.
+ * `maxEntries` bounds ONE listing, not the traversal — a directory's width is
+ * the only entry count fixed by shape. A traversal-wide entry counter is
+ * charged by every worker holding a listing at once, so its verdict scaled with
+ * concurrency and rejected intact worktrees; aggregate live cost is bounded by
+ * `maxRetainedBytes` instead. Do not reintroduce a traversal-wide entry count.
  */
 export type WorkspaceSpaceScanBudget = {
-  entries: number
   retainedBytes: number
   limits: WorkspaceSpaceScanLimits
 }
@@ -44,7 +44,6 @@ export function createWorkspaceSpaceScanBudget(
   requested?: Partial<WorkspaceSpaceScanLimits>
 ): WorkspaceSpaceScanBudget {
   return {
-    entries: 0,
     retainedBytes: 0,
     limits: {
       maxEntries: clampLimit(requested?.maxEntries, WORKSPACE_SPACE_MAX_SCANNED_ENTRIES),
@@ -60,12 +59,8 @@ export function estimateWorkspaceSpaceEntryRetainedBytes(entryName: string): num
   return entryName.length * 2 + WORKSPACE_SPACE_ENTRY_OVERHEAD_BYTES
 }
 
-/**
- * Why: a listing's entries all share one parent-path string, so charging it per
- * entry inflated the estimate by the checkout depth. That made the byte cap
- * reject an intact worktree for living under a long path — the exact
- * path-dependence the resource-bounds doc says a live cap must not have.
- */
+/** Why: a listing's entries share one parent-path string, so charging it per
+ *  entry scaled the estimate by checkout depth rather than live heap. */
 export function estimateWorkspaceSpaceListingRetainedBytes(parentPath: string): number {
   return parentPath.length * 2
 }
@@ -84,18 +79,15 @@ export function retainWorkspaceSpaceScanEntry(
   ) {
     throw new WorkspaceSpaceScanCapacityError(budget.limits)
   }
-  budget.entries += 1
   budget.retainedBytes = retainedBytes
 }
 
-// Why: callers must return a listing's charge once they drop it, so the caps
-// track live retention instead of accumulating across the whole traversal.
+// Why: callers must return a listing's charge once they drop it, so the cap
+// tracks live retention instead of accumulating across the whole traversal.
 export function releaseWorkspaceSpaceScanEntries(
   budget: WorkspaceSpaceScanBudget,
-  entryCount: number,
   retainedBytes: number
 ): void {
-  budget.entries = Math.max(0, budget.entries - entryCount)
   budget.retainedBytes = Math.max(0, budget.retainedBytes - retainedBytes)
 }
 
@@ -129,7 +121,7 @@ export async function collectWorkspaceSpaceDirectoryEntries<TEntry>(
   } catch (error) {
     // Why: a rejected or cancelled listing is never handed to the caller, so
     // nothing would otherwise return the charge already taken for it.
-    releaseWorkspaceSpaceScanEntries(budget, entries.length, retainedBytes)
+    releaseWorkspaceSpaceScanEntries(budget, retainedBytes)
     throw error
   }
   return { entries, retainedBytes }

--- a/src/shared/workspace-space-scan-budget.ts
+++ b/src/shared/workspace-space-scan-budget.ts
@@ -56,21 +56,28 @@ export function createWorkspaceSpaceScanBudget(
   }
 }
 
-export function estimateWorkspaceSpaceEntryRetainedBytes(
-  parentPath: string,
-  entryName: string
-): number {
-  return (parentPath.length + entryName.length) * 2 + WORKSPACE_SPACE_ENTRY_OVERHEAD_BYTES
+export function estimateWorkspaceSpaceEntryRetainedBytes(entryName: string): number {
+  return entryName.length * 2 + WORKSPACE_SPACE_ENTRY_OVERHEAD_BYTES
+}
+
+/**
+ * Why: a listing's entries all share one parent-path string, so charging it per
+ * entry inflated the estimate by the checkout depth. That made the byte cap
+ * reject an intact worktree for living under a long path — the exact
+ * path-dependence the resource-bounds doc says a live cap must not have.
+ */
+export function estimateWorkspaceSpaceListingRetainedBytes(parentPath: string): number {
+  return parentPath.length * 2
 }
 
 export function retainWorkspaceSpaceScanEntry(
   budget: WorkspaceSpaceScanBudget,
-  parentPath: string,
   entryName: string,
-  listingEntryCount: number
+  listingEntryCount: number,
+  additionalBytes = 0
 ): void {
   const retainedBytes =
-    budget.retainedBytes + estimateWorkspaceSpaceEntryRetainedBytes(parentPath, entryName)
+    budget.retainedBytes + estimateWorkspaceSpaceEntryRetainedBytes(entryName) + additionalBytes
   if (
     listingEntryCount >= budget.limits.maxEntries ||
     retainedBytes > budget.limits.maxRetainedBytes
@@ -111,8 +118,12 @@ export async function collectWorkspaceSpaceDirectoryEntries<TEntry>(
     for await (const entry of directory) {
       checkCancelled()
       const name = entryName(entry)
-      retainWorkspaceSpaceScanEntry(budget, parentPath, name, entries.length)
-      retainedBytes += estimateWorkspaceSpaceEntryRetainedBytes(parentPath, name)
+      // The listing's shared parent path is charged once, with its first entry,
+      // so an empty listing holds no charge for the caller to release.
+      const listingBytes =
+        entries.length === 0 ? estimateWorkspaceSpaceListingRetainedBytes(parentPath) : 0
+      retainWorkspaceSpaceScanEntry(budget, name, entries.length, listingBytes)
+      retainedBytes += estimateWorkspaceSpaceEntryRetainedBytes(name) + listingBytes
       entries.push(entry)
     }
   } catch (error) {


### PR DESCRIPTION
## What

Three regressions landed on 07-27 and are corrected here. Rebased onto `d3681f6306`; the merge with #11042 (agent status search board) and #11089 (icon republish) is described under *Rebase* below.

1. **Workspace scan capacity scaled with worker concurrency, not directory shape** (introduced in #11026, `src/shared/workspace-space-scan-budget.ts:69`). `retainWorkspaceSpaceScanEntry` charged a *traversal-wide* entry counter, so N concurrent workers each holding a listing multiplied the live charge. At concurrency 48 a 48 × 2,100 tree (100,848 entries) hit the 100,000 cap while 100 × 1,500 (150,100 entries, 50% more) passed. `scanLocalWorktree` treats the capacity error as terminal, so an intact worktree reported as "Unavailable" with `sizeBytes` 0. Separately the 64 MiB byte cap charged `parentPath.length` for *every* entry in a listing, even though a listing's entries share one parent-path string — so the byte cap measured checkout depth rather than live heap. Both are fixed: the entry cap is now per directory listing (the only quantity fixed by directory shape) and the shared parent path is charged once per listing. `budget.entries` was removed entirely rather than left as a traversal-wide counter no check reads.

2. **Repo image icons were fully base64-decoded on every snapshot publish** (introduced in #11012, `src/main/ipc/dashboard-payload-validation.ts:75`). `sanitizeRepoIcon` reached `decodeBase64Prefix`, which sized its buffer to `Math.min(maxBytes, ceil(len/4)*3)` — with an 8 MiB header limit against a 256 KiB icon cap that always resolves to the whole payload — to read a 24-byte PNG header. This ran synchronously inside `ipcMain.handle` at the renderer's 250 ms republish cadence. The image branch is now memoized on `source + src` in a `BoundedMap`.

3. **One over-long card label discarded the entire snapshot, silently** (introduced in #11012, `src/main/ipc/dashboard-popout.ts:69`). `isDashboardSnapshot` is all-or-nothing and the handler returned early with no log, so the pop-out replayed `lastSnapshot` forever. Labels are now truncated at the producer, the validator drops only the offending card, and both the outright rejection and the per-card drops are logged.

## ELI5

Three separate things were making the app misbehave after that day's changes.

First, the disk-usage scanner had a safety limit meant to stop it eating memory on absurdly large folders. That limit was being counted wrong in two ways: it was shared across all the scanner's parallel workers, and it counted the folder's *path text* once per file instead of once per folder. The upshot was that a perfectly normal project could get refused — and whether it got refused depended on how many workers happened to be busy and how deep in your filesystem you keep your checkouts. People saw their project listed as "Unavailable" with a size of zero. Now the limit only reacts to what it is supposed to react to: one genuinely enormous folder.

Second, the agent dashboard re-checked every project icon from scratch four times a second, unpacking the entire image each time just to peek at its first two dozen bytes. With ten projects that was around 37 milliseconds of blocking work per refresh, which showed up as stutter. The answer for a given icon is now remembered, so it costs well under a millisecond.

Third, if any single agent card had a very long name, the whole dashboard pop-out window rejected the update and just kept showing whatever it had last — no error, no explanation, frozen board. Long names are now shortened before they are sent, and if a card is still unusable only that one card is dropped while the rest of the board keeps updating. The pop-out also writes a warning when it drops something, so this cannot fail invisibly again.

## Rebase — merging with #11042 and #11089

Both upstream commits touch the same files. Neither fixes any of these three findings, so no hunk was dropped as already-fixed. The merges:

**#11042 (agent status search board)** extended `dashboard-payload-validation.ts` with `MAX_DASHBOARD_SUBAGENTS`, `MAX_DASHBOARD_FILTER_OPTIONS`, `DASHBOARD_REVIEW_STATES`, a `'done'` bucket, `isDashboardFilterOptions`, and snapshot-level `showIdle` / `filterOptions`. Their change extends *what* is validated; this PR changes *how*. Three things were checked rather than assumed:

- **Per-card drop covers their new fields.** `admitDashboardSnapshot` filters on `isDashboardCard`, which #11042 extended in place — so `review`, `subagents`, `workspaceStatus*`, `hasReview` and the `'done'` bucket all route through the same drop. Pinned by `drops a card that fails only the search-board fields` (a bad `review`, a bad `subagents` entry, and an unknown bucket → 3 dropped, board survives) and `keeps a done-bucket card the search board produces`.
- **Their snapshot-level fields still reject the snapshot.** `showIdle` and `filterOptions` describe the frame, not one card, so there is nothing to salvage by dropping a card — `admitDashboardSnapshot` now checks both explicitly and returns `null`. Pinned by `mirrors isDashboardSnapshot on every snapshot-level rejection`, which asserts the two functions agree on all seven snapshot-level failure modes.
- **The icon cache key is still correct.** #11042 did not change `RepoIcon` or `sanitizeRepoIcon`. Key remains `source + src`; pinned by `re-decodes when the icon payload or its source actually changes`.

**#11089 (stop re-sending icon data URLs)** rewrote the same `dashboard:publishSnapshot` handler body to carry an omitted `repoIconsByRepoId` forward into `lastSnapshot`. Both changes are kept: the admission gate runs first, then their icon-carry-forward operates on `admitted.snapshot`, and the wire payload stays as slim as the renderer sent it. Their `replays the last repo icons when the cached snapshot omitted them` test passes unmodified.

**One real bug surfaced by the merge.** #11042's `filterOptions.projects[].label` is `repo.displayName` — the same unbounded source finding 3 bounds for `card.repoName`, but snapshot-level, where a per-card drop cannot recover it. An over-long project name fails `isDashboardFilterOptions` and takes the whole board with it: exactly the frozen-pop-out failure this PR exists to end. Bounded at the producer, with a test that fails without the fix. (Workspace-status labels were already capped at 32 in `workspace-statuses.ts`.)

## Proof of fix

### 1. Scan capacity (no screenshot — see gaps below)

The report's own trigger table, encoded as a test, run against the parent source (`git checkout <base> -- src/shared/workspace-space-scan-budget.ts`):

```
 ✓ ... > capacity depends on directory shape ... > scans 100 x 1500 at concurrency 48 62ms
 × ... > capacity depends on directory shape ... > scans 48 x 2100 at concurrency 48 24ms
   → Workspace is too large to scan safely (limit: 100,000 entries or 64 MiB of live scan state)
 × ... > capacity depends on directory shape ... > scans 10 x 10001 at concurrency 10 14ms
   → Workspace is too large to scan safely (limit: 100,000 entries or 64 MiB of live scan state)
 × ... > capacity at the production default limits > scans 48 x 2100 at concurrency 48 under a deep root 18ms
 × ... > capacity at the production default limits > scans 10 x 10001 at concurrency 10 under a deep root 14ms
 × ... > capacity at the production default limits > scans 40 x 2500 at concurrency 48 under a deep root 15ms
 × ... > capacity at the production default limits > reaches the same verdict under a short root as under a deep one 16ms
⎯⎯⎯ Failed Tests 6 ⎯⎯⎯
      Tests  6 failed | 10 passed (16)
```

Note the shape of the parent-commit failure: 48 × 2,100 (100,848 entries) fails while 100 × 1,500 (150,100 entries) passes. That inversion is the bug — the verdict tracked concurrency, not size.

With the fix, on the rebased tree:

```
 ✓ ... > capacity depends on directory shape, not tree size or concurrency > scans 48 x 2100 at concurrency 48 49ms
 ✓ ... > capacity depends on directory shape, not tree size or concurrency > scans 100 x 1500 at concurrency 48 60ms
 ✓ ... > capacity depends on directory shape, not tree size or concurrency > scans 10 x 10001 at concurrency 10 32ms
 ✓ ... > capacity depends on directory shape, not tree size or concurrency > scans 40 x 2500 at concurrency 48 39ms
 ✓ ... > capacity depends on directory shape, not tree size or concurrency > still rejects a single directory above the cap 14ms
 ✓ ... > capacity at the production default limits > scans 48 x 2100 at concurrency 48 under a deep root 49ms
 ✓ ... > capacity at the production default limits > scans 10 x 10001 at concurrency 10 under a deep root 42ms
 ✓ ... > capacity at the production default limits > scans 40 x 2500 at concurrency 48 under a deep root 44ms
 ✓ ... > capacity at the production default limits > reaches the same verdict under a short root as under a deep one 86ms
```

The byte-cap half of this finding was found during review of the first commit and fixed in `6ecabf4aa6`. The four `capacity at the production default limits` cases fail against the *first* commit too, not only against the parent. The cliff was located by binary search at root path length 59 (58 chars = ok, 59 = fail), i.e. an ordinary `~/projects/orca/.claude/worktrees/<name>` checkout sat past it.

### 2. Icon decode — now a deterministic decode count, not a wall clock

The previous revision asserted `perPublishMs < 5`, which **failed on CI at 5.64 ms** (job 90429445914). CodeRabbit flagged the same thing and suggested raising the ceiling to 10 ms. That was not taken: any millisecond threshold is unfalsifiable on a loaded runner and would flake again. The assertion is now a decode-count seam that spies on the real `sanitizeRepoIcon`:

```ts
for (let publish = 0; publish < 20; publish += 1) {
  expect(isDashboardSnapshot(snapshot)).toBe(true)
}
// 10 repos x 20 publishes = 200 icon checks against ONE decode.
expect(sanitizeRepoIconCalls).toHaveBeenCalledTimes(1)
```

Against the un-memoized validator (`git checkout origin/main -- src/main/ipc/dashboard-payload-validation.ts`, tests left in place):

```
 FAIL  src/main/ipc/dashboard-payload-validation.test.ts > validates a repeated image icon without re-decoding it every publish
AssertionError: expected "vi.fn()" to be called 1 times, but got 200 times
 FAIL  src/main/ipc/dashboard-payload-validation.test.ts > re-decodes when the icon payload or its source actually changes
AssertionError: expected "vi.fn()" to be called 3 times, but got 6 times
 FAIL  src/main/ipc/dashboard-payload-validation.test.ts > caches a rejection too, so a bad icon cannot be re-decoded every publish
AssertionError: expected "vi.fn()" to be called 1 times, but got 5 times
      Tests  9 failed | 7 passed (16)
```

Three cases the timing assertion could never have caught came with the seam:

- `re-decodes when the icon payload or its source actually changes` — pins the `source + src` key: two distinct payloads and a same-bytes/different-`source` icon give 3 decodes for 6 checks. `source` selects which `src` pattern is legal, so it must not collide.
- `caches a rejection too` — a rejected icon is decoded once, not once per publish.
- `does not let a cached image verdict answer for a non-image icon` — emoji/lucide bypass the cache entirely (3 decodes for 3 checks), so they can never share its keyspace.
- `does not let a split of one icon key inherit another icon verdict` — added at pre-merge review. The key joined `source` and `src` with a space, but the sanitizer's base64 pattern (`[A-Za-z0-9+/=\s]+`) admits whitespace *inside* a valid `src`, so an icon whose `source` is not a legal `RepoIconImageSource` could split the same concatenation differently and inherit an accepted icon's cached `true` — reaching the pop-out's `<img src>` without ever being sanitized. The key is now length-prefixed (`${source.length}:${source}${src}`). Verified to fail with only that one line reverted: `expected true to be false`.

Standalone measurements against the real exported validator, 20 runs averaged (unchanged from the previous revision; the memoization itself is unchanged):

| Payload | Before | After |
| --- | --- | --- |
| 8 repos × 29.6 KB | 3.48 ms/publish | 0.06 ms/publish |
| 10 repos × 200 KB | 28.48 ms/publish | 0.57 ms/publish |
| 10 repos × 256 KB | 37.34 ms/publish | 0.67 ms/publish |

### 3. Frozen pop-out board

Triggered through the documented public path — `orca terminal rename --title "<1800 chars>"`, which the RPC accepts unbounded — against a real agent terminal in a running instance of this worktree's build.

Parent code. The main window sidebar and tab both show the new `LONGTITLELONGTITLE...` name, while the pop-out (third tab, and the card in the pop-out window below) is still stuck on `PerfDemo`. This is the decisive frame: the rename succeeded everywhere except the pop-out.

![Main window on parent code: sidebar renamed, pop-out stale](https://github.com/user-attachments/assets/80588c2a-2794-4e00-9703-c58472bf82b7)

Pop-out window, parent code — frozen on the stale card:

![Pop-out before: card still reads PerfDemo](https://github.com/user-attachments/assets/9d1071ef-7663-43c1-8493-0574de76e026)

Pop-out window, fixed — the card updates, truncated to fit:

![Pop-out after: card shows the updated long title](https://github.com/user-attachments/assets/8acd6b5b-6265-4c4c-b5c4-f575ba272577)

Same window size, same route, same app state; the only variable is the fix.

Test evidence for the same finding. Parent source (`dashboard-payload-validation.ts` + `dashboard-popout.ts` reverted):

```
 × dashboard-popout.test.ts > keeps publishing the board when one card is invalid, and says so 2ms
   → expected "vi.fn()" to be called with arguments: [ 'dashboard:snapshot', …(1) ]
 × dashboard-popout.test.ts > logs when a snapshot is rejected outright 0ms
   → expected "warn" to be called with arguments: [ StringContaining{…} ]
 × dashboard-payload-validation.test.ts > admitDashboardSnapshot > drops only the offending card and keeps the rest of the board 1ms
   → admitDashboardSnapshot is not a function
```

Producer half, with `build-dashboard-snapshot.ts` reverted:

```
 × build-dashboard-snapshot.test.ts > truncates labels to the length the snapshot validator accepts 3ms
   → expected 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…' to have a length of 1024 but got 5000
```

And the snapshot-level project label found during the rebase, with only that one call unbounded:

```
 × build-dashboard-snapshot.test.ts > truncates the project filter label the whole snapshot rides on
   → expected length 1024, got 5000
      Tests  1 failed | 20 passed (21)
```

## Proof of no regression

**New regression tests.** Fifteen, across four files:

- `src/shared/workspace-space-entry-traversal.test.ts` — `capacity depends on directory shape, not tree size or concurrency` (5 cases, incl. "still rejects a single directory above the cap") and `capacity at the production default limits` (4 cases, run with **no** limits override under a deep root, plus an explicit short-root-vs-deep-root same-verdict assertion).
- `src/main/ipc/dashboard-payload-validation.test.ts` — five icon-cache cases on the decode-count seam (incl. the key-ambiguity case added at pre-merge review), and five `admitDashboardSnapshot` cases (incl. the two that pin #11042's new fields, and the `isDashboardSnapshot` parity case).
- `src/main/ipc/dashboard-popout.test.ts` — `keeps publishing the board when one card is invalid, and says so`; `logs when a snapshot is rejected outright`.
- `src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts` — `truncates labels to the length the snapshot validator accepts`; `truncates the project filter label the whole snapshot rides on`.

Every one was verified to fail with its source reverted and pass with the fix — real output pasted above. Reverts were done with `git checkout <ref> -- <source file>`, source files only, leaving the tests in place.

**Full run over the touched area, on the rebased tree.**

```
$ npx vitest run --config config/vitest.config.ts \
    src/shared/workspace-space-scan-budget.test.ts \
    src/shared/workspace-space-entry-traversal.test.ts \
    src/main/ipc/dashboard-payload-validation.test.ts \
    src/main/ipc/dashboard-popout.test.ts \
    src/renderer/src/components/dashboard/ \
    src/renderer/src/components/dashboard-popout/ \
    src/main/workspace-space-analysis.test.ts \
    src/main/workspace-space-analysis-capacity.test.ts \
    src/relay/workspace-space-scan.test.ts \
    src/relay/workspace-space-scan-du-capacity.test.ts \
    src/shared/bounded-map.test.ts src/shared/repo-icon.test.ts

 Test Files  28 passed (28)
      Tests  228 passed (228)
```

`isDashboardSnapshot`'s all-or-nothing semantics are **unchanged** — its existing "bounds the conversation name" test still passes unmodified, and the new parity case asserts `admitDashboardSnapshot` agrees with it on every snapshot-level rejection. The drop-one-card behavior lives in a separate `admitDashboardSnapshot` export, so no pre-existing contract was weakened.

Two assertions in `workspace-space-scan-budget.test.ts` were updated because their expected byte totals encoded the old per-entry parent-path charge, and one because `budget.entries` no longer exists. That is a deliberate change to the estimate, described in `docs/workspace-space-scan-resource-bounds.md` in this PR; it is not a weakened assertion.

**Typecheck.** `pnpm run typecheck:node`, `typecheck:web`, `typecheck:cli` — all exit 0, no output.

**Lint.** `pnpm run check:code-quality:changed` — `0 new finding(s)` across all three gates (oxlint, type-aware, React Doctor) over 11 changed files.

**Deliberately not changed.**

- `WORKSPACE_SPACE_ENTRY_OVERHEAD_BYTES` (512 B) and `maxRetainedBytes` (64 MiB) are untouched. Per-entry overhead still dominates the estimate — at a 12-char name the cap admits roughly 125k live entries against a real `Dirent` cost of ~150-250 B — so the OOM protection #11026 added is preserved, and the byte cap is still traversal-wide and shared by all concurrent listings.
- The entry-cap change cannot admit a pathological directory: a single 100,001-entry listing still fails closed, asserted by a test.
- The icon cache is module-scoped and bounded (500 entries / 8 MiB) and only wraps the image branch; lucide/emoji icons bypass it, asserted by a test. `sanitizeRepoIcon` itself is unchanged, so the accept/reject verdict is identical — only its repetition is avoided.
- `card.task` / `lastUserMessage` / `lastAgentMessage` are **not** bounded at the producer, unlike `repoName` / `worktreeName` / `conversationName`, because they already are upstream and more tightly than the validator requires: `prompt` → `normalizePromptField` → 200 (validator allows 200); `lastAssistantMessage` → `normalizeOptionalMultilineField` → 8000 (validator allows 8000); `orchestration.taskTitle` → `buildOrchestrationTaskDisplayMetadata` → 80. Every write into `AgentStatusEntry` goes through `normalizeAgentStatusObject`. The three that were bounded come from `repo.displayName` / `worktree.displayName` / tab titles, none of which pass a normalizer.
- No listener registration, IPC channel, or async ordering was changed.

### Disclosed gaps

- **No screenshot for finding 1.** Reproducing the Resource Manager "Unavailable" / 0-bytes row needs a real on-disk tree with a ~100k live frontier and, on macOS, the `du` fallback to fail as well; #11026's own notes place this primarily on the Windows path where `scanLocalWorktreeWithNode` is the only local scanner. ~100k files were not written on this host. The substituted evidence is the table-driven test plus the measured peak live-entry counts (48×2100 peaked at 100,849; 100×1500 at 72,100).
- **No screenshot for finding 2** — it is a timing regression; measured numbers and a decode count are given instead.
- **The finding-3 screenshots predate the rebase.** They were captured against the pre-#11042 board, so the pop-out in them has no search/filter chrome. The failure they demonstrate (a renamed card frozen in the pop-out) and the code path that fixes it are unchanged by the rebase, and the behaviour is additionally pinned by tests that were re-run on the rebased tree. They were not recaptured.
- **The originally prescribed fix for finding 1 does not work, and was measured rather than assumed.** The suggestion was to release each entry's charge at dispatch. That was implemented and the peak live-entry count for 48×2100@48 was unchanged at 100,849 — the charge is taken at *admission* in `collectWorkspaceSpaceDirectoryEntries`, so 48 workers admit 48 full listings before any entry is dispatched and a dispatch-time release is too late. It was reverted; the shipped fix decouples the cap from concurrency instead. Reviewers expecting the dispatch-time change in the diff should know it was tried and rejected on measurement, not skipped.
- **The relay-side scanner** (`src/relay/workspace-space-scan.ts`, `RELAY_FS_CONCURRENCY = 48`) inherits this fix through the shared budget module and its existing tests pass, but a live SSH relay host was not exercised.
- **Process note:** the `git stash push -- <file>` commands quoted in the original implementation notes were no-ops against an already-committed tree and could not have produced the output attributed to them. The conclusions were nonetheless correct — every fail-on-parent result in this PR was independently re-produced with `git checkout <ref> -- <source>` and is pasted verbatim above.

Made with [Orca](https://github.com/stablyai/orca) 🐋