### PR TITLE
fix(automations): tolerate scheduler tick latency before applying missed-run grace

### DIFF
--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -57,6 +57,78 @@ describe('AutomationService', () => {
     rmSync(testState.dir, { recursive: true, force: true })
   })
 
+  it('dispatches a zero-grace automation when the tick lands within one tick interval', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:59:00'))
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const automation = store.createAutomation({
+      name: 'Zero-grace check',
+      prompt: 'Check the repo',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-12T00:00:00').getTime(),
+      missedRunGraceMinutes: 0
+    })
+
+    vi.setSystemTime(new Date('2026-05-13T09:00:45'))
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({
+      isDestroyed: () => false,
+      send
+    } as never)
+
+    service.start()
+    service.setRendererReady()
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith('automations:dispatchRequested', expect.any(Object))
+    )
+    service.stop()
+
+    expect(store.listAutomationRuns(automation.id)[0]?.status).toBe('dispatching')
+  })
+
+  it('skips a zero-grace automation when the delay exceeds one tick interval', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:59:00'))
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const automation = store.createAutomation({
+      name: 'Zero-grace skip',
+      prompt: 'Check the repo',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+      dtstart: new Date('2026-05-12T00:00:00').getTime(),
+      missedRunGraceMinutes: 0
+    })
+
+    vi.setSystemTime(new Date('2026-05-13T09:01:30'))
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({
+      isDestroyed: () => false,
+      send
+    } as never)
+
+    service.start()
+    service.setRendererReady()
+    await vi.waitFor(() => {
+      const runs = store.listAutomationRuns(automation.id)
+      return runs.length > 0 && runs[0]?.status === 'skipped_missed'
+    })
+    service.stop()
+
+    expect(store.listAutomationRuns(automation.id)[0]?.status).toBe('skipped_missed')
+    expect(send).not.toHaveBeenCalled()
+  })
+
   it('dispatches an enabled automation when its next run is due', async () => {
     vi.setSystemTime(new Date('2026-05-13T08:59:00'))
     const store = await createStore()

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -250,7 +250,10 @@ export class AutomationService {
       return
     }
     const graceMs = automation.missedRunGraceMinutes * 60 * 1000
-    if (now - scheduledFor > graceMs) {
+    // Why: grace covers app downtime, not the scheduler's own tick latency.
+    // Without subtracting tickMs, "No grace" (0 min) can never run (#11299).
+    const lateness = now - scheduledFor - this.tickMs
+    if (lateness > graceMs) {
       const missed = this.runs.createRun(automation, scheduledFor)
       this.runs.updateRun({
         runId: missed.id,


### PR DESCRIPTION
## Summary

The missed-run grace window is meant to cover app downtime (laptop asleep, Orca closed), but it was being measured against the scheduler's own tick latency as well. With **\No grace\** (\missedRunGraceMinutes: 0\), the condition \
ow - scheduledFor > 0\ was always true because the evaluation tick fires up to \	ickMs\ (default 60 s) after the scheduled instant, so the automation could never dispatch — every occurrence was recorded as \skipped_missed\.

## Fix

Subtract one \	ickMs\ interval from the measured delay before comparing to the grace window:

\\\diff
- if (now - scheduledFor > graceMs) {
+ const lateness = now - scheduledFor - this.tickMs
+ if (lateness > graceMs) {
\\\

This separates two independent concepts that were conflated:

- **Tick latency** (inherent to the scheduler, up to one \	ickMs\): always tolerated.
- **App downtime** (what grace covers): compared against \graceMs\ after tick latency is excluded.

With grace = 0, the automation runs as long as the tick catches it within one interval (~60 s). If the app was genuinely down past \graceMs + tickMs\, the run is still correctly skipped.

## Testing

- \pnpm exec vitest run --config config/vitest.config.ts src/main/automations/service.test.ts\ — 14 passed (12 existing + 2 new).
- Verified the new positive test **fails without the fix** (reverted \service.ts\, confirmed \send\ was never called) and **passes with the fix**.
- \pnpm run typecheck:node\ — clean.
- Native + type-aware oxlint on changed files — clean.

New tests:

1. **Dispatches a zero-grace automation when the tick lands within one tick interval** — 45 s late, within the 60 s tick: dispatches normally.
2. **Skips a zero-grace automation when the delay exceeds one tick interval** — 90 s late, past one tick: correctly \skipped_missed\.

## Security audit

No new network calls, credential access, or IPC surface. The change only adjusts a timing comparison inside the existing scheduler loop.

Closes #11299