### PR TITLE
fix(skills): stop calling the updater's own install a modified copy

### DIFF
--- a/config/tsconfig.node.json
+++ b/config/tsconfig.node.json
@@ -4,6 +4,7 @@
     "../electron.vite.config.*",
     "../build-plugins/**/*",
     "../src/main/**/*",
+    "../src/renderer/src/lib/skill-freshness-display-status.ts",
     "../src/preload/**/*",
     "../src/shared/**/*",
     "../src/relay/**/*",

--- a/src/main/skills/skill-freshness-inventory.test.ts
+++ b/src/main/skills/skill-freshness-inventory.test.ts
@@ -1,6 +1,8 @@
+import { execFile } from 'node:child_process'
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { promisify } from 'node:util'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { Repo } from '../../shared/types'
 import type {
@@ -13,8 +15,30 @@ import {
   MAXIMUM_REPOSITORY_SKILL_ROOTS
 } from './skill-freshness-inventory'
 import { describeObservedSkillFile, skillPackageDigest } from './skill-package-identity'
+import { getSkillFreshnessDisplayStatus } from '../../renderer/src/lib/skill-freshness-display-status'
 
 const temporaryDirectories: string[] = []
+
+const execFileAsync = promisify(execFile)
+
+// Why: hashed with real git, not Orca's tree-sha port — the port validating
+// itself here would prove nothing about matching the updater lock's hash.
+async function gitTreeShaOf(directory: string): Promise<string> {
+  const gitDir = await mkdtemp(join(tmpdir(), 'orca-skill-hash-'))
+  temporaryDirectories.push(gitDir)
+  const env = {
+    ...process.env,
+    GIT_DIR: gitDir,
+    GIT_WORK_TREE: directory,
+    GIT_INDEX_FILE: join(gitDir, 'scratch-index'),
+    GIT_CONFIG_GLOBAL: join(gitDir, 'no-config'),
+    GIT_CONFIG_SYSTEM: join(gitDir, 'no-config')
+  }
+  await execFileAsync('git', ['init', '--quiet'], { env, cwd: directory })
+  await execFileAsync('git', ['add', '-A'], { env, cwd: directory })
+  const { stdout } = await execFileAsync('git', ['write-tree'], { env, cwd: directory })
+  return stdout.trim()
+}
 
 function snapshot(releaseRevision: number, markdown: string): SkillKnownSnapshot {
   const observed = describeObservedSkillFile('SKILL.md', Buffer.from(markdown), false)
@@ -115,6 +139,22 @@ async function fixture() {
   }
 }
 
+async function writeSkillLockHash(homeDir: string, skillFolderHash: string): Promise<void> {
+  await writeFile(
+    join(homeDir, '.agents', '.skill-lock.json'),
+    `${JSON.stringify({
+      version: 3,
+      skills: {
+        'orca-cli': {
+          skillFolderHash,
+          skillPath: 'skills/orca-cli/SKILL.md',
+          source: 'stablyai/orca'
+        }
+      }
+    })}\n`
+  )
+}
+
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map((root) => rm(root, { recursive: true })))
 })
@@ -176,6 +216,80 @@ describe('read-only skill freshness inventory', () => {
       'unrecognized'
     ])
     expect(inventory.eligibleUpdateNames).toEqual([])
