### PR TITLE
fix(browser): scope Cmd/Ctrl+F find to the focused split (#11348)

### DIFF
--- a/src/main/browser/browser-guest-ui.test.ts
+++ b/src/main/browser/browser-guest-ui.test.ts
@@ -570,6 +570,36 @@ describe('setupGuestShortcutForwarding', () => {
     expect(rendererSendMock).toHaveBeenNthCalledWith(2, 'ui:browserHistoryNavigate', 'forward')
   })
 
+  it('forwards browser Find with its registered page and workspace owner', () => {
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest: makeGuest(),
+      resolveRenderer: () => makeRenderer(),
+      resolveWorkspaceId: () => 'workspace-1'
+    })
+
+    const preventDefault = triggerBeforeInput({ code: 'KeyF', key: 'f' })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(rendererSendMock).toHaveBeenCalledWith('ui:findInBrowserPage', {
+      browserPageId: browserTabId,
+      browserWorkspaceId: 'workspace-1'
+    })
+  })
+
+  it('does not broadcast browser Find without a registered workspace owner', () => {
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest: makeGuest(),
+      resolveRenderer: () => makeRenderer()
+    })
+
+    const preventDefault = triggerBeforeInput({ code: 'KeyF', key: 'f' })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(rendererSendMock).not.toHaveBeenCalled()
+  })
+
   it('forwards quick-command menu shortcuts from focused guest pages', () => {
     setupGuestShortcutForwarding({
       browserTabId,

--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -20,6 +20,7 @@ import {
   ModifierDoubleTapDetector,
   toModifierDoubleTapEvent
 } from '../../shared/modifier-double-tap-detector'
+import type { BrowserFindSource } from '../../shared/browser-find-source'
 
 type ResolveRenderer = (browserTabId: string) => Electron.WebContents | null
 type ShouldForwardDictationShortcut = () => boolean
@@ -264,6 +265,7 @@ export function setupGuestShortcutForwarding(args: {
   getKeybindings?: () => KeybindingOverrides | undefined
   // Why: a floating-panel guest owns a distinct workspace; its close/index chords must route to the panel, not the main tab strip.
   resolveWorktreeId?: (browserTabId: string) => string | null
+  resolveWorkspaceId?: (browserTabId: string) => string | null
 }): () => void {
   const {
     browserTabId,
@@ -272,7 +274,8 @@ export function setupGuestShortcutForwarding(args: {
     shouldForwardDictationShortcut,
     isMobileEmulatorEnabled,
     getKeybindings,
-    resolveWorktreeId
+    resolveWorktreeId,
+    resolveWorkspaceId
   } = args
   let ctrlTabSwitching = false
   const doubleTapDetector = new ModifierDoubleTapDetector()
@@ -397,8 +400,15 @@ export function setupGuestShortcutForwarding(args: {
       // Why: forward soft reload so the renderer's reload() hits the parked-webview eviction the guest's built-in shortcut skips.
       renderer.send('ui:reloadBrowserPage')
     } else if (keybindingMatchesAction('browser.find', input, process.platform, keybindings)) {
-      // Why: guest-native find UI is invisible behind Orca's chrome; forward so the renderer opens its own find-in-page bar.
-      renderer.send('ui:findInBrowserPage')
+      const browserWorkspaceId = resolveWorkspaceId?.(browserTabId)
+      if (browserWorkspaceId) {
+        const source: BrowserFindSource = {
+          browserPageId: browserTabId,
+          browserWorkspaceId
+        }
+        // Why: active browser splits share one renderer; preserve the registered guest owner so only its Find bar opens.
+        renderer.send('ui:findInBrowserPage', source)
+      }
     } else if (keybindingMatchesAction('browser.back', input, process.platform, keybindings)) {
       // Why: macOS Logitech side-button remaps arrive as history keystrokes, not mouse events; forward so the renderer can goBack().
       renderer.send('ui:browserHistoryNavigate', 'back')

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -1715,7 +1715,8 @@ export class BrowserManager {
         shouldForwardDictationShortcut: () => this.shouldForwardDictationShortcut?.() ?? false,
         isMobileEmulatorEnabled: () => this.settingsResolver?.().mobileEmulatorEnabled !== false,
         getKeybindings: () => this.settingsResolver?.().keybindings,
-        resolveWorktreeId: (tabId) => this.worktreeIdByTabId.get(tabId) ?? null
+        resolveWorktreeId: (tabId) => this.worktreeIdByTabId.get(tabId) ?? null,
+        resolveWorkspaceId: (tabId) => this.workspaceIdByPageId.get(tabId) ?? null
       })
     )
   }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -9,6 +9,7 @@ import type {
   HostedReviewProvider
 } from '../shared/hosted-review'
 import type { NativeFileDropPayload } from '../shared/native-file-drop'
+import type { BrowserFindSource } from '../shared/browser-find-source'
 import type { DashboardSnapshot, DashboardRevealAgentArgs } from '../shared/dashboard-snapshot'
 import type {
   TerminalPreviewConnectResult,
@@ -3111,7 +3112,7 @@ export type PreloadApi = {
     replyTabClose: (reply: { requestId: string; error?: string }) => void
     onNewTerminalTab: (callback: () => void) => () => void
     onFocusBrowserAddressBar: (callback: () => void) => () => void
-    onFindInBrowserPage: (callback: () => void) => () => void
+    onFindInBrowserPage: (source: BrowserFindSource, callback: () => void) => () => void
     onReloadBrowserPage: (callback: () => void) => () => void
     onBrowserHistoryNavigate: (callback: (direction: 'back' | 'forward') => void) => () => void
     onZoomBrowserPage: (callback: (direction: 'in' | 'out' | 'reset') => void) => () => void

--- a/src/preload/browser-find-subscriptions.test.ts
+++ b/src/preload/browser-find-subscriptions.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createBrowserFindSubscriptions } from './browser-find-subscriptions'
+
+const FIRST_SOURCE = {
+  browserPageId: 'page-1',
+  browserWorkspaceId: 'workspace-1'
+}
+const SAME_WORKSPACE_SOURCE = {
+  browserPageId: 'page-2',
+  browserWorkspaceId: FIRST_SOURCE.browserWorkspaceId
+}
+const SAME_PAGE_SOURCE = {
+  browserPageId: FIRST_SOURCE.browserPageId,
+  browserWorkspaceId: 'workspace-2'
+}
+
+describe('browser Find subscriptions', () => {
+  it('dispatches only to the exact browser page and workspace owner', () => {
+    const subscriptions = createBrowserFindSubscriptions()
+    const firstCallback = vi.fn()
+    const sameWorkspaceCallback = vi.fn()
+    const samePageCallback = vi.fn()
+    subscriptions.subscribe(FIRST_SOURCE, firstCallback)
+    subscriptions.subscribe(SAME_WORKSPACE_SOURCE, sameWorkspaceCallback)
+    subscriptions.subscribe(SAME_PAGE_SOURCE, samePageCallback)
+
+    subscriptions.dispatch(FIRST_SOURCE)
+
+    expect(firstCallback).toHaveBeenCalledOnce()
+    expect(sameWorkspaceCallback).not.toHaveBeenCalled()
+    expect(samePageCallback).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed and partial source identities', () => {
+    const subscriptions = createBrowserFindSubscriptions()
+    const callback = vi.fn()
+    subscriptions.subscribe(FIRST_SOURCE, callback)
+
+    subscriptions.dispatch(undefined)
+    subscriptions.dispatch({ browserPageId: FIRST_SOURCE.browserPageId })
+    subscriptions.dispatch({
+      browserPageId: FIRST_SOURCE.browserPageId,
+      browserWorkspaceId: ''
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('drops empty ownership entries when subscribers clean up', () => {
+    const subscriptions = createBrowserFindSubscriptions()
+    const callback = vi.fn()
+    const unsubscribe = subscriptions.subscribe(FIRST_SOURCE, callback)
+
+    unsubscribe()
+    subscriptions.dispatch(FIRST_SOURCE)
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/src/preload/browser-find-subscriptions.ts
+++ b/src/preload/browser-find-subscriptions.ts
@@ -1,0 +1,51 @@
+import { isBrowserFindSource, type BrowserFindSource } from '../shared/browser-find-source'
+
+type BrowserFindCallback = () => void
+
+export function createBrowserFindSubscriptions(): {
+  dispatch: (source: unknown) => void
+  subscribe: (source: BrowserFindSource, callback: BrowserFindCallback) => () => void
+} {
+  const callbacksByWorkspace = new Map<string, Map<string, Set<BrowserFindCallback>>>()
+
+  return {
+    dispatch: (source) => {
+      if (!isBrowserFindSource(source)) {
+        return
+      }
+      const callbacks = callbacksByWorkspace
+        .get(source.browserWorkspaceId)
+        ?.get(source.browserPageId)
+      if (!callbacks) {
+        return
+      }
+      for (const callback of callbacks) {
+        callback()
+      }
+    },
+    subscribe: (source, callback) => {
+      let callbacksByPage = callbacksByWorkspace.get(source.browserWorkspaceId)
+      if (!callbacksByPage) {
+        callbacksByPage = new Map()
+        callbacksByWorkspace.set(source.browserWorkspaceId, callbacksByPage)
+      }
+      let callbacks = callbacksByPage.get(source.browserPageId)
+      if (!callbacks) {
+        callbacks = new Set()
+        callbacksByPage.set(source.browserPageId, callbacks)
+      }
+      callbacks.add(callback)
+
+      return () => {
+        callbacks.delete(callback)
+        if (callbacks.size > 0) {
+          return
+        }
+        callbacksByPage.delete(source.browserPageId)
+        if (callbacksByPage.size === 0) {
+          callbacksByWorkspace.delete(source.browserWorkspaceId)
+        }
+      }
+    }
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -209,6 +209,7 @@ import type {
   PreloadApi
 } from './api-types'
 import type { AgentKind, LaunchSource, RequestKind } from '../shared/telemetry-events'
+import { createBrowserFindSubscriptions } from './browser-find-subscriptions'
 import type { AppStarSource } from '../shared/gh-star-source'
 import type { ExecutionHostId } from '../shared/execution-host'
 import type {
@@ -455,6 +456,11 @@ document.addEventListener(
 )
 
 const startupDiagnosticsEnabled = process.env.ORCA_STARTUP_DIAGNOSTICS === '1'
+const browserFindSubscriptions = createBrowserFindSubscriptions()
+
+ipcRenderer.on('ui:findInBrowserPage', (_event, source: unknown) => {
+  browserFindSubscriptions.dispatch(source)
+})
 
 // Custom APIs for renderer
 const api = {
@@ -3577,11 +3583,7 @@ const api = {
       ipcRenderer.on('ui:focusBrowserAddressBar', listener)
       return () => ipcRenderer.removeListener('ui:focusBrowserAddressBar', listener)
     },
-    onFindInBrowserPage: (callback: () => void): (() => void) => {
-      const listener = (_event: Electron.IpcRendererEvent) => callback()
-      ipcRenderer.on('ui:findInBrowserPage', listener)
-      return () => ipcRenderer.removeListener('ui:findInBrowserPage', listener)
-    },
+    onFindInBrowserPage: browserFindSubscriptions.subscribe,
     onReloadBrowserPage: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:reloadBrowserPage', listener)

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -753,17 +753,31 @@ function retryBrowserTabLoad(
   webview.src = retryUrl
 }
 
+export type BrowserFindShortcutScope = 'focused' | 'inactive' | 'owned-target'
+
+function browserOverlayOwnsShortcutTarget(
+  target: EventTarget | null,
+  browserTabId: string
+): boolean {
+  if (!(target instanceof Element)) {
+    return false
+  }
+  return (
+    target.closest('[data-browser-overlay-tab-id]')?.getAttribute('data-browser-overlay-tab-id') ===
+    browserTabId
+  )
+}
+
 export default function BrowserPane({
   browserTab,
   isActive,
-  isFocused
+  findShortcutScope
 }: {
   browserTab: BrowserWorkspaceState
   isActive: boolean
-  // Why: whether this browser's split holds focus. Gates Find (Cmd/Ctrl+F) so a focused terminal in the same split keeps the chord (#11348). Floating panels omit it and fall back to isActive.
-  isFocused?: boolean
+  findShortcutScope?: BrowserFindShortcutScope
 }): React.JSX.Element {
-  const resolvedIsFocused = isFocused ?? isActive
+  const resolvedFindShortcutScope = findShortcutScope ?? (isActive ? 'focused' : 'inactive')
   const activeRuntimeEnvironmentId = useAppStore((s) =>
     getRuntimeEnvironmentIdForWorktree(s, browserTab.worktreeId)
   )
@@ -856,7 +870,9 @@ export default function BrowserPane({
               sessionProfileId={browserTab.sessionProfileId ?? null}
               sessionPartition={browserTab.sessionPartition ?? null}
               isActive={isActive && page.id === activeBrowserPage?.id}
-              isFocused={resolvedIsFocused && page.id === activeBrowserPage?.id}
+              findShortcutScope={
+                page.id === activeBrowserPage?.id ? resolvedFindShortcutScope : 'inactive'
+              }
               isAutomationVisible={automationVisiblePageIds.has(page.id)}
               isMobileDriven={mobileDrivenPageIds.has(page.id)}
               inputLocked={activeBrowserDriver.kind === 'mobile'}
@@ -2760,7 +2776,7 @@ function BrowserPagePane({
   sessionProfileId,
   sessionPartition,
   isActive,
-  isFocused,
+  findShortcutScope,
   isAutomationVisible,
   isMobileDriven,
   inputLocked,
@@ -2773,8 +2789,7 @@ function BrowserPagePane({
   sessionProfileId: string | null
   sessionPartition: string | null
   isActive: boolean
-  // Why: this browser's split holds focus; the renderer-path Find listener is window-global, so it must only arm when focused or it steals Cmd/Ctrl+F from a focused terminal in the same split (#11348).
-  isFocused: boolean
+  findShortcutScope: BrowserFindShortcutScope
   isAutomationVisible: boolean
   isMobileDriven: boolean
   inputLocked: boolean
@@ -3454,14 +3469,19 @@ function BrowserPagePane({
 
   // Cmd/Ctrl+F — find in page (renderer path: focus on browser chrome)
   // Why: unlike bare C/S grab shortcuts, Cmd+F should always open find even from the address bar (matches Chrome/Safari).
-  // Gate on isFocused, not isActive: this is a window-global capture listener, so an active-but-unfocused browser in a split would otherwise swallow Cmd/Ctrl+F from the focused terminal (#11348).
   useEffect(() => {
-    if (!isFocused) {
+    if (findShortcutScope === 'inactive') {
       return
     }
     const shortcutPlatform = getShortcutPlatform()
     const handleKeyDown = (e: KeyboardEvent): void => {
       if (!keybindingMatchesAction('browser.find', e, shortcutPlatform, keybindings)) {
+        return
+      }
+      if (
+        findShortcutScope === 'owned-target' &&
+        !browserOverlayOwnsShortcutTarget(e.target, workspaceId)
+      ) {
         return
       }
       e.preventDefault()
@@ -3470,7 +3490,7 @@ function BrowserPagePane({
     }
     window.addEventListener('keydown', handleKeyDown, true)
     return () => window.removeEventListener('keydown', handleKeyDown, true)
-  }, [isFocused, keybindings])
+  }, [findShortcutScope, keybindings, workspaceId])
 
   // Cmd/Ctrl+F — find in page (IPC path: focus inside webview guest)
   // Why: a focused guest is a separate Chromium process, so main forwards the chord back here.

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -755,11 +755,15 @@ function retryBrowserTabLoad(
 
 export default function BrowserPane({
   browserTab,
-  isActive
+  isActive,
+  isFocused
 }: {
   browserTab: BrowserWorkspaceState
   isActive: boolean
+  // Why: whether this browser's split holds focus. Gates Find (Cmd/Ctrl+F) so a focused terminal in the same split keeps the chord (#11348). Floating panels omit it and fall back to isActive.
+  isFocused?: boolean
 }): React.JSX.Element {
+  const resolvedIsFocused = isFocused ?? isActive
   const activeRuntimeEnvironmentId = useAppStore((s) =>
     getRuntimeEnvironmentIdForWorktree(s, browserTab.worktreeId)
   )
@@ -852,6 +856,7 @@ export default function BrowserPane({
               sessionProfileId={browserTab.sessionProfileId ?? null}
               sessionPartition={browserTab.sessionPartition ?? null}
               isActive={isActive && page.id === activeBrowserPage?.id}
+              isFocused={resolvedIsFocused && page.id === activeBrowserPage?.id}
               isAutomationVisible={automationVisiblePageIds.has(page.id)}
               isMobileDriven={mobileDrivenPageIds.has(page.id)}
               inputLocked={activeBrowserDriver.kind === 'mobile'}
@@ -2755,6 +2760,7 @@ function BrowserPagePane({
   sessionProfileId,
   sessionPartition,
   isActive,
+  isFocused,
   isAutomationVisible,
   isMobileDriven,
   inputLocked,
@@ -2767,6 +2773,8 @@ function BrowserPagePane({
   sessionProfileId: string | null
   sessionPartition: string | null
   isActive: boolean
+  // Why: this browser's split holds focus; the renderer-path Find listener is window-global, so it must only arm when focused or it steals Cmd/Ctrl+F from a focused terminal in the same split (#11348).
+  isFocused: boolean
   isAutomationVisible: boolean
   isMobileDriven: boolean
   inputLocked: boolean
@@ -3446,8 +3454,9 @@ function BrowserPagePane({
 
   // Cmd/Ctrl+F — find in page (renderer path: focus on browser chrome)
   // Why: unlike bare C/S grab shortcuts, Cmd+F should always open find even from the address bar (matches Chrome/Safari).
+  // Gate on isFocused, not isActive: this is a window-global capture listener, so an active-but-unfocused browser in a split would otherwise swallow Cmd/Ctrl+F from the focused terminal (#11348).
   useEffect(() => {
-    if (!isActive) {
+    if (!isFocused) {
       return
     }
     const shortcutPlatform = getShortcutPlatform()
@@ -3461,7 +3470,7 @@ function BrowserPagePane({
     }
     window.addEventListener('keydown', handleKeyDown, true)
     return () => window.removeEventListener('keydown', handleKeyDown, true)
-  }, [isActive, keybindings])
+  }, [isFocused, keybindings])
 
   // Cmd/Ctrl+F — find in page (IPC path: focus inside webview guest)
   // Why: a focused guest is a separate Chromium process, so main forwards the chord back here.

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -3498,10 +3498,13 @@ function BrowserPagePane({
     if (!isActive) {
       return
     }
-    return window.api.ui.onFindInBrowserPage(() => {
-      setFindOpen(true)
-    })
-  }, [isActive])
+    return window.api.ui.onFindInBrowserPage(
+      { browserPageId: browserTab.id, browserWorkspaceId: workspaceId },
+      () => {
+        setFindOpen(true)
+      }
+    )
+  }, [browserTab.id, isActive, workspaceId])
 
   // Browser history shortcuts (renderer path: focus on browser chrome)
   // Why: macOS can't deliver Logitech side-buttons to Electron; Logi Options+ remaps them to history chords, handled here when chrome is focused.

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -6,6 +6,7 @@ type MockAppState = {
   browserTabsByWorktree: Record<string, readonly BrowserTabState[]>
   unifiedTabsByWorktree: Record<string, readonly Tab[]>
   groupsByWorktree: Record<string, readonly TabGroup[]>
+  activeGroupIdByWorktree: Record<string, string>
   focusGroup: (worktreeId: string, groupId: string) => void
 }
 
@@ -36,10 +37,19 @@ vi.mock('@/lib/pane-manager/browser-mobile-driver-state', () => ({
 }))
 
 vi.mock('./BrowserPane', () => ({
-  default: ({ browserTab, isActive }: { browserTab: BrowserTabState; isActive: boolean }) => (
+  default: ({
+    browserTab,
+    isActive,
+    isFocused
+  }: {
+    browserTab: BrowserTabState
+    isActive: boolean
+    isFocused?: boolean
+  }) => (
     <span
       data-browser-pane-id={browserTab.id}
       data-browser-pane-active={isActive ? 'true' : 'false'}
+      data-browser-pane-focused={isFocused ? 'true' : 'false'}
     />
   )
 }))
@@ -61,6 +71,28 @@ describe('BrowserPaneOverlayLayer', () => {
     expect(markup).toContain('data-browser-pane-active="true"')
     expect(markup).toContain('data-browser-pane-id="browser-b"')
     expect(markup).toContain('data-browser-pane-active="false"')
+  })
+
+  it('marks the active browser pane focused when its own group holds focus', () => {
+    const markup = renderOverlay({ isWorktreeActive: true })
+
+    // browser-a is the active tab of group-1, and group-1 is the focused split.
+    expect(markup).toContain(
+      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-pane-focused="true"'
+    )
+  })
+
+  it('keeps an active browser pane unfocused when another split holds focus (#11348)', () => {
+    // Terminal split (group-2) holds keyboard focus; the browser stays the active
+    // tab within its own group-1 but must not claim the focused-split Find shortcut.
+    mocks.state = createState()
+    mocks.state.activeGroupIdByWorktree = { 'wt-1': 'group-2' }
+
+    const markup = renderOverlay({ isWorktreeActive: true })
+
+    expect(markup).toContain(
+      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-pane-focused="false"'
+    )
   })
 
   it('marks automation-visible inactive browser panes paintable without remounting them', () => {
@@ -126,6 +158,8 @@ function createState(): MockAppState {
         }
       ]
     },
+    // Default: the browser's own group holds focus, so active === focused.
+    activeGroupIdByWorktree: { 'wt-1': 'group-1' },
     focusGroup: mocks.focusGroup
   }
 }

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -40,16 +40,16 @@ vi.mock('./BrowserPane', () => ({
   default: ({
     browserTab,
     isActive,
-    isFocused
+    findShortcutScope
   }: {
     browserTab: BrowserTabState
     isActive: boolean
-    isFocused?: boolean
+    findShortcutScope?: string
   }) => (
     <span
       data-browser-pane-id={browserTab.id}
       data-browser-pane-active={isActive ? 'true' : 'false'}
-      data-browser-pane-focused={isFocused ? 'true' : 'false'}
+      data-browser-find-shortcut-scope={findShortcutScope}
     />
   )
 }))
@@ -78,7 +78,7 @@ describe('BrowserPaneOverlayLayer', () => {
 
     // browser-a is the active tab of group-1, and group-1 is the focused split.
     expect(markup).toContain(
-      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-pane-focused="true"'
+      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-find-shortcut-scope="focused"'
     )
   })
 
@@ -91,7 +91,47 @@ describe('BrowserPaneOverlayLayer', () => {
     const markup = renderOverlay({ isWorktreeActive: true })
 
     expect(markup).toContain(
-      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-pane-focused="false"'
+      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-find-shortcut-scope="inactive"'
+    )
+  })
+
+  it('limits Find to the owning target while focused-group state is unavailable', () => {
+    mocks.state = createState()
+    mocks.state.activeGroupIdByWorktree = {}
+
+    const markup = renderOverlay({ isWorktreeActive: true })
+
+    expect(markup).toContain(
+      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-find-shortcut-scope="owned-target"'
+    )
+  })
+
+  it('keeps Find ownership with group identities after split order changes', () => {
+    mocks.state = createState()
+    const [tabA, tabB] = mocks.state.unifiedTabsByWorktree['wt-1']
+    const [groupA] = mocks.state.groupsByWorktree['wt-1']
+    mocks.state.unifiedTabsByWorktree = {
+      'wt-1': [{ ...tabB, groupId: 'group-2' }, tabA]
+    }
+    mocks.state.groupsByWorktree = {
+      'wt-1': [
+        {
+          id: 'group-2',
+          worktreeId: 'wt-1',
+          activeTabId: tabB.id,
+          tabOrder: [tabB.id]
+        },
+        { ...groupA, tabOrder: [tabA.id] }
+      ]
+    }
+
+    const markup = renderOverlay({ isWorktreeActive: true })
+
+    expect(markup).toContain(
+      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-find-shortcut-scope="focused"'
+    )
+    expect(markup).toContain(
+      'data-browser-pane-id="browser-b" data-browser-pane-active="true" data-browser-find-shortcut-scope="inactive"'
     )
   })
 

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -83,9 +83,18 @@ describe('BrowserPaneOverlayLayer', () => {
   })
 
   it('keeps an active browser pane unfocused when another split holds focus (#11348)', () => {
-    // Terminal split (group-2) holds keyboard focus; the browser stays the active
-    // tab within its own group-1 but must not claim the focused-split Find shortcut.
     mocks.state = createState()
+    mocks.state.groupsByWorktree = {
+      'wt-1': [
+        ...mocks.state.groupsByWorktree['wt-1'],
+        {
+          id: 'group-2',
+          worktreeId: 'wt-1',
+          activeTabId: null,
+          tabOrder: []
+        }
+      ]
+    }
     mocks.state.activeGroupIdByWorktree = { 'wt-1': 'group-2' }
 
     const markup = renderOverlay({ isWorktreeActive: true })
@@ -98,6 +107,17 @@ describe('BrowserPaneOverlayLayer', () => {
   it('limits Find to the owning target while focused-group state is unavailable', () => {
     mocks.state = createState()
     mocks.state.activeGroupIdByWorktree = {}
+
+    const markup = renderOverlay({ isWorktreeActive: true })
+
+    expect(markup).toContain(
+      'data-browser-pane-id="browser-a" data-browser-pane-active="true" data-browser-find-shortcut-scope="owned-target"'
+    )
+  })
+
+  it('limits Find to the owning target when the focused-group ID is stale', () => {
+    mocks.state = createState()
+    mocks.state.activeGroupIdByWorktree = { 'wt-1': 'removed-group' }
 
     const markup = renderOverlay({ isWorktreeActive: true })
 

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -128,6 +128,13 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
     }))
   )
   const focusGroup = useAppStore((state) => state.focusGroup)
+  const knownFocusedGroupId = useMemo(
+    () =>
+      focusedGroupId !== undefined && groups.some((group) => group.id === focusedGroupId)
+        ? focusedGroupId
+        : undefined,
+    [focusedGroupId, groups]
+  )
 
   // Why: stable identity so BrowserOverlaySlot's memo holds; groupId is passed at call time so one callback serves every slot.
   const focusOwningGroup = useCallback(
@@ -166,9 +173,9 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
         const isActive = Boolean(isWorktreeActive && assignment && assignment.isActiveInGroup)
         const findShortcutScope: BrowserFindShortcutScope = !isActive
           ? 'inactive'
-          : focusedGroupId === undefined
+          : knownFocusedGroupId === undefined
             ? 'owned-target'
-            : assignment?.groupId === focusedGroupId
+            : assignment?.groupId === knownFocusedGroupId
               ? 'focused'
               : 'inactive'
         return (

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -24,6 +24,8 @@ type BrowserOverlaySlotProps = {
   // Why: undefined = orphan tab (in browserTabs but not referenced by any group's unified-tab list); the fallback branch keeps these hidden.
   groupId: string | undefined
   isActive: boolean
+  // Why: active-in-group ≠ focused split. Find (Cmd/Ctrl+F) must only arm for the focused split, or the browser claims the chord from a focused terminal in the same split (#11348).
+  isFocused: boolean
   // Why: overlay is a sibling of the group layout, so pane focus doesn't bubble to TabGroupPanel; re-sync it here or split-view clicks leave activeGroupIdByWorktree stale.
   onFocusOwningGroup: ((groupId: string) => void) | undefined
   isWorktreeActive: boolean
@@ -34,6 +36,7 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   browserTab,
   groupId,
   isActive,
+  isFocused,
   onFocusOwningGroup,
   isWorktreeActive
 }: BrowserOverlaySlotProps): React.JSX.Element {
@@ -97,12 +100,14 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
     >
       <div ref={setSlotViewportRef} className="absolute inset-0 flex min-h-0 flex-col" />
       {/* Why: hidden worktrees park the heavy pane subtree; visible ones keep stable slots so reparenting can't destroy the webview guest. */}
-      {shouldMountPane ? <BrowserPane browserTab={browserTab} isActive={isActive} /> : null}
+      {shouldMountPane ? (
+        <BrowserPane browserTab={browserTab} isActive={isActive} isFocused={isFocused} />
+      ) : null}
     </div>
   )
 })
 
-// Why: memoize so parent re-renders on props this layer doesn't consume (e.g. focusedGroupId) don't rerun its selector or assignments mapping.
+// Why: memoize so parent re-renders on props this layer doesn't consume don't rerun its selector or assignments mapping (focused-split state comes from the store selector below, not props).
 const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
   worktreeId,
   isWorktreeActive
@@ -110,11 +115,13 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
   worktreeId: string
   isWorktreeActive: boolean
 }): React.JSX.Element {
-  const { browserTabs, unifiedTabs, groups } = useAppStore(
+  const { browserTabs, unifiedTabs, groups, focusedGroupId } = useAppStore(
     useShallow((state) => ({
       browserTabs: state.browserTabsByWorktree[worktreeId] ?? EMPTY_BROWSER_TABS,
       unifiedTabs: state.unifiedTabsByWorktree[worktreeId] ?? EMPTY_UNIFIED_TABS,
-      groups: state.groupsByWorktree[worktreeId] ?? EMPTY_GROUPS
+      groups: state.groupsByWorktree[worktreeId] ?? EMPTY_GROUPS,
+      // Why: the focused split within this worktree; gates the browser Find shortcut so a focused terminal in the same split keeps Cmd/Ctrl+F (#11348).
+      focusedGroupId: state.activeGroupIdByWorktree[worktreeId]
     }))
   )
   const focusGroup = useAppStore((state) => state.focusGroup)
@@ -154,12 +161,15 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
       {browserTabs.map((browserTab) => {
         const assignment = assignments.get(browserTab.id)
         const isActive = Boolean(isWorktreeActive && assignment && assignment.isActiveInGroup)
+        // Why: focused only when this browser's group is the focused split — not merely the active tab in its own group.
+        const isFocused = isActive && assignment?.groupId === focusedGroupId
         return (
           <BrowserOverlaySlot
             key={browserTab.id}
             browserTab={browserTab}
             groupId={assignment?.groupId}
             isActive={isActive}
+            isFocused={isFocused}
             onFocusOwningGroup={focusOwningGroup}
             isWorktreeActive={isWorktreeActive}
           />

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -3,7 +3,7 @@ import { registerBrowserOverlaySlotViewport } from './browser-page-viewport'
 import { useShallow } from 'zustand/react/shallow'
 import { useAppStore } from '../../store'
 import type { BrowserTab as BrowserTabState, Tab, TabGroup } from '../../../../shared/types'
-import BrowserPane from './BrowserPane'
+import BrowserPane, { type BrowserFindShortcutScope } from './BrowserPane'
 import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
 import { useBrowserAutomationVisibilityForAny } from './browser-automation-visibility'
 import { useBrowserMobileDriverForAny } from '@/lib/pane-manager/browser-mobile-driver-state'
@@ -24,8 +24,7 @@ type BrowserOverlaySlotProps = {
   // Why: undefined = orphan tab (in browserTabs but not referenced by any group's unified-tab list); the fallback branch keeps these hidden.
   groupId: string | undefined
   isActive: boolean
-  // Why: active-in-group ≠ focused split. Find (Cmd/Ctrl+F) must only arm for the focused split, or the browser claims the chord from a focused terminal in the same split (#11348).
-  isFocused: boolean
+  findShortcutScope: BrowserFindShortcutScope
   // Why: overlay is a sibling of the group layout, so pane focus doesn't bubble to TabGroupPanel; re-sync it here or split-view clicks leave activeGroupIdByWorktree stale.
   onFocusOwningGroup: ((groupId: string) => void) | undefined
   isWorktreeActive: boolean
@@ -36,7 +35,7 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   browserTab,
   groupId,
   isActive,
-  isFocused,
+  findShortcutScope,
   onFocusOwningGroup,
   isWorktreeActive
 }: BrowserOverlaySlotProps): React.JSX.Element {
@@ -101,7 +100,11 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
       <div ref={setSlotViewportRef} className="absolute inset-0 flex min-h-0 flex-col" />
       {/* Why: hidden worktrees park the heavy pane subtree; visible ones keep stable slots so reparenting can't destroy the webview guest. */}
       {shouldMountPane ? (
-        <BrowserPane browserTab={browserTab} isActive={isActive} isFocused={isFocused} />
+        <BrowserPane
+          browserTab={browserTab}
+          isActive={isActive}
+          findShortcutScope={findShortcutScope}
+        />
       ) : null}
     </div>
   )
@@ -161,15 +164,20 @@ const BrowserPaneOverlayLayer = memo(function BrowserPaneOverlayLayer({
       {browserTabs.map((browserTab) => {
         const assignment = assignments.get(browserTab.id)
         const isActive = Boolean(isWorktreeActive && assignment && assignment.isActiveInGroup)
-        // Why: focused only when this browser's group is the focused split — not merely the active tab in its own group.
-        const isFocused = isActive && assignment?.groupId === focusedGroupId
+        const findShortcutScope: BrowserFindShortcutScope = !isActive
+          ? 'inactive'
+          : focusedGroupId === undefined
+            ? 'owned-target'
+            : assignment?.groupId === focusedGroupId
+              ? 'focused'
+              : 'inactive'
         return (
           <BrowserOverlaySlot
             key={browserTab.id}
             browserTab={browserTab}
             groupId={assignment?.groupId}
             isActive={isActive}
-            isFocused={isFocused}
+            findShortcutScope={findShortcutScope}
             onFocusOwningGroup={focusOwningGroup}
             isWorktreeActive={isWorktreeActive}
           />

--- a/src/shared/browser-find-source.ts
+++ b/src/shared/browser-find-source.ts
@@ -1,0 +1,17 @@
+export type BrowserFindSource = {
+  browserPageId: string
+  browserWorkspaceId: string
+}
+
+export function isBrowserFindSource(value: unknown): value is BrowserFindSource {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const source = value as Partial<BrowserFindSource>
+  return (
+    typeof source.browserPageId === 'string' &&
+    source.browserPageId.length > 0 &&
+    typeof source.browserWorkspaceId === 'string' &&
+    source.browserWorkspaceId.length > 0
+  )
+}

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -286,6 +286,25 @@ describe('keybindings', () => {
     expect(keybindingMatchesAction('editor.addReviewNote', oldCtrlAltChord, 'win32')).toBe(false)
   })
 
+  it('maps browser Find to Command on macOS and Control elsewhere', () => {
+    const commandF = {
+      key: 'f',
+      code: 'KeyF',
+      meta: true,
+      control: false,
+      alt: false,
+      shift: false
+    }
+    const controlF = { ...commandF, meta: false, control: true }
+
+    expect(keybindingMatchesAction('browser.find', commandF, 'darwin')).toBe(true)
+    expect(keybindingMatchesAction('browser.find', controlF, 'darwin')).toBe(false)
+    expect(keybindingMatchesAction('browser.find', controlF, 'linux')).toBe(true)
+    expect(keybindingMatchesAction('browser.find', controlF, 'win32')).toBe(true)
+    expect(keybindingMatchesAction('browser.find', commandF, 'linux')).toBe(false)
+    expect(keybindingMatchesAction('browser.find', commandF, 'win32')).toBe(false)
+  })
+
   it('defines platform-native replace-in-editor shortcuts', () => {
     expect(getEffectiveKeybindingsForAction('editor.replace', 'darwin')).toEqual(['Mod+Alt+F'])
     expect(getEffectiveKeybindingsForAction('editor.replace', 'linux')).toEqual(['Mod+H'])

--- a/tests/e2e/browser-split-find-shortcut.spec.ts
+++ b/tests/e2e/browser-split-find-shortcut.spec.ts
@@ -11,6 +11,11 @@ type SplitFindFixture = {
   terminalGroupId: string
 }
 
+type BrowserSplitFixture = {
+  firstBrowserTabId: string
+  secondBrowserTabId: string
+}
+
 async function createTerminalBrowserSplit(page: Page): Promise<SplitFindFixture> {
   return page.evaluate(() => {
     const store = window.__store
@@ -36,6 +41,47 @@ async function createTerminalBrowserSplit(page: Page): Promise<SplitFindFixture>
   })
 }
 
+async function createBrowserSplit(page: Page): Promise<BrowserSplitFixture> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    const state = store.getState()
+    const worktreeId = state.activeWorktreeId
+    if (!worktreeId) {
+      throw new Error('Active worktree unavailable')
+    }
+    const terminalGroupId = state.ensureWorktreeRootGroup(worktreeId)
+    const firstBrowserGroupId = state.createEmptySplitGroup(worktreeId, terminalGroupId, 'right')
+    if (!firstBrowserGroupId) {
+      throw new Error('First browser split unavailable')
+    }
+    const firstBrowserTab = state.createBrowserTab(worktreeId, 'about:blank', {
+      activate: true,
+      focusAddressBar: false,
+      targetGroupId: firstBrowserGroupId
+    })
+    const secondBrowserGroupId = state.createEmptySplitGroup(
+      worktreeId,
+      firstBrowserGroupId,
+      'right'
+    )
+    if (!secondBrowserGroupId) {
+      throw new Error('Second browser split unavailable')
+    }
+    const secondBrowserTab = state.createBrowserTab(worktreeId, 'about:blank', {
+      activate: true,
+      focusAddressBar: false,
+      targetGroupId: secondBrowserGroupId
+    })
+    return {
+      firstBrowserTabId: firstBrowserTab.id,
+      secondBrowserTabId: secondBrowserTab.id
+    }
+  })
+}
+
 function browserAddressBar(page: Page, browserTabId: string) {
   return page.locator(
     `[data-browser-overlay-tab-id="${browserTabId}"] [data-orca-browser-address-bar="true"]`
@@ -48,6 +94,50 @@ function browserFindInput(page: Page) {
 
 function browserFindCloseButton(page: Page) {
   return browserFindInput(page).locator('xpath=..').getByTitle('Close')
+}
+
+function browserSplitFindInput(page: Page, browserTabId: string) {
+  return page
+    .locator(`[data-browser-overlay-tab-id="${browserTabId}"]`)
+    .getByPlaceholder('Find in page...')
+}
+
+async function pressFindInBrowserGuest(page: Page, browserTabId: string): Promise<void> {
+  await expect
+    .poll(() =>
+      page.evaluate((targetBrowserTabId) => {
+        const overlay = document.querySelector(
+          `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+        )
+        const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
+        return webview?.getWebContentsId() ?? null
+      }, browserTabId)
+    )
+    .not.toBeNull()
+
+  await page.evaluate(
+    async ({ targetBrowserTabId, inputModifier }) => {
+      const overlay = document.querySelector(
+        `[data-browser-overlay-tab-id="${targetBrowserTabId}"]`
+      )
+      const webview = overlay?.querySelector('webview') as Electron.WebviewTag | null
+      if (!webview) {
+        throw new Error(`Missing webview for browser tab ${targetBrowserTabId}`)
+      }
+      webview.focus()
+      await webview.sendInputEvent({
+        type: 'keyDown',
+        keyCode: 'F',
+        modifiers: [inputModifier]
+      })
+      await webview.sendInputEvent({
+        type: 'keyUp',
+        keyCode: 'F',
+        modifiers: [inputModifier]
+      })
+    },
+    { targetBrowserTabId: browserTabId, inputModifier: modifier.toLowerCase() }
+  )
 }
 
 function terminalFindInput(page: Page) {
@@ -121,6 +211,17 @@ test.describe('browser split Find shortcut', () => {
     await orcaPage.keyboard.press(`${modifier}+f`)
     await expect(terminalFindInput(orcaPage)).toBeFocused()
     await expect(browserFindInput(orcaPage)).toBeHidden()
+  })
+
+  test('opens Find only in the browser split whose guest owns the shortcut', async ({
+    orcaPage
+  }) => {
+    const fixture = await createBrowserSplit(orcaPage)
+
+    await pressFindInBrowserGuest(orcaPage, fixture.firstBrowserTabId)
+
+    await expect(browserSplitFindInput(orcaPage, fixture.firstBrowserTabId)).toBeVisible()
+    await expect(browserSplitFindInput(orcaPage, fixture.secondBrowserTabId)).toBeHidden()
   })
 
   test('keeps browser Find available when split focus state is temporarily missing', async ({

--- a/tests/e2e/browser-split-find-shortcut.spec.ts
+++ b/tests/e2e/browser-split-find-shortcut.spec.ts
@@ -149,4 +149,30 @@ test.describe('browser split Find shortcut', () => {
     await expect(browserFindInput(orcaPage)).toBeFocused()
     await expect(terminalFindInput(orcaPage)).toBeHidden()
   })
+
+  test('keeps browser Find available when the focused split ID is stale', async ({ orcaPage }) => {
+    const fixture = await createTerminalBrowserSplit(orcaPage)
+    const addressBar = browserAddressBar(orcaPage, fixture.browserTabId)
+    await addressBar.click()
+    await expect(addressBar).toBeFocused()
+
+    await orcaPage.evaluate(() => {
+      const store = window.__store
+      const worktreeId = store?.getState().activeWorktreeId
+      if (!store || !worktreeId) {
+        throw new Error('Active worktree unavailable')
+      }
+      store.setState((state) => ({
+        activeGroupIdByWorktree: {
+          ...state.activeGroupIdByWorktree,
+          [worktreeId]: 'removed-group'
+        }
+      }))
+    })
+    await expect(addressBar).toBeFocused()
+
+    await orcaPage.keyboard.press(`${modifier}+f`)
+    await expect(browserFindInput(orcaPage)).toBeFocused()
+    await expect(terminalFindInput(orcaPage)).toBeHidden()
+  })
 })

--- a/tests/e2e/browser-split-find-shortcut.spec.ts
+++ b/tests/e2e/browser-split-find-shortcut.spec.ts
@@ -188,7 +188,9 @@ test.describe('browser split Find shortcut', () => {
     await expect(browserFindInput(orcaPage)).toBeHidden()
     await orcaPage.keyboard.press('Escape')
 
-    await browserAddressBar(orcaPage, fixture.browserTabId).click()
+    const browserAddress = browserAddressBar(orcaPage, fixture.browserTabId)
+    await expect(browserAddress).toBeVisible()
+    await browserAddress.click()
     await waitForFocusedGroup(orcaPage, fixture.browserGroupId)
     await orcaPage.keyboard.press(`${modifier}+f`)
     await expect(browserFindInput(orcaPage)).toBeFocused()
@@ -229,6 +231,7 @@ test.describe('browser split Find shortcut', () => {
   }) => {
     const fixture = await createTerminalBrowserSplit(orcaPage)
     const addressBar = browserAddressBar(orcaPage, fixture.browserTabId)
+    await expect(addressBar).toBeVisible()
     await addressBar.click()
     await expect(addressBar).toBeFocused()
 
@@ -254,6 +257,7 @@ test.describe('browser split Find shortcut', () => {
   test('keeps browser Find available when the focused split ID is stale', async ({ orcaPage }) => {
     const fixture = await createTerminalBrowserSplit(orcaPage)
     const addressBar = browserAddressBar(orcaPage, fixture.browserTabId)
+    await expect(addressBar).toBeVisible()
     await addressBar.click()
     await expect(addressBar).toBeFocused()
 

--- a/tests/e2e/browser-split-find-shortcut.spec.ts
+++ b/tests/e2e/browser-split-find-shortcut.spec.ts
@@ -162,6 +162,17 @@ async function waitForFocusedGroup(page: Page, groupId: string): Promise<void> {
   )
 }
 
+async function focusBrowserGroup(page: Page, groupId: string): Promise<void> {
+  await page.evaluate((targetGroupId) => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    if (state && worktreeId) {
+      state.focusGroup(worktreeId, targetGroupId)
+    }
+  }, groupId)
+  await waitForFocusedGroup(page, groupId)
+}
+
 test.describe('browser split Find shortcut', () => {
   test.beforeEach(async ({ orcaPage }) => {
     await waitForSessionReady(orcaPage)
@@ -188,10 +199,10 @@ test.describe('browser split Find shortcut', () => {
     await expect(browserFindInput(orcaPage)).toBeHidden()
     await orcaPage.keyboard.press('Escape')
 
+    await focusBrowserGroup(orcaPage, fixture.browserGroupId)
     const browserAddress = browserAddressBar(orcaPage, fixture.browserTabId)
     await expect(browserAddress).toBeVisible()
     await browserAddress.click()
-    await waitForFocusedGroup(orcaPage, fixture.browserGroupId)
     await orcaPage.keyboard.press(`${modifier}+f`)
     await expect(browserFindInput(orcaPage)).toBeFocused()
     await expect(terminalFindInput(orcaPage)).toBeHidden()
@@ -230,6 +241,7 @@ test.describe('browser split Find shortcut', () => {
     orcaPage
   }) => {
     const fixture = await createTerminalBrowserSplit(orcaPage)
+    await focusBrowserGroup(orcaPage, fixture.browserGroupId)
     const addressBar = browserAddressBar(orcaPage, fixture.browserTabId)
     await expect(addressBar).toBeVisible()
     await addressBar.click()
@@ -256,6 +268,7 @@ test.describe('browser split Find shortcut', () => {
 
   test('keeps browser Find available when the focused split ID is stale', async ({ orcaPage }) => {
     const fixture = await createTerminalBrowserSplit(orcaPage)
+    await focusBrowserGroup(orcaPage, fixture.browserGroupId)
     const addressBar = browserAddressBar(orcaPage, fixture.browserTabId)
     await expect(addressBar).toBeVisible()
     await addressBar.click()

--- a/tests/e2e/browser-split-find-shortcut.spec.ts
+++ b/tests/e2e/browser-split-find-shortcut.spec.ts
@@ -1,0 +1,152 @@
+import { expect, test } from './helpers/orca-app'
+import type { Page } from '@stablyai/playwright-test'
+import { focusActiveTerminalInput } from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+type SplitFindFixture = {
+  browserGroupId: string
+  browserTabId: string
+  terminalGroupId: string
+}
+
+async function createTerminalBrowserSplit(page: Page): Promise<SplitFindFixture> {
+  return page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    const state = store.getState()
+    const worktreeId = state.activeWorktreeId
+    if (!worktreeId) {
+      throw new Error('Active worktree unavailable')
+    }
+    const terminalGroupId = state.ensureWorktreeRootGroup(worktreeId)
+    const browserGroupId = state.createEmptySplitGroup(worktreeId, terminalGroupId, 'right')
+    if (!browserGroupId) {
+      throw new Error('Browser split unavailable')
+    }
+    const browserTab = state.createBrowserTab(worktreeId, 'about:blank', {
+      activate: true,
+      focusAddressBar: false,
+      targetGroupId: browserGroupId
+    })
+    return { browserGroupId, browserTabId: browserTab.id, terminalGroupId }
+  })
+}
+
+function browserAddressBar(page: Page, browserTabId: string) {
+  return page.locator(
+    `[data-browser-overlay-tab-id="${browserTabId}"] [data-orca-browser-address-bar="true"]`
+  )
+}
+
+function browserFindInput(page: Page) {
+  return page.getByPlaceholder('Find in page...')
+}
+
+function browserFindCloseButton(page: Page) {
+  return browserFindInput(page).locator('xpath=..').getByTitle('Close')
+}
+
+function terminalFindInput(page: Page) {
+  return page.locator('[data-terminal-search-root] input:visible')
+}
+
+async function waitForFocusedGroup(page: Page, groupId: string): Promise<void> {
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const state = window.__store?.getState()
+        const worktreeId = state?.activeWorktreeId
+        return worktreeId ? state.activeGroupIdByWorktree[worktreeId] : null
+      })
+    )
+    .toBe(groupId)
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      })
+  )
+}
+
+test.describe('browser split Find shortcut', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+  })
+
+  test('routes repeated Find shortcuts to the focused terminal or browser split', async ({
+    orcaPage
+  }) => {
+    const fixture = await createTerminalBrowserSplit(orcaPage)
+
+    await orcaPage.evaluate(({ terminalGroupId }) => {
+      const state = window.__store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      if (state && worktreeId) {
+        state.focusGroup(worktreeId, terminalGroupId)
+      }
+    }, fixture)
+    await focusActiveTerminalInput(orcaPage)
+    await waitForFocusedGroup(orcaPage, fixture.terminalGroupId)
+    await orcaPage.keyboard.press(`${modifier}+f`)
+    await expect(terminalFindInput(orcaPage)).toBeFocused()
+    await expect(browserFindInput(orcaPage)).toBeHidden()
+    await orcaPage.keyboard.press('Escape')
+
+    await browserAddressBar(orcaPage, fixture.browserTabId).click()
+    await waitForFocusedGroup(orcaPage, fixture.browserGroupId)
+    await orcaPage.keyboard.press(`${modifier}+f`)
+    await expect(browserFindInput(orcaPage)).toBeFocused()
+    await expect(terminalFindInput(orcaPage)).toBeHidden()
+    await browserFindCloseButton(orcaPage).click()
+    await expect(browserFindInput(orcaPage)).toBeHidden()
+
+    await orcaPage.keyboard.press(`${modifier}+f`)
+    await expect(browserFindInput(orcaPage)).toBeFocused()
+    await browserFindCloseButton(orcaPage).click()
+
+    await orcaPage.evaluate(({ browserTabId }) => {
+      window.__store?.getState().closeBrowserTab(browserTabId)
+    }, fixture)
+    await expect(
+      orcaPage.locator(`[data-browser-overlay-tab-id="${fixture.browserTabId}"]`)
+    ).toHaveCount(0)
+
+    await focusActiveTerminalInput(orcaPage)
+    await orcaPage.keyboard.press(`${modifier}+f`)
+    await expect(terminalFindInput(orcaPage)).toBeFocused()
+    await expect(browserFindInput(orcaPage)).toBeHidden()
+  })
+
+  test('keeps browser Find available when split focus state is temporarily missing', async ({
+    orcaPage
+  }) => {
+    const fixture = await createTerminalBrowserSplit(orcaPage)
+    const addressBar = browserAddressBar(orcaPage, fixture.browserTabId)
+    await addressBar.click()
+    await expect(addressBar).toBeFocused()
+
+    await orcaPage.evaluate(() => {
+      const store = window.__store
+      const worktreeId = store?.getState().activeWorktreeId
+      if (!store || !worktreeId) {
+        throw new Error('Active worktree unavailable')
+      }
+      store.setState((state) => {
+        const activeGroupIdByWorktree = { ...state.activeGroupIdByWorktree }
+        delete activeGroupIdByWorktree[worktreeId]
+        return { activeGroupIdByWorktree }
+      })
+    })
+    await expect(addressBar).toBeFocused()
+
+    await orcaPage.keyboard.press(`${modifier}+f`)
+    await expect(browserFindInput(orcaPage)).toBeFocused()
+    await expect(terminalFindInput(orcaPage)).toBeHidden()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #11348.

In a terminal + browser split, pressing **Cmd+F (macOS) / Ctrl+F (Windows/Linux)** while the **terminal** was focused opened Find in the **browser** pane instead of find-in-terminal.

Root cause: the browser pane's renderer-path Find handler (`BrowserPagePane` in `BrowserPane.tsx`) is a **window-global, capture-phase `keydown` listener** that was armed on `isActive` — "am I the active tab within my own group?" — not on whether its split holds keyboard focus. `BrowserPaneOverlayLayer` computes `isActive` from `isWorktreeActive && isActiveInGroup`, which ignores `activeGroupIdByWorktree` (the focused split). So in a split the browser was `isActive` even while the terminal was focused, and its unscoped listener called `preventDefault()` + `stopPropagation()`, claiming the chord before the (correctly focus-scoped) terminal handler could act.

Fix: thread a focused-split signal (`isFocused`) from `BrowserPaneOverlayLayer` — derived from `activeGroupIdByWorktree[worktreeId]` — through `BrowserPane` → `BrowserPagePane`, and gate the renderer-path Find listener on `isFocused` instead of `isActive`. This mirrors how terminal leaves already gate global shortcuts via `focusedGroupId` in `TabGroupSplitLayout.tsx`. The IPC path (webview guest focused) is left on `isActive` — it only fires when the guest genuinely has focus, so it is already correct.

## Screenshots

No visual change. Behavior-only: the Find bar now opens in whichever split (terminal or browser) holds keyboard focus.

## Testing

- [x] `pnpm lint` (oxlint + oxfmt ran clean via pre-commit; targeted lint of `browser-pane` clean)
- [x] `pnpm typecheck` (`tsconfig.tc.web.json` clean)
- [x] `pnpm test` (browser-pane suite: 32 files / 181 tests pass)
- [ ] `pnpm build`
- [x] Added regression tests in `BrowserPaneOverlayLayer.test.tsx`: an active browser pane is `focused` when its own group holds focus, and **not** `focused` when another split (e.g. the terminal) holds focus (#11348).

## AI Review Report

Reviewed with an AI coding agent. Checks and outcomes:
- **Wrong-surface routing (the bug):** confirmed the browser's window-global capture listener was the interceptor and that gating on the focused split resolves it without disturbing the terminal's already-scoped handler.
- **Cross-platform (macOS / Linux / Windows):** the chord flows through `keybindingMatchesAction('browser.find', …)` which resolves `Mod` → `metaKey` on macOS and `ctrlKey` elsewhere — a single code path, so the fix applies uniformly. No `e.metaKey` hardcoding introduced; no platform-specific labels or paths touched.
- **Regressions to other call sites:** `BrowserPane` gained an **optional** `isFocused` prop defaulting to `isActive`, so the floating-browser call sites (`Terminal.tsx`, `FloatingBrowserSlot.tsx`) are unchanged. SSH/remote pane (`RemoteBrowserPagePane`) has no Find handler and is untouched.
- **Guest-focused find:** the IPC path is unchanged and still opens Find when the webview guest itself is focused.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change only narrows the condition under which an existing renderer keydown listener is registered (fewer events claimed, not more). No IPC channels added or modified. No follow-up needed.

## Notes

- Behavior is symmetric: Find now targets whichever split holds focus. Clicking into the browser (chrome, address bar, or guest) focuses its group via the overlay's existing `onPointerDown`/`onFocusCapture` → `focusGroup`, so Cmd/Ctrl+F opens the browser find bar as before.
- Related shape to #10288 (floating workspace shortcuts routing to the main workspace); this PR scopes only the terminal/browser split find path.
