### PR TITLE
fix(mobile): close terminal session tabs authoritatively

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -5216,6 +5216,7 @@ export default function SessionScreen() {
           onRename: setRenameTarget,
           onClear: (target) => void handleClearTerminal(target),
           onClose: (target) => void handleCloseTerminal(target),
+          onCloseSessionTab: (tab) => void handleCloseSessionTab(tab),
           bulkCloseActions
         })}
         onClose={() => setActionTarget(null)}

--- a/mobile/src/session/mobile-terminal-action-sheet-actions.test.ts
+++ b/mobile/src/session/mobile-terminal-action-sheet-actions.test.ts
@@ -9,24 +9,38 @@ vi.mock('lucide-react-native', () => ({
   SquareTerminal: vi.fn()
 }))
 
+type SheetArgs = Parameters<typeof getMobileTerminalActionSheetActions>[0]
+
+function buildActions(overrides: Partial<SheetArgs> = {}) {
+  return getMobileTerminalActionSheetActions({
+    target: { handle: 'terminal-1' },
+    tabs: [],
+    isTabChatView: () => false,
+    nativeChatTranscriptIsLocalReadable: true,
+    onDismiss: vi.fn(),
+    onToggleChat: vi.fn(),
+    isPhoneMode: () => false,
+    onToggleDisplayMode: vi.fn(),
+    onRename: vi.fn(),
+    onClear: vi.fn(),
+    onClose: vi.fn(),
+    onCloseSessionTab: vi.fn(),
+    ...overrides
+  })
+}
+
+const terminalTab = (id: string, handle: string | null) => ({
+  type: 'terminal',
+  id,
+  terminal: handle
+})
+
 describe('getMobileTerminalActionSheetActions', () => {
   it('defers Rename until after the action sheet closes', () => {
     const target = { handle: 'terminal-1' }
     const onDismiss = vi.fn()
     const onRename = vi.fn()
-    const actions = getMobileTerminalActionSheetActions({
-      target,
-      tabs: [],
-      isTabChatView: () => false,
-      nativeChatTranscriptIsLocalReadable: true,
-      onDismiss,
-      onToggleChat: vi.fn(),
-      isPhoneMode: () => false,
-      onToggleDisplayMode: vi.fn(),
-      onRename,
-      onClear: vi.fn(),
-      onClose: vi.fn()
-    })
+    const actions = buildActions({ target, onDismiss, onRename })
 
     const rename = actions.find((action) => action.label === 'Rename')
     expect(rename).toMatchObject({ closeBeforePress: true })
@@ -34,5 +48,52 @@ describe('getMobileTerminalActionSheetActions', () => {
     rename?.onPress()
     expect(onRename).toHaveBeenCalledWith(target)
     expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  // Why: handle-only close lets the pending-terminal effect resurrect the tab (#6927, #7345).
+  it('closes the handle through its session tab, not the handle-only path', () => {
+    const onClose = vi.fn()
+    const onCloseSessionTab = vi.fn()
+    const tab = terminalTab('tab-1::leaf-1', 'terminal-1')
+    const actions = buildActions({
+      target: { handle: 'terminal-1' },
+      tabs: [tab],
+      onClose,
+      onCloseSessionTab
+    })
+
+    actions.find((action) => action.label === 'Close')?.onPress()
+    expect(onCloseSessionTab).toHaveBeenCalledWith(tab)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('closes the split leaf that owns the handle, not its sibling', () => {
+    const onCloseSessionTab = vi.fn()
+    const first = terminalTab('tab-1::leaf-1', 'terminal-1')
+    const second = terminalTab('tab-1::leaf-2', 'terminal-2')
+    const actions = buildActions({
+      target: { handle: 'terminal-2' },
+      tabs: [first, second],
+      onCloseSessionTab
+    })
+
+    actions.find((action) => action.label === 'Close')?.onPress()
+    expect(onCloseSessionTab).toHaveBeenCalledWith(second)
+  })
+
+  it('falls back to the handle close when no session tab owns the handle', () => {
+    const onClose = vi.fn()
+    const onCloseSessionTab = vi.fn()
+    const target = { handle: 'terminal-9' }
+    const actions = buildActions({
+      target,
+      tabs: [terminalTab('tab-1::leaf-1', 'terminal-1'), terminalTab('tab-2::leaf-1', null)],
+      onClose,
+      onCloseSessionTab
+    })
+
+    actions.find((action) => action.label === 'Close')?.onPress()
+    expect(onClose).toHaveBeenCalledWith(target)
+    expect(onCloseSessionTab).not.toHaveBeenCalled()
   })
 })

--- a/mobile/src/session/mobile-terminal-action-sheet-actions.ts
+++ b/mobile/src/session/mobile-terminal-action-sheet-actions.ts
@@ -7,9 +7,12 @@ type TerminalTab = MobileNativeChatTab & { id: string; terminal: string | null }
 
 /** Builds the terminal long-press menu without adding another action block to the
  *  already dense session route. Native chat stays first as the view switch. */
-export function getMobileTerminalActionSheetActions<Target extends { handle: string }>(args: {
+export function getMobileTerminalActionSheetActions<
+  Target extends { handle: string },
+  Tab extends TerminalTab
+>(args: {
   target: Target | null
-  tabs: readonly TerminalTab[]
+  tabs: readonly Tab[]
   isTabChatView: (tabId: string) => boolean
   nativeChatTranscriptIsLocalReadable: boolean
   onDismiss: () => void
@@ -18,7 +21,10 @@ export function getMobileTerminalActionSheetActions<Target extends { handle: str
   onToggleDisplayMode: (handle: string) => void
   onRename: (target: Target) => void
   onClear: (target: Target) => void
+  /** Fallback for a live handle with no matching session tab. */
   onClose: (target: Target) => void
+  /** Preferred path runs host teardown and records the local tombstone. */
+  onCloseSessionTab: (tab: Tab) => void
   /** Appended after Close; receives the pressed tab's id so the session route's
    *  bulk-close builder can resolve the anchor itself. */
   bulkCloseActions?: (anchorTabId: string | undefined, dismiss: () => void) => ActionSheetAction[]
@@ -28,6 +34,7 @@ export function getMobileTerminalActionSheetActions<Target extends { handle: str
     return []
   }
   const phoneMode = args.isPhoneMode(target.handle)
+  const sessionTab = args.tabs.find((tab) => tab.terminal === target.handle)
   return [
     ...getMobileNativeChatToggleActions({
       terminalHandle: target.handle,
@@ -65,12 +72,13 @@ export function getMobileTerminalActionSheetActions<Target extends { handle: str
       destructive: true,
       onPress: () => {
         args.onDismiss()
+        if (sessionTab) {
+          args.onCloseSessionTab(sessionTab)
+          return
+        }
         args.onClose(target)
       }
     },
-    ...(args.bulkCloseActions?.(
-      args.tabs.find((tab) => tab.terminal === target.handle)?.id,
-      args.onDismiss
-    ) ?? [])
+    ...(args.bulkCloseActions?.(sessionTab?.id, args.onDismiss) ?? [])
   ]
 }


### PR DESCRIPTION
## Summary

- Route terminal long-press Close through the authoritative session-tab close path when the terminal handle belongs to a session tab.
- Keep the handle-only close as a fallback for live handles that have no session-tab owner.
- Cover single terminals, split-leaf ownership, and the fallback path.

Fixes #6927
Fixes #7345

## Merge ordering

Depends on #11251 (`brennanb2025/mobile-9717-dup-sessions`, issue #9717) — **land #11251 first.**

This PR correctly routes more terminal closes through the authoritative
`session.tabs.close` path, which prunes `sessionTabs` and clears
`activeSessionTabId`. That legitimately reaches the empty-session-tab-list state
far more often, and on `main` that state can trigger an unsolicited replacement
terminal — the duplicate-session bug in #9717. Landing this PR first therefore
makes #9717 more reachable without introducing it.

#11251 fixes the auto-create side (`use-initial-session-terminal-autocreate.ts`)
by treating an authoritative empty snapshot as a real empty workspace. The two
branches combine cleanly and do not require an atomic merge, but this PR should
not land before #11251. #11251 records the same ordering constraint.

## Root cause

Terminal long-press Close was the only mobile tab close that called handle-only `terminal.close`. That removed the PTY-facing terminal but did not prune the mobile `sessionTabs`, clear `activeSessionTabId`, or record the local close tombstone. The host could therefore republish the same active tab as pending, after which the pending-terminal activation effect materialized a fresh PTY into the same tab id.

#7345 reports this exact terminal resurrection path. #6927 sees it as every tab being unclosable because a headless `orca serve` session normally publishes terminal tabs; #10486 is separate because its trigger is viewing/activation and does not exercise close.

## Reliability contract

- **Invariant (`terminal-session.explicit-close-retirement`):** an explicit mobile terminal-tab close uses the session-tab owner transaction, removes the local mirror, clears active ownership, and records the tombstone; an unmatched live handle retains the existing fallback.
- **Failure source:** #6927 and #7345.
- **Oracle:** action-sheet tests assert the matching session tab is closed, the owning split leaf is selected, and unmatched handles use the fallback. Replacing the new routing branch with the old handle-only call makes 2 of 4 focused tests fail.
- **Gate:** existing `terminal-session.explicit-close-retirement` is partial; this PR adds the mobile route-level oracle and records live-device validation as a gap.
- **Provider/platform coverage:** the pure mobile routing contract is provider- and path-agnostic, so local, daemon, SSH, WSL, folder workspaces, and git worktrees are unaffected below the existing close RPC. The full suite and static gates ran on macOS; a physical phone/relay journey was not run.
- **Performance budget:** one bounded session-tab lookup occurs when the action sheet is built and is reused for bulk-close anchoring. No polling, provider inventory, render loop, listener, subprocess, or startup work is added.
- **Diagnostics:** focused assertion names distinguish owner routing, split selection, and fallback behavior.
- **Residual gap:** mobile does not interpret `RuntimeMobileSessionTabCloseResult.refused`, but `session.tabs.close` hardcodes user intent and cannot currently reach a refusal branch. Handling a future user-close refusal is intentionally out of this P1 scope.

## Verification

Against parent `d3681f6306`:

- Parent: 351 test files, 2,590 passed, 2 skipped
- This PR: 351 test files, 2,593 passed, 2 skipped
- `cd mobile && pnpm install` using the repository-pinned pnpm 10.24.0
- Full mobile Vitest suite with `--maxWorkers=2`
- Full mobile oxlint
- Full mobile `oxfmt --check .`
- Mobile `tsc --noEmit`
- Non-vacuity mutation: old routing produces 2 focused failures

No device validation is claimed.

### CI note (pre-existing unrelated flake)

`tests 12/16` failed once on this commit. All 233 shard files and 2,247 tests
**passed**; the job exited 1 solely on `Unhandled Rejection: Error: Unable to
remove watcher: Invalid argument`, thrown from `@parcel/watcher`'s Linux
inotify backend (`inotify_rm_watch` -> `EINVAL`).

Not caused by this PR:

- The root Vitest config's `include` matches no file under the repo-root
  `mobile/` directory, so this mobile-only diff leaves shard 12's file set
  byte-identical to the parent — it cannot shift shard contents.
- Re-running the same job on the identical tree passed.
- The blamed file (`src/main/plugins/plugin-content-safety.test.ts`) contains no
  watcher code; Vitest attributes an async native error to whichever test was
  in flight.

The latent hazard is in `src/main/ipc/parcel-watcher-in-process-fallback.ts`:
the cancellation path deliberately swallows unsubscribe failures ("so they never
surface as unhandled rejections"), but the normal teardown path awaits
`subscription.unsubscribe()` unguarded. Desktop main-process code, unrelated to
this mobile fix, and intentionally left out of scope here.

