### PR TITLE
test(skills): execute the plugin-cache entry limit instead of reasoning about it

### DIFF
--- a/src/main/skills/skill-freshness-inventory.test.ts
+++ b/src/main/skills/skill-freshness-inventory.test.ts
@@ -15,6 +15,7 @@ import {
   MAXIMUM_REPOSITORY_SKILL_ROOTS
 } from './skill-freshness-inventory'
 import { describeObservedSkillFile, skillPackageDigest } from './skill-package-identity'
+import { MAXIMUM_PLUGIN_SCAN_ENTRIES } from './skill-plugin-cache-scan'
 import { getSkillFreshnessDisplayStatus } from '../../renderer/src/lib/skill-freshness-display-status'
 
 const temporaryDirectories: string[] = []
@@ -704,6 +705,44 @@ describe('read-only skill freshness inventory', () => {
         reason: 'depth-limit',
         errorCode: null
       })
+    ])
+  })
+
+  it('invents no installations when the plugin cache trips the entry budget (#10918)', async () => {
+    const test = await fixture()
+    await test.writeSkill(join(test.homeDir, '.agents', 'skills'), test.currentMarkdown)
+    const pluginCache = join(test.homeDir, '.codex', 'plugins', 'cache')
+    await mkdir(pluginCache, { recursive: true })
+    // Why: the production bound, not an injected one — #10918 is the real constant
+    // collapsing the scan to the cache root, and only a real cache proves that path.
+    const entries = Array.from({ length: MAXIMUM_PLUGIN_SCAN_ENTRIES + 1 }, (_, index) =>
+      join(pluginCache, `entry-${index}`)
+    )
+    for (let index = 0; index < entries.length; index += 512) {
+      await Promise.all(entries.slice(index, index + 512).map((path) => writeFile(path, '')))
+    }
+
+    const inventory = await inventorySkillFreshness({
+      currentAppVersion: '2.0.0',
+      homeDir: test.homeDir,
+      repos: [],
+      resourceRoot: test.resourceRoot
+    })
+
+    // Why: assert the bound actually tripped first — if the fixture stopped reaching it,
+    // the placement assertion below would still pass and cover nothing.
+    expect(inventory.scanIssues).toEqual([
+      expect.objectContaining({
+        rootId: 'codex-plugin-cache',
+        path: pluginCache,
+        reason: 'entry-limit',
+        errorCode: null
+      })
+    ])
+    // Why: the truncated root is not evidence of a copy. Fabricating one per manifest name
+    // is what pinned an unclearable "Needs attention" on every card in #10918.
+    expect(inventory.installations).toEqual([
+      expect.objectContaining({ name: 'orca-cli', status: 'current', topology: 'canonical-copy' })
     ])
   })
 })

--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -29,10 +29,58 @@ describe('plugin skill candidate scan', () => {
       })
     )
 
-    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), 1)
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
+      maximumCandidates: 1
+    })
 
     expect(result.candidates).toHaveLength(1)
     expect(result.issues).toEqual([{ path: root, reason: 'candidate-limit', errorCode: null }])
