### PR TITLE
refactor(shared): add abortable sleep primitive

### DIFF
--- a/mobile/src/source-control/mobile-source-control-screen-state.ts
+++ b/mobile/src/source-control/mobile-source-control-screen-state.ts
@@ -123,9 +123,7 @@ export function firstParam(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? '') : (value ?? '')
 }
 
-export function wait(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
+export { sleep as wait } from '../../../src/shared/sleep'
 
 export function formatBranchLabel(branch: string | undefined, head: string | undefined): string {
   if (branch?.startsWith('refs/heads/')) {

--- a/src/main/ipc/pty-management.ts
+++ b/src/main/ipc/pty-management.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron'
+import { sleep } from '../../shared/sleep'
 import { DaemonPtyRouter } from '../daemon/daemon-pty-router'
 import { DegradedDaemonPtyProvider } from '../daemon/degraded-daemon-pty-provider'
 import type { DaemonPtyAdapter } from '../daemon/daemon-pty-adapter'
@@ -8,10 +9,6 @@ import type { DaemonSessionInfo } from '../daemon/types'
 // Why: poll past the daemon's 5s SIGTERM→SIGKILL ladder (KILL_TIMEOUT_MS in session.ts), else slow-exiting shells falsely look "refused".
 const MAX_POLL_ATTEMPTS = 65
 const POLL_INTERVAL_MS = 100
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
 
 function getDaemonAdapters(): DaemonPtyAdapter[] {
   const provider = getDaemonProvider()

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -102,9 +102,7 @@ export function isGssapiSystemSshFallbackCandidate(
   return (isAuthError(err) || isPassphraseError(err)) && resolved?.gssapiAuthentication === true
 }
 
-export function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
+export { sleep } from '../../shared/sleep'
 
 export function shellEscape(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`

--- a/src/renderer/src/lib/workspace-port-actions.ts
+++ b/src/renderer/src/lib/workspace-port-actions.ts
@@ -6,6 +6,7 @@ import {
   type RuntimeClientTarget
 } from '@/runtime/runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
+import { sleep } from '../../../shared/sleep'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 import type {
   WorkspacePort,
@@ -37,10 +38,6 @@ type WorkspacePortScanByKeySetter = ReturnType<
 type WorkspacePortScanRefreshingSetter = ReturnType<
   typeof useAppStore.getState
 >['setWorkspacePortScanRefreshing']
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => window.setTimeout(resolve, ms))
-}
 
 export function shouldOpenWorkspacePortInOrcaBrowser(
   settings: { openLinksInApp?: boolean } | null | undefined
@@ -199,7 +196,7 @@ export async function refreshWorkspacePortScanAfterStop(args: {
     // port row after the process actually exits. Failures here are swallowed
     // because the UI is already correct from the first scan; surfacing a
     // 'Failed to refresh ports' toast on top of the stop success would lie.
-    await delay(WORKSPACE_PORT_STOP_SETTLE_MS)
+    await sleep(WORKSPACE_PORT_STOP_SETTLE_MS)
     try {
       const settledScan = await scanWorkspacePortsForTarget(args.runtimeTarget)
       publishScan(settledScan)

--- a/src/shared/sleep.test.ts
+++ b/src/shared/sleep.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sleep } from './sleep'
+
+describe('sleep', () => {
+  it('waits for a zero-delay timer', async () => {
+    vi.useFakeTimers()
+    try {
+      const pending = sleep(0)
+
+      expect(vi.getTimerCount()).toBe(1)
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(pending).resolves.toBeUndefined()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects an already-aborted signal without starting a timer or listener', async () => {
+    vi.useFakeTimers()
+    try {
+      const controller = new AbortController()
+      const addEventListener = vi.spyOn(controller.signal, 'addEventListener')
+      controller.abort()
+
+      await expect(sleep(100, controller.signal)).rejects.toMatchObject({ name: 'AbortError' })
+      expect(addEventListener).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects on abort and cleans up its timer and listener', async () => {
+    vi.useFakeTimers()
+    try {
+      const controller = new AbortController()
+      const addEventListener = vi.spyOn(controller.signal, 'addEventListener')
+      const removeEventListener = vi.spyOn(controller.signal, 'removeEventListener')
+      const pending = sleep(100, controller.signal)
+      const listener = addEventListener.mock.calls[0]?.[1]
+
+      expect(listener).toBeTypeOf('function')
+      expect(vi.getTimerCount()).toBe(1)
+      controller.abort()
+
+      const error = await pending.catch((reason: unknown) => reason)
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error).toMatchObject({ name: 'AbortError' })
+      expect(removeEventListener).toHaveBeenCalledWith('abort', listener)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('removes its abort listener after the timer completes', async () => {
+    vi.useFakeTimers()
+    try {
+      const controller = new AbortController()
+      const addEventListener = vi.spyOn(controller.signal, 'addEventListener')
+      const removeEventListener = vi.spyOn(controller.signal, 'removeEventListener')
+      const pending = sleep(100, controller.signal)
+      const listener = addEventListener.mock.calls[0]?.[1]
+
+      await vi.advanceTimersByTimeAsync(100)
+      await expect(pending).resolves.toBeUndefined()
+      expect(removeEventListener).toHaveBeenCalledWith('abort', listener)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/shared/sleep.ts
+++ b/src/shared/sleep.ts
@@ -1,0 +1,29 @@
+/** Waits for a timer, rejecting if the optional cancellation signal aborts. */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(createAbortError())
+  }
+
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => finish(createAbortError())
+    const timer = setTimeout(() => finish(), ms)
+
+    function finish(error?: Error): void {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', onAbort)
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function createAbortError(): Error {
+  const error = new Error('Sleep aborted')
+  error.name = 'AbortError'
+  return error
+}

--- a/src/shared/sleep.ts
+++ b/src/shared/sleep.ts
@@ -8,6 +8,7 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     const onAbort = (): void => finish(createAbortError())
     const timer = setTimeout(() => finish(), ms)
 
+    /** Settles the wait and releases its timer and abort listener. */
     function finish(error?: Error): void {
       clearTimeout(timer)
       signal?.removeEventListener('abort', onAbort)
@@ -22,6 +23,7 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   })
 }
 
+/** Creates an AbortError without relying on DOMException availability. */
 function createAbortError(): Error {
   const error = new Error('Sleep aborted')
   error.name = 'AbortError'


### PR DESCRIPTION
## Summary

Adds `src/shared/sleep.ts`, a process-agnostic timer primitive with an optional `AbortSignal`. It rejects cancellation with a portable `Error` named `AbortError`, clears its timer, and removes its abort listener.

Migrates four behaviorally equivalent no-signal copies in main PTY management, the SSH compatibility export, renderer workspace-port refresh, and mobile source-control state.

Related to #10983; this is intentionally the first safe slice, not a full resolution of the umbrella issue.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] Node, CLI, Web, and mobile typechecks
- [x] Targeted Vitest: `src/shared/sleep.test.ts` and `src/main/ssh/ssh-connection-utils.test.ts` (75 tests)
- [x] Mobile lint and format checks
- [x] `pnpm run check:max-lines-ratchet`
- [x] Added cancellation, cleanup, listener-leak, portable AbortError, and zero-delay coverage

`pnpm test -- src/shared/sleep.test.ts` cannot pass its native-runtime preflight in this checkout: the repository's patched `node-pty` artifact is unavailable locally. The same targeted tests pass when Vitest is invoked directly; the preflight also fails under Node 24.

## AI Review Report

Reviewed the staged diff for cancellation races, double settlement, timer/listener cleanup, zero-delay behavior, and cross-runtime typing. Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. The helper has no platform-specific behavior: it uses a portable standard `Error` named `AbortError`, platform-neutral `setTimeout`/`clearTimeout`, and `AbortSignal`; Node, CLI, Web, and mobile typechecks pass. The migrated copies have no existing signal or `unref` semantics, while special-semantics copies were left untouched.

## Security Audit

No user input, command execution, filesystem paths, IPC surface, credentials, or dependencies were added. The change only manages in-process timers and abort listeners.

## Notes

Remaining #10983 scope is intentionally excluded: the other sleep/delay variants (including Node `unref` and abort-to-resolve behavior), inline timer copies, the 993 timeout/interval constants, and test-only export cleanup. This PR does not use `Closes #10983`.
