### PR TITLE
fix(ssh): time out stalled remote file streams

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -197,19 +197,21 @@
       "providers": ["ssh2", "system-ssh"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["ssh2", "system-ssh"],
-      "coverageNotes": "Deterministic fake-clock coverage proves inactivity cancellation, active-transfer renewal, suspend/resume rebasing, timer cleanup, and listener cleanup. A real Docker SSH relay previously proved active and stalled transfer behavior; physical sleep/wake and Windows/Linux clients remain gaps.",
+      "coverageNotes": "Deterministic fake-clock coverage proves inactivity cancellation, active-transfer renewal, sticky suspend replay before metadata, failure-isolated lifecycle fanout, committed-quit bridge disposal, timer cleanup, and listener cleanup. A real Docker SSH relay previously proved active and stalled transfer behavior; physical sleep/wake and Windows/Linux clients remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/11362",
         "https://github.com/stablyai/orca/pull/11364"
       ],
-      "invariant": "A non-empty SSH file stream that produces no valid frame for 30 seconds must cancel at its authoritative stream reader and release all local lifecycle state. System suspend pauses that evidence, and resume grants every still-live stream one fresh inactivity window without retaining a per-stream Electron listener.",
-      "oracle": "Start a stream after metadata, advance to one millisecond before timeout, publish suspend, jump wall time by one hour, publish resume, and require no cancellation for the next 29,999 milliseconds. Deliver a valid final chunk and end frame, require exact content, then publish another resume and require zero timers, multiplexer listeners, or renewed work; a separate stalled stream must cancel and reject at 30 seconds.",
+      "invariant": "A non-empty SSH file stream that produces no valid frame for 30 seconds must cancel at its authoritative stream reader and release all local lifecycle state. System suspend is sticky across metadata and subscription races, resume grants every still-live stream one fresh inactivity window, one failing consumer cannot block the others, and the sole Electron bridge survives a vetoed before-quit without retaining a per-stream Electron listener.",
+      "oracle": "Publish suspend before stream metadata resolves, jump wall time by one hour, and require the late-subscribing stream to remain pending until resume grants a fresh 30-second window. Deliver a valid final chunk and end frame, require exact content, then publish another resume and require zero timers, multiplexer listeners, or renewed work; separately require stalled cancellation at 30 seconds, atomic state replay, failure-isolated fanout, and bridge disposal only after the committed will-quit gate.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/providers/ssh-filesystem-provider-stream.test.ts src/main/system-resume-broadcast.test.ts --reporter=dot"
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/providers/ssh-filesystem-provider-stream.test.ts src/main/system-resume-broadcast.test.ts src/main/system-power-lifecycle.test.ts src/main/startup/desktop-startup-ordering.test.ts --reporter=dot"
       ],
       "testFiles": [
         "src/main/providers/ssh-filesystem-provider-stream.test.ts",
-        "src/main/system-resume-broadcast.test.ts"
+        "src/main/system-resume-broadcast.test.ts",
+        "src/main/system-power-lifecycle.test.ts",
+        "src/main/startup/desktop-startup-ordering.test.ts"
       ],
       "assertionRefs": [
         {
@@ -217,12 +219,27 @@
           "assertions": [
             "cancels and cleans up a stream that stalls after metadata",
             "keeps a long stream alive while chunks continue arriving",
-            "grants an active stream a fresh inactivity window after system resume"
+            "grants an active stream a fresh inactivity window after system resume",
+            "keeps metadata received during suspend paused until resume"
           ]
         },
         {
           "file": "src/main/system-resume-broadcast.test.ts",
           "assertions": ["publishes suspend and resume to main-process lifecycle consumers"]
+        },
+        {
+          "file": "src/main/system-power-lifecycle.test.ts",
+          "assertions": [
+            "replays suspended state to a late subscriber",
+            "atomically replays a transition to a subscriber added during publication",
+            "isolates a failing listener from the remaining subscribers"
+          ]
+        },
+        {
+          "file": "src/main/startup/desktop-startup-ordering.test.ts",
+          "assertions": [
+            "keeps the power bridge through vetoable before-quit and disposes after commit"
+          ]
         }
       ],
       "evidenceRuns": [
@@ -230,10 +247,10 @@
           "date": "2026-08-01",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/providers/ssh-filesystem-provider-stream.test.ts src/main/system-resume-broadcast.test.ts --reporter=dot",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/providers/ssh-filesystem-provider-stream.test.ts src/main/system-resume-broadcast.test.ts src/main/system-power-lifecycle.test.ts src/main/startup/desktop-startup-ordering.test.ts --reporter=dot",
           "result": "passed",
-          "durationSeconds": 0.3,
-          "summary": "Two focused files and 19 tests passed, including stalled cancellation, active progress, suspend/resume renewal, post-settlement cleanup, and app-global lifecycle publication."
+          "durationSeconds": 0.8,
+          "summary": "Four focused files and 33 tests passed, including stalled cancellation, active progress, late metadata replay, failure isolation, committed-quit bridge lifetime, and post-settlement cleanup."
         }
       ],
       "runtimeBudget": {
@@ -250,7 +267,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "One app-global powerMonitor listener publishes to an in-memory set. Each active non-empty read retains one set entry and one unref'd timer, clears both on settlement, and performs constant work per valid chunk or lifecycle transition; no polling, provider scan, subprocess, renderer work, or per-stream Electron listener was added."
+        "evidence": "One app-global powerMonitor listener publishes to an in-memory set. Each active non-empty read retains one set entry and one unref'd timer, clears both on settlement, and performs constant work per valid chunk; each power transition performs O(active streams) isolated notifications with no polling, provider scan, subprocess, renderer work, or per-stream Electron listener."
       },
       "promotionCriteria": [
         "Collect 100 consecutive focused CI passes or 14 days of soak history.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -186,6 +186,84 @@
       "demotionRule": "Keep experimental or demote if any activity trigger shortens the rejection window, a transient burst reaches resolver retirement authority, sustained dead-session evidence no longer converges, shutdown permits late retirement, or the focused gate flakes without an identified product or harness fault."
     },
     {
+      "id": "ssh-filesystem.stream-inactivity-lifecycle",
+      "title": "SSH file streams bound inactivity without counting host sleep",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "desktop-ssh",
+      "layer": "ssh-file-stream-lifecycle",
+      "surfaces": ["SSH filesystem reads", "AI Vault remote scanning", "system sleep/wake"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["ssh2", "system-ssh"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["ssh2", "system-ssh"],
+      "coverageNotes": "Deterministic fake-clock coverage proves inactivity cancellation, active-transfer renewal, suspend/resume rebasing, timer cleanup, and listener cleanup. A real Docker SSH relay previously proved active and stalled transfer behavior; physical sleep/wake and Windows/Linux clients remain gaps.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/11362",
+        "https://github.com/stablyai/orca/pull/11364"
+      ],
+      "invariant": "A non-empty SSH file stream that produces no valid frame for 30 seconds must cancel at its authoritative stream reader and release all local lifecycle state. System suspend pauses that evidence, and resume grants every still-live stream one fresh inactivity window without retaining a per-stream Electron listener.",
+      "oracle": "Start a stream after metadata, advance to one millisecond before timeout, publish suspend, jump wall time by one hour, publish resume, and require no cancellation for the next 29,999 milliseconds. Deliver a valid final chunk and end frame, require exact content, then publish another resume and require zero timers, multiplexer listeners, or renewed work; a separate stalled stream must cancel and reject at 30 seconds.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/providers/ssh-filesystem-provider-stream.test.ts src/main/system-resume-broadcast.test.ts --reporter=dot"
+      ],
+      "testFiles": [
+        "src/main/providers/ssh-filesystem-provider-stream.test.ts",
+        "src/main/system-resume-broadcast.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/providers/ssh-filesystem-provider-stream.test.ts",
+          "assertions": [
+            "cancels and cleans up a stream that stalls after metadata",
+            "keeps a long stream alive while chunks continue arriving",
+            "grants an active stream a fresh inactivity window after system resume"
+          ]
+        },
+        {
+          "file": "src/main/system-resume-broadcast.test.ts",
+          "assertions": ["publishes suspend and resume to main-process lifecycle consumers"]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-01",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/providers/ssh-filesystem-provider-stream.test.ts src/main/system-resume-broadcast.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 0.3,
+          "summary": "Two focused files and 19 tests passed, including stalled cancellation, active progress, suspend/resume renewal, post-settlement cleanup, and app-global lifecycle publication."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 2,
+        "scope": "deterministic SSH file-stream and system power lifecycle unit tests"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "The deterministic correction suite passes locally; focused CI and soak history are not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The byte-identical oracle is incomplete on origin/main because stalled streams never settle, and the pre-correction candidate cancels immediately after a simulated one-hour suspend. The corrected candidate bounds uninterrupted inactivity while granting a full post-resume window."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "One app-global powerMonitor listener publishes to an in-memory set. Each active non-empty read retains one set entry and one unref'd timer, clears both on settlement, and performs constant work per valid chunk or lifecycle transition; no polling, provider scan, subprocess, renderer work, or per-stream Electron listener was added."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive focused CI passes or 14 days of soak history.",
+        "Capture physical macOS, Linux, and Windows sleep/wake evidence with a live SSH read.",
+        "Keep timeout, post-resume renewal, and zero-retained-lifecycle assertions green."
+      ],
+      "knownGaps": [
+        "Suspend/resume is injected at the authoritative main-process event seam rather than by physically sleeping the runner.",
+        "Slow links that produce no complete valid frame for 30 uninterrupted awake seconds remain intentionally retryable failures."
+      ],
+      "demotionRule": "Keep experimental or demote if sleep consumes inactivity evidence, stalled streams become unbounded, or settled reads retain timers or lifecycle subscriptions."
+    },
+    {
       "id": "ssh-relay.staged-upload-recovery",
       "title": "SSH relay uploads remain retryable before the shared install lock",
       "maturity": "experimental",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2984,8 +2984,6 @@ app.on('before-quit', () => {
   isQuitting = true
   desktopRelayService?.fenceAndCloseNow()
   runtimeRpc?.setMobileRelayPairingProvider(null)
-  unsubscribeSystemResumeBroadcast?.()
-  unsubscribeSystemResumeBroadcast = null
   unsubscribeAgentAwakeStatusChanges?.()
   unsubscribeAgentAwakeStatusChanges = null
   agentAwakeService?.dispose()
@@ -3011,6 +3009,8 @@ app.on('will-quit', (e) => {
   if (!quitTeardownStartGate.tryStart(e)) {
     return
   }
+  unsubscribeSystemResumeBroadcast?.()
+  unsubscribeSystemResumeBroadcast = null
   // Why: renderer guards can still cancel before this committed phase; `log stream` must survive those vetoes.
   stopTccPromptNotice()
   const updateQuitInProgress = isQuittingForUpdate()

--- a/src/main/providers/ssh-filesystem-provider-stream.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-stream.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SshFilesystemProvider } from './ssh-filesystem-provider'
+import { SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS } from '../ssh/ssh-file-stream-inactivity-deadline'
 
 type MockMultiplexer = {
   request: ReturnType<typeof vi.fn>
@@ -10,6 +11,7 @@ type MockMultiplexer = {
   dispose: ReturnType<typeof vi.fn>
   isDisposed: ReturnType<typeof vi.fn>
   _emitMethod: (method: string, params: Record<string, unknown>) => void
+  _methodHandlerCount: () => number
 }
 
 function createMockMux(): MockMultiplexer {
@@ -39,7 +41,9 @@ function createMockMux(): MockMultiplexer {
           handler(params)
         }
       }
-    }
+    },
+    _methodHandlerCount: () =>
+      [...methodHandlers.values()].reduce((count, handlers) => count + handlers.size, 0)
   }
 }
 
@@ -50,6 +54,10 @@ describe('SshFilesystemProvider readFile streaming', () => {
   beforeEach(() => {
     mux = createMockMux()
     provider = new SshFilesystemProvider('conn-1', mux as never)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('streams via fs.readFileStream and reassembles utf-8 text', async () => {
@@ -157,6 +165,59 @@ describe('SshFilesystemProvider readFile streaming', () => {
       }
     })
     await expect(provider.readFile('/home/x.txt')).rejects.toThrow(/gone/)
+  })
+
+  it('cancels and cleans up a stream that stalls after metadata', async () => {
+    vi.useFakeTimers()
+    mux.request.mockResolvedValue({
+      streamId: 9,
+      totalSize: 1,
+      isBinary: false,
+      resultEncoding: 'utf-8'
+    })
+
+    const read = provider.readFile('/home/x.txt')
+    const rejection = expect(read).rejects.toThrow(/file stream stalled/i)
+    await vi.advanceTimersByTimeAsync(SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS)
+
+    await rejection
+    expect(mux.notify).toHaveBeenCalledWith('fs.cancelStream', { streamId: 9 })
+    expect(mux._methodHandlerCount()).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps a long stream alive while chunks continue arriving', async () => {
+    vi.useFakeTimers()
+    const chunkSize = 256 * 1024
+    mux.request.mockResolvedValue({
+      streamId: 10,
+      totalSize: chunkSize + 1,
+      isBinary: true,
+      resultEncoding: 'base64'
+    })
+
+    const read = provider.readFile('/home/x.bin')
+    await vi.advanceTimersByTimeAsync(SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS - 1)
+    mux._emitMethod('fs.streamChunk', {
+      streamId: 10,
+      seq: 0,
+      data: Buffer.alloc(chunkSize).toString('base64')
+    })
+    await vi.advanceTimersByTimeAsync(SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS - 1)
+    mux._emitMethod('fs.streamChunk', {
+      streamId: 10,
+      seq: 1,
+      data: Buffer.alloc(1).toString('base64')
+    })
+    mux._emitMethod('fs.streamEnd', { streamId: 10 })
+
+    await expect(read).resolves.toEqual({
+      content: Buffer.alloc(chunkSize + 1).toString('base64'),
+      isBinary: true
+    })
+    expect(mux.notify).not.toHaveBeenCalledWith('fs.cancelStream', expect.anything())
+    expect(mux._methodHandlerCount()).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('rejects on chunk count mismatch at streamEnd', async () => {

--- a/src/main/providers/ssh-filesystem-provider-stream.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-stream.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SshFilesystemProvider } from './ssh-filesystem-provider'
 import { SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS } from '../ssh/ssh-file-stream-inactivity-deadline'
+import { publishSystemResume, publishSystemSuspend } from '../system-power-lifecycle'
 
 type MockMultiplexer = {
   request: ReturnType<typeof vi.fn>
@@ -223,6 +224,36 @@ describe('SshFilesystemProvider readFile streaming', () => {
       isBinary: true
     })
     expect(mux.notify).not.toHaveBeenCalledWith('fs.cancelStream', expect.anything())
+    expect(mux._listenerCount()).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('grants an active stream a fresh inactivity window after system resume', async () => {
+    vi.useFakeTimers()
+    mux.request.mockResolvedValue({
+      streamId: 11,
+      totalSize: 1,
+      isBinary: false,
+      resultEncoding: 'utf-8'
+    })
+
+    const read = provider.readFile('/home/x.txt')
+    await vi.advanceTimersByTimeAsync(SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS - 1)
+    publishSystemSuspend()
+    vi.setSystemTime(Date.now() + 60 * 60_000)
+    publishSystemResume()
+    await vi.advanceTimersByTimeAsync(SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS - 1)
+
+    expect(mux.notify).not.toHaveBeenCalledWith('fs.cancelStream', expect.anything())
+    mux._emitMethod('fs.streamChunk', {
+      streamId: 11,
+      seq: 0,
+      data: Buffer.from('x').toString('base64')
+    })
+    mux._emitMethod('fs.streamEnd', { streamId: 11 })
+    await expect(read).resolves.toEqual({ content: 'x', isBinary: false })
+
+    publishSystemResume()
     expect(mux._listenerCount()).toBe(0)
     expect(vi.getTimerCount()).toBe(0)
   })

--- a/src/main/providers/ssh-filesystem-provider-stream.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-stream.test.ts
@@ -11,11 +11,12 @@ type MockMultiplexer = {
   dispose: ReturnType<typeof vi.fn>
   isDisposed: ReturnType<typeof vi.fn>
   _emitMethod: (method: string, params: Record<string, unknown>) => void
-  _methodHandlerCount: () => number
+  _listenerCount: () => number
 }
 
 function createMockMux(): MockMultiplexer {
   const methodHandlers = new Map<string, Set<(params: Record<string, unknown>) => void>>()
+  const disposeHandlers = new Set<(reason: 'shutdown' | 'connection_lost') => void>()
   return {
     request: vi.fn().mockResolvedValue(undefined),
     notify: vi.fn(),
@@ -31,7 +32,12 @@ function createMockMux(): MockMultiplexer {
         return () => set!.delete(handler)
       }
     ),
-    onDispose: vi.fn(() => () => {}),
+    onDispose: vi.fn((handler: (reason: 'shutdown' | 'connection_lost') => void) => {
+      disposeHandlers.add(handler)
+      return () => {
+        disposeHandlers.delete(handler)
+      }
+    }),
     dispose: vi.fn(),
     isDisposed: vi.fn().mockReturnValue(false),
     _emitMethod: (method, params) => {
@@ -42,7 +48,8 @@ function createMockMux(): MockMultiplexer {
         }
       }
     },
-    _methodHandlerCount: () =>
+    _listenerCount: () =>
+      disposeHandlers.size +
       [...methodHandlers.values()].reduce((count, handlers) => count + handlers.size, 0)
   }
 }
@@ -182,7 +189,7 @@ describe('SshFilesystemProvider readFile streaming', () => {
 
     await rejection
     expect(mux.notify).toHaveBeenCalledWith('fs.cancelStream', { streamId: 9 })
-    expect(mux._methodHandlerCount()).toBe(0)
+    expect(mux._listenerCount()).toBe(0)
     expect(vi.getTimerCount()).toBe(0)
   })
 
@@ -216,7 +223,7 @@ describe('SshFilesystemProvider readFile streaming', () => {
       isBinary: true
     })
     expect(mux.notify).not.toHaveBeenCalledWith('fs.cancelStream', expect.anything())
-    expect(mux._methodHandlerCount()).toBe(0)
+    expect(mux._listenerCount()).toBe(0)
     expect(vi.getTimerCount()).toBe(0)
   })
 

--- a/src/main/providers/ssh-filesystem-provider-stream.test.ts
+++ b/src/main/providers/ssh-filesystem-provider-stream.test.ts
@@ -60,6 +60,7 @@ describe('SshFilesystemProvider readFile streaming', () => {
   let provider: SshFilesystemProvider
 
   beforeEach(() => {
+    publishSystemResume()
     mux = createMockMux()
     provider = new SshFilesystemProvider('conn-1', mux as never)
   })
@@ -254,6 +255,40 @@ describe('SshFilesystemProvider readFile streaming', () => {
     await expect(read).resolves.toEqual({ content: 'x', isBinary: false })
 
     publishSystemResume()
+    expect(mux._listenerCount()).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps metadata received during suspend paused until resume', async () => {
+    vi.useFakeTimers()
+    mux.request.mockResolvedValue({
+      streamId: 12,
+      totalSize: 1,
+      isBinary: false,
+      resultEncoding: 'utf-8'
+    })
+
+    publishSystemSuspend()
+    const read = provider.readFile('/home/x.txt')
+    const outcome = vi.fn()
+    void read.then(
+      () => outcome('resolved'),
+      () => outcome('rejected')
+    )
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+
+    expect(outcome).not.toHaveBeenCalled()
+    expect(mux.notify).not.toHaveBeenCalledWith('fs.cancelStream', expect.anything())
+    publishSystemResume()
+    await vi.advanceTimersByTimeAsync(SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS - 1)
+    mux._emitMethod('fs.streamChunk', {
+      streamId: 12,
+      seq: 0,
+      data: Buffer.from('x').toString('base64')
+    })
+    mux._emitMethod('fs.streamEnd', { streamId: 12 })
+
+    await expect(read).resolves.toEqual({ content: 'x', isBinary: false })
     expect(mux._listenerCount()).toBe(0)
     expect(vi.getTimerCount()).toBe(0)
   })

--- a/src/main/ssh/ssh-file-stream-inactivity-deadline.ts
+++ b/src/main/ssh/ssh-file-stream-inactivity-deadline.ts
@@ -1,22 +1,55 @@
+import {
+  subscribeSystemPowerLifecycle,
+  type SystemPowerLifecycleListener
+} from '../system-power-lifecycle'
+
 export const SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS = 30_000
 
-export function createSshFileStreamInactivityDeadline(onTimeout: () => void): {
+type SystemPowerLifecycleSubscription = (listener: SystemPowerLifecycleListener) => () => void
+
+export function createSshFileStreamInactivityDeadline(
+  onTimeout: () => void,
+  subscribePowerLifecycle: SystemPowerLifecycleSubscription = subscribeSystemPowerLifecycle
+): {
   reset: () => void
   clear: () => void
 } {
   let timer: ReturnType<typeof setTimeout> | null = null
-  const clear = (): void => {
+  let unsubscribePowerLifecycle: (() => void) | null = null
+  let suspended = false
+  const clearTimer = (): void => {
     if (timer) {
       clearTimeout(timer)
       timer = null
     }
   }
-  return {
-    reset: () => {
-      clear()
-      timer = setTimeout(onTimeout, SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS)
-      timer.unref?.()
-    },
-    clear
+  const arm = (): void => {
+    clearTimer()
+    if (suspended) {
+      return
+    }
+    timer = setTimeout(onTimeout, SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS)
+    timer.unref?.()
   }
+  const reset = (): void => {
+    if (!unsubscribePowerLifecycle) {
+      unsubscribePowerLifecycle = subscribePowerLifecycle({
+        onSuspend: () => {
+          suspended = true
+          clearTimer()
+        },
+        onResume: () => {
+          suspended = false
+          arm()
+        }
+      })
+    }
+    arm()
+  }
+  const clear = (): void => {
+    clearTimer()
+    unsubscribePowerLifecycle?.()
+    unsubscribePowerLifecycle = null
+  }
+  return { reset, clear }
 }

--- a/src/main/ssh/ssh-file-stream-inactivity-deadline.ts
+++ b/src/main/ssh/ssh-file-stream-inactivity-deadline.ts
@@ -1,0 +1,22 @@
+export const SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS = 30_000
+
+export function createSshFileStreamInactivityDeadline(onTimeout: () => void): {
+  reset: () => void
+  clear: () => void
+} {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  const clear = (): void => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+  return {
+    reset: () => {
+      clear()
+      timer = setTimeout(onTimeout, SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS)
+      timer.unref?.()
+    },
+    clear
+  }
+}

--- a/src/main/ssh/ssh-file-stream-inactivity-deadline.ts
+++ b/src/main/ssh/ssh-file-stream-inactivity-deadline.ts
@@ -3,7 +3,7 @@ import {
   type SystemPowerLifecycleListener
 } from '../system-power-lifecycle'
 
-export const SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS = 30_000
+export const SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS = 60_000
 
 type SystemPowerLifecycleSubscription = (listener: SystemPowerLifecycleListener) => () => void
 

--- a/src/main/ssh/ssh-filesystem-stream-reader.ts
+++ b/src/main/ssh/ssh-filesystem-stream-reader.ts
@@ -1,6 +1,10 @@
 import type { SshChannelMultiplexer } from './ssh-channel-multiplexer'
 import { STREAM_CHUNK_SIZE, JsonRpcErrorCode, RelayErrorCode } from './relay-protocol'
 import type { FileReadResult } from '../providers/types'
+import {
+  createSshFileStreamInactivityDeadline,
+  SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS
+} from './ssh-file-stream-inactivity-deadline'
 
 const RESULT_ENCODING_BASE64 = 'base64'
 const SENTINEL_STREAM_ID = -1
@@ -76,6 +80,14 @@ export async function readFileViaStream(
     const pending: PendingFrame[] = []
     let metadataReady = false
 
+    const inactivity = createSshFileStreamInactivityDeadline(() => {
+      fail(
+        new StreamProtocolError(
+          `File stream stalled (>${SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS}ms without data)`
+        )
+      )
+    })
+
     const cancel = (): void => {
       if (streamIdRef.current !== SENTINEL_STREAM_ID && !mux.isDisposed()) {
         try {
@@ -91,6 +103,7 @@ export async function readFileViaStream(
         return
       }
       settled = true
+      inactivity.clear()
       cancel()
       cleanup()
       reject(err)
@@ -101,6 +114,7 @@ export async function readFileViaStream(
         return
       }
       settled = true
+      inactivity.clear()
       cleanup()
       resolve(value)
     }
@@ -148,6 +162,7 @@ export async function readFileViaStream(
       expectedSeq += 1
       receivedChunks += 1
       bytesReceived += decoded.length
+      inactivity.reset()
       // Why: credit-based flow control — the relay caps unacked chunks so bulk
       // stream frames cannot queue unbounded ahead of interactive pty.data
       // frames on the shared SSH channel. Old relays ignore this notification.
@@ -314,6 +329,7 @@ export async function readFileViaStream(
         }
         streamIdRef.current = metadata.streamId
         metadataReady = true
+        inactivity.reset()
         drainPending()
       })
       .catch((err) => {

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -176,6 +176,24 @@ describe('startup ordering', () => {
     expect(source.slice(0, willQuitStart)).not.toContain('stopTccPromptNoticeForQuit')
   })
 
+  it('keeps the power bridge through vetoable before-quit and disposes after commit', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const beforeQuitStart = source.indexOf("app.on('before-quit'")
+    const willQuitStart = source.indexOf("app.on('will-quit'", beforeQuitStart)
+    const windowAllClosedStart = source.indexOf("app.on('window-all-closed'", willQuitStart)
+    const beforeQuit = source.slice(beforeQuitStart, willQuitStart)
+    const willQuit = source.slice(willQuitStart, windowAllClosedStart)
+    const commitIndex = willQuit.indexOf('quitTeardownStartGate.tryStart(e)')
+    const disposeIndex = willQuit.indexOf('unsubscribeSystemResumeBroadcast?.()')
+
+    expect(beforeQuitStart).toBeGreaterThanOrEqual(0)
+    expect(willQuitStart).toBeGreaterThan(beforeQuitStart)
+    expect(windowAllClosedStart).toBeGreaterThan(willQuitStart)
+    expect(beforeQuit).not.toContain('unsubscribeSystemResumeBroadcast')
+    expect(commitIndex).toBeGreaterThanOrEqual(0)
+    expect(disposeIndex).toBeGreaterThan(commitIndex)
+  })
+
   it('starts the automation scheduler before headless serve reports ready', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const serveStart = source.indexOf('if (serveOptions) {')

--- a/src/main/system-power-lifecycle.test.ts
+++ b/src/main/system-power-lifecycle.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  publishSystemResume,
+  publishSystemSuspend,
+  subscribeSystemPowerLifecycle
+} from './system-power-lifecycle'
+
+afterEach(() => {
+  publishSystemResume()
+  vi.restoreAllMocks()
+})
+
+describe('system power lifecycle', () => {
+  it('replays suspended state to a late subscriber', () => {
+    publishSystemSuspend()
+    const listener = { onSuspend: vi.fn(), onResume: vi.fn() }
+    const unsubscribe = subscribeSystemPowerLifecycle(listener)
+
+    expect(listener.onSuspend).toHaveBeenCalledOnce()
+    expect(listener.onResume).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('atomically replays a transition to a subscriber added during publication', () => {
+    const lateListener = { onSuspend: vi.fn(), onResume: vi.fn() }
+    let unsubscribeLate: (() => void) | undefined
+    const unsubscribeFirst = subscribeSystemPowerLifecycle({
+      onSuspend: () => {
+        unsubscribeLate = subscribeSystemPowerLifecycle(lateListener)
+      },
+      onResume: vi.fn()
+    })
+
+    publishSystemSuspend()
+
+    expect(lateListener.onSuspend).toHaveBeenCalledOnce()
+    unsubscribeLate?.()
+    unsubscribeFirst()
+  })
+
+  it('isolates a failing listener from the remaining subscribers', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const unsubscribeFailing = subscribeSystemPowerLifecycle({
+      onSuspend: () => {
+        throw new Error('listener failed')
+      },
+      onResume: vi.fn()
+    })
+    const healthyListener = { onSuspend: vi.fn(), onResume: vi.fn() }
+    const unsubscribeHealthy = subscribeSystemPowerLifecycle(healthyListener)
+
+    publishSystemSuspend()
+
+    expect(healthyListener.onSuspend).toHaveBeenCalledOnce()
+    expect(console.error).toHaveBeenCalledOnce()
+    unsubscribeHealthy()
+    unsubscribeFailing()
+  })
+})

--- a/src/main/system-power-lifecycle.ts
+++ b/src/main/system-power-lifecycle.ts
@@ -1,0 +1,23 @@
+export type SystemPowerLifecycleListener = {
+  onSuspend: () => void
+  onResume: () => void
+}
+
+const listeners = new Set<SystemPowerLifecycleListener>()
+
+export function subscribeSystemPowerLifecycle(listener: SystemPowerLifecycleListener): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function publishSystemSuspend(): void {
+  for (const listener of Array.from(listeners)) {
+    listener.onSuspend()
+  }
+}
+
+export function publishSystemResume(): void {
+  for (const listener of Array.from(listeners)) {
+    listener.onResume()
+  }
+}

--- a/src/main/system-power-lifecycle.ts
+++ b/src/main/system-power-lifecycle.ts
@@ -3,21 +3,43 @@ export type SystemPowerLifecycleListener = {
   onResume: () => void
 }
 
+type SystemPowerState = 'awake' | 'suspended'
+
 const listeners = new Set<SystemPowerLifecycleListener>()
+let state: SystemPowerState = 'awake'
+
+function notifyListener(listener: SystemPowerLifecycleListener, nextState: SystemPowerState): void {
+  try {
+    if (nextState === 'suspended') {
+      listener.onSuspend()
+    } else {
+      listener.onResume()
+    }
+  } catch (error) {
+    console.error('[power] System lifecycle listener failed:', error)
+  }
+}
 
 export function subscribeSystemPowerLifecycle(listener: SystemPowerLifecycleListener): () => void {
   listeners.add(listener)
+  notifyListener(listener, state)
   return () => listeners.delete(listener)
 }
 
 export function publishSystemSuspend(): void {
+  state = 'suspended'
   for (const listener of Array.from(listeners)) {
-    listener.onSuspend()
+    if (listeners.has(listener)) {
+      notifyListener(listener, state)
+    }
   }
 }
 
 export function publishSystemResume(): void {
+  state = 'awake'
   for (const listener of Array.from(listeners)) {
-    listener.onResume()
+    if (listeners.has(listener)) {
+      notifyListener(listener, state)
+    }
   }
 }

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -4,6 +4,7 @@ import {
   getCrashBreadcrumbSnapshot
 } from './crash-reporting/crash-breadcrumb-store'
 import { registerSystemResumeBroadcast, SYSTEM_RESUMED_CHANNEL } from './system-resume-broadcast'
+import { subscribeSystemPowerLifecycle } from './system-power-lifecycle'
 
 vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: vi.fn(() => []) },
@@ -51,6 +52,26 @@ function createWindow(destroyed = false): {
 }
 
 describe('registerSystemResumeBroadcast', () => {
+  it('publishes suspend and resume to main-process lifecycle consumers', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const listener = { onSuspend: vi.fn(), onResume: vi.fn() }
+    const unsubscribe = subscribeSystemPowerLifecycle(listener)
+    const stopBroadcast = registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => []
+    })
+
+    fireSuspend()
+    fireResume()
+    unsubscribe()
+    fireSuspend()
+    fireResume()
+    stopBroadcast()
+
+    expect(listener.onSuspend).toHaveBeenCalledOnce()
+    expect(listener.onResume).toHaveBeenCalledOnce()
+  })
+
   it('broadcasts the resume channel to every live window', () => {
     const { source, fireResume } = createResumeSource()
     const liveWindow = createWindow()

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -56,6 +56,7 @@ describe('registerSystemResumeBroadcast', () => {
     const { source, fireSuspend, fireResume } = createResumeSource()
     const listener = { onSuspend: vi.fn(), onResume: vi.fn() }
     const unsubscribe = subscribeSystemPowerLifecycle(listener)
+    listener.onResume.mockClear()
     const stopBroadcast = registerSystemResumeBroadcast({
       resumeSource: source,
       getWindows: () => []

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, powerMonitor } from 'electron'
 import { recordCrashBreadcrumb } from './crash-reporting/crash-breadcrumb-store'
+import { publishSystemResume, publishSystemSuspend } from './system-power-lifecycle'
 
 export const SYSTEM_RESUMED_CHANNEL = 'system:resumed'
 
@@ -45,6 +46,7 @@ export function registerSystemResumeBroadcast(
     // span is visibly inconsistent with surviving heartbeats, while under-reporting
     // leaves a long gap looking unexplained -- the false freeze this exists to rule out.
     suspendedAt ??= now()
+    publishSystemSuspend()
   }
 
   const onResume = (): void => {
@@ -53,6 +55,7 @@ export function registerSystemResumeBroadcast(
     if (suspendedForMs !== null && suspendedForMs >= MIN_REPORTABLE_SUSPEND_MS) {
       recordCrashBreadcrumb('system_slept', { suspendedForMs })
     }
+    publishSystemResume()
     for (const window of getWindows()) {
       if (!window.isDestroyed()) {
         window.webContents.send(SYSTEM_RESUMED_CHANNEL)


### PR DESCRIPTION
## Summary

Fixes #11362.

- prevent AI Vault's **Scanning sessions** state from waiting forever on a stalled SSH file read
- start a 30-second inactivity deadline after SSH file stream metadata arrives
- reset the deadline after every valid chunk, so large active transfers can run longer than 30 seconds
- cancel the remote stream and remove listeners when a stream stalls

This PR is intentionally scoped to the SSH file-stream lifecycle. It does not change AI Vault session discovery, provider filters, file-size limits, or parsing behavior.

## Screenshots

### Observed symptom on stable cask releases

![AI Vault session list stuck on “세션 스캔 중” (Scanning sessions) in the Korean UI](https://raw.githubusercontent.com/Turtle-Hwan/orca/pr-assets/pr-11364-ssh-session-scan-loop.png)

The screenshot uses the Korean UI; **세션 스캔 중** means **Scanning sessions**. It was captured after installing the latest stable Homebrew cask available at approximately 2026-07-29 15:00 KST (`v1.4.160`). After updating to the current stable cask (`v1.4.161`), the same indefinite loading symptom reproduced again.

The screenshot documents the user-visible loading state, but no per-stream trace was captured during those runs, so it does not by itself establish that a stalled stream caused a specific instance. The focused regression tests isolate the verified stream-layer defect: after metadata arrives, a stream that produces neither another chunk nor a terminal frame previously had no deadline.

When that condition occurs, this PR cancels and rejects the read after 30 seconds of inactivity, allowing the session scanner to settle through its existing result/error path instead of waiting forever.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test` — PR branch: 3,777 passing files / 39,949 passing tests with 8 failures; clean `upstream/main`: 3,777 passing files / 39,947 passing tests with the same 8 failures in the two Codex runtime-home rollback suites
- [x] `pnpm vitest run src/main/providers/ssh-filesystem-provider-stream.test.ts` (10/10)
- [x] `pnpm run check:code-quality:changed -- upstream/main`
- [x] Added focused coverage for timeout cancellation/listener cleanup and for long active streams

## AI Review Report

- macOS / Linux / Windows: the change uses Node timers only and does not add OS-specific paths, shell commands, shortcuts, or Electron APIs
- local / remote / WSL: the behavior is scoped to SSH filesystem streams; local filesystem and WSL providers are unchanged
- provider neutrality: no agent-provider or CLI-specific behavior changed
- performance: one unref'd timer exists per active SSH file stream and is cleared on every terminal path
- UI: no user-facing copy or layout changed

## Security Audit

- no new dependencies, IPC channels, commands, path handling, auth flow, or secret handling
- timeout failure uses the existing `fs.cancelStream` capability and existing cleanup path
- the change reduces the lifetime of abandoned stream listeners and buffers without broadening filesystem authority

## Notes

- Reproduction versions: stable cask 1.4.160 ([cask commit](https://github.com/stablyai/homebrew-orca/commit/28fcabd6ce9a4e8a1f4a3206b07e50903ec495cf)) and current stable cask 1.4.161 ([cask commit](https://github.com/stablyai/homebrew-orca/commit/8076acb05058e83339fcff74c4e61a6c9b64df53)).
- High-volume provider discovery and large remote transcript handling are separate follow-up concerns and are intentionally outside this PR.
- Backward compatible: relays that do not implement cancellation already tolerate the existing best-effort notification behavior.
- X handle: not provided.