### PR TITLE
fix(mobile): recover when half-open sockets omit close events

### DIFF
--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -707,6 +707,29 @@ describe('mobile rpc-client connection timeout', () => {
       client.close()
     })
 
+    it('reconnects when the half-open socket omits its close callback', async () => {
+      const client = connect('ws://desktop.invalid', 'token', 'server-key')
+      const socket = mockSockets[0]!
+      openAndAuthenticate(socket)
+      socket.emitCloseOnClose = false
+
+      client.notifyForeground()
+      await vi.advanceTimersByTimeAsync(8_000)
+
+      expect(socket.close).toHaveBeenCalledTimes(1)
+      expect(client.getState()).toBe('reconnecting')
+
+      await vi.advanceTimersByTimeAsync(500)
+      expect(mockSockets).toHaveLength(2)
+      openAndAuthenticate(mockSockets[1]!)
+      expect(client.getState()).toBe('connected')
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(mockSockets).toHaveLength(2)
+
+      client.close()
+    })
+
     it('keeps a healthy connection when the foreground probe is answered', async () => {
       const { client, socket } = connectAuthenticated()
 

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -718,6 +718,8 @@ describe('mobile rpc-client connection timeout', () => {
 
       expect(socket.close).toHaveBeenCalledTimes(1)
       expect(client.getState()).toBe('reconnecting')
+      socket.onclose?.()
+      expect(client.getState()).toBe('reconnecting')
 
       await vi.advanceTimersByTimeAsync(500)
       expect(mockSockets).toHaveLength(2)
@@ -731,6 +733,21 @@ describe('mobile rpc-client connection timeout', () => {
       client.close()
     })
 
+    it('coalesces repeated foreground probes while one probe is pending', async () => {
+      const client = connectAuthenticated().client
+      const socket = mockSockets[0]!
+      client.notifyForeground()
+      client.notifyForeground()
+      client.notifyForeground()
+      expect(sentRequests(socket, 'status.get')).toHaveLength(1)
+      await vi.advanceTimersByTimeAsync(8_000)
+      expect(socket.close).toHaveBeenCalledTimes(1)
+      expect(client.getState()).toBe('reconnecting')
+
+      await vi.advanceTimersByTimeAsync(500)
+      expect(mockSockets).toHaveLength(2)
+      client.close()
+    })
     it('keeps a healthy connection when the foreground probe is answered', async () => {
       const { client, socket } = connectAuthenticated()
 

--- a/mobile/src/transport/rpc-client.test.ts
+++ b/mobile/src/transport/rpc-client.test.ts
@@ -723,6 +723,7 @@ describe('mobile rpc-client connection timeout', () => {
       expect(mockSockets).toHaveLength(2)
       openAndAuthenticate(mockSockets[1]!)
       expect(client.getState()).toBe('connected')
+      expect(client.getReconnectAttempt()).toBe(0)
 
       await vi.advanceTimersByTimeAsync(1_000)
       expect(mockSockets).toHaveLength(2)

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -161,6 +161,7 @@ export function connect(
   let connectTimer: ReturnType<typeof setTimeout> | null = null
   let handshakeTimer: ReturnType<typeof setTimeout> | null = null
   let activityProbeTimer: ReturnType<typeof setInterval> | null = null
+  let activityProbeInFlight = false
   let intentionallyClosed = false
   // Consecutive auth rejections; tolerate up to AUTH_RETRY_BUDGET (issue #5200) before latching to avoid a needless re-pair.
   let authRejectionCount = 0
@@ -764,15 +765,17 @@ export function connect(
 
   // Why: app-level liveness probe (see ACTIVITY_PROBE_INTERVAL_MS) — force-closes the WS on failure so onclose reconnects.
   function runActivityProbe() {
-    if (state !== 'connected' || !ws) {
+    if (state !== 'connected' || !ws || activityProbeInFlight) {
       return
     }
+    activityProbeInFlight = true
     const probeWs = ws
     const id = nextId()
     const probeInboundSequence = inboundSequence
     let timedOut = false
     const timeout = setTimeout(() => {
       timedOut = true
+      activityProbeInFlight = false
       pending.delete(id)
       if (inboundSequence > probeInboundSequence) {
         return
@@ -792,16 +795,19 @@ export function connect(
         if (timedOut) {
           return
         }
+        activityProbeInFlight = false
         clearTimeout(timeout)
       },
       reject: () => {
         if (timedOut) {
           return
         }
+        activityProbeInFlight = false
         clearTimeout(timeout)
       }
     })
     if (!sendEncrypted({ id, deviceToken, method: 'status.get' })) {
+      activityProbeInFlight = false
       clearTimeout(timeout)
       pending.delete(id)
     }

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -781,6 +781,10 @@ export function connect(
       // Why: stale probe timers must not close a replacement socket.
       if (probeWs === ws && probeWs.readyState === WebSocket.OPEN) {
         probeWs.close()
+        // Why: React Native can omit onclose for a wedged iOS transport.
+        if (probeWs === ws) {
+          handleSocketClosed(probeWs, { timedOut: true })
+        }
       }
     }, 8_000)
     pending.set(id, {


### PR DESCRIPTION
## Summary

Recover the mobile RPC transport when its existing liveness probe detects a half-open WebSocket but React Native does not deliver the socket's `onclose` callback.

The underlying MagicSock receive-loop failure remains outside Orca. Public Tailscale reports include the exact closed [ReceiveDERP issue](https://github.com/tailscale/tailscale/issues/13322) and the similar open [iOS ReceiveIPv4/DERP issue](https://github.com/tailscale/tailscale/issues/15271); neither currently has a linked fix PR. A search of `stablyai/orca` found no exact `ReceiveDERP` issue or PR.

Orca already sends an application-level `status.get` probe every 20 seconds and waits 8 seconds for validated inbound activity. Previously, the timeout only called `WebSocket.close()`. If iOS kept the transport wedged and omitted `onclose`, Orca stayed visibly `connected` while RPC traffic was dead.

This change mirrors the existing connect-timeout recovery path: after closing the silent socket, it enters the normal close lifecycle only if that socket is still current. The existing lifecycle provides stream replay, delivery-ambiguity handling, bounded backoff, the retry cap/trickle policy, and stale-event fencing. Synchronous or late close events cannot create a second reconnect.

User impact: Orca can move from a false connected state into its existing bounded reconnect flow without requiring the user to restart the app. Manual Force Reconnect, pairing, relay selection, SSH, and folder workspaces are unchanged.

## Screenshots

No visual change.

## Testing

- [x] `cd mobile && pnpm lint`
- [x] `cd mobile && pnpm typecheck`
- [x] `cd mobile && pnpm test` — 354 files; 2,599 passed, 2 skipped
- [x] Focused transport/recovery suite — 6 files; 77 passed
- [x] Real-socket live recovery harness — 1 passed, 2 longer opt-in scenarios skipped
- [x] `cd mobile && pnpm exec expo export --platform ios` — iOS Hermes bundle exported successfully
- [x] Added a deterministic regression that suppresses `onclose`, proves the pre-fix client remains falsely connected, and verifies one replacement socket with no reconnect storm
- [x] `git diff --check`

The mobile workspace has no `build` script; the Expo iOS export is the available target bundle build used here. A signed native install was not performed.

## AI Review Report

The same read-only reviewer assessed the baseline design and the frozen final diff. It independently reproduced the architectural gap, verified the binary diff SHA-256 and changed blob IDs, and returned PASS with no P0-P3 findings.

The review checked:

- half-open detection within the existing 8-second probe grace;
- single-flight recovery under synchronous, missing, and late close callbacks;
- reuse of the existing bounded retry/backoff and trickle policy;
- healthy probe replies and unrelated validated traffic;
- pending RPC delivery ambiguity, stream replay, and timer cleanup;
- unchanged Force Reconnect, pairing, relay, SSH, and folder-workspace boundaries;
- cross-platform impact: the patch changes only generic React Native WebSocket lifecycle handling and adds no shortcuts, labels, paths, shell behavior, native modules, or Electron-specific behavior.

## Security Audit

No new input surface, command execution, filesystem path, IPC method, dependency, credential, token, encryption, or authorization behavior is introduced. The patch does not log secrets or endpoints beyond existing redaction. It reuses the authenticated RPC client's existing close/reconnect path and its delivery-unknown marking for frames that may already have reached the host.

## Notes

- This mitigates the Orca symptom; it does not repair Tailscale MagicSock or add a relay.
- The missing-`onclose` behavior is covered deterministically with a mocked React Native WebSocket.
- The real-socket integration harness uses an in-process server, not a physical iPhone or a reproduced Tailscale `ReceiveDERP` outage.
- Physical-device verification should reproduce a real iOS/Tailscale failure, confirm the app leaves the false connected state, and confirm one recovered session without duplicate terminal or notification streams.

## Contributor

- X: [@himomohi](https://x.com/himomohi)
- Threads: [@appcast](https://www.threads.com/@appcast)
