### PR TITLE
feat(linear): show project labels in Linear task views

### DIFF
--- a/src/main/linear/issues-project.test.ts
+++ b/src/main/linear/issues-project.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LinearClientForWorkspace } from './client'
+
+const rawRequest = vi.fn()
+const getClients = vi.fn()
+
+vi.mock('./client', () => ({
+  acquire: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+  getClients: (...args: unknown[]) => getClients(...args),
+  isAuthError: vi.fn().mockReturnValue(false),
+  clearToken: vi.fn()
+}))
+
+function makeEntry(): LinearClientForWorkspace {
+  return {
+    workspace: {
+      id: 'workspace-1',
+      organizationId: 'workspace-1',
+      organizationName: 'Workspace',
+      displayName: 'Ada',
+      email: 'ada@example.com'
+    },
+    client: { client: { rawRequest } }
+  } as unknown as LinearClientForWorkspace
+}
+
+function rawIssue(id: string, project: { id: string; name: string; color?: string | null } | null) {
+  return {
+    id,
+    identifier: id,
+    title: id,
+    description: 'Description',
+    url: `https://linear.app/${id}`,
+    estimate: 3,
+    priority: 2,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    labelIds: [],
+    project,
+    state: { name: 'Todo', type: 'unstarted', color: '#888888' },
+    team: { id: 'team-1', name: 'Team', key: 'TM' },
+    labels: { nodes: [] }
+  }
+}
+
+describe('Linear issue collection projects', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    getClients.mockReturnValue([makeEntry()])
+  })
+
+  it('selects and maps optional projects for issue lists', async () => {
+    rawRequest.mockResolvedValueOnce({
+      data: {
+        issues: {
+          nodes: [
+            rawIssue('LIN-1', { id: 'project-1', name: 'Orca', color: '#5e6ad2' }),
+            rawIssue('LIN-2', null)
+          ]
+        }
+      }
+    })
+    const { listIssues } = await import('./issues')
+
+    await expect(listIssues('all', 10, 'workspace-1')).resolves.toMatchObject({
+      items: [
+        { id: 'LIN-1', project: { id: 'project-1', name: 'Orca', color: '#5e6ad2' } },
+        { id: 'LIN-2', project: undefined }
+      ]
+    })
+    expect(rawRequest.mock.calls[0][0]).toContain('project {')
+    expect(rawRequest.mock.calls[0][0]).toContain('color')
+  })
+
+  it('maps project summaries for issue search results', async () => {
+    rawRequest.mockResolvedValueOnce({
+      data: {
+        searchIssues: {
+          nodes: [rawIssue('LIN-1', { id: 'project-1', name: 'Orca', color: null })]
+        }
+      }
+    })
+    const { searchIssues } = await import('./issues')
+
+    await expect(searchIssues('Orca', 10, 'workspace-1')).resolves.toMatchObject([
+      { project: { id: 'project-1', name: 'Orca', color: undefined } }
+    ])
+  })
+})

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -56,6 +56,11 @@ type LinearIssueNode = {
     name?: string | null
     key?: string | null
   } | null
