### PR TITLE
fix(terminal): clear title-derived agent rows after split pane close

### DIFF
--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -224,6 +224,27 @@ describe('buildWorktreeAgentRows', () => {
     expect(rows.map((row) => row.paneKey)).toEqual([PANE_KEY_1])
   })
 
+  it('drops hook rows whose pane leaf is no longer in the tab layout', () => {
+    const closedAgentPaneKey = makePaneKey('tab-1', LEAF_ID_1_SECOND)
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [
+        makeEntry(closedAgentPaneKey, 2000, {
+          state: 'working',
+          agentType: 'codex',
+          prompt: 'Codex'
+        })
+      ],
+      retained: [],
+      terminalLayoutsByTabId: {
+        'tab-1': makeSinglePaneLayout(LEAF_ID_1)
+      },
+      now: 3000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
   it('keeps a retained legacy numeric row for a different split pane', () => {
     const liveEntry = makeEntry(PANE_KEY_1, 2000, {
       state: 'working',

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -74,6 +74,12 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimeAgentOrchestrationByPaneKey = useAppStore(
     useShallow((s) => (active ? selectRuntimeAgentOrchestrationForWorktree(s, worktreeId) : {}))
   )
+  const recentlyRetiredAgentStatusPaneKeys = useAppStore(
+    useShallow((s) => (active ? s.recentlyRetiredAgentStatusPaneKeys : {}))
+  )
+  const suppressedTitleDerivedLeafIdsByTabId = useAppStore(
+    useShallow((s) => (active ? s.suppressedTitleDerivedLeafIdsByTabId : {}))
+  )
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
@@ -104,6 +110,8 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
         ptyIdsByTabId,
         terminalLayoutsByTabId,
         runtimeAgentOrchestrationByPaneKey,
+        recentlyRetiredAgentStatusPaneKeys,
+        suppressedTitleDerivedLeafIdsByTabId,
         now
       })
     )
@@ -118,6 +126,8 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
+    recentlyRetiredAgentStatusPaneKeys,
+    suppressedTitleDerivedLeafIdsByTabId,
     agentFreshnessSignature
   ])
 }