+  })
+
+  it('stops at the entry budget and reports the truncation at the scan root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-entry-limit-'))
+    temporaryDirectories.push(root)
+    await Promise.all(
+      ['one', 'two'].map(async (vendor) => {
+        await mkdir(join(root, vendor, 'orca-cli'), { recursive: true })
+        await writeFile(join(root, vendor, 'orca-cli', 'SKILL.md'), '# Orca CLI\n')
+      })
+    )
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
+      maximumEntries: 1
+    })
+
+    // Why: the walk ends before descending, so both real skills go unseen. The issue is
+    // all that stops the dialog reporting all-clear over a scan that never reached them.
+    expect(result.candidates).toEqual([])
+    expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
+  })
+
+  it('stops at the entry budget while resolving declared skill roots', async () => {
+    // Why: a declared root costs a resolve before it can be rejected, and a root that does
+    // not exist reads no dirent at all — so the dirent guard never sees a manifest that
+    // spends the whole scan on missing paths. Only this guard bounds that.
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-entry-limit-declared-'))
+    temporaryDirectories.push(root)
+    const candidate = join(root, 'a-skills', 'orca-cli')
+    await mkdir(join(root, '.codex-plugin'), { recursive: true })
+    await mkdir(candidate, { recursive: true })
+    await writeFile(
+      join(root, '.codex-plugin', 'plugin.json'),
+      '{"skills":["./a-skills","./missing-one","./missing-two"]}\n'
+    )
+    await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+
+    // Budget: the root's two dirents, a-skills', the skill's, and the first declared root.
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
+      maximumEntries: 5
+    })
+
+    // Why: the declared root that exists was fully walked, so the bound is being crossed by
+    // a resolve of the roots after it — not by the dirent loop stopping the scan early.
+    expect(result.candidates).toEqual([{ name: 'orca-cli', path: candidate }])
+    expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
   })
 
   it('completes a real-shaped Codex cache without reporting coverage issues', async () => {
@@ -554,7 +602,9 @@ describe('plugin skill candidate scan', () => {
       })
     )
 
-    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), 1)
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
+      maximumCandidates: 1
+    })
 
     // Why: the deep trees above exist to spend the display budget, so assert it is full —
     // otherwise this passes with budget to spare and stops covering the case it is named

--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { isSkillScanIssueNeedingAttention } from '../../shared/skill-freshness'
 import {
   MAXIMUM_PLUGIN_SCAN_ATTENTION_ISSUES,
+  MAXIMUM_PLUGIN_SCAN_DEPTH,
   MAXIMUM_PLUGIN_SCAN_ISSUES,
   scanKnownPluginSkillCandidates
 } from './skill-plugin-cache-scan'
