### PR TITLE
feat(mobile): support physical terminal keyboard input (#10148 review fixes)

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -117,9 +117,7 @@ import { createTerminalLiveAccessoryInput } from '../../../../src/terminal/termi
 import { getTerminalLiveAccessoryRawSendTarget } from '../../../../src/terminal/terminal-live-accessory-raw-send-target'
 import {
   clearTerminalLiveInputFocusTimer,
-  focusTerminalLiveInputTarget,
-  isTerminalLiveInputWithinByteLimit,
-  scheduleTerminalLiveInputFocus
+  isTerminalLiveInputWithinByteLimit
 } from '../../../../src/terminal/terminal-live-input'
 import { dismissTerminalKeyboard } from '../../../../src/terminal/terminal-keyboard-dismiss'
 import type { TerminalLiveInputSender } from '../../../../src/terminal/terminal-live-input-sender'
@@ -127,10 +125,9 @@ import { isTerminalSendRpcAccepted } from '../../../../src/terminal/terminal-sen
 import { sendMobileTerminalQueryReply } from '../../../../src/terminal/mobile-terminal-query-reply'
 import { TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY } from '../../../../../src/shared/protocol-version'
 import { useTerminalLiveInputCommit } from '../../../../src/terminal/use-terminal-live-input-commit'
-import {
-  getTerminalCommandKeyboardType,
-  getTerminalLiveInputKeyboardType
-} from '../../../../src/terminal/terminal-keyboard-type'
+import { useTerminalLiveHardwareKeyboard } from '../../../../src/terminal/use-terminal-live-hardware-keyboard'
+import { MobileTerminalLiveInputBar } from '../../../../src/session/MobileTerminalLiveInputBar'
+import { getTerminalCommandKeyboardType } from '../../../../src/terminal/terminal-keyboard-type'
 import { normalizeTerminalTextInput } from '../../../../src/terminal/terminal-text-input-normalization'
 import {
   appendBufferedDictation,
@@ -186,7 +183,6 @@ import { useMobileSessionImageAttachments } from '../../../../src/session/use-mo
 import { useMobileAttachmentInputLeaseGate } from '../../../../src/session/use-mobile-attachment-input-lease-gate'
 import { useMobileTerminalPaste } from '../../../../src/session/use-mobile-terminal-paste'
 import { useTerminalLiveInputModePreference } from '../../../../src/session/use-terminal-live-input-mode-preference'
-import { MobileTerminalLiveInputStatus } from '../../../../src/session/MobileTerminalLiveInputStatus'
 import { MobileTerminalInputActions } from '../../../../src/session/MobileTerminalInputActions'
 import { resolveMobileFileTabDoc } from '../../../../src/files/mobile-file-tab-doc'
 import { captureMobileFileMutationOwnership } from '../../../../src/files/mobile-file-mutation-ownership'
@@ -1051,6 +1047,7 @@ export default function SessionScreen() {
     flushPendingLiveInputBeforeExternalSend,
     handleLiveInputAccessoryBytes,
     handleLiveInputChange,
+    handleLiveInputHardwareKey,
     handleLiveInputKeyPress,
     handleLiveInputSubmit
   } = useTerminalLiveInputCommit({
@@ -1071,6 +1068,37 @@ export default function SessionScreen() {
     activeSessionTab?.type !== 'file' &&
     activeSessionTab?.type !== 'browser'
   const liveInputEnabled = activeHandle ? liveInputTerminalHandles.has(activeHandle) : false
+  const hardwareKeyboardModalOpen =
+    showHeaderMoreActions ||
+    showQuickCommands ||
+    showCreateTabDrawer ||
+    pendingDiffNotesDelivery != null ||
+    actionTarget != null ||
+    markdownActionTarget != null ||
+    fileActionTarget != null ||
+    browserActionTarget != null ||
+    leaveDrafts != null ||
+    discardMarkdownTarget != null ||
+    renameTarget != null ||
+    showCreateBrowserModal ||
+    showCustomKeyModal ||
+    showDictationSetup ||
+    deleteKeyTarget != null
+  const {
+    showSoftInputOnFocus,
+    hardwareCaptureEnabled,
+    requestSoftKeyboardFocus,
+    clearSoftKeyboardRequest,
+    onHardwareKey
+  } = useTerminalLiveHardwareKeyboard({
+    focusScopeKey: activeHandle,
+    liveInputEnabled,
+    canSend,
+    liveInputRef,
+    liveInputFocusTimerRef,
+    modalOpen: hardwareKeyboardModalOpen,
+    handleLiveInputHardwareKey
+  })
   const [browserScreencastSupported, setBrowserScreencastSupported] = useState<boolean | null>(null)
   // Why: hosts without aiVault.v1 reject listSessions, so hide the header entry instead of a dead-end "update this host" panel.
   const [agentSessionHistorySupported, setAgentSessionHistorySupported] = useState<boolean | null>(
@@ -2559,6 +2587,7 @@ export default function SessionScreen() {
     const onHide = () => {
       notifyKeyboardVisibility(false)
       setKeyboardHeight(0)
+      clearSoftKeyboardRequest()
     }
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow'
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide'
@@ -2568,7 +2597,7 @@ export default function SessionScreen() {
       showSub.remove()
       hideSub.remove()
     }
-  }, [notifyKeyboardVisibility])
+  }, [clearSoftKeyboardRequest, notifyKeyboardVisibility])
 
   const scrollActiveTabIntoView = useCallback((tabId: string | null, animated: boolean) => {
     if (!tabId) {
@@ -3090,12 +3119,9 @@ export default function SessionScreen() {
     if (!canSend || !liveInputEnabled) {
       return
     }
-    focusTerminalLiveInputTarget(liveInputRef.current, {
-      keyboardHeight,
-      refocus: () =>
-        scheduleTerminalLiveInputFocus(liveInputFocusTimerRef, () => liveInputRef.current?.focus())
-    })
-  }, [canSend, keyboardHeight, liveInputEnabled])
+    // Why: defer focus until showSoftInputOnFocus commits; immediate focus races the latch.
+    requestSoftKeyboardFocus()
+  }, [canSend, liveInputEnabled, requestSoftKeyboardFocus])
 
   const clearSessionTabActionSheetKeyboardListener = useCallback(() => {
     sessionTabActionSheetKeyboardHideSubRef.current?.remove()
@@ -3127,6 +3153,7 @@ export default function SessionScreen() {
       sessionTabActionSheetRequestSeqRef.current += 1
       const requestSeq = sessionTabActionSheetRequestSeqRef.current
       clearSessionTabActionSheetKeyboardListener()
+      clearSoftKeyboardRequest()
       let didOpen = false
       const openAfterDismiss = () => {
         if (didOpen || requestSeq !== sessionTabActionSheetRequestSeqRef.current) {
@@ -3156,6 +3183,7 @@ export default function SessionScreen() {
     },
     [
       clearSessionTabActionSheetKeyboardListener,
+      clearSoftKeyboardRequest,
       keyboardHeight,
       openSessionTabActionSheet,
       scheduleDelayedAction
@@ -3163,13 +3191,14 @@ export default function SessionScreen() {
   )
 
   const dismissSoftwareKeyboard = useCallback(() => {
+    clearSoftKeyboardRequest()
     dismissTerminalKeyboard({
       clearPendingLiveInputFocus: () => clearTerminalLiveInputFocusTimer(liveInputFocusTimerRef),
       commandInput: commandInputRef.current,
       dismissKeyboard: () => Keyboard.dismiss(),
       liveInput: liveInputRef.current
     })
-  }, [])
+  }, [clearSoftKeyboardRequest])
 
   const handleTerminalTap = useCallback(
     (handle: string) => {
@@ -3282,12 +3311,19 @@ export default function SessionScreen() {
     const nextEnabled = toggleTerminalLiveInput(activeHandle)
     clearPendingLiveInputCommit()
     if (nextEnabled) {
-      scheduleTerminalLiveInputFocus(liveInputFocusTimerRef, () => liveInputRef.current?.focus())
+      requestSoftKeyboardFocus()
     } else {
+      clearSoftKeyboardRequest()
       clearTerminalLiveInputFocusTimer(liveInputFocusTimerRef)
       liveInputRef.current?.blur()
     }
-  }, [activeHandle, clearPendingLiveInputCommit, toggleTerminalLiveInput])
+  }, [
+    activeHandle,
+    clearPendingLiveInputCommit,
+    clearSoftKeyboardRequest,
+    requestSoftKeyboardFocus,
+    toggleTerminalLiveInput
+  ])
 
   const allowTerminalGestureInput = useCallback(
     (handle: string, sequenceCount: number): boolean => {
@@ -4974,62 +5010,28 @@ export default function SessionScreen() {
 
                 {/* Input bar */}
                 {liveInputEnabled ? (
-                  <View style={[styles.inputBar, styles.liveInputBar]}>
-                    <Pressable
-                      style={({ pressed }) => [
-                        styles.liveInputFocusTarget,
-                        pressed && styles.liveInputFocusTargetPressed,
-                        !canSend && styles.liveInputFocusTargetDisabled
-                      ]}
-                      disabled={!canSend}
-                      onPress={focusLiveInput}
-                      accessibilityRole="button"
-                      accessibilityLabel="Show keyboard for live terminal input"
-                      accessibilityHint="Typed text is sent directly to the active terminal"
-                    >
-                      <KeyboardIcon size={16} color={colors.textSecondary} strokeWidth={2} />
-                      <MobileTerminalLiveInputStatus
-                        dictation={dictation}
-                        isAttaching={isAttaching}
-                      />
-                    </Pressable>
-                    <MobileTerminalInputActions
-                      canSend={canSend}
-                      isAttaching={isAttaching}
-                      dictation={dictation}
-                      dictationMode={dictationMode}
-                      buttonStyle={styles.dictationButton}
-                      activeButtonStyle={styles.dictationButtonActive}
-                      disabledButtonStyle={styles.sendButtonDisabled}
-                      onAttachImage={() => void attachImage('library')}
-                      onAttachFile={() => void attachImage('files')}
-                      onDictationToggle={handleDictationToggle}
-                      onDictationPressIn={handleDictationPressIn}
-                      onDictationPressOut={handleDictationPressOut}
-                      onDictationCancel={cancelDictation}
-                    />
-                    <TextInput
-                      ref={liveInputRef}
-                      style={styles.liveInputCapture}
-                      value={liveInputCapture}
-                      onChangeText={handleLiveInputChange}
-                      onKeyPress={handleLiveInputKeyPress}
-                      onSubmitEditing={handleLiveInputSubmit}
-                      placeholder=""
-                      showSoftInputOnFocus
-                      autoCapitalize="none"
-                      autoCorrect={false}
-                      spellCheck={false}
-                      smartInsertDelete={false}
-                      // Why: iOS textContentType overrides autoComplete and can narrow the keyboard; keep IME switching available.
-                      autoComplete="off"
-                      keyboardType={getTerminalLiveInputKeyboardType(Platform.OS)}
-                      returnKeyType="default"
-                      blurOnSubmit={false}
-                      editable={canSend}
-                      importantForAutofill="no"
-                    />
-                  </View>
+                  <MobileTerminalLiveInputBar
+                    canSend={canSend}
+                    liveInputCapture={liveInputCapture}
+                    liveInputRef={liveInputRef}
+                    hardwareCaptureEnabled={hardwareCaptureEnabled}
+                    showSoftInputOnFocus={showSoftInputOnFocus}
+                    isAttaching={isAttaching}
+                    dictation={dictation}
+                    dictationMode={dictationMode}
+                    styles={styles}
+                    onFocusPress={focusLiveInput}
+                    onChangeText={handleLiveInputChange}
+                    onKeyPress={handleLiveInputKeyPress}
+                    onSubmitEditing={handleLiveInputSubmit}
+                    onHardwareKey={onHardwareKey}
+                    onAttachImage={() => void attachImage('library')}
+                    onAttachFile={() => void attachImage('files')}
+                    onDictationToggle={handleDictationToggle}
+                    onDictationPressIn={handleDictationPressIn}
+                    onDictationPressOut={handleDictationPressOut}
+                    onDictationCancel={cancelDictation}
+                  />
                 ) : (
                   <View style={styles.inputBar}>
                     <TextInput

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@noble/hashes": "1.8.0",
+    "@orca/expo-hardware-keyboard": "file:./packages/expo-hardware-keyboard",
     "@orca/expo-two-way-audio": "file:./packages/expo-two-way-audio",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@xterm/addon-unicode11": "0.10.0-beta.285",

--- a/mobile/packages/expo-hardware-keyboard/android/build.gradle
+++ b/mobile/packages/expo-hardware-keyboard/android/build.gradle
@@ -1,0 +1,19 @@
+apply plugin: 'com.android.library'
+
+group = 'expo.modules.hardwarekeyboard'
+version = '0.0.1'
+
+def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+apply from: expoModulesCorePlugin
+applyKotlinExpoModulesCorePlugin()
+useCoreDependencies()
+useExpoPublishing()
+useDefaultAndroidSdkVersions()
+
+android {
+  namespace "expo.modules.hardwarekeyboard"
+  defaultConfig {
+    versionCode 1
+    versionName "0.0.1"
+  }
+}

--- a/mobile/packages/expo-hardware-keyboard/android/src/main/AndroidManifest.xml
+++ b/mobile/packages/expo-hardware-keyboard/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/mobile/packages/expo-hardware-keyboard/android/src/main/java/expo/modules/hardwarekeyboard/ExpoHardwareKeyboardModule.kt
+++ b/mobile/packages/expo-hardware-keyboard/android/src/main/java/expo/modules/hardwarekeyboard/ExpoHardwareKeyboardModule.kt
@@ -1,0 +1,18 @@
+package expo.modules.hardwarekeyboard
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class ExpoHardwareKeyboardModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("ExpoHardwareKeyboard")
+
+    View(HardwareKeyboardCaptureView::class) {
+      Events("onHardwareKey")
+
+      Prop("enabled") { view: HardwareKeyboardCaptureView, enabled: Boolean ->
+        view.captureEnabled = enabled
+      }
+    }
+  }
+}

--- a/mobile/packages/expo-hardware-keyboard/android/src/main/java/expo/modules/hardwarekeyboard/HardwareKeyboardCaptureView.kt
+++ b/mobile/packages/expo-hardware-keyboard/android/src/main/java/expo/modules/hardwarekeyboard/HardwareKeyboardCaptureView.kt
@@ -78,9 +78,13 @@ class HardwareKeyboardCaptureView(context: Context, appContext: AppContext) :
     return true
   }
 
+  // Shift and Caps Lock change case but do not indicate alternate-layout text.
   private fun producesAlternateLayoutText(event: KeyEvent): Boolean {
-    val metaWithoutCtrl = event.metaState and KeyEvent.META_CTRL_MASK.inv()
-    val alternateCharacter = event.getUnicodeChar(metaWithoutCtrl)
+    val altOnly = event.metaState and KeyEvent.META_ALT_MASK
+    if (altOnly == 0) {
+      return false
+    }
+    val alternateCharacter = event.getUnicodeChar(altOnly)
     val unmodifiedCharacter = event.getUnicodeChar(0)
     return alternateCharacter != 0 && alternateCharacter != unmodifiedCharacter
   }

--- a/mobile/packages/expo-hardware-keyboard/android/src/main/java/expo/modules/hardwarekeyboard/HardwareKeyboardCaptureView.kt
+++ b/mobile/packages/expo-hardware-keyboard/android/src/main/java/expo/modules/hardwarekeyboard/HardwareKeyboardCaptureView.kt
@@ -1,0 +1,132 @@
+package expo.modules.hardwarekeyboard
+
+import android.content.Context
+import android.view.KeyEvent
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.ExpoView
+
+/**
+ * ViewGroup host for the RN TextInput. Intercepts terminal special keys and
+ * Ctrl-modified printable keys on ACTION_DOWN; leaves plain/Shift printable,
+ * Enter (onSubmitEditing), Ctrl+Space (IME switch), and Meta/system shortcuts
+ * to TextInput / the system.
+ */
+class HardwareKeyboardCaptureView(context: Context, appContext: AppContext) :
+  ExpoView(context, appContext) {
+
+  private val onHardwareKey by EventDispatcher()
+
+  var captureEnabled: Boolean = true
+
+  override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+    if (!captureEnabled || event.action != KeyEvent.ACTION_DOWN) {
+      return super.dispatchKeyEvent(event)
+    }
+
+    val meta = event.metaState
+    val hasMeta = (meta and KeyEvent.META_META_ON) != 0
+    // Why: Meta stays system-owned so Cmd/Win shortcuts are not stolen.
+    if (hasMeta) {
+      return super.dispatchKeyEvent(event)
+    }
+
+    val ctrl = (meta and KeyEvent.META_CTRL_ON) != 0
+    val alt = (meta and KeyEvent.META_ALT_ON) != 0
+    val shift = (meta and KeyEvent.META_SHIFT_ON) != 0
+    val repeat = event.repeatCount > 0
+
+    // Why: Enter is owned by TextInput onSubmitEditing (same as TS mapper ignore).
+    if (
+      event.keyCode == KeyEvent.KEYCODE_ENTER ||
+      event.keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER
+    ) {
+      return super.dispatchKeyEvent(event)
+    }
+
+    // Why: Ctrl+Space switches input methods; must not become terminal NUL.
+    if (ctrl && event.keyCode == KeyEvent.KEYCODE_SPACE) {
+      return super.dispatchKeyEvent(event)
+    }
+
+    val key = canonicalKey(event) ?: return super.dispatchKeyEvent(event)
+    val isSpecial = isTerminalSpecialKey(key)
+    val isAlternateLayoutPrintable =
+      key.length == 1 &&
+        ((meta and KeyEvent.META_ALT_RIGHT_ON) != 0 || producesAlternateLayoutText(event))
+    // Why: AltGr and layout-specific Alt characters belong to TextInput even
+    // when a keyboard reports AltGr as synthesized Ctrl+Alt.
+    val isCtrlPrintable =
+      ctrl && !isAlternateLayoutPrintable && key.length == 1 && key[0] in '!'..'~'
+
+    if (!isSpecial && !isCtrlPrintable) {
+      return super.dispatchKeyEvent(event)
+    }
+
+    onHardwareKey(
+      mapOf(
+        "key" to key,
+        "modifiers" to mapOf(
+          "ctrl" to ctrl,
+          "alt" to alt,
+          "shift" to shift,
+          "meta" to false
+        ),
+        "repeat" to repeat
+      )
+    )
+    return true
+  }
+
+  private fun producesAlternateLayoutText(event: KeyEvent): Boolean {
+    val metaWithoutCtrl = event.metaState and KeyEvent.META_CTRL_MASK.inv()
+    val alternateCharacter = event.getUnicodeChar(metaWithoutCtrl)
+    val unmodifiedCharacter = event.getUnicodeChar(0)
+    return alternateCharacter != 0 && alternateCharacter != unmodifiedCharacter
+  }
+
+  private fun canonicalKey(event: KeyEvent): String? {
+    return when (event.keyCode) {
+      KeyEvent.KEYCODE_DPAD_UP -> "ArrowUp"
+      KeyEvent.KEYCODE_DPAD_DOWN -> "ArrowDown"
+      KeyEvent.KEYCODE_DPAD_LEFT -> "ArrowLeft"
+      KeyEvent.KEYCODE_DPAD_RIGHT -> "ArrowRight"
+      KeyEvent.KEYCODE_ESCAPE -> "Escape"
+      KeyEvent.KEYCODE_TAB -> "Tab"
+      KeyEvent.KEYCODE_DEL -> "Backspace"
+      KeyEvent.KEYCODE_FORWARD_DEL -> "Delete"
+      KeyEvent.KEYCODE_MOVE_HOME -> "Home"
+      KeyEvent.KEYCODE_MOVE_END -> "End"
+      KeyEvent.KEYCODE_PAGE_UP -> "PageUp"
+      KeyEvent.KEYCODE_PAGE_DOWN -> "PageDown"
+      KeyEvent.KEYCODE_F1 -> "F1"
+      KeyEvent.KEYCODE_F2 -> "F2"
+      KeyEvent.KEYCODE_F3 -> "F3"
+      KeyEvent.KEYCODE_F4 -> "F4"
+      KeyEvent.KEYCODE_F5 -> "F5"
+      KeyEvent.KEYCODE_F6 -> "F6"
+      KeyEvent.KEYCODE_F7 -> "F7"
+      KeyEvent.KEYCODE_F8 -> "F8"
+      KeyEvent.KEYCODE_F9 -> "F9"
+      KeyEvent.KEYCODE_F10 -> "F10"
+      KeyEvent.KEYCODE_F11 -> "F11"
+      KeyEvent.KEYCODE_F12 -> "F12"
+      KeyEvent.KEYCODE_SPACE -> " "
+      else -> {
+        val label = event.displayLabel
+        if (label != '\u0000' && !label.isISOControl()) {
+          label.lowercaseChar().toString()
+        } else {
+          null
+        }
+      }
+    }
+  }
+
+  private fun isTerminalSpecialKey(key: String): Boolean {
+    return key == "ArrowUp" || key == "ArrowDown" || key == "ArrowLeft" || key == "ArrowRight" ||
+      key == "Escape" || key == "Tab" || key == "Backspace" || key == "Delete" ||
+      key == "Home" || key == "End" || key == "PageUp" || key == "PageDown" ||
+      key.startsWith("F")
+  }
+}

--- a/mobile/packages/expo-hardware-keyboard/expo-module.config.json
+++ b/mobile/packages/expo-hardware-keyboard/expo-module.config.json
@@ -1,0 +1,9 @@
+{
+  "platforms": ["ios", "android"],
+  "ios": {
+    "modules": ["ExpoHardwareKeyboardModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.hardwarekeyboard.ExpoHardwareKeyboardModule"]
+  }
+}

--- a/mobile/packages/expo-hardware-keyboard/ios/ExpoHardwareKeyboard.podspec
+++ b/mobile/packages/expo-hardware-keyboard/ios/ExpoHardwareKeyboard.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'ExpoHardwareKeyboard'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = 'https://github.com/stablyai/orca'
+  s.platforms      = { :ios => '15.1' }
+  s.swift_version  = '5.9'
+  s.source         = { git: 'https://github.com/stablyai/orca.git' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+  s.source_files = '**/*.{h,m,mm,swift}'
+end

--- a/mobile/packages/expo-hardware-keyboard/ios/ExpoHardwareKeyboardModule.swift
+++ b/mobile/packages/expo-hardware-keyboard/ios/ExpoHardwareKeyboardModule.swift
@@ -1,0 +1,15 @@
+import ExpoModulesCore
+
+public class ExpoHardwareKeyboardModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExpoHardwareKeyboard")
+
+    View(HardwareKeyboardCaptureView.self) {
+      Events("onHardwareKey")
+
+      Prop("enabled") { (view: HardwareKeyboardCaptureView, enabled: Bool) in
+        view.enabled = enabled
+      }
+    }
+  }
+}

--- a/mobile/packages/expo-hardware-keyboard/ios/HardwareKeyboardCaptureView.swift
+++ b/mobile/packages/expo-hardware-keyboard/ios/HardwareKeyboardCaptureView.swift
@@ -1,0 +1,168 @@
+import ExpoModulesCore
+import UIKit
+
+/**
+ * Hosts the RN TextInput as a child so physical keys stay in the responder chain.
+ * Emits terminal navigation/control keys via UIKeyCommand; leaves Cmd/Meta and
+ * ordinary printable input to the system / TextInput. Does not register
+ * Ctrl+Space (IME switcher) or Enter (onSubmitEditing).
+ */
+public class HardwareKeyboardCaptureView: ExpoView {
+  let onHardwareKey = EventDispatcher()
+  var enabled: Bool = true
+
+  public required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    backgroundColor = .clear
+    isUserInteractionEnabled = true
+  }
+
+  public override var canBecomeFirstResponder: Bool {
+    return enabled
+  }
+
+  public override var keyCommands: [UIKeyCommand]? {
+    guard enabled else {
+      return nil
+    }
+    return Self.buildTerminalKeyCommands(action: #selector(handleKeyCommand(_:)))
+  }
+
+  @objc func handleKeyCommand(_ sender: UIKeyCommand) {
+    guard enabled else {
+      return
+    }
+    // Why: Meta/Command stays system-owned (copy/paste/select-all).
+    if sender.modifierFlags.contains(.command) {
+      return
+    }
+    let input = sender.input ?? ""
+    // Why: never claim Ctrl+Space — system input-method switching.
+    if sender.modifierFlags.contains(.control) && input == " " {
+      return
+    }
+    let key = Self.canonicalKey(fromInput: input)
+    onHardwareKey([
+      "key": key,
+      "modifiers": [
+        "ctrl": sender.modifierFlags.contains(.control),
+        "alt": sender.modifierFlags.contains(.alternate),
+        "shift": sender.modifierFlags.contains(.shift),
+        "meta": false
+      ],
+      "repeat": false
+    ])
+  }
+
+  private static func buildTerminalKeyCommands(action: Selector) -> [UIKeyCommand] {
+    var commands: [UIKeyCommand] = []
+
+    let specials: [String] = [
+      UIKeyCommand.inputUpArrow,
+      UIKeyCommand.inputDownArrow,
+      UIKeyCommand.inputLeftArrow,
+      UIKeyCommand.inputRightArrow,
+      UIKeyCommand.inputEscape,
+      "\t",
+      "\u{8}",
+      "\u{7f}",
+      UIKeyCommand.inputDelete
+    ]
+
+    var homeEndPage: [String] = []
+    if #available(iOS 15.0, *) {
+      homeEndPage = [
+        UIKeyCommand.inputHome,
+        UIKeyCommand.inputEnd,
+        UIKeyCommand.inputPageUp,
+        UIKeyCommand.inputPageDown
+      ]
+    }
+
+    let modifierSets: [UIKeyModifierFlags] = [
+      [],
+      [.shift],
+      [.control],
+      [.alternate],
+      [.shift, .control],
+      [.shift, .alternate],
+      [.control, .alternate],
+      [.shift, .control, .alternate]
+    ]
+
+    for input in specials + homeEndPage {
+      for modifiers in modifierSets where !modifiers.contains(.command) {
+        let command = UIKeyCommand(input: input, modifierFlags: modifiers, action: action)
+        if #available(iOS 15.0, *) {
+          command.wantsPriorityOverSystemBehavior = true
+        }
+        commands.append(command)
+      }
+    }
+
+    // Official function-key inputs (available at this package's iOS 15.1 floor).
+    let fKeys: [String] = [
+      UIKeyCommand.f1, UIKeyCommand.f2, UIKeyCommand.f3, UIKeyCommand.f4,
+      UIKeyCommand.f5, UIKeyCommand.f6, UIKeyCommand.f7, UIKeyCommand.f8,
+      UIKeyCommand.f9, UIKeyCommand.f10, UIKeyCommand.f11, UIKeyCommand.f12
+    ]
+    for input in fKeys {
+      for modifiers in modifierSets where !modifiers.contains(.command) {
+        let command = UIKeyCommand(input: input, modifierFlags: modifiers, action: action)
+        if #available(iOS 15.0, *) {
+          command.wantsPriorityOverSystemBehavior = true
+        }
+        commands.append(command)
+      }
+    }
+
+    // Ctrl + a–z (terminal interrupt/navigation); intentionally omit Ctrl+Space.
+    for scalar in UnicodeScalar("a").value...UnicodeScalar("z").value {
+      let ch = String(UnicodeScalar(scalar)!)
+      let command = UIKeyCommand(input: ch, modifierFlags: .control, action: action)
+      if #available(iOS 15.0, *) {
+        command.wantsPriorityOverSystemBehavior = true
+      }
+      commands.append(command)
+    }
+
+    return commands
+  }
+
+  private static func canonicalKey(fromInput input: String) -> String {
+    switch input {
+    case UIKeyCommand.inputUpArrow: return "ArrowUp"
+    case UIKeyCommand.inputDownArrow: return "ArrowDown"
+    case UIKeyCommand.inputLeftArrow: return "ArrowLeft"
+    case UIKeyCommand.inputRightArrow: return "ArrowRight"
+    case UIKeyCommand.inputEscape: return "Escape"
+    case "\t": return "Tab"
+    case "\u{8}", "\u{7f}": return "Backspace"
+    case UIKeyCommand.inputDelete: return "Delete"
+    case UIKeyCommand.f1: return "F1"
+    case UIKeyCommand.f2: return "F2"
+    case UIKeyCommand.f3: return "F3"
+    case UIKeyCommand.f4: return "F4"
+    case UIKeyCommand.f5: return "F5"
+    case UIKeyCommand.f6: return "F6"
+    case UIKeyCommand.f7: return "F7"
+    case UIKeyCommand.f8: return "F8"
+    case UIKeyCommand.f9: return "F9"
+    case UIKeyCommand.f10: return "F10"
+    case UIKeyCommand.f11: return "F11"
+    case UIKeyCommand.f12: return "F12"
+    default:
+      break
+    }
+    if #available(iOS 15.0, *) {
+      switch input {
+      case UIKeyCommand.inputHome: return "Home"
+      case UIKeyCommand.inputEnd: return "End"
+      case UIKeyCommand.inputPageUp: return "PageUp"
+      case UIKeyCommand.inputPageDown: return "PageDown"
+      default: break
+      }
+    }
+    return input
+  }
+}

--- a/mobile/packages/expo-hardware-keyboard/ios/HardwareKeyboardCaptureView.swift
+++ b/mobile/packages/expo-hardware-keyboard/ios/HardwareKeyboardCaptureView.swift
@@ -21,11 +21,16 @@ public class HardwareKeyboardCaptureView: ExpoView {
     return enabled
   }
 
+  // UIKit re-reads this invariant command set for every key event.
+  private static let terminalKeyCommands: [UIKeyCommand] = buildTerminalKeyCommands(
+    action: #selector(HardwareKeyboardCaptureView.handleKeyCommand(_:))
+  )
+
   public override var keyCommands: [UIKeyCommand]? {
     guard enabled else {
       return nil
     }
-    return Self.buildTerminalKeyCommands(action: #selector(handleKeyCommand(_:)))
+    return Self.terminalKeyCommands
   }
 
   @objc func handleKeyCommand(_ sender: UIKeyCommand) {

--- a/mobile/packages/expo-hardware-keyboard/package.json
+++ b/mobile/packages/expo-hardware-keyboard/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@orca/expo-hardware-keyboard",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Native view capturing physical keyboard events for live terminal input",
+  "keywords": [
+    "expo",
+    "hardware-keyboard",
+    "react-native",
+    "terminal"
+  ],
+  "license": "MIT",
+  "author": "Orca contributors",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "expo-modules-core": "~55.0.25",
+    "typescript": "6.0.3"
+  },
+  "peerDependencies": {
+    "expo": "*",
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/mobile/packages/expo-hardware-keyboard/src/ExpoHardwareKeyboard.types.ts
+++ b/mobile/packages/expo-hardware-keyboard/src/ExpoHardwareKeyboard.types.ts
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react'
+
+export type HardwareKeyboardModifiers = {
+  readonly ctrl: boolean
+  readonly alt: boolean
+  readonly shift: boolean
+  readonly meta: boolean
+}
+
+export type HardwareKeyboardKeyEvent = {
+  readonly key: string
+  readonly modifiers: HardwareKeyboardModifiers
+  readonly repeat: boolean
+}
+
+export type HardwareKeyboardCaptureViewProps = {
+  readonly enabled?: boolean
+  readonly onHardwareKey?: (event: { nativeEvent: HardwareKeyboardKeyEvent }) => void
+  readonly children?: ReactNode
+  readonly style?: unknown
+}

--- a/mobile/packages/expo-hardware-keyboard/src/ExpoHardwareKeyboardModule.ts
+++ b/mobile/packages/expo-hardware-keyboard/src/ExpoHardwareKeyboardModule.ts
@@ -1,0 +1,19 @@
+import { requireNativeViewManager } from 'expo-modules-core'
+import type { ComponentType } from 'react'
+import type { HardwareKeyboardCaptureViewProps } from './ExpoHardwareKeyboard.types'
+
+type NativeCaptureView = ComponentType<HardwareKeyboardCaptureViewProps>
+
+// Why: requireNativeViewManager throws when the native module is absent (web/tests).
+let NativeHardwareKeyboardCaptureView: NativeCaptureView | null = null
+try {
+  NativeHardwareKeyboardCaptureView = requireNativeViewManager(
+    'ExpoHardwareKeyboard'
+  ) as NativeCaptureView
+} catch {
+  NativeHardwareKeyboardCaptureView = null
+}
+
+export function getNativeHardwareKeyboardCaptureView(): NativeCaptureView | null {
+  return NativeHardwareKeyboardCaptureView
+}

--- a/mobile/packages/expo-hardware-keyboard/src/ExpoHardwareKeyboardModule.web.ts
+++ b/mobile/packages/expo-hardware-keyboard/src/ExpoHardwareKeyboardModule.web.ts
@@ -1,0 +1,6 @@
+import type { ComponentType } from 'react'
+import type { HardwareKeyboardCaptureViewProps } from './ExpoHardwareKeyboard.types'
+
+export function getNativeHardwareKeyboardCaptureView(): ComponentType<HardwareKeyboardCaptureViewProps> | null {
+  return null
+}

--- a/mobile/packages/expo-hardware-keyboard/src/HardwareKeyboardCaptureView.tsx
+++ b/mobile/packages/expo-hardware-keyboard/src/HardwareKeyboardCaptureView.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { View, type ViewProps } from 'react-native'
+import { getNativeHardwareKeyboardCaptureView } from './ExpoHardwareKeyboardModule'
+import type { HardwareKeyboardCaptureViewProps } from './ExpoHardwareKeyboard.types'
+
+type Props = HardwareKeyboardCaptureViewProps & ViewProps
+
+const NativeView = getNativeHardwareKeyboardCaptureView()
+
+/**
+ * Wraps the live-terminal TextInput so physical keys enter the native
+ * responder/view chain. Falls back to a plain View on web/tests.
+ */
+export function HardwareKeyboardCaptureView({
+  enabled = true,
+  onHardwareKey,
+  children,
+  style,
+  ...rest
+}: Props): React.JSX.Element {
+  if (!NativeView) {
+    return (
+      <View style={style} {...rest}>
+        {children}
+      </View>
+    )
+  }
+
+  return (
+    <NativeView enabled={enabled} onHardwareKey={onHardwareKey} style={style} {...rest}>
+      {children}
+    </NativeView>
+  )
+}

--- a/mobile/packages/expo-hardware-keyboard/src/index.ts
+++ b/mobile/packages/expo-hardware-keyboard/src/index.ts
@@ -1,0 +1,6 @@
+export { HardwareKeyboardCaptureView } from './HardwareKeyboardCaptureView'
+export type {
+  HardwareKeyboardCaptureViewProps,
+  HardwareKeyboardKeyEvent,
+  HardwareKeyboardModifiers
+} from './ExpoHardwareKeyboard.types'

--- a/mobile/packages/expo-hardware-keyboard/tsconfig.json
+++ b/mobile/packages/expo-hardware-keyboard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
+      '@orca/expo-hardware-keyboard':
+        specifier: file:./packages/expo-hardware-keyboard
+        version: file:packages/expo-hardware-keyboard(expo@55.0.27)(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
       '@orca/expo-two-way-audio':
         specifier: file:./packages/expo-two-way-audio
         version: file:packages/expo-two-way-audio(expo@55.0.27)(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
@@ -1890,6 +1893,13 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@orca/expo-hardware-keyboard@file:packages/expo-hardware-keyboard':
+    resolution: {directory: packages/expo-hardware-keyboard, type: directory}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   '@orca/expo-two-way-audio@file:packages/expo-two-way-audio':
     resolution: {directory: packages/expo-two-way-audio, type: directory}
@@ -8840,6 +8850,12 @@ snapshots:
     optional: true
 
   '@noble/hashes@1.8.0': {}
+
+  '@orca/expo-hardware-keyboard@file:packages/expo-hardware-keyboard(expo@55.0.27)(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      expo: 55.0.27(@babel/core@7.29.7)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.14)(react-dom@19.2.6(react@19.2.6))(react-native-webview@13.16.1(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6))(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      react: 19.2.6
+      react-native: 0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6)
 
   '@orca/expo-two-way-audio@file:packages/expo-two-way-audio(expo@55.0.27)(react-native@0.83.9(@babel/core@7.29.7)(@react-native/metro-config@0.85.2(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)':
     dependencies:

--- a/mobile/src/session/MobileTerminalLiveInputBar.tsx
+++ b/mobile/src/session/MobileTerminalLiveInputBar.tsx
@@ -1,0 +1,133 @@
+import type { RefObject } from 'react'
+import { Platform, Pressable, TextInput, View, type StyleProp, type ViewStyle } from 'react-native'
+import { Keyboard as KeyboardIcon } from 'lucide-react-native'
+import { HardwareKeyboardCaptureView } from '@orca/expo-hardware-keyboard'
+import { getTerminalLiveInputKeyboardType } from '../terminal/terminal-keyboard-type'
+import type { TerminalLiveHardwareKeyEvent } from '../terminal/terminal-live-hardware-key-mapping'
+import { colors } from '../theme/mobile-theme'
+import { MobileTerminalLiveInputStatus } from './MobileTerminalLiveInputStatus'
+import { MobileTerminalInputActions } from './MobileTerminalInputActions'
+
+type DictationState = {
+  readonly isStarting: boolean
+  readonly isRecording: boolean
+  readonly isProcessing: boolean
+}
+
+type Props = {
+  readonly canSend: boolean
+  readonly liveInputCapture: string
+  readonly liveInputRef: RefObject<TextInput | null>
+  readonly hardwareCaptureEnabled: boolean
+  readonly showSoftInputOnFocus: boolean
+  readonly isAttaching: boolean
+  readonly dictation: DictationState
+  readonly dictationMode: 'toggle' | 'hold'
+  readonly styles: {
+    readonly inputBar: StyleProp<ViewStyle>
+    readonly liveInputBar: StyleProp<ViewStyle>
+    readonly liveInputFocusTarget: StyleProp<ViewStyle>
+    readonly liveInputFocusTargetPressed: StyleProp<ViewStyle>
+    readonly liveInputFocusTargetDisabled: StyleProp<ViewStyle>
+    readonly liveInputCapture: StyleProp<ViewStyle>
+    readonly dictationButton: StyleProp<ViewStyle>
+    readonly dictationButtonActive: StyleProp<ViewStyle>
+    readonly sendButtonDisabled: StyleProp<ViewStyle>
+  }
+  readonly onFocusPress: () => void
+  readonly onChangeText: (text: string) => void
+  readonly onKeyPress: (event: { nativeEvent: { key: string } }) => void
+  readonly onSubmitEditing: () => void
+  readonly onHardwareKey: (event: { nativeEvent: TerminalLiveHardwareKeyEvent }) => void
+  readonly onAttachImage: () => void
+  readonly onAttachFile: () => void
+  readonly onDictationToggle: () => void
+  readonly onDictationPressIn: () => void
+  readonly onDictationPressOut: () => void
+  readonly onDictationCancel: () => void
+}
+
+export function MobileTerminalLiveInputBar({
+  canSend,
+  liveInputCapture,
+  liveInputRef,
+  hardwareCaptureEnabled,
+  showSoftInputOnFocus,
+  isAttaching,
+  dictation,
+  dictationMode,
+  styles,
+  onFocusPress,
+  onChangeText,
+  onKeyPress,
+  onSubmitEditing,
+  onHardwareKey,
+  onAttachImage,
+  onAttachFile,
+  onDictationToggle,
+  onDictationPressIn,
+  onDictationPressOut,
+  onDictationCancel
+}: Props): React.JSX.Element {
+  return (
+    <View style={[styles.inputBar, styles.liveInputBar]}>
+      <Pressable
+        style={({ pressed }) => [
+          styles.liveInputFocusTarget,
+          pressed && styles.liveInputFocusTargetPressed,
+          !canSend && styles.liveInputFocusTargetDisabled
+        ]}
+        disabled={!canSend}
+        onPress={onFocusPress}
+        accessibilityRole="button"
+        accessibilityLabel="Show keyboard for live terminal input"
+        accessibilityHint="Typed text is sent directly to the active terminal"
+      >
+        <KeyboardIcon size={16} color={colors.textSecondary} strokeWidth={2} />
+        <MobileTerminalLiveInputStatus dictation={dictation} isAttaching={isAttaching} />
+      </Pressable>
+      <MobileTerminalInputActions
+        canSend={canSend}
+        isAttaching={isAttaching}
+        dictation={dictation}
+        dictationMode={dictationMode}
+        buttonStyle={styles.dictationButton}
+        activeButtonStyle={styles.dictationButtonActive}
+        disabledButtonStyle={styles.sendButtonDisabled}
+        onAttachImage={onAttachImage}
+        onAttachFile={onAttachFile}
+        onDictationToggle={onDictationToggle}
+        onDictationPressIn={onDictationPressIn}
+        onDictationPressOut={onDictationPressOut}
+        onDictationCancel={onDictationCancel}
+      />
+      <HardwareKeyboardCaptureView
+        enabled={hardwareCaptureEnabled}
+        onHardwareKey={onHardwareKey}
+        style={styles.liveInputCapture}
+      >
+        <TextInput
+          ref={liveInputRef}
+          style={styles.liveInputCapture}
+          value={liveInputCapture}
+          onChangeText={onChangeText}
+          onKeyPress={onKeyPress}
+          onSubmitEditing={onSubmitEditing}
+          placeholder=""
+          showSoftInputOnFocus={showSoftInputOnFocus}
+          autoCapitalize="none"
+          autoCorrect={false}
+          spellCheck={false}
+          smartInsertDelete={false}
+          // Why: iOS textContentType overrides autoComplete and can narrow the keyboard.
+          autoComplete="off"
+          keyboardType={getTerminalLiveInputKeyboardType(Platform.OS)}
+          returnKeyType="default"
+          blurOnSubmit={false}
+          editable={canSend}
+          importantForAutofill="no"
+        />
+      </HardwareKeyboardCaptureView>
+    </View>
+  )
+}

--- a/mobile/src/terminal/terminal-live-hardware-key-mapping.test.ts
+++ b/mobile/src/terminal/terminal-live-hardware-key-mapping.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest'
+import { mapTerminalLiveHardwareKeyEvent } from './terminal-live-hardware-key-mapping'
+
+describe('terminal live hardware key mapping', () => {
+  it('Given Meta modifiers When mapped Then ignores the event (system-owned)', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'c',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: true },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given plain printable When mapped Then ignores so TextInput owns typing', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'a',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given Shift+printable When mapped Then ignores so TextInput owns typing', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'A',
+          modifiers: { ctrl: false, alt: false, shift: true, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given Option+printable When mapped Then ignores so TextInput owns accented input', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'e',
+          modifiers: { ctrl: false, alt: true, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given ArrowLeft with empty field When mapped Then sends CSI left', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'ArrowLeft',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x1b[D' })
+  })
+
+  it('Given Tab When mapped Then sends tab byte', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Tab',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\t' })
+  })
+
+  it('Given Shift+Tab When mapped Then sends reverse-tab bytes', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Tab',
+          modifiers: { ctrl: false, alt: false, shift: true, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x1b[Z' })
+  })
+
+  it('Given Shift+ArrowLeft When mapped Then preserves the modifier in CSI bytes', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'ArrowLeft',
+          modifiers: { ctrl: false, alt: false, shift: true, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x1b[1;2D' })
+  })
+
+  it('Given Escape When mapped Then sends ESC', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Escape',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x1b' })
+  })
+
+  it('Given F5 When mapped Then sends CSI function sequence', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'F5',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x1b[15~' })
+  })
+
+  it('Given Ctrl+C When mapped Then sends ETX interrupt byte', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'c',
+          modifiers: { ctrl: true, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x03' })
+  })
+
+  it('Given Ctrl+Alt+Space When mapped Then preserves the input-method shortcut', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: ' ',
+          modifiers: { ctrl: true, alt: true, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given Backspace with field text When mapped Then local-edits via accessory backspace', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Backspace',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: 'ab' }
+      )
+    ).toEqual({ kind: 'local-edit', localEdit: 'backspace' })
+  })
+
+  it('Given Backspace with empty field When mapped Then sends DEL', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Backspace',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x7f' })
+  })
+
+  it('Given Enter When mapped Then ignores so submit path owns CR', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Enter',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given Option+ArrowLeft When mapped Then sends alt-modified CSI left', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'ArrowLeft',
+          modifiers: { ctrl: false, alt: true, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x1b[1;3D' })
+  })
+
+  it('Given Tab with held Hangul When mapped Then flushes the field then sends tab', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Tab',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '한', sentText: '' }
+      )
+    ).toEqual({ kind: 'flush-field-then-send', bytes: '\t' })
+  })
+
+  it('Given ArrowLeft after sent text When mapped Then resets the stale field baseline', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'ArrowLeft',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: 'ab' }
+      )
+    ).toEqual({ kind: 'flush-field-then-send', bytes: '\x1b[D' })
+  })
+})

