### PR TITLE
fix(tabs): stop dropping tab closes that have nowhere to route

### DIFF
--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -12,9 +12,10 @@ import {
 } from '@/runtime/web-session-tabs-sync'
 import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
 import { guardPinnedTabClose, resolvePinnedTabLabel } from '@/store/pinned-tab-close-guard'
-import type {
-  TerminalTabCloseReason,
-  TerminalTabRetirementPlan
+import {
+  classifyTerminalRetirementWorktree,
+  type TerminalTabCloseReason,
+  type TerminalTabRetirementPlan
 } from '@/store/slices/terminal-tab-retirement'
 import { closeLocalTerminalTabState } from './close-local-terminal-tab-state'
 import { getTerminalIncarnationHandle } from './terminal-close-incarnation'
@@ -73,10 +74,19 @@ export function closeTerminalTab(
     return
   }
   const { worktreeId: owningWorktreeId, terminalTabId } = target
+  // Why: an unresolved owner used to abort the whole close, so the tab strip's X did nothing at
+  // all — no prune, no error, no toast — whenever the tab's worktree row was missing from the
+  // owner catalogs (startup, a failed runtime-environment list, a removed runtime). Provider
+  // teardown already fails closed per PTY inside the retirement plan (unroutablePtyIds), so the
+  // only safe thing this gate can still add is skipping the host-directed close, never the local
+  // prune the user asked for.
   const worktreeRoute = resolveTerminalWorktreeRoute(state, owningWorktreeId)
   if (!worktreeRoute) {
-    options?.onCancel?.()
-    return
+    // Why: log the worktree SHAPE, never the id — worktree ids embed absolute paths.
+    console.warn('[terminal-close] closing locally; tab has no resolvable owner', {
+      tabId: terminalTabId,
+      worktreeKind: classifyTerminalRetirementWorktree(owningWorktreeId)
+    })
   }
 
   // Why: a pinned tab routes through the confirmation guard instead of closing
@@ -101,7 +111,7 @@ export function closeTerminalTab(
     return
   }
 
-  const runtimeEnvironmentId = worktreeRoute.runtimeEnvironmentId
+  const runtimeEnvironmentId = worktreeRoute?.runtimeEnvironmentId ?? null
   if (runtimeEnvironmentId && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
     if (options?.reason === 'pty-exit') {
       // Why: stream exit is not host-tab closure; the HUB snapshot decides whether reconnect restores or removes this tab.
@@ -233,11 +243,10 @@ export function activateTerminalTab(tabId: string): void {
     Object.entries(s.tabsByWorktree).find(([, worktreeTabs]) =>
       worktreeTabs.some((tab) => tab.id === tabId)
     )?.[0] ?? null
+  // Why: same fail-closed shape as the close path — an unresolved owner must only skip the
+  // host-directed activation, never the local selection the user just clicked.
   const worktreeRoute = resolveTerminalWorktreeRoute(s, owningWorktreeId)
-  if (!worktreeRoute) {
-    return
-  }
-  const runtimeEnvironmentId = worktreeRoute.runtimeEnvironmentId
+  const runtimeEnvironmentId = worktreeRoute?.runtimeEnvironmentId ?? null
   if (owningWorktreeId && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
     // Why: activation needs to update the host's active tab as well as the
     // local optimistic state, otherwise the next host snapshot snaps back.

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -243,11 +243,16 @@ export function activateTerminalTab(tabId: string): void {
     Object.entries(s.tabsByWorktree).find(([, worktreeTabs]) =>
       worktreeTabs.some((tab) => tab.id === tabId)
     )?.[0] ?? null
+  // Why this stays a hard return: no owning worktree means the tab is in no strip at all, so
+  // there is nothing to select — distinct from an owner that exists but cannot be routed.
+  if (!owningWorktreeId) {
+    return
+  }
   // Why: same fail-closed shape as the close path — an unresolved owner must only skip the
   // host-directed activation, never the local selection the user just clicked.
   const worktreeRoute = resolveTerminalWorktreeRoute(s, owningWorktreeId)
   const runtimeEnvironmentId = worktreeRoute?.runtimeEnvironmentId ?? null
-  if (owningWorktreeId && isWebRuntimeSessionActive(runtimeEnvironmentId)) {
+  if (isWebRuntimeSessionActive(runtimeEnvironmentId)) {
     // Why: activation needs to update the host's active tab as well as the
     // local optimistic state, otherwise the next host snapshot snaps back.
     void activateWebRuntimeSessionTab({

--- a/src/renderer/src/components/terminal/terminal-tab-close-unrouted-owner.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-close-unrouted-owner.test.ts
@@ -131,4 +131,23 @@ describe('closing a terminal tab whose worktree owner cannot be resolved', () =>
     expect(setActiveTab).toHaveBeenCalledWith('tab-1')
     expect(setActiveTabType).toHaveBeenCalledWith('terminal')
   })
+
+  // Why: relaxing the route guard must not also relax the existence check. A tab in no worktree's
+  // strip has nothing to select, and activating it would point the app at a tab that renders nothing.
+  it('does not activate a tab that belongs to no worktree at all', () => {
+    const setActiveTab = vi.fn()
+    const setActiveTabType = vi.fn()
+    getStateMock.mockReturnValue(
+      unroutableOwnerState({
+        tabsByWorktree: { [WORKTREE_ID]: [{ id: 'tab-1' }] },
+        setActiveTab,
+        setActiveTabType
+      })
+    )
+
+    activateTerminalTab('tab-vanished')
+
+    expect(setActiveTab).not.toHaveBeenCalled()
+    expect(setActiveTabType).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/terminal/terminal-tab-close-unrouted-owner.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-close-unrouted-owner.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { closeWebRuntimeSessionTabMock, getStateMock } = vi.hoisted(() => ({
+  closeWebRuntimeSessionTabMock: vi.fn(),
+  getStateMock: vi.fn()
+}))
+
+vi.mock('@/store', () => ({ useAppStore: { getState: getStateMock } }))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  activateWebRuntimeSessionTab: vi.fn(),
+  closeWebRuntimeSessionTab: closeWebRuntimeSessionTabMock,
+  createWebRuntimeSessionTerminal: vi.fn(),
+  isWebRuntimeSessionActive: vi.fn(() => false),
+  isWebTerminalSurfaceTabId: vi.fn(() => false),
+  toHostSessionTabId: vi.fn((tabId: string) => tabId)
+}))
+
+vi.mock('@/runtime/web-session-tabs-sync', () => ({
+  getLatestWebSessionTabsPublicationEpoch: vi.fn(() => null),
+  resolveHostSessionTabIdForWebSessionTab: vi.fn(() => null)
+}))
+
+import { activateTerminalTab, closeTerminalTab } from './terminal-tab-actions'
+
+const WORKTREE_ID = 'repo-1::/Users/me/code/repo-1'
+
+/**
+ * The owner catalogs are present but hold no row for this worktree, and a saved runtime
+ * environment blocks the legacy-local fallback — the state Orca is in during startup hydration,
+ * after a failed `runtimeEnvironments.list()`, and while a repo's worktree scan is still pending.
+ */
+function unroutableOwnerState(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    settings: { activeRuntimeEnvironmentId: null },
+    repos: [{ id: 'repo-1', connectionId: null, executionHostId: undefined }],
+    worktreesByRepo: {},
+    detectedWorktreesByRepo: {},
+    runtimeEnvironments: [{ id: 'env-1' }],
+    runtimeEnvironmentCatalogHydrated: true,
+    removedRuntimeEnvironmentIds: new Set<string>(),
+    unifiedTabsByWorktree: {},
+    openFiles: [],
+    browserTabsByWorktree: {},
+    setActiveTab: vi.fn(),
+    setActiveTabType: vi.fn(),
+    setActiveWorktree: vi.fn(),
+    setActiveFile: vi.fn(),
+    setActiveBrowserTab: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('closing a terminal tab whose worktree owner cannot be resolved', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  it('still prunes the tab instead of ignoring the close', () => {
+    const closeTab = vi.fn()
+    const onClosed = vi.fn()
+    const onCancel = vi.fn()
+    getStateMock.mockReturnValue(
+      unroutableOwnerState({
+        tabsByWorktree: { [WORKTREE_ID]: [{ id: 'tab-1' }, { id: 'tab-2' }] },
+        activeWorktreeId: WORKTREE_ID,
+        activeTabId: 'tab-1',
+        closeTab
+      })
+    )
+
+    closeTerminalTab('tab-1', { onClosed, onCancel })
+
+    expect(closeTab).toHaveBeenCalledWith('tab-1')
+    expect(onClosed).toHaveBeenCalledTimes(1)
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('skips the host-directed close, which is the only part the missing owner invalidates', () => {
+    getStateMock.mockReturnValue(
+      unroutableOwnerState({
+        tabsByWorktree: { [WORKTREE_ID]: [{ id: 'tab-1' }] },
+        activeWorktreeId: WORKTREE_ID,
+        activeTabId: 'tab-1',
+        closeTab: vi.fn()
+      })
+    )
+
+    closeTerminalTab('tab-1')
+
+    expect(closeWebRuntimeSessionTabMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps honoring the pinned-tab confirmation guard', () => {
+    const closeTab = vi.fn()
+    const onCancel = vi.fn()
+    getStateMock.mockReturnValue(
+      unroutableOwnerState({
+        tabsByWorktree: { [WORKTREE_ID]: [{ id: 'tab-1' }] },
+        unifiedTabsByWorktree: {
+          [WORKTREE_ID]: [
+            { id: 'tab-1', entityId: 'tab-1', contentType: 'terminal', isPinned: true }
+          ]
+        },
+        activeWorktreeId: WORKTREE_ID,
+        activeTabId: 'tab-1',
+        closeTab
+      })
+    )
+
+    closeTerminalTab('tab-1', { rejectPinned: true, onCancel })
+
+    expect(closeTab).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('still selects the tab on activation', () => {
+    const setActiveTab = vi.fn()
+    const setActiveTabType = vi.fn()
+    getStateMock.mockReturnValue(
+      unroutableOwnerState({
+        tabsByWorktree: { [WORKTREE_ID]: [{ id: 'tab-1' }] },
+        setActiveTab,
+        setActiveTabType
+      })
+    )
+
+    activateTerminalTab('tab-1')
+
+    expect(setActiveTab).toHaveBeenCalledWith('tab-1')
+    expect(setActiveTabType).toHaveBeenCalledWith('terminal')
+  })
+})

--- a/src/renderer/src/store/slices/tab-group-state.test.ts
+++ b/src/renderer/src/store/slices/tab-group-state.test.ts
@@ -7,6 +7,7 @@ import {
   pickNeighbor,
   pickNextActiveTab,
   pushRecentTabId,
+  reconstructGroupForOrphanedTab,
   sanitizeRecentTabIds,
   updateGroup,
   patchTab
@@ -146,6 +147,44 @@ describe('pickNextActiveTab', () => {
 
   it('falls back to left neighbor when closing the rightmost and MRU is empty', () => {
     expect(pickNextActiveTab(['a', 'b', 'c'], undefined, 'c')).toBe('b')
+  })
+})
+
+describe('reconstructGroupForOrphanedTab', () => {
+  // Why: `tabOrder` is documented as canonical *visual* order, but reordering rewrites sortOrder in
+  // place without moving the array element — so building it from array order would be wrong for any
+  // group the user has ever dragged. The current caller discards this order, which is exactly why
+  // it needs pinning here: the contract, not the caller, is what a future caller will rely on.
+  it('orders the stand-in group visually, not by backing-array position', () => {
+    const tabs = [
+      makeTab({ id: 'c', worktreeId: 'w1', groupId: 'gone', sortOrder: 2 }),
+      makeTab({ id: 'a', worktreeId: 'w1', groupId: 'gone', sortOrder: 0 }),
+      makeTab({ id: 'b', worktreeId: 'w1', groupId: 'gone', sortOrder: 1 })
+    ]
+
+    const group = reconstructGroupForOrphanedTab(tabs, 'w1', tabs[1])
+
+    expect(group.tabOrder).toEqual(['a', 'b', 'c'])
+    expect(group.id).toBe('gone')
+    expect(group.activeTabId).toBe('a')
+  })
+
+  it('breaks a sortOrder tie by creation time', () => {
+    const tabs = [
+      makeTab({ id: 'newer', worktreeId: 'w1', groupId: 'gone', sortOrder: 0, createdAt: 200 }),
+      makeTab({ id: 'older', worktreeId: 'w1', groupId: 'gone', sortOrder: 0, createdAt: 100 })
+    ]
+
+    expect(reconstructGroupForOrphanedTab(tabs, 'w1', tabs[0]).tabOrder).toEqual(['older', 'newer'])
+  })
+
+  it('ignores tabs belonging to other groups', () => {
+    const tabs = [
+      makeTab({ id: 'mine', worktreeId: 'w1', groupId: 'gone', sortOrder: 1 }),
+      makeTab({ id: 'theirs', worktreeId: 'w1', groupId: 'other', sortOrder: 0 })
+    ]
+
+    expect(reconstructGroupForOrphanedTab(tabs, 'w1', tabs[0]).tabOrder).toEqual(['mine'])
   })
 })
 

--- a/src/renderer/src/store/slices/tab-group-state.ts
+++ b/src/renderer/src/store/slices/tab-group-state.ts
@@ -23,6 +23,23 @@ export function findGroupForTab(
   return groups.find((g) => g.id === groupId) ?? null
 }
 
+/** Stand-in group for a tab whose group record is missing, rebuilt from the tabs still pointing at
+ *  that id. Lets a close finish instead of dead-ending on the lookup; never persisted. */
+export function reconstructGroupForOrphanedTab(
+  tabs: readonly Tab[],
+  worktreeId: string,
+  tab: Tab
+): TabGroup {
+  return {
+    id: tab.groupId,
+    worktreeId,
+    activeTabId: tab.id,
+    tabOrder: tabs
+      .filter((candidate) => candidate.groupId === tab.groupId)
+      .map((candidate) => candidate.id)
+  }
+}
+
 export function findGroupAndWorktree(
   groupsByWorktree: Record<string, TabGroup[]>,
   groupId: string

--- a/src/renderer/src/store/slices/tab-group-state.ts
+++ b/src/renderer/src/store/slices/tab-group-state.ts
@@ -34,8 +34,14 @@ export function reconstructGroupForOrphanedTab(
     id: tab.groupId,
     worktreeId,
     activeTabId: tab.id,
+    // Why sorted, not backing-array order: reordering a tab rewrites `sortOrder` in place
+    // (applyTabOrderSortValues) without moving the array element, so the array stops matching
+    // visual order — and this tabOrder is what neighbor selection walks when the active tab closes.
     tabOrder: tabs
       .filter((candidate) => candidate.groupId === tab.groupId)
+      .toSorted(
+        (left, right) => left.sortOrder - right.sortOrder || left.createdAt - right.createdAt
+      )
       .map((candidate) => candidate.id)
   }
 }

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -22,6 +22,7 @@ import {
   patchTab,
   pickNextActiveTab,
   pushRecentTabId,
+  reconstructGroupForOrphanedTab,
   sanitizeRecentTabIds,
   updateGroup
 } from './tab-group-state'
@@ -888,10 +889,15 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       return null
     }
     const { tab, worktreeId } = found
-    const group = findGroupForTab(state.groupsByWorktree, worktreeId, tab.groupId)
-    if (!group) {
-      return null
-    }
+    const groupRecord = findGroupForTab(state.groupsByWorktree, worktreeId, tab.groupId)
+    // Why: a tab whose group record is gone (host snapshot desync, or a collapse that dropped the
+    // group while the tab still pointed at it) used to dead-end here, and every close path funnels
+    // through this action — so the tab stayed in the strip forever, unclosable even across
+    // restarts. Rebuild a stand-in group from the tabs that still reference the id so the close
+    // completes; the phantom group is never written back to `groupsByWorktree`.
+    const group =
+      groupRecord ??
+      reconstructGroupForOrphanedTab(state.unifiedTabsByWorktree[worktreeId] ?? [], worktreeId, tab)
 
     if (tab.contentType === 'terminal' && !opts?.terminalRetirementHandled) {
       const dedupedGroupOrder = dedupeTabOrder(group.tabOrder)
@@ -950,6 +956,19 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         )
         nextLayoutByWorktree = collapsedState.layoutByWorktree
         nextActiveGroupIdByWorktree = collapsedState.activeGroupIdByWorktree
+      }
+      // Why: the tab strip renders `activeGroupIdByWorktree`'s group, so a phantom id left pointing
+      // at nothing would render empty once its last orphan closes even though real groups remain.
+      if (
+        !groupRecord &&
+        nextActiveGroupIdByWorktree[worktreeId] === group.id &&
+        !nextTabs.some((item) => item.groupId === group.id) &&
+        nextGroups.length > 0
+      ) {
+        nextActiveGroupIdByWorktree = {
+          ...nextActiveGroupIdByWorktree,
+          [worktreeId]: nextGroups[0].id
+        }
       }
       const shouldDeactivateWorktree =
         current.activeWorktreeId === worktreeId &&

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -965,9 +965,15 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
         !nextTabs.some((item) => item.groupId === group.id) &&
         nextGroups.length > 0
       ) {
+        // Why prefer a populated group: nextGroups[0] can itself be an empty split, which would
+        // re-create the very empty strip this branch exists to avoid. Same policy as
+        // selectHydratedActiveGroupId.
+        const repointTarget =
+          nextGroups.find((candidate) => nextTabs.some((item) => item.groupId === candidate.id)) ??
+          nextGroups[0]
         nextActiveGroupIdByWorktree = {
           ...nextActiveGroupIdByWorktree,
-          [worktreeId]: nextGroups[0].id
+          [worktreeId]: repointTarget.id
         }
       }
       const shouldDeactivateWorktree =

--- a/src/renderer/src/store/slices/unified-tab-orphaned-group-close.test.ts
+++ b/src/renderer/src/store/slices/unified-tab-orphaned-group-close.test.ts
@@ -84,6 +84,37 @@ describe('closeUnifiedTab with a missing group record', () => {
     ])
   })
 
+  // Why: nextGroups[0] can be an empty split, which re-creates the empty strip this repoint exists
+  // to prevent.
+  it('repoints at a group that actually has tabs rather than the first empty split', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    store.setState({
+      unifiedTabsByWorktree: {
+        [WORKTREE_ID]: [
+          makeUnifiedTab({ id: 'tab-1', worktreeId: WORKTREE_ID, groupId: PHANTOM_GROUP_ID }),
+          makeUnifiedTab({ id: 'tab-2', worktreeId: WORKTREE_ID, groupId: 'group-populated' })
+        ]
+      },
+      groupsByWorktree: {
+        [WORKTREE_ID]: [
+          makeTabGroup({ id: 'group-empty', worktreeId: WORKTREE_ID, tabOrder: [] }),
+          makeTabGroup({
+            id: 'group-populated',
+            worktreeId: WORKTREE_ID,
+            activeTabId: 'tab-2',
+            tabOrder: ['tab-2']
+          })
+        ]
+      },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: PHANTOM_GROUP_ID }
+    })
+
+    store.getState().closeUnifiedTab('tab-1')
+
+    expect(store.getState().activeGroupIdByWorktree[WORKTREE_ID]).toBe('group-populated')
+  })
+
   it('leaves a live group record untouched', () => {
     const store = createTestStore()
     seedWorktree(store)

--- a/src/renderer/src/store/slices/unified-tab-orphaned-group-close.test.ts
+++ b/src/renderer/src/store/slices/unified-tab-orphaned-group-close.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { createTestStore, makeTabGroup, makeUnifiedTab, makeWorktree } from './store-test-helpers'
+
+const WORKTREE_ID = 'repo1::/path/wt1'
+const PHANTOM_GROUP_ID = 'group-that-vanished'
+
+function seedWorktree(store: ReturnType<typeof createTestStore>): void {
+  store.setState({
+    worktreesByRepo: {
+      repo1: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1', path: '/path/wt1' })]
+    }
+  })
+}
+
+describe('closeUnifiedTab with a missing group record', () => {
+  it('closes a tab whose group record is gone instead of leaving it in the strip', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    store.setState({
+      unifiedTabsByWorktree: {
+        [WORKTREE_ID]: [
+          makeUnifiedTab({ id: 'tab-1', worktreeId: WORKTREE_ID, groupId: PHANTOM_GROUP_ID }),
+          makeUnifiedTab({ id: 'tab-2', worktreeId: WORKTREE_ID, groupId: PHANTOM_GROUP_ID })
+        ]
+      },
+      groupsByWorktree: { [WORKTREE_ID]: [] },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: PHANTOM_GROUP_ID }
+    })
+
+    const result = store.getState().closeUnifiedTab('tab-1')
+
+    expect(result).toEqual({ closedTabId: 'tab-1', wasLastTab: false, worktreeId: WORKTREE_ID })
+    expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID].map((tab) => tab.id)).toEqual([
+      'tab-2'
+    ])
+  })
+
+  it('reports the last orphan as such so callers can fall back to the empty state', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    store.setState({
+      unifiedTabsByWorktree: {
+        [WORKTREE_ID]: [
+          makeUnifiedTab({ id: 'tab-1', worktreeId: WORKTREE_ID, groupId: PHANTOM_GROUP_ID })
+        ]
+      },
+      groupsByWorktree: { [WORKTREE_ID]: [] },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: PHANTOM_GROUP_ID }
+    })
+
+    expect(store.getState().closeUnifiedTab('tab-1')?.wasLastTab).toBe(true)
+    expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID]).toHaveLength(0)
+  })
+
+  it('repoints the worktree at a real group once the phantom group has no tabs left', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    store.setState({
+      unifiedTabsByWorktree: {
+        [WORKTREE_ID]: [
+          makeUnifiedTab({ id: 'tab-1', worktreeId: WORKTREE_ID, groupId: PHANTOM_GROUP_ID }),
+          makeUnifiedTab({ id: 'tab-2', worktreeId: WORKTREE_ID, groupId: 'group-live' })
+        ]
+      },
+      groupsByWorktree: {
+        [WORKTREE_ID]: [
+          makeTabGroup({
+            id: 'group-live',
+            worktreeId: WORKTREE_ID,
+            activeTabId: 'tab-2',
+            tabOrder: ['tab-2']
+          })
+        ]
+      },
+      activeGroupIdByWorktree: { [WORKTREE_ID]: PHANTOM_GROUP_ID }
+    })
+
+    store.getState().closeUnifiedTab('tab-1')
+
+    // Why: the strip renders the active group's tabs, so a phantom id would render empty here.
+    expect(store.getState().activeGroupIdByWorktree[WORKTREE_ID]).toBe('group-live')
+    expect(store.getState().groupsByWorktree[WORKTREE_ID].map((group) => group.id)).toEqual([
+      'group-live'
+    ])
+  })
+
+  it('leaves a live group record untouched', () => {
+    const store = createTestStore()
+    seedWorktree(store)
+    const tab = store.getState().createUnifiedTab(WORKTREE_ID, 'terminal')
+    store.getState().createUnifiedTab(WORKTREE_ID, 'terminal')
+    const groupId = store.getState().groupsByWorktree[WORKTREE_ID][0].id
+
+    store.getState().closeUnifiedTab(tab.id)
+
+    expect(store.getState().activeGroupIdByWorktree[WORKTREE_ID]).toBe(groupId)
+    expect(store.getState().groupsByWorktree[WORKTREE_ID][0].tabOrder).not.toContain(tab.id)
+  })
+})


