### PR TITLE
fix(windows): resolve fnm default Node directory

### DIFF
--- a/src/main/codex-cli/command.test.ts
+++ b/src/main/codex-cli/command.test.ts
@@ -312,43 +312,4 @@ describe('getVersionManagerBinPaths', () => {
     expect(paths).toContain(join(root, '.local', 'bin'))
     expect(paths).toContain(join(root, 'AppData', 'Roaming', 'npm'))
   })
-
-  it('uses the configured Windows fnm directory without a POSIX bin suffix', () => {
-    const root = mkdtempSync(join(tmpdir(), 'orca-vm-paths-'))
-    const fnmDir = join(root, 'fnm-data')
-    const paths = getVersionManagerBinPaths({
-      platform: 'win32',
-      pathEnv: '',
-      homePath: root,
-      env: { FNM_DIR: fnmDir }
-    })
-
-    expect(paths).toContain(join(fnmDir, 'aliases', 'default'))
-    expect(paths).not.toContain(join(fnmDir, 'aliases', 'default', 'bin'))
-  })
-
-  it('falls back to the Windows roaming AppData fnm directory', () => {
-    const root = mkdtempSync(join(tmpdir(), 'orca-vm-paths-'))
-    const appData = join(root, 'Roaming')
-    const paths = getVersionManagerBinPaths({
-      platform: 'win32',
-      pathEnv: '',
-      homePath: root,
-      env: { APPDATA: appData }
-    })
-
-    expect(paths).toContain(join(appData, 'fnm', 'aliases', 'default'))
-  })
-
-  it('derives the Windows roaming AppData fnm directory from home', () => {
-    const root = mkdtempSync(join(tmpdir(), 'orca-vm-paths-'))
-    const paths = getVersionManagerBinPaths({
-      platform: 'win32',
-      pathEnv: '',
-      homePath: root,
-      env: {}
-    })
-
-    expect(paths).toContain(join(root, 'AppData', 'Roaming', 'fnm', 'aliases', 'default'))
-  })
 })

--- a/src/main/codex-cli/command.test.ts
+++ b/src/main/codex-cli/command.test.ts
@@ -312,4 +312,43 @@ describe('getVersionManagerBinPaths', () => {
     expect(paths).toContain(join(root, '.local', 'bin'))
     expect(paths).toContain(join(root, 'AppData', 'Roaming', 'npm'))
   })
+
+  it('uses the configured Windows fnm directory without a POSIX bin suffix', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-vm-paths-'))
+    const fnmDir = join(root, 'fnm-data')
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      pathEnv: '',
+      homePath: root,
+      env: { FNM_DIR: fnmDir }
+    })
+
+    expect(paths).toContain(join(fnmDir, 'aliases', 'default'))
+    expect(paths).not.toContain(join(fnmDir, 'aliases', 'default', 'bin'))
+  })
+
+  it('falls back to the Windows roaming AppData fnm directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-vm-paths-'))
+    const appData = join(root, 'Roaming')
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      pathEnv: '',
+      homePath: root,
+      env: { APPDATA: appData }
+    })
+
+    expect(paths).toContain(join(appData, 'fnm', 'aliases', 'default'))
+  })
+
+  it('derives the Windows roaming AppData fnm directory from home', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-vm-paths-'))
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      pathEnv: '',
+      homePath: root,
+      env: {}
+    })
+
+    expect(paths).toContain(join(root, 'AppData', 'Roaming', 'fnm', 'aliases', 'default'))
+  })
 })

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -6,6 +6,7 @@ type ResolveCommandOptions = {
   pathEnv?: string | null
   platform?: NodeJS.Platform
   homePath?: string
+  env?: NodeJS.ProcessEnv
 }
 
 function getExecutableNames(platform: NodeJS.Platform, commandName: string): string[] {
@@ -85,11 +86,28 @@ function isRunnableCommand(platform: NodeJS.Platform, candidate: string): boolea
   }
 }
 
