### PR TITLE
fix(rate-limits): fix Antigravity CLI quota parsing and status bar visibility

### DIFF
--- a/src/main/rate-limits/agy-pty-fetcher.ts
+++ b/src/main/rate-limits/agy-pty-fetcher.ts
@@ -1,0 +1,277 @@
+import type { IPty } from 'node-pty'
+import type { ProviderRateLimits } from '../../shared/rate-limit-types'
+import {
+  FIVE_HOUR_RE,
+  WEEKLY_RE,
+  parsePtyStatus,
+  stripPtyControlSequences
+} from './agy-pty-status-parser'
+import { cleanupHiddenRateLimitPty, registerHiddenRateLimitPty } from './hidden-pty-cleanup'
+import { resolveHiddenRateLimitPtyCwd } from './hidden-rate-limit-pty-cwd'
+import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
+
+export async function fetchAntigravityRateLimitsViaPty(
+  signal?: AbortSignal
+): Promise<ProviderRateLimits> {
+  const pty = await import('node-pty')
+
+  if (signal?.aborted) {
+    return {
+      provider: 'antigravity',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: 'Aborted',
+      status: 'error'
+    }
+  }
+
+  const spawnFile = process.platform === 'win32' ? 'cmd.exe' : 'agy'
+  const spawnArgs = process.platform === 'win32' ? ['/d', '/c', 'agy'] : []
+
+  return new Promise<ProviderRateLimits>((resolve) => {
+    let output = ''
+    let resolved = false
+    let sentStatus = false
+    let postCommandOffset = 0
+    let settleTimer: ReturnType<typeof setTimeout> | null = null
+    let timeout: ReturnType<typeof setTimeout> | null = null
+
+    let term: IPty
+    let termDisposables: { dispose: () => void }[] = []
+    try {
+      term = pty.spawn(spawnFile, spawnArgs, {
+        name: 'xterm-256color',
+        cols: 200,
+        rows: 100,
+        cwd: resolveHiddenRateLimitPtyCwd(),
+        env: {
+          ...process.env,
+          TERM: 'xterm-256color'
+        }
+      })
+      termDisposables = [registerHiddenRateLimitPty(term)]
+    } catch (err) {
+      resolve({
+        provider: 'antigravity',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: `Failed to spawn CLI: ${err instanceof Error ? err.message : String(err)}`,
+        status: 'unavailable'
+      })
+      return
+    }
+
+    let statusEnter: ReturnType<typeof setTimeout> | null = null
+    function sendStatusCommand(): void {
+      sentStatus = true
+      postCommandOffset = output.length
+      if (statusNudge) {
+        clearTimeout(statusNudge)
+        statusNudge = null
+      }
+      term.write('/usage')
+      statusEnter = setTimeout(() => {
+        statusEnter = null
+        term.write('\r')
+        statusEnter = setTimeout(() => {
+          statusEnter = null
+          if (!resolved && !settleTimer) {
+            term.write('\r')
+          }
+        }, 3000)
+      }, 350)
+    }
+
+    let statusNudge: ReturnType<typeof setTimeout> | null = null
+    function armStatusNudge(): void {
+      if (sentStatus || resolved) {
+        return
+      }
+      // Reset on every data event so the nudge only fires after 2.5s of silence
+      if (statusNudge) {
+        clearTimeout(statusNudge)
+      }
+      statusNudge = setTimeout(() => {
+        statusNudge = null
+        if (!resolved && !sentStatus) {
+          sendStatusCommand()
+        }
+      }, 2500)
+    }
+    termDisposables.push({
+      dispose: () => {
+        if (statusNudge) {
+          clearTimeout(statusNudge)
+          statusNudge = null
+        }
+        if (statusEnter) {
+          clearTimeout(statusEnter)
+          statusEnter = null
+        }
+      }
+    })
+
+    function settleAborted(): void {
+      if (resolved) {
+        return
+      }
+      resolved = true
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      if (settleTimer) {
+        clearTimeout(settleTimer)
+      }
+      cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
+      resolve({
+        provider: 'antigravity',
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: 'Aborted',
+        status: 'error'
+      })
+    }
+
+    if (signal) {
+      if (signal.aborted) {
+        settleAborted()
+        return
+      }
+      signal.addEventListener('abort', settleAborted, { once: true })
+      termDisposables.push({
+        dispose: () => signal.removeEventListener('abort', settleAborted)
+      })
+    }
+
+    timeout = setTimeout(() => {
+      if (!resolved) {
+        resolved = true
+        if (settleTimer) {
+          clearTimeout(settleTimer)
+        }
+        cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
+        resolve({
+          provider: 'antigravity',
+          session: null,
+          weekly: null,
+          updatedAt: Date.now(),
+          error: withMacTailscaleDnsHint('PTY timeout', output),
+          status: 'error'
+        })
+      }
+    }, 15000)
+
+    const onDataDisposable = term.onData((data) => {
+      output += data
+      if (output.length > 100000) {
+        output = output.slice(-100000)
+      }
+
+      armStatusNudge()
+
+      if (!sentStatus) {
+        // agy sends the '>' prompt mid-chunk followed by status-bar lines, so
+        // checking only the end of data or stripped output misses it. Instead,
+        // look for a line that is just the prompt character in the accumulated output.
+        const stripped = stripPtyControlSequences(output)
+        if (/[>›]\s*$/.test(data) || /^[>›]\s*$/m.test(stripped)) {
+          sendStatusCommand()
+          return
+        }
+      }
+
+      const probe =
+        sentStatus && !settleTimer
+          ? stripPtyControlSequences(output.slice(postCommandOffset))
+          : null
+      if (probe !== null) {
+        if (FIVE_HOUR_RE.test(probe) || WEEKLY_RE.test(probe)) {
+          settleTimer = setTimeout(() => {
+            settleTimer = null
+            if (resolved) {
+              return
+            }
+            resolved = true
+            if (timeout) {
+              clearTimeout(timeout)
+            }
+            cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
+
+            const clean = stripPtyControlSequences(output)
+            const { session, weekly } = parsePtyStatus(clean)
+
+            resolve({
+              provider: 'antigravity',
+              session,
+              weekly,
+              updatedAt: Date.now(),
+              error:
+                session || weekly
+                  ? null
+                  : withMacTailscaleDnsHint('Failed to parse CLI output', clean),
+              status: session || weekly ? 'ok' : 'error'
+            })
+          }, 500)
+        } else if (/not signed in|Token refresh failed/i.test(probe)) {
+          // Fast-fail if CLI reports it is not signed in or failed to refresh its token
+          if (resolved) {
+            return
+          }
+          resolved = true
+          if (timeout) {
+            clearTimeout(timeout)
+          }
+          if (settleTimer) {
+            clearTimeout(settleTimer)
+          }
+          cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
+          resolve({
+            provider: 'antigravity',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error: /Token refresh failed/i.test(probe)
+              ? 'Token refresh failed'
+              : 'Antigravity CLI not signed in',
+            status: 'error'
+          })
+        }
+      }
+    })
+    if (onDataDisposable) {
+      termDisposables.push(onDataDisposable)
+    }
+
+    const onExitDisposable = term.onExit(() => {
+      cleanupHiddenRateLimitPty(term, termDisposables, { kill: false })
+      if (settleTimer) {
+        clearTimeout(settleTimer)
+      }
+      if (!resolved) {
+        resolved = true
+        if (timeout) {
+          clearTimeout(timeout)
+        }
+        const clean = stripPtyControlSequences(output)
+        const { session, weekly } = parsePtyStatus(clean)
+        resolve({
+          provider: 'antigravity',
+          session,
+          weekly,
+          updatedAt: Date.now(),
+          error:
+            session || weekly
+              ? null
+              : withMacTailscaleDnsHint('CLI exited before status was available', clean),
+          status: session || weekly ? 'ok' : 'error'
+        })
+      }
+    })
+    if (onExitDisposable) {
+      termDisposables.push(onExitDisposable)
+    }
+  })
+}

