### PR TITLE
fix(cli): stop the WSL launcher from forwarding a duplicate PATH

### DIFF
--- a/src/main/cli/wsl-cli-scripts.test.ts
+++ b/src/main/cli/wsl-cli-scripts.test.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { buildWslLauncher } from './wsl-cli-scripts'
+
+const WIN_LAUNCHER = 'C:\\Users\\me\\AppData\\Local\\Programs\\Orca\\resources\\bin\\orca.exe'
+
+let stubDir: string
+
+/** Runs the generated launcher and returns the WSLENV its Windows child actually receives. */
+function forwardedWslenv(wslenv: string | undefined): string {
+  const env: NodeJS.ProcessEnv = { PATH: `${stubDir}:${process.env.PATH ?? ''}` }
+  if (wslenv !== undefined) {
+    env.WSLENV = wslenv
+  }
+  return execFileSync('bash', ['-c', buildWslLauncher(WIN_LAUNCHER)], { encoding: 'utf8', env })
+}
+
+// Why: the launcher only ever runs inside a WSL distro, and exercising it needs bash, executable
+// /bin/sh stubs, and a colon-separated PATH — none of which a native Windows checkout provides.
+describe.skipIf(process.platform === 'win32')('buildWslLauncher WSLENV sanitization', () => {
+  // Why: stubbing the two interop tools on PATH lets these run the shipped launcher unmodified
+  // instead of asserting against a rewritten copy of it.
+  beforeAll(() => {
+    stubDir = mkdtempSync(join(tmpdir(), 'orca-wsl-launcher-'))
+    writeFileSync(join(stubDir, 'wslpath'), '#!/bin/sh\nprintf "C:\\\\stub"\n', { mode: 0o755 })
+    writeFileSync(join(stubDir, 'powershell.exe'), '#!/bin/sh\nprintf "%s" "${WSLENV-<unset>}"\n', {
+      mode: 0o755
+    })
+  })
+
+  afterAll(() => {
+    rmSync(stubDir, { recursive: true, force: true })
+  })
+
+  // Why: WSLENV forwards the Linux PATH as "PATH" next to the Windows "Path" the child already
+  // has, and the launcher rejects the case-insensitive duplicate before the CLI starts.
+  it('drops a PATH entry so the Windows child never sees a duplicate key', () => {
+    expect(forwardedWslenv('PATH/l')).toBe('')
+    expect(forwardedWslenv('PATH')).toBe('')
+  })
+
+  it('drops PATH regardless of case or share flags', () => {
+    expect(forwardedWslenv('Path/l')).toBe('')
+    expect(forwardedWslenv('pAtH/up')).toBe('')
+    expect(forwardedWslenv('PATH/l:Path:pAtH/u')).toBe('')
+  })
+
+  it('keeps every other entry in its original order', () => {
+    expect(forwardedWslenv('GIT_TERMINAL_PROMPT:ORCA_TAB_ID/u')).toBe(
+      'GIT_TERMINAL_PROMPT:ORCA_TAB_ID/u'
+    )
+    expect(forwardedWslenv('ORCA_TAB_ID/u:PATH/l:ORCA_WORKTREE_ID/u')).toBe(
+      'ORCA_TAB_ID/u:ORCA_WORKTREE_ID/u'
+    )
+    expect(forwardedWslenv('PATH/l:ORCA_USER_DATA_PATH/p')).toBe('ORCA_USER_DATA_PATH/p')
+  })
+
+  it('keeps variables that merely contain PATH in their name', () => {
+    expect(forwardedWslenv('PATHFINDER/u')).toBe('PATHFINDER/u')
+    expect(forwardedWslenv('MY_PATH/u:PATH/l:PATH_EXTRA')).toBe('MY_PATH/u:PATH_EXTRA')
+  })
+
+  it('collapses empty segments instead of forwarding them', () => {
+    expect(forwardedWslenv('A::B')).toBe('A:B')
+    expect(forwardedWslenv(':A:')).toBe('A')
+  })
+
+  it('survives an unset or empty WSLENV under set -u', () => {
+    expect(forwardedWslenv(undefined)).toBe('')
+    expect(forwardedWslenv('')).toBe('')
+  })
+})

--- a/src/main/cli/wsl-cli-scripts.ts
+++ b/src/main/cli/wsl-cli-scripts.ts
@@ -28,6 +28,24 @@ ORCA_WSL_CWD=$(pwd -P 2>/dev/null) || {
 }
 ORCA_BRIDGE_PS1_WIN=$(wslpath -w "$ORCA_BRIDGE_PS1")
 ORCA_WSL_CWD_WIN=$(wslpath -w "$ORCA_WSL_CWD")