-function getBaseVersionManagerDirectories(platform: NodeJS.Platform, homePath: string): string[] {
+function getFnmDefaultDirectory(
+  platform: NodeJS.Platform,
+  homePath: string,
+  env: NodeJS.ProcessEnv
+): string {
+  if (platform !== 'win32') {
+    return join(homePath, '.fnm', 'aliases', 'default', 'bin')
+  }
+  const appData = env.APPDATA?.trim() || join(homePath, 'AppData', 'Roaming')
+  const fnmDir = env.FNM_DIR?.trim() || join(appData, 'fnm')
+  return join(fnmDir, 'aliases', 'default')
+}
+
+function getBaseVersionManagerDirectories(
+  platform: NodeJS.Platform,
+  homePath: string,
+  env: NodeJS.ProcessEnv
+): string[] {
   const directories = [
     join(homePath, '.volta', 'bin'),
     join(homePath, '.asdf', 'shims'),
-    join(homePath, '.fnm', 'aliases', 'default', 'bin'),
+    getFnmDefaultDirectory(platform, homePath, env),
     // Why: mise (formerly rtx) exposes managed tool binaries via a shims
     // directory, similar to asdf. Without this, users who installed node
     // or CLI tools through mise can't be found by the fallback probe.
@@ -139,9 +157,10 @@ function getNvmVersionDirectories(homePath: string): string[] {
 function getVersionManagerDirectories(
   platform: NodeJS.Platform,
   homePath: string,
-  executableNames: string[]
+  executableNames: string[],
+  env: NodeJS.ProcessEnv
 ): string[] {
-  const directories = getBaseVersionManagerDirectories(platform, homePath)
+  const directories = getBaseVersionManagerDirectories(platform, homePath, env)
 
   // Why: GUI-launched Electron apps do not inherit shell init from nvm, so
   // command resolution probes the newest installed Node versions explicitly.
@@ -162,8 +181,9 @@ export function resolveCliCommand(
   options: ResolveCommandOptions = {}
 ): string {
   const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
   const executableNames = getExecutableNames(platform, commandName)
-  const pathEnv = options.pathEnv ?? process.env.PATH ?? process.env.Path ?? null
+  const pathEnv = options.pathEnv ?? env.PATH ?? env.Path ?? null
   const pathCandidate = findFirstExecutable(platform, splitPath(pathEnv), executableNames)
   if (pathCandidate) {
     return pathCandidate
@@ -172,7 +192,7 @@ export function resolveCliCommand(
   const homePath = options.homePath ?? homedir()
   const versionManagerCandidate = findFirstExecutable(
     platform,
-    getVersionManagerDirectories(platform, homePath, executableNames),
+    getVersionManagerDirectories(platform, homePath, executableNames, env),
     executableNames
   )
   return versionManagerCandidate ?? commandName
@@ -183,14 +203,15 @@ export function resolveCliCommands(
   options: ResolveCommandOptions = {}
 ): Map<string, string> {
   const platform = options.platform ?? process.platform
-  const pathEnv = options.pathEnv ?? process.env.PATH ?? process.env.Path ?? null
+  const env = options.env ?? process.env
+  const pathEnv = options.pathEnv ?? env.PATH ?? env.Path ?? null
   const pathDirectories = splitPath(pathEnv)
   const homePath = options.homePath ?? homedir()
   // Why: agent detection probes many CLIs at once; compute expensive install
   // directories, especially nvm versions, once per detection pass.
   const installDirectories = [
     ...getNvmVersionDirectories(homePath),
-    ...getBaseVersionManagerDirectories(platform, homePath)
+    ...getBaseVersionManagerDirectories(platform, homePath, env)
   ]
   const resolved = new Map<string, string>()
 
@@ -221,6 +242,7 @@ export function resolveClaudeCommand(options: ResolveCommandOptions = {}): strin
 export function getVersionManagerBinPaths(options: ResolveCommandOptions = {}): string[] {
   const platform = options.platform ?? process.platform
   const homePath = options.homePath ?? homedir()
+  const env = options.env ?? process.env
   const nodeNames = getExecutableNames(platform, 'node')
-  return getVersionManagerDirectories(platform, homePath, nodeNames)
+  return getVersionManagerDirectories(platform, homePath, nodeNames, env)
 }

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -95,9 +95,14 @@ function getFnmDefaultDirectory(
   if (platform !== 'win32') {
     return join(homePath, '.fnm', 'aliases', 'default', 'bin')
   }
+  const readEnv = (name: string): string | undefined => {
+    const normalizedName = name.toLowerCase()
+    return Object.entries(env).find(([key]) => key.toLowerCase() === normalizedName)?.[1]
+  }
   const appData =
-    normalizeSingleWindowsPathEntry(env.APPDATA) ?? win32.join(homePath, 'AppData', 'Roaming')
-  const fnmDir = normalizeSingleWindowsPathEntry(env.FNM_DIR) ?? win32.join(appData, 'fnm')
+    normalizeSingleWindowsPathEntry(readEnv('APPDATA')) ??
+    win32.join(homePath, 'AppData', 'Roaming')
+  const fnmDir = normalizeSingleWindowsPathEntry(readEnv('FNM_DIR')) ?? win32.join(appData, 'fnm')
   return win32.join(fnmDir, 'aliases', 'default')
 }
 

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -1,6 +1,7 @@
 import { accessSync, constants, existsSync, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, dirname, join, win32 } from 'node:path'
+import { normalizeSingleWindowsPathEntry } from '../../shared/windows-path-entry'
 
 type ResolveCommandOptions = {
   pathEnv?: string | null
@@ -95,20 +96,9 @@ function getFnmDefaultDirectory(
     return join(homePath, '.fnm', 'aliases', 'default', 'bin')
   }
   const appData =
-    getFullyQualifiedWindowsEnvironmentPath(env.APPDATA) ??
-    win32.join(homePath, 'AppData', 'Roaming')
-  const fnmDir = getFullyQualifiedWindowsEnvironmentPath(env.FNM_DIR) ?? win32.join(appData, 'fnm')
+    normalizeSingleWindowsPathEntry(env.APPDATA) ?? win32.join(homePath, 'AppData', 'Roaming')
+  const fnmDir = normalizeSingleWindowsPathEntry(env.FNM_DIR) ?? win32.join(appData, 'fnm')
   return win32.join(fnmDir, 'aliases', 'default')
-}
-
-function getFullyQualifiedWindowsEnvironmentPath(value: string | undefined): string | null {
-  const normalized = value?.trim()
-  return normalized &&
-    !normalized.includes('\0') &&
-    win32.isAbsolute(normalized) &&
-    win32.parse(normalized).root.length > 1
-    ? normalized
-    : null
 }
 
 function getBaseVersionManagerDirectories(

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -1,6 +1,6 @@
 import { accessSync, constants, existsSync, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { delimiter, dirname, join } from 'node:path'
+import { delimiter, dirname, join, win32 } from 'node:path'
 
 type ResolveCommandOptions = {
   pathEnv?: string | null
@@ -94,9 +94,21 @@ function getFnmDefaultDirectory(
   if (platform !== 'win32') {
     return join(homePath, '.fnm', 'aliases', 'default', 'bin')
   }
-  const appData = env.APPDATA?.trim() || join(homePath, 'AppData', 'Roaming')
-  const fnmDir = env.FNM_DIR?.trim() || join(appData, 'fnm')
-  return join(fnmDir, 'aliases', 'default')
+  const appData =
+    getFullyQualifiedWindowsEnvironmentPath(env.APPDATA) ??
+    win32.join(homePath, 'AppData', 'Roaming')
+  const fnmDir = getFullyQualifiedWindowsEnvironmentPath(env.FNM_DIR) ?? win32.join(appData, 'fnm')
+  return win32.join(fnmDir, 'aliases', 'default')
+}
+
+function getFullyQualifiedWindowsEnvironmentPath(value: string | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized &&
+    !normalized.includes('\0') &&
+    win32.isAbsolute(normalized) &&
+    win32.parse(normalized).root.length > 1
+    ? normalized
+    : null
 }
 
 function getBaseVersionManagerDirectories(

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -143,6 +143,10 @@ function getBaseVersionManagerDirectories(
   return directories
 }
 
+export function getWindowsFnmDefaultDirectory(homePath: string, env: NodeJS.ProcessEnv): string {
+  return getFnmDefaultDirectory('win32', homePath, env)
+}
+
 function getNvmVersionDirectories(homePath: string): string[] {
   const nvmVersionsDir = join(homePath, '.nvm', 'versions', 'node')
   if (!existsSync(nvmVersionsDir)) {

--- a/src/main/codex-cli/windows-fnm-path.test.ts
+++ b/src/main/codex-cli/windows-fnm-path.test.ts
@@ -1,7 +1,7 @@
 import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, win32 } from 'node:path'
-import { spawnSync } from 'node:child_process'
+import { join, parse, win32 } from 'node:path'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
 import { normalizeSingleWindowsPathEntry } from '../../shared/windows-path-entry'
 import { getVersionManagerBinPaths, resolveCliCommand } from './command'
@@ -31,6 +31,9 @@ const invalidWindowsDirectories: [string, string | undefined][] = [
   ['trailing-space component', 'D:\\invalid \\directory'],
   ['reserved DOS component', 'D:\\NUL.txt\\directory'],
   ['named pipe namespace', '\\\\.\\pipe\\orca-fnm'],
+  ['extended drive namespace', '\\\\?\\C:\\fnm'],
+  ['extended UNC namespace', '\\\\?\\UNC\\server\\share\\fnm'],
+  ['extended volume namespace', '\\\\?\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\fnm'],
   ['GLOBALROOT namespace', '\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\fnm'],
   ['incomplete extended UNC', '\\\\?\\UNC\\server'],
   ['noncanonical extended UNC', '\\\\?\\UNC/server/share']
@@ -40,8 +43,6 @@ const validWindowsDirectories: [string, string][] = [
   ['spaces', 'C:\\Program Files\\fnm data'],
   ['Unicode', 'C:\\用户\\fnm-λ'],
   ['UNC', '\\\\server\\share\\fnm'],
-  ['extended drive', '\\\\?\\C:\\very long\\fnm'],
-  ['extended UNC', '\\\\?\\UNC\\server\\share\\fnm'],
   ['device', '\\\\.\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\fnm'],
   ['trailing separator', 'C:\\fnm\\']
 ]
@@ -59,25 +60,54 @@ function installNode(directory: string): string {
   return nodePath
 }
 
-function expectNodeLaunch(paths: string[], expectedNodePath: string): void {
+function getNodeLaunchEnvironment(paths: string[]): NodeJS.ProcessEnv {
+  return {
+    ComSpec: process.env.ComSpec,
+    PATHEXT: '.EXE',
+    Path: paths.join(';'),
+    SystemRoot: process.env.SystemRoot
+  }
+}
+
+function expectReportedNodePath(output: string, expectedNodePath: string): void {
+  if (expectedNodePath.startsWith('\\\\.\\')) {
+    expect(output.trim().toLowerCase()).toBe(expectedNodePath.toLowerCase())
+    return
+  }
+  expect(realpathSync(output.trim()).toLowerCase()).toBe(
+    realpathSync(expectedNodePath).toLowerCase()
+  )
+}
+
+function expectCmdNodeLaunch(paths: string[], expectedNodePath: string): void {
   const result = spawnSync(
     process.env.ComSpec ?? 'C:\\Windows\\System32\\cmd.exe',
     ['/d', '/s', '/c', 'node.exe -p process.execPath'],
     {
       encoding: 'utf8',
-      env: {
-        ComSpec: process.env.ComSpec,
-        PATHEXT: '.EXE',
-        Path: paths.join(';'),
-        SystemRoot: process.env.SystemRoot
-      }
+      env: getNodeLaunchEnvironment(paths)
     }
   )
 
   expect(result.status, result.stderr).toBe(0)
-  expect(realpathSync(result.stdout.trim()).toLowerCase()).toBe(
-    realpathSync(expectedNodePath).toLowerCase()
-  )
+  expectReportedNodePath(result.stdout, expectedNodePath)
+}
+
+function expectDirectNodeLaunch(paths: string[], expectedNodePath: string): void {
+  const result = spawnSync('node.exe', ['-p', 'process.execPath'], {
+    encoding: 'utf8',
+    env: getNodeLaunchEnvironment(paths)
+  })
+
+  expect(result.error, result.stderr).toBeUndefined()
+  expect(result.status, result.stderr).toBe(0)
+  expectReportedNodePath(result.stdout, expectedNodePath)
+}
+
+function toExtendedVolumePath(localPath: string): string {
+  const driveRoot = parse(localPath).root
+  const volumeRoot = execFileSync('mountvol.exe', [driveRoot, '/L'], { encoding: 'utf8' }).trim()
+  return `${volumeRoot}${localPath.slice(driveRoot.length)}`
 }
 
 afterEach(() => {
@@ -164,8 +194,10 @@ describeWindows('Windows fnm Node process launch', () => {
   it.each([
     ['reserved DOS component', 'NUL.txt'],
     ['named pipe namespace', '\\\\.\\pipe\\orca-fnm'],
+    ['extended drive namespace', '\\\\?\\C:\\fnm'],
+    ['extended UNC namespace', '\\\\?\\UNC\\server\\share\\fnm'],
     ['GLOBALROOT namespace', '\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\fnm']
-  ])('rejects a %s before launching a child from PATH', (_label, configuredFnmDir) => {
+  ])('rejects %s before launching a child from PATH', (_label, configuredFnmDir) => {
     const root = createTestRoot()
     const appData = join(root, 'AppData', 'Roaming')
     const expectedNodePath = installNode(join(appData, 'fnm', 'aliases', 'default'))
@@ -178,7 +210,36 @@ describeWindows('Windows fnm Node process launch', () => {
     })
 
     expect(paths).not.toContain(win32.join(fnmDir, 'aliases', 'default'))
-    expectNodeLaunch(paths, expectedNodePath)
+    expectCmdNodeLaunch(paths, expectedNodePath)
+  })
+
+  it('rejects an extended volume path while preserving volume device lookup', () => {
+    const root = createTestRoot()
+    const fnmDir = join(root, 'configured-fnm')
+    installNode(join(fnmDir, 'aliases', 'default'))
+    const expectedNodePath = installNode(join(root, '.bun', 'bin'))
+    const extendedFnmDir = toExtendedVolumePath(fnmDir)
+    const deviceFnmDir = extendedFnmDir.replace('\\\\?\\', '\\\\.\\')
+
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: root,
+      env: { FNM_DIR: extendedFnmDir }
+    })
+
+    expect(paths).not.toContain(win32.join(extendedFnmDir, 'aliases', 'default'))
+    expect(paths.indexOf(join(root, '.bun', 'bin'))).toBeGreaterThan(0)
+    expectDirectNodeLaunch(paths, expectedNodePath)
+
+    const devicePaths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: root,
+      env: { FNM_DIR: deviceFnmDir }
+    })
+    expect(devicePaths).toContain(win32.join(deviceFnmDir, 'aliases', 'default'))
+    const deviceNodePath = win32.join(deviceFnmDir, 'aliases', 'default', 'node.exe')
+    expectDirectNodeLaunch(devicePaths, deviceNodePath)
+    expectCmdNodeLaunch(devicePaths, deviceNodePath)
   })
 
   it('rejects an FNM_DIR that injects a second PATH entry', () => {
@@ -194,7 +255,7 @@ describeWindows('Windows fnm Node process launch', () => {
       env: { APPDATA: appData, FNM_DIR: `${escaped};${join(root, 'suffix')}` }
     })
 
-    expectNodeLaunch(paths, expectedNodePath)
+    expectCmdNodeLaunch(paths, expectedNodePath)
     expect(paths).toContain(join(appData, 'fnm', 'aliases', 'default'))
   })
 
@@ -211,7 +272,7 @@ describeWindows('Windows fnm Node process launch', () => {
       env: { APPDATA: `${escaped};${join(root, 'suffix')}` }
     })
 
-    expectNodeLaunch(paths, expectedNodePath)
+    expectCmdNodeLaunch(paths, expectedNodePath)
     expect(paths).toContain(expectedDefault)
   })
 
@@ -231,7 +292,7 @@ describeWindows('Windows fnm Node process launch', () => {
 
     expect(paths).toContain(fnmDefault)
     expect(paths).not.toContain(appDataDefault)
-    expectNodeLaunch(paths, expectedNodePath)
+    expectCmdNodeLaunch(paths, expectedNodePath)
   })
 
   it('launches Node from a higher-priority non-fnm directory', () => {
@@ -248,6 +309,6 @@ describeWindows('Windows fnm Node process launch', () => {
     })
 
     expect(paths.indexOf(voltaBin)).toBeLessThan(paths.indexOf(join(fnmDir, 'aliases', 'default')))
-    expectNodeLaunch(paths, expectedNodePath)
+    expectCmdNodeLaunch(paths, expectedNodePath)
   })
 })

--- a/src/main/codex-cli/windows-fnm-path.test.ts
+++ b/src/main/codex-cli/windows-fnm-path.test.ts
@@ -4,7 +4,7 @@ import { join, win32 } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
 import { normalizeSingleWindowsPathEntry } from '../../shared/windows-path-entry'
-import { getVersionManagerBinPaths } from './command'
+import { getVersionManagerBinPaths, resolveCliCommand } from './command'
 
 const describeWindows = describe.runIf(process.platform === 'win32')
 const testRoots: string[] = []
@@ -29,6 +29,9 @@ const invalidWindowsDirectories: [string, string | undefined][] = [
   ['control-character-containing', 'D:\\invalid\u0001directory'],
   ['trailing-dot component', 'D:\\invalid.\\directory'],
   ['trailing-space component', 'D:\\invalid \\directory'],
+  ['reserved DOS component', 'D:\\NUL.txt\\directory'],
+  ['named pipe namespace', '\\\\.\\pipe\\orca-fnm'],
+  ['GLOBALROOT namespace', '\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\fnm'],
   ['incomplete extended UNC', '\\\\?\\UNC\\server'],
   ['noncanonical extended UNC', '\\\\?\\UNC/server/share']
 ]
@@ -144,9 +147,40 @@ describe('Windows fnm directory selection', () => {
 
     expect(paths.indexOf(voltaBin)).toBeLessThan(paths.indexOf(fnmDefault))
   })
+
+  it('keeps the bare Node fallback when no safe installation exists', () => {
+    expect(
+      resolveCliCommand('node', {
+        platform: 'win32',
+        pathEnv: '',
+        homePath: windowsHome,
+        env: { FNM_DIR: 'C:\\NUL.txt', APPDATA: '\\\\.\\pipe\\orca-fnm' }
+      })
+    ).toBe('node')
+  })
 })
 
 describeWindows('Windows fnm Node process launch', () => {
+  it.each([
+    ['reserved DOS component', 'NUL.txt'],
+    ['named pipe namespace', '\\\\.\\pipe\\orca-fnm'],
+    ['GLOBALROOT namespace', '\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\fnm']
+  ])('rejects a %s before launching a child from PATH', (_label, configuredFnmDir) => {
+    const root = createTestRoot()
+    const appData = join(root, 'AppData', 'Roaming')
+    const expectedNodePath = installNode(join(appData, 'fnm', 'aliases', 'default'))
+    const fnmDir = configuredFnmDir === 'NUL.txt' ? join(root, configuredFnmDir) : configuredFnmDir
+
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: root,
+      env: { APPDATA: appData, FNM_DIR: fnmDir }
+    })
+
+    expect(paths).not.toContain(win32.join(fnmDir, 'aliases', 'default'))
+    expectNodeLaunch(paths, expectedNodePath)
+  })
+
   it('rejects an FNM_DIR that injects a second PATH entry', () => {
     const root = createTestRoot()
     const escaped = join(root, 'escaped')

--- a/src/main/codex-cli/windows-fnm-path.test.ts
+++ b/src/main/codex-cli/windows-fnm-path.test.ts
@@ -141,6 +141,17 @@ describe('Windows fnm directory selection', () => {
     expect(paths).not.toContain(win32.join(fnmDefault, 'bin'))
   })
 
+  it('honors Windows environment key casing', () => {
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: windowsHome,
+      env: { appdata: windowsAppData, fnm_dir: windowsFnmDir }
+    })
+
+    expect(paths).toContain(win32.join(windowsFnmDir, 'aliases', 'default'))
+    expect(paths).not.toContain(win32.join(windowsAppData, 'fnm', 'aliases', 'default'))
+  })
+
   it.each(invalidWindowsDirectories)('falls back to APPDATA for %s FNM_DIR', (_label, fnmDir) => {
     const paths = getVersionManagerBinPaths({
       platform: 'win32',

--- a/src/main/codex-cli/windows-fnm-path.test.ts
+++ b/src/main/codex-cli/windows-fnm-path.test.ts
@@ -1,0 +1,152 @@
+import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, win32 } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getVersionManagerBinPaths } from './command'
+
+const describeWindows = describe.runIf(process.platform === 'win32')
+const testRoots: string[] = []
+const windowsHome = 'C:\\Users\\orca-test'
+const windowsAppData = 'D:\\Profiles\\orca-test\\Roaming'
+const windowsFnmDir = 'E:\\fnm-data'
+const invalidWindowsDirectories: [string, string | undefined][] = [
+  ['missing', undefined],
+  ['empty', ''],
+  ['whitespace', '   '],
+  ['relative', 'relative\\directory'],
+  ['root-relative', '\\root-relative\\directory'],
+  ['unexpanded', '%APPDATA%\\directory'],
+  ['quoted', '"D:\\quoted"'],
+  ['NUL-containing', 'D:\\malformed\0directory']
+]
+
+function createTestRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-windows-fnm-path-'))
+  testRoots.push(root)
+  return root
+}
+
+function installNode(directory: string): string {
+  mkdirSync(directory, { recursive: true })
+  const nodePath = join(directory, 'node.exe')
+  copyFileSync(process.execPath, nodePath)
+  return nodePath
+}
+
+function expectNodeLaunch(paths: string[], expectedNodePath: string): void {
+  const result = spawnSync(
+    process.env.ComSpec ?? 'C:\\Windows\\System32\\cmd.exe',
+    ['/d', '/s', '/c', 'node.exe -p process.execPath'],
+    {
+      encoding: 'utf8',
+      env: {
+        ComSpec: process.env.ComSpec,
+        PATHEXT: '.EXE',
+        Path: paths.join(';'),
+        SystemRoot: process.env.SystemRoot
+      }
+    }
+  )
+
+  expect(result.status, result.stderr).toBe(0)
+  expect(realpathSync(result.stdout.trim()).toLowerCase()).toBe(
+    realpathSync(expectedNodePath).toLowerCase()
+  )
+}
+
+afterEach(() => {
+  for (const root of testRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('Windows fnm directory selection', () => {
+  it('prefers FNM_DIR over APPDATA without a POSIX bin suffix', () => {
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: windowsHome,
+      env: { APPDATA: windowsAppData, FNM_DIR: windowsFnmDir }
+    })
+    const fnmDefault = win32.join(windowsFnmDir, 'aliases', 'default')
+
+    expect(paths).toContain(fnmDefault)
+    expect(paths).not.toContain(win32.join(windowsAppData, 'fnm', 'aliases', 'default'))
+    expect(paths).not.toContain(win32.join(fnmDefault, 'bin'))
+  })
+
+  it.each(invalidWindowsDirectories)('falls back to APPDATA for %s FNM_DIR', (_label, fnmDir) => {
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: windowsHome,
+      env: { APPDATA: windowsAppData, FNM_DIR: fnmDir }
+    })
+
+    expect(paths).toContain(win32.join(windowsAppData, 'fnm', 'aliases', 'default'))
+  })
+
+  it.each(invalidWindowsDirectories)(
+    'falls back to the home-derived roaming directory for %s APPDATA',
+    (_label, appData) => {
+      const paths = getVersionManagerBinPaths({
+        platform: 'win32',
+        homePath: windowsHome,
+        env: { APPDATA: appData }
+      })
+
+      expect(paths).toContain(
+        win32.join(windowsHome, 'AppData', 'Roaming', 'fnm', 'aliases', 'default')
+      )
+    }
+  )
+
+  it('preserves higher-priority non-fnm Node directories', () => {
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: windowsHome,
+      env: { FNM_DIR: windowsFnmDir }
+    })
+    const voltaBin = join(windowsHome, '.volta', 'bin')
+    const fnmDefault = win32.join(windowsFnmDir, 'aliases', 'default')
+
+    expect(paths.indexOf(voltaBin)).toBeLessThan(paths.indexOf(fnmDefault))
+  })
+})
+
+describeWindows('Windows fnm Node process launch', () => {
+  it('launches Node from FNM_DIR instead of APPDATA', () => {
+    const root = createTestRoot()
+    const fnmDefault = join(root, 'configured-fnm', 'aliases', 'default')
+    const appData = join(root, 'AppData', 'Roaming')
+    const appDataDefault = join(appData, 'fnm', 'aliases', 'default')
+    const expectedNodePath = installNode(fnmDefault)
+    installNode(appDataDefault)
+
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: root,
+      env: { APPDATA: appData, FNM_DIR: join(root, 'configured-fnm') }
+    })
+
+    expect(paths).toContain(fnmDefault)
+    expect(paths).not.toContain(appDataDefault)
+    expectNodeLaunch(paths, expectedNodePath)
+  })
+
+  it('launches Node from a higher-priority non-fnm directory', () => {
+    const root = createTestRoot()
+    const voltaBin = join(root, '.volta', 'bin')
+    const expectedNodePath = installNode(voltaBin)
+    const fnmDir = join(root, 'fnm')
+    installNode(join(fnmDir, 'aliases', 'default'))
+
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: root,
+      env: { FNM_DIR: fnmDir }
+    })
+
+    expect(paths.indexOf(voltaBin)).toBeLessThan(paths.indexOf(join(fnmDir, 'aliases', 'default')))
+    expectNodeLaunch(paths, expectedNodePath)
+  })
+})

--- a/src/main/codex-cli/windows-fnm-path.test.ts
+++ b/src/main/codex-cli/windows-fnm-path.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { afterEach, describe, expect, it } from 'vitest'
+import { normalizeSingleWindowsPathEntry } from '../../shared/windows-path-entry'
 import { getVersionManagerBinPaths } from './command'
 
 const describeWindows = describe.runIf(process.platform === 'win32')
@@ -18,7 +19,28 @@ const invalidWindowsDirectories: [string, string | undefined][] = [
   ['root-relative', '\\root-relative\\directory'],
   ['unexpanded', '%APPDATA%\\directory'],
   ['quoted', '"D:\\quoted"'],
-  ['NUL-containing', 'D:\\malformed\0directory']
+  ['NUL-containing', 'D:\\malformed\0directory'],
+  ['PATH-delimited', 'D:\\escaped;D:\\suffix'],
+  ['pipe-containing', 'D:\\invalid|directory'],
+  ['stream-colon-containing', 'D:\\invalid:directory'],
+  ['wildcard-containing', 'D:\\invalid*directory'],
+  ['question-mark-containing', 'D:\\invalid?directory'],
+  ['angle-bracket-containing', 'D:\\invalid<directory'],
+  ['control-character-containing', 'D:\\invalid\u0001directory'],
+  ['trailing-dot component', 'D:\\invalid.\\directory'],
+  ['trailing-space component', 'D:\\invalid \\directory'],
+  ['incomplete extended UNC', '\\\\?\\UNC\\server'],
+  ['noncanonical extended UNC', '\\\\?\\UNC/server/share']
+]
+const validWindowsDirectories: [string, string][] = [
+  ['drive', 'C:\\fnm'],
+  ['spaces', 'C:\\Program Files\\fnm data'],
+  ['Unicode', 'C:\\用户\\fnm-λ'],
+  ['UNC', '\\\\server\\share\\fnm'],
+  ['extended drive', '\\\\?\\C:\\very long\\fnm'],
+  ['extended UNC', '\\\\?\\UNC\\server\\share\\fnm'],
+  ['device', '\\\\.\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\fnm'],
+  ['trailing separator', 'C:\\fnm\\']
 ]
 
 function createTestRoot(): string {
@@ -62,6 +84,17 @@ afterEach(() => {
 })
 
 describe('Windows fnm directory selection', () => {
+  it.each(validWindowsDirectories)('accepts a valid %s directory', (_label, directory) => {
+    expect(normalizeSingleWindowsPathEntry(directory)).toBe(directory)
+    expect(
+      getVersionManagerBinPaths({
+        platform: 'win32',
+        homePath: windowsHome,
+        env: { FNM_DIR: directory }
+      })
+    ).toContain(win32.join(directory, 'aliases', 'default'))
+  })
+
   it('prefers FNM_DIR over APPDATA without a POSIX bin suffix', () => {
     const paths = getVersionManagerBinPaths({
       platform: 'win32',
@@ -114,6 +147,40 @@ describe('Windows fnm directory selection', () => {
 })
 
 describeWindows('Windows fnm Node process launch', () => {
+  it('rejects an FNM_DIR that injects a second PATH entry', () => {
+    const root = createTestRoot()
+    const escaped = join(root, 'escaped')
+    const appData = join(root, 'AppData', 'Roaming')
+    const expectedNodePath = installNode(join(appData, 'fnm', 'aliases', 'default'))
+    installNode(escaped)
+
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: root,
+      env: { APPDATA: appData, FNM_DIR: `${escaped};${join(root, 'suffix')}` }
+    })
+
+    expectNodeLaunch(paths, expectedNodePath)
+    expect(paths).toContain(join(appData, 'fnm', 'aliases', 'default'))
+  })
+
+  it('rejects an APPDATA value that injects a second PATH entry', () => {
+    const root = createTestRoot()
+    const escaped = join(root, 'escaped')
+    const expectedDefault = join(root, 'AppData', 'Roaming', 'fnm', 'aliases', 'default')
+    const expectedNodePath = installNode(expectedDefault)
+    installNode(escaped)
+
+    const paths = getVersionManagerBinPaths({
+      platform: 'win32',
+      homePath: root,
+      env: { APPDATA: `${escaped};${join(root, 'suffix')}` }
+    })
+
+    expectNodeLaunch(paths, expectedNodePath)
+    expect(paths).toContain(expectedDefault)
+  })
+
   it('launches Node from FNM_DIR instead of APPDATA', () => {
     const root = createTestRoot()
     const fnmDefault = join(root, 'configured-fnm', 'aliases', 'default')

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -196,6 +196,32 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('deduplicates mixed-case PATH at the detached Windows daemon boundary', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    const baseKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'Path'
+    const overrideKey = baseKey === 'PATH' ? 'Path' : 'PATH'
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'mixed-path-key',
+        cols: 80,
+        rows: 24,
+        env: { COMSPEC: CMD_ABS, [overrideKey]: 'C:\\fnm;C:\\existing' }
+      })
+      const spawnEnv = spawnMock.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+
+      expect(Object.keys(spawnEnv).filter((key) => key.toLowerCase() === 'path')).toEqual([baseKey])
+      expect(spawnEnv[baseKey]).toBe('C:\\fnm;C:\\existing')
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
+
   it('appends Git prompt guards after the detached daemon inherited config', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -32,6 +32,7 @@ import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
+import { canonicalizeWindowsPathKey } from '../pty/windows-environment-path'
 import { parseWslPath } from '../wsl'
 import { addWslEnvKeys } from '../wsl-env'
 import {
@@ -559,8 +560,9 @@ function spawnDaemonPtyWithWindowsFallback(args: {
  */
 export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandle {
   const size = normalizePtySize(opts.cols, opts.rows)
+  const inheritedEnv = stripInheritedBuildModeEnv(process.env)
   const env: Record<string, string> = {
-    ...mergeGitConfigEnvProtocol(stripInheritedBuildModeEnv(process.env), opts.env),
+    ...mergeGitConfigEnvProtocol(inheritedEnv, opts.env),
     TERM: 'xterm-256color',
     COLORTERM: 'truecolor',
     TERM_PROGRAM: 'Orca',
@@ -780,6 +782,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   })
 
   let proc: pty.IPty
+  canonicalizeWindowsPathKey(env, inheritedEnv, env)
   try {
     const spawned = spawnDaemonPtyWithWindowsFallback({
       shellPath,

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -144,6 +144,10 @@ import {
 } from '../agent-hooks/migration-unsupported-pty-state'
 import { parseWslPath } from '../wsl'
 import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
+import {
+  shouldApplyWindowsFnmNodeFallback,
+  withWindowsFnmNodeFallback
+} from '../pty/windows-fnm-node-fallback'
 import { addOrcaWslInteropEnv, stampWslOrchestrationCompatibilityHost } from '../pty/wsl-orca-env'
 import { PtyProducerFlowController } from './pty-producer-flow-control'
 import { beginTerminalInstall } from './watcher-removal-gate'
@@ -3795,6 +3799,15 @@ export function registerPtyHandlers(
           skipCodexHomeEnv,
           settings: getSettings?.()
         })
+      if (
+        shouldApplyWindowsFnmNodeFallback({
+          connectionId: args.connectionId,
+          isAgentLaunch: isTuiAgent(args.launchAgent),
+          isWsl: codexSelectionTarget.runtime === 'wsl'
+        })
+      ) {
+        env = await withWindowsFnmNodeFallback(env)
+      }
       if (isDaemonHostSpawn && sessionId) {
         if (!isSafePtySessionId(sessionId, app.getPath('userData'))) {
           throw new Error('Invalid PTY session id')
@@ -4947,6 +4960,16 @@ export function registerPtyHandlers(
       const codexResumeHome = codexResumeLaunch.codexResumeHome
       const launchCommand = codexResumeLaunch.command
       baseEnv = stripSequencedStartupResumeArgv(baseEnv, codexResumeLaunch)
+      if (
+        nativeWindowsConptySpawn &&
+        shouldApplyWindowsFnmNodeFallback({
+          connectionId: args.connectionId,
+          isAgentLaunch: isTuiAgent(args.launchAgent),
+          isWsl: codexSelectionTarget.runtime === 'wsl'
+        })
+      ) {
+        baseEnv = await withWindowsFnmNodeFallback(baseEnv)
+      }
       // Why: declared after the strip so a local-provider spawn cannot capture the
       // pre-strip env — only the daemon branch below re-derives this from baseEnv.
       let env: Record<string, string> | undefined = baseEnv

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -478,6 +478,22 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.PATH).toBe(process.env.PATH)
     })
 
+    it('deduplicates mixed-case PATH at the native Windows spawn boundary', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const baseKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'Path'
+      const overrideKey = baseKey === 'PATH' ? 'Path' : 'PATH'
+
+      await provider.spawn({
+        cols: 80,
+        rows: 24,
+        env: { COMSPEC: CMD_ABS, [overrideKey]: 'C:\\fnm;C:\\existing' }
+      })
+
+      const spawnEnv = spawnMock.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+      expect(Object.keys(spawnEnv).filter((key) => key.toLowerCase() === 'path')).toEqual([baseKey])
+      expect(spawnEnv[baseKey]).toBe('C:\\fnm;C:\\existing')
+    })
+
     it('keeps an explicitly requested NODE_ENV for spawned terminals', async () => {
       // Why: only the ambient value is stripped; a caller-supplied NODE_ENV still wins.
       const previous = process.env.NODE_ENV

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -38,6 +38,7 @@ import type { ShellReadySignal } from './local-pty-shell-ready'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
+import { canonicalizeWindowsPathKey } from '../pty/windows-environment-path'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
 import { addWslEnvKeys } from '../wsl-env'
 import {
@@ -646,8 +647,9 @@ export class LocalPtyProvider implements IPtyProvider {
     ensureNodePtySpawnHelperExecutable()
     validateWorkingDirectory(validationCwd)
 
+    const inheritedEnv = stripInheritedBuildModeEnv(process.env)
     const spawnEnv: Record<string, string> = {
-      ...mergeGitConfigEnvProtocol(stripInheritedBuildModeEnv(process.env), args.env),
+      ...mergeGitConfigEnvProtocol(inheritedEnv, args.env),
       TERM: 'xterm-256color',
       COLORTERM: 'truecolor',
       TERM_PROGRAM: 'Orca',
@@ -790,6 +792,7 @@ export class LocalPtyProvider implements IPtyProvider {
       }
     }
     promoteAgentTeamsShimPath(finalEnv, args.env?.PATH)
+    canonicalizeWindowsPathKey(finalEnv, inheritedEnv, finalEnv)
 
     // Why: worktree-scoped HISTFILE — without it worktrees share one global history (terminal-history-scope-design §7–§10).
     const worktreeId = args.worktreeId

--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -12,6 +12,7 @@ vi.mock('node:child_process', () => ({
 
 import {
   __resetPersistedWindowsPathCacheForTests,
+  canonicalizeWindowsPathKey,
   mergePersistedWindowsPath,
   mergePersistedWindowsPathAsync,
   readPersistedWindowsPathSegments,
@@ -19,6 +20,31 @@ import {
 } from './windows-environment-path'
 
 type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
+
+describe('canonicalizeWindowsPathKey', () => {
+  it.each([
+    ['PATH', 'Path'],
+    ['Path', 'PATH'],
+    ['Path', 'path']
+  ])('uses the base %s spelling for a %s override', (baseKey, overrideKey) => {
+    const baseEnv = { [baseKey]: 'C:\\stale' }
+    const overrideEnv = { [overrideKey]: 'C:\\fnm;C:\\existing' }
+    const env = { ...baseEnv, ...overrideEnv }
+
+    canonicalizeWindowsPathKey(env, baseEnv, overrideEnv, 'win32')
+
+    expect(Object.keys(env).filter((key) => key.toLowerCase() === 'path')).toEqual([baseKey])
+    expect(env[baseKey]).toBe('C:\\fnm;C:\\existing')
+  })
+
+  it('does not change non-Windows merges', () => {
+    const env = { PATH: '/usr/bin', Path: '/override' }
+
+    canonicalizeWindowsPathKey(env, { PATH: '/usr/bin' }, { Path: '/override' }, 'linux')
+
+    expect(env).toEqual({ PATH: '/usr/bin', Path: '/override' })
+  })
+})
 
 describe('readPersistedWindowsPathSegments', () => {
   it('reads machine and user Path values from the Windows registry', () => {

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -240,6 +240,31 @@ export function __resetPersistedWindowsPathCacheForTests(): void {
   pendingPersistedWindowsPathRefresh = undefined
 }
 
+export function canonicalizeWindowsPathKey(
+  env: NodeJS.ProcessEnv,
+  baseEnv: NodeJS.ProcessEnv,
+  overrideEnv: NodeJS.ProcessEnv | undefined,
+  platform: NodeJS.Platform = process.platform
+): void {
+  if (platform !== 'win32') {
+    return
+  }
+  const overrideEntries = Object.entries(overrideEnv ?? {}).filter(
+    ([key]) => key.toLowerCase() === 'path'
+  )
+  if (overrideEntries.length === 0) {
+    return
+  }
+  const [overrideKey, overrideValue] = overrideEntries.at(-1)!
+  const pathKey = Object.keys(baseEnv).find((key) => key.toLowerCase() === 'path') ?? overrideKey
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'path') {
+      delete env[key]
+    }
+  }
+  env[pathKey] = overrideValue
+}
+
 function mergeWindowsPathSegments(
   env: NodeJS.ProcessEnv,
   persistedSegments: string[],

--- a/src/main/pty/windows-fnm-node-fallback.test.ts
+++ b/src/main/pty/windows-fnm-node-fallback.test.ts
@@ -8,6 +8,7 @@ import {
   type WindowsNodeProbe,
   withWindowsFnmNodeFallback
 } from './windows-fnm-node-fallback'
+import { canonicalizeWindowsPathKey } from './windows-environment-path'
 
 const itWindows = it.runIf(process.platform === 'win32')
 const tempDirectories: string[] = []
@@ -227,6 +228,26 @@ describe('Windows fnm Node child fallback', () => {
 })
 
 describe('native Windows fnm Node child fallback', () => {
+  itWindows('keeps fnm first when the detached daemon PATH spelling differs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-daemon-path-key-'))
+    tempDirectories.push(root)
+    const fnmRoot = join(root, 'fnm')
+    const fnmNode = createNode(join(fnmRoot, 'aliases', 'default'))
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    const mainEnv = sourceEnvWithPathKey('Path', system32)
+    const daemonEnv = sourceEnvWithPathKey('PATH', system32)
+    const overlay = await withWindowsFnmNodeFallback(
+      { Path: system32, FNM_DIR: fnmRoot },
+      { homePath: root, sourceEnv: mainEnv }
+    )
+    const providerEnv = { ...daemonEnv, ...overlay }
+
+    canonicalizeWindowsPathKey(providerEnv, daemonEnv, overlay)
+
+    expect(Object.keys(providerEnv).filter((key) => key.toLowerCase() === 'path')).toEqual(['PATH'])
+    expect(normalized(runNode(providerEnv))).toBe(normalized(fnmNode))
+  })
+
   itWindows.each([
     ['PATH', 'Path'],
     ['Path', 'PATH'],

--- a/src/main/pty/windows-fnm-node-fallback.test.ts
+++ b/src/main/pty/windows-fnm-node-fallback.test.ts
@@ -1,0 +1,315 @@
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, win32 } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  shouldApplyWindowsFnmNodeFallback,
+  type WindowsNodeProbe,
+  withWindowsFnmNodeFallback
+} from './windows-fnm-node-fallback'
+
+const itWindows = it.runIf(process.platform === 'win32')
+const tempDirectories: string[] = []
+
+function sourceEnv(pathValue: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env = { ...process.env, ...extra }
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'path') {
+      delete env[key]
+    }
+  }
+  env.Path = pathValue
+  return env
+}
+
+function createNode(directory: string): string {
+  mkdirSync(directory, { recursive: true })
+  const target = join(directory, 'node.exe')
+  copyFileSync(process.execPath, target)
+  return target
+}
+
+function normalized(pathValue: string): string {
+  return win32.normalize(pathValue).toLowerCase()
+}
+
+function runNode(env: NodeJS.ProcessEnv): string {
+  const result = spawnSync('node.exe', ['-p', 'process.execPath'], {
+    encoding: 'utf8',
+    env,
+    windowsHide: true
+  })
+  expect(result.status, result.stderr).toBe(0)
+  return result.stdout.trim()
+}
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('Windows fnm Node child fallback', () => {
+  it.each([
+    ['SSH', { connectionId: 'ssh-1', isAgentLaunch: true, isWsl: false, platform: 'win32' }],
+    ['WSL', { connectionId: null, isAgentLaunch: true, isWsl: true, platform: 'win32' }],
+    ['bare shell', { connectionId: null, isAgentLaunch: false, isWsl: false, platform: 'win32' }],
+    ['non-Windows', { connectionId: null, isAgentLaunch: true, isWsl: false, platform: 'linux' }]
+  ] as const)('bypasses the %s route', (_label, route) => {
+    expect(shouldApplyWindowsFnmNodeFallback(route)).toBe(false)
+  })
+
+  it('selects only a native local Windows agent launch', () => {
+    expect(
+      shouldApplyWindowsFnmNodeFallback({
+        connectionId: null,
+        isAgentLaunch: true,
+        isWsl: false,
+        platform: 'win32'
+      })
+    ).toBe(true)
+  })
+
+  it('preserves a working inherited Node and PATH byte-for-byte', async () => {
+    const overlay = { Path: 'C:\\preferred;C:\\existing', FNM_DIR: 'C:\\fnm' }
+    const probeNode = vi.fn<WindowsNodeProbe>().mockResolvedValue(true)
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      homePath: 'C:\\Users\\dev',
+      platform: 'win32',
+      probeNode,
+      sourceEnv: sourceEnv('C:\\source')
+    })
+
+    expect(result).toBe(overlay)
+    expect(result?.Path).toBe('C:\\preferred;C:\\existing')
+    expect(probeNode).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves an inherited uppercase PATH key when fallback is needed', async () => {
+    const fnmDir = 'C:\\fnm'
+    const expectedDirectory = win32.join(fnmDir, 'aliases', 'default')
+    const probeNode = vi.fn<WindowsNodeProbe>(async (env) => env.PATH === expectedDirectory)
+
+    const result = await withWindowsFnmNodeFallback(
+      { PATH: 'C:\\existing', FNM_DIR: fnmDir },
+      {
+        homePath: 'C:\\Users\\dev',
+        platform: 'win32',
+        probeNode,
+        sourceEnv: { Path: 'C:\\source' }
+      }
+    )
+
+    expect(result?.PATH).toBe(`${expectedDirectory};C:\\existing`)
+    expect(result).not.toHaveProperty('Path')
+  })
+
+  it.each([
+    ['drive', 'C:\\fnm'],
+    ['spaces', 'C:\\User Data\\fnm'],
+    ['Unicode', 'C:\\Users\\开发者\\fnm'],
+    ['UNC', '\\\\server\\share\\fnm'],
+    ['trailing separator', 'C:\\fnm\\']
+  ])('uses a runnable valid %s candidate', async (_label, fnmDir) => {
+    const expectedDirectory = win32.join(fnmDir, 'aliases', 'default')
+    const probeNode = vi.fn<WindowsNodeProbe>(async (env) => env.Path === expectedDirectory)
+
+    const result = await withWindowsFnmNodeFallback(undefined, {
+      homePath: 'C:\\Users\\dev',
+      platform: 'win32',
+      probeNode,
+      sourceEnv: sourceEnv('C:\\Windows\\System32', { FNM_DIR: fnmDir })
+    })
+
+    expect(result?.Path?.split(';')).toEqual([expectedDirectory, 'C:\\Windows\\System32'])
+    expect(probeNode).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    'C:\\escaped;C:\\suffix',
+    'C:\\invalid|component',
+    '\\\\?\\C:\\fnm',
+    '\\\\.\\pipe\\fnm',
+    'relative\\fnm'
+  ])('ignores a malformed candidate without changing PATH: %s', async (fnmDir) => {
+    const overlay = { Path: 'C:\\Windows\\System32', FNM_DIR: fnmDir }
+    const probeNode = vi.fn<WindowsNodeProbe>().mockResolvedValue(false)
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      homePath: 'C:\\missing-home',
+      platform: 'win32',
+      probeNode,
+      sourceEnv: sourceEnv('C:\\source', { APPDATA: 'relative\\appdata' })
+    })
+
+    expect(result).toBe(overlay)
+    expect(result?.Path).toBe('C:\\Windows\\System32')
+  })
+
+  it('ignores a candidate whose node.exe cannot run', async () => {
+    const overlay = { Path: 'C:\\Windows\\System32', FNM_DIR: 'C:\\missing-fnm' }
+    const probeNode = vi.fn<WindowsNodeProbe>().mockResolvedValue(false)
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      homePath: 'C:\\Users\\dev',
+      platform: 'win32',
+      probeNode,
+      sourceEnv: sourceEnv('C:\\source')
+    })
+
+    expect(result).toBe(overlay)
+    expect(probeNode).toHaveBeenCalledTimes(2)
+  })
+
+  it('filters unsafe home-derived entries before the executable probe', async () => {
+    const overlay = { Path: 'C:\\Windows\\System32' }
+    const probedPaths: string[] = []
+    const probeNode = vi.fn<WindowsNodeProbe>(async (env) => {
+      probedPaths.push(env.Path ?? '')
+      return false
+    })
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      homePath: 'C:\\escaped;C:\\suffix',
+      platform: 'win32',
+      probeNode,
+      sourceEnv: { Path: 'C:\\source' }
+    })
+
+    expect(result).toBe(overlay)
+    expect(probedPaths.every((pathValue) => !pathValue.includes('escaped;'))).toBe(true)
+    expect(probeNode).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not probe or mutate non-Windows environments', async () => {
+    const overlay = { PATH: '/usr/bin' }
+    const probeNode = vi.fn<WindowsNodeProbe>().mockResolvedValue(false)
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      platform: 'linux',
+      probeNode
+    })
+
+    expect(result).toBe(overlay)
+    expect(probeNode).not.toHaveBeenCalled()
+  })
+})
+
+describe('native Windows fnm Node child fallback', () => {
+  itWindows('keeps a real working inherited node.exe ahead of fnm', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-inherited-'))
+    tempDirectories.push(root)
+    const inheritedDirectory = join(root, 'inherited')
+    const inheritedNode = createNode(inheritedDirectory)
+    const fnmRoot = join(root, 'fnm')
+    createNode(join(fnmRoot, 'aliases', 'default'))
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    const overlay = { Path: `${system32};${inheritedDirectory}`, FNM_DIR: fnmRoot }
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      sourceEnv: sourceEnv(overlay.Path)
+    })
+
+    expect(result).toBe(overlay)
+    expect(normalized(runNode(sourceEnv(result?.Path ?? '')))).toBe(normalized(inheritedNode))
+  })
+
+  itWindows('adds a validated fnm default for real child and cmd.exe lookup', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-child-'))
+    tempDirectories.push(root)
+    const fnmRoot = join(root, 'fnm with 空格')
+    const fnmNode = createNode(join(fnmRoot, 'aliases', 'default'))
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    const overlay = { Path: system32, FNM_DIR: fnmRoot }
+    const disabledEnv = sourceEnv(system32)
+    const disabledDirect = spawnSync('node.exe', ['--version'], {
+      env: disabledEnv,
+      windowsHide: true
+    })
+    const disabledCmd = spawnSync(
+      process.env.ComSpec ?? join(system32, 'cmd.exe'),
+      ['/d', '/s', '/c', 'node.exe --version'],
+      { env: disabledEnv, windowsHide: true }
+    )
+
+    expect(disabledDirect.status).not.toBe(0)
+    expect(disabledCmd.status).not.toBe(0)
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      homePath: join(root, 'empty-home'),
+      sourceEnv: sourceEnv(system32)
+    })
+    const childEnv = sourceEnv(result?.Path ?? '')
+    const cmdResult = spawnSync(
+      process.env.ComSpec ?? join(system32, 'cmd.exe'),
+      ['/d', '/s', '/c', 'node.exe -p process.execPath'],
+      { encoding: 'utf8', env: childEnv, windowsHide: true }
+    )
+
+    expect(result?.Path?.split(';')[0]).toBe(win32.join(fnmRoot, 'aliases', 'default'))
+    expect(normalized(runNode(childEnv))).toBe(normalized(fnmNode))
+    expect(cmdResult.status, cmdResult.stderr).toBe(0)
+    expect(normalized(cmdResult.stdout.trim())).toBe(normalized(fnmNode))
+  })
+
+  itWindows('accepts an fnm default directory junction after executing its node.exe', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-junction-'))
+    tempDirectories.push(root)
+    const fnmRoot = join(root, 'fnm')
+    const versionDirectory = join(fnmRoot, 'node-versions', 'v22', 'installation')
+    const versionNode = createNode(versionDirectory)
+    const defaultDirectory = join(fnmRoot, 'aliases', 'default')
+    mkdirSync(join(fnmRoot, 'aliases'), { recursive: true })
+    symlinkSync(versionDirectory, defaultDirectory, 'junction')
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+
+    const result = await withWindowsFnmNodeFallback(
+      { Path: system32, FNM_DIR: fnmRoot },
+      { homePath: join(root, 'empty-home'), sourceEnv: sourceEnv(system32) }
+    )
+    const resolvedNode = normalized(runNode(sourceEnv(result?.Path ?? '')))
+
+    expect(result?.Path?.split(';')).toEqual([defaultDirectory, system32])
+    expect([normalized(versionNode), normalized(join(defaultDirectory, 'node.exe'))]).toContain(
+      resolvedNode
+    )
+  })
+
+  itWindows('leaves PATH unchanged when the selected fnm directory does not exist', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-missing-'))
+    tempDirectories.push(root)
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    const overlay = { Path: system32, FNM_DIR: join(root, 'missing') }
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      homePath: join(root, 'empty-home'),
+      sourceEnv: sourceEnv(system32)
+    })
+
+    expect(result).toBe(overlay)
+    expect(result?.Path).toBe(system32)
+  })
+
+  itWindows('preserves a runnable inherited non-fnm Node', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-node-fallback-'))
+    tempDirectories.push(root)
+    const fallbackDirectory = join(root, 'inherited-node')
+    const fallbackNode = createNode(fallbackDirectory)
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    const overlay = {
+      Path: `${system32};${fallbackDirectory}`,
+      FNM_DIR: join(root, 'missing-fnm')
+    }
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      homePath: root,
+      sourceEnv: sourceEnv(system32)
+    })
+
+    expect(result).toBe(overlay)
+    expect(result?.Path?.split(';')).toEqual([system32, fallbackDirectory])
+    expect(normalized(runNode(sourceEnv(result?.Path ?? '')))).toBe(normalized(fallbackNode))
+  })
+})

--- a/src/main/pty/windows-fnm-node-fallback.test.ts
+++ b/src/main/pty/windows-fnm-node-fallback.test.ts
@@ -23,6 +23,13 @@ function sourceEnv(pathValue: string, extra: NodeJS.ProcessEnv = {}): NodeJS.Pro
   return env
 }
 
+function sourceEnvWithPathKey(pathKey: string, pathValue: string): NodeJS.ProcessEnv {
+  const env = sourceEnv(pathValue)
+  delete env.Path
+  env[pathKey] = pathValue
+  return env
+}
+
 function createNode(directory: string): string {
   mkdirSync(directory, { recursive: true })
   const target = join(directory, 'node.exe')
@@ -87,10 +94,10 @@ describe('Windows fnm Node child fallback', () => {
     expect(probeNode).toHaveBeenCalledTimes(1)
   })
 
-  it('preserves an inherited uppercase PATH key when fallback is needed', async () => {
+  it('uses the inherited PATH key spelling when fallback is needed', async () => {
     const fnmDir = 'C:\\fnm'
     const expectedDirectory = win32.join(fnmDir, 'aliases', 'default')
-    const probeNode = vi.fn<WindowsNodeProbe>(async (env) => env.PATH === expectedDirectory)
+    const probeNode = vi.fn<WindowsNodeProbe>(async (env) => env.Path === expectedDirectory)
 
     const result = await withWindowsFnmNodeFallback(
       { PATH: 'C:\\existing', FNM_DIR: fnmDir },
@@ -102,8 +109,30 @@ describe('Windows fnm Node child fallback', () => {
       }
     )
 
-    expect(result?.PATH).toBe(`${expectedDirectory};C:\\existing`)
-    expect(result).not.toHaveProperty('Path')
+    expect(result?.Path).toBe(`${expectedDirectory};C:\\existing`)
+    expect(result).not.toHaveProperty('PATH')
+  })
+
+  it.each([
+    ['PATH', 'Path'],
+    ['Path', 'PATH'],
+    ['Path', 'path']
+  ])('canonicalizes a working %s/%s provider merge', async (sourceKey, overlayKey) => {
+    const overlay = { [overlayKey]: 'C:\\agent-node', FNM_DIR: 'C:\\fnm' }
+    const source = { [sourceKey]: 'C:\\source' }
+    const probeNode = vi.fn<WindowsNodeProbe>().mockResolvedValue(true)
+
+    const result = await withWindowsFnmNodeFallback(overlay, {
+      platform: 'win32',
+      probeNode,
+      sourceEnv: source
+    })
+    const providerEnv = { ...source, ...result }
+
+    expect(Object.keys(providerEnv).filter((key) => key.toLowerCase() === 'path')).toEqual([
+      sourceKey
+    ])
+    expect(providerEnv[sourceKey]).toBe('C:\\agent-node')
   })
 
   it.each([
@@ -198,6 +227,30 @@ describe('Windows fnm Node child fallback', () => {
 })
 
 describe('native Windows fnm Node child fallback', () => {
+  itWindows.each([
+    ['PATH', 'Path'],
+    ['Path', 'PATH'],
+    ['Path', 'path']
+  ])('keeps fnm first after a real %s/%s provider merge', async (sourceKey, overlayKey) => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-path-key-'))
+    tempDirectories.push(root)
+    const fnmRoot = join(root, 'fnm')
+    const fnmNode = createNode(join(fnmRoot, 'aliases', 'default'))
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    const source = sourceEnvWithPathKey(sourceKey, system32)
+
+    const result = await withWindowsFnmNodeFallback(
+      { [overlayKey]: system32, FNM_DIR: fnmRoot },
+      { homePath: root, sourceEnv: source }
+    )
+    const providerEnv = { ...source, ...result }
+
+    expect(Object.keys(providerEnv).filter((key) => key.toLowerCase() === 'path')).toEqual([
+      sourceKey
+    ])
+    expect(normalized(runNode(providerEnv))).toBe(normalized(fnmNode))
+  })
+
   itWindows('keeps a real working inherited node.exe ahead of fnm', async () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-fnm-inherited-'))
     tempDirectories.push(root)

--- a/src/main/pty/windows-fnm-node-fallback.test.ts
+++ b/src/main/pty/windows-fnm-node-fallback.test.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -252,6 +252,71 @@ describe('native Windows fnm Node child fallback', () => {
     expect(normalized(runNode(childEnv))).toBe(normalized(fnmNode))
     expect(cmdResult.status, cmdResult.stderr).toBe(0)
     expect(normalized(cmdResult.stdout.trim())).toBe(normalized(fnmNode))
+  })
+
+  itWindows('starts a real Node-backed agent shim without a persistent Node PATH', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-agent-'))
+    tempDirectories.push(root)
+    const agentDirectory = join(root, 'agent-bin')
+    mkdirSync(agentDirectory)
+    writeFileSync(join(agentDirectory, 'test-agent.cmd'), '@node.exe -p process.execPath\r\n')
+    const fnmRoot = join(root, 'fnm')
+    const fnmNode = createNode(join(fnmRoot, 'aliases', 'default'))
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    const inheritedPath = `${system32};${agentDirectory}`
+
+    const result = await withWindowsFnmNodeFallback(
+      { Path: inheritedPath, FNM_DIR: fnmRoot },
+      { homePath: root, sourceEnv: sourceEnv(inheritedPath) }
+    )
+    const childEnv = sourceEnv(result?.Path ?? '')
+    const agentResult = spawnSync(
+      process.env.ComSpec ?? join(system32, 'cmd.exe'),
+      ['/d', '/s', '/c', 'test-agent.cmd'],
+      { encoding: 'utf8', env: childEnv, windowsHide: true }
+    )
+
+    expect(agentResult.status, agentResult.stderr).toBe(0)
+    expect(normalized(agentResult.stdout.trim())).toBe(normalized(fnmNode))
+  })
+
+  itWindows('prefers FNM_DIR over APPDATA for the agent child', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-precedence-'))
+    tempDirectories.push(root)
+    const fnmRoot = join(root, 'configured-fnm')
+    const fnmNode = createNode(join(fnmRoot, 'aliases', 'default'))
+    const appData = join(root, 'AppData', 'Roaming')
+    createNode(join(appData, 'fnm', 'aliases', 'default'))
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+
+    const result = await withWindowsFnmNodeFallback(
+      { Path: system32, FNM_DIR: fnmRoot, APPDATA: appData },
+      { homePath: root, sourceEnv: sourceEnv(system32) }
+    )
+
+    expect(result?.Path?.split(';')[0]).toBe(win32.join(fnmRoot, 'aliases', 'default'))
+    expect(result?.Path).not.toContain(win32.join(appData, 'fnm', 'aliases', 'default'))
+    expect(normalized(runNode(sourceEnv(result?.Path ?? '')))).toBe(normalized(fnmNode))
+  })
+
+  itWindows('rejects PATH-delimited FNM_DIR before the agent child launch', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fnm-delimiter-'))
+    tempDirectories.push(root)
+    const escapedDirectory = join(root, 'escaped')
+    createNode(escapedDirectory)
+    const appData = join(root, 'AppData', 'Roaming')
+    const appDataNode = createNode(join(appData, 'fnm', 'aliases', 'default'))
+    const system32 = join(process.env.SystemRoot ?? 'C:\\Windows', 'System32')
+    const injectedFnmDir = `${escapedDirectory};${join(root, 'suffix')}`
+
+    const result = await withWindowsFnmNodeFallback(
+      { Path: system32, FNM_DIR: injectedFnmDir, APPDATA: appData },
+      { homePath: root, sourceEnv: sourceEnv(system32) }
+    )
+
+    expect(result?.Path?.split(';')[0]).toBe(win32.join(appData, 'fnm', 'aliases', 'default'))
+    expect(result?.Path).not.toContain(escapedDirectory)
+    expect(normalized(runNode(sourceEnv(result?.Path ?? '')))).toBe(normalized(appDataNode))
   })
 
   itWindows('accepts an fnm default directory junction after executing its node.exe', async () => {

--- a/src/main/pty/windows-fnm-node-fallback.ts
+++ b/src/main/pty/windows-fnm-node-fallback.ts
@@ -69,6 +69,25 @@ function setPath(
   return next
 }
 
+function canonicalizeOverlayPath(
+  sourceEnv: NodeJS.ProcessEnv,
+  overlay: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  const overlayPathEntries = Object.entries(overlay ?? {}).filter(
+    ([key]) => key.toLowerCase() === 'path'
+  )
+  if (overlayPathEntries.length === 0) {
+    return overlay
+  }
+  const [overlayPathKey, overlayPathValue] = overlayPathEntries.at(-1)!
+  const pathKey =
+    Object.keys(sourceEnv).find((key) => key.toLowerCase() === 'path') ?? overlayPathKey
+  if (overlayPathEntries.length === 1 && overlayPathKey === pathKey) {
+    return overlay
+  }
+  return setPath(overlay ?? {}, pathKey, overlayPathValue)
+}
+
 function prependUniquePath(directory: string, inheritedPath: string): string {
   const remaining = inheritedPath
     .split(';')
@@ -128,27 +147,28 @@ export async function withWindowsFnmNodeFallback(
   }
 
   const sourceEnv = options.sourceEnv ?? process.env
-  const effectiveEnv = mergeWindowsEnv(sourceEnv, overlay)
+  const canonicalOverlay = canonicalizeOverlayPath(sourceEnv, overlay)
+  const effectiveEnv = mergeWindowsEnv(sourceEnv, canonicalOverlay)
   const probeNode = options.probeNode ?? probeNodeWithCmd
   if (await probeNode(effectiveEnv)) {
-    return overlay
+    return canonicalOverlay
   }
 
   const pathKey =
-    Object.keys(overlay ?? {}).find((key) => key.toLowerCase() === 'path') ??
     Object.keys(sourceEnv).find((key) => key.toLowerCase() === 'path') ??
+    Object.keys(canonicalOverlay ?? {}).find((key) => key.toLowerCase() === 'path') ??
     'Path'
   const inheritedPath = readEnv(effectiveEnv, 'PATH') ?? ''
   const fnmDirectory = normalizeSingleWindowsPathEntry(
     getWindowsFnmDefaultDirectory(options.homePath ?? homedir(), effectiveEnv)
   )
   if (!fnmDirectory) {
-    return overlay
+    return canonicalOverlay
   }
   const candidateProbeEnv = setPath(effectiveEnv, pathKey, fnmDirectory)
   if (!(await probeNode(candidateProbeEnv))) {
-    return overlay
+    return canonicalOverlay
   }
 
-  return setPath(overlay ?? {}, pathKey, prependUniquePath(fnmDirectory, inheritedPath))
+  return setPath(canonicalOverlay ?? {}, pathKey, prependUniquePath(fnmDirectory, inheritedPath))
 }

--- a/src/main/pty/windows-fnm-node-fallback.ts
+++ b/src/main/pty/windows-fnm-node-fallback.ts
@@ -1,0 +1,154 @@
+import { execFile, type ChildProcess } from 'node:child_process'
+import { homedir } from 'node:os'
+import { win32 } from 'node:path'
+import { normalizeSingleWindowsPathEntry } from '../../shared/windows-path-entry'
+import { getWindowsFnmDefaultDirectory } from '../codex-cli/command'
+import { getCmdExePath } from '../win32-utils'
+import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
+
+const NODE_PROBE_TIMEOUT_MS = 3_000
+
+export type WindowsNodeProbe = (env: NodeJS.ProcessEnv) => Promise<boolean>
+
+type WindowsFnmNodeFallbackOptions = {
+  homePath?: string
+  platform?: NodeJS.Platform
+  probeNode?: WindowsNodeProbe
+  sourceEnv?: NodeJS.ProcessEnv
+}
+
+type WindowsFnmNodeFallbackRoute = {
+  connectionId?: string | null
+  isAgentLaunch: boolean
+  isWsl: boolean
+  platform?: NodeJS.Platform
+}
+
+export function shouldApplyWindowsFnmNodeFallback(route: WindowsFnmNodeFallbackRoute): boolean {
+  return (
+    (route.platform ?? process.platform) === 'win32' &&
+    !route.connectionId &&
+    !route.isWsl &&
+    route.isAgentLaunch
+  )
+}
+
+function readEnv(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const normalizedName = name.toLowerCase()
+  return Object.entries(env).find(([key]) => key.toLowerCase() === normalizedName)?.[1]
+}
+
+function mergeWindowsEnv(
+  sourceEnv: NodeJS.ProcessEnv,
+  overlay: Record<string, string> | undefined
+): NodeJS.ProcessEnv {
+  const merged = { ...sourceEnv }
+  for (const [key, value] of Object.entries(overlay ?? {})) {
+    for (const existingKey of Object.keys(merged)) {
+      if (existingKey !== key && existingKey.toLowerCase() === key.toLowerCase()) {
+        delete merged[existingKey]
+      }
+    }
+    merged[key] = value
+  }
+  return merged
+}
+
+function setPath(
+  env: NodeJS.ProcessEnv,
+  pathKey: string,
+  pathValue: string
+): Record<string, string> {
+  const next: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined && key.toLowerCase() !== 'path') {
+      next[key] = value
+    }
+  }
+  next[pathKey] = pathValue
+  return next
+}
+
+function prependUniquePath(directory: string, inheritedPath: string): string {
+  const remaining = inheritedPath
+    .split(';')
+    .filter((entry) => entry && entry.toLowerCase() !== directory.toLowerCase())
+  return [directory, ...remaining].join(';')
+}
+
+function getProbeCwd(env: NodeJS.ProcessEnv): string {
+  const systemRoot = readEnv(env, 'SystemRoot')
+  const root = systemRoot && /^[a-z]:[\\/]/i.test(systemRoot) ? systemRoot : 'C:\\Windows'
+  return win32.join(root, 'System32')
+}
+
+async function probeNodeWithCmd(env: NodeJS.ProcessEnv): Promise<boolean> {
+  return await new Promise((resolve) => {
+    // Why: cmd performs PATH and UNC lookup in its child, avoiding a main-thread CreateProcess search across network entries.
+    let child: ChildProcess
+    let settled = false
+    let timer: NodeJS.Timeout
+    try {
+      child = execFile(
+        getCmdExePath(),
+        ['/d', '/s', '/c', 'node.exe --version'],
+        { cwd: getProbeCwd(env), encoding: 'utf8', env, windowsHide: true },
+        (error) => {
+          if (settled) {
+            return
+          }
+          settled = true
+          clearTimeout(timer)
+          resolve(error === null)
+        }
+      )
+    } catch {
+      resolve(false)
+      return
+    }
+    timer = setTimeout(() => {
+      if (settled) {
+        return
+      }
+      settled = true
+      const pid = child.pid
+      void (pid ? terminateWindowsProcessTree(pid) : Promise.resolve()).finally(() =>
+        resolve(false)
+      )
+    }, NODE_PROBE_TIMEOUT_MS)
+  })
+}
+
+export async function withWindowsFnmNodeFallback(
+  overlay: Record<string, string> | undefined,
+  options: WindowsFnmNodeFallbackOptions = {}
+): Promise<Record<string, string> | undefined> {
+  if ((options.platform ?? process.platform) !== 'win32') {
+    return overlay
+  }
+
+  const sourceEnv = options.sourceEnv ?? process.env
+  const effectiveEnv = mergeWindowsEnv(sourceEnv, overlay)
+  const probeNode = options.probeNode ?? probeNodeWithCmd
+  if (await probeNode(effectiveEnv)) {
+    return overlay
+  }
+
+  const pathKey =
+    Object.keys(overlay ?? {}).find((key) => key.toLowerCase() === 'path') ??
+    Object.keys(sourceEnv).find((key) => key.toLowerCase() === 'path') ??
+    'Path'
+  const inheritedPath = readEnv(effectiveEnv, 'PATH') ?? ''
+  const fnmDirectory = normalizeSingleWindowsPathEntry(
+    getWindowsFnmDefaultDirectory(options.homePath ?? homedir(), effectiveEnv)
+  )
+  if (!fnmDirectory) {
+    return overlay
+  }
+  const candidateProbeEnv = setPath(effectiveEnv, pathKey, fnmDirectory)
+  if (!(await probeNode(candidateProbeEnv))) {
+    return overlay
+  }
+
+  return setPath(overlay ?? {}, pathKey, prependUniquePath(fnmDirectory, inheritedPath))
+}

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { homedir, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -93,7 +93,7 @@ describe('patchPackagedProcessPath', () => {
     expect(process.env.PATH).toBe('/usr/bin:/bin')
   })
 
-  itWindows('prepends Windows user-local CLI dirs for packaged Start Menu launches', async () => {
+  itWindows('preserves inherited PATH for packaged Windows launches', async () => {
     const { app } = await import('electron')
     const { patchPackagedProcessPath } = await import('./configure-process')
 
@@ -104,10 +104,7 @@ describe('patchPackagedProcessPath', () => {
 
     patchPackagedProcessPath()
 
-    const segments = (process.env.PATH ?? '').split(pathDelimiter)
-    const userLocalBin = join(homedir(), '.local', 'bin')
-    expect(segments).toContain(userLocalBin)
-    expect(segments.indexOf(userLocalBin)).toBeLessThan(segments.indexOf('C:\\Windows\\System32'))
+    expect(process.env.PATH).toBe(`C:\\Windows\\System32${pathDelimiter}C:\\Windows`)
   })
 })
 

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -3,6 +3,8 @@ import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+const itWindows = it.runIf(process.platform === 'win32')
+
 vi.mock('electron', () => {
   const paths = new Map<string, string>([['appData', '/tmp/app-data']])
   return {
@@ -91,7 +93,7 @@ describe('patchPackagedProcessPath', () => {
     expect(process.env.PATH).toBe('/usr/bin:/bin')
   })
 
-  it('prepends Windows user-local CLI dirs for packaged Start Menu launches', async () => {
+  itWindows('prepends Windows user-local CLI dirs for packaged Start Menu launches', async () => {
     const { app } = await import('electron')
     const { patchPackagedProcessPath } = await import('./configure-process')
 

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { normalizeSingleWindowsPathEntry } from '../../shared/windows-path-entry'
 import { getVersionManagerBinPaths } from '../codex-cli/command'
 import { getMainE2EConfig } from '../e2e-config'
 
@@ -124,11 +125,18 @@ export function patchPackagedProcessPath(): void {
   // Why: version-manager CLIs use env-node shebangs, so node must be on PATH or spawns fail (also seeds Windows user-local dirs).
   extraPaths.push(...getVersionManagerBinPaths())
 
+  const safeExtraPaths =
+    process.platform === 'win32'
+      ? extraPaths
+          .map((path) => normalizeSingleWindowsPathEntry(path))
+          .filter((path): path is string => path !== null)
+      : extraPaths
+
   const pathKey = process.platform === 'win32' && process.env.Path !== undefined ? 'Path' : 'PATH'
   const currentPath = process.env[pathKey] ?? ''
   const pathDelimiter = getProcessPathDelimiter()
   const existing = new Set(currentPath.split(pathDelimiter))
-  const missing = extraPaths.filter((path) => !existing.has(path))
+  const missing = safeExtraPaths.filter((path) => !existing.has(path))
 
   if (missing.length > 0) {
     process.env[pathKey] = [...missing, ...currentPath.split(pathDelimiter).filter(Boolean)].join(

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -2,7 +2,6 @@ import { app } from 'electron'
 import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { normalizeSingleWindowsPathEntry } from '../../shared/windows-path-entry'
 import { getVersionManagerBinPaths } from '../codex-cli/command'
 import { getMainE2EConfig } from '../e2e-config'
 
@@ -67,10 +66,6 @@ export function configureElectronNetworkCompatibility(
   app.commandLine.appendSwitch('disable-http2')
 }
 
-function getProcessPathDelimiter(): string {
-  return process.platform === 'win32' ? ';' : ':'
-}
-
 function requestDevParentShutdown(): void {
   devParentShutdownRequested = true
   app.quit()
@@ -96,52 +91,42 @@ export function patchPackagedProcessPath(): void {
     return
   }
 
-  const home = process.env.HOME ?? ''
-  const extraPaths: string[] = []
-
-  if (process.platform !== 'win32') {
-    extraPaths.push(
-      '/opt/homebrew/bin',
-      '/opt/homebrew/sbin',
-      '/usr/local/bin',
-      '/usr/local/sbin',
-      '/snap/bin',
-      '/home/linuxbrew/.linuxbrew/bin',
-      '/nix/var/nix/profiles/default/bin'
-    )
-
-    if (home) {
-      extraPaths.push(
-        join(home, 'bin'),
-        join(home, '.local/bin'),
-        join(home, '.nix-profile/bin'),
-        // Why: some agent CLIs install into ~/.<name>/bin; GUI-launched Electron's minimal PATH misses them (stablyai/orca#829).
-        join(home, '.opencode/bin'),
-        join(home, '.vite-plus/bin')
-      )
-    }
+  // Why: Windows terminal children own their PATH fallback; changing main's PATH shadows working inherited tools for every descendant.
+  if (process.platform === 'win32') {
+    return
   }
 
-  // Why: version-manager CLIs use env-node shebangs, so node must be on PATH or spawns fail (also seeds Windows user-local dirs).
+  const home = process.env.HOME ?? ''
+  const extraPaths = [
+    '/opt/homebrew/bin',
+    '/opt/homebrew/sbin',
+    '/usr/local/bin',
+    '/usr/local/sbin',
+    '/snap/bin',
+    '/home/linuxbrew/.linuxbrew/bin',
+    '/nix/var/nix/profiles/default/bin'
+  ]
+
+  if (home) {
+    extraPaths.push(
+      join(home, 'bin'),
+      join(home, '.local/bin'),
+      join(home, '.nix-profile/bin'),
+      // Why: some agent CLIs install into ~/.<name>/bin; GUI-launched Electron's minimal PATH misses them (stablyai/orca#829).
+      join(home, '.opencode/bin'),
+      join(home, '.vite-plus/bin')
+    )
+  }
+
+  // Why: version-manager CLIs use env-node shebangs, so node must be on PATH or spawns fail.
   extraPaths.push(...getVersionManagerBinPaths())
 
-  const safeExtraPaths =
-    process.platform === 'win32'
-      ? extraPaths
-          .map((path) => normalizeSingleWindowsPathEntry(path))
-          .filter((path): path is string => path !== null)
-      : extraPaths
-
-  const pathKey = process.platform === 'win32' && process.env.Path !== undefined ? 'Path' : 'PATH'
-  const currentPath = process.env[pathKey] ?? ''
-  const pathDelimiter = getProcessPathDelimiter()
-  const existing = new Set(currentPath.split(pathDelimiter))
-  const missing = safeExtraPaths.filter((path) => !existing.has(path))
+  const currentPath = process.env.PATH ?? ''
+  const existing = new Set(currentPath.split(':'))
+  const missing = extraPaths.filter((path) => !existing.has(path))
 
   if (missing.length > 0) {
-    process.env[pathKey] = [...missing, ...currentPath.split(pathDelimiter).filter(Boolean)].join(
-      pathDelimiter
-    )
+    process.env.PATH = [...missing, ...currentPath.split(':').filter(Boolean)].join(':')
   }
 }
 

--- a/src/main/startup/windows-path-mutation.test.ts
+++ b/src/main/startup/windows-path-mutation.test.ts
@@ -46,19 +46,22 @@ afterEach(() => {
 })
 
 describe('packaged process PATH mutation', () => {
-  it.each(['C:\\escaped;C:\\suffix', 'C:\\invalid|component'])(
-    'rejects an unsafe Windows candidate before PATH mutation: %s',
-    async (candidate) => {
-      setPlatform('win32')
-      process.env.Path = 'C:\\Windows\\System32'
-      getVersionManagerBinPathsMock.mockReturnValue([candidate])
-      const { patchPackagedProcessPath } = await import('./configure-process')
+  it.each([
+    'C:\\escaped;C:\\suffix',
+    'C:\\invalid|component',
+    '\\\\?\\C:\\fnm',
+    '\\\\?\\UNC\\server\\share\\fnm',
+    '\\\\?\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\fnm'
+  ])('rejects an unsafe Windows candidate before PATH mutation: %s', async (candidate) => {
+    setPlatform('win32')
+    process.env.Path = 'C:\\Windows\\System32'
+    getVersionManagerBinPathsMock.mockReturnValue([candidate])
+    const { patchPackagedProcessPath } = await import('./configure-process')
 
-      patchPackagedProcessPath()
+    patchPackagedProcessPath()
 
-      expect(process.env.Path).toBe('C:\\Windows\\System32')
-    }
-  )
+    expect(process.env.Path).toBe('C:\\Windows\\System32')
+  })
 
   it('preserves the non-Windows path route used by Linux and WSL', async () => {
     setPlatform('linux')

--- a/src/main/startup/windows-path-mutation.test.ts
+++ b/src/main/startup/windows-path-mutation.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const getVersionManagerBinPathsMock = vi.fn<() => string[]>()
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => ''),
+    setPath: vi.fn(),
+    quit: vi.fn(),
+    exit: vi.fn(),
+    isPackaged: true,
+    commandLine: {
+      appendSwitch: vi.fn(),
+      getSwitchValue: vi.fn(() => '')
+    }
+  }
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  getVersionManagerBinPaths: getVersionManagerBinPathsMock
+}))
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+const originalPath = process.env.PATH
+const originalWindowsPath = process.env.Path
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+  if (originalPath === undefined) {
+    delete process.env.PATH
+  } else {
+    process.env.PATH = originalPath
+  }
+  if (originalWindowsPath === undefined) {
+    delete process.env.Path
+  } else {
+    process.env.Path = originalWindowsPath
+  }
+  getVersionManagerBinPathsMock.mockReset()
+})
+
+describe('packaged process PATH mutation', () => {
+  it.each(['C:\\escaped;C:\\suffix', 'C:\\invalid|component'])(
+    'rejects an unsafe Windows candidate before PATH mutation: %s',
+    async (candidate) => {
+      setPlatform('win32')
+      process.env.Path = 'C:\\Windows\\System32'
+      getVersionManagerBinPathsMock.mockReturnValue([candidate])
+      const { patchPackagedProcessPath } = await import('./configure-process')
+
+      patchPackagedProcessPath()
+
+      expect(process.env.Path).toBe('C:\\Windows\\System32')
+    }
+  )
+
+  it('preserves the non-Windows path route used by Linux and WSL', async () => {
+    setPlatform('linux')
+    process.env.PATH = '/usr/bin'
+    getVersionManagerBinPathsMock.mockReturnValue(['/home/test/.fnm/aliases/default/bin'])
+    const { patchPackagedProcessPath } = await import('./configure-process')
+
+    patchPackagedProcessPath()
+
+    expect(process.env.PATH?.split(':')).toContain('/home/test/.fnm/aliases/default/bin')
+  })
+})

--- a/src/main/startup/windows-path-mutation.test.ts
+++ b/src/main/startup/windows-path-mutation.test.ts
@@ -46,21 +46,16 @@ afterEach(() => {
 })
 
 describe('packaged process PATH mutation', () => {
-  it.each([
-    'C:\\escaped;C:\\suffix',
-    'C:\\invalid|component',
-    '\\\\?\\C:\\fnm',
-    '\\\\?\\UNC\\server\\share\\fnm',
-    '\\\\?\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\fnm'
-  ])('rejects an unsafe Windows candidate before PATH mutation: %s', async (candidate) => {
+  it('leaves the packaged Windows process PATH untouched', async () => {
     setPlatform('win32')
     process.env.Path = 'C:\\Windows\\System32'
-    getVersionManagerBinPathsMock.mockReturnValue([candidate])
+    getVersionManagerBinPathsMock.mockReturnValue(['C:\\fnm\\aliases\\default'])
     const { patchPackagedProcessPath } = await import('./configure-process')
 
     patchPackagedProcessPath()
 
     expect(process.env.Path).toBe('C:\\Windows\\System32')
+    expect(getVersionManagerBinPathsMock).not.toHaveBeenCalled()
   })
 
   it('preserves the non-Windows path route used by Linux and WSL', async () => {

--- a/src/shared/windows-path-entry.test.ts
+++ b/src/shared/windows-path-entry.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSingleWindowsPathEntry } from './windows-path-entry'
+
+const validPaths = [
+  'C:\\fnm',
+  'C:/fnm',
+  'C:\\Program Files\\fnm data',
+  'C:\\用户\\fnm-λ',
+  '\\\\server\\share\\fnm',
+  '//server/share/fnm',
+  '\\\\?\\C:\\very long\\fnm',
+  '\\\\?\\UNC\\server\\share\\fnm',
+  '\\\\.\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\fnm'
+]
+
+const invalidPaths = [
+  undefined,
+  '',
+  'relative\\fnm',
+  '\\root-relative\\fnm',
+  '\\\\server',
+  'C:\\fnm;',
+  'C:\\fnm\\CON',
+  'C:\\con\\fnm',
+  'C:\\fnm\\NUL.txt',
+  'C:\\fnm\\prn.log',
+  'C:\\fnm\\AUX',
+  'C:\\fnm\\COM1',
+  'C:\\fnm\\LPT9.log',
+  '\\\\.\\pipe\\orca-fnm',
+  '\\\\?\\pipe\\orca-fnm',
+  '\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\fnm',
+  '\\\\.\\PhysicalDrive0',
+  '\\\\server\\pipe\\orca-fnm',
+  '\\\\?\\UNC\\server\\pipe\\orca-fnm',
+  '\\\\?\\UNC\\server',
+  '\\\\?\\UNC/server/share',
+  '\\\\?\\C:\\fnm/aliases',
+  ' C:\\fnm',
+  'C:\\fnm '
+]
+
+describe('normalizeSingleWindowsPathEntry', () => {
+  it.each(validPaths)('accepts filesystem path %s', (path) => {
+    expect(normalizeSingleWindowsPathEntry(path)).toBe(path)
+  })
+
+  it.each(invalidPaths)('rejects unsafe path %s', (path) => {
+    expect(normalizeSingleWindowsPathEntry(path)).toBeNull()
+  })
+})

--- a/src/shared/windows-path-entry.test.ts
+++ b/src/shared/windows-path-entry.test.ts
@@ -8,8 +8,6 @@ const validPaths = [
   'C:\\用户\\fnm-λ',
   '\\\\server\\share\\fnm',
   '//server/share/fnm',
-  '\\\\?\\C:\\very long\\fnm',
-  '\\\\?\\UNC\\server\\share\\fnm',
   '\\\\.\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\fnm'
 ]
 
@@ -29,6 +27,9 @@ const invalidPaths = [
   'C:\\fnm\\LPT9.log',
   '\\\\.\\pipe\\orca-fnm',
   '\\\\?\\pipe\\orca-fnm',
+  '\\\\?\\C:\\very long\\fnm',
+  '\\\\?\\UNC\\server\\share\\fnm',
+  '\\\\?\\Volume{01234567-89ab-cdef-0123-456789abcdef}\\fnm',
   '\\\\?\\GLOBALROOT\\Device\\HarddiskVolume1\\fnm',
   '\\\\.\\PhysicalDrive0',
   '\\\\server\\pipe\\orca-fnm',

--- a/src/shared/windows-path-entry.ts
+++ b/src/shared/windows-path-entry.ts
@@ -1,0 +1,56 @@
+import { win32 } from 'node:path'
+
+const WINDOWS_DEVICE_PATH_PREFIX = /^\\\\[?.]\\/
+const WINDOWS_DRIVE_PATH_PREFIX = /^[A-Za-z]:[\\/]/
+const WINDOWS_EXTENDED_UNC_PREFIX = /^\\\\\?\\UNC[\\/]/i
+const WINDOWS_EXTENDED_UNC_PATH = /^\\\\\?\\UNC\\[^\\/]+\\[^\\/]+(?:[\\/]|$)/i
+const INVALID_WINDOWS_COMPONENT_CHARACTERS = '<>"|?*;:'
+
+export function normalizeSingleWindowsPathEntry(value: string | undefined): string | null {
+  const normalized = value?.trim()
+  if (!normalized || !hasFullyQualifiedWindowsRoot(normalized)) {
+    return null
+  }
+
+  const isDevicePath = WINDOWS_DEVICE_PATH_PREFIX.test(normalized)
+  const withoutDevicePrefix = isDevicePath ? normalized.slice(4) : normalized
+  const withoutDrive = WINDOWS_DRIVE_PATH_PREFIX.test(withoutDevicePrefix)
+    ? withoutDevicePrefix.slice(2)
+    : withoutDevicePrefix
+
+  if (hasInvalidWindowsPathEntryCharacter(withoutDrive)) {
+    return null
+  }
+  if (!isDevicePath && hasInvalidOrdinaryWindowsComponent(withoutDrive)) {
+    return null
+  }
+  return normalized
+}
+
+function hasFullyQualifiedWindowsRoot(value: string): boolean {
+  if (!win32.isAbsolute(value) || win32.parse(value).root.length <= 1) {
+    return false
+  }
+  return !WINDOWS_EXTENDED_UNC_PREFIX.test(value) || WINDOWS_EXTENDED_UNC_PATH.test(value)
+}
+
+function hasInvalidWindowsPathEntryCharacter(value: string): boolean {
+  for (const character of value) {
+    if (character.charCodeAt(0) < 32 || INVALID_WINDOWS_COMPONENT_CHARACTERS.includes(character)) {
+      return true
+    }
+  }
+  return false
+}
+
+function hasInvalidOrdinaryWindowsComponent(value: string): boolean {
+  return value
+    .split(/[\\/]/)
+    .filter(Boolean)
+    .some(
+      (component) =>
+        component !== '.' &&
+        component !== '..' &&
+        (component.endsWith(' ') || component.endsWith('.'))
+    )
+}

--- a/src/shared/windows-path-entry.ts
+++ b/src/shared/windows-path-entry.ts
@@ -1,56 +1,89 @@
-import { win32 } from 'node:path'
-
+const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/](.*)$/s
+const WINDOWS_UNC_PATH = /^(?:\\\\|\/\/)([^\\/]+)[\\/]([^\\/]+)(?:[\\/](.*))?$/s
+const WINDOWS_EXTENDED_DRIVE_PATH = /^\\\\\?\\[A-Za-z]:\\(.*)$/s
+const WINDOWS_EXTENDED_UNC_PATH = /^\\\\\?\\UNC\\([^\\]+)\\([^\\]+)(?:\\(.*))?$/is
+const WINDOWS_VOLUME_PATH =
+  /^\\\\[?.]\\(Volume\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\})\\(.*)$/is
 const WINDOWS_DEVICE_PATH_PREFIX = /^\\\\[?.]\\/
-const WINDOWS_DRIVE_PATH_PREFIX = /^[A-Za-z]:[\\/]/
-const WINDOWS_EXTENDED_UNC_PREFIX = /^\\\\\?\\UNC[\\/]/i
-const WINDOWS_EXTENDED_UNC_PATH = /^\\\\\?\\UNC\\[^\\/]+\\[^\\/]+(?:[\\/]|$)/i
 const INVALID_WINDOWS_COMPONENT_CHARACTERS = '<>"|?*;:'
+const RESERVED_WINDOWS_COMPONENT =
+  /^(?:CON|PRN|AUX|NUL|CLOCK\$|CONIN\$|CONOUT\$|COM[1-9¹²³]|LPT[1-9¹²³])$/i
+
+type ParsedWindowsPath = {
+  components: string[]
+  uncShare?: string
+}
 
 export function normalizeSingleWindowsPathEntry(value: string | undefined): string | null {
-  const normalized = value?.trim()
-  if (!normalized || !hasFullyQualifiedWindowsRoot(normalized)) {
+  if (!value || value.trim() !== value) {
     return null
   }
 
-  const isDevicePath = WINDOWS_DEVICE_PATH_PREFIX.test(normalized)
-  const withoutDevicePrefix = isDevicePath ? normalized.slice(4) : normalized
-  const withoutDrive = WINDOWS_DRIVE_PATH_PREFIX.test(withoutDevicePrefix)
-    ? withoutDevicePrefix.slice(2)
-    : withoutDevicePrefix
-
-  if (hasInvalidWindowsPathEntryCharacter(withoutDrive)) {
+  const parsed = parseWindowsFilesystemPath(value)
+  if (!parsed || parsed.uncShare?.toLowerCase() === 'pipe') {
     return null
   }
-  if (!isDevicePath && hasInvalidOrdinaryWindowsComponent(withoutDrive)) {
-    return null
-  }
-  return normalized
+  return parsed.components.some(hasInvalidWindowsComponent) ? null : value
 }
 
-function hasFullyQualifiedWindowsRoot(value: string): boolean {
-  if (!win32.isAbsolute(value) || win32.parse(value).root.length <= 1) {
+function parseWindowsFilesystemPath(value: string): ParsedWindowsPath | null {
+  if (WINDOWS_DEVICE_PATH_PREFIX.test(value) && value.includes('/')) {
+    return null
+  }
+
+  let match = WINDOWS_EXTENDED_DRIVE_PATH.exec(value)
+  if (match) {
+    return { components: splitWindowsComponents(match[1]) }
+  }
+
+  match = WINDOWS_EXTENDED_UNC_PATH.exec(value)
+  if (match) {
+    return {
+      components: [match[1], match[2], ...splitWindowsComponents(match[3])],
+      uncShare: match[2]
+    }
+  }
+
+  match = WINDOWS_VOLUME_PATH.exec(value)
+  if (match) {
+    return { components: [match[1], ...splitWindowsComponents(match[2])] }
+  }
+
+  if (WINDOWS_DEVICE_PATH_PREFIX.test(value)) {
+    return null
+  }
+
+  match = WINDOWS_DRIVE_PATH.exec(value)
+  if (match) {
+    return { components: splitWindowsComponents(match[1]) }
+  }
+
+  match = WINDOWS_UNC_PATH.exec(value)
+  if (match) {
+    return {
+      components: [match[1], match[2], ...splitWindowsComponents(match[3])],
+      uncShare: match[2]
+    }
+  }
+
+  return null
+}
+
+function splitWindowsComponents(value: string | undefined): string[] {
+  return value?.split(/[\\/]/).filter(Boolean) ?? []
+}
+
+function hasInvalidWindowsComponent(component: string): boolean {
+  if (component === '.' || component === '..') {
     return false
   }
-  return !WINDOWS_EXTENDED_UNC_PREFIX.test(value) || WINDOWS_EXTENDED_UNC_PATH.test(value)
-}
-
-function hasInvalidWindowsPathEntryCharacter(value: string): boolean {
-  for (const character of value) {
+  if (component.endsWith(' ') || component.endsWith('.')) {
+    return true
+  }
+  for (const character of component) {
     if (character.charCodeAt(0) < 32 || INVALID_WINDOWS_COMPONENT_CHARACTERS.includes(character)) {
       return true
     }
   }
-  return false
-}
-
-function hasInvalidOrdinaryWindowsComponent(value: string): boolean {
-  return value
-    .split(/[\\/]/)
-    .filter(Boolean)
-    .some(
-      (component) =>
-        component !== '.' &&
-        component !== '..' &&
-        (component.endsWith(' ') || component.endsWith('.'))
-    )
+  return RESERVED_WINDOWS_COMPONENT.test(component.split('.')[0].trimEnd())
 }

--- a/src/shared/windows-path-entry.ts
+++ b/src/shared/windows-path-entry.ts
@@ -1,10 +1,9 @@
 const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/](.*)$/s
 const WINDOWS_UNC_PATH = /^(?:\\\\|\/\/)([^\\/]+)[\\/]([^\\/]+)(?:[\\/](.*))?$/s
-const WINDOWS_EXTENDED_DRIVE_PATH = /^\\\\\?\\[A-Za-z]:\\(.*)$/s
-const WINDOWS_EXTENDED_UNC_PATH = /^\\\\\?\\UNC\\([^\\]+)\\([^\\]+)(?:\\(.*))?$/is
 const WINDOWS_VOLUME_PATH =
-  /^\\\\[?.]\\(Volume\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\})\\(.*)$/is
+  /^\\\\\.\\(Volume\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\})\\(.*)$/is
 const WINDOWS_DEVICE_PATH_PREFIX = /^\\\\[?.]\\/
+const WINDOWS_EXTENDED_PATH_PREFIX = /^\\\\\?\\/
 const INVALID_WINDOWS_COMPONENT_CHARACTERS = '<>"|?*;:'
 const RESERVED_WINDOWS_COMPONENT =
   /^(?:CON|PRN|AUX|NUL|CLOCK\$|CONIN\$|CONOUT\$|COM[1-9¹²³]|LPT[1-9¹²³])$/i
@@ -27,24 +26,15 @@ export function normalizeSingleWindowsPathEntry(value: string | undefined): stri
 }
 
 function parseWindowsFilesystemPath(value: string): ParsedWindowsPath | null {
+  // Why: cmd rejects extended PATH entries, and extended volumes can poison later child lookup.
+  if (WINDOWS_EXTENDED_PATH_PREFIX.test(value)) {
+    return null
+  }
   if (WINDOWS_DEVICE_PATH_PREFIX.test(value) && value.includes('/')) {
     return null
   }
 
-  let match = WINDOWS_EXTENDED_DRIVE_PATH.exec(value)
-  if (match) {
-    return { components: splitWindowsComponents(match[1]) }
-  }
-
-  match = WINDOWS_EXTENDED_UNC_PATH.exec(value)
-  if (match) {
-    return {
-      components: [match[1], match[2], ...splitWindowsComponents(match[3])],
-      uncShare: match[2]
-    }
-  }
-
-  match = WINDOWS_VOLUME_PATH.exec(value)
+  let match = WINDOWS_VOLUME_PATH.exec(value)
   if (match) {
     return { components: [match[1], ...splitWindowsComponents(match[2])] }
   }


### PR DESCRIPTION
## Summary

On Windows, Orca now adds fnm's actual default Node directory to the GUI process PATH instead of probing the POSIX-only `~/.fnm/aliases/default/bin` layout.

Resolution order is:

1. `%FNM_DIR%\aliases\default` when `FNM_DIR` is set
2. `%APPDATA%\fnm\aliases\default`
3. `<home>\AppData\Roaming\fnm\aliases\default` when `APPDATA` is unavailable

macOS and Linux keep the existing `~/.fnm/aliases/default/bin` path unchanged.

Fixes #11356

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — not run in full. Targeted native and type-aware oxlint passed. `pnpm check:code-quality:changed` is currently blocked on Windows/Node 24 by its existing `spawnSync pnpm.cmd EINVAL` failure.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — not run in full. `src/main/codex-cli/command.test.ts`: 28 passed, 1 existing platform skip.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions

Additional checks:

- `oxfmt --check` on both changed files
- `git diff --check`
- fail-before verification: both new Windows fnm assertions failed on `main` before the resolver change

## AI Review Report

Reviewed the focused diff against #11356 and the command resolver's startup, direct resolution, and batch-detection call sites.

The review checked:

- Windows precedence: explicit `FNM_DIR`, then `APPDATA`, then the home-derived roaming directory
- macOS/Linux compatibility: their existing fnm path is unchanged
- local/SSH boundary: only the local Electron process and local command discovery consume this host environment; remote execution paths do not inherit the new directory
- performance: the change adds no filesystem scans or subprocesses beyond the existing directory list probe
- agent compatibility: the shared resolver continues to serve Codex, Claude, Cursor, and other local CLI detection without agent-specific branching

No blocking correctness findings remained after adding the home-derived fallback test. There is no UI or Electron renderer behavior change.

## Security Audit

The new paths come only from the existing process environment (`FNM_DIR` and `APPDATA`) or the already trusted home directory. They are added to the same candidate/PATH list that already accepts user-controlled PATH and version-manager directories; no shell command is constructed and no string interpolation boundary is added.

No auth, secrets, dependencies, IPC contracts, or persisted state are changed. No path is written or deleted.

## Notes

- This intentionally does not change fnm discovery on non-Windows platforms.
- The local workaround remains adding `%APPDATA%\fnm\aliases\default` to the Windows User PATH until a release containing this fix is installed.
- X handle: Not provided.