--- a/src/main/rate-limits/agy-pty-status-parser.test.ts
+++ b/src/main/rate-limits/agy-pty-status-parser.test.ts
@@ -30,4 +30,10 @@ describe('agy-pty-status-parser', () => {
       resetDescription: 'Jul 30, 3:00 PM'
     })
   })
+
+  it('strips ANSI and PTY control sequences correctly', () => {
+    const ansiInput = '\x1b[31mFive hour limit\x1b[0m\r\n\x1b[32m19% used\x1b[0m'
+    const clean = stripPtyControlSequences(ansiInput)
+    expect(clean).toBe('Five hour limit\r\n19% used')
+  })
 })

--- a/src/main/rate-limits/agy-pty-status-parser.test.ts
+++ b/src/main/rate-limits/agy-pty-status-parser.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { parsePtyStatus, stripPtyControlSequences } from './agy-pty-status-parser'
+
+describe('agy-pty-status-parser', () => {
+  it('parses multi-line Antigravity five hour and weekly limit output', () => {
+    const rawOutput = `
+    Five hour limit
+    ████░░░░░░░░░░░ 19% used
+    Refreshes in 4h 12m
+
+    Weekly limit
+    ███████████████ 100% remaining
+    Refreshes Jul 30, 3:00 PM
+    `
+
+    const clean = stripPtyControlSequences(rawOutput)
+    const { session, weekly } = parsePtyStatus(clean)
+
+    expect(session).toEqual({
+      usedPercent: 19,
+      windowMinutes: 300,
+      resetsAt: expect.any(Number),
+      resetDescription: '4h 12m'
+    })
+
+    expect(weekly).toEqual({
+      usedPercent: 0,
+      windowMinutes: 10080,
+      resetsAt: expect.any(Number),
+      resetDescription: 'Jul 30, 3:00 PM'
+    })
+  })
+})