@@ -63,9 +64,13 @@ describe('plugin skill candidate scan', () => {
   it('stops walking the directory whose read crossed the entry budget', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-plugin-entry-limit-stop-'))
     temporaryDirectories.push(root)
-    // Nine levels puts the deepest directory exactly at the traversal depth bound, so its
-    // children are the first thing a walk that failed to stop would reject on depth.
-    const segments = Array.from({ length: 9 }, (_, index) => `level-${index}`)
+    // Why: read off the depth bound rather than hardcoded. The deepest directory has to
+    // sit exactly at it, so its children are the first thing a walk that failed to stop
+    // would reject on depth — one level shallower and the mutant walks them silently.
+    const segments = Array.from(
+      { length: MAXIMUM_PLUGIN_SCAN_DEPTH },
+      (_, index) => `level-${index}`
+    )
     await Promise.all(
       ['a', 'b'].map((name) => mkdir(join(root, ...segments, name), { recursive: true }))
     )

--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -60,10 +60,14 @@ describe('plugin skill candidate scan', () => {
     expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
   })
 
-  it('stops at the entry budget while resolving declared skill roots', async () => {
-    // Why: a declared root costs a resolve before it can be rejected, and a root that does
-    // not exist reads no dirent at all — so the dirent guard never sees a manifest that
-    // spends the whole scan on missing paths. Only this guard bounds that.
+  // Why: a declared root costs a resolve before it can be rejected, and a root that does
+  // not exist reads no dirent at all — so the dirent guard never sees a manifest that
+  // spends the whole scan on missing paths. Only the resolve guard bounds that, and only
+  // this shape lets its threshold be read off the entry count instead of assumed.
+  async function createManifestWithMissingSkillRoots(): Promise<{
+    root: string
+    candidate: string
+  }> {
     const root = await mkdtemp(join(tmpdir(), 'orca-plugin-entry-limit-declared-'))
     temporaryDirectories.push(root)
     // Why: the manifest sits under a vendor directory, not at the scan root, so the
@@ -77,17 +81,41 @@ describe('plugin skill candidate scan', () => {
       '{"skills":["./a-skills","./missing-one","./missing-two"]}\n'
     )
     await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+    return { root, candidate }
+  }
 
-    // Budget: the root's dirent, the vendor's two, a-skills', the skill's, and the first
-    // declared root.
+  // Why: the scan reads exactly eight entries here — the root's dirent, the vendor's two,
+  // a-skills' and its skill's, then one resolve per declared root. Both budgets below are
+  // stated against that count so each guard's threshold is asserted, not just its firing.
+  const DECLARED_ROOT_SCAN_ENTRIES = 8
+
+  it('stops at the entry budget while resolving declared skill roots', async () => {
+    const { root, candidate } = await createManifestWithMissingSkillRoots()
+
+    // Why: one short of the full count, so only the last declared root's resolve crosses
+    // it. A guard that admitted that root would run the scan to completion and report
+    // nothing, which is what makes the issue below an assertion on the threshold.
     const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
-      maximumEntries: 6
+      maximumEntries: DECLARED_ROOT_SCAN_ENTRIES - 1
     })
 
     // Why: the declared root that exists was fully walked, so the bound is being crossed by
     // a resolve of the roots after it — not by the dirent loop stopping the scan early.
     expect(result.candidates).toEqual([{ name: 'orca-cli', path: candidate }])
     expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
+  })
+
+  it('resolves the last declared skill root when the entry budget is exactly spent', async () => {
+    const { root, candidate } = await createManifestWithMissingSkillRoots()
+
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
+      maximumEntries: DECLARED_ROOT_SCAN_ENTRIES
+    })
+
+    // Why: a budget the scan fits inside is not a truncation. Firing one entry early would
+    // pin the same unclearable attention #10918 did, on a scan that missed nothing.
+    expect(result.candidates).toEqual([{ name: 'orca-cli', path: candidate }])
+    expect(result.issues).toEqual([])
   })
 
   it('completes a real-shaped Codex cache without reporting coverage issues', async () => {

--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -47,13 +47,16 @@ describe('plugin skill candidate scan', () => {
       })
     )
 
+    // Budget: the root's two vendor dirents, one's, and its skill's — so the count is
+    // crossed inside 'two', not at the root. That is what pins the issue to the scan
+    // root the dialog can name rather than whichever directory happened to cross it.
     const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
-      maximumEntries: 1
+      maximumEntries: 4
     })
 
-    // Why: the walk ends before descending, so both real skills go unseen. The issue is
-    // all that stops the dialog reporting all-clear over a scan that never reached them.
-    expect(result.candidates).toEqual([])
+    // Why: the second vendor's skill goes unseen. The issue is all that stops the dialog
+    // reporting all-clear over a scan that never reached it.
+    expect(result.candidates).toEqual([{ name: 'orca-cli', path: join(root, 'one', 'orca-cli') }])
     expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
   })
 
@@ -63,18 +66,22 @@ describe('plugin skill candidate scan', () => {
     // spends the whole scan on missing paths. Only this guard bounds that.
     const root = await mkdtemp(join(tmpdir(), 'orca-plugin-entry-limit-declared-'))
     temporaryDirectories.push(root)
-    const candidate = join(root, 'a-skills', 'orca-cli')
-    await mkdir(join(root, '.codex-plugin'), { recursive: true })
+    // Why: the manifest sits under a vendor directory, not at the scan root, so the
+    // directory whose declared roots cross the budget is not the root the issue names.
+    const packageRoot = join(root, 'vendor')
+    const candidate = join(packageRoot, 'a-skills', 'orca-cli')
+    await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
     await mkdir(candidate, { recursive: true })
     await writeFile(
-      join(root, '.codex-plugin', 'plugin.json'),
+      join(packageRoot, '.codex-plugin', 'plugin.json'),
       '{"skills":["./a-skills","./missing-one","./missing-two"]}\n'
     )
     await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
 
-    // Budget: the root's two dirents, a-skills', the skill's, and the first declared root.
+    // Budget: the root's dirent, the vendor's two, a-skills', the skill's, and the first
+    // declared root.
     const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
-      maximumEntries: 5
+      maximumEntries: 6
     })
 
     // Why: the declared root that exists was fully walked, so the bound is being crossed by

--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -60,6 +60,29 @@ describe('plugin skill candidate scan', () => {
     expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
   })
 