### PR DESCRIPTION
Fixes #11308

## Summary

Closing a tab was sometimes a completely silent no-op — no prune, no error, no toast, no log — and retrying did not help while the triggering condition held. Two independent dead ends caused it; this PR fixes both. The full trace is in #11308.

**1. `closeTerminalTab` aborted the whole close when the tab's worktree owner could not be routed.**

```ts
const worktreeRoute = resolveTerminalWorktreeRoute(state, owningWorktreeId)
if (!worktreeRoute) {
  options?.onCancel?.()
  return          // no prune, no error
}
```

`resolveTerminalWorktreeRoute` returns `null` for a tab whose worktree row is absent from `worktreesByRepo`/`detectedWorktreesByRepo` when the legacy-local fallback in `worktree-operation-route.ts` is gated off — during startup hydration (`runtimeEnvironmentCatalogHydrated` starts `false`), for the entire session if the fire-and-forget `runtimeEnvironments.list()` in `fetchSettings` throws, once any runtime environment has been removed (`removedRuntimeEnvironmentIds`), or with two or more saved runtimes. The tab-strip X calls `closeTerminalTab(tabId)` with no `onCancel`, so hitting this branch is indistinguishable from the click never registering.

The gate bought nothing for safety: provider teardown already fails closed **per PTY** inside `buildTerminalTabRetirementPlan`, which routes each PTY through `resolveTerminalHostOwnership(..., 'teardown')` and drops anything it cannot attribute into `unroutablePtyIds` (skipped and warned). So an unresolved owner now skips only the host-directed close and keeps the local prune the user asked for, plus a warning that logs the worktree *kind*, never the id (worktree ids embed absolute paths). `activateTerminalTab` carried the same guard and could not even select those tabs; same treatment.

