### PR TITLE
fix(source-control): preserve Windows command override paths

### DIFF
--- a/src/main/agent-hooks/first-work-generation-target.ts
+++ b/src/main/agent-hooks/first-work-generation-target.ts
@@ -17,6 +17,7 @@ export async function resolveGenerationTarget(
     return {
       kind: 'remote',
       cwd: worktreePath,
+      commandPathFlavor: provider.getHostPlatform?.()?.pathFlavor ?? 'posix',
       execute: (plan, cwd, timeoutMs, operation) =>
         provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
       missingBinaryLocation: 'remote PATH'

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -2619,7 +2619,10 @@ describe('registerFilesystemHandlers', () => {
       defaultModelId: 'auto'
     })
     const executeCommitMessagePlan = vi.fn()
-    getSshGitProviderMock.mockReturnValue({ executeCommitMessagePlan })
+    getSshGitProviderMock.mockReturnValue({
+      executeCommitMessagePlan,
+      getHostPlatform: () => ({ pathFlavor: 'windows' })
+    })
     const storeWithOverride = {
       ...store,
       getSettings: () => ({
@@ -2640,7 +2643,8 @@ describe('registerFilesystemHandlers', () => {
       'cursor',
       '/remote/repo',
       expect.any(Function),
-      'npx cursor-agent'
+      'npx cursor-agent',
+      'windows'
     )
     const execute = discoverCommitMessageModelsRemoteMock.mock.calls[0]?.[2] as (
       plan: unknown,
@@ -2669,7 +2673,8 @@ describe('registerFilesystemHandlers', () => {
     resolveCommitMessageSettingsMock.mockReturnValue({ ok: true, params })
     getSshGitProviderMock.mockReturnValue({
       getStagedCommitContext: vi.fn().mockResolvedValue(context),
-      executeCommitMessagePlan
+      executeCommitMessagePlan,
+      getHostPlatform: () => ({ pathFlavor: 'windows' })
     })
     generateCommitMessageFromContextMock.mockResolvedValue({
       success: true,
@@ -2694,6 +2699,7 @@ describe('registerFilesystemHandlers', () => {
       expect.objectContaining({
         kind: 'remote',
         cwd: '/remote/repo',
+        commandPathFlavor: 'windows',
         missingBinaryLocation: 'remote PATH'
       })
     )

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1452,6 +1452,7 @@ export function registerFilesystemHandlers(
         return generateCommitMessageFromContext(context, resolvedSettings.params, {
           kind: 'remote',
           cwd: args.worktreePath,
+          commandPathFlavor: provider.getHostPlatform?.()?.pathFlavor ?? 'posix',
           execute: (plan, cwd, timeoutMs, operation) =>
             provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
           missingBinaryLocation: 'remote PATH'
@@ -1535,7 +1536,8 @@ export function registerFilesystemHandlers(
           agentId as TuiAgent,
           args.worktreePath,
           (plan, cwd, timeoutMs) => provider.executeCommitMessagePlan(plan, cwd, timeoutMs),
-          agentCommandOverride
+          agentCommandOverride,
+          provider.getHostPlatform?.()?.pathFlavor ?? 'posix'
         )
       }
       let localRuntimeTarget: CommitMessageAgentRuntimeTarget = { runtime: 'host' }
@@ -1665,6 +1667,7 @@ export function registerFilesystemHandlers(
         return generatePullRequestFieldsFromContext(context, resolvedSettings.params, {
           kind: 'remote',
           cwd: args.worktreePath,
+          commandPathFlavor: provider.getHostPlatform?.()?.pathFlavor ?? 'posix',
           execute: (plan, cwd, timeoutMs, operation) =>
             provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
           missingBinaryLocation: 'remote PATH'

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -658,6 +658,7 @@ export class RuntimeGitCommands {
       return generateCommitMessageFromContext(context, resolvedSettings.params, {
         kind: 'remote',
         cwd: target.worktree.path,
+        commandPathFlavor: provider.getHostPlatform?.()?.pathFlavor ?? 'posix',
         execute: (plan, cwd, timeoutMs, operation) =>
           provider.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
         missingBinaryLocation: 'remote PATH'
@@ -798,6 +799,7 @@ export class RuntimeGitCommands {
       return generatePullRequestFieldsFromContext(context, resolvedSettings.params, {
         kind: 'remote',
         cwd: target.worktree.path,
+        commandPathFlavor: provider!.getHostPlatform?.()?.pathFlavor ?? 'posix',
         execute: (plan, cwd, timeoutMs, operation) =>
           provider!.executeCommitMessagePlan(plan, cwd, timeoutMs, operation),
         missingBinaryLocation: 'remote PATH'
@@ -852,7 +854,8 @@ export class RuntimeGitCommands {
         typedAgentId,
         target.worktree.path,
         (plan, cwd, timeoutMs) => provider.executeCommitMessagePlan(plan, cwd, timeoutMs),
-        agentCommandOverride
+        agentCommandOverride,
+        provider.getHostPlatform?.()?.pathFlavor ?? 'posix'
       )
     }
     const localEnv = await prepareLocalCommitMessageAgentEnv(

--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -473,6 +473,27 @@ describe('discoverCommitMessageModelsLocal', () => {
     }
   })
 
+  it('preserves native Windows paths during local model discovery', async () => {
+    await withPlatform('win32', async () => {
+      const child = createMockDiscoveryChild()
+      spawnMock.mockReturnValue(child as never)
+
+      const pending = discoverCommitMessageModelsLocal(
+        'cursor',
+        undefined,
+        '"C:\\Program Files\\Agent\\agent.exe" --profile C:\\Users\\Ada\\agent.json'
+      )
+
+      child.stdout.emit('data', Buffer.from('auto - Auto\n'))
+      child.emit('close', 0)
+
+      await expect(pending).resolves.toMatchObject({ success: true, defaultModelId: 'auto' })
+      const [spawnCommand, spawnArgs] = spawnMock.mock.calls[0] ?? []
+      expect(spawnCommand).toBe('C:\\Program Files\\Agent\\agent.exe')
+      expect(spawnArgs).toEqual(['--profile', 'C:\\Users\\Ada\\agent.json', '--list-models'])
+    })
+  })
+
   it('discovers dynamic models through the selected WSL distro login shell', async () => {
     await withPlatform('win32', async () => {
       const listeners = new Map<string, (value: unknown) => void>()
@@ -486,10 +507,15 @@ describe('discoverCommitMessageModelsLocal', () => {
       }
       spawnMock.mockReturnValue(child as never)
 
-      const pending = discoverCommitMessageModelsLocal('cursor', undefined, undefined, {
-        cwd: 'C:\\repo',
-        wslDistro: 'Ubuntu'
-      })
+      const pending = discoverCommitMessageModelsLocal(
+        'cursor',
+        undefined,
+        '/opt/My\\ Agent/cursor-agent',
+        {
+          cwd: 'C:\\repo',
+          wslDistro: 'Ubuntu'
+        }
+      )
 
       listeners.get('stdout:data')?.(Buffer.from('auto - Auto\n'))
       listeners.get('close')?.(0)
@@ -509,7 +535,7 @@ describe('discoverCommitMessageModelsLocal', () => {
       const shellCommand = spawnMock.mock.calls[0]?.[1]?.[5] as string
       expect(shellCommand).toContain('getent passwd')
       expect(shellCommand).toContain('/mnt/c/repo')
-      expect(shellCommand).toContain("'cursor-agent'")
+      expect(shellCommand).toContain("'/opt/My Agent/cursor-agent'")
       expect(shellCommand).toContain('--list-models')
     })
   })
@@ -770,6 +796,42 @@ describe('generateCommitMessageFromContext', () => {
       message: 'Add README note',
       agentLabel: 'agent'
     })
+  })
+
+  it('plans command overrides with the remote Windows path flavor', async () => {
+    const execute = vi.fn(async (plan) => {
+      expect(plan.binary).toBe('C:\\Tools\\agent.exe')
+      expect(plan.args[0]).toBe('C:\\Program Files\\Agent\\config.json')
+      return {
+        stdout: 'Add README note.\n',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false
+      }
+    })
+
+    const result = await generateCommitMessageFromContext(
+      {
+        branch: 'main',
+        stagedSummary: 'M\tREADME.md',
+        stagedPatch: '+hello'
+      },
+      {
+        agentId: 'custom',
+        model: '',
+        customAgentCommand: 'C:\\Tools\\agent.exe "C:\\Program Files\\Agent\\config.json"'
+      },
+      {
+        kind: 'remote',
+        cwd: 'C:\\repo',
+        commandPathFlavor: 'windows',
+        missingBinaryLocation: 'remote PATH',
+        execute
+      }
+    )
+
+    expect(result).toMatchObject({ success: true, message: 'Add README note' })
+    expect(execute).toHaveBeenCalledOnce()
   })
 
   it('exposes raw CLI failure output only after path sanitization', async () => {
@@ -1987,6 +2049,53 @@ describe('generateCommitMessageFromContext', () => {
         process.env.ComSpec = originalComSpec
       }
     }
+  })
+
+  it('spawns native Windows agent command override paths without corrupting backslashes', async () => {
+    await withPlatform('win32', async () => {
+      const listeners = new Map<string, (value: unknown) => void>()
+      const child = {
+        pid: 123,
+        kill: vi.fn(),
+        stdout: { on: vi.fn((event, callback) => listeners.set(`stdout:${event}`, callback)) },
+        stderr: { on: vi.fn((event, callback) => listeners.set(`stderr:${event}`, callback)) },
+        stdin: { end: vi.fn() },
+        on: vi.fn((event, callback) => listeners.set(event, callback))
+      }
+      spawnMock.mockReturnValue(child as never)
+
+      const pending = generateCommitMessageFromContext(
+        {
+          branch: 'main',
+          stagedSummary: 'M\tREADME.md',
+          stagedPatch: '+hello'
+        },
+        {
+          agentId: 'cursor',
+          model: 'auto',
+          agentCommandOverride:
+            '"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -File "C:\\Program Files\\cursor-agent.ps1"'
+        },
+        {
+          kind: 'local',
+          cwd: 'C:\\repo'
+        }
+      )
+
+      listeners.get('stdout:data')?.(Buffer.from('Update README\n'))
+      listeners.get('close')?.(0)
+
+      await expect(pending).resolves.toMatchObject({
+        success: true,
+        message: 'Update README'
+      })
+      const [spawnCommand, spawnArgs, spawnOptions] = spawnMock.mock.calls[0] ?? []
+      expect(spawnCommand).toBe('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
+      expect(spawnArgs).toEqual(
+        expect.arrayContaining(['-File', 'C:\\Program Files\\cursor-agent.ps1'])
+      )
+      expect(spawnOptions).toMatchObject({ cwd: 'C:\\repo', windowsHide: true })
+    })
   })
 
   it('rejects unsafe argv prompts for Windows batch-script agent commands', async () => {

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -17,7 +17,8 @@ import {
 } from '../../shared/pull-request-generation'
 import {
   cleanGeneratedCommitMessage,
-  excerptAgentFailureOutput
+  excerptAgentFailureOutput,
+  type CommandTemplatePathFlavor
 } from '../../shared/commit-message-prompt'
 import {
   captureAgentGenerationFailureOutput,
@@ -104,6 +105,7 @@ export type CommitMessageGenerationTarget =
   | {
       kind: 'remote'
       cwd: string
+      commandPathFlavor?: CommandTemplatePathFlavor
       execute: (
         plan: CommitMessagePlan,
         cwd: string,
@@ -289,13 +291,14 @@ function finalizeModelDiscoveryOutput(
 
 function planModelDiscovery(
   spec: NonNullable<ReturnType<typeof getCommitMessageAgentSpec>>,
-  agentCommandOverride?: string
+  agentCommandOverride?: string,
+  pathFlavor: CommandTemplatePathFlavor = 'posix'
 ): { ok: true; plan: CommitMessagePlan } | { ok: false; error: string } {
   const modelDiscovery = spec.modelDiscovery
   if (!modelDiscovery) {
     return { ok: false, error: `${spec.label} does not support dynamic model discovery.` }
   }
-  const command = planAgentBinary(modelDiscovery.binary, agentCommandOverride)
+  const command = planAgentBinary(modelDiscovery.binary, agentCommandOverride, pathFlavor)
   if (!command.ok) {
     return command
   }
@@ -335,7 +338,9 @@ export async function discoverCommitMessageModelsLocal(
       const spawnEnv = env ?? process.env
       let discoveryStdin: string | null = null
       try {
-        const planned = planModelDiscovery(spec, agentCommandOverride)
+        const pathFlavor =
+          process.platform === 'win32' && !options.wslDistro ? 'windows' : 'posix'
+        const planned = planModelDiscovery(spec, agentCommandOverride, pathFlavor)
         if (!planned.ok) {
           markProcessClosed()
           resolve({ success: false, error: planned.error })
@@ -501,7 +506,8 @@ export async function discoverCommitMessageModelsRemote(
     cwd: string,
     timeoutMs: number
   ) => Promise<RemoteCommitMessageExecResult>,
-  agentCommandOverride?: string
+  agentCommandOverride?: string,
+  pathFlavor: CommandTemplatePathFlavor = 'posix'
 ): Promise<DiscoverCommitMessageModelsResult> {
   const spec = getCommitMessageAgentSpec(agentId)
   if (!spec) {
@@ -510,7 +516,7 @@ export async function discoverCommitMessageModelsRemote(
   if (spec.modelSource === 'static' || !spec.modelDiscovery) {
     return toModelDiscoveryCapability(spec)
   }
-  const planned = planModelDiscovery(spec, agentCommandOverride)
+  const planned = planModelDiscovery(spec, agentCommandOverride, pathFlavor)
   if (!planned.ok) {
     return { success: false, error: planned.error }
   }
@@ -1066,6 +1072,13 @@ function formatCommitMessageGenerationResult(
   }
 }
 
+function getCommandPathFlavor(target: CommitMessageGenerationTarget): CommandTemplatePathFlavor {
+  if (target.kind === 'remote') {
+    return target.commandPathFlavor ?? 'posix'
+  }
+  return process.platform === 'win32' && !target.wslDistro ? 'windows' : 'posix'
+}
+
 export async function generateCommitMessageFromContext(
   context: CommitMessageDraftContext,
   params: GenerateCommitMessageParams,
@@ -1083,7 +1096,9 @@ export async function generateCommitMessageFromContext(
           linkedIssue: formatLinkedIssueTemplateValue(context.linkedIssue)
         })
       : buildCommitMessagePrompt(context, params.customPrompt ?? '')
-  const planned = planCommitMessageGeneration(params, prompt)
+  const planned = planCommitMessageGeneration(params, prompt, {
+    commandPathFlavor: getCommandPathFlavor(target)
+  })
   if (!planned.ok) {
     return { success: false, error: planned.error }
   }
@@ -1155,7 +1170,9 @@ export async function generatePullRequestFieldsFromContext(
           linkedIssue: formatLinkedIssueTemplateValue(context.linkedIssue)
         })
       : buildPullRequestFieldsPrompt(context, params.customPrompt ?? '')
-  const planned = planCommitMessageGeneration(params, prompt)
+  const planned = planCommitMessageGeneration(params, prompt, {
+    commandPathFlavor: getCommandPathFlavor(target)
+  })
   if (!planned.ok) {
     return {
       success: false,
@@ -1205,7 +1222,9 @@ export async function generateBranchNameFromContext(
           assistantMessage: context.assistantMessage ?? ''
         })
       : buildBranchNamePrompt(context, params.customPrompt ?? '')
-  const planned = planCommitMessageGeneration(params, prompt)
+  const planned = planCommitMessageGeneration(params, prompt, {
+    commandPathFlavor: getCommandPathFlavor(target)
+  })
   if (!planned.ok) {
     return { success: false, error: planned.error }
   }

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -215,6 +215,27 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
+  it('preserves native Windows paths in preset agent command overrides', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'cursor',
+        model: 'auto',
+        agentCommandOverride:
+          '"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -File "C:\\Program Files\\cursor-agent.ps1"'
+      },
+      'PROMPT',
+      { commandPathFlavor: 'windows' }
+    )
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        binary: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+        args: expect.arrayContaining(['-File', 'C:\\Program Files\\cursor-agent.ps1'])
+      }
+    })
+  })
+
   it.each([
     ['long option', '--model gpt-5.6-luna', ['--model', 'gpt-5.6-luna'], []],
     ['short option', '-m gpt-5.6-luna', ['-m', 'gpt-5.6-luna'], []],

--- a/src/shared/commit-message-plan.ts
+++ b/src/shared/commit-message-plan.ts
@@ -3,7 +3,11 @@ import {
   getCommitMessageModel,
   isCustomAgentId
 } from './commit-message-agent-spec'
-import { planCustomCommand, tokenizeCustomCommandTemplate } from './commit-message-prompt'
+import {
+  planCustomCommand,
+  tokenizeCustomCommandTemplate,
+  type CommandTemplatePathFlavor
+} from './commit-message-prompt'
 import type { TuiAgent } from './types'
 
 // Why: planning is a pure transformation from "user request + prompt text"
@@ -34,16 +38,21 @@ export type CommitMessagePlanResult =
   | { ok: true; plan: CommitMessagePlan }
   | { ok: false; error: string }
 
+export type CommitMessagePlanOptions = {
+  commandPathFlavor?: CommandTemplatePathFlavor
+}
+
 export function planAgentBinary(
   defaultBinary: string,
-  commandOverride: string | undefined
+  commandOverride: string | undefined,
+  pathFlavor: CommandTemplatePathFlavor = 'posix'
 ): { ok: true; binary: string; prefixArgs: string[] } | { ok: false; error: string } {
   const command = commandOverride?.trim()
   if (!command) {
     return { ok: true, binary: defaultBinary, prefixArgs: [] }
   }
 
-  const tokenized = tokenizeCustomCommandTemplate(command)
+  const tokenized = tokenizeCustomCommandTemplate(command, pathFlavor)
   if (!tokenized.ok) {
     return { ok: false, error: `Agent command override is invalid: ${tokenized.error}` }
   }
@@ -55,13 +64,14 @@ export function planAgentBinary(
 }
 
 function planAdditionalAgentArgs(
-  agentArgs: string | null | undefined
+  agentArgs: string | null | undefined,
+  pathFlavor: CommandTemplatePathFlavor
 ): { ok: true; args: string[] } | { ok: false; error: string } {
   const trimmed = agentArgs?.trim()
   if (!trimmed) {
     return { ok: true, args: [] }
   }
-  const tokenized = tokenizeCustomCommandTemplate(trimmed)
+  const tokenized = tokenizeCustomCommandTemplate(trimmed, pathFlavor)
   if (!tokenized.ok) {
     return { ok: false, error: `CLI arguments are invalid: ${tokenized.error}` }
   }
@@ -158,8 +168,10 @@ function insertAdditionalAgentArgs(args: {
 
 export function planCommitMessageGeneration(
   input: CommitMessagePlanInput,
-  prompt: string
+  prompt: string,
+  options: CommitMessagePlanOptions = {}
 ): CommitMessagePlanResult {
+  const pathFlavor = options.commandPathFlavor ?? 'posix'
   if (isCustomAgentId(input.agentId)) {
     const command = input.customAgentCommand?.trim() ?? ''
     if (!command) {
@@ -168,11 +180,11 @@ export function planCommitMessageGeneration(
         error: 'Custom command is empty. Add one in Settings → Git → AI Commit Messages.'
       }
     }
-    const planned = planCustomCommand(command, prompt)
+    const planned = planCustomCommand(command, prompt, pathFlavor)
     if (!planned.ok) {
       return { ok: false, error: planned.error }
     }
-    const agentArgs = planAdditionalAgentArgs(input.agentArgs)
+    const agentArgs = planAdditionalAgentArgs(input.agentArgs, pathFlavor)
     if (!agentArgs.ok) {
       return agentArgs
     }
@@ -223,7 +235,7 @@ export function planCommitMessageGeneration(
     model: input.model,
     thinkingLevel: input.thinkingLevel
   })
-  const agentArgs = planAdditionalAgentArgs(input.agentArgs)
+  const agentArgs = planAdditionalAgentArgs(input.agentArgs, pathFlavor)
   if (!agentArgs.ok) {
     return agentArgs
   }
@@ -243,7 +255,7 @@ export function planCommitMessageGeneration(
     promptDelivery: spec.promptDelivery,
     prompt: argvPrompt
   })
-  const command = planAgentBinary(spec.binary, input.agentCommandOverride)
+  const command = planAgentBinary(spec.binary, input.agentCommandOverride, pathFlavor)
   if (!command.ok) {
     return { ok: false, error: command.error }
   }

--- a/src/shared/commit-message-prompt.test.ts
+++ b/src/shared/commit-message-prompt.test.ts
@@ -268,6 +268,28 @@ describe('tokenizeCustomCommandTemplate', () => {
     expect(r).toEqual({ ok: true, tokens: ['claude', '--msg', 'she said "hi"'] })
   })
 
+  it('keeps native path separators literal for Windows targets', () => {
+    const r = tokenizeCustomCommandTemplate(
+      '"C:\\Program Files\\Agent\\agent.exe" --config C:\\Users\\Ada\\agent.json',
+      'windows'
+    )
+    expect(r).toEqual({
+      ok: true,
+      tokens: ['C:\\Program Files\\Agent\\agent.exe', '--config', 'C:\\Users\\Ada\\agent.json']
+    })
+  })
+
+  it('retains POSIX backslash escape semantics for WSL and SSH targets', () => {
+    const r = tokenizeCustomCommandTemplate(
+      '/opt/My\\ Agent/bin/agent --label hello\\ world',
+      'posix'
+    )
+    expect(r).toEqual({
+      ok: true,
+      tokens: ['/opt/My Agent/bin/agent', '--label', 'hello world']
+    })
+  })
+
   it('keeps adjacent quoted/unquoted regions in one token (a"b"c → abc)', () => {
     const r = tokenizeCustomCommandTemplate('foo a"b"c')
     expect(r).toEqual({ ok: true, tokens: ['foo', 'abc'] })

--- a/src/shared/commit-message-prompt.ts
+++ b/src/shared/commit-message-prompt.ts
@@ -137,9 +137,7 @@ export type TokenizeCustomCommandResult =
 
 export type CommandTemplatePathFlavor = 'posix' | 'windows'
 
-// Why: this parser only groups argv; Windows keeps path separators literal,
-// while POSIX targets retain the existing backslash escapes. We do not expand
-// variables, substitutions, globs, or `~`.
+// Why: POSIX honors backslash escapes; Windows preserves them literally.
 export function tokenizeCustomCommandTemplate(
   template: string,
   pathFlavor: CommandTemplatePathFlavor = 'posix'

--- a/src/shared/commit-message-prompt.ts
+++ b/src/shared/commit-message-prompt.ts
@@ -135,13 +135,15 @@ export type TokenizeCustomCommandResult =
   | { ok: true; tokens: string[] }
   | { ok: false; error: string }
 
-// Why: deliberately POSIX-shell-style only for *grouping* (single + double
-// quotes, backslash escapes inside double quotes). We do NOT expand `$VAR`,
-// command substitution, backticks, globs, or `~`. The user's intent is
-// "spawn this exact CLI" — adding shell semantics on top would create
-// surprising behavior across platforms (especially Windows) and a security
-// surface we don't need.
-export function tokenizeCustomCommandTemplate(template: string): TokenizeCustomCommandResult {
+export type CommandTemplatePathFlavor = 'posix' | 'windows'
+
+// Why: this parser only groups argv; Windows keeps path separators literal,
+// while POSIX targets retain the existing backslash escapes. We do not expand
+// variables, substitutions, globs, or `~`.
+export function tokenizeCustomCommandTemplate(
+  template: string,
+  pathFlavor: CommandTemplatePathFlavor = 'posix'
+): TokenizeCustomCommandResult {
   const tokens: string[] = []
   let current = ''
   let inToken = false
@@ -151,7 +153,7 @@ export function tokenizeCustomCommandTemplate(template: string): TokenizeCustomC
   while (i < template.length) {
     const ch = template[i]
     if (quote) {
-      if (ch === '\\' && quote === '"' && i + 1 < template.length) {
+      if (ch === '\\' && quote === '"' && pathFlavor === 'posix' && i + 1 < template.length) {
         current += template[i + 1]
         i += 2
         continue
@@ -176,7 +178,7 @@ export function tokenizeCustomCommandTemplate(template: string): TokenizeCustomC
       continue
     }
 
-    if (ch === '\\' && i + 1 < template.length) {
+    if (ch === '\\' && pathFlavor === 'posix' && i + 1 < template.length) {
       current += template[i + 1]
       inToken = true
       i += 2
@@ -220,8 +222,12 @@ export type CustomCommandPlan =
  * substituted prompt is always passed as a single argument regardless of
  * whether the template wrote `{prompt}` or `"{prompt}"`.
  */
-export function planCustomCommand(template: string, prompt: string): CustomCommandPlan {
-  const tokenized = tokenizeCustomCommandTemplate(template)
+export function planCustomCommand(
+  template: string,
+  prompt: string,
+  pathFlavor: CommandTemplatePathFlavor = 'posix'
+): CustomCommandPlan {
+  const tokenized = tokenizeCustomCommandTemplate(template, pathFlavor)
   if (!tokenized.ok) {
     return { ok: false, error: tokenized.error }
   }


### PR DESCRIPTION
## Summary

- Tokenize custom commands using the execution target path flavor.
- Preserve native Windows backslashes while retaining POSIX escaping for macOS, Linux, WSL, and POSIX SSH targets.
- Propagate SSH host path flavor through commit, PR, branch-name, and model-discovery planning.

Fixes #11375

## Screenshots

No visual change.

## Testing

- [ ] pnpm lint
- [x] pnpm typecheck
- [ ] pnpm test
- [ ] pnpm build
- [x] Added or updated high-quality tests that would catch regressions

Focused checks:

- 304 tests passed, 1 skipped across command parsing, planning, generation, IPC, runtime, branch rename, and renderer plan coverage.
- pnpm run check:code-quality:changed
- pnpm run check:max-lines-ratchet
- git diff --check

## AI Review Report

Reviewed command tokenization, all local and SSH generation callers, WSL isolation, and model discovery. Greptile rated the change 5/5 with no files needing attention. CodeRabbit flagged one verbose comment; commit 8a55e3ba8 condensed it. Cross-platform review verified that macOS, Linux, WSL, and POSIX SSH keep existing backslash escapes while native and SSH Windows preserve path separators.

## Security Audit

The tokenizer remains argv-only and does not add shell execution, variable expansion, command substitution, globbing, or home expansion. The review covered arbitrary command overrides, quoted paths, WSL host separation, SSH host path flavor, and fallback behavior when remote platform detection is unavailable. No secrets or dependency changes are included.

## Notes

The path flavor defaults to POSIX for backward compatibility. Native Windows is selected only for a local win32 target without WSL or an SSH host explicitly detected as Windows.