### PR TITLE
fix(tabs): trust native OpenCode titles without hook signals

### DIFF
--- a/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
@@ -161,6 +161,22 @@ describe('OpenCode native title tab identity', () => {
     }
   })
 
+  it.each([false, true])(
+    'keeps completed Claude ownership over an SSH/tmux restored title when observed=%s',
+    (hasObservedAgentSignal) => {
+      expect(
+        resolveTabAgentFromSignals({
+          hasObservedAgentSignal,
+          isRemote: true,
+          title: 'tmux | OC | Previous task',
+          hookAgent: null,
+          focusedCompletedHookAgent: 'claude',
+          launchAgent: 'claude'
+        })
+      ).toBe('claude')
+    }
+  )
+
   it('keeps matching sleeping ownership and preserves the no-signal fallback', () => {
     expect(
       resolveTabAgentFromSignals({

--- a/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
@@ -4,13 +4,17 @@ import { act, createElement } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '@/store'
-import type { TerminalTab, TuiAgent } from '../../../shared/types'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../shared/types'
 import { parseWorkspaceSession } from '../../../shared/workspace-session-schema'
 import { resolveTabAgentFromSignals, useTabAgent } from './use-tab-agent'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
 
 const initialAppState = useAppStore.getInitialState()
+const FOCUSED_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const SIBLING_LEAF_ID = '22222222-2222-4222-8222-222222222222'
 let latestAgent: TuiAgent | null | undefined
 let root: Root | null = null
 const identityScenarios: [
@@ -25,6 +29,33 @@ const identityScenarios: [
 function HookProbe({ tab }: { tab: TerminalTab }): null {
   latestAgent = useTabAgent(tab)
   return null
+}
+
+function splitLayout(): TerminalLayoutSnapshot {
+  return {
+    root: null,
+    activeLeafId: FOCUSED_LEAF_ID,
+    expandedLeafId: null,
+    ptyIdsByLeafId: {
+      [FOCUSED_LEAF_ID]: 'pty-opencode',
+      [SIBLING_LEAF_ID]: 'pty-sibling'
+    }
+  }
+}
+
+function sleepingClaudeRecord(paneKey: string): SleepingAgentSessionRecord {
+  return {
+    paneKey,
+    tabId: 'opencode-tab',
+    worktreeId: 'worktree-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: 'claude-session' },
+    prompt: '',
+    state: 'working',
+    capturedAt: 1,
+    updatedAt: 1,
+    origin: 'live'
+  }
 }
 
 describe('OpenCode native title tab identity', () => {
@@ -115,6 +146,73 @@ describe('OpenCode native title tab identity', () => {
     ).toBe('opencode')
   })
 
+  it('keeps current sleeping Claude ownership over a replayed OpenCode title', () => {
+    for (const hasObservedAgentSignal of [false, true]) {
+      expect(
+        resolveTabAgentFromSignals({
+          hasObservedAgentSignal,
+          isRemote: true,
+          title: 'tmux | OC | Previous task',
+          hookAgent: null,
+          sleepingSessionAgent: 'claude',
+          launchAgent: 'claude'
+        })
+      ).toBe('claude')
+    }
+  })
+
+  it('keeps matching sleeping ownership and preserves the no-signal fallback', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: false,
+        isRemote: true,
+        title: 'tmux | OC | Current task',
+        hookAgent: null,
+        sleepingSessionAgent: 'opencode',
+        launchAgent: 'opencode'
+      })
+    ).toBe('opencode')
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: false,
+        isRemote: true,
+        title: 'Terminal 1',
+        hookAgent: null
+      })
+    ).toBeNull()
+  })
+
+  it('keeps restored split-pane ownership over an SSH/tmux title replay', () => {
+    const paneKey = makePaneKey('opencode-tab', FOCUSED_LEAF_ID)
+    const parsed = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: 'worktree-1',
+      activeTabId: 'opencode-tab',
+      tabsByWorktree: {
+        'worktree-1': [{ ...staleClaudeTab, title: 'tmux | OC | Previous task' }]
+      },
+      terminalLayoutsByTabId: { 'opencode-tab': splitLayout() },
+      sleepingAgentSessionsByPaneKey: { [paneKey]: sleepingClaudeRecord(paneKey) }
+    })
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) {
+      return
+    }
+    const restoredTab = parsed.value.tabsByWorktree['worktree-1']![0]!
+    const restoredSleeping = parsed.value.sleepingAgentSessionsByPaneKey?.[paneKey]
+
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: false,
+        isRemote: true,
+        title: restoredTab.title,
+        hookAgent: null,
+        sleepingSessionAgent: restoredSleeping?.agent,
+        launchAgent: restoredTab.launchAgent
+      })
+    ).toBe('claude')
+  })
+
   it('keeps stronger live identity and rejects non-native OpenCode lookalikes', () => {
     expect(
       resolveTabAgentFromSignals({
@@ -122,6 +220,7 @@ describe('OpenCode native title tab identity', () => {
         isRemote: false,
         title: 'OC | Greeting',
         hookAgent: 'claude',
+        sleepingSessionAgent: 'claude',
         launchAgent: 'claude'
       })
     ).toBe('claude')
@@ -132,6 +231,7 @@ describe('OpenCode native title tab identity', () => {
         title: 'OC | Greeting',
         hookAgent: null,
         processAgent: 'codex',
+        sleepingSessionAgent: 'claude',
         launchAgent: 'claude'
       })
     ).toBe('codex')
@@ -158,7 +258,7 @@ describe('OpenCode native title tab identity', () => {
     }
   })
 
-  it('updates a mounted inactive tab without clearing metadata or probing providers', async () => {
+  it('updates a mounted inactive/restored split without provider probes', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -169,6 +269,25 @@ describe('OpenCode native title tab identity', () => {
     })
 
     expect(latestAgent).toBe('opencode')
+    expect(clearTabLaunchAgent).not.toHaveBeenCalled()
+    expect(getForegroundProcess).not.toHaveBeenCalled()
+    const paneKey = makePaneKey('opencode-tab', FOCUSED_LEAF_ID)
+
+    await act(async () => {
+      useAppStore.setState({
+        ptyIdsByTabId: { 'opencode-tab': ['pty-opencode', 'pty-sibling'] },
+        terminalLayoutsByTabId: { 'opencode-tab': splitLayout() },
+        sleepingAgentSessionsByPaneKey: { [paneKey]: sleepingClaudeRecord(paneKey) }
+      })
+      root?.render(
+        createElement(HookProbe, {
+          tab: { ...staleClaudeTab, title: 'tmux | OC | Previous task' }
+        })
+      )
+      await Promise.resolve()
+    })
+
+    expect(latestAgent).toBe('claude')
     expect(clearTabLaunchAgent).not.toHaveBeenCalled()
     expect(getForegroundProcess).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { TerminalTab, TuiAgent } from '../../../shared/types'
+import { parseWorkspaceSession } from '../../../shared/workspace-session-schema'
+import { resolveTabAgentFromSignals, useTabAgent } from './use-tab-agent'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const initialAppState = useAppStore.getInitialState()
+let latestAgent: TuiAgent | null | undefined
+let root: Root | null = null
+const identityScenarios: [
+  string,
+  { isRemote: boolean; title?: string; siblingHookAgent?: TuiAgent }
+][] = [
+  ['live local', { isRemote: false }],
+  ['inactive local split', { isRemote: false, siblingHookAgent: 'claude' }],
+  ['inactive SSH/tmux', { isRemote: true, title: 'tmux | OC | Greeting' }]
+]
+
+function HookProbe({ tab }: { tab: TerminalTab }): null {
+  latestAgent = useTabAgent(tab)
+  return null
+}
+
+describe('OpenCode native title tab identity', () => {
+  const originalApi = window.api
+  const getForegroundProcess = vi.fn()
+  const clearTabLaunchAgent = vi.fn()
+  const staleClaudeTab: TerminalTab = {
+    id: 'opencode-tab',
+    ptyId: 'pty-opencode',
+    worktreeId: 'worktree-1',
+    title: 'OC | Greeting',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    launchAgent: 'claude'
+  }
+
+  beforeEach(() => {
+    latestAgent = undefined
+    getForegroundProcess.mockReset()
+    clearTabLaunchAgent.mockReset()
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({
+      activeTabId: 'other-tab',
+      ptyIdsByTabId: { 'opencode-tab': ['pty-opencode'] },
+      agentStatusByPaneKey: {},
+      terminalLayoutsByTabId: {},
+      clearTabLaunchAgent
+    })
+    window.api = {
+      ...originalApi,
+      pty: {
+        ...originalApi?.pty,
+        getForegroundProcess
+      }
+    } as typeof window.api
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+      root = null
+    }
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+    window.api = originalApi
+  })
+
+  it.each(identityScenarios)(
+    'uses native OpenCode identity for a %s tab with stale Claude metadata',
+    (_name, extra) => {
+      expect(
+        resolveTabAgentFromSignals({
+          hasObservedAgentSignal: false,
+          isRemote: extra.isRemote,
+          title: extra.title ?? 'OC | Greeting',
+          hookAgent: null,
+          launchAgent: 'claude',
+          siblingHookAgent: extra.siblingHookAgent
+        })
+      ).toBe('opencode')
+    }
+  )
+
+  it('reclaims stale Claude identity loaded from a persisted tab', () => {
+    const parsed = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: 'worktree-1',
+      activeTabId: 'opencode-tab',
+      tabsByWorktree: { 'worktree-1': [staleClaudeTab] },
+      terminalLayoutsByTabId: {}
+    })
+    expect(parsed.ok).toBe(true)
+    if (!parsed.ok) {
+      return
+    }
+    const restoredTab = parsed.value.tabsByWorktree['worktree-1']![0]!
+
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: false,
+        isRemote: false,
+        title: restoredTab.title,
+        hookAgent: null,
+        launchAgent: restoredTab.launchAgent
+      })
+    ).toBe('opencode')
+  })
+
+  it('keeps stronger live identity and rejects non-native OpenCode lookalikes', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: false,
+        isRemote: false,
+        title: 'OC | Greeting',
+        hookAgent: 'claude',
+        launchAgent: 'claude'
+      })
+    ).toBe('claude')
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: false,
+        isRemote: false,
+        title: 'OC | Greeting',
+        hookAgent: null,
+        processAgent: 'codex',
+        launchAgent: 'claude'
+      })
+    ).toBe('codex')
+
+    for (const title of [
+      'OpenCode ready',
+      'oc | Greeting',
+      'my session | OC | Greeting',
+      '⠋ Fix foo | OC | Greeting',
+      '✦ Gemini CLI',
+      '⠋ Codex',
+      'Cursor Agent',
+      'Pi ready'
+    ]) {
+      expect(
+        resolveTabAgentFromSignals({
+          hasObservedAgentSignal: false,
+          isRemote: false,
+          title,
+          hookAgent: null,
+          launchAgent: 'claude'
+        })
+      ).toBe('claude')
+    }
+  })
+
+  it('updates a mounted inactive tab without clearing metadata or probing providers', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(createElement(HookProbe, { tab: staleClaudeTab }))
+      await Promise.resolve()
+    })
+
+    expect(latestAgent).toBe('opencode')
+    expect(clearTabLaunchAgent).not.toHaveBeenCalled()
+    expect(getForegroundProcess).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-sleeping-session.test.ts
@@ -84,9 +84,7 @@ describe('resolveTabAgentFromSignals sleeping-session precedence', () => {
     ).toBe('codex')
   })
 
