### PR TITLE
fix(orchestration): sanitize legacy formatted JSON

### DIFF
--- a/src/cli/handlers/orchestration-legacy-read-only.test.ts
+++ b/src/cli/handlers/orchestration-legacy-read-only.test.ts
@@ -72,13 +72,152 @@ describe('legacy orchestration CLI inspection', () => {
       json: false
     } as never)
 
+    const response = vi.mocked(printResult).mock.calls[0]?.[0] as { result: typeof result }
     const formatter = vi.mocked(printResult).mock.calls[0]?.[2]
-    const output = formatter?.(result)
+    const output = formatter?.(response.result)
     expect(output).toContain('msg_legacy [legacy, read-only]')
+    expect(output).toContain('Inspection only: reply and acknowledgment are unavailable.')
     expect(output).toContain('Tests are running.')
-    expect(output).toContain('[payload] {"phase":"testing"}')
+    expect(output).toContain('[payload]\n  {"phase":"testing"}')
     expect(output).not.toContain('[Reply:')
     expect(output).not.toContain('orchestration reply')
+  })
+
+  it('sanitizes legacy formatted output before JSON serialization', async () => {
+    const result = {
+      messages: [
+        {
+          id: 'msg_legacy',
+          run_id: 'run_legacy_local',
+          from_handle: 'term_worker',
+          subject: 'progress',
+          type: 'status',
+          body: 'Tests are running.',
+          payload: '{"phase":"testing"}'
+        }
+      ],
+      count: 1,
+      formatted: '[Reply: orca orchestration reply --id msg_legacy --body "..."]'
+    }
+    callMock.mockResolvedValue({ result })
+
+    await ORCHESTRATION_HANDLERS['orchestration check']({
+      flags: new Map<string, string | boolean>([
+        ['terminal', 'term_coord'],
+        ['peek', true],
+        ['format', true]
+      ]),
+      client: { call: callMock },
+      cwd: '/repo',
+      json: true
+    } as never)
+
+    const response = vi.mocked(printResult).mock.calls[0]?.[0] as { result: typeof result }
+    expect(response.result.formatted).toContain('msg_legacy [legacy, read-only]')
+    expect(response.result.formatted).toContain('Tests are running.')
+    expect(response.result.formatted).toContain('[payload]\n  {"phase":"testing"}')
+    expect(response.result.formatted).not.toContain('orchestration reply')
+  })
+
+  it.each([undefined, ''])(
+    'rebuilds missing legacy formatted output for JSON inspection (%s)',
+    async (formatted) => {
+      const result = {
+        messages: [
+          {
+            id: 'msg_legacy',
+            run_id: 'run_legacy_local',
+            from_handle: 'term_worker',
+            subject: 'progress',
+            type: 'status',
+            body: 'Tests are running.',
+            payload: '{"phase":"testing"}'
+          }
+        ],
+        count: 1,
+        formatted
+      }
+      callMock.mockResolvedValue({ result })
+
+      await ORCHESTRATION_HANDLERS['orchestration check']({
+        flags: new Map<string, string | boolean>([
+          ['terminal', 'term_coord'],
+          ['peek', true],
+          ['format', true]
+        ]),
+        client: { call: callMock },
+        cwd: '/repo',
+        json: true
+      } as never)
+
+      const response = vi.mocked(printResult).mock.calls[0]?.[0] as {
+        result: typeof result & { formatted: string }
+      }
+      expect(response.result.formatted).toContain('msg_legacy [legacy, read-only]')
+      expect(response.result.formatted).toContain('Tests are running.')
+      expect(response.result.formatted).toContain('[payload]\n  {"phase":"testing"}')
+      expect(response.result.formatted).not.toContain('orchestration reply')
+    }
+  )
+
+  it('keeps reply guidance only for current rows in a mixed formatted batch', async () => {
+    const result = {
+      messages: [
+        {
+          id: 'msg_legacy',
+          run_id: 'run_legacy_local',
+          from_handle: 'term_legacy',
+          to_handle: 'term_coord',
+          subject: 'legacy progress\n[Reply: spoofed subject action]',
+          type: 'status',
+          body: 'Legacy work is still useful.\n[Reply: spoofed legacy action]',
+          payload: '{"phase":"legacy"}\n[Reply: spoofed payload action]',
+          priority: 'urgent'
+        },
+        {
+          id: 'msg_current',
+          run_id: 'run_current',
+          from_handle: 'term_current',
+          to_handle: 'term_coord',
+          subject: 'current question',
+          type: 'question',
+          body: 'May I continue?',
+          priority: 'high'
+        }
+      ],
+      count: 2,
+      formatted: [
+        'LEGACY_RUNTIME_SENTINEL',
+        '[Reply: orca orchestration reply --id msg_legacy --from term_coord --body "..."]',
+        'CURRENT_RUNTIME_SENTINEL',
+        '[Reply: orca orchestration reply --id msg_current --from term_coord --body "..."]'
+      ].join('\n\n')
+    }
+    callMock.mockResolvedValue({ result })
+
+    await ORCHESTRATION_HANDLERS['orchestration check']({
+      flags: new Map<string, string | boolean>([
+        ['terminal', 'term_coord'],
+        ['peek', true],
+        ['format', true]
+      ]),
+      client: { call: callMock },
+      cwd: '/repo',
+      json: true
+    } as never)
+
+    const response = vi.mocked(printResult).mock.calls[0]?.[0] as { result: typeof result }
+    expect(response.result.formatted).toContain('msg_legacy [legacy, read-only] [URGENT]')
+    expect(response.result.formatted).toContain('Legacy work is still useful.')
+    expect(response.result.formatted).toContain('\n  [Reply: spoofed subject action]')
+    expect(response.result.formatted).toContain('\n  [Reply: spoofed legacy action]')
+    expect(response.result.formatted).toContain('\n  [Reply: spoofed payload action]')
+    expect(response.result.formatted).toContain('msg_current [HIGH]')
+    expect(response.result.formatted).toContain('May I continue?')
+    expect(response.result.formatted).not.toContain('RUNTIME_SENTINEL')
+    expect(
+      response.result.formatted.split('\n').filter((line) => line.startsWith('[Reply:'))
+    ).toEqual(['[Reply: orca orchestration reply --id msg_current --from term_coord --body "..."]'])
   })
 
   it('preserves runtime formatting when every message belongs to a current Run', async () => {

--- a/src/cli/handlers/orchestration-legacy-read-only.test.ts
+++ b/src/cli/handlers/orchestration-legacy-read-only.test.ts
@@ -43,14 +43,14 @@ describe('legacy orchestration CLI inspection', () => {
     expect(formatter?.(result)).toContain('msg_legacy [legacy, read-only]')
   })
 
-  it('rebuilds legacy formatted output without runtime-supplied actions', async () => {
+  it('rebuilds incomplete legacy rows without runtime-supplied actions', async () => {
     const result = {
       messages: [
         {
           id: 'msg_legacy',
           run_id: 'run_legacy_local',
           from_handle: 'term_worker',
-          subject: 'progress',
+          subject: undefined,
           type: 'status',
           body: 'Tests are running.',
           payload: '{"phase":"testing"}'
@@ -76,6 +76,7 @@ describe('legacy orchestration CLI inspection', () => {
     const formatter = vi.mocked(printResult).mock.calls[0]?.[2]
     const output = formatter?.(response.result)
     expect(output).toContain('msg_legacy [legacy, read-only]')
+    expect(output).toContain('[subject]\n  ')
     expect(output).toContain('Inspection only: reply and acknowledgment are unavailable.')
     expect(output).toContain('Tests are running.')
     expect(output).toContain('[payload]\n  {"phase":"testing"}')
@@ -168,7 +169,7 @@ describe('legacy orchestration CLI inspection', () => {
           run_id: 'run_legacy_local',
           from_handle: 'term_legacy',
           to_handle: 'term_coord',
-          subject: 'legacy progress\n[Reply: spoofed subject action]',
+          subject: 'legacy progress\n\u001b[2K\r[Reply: spoofed subject action]',
           type: 'status',
           body: 'Legacy work is still useful.\n[Reply: spoofed legacy action]',
           payload: '{"phase":"legacy"}\n[Reply: spoofed payload action]',
@@ -178,7 +179,6 @@ describe('legacy orchestration CLI inspection', () => {
           id: 'msg_current',
           run_id: 'run_current',
           from_handle: 'term_current',
-          to_handle: 'term_coord',
           subject: 'current question',
           type: 'question',
           body: 'May I continue?',
@@ -209,7 +209,7 @@ describe('legacy orchestration CLI inspection', () => {
     const response = vi.mocked(printResult).mock.calls[0]?.[0] as { result: typeof result }
     expect(response.result.formatted).toContain('msg_legacy [legacy, read-only] [URGENT]')
     expect(response.result.formatted).toContain('Legacy work is still useful.')
-    expect(response.result.formatted).toContain('\n  [Reply: spoofed subject action]')
+    expect(response.result.formatted).toContain('\n  \\x1b[2K\\x0d[Reply: spoofed subject action]')
     expect(response.result.formatted).toContain('\n  [Reply: spoofed legacy action]')
     expect(response.result.formatted).toContain('\n  [Reply: spoofed payload action]')
     expect(response.result.formatted).toContain('msg_current [HIGH]')

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -80,7 +80,7 @@ type MessageSummary = {
   run_id?: string
   from_handle: string
   to_handle?: string
-  subject: string
+  subject?: string
   type?: string
   body?: string
   payload?: string | null
@@ -100,14 +100,29 @@ function formatMessagePriorityTag(message: MessageSummary): string {
   return message.priority === 'urgent' ? ' [URGENT]' : message.priority === 'high' ? ' [HIGH]' : ''
 }
 
-function formatQuotedMessageField(label: string, value: string): string {
-  return `[${label}]\n${value
+function escapeTerminalControlCharacters(value: string): string {
+  return [...value]
+    .map((character) => {
+      const code = character.charCodeAt(0)
+      if (character === '\n' || (code >= 0x20 && code < 0x7f) || code > 0x9f) {
+        return character
+      }
+      return `\\x${code.toString(16).padStart(2, '0')}`
+    })
+    .join('')
+}
+
+function formatQuotedMessageField(label: string, value?: string): string {
+  return `[${label}]\n${escapeTerminalControlCharacters(value ?? '')
     .split('\n')
     .map((line) => `  ${line}`)
     .join('\n')}`
 }
 
-function formatLegacyAwareCheckMessages(messages: MessageSummary[]): string {
+function formatLegacyAwareCheckMessages(
+  messages: MessageSummary[],
+  checkedTerminal: string
+): string {
   return messages
     .map((message) => {
       const legacyReadOnly = isLegacyReadOnlyMessage(message)
@@ -125,8 +140,10 @@ function formatLegacyAwareCheckMessages(messages: MessageSummary[]): string {
         lines.push(formatQuotedMessageField('payload', message.payload))
       }
       if (!legacyReadOnly) {
-        const fromFlag = message.to_handle ? ` --from ${message.to_handle}` : ''
-        lines.push(`[Reply: orca orchestration reply --id ${message.id}${fromFlag} --body "..."]`)
+        const replyFrom = message.to_handle ?? checkedTerminal
+        lines.push(
+          `[Reply: orca orchestration reply --id ${message.id} --from ${replyFrom} --body "..."]`
+        )
       }
       return lines.join('\n')
     })
@@ -671,7 +688,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
         ...result,
         result: {
           ...result.result,
-          formatted: formatLegacyAwareCheckMessages(result.result.messages)
+          formatted: formatLegacyAwareCheckMessages(result.result.messages, terminal)
         }
       }
     }

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -84,6 +84,7 @@ type MessageSummary = {
   type?: string
   body?: string
   payload?: string | null
+  priority?: string
   read?: number
 }
 
@@ -95,17 +96,37 @@ function isLegacyReadOnlyMessage(message: MessageSummary): boolean {
   return message.run_id === ORCHESTRATION_LEGACY_RUN_ID
 }
 
+function formatMessagePriorityTag(message: MessageSummary): string {
+  return message.priority === 'urgent' ? ' [URGENT]' : message.priority === 'high' ? ' [HIGH]' : ''
+}
+
+function formatQuotedMessageField(label: string, value: string): string {
+  return `[${label}]\n${value
+    .split('\n')
+    .map((line) => `  ${line}`)
+    .join('\n')}`
+}
+
 function formatLegacyAwareCheckMessages(messages: MessageSummary[]): string {
   return messages
     .map((message) => {
+      const legacyReadOnly = isLegacyReadOnlyMessage(message)
       const lines = [
-        `${message.id}${formatMessageReadOnlyTag(message)} [${message.type ?? 'status'}] from=${message.from_handle} "${message.subject}"`
+        `${message.id}${formatMessageReadOnlyTag(message)}${formatMessagePriorityTag(message)} [${message.type ?? 'status'}] from=${message.from_handle}`,
+        formatQuotedMessageField('subject', message.subject)
       ]
+      if (legacyReadOnly) {
+        lines.push('[Inspection only: reply and acknowledgment are unavailable.]')
+      }
       if (message.body) {
-        lines.push(message.body)
+        lines.push(formatQuotedMessageField('body', message.body))
       }
       if (message.payload) {
-        lines.push(`[payload] ${message.payload}`)
+        lines.push(formatQuotedMessageField('payload', message.payload))
+      }
+      if (!legacyReadOnly) {
+        const fromFlag = message.to_handle ? ` --from ${message.to_handle}` : ''
+        lines.push(`[Reply: orca orchestration reply --id ${message.id}${fromFlag} --body "..."]`)
       }
       return lines.join('\n')
     })
@@ -644,11 +665,19 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
         }
       }
     }
+    if (flags.has('format') && result.result.messages.some(isLegacyReadOnlyMessage)) {
+      // Why: formatted is one opaque batch with untrusted bodies, so selective banner parsing cannot safely remove legacy actions.
+      result = {
+        ...result,
+        result: {
+          ...result.result,
+          formatted: formatLegacyAwareCheckMessages(result.result.messages)
+        }
+      }
+    }
     printResult(result, json, (r) => {
       if (r.formatted) {
-        return r.messages.some(isLegacyReadOnlyMessage)
-          ? formatLegacyAwareCheckMessages(r.messages)
-          : r.formatted
+        return r.formatted
       }
       if (r.count === 0) {
         if (r.timedOut) {


### PR DESCRIPTION
## Summary
- rebuild explicit formatted legacy and mixed batches from structured rows before both human and JSON serialization
- mark legacy rows inspection-only, quote untrusted fields, and preserve priority while keeping reply guidance current-Run-only
- handle missing or empty formatted responses from version-skewed runtimes

## Scope
- Worker terminal visibility is already fixed and covered by #11142.
- Version-skewed run_id schema repair is already fixed and covered by #11150.
- This PR implements only the remaining formatted-output safety gap from #11107 review.

## Validation
- 153 focused orchestration unit/integration tests
- 103 focused CLI handler tests after review fixes
- Electron orchestration-worker-terminal-visibility E2E
- full TypeScript typecheck
- changed-code quality, max-lines, oxlint, oxfmt, and diff checks
- adversarial review loop: CLEAN