**2. `closeUnifiedTab` dead-ended when the tab's group record was missing.**

```ts
const group = findGroupForTab(state.groupsByWorktree, worktreeId, tab.groupId)
if (!group) {
  return null     // tab stays in unifiedTabsByWorktree forever
}
```

Every close path funnels through this action, so a tab left pointing at a group id that was collapsed or lost in a host-snapshot desync rendered in the strip (`TabBar` filters on `tab.groupId === resolvedGroupId`) and could never be removed — not by the X, not by Close Others / Close to the Right, not after a restart. It now rebuilds a stand-in group from the tabs still referencing that id (never written back to `groupsByWorktree`) so the close completes, and repoints `activeGroupIdByWorktree` at a real group once the phantom has no tabs left, so the strip cannot render empty while real groups remain.

## Screenshots

No visual change — the tab that used to be stuck now closes.

## Testing

- [x] `pnpm lint` — `oxlint` clean and `check:max-lines-ratchet` OK (354 grandfathered, no new bypasses). The `oxlint --config config/oxlint-react-doctor.json` step could not run in my checkout: the installed `oxlint-plugin-react-doctor` is 0.2.10 while `package.json` pins 0.9.1, so the config fails to parse on **any** file, including untouched ones. Please let CI adjudicate that gate.
- [x] `pnpm typecheck` — no new errors. The 3 pre-existing `src/shared/emoji-shortcode-catalog.ts` `TS18046` errors reproduce on a clean tree at this base.
- [x] `pnpm test` — full suite run: **39,741 passed**, 46 failed across 10 files. Every one of those 10 files fails **identically on `origin/main`** in my environment (same subset re-run on a detached `origin/main` and on this branch: 43 failed / 26 passed, same per-file statuses; the two that pass in isolation fail only under full-suite parallel load, on both). The cause is local: this machine runs Node 26.5.0 while `package.json` pins Node 24, and under 26 `window.localStorage` is unavailable to happy-dom (`ExperimentalWarning: localStorage is not available because --localstorage-file was not provided`). None of the 10 are in the code this PR touches. The areas that are — `src/renderer/src/components/terminal`, `src/renderer/src/components/terminal-pane` (211 files / 2,665 tests) and `src/renderer/src/store` (142 files / 2,126 tests) — are fully green.
- [ ] `pnpm build` — not run locally (see the node_modules note above).
- [x] Added or updated high-quality tests that would catch regressions

