### PR TITLE
fix(remote-runtime): fit retries within recovery budget

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS,
+  REMOTE_RUNTIME_RECOVERY_ATTEMPT_TIMEOUT_MS,
   RemoteRuntimePtyRecoveryState,
   retryAllRemoteRuntimePtyRecoveriesNow
 } from './remote-runtime-pty-recovery-state'
@@ -69,6 +70,26 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     expect(state.isActive).toBe(false)
     expect(state.isCurrent(epoch)).toBe(false)
     expect(onChange).toHaveBeenCalled()
+  })
+
+  it('completes eight timed-out attempts inside the bounded recovery window', async () => {
+    vi.useFakeTimers()
+    const state = new RemoteRuntimePtyRecoveryState()
+    let completedAttempts = 0
+    const runAttempt = (epoch: number): void => {
+      setTimeout(() => {
+        completedAttempts += 1
+        state.schedule(epoch, runAttempt)
+      }, REMOTE_RUNTIME_RECOVERY_ATTEMPT_TIMEOUT_MS)
+    }
+    const epoch = state.begin()
+
+    runAttempt(epoch)
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+
+    expect(completedAttempts).toBe(8)
+    expect(state.attemptCount).toBe(8)
+    expect(state.currentPhase).toBe('disconnected')
   })
 
   it('advances a pending backoff immediately via retryNow and the active registry', async () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -1,4 +1,6 @@
-const RECOVERY_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000, 15_000, 30_000] as const
+export const REMOTE_RUNTIME_RECOVERY_ATTEMPT_TIMEOUT_MS = 5_000
+// Why: 4 秒退避上限与 5 秒探测共同保证一分钟内能完成至少 8 次恢复尝试。
+const RECOVERY_DELAYS_MS = [250, 500, 1000, 2000, 4000] as const
 export const REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS = 60_000
 
 export type RemoteRuntimePtyRecoveryPhase =

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -825,6 +825,92 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(latestSubscribePayload()).toMatchObject({ terminal: 'legacy-terminal-1' })
   })
 
