### PR TITLE
perf(vault): look up resume worktrees through the shared index

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
@@ -9,6 +9,7 @@ import {
   type AiVaultSession
 } from '../../../../shared/ai-vault-types'
 import type { AppState } from '@/store/types'
+import { getIndexedWorktreeMap } from '@/store/worktree-repo-index'
 import { translate } from '@/i18n/i18n'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
@@ -145,9 +146,7 @@ export function isKnownAiVaultResumeWorkspaceTarget(
   }
 
   const worktreeId = workspaceKey?.type === 'worktree' ? workspaceKey.worktreeId : workspaceId
-  return Object.values(state.worktreesByRepo).some((worktrees) =>
-    worktrees.some((worktree) => worktree.id === worktreeId)
-  )
+  return getIndexedWorktreeMap(state.worktreesByRepo).has(worktreeId)
 }
 
 function resolveSupportedResumeWorktreeId(args: {

--- a/src/renderer/src/lib/ai-vault-resume-target.ts
+++ b/src/renderer/src/lib/ai-vault-resume-target.ts
@@ -11,6 +11,7 @@ import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { isWslUncPath } from '../../../shared/wsl-paths'
 import type { AppState } from '@/store/types'
+import { getIndexedWorktreeMap } from '@/store/worktree-repo-index'
 import { getFolderWorkspaceCandidateRepos } from './folder-workspace-connection'
 
 export type AiVaultResumeTargetStatus = 'local' | 'ssh' | 'runtime' | 'unknown'
@@ -132,9 +133,7 @@ export function getAiVaultResumeWorkspaceExecutionHostId(
   }
 
   const worktreeId = workspaceKey?.type === 'worktree' ? workspaceKey.worktreeId : workspaceId
-  const worktree = Object.values(state.worktreesByRepo ?? {})
-    .flat()
-    .find((candidate) => candidate.id === worktreeId)
+  const worktree = getIndexedWorktreeMap(state.worktreesByRepo ?? {}).get(worktreeId)
   const worktreeHostId = normalizeExecutionHostId(worktree?.hostId)
   if (worktreeHostId) {
     return worktreeHostId
@@ -158,9 +157,7 @@ export function getAiVaultResumeWorkspaceTargetStatus(
   }
 
   const worktreeId = workspaceKey?.type === 'worktree' ? workspaceKey.worktreeId : workspaceId
-  const worktree = Object.values(state.worktreesByRepo ?? {})
-    .flat()
-    .find((candidate) => candidate.id === worktreeId)
+  const worktree = getIndexedWorktreeMap(state.worktreesByRepo ?? {}).get(worktreeId)
   const worktreeHost = getAiVaultResumeExecutionHostTargetStatus(worktree?.hostId)
   if (worktreeHost !== 'unknown') {
     return worktreeHost


### PR DESCRIPTION
Small follow-up to #11303 / #11314. Uses an index that already exists rather than adding anything.

## What

Resolving a session's resume target scanned every worktree in every repo, three times over:

```ts
// ai-vault-resume-target.ts:135 and :161
const worktree = Object.values(state.worktreesByRepo ?? {})
  .flat()
  .find((candidate) => candidate.id === worktreeId)

// ai-vault-session-resume.ts:148
return Object.values(state.worktreesByRepo).some((worktrees) =>
  worktrees.some((worktree) => worktree.id === worktreeId)
)
```

The two `.flat()` calls also allocate a fresh 1124-element array each time. All three run per **visible session row**, so one panel render repeats them ~20 times.

`getIndexedWorktreeMap` (`store/worktree-repo-index.ts`) already does exactly this and is WeakMap-cached on `worktreesByRepo`, so the index is built once per store snapshot instead of once per call. `connection-owner-resolution.ts:63` already resolves worktrees this way — this just brings the vault path in line.

## Result

~1.6ms → ~0.002ms per render pass at 1124 worktrees. Net **-4 lines**.

To be clear about scale: this is a small win, not a fix for a visible stall. The real ones were #11303 (map rebuilds) and #11314 (189.7ms → 0.8ms). This is the tidy-up that was left over, and it's worth doing mainly because it deletes code and reuses an existing helper.

## Behavior

Unchanged. The one place a `Map` could differ from `.find()` is a duplicate id resolving to a *different* object — `find()` takes the first, the map takes the last writer.

That can't happen here: worktree ids are `repoId::path`, so a duplicate id within a repo array (the documented `createWorktree`/`fetchWorktrees` race the index was built to absorb) necessarily refers to the same worktree. Verified against a real 1124-worktree profile: zero ids appear under more than one repo.

## Verification

- 4810 tests pass across `right-sidebar/` and `lib/`
- `tsc --noEmit -p config/tsconfig.tc.web.json` clean
- `oxlint` clean

No new tests: this is a swap to an existing helper with no behavior change, and the resume paths are already covered by `ai-vault-session-resume.test.ts`.