+  it('stops walking the directory whose read crossed the entry budget', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-plugin-entry-limit-stop-'))
+    temporaryDirectories.push(root)
+    // Nine levels puts the deepest directory exactly at the traversal depth bound, so its
+    // children are the first thing a walk that failed to stop would reject on depth.
+    const segments = Array.from({ length: 9 }, (_, index) => `level-${index}`)
+    await Promise.all(
+      ['a', 'b'].map((name) => mkdir(join(root, ...segments, name), { recursive: true }))
+    )
+
+    // Budget: one dirent per level down to the deepest directory, plus the first of its
+    // two children — so the count is crossed on the second, with the first already read.
+    const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']), {
+      maximumEntries: segments.length + 1
+    })
+
+    // Why: the entries already read before the bound must not still be descended. A scan
+    // that keeps walking reports the leftovers as depth-truncated, which is a coverage
+    // failure the walk never observed — exactly the kind of unaccountable claim #10918 was.
+    expect(result.candidates).toEqual([])
+    expect(result.issues).toEqual([{ path: root, reason: 'entry-limit', errorCode: null }])
+  })
+
   // Why: a declared root costs a resolve before it can be rejected, and a root that does
   // not exist reads no dirent at all — so the dirent guard never sees a manifest that
   // spends the whole scan on missing paths. Only the resolve guard bounds that, and only

