### PR TITLE
feat(kimi): add K3 to the commit-message model picker

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -48,8 +48,10 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
   it('uses the provider-qualified Kimi model id accepted by the CLI', () => {
     expect(COMMIT_MESSAGE_AGENT_SPECS.kimi?.models.map((m) => m.id)).toEqual([
       'default',
-      'kimi-code/kimi-for-coding'
+      'kimi-code/kimi-for-coding',
+      'kimi-code/k3'
     ])
+    expect(getCommitMessageModel('kimi', 'kimi-code/k3')?.thinkingLevels).toBeUndefined()
   })
 
   it('lists Copilot hosted CLI models even when account policy filters the picker', () => {

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -555,6 +555,12 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
           { id: 'off', label: 'Off' }
         ],
         defaultThinkingLevel: 'on'
+      },
+      {
+        // Why: K3's managed profile is always-thinking, so exposing Off would
+        // generate a conflicting --no-thinking argument.
+        id: 'kimi-code/k3',
+        label: 'Kimi K3'
       }
     ],
     defaultModelId: 'default'


### PR DESCRIPTION
## Summary

- Add `kimi-code/k3` to the Kimi model picker used by AI-authored commit messages.
- Keep the configured default model unchanged.
- Omit the thinking-level control for K3 so Orca does not pass `--no-thinking` to an always-thinking model.

## Screenshots

The Kimi model picker now includes **Kimi K3** alongside the existing options.

<img width="3456" height="2168" alt="Kimi model picker with Kimi K3" src="https://github.com/user-attachments/assets/7f6e527b-74df-478a-8409-ab680a4d4c6f" />

## Testing

- `pnpm vitest run src/shared/commit-message-agent-spec.test.ts src/main/commit-message-agent.test.ts src/main/commit-message-agent-runtime.test.ts` (76 tests passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check upstream/main...HEAD`
- `pnpm test` (39,954 passed; one unrelated `src/main/ssh/ssh-system-transport.integration.test.ts` case timed out under full-suite load; the file passed 3/3 when rerun in isolation)

## AI Review Report

- Verified the Kimi K3 model ID and display label against the current Kimi CLI model surface.
- Checked that the configured default remains unchanged and that K3 does not expose a thinking toggle that could generate a conflicting `--no-thinking` argument.
- Reviewed the change for macOS, Linux, Windows, local, WSL, and SSH behavior; it only extends shared model metadata and does not add platform-specific behavior.

## Security Audit

- No changes to authentication, credentials, dependencies, IPC, command execution, paths, or network behavior.
- No local Kimi profile or token data is included.

## Notes

- Verified with Kimi CLI `0.30.0`.
- No paid Kimi K3 generation was executed for this PR.
