### PR TITLE
fix(terminal): harden remote parking restores under load

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -12300,7 +12300,7 @@ describe('registerPtyHandlers', () => {
         vi.advanceTimersByTime(1)
       }
       expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
-        rendererInFlightChars: 8 * 1024 * 1024,
+        rendererInFlightChars: 2 * 1024 * 1024,
         flushScheduled: false
       })
 
@@ -12519,7 +12519,7 @@ describe('registerPtyHandlers', () => {
       for (let index = 0; index < 400; index++) {
         vi.advanceTimersByTime(1)
       }
-      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(512)
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(128)
       expect(vi.getTimerCount()).toBe(0)
 
       writeListener(mainWindowIpcEvent, {
@@ -12528,8 +12528,8 @@ describe('registerPtyHandlers', () => {
       })
       interactiveProc.emitData('\x1b[20;2Hredraw')
 
-      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(513)
-      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(513, 'pty:data', {
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(129)
+      expect(mainWindow.webContents.send).toHaveBeenNthCalledWith(129, 'pty:data', {
         id: interactiveSpawn.id,
         data: '\x1b[20;2Hredraw'
       })
@@ -12543,7 +12543,7 @@ describe('registerPtyHandlers', () => {
         })
         interactiveProc.emitData(reserveChunk)
       }
-      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(529)
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(145)
 
       writeListener(mainWindowIpcEvent, {
         id: interactiveSpawn.id,
@@ -12551,7 +12551,7 @@ describe('registerPtyHandlers', () => {
       })
       interactiveProc.emitData(reserveChunk)
       // Why: reserve-exhausted send stays gated, and the fully gated arrival emits one delivery resync probe (not pty:data).
-      expect(getPtyDataSendCalls()).toHaveLength(529)
+      expect(getPtyDataSendCalls()).toHaveLength(145)
       expect(getDeliveryResyncProbeCalls()).toHaveLength(1)
     } finally {
       vi.useRealTimers()
@@ -12588,11 +12588,11 @@ describe('registerPtyHandlers', () => {
         vi.advanceTimersByTime(1)
       }
 
-      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(512)
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(128)
       ackData(null, { id: spawns[0].id, charCount: 16 * 1024 })
       vi.advanceTimersByTime(1)
 
-      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(513)
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(129)
     } finally {
       vi.useRealTimers()
     }
@@ -12625,7 +12625,7 @@ describe('registerPtyHandlers', () => {
       for (let index = 0; index < 400; index++) {
         vi.advanceTimersByTime(1)
       }
-      expect(getPtyDataSendCalls()).toHaveLength(512)
+      expect(getPtyDataSendCalls()).toHaveLength(128)
       expect(vi.getTimerCount()).toBe(0)
 
       mainWindow.webContents.send.mockClear()
@@ -12690,7 +12690,7 @@ describe('registerPtyHandlers', () => {
         vi.advanceTimersByTime(1)
       }
       expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
-        rendererInFlightChars: 8 * 1024 * 1024,
+        rendererInFlightChars: 2 * 1024 * 1024,
         flushScheduled: false
       })
 
@@ -12771,7 +12771,7 @@ describe('registerPtyHandlers', () => {
         vi.advanceTimersByTime(1)
       }
       expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
-        rendererInFlightChars: 8 * 1024 * 1024,
+        rendererInFlightChars: 2 * 1024 * 1024,
         flushScheduled: false
       })
 
@@ -12789,7 +12789,7 @@ describe('registerPtyHandlers', () => {
         ['pty:exit', { id: finalSpawn.id, code: 0, incarnationId: finalSpawn.incarnationId }]
       ])
       expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
-        rendererInFlightChars: 8 * 1024 * 1024,
+        rendererInFlightChars: 2 * 1024 * 1024,
         flushScheduled: false
       })
       expect(vi.getTimerCount()).toBe(timerCountBeforeExit)
@@ -12864,7 +12864,7 @@ describe('registerPtyHandlers', () => {
       for (let index = 0; index < 400; index++) {
         vi.advanceTimersByTime(1)
       }
-      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(512)
+      expect(mainWindow.webContents.send).toHaveBeenCalledTimes(128)
 
       const activeIndex = procs.length - 1
       procs[activeIndex]!.emitData('active-output')
@@ -12872,8 +12872,8 @@ describe('registerPtyHandlers', () => {
       vi.advanceTimersByTime(2)
 
       // Why: the fully gated arrival also emits a delivery resync probe, so count pty:data sends not raw webContents.send.
-      expect(getPtyDataSendCalls()).toHaveLength(513)
-      expect(getPtyDataSendCalls()[512]).toEqual([
+      expect(getPtyDataSendCalls()).toHaveLength(129)
+      expect(getPtyDataSendCalls()[128]).toEqual([
         'pty:data',
         {
           id: spawns[activeIndex]!.id,
@@ -12883,7 +12883,7 @@ describe('registerPtyHandlers', () => {
       expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
         activeRendererPtyCount: 1,
         pendingPtyCount: procs.length - 1,
-        rendererInFlightChars: 8 * 1024 * 1024 + 'active-output'.length
+        rendererInFlightChars: 2 * 1024 * 1024 + 'active-output'.length
       })
       ackData(null, { id: spawns[0]!.id, charCount: 16 * 1024 })
     } finally {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1885,7 +1885,8 @@ export function registerPtyHandlers(
   const PTY_BATCH_FLUSH_CHUNK_CHARS = 16 * 1024
   const PTY_BATCH_FLUSH_MAX_WRITES = 2
   const PTY_RENDERER_IN_FLIGHT_HIGH_WATER_CHARS = 512 * 1024
-  const PTY_RENDERER_TOTAL_IN_FLIGHT_HIGH_WATER_CHARS = 8 * 1024 * 1024
+  // Why 2 MiB: cap aggregate fan-in at the renderer queue budget; parse ACKs sustain healthy throughput.
+  const PTY_RENDERER_TOTAL_IN_FLIGHT_HIGH_WATER_CHARS = 2 * 1024 * 1024
   // Why: cap unbounded pendingData growth when the renderer can't receive (frozen/reloading); beyond it bytes drop and the pane heals from the main buffer snapshot via the droppedOutput sentinel (#7630).
   // Why read settings live: the cap scales with the user's scrollback so power users don't lose lines their scrollback would have retained.
   const pendingDataCapChars = (): number =>

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -93,6 +93,7 @@ import {
 } from './terminal-pane/terminal-hidden-view-parking'
 import {
   TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS,
+  selectTerminalLayoutPaneCountByTabId,
   selectForceParkEvictableTabIds,
   selectRetentionForceParkedTerminalWorktrees,
   type TerminalWorktreeRetentionCandidate
@@ -293,9 +294,11 @@ function Terminal(): React.JSX.Element | null {
   )
   const activeView = useAppStore((s) => s.activeView)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const terminalLayoutPaneCountByTabId = useAppStore(selectTerminalLayoutPaneCountByTabId)
   const pendingStartupByTabId = useAppStore((s) => s.pendingStartupByTabId)
   const terminalParkingEnabled = useAppStore((s) => s.settings?.terminalHiddenViewParking !== false)
   const terminalSshParkingEnabled = useAppStore((s) => s.settings?.terminalSshViewParking !== false)
+  const terminalScrollbackRows = useAppStore((s) => s.settings?.terminalScrollbackRows)
   const terminalRetentionBudgetEnabled = useAppStore(
     (s) => s.settings?.terminalHiddenWorktreeRetentionBudget !== false
   )
@@ -978,8 +981,8 @@ function Terminal(): React.JSX.Element | null {
         nextParkedTerminalWorktreeIds.delete(worktreeId)
       }
     }
-    // C1 retention budget: worktrees ordinary parking can never evict (SSH off,
-    // remote-runtime, uncoverable tabs) force-park beyond a count/TTL bound —
+    // Worktrees ordinary parking cannot evict (SSH off, remote-runtime,
+    // uncoverable tabs) force-park beyond the pane-weight budget or TTL —
     // added AFTER the coverage veto because darkness for their uncoverable tabs
     // is the accepted cost of bounding retention.
     const retentionBudgetCandidates: TerminalWorktreeRetentionCandidate[] = retentionCandidates.map(
@@ -1014,6 +1017,10 @@ function Terminal(): React.JSX.Element | null {
               pendingStartupByTabId[tab.id] !== undefined ||
               tab.pendingActivationSpawn === true ||
               (typeof tab.pendingActivationSpawn === 'number' && tab.pendingActivationSpawn > 0)
+          ),
+          retainedPaneCount: tabs.reduce(
+            (count, tab) => count + (terminalLayoutPaneCountByTabId[tab.id] ?? 1),
+            0
           )
         }
       }
@@ -1023,6 +1030,7 @@ function Terminal(): React.JSX.Element | null {
       parkingEnabled: terminalParkingEnabled,
       retentionBudgetEnabled: terminalRetentionBudgetEnabled,
       nowMs,
+      scrollbackRows: terminalScrollbackRows,
       ...overrides
     })
     const capturedForceParked = forceParkedCaptureDoneRef.current
@@ -1047,9 +1055,7 @@ function Terminal(): React.JSX.Element | null {
         // uses), so SSH classes whose reveal has no local snapshot still show
         // last-known content. includeLocalBuffers:false is required here, not
         // optional — a heap fix must not plant 512KB/pane of scrollback strings
-        // in the store for local worktrees that already have the daemon
-        // snapshot; a remote-runtime pane in a local repo likewise needs none,
-        // its reveal repaints from the runtime's own subscribe snapshot.
+        // in the store when the daemon/runtime already owns the snapshot.
         // Eviction-exempt tabs never unmount (per-tab exclusion), so they need
         // no pre-unmount capture — skipping spares a serialize+setTabLayout
         // walk on live panes per force-park episode.
@@ -1128,9 +1134,11 @@ function Terminal(): React.JSX.Element | null {
     pendingStartupByTabId,
     renderedActiveWorktreeId,
     tabsByWorktree,
+    terminalLayoutPaneCountByTabId,
     terminalParkingEnabled,
     terminalParkingRevision,
     terminalRetentionBudgetEnabled,
+    terminalScrollbackRows,
     terminalSshParkingEnabled,
     workspaceSurfaces
   ])

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -127,7 +127,10 @@ import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution
 import { safeFit, safeFitAndThen } from '@/lib/pane-manager/pane-tree-ops'
 import { applyDesktopFitFallbackAfterReplay } from './desktop-fit-fallback'
 import { clearTerminalScrollbackAndFollowOutput } from '@/lib/pane-manager/terminal-scrollback-clear'
-import { captureTerminalShutdownLayout } from './terminal-shutdown-layout-capture'
+import {
+  captureTerminalShutdownLayout,
+  selectRemoteRuntimeScrollbackLeafIds
+} from './terminal-shutdown-layout-capture'
 import { getOverrideAffectedPanes, getPanesNeedingOverrideFit } from './override-affected-panes'
 import {
   inspectRuntimeTerminalProcess,
@@ -200,7 +203,10 @@ function isInsideNativeChatRoot(target: EventTarget | null): boolean {
 }
 
 // Why: registry lives in a leaf module to break the slice → TerminalPane → store → slice import cycle that leaves createTerminalSlice undefined at init.
-import { shutdownBufferCaptures } from './shutdown-buffer-captures'
+import {
+  shutdownBufferCaptures,
+  type ShutdownBufferCaptureOptions
+} from './shutdown-buffer-captures'
 import { mergeCapturedLeafState } from './merge-captured-leaf-state'
 import { pasteTerminalText } from './terminal-bracketed-paste'
 import {
@@ -2370,7 +2376,7 @@ function TerminalPane(
 
   // Register a shutdown capture callback; App.tsx's beforeunload handler invokes all to serialize terminal buffers.
   useEffect(() => {
-    const captureBuffers = (options?: { includeLocalBuffers?: boolean }): void => {
+    const captureBuffers = (options?: ShutdownBufferCaptureOptions): void => {
       const manager = managerRef.current
       const container = containerRef.current
       if (!manager || !container) {
@@ -2384,19 +2390,29 @@ function TerminalPane(
       const state = useAppStore.getState()
       const existing = state.terminalLayoutsByTabId[tabId]
       const includeLocalBuffers = options?.includeLocalBuffers ?? true
+      const paneTransports = paneTransportsRef.current
       const shouldCaptureScrollbackBuffers = includeLocalBuffers
         ? true
         : shouldPreserveTerminalScrollbackBuffers(worktreeId, state.repos)
+      const excludedScrollbackLeafIds =
+        options?.excludeRemoteRuntimeScrollback === true
+          ? selectRemoteRuntimeScrollbackLeafIds({
+              panes,
+              paneTransports,
+              existingLayout: existing
+            })
+          : undefined
       const layout = captureTerminalShutdownLayout({
         manager,
         container,
         expandedPaneId: expandedPaneIdRef.current,
-        paneTransports: paneTransportsRef.current,
+        paneTransports,
         paneTitlesByPaneId: paneTitlesRef.current,
         existingLayout: existing,
         // Why: beforeunload skips local/floating bytes (session payloads prune them); worktree sleep keeps them as defense-in-depth.
         captureBuffers: shouldCaptureScrollbackBuffers,
-        clearedScrollbackLeafIds: clearedScrollbackLeafIdsRef.current
+        clearedScrollbackLeafIds: clearedScrollbackLeafIdsRef.current,
+        excludedScrollbackLeafIds
       })
       setTabLayout(tabId, layout)
       for (const pane of panes) {

--- a/src/renderer/src/components/terminal-pane/force-park-buffer-capture.test.ts
+++ b/src/renderer/src/components/terminal-pane/force-park-buffer-capture.test.ts
@@ -44,7 +44,10 @@ describe('captureForceParkedWorktreeBuffers', () => {
     })
 
     expect(captured).toBe(true)
-    expect(capture).toHaveBeenCalledWith({ includeLocalBuffers: false })
+    expect(capture).toHaveBeenCalledWith({
+      includeLocalBuffers: false,
+      excludeRemoteRuntimeScrollback: true
+    })
   })
 
   it('reports an incomplete episode when a tab has no registered capture', () => {

--- a/src/renderer/src/components/terminal-pane/force-park-buffer-capture.ts
+++ b/src/renderer/src/components/terminal-pane/force-park-buffer-capture.ts
@@ -23,7 +23,8 @@ export function captureForceParkedWorktreeBuffers({
     return true
   }
   const { requested, captured } = captureTerminalShutdownBuffersBestEffort(tabIds, {
-    includeLocalBuffers: false
+    includeLocalBuffers: false,
+    excludeRemoteRuntimeScrollback: true
   })
   return captured === requested
 }

--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts
@@ -44,6 +44,28 @@ describe('hidden output restore scheduler', () => {
     expect(secondRestore).toHaveBeenCalledTimes(1)
   })
 
+  it('waits for an inactive restore to finish before starting the next', async () => {
+    let settleFirst: (() => void) | undefined
+    const firstRestore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleFirst = resolve
+        })
+    )
+    const secondRestore = vi.fn()
+
+    scheduleHiddenOutputRestore({}, firstRestore, 'inactive')
+    scheduleHiddenOutputRestore({}, secondRestore, 'inactive')
+
+    await vi.advanceTimersByTimeAsync(160)
+    expect(firstRestore).toHaveBeenCalledTimes(1)
+    expect(secondRestore).not.toHaveBeenCalled()
+
+    settleFirst?.()
+    await vi.advanceTimersByTimeAsync(16)
+    expect(secondRestore).toHaveBeenCalledTimes(1)
+  })
+
   it('cancels pending inactive restore when a target is promoted', () => {
     const target = {}
     const inactiveRestore = vi.fn()
@@ -98,6 +120,45 @@ describe('hidden output restore scheduler', () => {
     vi.runOnlyPendingTimers()
 
     expect(requestRestore).not.toHaveBeenCalled()
+  })
+
+  it('releases a canceled inactive slot and ignores its stale completion', async () => {
+    const firstTarget = {}
+    let settleFirst: (() => void) | undefined
+    let settleSecond: (() => void) | undefined
+    const firstRestore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleFirst = resolve
+        })
+    )
+    const secondRestore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleSecond = resolve
+        })
+    )
+    const thirdRestore = vi.fn()
+
+    scheduleHiddenOutputRestore(firstTarget, firstRestore, 'inactive')
+    scheduleHiddenOutputRestore({}, secondRestore, 'inactive')
+    scheduleHiddenOutputRestore({}, thirdRestore, 'inactive')
+    await vi.advanceTimersByTimeAsync(16)
+
+    cancelScheduledHiddenOutputRestore(firstTarget)
+    await vi.advanceTimersByTimeAsync(16)
+
+    expect(firstRestore).toHaveBeenCalledTimes(1)
+    expect(secondRestore).toHaveBeenCalledTimes(1)
+    expect(thirdRestore).not.toHaveBeenCalled()
+
+    settleFirst?.()
+    await vi.advanceTimersByTimeAsync(160)
+    expect(thirdRestore).not.toHaveBeenCalled()
+
+    settleSecond?.()
+    await vi.advanceTimersByTimeAsync(16)
+    expect(thirdRestore).toHaveBeenCalledTimes(1)
   })
 
   it('releases active priority when its target is canceled', async () => {

--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts
@@ -57,6 +57,38 @@ describe('hidden output restore scheduler', () => {
     expect(activeRestore).toHaveBeenCalledTimes(1)
   })
 
+  it('waits for every active restore before draining inactive panes', async () => {
+    let settleFirst: (() => void) | undefined
+    let settleSecond: (() => void) | undefined
+    const inactiveRestore = vi.fn()
+    const firstActiveRestore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleFirst = resolve
+        })
+    )
+    const secondActiveRestore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleSecond = resolve
+        })
+    )
+
+    scheduleHiddenOutputRestore({}, inactiveRestore, 'inactive')
+    scheduleHiddenOutputRestore({}, firstActiveRestore, 'active')
+    scheduleHiddenOutputRestore({}, secondActiveRestore, 'active')
+    await vi.advanceTimersByTimeAsync(160)
+    expect(inactiveRestore).not.toHaveBeenCalled()
+
+    settleFirst?.()
+    await vi.advanceTimersByTimeAsync(160)
+    expect(inactiveRestore).not.toHaveBeenCalled()
+
+    settleSecond?.()
+    await vi.advanceTimersByTimeAsync(16)
+    expect(inactiveRestore).toHaveBeenCalledTimes(1)
+  })
+
   it('can cancel pending inactive restores', () => {
     const target = {}
     const requestRestore = vi.fn()
@@ -66,5 +98,51 @@ describe('hidden output restore scheduler', () => {
     vi.runOnlyPendingTimers()
 
     expect(requestRestore).not.toHaveBeenCalled()
+  })
+
+  it('releases active priority when its target is canceled', async () => {
+    const activeTarget = {}
+    const activeRestore = vi.fn(() => new Promise<void>(() => undefined))
+    const inactiveRestore = vi.fn()
+
+    scheduleHiddenOutputRestore(activeTarget, activeRestore, 'active')
+    scheduleHiddenOutputRestore({}, inactiveRestore, 'inactive')
+    cancelScheduledHiddenOutputRestore(activeTarget)
+    await vi.advanceTimersByTimeAsync(16)
+
+    expect(inactiveRestore).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores completion from a superseded active restore', async () => {
+    const activeTarget = {}
+    let settleFirst: (() => void) | undefined
+    let settleSecond: (() => void) | undefined
+    const inactiveRestore = vi.fn()
+
+    scheduleHiddenOutputRestore(
+      activeTarget,
+      () =>
+        new Promise<void>((resolve) => {
+          settleFirst = resolve
+        }),
+      'active'
+    )
+    scheduleHiddenOutputRestore(
+      activeTarget,
+      () =>
+        new Promise<void>((resolve) => {
+          settleSecond = resolve
+        }),
+      'active'
+    )
+    scheduleHiddenOutputRestore({}, inactiveRestore, 'inactive')
+
+    settleFirst?.()
+    await vi.advanceTimersByTimeAsync(160)
+    expect(inactiveRestore).not.toHaveBeenCalled()
+
+    settleSecond?.()
+    await vi.advanceTimersByTimeAsync(16)
+    expect(inactiveRestore).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.test.ts
@@ -44,6 +44,30 @@ describe('hidden output restore scheduler', () => {
     expect(secondRestore).toHaveBeenCalledTimes(1)
   })
 
+  it('promotes queued work whose priority becomes active before the drain', async () => {
+    let isActive = false
+    let settleActive: (() => void) | undefined
+    const inactiveRestore = vi.fn()
+    const promotedRestore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleActive = resolve
+        })
+    )
+
+    scheduleHiddenOutputRestore({}, inactiveRestore, 'inactive')
+    scheduleHiddenOutputRestore({}, promotedRestore, () => (isActive ? 'active' : 'inactive'))
+    isActive = true
+
+    await vi.advanceTimersByTimeAsync(16)
+    expect(promotedRestore).toHaveBeenCalledTimes(1)
+    expect(inactiveRestore).not.toHaveBeenCalled()
+
+    settleActive?.()
+    await vi.advanceTimersByTimeAsync(16)
+    expect(inactiveRestore).toHaveBeenCalledTimes(1)
+  })
+
   it('waits for an inactive restore to finish before starting the next', async () => {
     let settleFirst: (() => void) | undefined
     const firstRestore = vi.fn(

--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
@@ -113,12 +113,11 @@ function takeNextScheduledRestore(): {
     | {
         target: object
         entry: HiddenOutputRestoreEntry
-        priority: HiddenOutputRestorePriority
       }
     | undefined
   for (const [target, entry] of inactiveRestoreQueue) {
     const priority = resolveRestorePriority(entry.priority)
-    fallback ??= { target, entry, priority }
+    fallback ??= { target, entry }
     if (priority === 'active') {
       inactiveRestoreQueue.delete(target)
       return { target, entry, priority }
@@ -128,7 +127,7 @@ function takeNextScheduledRestore(): {
     return null
   }
   inactiveRestoreQueue.delete(fallback.target)
-  return fallback
+  return { ...fallback, priority: 'inactive' }
 }
 
 function drainInactiveRestoreQueue(): void {

--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
@@ -1,6 +1,6 @@
 type HiddenOutputRestorePriority = 'active' | 'inactive'
 
-type HiddenOutputRestoreRequest = () => void
+type HiddenOutputRestoreRequest = () => void | Promise<void>
 
 type HiddenOutputRestoreEntry = {
   requestRestore: HiddenOutputRestoreRequest
@@ -11,6 +11,8 @@ type HiddenOutputRestoreEntry = {
 const INACTIVE_RESTORE_INTERVAL_MS = 16
 
 const inactiveRestoreQueue = new Map<object, HiddenOutputRestoreEntry>()
+// Why: overlapping deep replays can starve the active pane the user is returning to.
+const activeRestoreTokensByTarget = new Map<object, object>()
 let inactiveRestoreTimer: ReturnType<typeof setTimeout> | null = null
 
 function clearInactiveRestoreTimer(): void {
@@ -22,14 +24,48 @@ function clearInactiveRestoreTimer(): void {
 }
 
 function scheduleInactiveRestoreDrain(): void {
-  if (inactiveRestoreTimer !== null || inactiveRestoreQueue.size === 0) {
+  if (
+    inactiveRestoreTimer !== null ||
+    activeRestoreTokensByTarget.size > 0 ||
+    inactiveRestoreQueue.size === 0
+  ) {
     return
   }
   inactiveRestoreTimer = setTimeout(drainInactiveRestoreQueue, INACTIVE_RESTORE_INTERVAL_MS)
 }
 
+function finishActiveRestore(target: object, token: object): void {
+  if (activeRestoreTokensByTarget.get(target) !== token) {
+    return
+  }
+  activeRestoreTokensByTarget.delete(target)
+  scheduleInactiveRestoreDrain()
+}
+
+function runActiveRestore(target: object, requestRestore: HiddenOutputRestoreRequest): void {
+  const token = {}
+  activeRestoreTokensByTarget.set(target, token)
+  try {
+    const completion = requestRestore()
+    if (completion) {
+      void completion.then(
+        () => finishActiveRestore(target, token),
+        () => finishActiveRestore(target, token)
+      )
+      return
+    }
+  } catch (error) {
+    finishActiveRestore(target, token)
+    throw error
+  }
+  finishActiveRestore(target, token)
+}
+
 function drainInactiveRestoreQueue(): void {
   inactiveRestoreTimer = null
+  if (activeRestoreTokensByTarget.size > 0) {
+    return
+  }
   const next = inactiveRestoreQueue.entries().next()
   if (next.done) {
     return
@@ -47,7 +83,7 @@ export function scheduleHiddenOutputRestore(
 ): void {
   if (priority === 'active') {
     cancelScheduledHiddenOutputRestore(target)
-    requestRestore()
+    runActiveRestore(target, requestRestore)
     return
   }
   inactiveRestoreQueue.set(target, { requestRestore })
@@ -56,12 +92,17 @@ export function scheduleHiddenOutputRestore(
 
 export function cancelScheduledHiddenOutputRestore(target: object): void {
   inactiveRestoreQueue.delete(target)
+  const activeToken = activeRestoreTokensByTarget.get(target)
+  if (activeToken) {
+    finishActiveRestore(target, activeToken)
+  }
   if (inactiveRestoreQueue.size === 0) {
     clearInactiveRestoreTimer()
   }
 }
 
 export function resetHiddenOutputRestoreSchedulerForTests(): void {
+  activeRestoreTokensByTarget.clear()
   inactiveRestoreQueue.clear()
   clearInactiveRestoreTimer()
 }

--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
@@ -6,6 +6,11 @@ type HiddenOutputRestoreEntry = {
   requestRestore: HiddenOutputRestoreRequest
 }
 
+type InactiveHiddenOutputRestore = {
+  target: object
+  token: object
+}
+
 // Why: one inactive xterm scrollback replay per frame keeps tab return focused
 // on the active pane while still catching watched split panes up quickly.
 const INACTIVE_RESTORE_INTERVAL_MS = 16
@@ -13,6 +18,7 @@ const INACTIVE_RESTORE_INTERVAL_MS = 16
 const inactiveRestoreQueue = new Map<object, HiddenOutputRestoreEntry>()
 // Why: overlapping deep replays can starve the active pane the user is returning to.
 const activeRestoreTokensByTarget = new Map<object, object>()
+let inactiveRestore: InactiveHiddenOutputRestore | null = null
 let inactiveRestoreTimer: ReturnType<typeof setTimeout> | null = null
 
 function clearInactiveRestoreTimer(): void {
@@ -26,6 +32,7 @@ function clearInactiveRestoreTimer(): void {
 function scheduleInactiveRestoreDrain(): void {
   if (
     inactiveRestoreTimer !== null ||
+    inactiveRestore !== null ||
     activeRestoreTokensByTarget.size > 0 ||
     inactiveRestoreQueue.size === 0
   ) {
@@ -61,9 +68,36 @@ function runActiveRestore(target: object, requestRestore: HiddenOutputRestoreReq
   finishActiveRestore(target, token)
 }
 
+function finishInactiveRestore(target: object, token: object): void {
+  if (inactiveRestore?.target !== target || inactiveRestore.token !== token) {
+    return
+  }
+  inactiveRestore = null
+  scheduleInactiveRestoreDrain()
+}
+
+function runInactiveRestore(target: object, requestRestore: HiddenOutputRestoreRequest): void {
+  const token = {}
+  inactiveRestore = { target, token }
+  try {
+    const completion = requestRestore()
+    if (completion) {
+      void completion.then(
+        () => finishInactiveRestore(target, token),
+        () => finishInactiveRestore(target, token)
+      )
+      return
+    }
+  } catch (error) {
+    finishInactiveRestore(target, token)
+    throw error
+  }
+  finishInactiveRestore(target, token)
+}
+
 function drainInactiveRestoreQueue(): void {
   inactiveRestoreTimer = null
-  if (activeRestoreTokensByTarget.size > 0) {
+  if (inactiveRestore !== null || activeRestoreTokensByTarget.size > 0) {
     return
   }
   const next = inactiveRestoreQueue.entries().next()
@@ -72,8 +106,7 @@ function drainInactiveRestoreQueue(): void {
   }
   const [target, entry] = next.value
   inactiveRestoreQueue.delete(target)
-  entry.requestRestore()
-  scheduleInactiveRestoreDrain()
+  runInactiveRestore(target, entry.requestRestore)
 }
 
 export function scheduleHiddenOutputRestore(
@@ -92,6 +125,10 @@ export function scheduleHiddenOutputRestore(
 
 export function cancelScheduledHiddenOutputRestore(target: object): void {
   inactiveRestoreQueue.delete(target)
+  const inactiveToken = inactiveRestore?.target === target ? inactiveRestore.token : null
+  if (inactiveToken) {
+    finishInactiveRestore(target, inactiveToken)
+  }
   const activeToken = activeRestoreTokensByTarget.get(target)
   if (activeToken) {
     finishActiveRestore(target, activeToken)
@@ -103,6 +140,7 @@ export function cancelScheduledHiddenOutputRestore(target: object): void {
 
 export function resetHiddenOutputRestoreSchedulerForTests(): void {
   activeRestoreTokensByTarget.clear()
+  inactiveRestore = null
   inactiveRestoreQueue.clear()
   clearInactiveRestoreTimer()
 }

--- a/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
+++ b/src/renderer/src/components/terminal-pane/hidden-output-restore-scheduler.ts
@@ -1,9 +1,12 @@
 type HiddenOutputRestorePriority = 'active' | 'inactive'
 
+type HiddenOutputRestorePriorityResolver = () => HiddenOutputRestorePriority
+
 type HiddenOutputRestoreRequest = () => void | Promise<void>
 
 type HiddenOutputRestoreEntry = {
   requestRestore: HiddenOutputRestoreRequest
+  priority: HiddenOutputRestorePriority | HiddenOutputRestorePriorityResolver
 }
 
 type InactiveHiddenOutputRestore = {
@@ -95,31 +98,66 @@ function runInactiveRestore(target: object, requestRestore: HiddenOutputRestoreR
   finishInactiveRestore(target, token)
 }
 
+function resolveRestorePriority(
+  priority: HiddenOutputRestorePriority | HiddenOutputRestorePriorityResolver
+): HiddenOutputRestorePriority {
+  return typeof priority === 'function' ? priority() : priority
+}
+
+function takeNextScheduledRestore(): {
+  target: object
+  entry: HiddenOutputRestoreEntry
+  priority: HiddenOutputRestorePriority
+} | null {
+  let fallback:
+    | {
+        target: object
+        entry: HiddenOutputRestoreEntry
+        priority: HiddenOutputRestorePriority
+      }
+    | undefined
+  for (const [target, entry] of inactiveRestoreQueue) {
+    const priority = resolveRestorePriority(entry.priority)
+    fallback ??= { target, entry, priority }
+    if (priority === 'active') {
+      inactiveRestoreQueue.delete(target)
+      return { target, entry, priority }
+    }
+  }
+  if (!fallback) {
+    return null
+  }
+  inactiveRestoreQueue.delete(fallback.target)
+  return fallback
+}
+
 function drainInactiveRestoreQueue(): void {
   inactiveRestoreTimer = null
   if (inactiveRestore !== null || activeRestoreTokensByTarget.size > 0) {
     return
   }
-  const next = inactiveRestoreQueue.entries().next()
-  if (next.done) {
+  const next = takeNextScheduledRestore()
+  if (!next) {
     return
   }
-  const [target, entry] = next.value
-  inactiveRestoreQueue.delete(target)
-  runInactiveRestore(target, entry.requestRestore)
+  if (next.priority === 'active') {
+    runActiveRestore(next.target, next.entry.requestRestore)
+    return
+  }
+  runInactiveRestore(next.target, next.entry.requestRestore)
 }
 
 export function scheduleHiddenOutputRestore(
   target: object,
   requestRestore: HiddenOutputRestoreRequest,
-  priority: HiddenOutputRestorePriority
+  priority: HiddenOutputRestorePriority | HiddenOutputRestorePriorityResolver
 ): void {
-  if (priority === 'active') {
+  if (resolveRestorePriority(priority) === 'active') {
     cancelScheduledHiddenOutputRestore(target)
     runActiveRestore(target, requestRestore)
     return
   }
-  inactiveRestoreQueue.set(target, { requestRestore })
+  inactiveRestoreQueue.set(target, { requestRestore, priority })
   scheduleInactiveRestoreDrain()
 }
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -192,6 +192,7 @@ type StoreState = {
     localWindowsRuntimeDefault?: { kind: 'windows-host' } | { kind: 'wsl'; distro: string | null }
     terminalMainSideEffectAuthority?: boolean
     terminalHiddenDeliveryGate?: boolean
+    terminalSshViewParking?: boolean
     notifications?: {
       enabled?: boolean
       agentTaskComplete?: boolean
@@ -19896,9 +19897,13 @@ describe('connectPanePty', () => {
 
     const pane = createPane(1)
     const { writes } = captureCallbackTerminalWrites(pane)
+    pane.terminal.write(
+      `captured-early-marker\r\n${Array.from({ length: 12 }, (_, index) => `captured-${index}\r\n`).join('')}`
+    )
     const deps = createDeps({
       restoredLeafId: LEAF_1,
-      restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId }
+      restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId },
+      restoredViewportBlankingPanesRef: { current: new Set([1]) }
     })
 
     connectPanePty(pane as never, createManager(1) as never, deps as never)
@@ -19913,6 +19918,11 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(20)
 
     expect(writes).toContain('relay-fallback-output')
+    expect(writes).toContain('\x1b[2J\x1b[H')
+    expect(writes).not.toContain('\x1b[2J\x1b[3J\x1b[H')
+    expect((await renderHeadlessBuffer(writes, 80, 6)).join('\n')).toContain(
+      'captured-early-marker'
+    )
     // Why: a stalled reveal must cost exactly one bounded probe — a re-probe
     // would buy a second timeout window before the relay paint.
     expect(window.api.pty.getMainBufferSnapshot).toHaveBeenCalledTimes(1)
@@ -19952,6 +19962,47 @@ describe('connectPanePty', () => {
 
     expect(window.api.pty.getMainBufferSnapshot).not.toHaveBeenCalled()
     expect(writes).toContain('relay-reconnect-output')
+  })
+
+  it('preserves restored scrollback through relay replay without a parked watcher', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const sshPtyId = toAppSshPtyId('conn-1', 'relay-pty-1')
+    const transport = createMockTransport(sshPtyId)
+    transport.connect.mockImplementation(async () => {
+      transport.getPtyId.mockReturnValue(sshPtyId)
+      return { id: sshPtyId, isReattach: true, replay: 'relay-reconnect-output' }
+    })
+    transportFactoryQueue.push(transport)
+
+    mockStoreState = {
+      ...mockStoreState,
+      settings: { ...mockStoreState.settings, terminalSshViewParking: false },
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      repos: [{ id: 'repo1', connectionId: 'conn-1' }],
+      deferredSshReconnectTargets: ['conn-1'],
+      deferredSshSessionIdsByTabId: { 'tab-1': sshPtyId }
+    }
+
+    const pane = createPane(1)
+    const { writes } = captureCallbackTerminalWrites(pane)
+    pane.terminal.write(
+      `captured-early-marker\r\n${Array.from({ length: 12 }, (_, index) => `captured-${index}\r\n`).join('')}`
+    )
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: sshPtyId },
+      restoredViewportBlankingPanesRef: { current: new Set([1]) }
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(window.api.pty.getMainBufferSnapshot).not.toHaveBeenCalled()
+    expect(writes).toContain('\x1b[2J\x1b[H')
+    expect(writes).not.toContain('\x1b[2J\x1b[3J\x1b[H')
+    expect((await renderHeadlessBuffer(writes, 80, 6)).join('\n')).toContain(
+      'captured-early-marker'
+    )
   })
 
   it('does not auto-reconnect after a user cancels deferred SSH passphrase auth', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -14003,12 +14003,21 @@ describe('connectPanePty', () => {
       const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
         typeof vi.fn
       >
-      getMainBufferSnapshot.mockResolvedValue({
+      const promotedSnapshot = {
         data: 'promoted snapshot\r\n',
         cols: 100,
         rows: 30,
         seq: 64
-      })
+      }
+      const promotedSnapshotResolver: {
+        current: ((snapshot: typeof promotedSnapshot) => void) | null
+      } = { current: null }
+      getMainBufferSnapshot.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            promotedSnapshotResolver.current = resolve
+          })
+      )
 
       const pane = createPane(1)
       const manager = createManager(1, 1)
@@ -14036,6 +14045,9 @@ describe('connectPanePty', () => {
 
       expect(blockingRestore).not.toHaveBeenCalled()
       expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+      expect(promotedSnapshotResolver.current).not.toBeNull()
+      promotedSnapshotResolver.current?.(promotedSnapshot)
+      await flushAsyncTicks(20)
       expect(pane.terminal.write).toHaveBeenCalledWith(
         expect.stringContaining('promoted snapshot'),
         expect.any(Function)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -11104,6 +11104,54 @@ describe('connectPanePty', () => {
       )
     })
 
+    it('releases post-snapshot live bytes when the active split stays layout-collapsed', async () => {
+      enableMainAuthority()
+      const deps = createDeps({ isVisibleRef: { current: false } })
+      const { pane, transport, dataCallback } = await connectHiddenPane(deps)
+      vi.useFakeTimers()
+      Object.defineProperties(pane.container, {
+        isConnected: { configurable: true, value: true },
+        offsetParent: { configurable: true, value: {} },
+        getBoundingClientRect: {
+          configurable: true,
+          value: () => ({ width: 0, height: 0 })
+        }
+      })
+      const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+        typeof vi.fn
+      >
+      getMainBufferSnapshot.mockResolvedValue({
+        data: 'source-grid hidden snapshot\r\n',
+        cols: 80,
+        rows: 24,
+        seq: 64
+      })
+      pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 2, rows: 1 })) as never
+      transport.resize.mockClear()
+
+      dataCallback('hidden output\r\n', { seq: 16, rawLength: 16 })
+      const { _dispatchPtyModelRestoreNeededForTest } = await import('./pty-model-restore-channel')
+      _dispatchPtyModelRestoreNeededForTest({ id: 'pty-id', reason: 'hidden-drop', markerSeq: 64 })
+      ;(deps.isVisibleRef as { current: boolean }).current = true
+      const { requestTerminalBacklogRecovery } =
+        await import('@/lib/pane-manager/pane-terminal-output-scheduler')
+      requestTerminalBacklogRecovery(pane.terminal as never)
+      await flushAsyncTicks(20)
+
+      dataCallback('live-after-collapsed-restore', { seq: 92, rawLength: 28 })
+      expect(pane.terminal.write.mock.calls.map((call) => String(call[0])).join('')).not.toContain(
+        'live-after-collapsed-restore'
+      )
+
+      await vi.advanceTimersByTimeAsync(128)
+      await flushAsyncTicks(20)
+
+      expect(transport.resize).not.toHaveBeenCalled()
+      expect(pane.terminal.write.mock.calls.map((call) => String(call[0])).join('')).toContain(
+        'live-after-collapsed-restore'
+      )
+    })
+
     it('kicks pane recovery when reveal finds the write pipeline certified dead', async () => {
       // 2026-07-13 fossil-pane incident: bytes drop while hidden, pipeline certified dead, cert recovery empty — reveal must re-kick it.
       enableMainAuthority()
@@ -13927,6 +13975,69 @@ describe('connectPanePty', () => {
       expect(pane.terminal.write).not.toHaveBeenCalledWith(hidden)
       expect(pane.terminal.write).toHaveBeenCalledWith(
         expect.stringContaining('inactive snapshot'),
+        expect.any(Function)
+      )
+    } finally {
+      disposable?.dispose()
+      resetHiddenOutputRestoreSchedulerForTests()
+    }
+  })
+
+  it('promotes a deferred hidden restore when its pane becomes active before the drain', async () => {
+    const { resetHiddenOutputRestoreSchedulerForTests, scheduleHiddenOutputRestore } =
+      await import('./hidden-output-restore-scheduler')
+    let disposable: { dispose: () => void } | null = null
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport('pty-id')
+      const capturedDataCallback: {
+        current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+      } = { current: null }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+      const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+        typeof vi.fn
+      >
+      getMainBufferSnapshot.mockResolvedValue({
+        data: 'promoted snapshot\r\n',
+        cols: 100,
+        rows: 30,
+        seq: 64
+      })
+
+      const pane = createPane(1)
+      const manager = createManager(1, 1)
+      const deps = createDeps({
+        isActiveRef: { current: false },
+        isVisibleRef: { current: false }
+      })
+      disposable = connectPanePty(pane as never, manager as never, deps as never)
+      await flushAsyncTicks(6)
+
+      const blockingRestore = vi.fn(() => new Promise<void>(() => undefined))
+      scheduleHiddenOutputRestore({}, blockingRestore, 'inactive')
+      const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+      const live = 'visible promoted output\r\n'
+      capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+      ;(deps.isVisibleRef as { current: boolean }).current = true
+      capturedDataCallback.current?.(live, {
+        seq: hidden.length + live.length,
+        rawLength: live.length
+      })
+      ;(deps.isActiveRef as { current: boolean }).current = true
+
+      await new Promise((resolve) => setTimeout(resolve, 30))
+      await flushAsyncTicks(20)
+
+      expect(blockingRestore).not.toHaveBeenCalled()
+      expect(getMainBufferSnapshot).toHaveBeenCalledWith('pty-id', { scrollbackRows: 5000 })
+      expect(pane.terminal.write).toHaveBeenCalledWith(
+        expect.stringContaining('promoted snapshot'),
         expect.any(Function)
       )
     } finally {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7663,6 +7663,8 @@ export function connectPanePty(
       const revealFollowsTerminalPark =
         mountFollowsTerminalPark && connectResult?.isReattach === true
       mountFollowsTerminalPark = false
+      const hasRestoredScrollback =
+        deps.restoredViewportBlankingPanesRef?.current.has(pane.id) ?? false
       // Why: a relay restart empties the replay buffer, but main's model may
       // still hold the session — a park-reveal probes it even with no replay
       // so the reveal is never blank when main has content. Prefetched (before
@@ -7769,8 +7771,8 @@ export function connectPanePty(
             }
           } else if (connectResult?.replay) {
             rememberReattachPayloadAgentSignal(connectResult.replay, { fullScreenReplay: true })
-            // Relay replay may overlap xterm's pre-disconnect content; clear first to avoid duplication.
-            writeReplayData('\x1b[2J\x1b[3J\x1b[H')
+            // A restored capture may be the only history outside the relay's 100KiB tail.
+            writeReplayData(hasRestoredScrollback ? '\x1b[2J\x1b[H' : '\x1b[2J\x1b[3J\x1b[H')
             // Why: raw relay replay may contain the app's own kitty pushes; re-arm with set semantics so redelivery can't grow the stack.
             kittyKeyboardModes.scanReplay(connectResult.replay)
             writeReplayData(connectResult.replay)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7048,6 +7048,16 @@ export function connectPanePty(
         }
         cancelScheduledHiddenOutputRestore(pane.terminal)
         hiddenOutputRestoreScheduled = false
+        let restoreRequested = false
+        scheduleHiddenOutputRestore(
+          pane.terminal,
+          () => {
+            restoreRequested = requestHiddenOutputRestoreIfNeeded({ bypassScheduler: true })
+            return hiddenOutputRestoreInFlight ?? undefined
+          },
+          priority
+        )
+        return restoreRequested
       }
       clearHiddenOutputRestoreDeferredRetryTimer()
       hiddenOutputRestoreRetryDeferred = false

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7070,10 +7070,11 @@ export function connectPanePty(
                 ) {
                   return
                 }
-                requestHiddenOutputRestoreIfNeeded({
+                const restoreRequested = requestHiddenOutputRestoreIfNeeded({
                   bypassScheduler: true,
                   debugPriority: priority
                 })
+                return restoreRequested ? (hiddenOutputRestoreInFlight ?? undefined) : undefined
               },
               priority
             )

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -504,10 +504,6 @@ type E2eTerminalPtyOutputDebugSnapshot = {
   hiddenRendererSkipCount: number
   hiddenRendererSkippedChars: number
   hiddenRendererMode2031ReplyCount: number
-  activeHiddenRestoreCount: number
-  activeHiddenRestoreSnapshotMs: number
-  activeHiddenRestoreReplayMs: number
-  activeHiddenRestoreTotalMs: number
 }
 
 type E2eTerminalPtyOutputDebugApi = {
@@ -541,21 +537,13 @@ type ColdRestoreAgentResumeStartup = PendingStartupCommand & {
 const e2eTerminalPtyOutputDebugState: E2eTerminalPtyOutputDebugSnapshot = {
   hiddenRendererSkipCount: 0,
   hiddenRendererSkippedChars: 0,
-  hiddenRendererMode2031ReplyCount: 0,
-  activeHiddenRestoreCount: 0,
-  activeHiddenRestoreSnapshotMs: 0,
-  activeHiddenRestoreReplayMs: 0,
-  activeHiddenRestoreTotalMs: 0
+  hiddenRendererMode2031ReplyCount: 0
 }
 
 function resetE2eTerminalPtyOutputDebug(): void {
   e2eTerminalPtyOutputDebugState.hiddenRendererSkipCount = 0
   e2eTerminalPtyOutputDebugState.hiddenRendererSkippedChars = 0
   e2eTerminalPtyOutputDebugState.hiddenRendererMode2031ReplyCount = 0
-  e2eTerminalPtyOutputDebugState.activeHiddenRestoreCount = 0
-  e2eTerminalPtyOutputDebugState.activeHiddenRestoreSnapshotMs = 0
-  e2eTerminalPtyOutputDebugState.activeHiddenRestoreReplayMs = 0
-  e2eTerminalPtyOutputDebugState.activeHiddenRestoreTotalMs = 0
 }
 
 function exposeE2eTerminalPtyOutputDebug(): void {
@@ -584,22 +572,6 @@ function recordHiddenMode2031Reply(): void {
   }
   exposeE2eTerminalPtyOutputDebug()
   e2eTerminalPtyOutputDebugState.hiddenRendererMode2031ReplyCount += 1
-}
-
-function recordActiveHiddenRestoreTiming(
-  priority: 'active' | 'inactive' | undefined,
-  snapshotMs: number,
-  replayMs: number,
-  totalMs: number
-): void {
-  if (!e2eConfig.exposeStore || priority !== 'active') {
-    return
-  }
-  exposeE2eTerminalPtyOutputDebug()
-  e2eTerminalPtyOutputDebugState.activeHiddenRestoreCount += 1
-  e2eTerminalPtyOutputDebugState.activeHiddenRestoreSnapshotMs = snapshotMs
-  e2eTerminalPtyOutputDebugState.activeHiddenRestoreReplayMs = replayMs
-  e2eTerminalPtyOutputDebugState.activeHiddenRestoreTotalMs = totalMs
 }
 
 function exposeE2eTerminalPtyDataInjection(): void {
@@ -7014,10 +6986,7 @@ export function connectPanePty(
       }
     }
 
-    function requestHiddenOutputRestoreIfNeeded(opts?: {
-      bypassScheduler?: boolean
-      debugPriority?: 'active' | 'inactive'
-    }): boolean {
+    function requestHiddenOutputRestoreIfNeeded(opts?: { bypassScheduler?: boolean }): boolean {
       // Why: once the write pipeline is probe-certified dead a restore can never parse; recovery owns the pane and the remount gets a fresh xterm + restore.
       if (isTerminalWritePipelineCertifiedDead(pane.terminal)) {
         // Why the re-kick: certification's recovery request can be budget-declined or cancelled by a sibling remount; without this, a revealed dead pane keeps the stale frame forever.
@@ -7048,7 +7017,9 @@ export function connectPanePty(
         return true
       }
       if (!opts?.bypassScheduler) {
-        const priority = isActiveSplitPane() ? 'active' : 'inactive'
+        const resolvePriority = (): 'active' | 'inactive' =>
+          isActiveSplitPane() ? 'active' : 'inactive'
+        const priority = resolvePriority()
         if (priority === 'inactive') {
           if (!hiddenOutputRestoreScheduled) {
             hiddenOutputRestoreScheduled = true
@@ -7071,12 +7042,11 @@ export function connectPanePty(
                   return
                 }
                 const restoreRequested = requestHiddenOutputRestoreIfNeeded({
-                  bypassScheduler: true,
-                  debugPriority: priority
+                  bypassScheduler: true
                 })
                 return restoreRequested ? (hiddenOutputRestoreInFlight ?? undefined) : undefined
               },
-              priority
+              resolvePriority
             )
           }
           return true
@@ -7087,10 +7057,7 @@ export function connectPanePty(
         scheduleHiddenOutputRestore(
           pane.terminal,
           () => {
-            restoreRequested = requestHiddenOutputRestoreIfNeeded({
-              bypassScheduler: true,
-              debugPriority: priority
-            })
+            restoreRequested = requestHiddenOutputRestoreIfNeeded({ bypassScheduler: true })
             return hiddenOutputRestoreInFlight ?? undefined
           },
           priority
@@ -7099,9 +7066,6 @@ export function connectPanePty(
       }
       clearHiddenOutputRestoreDeferredRetryTimer()
       hiddenOutputRestoreRetryDeferred = false
-      const restoreStartedAt = performance.now()
-      let restoreSnapshotMs = 0
-      let restoreReplayMs = 0
 
       hiddenOutputRestoreInFlight = (async () => {
         // Backstop (rc.7.perf loop): bound how many snapshot fetch+replay rounds one task burns before yielding to the live stream.
@@ -7128,15 +7092,12 @@ export function connectPanePty(
           const restoreGeneration = hiddenOutputRestoreGeneration
           hiddenOutputRestoreNeeded = false
           let snapshot: PtyBufferSnapshot | null = null
-          const snapshotStartedAt = performance.now()
           try {
             snapshot = await serializeHiddenOutputSnapshot(currentPtyId, {
               scrollbackRows: resolveHiddenRestoreScrollbackRows(pane.terminal.options.scrollback)
             })
           } catch {
             snapshot = null
-          } finally {
-            restoreSnapshotMs += performance.now() - snapshotStartedAt
           }
           if (disposed) {
             return
@@ -7160,12 +7121,7 @@ export function connectPanePty(
           }
           hiddenOutputRestoreDeferredRetryAttempts = 0
           restoreIterations += 1
-          const replayStartedAt = performance.now()
-          try {
-            await applyMainBufferSnapshot(snapshot)
-          } finally {
-            restoreReplayMs += performance.now() - replayStartedAt
-          }
+          await applyMainBufferSnapshot(snapshot)
           if (
             disposed ||
             hiddenOutputRestoreGeneration !== restoreGeneration ||
@@ -7217,12 +7173,6 @@ export function connectPanePty(
       const hiddenOutputRestoreTask = hiddenOutputRestoreInFlight
       let trackedHiddenOutputRestore: Promise<void>
       trackedHiddenOutputRestore = hiddenOutputRestoreTask.finally(() => {
-        recordActiveHiddenRestoreTiming(
-          opts?.debugPriority,
-          restoreSnapshotMs,
-          restoreReplayMs,
-          performance.now() - restoreStartedAt
-        )
         if (hiddenOutputRestoreInFlight === trackedHiddenOutputRestore) {
           hiddenOutputRestoreInFlight = null
         }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -504,6 +504,10 @@ type E2eTerminalPtyOutputDebugSnapshot = {
   hiddenRendererSkipCount: number
   hiddenRendererSkippedChars: number
   hiddenRendererMode2031ReplyCount: number
+  activeHiddenRestoreCount: number
+  activeHiddenRestoreSnapshotMs: number
+  activeHiddenRestoreReplayMs: number
+  activeHiddenRestoreTotalMs: number
 }
 
 type E2eTerminalPtyOutputDebugApi = {
@@ -537,13 +541,21 @@ type ColdRestoreAgentResumeStartup = PendingStartupCommand & {
 const e2eTerminalPtyOutputDebugState: E2eTerminalPtyOutputDebugSnapshot = {
   hiddenRendererSkipCount: 0,
   hiddenRendererSkippedChars: 0,
-  hiddenRendererMode2031ReplyCount: 0
+  hiddenRendererMode2031ReplyCount: 0,
+  activeHiddenRestoreCount: 0,
+  activeHiddenRestoreSnapshotMs: 0,
+  activeHiddenRestoreReplayMs: 0,
+  activeHiddenRestoreTotalMs: 0
 }
 
 function resetE2eTerminalPtyOutputDebug(): void {
   e2eTerminalPtyOutputDebugState.hiddenRendererSkipCount = 0
   e2eTerminalPtyOutputDebugState.hiddenRendererSkippedChars = 0
   e2eTerminalPtyOutputDebugState.hiddenRendererMode2031ReplyCount = 0
+  e2eTerminalPtyOutputDebugState.activeHiddenRestoreCount = 0
+  e2eTerminalPtyOutputDebugState.activeHiddenRestoreSnapshotMs = 0
+  e2eTerminalPtyOutputDebugState.activeHiddenRestoreReplayMs = 0
+  e2eTerminalPtyOutputDebugState.activeHiddenRestoreTotalMs = 0
 }
 
 function exposeE2eTerminalPtyOutputDebug(): void {
@@ -572,6 +584,22 @@ function recordHiddenMode2031Reply(): void {
   }
   exposeE2eTerminalPtyOutputDebug()
   e2eTerminalPtyOutputDebugState.hiddenRendererMode2031ReplyCount += 1
+}
+
+function recordActiveHiddenRestoreTiming(
+  priority: 'active' | 'inactive' | undefined,
+  snapshotMs: number,
+  replayMs: number,
+  totalMs: number
+): void {
+  if (!e2eConfig.exposeStore || priority !== 'active') {
+    return
+  }
+  exposeE2eTerminalPtyOutputDebug()
+  e2eTerminalPtyOutputDebugState.activeHiddenRestoreCount += 1
+  e2eTerminalPtyOutputDebugState.activeHiddenRestoreSnapshotMs = snapshotMs
+  e2eTerminalPtyOutputDebugState.activeHiddenRestoreReplayMs = replayMs
+  e2eTerminalPtyOutputDebugState.activeHiddenRestoreTotalMs = totalMs
 }
 
 function exposeE2eTerminalPtyDataInjection(): void {
@@ -6986,7 +7014,10 @@ export function connectPanePty(
       }
     }
 
-    function requestHiddenOutputRestoreIfNeeded(opts?: { bypassScheduler?: boolean }): boolean {
+    function requestHiddenOutputRestoreIfNeeded(opts?: {
+      bypassScheduler?: boolean
+      debugPriority?: 'active' | 'inactive'
+    }): boolean {
       // Why: once the write pipeline is probe-certified dead a restore can never parse; recovery owns the pane and the remount gets a fresh xterm + restore.
       if (isTerminalWritePipelineCertifiedDead(pane.terminal)) {
         // Why the re-kick: certification's recovery request can be budget-declined or cancelled by a sibling remount; without this, a revealed dead pane keeps the stale frame forever.
@@ -7039,7 +7070,10 @@ export function connectPanePty(
                 ) {
                   return
                 }
-                requestHiddenOutputRestoreIfNeeded({ bypassScheduler: true })
+                requestHiddenOutputRestoreIfNeeded({
+                  bypassScheduler: true,
+                  debugPriority: priority
+                })
               },
               priority
             )
@@ -7052,7 +7086,10 @@ export function connectPanePty(
         scheduleHiddenOutputRestore(
           pane.terminal,
           () => {
-            restoreRequested = requestHiddenOutputRestoreIfNeeded({ bypassScheduler: true })
+            restoreRequested = requestHiddenOutputRestoreIfNeeded({
+              bypassScheduler: true,
+              debugPriority: priority
+            })
             return hiddenOutputRestoreInFlight ?? undefined
           },
           priority
@@ -7061,6 +7098,9 @@ export function connectPanePty(
       }
       clearHiddenOutputRestoreDeferredRetryTimer()
       hiddenOutputRestoreRetryDeferred = false
+      const restoreStartedAt = performance.now()
+      let restoreSnapshotMs = 0
+      let restoreReplayMs = 0
 
       hiddenOutputRestoreInFlight = (async () => {
         // Backstop (rc.7.perf loop): bound how many snapshot fetch+replay rounds one task burns before yielding to the live stream.
@@ -7087,12 +7127,15 @@ export function connectPanePty(
           const restoreGeneration = hiddenOutputRestoreGeneration
           hiddenOutputRestoreNeeded = false
           let snapshot: PtyBufferSnapshot | null = null
+          const snapshotStartedAt = performance.now()
           try {
             snapshot = await serializeHiddenOutputSnapshot(currentPtyId, {
               scrollbackRows: resolveHiddenRestoreScrollbackRows(pane.terminal.options.scrollback)
             })
           } catch {
             snapshot = null
+          } finally {
+            restoreSnapshotMs += performance.now() - snapshotStartedAt
           }
           if (disposed) {
             return
@@ -7116,7 +7159,12 @@ export function connectPanePty(
           }
           hiddenOutputRestoreDeferredRetryAttempts = 0
           restoreIterations += 1
-          await applyMainBufferSnapshot(snapshot)
+          const replayStartedAt = performance.now()
+          try {
+            await applyMainBufferSnapshot(snapshot)
+          } finally {
+            restoreReplayMs += performance.now() - replayStartedAt
+          }
           if (
             disposed ||
             hiddenOutputRestoreGeneration !== restoreGeneration ||
@@ -7168,6 +7216,12 @@ export function connectPanePty(
       const hiddenOutputRestoreTask = hiddenOutputRestoreInFlight
       let trackedHiddenOutputRestore: Promise<void>
       trackedHiddenOutputRestore = hiddenOutputRestoreTask.finally(() => {
+        recordActiveHiddenRestoreTiming(
+          opts?.debugPriority,
+          restoreSnapshotMs,
+          restoreReplayMs,
+          performance.now() - restoreStartedAt
+        )
         if (hiddenOutputRestoreInFlight === trackedHiddenOutputRestore) {
           hiddenOutputRestoreInFlight = null
         }

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -929,6 +929,96 @@ describe('createIpcPtyTransport', () => {
     }
   })
 
+  it('preserves the latest agent lifecycle transition through queue eviction', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor, MAX_PENDING_PTY_SIDE_EFFECTS } =
+        await import('./pty-transport')
+      const onAgentBecameWorking = vi.fn()
+      const onAgentBecameIdle = vi.fn()
+      const processor = createPtyOutputProcessor({
+        onTitleChange: vi.fn(),
+        onAgentBecameWorking,
+        onAgentBecameIdle
+      })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;. Claude working\x07', callbacks)
+      for (let i = 0; i < MAX_PENDING_PTY_SIDE_EFFECTS; i++) {
+        processor.processData(`\x1b]0;shell-title-${i}\x07`, callbacks)
+      }
+      processor.processData('\x1b]0;* Claude idle\x07', callbacks)
+      processor.flushPendingSideEffects()
+
+      expect(onAgentBecameWorking).toHaveBeenCalledTimes(1)
+      expect(onAgentBecameIdle).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('resets stale-title timing when a working title survives queue eviction', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor, MAX_PENDING_PTY_SIDE_EFFECTS } =
+        await import('./pty-transport')
+      const onAgentBecameIdle = vi.fn()
+      const processor = createPtyOutputProcessor({
+        onTitleChange: vi.fn(),
+        onAgentBecameWorking: vi.fn(),
+        onAgentBecameIdle,
+        onAgentStatus: vi.fn()
+      })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;. Claude working\x07', callbacks)
+      await vi.advanceTimersByTimeAsync(0)
+      processor.processData('plain output\r\n', callbacks)
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(2_900)
+
+      processor.processData('\x1b]0;. Claude working\x07', callbacks)
+      for (let i = 0; i < MAX_PENDING_PTY_SIDE_EFFECTS; i++) {
+        processor.processData(`\x1b]9999;{"state":"working","prompt":"${i}"}\x07`, callbacks)
+      }
+      processor.flushPendingSideEffects()
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(onAgentBecameIdle).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('preserves an agent exit title through queue eviction', async () => {
+    vi.useFakeTimers()
+    try {
+      const { createPtyOutputProcessor, MAX_PENDING_PTY_SIDE_EFFECTS } =
+        await import('./pty-transport')
+      const onAgentExited = vi.fn()
+      const processor = createPtyOutputProcessor({
+        onTitleChange: vi.fn(),
+        onAgentBecameWorking: vi.fn(),
+        onAgentBecameIdle: vi.fn(),
+        onAgentExited,
+        onAgentStatus: vi.fn()
+      })
+      const callbacks = { onData: vi.fn() }
+
+      processor.processData('\x1b]0;. Claude working\x07', callbacks)
+      processor.processData('\x1b]0;* Claude idle\x07', callbacks)
+      processor.processData('\x1b]0;shell prompt\x07', callbacks)
+      for (let i = 0; i < MAX_PENDING_PTY_SIDE_EFFECTS; i++) {
+        processor.processData(`\x1b]9999;{"state":"working","prompt":"${i}"}\x07`, callbacks)
+      }
+      processor.flushPendingSideEffects()
+
+      expect(onAgentExited).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('collapses evicted agent-status payloads onto the survivor, keeping the newest', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -108,6 +108,11 @@ type PendingPtySideEffect = {
   suppressAttentionEvents: boolean
 }
 
+type EvictedAgentTitleTransition = {
+  phase: 'working' | 'settled' | 'cleared'
+  title: string
+}
+
 function isIgnoredCursorNativeTitle(title: string): boolean {
   return title.trim().toLowerCase() === 'cursor agent'
 }
@@ -165,6 +170,7 @@ export function createPtyOutputProcessor({
   let pendingSideEffects: PendingPtySideEffect[] = []
   let pendingSideEffectIndex = 0
   let pendingWorkingTitleSideEffects = 0
+  let evictedAgentTitleTransitions: EvictedAgentTitleTransition[] = []
   const agentTracker =
     onAgentBecameIdle || onAgentBecameWorking || onAgentExited
       ? createAgentStatusTracker(
@@ -199,6 +205,37 @@ export function createPtyOutputProcessor({
     }
   }
 
+  function carryEvictedAgentTitleTransitions(next: PendingPtySideEffect): void {
+    if (!agentTracker || next.suppressAttentionEvents) {
+      return
+    }
+    for (const title of next.titles) {
+      const status = detectAgentStatusFromTitle(title)
+      const phase = status === 'working' ? 'working' : status === null ? 'cleared' : 'settled'
+      const prior = evictedAgentTitleTransitions.at(-1)
+      if (prior?.phase === phase) {
+        prior.title = title
+        continue
+      }
+      evictedAgentTitleTransitions.push({ phase, title })
+      if (evictedAgentTitleTransitions.length > 3) {
+        evictedAgentTitleTransitions.shift()
+      }
+    }
+  }
+
+  function flushEvictedAgentTitleTransitions(): void {
+    const transitions = evictedAgentTitleTransitions
+    evictedAgentTitleTransitions = []
+    if (transitions.length > 0) {
+      // Carried titles are fresh observations; an older fallback must not clear them.
+      clearStaleTitleTimer()
+    }
+    for (const transition of transitions) {
+      applyObservedTerminalTitle(transition.title)
+    }
+  }
+
   function clearStaleTitleTimer(): void {
     if (staleTitleTimer) {
       clearTimeout(staleTitleTimer)
@@ -214,9 +251,8 @@ export function createPtyOutputProcessor({
     sideEffectDrainTimer = setTimeout(drainPtySideEffects, 0)
   }
 
-  // Why: oldest-first eviction at the cap. Evicted titles are safe to drop (titles are last-wins);
-  // bells and agent-status payloads collapse onto the next-oldest survivor so a pending bell latch
-  // and the newest statuses still apply on drain instead of vanishing.
+  // Why: oldest-first eviction at the cap. Display titles are last-wins, lifecycle phases carry
+  // separately, and bells/statuses collapse onto the next survivor instead of vanishing.
   function evictOldestPendingSideEffectsIfFull(): void {
     while (pendingSideEffects.length - pendingSideEffectIndex >= MAX_PENDING_PTY_SIDE_EFFECTS) {
       const evicted = pendingSideEffects[pendingSideEffectIndex]
@@ -224,6 +260,8 @@ export function createPtyOutputProcessor({
         return
       }
       pendingSideEffectIndex += 1
+      // Why: the queue may drop display titles, but the latest agent lifecycle edge must survive.
+      carryEvictedAgentTitleTransitions(evicted)
       // Why: mirror applyPtySideEffect's accounting so stale-probe arming doesn't stick past eviction.
       pendingWorkingTitleSideEffects -= countWorkingTitles(evicted.titles)
       if (pendingWorkingTitleSideEffects < 0) {
@@ -288,7 +326,9 @@ export function createPtyOutputProcessor({
       data.length > 0 &&
       titles.length === 0 &&
       !suppressAttentionEvents &&
-      (isWorkingTitle(lastEmittedTitle) || pendingWorkingTitleSideEffects > 0)
+      (isWorkingTitle(lastEmittedTitle) ||
+        pendingWorkingTitleSideEffects > 0 ||
+        evictedAgentTitleTransitions.some((transition) => transition.phase === 'working'))
     )
     const shouldEmitEmptyTitleScan = scannedForTitles || needsStaleTitleProbe
     const emptyTitleScanEffect: PendingPtySideEffect['titleScanEffect'] = ignoredCursorNativeTitle
@@ -390,6 +430,7 @@ export function createPtyOutputProcessor({
 
   function drainPtySideEffects(options: { flushAll?: boolean } = {}): void {
     sideEffectDrainTimer = null
+    flushEvictedAgentTitleTransitions()
     const maxEffects = options.flushAll ? Number.POSITIVE_INFINITY : MAX_PTY_SIDE_EFFECTS_PER_DRAIN
     let processed = 0
     while (pendingSideEffectIndex < pendingSideEffects.length && processed < maxEffects) {
@@ -488,6 +529,7 @@ export function createPtyOutputProcessor({
     pendingSideEffects.length = 0
     pendingSideEffectIndex = 0
     pendingWorkingTitleSideEffects = 0
+    evictedAgentTitleTransitions.length = 0
     clearStaleTitleTimer()
     agentTracker?.reset()
     bellDetector.reset()

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -76,6 +76,7 @@ export const MAX_PENDING_PTY_SIDE_EFFECTS = 512
 // Why: agent status is last-wins store state, but payloads can carry KB-scale prompt/tool strings;
 // carry only the newest few through eviction so a status flood cannot re-grow what it evicted.
 export const MAX_EVICTED_AGENT_STATUS_PAYLOAD_CARRY = 16
+const MAX_EVICTED_AGENT_TITLE_TRANSITION_CARRY = 3
 
 type PtyOutputCallbacks = Parameters<PtyTransport['connect']>[0]['callbacks']
 
@@ -218,7 +219,7 @@ export function createPtyOutputProcessor({
         continue
       }
       evictedAgentTitleTransitions.push({ phase, title })
-      if (evictedAgentTitleTransitions.length > 3) {
+      if (evictedAgentTitleTransitions.length > MAX_EVICTED_AGENT_TITLE_TRANSITION_CARRY) {
         evictedAgentTitleTransitions.shift()
       }
     }

--- a/src/renderer/src/components/terminal-pane/shutdown-buffer-captures.ts
+++ b/src/renderer/src/components/terminal-pane/shutdown-buffer-captures.ts
@@ -1,5 +1,7 @@
 export type ShutdownBufferCaptureOptions = {
   includeLocalBuffers?: boolean
+  /** Force-parking remote-runtime panes restores from the host snapshot. */
+  excludeRemoteRuntimeScrollback?: boolean
 }
 
 /** Map of tabId → buffer-capture callback, one per mounted TerminalPane.

--- a/src/renderer/src/components/terminal-pane/terminal-eviction-exempt-tabs.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-eviction-exempt-tabs.test.ts
@@ -56,6 +56,21 @@ describe('selectEvictionExemptTerminalTabLayoutKey', () => {
     )
   })
 
+  it('is stable across leaf-map insertion order', () => {
+    const first = layoutState({
+      [LEAF_ID]: PTY_ID,
+      [SECOND_LEAF_ID]: 'pty-local-detached'
+    })
+    const reversed = layoutState({
+      [SECOND_LEAF_ID]: 'pty-local-detached',
+      [LEAF_ID]: PTY_ID
+    })
+
+    expect(selectEvictionExemptTerminalTabLayoutKey(first, TABS)).toBe(
+      selectEvictionExemptTerminalTabLayoutKey(reversed, TABS)
+    )
+  })
+
   it('tolerates tabs with no persisted layout', () => {
     expect(selectEvictionExemptTerminalTabLayoutKey({ terminalLayoutsByTabId: {} }, TABS)).toBe(
       JSON.stringify([[TAB_ID, []]])

--- a/src/renderer/src/components/terminal-pane/terminal-eviction-exempt-tabs.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-eviction-exempt-tabs.test.ts
@@ -41,9 +41,24 @@ describe('selectEvictionExemptTerminalTabLayoutKey', () => {
     ).not.toBe(selectEvictionExemptTerminalTabLayoutKey(layoutState({ [LEAF_ID]: PTY_ID }), TABS))
   })
 
+  it('does not collide when a pty id contains layout-key delimiters', () => {
+    const embeddedLeaf = `pty-local-detached,${SECOND_LEAF_ID}:second`
+    expect(
+      selectEvictionExemptTerminalTabLayoutKey(layoutState({ [LEAF_ID]: embeddedLeaf }), TABS)
+    ).not.toBe(
+      selectEvictionExemptTerminalTabLayoutKey(
+        layoutState({
+          [LEAF_ID]: 'pty-local-detached',
+          [SECOND_LEAF_ID]: 'second'
+        }),
+        TABS
+      )
+    )
+  })
+
   it('tolerates tabs with no persisted layout', () => {
     expect(selectEvictionExemptTerminalTabLayoutKey({ terminalLayoutsByTabId: {} }, TABS)).toBe(
-      `${TAB_ID}=`
+      JSON.stringify([[TAB_ID, []]])
     )
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-eviction-exempt-tabs.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-eviction-exempt-tabs.ts
@@ -75,13 +75,12 @@ export function selectEvictionExemptTerminalTabLayoutKey(
   state: EvictionExemptTabLayoutState,
   tabs: readonly ParkableTerminalTabModel[]
 ): string {
-  return tabs
-    .map((tab) => {
-      const ptyIdsByLeafId = state.terminalLayoutsByTabId[tab.id]?.ptyIdsByLeafId ?? {}
-      const leafPtys = Object.entries(ptyIdsByLeafId)
-        .map(([leafId, ptyId]) => `${leafId}:${ptyId}`)
-        .join(',')
-      return `${tab.id}=${leafPtys}`
-    })
-    .join('|')
+  return JSON.stringify(
+    tabs.map((tab) => [
+      tab.id,
+      Object.entries(state.terminalLayoutsByTabId[tab.id]?.ptyIdsByLeafId ?? {}).sort(
+        ([leftLeafId], [rightLeafId]) => leftLeafId.localeCompare(rightLeafId)
+      )
+    ])
+  )
 }

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
@@ -25,6 +25,7 @@ export type TerminalColdParkPolicyOverrides = {
   hotRetainMs?: number
   hotRetainLimit?: number
   retentionTtlMs?: number
+  /** Default-scrollback pane units for un-parkable hidden renderer views. */
   retentionLimit?: number
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { TERMINAL_WORKTREE_PARK_DELAY_MS } from './terminal-hidden-view-parking'
 import {
   TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS,
+  countTerminalLayoutPanes,
+  getTerminalHiddenPaneRetentionWeight,
   isEvictionExemptTerminalPty,
   selectForceParkEvictableTabIds,
   selectRetentionForceParkedTerminalWorktrees,
+  selectTerminalLayoutPaneCountByTabId,
   type TerminalWorktreeRetentionCandidate
 } from './terminal-hidden-worktree-retention'
 
@@ -40,6 +43,7 @@ describe('selectRetentionForceParkedTerminalWorktrees', () => {
       hasActivityTerminalPortal: false,
       ordinaryParkingCovers: false,
       hasPendingSpawnWork: false,
+      retainedPaneCount: 1,
       ...partial
     }
   }
@@ -73,13 +77,62 @@ describe('selectRetentionForceParkedTerminalWorktrees', () => {
       retentionCandidate('wt-3', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS - 1),
       retentionCandidate('wt-4', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS)
     ]
-    // Why limit 2: wt-4 is last-active exempt, wt-3 fills the remaining slot; the two oldest evict.
+    // Why limit 2: newest wt-4 claims one unit, wt-3 claims the other; the two oldest evict.
     expect(
       selectRetentionForceParkedTerminalWorktrees({ ...base, worktrees, retentionLimit: 2 })
     ).toEqual(new Set(['wt-1', 'wt-2']))
   })
 
-  it('force-parks past the TTL even under the limit, sparing a last-active candidate inside it', () => {
+  it('force-parks a newest candidate that exceeds the pane budget by itself', () => {
+    const worktrees = [
+      retentionCandidate('wt-many-panes', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS, {
+        retainedPaneCount: 13
+      })
+    ]
+
+    expect(selectRetentionForceParkedTerminalWorktrees({ ...base, worktrees })).toEqual(
+      new Set(['wt-many-panes'])
+    )
+  })
+
+  it('spends the budget on the newest weighted worktrees first', () => {
+    const worktrees = [
+      retentionCandidate('wt-old-small', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS - 2, {
+        retainedPaneCount: 2
+      }),
+      retentionCandidate('wt-middle', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS - 1, {
+        retainedPaneCount: 3
+      }),
+      retentionCandidate('wt-new', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS, {
+        retainedPaneCount: 4
+      })
+    ]
+
+    expect(
+      selectRetentionForceParkedTerminalWorktrees({
+        ...base,
+        worktrees,
+        retentionLimit: 6
+      })
+    ).toEqual(new Set(['wt-middle']))
+  })
+
+  it('weights high-scrollback panes against the same renderer budget', () => {
+    const worktrees = [
+      retentionCandidate('wt-old', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS - 1),
+      retentionCandidate('wt-new', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS)
+    ]
+
+    expect(
+      selectRetentionForceParkedTerminalWorktrees({
+        ...base,
+        worktrees,
+        scrollbackRows: 50_000
+      })
+    ).toEqual(new Set(['wt-old']))
+  })
+
+  it('force-parks past the TTL even under the limit while retaining a newer candidate', () => {
     const worktrees = [
       retentionCandidate('wt-old', nowMs - TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS),
       retentionCandidate('wt-recent', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS)
@@ -89,10 +142,9 @@ describe('selectRetentionForceParkedTerminalWorktrees', () => {
     )
   })
 
-  // Why: the last-active exemption keeps the warm cap's "return is always instant"
-  // promise, but carrying it into the eviction clock made "none past 45 minutes"
-  // false — a lone hidden un-parkable worktree stayed mounted for the whole session.
-  it('force-parks the last-active candidate once it passes the TTL (the exemption bounds the cap, not the clock)', () => {
+  // Why: capacity never overrides the absolute clock; otherwise a lone hidden
+  // un-parkable worktree could stay mounted for the whole session.
+  it('force-parks the newest candidate once it passes the TTL', () => {
     const lone = [retentionCandidate('wt-lone', nowMs - TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS)]
     expect(selectRetentionForceParkedTerminalWorktrees({ ...base, worktrees: lone })).toEqual(
       new Set(['wt-lone'])
@@ -124,7 +176,7 @@ describe('selectRetentionForceParkedTerminalWorktrees', () => {
   // again the instant the lease ends — the remount/reattach thrash Bug #2.
   it('holds a candidate out of force-park until its post-measure cool-down ends', () => {
     const aged = nowMs - TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS
-    // Why the recent sibling: it takes the last-active exemption, so the aged
+    // Why the recent sibling: it claims the only capacity, so the aged
     // candidate's verdict is decided by the cool-down alone.
     const recent = retentionCandidate('wt-recent', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS)
     expect(
@@ -175,6 +227,77 @@ describe('selectRetentionForceParkedTerminalWorktrees', () => {
         expect(later.has(id)).toBe(true)
       }
     }
+  })
+})
+
+describe('terminal hidden pane retention weight', () => {
+  it('counts split leaves, PTY-only rootless layouts, and a fresh one-pane layout', () => {
+    expect(
+      countTerminalLayoutPanes({
+        root: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', leafId: 'leaf-1' },
+          second: { type: 'leaf', leafId: 'leaf-2' }
+        },
+        activeLeafId: 'leaf-1',
+        expandedLeafId: null
+      })
+    ).toBe(2)
+    expect(
+      countTerminalLayoutPanes({
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { 'leaf-1': 'pty-1', 'leaf-2': 'pty-2', 'leaf-3': 'pty-3' }
+      })
+    ).toBe(3)
+    expect(countTerminalLayoutPanes(undefined)).toBe(1)
+  })
+
+  it('scales pane weight by configured scrollback rows', () => {
+    expect(getTerminalHiddenPaneRetentionWeight(3, 5_000)).toBe(3)
+    expect(getTerminalHiddenPaneRetentionWeight(3, 25_000)).toBe(15)
+    expect(getTerminalHiddenPaneRetentionWeight(2, 50_000)).toBe(20)
+  })
+
+  it('reuses pane counts across unrelated store writes and buffer-only layout changes', () => {
+    const root = { type: 'leaf' as const, leafId: 'leaf-1' }
+    const terminalLayoutsByTabId = {
+      'tab-1': { root, activeLeafId: 'leaf-1', expandedLeafId: null }
+    }
+    const first = selectTerminalLayoutPaneCountByTabId({ terminalLayoutsByTabId })
+
+    expect(selectTerminalLayoutPaneCountByTabId({ terminalLayoutsByTabId })).toBe(first)
+    expect(
+      selectTerminalLayoutPaneCountByTabId({
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root,
+            activeLeafId: 'leaf-1',
+            expandedLeafId: null,
+            buffersByLeafId: { 'leaf-1': 'updated buffer' }
+          }
+        }
+      })
+    ).toBe(first)
+
+    const changed = selectTerminalLayoutPaneCountByTabId({
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: root,
+            second: { type: 'leaf', leafId: 'leaf-2' }
+          },
+          activeLeafId: 'leaf-1',
+          expandedLeafId: null
+        }
+      }
+    })
+    expect(changed).not.toBe(first)
+    expect(changed).toEqual({ 'tab-1': 2 })
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts
@@ -95,6 +95,22 @@ describe('selectRetentionForceParkedTerminalWorktrees', () => {
     )
   })
 
+  it('does not let empty retained topology bypass the pane budget', () => {
+    const worktrees = [
+      retentionCandidate('wt-empty-topology', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS, {
+        retainedPaneCount: 0
+      })
+    ]
+
+    expect(
+      selectRetentionForceParkedTerminalWorktrees({
+        ...base,
+        worktrees,
+        retentionLimit: 0
+      })
+    ).toEqual(new Set(['wt-empty-topology']))
+  })
+
   it('spends the budget on the newest weighted worktrees first', () => {
     const worktrees = [
       retentionCandidate('wt-old-small', nowMs - TERMINAL_WORKTREE_PARK_DELAY_MS - 2, {
@@ -259,6 +275,13 @@ describe('terminal hidden pane retention weight', () => {
     expect(getTerminalHiddenPaneRetentionWeight(3, 5_000)).toBe(3)
     expect(getTerminalHiddenPaneRetentionWeight(3, 25_000)).toBe(15)
     expect(getTerminalHiddenPaneRetentionWeight(2, 50_000)).toBe(20)
+  })
+
+  it('charges one pane when retained topology is empty or invalid', () => {
+    expect(getTerminalHiddenPaneRetentionWeight(0, 5_000)).toBe(1)
+    expect(getTerminalHiddenPaneRetentionWeight(-1, 5_000)).toBe(1)
+    expect(getTerminalHiddenPaneRetentionWeight(0.5, 5_000)).toBe(1)
+    expect(getTerminalHiddenPaneRetentionWeight(Number.NaN, 5_000)).toBe(1)
   })
 
   it('reuses pane counts across unrelated store writes and buffer-only layout changes', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
@@ -70,8 +70,9 @@ export function getTerminalHiddenPaneRetentionWeight(
   retainedPaneCount: number,
   scrollbackRows: unknown
 ): number {
-  const paneCount =
-    Number.isFinite(retainedPaneCount) && retainedPaneCount > 0 ? Math.floor(retainedPaneCount) : 0
+  const paneCount = Number.isFinite(retainedPaneCount)
+    ? Math.max(1, Math.floor(retainedPaneCount))
+    : 1
   const rowWeight = Math.ceil(
     normalizeDesktopTerminalScrollbackRows(scrollbackRows) /
       DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
@@ -1,32 +1,83 @@
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import {
+  DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT,
+  normalizeDesktopTerminalScrollbackRows
+} from '../../../../shared/terminal-scrollback-policy'
+import type { TerminalLayoutSnapshot } from '../../../../shared/types'
+import {
   TERMINAL_WORKTREE_COLD_PARK_DELAY_MS,
   isSnapshotBackedTerminalPty,
-  selectIdsBeyondHotRetain,
-  type ColdParkRetainCandidate,
   type TerminalColdParkPolicyOverrides
 } from './terminal-hidden-view-parking'
+import { collectLeafIdsInOrder } from './terminal-layout-leaf-ids'
 
 // Why these sizes: a retained hidden pane costs a measured ~2.5MB of V8 heap
 // at the 5k-row default scrollback and ~19MB at 50k (plus per-pane queues),
-// not the ~4-5MB per WORKTREE the warm cap assumed — so un-parkable worktrees
-// (pty classes parking can't restore) get a retention budget: at most 12 stay
-// mounted while hidden and none past 45 minutes, evicted least-recently-hidden
-// first via force-park. The TTL is absolute: the last-active exemption bounds
-// the cap, never the clock.
+// not the ~4-5MB per WORKTREE the warm cap assumed. Un-parkable worktrees
+// therefore share 12 default-scrollback pane units while hidden; split panes,
+// tabs, and larger scrollback all spend that budget. Newer worktrees claim
+// capacity first, candidates that do not fit force-park, and none survive past
+// 45 minutes. The newest candidate stays warm only when it fits.
 // NOT covered by this bound: eviction-exempt TABS (isEvictionExemptTerminalPty
 // — live local ptys a remount would respawn, orphaning the shell). Their panes
 // stay mounted through a force-park at any age, so a fleet-wide daemon
 // fail-open can leave the budget freeing nothing; Terminal.tsx logs that
 // degenerate case rather than pretending the bound held.
-// Also NOT covered: per-pane scrollback size. Hidden-pane scrollback demotion
-// was intentionally removed — the bound is worktree count + TTL only, so a
-// spared worktree (last-active, exempt tabs) can hold full 50k-row scrollback
-// indefinitely. Accepted tradeoff: high-scrollback users rely on unmount
-// eviction, not demotion.
-export const TERMINAL_HIDDEN_WORKTREE_RETENTION_LIMIT = 12
+// Scrollback is weighted instead of demoted: a 50k pane spends 10 units.
+export const TERMINAL_HIDDEN_PANE_RETENTION_LIMIT = 12
 export const TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS = 45 * 60_000
+
+export function countTerminalLayoutPanes(layout: TerminalLayoutSnapshot | undefined): number {
+  return Math.max(
+    1,
+    collectLeafIdsInOrder(layout?.root).length,
+    Object.keys(layout?.ptyIdsByLeafId ?? {}).length
+  )
+}
+
+type TerminalLayoutPaneCountState = {
+  terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
+}
+
+let cachedTerminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot> | null = null
+let cachedTerminalLayoutPaneCountByTabId: Readonly<Record<string, number>> = {}
+
+export function selectTerminalLayoutPaneCountByTabId(
+  state: TerminalLayoutPaneCountState
+): Readonly<Record<string, number>> {
+  if (state.terminalLayoutsByTabId === cachedTerminalLayoutsByTabId) {
+    return cachedTerminalLayoutPaneCountByTabId
+  }
+  const next = Object.fromEntries(
+    Object.entries(state.terminalLayoutsByTabId).map(([tabId, layout]) => [
+      tabId,
+      countTerminalLayoutPanes(layout)
+    ])
+  )
+  const nextKeys = Object.keys(next)
+  if (
+    Object.keys(cachedTerminalLayoutPaneCountByTabId).length !== nextKeys.length ||
+    nextKeys.some((tabId) => cachedTerminalLayoutPaneCountByTabId[tabId] !== next[tabId])
+  ) {
+    cachedTerminalLayoutPaneCountByTabId = next
+  }
+  cachedTerminalLayoutsByTabId = state.terminalLayoutsByTabId
+  return cachedTerminalLayoutPaneCountByTabId
+}
+
+export function getTerminalHiddenPaneRetentionWeight(
+  retainedPaneCount: number,
+  scrollbackRows: unknown
+): number {
+  const paneCount =
+    Number.isFinite(retainedPaneCount) && retainedPaneCount > 0 ? Math.floor(retainedPaneCount) : 0
+  const rowWeight = Math.ceil(
+    normalizeDesktopTerminalScrollbackRows(scrollbackRows) /
+      DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT
+  )
+  return paneCount * rowWeight
+}
 
 // Why: an eviction-exempt pty is a live local one a remount could not reattach
 // (daemon-fail-open separator-less ids, ptys minted under another worktree) — a
@@ -59,21 +110,22 @@ export type TerminalWorktreeRetentionCandidate = {
   ordinaryParkingCovers: boolean
   /** Pending startup or activation spawn — a mount is imminent; never evict. */
   hasPendingSpawnWork: boolean
+  /** Mounted renderer burden represented by the persisted tab/split topology. */
+  retainedPaneCount: number
 }
 
 /**
- * Retention budget over the worktrees ordinary parking can never evict: any
- * hidden un-parkable worktree beyond the retention limit or TTL force-parks —
+ * Retention budget over the worktrees ordinary parking can never evict: hidden
+ * pane weight beyond the retention limit, or any worktree past TTL, force-parks —
  * panes unmount, watchers cover the tabs whose transport exists, and reveal
  * restores per pty class (the app-restart experience). Eviction-exempt tabs
  * do NOT veto the worktree: they keep their mounted panes via the per-tab
  * exclusion (Activity-portal pattern) while sibling tabs unmount, so one
  * exempt tab can no longer pin co-located remote-runtime tabs forever.
- * Ranking reuses the hot-retain machinery, so deterministic ties hold here too,
- * and the verdict changes only at deadlines or on real state transitions (no
- * new flip-loop inputs). The last-active exemption it carries spares one
- * worktree from the CAP only — the TTL below overrides it, else a lone hidden
- * un-parkable worktree would stay mounted for the whole session.
+ * Newest candidates claim the pane/scrollback budget first, deterministic ties
+ * break by id, and an individually-overweight newest candidate force-parks
+ * instead of defeating the bound. Older candidates may use capacity left by a
+ * newer candidate that did not fit.
  */
 export function selectRetentionForceParkedTerminalWorktrees(
   args: {
@@ -81,13 +133,20 @@ export function selectRetentionForceParkedTerminalWorktrees(
     parkingEnabled: boolean
     retentionBudgetEnabled: boolean
     nowMs: number
+    scrollbackRows?: number
   } & TerminalColdParkPolicyOverrides
 ): Set<string> {
   if (!args.parkingEnabled || !args.retentionBudgetEnabled) {
     return new Set()
   }
   const coldParkDelayMs = args.coldParkDelayMs ?? TERMINAL_WORKTREE_COLD_PARK_DELAY_MS
-  const candidates: ColdParkRetainCandidate[] = []
+  const retentionTtlMs = args.retentionTtlMs ?? TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS
+  const forceParkedIds = new Set<string>()
+  const retainedCandidates: {
+    id: string
+    hiddenSinceMs: number
+    weight: number
+  }[] = []
   for (const worktree of args.worktrees) {
     if (
       worktree.hiddenSinceMs === null ||
@@ -101,19 +160,26 @@ export function selectRetentionForceParkedTerminalWorktrees(
     ) {
       continue
     }
-    candidates.push({ id: worktree.worktreeId, hiddenSinceMs: worktree.hiddenSinceMs })
+    if (args.nowMs - worktree.hiddenSinceMs >= retentionTtlMs) {
+      forceParkedIds.add(worktree.worktreeId)
+      continue
+    }
+    retainedCandidates.push({
+      id: worktree.worktreeId,
+      hiddenSinceMs: worktree.hiddenSinceMs,
+      weight: getTerminalHiddenPaneRetentionWeight(worktree.retainedPaneCount, args.scrollbackRows)
+    })
   }
-  const retentionTtlMs = args.retentionTtlMs ?? TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS
-  const forceParkedIds = selectIdsBeyondHotRetain(candidates, {
-    nowMs: args.nowMs,
-    hotRetainMs: retentionTtlMs,
-    hotRetainLimit: args.retentionLimit ?? TERMINAL_HIDDEN_WORKTREE_RETENTION_LIMIT
+  retainedCandidates.sort((left, right) => {
+    const recencyDelta = right.hiddenSinceMs - left.hiddenSinceMs
+    return recencyDelta === 0 ? left.id.localeCompare(right.id) : recencyDelta
   })
-  // Why re-applied here: selectIdsBeyondHotRetain spares the last-active id from
-  // its clock too, which is right for the warm cap (instant return after a
-  // meeting) but makes "none past 45 minutes" false for a lone hidden worktree.
-  for (const candidate of candidates) {
-    if (args.nowMs - candidate.hiddenSinceMs >= retentionTtlMs) {
+  const retentionLimit = Math.max(0, args.retentionLimit ?? TERMINAL_HIDDEN_PANE_RETENTION_LIMIT)
+  let retainedWeight = 0
+  for (const candidate of retainedCandidates) {
+    if (retainedWeight + candidate.weight <= retentionLimit) {
+      retainedWeight += candidate.weight
+    } else {
       forceParkedIds.add(candidate.id)
     }
   }

--- a/src/renderer/src/components/terminal-pane/terminal-parking-e2e-overrides.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-parking-e2e-overrides.ts
@@ -16,13 +16,12 @@ export function getTerminalParkingPolicyOverrides(): TerminalColdParkPolicyOverr
   const delayMs = e2eConfig.terminalParkingDelayMs
   const retentionLimit = e2eConfig.terminalRetentionLimit
   return {
-    // Why the retention TTL keeps production timing: it is absolute (the
-    // last-active exemption does not spare it), so shrinking it here would
-    // evict the newest hidden worktree the cap specs assert stays mounted.
+    // Why the retention TTL keeps production timing: it is absolute, so
+    // shrinking it here would evict the newest candidate despite fitting capacity.
     ...(typeof delayMs === 'number' && Number.isFinite(delayMs) && delayMs > 0
       ? { coldParkDelayMs: delayMs, hotRetainMs: delayMs }
       : {}),
-    // Why: limit=1 lets a spec force-park with only two hidden un-parkable worktrees (production floor is 12).
+    // Why: a one-unit override lets two one-pane worktrees exceed the test budget.
     ...(typeof retentionLimit === 'number' && Number.isInteger(retentionLimit) && retentionLimit > 0
       ? { retentionLimit }
       : {})

--- a/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.test.ts
@@ -2,9 +2,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../shared/terminal-scrollback-limits'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 import { getUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
+import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 
-const LEAF_ID = '11111111-1111-4111-8111-111111111111' as const
-const LEAF_ID_2 = '22222222-2222-4222-8222-222222222222' as const
+const LEAF_ID = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
+const LEAF_ID_2 = '22222222-2222-4222-8222-222222222222' as TerminalLeafId
 
 // Why: capture now appends an absolute cursor restore (see
 // terminal-serialize-absolute-cursor.ts), so pane mocks must expose the
@@ -327,6 +328,87 @@ describe('captureTerminalShutdownLayout', () => {
     expect(layout.scrollbackRefsByLeafId).toBeUndefined()
     expect(layout.ptyIdsByLeafId).toEqual({ [LEAF_ID]: 'pty-1' })
     expect(layout.titlesByLeafId).toEqual({ [LEAF_ID]: 'local shell' })
+  })
+
+  it('skips excluded remote-runtime scrollback while capturing sibling panes', async () => {
+    const { captureTerminalShutdownLayout } = await import('./terminal-shutdown-layout-capture')
+    const excludedSerialize = vi.fn(() => 'remote snapshot')
+    const capturedSerialize = vi.fn(() => 'ssh snapshot')
+    const firstPane = {
+      id: 1,
+      leafId: LEAF_ID,
+      terminal: mockTerminal(1_000),
+      serializeAddon: { serialize: excludedSerialize }
+    }
+    const secondPane = {
+      id: 2,
+      leafId: LEAF_ID_2,
+      terminal: mockTerminal(1_000),
+      serializeAddon: { serialize: capturedSerialize }
+    }
+    const manager = {
+      getPanes: vi.fn(() => [firstPane, secondPane]),
+      getActivePane: vi.fn(() => secondPane)
+    }
+
+    const layout = captureTerminalShutdownLayout({
+      manager: manager as never,
+      container: mockRootForSplit(),
+      expandedPaneId: null,
+      paneTransports: new Map([
+        [1, { getPtyId: vi.fn(() => 'remote:env-1@@terminal-1') }],
+        [2, { getPtyId: vi.fn(() => 'ssh:conn-1@@pty-2') }]
+      ]),
+      paneTitlesByPaneId: {},
+      existingLayout: {
+        root: null,
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        buffersByLeafId: {
+          [LEAF_ID]: 'prior remote snapshot',
+          [LEAF_ID_2]: 'prior ssh snapshot'
+        },
+        scrollbackRefsByLeafId: {
+          [LEAF_ID]: 'remote-ref',
+          [LEAF_ID_2]: 'ssh-ref'
+        }
+      },
+      excludedScrollbackLeafIds: new Set([LEAF_ID])
+    })
+
+    expect(excludedSerialize).not.toHaveBeenCalled()
+    expect(capturedSerialize).toHaveBeenCalledOnce()
+    expect(layout.buffersByLeafId).toEqual({
+      [LEAF_ID_2]: `ssh snapshot${CURSOR_HOME}`
+    })
+    expect(layout.scrollbackRefsByLeafId).toEqual({ [LEAF_ID_2]: 'ssh-ref' })
+  })
+
+  it('uses the persisted pty binding to exclude a remote-runtime pane during attach', async () => {
+    const { selectRemoteRuntimeScrollbackLeafIds } =
+      await import('./terminal-shutdown-layout-capture')
+    const panes = [
+      { id: 1, leafId: LEAF_ID },
+      { id: 2, leafId: LEAF_ID_2 }
+    ]
+    const excluded = selectRemoteRuntimeScrollbackLeafIds({
+      panes,
+      paneTransports: new Map([
+        [1, { getPtyId: () => null }],
+        [2, { getPtyId: () => 'repo::/worktree@@live-local' }]
+      ]),
+      existingLayout: {
+        root: null,
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: {
+          [LEAF_ID]: 'remote:env-1@@terminal-1',
+          [LEAF_ID_2]: 'remote:stale-env@@terminal-2'
+        }
+      }
+    })
+
+    expect(excluded).toEqual(new Set([LEAF_ID]))
   })
 
   it('does not preserve stale prior PTY bindings as shutdown focus targets', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shutdown-layout-capture.ts
@@ -8,6 +8,7 @@ import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../shared/terminal-scrollback-limits'
 import { serializeWithAbsoluteCursor } from '../../../../shared/terminal-serialize-absolute-cursor'
 import { getUtf8ByteLength, measureUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
+import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 
 const MAX_BUFFER_BYTES = TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT
 
@@ -16,6 +17,23 @@ type ShutdownPane = Pick<ManagedPane, 'id' | 'leafId' | 'terminal' | 'serializeA
 type ShutdownPaneManager = {
   getPanes(): ShutdownPane[]
   getActivePane(): ShutdownPane | null
+}
+
+export function selectRemoteRuntimeScrollbackLeafIds(args: {
+  panes: readonly Pick<ShutdownPane, 'id' | 'leafId'>[]
+  paneTransports: ReadonlyMap<number, Pick<PtyTransport, 'getPtyId'>>
+  existingLayout: TerminalLayoutSnapshot | undefined
+}): Set<string> {
+  const excludedLeafIds = new Set<string>()
+  for (const pane of args.panes) {
+    const livePtyId = args.paneTransports.get(pane.id)?.getPtyId()
+    // The persisted binding covers the attach gap before transport reports its PTY.
+    const ptyId = livePtyId ?? args.existingLayout?.ptyIdsByLeafId?.[pane.leafId] ?? null
+    if (ptyId && isRemoteRuntimePtyId(ptyId)) {
+      excludedLeafIds.add(pane.leafId)
+    }
+  }
+  return excludedLeafIds
 }
 
 type CaptureTerminalShutdownLayoutArgs = {
@@ -27,6 +45,7 @@ type CaptureTerminalShutdownLayoutArgs = {
   existingLayout: TerminalLayoutSnapshot | undefined
   captureBuffers?: boolean
   clearedScrollbackLeafIds?: ReadonlySet<string>
+  excludedScrollbackLeafIds?: ReadonlySet<string>
 }
 
 function omitClearedLeafState(
@@ -97,13 +116,17 @@ export function captureTerminalShutdownLayout({
   paneTitlesByPaneId,
   existingLayout,
   captureBuffers = true,
-  clearedScrollbackLeafIds
+  clearedScrollbackLeafIds,
+  excludedScrollbackLeafIds
 }: CaptureTerminalShutdownLayoutArgs): TerminalLayoutSnapshot {
   const panes = manager.getPanes()
   const buffers: Record<string, string> = {}
 
   if (captureBuffers) {
     for (const pane of panes) {
+      if (excludedScrollbackLeafIds?.has(pane.leafId)) {
+        continue
+      }
       try {
         // Why: non-focused panes may have renderer-throttled PTY bytes queued;
         // push them into xterm before taking the shutdown scrollback snapshot.
@@ -138,6 +161,10 @@ export function captureTerminalShutdownLayout({
     new Map(panes.map((pane) => [pane.id, pane.leafId]))
   )
   const currentLeafIds = new Set(panes.map((p) => p.leafId))
+  const omittedScrollbackLeafIds = new Set([
+    ...(clearedScrollbackLeafIds ?? []),
+    ...(excludedScrollbackLeafIds ?? [])
+  ])
   const livePtyIdsByLeafId: Record<string, string> = {}
   const preservedPtyIdsByLeafId: Record<string, string> = {}
   for (const pane of panes) {
@@ -157,13 +184,13 @@ export function captureTerminalShutdownLayout({
 
   const mergedBuffers = captureBuffers
     ? mergeCapturedLeafState({
-        prior: omitClearedLeafState(existingLayout?.buffersByLeafId, clearedScrollbackLeafIds),
+        prior: omitClearedLeafState(existingLayout?.buffersByLeafId, omittedScrollbackLeafIds),
         fresh: buffers,
         currentLeafIds
       })
     : {}
   const mergedScrollbackRefs = mergeCapturedLeafState({
-    prior: omitClearedLeafState(existingLayout?.scrollbackRefsByLeafId, clearedScrollbackLeafIds),
+    prior: omitClearedLeafState(existingLayout?.scrollbackRefsByLeafId, omittedScrollbackLeafIds),
     fresh: {},
     currentLeafIds
   })

--- a/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.test.ts
@@ -484,6 +484,45 @@ describe('registerTerminalSideEffectFactConsumer', () => {
     expect(later).toEqual([])
   })
 
+  it('keeps attention facts through title churn that exceeds the handoff cap', () => {
+    const dispose = registerTerminalSideEffectFactConsumer({
+      ptyId: PTY_ID,
+      callbacks: createCallbackRecorder().callbacks
+    })
+    dispose()
+    _dispatchTerminalSideEffectBatchForTest(
+      batch([{ kind: 'bell' }, { kind: 'command-code-done', prompt: 'Ship it' }], { seq: 1 })
+    )
+    for (let seq = 2; seq <= 130; seq += 1) {
+      _dispatchTerminalSideEffectBatchForTest(
+        batch(
+          [
+            {
+              kind: 'title',
+              normalizedTitle: `Codex frame ${seq}`,
+              rawTitle: `Codex frame ${seq}`
+            }
+          ],
+          { seq }
+        )
+      )
+    }
+
+    const events: unknown[][] = []
+    registerTerminalSideEffectFactConsumer({
+      ptyId: PTY_ID,
+      callbacks: {
+        onBell: () => events.push(['bell']),
+        onCommandCodeDone: (prompt) => events.push(['cc-done', prompt]),
+        onTitleChange: (title) => events.push(['title', title])
+      }
+    })
+
+    expect(events).toContainEqual(['bell'])
+    expect(events).toContainEqual(['cc-done', 'Ship it'])
+    expect(events.at(-1)).toEqual(['title', 'Codex frame 130'])
+  })
+
   it('does not buffer replay batches across a handoff', () => {
     // Why: the next consumer requests its own snapshot; a held replay would
     // regress the title it just restored.
@@ -538,7 +577,7 @@ describe('registerTerminalSideEffectFactConsumer', () => {
     expect(events).toEqual([['title', 'live', 'live']])
   })
 
-  it('drops a handoff-buffered batch once the buffer TTL expires', () => {
+  it('keeps handoff facts through relay and SSH retry settlement, then expires them', () => {
     vi.useFakeTimers()
     try {
       const dispose = registerTerminalSideEffectFactConsumer({
@@ -548,12 +587,21 @@ describe('registerTerminalSideEffectFactConsumer', () => {
       dispose()
       _dispatchTerminalSideEffectBatchForTest(batch([{ kind: 'bell' }]))
 
-      vi.advanceTimersByTime(15_001)
+      vi.advanceTimersByTime(61_001)
 
       const { callbacks, events } = createCallbackRecorder()
-      registerTerminalSideEffectFactConsumer({ ptyId: PTY_ID, callbacks })
+      const disposeAfterRetry = registerTerminalSideEffectFactConsumer({ ptyId: PTY_ID, callbacks })
 
-      expect(events).toEqual([])
+      expect(events).toEqual([['bell']])
+
+      disposeAfterRetry()
+      _dispatchTerminalSideEffectBatchForTest(batch([{ kind: 'bell' }]))
+      vi.advanceTimersByTime(75_001)
+
+      const expired = createCallbackRecorder()
+      registerTerminalSideEffectFactConsumer({ ptyId: PTY_ID, callbacks: expired.callbacks })
+
+      expect(expired.events).toEqual([])
     } finally {
       vi.useRealTimers()
     }

--- a/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.ts
@@ -173,7 +173,9 @@ function applyBatchToConsumer(entry: ConsumerEntry, batch: TerminalSideEffectBat
 // dropped in that window is lost for good. Only a PTY that just lost its
 // consumer buffers (never-consumed PTYs still drop, per the module contract),
 // bounded in time, batches, and PTYs so an abandoned handoff retains nothing.
-const HANDOFF_FACT_BUFFER_TTL_MS = 15_000
+// Why 75s: a reveal can traverse a 30s relay request and 31s direct-pane
+// settlement before registration; keep scheduling margin beyond that chain.
+const HANDOFF_FACT_BUFFER_TTL_MS = 75_000
 const MAX_HANDOFF_FACT_BATCHES = 64
 const MAX_HANDOFF_FACT_PTYS = 32
 
@@ -215,8 +217,15 @@ function bufferHandoffFactBatch(batch: TerminalSideEffectBatch): void {
   if (batch.replay) {
     return
   }
-  if (buffer.batches.length >= MAX_HANDOFF_FACT_BATCHES) {
-    buffer.batches.shift()
+  const isTitleOnly = (candidate: TerminalSideEffectBatch): boolean =>
+    candidate.facts.every((fact) => fact.kind === 'title')
+  if (isTitleOnly(batch)) {
+    // Why: title state is last-wins; compact spinner frames so they cannot evict attention facts.
+    buffer.batches = buffer.batches.filter((candidate) => !isTitleOnly(candidate))
+  }
+  while (buffer.batches.length >= MAX_HANDOFF_FACT_BATCHES) {
+    const titleOnlyIndex = buffer.batches.findIndex(isTitleOnly)
+    buffer.batches.splice(Math.max(titleOnlyIndex, 0), 1)
   }
   buffer.batches.push(batch)
 }

--- a/src/renderer/src/lib/pane-manager/pane-fit-continuation-retry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-continuation-retry.ts
@@ -3,18 +3,29 @@ import { getLivePaneCensus } from './pane-manager-registry'
 import type { ManagedPane } from './pane-manager-types'
 
 const MAX_RETRY_FRAMES = 40
+const COLLAPSED_LAYOUT_RETRY_FRAMES = 4
 const LAYOUT_SETTLE_MS = 16
 
 type RetrySchedule = { cancel: () => void }
 
 type RetryState = {
   attempts: number
+  collapsedLayoutAttempts: number
   schedule: RetrySchedule | null
   retry: () => boolean
   onExhausted: () => void
 }
 
 const retryByPane = new WeakMap<ManagedPane, RetryState>()
+
+function isConnectedCollapsedPane(pane: ManagedPane): boolean {
+  const container = pane.container
+  if (container.isConnected !== true || container.offsetParent == null) {
+    return false
+  }
+  const rect = container.getBoundingClientRect?.()
+  return Boolean(rect && (rect.width === 0 || rect.height === 0))
+}
 
 function scheduleRetryTick(run: () => void): RetrySchedule {
   if (typeof requestAnimationFrame === 'function') {
@@ -59,6 +70,7 @@ export function armPaneFitContinuationRetry(
 ): void {
   const state = retryByPane.get(pane) ?? {
     attempts: 0,
+    collapsedLayoutAttempts: 0,
     schedule: null,
     ...callbacks
   }
@@ -75,6 +87,15 @@ export function armPaneFitContinuationRetry(
       return
     }
     state.attempts += 1
+    state.collapsedLayoutAttempts = isConnectedCollapsedPane(pane)
+      ? state.collapsedLayoutAttempts + 1
+      : 0
+    if (state.collapsedLayoutAttempts >= COLLAPSED_LAYOUT_RETRY_FRAMES) {
+      // Why: a connected 0×0 split has no destination grid; waiting the full reveal budget only stalls replay and live output.
+      clearPaneFitContinuationRetry(pane)
+      state.onExhausted()
+      return
+    }
     if (state.attempts >= MAX_RETRY_FRAMES) {
       // Why leafId + census: `pane.id` restarts at 1 per PaneManager and there
       // is one manager per tab, so a burst of identical `paneId: 1` crumbs

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -22,6 +22,7 @@ function flushAnimationFrames(timestamp = 16): void {
 type TestPane = ManagedPane & {
   setRect: (rect: { width: number; height: number }) => void
   setXtermRect: (rect: { width: number; height: number }) => void
+  setLayoutConnection: (connected: boolean, hasOffsetParent: boolean) => void
 }
 
 function createPane(options: {
@@ -31,6 +32,8 @@ function createPane(options: {
   let rect = options.rect
   // Why: the reveal gate measures the inner xterm host, which can differ from the outer .pane.
   let xtermRect: { width: number; height: number } | null = null
+  let layoutConnected = false
+  let layoutHasOffsetParent = false
   const leafId = '22222222-2222-4222-8222-222222222222'
   const pane = {
     id: 7,
@@ -39,6 +42,12 @@ function createPane(options: {
     terminal: { cols: 80, rows: 24 },
     container: {
       dataset: {},
+      get isConnected() {
+        return layoutConnected
+      },
+      get offsetParent() {
+        return layoutHasOffsetParent ? {} : null
+      },
       getBoundingClientRect: () => ({ width: rect.width, height: rect.height })
     },
     xtermContainer: {
@@ -59,6 +68,10 @@ function createPane(options: {
     },
     setXtermRect: (next: { width: number; height: number }) => {
       xtermRect = next
+    },
+    setLayoutConnection: (connected: boolean, hasOffsetParent: boolean) => {
+      layoutConnected = connected
+      layoutHasOffsetParent = hasOffsetParent
     }
   }
   return pane as unknown as TestPane
@@ -150,6 +163,65 @@ describe('safeFitAndThen unmeasurable-pane retry', () => {
     expect(continuation).not.toHaveBeenCalled()
 
     safeFit(pane)
+
+    expect(continuation).toHaveBeenCalledTimes(1)
+    await expect(handle.completion).resolves.toBe(true)
+  })
+
+  it('settles a persistently collapsed connected split without the hidden-pane retry delay', async () => {
+    const pane = createPane({ rect: { width: 0, height: 0 } })
+    const continuation = vi.fn()
+    pane.setLayoutConnection(true, true)
+
+    const handle = safeFitAndThen(pane, 'hidden-snapshot-pty-resize', continuation, {
+      retryIfUnmeasurable: true
+    })
+    for (let frame = 0; frame < 4; frame += 1) {
+      flushAnimationFrames(frame * 16)
+      vi.advanceTimersByTime(16)
+    }
+
+    expect(continuation).not.toHaveBeenCalled()
+    expect(recordRendererCrashBreadcrumb).not.toHaveBeenCalled()
+    await expect(handle.completion).resolves.toBe(false)
+  })
+
+  it('keeps retrying a connected pane hidden by an ancestor', async () => {
+    const pane = createPane({ rect: { width: 0, height: 0 } })
+    const continuation = vi.fn()
+    pane.setLayoutConnection(true, false)
+
+    const handle = safeFitAndThen(pane, 'hidden-snapshot-pty-resize', continuation, {
+      retryIfUnmeasurable: true
+    })
+    for (let frame = 0; frame < 4; frame += 1) {
+      flushAnimationFrames(frame * 16)
+      vi.advanceTimersByTime(16)
+    }
+    pane.setRect({ width: 800, height: 600 })
+    pane.setLayoutConnection(true, true)
+    flushAnimationFrames(64)
+    vi.advanceTimersByTime(16)
+
+    expect(continuation).toHaveBeenCalledTimes(1)
+    await expect(handle.completion).resolves.toBe(true)
+  })
+
+  it('still accepts a connected split that gains layout within the collapsed retry window', async () => {
+    const pane = createPane({ rect: { width: 0, height: 0 } })
+    const continuation = vi.fn()
+    pane.setLayoutConnection(true, true)
+
+    const handle = safeFitAndThen(pane, 'hidden-snapshot-pty-resize', continuation, {
+      retryIfUnmeasurable: true
+    })
+    for (let frame = 0; frame < 3; frame += 1) {
+      flushAnimationFrames(frame * 16)
+      vi.advanceTimersByTime(16)
+    }
+    pane.setRect({ width: 800, height: 600 })
+    flushAnimationFrames(64)
+    vi.advanceTimersByTime(16)
 
     expect(continuation).toHaveBeenCalledTimes(1)
     await expect(handle.completion).resolves.toBe(true)

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1332,14 +1332,14 @@ describe('pane terminal output scheduler', () => {
 
     expect(terminal.write).not.toHaveBeenCalled()
 
-    // Why 12: promoted backlogs use the parse-clocked high-priority budget
+    // Why 8: promoted backlogs use the parse-clocked high-priority budget
     // (HIGH_PRIORITY_MAX_WRITES_PER_DRAIN) so a visible flood drains at the
     // parser's pace instead of a fixed 2-write drip.
     vi.advanceTimersByTime(0)
-    expect(terminal.write).toHaveBeenCalledTimes(12)
+    expect(terminal.write).toHaveBeenCalledTimes(8)
 
     vi.advanceTimersByTime(4)
-    expect(terminal.write).toHaveBeenCalledTimes(24)
+    expect(terminal.write).toHaveBeenCalledTimes(16)
   })
 
   it('yields high-priority backlog drains when writes spend the frame budget', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1332,14 +1332,14 @@ describe('pane terminal output scheduler', () => {
 
     expect(terminal.write).not.toHaveBeenCalled()
 
-    // Why 8: promoted backlogs use the parse-clocked high-priority budget
+    // Why 12: promoted backlogs use the parse-clocked high-priority budget
     // (HIGH_PRIORITY_MAX_WRITES_PER_DRAIN) so a visible flood drains at the
     // parser's pace instead of a fixed 2-write drip.
     vi.advanceTimersByTime(0)
-    expect(terminal.write).toHaveBeenCalledTimes(8)
+    expect(terminal.write).toHaveBeenCalledTimes(12)
 
     vi.advanceTimersByTime(4)
-    expect(terminal.write).toHaveBeenCalledTimes(16)
+    expect(terminal.write).toHaveBeenCalledTimes(24)
   })
 
   it('yields high-priority backlog drains when writes spend the frame budget', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -92,8 +92,8 @@ const BACKGROUND_DRAIN_INTERVAL_MS = 16
 const HIGH_PRIORITY_DRAIN_INTERVAL_MS = 4
 const BACKGROUND_CHUNK_CHARS = 16 * 1024
 const MAX_WRITES_PER_DRAIN = 2
-// Why 12: visible split-pane fan-in needs 192KB/tick; the 8ms budget still bounds slow parsers.
-const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 12
+// Why 8: per-tick volume (8 x 16KB = 128KB ≈ 1.3ms parse) sets the sustained ceiling (~30MB/s) within DRAIN_TIME_BUDGET_MS; at 2 it was only 8MB/s against a ~100MB/s parser (see throughput bench).
+const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 8
 const DRAIN_TIME_BUDGET_MS = 8
 const LARGE_BACKLOG_CHARS = 512 * 1024
 const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -92,8 +92,8 @@ const BACKGROUND_DRAIN_INTERVAL_MS = 16
 const HIGH_PRIORITY_DRAIN_INTERVAL_MS = 4
 const BACKGROUND_CHUNK_CHARS = 16 * 1024
 const MAX_WRITES_PER_DRAIN = 2
-// Why 8: per-tick volume (8 x 16KB = 128KB ≈ 1.3ms parse) sets the sustained ceiling (~30MB/s) within DRAIN_TIME_BUDGET_MS; at 2 it was only 8MB/s against a ~100MB/s parser (see throughput bench).
-const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 8
+// Why 12: visible split-pane fan-in needs 192KB/tick; the 8ms budget still bounds slow parsers.
+const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 12
 const DRAIN_TIME_BUDGET_MS = 8
 const LARGE_BACKLOG_CHARS = 512 * 1024
 const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024

--- a/src/shared/e2e-config.ts
+++ b/src/shared/e2e-config.ts
@@ -29,7 +29,7 @@ export function createE2EConfig(input: E2EConfigInput): E2EConfig {
     input.terminalParkingDelayMs > 0
       ? input.terminalParkingDelayMs
       : null
-  // Why: a worktree count — only a positive integer is a meaningful budget.
+  // Why: pane-weight units — only a positive integer is a meaningful budget.
   const terminalRetentionLimit =
     typeof input.terminalRetentionLimit === 'number' &&
     Number.isInteger(input.terminalRetentionLimit) &&

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2857,7 +2857,7 @@ export type GlobalSettings = {
   terminalHiddenViewParking?: boolean
   /** Kill switch for SSH terminal parking (C1): SSH panes park like local ones; reveal restores from main's headless model, falling back to relay replay. */
   terminalSshViewParking?: boolean
-  /** Kill switch for the hidden-worktree retention budget (C1): force-parks the least-recently-hidden un-parkable worktrees beyond a count budget or TTL. */
+  /** Kill switch for the hidden-worktree retention budget (C1): force-parks un-parkable worktrees beyond a pane-weight budget or TTL. */
   terminalHiddenWorktreeRetentionBudget?: boolean
   /** Kill switch for main-process PTY side-effect authority; on (default) = title/bell/agent facts via pty:sideEffect channel, not renderer byte parsing. */
   terminalMainSideEffectAuthority?: boolean

--- a/tests/e2e/artificial-opencode-hidden-pressure-completion.ts
+++ b/tests/e2e/artificial-opencode-hidden-pressure-completion.ts
@@ -1,0 +1,28 @@
+import type { Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+
+export async function waitForHiddenPressureCompletion(
+  orcaPage: Page,
+  hiddenPanes: { ptyId: string }[],
+  runId: string
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        orcaPage.evaluate(
+          async ({ panes, markerPrefix }) => {
+            const snapshots = await Promise.all(
+              panes.map((pane) =>
+                window.api.pty.getMainBufferSnapshot(pane.ptyId, { scrollbackRows: 50 })
+              )
+            )
+            return snapshots.filter((snapshot, index) =>
+              snapshot?.data.includes(`${markerPrefix}${index}`)
+            ).length
+          },
+          { panes: hiddenPanes, markerPrefix: `OPENCODE_PRESSURE_DONE_${runId}_` }
+        ),
+      { timeout: 60_000, message: 'Hidden PTY pressure generators did not finish' }
+    )
+    .toBe(hiddenPanes.length)
+}

--- a/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
@@ -8,7 +8,10 @@ import {
   writePressureOutputScript
 } from './artificial-opencode-hidden-pressure-script'
 import { waitForHiddenPressureCompletion } from './artificial-opencode-hidden-pressure-completion'
-import { waitForMarkerLatency } from './artificial-opencode-pane-interactions'
+import {
+  describeHiddenOutputRestoreMeasurement,
+  measureHiddenOutputRestoreLatency
+} from './artificial-opencode-hidden-restore-measurement'
 import {
   ensureTerminalVisible,
   getActiveWorktreeId,
@@ -217,22 +220,22 @@ export async function runHiddenRealPtyPressureScenario<
     expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_HIDDEN_PRESSURE_TIMER_DRIFT_MS)
 
     await deps.releaseTerminalAckGate(orcaPage)
-    const restoreLatencyMs = await measureHiddenOutputRestoreLatency(
+    const restoreMeasurement = await measureHiddenOutputRestoreLatency(
       orcaPage,
       secondWorktreeId,
       runId
     )
     testInfo.annotations.push({
       type: `opencode-hidden-real-pty-restore${annotationSuffix ?? ''}`,
-      description: `panes=${hiddenPanes.length + 1} restore=${restoreLatencyMs.toFixed(
-        1
-      )}ms hiddenDeliveryDroppedChars=${
-        mainPressure?.hiddenDeliveryDroppedChars ?? 0
-      } mainPeakInFlightChars=${mainPressure?.peakRendererInFlightChars ?? 0} heldAckChars=${
-        ackGate?.heldAckChars ?? 0
-      }`
+      description: describeHiddenOutputRestoreMeasurement({
+        paneCount: hiddenPanes.length + 1,
+        measurement: restoreMeasurement,
+        hiddenDeliveryDroppedChars: mainPressure?.hiddenDeliveryDroppedChars ?? 0,
+        mainPeakInFlightChars: mainPressure?.peakRendererInFlightChars ?? 0,
+        heldAckChars: ackGate?.heldAckChars ?? 0
+      })
     })
-    expect(restoreLatencyMs).toBeLessThan(MAX_HIDDEN_RESTORE_LATENCY_MS)
+    expect(restoreMeasurement.elapsedMs).toBeLessThan(MAX_HIDDEN_RESTORE_LATENCY_MS)
   } finally {
     await cleanupHiddenPressureScenario({
       deps,
@@ -260,17 +263,6 @@ async function waitForMainHiddenDeliveryDrops<TMainPressure extends HiddenPressu
       { timeout: 30_000, message: 'Main hidden-delivery gate did not drop hidden PTY output' }
     )
     .toBeGreaterThanOrEqual(minimumDroppedChars)
-}
-
-async function measureHiddenOutputRestoreLatency(
-  orcaPage: Page,
-  worktreeId: string,
-  runId: string
-): Promise<number> {
-  const restoreStart = performance.now()
-  await switchToWorktree(orcaPage, worktreeId)
-  await waitForMarkerLatency(orcaPage, `OPENCODE_PRESSURE_DONE_${runId}_`, 20_000)
-  return performance.now() - restoreStart
 }
 
 async function startHiddenPressureCommands({

--- a/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
@@ -7,6 +7,7 @@ import {
   type HiddenPressureOutputMode,
   writePressureOutputScript
 } from './artificial-opencode-hidden-pressure-script'
+import { waitForHiddenPressureCompletion } from './artificial-opencode-hidden-pressure-completion'
 import { waitForMarkerLatency } from './artificial-opencode-pane-interactions'
 import {
   ensureTerminalVisible,
@@ -174,6 +175,8 @@ export async function runHiddenRealPtyPressureScenario<
       typingPtyId,
       runId
     )
+    // Why: typing must overlap live pressure, but restore must start from a complete hidden model rather than timing the remaining generators.
+    await waitForHiddenPressureCompletion(orcaPage, hiddenPanes, runId)
     const debug = await deps.readTerminalPtyOutputDebug(orcaPage)
     const scheduler = await deps.readTerminalOutputSchedulerDebug(orcaPage)
     const mainPressure = await deps.readMainPtyPressureDebug(orcaPage)
@@ -249,14 +252,14 @@ export async function runHiddenRealPtyPressureScenario<
 async function waitForMainHiddenDeliveryDrops<TMainPressure extends HiddenPressureMainSnapshot>(
   orcaPage: Page,
   deps: { readMainPtyPressureDebug: (page: Page) => Promise<TMainPressure | null> },
-  pressureOutputChars: number
+  minimumDroppedChars: number
 ): Promise<void> {
   await expect
     .poll(
       async () => (await deps.readMainPtyPressureDebug(orcaPage))?.hiddenDeliveryDroppedChars ?? 0,
       { timeout: 30_000, message: 'Main hidden-delivery gate did not drop hidden PTY output' }
     )
-    .toBeGreaterThanOrEqual(pressureOutputChars)
+    .toBeGreaterThanOrEqual(minimumDroppedChars)
 }
 
 async function measureHiddenOutputRestoreLatency(

--- a/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-hidden-pressure-scenario.ts
@@ -7,6 +7,7 @@ import {
   type HiddenPressureOutputMode,
   writePressureOutputScript
 } from './artificial-opencode-hidden-pressure-script'
+import { waitForMarkerLatency } from './artificial-opencode-pane-interactions'
 import {
   ensureTerminalVisible,
   getActiveWorktreeId,
@@ -16,7 +17,6 @@ import {
   waitForSessionReady
 } from './helpers/store'
 import {
-  getTerminalContent,
   sendToTerminal,
   waitForActivePanePtyId,
   waitForActiveTerminalManager
@@ -83,11 +83,8 @@ type HiddenPressureAckGate = {
   heldAckChars: number
 }
 
-// Why: restore still has to finish promptly, but parallel Electron workers on
-// Linux CI can overshoot the 1s product target without a responsiveness regression.
-// Main relaxed this to 4s for drain-plus-poll overhead on loaded OSS runners; this
-// branch keeps a far stricter budget with only a small margin for the whole-buffer
-// serialize-poll overhead (seen at ~1.5s), so a genuinely slow restore is still caught.
+// Why: keep a runtime backstop so loaded CI still emits the measurement;
+// saved perf reports enforce the stricter 1s product budget.
 const MAX_HIDDEN_RESTORE_LATENCY_MS = 2_000
 // Why: Phase-4 hidden-delivery gate contract — hidden PTY bytes are dropped in
 // main after model ingestion, so renderer-delivery pressure must stay FAR
@@ -269,12 +266,7 @@ async function measureHiddenOutputRestoreLatency(
 ): Promise<number> {
   const restoreStart = performance.now()
   await switchToWorktree(orcaPage, worktreeId)
-  await expect
-    .poll(() => getTerminalContent(orcaPage, 20_000), {
-      timeout: 20_000,
-      message: 'Hidden PTY output was not restored from main buffer on return'
-    })
-    .toContain(`OPENCODE_PRESSURE_DONE_${runId}_`)
+  await waitForMarkerLatency(orcaPage, `OPENCODE_PRESSURE_DONE_${runId}_`, 20_000)
   return performance.now() - restoreStart
 }
 

--- a/tests/e2e/artificial-opencode-hidden-restore-measurement.ts
+++ b/tests/e2e/artificial-opencode-hidden-restore-measurement.ts
@@ -1,0 +1,60 @@
+import type { Page } from '@stablyai/playwright-test'
+import { waitForMarkerLatency } from './artificial-opencode-pane-interactions'
+import {
+  measureTerminalOperationLatency,
+  type TerminalLatencyMeasurement
+} from './artificial-opencode-terminal-latency-measurement'
+import { switchToWorktree } from './helpers/store'
+
+export async function measureHiddenOutputRestoreLatency(
+  page: Page,
+  worktreeId: string,
+  runId: string
+): Promise<TerminalLatencyMeasurement> {
+  return measureTerminalOperationLatency(page, async () => {
+    await switchToWorktree(page, worktreeId)
+    await waitForMarkerLatency(page, `OPENCODE_PRESSURE_DONE_${runId}_`, 20_000)
+  })
+}
+
+function formatOptionalMetric(value: number | null, suffix: string): string {
+  return value == null ? 'na' : `${value.toFixed(1)}${suffix}`
+}
+
+export function describeHiddenOutputRestoreMeasurement({
+  paneCount,
+  measurement,
+  hiddenDeliveryDroppedChars,
+  mainPeakInFlightChars,
+  heldAckChars
+}: {
+  paneCount: number
+  measurement: TerminalLatencyMeasurement
+  hiddenDeliveryDroppedChars: number
+  mainPeakInFlightChars: number
+  heldAckChars: number
+}): string {
+  return `panes=${paneCount} restore=${measurement.elapsedMs.toFixed(
+    1
+  )}ms restoreRendererDrift=${measurement.maxTimerDriftMs.toFixed(
+    1
+  )}ms restoreControllerDrift=${measurement.controllerMaxTimerDriftMs.toFixed(
+    1
+  )}ms restoreRendererLongTask=${measurement.rendererMaxLongTaskMs.toFixed(
+    1
+  )}ms restoreLongTaskSupported=${
+    measurement.rendererLongTaskSupported
+  } restoreRendererTask=${formatOptionalMetric(
+    measurement.rendererTaskDurationMs,
+    'ms'
+  )} restoreRendererScript=${formatOptionalMetric(
+    measurement.rendererScriptDurationMs,
+    'ms'
+  )} restoreHostCpuBusy=${formatOptionalMetric(
+    measurement.hostCpuBusyPercent,
+    '%'
+  )} restoreHostCpuPressureWait=${formatOptionalMetric(
+    measurement.hostCpuPressureWaitMs,
+    'ms'
+  )} hiddenDeliveryDroppedChars=${hiddenDeliveryDroppedChars} mainPeakInFlightChars=${mainPeakInFlightChars} heldAckChars=${heldAckChars}`
+}

--- a/tests/e2e/artificial-opencode-pane-interactions.ts
+++ b/tests/e2e/artificial-opencode-pane-interactions.ts
@@ -2,7 +2,6 @@ import type { Page } from '@stablyai/playwright-test'
 import { expect } from './helpers/orca-app'
 import { ensureTerminalVisible } from './helpers/store'
 import {
-  getTerminalContent,
   splitActiveTerminalPane,
   waitForActiveTerminalManager,
   waitForPaneIdentitySnapshot
@@ -76,12 +75,59 @@ export async function waitForMarkerLatency(
 ): Promise<number> {
   const start = performance.now()
   while (performance.now() - start < timeoutMs) {
-    if ((await getTerminalContent(page, 12_000)).includes(marker)) {
+    if (await activeTerminalTailContains(page, marker)) {
       return performance.now() - start
     }
     await page.waitForTimeout(5)
   }
   throw new Error(`Timed out waiting for terminal marker ${marker}`)
+}
+
+// Marker probes only need recent text; serializing full scrollback can dominate the latency under test.
+export async function activeTerminalTailContains(
+  page: Page,
+  expected: string,
+  maxRows = 200
+): Promise<boolean> {
+  return page.evaluate(
+    ({ expected, maxRows }) => {
+      const state = window.__store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      const tabs = worktreeId ? (state?.tabsByWorktree[worktreeId] ?? []) : []
+      const preferredTabId =
+        state?.activeTabType === 'terminal'
+          ? state.activeTabId
+          : worktreeId
+            ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const tabId =
+        preferredTabId && tabs.some((tab) => tab.id === preferredTabId)
+          ? preferredTabId
+          : (tabs[0]?.id ?? null)
+      const manager = tabId ? window.__paneManagers?.get(tabId) : null
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      const buffer = pane?.terminal?.buffer?.active
+      if (!buffer) {
+        return false
+      }
+      const firstRow = Math.max(0, buffer.length - maxRows)
+      let logicalHead = ''
+      for (let row = buffer.length - 1; row >= firstRow; row -= 1) {
+        const line = buffer.getLine(row)
+        if (!line) {
+          logicalHead = ''
+          continue
+        }
+        logicalHead = line.translateToString(true) + logicalHead
+        if (logicalHead.includes(expected)) {
+          return true
+        }
+        logicalHead = line.isWrapped ? logicalHead.slice(0, expected.length) : ''
+      }
+      return false
+    },
+    { expected, maxRows }
+  )
 }
 
 export async function getTerminalContentForPtyId(

--- a/tests/e2e/artificial-opencode-revisit-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-revisit-pressure-scenario.ts
@@ -28,7 +28,13 @@ type RevisitPressureMeasurement = {
 
 // Why: the renderer hidden-skip counters were deleted with the skip grammar;
 // only the mode-2031 fact-reply counter still exists renderer-side.
-type RevisitPressureDebug = { hiddenRendererMode2031ReplyCount: number }
+type RevisitPressureDebug = {
+  hiddenRendererMode2031ReplyCount: number
+  activeHiddenRestoreCount: number
+  activeHiddenRestoreSnapshotMs: number
+  activeHiddenRestoreReplayMs: number
+  activeHiddenRestoreTotalMs: number
+}
 
 type RevisitPressureSchedulerSnapshot = {
   peakQueuedChars: number
@@ -201,11 +207,18 @@ export async function runRendererBackpressureRevisitScenario<
     await deps.focusPane(orcaPage, revisitPane.paneKey)
     await sendToTerminal(orcaPage, revisitPane.ptyId, `printf '\\n${revisitMarker}\\n'\r`)
     const revisitLatencyMs = await waitForMarkerLatency(orcaPage, revisitMarker, 10_000)
+    const revisitDebug = await deps.readTerminalPtyOutputDebug(orcaPage)
     testInfo.annotations.push({
       type: 'opencode-main-pressure-worktree-revisit-marker',
       description: `panes=${panes.length + 1} revisit=${revisitLatencyMs.toFixed(
         1
-      )}ms heldAckChars=${ackGate?.heldAckChars ?? 0}`
+      )}ms heldAckChars=${ackGate?.heldAckChars ?? 0} activeRestores=${
+        revisitDebug?.activeHiddenRestoreCount ?? 0
+      } activeRestoreSnapshot=${(revisitDebug?.activeHiddenRestoreSnapshotMs ?? 0).toFixed(
+        1
+      )}ms activeRestoreReplay=${(revisitDebug?.activeHiddenRestoreReplayMs ?? 0).toFixed(
+        1
+      )}ms activeRestoreTotal=${(revisitDebug?.activeHiddenRestoreTotalMs ?? 0).toFixed(1)}ms`
     })
     // Why: this printf is measured after a worktree switch/focus while the
     // background panes are still ACK-gate-held, so it gets its own under-load

--- a/tests/e2e/artificial-opencode-revisit-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-revisit-pressure-scenario.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import { rmSync } from 'node:fs'
 import path from 'node:path'
 import { writePressureOutputScript } from './artificial-opencode-hidden-pressure-script'
+import { waitForMarkerLatency } from './artificial-opencode-pane-interactions'
 import {
   ensureTerminalVisible,
   getAllWorktreeIds,
@@ -12,7 +13,6 @@ import {
   waitForSessionReady
 } from './helpers/store'
 import {
-  getTerminalContent,
   sendToTerminal,
   waitForActivePanePtyId,
   waitForActiveTerminalManager
@@ -260,21 +260,6 @@ async function startRealPtyPressureCommands({
       )
     )
   )
-}
-
-async function waitForMarkerLatency(
-  page: Page,
-  marker: string,
-  timeoutMs: number
-): Promise<number> {
-  const start = performance.now()
-  while (performance.now() - start < timeoutMs) {
-    if ((await getTerminalContent(page, 12_000)).includes(marker)) {
-      return performance.now() - start
-    }
-    await page.waitForTimeout(5)
-  }
-  throw new Error(`Timed out waiting for terminal marker ${marker}`)
 }
 
 function expectPressureStayedBounded<TMeasurement extends RevisitPressureMeasurement>({

--- a/tests/e2e/artificial-opencode-revisit-pressure-scenario.ts
+++ b/tests/e2e/artificial-opencode-revisit-pressure-scenario.ts
@@ -28,13 +28,7 @@ type RevisitPressureMeasurement = {
 
 // Why: the renderer hidden-skip counters were deleted with the skip grammar;
 // only the mode-2031 fact-reply counter still exists renderer-side.
-type RevisitPressureDebug = {
-  hiddenRendererMode2031ReplyCount: number
-  activeHiddenRestoreCount: number
-  activeHiddenRestoreSnapshotMs: number
-  activeHiddenRestoreReplayMs: number
-  activeHiddenRestoreTotalMs: number
-}
+type RevisitPressureDebug = { hiddenRendererMode2031ReplyCount: number }
 
 type RevisitPressureSchedulerSnapshot = {
   peakQueuedChars: number
@@ -207,18 +201,11 @@ export async function runRendererBackpressureRevisitScenario<
     await deps.focusPane(orcaPage, revisitPane.paneKey)
     await sendToTerminal(orcaPage, revisitPane.ptyId, `printf '\\n${revisitMarker}\\n'\r`)
     const revisitLatencyMs = await waitForMarkerLatency(orcaPage, revisitMarker, 10_000)
-    const revisitDebug = await deps.readTerminalPtyOutputDebug(orcaPage)
     testInfo.annotations.push({
       type: 'opencode-main-pressure-worktree-revisit-marker',
       description: `panes=${panes.length + 1} revisit=${revisitLatencyMs.toFixed(
         1
-      )}ms heldAckChars=${ackGate?.heldAckChars ?? 0} activeRestores=${
-        revisitDebug?.activeHiddenRestoreCount ?? 0
-      } activeRestoreSnapshot=${(revisitDebug?.activeHiddenRestoreSnapshotMs ?? 0).toFixed(
-        1
-      )}ms activeRestoreReplay=${(revisitDebug?.activeHiddenRestoreReplayMs ?? 0).toFixed(
-        1
-      )}ms activeRestoreTotal=${(revisitDebug?.activeHiddenRestoreTotalMs ?? 0).toFixed(1)}ms`
+      )}ms heldAckChars=${ackGate?.heldAckChars ?? 0}`
     })
     // Why: this printf is measured after a worktree switch/focus while the
     // background panes are still ACK-gate-held, so it gets its own under-load

--- a/tests/e2e/artificial-opencode-terminal-latency-measurement.ts
+++ b/tests/e2e/artificial-opencode-terminal-latency-measurement.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@stablyai/playwright-test'
+import type { CDPSession, Page } from '@stablyai/playwright-test'
 import { readFileSync } from 'node:fs'
 import { performance } from 'node:perf_hooks'
 import {
@@ -8,20 +8,25 @@ import {
 } from './artificial-opencode-pane-interactions'
 import { sendToTerminal } from './helpers/terminal'
 
-export type TypingMeasurement = {
-  latencies: number[]
-  dispatchLatencies: number[]
-  echoLatencies: number[]
-  medianLatencyMs: number
-  worstLatencyMs: number
+export type TerminalLatencyMeasurement = {
   maxTimerDriftMs: number
   controllerMaxTimerDriftMs: number
   rendererMaxLongTaskMs: number
   rendererLongTaskSupported: boolean
   rendererKeydownCount: number
+  rendererTaskDurationMs: number | null
+  rendererScriptDurationMs: number | null
   hostCpuBusyPercent: number | null
   hostCpuPressureWaitMs: number | null
   elapsedMs: number
+}
+
+export type TypingMeasurement = TerminalLatencyMeasurement & {
+  latencies: number[]
+  dispatchLatencies: number[]
+  echoLatencies: number[]
+  medianLatencyMs: number
+  worstLatencyMs: number
   frameCount: number
 }
 
@@ -29,6 +34,11 @@ type HostCpuSnapshot = {
   idleTicks: number
   pressureWaitMicros: number | null
   totalTicks: number
+}
+
+type RendererDurationSnapshot = {
+  scriptDurationMs: number
+  taskDurationMs: number
 }
 
 const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
@@ -103,17 +113,59 @@ function startControllerTimerDrift(): () => number {
   }
 }
 
-export async function measureTerminalTypingDuringLoad(
-  page: Page,
-  scriptPath: string,
-  ptyId: string,
-  runId: string,
-  frameCount: number
-): Promise<TypingMeasurement> {
-  await sendToTerminal(page, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
-  await waitForTerminalOutputForPtyId(page, ptyId, `OPENCODE_TYPING_READY_${runId}`, 10_000)
-  await focusActiveTerminalInput(page)
+async function readRendererDurationSnapshot(
+  session: CDPSession
+): Promise<RendererDurationSnapshot> {
+  const { metrics } = await session.send('Performance.getMetrics')
+  const metric = (name: string): number =>
+    (metrics.find((candidate) => candidate.name === name)?.value ?? 0) * 1_000
+  return {
+    scriptDurationMs: metric('ScriptDuration'),
+    taskDurationMs: metric('TaskDuration')
+  }
+}
 
+async function startRendererDurationMeasurement(page: Page): Promise<{
+  stop: () => Promise<{
+    scriptDurationMs: number | null
+    taskDurationMs: number | null
+  }>
+}> {
+  let session: CDPSession | null = null
+  let start: RendererDurationSnapshot | null = null
+  try {
+    session = await page.context().newCDPSession(page)
+    await session.send('Performance.enable')
+    start = await readRendererDurationSnapshot(session)
+  } catch {
+    await session?.detach().catch(() => {})
+    session = null
+  }
+  return {
+    stop: async () => {
+      if (!session || !start) {
+        return { scriptDurationMs: null, taskDurationMs: null }
+      }
+      try {
+        const end = await readRendererDurationSnapshot(session)
+        return {
+          scriptDurationMs: end.scriptDurationMs - start.scriptDurationMs,
+          taskDurationMs: end.taskDurationMs - start.taskDurationMs
+        }
+      } catch {
+        return { scriptDurationMs: null, taskDurationMs: null }
+      } finally {
+        await session.detach().catch(() => {})
+      }
+    }
+  }
+}
+
+export async function measureTerminalOperationLatency(
+  page: Page,
+  operation: () => Promise<void>
+): Promise<TerminalLatencyMeasurement> {
+  const rendererDuration = await startRendererDurationMeasurement(page)
   const rendererWatcher = await page.evaluateHandle((sampleMs) => {
     let maxTimerDriftMs = 0
     let maxLongTaskMs = 0
@@ -152,12 +204,13 @@ export async function measureTerminalTypingDuringLoad(
   const stopControllerTimer = startControllerTimerDrift()
   const hostCpuStart = readHostCpuSnapshot()
   const measurementStart = performance.now()
-  const latencies: number[] = []
-  const dispatchLatencies: number[] = []
-  const echoLatencies: number[] = []
   let controllerMaxTimerDriftMs = 0
   let elapsedMs = 0
   let hostCpuEnd: HostCpuSnapshot | null = null
+  let rendererDurationDelta = {
+    scriptDurationMs: null as number | null,
+    taskDurationMs: null as number | null
+  }
   let rendererTiming = {
     keydownCount: 0,
     longTaskSupported: false,
@@ -165,6 +218,48 @@ export async function measureTerminalTypingDuringLoad(
     maxTimerDriftMs: 0
   }
   try {
+    await operation()
+  } finally {
+    try {
+      rendererTiming = await rendererWatcher.evaluate((watcher) => watcher.stop())
+    } finally {
+      controllerMaxTimerDriftMs = stopControllerTimer()
+      hostCpuEnd = readHostCpuSnapshot()
+      elapsedMs = performance.now() - measurementStart
+      rendererDurationDelta = await rendererDuration.stop()
+      await rendererWatcher.dispose()
+    }
+  }
+  const hostCpu = hostCpuDelta(hostCpuStart, hostCpuEnd)
+  return {
+    maxTimerDriftMs: rendererTiming.maxTimerDriftMs,
+    controllerMaxTimerDriftMs,
+    rendererMaxLongTaskMs: rendererTiming.maxLongTaskMs,
+    rendererLongTaskSupported: rendererTiming.longTaskSupported,
+    rendererKeydownCount: rendererTiming.keydownCount,
+    rendererTaskDurationMs: rendererDurationDelta.taskDurationMs,
+    rendererScriptDurationMs: rendererDurationDelta.scriptDurationMs,
+    hostCpuBusyPercent: hostCpu.busyPercent,
+    hostCpuPressureWaitMs: hostCpu.pressureWaitMs,
+    elapsedMs
+  }
+}
+
+export async function measureTerminalTypingDuringLoad(
+  page: Page,
+  scriptPath: string,
+  ptyId: string,
+  runId: string,
+  frameCount: number
+): Promise<TypingMeasurement> {
+  await sendToTerminal(page, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+  await waitForTerminalOutputForPtyId(page, ptyId, `OPENCODE_TYPING_READY_${runId}`, 10_000)
+  await focusActiveTerminalInput(page)
+
+  const latencies: number[] = []
+  const dispatchLatencies: number[] = []
+  const echoLatencies: number[] = []
+  const timing = await measureTerminalOperationLatency(page, async () => {
     for (const [index, char] of KEY_LATENCY_SAMPLES.split('').entries()) {
       const marker = `OPENCODE_TYPING_KEY_${runId}_${index + 1}`
       const start = performance.now()
@@ -176,31 +271,14 @@ export async function measureTerminalTypingDuringLoad(
       echoLatencies.push(completed - dispatched)
       latencies.push(completed - start)
     }
-  } finally {
-    try {
-      rendererTiming = await rendererWatcher.evaluate((watcher) => watcher.stop())
-    } finally {
-      controllerMaxTimerDriftMs = stopControllerTimer()
-      hostCpuEnd = readHostCpuSnapshot()
-      elapsedMs = performance.now() - measurementStart
-      await rendererWatcher.dispose()
-    }
-  }
-  const hostCpu = hostCpuDelta(hostCpuStart, hostCpuEnd)
+  })
   return {
+    ...timing,
     latencies,
     dispatchLatencies,
     echoLatencies,
     medianLatencyMs: median(latencies),
     worstLatencyMs: Math.max(...latencies),
-    maxTimerDriftMs: rendererTiming.maxTimerDriftMs,
-    controllerMaxTimerDriftMs,
-    rendererMaxLongTaskMs: rendererTiming.maxLongTaskMs,
-    rendererLongTaskSupported: rendererTiming.longTaskSupported,
-    rendererKeydownCount: rendererTiming.keydownCount,
-    hostCpuBusyPercent: hostCpu.busyPercent,
-    hostCpuPressureWaitMs: hostCpu.pressureWaitMs,
-    elapsedMs,
     frameCount
   }
 }

--- a/tests/e2e/artificial-opencode-terminal-latency-measurement.ts
+++ b/tests/e2e/artificial-opencode-terminal-latency-measurement.ts
@@ -50,6 +50,15 @@ function median(values: number[]): number {
   return sorted[Math.floor(sorted.length / 2)] ?? 0
 }
 
+function readLinuxCpuPressureWaitMicros(): number | null {
+  try {
+    const match = readFileSync('/proc/pressure/cpu', 'utf8').match(/^some\s+.*\btotal=(\d+)$/m)
+    return match ? Number(match[1]) : null
+  } catch {
+    return null
+  }
+}
+
 function readHostCpuSnapshot(): HostCpuSnapshot | null {
   if (process.platform !== 'linux') {
     return null
@@ -64,12 +73,9 @@ function readHostCpuSnapshot(): HostCpuSnapshot | null {
     if (!cpuFields || cpuFields.length < 4 || cpuFields.some((value) => !Number.isFinite(value))) {
       return null
     }
-    const pressureMatch = readFileSync('/proc/pressure/cpu', 'utf8').match(
-      /^some\s+.*\btotal=(\d+)$/m
-    )
     return {
       idleTicks: cpuFields[3] + (cpuFields[4] ?? 0),
-      pressureWaitMicros: pressureMatch ? Number(pressureMatch[1]) : null,
+      pressureWaitMicros: readLinuxCpuPressureWaitMicros(),
       totalTicks: cpuFields.reduce((total, value) => total + value, 0)
     }
   } catch {

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -61,10 +61,6 @@ type SyntheticOpenCodeWindow = Window & {
 // counter still has a renderer-side producer.
 type TerminalPtyOutputDebugSnapshot = {
   hiddenRendererMode2031ReplyCount: number
-  activeHiddenRestoreCount: number
-  activeHiddenRestoreSnapshotMs: number
-  activeHiddenRestoreReplayMs: number
-  activeHiddenRestoreTotalMs: number
 }
 
 type TerminalOutputSchedulerDebugSnapshot = {

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -16,26 +16,16 @@ import {
   waitForActivePanePtyId,
   waitForActiveTerminalManager
 } from './helpers/terminal'
+import { ensureActiveWorktreePaneLoad, focusPane } from './artificial-opencode-pane-interactions'
 import {
-  ensureActiveWorktreePaneLoad,
-  focusActiveTerminalInput,
-  focusPane,
-  waitForMarkerLatency,
-  waitForTerminalOutputForPtyId
-} from './artificial-opencode-pane-interactions'
+  measureTerminalTypingDuringLoad,
+  type TypingMeasurement
+} from './artificial-opencode-typing-measurement'
 import { runHiddenRealPtyPressureScenario } from './artificial-opencode-hidden-pressure-scenario'
 import type { HiddenPressureOutputMode } from './artificial-opencode-hidden-pressure-script'
 import { runMainPressureScenario } from './artificial-opencode-main-pressure-scenario'
 import { runRendererBackpressureRevisitScenario } from './artificial-opencode-revisit-pressure-scenario'
 import { startSyntheticOpenCodeInjection } from './artificial-opencode-synthetic-injection'
-
-type TypingMeasurement = {
-  latencies: number[]
-  medianLatencyMs: number
-  worstLatencyMs: number
-  maxTimerDriftMs: number
-  frameCount: number
-}
 
 type SyntheticOpenCodeWindow = Window & {
   __terminalPtyDataInjection?: {
@@ -108,7 +98,6 @@ type MainPtyPressureDebugSnapshot = {
   pendingDroppedChars: number
 }
 
-const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
 const DEFAULT_SAME_WORKSPACE_PANES = 5
 const DEFAULT_CROSS_WORKSPACE_PANES_PER_WORKTREE = 3
 const DEFAULT_PRESSURE_BACKGROUND_PANES = 17
@@ -117,7 +106,6 @@ const DEFAULT_HIDDEN_PRESSURE_PANES = 17
 const HIDDEN_PRESSURE_START_DELAY_MS = 1200
 const DEFAULT_FRAME_COUNT = 180
 const DEFAULT_FRAME_INTERVAL_MS = 6
-const TIMER_SAMPLE_MS = 16
 const MAIN_RENDERER_PRESSURE_TARGET_CHARS = 2 * 1024 * 1024
 // Why: these are regression budgets, not observed baselines. Repeated local
 // 100-pane OpenCode-scale runs are below 50ms worst-key latency; keep enough
@@ -233,57 +221,13 @@ function writeInteractivePromptScript(scriptPath: string, runId: string): void {
   writeFileSync(scriptPath, interactivePromptScript(runId))
 }
 
-function median(values: number[]): number {
-  const sorted = [...values].sort((a, b) => a - b)
-  return sorted[Math.floor(sorted.length / 2)] ?? 0
-}
-
 async function measureTypingDuringLoad(
   page: Page,
   scriptPath: string,
   ptyId: string,
   runId: string
 ): Promise<TypingMeasurement> {
-  await sendToTerminal(page, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
-  await waitForTerminalOutputForPtyId(page, ptyId, `OPENCODE_TYPING_READY_${runId}`, 10_000)
-  await focusActiveTerminalInput(page)
-
-  const eventLoop = await page.evaluateHandle((sampleMs) => {
-    let maxTimerDriftMs = 0
-    let lastTick = performance.now()
-    const timer = window.setInterval(() => {
-      const now = performance.now()
-      maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - sampleMs)
-      lastTick = now
-    }, sampleMs)
-    return {
-      stop: () => {
-        window.clearInterval(timer)
-        return maxTimerDriftMs
-      }
-    }
-  }, TIMER_SAMPLE_MS)
-
-  const latencies: number[] = []
-  for (const [index, char] of [...KEY_LATENCY_SAMPLES].entries()) {
-    const marker = `OPENCODE_TYPING_KEY_${runId}_${index + 1}`
-    const start = performance.now()
-    await page.keyboard.type(char)
-    // Why: wait up to the under-load budget so a slow echo is measured and
-    // asserted per-scenario, not thrown as a confusing "did not contain".
-    await waitForMarkerLatency(page, marker, MAX_WORST_KEY_LATENCY_UNDER_LOAD_MS)
-    latencies.push(performance.now() - start)
-  }
-
-  const maxTimerDriftMs = await eventLoop.evaluate((watcher) => watcher.stop())
-  await eventLoop.dispose()
-  return {
-    latencies,
-    medianLatencyMs: median(latencies),
-    worstLatencyMs: Math.max(...latencies),
-    maxTimerDriftMs,
-    frameCount: FRAME_COUNT
-  }
+  return measureTerminalTypingDuringLoad(page, scriptPath, ptyId, runId, FRAME_COUNT)
 }
 
 async function resetTerminalPtyOutputDebug(page: Page): Promise<void> {
@@ -388,7 +332,29 @@ function annotateTypingMeasurement(
       1
     )}ms worst=${measurement.worstLatencyMs.toFixed(
       1
-    )}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(1)}ms samples=${measurement.latencies
+    )}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(
+      1
+    )}ms controllerDrift=${measurement.controllerMaxTimerDriftMs.toFixed(
+      1
+    )}ms rendererLongTask=${measurement.rendererMaxLongTaskMs.toFixed(
+      1
+    )}ms rendererLongTaskSupported=${
+      measurement.rendererLongTaskSupported
+    } rendererKeydowns=${measurement.rendererKeydownCount} typingElapsed=${measurement.elapsedMs.toFixed(
+      1
+    )}ms dispatchSamples=${measurement.dispatchLatencies
+      .map((value) => value.toFixed(1))
+      .join(',')} echoSamples=${measurement.echoLatencies
+      .map((value) => value.toFixed(1))
+      .join(',')} hostCpuBusy=${
+      measurement.hostCpuBusyPercent == null
+        ? 'na'
+        : `${measurement.hostCpuBusyPercent.toFixed(1)}%`
+    } hostCpuPressureWait=${
+      measurement.hostCpuPressureWaitMs == null
+        ? 'na'
+        : `${measurement.hostCpuPressureWaitMs.toFixed(1)}ms`
+    } samples=${measurement.latencies
       .map((value) => value.toFixed(1))
       .join(',')}${mode2031Summary}${schedulerSummary}${mainPressureSummary}${ackGateSummary}`
   })

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -61,6 +61,10 @@ type SyntheticOpenCodeWindow = Window & {
 // counter still has a renderer-side producer.
 type TerminalPtyOutputDebugSnapshot = {
   hiddenRendererMode2031ReplyCount: number
+  activeHiddenRestoreCount: number
+  activeHiddenRestoreSnapshotMs: number
+  activeHiddenRestoreReplayMs: number
+  activeHiddenRestoreTotalMs: number
 }
 
 type TerminalOutputSchedulerDebugSnapshot = {

--- a/tests/e2e/artificial-opencode-terminal-load.spec.ts
+++ b/tests/e2e/artificial-opencode-terminal-load.spec.ts
@@ -20,7 +20,7 @@ import { ensureActiveWorktreePaneLoad, focusPane } from './artificial-opencode-p
 import {
   measureTerminalTypingDuringLoad,
   type TypingMeasurement
-} from './artificial-opencode-typing-measurement'
+} from './artificial-opencode-terminal-latency-measurement'
 import { runHiddenRealPtyPressureScenario } from './artificial-opencode-hidden-pressure-scenario'
 import type { HiddenPressureOutputMode } from './artificial-opencode-hidden-pressure-script'
 import { runMainPressureScenario } from './artificial-opencode-main-pressure-scenario'
@@ -338,8 +338,14 @@ function annotateTypingMeasurement(
       1
     )}ms rendererLongTask=${measurement.rendererMaxLongTaskMs.toFixed(
       1
-    )}ms rendererLongTaskSupported=${
-      measurement.rendererLongTaskSupported
+    )}ms rendererLongTaskSupported=${measurement.rendererLongTaskSupported} rendererTask=${
+      measurement.rendererTaskDurationMs == null
+        ? 'na'
+        : `${measurement.rendererTaskDurationMs.toFixed(1)}ms`
+    } rendererScript=${
+      measurement.rendererScriptDurationMs == null
+        ? 'na'
+        : `${measurement.rendererScriptDurationMs.toFixed(1)}ms`
     } rendererKeydowns=${measurement.rendererKeydownCount} typingElapsed=${measurement.elapsedMs.toFixed(
       1
     )}ms dispatchSamples=${measurement.dispatchLatencies

--- a/tests/e2e/artificial-opencode-typing-measurement.ts
+++ b/tests/e2e/artificial-opencode-typing-measurement.ts
@@ -1,0 +1,206 @@
+import type { Page } from '@stablyai/playwright-test'
+import { readFileSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
+import {
+  focusActiveTerminalInput,
+  waitForMarkerLatency,
+  waitForTerminalOutputForPtyId
+} from './artificial-opencode-pane-interactions'
+import { sendToTerminal } from './helpers/terminal'
+
+export type TypingMeasurement = {
+  latencies: number[]
+  dispatchLatencies: number[]
+  echoLatencies: number[]
+  medianLatencyMs: number
+  worstLatencyMs: number
+  maxTimerDriftMs: number
+  controllerMaxTimerDriftMs: number
+  rendererMaxLongTaskMs: number
+  rendererLongTaskSupported: boolean
+  rendererKeydownCount: number
+  hostCpuBusyPercent: number | null
+  hostCpuPressureWaitMs: number | null
+  elapsedMs: number
+  frameCount: number
+}
+
+type HostCpuSnapshot = {
+  idleTicks: number
+  pressureWaitMicros: number | null
+  totalTicks: number
+}
+
+const KEY_LATENCY_SAMPLES = 'abcdefghijklmnop'
+const MAX_KEY_ECHO_LATENCY_MS = 3_000
+const TIMER_SAMPLE_MS = 16
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)] ?? 0
+}
+
+function readHostCpuSnapshot(): HostCpuSnapshot | null {
+  if (process.platform !== 'linux') {
+    return null
+  }
+  try {
+    const cpuFields = readFileSync('/proc/stat', 'utf8')
+      .split('\n')[0]
+      ?.trim()
+      .split(/\s+/)
+      .slice(1)
+      .map(Number)
+    if (!cpuFields || cpuFields.length < 4 || cpuFields.some((value) => !Number.isFinite(value))) {
+      return null
+    }
+    const pressureMatch = readFileSync('/proc/pressure/cpu', 'utf8').match(
+      /^some\s+.*\btotal=(\d+)$/m
+    )
+    return {
+      idleTicks: cpuFields[3] + (cpuFields[4] ?? 0),
+      pressureWaitMicros: pressureMatch ? Number(pressureMatch[1]) : null,
+      totalTicks: cpuFields.reduce((total, value) => total + value, 0)
+    }
+  } catch {
+    return null
+  }
+}
+
+function hostCpuDelta(
+  start: HostCpuSnapshot | null,
+  end: HostCpuSnapshot | null
+): {
+  busyPercent: number | null
+  pressureWaitMs: number | null
+} {
+  if (!start || !end) {
+    return { busyPercent: null, pressureWaitMs: null }
+  }
+  const totalTicks = end.totalTicks - start.totalTicks
+  const idleTicks = end.idleTicks - start.idleTicks
+  const pressureWaitMicros =
+    start.pressureWaitMicros == null || end.pressureWaitMicros == null
+      ? null
+      : end.pressureWaitMicros - start.pressureWaitMicros
+  return {
+    busyPercent: totalTicks > 0 ? ((totalTicks - idleTicks) / totalTicks) * 100 : null,
+    pressureWaitMs: pressureWaitMicros == null ? null : pressureWaitMicros / 1_000
+  }
+}
+
+function startControllerTimerDrift(): () => number {
+  let maxTimerDriftMs = 0
+  let lastTick = performance.now()
+  const timer = setInterval(() => {
+    const now = performance.now()
+    maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - TIMER_SAMPLE_MS)
+    lastTick = now
+  }, TIMER_SAMPLE_MS)
+  return () => {
+    clearInterval(timer)
+    return maxTimerDriftMs
+  }
+}
+
+export async function measureTerminalTypingDuringLoad(
+  page: Page,
+  scriptPath: string,
+  ptyId: string,
+  runId: string,
+  frameCount: number
+): Promise<TypingMeasurement> {
+  await sendToTerminal(page, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+  await waitForTerminalOutputForPtyId(page, ptyId, `OPENCODE_TYPING_READY_${runId}`, 10_000)
+  await focusActiveTerminalInput(page)
+
+  const rendererWatcher = await page.evaluateHandle((sampleMs) => {
+    let maxTimerDriftMs = 0
+    let maxLongTaskMs = 0
+    let keydownCount = 0
+    let lastTick = window.performance.now()
+    const timer = window.setInterval(() => {
+      const now = window.performance.now()
+      maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - sampleMs)
+      lastTick = now
+    }, sampleMs)
+    const onKeydown = (): void => {
+      keydownCount += 1
+    }
+    window.addEventListener('keydown', onKeydown, true)
+    const longTaskSupported = PerformanceObserver.supportedEntryTypes.includes('longtask')
+    const observer = longTaskSupported
+      ? new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            maxLongTaskMs = Math.max(maxLongTaskMs, entry.duration)
+          }
+        })
+      : null
+    observer?.observe({ type: 'longtask' })
+    return {
+      stop: () => {
+        window.clearInterval(timer)
+        window.removeEventListener('keydown', onKeydown, true)
+        for (const entry of observer?.takeRecords() ?? []) {
+          maxLongTaskMs = Math.max(maxLongTaskMs, entry.duration)
+        }
+        observer?.disconnect()
+        return { keydownCount, longTaskSupported, maxLongTaskMs, maxTimerDriftMs }
+      }
+    }
+  }, TIMER_SAMPLE_MS)
+  const stopControllerTimer = startControllerTimerDrift()
+  const hostCpuStart = readHostCpuSnapshot()
+  const measurementStart = performance.now()
+  const latencies: number[] = []
+  const dispatchLatencies: number[] = []
+  const echoLatencies: number[] = []
+  let controllerMaxTimerDriftMs = 0
+  let elapsedMs = 0
+  let hostCpuEnd: HostCpuSnapshot | null = null
+  let rendererTiming = {
+    keydownCount: 0,
+    longTaskSupported: false,
+    maxLongTaskMs: 0,
+    maxTimerDriftMs: 0
+  }
+  try {
+    for (const [index, char] of KEY_LATENCY_SAMPLES.split('').entries()) {
+      const marker = `OPENCODE_TYPING_KEY_${runId}_${index + 1}`
+      const start = performance.now()
+      await page.keyboard.type(char)
+      const dispatched = performance.now()
+      await waitForMarkerLatency(page, marker, MAX_KEY_ECHO_LATENCY_MS)
+      const completed = performance.now()
+      dispatchLatencies.push(dispatched - start)
+      echoLatencies.push(completed - dispatched)
+      latencies.push(completed - start)
+    }
+  } finally {
+    try {
+      rendererTiming = await rendererWatcher.evaluate((watcher) => watcher.stop())
+    } finally {
+      controllerMaxTimerDriftMs = stopControllerTimer()
+      hostCpuEnd = readHostCpuSnapshot()
+      elapsedMs = performance.now() - measurementStart
+      await rendererWatcher.dispose()
+    }
+  }
+  const hostCpu = hostCpuDelta(hostCpuStart, hostCpuEnd)
+  return {
+    latencies,
+    dispatchLatencies,
+    echoLatencies,
+    medianLatencyMs: median(latencies),
+    worstLatencyMs: Math.max(...latencies),
+    maxTimerDriftMs: rendererTiming.maxTimerDriftMs,
+    controllerMaxTimerDriftMs,
+    rendererMaxLongTaskMs: rendererTiming.maxLongTaskMs,
+    rendererLongTaskSupported: rendererTiming.longTaskSupported,
+    rendererKeydownCount: rendererTiming.keydownCount,
+    hostCpuBusyPercent: hostCpu.busyPercent,
+    hostCpuPressureWaitMs: hostCpu.pressureWaitMs,
+    elapsedMs,
+    frameCount
+  }
+}

--- a/tests/e2e/terminal-parked-memory.spec.ts
+++ b/tests/e2e/terminal-parked-memory.spec.ts
@@ -17,6 +17,7 @@ import {
   waitForActiveTerminalManager,
   waitForPaneIdentitySnapshot
 } from './helpers/terminal'
+import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../src/shared/terminal-scrollback-policy'
 
 // Why: production cold-park hysteresis is 30s. The fast-park env override is
 // scoped to this spec's app launches via orcaAppExtraEnv (same pattern as
@@ -394,6 +395,9 @@ test.describe('Terminal parked memory', () => {
 const RETENTION_TAB_COUNT = 4
 const RETENTION_FILL_LINE_COUNT = 12_000
 const RETENTION_SCROLLBACK_ROWS = 25_000
+const RETENTION_PANE_WEIGHT = Math.ceil(
+  RETENTION_SCROLLBACK_ROWS / DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT
+)
 // Why 12: xterm packs each cell as 3 uint32s in the BufferLine typed array.
 const XTERM_BYTES_PER_CELL = 12
 // Why 40: this staging measures ~87 MB of retained buffer, so half of that is a
@@ -597,12 +601,8 @@ test.describe('Terminal hidden worktree retention budget', () => {
   test.use({
     orcaAppExtraEnv: {
       ORCA_E2E_TERMINAL_PARKING_DELAY_MS: String(PARKING_DELAY_MS),
-      // Why limit=1: the retention TTL is absolute production timing (45min) and
-      // the parking-delay override deliberately no longer shrinks it, so the
-      // COUNT CAP is the only knob a test can drive. With a budget of 1 the
-      // newest hidden un-parkable worktree takes the last-active exemption and
-      // the older one force-parks — cap and exemption proven in one run.
-      ORCA_E2E_TERMINAL_RETENTION_LIMIT: '1'
+      // The newer one-pane decoy exactly fits; the four-pane victim does not.
+      ORCA_E2E_TERMINAL_RETENTION_LIMIT: String(RETENTION_PANE_WEIGHT)
     },
     orcaAppExtraArgs: ['--enable-precise-memory-info']
   })
@@ -666,8 +666,7 @@ test.describe('Terminal hidden worktree retention budget', () => {
         await stageUnparkableWorktreeTabs(orcaPage, victimWorktreeId)
       }
 
-      // Hiding the victim first makes the decoy the more-recently-hidden
-      // candidate, so the cap's last-active exemption lands on the decoy.
+      // Hiding the victim first lets the newer decoy claim the weighted budget.
       await switchToWorktree(orcaPage, decoyWorktreeId)
       await expect
         .poll(() => orcaPage.evaluate(() => window.__store?.getState().activeWorktreeId), {
@@ -761,8 +760,7 @@ test.describe('Terminal hidden worktree retention budget', () => {
 
       // Primary gate: the staged buffers are gone, not merely hidden.
       expect(after.buffers.cells).toBeLessThan(before.buffers.cells * MAX_RETAINED_CELL_FRACTION)
-      // The decoy holds the cap's last-active exemption, so it stays mounted —
-      // this is the same run proving the cap did not simply evict everything.
+      // The newer decoy fits the budget, proving the cap did not evict everything.
       expect(await countMountedPaneManagers(orcaPage, decoyTabIds)).toBe(decoyTabIds.length)
       // Secondary only: freed typed arrays return to the allocator's free lists,
       // not the OS, so RSS fell just 0.7-3.0 MB locally while 87 MB of buffer was

--- a/tests/e2e/terminal-retention-budget.spec.ts
+++ b/tests/e2e/terminal-retention-budget.spec.ts
@@ -25,8 +25,7 @@ test.use({
   seedTestRepo: false,
   orcaAppExtraEnv: {
     ORCA_E2E_TERMINAL_PARKING_DELAY_MS: String(PARKING_DELAY_MS),
-    // Why limit=1: two hidden un-parkable worktrees then exceed the budget while
-    // the last-active exemption still spares exactly one — the smallest live proof.
+    // Two one-pane worktrees exceed this one-unit test budget.
     ORCA_E2E_TERMINAL_RETENTION_LIMIT: '1'
   }
 })
@@ -66,6 +65,19 @@ test.describe('terminal hidden-worktree retention budget', () => {
           message: 'older worktree marker did not render before hiding'
         })
         .toContain(`${olderMarker}:`)
+      // Push the marker outside the relay's 100KiB tail while retaining it in
+      // the force-park capture.
+      await sendToTerminal(
+        orcaPage,
+        olderPtyId,
+        `for i in $(seq 1 3000); do echo "RETENTION_PAD_$i:0123456789012345678901234567890123456789"; done; echo "${olderMarker}_PAD_DONE:"\r`
+      )
+      await expect
+        .poll(() => getTerminalContent(orcaPage, 20_000), {
+          timeout: 60_000,
+          message: 'retention pad output did not finish before hiding'
+        })
+        .toContain(`${olderMarker}_PAD_DONE:`)
 
       // Why: with SSH view parking off, SSH ptys are not park-restorable, so the
       // hidden remote worktrees join the un-parkable class the budget governs.
@@ -110,15 +122,15 @@ test.describe('terminal hidden-worktree retention budget', () => {
 
       // The older worktree must force-park (its pane managers unmount)…
       await waitForTabParked(orcaPage, olderTabId, { parkDelayMs: PARKING_DELAY_MS })
-      // …while the newest hidden worktree keeps its mounted panes (last-active exemption).
+      // …while the newest hidden worktree claims the one-pane retention capacity.
       const newerStillMounted = await orcaPage.evaluate(
         (tabId) => window.__paneManagers?.get(tabId) !== undefined,
         newerTabId
       )
       expect(newerStillMounted).toBe(true)
 
-      // Reveal the evicted worktree: with SSH parking disabled the model paint is
-      // off, so the relay replay must restore the marker tail — never a blank pane.
+      // SSH model restore is disabled, so deep history must survive through the
+      // force-park capture while the relay tail repaints the viewport.
       await orcaPage.evaluate(
         ({ worktreeId, tabId }) => {
           const state = window.__store?.getState()
@@ -130,9 +142,9 @@ test.describe('terminal hidden-worktree retention budget', () => {
       )
       await waitForActiveTerminalManager(orcaPage, 60_000)
       await expect
-        .poll(() => getTerminalContent(orcaPage, 20_000), {
+        .poll(() => getTerminalContent(orcaPage, 2_000_000), {
           timeout: 60_000,
-          message: 'revealed evicted worktree did not restore the marker via relay replay'
+          message: 'revealed evicted worktree lost captured history beyond the relay tail'
         })
         .toContain(`${olderMarker}:`)
     } finally {


### PR DESCRIPTION
## ELI5 (Explain Like I'm 5)

Imagine Orca terminals as little TVs for your shells. When you leave a workspace, some TVs get **parked** (turned off to save power) and some stay **warm** so switching back is instant.

**The problem:** Under heavy load (lots of output, many SSH/remote panes, pressure tests), the “warm TV” system got overwhelmed:

1. **Too many expensive warm terminals** — It used to keep up to ~12 hidden worktrees warm, counting each the same. A simple one-pane terminal and a monster with many splits + huge scrollback both “cost 1.” Fat ones used too much memory/CPU and squeezed out the ones you actually care about.
2. **Everyone rushes the door at once** — When you return to a tab, background/split panes tried to restore at the same time as the pane you’re looking at, so the important one lagged.
3. **Too much text jammed in the hallway** — Main process could ship up to 8 MiB of terminal text to the UI at once; that made typing feel sticky under load.
4. **Stuck waiting for invisible panes** — A pane that is “connected” but has size 0×0 never gets a real grid. The code could wait forever (or invent fake 2×1 geometry) instead of releasing held output and moving on.
5. **Agent “status lights” getting lost** — Under pressure, side-effect queues drop old events; this PR still carries the important “agent working / settled” title transitions so status doesn’t go dark.

**What you should feel as a user:** Hidden SSH/remote terminals stay warm more fairly under load, switching back is snappier for the pane you care about, typing doesn’t freeze when lots of output is flying, and you shouldn’t see blank restores or stuck “waiting for layout” deadlocks. No intentional UI redesign.

Follow-up to #10625.

---

## What this PR is

**Title:** `fix(terminal): harden remote parking restores under load`  
**Scale:** ~+1,761 / −248 across 36 files (mostly terminal parking/retention + tests)  
**Base idea:** When you leave a worktree, Orca can **park** terminals (save resources) or keep some **warm** for a fast return. Under heavy output—especially SSH/remote + many panes—that system was failing in predictable ways: wrong things staying warm, restores fighting each other, output flooding the UI, and 0×0 panes getting stuck.

This is load-sensitive plumbing, not a feature/UI redesign.

## The five real fixes

| # | Fix | What changed | Why it matters |
|---|-----|--------------|----------------|
| 1 | **Weighted retention budget** | Not “keep 12 worktrees,” but ~**12 pane-units** (panes × scrollback weight). Newest candidates claim budget first; anything that doesn’t fit or is older than **45 min** force-parks. Invalid/zero topology still costs at least one pane unit. | Fat multi-pane/high-scrollback worktrees can no longer monopolize warm retention and starve simpler ones you actually return to. |
| 2 | **Restore priority + serialization** | Active pane restores **first** (live priority from current focus). Inactive/split restores run **one-at-a-time** behind active work; active restore acts as a barrier so background replay can’t starve the pane you’re looking at. Priority can re-resolve at drain time (focus may have changed while queued). | Returning to a tab feels snappy for the pane you care about; background splits catch up without freezing the return path. |
| 3 | **2 MiB main→renderer in-flight cap** | Aggregate in-flight high-water dropped **8 MiB → 2 MiB** (aligned with renderer queue budget; ACKs still sustain healthy throughput). | Typing stays responsive when lots of output is flying under pressure. |
| 4 | **Collapsed 0×0 pane unblock** | Connected panes with zero width/height exhaust fit-retry after **4 frames**, release held output, and **do not** forward fake `2×1` geometry. | Avoids forever-waiting-for-layout deadlocks and bogus resizes that corrupt terminal state. |
| 5 | **Safer lifecycle under pressure** | Carry latest agent working/settled/cleared title transitions when side-effect queues evict; don’t wipe real restored scrollback on relay replay when a capture already restored history; skip double-capturing remote-runtime scrollback on shutdown. | Status lights don’t go dark under load; reconnect/shutdown don’t blank or duplicate remote history. |

## Where the production logic lives

Most of the line count is tests + E2E pressure/latency measurement. The behavioral changes cluster here:

| Area | Primary files |
|------|----------------|
| Retention / force-park budget | `terminal-hidden-worktree-retention.ts`, `Terminal.tsx` |
| Restore scheduling | `hidden-output-restore-scheduler.ts`, `pty-connection.ts` |
| Output fan-in / flow control | `src/main/ipc/pty.ts` |
| Agent side-effects under eviction | `pty-transport.ts` |
| Collapsed fit retry | `pane-fit-continuation-retry.ts` |
| Shutdown / remote scrollback capture | `TerminalPane.tsx`, `terminal-shutdown-layout-capture.ts` |

## Why it looks huge

- ~1.7k lines added mostly because this path is **load-sensitive**: retention math, restore concurrency, and output backpressure all need regression coverage.
- Large surface is unit tests + E2E pressure/latency attribution (restore stalls, typing under load, retention budget, parked memory).
- Production logic changes are concentrated in the table above; not a broad refactor across the app.

## Summary (technical)

- Keep SSH and remote hidden-worktree terminals retained under output pressure with pane/scrollback-weighted bounds.
- Prioritize restores from live pane state, serialize inactive restores behind active work, and cap aggregate main-to-renderer in-flight output at 2 MiB.
- Release held output for connected zero-sized panes without forwarding fallback `2×1` geometry, while preserving reconnect, shutdown, scrollback, and agent-lifecycle state.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` at `83ccd686b084a393999531b0cc0ace7a8e465cae`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 39,984 passed; 70 skipped
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Additional validation:

- Focused PTY suite: 531 passed.
- Reviewer-focused suites: 120 passed; restore scheduler: 10 passed.
- Reliability gates and max-lines ratchet passed.
- [Exact-final-head PR matrix](https://github.com/stablyai/orca/actions/runs/30463094537): 16 test shards, package/build, typecheck, static analysis, Git compatibility, shell contracts, 10 Playwright E2E shards, and Docker SSH watcher isolation.
- Exact-final-head independent workflows: [Windows restart](https://github.com/stablyai/orca/actions/runs/30463088232), [Windows crash survival](https://github.com/stablyai/orca/actions/runs/30463094419), [Wayland terminal input](https://github.com/stablyai/orca/actions/runs/30463094268), and [golden macOS/Linux](https://github.com/stablyai/orca/actions/runs/30463093646).
- Earlier exact-production full E2E matrix, including Docker SSH parking and retention, also passed with zero pressure-test drops.

Five independent Linux pressure replicas ran at the final SHA: [1](https://github.com/stablyai/orca/actions/runs/30463185230), [2](https://github.com/stablyai/orca/actions/runs/30463185188), [3](https://github.com/stablyai/orca/actions/runs/30463185437), [4](https://github.com/stablyai/orca/actions/runs/30463185327), [5](https://github.com/stablyai/orca/actions/runs/30463185029).

| Metric | Final-head range |
|---|---:|
| Typing median | 5.7–8.0 ms |
| Typing worst | 30.0–81.8 ms |
| Typing controller drift | 1.6–8.6 ms |
| Typing renderer timer drift | 0.0–112.2 ms |
| Typing renderer task / script | 48.0–68.9 / 16.1–21.4 ms |
| Typing host CPU / PSI wait | 36.7–71.0% / 6.2–32.5 ms |
| Restore | 176.0–251.2 ms |
| Restore renderer task / script | 135.0–205.4 / 87.2–161.5 ms |
| Restore host CPU / PSI wait | 47.5–69.8% / 6.7–68.7 ms |
| Renderer peak queued chars | 890–1,810 |
| Main peak pending / in-flight chars | 273–481 / 3,714–3,809 |
| Final queued chars / backlog drops | 0 / 0 in every run |

The two slower typing samples coincided with renderer timer drift while controller drift stayed below 9 ms, typing had no renderer long task, and delivery queues remained bounded and drained. Together with the attributed replica where a 244.7 ms wall interval contained only 84.2 ms of renderer task time, this identifies hosted-runner renderer descheduling rather than synchronous renderer work, Playwright delay, or queue accumulation. No performance threshold was lowered.

## AI Review Report

The review traced restore authority, retained-state persistence, cleanup, concurrency, stale scheduling state, PTY reconnects, shutdown capture, SSH/remote execution, and folder workspaces. It added or hardened:

- pane/scrollback-weighted retention with a minimum one-pane cost for invalid or zero topology;
- live-priority scheduling, active restore barriers, and serialized inactive restores;
- bounded main-to-renderer fan-in and bounded PTY lifecycle carry state;
- four-frame connected-collapsed fit exhaustion and held-output release without bogus geometry;
- remote-runtime shutdown capture without duplicate scrollback;
- deterministic, encoding-safe layout keys independent of insertion order;
- Linux CPU attribution that preserves `/proc/stat` utilization when PSI is unavailable.

The final Greptile review covered `83ccd686b0`, returned 5/5 confidence, and identified no file needing attention. CodeRabbit generated no new actionable final-head comments. Every review thread is resolved.

Cross-platform behavior was checked for macOS, Linux, Windows, SSH, and folder workspaces. The change introduces no shortcut, path-separator, shell, Git-version, or provider-specific assumption and stays behind existing PTY/runtime abstractions.

## Security Audit

No dependency, authentication, secret, external-command, or user-controlled-path surface was added. The IPC changes stay within the existing PTY flow-control and resize channels. The audit checked stale PTY ownership, bounded queues, disconnect/shutdown cleanup, invalid geometry forwarding, and remote output routing; no security follow-up remains.

## Notes

Follow-up to #10625.

An earlier full-matrix attempt had one transient headless-to-desktop lifecycle failure after promotion, renderer mount, and daemon-PTY probing had succeeded; the runtime reconnect briefly saw an unavailable socket. The trace was inspected, and the entire 40-test shard passed on a fresh runner at the same SHA with no code change.
