### PR TITLE
fix(checks): rank successful checks above skipped and neutral

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -251,7 +251,6 @@ inline src/renderer/src/components/tab-bar/TabBar.tsx
 inline src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts
 inline src/renderer/src/components/tab-group/useTabDragSplit.ts
 inline src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.ts
-inline src/renderer/src/components/task-page-cache-selectors.ts
 inline src/renderer/src/components/terminal-pane/TerminalPane.tsx
 inline src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
 inline src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -61,6 +61,10 @@ import {
 } from '../../../src/session/mobile-file-syntax'
 import { buildGitHubCheckSummary } from '../../../src/tasks/github-check-summary'
 import { buildGitLabCheckSummary } from '../../../src/tasks/gitlab-check-summary'
+import {
+  getGitHubPRSignalTone,
+  getHostedChecksLabel
+} from '../../../src/tasks/mobile-hosted-check-status'
 import { buildTaskWorkspaceCreateParams } from '../../../src/tasks/workspace-create-params'
 import { MOBILE_TASKS_CAPABILITY } from '../../../src/tasks/mobile-tasks-capability'
 import {
@@ -139,7 +143,7 @@ import {
 import type {
   BaseRefSearchResult,
   GitHubOwnerRepo,
-  GitHubPRCheckSummary,
+  ProviderCheckSummary,
   PersistedTrustedOrcaHooks,
   SparsePreset,
   TuiAgent
@@ -183,7 +187,7 @@ type GitHubWorkItem = {
   reviewDecision?: string | null
   reviewRequests?: GitHubAssignableUser[]
   latestReviews?: GitHubPRReviewSummary[]
-  checksSummary?: GitHubPRCheckSummary
+  checksSummary?: ProviderCheckSummary
   mergeable?: GitHubPRMergeableState
   mergeStateStatus?: string | null
 }
@@ -232,7 +236,7 @@ type GitLabWorkItem = {
   baseRefName?: string
   isCrossRepository?: boolean
   projectRef?: { host: string; path: string }
-  checksSummary?: GitHubPRCheckSummary
+  checksSummary?: ProviderCheckSummary
   repoId: string
   repoName: string
 }
@@ -1251,25 +1255,6 @@ function hostedBranchSummary(item: TaskItem): { head: string; base: string } | n
   return null
 }
 
-function getGitHubChecksLabel(item: GitHubWorkItem): string {
-  const summary = item.checksSummary
-  if (!summary) {
-    return 'Checks'
-  }
-  if (summary.total === 0) {
-    return 'No checks'
-  }
-  if (summary.failed > 0) {
-    return `${summary.failed} failing`
-  }
-  if (summary.pending > 0) {
-    return `${summary.pending} pending`
-  }
-  return summary.state === 'neutral'
-    ? 'Unresolved checks'
-    : `${summary.passed}/${summary.total} passed`
-}
-
 function getGitHubMergeLabel(item: GitHubWorkItem): string {
   if (item.mergeable === undefined && item.mergeStateStatus === undefined) {
     return 'Merge'
@@ -1371,46 +1356,6 @@ function getHostedStateConfirmMessage(pending: PendingHostedStateChange): string
 function getHostedStateConfirmLabel(pending: PendingHostedStateChange): string {
   const target = hostedStateChangeTarget(pending)
   return `${hostedStateChangeAction(pending.nextState)} ${target.labelTarget}`
-}
-
-function getGitHubPRSignalTone(
-  item: GitHubWorkItem,
-  signal: 'review' | 'checks' | 'merge'
-): 'neutral' | 'success' | 'warning' | 'danger' {
-  if (signal === 'review') {
-    if (item.reviewDecision === 'APPROVED') {
-      return 'success'
-    }
-    if (item.reviewDecision === 'CHANGES_REQUESTED') {
-      return 'danger'
-    }
-    if (item.reviewRequests && item.reviewRequests.length > 0) {
-      return 'warning'
-    }
-    return 'neutral'
-  }
-  if (signal === 'checks') {
-    if (item.checksSummary?.state === 'success') {
-      return 'success'
-    }
-    if (item.checksSummary?.state === 'failure') {
-      return 'danger'
-    }
-    if (item.checksSummary?.state === 'pending') {
-      return 'warning'
-    }
-    return 'neutral'
-  }
-  if (item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'BLOCKED') {
-    return 'danger'
-  }
-  if (item.mergeStateStatus === 'BEHIND' || item.checksSummary?.state === 'pending') {
-    return 'warning'
-  }
-  if (item.mergeable === 'MERGEABLE' || item.mergeStateStatus === 'CLEAN') {
-    return 'success'
-  }
-  return 'neutral'
 }
 
 function mergeGitHubAssignableUsers(
@@ -9693,6 +9638,7 @@ export default function MobileTasksScreen() {
             const item = entry.item
             const repo = taskRepositoryMeta(item, reposById)
             const isGitHubPr = item.provider === 'github' && item.source.type === 'pr'
+            const isGitLabMr = item.provider === 'gitlab' && item.source.type === 'mr'
             const githubPrDelta = isGitHubPr ? formatGitHubPRDelta(item.source) : null
             const branchSummary = hostedBranchSummary(item)
             return (
@@ -9738,25 +9684,27 @@ export default function MobileTasksScreen() {
                       </Text>
                     </View>
                   ) : null}
-                  {isGitHubPr ? (
+                  {isGitHubPr || isGitLabMr ? (
                     <View style={styles.prSignalRow}>
-                      {githubPrDelta ? (
+                      {isGitHubPr && githubPrDelta ? (
                         <View style={styles.prSignalChip}>
                           <Text style={styles.prSignalText} numberOfLines={1}>
                             {githubPrDelta}
                           </Text>
                         </View>
                       ) : null}
-                      <View
-                        style={[
-                          styles.prSignalChip,
-                          getPrSignalToneStyle(getGitHubPRSignalTone(item.source, 'review'))
-                        ]}
-                      >
-                        <Text style={styles.prSignalText} numberOfLines={1}>
-                          {getGitHubReviewSummary(item.source)}
-                        </Text>
-                      </View>
+                      {isGitHubPr ? (
+                        <View
+                          style={[
+                            styles.prSignalChip,
+                            getPrSignalToneStyle(getGitHubPRSignalTone(item.source, 'review'))
+                          ]}
+                        >
+                          <Text style={styles.prSignalText} numberOfLines={1}>
+                            {getGitHubReviewSummary(item.source)}
+                          </Text>
+                        </View>
+                      ) : null}
                       <View
                         style={[
                           styles.prSignalChip,
@@ -9764,19 +9712,21 @@ export default function MobileTasksScreen() {
                         ]}
                       >
                         <Text style={styles.prSignalText} numberOfLines={1}>
-                          {getGitHubChecksLabel(item.source)}
+                          {getHostedChecksLabel(item.source)}
                         </Text>
                       </View>
-                      <View
-                        style={[
-                          styles.prSignalChip,
-                          getPrSignalToneStyle(getGitHubPRSignalTone(item.source, 'merge'))
-                        ]}
-                      >
-                        <Text style={styles.prSignalText} numberOfLines={1}>
-                          {getGitHubMergeLabel(item.source)}
-                        </Text>
-                      </View>
+                      {isGitHubPr ? (
+                        <View
+                          style={[
+                            styles.prSignalChip,
+                            getPrSignalToneStyle(getGitHubPRSignalTone(item.source, 'merge'))
+                          ]}
+                        >
+                          <Text style={styles.prSignalText} numberOfLines={1}>
+                            {getGitHubMergeLabel(item.source)}
+                          </Text>
+                        </View>
+                      ) : null}
                     </View>
                   ) : null}
                 </View>

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -185,27 +185,23 @@ type GitHubWorkItem = {
   mergeable?: GitHubPRMergeableState
   mergeStateStatus?: string | null
 }
-
 type GitHubAssignableUser = {
   login: string
   name?: string | null
   avatarUrl?: string | null
 }
-
 type GitHubPRReviewSummary = {
   login: string
   state?: string | null
   avatarUrl?: string | null
 }
-
 type GitHubPRCheckSummary = {
-  state: 'success' | 'failure' | 'pending' | 'none'
+  state: 'success' | 'failure' | 'pending' | 'neutral' | 'none'
   total: number
   passed: number
   failed: number
   pending: number
 }
-
 type GitHubPRMergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
 
 type GitHubPRReviewerRow = {
@@ -214,13 +210,11 @@ type GitHubPRReviewerRow = {
   avatarUrl?: string | null
   stateLabel: string
 }
-
 type GitHubRepoSources = {
   issues: GitHubOwnerRepo | null
   prs: GitHubOwnerRepo | null
   upstreamCandidate: GitHubOwnerRepo | null
 }
-
 type TaskRuntimeStatus = {
   capabilities?: string[]
 }
@@ -229,7 +223,6 @@ type TasksSupportState =
   | { kind: 'unknown'; client: RpcClient | null }
   | { kind: 'supported'; client: RpcClient }
   | { kind: 'unsupported'; client: RpcClient }
-
 type GitLabWorkItem = {
   id: string
   type: 'issue' | 'mr'
@@ -1276,7 +1269,9 @@ function getGitHubChecksLabel(item: GitHubWorkItem): string {
   if (summary.pending > 0) {
     return `${summary.pending} pending`
   }
-  return `${summary.passed}/${summary.total} passed`
+  return summary.state === 'neutral'
+    ? 'Unresolved checks'
+    : `${summary.passed}/${summary.total} passed`
 }
 
 function getGitHubMergeLabel(item: GitHubWorkItem): string {

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -60,6 +60,7 @@ import {
   resolveMobileSyntaxLanguage
 } from '../../../src/session/mobile-file-syntax'
 import { buildGitHubCheckSummary } from '../../../src/tasks/github-check-summary'
+import { buildGitLabCheckSummary } from '../../../src/tasks/gitlab-check-summary'
 import { buildTaskWorkspaceCreateParams } from '../../../src/tasks/workspace-create-params'
 import { MOBILE_TASKS_CAPABILITY } from '../../../src/tasks/mobile-tasks-capability'
 import {
@@ -138,6 +139,7 @@ import {
 import type {
   BaseRefSearchResult,
   GitHubOwnerRepo,
+  GitHubPRCheckSummary,
   PersistedTrustedOrcaHooks,
   SparsePreset,
   TuiAgent
@@ -195,13 +197,6 @@ type GitHubPRReviewSummary = {
   state?: string | null
   avatarUrl?: string | null
 }
-type GitHubPRCheckSummary = {
-  state: 'success' | 'failure' | 'pending' | 'neutral' | 'none'
-  total: number
-  passed: number
-  failed: number
-  pending: number
-}
 type GitHubPRMergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
 
 type GitHubPRReviewerRow = {
@@ -237,6 +232,7 @@ type GitLabWorkItem = {
   baseRefName?: string
   isCrossRepository?: boolean
   projectRef?: { host: string; path: string }
+  checksSummary?: GitHubPRCheckSummary
   repoId: string
   repoName: string
 }
@@ -4363,6 +4359,19 @@ export default function MobileTasksScreen() {
             assignees: details.assignees ?? [],
             pipelineJobs: details.pipelineJobs ?? []
           })
+          const checksSummary = buildGitLabCheckSummary(details.pipelineJobs ?? [])
+          setActionItem((current) =>
+            current?.provider === 'gitlab' && current.source.id === actionItem.source.id
+              ? { ...current, source: { ...current.source, checksSummary } }
+              : current
+          )
+          setItems((current) =>
+            current.map((candidate) =>
+              candidate.provider === 'gitlab' && candidate.source.id === actionItem.source.id
+                ? { ...candidate, source: { ...candidate.source, checksSummary } }
+                : candidate
+            )
+          )
         }
         return
       }

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -62,7 +62,7 @@ import {
 import { buildGitHubCheckSummary } from '../../../src/tasks/github-check-summary'
 import { buildGitLabCheckSummary } from '../../../src/tasks/gitlab-check-summary'
 import {
-  getGitHubPRSignalTone,
+  getHostedReviewSignalTone,
   getHostedChecksLabel
 } from '../../../src/tasks/mobile-hosted-check-status'
 import { buildTaskWorkspaceCreateParams } from '../../../src/tasks/workspace-create-params'
@@ -9697,7 +9697,7 @@ export default function MobileTasksScreen() {
                         <View
                           style={[
                             styles.prSignalChip,
-                            getPrSignalToneStyle(getGitHubPRSignalTone(item.source, 'review'))
+                            getPrSignalToneStyle(getHostedReviewSignalTone(item.source, 'review'))
                           ]}
                         >
                           <Text style={styles.prSignalText} numberOfLines={1}>
@@ -9708,7 +9708,7 @@ export default function MobileTasksScreen() {
                       <View
                         style={[
                           styles.prSignalChip,
-                          getPrSignalToneStyle(getGitHubPRSignalTone(item.source, 'checks'))
+                          getPrSignalToneStyle(getHostedReviewSignalTone(item.source, 'checks'))
                         ]}
                       >
                         <Text style={styles.prSignalText} numberOfLines={1}>
@@ -9719,7 +9719,7 @@ export default function MobileTasksScreen() {
                         <View
                           style={[
                             styles.prSignalChip,
-                            getPrSignalToneStyle(getGitHubPRSignalTone(item.source, 'merge'))
+                            getPrSignalToneStyle(getHostedReviewSignalTone(item.source, 'merge'))
                           ]}
                         >
                           <Text style={styles.prSignalText} numberOfLines={1}>

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -62,6 +62,8 @@ import {
 import { buildGitHubCheckSummary } from '../../../src/tasks/github-check-summary'
 import { buildGitLabCheckSummary } from '../../../src/tasks/gitlab-check-summary'
 import {
+  getHostedMergeLabel,
+  getHostedReviewLabel,
   getHostedReviewSignalTone,
   getHostedChecksLabel
 } from '../../../src/tasks/mobile-hosted-check-status'
@@ -237,6 +239,9 @@ type GitLabWorkItem = {
   isCrossRepository?: boolean
   projectRef?: { host: string; path: string }
   checksSummary?: ProviderCheckSummary
+  mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+  reviewDecision?: 'approved' | 'changes_requested' | 'review_required' | null
+  reviewerCount?: number
   repoId: string
   repoName: string
 }
@@ -4281,7 +4286,7 @@ export default function MobileTasksScreen() {
         const details = response.result as {
           body?: string
           comments?: DetailComment[]
-          item?: { labels?: string[] }
+          item?: { labels?: string[]; mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' }
           assignees?: string[]
           pipelineJobs?: Array<{
             id?: number
@@ -4291,6 +4296,8 @@ export default function MobileTasksScreen() {
             webUrl?: string | null
             duration?: number | null
           }>
+          reviewers?: unknown[]
+          approvalState?: { approvalsRequired: number | null; approvalsLeft: number | null }
         } | null
         if (!details) {
           throw new Error('Details not found')
@@ -4305,15 +4312,40 @@ export default function MobileTasksScreen() {
             pipelineJobs: details.pipelineJobs ?? []
           })
           const checksSummary = buildGitLabCheckSummary(details.pipelineJobs ?? [])
+          const reviewDecision =
+            details.approvalState?.approvalsRequired && details.approvalState.approvalsLeft === 0
+              ? 'approved'
+              : details.approvalState?.approvalsLeft && details.approvalState.approvalsLeft > 0
+                ? 'review_required'
+                : undefined
+          const hydratedStatus = {
+            ...(details.item?.mergeable !== undefined ? { mergeable: details.item.mergeable } : {}),
+            ...(reviewDecision !== undefined ? { reviewDecision } : {}),
+            ...(details.reviewers !== undefined ? { reviewerCount: details.reviewers.length } : {})
+          }
           setActionItem((current) =>
             current?.provider === 'gitlab' && current.source.id === actionItem.source.id
-              ? { ...current, source: { ...current.source, checksSummary } }
+              ? {
+                  ...current,
+                  source: {
+                    ...current.source,
+                    checksSummary,
+                    ...hydratedStatus
+                  }
+                }
               : current
           )
           setItems((current) =>
             current.map((candidate) =>
               candidate.provider === 'gitlab' && candidate.source.id === actionItem.source.id
-                ? { ...candidate, source: { ...candidate.source, checksSummary } }
+                ? {
+                    ...candidate,
+                    source: {
+                      ...candidate.source,
+                      checksSummary,
+                      ...hydratedStatus
+                    }
+                  }
                 : candidate
             )
           )
@@ -9693,7 +9725,7 @@ export default function MobileTasksScreen() {
                           </Text>
                         </View>
                       ) : null}
-                      {isGitHubPr ? (
+                      {isGitHubPr || isGitLabMr ? (
                         <View
                           style={[
                             styles.prSignalChip,
@@ -9701,7 +9733,9 @@ export default function MobileTasksScreen() {
                           ]}
                         >
                           <Text style={styles.prSignalText} numberOfLines={1}>
-                            {getGitHubReviewSummary(item.source)}
+                            {isGitHubPr
+                              ? getGitHubReviewSummary(item.source)
+                              : getHostedReviewLabel(item.source)}
                           </Text>
                         </View>
                       ) : null}
@@ -9715,7 +9749,7 @@ export default function MobileTasksScreen() {
                           {getHostedChecksLabel(item.source)}
                         </Text>
                       </View>
-                      {isGitHubPr ? (
+                      {isGitHubPr || isGitLabMr ? (
                         <View
                           style={[
                             styles.prSignalChip,
@@ -9723,7 +9757,9 @@ export default function MobileTasksScreen() {
                           ]}
                         >
                           <Text style={styles.prSignalText} numberOfLines={1}>
-                            {getGitHubMergeLabel(item.source)}
+                            {isGitHubPr
+                              ? getGitHubMergeLabel(item.source)
+                              : getHostedMergeLabel(item.source)}
                           </Text>
                         </View>
                       ) : null}

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -151,6 +151,7 @@ import type {
   TuiAgent
 } from '../../../../src/shared/types'
 import type { SshConnectionState } from '../../../../src/shared/ssh-types'
+import type { HostedReviewDecision } from '../../../../src/shared/hosted-review'
 import {
   githubProjectHost,
   githubProjectIdentityKey as githubProjectKey
@@ -240,7 +241,7 @@ type GitLabWorkItem = {
   projectRef?: { host: string; path: string }
   checksSummary?: ProviderCheckSummary
   mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
-  reviewDecision?: 'approved' | 'changes_requested' | 'review_required' | null
+  reviewDecision?: HostedReviewDecision
   reviewerCount?: number
   repoId: string
   repoName: string
@@ -4312,7 +4313,7 @@ export default function MobileTasksScreen() {
             pipelineJobs: details.pipelineJobs ?? []
           })
           const checksSummary = buildGitLabCheckSummary(details.pipelineJobs ?? [])
-          const reviewDecision =
+          const reviewDecision: Exclude<HostedReviewDecision, null> | undefined =
             details.approvalState?.approvalsRequired && details.approvalState.approvalsLeft === 0
               ? 'approved'
               : details.approvalState?.approvalsLeft && details.approvalState.approvalsLeft > 0

--- a/mobile/src/session/github-pr-value-readers.ts
+++ b/mobile/src/session/github-pr-value-readers.ts
@@ -1,7 +1,7 @@
 import type {
   CheckStatus,
   GitHubAssignableUser,
-  GitHubPRCheckSummary,
+  ProviderCheckSummary,
   GitHubPRMergeMethod,
   GitHubPRMergeMethodSettings,
   GitHubPRReviewSummary,
@@ -182,7 +182,7 @@ export function readMergeMethodSettings(value: unknown): GitHubPRMergeMethodSett
   }
 }
 
-export function readCheckSummary(value: unknown): GitHubPRCheckSummary | undefined {
+export function readCheckSummary(value: unknown): ProviderCheckSummary | undefined {
   if (!isRecord(value)) {
     return undefined
   }

--- a/mobile/src/session/github-pr-value-readers.ts
+++ b/mobile/src/session/github-pr-value-readers.ts
@@ -187,7 +187,13 @@ export function readCheckSummary(value: unknown): GitHubPRCheckSummary | undefin
     return undefined
   }
   const state = value.state
-  if (state !== 'success' && state !== 'failure' && state !== 'pending' && state !== 'none') {
+  if (
+    state !== 'success' &&
+    state !== 'failure' &&
+    state !== 'pending' &&
+    state !== 'neutral' &&
+    state !== 'none'
+  ) {
     return undefined
   }
   return {
@@ -195,6 +201,7 @@ export function readCheckSummary(value: unknown): GitHubPRCheckSummary | undefin
     total: readNumber(value.total) ?? 0,
     passed: readNumber(value.passed) ?? 0,
     failed: readNumber(value.failed) ?? 0,
-    pending: readNumber(value.pending) ?? 0
+    pending: readNumber(value.pending) ?? 0,
+    neutral: readNumber(value.neutral) ?? 0
   }
 }

--- a/mobile/src/tasks/github-check-summary.test.ts
+++ b/mobile/src/tasks/github-check-summary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { buildGitHubCheckSummary } from './github-check-summary'
+import { buildGitLabCheckSummary } from './gitlab-check-summary'
 
 describe('buildGitHubCheckSummary', () => {
   it('returns none for empty check lists', () => {
@@ -8,7 +9,8 @@ describe('buildGitHubCheckSummary', () => {
       total: 0,
       passed: 0,
       failed: 0,
-      pending: 0
+      pending: 0,
+      neutral: 0
     })
   })
 
@@ -24,22 +26,35 @@ describe('buildGitHubCheckSummary', () => {
       total: 3,
       passed: 1,
       failed: 1,
-      pending: 1
+      pending: 1,
+      neutral: 0
     })
   })
 
-  it('marks all completed non-failing checks as successful', () => {
+  it('keeps neutral and unknown terminal conclusions out of passed', () => {
     expect(
       buildGitHubCheckSummary([
         { status: 'completed', conclusion: 'success' },
         { status: 'completed', conclusion: 'neutral' }
       ])
     ).toEqual({
-      state: 'success',
+      state: 'neutral',
       total: 2,
-      passed: 2,
+      passed: 1,
       failed: 0,
-      pending: 0
+      pending: 0,
+      neutral: 1
+    })
+  })
+
+  it('rolls up GitLab jobs with unknown terminal statuses as neutral', () => {
+    expect(buildGitLabCheckSummary([{ status: 'success' }, { status: 'future_status' }])).toEqual({
+      state: 'neutral',
+      total: 2,
+      passed: 1,
+      failed: 0,
+      pending: 0,
+      neutral: 1
     })
   })
 })

--- a/mobile/src/tasks/github-check-summary.ts
+++ b/mobile/src/tasks/github-check-summary.ts
@@ -4,11 +4,12 @@ export type GitHubCheckLike = {
 }
 
 export type GitHubCheckSummary = {
-  state: 'success' | 'failure' | 'pending' | 'none'
+  state: 'success' | 'failure' | 'pending' | 'neutral' | 'none'
   total: number
   passed: number
   failed: number
   pending: number
+  neutral: number
 }
 
 function isFailedCheck(check: GitHubCheckLike): boolean {
@@ -28,18 +29,32 @@ function isPendingCheck(check: GitHubCheckLike): boolean {
 export function buildGitHubCheckSummary(checks: GitHubCheckLike[]): GitHubCheckSummary {
   let failed = 0
   let pending = 0
+  let neutral = 0
 
   for (const check of checks) {
-    if (isFailedCheck(check)) {
+    if (isFailedCheck(check) || check.conclusion === 'action_required') {
       failed += 1
     } else if (isPendingCheck(check)) {
       pending += 1
+    } else if (check.conclusion === 'success') {
+      continue
+    } else {
+      neutral += 1
     }
   }
 
   const total = checks.length
-  const passed = Math.max(0, total - failed - pending)
-  const state = total === 0 ? 'none' : failed > 0 ? 'failure' : pending > 0 ? 'pending' : 'success'
+  const passed = total - failed - pending - neutral
+  const state =
+    total === 0
+      ? 'none'
+      : failed > 0
+        ? 'failure'
+        : pending > 0
+          ? 'pending'
+          : neutral > 0
+            ? 'neutral'
+            : 'success'
 
-  return { state, total, passed, failed, pending }
+  return { state, total, passed, failed, pending, neutral }
 }

--- a/mobile/src/tasks/gitlab-check-summary.ts
+++ b/mobile/src/tasks/gitlab-check-summary.ts
@@ -1,9 +1,9 @@
 import { buildGitHubCheckSummary, type GitHubCheckLike } from './github-check-summary'
-import type { GitHubPRCheckSummary } from '../../../src/shared/types'
+import type { ProviderCheckSummary } from '../../../src/shared/types'
 
 type GitLabPipelineJobLike = { status: string }
 
-export function buildGitLabCheckSummary(jobs: GitLabPipelineJobLike[]): GitHubPRCheckSummary {
+export function buildGitLabCheckSummary(jobs: GitLabPipelineJobLike[]): ProviderCheckSummary {
   return buildGitHubCheckSummary(
     jobs.map((job): GitHubCheckLike => {
       const status = job.status.toLowerCase()

--- a/mobile/src/tasks/gitlab-check-summary.ts
+++ b/mobile/src/tasks/gitlab-check-summary.ts
@@ -1,0 +1,40 @@
+import {
+  buildGitHubCheckSummary,
+  type GitHubCheckLike,
+  type GitHubCheckSummary
+} from './github-check-summary'
+
+type GitLabPipelineJobLike = { status: string }
+
+export function buildGitLabCheckSummary(jobs: GitLabPipelineJobLike[]): GitHubCheckSummary {
+  return buildGitHubCheckSummary(
+    jobs.map((job): GitHubCheckLike => {
+      const status = job.status.toLowerCase()
+      const nonterminal = [
+        'created',
+        'pending',
+        'scheduled',
+        'waiting_for_callback',
+        'waiting_for_resource',
+        'preparing'
+      ].includes(status)
+      return {
+        status: status === 'running' ? 'in_progress' : nonterminal ? 'queued' : 'completed',
+        conclusion:
+          status === 'success'
+            ? 'success'
+            : status === 'failed'
+              ? 'failure'
+              : ['canceled', 'canceling'].includes(status)
+                ? 'cancelled'
+                : status === 'skipped'
+                  ? 'skipped'
+                  : ['manual', 'action_required'].includes(status)
+                    ? 'action_required'
+                    : status === 'running' || nonterminal
+                      ? 'pending'
+                      : null
+      }
+    })
+  )
+}

--- a/mobile/src/tasks/gitlab-check-summary.ts
+++ b/mobile/src/tasks/gitlab-check-summary.ts
@@ -1,12 +1,9 @@
-import {
-  buildGitHubCheckSummary,
-  type GitHubCheckLike,
-  type GitHubCheckSummary
-} from './github-check-summary'
+import { buildGitHubCheckSummary, type GitHubCheckLike } from './github-check-summary'
+import type { GitHubPRCheckSummary } from '../../../src/shared/types'
 
 type GitLabPipelineJobLike = { status: string }
 
-export function buildGitLabCheckSummary(jobs: GitLabPipelineJobLike[]): GitHubCheckSummary {
+export function buildGitLabCheckSummary(jobs: GitLabPipelineJobLike[]): GitHubPRCheckSummary {
   return buildGitHubCheckSummary(
     jobs.map((job): GitHubCheckLike => {
       const status = job.status.toLowerCase()

--- a/mobile/src/tasks/mobile-hosted-check-status.test.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getHostedChecksLabel, getHostedReviewSignalTone } from './mobile-hosted-check-status'
+import {
+  getHostedChecksLabel,
+  getHostedReviewLabel,
+  getHostedReviewSignalTone
+} from './mobile-hosted-check-status'
 
 describe('mobile hosted check status', () => {
   it('renders a hydrated neutral GitLab summary as unresolved checks', () => {
@@ -18,9 +22,42 @@ describe('mobile hosted check status', () => {
   it('accepts provider-neutral GitHub status fields without a shared work-item type', () => {
     expect(
       getHostedReviewSignalTone(
-        { reviewDecision: 'APPROVED', reviewRequests: [], mergeable: 'UNKNOWN' },
+        { reviewDecision: 'approved', reviewRequests: [], mergeable: 'UNKNOWN' },
         'review'
       )
     ).toBe('success')
+  })
+
+  it('renders hydrated GitLab approval, merge, and check states', () => {
+    expect(getHostedReviewLabel({ reviewDecision: 'review_required', reviewerCount: 2 })).toBe(
+      'Review required'
+    )
+    expect(
+      getHostedReviewSignalTone(
+        {
+          reviewDecision: 'review_required',
+          reviewerCount: 2,
+          mergeable: 'MERGEABLE',
+          checksSummary: {
+            state: 'success',
+            total: 1,
+            passed: 1,
+            failed: 0,
+            pending: 0,
+            neutral: 0
+          }
+        },
+        'review'
+      )
+    ).toBe('warning')
+    expect(getHostedReviewSignalTone({ mergeable: 'MERGEABLE' }, 'merge')).toBe('success')
+    expect(getHostedReviewSignalTone({ reviewDecision: 'approved' }, 'review')).toBe('success')
+    expect(getHostedReviewSignalTone({ mergeable: 'CONFLICTING' }, 'merge')).toBe('danger')
+  })
+
+  it('keeps missing GitLab enrichment neutral', () => {
+    expect(getHostedReviewLabel({})).toBe('No reviewers')
+    expect(getHostedReviewSignalTone({}, 'review')).toBe('neutral')
+    expect(getHostedReviewSignalTone({}, 'merge')).toBe('neutral')
   })
 })

--- a/mobile/src/tasks/mobile-hosted-check-status.test.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { HostedReviewDecision } from '../../../src/shared/hosted-review'
 import {
   getHostedChecksLabel,
   getHostedReviewLabel,
@@ -53,6 +54,13 @@ describe('mobile hosted check status', () => {
     expect(getHostedReviewSignalTone({ mergeable: 'MERGEABLE' }, 'merge')).toBe('success')
     expect(getHostedReviewSignalTone({ reviewDecision: 'approved' }, 'review')).toBe('success')
     expect(getHostedReviewSignalTone({ mergeable: 'CONFLICTING' }, 'merge')).toBe('danger')
+  })
+
+  it('renders a shared typed GitLab review decision', () => {
+    const reviewDecision: HostedReviewDecision = 'changes_requested'
+
+    expect(getHostedReviewLabel({ reviewDecision })).toBe('Changes requested')
+    expect(getHostedReviewSignalTone({ reviewDecision }, 'review')).toBe('danger')
   })
 
   it('keeps missing GitLab enrichment neutral', () => {

--- a/mobile/src/tasks/mobile-hosted-check-status.test.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { getGitHubPRSignalTone, getHostedChecksLabel } from './mobile-hosted-check-status'
+
+describe('mobile hosted check status', () => {
+  it('renders a hydrated neutral GitLab summary as unresolved checks', () => {
+    const summary = {
+      state: 'neutral' as const,
+      total: 2,
+      passed: 1,
+      failed: 0,
+      pending: 0,
+      neutral: 1
+    }
+    expect(getHostedChecksLabel({ checksSummary: summary })).toBe('Unresolved checks')
+    expect(getGitHubPRSignalTone({ checksSummary: summary }, 'checks')).toBe('neutral')
+  })
+})

--- a/mobile/src/tasks/mobile-hosted-check-status.test.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getGitHubPRSignalTone, getHostedChecksLabel } from './mobile-hosted-check-status'
+import { getHostedChecksLabel, getHostedReviewSignalTone } from './mobile-hosted-check-status'
 
 describe('mobile hosted check status', () => {
   it('renders a hydrated neutral GitLab summary as unresolved checks', () => {
@@ -12,6 +12,15 @@ describe('mobile hosted check status', () => {
       neutral: 1
     }
     expect(getHostedChecksLabel({ checksSummary: summary })).toBe('Unresolved checks')
-    expect(getGitHubPRSignalTone({ checksSummary: summary }, 'checks')).toBe('neutral')
+    expect(getHostedReviewSignalTone({ checksSummary: summary }, 'checks')).toBe('neutral')
+  })
+
+  it('accepts provider-neutral GitHub status fields without a shared work-item type', () => {
+    expect(
+      getHostedReviewSignalTone(
+        { reviewDecision: 'APPROVED', reviewRequests: [], mergeable: 'UNKNOWN' },
+        'review'
+      )
+    ).toBe('success')
   })
 })

--- a/mobile/src/tasks/mobile-hosted-check-status.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.ts
@@ -1,0 +1,63 @@
+import type { ProviderCheckSummary, GitHubWorkItem } from '../../../src/shared/types'
+
+export function getHostedChecksLabel(item: { checksSummary?: ProviderCheckSummary }): string {
+  const summary = item.checksSummary
+  if (!summary) {
+    return 'Checks'
+  }
+  if (summary.total === 0) {
+    return 'No checks'
+  }
+  if (summary.failed > 0) {
+    return `${summary.failed} failing`
+  }
+  if (summary.pending > 0) {
+    return `${summary.pending} pending`
+  }
+  return summary.state === 'neutral'
+    ? 'Unresolved checks'
+    : `${summary.passed}/${summary.total} passed`
+}
+
+export function getGitHubPRSignalTone(
+  item: Pick<
+    GitHubWorkItem,
+    'reviewDecision' | 'reviewRequests' | 'checksSummary' | 'mergeable' | 'mergeStateStatus'
+  >,
+  signal: 'review' | 'checks' | 'merge'
+): 'neutral' | 'success' | 'warning' | 'danger' {
+  if (signal === 'review') {
+    if (item.reviewDecision === 'APPROVED') {
+      return 'success'
+    }
+    if (item.reviewDecision === 'CHANGES_REQUESTED') {
+      return 'danger'
+    }
+    if (item.reviewRequests && item.reviewRequests.length > 0) {
+      return 'warning'
+    }
+    return 'neutral'
+  }
+  if (signal === 'checks') {
+    if (item.checksSummary?.state === 'success') {
+      return 'success'
+    }
+    if (item.checksSummary?.state === 'failure') {
+      return 'danger'
+    }
+    if (item.checksSummary?.state === 'pending') {
+      return 'warning'
+    }
+    return 'neutral'
+  }
+  if (item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'BLOCKED') {
+    return 'danger'
+  }
+  if (item.mergeStateStatus === 'BEHIND' || item.checksSummary?.state === 'pending') {
+    return 'warning'
+  }
+  if (item.mergeable === 'MERGEABLE' || item.mergeStateStatus === 'CLEAN') {
+    return 'success'
+  }
+  return 'neutral'
+}

--- a/mobile/src/tasks/mobile-hosted-check-status.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.ts
@@ -1,4 +1,12 @@
-import type { ProviderCheckSummary, GitHubWorkItem } from '../../../src/shared/types'
+import type { ProviderCheckSummary } from '../../../src/shared/types'
+
+export type MobileHostedReviewStatus = {
+  checksSummary?: ProviderCheckSummary
+  reviewDecision?: string | null
+  reviewRequests?: readonly unknown[]
+  mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+  mergeStateStatus?: string | null
+}
 
 export function getHostedChecksLabel(item: { checksSummary?: ProviderCheckSummary }): string {
   const summary = item.checksSummary
@@ -19,11 +27,8 @@ export function getHostedChecksLabel(item: { checksSummary?: ProviderCheckSummar
     : `${summary.passed}/${summary.total} passed`
 }
 
-export function getGitHubPRSignalTone(
-  item: Pick<
-    GitHubWorkItem,
-    'reviewDecision' | 'reviewRequests' | 'checksSummary' | 'mergeable' | 'mergeStateStatus'
-  >,
+export function getHostedReviewSignalTone(
+  item: MobileHostedReviewStatus,
   signal: 'review' | 'checks' | 'merge'
 ): 'neutral' | 'success' | 'warning' | 'danger' {
   if (signal === 'review') {

--- a/mobile/src/tasks/mobile-hosted-check-status.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.ts
@@ -1,11 +1,41 @@
-import type { ProviderCheckSummary } from '../../../src/shared/types'
+import type { ProviderCheckSummary, PRMergeableState } from '../../../src/shared/types'
 
 export type MobileHostedReviewStatus = {
   checksSummary?: ProviderCheckSummary
   reviewDecision?: string | null
   reviewRequests?: readonly unknown[]
-  mergeable?: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
+  reviewerCount?: number
+  mergeable?: PRMergeableState
   mergeStateStatus?: string | null
+}
+
+export function getHostedReviewLabel(item: MobileHostedReviewStatus): string {
+  if (item.reviewDecision === 'approved' || item.reviewDecision === 'APPROVED') {
+    return 'Approved'
+  }
+  if (item.reviewDecision === 'changes_requested' || item.reviewDecision === 'CHANGES_REQUESTED') {
+    return 'Changes requested'
+  }
+  if (item.reviewDecision === 'review_required' || item.reviewDecision === 'REVIEW_REQUIRED') {
+    return 'Review required'
+  }
+  const reviewerCount = item.reviewerCount ?? item.reviewRequests?.length
+  return reviewerCount
+    ? `${reviewerCount} reviewer${reviewerCount === 1 ? '' : 's'}`
+    : 'No reviewers'
+}
+
+export function getHostedMergeLabel(item: MobileHostedReviewStatus): string {
+  if (item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'BLOCKED') {
+    return 'Conflicts'
+  }
+  if (item.mergeStateStatus === 'BEHIND' || item.checksSummary?.state === 'pending') {
+    return 'Behind'
+  }
+  if (item.mergeable === 'MERGEABLE' || item.mergeStateStatus === 'CLEAN') {
+    return 'Able to merge'
+  }
+  return 'Unknown'
 }
 
 export function getHostedChecksLabel(item: { checksSummary?: ProviderCheckSummary }): string {
@@ -32,13 +62,21 @@ export function getHostedReviewSignalTone(
   signal: 'review' | 'checks' | 'merge'
 ): 'neutral' | 'success' | 'warning' | 'danger' {
   if (signal === 'review') {
-    if (item.reviewDecision === 'APPROVED') {
+    if (item.reviewDecision === 'approved' || item.reviewDecision === 'APPROVED') {
       return 'success'
     }
-    if (item.reviewDecision === 'CHANGES_REQUESTED') {
+    if (
+      item.reviewDecision === 'changes_requested' ||
+      item.reviewDecision === 'CHANGES_REQUESTED'
+    ) {
       return 'danger'
     }
-    if (item.reviewRequests && item.reviewRequests.length > 0) {
+    if (
+      item.reviewDecision === 'review_required' ||
+      item.reviewDecision === 'REVIEW_REQUIRED' ||
+      item.reviewerCount !== undefined ||
+      item.reviewRequests?.length
+    ) {
       return 'warning'
     }
     return 'neutral'

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -658,11 +658,12 @@ function checkRollupEntries(value: unknown): unknown[] {
 function deriveWorkItemCheckSummary(value: unknown): GitHubWorkItem['checksSummary'] {
   const entries = checkRollupEntries(value)
   if (entries.length === 0) {
-    return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0 }
+    return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0, neutral: 0 }
   }
   let passed = 0
   let failed = 0
   let pending = 0
+  let neutral = 0
   for (const entry of entries) {
     if (typeof entry !== 'object' || entry === null) {
       pending += 1
@@ -671,7 +672,7 @@ function deriveWorkItemCheckSummary(value: unknown): GitHubWorkItem['checksSumma
     const raw = entry as Record<string, unknown>
     const conclusion = String(raw.conclusion ?? raw.state ?? '').toUpperCase()
     const status = String(raw.status ?? '').toUpperCase()
-    if (['SUCCESS', 'NEUTRAL', 'SKIPPED'].includes(conclusion)) {
+    if (['SUCCESS', 'SKIPPED'].includes(conclusion)) {
       passed += 1
     } else if (
       ['FAILURE', 'ERROR', 'TIMED_OUT', 'CANCELLED', 'ACTION_REQUIRED', 'STARTUP_FAILURE'].includes(
@@ -679,18 +680,19 @@ function deriveWorkItemCheckSummary(value: unknown): GitHubWorkItem['checksSumma
       )
     ) {
       failed += 1
-    } else if (status === 'COMPLETED' && conclusion) {
-      failed += 1
+    } else if (status === 'COMPLETED') {
+      neutral += 1
     } else {
       pending += 1
     }
   }
   return {
-    state: failed > 0 ? 'failure' : pending > 0 ? 'pending' : 'success',
+    state: failed > 0 ? 'failure' : pending > 0 ? 'pending' : neutral > 0 ? 'neutral' : 'success',
     total: entries.length,
     passed,
     failed,
-    pending
+    pending,
+    neutral
   }
 }
 

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -1,4 +1,5 @@
 import type { PRInfo, IssueInfo, CheckStatus, PRCheckDetail } from '../../shared/types'
+import { derivePRCheckStatusFromRollup } from '../../shared/pr-check-status'
 
 // ── REST API check-runs mapping ───────────────────────────────────────
 // The REST check-runs endpoint returns separate status + conclusion fields
@@ -143,44 +144,5 @@ export function mapIssueInfo(data: {
 }
 
 export function deriveCheckStatus(rollup: unknown[] | null | undefined): CheckStatus {
-  if (!rollup || !Array.isArray(rollup) || rollup.length === 0) {
-    return 'neutral'
-  }
-
-  let hasFailure = false
-  let hasPending = false
-
-  for (const check of rollup as { status?: string; conclusion?: string; state?: string }[]) {
-    const conclusion = check.conclusion?.toUpperCase()
-    const status = check.status?.toUpperCase()
-    const state = check.state?.toUpperCase()
-
-    if (
-      conclusion === 'FAILURE' ||
-      conclusion === 'TIMED_OUT' ||
-      conclusion === 'CANCELLED' ||
-      // Why: action_required (e.g. an unapproved workflow run) blocks merge until
-      // someone acts; treat it as needs-attention rather than a silent pass.
-      conclusion === 'ACTION_REQUIRED' ||
-      state === 'FAILURE' ||
-      state === 'ERROR'
-    ) {
-      hasFailure = true
-    } else if (
-      status === 'IN_PROGRESS' ||
-      status === 'QUEUED' ||
-      status === 'PENDING' ||
-      state === 'PENDING'
-    ) {
-      hasPending = true
-    }
-  }
-
-  if (hasFailure) {
-    return 'failure'
-  }
-  if (hasPending) {
-    return 'pending'
-  }
-  return 'success'
+  return derivePRCheckStatusFromRollup(rollup)
 }

--- a/src/main/gitlab/mappers-workitem.test.ts
+++ b/src/main/gitlab/mappers-workitem.test.ts
@@ -52,6 +52,18 @@ describe('mapMRToWorkItem', () => {
     expect(item.isCrossRepository).toBe(true)
   })
 
+  it('maps GitLab mergeability when the MR payload includes merge status', () => {
+    expect(
+      mapMRToWorkItem(
+        { iid: 1, title: 't', state: 'opened', detailed_merge_status: 'mergeable' },
+        'g/p'
+      ).mergeable
+    ).toBe('MERGEABLE')
+    expect(
+      mapMRToWorkItem({ iid: 2, title: 't', state: 'opened', has_conflicts: true }, 'g/p').mergeable
+    ).toBe('CONFLICTING')
+  })
+
   it('does not flag cross-repository when project ids are absent', () => {
     const item = mapMRToWorkItem({ iid: 1, title: 't', state: 'opened' }, 'g/p')
     expect(item.isCrossRepository).toBe(false)

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -245,4 +245,12 @@ describe('derivePipelineStatus', () => {
   it('handles a single object with status', () => {
     expect(derivePipelineStatus({ status: 'success' })).toBe('success')
   })
+
+  it('keeps malformed and unknown array jobs neutral', () => {
+    expect(derivePipelineStatus([{ status: 'future_status' }])).toBe('neutral')
+    expect(derivePipelineStatus([{}])).toBe('neutral')
+    expect(derivePipelineStatus([{ status: 'success' }, { status: 'future_status' }])).toBe(
+      'neutral'
+    )
+  })
 })

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -38,8 +38,9 @@ describe('mapPipelineJobStatusToConclusion', () => {
     expect(mapPipelineJobStatusToConclusion('skipped')).toBe('skipped')
   })
 
-  it("maps 'manual' to neutral so it doesn't stall pending forever", () => {
-    expect(mapPipelineJobStatusToConclusion('manual')).toBe('neutral')
+  it('maps manual and action-required jobs to an actionable conclusion', () => {
+    expect(mapPipelineJobStatusToConclusion('manual')).toBe('action_required')
+    expect(mapPipelineJobStatusToConclusion('action_required')).toBe('action_required')
   })
 
   it('maps active lifecycle states to pending', () => {

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -228,7 +228,7 @@ describe('derivePipelineStatus', () => {
     expect(derivePipelineStatus('success')).toBe('success')
     expect(derivePipelineStatus('failed')).toBe('failure')
     expect(derivePipelineStatus('running')).toBe('pending')
-    expect(derivePipelineStatus('manual')).toBe('neutral')
+    expect(derivePipelineStatus('manual')).toBe('failure')
   })
 
   it('rolls up an array of jobs', () => {
@@ -239,6 +239,7 @@ describe('derivePipelineStatus', () => {
 
   it('failure beats pending in the rollup', () => {
     expect(derivePipelineStatus([{ status: 'failed' }, { status: 'running' }])).toBe('failure')
+    expect(derivePipelineStatus([{ status: 'manual' }, { status: 'success' }])).toBe('failure')
   })
 
   it('handles a single object with status', () => {

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -161,19 +161,20 @@ export function derivePipelineStatus(
   }
   let hasFailure = false
   let hasPending = false
+  let hasUnknown = false
   for (const job of rollup) {
-    const s = job.status?.toLowerCase()
-    if (s === 'failed' || s === 'manual' || s === 'action_required') {
-      hasFailure = true
-    } else if (
-      s === 'created' ||
-      s === 'pending' ||
-      s === 'running' ||
-      s === 'waiting_for_resource' ||
-      s === 'preparing' ||
-      s === 'scheduled'
+    const s = job.status?.toLowerCase() ?? ''
+    const conclusion = mapPipelineJobStatusToConclusion(s)
+    if (
+      conclusion === 'failure' ||
+      conclusion === 'cancelled' ||
+      conclusion === 'action_required'
     ) {
+      hasFailure = true
+    } else if (conclusion === 'pending') {
       hasPending = true
+    } else if (conclusion !== 'success' && conclusion !== 'skipped' && conclusion !== 'neutral') {
+      hasUnknown = true
     }
   }
   if (hasFailure) {
@@ -182,7 +183,7 @@ export function derivePipelineStatus(
   if (hasPending) {
     return 'pending'
   }
-  return 'success'
+  return hasUnknown ? 'neutral' : 'success'
 }
 
 // ── Raw → GitLabWorkItem mapping ────────────────────────────────────

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -163,7 +163,7 @@ export function derivePipelineStatus(
   let hasPending = false
   for (const job of rollup) {
     const s = job.status?.toLowerCase()
-    if (s === 'failed') {
+    if (s === 'failed' || s === 'manual' || s === 'action_required') {
       hasFailure = true
     } else if (
       s === 'created' ||
@@ -283,7 +283,7 @@ function classifyPipelineString(status: string): CheckStatus {
   if (s === 'success') {
     return 'success'
   }
-  if (s === 'failed') {
+  if (s === 'failed' || s === 'manual' || s === 'action_required') {
     return 'failure'
   }
   if (

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -210,6 +210,8 @@ type GitLabMRRawForWorkItem = {
    *  when the workspace flow can't safely resolve the head. */
   source_project_id?: number
   target_project_id?: number
+  has_conflicts?: boolean
+  detailed_merge_status?: string
 }
 
 export function mapMRToWorkItem(
@@ -238,6 +240,9 @@ export function mapMRToWorkItem(
       data.target_project_id !== undefined &&
       data.source_project_id !== data.target_project_id,
     repoId,
+    ...(data.has_conflicts !== undefined || data.detailed_merge_status !== undefined
+      ? { mergeable: deriveMergeable(data) }
+      : {}),
     ...(projectRef ? { projectRef } : {})
   }
 }

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -231,6 +231,7 @@ import {
   validateTaskPageGitHubDuplicateTarget,
   type TaskPageGitHubCloseAction
 } from '@/components/task-page-github-status-actions'
+import { sortChecksBySeverity } from '../../../shared/pr-check-severity-order'
 
 // Why: the dialog lacks repository context, so recover its host-aware identity from the canonical item URL.
 function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
@@ -4320,17 +4321,6 @@ function CommentReplyForm({
   )
 }
 
-const CHECK_SORT_ORDER: Record<string, number> = {
-  failure: 0,
-  timed_out: 0,
-  action_required: 0,
-  cancelled: 1,
-  pending: 2,
-  neutral: 3,
-  skipped: 4,
-  success: 5
-}
-
 function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
   return check.conclusion ?? 'pending'
 }
@@ -4474,11 +4464,7 @@ function ChecksTab({
   const prRepo = useMemo(() => resolvePullRequestRepo(item), [item])
   const runtimeHost = getGitHubSourceRuntimeHost(sourceContext)
   const canUseChecksRepoContext = canUseGitHubRepoContext(repoPath, sourceContext)
-  const sorted = [...list].sort(
-    (a, b) =>
-      (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
-      (CHECK_SORT_ORDER[getCheckConclusion(b)] ?? 3)
-  )
+  const sorted = sortChecksBySeverity(list)
   const failedChecks = getBrokenChecks(list)
   const counts = getCheckCounts(list)
   const summaryLabel = getChecksSummaryLabel(list)

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -227,6 +227,7 @@ import {
 } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { sortChecksBySeverity } from '../../../shared/pr-check-severity-order'
 
 // Why: the item URL is the only host-aware repository identity present on every work item across IPC.
 function parseOwnerRepoFromItemUrl(url: string): GitHubOwnerRepo | null {
@@ -4329,17 +4330,6 @@ function CommentReplyForm({
   )
 }
 
-const CHECK_SORT_ORDER: Record<string, number> = {
-  failure: 0,
-  timed_out: 0,
-  action_required: 0,
-  cancelled: 1,
-  pending: 2,
-  neutral: 3,
-  skipped: 4,
-  success: 5
-}
-
 function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
   return check.conclusion ?? 'pending'
 }
@@ -4578,11 +4568,7 @@ function ChecksTab({
   const prRepo = useMemo(() => resolvePullRequestRepo(item), [item])
   const runtimeHost = getGitHubSourceRuntimeHost(sourceContext)
   const canUseChecksRepoContext = canUseGitHubRepoContext(repoPath, sourceContext)
-  const sorted = [...list].sort(
-    (a, b) =>
-      (CHECK_SORT_ORDER[getCheckConclusion(a)] ?? 3) -
-      (CHECK_SORT_ORDER[getCheckConclusion(b)] ?? 3)
-  )
+  const sorted = sortChecksBySeverity(list)
   const failedChecks = getBrokenChecks(list)
   const counts = getCheckCounts(list)
   const summaryLabel = getChecksSummaryLabel(list)

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -2026,6 +2026,9 @@ function getChecksLabel(item: GitHubWorkItem): string {
   if (summary.pending > 0) {
     return `${summary.pending} pending`
   }
+  if (summary.neutral > 0) {
+    return `${summary.neutral} unresolved`
+  }
   return `${summary.passed}/${summary.total} passed`
 }
 

--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -6,7 +6,7 @@ function pr(overrides: Partial<GitHubPRMergeStateInput> = {}): GitHubPRMergeStat
     state: 'open',
     mergeable: 'MERGEABLE',
     mergeStateStatus: 'CLEAN',
-    checksSummary: { state: 'success', total: 1, passed: 1, failed: 0, pending: 0 },
+    checksSummary: { state: 'success', total: 1, passed: 1, failed: 0, pending: 0, neutral: 0 },
     autoMergeAllowed: true,
     ...overrides
   }
@@ -44,7 +44,14 @@ describe('presentGitHubPRMergeState', () => {
       presentGitHubPRMergeState(
         pr({
           mergeStateStatus: 'BLOCKED',
-          checksSummary: { state: 'pending', total: 1, passed: 0, failed: 0, pending: 1 }
+          checksSummary: {
+            state: 'pending',
+            total: 1,
+            passed: 0,
+            failed: 0,
+            pending: 1,
+            neutral: 0
+          }
         })
       ).autoMergeAction
     ).toMatchObject({ kind: 'enable', label: 'Enable auto-merge' })
@@ -53,7 +60,16 @@ describe('presentGitHubPRMergeState', () => {
   it('does not offer enable auto-merge when only optional checks are pending', () => {
     expect(
       presentGitHubPRMergeState(
-        pr({ checksSummary: { state: 'pending', total: 1, passed: 0, failed: 0, pending: 1 } })
+        pr({
+          checksSummary: {
+            state: 'pending',
+            total: 1,
+            passed: 0,
+            failed: 0,
+            pending: 1,
+            neutral: 0
+          }
+        })
       )
     ).toMatchObject({
       label: 'Checks pending',
@@ -68,7 +84,14 @@ describe('presentGitHubPRMergeState', () => {
         pr({
           mergeable: 'UNKNOWN',
           mergeStateStatus: 'UNSTABLE',
-          checksSummary: { state: 'failure', total: 1, passed: 0, failed: 1, pending: 0 }
+          checksSummary: {
+            state: 'failure',
+            total: 1,
+            passed: 0,
+            failed: 1,
+            pending: 0,
+            neutral: 0
+          }
         })
       ).autoMergeAction
     ).toBeNull()
@@ -110,7 +133,7 @@ describe('presentGitHubPRMergeState', () => {
     expect(
       presentGitHubPRMergeState({
         state: 'open',
-        checksSummary: { state: 'success', total: 1, passed: 1, failed: 0, pending: 0 }
+        checksSummary: { state: 'success', total: 1, passed: 1, failed: 0, pending: 0, neutral: 0 }
       })
     ).toMatchObject({ label: 'Checks passed', directMergeAvailable: true, autoMergeAction: null })
     expect(presentGitHubPRMergeState(pr())).toMatchObject({
@@ -135,12 +158,30 @@ describe('presentGitHubPRMergeState', () => {
     })
     expect(
       presentGitHubPRMergeState(
-        pr({ checksSummary: { state: 'pending', total: 1, passed: 0, failed: 0, pending: 1 } })
+        pr({
+          checksSummary: {
+            state: 'pending',
+            total: 1,
+            passed: 0,
+            failed: 0,
+            pending: 1,
+            neutral: 0
+          }
+        })
       )
     ).toMatchObject({ label: 'Checks pending', directMergeAvailable: true })
     expect(
       presentGitHubPRMergeState(
-        pr({ checksSummary: { state: 'failure', total: 1, passed: 0, failed: 1, pending: 0 } })
+        pr({
+          checksSummary: {
+            state: 'failure',
+            total: 1,
+            passed: 0,
+            failed: 1,
+            pending: 0,
+            neutral: 0
+          }
+        })
       )
     ).toMatchObject({ label: 'Checks failed', directMergeAvailable: true })
     expect(presentGitHubPRMergeState(pr())).toMatchObject({
@@ -155,7 +196,14 @@ describe('presentGitHubPRMergeState', () => {
         pr({
           mergeable: 'UNKNOWN',
           mergeStateStatus: null,
-          checksSummary: { state: 'pending', total: 1, passed: 0, failed: 0, pending: 1 }
+          checksSummary: {
+            state: 'pending',
+            total: 1,
+            passed: 0,
+            failed: 0,
+            pending: 1,
+            neutral: 0
+          }
         })
       )
     ).toMatchObject({
@@ -168,7 +216,7 @@ describe('presentGitHubPRMergeState', () => {
     expect(
       presentGitHubPRMergeState({
         state: 'open',
-        checksSummary: { state: 'success', total: 3, passed: 3, failed: 0, pending: 0 }
+        checksSummary: { state: 'success', total: 3, passed: 3, failed: 0, pending: 0, neutral: 0 }
       })
     ).toMatchObject({
       label: 'Checks passed',
@@ -179,7 +227,14 @@ describe('presentGitHubPRMergeState', () => {
         pr({
           mergeable: 'UNKNOWN',
           mergeStateStatus: null,
-          checksSummary: { state: 'success', total: 3, passed: 3, failed: 0, pending: 0 }
+          checksSummary: {
+            state: 'success',
+            total: 3,
+            passed: 3,
+            failed: 0,
+            pending: 0,
+            neutral: 0
+          }
         })
       )
     ).toMatchObject({

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -1,6 +1,6 @@
 import type {
   CheckStatus,
-  GitHubPRCheckSummary,
+  ProviderCheckSummary,
   PRMergeableState,
   PRReviewDecision,
   PRState
@@ -14,7 +14,7 @@ export type GitHubPRMergeStateInput = {
   mergeStateStatus?: string | null
   reviewDecision?: PRReviewDecision | null
   checksStatus?: CheckStatus
-  checksSummary?: GitHubPRCheckSummary
+  checksSummary?: ProviderCheckSummary
   autoMergeEnabled?: boolean
   autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -99,6 +99,7 @@ import {
 import { translate } from '@/i18n/i18n'
 import { useActiveWorktree } from '@/store/selectors'
 import { useAppStore } from '@/store'
+import { sortChecksBySeverity } from '../../../../shared/pr-check-severity-order'
 
 export const PullRequestIcon = GitPullRequest
 
@@ -502,17 +503,6 @@ export function ConflictTriageStrip({
       </div>
     </div>
   )
-}
-
-const CHECK_SORT_ORDER: Record<string, number> = {
-  failure: 0,
-  timed_out: 0,
-  action_required: 0,
-  cancelled: 1,
-  pending: 2,
-  neutral: 3,
-  skipped: 4,
-  success: 5
 }
 
 type CheckDetailsLoadState = {
@@ -970,15 +960,7 @@ export function ChecksList({
     shouldConstrainCheckList && checks.length > 0
   )
   detailsContextRef.current = checkDetailsContextKey
-  const sorted = React.useMemo(
-    () =>
-      [...checks].sort(
-        (a, b) =>
-          (CHECK_SORT_ORDER[a.conclusion ?? 'pending'] ?? 3) -
-          (CHECK_SORT_ORDER[b.conclusion ?? 'pending'] ?? 3)
-      ),
-    [checks]
-  )
+  const sorted = React.useMemo(() => sortChecksBySeverity(checks), [checks])
   const rows = React.useMemo(
     () =>
       sorted.map((check, index) => ({

--- a/src/renderer/src/components/task-page-cache-selectors.test.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.test.ts
@@ -46,6 +46,32 @@ describe('task page cache selectors', () => {
     })
   })
 
+  it('reconciles a changed neutral check count', () => {
+    const current = {
+      ...workItem('pr-1', 'repo-1'),
+      checksSummary: {
+        state: 'neutral' as const,
+        total: 1,
+        passed: 1,
+        failed: 0,
+        pending: 0,
+        neutral: 0
+      }
+    }
+    const refreshed = {
+      ...current,
+      checksSummary: {
+        state: 'neutral' as const,
+        total: 2,
+        passed: 1,
+        failed: 0,
+        pending: 0,
+        neutral: 1
+      }
+    }
+    expect(reconcileTaskPageItemsAfterLandingRefresh([current], [refreshed])).toEqual([refreshed])
+  })
+
   it('keeps the selected work-item cache slice shallow-equal across unrelated cache writes', () => {
     const repo = { id: 'repo-1', path: '/repo/one' }
     const selectedEntry = entry<GitHubWorkItem[]>([workItem('issue-1', 'repo-1')])

--- a/src/renderer/src/components/task-page-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.ts
@@ -1,12 +1,22 @@
-/* eslint-disable max-lines -- Why: TaskPage cache reconciliation helpers are
-   kept together so list refresh and drawer lookup behavior stay consistent. */
 import {
   workItemsCacheKey,
   type CacheEntry,
   type WorkItemsCacheError,
   type WorkItemsCacheSources
 } from '@/store/slices/github'
-import type { GitHubWorkItem, LinearCollectionResult, LinearIssue } from '../../../shared/types'
+import type { GitHubWorkItem } from '../../../shared/types'
+import {
+  taskPageWorkItemKey,
+  taskPageWorkItemStatusSignature,
+  taskPageWorkItemKeyOrderSignature,
+  taskPageWorkItemPaginationBoundary
+} from './task-page-work-item-signatures'
+export {
+  findTaskPageLinearDrawerIssue,
+  findTaskPageLinearIssue,
+  reconcileTaskPageLinearIssuesAfterLandingRefresh,
+  shouldReplaceTaskPageLinearIssuesAfterRefresh
+} from './task-page-linear-cache-selectors'
 
 export type TaskPageRepoCacheInput = {
   id: string
@@ -34,9 +44,6 @@ export type TaskPageWorkItemsFetchOptions = {
 }
 
 type WorkItemsCache = Record<string, CacheEntry<GitHubWorkItem[]>>
-type LinearIssueCache = Record<string, CacheEntry<LinearIssue>>
-type LinearSearchCache = Record<string, CacheEntry<LinearIssue[]>>
-type LinearListCache = Record<string, CacheEntry<LinearCollectionResult<LinearIssue>>>
 export type TaskPageWorkItemPages = readonly (GitHubWorkItem[] | null)[]
 
 export function deriveTaskPageGitHubWorkItemsFetchOptions(
@@ -149,56 +156,6 @@ export function reconcileTaskPagePagesWithWorkItemsCache(
   return changed ? nextPages : (pages as (GitHubWorkItem[] | null)[])
 }
 
-function taskPageWorkItemKey(item: GitHubWorkItem): string {
-  return `${item.repoId}\u0000${item.id}`
-}
-
-function sortedStrings(values: readonly string[] | undefined): string {
-  return [...(values ?? [])].sort().join('\u0000')
-}
-
-function sortedLogins(users: readonly { login: string | null | undefined }[] | undefined): string {
-  return [...(users ?? [])]
-    .map((user) => user.login ?? '')
-    .sort()
-    .join('\u0000')
-}
-
-function taskPageWorkItemStatusSignature(item: GitHubWorkItem): string {
-  return JSON.stringify([
-    item.type,
-    item.number,
-    item.title,
-    item.state,
-    item.url,
-    item.author,
-    item.branchName ?? null,
-    item.baseRefName ?? null,
-    sortedStrings(item.labels),
-    sortedLogins(item.assignees),
-    sortedLogins(item.reviewRequests),
-    item.reviewDecision ?? null,
-    item.checksSummary?.state ?? null,
-    item.checksSummary?.total ?? null,
-    item.checksSummary?.failed ?? null,
-    item.checksSummary?.pending ?? null,
-    item.mergeable ?? null,
-    item.autoMergeEnabled ?? null,
-    item.autoMergeAllowed ?? null,
-    item.mergeQueueRequired ?? null,
-    item.mergeStateStatus ?? null,
-    item.updatedAt
-  ])
-}
-
-function taskPageWorkItemKeyOrderSignature(items: readonly GitHubWorkItem[]): string {
-  return items.map(taskPageWorkItemKey).join('\u0000')
-}
-
-function taskPageWorkItemPaginationBoundary(items: readonly GitHubWorkItem[]): string | null {
-  return items.at(-1)?.updatedAt ?? null
-}
-
 export function shouldReplaceTaskPageItemsAfterRefresh(
   currentItems: readonly GitHubWorkItem[],
   refreshedItems: readonly GitHubWorkItem[]
@@ -273,66 +230,6 @@ export function reconcileTaskPagePagesAfterLandingRefresh(
   return [nextFirstPage, ...pages.slice(1)]
 }
 
-function linearIssueKey(issue: LinearIssue): string {
-  return issue.id
-}
-
-function linearIssueStatusSignature(issue: LinearIssue): string {
-  return JSON.stringify([
-    issue.identifier,
-    issue.title,
-    issue.url,
-    issue.state.name,
-    issue.state.type,
-    issue.state.color,
-    issue.team.id,
-    issue.team.name,
-    issue.team.key,
-    sortedStrings(issue.labels),
-    issue.assignee?.id ?? null,
-    issue.assignee?.displayName ?? null,
-    issue.priority,
-    issue.updatedAt
-  ])
-}
-
-export function shouldReplaceTaskPageLinearIssuesAfterRefresh(
-  currentIssues: readonly LinearIssue[],
-  refreshedIssues: readonly LinearIssue[]
-): boolean {
-  if (currentIssues.length !== refreshedIssues.length) {
-    return true
-  }
-  const currentKeys = new Set(currentIssues.map(linearIssueKey))
-  for (const issue of refreshedIssues) {
-    if (!currentKeys.has(linearIssueKey(issue))) {
-      return true
-    }
-  }
-  return false
-}
-
-export function reconcileTaskPageLinearIssuesAfterLandingRefresh(
-  currentIssues: readonly LinearIssue[],
-  refreshedIssues: readonly LinearIssue[]
-): LinearIssue[] {
-  if (shouldReplaceTaskPageLinearIssuesAfterRefresh(currentIssues, refreshedIssues)) {
-    return [...refreshedIssues]
-  }
-
-  const refreshedByKey = new Map(refreshedIssues.map((issue) => [linearIssueKey(issue), issue]))
-  let changed = false
-  const next = currentIssues.map((issue) => {
-    const refreshed = refreshedByKey.get(linearIssueKey(issue))
-    if (!refreshed || linearIssueStatusSignature(issue) === linearIssueStatusSignature(refreshed)) {
-      return issue
-    }
-    changed = true
-    return refreshed
-  })
-  return changed ? next : (currentIssues as LinearIssue[])
-}
-
 export function findTaskPageDialogWorkItem(
   workItemsCache: WorkItemsCache,
   dialogWorkItemKey: TaskPageDialogWorkItemKey
@@ -351,34 +248,3 @@ export function findTaskPageDialogWorkItem(
   }
   return null
 }
-
-export function findTaskPageLinearIssue(
-  linearIssueCache: LinearIssueCache,
-  linearSearchCache: LinearSearchCache,
-  linearListCache: LinearListCache,
-  linearIssueId: string | null
-): LinearIssue | null {
-  if (!linearIssueId) {
-    return null
-  }
-  for (const entry of Object.values(linearIssueCache)) {
-    if (entry?.data?.id === linearIssueId) {
-      return entry.data
-    }
-  }
-  for (const entry of Object.values(linearSearchCache)) {
-    const found = entry?.data?.find((issue) => issue.id === linearIssueId)
-    if (found) {
-      return found
-    }
-  }
-  for (const entry of Object.values(linearListCache)) {
-    const found = entry?.data?.items.find((issue) => issue.id === linearIssueId)
-    if (found) {
-      return found
-    }
-  }
-  return null
-}
-
-export const findTaskPageLinearDrawerIssue = findTaskPageLinearIssue

--- a/src/renderer/src/components/task-page-linear-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-linear-cache-selectors.ts
@@ -1,0 +1,92 @@
+import type { CacheEntry } from '@/store/slices/github'
+import type { LinearCollectionResult, LinearIssue } from '../../../shared/types'
+import { sortedStrings } from './task-page-work-item-signatures'
+
+type LinearIssueCache = Record<string, CacheEntry<LinearIssue>>
+type LinearSearchCache = Record<string, CacheEntry<LinearIssue[]>>
+type LinearListCache = Record<string, CacheEntry<LinearCollectionResult<LinearIssue>>>
+
+function linearIssueKey(issue: LinearIssue): string {
+  return issue.id
+}
+
+function linearIssueStatusSignature(issue: LinearIssue): string {
+  return JSON.stringify([
+    issue.identifier,
+    issue.title,
+    issue.url,
+    issue.state.name,
+    issue.state.type,
+    issue.state.color,
+    issue.team.id,
+    issue.team.name,
+    issue.team.key,
+    sortedStrings(issue.labels),
+    issue.assignee?.id ?? null,
+    issue.assignee?.displayName ?? null,
+    issue.priority,
+    issue.updatedAt
+  ])
+}
+
+export function shouldReplaceTaskPageLinearIssuesAfterRefresh(
+  currentIssues: readonly LinearIssue[],
+  refreshedIssues: readonly LinearIssue[]
+): boolean {
+  if (currentIssues.length !== refreshedIssues.length) {
+    return true
+  }
+  const currentKeys = new Set(currentIssues.map(linearIssueKey))
+  return refreshedIssues.some((issue) => !currentKeys.has(linearIssueKey(issue)))
+}
+
+export function reconcileTaskPageLinearIssuesAfterLandingRefresh(
+  currentIssues: readonly LinearIssue[],
+  refreshedIssues: readonly LinearIssue[]
+): LinearIssue[] {
+  if (shouldReplaceTaskPageLinearIssuesAfterRefresh(currentIssues, refreshedIssues)) {
+    return [...refreshedIssues]
+  }
+  const refreshedByKey = new Map(refreshedIssues.map((issue) => [linearIssueKey(issue), issue]))
+  let changed = false
+  const next = currentIssues.map((issue) => {
+    const refreshed = refreshedByKey.get(linearIssueKey(issue))
+    if (!refreshed || linearIssueStatusSignature(issue) === linearIssueStatusSignature(refreshed)) {
+      return issue
+    }
+    changed = true
+    return refreshed
+  })
+  return changed ? next : (currentIssues as LinearIssue[])
+}
+
+export function findTaskPageLinearIssue(
+  linearIssueCache: LinearIssueCache,
+  linearSearchCache: LinearSearchCache,
+  linearListCache: LinearListCache,
+  linearIssueId: string | null
+): LinearIssue | null {
+  if (!linearIssueId) {
+    return null
+  }
+  for (const entry of Object.values(linearIssueCache)) {
+    if (entry?.data?.id === linearIssueId) {
+      return entry.data
+    }
+  }
+  for (const entry of Object.values(linearSearchCache)) {
+    const found = entry?.data?.find((issue) => issue.id === linearIssueId)
+    if (found) {
+      return found
+    }
+  }
+  for (const entry of Object.values(linearListCache)) {
+    const found = entry?.data?.items.find((issue) => issue.id === linearIssueId)
+    if (found) {
+      return found
+    }
+  }
+  return null
+}
+
+export const findTaskPageLinearDrawerIssue = findTaskPageLinearIssue

--- a/src/renderer/src/components/task-page-pr-check-summary.test.ts
+++ b/src/renderer/src/components/task-page-pr-check-summary.test.ts
@@ -20,7 +20,8 @@ describe('deriveTaskPagePRCheckSummary', () => {
       total: 0,
       passed: 0,
       failed: 0,
-      pending: 0
+      pending: 0,
+      neutral: 0
     })
   })
 
@@ -36,11 +37,12 @@ describe('deriveTaskPagePRCheckSummary', () => {
       total: 3,
       passed: 1,
       failed: 1,
-      pending: 1
+      pending: 1,
+      neutral: 0
     })
   })
 
-  it('treats neutral and skipped checks as passed for the compact PR table label', () => {
+  it('keeps neutral checks out of passed while skipped checks pass', () => {
     expect(
       deriveTaskPagePRCheckSummary([
         check({ conclusion: 'success' }),
@@ -48,11 +50,12 @@ describe('deriveTaskPagePRCheckSummary', () => {
         check({ conclusion: 'skipped' })
       ])
     ).toEqual({
-      state: 'success',
+      state: 'neutral',
       total: 3,
-      passed: 3,
+      passed: 2,
       failed: 0,
-      pending: 0
+      pending: 0,
+      neutral: 1
     })
   })
 
@@ -67,7 +70,23 @@ describe('deriveTaskPagePRCheckSummary', () => {
       total: 2,
       passed: 1,
       failed: 1,
-      pending: 0
+      pending: 0,
+      neutral: 0
+    })
+  })
+
+  it('keeps unknown completed outcomes neutral', () => {
+    expect(
+      deriveTaskPagePRCheckSummary([
+        check({ conclusion: 'future_state' as PRCheckDetail['conclusion'] })
+      ])
+    ).toEqual({
+      state: 'neutral',
+      total: 1,
+      passed: 0,
+      failed: 0,
+      pending: 0,
+      neutral: 1
     })
   })
 })

--- a/src/renderer/src/components/task-page-pr-check-summary.ts
+++ b/src/renderer/src/components/task-page-pr-check-summary.ts
@@ -14,17 +14,20 @@ function isPendingCheck(check: PRCheckDetail): boolean {
 
 export function deriveTaskPagePRCheckSummary(checks: PRCheckDetail[]): GitHubPRCheckSummary {
   if (checks.length === 0) {
-    return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0 }
+    return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0, neutral: 0 }
   }
 
   let passed = 0
   let failed = 0
   let pending = 0
+  let neutral = 0
 
   for (const check of checks) {
     const conclusion = getCheckConclusion(check)
-    if (conclusion === 'success' || conclusion === 'neutral' || conclusion === 'skipped') {
+    if (conclusion === 'success' || conclusion === 'skipped') {
       passed += 1
+    } else if (conclusion === 'neutral') {
+      neutral += 1
     } else if (
       conclusion === 'failure' ||
       conclusion === 'timed_out' ||
@@ -37,15 +40,16 @@ export function deriveTaskPagePRCheckSummary(checks: PRCheckDetail[]): GitHubPRC
     } else if (isPendingCheck(check)) {
       pending += 1
     } else {
-      passed += 1
+      neutral += 1
     }
   }
 
   return {
-    state: failed > 0 ? 'failure' : pending > 0 ? 'pending' : 'success',
+    state: failed > 0 ? 'failure' : pending > 0 ? 'pending' : neutral > 0 ? 'neutral' : 'success',
     total: checks.length,
     passed,
     failed,
-    pending
+    pending,
+    neutral
   }
 }

--- a/src/renderer/src/components/task-page-pr-check-summary.ts
+++ b/src/renderer/src/components/task-page-pr-check-summary.ts
@@ -1,4 +1,4 @@
-import type { GitHubPRCheckSummary, PRCheckDetail } from '../../../shared/types'
+import type { PRCheckDetail, ProviderCheckSummary } from '../../../shared/types'
 
 function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDetail['conclusion']> {
   return check.conclusion ?? 'pending'
@@ -12,7 +12,7 @@ function isPendingCheck(check: PRCheckDetail): boolean {
   )
 }
 
-export function deriveTaskPagePRCheckSummary(checks: PRCheckDetail[]): GitHubPRCheckSummary {
+export function deriveTaskPagePRCheckSummary(checks: PRCheckDetail[]): ProviderCheckSummary {
   if (checks.length === 0) {
     return { state: 'none', total: 0, passed: 0, failed: 0, pending: 0, neutral: 0 }
   }

--- a/src/renderer/src/components/task-page-work-item-signatures.ts
+++ b/src/renderer/src/components/task-page-work-item-signatures.ts
@@ -1,0 +1,54 @@
+import type { GitHubWorkItem } from '../../../shared/types'
+
+export function taskPageWorkItemKey(item: GitHubWorkItem): string {
+  return `${item.repoId}\u0000${item.id}`
+}
+
+export function sortedStrings(values: readonly string[] | undefined): string {
+  return [...(values ?? [])].sort().join('\u0000')
+}
+
+function sortedLogins(users: readonly { login: string | null | undefined }[] | undefined): string {
+  return [...(users ?? [])]
+    .map((user) => user.login ?? '')
+    .sort()
+    .join('\u0000')
+}
+
+export function taskPageWorkItemStatusSignature(item: GitHubWorkItem): string {
+  return JSON.stringify([
+    item.type,
+    item.number,
+    item.title,
+    item.state,
+    item.url,
+    item.author,
+    item.branchName ?? null,
+    item.baseRefName ?? null,
+    sortedStrings(item.labels),
+    sortedLogins(item.assignees),
+    sortedLogins(item.reviewRequests),
+    item.reviewDecision ?? null,
+    item.checksSummary?.state ?? null,
+    item.checksSummary?.total ?? null,
+    item.checksSummary?.failed ?? null,
+    item.checksSummary?.pending ?? null,
+    item.checksSummary?.neutral ?? null,
+    item.mergeable ?? null,
+    item.autoMergeEnabled ?? null,
+    item.autoMergeAllowed ?? null,
+    item.mergeQueueRequired ?? null,
+    item.mergeStateStatus ?? null,
+    item.updatedAt
+  ])
+}
+
+export function taskPageWorkItemKeyOrderSignature(items: readonly GitHubWorkItem[]): string {
+  return items.map(taskPageWorkItemKey).join('\u0000')
+}
+
+export function taskPageWorkItemPaginationBoundary(
+  items: readonly GitHubWorkItem[]
+): string | null {
+  return items.at(-1)?.updatedAt ?? null
+}

--- a/src/renderer/src/store/slices/github-checks.test.ts
+++ b/src/renderer/src/store/slices/github-checks.test.ts
@@ -15,6 +15,13 @@ describe('deriveCheckStatusFromChecks', () => {
     ]
     expect(deriveCheckStatusFromChecks(checks)).toBe('failure')
   })
+
+  it('keeps an unknown terminal conclusion neutral rather than pending', () => {
+    const checks = [
+      { name: 'future-check', status: 'completed', conclusion: 'future_state', url: null }
+    ] as unknown as PRCheckDetail[]
+    expect(deriveCheckStatusFromChecks(checks)).toBe('neutral')
+  })
 })
 
 describe('normalizeBranchName', () => {

--- a/src/renderer/src/store/slices/github-checks.ts
+++ b/src/renderer/src/store/slices/github-checks.ts
@@ -1,42 +1,14 @@
 import type { AppState } from '../types'
-import type { PRCheckDetail, CheckStatus, GitHubOwnerRepo } from '../../../../shared/types'
+import type { PRCheckDetail, GitHubOwnerRepo } from '../../../../shared/types'
 import { getGitHubPRCacheKey } from './github-cache-key'
 import { githubRepoIdentityKey } from '../../../../shared/github-repository-identity-key'
+import { derivePRCheckStatus } from '../../../../shared/pr-check-status'
 
 export function normalizeBranchName(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
 
-export function deriveCheckStatusFromChecks(checks: PRCheckDetail[]): CheckStatus {
-  if (checks.length === 0) {
-    return 'neutral'
-  }
-
-  let hasPending = false
-
-  for (const check of checks) {
-    if (
-      check.conclusion === 'failure' ||
-      check.conclusion === 'timed_out' ||
-      check.conclusion === 'cancelled' ||
-      // Why: action_required (e.g. an unapproved workflow run) blocks merge until
-      // someone acts; treat it as needs-attention rather than a silent pass.
-      check.conclusion === 'action_required'
-    ) {
-      return 'failure'
-    }
-
-    if (
-      check.status === 'queued' ||
-      check.status === 'in_progress' ||
-      check.conclusion === 'pending'
-    ) {
-      hasPending = true
-    }
-  }
-
-  return hasPending ? 'pending' : 'success'
-}
+export const deriveCheckStatusFromChecks = derivePRCheckStatus
 
 export function syncPRChecksStatus(
   state: AppState,

--- a/src/shared/gitlab-pipeline-checks.test.ts
+++ b/src/shared/gitlab-pipeline-checks.test.ts
@@ -49,7 +49,7 @@ describe('gitLabPipelineJobsToPRChecks', () => {
       {
         name: 'deploy: deploy',
         status: 'completed',
-        conclusion: 'neutral',
+        conclusion: 'action_required',
         url: null
       },
       {

--- a/src/shared/gitlab-pipeline-checks.ts
+++ b/src/shared/gitlab-pipeline-checks.ts
@@ -35,10 +35,8 @@ export function mapGitLabPipelineJobStatusToConclusion(
   if (s === 'skipped') {
     return 'skipped'
   }
-  // Why: manual GitLab jobs are intentionally waiting for a human trigger;
-  // treating them as pending would make the Checks tab look stuck forever.
-  if (s === 'manual') {
-    return 'neutral'
+  if (s === 'manual' || s === 'action_required') {
+    return 'action_required'
   }
   if (
     s === 'created' ||

--- a/src/shared/gitlab-types.ts
+++ b/src/shared/gitlab-types.ts
@@ -1,5 +1,5 @@
 /* GitLab-specific shared types, split from `./types` to avoid merge conflicts on upstream syncs; re-exported from `./types` for import stability. */
-import type { CheckStatus, ClassifiedError, PRConflictSummary } from './types'
+import type { CheckStatus, ClassifiedError, PRConflictSummary, ProviderCheckSummary } from './types'
 
 // Why: flat owner/repo is inadequate — projects nest (`group/subgroup/project`) and self-hosted hosts must travel with the path for URL/glab targeting.
 export type GitLabProjectRef = { host: string; path: string }
@@ -172,6 +172,7 @@ export type GitLabWorkItem = {
   repoId: string
   /** Exact GitLab project that produced this row — mutations/details use it instead of re-resolving the repo preference. */
   projectRef?: GitLabProjectRef
+  checksSummary?: ProviderCheckSummary
 }
 
 export type GitLabMRFile = {

--- a/src/shared/gitlab-types.ts
+++ b/src/shared/gitlab-types.ts
@@ -1,5 +1,6 @@
 /* GitLab-specific shared types, split from `./types` to avoid merge conflicts on upstream syncs; re-exported from `./types` for import stability. */
 import type { CheckStatus, ClassifiedError, PRConflictSummary, ProviderCheckSummary } from './types'
+import type { HostedReviewDecision } from './hosted-review'
 
 // Why: flat owner/repo is inadequate — projects nest (`group/subgroup/project`) and self-hosted hosts must travel with the path for URL/glab targeting.
 export type GitLabProjectRef = { host: string; path: string }
@@ -173,6 +174,9 @@ export type GitLabWorkItem = {
   /** Exact GitLab project that produced this row — mutations/details use it instead of re-resolving the repo preference. */
   projectRef?: GitLabProjectRef
   checksSummary?: ProviderCheckSummary
+  mergeable?: MRMergeableState
+  reviewDecision?: HostedReviewDecision
+  reviewerCount?: number
 }
 
 export type GitLabMRFile = {

--- a/src/shared/hosted-review-github.ts
+++ b/src/shared/hosted-review-github.ts
@@ -1,5 +1,6 @@
 import type { PRCheckDetail, PRComment, PRInfo } from './types'
 import type { HostedReviewInfo, HostedReviewQueueSummary } from './hosted-review'
+import { derivePRCheckStatus } from './pr-check-status'
 
 export type HostedReviewFromGitHubPRInfoArgs = {
   pr: PRInfo
@@ -32,33 +33,10 @@ function deriveChecksStatus(
   prChecksStatus: PRInfo['checksStatus'],
   checks?: PRCheckDetail[]
 ): PRInfo['checksStatus'] {
-  if (!checks || checks.length === 0) {
+  if (!checks) {
     return prChecksStatus
   }
-  const hasFailure = checks.some(
-    (check) =>
-      check.conclusion === 'failure' ||
-      check.conclusion === 'timed_out' ||
-      check.conclusion === 'cancelled' ||
-      // Why: action_required (e.g. a workflow awaiting approval) blocks merge;
-      // treat it as failure so the review queue doesn't report a clean PR.
-      check.conclusion === 'action_required'
-  )
-  if (hasFailure) {
-    return 'failure'
-  }
-  const hasPending = checks.some(
-    (check) =>
-      check.status !== 'completed' || check.conclusion === null || check.conclusion === 'pending'
-  )
-  if (hasPending) {
-    return 'pending'
-  }
-  const hasSuccess = checks.some((check) => check.conclusion === 'success')
-  if (hasSuccess) {
-    return 'success'
-  }
-  return 'neutral'
+  return derivePRCheckStatus(checks)
 }
 
 export function hostedReviewSummaryFromGitHubPRInfo(

--- a/src/shared/hosted-review-gitlab.ts
+++ b/src/shared/hosted-review-gitlab.ts
@@ -1,5 +1,6 @@
 import type { HostedReviewInfo, HostedReviewQueueSummary } from './hosted-review'
 import type { PRCheckDetail, PRComment } from './types'
+import { derivePRCheckStatus } from './pr-check-status'
 
 export type HostedReviewFromGitLabInfoArgs = {
   review: HostedReviewInfo & { provider: 'gitlab' }
@@ -58,27 +59,10 @@ function deriveChecksStatus(
   reviewStatus: HostedReviewInfo['status'],
   checks?: PRCheckDetail[]
 ): HostedReviewInfo['status'] {
-  if (!checks || checks.length === 0) {
+  if (!checks) {
     return reviewStatus
   }
-  const hasFailure = checks.some(
-    (check) => check.conclusion === 'failure' || check.conclusion === 'timed_out'
-  )
-  if (hasFailure) {
-    return 'failure'
-  }
-  const hasPending = checks.some(
-    (check) =>
-      check.status !== 'completed' || check.conclusion === null || check.conclusion === 'pending'
-  )
-  if (hasPending) {
-    return 'pending'
-  }
-  const hasSuccess = checks.some((check) => check.conclusion === 'success')
-  if (hasSuccess) {
-    return 'success'
-  }
-  return 'neutral'
+  return derivePRCheckStatus(checks)
 }
 
 export function hostedReviewSummaryFromGitLabInfo(

--- a/src/shared/pr-check-severity-order.test.ts
+++ b/src/shared/pr-check-severity-order.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import type { PRCheckDetail } from './types'
 import { getCheckSeverityRank, sortChecksBySeverity } from './pr-check-severity-order'
 
 const check = (name: string, conclusion: string | null) =>
-  ({ name, conclusion }) as { name: string; conclusion: never }
+  ({ name, conclusion }) as Pick<PRCheckDetail, 'name' | 'conclusion'>
 
 describe('PR check severity order', () => {
   it('keeps passing checks above the skipped and neutral noise', () => {
@@ -38,6 +39,36 @@ describe('PR check severity order', () => {
       'pending',
       'success',
       'skipped'
+    ])
+  })
+
+  it('covers every known conclusion and preserves input order within equal ranks', () => {
+    const sorted = sortChecksBySeverity([
+      check('success-a', 'success'),
+      check('unknown', 'future_state'),
+      check('skipped', 'skipped'),
+      check('action-required', 'action_required'),
+      check('pending', 'pending'),
+      check('timed-out', 'timed_out'),
+      check('neutral', 'neutral'),
+      check('cancelled', 'cancelled'),
+      check('failure', 'failure'),
+      check('success-b', 'success'),
+      check('failure-b', 'failure-b')
+    ])
+
+    expect(sorted.map((c) => c.name)).toEqual([
+      'action-required',
+      'timed-out',
+      'failure',
+      'cancelled',
+      'pending',
+      'success-a',
+      'success-b',
+      'neutral',
+      'skipped',
+      'unknown',
+      'failure-b'
     ])
   })
 

--- a/src/shared/pr-check-severity-order.test.ts
+++ b/src/shared/pr-check-severity-order.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { PRCheckDetail } from './types'
 import { getCheckSeverityRank, sortChecksBySeverity } from './pr-check-severity-order'
+import { mapGitLabPipelineJobStatusToConclusion } from './gitlab-pipeline-checks'
 
 const check = (name: string, conclusion: string | null) =>
   ({ name, conclusion }) as Pick<PRCheckDetail, 'name' | 'conclusion'>
@@ -104,5 +105,22 @@ describe('PR check severity order', () => {
     const checks = [check('success', 'success'), check('failure', 'failure')]
     sortChecksBySeverity(checks)
     expect(checks.map((c) => c.name)).toEqual(['success', 'failure'])
+  })
+
+  it('orders normalized provider states with stable ties', () => {
+    const checks = [
+      // Preserve an unrecognized provider value so it remains visibly unknown.
+      check('future', 'future_state'),
+      check('manual', mapGitLabPipelineJobStatusToConclusion('manual')),
+      check('pass-a', 'success'),
+      check('pass-b', 'success')
+    ]
+
+    expect(sortChecksBySeverity(checks).map((item) => item.name)).toEqual([
+      'manual',
+      'pass-a',
+      'pass-b',
+      'future'
+    ])
   })
 })

--- a/src/shared/pr-check-severity-order.test.ts
+++ b/src/shared/pr-check-severity-order.test.ts
@@ -47,6 +47,23 @@ describe('PR check severity order', () => {
     )
   })
 
+  // Why: an object-literal rank table would resolve these off Object.prototype and
+  // return a function, turning the comparator into NaN and scrambling the list.
+  it('treats prototype property names as unknown conclusions', () => {
+    for (const inherited of ['constructor', 'toString', 'hasOwnProperty', '__proto__']) {
+      expect(getCheckSeverityRank(inherited)).toBe(
+        getCheckSeverityRank('stale_from_a_future_github')
+      )
+    }
+
+    const sorted = sortChecksBySeverity([
+      check('inherited', 'constructor'),
+      check('failure', 'failure'),
+      check('success', 'success')
+    ])
+    expect(sorted.map((c) => c.name)).toEqual(['failure', 'success', 'inherited'])
+  })
+
   it('treats a missing conclusion as pending', () => {
     expect(getCheckSeverityRank(null)).toBe(getCheckSeverityRank('pending'))
     expect(getCheckSeverityRank(undefined)).toBe(getCheckSeverityRank('pending'))

--- a/src/shared/pr-check-severity-order.test.ts
+++ b/src/shared/pr-check-severity-order.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { getCheckSeverityRank, sortChecksBySeverity } from './pr-check-severity-order'
+
+const check = (name: string, conclusion: string | null) =>
+  ({ name, conclusion }) as { name: string; conclusion: never }
+
+describe('PR check severity order', () => {
+  it('keeps passing checks above the skipped and neutral noise', () => {
+    const sorted = sortChecksBySeverity([
+      check('daily-cleanup', 'skipped'),
+      check('Test Results', 'success'),
+      check('build-admin', 'skipped'),
+      check('advisory', 'neutral'),
+      check('Validate Configs', 'success')
+    ])
+
+    expect(sorted.map((c) => c.name)).toEqual([
+      'Test Results',
+      'Validate Configs',
+      'advisory',
+      'daily-cleanup',
+      'build-admin'
+    ])
+  })
+
+  it('orders failures, then in-flight work, then successes', () => {
+    const sorted = sortChecksBySeverity([
+      check('success', 'success'),
+      check('skipped', 'skipped'),
+      check('pending', null),
+      check('cancelled', 'cancelled'),
+      check('failure', 'failure')
+    ])
+
+    expect(sorted.map((c) => c.name)).toEqual([
+      'failure',
+      'cancelled',
+      'pending',
+      'success',
+      'skipped'
+    ])
+  })
+
+  it('sinks unknown conclusions below every known state', () => {
+    expect(getCheckSeverityRank('stale_from_a_future_github')).toBeGreaterThan(
+      getCheckSeverityRank('skipped')
+    )
+  })
+
+  it('treats a missing conclusion as pending', () => {
+    expect(getCheckSeverityRank(null)).toBe(getCheckSeverityRank('pending'))
+    expect(getCheckSeverityRank(undefined)).toBe(getCheckSeverityRank('pending'))
+  })
+
+  it('leaves the input array untouched', () => {
+    const checks = [check('success', 'success'), check('failure', 'failure')]
+    sortChecksBySeverity(checks)
+    expect(checks.map((c) => c.name)).toEqual(['success', 'failure'])
+  })
+})

--- a/src/shared/pr-check-severity-order.ts
+++ b/src/shared/pr-check-severity-order.ts
@@ -2,22 +2,24 @@ import type { PRCheckDetail } from './types'
 
 // Why: `neutral`/`skipped` carry no signal, so they sink below `success` — otherwise a
 // wall of skipped jobs buries the passing checks a reviewer actually reads.
-const CHECK_SEVERITY_RANK: Record<string, number> = {
-  failure: 0,
-  timed_out: 0,
-  action_required: 0,
-  cancelled: 1,
-  pending: 2,
-  success: 3,
-  neutral: 4,
-  skipped: 5
-}
+// A Map, not an object: conclusions arrive from provider payloads, and an object
+// would resolve `constructor`/`toString` off the prototype into a non-number rank.
+const CHECK_SEVERITY_RANK = new Map<string, number>([
+  ['failure', 0],
+  ['timed_out', 0],
+  ['action_required', 0],
+  ['cancelled', 1],
+  ['pending', 2],
+  ['success', 3],
+  ['neutral', 4],
+  ['skipped', 5]
+])
 
 // Why: an unrecognized conclusion sinks to the bottom instead of masquerading as `neutral`.
 const UNKNOWN_CHECK_RANK = 6
 
 export function getCheckSeverityRank(conclusion: string | null | undefined): number {
-  return CHECK_SEVERITY_RANK[conclusion ?? 'pending'] ?? UNKNOWN_CHECK_RANK
+  return CHECK_SEVERITY_RANK.get(conclusion ?? 'pending') ?? UNKNOWN_CHECK_RANK
 }
 
 export function sortChecksBySeverity<T extends Pick<PRCheckDetail, 'conclusion'>>(

--- a/src/shared/pr-check-severity-order.ts
+++ b/src/shared/pr-check-severity-order.ts
@@ -1,0 +1,29 @@
+import type { PRCheckDetail } from './types'
+
+// Why: `neutral`/`skipped` carry no signal, so they sink below `success` — otherwise a
+// wall of skipped jobs buries the passing checks a reviewer actually reads.
+const CHECK_SEVERITY_RANK: Record<string, number> = {
+  failure: 0,
+  timed_out: 0,
+  action_required: 0,
+  cancelled: 1,
+  pending: 2,
+  success: 3,
+  neutral: 4,
+  skipped: 5
+}
+
+// Why: an unrecognized conclusion sinks to the bottom instead of masquerading as `neutral`.
+const UNKNOWN_CHECK_RANK = 6
+
+export function getCheckSeverityRank(conclusion: string | null | undefined): number {
+  return CHECK_SEVERITY_RANK[conclusion ?? 'pending'] ?? UNKNOWN_CHECK_RANK
+}
+
+export function sortChecksBySeverity<T extends Pick<PRCheckDetail, 'conclusion'>>(
+  checks: readonly T[]
+): T[] {
+  return [...checks].sort(
+    (a, b) => getCheckSeverityRank(a.conclusion) - getCheckSeverityRank(b.conclusion)
+  )
+}

--- a/src/shared/pr-check-severity-order.ts
+++ b/src/shared/pr-check-severity-order.ts
@@ -25,7 +25,12 @@ export function getCheckSeverityRank(conclusion: string | null | undefined): num
 export function sortChecksBySeverity<T extends Pick<PRCheckDetail, 'conclusion'>>(
   checks: readonly T[]
 ): T[] {
-  return [...checks].sort(
-    (a, b) => getCheckSeverityRank(a.conclusion) - getCheckSeverityRank(b.conclusion)
-  )
+  return checks
+    .map((check, index) => ({ check, index }))
+    .sort(
+      (a, b) =>
+        getCheckSeverityRank(a.check.conclusion) - getCheckSeverityRank(b.check.conclusion) ||
+        a.index - b.index
+    )
+    .map(({ check }) => check)
 }

--- a/src/shared/pr-check-status.test.ts
+++ b/src/shared/pr-check-status.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from './pr-check-status'
+import type { PRCheckDetail } from './types'
+
+const check = (
+  status: PRCheckDetail['status'],
+  conclusion: PRCheckDetail['conclusion']
+): PRCheckDetail => ({ name: 'ci', status, conclusion, url: null })
+
+describe('provider-neutral check status', () => {
+  it('keeps explicit nonterminal and missing-conclusion checks pending', () => {
+    expect(derivePRCheckStatus([check('queued', null)])).toBe('pending')
+    expect(derivePRCheckStatus([check('in_progress', null)])).toBe('pending')
+    expect(derivePRCheckStatus([check('completed', 'pending')])).toBe('pending')
+  })
+
+  it('keeps completed unknown conclusions neutral while preserving attention states', () => {
+    expect(derivePRCheckStatus([check('completed', null)])).toBe('neutral')
+    expect(
+      derivePRCheckStatus([check('completed', 'future_state' as PRCheckDetail['conclusion'])])
+    ).toBe('neutral')
+    expect(derivePRCheckStatus([check('completed', 'action_required')])).toBe('failure')
+  })
+
+  it('normalizes GitHub-style rollups without turning malformed data into success', () => {
+    expect(derivePRCheckStatusFromRollup([{ status: 'IN_PROGRESS', conclusion: null }])).toBe(
+      'pending'
+    )
+    expect(
+      derivePRCheckStatusFromRollup([{ status: 'COMPLETED', conclusion: 'future_state' }])
+    ).toBe('neutral')
+    expect(derivePRCheckStatusFromRollup([{}])).toBe('neutral')
+    expect(derivePRCheckStatusFromRollup([{ state: 'PENDING' }])).toBe('pending')
+    expect(derivePRCheckStatusFromRollup([{ state: 'ERROR' }])).toBe('failure')
+  })
+})

--- a/src/shared/pr-check-status.ts
+++ b/src/shared/pr-check-status.ts
@@ -34,3 +34,41 @@ export function derivePRCheckStatus(checks: readonly PRCheckDetail[]): CheckStat
   }
   return hasSuccess ? 'success' : 'neutral'
 }
+
+type RawCheckRollup = { status?: unknown; conclusion?: unknown; state?: unknown }
+
+function normalizeRollupCheck(raw: RawCheckRollup, index: number): PRCheckDetail {
+  const status = String(raw.status ?? '').toLowerCase()
+  const state = String(raw.state ?? '').toLowerCase()
+  const conclusion = String(raw.conclusion ?? '').toLowerCase()
+  const normalizedConclusion =
+    conclusion ||
+    (state === 'failure' || state === 'error' ? 'failure' : state === 'success' ? 'success' : '')
+  const isPending =
+    status === 'queued' ||
+    status === 'in_progress' ||
+    status === 'pending' ||
+    state === 'pending' ||
+    conclusion === 'pending'
+
+  return {
+    name: `check-${index}`,
+    status: isPending ? (status === 'in_progress' ? 'in_progress' : 'queued') : 'completed',
+    conclusion: (isPending
+      ? 'pending'
+      : normalizedConclusion || null) as PRCheckDetail['conclusion'],
+    url: null
+  }
+}
+
+/** Derives status from provider rollups while retaining status/conclusion semantics. */
+export function derivePRCheckStatusFromRollup(rollup: unknown): CheckStatus {
+  if (!Array.isArray(rollup) || rollup.length === 0) {
+    return 'neutral'
+  }
+  return derivePRCheckStatus(
+    rollup.map((raw, index) =>
+      normalizeRollupCheck(raw && typeof raw === 'object' ? (raw as RawCheckRollup) : {}, index)
+    )
+  )
+}

--- a/src/shared/pr-check-status.ts
+++ b/src/shared/pr-check-status.ts
@@ -1,0 +1,36 @@
+import type { CheckStatus, PRCheckDetail } from './types'
+
+/** Derives the review status from the normalized check contract. */
+export function derivePRCheckStatus(checks: readonly PRCheckDetail[]): CheckStatus {
+  if (checks.length === 0) {
+    return 'neutral'
+  }
+
+  let hasPending = false
+  let hasSuccess = false
+  for (const check of checks) {
+    if (
+      check.conclusion === 'failure' ||
+      check.conclusion === 'timed_out' ||
+      check.conclusion === 'cancelled' ||
+      check.conclusion === 'action_required'
+    ) {
+      return 'failure'
+    }
+    if (
+      check.status === 'queued' ||
+      check.status === 'in_progress' ||
+      check.conclusion === 'pending'
+    ) {
+      hasPending = true
+    }
+    if (check.conclusion === 'success') {
+      hasSuccess = true
+    }
+  }
+
+  if (hasPending) {
+    return 'pending'
+  }
+  return hasSuccess ? 'success' : 'neutral'
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1542,7 +1542,7 @@ export type GitHubAssignableUser = {
   avatarUrl: string
 }
 
-export type GitHubPRCheckSummary = {
+export type ProviderCheckSummary = {
   state: 'success' | 'failure' | 'pending' | 'neutral' | 'none'
   total: number
   passed: number
@@ -1587,7 +1587,7 @@ export type GitHubWorkItem = {
   reviewRequests?: GitHubAssignableUser[]
   latestReviews?: GitHubPRReviewSummary[]
   assignees?: GitHubAssignableUser[]
-  checksSummary?: GitHubPRCheckSummary
+  checksSummary?: ProviderCheckSummary
   mergeable?: PRMergeableState
   autoMergeEnabled?: boolean
   autoMergeAllowed?: boolean | null

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1543,11 +1543,12 @@ export type GitHubAssignableUser = {
 }
 
 export type GitHubPRCheckSummary = {
-  state: 'success' | 'failure' | 'pending' | 'none'
+  state: 'success' | 'failure' | 'pending' | 'neutral' | 'none'
   total: number
   passed: number
   failed: number
   pending: number
+  neutral: number
 }
 
 export type GitHubPRReviewSummary = {


### PR DESCRIPTION
## Summary

The PR checks list sorted `skipped` and `neutral` **above** `success`, so on a repo where most workflow jobs are conditional, the checks panel opens on a wall of `Skipped` rows and every passing check sits below the fold. You have to scroll past a dozen no-op jobs to learn whether anything actually ran.

The rank map lived in three duplicated copies (`checks-panel-content.tsx`, `PullRequestPage.tsx`, `GitHubItemDialog.tsx`), all with `neutral: 3, skipped: 4, success: 5`.

This PR moves the no-signal conclusions to the bottom and extracts the single ordering into `src/shared/pr-check-severity-order.ts`:

| | before | after |
|---|---|---|
| `failure` / `timed_out` / `action_required` | 0 | 0 |
| `cancelled` | 1 | 1 |
| `pending` | 2 | 2 |
| `success` | 5 | **3** |
| `neutral` | 3 | **4** |
| `skipped` | 4 | **5** |
| unrecognized conclusion | 3 (silently `neutral`) | **6** (last) |

Relative order inside the failure tier and the ties between `failure`/`timed_out`/`action_required` are unchanged, so nothing about failure triage moves.

## Screenshots

Ordering change only — same rows, same styling, no layout or token changes.

On a PR with 19 passing checks and ~7 skipped jobs, the panel now reads:

```
before                          after
─ daily-cleanup     Skipped     ✓ Smoke: Lab API     Successful
─ build-admin       Skipped     ✓ Validate Configs   Successful
─ build-monitor     Skipped     ✓ Validate Kustomize Successful
─ cleanup-preview   Skipped     …
… (scroll) …                    ─ daily-cleanup      Skipped
✓ Smoke: Lab API    Successful  ─ build-admin        Skipped
```

## Testing

- [x] `pnpm lint` — every sub-step run individually and passing (`oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:reliability-gates`, `check:max-lines-ratchet`, `verify:bundled-skill-guides`, `verify:skill-bundle-manifest`, `verify:localization-catalog`, `verify:localization-coverage`). The single chained `pnpm lint` invocation OOM-killed the linter process on my machine before finishing; each step is green on its own.
- [x] `pnpm typecheck`
- [x] `pnpm test` — targeted plus a broad sweep of `src/renderer/src/components` and `src/shared`: 1697 files / 14339 tests passing
- [x] `pnpm build` (`build:desktop` and `build:native`, both exit 0)
- [x] Added `src/shared/pr-check-severity-order.test.ts`: pins the reported regression (passing checks above skipped/neutral noise), the failure → in-flight → success tiering, unknown conclusions sinking last, prototype property names (`constructor`, `toString`, `hasOwnProperty`, `__proto__`) ranking as unknown, `null`/`undefined` treated as `pending`, and that the input array is not mutated.

## AI Review Report

Reviewed the diff with Claude, focused on:

- **Behavior scope** — verified the only ordering change is `success` moving above `neutral`/`skipped` plus unknown conclusions sinking last. Counters (`passingCount`, `failingCount`, `pendingCount`), the summary label, auto-expand-first-failed, and check-detail keys all derive from the unsorted list or from row identity, so none of them shift.
- **Row identity** — `getCheckDetailsKey(contextKey, check, index)` uses the sorted index as a fallback when `checkRunId` is absent, so expanded-details state is keyed off list position. Rechecked that keys are recomputed from the same `sorted` array they index into, and that the existing prune-invalid-keys effect covers the reordering.
- **Cross-platform** — pure comparator logic, no `metaKey`, no shortcut labels, no paths, no shell, no Electron API. Identical on macOS, Linux, and Windows.
- **SSH/remote and folder workspaces** — the module is a pure function over already-fetched `PRCheckDetail[]`; it does not touch a process, file, credential, or network path. `FolderWorkspacePrChecksPanel` renders through the same `ChecksList`, so folder workspaces get the fix too.
- **Git providers** — naming is provider-neutral and the ranks are keyed on the generic `PRCheckDetail['conclusion']` union, so GitLab pipeline checks (which map into the same conclusions via `src/shared/gitlab-pipeline-checks.ts`) sort by the same rule.
- **Performance** — one `Object`-lookup comparator over an already-materialized array, memoized in the sidebar panel exactly as before. No new allocation in a hot path; three duplicated maps became one.
- **Naming** — `pr-check-severity-order.ts` per AGENTS.md (no `helpers`/`utils`/`common`).

Flagged and addressed: the old `?? 3` fallback quietly ranked unrecognized conclusions as `neutral`, meaning a future GitHub conclusion would outrank real successes. Replaced with an explicit last-place rank and covered by a test.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface is touched. The new module is a pure comparator over data already fetched and rendered; no new dependency, no new IPC channel, no user-controlled string reaching a shell or filesystem call.

**Correction to my first pass:** this section originally claimed the rank lookup could not reach prototype-inherited properties. That was wrong, and CodeRabbit caught it. The rank table was an object literal, so a conclusion named `constructor`/`toString`/`__proto__` resolved a function off `Object.prototype`, skipped the `?? UNKNOWN_CHECK_RANK` fallback, and made the comparator return `NaN` — scrambling the whole list rather than misplacing one row. `conclusion` arrives as `string` from provider payloads, so the union type does not actually constrain it. Fixed in 9c068e2: the table is now a `Map`, with prototype property names covered in the test.

## Notes

No platform-, remote-, agent-, integration-, or provider-specific behavior. Follow-up worth considering (not in this PR): `getCheckConclusion` and `getCheckStatusLabel` are still duplicated verbatim between `PullRequestPage.tsx` and `GitHubItemDialog.tsx` and could join the same module.