--- a/src/main/rate-limits/agy-pty-status-parser.ts
+++ b/src/main/rate-limits/agy-pty-status-parser.ts
@@ -1,0 +1,66 @@
+import type { RateLimitWindow } from '../../shared/rate-limit-types'
+import { extractClaudePtyResetMetadata } from './claude-pty-reset-parser'
+
+export const FIVE_HOUR_RE =
+  /(?<![\w-][^\S\r\n]{0,4})five\s+hour\s+limit[\s\S]*?(\d+(?:\.\d+)?)%(?:\s*(?:(?:\d+(?:\.\d+)?)%?\s*)?(used|left|remaining))?/i
+export const WEEKLY_RE =
+  /(?<![\w-][^\S\r\n]{0,4})weekly\s+limit[\s\S]*?(\d+(?:\.\d+)?)%(?:\s*(?:(?:\d+(?:\.\d+)?)%?\s*)?(used|left|remaining))?/i
+
+const ANY_LIMIT_LABEL_RE = /(?:five\s+hour|weekly)\s+limit/i
+const FIVE_HOUR_LABEL_RE = /five\s+hour\s+limit/i
+const WEEKLY_LABEL_RE = /weekly\s+limit/i
+// eslint-disable-next-line no-control-regex
+const PTY_CONTROL_SEQUENCE_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g
+
+export function stripPtyControlSequences(output: string): string {
+  return output.replace(PTY_CONTROL_SEQUENCE_RE, '')
+}
+
+export function isPtyLimitLabel(line: string): boolean {
+  return ANY_LIMIT_LABEL_RE.test(line)
+}
+function isFiveHourLimitLabel(line: string): boolean {
+  return FIVE_HOUR_LABEL_RE.test(line)
+}
+function isWeeklyLimitLabel(line: string): boolean {
+  return WEEKLY_LABEL_RE.test(line)
+}
+
+function ptyUsedPercent(match: RegExpExecArray): number {
+  const rawPct = Number.parseFloat(match[1])
+  const oriented = ['left', 'remaining'].includes(match[2]?.toLowerCase() ?? '')
+    ? 100 - rawPct
+    : rawPct
+  return Math.min(100, Math.max(0, oriented))
+}
+
+export function parsePtyStatus(output: string): {
+  session: RateLimitWindow | null
+  weekly: RateLimitWindow | null
+} {
+  const fiveMatch = FIVE_HOUR_RE.exec(output)
+  const weeklyMatch = WEEKLY_RE.exec(output)
+  const lines = output.split(/\r\n|\n|\r/)
+  const sessionReset = extractClaudePtyResetMetadata(lines, isFiveHourLimitLabel, isPtyLimitLabel)
+  const weeklyReset = extractClaudePtyResetMetadata(lines, isWeeklyLimitLabel, isPtyLimitLabel)
+
+  const session: RateLimitWindow | null = fiveMatch
+    ? {
+        usedPercent: ptyUsedPercent(fiveMatch),
+        windowMinutes: 300,
+        resetsAt: sessionReset.resetsAt,
+        resetDescription: sessionReset.resetDescription
+      }
+    : null
+
+  const weekly: RateLimitWindow | null = weeklyMatch
+    ? {
+        usedPercent: ptyUsedPercent(weeklyMatch),
+        windowMinutes: 10080,
+        resetsAt: weeklyReset.resetsAt,
+        resetDescription: weeklyReset.resetDescription
+      }
+    : null
+
+  return { session, weekly }
+}