+# Why: a PATH entry in WSLENV reaches the Windows child as "PATH" beside the "Path" it already
+# inherits, and orca.exe aborts on that case-insensitive duplicate before the CLI starts.
+ORCA_WSLENV=
+ORCA_WSLENV_REST=\${WSLENV:-}
+while [ -n "$ORCA_WSLENV_REST" ]; do
+  ORCA_WSLENV_ENTRY=\${ORCA_WSLENV_REST%%:*}
+  if [ "$ORCA_WSLENV_ENTRY" = "$ORCA_WSLENV_REST" ]; then
+    ORCA_WSLENV_REST=
+  else
+    ORCA_WSLENV_REST=\${ORCA_WSLENV_REST#*:}
+  fi
+  [ -n "$ORCA_WSLENV_ENTRY" ] || continue
+  case "\${ORCA_WSLENV_ENTRY%%/*}" in
+    [Pp][Aa][Tt][Hh]) continue ;;
+  esac
+  ORCA_WSLENV=\${ORCA_WSLENV:+$ORCA_WSLENV:}$ORCA_WSLENV_ENTRY
+done
+export WSLENV="$ORCA_WSLENV"
 exec "$ORCA_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$ORCA_BRIDGE_PS1_WIN" "$ORCA_WIN_LAUNCHER" -WslCwd "$ORCA_WSL_CWD_WIN" "$@"
 `
 }


### PR DESCRIPTION
## Summary

Fixes #9498 — the Orca-managed CLI is completely unusable from WSL on affected machines. Even `orca --version` exits immediately:

```
Unable to start the Orca CLI: An item with the same key has already been added. Key in dictionary: 'PATH'; Key being added: 'Path'
```

**Cause.** When `WSLENV` contains a `PATH` entry, WSL forwards the Linux `PATH` into the Windows child process under the name `PATH`, while that process already inherits `Path` from Windows. The Windows launcher builds its environment map case-insensitively and throws on the duplicate key before the CLI ever initializes.

Nothing in Orca adds that `WSLENV` entry — other WSL tooling does — which is why this only reproduces for some users and why it survived across releases (originally reported on 1.4.145, still reproducing on 1.4.159).

**Fix.** The generated bash launcher now strips only the `PATH` entry from `WSLENV` before `exec`ing the PowerShell bridge. Every other shared variable still crosses the boundary — the `ORCA_*` terminal/agent handles, git prompt control — and the Windows child keeps the `Path` it would have inherited anyway.

Existing installs pick this up automatically: `managedScriptMatches()` already reinstalls a launcher whose contents drifted from `buildWslLauncher()`, so no manual re-registration is needed.

## Screenshots

`No visual change` — this only touches the generated WSL CLI launcher script.

Before / after on the same machine, same command, only the launcher swapped:

```console
$ WSLENV="PATH/l:$WSLENV" orca-ide --version        # before
Unable to start the Orca CLI: 항목이 이미 추가되었습니다. 사전에 있는 키: 'PATH'  추가되는 키: 'Path'