+  project?: {
+    id: string
+    name: string
+    color?: string | null
+  } | null
   assignee?: {
     id: string
     displayName: string
@@ -161,6 +166,11 @@ const LINEAR_ISSUE_NODE_FIELDS = `
     id
     name
     key
+  }
+  project {
+    id
+    name
+    color
   }
   assignee {
     id
@@ -414,6 +424,13 @@ function mapRawIssueForWorkspace(
       name: issue.team?.name ?? '',
       key: issue.team?.key ?? ''
     },
+    project: issue.project
+      ? {
+          id: issue.project.id,
+          name: issue.project.name,
+          color: issue.project.color ?? undefined
+        }
+      : undefined,
     labels: labelNodes.map((label) => label.name),
     // Why: labelIds drives full-replace updates. Keep Linear's complete id
     // list even when display label nodes are paginated.

--- a/src/main/linear/projects.test.ts
+++ b/src/main/linear/projects.test.ts
@@ -30,12 +30,16 @@ function makeEntry(): LinearClientForWorkspace {
   } as unknown as LinearClientForWorkspace
 }
 
-function rawIssue(id: string) {
+function rawIssue(
+  id: string,
+  project: { id: string; name: string; color?: string | null } | null = null
+) {
   return {
     id,
     identifier: id,
     title: id,
     url: `https://linear.app/${id}`,
+    project,
     priority: 0,
     updatedAt: '2026-01-01T00:00:00.000Z',
     labelIds: [],
@@ -217,6 +221,32 @@ describe('Linear project queries', () => {
     await expect(stalePromise).resolves.toMatchObject({
       items: [{ id: 'LIN-STALE' }]
     })
+  })
+
+  it('selects and maps optional project summaries for project issue reads', async () => {
+    rawRequest.mockResolvedValueOnce({
+      data: {
+        project: {
+          issues: {
+            nodes: [
+              rawIssue('LIN-1', { id: 'project-1', name: 'Orca', color: '#5e6ad2' }),
+              rawIssue('LIN-2')
+            ],
+            pageInfo: { hasNextPage: false }
+          }
+        }
+      }
+    })
+    const { listProjectIssues } = await import('./projects')
+
+    await expect(listProjectIssues('project-1', 20, 'workspace-1')).resolves.toMatchObject({
+      items: [
+        { id: 'LIN-1', project: { id: 'project-1', name: 'Orca', color: '#5e6ad2' } },
+        { id: 'LIN-2', project: undefined }
+      ]
+    })
+    expect(rawRequest.mock.calls[0][0]).toContain('project {')
+    expect(rawRequest.mock.calls[0][0]).toContain('color')
   })
 
   it('loads project issue reads above Linear connection page size', async () => {
@@ -465,6 +495,31 @@ describe('Linear project queries', () => {
     staleRequest.resolve(customViewIssuesResponse('ISSUE-STALE'))
     await expect(stalePromise).resolves.toMatchObject({
       items: [{ id: 'ISSUE-STALE' }]
+    })
+  })
+
+  it('maps optional project summaries for issue custom views', async () => {
+    rawRequest.mockResolvedValueOnce({
+      data: {
+        customView: {
+          modelName: 'Issue',
+          issues: {
+            nodes: [
+              rawIssue('ISSUE-1', { id: 'project-1', name: 'Orca', color: null }),
+              rawIssue('ISSUE-2')
+            ],
+            pageInfo: { hasNextPage: false }
+          }
+        }
+      }
+    })
+    const { listCustomViewIssues } = await import('./projects')
+
+    await expect(listCustomViewIssues('view-1', 20, 'workspace-1')).resolves.toMatchObject({
+      items: [
+        { id: 'ISSUE-1', project: { id: 'project-1', name: 'Orca', color: undefined } },
+        { id: 'ISSUE-2', project: undefined }
+      ]
     })
   })
 

--- a/src/main/linear/projects.ts
+++ b/src/main/linear/projects.ts
@@ -121,6 +121,11 @@ type LinearIssueNode = {
     name?: string | null
     key?: string | null
   } | null
+  project?: {
+    id: string
+    name: string
+    color?: string | null
+  } | null
   assignee?: LinearUserNode | null
   labels?: LinearConnection<{ id: string; name: string }> | null
 }
@@ -298,6 +303,11 @@ const ORCA_ISSUE_FIELDS = `
     id
     name
     key
+  }
+  project {
+    id
+    name
+    color
   }
   assignee {
     id
@@ -713,6 +723,13 @@ function mapIssueForWorkspace(
       name: issue.team?.name ?? '',
       key: issue.team?.key ?? ''
     },
+    project: issue.project
+      ? {
+          id: issue.project.id,
+          name: issue.project.name,
+          color: issue.project.color ?? undefined
+        }
+      : undefined,
     labels: labelNodes.map((label) => label.name),
     labelIds: issue.labelIds ?? labelNodes.map((label) => label.id),
     assignee: mapUser(issue.assignee),

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -193,6 +193,7 @@ import {
 } from '../../../shared/execution-host-registry'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
 import LinearIssueWorkspace from '@/components/LinearIssueWorkspace'
+import { LinearIssueProjectLabel } from '@/components/linear-issue-project-label'
 import {
   LinearCollectionNotice,
   LinearCustomViewTable,
@@ -235,6 +236,7 @@ import {
   deriveTaskPageGitHubWorkItemsFetchOptions,
   findTaskPageDialogWorkItem,
   findTaskPageLinearIssue,
+  preferFreshTaskPageLinearIssue,
   reconcileTaskPageLinearIssuesAfterLandingRefresh,
   reconcileTaskPagePagesAfterLandingRefresh,
   reconcileTaskPagePagesWithWorkItemsCache,
@@ -429,6 +431,7 @@ import {
 import { translate } from '@/i18n/i18n'
 import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
 import {
+  DEFAULT_LINEAR_DISPLAY_PROPERTIES,
   getGitHubModeButtons,
   getGitHubTaskKindPresets,
   getGitLabIssueFilters,
@@ -962,6 +965,9 @@ function TaskPageJiraErrorBanner({
 
 function getLinearIssueGridTemplate(visibleProperties: ReadonlySet<LinearDisplayProperty>): string {
   const columns = ['96px', 'minmax(240px,1.55fr)']
+  if (visibleProperties.has('project')) {
+    columns.push('minmax(140px,0.75fr)')
+  }
   if (visibleProperties.has('labels')) {
     columns.push('minmax(168px,0.9fr)')
   }
@@ -5150,14 +5156,16 @@ export default function TaskPage(): React.JSX.Element {
 
   const displayedLinearIssues = useMemo(
     () =>
-      activeLinearIssues.map(
-        (issue) =>
+      activeLinearIssues.map((issue) =>
+        preferFreshTaskPageLinearIssue(
+          issue,
           findTaskPageLinearIssue(
             linearCacheSnapshot.issueCache,
             linearCacheSnapshot.searchCache,
             linearCacheSnapshot.listCache,
             issue.id
-          ) ?? issue
+          )
+        )
       ),
     [
       activeLinearIssues,
@@ -11378,6 +11386,9 @@ export default function TaskPage(): React.JSX.Element {
                 >
                   <span>{translate('auto.components.TaskPage.37e7ee311e', 'Key')}</span>
                   <span>{translate('auto.components.TaskPage.b1eaa18ace', 'Issue')}</span>
+                  {effectiveLinearDisplayProperties.has('project') ? (
+                    <span>{translate('auto.components.TaskPage.00022ec0ba', 'Project')}</span>
+                  ) : null}
                   {effectiveLinearDisplayProperties.has('labels') ? (
                     <span>{translate('auto.components.TaskPage.d0ca4aa1d0', 'Labels')}</span>
                   ) : null}
@@ -11401,10 +11412,41 @@ export default function TaskPage(): React.JSX.Element {
                 </div>
               ) : null}
 
+
               <div
                 className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek"
                 style={{ scrollbarGutter: 'stable' }}
               >
+                {linearViewMode === 'list' && linearGroupBy === 'none' ? (
+                  <div
+                    className="sticky top-0 z-10 grid h-8 items-center gap-3 border-b border-border/50 bg-muted px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground max-lg:!hidden lg:grid-cols-[var(--linear-grid-template)] [&>span]:min-w-0 [&>span]:truncate"
+                    style={linearIssueGridStyle}
+                  >
+                    <span>{translate('auto.components.TaskPage.37e7ee311e', 'Key')}</span>
+                    <span>{translate('auto.components.TaskPage.b1eaa18ace', 'Issue')}</span>
+                    {effectiveLinearDisplayProperties.has('project') ? (
+                      <span>{translate('auto.components.TaskPage.00022ec0ba', 'Project')}</span>
+                    ) : null}
+                    {effectiveLinearDisplayProperties.has('labels') ? (
+                      <span>{translate('auto.components.TaskPage.d0ca4aa1d0', 'Labels')}</span>
+                    ) : null}
+                    {effectiveLinearDisplayProperties.has('team') ? (
+                      <span>{translate('auto.components.TaskPage.a98cbe7664', 'Team')}</span>
+                    ) : null}
+                    {effectiveLinearDisplayProperties.has('state') ? (
+                      <span>{translate('auto.components.TaskPage.154b0fa623', 'Status')}</span>
+                    ) : null}
+                    {effectiveLinearDisplayProperties.has('assignee') ? (
+                      <span className="text-center">
+                        {translate('auto.components.TaskPage.d2a876ca53', 'Assignee')}
+                      </span>
+                    ) : null}
+                    {effectiveLinearDisplayProperties.has('updated') ? (
+                      <span>{translate('auto.components.TaskPage.f362667d55', 'Updated')}</span>
+                    ) : null}
+                    <span />
+                  </div>
+                ) : null}
                 {activeLinearIssueError ? (
                   <div className="border-b border-border px-4 py-4 text-sm text-destructive">
                     {activeLinearIssueError}
@@ -11714,6 +11756,12 @@ export default function TaskPage(): React.JSX.Element {
                                   {effectiveLinearDisplayProperties.has('team') ? (
                                     <span className="truncate">{teamLabel}</span>
                                   ) : null}
+                                  {effectiveLinearDisplayProperties.has('project') ? (
+                                    <LinearIssueProjectLabel
+                                      project={issue.project}
+                                      className="max-w-full text-[11px]"
+                                    />
+                                  ) : null}
                                   {effectiveLinearDisplayProperties.has('updated') ? (
                                     <span>{formatRelativeTime(issue.updatedAt)}</span>
                                   ) : null}
@@ -11851,8 +11899,21 @@ export default function TaskPage(): React.JSX.Element {
                                   <span className="truncate">{attachedWorkspaceLabel}</span>
                                 </span>
                               ) : null}
+                              {effectiveLinearDisplayProperties.has('project') ? (
+                                <LinearIssueProjectLabel
+                                  project={issue.project}
+                                  className="max-w-[12rem] text-[11px] lg:!hidden"
+                                />
+                              ) : null}
                             </div>
                           </div>
+
+                          {effectiveLinearDisplayProperties.has('project') ? (
+                            <LinearIssueProjectLabel
+                              project={issue.project}
+                              className="text-[12px] max-lg:!hidden"
+                            />
+                          ) : null}
 
                           {effectiveLinearDisplayProperties.has('labels') ? (
                             <div className="flex min-w-0 items-center gap-1 max-lg:!hidden">

--- a/src/renderer/src/components/linear-issue-project-label.test.tsx
+++ b/src/renderer/src/components/linear-issue-project-label.test.tsx
@@ -1,0 +1,40 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { i18n } from '@/i18n/i18n'
+import { LinearIssueProjectLabel } from './linear-issue-project-label'
+
+describe('LinearIssueProjectLabel', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
+  })
+
+  it('renders the project name and Linear color marker', () => {
+    const html = renderToStaticMarkup(
+      <LinearIssueProjectLabel project={{ id: 'project-1', name: 'Orca', color: '#5e6ad2' }} />
+    )
+
+    expect(html).toContain('Orca')
+    expect(html).toContain('data-slot="linear-issue-project-marker"')
+    expect(html).toContain('background-color:#5e6ad2')
+  })
+
+  it('uses the muted marker when Linear omits a project color', () => {
+    const html = renderToStaticMarkup(
+      <LinearIssueProjectLabel project={{ id: 'project-1', name: 'Orca' }} />
+    )
+
+    expect(html).toContain('data-slot="linear-issue-project-marker"')
+    expect(html).toContain('bg-muted')
+    expect(html).not.toContain('background-color:')
+  })
+
+  it('renders localized unassigned copy without a marker', async () => {
+    await i18n.changeLanguage('ko')
+
+    const html = renderToStaticMarkup(<LinearIssueProjectLabel />)
+
+    expect(html).toContain('프로젝트 없음')
+    expect(html).not.toContain('data-slot="linear-issue-project-marker"')
+  })
+})

--- a/src/renderer/src/components/linear-issue-project-label.tsx
+++ b/src/renderer/src/components/linear-issue-project-label.tsx
@@ -1,0 +1,37 @@
+import type { LinearProjectSummary } from '../../../shared/types'
+
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+
+type LinearIssueProjectLabelProps = {
+  project?: LinearProjectSummary
+  className?: string
+}
+
+export function LinearIssueProjectLabel({
+  project,
+  className
+}: LinearIssueProjectLabelProps): React.JSX.Element {
+  return (
+    <div
+      data-slot="linear-issue-project-label"
+      className={cn('flex min-w-0 items-center gap-1.5 text-muted-foreground', className)}
+    >
+      {project ? (
+        <>
+          <span
+            data-slot="linear-issue-project-marker"
+            aria-hidden
+            className="size-2 shrink-0 rounded-full bg-muted"
+            style={project.color ? { backgroundColor: project.color } : undefined}
+          />
+          <span className="min-w-0 truncate">{project.name}</span>
+        </>
+      ) : (
+        <span className="min-w-0 truncate">
+          {translate('auto.components.TaskPage.1742eafc14', 'No Project')}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/task-page-cache-selectors.test.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.test.ts
@@ -11,6 +11,7 @@ import {
   deriveTaskPageGitHubWorkItemsFetchOptions,
   findTaskPageDialogWorkItem,
   findTaskPageLinearDrawerIssue,
+  preferFreshTaskPageLinearIssue,
   reconcileTaskPageItemsAfterLandingRefresh,
   reconcileTaskPageLinearIssuesAfterLandingRefresh,
   reconcileTaskPagePagesAfterLandingRefresh,
@@ -352,6 +353,46 @@ describe('task page cache selectors', () => {
     )
 
     expect(next).toEqual([refreshedFirst, refreshedSecond])
+  })
+
+  it('merges Linear landing refresh project-only changes', () => {
+    const current = {
+      ...linearIssue('LIN-1'),
+      identifier: 'ENG-1',
+      url: 'https://linear.test/ENG-1',
+      state: { name: 'Todo', type: 'unstarted', color: '#111111' },
+      team: { id: 'team-1', name: 'Team', key: 'ENG' },
+      labels: [],
+      labelIds: [],
+      priority: 2,
+      updatedAt: '2026-01-01',
+      project: { id: 'project-1', name: 'Orca', color: '#5e6ad2' }
+    } as LinearIssue
+    const refreshed = {
+      ...current,
+      project: { id: 'project-1', name: 'Orca Desktop', color: '#26b5ce' }
+    }
+
+    const next = reconcileTaskPageLinearIssuesAfterLandingRefresh([current], [refreshed])
+
+    expect(next).toEqual([refreshed])
+  })
+
+  it('prefers a fresher context issue over a stale general-cache issue', () => {
+    const cached = {
+      ...linearIssue('LIN-1'),
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      project: { id: 'project-1', name: 'Orca', color: '#5e6ad2' }
+    } as LinearIssue
+    const current = {
+      ...cached,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      project: { id: 'project-2', name: 'Desktop', color: '#26b5ce' }
+    }
+
+    expect(preferFreshTaskPageLinearIssue(current, cached)).toBe(current)
+    expect(preferFreshTaskPageLinearIssue(cached, current)).toBe(current)
+    expect(preferFreshTaskPageLinearIssue(current, null)).toBe(current)
   })
 
   it('returns null while the Linear drawer is closed and finds open issues by stable reference', () => {

--- a/src/renderer/src/components/task-page-cache-selectors.test.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.test.ts
@@ -395,6 +395,21 @@ describe('task page cache selectors', () => {
     expect(preferFreshTaskPageLinearIssue(current, null)).toBe(current)
   })
 
+  it('prefers a parseable current issue over a cached issue with an unparseable updatedAt', () => {
+    const cached = {
+      ...linearIssue('LIN-1'),
+      updatedAt: 'not-a-date',
+      project: { id: 'project-1', name: 'Orca', color: '#5e6ad2' }
+    } as LinearIssue
+    const current = {
+      ...cached,
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      project: { id: 'project-2', name: 'Desktop', color: '#26b5ce' }
+    }
+
+    expect(preferFreshTaskPageLinearIssue(current, cached)).toBe(current)
+  })
+
   it('returns null while the Linear drawer is closed and finds open issues by stable reference', () => {
     const issue = linearIssue('LIN-1')
     const searchIssue = linearIssue('LIN-2')

--- a/src/renderer/src/components/task-page-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.ts
@@ -14,6 +14,7 @@ import {
 export {
   findTaskPageLinearDrawerIssue,
   findTaskPageLinearIssue,
+  preferFreshTaskPageLinearIssue,
   reconcileTaskPageLinearIssuesAfterLandingRefresh,
   shouldReplaceTaskPageLinearIssuesAfterRefresh
 } from './task-page-linear-cache-selectors'
@@ -230,6 +231,7 @@ export function reconcileTaskPagePagesAfterLandingRefresh(
   return [nextFirstPage, ...pages.slice(1)]
 }
 
+
 export function findTaskPageDialogWorkItem(
   workItemsCache: WorkItemsCache,
   dialogWorkItemKey: TaskPageDialogWorkItemKey
@@ -248,3 +250,4 @@ export function findTaskPageDialogWorkItem(
   }
   return null
 }
+

--- a/src/renderer/src/components/task-page-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-cache-selectors.ts
@@ -251,3 +251,4 @@ export function findTaskPageDialogWorkItem(
   return null
 }
 
+

--- a/src/renderer/src/components/task-page-linear-cache-selectors.ts
+++ b/src/renderer/src/components/task-page-linear-cache-selectors.ts
@@ -22,6 +22,9 @@ function linearIssueStatusSignature(issue: LinearIssue): string {
     issue.team.id,
     issue.team.name,
     issue.team.key,
+    issue.project?.id ?? null,
+    issue.project?.name ?? null,
+    issue.project?.color ?? null,
     sortedStrings(issue.labels),
     issue.assignee?.id ?? null,
     issue.assignee?.displayName ?? null,
@@ -88,6 +91,23 @@ export function findTaskPageLinearIssue(
     }
   }
   return null
+}
+
+export function preferFreshTaskPageLinearIssue(
+  currentIssue: LinearIssue,
+  cachedIssue: LinearIssue | null
+): LinearIssue {
+  if (!cachedIssue) {
+    return currentIssue
+  }
+  const currentUpdatedAt = Date.parse(currentIssue.updatedAt)
+  const cachedUpdatedAt = Date.parse(cachedIssue.updatedAt)
+  // Why: context reads can be newer than general caches. Guard both timestamps so
+  // an unparseable cached updatedAt (NaN comparisons are always false) cannot win.
+  return Number.isFinite(currentUpdatedAt) &&
+    (!Number.isFinite(cachedUpdatedAt) || currentUpdatedAt > cachedUpdatedAt)
+    ? currentIssue
+    : cachedIssue
 }
 
 export const findTaskPageLinearDrawerIssue = findTaskPageLinearIssue

--- a/src/renderer/src/components/task-page-localized-options.test.ts
+++ b/src/renderer/src/components/task-page-localized-options.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { i18n } from '@/i18n/i18n'
 import {
+  DEFAULT_LINEAR_DISPLAY_PROPERTIES,
   getGitHubModeButtons,
   getGitHubTaskKindPresets,
+  getLinearDisplayProperties,
   getLinearPriorityLabel
 } from './task-page-localized-options'
 
@@ -42,6 +44,17 @@ describe('task-page-localized-options', () => {
       'PRs',
       'Projects'
     ])
+  })
+
+  it('refreshes the default-visible Linear Project property when the UI language changes', async () => {
+    expect(DEFAULT_LINEAR_DISPLAY_PROPERTIES).toContain('project')
+    expect(getLinearDisplayProperties()).toContainEqual({ id: 'project', label: 'Project' })
+
+    await i18n.changeLanguage('ko')
+
+    expect(getLinearDisplayProperties()).toContainEqual({ id: 'project', label: '프로젝트' })
+
+    await i18n.changeLanguage('en')
   })
 
   it('refreshes Linear priority labels when the UI language changes', async () => {

--- a/src/renderer/src/components/task-page-localized-options.tsx
+++ b/src/renderer/src/components/task-page-localized-options.tsx
@@ -49,6 +49,16 @@ export type {
   LinearViewMode
 } from '../../../shared/linear/issue-view-resume-state'
 
+export const DEFAULT_LINEAR_DISPLAY_PROPERTIES = [
+  'state',
+  'priority',
+  'assignee',
+  'team',
+  'project',
+  'labels',
+  'updated'
+] satisfies LinearDisplayProperty[]
+
 export function LinearIcon({ className }: { className?: string }): React.JSX.Element {
   return (
     <svg viewBox="0 0 24 24" aria-hidden className={className} fill="currentColor">
@@ -204,6 +214,7 @@ export const getLinearDisplayProperties = createLocalizedCatalog(
       priority: translate('auto.components.TaskPage.c8d5bec5f7', 'Priority'),
       assignee: translate('auto.components.TaskPage.d2a876ca53', 'Assignee'),
       team: translate('auto.components.TaskPage.a98cbe7664', 'Team'),
+      project: translate('auto.components.TaskPage.00022ec0ba', 'Project'),
       labels: translate('auto.components.TaskPage.d0ca4aa1d0', 'Labels'),
       updated: translate('auto.components.TaskPage.f362667d55', 'Updated')
     }

--- a/src/shared/linear/issue-view-resume-state.ts
+++ b/src/shared/linear/issue-view-resume-state.ts
@@ -19,6 +19,7 @@ export const LINEAR_DISPLAY_PROPERTIES = [
   'priority',
   'assignee',
   'team',
+  'project',
   'labels',
   'updated'
 ] as const


### PR DESCRIPTION
## Summary

Linear task views can now show each issue’s **Project** so similarly named issues across projects are easier to scan.

- Fetch optional project `id` / `name` / `color` on Linear issue collections (lists, search, project issues, issue-model custom views)
- Add **Project** to Display properties and enable it by default
- Render a shared project label (color marker + truncated name, muted marker fallback, localized **No Project**) in desktop list, compact/grouped rows, and board cards
- Prefer fresher context issues over stale general-cache entries when reconciling list rows

Fixes #11358

## Screenshots

<img width="2938" height="1698" alt="Linear task list showing Project column with color markers" src="https://github.com/user-attachments/assets/01939c25-c831-438b-99de-6e588baed55a" />

## Testing

- [x] `pnpm typecheck`
- [x] Focused Vitest suites for Linear project mapping, display-property catalog, cache freshness, and project-label presentation
- [x] `pnpm run check:max-lines-ratchet`
- [x] `pnpm run verify:localization-catalog` / `verify:localization-coverage`
- [x] Manual UI check in local `pnpm dev` app: Linear task list shows Project column / chips with colors and No Project empty state; View menu toggles work
- [ ] `pnpm lint` — full lint currently fails on a pre-existing switch-exhaustiveness error in `skill-freshness-group.tsx` (unrelated to this PR); staged-file oxlint via lint-staged passed
- [ ] `pnpm test` (full suite not re-run end-to-end for this PR)
- [ ] `pnpm build` (not re-run end-to-end for this PR)
- [x] Added/updated high-quality regression tests for collection mapping, label presentation, display defaults, and cache freshness

## AI Review Report

Reviewed for correctness (project mapping on all collection paths, empty/missing-color presentation, display-property wiring across list/board), cache reconciliation (project fields in status signatures; fresher context issue preference so scoped project issues are not overwritten by stale general-cache entries), performance (one collection query field set, no per-issue project fetches), and UI consistency (shared label component, sticky list header alignment).

Cross-platform: no OS-specific shortcuts, path, or shell behavior; Electron renderer UI only. SSH/remote: Linear API path unchanged; project summary is part of existing authenticated collection payloads.

## Security Audit

- No new command execution, path handling, secrets, or IPC surfaces
- Project color is treated as untrusted presentation metadata (inline style on a decorative marker only; name is text-rendered)
- GraphQL field selection extended with fixed `project { id name color }` only — no user-controlled query fragments

## Notes

- Project grouping, filtering, ordering, and persistence of Linear View settings remain out of scope (session-local like other display properties)
- Sticky list header moved into the scrolling body so the Project column header stays aligned while scrolling