--- a/src/main/rate-limits/claude-pty-reset-parser.ts
+++ b/src/main/rate-limits/claude-pty-reset-parser.ts
@@ -1,7 +1,7 @@
 import type { RateLimitWindow } from '../../shared/rate-limit-types'
 import { buildWallClockTimestamp } from './time-zone-wall-clock'
 
-const RESET_LINE_RE = /resets?\s+(?:at\s+|in\s+)?(.+)/i
+const RESET_LINE_RE = /(?:resets?|refreshes?)\s+(?:at\s+|in\s+)?(.+)/i
 const MONTH_PATTERN =
   'jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?'
 const MONTH_DAY_COMPACT_RE = new RegExp(

--- a/src/main/rate-limits/gemini-usage-fetcher.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.ts
@@ -2,8 +2,10 @@ import { net } from 'electron'
 import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 import {
   loadProjectId,
+  readAntigravityCredentials,
   readAuthJson,
   readGeminiCredentials,
+  saveAntigravityCredentials,
   saveGeminiCredentials,
   tryRefreshTokenFromBundle,
   type GeminiCredentials,
@@ -41,7 +43,11 @@ function parseQuotaResponse(data: unknown): QuotaBucket[] {
   return rawBuckets.filter((b) => isQuotaBucket(b))
 }
 
-async function fetchQuota(accessToken: string, projectId: string): Promise<ProviderRateLimits> {
+async function fetchQuota(
+  accessToken: string,
+  projectId: string,
+  provider: 'gemini' | 'antigravity' = 'gemini'
+): Promise<ProviderRateLimits> {
   const controller = new AbortController()
   const timeout = setTimeout(() => {
     controller.abort()
@@ -55,7 +61,7 @@ async function fetchQuota(accessToken: string, projectId: string): Promise<Provi
     })
     if (!res.ok) {
       return {
-        provider: 'gemini',
+        provider,
         session: null,
         weekly: null,
         updatedAt: Date.now(),
@@ -68,7 +74,7 @@ async function fetchQuota(accessToken: string, projectId: string): Promise<Provi
       parseQuotaResponse(data).map((b) => ({ ...buildRateLimitBucket(b), modelId: b.modelId }))
     )
     return {
-      provider: 'gemini',
+      provider,
       session: deriveSessionSummary(buckets),
       weekly: null,
       buckets,
@@ -83,7 +89,8 @@ async function fetchQuota(accessToken: string, projectId: string): Promise<Provi
 
 async function fetchViaAuthJson(
   auth: GoogleAuthEntry,
-  geminiCliOAuthEnabled = false
+  geminiCliOAuthEnabled = false,
+  provider: 'gemini' | 'antigravity' = 'gemini'
 ): Promise<ProviderRateLimits> {
   let accessToken = auth.access
   const refreshToken = (auth.refresh || '').split('|')[0] ?? ''
@@ -91,7 +98,7 @@ async function fetchViaAuthJson(
     const refreshResult = await tryRefreshTokenFromBundle(refreshToken, geminiCliOAuthEnabled)
     if (!refreshResult?.accessToken) {
       return {
-        provider: 'gemini',
+        provider,
         session: null,
         weekly: null,
         updatedAt: Date.now(),
@@ -102,30 +109,33 @@ async function fetchViaAuthJson(
     accessToken = refreshResult.accessToken
   }
   let effectiveProjectId = ''
-  try {
-    effectiveProjectId = await loadProjectId(accessToken)
-  } catch {
-    effectiveProjectId =
-      (auth.refresh || '').split('|')[1] || (auth.refresh || '').split('|')[2] || ''
-  }
-  if (!effectiveProjectId) {
-    return {
-      provider: 'gemini',
-      session: null,
-      weekly: null,
-      updatedAt: Date.now(),
-      error: 'Gemini project ID not found',
-      status: 'error'
+  if (provider === 'gemini') {
+    try {
+      effectiveProjectId = await loadProjectId(accessToken)
+    } catch {
+      effectiveProjectId =
+        (auth.refresh || '').split('|')[1] || (auth.refresh || '').split('|')[2] || ''
+    }
+    if (!effectiveProjectId) {
+      return {
+        provider,
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: 'Gemini project ID not found',
+        status: 'error'
+      }
     }
   }
-  const result = await fetchQuota(accessToken, effectiveProjectId)
+  const result = await fetchQuota(accessToken, effectiveProjectId, provider)
   if (result.status === 'error' && result.error?.includes('401')) {
     const refreshResult = await tryRefreshTokenFromBundle(refreshToken, geminiCliOAuthEnabled)
     if (refreshResult?.accessToken) {
-      const newProjectId = await loadProjectId(refreshResult.accessToken).catch(() => {
-        return effectiveProjectId
-      })
-      return fetchQuota(refreshResult.accessToken, newProjectId)
+      const newProjectId =
+        provider === 'gemini'
+          ? await loadProjectId(refreshResult.accessToken).catch(() => effectiveProjectId)
+          : effectiveProjectId
+      return fetchQuota(refreshResult.accessToken, newProjectId, provider)
     }
   }
   return result
@@ -133,10 +143,14 @@ async function fetchViaAuthJson(
 
 async function fetchViaOauthCreds(
   creds: GeminiCredentials,
-  geminiCliOAuthEnabled = false
+  geminiCliOAuthEnabled = false,
+  provider: 'gemini' | 'antigravity' = 'gemini'
 ): Promise<ProviderRateLimits> {
   let accessToken = creds.access_token
   let currentCreds = creds
+  const saveCreds = (c: GeminiCredentials) =>
+    provider === 'antigravity' ? saveAntigravityCredentials(c) : saveGeminiCredentials(c)
+
   if (creds.expiry_date < Date.now()) {
     const refreshResult = await tryRefreshTokenFromBundle(
       creds.refresh_token,
@@ -144,7 +158,7 @@ async function fetchViaOauthCreds(
     )
     if (!refreshResult?.accessToken) {
       return {
-        provider: 'gemini',
+        provider,
         session: null,
         weekly: null,
         updatedAt: Date.now(),
@@ -160,44 +174,95 @@ async function fetchViaOauthCreds(
         ? Date.now() + refreshResult.expiresIn * 1000
         : creds.expiry_date
     }
-    await saveGeminiCredentials(currentCreds)
+    await saveCreds(currentCreds)
   }
-  const projectId = await loadProjectId(accessToken).catch(() => {
-    return ''
-  })
-  if (!projectId) {
-    return {
-      provider: 'gemini',
-      session: null,
-      weekly: null,
-      updatedAt: Date.now(),
-      error: 'Gemini project ID not found',
-      status: 'error'
+  let projectId = ''
+  if (provider === 'gemini') {
+    projectId = await loadProjectId(accessToken).catch(() => {
+      return ''
+    })
+    if (!projectId) {
+      return {
+        provider,
+        session: null,
+        weekly: null,
+        updatedAt: Date.now(),
+        error: 'Gemini project ID not found',
+        status: 'error'
+      }
     }
   }
-  const result = await fetchQuota(accessToken, projectId)
+  const result = await fetchQuota(accessToken, projectId, provider)
   if (result.status === 'error' && result.error?.includes('401')) {
     const refreshResult = await tryRefreshTokenFromBundle(
       currentCreds.refresh_token,
       geminiCliOAuthEnabled
     )
     if (refreshResult?.accessToken) {
-      const newProjectId = await loadProjectId(refreshResult.accessToken).catch(() => {
-        return ''
-      })
-      if (newProjectId) {
-        await saveGeminiCredentials({
+      const newProjectId =
+        provider === 'gemini' ? await loadProjectId(refreshResult.accessToken).catch(() => '') : ''
+      if (newProjectId || provider === 'antigravity') {
+        const updatedCreds = {
           ...currentCreds,
           access_token: refreshResult.accessToken,
           expiry_date: refreshResult.expiresIn
             ? Date.now() + refreshResult.expiresIn * 1000
             : currentCreds.expiry_date
-        })
-        return fetchQuota(refreshResult.accessToken, newProjectId)
+        }
+        await saveCreds(updatedCreds)
+        return fetchQuota(refreshResult.accessToken, newProjectId, provider)
       }
     }
   }
   return result
+}
+
+import { fetchAntigravityRateLimitsViaPty } from './agy-pty-fetcher'
+
+export async function fetchAntigravityRateLimits(
+  _geminiCliOAuthEnabled: boolean,
+  signal?: AbortSignal
+): Promise<ProviderRateLimits> {
+  if (signal?.aborted) {
+    return {
+      provider: 'antigravity',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: 'Rate-limit fetch aborted',
+      status: 'error'
+    }
+  }
+
+  // agy CLI often fails to refresh its own token if the OAuth client secret isn't embedded.
+  // Orca previously managed the antigravity-oauth-token lifecycle. We must continue to do so,
+  // otherwise the PTY invocation will fail with "Token refresh failed".
+  try {
+    const creds = await readAntigravityCredentials()
+    if (creds && creds.expiry_date < Date.now()) {
+      const refreshResult = await tryRefreshTokenFromBundle(
+        creds.refresh_token,
+        true // Always allow token refresh for Antigravity
+      )
+      if (refreshResult?.accessToken) {
+        await saveAntigravityCredentials({
+          ...creds,
+          access_token: refreshResult.accessToken,
+          expiry_date: refreshResult.expiresIn
+            ? Date.now() + refreshResult.expiresIn * 1000
+            : creds.expiry_date,
+          ...(refreshResult.newRefreshToken ? { refresh_token: refreshResult.newRefreshToken } : {})
+        })
+      }
+    }
+  } catch (err) {
+    // Ignore errors here and let the PTY fetcher fail naturally if the token is truly dead,
+    // or log them if necessary. The PTY fetcher handles surfacing errors to the user.
+    console.error('Failed to pre-refresh Antigravity token:', err)
+  }
+
+  // Use the PTY-based fetcher as it is the official way to query Antigravity limits
+  return fetchAntigravityRateLimitsViaPty(signal)
 }
 
 export async function fetchGeminiRateLimits(

--- a/src/main/rate-limits/gemini-usage-fetcher.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.ts
@@ -16,6 +16,7 @@ import {
   deduplicateBuckets,
   deriveSessionSummary
 } from './gemini-bucket-formatting'
+import { fetchAntigravityRateLimitsViaPty } from './agy-pty-fetcher'
 
 const API_TIMEOUT_MS = 10_000
 const RETRIEVE_QUOTA_URL = 'https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota'
@@ -216,8 +217,6 @@ async function fetchViaOauthCreds(
   }
   return result
 }
-
-import { fetchAntigravityRateLimitsViaPty } from './agy-pty-fetcher'
 
 export async function fetchAntigravityRateLimits(
   _geminiCliOAuthEnabled: boolean,

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -101,10 +101,8 @@ export function hasUsageProviderSettingsForProvider(
     return Boolean(settings.opencodeSessionCookie?.trim())
   }
   if (providerId === 'antigravity') {
-    // Why: the Antigravity snapshot mirrors the Gemini fetch, which stays
-    // 'unavailable' until the user opts into Gemini CLI OAuth. Without that
-    // gate the default-on checked item would pin a permanently dead bar.
-    return settings.antigravityUsageConfigured === true && settings.geminiCliOAuthEnabled === true
+    // Why: Antigravity has its own PTY fetcher and should not be gated behind Gemini CLI OAuth.
+    return settings.antigravityUsageConfigured === true
   }
   if (providerId === 'minimax') {
     return settings.minimaxCookieConfigured === true

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -9,10 +9,8 @@ export type UsageProviderSettings = Pick<
   | 'geminiCliOAuthEnabled'
 > & {
   // Why: Antigravity has no separate persisted usage credential in Orca. The
-  // checked status-bar item is the durable user signal; StatusBar only sets
-  // this after PATH detection says the agent is available. Durability further
-  // requires geminiCliOAuthEnabled — the snapshot mirrors the Gemini fetch,
-  // which never yields data while that opt-in is off.
+  // checked status-bar item is the durable user signal; StatusBar sets this
+  // after PATH detection says the agent is available.
   antigravityUsageConfigured: boolean
   // Why: MiniMax/Grok sign-in live on disk, not in settings; main sets these each poll.
   minimaxCookieConfigured: boolean
@@ -74,8 +72,7 @@ export function hasUsageProviderSettings(
     (settings?.claudeManagedAccounts?.length ?? 0) > 0 ||
     settings?.geminiCliOAuthEnabled === true ||
     Boolean(settings?.opencodeSessionCookie?.trim()) ||
-    // Antigravity's durable signal requires geminiCliOAuthEnabled, so it is
-    // already covered by the gemini term above.
+    settings?.antigravityUsageConfigured === true ||
     settings?.minimaxCookieConfigured === true ||
     settings?.grokAuthConfigured === true
   )


### PR DESCRIPTION
## Summary
Fixes issues with Antigravity (agy) CLI quota parsing and status bar visibility.

- Update PTY regexes to match 'five hour limit' (not '5h limit') and use `[\s\S]*?` to capture percentage across newlines in agy TUI output.
- Increase PTY viewport to 200x100 so agy renders full status lines.
- Add `postCommandOffset` to only parse output after `/usage` is sent.
- Reset `armStatusNudge` on every data event (not just the first).
- Broaden prompt detection to catch `>` on its own line.
- Match 'refreshes' in addition to 'resets' in reset-time parser.
- Decouple Antigravity status bar visibility from Gemini CLI OAuth setting.
- Always allow token refresh for Antigravity pre-PTY hydration.
- Add unit tests for agy PTY status parser.