### PR TITLE
fix(windows): preserve native paths in agent commands

### DIFF
--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -215,6 +215,27 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
+  it('keeps native Windows paths in preset agent command overrides', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'cursor',
+        model: 'gpt-5.2',
+        agentCommandOverride:
+          'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile'
+      },
+      'PROMPT'
+    )
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.plan.binary).toBe(
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+    )
+    expect(result.plan.args.slice(0, 4)).toEqual(['-NoProfile', '--print', '--mode', 'ask'])
+  })
+
   it.each([
     ['long option', '--model gpt-5.6-luna', ['--model', 'gpt-5.6-luna'], []],
     ['short option', '-m gpt-5.6-luna', ['-m', 'gpt-5.6-luna'], []],

--- a/src/shared/commit-message-prompt.test.ts
+++ b/src/shared/commit-message-prompt.test.ts
@@ -268,6 +268,38 @@ describe('tokenizeCustomCommandTemplate', () => {
     expect(r).toEqual({ ok: true, tokens: ['claude', '--msg', 'she said "hi"'] })
   })
 
+  it('preserves native Windows path separators', () => {
+    const r = tokenizeCustomCommandTemplate(
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile'
+    )
+    expect(r).toEqual({
+      ok: true,
+      tokens: ['C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe', '-NoProfile']
+    })
+  })
+
+  it('preserves UNC path separators', () => {
+    const command = String.raw`\\server\share\agent.exe --print`
+    const r = tokenizeCustomCommandTemplate(command)
+    expect(r).toEqual({
+      ok: true,
+      tokens: [String.raw`\\server\share\agent.exe`, '--print']
+    })
+  })
+
+  it('preserves native Windows paths inside double quotes', () => {
+    const r = tokenizeCustomCommandTemplate('agent --file "C:\\Program Files\\Agent\\run.ps1"')
+    expect(r).toEqual({
+      ok: true,
+      tokens: ['agent', '--file', 'C:\\Program Files\\Agent\\run.ps1']
+    })
+  })
+
+  it('keeps backslash-escaped whitespace grouped', () => {
+    const r = tokenizeCustomCommandTemplate('agent hello\\ world')
+    expect(r).toEqual({ ok: true, tokens: ['agent', 'hello world'] })
+  })
+
   it('keeps adjacent quoted/unquoted regions in one token (a"b"c → abc)', () => {
     const r = tokenizeCustomCommandTemplate('foo a"b"c')
     expect(r).toEqual({ ok: true, tokens: ['foo', 'abc'] })

--- a/src/shared/commit-message-prompt.test.ts
+++ b/src/shared/commit-message-prompt.test.ts
@@ -263,9 +263,14 @@ describe('tokenizeCustomCommandTemplate', () => {
     expect(r).toEqual({ ok: true, tokens: ['agent', '--json', '{"k":"v"}'] })
   })
 
-  it('honors backslash escapes inside double quotes', () => {
+  it('escapes double quotes inside double-quoted segments', () => {
     const r = tokenizeCustomCommandTemplate('claude --msg "she said \\"hi\\""')
     expect(r).toEqual({ ok: true, tokens: ['claude', '--msg', 'she said "hi"'] })
+  })
+
+  it('preserves consecutive backslashes inside double-quoted segments', () => {
+    const r = tokenizeCustomCommandTemplate(String.raw`agent --value "a\\b"`)
+    expect(r).toEqual({ ok: true, tokens: ['agent', '--value', String.raw`a\\b`] })
   })
 
   it('preserves native Windows path separators', () => {

--- a/src/shared/commit-message-prompt.ts
+++ b/src/shared/commit-message-prompt.ts
@@ -135,12 +135,9 @@ export type TokenizeCustomCommandResult =
   | { ok: true; tokens: string[] }
   | { ok: false; error: string }
 
-// Why: deliberately POSIX-shell-style only for *grouping* (single + double
-// quotes, backslash escapes inside double quotes). We do NOT expand `$VAR`,
-// command substitution, backticks, globs, or `~`. The user's intent is
-// "spawn this exact CLI" — adding shell semantics on top would create
-// surprising behavior across platforms (especially Windows) and a security
-// surface we don't need.
+// Why: shell-style syntax is only for grouping. Backslashes escape grouping
+// syntax but otherwise stay literal so native Windows paths survive unchanged.
+// We do NOT expand `$VAR`, command substitution, backticks, globs, or `~`.
 export function tokenizeCustomCommandTemplate(template: string): TokenizeCustomCommandResult {
   const tokens: string[] = []
   let current = ''
@@ -151,7 +148,7 @@ export function tokenizeCustomCommandTemplate(template: string): TokenizeCustomC
   while (i < template.length) {
     const ch = template[i]
     if (quote) {
-      if (ch === '\\' && quote === '"' && i + 1 < template.length) {
+      if (ch === '\\' && quote === '"' && template[i + 1] === '"') {
         current += template[i + 1]
         i += 2
         continue
@@ -176,7 +173,11 @@ export function tokenizeCustomCommandTemplate(template: string): TokenizeCustomC
       continue
     }
 
-    if (ch === '\\' && i + 1 < template.length) {
+    if (
+      ch === '\\' &&
+      i + 1 < template.length &&
+      (template[i + 1] === '"' || template[i + 1] === "'" || /\s/.test(template[i + 1]))
+    ) {
       current += template[i + 1]
       inToken = true
       i += 2


### PR DESCRIPTION
## Summary

- Preserve literal backslashes in Source Control AI command templates unless they escape grouping syntax.
- Allow native Windows drive-letter paths, quoted paths with spaces, and UNC paths in agent command overrides.
- Cover the tokenizer directly and the preset-agent generation plan that previously corrupted an absolute `powershell.exe` override.

This addresses the secondary Windows command-override failure described in [the Windows reproduction on #10190](https://github.com/stablyai/orca/pull/10190#issuecomment-5117267853). It does not address the separate Cursor `.cmd` multiline-prompt limitation discussed in that comment.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` - not run in full; targeted Vitest run passed 134 tests across `commit-message-prompt`, `commit-message-plan`, and `tui-agent-startup`
- [ ] `pnpm build` - not run
- [x] Added or updated high-quality tests that would catch regressions

Additional checks:

- Native and type-aware oxlint on all changed files
- `git diff --check`
- Fail-before verification: the three Windows-path scenarios failed against `main` before the tokenizer change

## AI Review Report

Reviewed the complete diff against `origin/main` for correctness, regressions, cross-platform behavior, SSH/remote behavior, supported agent compatibility, performance, and command-execution safety. No blocking or advisory findings remained.

The main compatibility risk was weakening the existing grouping contract while preserving Windows separators. The updated tokenizer still supports single and double quotes, escaped quotes, escaped whitespace, and adjacent quoted/unquoted token regions. Tests cover drive-letter paths, quoted paths with spaces, UNC paths, escaped whitespace, and the real preset-agent planning path. The shared parser remains platform-neutral, so local, SSH, and remote planning receive the same deterministic argv without adding a host-platform assumption. No UI, shortcut, label, Electron, git-provider, or integration-specific behavior changes.

The loop remains linear in the command length and adds no I/O, subprocess, dependency, or hot-path work.

## Security Audit

The command template is still converted directly to a binary plus argv and is not evaluated by a shell. The change only decides when a backslash is literal; it does not add variable expansion, command substitution, backticks, globbing, tilde expansion, or string interpolation. Quotes and escaped whitespace remain grouping syntax, so paths with spaces still form one argv entry.

Reviewed command execution, path handling, prompt substitution, and malformed quote handling. No auth, secrets, dependency, network, filesystem traversal, or IPC surface is touched. Preserving a literal backslash does not introduce a new injection boundary because the resulting values remain separate spawn arguments.

## Notes

- Windows native absolute paths can now be pasted into an agent command override without replacing `\` with `/`.
- POSIX command grouping remains supported; arbitrary backslashes are now literal unless they escape a quote or whitespace.
- X handle: Not provided
