### PR TITLE
feat(editor): add JSP syntax highlighting backed by the HTML language service

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -47,6 +47,12 @@ describe('detectLanguage', () => {
     expect(detectLanguage('C:\\Users\\alice\\.codex\\LOG.JSONL')).toBe('jsonl')
   })
 
+  it('maps .jsp/.jspf files to the dedicated jsp language id (case-insensitive)', () => {
+    expect(detectLanguage('src/main/webapp/WEB-INF/views/list.jsp')).toBe('jsp')
+    expect(detectLanguage('src/main/webapp/WEB-INF/include/header.jspf')).toBe('jsp')
+    expect(detectLanguage('views/DETAIL.JSP')).toBe('jsp')
+  })
+
   it('keeps .json/.jsonc on the built-in json language and unknown on plaintext', () => {
     expect(detectLanguage('config/settings.json')).toBe('json')
     expect(detectLanguage('config/tsconfig.jsonc')).toBe('json')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -84,6 +84,8 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.vue': 'vue',
   '.svelte': 'svelte',
   '.astro': 'astro',
+  '.jsp': 'jsp',
+  '.jspf': 'jsp',
   '.sv': 'systemverilog',
   '.svh': 'systemverilog',
   '.v': 'verilog',

--- a/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  jspHtmlModeConfiguration,
+  jspLanguageConfiguration,
+  jspMonarchLanguage,
+  registerJspLanguage
+} from './register-jsp'
+
+type MonarchAction = {
+  next?: string
+  nextEmbedded?: string
+  switchTo?: string
+}
+type MonarchRule = [RegExp, string | MonarchAction, string?] | { include: string }
+
+function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction, string?] {
+  return Array.isArray(rule)
+}
+
+function findRule(
+  state: string,
+  source: string
+): [RegExp, string | MonarchAction, string?] | undefined {
+  const tokenizer = jspMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  const matched = tokenizer[state].find((rule) => {
+    if (!isRuleEntry(rule)) {
+      return false
+    }
+    const [regexp] = rule
+    regexp.lastIndex = 0
+    const match = regexp.exec(source)
+    return match !== null && match.index === 0
+  })
+
+  return matched && isRuleEntry(matched) ? matched : undefined
+}
+
+function tokenFor(state: string, source: string): string | undefined {
+  const rule = findRule(state, source)
+  if (!rule) {
+    return undefined
+  }
+  const [, action] = rule
+  return typeof action === 'string' ? action : action.next
+}
+
+function nextStateFor(state: string, source: string): string | undefined {
+  const rule = findRule(state, source)
+  if (!rule) {
+    return undefined
+  }
+  const [, action, shortcut] = rule
+  const next = typeof action === 'object' ? (action.next ?? action.switchTo) : shortcut
+  return next?.replace(/^@/, '')
+}
+
+describe('registerJspLanguage', () => {
+  it('registers the jsp language and attaches the HTML language service once', () => {
+    const languages: { id: string }[] = [{ id: 'html' }]
+    const register = vi.fn((entry: { id: string }) => {
+      languages.push({ id: entry.id })
+    })
+    const setMonarchTokensProvider = vi.fn()
+    const setLanguageConfiguration = vi.fn()
+    const getLanguages = vi.fn(() => languages)
+    const registerHTMLLanguageService = vi.fn()
+    const monacoMock = {
+      languages: {
+        register,
+        setMonarchTokensProvider,
+        setLanguageConfiguration,
+        getLanguages
+      },
+      html: { registerHTMLLanguageService }
+    }
+
+    registerJspLanguage(monacoMock as never)
+    registerJspLanguage(monacoMock as never)
+
+    expect(register).toHaveBeenCalledTimes(1)
+    expect(register).toHaveBeenCalledWith({
+      id: 'jsp',
+      extensions: ['.jsp', '.jspf'],
+      aliases: ['JSP', 'JavaServer Pages']
+    })
+    expect(setMonarchTokensProvider).toHaveBeenCalledWith('jsp', jspMonarchLanguage)
+    expect(setLanguageConfiguration).toHaveBeenCalledWith('jsp', jspLanguageConfiguration)
+    expect(registerHTMLLanguageService).toHaveBeenCalledTimes(1)
+    expect(registerHTMLLanguageService).toHaveBeenCalledWith(
+      'jsp',
+      undefined,
+      jspHtmlModeConfiguration
+    )
+  })
+
+  it('keeps HTML diagnostics and formatting off while keeping completion on', () => {
+    expect(jspHtmlModeConfiguration.diagnostics).toBe(false)
+    expect(jspHtmlModeConfiguration.documentFormattingEdits).toBe(false)
+    expect(jspHtmlModeConfiguration.documentRangeFormattingEdits).toBe(false)
+    expect(jspHtmlModeConfiguration.completionItems).toBe(true)
+    expect(jspHtmlModeConfiguration.hovers).toBe(true)
+    expect(jspHtmlModeConfiguration.foldingRanges).toBe(true)
+  })
+
+  it('enters dedicated states for directives, scriptlets, comments and EL', () => {
+    expect(nextStateFor('root', '<%@ page contentType="text/html" %>')).toBe('jspDirective')
+    expect(nextStateFor('root', '<% int total = 0; %>')).toBe('jspScriptlet')
+    expect(nextStateFor('root', '<%= user.getName() %>')).toBe('jspScriptlet')
+    expect(nextStateFor('root', '<%-- hidden from output --%>')).toBe('jspComment')
+    expect(nextStateFor('root', '${user.name}')).toBe('elExpression')
+    expect(nextStateFor('root', '<!-- sent to the browser -->')).toBe('htmlComment')
+  })
+
+  it('treats JSTL and custom tag prefixes as tags', () => {
+    expect(tokenFor('root', '<c:if test="${ok}">')).toBe('tag')
+    expect(tokenFor('root', '</c:forEach>')).toBe('tag')
+    expect(tokenFor('root', '<my:widget />')).toBe('tag')
+    expect(tokenFor('root', '<div class="row">')).toBe('tag')
+  })
+
+  it('reads EL and scriptlets inside tag attribute values', () => {
+    expect(nextStateFor('attributeValueDouble', '${row.id}"')).toBe('elExpression')
+    expect(nextStateFor('attributeValueDouble', '<%= row.getId() %>"')).toBe('jspScriptlet')
+    expect(nextStateFor('tagRest', '${row.id}')).toBe('elExpression')
+  })
+
+  it('uses theme-backed token names for operators', () => {
+    // vs-dark defines operator.scss/sql/swift but no plain `operator`, so a
+    // bare 'operator' token would render unstyled.
+    expect(tokenFor('jspScriptlet', '>= 10')).toBe('keyword.operator')
+    expect(tokenFor('elExpression', 'ne 0')).toBe('keyword.operator')
+    expect(JSON.stringify(jspMonarchLanguage.tokenizer)).not.toContain('"operator"')
+  })
+
+  it('embeds javascript and css for script and style blocks', () => {
+    const tokenizer = jspMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+    const scriptRule = tokenizer.scriptOpen.find(
+      (rule) => isRuleEntry(rule) && typeof rule[1] === 'object'
+    )
+    const styleRule = tokenizer.styleOpen.find(
+      (rule) => isRuleEntry(rule) && typeof rule[1] === 'object'
+    )
+
+    expect(isRuleEntry(scriptRule!) && (scriptRule![1] as MonarchAction).nextEmbedded).toBe(
+      'javascript'
+    )
+    expect(isRuleEntry(styleRule!) && (styleRule![1] as MonarchAction).nextEmbedded).toBe('css')
+  })
+
+  it('excludes angle brackets from bracket pairs so comparisons do not mismatch', () => {
+    const bracketChars = [
+      ...(jspLanguageConfiguration.brackets ?? []).flat(),
+      ...(jspLanguageConfiguration.autoClosingPairs ?? []).flatMap((pair) =>
+        'open' in pair ? [pair.open, pair.close] : []
+      )
+    ]
+
+    expect(bracketChars).not.toContain('<')
+    expect(bracketChars).not.toContain('>')
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
@@ -7,6 +7,7 @@ import {
 } from './register-jsp'
 
 type MonarchAction = {
+  token?: string
   next?: string
   nextEmbedded?: string
   switchTo?: string
@@ -17,22 +18,22 @@ function isRuleEntry(rule: MonarchRule): rule is [RegExp, string | MonarchAction
   return Array.isArray(rule)
 }
 
+function rulesFor(state: string): [RegExp, string | MonarchAction, string?][] {
+  const tokenizer = jspMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
+  return tokenizer[state].flatMap((rule) =>
+    isRuleEntry(rule) ? [rule] : rulesFor(rule.include.replace(/^@/, ''))
+  )
+}
+
 function findRule(
   state: string,
   source: string
 ): [RegExp, string | MonarchAction, string?] | undefined {
-  const tokenizer = jspMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-  const matched = tokenizer[state].find((rule) => {
-    if (!isRuleEntry(rule)) {
-      return false
-    }
-    const [regexp] = rule
+  return rulesFor(state).find(([regexp]) => {
     regexp.lastIndex = 0
     const match = regexp.exec(source)
     return match !== null && match.index === 0
   })
-
-  return matched && isRuleEntry(matched) ? matched : undefined
 }
 
 function tokenFor(state: string, source: string): string | undefined {
@@ -41,7 +42,7 @@ function tokenFor(state: string, source: string): string | undefined {
     return undefined
   }
   const [, action] = rule
-  return typeof action === 'string' ? action : action.next
+  return typeof action === 'string' ? action : action.token
 }
 
 function nextStateFor(state: string, source: string): string | undefined {
@@ -52,6 +53,16 @@ function nextStateFor(state: string, source: string): string | undefined {
   const [, action, shortcut] = rule
   const next = typeof action === 'object' ? (action.next ?? action.switchTo) : shortcut
   return next?.replace(/^@/, '')
+}
+
+function matchLengthFor(state: string, source: string): number | undefined {
+  const rule = findRule(state, source)
+  if (!rule) {
+    return undefined
+  }
+  const [regexp] = rule
+  regexp.lastIndex = 0
+  return regexp.exec(source)?.[0].length
 }
 
 describe('registerJspLanguage', () => {
@@ -85,6 +96,7 @@ describe('registerJspLanguage', () => {
     })
     expect(setMonarchTokensProvider).toHaveBeenCalledWith('jsp', jspMonarchLanguage)
     expect(setLanguageConfiguration).toHaveBeenCalledWith('jsp', jspLanguageConfiguration)
+    // A second registration would create another worker and provider set.
     expect(registerHTMLLanguageService).toHaveBeenCalledTimes(1)
     expect(registerHTMLLanguageService).toHaveBeenCalledWith(
       'jsp',
@@ -93,8 +105,8 @@ describe('registerJspLanguage', () => {
     )
   })
 
-  it('keeps HTML diagnostics and formatting off while keeping completion on', () => {
-    expect(jspHtmlModeConfiguration.diagnostics).toBe(false)
+  it('keeps buffer-editing HTML features off and read-only ones on', () => {
+    expect(jspHtmlModeConfiguration.rename).toBe(false)
     expect(jspHtmlModeConfiguration.documentFormattingEdits).toBe(false)
     expect(jspHtmlModeConfiguration.documentRangeFormattingEdits).toBe(false)
     expect(jspHtmlModeConfiguration.completionItems).toBe(true)
@@ -108,20 +120,101 @@ describe('registerJspLanguage', () => {
     expect(nextStateFor('root', '<%= user.getName() %>')).toBe('jspScriptlet')
     expect(nextStateFor('root', '<%-- hidden from output --%>')).toBe('jspComment')
     expect(nextStateFor('root', '${user.name}')).toBe('elExpression')
+    expect(nextStateFor('root', '#{bean.value}')).toBe('elExpression')
     expect(nextStateFor('root', '<!-- sent to the browser -->')).toBe('htmlComment')
   })
 
-  it('treats JSTL and custom tag prefixes as tags', () => {
-    expect(tokenFor('root', '<c:if test="${ok}">')).toBe('tag')
-    expect(tokenFor('root', '</c:forEach>')).toBe('tag')
-    expect(tokenFor('root', '<my:widget />')).toBe('tag')
-    expect(tokenFor('root', '<div class="row">')).toBe('tag')
+  it('consumes the whole opening delimiter for each JSP construct', () => {
+    expect(matchLengthFor('root', '<%-- hidden --%>')).toBe(4)
+    expect(matchLengthFor('root', '<%@ page %>')).toBe(3)
+    expect(matchLengthFor('root', '<%= user.getName() %>')).toBe(3)
+    expect(matchLengthFor('root', '<%! int counter = 0; %>')).toBe(3)
+    expect(matchLengthFor('root', '<% int total = 0; %>')).toBe(2)
   })
 
-  it('reads EL and scriptlets inside tag attribute values', () => {
-    expect(nextStateFor('attributeValueDouble', '${row.id}"')).toBe('elExpression')
-    expect(nextStateFor('attributeValueDouble', '<%= row.getId() %>"')).toBe('jspScriptlet')
-    expect(nextStateFor('tagRest', '${row.id}')).toBe('elExpression')
+  it('matches namespaced tag names in full, not just the prefix', () => {
+    // The generic tag rule would stop at `<c`, so match length is what
+    // distinguishes the JSTL rule from it.
+    expect(matchLengthFor('root', '<c:if test="${ok}">')).toBe(5)
+    expect(matchLengthFor('root', '</c:forEach>')).toBe(11)
+    expect(matchLengthFor('root', '<div class="row">')).toBe(4)
+  })
+
+  it('leaves every nested state through its closing delimiter', () => {
+    expect(nextStateFor('jspDirective', '%>')).toBe('pop')
+    expect(nextStateFor('jspScriptlet', '%>')).toBe('pop')
+    expect(nextStateFor('jspComment', '--%>')).toBe('pop')
+    expect(nextStateFor('htmlComment', '-->')).toBe('pop')
+    expect(nextStateFor('javaBlockComment', '*/')).toBe('pop')
+    expect(nextStateFor('elExpression', '}')).toBe('pop')
+    expect(nextStateFor('attributeValueDouble', '" />')).toBe('pop')
+    expect(nextStateFor('attributeValueSingle', "' />")).toBe('pop')
+    expect(nextStateFor('tagRest', '>')).toBe('pop')
+    expect(nextStateFor('tagRest', '/>')).toBe('pop')
+  })
+
+  it('treats a JSP comment inside a tag as a comment, not a scriptlet', () => {
+    // Without this rule the `--%>` terminator is swallowed by the operator run
+    // and Java tokenization leaks to end of file.
+    expect(nextStateFor('tagRest', '<%-- escapeXml="false" --%> />')).toBe('jspComment')
+    expect(nextStateFor('attributeValueDouble', '<%-- x --%>"')).toBe('jspComment')
+    expect(nextStateFor('attributeValueSingle', "<%-- x --%>'")).toBe('jspComment')
+  })
+
+  it('does not let an operator run swallow the scriptlet terminator', () => {
+    expect(matchLengthFor('jspScriptlet', '++%>')).toBe(2)
+    expect(tokenFor('jspScriptlet', '% 2')).toBe('keyword.operator')
+  })
+
+  it('keeps scriptlet-looking text inert inside a JSP comment', () => {
+    expect(tokenFor('jspComment', '<% still a comment --%>')).toBe('comment')
+    expect(nextStateFor('jspComment', '<% still a comment --%>')).toBeUndefined()
+  })
+
+  it('does not close a tag on a `>` inside an attribute value', () => {
+    expect(tokenFor('attributeValueDouble', '> b">')).toBe('attribute.value')
+    expect(nextStateFor('attributeValueDouble', '> b">')).toBeUndefined()
+    expect(tokenFor('elExpression', "> b ? 'x' : 'y'}")).toBe('keyword.operator')
+  })
+
+  it('is case-sensitive for Java tokens but not for script and style tags', () => {
+    expect(jspMonarchLanguage.ignoreCase).toBeUndefined()
+    // `List list` must not colour the variable as a type.
+    expect(tokenFor('jspScriptlet', 'List list')).toBe('type')
+    expect(tokenFor('jspScriptlet', 'list = null')).toBe('identifier')
+    expect(tokenFor('jspScriptlet', 'IF (x)')).toBe('identifier')
+    expect(nextStateFor('root', '<SCRIPT type="text/javascript">')).toBe('scriptOpen')
+    expect(nextStateFor('root', '<STYLE>')).toBe('styleOpen')
+  })
+
+  it('pops the embedded language when the script or style block closes', () => {
+    const scriptRule = rulesFor('scriptBody')[0]
+    const styleRule = rulesFor('styleBody')[0]
+    const scriptAction = scriptRule[1] as MonarchAction
+    const styleAction = styleRule[1] as MonarchAction
+
+    // Monarch throws 'no rule containing nextEmbedded: "@pop"' without these.
+    expect(scriptAction.nextEmbedded).toBe('@pop')
+    expect(scriptAction.next).toBe('@pop')
+    expect(styleAction.nextEmbedded).toBe('@pop')
+    expect(styleAction.next).toBe('@pop')
+
+    expect(scriptRule[0].test('</SCRIPT >')).toBe(true)
+    expect(styleRule[0].test('</STYLE>')).toBe(true)
+  })
+
+  it('embeds javascript and css when the opening tag closes', () => {
+    const scriptOpen = rulesFor('scriptOpen').find(
+      (rule) => typeof rule[1] === 'object' && rule[1].nextEmbedded === 'javascript'
+    )
+    const styleOpen = rulesFor('styleOpen').find(
+      (rule) => typeof rule[1] === 'object' && rule[1].nextEmbedded === 'css'
+    )
+
+    expect(scriptOpen).toBeDefined()
+    expect(styleOpen).toBeDefined()
+    expect((scriptOpen?.[1] as MonarchAction | undefined)?.switchTo).toBe('@scriptBody')
+    expect((styleOpen?.[1] as MonarchAction | undefined)?.switchTo).toBe('@styleBody')
   })
 
   it('uses theme-backed token names for operators', () => {
@@ -132,19 +225,29 @@ describe('registerJspLanguage', () => {
     expect(JSON.stringify(jspMonarchLanguage.tokenizer)).not.toContain('"operator"')
   })
 
-  it('embeds javascript and css for script and style blocks', () => {
+  it('only references tokenizer states that exist', () => {
     const tokenizer = jspMonarchLanguage.tokenizer as Record<string, MonarchRule[]>
-    const scriptRule = tokenizer.scriptOpen.find(
-      (rule) => isRuleEntry(rule) && typeof rule[1] === 'object'
-    )
-    const styleRule = tokenizer.styleOpen.find(
-      (rule) => isRuleEntry(rule) && typeof rule[1] === 'object'
-    )
+    const declared = new Set(Object.keys(tokenizer))
 
-    expect(isRuleEntry(scriptRule!) && (scriptRule![1] as MonarchAction).nextEmbedded).toBe(
-      'javascript'
-    )
-    expect(isRuleEntry(styleRule!) && (styleRule![1] as MonarchAction).nextEmbedded).toBe('css')
+    Object.values(tokenizer).forEach((rules) => {
+      rules.forEach((rule) => {
+        if (!isRuleEntry(rule)) {
+          expect(declared).toContain(rule.include.replace(/^@/, ''))
+          return
+        }
+        const [, action, shortcut] = rule
+        const targets = [
+          shortcut,
+          typeof action === 'object' ? action.next : undefined,
+          typeof action === 'object' ? action.switchTo : undefined
+        ]
+        targets.forEach((target) => {
+          if (target && target !== '@pop' && target !== '@popall') {
+            expect(declared).toContain(target.replace(/^@/, ''))
+          }
+        })
+      })
+    })
   })
 
   it('excludes angle brackets from bracket pairs so comparisons do not mismatch', () => {

--- a/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.test.ts
@@ -166,6 +166,13 @@ describe('registerJspLanguage', () => {
     expect(tokenFor('jspScriptlet', '% 2')).toBe('keyword.operator')
   })
 
+  it('does not let a comment swallow the scriptlet terminator', () => {
+    // A line comment before the terminator is valid JSP: the container
+    // finds the closing delimiter first, so the comment must stop there.
+    expect(matchLengthFor('jspScriptlet', '// done %>')).toBe(8)
+    expect(matchLengthFor('javaBlockComment', ' note %> */')).toBe(6)
+  })
+
   it('keeps scriptlet-looking text inert inside a JSP comment', () => {
     expect(tokenFor('jspComment', '<% still a comment --%>')).toBe('comment')
     expect(nextStateFor('jspComment', '<% still a comment --%>')).toBeUndefined()

--- a/src/renderer/src/lib/monaco-languages/register-jsp.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.ts
@@ -57,7 +57,7 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
     // Covers `<% %>`, `<%= %>` and `<%! %>`; all three need the same Java tokens.
     jspScriptlet: [
       [/%>/, 'metatag', '@pop'],
-      [/\/\/[^\n]*/, 'comment'],
+      [/\/\/(?:(?!%>)[^\n])*/, 'comment'],
       [/\/\*/, 'comment', '@javaBlockComment'],
       [/"([^"\\]|\\.)*"/, 'string'],
       [/'([^'\\]|\\.)*'/, 'string'],
@@ -79,7 +79,7 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
 
     javaBlockComment: [
       [/\*\//, 'comment', '@pop'],
-      [/[^*]+/, 'comment'],
+      [/(?:(?!%>)[^*])+/, 'comment'],
       [/./, 'comment']
     ],
 

--- a/src/renderer/src/lib/monaco-languages/register-jsp.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.ts
@@ -1,0 +1,206 @@
+import type * as Monaco from 'monaco-editor'
+
+type MonacoModule = typeof Monaco
+
+// Why: token names must exist in Monaco's built-in themes or they render
+// unstyled. Plain `operator` is only defined as operator.scss/sql/swift in
+// vs-dark, so operators use `keyword.operator`, which falls back to `keyword`.
+export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
+  defaultToken: '',
+  tokenPostfix: '.jsp',
+  ignoreCase: true,
+  brackets: [
+    { open: '{', close: '}', token: 'delimiter.curly' },
+    { open: '[', close: ']', token: 'delimiter.square' },
+    { open: '(', close: ')', token: 'delimiter.parenthesis' }
+  ],
+  tokenizer: {
+    root: [
+      [/<%--/, 'comment', '@jspComment'],
+      [/<%@/, 'metatag', '@jspDirective'],
+      [/<%[=!]?/, 'metatag', '@jspScriptlet'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<script(?=[\s>])/, 'tag', '@scriptOpen'],
+      [/<style(?=[\s>])/, 'tag', '@styleOpen'],
+      [/<!--/, 'comment', '@htmlComment'],
+      [/<\/?[a-zA-Z][\w.-]*:[\w.-]+/, 'tag', '@tagRest'],
+      [/<\/?[a-zA-Z][\w-]*/, 'tag', '@tagRest'],
+      [/[^<$]+/, ''],
+      [/./, '']
+    ],
+
+    htmlComment: [
+      [/-->/, 'comment', '@pop'],
+      [/[^-]+/, 'comment'],
+      [/./, 'comment']
+    ],
+
+    jspComment: [
+      [/--%>/, 'comment', '@pop'],
+      [/[^-]+/, 'comment'],
+      [/./, 'comment']
+    ],
+
+    // `<%@ page contentType="..." %>` reads as markup, not as Java.
+    jspDirective: [
+      [/%>/, 'metatag', '@pop'],
+      [/[a-zA-Z_][\w.-]*(?=\s*=)/, 'attribute.name'],
+      [/[a-zA-Z_][\w.-]*/, 'keyword'],
+      [/=/, 'delimiter'],
+      [/"[^"]*"/, 'attribute.value'],
+      [/'[^']*'/, 'attribute.value'],
+      [/\s+/, 'white'],
+      [/./, '']
+    ],
+
+    jspScriptlet: [
+      [/%>/, 'metatag', '@pop'],
+      [/\/\/[^\n]*/, 'comment'],
+      [/\/\*/, 'comment', '@javaBlockComment'],
+      [/"([^"\\]|\\.)*"/, 'string'],
+      [/'([^'\\]|\\.)*'/, 'string'],
+      [/\b(?:true|false|null)\b/, 'constant'],
+      [
+        /\b(?:if|else|for|while|do|switch|case|default|break|continue|return|try|catch|finally|throw|throws|new|instanceof|import|package|class|public|private|protected|static|final)\b/,
+        'keyword'
+      ],
+      [/\b(?:int|long|short|byte|float|double|boolean|char|void|String|Object|List|Map)\b/, 'type'],
+      [/\d[\d_]*\.?[\d_]*(?:[eE][-+]?\d+)?[fFdDlL]?/, 'number'],
+      [/[{}()[\]]/, '@brackets'],
+      [/[<>=!&|+\-*/%^~?:]+/, 'keyword.operator'],
+      [/[;,.]/, 'delimiter'],
+      [/[a-zA-Z_$][\w$]*/, 'identifier'],
+      [/\s+/, 'white'],
+      [/./, '']
+    ],
+
+    javaBlockComment: [
+      [/\*\//, 'comment', '@pop'],
+      [/[^*]+/, 'comment'],
+      [/./, 'comment']
+    ],
+
+    elExpression: [
+      [/\}/, 'delimiter.curly', '@pop'],
+      [/\b(?:and|or|not|eq|ne|gt|lt|ge|le|div|mod|empty|instanceof)\b/, 'keyword.operator'],
+      [/\b(?:true|false|null)\b/, 'constant'],
+      [/"([^"\\]|\\.)*"/, 'string'],
+      [/'([^'\\]|\\.)*'/, 'string'],
+      [/\d[\d_]*\.?[\d_]*/, 'number'],
+      [/[()[\]]/, '@brackets'],
+      [/[<>=!&|+\-*/%?:]+/, 'keyword.operator'],
+      [/[,.]/, 'delimiter'],
+      [/[a-zA-Z_$][\w$]*/, 'variable'],
+      [/\s+/, 'white'],
+      [/./, '']
+    ],
+
+    // Shared by plain HTML, JSTL and custom tags: attribute values may embed
+    // both EL and scriptlet expressions.
+    tagRest: [
+      [/\/?>/, 'tag', '@pop'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%[=!]?/, 'metatag', '@jspScriptlet'],
+      [/[a-zA-Z_:][\w.:-]*(?=\s*=)/, 'attribute.name'],
+      [/[a-zA-Z_:][\w.:-]*/, 'attribute.name'],
+      [/=/, 'delimiter'],
+      [/"/, 'attribute.value', '@attributeValueDouble'],
+      [/'/, 'attribute.value', '@attributeValueSingle'],
+      [/\s+/, 'white'],
+      [/./, '']
+    ],
+
+    attributeValueDouble: [
+      [/"/, 'attribute.value', '@pop'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%[=!]?/, 'metatag', '@jspScriptlet'],
+      [/[^"$<]+/, 'attribute.value'],
+      [/./, 'attribute.value']
+    ],
+
+    attributeValueSingle: [
+      [/'/, 'attribute.value', '@pop'],
+      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%[=!]?/, 'metatag', '@jspScriptlet'],
+      [/[^'$<]+/, 'attribute.value'],
+      [/./, 'attribute.value']
+    ],
+
+    scriptOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', switchTo: '@scriptBody', nextEmbedded: 'javascript' }],
+      { include: '@tagRest' }
+    ],
+    scriptBody: [[/<\/script\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+
+    styleOpen: [
+      [/\/>/, 'tag', '@pop'],
+      [/>/, { token: 'tag', switchTo: '@styleBody', nextEmbedded: 'css' }],
+      { include: '@tagRest' }
+    ],
+    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]]
+  }
+}
+
+export const jspLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+  comments: { blockComment: ['<%--', '--%>'] },
+  brackets: [
+    ['{', '}'],
+    ['[', ']'],
+    ['(', ')']
+  ],
+  // Why: `<`/`>` are excluded because scriptlets and EL use them as comparison
+  // operators, which would produce false bracket matches.
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" }
+  ],
+  surroundingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '"', close: '"' },
+    { open: "'", close: "'" }
+  ]
+}
+
+// Why: JSP is HTML plus server-side template syntax — the same shape Monaco
+// already serves for Razor and Handlebars. Reusing the HTML language service
+// gives tag completion, hovers and folding. Diagnostics and formatting stay off
+// because that service does not understand scriptlets and would report them as
+// malformed markup.
+export const jspHtmlModeConfiguration: Monaco.html.ModeConfiguration = {
+  completionItems: true,
+  hovers: true,
+  documentSymbols: true,
+  links: true,
+  documentHighlights: true,
+  rename: true,
+  colors: true,
+  foldingRanges: true,
+  selectionRanges: true,
+  diagnostics: false,
+  documentFormattingEdits: false,
+  documentRangeFormattingEdits: false
+}
+
+export function registerJspLanguage(monaco: MonacoModule): void {
+  const jspAlreadyRegistered = monaco.languages
+    .getLanguages()
+    .some((language) => language.id === 'jsp')
+  if (jspAlreadyRegistered) {
+    return
+  }
+
+  monaco.languages.register({
+    id: 'jsp',
+    extensions: ['.jsp', '.jspf'],
+    aliases: ['JSP', 'JavaServer Pages']
+  })
+  monaco.languages.setMonarchTokensProvider('jsp', jspMonarchLanguage)
+  monaco.languages.setLanguageConfiguration('jsp', jspLanguageConfiguration)
+  monaco.html.registerHTMLLanguageService('jsp', undefined, jspHtmlModeConfiguration)
+}

--- a/src/renderer/src/lib/monaco-languages/register-jsp.ts
+++ b/src/renderer/src/lib/monaco-languages/register-jsp.ts
@@ -2,13 +2,16 @@ import type * as Monaco from 'monaco-editor'
 
 type MonacoModule = typeof Monaco
 
-// Why: token names must exist in Monaco's built-in themes or they render
-// unstyled. Plain `operator` is only defined as operator.scss/sql/swift in
-// vs-dark, so operators use `keyword.operator`, which falls back to `keyword`.
+// Why: `ignoreCase` is off because scriptlets are Java, which is case-sensitive
+// — with it on, `List list` colours the variable as a type. Monarch has no
+// per-rule casing, so the four HTML tags that genuinely need it spell it out.
+//
+// Token names must exist in the built-in themes: vs-dark defines
+// operator.scss/sql/swift but no plain `operator`, so operators use
+// `keyword.operator`, which falls back to `keyword`.
 export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
   defaultToken: '',
   tokenPostfix: '.jsp',
-  ignoreCase: true,
   brackets: [
     { open: '{', close: '}', token: 'delimiter.curly' },
     { open: '[', close: ']', token: 'delimiter.square' },
@@ -19,14 +22,13 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/<%--/, 'comment', '@jspComment'],
       [/<%@/, 'metatag', '@jspDirective'],
       [/<%[=!]?/, 'metatag', '@jspScriptlet'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
-      [/<script(?=[\s>])/, 'tag', '@scriptOpen'],
-      [/<style(?=[\s>])/, 'tag', '@styleOpen'],
+      [/[$#]\{/, 'delimiter.curly', '@elExpression'],
+      [/<[sS][cC][rR][iI][pP][tT](?=[\s>])/, 'tag', '@scriptOpen'],
+      [/<[sS][tT][yY][lL][eE](?=[\s>])/, 'tag', '@styleOpen'],
       [/<!--/, 'comment', '@htmlComment'],
       [/<\/?[a-zA-Z][\w.-]*:[\w.-]+/, 'tag', '@tagRest'],
       [/<\/?[a-zA-Z][\w-]*/, 'tag', '@tagRest'],
-      [/[^<$]+/, ''],
-      [/./, '']
+      [/[^<$#]+/, '']
     ],
 
     htmlComment: [
@@ -49,10 +51,10 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/=/, 'delimiter'],
       [/"[^"]*"/, 'attribute.value'],
       [/'[^']*'/, 'attribute.value'],
-      [/\s+/, 'white'],
-      [/./, '']
+      [/\s+/, 'white']
     ],
 
+    // Covers `<% %>`, `<%= %>` and `<%! %>`; all three need the same Java tokens.
     jspScriptlet: [
       [/%>/, 'metatag', '@pop'],
       [/\/\/[^\n]*/, 'comment'],
@@ -61,17 +63,18 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/'([^'\\]|\\.)*'/, 'string'],
       [/\b(?:true|false|null)\b/, 'constant'],
       [
-        /\b(?:if|else|for|while|do|switch|case|default|break|continue|return|try|catch|finally|throw|throws|new|instanceof|import|package|class|public|private|protected|static|final)\b/,
+        /\b(?:if|else|for|while|do|switch|case|default|break|continue|return|try|catch|finally|throw|throws|new|instanceof|import|package|class|interface|enum|extends|implements|public|private|protected|static|final|abstract|synchronized|assert|this|super)\b/,
         'keyword'
       ],
       [/\b(?:int|long|short|byte|float|double|boolean|char|void|String|Object|List|Map)\b/, 'type'],
       [/\d[\d_]*\.?[\d_]*(?:[eE][-+]?\d+)?[fFdDlL]?/, 'number'],
       [/[{}()[\]]/, '@brackets'],
-      [/[<>=!&|+\-*/%^~?:]+/, 'keyword.operator'],
+      // Why: `%` is split out with a lookahead so a run like `i++%>` cannot
+      // swallow the closing `%>` and leak Java tokenization to end of file.
+      [/%(?!>)|[<>=!&|+\-*/^~?:]+/, 'keyword.operator'],
       [/[;,.]/, 'delimiter'],
       [/[a-zA-Z_$][\w$]*/, 'identifier'],
-      [/\s+/, 'white'],
-      [/./, '']
+      [/\s+/, 'white']
     ],
 
     javaBlockComment: [
@@ -88,41 +91,43 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/'([^'\\]|\\.)*'/, 'string'],
       [/\d[\d_]*\.?[\d_]*/, 'number'],
       [/[()[\]]/, '@brackets'],
+      // `fn:length(x)` — the namespace colon is a separator, not an operator.
+      [/:(?=[a-zA-Z_])/, 'delimiter'],
       [/[<>=!&|+\-*/%?:]+/, 'keyword.operator'],
       [/[,.]/, 'delimiter'],
       [/[a-zA-Z_$][\w$]*/, 'variable'],
-      [/\s+/, 'white'],
-      [/./, '']
+      [/\s+/, 'white']
     ],
 
     // Shared by plain HTML, JSTL and custom tags: attribute values may embed
     // both EL and scriptlet expressions.
     tagRest: [
       [/\/?>/, 'tag', '@pop'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%--/, 'comment', '@jspComment'],
+      [/[$#]\{/, 'delimiter.curly', '@elExpression'],
       [/<%[=!]?/, 'metatag', '@jspScriptlet'],
-      [/[a-zA-Z_:][\w.:-]*(?=\s*=)/, 'attribute.name'],
       [/[a-zA-Z_:][\w.:-]*/, 'attribute.name'],
       [/=/, 'delimiter'],
       [/"/, 'attribute.value', '@attributeValueDouble'],
       [/'/, 'attribute.value', '@attributeValueSingle'],
-      [/\s+/, 'white'],
-      [/./, '']
+      [/\s+/, 'white']
     ],
 
     attributeValueDouble: [
       [/"/, 'attribute.value', '@pop'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%--/, 'comment', '@jspComment'],
+      [/[$#]\{/, 'delimiter.curly', '@elExpression'],
       [/<%[=!]?/, 'metatag', '@jspScriptlet'],
-      [/[^"$<]+/, 'attribute.value'],
+      [/[^"$#<]+/, 'attribute.value'],
       [/./, 'attribute.value']
     ],
 
     attributeValueSingle: [
       [/'/, 'attribute.value', '@pop'],
-      [/\$\{/, 'delimiter.curly', '@elExpression'],
+      [/<%--/, 'comment', '@jspComment'],
+      [/[$#]\{/, 'delimiter.curly', '@elExpression'],
       [/<%[=!]?/, 'metatag', '@jspScriptlet'],
-      [/[^'$<]+/, 'attribute.value'],
+      [/[^'$#<]+/, 'attribute.value'],
       [/./, 'attribute.value']
     ],
 
@@ -131,14 +136,18 @@ export const jspMonarchLanguage: Monaco.languages.IMonarchLanguage = {
       [/>/, { token: 'tag', switchTo: '@scriptBody', nextEmbedded: 'javascript' }],
       { include: '@tagRest' }
     ],
-    scriptBody: [[/<\/script\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]],
+    scriptBody: [
+      [/<\/[sS][cC][rR][iI][pP][tT]\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]
+    ],
 
     styleOpen: [
       [/\/>/, 'tag', '@pop'],
       [/>/, { token: 'tag', switchTo: '@styleBody', nextEmbedded: 'css' }],
       { include: '@tagRest' }
     ],
-    styleBody: [[/<\/style\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]]
+    styleBody: [
+      [/<\/[sS][tT][yY][lL][eE]\s*>/, { token: 'tag', next: '@pop', nextEmbedded: '@pop' }]
+    ]
   }
 }
 
@@ -168,21 +177,19 @@ export const jspLanguageConfiguration: Monaco.languages.LanguageConfiguration = 
 }
 
 // Why: JSP is HTML plus server-side template syntax — the same shape Monaco
-// already serves for Razor and Handlebars. Reusing the HTML language service
-// gives tag completion, hovers and folding. Diagnostics and formatting stay off
-// because that service does not understand scriptlets and would report them as
-// malformed markup.
+// already serves for Razor and Handlebars. Only the ten keys below are read by
+// the HTML mode. Formatting and rename are off because both act on a parse of
+// the file as HTML, and `<% ... %>` is not markup: formatting would move it and
+// rename would edit spans derived from a mis-parse.
 export const jspHtmlModeConfiguration: Monaco.html.ModeConfiguration = {
   completionItems: true,
   hovers: true,
   documentSymbols: true,
   links: true,
   documentHighlights: true,
-  rename: true,
-  colors: true,
-  foldingRanges: true,
   selectionRanges: true,
-  diagnostics: false,
+  foldingRanges: true,
+  rename: false,
   documentFormattingEdits: false,
   documentRangeFormattingEdits: false
 }
@@ -202,5 +209,7 @@ export function registerJspLanguage(monaco: MonacoModule): void {
   })
   monaco.languages.setMonarchTokensProvider('jsp', jspMonarchLanguage)
   monaco.languages.setLanguageConfiguration('jsp', jspLanguageConfiguration)
+  // Why: registering twice would create a second worker and provider set —
+  // the call has no internal dedupe — so it stays behind the guard above.
   monaco.html.registerHTMLLanguageService('jsp', undefined, jspHtmlModeConfiguration)
 }

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -9,6 +9,7 @@ import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerJsonlLanguage } from './monaco-languages/register-jsonl'
+import { registerJspLanguage } from './monaco-languages/register-jsp'
 import { registerNimLanguage } from './monaco-languages/register-nim'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
@@ -29,6 +30,7 @@ globalThis.MonacoEnvironment = {
       case 'html':
       case 'handlebars':
       case 'razor':
+      case 'jsp':
         return new htmlWorker()
       case 'typescript':
       case 'javascript':
@@ -79,6 +81,7 @@ registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
 registerJsonlLanguage(monaco)
+registerJspLanguage(monaco)
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)
 installMonacoPeekReferencesPreviewOptions()


### PR DESCRIPTION
## Summary

`.jsp` and `.jspf` files open as plaintext today — they are not in `EXT_TO_LANGUAGE`, so `detectLanguage()` returns `'plaintext'` and nothing is highlighted.

This registers a dedicated `jsp` language with a Monarch tokenizer for directives, scriptlets, expressions, EL and JSTL/custom tags, **and attaches Monaco's HTML language service to it**.

That second part is the reason this is not just another tokenizer. Monaco already serves Razor and Handlebars through `registerHTMLLanguageService` because they are "HTML plus server-side template syntax" — exactly what JSP is. Reusing it gives tag completion, hovers, document symbols and syntax-aware folding inside JSP markup, which a tokenizer-only registration silently gives up. The worker route (`case 'jsp'` in the existing html group) is required rather than optional: `MonacoEnvironment.getWorker` takes precedence over Monaco's own fallback, so without it every language-service call would reach the plain editor worker and fail.

`rename` and both formatting providers stay off. They are the ones that act on a parse of the file as HTML, and `<% ... %>` is not markup — formatting would relocate it and rename would edit spans derived from a mis-parse.

Related: **#10858 by @hwantage** addresses the same issue with a Monarch tokenizer. I read that PR before writing this, and it is what prompted me to check whether the HTML language service could be attached to a custom language id — that turned out to be the gap this PR closes. If the maintainers prefer that PR's shape, the language-service wiring here can be lifted into it and I am happy to close this one.

## Screenshots

Same `demo.jsp` opened in a build from this branch.

**Before** — `.jsp` is not in the extension table, so the file falls back to `plaintext`:

<img width="900" alt="JSP file rendered as plaintext" src="https://github.com/user-attachments/assets/fd485b69-8690-4d77-ada0-298825094768" />

**After** — directives, scriptlets, EL, JSTL tags and the embedded JS/CSS blocks are highlighted:

<img width="900" alt="JSP file with directives, scriptlets, EL and JSTL highlighted" src="https://github.com/user-attachments/assets/fda80ad0-68fd-4c69-9154-bfa73b686643" />

Verified in the running app, not only in tests: typing `<` inside markup produces HTML tag completions, and folding handles are placed on tag boundaries rather than indentation.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

The two unchecked boxes are explained under Notes.

## AI Review Report

Three independent AI review passes were run against this branch — layering/registration, tokenizer correctness, and conventions/security — each checking Monaco's own sources rather than reasoning from memory. They found four defects that are fixed in `ffaa740a2`:

- **State could leak past its terminator (two paths).** `tagRest` and both attribute-value states had no `<%--` rule, so a JSP comment inside a tag (`<c:out value="x" <%-- note --%> />`) entered the scriptlet state, where `--%>` was absorbed by the operator character class instead of closing it — Java tokenization then ran to end of file. The same class contained both `%` and `>`, so an operator run written against the terminator (`<%=i++%>`, no spaces) swallowed it. Fixed by adding the comment rule to all three states and giving `%` a negative lookahead.
- **`rename: true` edited the buffer from an untrusted parse.** It is the only enabled provider that writes, and `htmlWorker.doRename()` derives its edits from parsing the file as HTML, which scriptlets break. Turned off, which also makes the configuration internally consistent with formatting being off.
- **`ignoreCase: true` mis-coloured Java identifiers.** Carried over from the sibling Vue/Svelte/Astro modules, where it only affects HTML tag matching. JSP is the one language here that tokenizes a case-sensitive language directly, so `List list`, `Map map` and `String string` coloured the variable as a type. Turned off; the four HTML tags that genuinely need case-insensitivity spell the characters out.
- **Two mode-configuration flags were inert.** `diagnostics` and `colors` are not read by the HTML mode at all (it consumes ten keys; those two are handled only by the css and typescript modes), so an earlier revision of this PR described them as the guard against scriptlet false positives. That was wrong — the actual guard is formatting and rename staying off. The flags are removed and the comment corrected.

Tests grew from 8 to 16 as a result, covering the paths the reviews identified as unprotected: the embedded-language pop contract (Monarch throws, not just mis-colours, if it is missing), match lengths that distinguish the namespaced-tag rule from the generic one, every state's exit delimiter, and a state-reference integrity check.

Cross-platform compatibility (macOS, Linux, Windows) was explicitly checked. Nothing here branches on platform: the change is a language registration plus lookup-table entries, and extension matching already handles both path separators and casing. No keyboard shortcuts, labels, shell behavior, path utilities or Electron platform differences are touched, and nothing is specific to SSH, remote or local hosts, a particular agent, or a git provider. The HTML worker is already bundled and routed, so there is no new dependency; the worker is constructed only when a `jsp` model exists and is released after idle.

## Security Audit

No meaningful risk surface. The change registers a tokenizer and reuses an already-bundled language worker. There is no command execution, no path resolution, no IPC, no auth, no secrets and no dependency change. The tokenizer only classifies text; it never evaluates scriptlets or EL. The regex rules were reviewed individually for catastrophic backtracking — every quantifier sits on a single character class or on an alternation whose branches start with disjoint characters, so there is no nested-quantifier path, and Monarch matches within a single line regardless. No follow-up needed.

## Notes

- `pnpm lint`: oxlint and the code-quality audits pass. The chain stops later at `verify:skill-bundle-manifest`, which reports stale generated artifacts under `resources/skills/` — a pre-existing state unrelated to this change, and those files are not part of this diff.
- `pnpm test`: the full suite on a Windows machine fails a set of pre-existing tests that require a POSIX shell (`spawn /bin/sh ENOENT`); the count is unchanged by this PR. The test files touched here pass.
- Scriptlets and EL inside `<script>` blocks are not highlighted as JSP. Once the tokenizer hands the block to the embedded JavaScript tokenizer, Monarch cannot re-enter host rules — the same limitation Monaco's own HTML mode has. Worth stating explicitly because embedding `${...}` in a script block is common in real JSP.
- Registering the HTML language service twice would create a second worker and provider set — the call has no internal dedupe — so it sits behind the same guard as the language registration, and a test asserts it runs once across repeated calls.
- `mobile/src/session/mobile-file-language.ts` has a separate extension table for the mobile surface and is not touched here; it feeds a different highlighter.
