### PR TITLE
refactor(renderer): consolidate platform detection

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -124,7 +124,8 @@ import { BrowserImportHintButton } from './BrowserImportHintButton'
 import { BrowserToolbarMenu } from './BrowserToolbarMenu'
 import BrowserFind from './BrowserFind'
 import { BrowserMobileDriverOverlay } from './BrowserMobileDriverOverlay'
-import { getShortcutPlatform, useShortcutLabel } from '@/hooks/useShortcutLabel'
+import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { getRemoteBrowserFrameStyle } from './remote-browser-frame-style'
 import {
   getRemoteBrowserKeyboardShortcut,
@@ -2012,7 +2013,7 @@ function RemoteBrowserPagePane({
     if (!isActive) {
       return
     }
-    const shortcutPlatform = getShortcutPlatform()
+    const shortcutPlatform = getRendererAppPlatform()
     const handleKeyDown = (e: KeyboardEvent): void => {
       const method = keybindingMatchesAction('browser.back', e, shortcutPlatform, keybindings)
         ? 'browser.back'
@@ -3450,7 +3451,7 @@ function BrowserPagePane({
     if (!isActive) {
       return
     }
-    const shortcutPlatform = getShortcutPlatform()
+    const shortcutPlatform = getRendererAppPlatform()
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (!keybindingMatchesAction('browser.find', e, shortcutPlatform, keybindings)) {
         return
@@ -3480,7 +3481,7 @@ function BrowserPagePane({
     if (!isActive) {
       return
     }
-    const shortcutPlatform = getShortcutPlatform()
+    const shortcutPlatform = getRendererAppPlatform()
     const handleKeyDown = (e: KeyboardEvent): void => {
       const direction = keybindingMatchesAction('browser.back', e, shortcutPlatform, keybindings)
         ? 'back'
@@ -3522,7 +3523,7 @@ function BrowserPagePane({
     if (!isActive) {
       return
     }
-    const shortcutPlatform = getShortcutPlatform()
+    const shortcutPlatform = getRendererAppPlatform()
     const handleKeyDown = (e: KeyboardEvent): void => {
       const isHardReload = keybindingMatchesAction(
         'browser.hardReload',
@@ -4149,7 +4150,7 @@ function BrowserPagePane({
     if (!isActive) {
       return
     }
-    const shortcutPlatform = getShortcutPlatform()
+    const shortcutPlatform = getRendererAppPlatform()
     const handleKeyDown = (e: KeyboardEvent): void => {
       // Why: don't intercept in editable targets so native Cmd+C still copies in inputs/contentEditable.
       if (isEditableKeyboardTarget(e.target)) {
@@ -4172,7 +4173,7 @@ function BrowserPagePane({
     if (!isActive) {
       return
     }
-    const shortcutPlatform = getShortcutPlatform()
+    const shortcutPlatform = getRendererAppPlatform()
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (!keybindingMatchesAction('browser.focusAddressBar', e, shortcutPlatform, keybindings)) {
         return

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -110,8 +110,8 @@ vi.mock('@/components/terminal-pane/terminal-user-input-signal', () => ({
 vi.mock('@/components/terminal-pane/use-system-prefers-dark', () => ({
   useSystemPrefersDark: () => false
 }))
-vi.mock('@/lib/shortcut-platform', () => ({
-  getShortcutPlatform: () => platformState.value
+vi.mock('@/lib/renderer-app-platform', () => ({
+  getRendererAppPlatform: () => platformState.value
 }))
 vi.mock('@/components/terminal-pane/terminal-ime-native-text-forwarder', () => ({
   installTerminalImeNativeTextForwarder: (args: { sendInput: (data: string) => void }) => {

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Terminal } from '@xterm/xterm'
 import '@xterm/xterm/css/xterm.css'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { subscribeToTerminalUserInput } from '@/components/terminal-pane/terminal-user-input-signal'
 import { composeActiveTerminalTheme } from '@/components/terminal-pane/terminal-appearance'
 import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
@@ -223,7 +223,7 @@ export function AgentTerminalPreview({
         // Why: route through terminal.input so the chord's bytes carry core's user-input signal, like typed keys.
         sendInput: (data) => terminal?.input(data),
         getShortcutContext: () => ({
-          clientPlatform: getShortcutPlatform(),
+          clientPlatform: getRendererAppPlatform(),
           macOptionAsAlt: macOptionAsAltRef.current,
           keybindings: useAppStore.getState().keybindings,
           terminalInput: terminalInputRef.current,

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-ime-bridge.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-ime-bridge.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { installTerminalImeCompositionTracker } from '@/components/terminal-pane/terminal-ime-composition-tracker'
 import { installTerminalImeNativeTextForwarder } from '@/components/terminal-pane/terminal-ime-native-text-forwarder'
 import { getMacNativeTextInputSourceTracker } from '@/components/terminal-pane/terminal-ime-input-source'
@@ -18,7 +18,7 @@ export type PreviewImeBridge = {
  * TerminalPane's forwarder, macOS-only like the pane's install.
  */
 export function installPreviewImeBridge(terminal: Terminal): PreviewImeBridge | null {
-  if (getShortcutPlatform() !== 'darwin') {
+  if (getRendererAppPlatform() !== 'darwin') {
     return null
   }
   // Why: prewarm the async input-source lookup before the first native-text key needs classification.

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { useAppStore } from '@/store'
 import { prefetchLayoutBaseCharacters } from '@/lib/keyboard-layout/layout-base-character'
@@ -28,7 +28,7 @@ export function installPreviewTerminalKeyHandler(args: {
   getShortcutContext: () => Omit<PreviewShortcutContext, 'optionKeyLocation'>
 }): () => void {
   const { terminal } = args
-  const platform = getShortcutPlatform()
+  const platform = getRendererAppPlatform()
   const consumedClipboardKeys = new Set<string>()
   const nativeOnlyShortcutTracker = createTerminalNativeOnlyShortcutTracker()
   const consumeEvent = (event: KeyboardEvent): false => {

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-paste.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-paste.ts
@@ -1,5 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import {
   executeTerminalPastePlan,
   planTerminalPasteWithYield
@@ -38,7 +38,7 @@ export function createPreviewClipboardPaster(deps: {
     if (!targetIsCurrent()) {
       return
     }
-    const platform = getShortcutPlatform()
+    const platform = getRendererAppPlatform()
     const plan = await planTerminalPasteWithYield({
       text,
       source,

--- a/src/renderer/src/components/dictation/use-hold-dictation-gesture.ts
+++ b/src/renderer/src/components/dictation/use-hold-dictation-gesture.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, type MutableRefObject } from 'react'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { keybindingMatchesAction, type KeybindingOverrides } from '../../../../shared/keybindings'
 import type { DictationState } from '../../../../shared/speech-types'
 import type { GlobalSettings } from '../../../../shared/types'
@@ -124,7 +124,7 @@ export function useHoldDictationGesture({
     }
 
     const handleKeyDown = (e: KeyboardEvent): void => {
-      if (keybindingMatchesAction('voice.dictation', e, getShortcutPlatform(), keybindings)) {
+      if (keybindingMatchesAction('voice.dictation', e, getRendererAppPlatform(), keybindings)) {
         if (!settings?.voice?.enabled || !settings.voice.sttModel) {
           return
         }
@@ -143,7 +143,7 @@ export function useHoldDictationGesture({
         return
       }
       if (
-        !keybindingMatchesAction('voice.dictation', e, getShortcutPlatform(), keybindings) &&
+        !keybindingMatchesAction('voice.dictation', e, getRendererAppPlatform(), keybindings) &&
         releaseMatcherRef.current?.(e) !== true
       ) {
         return

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -74,7 +74,7 @@ import {
 import { installOpenDraftAddReviewNoteGuard } from './editor-shortcuts'
 import { usePreserveSectionDuringExternalEdit } from './usePreserveSectionDuringExternalEdit'
 import { openHttpLink, type HttpLinkSourceOwner } from '@/lib/http-link-routing'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
 import { markdownPreviewUrlTransform } from './markdown-preview-url-transform'
 import { prewarmMarkdownPreviewLocalImages } from './markdown-preview-local-images'
@@ -956,7 +956,7 @@ export default function MarkdownPreview({
       const targetInsidePreview = target instanceof Node && root.contains(target)
 
       if (
-        isMarkdownPreviewFindShortcut(event, getShortcutPlatform(), keybindings) &&
+        isMarkdownPreviewFindShortcut(event, getRendererAppPlatform(), keybindings) &&
         targetInsidePreview
       ) {
         event.preventDefault()
@@ -967,7 +967,7 @@ export default function MarkdownPreview({
 
       const reviewNoteKey = resolveMarkdownPreviewAddReviewNoteKey({
         event,
-        platform: getShortcutPlatform(),
+        platform: getRendererAppPlatform(),
         keybindings,
         targetInsidePreview,
         markdownAnnotationsEnabled,

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -10,7 +10,7 @@ import {
 } from 'pdfjs-dist/web/pdf_viewer.mjs'
 import 'pdfjs-dist/web/pdf_viewer.css'
 import PdfFind from './PdfFind'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { useAppStore } from '@/store'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
@@ -194,7 +194,7 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
-      const platform = getShortcutPlatform()
+      const platform = getRendererAppPlatform()
       if (keybindingMatchesAction('editor.find', e, platform, keybindings)) {
         e.preventDefault()
         e.stopPropagation()

--- a/src/renderer/src/components/editor/editor-shortcuts.test.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.test.ts
@@ -7,8 +7,8 @@ const shortcutState = vi.hoisted(() => ({
   platform: 'darwin' as NodeJS.Platform
 }))
 
-vi.mock('@/lib/shortcut-platform', () => ({
-  getShortcutPlatform: () => shortcutState.platform
+vi.mock('@/lib/renderer-app-platform', () => ({
+  getRendererAppPlatform: () => shortcutState.platform
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/editor/editor-shortcuts.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.ts
@@ -1,5 +1,5 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { useAppStore } from '@/store'
 import { keybindingMatchesAction, type KeybindingActionId } from '../../../../shared/keybindings'
 
@@ -10,7 +10,7 @@ export function editorShortcutMatches(
   return keybindingMatchesAction(
     actionId,
     event,
-    getShortcutPlatform(),
+    getRendererAppPlatform(),
     useAppStore.getState().keybindings
   )
 }

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.test.ts
@@ -4,10 +4,10 @@ import StarterKit from '@tiptap/starter-kit'
 import { createIsolatedMarkdownExtensionForTests } from './isolated-markdown-extension-for-tests'
 import { createRichMarkdownKeyHandler, type KeyHandlerContext } from './rich-markdown-key-handler'
 
-// Why: keybinding matching resolves the platform from navigator.userAgent,
-// which is environment-dependent under vitest; pin it for determinism.
-vi.mock('@/lib/shortcut-platform', () => ({
-  getShortcutPlatform: () => 'darwin' as NodeJS.Platform
+// Why: keybinding matching resolves the platform through the preload-aware
+// renderer platform module; pin it for deterministic shortcut coverage.
+vi.mock('@/lib/renderer-app-platform', () => ({
+  getRendererAppPlatform: () => 'darwin' as NodeJS.Platform
 }))
 
 const extensions = [StarterKit, createIsolatedMarkdownExtensionForTests()]

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.ts
@@ -1,6 +1,6 @@
 import type { MutableRefObject, Dispatch, SetStateAction } from 'react'
 import type { Editor } from '@tiptap/react'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { useAppStore } from '@/store'
 import { isMarkdownPreviewFindShortcut } from './markdown-preview-search'
 import { handleRichMarkdownAddReviewNoteShortcut } from './rich-markdown-annotation-shortcut'
@@ -84,7 +84,7 @@ export function createRichMarkdownKeyHandler(
     if (
       isMarkdownPreviewFindShortcut(
         event,
-        getShortcutPlatform(),
+        getRendererAppPlatform(),
         useAppStore.getState().keybindings
       )
     ) {

--- a/src/renderer/src/components/editor/useMarkdownPreviewShortcut.ts
+++ b/src/renderer/src/components/editor/useMarkdownPreviewShortcut.ts
@@ -1,6 +1,6 @@
 import { useEffect, type RefObject } from 'react'
 import { detectLanguage } from '@/lib/language-detect'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { useAppStore } from '@/store'
 import type { OpenFile } from '@/store/slices/editor'
 import { canOpenMarkdownPreview, isMarkdownPreviewShortcut } from './markdown-preview-controls'
@@ -53,7 +53,7 @@ export function useMarkdownPreviewShortcut({
     const handleKeyDown = (event: KeyboardEvent): void => {
       if (
         event.defaultPrevented ||
-        !isMarkdownPreviewShortcut(event, getShortcutPlatform(), keybindings)
+        !isMarkdownPreviewShortcut(event, getRendererAppPlatform(), keybindings)
       ) {
         return
       }

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { RefObject } from 'react'
 import type { Editor } from '@tiptap/react'
 import { TextSelection } from '@tiptap/pm/state'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { useAppStore } from '@/store'
 import {
   isMarkdownPreviewFindShortcut,
@@ -309,7 +309,7 @@ export function useRichMarkdownSearch({
       const target = event.target
       const targetInsideEditor = target instanceof Node && root.contains(target)
       if (
-        isMarkdownPreviewFindShortcut(event, getShortcutPlatform(), keybindings) &&
+        isMarkdownPreviewFindShortcut(event, getRendererAppPlatform(), keybindings) &&
         targetInsideEditor
       ) {
         event.preventDefault()
@@ -319,7 +319,7 @@ export function useRichMarkdownSearch({
       }
 
       if (
-        isMarkdownPreviewReplaceShortcut(event, getShortcutPlatform(), keybindings) &&
+        isMarkdownPreviewReplaceShortcut(event, getRendererAppPlatform(), keybindings) &&
         targetInsideEditor
       ) {
         event.preventDefault()

--- a/src/renderer/src/components/feature-wall/EditorAnimatedVisual.tsx
+++ b/src/renderer/src/components/feature-wall/EditorAnimatedVisual.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef } from 'react'
 import type { JSX, ReactNode } from 'react'
 import { cn } from '@/lib/utils'
-import { getShortcutPlatform } from '@/hooks/useShortcutLabel'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { translate } from '@/i18n/i18n'
 
 // Why: the visual leans on direct DOM mutation (typing into a node, swapping
@@ -275,7 +275,7 @@ function SlashRow(props: {
 
 export function EditorAnimatedVisual(props: { reducedMotion: boolean }): JSX.Element {
   const { reducedMotion } = props
-  const editorShortcutPrefix = getShortcutPlatform() === 'darwin' ? '⌘' : 'Ctrl+'
+  const editorShortcutPrefix = getRendererAppPlatform() === 'darwin' ? '⌘' : 'Ctrl+'
   const boldShortcutLabel = `${editorShortcutPrefix}B`
   const italicShortcutLabel = `${editorShortcutPrefix}I`
 

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -59,7 +59,7 @@ import {
 import { closeTerminalTab } from '@/components/terminal/terminal-tab-actions'
 import { guardPinnedTabClose, resolvePinnedTabLabel } from '@/store/pinned-tab-close-guard'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import {
   ORCHESTRATION_SETUP_DISMISSED_STORAGE_KEY,
   ORCHESTRATION_SETUP_STATE_EVENT,
@@ -70,9 +70,7 @@ import {
 import { useAppStore } from '@/store'
 import type { OpenFile } from '@/store/slices/editor'
 import { destroyWorkspaceWebviews } from '@/store/slices/browser-webview-cleanup'
-import {
-  createTerminalPaneHandleRegistry
-} from './terminal-pane-handle-registry'
+import { createTerminalPaneHandleRegistry } from './terminal-pane-handle-registry'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import {
   keybindingMatchesAction,
@@ -1170,7 +1168,7 @@ export function FloatingTerminalPanel({
   const resolveFloatingPanelShortcut = useCallback(
     (input: FloatingPanelShortcutInput): FloatingPanelShortcutResolution | null => {
       const state = useAppStore.getState()
-      const platform = getShortcutPlatform()
+      const platform = getRendererAppPlatform()
       const terminalShortcutPolicy = state.settings?.terminalShortcutPolicy
       const isFloatingTerminalInput = isFloatingWorkspaceTerminalInputTarget(input.target)
       const context: KeybindingContext = input.doubleTapModifier
@@ -1409,7 +1407,7 @@ export function FloatingTerminalPanel({
         ? 'terminal'
         : 'app'
       const matches = (actionId: KeybindingActionId): boolean =>
-        keybindingMatchesAction(actionId, event, getShortcutPlatform(), state.keybindings, {
+        keybindingMatchesAction(actionId, event, getRendererAppPlatform(), state.keybindings, {
           context,
           terminalShortcutPolicy: state.settings?.terminalShortcutPolicy
         })

--- a/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerKeys.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import type React from 'react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import type { InlineInput } from './FileExplorerRow'
 import type { TreeNode } from './file-explorer-types'
 import type { FileExplorerRowProjection } from './file-explorer-row-projection'
@@ -156,7 +156,7 @@ export function useFileExplorerKeys(opts: {
       // Why: require focus inside the explorer shell (includes the scrollbar, not just
       // the viewport — Radix renders the scrollbar as a sibling of the viewport).
       const inExplorer = focusInExplorer()
-      const platform = getShortcutPlatform()
+      const platform = getRendererAppPlatform()
       const wantUndo =
         keybindingMatchesAction('fileExplorer.undo', e, platform, keybindings) &&
         fileExplorerHasUndo()

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -83,7 +83,7 @@ import {
 } from '@/lib/windows-terminal-capabilities'
 import { useWindowsTerminalCapabilityOwnerKey } from '@/hooks/useWindowsTerminalCapabilityOwnerKey'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import {
   isWebClientLocation,
@@ -610,7 +610,9 @@ function Settings(): React.JSX.Element {
       if (event.defaultPrevented) {
         return
       }
-      if (!keybindingMatchesAction('settings.search', event, getShortcutPlatform(), keybindings)) {
+      if (
+        !keybindingMatchesAction('settings.search', event, getRendererAppPlatform(), keybindings)
+      ) {
         return
       }
       const input = searchInputRef.current

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -144,7 +144,7 @@ import {
   getFolderWorkspacePathStatusDescription,
   getFolderWorkspacePathStatusTitle
 } from '@/lib/folder-workspace-path-status'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import {
   SCROLL_TO_CURRENT_WORKSPACE_REVEAL_REQUEST_EVENT,
   type ScrollToCurrentWorkspaceRevealRequestDetail
@@ -2549,7 +2549,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         return
       }
 
-      const platform = getShortcutPlatform()
+      const platform = getRendererAppPlatform()
       if (keybindingMatchesAction('sidebar.focusWorktreeList', e, platform, keybindings)) {
         scrollRef.current?.focus()
         e.preventDefault()

--- a/src/renderer/src/components/tab-bar/RecentTabSwitcher.tsx
+++ b/src/renderer/src/components/tab-bar/RecentTabSwitcher.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom'
 import { FileText, GitCompare, Globe2, TerminalSquare } from 'lucide-react'
 import { useAppStore } from '../../store'
 import { activateCyclableTab } from '../../hooks/ipc-tab-switch'
-import { getShortcutPlatform } from '../../hooks/useShortcutLabel'
+import { getRendererAppPlatform } from '../../lib/renderer-app-platform'
 import {
   isRecentTabSwitcherCommitRelease,
   matchesRecentTabSwitcherChord
@@ -113,7 +113,7 @@ export default function RecentTabSwitcher(): React.JSX.Element | null {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
       const store = useAppStore.getState()
-      if (matchesRecentTabSwitcherChord(event, getShortcutPlatform(), store.keybindings)) {
+      if (matchesRecentTabSwitcherChord(event, getRendererAppPlatform(), store.keybindings)) {
         // Why: Electron's native before-input-event path is authoritative, but
         // CDP/test-dispatched keys can reach the renderer directly. Respect the
         // keybinding registry here too so tests do not bypass user customization.

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.keyboard.test.ts
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsMenu.keyboard.test.ts
@@ -58,8 +58,8 @@ vi.mock('../../../../shared/keybindings', () => ({
   keybindingMatchesAction: keybindingsMock.matchAction
 }))
 
-vi.mock('@/lib/shortcut-platform', () => ({
-  getShortcutPlatform: () => 'darwin' as const
+vi.mock('@/lib/renderer-app-platform', () => ({
+  getRendererAppPlatform: () => 'darwin' as const
 }))
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/tab-bar/tab-bar-quick-commands-shortcut.ts
+++ b/src/renderer/src/components/tab-bar/tab-bar-quick-commands-shortcut.ts
@@ -8,7 +8,7 @@ import {
   ModifierDoubleTapDetector,
   toModifierDoubleTapEvent
 } from '../../../../shared/modifier-double-tap-detector'
-import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { TOGGLE_QUICK_COMMANDS_MENU_EVENT } from '@/lib/quick-commands-menu-events'
 import { useAppStore } from '@/store'
 
@@ -48,7 +48,7 @@ export function useTabBarQuickCommandsShortcut({
     if (activeView !== 'terminal') {
       return
     }
-    const platform = getShortcutPlatform()
+    const platform = getRendererAppPlatform()
     const doubleTapDetector = new ModifierDoubleTapDetector()
     const matchesShortcut = (input: KeybindingInput, target: EventTarget | null): boolean => {
       const context = getQuickCommandsShortcutContext(target)

--- a/src/renderer/src/hooks/useShortcutLabel.ts
+++ b/src/renderer/src/hooks/useShortcutLabel.ts
@@ -9,8 +9,6 @@ import {
 import { useAppStore } from '../store'
 import { getRendererAppPlatform } from '../lib/renderer-app-platform'
 
-export { getRendererAppPlatform }
-
 export type ShortcutKeyComboDetails = {
   keys: string[]
   doubleTap: boolean

--- a/src/renderer/src/hooks/useShortcutLabel.ts
+++ b/src/renderer/src/hooks/useShortcutLabel.ts
@@ -7,9 +7,9 @@ import {
   type KeybindingOverrides
 } from '../../../shared/keybindings'
 import { useAppStore } from '../store'
-import { getShortcutPlatform } from '../lib/shortcut-platform'
+import { getRendererAppPlatform } from '../lib/renderer-app-platform'
 
-export { getShortcutPlatform }
+export { getRendererAppPlatform }
 
 export type ShortcutKeyComboDetails = {
   keys: string[]
@@ -20,7 +20,7 @@ export function formatShortcutLabel(
   actionId: KeybindingActionId,
   overrides?: KeybindingOverrides
 ): string {
-  const platform = getShortcutPlatform()
+  const platform = getRendererAppPlatform()
   return formatKeybindingList(
     getEffectiveKeybindingsForAction(actionId, platform, overrides),
     platform
@@ -31,7 +31,7 @@ export function formatPrimaryShortcutLabel(
   actionId: KeybindingActionId,
   overrides?: KeybindingOverrides
 ): string {
-  const platform = getShortcutPlatform()
+  const platform = getRendererAppPlatform()
   const [binding] = getEffectiveKeybindingsForAction(actionId, platform, overrides)
   return binding ? formatKeybindingList([binding], platform) : 'Unassigned'
 }
@@ -48,7 +48,7 @@ export function formatOptionalShortcutLabel(
   actionId: KeybindingActionId,
   overrides?: KeybindingOverrides
 ): string | null {
-  const platform = getShortcutPlatform()
+  const platform = getRendererAppPlatform()
   const bindings = getEffectiveKeybindingsForAction(actionId, platform, overrides)
   if (bindings.length === 0) {
     return null
@@ -77,7 +77,7 @@ export function formatShortcutKeyComboDetails(
   actionId: KeybindingActionId,
   overrides?: KeybindingOverrides
 ): ShortcutKeyComboDetails[] {
-  const platform = getShortcutPlatform()
+  const platform = getRendererAppPlatform()
   return getEffectiveKeybindingsForAction(actionId, platform, overrides).map((binding) => ({
     keys: formatKeybinding(binding, platform),
     doubleTap: isDoubleTapBinding(binding)

--- a/src/renderer/src/lib/renderer-app-platform.test.ts
+++ b/src/renderer/src/lib/renderer-app-platform.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getRendererAppPlatform, isMacOs } from './renderer-app-platform'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getRendererAppPlatform', () => {
+  it('uses the preload-reported platform ahead of the renderer user agent', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Windows NT 10.0)' })
+    vi.stubGlobal('window', {
+      api: { platform: { get: () => ({ platform: 'darwin' as const }) } }
+    })
+
+    expect(getRendererAppPlatform()).toBe('darwin')
+    expect(isMacOs()).toBe(true)
+  })
+
+  it.each([
+    { userAgent: 'Mozilla/5.0 (Windows NT 10.0)', platform: 'win32' },
+    { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X)', platform: 'darwin' },
+    { userAgent: 'Mozilla/5.0 (X11; Linux x86_64)', platform: 'linux' }
+  ] as const)(
+    'uses the user agent when preload is unavailable: $platform',
+    ({ userAgent, platform }) => {
+      vi.stubGlobal('navigator', { userAgent })
+      vi.stubGlobal('window', undefined)
+
+      expect(getRendererAppPlatform()).toBe(platform)
+    }
+  )
+
+  it('uses the stable Windows fallback without browser globals', () => {
+    vi.stubGlobal('navigator', undefined)
+    vi.stubGlobal('window', undefined)
+
+    expect(getRendererAppPlatform()).toBe('win32')
+    expect(isMacOs()).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/renderer-app-platform.ts
+++ b/src/renderer/src/lib/renderer-app-platform.ts
@@ -16,3 +16,7 @@ export function getRendererAppPlatform(): NodeJS.Platform {
   }
   return 'win32'
 }
+
+export function isMacOs(): boolean {
+  return getRendererAppPlatform() === 'darwin'
+}

--- a/src/renderer/src/lib/screen-submit-shortcut.ts
+++ b/src/renderer/src/lib/screen-submit-shortcut.ts
@@ -1,4 +1,4 @@
-import { getShortcutPlatform } from './shortcut-platform'
+import { getRendererAppPlatform } from './renderer-app-platform'
 
 type ScreenSubmitShortcutEvent = {
   key: string
@@ -21,16 +21,16 @@ export function isScreenSubmitShortcut(event: ScreenSubmitShortcutEvent): boolea
   }
   // Why: screen submit is form-local behavior, so it stays fixed to the
   // platform convention instead of reading user-configurable app keybindings.
-  const platform = getShortcutPlatform()
+  const platform = getRendererAppPlatform()
   return platform === 'darwin'
     ? Boolean(event.metaKey) && !event.ctrlKey
     : Boolean(event.ctrlKey) && !event.metaKey
 }
 
 export function getScreenSubmitModifierLabel(): string {
-  return getShortcutPlatform() === 'darwin' ? '⌘' : 'Ctrl'
+  return getRendererAppPlatform() === 'darwin' ? '⌘' : 'Ctrl'
 }
 
 export function getScreenSubmitShortcutLabel(): string {
-  return getShortcutPlatform() === 'darwin' ? '⌘ Enter' : 'Ctrl+Enter'
+  return getRendererAppPlatform() === 'darwin' ? '⌘ Enter' : 'Ctrl+Enter'
 }

--- a/src/renderer/src/lib/shortcut-platform.ts
+++ b/src/renderer/src/lib/shortcut-platform.ts
@@ -1,6 +1,0 @@
-export function getShortcutPlatform(): NodeJS.Platform {
-  if (navigator.userAgent.includes('Mac')) {
-    return 'darwin'
-  }
-  return navigator.userAgent.includes('Windows') ? 'win32' : 'linux'
-}

--- a/src/renderer/src/lib/update-check-click-options.ts
+++ b/src/renderer/src/lib/update-check-click-options.ts
@@ -3,11 +3,7 @@ import { isMacOs } from './renderer-app-platform'
 
 type UpdateCheckClickEvent = Pick<MouseEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>
 
-function isMacShortcutPlatform(): boolean {
-  return isMacOs()
-}
-
-export function getUpdateCheckHint(isMac = isMacShortcutPlatform()): string {
+export function getUpdateCheckHint(isMac = isMacOs()): string {
   const rcClickLabel = isMac ? '⇧+click' : 'Shift+click'
   const perfClickLabel = isMac ? '⌘+click' : 'Ctrl+click'
   const releaseHints = `${rcClickLabel} checks the latest RC; ${perfClickLabel} checks the latest perf build.`
@@ -16,7 +12,7 @@ export function getUpdateCheckHint(isMac = isMacShortcutPlatform()): string {
 
 export function getUpdateCheckClickOptions(
   event: UpdateCheckClickEvent,
-  isMac = isMacShortcutPlatform()
+  isMac = isMacOs()
 ): UpdateCheckOptions {
   if (isMac && event.altKey) {
     return { localBuild: true }

--- a/src/renderer/src/lib/update-check-click-options.ts
+++ b/src/renderer/src/lib/update-check-click-options.ts
@@ -1,10 +1,10 @@
 import type { UpdateCheckOptions } from '../../../shared/types'
-import { getShortcutPlatform } from './shortcut-platform'
+import { isMacOs } from './renderer-app-platform'
 
 type UpdateCheckClickEvent = Pick<MouseEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>
 
 function isMacShortcutPlatform(): boolean {
-  return getShortcutPlatform() === 'darwin'
+  return isMacOs()
 }
 
 export function getUpdateCheckHint(isMac = isMacShortcutPlatform()): string {


### PR DESCRIPTION
## Summary

- Consolidate the renderer shared platform lookup on preload-aware `getRendererAppPlatform()`.
- Delete `shortcut-platform.ts` and migrate every direct consumer, including shortcut-label formatting and test mocks.
- Add `isMacOs()` with regression coverage for preload authority, macOS/Linux/Windows UA fallback, and no-browser-global fallback.

## Why

The two shared renderer platform modules disagreed on fallback and authority. Shortcut paths could classify a renderer from its UA even when preload reported the authoritative Electron platform.

## Scope

This is the safe shared-module slice of #10972. It deliberately does not codemod the remaining inline `navigator.userAgent.includes('Mac')` sites; those need a separate, lower-conflict follow-up.

## Screenshots

No visual change.

## Testing

- [x] Focused Vitest platform/shortcut suites — 7 files, 72 tests passed
- [x] Follow-up helper suites — 2 files, 10 tests passed
- [x] `pnpm run typecheck` — node, CLI, and web
- [x] `pnpm lint`
- [x] `pnpm exec oxfmt --check` on changed files
- [x] `git diff --check`

## AI Review Report

Reviewed the shared lookup and migrated call sites for macOS, Linux, Windows, preload-backed Electron rendering, and browser/remote rendering. Preload remains authoritative when it differs from the renderer UA; UA remains the fallback when preload is unavailable; tests/SSR without browser globals retain the stable fallback.

## Security Audit

No new input handling, command execution, filesystem, IPC, authentication, dependency, or network surface. This change only consolidates an existing platform read path.

## Notes

- The direct-module consolidation is complete; the remaining inline renderer UA checks are intentionally out of scope for this small PR.
- Validation ran on Node 22.22.3 while the package declares Node 24; all listed checks passed.