### PR TITLE
fix(browser): handle Windows helper stdout inheritance

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -1,14 +1,22 @@
 /* eslint-disable max-lines */
+import { EventEmitter } from 'node:events'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { execFileMock, webContentsFromIdMock, existsSyncMock, readFileSyncMock, stdinWrites } =
-  vi.hoisted(() => ({
-    execFileMock: vi.fn(),
-    webContentsFromIdMock: vi.fn(),
-    existsSyncMock: vi.fn(() => false),
-    readFileSyncMock: vi.fn(() => Buffer.from('')),
-    stdinWrites: [] as string[]
-  }))
+const {
+  execFileMock,
+  webContentsFromIdMock,
+  existsSyncMock,
+  readFileSyncMock,
+  platformMock,
+  stdinWrites
+} = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  webContentsFromIdMock: vi.fn(),
+  existsSyncMock: vi.fn(() => false),
+  readFileSyncMock: vi.fn(() => Buffer.from('')),
+  platformMock: vi.fn(() => 'darwin'),
+  stdinWrites: [] as string[]
+}))
 
 vi.mock('child_process', () => ({ execFile: execFileMock }))
 vi.mock('fs', () => ({
@@ -18,7 +26,7 @@ vi.mock('fs', () => ({
   chmodSync: vi.fn(),
   constants: { X_OK: 1 }
 }))
-vi.mock('os', () => ({ platform: () => 'darwin', arch: () => 'arm64' }))
+vi.mock('os', () => ({ platform: platformMock, arch: () => 'arm64' }))
 vi.mock('electron', () => {
   return {
     app: { getPath: vi.fn(() => '/app'), getAppPath: vi.fn(() => '/project'), isPackaged: false },
@@ -307,6 +315,7 @@ describe('AgentBrowserBridge', () => {
     CdpWsProxyMock.instances.length = 0
     existsSyncMock.mockReturnValue(false)
     readFileSyncMock.mockReturnValue(Buffer.from(''))
+    platformMock.mockReturnValue('darwin')
     const wc = mockWebContents(100)
     webContentsFromIdMock.mockReturnValue(wc)
     bridge = new AgentBrowserBridge(mockBrowserManager())
@@ -434,6 +443,58 @@ describe('AgentBrowserBridge', () => {
     ).toBe('orca-tab-tab-b')
     expect(result).toEqual({ browserPageId: 'tab-b', snapshot: 'tree output' })
     expect(b.getActiveWebContentsId()).toBe(1)
+  })
+
+  it('returns large Windows snapshot output when a new page session keeps stdout open', async () => {
+    platformMock.mockReturnValue('win32')
+    const tabs = new Map([
+      ['tab-a', 1],
+      ['tab-b', 2]
+    ])
+    const wc1 = mockWebContents(1, 'https://a.com', 'A')
+    const wc2 = mockWebContents(2, 'https://b.com', 'B')
+    webContentsFromIdMock.mockImplementation((id: number) => (id === 1 ? wc1 : wc2))
+    const b = new AgentBrowserBridge(mockBrowserManager(tabs))
+    b.setActiveTab(1)
+    const snapshot = 'x'.repeat(256 * 1024)
+
+    execFileMock.mockImplementation(
+      (_bin: string, args: string[], _opts: unknown, cb: ExecFileCallback) => {
+        if (args.includes('close')) {
+          cb(null, JSON.stringify({ success: true, data: null }), '')
+          return { kill: vi.fn() }
+        }
+        const child = new EventEmitter() as EventEmitter & {
+          stdout: EventEmitter
+          stdin: { on: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+          kill: ReturnType<typeof vi.fn>
+        }
+        child.stdout = new EventEmitter()
+        child.stdin = { on: vi.fn(), end: vi.fn() }
+        child.kill = vi.fn()
+        const output = JSON.stringify({ success: true, data: { snapshot } })
+        queueMicrotask(() => {
+          const exitOffset = 128 * 1024
+          for (let offset = 0; offset < exitOffset; offset += 16 * 1024) {
+            child.stdout.emit('data', Buffer.from(output.slice(offset, offset + 16 * 1024)))
+          }
+          child.emit('exit', 0, null)
+          queueMicrotask(() => {
+            for (let offset = exitOffset; offset < output.length; offset += 16 * 1024) {
+              child.stdout.emit('data', Buffer.from(output.slice(offset, offset + 16 * 1024)))
+            }
+          })
+        })
+        return child
+      }
+    )
+
+    await expect(b.snapshot(undefined, 'tab-b')).resolves.toEqual({
+      browserPageId: 'tab-b',
+      snapshot
+    })
+    const args = execFileMock.mock.calls.at(-1)![1] as string[]
+    expect(args[args.indexOf('--session') + 1]).toBe('orca-tab-tab-b')
   })
 
   it('translates error response to BrowserError', async () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -50,6 +50,7 @@ import type {
 import { assertClipboardTextWriteWithinLimitWithYield } from '../../shared/clipboard-text'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import { iterateBrowserTextInsertionChunks } from './browser-text-insertion'
+import { captureAgentBrowserJsonAtProcessExit } from './agent-browser-windows-json-exit'
 
 // Why: must exceed agent-browser's internal timeouts (goto 30s, wait 60s) so the bridge never kills a command before its own timeout fires.
 const EXEC_TIMEOUT_MS = 90_000
@@ -2660,6 +2661,69 @@ export class AgentBrowserBridge {
     return new Promise<string>((resolve, reject) => {
       const session = this.sessions.get(sessionName)
       let child: ChildProcess | null = null
+      let finished = false
+      let detachWindowsExitCapture = (): void => {}
+      const finish = (error: Error | null, stdout: string, stderr: string): void => {
+        if (finished) {
+          return
+        }
+        finished = true
+        detachWindowsExitCapture()
+        if (session && session.activeProcess === child) {
+          session.activeProcess = null
+        }
+        if (child && this.cancelledProcesses.has(child)) {
+          this.cancelledProcesses.delete(child)
+          reject(new BrowserError('browser_tab_closed', 'Tab was closed while command was running'))
+          return
+        }
+
+        const liveSession = this.sessions.get(sessionName)
+
+        if (error && (error as NodeJS.ErrnoException & { killed?: boolean }).killed) {
+          if (execOptions?.timeoutError) {
+            reject(execOptions.timeoutError)
+            return
+          }
+          if (liveSession) {
+            liveSession.consecutiveTimeouts++
+            if (liveSession.consecutiveTimeouts >= CONSECUTIVE_TIMEOUT_LIMIT) {
+              // Why: 3 consecutive timeouts means the daemon is likely stuck — destroy and recreate
+              this.destroySession(sessionName)
+            }
+          }
+          reject(new BrowserError('browser_error', 'Browser command timed out'))
+          return
+        }
+
+        if (liveSession) {
+          liveSession.consecutiveTimeouts = 0
+        }
+
+        if (error) {
+          // Why: agent-browser exits non-zero on failure but still writes structured JSON to stdout — parse it for the real error.
+          if (stdout) {
+            try {
+              const parsed = JSON.parse(stdout)
+              if (parsed.error) {
+                const code = classifyErrorCode(parsed.error)
+                reject(
+                  this.createCommandError(sessionName, parsed.error, code, session?.webContentsId)
+                )
+                return
+              }
+            } catch {
+              // stdout not valid JSON — fall through to stderr/error.message
+            }
+          }
+          const message = stderr || error.message
+          const code = classifyErrorCode(message)
+          reject(this.createCommandError(sessionName, message, code, session?.webContentsId))
+          return
+        }
+
+        resolve(stdout)
+      }
       child = execFile(
         this.agentBrowserBin,
         args,
@@ -2671,65 +2735,13 @@ export class AgentBrowserBridge {
             ? { ...process.env, ...execOptions.envOverrides }
             : process.env
         },
-        (error, stdout, stderr) => {
-          if (session && session.activeProcess === child) {
-            session.activeProcess = null
-          }
-          if (child && this.cancelledProcesses.has(child)) {
-            this.cancelledProcesses.delete(child)
-            reject(
-              new BrowserError('browser_tab_closed', 'Tab was closed while command was running')
-            )
-            return
-          }
-
-          const liveSession = this.sessions.get(sessionName)
-
-          if (error && (error as NodeJS.ErrnoException & { killed?: boolean }).killed) {
-            if (execOptions?.timeoutError) {
-              reject(execOptions.timeoutError)
-              return
-            }
-            if (liveSession) {
-              liveSession.consecutiveTimeouts++
-              if (liveSession.consecutiveTimeouts >= CONSECUTIVE_TIMEOUT_LIMIT) {
-                // Why: 3 consecutive timeouts means the daemon is likely stuck — destroy and recreate
-                this.destroySession(sessionName)
-              }
-            }
-            reject(new BrowserError('browser_error', 'Browser command timed out'))
-            return
-          }
-
-          if (liveSession) {
-            liveSession.consecutiveTimeouts = 0
-          }
-
-          if (error) {
-            // Why: agent-browser exits non-zero on failure but still writes structured JSON to stdout — parse it for the real error.
-            if (stdout) {
-              try {
-                const parsed = JSON.parse(stdout)
-                if (parsed.error) {
-                  const code = classifyErrorCode(parsed.error)
-                  reject(
-                    this.createCommandError(sessionName, parsed.error, code, session?.webContentsId)
-                  )
-                  return
-                }
-              } catch {
-                // stdout not valid JSON — fall through to stderr/error.message
-              }
-            }
-            const message = stderr || error.message
-            const code = classifyErrorCode(message)
-            reject(this.createCommandError(sessionName, message, code, session?.webContentsId))
-            return
-          }
-
-          resolve(stdout)
-        }
+        finish
       )
+      if (!finished) {
+        detachWindowsExitCapture = captureAgentBrowserJsonAtProcessExit(child, (stdout) => {
+          finish(null, stdout, '')
+        })
+      }
       if (session) {
         session.activeProcess = child
       }

--- a/src/main/browser/agent-browser-windows-json-exit.ts
+++ b/src/main/browser/agent-browser-windows-json-exit.ts
@@ -1,0 +1,76 @@
+import type { ChildProcess } from 'node:child_process'
+import { platform } from 'node:os'
+
+const MAX_CAPTURE_BYTES = 50 * 1024 * 1024
+
+// Windows daemons can inherit stdout, preventing execFile's close callback after the command exits.
+export function captureAgentBrowserJsonAtProcessExit(
+  child: ChildProcess,
+  onComplete: (stdout: string) => void
+): () => void {
+  if (platform() !== 'win32' || !child.stdout) {
+    return () => {}
+  }
+
+  const chunks: Buffer[] = []
+  let bytes = 0
+  let exited = false
+  let detached = false
+  let pendingCheck: NodeJS.Immediate | null = null
+
+  const detach = (): void => {
+    if (detached) {
+      return
+    }
+    detached = true
+    if (pendingCheck) {
+      clearImmediate(pendingCheck)
+      pendingCheck = null
+    }
+    child.stdout?.off('data', onData)
+    child.off('exit', onExit)
+  }
+
+  const checkComplete = (): void => {
+    pendingCheck = null
+    if (!exited || detached) {
+      return
+    }
+    const stdout = Buffer.concat(chunks, bytes).toString('utf8')
+    try {
+      JSON.parse(stdout)
+    } catch {
+      return
+    }
+    detach()
+    onComplete(stdout)
+  }
+
+  const scheduleCheck = (): void => {
+    if (!pendingCheck && !detached) {
+      pendingCheck = setImmediate(checkComplete)
+    }
+  }
+
+  function onData(chunk: Buffer | string): void {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    bytes += buffer.byteLength
+    if (bytes > MAX_CAPTURE_BYTES) {
+      detach()
+      return
+    }
+    chunks.push(buffer)
+    if (exited) {
+      scheduleCheck()
+    }
+  }
+
+  function onExit(): void {
+    exited = true
+    scheduleCheck()
+  }
+
+  child.stdout.on('data', onData)
+  child.once('exit', onExit)
+  return detach
+}


### PR DESCRIPTION
## Summary

- finish Windows bundled helper commands once complete JSON is available after the command process exits
- preserve the existing output bound and callback-based error handling on other platforms
- cover explicit page-session routing with a 256 KiB response split across process exit without a stdout close event

## Root cause

When a newly routed browser page starts an `agent-browser` daemon on Windows, the daemon can inherit the short-lived command process's piped stdout handle. Node's `execFile` callback waits for that handle to close even though the command has exited and already emitted complete JSON. The local runtime named pipe then reaches its 30-second idle timeout and closes before the CLI receives a response. A direct helper call succeeds because the page daemon is already running.

## Impact

Typed browser commands such as snapshot and screenshot now complete for newly routed Windows page sessions instead of timing out. macOS and Linux retain the existing `execFile` completion path.

## Validation

- `vitest`: 168 passed, 2 platform-skipped across browser bridge, runtime browser/RPC, CLI browser, and local transport suites
- `typecheck:node`
- `typecheck:cli`
- formatting check for changed files
- standard, type-aware, and React Doctor lint scans for changed files
- max-lines ratchet