### PR TITLE
fix(worktree-palette): stop blanked display names from crashing Cmd+J

### DIFF
--- a/src/main/runtime/rpc/methods/worktree-schemas.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.test.ts
@@ -46,6 +46,7 @@ describe('worktree RPC schemas', () => {
     const parsed = WorktreeSet.parse({ worktree: 'id:r1::/repos/wt', comment: 'note' })
 
     expect(parsed.displayName).toBeUndefined()
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'displayName')).toBe(false)
   })
 
   it('ignores a non-string display name rather than persisting it', () => {

--- a/src/main/runtime/rpc/methods/worktree-schemas.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { WorktreeActivate, WorktreeCreate } from './worktree-schemas'
+import { WorktreeActivate, WorktreeCreate, WorktreeSet } from './worktree-schemas'
 
 describe('worktree RPC schemas', () => {
   it('validates additive navigation intent', () => {
@@ -30,5 +30,27 @@ describe('worktree RPC schemas', () => {
     })
 
     expect(parsed.success).toBe(false)
+  })
+
+  it('keeps a blanked display name on remote hosts instead of dropping the clear', () => {
+    // Blanking sends displayName:'' meaning "fall back to the branch/folder name".
+    // Coercing it to undefined made updateManagedWorktreeMeta's omitUndefinedProperties
+    // drop the key, so an SSH/paired-web rename-to-blank silently kept the old name.
+    const parsed = WorktreeSet.parse({ worktree: 'id:r1::/repos/wt', displayName: '' })
+
+    expect(parsed.displayName).toBe('')
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'displayName')).toBe(true)
+  })
+
+  it('still omits a display name that was never sent', () => {
+    const parsed = WorktreeSet.parse({ worktree: 'id:r1::/repos/wt', comment: 'note' })
+
+    expect(parsed.displayName).toBeUndefined()
+  })
+
+  it('ignores a non-string display name rather than persisting it', () => {
+    const parsed = WorktreeSet.parse({ worktree: 'id:r1::/repos/wt', displayName: 42 })
+
+    expect(parsed.displayName).toBeUndefined()
   })
 })

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -189,7 +189,10 @@ export const WorktreePrefetchCreateBase = z.object({
 })
 
 export const WorktreeSet = WorktreeSelector.extend({
-  displayName: OptionalString,
+  // Why: '' is the blanking contract — "fall back to the branch/folder name".
+  // OptionalString coerced it to undefined, so on remote/SSH hosts clearing the
+  // name was dropped here and the old name came back on the next refresh.
+  displayName: OptionalPlainString,
   // Why: empty comments are meaningful metadata updates, so use the plain
   // string parser instead of OptionalString's empty-as-undefined behavior.
   comment: OptionalPlainString,

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -23,7 +23,6 @@ import {
   CommandEmpty,
   CommandItem
 } from '@/components/ui/command'
-import { branchName } from '@/lib/git-utils'
 import { parseGitHubIssueOrPRNumber, parseGitHubIssueOrPRLink } from '@/lib/github-links'
 import { getLinkedWorkItemSuggestedName, getLinkedWorkItemWorkspaceName } from '@/lib/new-workspace'
 import type { LinkedWorkItemSummary } from '@/lib/new-workspace'
@@ -48,6 +47,10 @@ import {
   type MatchRange,
   type PaletteSearchResult
 } from '@/lib/worktree-palette-search'
+import {
+  resolveWorktreeBranchLabel,
+  resolveWorktreeDisplayName
+} from '@/lib/worktree-default-display-name'
 import {
   CREATE_WORKTREE_ITEM_ID,
   createWorktreePaletteRequestGuard,
@@ -1794,7 +1797,10 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                 const worktree = entry.worktree
                 const repo = repoMap.get(worktree.repoId)
                 const repoName = repo?.displayName ?? ''
-                const branch = branchName(worktree.branch)
+                // Why: both must match searchWorktrees' resolution, or highlight ranges land on
+                // the wrong text — and a branch-less row would throw here before search ever ran.
+                const branch = resolveWorktreeBranchLabel(worktree)
+                const worktreeLabel = resolveWorktreeDisplayName(worktree)
                 const status = getWorktreeStatus(
                   tabsByWorktree[worktree.id] ?? [],
                   browserTabsByWorktree[worktree.id] ?? [],
@@ -1862,11 +1868,11 @@ export default function WorktreeJumpPalette(): React.JSX.Element | null {
                             <span className="truncate text-[14px] font-semibold text-foreground">
                               {entry.match.displayNameRange ? (
                                 <HighlightedText
-                                  text={worktree.displayName}
+                                  text={worktreeLabel}
                                   matchRange={entry.match.displayNameRange}
                                 />
                               ) : (
-                                worktree.displayName
+                                worktreeLabel
                               )}
                             </span>
                             {isCurrentWorktree && (

--- a/src/renderer/src/components/cmd-j/worktree-checks-review-index.test.ts
+++ b/src/renderer/src/components/cmd-j/worktree-checks-review-index.test.ts
@@ -177,4 +177,25 @@ describe('buildWorktreeChecksReviewIndex', () => {
     expect(reviews.has(localWorktree)).toBe(false)
     expect(reviews.get(sshWorktree)).toMatchObject({ provider: 'github', number: 42 })
   })
+
+  it('skips a branch-less worktree instead of throwing', () => {
+    // Why: Cmd+J builds this index for every worktree before any query is typed,
+    // so a folder workspace (empty branch) or a partially hydrated row reaches it.
+    const branchless: Worktree = {
+      ...worktree,
+      id: 'worktree-folder',
+      branch: undefined as unknown as string,
+      displayName: undefined as unknown as string
+    }
+
+    const reviews = buildWorktreeChecksReviewIndex({
+      worktrees: [branchless],
+      repoByHostIdentity: new Map([[getRepoHostIdentity(repo), repo]]),
+      prCache: {},
+      hostedReviewCache: {},
+      settings: null
+    })
+
+    expect(reviews.has(branchless)).toBe(false)
+  })
 })

--- a/src/renderer/src/components/cmd-j/worktree-checks-review-index.ts
+++ b/src/renderer/src/components/cmd-j/worktree-checks-review-index.ts
@@ -1,4 +1,4 @@
-import { branchName } from '@/lib/git-utils'
+import { resolveWorktreeBranchLabel } from '@/lib/worktree-default-display-name'
 import { getGitHubPRCacheKey } from '@/store/slices/github-cache-key'
 import { getHostedReviewCacheKey } from '@/store/slices/hosted-review-cache-identity'
 import { getRepoHostIdentityForParts } from '@/store/slices/repo-host-identity'
@@ -35,7 +35,9 @@ export function buildWorktreeChecksReviewIndex({
     if (!repo) {
       continue
     }
-    const branch = branchName(worktree.branch)
+    // Why: Cmd+J builds this index for every worktree before search runs, so a
+    // branch-less folder workspace or partially hydrated row must not throw here.
+    const branch = resolveWorktreeBranchLabel(worktree)
     const prKey = getGitHubPRCacheKey(
       repo.path,
       repo.id,

--- a/src/renderer/src/components/sidebar/worktree-meta-updates.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-meta-updates.test.ts
@@ -49,6 +49,19 @@ describe('buildWorktreeMetaUpdates', () => {
     })
   })
 
+  it('clears a display name with empty string, never a present-undefined key', () => {
+    const updates = buildWorktreeMetaUpdates({
+      displayNameInput: '   ',
+      currentDisplayName: 'Custom Name',
+      issueInput: '',
+      prInput: '',
+      commentInput: ''
+    })
+
+    expect(updates.displayName).toBe('')
+    expect(Object.values(updates).every((value) => value !== undefined)).toBe(true)
+  })
+
   it('rejects PR URLs in the issue input', () => {
     expect(
       buildWorktreeMetaUpdates({

--- a/src/renderer/src/components/sidebar/worktree-meta-updates.ts
+++ b/src/renderer/src/components/sidebar/worktree-meta-updates.ts
@@ -48,12 +48,14 @@ export function buildWorktreeMetaUpdates(args: {
   const finalLinkedPR =
     trimmedPR === '' ? null : linkedPRNumber !== null ? linkedPRNumber : undefined
 
+  // Why: blanking the field means "fall back to the branch/folder name", and the
+  // empty string is how that intent is persisted. Emitting `undefined` instead
+  // put a present-but-undefined key into the store spread, wiping the live name
+  // and crashing the worktree palette (crash a1f81ea1).
   const trimmedDisplayName = args.displayNameInput.trim()
   const updates: Partial<WorktreeMeta> = {
     comment: args.commentInput.trim(),
-    ...(trimmedDisplayName !== args.currentDisplayName && {
-      displayName: trimmedDisplayName || undefined
-    })
+    ...(trimmedDisplayName !== args.currentDisplayName && { displayName: trimmedDisplayName })
   }
   if (finalLinkedIssue !== undefined) {
     updates.linkedIssue = finalLinkedIssue

--- a/src/renderer/src/lib/browser-palette-search.test.ts
+++ b/src/renderer/src/lib/browser-palette-search.test.ts
@@ -331,4 +331,54 @@ describe('browser-palette-search', () => {
   it('rejects oversized whitespace before trimming', () => {
     expect(searchBrowserPages([], ' '.repeat(BROWSER_PALETTE_QUERY_MAX_BYTES + 1))).toEqual([])
   })
+
+  it('falls back to the branch label when a cleared display name left it undefined', () => {
+    // Why: Cmd+J runs this search over the same worktree objects as searchWorktrees,
+    // so the store-level display-name corruption reaches here too.
+    const cleared = makeWorktree({
+      displayName: undefined as unknown as string,
+      branch: 'refs/heads/feature/browser-search'
+    })
+    const entries: SearchableBrowserPage[] = [
+      {
+        page: makePage(),
+        workspace: makeWorkspace(),
+        worktree: cleared,
+        repoName: 'orca',
+        worktreeSortIndex: 0,
+        isCurrentPage: false,
+        isCurrentWorktree: false
+      }
+    ]
+
+    const results = searchBrowserPages(entries, 'browser-search')
+    expect(results[0]).toMatchObject({
+      worktreeName: 'feature/browser-search',
+      worktreeRange: { start: 'feature/'.length, end: 'feature/browser-search'.length }
+    })
+  })
+
+  it('lists a branch-less row on the empty query without throwing', () => {
+    const cleared = makeWorktree({
+      displayName: undefined as unknown as string,
+      branch: undefined as unknown as string,
+      path: '/repos/design-review'
+    })
+    const entries: SearchableBrowserPage[] = [
+      {
+        page: makePage(),
+        workspace: makeWorkspace(),
+        worktree: cleared,
+        repoName: 'orca',
+        worktreeSortIndex: 0,
+        isCurrentPage: false,
+        isCurrentWorktree: false
+      }
+    ]
+
+    expect(searchBrowserPages(entries, '')[0]).toMatchObject({
+      worktreeName: 'design-review',
+      worktreeRange: null
+    })
+  })
 })

--- a/src/renderer/src/lib/browser-palette-search.ts
+++ b/src/renderer/src/lib/browser-palette-search.ts
@@ -1,6 +1,7 @@
 import { ORCA_BROWSER_BLANK_URL } from '../../../shared/constants'
 import type { BrowserPage, BrowserWorkspace, Worktree } from '../../../shared/types'
 import { isClipboardTextByteLengthOverLimit } from '../../../shared/clipboard-text'
+import { resolveWorktreeDisplayName } from './worktree-default-display-name'
 import type { MatchRange } from './worktree-palette-search'
 
 export type SearchableBrowserPage = {
@@ -125,6 +126,8 @@ export function searchBrowserPages(
     const formattedUrl = formatBrowserPaletteUrl(entry.page.url)
     const title = entry.page.title || formattedUrl
     const fallbackSecondaryText = formattedUrl
+    // Why: a cleared display name leaves this undefined at runtime; findRange would throw.
+    const worktreeName = resolveWorktreeDisplayName(entry.worktree)
     const baseResult = {
       pageId: entry.page.id,
       workspaceId: entry.workspace.id,
@@ -132,7 +135,7 @@ export function searchBrowserPages(
       title,
       workspaceLabel: entry.workspace.label ?? null,
       repoName: entry.repoName,
-      worktreeName: entry.worktree.displayName,
+      worktreeName,
       isCurrentPage: entry.isCurrentPage,
       isCurrentWorktree: entry.isCurrentWorktree
     }
@@ -234,7 +237,7 @@ export function searchBrowserPages(
       continue
     }
 
-    const worktreeRange = findRange(entry.worktree.displayName, trimmedQuery)
+    const worktreeRange = findRange(worktreeName, trimmedQuery)
     if (worktreeRange) {
       results.push({
         ...baseResult,

--- a/src/renderer/src/lib/simulator-palette-search.test.ts
+++ b/src/renderer/src/lib/simulator-palette-search.test.ts
@@ -174,4 +174,49 @@ describe('simulator-palette-search', () => {
   it('rejects oversized whitespace before trimming simulator palette queries', () => {
     expect(searchSimulatorTabs([], ' '.repeat(SIMULATOR_PALETTE_QUERY_MAX_BYTES + 1))).toEqual([])
   })
+
+  it('falls back to the branch label when a cleared display name left it undefined', () => {
+    // Why: Cmd+J runs this search over the same worktree objects as searchWorktrees,
+    // so the store-level display-name corruption reaches here too.
+    const entries = [
+      {
+        tab: makeTab(),
+        worktree: makeWorktree({
+          displayName: undefined as unknown as string,
+          branch: 'refs/heads/feature/mobile-emulator'
+        }),
+        repoName: 'orca',
+        worktreeSortIndex: 0,
+        isCurrentTab: false,
+        isCurrentWorktree: false
+      }
+    ]
+
+    expect(searchSimulatorTabs(entries, 'mobile-emulator')[0]).toMatchObject({
+      worktreeName: 'feature/mobile-emulator',
+      worktreeRange: { start: 'feature/'.length, end: 'feature/mobile-emulator'.length }
+    })
+  })
+
+  it('lists a branch-less row on the empty query without throwing', () => {
+    const entries = [
+      {
+        tab: makeTab(),
+        worktree: makeWorktree({
+          displayName: undefined as unknown as string,
+          branch: undefined as unknown as string,
+          path: '/repos/design-review'
+        }),
+        repoName: 'orca',
+        worktreeSortIndex: 0,
+        isCurrentTab: false,
+        isCurrentWorktree: false
+      }
+    ]
+
+    expect(searchSimulatorTabs(entries, '')[0]).toMatchObject({
+      worktreeName: 'design-review',
+      worktreeRange: null
+    })
+  })
 })

--- a/src/renderer/src/lib/simulator-palette-search.ts
+++ b/src/renderer/src/lib/simulator-palette-search.ts
@@ -1,5 +1,6 @@
 import type { Tab, TabGroup, Worktree } from '../../../shared/types'
 import { isClipboardTextByteLengthOverLimit } from '../../../shared/clipboard-text'
+import { resolveWorktreeDisplayName } from './worktree-default-display-name'
 import type { MatchRange } from './worktree-palette-search'
 
 export type SearchableSimulatorTab = {
@@ -180,6 +181,8 @@ export function searchSimulatorTabs(
   for (const entry of entries) {
     const title = entry.tab.label || 'Mobile Emulator'
     const secondaryText = 'Mobile Emulator tab'
+    // Why: a cleared display name leaves this undefined at runtime; findRange would throw.
+    const worktreeName = resolveWorktreeDisplayName(entry.worktree)
     const baseResult = {
       tabId: entry.tab.id,
       worktreeId: entry.worktree.id,
@@ -187,7 +190,7 @@ export function searchSimulatorTabs(
       title,
       secondaryText,
       repoName: entry.repoName,
-      worktreeName: entry.worktree.displayName,
+      worktreeName,
       isCurrentTab: entry.isCurrentTab,
       isCurrentWorktree: entry.isCurrentWorktree
     }
@@ -253,7 +256,7 @@ export function searchSimulatorTabs(
       continue
     }
 
-    const worktreeRange = findRange(entry.worktree.displayName, trimmedQuery)
+    const worktreeRange = findRange(worktreeName, trimmedQuery)
     if (worktreeRange) {
       results.push({
         ...baseResult,

--- a/src/renderer/src/lib/workspace-tab-palette-results.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-results.ts
@@ -1,3 +1,4 @@
+import { resolveWorktreeDisplayName } from './worktree-default-display-name'
 import type { MatchRange } from './worktree-palette-search'
 import type {
   SearchableWorkspaceTab,
@@ -114,6 +115,8 @@ export function searchWorkspaceTabs(
   const results: WorkspaceTabPaletteSearchResult[] = []
 
   for (const entry of entries) {
+    // Why: a cleared display name leaves this undefined at runtime; findRange would throw.
+    const worktreeName = resolveWorktreeDisplayName(entry.worktree)
     const baseResult = {
       tabId: entry.tab.id,
       entityId: entry.tab.entityId,
@@ -123,7 +126,7 @@ export function searchWorkspaceTabs(
       title: entry.title,
       secondaryText: entry.secondaryText,
       repoName: entry.repoName,
-      worktreeName: entry.worktree.displayName,
+      worktreeName,
       isCurrentTab: entry.isCurrentTab,
       isCurrentWorktree: entry.isCurrentWorktree
     }
@@ -200,7 +203,7 @@ export function searchWorkspaceTabs(
       continue
     }
 
-    const worktreeRange = findRange(entry.worktree.displayName, trimmedQuery)
+    const worktreeRange = findRange(worktreeName, trimmedQuery)
     if (worktreeRange) {
       results.push({
         ...baseResult,

--- a/src/renderer/src/lib/workspace-tab-palette-search.test.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-search.test.ts
@@ -438,4 +438,36 @@ describe('workspace-tab-palette-search', () => {
       'terminal-other'
     ])
   })
+
+  it('falls back to the branch label when a cleared display name left it undefined', () => {
+    // Why: Cmd+J runs this search over the same worktree objects as searchWorktrees,
+    // so the store-level display-name corruption reaches here too.
+    const cleared = makeWorktree({
+      displayName: undefined as unknown as string,
+      branch: 'refs/heads/feature/workspace-tab-search'
+    })
+    const entries = buildEntries({ worktrees: [cleared] })
+
+    expect(searchWorkspaceTabs(entries, 'workspace-tab-search')[0]).toMatchObject({
+      worktreeName: 'feature/workspace-tab-search',
+      worktreeRange: {
+        start: 'feature/'.length,
+        end: 'feature/workspace-tab-search'.length
+      }
+    })
+  })
+
+  it('lists a branch-less row on the empty query without throwing', () => {
+    const cleared = makeWorktree({
+      displayName: undefined as unknown as string,
+      branch: undefined as unknown as string,
+      path: path.join('repos', 'design-review')
+    })
+    const entries = buildEntries({ worktrees: [cleared] })
+
+    expect(searchWorkspaceTabs(entries, '')[0]).toMatchObject({
+      worktreeName: 'design-review',
+      worktreeRange: null
+    })
+  })
 })

--- a/src/renderer/src/lib/worktree-default-display-name.test.ts
+++ b/src/renderer/src/lib/worktree-default-display-name.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveWorktreeBranchLabel,
+  resolveWorktreeDisplayName
+} from './worktree-default-display-name'
+
+describe('resolveWorktreeBranchLabel', () => {
+  it('strips refs/heads/ like the raw branchName call it replaces', () => {
+    expect(resolveWorktreeBranchLabel({ branch: 'refs/heads/feature/jump' })).toBe('feature/jump')
+  })
+
+  it('returns empty for a folder workspace, which carries no branch', () => {
+    expect(resolveWorktreeBranchLabel({ branch: '' })).toBe('')
+  })
+
+  it('returns empty instead of throwing when branch is absent at runtime', () => {
+    // The palette renders every row on an empty query, before any branch search runs,
+    // so an unguarded branchName() here crashed the whole palette.
+    expect(resolveWorktreeBranchLabel({ branch: undefined as unknown as string })).toBe('')
+  })
+})
+
+describe('resolveWorktreeDisplayName', () => {
+  it('prefers the custom name', () => {
+    expect(
+      resolveWorktreeDisplayName({
+        displayName: 'Design review',
+        branch: 'refs/heads/feature/jump',
+        path: '/repos/orca'
+      })
+    ).toBe('Design review')
+  })
+
+  it('falls back to the branch when the name was blanked to an empty string', () => {
+    expect(
+      resolveWorktreeDisplayName({
+        displayName: '',
+        branch: 'refs/heads/feature/jump',
+        path: '/repos/orca'
+      })
+    ).toBe('feature/jump')
+  })
+
+  it('treats a whitespace-only name as blank', () => {
+    expect(
+      resolveWorktreeDisplayName({
+        displayName: '   ',
+        branch: 'refs/heads/main',
+        path: '/repos/orca'
+      })
+    ).toBe('main')
+  })
+
+  it('falls back to the branch when a cleared name left the field undefined', () => {
+    expect(
+      resolveWorktreeDisplayName({
+        displayName: undefined as unknown as string,
+        branch: 'refs/heads/main',
+        path: '/repos/orca'
+      })
+    ).toBe('main')
+  })
+
+  it('falls back to the folder name for a branch-less folder workspace', () => {
+    expect(
+      resolveWorktreeDisplayName({ displayName: '', branch: '', path: '/repos/design-review' })
+    ).toBe('design-review')
+  })
+
+  it('resolves the folder name from a Windows path', () => {
+    expect(
+      resolveWorktreeDisplayName({
+        displayName: '',
+        branch: '',
+        path: 'C:\\Users\\alice\\repos\\design-review'
+      })
+    ).toBe('design-review')
+  })
+
+  it('keeps emoji and non-ASCII names intact', () => {
+    expect(
+      resolveWorktreeDisplayName({ displayName: '🚀 Läufer', branch: '', path: '/repos/x' })
+    ).toBe('🚀 Läufer')
+  })
+
+  it('returns empty rather than throwing when every source is missing', () => {
+    expect(
+      resolveWorktreeDisplayName({
+        displayName: undefined as unknown as string,
+        branch: undefined as unknown as string,
+        path: undefined as unknown as string
+      })
+    ).toBe('')
+  })
+})

--- a/src/renderer/src/lib/worktree-default-display-name.ts
+++ b/src/renderer/src/lib/worktree-default-display-name.ts
@@ -1,0 +1,34 @@
+import { branchName } from '@/lib/git-utils'
+import { basename } from '@/lib/path'
+import type { Worktree } from '../../../shared/types'
+
+type WorktreeDisplayNameSource = Pick<Worktree, 'displayName' | 'branch' | 'path'>
+
+/**
+ * `branch` is typed non-optional but is absent on folder workspaces and
+ * partially hydrated rows, and `branchName` throws on undefined. Every render
+ * and search read of the branch label must go through here.
+ */
+export function resolveWorktreeBranchLabel(worktree: Pick<Worktree, 'branch'>): string {
+  return typeof worktree.branch === 'string' ? branchName(worktree.branch) : ''
+}
+
+/**
+ * Renderer mirror of main-side `mergeWorktree`: a missing or blank custom name
+ * falls back to the branch, then the folder. `displayName` is typed non-optional
+ * but arrives undefined at runtime once a custom name is cleared (crash
+ * a1f81ea1), so every read must go through here instead of dereferencing it.
+ */
+export function resolveWorktreeDisplayName(worktree: WorktreeDisplayNameSource): string {
+  const custom = typeof worktree.displayName === 'string' ? worktree.displayName.trim() : ''
+  if (custom) {
+    return custom
+  }
+
+  const branch = resolveWorktreeBranchLabel(worktree).trim()
+  if (branch) {
+    return branch
+  }
+
+  return typeof worktree.path === 'string' ? basename(worktree.path).trim() : ''
+}

--- a/src/renderer/src/lib/worktree-palette-search.test.ts
+++ b/src/renderer/src/lib/worktree-palette-search.test.ts
@@ -141,6 +141,63 @@ describe('worktree-palette-search', () => {
     expect(searchWorktrees([makeWorktree()], query, repoMap, null, null)).toEqual([])
   })
 
+  it('falls back to branch text when a cleared display name left it undefined', () => {
+    const cleared = makeWorktree({
+      displayName: undefined as unknown as string,
+      branch: 'refs/heads/feature/worktree-jump'
+    })
+
+    expect(() => searchWorktrees([cleared], 'jump', repoMap, null, null)).not.toThrow()
+    // Highlight range indexes the branch-derived label the palette actually renders.
+    expect(searchWorktrees([cleared], 'jump', repoMap, null, null)[0]).toMatchObject({
+      worktreeId: 'wt-1',
+      matchedField: 'displayName',
+      displayNameRange: { start: 'feature/worktree-'.length, end: 'feature/worktree-jump'.length }
+    })
+  })
+
+  it('falls back to the folder name when both display name and branch are missing', () => {
+    const folderWorkspace = makeWorktree({
+      displayName: undefined as unknown as string,
+      branch: '',
+      path: '/tmp/design-review'
+    })
+
+    expect(searchWorktrees([folderWorkspace], 'design', repoMap, null, null)[0]).toMatchObject({
+      matchedField: 'displayName',
+      displayNameRange: { start: 0, end: 6 }
+    })
+  })
+
+  it('survives a cleared display name on composite repo/branch queries', () => {
+    const cleared = makeWorktree({
+      displayName: undefined as unknown as string,
+      branch: undefined as unknown as string
+    })
+
+    expect(() => searchWorktrees([cleared], 'orca/jump', repoMap, null, null)).not.toThrow()
+  })
+
+  it('still lists a branch-less row on the empty query, which renders every row', () => {
+    // Why: the empty query short-circuits before any branch read, so the row reaches the
+    // render loop untouched — the label resolution there has to be guarded too.
+    const cleared = makeWorktree({
+      displayName: undefined as unknown as string,
+      branch: undefined as unknown as string
+    })
+
+    expect(searchWorktrees([cleared], '', repoMap, null, null)).toEqual([
+      {
+        worktreeId: 'wt-1',
+        matchedField: null,
+        displayNameRange: null,
+        branchRange: null,
+        repoRange: null,
+        supportingText: null
+      }
+    ])
+  })
+
   it('returns a truncated comment snippet with the highlighted match range', () => {
     const results = searchWorktrees(
       [

--- a/src/renderer/src/lib/worktree-palette-search.ts
+++ b/src/renderer/src/lib/worktree-palette-search.ts
@@ -1,5 +1,8 @@
-import { branchName } from '@/lib/git-utils'
 import { issueCacheKey as getIssueCacheKey } from '@/store/slices/github'
+import {
+  resolveWorktreeBranchLabel,
+  resolveWorktreeDisplayName
+} from './worktree-default-display-name'
 import type { HostedReviewInfo } from '../../../shared/hosted-review'
 import type { Repo, Worktree } from '../../../shared/types'
 import { extractWorktreePaletteCommentSnippet } from './worktree-palette-comment-snippet'
@@ -101,7 +104,7 @@ export function searchWorktrees(
   for (const worktree of worktrees) {
     if (composite) {
       const repoName = repoMap.get(worktree.repoId)?.displayName ?? ''
-      const branch = branchName(worktree.branch)
+      const branch = resolveWorktreeBranchLabel(worktree)
       const repoIdx = repoName.toLowerCase().indexOf(composite.repoPart)
       const branchIdx = branch.toLowerCase().indexOf(composite.branchPart)
       if (repoIdx !== -1 && branchIdx !== -1) {
@@ -117,7 +120,7 @@ export function searchWorktrees(
       // that happens to contain a slash (e.g. "feature/foo") still get hits.
     }
 
-    const nameIndex = worktree.displayName.toLowerCase().indexOf(q)
+    const nameIndex = resolveWorktreeDisplayName(worktree).toLowerCase().indexOf(q)
     if (nameIndex !== -1) {
       results.push(
         makeResult(worktree.id, 'displayName', {
@@ -127,7 +130,7 @@ export function searchWorktrees(
       continue
     }
 
-    const branch = branchName(worktree.branch)
+    const branch = resolveWorktreeBranchLabel(worktree)
     const branchIndex = branch.toLowerCase().indexOf(q)
     if (branchIndex !== -1) {
       results.push(

--- a/src/renderer/src/store/slices/worktree-helpers.test.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.test.ts
@@ -51,4 +51,21 @@ describe('applyWorktreeUpdates', () => {
     expect(result['repo-b']?.[0]).toBe(samePathDifferentProject)
     expect(result['repo-b']?.[0]?.displayName).toBe('Project B')
   })
+
+  it('never lets a present-but-undefined value clobber existing worktree fields', () => {
+    const target = makeWorktree({
+      id: 'repo-a::/Users/alice/project',
+      repoId: 'repo-a',
+      displayName: 'Project A',
+      comment: 'notes'
+    })
+
+    const result = applyWorktreeUpdates({ 'repo-a': [target] }, target.id, {
+      displayName: undefined,
+      comment: 'edited'
+    })
+
+    expect(result['repo-a']?.[0]?.displayName).toBe('Project A')
+    expect(result['repo-a']?.[0]?.comment).toBe('edited')
+  })
 })

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -326,11 +326,51 @@ export function findWorktreeById(
   return undefined
 }
 
+type RequiredKey<T> = { [K in keyof T]-?: undefined extends T[K] ? never : K }[keyof T]
+
+// Why: a present-but-undefined key in a spread ERASES the field. That is the
+// intended wire signal for clearing optional metadata (pushTarget), but on a
+// field Worktree declares required it produced a live `displayName: undefined`
+// that crashed the worktree palette (crash a1f81ea1). Typed off Worktree so a
+// newly-required field is protected automatically.
+const ERASURE_PROTECTED_KEYS: Record<Extract<RequiredKey<Worktree>, keyof WorktreeMeta>, true> = {
+  displayName: true,
+  comment: true,
+  linkedIssue: true,
+  linkedPR: true,
+  linkedLinearIssue: true,
+  isArchived: true,
+  isUnread: true,
+  isPinned: true,
+  sortOrder: true,
+  lastActivityAt: true
+}
+
+export function withoutErasedRequiredWorktreeFields(
+  updates: Partial<WorktreeMeta>
+): Partial<WorktreeMeta> {
+  const erased = Object.keys(ERASURE_PROTECTED_KEYS).filter(
+    (key) =>
+      updates[key as keyof WorktreeMeta] === undefined &&
+      Object.prototype.hasOwnProperty.call(updates, key)
+  )
+  if (erased.length === 0) {
+    return updates
+  }
+
+  const next = { ...updates }
+  for (const key of erased) {
+    delete next[key as keyof WorktreeMeta]
+  }
+  return next
+}
+
 export function applyWorktreeUpdates(
   worktreesByRepo: Record<string, Worktree[]>,
   worktreeId: string,
-  updates: Partial<WorktreeMeta>
+  rawUpdates: Partial<WorktreeMeta>
 ): Record<string, Worktree[]> {
+  const updates = withoutErasedRequiredWorktreeFields(rawUpdates)
   const repoId = getRepoIdFromWorktreeId(worktreeId)
   const worktrees = worktreesByRepo[repoId]
   if (!worktrees) {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -20,6 +20,7 @@ import type { RuntimeWorktreeListResult } from '../../../../shared/runtime-types
 import {
   findWorktreeById,
   applyWorktreeUpdates,
+  withoutErasedRequiredWorktreeFields,
   getRepoIdFromWorktreeId,
   type DirectSshWorktreeFetchOptions,
   type WorktreeFetchOptions,
@@ -705,8 +706,10 @@ function notifyRuntimeScopeForbiddenIfNeeded(error: unknown): boolean {
 function applyDetectedWorktreeUpdates(
   detectedWorktreesByRepo: AppState['detectedWorktreesByRepo'],
   worktreeId: string,
-  updates: Partial<WorktreeMeta>
+  rawUpdates: Partial<WorktreeMeta>
 ): AppState['detectedWorktreesByRepo'] {
+  // Why: mirrors applyWorktreeUpdates — detected rows feed the same palette.
+  const updates = withoutErasedRequiredWorktreeFields(rawUpdates)
   let changed = false
   const nextByRepo: AppState['detectedWorktreesByRepo'] = {}
 


### PR DESCRIPTION
## What this fixes

Crash report `a1f81ea1-e7ea-4a48-a9f8-3ba9e6a2ef04` (cluster C), boundary `modal.worktree-palette`:

```
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at searchWorktrees (src/renderer/src/lib/worktree-palette-search.ts:120)
```

**User action that triggers it:** open a workspace's edit dialog, clear the **Display Name** field, and save. The dialog explicitly invites this — its help text reads *"Leave blank to use the branch or folder name."* The next time you open Cmd+J and type a character, the palette throws and the modal dies.

**Root cause, three layers deep:**

1. **Producer.** `buildWorktreeMetaUpdates` emitted `displayName: trimmedDisplayName || undefined` — a *present* key whose value is `undefined`, not an absent key.
2. **Store.** `applyWorktreeUpdates` merges with `{ ...worktree, ...updates }`. A present-but-undefined key in a spread **erases** the field, so the live `Worktree` ended up carrying `displayName: undefined` despite the type declaring it `string`.
3. **Reader.** `searchWorktrees` dereferenced `worktree.displayName.toLowerCase()` unguarded. Boom.

Reported on shipped build **1.4.159** (macOS), but the defect is **latent on all platforms and in earlier builds** — nothing in the path is OS-specific. Confirmed **not already fixed in `HEAD`/`origin/main`**: `origin/main` still has the raw `worktree.displayName.toLowerCase()` at line 120 and still has `trimmedDisplayName || undefined` in `worktree-meta-updates.ts`; the new helper module does not exist on main.

## Fix evidence

Real output, captured from this branch.

**Before — source reverted via `git stash` while keeping every new test in place.** This is the anti-tautology proof: if the tests passed here, they would not be testing anything.

```
$ git stash push -m "src-only-revert-proof" -- <the 10 changed source files>
$ pnpm vitest run --config config/vitest.config.ts <9 suites>

     × falls back to the branch label when a cleared display name left it undefined 2ms
     × lists a branch-less row on the empty query without throwing 2ms
     × never lets a present-but-undefined value clobber existing worktree fields 2ms
     × clears a display name with empty string, never a present-undefined key 2ms
     × skips a branch-less worktree instead of throwing 1ms
     × falls back to branch text when a cleared display name left it undefined 3ms
     × falls back to the folder name when both display name and branch are missing 1ms
     × survives a cleared display name on composite repo/branch queries 0ms
     × keeps a blanked display name on remote hosts instead of dropping the clear 3ms

 FAIL  src/renderer/src/lib/browser-palette-search.test.ts > falls back to the branch label when a cleared display name left it undefined
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
 FAIL  src/renderer/src/lib/simulator-palette-search.test.ts > falls back to the branch label when a cleared display name left it undefined
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
 FAIL  src/renderer/src/lib/workspace-tab-palette-search.test.ts > falls back to the branch label when a cleared display name left it undefined
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
 FAIL  src/renderer/src/lib/worktree-palette-search.test.ts > falls back to branch text when a cleared display name left it undefined
AssertionError: expected [Function] to not throw an error but 'TypeError: Cannot read properties of …' was thrown
"TypeError: Cannot read properties of undefined (reading 'toLowerCase')"
 FAIL  src/renderer/src/lib/worktree-palette-search.test.ts > survives a cleared display name on composite repo/branch queries
"TypeError: Cannot read properties of undefined (reading 'replace')"
 FAIL  src/renderer/src/components/cmd-j/worktree-checks-review-index.test.ts > skips a branch-less worktree instead of throwing
TypeError: Cannot read properties of undefined (reading 'replace')
 FAIL  src/renderer/src/components/sidebar/worktree-meta-updates.test.ts > clears a display name with empty string, never a present-undefined key
AssertionError: expected undefined to be '' // Object.is equality
 FAIL  src/main/runtime/rpc/methods/worktree-schemas.test.ts > keeps a blanked display name on remote hosts instead of dropping the clear
AssertionError: expected undefined to be '' // Object.is equality
 FAIL  src/renderer/src/store/slices/worktree-helpers.test.ts > never lets a present-but-undefined value clobber existing worktree fields
AssertionError: expected undefined to be 'Project A' // Object.is equality

 Test Files  9 failed (9)
      Tests  13 failed | 59 passed (72)
```

The reverted run reproduces the **exact** production error string, `Cannot read properties of undefined (reading 'toLowerCase')`, from the test suite.

**After — source restored:**

```
$ git stash pop
$ pnpm vitest run --config config/vitest.config.ts <9 suites>

 RUN  v4.1.5

 Test Files  9 passed (9)
      Tests  83 passed (83)
   Duration  416ms
```

**Broad regression sweep** over every touched area (store slices, lib, sidebar, cmd-j, RPC methods):

```
 Test Files  744 passed (744)
      Tests  7724 passed | 1 skipped (7725)
   Duration  33.78s
```

**Lint and typecheck:**

```
$ pnpm oxlint <11 changed source files>
LINT EXIT=0

$ pnpm typecheck
> tsc --noEmit -p config/tsconfig.node.json && tsc --noEmit -p config/tsconfig.tc.cli.json && tsc --noEmit -p config/tsconfig.tc.web.json
TYPECHECK EXIT=0
```

## ELI5

Every workspace has a nickname. The rename box says *"leave this blank and I'll just use the branch name instead"* — so people do leave it blank.

The bug: when you cleared the box, the app didn't store "blank." It stored *"this nickname no longer exists at all."* Those sound the same but aren't. It's the difference between a contact in your phone with an empty name field, and the contact record being ripped out entirely while the phone still insists it's there.

Later, the Cmd+J quick-jump window tries to search your workspaces by nickname. It reaches for a nickname the app promised would always be there, finds nothing, and the whole window falls over.

The fix does three things. It stores blank as *actually blank* instead of *gone*. It teaches the part that saves changes to refuse to delete fields that are supposed to always exist. And it teaches every part that reads a nickname to fall back gracefully — nickname, then branch name, then folder name — instead of assuming and crashing.

## Trade-offs

**What the UI shows when a display name is blanked — verified, not assumed.** It falls back to the **branch name**, and for a branch-less folder workspace to the **folder name**. This is exactly what the dialog's help text promises. It is **not** an empty label. Verified concretely:

- The new `resolveWorktreeDisplayName` implements `custom -> branch -> folder basename`, deliberately mirroring the main-process `mergeWorktree` (`src/main/ipc/worktree-metadata-merge.ts`), which already computed `meta?.displayName || branchShort || defaultDisplayName || basename(git.path)`. The renderer was the only place lacking that fallback.
- Covered by tests: blanked-to-`''` resolves to `feature/jump`; whitespace-only resolves to `main`; branch-less folder workspace resolves to `design-review`; a Windows path `C:\Users\alice\repos\design-review` also resolves to `design-review`.
- The sidebar card was already safe on its own: `getWorktreeCardTitleDisplay` already normalized blank names and preferred branch/issue titles. It needed no change.

**User-visible behavior changes — two, both corrections toward the documented promise:**

1. **On remote/SSH and paired-web hosts, blanking a display name now actually works.** `WorktreeSet.displayName` used `OptionalString`, which coerces `''` to `undefined`; the main process then dropped the key in `omitUndefinedProperties`, so the clear was silently discarded and the old name reappeared on the next refresh. It now uses `OptionalPlainString`, so `''` survives as a real clear. Local users saw the name clear (via the crashing path); remote users didn't. Both now behave the same. This was an unreported second bug found while fixing the first.
2. **Highlight ranges in the palette now land on the text actually rendered.** Search and render previously resolved the label independently; both now go through the same resolver, so a highlight can't be offset against a different string.

**Deliberate design costs:**

- The store guard is a **denylist keyed off the type**: `ERASURE_PROTECTED_KEYS` is typed as `Record<Extract<RequiredKey<Worktree>, keyof WorktreeMeta>, true>`, so if someone later makes a `WorktreeMeta` field required on `Worktree`, **the build fails until they add it**. It cannot silently rot. The cost is one more thing to keep in sync — mitigated by the compiler enforcing it.
- The guard is intentionally scoped to *required* fields only. Genuinely optional metadata (notably `pushTarget`) still uses present-undefined as its legitimate "erase this" wire signal, and that behavior is preserved untouched.
- Three layers of defense for one bug is arguably redundant. That's on purpose: the reader guards alone would leave corrupt `undefined` sitting in the store for other future consumers, and the producer fix alone wouldn't protect users whose state is *already* corrupted from running 1.4.159. Users with existing bad state are healed by the store guard on the next update.
- `resolveWorktreeDisplayName` does a `typeof` check on a field the type says is always a `string`. That looks like dead code to a reader who trusts the types. The comments explain why it isn't — this exact lie is what produced the crash.

## Adversarial review

Three rounds. Rounds 1 and 2 each found a real, shipped bypass — which is why this diff touches 20 files instead of 2.

- **Round 1 — found a real bypass.** The palette **render** site (`WorktreeJumpPalette.tsx:1798`) still called `branchName(worktree.branch)` unguarded, so the crash was only half-fixed. Also found the original tests only exercised the composite `repo/branch` query path, missing the empty-query render exposure — the empty query short-circuits before any branch read and hands every row straight to the render loop.
- **Round 2 — found a real bypass.** The fix guarded only **1 of 4** search paths in the same modal. `WorktreeJumpPalette` runs four independent searches over the same `Worktree` objects (worktree, browser page, simulator tab, workspace tab). Worst of the set: `buildWorktreeChecksReviewIndex` (`worktree-checks-review-index.ts:40`) called `branchName(worktree.branch)` unguarded and runs **before every search**, so it would throw ahead of any query being typed.
- **Round 3 (this review) — clean, no new bypasses.** Swept `.displayName.` and `branchName(` across the entire renderer. Findings:
  - All four palette searches, the checks/review index, and the render site now route through the shared resolver. No unguarded reader remains on any palette or sidebar path.
  - Audited every `{ ...worktree, ...updates }` spread in the renderer. Exactly two take a `Partial<WorktreeMeta>` (`worktree-helpers.ts:387`, `worktrees.ts:724`) and **both** are now guarded — the second, `applyDetectedWorktreeUpdates`, feeds detected rows into the same palette and would otherwise have been a live fourth bypass. The third spread merges a fully-built `Worktree` from a create result, which has no erasure exposure.
  - Remaining unguarded `worktree.displayName.trim()` reads at `AutomationsPage.tsx:657`, `github-work-item-workspace-attachment.ts:44`, and `smart-sort.ts:52` were each checked. `smart-sort` already `typeof`-guards; the other two are now unreachable with `undefined` because the store guard prevents the corrupt value from ever entering state, and they are off the palette path. Left unchanged deliberately rather than scattering redundant guards — the store is the correct choke point.
  - Grepped for the same `|| undefined` erasure shape in other meta-update producers. No other producer feeds `Partial<WorktreeMeta>` into a worktree spread.
  - A stray debug probe file (`src/renderer/src/__probe1.test.ts`) left over from investigation was found and removed; it is not in this commit.

## Scope

- **Addresses:** crash report `a1f81ea1-e7ea-4a48-a9f8-3ba9e6a2ef04` and the rest of **cluster C** (`modal.worktree-palette` / `searchWorktrees` / `toLowerCase`). Also fixes the previously unreported remote/SSH blanking bug found en route.
- **Affected shipped versions:** reported on **1.4.159** (macOS); **latent in earlier builds and on all platforms** — no part of the failing path is OS-specific.
- **NOT related to the separate 53-report heap-exhaustion cluster.** Different failure mode entirely (an unguarded property read versus memory pressure), different boundary, no shared code path. Nothing here should be expected to move those numbers.
- **Not already in HEAD** — verified against `origin/main` as described above.

Made with [Orca](https://github.com/stablyai/orca) 🐋
