### PR TITLE
feat(mobile): default the iOS terminal command bar to autocorrect

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -133,6 +133,7 @@ import {
 } from '../../../../src/terminal/terminal-keyboard-type'
 import {
   getTerminalImeInputProps,
+  getTerminalImeRemountKey,
   isTerminalAutocorrectEnabled,
   type TerminalAutocompletePreference
 } from '../../../../src/terminal/terminal-ime-input-props'
@@ -5041,13 +5042,7 @@ export default function SessionScreen() {
                     <TextInput
                       ref={commandInputRef}
                       // Why: Android caches IME inputType at mount, so toggling autocomplete must remount there; iOS updates in place.
-                      key={
-                        Platform.OS === 'android'
-                          ? commandAutocorrect
-                            ? 'cmd-input-ac-on'
-                            : 'cmd-input-ac-off'
-                          : 'cmd-input'
-                      }
+                      key={getTerminalImeRemountKey('command', Platform.OS, autocompletePref)}
                       style={styles.textInput}
                       value={input}
                       // Why: iOS kills active dictation/IME if JS writes a value differing from native text; store raw, normalize at send.

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -51,7 +51,7 @@ import type { RpcClient } from '../../../../src/transport/rpc-client'
 import { loadHosts } from '../../../../src/transport/host-store'
 import { startRuntimeCapabilityProbe } from '../../../../src/transport/runtime-capability-probe'
 import {
-  loadTerminalAutocompleteEnabled,
+  loadTerminalAutocompletePreference,
   loadTerminalLinkOpenMode,
   loadTerminalTextScale,
   HOST_DOCK_MIN_WIDTH,
@@ -131,6 +131,11 @@ import {
   getTerminalCommandKeyboardType,
   getTerminalLiveInputKeyboardType
 } from '../../../../src/terminal/terminal-keyboard-type'
+import {
+  getTerminalImeInputProps,
+  isTerminalAutocorrectEnabled,
+  type TerminalAutocompletePreference
+} from '../../../../src/terminal/terminal-ime-input-props'
 import { normalizeTerminalTextInput } from '../../../../src/terminal/terminal-text-input-normalization'
 import {
   appendBufferedDictation,
@@ -895,7 +900,8 @@ export default function SessionScreen() {
   // Why: baseline terminal zoom reloaded on focus so a Settings → Terminal change applies in place (panes stay mounted).
   const [terminalTextScale, setTerminalTextScale] = useState(1)
   // Why: terminal command-bar autocomplete opt-in, reloaded on focus so a Settings → Terminal toggle takes effect on return.
-  const [autocompleteEnabled, setAutocompleteEnabled] = useState(false)
+  const [autocompletePref, setAutocompletePref] = useState<TerminalAutocompletePreference>('unset')
+  const commandAutocorrect = isTerminalAutocorrectEnabled('command', Platform.OS, autocompletePref)
   const [terminalLinkOpenMode, setTerminalLinkOpenMode] =
     useState<MobileTerminalLinkOpenMode>('orca-browser')
   const [liveInputCapture, setLiveInputCapture] = useState('')
@@ -2773,9 +2779,9 @@ export default function SessionScreen() {
   useFocusEffect(
     useCallback(() => {
       let active = true
-      void loadTerminalAutocompleteEnabled().then((enabled) => {
+      void loadTerminalAutocompletePreference().then((preference) => {
         if (active) {
-          setAutocompleteEnabled(enabled)
+          setAutocompletePref(preference)
         }
       })
       return () => {
@@ -5018,8 +5024,8 @@ export default function SessionScreen() {
                       placeholder=""
                       showSoftInputOnFocus
                       autoCapitalize="none"
-                      autoCorrect={false}
-                      spellCheck={false}
+                      // Why: a hardcoded false here becomes Android's NO_SUGGESTIONS inputType, which Samsung Keyboard answers by killing IME composition (#6995).
+                      {...getTerminalImeInputProps('live', Platform.OS, autocompletePref)}
                       smartInsertDelete={false}
                       // Why: iOS textContentType overrides autoComplete and can narrow the keyboard; keep IME switching available.
                       autoComplete="off"
@@ -5037,7 +5043,7 @@ export default function SessionScreen() {
                       // Why: Android caches IME inputType at mount, so toggling autocomplete must remount there; iOS updates in place.
                       key={
                         Platform.OS === 'android'
-                          ? autocompleteEnabled
+                          ? commandAutocorrect
                             ? 'cmd-input-ac-on'
                             : 'cmd-input-ac-off'
                           : 'cmd-input'
@@ -5049,15 +5055,11 @@ export default function SessionScreen() {
                       placeholder="Type a command…"
                       placeholderTextColor={colors.textMuted}
                       autoCapitalize="none"
-                      autoCorrect={autocompleteEnabled}
-                      spellCheck={autocompleteEnabled}
+                      {...getTerminalImeInputProps('command', Platform.OS, autocompletePref)}
                       smartInsertDelete={false}
                       // Why: not autofill content, but keyboard must stay default so non-Latin IMEs remain selectable.
                       autoComplete="off"
-                      keyboardType={getTerminalCommandKeyboardType(
-                        Platform.OS,
-                        autocompleteEnabled
-                      )}
+                      keyboardType={getTerminalCommandKeyboardType(Platform.OS, commandAutocorrect)}
                       returnKeyType="send"
                       editable={canSend}
                       onSubmitEditing={() => void handleSend()}

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -902,7 +902,7 @@ export default function SessionScreen() {
   const [terminalTextScale, setTerminalTextScale] = useState(1)
   // Why: terminal command-bar autocomplete opt-in, reloaded on focus so a Settings → Terminal toggle takes effect on return.
   const [autocompletePref, setAutocompletePref] = useState<TerminalAutocompletePreference>('unset')
-  const commandAutocorrect = isTerminalAutocorrectEnabled('command', Platform.OS, autocompletePref)
+  const commandAutocorrect = isTerminalAutocorrectEnabled(Platform.OS, autocompletePref)
   const [terminalLinkOpenMode, setTerminalLinkOpenMode] =
     useState<MobileTerminalLinkOpenMode>('orca-browser')
   const [liveInputCapture, setLiveInputCapture] = useState('')
@@ -5025,8 +5025,8 @@ export default function SessionScreen() {
                       placeholder=""
                       showSoftInputOnFocus
                       autoCapitalize="none"
-                      // Why: a hardcoded false here becomes Android's NO_SUGGESTIONS inputType, which Samsung Keyboard answers by killing IME composition (#6995).
-                      {...getTerminalImeInputProps('live', Platform.OS, autocompletePref)}
+                      autoCorrect={false}
+                      spellCheck={false}
                       smartInsertDelete={false}
                       // Why: iOS textContentType overrides autoComplete and can narrow the keyboard; keep IME switching available.
                       autoComplete="off"
@@ -5042,7 +5042,7 @@ export default function SessionScreen() {
                     <TextInput
                       ref={commandInputRef}
                       // Why: Android caches IME inputType at mount, so toggling autocomplete must remount there; iOS updates in place.
-                      key={getTerminalImeRemountKey('command', Platform.OS, autocompletePref)}
+                      key={getTerminalImeRemountKey(Platform.OS, autocompletePref)}
                       style={styles.textInput}
                       value={input}
                       // Why: iOS kills active dictation/IME if JS writes a value differing from native text; store raw, normalize at send.
@@ -5050,7 +5050,7 @@ export default function SessionScreen() {
                       placeholder="Type a command…"
                       placeholderTextColor={colors.textMuted}
                       autoCapitalize="none"
-                      {...getTerminalImeInputProps('command', Platform.OS, autocompletePref)}
+                      {...getTerminalImeInputProps(Platform.OS, autocompletePref)}
                       smartInsertDelete={false}
                       // Why: not autofill content, but keyboard must stay default so non-Latin IMEs remain selectable.
                       autoComplete="off"

--- a/mobile/app/terminal-settings.tsx
+++ b/mobile/app/terminal-settings.tsx
@@ -334,9 +334,12 @@ export default function TerminalSettingsScreen() {
         <Text style={[styles.groupHeading, styles.inputGroupGap]}>KEYBOARD INPUT</Text>
         <Text style={styles.groupDescription}>
           Enable phone-style autocomplete, autocorrect, and spelling suggestions in the terminal
-          command bar. {Platform.OS === 'ios' ? 'On' : 'Off'} by default. Direct keyboard input
-          (when keys go straight to the terminal) always sends raw keystrokes, so suggestions
-          don&apos;t apply there.
+          command bar.{' '}
+          {isTerminalAutocorrectEnabled('command', Platform.OS, 'unset') ? 'On' : 'Off'} by default.
+          Direct keyboard input (when keys go straight to the terminal) never autocorrects.
+          {Platform.OS === 'android'
+            ? ' On Android the keyboard may still offer suggestions you can tap — suppressing them entirely is the same setting that stops Korean and Chinese from composing, so composition wins.'
+            : ''}
         </Text>
         <View style={[styles.section, styles.sectionTopGap]}>
           <View style={styles.row}>

--- a/mobile/app/terminal-settings.tsx
+++ b/mobile/app/terminal-settings.tsx
@@ -159,7 +159,7 @@ export default function TerminalSettingsScreen() {
   // Why: the switch must show what the command bar actually does, so an unset
   // preference resolves through the same per-platform default the input uses.
   const [autocompleteEnabled, setAutocompleteEnabled] = useState(() =>
-    isTerminalAutocorrectEnabled('command', Platform.OS, 'unset')
+    isTerminalAutocorrectEnabled(Platform.OS, 'unset')
   )
   // Why: a fast toggle before the initial load resolves must win — otherwise the
   // delayed read would clobber the user's choice with the stored (stale) value.
@@ -168,7 +168,7 @@ export default function TerminalSettingsScreen() {
     let stale = false
     void loadTerminalAutocompletePreference().then((preference) => {
       if (!stale && !userToggledAutocompleteRef.current) {
-        setAutocompleteEnabled(isTerminalAutocorrectEnabled('command', Platform.OS, preference))
+        setAutocompleteEnabled(isTerminalAutocorrectEnabled(Platform.OS, preference))
       }
     })
     return () => {
@@ -334,12 +334,9 @@ export default function TerminalSettingsScreen() {
         <Text style={[styles.groupHeading, styles.inputGroupGap]}>KEYBOARD INPUT</Text>
         <Text style={styles.groupDescription}>
           Enable phone-style autocomplete, autocorrect, and spelling suggestions in the terminal
-          command bar.{' '}
-          {isTerminalAutocorrectEnabled('command', Platform.OS, 'unset') ? 'On' : 'Off'} by default.
-          Direct keyboard input (when keys go straight to the terminal) never autocorrects.
-          {Platform.OS === 'android'
-            ? ' Left untouched on Android the keyboard may still offer suggestions you can tap; turning this off suppresses them, but also stops Korean and Chinese composing.'
-            : ''}
+          command bar. {isTerminalAutocorrectEnabled(Platform.OS, 'unset') ? 'On' : 'Off'} by
+          default. Direct keyboard input (when keys go straight to the terminal) always sends raw
+          keystrokes, so suggestions don&apos;t apply there.
         </Text>
         <View style={[styles.section, styles.sectionTopGap]}>
           <View style={styles.row}>

--- a/mobile/app/terminal-settings.tsx
+++ b/mobile/app/terminal-settings.tsx
@@ -338,7 +338,7 @@ export default function TerminalSettingsScreen() {
           {isTerminalAutocorrectEnabled('command', Platform.OS, 'unset') ? 'On' : 'Off'} by default.
           Direct keyboard input (when keys go straight to the terminal) never autocorrects.
           {Platform.OS === 'android'
-            ? ' On Android the keyboard may still offer suggestions you can tap — suppressing them entirely is the same setting that stops Korean and Chinese from composing, so composition wins.'
+            ? ' Left untouched on Android the keyboard may still offer suggestions you can tap; turning this off suppresses them, but also stops Korean and Chinese composing.'
             : ''}
         </Text>
         <View style={[styles.section, styles.sectionTopGap]}>

--- a/mobile/app/terminal-settings.tsx
+++ b/mobile/app/terminal-settings.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { View, Text, StyleSheet, Pressable, Switch } from 'react-native'
+import { Platform, View, Text, StyleSheet, Pressable, Switch } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import Animated, {
@@ -18,11 +18,12 @@ import { PickerModal, type PickerOption } from '../src/components/PickerModal'
 import { TerminalShortcutSettings } from '../src/components/TerminalShortcutSettings'
 import { setTerminalAutoRestoreFitMsForHost } from '../src/terminal/terminal-auto-restore-fit-state'
 import {
-  loadTerminalAutocompleteEnabled,
+  loadTerminalAutocompletePreference,
   loadTerminalTextScale,
   saveTerminalAutocompleteEnabled,
   saveTerminalTextScale
 } from '../src/storage/preferences'
+import { isTerminalAutocorrectEnabled } from '../src/terminal/terminal-ime-input-props'
 
 type RestoreValue = 'indefinite' | '60s' | '5m' | '30m'
 
@@ -155,15 +156,19 @@ export default function TerminalSettingsScreen() {
     void saveTerminalTextScale(opt.scale)
   }, [])
 
-  const [autocompleteEnabled, setAutocompleteEnabled] = useState(false)
+  // Why: the switch must show what the command bar actually does, so an unset
+  // preference resolves through the same per-platform default the input uses.
+  const [autocompleteEnabled, setAutocompleteEnabled] = useState(() =>
+    isTerminalAutocorrectEnabled('command', Platform.OS, 'unset')
+  )
   // Why: a fast toggle before the initial load resolves must win — otherwise the
   // delayed read would clobber the user's choice with the stored (stale) value.
   const userToggledAutocompleteRef = useRef(false)
   useEffect(() => {
     let stale = false
-    void loadTerminalAutocompleteEnabled().then((enabled) => {
+    void loadTerminalAutocompletePreference().then((preference) => {
       if (!stale && !userToggledAutocompleteRef.current) {
-        setAutocompleteEnabled(enabled)
+        setAutocompleteEnabled(isTerminalAutocorrectEnabled('command', Platform.OS, preference))
       }
     })
     return () => {
@@ -329,9 +334,9 @@ export default function TerminalSettingsScreen() {
         <Text style={[styles.groupHeading, styles.inputGroupGap]}>KEYBOARD INPUT</Text>
         <Text style={styles.groupDescription}>
           Enable phone-style autocomplete, autocorrect, and spelling suggestions in the terminal
-          command bar. Off by default so the keyboard never rewrites commands, flags, or paths.
-          Direct keyboard input (when keys go straight to the terminal) always sends raw keystrokes,
-          so suggestions don&apos;t apply there.
+          command bar. {Platform.OS === 'ios' ? 'On' : 'Off'} by default. Direct keyboard input
+          (when keys go straight to the terminal) always sends raw keystrokes, so suggestions
+          don&apos;t apply there.
         </Text>
         <View style={[styles.section, styles.sectionTopGap]}>
           <View style={styles.row}>

--- a/mobile/src/storage/preferences.test.ts
+++ b/mobile/src/storage/preferences.test.ts
@@ -11,7 +11,7 @@ import {
   loadDisabledTerminalLiveInputHandles,
   loadHostSidebarWidth,
   loadPushNotificationsEnabled,
-  loadTerminalAutocompleteEnabled,
+  loadTerminalAutocompletePreference,
   loadTerminalLinkOpenMode,
   readPushNotificationsPreference,
   readDisabledTerminalLiveInputHandlesPreference,
@@ -318,27 +318,27 @@ describe('terminal autocomplete preference', () => {
     vi.mocked(AsyncStorage.setItem).mockReset()
   })
 
-  it('defaults to disabled when unset', async () => {
+  it('reports unset when nothing is persisted, so the per-platform default applies', async () => {
     vi.mocked(AsyncStorage.getItem).mockResolvedValue(null)
 
-    await expect(loadTerminalAutocompleteEnabled()).resolves.toBe(false)
+    await expect(loadTerminalAutocompletePreference()).resolves.toBe('unset')
     expect(AsyncStorage.getItem).toHaveBeenCalledWith('orca:terminalAutocompleteEnabled')
   })
 
-  it('loads enabled only from the persisted true value', async () => {
+  it('keeps an explicit choice distinguishable from unset', async () => {
     vi.mocked(AsyncStorage.getItem).mockResolvedValue('true')
 
-    await expect(loadTerminalAutocompleteEnabled()).resolves.toBe(true)
+    await expect(loadTerminalAutocompletePreference()).resolves.toBe('on')
 
     vi.mocked(AsyncStorage.getItem).mockResolvedValue('false')
 
-    await expect(loadTerminalAutocompleteEnabled()).resolves.toBe(false)
+    await expect(loadTerminalAutocompletePreference()).resolves.toBe('off')
   })
 
-  it('falls back to disabled when storage cannot be read', async () => {
+  it('falls back to unset when storage cannot be read', async () => {
     vi.mocked(AsyncStorage.getItem).mockRejectedValue(new Error('storage unavailable'))
 
-    await expect(loadTerminalAutocompleteEnabled()).resolves.toBe(false)
+    await expect(loadTerminalAutocompletePreference()).resolves.toBe('unset')
   })
 
   it('persists the selected value', async () => {

--- a/mobile/src/storage/preferences.ts
+++ b/mobile/src/storage/preferences.ts
@@ -1,4 +1,8 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import {
+  parseTerminalAutocompletePreference,
+  type TerminalAutocompletePreference
+} from '../terminal/terminal-ime-input-props'
 
 const PINS_PREFIX = 'orca:pins:'
 const NOTIF_KEY = 'orca:pushNotificationsEnabled'
@@ -63,15 +67,14 @@ export async function saveTerminalTextScale(scale: number): Promise<void> {
 
 const AUTOCOMPLETE_KEY = 'orca:terminalAutocompleteEnabled'
 
-// Why: terminal command inputs default to autocorrect/suggestions OFF so the
-// keyboard never mangles commands, flags, or paths. Users who want phone-style
-// typing opt in via Settings → Terminal; the choice persists locally per device.
-export async function loadTerminalAutocompleteEnabled(): Promise<boolean> {
+// Why: unset must stay distinguishable from an explicit off — the default is
+// per-platform (see isTerminalAutocorrectEnabled), but an explicit choice in
+// Settings → Terminal wins everywhere and persists locally per device.
+export async function loadTerminalAutocompletePreference(): Promise<TerminalAutocompletePreference> {
   try {
-    const raw = await AsyncStorage.getItem(AUTOCOMPLETE_KEY)
-    return raw === 'true'
+    return parseTerminalAutocompletePreference(await AsyncStorage.getItem(AUTOCOMPLETE_KEY))
   } catch {
-    return false
+    return 'unset'
   }
 }
 

--- a/mobile/src/terminal/terminal-ime-input-props.test.ts
+++ b/mobile/src/terminal/terminal-ime-input-props.test.ts
@@ -5,7 +5,8 @@ import {
   getTerminalImeRemountKey,
   isTerminalAutocorrectEnabled,
   parseTerminalAutocompletePreference,
-  type TerminalAutocompletePreference
+  type TerminalAutocompletePreference,
+  type TerminalImePlatform
 } from './terminal-ime-input-props'
 
 const sessionRouteSource = readFileSync(
@@ -19,6 +20,7 @@ const terminalSettingsSource = readFileSync(
 )
 
 const PREFERENCES: readonly TerminalAutocompletePreference[] = ['on', 'off', 'unset']
+const PLATFORMS: readonly TerminalImePlatform[] = ['android', 'ios', 'web', 'windows', 'macos']
 
 describe('parseTerminalAutocompletePreference', () => {
   it('keeps a missing value distinguishable from an explicit off', () => {
@@ -36,86 +38,42 @@ describe('parseTerminalAutocompletePreference', () => {
 })
 
 describe('isTerminalAutocorrectEnabled', () => {
-  it('never enables autocorrect for direct (live) entry on any platform or preference', () => {
-    for (const platform of ['android', 'ios', 'web', 'windows', 'macos'] as const) {
-      for (const preference of PREFERENCES) {
-        expect(isTerminalAutocorrectEnabled('live', platform, preference)).toBe(false)
-      }
-    }
-  })
-
-  // #4606: non-direct entry is reviewed before send, so iOS gets phone-style typing by default.
+  // #4606: command-bar entry is buffered and reviewed before send, so iOS gets
+  // phone-style typing by default.
   it('defaults command-bar autocorrect on for iOS and off elsewhere', () => {
-    expect(isTerminalAutocorrectEnabled('command', 'ios', 'unset')).toBe(true)
-    expect(isTerminalAutocorrectEnabled('command', 'android', 'unset')).toBe(false)
-    expect(isTerminalAutocorrectEnabled('command', 'web', 'unset')).toBe(false)
+    expect(isTerminalAutocorrectEnabled('ios', 'unset')).toBe(true)
+    expect(isTerminalAutocorrectEnabled('android', 'unset')).toBe(false)
+    expect(isTerminalAutocorrectEnabled('web', 'unset')).toBe(false)
+    expect(isTerminalAutocorrectEnabled('windows', 'unset')).toBe(false)
+    expect(isTerminalAutocorrectEnabled('macos', 'unset')).toBe(false)
   })
 
   it('lets an explicit preference override the per-platform default in both directions', () => {
-    expect(isTerminalAutocorrectEnabled('command', 'ios', 'off')).toBe(false)
-    expect(isTerminalAutocorrectEnabled('command', 'android', 'on')).toBe(true)
+    expect(isTerminalAutocorrectEnabled('ios', 'off')).toBe(false)
+    expect(isTerminalAutocorrectEnabled('android', 'on')).toBe(true)
   })
 })
 
 describe('getTerminalImeInputProps', () => {
-  // #6995: RN maps autoCorrect={false} to Android's NO_SUGGESTIONS inputType, and Samsung
-  // Keyboard answers that flag by disabling IME composition — Hangul arrives as raw jamo.
-  // The one deliberate exception is an explicit command-bar Off — the user asked for
-  // suppression and it is reversible. Nothing else on Android may emit the flag.
-  it('emits an explicit false autoCorrect on Android only where the user asked for it', () => {
-    for (const entryMode of ['live', 'command'] as const) {
+  it('emits autoCorrect and spellCheck together from the resolved preference', () => {
+    for (const platform of PLATFORMS) {
       for (const preference of PREFERENCES) {
-        const props = getTerminalImeInputProps(entryMode, 'android', preference)
-        expect(props.autoCorrect === false, `${entryMode}/${preference}`).toBe(
-          entryMode === 'command' && preference === 'off'
+        const enabled = isTerminalAutocorrectEnabled(platform, preference)
+        expect(getTerminalImeInputProps(platform, preference), `${platform}/${preference}`).toEqual(
+          { autoCorrect: enabled, spellCheck: enabled }
         )
       }
     }
   })
 
-  it('omits autoCorrect entirely on Android when the preference is untouched', () => {
-    expect(getTerminalImeInputProps('live', 'android', 'unset')).toEqual({})
-    expect(getTerminalImeInputProps('command', 'android', 'unset')).toEqual({})
-  })
-
-  // Otherwise Off emits the same props as untouched — a control that does nothing, with no
-  // way back to suppression. It costs IME composition, which is the point of asking.
-  it('honours an explicit Android Off instead of making the switch a no-op', () => {
-    expect(getTerminalImeInputProps('command', 'android', 'off')).toEqual({ autoCorrect: false })
-    expect(getTerminalImeInputProps('command', 'android', 'off')).not.toEqual(
-      getTerminalImeInputProps('command', 'android', 'unset')
-    )
-  })
-
-  // The toggle never claimed to govern direct entry, and #6995 was reported on the live path,
-  // so an explicit Off must not reintroduce NO_SUGGESTIONS there.
-  it('keeps Android direct entry composing even when the user turned autocorrect off', () => {
-    for (const preference of PREFERENCES) {
-      expect(getTerminalImeInputProps('live', 'android', preference)).toEqual({})
-    }
-  })
-
-  it('still opts Android into autocorrect when the user asked for it', () => {
-    expect(getTerminalImeInputProps('command', 'android', 'on')).toEqual({ autoCorrect: true })
-  })
-
-  // spellCheck is iOS-only in RN, so it must not ride along on the Android path.
-  it('keeps spellCheck off the Android props entirely', () => {
-    for (const preference of PREFERENCES) {
-      expect(
-        Object.hasOwn(getTerminalImeInputProps('command', 'android', preference), 'spellCheck')
-      ).toBe(false)
-    }
-  })
-
-  it('keeps iOS direct entry raw while defaulting the command bar to autocorrect', () => {
-    expect(getTerminalImeInputProps('live', 'ios', 'unset')).toEqual({
-      autoCorrect: false,
-      spellCheck: false
-    })
-    expect(getTerminalImeInputProps('command', 'ios', 'unset')).toEqual({
+  it('defaults the iOS command bar to autocorrect while Android stays raw (#4606)', () => {
+    expect(getTerminalImeInputProps('ios', 'unset')).toEqual({
       autoCorrect: true,
       spellCheck: true
+    })
+    expect(getTerminalImeInputProps('android', 'unset')).toEqual({
+      autoCorrect: false,
+      spellCheck: false
     })
   })
 })
@@ -131,36 +89,32 @@ function sliceBetween(source: string, startAnchor: string, endAnchor: string): s
 }
 
 describe('getTerminalImeRemountKey', () => {
-  // Android caches inputType at mount. Before the explicit-Off case existed the key tracked a
-  // boolean, which cannot distinguish {} from {autoCorrect:false} — so unset -> off would have
-  // kept the key and the user's Off would never have reached the IME.
-  it('gives every distinct Android prop shape a distinct key', () => {
-    const keys = PREFERENCES.map((preference) =>
-      getTerminalImeRemountKey('command', 'android', preference)
-    )
-    expect(new Set(keys).size).toBe(PREFERENCES.length)
-  })
-
+  // Android caches IME inputType at mount, so the key must change exactly when the emitted
+  // props change. Deriving it from the props (not a separately-maintained boolean) makes
+  // key-vs-props drift structurally impossible.
   it('changes the Android key exactly when the emitted props change', () => {
     for (const a of PREFERENCES) {
       for (const b of PREFERENCES) {
         const sameProps =
-          JSON.stringify(getTerminalImeInputProps('command', 'android', a)) ===
-          JSON.stringify(getTerminalImeInputProps('command', 'android', b))
+          JSON.stringify(getTerminalImeInputProps('android', a)) ===
+          JSON.stringify(getTerminalImeInputProps('android', b))
         const sameKey =
-          getTerminalImeRemountKey('command', 'android', a) ===
-          getTerminalImeRemountKey('command', 'android', b)
+          getTerminalImeRemountKey('android', a) === getTerminalImeRemountKey('android', b)
         expect(sameKey, `${a} vs ${b}`).toBe(sameProps)
       }
     }
   })
 
+  it('remounts the Android input when the user opts in to autocorrect', () => {
+    expect(getTerminalImeRemountKey('android', 'on')).not.toBe(
+      getTerminalImeRemountKey('android', 'unset')
+    )
+  })
+
   // iOS updates inputType in place, so remounting would only cost focus and IME state.
   it('keeps one stable key off Android so the input is never remounted', () => {
     for (const platform of ['ios', 'web', 'windows', 'macos'] as const) {
-      const keys = PREFERENCES.map((preference) =>
-        getTerminalImeRemountKey('command', platform, preference)
-      )
+      const keys = PREFERENCES.map((preference) => getTerminalImeRemountKey(platform, preference))
       expect(new Set(keys).size).toBe(1)
     }
   })
@@ -174,8 +128,7 @@ describe('getTerminalImeRemountKey', () => {
 // here and be re-pinned. Known gap: swapping the argument for a different value of the same
 // type would still pass — the unit tests above own correctness, these only own the hookup.
 describe('session route IME wiring', () => {
-  // Element-scoped, not file-scoped: ~20 other mobile fields legitimately hardcode
-  // autoCorrect={false}, and this route has non-terminal inputs of its own.
+  // Element-scoped, not file-scoped: this route has non-terminal inputs of its own.
   const liveInput = sliceBetween(
     sessionRouteSource,
     'ref={liveInputRef}',
@@ -187,32 +140,24 @@ describe('session route IME wiring', () => {
     'onSubmitEditing={() => void handleSend()}'
   )
 
-  // Guard the call sites: the pure module is only a fix if the route actually uses it.
-  it('routes both terminal inputs through the IME prop builder', () => {
-    expect(liveInput).toContain("getTerminalImeInputProps('live', Platform.OS, autocompletePref)")
-    expect(commandInput).toContain(
-      "getTerminalImeInputProps('command', Platform.OS, autocompletePref)"
-    )
+  // Guard the call site: the pure module is only a fix if the route actually uses it.
+  it('routes the command input through the IME prop builder', () => {
+    expect(commandInput).toContain('getTerminalImeInputProps(Platform.OS, autocompletePref)')
+    expect(commandInput).not.toMatch(/autoCorrect=\{/)
+    expect(commandInput).not.toMatch(/spellCheck=\{/)
   })
 
-  // #6995: a literal false on either terminal input reintroduces NO_SUGGESTIONS on Android.
-  it('hardcodes neither autoCorrect nor spellCheck on either terminal input', () => {
-    for (const [name, element] of [
-      ['live', liveInput],
-      ['command', commandInput]
-    ] as const) {
-      expect(element, `${name} input`).not.toMatch(/autoCorrect=\{(false|true)\}/)
-      expect(element, `${name} input`).not.toMatch(/spellCheck=\{(false|true)\}/)
-    }
+  // The settings copy promises direct input always sends raw keystrokes; the live input
+  // must stay hardcoded raw for that sentence to remain true.
+  it('keeps the live input hardcoded raw on every platform', () => {
+    expect(liveInput).toContain('autoCorrect={false}')
+    expect(liveInput).toContain('spellCheck={false}')
   })
 
-  // Android caches inputType at mount, so the key must derive from the emitted props. A key
-  // computed from the boolean instead cannot tell {} from {autoCorrect:false}, and an explicit
-  // Off would silently never reach the IME.
+  // Android caches inputType at mount, so the key must derive from the emitted props — a
+  // separately-maintained boolean can drift from what the input actually received.
   it('derives the command-input remount key from the emitted props, not a boolean', () => {
-    expect(commandInput).toContain(
-      "key={getTerminalImeRemountKey('command', Platform.OS, autocompletePref)}"
-    )
+    expect(commandInput).toContain('key={getTerminalImeRemountKey(Platform.OS, autocompletePref)}')
     expect(commandInput).not.toMatch(/key=\{[^}]*commandAutocorrect/)
   })
 
@@ -226,11 +171,13 @@ describe('session route IME wiring', () => {
     // Both the initial value and the post-load value must go through the resolver,
     // or the row renders a default the command bar does not actually use.
     expect(autocompleteState).not.toContain('useState(false)')
-    expect(
-      autocompleteState.match(/isTerminalAutocorrectEnabled\('command', Platform\.OS,/g)?.length
-    ).toBe(2)
+    expect(autocompleteState.match(/isTerminalAutocorrectEnabled\(Platform\.OS,/g)?.length).toBe(2)
     // ...and so must the "On/Off by default" sentence in the group description.
-    const groupDescription = sliceBetween(terminalSettingsSource, 'KEYBOARD INPUT', 'by default')
-    expect(groupDescription).toContain("isTerminalAutocorrectEnabled('command', Platform.OS,")
+    const groupDescription = sliceBetween(
+      terminalSettingsSource,
+      'KEYBOARD INPUT',
+      'Direct keyboard input'
+    )
+    expect(groupDescription).toContain('isTerminalAutocorrectEnabled(Platform.OS,')
   })
 })

--- a/mobile/src/terminal/terminal-ime-input-props.test.ts
+++ b/mobile/src/terminal/terminal-ime-input-props.test.ts
@@ -64,9 +64,6 @@ describe('getTerminalImeInputProps', () => {
       for (const preference of PREFERENCES) {
         const props = getTerminalImeInputProps(entryMode, 'android', preference)
         expect(props.autoCorrect).not.toBe(false)
-        expect(Object.hasOwn(props, 'autoCorrect')).toBe(
-          isTerminalAutocorrectEnabled(entryMode, 'android', preference)
-        )
       }
     }
   })
@@ -101,28 +98,72 @@ describe('getTerminalImeInputProps', () => {
   })
 })
 
+// Why: a slice between anchors silently runs to EOF if an anchor rots, which turns
+// every assertion below it vacuous — so a missing anchor must fail loudly instead.
+function sliceBetween(source: string, startAnchor: string, endAnchor: string): string {
+  const start = source.indexOf(startAnchor)
+  expect(start, `start anchor not found: ${startAnchor}`).toBeGreaterThan(-1)
+  const end = source.indexOf(endAnchor, start)
+  expect(end, `end anchor not found after start: ${endAnchor}`).toBeGreaterThan(-1)
+  return source.slice(start, end)
+}
+
 describe('session route IME wiring', () => {
+  // Element-scoped, not file-scoped: ~20 other mobile fields legitimately hardcode
+  // autoCorrect={false}, and this route has non-terminal inputs of its own.
+  const liveInput = sliceBetween(
+    sessionRouteSource,
+    'ref={liveInputRef}',
+    'importantForAutofill="no"'
+  )
+  const commandInput = sliceBetween(
+    sessionRouteSource,
+    'ref={commandInputRef}',
+    'onSubmitEditing={() => void handleSend()}'
+  )
+
   // Guard the call sites: the pure module is only a fix if the route actually uses it.
   it('routes both terminal inputs through the IME prop builder', () => {
-    expect(sessionRouteSource).toContain(
-      "{...getTerminalImeInputProps('live', Platform.OS, autocompletePref)}"
-    )
-    expect(sessionRouteSource).toContain(
-      "{...getTerminalImeInputProps('command', Platform.OS, autocompletePref)}"
+    expect(liveInput).toContain("getTerminalImeInputProps('live', Platform.OS, autocompletePref)")
+    expect(commandInput).toContain(
+      "getTerminalImeInputProps('command', Platform.OS, autocompletePref)"
     )
   })
 
-  it('hardcodes neither autoCorrect nor spellCheck on the terminal inputs', () => {
-    expect(sessionRouteSource).not.toContain('autoCorrect={false}')
-    expect(sessionRouteSource).not.toContain('spellCheck={false}')
-    expect(sessionRouteSource).not.toContain('autoCorrect={autocompleteEnabled}')
+  // #6995: a literal false on either terminal input reintroduces NO_SUGGESTIONS on Android.
+  it('hardcodes neither autoCorrect nor spellCheck on either terminal input', () => {
+    for (const [name, element] of [
+      ['live', liveInput],
+      ['command', commandInput]
+    ] as const) {
+      expect(element, `${name} input`).not.toMatch(/autoCorrect=\{(false|true)\}/)
+      expect(element, `${name} input`).not.toMatch(/spellCheck=\{(false|true)\}/)
+    }
+  })
+
+  // Android caches inputType at mount, so the prop shape and the remount key must flip together.
+  it('keys the Android command-input remount off the same resolved value it emits', () => {
+    expect(commandInput).toContain('commandAutocorrect')
+    expect(sessionRouteSource).toContain(
+      "isTerminalAutocorrectEnabled('command', Platform.OS, autocompletePref)"
+    )
   })
 
   // Otherwise the toggle reads "Off" on iOS while the command bar autocorrects (#4606).
-  it('resolves the settings toggle through the same per-platform default', () => {
-    expect(terminalSettingsSource).toContain("isTerminalAutocorrectEnabled('command', Platform.OS,")
-    expect(terminalSettingsSource).not.toContain(
-      'const [autocompleteEnabled, setAutocompleteEnabled] = useState(false)'
+  it('resolves the settings toggle and its copy through the same per-platform default', () => {
+    const autocompleteState = sliceBetween(
+      terminalSettingsSource,
+      'const [autocompleteEnabled, setAutocompleteEnabled]',
+      'const toggleAutocomplete'
     )
+    // Both the initial value and the post-load value must go through the resolver,
+    // or the row renders a default the command bar does not actually use.
+    expect(autocompleteState).not.toContain('useState(false)')
+    expect(
+      autocompleteState.match(/isTerminalAutocorrectEnabled\('command', Platform\.OS,/g)?.length
+    ).toBe(2)
+    // ...and so must the "On/Off by default" sentence in the group description.
+    const groupDescription = sliceBetween(terminalSettingsSource, 'KEYBOARD INPUT', 'by default')
+    expect(groupDescription).toContain("isTerminalAutocorrectEnabled('command', Platform.OS,")
   })
 })

--- a/mobile/src/terminal/terminal-ime-input-props.test.ts
+++ b/mobile/src/terminal/terminal-ime-input-props.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import {
   getTerminalImeInputProps,
+  getTerminalImeRemountKey,
   isTerminalAutocorrectEnabled,
   parseTerminalAutocompletePreference,
   type TerminalAutocompletePreference
@@ -59,18 +60,39 @@ describe('isTerminalAutocorrectEnabled', () => {
 describe('getTerminalImeInputProps', () => {
   // #6995: RN maps autoCorrect={false} to Android's NO_SUGGESTIONS inputType, and Samsung
   // Keyboard answers that flag by disabling IME composition — Hangul arrives as raw jamo.
-  it('never emits an explicit false autoCorrect on Android', () => {
+  // The one deliberate exception is an explicit command-bar Off — the user asked for
+  // suppression and it is reversible. Nothing else on Android may emit the flag.
+  it('emits an explicit false autoCorrect on Android only where the user asked for it', () => {
     for (const entryMode of ['live', 'command'] as const) {
       for (const preference of PREFERENCES) {
         const props = getTerminalImeInputProps(entryMode, 'android', preference)
-        expect(props.autoCorrect).not.toBe(false)
+        expect(props.autoCorrect === false, `${entryMode}/${preference}`).toBe(
+          entryMode === 'command' && preference === 'off'
+        )
       }
     }
   })
 
-  it('omits autoCorrect entirely on Android when suggestions stay suppressed', () => {
+  it('omits autoCorrect entirely on Android when the preference is untouched', () => {
     expect(getTerminalImeInputProps('live', 'android', 'unset')).toEqual({})
-    expect(getTerminalImeInputProps('command', 'android', 'off')).toEqual({})
+    expect(getTerminalImeInputProps('command', 'android', 'unset')).toEqual({})
+  })
+
+  // Otherwise Off emits the same props as untouched — a control that does nothing, with no
+  // way back to suppression. It costs IME composition, which is the point of asking.
+  it('honours an explicit Android Off instead of making the switch a no-op', () => {
+    expect(getTerminalImeInputProps('command', 'android', 'off')).toEqual({ autoCorrect: false })
+    expect(getTerminalImeInputProps('command', 'android', 'off')).not.toEqual(
+      getTerminalImeInputProps('command', 'android', 'unset')
+    )
+  })
+
+  // The toggle never claimed to govern direct entry, and #6995 was reported on the live path,
+  // so an explicit Off must not reintroduce NO_SUGGESTIONS there.
+  it('keeps Android direct entry composing even when the user turned autocorrect off', () => {
+    for (const preference of PREFERENCES) {
+      expect(getTerminalImeInputProps('live', 'android', preference)).toEqual({})
+    }
   })
 
   it('still opts Android into autocorrect when the user asked for it', () => {
@@ -108,6 +130,42 @@ function sliceBetween(source: string, startAnchor: string, endAnchor: string): s
   return source.slice(start, end)
 }
 
+describe('getTerminalImeRemountKey', () => {
+  // Android caches inputType at mount. Before the explicit-Off case existed the key tracked a
+  // boolean, which cannot distinguish {} from {autoCorrect:false} — so unset -> off would have
+  // kept the key and the user's Off would never have reached the IME.
+  it('gives every distinct Android prop shape a distinct key', () => {
+    const keys = PREFERENCES.map((preference) =>
+      getTerminalImeRemountKey('command', 'android', preference)
+    )
+    expect(new Set(keys).size).toBe(PREFERENCES.length)
+  })
+
+  it('changes the Android key exactly when the emitted props change', () => {
+    for (const a of PREFERENCES) {
+      for (const b of PREFERENCES) {
+        const sameProps =
+          JSON.stringify(getTerminalImeInputProps('command', 'android', a)) ===
+          JSON.stringify(getTerminalImeInputProps('command', 'android', b))
+        const sameKey =
+          getTerminalImeRemountKey('command', 'android', a) ===
+          getTerminalImeRemountKey('command', 'android', b)
+        expect(sameKey, `${a} vs ${b}`).toBe(sameProps)
+      }
+    }
+  })
+
+  // iOS updates inputType in place, so remounting would only cost focus and IME state.
+  it('keeps one stable key off Android so the input is never remounted', () => {
+    for (const platform of ['ios', 'web', 'windows', 'macos'] as const) {
+      const keys = PREFERENCES.map((preference) =>
+        getTerminalImeRemountKey('command', platform, preference)
+      )
+      expect(new Set(keys).size).toBe(1)
+    }
+  })
+})
+
 describe('session route IME wiring', () => {
   // Element-scoped, not file-scoped: ~20 other mobile fields legitimately hardcode
   // autoCorrect={false}, and this route has non-terminal inputs of its own.
@@ -141,12 +199,14 @@ describe('session route IME wiring', () => {
     }
   })
 
-  // Android caches inputType at mount, so the prop shape and the remount key must flip together.
-  it('keys the Android command-input remount off the same resolved value it emits', () => {
-    expect(commandInput).toContain('commandAutocorrect')
-    expect(sessionRouteSource).toContain(
-      "isTerminalAutocorrectEnabled('command', Platform.OS, autocompletePref)"
+  // Android caches inputType at mount, so the key must derive from the emitted props. A key
+  // computed from the boolean instead cannot tell {} from {autoCorrect:false}, and an explicit
+  // Off would silently never reach the IME.
+  it('derives the command-input remount key from the emitted props, not a boolean', () => {
+    expect(commandInput).toContain(
+      "key={getTerminalImeRemountKey('command', Platform.OS, autocompletePref)}"
     )
+    expect(commandInput).not.toMatch(/key=\{[^}]*commandAutocorrect/)
   })
 
   // Otherwise the toggle reads "Off" on iOS while the command bar autocorrects (#4606).

--- a/mobile/src/terminal/terminal-ime-input-props.test.ts
+++ b/mobile/src/terminal/terminal-ime-input-props.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import {
+  getTerminalImeInputProps,
+  isTerminalAutocorrectEnabled,
+  parseTerminalAutocompletePreference,
+  type TerminalAutocompletePreference
+} from './terminal-ime-input-props'
+
+const sessionRouteSource = readFileSync(
+  new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
+  'utf8'
+)
+
+const terminalSettingsSource = readFileSync(
+  new URL('../../app/terminal-settings.tsx', import.meta.url),
+  'utf8'
+)
+
+const PREFERENCES: readonly TerminalAutocompletePreference[] = ['on', 'off', 'unset']
+
+describe('parseTerminalAutocompletePreference', () => {
+  it('keeps a missing value distinguishable from an explicit off', () => {
+    expect(parseTerminalAutocompletePreference(null)).toBe('unset')
+    expect(parseTerminalAutocompletePreference(undefined)).toBe('unset')
+    expect(parseTerminalAutocompletePreference('false')).toBe('off')
+    expect(parseTerminalAutocompletePreference('true')).toBe('on')
+  })
+
+  it('treats unrecognized persisted values as unset rather than off', () => {
+    expect(parseTerminalAutocompletePreference('')).toBe('unset')
+    expect(parseTerminalAutocompletePreference('TRUE')).toBe('unset')
+    expect(parseTerminalAutocompletePreference('1')).toBe('unset')
+  })
+})
+
+describe('isTerminalAutocorrectEnabled', () => {
+  it('never enables autocorrect for direct (live) entry on any platform or preference', () => {
+    for (const platform of ['android', 'ios', 'web', 'windows', 'macos'] as const) {
+      for (const preference of PREFERENCES) {
+        expect(isTerminalAutocorrectEnabled('live', platform, preference)).toBe(false)
+      }
+    }
+  })
+
+  // #4606: non-direct entry is reviewed before send, so iOS gets phone-style typing by default.
+  it('defaults command-bar autocorrect on for iOS and off elsewhere', () => {
+    expect(isTerminalAutocorrectEnabled('command', 'ios', 'unset')).toBe(true)
+    expect(isTerminalAutocorrectEnabled('command', 'android', 'unset')).toBe(false)
+    expect(isTerminalAutocorrectEnabled('command', 'web', 'unset')).toBe(false)
+  })
+
+  it('lets an explicit preference override the per-platform default in both directions', () => {
+    expect(isTerminalAutocorrectEnabled('command', 'ios', 'off')).toBe(false)
+    expect(isTerminalAutocorrectEnabled('command', 'android', 'on')).toBe(true)
+  })
+})
+
+describe('getTerminalImeInputProps', () => {
+  // #6995: RN maps autoCorrect={false} to Android's NO_SUGGESTIONS inputType, and Samsung
+  // Keyboard answers that flag by disabling IME composition — Hangul arrives as raw jamo.
+  it('never emits an explicit false autoCorrect on Android', () => {
+    for (const entryMode of ['live', 'command'] as const) {
+      for (const preference of PREFERENCES) {
+        const props = getTerminalImeInputProps(entryMode, 'android', preference)
+        expect(props.autoCorrect).not.toBe(false)
+        expect(Object.hasOwn(props, 'autoCorrect')).toBe(
+          isTerminalAutocorrectEnabled(entryMode, 'android', preference)
+        )
+      }
+    }
+  })
+
+  it('omits autoCorrect entirely on Android when suggestions stay suppressed', () => {
+    expect(getTerminalImeInputProps('live', 'android', 'unset')).toEqual({})
+    expect(getTerminalImeInputProps('command', 'android', 'off')).toEqual({})
+  })
+
+  it('still opts Android into autocorrect when the user asked for it', () => {
+    expect(getTerminalImeInputProps('command', 'android', 'on')).toEqual({ autoCorrect: true })
+  })
+
+  // spellCheck is iOS-only in RN, so it must not ride along on the Android path.
+  it('keeps spellCheck off the Android props entirely', () => {
+    for (const preference of PREFERENCES) {
+      expect(
+        Object.hasOwn(getTerminalImeInputProps('command', 'android', preference), 'spellCheck')
+      ).toBe(false)
+    }
+  })
+
+  it('keeps iOS direct entry raw while defaulting the command bar to autocorrect', () => {
+    expect(getTerminalImeInputProps('live', 'ios', 'unset')).toEqual({
+      autoCorrect: false,
+      spellCheck: false
+    })
+    expect(getTerminalImeInputProps('command', 'ios', 'unset')).toEqual({
+      autoCorrect: true,
+      spellCheck: true
+    })
+  })
+})
+
+describe('session route IME wiring', () => {
+  // Guard the call sites: the pure module is only a fix if the route actually uses it.
+  it('routes both terminal inputs through the IME prop builder', () => {
+    expect(sessionRouteSource).toContain(
+      "{...getTerminalImeInputProps('live', Platform.OS, autocompletePref)}"
+    )
+    expect(sessionRouteSource).toContain(
+      "{...getTerminalImeInputProps('command', Platform.OS, autocompletePref)}"
+    )
+  })
+
+  it('hardcodes neither autoCorrect nor spellCheck on the terminal inputs', () => {
+    expect(sessionRouteSource).not.toContain('autoCorrect={false}')
+    expect(sessionRouteSource).not.toContain('spellCheck={false}')
+    expect(sessionRouteSource).not.toContain('autoCorrect={autocompleteEnabled}')
+  })
+
+  // Otherwise the toggle reads "Off" on iOS while the command bar autocorrects (#4606).
+  it('resolves the settings toggle through the same per-platform default', () => {
+    expect(terminalSettingsSource).toContain("isTerminalAutocorrectEnabled('command', Platform.OS,")
+    expect(terminalSettingsSource).not.toContain(
+      'const [autocompleteEnabled, setAutocompleteEnabled] = useState(false)'
+    )
+  })
+})

--- a/mobile/src/terminal/terminal-ime-input-props.test.ts
+++ b/mobile/src/terminal/terminal-ime-input-props.test.ts
@@ -166,6 +166,13 @@ describe('getTerminalImeRemountKey', () => {
   })
 })
 
+// These tests scan source text ON PURPOSE — please don't "fix" them by extracting the
+// matched expressions into variables. The module above is pure and fully unit-tested; what
+// it cannot prove is that the route still *calls* it. Rendering the real screen isn't a
+// viable alternative (a 5k-line route behind navigation, RPC and native deps), so these
+// guard the wiring instead. They are deliberately narrow: a rename or reflow SHOULD fail
+// here and be re-pinned. Known gap: swapping the argument for a different value of the same
+// type would still pass — the unit tests above own correctness, these only own the hookup.
 describe('session route IME wiring', () => {
   // Element-scoped, not file-scoped: ~20 other mobile fields legitimately hardcode
   // autoCorrect={false}, and this route has non-terminal inputs of its own.

--- a/mobile/src/terminal/terminal-ime-input-props.ts
+++ b/mobile/src/terminal/terminal-ime-input-props.ts
@@ -53,7 +53,32 @@ export function getTerminalImeInputProps(
     // and Samsung Keyboard answers that flag by switching IME composition off entirely —
     // Hangul then arrives as raw jamo (#6995). Omitting the prop drops the flag without
     // asking for autocorrect. spellCheck is iOS-only, so it stays off the Android path.
-    return enabled ? { autoCorrect: true } : {}
+    if (enabled) {
+      return { autoCorrect: true }
+    }
+    // Why: an Off switch that emitted the same props as untouched would be a control that
+    // does nothing, leaving no way back to suppression. Honour it with NO_SUGGESTIONS even
+    // though that costs IME composition — the user asked, and it is reversible. Only the
+    // command bar, because the toggle never claimed to govern direct entry.
+    if (preference === 'off' && entryMode === 'command') {
+      return { autoCorrect: false }
+    }
+    return {}
   }
   return { autoCorrect: enabled, spellCheck: enabled }
+}
+
+// Why: Android caches IME inputType at mount, so the remount key must change whenever the
+// emitted props change — and on Android that is a three-way split ({} vs true vs false), not
+// the boolean the key used to track. Keying off the props themselves keeps the two in step.
+export function getTerminalImeRemountKey(
+  entryMode: TerminalInputEntryMode,
+  platform: TerminalImePlatform,
+  preference: TerminalAutocompletePreference
+): string {
+  if (platform !== 'android') {
+    return `${entryMode}-input`
+  }
+  const { autoCorrect } = getTerminalImeInputProps(entryMode, platform, preference)
+  return `${entryMode}-input-ac-${autoCorrect === undefined ? 'omitted' : String(autoCorrect)}`
 }

--- a/mobile/src/terminal/terminal-ime-input-props.ts
+++ b/mobile/src/terminal/terminal-ime-input-props.ts
@@ -1,0 +1,59 @@
+export type TerminalImePlatform = 'android' | 'ios' | 'web' | 'windows' | 'macos'
+
+/** `live` streams keystrokes straight to the PTY; `command` buffers a line until send. */
+export type TerminalInputEntryMode = 'live' | 'command'
+
+/** Tri-state: `unset` still needs a per-platform default, so it can't collapse to a boolean. */
+export type TerminalAutocompletePreference = 'on' | 'off' | 'unset'
+
+export type TerminalImeInputProps = {
+  readonly autoCorrect?: boolean
+  readonly spellCheck?: boolean
+}
+
+export function parseTerminalAutocompletePreference(
+  raw: string | null | undefined
+): TerminalAutocompletePreference {
+  if (raw === 'true') {
+    return 'on'
+  }
+  if (raw === 'false') {
+    return 'off'
+  }
+  return 'unset'
+}
+
+export function isTerminalAutocorrectEnabled(
+  entryMode: TerminalInputEntryMode,
+  platform: TerminalImePlatform,
+  preference: TerminalAutocompletePreference
+): boolean {
+  // Why: direct keystrokes reach the shell with no review step, so a correction there
+  // is unrecoverable; the settings copy promises direct input always stays raw.
+  if (entryMode === 'live') {
+    return false
+  }
+  if (preference !== 'unset') {
+    return preference === 'on'
+  }
+  // Why: iOS phones are used to type agent prompts into the buffered command bar, which
+  // is reviewed before send, so autocorrect helps there (#4606). Android keeps the old
+  // default because its suggestion strip already commits inline.
+  return platform === 'ios'
+}
+
+export function getTerminalImeInputProps(
+  entryMode: TerminalInputEntryMode,
+  platform: TerminalImePlatform,
+  preference: TerminalAutocompletePreference
+): TerminalImeInputProps {
+  const enabled = isTerminalAutocorrectEnabled(entryMode, platform, preference)
+  if (platform === 'android') {
+    // Why: React Native turns autoCorrect={false} into Android's NO_SUGGESTIONS inputType,
+    // and Samsung Keyboard answers that flag by switching IME composition off entirely —
+    // Hangul then arrives as raw jamo (#6995). Omitting the prop drops the flag without
+    // asking for autocorrect. spellCheck is iOS-only, so it stays off the Android path.
+    return enabled ? { autoCorrect: true } : {}
+  }
+  return { autoCorrect: enabled, spellCheck: enabled }
+}

--- a/mobile/src/terminal/terminal-ime-input-props.ts
+++ b/mobile/src/terminal/terminal-ime-input-props.ts
@@ -1,14 +1,11 @@
 export type TerminalImePlatform = 'android' | 'ios' | 'web' | 'windows' | 'macos'
 
-/** `live` streams keystrokes straight to the PTY; `command` buffers a line until send. */
-export type TerminalInputEntryMode = 'live' | 'command'
-
 /** Tri-state: `unset` still needs a per-platform default, so it can't collapse to a boolean. */
 export type TerminalAutocompletePreference = 'on' | 'off' | 'unset'
 
 export type TerminalImeInputProps = {
-  readonly autoCorrect?: boolean
-  readonly spellCheck?: boolean
+  readonly autoCorrect: boolean
+  readonly spellCheck: boolean
 }
 
 export function parseTerminalAutocompletePreference(
@@ -24,61 +21,35 @@ export function parseTerminalAutocompletePreference(
 }
 
 export function isTerminalAutocorrectEnabled(
-  entryMode: TerminalInputEntryMode,
   platform: TerminalImePlatform,
   preference: TerminalAutocompletePreference
 ): boolean {
-  // Why: direct keystrokes reach the shell with no review step, so a correction there
-  // is unrecoverable; the settings copy promises direct input always stays raw.
-  if (entryMode === 'live') {
-    return false
-  }
   if (preference !== 'unset') {
     return preference === 'on'
   }
-  // Why: iOS phones are used to type agent prompts into the buffered command bar, which
-  // is reviewed before send, so autocorrect helps there (#4606). Android keeps the old
-  // default because its suggestion strip already commits inline.
+  // Why: iOS phones type agent prompts into the buffered command bar, which is reviewed
+  // before send, so autocorrect helps there (#4606). Everywhere else keeps the old
+  // raw-keystrokes default.
   return platform === 'ios'
 }
 
 export function getTerminalImeInputProps(
-  entryMode: TerminalInputEntryMode,
   platform: TerminalImePlatform,
   preference: TerminalAutocompletePreference
 ): TerminalImeInputProps {
-  const enabled = isTerminalAutocorrectEnabled(entryMode, platform, preference)
-  if (platform === 'android') {
-    // Why: React Native turns autoCorrect={false} into Android's NO_SUGGESTIONS inputType,
-    // and Samsung Keyboard answers that flag by switching IME composition off entirely —
-    // Hangul then arrives as raw jamo (#6995). Omitting the prop drops the flag without
-    // asking for autocorrect. spellCheck is iOS-only, so it stays off the Android path.
-    if (enabled) {
-      return { autoCorrect: true }
-    }
-    // Why: an Off switch that emitted the same props as untouched would be a control that
-    // does nothing, leaving no way back to suppression. Honour it with NO_SUGGESTIONS even
-    // though that costs IME composition — the user asked, and it is reversible. Only the
-    // command bar, because the toggle never claimed to govern direct entry.
-    if (preference === 'off' && entryMode === 'command') {
-      return { autoCorrect: false }
-    }
-    return {}
-  }
+  const enabled = isTerminalAutocorrectEnabled(platform, preference)
   return { autoCorrect: enabled, spellCheck: enabled }
 }
 
-// Why: Android caches IME inputType at mount, so the remount key must change whenever the
-// emitted props change — and on Android that is a three-way split ({} vs true vs false), not
-// the boolean the key used to track. Keying off the props themselves keeps the two in step.
+// Why: Android caches IME inputType at mount, so the remount key must change exactly when
+// the emitted props change. Deriving it from the props themselves keeps the two in step.
 export function getTerminalImeRemountKey(
-  entryMode: TerminalInputEntryMode,
   platform: TerminalImePlatform,
   preference: TerminalAutocompletePreference
 ): string {
   if (platform !== 'android') {
-    return `${entryMode}-input`
+    return 'command-input'
   }
-  const { autoCorrect } = getTerminalImeInputProps(entryMode, platform, preference)
-  return `${entryMode}-input-ac-${autoCorrect === undefined ? 'omitted' : String(autoCorrect)}`
+  const { autoCorrect } = getTerminalImeInputProps(platform, preference)
+  return `command-input-ac-${String(autoCorrect)}`
 }


### PR DESCRIPTION
Fixes #4606

## Summary

**On iPhone, the terminal command bar now enables autocorrect by default.** #4606 asked for phone-style autocorrect for non-direct entry — the buffered command bar where text is reviewed before send. Direct/live entry (keys streaming straight to the PTY) stays raw on every platform, and an explicit Settings choice wins everywhere.

> **Scope note:** an earlier revision of this PR also claimed #6995 (Android Hangul arriving as decomposed jamo) via an Android `autoCorrect`-omission change. That half was dropped: #6995 was already fixed on `main` by #7011 (4f0a141951) and #7273 (e8c2b79a93), and a physical Samsung device with Samsung Keyboard — predictive text on and off, both keyboard modes — composes Hangul correctly on a release build that does not contain the omission change. Shipping it anyway would have surfaced the suggestion strip over the invisible live-input buffer to fix something that no longer reproduces.

### What changed

- **The stored preference is tri-state** (`'on' | 'off' | 'unset'`). Collapsing to a boolean at read time made "never touched it" indistinguishable from "explicitly turned it off" — but the default is now per-platform, so `unset` has to survive to the resolution point. An explicit choice still overrides the default in both directions.
- **`unset` resolves to autocorrect on for the iOS command bar** and off everywhere else (Android and desktop keep the old raw-keystrokes default). A new pure module `mobile/src/terminal/terminal-ime-input-props.ts` owns the decision; the command input spreads its result.
- **The settings toggle and its copy resolve through the same function as the input**, so the row can't display "Off" while the command bar autocorrects — which is exactly the drift that blocked #4606.
- **The Android remount key is derived from the emitted props.** Android caches IME `inputType` at mount, so the input must remount when its IME props change. Deriving the key from the same props the input receives (instead of a separately-maintained boolean) makes key-vs-props drift structurally impossible.

<!-- user-visible-before-after:start -->
## What the user sees before and after

### Before

The iPhone buffered command bar defaults to autocorrect and spelling suggestions being off, even though it behaves like a normal text-entry field.

### After

The buffered command bar uses iPhone-style autocorrect, autocomplete, and spelling suggestions by default. Direct terminal input remains raw, and the user's explicit setting overrides the default without requiring a restart.
<!-- user-visible-before-after:end -->

## Screenshots

Exact-head iOS simulator A/B at `e2cbcb56da7289fda9e1e15e63570d062499fae8`, using the same paired device, host, terminal, and client rig. Only the Metro-served client bundle changed.

### Before and after — default behavior

The parent command bar has no QuickType prediction strip. At the PR head, the strip appears by default.

| Before — parent, suggestions absent | After — PR head, suggestions present |
| --- | --- |
| ![Parent command bar without the QuickType prediction strip](https://github.com/user-attachments/assets/2f06d806-3120-401f-ba4b-026432a3ec49) | ![PR head command bar with the QuickType prediction strip](https://github.com/user-attachments/assets/cdf289ae-1a96-48a9-a7e3-f97e62cd84e6) |

### Autocorrection works

Typing “teh” offers “the”; pressing space autocorrects the buffered command to “the ” before it is sent.

| Typed text and suggestion | Corrected buffered command |
| --- | --- |
| ![The command bar contains teh and offers the as a correction](https://github.com/user-attachments/assets/2559f8c1-b238-4852-b1ea-d0beefb51be4) | ![The command bar contains the autocorrected word the](https://github.com/user-attachments/assets/6e1582ed-51f5-4a24-80a3-ae8ac9c07c9f) |

### Explicit Off applies without restart

Turning the preference Off removes the prediction strip when returning to the same command bar without relaunching the app.

| Preference set to Off | Same session, suggestions absent |
| --- | --- |
| ![Terminal settings with Autocomplete and autocorrect set to Off](https://github.com/user-attachments/assets/169f7b26-86fc-4bba-92ca-bffe00188184) | ![Command bar without suggestions immediately after turning the preference off](https://github.com/user-attachments/assets/1e7918d4-d521-407a-bbae-1a657490f291) |

Full rig details, attribution, and caveats are recorded in `qa-device-lane-b/.qa-artifacts/QA-REPORT-LANE-B.md` Item 3.

## Testing

- [x] `pnpm lint` — clean (mobile oxlint + react-doctor oxlint, via the suite and the pre-commit hooks)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — **354 files / 2610 passed + 2 skipped**, 0 failures
- [x] `pnpm format:check` — clean
- [ ] `pnpm build` — not run locally; this is mobile-only and touches no packaged desktop code
- [x] Added or updated high-quality tests that would catch regressions

Suite vs. its own measured parent (`adc10cd21a`, re-measured in the same checkout): **354 files / 2610 passed** vs **353 / 2597** — +1 file, +13 tests.

> ⚠️ Note for reviewers: PR Checks' 16 test shards run the **root** vitest config, which excludes `mobile/**` — they gate none of these tests. The gating job is the separate **Mobile Checks** workflow.

Non-vacuity was proven by revert, not assumed — restoring each changed source file to its merge-base version breaks the suite:

| reverted file | what fails |
|---|---|
| `terminal-ime-input-props.ts` (deleted) | both test files fail to load |
| `session/[worktreeId].tsx` | 2 wiring guards (prop-builder call, props-derived remount key) |
| `terminal-settings.tsx` | 1 guard (toggle/copy must use the shared resolver) |
| `storage/preferences.ts` | 3 tri-state preference tests |

The source-text wiring guards are anchored slices scoped to the two terminal elements; a rotted anchor fails loudly (`start anchor not found: …`) rather than slicing to EOF and passing vacuously.

## AI Review Report

Brennan's same-model/same-reasoning review loop completed a fresh full pass against exact head `e2cbcb56da7289fda9e1e15e63570d062499fae8`. It found no meaningful issues, so no source change or push was needed and the exact-head simulator evidence remains current.

The pass covered tri-state migration and persistence, platform defaults, settings/input resolver agreement, Android remount behavior, direct-input raw-keystroke preservation, test non-vacuity, SSH and folder-workspace behavior, and scope. Mobile tests (354 files / 2610 passed / 2 skipped), typecheck, lint, format, and GitHub checks are green.

## Security Audit

Low risk; no auth, secrets, IPC, dependency, or command-execution surface is touched. No new dependency, no network call, no filesystem access, no shell invocation.

- **Input handling:** the live/direct input is untouched by this PR — it keeps hardcoded `autoCorrect={false}` / `spellCheck={false}`, and a wiring guard now pins that (the settings copy promises direct input always sends raw keystrokes). Autocorrect applies only to the buffered command bar, where text is reviewed before it reaches the PTY.
- **Storage:** the persisted value is a local `AsyncStorage` device preference, never transmitted. Parsing is a closed allowlist (`'true'`/`'false'`, everything else → `unset`), so a corrupted or attacker-written value degrades to the default rather than an arbitrary state.
- **Path handling / SSH / folder workspaces:** untouched; behaves identically for local, SSH, and folder-workspace sessions.

## Notes

- **Why #6995 is not in this PR:** already fixed on `main` by #7011 and #7273 (the live-text-commit / Hangul-mirror machinery), confirmed on a physical Samsung device running a build without the omission change. The `autoCorrect`-omission theory was source-correct about RN's flag mapping but did not survive device testing as a needed fix.
- **iOS autocorrect is global for the command bar**, with no tab-type distinction — #4606 asked for non-direct entry generally. Caveat: the same command bar sends shell commands in a terminal tab, and `normalizeTerminalTextInput` currently repairs only en/em dashes — smart quotes and autocorrected words are not repaired. If that proves noisy, the narrower fix is to extend normalization rather than revert the default.
- **Android behavior is unchanged** in every state: `unset`/`off` emit `autoCorrect={false}` exactly as before this PR, and `on` emits `autoCorrect={true}` as before.