$ WSLENV="PATH/l:$WSLENV" orca-ide --version        # after
orca
$ WSLENV="PATH/l:$WSLENV" orca-ide status --json    # after
{ "id": "local-status", "ok": true, "result": { ... "appVersion": "1.4.159" } }
```

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 38,746 / 38,900 pass. 14 failures are pre-existing on this machine and unrelated to this change; see below.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

**On the `pnpm test` failures.** I verified they are not caused by this PR by stashing the change and re-running the same 9 files against a clean tree:

```
clean tree (this change stashed)  ->  8 failed | 1 passed   /  13 failed | 371 passed | 40 skipped
with this change applied          ->  8 failed | 1 passed   /  13 failed | 371 passed | 40 skipped
```

Identical. They live in PTY / relay / process-startup suites with no path to `src/main/cli/`, and the causes are all local-environment leakage: the suite inherits my shell's real `WSLENV` (`POWERLEVEL9K_DISABLE_CONFIGURATION_WIZARD`) and a `PROMPT_COMMAND` that trips a `syntax error`, plus a timing assertion (`expected 6765 to be less than 6000`) and a git-version-dependent message. `node-pty` also had to be rebuilt for Node 24 locally.

`src/main/cli/` itself is green: **12 files, 116 tests passing.**

**New tests.** `src/main/cli/wsl-cli-scripts.test.ts` (6 cases). These do not string-match the generated script — they execute the real launcher under `bash` and observe the `WSLENV` the Windows child actually receives, with `wslpath` / `powershell.exe` replaced by stubs on `PATH` so the shipped control flow runs unmodified. Coverage: `PATH` removal, case variants (`Path`, `pAtH`), share flags (`/l`, `/u`, `/up`), order preservation, PATH-lookalike names (`PATHFINDER`, `MY_PATH`) surviving, empty-segment collapsing, and unset/empty `WSLENV` under `set -u`.

## AI Review Report

Reviewed with Claude Code. Risks checked and outcomes:

- **Cross-platform (macOS / Linux / Windows).** This code path is Windows-host-only: `buildWslLauncher()` emits the bash shim that a WSL distro runs to reach `orca.exe`. Native macOS and Linux installs go through `cli-installer.ts` and are untouched. No shortcut, accelerator, or label strings involved; no `metaKey` / `CmdOrCtrl` surface; no `path.join` / separator logic changed. Verified `src/main/cli/` suites pass, which cover the macOS/Linux installer paths too.
- **Shell portability.** The added block uses only POSIX parameter expansion (`${v%%:*}`, `${v#*:}`, `${v:+…}`, `${v:-}`) and a `case` glob — no arrays, no here-strings, no `awk`/`sed` dependency, so it does not regress on older bash or a `sh`-backed shell. Confirmed it is safe under the script's existing `set -euo pipefail`, including when `WSLENV` is unset.
- **Correctness of the filter.** Matching is anchored on the entry name before `/`, so `PATHFINDER` and `MY_PATH` are preserved while `PATH`, `Path`, and `pAtH/up` are dropped. Order of surviving entries is unchanged.
- **SSH / remote.** WSL CLI registration is local-interop only; the relay and SSH provider paths are not reachable from this script and were not modified.
- **Folder workspaces vs worktrees.** Not applicable — no repo or workspace assumptions; the existing `pwd -P` cwd-repair block is untouched.
- **Performance.** One linear pass over `WSLENV` (tens of entries) once per CLI invocation, before `exec`. No measurable cost.
- **Flagged and addressed.** Initial draft used a bash array with `IFS`; replaced with pure parameter expansion after review flagged `set -u` behavior with empty arrays on bash < 4.4.

## Security Audit

- **Input handling.** `WSLENV` is attacker-influencable in principle (any process that can set the user's environment). The added code only splits on `:` and compares a prefix — no `eval`, no command substitution, no subshell, no filename expansion of the value. A hostile `WSLENV` cannot inject a command here.
- **Command execution.** The `exec` line is unchanged: same binary resolution, same argument order, same quoting. `"$@"` forwarding is untouched.
- **Path handling.** No change. `wslpath -w` conversions and the `$ORCA_BRIDGE_PS1` / `$ORCA_WIN_LAUNCHER` quoting are as before.
- **Secrets.** The change only *removes* a variable from what crosses into the Windows process, and never logs or transmits environment contents. Net effect is a slightly smaller cross-boundary surface.
- **Auth / IPC / dependencies.** Not touched. No new dependencies.
- **Follow-up.** None identified.

## Notes

- **Platform-specific:** Windows host + WSL only. Requires a `WSLENV` that carries a `PATH` entry to reproduce, which is why it is intermittent across users rather than universal.
- **Behavior change to be aware of:** if someone deliberately set `WSLENV=PATH/...` to expose the Linux `PATH` to Windows children, the Orca launcher no longer forwards it. That is intentional and lossless in practice — `orca.exe` resolves against the Windows `Path`, and before this change the invocation aborted outright, so there is no working behavior being removed.
- **Reproduction environment:** Windows 11 + WSL2, Ubuntu 24.04, Orca 1.4.159. The original reporter saw the same failure on 1.4.145 and confirmed it again on 1.4.159.
- **One thing I could not confirm.** I reproduced the exact failure by prefixing `WSLENV` with `PATH/l`, but I could not verify that the reporter's shell actually carried a `PATH` entry in `WSLENV`. That mechanism is what the issue itself points at ("environment variables inherited through WSL-to-Windows interop are processed case-insensitively"), and it is the only route I found that puts both `PATH` and `Path` into the Windows environment block from the WSL side — so I am confident it is the cause, but it is an inference rather than a capture from the reporting machine. @JunhyeokJang1006, if you can paste `echo "$WSLENV"` from a shell where `orca --version` fails, that would settle it. Note that a `PATH` variable created independently on the Windows side (e.g. via `setx PATH`) would raise the same .NET error and would *not* be addressed by this change.