+  it('uses the remaining recovery deadline to verify a legacy pane owner', async () => {
+    vi.useFakeTimers()
+    try {
+      let resolvePaneCalls = 0
+      runtimeCall.mockImplementation(
+        (request: { method: string; params?: unknown; timeoutMs?: number }) => {
+          if (request.method === 'terminal.resolvePane') {
+            resolvePaneCalls += 1
+            const params = request.params as { paneKey: string; worktreeId: string }
+            const separator = params.paneKey.indexOf(':')
+            const response = {
+              ok: true,
+              result: {
+                terminal: {
+                  handle: 'legacy-terminal-1',
+                  tabId: params.paneKey.slice(0, separator),
+                  leafId: params.paneKey.slice(separator + 1),
+                  ptyId: 'ssh:hub-private@@pty-2',
+                  ...(resolvePaneCalls === 1 ? { worktreeId: params.worktreeId } : {})
+                }
+              }
+            }
+            return resolvePaneCalls === 1
+              ? Promise.resolve(response)
+              : new Promise((resolve) => setTimeout(() => resolve(response), 2_000))
+          }
+          if (request.method === 'session.tabs.list') {
+            return Promise.resolve({
+              ok: true,
+              result: {
+                worktree: 'id:wt-1',
+                publicationEpoch: 'legacy-epoch',
+                snapshotVersion: 1,
+                activeGroupId: 'group-1',
+                activeTabId: 'tab-1',
+                activeTabType: 'terminal',
+                tabs: [
+                  {
+                    type: 'terminal',
+                    id: 'tab-1::pane:1',
+                    parentTabId: 'tab-1',
+                    leafId: 'pane:1',
+                    title: 'Terminal',
+                    isActive: true,
+                    status: 'ready',
+                    terminal: 'legacy-terminal-1'
+                  }
+                ]
+              }
+            })
+          }
+          throw new Error(`Unexpected method ${request.method}`)
+        }
+      )
+      const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+      const transport = createRemoteRuntimePtyTransport('legacy-env', {
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: 'pane:1'
+      })
+
+      transport.attach({
+        existingPtyId: 'remote:legacy-env@@legacy-terminal-1',
+        callbacks: {}
+      })
+      await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+      const initialCallbacks = subscriptionCallbacks
+
+      initialCallbacks?.onClose?.()
+      await vi.advanceTimersByTimeAsync(2_000)
+      await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+
+      const recoveryResolve = runtimeCall.mock.calls
+        .map(([request]) => request as { method: string; timeoutMs?: number })
+        .findLast((request) => request.method === 'terminal.resolvePane')
+      const legacyInventory = runtimeCall.mock.calls
+        .map(([request]) => request as { method: string; timeoutMs?: number })
+        .find((request) => request.method === 'session.tabs.list')
+      expect(recoveryResolve?.timeoutMs).toBe(5_000)
+      expect(legacyInventory?.timeoutMs).toBe(3_000)
+      transport.destroy?.()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('rejects a legacy pane handle absent from the requested worktree session', async () => {
     runtimeCall.mockImplementation(async (request: { method: string }) => {
       if (request.method === 'terminal.resolvePane') {
@@ -1406,8 +1492,8 @@ describe('createRemoteRuntimePtyTransport', () => {
         .map(([args]) => args)
         .filter((args) => args.method === 'session.tabs.list')
         .map((args) => args.timeoutMs as number)
-      expect(listTimeouts[0]).toBe(15_000)
-      expect(listTimeouts.every((timeoutMs) => timeoutMs > 0 && timeoutMs <= 15_000)).toBe(true)
+      expect(listTimeouts[0]).toBe(5_000)
+      expect(listTimeouts.every((timeoutMs) => timeoutMs > 0 && timeoutMs <= 5_000)).toBe(true)
       expect(listTimeouts.at(-1)).toBeLessThanOrEqual(1_000)
       expect(onError).not.toHaveBeenCalled()
       expect(onPtyExit).not.toHaveBeenCalled()
@@ -3114,11 +3200,13 @@ describe('createRemoteRuntimePtyTransport', () => {
 
   it('keeps retrying when the first post-partition terminal reattach fails', async () => {
     let subscribeAttempt = 0
+    const connectionTimeouts: number[] = []
     const recoveryPhases: string[] = []
     const transportCallbacks: NonNullable<typeof subscriptionCallbacks>[] = []
     runtimeSubscribe.mockImplementation(
-      async (_args: unknown, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
+      async (args: { timeoutMs: number }, callbacks: NonNullable<typeof subscriptionCallbacks>) => {
         subscribeAttempt += 1
+        connectionTimeouts.push(args.timeoutMs)
         transportCallbacks.push(callbacks)
         subscriptionCallbacks = callbacks
         if (subscribeAttempt === 2) {
@@ -3151,6 +3239,13 @@ describe('createRemoteRuntimePtyTransport', () => {
     await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(3))
     expect(onError).not.toHaveBeenCalled()
     expect(recoveryPhases).toContain('backoff')
+    expect(connectionTimeouts).toEqual([15_000, 5_000, 5_000])
+    expect(
+      runtimeCall.mock.calls
+        .map(([args]) => args as { method: string; timeoutMs?: number })
+        .filter((args) => args.method === 'terminal.resolvePane')
+        .map((args) => args.timeoutMs)
+    ).toEqual([5_000, 5_000])
     transport.destroy?.()
   })
 
@@ -3343,7 +3438,7 @@ describe('createRemoteRuntimePtyTransport', () => {
     rejectReconnect(new Error('reconnect failed'))
 
     await expect(accepted).resolves.toBe(false)
-    expect(onError).toHaveBeenCalledWith('reconnect failed')
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith('reconnect failed'))
   })
 
   it('releases pending claimed input when the remote terminal ends', async () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -54,6 +54,7 @@ import {
 } from './remote-runtime-pty-batching'
 import {
   REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS,
+  REMOTE_RUNTIME_RECOVERY_ATTEMPT_TIMEOUT_MS,
   RemoteRuntimePtyRecoveryState
 } from './remote-runtime-pty-recovery-state'
 import { createBrowserUuid } from '@/lib/browser-uuid'
@@ -105,6 +106,36 @@ function isRemoteTerminalGoneMessage(message: string): boolean {
     message.includes('no_connected_pty') ||
     message.toLocaleLowerCase('en-US').includes('explicitly killed')
   )
+}
+
+function createRemoteRuntimeAttemptTimeoutError(): Error {
+  return Object.assign(new Error('Timed out waiting for the remote Orca runtime.'), {
+    code: 'runtime_timeout'
+  })
+}
+
+function waitForRemoteRuntimeResult<T>(request: Promise<T>, timeoutMs: number): Promise<T> {
+  if (timeoutMs <= 0) {
+    return Promise.reject(createRemoteRuntimeAttemptTimeoutError())
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(createRemoteRuntimeAttemptTimeoutError())
+    }, timeoutMs)
+    if (typeof timer.unref === 'function') {
+      timer.unref()
+    }
+    void request.then(
+      (result) => {
+        clearTimeout(timer)
+        resolve(result)
+      },
+      (error: unknown) => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
 }
 
 /** PTY transport for a renderer pane backed by a terminal on a remote Orca runtime, over runtime RPC plus the multiplexed stream. */
@@ -419,7 +450,8 @@ export function createRemoteRuntimePtyTransport(
   async function waitForResubscribeHostSessionHandle(
     hostTabId: string,
     previousHandle: string,
-    requireReplacement: boolean
+    requireReplacement: boolean,
+    timeoutMs = HOST_SESSION_ATTACH_TIMEOUT_MS
   ): Promise<string | null | undefined> {
     if (!worktreeId) {
       return null
@@ -439,7 +471,7 @@ export function createRemoteRuntimePtyTransport(
       return undefined
     }
     while (!destroyed && connected && handle === previousHandle) {
-      const requestRemainingMs = HOST_SESSION_ATTACH_TIMEOUT_MS - (Date.now() - startedAt)
+      const requestRemainingMs = timeoutMs - (Date.now() - startedAt)
       if (requestRemainingMs <= 0) {
         return finishWithUnknownLiveness()
       }
@@ -468,7 +500,7 @@ export function createRemoteRuntimePtyTransport(
         // Why: the inventory can race the reconnect that invalidated the handle; unknown liveness must not retire the pane.
         lastListError = error
       }
-      const remainingMs = HOST_SESSION_ATTACH_TIMEOUT_MS - (Date.now() - startedAt)
+      const remainingMs = timeoutMs - (Date.now() - startedAt)
       if (remainingMs <= 0) {
         return finishWithUnknownLiveness()
       }
@@ -750,7 +782,9 @@ export function createRemoteRuntimePtyTransport(
     return null
   }
 
-  async function resolvePersistedHostPane(): Promise<RuntimeTerminalResolvePane | null> {
+  async function resolvePersistedHostPane(
+    timeoutMs?: number
+  ): Promise<RuntimeTerminalResolvePane | null> {
     if (!tabId || !leafId || !worktreeId) {
       return null
     }
@@ -758,11 +792,13 @@ export function createRemoteRuntimePtyTransport(
     if (resolvePaneUnavailable) {
       return null
     }
+    const deadlineAt = timeoutMs === undefined ? null : Date.now() + timeoutMs
     let terminal: RuntimeTerminalResolvePane
     try {
       const resolved = await callRuntime<{ terminal: RuntimeTerminalResolvePane }>(
         'terminal.resolvePane',
-        { paneKey, worktreeId }
+        { paneKey, worktreeId },
+        timeoutMs
       )
       terminal = resolved.terminal
     } catch (error) {
@@ -785,14 +821,26 @@ export function createRemoteRuntimePtyTransport(
     }
     if (terminal.worktreeId === undefined) {
       const worktree = toRuntimeWorktreeSelector(worktreeId)
-      const listed = await listRemoteRuntimeSessionTabsDeduped({
+      const inventoryTimeoutMs =
+        deadlineAt === null ? null : Math.max(0, Math.ceil(deadlineAt - Date.now()))
+      if (inventoryTimeoutMs === 0) {
+        throw createRemoteRuntimeAttemptTimeoutError()
+      }
+      const inventoryRequest = listRemoteRuntimeSessionTabsDeduped({
         environmentId: currentRuntimeEnvironmentId,
         worktreeId,
         load: () =>
-          callRuntime<RuntimeMobileSessionTabsResult>('session.tabs.list', {
-            worktree
-          })
+          callRuntime<RuntimeMobileSessionTabsResult>(
+            'session.tabs.list',
+            { worktree },
+            inventoryTimeoutMs ?? undefined
+          )
       })
+      // Why: 去重可能复用其他窗格的慢请求，恢复验证仍必须受当前尝试的剩余预算约束。
+      const listed =
+        inventoryTimeoutMs === null
+          ? await inventoryRequest
+          : await waitForRemoteRuntimeResult(inventoryRequest, inventoryTimeoutMs)
       const exactLegacyOwner = getHostSessionTerminalSurfaces(listed, tabId, {
         matchRequestedLeaf: true
       }).some((surface) => surface.status === 'ready' && surface.terminal === terminal.handle)
@@ -1188,7 +1236,8 @@ export function createRemoteRuntimePtyTransport(
       const nextHandle = await waitForResubscribeHostSessionHandle(
         hostTabId,
         previousHandle,
-        requireReplacement
+        requireReplacement,
+        REMOTE_RUNTIME_RECOVERY_ATTEMPT_TIMEOUT_MS
       )
       if (
         destroyed ||
@@ -1210,7 +1259,7 @@ export function createRemoteRuntimePtyTransport(
         rebindRemoteTerminalHandle(nextHandle)
       }
     } else if (tabId && leafId && worktreeId) {
-      const resolved = await resolvePersistedHostPane()
+      const resolved = await resolvePersistedHostPane(REMOTE_RUNTIME_RECOVERY_ATTEMPT_TIMEOUT_MS)
       if (destroyed || !connected || handle !== previousHandle) {
         return
       }
@@ -1329,6 +1378,9 @@ export function createRemoteRuntimePtyTransport(
       terminal: subscribedHandle,
       client: { id: clientId, type: 'desktop' },
       viewport: subscribedViewport ?? undefined,
+      connectionTimeoutMs: recovery.isActive
+        ? REMOTE_RUNTIME_RECOVERY_ATTEMPT_TIMEOUT_MS
+        : undefined,
       callbacks: {
         onData: (data, meta) => {
           if (isCurrentSubscription()) {

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-connection-timeout.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer-connection-timeout.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getRemoteRuntimeTerminalMultiplexer,
+  resetRemoteRuntimeTerminalMultiplexersForTests
+} from './remote-runtime-terminal-multiplexer'
+
+type MultiplexCallbacks = {
+  onResponse: (response: unknown) => void
+  onBinary?: (bytes: Uint8Array<ArrayBufferLike>) => void
+  onError?: (error: { code: string; message: string }) => void
+  onClose?: () => void
+}
+
+const streamCallbacks = () => ({
+  onData: vi.fn(),
+  onSnapshot: vi.fn()
+})
+
+function timeoutError(): Error {
+  return Object.assign(
+    new Error('Timed out waiting for the remote Orca runtime subscription to start.'),
+    { code: 'runtime_timeout' }
+  )
+}
+
+describe('remote runtime terminal multiplexer connection deadlines', () => {
+  const runtimeSubscribe = vi.fn()
+  const sendBinary = vi.fn()
+  const unsubscribe = vi.fn()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resetRemoteRuntimeTerminalMultiplexersForTests()
+    vi.stubGlobal('window', {
+      api: {
+        runtimeEnvironments: {
+          subscribe: runtimeSubscribe
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    resetRemoteRuntimeTerminalMultiplexersForTests()
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('times out a recovery subscriber without cancelling a default handshake', async () => {
+    let callbacks: MultiplexCallbacks | null = null
+    let resolveSubscribe: (handle: {
+      unsubscribe: () => void
+      sendBinary: (bytes: Uint8Array<ArrayBufferLike>) => void
+    }) => void = () => {}
+    runtimeSubscribe.mockImplementation((_args: unknown, nextCallbacks: MultiplexCallbacks) => {
+      callbacks = nextCallbacks
+      return new Promise((resolve) => {
+        resolveSubscribe = resolve
+      })
+    })
+    const multiplexer = getRemoteRuntimeTerminalMultiplexer('env-default-first')
+    const defaultSubscription = multiplexer.subscribeTerminal({
+      terminal: 'terminal-default',
+      client: { id: 'desktop-default', type: 'desktop' },
+      callbacks: streamCallbacks()
+    })
+    const recoverySubscription = multiplexer.subscribeTerminal({
+      terminal: 'terminal-recovery',
+      client: { id: 'desktop-recovery', type: 'desktop' },
+      connectionTimeoutMs: 5_000,
+      callbacks: streamCallbacks()
+    })
+    const recoveryTimeout = expect(recoverySubscription).rejects.toMatchObject({
+      code: 'runtime_timeout'
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await recoveryTimeout
+    expect(runtimeSubscribe).toHaveBeenCalledOnce()
+    expect(runtimeSubscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 15_000 }),
+      expect.any(Object)
+    )
+
+    resolveSubscribe({ unsubscribe, sendBinary })
+    ;(callbacks as MultiplexCallbacks | null)?.onResponse({
+      ok: true,
+      result: { type: 'ready' }
+    })
+    const defaultStream = await defaultSubscription
+
+    defaultStream.close()
+  })
+
+  it('lets a default subscriber continue after a recovery handshake times out', async () => {
+    const connectionTimeouts: number[] = []
+    runtimeSubscribe.mockImplementation(
+      (args: { timeoutMs: number }, callbacks: MultiplexCallbacks) => {
+        connectionTimeouts.push(args.timeoutMs)
+        if (connectionTimeouts.length === 1) {
+          return new Promise((_, reject) => {
+            setTimeout(() => reject(timeoutError()), args.timeoutMs)
+          })
+        }
+        queueMicrotask(() => callbacks.onResponse({ ok: true, result: { type: 'ready' } }))
+        return Promise.resolve({ unsubscribe, sendBinary })
+      }
+    )
+    const multiplexer = getRemoteRuntimeTerminalMultiplexer('env-recovery-first')
+    const recoverySubscription = multiplexer.subscribeTerminal({
+      terminal: 'terminal-recovery',
+      client: { id: 'desktop-recovery', type: 'desktop' },
+      connectionTimeoutMs: 5_000,
+      callbacks: streamCallbacks()
+    })
+    const defaultSubscription = multiplexer.subscribeTerminal({
+      terminal: 'terminal-default',
+      client: { id: 'desktop-default', type: 'desktop' },
+      callbacks: streamCallbacks()
+    })
+    const recoveryTimeout = expect(recoverySubscription).rejects.toMatchObject({
+      code: 'runtime_timeout'
+    })
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await recoveryTimeout
+    const defaultStream = await defaultSubscription
+
+    expect(connectionTimeouts).toEqual([5_000, 10_000])
+    defaultStream.close()
+  })
+})

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -1,6 +1,9 @@
 /* eslint-disable max-lines -- Why: the remote terminal multiplexer owns one bridged subscription, stream lifecycle, binary frame parsing, and remote lock events as a single transport contract. */
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
-import { isRecoverableRemoteRuntimeConnectionError } from '../../../shared/remote-runtime-client-error-classification'
+import {
+  isRecoverableRemoteRuntimeConnectionError,
+  toRemoteRuntimeClientErrorLike
+} from '../../../shared/remote-runtime-client-error-classification'
 import {
   TerminalStreamOpcode,
   decodeTerminalStreamFrame,
@@ -133,6 +136,9 @@ type RemoteRuntimeSnapshotRequest = {
 }
 
 const CONTROL_STREAM_ID = 0
+const REMOTE_TERMINAL_CONNECTION_TIMEOUT_MS = 15_000
+const REMOTE_TERMINAL_CONNECTION_TIMEOUT_MESSAGE =
+  'Timed out waiting for the remote Orca runtime subscription to start.'
 const MAX_REMOTE_TERMINAL_SNAPSHOT_BYTES = 2 * 1024 * 1024
 const REMOTE_TERMINAL_SNAPSHOT_REQUEST_TIMEOUT_MS = 10_000
 const REMOTE_TERMINAL_RESYNC_TIMEOUT_MS = 10_000
@@ -144,6 +150,48 @@ const REMOTE_TERMINAL_RESYNC_RETRY_MAX_MS = 5_000
 // skipped but live output continues, so it must not surface a fatal red banner.
 export const REMOTE_TERMINAL_SNAPSHOT_TOO_LARGE =
   'Remote terminal snapshot exceeded the 2 MiB replay limit; live output will continue.'
+
+function createRemoteTerminalConnectionTimeoutError(): Error {
+  return Object.assign(new Error(REMOTE_TERMINAL_CONNECTION_TIMEOUT_MESSAGE), {
+    code: 'runtime_timeout'
+  })
+}
+
+function isRemoteTerminalConnectionTimeout(error: unknown): boolean {
+  const clientError = toRemoteRuntimeClientErrorLike(error)
+  return (
+    clientError.code === 'runtime_timeout' ||
+    clientError.code === 'timeout' ||
+    clientError.message.toLowerCase().includes('timed out waiting for the remote orca runtime')
+  )
+}
+
+function waitForRemoteTerminalConnection(
+  connection: Promise<void>,
+  timeoutMs: number
+): Promise<void> {
+  if (timeoutMs <= 0) {
+    return Promise.reject(createRemoteTerminalConnectionTimeoutError())
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(createRemoteTerminalConnectionTimeoutError())
+    }, timeoutMs)
+    if (typeof timer.unref === 'function') {
+      timer.unref()
+    }
+    void connection.then(
+      () => {
+        clearTimeout(timer)
+        resolve()
+      },
+      (error: unknown) => {
+        clearTimeout(timer)
+        reject(error)
+      }
+    )
+  })
+}
 
 type E2eRemoteTerminalMultiplexAckGateSnapshot = {
   heldTerminalCount: number
@@ -216,6 +264,7 @@ class RemoteRuntimeTerminalMultiplexer {
   private readonly streams = new Map<number, RemoteRuntimeMultiplexedTerminalState>()
   private subscription: RuntimeEnvironmentSubscriptionHandle | null = null
   private connectPromise: Promise<void> | null = null
+  private connectAttemptDeadlineAt: number | null = null
   private readyResolver: (() => void) | null = null
   private readyRejecter: ((error: Error) => void) | null = null
   private ready = false
@@ -243,6 +292,7 @@ class RemoteRuntimeTerminalMultiplexer {
     terminal: string
     client: { id: string; type: 'desktop' | 'mobile' }
     viewport?: { cols: number; rows: number }
+    connectionTimeoutMs?: number
     callbacks: RemoteRuntimeMultiplexedTerminalCallbacks
   }): Promise<RemoteRuntimeMultiplexedTerminal> {
     const streamId = this.allocateStreamId()
@@ -311,7 +361,7 @@ class RemoteRuntimeTerminalMultiplexer {
     }
 
     try {
-      await this.ensureConnected()
+      await this.ensureConnected(args.connectionTimeoutMs ?? REMOTE_TERMINAL_CONNECTION_TIMEOUT_MS)
       if (this.streams.get(streamId) !== state) {
         return stream
       }
@@ -355,13 +405,37 @@ class RemoteRuntimeTerminalMultiplexer {
     throw new Error('No remote terminal stream ids available.')
   }
 
-  private ensureConnected(): Promise<void> {
-    if (this.ready && this.subscription) {
-      return Promise.resolve()
+  private async ensureConnected(timeoutMs: number): Promise<void> {
+    const callerDeadlineAt = Date.now() + timeoutMs
+    while (!this.ready || !this.subscription) {
+      const callerRemainingMs = callerDeadlineAt - Date.now()
+      if (callerRemainingMs <= 0) {
+        throw createRemoteTerminalConnectionTimeoutError()
+      }
+      const connectPromise = this.connectPromise ?? this.startConnection(callerRemainingMs)
+      const attemptRemainingMs = Math.max(
+        0,
+        (this.connectAttemptDeadlineAt ?? callerDeadlineAt) - Date.now()
+      )
+      try {
+        // Why: 共享连接可由 15 秒普通订阅或 5 秒恢复订阅创建，但每个调用者都必须遵守自己的截止时间。
+        await waitForRemoteTerminalConnection(connectPromise, callerRemainingMs)
+        return
+      } catch (error) {
+        const remainingAfterFailureMs = callerDeadlineAt - Date.now()
+        if (
+          !isRemoteTerminalConnectionTimeout(error) ||
+          remainingAfterFailureMs <= 0 ||
+          attemptRemainingMs >= callerRemainingMs
+        ) {
+          throw error
+        }
+        // Why: 较短调用者创建的共享尝试超时后，较长调用者仍应使用自己的剩余预算继续连接。
+      }
     }
-    if (this.connectPromise) {
-      return this.connectPromise
-    }
+  }
+
+  private startConnection(timeoutMs: number): Promise<void> {
     const connectPromise = new Promise<void>((resolve, reject) => {
       this.readyResolver = resolve
       this.readyRejecter = reject
@@ -371,7 +445,7 @@ class RemoteRuntimeTerminalMultiplexer {
             selector: this.environmentId,
             method: 'terminal.multiplex',
             params: {},
-            timeoutMs: 15_000,
+            timeoutMs,
             expectedEnvironmentPairingRevision: this.environmentRevision
           },
           {
@@ -401,6 +475,7 @@ class RemoteRuntimeTerminalMultiplexer {
         .catch((error) => {
           if (this.connectPromise === connectPromise) {
             this.connectPromise = null
+            this.connectAttemptDeadlineAt = null
             this.readyResolver = null
             this.readyRejecter = null
           }
@@ -408,7 +483,8 @@ class RemoteRuntimeTerminalMultiplexer {
         })
     })
     this.connectPromise = connectPromise
-    return this.connectPromise
+    this.connectAttemptDeadlineAt = Date.now() + timeoutMs
+    return connectPromise
   }
 
   private handleResponse(response: RuntimeRpcResponse<unknown>): void {
@@ -973,6 +1049,7 @@ class RemoteRuntimeTerminalMultiplexer {
     const closingSubscription = this.subscription
     this.ready = false
     this.connectPromise = null
+    this.connectAttemptDeadlineAt = null
     this.readyRejecter?.(new Error(message ?? 'Remote runtime connection closed.'))
     this.readyResolver = null
     this.readyRejecter = null
@@ -1001,6 +1078,7 @@ class RemoteRuntimeTerminalMultiplexer {
     this.subscription?.unsubscribe()
     this.subscription = null
     this.connectPromise = null
+    this.connectAttemptDeadlineAt = null
     this.ready = false
     this.releaseIfCurrent(this.environmentId, this)
   }


### PR DESCRIPTION
## Summary

- Keep remote PTY automatic recovery within its one-minute wall-clock budget by capping retry backoff at four seconds.
- Apply a five-second timeout to reconnect inventory, pane resolution, and terminal multiplexer probes while preserving the 15-second initial connection timeout.
- Add regression coverage for eight completed timed-out attempts and recovery-specific timeout propagation.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` (focused recovery tests run below)
- [ ] `pnpm build` (Electron Vite build run below; full native build not run)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional focused verification:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts` (98 tests passed)
- `pnpm run build:electron-vite`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm run check:reliability-gates`

## AI Review Report

Reviewed the retry-budget arithmetic, timer cancellation and stale-epoch handling, every terminal reconnect path, and default-versus-recovery timeout propagation. The main regression risk was shortening ordinary first connections; the implementation instead threads an optional recovery-only timeout and tests that initial connections remain at 15 seconds while recovery uses five seconds. Cross-platform review confirmed that no shortcuts, labels, paths, shell behavior, or platform-specific Electron APIs changed; the timer and IPC behavior is equivalent on macOS, Linux, and Windows, including SSH-hosted runtimes.

## Security Audit

Reviewed the existing IPC boundary and timeout propagation along with input handling, command execution, path handling, authentication, secrets, and dependencies. The change only passes bounded internal numeric timeout values through existing typed IPC calls; it adds no user-controlled input, commands, file access, credentials, or dependencies. No follow-up is required.

## Notes

Fixes #11305.
