### PR TITLE
fix(editor): drop the unreachable uppercase .R extension key

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -59,6 +59,11 @@ describe('detectLanguage', () => {
     expect(detectLanguage('scripts/legacy.cjs')).toBe('javascript')
   })
 
+  it('maps .r files to the r language id regardless of case', () => {
+    expect(detectLanguage('analysis/model.r')).toBe('r')
+    expect(detectLanguage('analysis/MODEL.R')).toBe('r')
+  })
+
   it('keeps .json/.jsonc on the built-in json language and unknown on plaintext', () => {
     expect(detectLanguage('config/settings.json')).toBe('json')
     expect(detectLanguage('config/tsconfig.jsonc')).toBe('json')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -74,7 +74,6 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.proto': 'proto',
   '.lua': 'lua',
   '.r': 'r',
-  '.R': 'r',
   '.scala': 'scala',
   '.dart': 'dart',
   '.ex': 'elixir',


### PR DESCRIPTION
## Summary

`EXT_TO_LANGUAGE` has both `'.r'` and `'.R'` mapped to `r`, but the lookup key is lowercased first:

```ts
const ext = extname(filename).toLowerCase()
return EXT_TO_LANGUAGE[ext] ?? 'plaintext'
```

No input can ever reach the `'.R'` entry — `'.r'` already covers `model.R`, `MODEL.R` and every other casing. Removing it changes no behaviour.

It is worth removing rather than leaving alone: as written, the entry reads like uppercase extensions need their own row, which invites the same addition for `.SVG`, `.JSON` and so on. `'.R'` is currently the only key in the table with an uppercase character, so this keeps that property true.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

The two unchecked boxes are explained under Notes.

## AI Review Report

Reviewed with an AI coding agent. The check that mattered was whether the entry is genuinely unreachable rather than merely redundant: `detectLanguage` lowercases the extension before the lookup (`language-detect.ts:123`), and `FILENAME_TO_LANGUAGE` — which is consulted first and is *not* lowercased — contains no key ending in `.R`, so there is no path that bypasses the normalization. A scan of the table confirmed `'.R'` is the only key containing an uppercase character, so no sibling entry has the same problem.

The added test asserts both `model.r` and `MODEL.R` resolve to `r`, so if the lowercasing in `detectLanguage` were ever removed, this deletion would surface as a failing test rather than as silently broken highlighting for uppercase `.R` files.

Cross-platform compatibility (macOS, Linux, Windows) was explicitly checked. This is the removal of one entry from a lookup table; no platform branch, path handling, shortcut, label, shell behavior or Electron-specific code is involved. Case-insensitive filesystems are the reason the lowercasing exists in the first place, and that behaviour is unchanged and now covered by a test.

## Security Audit

No risk surface. One line is removed from a static lookup table and a test is added. No input handling, command execution, path resolution, auth, secrets, IPC or dependency changes.

## Notes

- `pnpm lint`: oxlint and the code-quality audits pass. The chain stops later at `verify:skill-bundle-manifest`, which reports stale generated artifacts under `resources/skills/` — a pre-existing state unrelated to this change, and those files are not part of this diff.
- `pnpm test`: the full suite on a Windows machine fails a set of pre-existing tests that require a POSIX shell (`spawn /bin/sh ENOENT`); the count is unchanged by this PR. `language-detect.test.ts` passes 11/11.
