### PR TITLE
fix(skills): pass -y so the pasted skill install never stalls on a prompt

### DIFF
--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -119,7 +119,7 @@ describe('onboarding feature setup runner', () => {
 
     expect(text).toBe(ALL_SKILL_INSTALL_COMMAND)
     expect(text).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli computer-use orchestration orca-linear --global'
+      'npx skills add https://github.com/stablyai/orca --skill orca-cli computer-use orchestration orca-linear --global -y'
     )
   })
 

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -119,7 +119,7 @@ describe('onboarding feature setup runner', () => {
 
     expect(text).toBe(ALL_SKILL_INSTALL_COMMAND)
     expect(text).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli computer-use orchestration orca-linear --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orca-cli computer-use orchestration orca-linear --global -y'
     )
   })
 

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -118,7 +118,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
   )
 
   // Expectations are pinned rather than rebuilt from the builder: this is the only
-  // coverage that the non-interactive `-y` reaches the Windows rewrite.
+  // coverage that both non-interactive flags reach the Windows rewrite.
   it('reinstalls Windows-host skill updates through the add path', () => {
     expect(
       buildSkillCommandForRuntime(
@@ -129,13 +129,15 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         },
         'win32'
       )
-    ).toBe('npx skills add https://github.com/stablyai/orca --skill orchestration --global -y')
+    ).toBe(
+      'npx --yes skills add https://github.com/stablyai/orca --skill orchestration --global -y'
+    )
   })
 
   it('treats missing runtime as a Windows host fallback for skill updates', () => {
     expect(
       buildSkillCommandForRuntime('npx skills update orca-cli --global', undefined, 'win32')
-    ).toBe('npx skills add https://github.com/stablyai/orca --skill orca-cli --global -y')
+    ).toBe('npx --yes skills add https://github.com/stablyai/orca --skill orca-cli --global -y')
   })
 
   it('keeps non-Windows host skill updates on the update path', () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -4,7 +4,6 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
-import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-command'
 import {
   buildSkillCommandForRuntime,
@@ -118,6 +117,8 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     }
   )
 
