### PR TITLE
fix(mobile): recompose iOS NFD Hangul before terminal send

### DIFF
--- a/mobile/src/terminal/terminal-ios-hangul-nfd-input.test.ts
+++ b/mobile/src/terminal/terminal-ios-hangul-nfd-input.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTerminalLiveMirrorPayload,
+  computeTerminalLiveMirrorStep
+} from './terminal-live-hangul-mirror'
+import { normalizeTerminalTextInput } from './terminal-text-input-normalization'
+
+// 두벌식 (2-set) composition states for 안녕하세요, as the field shows them
+// keystroke by keystroke: ㅇ ㅏ ㄴ ㄴ ㅕ ㅇ ㅎ ㅏ ㅅ ㅔ ㅇ ㅛ.
+const DUBEOLSIK_FIELD_STATES = [
+  'ㅇ',
+  '아',
+  '안',
+  '안ㄴ',
+  '안녀',
+  '안녕',
+  '안녕ㅎ',
+  '안녕하',
+  '안녕핫',
+  '안녕하세',
+  '안녕하셍',
+  '안녕하세요'
+] as const
+
+const DEL = '\x7f'
+
+// Minimal PTY line model: DEL erases one code point, everything else appends.
+function applyToPty(pty: string, payload: string): string {
+  let next = Array.from(pty)
+  for (const codePoint of Array.from(payload)) {
+    if (codePoint === DEL) {
+      next = next.slice(0, -1)
+      continue
+    }
+    next.push(codePoint)
+  }
+  return next.join('')
+}
+
+// Replays handleLiveInputChange → applyLiveInputMirror, then the settle-timer
+// commit that flushes the last held syllable.
+function replayLiveInput(fieldStates: readonly string[]): string {
+  let sentText = ''
+  let heldText = ''
+  let pty = ''
+
+  const step = (fieldText: string, commitHeld: boolean): void => {
+    const mirror = computeTerminalLiveMirrorStep(sentText, normalizeTerminalTextInput(fieldText), {
+      commitHeld
+    })
+    pty = applyToPty(pty, buildTerminalLiveMirrorPayload(mirror))
+    sentText = mirror.nextSentText
+    heldText = mirror.heldText
+  }
+
+  for (const fieldText of fieldStates) {
+    step(fieldText, false)
+  }
+  step(sentText + heldText, true)
+  return pty
+}
+
+describe('iOS decomposed (NFD) Hangul live input', () => {
+  it('Given an NFD field (iOS) When the user types 안녕하세요 Then the PTY receives composed syllables, not jamo', () => {
+    // Given: Apple text input hands React Native decomposed conjoining jamo, so
+    // one syllable arrives as 2-3 code points instead of one.
+    const nfdStates = DUBEOLSIK_FIELD_STATES.map((state) => state.normalize('NFD'))
+    expect(Array.from(nfdStates.at(-1) ?? '')).toHaveLength(12)
+
+    // When
+    const pty = replayLiveInput(nfdStates)
+
+    // Then: the mirror holds only the trailing code point, so without
+    // recomposition every leading jamo is committed on its own (#6995 iOS).
+    expect(Array.from(pty)).toHaveLength(5)
+    expect(pty).toBe('안녕하세요')
+  })
+
+  it('Given a precomposed NFC field (Android/Gboard) When the same keys are typed Then the PTY result is unchanged', () => {
+    // Given / When
+    const pty = replayLiveInput(DUBEOLSIK_FIELD_STATES)
+
+    // Then
+    expect(pty).toBe('안녕하세요')
+  })
+
+  it('Given NFD Latin diacritics When mirrored Then combining marks reach the PTY already composed', () => {
+    // Given / When: iOS also hands back NFD for Vietnamese/European accents.
+    const pty = replayLiveInput(['tie', 'tiế', 'tiếng'].map((state) => state.normalize('NFD')))
+
+    // Then
+    expect(pty).toBe('tiếng')
+    expect(Array.from(pty)).toHaveLength(5)
+  })
+})