-  it('keeps an explicit title ahead of a conflicting sleeping-session record', () => {
-    // Why: sleeping identity ranks below title — a live/last-known explicit title
-    // is at least as fresh as the hibernation snapshot.
+  it('keeps current sleeping ownership ahead of an unversioned conflicting title', () => {
     expect(
       resolveTabAgentFromSignals({
         hasObservedAgentSignal: true,
@@ -96,7 +94,7 @@ describe('resolveTabAgentFromSignals sleeping-session precedence', () => {
         sleepingSessionAgent: 'gemini',
         launchAgent: 'codex'
       })
-    ).toBe('claude')
+    ).toBe('gemini')
   })
 
   it('keeps a genuine tab icon when its sleeping record matches the launchAgent', () => {

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -263,7 +263,7 @@ describe('resolveTabAgentFromSignals', () => {
   it('uses OpenCode native session titles to replace stale Claude launch identity', () => {
     expect(
       resolveTabAgentFromSignals({
-        hasObservedAgentSignal: true,
+        hasObservedAgentSignal: false,
         isRemote: false,
         title: 'OC | Understand about the plugin',
         hookAgent: null,
@@ -571,6 +571,17 @@ describe('useTabAgent', () => {
 
     expect(latestHookAgent).toBe('codex')
     expect(getForegroundProcess).not.toHaveBeenCalled()
+  })
+
+  it('uses an OpenCode native title when stale Claude launch metadata has no hook signal', async () => {
+    await renderHookProbe({
+      ...baseTab,
+      title: 'OC | Greeting',
+      launchAgent: 'claude'
+    })
+
+    expect(latestHookAgent).toBe('opencode')
+    expect(clearTabLaunchAgent).not.toHaveBeenCalled()
   })
 
   it('does not clear launch identity while the live hook row persists at a shell title', async () => {

--- a/src/renderer/src/lib/use-tab-agent.test.ts
+++ b/src/renderer/src/lib/use-tab-agent.test.ts
@@ -573,17 +573,6 @@ describe('useTabAgent', () => {
     expect(getForegroundProcess).not.toHaveBeenCalled()
   })
 
-  it('uses an OpenCode native title when stale Claude launch metadata has no hook signal', async () => {
-    await renderHookProbe({
-      ...baseTab,
-      title: 'OC | Greeting',
-      launchAgent: 'claude'
-    })
-
-    expect(latestHookAgent).toBe('opencode')
-    expect(clearTabLaunchAgent).not.toHaveBeenCalled()
-  })
-
   it('does not clear launch identity while the live hook row persists at a shell title', async () => {
     const paneKey = makePaneKey('tab-1', LEAF_ID)
     useAppStore.setState({

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -12,6 +12,7 @@ import {
 } from './tab-agent'
 import { resolveExplicitTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import { resolveCompatibleAgentTypeForOwner } from '../../../shared/agent-title-owner'
+import { isOpenCodeNativeTitle } from '../../../shared/opencode-terminal-title'
 import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
 import type { TerminalTab, TuiAgent } from '../../../shared/types'
 
@@ -110,12 +111,12 @@ export function resolveTabAgentFromSignals(args: {
     owner
   )
   const priorIdentity = idleFocusedIdentity ?? launchAgent
-  // Why: a completed hook already proves activity, so it arms the reuse override without waiting for hasObservedAgentSignal (false for one mount commit).
+  // Why: completed hooks and OpenCode's native OSC title are direct runtime evidence, even without a live hook signal.
   const titleReclaimsReusedPane =
     priorIdentity !== null &&
     explicitTitleAgent !== null &&
     explicitTitleAgent !== priorIdentity &&
-    (args.hasObservedAgentSignal || hasCompletedHook)
+    (args.hasObservedAgentSignal || hasCompletedHook || isOpenCodeNativeTitle(args.title))
   const titleAgent = processProvesShell
     ? null
     : titleReclaimsReusedPane

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -104,6 +104,7 @@ export function resolveTabAgentFromSignals(args: {
     args.siblingCompletedHookAgent,
     launchAgent
   )
+  const sleepingSessionAgent = args.sleepingSessionAgent ?? null
 
   // Title carries identity only as a reuse override (names a DIFFERENT-group agent) or a legacy standalone id when no hook — same-group titles say nothing (OMP wraps Pi), so the record wins.
   const explicitTitleAgent = resolveSignalAgentForLaunchOwner(
@@ -117,13 +118,15 @@ export function resolveTabAgentFromSignals(args: {
     explicitTitleAgent !== null &&
     explicitTitleAgent !== priorIdentity &&
     (args.hasObservedAgentSignal || hasCompletedHook || isOpenCodeNativeTitle(args.title))
-  const titleAgent = processProvesShell
-    ? null
-    : titleReclaimsReusedPane
-      ? explicitTitleAgent
-      : priorIdentity
-        ? null
-        : explicitTitleAgent
+  // Why: titles have no PTY/provider generation, so they cannot displace a current provider-session owner.
+  const titleAgent =
+    processProvesShell || sleepingSessionAgent
+      ? null
+      : titleReclaimsReusedPane
+        ? explicitTitleAgent
+        : priorIdentity
+          ? null
+          : explicitTitleAgent
 
   const launchedAgentExited = resolveLaunchedAgentExitEvidence({
     title: args.title,
@@ -139,7 +142,6 @@ export function resolveTabAgentFromSignals(args: {
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
   // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
   const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
-  const sleepingSessionAgent = args.sleepingSessionAgent ?? null
   // Identity-first precedence (see JSDoc): live hook > process > title > idle > sleeping > launch > sibling.
   return (
     liveFocusedIdentity ??
@@ -161,9 +163,9 @@ export function resolveTabAgentFromSignals(args: {
  *
  * 1. Live focused hook — ground truth while the agent works; never title-overridden.
  * 2. Process identity — recognized foreground process (local only); re-owned within its title-identity group so OMP's nested `pi` (shell → omp → pi) can't flip the icon.
- * 3. Title — only a reuse override (names a DIFFERENT-group agent) or a legacy standalone identity when the pane has no hook.
+ * 3. Title — only a reuse override (names a DIFFERENT-group agent) or a legacy standalone identity when the pane has no sleeping session.
  * 4. Idle focused identity — the pane's own hook record after it went idle; suppressed locally once OSC 133;D proves exit.
- * 5. Sleeping session identity — a hibernated pane's captured session record.
+ * 5. Sleeping session identity — current provider-session ownership; also vetoes an unversioned title.
  * 6. launchAgent — bootstrap before any hook/process signal; cleared once exit evidence shows it left.
  * 7. Sibling-pane identity (live, then idle) — split-tab fallback.
  */

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -87,7 +87,7 @@ export function resolveTabAgentFromSignals(args: {
     sleepingSessionAgent: args.sleepingSessionAgent
   }) as TuiAgent | null
 
-  // The live/idle split governs title override: a LIVE hook is never title-overridden; an IDLE record can be reclaimed by a cross-group title. Siblings normalize vs launchAgent only.
+  // The live/idle split governs title override; siblings normalize against launch intent only.
   const liveFocusedIdentity = resolveSignalAgentForLaunchOwner(args.hookAgent, owner)
   const liveSiblingIdentity = resolveSignalAgentForLaunchOwner(args.siblingHookAgent, launchAgent)
   // Why: OSC 133;D proves this local pane returned to shell, so the idle identity is stale; remote titles lag runtime, so keep it there.
@@ -112,15 +112,18 @@ export function resolveTabAgentFromSignals(args: {
     owner
   )
   const priorIdentity = idleFocusedIdentity ?? launchAgent
-  // Why: completed hooks and OpenCode's native OSC title are direct runtime evidence, even without a live hook signal.
+  const nativeOpenCodeTitle = explicitTitleAgent === 'opencode' && isOpenCodeNativeTitle(args.title)
+  // Why: native OpenCode titles can reclaim stale launch intent before any observed hook signal.
   const titleReclaimsReusedPane =
     priorIdentity !== null &&
     explicitTitleAgent !== null &&
     explicitTitleAgent !== priorIdentity &&
-    (args.hasObservedAgentSignal || hasCompletedHook || isOpenCodeNativeTitle(args.title))
-  // Why: titles have no PTY/provider generation, so they cannot displace a current provider-session owner.
+    (args.hasObservedAgentSignal || hasCompletedHook || nativeOpenCodeTitle)
+  // Why: native OpenCode titles lack a provider generation and cannot displace durable ownership.
   const titleAgent =
-    processProvesShell || sleepingSessionAgent
+    processProvesShell ||
+    sleepingSessionAgent ||
+    (nativeOpenCodeTitle && idleFocusedIdentity !== null)
       ? null
       : titleReclaimsReusedPane
         ? explicitTitleAgent
@@ -142,7 +145,7 @@ export function resolveTabAgentFromSignals(args: {
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
   // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
   const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
-  // Identity-first precedence (see JSDoc): live hook > process > title > idle > sleeping > launch > sibling.
+  // Identity-first precedence (see JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
   return (
     liveFocusedIdentity ??
     processAgent ??
@@ -163,9 +166,9 @@ export function resolveTabAgentFromSignals(args: {
  *
  * 1. Live focused hook — ground truth while the agent works; never title-overridden.
  * 2. Process identity — recognized foreground process (local only); re-owned within its title-identity group so OMP's nested `pi` (shell → omp → pi) can't flip the icon.
- * 3. Title — only a reuse override (names a DIFFERENT-group agent) or a legacy standalone identity when the pane has no sleeping session.
- * 4. Idle focused identity — the pane's own hook record after it went idle; suppressed locally once OSC 133;D proves exit.
- * 5. Sleeping session identity — current provider-session ownership; also vetoes an unversioned title.
+ * 3. Title — only a reuse override or legacy standalone identity; native OpenCode titles cannot displace durable ownership.
+ * 4. Idle focused identity — the pane's own completed hook; suppressed locally once OSC 133;D proves exit.
+ * 5. Sleeping session identity — current provider-session ownership.
  * 6. launchAgent — bootstrap before any hook/process signal; cleared once exit evidence shows it left.
  * 7. Sibling-pane identity (live, then idle) — split-tab fallback.
  */


### PR DESCRIPTION
## Summary

- Treat the exact native OpenCode OC | title as direct runtime identity evidence.
- Let it replace stale Claude launch metadata when hooks and foreground-process signals are unavailable.
- Preserve launch-intent precedence for ordinary conflicting titles.

This closes the remaining integration gap after #9102.

Fixes #11329

## Screenshots

No visual layout change. The visible result is that the existing OpenCode icon replaces the incorrect Claude icon for affected tabs.

## Testing

- [ ] pnpm lint
- [x] pnpm typecheck
- [ ] pnpm test
- [ ] pnpm build
- [x] Added or updated high-quality tests that would catch regressions

Focused checks:

- 96 tests passed across tab identity, process signals, sleeping sessions, Pi/OMP identity, native OpenCode titles, and pane ownership.
- pnpm run check:code-quality:changed
- pnpm run check:max-lines-ratchet
- git diff --check

## AI Review Report

Reviewed the title, launch metadata, hook, process, sleeping-session, split-pane, and remote precedence chain. Greptile rated the change 5/5 and CodeRabbit generated no actionable code comments. Cross-platform review confirmed the change is title-classification only and does not alter shortcuts, paths, shells, or Electron platform branches on macOS, Linux, or Windows.

## Security Audit

No command execution, path handling, IPC, auth, secrets, dependencies, or persisted data changed. The native title matcher already existed; this PR only uses its exact high-confidence result in the identity resolver.

## Notes

The exact native OpenCode marker is the only new no-hook override. Ordinary conflicting titles still wait for observed activity, preserving the existing launch-window anti-flicker behavior.