### PR TITLE
fix(agent-status): clear sticky working after Claude /compact

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -1563,15 +1563,16 @@ describe('shared agent-hook-listener', () => {
     expect(event).toBeNull()
   })
 
-  it('keeps the cached prompt when a harness-injected turn fires UserPromptSubmit', () => {
+  it('ignores harness-injected UserPromptSubmit so it cannot mint a sticky working row', () => {
     normalizeHookPayload(
       state,
       'claude',
       { paneKey: PANE_KEY, payload: { hook_event_name: 'UserPromptSubmit', prompt: 'fix login' } },
       'production'
     )
-    // Why: the harness injects background task notifications as user turns;
-    // they must not replace the user's real prompt in status labels.
+    // Why: harness injects task notifications / compact summaries as user turns that fire
+    // UserPromptSubmit without a matching Stop. Emitting working here left worktrees stuck
+    // on the spinner after /compact (issue #11352). Ignore machinery; keep prior status.
     const event = normalizeHookPayload(
       state,
       'claude',
@@ -1584,13 +1585,27 @@ describe('shared agent-hook-listener', () => {
       },
       'production'
     )
-    expect(event).not.toBeNull()
-    expect(event!.payload.state).toBe('working')
-    expect(event!.payload.prompt).toBe('fix login')
-    expect(event!.hasExplicitPrompt).toBe(false)
+    expect(event).toBeNull()
+    // A later real tool event must still show the cached user prompt, not the harness tags.
+    const toolEvent = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'echo hi' }
+        }
+      },
+      'production'
+    )
+    expect(toolEvent).not.toBeNull()
+    expect(toolEvent!.payload.state).toBe('working')
+    expect(toolEvent!.payload.prompt).toBe('fix login')
   })
 