--- a/mobile/src/terminal/terminal-text-input-normalization.test.ts
+++ b/mobile/src/terminal/terminal-text-input-normalization.test.ts
@@ -11,4 +11,29 @@ describe('normalizeTerminalTextInput', () => {
   it('keeps ASCII hyphens unchanged', () => {
     expect(normalizeTerminalTextInput('git checkout -- file')).toBe('git checkout -- file')
   })
+
+  it('recomposes decomposed Hangul that iOS hands back as conjoining jamo', () => {
+    const decomposed = '안녕하세요'.normalize('NFD')
+    expect(Array.from(decomposed)).toHaveLength(12)
+
+    const normalized = normalizeTerminalTextInput(decomposed)
+
+    expect(normalized).toBe('안녕하세요')
+    expect(Array.from(normalized)).toHaveLength(5)
+  })
+
+  it('recomposes decomposed Latin diacritics and stays idempotent on composed text', () => {
+    expect(normalizeTerminalTextInput('tiếng'.normalize('NFD'))).toBe('tiếng')
+    expect(normalizeTerminalTextInput('안녕하세요')).toBe('안녕하세요')
+    expect(normalizeTerminalTextInput(normalizeTerminalTextInput('café'.normalize('NFD')))).toBe(
+      'café'
+    )
+  })
+
+  it('leaves compatibility forms alone so NFC never becomes a lossy NFKC fold', () => {
+    // NFKC would fold these into different characters and silently rewrite a command.
+    expect(normalizeTerminalTextInput('ㅇㅏㄴ')).toBe('ㅇㅏㄴ')
+    expect(normalizeTerminalTextInput('ｇｉｔ')).toBe('ｇｉｔ')
+    expect(normalizeTerminalTextInput('①')).toBe('①')
+  })
 })

--- a/mobile/src/terminal/terminal-text-input-normalization.ts
+++ b/mobile/src/terminal/terminal-text-input-normalization.ts
@@ -4,6 +4,11 @@
 // value written back into the field, and that write-back kills iOS dictation (#7925).
 const IOS_SMART_DASH_REPLACEMENT_PATTERN = /[\u2013\u2014]/g
 
+// Why: Apple text input hands back decomposed (NFD) text, so one Hangul syllable
+// arrives as 2-3 conjoining jamo. The live mirror holds only the trailing code
+// point, so every leading jamo would commit on its own (#6995 iOS). NFC — never
+// NFKC, which rewrites compatibility jamo and full-width forms — recomposes them
+// before the PTY sees anything; it is a no-op for already-composed input.
 export function normalizeTerminalTextInput(text: string): string {
-  return text.replace(IOS_SMART_DASH_REPLACEMENT_PATTERN, '--')
+  return text.normalize('NFC').replace(IOS_SMART_DASH_REPLACEMENT_PATTERN, '--')
 }


### PR DESCRIPTION
## Summary

- NFC-normalize outbound terminal text so Apple NFD Hangul reaches the live mirror as complete syllables.
- Keep the React Native field write-back verbatim for iOS dictation/IME stability, and deliberately avoid lossy NFKC folding.
- Add real mirror-pipeline coverage for Hangul and Latin NFD plus compatibility-form guards.

Fixes #11235. Thanks @lkjsays for the iOS reproduction report in #6995.

Test: NFC(안녕하세요) == 안녕하세요

## Screenshots

No visual change.

## Testing

- [x] pnpm --dir mobile lint
- [x] pnpm --dir mobile typecheck
- [x] pnpm --dir mobile test — 352 files, 2,596 passed, 2 skipped
- [x] pnpm --dir mobile format:check
- [ ] pnpm build — not run; no native or build-system changes
- [x] Added regression tests; removing the NFC normalization makes four new assertions fail

## AI Review Report

A same-model independent review returned clean. It checked the real live-mirror pipeline, raw field write-back, NFC versus NFKC fidelity, neighboring input paths, and per-keystroke cost; no correctness, regression, or meaningful performance concerns were found. The change is platform-neutral outside the documented iOS source behavior and touches no shortcuts, labels, paths, shell behavior, Git/provider behavior, or Electron platform branches; SSH and folder workspaces use the same pre-transport mobile path.

## Security Audit

Reviewed the command-input transformation for silent rewriting risk. NFC only recomposes canonically equivalent text; tests prove compatibility jamo, full-width forms, and circled characters are preserved, and the change introduces no auth, secret, dependency, path, IPC, or command-execution surface.

## Notes

The rebased branch bundle loaded on an iPhone 17 Pro simulator running iOS 26.5, and a connected session plus real terminal surface rendered successfully. Simulator automation could not inject Korean IME composition events end to end, so device-level Korean typing remains unverified; the regression is proven through the production mirror algorithm with real NFD field states.

![image](https://github.com/user-attachments/assets/183f1532-d8aa-4844-a7e3-ae610bc1ca90)
![image](https://github.com/user-attachments/assets/e7615b2f-5fec-4b2b-b723-10ce993fc7a3)
![image](https://github.com/user-attachments/assets/901c754e-6ece-4b2c-94b0-601efc68a348)
![image](https://github.com/user-attachments/assets/b93814d7-e742-43f4-9ea8-969964715cd1)