### PR TITLE
fix(editor): highlight Justfiles and Terraform variables

### DIFF
--- a/mobile/src/session/mobile-file-language.ts
+++ b/mobile/src/session/mobile-file-language.ts
@@ -60,12 +60,17 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.lua': 'lua',
   '.r': 'r',
   '.R': 'r',
-  '.make': 'makefile'
+  '.make': 'makefile',
+  '.tfvars': 'hcl'
 }
 
 const FILENAME_TO_LANGUAGE: Record<string, string> = {
   Dockerfile: 'dockerfile',
   Makefile: 'makefile',
+  justfile: 'shell',
+  Justfile: 'shell',
+  '.justfile': 'shell',
+  '.just': 'shell',
   'CMakeLists.txt': 'cmake',
   '.gitignore': 'ini',
   '.gitattributes': 'ini',

--- a/mobile/src/session/mobile-file-syntax.test.ts
+++ b/mobile/src/session/mobile-file-syntax.test.ts
@@ -20,6 +20,39 @@ describe('mobile file syntax highlighting', () => {
     expect(resolveMobileSyntaxLanguage('Dockerfile')).toBe('plaintext')
   })
 
+  it('detects Terraform variable files and canonical Justfile names', () => {
+    expect(detectMobileFileLanguage('environments/production.tfvars')).toBe('hcl')
+    expect(detectMobileFileLanguage('C:\\repo\\terraform\\LOCAL.TFVARS')).toBe('hcl')
+    expect(detectMobileFileLanguage('justfile')).toBe('shell')
+    expect(detectMobileFileLanguage('C:\\repo\\Justfile')).toBe('shell')
+    expect(detectMobileFileLanguage('/home/user/project/.justfile')).toBe('shell')
+    expect(detectMobileFileLanguage('/home/user/project/.just')).toBe('shell')
+  })
+
+  it('uses available mobile grammars for Terraform variables and Justfiles', () => {
+    const tfvarsLanguage = resolveMobileSyntaxLanguage('environments/production.tfvars')
+    const justfileLanguage = resolveMobileSyntaxLanguage('Justfile')
+
+    expect(tfvarsLanguage).toBe('ini')
+    expect(justfileLanguage).toBe('bash')
+    expect(
+      highlightMobileCode('# environment\nregion = "us-east-1"', tfvarsLanguage)
+    ).toMatchObject({
+      highlighted: true,
+      segments: expect.arrayContaining([
+        { text: '# environment', kind: 'comment' },
+        { text: '"us-east-1"', kind: 'string' }
+      ])
+    })
+    expect(highlightMobileCode('# build\nbuild:\n  echo "ready"', justfileLanguage)).toMatchObject({
+      highlighted: true,
+      segments: expect.arrayContaining([
+        { text: '# build', kind: 'comment' },
+        { text: '"ready"', kind: 'string' }
+      ])
+    })
+  })
+
   it('emits semantic syntax segments for highlighted code', () => {
     const result = highlightMobileCode('const label: string = "Orca"', 'typescript')
 

--- a/mobile/src/session/mobile-file-syntax.ts
+++ b/mobile/src/session/mobile-file-syntax.ts
@@ -40,6 +40,7 @@ const MAX_DIFF_HIGHLIGHT_SEGMENTS = 4_000
 const MAX_DIFF_LINE_HIGHLIGHT_SEGMENTS = 96
 
 const LANGUAGE_ALIASES: Record<string, string> = {
+  hcl: 'ini',
   javascriptreact: 'javascript',
   jsx: 'javascript',
   typescriptreact: 'typescript',

--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -64,6 +64,18 @@ describe('detectLanguage', () => {
     expect(detectLanguage('analysis/MODEL.R')).toBe('r')
   })
 
+  it('maps Terraform variable files to the Monaco HCL language id', () => {
+    expect(detectLanguage('environments/production.tfvars')).toBe('hcl')
+    expect(detectLanguage('C:\\repo\\terraform\\LOCAL.TFVARS')).toBe('hcl')
+  })
+
+  it('maps canonical Justfile names to the supported shell language id', () => {
+    expect(detectLanguage('justfile')).toBe('shell')
+    expect(detectLanguage('C:\\repo\\Justfile')).toBe('shell')
+    expect(detectLanguage('/home/user/project/.justfile')).toBe('shell')
+    expect(detectLanguage('/home/user/project/.just')).toBe('shell')
+  })
+
   it('keeps .json/.jsonc on the built-in json language and unknown on plaintext', () => {
     expect(detectLanguage('config/settings.json')).toBe('json')
     expect(detectLanguage('config/tsconfig.jsonc')).toBe('json')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -94,6 +94,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.nimble': 'nim',
   '.tf': 'hcl',
   '.hcl': 'hcl',
+  '.tfvars': 'hcl',
   '.prisma': 'graphql',
   '.csv': 'csv',
   '.tsv': 'tsv'
@@ -102,6 +103,10 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
 const FILENAME_TO_LANGUAGE: Record<string, string> = {
   Dockerfile: 'dockerfile',
   Makefile: 'makefile',
+  justfile: 'shell',
+  Justfile: 'shell',
+  '.justfile': 'shell',
+  '.just': 'shell',
   'CMakeLists.txt': 'cmake',
   '.gitignore': 'ini',
   '.gitattributes': 'ini',


### PR DESCRIPTION
## Summary

`justfile` and `*.tfvars` currently render as plaintext in the file preview on desktop and mobile. This maps them to shell and HCL.

- Detect `.tfvars` files as HCL in desktop and mobile file previews.
- Detect `justfile`, `Justfile`, `.justfile`, and `.just` as shell syntax on both clients.
- Keep mobile highlighting effective by resolving HCL to the bundled INI grammar and shell to Bash.

Closes #11215

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — under the required Node 24 runtime, 39,603 tests passed and 64 skipped; one SSH system-transport integration test failed only in the full concurrent suite and passed 3/3 when rerun alone (pre-existing and unrelated: this diff touches only language-detection lookup tables, no transport code)
- [x] `pnpm build` — desktop, web, relay, CLI, and both macOS Swift architecture builds completed; the final universal-binary step failed because `lipo` could not find the architecture outputs at its expected paths (pre-existing: that step lives in `config/scripts/build-computer-macos.mjs`, which is unchanged on `main` and untouched by this PR)
- [x] `cd mobile && ./node_modules/.bin/vitest run --config vitest.config.ts` — 352 files passed; 2,597 tests passed and 2 skipped
- [x] `cd mobile && ./node_modules/.bin/tsc --noEmit`
- [x] `cd mobile && ./node_modules/.bin/oxlint src app`
- [x] Added desktop and mobile regression tests for Unix and Windows paths, canonical Justfile names, case-insensitive `.tfvars`, grammar resolution, and semantic token output

## AI Review Report

The review traced both runtime paths before choosing language IDs. Monaco 0.55.1 bundles HCL and shell but not Makefile; mobile lowlight bundles INI, Makefile, and Bash but not HCL. The implementation therefore uses native HCL on desktop, shell for Justfiles on both clients, and the existing INI grammar as the mobile HCL fallback.

Cross-platform review covered macOS, Linux, and Windows path separators and extension casing. The change does not touch shortcuts, labels, shell execution, Electron platform behavior, SSH transport, git providers, agents, or integrations. Lookups remain constant-time map accesses, and there is no meaningful performance risk or UI layout change.

CodeRabbit and Greptile both reviewed the branch and raised no actionable findings.

## Security Audit

The change adds no dependency, command execution, filesystem access, IPC, authentication, secret handling, or network surface. File paths are used only for in-memory filename and extension matching; no path is opened or executed by the new logic.

## Notes

- Mobile HCL highlighting is an intentional approximation using the bundled INI grammar; it colors comments, assignments, and strings without adding a grammar dependency.
- Shell is used for Justfiles because it is available on both clients and covers comments and recipe bodies; desktop Monaco does not ship a Makefile language.
- X handle: not provided.