New tests, both verified to fail against the pre-fix code (2/4 and 3/4 respectively, the rest being guard-preservation assertions that must pass either way):

- `src/renderer/src/components/terminal/terminal-tab-close-unrouted-owner.test.ts` — drives the real owner resolver from a store state with populated-but-empty catalogs and a saved runtime: the close prunes and fires `onClosed`, the host-directed close stays suppressed, the pinned-tab confirmation guard still rejects, and activation still selects.
- `src/renderer/src/store/slices/unified-tab-orphaned-group-close.test.ts` — closes a tab whose group record is gone, checks `wasLastTab` for the final orphan, checks the active-group repoint, and asserts a live group record is untouched.

## AI Review Report

Reviewed with Claude Code, focused on the risk of loosening two fail-closed guards.

- **Does dropping the route guard let a close kill the wrong PTY?** No. Read `buildTerminalTabRetirementPlan`: PTY attribution is independent of this gate and uses the stricter `'teardown'` purpose, pushing unattributable ids to `unroutablePtyIds` where they are skipped and warned. The route gate only ever controlled the *host-directed* close, which is still skipped. Verified by test that `closeWebRuntimeSessionTab` is not called on the unresolved path.
- **Does it weaken the pinned-tab confirmation?** No — the guard sits after the route resolution and is unchanged; covered by a test on the unresolved path.
- **Can a reconstructed group leak into persisted state?** No. The stand-in is a local value; `nextGroups` maps over `groupsByWorktree` and finds no match, so nothing is written. The active-group repoint only fires when the record was genuinely missing, the phantom is the active id, no tabs still reference it, and a real group exists.
- **Cross-platform (macOS, Linux, Windows):** no platform-dependent code touched — no shortcuts, accelerators, shortcut labels, path handling, or shell behavior. The changes are store/action logic that runs identically on all three. Worktree ids are treated as opaque strings and, per the existing convention, only their *kind* is logged, never the id.
- **SSH, folder-workspace, and remote coverage:** the unresolved-owner path is the one that most often affects SSH and runtime-owned worktrees, which is what the fix targets. Folder workspaces route through `resolveFolderWorkspaceOperationRoute` and are unaffected. Host-authoritative remote closes still go through `closeWebRuntimeSessionTab` unchanged.
- **Regression surface:** ran `src/renderer/src/components/terminal`, `src/renderer/src/components/terminal-pane` (211 files, 2665 tests) and `src/renderer/src/store` (142 files, 2126 tests) before the full suite; all green.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change removes two early returns and adds one `console.warn`, which deliberately logs the worktree *kind* rather than the id because worktree ids embed absolute paths — matching the existing `[terminal-retirement]` convention. No user-controlled string reaches a shell, filesystem, or network call. The RPC that is skipped on the unresolved path is the only outbound effect touched, and skipping it is strictly less privileged than the previous behavior.

