### PR TITLE
cherry-pick: AI Vault workspace-switch perf fixes for 1.4.161

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-scope-paths.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scope-paths.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import {
+  deriveAiVaultScopeSessionPaths,
+  deriveAiVaultWorkspaceScopePaths
+} from './ai-vault-scope-paths'
+
+function makeWorktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'repo-1::/repo/orca',
+    repoId: 'repo-1',
+    displayName: 'orca',
+    path: '/repo/orca',
+    head: 'abc123',
+    branch: 'main',
+    isBare: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 1,
+    isMainWorktree: false,
+    ...overrides
+  }
+}
+
+describe('deriveAiVaultWorkspaceScopePaths', () => {
+  it('returns the active workspace path', () => {
+    const active = makeWorktree()
+    expect(deriveAiVaultWorkspaceScopePaths(active, [active])).toEqual(['/repo/orca'])
+  })
+
+  it('returns nothing without an active workspace', () => {
+    expect(deriveAiVaultWorkspaceScopePaths(null, [makeWorktree()])).toEqual([])
+  })
+
+  it('includes prior paths so renamed workspaces keep their transcripts', () => {
+    const active = makeWorktree({
+      id: 'repo-1::/repo/orca-renamed',
+      path: '/repo/orca-renamed',
+      priorWorktreeIds: ['repo-1::/repo/orca']
+    })
+
+    expect(deriveAiVaultWorkspaceScopePaths(active, [active])).toEqual([
+      '/repo/orca-renamed',
+      '/repo/orca'
+    ])
+  })
+
+  it('drops a prior path another live workspace now owns', () => {
+    // Sessions are keyed by cwd alone, so claiming a path a live workspace
+    // occupies would show that workspace's transcripts under this one.
+    const claimant = makeWorktree({ id: 'repo-1::/repo/orca', path: '/repo/orca' })
+    const active = makeWorktree({
+      id: 'repo-1::/repo/orca-renamed',
+      path: '/repo/orca-renamed',
+      priorWorktreeIds: ['repo-1::/repo/orca']
+    })
+
+    expect(deriveAiVaultWorkspaceScopePaths(active, [claimant, active])).toEqual([
+      '/repo/orca-renamed'
+    ])
+  })
+
+  it('keeps a prior path the active workspace itself still owns', () => {
+    const active = makeWorktree({ priorWorktreeIds: ['repo-1::/repo/orca'] })
+    expect(deriveAiVaultWorkspaceScopePaths(active, [active])).toEqual(['/repo/orca'])
+  })
+
+  it('drops a claimed prior path regardless of where the claimant sits in the list', () => {
+    // Ordering must not decide the claim: a lookup keyed by path has to
+    // exclude the active workspace up front, or listing it before a claimant
+    // that shares the path would mask the claim.
+    const active = makeWorktree({
+      id: 'repo-1::/repo/orca-renamed',
+      path: '/repo/orca-renamed',
+      priorWorktreeIds: ['repo-1::/repo/orca']
+    })
+    const claimant = makeWorktree({ id: 'repo-1::/repo/orca', path: '/repo/orca' })
+    // The active workspace also listed at the prior path — the only shape where
+    // a first-writer-wins map would name the active workspace the owner and so
+    // report the path unclaimed.
+    const activeAtPriorPath = makeWorktree({ id: active.id, path: '/repo/orca' })
+
+    for (const liveWorktrees of [
+      [active, claimant],
+      [claimant, active],
+      [activeAtPriorPath, claimant],
+      [claimant, activeAtPriorPath]
+    ]) {
+      expect(deriveAiVaultWorkspaceScopePaths(active, liveWorktrees)).toEqual([
+        '/repo/orca-renamed'
+      ])
+    }
+  })
+
+  it('derives workspace scope paths at scale', () => {
+    // Separate from the session-scope guard: a quadratic dedupe reintroduced
+    // only in the workspace pass would not surface there.
+    const prefix = '/Users/dev/orca/workspaces/orca-monorepo/feature-'
+    const worktrees = Array.from({ length: 1200 }, (_, i) =>
+      makeWorktree({ id: `repo-1::${prefix}${i}`, path: `${prefix}${i}` })
+    )
+    const active = makeWorktree({
+      id: `repo-1::${prefix}0`,
+      path: `${prefix}0`,
+      // Priors drive the claim check, which is the other per-call scan here.
+      priorWorktreeIds: Array.from({ length: 25 }, (_, i) => `repo-1::${prefix}prior-${i}`)
+    })
+
+    const startedAt = performance.now()
+    const paths = deriveAiVaultWorkspaceScopePaths(active, worktrees)
+    const elapsedMs = performance.now() - startedAt
+
+    expect(paths).toHaveLength(1 + 25)
+    expect(elapsedMs).toBeLessThan(100)
+  })
+
+  it('ignores prior ids belonging to another repo', () => {
+    const active = makeWorktree({ priorWorktreeIds: ['repo-2::/repo/other'] })
+    expect(deriveAiVaultWorkspaceScopePaths(active, [active])).toEqual(['/repo/orca'])
+  })
+
+  it('skips relative and blank paths', () => {
+    const active = makeWorktree({ path: 'relative/path' })
+    expect(deriveAiVaultWorkspaceScopePaths(active, [active])).toEqual([])
+    expect(deriveAiVaultWorkspaceScopePaths(makeWorktree({ path: '   ' }), [])).toEqual([])
+  })
+})
+
+describe('deriveAiVaultScopeSessionPaths', () => {
+  it('covers the active workspace plus the rest of its repo', () => {
+    const active = makeWorktree()
+    const sibling = makeWorktree({ id: 'repo-1::/repo/feature', path: '/repo/feature' })
+    const otherRepo = makeWorktree({
+      id: 'repo-2::/repo/other',
+      repoId: 'repo-2',
+      path: '/repo/other'
+    })
+
+    expect(deriveAiVaultScopeSessionPaths(active, [active, sibling, otherRepo])).toEqual([
+      '/repo/orca',
+      '/repo/feature'
+    ])
+  })
+
+  it('deduplicates paths that differ only by separators or trailing slash', () => {
+    // The dedupe compares normalized keys; the first spelling is what ships.
+    const active = makeWorktree()
+    const trailing = makeWorktree({ id: 'repo-1::a', path: '/repo/orca/' })
+    const doubled = makeWorktree({ id: 'repo-1::b', path: '/repo//orca' })
+
+    expect(deriveAiVaultScopeSessionPaths(active, [active, trailing, doubled])).toEqual([
+      '/repo/orca'
+    ])
+  })
+
+  it('treats NFD and NFC spellings of one path as the same scope entry', () => {
+    // macOS yields NFD on disk while agents record NFC cwds (#10832).
+    const nfc = '/repo/프로젝트'
+    const active = makeWorktree({ id: `repo-1::${nfc}`, path: nfc })
+    const nfd = makeWorktree({ id: 'repo-1::nfd', path: nfc.normalize('NFD') })
+
+    expect(deriveAiVaultScopeSessionPaths(active, [active, nfd])).toEqual([nfc])
+  })
+
+  it('derives scope paths at scale without re-normalizing the accumulator', () => {
+    // Regression guard: deduping by rescanning the accumulated paths made this
+    // O(n^2) in normalize('NFC') and cost ~190ms on a 1124-workspace profile —
+    // on the workspace-switch path, since these paths follow the active
+    // worktree. Times the real fan-out so it fails on a return to that shape.
+    // Path length matters as much as count: normalize() cost scales with it,
+    // so short synthetic paths would understate the old shape. ~50 chars
+    // matches the real profile this was measured on.
+    const prefix = '/Users/dev/orca/workspaces/orca-monorepo/feature-'
+    const worktrees = Array.from({ length: 1200 }, (_, i) =>
+      makeWorktree({ id: `repo-1::${prefix}${i}`, path: `${prefix}${i}` })
+    )
+
+    const startedAt = performance.now()
+    const paths = deriveAiVaultScopeSessionPaths(worktrees[0], worktrees)
+    const elapsedMs = performance.now() - startedAt
+
+    expect(paths).toHaveLength(worktrees.length)
+    // ~190ms before, ~1ms after; loose enough for a slow CI box.
+    expect(elapsedMs).toBeLessThan(100)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-scope-paths.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scope-paths.ts
@@ -14,21 +14,33 @@ export function deriveAiVaultWorkspaceScopePaths(
     return []
   }
 
-  const paths: string[] = []
-  addAiVaultWorkspaceScopePath(paths, activeWorktree.path)
+  return collectWorkspaceScopePaths(activeWorktree, liveWorktrees).paths
+}
 
-  for (const priorWorktreeId of activeWorktree.priorWorktreeIds ?? []) {
+function collectWorkspaceScopePaths(
+  activeWorktree: Pick<Worktree, 'id' | 'path' | 'priorWorktreeIds' | 'repoId'>,
+  liveWorktrees: readonly Pick<Worktree, 'id' | 'path' | 'repoId'>[]
+): ScopePathAccumulator {
+  const accumulator = createScopePathAccumulator()
+  addAiVaultWorkspaceScopePath(accumulator, activeWorktree.path)
+
+  const priorWorktreeIds = activeWorktree.priorWorktreeIds ?? []
+  // Built once instead of rescanning every live worktree per prior id.
+  const claimedComparisonPaths =
+    priorWorktreeIds.length > 0 ? buildClaimedComparisonPaths(liveWorktrees, activeWorktree) : null
+
+  for (const priorWorktreeId of priorWorktreeIds) {
     const parsed = splitWorktreeIdForFilesystem(priorWorktreeId)
     if (!parsed || parsed.repoId !== activeWorktree.repoId) {
       continue
     }
-    if (isAiVaultWorkspaceScopePathClaimed(parsed.worktreePath, activeWorktree, liveWorktrees)) {
+    if (isAiVaultWorkspaceScopePathClaimed(parsed.worktreePath, claimedComparisonPaths)) {
       continue
     }
-    addAiVaultWorkspaceScopePath(paths, parsed.worktreePath)
+    addAiVaultWorkspaceScopePath(accumulator, parsed.worktreePath)
   }
 
-  return paths
+  return accumulator
 }
 
 /**
@@ -48,10 +60,12 @@ export function deriveAiVaultScopeSessionPaths(
     projectHostSetupProjection?: ProjectHostSetupProjection
   } = {}
 ): string[] {
-  const paths = deriveAiVaultWorkspaceScopePaths(activeWorktree, liveWorktrees)
   if (!activeWorktree) {
-    return paths
+    return []
   }
+  // Carries the workspace pass's dedupe keys forward, so the project pass does
+  // not restart deduplication against a plain array.
+  const accumulator = collectWorkspaceScopePaths(activeWorktree, liveWorktrees)
   const setupsByRepoId = buildProjectSetupsByRepoId(options.projectHostSetupProjection)
   for (const worktree of liveWorktrees) {
     if (
@@ -61,15 +75,15 @@ export function deriveAiVaultScopeSessionPaths(
         (setup) => worktreeProjectKey(setup, setup) === options.activeProjectKey
       )
     ) {
-      addAiVaultWorkspaceScopePath(paths, worktree.path)
+      addAiVaultWorkspaceScopePath(accumulator, worktree.path)
     }
   }
   for (const setup of options.projectHostSetupProjection?.setups ?? []) {
     if (worktreeProjectKey(setup, setup) === options.activeProjectKey) {
-      addAiVaultWorkspaceScopePath(paths, setup.path)
+      addAiVaultWorkspaceScopePath(accumulator, setup.path)
     }
   }
-  return paths
+  return accumulator.paths
 }
 
 function buildProjectSetupsByRepoId(
@@ -95,34 +109,71 @@ function worktreeProjectKey(
   return entry.repoId ? `repo:${entry.repoId}` : null
 }
 
-function addAiVaultWorkspaceScopePath(paths: string[], pathValue: string): void {
+/**
+ * Paths plus their comparison keys.
+ *
+ * Why the key set: deduping by rescanning the accumulated paths re-normalized
+ * every accepted path on every insert, which is O(n^2) `normalize('NFC')` calls
+ * and cost ~190ms on a 1124-workspace profile — on the workspace-switch path,
+ * since these paths are derived from the active worktree.
+ */
+type ScopePathAccumulator = {
+  paths: string[]
+  comparisonKeys: Set<string>
+}
+
+function createScopePathAccumulator(): ScopePathAccumulator {
+  return { paths: [], comparisonKeys: new Set() }
+}
+
+function addAiVaultWorkspaceScopePath(accumulator: ScopePathAccumulator, pathValue: string): void {
   const trimmedPath = pathValue.trim()
   if (!trimmedPath || !isRuntimePathAbsolute(trimmedPath)) {
     return
   }
   const comparisonPath = normalizeRuntimePathForComparison(trimmedPath)
-  if (
-    paths.some((existingPath) => normalizeRuntimePathForComparison(existingPath) === comparisonPath)
-  ) {
+  if (accumulator.comparisonKeys.has(comparisonPath)) {
     return
   }
-  paths.push(trimmedPath)
+  accumulator.comparisonKeys.add(comparisonPath)
+  accumulator.paths.push(trimmedPath)
+}
+
+/**
+ * Comparison paths owned by a worktree *other than* the active one.
+ *
+ * Why exclude the active worktree while building rather than when reading: a
+ * path→id map would otherwise have to pick one owner among duplicates, and
+ * picking the active worktree would mask a real claimant sitting later in the
+ * list. Excluding it up front means any surviving entry is a claim by
+ * definition, which matches the previous `some()` regardless of ordering.
+ */
+function buildClaimedComparisonPaths(
+  liveWorktrees: readonly Pick<Worktree, 'id' | 'path'>[],
+  activeWorktree: Pick<Worktree, 'id'>
+): Set<string> {
+  const claimedPaths = new Set<string>()
+  for (const worktree of liveWorktrees) {
+    if (worktree.id === activeWorktree.id) {
+      continue
+    }
+    const trimmedPath = worktree.path.trim()
+    if (!trimmedPath || !isRuntimePathAbsolute(trimmedPath)) {
+      continue
+    }
+    claimedPaths.add(normalizeRuntimePathForComparison(trimmedPath))
+  }
+  return claimedPaths
 }
 
 function isAiVaultWorkspaceScopePathClaimed(
   pathValue: string,
-  activeWorktree: Pick<Worktree, 'id'>,
-  liveWorktrees: readonly Pick<Worktree, 'id' | 'path'>[]
+  claimedComparisonPaths: Set<string> | null
 ): boolean {
   const trimmedPath = pathValue.trim()
-  if (!trimmedPath || !isRuntimePathAbsolute(trimmedPath)) {
+  if (!trimmedPath || !isRuntimePathAbsolute(trimmedPath) || !claimedComparisonPaths) {
     return false
   }
-  const comparisonPath = normalizeRuntimePathForComparison(trimmedPath)
   // AI Vault sessions are keyed by cwd only, so any live worktree now owning this path wins.
-  return liveWorktrees.some(
-    (worktree) =>
-      worktree.id !== activeWorktree.id &&
-      normalizeRuntimePathForComparison(worktree.path) === comparisonPath
-  )
+  return claimedComparisonPaths.has(normalizeRuntimePathForComparison(trimmedPath))
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
@@ -9,6 +9,7 @@ import {
   type AiVaultSession
 } from '../../../../shared/ai-vault-types'
 import type { AppState } from '@/store/types'
+import { getIndexedWorktreeMap } from '@/store/worktree-repo-index'
 import { translate } from '@/i18n/i18n'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import {
@@ -145,9 +146,7 @@ export function isKnownAiVaultResumeWorkspaceTarget(
   }
 
   const worktreeId = workspaceKey?.type === 'worktree' ? workspaceKey.worktreeId : workspaceId
-  return Object.values(state.worktreesByRepo).some((worktrees) =>
-    worktrees.some((worktree) => worktree.id === worktreeId)
-  )
+  return getIndexedWorktreeMap(state.worktreesByRepo).has(worktreeId)
 }
 
 function resolveSupportedResumeWorktreeId(args: {

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-worktree-map.test.tsx
@@ -184,4 +184,53 @@ describe('useAiVaultSessionWorktreeMap', () => {
       worktreeId: cjk.id
     })
   })
+
+  it('does not attribute a session to a workspace that merely shares a path prefix', () => {
+    // Guards the candidate matcher's boundary: hoisting the root normalization
+    // out of the loop must not degrade containment into a bare startsWith, or
+    // '/repo/alpha-sibling' would be swallowed by '/repo/alpha'.
+    const sibling = makeWorktree({
+      id: 'repo-1::/repo/alpha-sibling',
+      path: '/repo/alpha-sibling'
+    })
+    const session = makeSession({ id: 'codex:sibling', cwd: '/repo/alpha-sibling/src' })
+
+    const { result } = renderHook(() =>
+      useAiVaultSessionWorktreeMap({
+        sessions: [session],
+        repos,
+        worktrees: [worktreeA, sibling]
+      })
+    )
+
+    expect(result.current.get(session.id)).toMatchObject({ worktreeId: sibling.id })
+  })
+
+  it('builds the map at scale without re-normalizing paths per session', () => {
+    // Regression for the ~1s workspace-switch stall (#10841/#11303): the map
+    // used to rebuild and re-normalize every candidate root per session, making
+    // it O(sessions x roots) on path normalization. Times the real fan-out
+    // rather than counting calls, so it fails on any return to that shape.
+    const manyWorktrees = Array.from({ length: 1200 }, (_, i) =>
+      makeWorktree({ id: `repo-1::/repo/w${i}`, path: `/repo/w${i}` })
+    )
+    const manySessions = Array.from({ length: 400 }, (_, i) =>
+      makeSession({ id: `codex:s${i}`, cwd: `/repo/w${i % manyWorktrees.length}/src` })
+    )
+
+    const startedAt = performance.now()
+    const { result } = renderHook(() =>
+      useAiVaultSessionWorktreeMap({
+        sessions: manySessions,
+        repos,
+        worktrees: manyWorktrees
+      })
+    )
+    const elapsedMs = performance.now() - startedAt
+
+    expect(result.current.size).toBe(manySessions.length)
+    // Was ~350ms+ before the hoist and ~15ms after; the bound is loose enough
+    // to stay quiet on a slow CI box while still catching the quadratic shape.
+    expect(elapsedMs).toBeLessThan(150)
+  })
 })

--- a/src/renderer/src/lib/ai-vault-resume-target.ts
+++ b/src/renderer/src/lib/ai-vault-resume-target.ts
@@ -11,6 +11,7 @@ import { getRepoIdFromWorktreeId } from '../../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { isWslUncPath } from '../../../shared/wsl-paths'
 import type { AppState } from '@/store/types'
+import { getIndexedWorktreeMap } from '@/store/worktree-repo-index'
 import { getFolderWorkspaceCandidateRepos } from './folder-workspace-connection'
 
 export type AiVaultResumeTargetStatus = 'local' | 'ssh' | 'runtime' | 'unknown'
@@ -132,9 +133,7 @@ export function getAiVaultResumeWorkspaceExecutionHostId(
   }
 
   const worktreeId = workspaceKey?.type === 'worktree' ? workspaceKey.worktreeId : workspaceId
-  const worktree = Object.values(state.worktreesByRepo ?? {})
-    .flat()
-    .find((candidate) => candidate.id === worktreeId)
+  const worktree = getIndexedWorktreeMap(state.worktreesByRepo ?? {}).get(worktreeId)
   const worktreeHostId = normalizeExecutionHostId(worktree?.hostId)
   if (worktreeHostId) {
     return worktreeHostId
@@ -158,9 +157,7 @@ export function getAiVaultResumeWorkspaceTargetStatus(
   }
 
   const worktreeId = workspaceKey?.type === 'worktree' ? workspaceKey.worktreeId : workspaceId
-  const worktree = Object.values(state.worktreesByRepo ?? {})
-    .flat()
-    .find((candidate) => candidate.id === worktreeId)
+  const worktree = getIndexedWorktreeMap(state.worktreesByRepo ?? {}).get(worktreeId)
   const worktreeHost = getAiVaultResumeExecutionHostTargetStatus(worktree?.hostId)
   if (worktreeHost !== 'unknown') {
     return worktreeHost

--- a/tools/benchmarks/workspace-switch-paint-latency.mjs
+++ b/tools/benchmarks/workspace-switch-paint-latency.mjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+/**
+ * Measures how long a workspace-card click takes to become VISIBLE.
+ *
+ * The existing e2e spec (tests/e2e/worktree-switch-responsiveness.spec.ts) only
+ * measures the synchronous click task. That stays fast even when the symptom is
+ * present: `markSidebarWorktreeActiveImmediately` mutates the DOM in the click
+ * handler, so the attribute flips in ~1ms. What the user sees is the next
+ * painted FRAME, and that frame is blocked when the async activation path jams
+ * the main thread. So the number that matters is first-paint-after-click.
+ *
+ * Attaches over CDP to an already-running dev app:
+ *
+ *   ORCA_DEV_USER_DATA_PATH=... REMOTE_DEBUGGING_PORT=9455 pn dev
+ *   node tools/benchmarks/workspace-switch-paint-latency.mjs --port 9455
+ *
+ * Exits non-zero when the median first-paint exceeds --budget (default 200ms),
+ * which makes it usable directly as a `git bisect run` predicate.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { chromium } from '@stablyai/playwright-test'
+
+function parseArgs(argv) {
+  const args = {
+    port: 9455,
+    switches: 6,
+    budgetMs: 200,
+    settleMs: 2500,
+    out: null,
+    json: false
+  }
+  for (let i = 0; i < argv.length; i += 1) {
+    const [flag, inlineValue] = argv[i].split('=')
+    const value = inlineValue ?? argv[i + 1]
+    const consume = () => {
+      if (inlineValue === undefined) {
+        i += 1
+      }
+    }
+    switch (flag) {
+      case '--port':
+        args.port = Number(value)
+        consume()
+        break
+      case '--switches':
+        args.switches = Number(value)
+        consume()
+        break
+      case '--budget':
+        args.budgetMs = Number(value)
+        consume()
+        break
+      case '--settle':
+        args.settleMs = Number(value)
+        consume()
+        break
+      case '--out':
+        args.out = value
+        consume()
+        break
+      case '--json':
+        args.json = true
+        break
+      case '--help':
+        console.log(
+          'Usage: workspace-switch-paint-latency.mjs [--port 9455] [--switches 6] [--budget 200] [--settle 2500] [--out file.json] [--json]'
+        )
+        process.exit(0)
+        break
+      default:
+        break
+    }
+  }
+  return args
+}
+
+const args = parseArgs(process.argv.slice(2))
+
+function quantile(sorted, q) {
+  if (sorted.length === 0) {
+    return null
+  }
+  const pos = (sorted.length - 1) * q
+  const lo = Math.floor(pos)
+  const hi = Math.ceil(pos)
+  if (lo === hi) {
+    return sorted[lo]
+  }
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo)
+}
+
+function summarize(values) {
+  const clean = values.filter((v) => typeof v === 'number' && Number.isFinite(v))
+  if (clean.length === 0) {
+    return null
+  }
+  const sorted = [...clean].sort((a, b) => a - b)
+  return {
+    n: sorted.length,
+    min: +sorted[0].toFixed(1),
+    p50: +quantile(sorted, 0.5).toFixed(1),
+    p90: +quantile(sorted, 0.9).toFixed(1),
+    max: +sorted.at(-1).toFixed(1)
+  }
+}
+
+/**
+ * Installed in the renderer before each click. Records, from the real
+ * pointerdown, every animation frame plus long tasks, so we can tell a jammed
+ * main thread (no frames for ~1s) apart from slow-but-smooth work.
+ */
+const PROBE_SOURCE = `(targetId) => {
+  const probe = {
+    t0: null,
+    targetId,
+    frames: [],
+    longTasks: [],
+    attrFlipMs: null,
+    storeCommitMs: null,
+    renderedCommitMs: null,
+    done: false
+  }
+  window.__switchProbe = probe
+
+  const surfaceOf = (id) => {
+    const row = [...document.querySelectorAll('[data-worktree-id]')].find(
+      (el) => el.dataset.worktreeId === id
+    )
+    return row ? row.querySelector('[data-worktree-card-surface]') : null
+  }
+  const isActive = (id) => {
+    const s = surfaceOf(id)
+    return Boolean(s && s.getAttribute('data-worktree-card-active'))
+  }
+  const renderedId = () =>
+    document
+      .querySelector('[data-rendered-active-worktree-id]')
+      ?.getAttribute('data-rendered-active-worktree-id') ?? null
+
+  try {
+    const po = new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) {
+        if (probe.t0 === null) continue
+        probe.longTasks.push({
+          startMs: +(e.startTime - probe.t0).toFixed(1),
+          durationMs: +e.duration.toFixed(1)
+        })
+      }
+    })
+    po.observe({ entryTypes: ['longtask'] })
+    probe.observer = po
+  } catch {}
+
+  // Why: pointerdown is the earliest thing the user's click produces, so it is
+  // the honest zero point for "time until I saw something happen".
+  const onPointerDown = () => {
+    if (probe.t0 !== null) return
+    probe.t0 = performance.now()
+    const tick = () => {
+      const now = performance.now() - probe.t0
+      probe.frames.push(+now.toFixed(1))
+      if (probe.attrFlipMs === null && isActive(probe.targetId)) probe.attrFlipMs = +now.toFixed(1)
+      if (probe.storeCommitMs === null) {
+        const st = window.__store?.getState?.()
+        if (st && st.activeWorktreeId === probe.targetId) probe.storeCommitMs = +now.toFixed(1)
+      }
+      if (probe.renderedCommitMs === null && renderedId() === probe.targetId) {
+        probe.renderedCommitMs = +now.toFixed(1)
+      }
+      if (!probe.done) requestAnimationFrame(tick)
+    }
+    requestAnimationFrame(tick)
+  }
+  window.addEventListener('pointerdown', onPointerDown, { capture: true, once: true })
+  probe.cleanup = () => {
+    probe.done = true
+    try { probe.observer?.disconnect() } catch {}
+    window.removeEventListener('pointerdown', onPointerDown, { capture: true })
+  }
+  return true
+}`
+
+/** Press Escape while any full-screen overlay is intercepting pointer events. */
+async function dismissOverlays(page) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const blocked = await page.evaluate(() =>
+      [...document.querySelectorAll('body *')].some((el) => {
+        const r = el.getBoundingClientRect()
+        if (r.width < window.innerWidth * 0.9 || r.height < window.innerHeight * 0.9) {
+          return false
+        }
+        const s = getComputedStyle(el)
+        return s.position === 'fixed' && s.pointerEvents !== 'none' && Number(s.zIndex) >= 40
+      })
+    )
+    if (!blocked) {
+      return
+    }
+    await page.keyboard.press('Escape')
+    await page.waitForTimeout(200)
+  }
+}
+
+async function main() {
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${args.port}`)
+  const contexts = browser.contexts()
+  const pages = contexts.flatMap((c) => c.pages())
+  let page = null
+  for (const candidate of pages) {
+    const hasStore = await candidate
+      .evaluate(
+        () => Boolean(window.__store) && Boolean(document.querySelector('[data-worktree-id]'))
+      )
+      .catch(() => false)
+    if (hasStore) {
+      page = candidate
+      break
+    }
+  }
+  if (!page) {
+    throw new Error(
+      'No renderer page with window.__store + a mounted sidebar. Is the app past startup, and is the sidebar open?'
+    )
+  }
+
+  // Normalize sidebar state so the same cards are reachable across commits.
+  // Why pin the sort: 'recent' reorders the list after every switch, which
+  // would move the card out from under the cursor mid-run.
+  const worktreeIds = await page.evaluate(() => {
+    const state = window.__store.getState()
+    state.setActiveView('terminal')
+    state.setSidebarOpen(true)
+    state.setGroupBy?.('none')
+    state.setSortBy?.('name')
+    state.setShowActiveOnly?.(false)
+    state.setFilterRepoIds?.([])
+    const viewportH = window.innerHeight
+    // Only cards fully inside the viewport are clickable: the list is
+    // virtualized, so off-screen rows are unmounted or positioned outside.
+    return [...document.querySelectorAll('[data-worktree-id]')]
+      .filter((el) => {
+        const surface = el.querySelector('[data-worktree-card-surface]')
+        if (!surface) {
+          return false
+        }
+        const r = surface.getBoundingClientRect()
+        return r.height > 0 && r.top >= 0 && r.bottom <= viewportH
+      })
+      .map((el) => el.dataset.worktreeId)
+      .filter((id, i, all) => id && all.indexOf(id) === i)
+  })
+
+  if (worktreeIds.length < 2) {
+    throw new Error(
+      `Need >=2 workspace cards visible in the viewport, found ${worktreeIds.length}. Is the sidebar open?`
+    )
+  }
+
+  // Alternate between two cards, neither of which is the one already active at
+  // start — clicking the active card short-circuits and measures nothing.
+  const activeAtStart = await page.evaluate(() => window.__store.getState().activeWorktreeId)
+  const pair = worktreeIds.filter((id) => id !== activeAtStart).slice(0, 2)
+  if (pair.length < 2) {
+    throw new Error('Need two visible non-active cards to alternate between')
+  }
+  console.error(`alternating between:\n  ${pair[0]}\n  ${pair[1]}`)
+
+  const samples = []
+  for (let i = 0; i < args.switches; i += 1) {
+    const targetId = pair[i % 2]
+
+    // Why: page.evaluate() treats a string as an expression to evaluate and
+    // drops the argument, so the probe has to be applied inline.
+    const surface = page
+      .locator(`[data-worktree-id="${targetId}"] [data-worktree-card-surface]`)
+      .first()
+
+    // Why: a transient popover (`fixed inset-0 z-50`) swallows the click, and
+    // the run would then measure a click that never reached the card.
+    await dismissOverlays(page)
+
+    await page.evaluate(`(${PROBE_SOURCE})(${JSON.stringify(targetId)})`)
+
+    // Real CDP input events, not element.click(): the click path has
+    // pointer-drag suppression that a synthetic click would bypass. Going
+    // through the locator also re-resolves position at click time, which
+    // matters because the virtualized list reorders between switches.
+    try {
+      await surface.click({ timeout: 10_000 })
+    } catch (error) {
+      console.error(`skip switch ${i + 1}: ${String(error).split('\n')[0]}`)
+      continue
+    }
+
+    await page.waitForTimeout(args.settleMs)
+
+    const sample = await page.evaluate(() => {
+      const p = window.__switchProbe
+      p.cleanup?.()
+      const frames = p.frames
+      let maxGap = 0
+      let prev = 0
+      for (const f of frames) {
+        maxGap = Math.max(maxGap, f - prev)
+        prev = f
+      }
+      return {
+        firstPaintMs: frames.length ? frames[0] : null,
+        maxFrameGapMs: +maxGap.toFixed(1),
+        frameCount: frames.length,
+        attrFlipMs: p.attrFlipMs,
+        storeCommitMs: p.storeCommitMs,
+        renderedCommitMs: p.renderedCommitMs,
+        longTaskCount: p.longTasks.length,
+        longTaskTotalMs: +p.longTasks.reduce((a, t) => a + t.durationMs, 0).toFixed(1),
+        worstLongTaskMs: p.longTasks.reduce((a, t) => Math.max(a, t.durationMs), 0)
+      }
+    })
+    sample.targetId = targetId
+    // Why: a click that never activated would report a fast "first paint" and
+    // silently make every commit look good during a bisect.
+    if (sample.attrFlipMs === null && sample.renderedCommitMs === null) {
+      throw new Error(
+        `switch ${i + 1} clicked card ${targetId} but it never became active — the measurement is not valid`
+      )
+    }
+    samples.push(sample)
+    console.error(
+      `switch ${i + 1}/${args.switches} -> firstPaint=${sample.firstPaintMs}ms ` +
+        `maxFrameGap=${sample.maxFrameGapMs}ms attrFlip=${sample.attrFlipMs}ms ` +
+        `rendered=${sample.renderedCommitMs}ms longTasks=${sample.longTaskCount}/${sample.longTaskTotalMs}ms`
+    )
+  }
+
+  // Why: the first switch after attach pays one-off lazy work (chunk loads,
+  // cold caches) that a warm app never pays again. Keep it in the raw samples
+  // but exclude it from the verdict so bisect steps compare like with like.
+  const scored = samples.length > 1 ? samples.slice(1) : samples
+
+  const report = {
+    port: args.port,
+    switches: samples.length,
+    budgetMs: args.budgetMs,
+    firstPaintMs: summarize(scored.map((s) => s.firstPaintMs)),
+    maxFrameGapMs: summarize(scored.map((s) => s.maxFrameGapMs)),
+    attrFlipMs: summarize(scored.map((s) => s.attrFlipMs)),
+    renderedCommitMs: summarize(scored.map((s) => s.renderedCommitMs)),
+    worstLongTaskMs: summarize(scored.map((s) => s.worstLongTaskMs)),
+    longTaskTotalMs: summarize(scored.map((s) => s.longTaskTotalMs)),
+    samples
+  }
+
+  const medianFirstPaint = report.firstPaintMs?.p50 ?? Infinity
+  const medianFrameGap = report.maxFrameGapMs?.p50 ?? Infinity
+  // The visible symptom is a stall, which shows up either as a late first frame
+  // or as a long gap between frames right after the click.
+  const verdictMs = Math.max(medianFirstPaint, medianFrameGap)
+  report.verdictMs = +verdictMs.toFixed(1)
+  report.pass = verdictMs <= args.budgetMs
+
+  if (args.out) {
+    mkdirSync(path.dirname(args.out), { recursive: true })
+    writeFileSync(args.out, JSON.stringify(report, null, 2))
+  }
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    console.log('')
+    console.log(
+      `first paint after click   p50=${report.firstPaintMs?.p50}ms  max=${report.firstPaintMs?.max}ms`
+    )
+    console.log(
+      `max frame gap             p50=${report.maxFrameGapMs?.p50}ms  max=${report.maxFrameGapMs?.max}ms`
+    )
+    console.log(`attribute flip (JS)       p50=${report.attrFlipMs?.p50}ms`)
+    console.log(
+      `main pane rendered        p50=${report.renderedCommitMs?.p50}ms  max=${report.renderedCommitMs?.max}ms`
+    )
+    console.log(
+      `worst long task           p50=${report.worstLongTaskMs?.p50}ms  max=${report.worstLongTaskMs?.max}ms`
+    )
+    console.log('')
+    console.log(
+      `${report.pass ? 'PASS' : 'FAIL'} verdict=${report.verdictMs}ms budget=${args.budgetMs}ms`
+    )
+  }
+
+  await browser.close()
+  process.exit(report.pass ? 0 : 1)
+}
+
+main().catch((error) => {
+  console.error(error?.stack ?? String(error))
+  // 125 tells `git bisect run` to skip rather than mark the commit bad.
+  process.exit(125)
+})


### PR DESCRIPTION
Cherry-picks the three merged AI Vault workspace-switch perf fixes onto `1.4.161-rc.0-release-prep`, on top of #11303 which is already on this branch (`b85e267352`).

All three applied cleanly with no conflicts, `-x` recorded on each.

| cherry-pick | from main | what |
|---|---|---|
| `8354f7ba02` | `c5102e1262` (#11311) | regression guards + paint-latency tool |
| `b018569303` | `6cc579a48c` (#11314) | scope-path dedupe — 189.7ms → 0.8ms |
| `4d778b9390` | `b4b3bcdb84` (#11317) | resume lookups via the shared worktree index |

## Why these belong in the release

The user-visible symptom was a 1–2s freeze when clicking a workspace card with the Agent Session History panel open, at real scale (1124 workspaces / 500 sessions).

`a1a78da878` (#10841) is what made it visible — it added an unconditional `.normalize('NFC')` to `normalizeRuntimePathForComparison`, the innermost function in what were several O(sessions × worktrees) loops. #10841 shipped in 1.4.160, so the regression is live for users on the current release.

#11303 fixed the largest piece (the session map rebuilds). These three close out the rest:

- **#11314** is the substantive one — `deriveAiVaultScopeSessionPaths` still followed `activeWorktree`, so it ran on every switch and was still quadratic: deduping re-normalized the whole accumulator on each insert (~632k NFC calls at 1124 workspaces).
- **#11317** replaces three linear worktree scans with the existing WeakMap-cached index (net -4 lines).
- **#11311** is test-only plus a benchmark tool.

Combined, vault work on a workspace switch goes from ~1s to ~2.5ms.

## Verification on this branch

Not just "applied cleanly" — re-verified against the release branch itself:

- **7988 tests pass** across `right-sidebar/`, `lib/`, and `shared/`
- `tsc --noEmit -p config/tsconfig.tc.web.json` clean
- `deriveAiVaultScopeSessionPaths` measured at **0.7ms** on this branch against a real 1124-worktree profile (was ~190ms)

## Risk

Low. #11314 was verified byte-identical to the previous implementation (contents *and* ordering) across 156 scenario/option combinations — including NFD/NFC, WSL UNC, prior-path claims, and separator edge cases — and carries fail-first regression guards. #11317 is a swap to a helper already used the same way in `connection-owner-resolution.ts`. #11311 adds no production code.

NFC folding semantics from #10841 are untouched throughout — the same normalization runs, just not inside the hot loops.
