### PR TITLE
fix(mobile): route terminal wheel scrolling through the gesture router

### DIFF
--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -11,6 +11,7 @@ import { TERMINAL_WEBVIEW_THEME_JS } from './terminal-webview-theme-injected'
 import { TERMINAL_QUERY_REPLY_JS } from './terminal-webview-query-reply-injected'
 import { URL_TAP_WEBVIEW_JS } from './terminal-webview-url-tap'
 import { TERMINAL_WEBGL_RECOVERY_JS } from './terminal-webview-webgl-recovery-injected'
+import { TERMINAL_WHEEL_SCROLL_JS } from './terminal-webview-wheel-scroll-injected'
 
 const DEFAULT_TERMINAL_THEME: RuntimeMobileTerminalTheme['theme'] = {
   background: colors.terminalBg,
@@ -688,6 +689,7 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
     initRows = rows || 24;
     firstDataPending = true;
     smoothScrollOffsetY = 0;
+    wheelAccumDeltaY = 0;
     mouseModeScanTail = '';
     trackedMouseTrackingMode = 'none';
     sgrMouseMode = false;
@@ -1634,6 +1636,10 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
   // terminal-webview-tap-dispatch-injected.ts (extracted for max-lines).
   ${TERMINAL_TAP_DISPATCH_JS}
 
+  // External mouse / trackpad scroll: see
+  // terminal-webview-wheel-scroll-injected.ts (extracted for max-lines).
+  ${TERMINAL_WHEEL_SCROLL_JS}
+
   btnCopy.addEventListener('click', function(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -1689,6 +1695,8 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
     // replacement needs gesture handlers or tab-switch replays stop scrolling.
     targetSurface.addEventListener('mousedown', function(e) { e.preventDefault(); e.stopPropagation(); }, true);
     targetSurface.addEventListener('click', function(e) { e.preventDefault(); e.stopPropagation(); }, true);
+
+    attachSurfaceWheelHandler(targetSurface);
 
     targetSurface.addEventListener('touchstart', function(e) {
       if (dispatcherShouldBlockSurface()) return;

--- a/mobile/src/terminal/terminal-webview-wheel-scroll-injected.ts
+++ b/mobile/src/terminal/terminal-webview-wheel-scroll-injected.ts
@@ -1,0 +1,53 @@
+// Indirect-pointer (external mouse / trackpad) scroll for the terminal surface,
+// injected into XTERM_HTML. Extracted from terminal-webview-html.ts to keep that
+// file within its max-lines budget. Closes over host-IIFE state/functions:
+// term, getCellHeight, getTotalScale, shouldRouteScrollToTerminalInput,
+// routeScrollLines, enqueueNormalBufferScrollDelta, resetSmoothScrollOffset,
+// and dispatcherShouldBlockSurface.
+export const TERMINAL_WHEEL_SCROLL_JS = `
+  var wheelAccumDeltaY = 0;
+
+  function wheelEventPixelDeltaY(e) {
+    var delta = e.deltaY;
+    if (typeof delta !== 'number' || !isFinite(delta) || delta === 0) return 0;
+    // DOM_DELTA_LINE / DOM_DELTA_PAGE: Android WebView reports line-mode deltas
+    // for external mouse wheels, iOS trackpads report pixels.
+    if (e.deltaMode === 1) return delta * getCellHeight() * getTotalScale();
+    if (e.deltaMode === 2) return delta * window.innerHeight;
+    return delta;
+  }
+
+  function attachSurfaceWheelHandler(targetSurface) {
+    targetSurface.addEventListener('wheel', function(e) {
+      if (dispatcherShouldBlockSurface()) return;
+      if (!term) return;
+      // Why: xterm's own wheel handler scrolls its hidden viewport or emits
+      // cursor keys through onData, which the mobile query-reply gate drops.
+      // Claim the event so indirect pointers share the touch scroll router.
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Why: a trackpad pinch arrives as ctrl+wheel. Swallow it rather than
+      // firing cursor keys at the TUI; two-finger pinch still drives text size.
+      if (e.ctrlKey) return;
+
+      var deltaY = wheelEventPixelDeltaY(e);
+      if (deltaY === 0) return;
+
+      if (shouldRouteScrollToTerminalInput()) {
+        resetSmoothScrollOffset();
+        var effectiveCellH = getCellHeight() * getTotalScale();
+        if (!(effectiveCellH > 0)) return;
+        wheelAccumDeltaY += deltaY;
+        var lines = Math.trunc(wheelAccumDeltaY / effectiveCellH);
+        if (lines !== 0) {
+          wheelAccumDeltaY -= lines * effectiveCellH;
+          routeScrollLines(lines, e.clientX, e.clientY);
+        }
+        return;
+      }
+      wheelAccumDeltaY = 0;
+      enqueueNormalBufferScrollDelta(deltaY);
+    }, { capture: true, passive: false });
+  }
+`

--- a/mobile/src/terminal/terminal-webview-wheel-scroll.test.ts
+++ b/mobile/src/terminal/terminal-webview-wheel-scroll.test.ts
@@ -1,0 +1,292 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { XTERM_HTML } from './terminal-webview-html'
+
+function iifeSource(): string {
+  const start = XTERM_HTML.indexOf('(function() {')
+  const end = XTERM_HTML.lastIndexOf('})();')
+  return XTERM_HTML.slice(start, end + '})();'.length)
+}
+
+function bodyMarkup(): string {
+  const start = XTERM_HTML.indexOf('<body>') + '<body>'.length
+  const end = XTERM_HTML.indexOf('<script>', start)
+  return XTERM_HTML.slice(start, end)
+}
+
+type BufferState = {
+  baseY: number
+  type: 'alternate' | 'normal'
+  viewportY: number
+}
+
+type TerminalStub = ReturnType<typeof makeTerminal>
+type RegisteredWindowListener = {
+  listener: EventListenerOrEventListenerObject
+  options?: boolean | AddEventListenerOptions
+  type: string
+}
+
+const CELL_HEIGHT = 15
+const ESC = '\u001b'
+const ESC_ARROW_DOWN = `${ESC}[B`
+const ESC_APP_ARROW_UP = `${ESC}OA`
+
+function makeTerminal(buffer: BufferState, scrollLines: (lines: number) => void) {
+  const terminal = {
+    cols: 40,
+    rows: 24,
+    options: { fontSize: 13 },
+    modes: { mouseTrackingMode: 'none' as string },
+    element: null as HTMLElement | null,
+    _core: {
+      _renderService: { dimensions: { css: { cell: { width: 8, height: CELL_HEIGHT } } } }
+    },
+    buffer: {
+      active: {
+        get baseY() {
+          return buffer.baseY
+        },
+        get type() {
+          return buffer.type
+        },
+        get viewportY() {
+          return buffer.viewportY
+        },
+        cursorY: 0,
+        length: 1,
+        getLine: () => null
+      }
+    },
+    write(_data: string, callback?: () => void) {
+      callback?.()
+    },
+    open(surface: HTMLElement) {
+      terminal.element = surface
+    },
+    loadAddon() {},
+    resize(cols: number, rows: number) {
+      terminal.cols = cols
+      terminal.rows = rows
+    },
+    clear() {},
+    reset() {},
+    refresh() {},
+    selectAll() {},
+    clearSelection() {},
+    select() {},
+    scrollLines,
+    scrollToBottom() {},
+    scrollToLine() {},
+    attachCustomKeyEventHandler() {},
+    getSelection: () => '',
+    onData: () => ({ dispose() {} }),
+    onLineFeed: () => ({ dispose() {} }),
+    onScroll: () => ({ dispose() {} }),
+    onWriteParsed: () => ({ dispose() {} }),
+    dispose() {}
+  }
+  return terminal
+}
+
+function dispatchWheel(deltaY: number, init: WheelEventInit = {}): WheelEvent {
+  const surface = document.getElementById('terminal-surface')
+  if (!surface) {
+    throw new Error('terminal surface missing')
+  }
+  const event = new WheelEvent('wheel', {
+    bubbles: true,
+    cancelable: true,
+    clientX: 40,
+    clientY: 60,
+    deltaMode: 0,
+    deltaY,
+    ...init
+  })
+  if (init.ctrlKey) {
+    // Why: happy-dom drops modifier flags from the WheelEvent init dict.
+    Object.defineProperty(event, 'ctrlKey', { value: true })
+  }
+  surface.dispatchEvent(event)
+  return event
+}
+
+function terminalInputBytes(postMessage: ReturnType<typeof vi.fn>): string {
+  return postMessage.mock.calls
+    .map(([raw]) => JSON.parse(String(raw)) as { bytes?: string; type: string })
+    .filter((msg) => msg.type === 'terminal-input')
+    .map((msg) => msg.bytes ?? '')
+    .join('')
+}
+
+describe('terminal WebView external pointer wheel scrolling', () => {
+  let animationFrames: Array<() => void>
+  let buffer: BufferState
+  let postMessage: ReturnType<typeof vi.fn>
+  let registeredWindowListeners: RegisteredWindowListener[]
+  let scrollLines: ReturnType<typeof vi.fn>
+  let terminals: TerminalStub[]
+
+  function boot(): void {
+    document.body.innerHTML = bodyMarkup()
+    new Function(iifeSource())()
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({ type: 'init', cols: 40, rows: 24, initialData: '' })
+      })
+    )
+    // Why: init commits the replacement surface on the next animation frame.
+    while (animationFrames.length > 0) {
+      animationFrames.shift()?.()
+    }
+  }
+
+  function flushFrames(): void {
+    for (let i = 0; i < 4 && animationFrames.length > 0; i++) {
+      animationFrames.shift()?.()
+    }
+  }
+
+  beforeEach(() => {
+    animationFrames = []
+    buffer = { baseY: 0, type: 'normal', viewportY: 0 }
+    registeredWindowListeners = []
+    scrollLines = vi.fn()
+    terminals = []
+    const addWindowEventListener = window.addEventListener.bind(window)
+    vi.spyOn(window, 'addEventListener').mockImplementation(((
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ) => {
+      registeredWindowListeners.push({ type, listener, options })
+      addWindowEventListener(type, listener, options)
+    }) as typeof window.addEventListener)
+    vi.stubGlobal('requestAnimationFrame', (callback: () => void) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', () => {})
+    Object.defineProperty(window, 'innerWidth', { value: 381, configurable: true })
+    Object.defineProperty(window, 'innerHeight', { value: 612, configurable: true })
+    postMessage = vi.fn()
+    const webWindow = window as unknown as {
+      Terminal: new () => TerminalStub
+      ReactNativeWebView: { postMessage: (data: string) => void }
+    }
+    webWindow.Terminal = function () {
+      const terminal = makeTerminal(buffer, scrollLines)
+      terminals.push(terminal)
+      return terminal
+    } as unknown as new () => TerminalStub
+    webWindow.ReactNativeWebView = { postMessage }
+  })
+
+  afterEach(() => {
+    for (const { type, listener, options } of registeredWindowListeners) {
+      window.removeEventListener(type, listener as EventListener, options)
+    }
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('turns an alternate-screen wheel scroll into cursor keys (#6863, #8818)', () => {
+    buffer = { baseY: 0, type: 'alternate', viewportY: 0 }
+    boot()
+    expect(terminals).toHaveLength(1)
+
+    dispatchWheel(3 * CELL_HEIGHT)
+
+    // Why: alt-screen TUIs (Claude Code, vim) have no scrollback, so an external
+    // mouse/trackpad wheel must reach the PTY as cursor keys the way touch does.
+    expect(terminalInputBytes(postMessage)).toBe(ESC_ARROW_DOWN.repeat(3))
+  })
+
+  it('sends application cursor keys when the TUI enabled DECCKM', () => {
+    buffer = { baseY: 0, type: 'alternate', viewportY: 0 }
+    boot()
+    const terminal = terminals[0]
+    if (!terminal) {
+      throw new Error('terminal missing')
+    }
+    ;(terminal.modes as Record<string, unknown>).applicationCursorKeysMode = true
+
+    dispatchWheel(-2 * CELL_HEIGHT)
+
+    expect(terminalInputBytes(postMessage)).toBe(ESC_APP_ARROW_UP.repeat(2))
+  })
+
+  it('reports the wheel as mouse tracking bytes when the TUI asked for them', () => {
+    buffer = { baseY: 0, type: 'alternate', viewportY: 0 }
+    boot()
+    const terminal = terminals[0]
+    if (!terminal) {
+      throw new Error('terminal missing')
+    }
+    terminal.modes.mouseTrackingMode = 'any'
+
+    dispatchWheel(CELL_HEIGHT)
+
+    // Default (non-SGR) encoding: wheel-down button 65 + 32 = 97 ('a'), then two
+    // printable cell bytes (their value depends on the fit scale, not on routing).
+    const bytes = terminalInputBytes(postMessage)
+    expect(bytes.slice(0, 4)).toBe(`${ESC}[Ma`)
+    expect(bytes).toHaveLength(6)
+    expect(bytes.charCodeAt(4)).toBeGreaterThanOrEqual(33)
+    expect(bytes.charCodeAt(5)).toBeGreaterThanOrEqual(33)
+  })
+
+  it('scrolls normal-buffer scrollback from a wheel instead of leaving it frozen', () => {
+    buffer = { baseY: 20, type: 'normal', viewportY: 20 }
+    boot()
+
+    dispatchWheel(-3 * CELL_HEIGHT)
+    flushFrames()
+
+    expect(scrollLines).toHaveBeenCalledWith(-3)
+  })
+
+  it('converts line-mode deltas that Android reports for external mouse wheels', () => {
+    buffer = { baseY: 0, type: 'alternate', viewportY: 0 }
+    boot()
+
+    dispatchWheel(2, { deltaMode: 1 })
+
+    expect(terminalInputBytes(postMessage)).toBe(ESC_ARROW_DOWN.repeat(2))
+  })
+
+  it('swallows a trackpad pinch instead of firing cursor keys at the TUI', () => {
+    buffer = { baseY: 0, type: 'alternate', viewportY: 0 }
+    boot()
+
+    const event = dispatchWheel(3 * CELL_HEIGHT, { ctrlKey: true })
+
+    expect(terminalInputBytes(postMessage)).toBe('')
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('claims the wheel so xterm does not double-apply it', () => {
+    buffer = { baseY: 20, type: 'normal', viewportY: 20 }
+    boot()
+
+    const event = dispatchWheel(-CELL_HEIGHT)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('clears fractional wheel state when the terminal is recreated', () => {
+    buffer = { baseY: 0, type: 'alternate', viewportY: 0 }
+    boot()
+    dispatchWheel(CELL_HEIGHT - 1)
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({ type: 'init', cols: 40, rows: 24, initialData: '' })
+      })
+    )
+    flushFrames()
+    dispatchWheel(1)
+
+    expect(terminalInputBytes(postMessage)).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

- Capture external mouse and trackpad wheel events before xterm can turn them into dropped terminal input.
- Reuse the existing touch scroll router for normal-buffer scrollback, alternate-screen cursor keys, and TUI mouse tracking.
- Normalize pixel, line, and page deltas; swallow trackpad pinch events; reset fractional state when a terminal surface is recreated.

## Scope

This fixes the trackpad behavior confirmed in the 2026-07-28 iPad comment on #6863 and the wheel portion of #8818. The original #6863 Android phone/finger premise does not reproduce on current main; touch routing landed earlier in #1940 and #5844, so this PR does not claim to close #6863 as filed. The click/drag portion of #8818 is deliberately out of scope.

## Validation

- Mobile suite: 352 files passed; 2,598 tests passed; 2 skipped.
- Focused terminal routing suite after the final rebase: 8 files / 58 tests passed.
- Mobile lint, typecheck, format check, and git diff check passed.
- Same-model senior review loop returned CLEAN after one fractional wheel-state lifecycle finding was fixed and covered by a regression test.
- The current branch bundled and launched in the iOS simulator and reached the Orca host list.

The iOS simulator cannot synthesize a real external trackpad wheel, no live desktop host was available to reach a terminal session, and Android device/emulator validation was unavailable because adb is not installed. Device-level indirect-pointer behavior is therefore assumed from WebView event semantics and the integration coverage for normal/alternate buffers, TUI mouse tracking, Android line-mode deltas, pinch suppression, and surface recreation.