### PR TITLE
fix(build): stop `pnpm -r` from crawling the mobile workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# The desktop app is a single-project install. `mobile/` is a separate workspace
+# with its own pnpm-workspace.yaml and lockfile, so keep it out of the root
+# package graph. Without this file `pnpm -r` auto-discovers mobile/ and its
+# nested package, and the root's patchedDependencies fail as ERR_PNPM_UNUSED_PATCH.
+packages: []


### PR DESCRIPTION
## Problem

`pnpm i -r` at the repo root fails:

```
ERR_PNPM_UNUSED_PATCH  The following patches were not used:
@xterm/addon-serialize@0.15.0-beta.287, @xterm/addon-ligatures@0.11.0-beta.287,
node-pty@1.1.0, @xterm/addon-webgl@0.20.0-beta.286, @xterm/xterm@6.1.0-beta.287
```

## Cause

The repo root had no `pnpm-workspace.yaml`. With `-r`, pnpm falls back to auto-discovering projects by crawling the directory tree, so it pulls in two projects that were never meant to be part of the root install:

```
Scope: all 3 projects
  .                                    (orca)
  mobile                               (orca-mobile)
  mobile/packages/expo-two-way-audio   (@orca/expo-two-way-audio)
```

`mobile/` is an **independent** workspace — it has its own `pnpm-workspace.yaml`, its own `pnpm-lock.yaml`, and CI installs it separately via `working-directory: mobile`. Once pnpm treats it as a member of the root workspace, the root's `patchedDependencies` are validated against a package graph that includes the mobile projects, and the unused-patch check trips.

The same crawl also produced the long-standing warning that `pnpm.overrides` in `mobile/package.json` "will not take effect".

## Fix

Declare the root as an explicit single-project install:

```yaml
packages: []
```

This keeps the desktop and mobile package graphs separate — the way CI already treats them.

## Verification

| Check | Before | After |
|---|---|---|
| `pnpm i -r` (root) | `ERR_PNPM_UNUSED_PATCH` | exit 0 |
| `pnpm install --frozen-lockfile` (root) | ok | ok |
| `pnpm install --frozen-lockfile` (`mobile/`) | ok | ok |

- Neither `pnpm-lock.yaml` nor `mobile/pnpm-lock.yaml` changes (root lockfile MD5 identical before/after) — this is purely a resolution-scope fix, not a dependency change.
- Patches still apply for real, not just in the lockfile: `node_modules/node-pty/binding.gyp` has 0 occurrences of `SpectreMitigation`, confirming `config/patches/node-pty@1.1.0.patch` is applied on disk.
- `.github/workflows/win-crash-survival-e2e.yml` already lists `pnpm-workspace.yaml` in its `paths` filter and cache key, so CI anticipated this file existing.

Made with [Orca](https://github.com/stablyai/orca) 🐋