### Verifying the regression tests are not vacuous

All four added tests fail against the pre-fix code — confirmed by reverting each change, not assumed:

- `repoints at a group that actually has tabs` — fails with `nextGroups[0]`
- `does not activate a tab that belongs to no worktree at all` — fails without the `!owningWorktreeId` return
- `orders the stand-in group visually` / `breaks a sortOrder tie by creation time` — fail without the `toSorted`

Note the third case is a **contract fix, not a behavior fix**: the sole caller discards the reconstructed `tabOrder`, so it is pinned by direct unit tests rather than a store-level test that would assert nothing. Reasoning is in the review thread.

## Notes

No X handle to share — I'm not on X, so there's nothing to shout out. Every other item in CONTRIBUTING's PR checklist is covered above.

Two related-but-separate issues surfaced while tracing this and are **not** fixed here (documented at the end of #11308):

- Remote/host-owned worktrees prune locally and fire the host close as `void closeWebRuntimeSessionTab(...)`; the catch in `web-runtime-session.ts` clears the close intents, so an RPC failure lets the next host snapshot re-add the tab. That is the "closed, then it came back" symptom, distinct from "won't close", and fixing it means reworking close-intent retention.
- `pinned-tab-close-confirm.ts` swallows a confirm click landing within its 350ms `INTER_REQUEST_ACTION_GUARD_MS` when another request is queued. The dialog stays up, so a second click works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


