### PR TITLE
fix(mobile): keep closed sessions empty

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -198,6 +198,7 @@ import {
   confirmsMirroredTabSelection,
   type AppliedSnapshotMarker
 } from '../../../../src/session/session-tab-snapshot-gate'
+import { useInitialSessionTerminalAutoCreate } from '../../../../src/session/use-initial-session-terminal-autocreate'
 import {
   buildMarkdownDiskFallbackDoc,
   shouldReadMarkdownFromDiskAfterReadTabFailure
@@ -1033,6 +1034,8 @@ export default function SessionScreen() {
   const handleCreateBrowserRef = useRef<((rawUrl?: string) => Promise<boolean>) | null>(null)
 
   const initialEmptySessionAutoCreateRef = useRef<string | null>(null)
+  // Why: emptiness after a populated list is a close, not a cold hydrate — see initial-session-terminal.
+  const sawSessionTabsRef = useRef(false)
   const markdownSaveSeqRef = useRef<Map<string, number>>(new Map())
   const markdownSaveInFlightRef = useRef<Set<string>>(new Set())
   const subscribeSeqRef = useRef<Map<string, number>>(new Map())
@@ -1774,6 +1777,7 @@ export default function SessionScreen() {
         nextTabs = [...orphanedDraftTabs, ...nextTabs]
       }
       sessionTabsRef.current = nextTabs
+      sawSessionTabsRef.current ||= nextTabs.length > 0
       // Why: subscribe snapshots often repeat identical payloads; skip re-set to avoid a subscription teardown/replay loop.
       setSessionTabs((prev) => (mobileSessionTabsEqual(prev, nextTabs) ? prev : nextTabs))
       const terminalTabs = getTerminalRecordsFromSessionTabs(nextTabs)
@@ -2633,6 +2637,7 @@ export default function SessionScreen() {
     pendingBrowserFocusPageIdRef.current = null
     pendingTerminalActivationAttemptRef.current = null
     initialEmptySessionAutoCreateRef.current = null
+    sawSessionTabsRef.current = false
     terminalDiagnosticsRef.current.resetRoute()
     appliedSnapshotMarkerRef.current = { epoch: null, version: -1 }
     closedTabTombstonesRef.current.clear()
@@ -4227,22 +4232,19 @@ export default function SessionScreen() {
   const showEmptyState =
     connState === 'connected' && terminalsLoaded && visibleTabs.length === 0 && !activeHandle
 
-  useEffect(() => {
-    if (
-      !client ||
-      !showEmptyState ||
-      creating ||
-      creatingBrowser ||
-      creatingMarkdown ||
-      initialEmptySessionAutoCreateRef.current === worktreeId
-    ) {
-      return
-    }
-    // Why: a sleeping/new workspace can hydrate with zero tabs; create the first terminal once so mobile isn't blank.
-    initialEmptySessionAutoCreateRef.current = worktreeId
-    setCreateError('')
-    void handleCreateTerminal()
-  }, [client, creating, creatingBrowser, creatingMarkdown, showEmptyState, worktreeId])
+  // Why: a sleeping/new workspace can hydrate with zero tabs; create the first terminal once so mobile isn't blank.
+  useInitialSessionTerminalAutoCreate({
+    client,
+    connState,
+    terminalsLoaded,
+    visibleTabCount: visibleTabs.length,
+    activeHandle,
+    createInFlight: creating || creatingBrowser || creatingMarkdown,
+    sawSessionTabsRef,
+    autoCreatedForWorktreeRef: initialEmptySessionAutoCreateRef,
+    worktreeId,
+    createTerminal: () => void handleCreateTerminal()
+  })
 
   // Why: reconnect trickles to 90s at its give-up cap; surface tap-to-retry so recovery needn't wait it out (issue #5049).
   const connectionVerdict = classifyConnection({

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -198,7 +198,11 @@ import {
   confirmsMirroredTabSelection,
   type AppliedSnapshotMarker
 } from '../../../../src/session/session-tab-snapshot-gate'
-import { useInitialSessionTerminalAutoCreate } from '../../../../src/session/use-initial-session-terminal-autocreate'
+import {
+  createInitialSessionAutoCreateState,
+  useInitialSessionTerminalAutoCreate,
+  useWorktreeSessionTabsLoaded
+} from '../../../../src/session/use-initial-session-terminal-autocreate'
 import {
   buildMarkdownDiskFallbackDoc,
   shouldReadMarkdownFromDiskAfterReadTabFailure
@@ -891,7 +895,7 @@ export default function SessionScreen() {
   const appliedSessionTabsRevisionRef = useRef(0)
   // Why: after an optimistic close, suppress the tab (with expiry) until the publisher confirms, so an in-flight snapshot can't flash it back.
   const closedTabTombstonesRef = useRef<Map<string, number>>(new Map())
-  const [terminalsLoaded, setTerminalsLoaded] = useState(false)
+  const [terminalsLoaded, setTerminalsLoaded] = useWorktreeSessionTabsLoaded(worktreeId)
   const [input, setInput] = useState('')
   // Why: baseline terminal zoom reloaded on focus so a Settings → Terminal change applies in place (panes stay mounted).
   const [terminalTextScale, setTerminalTextScale] = useState(1)
@@ -1033,9 +1037,7 @@ export default function SessionScreen() {
   // Why: route the terminal URL tap through a ref so it runs the current handleCreateBrowser closure (the memoized one may hold a null-client render).
   const handleCreateBrowserRef = useRef<((rawUrl?: string) => Promise<boolean>) | null>(null)
 
-  const initialEmptySessionAutoCreateRef = useRef<string | null>(null)
-  // Why: emptiness after a populated list is a close, not a cold hydrate — see initial-session-terminal.
-  const sawSessionTabsRef = useRef(false)
+  const initialSessionAutoCreateRef = useRef(createInitialSessionAutoCreateState())
   const markdownSaveSeqRef = useRef<Map<string, number>>(new Map())
   const markdownSaveInFlightRef = useRef<Set<string>>(new Set())
   const subscribeSeqRef = useRef<Map<string, number>>(new Map())
@@ -1777,7 +1779,7 @@ export default function SessionScreen() {
         nextTabs = [...orphanedDraftTabs, ...nextTabs]
       }
       sessionTabsRef.current = nextTabs
-      sawSessionTabsRef.current ||= nextTabs.length > 0
+      initialSessionAutoCreateRef.current.sawSessionTabs ||= nextTabs.length > 0
       // Why: subscribe snapshots often repeat identical payloads; skip re-set to avoid a subscription teardown/replay loop.
       setSessionTabs((prev) => (mobileSessionTabsEqual(prev, nextTabs) ? prev : nextTabs))
       const terminalTabs = getTerminalRecordsFromSessionTabs(nextTabs)
@@ -2636,8 +2638,7 @@ export default function SessionScreen() {
     pendingActiveTerminalHandleRef.current = null
     pendingBrowserFocusPageIdRef.current = null
     pendingTerminalActivationAttemptRef.current = null
-    initialEmptySessionAutoCreateRef.current = null
-    sawSessionTabsRef.current = false
+    initialSessionAutoCreateRef.current = createInitialSessionAutoCreateState()
     terminalDiagnosticsRef.current.resetRoute()
     appliedSnapshotMarkerRef.current = { epoch: null, version: -1 }
     closedTabTombstonesRef.current.clear()
@@ -4232,17 +4233,18 @@ export default function SessionScreen() {
   const showEmptyState =
     connState === 'connected' && terminalsLoaded && visibleTabs.length === 0 && !activeHandle
 
-  // Why: a sleeping/new workspace can hydrate with zero tabs; create the first terminal once so mobile isn't blank.
+  // Why: a newly created workspace can hydrate with zero tabs before its first terminal exists.
   useInitialSessionTerminalAutoCreate({
     client,
+    newlyCreatedWorkspace: created === '1',
     connState,
     terminalsLoaded,
     visibleTabCount: visibleTabs.length,
     activeHandle,
     createInFlight: creating || creatingBrowser || creatingMarkdown,
-    sawSessionTabsRef,
-    autoCreatedForWorktreeRef: initialEmptySessionAutoCreateRef,
+    stateRef: initialSessionAutoCreateRef,
     worktreeId,
+    consumeCreationRoute: () => router.setParams({ created: undefined }),
     createTerminal: () => void handleCreateTerminal()
   })
 

--- a/mobile/src/session/initial-session-terminal.test.ts
+++ b/mobile/src/session/initial-session-terminal.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  shouldAutoCreateInitialSessionTerminal,
+  type InitialSessionTerminalAutoCreateInput
+} from './initial-session-terminal'
+
+function baseInput(
+  overrides: Partial<InitialSessionTerminalAutoCreateInput> = {}
+): InitialSessionTerminalAutoCreateInput {
+  return {
+    connected: true,
+    tabsLoaded: true,
+    visibleTabCount: 0,
+    hasActiveTerminalHandle: false,
+    createInFlight: false,
+    sawSessionTabs: false,
+    autoCreatedForWorktree: false,
+    ...overrides
+  }
+}
+
+/**
+ * Replays the route state the session screen actually holds
+ * (`app/h/[hostId]/session/[worktreeId].tsx`): `applySessionTabs` publishes the
+ * tab list and flips `terminalsLoaded`, `handleCloseSessionTab` prunes the
+ * closed tab and nulls the active handle.
+ */
+class SessionRouteState {
+  tabsLoaded = false
+  tabIds: string[] = []
+  activeHandle: string | null = null
+  sawSessionTabs = false
+  autoCreatedForWorktree = false
+
+  applySessionTabs(tabIds: string[], activeHandle: string | null = tabIds[0] ? 'pty-1' : null) {
+    this.tabIds = tabIds
+    this.activeHandle = activeHandle
+    if (tabIds.length > 0) {
+      this.sawSessionTabs = true
+    }
+    this.tabsLoaded = true
+  }
+
+  closeSessionTab(tabId: string) {
+    this.tabIds = this.tabIds.filter((candidate) => candidate !== tabId)
+    this.activeHandle = null
+  }
+
+  gate(): boolean {
+    return shouldAutoCreateInitialSessionTerminal({
+      connected: true,
+      tabsLoaded: this.tabsLoaded,
+      visibleTabCount: this.tabIds.length,
+      hasActiveTerminalHandle: this.activeHandle !== null,
+      createInFlight: false,
+      sawSessionTabs: this.sawSessionTabs,
+      autoCreatedForWorktree: this.autoCreatedForWorktree
+    })
+  }
+}
+
+describe('shouldAutoCreateInitialSessionTerminal', () => {
+  it('creates the first terminal for a workspace that hydrates with nothing', () => {
+    const route = new SessionRouteState()
+    route.applySessionTabs([])
+    expect(route.gate()).toBe(true)
+  })
+
+  it('does not re-create after the user closes the last tab (#9717, #7345)', () => {
+    const route = new SessionRouteState()
+    route.applySessionTabs(['tab-1'])
+    expect(route.gate()).toBe(false)
+
+    route.closeSessionTab('tab-1')
+    expect(route.tabIds).toHaveLength(0)
+    expect(route.activeHandle).toBeNull()
+    // Emptiness that follows a populated list is a close, not a cold hydrate.
+    expect(route.gate()).toBe(false)
+  })
+
+  it('does not re-create when the host drops every tab mid-session', () => {
+    const route = new SessionRouteState()
+    route.applySessionTabs(['tab-1', 'tab-2'])
+    route.applySessionTabs([], null)
+    expect(route.gate()).toBe(false)
+  })
+
+  it('stays armed while an empty workspace is still loading', () => {
+    expect(shouldAutoCreateInitialSessionTerminal(baseInput({ tabsLoaded: false }))).toBe(false)
+  })
+
+  it('waits for the host connection', () => {
+    expect(shouldAutoCreateInitialSessionTerminal(baseInput({ connected: false }))).toBe(false)
+  })
+
+  it('defers to a lagging snapshot that still has a streaming terminal', () => {
+    expect(
+      shouldAutoCreateInitialSessionTerminal(baseInput({ hasActiveTerminalHandle: true }))
+    ).toBe(false)
+  })
+
+  it('does not stack a second create on an in-flight one', () => {
+    expect(shouldAutoCreateInitialSessionTerminal(baseInput({ createInFlight: true }))).toBe(false)
+  })
+
+  it('fires at most once per workspace on this route', () => {
+    expect(
+      shouldAutoCreateInitialSessionTerminal(baseInput({ autoCreatedForWorktree: true }))
+    ).toBe(false)
+  })
+
+  it('does not fire while tabs are visible', () => {
+    expect(shouldAutoCreateInitialSessionTerminal(baseInput({ visibleTabCount: 2 }))).toBe(false)
+  })
+})

--- a/mobile/src/session/initial-session-terminal.test.ts
+++ b/mobile/src/session/initial-session-terminal.test.ts
@@ -8,6 +8,7 @@ function baseInput(
   overrides: Partial<InitialSessionTerminalAutoCreateInput> = {}
 ): InitialSessionTerminalAutoCreateInput {
   return {
+    newlyCreatedWorkspace: true,
     connected: true,
     tabsLoaded: true,
     visibleTabCount: 0,
@@ -26,6 +27,7 @@ function baseInput(
  * closed tab and nulls the active handle.
  */
 class SessionRouteState {
+  newlyCreatedWorkspace = true
   tabsLoaded = false
   tabIds: string[] = []
   activeHandle: string | null = null
@@ -48,6 +50,7 @@ class SessionRouteState {
 
   gate(): boolean {
     return shouldAutoCreateInitialSessionTerminal({
+      newlyCreatedWorkspace: this.newlyCreatedWorkspace,
       connected: true,
       tabsLoaded: this.tabsLoaded,
       visibleTabCount: this.tabIds.length,
@@ -76,6 +79,34 @@ describe('shouldAutoCreateInitialSessionTerminal', () => {
     expect(route.activeHandle).toBeNull()
     // Emptiness that follows a populated list is a close, not a cold hydrate.
     expect(route.gate()).toBe(false)
+  })
+
+  it('does not re-create after the consumed creation route remounts empty', () => {
+    const creationRoute = new SessionRouteState()
+    creationRoute.applySessionTabs([])
+    expect(creationRoute.gate()).toBe(true)
+    creationRoute.newlyCreatedWorkspace = false
+    creationRoute.autoCreatedForWorktree = true
+    creationRoute.applySessionTabs(['tab-1'])
+    creationRoute.closeSessionTab('tab-1')
+    expect(creationRoute.gate()).toBe(false)
+
+    const reopenedRoute = new SessionRouteState()
+    reopenedRoute.newlyCreatedWorkspace = creationRoute.newlyCreatedWorkspace
+    reopenedRoute.applySessionTabs([])
+    expect(reopenedRoute.gate()).toBe(false)
+  })
+
+  it('does not create from stale empty state while switching ordinary workspace routes', () => {
+    expect(
+      shouldAutoCreateInitialSessionTerminal(
+        baseInput({
+          newlyCreatedWorkspace: false,
+          tabsLoaded: true,
+          visibleTabCount: 0
+        })
+      )
+    ).toBe(false)
   })
 
   it('does not re-create when the host drops every tab mid-session', () => {

--- a/mobile/src/session/initial-session-terminal.ts
+++ b/mobile/src/session/initial-session-terminal.ts
@@ -1,0 +1,44 @@
+// Mirrors the desktop `shouldAutoCreateInitialTerminal` gate: a workspace that
+// hydrates with nothing to show gets one terminal so the session isn't blank.
+// Kept pure (no react-native imports) so the gate is unit-testable.
+
+export type InitialSessionTerminalAutoCreateInput = {
+  /** Host connection is up and an RPC client is attached. */
+  connected: boolean
+  /** At least one session-tab snapshot has been applied on this route. */
+  tabsLoaded: boolean
+  /** Session tabs currently rendered on the phone. */
+  visibleTabCount: number
+  /** A terminal is still streaming even though the tab list reads empty. */
+  hasActiveTerminalHandle: boolean
+  /** A terminal, browser, or markdown create is already in flight. */
+  createInFlight: boolean
+  /** This route has shown at least one session tab for this workspace. */
+  sawSessionTabs: boolean
+  /** This route already auto-created a terminal for this workspace. */
+  autoCreatedForWorktree: boolean
+}
+
+/**
+ * Whether to auto-create the first terminal of an empty mobile session.
+ *
+ * `sawSessionTabs` is the resurrection guard: emptiness that *follows* a
+ * populated tab list was produced by a close (the user's, or the host dropping
+ * a dead pane), and re-creating there spawns a brand-new terminal the user
+ * never asked for — issues #9717 / #7345. Only a workspace that has shown
+ * nothing since this route opened is eligible.
+ */
+export function shouldAutoCreateInitialSessionTerminal(
+  input: InitialSessionTerminalAutoCreateInput
+): boolean {
+  if (!input.connected || !input.tabsLoaded) {
+    return false
+  }
+  if (input.visibleTabCount > 0 || input.hasActiveTerminalHandle) {
+    return false
+  }
+  if (input.createInFlight || input.autoCreatedForWorktree) {
+    return false
+  }
+  return !input.sawSessionTabs
+}

--- a/mobile/src/session/initial-session-terminal.ts
+++ b/mobile/src/session/initial-session-terminal.ts
@@ -1,8 +1,10 @@
-// Mirrors the desktop `shouldAutoCreateInitialTerminal` gate: a workspace that
-// hydrates with nothing to show gets one terminal so the session isn't blank.
+// Mirrors the desktop `shouldAutoCreateInitialTerminal` gate: a newly created
+// workspace that hydrates empty gets one terminal so the session isn't blank.
 // Kept pure (no react-native imports) so the gate is unit-testable.
 
 export type InitialSessionTerminalAutoCreateInput = {
+  /** Navigation came directly from creating this workspace. */
+  newlyCreatedWorkspace: boolean
   /** Host connection is up and an RPC client is attached. */
   connected: boolean
   /** At least one session-tab snapshot has been applied on this route. */
@@ -20,18 +22,18 @@ export type InitialSessionTerminalAutoCreateInput = {
 }
 
 /**
- * Whether to auto-create the first terminal of an empty mobile session.
+ * Whether to auto-create the first terminal of a newly created mobile session.
  *
  * `sawSessionTabs` is the resurrection guard: emptiness that *follows* a
  * populated tab list was produced by a close (the user's, or the host dropping
  * a dead pane), and re-creating there spawns a brand-new terminal the user
  * never asked for — issues #9717 / #7345. Only a workspace that has shown
- * nothing since this route opened is eligible.
+ * nothing since its creation route opened is eligible.
  */
 export function shouldAutoCreateInitialSessionTerminal(
   input: InitialSessionTerminalAutoCreateInput
 ): boolean {
-  if (!input.connected || !input.tabsLoaded) {
+  if (!input.newlyCreatedWorkspace || !input.connected || !input.tabsLoaded) {
     return false
   }
   if (input.visibleTabCount > 0 || input.hasActiveTerminalHandle) {

--- a/mobile/src/session/mobile-session-startup-source.test.ts
+++ b/mobile/src/session/mobile-session-startup-source.test.ts
@@ -23,35 +23,44 @@ function sliceBetween(startPattern: string, endPattern: string): string {
 }
 
 describe('mobile session startup', () => {
-  it('auto-creates one terminal for an initially empty connected session', () => {
-    expect(source).toContain('const initialEmptySessionAutoCreateRef = useRef<string | null>(null)')
-    expect(source).toContain('initialEmptySessionAutoCreateRef.current = null')
+  it('auto-creates one terminal for a newly created empty session', () => {
+    expect(source).toContain('useWorktreeSessionTabsLoaded(worktreeId)')
+    expect(source).toContain(
+      'initialSessionAutoCreateRef.current = createInitialSessionAutoCreateState()'
+    )
 
     const autoCreateCall = sliceBetween(
       'useInitialSessionTerminalAutoCreate({',
       'const connectionVerdict ='
     )
-    expect(autoCreateCall).toContain('autoCreatedForWorktreeRef: initialEmptySessionAutoCreateRef')
+    expect(autoCreateCall).toContain('stateRef: initialSessionAutoCreateRef')
+    expect(autoCreateCall).toContain(
+      'consumeCreationRoute: () => router.setParams({ created: undefined })'
+    )
+    expect(autoCreateCall).toContain("newlyCreatedWorkspace: created === '1'")
     expect(autoCreateCall).toContain('visibleTabCount: visibleTabs.length')
     expect(autoCreateCall).toContain('createTerminal: () => void handleCreateTerminal()')
 
     expect(autoCreateHookSource).toContain('shouldAutoCreateInitialSessionTerminal({')
-    expect(autoCreateHookSource).toContain('autoCreatedForWorktreeRef.current === worktreeId')
-    expect(autoCreateHookSource).toContain('autoCreatedForWorktreeRef.current = worktreeId')
+    expect(autoCreateHookSource).toContain('stateRef.current.autoCreatedForWorktree === worktreeId')
+    expect(autoCreateHookSource).toContain('stateRef.current.autoCreatedForWorktree = worktreeId')
+    expect(autoCreateHookSource).toContain('newlyCreatedWorkspace && terminalsLoaded')
+    expect(autoCreateHookSource).toContain('consumeCreationRouteRef.current()')
     expect(autoCreateHookSource).toContain('createTerminalRef.current()')
   })
 
   it('arms the auto-create only until the route has published a tab (#9717)', () => {
     // Emptiness after a populated list is a close, not a cold hydrate.
-    expect(source).toContain('sawSessionTabsRef.current ||= nextTabs.length > 0')
-    expect(source).toContain('sawSessionTabsRef.current = false')
+    expect(source).toContain(
+      'initialSessionAutoCreateRef.current.sawSessionTabs ||= nextTabs.length > 0'
+    )
 
     const autoCreateCall = sliceBetween(
       'useInitialSessionTerminalAutoCreate({',
       'const connectionVerdict ='
     )
-    expect(autoCreateCall).toContain('sawSessionTabsRef')
-    expect(autoCreateHookSource).toContain('sawSessionTabs: sawSessionTabsRef.current')
+    expect(autoCreateCall).toContain('stateRef: initialSessionAutoCreateRef')
+    expect(autoCreateHookSource).toContain('sawSessionTabs: stateRef.current.sawSessionTabs')
   })
 
   it('delegates stream ownership while retaining the exact terminal polling cadence', () => {

--- a/mobile/src/session/mobile-session-startup-source.test.ts
+++ b/mobile/src/session/mobile-session-startup-source.test.ts
@@ -44,7 +44,8 @@ describe('mobile session startup', () => {
     expect(autoCreateHookSource).toContain('shouldAutoCreateInitialSessionTerminal({')
     expect(autoCreateHookSource).toContain('stateRef.current.autoCreatedForWorktree === worktreeId')
     expect(autoCreateHookSource).toContain('stateRef.current.autoCreatedForWorktree = worktreeId')
-    expect(autoCreateHookSource).toContain('newlyCreatedWorkspace && terminalsLoaded')
+    expect(autoCreateHookSource).toContain("connState === 'connected'")
+    expect(autoCreateHookSource).toContain('(visibleTabCount > 0 || activeHandle !== null)')
     // Why: both callbacks are re-created every render, so the effect must reach them
     // through useEffectEvent rather than deps or a render-time ref write.
     expect(autoCreateHookSource).toContain('useEffectEvent(args.consumeCreationRoute)')

--- a/mobile/src/session/mobile-session-startup-source.test.ts
+++ b/mobile/src/session/mobile-session-startup-source.test.ts
@@ -45,8 +45,12 @@ describe('mobile session startup', () => {
     expect(autoCreateHookSource).toContain('stateRef.current.autoCreatedForWorktree === worktreeId')
     expect(autoCreateHookSource).toContain('stateRef.current.autoCreatedForWorktree = worktreeId')
     expect(autoCreateHookSource).toContain('newlyCreatedWorkspace && terminalsLoaded')
-    expect(autoCreateHookSource).toContain('consumeCreationRouteRef.current()')
-    expect(autoCreateHookSource).toContain('createTerminalRef.current()')
+    // Why: both callbacks are re-created every render, so the effect must reach them
+    // through useEffectEvent rather than deps or a render-time ref write.
+    expect(autoCreateHookSource).toContain('useEffectEvent(args.consumeCreationRoute)')
+    expect(autoCreateHookSource).toContain('useEffectEvent(args.createTerminal)')
+    expect(autoCreateHookSource).toContain('consumeCreationRoute()')
+    expect(autoCreateHookSource).toContain('createTerminal()')
   })
 
   it('arms the auto-create only until the route has published a tab (#9717)', () => {

--- a/mobile/src/session/mobile-session-startup-source.test.ts
+++ b/mobile/src/session/mobile-session-startup-source.test.ts
@@ -9,6 +9,10 @@ const reconciliationHookSource = readFileSync(
   new URL('./use-mobile-session-tabs-reconciliation.ts', import.meta.url),
   'utf8'
 )
+const autoCreateHookSource = readFileSync(
+  new URL('./use-initial-session-terminal-autocreate.ts', import.meta.url),
+  'utf8'
+)
 
 function sliceBetween(startPattern: string, endPattern: string): string {
   const start = source.indexOf(startPattern)
@@ -23,14 +27,31 @@ describe('mobile session startup', () => {
     expect(source).toContain('const initialEmptySessionAutoCreateRef = useRef<string | null>(null)')
     expect(source).toContain('initialEmptySessionAutoCreateRef.current = null')
 
-    const autoCreateEffect = sliceBetween(
-      'if (\n      !client ||\n      !showEmptyState',
-      'const terminalSummary ='
+    const autoCreateCall = sliceBetween(
+      'useInitialSessionTerminalAutoCreate({',
+      'const connectionVerdict ='
     )
-    expect(autoCreateEffect).toContain('initialEmptySessionAutoCreateRef.current === worktreeId')
-    expect(autoCreateEffect).toContain('initialEmptySessionAutoCreateRef.current = worktreeId')
-    expect(autoCreateEffect).toContain("setCreateError('')")
-    expect(autoCreateEffect).toContain('void handleCreateTerminal()')
+    expect(autoCreateCall).toContain('autoCreatedForWorktreeRef: initialEmptySessionAutoCreateRef')
+    expect(autoCreateCall).toContain('visibleTabCount: visibleTabs.length')
+    expect(autoCreateCall).toContain('createTerminal: () => void handleCreateTerminal()')
+
+    expect(autoCreateHookSource).toContain('shouldAutoCreateInitialSessionTerminal({')
+    expect(autoCreateHookSource).toContain('autoCreatedForWorktreeRef.current === worktreeId')
+    expect(autoCreateHookSource).toContain('autoCreatedForWorktreeRef.current = worktreeId')
+    expect(autoCreateHookSource).toContain('createTerminalRef.current()')
+  })
+
+  it('arms the auto-create only until the route has published a tab (#9717)', () => {
+    // Emptiness after a populated list is a close, not a cold hydrate.
+    expect(source).toContain('sawSessionTabsRef.current ||= nextTabs.length > 0')
+    expect(source).toContain('sawSessionTabsRef.current = false')
+
+    const autoCreateCall = sliceBetween(
+      'useInitialSessionTerminalAutoCreate({',
+      'const connectionVerdict ='
+    )
+    expect(autoCreateCall).toContain('sawSessionTabsRef')
+    expect(autoCreateHookSource).toContain('sawSessionTabs: sawSessionTabsRef.current')
   })
 
   it('delegates stream ownership while retaining the exact terminal polling cadence', () => {

--- a/mobile/src/session/use-initial-session-terminal-autocreate.test.ts
+++ b/mobile/src/session/use-initial-session-terminal-autocreate.test.ts
@@ -1,4 +1,4 @@
-import { createElement, type MutableRefObject } from 'react'
+import { createElement, type RefObject } from 'react'
 import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
@@ -15,7 +15,7 @@ type HarnessProps = {
 
 describe('useInitialSessionTerminalAutoCreate', () => {
   let renderer: ReactTestRenderer | null = null
-  let stateRef: MutableRefObject<{
+  let stateRef: RefObject<{
     autoCreatedForWorktree: string | null
     sawSessionTabs: boolean
   }>

--- a/mobile/src/session/use-initial-session-terminal-autocreate.test.ts
+++ b/mobile/src/session/use-initial-session-terminal-autocreate.test.ts
@@ -1,0 +1,150 @@
+import { createElement, type MutableRefObject } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useInitialSessionTerminalAutoCreate,
+  useWorktreeSessionTabsLoaded
+} from './use-initial-session-terminal-autocreate'
+
+type HarnessProps = {
+  newlyCreatedWorkspace: boolean
+  terminalsLoaded: boolean
+  visibleTabCount: number
+  worktreeId: string
+}
+
+describe('useInitialSessionTerminalAutoCreate', () => {
+  let renderer: ReactTestRenderer | null = null
+  let stateRef: MutableRefObject<{
+    autoCreatedForWorktree: string | null
+    sawSessionTabs: boolean
+  }>
+  const consumeCreationRoute = vi.fn()
+  const createTerminal = vi.fn()
+
+  function Harness(props: HarnessProps): null {
+    useInitialSessionTerminalAutoCreate({
+      client: {},
+      newlyCreatedWorkspace: props.newlyCreatedWorkspace,
+      connState: 'connected',
+      terminalsLoaded: props.terminalsLoaded,
+      visibleTabCount: props.visibleTabCount,
+      activeHandle: null,
+      createInFlight: false,
+      stateRef,
+      worktreeId: props.worktreeId,
+      consumeCreationRoute,
+      createTerminal
+    })
+    return null
+  }
+
+  async function render(props: HarnessProps): Promise<void> {
+    await act(async () => {
+      if (renderer) {
+        renderer.update(createElement(Harness, props))
+      } else {
+        renderer = create(createElement(Harness, props))
+      }
+    })
+  }
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    stateRef = {
+      current: { autoCreatedForWorktree: null, sawSessionTabs: false }
+    }
+    consumeCreationRoute.mockClear()
+    createTerminal.mockClear()
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] !== 'string' || !args[0].includes('react-test-renderer is deprecated')) {
+        throw new Error(String(args[0]))
+      }
+    })
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    vi.restoreAllMocks()
+  })
+
+  it('waits for the new worktree snapshot after route reuse', async () => {
+    await render({
+      newlyCreatedWorkspace: false,
+      terminalsLoaded: true,
+      visibleTabCount: 0,
+      worktreeId: 'existing'
+    })
+    await render({
+      newlyCreatedWorkspace: true,
+      terminalsLoaded: false,
+      visibleTabCount: 0,
+      worktreeId: 'new'
+    })
+    expect(consumeCreationRoute).not.toHaveBeenCalled()
+    expect(createTerminal).not.toHaveBeenCalled()
+
+    await render({
+      newlyCreatedWorkspace: true,
+      terminalsLoaded: true,
+      visibleTabCount: 0,
+      worktreeId: 'new'
+    })
+    expect(consumeCreationRoute).toHaveBeenCalledOnce()
+    expect(createTerminal).toHaveBeenCalledOnce()
+  })
+
+  it('consumes a populated creation route before a later remount', async () => {
+    await render({
+      newlyCreatedWorkspace: true,
+      terminalsLoaded: true,
+      visibleTabCount: 1,
+      worktreeId: 'new'
+    })
+    expect(consumeCreationRoute).toHaveBeenCalledOnce()
+    expect(createTerminal).not.toHaveBeenCalled()
+
+    act(() => renderer?.unmount())
+    renderer = null
+    stateRef = {
+      current: { autoCreatedForWorktree: null, sawSessionTabs: false }
+    }
+    await render({
+      newlyCreatedWorkspace: false,
+      terminalsLoaded: true,
+      visibleTabCount: 0,
+      worktreeId: 'new'
+    })
+    expect(createTerminal).not.toHaveBeenCalled()
+  })
+})
+
+describe('useWorktreeSessionTabsLoaded', () => {
+  let renderer: ReactTestRenderer | null = null
+  let current: readonly [boolean, (loaded: boolean) => void] | null = null
+
+  function Harness({ worktreeId }: { worktreeId: string }): null {
+    current = useWorktreeSessionTabsLoaded(worktreeId)
+    return null
+  }
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    current = null
+  })
+
+  it('does not carry a loaded snapshot across a reused route', async () => {
+    await act(async () => {
+      renderer = create(createElement(Harness, { worktreeId: 'existing' }))
+    })
+    act(() => current?.[1](true))
+    expect(current?.[0]).toBe(true)
+
+    await act(async () => {
+      renderer?.update(createElement(Harness, { worktreeId: 'new' }))
+    })
+    expect(current?.[0]).toBe(false)
+  })
+})

--- a/mobile/src/session/use-initial-session-terminal-autocreate.test.ts
+++ b/mobile/src/session/use-initial-session-terminal-autocreate.test.ts
@@ -11,6 +11,8 @@ type HarnessProps = {
   terminalsLoaded: boolean
   visibleTabCount: number
   worktreeId: string
+  connected?: boolean
+  hasClient?: boolean
 }
 
 describe('useInitialSessionTerminalAutoCreate', () => {
@@ -24,9 +26,9 @@ describe('useInitialSessionTerminalAutoCreate', () => {
 
   function Harness(props: HarnessProps): null {
     useInitialSessionTerminalAutoCreate({
-      client: {},
+      client: props.hasClient === false ? null : {},
       newlyCreatedWorkspace: props.newlyCreatedWorkspace,
-      connState: 'connected',
+      connState: props.connected === false ? 'disconnected' : 'connected',
       terminalsLoaded: props.terminalsLoaded,
       visibleTabCount: props.visibleTabCount,
       activeHandle: null,
@@ -91,6 +93,15 @@ describe('useInitialSessionTerminalAutoCreate', () => {
       visibleTabCount: 0,
       worktreeId: 'new'
     })
+    expect(consumeCreationRoute).not.toHaveBeenCalled()
+    expect(createTerminal).toHaveBeenCalledOnce()
+
+    await render({
+      newlyCreatedWorkspace: true,
+      terminalsLoaded: true,
+      visibleTabCount: 1,
+      worktreeId: 'new'
+    })
     expect(consumeCreationRoute).toHaveBeenCalledOnce()
     expect(createTerminal).toHaveBeenCalledOnce()
   })
@@ -118,6 +129,34 @@ describe('useInitialSessionTerminalAutoCreate', () => {
     })
     expect(createTerminal).not.toHaveBeenCalled()
   })
+
+  it.each([
+    { connected: false, hasClient: true },
+    { connected: true, hasClient: false }
+  ])(
+    'keeps the creation route armed until a client reconnects (connected=$connected, hasClient=$hasClient)',
+    async ({ connected, hasClient }) => {
+      await render({
+        newlyCreatedWorkspace: true,
+        terminalsLoaded: true,
+        visibleTabCount: 0,
+        worktreeId: 'new',
+        connected,
+        hasClient
+      })
+      expect(consumeCreationRoute).not.toHaveBeenCalled()
+      expect(createTerminal).not.toHaveBeenCalled()
+
+      await render({
+        newlyCreatedWorkspace: true,
+        terminalsLoaded: true,
+        visibleTabCount: 0,
+        worktreeId: 'new'
+      })
+      expect(consumeCreationRoute).not.toHaveBeenCalled()
+      expect(createTerminal).toHaveBeenCalledOnce()
+    }
+  )
 })
 
 describe('useWorktreeSessionTabsLoaded', () => {

--- a/mobile/src/session/use-initial-session-terminal-autocreate.ts
+++ b/mobile/src/session/use-initial-session-terminal-autocreate.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, type MutableRefObject } from 'react'
+import { shouldAutoCreateInitialSessionTerminal } from './initial-session-terminal'
+
+type InitialSessionTerminalAutoCreateArgs = {
+  client: unknown
+  connState: string
+  terminalsLoaded: boolean
+  visibleTabCount: number
+  activeHandle: string | null
+  createInFlight: boolean
+  /** Set once this route has published a non-empty tab list for the workspace. */
+  sawSessionTabsRef: MutableRefObject<boolean>
+  /** Worktree this route already auto-created for, or null. */
+  autoCreatedForWorktreeRef: MutableRefObject<string | null>
+  worktreeId: string
+  createTerminal: () => void
+}
+
+/**
+ * Creates the first terminal of a mobile session that hydrates with nothing to
+ * show, at most once per workspace per route. Deliberately silent when the tab
+ * list empties *after* being populated — see initial-session-terminal.
+ */
+export function useInitialSessionTerminalAutoCreate(
+  args: InitialSessionTerminalAutoCreateArgs
+): void {
+  const {
+    client,
+    connState,
+    terminalsLoaded,
+    visibleTabCount,
+    activeHandle,
+    createInFlight,
+    sawSessionTabsRef,
+    autoCreatedForWorktreeRef,
+    worktreeId
+  } = args
+  // Why: the route re-creates `createTerminal` every render; a ref keeps it out of the deps.
+  const createTerminalRef = useRef(args.createTerminal)
+  createTerminalRef.current = args.createTerminal
+
+  useEffect(() => {
+    if (
+      !client ||
+      !shouldAutoCreateInitialSessionTerminal({
+        connected: connState === 'connected',
+        tabsLoaded: terminalsLoaded,
+        visibleTabCount,
+        hasActiveTerminalHandle: activeHandle !== null,
+        createInFlight,
+        sawSessionTabs: sawSessionTabsRef.current,
+        autoCreatedForWorktree: autoCreatedForWorktreeRef.current === worktreeId
+      })
+    ) {
+      return
+    }
+    autoCreatedForWorktreeRef.current = worktreeId
+    createTerminalRef.current()
+  }, [
+    activeHandle,
+    autoCreatedForWorktreeRef,
+    client,
+    connState,
+    createInFlight,
+    sawSessionTabsRef,
+    terminalsLoaded,
+    visibleTabCount,
+    worktreeId
+  ])
+}

--- a/mobile/src/session/use-initial-session-terminal-autocreate.ts
+++ b/mobile/src/session/use-initial-session-terminal-autocreate.ts
@@ -52,7 +52,13 @@ export function useInitialSessionTerminalAutoCreate(
   const createTerminal = useEffectEvent(args.createTerminal)
 
   useEffect(() => {
-    if (newlyCreatedWorkspace && terminalsLoaded) {
+    if (
+      newlyCreatedWorkspace &&
+      client &&
+      connState === 'connected' &&
+      terminalsLoaded &&
+      (visibleTabCount > 0 || activeHandle !== null)
+    ) {
       consumeCreationRoute()
     }
     if (

--- a/mobile/src/session/use-initial-session-terminal-autocreate.ts
+++ b/mobile/src/session/use-initial-session-terminal-autocreate.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef, type MutableRefObject } from 'react'
+import { useEffect, useEffectEvent, useReducer, type RefObject } from 'react'
 import { shouldAutoCreateInitialSessionTerminal } from './initial-session-terminal'
 
 type InitialSessionTerminalAutoCreateState = {
@@ -18,7 +18,7 @@ type InitialSessionTerminalAutoCreateArgs = {
   visibleTabCount: number
   activeHandle: string | null
   createInFlight: boolean
-  stateRef: MutableRefObject<InitialSessionTerminalAutoCreateState>
+  stateRef: RefObject<InitialSessionTerminalAutoCreateState>
   worktreeId: string
   consumeCreationRoute: () => void
   createTerminal: () => void
@@ -42,15 +42,14 @@ export function useInitialSessionTerminalAutoCreate(
     stateRef,
     worktreeId
   } = args
-  const consumeCreationRouteRef = useRef(args.consumeCreationRoute)
-  consumeCreationRouteRef.current = args.consumeCreationRoute
-  // Why: the route re-creates `createTerminal` every render; a ref keeps it out of the deps.
-  const createTerminalRef = useRef(args.createTerminal)
-  createTerminalRef.current = args.createTerminal
+  // Why: the route re-creates both callbacks every render; useEffectEvent keeps them
+  // out of the deps without mutating a ref during render.
+  const consumeCreationRoute = useEffectEvent(args.consumeCreationRoute)
+  const createTerminal = useEffectEvent(args.createTerminal)
 
   useEffect(() => {
     if (newlyCreatedWorkspace && terminalsLoaded) {
-      consumeCreationRouteRef.current()
+      consumeCreationRoute()
     }
     if (
       !client ||
@@ -68,7 +67,7 @@ export function useInitialSessionTerminalAutoCreate(
       return
     }
     stateRef.current.autoCreatedForWorktree = worktreeId
-    createTerminalRef.current()
+    createTerminal()
   }, [
     activeHandle,
     client,

--- a/mobile/src/session/use-initial-session-terminal-autocreate.ts
+++ b/mobile/src/session/use-initial-session-terminal-autocreate.ts
@@ -6,6 +6,10 @@ type InitialSessionTerminalAutoCreateState = {
   sawSessionTabs: boolean
 }
 
+/**
+ * Fresh auto-create bookkeeping. The route must re-create this on every worktree
+ * change, or a revisit inherits the previous workspace's `sawSessionTabs`.
+ */
 export function createInitialSessionAutoCreateState(): InitialSessionTerminalAutoCreateState {
   return { autoCreatedForWorktree: null, sawSessionTabs: false }
 }
@@ -81,6 +85,10 @@ export function useInitialSessionTerminalAutoCreate(
   ])
 }
 
+/**
+ * Tracks "tabs hydrated" per worktree so a reused route reports `false` until the
+ * new workspace's own snapshot lands, rather than inheriting the old one's.
+ */
 export function useWorktreeSessionTabsLoaded(
   worktreeId: string
 ): readonly [boolean, (loaded: boolean) => void] {

--- a/mobile/src/session/use-initial-session-terminal-autocreate.ts
+++ b/mobile/src/session/use-initial-session-terminal-autocreate.ts
@@ -1,70 +1,93 @@
-import { useEffect, useRef, type MutableRefObject } from 'react'
+import { useEffect, useReducer, useRef, type MutableRefObject } from 'react'
 import { shouldAutoCreateInitialSessionTerminal } from './initial-session-terminal'
+
+type InitialSessionTerminalAutoCreateState = {
+  autoCreatedForWorktree: string | null
+  sawSessionTabs: boolean
+}
+
+export function createInitialSessionAutoCreateState(): InitialSessionTerminalAutoCreateState {
+  return { autoCreatedForWorktree: null, sawSessionTabs: false }
+}
 
 type InitialSessionTerminalAutoCreateArgs = {
   client: unknown
+  newlyCreatedWorkspace: boolean
   connState: string
   terminalsLoaded: boolean
   visibleTabCount: number
   activeHandle: string | null
   createInFlight: boolean
-  /** Set once this route has published a non-empty tab list for the workspace. */
-  sawSessionTabsRef: MutableRefObject<boolean>
-  /** Worktree this route already auto-created for, or null. */
-  autoCreatedForWorktreeRef: MutableRefObject<string | null>
+  stateRef: MutableRefObject<InitialSessionTerminalAutoCreateState>
   worktreeId: string
+  consumeCreationRoute: () => void
   createTerminal: () => void
 }
 
 /**
- * Creates the first terminal of a mobile session that hydrates with nothing to
- * show, at most once per workspace per route. Deliberately silent when the tab
- * list empties *after* being populated — see initial-session-terminal.
+ * Creates the first terminal of a newly created mobile workspace that hydrates
+ * empty, at most once per route. See initial-session-terminal.
  */
 export function useInitialSessionTerminalAutoCreate(
   args: InitialSessionTerminalAutoCreateArgs
 ): void {
   const {
     client,
+    newlyCreatedWorkspace,
     connState,
     terminalsLoaded,
     visibleTabCount,
     activeHandle,
     createInFlight,
-    sawSessionTabsRef,
-    autoCreatedForWorktreeRef,
+    stateRef,
     worktreeId
   } = args
+  const consumeCreationRouteRef = useRef(args.consumeCreationRoute)
+  consumeCreationRouteRef.current = args.consumeCreationRoute
   // Why: the route re-creates `createTerminal` every render; a ref keeps it out of the deps.
   const createTerminalRef = useRef(args.createTerminal)
   createTerminalRef.current = args.createTerminal
 
   useEffect(() => {
+    if (newlyCreatedWorkspace && terminalsLoaded) {
+      consumeCreationRouteRef.current()
+    }
     if (
       !client ||
       !shouldAutoCreateInitialSessionTerminal({
+        newlyCreatedWorkspace,
         connected: connState === 'connected',
         tabsLoaded: terminalsLoaded,
         visibleTabCount,
         hasActiveTerminalHandle: activeHandle !== null,
         createInFlight,
-        sawSessionTabs: sawSessionTabsRef.current,
-        autoCreatedForWorktree: autoCreatedForWorktreeRef.current === worktreeId
+        sawSessionTabs: stateRef.current.sawSessionTabs,
+        autoCreatedForWorktree: stateRef.current.autoCreatedForWorktree === worktreeId
       })
     ) {
       return
     }
-    autoCreatedForWorktreeRef.current = worktreeId
+    stateRef.current.autoCreatedForWorktree = worktreeId
     createTerminalRef.current()
   }, [
     activeHandle,
-    autoCreatedForWorktreeRef,
     client,
     connState,
     createInFlight,
-    sawSessionTabsRef,
+    newlyCreatedWorkspace,
+    stateRef,
     terminalsLoaded,
     visibleTabCount,
     worktreeId
   ])
+}
+
+export function useWorktreeSessionTabsLoaded(
+  worktreeId: string
+): readonly [boolean, (loaded: boolean) => void] {
+  const [loadedForWorktree, setLoaded] = useReducer(
+    (_current: string | null, loaded: boolean) => (loaded ? worktreeId : null),
+    null
+  )
+  return [loadedForWorktree === worktreeId, setLoaded]
 }


### PR DESCRIPTION
## Summary

Closing the last terminal tab on mobile immediately spawned a brand-new one, and it recurred on every visit to the workspace.

The session route treated "zero session tabs" as "this workspace has never had anything" and auto-created a terminal. But `handleCloseSessionTab` prunes the tab locally and nulls `activeHandle`, which produces exactly that state — so the close was followed by an unsolicited spawn. The guard was also re-armed by the route's worktree-change reset, so leaving and returning made it happen again.

This gates the auto-create on whether the route has ever published a *non-empty* tab list for the workspace. A cold hydrate still gets its first terminal; an emptied list now gets the empty state and its Create Tab button.

Scope note: #9717 bundles two mechanisms. The "which session do I want to resume" half was already fixed on `main` by #10647 and is in this PR's baseline. This is the other half. It is **not** a duplicate of #10486, which is a same-content *mirror* tab (a renderer `ptyIdsByTabId` ownership miss, fixed as #11259); #9717's extra sessions are fresh processes.

## Screenshots

No visual change to any component. The behavioral change is which state the route lands in after the final close: previously a new terminal, now the pre-existing empty state with its Create Tab button. Device validation is in Testing below.

## Testing

- [x] `pnpm lint` — mobile `oxlint`, 0 findings; root `oxlint`, 0 warnings / 0 errors
- [x] `pnpm typecheck` — mobile `tsc --noEmit` clean
- [x] `pnpm test` — mobile suite **357 files / 2621 passed, 2 skipped**, against my own parent baseline `0349cb6bdb` of **355 / 2606, 2 skipped** (+2 files, +15 tests)
- [ ] `pnpm build` — **not run.** `mobile/` is an Expo app with no `build` script, and this PR touches only `mobile/src/session/**` + the session route. The root Electron build is unaffected; root `typecheck` is green in CI.
- [x] Added or updated high-quality tests that would catch regressions

Non-vacuity was proven by mutation, re-verified on current `main`:
- Replacing the gate's `return !input.sawSessionTabs` with `return true` turns **2** tests red — the close repro and the host-drops-every-tab case.
- Reverting the hook's `useEffectEvent` wiring to a render-time ref write turns the `mobile-session-startup-source` pin red.

Also ran the gates that PR Checks' `static analysis` job silently skipped on the previous push (React Doctor is step 5 of ~17, and an early failure skips the rest): max-lines ratchet, localization catalog, localization coverage, Zustand selector fan-out, reliability gate manifest, changed-code quality. All pass. No `max-lines` disable or per-file bump was added.

## AI Review Report

Reviewed for: whether the guard can strand a genuinely empty workspace with no terminal; per-route and per-worktree state leakage across reused routes; and the SSH and folder-workspace paths.

Flagged and fixed:
- **React Doctor, blocking: "Ref mutated during render" ×2.** The hook kept both callbacks out of the effect deps by writing latest-refs during render. React can replay or discard a render, so the write can leak from UI that never commits. This failed PR Checks. Replaced with `useEffectEvent` (React 19.2, already used in `SourceControl.tsx`) — same stable-callback-outside-deps behavior, no render-time mutation. CodeRabbit independently flagged the same lines.
- Retired the deprecated `MutableRefObject` for `RefObject` in the impl and its test (CodeRabbit).
- Added docstrings to the two exported helpers, both of which exist for a non-obvious per-route reset contract (CodeRabbit docstring coverage).

Cross-platform: explicitly checked. This is React Native code with no keyboard shortcuts, no shortcut labels, no path handling, no shell invocation, and no Electron platform branches. The gate is pure, client-side, and workspace-kind agnostic — it has no `react-native` imports at all. Folder workspaces take the same route and snapshot path as git worktrees. An unreachable SSH host leaves `connState !== 'connected'`, which already blocked auto-create and still does.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change only *removes* a condition under which the client issues a terminal-create RPC, so it strictly narrows what the phone can cause the host to spawn — the direction that reduces risk. No new dependencies; `mobile/pnpm-lock.yaml` is unchanged. No follow-up needed.

## Notes

**Merge ordering: land this before or together with #11240.** #11240 (the #6927 close-path fix) correctly routes more terminal closes through the authoritative session-tab close path, which feeds *more* closes into the path fixed here and makes the unsolicited spawn easier to hit. The branches combine cleanly and do not need an atomic merge, but #11240 should not land first.

Two residuals found during this investigation, deliberately left unfixed as out of scope:

1. **The host conflates "unpublished" with "empty."** `getMobileSessionTabsForWorktree` answers "I hold no snapshot for this worktree" with `{ tabs: [], publicationEpoch: 'none', snapshotVersion: 0 }` — wire-identical to a genuinely empty workspace — and `acceptSessionSnapshot` accepts a new epoch unconditionally, so mobile applies a pre-publication read as authoritative. The sibling `fetchTerminals` already defends against this class by requiring two consecutive empties before trusting zero; `applySessionTabs` has no such guard and sets `terminalsLoaded = true` on any accepted snapshot. Fixing this properly needs a distinct sentinel and a protocol decision, not a mobile-only change.

2. **View-driven materialize can relaunch a dead agent tab in place.** `shouldMaterializePendingTerminal` spawns a fresh PTY for any mobile activation of a non-`ready` tab, and mobile auto-activates any active pending terminal tab. A desktop tab whose agent process has exited is published `pending-handle`, so merely opening that workspace on the phone can relaunch the agent — and because the tab keeps its id, this *replaces* a finished session rather than adding one, matching the "too many sessions instead of the original sessions" report. This is the same principle #10647 settled for desktop (navigation is not consent to start a process), still live on the mobile side.

Suggested issue hygiene: keep #9717 open and split it. The resume-picker half is closed by #10647; the remaining half is this PR plus residual 2.

There is also one non-blocking React Doctor *warning* left on a line this PR adds — "Ref initializer runs on every render" at `[worktreeId].tsx:1040`, for `useRef(createInitialSessionAutoCreateState())`. Left as-is deliberately: the three adjacent pre-existing ref declarations use the same eager-init idiom, and the null-guarded lazy alternative would push a nullable state type through the hook's signature for one small object allocation.