+  })
+
+  it('trusts the updater lock for canonical bytes the bundle has never seen (#11220 scan half)', async () => {
+    // The steady state days after a release: `skills update` installed source-repo
+    // HEAD, wrote its lock, and no shipped bundle knows that revision yet.
+    const test = await fixture()
+    const upstreamMarkdown = `${test.newerMarkdown}\nUpstream edit no bundle has shipped.\n`
+    const canonical = await test.writeSkill(
+      join(test.homeDir, '.agents', 'skills'),
+      upstreamMarkdown
+    )
+    await writeSkillLockHash(test.homeDir, await gitTreeShaOf(canonical))
+
+    const inventory = await inventorySkillFreshness({
+      currentAppVersion: '2.0.0',
+      homeDir: test.homeDir,
+      repos: [],
+      resourceRoot: test.resourceRoot
+    })
+
+    expect(inventory.installations[0]).toMatchObject({
+      topology: 'canonical-copy',
+      status: 'newer-known'
+    })
+    // Why: ahead of the bundle means there is nothing this build can update to.
+    expect(inventory.eligibleUpdateNames).toEqual([])
+    // The user-visible verdict, across both halves of the fix: the row must read
+    // up to date, not amber "may be modified… remove it" over the CLI's own install.
+    expect(getSkillFreshnessDisplayStatus(inventory, 'orca-cli')).toBe('up-to-date')
+  })
+
+  it('still flags canonical bytes that do not match what the lock says was installed', async () => {
+    const test = await fixture()
+    const editedMarkdown = `${test.currentMarkdown}\nLocal edit the updater never wrote.\n`
+    await test.writeSkill(join(test.homeDir, '.agents', 'skills'), editedMarkdown)
+    const elsewhere = await test.writeSkill(join(test.root, 'elsewhere'), test.newerMarkdown)
+    await writeSkillLockHash(test.homeDir, await gitTreeShaOf(elsewhere))
+
+    const inventory = await inventorySkillFreshness({
+      currentAppVersion: '2.0.0',
+      homeDir: test.homeDir,
+      repos: [],
+      resourceRoot: test.resourceRoot
+    })
+
+    expect(inventory.installations[0]).toMatchObject({
+      topology: 'canonical-copy',
+      status: 'unrecognized'
+    })
+    expect(getSkillFreshnessDisplayStatus(inventory, 'orca-cli')).toBe('needs-attention')
+  })
+
+  it('does not let the lock vouch for a same-name copy outside the placements it wrote', async () => {
+    const test = await fixture()
+    await test.writeSkill(join(test.homeDir, '.agents', 'skills'), test.currentMarkdown)
+    const independent = await test.writeSkill(
+      join(test.homeDir, '.claude', 'skills'),
+      '---\nname: orca-cli\n---\n\nAnother tool.\n'
+    )
+    await writeSkillLockHash(test.homeDir, await gitTreeShaOf(independent))
+
+    const inventory = await inventorySkillFreshness({
+      currentAppVersion: '2.0.0',
+      homeDir: test.homeDir,
+      repos: [],
+      resourceRoot: test.resourceRoot
+    })
+
+    expect(inventory.installations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ topology: 'independent-copy', status: 'unrecognized' })
+      ])
+    )
+    expect(getSkillFreshnessDisplayStatus(inventory, 'orca-cli')).toBe('needs-attention')
   })
 
   it('retains full-file identity without projecting unused metadata', async () => {

--- a/src/main/skills/skill-freshness-inventory.ts
+++ b/src/main/skills/skill-freshness-inventory.ts
@@ -1,9 +1,10 @@
 import { lstat } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { Repo } from '../../shared/types'
-import type {
-  SkillFreshnessInstallation,
-  SkillFreshnessInventory
+import {
+  SUPPORTED_GLOBAL_SKILL_TOPOLOGIES,
+  type SkillFreshnessInstallation,
+  type SkillFreshnessInventory
 } from '../../shared/skill-freshness'
 import { buildSkillDiscoverySources, type SkillScanRoot } from './skill-discovery-sources'
 import { loadSkillBundleArtifacts } from './skill-bundle-artifacts'
@@ -21,6 +22,24 @@ import { convergableSkillNames } from './skill-update-convergence'
 import { readGloballyUpdatableSkillLocks } from './skill-update-registration'
 
 export const MAXIMUM_REPOSITORY_SKILL_ROOTS = 128
+
+// Why: the updater installs source-repo HEAD, which legitimately runs ahead of the
+// bundled registry — content the bundle has never seen is the steady state right
+// after an update. Bytes whose git tree sha equals the lock's recorded hash are the
+// CLI's own install, not a user edit, so calling them "unrecognized" (modified) is
+// false. Judged only over the placements the update command writes; a same-name
+// copy elsewhere earns no trust from someone else's lock entry.
+function trustLockInstalledRevision(
+  installation: SkillFreshnessInstallation,
+  globalSkillLocks: ReadonlyMap<string, string>
+): SkillFreshnessInstallation {
+  return installation.status === 'unrecognized' &&
+    SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(installation.topology) &&
+    installation.observedGitTreeSha != null &&
+    installation.observedGitTreeSha === globalSkillLocks.get(installation.name)
+    ? { ...installation, status: 'newer-known' }
+    : installation
+}
 
 export function boundRepositorySkillRoots(roots: readonly SkillScanRoot[]): {
   scanned: SkillScanRoot[]
@@ -160,11 +179,13 @@ export async function inventorySkillFreshness(args: {
   const installations = dedupeSkillFreshnessPlacements([
     ...homeInstallations,
     ...unsupportedInstallations
-  ]).sort(
-    (left, right) =>
-      left.name.localeCompare(right.name, 'en') ||
-      left.unresolvedPath.localeCompare(right.unresolvedPath, 'en')
-  )
+  ])
+    .map((installation) => trustLockInstalledRevision(installation, globalSkillLocks))
+    .sort(
+      (left, right) =>
+        left.name.localeCompare(right.name, 'en') ||
+        left.unresolvedPath.localeCompare(right.unresolvedPath, 'en')
+    )
 
   return {
     schemaVersion: 1,

--- a/src/main/skills/skill-update-outcome.test.ts
+++ b/src/main/skills/skill-update-outcome.test.ts
@@ -223,12 +223,15 @@ describe('skillUpdateFailedNames over a real inventory', () => {
     })
     const locks = await readGloballyUpdatableSkillLocks({ homeDir })
 
-    // Guard the premise: this is the unrecognized path, not an accidental match.
+    // Guard the premise: no snapshot knows these bytes, so recognition can only
+    // come from the lock — the scan now reclassifies that match to 'newer-known'
+    // (the #11220 scan half), and the verdict accepts it either way.
     const canonical = inventory.installations.filter(
       (entry) => entry.name === 'orca-cli' && entry.topology === 'canonical-copy'
     )
     expect(canonical).toHaveLength(1)
-    expect(canonical[0].status).toBe('unrecognized')
+    expect(canonical[0].status).toBe('newer-known')
+    expect(canonical[0].installedReleaseRevision).toBeNull()
 
     expect(skillUpdateFailedNames(['orca-cli'], inventory.installations, locks)).toEqual([])
   })

--- a/src/renderer/src/components/skills/skill-freshness-grouping.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-grouping.test.ts
@@ -99,6 +99,14 @@ describe('groupSkillFreshness', () => {
     expect(groups[0]?.locations[0]?.chip).toBe('unrecognized')
   })
 
+  it('raises no row for a copy that is ahead of this build', () => {
+    // Why: 'newer-known' is recognized official content — the updater's own install
+    // or a newer release's bytes. The badge stays green for it, so a row here would
+    // recreate the badge/dialog disagreement #11128 removed, from the other side.
+    const groups = groupSkillFreshness([placement('orchestration', { status: 'newer-known' })], [])
+    expect(groups).toEqual([])
+  })
+
   it('groups a blocked skill and flags the culprit location, not the main copy', () => {
     const groups = groupSkillFreshness(
       [

--- a/src/renderer/src/lib/skill-freshness-display-status.test.ts
+++ b/src/renderer/src/lib/skill-freshness-display-status.test.ts
@@ -149,6 +149,25 @@ describe('getSkillFreshnessDisplayStatus', () => {
     )
   })
 
+  it('shows recognized-newer content as up to date instead of blaming the user', () => {
+    // Why: 'newer-known' is official content ahead of this build — the updater's own
+    // install or a newer release's bytes. Amber here sent users on a remove/reinstall
+    // loop that lands the same newer content (#11220's scan half).
+    const value = inventory([placement('newer-known')])
+
+    expect(getSkillFreshnessDisplayStatus(value, SKILL_NAME)).toBe('up-to-date')
+    expect(hasSkillCopyNeedingAttention(value, SKILL_NAME)).toBe(false)
+  })
+
+  it('still reports drift beside a newer-known copy', () => {
+    expect(
+      getSkillFreshnessDisplayStatus(
+        inventory([placement('newer-known'), placement('unrecognized', 1)]),
+        SKILL_NAME
+      )
+    ).toBe('needs-attention')
+  })
+
   it('still reports drift in our own copy when a plugin-managed one sits alongside', () => {
     expect(
       getSkillFreshnessDisplayStatus(

--- a/src/renderer/src/lib/skill-freshness-display-status.ts
+++ b/src/renderer/src/lib/skill-freshness-display-status.ts
@@ -24,8 +24,12 @@ export function getSkillFreshnessDisplayStatus(
       continue
     }
     hasPlacement = true
+    // Why: 'newer-known' is recognized official content ahead of this build — the
+    // updater's own install or a newer release's bytes. There is nothing to fix and
+    // nothing to update to, so amber would send the user chasing a phantom edit.
     if (
       installation.status !== 'current' &&
+      installation.status !== 'newer-known' &&
       !(installation.status === 'unrecognized' && installation.topology === 'plugin-cache')
     ) {
       hasBlockedCopy = true

--- a/src/shared/skill-freshness.ts
+++ b/src/shared/skill-freshness.ts
@@ -98,6 +98,10 @@ export type SkillFreshnessInstallation = {
 export function isSkillCopyNeedingAttention(installation: SkillFreshnessInstallation): boolean {
   return (
     installation.status !== 'current' &&
+    // Why: 'newer-known' is recognized official content ahead of this build — the
+    // updater's own install or a newer release's bytes. There is nothing to fix and
+    // nothing to update to, so amber would send the user chasing a phantom edit.
+    installation.status !== 'newer-known' &&
     !(installation.status === 'unrecognized' && installation.topology === 'plugin-cache') &&
     !(
       SUPPORTED_GLOBAL_SKILL_TOPOLOGIES.has(installation.topology) &&


### PR DESCRIPTION
## The bug

Click **Update** on a skill. The CLI fetches source-repo HEAD, writes the bytes, exits 0, records its lock. The run dialog says "Updated 1 skill" (#11220). Then the row goes amber **Needs attention**, and Details advises the copy "may be modified… Remove it" — about bytes our own button just installed. Following that advice loops: remove + reinstall lands the same newer content. The skill also silently drops out of update eligibility until a future build bundles that revision.

Content newer than the bundle is the steady state, not an edge case — skills/ gets commits ~every other day, so upstream runs ahead of any shipped bundle within days of a release. #11220 fixed the post-run verdict only; the scan itself never consulted the updater lock.

## The fix (two halves; each is inert without the other)

- **Scan** (`skill-freshness-inventory.ts`): a canonical/provider-alias placement classified `unrecognized` whose observed git tree sha equals the lock's `skillFolderHash` is the CLI's own install — reclassify to `newer-known`. Judged only over the placements the update command writes; a same-name copy elsewhere earns no trust from someone else's lock entry.
- **Display**: `newer-known` is recognized official content ahead of this build — exempt it from attention in the two deciders that #11128 left: the inline `hasBlockedCopy` loop in `getSkillFreshnessDisplayStatus`, and the shared `isSkillCopyNeedingAttention` predicate (which #11128 introduced precisely so the badge, the pill's amber Details, and the dialog rows cannot disagree — one edit covers all three).

This lands on top of #11128 and #11248, which reshaped the same surface: #11128's shared predicate is where the exemption now lives, and #11248's `newer` chip + skipped-reason copy already give a pinned post-run `newer-known` row honest wording ("later version… Orca left it alone rather than roll it back").

**Eligibility deliberately unchanged**: `newer-known` still doesn't produce `hasOutdated`, so no update is offered. Ahead of the bundle means there is nothing this build can prove an update would change; offering one risks the provably-unperformable update (#11110) when source HEAD still equals the lock. When a future build bundles a newer revision, the copy classifies `outdated` via the snapshot registry and the offer returns on its own.

## Why trusting the lock is sound (verified against `skills` CLI v1.5.20 source, vercel-labs/skills)

- `skillFolderHash` for GitHub sources **is the git tree SHA of the skill folder** (Trees API entry `type === 'tree'`, `blob.ts` `getSkillFolderHashFromTree`; schema comment in `skill-lock.ts:26-31`). Git tree shas cover contents, modes, symlinks, and nested dirs — sha equality is byte-for-byte folder equality.
- **The lock is written only after the files land**: `add.ts` installs first (`installSkillForAgent`/`installBlobSkillForAgent`), then writes lock entries only for skills in `successfulSkillNames` (`add.ts` ~1809-1856). Every mismatch scenario (clone-vs-tree race, skipped file, torn lock write, interrupted install) makes disk ≠ lock and **fails closed** to today's amber behavior.
- Its update predicate is `latestHash !== entry.skillFolderHash` (`update.ts:373-375`, `:410-411`) — lock vs source, never disk. That's why a stale lock can never be converged by re-running, and why the scan trusting disk == lock is the only honest read.
- Non-GitHub sources record a custom sha256 (64 hex) that can never equal a 40-hex tree sha — the new path is inert there, again failing closed.

## Proof

- **Fail-first**: the new tests are red with the fix reverted (both on the original base a6423d565b and re-verified after rebasing onto a721125d06).
- **Per-half mutation (re-run post-rebase)**: reverting the scan half alone → 2 tests fail; reverting the whole display half → 2 fail; reverting ONLY the shared-predicate exemption → 2 fail (display unit + grouping row test); reverting ONLY the inline-loop exemption → 2 fail. No piece is silently removable.
- **Must-not-weaken**: sha ≠ lock stays `unrecognized`/amber; no lock entry stays flagged; a same-name independent copy at the lock's own sha is not trusted; plugin-cache behavior untouched; a `newer-known`-only skill produces no dialog row (would recreate the badge/dialog disagreement #11128 removed, from the other side).
- Unit tests hash fixtures with **real git** (`write-tree` in an isolated GIT_DIR), not Orca's own tree-sha port.

## Live A/B (real app, isolated $HOME, real-git-hashed lock; fresh main process per side)

Fixture: bundled `orchestration` + `orca-cli` copied to `$HOME/.agents/skills` with an appended line (unknown to every bundled snapshot), provider symlinks, lock v3 with each folder's real `git write-tree` sha.

**origin/main @ a721125d06 (includes #11128/#11248)** — scan: `unrecognized` despite sha == lock; sidebar + pill amber "Needs attention"; Details now shows the full misleading advice for both of the CLI's own installs:

![A2-details-dialog.png](https://github.com/user-attachments/assets/124993be-bf52-4f7e-9819-531a075ea8c3)

**this branch @ 297985165e, same fixture** — scan: `newer-known`; sidebar + pill "Up to date", no attention affordance, no "modified" text anywhere:

![B2-orchestration-green.png](https://github.com/user-attachments/assets/143397b8-87b3-4dec-a970-a56147e16edc)

**Live negative control on this branch**: appending one more line (lock not updated) flips the same skill back to `unrecognized` / "Needs attention" on Re-check; restoring the bytes flips it green again.

<details><summary>Pre-rebase A/B against a6423d565b (before #11128 landed)</summary>

Same fixture and result at the badge/pill level. One rig note from that round: the dialog could not render the "may be modified… Remove it" sentence there, because before #11128 the dialog only listed outdated-or-pinned skills — the badge said "Needs attention" while the dialog said "All installed Orca skills are up to date":

![A-orchestration-amber.png](https://github.com/user-attachments/assets/9ca40dd6-cc07-4d7b-ace1-f09b4099c97b)
![A-details-dialog.png](https://github.com/user-attachments/assets/a297ffff-74c9-4f3a-853a-16adbac14fed)
![B-orchestration-green.png](https://github.com/user-attachments/assets/6ae34076-c6ea-4439-a902-4c761527e79e)

</details>
