### PR TITLE
feat(quick-open): support multi-term file search

### DIFF
--- a/src/renderer/src/components/quick-open-search.test.ts
+++ b/src/renderer/src/components/quick-open-search.test.ts
@@ -174,6 +174,22 @@ describe('quick-open-search', () => {
     })
   })
 
+  it('skips streamed paths for oversized or excessive-term queries', () => {
+    const oversized = new QuickOpenPathRanker(
+      'secret-quick-open'.repeat(QUICK_OPEN_QUERY_MAX_BYTES),
+      8
+    )
+    oversized.consider('src/secret.ts')
+    expect(oversized.result()).toEqual({ paths: [], totalCount: 0 })
+
+    const excessive = new QuickOpenPathRanker(
+      Array.from({ length: 33 }, (_, index) => `term-${index}`).join(' '),
+      8
+    )
+    excessive.consider('src/file.ts')
+    expect(excessive.result()).toEqual({ paths: [], totalCount: 0 })
+  })
+
   it('returns scores sorted ascending', () => {
     const files = [
       'src/components/QuickOpen.tsx',

--- a/src/renderer/src/components/quick-open-search.test.ts
+++ b/src/renderer/src/components/quick-open-search.test.ts
@@ -70,6 +70,43 @@ describe('quick-open-search', () => {
     ).toEqual(['src/components/Button.tsx', 'button-area/deep/path/file.tsx'])
   })
 
+  it('matches every whitespace-separated term regardless of term order', () => {
+    const files = prepareQuickOpenFiles(['apps/web/.env', 'apps/api/.env', 'packages/shared/.env'])
+
+    expect(rankQuickOpenFiles('.env api', files).map((item) => item.path)).toEqual([
+      'apps/api/.env'
+    ])
+    expect(rankQuickOpenFiles('api .env', files).map((item) => item.path)).toEqual([
+      'apps/api/.env'
+    ])
+  })
+
+  it('deduplicates terms separated by mixed whitespace', () => {
+    const files = prepareQuickOpenFiles(['apps/api/.env', 'services/api/.env.local'])
+
+    expect(rankQuickOpenFiles('\t.env\napi api  ', files)).toEqual(
+      rankQuickOpenFiles('.env api', files)
+    )
+  })
+
+  it('keeps matches whose combined term score is negative one', () => {
+    const files = prepareQuickOpenFiles(['a1234b/c/file.ts'])
+
+    expect(rankQuickOpenFiles('ab c', files)).toEqual([{ path: 'a1234b/c/file.ts', score: -1 }])
+  })
+
+  it('keeps multi-term matches when an individual term scores negative one', () => {
+    const files = prepareQuickOpenFiles(['a123/b/c/file.ts'])
+
+    expect(rankQuickOpenFiles('ab c', files)).toEqual([{ path: 'a123/b/c/file.ts', score: -6 }])
+  })
+
+  it('preserves the single-term negative-one exclusion', () => {
+    const files = prepareQuickOpenFiles(['a123/b/file.ts'])
+
+    expect(rankQuickOpenFiles('ab', files)).toEqual([])
+  })
+
   it('uses natural order for tie-heavy results at the limit boundary', () => {
     const files = Array.from({ length: 10 }, (_, index) => `src/path-${9 - index}.bin`)
 
@@ -101,6 +138,40 @@ describe('quick-open-search', () => {
         (_, index) => `bulk/special-${index}/needle.ts`
       )
     )
+  })
+
+  it('returns 50 top-ranked multi-term results from a 100k synthetic list', () => {
+    const fillerCount = 99_940
+    const topCandidateCount = 60
+    const files = [
+      ...Array.from(
+        { length: fillerCount },
+        (_, index) => `n-x-e-x-e-x-d-x-l-x-e/group-${index}/file.ts`
+      ),
+      ...Array.from({ length: topCandidateCount }, (_, index) => `bulk/special-${index}/needle.ts`)
+    ]
+
+    const results = rankQuickOpenFiles('needle special', prepareQuickOpenFiles(files))
+
+    expect(results).toHaveLength(QUICK_OPEN_RESULT_LIMIT)
+    expect(results.map((item) => item.path)).toEqual(
+      Array.from(
+        { length: QUICK_OPEN_RESULT_LIMIT },
+        (_, index) => `bulk/special-${index}/needle.ts`
+      )
+    )
+  })
+
+  it('ranks multi-term matches through the streaming path used on remote hosts', () => {
+    const ranker = new QuickOpenPathRanker('.env api', 8)
+    for (const path of ['apps/web/.env', 'apps/api/.env', 'packages/shared/.env']) {
+      ranker.consider(path)
+    }
+
+    expect(ranker.result()).toEqual({
+      paths: ['apps/api/.env'],
+      totalCount: 1
+    })
   })
 
   it('returns scores sorted ascending', () => {
@@ -184,6 +255,22 @@ describe('quick-open-search', () => {
         prepareQuickOpenFiles(['src/a.ts'])
       )
     ).toEqual([])
+  })
+
+  it('rejects queries with more than 32 unique terms', () => {
+    const terms = Array.from({ length: 33 }, (_, index) => `term-${index}`)
+    const file = {
+      path: terms.join('/'),
+      inputIndex: 0,
+      get lowerPath(): string {
+        throw new Error('excessive terms must not scan indexed paths')
+      },
+      get lowerFilename(): string {
+        throw new Error('excessive terms must not scan indexed filenames')
+      }
+    } as QuickOpenIndexedFile
+
+    expect(rankQuickOpenFiles(terms.join(' '), [file])).toEqual([])
   })
 
   it('matches Windows-style path queries against slash-normalized file paths', () => {

--- a/src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-classifier.test.ts
@@ -200,6 +200,15 @@ describe('tab create entry classification', () => {
     })
   })
 
+  it('keeps multi-term file matches in the tab entry list without creating a spaced filename', () => {
+    const files = readyFiles(['apps/web/.env', 'apps/api/.env', 'packages/shared/.env'])
+
+    expect(getTabEntryOptions('.env api', files).map((option) => option.classification)).toEqual([
+      { kind: 'search', engine: 'google', query: '.env api' },
+      { kind: 'existing-file', matchKind: 'fuzzy', relativePath: 'apps/api/.env' }
+    ])
+  })
+
   it('returns duplicate basename matches as separate open-file options', () => {
     expect(
       getTabEntryOptions('index.ts', readyFiles(['src/index.ts', 'docs/index.ts'])).map(
@@ -242,7 +251,7 @@ describe('tab create entry classification', () => {
       getTabEntryOptions('type script', readyFiles(['docs/typescript-guide.md'])).map(
         (option) => option.classification.kind
       )
-    ).toEqual(['search'])
+    ).toEqual(['search', 'existing-file'])
   })
 
   it('never offers to create a file from a spaced phrase without path syntax', () => {
@@ -466,6 +475,30 @@ describe('tab create entry classification', () => {
     })
   })
 
+  it('blocks excessive multi-term queries before reading listed files', () => {
+    const query = Array.from({ length: 33 }, (_, index) => `term-${index}`).join(' ')
+    const fileList = {
+      get files(): string[] {
+        throw new Error('excessive term queries must not read file lists')
+      },
+      loading: false,
+      loadError: null
+    }
+
+    expect(classifyTabEntryQuery(query, fileList)).toEqual({
+      kind: 'blocked',
+      message: 'Search text is too large.'
+    })
+  })
+
+  it('blocks excessive multi-term queries that exactly match a listed path', () => {
+    const query = Array.from({ length: 33 }, (_, index) => `term-${index}`).join(' ')
+
+    expect(
+      getTabEntryOptions(query, readyFiles([query])).map((option) => option.classification)
+    ).toEqual([{ kind: 'blocked', message: 'Search text is too large.' }])
+  })
+
   it('offers both exact file and URL actions for host-like filenames', () => {
     expect(
       getTabEntryOptions('example.com', readyFiles(['example.com'])).map(
@@ -490,6 +523,25 @@ describe('tab create entry classification', () => {
         localPlatform: 'posix'
       })
     ).toMatchObject({ kind: 'blocked', message: 'Enter an absolute path for this computer.' })
+  })
+
+  it('allows absolute paths containing more than 32 space-separated words', () => {
+    const words = Array.from({ length: 33 }, (_, index) => `folder-${index}`).join(' ')
+    const posixPath = `/tmp/${words}/notes.md`
+    const windowsPath = `C:\\tmp\\${words}\\notes.md`
+
+    expect(
+      classifyTabEntryQuery(posixPath, readyFiles([]), {
+        allowAbsolutePaths: true,
+        localPlatform: 'posix'
+      })
+    ).toEqual({ kind: 'absolute-file', filePath: posixPath })
+    expect(
+      classifyTabEntryQuery(windowsPath, readyFiles([]), {
+        allowAbsolutePaths: true,
+        localPlatform: 'windows'
+      })
+    ).toEqual({ kind: 'absolute-file', filePath: windowsPath.replace(/\\/g, '/') })
   })
 
   it('classifies drive and UNC paths only for Windows clients', () => {

--- a/src/renderer/src/components/tab-bar/tab-create-entry-classifier.ts
+++ b/src/renderer/src/components/tab-bar/tab-create-entry-classifier.ts
@@ -1,4 +1,8 @@
-import { getPreparedQuickOpenFiles, isQuickOpenQueryTooLarge } from '../quick-open-search'
+import {
+  getPreparedQuickOpenFiles,
+  isQuickOpenQueryTermLimitExceeded,
+  isQuickOpenQueryTooLarge
+} from '../quick-open-search'
 import type { RuntimeFileListState } from '../quick-open-file-list'
 import { translate } from '@/i18n/i18n'
 import { getTabEntryOmniboxPlaceholder } from './tab-create-entry-copy'
@@ -187,6 +191,18 @@ export function getTabEntryOptions(
     return explicitUrl.kind === 'blocked'
       ? [blockedOption('invalid-url', explicitUrl.message)]
       : toOptions([explicitUrl], limit)
+  }
+
+  if (isQuickOpenQueryTermLimitExceeded(trimmed)) {
+    return [
+      blockedOption(
+        'query-too-large',
+        translate(
+          'auto.components.tab.bar.tab.create.entry.classifier.queryTooLarge',
+          'Search text is too large.'
+        )
+      )
+    ]
   }
 
   const hostUrl = classifyHostUrl(trimmed)

--- a/src/shared/quick-open-path-search.ts
+++ b/src/shared/quick-open-path-search.ts
@@ -90,10 +90,10 @@ export class QuickOpenPathRanker {
   }
 
   consider(path: string): void {
-    const file = prepareQuickOpenFile(path, this.inputIndex++)
     if (this.queryTerms === null) {
       return
     }
+    const file = prepareQuickOpenFile(path, this.inputIndex++)
     const score = scoreIndexedFile(this.queryTerms, file)
     if (score === null) {
       return

--- a/src/shared/quick-open-path-search.ts
+++ b/src/shared/quick-open-path-search.ts
@@ -5,6 +5,7 @@ export const QUICK_OPEN_RESULT_LIMIT = 50
 export const QUICK_OPEN_QUERY_MAX_BYTES = 2 * 1024
 export const QUICK_OPEN_REMOTE_QUERY_MAX_CODE_UNITS = 256
 export const QUICK_OPEN_SEARCH_VERSION = 1
+const QUICK_OPEN_QUERY_MAX_TERMS = 32
 
 export type QuickOpenIndexedFile = {
   path: string
@@ -47,28 +48,36 @@ export function isQuickOpenRemoteQueryTooLarge(query: string): boolean {
   return query.length > QUICK_OPEN_REMOTE_QUERY_MAX_CODE_UNITS || isQuickOpenQueryTooLarge(query)
 }
 
+export function isQuickOpenQueryTermLimitExceeded(query: string): boolean {
+  return getNormalizedQuickOpenQueryTerms(query).length > QUICK_OPEN_QUERY_MAX_TERMS
+}
+
 export function rankQuickOpenFiles(
   query: string,
   files: readonly QuickOpenIndexedFile[],
   limit = QUICK_OPEN_RESULT_LIMIT
 ): QuickOpenSearchResult[] {
-  if (limit <= 0 || isQuickOpenQueryTooLarge(query)) {
+  if (limit <= 0) {
+    return []
+  }
+  const queryTerms = prepareQuickOpenQueryTerms(query)
+  if (queryTerms === null) {
     return []
   }
 
-  const normalizedQuery = normalizeQuickOpenQuery(query)
   const results: QuickOpenRankedResult[] = []
   for (const file of files) {
-    const score = normalizedQuery ? fuzzyMatchIndexedFile(normalizedQuery, file) : 0
-    if (score !== -1) {
-      retainTopResult(results, { path: file.path, score, inputIndex: file.inputIndex }, limit)
+    const score = scoreIndexedFile(queryTerms, file)
+    if (score === null) {
+      continue
     }
+    retainTopResult(results, { path: file.path, score, inputIndex: file.inputIndex }, limit)
   }
   return finalizeResults(results)
 }
 
 export class QuickOpenPathRanker {
-  private readonly normalizedQuery: string | null
+  private readonly queryTerms: string[] | null
   private readonly retained: QuickOpenRankedResult[] = []
   private inputIndex = 0
   private matchCount = 0
@@ -77,17 +86,16 @@ export class QuickOpenPathRanker {
     query: string,
     private readonly limit: number
   ) {
-    this.normalizedQuery =
-      limit <= 0 || isQuickOpenQueryTooLarge(query) ? null : normalizeQuickOpenQuery(query)
+    this.queryTerms = limit <= 0 ? null : prepareQuickOpenQueryTerms(query)
   }
 
   consider(path: string): void {
     const file = prepareQuickOpenFile(path, this.inputIndex++)
-    if (this.normalizedQuery === null) {
+    if (this.queryTerms === null) {
       return
     }
-    const score = this.normalizedQuery ? fuzzyMatchIndexedFile(this.normalizedQuery, file) : 0
-    if (score === -1) {
+    const score = scoreIndexedFile(this.queryTerms, file)
+    if (score === null) {
       return
     }
     this.matchCount++
@@ -106,8 +114,54 @@ export class QuickOpenPathRanker {
   }
 }
 
-function normalizeQuickOpenQuery(query: string): string {
-  return query.trim().replace(/\\/g, '/').toLowerCase()
+function prepareQuickOpenQueryTerms(
+  query: string,
+  maxBytes = QUICK_OPEN_QUERY_MAX_BYTES
+): string[] | null {
+  if (isQuickOpenQueryTooLarge(query, maxBytes)) {
+    return null
+  }
+  const queryTerms = getNormalizedQuickOpenQueryTerms(query)
+  return queryTerms.length > QUICK_OPEN_QUERY_MAX_TERMS ? null : queryTerms
+}
+
+function getNormalizedQuickOpenQueryTerms(query: string): string[] {
+  // Why: Quick Open presents slash-normalized paths even on Windows; users
+  // still naturally type backslashes in path queries.
+  const normalizedQuery = query.trim().replace(/\\/g, '/').toLowerCase()
+  if (!normalizedQuery) {
+    return []
+  }
+  return [...new Set(normalizedQuery.split(/\s+/))].sort((a, b) => b.length - a.length)
+}
+
+function scoreIndexedFile(
+  queryTerms: readonly string[],
+  file: QuickOpenIndexedFile
+): number | null {
+  if (queryTerms.length === 0) {
+    return 0
+  }
+  const score = fuzzyMatchIndexedFileTerms(queryTerms, file)
+  if (score === null || (queryTerms.length === 1 && score === -1)) {
+    return null
+  }
+  return score
+}
+
+function fuzzyMatchIndexedFileTerms(
+  queryTerms: readonly string[],
+  file: QuickOpenIndexedFile
+): number | null {
+  let totalScore = 0
+  for (const queryTerm of queryTerms) {
+    const score = fuzzyMatchIndexedFile(queryTerm, file)
+    if (score === null) {
+      return null
+    }
+    totalScore += score
+  }
+  return totalScore
 }
 
 function prepareQuickOpenFile(path: string, inputIndex: number): QuickOpenIndexedFile {
@@ -121,7 +175,7 @@ function prepareQuickOpenFile(path: string, inputIndex: number): QuickOpenIndexe
   }
 }
 
-function fuzzyMatchIndexedFile(query: string, file: QuickOpenIndexedFile): number {
+function fuzzyMatchIndexedFile(query: string, file: QuickOpenIndexedFile): number | null {
   let qi = 0
   let score = 0
   let lastMatchIdx = -1
@@ -145,7 +199,7 @@ function fuzzyMatchIndexedFile(query: string, file: QuickOpenIndexedFile): numbe
   }
 
   if (qi < query.length) {
-    return -1
+    return null
   }
   if (file.lowerFilename.includes(query)) {
     score -= 100


### PR DESCRIPTION
## Summary

- Split Quick Open queries on whitespace and require every unique term to fuzzy-match the normalized relative path.
- Keep term order irrelevant, preserve filename ranking bonuses and existing single-term behavior.
- Apply the same behavior to Quick Open and the tab-bar file picker.
- Bound queries to 2 KiB and 32 unique terms before scanning indexed files.

Closes #11366

## Screenshots

### Before: filename only

Searching `.env` shows every repeated filename in the monorepo.

<img width="960" alt="Quick Open showing four .env matches" src="https://github.com/user-attachments/assets/abd8d471-fefd-410b-8077-864b1f8967ec" />

### After: filename plus folder term

Searching `.env api` narrows the list to `apps/api/.env`.

<img width="960" alt="Quick Open filtering .env results with the api folder term" src="https://github.com/user-attachments/assets/70b5dc61-1443-4e1e-8b7d-f6a6c20b3e6e" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (39,964 passed; 71 skipped)
- [x] `pnpm build`
- [x] Added high-quality regression tests for term order, duplicate/mixed whitespace, score sentinel behavior, query bounds, 100k-file ranking, tab-bar integration, and POSIX/Windows absolute-path compatibility

All repository checks ran under the required Node 24 runtime.

## AI Review Report

The AI review explicitly checked macOS, Linux, and Windows path behavior; local, folder-workspace, worktree, and SSH/remote compatibility; tab-bar integration; renderer performance; UI behavior; and security boundaries.

The first review caught a valid combined score of `-1` being mistaken for no match and a term-limit check happening after tab-bar file-list access. The follow-up review caught a single-term compatibility regression and absolute paths with many spaces being classified as search queries. I added regression tests and fixed all four findings. Final review reported no Critical or Important findings.

No keyboard shortcuts, shortcut labels, shell commands, Electron platform APIs, agent integrations, or git-provider behavior changed.

## Security Audit

The search processes indexed relative path strings only; it does not read file contents or add command execution, auth, secret, dependency, filesystem-write, or IPC behavior. Raw input is rejected above 2 KiB, and fuzzy work is capped at 32 unique terms before file-list access. Absolute local paths and explicit URLs retain their existing validation paths before the search-term cap. No follow-up security work is required.

## Notes

- UI layout and styling are unchanged; this is a search behavior change.
- Verified manually in the macOS development app with repeated `.env` files.
- Slash normalization covers Windows-style queries, and tests cover POSIX and Windows absolute-path handling.
- The matcher is renderer-only and uses the same indexed relative paths for local, folder, worktree, and SSH-backed workspaces.
- Contributor: @MinseongS