-  it('resolves an empty prompt for a harness-injected turn with nothing cached', () => {
+  it('ignores a harness-injected UserPromptSubmit with nothing cached', () => {
     const event = normalizeHookPayload(
       state,
       'claude',
@@ -1603,9 +1618,66 @@ describe('shared agent-hook-listener', () => {
       },
       'production'
     )
-    expect(event).not.toBeNull()
-    expect(event!.payload.prompt).toBe('')
-    expect(event!.hasExplicitPrompt).toBe(false)
+    expect(event).toBeNull()
+  })
+
+  it('does not leave working after a compact-summary UserPromptSubmit (issue #11352)', () => {
+    // Live repro: after /compact Claude injects "This session is being continued…" with no Stop.
+    const event = normalizeHookPayload(
+      state,
+      'claude',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'UserPromptSubmit',
+          prompt:
+            'This session is being continued from a previous conversation that ran out of context. The summary below covers the earlier portion of the conversation.'
+        }
+      },
+      'production'
+    )
+    expect(event).toBeNull()
+  })
+
+  it('maps Claude PreCompact to working and PostCompact to done (issue #11352)', () => {
+    const pre = normalizeHookPayload(
+      state,
+      'claude',
+      { paneKey: PANE_KEY, payload: { hook_event_name: 'PreCompact', trigger: 'manual' } },
+      'production'
+    )
+    expect(pre).not.toBeNull()
+    expect(pre!.payload.state).toBe('working')
+    expect(pre!.payload.agentType).toBe('claude')
+
+    const post = normalizeHookPayload(
+      state,
+      'claude',
+      { paneKey: PANE_KEY, payload: { hook_event_name: 'PostCompact', trigger: 'manual' } },
+      'production'
+    )
+    expect(post).not.toBeNull()
+    expect(post!.payload.state).toBe('done')
+    expect(post!.payload.agentType).toBe('claude')
+  })
+
+  it('clears a sticky working row when Claude PostCompact fires after a real turn', () => {
+    normalizeHookPayload(
+      state,
+      'claude',
+      { paneKey: PANE_KEY, payload: { hook_event_name: 'UserPromptSubmit', prompt: '/compact' } },
+      'production'
+    )
+    const post = normalizeHookPayload(
+      state,
+      'claude',
+      { paneKey: PANE_KEY, payload: { hook_event_name: 'PostCompact', trigger: 'manual' } },
+      'production'
+    )
+    expect(post).not.toBeNull()
+    expect(post!.payload.state).toBe('done')
+    // Why: slash-command prompt is a real user turn; keep it on the done row for history.
+    expect(post!.payload.prompt).toBe('/compact')
   })
 
   it('treats a custom-element paste as an explicit user turn, not machinery', () => {

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -1452,6 +1452,76 @@ describe('shared agent-hook-listener', () => {
     expect(stopped?.providerSession).toMatchObject({ key: 'session_id', id: 'session_abc' })
   })
 
+  // Why: Kimi shares Claude-compatible compact/harness hooks; cover the same sticky-working
+  // guards so a Kimi-only regression cannot slip past the Claude-only tests (issue #11352).
+  it('ignores harness-injected UserPromptSubmit for Kimi', () => {
+    normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'UserPromptSubmit',
+          prompt: [{ type: 'text', text: 'list the files here' }]
+        }
+      },
+      'production'
+    )
+    const harness = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'UserPromptSubmit',
+          prompt:
+            'This session is being continued from a previous conversation that ran out of context.'
+        }
+      },
+      'production'
+    )
+    expect(harness).toBeNull()
+    const tool = normalizeHookPayload(
+      state,
+      'kimi',
+      {
+        paneKey: PANE_KEY,
+        payload: {
+          hook_event_name: 'PreToolUse',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls' }
+        }
+      },
+      'production'
+    )
+    expect(tool).not.toBeNull()
+    expect(tool!.payload.state).toBe('working')
+    expect(tool!.payload.prompt).toBe('list the files here')
+    expect(tool!.payload.agentType).toBe('kimi')
+  })
+
+  it('maps Kimi PreCompact to working and PostCompact to done (issue #11352)', () => {
+    const pre = normalizeHookPayload(
+      state,
+      'kimi',
+      { paneKey: PANE_KEY, payload: { hook_event_name: 'PreCompact', trigger: 'manual' } },
+      'production'
+    )
+    expect(pre).not.toBeNull()
+    expect(pre!.payload.state).toBe('working')
+    expect(pre!.payload.agentType).toBe('kimi')
+
+    const post = normalizeHookPayload(
+      state,
+      'kimi',
+      { paneKey: PANE_KEY, payload: { hook_event_name: 'PostCompact', trigger: 'manual' } },
+      'production'
+    )
+    expect(post).not.toBeNull()
+    expect(post!.payload.state).toBe('done')
+    expect(post!.payload.agentType).toBe('kimi')
+  })
+
   it('normalizes MiMo Code OpenCode-compatible lifecycle events as mimo-code status', () => {
     const message = normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -489,6 +489,17 @@ function stripGrokUserQueryWrapper(promptText: string): string {
   return text.trim()
 }
 
+// Why: harness-injected UserPromptSubmit (compact summary, task-notification envelopes,
+// system-reminders, local-command machinery) is not a real user turn. Emitting `working`
+// with no matching Stop left worktrees stuck on the spinner after /compact (issue #11352).
+// Shared by Claude and Kimi so the two Claude-compatible paths cannot drift on this bug class.
+function shouldIgnoreHarnessInjectedUserPromptSubmit(
+  eventName: unknown,
+  promptText: string
+): boolean {
+  return eventName === 'UserPromptSubmit' && isKnownHarnessInjectedUserTurnText(promptText)
+}
+
 function resolvePrompt(
   state: HookListenerState,
   paneKey: string,
@@ -2559,12 +2570,9 @@ function normalizeClaudeEvent(
     return normalizeClaudeSubagentLifecycleEvent(state, eventName, paneKey, hookPayload)
   }
 
-  // Why: harness-injected UserPromptSubmit (compact summary, task-notification envelopes,
-  // system-reminders, local-command machinery) is not a real user turn. Emitting `working`
-  // with no matching Stop left worktrees stuck on the spinner after /compact (issue #11352).
-  // Real tool activity still arrives as PreToolUse/PostToolUse; do not mint a working row
-  // from machinery alone. resolvePrompt already preserves the cached user prompt for labels.
-  if (eventName === 'UserPromptSubmit' && isKnownHarnessInjectedUserTurnText(promptText)) {
+  // Why: do not mint a working row from machinery alone; real tool activity still arrives as
+  // PreToolUse/PostToolUse. resolvePrompt already preserves the cached user prompt for labels.
+  if (shouldIgnoreHarnessInjectedUserPromptSubmit(eventName, promptText)) {
     return null
   }
 
@@ -2784,9 +2792,7 @@ function normalizeKimiEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
-  // Why: Kimi shares Claude's harness-injected UserPromptSubmit shapes; same sticky-working
-  // risk after compact/local-command machinery (issue #11352).
-  if (eventName === 'UserPromptSubmit' && isKnownHarnessInjectedUserTurnText(promptText)) {
+  if (shouldIgnoreHarnessInjectedUserPromptSubmit(eventName, promptText)) {
     return null
   }
 

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2559,19 +2559,31 @@ function normalizeClaudeEvent(
     return normalizeClaudeSubagentLifecycleEvent(state, eventName, paneKey, hookPayload)
   }
 
+  // Why: harness-injected UserPromptSubmit (compact summary, task-notification envelopes,
+  // system-reminders, local-command machinery) is not a real user turn. Emitting `working`
+  // with no matching Stop left worktrees stuck on the spinner after /compact (issue #11352).
+  // Real tool activity still arrives as PreToolUse/PostToolUse; do not mint a working row
+  // from machinery alone. resolvePrompt already preserves the cached user prompt for labels.
+  if (eventName === 'UserPromptSubmit' && isKnownHarnessInjectedUserTurnText(promptText)) {
+    return null
+  }
+
   // Why: Claude's auto-allowed AskUserQuestion emits PreToolUse (not PermissionRequest; its Notification hook isn't registered) while blocked on a human answer.
   // Treat that PreToolUse as waiting so the sidebar shows amber attention, not a spinner that decays to grey. Mirrors normalizeKimiEvent.
   const isAskUserQuestion =
     eventName === 'PreToolUse' && isAskUserQuestionTool(readString(hookPayload, 'tool_name'))
+  // Why: /compact can take minutes and does not emit Stop. PreCompact marks the pane busy;
+  // PostCompact clears it so a finished compact cannot leave a sticky working spinner (#11352).
   const stateName =
     eventName === 'UserPromptSubmit' ||
     eventName === 'PostToolUse' ||
     eventName === 'PostToolUseFailure' ||
+    eventName === 'PreCompact' ||
     (eventName === 'PreToolUse' && !isAskUserQuestion)
       ? 'working'
       : eventName === 'PermissionRequest' || isAskUserQuestion
         ? 'waiting'
-        : eventName === 'Stop' || eventName === 'StopFailure'
+        : eventName === 'Stop' || eventName === 'StopFailure' || eventName === 'PostCompact'
           ? 'done'
           : null
 
@@ -2772,6 +2784,12 @@ function normalizeKimiEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
+  // Why: Kimi shares Claude's harness-injected UserPromptSubmit shapes; same sticky-working
+  // risk after compact/local-command machinery (issue #11352).
+  if (eventName === 'UserPromptSubmit' && isKnownHarnessInjectedUserTurnText(promptText)) {
+    return null
+  }
+
   const toolName = readString(hookPayload, 'tool_name')
   const isUserInputTool = isKimiUserInputTool(toolName)
 
@@ -2780,12 +2798,13 @@ function normalizeKimiEvent(
     eventName === 'UserPromptSubmit' ||
     eventName === 'PostToolUse' ||
     eventName === 'PostToolUseFailure' ||
+    eventName === 'PreCompact' ||
     (eventName === 'PreToolUse' && !isUserInputTool)
   ) {
     stateName = 'working'
   } else if (eventName === 'PermissionRequest' || (eventName === 'PreToolUse' && isUserInputTool)) {
     stateName = 'waiting'
-  } else if (eventName === 'Stop' || eventName === 'StopFailure') {
+  } else if (eventName === 'Stop' || eventName === 'StopFailure' || eventName === 'PostCompact') {
     stateName = 'done'
   }
 


### PR DESCRIPTION
## Summary

Fixes Claude worktrees that stay stuck on **Working…** after `/compact` finishes (and the TUI is idle).

**User-visible change:** after compaction completes, the sidebar/card agent row returns to idle/`done` instead of spinning forever with an empty prompt and no tools.

### Root cause

1. Claude `/compact` injects a harness user turn (`This session is being continued from a previous conversation…`) that fires **`UserPromptSubmit`**.
2. Orca mapped every Claude `UserPromptSubmit` → **`working`**, including harness machinery. There is no matching **`Stop`**.
3. Claude **`PreCompact` / `PostCompact` were ignored** for status, so compact neither showed as busy nor cleared on completion.
4. Hook status is authoritative; the idle title (`✳ …`) does not clear `working`, so the spinner sticks until the 30‑minute stale window or a new real turn.

Live diagnosis on Orca `1.4.161` / snapstudio `local-moderation` is documented in the issue.

### Fix

1. **Ignore harness-injected `UserPromptSubmit`** for Claude and Kimi (return no status update). Real activity still arrives via PreToolUse/PostToolUse/Stop.
2. Map Claude/Kimi **`PreCompact` → `working`** and **`PostCompact` → `done`** so multi-minute compact shows activity and clears cleanly (also covers a real `/compact` slash-command submit without a Stop).

### Tests

- Harness `UserPromptSubmit` (task-notification / system-reminder / compact-summary) does not mint a sticky working row; cached user prompt is preserved for later real tool events.
- PreCompact → working, PostCompact → done.
- PostCompact clears working after a real `/compact` UserPromptSubmit.

```bash
pnpm exec vitest run src/shared/agent-hook-listener.test.ts
pnpm typecheck
```

Fixes #11352

## Related

- Follow-up UX for a dedicated compacting status: #9225
- Separate post-update class (stale `ORCA_AGENT_HOOK_PORT` on long-lived PTYs) is **out of scope** here; this PR fixes the compact harness path that repros with a live hook port.

## AI agent review summary

- **Cross-platform:** Status normalization is shared/main-process hook logic; no UI/OS-specific paths. Same Claude/Kimi event names on macOS/Linux/Windows.
- **SSH/remote:** Hooks still attribute by `ORCA_PANE_KEY`; no cwd-based resolution change. Dead remote hook ports remain a separate issue.
- **Agent/integration:** Claude + Kimi (Claude-compatible hooks). Other agents unchanged. Devin still uses its own `PostCompaction` → working mapping.
- **Performance:** Early null return for harness UserPromptSubmit; no extra I/O.
- **UI quality:** Sidebar spinner clears after compact; PreCompact briefly shows working during long compact (honest busy state).
- **Security:** No new network surface; only changes how already-received hook payloads map to status states.

## Manual verification

1. Resume a long Claude session in Orca; run `/compact`.
2. While compacting, card may show working (PreCompact).
3. After “Compacted” and idle `✳` title + `❯` prompt, card should **not** stay on Working….
4. Real user prompts still show working with tools and clear on Stop.