--- a/src/renderer/src/components/sidebar/worktree-agent-row-pane-gates.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-pane-gates.ts
@@ -1,0 +1,150 @@
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type {
+  AgentStatusEntry,
+  AgentStatusOrchestrationContext
+} from '../../../../shared/agent-status-types'
+import {
+  makePaneKey,
+  parseLegacyNumericPaneKey,
+  parsePaneKey
+} from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalPaneLayoutNode } from '../../../../shared/types'
+import { resolveRuntimePaneTitleLeafId } from '@/lib/runtime-pane-title-leaf-id'
+
+export type WorktreeAgentRowLayoutGateArgs = {
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  recentlyRetiredAgentStatusPaneKeys?: Record<string, true>
+}
+
+function collectLayoutLeafIds(node: TerminalPaneLayoutNode | null): string[] {
+  if (!node) {
+    return []
+  }
+  if (node.type === 'leaf') {
+    return [node.leafId]
+  }
+  return [...collectLayoutLeafIds(node.first), ...collectLayoutLeafIds(node.second)]
+}
+
+function countTerminalLayoutLeaves(node: TerminalPaneLayoutNode | null | undefined): number {
+  if (!node) {
+    return 0
+  }
+  if (node.type === 'leaf') {
+    return 1
+  }
+  return countTerminalLayoutLeaves(node.first) + countTerminalLayoutLeaves(node.second)
+}
+
+function seenStablePaneKeysForTab(seenPaneKeys: Set<string>, tabId: string): string[] {
+  const keys: string[] = []
+  for (const paneKey of seenPaneKeys) {
+    const parsed = parsePaneKey(paneKey)
+    if (parsed?.tabId === tabId) {
+      keys.push(paneKey)
+    }
+  }
+  return keys
+}
+
+export function isAgentPaneKeyLiveInLayout(
+  paneKey: string,
+  args: WorktreeAgentRowLayoutGateArgs
+): boolean {
+  if (args.recentlyRetiredAgentStatusPaneKeys?.[paneKey] === true) {
+    return false
+  }
+  const parsed = parsePaneKey(paneKey)
+  if (!parsed) {
+    return true
+  }
+  const layout = args.terminalLayoutsByTabId?.[parsed.tabId]
+  if (!layout?.root) {
+    return true
+  }
+  return collectLayoutLeafIds(layout.root).includes(parsed.leafId)
+}
+
+export function isRetainedLegacyAliasOfSeenStablePane(args: {
+  paneKey: string
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  seenPaneKeys: Set<string>
+}): boolean {
+  const legacy = parseLegacyNumericPaneKey(args.paneKey)
+  if (!legacy) {
+    return false
+  }
+  const stablePaneKeys = seenStablePaneKeysForTab(args.seenPaneKeys, legacy.tabId)
+  if (stablePaneKeys.length === 0) {
+    return false
+  }
+
+  const layout = args.terminalLayoutsByTabId?.[legacy.tabId]
+  const leafId = resolveRuntimePaneTitleLeafId(layout, legacy.numericPaneId)
+  if (leafId) {
+    return args.seenPaneKeys.has(makePaneKey(legacy.tabId, leafId))
+  }
+
+  return countTerminalLayoutLeaves(layout?.root) === 1 && stablePaneKeys.length === 1
+}
+
+function markSeenPaneKeyForCurrentTab(args: {
+  paneKey: string | undefined
+  currentTabIds: Set<string>
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  seenPaneKeys: Set<string>
+}): void {
+  if (!args.paneKey) {
+    return
+  }
+  const parsed = parsePaneKey(args.paneKey)
+  if (parsed) {
+    if (args.currentTabIds.has(parsed.tabId)) {
+      args.seenPaneKeys.add(args.paneKey)
+    }
+    return
+  }
+
+  const legacy = parseLegacyNumericPaneKey(args.paneKey)
+  if (!legacy || !args.currentTabIds.has(legacy.tabId)) {
+    return
+  }
+  args.seenPaneKeys.add(args.paneKey)
+  const leafId = resolveRuntimePaneTitleLeafId(
+    args.terminalLayoutsByTabId?.[legacy.tabId],
+    legacy.numericPaneId
+  )
+  if (leafId) {
+    args.seenPaneKeys.add(makePaneKey(legacy.tabId, leafId))
+  }
+}
+
+export function markCompletedWorkerParentPaneKeysSeen(args: {
+  entries: AgentStatusEntry[]
+  retained: RetainedAgentEntry[]
+  runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
+  currentTabIds: Set<string>
+  seenPaneKeys: Set<string>
+  entryWithRuntimeOrchestration: (entry: AgentStatusEntry) => AgentStatusEntry
+}): void {
+  const markEntry = (entry: AgentStatusEntry): void => {
+    const rowEntry = args.entryWithRuntimeOrchestration(entry)
+    if (rowEntry.state !== 'done') {
+      return
+    }
+    markSeenPaneKeyForCurrentTab({
+      paneKey: rowEntry.orchestration?.parentPaneKey,
+      currentTabIds: args.currentTabIds,
+      terminalLayoutsByTabId: args.terminalLayoutsByTabId,
+      seenPaneKeys: args.seenPaneKeys
+    })
+  }
+
+  for (const entry of args.entries) {
+    markEntry(entry)
+  }
+  for (const retained of args.retained) {
+    markEntry(retained.entry)
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -7,17 +7,8 @@ import {
   type AgentStatusEntry,
   type AgentStatusOrchestrationContext
 } from '../../../../shared/agent-status-types'
-import {
-  makePaneKey,
-  parseLegacyNumericPaneKey,
-  parsePaneKey
-} from '../../../../shared/stable-pane-id'
-import type {
-  TerminalLayoutSnapshot,
-  TerminalPaneLayoutNode,
-  TerminalTab
-} from '../../../../shared/types'
-import { resolveRuntimePaneTitleLeafId } from '@/lib/runtime-pane-title-leaf-id'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/types'
 import {
   buildTitleDerivedAgentRows,
   resolveAgentTypeFromTerminalTitle
@@ -29,6 +20,11 @@ import {
   effectiveWorktreeAgentRowStartedAt,
   tabFromWorktreeAttributedStatusEntry
 } from './worktree-agent-row-fallback-tab'
+import {
+  isAgentPaneKeyLiveInLayout,
+  isRetainedLegacyAliasOfSeenStablePane,
+  markCompletedWorkerParentPaneKeysSeen
+} from './worktree-agent-row-pane-gates'
 
 /**
  * Resolves the sidebar row agent type, prioritizing launch agent configuration
@@ -92,115 +88,6 @@ function entryWithRuntimeOrchestration(
   return { ...entry, orchestration }
 }
 
-function countTerminalLayoutLeaves(node: TerminalPaneLayoutNode | null | undefined): number {
-  if (!node) {
-    return 0
-  }
-  if (node.type === 'leaf') {
-    return 1
-  }
-  return countTerminalLayoutLeaves(node.first) + countTerminalLayoutLeaves(node.second)
-}
-
-function seenStablePaneKeysForTab(seenPaneKeys: Set<string>, tabId: string): string[] {
-  const keys: string[] = []
-  for (const paneKey of seenPaneKeys) {
-    const parsed = parsePaneKey(paneKey)
-    if (parsed?.tabId === tabId) {
-      keys.push(paneKey)
-    }
-  }
-  return keys
-}
-
-function isRetainedLegacyAliasOfSeenStablePane(args: {
-  paneKey: string
-  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
-  seenPaneKeys: Set<string>
-}): boolean {
-  const legacy = parseLegacyNumericPaneKey(args.paneKey)
-  if (!legacy) {
-    return false
-  }
-  const stablePaneKeys = seenStablePaneKeysForTab(args.seenPaneKeys, legacy.tabId)
-  if (stablePaneKeys.length === 0) {
-    return false
-  }
-
-  const layout = args.terminalLayoutsByTabId?.[legacy.tabId]
-  const leafId = resolveRuntimePaneTitleLeafId(layout, legacy.numericPaneId)
-  if (leafId) {
-    return args.seenPaneKeys.has(makePaneKey(legacy.tabId, leafId))
-  }
-
-  // Why: old PaneManager ids can advance across remounts/updates even for a
-  // single physical pane. Once the tab has exactly one current stable pane,
-  // retained numeric rows under that tab are stale aliases of it.
-  return countTerminalLayoutLeaves(layout?.root) === 1 && stablePaneKeys.length === 1
-}
-
-function markSeenPaneKeyForCurrentTab(args: {
-  paneKey: string | undefined
-  currentTabIds: Set<string>
-  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
-  seenPaneKeys: Set<string>
-}): void {
-  if (!args.paneKey) {
-    return
-  }
-  const parsed = parsePaneKey(args.paneKey)
-  if (parsed) {
-    if (args.currentTabIds.has(parsed.tabId)) {
-      args.seenPaneKeys.add(args.paneKey)
-    }
-    return
-  }
-
-  const legacy = parseLegacyNumericPaneKey(args.paneKey)
-  if (!legacy || !args.currentTabIds.has(legacy.tabId)) {
-    return
-  }
-  args.seenPaneKeys.add(args.paneKey)
-  const leafId = resolveRuntimePaneTitleLeafId(
-    args.terminalLayoutsByTabId?.[legacy.tabId],
-    legacy.numericPaneId
-  )
-  if (leafId) {
-    args.seenPaneKeys.add(makePaneKey(legacy.tabId, leafId))
-  }
-}
-
-function markCompletedWorkerParentPaneKeysSeen(args: {
-  entries: AgentStatusEntry[]
-  retained: RetainedAgentEntry[]
-  runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
-  terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
-  currentTabIds: Set<string>
-  seenPaneKeys: Set<string>
-}): void {
-  const markEntry = (entry: AgentStatusEntry): void => {
-    const rowEntry = entryWithRuntimeOrchestration(entry, args.runtimeAgentOrchestrationByPaneKey)
-    if (rowEntry.state !== 'done') {
-      return
-    }
-    // Why: completed worker rows can be attributed to a child pane while the
-    // visible parent pane still has a stale spinner title.
-    markSeenPaneKeyForCurrentTab({
-      paneKey: rowEntry.orchestration?.parentPaneKey,
-      currentTabIds: args.currentTabIds,
-      terminalLayoutsByTabId: args.terminalLayoutsByTabId,
-      seenPaneKeys: args.seenPaneKeys
-    })
-  }
-
-  for (const entry of args.entries) {
-    markEntry(entry)
-  }
-  for (const retained of args.retained) {
-    markEntry(retained.entry)
-  }
-}
-
 export function buildWorktreeAgentRows(args: {
   tabs: TerminalTab[]
   entries: AgentStatusEntry[]
@@ -209,6 +96,8 @@ export function buildWorktreeAgentRows(args: {
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  recentlyRetiredAgentStatusPaneKeys?: Record<string, true>
+  suppressedTitleDerivedLeafIdsByTabId?: Record<string, Record<string, true>>
   now: number
 }): DashboardAgentRow[] {
   const rows: DashboardAgentRow[] = []
@@ -232,6 +121,9 @@ export function buildWorktreeAgentRows(args: {
   for (const tab of args.tabs) {
     const explicitEntries = entriesByTabId.get(tab.id) ?? []
     for (const entry of explicitEntries) {
+      if (!isAgentPaneKeyLiveInLayout(entry.paneKey, args)) {
+        continue
+      }
       const rowEntry = entryWithRuntimeOrchestration(entry, args.runtimeAgentOrchestrationByPaneKey)
       const isFresh = isExplicitAgentStatusFresh(rowEntry, args.now, AGENT_STATUS_STALE_AFTER_MS)
       const shouldDecay =
@@ -260,7 +152,9 @@ export function buildWorktreeAgentRows(args: {
     runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey,
     terminalLayoutsByTabId: args.terminalLayoutsByTabId,
     currentTabIds,
-    seenPaneKeys
+    seenPaneKeys,
+    entryWithRuntimeOrchestration: (entry) =>
+      entryWithRuntimeOrchestration(entry, args.runtimeAgentOrchestrationByPaneKey)
   })
 
   rows.push(...buildTitleDerivedAgentRows({ ...args, seenPaneKeys }))
@@ -270,6 +164,9 @@ export function buildWorktreeAgentRows(args: {
   // worktree card instead of waiting for tab membership that may never arrive.
   for (const entry of args.entries) {
     if (seenPaneKeys.has(entry.paneKey)) {
+      continue
+    }
+    if (!isAgentPaneKeyLiveInLayout(entry.paneKey, args)) {
       continue
     }
     const rowEntry = entryWithRuntimeOrchestration(entry, args.runtimeAgentOrchestrationByPaneKey)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
 import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../../shared/types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { detachTerminalLayoutLeaf } from '@/components/terminal-pane/terminal-layout-leaf-detach'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
 
 const LEAF_ID_1 = '77777777-7777-4777-8777-777777777777'
@@ -266,6 +267,127 @@ describe('buildTitleDerivedAgentRows', () => {
       },
       ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
       terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not keep a title-derived row after split close prunes the agent leaf binding', () => {
+    const detached = detachTerminalLayoutLeaf(
+      {
+        ...makeSplitLayout(),
+        ptyIdsByLeafId: { [LEAF_ID_1]: 'pty-agent', [LEAF_ID_2]: 'pty-shell' },
+        paneIdsByLeafId: { [LEAF_ID_1]: 1, [LEAF_ID_2]: 2 }
+      },
+      LEAF_ID_1
+    )
+    expect(detached).not.toBeNull()
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 2: 'bash' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+      terminalLayoutsByTabId: {
+        'tab-1': detached!.sourceLayout
+      },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not synthesize a row for a closed split leaf that lost its PTY binding', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': {
+          1: '⠋ Codex',
+          2: 'bash'
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          ...makeSplitLayout(),
+          ptyIdsByLeafId: { [LEAF_ID_2]: 'pty-shell' },
+          paneIdsByLeafId: { [LEAF_ID_1]: 1, [LEAF_ID_2]: 2 }
+        }
+      },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not attribute a surviving split shell to tab launchAgent after the agent pane closes', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'codex' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 2: '⠼ demo-repo' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          ...makeSplitLayout(),
+          ptyIdsByLeafId: { [LEAF_ID_2]: 'pty-shell' },
+          paneIdsByLeafId: { [LEAF_ID_2]: 2 }
+        }
+      },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not resurrect a title-derived row for a suppressed split leaf', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'codex' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '⠋ Codex' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      suppressedTitleDerivedLeafIdsByTabId: { 'tab-1': { [LEAF_ID_1]: true } },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('drops stale agent titles that replay to a removed split leaf', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 2: '⠋ Codex' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+
+  it('does not synthesize title-derived rows from a polluted tab title when the runtime map is empty', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: '⠋ Codex' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {},
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
       now: 2000
     })
 

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -2,6 +2,10 @@ import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-status'
 import { containsBrailleSpinner } from '../../../../shared/agent-title-core'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
+import {
+  resolveRuntimePaneTitleForLayoutLeaf,
+  resolveRuntimePaneTitleLeafIdFromRoot
+} from '@/lib/runtime-pane-title-leaf-id'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import type {
   AgentStatusEntry,
@@ -50,6 +54,7 @@ export function buildTitleDerivedAgentRows(args: {
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+  suppressedTitleDerivedLeafIdsByTabId?: Record<string, Record<string, true>>
   seenPaneKeys: Set<string>
   now: number
 }): DashboardAgentRow[] {
@@ -63,21 +68,28 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
     const layout = terminalLayoutsByTabId[tab.id]
-    const paneTitles = runtimePaneTitlesByTabId[tab.id]
-    const paneTitleEntries =
-      paneTitles && Object.keys(paneTitles).length > 0
-        ? Object.entries(paneTitles).sort(([a], [b]) => Number(a) - Number(b))
-        : []
+    const unfilteredPaneTitles = runtimePaneTitlesByTabId[tab.id]
+    const paneTitles = filterRuntimePaneTitlesToLayoutBindings(unfilteredPaneTitles, layout)
+    const layoutLeafIds = collectLeafIds(layout?.root ?? null)
+    const hasRuntimePaneTitles = paneTitles && Object.keys(paneTitles).length > 0
+    const allowLaunchAgentSpinnerFallback = layoutLeafIds.length <= 1
 
-    if (paneTitleEntries.length > 0) {
-      for (const [paneId, title] of paneTitleEntries) {
-        const leafId = resolveLeafIdForTitleFallback({
-          layout,
-          paneTitleEntries,
-          paneId: Number(paneId),
-          title
-        })
-        if (!leafId) {
+    const ptyIdsByLeafId = layout?.ptyIdsByLeafId
+    const gateTitleDerivedLeafOnLivePty =
+      ptyIdsByLeafId !== undefined && Object.keys(ptyIdsByLeafId).length > 0
+
+    const suppressedLeafIds = args.suppressedTitleDerivedLeafIdsByTabId?.[tab.id]
+
+    if (hasRuntimePaneTitles && layoutLeafIds.length > 0) {
+      for (const leafId of layoutLeafIds) {
+        if (suppressedLeafIds?.[leafId]) {
+          continue
+        }
+        if (gateTitleDerivedLeafOnLivePty && !ptyIdsByLeafId[leafId]) {
+          continue
+        }
+        const title = resolveRuntimePaneTitleForLayoutLeaf(layout, paneTitles, leafId)
+        if (!title) {
           continue
         }
         const row = buildTitleDerivedAgentRow({
@@ -85,6 +97,7 @@ export function buildTitleDerivedAgentRows(args: {
           leafId,
           title,
           now: args.now,
+          allowLaunchAgentSpinnerFallback,
           runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
         })
         if (!row || args.seenPaneKeys.has(row.paneKey)) {
@@ -96,8 +109,32 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
 
+    if (hasRuntimePaneTitles) {
+      continue
+    }
+
+    const hadUnfilteredRuntimePaneTitles =
+      unfilteredPaneTitles && Object.keys(unfilteredPaneTitles).length > 0
+    // Why: pane titles existed but none matched a live layout leaf — they belong
+    // to removed split panes. Suppress the tab title fallback so stale agent
+    // output is not re-synthesized.
+    if (hadUnfilteredRuntimePaneTitles) {
+      continue
+    }
+
+    // Why: suppress polluted tab titles (spinner + named agent) when there is no
+    // launchAgent to back the attribution. Bare spinners with a launchAgent pass
+    // through so launchAgent can provide the type.
+    if (
+      !tab.launchAgent &&
+      containsBrailleSpinner(tab.title) &&
+      resolveAgentTypeFromTerminalTitle(tab.title)
+    ) {
+      continue
+    }
+
     const leafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
-    if (!leafId) {
+    if (!leafId || suppressedLeafIds?.[leafId]) {
       continue
     }
     const row = buildTitleDerivedAgentRow({
@@ -105,6 +142,7 @@ export function buildTitleDerivedAgentRows(args: {
       leafId,
       title: tab.title,
       now: args.now,
+      allowLaunchAgentSpinnerFallback,
       runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
     })
     if (!row || args.seenPaneKeys.has(row.paneKey)) {
@@ -121,11 +159,47 @@ export function buildTitleDerivedAgentRows(args: {
  * Constructs a dashboard agent row from a terminal tab's title fallback,
  * normalising Pi-compatible agent names to their owner.
  */
+function filterRuntimePaneTitlesToLayoutBindings(
+  paneTitles: Record<number, string> | undefined,
+  layout: TerminalLayoutSnapshot | undefined
+): Record<number, string> | undefined {
+  if (!paneTitles) {
+    return paneTitles
+  }
+  const layoutLeafIds = collectLeafIds(layout?.root ?? null)
+  if (layoutLeafIds.length === 0) {
+    return paneTitles
+  }
+  const liveLeafIds = new Set(layoutLeafIds)
+  const paneIdsByLeafId = layout?.paneIdsByLeafId
+  if (paneIdsByLeafId && Object.keys(paneIdsByLeafId).length > 0) {
+    const livePaneIds = new Set(Object.values(paneIdsByLeafId))
+    const filtered: Record<number, string> = {}
+    for (const [paneId, title] of Object.entries(paneTitles)) {
+      const numericPaneId = Number(paneId)
+      if (livePaneIds.has(numericPaneId)) {
+        filtered[numericPaneId] = title
+      }
+    }
+    return filtered
+  }
+  const filtered: Record<number, string> = {}
+  for (const [paneId, title] of Object.entries(paneTitles)) {
+    const numericPaneId = Number(paneId)
+    const leafId = resolveRuntimePaneTitleLeafIdFromRoot(layout?.root, String(numericPaneId))
+    if (leafId && liveLeafIds.has(leafId)) {
+      filtered[numericPaneId] = title
+    }
+  }
+  return filtered
+}
+
 function buildTitleDerivedAgentRow(args: {
   tab: TerminalTab
   leafId: string
   title: string
   now: number
+  allowLaunchAgentSpinnerFallback: boolean
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
 }): DashboardAgentRow | null {
   const title = normalizeCompatibleAgentTitleForOwner(args.title, args.tab.launchAgent)
@@ -152,7 +226,10 @@ function buildTitleDerivedAgentRow(args: {
   // title alone, so a non-agent title must never become a row. Residual: a split
   // pane whose own title carries a braille glyph is still attributed to launchAgent.
   const agentType =
-    titleAgentType ?? (containsBrailleSpinner(title) ? (args.tab.launchAgent ?? null) : null)
+    titleAgentType ??
+    (args.allowLaunchAgentSpinnerFallback && containsBrailleSpinner(title)
+      ? (args.tab.launchAgent ?? null)
+      : null)
   if (!agentType) {
     return null
   }
@@ -226,28 +303,6 @@ function titleStatusToRowState(
     return 'working'
   }
   return 'idle'
-}
-
-function resolveLeafIdForTitleFallback(args: {
-  layout: TerminalLayoutSnapshot | undefined
-  paneTitleEntries: [string, string][]
-  paneId: number
-  title: string
-}): string | null {
-  const matchingTitleLeafIds = Object.entries(args.layout?.titlesByLeafId ?? {})
-    .filter(([, title]) => title === args.title)
-    .map(([leafId]) => leafId)
-  if (matchingTitleLeafIds.length === 1) {
-    return matchingTitleLeafIds[0]
-  }
-
-  const leafIds = collectLeafIds(args.layout?.root ?? null)
-  if (leafIds.length === 1) {
-    return leafIds[0]
-  }
-
-  const paneIndex = args.paneTitleEntries.findIndex(([paneId]) => Number(paneId) === args.paneId)
-  return paneIndex >= 0 ? (leafIds[paneIndex] ?? null) : null
 }
 
 function collectLeafIds(node: TerminalPaneLayoutNode | null): string[] {

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1024,6 +1024,7 @@ function TerminalPane(
     if (Object.keys(mergedPtyIds).length > 0) {
       layout.ptyIdsByLeafId = mergedPtyIds
     }
+    layout.paneIdsByLeafId = Object.fromEntries(currentPanes.map((pane) => [pane.leafId, pane.id]))
     layout.activeLeafId = resolveTerminalLayoutActiveLeafId({
       root: layout.root,
       activeLeafId: layout.activeLeafId,
@@ -1276,14 +1277,26 @@ function TerminalPane(
         clearSessionRestoredBannerForPane(paneId)
         const leafId = manager.getLeafId(paneId)
         if (leafId) {
-          useAppStore.getState().setCacheTimerStartedAt(makePaneKey(tabId, leafId), null)
-          useAppStore.getState().dropAgentStatus(makePaneKey(tabId, leafId))
+          removedTitleLeafIdsRef.current.add(leafId)
+        }
+        if (paneId in paneTitlesRef.current) {
+          const next = { ...paneTitlesRef.current }
+          delete next[paneId]
+          paneTitlesRef.current = next
+          setPaneTitles((prev) => {
+            if (!(paneId in prev)) {
+              return prev
+            }
+            const nextTitles = { ...prev }
+            delete nextTitles[paneId]
+            return nextTitles
+          })
         }
         syncPanePtyLayoutBinding(paneId, null)
         manager.closePane(paneId)
       }
     },
-    [clearSessionRestoredBannerForPane, onCloseTab, syncPanePtyLayoutBinding, tabId]
+    [clearSessionRestoredBannerForPane, onCloseTab, syncPanePtyLayoutBinding]
   )
 
   // Cmd+W confirms before killing a shell with a running child (e.g. npm run dev); idle prompts close immediately, and Ctrl+D bypasses by design.

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4,7 +4,17 @@ import type { ManagedPaneInternal } from '@/lib/pane-manager/pane-manager-types'
 import type { IBuffer, IDisposable } from '@xterm/xterm'
 import { resolveCursorAgentImeAnchor } from '@/lib/pane-manager/terminal-ime-anchor'
 import { installTerminalImeCompositionRoute } from './terminal-ime-composition-route'
-import { detectAgentStatusFromTitle, agentTypeToIconAgent, isClaudeAgent } from '@/lib/agent-status'
+import {
+  detectAgentStatusFromTitle,
+  agentTypeToIconAgent,
+  isClaudeAgent,
+  formatAgentTypeLabel
+} from '@/lib/agent-status'
+import {
+  isExplicitAgentStatusFresh,
+  resolveCommittedTitleAgentType,
+  resolveTitleActivityLabel
+} from '@/lib/pane-agent-evidence'
 import { resolvePaneTitleDecision } from './terminal-title-evidence'
 import { blocksCodexPaneInput } from '../codex-restart-notice-state'
 import { resolveLiveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
@@ -180,6 +190,7 @@ import { resolveSshPaneConnectGate } from './ssh-pane-connect-gate'
 import { dispatchTerminalCommandFinishedEvent } from '@/hooks/terminal-command-finished-event'
 import { e2eConfig } from '@/lib/e2e-config'
 import {
+  AGENT_STATUS_STALE_AFTER_MS,
   isFreshNonDoneAgentStatus,
   type AgentStatusEntry,
   type AgentType
@@ -287,7 +298,7 @@ import {
   resolveCompatibleAgentTypeForOwner
 } from '../../../../shared/agent-title-owner'
 import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
-import { resolveCommittedTitleAgentType } from '@/lib/pane-agent-evidence'
+
 import {
   isExpectedAgentProcess,
   recognizeAgentProcessFromCommandLine
@@ -2692,6 +2703,9 @@ export function connectPanePty(
     rawTitle: string,
     meta?: { staleWorkingTitleClear?: boolean }
   ): void => {
+    if (disposed) {
+      return
+    }
     // Why: one owner-aware decision drives the display label, the runtime/tab
     // title, task-completion tracking, and the renderer gate, so raw title text
     // can no longer disable GPU behind stronger owner evidence (#7428/#7447).
@@ -2802,6 +2816,43 @@ export function connectPanePty(
         state: 'working',
         prompt: normalizedPrompt || (currentEntry?.state === 'working' ? currentEntry.prompt : ''),
         agentType: 'command-code'
+      },
+      currentTitle,
+      undefined,
+      routing
+    )
+  }
+
+  const seedTitleSideEffectWorkingStatus = (): void => {
+    const routing = resolveCurrentAgentStatusRouting()
+    if (!routing) {
+      return
+    }
+    const now = Date.now()
+    const currentState = useAppStore.getState()
+    const currentEntry = currentState.agentStatusByPaneKey[cacheKey]
+    if (
+      currentEntry &&
+      isExplicitAgentStatusFresh(currentEntry, now, AGENT_STATUS_STALE_AFTER_MS) &&
+      (currentEntry.state === 'working' ||
+        currentEntry.state === 'waiting' ||
+        currentEntry.state === 'blocked')
+    ) {
+      return
+    }
+    const agentType = getAuthoritativePaneAgent()
+    if (!agentType || agentType === 'unknown') {
+      return
+    }
+    const currentTitle = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
+    const titleLabel = currentTitle ? resolveTitleActivityLabel(currentTitle) : null
+    const prompt = currentEntry?.prompt?.trim() || titleLabel || formatAgentTypeLabel(agentType)
+    currentState.setAgentStatus(
+      cacheKey,
+      {
+        state: 'working',
+        prompt,
+        agentType
       },
       currentTitle,
       undefined,
@@ -3236,6 +3287,7 @@ export function connectPanePty(
   const onAgentBecameWorking = (): void => {
     suppressNativeWindowsIdleCodexFocusReports = false
     clearSuppressedTitleSideEffects()
+    seedTitleSideEffectWorkingStatus()
     if (syncAgentTaskCompleteTrackingEnabled()) {
       requiresFreshWorkingForAgentTaskCompleteNotification = false
       agentCompletionCoordinator.observeTitleWorking()

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-detach.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-detach.ts
@@ -52,12 +52,32 @@ function omitLeafRecord(
   return Object.keys(next).length > 0 ? next : undefined
 }
 
+function omitLeafNumberRecord(
+  source: Record<string, number> | undefined,
+  leafId: string
+): Record<string, number> | undefined {
+  if (!source || !Object.prototype.hasOwnProperty.call(source, leafId)) {
+    return source
+  }
+  const next = { ...source }
+  delete next[leafId]
+  return Object.keys(next).length > 0 ? next : undefined
+}
+
 function singleLeafRecord(
   source: Record<string, string> | undefined,
   leafId: string
 ): Record<string, string> | undefined {
   const value = source?.[leafId]
   return value ? { [leafId]: value } : undefined
+}
+
+function singleLeafNumberRecord(
+  source: Record<string, number> | undefined,
+  leafId: string
+): Record<string, number> | undefined {
+  const value = source?.[leafId]
+  return value === undefined ? undefined : { [leafId]: value }
 }
 
 export function detachTerminalLayoutLeaf(
@@ -83,6 +103,7 @@ export function detachTerminalLayoutLeaf(
   const buffersByLeafId = omitLeafRecord(layout.buffersByLeafId, leafId)
   const scrollbackRefsByLeafId = omitLeafRecord(layout.scrollbackRefsByLeafId, leafId)
   const titlesByLeafId = omitLeafRecord(layout.titlesByLeafId, leafId)
+  const paneIdsByLeafId = omitLeafNumberRecord(layout.paneIdsByLeafId, leafId)
   const sourceLayout: TerminalLayoutSnapshot = {
     root: removal.node,
     activeLeafId: resolveTerminalLayoutActiveLeafId({
@@ -94,13 +115,15 @@ export function detachTerminalLayoutLeaf(
     ...(ptyIdsByLeafId ? { ptyIdsByLeafId } : {}),
     ...(buffersByLeafId ? { buffersByLeafId } : {}),
     ...(scrollbackRefsByLeafId ? { scrollbackRefsByLeafId } : {}),
-    ...(titlesByLeafId ? { titlesByLeafId } : {})
+    ...(titlesByLeafId ? { titlesByLeafId } : {}),
+    ...(paneIdsByLeafId ? { paneIdsByLeafId } : {})
   }
 
   const detachedPtyIdsByLeafId = singleLeafRecord(layout.ptyIdsByLeafId, leafId)
   const detachedBuffersByLeafId = singleLeafRecord(layout.buffersByLeafId, leafId)
   const detachedScrollbackRefsByLeafId = singleLeafRecord(layout.scrollbackRefsByLeafId, leafId)
   const detachedTitlesByLeafId = singleLeafRecord(layout.titlesByLeafId, leafId)
+  const detachedPaneIdsByLeafId = singleLeafNumberRecord(layout.paneIdsByLeafId, leafId)
   return {
     sourceLayout,
     detachedLayout: {
@@ -112,7 +135,8 @@ export function detachTerminalLayoutLeaf(
       ...(detachedScrollbackRefsByLeafId
         ? { scrollbackRefsByLeafId: detachedScrollbackRefsByLeafId }
         : {}),
-      ...(detachedTitlesByLeafId ? { titlesByLeafId: detachedTitlesByLeafId } : {})
+      ...(detachedTitlesByLeafId ? { titlesByLeafId: detachedTitlesByLeafId } : {}),
+      ...(detachedPaneIdsByLeafId ? { paneIdsByLeafId: detachedPaneIdsByLeafId } : {})
     },
     ptyId: detachedPtyIdsByLeafId?.[leafId] ?? null
   }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-close-identity.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-close-identity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   resolveTabTitleAfterPaneClose,
+  shouldClearLaunchAgentAfterSplitPaneClose,
   shouldClearLaunchAgentForClosedPane
 } from './terminal-pane-close-identity'
 
@@ -28,5 +29,123 @@ describe('resolveTabTitleAfterPaneClose', () => {
   it('resets to the tab fallback when the promoted shell has no title', () => {
     expect(resolveTabTitleAfterPaneClose({ 1: 'closed agent' }, 2)).toBe('')
     expect(resolveTabTitleAfterPaneClose({}, null)).toBe('')
+  })
+
+  it('does not reuse an agent-polluted tab title when the survivor has no runtime title', () => {
+    expect(
+      resolveTabTitleAfterPaneClose({}, 1, {
+        title: '⠋ Codex',
+        customTitle: null,
+        quickCommandLabel: null,
+        defaultTitle: 'Terminal 1'
+      })
+    ).toBe('Terminal 1')
+    expect(
+      resolveTabTitleAfterPaneClose({}, 1, {
+        title: '⠋ Codex',
+        customTitle: null,
+        quickCommandLabel: null,
+        defaultTitle: undefined
+      })
+    ).toBe('')
+  })
+
+  it('keeps a non-agent tab title when the runtime map is empty', () => {
+    expect(
+      resolveTabTitleAfterPaneClose({}, 1, {
+        title: 'bash',
+        customTitle: null,
+        quickCommandLabel: null,
+        defaultTitle: undefined
+      })
+    ).toBe('bash')
+  })
+})
+
+describe('shouldClearLaunchAgentAfterSplitPaneClose', () => {
+  const agentPaneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
+  const shellPaneKey = 'tab-1:22222222-2222-4222-8222-222222222222'
+
+  it('clears launch identity when the closed split pane had the live agent', () => {
+    expect(
+      shouldClearLaunchAgentAfterSplitPaneClose({
+        tab: { launchAgent: 'codex', ptyId: 'pty-shell' },
+        closedPtyId: 'pty-agent',
+        closedPaneKey: agentPaneKey,
+        survivingPaneKeys: [shellPaneKey],
+        agentStatusByPaneKey: {
+          [agentPaneKey]: {
+            paneKey: agentPaneKey,
+            state: 'working',
+            agentType: 'codex',
+            prompt: 'Codex',
+            updatedAt: 0,
+            stateStartedAt: 0,
+            stateHistory: []
+          }
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('keeps launch identity when a surviving split pane still has a live agent', () => {
+    expect(
+      shouldClearLaunchAgentAfterSplitPaneClose({
+        tab: { launchAgent: 'codex', ptyId: 'pty-shell' },
+        closedPtyId: 'pty-agent',
+        closedPaneKey: agentPaneKey,
+        survivingPaneKeys: [shellPaneKey],
+        agentStatusByPaneKey: {
+          [shellPaneKey]: {
+            paneKey: shellPaneKey,
+            state: 'working',
+            agentType: 'codex',
+            prompt: 'Codex',
+            updatedAt: 0,
+            stateStartedAt: 0,
+            stateHistory: []
+          }
+        }
+      })
+    ).toBe(false)
+  })
+
+  it('clears launch identity when a title-derived agent pane closes without hook status', () => {
+    expect(
+      shouldClearLaunchAgentAfterSplitPaneClose({
+        tab: { launchAgent: 'codex', ptyId: 'pty-shell' },
+        closedPtyId: 'pty-agent',
+        closedPaneId: 1,
+        closedPaneKey: agentPaneKey,
+        runtimePaneTitlesByPaneId: { 1: '⠋ Codex' },
+        survivingPaneKeys: [shellPaneKey],
+        agentStatusByPaneKey: {}
+      })
+    ).toBe(true)
+  })
+
+  it('clears launch identity when a different agent survives in the split', () => {
+    const piPaneKey = 'tab-1:33333333-3333-4333-8333-333333333333'
+    expect(
+      shouldClearLaunchAgentAfterSplitPaneClose({
+        tab: { launchAgent: 'codex', ptyId: 'pty-shell' },
+        closedPtyId: 'pty-agent',
+        closedPaneId: 1,
+        closedPaneKey: agentPaneKey,
+        runtimePaneTitlesByPaneId: { 1: '⠋ Codex' },
+        survivingPaneKeys: [piPaneKey],
+        agentStatusByPaneKey: {
+          [piPaneKey]: {
+            paneKey: piPaneKey,
+            state: 'working',
+            agentType: 'pi',
+            prompt: 'Pi',
+            updatedAt: 0,
+            stateStartedAt: 0,
+            stateHistory: []
+          }
+        }
+      })
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-pane-close-identity.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-close-identity.ts
@@ -1,4 +1,44 @@
+import type { AgentStatusEntry, AgentType } from '../../../../shared/agent-status-types'
+import { containsBrailleSpinner } from '../../../../shared/agent-title-core'
+import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
+import { resolveAgentTypeFromTerminalTitle } from '@/components/sidebar/worktree-title-derived-agent-rows'
 import type { TerminalTab } from '../../../../shared/types'
+
+function survivingPaneHostsSameAgentType(
+  survivingPaneKeys: readonly string[],
+  agentStatusByPaneKey: Readonly<Record<string, AgentStatusEntry>>,
+  agentType: AgentType | null | undefined
+): boolean {
+  if (!agentType || agentType === 'unknown') {
+    return false
+  }
+  return survivingPaneKeys.some((paneKey) => agentStatusByPaneKey[paneKey]?.agentType === agentType)
+}
+
+function resolveClosedPaneAgentType(args: {
+  closedPaneKey: string
+  closedPaneId?: number | null
+  runtimePaneTitlesByPaneId?: Readonly<Record<number, string>>
+  launchAgent?: TerminalTab['launchAgent']
+  agentStatusByPaneKey: Readonly<Record<string, AgentStatusEntry>>
+}): AgentType | null {
+  const hookEntry = args.agentStatusByPaneKey[args.closedPaneKey]
+  if (hookEntry?.agentType && hookEntry.agentType !== 'unknown') {
+    return hookEntry.agentType
+  }
+  if (args.closedPaneId != null && args.runtimePaneTitlesByPaneId) {
+    const title = args.runtimePaneTitlesByPaneId[args.closedPaneId]?.trim()
+    if (title) {
+      return resolveAgentTypeFromTerminalTitle(title, args.launchAgent)
+    }
+  }
+  return args.launchAgent ?? null
+}
+
+type TabTitleFallbackFields = Pick<
+  TerminalTab,
+  'title' | 'defaultTitle' | 'quickCommandLabel' | 'customTitle'
+>
 
 export function shouldClearLaunchAgentForClosedPane(
   tab: Pick<TerminalTab, 'launchAgent' | 'ptyId'> | null | undefined,
@@ -9,11 +49,87 @@ export function shouldClearLaunchAgentForClosedPane(
   return Boolean(tab?.launchAgent && closedPtyId && tab.ptyId === closedPtyId)
 }
 
+export function closedPaneHostedTitleDerivedAgent(args: {
+  closedPaneId: number | null | undefined
+  runtimePaneTitlesByPaneId?: Readonly<Record<number, string>>
+  launchAgent?: TerminalTab['launchAgent']
+}): boolean {
+  if (args.closedPaneId == null || !args.runtimePaneTitlesByPaneId) {
+    return false
+  }
+  const title = args.runtimePaneTitlesByPaneId[args.closedPaneId]?.trim()
+  if (!title || classifyTitleActivity(title) === null) {
+    return false
+  }
+  if (resolveAgentTypeFromTerminalTitle(title, args.launchAgent) !== null) {
+    return true
+  }
+  // Why: hook-less agents (Codex/Cursor over SSH) surface only spinner+cwd titles.
+  return containsBrailleSpinner(title) && Boolean(args.launchAgent)
+}
+
+export function shouldClearLaunchAgentAfterSplitPaneClose(args: {
+  tab: Pick<TerminalTab, 'launchAgent' | 'ptyId'> | null | undefined
+  closedPtyId: string | null | undefined
+  closedPaneId?: number | null
+  closedPaneKey: string | null
+  runtimePaneTitlesByPaneId?: Readonly<Record<number, string>>
+  survivingPaneKeys: readonly string[]
+  agentStatusByPaneKey: Readonly<Record<string, AgentStatusEntry>>
+}): boolean {
+  if (shouldClearLaunchAgentForClosedPane(args.tab, args.closedPtyId)) {
+    return true
+  }
+  if (!args.tab?.launchAgent || !args.closedPaneKey) {
+    return false
+  }
+  const closedPaneHadAgent =
+    args.closedPaneKey in args.agentStatusByPaneKey ||
+    closedPaneHostedTitleDerivedAgent({
+      closedPaneId: args.closedPaneId,
+      runtimePaneTitlesByPaneId: args.runtimePaneTitlesByPaneId,
+      launchAgent: args.tab.launchAgent
+    })
+  if (!closedPaneHadAgent) {
+    return false
+  }
+  const closedAgentType = resolveClosedPaneAgentType({
+    closedPaneKey: args.closedPaneKey,
+    closedPaneId: args.closedPaneId,
+    runtimePaneTitlesByPaneId: args.runtimePaneTitlesByPaneId,
+    launchAgent: args.tab.launchAgent,
+    agentStatusByPaneKey: args.agentStatusByPaneKey
+  })
+  return !survivingPaneHostsSameAgentType(
+    args.survivingPaneKeys,
+    args.agentStatusByPaneKey,
+    closedAgentType
+  )
+}
+
 export function resolveTabTitleAfterPaneClose(
   runtimePaneTitlesByPaneId: Readonly<Record<number, string>>,
-  activePaneId: number | null | undefined
+  activePaneId: number | null | undefined,
+  tab?: TabTitleFallbackFields | null
 ): string {
+  const survivorTitle =
+    activePaneId == null ? '' : (runtimePaneTitlesByPaneId[activePaneId]?.trim() ?? '')
+  if (survivorTitle) {
+    return survivorTitle
+  }
+
+  const stableTitle =
+    tab?.customTitle?.trim() || tab?.quickCommandLabel?.trim() || tab?.defaultTitle?.trim() || ''
+  if (stableTitle) {
+    return stableTitle
+  }
+
+  const liveTitle = tab?.title?.trim() ?? ''
+  if (liveTitle && classifyTitleActivity(liveTitle) === null) {
+    return liveTitle
+  }
+
   // Why: an empty update resets the tab to its stable fallback instead of
   // leaving the closed pane's agent title attached to an untitled survivor.
-  return activePaneId == null ? '' : (runtimePaneTitlesByPaneId[activePaneId] ?? '')
+  return ''
 }

--- a/src/renderer/src/components/terminal-pane/terminal-parked-pty-watcher.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-pty-watcher.ts
@@ -117,6 +117,12 @@ export function collapseParkedExitedLeaf(tabId: string, ptyId: string): void {
     state.clearTabLaunchAgent(tabId)
   }
   state.setTabLayout(tabId, detached.sourceLayout)
+  const survivingPaneIds = new Set(
+    [...(parkedWatchersByTabId.get(tabId)?.paneIdByPtyId.entries() ?? [])]
+      .filter(([candidatePtyId]) => candidatePtyId !== ptyId)
+      .map(([, paneId]) => paneId)
+  )
+  state.retainRuntimePaneTitlesForTab(tabId, survivingPaneIds)
   const activeLeafId = detached.sourceLayout.activeLeafId
   const activePtyId = activeLeafId
     ? detached.sourceLayout.ptyIdsByLeafId?.[activeLeafId]
@@ -126,6 +132,10 @@ export function collapseParkedExitedLeaf(tabId: string, ptyId: string): void {
     : null
   state.updateTabTitle(
     tabId,
-    resolveTabTitleAfterPaneClose(state.runtimePaneTitlesByTabId[tabId] ?? {}, activePaneId)
+    resolveTabTitleAfterPaneClose(
+      state.runtimePaneTitlesByTabId[tabId] ?? {},
+      activePaneId,
+      terminalTab
+    )
   )
 }

--- a/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parked-tab-watchers.test.ts
@@ -94,7 +94,7 @@ type MockStoreState = {
 let mockStoreState: MockStoreState
 
 vi.mock('@/store', () => ({
-  useAppStore: { getState: () => mockStoreState }
+  useAppStore: { getState: () => ({ ...mockStoreState, retainRuntimePaneTitlesForTab: vi.fn() }) }
 }))
 
 import {

--- a/src/renderer/src/components/terminal-pane/terminal-split-pane-agent-close-cleanup.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-split-pane-agent-close-cleanup.ts
@@ -1,0 +1,47 @@
+import { shouldClearLaunchAgentAfterSplitPaneClose } from '@/components/terminal-pane/terminal-pane-close-identity'
+import { detachTerminalLayoutLeaf } from '@/components/terminal-pane/terminal-layout-leaf-detach'
+import type { AppState } from '@/store/types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
+
+export function runTerminalSplitPaneAgentCloseCleanup(args: {
+  tabId: string
+  worktreeId: string
+  closedPaneId: number
+  closedLeafId: string
+  closedPtyId: string | null
+  survivingPaneIds: ReadonlySet<number>
+  survivingPaneKeys: readonly string[]
+  getState: () => AppState
+}): void {
+  const store = args.getState()
+  const terminalTab = store.tabsByWorktree[args.worktreeId]?.find(
+    (candidate) => candidate.id === args.tabId
+  )
+  const closedPaneKey = makePaneKey(args.tabId, args.closedLeafId)
+  const detachedLayout = detachTerminalLayoutLeaf(
+    store.terminalLayoutsByTabId[args.tabId],
+    args.closedLeafId
+  )
+  if (detachedLayout) {
+    store.setTabLayout(args.tabId, detachedLayout.sourceLayout)
+  }
+  if (
+    shouldClearLaunchAgentAfterSplitPaneClose({
+      tab: terminalTab as Pick<TerminalTab, 'launchAgent' | 'ptyId'> | undefined,
+      closedPtyId: args.closedPtyId,
+      closedPaneId: args.closedPaneId,
+      closedPaneKey,
+      runtimePaneTitlesByPaneId: store.runtimePaneTitlesByTabId[args.tabId] ?? {},
+      survivingPaneKeys: args.survivingPaneKeys,
+      agentStatusByPaneKey: store.agentStatusByPaneKey
+    })
+  ) {
+    store.clearTabLaunchAgent(args.tabId)
+  }
+  store.retireAgentPaneAuthority(closedPaneKey)
+  store.suppressTitleDerivedAgentLeaf(args.tabId, args.closedLeafId)
+  store.setCacheTimerStartedAt(closedPaneKey, null)
+  store.dropAgentStatus(closedPaneKey)
+  store.retainRuntimePaneTitlesForTab(args.tabId, args.survivingPaneIds)
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -145,6 +145,7 @@ import {
   resolveTabTitleAfterPaneClose,
   shouldClearLaunchAgentForClosedPane
 } from './terminal-pane-close-identity'
+import { runTerminalSplitPaneAgentCloseCleanup } from './terminal-split-pane-agent-close-cleanup'
 
 export function resetTerminalKeyboardProtocolAfterInterrupt(terminal: Terminal): void {
   // Guarded output path so a throwing xterm can't escape the key handler.
@@ -1259,7 +1260,23 @@ export function useTerminalPaneLifecycle({
         const terminalTab = useAppStore
           .getState()
           .tabsByWorktree[worktreeId]?.find((candidate) => candidate.id === tabId)
-        if (!isDetachedToTab && shouldClearLaunchAgentForClosedPane(terminalTab, closedPtyId)) {
+        const closedLeafId = closedPane?.leafId
+        if (closedLeafId && !isDetachedToTab) {
+          const survivingPanes = managerRef.current?.getPanes() ?? []
+          runTerminalSplitPaneAgentCloseCleanup({
+            tabId,
+            worktreeId,
+            closedPaneId: paneId,
+            closedLeafId,
+            closedPtyId,
+            survivingPaneIds: new Set(survivingPanes.map((pane) => pane.id)),
+            survivingPaneKeys: survivingPanes.map((pane) => makePaneKey(tabId, pane.leafId)),
+            getState: useAppStore.getState
+          })
+        } else if (
+          !isDetachedToTab &&
+          shouldClearLaunchAgentForClosedPane(terminalTab, closedPtyId)
+        ) {
           useAppStore.getState().clearTabLaunchAgent(tabId)
         }
         const panePtyBinding = panePtyBindings.get(paneId)
@@ -1302,7 +1319,13 @@ export function useTerminalPaneLifecycle({
           }
           paneTransportsRef.current.delete(paneId)
         }
-        clearRuntimePaneTitle(tabId, paneId)
+        if (!closedLeafId || isDetachedToTab) {
+          clearRuntimePaneTitle(tabId, paneId)
+          const survivingPaneIds = new Set(
+            managerRef.current?.getPanes().map((pane) => pane.id) ?? []
+          )
+          useAppStore.getState().retainRuntimePaneTitlesForTab(tabId, survivingPaneIds)
+        }
         paneFontSizesRef.current.delete(paneId)
         replayingPanesRef.current.delete(paneId)
         restoredViewportBlankingPanesRef.current.delete(paneId)
@@ -1329,7 +1352,10 @@ export function useTerminalPaneLifecycle({
         if (newActivePane) {
           reportActiveRendererPtyForPane(paneTransportsRef.current, newActivePane.id)
           const paneTitles = useAppStore.getState().runtimePaneTitlesByTabId[tabId] ?? {}
-          updateTabTitle(tabId, resolveTabTitleAfterPaneClose(paneTitles, newActivePane.id))
+          updateTabTitle(
+            tabId,
+            resolveTabTitleAfterPaneClose(paneTitles, newActivePane.id, terminalTab)
+          )
         }
         scheduleRuntimeGraphSync()
       },

--- a/src/renderer/src/lib/runtime-pane-title-leaf-id.test.ts
+++ b/src/renderer/src/lib/runtime-pane-title-leaf-id.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { TerminalLayoutSnapshot } from '../../../shared/types'
 import {
   resolveRuntimePaneTitleForLeaf,
+  resolveRuntimePaneTitleForLayoutLeaf,
   resolveRuntimePaneTitleLeafResolution
 } from './runtime-pane-title-leaf-id'
 
@@ -46,6 +47,38 @@ describe('resolveRuntimePaneTitleForLeaf', () => {
 
   it('uses a lone title when the tab has no resolved layout root', () => {
     expect(resolveRuntimePaneTitleForLeaf(undefined, { 7: 'Codex' }, LEAF_A)).toBe('Codex')
+  })
+})
+
+describe('resolveRuntimePaneTitleForLayoutLeaf', () => {
+  it('reads runtime titles through the live pane id bound to the leaf', () => {
+    expect(
+      resolveRuntimePaneTitleForLayoutLeaf(
+        {
+          ...leafLayout,
+          activeLeafId: null,
+          expandedLeafId: null,
+          paneIdsByLeafId: { [LEAF_A]: 1 }
+        },
+        { 1: 'Codex', 2: 'stale Codex' },
+        LEAF_A
+      )
+    ).toBe('Codex')
+  })
+
+  it('does not replay a lone closed-pane title onto an unmapped survivor leaf', () => {
+    expect(
+      resolveRuntimePaneTitleForLayoutLeaf(
+        {
+          root: { type: 'leaf', leafId: LEAF_B },
+          activeLeafId: LEAF_B,
+          expandedLeafId: null,
+          paneIdsByLeafId: { [LEAF_B]: 2 }
+        },
+        { 1: '⠋ Codex' },
+        LEAF_B
+      )
+    ).toBeNull()
   })
 })
 

--- a/src/renderer/src/lib/runtime-pane-title-leaf-id.ts
+++ b/src/renderer/src/lib/runtime-pane-title-leaf-id.ts
@@ -63,6 +63,24 @@ export function resolveRuntimePaneTitleForLeaf(
   return resolveRuntimePaneTitleLeafResolution(tabLayout, paneTitles, leafId).title
 }
 
+export function resolveRuntimePaneTitleForLayoutLeaf(
+  tabLayout: TerminalLayoutSnapshot | undefined,
+  paneTitles: Record<number, string> | undefined,
+  leafId: string
+): string | null {
+  const paneIdsByLeafId = tabLayout?.paneIdsByLeafId
+  const mappedPaneId = paneIdsByLeafId?.[leafId]
+  if (mappedPaneId != null) {
+    return paneTitles?.[mappedPaneId]?.trim() || null
+  }
+  // Why: once pane ids are bound per leaf, replay-order fallback must not
+  // attribute a closed pane's lone title to an unrelated survivor.
+  if (paneIdsByLeafId && Object.keys(paneIdsByLeafId).length > 0) {
+    return null
+  }
+  return resolveRuntimePaneTitleForLeaf(tabLayout, paneTitles, leafId)
+}
+
 export function resolveRuntimePaneTitleLeafResolution(
   tabLayout: { root?: TerminalLayoutSnapshot['root'] } | undefined,
   paneTitles: Record<number, string> | undefined,

--- a/src/renderer/src/lib/worktree-status-spinner-launch-agent.test.ts
+++ b/src/renderer/src/lib/worktree-status-spinner-launch-agent.test.ts
@@ -123,7 +123,7 @@ describe('#9040 spinner attribution matches named-provider dot/row agreement', (
 
   it('agrees for a spinner pane title too', () => {
     const tab = { id: 'tab-1', title: 'bash', launchAgent: 'claude' } satisfies Partial<TerminalTab>
-    const paneTitles = { 'tab-1': { 0: '⠙ refactoring the parser' } }
+    const paneTitles = { 'tab-1': { 1: '⠙ refactoring the parser' } }
     const layouts = { 'tab-1': singleLeafLayout() }
 
     expect(

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -536,6 +536,8 @@ export type TerminalSlice = {
   ptyIdsByTabId: Record<string, string[]>
   /** Live pane titles by tabId then paneId; preserves per-pane agent status (unlike the legacy tab title) while TerminalPane is mounted. */
   runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+  /** Split leaves tombstoned on agent-pane close so title-derived rows cannot resurrect them. */
+  suppressedTitleDerivedLeafIdsByTabId: Record<string, Record<string, true>>
   /** Per-tab unread flags (BEL or agent-complete); ephemeral UI state, not persisted. Cleared when the user activates/interacts with the tab. */
   unreadTerminalTabs: Record<string, true>
   /** Pane-keyed attention marker (narrower than unreadTerminalTabs); clears when the user interacts with the exact pane that raised it. */
@@ -672,6 +674,8 @@ export type TerminalSlice = {
   clearTabLaunchAgent: (tabId: string) => void
   setRuntimePaneTitle: (tabId: string, paneId: number, title: string) => void
   clearRuntimePaneTitle: (tabId: string, paneId: number) => void
+  retainRuntimePaneTitlesForTab: (tabId: string, survivingPaneIds: ReadonlySet<number>) => void
+  suppressTitleDerivedAgentLeaf: (tabId: string, leafId: string) => void
   /** Mark a tab unread (agent working→idle); skipped when the tab is visible, since a "seen" flag would never clear. */
   markTerminalTabUnread: (tabId: string) => void
   markTerminalPaneUnread: (paneKey: string) => void
@@ -998,6 +1002,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   activeTabIdByWorktree: {},
   ptyIdsByTabId: {},
   runtimePaneTitlesByTabId: {},
+  suppressedTitleDerivedLeafIdsByTabId: {},
   unreadTerminalTabs: {},
   unreadTerminalPanes: {},
   unreadAgentCompletionPanes: {},
@@ -1587,6 +1592,10 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       delete nextPendingReconnectPtyIdByTabId[tabId]
       const nextRuntimePaneTitlesByTabId = { ...s.runtimePaneTitlesByTabId }
       delete nextRuntimePaneTitlesByTabId[tabId]
+      const nextSuppressedTitleDerivedLeafIdsByTabId = {
+        ...s.suppressedTitleDerivedLeafIdsByTabId
+      }
+      delete nextSuppressedTitleDerivedLeafIdsByTabId[tabId]
       const nextDirectSshPaneRetryByTabId = { ...s.directSshPaneRetryByTabId }
       delete nextDirectSshPaneRetryByTabId[tabId]
       const nextDirectSshLivePtyBindingByTabId = {
@@ -1699,6 +1708,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         deferredSshSessionIdsByTabId: nextDeferredSshSessionIdsByTabId,
         pendingReconnectPtyIdByTabId: nextPendingReconnectPtyIdByTabId,
         runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId,
+        suppressedTitleDerivedLeafIdsByTabId: nextSuppressedTitleDerivedLeafIdsByTabId,
         directSshPaneRetryByTabId: nextDirectSshPaneRetryByTabId,
         directSshLivePtyBindingByTabId: nextDirectSshLivePtyBindingByTabId,
         directSshPaneRetryHistoryByTabId: nextDirectSshPaneRetryHistoryByTabId,
@@ -2092,6 +2102,60 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       return {
         runtimePaneTitlesByTabId: next,
         ...(shouldBump ? { sortEpoch: s.sortEpoch + 1 } : {})
+      }
+    })
+  },
+
+  retainRuntimePaneTitlesForTab: (tabId, survivingPaneIds) => {
+    set((s) => {
+      const currentByPane = s.runtimePaneTitlesByTabId[tabId]
+      if (!currentByPane) {
+        return s
+      }
+      const nextByPane: Record<number, string> = {}
+      let removedClassifiedTitle = false
+      for (const [paneId, title] of Object.entries(currentByPane)) {
+        const numericPaneId = Number(paneId)
+        if (!survivingPaneIds.has(numericPaneId)) {
+          if (classifyTitleActivity(title) !== null) {
+            removedClassifiedTitle = true
+          }
+          continue
+        }
+        nextByPane[numericPaneId] = title
+      }
+      if (Object.keys(nextByPane).length === Object.keys(currentByPane).length) {
+        return s
+      }
+      const next = { ...s.runtimePaneTitlesByTabId }
+      if (Object.keys(nextByPane).length > 0) {
+        next[tabId] = nextByPane
+      } else {
+        delete next[tabId]
+      }
+      const ownerWorktreeId = removedClassifiedTitle
+        ? getTerminalTabOwnerWorktreeId(s.tabsByWorktree, tabId)
+        : null
+      const isActive = ownerWorktreeId !== null && ownerWorktreeId === s.activeWorktreeId
+      const shouldBump = removedClassifiedTitle && ownerWorktreeId !== null && !isActive
+      return {
+        runtimePaneTitlesByTabId: next,
+        ...(shouldBump ? { sortEpoch: s.sortEpoch + 1 } : {})
+      }
+    })
+  },
+
+  suppressTitleDerivedAgentLeaf: (tabId, leafId) => {
+    set((s) => {
+      const current = s.suppressedTitleDerivedLeafIdsByTabId[tabId]
+      if (current?.[leafId]) {
+        return s
+      }
+      return {
+        suppressedTitleDerivedLeafIdsByTabId: {
+          ...s.suppressedTitleDerivedLeafIdsByTabId,
+          [tabId]: { ...current, [leafId]: true }
+        }
       }
     })
   },
@@ -3149,6 +3213,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const nextRuntimePaneTitlesByTabId = keepIdentifiers
         ? s.runtimePaneTitlesByTabId
         : { ...s.runtimePaneTitlesByTabId }
+      const nextSuppressedTitleDerivedLeafIdsByTabId = keepIdentifiers
+        ? s.suppressedTitleDerivedLeafIdsByTabId
+        : { ...s.suppressedTitleDerivedLeafIdsByTabId }
       const nextSuppressedPtyExitIds = {
         ...s.suppressedPtyExitIds,
         ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
@@ -3187,6 +3254,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       for (const tab of tabs) {
         if (!keepIdentifiers) {
           delete nextRuntimePaneTitlesByTabId[tab.id]
+          delete nextSuppressedTitleDerivedLeafIdsByTabId[tab.id]
         }
         delete nextPendingSetupSplitByTabId[tab.id]
         delete nextPendingIssueCommandSplitByTabId[tab.id]
@@ -3246,6 +3314,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ptyIdsByTabId: nextPtyIdsByTabId,
         lastKnownRelayPtyIdByTabId: nextLastKnownRelay,
         runtimePaneTitlesByTabId: nextRuntimePaneTitlesByTabId,
+        suppressedTitleDerivedLeafIdsByTabId: nextSuppressedTitleDerivedLeafIdsByTabId,
         suppressedPtyExitIds: nextSuppressedPtyExitIds,
         pendingPtyShutdownIds: nextPendingPtyShutdownIds,
         pendingCodexPaneRestartIds: nextPendingCodexPaneRestartIds,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1086,6 +1086,8 @@ export type TerminalLayoutSnapshot = {
   /** User-assigned pane titles, keyed by stable layout leaf UUID.
    *  Persisted alongside buffers via the existing session:set flow. */
   titlesByLeafId?: Record<string, string>
+  /** Live PaneManager numeric ids per layout leaf for runtime title lookup. */
+  paneIdsByLeafId?: Record<string, number>
 }
 
 /** Minimal subset of OpenFile persisted across restarts.

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -59,7 +59,8 @@ const terminalLayoutSnapshotSchema = z.object({
   ptyIdsByLeafId: z.record(z.string(), z.string()).optional(),
   buffersByLeafId: z.record(z.string(), z.string()).optional(),
   scrollbackRefsByLeafId: z.record(z.string(), z.string()).optional(),
-  titlesByLeafId: z.record(z.string(), z.string()).optional()
+  titlesByLeafId: z.record(z.string(), z.string()).optional(),
+  paneIdsByLeafId: z.record(z.string(), z.number()).optional()
 })
 
 // ─── Terminal tab (legacy) ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

When a split terminal pane is closed, title-derived agent rows are not cleaned up — they persist in the sidebar even though the associated pane no longer exists.

This PR ensures proper cleanup by:
- Tracking suppressed leaf IDs so cleaned-up rows are not re-synthesized
- Gating title fallback rows when pane titles existed but belong to removed panes
- Suppressing "polluted" tab titles (spinner + named agent) when no launchAgent backs the attribution
- Adding `retainRuntimePaneTitlesForTab` to prune stale runtime pane titles after pane close

Closes #11372.

## Screenshots

No visual change — title-derived agent rows are now properly cleared when their split pane is closed instead of lingering in the sidebar.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (3766 passed, 1 pre-existing integration test failure unrelated to changes)
- [x] `pnpm build`

## AI Review Report

Checked:
- Cross-platform compatibility: changes are in shared renderer logic with no platform-specific code paths
- SSH/remote compatibility: no SSH-specific code added; agent row resolution uses existing layout primitives
- Performance: added logic runs only during split pane close, not in hot paths
- Security: no new auth, input handling, or IPC surface

## Notes

- New `filterRuntimePaneTitlesToLayoutBindings` ensures pane titles map to live layout leaves before creating rows
- `resolveRuntimePaneTitleLeafIdFromRoot` validates pane IDs against `FIRST_PANE_ID` (≥1), which surfaced a pre-existing test using invalid pane ID 0