### PR TITLE
feat(ports): name the dev server behind each workspace port

### DIFF
--- a/src/main/ports/dev-server-signature.test.ts
+++ b/src/main/ports/dev-server-signature.test.ts
@@ -26,7 +26,11 @@ describe('identifyDevServer', () => {
     ['nuxt', 'node /home/dev/app/node_modules/.bin/nuxt dev', 'Nuxt'],
     ['astro', 'node /home/dev/app/node_modules/.bin/astro dev', 'Astro'],
     ['angular', 'node /home/dev/app/node_modules/@angular/cli/bin/ng.js serve', 'Angular'],
-    ['create react app', 'node /home/dev/app/node_modules/.bin/react-scripts start', 'Create React App'],
+    [
+      'create react app',
+      'node /home/dev/app/node_modules/.bin/react-scripts start',
+      'Create React App'
+    ],
     ['webpack dev server', 'node /home/dev/app/node_modules/.bin/webpack serve', 'webpack'],
     ['storybook', 'node /home/dev/app/node_modules/.bin/storybook dev -p 6006', 'Storybook'],
     ['django', 'python3 manage.py runserver 0.0.0.0:8000', 'Django'],
@@ -37,6 +41,23 @@ describe('identifyDevServer', () => {
     ['laravel', 'php artisan serve --port=8000', 'Laravel'],
     ['phoenix', '/usr/bin/elixir -S mix phx.server', 'Phoenix'],
     ['hugo', '/usr/local/bin/hugo server -D', 'Hugo']
+  ])('identifies %s', (_case, commandLine, label) => {
+    expect(identifyDevServer({ commandLine })?.label).toBe(label)
+  })
+
+  // Captured verbatim from `ps -o command=` against live processes, which is
+  // how these reach the classifier in production.
+  it.each([
+    [
+      'vite through the bin shim, as macOS reports it',
+      'node node_modules/.bin/../vite/bin/vite.js --config vite.web.config.ts --port 5173 --host 127.0.0.1',
+      'Vite'
+    ],
+    [
+      'electron-vite from a pnpm virtual store path',
+      '/Users/dev/.nvm/versions/node/v24.18.0/bin/node /repo/node_modules/.pnpm/electron-vite@5.0.0_rolldown-vite@7.3.1/node_modules/electron-vite/bin/electron-vite.js dev --remote-debugging-port=9453',
+      'electron-vite'
+    ]
   ])('identifies %s', (_case, commandLine, label) => {
     expect(identifyDevServer({ commandLine })?.label).toBe(label)
   })
@@ -85,7 +106,8 @@ describe('identifyDevServer', () => {
   it('keeps quoted paths containing spaces intact', () => {
     expect(
       identifyDevServer({
-        commandLine: '"C:\\Program Files\\nodejs\\node.exe" "C:\\My Apps\\web\\node_modules\\.bin\\next" dev'
+        commandLine:
+          '"C:\\Program Files\\nodejs\\node.exe" "C:\\My Apps\\web\\node_modules\\.bin\\next" dev'
       })?.label
     ).toBe('Next.js')
   })

--- a/src/main/ports/dev-server-signature.test.ts
+++ b/src/main/ports/dev-server-signature.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { identifyDevServer } from './dev-server-signature'
+
+// Command lines below are shaped the way each platform actually reports them:
+//   Linux   -> /proc/<pid>/cmdline, NUL separators joined with spaces
+//   macOS   -> `ps -o command=`, absolute argv0, unquoted
+//   Windows -> Win32_Process.CommandLine, quoted paths with backslashes
+describe('identifyDevServer', () => {
+  it.each([
+    [
+      'vite via the bin shim (linux)',
+      'node /home/dev/app/node_modules/.bin/vite --port 5173',
+      'Vite'
+    ],
+    [
+      'vite via the package entry (macos)',
+      '/usr/local/bin/node /Users/dev/app/node_modules/vite/bin/vite.js',
+      'Vite'
+    ],
+    [
+      'vite with a quoted windows path',
+      '"C:\\Program Files\\nodejs\\node.exe" "C:\\src\\app\\node_modules\\vite\\bin\\vite.js"',
+      'Vite'
+    ],
+    ['next dev', 'node /home/dev/app/node_modules/.bin/next dev --turbopack', 'Next.js'],
+    ['nuxt', 'node /home/dev/app/node_modules/.bin/nuxt dev', 'Nuxt'],
+    ['astro', 'node /home/dev/app/node_modules/.bin/astro dev', 'Astro'],
+    ['angular', 'node /home/dev/app/node_modules/@angular/cli/bin/ng.js serve', 'Angular'],
+    ['create react app', 'node /home/dev/app/node_modules/.bin/react-scripts start', 'Create React App'],
+    ['webpack dev server', 'node /home/dev/app/node_modules/.bin/webpack serve', 'webpack'],
+    ['storybook', 'node /home/dev/app/node_modules/.bin/storybook dev -p 6006', 'Storybook'],
+    ['django', 'python3 manage.py runserver 0.0.0.0:8000', 'Django'],
+    ['uvicorn', '/usr/bin/python3 /usr/local/bin/uvicorn main:app --reload', 'Uvicorn'],
+    ['flask', '/usr/bin/python3 -m flask run --debug', 'Flask'],
+    ['rails via puma', 'puma 6.4.2 (tcp://0.0.0.0:3000) [app]', 'Rails'],
+    ['rails server', '/usr/bin/ruby bin/rails server -p 3000', 'Rails'],
+    ['laravel', 'php artisan serve --port=8000', 'Laravel'],
+    ['phoenix', '/usr/bin/elixir -S mix phx.server', 'Phoenix'],
+    ['hugo', '/usr/local/bin/hugo server -D', 'Hugo']
+  ])('identifies %s', (_case, commandLine, label) => {
+    expect(identifyDevServer({ commandLine })?.label).toBe(label)
+  })
+
+  it('identifies next.js from the rewritten process title alone', () => {
+    // Next renames its process once booted, so argv0 no longer mentions `next`.
+    expect(identifyDevServer({ processName: 'next-server (v15.0.0)' })?.label).toBe('Next.js')
+  })
+
+  it('falls back to the package manager script when the framework is hidden', () => {
+    expect(identifyDevServer({ commandLine: 'npm run dev' })).toEqual({
+      id: 'npm-script',
+      label: 'npm dev'
+    })
+    expect(identifyDevServer({ commandLine: '/usr/bin/pnpm dev' })?.label).toBe('pnpm dev')
+  })
+
+  it('prefers the framework over the package manager that launched it', () => {
+    expect(identifyDevServer({ commandLine: 'pnpm exec vite dev' })?.label).toBe('Vite')
+  })
+
+  it('returns undefined for a plain node process so callers keep the process name', () => {
+    expect(identifyDevServer({ processName: 'node', commandLine: 'node index.js' })).toBeUndefined()
+  })
+
+  it('returns undefined when no command line was collected', () => {
+    expect(identifyDevServer({ processName: 'node' })).toBeUndefined()
+    expect(identifyDevServer({})).toBeUndefined()
+  })
+
+  it('does not match a directory that merely shares a framework name', () => {
+    // The worktree path lands in argv for attribution; it must not be read as
+    // evidence of the framework itself.
+    expect(
+      identifyDevServer({ commandLine: 'node /home/dev/vite-playground/server.js' })
+    ).toBeUndefined()
+    expect(identifyDevServer({ commandLine: 'node /home/dev/next/build/index.js' })).toBeUndefined()
+  })
+
+  it('is case insensitive across windows executable casing', () => {
+    expect(
+      identifyDevServer({ commandLine: '"C:\\src\\app\\node_modules\\.bin\\Vite.CMD"' })?.label
+    ).toBe('Vite')
+  })
+
+  it('keeps quoted paths containing spaces intact', () => {
+    expect(
+      identifyDevServer({
+        commandLine: '"C:\\Program Files\\nodejs\\node.exe" "C:\\My Apps\\web\\node_modules\\.bin\\next" dev'
+      })?.label
+    ).toBe('Next.js')
+  })
+})

--- a/src/main/ports/dev-server-signature.test.ts
+++ b/src/main/ports/dev-server-signature.test.ts
@@ -36,7 +36,6 @@ describe('identifyDevServer', () => {
     ['django', 'python3 manage.py runserver 0.0.0.0:8000', 'Django'],
     ['uvicorn', '/usr/bin/python3 /usr/local/bin/uvicorn main:app --reload', 'Uvicorn'],
     ['flask', '/usr/bin/python3 -m flask run --debug', 'Flask'],
-    ['rails via puma', 'puma 6.4.2 (tcp://0.0.0.0:3000) [app]', 'Rails'],
     ['rails server', '/usr/bin/ruby bin/rails server -p 3000', 'Rails'],
     ['laravel', 'php artisan serve --port=8000', 'Laravel'],
     ['phoenix', '/usr/bin/elixir -S mix phx.server', 'Phoenix'],
@@ -62,6 +61,17 @@ describe('identifyDevServer', () => {
     expect(identifyDevServer({ commandLine })?.label).toBe(label)
   })
 
+  it('reports the server, not a framework, when only puma is visible', () => {
+    // Sinatra, Hanami, Roda and bare `bundle exec puma` are indistinguishable
+    // here, so naming this "Rails" would be wrong for every one of them.
+    expect(identifyDevServer({ commandLine: 'puma 6.4.2 (tcp://0.0.0.0:3000) [app]' })?.label).toBe(
+      'Puma'
+    )
+    expect(
+      identifyDevServer({ commandLine: '/usr/bin/ruby bin/rails server -p 3000' })?.label
+    ).toBe('Rails')
+  })
+
   it('identifies next.js from the rewritten process title alone', () => {
     // Next renames its process once booted, so argv0 no longer mentions `next`.
     expect(identifyDevServer({ processName: 'next-server (v15.0.0)' })?.label).toBe('Next.js')
@@ -77,6 +87,12 @@ describe('identifyDevServer', () => {
 
   it('prefers the framework over the package manager that launched it', () => {
     expect(identifyDevServer({ commandLine: 'pnpm exec vite dev' })?.label).toBe('Vite')
+  })
+
+  it('does not pair a process name with a script token from elsewhere in argv', () => {
+    // `npm` + `dev` are both present, but only across the two fields. Joining
+    // them would invent an `npm dev` script this process is not running.
+    expect(identifyDevServer({ processName: 'npm', commandLine: 'node dev.js' })).toBeUndefined()
   })
 
   it('returns undefined for a plain node process so callers keep the process name', () => {

--- a/src/main/ports/dev-server-signature.ts
+++ b/src/main/ports/dev-server-signature.ts
@@ -1,0 +1,169 @@
+// Recognizes which dev server is behind a listening port, from the command
+// line the port scanner already collects for attribution.
+//
+// Why this classification runs in main and not the renderer: argv routinely
+// carries secrets (`--api-key=…`, `--token=…`). Only the bounded label below
+// crosses the IPC/RPC boundary, so raw command lines never reach renderer,
+// web, or mobile clients.
+
+import type { DevServerIdentity } from '../../shared/workspace-ports'
+
+/** Stripped so `vite.js`, `next.cmd`, and `node.exe` all reduce to one token. */
+const EXECUTABLE_EXTENSION = /\.(?:js|mjs|cjs|ts|mts|cts|exe|cmd|bat|ps1|sh)$/
+
+type DevServerSignature = {
+  id: string
+  /** Product name. A proper noun — never localized. */
+  label: string
+  /** Matches when every token of any one clause is present. */
+  clauses: readonly (readonly string[])[]
+}
+
+// Ordered most-specific first. A bare token is only used where it is
+// unambiguous on its own (`vite` only appears as an executable name); anything
+// that doubles as a common word is paired with a companion token.
+const DEV_SERVER_SIGNATURES: readonly DevServerSignature[] = [
+  // Next.js renames its process to `next-server (v15.0.0)` once booted.
+  { id: 'next', label: 'Next.js', clauses: [['next-server'], ['next', 'dev'], ['next', 'start']] },
+  { id: 'nuxt', label: 'Nuxt', clauses: [['nuxt'], ['nuxi']] },
+  { id: 'astro', label: 'Astro', clauses: [['astro']] },
+  { id: 'remix', label: 'Remix', clauses: [['remix']] },
+  { id: 'sveltekit', label: 'SvelteKit', clauses: [['svelte-kit']] },
+  { id: 'gatsby', label: 'Gatsby', clauses: [['gatsby']] },
+  { id: 'docusaurus', label: 'Docusaurus', clauses: [['docusaurus']] },
+  { id: 'angular', label: 'Angular', clauses: [['ng', 'serve']] },
+  { id: 'react-scripts', label: 'Create React App', clauses: [['react-scripts']] },
+  { id: 'storybook', label: 'Storybook', clauses: [['storybook'], ['start-storybook']] },
+  { id: 'expo', label: 'Expo', clauses: [['expo']] },
+  { id: 'metro', label: 'Metro', clauses: [['metro'], ['react-native', 'start']] },
+  { id: 'webpack', label: 'webpack', clauses: [['webpack-dev-server'], ['webpack', 'serve']] },
+  { id: 'parcel', label: 'Parcel', clauses: [['parcel']] },
+  // Vite is checked after the frameworks that wrap it so the wrapper wins.
+  { id: 'vite', label: 'Vite', clauses: [['vite']] },
+
+  { id: 'rails', label: 'Rails', clauses: [['puma'], ['rails', 'server'], ['rails', 's']] },
+  { id: 'django', label: 'Django', clauses: [['runserver']] },
+  { id: 'uvicorn', label: 'Uvicorn', clauses: [['uvicorn']] },
+  { id: 'gunicorn', label: 'Gunicorn', clauses: [['gunicorn']] },
+  { id: 'flask', label: 'Flask', clauses: [['flask', 'run']] },
+  { id: 'laravel', label: 'Laravel', clauses: [['artisan', 'serve']] },
+  { id: 'phoenix', label: 'Phoenix', clauses: [['phx.server']] },
+  { id: 'air', label: 'Air', clauses: [['air']] },
+  { id: 'hugo', label: 'Hugo', clauses: [['hugo']] },
+  { id: 'jekyll', label: 'Jekyll', clauses: [['jekyll']] },
+
+  { id: 'json-server', label: 'json-server', clauses: [['json-server']] },
+  { id: 'http-server', label: 'http-server', clauses: [['http-server']] }
+  // No bare `serve` entry: the token is too common as a script name, and the
+  // package-script fallback already reports it as e.g. `pnpm serve`.
+]
+
+/** Package managers whose `dev`-style script is the only visible signal. */
+const PACKAGE_MANAGERS = new Set(['npm', 'pnpm', 'yarn', 'bun', 'deno'])
+const PACKAGE_SCRIPTS = new Set(['dev', 'start', 'serve', 'develop', 'preview'])
+
+export type DevServerSource = {
+  processName?: string
+  commandLine?: string
+}
+
+/**
+ * Identify the dev server behind a listening process. Returns `undefined` when
+ * nothing matches, so callers keep showing the raw process name.
+ */
+export function identifyDevServer(source: DevServerSource): DevServerIdentity | undefined {
+  const tokens = tokenizeProcess(source)
+  if (tokens.size === 0) {
+    return undefined
+  }
+
+  for (const signature of DEV_SERVER_SIGNATURES) {
+    if (signature.clauses.some((clause) => clause.every((token) => tokens.has(token)))) {
+      return { id: signature.id, label: signature.label }
+    }
+  }
+
+  return identifyPackageScript(tokens)
+}
+
+/**
+ * Fall back to the package-manager script when the framework itself is not
+ * visible in argv. Both halves of the label come from the allowlists above, so
+ * the result stays bounded even though it reads like free text.
+ */
+function identifyPackageScript(tokens: Set<string>): DevServerIdentity | undefined {
+  let manager: string | undefined
+  let script: string | undefined
+  for (const token of tokens) {
+    if (!manager && PACKAGE_MANAGERS.has(token)) {
+      manager = token
+    } else if (!script && PACKAGE_SCRIPTS.has(token)) {
+      script = token
+    }
+  }
+  if (!manager || !script) {
+    return undefined
+  }
+  return { id: `${manager}-script`, label: `${manager} ${script}` }
+}
+
+/**
+ * Reduce a command line to comparable tokens: quote-aware argument split, then
+ * the lowercased basename of each argument with any executable extension
+ * removed. Taking the basename is what keeps a project directory named
+ * `vite-playground` from being mistaken for Vite itself.
+ */
+function tokenizeProcess(source: DevServerSource): Set<string> {
+  const tokens = new Set<string>()
+  // The process name is split the same way as the command line: a rewritten
+  // process title such as `next-server (v15.0.0)` carries its own whitespace,
+  // and the identifying token is only the first field.
+  for (const field of [source.commandLine, source.processName]) {
+    for (const argument of splitArguments(field ?? '')) {
+      const token = toToken(argument)
+      if (token) {
+        tokens.add(token)
+      }
+    }
+  }
+  return tokens
+}
+
+function toToken(argument: string): string {
+  const basename = argument.split(/[/\\]/).pop() ?? argument
+  return basename.toLowerCase().replace(EXECUTABLE_EXTENSION, '')
+}
+
+/** Split on whitespace while keeping quoted Windows paths (`"C:\Program Files\…"`) intact. */
+function splitArguments(commandLine: string): string[] {
+  const args: string[] = []
+  let current = ''
+  let quote: string | null = null
+
+  for (const char of commandLine) {
+    if (quote) {
+      if (char === quote) {
+        quote = null
+      } else {
+        current += char
+      }
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+    if (char === ' ' || char === '\t' || char === '\n') {
+      if (current) {
+        args.push(current)
+        current = ''
+      }
+      continue
+    }
+    current += char
+  }
+  if (current) {
+    args.push(current)
+  }
+  return args
+}

--- a/src/main/ports/dev-server-signature.ts
+++ b/src/main/ports/dev-server-signature.ts
@@ -39,6 +39,7 @@ const DEV_SERVER_SIGNATURES: readonly DevServerSignature[] = [
   { id: 'webpack', label: 'webpack', clauses: [['webpack-dev-server'], ['webpack', 'serve']] },
   { id: 'parcel', label: 'Parcel', clauses: [['parcel']] },
   // Vite is checked after the frameworks that wrap it so the wrapper wins.
+  { id: 'electron-vite', label: 'electron-vite', clauses: [['electron-vite']] },
   { id: 'vite', label: 'Vite', clauses: [['vite']] },
 
   { id: 'rails', label: 'Rails', clauses: [['puma'], ['rails', 'server'], ['rails', 's']] },

--- a/src/main/ports/dev-server-signature.ts
+++ b/src/main/ports/dev-server-signature.ts
@@ -42,7 +42,17 @@ const DEV_SERVER_SIGNATURES: readonly DevServerSignature[] = [
   { id: 'electron-vite', label: 'electron-vite', clauses: [['electron-vite']] },
   { id: 'vite', label: 'Vite', clauses: [['vite']] },
 
-  { id: 'rails', label: 'Rails', clauses: [['puma'], ['rails', 'server'], ['rails', 's']] },
+  {
+    id: 'rails',
+    label: 'Rails',
+    clauses: [
+      ['rails', 'server'],
+      ['rails', 's']
+    ]
+  },
+  // Reported as Puma, not Rails: Sinatra, Hanami, Roda and bare `bundle exec
+  // puma` all boot the same server, and Rails renames its process to `puma …`.
+  { id: 'puma', label: 'Puma', clauses: [['puma']] },
   { id: 'django', label: 'Django', clauses: [['runserver']] },
   { id: 'uvicorn', label: 'Uvicorn', clauses: [['uvicorn']] },
   { id: 'gunicorn', label: 'Gunicorn', clauses: [['gunicorn']] },
@@ -73,7 +83,12 @@ export type DevServerSource = {
  * nothing matches, so callers keep showing the raw process name.
  */
 export function identifyDevServer(source: DevServerSource): DevServerIdentity | undefined {
-  const tokens = tokenizeProcess(source)
+  // Signatures read both fields, because a rewritten title such as
+  // `next-server (v15.0.0)` is sometimes the only evidence left. The script
+  // fallback reads argv alone: a process merely *named* `npm` next to an
+  // unrelated `dev.js` would otherwise be reported as `npm dev`.
+  const argumentTokens = tokenize(source.commandLine)
+  const tokens = new Set([...argumentTokens, ...tokenize(source.processName)])
   if (tokens.size === 0) {
     return undefined
   }
@@ -84,7 +99,7 @@ export function identifyDevServer(source: DevServerSource): DevServerIdentity | 
     }
   }
 
-  return identifyPackageScript(tokens)
+  return identifyPackageScript(argumentTokens)
 }
 
 /**
@@ -114,17 +129,14 @@ function identifyPackageScript(tokens: Set<string>): DevServerIdentity | undefin
  * removed. Taking the basename is what keeps a project directory named
  * `vite-playground` from being mistaken for Vite itself.
  */
-function tokenizeProcess(source: DevServerSource): Set<string> {
+function tokenize(field: string | undefined): Set<string> {
   const tokens = new Set<string>()
-  // The process name is split the same way as the command line: a rewritten
-  // process title such as `next-server (v15.0.0)` carries its own whitespace,
-  // and the identifying token is only the first field.
-  for (const field of [source.commandLine, source.processName]) {
-    for (const argument of splitArguments(field ?? '')) {
-      const token = toToken(argument)
-      if (token) {
-        tokens.add(token)
-      }
+  // A process name is split like a command line: a rewritten title such as
+  // `next-server (v15.0.0)` carries its own whitespace.
+  for (const argument of splitArguments(field ?? '')) {
+    const token = toToken(argument)
+    if (token) {
+      tokens.add(token)
     }
   }
   return tokens

--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -233,6 +233,55 @@ describe('scanWorkspacePorts attribution work', () => {
     expect(win32WorktreePathResolveCalls).toHaveLength(0)
     expect(posixWorktreePathResolveCalls).toHaveLength(worktrees.length)
   })
+
+  it('labels the dev server behind each port and leaves plain processes unlabelled', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    const invokeCallback = (callback: unknown, stdout: string): void => {
+      if (typeof callback !== 'function') {
+        throw new Error('missing execFile callback')
+      }
+      ;(callback as (error: Error | null, stdout: string) => void)(null, stdout)
+    }
+    execFileMock.mockImplementation(
+      (command: string, args: string[], _options: unknown, callback: unknown) => {
+        if (command === 'lsof' && args.includes('-iTCP')) {
+          invokeCallback(
+            callback,
+            ['p123', 'cnode', 'n127.0.0.1:5173', 'p124', 'cnode', 'n127.0.0.1:4000'].join('\n')
+          )
+        } else if (command === 'lsof') {
+          invokeCallback(
+            callback,
+            ['p123', 'n/repo/worktrees/feature', 'p124', 'n/repo'].join('\n')
+          )
+        } else if (command === 'ps') {
+          invokeCallback(
+            callback,
+            [
+              '123 node /repo/worktrees/feature/node_modules/.bin/vite --port 5173',
+              '124 node /repo/server.js'
+            ].join('\n')
+          )
+        } else {
+          invokeCallback(callback, '')
+        }
+        return { kill: vi.fn() }
+      }
+    )
+
+    const scan = await scanWorkspacePorts(worktrees, {
+      lookup: () => undefined,
+      reconcileScan: vi.fn()
+    })
+
+    const vitePort = scan.ports.find((port) => port.port === 5173)
+    expect(vitePort?.devServer).toEqual({ id: 'vite', label: 'Vite' })
+    // The raw process name still rides along so the UI can show it as detail.
+    expect(vitePort?.processName).toBe('node')
+
+    // A bare `node server.js` stays unlabelled rather than guessing.
+    expect(scan.ports.find((port) => port.port === 4000)?.devServer).toBeUndefined()
+  })
 })
 
 describe('scanWorkspacePorts command timeout', () => {

--- a/src/main/ports/local-workspace-port-scanner.ts
+++ b/src/main/ports/local-workspace-port-scanner.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../shared/workspace-ports'
 import { getProcessOutputFields } from '../../shared/process-output-field-scanner'
 import { advertisedUrlWatcher, type AdvertisedUrlWatcher } from './advertised-url-watcher'
+import { identifyDevServer } from './dev-server-signature'
 import { WorkspacePortScanTimeoutBackoff } from './workspace-port-scan-timeout-backoff'
 
 const COMMAND_TIMEOUT_MS = 4_000
@@ -454,6 +455,7 @@ function enrichPort(
   urlWatcher: Pick<AdvertisedUrlWatcher, 'lookup'>
 ): WorkspacePort {
   const owner = attributePortToNormalizedWorkspaces(port, worktrees)
+  const devServer = identifyDevServer(port)
   const base = {
     id: `${port.host}:${port.port}:${port.pid ?? 'unknown'}`,
     bindHost: port.host,
@@ -461,6 +463,7 @@ function enrichPort(
     port: port.port,
     pid: port.pid,
     processName: port.processName,
+    ...(devServer ? { devServer } : {}),
     protocol: inferProtocol(port.port)
   }
 

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -37,6 +37,10 @@ import {
   browserUrlForPortForwardEntry
 } from '@/lib/workspace-port-urls'
 import { resolveLocalhostLabelRouteForPort } from '@/lib/workspace-port-localhost-label-selector'
+import {
+  formatWorkspacePortProcessTooltip,
+  getWorkspacePortProcessLabel
+} from '@/lib/workspace-port-process-label'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   Dialog,
@@ -108,6 +112,10 @@ function workspacePortAsExternal(port: WorkspacePort & { kind: 'workspace' }): W
     port: port.port,
     pid: port.pid,
     processName: port.processName,
+    // Why carried: these are other repos' listeners shown as External. Dropping
+    // the label here would show `node` for the very server this panel calls
+    // Vite when its own repo is active.
+    ...(port.devServer ? { devServer: port.devServer } : {}),
     protocol: port.protocol,
     kind: 'external'
   }
@@ -559,7 +567,7 @@ function LocalPortRow({
     [onStop, port]
   )
 
-  const processLabel = port.processName ?? (port.pid ? `PID ${port.pid}` : 'Unknown process')
+  const processLabel = getWorkspacePortProcessLabel(port)
   const address = addressForPort(port)
   const ownerLabel =
     port.kind === 'workspace'
@@ -595,7 +603,16 @@ function LocalPortRow({
             <div className="min-w-0 flex-1">
               <div className="flex min-w-0 items-center gap-1.5">
                 <span className="text-xs font-medium text-foreground">:{port.port}</span>
-                <span className="truncate text-xs text-muted-foreground">{processLabel}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {processLabel.label}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" sideOffset={4}>
+                    {formatWorkspacePortProcessTooltip(processLabel)}
+                  </TooltipContent>
+                </Tooltip>
               </div>
               <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
                 <span className="truncate">{address}</span>
@@ -745,7 +762,9 @@ function LocalPortDetailsDialog({
               : translate('auto.components.right.sidebar.PortsPanel.d41a8241ec', 'Port')}
           </DialogTitle>
           <DialogDescription>
-            {port ? `${port.processName ?? 'Unknown process'} · ${addressForPort(port)}` : ''}
+            {port
+              ? `${getWorkspacePortProcessLabel(port).label} · ${addressForPort(port)}`
+              : ''}
           </DialogDescription>
         </DialogHeader>
         {port && (
@@ -770,8 +789,10 @@ function LocalPortDetailsDialog({
               {translate('auto.components.right.sidebar.PortsPanel.5dd86dcf2f', 'Process')}
             </dt>
             <dd className="min-w-0 break-all text-foreground">
-              {port.processName ??
-                translate('auto.components.right.sidebar.PortsPanel.3e13cb63ee', 'Unknown')}
+              {port.devServer
+                ? formatWorkspacePortProcessTooltip(getWorkspacePortProcessLabel(port))
+                : (port.processName ??
+                  translate('auto.components.right.sidebar.PortsPanel.3e13cb63ee', 'Unknown'))}
             </dd>
             <dt className="text-muted-foreground">
               {translate('auto.components.right.sidebar.PortsPanel.57d930fa45', 'PID')}

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -762,9 +762,7 @@ function LocalPortDetailsDialog({
               : translate('auto.components.right.sidebar.PortsPanel.d41a8241ec', 'Port')}
           </DialogTitle>
           <DialogDescription>
-            {port
-              ? `${getWorkspacePortProcessLabel(port).label} · ${addressForPort(port)}`
-              : ''}
+            {port ? `${getWorkspacePortProcessLabel(port).label} · ${addressForPort(port)}` : ''}
           </DialogDescription>
         </DialogHeader>
         {port && (

--- a/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardPorts.tsx
@@ -17,6 +17,10 @@ import {
   resolvePortOpenInOrcaBrowser
 } from '@/lib/workspace-port-actions'
 import { useLocalhostLabelRouteForPort } from '@/lib/workspace-port-localhost-label-selector'
+import {
+  formatWorkspacePortProcessTooltip,
+  getWorkspacePortProcessLabel
+} from '@/lib/workspace-port-process-label'
 import { addressForPort } from '@/lib/workspace-port-urls'
 import type { WorkspacePort } from '../../../../shared/workspace-ports'
 import { WORKTREE_NATIVE_CONTEXT_MENU_ATTR } from './WorktreeContextMenu'
@@ -116,7 +120,7 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
     () => getActiveRuntimeTarget({ ...settings, activeRuntimeEnvironmentId: runtimeEnvironmentId }),
     [runtimeEnvironmentId, settings]
   )
-  const processLabel = port.processName ?? (port.pid ? `PID ${port.pid}` : 'Unknown process')
+  const processLabel = getWorkspacePortProcessLabel(port)
   const address = addressForPort(port)
   const canStop = canStopWorkspacePort(port)
   const openBrowserLabel = translate(
@@ -244,7 +248,7 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
         <Tooltip>
           <TooltipTrigger asChild>
             <span className="flex min-w-0 select-text items-baseline gap-1 overflow-hidden pr-[3.75rem] text-[11px] text-muted-foreground">
-              <span className="min-w-0 flex-1 truncate">{processLabel}</span>
+              <span className="min-w-0 flex-1 truncate">{processLabel.label}</span>
               <span className="shrink-0 text-muted-foreground/45">-</span>
               <span className="min-w-0 flex-[1.1] truncate text-muted-foreground/70">
                 {address}
@@ -253,7 +257,7 @@ function WorktreePortRow({ port }: { port: WorkspacePort }): React.JSX.Element {
           </TooltipTrigger>
           <TooltipContent side="top" sideOffset={4}>
             <span className="flex items-center gap-1.5">
-              <span>{processLabel}</span>
+              <span>{formatWorkspacePortProcessTooltip(processLabel)}</span>
               <span className="text-muted-foreground/60">-</span>
               <span>{address}</span>
             </span>

--- a/src/renderer/src/components/status-bar/ports-status-popover-rows.tsx
+++ b/src/renderer/src/components/status-bar/ports-status-popover-rows.tsx
@@ -15,6 +15,10 @@ import {
 } from '@/lib/workspace-port-actions'
 import type { WorkspacePortGroup } from '@/lib/workspace-port-groups'
 import { useLocalhostLabelRouteForPort } from '@/lib/workspace-port-localhost-label-selector'
+import {
+  formatWorkspacePortProcessTooltip,
+  getWorkspacePortProcessLabel
+} from '@/lib/workspace-port-process-label'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { useAppStore } from '@/store'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -94,7 +98,7 @@ export function PortRow({
     () => getActiveRuntimeTarget({ ...settings, activeRuntimeEnvironmentId: runtimeEnvironmentId }),
     [runtimeEnvironmentId, settings]
   )
-  const processLabel = port.processName ?? (port.pid ? `PID ${port.pid}` : 'Unknown process')
+  const processLabel = getWorkspacePortProcessLabel(port)
   const canStop = canStopWorkspacePort(port)
   const openBrowserLabel = translate(
     'auto.components.status.bar.ports.status.popover.rows.085f4f0334',
@@ -226,11 +230,11 @@ export function PortRow({
           <Tooltip delayDuration={200}>
             <TooltipTrigger asChild>
               <span className="block min-w-0 select-text truncate text-[11px] text-muted-foreground">
-                {processLabel}
+                {processLabel.label}
               </span>
             </TooltipTrigger>
             <TooltipContent side="top" sideOffset={4}>
-              {processLabel}
+              {formatWorkspacePortProcessTooltip(processLabel)}
             </TooltipContent>
           </Tooltip>
           <div className="absolute inset-y-0 right-0 flex items-center gap-0.5 rounded-md border border-border/40 bg-popover/95 px-0.5 can-hover:opacity-0 shadow-xs transition-opacity group-hover/port:opacity-100 group-focus-within/port:opacity-100">

--- a/src/renderer/src/lib/workspace-port-process-label.test.ts
+++ b/src/renderer/src/lib/workspace-port-process-label.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatWorkspacePortProcessTooltip,
+  getWorkspacePortProcessLabel
+} from './workspace-port-process-label'
+
+describe('getWorkspacePortProcessLabel', () => {
+  it('promotes the dev server over the process name', () => {
+    expect(
+      getWorkspacePortProcessLabel({
+        devServer: { id: 'vite', label: 'Vite' },
+        processName: 'node',
+        pid: 4242
+      })
+    ).toEqual({ label: 'Vite', detail: 'node' })
+  })
+
+  it('keeps the process name when no dev server was recognized', () => {
+    expect(getWorkspacePortProcessLabel({ processName: 'node', pid: 4242 })).toEqual({
+      label: 'node'
+    })
+  })
+
+  it('falls back to the pid, then to a placeholder', () => {
+    expect(getWorkspacePortProcessLabel({ pid: 4242 })).toEqual({ label: 'PID 4242' })
+    expect(getWorkspacePortProcessLabel({})).toEqual({ label: 'Unknown process' })
+  })
+
+  it('omits the detail when the process name only restates the dev server', () => {
+    expect(
+      getWorkspacePortProcessLabel({
+        devServer: { id: 'hugo', label: 'Hugo' },
+        processName: 'hugo'
+      })
+    ).toEqual({ label: 'Hugo' })
+  })
+
+  it('still labels a dev server whose process name is unknown', () => {
+    expect(getWorkspacePortProcessLabel({ devServer: { id: 'vite', label: 'Vite' } })).toEqual({
+      label: 'Vite'
+    })
+  })
+})
+
+describe('formatWorkspacePortProcessTooltip', () => {
+  it('joins the dev server and the raw process name', () => {
+    expect(formatWorkspacePortProcessTooltip({ label: 'Vite', detail: 'node' })).toBe('Vite — node')
+  })
+
+  it('returns the label alone when there is no detail', () => {
+    expect(formatWorkspacePortProcessTooltip({ label: 'node' })).toBe('node')
+  })
+})

--- a/src/renderer/src/lib/workspace-port-process-label.ts
+++ b/src/renderer/src/lib/workspace-port-process-label.ts
@@ -1,16 +1,8 @@
 import type { WorkspacePort } from '../../../shared/workspace-ports'
 
-/**
- * What a port row shows for the process behind the listener.
- *
- * A recognized dev server takes the primary slot, because "Vite" answers the
- * question a row of `node` never could. The raw process name is not discarded:
- * it moves to `detail` so it stays reachable for debugging.
- */
+/** A recognized dev server takes `label` and demotes the raw process name to `detail`. */
 export type WorkspacePortProcessLabel = {
-  /** Primary text: the dev server when recognized, otherwise the process. */
   label: string
-  /** Raw process name, set only when a dev server label displaced it. */
   detail?: string
 }
 

--- a/src/renderer/src/lib/workspace-port-process-label.ts
+++ b/src/renderer/src/lib/workspace-port-process-label.ts
@@ -1,0 +1,36 @@
+import type { WorkspacePort } from '../../../shared/workspace-ports'
+
+/**
+ * What a port row shows for the process behind the listener.
+ *
+ * A recognized dev server takes the primary slot, because "Vite" answers the
+ * question a row of `node` never could. The raw process name is not discarded:
+ * it moves to `detail` so it stays reachable for debugging.
+ */
+export type WorkspacePortProcessLabel = {
+  /** Primary text: the dev server when recognized, otherwise the process. */
+  label: string
+  /** Raw process name, set only when a dev server label displaced it. */
+  detail?: string
+}
+
+export function getWorkspacePortProcessLabel(
+  port: Pick<WorkspacePort, 'devServer' | 'processName' | 'pid'>
+): WorkspacePortProcessLabel {
+  const processLabel = port.processName ?? (port.pid ? `PID ${port.pid}` : 'Unknown process')
+  if (!port.devServer) {
+    return { label: processLabel }
+  }
+  // Why the equality guard: when the process name already is the product name
+  // (`hugo`, `puma`), repeating it as a tooltip detail is noise.
+  const detail =
+    port.processName && port.processName.toLowerCase() !== port.devServer.label.toLowerCase()
+      ? port.processName
+      : undefined
+  return { label: port.devServer.label, ...(detail ? { detail } : {}) }
+}
+
+/** Single-line form for tooltips and `title` attributes: `Vite — node`. */
+export function formatWorkspacePortProcessTooltip(labelled: WorkspacePortProcessLabel): string {
+  return labelled.detail ? `${labelled.label} — ${labelled.detail}` : labelled.label
+}

--- a/src/renderer/src/lib/workspace-port-scan-client.test.ts
+++ b/src/renderer/src/lib/workspace-port-scan-client.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspacePort } from '../../../shared/workspace-ports'
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  callRuntimeRpc: vi.fn(),
+  RuntimeRpcCallError: class RuntimeRpcCallError extends Error {
+    code = 'unknown'
+  }
+}))
+
+const scan = vi.fn()
+vi.stubGlobal('window', { api: { workspacePorts: { scan } } })
+
+const { runWorkspacePortScanForTarget } = await import('./workspace-port-scan-client')
+
+const localTarget = { kind: 'local' } as Parameters<typeof runWorkspacePortScanForTarget>[0]
+
+const workspacePort: WorkspacePort = {
+  id: '127.0.0.1:5173:123',
+  bindHost: '127.0.0.1',
+  connectHost: 'localhost',
+  port: 5173,
+  pid: 123,
+  processName: 'node',
+  protocol: 'http',
+  kind: 'workspace',
+  owner: {
+    worktreeId: 'repo::/repo',
+    repoId: 'repo',
+    displayName: 'main',
+    path: '/repo',
+    confidence: 'cwd'
+  }
+}
+
+function scanResultWith(port: unknown): unknown {
+  return { platform: 'darwin', scannedAt: 1_700_000_000_000, ports: [port] }
+}
+
+describe('workspace port scan response validation', () => {
+  beforeEach(() => {
+    scan.mockReset()
+  })
+
+  it('accepts a port carrying a dev server identity', async () => {
+    scan.mockResolvedValue(
+      scanResultWith({ ...workspacePort, devServer: { id: 'vite', label: 'Vite' } })
+    )
+
+    const result = await runWorkspacePortScanForTarget(localTarget)
+
+    expect(result.ports[0]?.devServer).toEqual({ id: 'vite', label: 'Vite' })
+  })
+
+  it('accepts a port with no dev server identity', async () => {
+    scan.mockResolvedValue(scanResultWith(workspacePort))
+
+    const result = await runWorkspacePortScanForTarget(localTarget)
+
+    expect(result.ports[0]?.devServer).toBeUndefined()
+  })
+
+  it.each([
+    ['a non-string label', { id: 'vite', label: { toString: 'Vite' } }],
+    ['a missing label', { id: 'vite' }],
+    ['a missing id', { label: 'Vite' }],
+    ['a non-object identity', 'Vite']
+  ])('rejects a scan whose dev server identity has %s', async (_case, devServer) => {
+    // Why this matters: a remote runtime supplies this payload and the label is
+    // rendered straight into a row, so a bad shape must fail here, not in React.
+    scan.mockResolvedValue(scanResultWith({ ...workspacePort, devServer }))
+
+    await expect(runWorkspacePortScanForTarget(localTarget)).rejects.toThrow(
+      'Workspace port scan returned an invalid response.'
+    )
+  })
+})

--- a/src/renderer/src/lib/workspace-port-scan-client.ts
+++ b/src/renderer/src/lib/workspace-port-scan-client.ts
@@ -33,6 +33,15 @@ function isOptionalFiniteNumber(value: unknown): boolean {
   return value === undefined || (typeof value === 'number' && Number.isFinite(value))
 }
 
+function isOptionalDevServerIdentity(value: unknown): boolean {
+  if (value === undefined) {
+    return true
+  }
+  // Why validated like every other field here: a remote runtime supplies this,
+  // and the label is rendered directly. A non-string label would crash the row.
+  return isRecord(value) && typeof value.id === 'string' && typeof value.label === 'string'
+}
+
 function isWorkspacePortOwner(value: unknown): boolean {
   if (!isRecord(value)) {
     return false
@@ -56,6 +65,7 @@ function isWorkspacePort(value: unknown): value is WorkspacePort {
     !Number.isFinite(value.port) ||
     !isOptionalFiniteNumber(value.pid) ||
     !isOptionalString(value.processName) ||
+    !isOptionalDevServerIdentity(value.devServer) ||
     !WORKSPACE_PORT_PROTOCOLS.has(value.protocol as WorkspacePort['protocol'])
   ) {
     return false

--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -519,9 +519,7 @@ describe('worktree-palette-search', () => {
       repoMap,
       null,
       null,
-      new Map([
-        ['wt-port', [{ port: 5173, processName: 'node', devServer: { label: 'Vite' } }]]
-      ])
+      new Map([['wt-port', [{ port: 5173, processName: 'node', devServer: { label: 'Vite' } }]]])
     )
 
     expect(results[0].supportingText).toEqual({

--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -511,4 +511,36 @@ describe('worktree-palette-search', () => {
       matchRange: { start: 0, end: 4 }
     })
   })
+
+  it('names a matched port by its dev server instead of the process', () => {
+    const results = searchWorktrees(
+      [makeWorktree({ id: 'wt-port' })],
+      '5173',
+      repoMap,
+      null,
+      null,
+      new Map([
+        ['wt-port', [{ port: 5173, processName: 'node', devServer: { label: 'Vite' } }]]
+      ])
+    )
+
+    expect(results[0].supportingText).toEqual({
+      labelKind: 'port',
+      text: '5173 · Vite',
+      matchRange: { start: 0, end: 4 }
+    })
+  })
+
+  it('falls back to the bare port number when neither dev server nor process is known', () => {
+    const results = searchWorktrees(
+      [makeWorktree({ id: 'wt-port' })],
+      '8080',
+      repoMap,
+      null,
+      null,
+      new Map([['wt-port', [{ port: 8080 }]]])
+    )
+
+    expect(results[0].supportingText?.text).toBe('8080')
+  })
 })

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -71,7 +71,10 @@ export function searchWorktrees(
   repoMap: Map<string, Repo>,
   prCache: Record<string, PRCacheEntry> | null,
   issueCache: Record<string, IssueCacheEntry> | null,
-  workspacePortsByWorktreeId?: Map<string, { port: number; processName?: string }[]>,
+  workspacePortsByWorktreeId?: Map<
+    string,
+    { port: number; processName?: string; devServer?: { label: string } }[]
+  >,
   checksReviewByWorktree?: ReadonlyMap<Worktree, HostedReviewInfo | null>
 ): PaletteSearchResult[] {
   if (isWorktreePaletteQueryTooLarge(query)) {
@@ -180,7 +183,10 @@ export function searchWorktrees(
       const portText = String(port.port)
       const portIndex = portText.indexOf(numericQuery)
       if (portIndex !== -1) {
-        const label = port.processName ? `${portText} · ${port.processName}` : portText
+        // The dev server names the port better than `node` does; fall back to
+        // the process, and to the bare number when neither is known.
+        const processText = port.devServer?.label ?? port.processName
+        const label = processText ? `${portText} · ${processText}` : portText
         results.push(
           makeResult(worktree.id, 'port', {
             supportingText: {

--- a/src/shared/workspace-ports.ts
+++ b/src/shared/workspace-ports.ts
@@ -7,6 +7,15 @@ export type WorkspacePortProbe = {
 
 export type WorkspacePortAttributionConfidence = 'cwd' | 'command' | 'none'
 
+/** The dev server recognized behind a listening process. `id` is intentionally
+ *  a plain string rather than a union: a newer server may report a framework an
+ *  older client has never heard of, and that must not fail validation. */
+export type DevServerIdentity = {
+  id: string
+  /** Product name for display. A proper noun — never localized. */
+  label: string
+}
+
 export type WorkspacePortOwner = {
   worktreeId: string
   repoId: string
@@ -24,6 +33,9 @@ type WorkspacePortBase = {
   port: number
   pid?: number
   processName?: string
+  /** Set when the command line identified a known dev server. Absent when the
+   *  process is unrecognized, in which case callers fall back to `processName`. */
+  devServer?: DevServerIdentity
   protocol: 'http' | 'https' | 'unknown'
 }
 


### PR DESCRIPTION
## Summary

The ports UI showed the raw OS process name, so every JS dev server rendered as `node`:

```
:5173  node          →   :5173  Vite
:3000  node          →   :3000  Next.js
:6006  node          →   :6006  Storybook
```

You could see *that* something was listening and *where*, but not *what*. This names it.

The scanner already collected each listener's command line to attribute it to a worktree (`local-workspace-port-scanner.ts`), then threw it away at `enrichPort`. This classifies it instead and carries a bounded label on the port.

Unrecognized processes are unchanged — they keep showing the process name exactly as today. Where a label does replace it, the raw process name moves to the tooltip so it stays available for debugging.

Recognized: Vite, electron-vite, Next.js, Nuxt, Astro, Remix, SvelteKit, Gatsby, Docusaurus, Angular, CRA, Storybook, Expo, Metro, webpack, Parcel, Rails, Django, Uvicorn, Gunicorn, Flask, Laravel, Phoenix, Air, Hugo, Jekyll, json-server, http-server — plus a `pnpm dev` style fallback when the framework isn't visible in argv.

Updated display sites: Ports panel (right sidebar), status-bar popover, worktree card, port details dialog, and the Cmd+J palette.

## Screenshots

Captured from the running dev build (`pnpm dev`) against **real listening processes** — no mocked state.

![Ports popover showing dev server labels](https://raw.githubusercontent.com/Docker-Hunterpedia/orca/pr-11258-screenshots/ports-popover.png)

The same frame shows both halves of the change:

- `:5173` → **electron-vite** and `:5180` → **Vite** are the labels. Before this PR both read `node`, because that is their OS process name.
- `:6769`, `:9453`, `:55278` → **Electron** are the untouched fallback. Unrecognized processes still show their process name exactly as they do today.

Worktree card hover, showing the same labels in the sidebar surface:

![Worktree card live ports](https://raw.githubusercontent.com/Docker-Hunterpedia/orca/pr-11258-screenshots/worktree-card-ports.png)

Images live on a separate branch of the fork, so no binaries land in this PR's diff.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` *(ports/palette scope — see below)*
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`pnpm lint` passes end to end, including the repo's custom gates: reliability-gate manifest (52 gates), **max-lines ratchet — "no new bypasses"**, bundled skill guides, skill-bundle manifest, localization catalog (parity across all 5 locales), and localization coverage. `pnpm typecheck` passes across all three projects. `pnpm run check:code-quality:changed` and `check:react-doctor:changed` both report **0 new findings across 14 changed files**. `oxfmt --check` is clean on every file this branch touches.

`pnpm build` was not run — it packages the app and is not needed to validate this change.

Tests: **156 passing** across the ports and palette scope (`src/main/ports/`, the four `workspace-port-*` lib modules, `worktree-palette-search`, and `components/ports/`). The full suite was not run locally; CI shards it.

46 test cases were added across 3 files:

- `dev-server-signature.test.ts` — command lines shaped the way each platform actually reports them: Linux `/proc/<pid>/cmdline` (NUL-joined), macOS `ps -o command=`, Windows `Win32_Process.CommandLine` (quoted, backslashes). Includes the negative cases that matter: a bare `node server.js` stays unlabelled, and a directory named `vite-playground` is not mistaken for Vite. Two cases are real command lines captured verbatim from live processes.
- `workspace-port-process-label.test.ts` — label/fallback precedence.
- `workspace-port-scan-client.test.ts` — rejection of malformed `devServer` payloads.
- Extended `local-workspace-port-scanner.test.ts` with end-to-end wiring.

**End-to-end verification in the running app.** Beyond unit tests, I queried the live scan through the app's own IPC (`window.api.workspacePorts.scan`) in the dev build:

```
:5173  → { id: 'electron-vite', label: 'electron-vite' }   owner: orca
:5180  → { id: 'vite',          label: 'Vite' }            owner: orca
:6769  → no devServer (Electron)
:9453  → no devServer (Electron)
:55278 → no devServer (Electron)
external ports → no devServer
```

## AI Review Report

I audited my own first pass rather than assuming it was complete. It was not — three real gaps surfaced, all fixed in this PR:

1. **Missing validation at the remote trust boundary.** `workspace-port-scan-client.ts` validates every field of an incoming scan (`pid`, `processName`, `advertisedUrl`) because remote scan results arrive from another host over RPC. The new field crossed that same boundary unvalidated, and its `label` renders straight into a row — a version-mismatched or hostile runtime sending `devServer: { label: {…} }` would have thrown inside React. Added `isOptionalDevServerIdentity` plus rejection tests.
2. **A converter silently dropping the field.** `workspacePortAsExternal` rebuilds the port object field-by-field; ports from other repos pass through it to render as "External". The same server would have read `Vite` in its own repo and `node` from another — the exact inconsistency this PR exists to remove.
3. **A fourth display site.** `worktree-palette-search.ts` builds its own `"5173 · node"` label for Cmd+J. Now shows the dev server. Search semantics deliberately untouched — port matching there is numeric-only, and making names searchable would be a behavior change beyond this PR.

Checked and found genuinely clean: preload and RPC are pass-through (`result: unknown`, no schema strips the field); no `RUNTIME_PROTOCOL_VERSION` bump needed, per the contract at `shared/protocol-version.ts:12-15`; the max-lines ratchet tracks only files with disables and none were added; the reliability-gate manifest is unaffected; mobile, CLI, and e2e have no port display surface.

**Cross-platform** was explicitly reviewed. The classifier is fed by all three platform paths and is tested against each one's real command-line format, including Windows quoted paths with spaces (`"C:\Program Files\nodejs\node.exe"`), backslash separators, and `.exe`/`.cmd` casing. No keyboard shortcuts, shortcut labels, or filesystem path construction are touched — matching splits on both separators rather than using `path`, since these are foreign-platform strings, not local paths. No Electron platform-specific APIs involved.

## Security Audit

**Command lines are not exposed to the renderer — deliberately.** argv routinely carries secrets (`--api-key=…`, `--token=…`). Classification runs in the main process and only a bounded label crosses the IPC/RPC boundary, so raw command lines never reach renderer, web, or mobile clients. The package-manager fallback reconstructs its label from two allowlists (manager, script name), so even that path cannot emit attacker-influenced text.

**Untrusted input is validated.** Scan results from a remote runtime are validated before rendering — see gap 1 above. Field-shape validation only, consistent with the sibling checks in that file; no length bounds, matching existing behavior for `processName`.

**No new command execution, no new IPC surface, no new dependencies, no auth or filesystem paths touched.** The classifier is a pure function over strings the scanner already had in memory. Matching is basename-scoped, which is a correctness safeguard as well as a security one — the worktree path is present in argv for attribution, so naive substring matching would false-positive on any project whose directory happens to be named after a framework.

No follow-up security work identified.

## Notes

- **SSH is out of scope and unchanged.** SSH ports use a separate type (`EnrichedDetectedPort`, `shared/ssh-types.ts`) scanned by the relay, which carries `processName` but no command line. Those rows degrade to exactly today's behavior. Extending coverage means adding argv to the relay's scan payload — a wire-format change to a component that deploys to remote hosts independently, so it belongs in its own PR.
- **Folder workspaces** are unaffected: attribution happens upstream and already handles them; classification is orthogonal.
- **No new localization keys.** Dev server names are proper nouns and are deliberately not translated. The details dialog reuses the existing `Process` row rather than adding a `Dev server` row, specifically to avoid inventing translations across all five locales.
- **CI has not run the gates on this PR.** Fork PRs need a maintainer to approve workflows, so only `track-community-pr` has executed so far. The lint/typecheck/test results above are from local runs; please approve the workflow run to confirm them independently.
- `electron-vite` was added to the signature table only after running the feature against the live app and seeing this repo's own dev server fall through to `node` — a good argument for driving the real UI rather than trusting fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017d6N1M478gPZCZES38tCxG
