### PR TITLE
Fix Windows PATH casing collisions in terminal environments

### DIFF
--- a/native/windows-cli-launcher/OrcaCliLauncher.cs
+++ b/native/windows-cli-launcher/OrcaCliLauncher.cs
@@ -10,6 +10,8 @@ internal static class OrcaCliLauncher
     {
         try
         {
+            NormalizeEnvironmentVariableCasing("Path", "PATH");
+
             string launcherDirectory = Path.GetDirectoryName(typeof(OrcaCliLauncher).Assembly.Location);
             string resourcesDirectory = Directory.GetParent(launcherDirectory).FullName;
             string appDirectory = Directory.GetParent(resourcesDirectory).FullName;
@@ -61,6 +63,20 @@ internal static class OrcaCliLauncher
         {
             Console.Error.WriteLine("Unable to start the Orca CLI: {0}", error.Message);
             return 1;
+        }
+    }
+
+    private static void NormalizeEnvironmentVariableCasing(
+        string preferredName,
+        string alternateName
+    )
+    {
+        string value = Environment.GetEnvironmentVariable(preferredName);
+        Environment.SetEnvironmentVariable(alternateName, null);
+        Environment.SetEnvironmentVariable(preferredName, null);
+        if (value != null)
+        {
+            Environment.SetEnvironmentVariable(preferredName, value);
         }
     }
 

--- a/src/main/git/runner.test.ts
+++ b/src/main/git/runner.test.ts
@@ -211,6 +211,30 @@ describe('appendGitConfigEnv', () => {
 })
 
 describe('mergeGitConfigEnvProtocol', () => {
+  it('collapses case-insensitive Windows keys and keeps the override casing', () => {
+    const env = mergeGitConfigEnvProtocol(
+      { Path: 'base-path', HOME: 'base-home' },
+      { PATH: 'override-path' },
+      'win32'
+    )
+
+    expect(Object.keys(env).filter((key) => key.toLowerCase() === 'path')).toEqual(['PATH'])
+    expect(env.PATH).toBe('override-path')
+    expect(env.Path).toBeUndefined()
+    expect(env.HOME).toBe('base-home')
+  })
+
+  it('preserves case-distinct environment keys on POSIX', () => {
+    const env = mergeGitConfigEnvProtocol(
+      { Path: 'mixed-case-path' },
+      { PATH: 'uppercase-path' },
+      'linux'
+    )
+
+    expect(env.Path).toBe('mixed-case-path')
+    expect(env.PATH).toBe('uppercase-path')
+  })
+
   it('replaces inherited indexed config atomically when an override has a smaller count', () => {
     const env = mergeGitConfigEnvProtocol(
       {

--- a/src/shared/git-credential-prompt-env.ts
+++ b/src/shared/git-credential-prompt-env.ts
@@ -6,9 +6,22 @@ const GIT_CONFIG_INDEXED_KEY_RE = /^GIT_CONFIG_(?:KEY|VALUE)_(\d+)$/
 /** Merge an indexed-config protocol as one atomic environment value. */
 export function mergeGitConfigEnvProtocol(
   baseEnv: NodeJS.ProcessEnv,
-  overrideEnv: NodeJS.ProcessEnv | undefined
+  overrideEnv: NodeJS.ProcessEnv | undefined,
+  platform: NodeJS.Platform = process.platform
 ): NodeJS.ProcessEnv {
-  const next = { ...baseEnv, ...overrideEnv }
+  const next: NodeJS.ProcessEnv = {}
+  const keyByNormalizedName = new Map<string, string>()
+  for (const env of [baseEnv, overrideEnv]) {
+    for (const [key, value] of Object.entries(env ?? {})) {
+      const normalizedName = platform === 'win32' ? key.toLowerCase() : key
+      const previousKey = keyByNormalizedName.get(normalizedName)
+      if (previousKey && previousKey !== key) {
+        delete next[previousKey]
+      }
+      next[key] = value
+      keyByNormalizedName.set(normalizedName, key)
+    }
+  }
   if (!overrideEnv || !Object.keys(overrideEnv).some((key) => GIT_CONFIG_WSLENV_KEY_RE.test(key))) {
     return next
   }


### PR DESCRIPTION
﻿## Summary

Fix Windows terminal environments that contain both `PATH` and `Path` after Orca merges inherited and override environment objects.

The bug has two failure modes:

1. JavaScript object spreading is case-sensitive, while Windows environment-variable names are not. An inherited `Path` plus an override `PATH` therefore produced two entries in the child environment block.
2. The native .NET CLI launcher accessed `ProcessStartInfo.EnvironmentVariables` before repairing the casing. `StringDictionary` then failed with `Item has already been added. Key in dictionary: 'PATH' Key being added: 'Path'`.

This PR:

- merges all Windows environment keys case-insensitively while preserving override precedence and casing;
- keeps POSIX case-distinct keys unchanged;
- normalizes `PATH`/`Path` in the native launcher before constructing any environment dictionary;
- adds Windows and POSIX regression coverage.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (run; code-quality checks passed, but the repository-wide command stopped at pre-existing stale generated skill artifacts: `resources/skills/current-manifest.json`, `snapshot-registry.json`, and `release-mapping.json`)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full suite not run)
- [ ] `pnpm build` (full application build not run; native Windows launcher compiled successfully)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification completed on Windows:

- `pnpm exec oxfmt --check src/shared/git-credential-prompt-env.ts src/main/git/runner.test.ts`
- `pnpm typecheck`
- `pnpm exec vitest run src/main/git/runner.test.ts config/scripts/build-windows-cli-launcher.test.mjs`
  - 2 test files passed
  - 39 tests passed, 1 skipped
- compiled the native launcher with `config/scripts/build-windows-cli-launcher.mjs`
- verified the compiled launcher in a real process whose raw Windows environment block still contained both `PATH` and `Path`
- verified `orca skills get orca-cli`, `orca status --json`, and a fresh `powershell.exe -NoProfile` child invocation

## AI Review Report

The review traced the environment flow from terminal creation through `mergeGitConfigEnvProtocol` into the native launcher and checked both producer and consumer failure boundaries.

Main risks reviewed:

- override precedence is retained when differently cased keys collide;
- only Windows receives case-insensitive key handling;
- macOS and Linux continue to preserve case-distinct environment names;
- the indexed Git config protocol remains atomically replaced;
- the launcher normalization happens before any `StringDictionary` access;
- no shell quoting, path lookup, SSH, folder-workspace, UI, shortcut, label, or Electron IPC behavior changes.

The review added explicit Windows/POSIX tests and retained the existing native launcher argument-preservation integration test. No unrelated cleanup was included.

## Security Audit

No authentication, authorization, secrets, dependencies, IPC contracts, or persistent machine/user environment settings are changed.

The native change modifies only the launcher process environment inherited by its child. It does not write the registry or mutate the parent process. Argument forwarding and executable-path resolution are unchanged. Environment values are copied without interpretation or command construction.

## Notes

The producer-side fix prevents future duplicate case-insensitive keys. The launcher-side normalization is defense in depth for environments produced by older Orca daemons or other Windows process launchers.
