### PR TITLE
fix(sidebar): contain nested agent metadata

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -218,7 +218,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
       {model && (
         <span
           className={cn(
-            'max-w-24 shrink-0 truncate font-mono text-[10px]',
+            'min-w-0 max-w-24 truncate font-mono text-[10px]',
             isFocusedPane ? 'text-foreground/70' : 'text-muted-foreground/70'
           )}
           title={model}
@@ -255,7 +255,7 @@ export const CompactAgentRow = React.memo(function CompactAgentRow({
     <div
       draggable={false}
       className={cn(
-        'compact-agent-row group/compact-agent-row min-w-0 cursor-pointer rounded-sm px-1 text-[11px] leading-none',
+        'compact-agent-row group/compact-agent-row min-w-0 overflow-hidden cursor-pointer rounded-sm px-1 text-[11px] leading-none',
         'text-muted-foreground worktree-agent-row-hover',
         hasChildDisclosure && 'worktree-agent-lineage-parent-row',
         isLineageChild && 'worktree-agent-lineage-child-row',


### PR DESCRIPTION
## Summary

- allow compact agent model metadata to shrink and ellipsize in narrow nested workspace cards
- clip compact agent-row overflow so metadata cannot paint outside the card at extreme lineage depths

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx` — 29 passed
- `pnpm run typecheck:web`
- `pnpm exec oxlint src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx --deny-warnings`
- Electron: verified the real sidebar surface with an eight-level nested workspace chain and a long model label; all model bounds remained inside their cards after the fix

## Electron proof

Before — fixed-width model metadata paints across progressively narrower cards:

![Before](https://github.com/user-attachments/assets/6f342981-1e0d-4d26-8d47-cd4921ee9300)

After — model metadata shrinks and rows remain visually contained:

![After](https://github.com/user-attachments/assets/20b1a290-e839-4b66-9aa6-f7c434be7b24)