### PR TITLE
feat: open markdown files from the OS file manager

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -311,6 +311,17 @@ module.exports = {
     // by ${isUpdated} inside so it never runs during an update's uninstallOldVersion.
     include: resolve(__dirname, 'nsis', 'daemon-host-uninstall.nsh')
   },
+  // Why: puts Orca in the OS "Open With" list for markdown without claiming the default handler.
+  fileAssociations: [
+    {
+      ext: ['md', 'markdown'],
+      name: 'Markdown File',
+      description: 'Markdown document',
+      role: 'Editor',
+      rank: 'Alternate',
+      mimeType: 'text/markdown'
+    }
+  ],
   mac: {
     icon: 'resources/build/icon.icns',
     entitlements: 'resources/build/entitlements.mac.plist',

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -62,6 +62,18 @@ describe('electron-builder config', () => {
     )
   })
 
+  it('declares a markdown file association for all platforms', () => {
+    const association = electronBuilderConfig.fileAssociations?.find((entry) =>
+      entry.ext?.includes('md')
+    )
+    expect(association).toBeTruthy()
+    expect(association.ext).toEqual(['md', 'markdown'])
+    expect(association.role).toBe('Editor')
+    // Why: Alternate keeps Orca out of the default-handler slot; it only joins the Open With list.
+    expect(association.rank).toBe('Alternate')
+    expect(association.mimeType).toBe('text/markdown')
+  })
+
   it('excludes repo-only source trees from app.asar', () => {
     expect(electronBuilderConfig.files).toEqual(
       expect.arrayContaining([

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1319,6 +1319,7 @@ function openMainWindow(): BrowserWindow {
     claudeAccounts,
     rateLimits,
     rendererWebContentsId,
+    osFileOpenRequests,
     automations,
     {
       prepareForCodexLaunch: prepareCodexRuntimeHomeForLaunch,
@@ -1349,8 +1350,7 @@ function openMainWindow(): BrowserWindow {
     pluginService ?? undefined,
     pluginMarketplaceService && pluginMarketplaceInstaller
       ? { marketplace: pluginMarketplaceService, installer: pluginMarketplaceInstaller }
-      : undefined,
-    osFileOpenRequests
+      : undefined
   )
   automations.setWebContents(window.webContents)
   automations.start()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -163,6 +163,10 @@ import {
   shouldBypassSingleInstanceLock,
   shouldSkipSingleInstanceLock
 } from './startup/single-instance-lock'
+import {
+  createOsFileOpenRequestQueue,
+  registerOsFileOpenRequests
+} from './startup/os-file-open-requests'
 import { startEventLoopStallProbe } from './startup/event-loop-stall-probe'
 import { startMainThreadChurnProbe } from './diagnostics/main-thread-churn-probe'
 import {
@@ -578,6 +582,15 @@ if (app.isPackaged && process.platform !== 'win32') {
 configureDevUserDataPath(is.dev)
 configureOrcaUserDataPathEnv()
 installServeSupervisorDisconnectQuit(isServeMode)
+
+// Why: macOS fires open-file before app.ready, so the queue must exist and be subscribed at module load.
+const osFileOpenRequests = createOsFileOpenRequestQueue()
+registerOsFileOpenRequests({
+  app,
+  queue: osFileOpenRequests,
+  platform: process.platform,
+  argv: process.argv
+})
 
 // Why: just past createMainWindow's 10s ready-to-show fallback, so a window revealed that way still gets its tray icon.
 const TRAY_CREATE_FALLBACK_MS = 12_000
@@ -1336,7 +1349,8 @@ function openMainWindow(): BrowserWindow {
     pluginService ?? undefined,
     pluginMarketplaceService && pluginMarketplaceInstaller
       ? { marketplace: pluginMarketplaceService, installer: pluginMarketplaceInstaller }
-      : undefined
+      : undefined,
+    osFileOpenRequests
   )
   automations.setWebContents(window.webContents)
   automations.start()

--- a/src/main/ipc/os-file-open.test.ts
+++ b/src/main/ipc/os-file-open.test.ts
@@ -109,4 +109,51 @@ describe('registerOsFileOpenHandlers', () => {
 
     expect(sender.destroyedListenerCount()).toBe(1)
   })
+
+  it('switches delivery to the most recently registered sender, not the first', async () => {
+    const queue = createOsFileOpenRequestQueue()
+    registerOsFileOpenHandlers(queue)
+    const handler = getHandler('osFileOpen:takePending')
+
+    const senderA = createFakeSender()
+    const senderB = createFakeSender()
+    await handler({ sender: senderA })
+    await handler({ sender: senderB })
+
+    queue.enqueue('/Users/x/later.md')
+    expect(senderB.send).toHaveBeenCalledWith('osFileOpen:opened', '/Users/x/later.md')
+    expect(senderA.send).not.toHaveBeenCalled()
+  })
+
+  it('does not let a superseded sender clobber the current owner when destroyed', async () => {
+    const queue = createOsFileOpenRequestQueue()
+    registerOsFileOpenHandlers(queue)
+    const handler = getHandler('osFileOpen:takePending')
+
+    const senderA = createFakeSender()
+    const senderB = createFakeSender()
+    await handler({ sender: senderA })
+    await handler({ sender: senderB })
+    senderA.destroy()
+
+    queue.enqueue('/Users/x/later.md')
+    expect(senderB.send).toHaveBeenCalledWith('osFileOpen:opened', '/Users/x/later.md')
+  })
+
+  it('clears delivery and buffers into pending when the current owner is destroyed', async () => {
+    const queue = createOsFileOpenRequestQueue()
+    registerOsFileOpenHandlers(queue)
+    const handler = getHandler('osFileOpen:takePending')
+
+    const senderA = createFakeSender()
+    const senderB = createFakeSender()
+    await handler({ sender: senderA })
+    await handler({ sender: senderB })
+    senderB.destroy()
+
+    queue.enqueue('/Users/x/later.md')
+    expect(senderA.send).not.toHaveBeenCalled()
+    expect(senderB.send).not.toHaveBeenCalled()
+    expect(queue.drain()).toEqual(['/Users/x/later.md'])
+  })
 })

--- a/src/main/ipc/os-file-open.test.ts
+++ b/src/main/ipc/os-file-open.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as OsFileOpenRequests from '../startup/os-file-open-requests'
+
+const handleMock = vi.fn()
+vi.mock('electron', () => ({ ipcMain: { handle: handleMock } }))
+
+const filterExistingFilesMock = vi.fn(async (paths: readonly string[]) => [...paths])
+vi.mock('../startup/os-file-open-requests', async (importOriginal) => ({
+  ...(await importOriginal<typeof OsFileOpenRequests>()),
+  filterExistingFiles: (paths: readonly string[]) => filterExistingFilesMock(paths)
+}))
+
+const { createOsFileOpenRequestQueue } = await import('../startup/os-file-open-requests')
+const { registerOsFileOpenHandlers } = await import('./os-file-open')
+
+function getHandler(channel: string): (event: unknown) => Promise<string[]> {
+  const entry = handleMock.mock.calls.find(([name]) => name === channel)
+  if (!entry) {
+    throw new Error(`handler not registered: ${channel}`)
+  }
+  return entry[1]
+}
+
+function createFakeSender(): {
+  send: ReturnType<typeof vi.fn>
+  once: ReturnType<typeof vi.fn>
+  removeListener: ReturnType<typeof vi.fn>
+  isDestroyed: () => boolean
+  destroy: () => void
+  destroyedListenerCount: () => number
+} {
+  let destroyed = false
+  let destroyHandlers: (() => void)[] = []
+  return {
+    send: vi.fn(),
+    once: vi.fn((eventName: string, handler: () => void) => {
+      if (eventName === 'destroyed') {
+        destroyHandlers.push(handler)
+      }
+    }),
+    removeListener: vi.fn((eventName: string, handler: () => void) => {
+      if (eventName === 'destroyed') {
+        destroyHandlers = destroyHandlers.filter((entry) => entry !== handler)
+      }
+    }),
+    isDestroyed: () => destroyed,
+    destroy: () => {
+      destroyed = true
+      for (const handler of destroyHandlers.splice(0, destroyHandlers.length)) {
+        handler()
+      }
+    },
+    destroyedListenerCount: () => destroyHandlers.length
+  }
+}
+
+describe('registerOsFileOpenHandlers', () => {
+  beforeEach(() => {
+    handleMock.mockClear()
+    filterExistingFilesMock.mockClear()
+  })
+
+  it('drains queued paths and filters out ones that no longer exist', async () => {
+    filterExistingFilesMock.mockResolvedValueOnce(['/Users/x/a.md'])
+    const queue = createOsFileOpenRequestQueue()
+    queue.enqueue('/Users/x/a.md')
+    queue.enqueue('/Users/x/gone.md')
+    registerOsFileOpenHandlers(queue)
+
+    const sender = createFakeSender()
+    const result = await getHandler('osFileOpen:takePending')({ sender })
+
+    expect(filterExistingFilesMock).toHaveBeenCalledWith(['/Users/x/a.md', '/Users/x/gone.md'])
+    expect(result).toEqual(['/Users/x/a.md'])
+  })
+
+  it('pushes later arrivals to the renderer that took the pending batch', async () => {
+    const queue = createOsFileOpenRequestQueue()
+    registerOsFileOpenHandlers(queue)
+
+    const sender = createFakeSender()
+    await getHandler('osFileOpen:takePending')({ sender })
+
+    queue.enqueue('/Users/x/later.md')
+    expect(sender.send).toHaveBeenCalledWith('osFileOpen:opened', '/Users/x/later.md')
+  })
+
+  it('stops pushing and resumes buffering after the renderer is destroyed', async () => {
+    const queue = createOsFileOpenRequestQueue()
+    registerOsFileOpenHandlers(queue)
+
+    const sender = createFakeSender()
+    await getHandler('osFileOpen:takePending')({ sender })
+    sender.destroy()
+
+    queue.enqueue('/Users/x/later.md')
+    expect(sender.send).not.toHaveBeenCalled()
+    expect(queue.drain()).toEqual(['/Users/x/later.md'])
+  })
+
+  it('does not accumulate destroyed listeners across repeated takePending calls', async () => {
+    const queue = createOsFileOpenRequestQueue()
+    registerOsFileOpenHandlers(queue)
+
+    const sender = createFakeSender()
+    const handler = getHandler('osFileOpen:takePending')
+    await handler({ sender })
+    await handler({ sender })
+
+    expect(sender.destroyedListenerCount()).toBe(1)
+  })
+})

--- a/src/main/ipc/os-file-open.ts
+++ b/src/main/ipc/os-file-open.ts
@@ -2,12 +2,15 @@ import { ipcMain } from 'electron'
 import type { WebContents } from 'electron'
 import { filterExistingFiles, type OsFileOpenRequestQueue } from '../startup/os-file-open-requests'
 
-// Why: WebContents survives renderer reloads, so track per-sender binding to avoid stacking 'destroyed' listeners.
-const boundSenders = new WeakSet<WebContents>()
-
 export function registerOsFileOpenHandlers(queue: OsFileOpenRequestQueue): void {
+  // Why: per-registration state — WebContents survives reloads (dedupes 'destroyed' listeners),
+  // and the single deliver slot must stay with whoever last took it (a stale sender's teardown must not clobber a newer owner).
+  const boundSenders = new WeakSet<WebContents>()
+  let currentOwner: WebContents | null = null
+
   ipcMain.handle('osFileOpen:takePending', async (event): Promise<string[]> => {
     const sender = event.sender as WebContents
+    currentOwner = sender
     // Why: taking the batch is the renderer's readiness signal, so later arrivals push instead of buffering.
     queue.setDeliver((filePath) => {
       if (!sender.isDestroyed()) {
@@ -19,7 +22,10 @@ export function registerOsFileOpenHandlers(queue: OsFileOpenRequestQueue): void 
       const cleanup = (): void => {
         boundSenders.delete(sender)
         sender.removeListener('destroyed', cleanup)
-        queue.setDeliver(null)
+        if (currentOwner === sender) {
+          currentOwner = null
+          queue.setDeliver(null)
+        }
       }
       sender.once('destroyed', cleanup)
     }

--- a/src/main/ipc/os-file-open.ts
+++ b/src/main/ipc/os-file-open.ts
@@ -1,0 +1,28 @@
+import { ipcMain } from 'electron'
+import type { WebContents } from 'electron'
+import { filterExistingFiles, type OsFileOpenRequestQueue } from '../startup/os-file-open-requests'
+
+// Why: WebContents survives renderer reloads, so track per-sender binding to avoid stacking 'destroyed' listeners.
+const boundSenders = new WeakSet<WebContents>()
+
+export function registerOsFileOpenHandlers(queue: OsFileOpenRequestQueue): void {
+  ipcMain.handle('osFileOpen:takePending', async (event): Promise<string[]> => {
+    const sender = event.sender as WebContents
+    // Why: taking the batch is the renderer's readiness signal, so later arrivals push instead of buffering.
+    queue.setDeliver((filePath) => {
+      if (!sender.isDestroyed()) {
+        sender.send('osFileOpen:opened', filePath)
+      }
+    })
+    if (!boundSenders.has(sender)) {
+      boundSenders.add(sender)
+      const cleanup = (): void => {
+        boundSenders.delete(sender)
+        sender.removeListener('destroyed', cleanup)
+        queue.setDeliver(null)
+      }
+      sender.once('destroyed', cleanup)
+    }
+    return filterExistingFiles(queue.drain())
+  })
+}

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -64,7 +64,8 @@ const {
   registerLocalhostWorktreeLabelHandlersMock,
   registerNativeChatHandlersMock,
   registerEmulatorFrameStreamHandlersMock,
-  registerEmulatorVideoStreamHandlersMock
+  registerEmulatorVideoStreamHandlersMock,
+  registerOsFileOpenHandlersMock
 } = vi.hoisted(() => ({
   getPathMock: vi.fn(() => '/test/user-data'),
   listEnvironmentsMock: vi.fn(() => []),
@@ -129,7 +130,8 @@ const {
   registerLocalhostWorktreeLabelHandlersMock: vi.fn(),
   registerNativeChatHandlersMock: vi.fn(),
   registerEmulatorFrameStreamHandlersMock: vi.fn(),
-  registerEmulatorVideoStreamHandlersMock: vi.fn()
+  registerEmulatorVideoStreamHandlersMock: vi.fn(),
+  registerOsFileOpenHandlersMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -378,6 +380,10 @@ vi.mock('./native-chat', () => ({
   registerNativeChatHandlers: registerNativeChatHandlersMock
 }))
 
+vi.mock('./os-file-open', () => ({
+  registerOsFileOpenHandlers: registerOsFileOpenHandlersMock
+}))
+
 import { registerCoreHandlers } from './register-core-handlers'
 
 describe('registerCoreHandlers', () => {
@@ -445,6 +451,7 @@ describe('registerCoreHandlers', () => {
     registerNativeChatHandlersMock.mockReset()
     registerEmulatorFrameStreamHandlersMock.mockReset()
     registerEmulatorVideoStreamHandlersMock.mockReset()
+    registerOsFileOpenHandlersMock.mockReset()
   })
 
   it('passes the store through to handler registrars that need it', async () => {
@@ -458,6 +465,7 @@ describe('registerCoreHandlers', () => {
     const claudeAccounts = { marker: 'claudeAccounts' }
     const rateLimits = { marker: 'rateLimits' }
     const agentAwakeService = { marker: 'agentAwakeService' }
+    const osFileOpenRequests = { marker: 'osFileOpenRequests' }
     const onBeforeRelaunch = vi.fn()
     const getAdditionalAiVaultCodexHomePaths = vi.fn(() => ['/runtime/codex/home'])
 
@@ -472,6 +480,7 @@ describe('registerCoreHandlers', () => {
       claudeAccounts as never,
       rateLimits as never,
       null,
+      osFileOpenRequests as never,
       undefined,
       undefined,
       agentAwakeService as never,
@@ -549,6 +558,7 @@ describe('registerCoreHandlers', () => {
     expect(registerCliHandlersMock).toHaveBeenCalled()
     expect(registerPreflightHandlersMock).toHaveBeenCalled()
     expect(registerShellHandlersMock).toHaveBeenCalledWith(store)
+    expect(registerOsFileOpenHandlersMock).toHaveBeenCalledWith(osFileOpenRequests)
     expect(registerClipboardHandlersMock).toHaveBeenCalledWith(store)
     expect(registerUpdaterHandlersMock).toHaveBeenCalled()
     expect(setTrustedBrowserRendererWebContentsIdMock).toHaveBeenCalledWith(null)
@@ -625,6 +635,7 @@ describe('registerCoreHandlers', () => {
     const codexAccounts2 = { marker: 'codexAccounts2' }
     const claudeAccounts2 = { marker: 'claudeAccounts2' }
     const rateLimits2 = { marker: 'rateLimits2' }
+    const osFileOpenRequests2 = { marker: 'osFileOpenRequests2' }
 
     registerCoreHandlers(
       store2 as never,
@@ -636,7 +647,8 @@ describe('registerCoreHandlers', () => {
       codexAccounts2 as never,
       claudeAccounts2 as never,
       rateLimits2 as never,
-      42
+      42,
+      osFileOpenRequests2 as never
     )
 
     // Web contents ID should always be updated
@@ -650,5 +662,6 @@ describe('registerCoreHandlers', () => {
     // Why: ipcMain.handle throws on duplicate channel registration, so the
     // memory handler must not be wired up a second time on reactivation.
     expect(registerMemoryHandlersMock).not.toHaveBeenCalled()
+    expect(registerOsFileOpenHandlersMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -92,6 +92,8 @@ import {
 } from '../ai-vault/runtime-session-scanner'
 import type { PluginService } from '../plugins/plugin-service'
 import type { PluginMarketplaceHandlerServices } from './plugin-marketplaces'
+import { registerOsFileOpenHandlers } from './os-file-open'
+import type { OsFileOpenRequestQueue } from '../startup/os-file-open-requests'
 
 let registered = false
 
@@ -123,7 +125,8 @@ export function registerCoreHandlers(
   keybindings?: KeybindingService,
   lifecycleOptions: CoreHandlerLifecycleOptions = {},
   pluginService?: PluginService,
-  marketplaceServices?: PluginMarketplaceHandlerServices
+  marketplaceServices?: PluginMarketplaceHandlerServices,
+  osFileOpenRequests?: OsFileOpenRequestQueue
 ): void {
   // Why: on macOS the app can stay alive after all windows close, then
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
@@ -198,6 +201,9 @@ export function registerCoreHandlers(
   })
   registerBrowserHandlers()
   registerShellHandlers(store)
+  if (osFileOpenRequests) {
+    registerOsFileOpenHandlers(osFileOpenRequests)
+  }
   registerPetHandlers()
   registerSessionHandlers(store)
   registerUIHandlers(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -118,6 +118,7 @@ export function registerCoreHandlers(
   claudeAccounts: ClaudeAccountService,
   rateLimits: RateLimitService,
   mainWindowWebContentsId: number | null = null,
+  osFileOpenRequests: OsFileOpenRequestQueue,
   automations?: AutomationService,
   commitMessageAgentEnv?: CommitMessageAgentEnvironmentResolvers,
   agentAwakeService?: AgentAwakeService,
@@ -125,8 +126,7 @@ export function registerCoreHandlers(
   keybindings?: KeybindingService,
   lifecycleOptions: CoreHandlerLifecycleOptions = {},
   pluginService?: PluginService,
-  marketplaceServices?: PluginMarketplaceHandlerServices,
-  osFileOpenRequests?: OsFileOpenRequestQueue
+  marketplaceServices?: PluginMarketplaceHandlerServices
 ): void {
   // Why: on macOS the app can stay alive after all windows close, then
   // openMainWindow() is called again on 'activate'. ipcMain.handle() throws
@@ -201,9 +201,7 @@ export function registerCoreHandlers(
   })
   registerBrowserHandlers()
   registerShellHandlers(store)
-  if (osFileOpenRequests) {
-    registerOsFileOpenHandlers(osFileOpenRequests)
-  }
+  registerOsFileOpenHandlers(osFileOpenRequests)
   registerPetHandlers()
   registerSessionHandlers(store)
   registerUIHandlers(store)

--- a/src/main/startup/os-file-open-requests.test.ts
+++ b/src/main/startup/os-file-open-requests.test.ts
@@ -2,6 +2,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { describe, expect, it, vi, beforeAll, afterAll } from 'vitest'
+import type { OsFileOpenApp } from './os-file-open-requests'
 import {
   createOsFileOpenRequestQueue,
   extractMarkdownPathsFromArgv,
@@ -92,10 +93,8 @@ describe('filterExistingFiles', () => {
   let directoryPath: string
 
   beforeAll(async () => {
-    tempDir = await mkdir(
-      join(tmpdir(), `orca-test-${Date.now()}-${Math.random().toString(36).slice(2)}`),
-      { recursive: true }
-    )
+    tempDir = join(tmpdir(), `orca-test-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+    await mkdir(tempDir, { recursive: true })
     existingFile = join(tempDir, 'test.md')
     await writeFile(existingFile, 'test content')
     directoryPath = join(tempDir, 'subdir')
@@ -152,23 +151,28 @@ describe('filterExistingFiles', () => {
 
 type OpenFileHandler = (event: { preventDefault: () => void }, filePath: string) => void
 
-function createFakeApp(): { on: ReturnType<typeof vi.fn>; fire: (filePath: string) => boolean } {
+function createFakeApp(): OsFileOpenApp & {
+  fire: (filePath: string) => boolean
+  on: ReturnType<typeof vi.fn>
+} {
   const handlers: OpenFileHandler[] = []
   const on = vi.fn((eventName: string, handler: OpenFileHandler) => {
     if (eventName === 'open-file') {
       handlers.push(handler)
     }
   })
-  return {
-    on,
-    fire(filePath) {
-      let defaultPrevented = false
-      for (const handler of handlers) {
-        handler({ preventDefault: () => (defaultPrevented = true) }, filePath)
+  const app: OsFileOpenApp & { fire: (filePath: string) => boolean; on: ReturnType<typeof vi.fn> } =
+    {
+      on: on as OsFileOpenApp['on'] & ReturnType<typeof vi.fn>,
+      fire(filePath) {
+        let defaultPrevented = false
+        for (const handler of handlers) {
+          handler({ preventDefault: () => (defaultPrevented = true) }, filePath)
+        }
+        return defaultPrevented
       }
-      return defaultPrevented
     }
-  }
+  return app
 }
 
 describe('registerOsFileOpenRequests', () => {

--- a/src/main/startup/os-file-open-requests.test.ts
+++ b/src/main/startup/os-file-open-requests.test.ts
@@ -150,29 +150,37 @@ describe('filterExistingFiles', () => {
 })
 
 type OpenFileHandler = (event: { preventDefault: () => void }, filePath: string) => void
+type SecondInstanceHandler = (event: unknown, argv: string[]) => void
 
 function createFakeApp(): OsFileOpenApp & {
-  fire: (filePath: string) => boolean
+  fireOpenFile: (filePath: string) => boolean
+  fireSecondInstance: (argv: string[]) => void
   on: ReturnType<typeof vi.fn>
 } {
-  const handlers: OpenFileHandler[] = []
-  const on = vi.fn((eventName: string, handler: OpenFileHandler) => {
+  const openFileHandlers: OpenFileHandler[] = []
+  const secondInstanceHandlers: SecondInstanceHandler[] = []
+  const on = vi.fn((eventName: string, handler: OpenFileHandler | SecondInstanceHandler) => {
     if (eventName === 'open-file') {
-      handlers.push(handler)
+      openFileHandlers.push(handler as OpenFileHandler)
+    } else if (eventName === 'second-instance') {
+      secondInstanceHandlers.push(handler as SecondInstanceHandler)
     }
   })
-  const app: OsFileOpenApp & { fire: (filePath: string) => boolean; on: ReturnType<typeof vi.fn> } =
-    {
-      on: on as OsFileOpenApp['on'] & ReturnType<typeof vi.fn>,
-      fire(filePath) {
-        let defaultPrevented = false
-        for (const handler of handlers) {
-          handler({ preventDefault: () => (defaultPrevented = true) }, filePath)
-        }
-        return defaultPrevented
+  return {
+    on: on as OsFileOpenApp['on'] & ReturnType<typeof vi.fn>,
+    fireOpenFile(filePath) {
+      let defaultPrevented = false
+      for (const handler of openFileHandlers) {
+        handler({ preventDefault: () => (defaultPrevented = true) }, filePath)
+      }
+      return defaultPrevented
+    },
+    fireSecondInstance(argv) {
+      for (const handler of secondInstanceHandlers) {
+        handler({}, argv)
       }
     }
-  return app
+  }
 }
 
 describe('registerOsFileOpenRequests', () => {
@@ -181,7 +189,7 @@ describe('registerOsFileOpenRequests', () => {
     const app = createFakeApp()
     registerOsFileOpenRequests({ app, queue, platform: 'darwin', argv: [] })
 
-    expect(app.fire('/Users/x/a.md')).toBe(true)
+    expect(app.fireOpenFile('/Users/x/a.md')).toBe(true)
     expect(queue.drain()).toEqual(['/Users/x/a.md'])
   })
 
@@ -197,7 +205,16 @@ describe('registerOsFileOpenRequests', () => {
     expect(queue.drain()).toEqual([])
   })
 
-  it('reads argv on win32 and does not subscribe to open-file', () => {
+  it('subscribes only to open-file on darwin, never second-instance', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const app = createFakeApp()
+    registerOsFileOpenRequests({ app, queue, platform: 'darwin', argv: [] })
+
+    expect(app.on).toHaveBeenCalledTimes(1)
+    expect(app.on).toHaveBeenCalledWith('open-file', expect.any(Function))
+  })
+
+  it('reads argv on win32 and subscribes to second-instance instead of open-file', () => {
     const queue = createOsFileOpenRequestQueue()
     const app = createFakeApp()
     registerOsFileOpenRequests({
@@ -207,7 +224,8 @@ describe('registerOsFileOpenRequests', () => {
       argv: ['C:\\Orca.exe', 'C:\\Users\\x\\a.md']
     })
 
-    expect(app.on).not.toHaveBeenCalled()
+    expect(app.on).toHaveBeenCalledTimes(1)
+    expect(app.on).toHaveBeenCalledWith('second-instance', expect.any(Function))
     expect(queue.drain()).toEqual(['C:\\Users\\x\\a.md'])
   })
 
@@ -221,5 +239,27 @@ describe('registerOsFileOpenRequests', () => {
       argv: ['/opt/orca/orca', '/home/x/a.md']
     })
     expect(queue.drain()).toEqual(['/home/x/a.md'])
+  })
+
+  it('enqueues markdown paths from a later win32 second-instance launch, filtering flags and non-markdown', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const app = createFakeApp()
+    registerOsFileOpenRequests({ app, queue, platform: 'win32', argv: ['C:\\Orca.exe'] })
+    queue.drain()
+
+    app.fireSecondInstance(['C:\\Orca.exe', '--flag', 'C:\\Users\\x\\b.md', 'C:\\Users\\x\\b.txt'])
+
+    expect(queue.drain()).toEqual(['C:\\Users\\x\\b.md'])
+  })
+
+  it('enqueues markdown paths from a later linux second-instance launch', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const app = createFakeApp()
+    registerOsFileOpenRequests({ app, queue, platform: 'linux', argv: ['/opt/orca/orca'] })
+    queue.drain()
+
+    app.fireSecondInstance(['/opt/orca/orca', '/home/x/b.md'])
+
+    expect(queue.drain()).toEqual(['/home/x/b.md'])
   })
 })

--- a/src/main/startup/os-file-open-requests.test.ts
+++ b/src/main/startup/os-file-open-requests.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createOsFileOpenRequestQueue,
+  extractMarkdownPathsFromArgv,
+  isMarkdownFilePath
+} from './os-file-open-requests'
+
+describe('isMarkdownFilePath', () => {
+  it('accepts absolute .md and .markdown paths regardless of case', () => {
+    expect(isMarkdownFilePath('/Users/x/Downloads/note.md')).toBe(true)
+    expect(isMarkdownFilePath('/Users/x/Downloads/NOTE.MD')).toBe(true)
+    expect(isMarkdownFilePath('/Users/x/Downloads/note.markdown')).toBe(true)
+  })
+
+  it('rejects relative paths, other extensions, and extensionless names', () => {
+    expect(isMarkdownFilePath('note.md')).toBe(false)
+    expect(isMarkdownFilePath('/Users/x/Downloads/note.txt')).toBe(false)
+    expect(isMarkdownFilePath('/Users/x/Downloads/note')).toBe(false)
+  })
+})
+
+describe('extractMarkdownPathsFromArgv', () => {
+  it('skips argv[0] and Chromium switches', () => {
+    const argv = [
+      '/Applications/Orca.app/Contents/MacOS/Orca',
+      '--enable-features=Foo',
+      '/Users/x/Downloads/a.md',
+      '/Users/x/Downloads/b.txt',
+      '/Users/x/Downloads/c.markdown'
+    ]
+    expect(extractMarkdownPathsFromArgv(argv)).toEqual([
+      '/Users/x/Downloads/a.md',
+      '/Users/x/Downloads/c.markdown'
+    ])
+  })
+
+  it('does not treat an executable path ending in .md as an argument', () => {
+    expect(extractMarkdownPathsFromArgv(['/tmp/weird.md'])).toEqual([])
+  })
+})
+
+describe('createOsFileOpenRequestQueue', () => {
+  it('buffers until a deliver target exists, then drains once', () => {
+    const queue = createOsFileOpenRequestQueue()
+    queue.enqueue('/Users/x/a.md')
+    queue.enqueue('/Users/x/b.md')
+    expect(queue.drain()).toEqual(['/Users/x/a.md', '/Users/x/b.md'])
+    expect(queue.drain()).toEqual([])
+  })
+
+  it('drops non-markdown paths instead of queueing them', () => {
+    const queue = createOsFileOpenRequestQueue()
+    queue.enqueue('/Users/x/a.txt')
+    expect(queue.drain()).toEqual([])
+  })
+
+  it('de-duplicates the same path while buffered', () => {
+    const queue = createOsFileOpenRequestQueue()
+    queue.enqueue('/Users/x/a.md')
+    queue.enqueue('/Users/x/a.md')
+    expect(queue.drain()).toEqual(['/Users/x/a.md'])
+  })
+
+  it('delivers immediately once a deliver target is set', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const deliver = vi.fn()
+    queue.setDeliver(deliver)
+    queue.enqueue('/Users/x/a.md')
+    expect(deliver).toHaveBeenCalledWith('/Users/x/a.md')
+    expect(queue.drain()).toEqual([])
+  })
+
+  it('returns to buffering when the deliver target is cleared', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const deliver = vi.fn()
+    queue.setDeliver(deliver)
+    queue.setDeliver(null)
+    queue.enqueue('/Users/x/a.md')
+    expect(deliver).not.toHaveBeenCalled()
+    expect(queue.drain()).toEqual(['/Users/x/a.md'])
+  })
+})

--- a/src/main/startup/os-file-open-requests.test.ts
+++ b/src/main/startup/os-file-open-requests.test.ts
@@ -6,7 +6,8 @@ import {
   createOsFileOpenRequestQueue,
   extractMarkdownPathsFromArgv,
   filterExistingFiles,
-  isMarkdownFilePath
+  isMarkdownFilePath,
+  registerOsFileOpenRequests
 } from './os-file-open-requests'
 
 describe('isMarkdownFilePath', () => {
@@ -146,5 +147,75 @@ describe('filterExistingFiles', () => {
       '/another/missing.md'
     ])
     expect(result).toEqual([file1, file2])
+  })
+})
+
+type OpenFileHandler = (event: { preventDefault: () => void }, filePath: string) => void
+
+function createFakeApp(): { on: ReturnType<typeof vi.fn>; fire: (filePath: string) => boolean } {
+  const handlers: OpenFileHandler[] = []
+  const on = vi.fn((eventName: string, handler: OpenFileHandler) => {
+    if (eventName === 'open-file') {
+      handlers.push(handler)
+    }
+  })
+  return {
+    on,
+    fire(filePath) {
+      let defaultPrevented = false
+      for (const handler of handlers) {
+        handler({ preventDefault: () => (defaultPrevented = true) }, filePath)
+      }
+      return defaultPrevented
+    }
+  }
+}
+
+describe('registerOsFileOpenRequests', () => {
+  it('routes macOS open-file events into the queue and prevents the default', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const app = createFakeApp()
+    registerOsFileOpenRequests({ app, queue, platform: 'darwin', argv: [] })
+
+    expect(app.fire('/Users/x/a.md')).toBe(true)
+    expect(queue.drain()).toEqual(['/Users/x/a.md'])
+  })
+
+  it('ignores argv on macOS so a double-registered path is not queued twice', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const app = createFakeApp()
+    registerOsFileOpenRequests({
+      app,
+      queue,
+      platform: 'darwin',
+      argv: ['/Applications/Orca', '/Users/x/a.md']
+    })
+    expect(queue.drain()).toEqual([])
+  })
+
+  it('reads argv on win32 and does not subscribe to open-file', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const app = createFakeApp()
+    registerOsFileOpenRequests({
+      app,
+      queue,
+      platform: 'win32',
+      argv: ['C:\\Orca.exe', 'C:\\Users\\x\\a.md']
+    })
+
+    expect(app.on).not.toHaveBeenCalled()
+    expect(queue.drain()).toEqual(['C:\\Users\\x\\a.md'])
+  })
+
+  it('reads argv on linux', () => {
+    const queue = createOsFileOpenRequestQueue()
+    const app = createFakeApp()
+    registerOsFileOpenRequests({
+      app,
+      queue,
+      platform: 'linux',
+      argv: ['/opt/orca/orca', '/home/x/a.md']
+    })
+    expect(queue.drain()).toEqual(['/home/x/a.md'])
   })
 })

--- a/src/main/startup/os-file-open-requests.test.ts
+++ b/src/main/startup/os-file-open-requests.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, expect, it, vi, beforeAll, afterAll } from 'vitest'
 import {
   createOsFileOpenRequestQueue,
   extractMarkdownPathsFromArgv,
+  filterExistingFiles,
   isMarkdownFilePath
 } from './os-file-open-requests'
 
@@ -78,5 +82,69 @@ describe('createOsFileOpenRequestQueue', () => {
     queue.enqueue('/Users/x/a.md')
     expect(deliver).not.toHaveBeenCalled()
     expect(queue.drain()).toEqual(['/Users/x/a.md'])
+  })
+})
+
+describe('filterExistingFiles', () => {
+  let tempDir: string
+  let existingFile: string
+  let directoryPath: string
+
+  beforeAll(async () => {
+    tempDir = await mkdir(
+      join(tmpdir(), `orca-test-${Date.now()}-${Math.random().toString(36).slice(2)}`),
+      { recursive: true }
+    )
+    existingFile = join(tempDir, 'test.md')
+    await writeFile(existingFile, 'test content')
+    directoryPath = join(tempDir, 'subdir')
+    await mkdir(directoryPath)
+  })
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns existing files', async () => {
+    const result = await filterExistingFiles([existingFile])
+    expect(result).toEqual([existingFile])
+  })
+
+  it('filters out directories', async () => {
+    const result = await filterExistingFiles([directoryPath])
+    expect(result).toEqual([])
+  })
+
+  it('filters out missing paths without rejecting', async () => {
+    const result = await filterExistingFiles(['/nonexistent/path/that/does/not/exist.md'])
+    expect(result).toEqual([])
+  })
+
+  it('preserves input order for existing files', async () => {
+    const file1 = join(tempDir, 'a.md')
+    const file2 = join(tempDir, 'b.md')
+    const file3 = join(tempDir, 'c.md')
+    await writeFile(file1, 'a')
+    await writeFile(file2, 'b')
+    await writeFile(file3, 'c')
+
+    const result = await filterExistingFiles([file3, file1, file2])
+    expect(result).toEqual([file3, file1, file2])
+  })
+
+  it('filters mixed paths, keeping only existing files in order', async () => {
+    const file1 = join(tempDir, 'x.md')
+    const file2 = join(tempDir, 'y.md')
+    await writeFile(file1, 'x')
+    await writeFile(file2, 'y')
+
+    const result = await filterExistingFiles([
+      file1,
+      '/nonexistent.md',
+      directoryPath,
+      file2,
+      '/another/missing.md'
+    ])
+    expect(result).toEqual([file1, file2])
   })
 })

--- a/src/main/startup/os-file-open-requests.ts
+++ b/src/main/startup/os-file-open-requests.ts
@@ -1,10 +1,16 @@
+import type { App } from 'electron'
 import { stat } from 'node:fs/promises'
-import { extname, isAbsolute } from 'node:path'
+import { extname } from 'node:path'
 
 const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown'])
+// Why: the test host's path flavor must not decide whether a Windows path counts as absolute.
+const ABSOLUTE_PATH_PATTERN = /^(?:\/|\\\\|[A-Za-z]:[\\/])/
 
 export function isMarkdownFilePath(candidate: string): boolean {
-  return isAbsolute(candidate) && MARKDOWN_EXTENSIONS.has(extname(candidate).toLowerCase())
+  return (
+    ABSOLUTE_PATH_PATTERN.test(candidate) &&
+    MARKDOWN_EXTENSIONS.has(extname(candidate).toLowerCase())
+  )
 }
 
 export function extractMarkdownPathsFromArgv(argv: readonly string[]): string[] {
@@ -55,4 +61,24 @@ export async function filterExistingFiles(paths: readonly string[]): Promise<str
     })
   )
   return results.filter((entry): entry is string => entry !== null)
+}
+
+export function registerOsFileOpenRequests(options: {
+  app: Pick<App, 'on'>
+  queue: OsFileOpenRequestQueue
+  platform: NodeJS.Platform
+  argv: readonly string[]
+}): void {
+  const { app, argv, platform, queue } = options
+  if (platform === 'darwin') {
+    // Why: macOS delivers open-file before app.ready, so this must run at module load — not inside whenReady.
+    app.on('open-file', (event, filePath) => {
+      event.preventDefault()
+      queue.enqueue(filePath)
+    })
+    return
+  }
+  for (const filePath of extractMarkdownPathsFromArgv(argv)) {
+    queue.enqueue(filePath)
+  }
 }

--- a/src/main/startup/os-file-open-requests.ts
+++ b/src/main/startup/os-file-open-requests.ts
@@ -1,10 +1,17 @@
-import type { App } from 'electron'
 import { stat } from 'node:fs/promises'
 import { extname } from 'node:path'
 
 const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown'])
 // Why: the test host's path flavor must not decide whether a Windows path counts as absolute.
 const ABSOLUTE_PATH_PATTERN = /^(?:\/|\\\\|[A-Za-z]:[\\/])/
+
+// Why: the function only registers the open-file event, so no need to pull in the full App type.
+export type OsFileOpenApp = {
+  on(
+    event: 'open-file',
+    listener: (event: { preventDefault: () => void }, filePath: string) => void
+  ): void
+}
 
 export function isMarkdownFilePath(candidate: string): boolean {
   return (
@@ -64,7 +71,7 @@ export async function filterExistingFiles(paths: readonly string[]): Promise<str
 }
 
 export function registerOsFileOpenRequests(options: {
-  app: Pick<App, 'on'>
+  app: OsFileOpenApp
   queue: OsFileOpenRequestQueue
   platform: NodeJS.Platform
   argv: readonly string[]

--- a/src/main/startup/os-file-open-requests.ts
+++ b/src/main/startup/os-file-open-requests.ts
@@ -1,0 +1,58 @@
+import { stat } from 'node:fs/promises'
+import { extname, isAbsolute } from 'node:path'
+
+const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown'])
+
+export function isMarkdownFilePath(candidate: string): boolean {
+  return isAbsolute(candidate) && MARKDOWN_EXTENSIONS.has(extname(candidate).toLowerCase())
+}
+
+export function extractMarkdownPathsFromArgv(argv: readonly string[]): string[] {
+  // Why: argv[0] is the executable; Electron also injects Chromium switches the OS never sent.
+  return argv.slice(1).filter((entry) => !entry.startsWith('-') && isMarkdownFilePath(entry))
+}
+
+export type OsFileOpenRequestQueue = {
+  enqueue(filePath: string): void
+  drain(): string[]
+  setDeliver(deliver: ((filePath: string) => void) | null): void
+}
+
+export function createOsFileOpenRequestQueue(): OsFileOpenRequestQueue {
+  const pending: string[] = []
+  let deliver: ((filePath: string) => void) | null = null
+
+  return {
+    enqueue(filePath) {
+      if (!isMarkdownFilePath(filePath)) {
+        return
+      }
+      if (deliver) {
+        deliver(filePath)
+        return
+      }
+      if (!pending.includes(filePath)) {
+        pending.push(filePath)
+      }
+    },
+    drain() {
+      return pending.splice(0, pending.length)
+    },
+    setDeliver(next) {
+      deliver = next
+    }
+  }
+}
+
+export async function filterExistingFiles(paths: readonly string[]): Promise<string[]> {
+  const results = await Promise.all(
+    paths.map(async (candidate) => {
+      try {
+        return (await stat(candidate)).isFile() ? candidate : null
+      } catch {
+        return null
+      }
+    })
+  )
+  return results.filter((entry): entry is string => entry !== null)
+}

--- a/src/main/startup/os-file-open-requests.ts
+++ b/src/main/startup/os-file-open-requests.ts
@@ -5,12 +5,13 @@ const MARKDOWN_EXTENSIONS = new Set(['.md', '.markdown'])
 // Why: the test host's path flavor must not decide whether a Windows path counts as absolute.
 const ABSOLUTE_PATH_PATTERN = /^(?:\/|\\\\|[A-Za-z]:[\\/])/
 
-// Why: the function only registers the open-file event, so no need to pull in the full App type.
+// Why: the function only registers these two events, so no need to pull in the full App type.
 export type OsFileOpenApp = {
   on(
     event: 'open-file',
     listener: (event: { preventDefault: () => void }, filePath: string) => void
   ): void
+  on(event: 'second-instance', listener: (event: unknown, argv: string[]) => void): void
 }
 
 export function isMarkdownFilePath(candidate: string): boolean {
@@ -88,4 +89,10 @@ export function registerOsFileOpenRequests(options: {
   for (const filePath of extractMarkdownPathsFromArgv(argv)) {
     queue.enqueue(filePath)
   }
+  // Why: Windows/Linux deliver a later file-open launch as a second OS process, relayed here via second-instance.
+  app.on('second-instance', (_event, secondArgv) => {
+    for (const filePath of extractMarkdownPathsFromArgv(secondArgv)) {
+      queue.enqueue(filePath)
+    }
+  })
 }

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -56,7 +56,7 @@ describe('acquireSingleInstanceLock', () => {
     expect(acquired).toBe(true)
     expect(fake.requestSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(fake.on).toHaveBeenCalledTimes(1)
-    expect(fake.on).toHaveBeenCalledWith('second-instance', expect.any(Function))
+    expect(fake.on).toHaveBeenCalledWith('second-instance', onSecondInstance)
     expect(fake.listeners['second-instance']).toHaveLength(1)
   })
 
@@ -68,25 +68,9 @@ describe('acquireSingleInstanceLock', () => {
 
     const [registered] = fake.listeners['second-instance'] ?? []
     expect(registered).toBeDefined()
-    registered?.({}, ['/some/app', '/some/file.md'])
+    registered?.()
 
-    expect(onSecondInstance).toHaveBeenCalledWith(['/some/app', '/some/file.md'])
-  })
-
-  it('forwards the second instance argv to the callback', () => {
-    const handlers = new Map<string, (event: unknown, argv: string[]) => void>()
-    const app = {
-      requestSingleInstanceLock: () => true,
-      on: (eventName: string, handler: (event: unknown, argv: string[]) => void) => {
-        handlers.set(eventName, handler)
-      }
-    } as unknown as App
-
-    const onSecondInstance = vi.fn()
-    expect(acquireSingleInstanceLock(app, onSecondInstance)).toBe(true)
-
-    handlers.get('second-instance')?.({}, ['/opt/orca/orca', '/home/x/a.md'])
-    expect(onSecondInstance).toHaveBeenCalledWith(['/opt/orca/orca', '/home/x/a.md'])
+    expect(onSecondInstance).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -56,7 +56,7 @@ describe('acquireSingleInstanceLock', () => {
     expect(acquired).toBe(true)
     expect(fake.requestSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(fake.on).toHaveBeenCalledTimes(1)
-    expect(fake.on).toHaveBeenCalledWith('second-instance', onSecondInstance)
+    expect(fake.on).toHaveBeenCalledWith('second-instance', expect.any(Function))
     expect(fake.listeners['second-instance']).toHaveLength(1)
   })
 
@@ -68,9 +68,25 @@ describe('acquireSingleInstanceLock', () => {
 
     const [registered] = fake.listeners['second-instance'] ?? []
     expect(registered).toBeDefined()
-    registered?.()
+    registered?.({}, ['/some/app', '/some/file.md'])
 
-    expect(onSecondInstance).toHaveBeenCalledTimes(1)
+    expect(onSecondInstance).toHaveBeenCalledWith(['/some/app', '/some/file.md'])
+  })
+
+  it('forwards the second instance argv to the callback', () => {
+    const handlers = new Map<string, (event: unknown, argv: string[]) => void>()
+    const app = {
+      requestSingleInstanceLock: () => true,
+      on: (eventName: string, handler: (event: unknown, argv: string[]) => void) => {
+        handlers.set(eventName, handler)
+      }
+    } as unknown as App
+
+    const onSecondInstance = vi.fn()
+    expect(acquireSingleInstanceLock(app, onSecondInstance)).toBe(true)
+
+    handlers.get('second-instance')?.({}, ['/opt/orca/orca', '/home/x/a.md'])
+    expect(onSecondInstance).toHaveBeenCalledWith(['/opt/orca/orca', '/home/x/a.md'])
   })
 })
 

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -26,11 +26,14 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
  * way dev (`orca-dev` userData) and packaged (`orca` userData) runs lock in
  * separate namespaces instead of serialising against each other.
  */
-export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void): boolean {
+export function acquireSingleInstanceLock(
+  app: App,
+  onSecondInstance: (argv: string[]) => void
+): boolean {
   if (!app.requestSingleInstanceLock()) {
     return false
   }
-  app.on('second-instance', onSecondInstance)
+  app.on('second-instance', (_event, argv) => onSecondInstance(argv))
   return true
 }
 

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -26,14 +26,11 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
  * way dev (`orca-dev` userData) and packaged (`orca` userData) runs lock in
  * separate namespaces instead of serialising against each other.
  */
-export function acquireSingleInstanceLock(
-  app: App,
-  onSecondInstance: (argv: string[]) => void
-): boolean {
+export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void): boolean {
   if (!app.requestSingleInstanceLock()) {
     return false
   }
-  app.on('second-instance', (_event, argv) => onSecondInstance(argv))
+  app.on('second-instance', onSecondInstance)
   return true
 }
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2511,6 +2511,10 @@ export type PreloadApi = {
     }) => Promise<ComputerUsePermissionSetupResult>
     reset: () => Promise<ComputerUsePermissionResetResult>
   }
+  osFileOpen: {
+    takePending: () => Promise<string[]>
+    onOpened: (listener: (filePath: string) => void) => () => void
+  }
   shell: {
     openPath: (path: string) => Promise<void>
     openInFileManager: (path: string) => Promise<ShellOpenLocalPathResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2374,7 +2374,7 @@ const api = {
         ipcRenderer.off('osFileOpen:opened', handler)
       }
     }
-  },
+  } satisfies PreloadApi['osFileOpen'],
 
   shell: {
     openPath: (path: string): Promise<void> => ipcRenderer.invoke('shell:openPath', path),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2364,6 +2364,18 @@ const api = {
     reset: (): Promise<unknown> => ipcRenderer.invoke('computerUsePermissions:reset')
   },
 
+  osFileOpen: {
+    takePending: (): Promise<string[]> => ipcRenderer.invoke('osFileOpen:takePending'),
+
+    onOpened: (listener: (filePath: string) => void): (() => void) => {
+      const handler = (_event: unknown, filePath: string): void => listener(filePath)
+      ipcRenderer.on('osFileOpen:opened', handler)
+      return () => {
+        ipcRenderer.off('osFileOpen:opened', handler)
+      }
+    }
+  },
+
   shell: {
     openPath: (path: string): Promise<void> => ipcRenderer.invoke('shell:openPath', path),
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -110,6 +110,10 @@ import {
 } from './runtime/sync-runtime-graph'
 import { useWebSessionTabsSync } from './runtime/web-session-tabs-sync'
 import { useGlobalFileDrop } from './hooks/useGlobalFileDrop'
+import {
+  pullPendingOsRequestedFiles,
+  useOsRequestedFileOpening
+} from './hooks/use-os-requested-file-opening'
 import { MacosTccPromptNoticeHost } from './hooks/MacosTccPromptNoticeHost'
 import { useRadixBodyPointerEventsRecovery } from './hooks/useRadixBodyPointerEventsRecovery'
 import { registerUpdaterBeforeUnloadBypass } from './lib/updater-beforeunload'
@@ -756,6 +760,7 @@ function App(): React.JSX.Element {
   useGlobalFileDrop()
   useAutoAckViewedAgent()
   useDashboardPopoutBridge(settings?.experimentalAgentDashboardPopout === true)
+  useOsRequestedFileOpening()
 
   useEffect(() => {
     return onOnboardingReopened(setOnboarding)
@@ -983,6 +988,8 @@ function App(): React.JSX.Element {
             actions.pruneLastVisitedTimestamps()
             actions.seedActiveWorktreeLastVisitedIfMissing()
           })
+          // Why: pull after session hydration — matching an existing workspace needs worktreesByRepo/folderWorkspaces populated.
+          await pullPendingOsRequestedFiles(() => cancelled)
           await timeRendererStartupStep('fetch-browser-session-profiles', () =>
             actions.fetchBrowserSessionProfiles()
           )

--- a/src/renderer/src/hooks/use-os-requested-file-opening-push-subscription.test.ts
+++ b/src/renderer/src/hooks/use-os-requested-file-opening-push-subscription.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// Why: a plain rejecting function, not vi.fn() — vi.fn()'s own call-result tracking
+// attaches a rejection handler internally, which silently defeats the process-level
+// "unhandled rejection" check below regardless of whether the fix under test is present.
+const openOsRequestedFileHolder = vi.hoisted(() => ({
+  impl: (_filePath: string) => Promise.resolve() as Promise<void>
+}))
+
+vi.mock('@/lib/open-os-requested-file', () => ({
+  openOsRequestedFile: (filePath: string) => openOsRequestedFileHolder.impl(filePath)
+}))
+
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock }
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, value: string) => value
+}))
+
+import { useOsRequestedFileOpening } from './use-os-requested-file-opening'
+
+const UNHANDLED_REJECTION_SETTLE_MS = 20
+
+// Why: mirrors monaco-delayer-cancellation-guard.test.ts's proof pattern for "no unhandled rejection".
+async function collectUnhandledRejections(run: () => void): Promise<unknown[]> {
+  const reasons: unknown[] = []
+  const onUnhandledRejection = (reason: unknown): void => {
+    reasons.push(reason)
+  }
+
+  process.on('unhandledRejection', onUnhandledRejection)
+  try {
+    run()
+    await new Promise((resolve) => setTimeout(resolve, UNHANDLED_REJECTION_SETTLE_MS))
+  } finally {
+    process.off('unhandledRejection', onUnhandledRejection)
+  }
+
+  return reasons
+}
+
+beforeEach(() => {
+  toastErrorMock.mockClear()
+  openOsRequestedFileHolder.impl = () => Promise.resolve()
+})
+
+afterEach(() => {
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('useOsRequestedFileOpening push subscription', () => {
+  it('reports a rejected push-delivered file without producing an unhandled rejection', async () => {
+    let pushListener: ((filePath: string) => void) | undefined
+    ;(window as unknown as { api: unknown }).api = {
+      osFileOpen: {
+        onOpened: vi.fn((listener: (filePath: string) => void) => {
+          pushListener = listener
+          return vi.fn()
+        })
+      }
+    }
+    openOsRequestedFileHolder.impl = () => Promise.reject(new Error('boom'))
+
+    renderHook(() => useOsRequestedFileOpening())
+    expect(pushListener).toBeDefined()
+
+    const unhandledRejections = await collectUnhandledRejections(() => {
+      pushListener?.('/Users/x/projects/a.md')
+    })
+
+    expect(unhandledRejections).toEqual([])
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/hooks/use-os-requested-file-opening.test.ts
+++ b/src/renderer/src/hooks/use-os-requested-file-opening.test.ts
@@ -49,4 +49,18 @@ describe('pullPendingOsRequestedFiles', () => {
     expect(openOsRequestedFileMock).toHaveBeenNthCalledWith(2, '/Users/x/projects/b.md')
     expect(openOsRequestedFileMock).toHaveBeenNthCalledWith(3, '/Users/x/projects/c.md')
   })
+
+  it('stops opening remaining paths once cancellation is reported mid-batch', async () => {
+    stubPendingPaths(['/Users/x/projects/a.md', '/Users/x/projects/b.md'])
+    let cancelled = false
+    openOsRequestedFileMock.mockImplementationOnce(async () => {
+      // Why: simulates unmount happening during the first path's async open.
+      cancelled = true
+    })
+
+    await pullPendingOsRequestedFiles(() => cancelled)
+
+    expect(openOsRequestedFileMock).toHaveBeenCalledTimes(1)
+    expect(openOsRequestedFileMock).toHaveBeenCalledWith('/Users/x/projects/a.md')
+  })
 })

--- a/src/renderer/src/hooks/use-os-requested-file-opening.test.ts
+++ b/src/renderer/src/hooks/use-os-requested-file-opening.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { openOsRequestedFileMock } = vi.hoisted(() => ({ openOsRequestedFileMock: vi.fn() }))
+
+vi.mock('@/lib/open-os-requested-file', () => ({
+  openOsRequestedFile: openOsRequestedFileMock
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() }
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, value: string) => value
+}))
+
+import { toast } from 'sonner'
+import { pullPendingOsRequestedFiles } from './use-os-requested-file-opening'
+
+beforeEach(() => {
+  openOsRequestedFileMock.mockReset()
+  vi.mocked(toast.error).mockClear()
+})
+
+function stubPendingPaths(paths: string[]): void {
+  globalThis.window = { api: { osFileOpen: { takePending: vi.fn(async () => paths) } } } as never
+}
+
+describe('pullPendingOsRequestedFiles', () => {
+  it('does not propagate a rejection from a single bad path', async () => {
+    stubPendingPaths(['/Users/x/projects/a.md'])
+    openOsRequestedFileMock.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(pullPendingOsRequestedFiles(() => false)).resolves.toBeUndefined()
+    expect(toast.error).toHaveBeenCalledTimes(1)
+  })
+
+  it('still opens the remaining paths after the first one fails', async () => {
+    stubPendingPaths(['/Users/x/projects/a.md', '/Users/x/projects/b.md', '/Users/x/projects/c.md'])
+    openOsRequestedFileMock
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+
+    await pullPendingOsRequestedFiles(() => false)
+
+    expect(openOsRequestedFileMock).toHaveBeenCalledTimes(3)
+    expect(openOsRequestedFileMock).toHaveBeenNthCalledWith(1, '/Users/x/projects/a.md')
+    expect(openOsRequestedFileMock).toHaveBeenNthCalledWith(2, '/Users/x/projects/b.md')
+    expect(openOsRequestedFileMock).toHaveBeenNthCalledWith(3, '/Users/x/projects/c.md')
+  })
+})

--- a/src/renderer/src/hooks/use-os-requested-file-opening.ts
+++ b/src/renderer/src/hooks/use-os-requested-file-opening.ts
@@ -23,6 +23,10 @@ export async function pullPendingOsRequestedFiles(isCancelled: () => boolean): P
     return
   }
   for (const pendingPath of pendingPaths) {
+    // Why: cancellation mid-batch must stop remaining opens, not just gate the batch's start.
+    if (isCancelled()) {
+      return
+    }
     await openOsRequestedFileAndReportFailure(pendingPath)
   }
 }

--- a/src/renderer/src/hooks/use-os-requested-file-opening.ts
+++ b/src/renderer/src/hooks/use-os-requested-file-opening.ts
@@ -1,4 +1,6 @@
 import { useEffect } from 'react'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
 import { openOsRequestedFile } from '@/lib/open-os-requested-file'
 
 // Why: run after session hydration — matching an existing workspace needs worktreesByRepo/folderWorkspaces populated.
@@ -8,7 +10,15 @@ export async function pullPendingOsRequestedFiles(isCancelled: () => boolean): P
     return
   }
   for (const pendingPath of pendingPaths) {
-    await openOsRequestedFile(pendingPath)
+    // Why: a bad path must not abort the rest, and must never surface as the startup effect's generic hydration-failure catch.
+    try {
+      await openOsRequestedFile(pendingPath)
+    } catch (err) {
+      console.warn('Failed to open OS-requested file:', pendingPath, err)
+      toast.error(
+        translate('auto.hooks.useOsRequestedFileOpening.b7f1c4a2d9', 'Could not open the file.')
+      )
+    }
   }
 }
 

--- a/src/renderer/src/hooks/use-os-requested-file-opening.ts
+++ b/src/renderer/src/hooks/use-os-requested-file-opening.ts
@@ -3,6 +3,19 @@ import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { openOsRequestedFile } from '@/lib/open-os-requested-file'
 
+// Why: shared by both entry points so a failure can never surface as the startup effect's
+// hydration-failure catch nor as an unhandled rejection from the push subscription.
+async function openOsRequestedFileAndReportFailure(filePath: string): Promise<void> {
+  try {
+    await openOsRequestedFile(filePath)
+  } catch (err) {
+    console.warn('Failed to open OS-requested file:', filePath, err)
+    toast.error(
+      translate('auto.hooks.useOsRequestedFileOpening.b7f1c4a2d9', 'Could not open the file.')
+    )
+  }
+}
+
 // Why: run after session hydration — matching an existing workspace needs worktreesByRepo/folderWorkspaces populated.
 export async function pullPendingOsRequestedFiles(isCancelled: () => boolean): Promise<void> {
   const pendingPaths = await window.api.osFileOpen.takePending()
@@ -10,15 +23,7 @@ export async function pullPendingOsRequestedFiles(isCancelled: () => boolean): P
     return
   }
   for (const pendingPath of pendingPaths) {
-    // Why: a bad path must not abort the rest, and must never surface as the startup effect's generic hydration-failure catch.
-    try {
-      await openOsRequestedFile(pendingPath)
-    } catch (err) {
-      console.warn('Failed to open OS-requested file:', pendingPath, err)
-      toast.error(
-        translate('auto.hooks.useOsRequestedFileOpening.b7f1c4a2d9', 'Could not open the file.')
-      )
-    }
+    await openOsRequestedFileAndReportFailure(pendingPath)
   }
 }
 
@@ -26,7 +31,7 @@ export async function pullPendingOsRequestedFiles(isCancelled: () => boolean): P
 export function useOsRequestedFileOpening(): void {
   useEffect(() => {
     return window.api.osFileOpen.onOpened((filePath) => {
-      void openOsRequestedFile(filePath)
+      void openOsRequestedFileAndReportFailure(filePath)
     })
   }, [])
 }

--- a/src/renderer/src/hooks/use-os-requested-file-opening.ts
+++ b/src/renderer/src/hooks/use-os-requested-file-opening.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { openOsRequestedFile } from '@/lib/open-os-requested-file'
+
+// Why: run after session hydration — matching an existing workspace needs worktreesByRepo/folderWorkspaces populated.
+export async function pullPendingOsRequestedFiles(isCancelled: () => boolean): Promise<void> {
+  const pendingPaths = await window.api.osFileOpen.takePending()
+  if (isCancelled()) {
+    return
+  }
+  for (const pendingPath of pendingPaths) {
+    await openOsRequestedFile(pendingPath)
+  }
+}
+
+// Why: own effect — files opened from the OS while Orca is already running have a lifecycle distinct from the startup hydration effect.
+export function useOsRequestedFileOpening(): void {
+  useEffect(() => {
+    return window.api.osFileOpen.onOpened((filePath) => {
+      void openOsRequestedFile(filePath)
+    })
+  }, [])
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -492,6 +492,15 @@
               "bf4f2a8a72": "Could not start the emulator. Check iOS or Android emulator setup and try another device."
             }
           }
+        },
+        "os": {
+          "requested": {
+            "file": {
+              "bdf34177f8": "Could not open the file: creating a workspace for its folder failed.",
+              "96019938b5": "Could not open the file.",
+              "8086cba22b": "Could not open the file: no project group was available for its folder."
+            }
+          }
         }
       },
       "orchestration": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -852,6 +852,9 @@
         "description": "Permission messages from macOS may appear when an agent or terminal tool running in Orca attempts to access protected files. Grant Full Disk Access in Settings to reduce these prompts.",
         "openSettings": "Open Settings",
         "dismiss": "Don't show again"
+      },
+      "useOsRequestedFileOpening": {
+        "b7f1c4a2d9": "Could not open the file."
       }
     },
     "components": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -460,6 +460,15 @@
               "bf4f2a8a72": "No se pudo iniciar el emulador. Revisa la configuración del emulador de iOS o Android y prueba con otro dispositivo."
             }
           }
+        },
+        "os": {
+          "requested": {
+            "file": {
+              "bdf34177f8": "Could not open the file: creating a workspace for its folder failed.",
+              "96019938b5": "Could not open the file.",
+              "8086cba22b": "Could not open the file: no project group was available for its folder."
+            }
+          }
         }
       },
       "orchestration": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -815,6 +815,9 @@
         "description": "Los mensajes de permisos de macOS pueden aparecer cuando un agente o una herramienta de terminal que se ejecuta en Orca intenta acceder a archivos protegidos. Concede acceso total al disco en Ajustes para reducir estos avisos.",
         "openSettings": "Abrir ajustes",
         "dismiss": "No volver a mostrar"
+      },
+      "useOsRequestedFileOpening": {
+        "b7f1c4a2d9": "Could not open the file."
       }
     },
     "components": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -815,6 +815,9 @@
         "description": "Orca で実行中のエージェントやターミナルツールが保護されたファイルにアクセスしようとすると、macOS の権限メッセージが表示されることがあります。これらの確認を減らすには、設定でフルディスクアクセスを許可してください。",
         "openSettings": "設定を開く",
         "dismiss": "今後表示しない"
+      },
+      "useOsRequestedFileOpening": {
+        "b7f1c4a2d9": "Could not open the file."
       }
     },
     "components": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -460,6 +460,15 @@
               "bf4f2a8a72": "エミュレータを起動できませんでした。 iOS または Android エミュレータの設定を確認し、別のデバイスを試す。"
             }
           }
+        },
+        "os": {
+          "requested": {
+            "file": {
+              "bdf34177f8": "Could not open the file: creating a workspace for its folder failed.",
+              "96019938b5": "Could not open the file.",
+              "8086cba22b": "Could not open the file: no project group was available for its folder."
+            }
+          }
         }
       },
       "orchestration": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -815,6 +815,9 @@
         "description": "Orca에서 실행 중인 에이전트나 터미널 도구가 보호된 파일에 접근하려고 하면 macOS 권한 메시지가 표시될 수 있습니다. 이러한 요청을 줄이려면 설정에서 전체 디스크 접근 권한을 허용하세요.",
         "openSettings": "설정 열기",
         "dismiss": "다시 표시하지 않기"
+      },
+      "useOsRequestedFileOpening": {
+        "b7f1c4a2d9": "Could not open the file."
       }
     },
     "components": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -460,6 +460,15 @@
               "bf4f2a8a72": "에뮬레이터를 시작할 수 없습니다. iOS 또는 Android 에뮬레이터 설정을 확인하고 다른 기기를 사용해 보세요."
             }
           }
+        },
+        "os": {
+          "requested": {
+            "file": {
+              "bdf34177f8": "Could not open the file: creating a workspace for its folder failed.",
+              "96019938b5": "Could not open the file.",
+              "8086cba22b": "Could not open the file: no project group was available for its folder."
+            }
+          }
         }
       },
       "orchestration": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -815,6 +815,9 @@
         "description": "当 Orca 中运行的代理或终端工具尝试访问受保护的文件时，macOS 可能会显示权限信息。请在“设置”中授予“完全磁盘访问权限”，以减少此类提示。",
         "openSettings": "打开设置",
         "dismiss": "不再显示"
+      },
+      "useOsRequestedFileOpening": {
+        "b7f1c4a2d9": "Could not open the file."
       }
     },
     "components": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -460,6 +460,15 @@
               "bf4f2a8a72": "无法启动模拟器。请检查 iOS 或 Android 模拟器设置，然后尝试其他设备。"
             }
           }
+        },
+        "os": {
+          "requested": {
+            "file": {
+              "bdf34177f8": "Could not open the file: creating a workspace for its folder failed.",
+              "96019938b5": "Could not open the file.",
+              "8086cba22b": "Could not open the file: no project group was available for its folder."
+            }
+          }
         }
       },
       "orchestration": {

--- a/src/renderer/src/lib/open-os-requested-file.test.ts
+++ b/src/renderer/src/lib/open-os-requested-file.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FolderWorkspace, ProjectGroup } from '../../../shared/types'
+
+type LocalProjectGroup = Pick<
+  ProjectGroup,
+  'id' | 'parentPath' | 'connectionId' | 'executionHostId'
+>
+
+let nextId = 0
+
+const store = {
+  worktreesByRepo: {} as Record<string, { id: string; path: string }[]>,
+  folderWorkspaces: [] as FolderWorkspace[],
+  projectGroups: [] as LocalProjectGroup[],
+  createProjectGroup: vi.fn(async (name: string) => {
+    const group: LocalProjectGroup = {
+      id: `group-${++nextId}`,
+      parentPath: '/Users/x/projects',
+      connectionId: null,
+      executionHostId: null
+    }
+    store.projectGroups.push(group)
+    return { ...group, name } as unknown as ProjectGroup
+  }),
+  createFolderWorkspace: vi.fn(
+    async (args: { projectGroupId: string; name?: string; folderPath?: string | null }) => {
+      const workspace = {
+        id: `folder-${++nextId}`,
+        projectGroupId: args.projectGroupId,
+        name: args.name ?? '',
+        folderPath: args.folderPath ?? ''
+      } as unknown as FolderWorkspace
+      store.folderWorkspaces.push(workspace)
+      return workspace
+    }
+  ),
+  openFile: vi.fn()
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => store
+  }
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() }
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, value: string) => value
+}))
+
+import { openOsRequestedFile } from './open-os-requested-file'
+
+beforeEach(() => {
+  nextId = 0
+  store.worktreesByRepo = {}
+  store.folderWorkspaces = []
+  store.projectGroups = []
+  store.createProjectGroup.mockClear()
+  store.createFolderWorkspace.mockClear()
+  store.openFile.mockClear()
+})
+
+describe('openOsRequestedFile serialization', () => {
+  it('creates exactly one workspace for two concurrent files in the same not-yet-created folder', async () => {
+    const fileA = '/Users/x/projects/newfolder/a.md'
+    const fileB = '/Users/x/projects/newfolder/b.md'
+
+    // Why: both start before either awaits the store update — only chain serialization prevents a duplicate.
+    await Promise.all([openOsRequestedFile(fileA), openOsRequestedFile(fileB)])
+
+    expect(store.createFolderWorkspace).toHaveBeenCalledTimes(1)
+    expect(store.folderWorkspaces).toHaveLength(1)
+  })
+
+  it('does not let a rejected call break the chain for a call queued after it', async () => {
+    store.createProjectGroup.mockImplementationOnce(async () => {
+      throw new Error('boom')
+    })
+
+    const first = openOsRequestedFile('/Users/x/projects/broken/a.md')
+    const second = openOsRequestedFile('/Users/x/projects/newfolder/b.md')
+
+    await expect(first).rejects.toThrow('boom')
+    await expect(second).resolves.toBeUndefined()
+
+    expect(store.createFolderWorkspace).toHaveBeenCalledTimes(1)
+    expect(store.folderWorkspaces).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/lib/open-os-requested-file.ts
+++ b/src/renderer/src/lib/open-os-requested-file.ts
@@ -1,9 +1,9 @@
 import { toast } from 'sonner'
-import { relativePathInsideRoot } from '../../../shared/cross-platform-path'
 import { folderWorkspaceToWorktree } from '../../../shared/folder-workspace-worktree'
 import { defaultProjectGroupNameForPath } from '@/components/sidebar/add-repo-dialog-types'
 import { useAppStore } from '@/store'
 import { detectLanguage } from './language-detect'
+import { findLocalProjectGroupForFilePath } from './os-requested-file-project-group'
 import { findWorkspaceForFilePath, type WorkspaceCandidate } from './os-requested-file-workspace'
 import { basename, dirname } from './path'
 import { activateAndRevealWorktree } from './worktree-activation'
@@ -29,13 +29,14 @@ function collectWorkspaceCandidates(): WorkspaceCandidate[] {
 async function resolveProjectGroupId(filePath: string, folderPath: string): Promise<string | null> {
   const state = useAppStore.getState()
   // Why: a folder-backed group the user already made is a better home than a new one.
-  const existing = state.projectGroups.find(
-    (group) => group.parentPath && relativePathInsideRoot(group.parentPath, filePath) !== null
-  )
+  const existing = findLocalProjectGroupForFilePath(filePath, state.projectGroups)
   if (existing) {
     return existing.id
   }
-  const created = await state.createProjectGroup(defaultProjectGroupNameForPath(folderPath))
+  // Why: the OS always hands over a local path, so the new group must not follow the active runtime.
+  const created = await state.createProjectGroup(defaultProjectGroupNameForPath(folderPath), {
+    runtimeEnvironmentId: null
+  })
   return created?.id ?? null
 }
 
@@ -59,11 +60,15 @@ export async function openOsRequestedFile(filePath: string): Promise<void> {
     }
     let created
     try {
-      created = await useAppStore.getState().createFolderWorkspace({
-        projectGroupId,
-        name: basename(folderPath),
-        folderPath
-      })
+      // Why: the OS always hands over a local path, so the new workspace must not follow the active runtime.
+      created = await useAppStore.getState().createFolderWorkspace(
+        {
+          projectGroupId,
+          name: basename(folderPath),
+          folderPath
+        },
+        { runtimeEnvironmentId: null }
+      )
     } catch (error) {
       toast.error(
         error instanceof Error

--- a/src/renderer/src/lib/open-os-requested-file.ts
+++ b/src/renderer/src/lib/open-os-requested-file.ts
@@ -40,7 +40,20 @@ async function resolveProjectGroupId(filePath: string, folderPath: string): Prom
   return created?.id ?? null
 }
 
-export async function openOsRequestedFile(filePath: string): Promise<void> {
+// Why: concurrent calls must not both miss the same not-yet-created workspace and each create a duplicate.
+let openOsRequestedFileChain: Promise<void> = Promise.resolve()
+
+export function openOsRequestedFile(filePath: string): Promise<void> {
+  const run = openOsRequestedFileChain.then(() => openOsRequestedFileSerially(filePath))
+  // Why: swallow so a rejected call doesn't wedge the chain for callers queued after it.
+  openOsRequestedFileChain = run.then(
+    () => undefined,
+    () => undefined
+  )
+  return run
+}
+
+async function openOsRequestedFileSerially(filePath: string): Promise<void> {
   const existing = findWorkspaceForFilePath(filePath, collectWorkspaceCandidates())
   let worktreeId = existing?.workspace.id ?? null
   // Why: an empty relative path means the match was the workspace root itself, not a file in it.

--- a/src/renderer/src/lib/open-os-requested-file.ts
+++ b/src/renderer/src/lib/open-os-requested-file.ts
@@ -1,0 +1,101 @@
+import { toast } from 'sonner'
+import { relativePathInsideRoot } from '../../../shared/cross-platform-path'
+import { folderWorkspaceToWorktree } from '../../../shared/folder-workspace-worktree'
+import { defaultProjectGroupNameForPath } from '@/components/sidebar/add-repo-dialog-types'
+import { useAppStore } from '@/store'
+import { detectLanguage } from './language-detect'
+import { findWorkspaceForFilePath, type WorkspaceCandidate } from './os-requested-file-workspace'
+import { basename, dirname } from './path'
+import { activateAndRevealWorktree } from './worktree-activation'
+import { translate } from '@/i18n/i18n'
+
+function collectWorkspaceCandidates(): WorkspaceCandidate[] {
+  const state = useAppStore.getState()
+  const candidates: WorkspaceCandidate[] = []
+  for (const worktrees of Object.values(state.worktreesByRepo)) {
+    for (const worktree of worktrees) {
+      candidates.push({ id: worktree.id, path: worktree.path })
+    }
+  }
+  for (const folderWorkspace of state.folderWorkspaces) {
+    candidates.push({
+      id: folderWorkspaceToWorktree(folderWorkspace).id,
+      path: folderWorkspace.folderPath
+    })
+  }
+  return candidates
+}
+
+async function resolveProjectGroupId(filePath: string, folderPath: string): Promise<string | null> {
+  const state = useAppStore.getState()
+  // Why: a folder-backed group the user already made is a better home than a new one.
+  const existing = state.projectGroups.find(
+    (group) => group.parentPath && relativePathInsideRoot(group.parentPath, filePath) !== null
+  )
+  if (existing) {
+    return existing.id
+  }
+  const created = await state.createProjectGroup(defaultProjectGroupNameForPath(folderPath))
+  return created?.id ?? null
+}
+
+export async function openOsRequestedFile(filePath: string): Promise<void> {
+  const existing = findWorkspaceForFilePath(filePath, collectWorkspaceCandidates())
+  let worktreeId = existing?.workspace.id ?? null
+  // Why: an empty relative path means the match was the workspace root itself, not a file in it.
+  let relativePath = existing?.relativePath ?? ''
+
+  if (!worktreeId || !relativePath) {
+    const folderPath = dirname(filePath)
+    const projectGroupId = await resolveProjectGroupId(filePath, folderPath)
+    if (!projectGroupId) {
+      toast.error(
+        translate(
+          'auto.lib.open.os.requested.file.8086cba22b',
+          'Could not open the file: no project group was available for its folder.'
+        )
+      )
+      return
+    }
+    let created
+    try {
+      created = await useAppStore.getState().createFolderWorkspace({
+        projectGroupId,
+        name: basename(folderPath),
+        folderPath
+      })
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : translate('auto.lib.open.os.requested.file.96019938b5', 'Could not open the file.')
+      )
+      return
+    }
+    if (!created) {
+      toast.error(
+        translate(
+          'auto.lib.open.os.requested.file.bdf34177f8',
+          'Could not open the file: creating a workspace for its folder failed.'
+        )
+      )
+      return
+    }
+    worktreeId = folderWorkspaceToWorktree(created).id
+    relativePath = basename(filePath)
+  }
+
+  activateAndRevealWorktree(worktreeId)
+  useAppStore.getState().openFile(
+    {
+      filePath,
+      relativePath,
+      worktreeId,
+      language: detectLanguage(filePath),
+      mode: 'edit',
+      // Why: the OS always hands over a local path, so never inherit a remote active runtime.
+      runtimeEnvironmentId: null
+    },
+    { focusEditor: true }
+  )
+}

--- a/src/renderer/src/lib/open-os-requested-file.ts
+++ b/src/renderer/src/lib/open-os-requested-file.ts
@@ -3,7 +3,7 @@ import { folderWorkspaceToWorktree } from '../../../shared/folder-workspace-work
 import { defaultProjectGroupNameForPath } from '@/components/sidebar/add-repo-dialog-types'
 import { useAppStore } from '@/store'
 import { detectLanguage } from './language-detect'
-import { findLocalProjectGroupForFilePath } from './os-requested-file-project-group'
+import { findLocalProjectGroupForOsRequestedFile } from './os-requested-file-project-group'
 import { findWorkspaceForFilePath, type WorkspaceCandidate } from './os-requested-file-workspace'
 import { basename, dirname } from './path'
 import { activateAndRevealWorktree } from './worktree-activation'
@@ -28,15 +28,15 @@ function collectWorkspaceCandidates(): WorkspaceCandidate[] {
 
 async function resolveProjectGroupId(filePath: string, folderPath: string): Promise<string | null> {
   const state = useAppStore.getState()
-  // Why: a folder-backed group the user already made is a better home than a new one.
-  const existing = findLocalProjectGroupForFilePath(filePath, state.projectGroups)
+  const groupName = defaultProjectGroupNameForPath(folderPath)
+  // Why: a folder-backed group the user already made is a better home than a new one; failing that, reuse a
+  // group this flow already created rather than pile up duplicates when the workspace lookup misses.
+  const existing = findLocalProjectGroupForOsRequestedFile(filePath, groupName, state.projectGroups)
   if (existing) {
     return existing.id
   }
   // Why: the OS always hands over a local path, so the new group must not follow the active runtime.
-  const created = await state.createProjectGroup(defaultProjectGroupNameForPath(folderPath), {
-    runtimeEnvironmentId: null
-  })
+  const created = await state.createProjectGroup(groupName, { runtimeEnvironmentId: null })
   return created?.id ?? null
 }
 

--- a/src/renderer/src/lib/open-os-requested-file.ts
+++ b/src/renderer/src/lib/open-os-requested-file.ts
@@ -4,27 +4,11 @@ import { defaultProjectGroupNameForPath } from '@/components/sidebar/add-repo-di
 import { useAppStore } from '@/store'
 import { detectLanguage } from './language-detect'
 import { findLocalProjectGroupForOsRequestedFile } from './os-requested-file-project-group'
-import { findWorkspaceForFilePath, type WorkspaceCandidate } from './os-requested-file-workspace'
+import { collectLocalWorkspaceCandidates } from './os-requested-file-workspace-candidates'
+import { findWorkspaceForFilePath } from './os-requested-file-workspace'
 import { basename, dirname } from './path'
 import { activateAndRevealWorktree } from './worktree-activation'
 import { translate } from '@/i18n/i18n'
-
-function collectWorkspaceCandidates(): WorkspaceCandidate[] {
-  const state = useAppStore.getState()
-  const candidates: WorkspaceCandidate[] = []
-  for (const worktrees of Object.values(state.worktreesByRepo)) {
-    for (const worktree of worktrees) {
-      candidates.push({ id: worktree.id, path: worktree.path })
-    }
-  }
-  for (const folderWorkspace of state.folderWorkspaces) {
-    candidates.push({
-      id: folderWorkspaceToWorktree(folderWorkspace).id,
-      path: folderWorkspace.folderPath
-    })
-  }
-  return candidates
-}
 
 async function resolveProjectGroupId(filePath: string, folderPath: string): Promise<string | null> {
   const state = useAppStore.getState()
@@ -54,7 +38,10 @@ export function openOsRequestedFile(filePath: string): Promise<void> {
 }
 
 async function openOsRequestedFileSerially(filePath: string): Promise<void> {
-  const existing = findWorkspaceForFilePath(filePath, collectWorkspaceCandidates())
+  const existing = findWorkspaceForFilePath(
+    filePath,
+    collectLocalWorkspaceCandidates(useAppStore.getState())
+  )
   let worktreeId = existing?.workspace.id ?? null
   // Why: an empty relative path means the match was the workspace root itself, not a file in it.
   let relativePath = existing?.relativePath ?? ''

--- a/src/renderer/src/lib/os-requested-file-project-group.test.ts
+++ b/src/renderer/src/lib/os-requested-file-project-group.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { findLocalProjectGroupForFilePath } from './os-requested-file-project-group'
+
+describe('findLocalProjectGroupForFilePath', () => {
+  it('chooses a local group whose parentPath contains the file', () => {
+    const group = {
+      id: 'g1',
+      parentPath: '/Users/x/projects',
+      connectionId: null,
+      executionHostId: null
+    }
+    expect(findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [group])).toEqual(
+      group
+    )
+  })
+
+  it('does not choose a remote group (truthy connectionId) with a matching parentPath', () => {
+    const remoteGroup = {
+      id: 'g1',
+      parentPath: '/Users/x/projects',
+      connectionId: 'ssh-host-1',
+      executionHostId: null
+    }
+    expect(
+      findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [remoteGroup])
+    ).toBeNull()
+  })
+
+  it('does not choose a group whose executionHostId is a remote runtime, even without connectionId', () => {
+    const runtimeGroup = {
+      id: 'g1',
+      parentPath: '/Users/x/projects',
+      connectionId: null,
+      executionHostId: 'runtime:env-1'
+    }
+    expect(
+      findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [runtimeGroup])
+    ).toBeNull()
+  })
+
+  it('skips a group with parentPath: null', () => {
+    const group = { id: 'g1', parentPath: null, connectionId: null, executionHostId: null }
+    expect(findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [group])).toBeNull()
+  })
+
+  it('returns null when no group matches', () => {
+    const group = {
+      id: 'g1',
+      parentPath: '/Users/x/other',
+      connectionId: null,
+      executionHostId: null
+    }
+    expect(findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [group])).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/os-requested-file-project-group.test.ts
+++ b/src/renderer/src/lib/os-requested-file-project-group.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import { findLocalProjectGroupForFilePath } from './os-requested-file-project-group'
+import {
+  findLocalProjectGroupByName,
+  findLocalProjectGroupForFilePath,
+  findLocalProjectGroupForOsRequestedFile
+} from './os-requested-file-project-group'
 
 describe('findLocalProjectGroupForFilePath', () => {
   it('chooses a local group whose parentPath contains the file', () => {
     const group = {
       id: 'g1',
+      name: 'orca',
       parentPath: '/Users/x/projects',
       connectionId: null,
-      executionHostId: null
+      executionHostId: null,
+      createdAt: 1
     }
     expect(findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [group])).toEqual(
       group
@@ -17,9 +23,11 @@ describe('findLocalProjectGroupForFilePath', () => {
   it('does not choose a remote group (truthy connectionId) with a matching parentPath', () => {
     const remoteGroup = {
       id: 'g1',
+      name: 'orca',
       parentPath: '/Users/x/projects',
       connectionId: 'ssh-host-1',
-      executionHostId: null
+      executionHostId: null,
+      createdAt: 1
     }
     expect(
       findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [remoteGroup])
@@ -29,9 +37,11 @@ describe('findLocalProjectGroupForFilePath', () => {
   it('does not choose a group whose executionHostId is a remote runtime, even without connectionId', () => {
     const runtimeGroup = {
       id: 'g1',
+      name: 'orca',
       parentPath: '/Users/x/projects',
       connectionId: null,
-      executionHostId: 'runtime:env-1'
+      executionHostId: 'runtime:env-1',
+      createdAt: 1
     }
     expect(
       findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [runtimeGroup])
@@ -39,17 +49,168 @@ describe('findLocalProjectGroupForFilePath', () => {
   })
 
   it('skips a group with parentPath: null', () => {
-    const group = { id: 'g1', parentPath: null, connectionId: null, executionHostId: null }
+    const group = {
+      id: 'g1',
+      name: 'orca',
+      parentPath: null,
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 1
+    }
     expect(findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [group])).toBeNull()
   })
 
   it('returns null when no group matches', () => {
     const group = {
       id: 'g1',
+      name: 'orca',
       parentPath: '/Users/x/other',
       connectionId: null,
-      executionHostId: null
+      executionHostId: null,
+      createdAt: 1
     }
     expect(findLocalProjectGroupForFilePath('/Users/x/projects/orca/note.md', [group])).toBeNull()
+  })
+})
+
+describe('findLocalProjectGroupByName', () => {
+  it('rejects a remote group (truthy connectionId) with a matching name', () => {
+    const remoteGroup = {
+      id: 'g1',
+      name: 'orca',
+      parentPath: null,
+      connectionId: 'ssh-host-1',
+      executionHostId: null,
+      createdAt: 1
+    }
+    expect(findLocalProjectGroupByName('orca', [remoteGroup])).toBeNull()
+  })
+
+  it('picks the oldest createdAt when several local groups share the name', () => {
+    const older = {
+      id: 'older',
+      name: 'orca',
+      parentPath: null,
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 100
+    }
+    const newer = {
+      id: 'newer',
+      name: 'orca',
+      parentPath: null,
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 200
+    }
+    expect(findLocalProjectGroupByName('orca', [newer, older])).toEqual(older)
+  })
+
+  it('returns null when no group has that name', () => {
+    const group = {
+      id: 'g1',
+      name: 'other-name',
+      parentPath: null,
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 1
+    }
+    expect(findLocalProjectGroupByName('orca', [group])).toBeNull()
+  })
+})
+
+describe('findLocalProjectGroupForOsRequestedFile', () => {
+  it('reuses a name-matching local group when no parentPath match exists', () => {
+    const nameMatch = {
+      id: 'g1',
+      name: 'orca',
+      parentPath: null,
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 1
+    }
+    expect(
+      findLocalProjectGroupForOsRequestedFile('/Users/x/projects/orca/note.md', 'orca', [nameMatch])
+    ).toEqual(nameMatch)
+  })
+
+  it('lets a parentPath match win over a name match (order matters)', () => {
+    const pathMatch = {
+      id: 'path-match',
+      name: 'unrelated',
+      parentPath: '/Users/x/projects',
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 1
+    }
+    const nameMatch = {
+      id: 'name-match',
+      name: 'orca',
+      parentPath: null,
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 1
+    }
+    const result = findLocalProjectGroupForOsRequestedFile(
+      '/Users/x/projects/orca/note.md',
+      'orca',
+      [nameMatch, pathMatch]
+    )
+    expect(result).toEqual(pathMatch)
+  })
+
+  it('rejects a remote group with a matching name', () => {
+    const remoteNameMatch = {
+      id: 'g1',
+      name: 'orca',
+      parentPath: null,
+      connectionId: 'ssh-host-1',
+      executionHostId: null,
+      createdAt: 1
+    }
+    expect(
+      findLocalProjectGroupForOsRequestedFile('/Users/x/projects/orca/note.md', 'orca', [
+        remoteNameMatch
+      ])
+    ).toBeNull()
+  })
+
+  it('picks the oldest local same-name group deterministically', () => {
+    const older = {
+      id: 'older',
+      name: 'orca',
+      parentPath: null,
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 100
+    }
+    const newer = {
+      id: 'newer',
+      name: 'orca',
+      parentPath: null,
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 200
+    }
+    expect(
+      findLocalProjectGroupForOsRequestedFile('/Users/x/projects/orca/note.md', 'orca', [
+        newer,
+        older
+      ])
+    ).toEqual(older)
+  })
+
+  it('returns null when nothing matches by path or name', () => {
+    const group = {
+      id: 'g1',
+      name: 'other-name',
+      parentPath: '/Users/x/other',
+      connectionId: null,
+      executionHostId: null,
+      createdAt: 1
+    }
+    expect(
+      findLocalProjectGroupForOsRequestedFile('/Users/x/projects/orca/note.md', 'orca', [group])
+    ).toBeNull()
   })
 })

--- a/src/renderer/src/lib/os-requested-file-project-group.ts
+++ b/src/renderer/src/lib/os-requested-file-project-group.ts
@@ -1,0 +1,25 @@
+import { relativePathInsideRoot } from '../../../shared/cross-platform-path'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
+import type { ProjectGroup } from '../../../shared/types'
+import { getProjectGroupExecutionHostIdForRows } from '@/components/sidebar/worktree-list-host-filtering'
+
+export type LocalProjectGroupCandidate = Pick<
+  ProjectGroup,
+  'id' | 'parentPath' | 'connectionId' | 'executionHostId'
+>
+
+// Why: the OS always hands over a local path; a remote-owned group must never claim it just because parentPath matches.
+export function findLocalProjectGroupForFilePath(
+  filePath: string,
+  projectGroups: readonly LocalProjectGroupCandidate[]
+): LocalProjectGroupCandidate | null {
+  return (
+    projectGroups.find(
+      (group) =>
+        group.parentPath &&
+        relativePathInsideRoot(group.parentPath, filePath) !== null &&
+        getProjectGroupExecutionHostIdForRows(group, LOCAL_EXECUTION_HOST_ID) ===
+          LOCAL_EXECUTION_HOST_ID
+    ) ?? null
+  )
+}

--- a/src/renderer/src/lib/os-requested-file-project-group.ts
+++ b/src/renderer/src/lib/os-requested-file-project-group.ts
@@ -5,8 +5,15 @@ import { getProjectGroupExecutionHostIdForRows } from '@/components/sidebar/work
 
 export type LocalProjectGroupCandidate = Pick<
   ProjectGroup,
-  'id' | 'parentPath' | 'connectionId' | 'executionHostId'
+  'id' | 'name' | 'parentPath' | 'connectionId' | 'executionHostId' | 'createdAt'
 >
+
+function isLocallyOwnedProjectGroup(group: LocalProjectGroupCandidate): boolean {
+  return (
+    getProjectGroupExecutionHostIdForRows(group, LOCAL_EXECUTION_HOST_ID) ===
+    LOCAL_EXECUTION_HOST_ID
+  )
+}
 
 // Why: the OS always hands over a local path; a remote-owned group must never claim it just because parentPath matches.
 export function findLocalProjectGroupForFilePath(
@@ -18,8 +25,38 @@ export function findLocalProjectGroupForFilePath(
       (group) =>
         group.parentPath &&
         relativePathInsideRoot(group.parentPath, filePath) !== null &&
-        getProjectGroupExecutionHostIdForRows(group, LOCAL_EXECUTION_HOST_ID) ===
-          LOCAL_EXECUTION_HOST_ID
+        isLocallyOwnedProjectGroup(group)
     ) ?? null
+  )
+}
+
+// Why: reuse a group this flow already created (orphaned by a failed/deleted workspace) instead of piling up
+// identically-named duplicates; oldest createdAt is the one a user is most likely to recognize.
+export function findLocalProjectGroupByName(
+  name: string,
+  projectGroups: readonly LocalProjectGroupCandidate[]
+): LocalProjectGroupCandidate | null {
+  let oldest: LocalProjectGroupCandidate | null = null
+  for (const group of projectGroups) {
+    if (group.name !== name || !isLocallyOwnedProjectGroup(group)) {
+      continue
+    }
+    if (!oldest || group.createdAt < oldest.createdAt) {
+      oldest = group
+    }
+  }
+  return oldest
+}
+
+// Why: a folder-backed group the user set up wins over one this flow named itself — reuse only kicks in as a
+// fallback once the path-based match misses.
+export function findLocalProjectGroupForOsRequestedFile(
+  filePath: string,
+  groupName: string,
+  projectGroups: readonly LocalProjectGroupCandidate[]
+): LocalProjectGroupCandidate | null {
+  return (
+    findLocalProjectGroupForFilePath(filePath, projectGroups) ??
+    findLocalProjectGroupByName(groupName, projectGroups)
   )
 }

--- a/src/renderer/src/lib/os-requested-file-workspace-candidates.test.ts
+++ b/src/renderer/src/lib/os-requested-file-workspace-candidates.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { collectLocalWorkspaceCandidates } from './os-requested-file-workspace-candidates'
+
+describe('collectLocalWorkspaceCandidates', () => {
+  it('includes a local worktree containing the path', () => {
+    const state = {
+      worktreesByRepo: {
+        'local-repo': [{ id: 'wt-local', path: '/Users/x/projects/orca', repoId: 'local-repo' }]
+      },
+      folderWorkspaces: []
+    }
+    expect(collectLocalWorkspaceCandidates(state)).toEqual([
+      { id: 'wt-local', path: '/Users/x/projects/orca' }
+    ])
+  })
+
+  it('excludes a remote/runtime-owned worktree containing the path', () => {
+    const state = {
+      worktreesByRepo: {
+        'runtime-repo': [
+          {
+            id: 'wt-remote',
+            path: '/Users/x/projects/orca',
+            repoId: 'runtime-repo',
+            hostId: 'runtime:env-1' as const
+          }
+        ]
+      },
+      folderWorkspaces: []
+    }
+    expect(collectLocalWorkspaceCandidates(state)).toEqual([])
+  })
+
+  it('includes a local folder workspace containing the path', () => {
+    const state = {
+      worktreesByRepo: {},
+      folderWorkspaces: [
+        {
+          id: 'fw-local',
+          folderPath: '/Users/x/Downloads',
+          connectionId: null,
+          projectGroupId: 'group-local'
+        }
+      ]
+    }
+    expect(collectLocalWorkspaceCandidates(state)).toEqual([
+      { id: 'folder:fw-local', path: '/Users/x/Downloads' }
+    ])
+  })
+
+  it('excludes an SSH-owned folder workspace (truthy connectionId) containing the path', () => {
+    const state = {
+      worktreesByRepo: {},
+      folderWorkspaces: [
+        {
+          id: 'fw-remote',
+          folderPath: '/Users/x/Downloads',
+          connectionId: 'ssh-host-1',
+          projectGroupId: 'group-remote'
+        }
+      ]
+    }
+    expect(collectLocalWorkspaceCandidates(state)).toEqual([])
+  })
+
+  it('keeps only the local candidate when a remote and a local candidate both contain the path', () => {
+    const state = {
+      worktreesByRepo: {
+        'local-repo': [{ id: 'wt-local', path: '/Users/x/projects/orca', repoId: 'local-repo' }],
+        'runtime-repo': [
+          {
+            id: 'wt-remote',
+            path: '/Users/x/projects/orca',
+            repoId: 'runtime-repo',
+            hostId: 'runtime:env-1' as const
+          }
+        ]
+      },
+      folderWorkspaces: []
+    }
+    expect(collectLocalWorkspaceCandidates(state).map((candidate) => candidate.id)).toEqual([
+      'wt-local'
+    ])
+  })
+})

--- a/src/renderer/src/lib/os-requested-file-workspace-candidates.ts
+++ b/src/renderer/src/lib/os-requested-file-workspace-candidates.ts
@@ -1,0 +1,43 @@
+import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
+import type { FolderWorkspace, Worktree } from '../../../shared/types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { getExecutionHostIdForWorktree } from './worktree-runtime-owner'
+import type { WorktreeRuntimeOwnerState } from './worktree-runtime-owner'
+import type { WorkspaceCandidate } from './os-requested-file-workspace'
+
+export type WorktreeCandidateSource = Pick<
+  Worktree,
+  'id' | 'path' | 'repoId' | 'hostId' | 'runtimeOwnerEnvironmentId'
+>
+
+export type FolderWorkspaceCandidateSource = Pick<
+  FolderWorkspace,
+  'id' | 'folderPath' | 'connectionId' | 'projectGroupId'
+>
+
+export type WorkspaceCandidateCollectionState = WorktreeRuntimeOwnerState & {
+  worktreesByRepo: Record<string, readonly WorktreeCandidateSource[]>
+  folderWorkspaces: readonly FolderWorkspaceCandidateSource[]
+}
+
+// Why: the OS always hands over a local path; a remote/SSH-owned candidate whose path string
+// happens to contain it must never be adopted — same defect class as the project-group fix.
+export function collectLocalWorkspaceCandidates(
+  state: WorkspaceCandidateCollectionState
+): WorkspaceCandidate[] {
+  const candidates: WorkspaceCandidate[] = []
+  for (const worktrees of Object.values(state.worktreesByRepo)) {
+    for (const worktree of worktrees) {
+      if (getExecutionHostIdForWorktree(state, worktree.id) === LOCAL_EXECUTION_HOST_ID) {
+        candidates.push({ id: worktree.id, path: worktree.path })
+      }
+    }
+  }
+  for (const folderWorkspace of state.folderWorkspaces) {
+    const id = folderWorkspaceKey(folderWorkspace.id)
+    if (getExecutionHostIdForWorktree(state, id) === LOCAL_EXECUTION_HOST_ID) {
+      candidates.push({ id, path: folderWorkspace.folderPath })
+    }
+  }
+  return candidates
+}

--- a/src/renderer/src/lib/os-requested-file-workspace.test.ts
+++ b/src/renderer/src/lib/os-requested-file-workspace.test.ts
@@ -51,4 +51,36 @@ describe('findWorkspaceForFilePath', () => {
       ])?.relativePath
     ).toBe('note.md')
   })
+
+  it('prefers deepest workspace even when ancestor path is longer due to Unicode encoding', () => {
+    // Why: roots in different Unicode forms (NFD vs NFC) can have different .length despite same meaning.
+    // Ancestor: 'éééééée' in NFD form (13 code units vs 7 in NFC)
+    const nfdDirName = 'éééééée'.normalize('NFD') // 13 units
+    const ancestorRoot = `/workspace/${nfdDirName}` // 11 + 13 = 24 units
+    // Descendant: same directory name in NFC form plus short segment
+    const ncfDirName = 'éééééée'.normalize('NFC') // 7 units
+    const descendantRoot = `/workspace/${ncfDirName}/x` // 11 + 7 + 2 = 20 units
+    const filePath = `${descendantRoot}/file.md`
+
+    // With old comparison (workspace.path.length > best.path.length):
+    //   ancestor: 24 > descendant: 20 → ancestor wins (WRONG — it's shallower)
+    // With new comparison (relativePath.length < best.relativePath.length):
+    //   ancestor relative: 'x/file.md' (9) > descendant relative: 'file.md' (7) → descendant wins (correct)
+    const result = findWorkspaceForFilePath(filePath, [
+      { id: 'ancestor', path: ancestorRoot },
+      { id: 'descendant', path: descendantRoot }
+    ])
+    expect(result?.workspace.id).toBe('descendant')
+    expect(result?.relativePath).toBe('file.md')
+  })
+
+  it('matches when file path exactly equals workspace root and returns empty relative path', () => {
+    const result = findWorkspaceForFilePath('/Users/x/Downloads', [
+      { id: 'dl', path: '/Users/x/Downloads' }
+    ])
+    expect(result).toEqual({
+      workspace: { id: 'dl', path: '/Users/x/Downloads' },
+      relativePath: ''
+    })
+  })
 })

--- a/src/renderer/src/lib/os-requested-file-workspace.test.ts
+++ b/src/renderer/src/lib/os-requested-file-workspace.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { findWorkspaceForFilePath } from './os-requested-file-workspace'
+
+describe('findWorkspaceForFilePath', () => {
+  it('returns null when no workspace contains the file', () => {
+    expect(
+      findWorkspaceForFilePath('/Users/x/Downloads/note.md', [
+        { id: 'w1', path: '/Users/x/projects/orca' }
+      ])
+    ).toBeNull()
+  })
+
+  it('matches a containing workspace and reports the relative path', () => {
+    expect(
+      findWorkspaceForFilePath('/Users/x/projects/orca/docs/note.md', [
+        { id: 'w1', path: '/Users/x/projects/orca' }
+      ])
+    ).toEqual({
+      workspace: { id: 'w1', path: '/Users/x/projects/orca' },
+      relativePath: 'docs/note.md'
+    })
+  })
+
+  it('prefers the deepest workspace when several contain the file', () => {
+    const result = findWorkspaceForFilePath('/Users/x/projects/orca/sub/note.md', [
+      { id: 'outer', path: '/Users/x/projects' },
+      { id: 'inner', path: '/Users/x/projects/orca' }
+    ])
+    expect(result?.workspace.id).toBe('inner')
+    expect(result?.relativePath).toBe('sub/note.md')
+  })
+
+  it('does not match a sibling directory that shares a name prefix', () => {
+    expect(
+      findWorkspaceForFilePath('/Users/x/projects/orca-extra/note.md', [
+        { id: 'w1', path: '/Users/x/projects/orca' }
+      ])
+    ).toBeNull()
+  })
+
+  it('ignores candidates with an empty path', () => {
+    expect(
+      findWorkspaceForFilePath('/Users/x/Downloads/note.md', [{ id: 'w1', path: '' }])
+    ).toBeNull()
+  })
+
+  it('matches a file sitting directly in the workspace root', () => {
+    expect(
+      findWorkspaceForFilePath('/Users/x/Downloads/note.md', [
+        { id: 'dl', path: '/Users/x/Downloads' }
+      ])?.relativePath
+    ).toBe('note.md')
+  })
+})

--- a/src/renderer/src/lib/os-requested-file-workspace.ts
+++ b/src/renderer/src/lib/os-requested-file-workspace.ts
@@ -20,8 +20,8 @@ export function findWorkspaceForFilePath(
     if (relativePath === null) {
       continue
     }
-    // Why: nested workspaces both match; the deepest root is the one the user thinks the file lives in.
-    if (!best || workspace.path.length > best.workspace.path.length) {
+    // Why: shorter relative path always means deeper root, immune to Unicode/encoding differences in root itself.
+    if (!best || relativePath.length < best.relativePath.length) {
       best = { workspace, relativePath }
     }
   }

--- a/src/renderer/src/lib/os-requested-file-workspace.ts
+++ b/src/renderer/src/lib/os-requested-file-workspace.ts
@@ -1,0 +1,29 @@
+import { relativePathInsideRoot } from '../../../shared/cross-platform-path'
+
+export type WorkspaceCandidate = { id: string; path: string }
+
+export type ResolvedOsFileWorkspace = {
+  workspace: WorkspaceCandidate
+  relativePath: string
+}
+
+export function findWorkspaceForFilePath(
+  filePath: string,
+  candidates: readonly WorkspaceCandidate[]
+): ResolvedOsFileWorkspace | null {
+  let best: ResolvedOsFileWorkspace | null = null
+  for (const workspace of candidates) {
+    if (!workspace.path) {
+      continue
+    }
+    const relativePath = relativePathInsideRoot(workspace.path, filePath)
+    if (relativePath === null) {
+      continue
+    }
+    // Why: nested workspaces both match; the deepest root is the one the user thinks the file lives in.
+    if (!best || workspace.path.length > best.workspace.path.length) {
+      best = { workspace, relativePath }
+    }
+  }
+  return best
+}

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1408,6 +1408,7 @@ function getRuntimeTargetCachePrefix(
 type FolderWorkspacePathStatusRouteOptions = { runtimeEnvironmentId?: string | null }
 type AddRepoPathRouteOptions = { runtimeEnvironmentId?: string | null }
 type RuntimeCatalogFetchOptions = { runtimeEnvironmentId?: string | null }
+type CreateProjectGroupRouteOptions = { runtimeEnvironmentId?: string | null }
 
 function getFolderWorkspacePathStatusRouteSettings(
   options: FolderWorkspacePathStatusRouteOptions | undefined,
@@ -1420,6 +1421,15 @@ function getFolderWorkspacePathStatusRouteSettings(
 
 function getAddRepoPathRouteSettings(
   options: AddRepoPathRouteOptions | undefined,
+  fallbackSettings: GlobalSettings | null
+): Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined {
+  return options && 'runtimeEnvironmentId' in options
+    ? { activeRuntimeEnvironmentId: options.runtimeEnvironmentId ?? null }
+    : fallbackSettings
+}
+
+function getCreateProjectGroupRouteSettings(
+  options: CreateProjectGroupRouteOptions | undefined,
   fallbackSettings: GlobalSettings | null
 ): Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined {
   return options && 'runtimeEnvironmentId' in options
@@ -1672,7 +1682,10 @@ export type RepoSlice = {
     runtimeEnvironmentId?: string | null
     mode: 'group' | 'separate'
   }) => Promise<ProjectGroupImportResult | null>
-  createProjectGroup: (name: string) => Promise<ProjectGroup | null>
+  createProjectGroup: (
+    name: string,
+    options?: CreateProjectGroupRouteOptions
+  ) => Promise<ProjectGroup | null>
   createFolderWorkspace: (
     args: {
       projectGroupId: string
@@ -2482,9 +2495,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  createProjectGroup: async (name) => {
+  createProjectGroup: async (name, options) => {
     try {
-      const target = getActiveRuntimeTarget(get().settings)
+      const target = getActiveRuntimeTarget(
+        getCreateProjectGroupRouteSettings(options, get().settings)
+      )
       const group =
         target.kind === 'local'
           ? await window.api.projectGroups.create({

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1408,6 +1408,7 @@ function getRuntimeTargetCachePrefix(
 type FolderWorkspacePathStatusRouteOptions = { runtimeEnvironmentId?: string | null }
 type AddRepoPathRouteOptions = { runtimeEnvironmentId?: string | null }
 type RuntimeCatalogFetchOptions = { runtimeEnvironmentId?: string | null }
+// Why: routing options are named per call family here; a create is not a catalog fetch.
 type CreateProjectGroupRouteOptions = { runtimeEnvironmentId?: string | null }
 
 function getFolderWorkspacePathStatusRouteSettings(


### PR DESCRIPTION
## Summary

Orca now appears in the OS "Open With" list for markdown files, and opening a `.md` that way loads it in an editor tab — no project setup required first.

Today Orca declares no document types, so a markdown file on the desktop or in `~/Downloads` cannot be handed to it at all. This adds the association and the plumbing behind it:

- **File association** — one top-level `fileAssociations` entry covering macOS (`CFBundleDocumentTypes`), Windows (installer registry) and Linux (`.desktop` `MimeType`). `rank: Alternate`, so Orca joins the list without taking over anyone's default markdown editor.
- **Main process** — collects paths from macOS's `open-file` event and from `argv` / `second-instance` on Windows and Linux, buffering them until the renderer is listening.
- **Renderer** — resolves which workspace should own the file. If an existing worktree or folder workspace already contains it, that one is reused; otherwise a folder workspace is created for the file's parent directory, inside a locally-owned project group.

The workspace step exists because Orca's model has no workspace-less buffer — even an untitled markdown file is written into a workspace (`createUntitledMarkdownFile`), and `AGENTS.md` treats folder workspaces as a first-class peer of git worktrees. Rather than introduce a new "file with no workspace" concept, an OS-opened file gets the same kind of folder workspace that "Add Folder as Project" creates. The visible cost is one project group plus one workspace the first time you open a file from a given folder; every later file from that folder reuses them.

## Screenshots

**Finder's "Open With" list for a `.md` file** — Orca is listed, and `Xcode.app (default)` is still the default handler, which is what `rank: Alternate` is for.

![Finder Open With list showing Orca](https://raw.githubusercontent.com/java-jaydev/orca/pr-assets/open-markdown-from-os/01-finder-open-with.png)

**The file opened in Orca** — no project was registered beforehand; the `orca-open-test` workspace was created automatically from the file's parent folder.

![lf-note.md open in Orca with an auto-created workspace](https://raw.githubusercontent.com/java-jaydev/orca/pr-assets/open-markdown-from-os/02-file-opened.png)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 39,573 passed / 62 skipped
- [x] `pnpm build` (`pnpm build:mac`, both arm64 and x64 slices)
- [x] Added or updated high-quality tests that would catch regressions

New tests, by area:

| Area | Coverage |
|---|---|
| `os-file-open-requests` | markdown path recognition, argv extraction (argv[0] and Chromium switches excluded), queue buffer/drain/dedup, deliver-target switching, `filterExistingFiles` against real fixtures (existing file, directory, missing path), per-platform registration — darwin subscribes to `open-file` only, win32/linux read argv and subscribe to `second-instance` |
| `os-file-open` IPC | pending drain, live push after the renderer takes the batch, listener de-duplication across repeated calls, and multi-sender ownership: a superseded sender's teardown must not clear the current owner's delivery |
| `os-requested-file-workspace` | containment matching, deepest-workspace selection, sibling-prefix rejection, file-equals-root case |
| `os-requested-file-project-group` | path-based match chosen, name-based fallback when no path match, path match wins over name match, remote group rejected on both paths (`connectionId` / remote `executionHostId`), `parentPath: null` skipped, deterministic oldest-first tie-break |
| `open-os-requested-file` | serialization — two concurrent opens in the same new folder create exactly one workspace; a rejected call does not wedge the chain |
| `use-os-requested-file-opening` | a failed open is reported rather than escaping as an unhandled rejection, on both the startup-pull and push paths |
| `register-core-handlers` | the OS file-open handlers are actually registered |
| `electron-builder-config` | the markdown association exists with `rank: Alternate` |

Manual verification on macOS, in two stages.

**Dev build** — opened `~/Downloads/orca-open-test/lf-note.md` with no project registered: tab opened, folder workspace created, editing showed the dirty indicator, `Cmd+S` saved, closing with unsaved changes warned. A second file from the same folder reused the workspace instead of creating another. A CRLF file round-tripped byte-for-byte (`0d 0a` preserved, UTF-8 intact).

**Packaged build** — after `lsregister`, `Orca.app` appeared in the LaunchServices list for `.md` (14 → 16 entries) while the default handler stayed unchanged, confirming `rank: Alternate` behaves. Opening a file against a completely fresh user-data profile created the workspace from scratch. A path delivered while first-run onboarding was still in progress was buffered and opened once the renderer finished hydrating.

Windows and Linux are covered by the automated tests only — see Notes.

Manual verification also caught a defect the automated suite missed. Opening a file from the same folder in a later session created a *second*, identically-named project group: `createProjectGroup` produces a group with `parentPath: null`, and the reuse lookup only matched groups whose `parentPath` contained the file — so a group this feature created could never be rediscovered, and groups accumulated. Fixed by adding a name-based fallback that carries the same host-provenance restriction as the path-based one, with the oldest group winning when several match. The fix is covered by tests verified through mutation testing.

## AI Review Report

Each task was implemented and then reviewed by a separate agent that read the diff against the task's requirements and ran the gates itself rather than trusting the implementer's report. Reviewers reproduced their own claims adversarially — reverting a fix and confirming the relevant test actually fails. Seven of ten tasks came back with changes required. The substantive ones:

- **Multi-renderer delivery (Critical).** The delivery slot had no ownership check. Orca's dashboard popout shares the same preload bridge, so it could take over delivery and then, when closed, clear the slot belonging to the still-live main window — after which every OS-opened file would be silently buffered forever. Reproduced with a two-sender probe. Fixed with an ownership check plus regression tests.
- **Remote execution host (Critical).** Local execution was enforced only on the editor tab. `createProjectGroup` and `createFolderWorkspace` still routed through the active runtime, so a user focused on a remote SSH environment would have had the group and workspace created on the wrong host for a guaranteed-local path — and a remote group with a coincidentally matching `parentPath` could be reused. Fixed by forcing the local host on both creation calls and restricting group reuse to locally-owned groups (reusing `getProjectGroupExecutionHostIdForRows` rather than a new comparison). This required adding an optional route-options parameter to `createProjectGroup`, mirroring the shape `createFolderWorkspace` already had; existing call sites are unaffected and their tests still pass.
- **Startup error isolation (Important).** The startup pull sat inside `App.tsx`'s hydration `try`, whose `catch` treats any throw as "session restore failed" — disabling session persistence and showing a permanent toast. One transient failure opening a file would have produced that false alarm. Now isolated per path, with the same reporting shared by the push subscription so the two entry points cannot drift.
- **Type-drift and coverage gaps (Important).** The preload block was not bound to its declared type, so `api-types.ts` and `index.ts` could diverge with a green typecheck; `satisfies` now binds them, verified by injecting drift and watching the check fail. Separately, `registerCoreHandlers`'s new parameter had been made optional on a mistaken reading of TS1016, which left the registration path with zero test coverage — it is now required, with a test that fails if the call is dropped.

Cross-platform: platform-dependent behavior sits behind injected `platform` checks that the tests drive for darwin, win32 and linux; the single `fileAssociations` entry feeds all three packagers (verified against `app-builder-lib`'s macOS, NSIS and Linux code paths). No shortcuts or shortcut labels are involved. SSH/remote: covered above — OS-handed paths are always local and are now forced onto the local host at every step. Agent, integration and git-provider behavior: untouched. Performance: one extra IPC round-trip during renderer startup, and a single `stat` per pending path. UI quality: no new components; failures surface through the existing toast pattern, and the three new strings went through the localization codemod with catalog parity verified.

## Security Audit

- **Input origin.** Paths arrive from LaunchServices, the Windows shell, or `argv`. They are treated as untrusted: absolute-path shape check, extension allow-list (`.md` / `.markdown`), and an existence + `isFile()` check before anything is handed to the renderer. Directories and missing paths are dropped.
- **Command execution.** None. Nothing in this change spawns a shell or a process. An earlier design that would have invoked `open -b <bundleId>` was dropped, so there is no execution surface at all.
- **IPC.** Two channels. `osFileOpen:takePending` is renderer→main with no arguments; `osFileOpen:opened` is a one-way main→renderer notification. The renderer cannot inject an arbitrary path into main through either, so there is no privilege escalation path.
- **File content.** Rendered through Orca's existing markdown pipeline. No new HTML rendering or sanitization path was introduced.
- **Persistence.** Opening a file can create a project group and a folder workspace in user settings. Worst case is a duplicate entry; no data loss. Creation is serialized so concurrent opens in one folder cannot produce duplicates.
- **Remote hosts.** Group and workspace creation are pinned to the local execution host, and remote-owned groups are excluded from reuse, so a local path can never cause writes against an SSH target.
- **Side effects.** Opening a file opens a file. No agent is started, no script is run.

## Notes

- **Windows and Linux are not manually verified.** The argv and `second-instance` paths are covered by unit tests that drive all three platforms, and the single `fileAssociations` entry is what electron-builder feeds to the NSIS and Linux packagers, but I only had macOS hardware. Worth a check by someone with those platforms before merge.
- **Folder association is deliberately out of scope.** Warp declares `public.folder`; this PR does not. macOS would be cheap — I confirmed from a real packaged build that `fileAssociations`-generated `CFBundleDocumentTypes` merges with `mac.extendInfo` rather than replacing it — but Windows has no folder equivalent short of `Directory\shell` registry work in the installer, and that felt like a separate topic. Happy to follow up.
- **Listener ordering.** The OS-file-open `second-instance` listener is registered before the single-instance lock's. If the file-path listener ever threw, `requestDesktopActivation()` would not run — the class of symptom #11055 guards against. The listener only runs a regex, `extname`, and a guarded `send`, so I left it rather than adding defensive code, but the ordering is worth knowing.
- **The branch contains a revert of one of its own commits.** `second-instance` argv was first plumbed through the single-instance lock callback; that turned out to collide with the source-text guard in `serve-desktop-activation-wiring.test.ts` left by #11055. Rather than weaken that guard, the OS-file-open module now subscribes to `second-instance` itself, and the lock callback and `requestDesktopActivation` are untouched. The widening was reverted so no unused signature ships.
- **`docs/preload-typecheck-hole.md`** is referenced from `CONTRIBUTING.md` but does not exist in the repo. Not touched here, just noting it.

X: @lee_jinkyu71869