+  // Expectations are pinned rather than rebuilt from the builder: this is the only
+  // coverage that the non-interactive `-y` reaches the Windows rewrite.
   it('reinstalls Windows-host skill updates through the add path', () => {
     expect(
       buildSkillCommandForRuntime(
@@ -128,13 +129,13 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         },
         'win32'
       )
-    ).toBe(buildAgentFeatureSkillInstallCommand(['orchestration']))
+    ).toBe('npx skills add https://github.com/stablyai/orca --skill orchestration --global -y')
   })
 
   it('treats missing runtime as a Windows host fallback for skill updates', () => {
     expect(
       buildSkillCommandForRuntime('npx skills update orca-cli --global', undefined, 'win32')
-    ).toBe(buildAgentFeatureSkillInstallCommand(['orca-cli']))
+    ).toBe('npx skills add https://github.com/stablyai/orca --skill orca-cli --global -y')
   })
 
   it('keeps non-Windows host skill updates on the update path', () => {

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -8,7 +8,7 @@ import { getOrchestrationUsageExamples } from '@/lib/orchestration-usage-example
 import { OrchestrationPane } from './OrchestrationPane'
 
 const INSTALL_COMMAND =
-  'npx skills add https://github.com/stablyai/orca --skill orchestration --global -y'
+  'npx --yes skills add https://github.com/stablyai/orca --skill orchestration --global -y'
 const UPDATE_COMMAND = INSTALL_COMMAND
 
 const mocks = vi.hoisted(() => ({

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -8,7 +8,7 @@ import { getOrchestrationUsageExamples } from '@/lib/orchestration-usage-example
 import { OrchestrationPane } from './OrchestrationPane'
 
 const INSTALL_COMMAND =
-  'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+  'npx skills add https://github.com/stablyai/orca --skill orchestration --global -y'
 const UPDATE_COMMAND = INSTALL_COMMAND
 
 const mocks = vi.hoisted(() => ({

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
@@ -115,7 +115,7 @@ describe('LinearAgentSkillInstallCta', () => {
     expect(rendered.textContent).toContain('Not installed')
     expect(rendered.textContent).toContain('Let your agents read and edit Linear tasks.')
     expect(rendered.textContent).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global'
+      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global -y'
     )
   })
 
@@ -129,7 +129,7 @@ describe('LinearAgentSkillInstallCta', () => {
     })
 
     expect(mocks.clipboardWrite).toHaveBeenCalledWith(
-      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global'
+      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global -y'
     )
     expect(mocks.toastSuccess).toHaveBeenCalled()
   })

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
@@ -115,7 +115,7 @@ describe('LinearAgentSkillInstallCta', () => {
     expect(rendered.textContent).toContain('Not installed')
     expect(rendered.textContent).toContain('Let your agents read and edit Linear tasks.')
     expect(rendered.textContent).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orca-linear --global -y'
     )
   })
 
@@ -129,7 +129,7 @@ describe('LinearAgentSkillInstallCta', () => {
     })
 
     expect(mocks.clipboardWrite).toHaveBeenCalledWith(
-      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orca-linear --global -y'
     )
     expect(mocks.toastSuccess).toHaveBeenCalled()
   })

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
@@ -344,9 +344,11 @@ describe('LinearAgentSkillSetupPrompt', () => {
       setupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(document.body.textContent).toContain("bash -lc 'npx --yes skills add")
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({
+        // Pinned whole: the only check that both non-interactive flags survive WSL wrapping.
+        command:
+          "wsl.exe -d 'Fedora' -- bash -lc 'npx --yes skills add https://github.com/stablyai/orca --skill orca-linear --global -y'",
         installedCommand:
           "wsl.exe -d 'Fedora' -- bash -lc 'npx skills update orca-linear --global'",
         terminalShellOverride: 'powershell.exe',

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
@@ -344,7 +344,7 @@ describe('LinearAgentSkillSetupPrompt', () => {
       setupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(document.body.textContent).toContain("wsl.exe -d 'Fedora' -- bash -lc 'npx skills add")
+    expect(document.body.textContent).toContain("bash -lc 'npx --yes skills add")
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({
         installedCommand:

--- a/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
@@ -438,7 +438,7 @@ describe('SkillFreshnessUpdateDialog', () => {
     await openViaRequest()
 
     expect(container?.textContent).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+      'npx skills add https://github.com/stablyai/orca --skill orchestration --global -y'
     )
   })
 

--- a/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
@@ -438,7 +438,7 @@ describe('SkillFreshnessUpdateDialog', () => {
     await openViaRequest()
 
     expect(container?.textContent).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orchestration --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orchestration --global -y'
     )
   })
 

--- a/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
@@ -32,7 +32,7 @@ describe('skippedReason', () => {
     const reason = skippedReason([row(null)], 'orchestration')
     expect(reason).toContain('reports the skill as already up to date')
     expect(reason).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orchestration --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orchestration --global -y'
     )
   })
 

--- a/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
@@ -32,7 +32,7 @@ describe('skippedReason', () => {
     const reason = skippedReason([row(null)], 'orchestration')
     expect(reason).toContain('reports the skill as already up to date')
     expect(reason).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+      'npx skills add https://github.com/stablyai/orca --skill orchestration --global -y'
     )
   })
 

--- a/src/shared/agent-feature-install-commands.test.ts
+++ b/src/shared/agent-feature-install-commands.test.ts
@@ -7,6 +7,7 @@ import {
   LINEAR_TICKETS_SKILL_UPDATE_COMMAND,
   ORCA_LINEAR_SKILL_UPDATE_COMMAND,
   ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
+  ORCA_CLI_SKILL_INSTALL_COMMAND,
   ORCA_CLI_SKILL_UPDATE_COMMAND,
   ORCHESTRATION_SKILL_UPDATE_COMMAND
 } from './agent-feature-install-commands'
@@ -35,7 +36,27 @@ describe('agent feature skill commands', () => {
     expect(ORCA_LINEAR_SKILL_UPDATE_COMMAND).toBe('npx skills update orca-linear --global')
     expect(LINEAR_TICKETS_SKILL_UPDATE_COMMAND).toBe('npx skills update linear-tickets --global')
     expect(ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND).toBe(
-      buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])
+      'npx skills add https://github.com/stablyai/orca --skill orca-cli orchestration --global -y'
+    )
+  })
+
+  it('builds install commands non-interactively so a pasted command never stops on a prompt', () => {
+    // Why: with more than one agent installed the CLI prompts for a target and the
+    // pasted command hangs, so `-y` is the fix and must not silently regress.
+    expect(buildAgentFeatureSkillInstallCommand(['orca-cli'])).toBe(
+      'npx skills add https://github.com/stablyai/orca --skill orca-cli --global -y'
+    )
+    expect(buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])).toBe(
+      'npx skills add https://github.com/stablyai/orca --skill orca-cli orchestration --global -y'
+    )
+    expect(ORCA_CLI_SKILL_INSTALL_COMMAND).toBe(
+      'npx skills add https://github.com/stablyai/orca --skill orca-cli --global -y'
+    )
+  })
+
+  it('rejects an empty install skill list', () => {
+    expect(() => buildAgentFeatureSkillInstallCommand([])).toThrow(
+      'At least one skill name is required.'
     )
   })
 })