--- a/mobile/src/terminal/terminal-live-hardware-key-mapping.test.ts
+++ b/mobile/src/terminal/terminal-live-hardware-key-mapping.test.ts
@@ -15,6 +15,46 @@ describe('terminal live hardware key mapping', () => {
     ).toEqual({ kind: 'ignore' })
   })
 
+  // A special key proves the Meta guard rather than the printable-key fallback.
+  it('Given Command+ArrowLeft When mapped Then ignores so iPadOS keeps the shortcut', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'ArrowLeft',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: true },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given Command+Shift+ArrowLeft When mapped Then ignores despite terminal modifiers', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'ArrowLeft',
+          modifiers: { ctrl: false, alt: false, shift: true, meta: true },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given Command+Backspace with field text When mapped Then leaves the field to the system', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Backspace',
+          modifiers: { ctrl: false, alt: false, shift: false, meta: true },
+          repeat: false
+        },
+        { heldText: '', sentText: 'ab' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
   it('Given plain printable When mapped Then ignores so TextInput owns typing', () => {
     expect(
       mapTerminalLiveHardwareKeyEvent(
@@ -195,6 +235,59 @@ describe('terminal live hardware key mapping', () => {
         { heldText: '', sentText: '' }
       )
     ).toEqual({ kind: 'ignore' })
+  })
+
+  // Modified Enter proves the explicit guard instead of the byte lookup.
+  it('Given Ctrl+Enter When mapped Then still ignores so submit path owns CR', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Enter',
+          modifiers: { ctrl: true, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given Shift+Enter When mapped Then still ignores so submit path owns CR', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'Enter',
+          modifiers: { ctrl: false, alt: false, shift: true, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'ignore' })
+  })
+
+  it('Given Shift+F5 When mapped Then sends the modified function sequence', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'F5',
+          modifiers: { ctrl: false, alt: false, shift: true, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x1b[15;2~' })
+  })
+
+  it('Given Ctrl+F5 When mapped Then sends the ctrl-modified function sequence', () => {
+    expect(
+      mapTerminalLiveHardwareKeyEvent(
+        {
+          key: 'F5',
+          modifiers: { ctrl: true, alt: false, shift: false, meta: false },
+          repeat: false
+        },
+        { heldText: '', sentText: '' }
+      )
+    ).toEqual({ kind: 'send-bytes', bytes: '\x1b[15;5~' })
   })
 
   it('Given Option+ArrowLeft When mapped Then sends alt-modified CSI left', () => {

--- a/mobile/src/terminal/terminal-live-hardware-key-mapping.ts
+++ b/mobile/src/terminal/terminal-live-hardware-key-mapping.ts
@@ -1,0 +1,212 @@
+import { buildTerminalShortcutKey, type TerminalShortcutModifier } from './terminal-accessory-keys'
+import { getTerminalLiveSpecialKeyDecision } from './terminal-live-text-commit'
+
+export type TerminalLiveHardwareKeyModifiers = {
+  readonly ctrl: boolean
+  readonly alt: boolean
+  readonly shift: boolean
+  readonly meta: boolean
+}
+
+export type TerminalLiveHardwareKeyEvent = {
+  readonly key: string
+  readonly modifiers: TerminalLiveHardwareKeyModifiers
+  readonly repeat: boolean
+}
+
+export type TerminalLiveHardwareKeyDecision =
+  | { readonly kind: 'ignore' }
+  | { readonly kind: 'local-edit'; readonly localEdit: 'backspace' | 'delete' }
+  | { readonly kind: 'send-bytes'; readonly bytes: string }
+  | { readonly kind: 'flush-field-then-send'; readonly bytes: string }
+
+const SPECIAL_DOM_KEYS = new Set([
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Escape',
+  'Esc',
+  'Tab',
+  'Backspace',
+  'Delete',
+  'Home',
+  'End',
+  'PageUp',
+  'PageDown',
+  'Enter',
+  'F1',
+  'F2',
+  'F3',
+  'F4',
+  'F5',
+  'F6',
+  'F7',
+  'F8',
+  'F9',
+  'F10',
+  'F11',
+  'F12'
+])
+
+function isInputMethodSwitcherShortcut(event: TerminalLiveHardwareKeyEvent): boolean {
+  return (
+    event.modifiers.ctrl && (event.key === ' ' || event.key === 'Space' || event.key === 'Spacebar')
+  )
+}
+
+// Meta, Enter, and Ctrl+Space stay system/TextInput-owned; printable Option input
+// must continue through TextInput so accented characters and IMEs keep working.
+export function mapTerminalLiveHardwareKeyEvent(
+  event: TerminalLiveHardwareKeyEvent,
+  options: {
+    readonly heldText: string
+    readonly sentText: string
+  }
+): TerminalLiveHardwareKeyDecision {
+  if (event.modifiers.meta) {
+    return { kind: 'ignore' }
+  }
+
+  if (event.key === 'Enter') {
+    return { kind: 'ignore' }
+  }
+
+  if (isInputMethodSwitcherShortcut(event)) {
+    return { kind: 'ignore' }
+  }
+
+  const key = event.key
+  const isSpecial = SPECIAL_DOM_KEYS.has(key)
+  const isSingleChar = key.length === 1
+  const hasTerminalModifier = event.modifiers.ctrl || event.modifiers.alt || event.modifiers.shift
+
+  if (!isSpecial && isSingleChar && !event.modifiers.ctrl) {
+    return { kind: 'ignore' }
+  }
+
+  if (isSpecial && !hasTerminalModifier && (key === 'Backspace' || key === 'Delete')) {
+    const decision = getTerminalLiveSpecialKeyDecision({
+      key,
+      heldText: options.heldText,
+      sentText: options.sentText
+    })
+    if (decision.kind === 'local-edit') {
+      return {
+        kind: 'local-edit',
+        localEdit: key === 'Backspace' ? 'backspace' : 'delete'
+      }
+    }
+    if (decision.kind === 'send-now') {
+      return getHardwareControlSendDecision(decision.bytes, options)
+    }
+    if (decision.kind === 'commit-held-then-send') {
+      return { kind: 'flush-field-then-send', bytes: decision.bytes }
+    }
+    return { kind: 'ignore' }
+  }
+
+  if (isSpecial && !hasTerminalModifier) {
+    const decision = getTerminalLiveSpecialKeyDecision({
+      key,
+      heldText: options.heldText,
+      sentText: options.sentText
+    })
+    if (decision.kind === 'send-now') {
+      return getHardwareControlSendDecision(decision.bytes, options)
+    }
+    if (decision.kind === 'commit-held-then-send') {
+      return { kind: 'flush-field-then-send', bytes: decision.bytes }
+    }
+    return { kind: 'ignore' }
+  }
+
+  // Ctrl/Alt modified special or printable → accessory key builder.
+  const shortcutKey = toShortcutKeyId(key)
+  if (!shortcutKey) {
+    return { kind: 'ignore' }
+  }
+  const modifiers = toShortcutModifiers(event.modifiers)
+  const built = buildTerminalShortcutKey({ key: shortcutKey, modifiers })
+  if (!built) {
+    return { kind: 'ignore' }
+  }
+  return getHardwareControlSendDecision(built.bytes, options)
+}
+
+// Why: terminal navigation/control invalidates the hidden field's editing
+// baseline; end that mirror session before later printable input resumes.
+function getHardwareControlSendDecision(
+  bytes: string,
+  options: { readonly heldText: string; readonly sentText: string }
+): TerminalLiveHardwareKeyDecision {
+  return options.heldText.length > 0 || options.sentText.length > 0
+    ? { kind: 'flush-field-then-send', bytes }
+    : { kind: 'send-bytes', bytes }
+}
+
+function toShortcutModifiers(
+  modifiers: TerminalLiveHardwareKeyModifiers
+): TerminalShortcutModifier[] {
+  const result: TerminalShortcutModifier[] = []
+  if (modifiers.ctrl) {
+    result.push('ctrl')
+  }
+  if (modifiers.alt) {
+    result.push('alt')
+  }
+  if (modifiers.shift) {
+    result.push('shift')
+  }
+  return result
+}
+
+function toShortcutKeyId(key: string): string | null {
+  switch (key) {
+    case 'ArrowUp':
+      return 'arrowUp'
+    case 'ArrowDown':
+      return 'arrowDown'
+    case 'ArrowLeft':
+      return 'arrowLeft'
+    case 'ArrowRight':
+      return 'arrowRight'
+    case 'Escape':
+    case 'Esc':
+      return 'escape'
+    case 'Tab':
+      return 'tab'
+    case 'Backspace':
+      return 'backspace'
+    case 'Delete':
+      return 'delete'
+    case 'Home':
+      return 'home'
+    case 'End':
+      return 'end'
+    case 'PageUp':
+      return 'pageUp'
+    case 'PageDown':
+      return 'pageDown'
+    case 'Enter':
+      return 'enter'
+    case 'F1':
+    case 'F2':
+    case 'F3':
+    case 'F4':
+    case 'F5':
+    case 'F6':
+    case 'F7':
+    case 'F8':
+    case 'F9':
+    case 'F10':
+    case 'F11':
+    case 'F12':
+      return key.toLowerCase()
+    default:
+      if (key.length === 1) {
+        return key
+      }
+      return null
+  }
+}

--- a/mobile/src/terminal/terminal-live-hardware-key-native-contract.test.ts
+++ b/mobile/src/terminal/terminal-live-hardware-key-native-contract.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const androidSource = readFileSync(
+  new URL(
+    '../../packages/expo-hardware-keyboard/android/src/main/java/expo/modules/hardwarekeyboard/HardwareKeyboardCaptureView.kt',
+    import.meta.url
+  ),
+  'utf8'
+)
+const iosSource = readFileSync(
+  new URL(
+    '../../packages/expo-hardware-keyboard/ios/HardwareKeyboardCaptureView.swift',
+    import.meta.url
+  ),
+  'utf8'
+)
+
+function expectPassThroughBeforeCanonicalKey(guard: string): void {
+  const guardStart = androidSource.indexOf(guard)
+  const canonicalKeyStart = androidSource.indexOf('val key = canonicalKey(event)')
+  expect(guardStart).toBeGreaterThanOrEqual(0)
+  expect(canonicalKeyStart).toBeGreaterThan(guardStart)
+  expect(androidSource.slice(guardStart, canonicalKeyStart)).toContain(
+    'return super.dispatchKeyEvent(event)'
+  )
+}
+
+describe('terminal live hardware key native contract', () => {
+  it('leaves Android Enter on the TextInput submit path', () => {
+    expectPassThroughBeforeCanonicalKey('event.keyCode == KeyEvent.KEYCODE_ENTER')
+  })
+
+  it('leaves every Android Ctrl+Space variant to the input-method switcher', () => {
+    expectPassThroughBeforeCanonicalKey('if (ctrl && event.keyCode == KeyEvent.KEYCODE_SPACE)')
+    expect(androidSource).not.toContain('ctrl && !alt && event.keyCode')
+  })
+
+  it('leaves Android AltGr printable input to TextInput and the active layout', () => {
+    expect(androidSource).toContain('KeyEvent.META_ALT_RIGHT_ON')
+    expect(androidSource).toContain('KeyEvent.META_CTRL_MASK.inv()')
+    expect(androidSource).toContain('event.getUnicodeChar(metaWithoutCtrl)')
+    expect(androidSource).toContain('ctrl && !isAlternateLayoutPrintable')
+  })
+
+  it('uses official iOS function-key inputs and never registers Ctrl+Space', () => {
+    expect(iosSource).toContain('UIKeyCommand.f1')
+    expect(iosSource).toContain('UIKeyCommand.f12')
+    expect(iosSource).not.toContain('UnicodeScalar(0xF704')
+    expect(iosSource).not.toContain('UIKeyCommand(input: " ", modifierFlags: .control')
+  })
+})

--- a/mobile/src/terminal/terminal-live-hardware-key-native-contract.test.ts
+++ b/mobile/src/terminal/terminal-live-hardware-key-native-contract.test.ts
@@ -16,31 +16,57 @@ const iosSource = readFileSync(
   'utf8'
 )
 
-function expectPassThroughBeforeCanonicalKey(guard: string): void {
-  const guardStart = androidSource.indexOf(guard)
-  const canonicalKeyStart = androidSource.indexOf('val key = canonicalKey(event)')
-  expect(guardStart).toBeGreaterThanOrEqual(0)
-  expect(canonicalKeyStart).toBeGreaterThan(guardStart)
-  expect(androidSource.slice(guardStart, canonicalKeyStart)).toContain(
-    'return super.dispatchKeyEvent(event)'
-  )
+// Match each guard with its own body to prevent unrelated pass-throughs from satisfying it.
+function collapse(source: string): string {
+  return source.replace(/\s+/g, ' ')
 }
 
+const android = collapse(androidSource)
+const ios = collapse(iosSource)
+
+const ANDROID_PASS_THROUGH = 'return super.dispatchKeyEvent(event) }'
+
 describe('terminal live hardware key native contract', () => {
+  it('leaves Android Meta shortcuts to the system', () => {
+    expect(android).toContain(`if (hasMeta) { ${ANDROID_PASS_THROUGH}`)
+  })
+
   it('leaves Android Enter on the TextInput submit path', () => {
-    expectPassThroughBeforeCanonicalKey('event.keyCode == KeyEvent.KEYCODE_ENTER')
+    expect(android).toContain(
+      'if ( event.keyCode == KeyEvent.KEYCODE_ENTER || ' +
+        `event.keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER ) { ${ANDROID_PASS_THROUGH}`
+    )
   })
 
   it('leaves every Android Ctrl+Space variant to the input-method switcher', () => {
-    expectPassThroughBeforeCanonicalKey('if (ctrl && event.keyCode == KeyEvent.KEYCODE_SPACE)')
+    expect(android).toContain(
+      `if (ctrl && event.keyCode == KeyEvent.KEYCODE_SPACE) { ${ANDROID_PASS_THROUGH}`
+    )
     expect(androidSource).not.toContain('ctrl && !alt && event.keyCode')
   })
 
   it('leaves Android AltGr printable input to TextInput and the active layout', () => {
     expect(androidSource).toContain('KeyEvent.META_ALT_RIGHT_ON')
-    expect(androidSource).toContain('KeyEvent.META_CTRL_MASK.inv()')
-    expect(androidSource).toContain('event.getUnicodeChar(metaWithoutCtrl)')
     expect(androidSource).toContain('ctrl && !isAlternateLayoutPrintable')
+    expect(androidSource).toContain('event.getUnicodeChar(altOnly)')
+  })
+
+  it('scopes Android alternate-layout detection to Alt so Shift/CapsLock cannot suppress Ctrl', () => {
+    // Full meta-state comparison made Shift/Caps Lock suppress Ctrl+letter.
+    expect(android).toContain('val altOnly = event.metaState and KeyEvent.META_ALT_MASK')
+    expect(android).toContain('if (altOnly == 0) { return false }')
+    expect(androidSource).not.toContain('KeyEvent.META_CTRL_MASK.inv()')
+  })
+
+  it('keeps iOS Command input system-owned', () => {
+    expect(ios).toContain('if sender.modifierFlags.contains(.command) { return }')
+    // Command chords must remain absent from registration and handling.
+    expect(ios).not.toContain('modifierSets: [UIKeyModifierFlags] = [ [.command]')
+    expect(
+      (ios.match(/for modifiers in modifierSets where !modifiers\.contains\(\.command\)/g) ?? [])
+        .length
+    ).toBeGreaterThanOrEqual(2)
+    expect(ios).toContain('"meta": false')
   })
 
   it('uses official iOS function-key inputs and never registers Ctrl+Space', () => {
@@ -48,5 +74,12 @@ describe('terminal live hardware key native contract', () => {
     expect(iosSource).toContain('UIKeyCommand.f12')
     expect(iosSource).not.toContain('UnicodeScalar(0xF704')
     expect(iosSource).not.toContain('UIKeyCommand(input: " ", modifierFlags: .control')
+    // The handler must refuse Ctrl+Space even if UIKit supplies it.
+    expect(ios).toContain('if sender.modifierFlags.contains(.control) && input == " " { return }')
+  })
+
+  it('builds the iOS key-command list once instead of per keystroke', () => {
+    expect(ios).toContain('private static let terminalKeyCommands: [UIKeyCommand]')
+    expect(ios).toContain('return Self.terminalKeyCommands')
   })
 })

--- a/mobile/src/terminal/terminal-live-hardware-keyboard-focus.test.ts
+++ b/mobile/src/terminal/terminal-live-hardware-keyboard-focus.test.ts
@@ -38,6 +38,31 @@ describe('terminal live hardware keyboard focus', () => {
     ).toBe(false)
   })
 
+  // Silent focus would immediately cancel an explicit soft-keyboard request.
+  it('Given an explicit soft-keyboard request When auto-silent checked Then stands down', () => {
+    expect(
+      shouldAutoSilentFocusLiveInput({
+        liveInputEnabled: true,
+        canSend: true,
+        wantSoftKeyboard: true,
+        isFocused: false,
+        modalOpen: false
+      })
+    ).toBe(false)
+  })
+
+  it('Given a terminal that cannot send When auto-silent checked Then stands down', () => {
+    expect(
+      shouldAutoSilentFocusLiveInput({
+        liveInputEnabled: true,
+        canSend: false,
+        wantSoftKeyboard: false,
+        isFocused: false,
+        modalOpen: false
+      })
+    ).toBe(false)
+  })
+
   it('Given unfocused live terminal When auto-silent checked Then focuses silently', () => {
     expect(
       shouldAutoSilentFocusLiveInput({

--- a/mobile/src/terminal/terminal-live-hardware-keyboard-focus.test.ts
+++ b/mobile/src/terminal/terminal-live-hardware-keyboard-focus.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getTerminalLiveHardwareKeyboardFocusDecision,
+  planExplicitSoftKeyboardFocus,
+  shouldAutoSilentFocusLiveInput
+} from './terminal-live-hardware-keyboard-focus'
+
+describe('terminal live hardware keyboard focus', () => {
+  it('Given live input active without soft request When decided Then silent-focus', () => {
+    expect(
+      getTerminalLiveHardwareKeyboardFocusDecision({
+        wantSoftKeyboard: false,
+        liveInputEnabled: true,
+        canSend: true
+      })
+    ).toEqual({ kind: 'silent-focus', showSoftInputOnFocus: false })
+  })
+
+  it('Given explicit soft request When decided Then soft-focus', () => {
+    expect(
+      getTerminalLiveHardwareKeyboardFocusDecision({
+        wantSoftKeyboard: true,
+        liveInputEnabled: true,
+        canSend: true
+      })
+    ).toEqual({ kind: 'soft-focus', showSoftInputOnFocus: true })
+  })
+
+  it('Given modal open When auto-silent checked Then does not steal focus', () => {
+    expect(
+      shouldAutoSilentFocusLiveInput({
+        liveInputEnabled: true,
+        canSend: true,
+        wantSoftKeyboard: false,
+        isFocused: false,
+        modalOpen: true
+      })
+    ).toBe(false)
+  })
+
+  it('Given unfocused live terminal When auto-silent checked Then focuses silently', () => {
+    expect(
+      shouldAutoSilentFocusLiveInput({
+        liveInputEnabled: true,
+        canSend: true,
+        wantSoftKeyboard: false,
+        isFocused: false,
+        modalOpen: false
+      })
+    ).toBe(true)
+  })
+
+  it('Given initially blurred input When soft latch is false Then defers focus until latch', () => {
+    expect(
+      planExplicitSoftKeyboardFocus({ alreadyWantsSoftKeyboard: false, isFocused: false })
+    ).toEqual({ kind: 'defer-until-latch' })
+  })
+
+  it('Given already focused silent field When soft requested Then blur-refocus after latch', () => {
+    expect(
+      planExplicitSoftKeyboardFocus({ alreadyWantsSoftKeyboard: false, isFocused: true })
+    ).toEqual({ kind: 'blur-refocus-after-latch' })
+  })
+
+  it('Given soft latch already true and unfocused When soft requested Then focus now', () => {
+    expect(
+      planExplicitSoftKeyboardFocus({ alreadyWantsSoftKeyboard: true, isFocused: false })
+    ).toEqual({ kind: 'focus-now' })
+  })
+
+  it('Given soft latch already true and focused When soft requested Then forces a responder cycle', () => {
+    expect(
+      planExplicitSoftKeyboardFocus({ alreadyWantsSoftKeyboard: true, isFocused: true })
+    ).toEqual({ kind: 'blur-refocus-after-latch' })
+  })
+})

--- a/mobile/src/terminal/terminal-live-hardware-keyboard-focus.ts
+++ b/mobile/src/terminal/terminal-live-hardware-keyboard-focus.ts
@@ -1,0 +1,63 @@
+/**
+ * Soft-keyboard request latch for live terminal hardware-keyboard focus.
+ * Silent focus keeps the hidden field first-responder without raising the IME;
+ * an explicit tap sets wantSoftKeyboard so the next focus opens the soft keyboard.
+ */
+
+export type TerminalLiveHardwareKeyboardFocusState = {
+  readonly wantSoftKeyboard: boolean
+  readonly liveInputEnabled: boolean
+  readonly canSend: boolean
+}
+
+export type TerminalLiveHardwareKeyboardFocusDecision =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'silent-focus'; readonly showSoftInputOnFocus: false }
+  | { readonly kind: 'soft-focus'; readonly showSoftInputOnFocus: true }
+
+export function getTerminalLiveHardwareKeyboardFocusDecision(
+  state: TerminalLiveHardwareKeyboardFocusState
+): TerminalLiveHardwareKeyboardFocusDecision {
+  if (!state.liveInputEnabled || !state.canSend) {
+    return { kind: 'idle' }
+  }
+  if (state.wantSoftKeyboard) {
+    return { kind: 'soft-focus', showSoftInputOnFocus: true }
+  }
+  return { kind: 'silent-focus', showSoftInputOnFocus: false }
+}
+
+/**
+ * Silent focus when live mode / send capability enables a silent opportunity.
+ * modalOpen is a runtime guard only — callers must NOT re-run silent focus solely
+ * because a modal closed (that would steal focus after action sheets).
+ */
+export function shouldAutoSilentFocusLiveInput(options: {
+  readonly liveInputEnabled: boolean
+  readonly canSend: boolean
+  readonly wantSoftKeyboard: boolean
+  readonly isFocused: boolean
+  readonly modalOpen: boolean
+}): boolean {
+  return (
+    options.liveInputEnabled &&
+    options.canSend &&
+    !options.wantSoftKeyboard &&
+    !options.isFocused &&
+    !options.modalOpen
+  )
+}
+
+// Explicit focus waits for the prop latch; an already focused silent field also
+// needs a fresh responder cycle on platforms where focus() alone is a no-op.
+export function planExplicitSoftKeyboardFocus(options: {
+  readonly alreadyWantsSoftKeyboard: boolean
+  readonly isFocused: boolean
+}): { readonly kind: 'focus-now' | 'defer-until-latch' | 'blur-refocus-after-latch' } {
+  if (!options.alreadyWantsSoftKeyboard) {
+    // Latch was false — set it, wait for re-render, then focus (blur first if needed).
+    return options.isFocused ? { kind: 'blur-refocus-after-latch' } : { kind: 'defer-until-latch' }
+  }
+  // Latch already true — can focus immediately; force IME if already focused silently.
+  return options.isFocused ? { kind: 'blur-refocus-after-latch' } : { kind: 'focus-now' }
+}

--- a/mobile/src/terminal/terminal-live-input-affordance.test.ts
+++ b/mobile/src/terminal/terminal-live-input-affordance.test.ts
@@ -9,6 +9,14 @@ const liveInputStatusSource = readFileSync(
   new URL('../session/MobileTerminalLiveInputStatus.tsx', import.meta.url),
   'utf8'
 )
+const liveInputBarSource = readFileSync(
+  new URL('../session/MobileTerminalLiveInputBar.tsx', import.meta.url),
+  'utf8'
+)
+const hardwareKeyboardHookSource = readFileSync(
+  new URL('./use-terminal-live-hardware-keyboard.ts', import.meta.url),
+  'utf8'
+)
 const commandInputStylesSource = readFileSync(
   new URL('../../app/h/[hostId]/session/mobile-session-command-input-styles.ts', import.meta.url),
   'utf8'
@@ -26,18 +34,22 @@ describe('terminal live input affordance', () => {
   it('keeps the live status row wired as the keyboard focus control', () => {
     const block = liveInputBarBlock()
 
-    expect(block).toContain('onPress={focusLiveInput}')
-    expect(block).toContain('accessibilityRole="button"')
-    expect(block).toContain('accessibilityLabel="Show keyboard for live terminal input"')
-    expect(block).toContain(
+    expect(block).toContain('<MobileTerminalLiveInputBar')
+    expect(block).toContain('onFocusPress={focusLiveInput}')
+    expect(block).toContain('showSoftInputOnFocus={showSoftInputOnFocus}')
+    expect(liveInputBarSource).toContain('accessibilityRole="button"')
+    expect(liveInputBarSource).toContain(
+      'accessibilityLabel="Show keyboard for live terminal input"'
+    )
+    expect(liveInputBarSource).toContain(
       'accessibilityHint="Typed text is sent directly to the active terminal"'
     )
-    expect(block).toContain('pressed && styles.liveInputFocusTargetPressed')
-    expect(block).toContain('!canSend && styles.liveInputFocusTargetDisabled')
-    expect(block).toContain('showSoftInputOnFocus')
-    expect(sessionRouteSource).toContain('focusTerminalLiveInputTarget(liveInputRef.current')
-    expect(sessionRouteSource).toContain('keyboardHeight')
-    expect(sessionRouteSource).toContain('scheduleTerminalLiveInputFocus(liveInputFocusTimerRef')
+    expect(liveInputBarSource).toContain('pressed && styles.liveInputFocusTargetPressed')
+    expect(liveInputBarSource).toContain('!canSend && styles.liveInputFocusTargetDisabled')
+    expect(sessionRouteSource).toContain('requestSoftKeyboardFocus()')
+    expect(hardwareKeyboardHookSource).toContain(
+      'scheduleTerminalLiveInputFocus(liveInputFocusTimerRef'
+    )
   })
 
   it('makes the live keyboard target visible instead of status-only chrome', () => {

--- a/mobile/src/terminal/use-terminal-live-hardware-keyboard.test.ts
+++ b/mobile/src/terminal/use-terminal-live-hardware-keyboard.test.ts
@@ -1,0 +1,202 @@
+import { createElement, type RefObject } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import type { TextInput } from 'react-native'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useTerminalLiveHardwareKeyboard } from './use-terminal-live-hardware-keyboard'
+import type { TerminalLiveInputFocusTimerRef } from './terminal-live-input'
+
+function suppressReactTestRendererDeprecationWarning(): () => void {
+  const originalConsoleError = console.error
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    const firstArg = args[0]
+    if (typeof firstArg === 'string' && firstArg.includes('react-test-renderer is deprecated')) {
+      return
+    }
+    originalConsoleError(...args)
+  })
+  return () => consoleErrorSpy.mockRestore()
+}
+
+describe('useTerminalLiveHardwareKeyboard soft focus latch', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('Given live mode is enabling When soft focus is requested first Then focuses after enabled and latched', async () => {
+    vi.useFakeTimers()
+    const focus = vi.fn()
+    const blur = vi.fn()
+    const isFocused = vi.fn(() => false)
+    const liveInputRef: RefObject<TextInput | null> = {
+      current: { focus, blur, isFocused } as unknown as TextInput
+    }
+    const liveInputFocusTimerRef: TerminalLiveInputFocusTimerRef = { current: null }
+    let api: ReturnType<typeof useTerminalLiveHardwareKeyboard> | null = null
+    let liveInputEnabled = false
+    let renderer: ReactTestRenderer | null = null
+
+    function Harness(): null {
+      api = useTerminalLiveHardwareKeyboard({
+        focusScopeKey: 'terminal-a',
+        liveInputEnabled,
+        canSend: true,
+        liveInputRef,
+        liveInputFocusTimerRef,
+        modalOpen: false,
+        handleLiveInputHardwareKey: () => {}
+      })
+      return null
+    }
+
+    const restore = suppressReactTestRendererDeprecationWarning()
+    try {
+      act(() => {
+        renderer = create(createElement(Harness))
+      })
+    } finally {
+      restore()
+    }
+    if (!api || !renderer) {
+      throw new Error('hardware keyboard hook did not render')
+    }
+
+    expect(api.showSoftInputOnFocus).toBe(false)
+
+    act(() => {
+      api?.requestSoftKeyboardFocus()
+    })
+
+    // The toggle has not re-rendered enabled yet, so the focus remains pending.
+    expect(api.showSoftInputOnFocus).toBe(false)
+    expect(focus).not.toHaveBeenCalled()
+
+    liveInputEnabled = true
+    act(() => renderer?.update(createElement(Harness)))
+
+    // Latch is now active, but focus is deferred until after the prop commits.
+    expect(api.showSoftInputOnFocus).toBe(true)
+    expect(focus).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    expect(focus).toHaveBeenCalled()
+    expect(blur).not.toHaveBeenCalled()
+  })
+
+  it('Given a modal blurred input When it closes Then only a terminal switch restores silent focus', async () => {
+    vi.useFakeTimers()
+    const focus = vi.fn()
+    const liveInputRef: RefObject<TextInput | null> = {
+      current: {
+        focus,
+        blur: vi.fn(),
+        isFocused: vi.fn(() => false)
+      } as unknown as TextInput
+    }
+    const liveInputFocusTimerRef: TerminalLiveInputFocusTimerRef = { current: null }
+    let modalOpen = true
+    let focusScopeKey = 'terminal-a'
+    let api: ReturnType<typeof useTerminalLiveHardwareKeyboard> | null = null
+    let renderer: ReactTestRenderer | null = null
+
+    function Harness(): null {
+      api = useTerminalLiveHardwareKeyboard({
+        focusScopeKey,
+        liveInputEnabled: true,
+        canSend: true,
+        liveInputRef,
+        liveInputFocusTimerRef,
+        modalOpen,
+        handleLiveInputHardwareKey: () => {}
+      })
+      return null
+    }
+
+    const restore = suppressReactTestRendererDeprecationWarning()
+    try {
+      act(() => {
+        renderer = create(createElement(Harness))
+      })
+    } finally {
+      restore()
+    }
+    if (!renderer) {
+      throw new Error('hardware keyboard hook did not render')
+    }
+    expect(api?.hardwareCaptureEnabled).toBe(false)
+
+    modalOpen = false
+    act(() => renderer?.update(createElement(Harness)))
+    await act(async () => vi.runAllTimersAsync())
+    expect(api?.hardwareCaptureEnabled).toBe(true)
+    expect(focus).not.toHaveBeenCalled()
+
+    focusScopeKey = 'terminal-b'
+    act(() => renderer?.update(createElement(Harness)))
+    await act(async () => vi.runAllTimersAsync())
+    expect(focus).toHaveBeenCalledOnce()
+  })
+
+  it('Given native events race a modal or disabled state When received Then JS rejects stale capture', () => {
+    const handleLiveInputHardwareKey = vi.fn()
+    const liveInputRef: RefObject<TextInput | null> = {
+      current: {
+        focus: vi.fn(),
+        blur: vi.fn(),
+        isFocused: vi.fn(() => true)
+      } as unknown as TextInput
+    }
+    const liveInputFocusTimerRef: TerminalLiveInputFocusTimerRef = { current: null }
+    let modalOpen = true
+    let canSend = true
+    let api: ReturnType<typeof useTerminalLiveHardwareKeyboard> | null = null
+    let renderer: ReactTestRenderer | null = null
+
+    function Harness(): null {
+      api = useTerminalLiveHardwareKeyboard({
+        focusScopeKey: 'terminal-a',
+        liveInputEnabled: true,
+        canSend,
+        liveInputRef,
+        liveInputFocusTimerRef,
+        modalOpen,
+        handleLiveInputHardwareKey
+      })
+      return null
+    }
+
+    const restore = suppressReactTestRendererDeprecationWarning()
+    try {
+      act(() => {
+        renderer = create(createElement(Harness))
+      })
+    } finally {
+      restore()
+    }
+    if (!api || !renderer) {
+      throw new Error('hardware keyboard hook did not render')
+    }
+    const event = {
+      nativeEvent: {
+        key: 'ArrowLeft',
+        modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+        repeat: false
+      }
+    }
+
+    api.onHardwareKey(event)
+    expect(handleLiveInputHardwareKey).not.toHaveBeenCalled()
+
+    modalOpen = false
+    act(() => renderer?.update(createElement(Harness)))
+    api.onHardwareKey(event)
+    expect(handleLiveInputHardwareKey).toHaveBeenCalledOnce()
+
+    canSend = false
+    act(() => renderer?.update(createElement(Harness)))
+    api.onHardwareKey(event)
+    expect(handleLiveInputHardwareKey).toHaveBeenCalledOnce()
+  })
+})

--- a/mobile/src/terminal/use-terminal-live-hardware-keyboard.ts
+++ b/mobile/src/terminal/use-terminal-live-hardware-keyboard.ts
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import type { TextInput } from 'react-native'
+import {
+  clearTerminalLiveInputFocusTimer,
+  scheduleTerminalLiveInputFocus,
+  type TerminalLiveInputFocusTimerRef
+} from './terminal-live-input'
+import {
+  getTerminalLiveHardwareKeyboardFocusDecision,
+  planExplicitSoftKeyboardFocus,
+  shouldAutoSilentFocusLiveInput
+} from './terminal-live-hardware-keyboard-focus'
+import type { TerminalLiveHardwareKeyEvent } from './terminal-live-hardware-key-mapping'
+
+type UseTerminalLiveHardwareKeyboardOptions = {
+  readonly focusScopeKey: string | null
+  readonly liveInputEnabled: boolean
+  readonly canSend: boolean
+  readonly liveInputRef: RefObject<TextInput | null>
+  readonly liveInputFocusTimerRef: TerminalLiveInputFocusTimerRef
+  readonly modalOpen: boolean
+  readonly handleLiveInputHardwareKey: (event: TerminalLiveHardwareKeyEvent) => void
+}
+
+export function useTerminalLiveHardwareKeyboard({
+  focusScopeKey,
+  liveInputEnabled,
+  canSend,
+  liveInputRef,
+  liveInputFocusTimerRef,
+  modalOpen,
+  handleLiveInputHardwareKey
+}: UseTerminalLiveHardwareKeyboardOptions): {
+  readonly showSoftInputOnFocus: boolean
+  readonly hardwareCaptureEnabled: boolean
+  readonly requestSoftKeyboardFocus: () => void
+  readonly clearSoftKeyboardRequest: () => void
+  readonly onHardwareKey: (event: { nativeEvent: TerminalLiveHardwareKeyEvent }) => void
+} {
+  const [wantSoftKeyboard, setWantSoftKeyboard] = useState(false)
+  // Why: explicit soft focus must run after React applies showSoftInputOnFocus=true.
+  const [pendingSoftFocusSeq, setPendingSoftFocusSeq] = useState(0)
+  const pendingSoftFocusNeedsBlurRef = useRef(false)
+  const modalOpenRef = useRef(modalOpen)
+  modalOpenRef.current = modalOpen
+
+  const decision = getTerminalLiveHardwareKeyboardFocusDecision({
+    wantSoftKeyboard,
+    liveInputEnabled,
+    canSend
+  })
+  const showSoftInputOnFocus = decision.kind === 'soft-focus'
+
+  const clearSoftKeyboardRequest = useCallback(() => {
+    setWantSoftKeyboard(false)
+  }, [])
+
+  const requestSoftKeyboardFocus = useCallback(() => {
+    // Why: the live-mode toggle requests focus before its enabled state re-renders.
+    if (!canSend) {
+      return
+    }
+    const isFocused = liveInputRef.current?.isFocused?.() ?? false
+    const plan = planExplicitSoftKeyboardFocus({
+      alreadyWantsSoftKeyboard: wantSoftKeyboard,
+      isFocused
+    })
+    setWantSoftKeyboard(true)
+    if (plan.kind === 'focus-now') {
+      scheduleTerminalLiveInputFocus(liveInputFocusTimerRef, () => liveInputRef.current?.focus())
+      return
+    }
+    pendingSoftFocusNeedsBlurRef.current = plan.kind === 'blur-refocus-after-latch'
+    setPendingSoftFocusSeq((seq) => seq + 1)
+  }, [canSend, liveInputFocusTimerRef, liveInputRef, wantSoftKeyboard])
+
+  // After wantSoftKeyboard commits, focus with showSoftInputOnFocus already true.
+  useEffect(() => {
+    if (pendingSoftFocusSeq === 0 || !showSoftInputOnFocus) {
+      return
+    }
+    const needsBlur = pendingSoftFocusNeedsBlurRef.current
+    pendingSoftFocusNeedsBlurRef.current = false
+    scheduleTerminalLiveInputFocus(liveInputFocusTimerRef, () => {
+      const input = liveInputRef.current
+      if (!input) {
+        return
+      }
+      if (needsBlur && input.isFocused?.()) {
+        input.blur()
+        scheduleTerminalLiveInputFocus(liveInputFocusTimerRef, () => input.focus())
+        return
+      }
+      input.focus()
+    })
+  }, [liveInputFocusTimerRef, liveInputRef, pendingSoftFocusSeq, showSoftInputOnFocus])
+
+  // Focus scope changes include terminal switches; modal close is intentionally
+  // absent from these dependencies so it cannot steal focus back.
+  useEffect(() => {
+    if (modalOpenRef.current) {
+      return
+    }
+    if (
+      !shouldAutoSilentFocusLiveInput({
+        liveInputEnabled,
+        canSend,
+        wantSoftKeyboard,
+        isFocused: liveInputRef.current?.isFocused?.() ?? false,
+        modalOpen: false
+      })
+    ) {
+      return
+    }
+    scheduleTerminalLiveInputFocus(liveInputFocusTimerRef, () => liveInputRef.current?.focus())
+  }, [
+    canSend,
+    focusScopeKey,
+    liveInputEnabled,
+    liveInputFocusTimerRef,
+    liveInputRef,
+    wantSoftKeyboard
+  ])
+
+  // Modal/action-sheet open: cancel pending focus and clear soft latch; do not
+  // re-trigger silent focus when the modal later closes.
+  useEffect(() => {
+    if (!modalOpen) {
+      return
+    }
+    clearTerminalLiveInputFocusTimer(liveInputFocusTimerRef)
+    setWantSoftKeyboard(false)
+  }, [liveInputFocusTimerRef, modalOpen])
+
+  const onHardwareKey = useCallback(
+    (event: { nativeEvent: TerminalLiveHardwareKeyEvent }) => {
+      // Why: native prop updates and queued view events can cross briefly when
+      // a modal opens or sending disables, so JS enforces the same ownership.
+      if (!liveInputEnabled || !canSend || modalOpen) {
+        return
+      }
+      handleLiveInputHardwareKey(event.nativeEvent)
+    },
+    [canSend, handleLiveInputHardwareKey, liveInputEnabled, modalOpen]
+  )
+
+  return {
+    showSoftInputOnFocus,
+    hardwareCaptureEnabled: liveInputEnabled && canSend && !modalOpen,
+    requestSoftKeyboardFocus,
+    clearSoftKeyboardRequest,
+    onHardwareKey
+  }
+}

--- a/mobile/src/terminal/use-terminal-live-input-commit.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.test.ts
@@ -315,6 +315,129 @@ describe('terminal live input commit hook', () => {
     await vi.waitFor(() => expect(sent).toEqual(['한', '\t']))
   })
 
+  it('Given hardware ArrowLeft When the event arrives Then sends CSI left without field text', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputHardwareKey({
+      key: 'ArrowLeft',
+      modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+      repeat: false
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['\x1b[D']))
+  })
+
+  it('Given hardware ArrowLeft after field text When it arrives Then clears the mirror baseline first', async () => {
+    const { handlers, sent, captures } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('ab')
+    await vi.waitFor(() => expect(sent).toEqual(['ab']))
+
+    handlers.handleLiveInputHardwareKey({
+      key: 'ArrowLeft',
+      modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+      repeat: false
+    })
+
+    await vi.waitFor(() => {
+      expect(captures.at(-1)).toBe('')
+      expect(sent).toEqual(['ab', '\x1b[D'])
+    })
+  })
+
+  it('Given hardware Ctrl+C When the event arrives Then sends interrupt byte', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputHardwareKey({
+      key: 'c',
+      modifiers: { ctrl: true, alt: false, shift: false, meta: false },
+      repeat: false
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['\x03']))
+  })
+
+  it('Given hardware Meta+C When the event arrives Then ignores system shortcut', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputHardwareKey({
+      key: 'c',
+      modifiers: { ctrl: false, alt: false, shift: false, meta: true },
+      repeat: false
+    })
+    await Promise.resolve()
+    expect(sent).toEqual([])
+  })
+
+  it('Given hardware Backspace with field text When the event arrives Then mirrors local edit without raw DEL', async () => {
+    const { handlers, sent, captures } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('ab')
+    await vi.waitFor(() => expect(sent).toEqual(['ab']))
+
+    handlers.handleLiveInputHardwareKey({
+      key: 'Backspace',
+      modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+      repeat: false
+    })
+
+    await vi.waitFor(() => {
+      expect(captures.at(-1)).toBe('a')
+      expect(sent).toEqual(['ab', '\x7f'])
+    })
+  })
+
+  it('Given rapid hardware Backspace When events arrive Then serializes both mirror erases', async () => {
+    const { handlers, sent, captures } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('ab')
+    await vi.waitFor(() => expect(sent).toEqual(['ab']))
+
+    const backspace = {
+      key: 'Backspace',
+      modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+      repeat: true
+    }
+    handlers.handleLiveInputHardwareKey(backspace)
+    handlers.handleLiveInputHardwareKey(backspace)
+
+    await vi.waitFor(() => {
+      expect(captures.at(-1)).toBe('')
+      expect(sent).toEqual(['ab', '\x7f', '\x7f'])
+    })
+  })
+
+  it('Given hardware Backspace with empty field When the event arrives Then sends DEL', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputHardwareKey({
+      key: 'Backspace',
+      modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+      repeat: false
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['\x7f']))
+  })
+
+  it('Given hardware Delete with field text When the event arrives Then follows accessory no-op local edit', async () => {
+    const { handlers, sent, captures } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('ab')
+    await vi.waitFor(() => expect(sent).toEqual(['ab']))
+
+    handlers.handleLiveInputHardwareKey({
+      key: 'Delete',
+      modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+      repeat: false
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    // Accessory forward-delete keeps field text; no terminal bytes when field is non-empty.
+    expect(captures.at(-1)).toBe('ab')
+    expect(sent).toEqual(['ab'])
+  })
+
+  it('Given hardware Ctrl+Space When the event arrives Then ignores for IME switching', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputHardwareKey({
+      key: ' ',
+      modifiers: { ctrl: true, alt: false, shift: false, meta: false },
+      repeat: false
+    })
+    await Promise.resolve()
+    expect(sent).toEqual([])
+  })
+
   it('Given Hangul pending When the tab type lags to undefined Then keeps the composition state', async () => {
     // Given: '한' held while the active tab is still a terminal
     const { handlers, sent, setActiveSessionTabType } = createTerminalLiveInputCommitHarness()

--- a/mobile/src/terminal/use-terminal-live-input-commit.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.ts
@@ -4,6 +4,10 @@ import { getTerminalLiveSpecialKeyDecision } from './terminal-live-text-commit'
 import { sendTerminalLiveControlAfterPendingFlush } from './terminal-live-control-send-order'
 import type { TerminalLiveAccessoryInput } from './terminal-live-accessory-input'
 import type { TerminalLiveInputSender } from './terminal-live-input-sender'
+import {
+  mapTerminalLiveHardwareKeyEvent,
+  type TerminalLiveHardwareKeyEvent
+} from './terminal-live-hardware-key-mapping'
 import { normalizeTerminalTextInput } from './terminal-text-input-normalization'
 import { useTerminalLivePendingInputFlush } from './use-terminal-live-pending-input-flush'
 import {
@@ -36,6 +40,7 @@ type TerminalLiveInputCommitHandlers = {
     input: TerminalLiveAccessoryInput
   ) => Promise<TerminalLiveAccessoryInputCommitResult>
   readonly handleLiveInputChange: (text: string) => void
+  readonly handleLiveInputHardwareKey: (event: TerminalLiveHardwareKeyEvent) => void
   readonly handleLiveInputKeyPress: (event: TerminalLiveInputKeyPressEvent) => void
   readonly handleLiveInputSubmit: () => void
 }
@@ -182,6 +187,56 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
     waitForPendingLiveInputFlush
   })
 
+  const handleLiveInputHardwareKey = useCallback(
+    (event: TerminalLiveHardwareKeyEvent) => {
+      if (!activeHandle || !liveInputTerminalHandles.has(activeHandle)) {
+        return
+      }
+      const ownsPendingState = pendingLiveInputHandleRef.current === activeHandle
+      if (pendingLiveInputHandleRef.current && !ownsPendingState) {
+        clearPendingLiveInputCommit()
+      }
+      const decision = mapTerminalLiveHardwareKeyEvent(event, {
+        heldText: ownsPendingState ? heldLiveInputTextRef.current : '',
+        sentText: ownsPendingState ? sentLiveInputTextRef.current : ''
+      })
+      switch (decision.kind) {
+        case 'ignore':
+          return
+        case 'local-edit':
+          // Why: native already consumed the key; mirror accessory local-edit so the
+          // hidden field and PTY stay in sync (same path as accessory ⌫/Del).
+          void handleLiveInputAccessoryBytes({
+            bytes: decision.localEdit === 'backspace' ? '\x7f' : '\x1b[3~',
+            localEdit: decision.localEdit
+          })
+          return
+        case 'send-bytes':
+          void sendTerminalLiveControlAfterPendingFlush(waitForPendingLiveInputFlush, () =>
+            sendLiveTerminalInputRef.current(activeHandle, decision.bytes)
+          )
+          return
+        case 'flush-field-then-send':
+          void sendTerminalLiveControlAfterPendingFlush(
+            () => flushPendingLiveInputText(activeHandle),
+            () => sendLiveTerminalInputRef.current(activeHandle, decision.bytes)
+          )
+          return
+        default:
+          decision satisfies never
+      }
+    },
+    [
+      activeHandle,
+      clearPendingLiveInputCommit,
+      flushPendingLiveInputText,
+      handleLiveInputAccessoryBytes,
+      liveInputTerminalHandles,
+      sendLiveTerminalInputRef,
+      waitForPendingLiveInputFlush
+    ]
+  )
+
   const handleLiveInputSubmit = useCallback(() => {
     if (!activeHandle || !liveInputTerminalHandles.has(activeHandle)) {
       return
@@ -197,6 +252,7 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
     flushPendingLiveInputBeforeExternalSend,
     handleLiveInputAccessoryBytes,
     handleLiveInputChange,
+    handleLiveInputHardwareKey,
     handleLiveInputKeyPress,
     handleLiveInputSubmit
   }


### PR DESCRIPTION
## Summary

This integration PR carries @bbingz's scoped physical-terminal-keyboard work from #10148 on top of current `main`, plus five review fixes. It is intentionally published on `brennanb2025/pr-10148-review-fixes`; the author's `feat/mobile-hardware-keyboard` branch was not modified or force-pushed.

- Capture navigation, control, function, and local-edit keys through native iOS/Android views while preserving IME, AltGr, and system-owned Command/Meta behavior.
- Fix Android Ctrl+letter capture when Shift or Caps Lock is active.
- Cache iOS's invariant key-command set instead of rebuilding 226 `UIKeyCommand` objects during key-event resolution.
- Repair the Android Enter contract oracle and add missing Command/Meta, modified Enter/F-key, and soft-keyboard-focus coverage.

## Root causes and review fixes

1. Android's AltGr heuristic removed Ctrl but retained Shift/Caps Lock before comparing produced characters. Letter case therefore looked like alternate-layout text and suppressed Ctrl+letter, including Ctrl+C with Caps Lock (issue #9702 item C).
2. UIKit re-reads `keyCommands` while resolving input. The prior getter rebuilt 13 special keys × 8 modifier sets + 12 function keys × 8 modifier sets + 26 Ctrl letters (226 commands) each time even though the set is invariant.
3. The Enter contract test searched a region broad enough for Ctrl+Space's unrelated pass-through to satisfy it.
4. No layer pinned Command/Meta pass-through, modified Enter/function-key mapping, or `wantSoftKeyboard`/`canSend` suppression of silent focus.

The smallest fixes scope alternate-layout probing to Alt state, hoist the iOS command list to one static allocation, and strengthen only the affected test oracles.

## Issue scope

This PR must not auto-close either issue:

- #9000 is **partial**. Terminal navigation/Option/Ctrl coverage is added, but app-wide Command shortcuts, editor controls, and other non-terminal hardware-keyboard surfaces remain outside scope; Command/Meta is deliberately system-owned here.
- #9702 covers items A-C. Item D (the browser `+` path hanging the app) is untouched.

## Verification

- Parent `origin/main@13c193a00a`: **351 test files / 2,590 passed / 2 skipped** (`pnpm test --maxWorkers=2`)
- This branch: **355 test files / 2,645 passed / 2 skipped** (`pnpm test --maxWorkers=2`)
- Focused physical-keyboard slice: **6 files / 75 tests passed**
- Source-revert anti-vacuity probe: **6/6 focused files RED**; the surviving commit-hook suite had 9 behavioral failures while its 18 pre-existing tests remained green
- Earlier review mutation battery: submitted PR **14/22**, fixed branch **24/24**
- `pnpm lint`
- `pnpm format:check` (oxfmt; no Prettier)
- `pnpm typecheck` (`tsc --noEmit`)
- `node config/scripts/check-max-lines-ratchet.mjs`
- `swiftc -parse` for both Swift files
- `git diff --check origin/main...HEAD`

The full suites were run at two workers because the host is saturated. They completed normally; no result above treats a silent or stalled lane as success.

## Reliability contract

- **Invariant (`terminal-input.mobile-hardware-routing`)**: while live input is enabled and sendable, supported physical keys reach the intended terminal exactly once; printable/IME/AltGr, Command/Meta, Ctrl+Space, modal ownership, and explicit software-keyboard focus remain platform-owned.
- **Failure source**: #9000, #9702 A-C, and the Android Shift/Caps Lock false-positive found during #10148 review.
- **Oracle**: the six focused mapping, native-contract, focus, affordance, ordering, and commit suites; the source-revert and mutation red/green probes demonstrate that the behavioral assertions are load-bearing.
- **Gate**: no existing reliability-manifest entry directly covers mobile physical-keyboard routing; the focused slice is recorded here as an accepted experimental gap rather than overstating coverage.
- **Provider/platform**: mobile/relay uses the existing PTY send path; local/daemon/SSH/WSL terminal ownership and desktop macOS/Linux/Windows input paths are unaffected. iOS and Android native capture are affected and retain explicit runtime-specific implementations.
- **Performance budget**: no polling, provider scans, IPC fanout, or subprocess work was added. Android remains bounded O(1); iOS changes per-resolution construction from 226 command allocations to a single process-lifetime static command array. The deterministic native contract pins static reuse; device-level latency/allocation profiling remains unperformed.
- **Diagnostics**: focused failures identify mapping, native registration/guard, focus ownership, send ordering, and commit behavior separately.

## Device/build gaps before merge

- The available physical iPad is currently **unavailable**, and simulator testing cannot settle #10447's real-device report that iPadOS Focus Engine may consume Tab/Up/Down. This implementation relies on `wantsPriorityOverSystemBehavior`; it has no `canBecomeFocused`/focus-update handling. Treat device behavior as unverified, not passed.
- No Android/Kotlin toolchain is installed here. Kotlin was reviewed and unit-contract tested but not compiled.
- Swift passed parse-only validation, not an iOS SDK build. Both native targets require real Android and iOS builds before merge.
- iOS held-key repeat remains device-unverified.