--- a/src/main/skills/skill-plugin-cache-scan.ts
+++ b/src/main/skills/skill-plugin-cache-scan.ts
@@ -51,7 +51,7 @@ function errorCode(error: unknown): string | null {
 
 // Why: overriding a bound is how its truncation path stays executable — reaching the real
 // entry budget costs a 16k-dirent fixture per case, and the declared-root guard below it
-// only fires when the count lands in a one-entry window. Production passes neither.
+// needs the running count parked just under that budget. Production passes neither.
 export type PluginSkillScanBounds = {
   maximumCandidates?: number
   maximumEntries?: number

--- a/src/main/skills/skill-plugin-cache-scan.ts
+++ b/src/main/skills/skill-plugin-cache-scan.ts
@@ -8,7 +8,7 @@ import {
 } from '../../shared/skill-freshness'
 import { declaredPluginSkillRoots, isWithinRoot } from './skill-plugin-manifest-roots'
 
-const MAXIMUM_PLUGIN_SCAN_DEPTH = 9
+export const MAXIMUM_PLUGIN_SCAN_DEPTH = 9
 const MAXIMUM_DECLARED_SKILL_SCAN_DEPTH = 6
 // Why: a skill package's own payload (templates, fixtures, sample apps) is not a skill
 // tree, and it is what drives ordinary caches past the depth and entry bounds. Descend

--- a/src/main/skills/skill-plugin-cache-scan.ts
+++ b/src/main/skills/skill-plugin-cache-scan.ts
@@ -17,7 +17,7 @@ const MAXIMUM_NESTED_SKILL_DEPTH = 2
 // Why: sized against a real multi-vendor cache, which reads ~7k entries once payload is
 // pruned. The bound still exists to stop a hostile or runaway tree; it is not a budget
 // ordinary installs are meant to exhaust.
-const MAXIMUM_PLUGIN_SCAN_ENTRIES = 16_384
+export const MAXIMUM_PLUGIN_SCAN_ENTRIES = 16_384
 export const MAXIMUM_PLUGIN_SKILL_CANDIDATES = 64
 export const MAXIMUM_PLUGIN_SCAN_ISSUES = 16
 // Why: an attention issue outranks the display budget, so nothing else bounds how many a
@@ -49,11 +49,21 @@ function errorCode(error: unknown): string | null {
     : null
 }
 
+// Why: overriding a bound is how its truncation path stays executable — reaching the real
+// entry budget costs a 16k-dirent fixture per case, and the declared-root guard below it
+// only fires when the count lands in a one-entry window. Production passes neither.
+export type PluginSkillScanBounds = {
+  maximumCandidates?: number
+  maximumEntries?: number
+}
+
 export async function scanKnownPluginSkillCandidates(
   rootPath: string,
   knownNames: ReadonlySet<string>,
-  maximumCandidates = MAXIMUM_PLUGIN_SKILL_CANDIDATES
+  bounds: PluginSkillScanBounds = {}
 ): Promise<KnownPluginSkillScan> {
+  const maximumCandidates = bounds.maximumCandidates ?? MAXIMUM_PLUGIN_SKILL_CANDIDATES
+  const maximumEntries = bounds.maximumEntries ?? MAXIMUM_PLUGIN_SCAN_ENTRIES
   const candidates: KnownPluginSkillCandidate[] = []
   const issues: KnownPluginSkillScanIssue[] = []
   const issueKeys = new Set<string>()
@@ -197,7 +207,7 @@ export async function scanKnownPluginSkillCandidates(
           break
         }
         entryCount += 1
-        if (entryCount > MAXIMUM_PLUGIN_SCAN_ENTRIES) {
+        if (entryCount > maximumEntries) {
           limitReached = true
           recordIssue(rootPath, 'entry-limit')
           break
@@ -233,7 +243,7 @@ export async function scanKnownPluginSkillCandidates(
       const skillRootDepth = withinDeclaredSkillRoot ? depth + 1 : 0
       for (const skillRoot of skillRoots.sort()) {
         entryCount += 1
-        if (entryCount > MAXIMUM_PLUGIN_SCAN_ENTRIES) {
+        if (entryCount > maximumEntries) {
           limitReached = true
           recordIssue(rootPath, 'entry-limit')
           return


### PR DESCRIPTION
## Why

The user-visible bug in #10918 — a plugin-cache entry limit collapsing the scan to the cache root and pinning "Needs attention" on every skill — already shipped fixed in #10865 (`2cf91b8e69`). What did not ship was coverage: the reporter pointed out that nothing actually drives the entry bound, and that is still true on `main`.

Every `entry-limit` test in the repo constructs a synthetic issue object at the display/dialog layer:

- `src/renderer/src/lib/skill-freshness-display-status.test.ts:108`, `:200`
- `src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx:613`

So both emission sites in `scanKnownPluginSkillCandidates` — the dirent read loop and the declared-skill-root resolve — were verified by reading the code, never by running it.

The gap existed because the bound is 16,384 dirents, and the second guard is harder still: it only fires when the running count is already parked just under the bound as the declared-root loop begins, so its crossing window is no wider than the roots left to resolve — which no realistic fixture hits by accident.

## What changed

Makes the entry bound injectable the way `maximumCandidates` already was. Rather than add a fourth positional number, the two bounds fold into a `PluginSkillScanBounds` bag; the production call site is unchanged and passes neither. **No bound value changes, no scan behavior changes, no renderer changes.** `MAXIMUM_PLUGIN_SCAN_DEPTH` also becomes an export: case 2's chain has to be exactly that deep, and hardcoding the 9 left the test passing but no longer covering if the bound moved. Three of its sibling bounds were already exported for the same reason, so this follows the module's existing convention rather than setting a new one.

Five new cases:

1. **Dirent read loop** — truncates the read, asserts the second vendor's skill goes unseen and the scan emits exactly `{ path: <root>, reason: 'entry-limit' }`. The budget is spent so the count is crossed inside a subdirectory, which is what makes the `<root>` in that issue an assertion rather than a coincidence.
2. **Dirent read loop, walk stop** — a nine-level chain whose deepest directory sits exactly at the traversal depth bound and crosses the budget on the second of its two children. The first child is already in the read entries when the bound trips, so a walk that fails to stop still descends it and reports a `depth-limit` for a path it never reached — a coverage claim the scan never observed. Asserting the issue list exactly is what covers that guard's `limitReached`, not just the issue it records.
3. **Declared-root resolve, one entry short of the full count** — a `.codex-plugin` manifest, one vendor directory below the scan root, declaring one real root plus two that do not exist. Declared roots are resolved without reading a dirent, so a manifest full of missing paths can spend the whole scan somewhere the dirent guard never looks; this is precisely what that guard bounds. The test asserts the real declared root was still fully walked, which is what pins the failure to the resolve guard rather than the read loop.
4. **Declared-root resolve, exactly at the full count** — the same fixture with a budget the scan fits inside, asserting it reports nothing. Both budgets are stated against the fixture's exact entry count, so the guard's threshold is asserted and not just its firing.
5. **`inventorySkillFreshness` at the production bound** — a real 16,385-entry cache, not an injected bound, asserting that a truncated scan yields zero fabricated placements. It uses the real constant deliberately: #10918 was the production value collapsing the scan, so only the production value shows that the 16,384 bound is actually reachable and surfaces as `entry-limit` end-to-end through `inventorySkillFreshness`. The existing depth-limit test at `skill-freshness-inventory.test.ts:675` already guards the fabrication removal in general; what is new here is that the entry bound specifically reaches it. Building 16,385 dirents is what it costs — 2-6s depending on machine load, and there is no cheaper way to reach a dirent bound than one dirent at a time.

## Non-vacuity

Each test was mutation-checked against the guard it claims to cover.

| Mutation | Result |
| --- | --- |
| Neuter the dirent-read guard | dirent and walk-stop tests fail; declared-root tests still pass |
| Neuter the declared-root guard | declared-root test fails; dirent tests still pass |
| Drop the dirent-read guard's `limitReached = true` | walk-stop test fails on a fabricated `depth-limit` |
| Reinstate the pre-#10865 `incompletePaths` fabrication in `inventorySkillFreshness` | inventory test fails with the `plugin-cache-scan-incomplete` placement that caused #10918 |
| Report the truncation at the crossing `directory` instead of `rootPath` — either guard | the guard's own test fails |
| Tighten either guard to `>=` | dirent test / declared-root exact-budget test fails |
| Loosen either guard to `> max + 1` | inventory test / declared-root test fails |
| Default the entry bound to something unreachable (`?? Number.MAX_SAFE_INTEGER`) | inventory test fails; every injected-bound test still passes |
| Raise `MAXIMUM_PLUGIN_SCAN_DEPTH` (fixture rot, not a defect) | walk-stop test keeps killing the `limitReached` mutant; with the depth hardcoded it did not |

An earlier revision left the declared-root guard's `>=` / `> max + 1` boundary unasserted on the claim that admitting one more declared root always costs at least one more dirent the read-loop guard then catches identically. That is false, and this fixture is why: a declared root that does not exist reads no dirent at all, and when it is the last one in the manifest the loop simply ends — the scan completes and reports nothing. Both boundaries are now asserted, one budget per direction, because no single budget can move in both.

The resolve guard's `limitReached = true` is the one mutation left unasserted. Dropping it changes no candidate — every fresh directory past the bound reads zero dirents — only which bound-adjacent issue the extra walking records on the way out, on a scan that already reports its truncation. Covering it needs an observable the walk can produce *without* reading a dirent, because the read-loop guard truncates any further read to nothing — in practice an `outside-root` symlink or an unreadable directory beside the manifest, and every symlink case in this file is `skipIf(win32)`. A Windows-skipped fixture is not worth one extra Details-only issue row, and the read-loop guard's flag, which is the same four statements, is asserted. `candidate-limit` has the same gap on `main`.

The declared-root test caught itself first: the original fixture I wrote passed under its own mutation, because the dirent guard tripped one entry later and produced an identical result. It was rebuilt around non-existent declared roots, which read no dirents at all, so only the resolve guard can end that scan.

The inventory test asserts the `entry-limit` scan issue *before* asserting placements — without that, a fixture that stopped reaching the bound would still pass and cover nothing.

## Verification

- `src/main/skills/` + `src/main/ipc/skills.test.ts`: 164 passed (17 files)
- `tsc --noEmit -p config/tsconfig.node.json`: clean (after `rm -f config/*.tsbuildinfo`)
- `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:max-lines-ratchet`: clean
- `oxfmt --check`: clean

Test-only enablement with no UI surface, so no screenshots.

Refs #10918. Does not close it — #10865 already did.