--- a/src/shared/agent-feature-install-commands.test.ts
+++ b/src/shared/agent-feature-install-commands.test.ts
@@ -42,7 +42,7 @@ describe('agent feature skill commands', () => {
 
   it('builds install commands non-interactively so a pasted command never stops on a prompt', () => {
     // Why: a pasted command hangs on npm's install-this-package prompt and on the
-    // CLI's agent selection, so both `npx --yes` and `-y` must not silently regress.
+    // CLI's own install selects, so both `npx --yes` and `-y` must not silently regress.
     expect(buildAgentFeatureSkillInstallCommand(['orca-cli'])).toBe(
       'npx --yes skills add https://github.com/stablyai/orca --skill orca-cli --global -y'
     )

--- a/src/shared/agent-feature-install-commands.test.ts
+++ b/src/shared/agent-feature-install-commands.test.ts
@@ -36,21 +36,21 @@ describe('agent feature skill commands', () => {
     expect(ORCA_LINEAR_SKILL_UPDATE_COMMAND).toBe('npx skills update orca-linear --global')
     expect(LINEAR_TICKETS_SKILL_UPDATE_COMMAND).toBe('npx skills update linear-tickets --global')
     expect(ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli orchestration --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orca-cli orchestration --global -y'
     )
   })
 
   it('builds install commands non-interactively so a pasted command never stops on a prompt', () => {
-    // Why: with more than one agent installed the CLI prompts for a target and the
-    // pasted command hangs, so `-y` is the fix and must not silently regress.
+    // Why: a pasted command hangs on npm's install-this-package prompt and on the
+    // CLI's agent selection, so both `npx --yes` and `-y` must not silently regress.
     expect(buildAgentFeatureSkillInstallCommand(['orca-cli'])).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orca-cli --global -y'
     )
     expect(buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli orchestration --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orca-cli orchestration --global -y'
     )
     expect(ORCA_CLI_SKILL_INSTALL_COMMAND).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli --global -y'
+      'npx --yes skills add https://github.com/stablyai/orca --skill orca-cli --global -y'
     )
   })
 

--- a/src/shared/agent-feature-install-commands.ts
+++ b/src/shared/agent-feature-install-commands.ts
@@ -14,9 +14,11 @@ export function buildAgentFeatureSkillInstallCommand(skillNames: readonly string
   }
   // Why: pasted into a live terminal, so any prompt strands the user and closing the panel
   // kills the session mid-prompt. Both flags are load-bearing, as in the headless updater:
-  // `npx --yes` skips npm's install-this-package prompt (npx re-resolves `latest` every
-  // run, so a cold or stale cache prompts); `skills … -y` skips the CLI's own selects, which
-  // fire even for a single agent because `--global` targets the canonical dir plus the provider's.
+  // `npx --yes` skips npm's install-this-package prompt (npx re-resolves `latest` every run,
+  // so a cold or stale cache prompts); `skills … -y` skips the CLI's own, whose `Proceed with
+  // installation?` confirm is unconditional and whose install-method select fires even for a
+  // single agent, since the CLI always adds its universal `.agents/skills` target alongside
+  // the agent's own dir. Neither prompt is a consequence of `--global`.
   return `npx --yes skills add ${ORCA_SKILLS_REPOSITORY_URL} --skill ${skillNames.join(' ')} --global -y`
 }
 

--- a/src/shared/agent-feature-install-commands.ts
+++ b/src/shared/agent-feature-install-commands.ts
@@ -12,7 +12,10 @@ export function buildAgentFeatureSkillInstallCommand(skillNames: readonly string
   if (skillNames.length === 0) {
     throw new Error('At least one skill name is required.')
   }
-  return `npx skills add ${ORCA_SKILLS_REPOSITORY_URL} --skill ${skillNames.join(' ')} --global`
+  // Why: `-y` because this command is pasted into a live terminal — with more than one
+  // agent installed the CLI stops on an agent-selection prompt the user cannot see coming,
+  // and closing the panel tears the session down mid-prompt.
+  return `npx skills add ${ORCA_SKILLS_REPOSITORY_URL} --skill ${skillNames.join(' ')} --global -y`
 }
 
 export function buildAgentFeatureSkillUpdateCommand(skillName: string): string {

--- a/src/shared/agent-feature-install-commands.ts
+++ b/src/shared/agent-feature-install-commands.ts
@@ -15,7 +15,8 @@ export function buildAgentFeatureSkillInstallCommand(skillNames: readonly string
   // Why: pasted into a live terminal, so any prompt strands the user and closing the panel
   // kills the session mid-prompt. Both flags are load-bearing, as in the headless updater:
   // `npx --yes` skips npm's install-this-package prompt (npx re-resolves `latest` every
-  // run, so a cold or stale cache prompts); `skills … -y` skips agent selection.
+  // run, so a cold or stale cache prompts); `skills … -y` skips the CLI's own selects, which
+  // fire even for a single agent because `--global` targets the canonical dir plus the provider's.
   return `npx --yes skills add ${ORCA_SKILLS_REPOSITORY_URL} --skill ${skillNames.join(' ')} --global -y`
 }
 

--- a/src/shared/agent-feature-install-commands.ts
+++ b/src/shared/agent-feature-install-commands.ts
@@ -12,10 +12,11 @@ export function buildAgentFeatureSkillInstallCommand(skillNames: readonly string
   if (skillNames.length === 0) {
     throw new Error('At least one skill name is required.')
   }
-  // Why: `-y` because this command is pasted into a live terminal — with more than one
-  // agent installed the CLI stops on an agent-selection prompt the user cannot see coming,
-  // and closing the panel tears the session down mid-prompt.
-  return `npx skills add ${ORCA_SKILLS_REPOSITORY_URL} --skill ${skillNames.join(' ')} --global -y`
+  // Why: pasted into a live terminal, so any prompt strands the user and closing the panel
+  // kills the session mid-prompt. Both flags are load-bearing, as in the headless updater:
+  // `npx --yes` skips npm's install-this-package prompt (npx re-resolves `latest` every
+  // run, so a cold or stale cache prompts); `skills … -y` skips agent selection.
+  return `npx --yes skills add ${ORCA_SKILLS_REPOSITORY_URL} --skill ${skillNames.join(' ')} --global -y`
 }
 
 export function buildAgentFeatureSkillUpdateCommand(skillName: string): string {


### PR DESCRIPTION
Fixes #9567

## The bug

`buildAgentFeatureSkillInstallCommand` in `src/shared/agent-feature-install-commands.ts` produces the command that **every** Settings and onboarding skill card pastes into a terminal:

```
npx skills add https://github.com/stablyai/orca --skill <names> --global
```

That command is *pasted*, not auto-run — `OnboardingInlineCommandTerminal.tsx` dispatches `PASTE_TERMINAL_TEXT_EVENT` with `command.trim()` and no trailing newline, into a session whose cwd is `$HOME`.

It could stall on prompts from **two** separate programs — npm and the `skills` CLI — and either one strands the user. Closing the panel then tears the PTY down mid-prompt — which is exactly the reporter's `session-killed: immediate: true` / `exit 1`.

1. **npm's own prompt.** `npx skills …` without `--yes` blocks on `Need to install the following packages: skills@x.y.z / Ok to proceed?` whenever the package is missing from the npx cache (`libnpmexec/lib/index.js`, the TTY branch). This is not just a first-run cost: `missingFromTree` documents that for a bare name in the npx tree it "check[s] if a newer version is available", so the prompt returns every time upstream publishes.
2. **The `skills` CLI's own prompts.** Without `-y` the CLI blocks before it finishes, and it does so for **every** user — not only the multi-agent case in the report. The `Proceed with installation?` confirm is gated on `!options.yes` alone. The **"Installation method"** select fires even when exactly one agent is installed, because the CLI calls `ensureUniversalAgents` and appends its universal `.agents/skills` targets to the detected agent's own dir, making `uniqueDirs.size > 1`. That set is built from each agent's *relative* `skillsDir`, so the trigger is the universal-target expansion, not `--global`. Agent selection fires on top of that whenever more than one agent is installed.

   Verified directly against `skills@1.5.20` in a scrubbed, non-agent env with exactly one installed agent (Claude Code): without `-y` the run stops rendering at `◆ Installation method` and waits; adding `-y` alone takes the identical command through to `Installed 1 skill` / `Done!`. (The CLI sets `options.yes = true` by itself when it detects it is running *inside* an agent, which is why an agent-run probe never reproduces the stall.)

## The fix

Build the command with both non-interactive flags. One line covers macOS, Linux, native Windows, and WSL, because both platform rewrites in `CliSkillRuntimeSetup.tsx` wrap this same string rather than rebuilding it:

- the WSL base64 login-shell wrapper, and
- the native-Windows `update` → reinstall rewrite (`normalizeWindowsSkillUpdateCommand`), which calls `buildAgentFeatureSkillInstallCommand` and so now also yields a non-interactive command.

```diff
-npx skills add https://github.com/stablyai/orca --skill <names> --global
+npx --yes skills add https://github.com/stablyai/orca --skill <names> --global -y
```

The two flags are distinct and both load-bearing, which is already the established pattern in this repo: `src/main/skills/skill-update-run.ts` spawns `['--yes', 'skills', 'update', …, '--global', '-y']` with a docblock spelling out why. The pasted command now matches the headless one.

It matters most on **WSL**: `OrchestrationSetupCard.tsx` passes `freshnessSkillName={undefined}` when the runtime is `wsl`, so WSL users get no background updater at all and the terminal paste is their only path.

`skill-freshness-skipped-reason.ts` — the manual-recovery sentence shown when the background updater gives up and hands the user a reinstall command — derives from the same builder and picks the flags up for free. Covered by an updated assertion.

### `--global` is deliberately kept

A prior proposal (#6580) suggested dropping `--global`. That premise does not hold on current `main`: `src/main/skills/skill-discovery-sources.ts` deliberately scans ten provider home roots (`.codex/skills`, `.agents/skills`, `.claude/skills`, `.grok/skills`, `.config/opencode/skills`, `.pi/agent/skills`, `.gemini/skills`, `.gemini/antigravity/skills`, `.cursor/skills`, `.codex/plugins/cache`) *precisely because* `--global` writes there — the in-repo comment states that intent explicitly. Removing it would narrow discovery coverage.

### What `-y` auto-accepts, and why none of it regresses Orca

- **Install method (symlink vs copy).** `-y` skips the "Installation method" select, leaving the CLI's own recommended default: symlink. That is the effective default in practice, not an edge case, since more than one distinct skills dir is targeted even for a single agent. Orca models that shape as a first-class topology: `classifyHomeSkillTopology` returns `provider-alias` for a link into `~/.agents/skills`, and `topologyDedupeBucket` buckets `provider-alias` together with `canonical-copy` as `managed-global`. So a symlinked install is treated as managed, not as a modified or unmanaged copy.

  Confirmed on disk after a real `-y` install: `~/.agents/skills/orca-cli` is the real directory (`canonical-copy`) and `~/.claude/skills/orca-cli` is a symlink resolving into it (`provider-alias`). Both land in the same `managed-global` bucket, so freshness dedupes them to one managed install rather than flagging a stray copy.
- **Agent targeting.** With several agents detected, `-y` installs to all of them rather than a user-chosen subset. Those are exactly the provider home roots Orca already scans, and the alternative today is the prompt that hangs.
- **Prompts that simply stop appearing.** The "Proceed with installation?" confirm and the one-time "Install the find-skills skill?" offer are skipped; neither installs anything extra.

## Tests

The existing shared-module assertion was **vacuous** — it compared `ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND` against `buildAgentFeatureSkillInstallCommand([...])`, i.e. the function against itself, so no change to the command could ever fail it. Replaced with a literal-string assertion, plus a dedicated test pinning both flags and one covering the empty-list throw. Two assertions in `CliSkillRuntimeSetup.test.tsx` were tautological the same way (they rebuilt the expectation from the builder they were meant to pin) and are now literals — that pair is the only coverage that the flags survive the native-Windows rewrite.

Verified non-vacuous: reverting only the source change makes the shared-module tests fail; restoring it makes them pass.

Assertions updated to pin the new command:

- `src/shared/agent-feature-install-commands.test.ts`
- `src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts`
- `src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx` (×2)
- `src/renderer/src/components/settings/OrchestrationPane.test.tsx`
- `src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx` (×2)
- `src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx` (the WSL wrapper surface)
- `src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts`
- `src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx`

Several of those use `toContain`, so a superstring would have passed silently; they were tightened so each rendered surface actually proves the flags reach it. Sites left alone are pure local fixtures passed *into* a component as a prop (`AgentSkillSetupPanel.test.tsx`, `BrowserUseSkillStep.test.tsx`) and one invalid-payload rejection fixture (`onboarding-feature-setup-validator.test.ts`) — none derive from the builder.

The update command (`npx skills update <name> --global`) is intentionally unchanged: `normalizeWindowsSkillUpdateCommand` parses it with an anchored regex, and the headless updater already passes `--yes` itself.

Green: the 8 changed test files pass (92 tests). Full `typecheck` clean, `oxlint` and `oxfmt` clean, max-lines ratchet clean. Broader skills/settings/onboarding sweeps are green too, and CI on this branch is passing.

## Related issues

- **#6162** — partially addressed. This removes the interactive-prompt failure mode. The upstream DEP0190 spawn bug and the native-Windows PromptScript footnote are separate and remain open.
- **#4642** — related, not closed. Its residual is the PromptScript / `~/.agents/skills` target still not landing under `--global`, which is a separate decision.


## Validated in the real app

Run against a dev build of this branch, in an isolated instance (temp `HOME`) so every skill genuinely reports **Not installed** and the install surfaces actually render. CDP owner verified as this worktree's own Electron process before attaching.

**Settings → Computer Use → Install.** This is the reporter's exact path: the command is *pasted* into a live terminal and left sitting at the prompt ("Press Enter to run the command."), which is why an interactive prompt could strand the session. The pasted command now ends in `-y`:

```
npx --yes skills add https://github.com/stablyai/orca --skill computer-use --global -y
```

![yflag-install-terminal.png](https://github.com/user-attachments/assets/f560f503-88e8-459f-9628-be7be5f70970)

**Settings → Orchestration → "Prefer your own terminal? Copy install command".** The manual-copy dialog carries the flag too:

```
npx --yes skills add https://github.com/stablyai/orca --skill orchestration --global -y
```

![yflag-copy-dialog.png](https://github.com/user-attachments/assets/a4be2e1b-b152-4454-9fd4-e59b67b71c26)

(Both flags shown above come from this PR. `npx --yes` answers npm's *package-install* prompt; `-y` answers the *skills CLI's* agent-selection prompt. They are independent, and either one alone still leaves a way to stall.)

Not reachable in this environment, so not visually validated: the WSL and native-Windows rewrites (macOS host). Those are covered by unit tests, including a newly pinned assertion on the Windows update→reinstall rewrite.




