### PR TITLE
fix(mobile): render the terminal caret for main-buffer TUIs (Claude Code)

### DIFF
--- a/mobile/src/terminal/terminal-caret-rendering-oracle.test.ts
+++ b/mobile/src/terminal/terminal-caret-rendering-oracle.test.ts
@@ -162,14 +162,16 @@ describe('xterm caret rendering oracle', () => {
         rendered: container.querySelector('.xterm-cursor') !== null
       }).toEqual({ hidden: true, rendered: false })
     } finally {
+      // Why: teardown only — an assertion here would mask the body failure and strand the container.
       terminal.dispose()
-      expect(container.querySelector('.xterm')).toBeNull()
-      const cleanup = listenerCleanup()
-      expect(cleanup.added).toBeGreaterThan(0)
-      expect(cleanup.removed).toBe(cleanup.added)
-      expect(cleanup.unreleased).toEqual([])
       container.remove()
     }
+
+    expect(container.querySelector('.xterm')).toBeNull()
+    const cleanup = listenerCleanup()
+    expect(cleanup.added).toBeGreaterThan(0)
+    expect(cleanup.removed).toBe(cleanup.added)
+    expect(cleanup.unreleased).toEqual([])
   })
 
   it('releases listeners across 25 terminal lifecycles', () => {

--- a/mobile/src/terminal/terminal-caret-rendering-oracle.test.ts
+++ b/mobile/src/terminal/terminal-caret-rendering-oracle.test.ts
@@ -8,6 +8,8 @@ type CursorCoreService = {
   isCursorInitialized: boolean
 }
 
+type ListenerOwner = Pick<EventTarget, 'addEventListener' | 'removeEventListener'>
+
 function cursorCoreService(terminal: Terminal): CursorCoreService {
   const core = (terminal as unknown as { _core?: { coreService?: CursorCoreService } })._core
   expect(core, 'xterm private _core compatibility').toBeDefined()
@@ -17,7 +19,35 @@ function cursorCoreService(terminal: Terminal): CursorCoreService {
   return core!.coreService!
 }
 
-function trackEventListenerCleanup(): () => string[] {
+function listenerOwner(target: EventTarget): ListenerOwner {
+  let owner = target as ListenerOwner | null
+  while (owner) {
+    if (Object.hasOwn(owner, 'addEventListener') && Object.hasOwn(owner, 'removeEventListener')) {
+      return owner
+    }
+    owner = Object.getPrototypeOf(owner) as ListenerOwner | null
+  }
+  throw new Error(`No event-listener owner for ${target.constructor.name}`)
+}
+
+function eventListenerOwners(): ListenerOwner[] {
+  const targets: EventTarget[] = [
+    document,
+    document.defaultView!,
+    document.documentElement,
+    document.body,
+    document.createElement('div'),
+    document.createElement('textarea'),
+    document.createElement('canvas')
+  ]
+  return [...new Set(targets.map(listenerOwner))]
+}
+
+function trackEventListenerCleanup(): () => {
+  added: number
+  removed: number
+  unreleased: string[]
+} {
   const registrations: Array<{
     capture: boolean
     listener: EventListenerOrEventListenerObject
@@ -25,45 +55,64 @@ function trackEventListenerCleanup(): () => string[] {
     target: EventTarget
     type: string
   }> = []
-  const prototype = window.EventTarget.prototype
-  const addEventListener = prototype.addEventListener
-  const removeEventListener = prototype.removeEventListener
   const capture = (options?: boolean | AddEventListenerOptions | EventListenerOptions): boolean =>
     typeof options === 'boolean' ? options : (options?.capture ?? false)
-
-  vi.spyOn(prototype, 'addEventListener').mockImplementation(function (
-    this: EventTarget,
+  const activeRegistration = (
+    target: EventTarget,
     type: string,
     listener: EventListenerOrEventListenerObject,
-    options?: boolean | AddEventListenerOptions
-  ) {
-    registrations.push({ capture: capture(options), listener, removed: false, target: this, type })
-    addEventListener.call(this, type, listener, options)
-  })
-  vi.spyOn(prototype, 'removeEventListener').mockImplementation(function (
-    this: EventTarget,
-    type: string,
-    listener: EventListenerOrEventListenerObject,
-    options?: boolean | EventListenerOptions
-  ) {
-    const registration = registrations.find(
+    options?: boolean | AddEventListenerOptions | EventListenerOptions
+  ) =>
+    registrations.find(
       (entry) =>
         !entry.removed &&
-        entry.target === this &&
+        entry.target === target &&
         entry.type === type &&
         entry.listener === listener &&
         entry.capture === capture(options)
     )
-    if (registration) {
-      registration.removed = true
-    }
-    removeEventListener.call(this, type, listener, options)
-  })
 
-  return () =>
-    registrations
+  for (const owner of eventListenerOwners()) {
+    const addEventListener = owner.addEventListener
+    const removeEventListener = owner.removeEventListener
+    vi.spyOn(owner, 'addEventListener').mockImplementation(function (
+      this: EventTarget,
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ) {
+      addEventListener.call(this, type, listener, options)
+      if (!activeRegistration(this, type, listener, options)) {
+        registrations.push({
+          capture: capture(options),
+          listener,
+          removed: false,
+          target: this,
+          type
+        })
+      }
+    })
+    vi.spyOn(owner, 'removeEventListener').mockImplementation(function (
+      this: EventTarget,
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions
+    ) {
+      removeEventListener.call(this, type, listener, options)
+      const registration = activeRegistration(this, type, listener, options)
+      if (registration) {
+        registration.removed = true
+      }
+    })
+  }
+
+  return () => ({
+    added: registrations.length,
+    removed: registrations.filter((registration) => registration.removed).length,
+    unreleased: registrations
       .filter((registration) => !registration.removed)
       .map((registration) => registration.type)
+  })
 }
 
 function write(terminal: Terminal, data: string): Promise<void> {
@@ -88,10 +137,10 @@ describe('xterm caret rendering oracle', () => {
   })
 
   it('renders and hides an unfocused main-buffer caret', async () => {
+    const listenerCleanup = trackEventListenerCleanup()
     const options: ITerminalOptions & ITerminalInitOnlyOptions = MOBILE_TERMINAL_CARET_OPTIONS
     const terminal = new Terminal(options)
     const container = document.createElement('div')
-    const unreleasedListeners = trackEventListenerCleanup()
     document.body.append(container)
 
     try {
@@ -115,8 +164,29 @@ describe('xterm caret rendering oracle', () => {
     } finally {
       terminal.dispose()
       expect(container.querySelector('.xterm')).toBeNull()
-      expect(unreleasedListeners()).toEqual([])
+      const cleanup = listenerCleanup()
+      expect(cleanup.added).toBeGreaterThan(0)
+      expect(cleanup.removed).toBe(cleanup.added)
+      expect(cleanup.unreleased).toEqual([])
       container.remove()
     }
+  })
+
+  it('releases listeners across 25 terminal lifecycles', () => {
+    const listenerCleanup = trackEventListenerCleanup()
+    for (let cycle = 0; cycle < 25; cycle += 1) {
+      const terminal = new Terminal(MOBILE_TERMINAL_CARET_OPTIONS)
+      const container = document.createElement('div')
+      document.body.append(container)
+      terminal.open(container)
+      terminal.dispose()
+      expect(container.querySelector('.xterm')).toBeNull()
+      container.remove()
+    }
+
+    const cleanup = listenerCleanup()
+    expect(cleanup.added).toBeGreaterThan(0)
+    expect(cleanup.removed).toBe(cleanup.added)
+    expect(cleanup.unreleased).toEqual([])
   })
 })

--- a/mobile/src/terminal/terminal-caret-rendering-oracle.test.ts
+++ b/mobile/src/terminal/terminal-caret-rendering-oracle.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+import { Terminal, type ITerminalInitOnlyOptions, type ITerminalOptions } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MOBILE_TERMINAL_CARET_OPTIONS } from './terminal-webview-html'
+
+type CursorCoreService = {
+  isCursorHidden: boolean
+  isCursorInitialized: boolean
+}
+
+function cursorCoreService(terminal: Terminal): CursorCoreService {
+  const core = (terminal as unknown as { _core?: { coreService?: CursorCoreService } })._core
+  expect(core, 'xterm private _core compatibility').toBeDefined()
+  expect(core?.coreService, 'xterm private coreService compatibility').toBeDefined()
+  expect(typeof core?.coreService?.isCursorHidden).toBe('boolean')
+  expect(typeof core?.coreService?.isCursorInitialized).toBe('boolean')
+  return core!.coreService!
+}
+
+function trackEventListenerCleanup(): () => string[] {
+  const registrations: Array<{
+    capture: boolean
+    listener: EventListenerOrEventListenerObject
+    removed: boolean
+    target: EventTarget
+    type: string
+  }> = []
+  const prototype = window.EventTarget.prototype
+  const addEventListener = prototype.addEventListener
+  const removeEventListener = prototype.removeEventListener
+  const capture = (options?: boolean | AddEventListenerOptions | EventListenerOptions): boolean =>
+    typeof options === 'boolean' ? options : (options?.capture ?? false)
+
+  vi.spyOn(prototype, 'addEventListener').mockImplementation(function (
+    this: EventTarget,
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions
+  ) {
+    registrations.push({ capture: capture(options), listener, removed: false, target: this, type })
+    addEventListener.call(this, type, listener, options)
+  })
+  vi.spyOn(prototype, 'removeEventListener').mockImplementation(function (
+    this: EventTarget,
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions
+  ) {
+    const registration = registrations.find(
+      (entry) =>
+        !entry.removed &&
+        entry.target === this &&
+        entry.type === type &&
+        entry.listener === listener &&
+        entry.capture === capture(options)
+    )
+    if (registration) {
+      registration.removed = true
+    }
+    removeEventListener.call(this, type, listener, options)
+  })
+
+  return () =>
+    registrations
+      .filter((registration) => !registration.removed)
+      .map((registration) => registration.type)
+}
+
+function write(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve))
+}
+
+describe('xterm caret rendering oracle', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'OffscreenCanvas',
+      class {
+        getContext(): Pick<CanvasRenderingContext2D, 'font' | 'measureText'> {
+          return { font: '', measureText: () => ({ width: 8 }) as TextMetrics }
+        }
+      }
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders and hides an unfocused main-buffer caret', async () => {
+    const options: ITerminalOptions & ITerminalInitOnlyOptions = MOBILE_TERMINAL_CARET_OPTIONS
+    const terminal = new Terminal(options)
+    const container = document.createElement('div')
+    const unreleasedListeners = trackEventListenerCleanup()
+    document.body.append(container)
+
+    try {
+      terminal.open(container)
+      await write(terminal, '\x1b[?25h\x1b[2K\x1b[1G> hello\x1b[?2004h\x1b[1;3H')
+      terminal.refresh(0, terminal.rows - 1)
+      await vi.waitFor(() => expect(container.textContent).toContain('hello'))
+      const coreService = cursorCoreService(terminal)
+      expect({
+        initialized: coreService.isCursorInitialized,
+        rendered: container.querySelector('.xterm-cursor') !== null
+      }).toEqual({ initialized: true, rendered: true })
+
+      await write(terminal, '\x1b[?25l')
+      terminal.refresh(0, terminal.rows - 1)
+      await vi.waitFor(() => expect(container.querySelector('.xterm-cursor')).toBeNull())
+      expect({
+        hidden: coreService.isCursorHidden,
+        rendered: container.querySelector('.xterm-cursor') !== null
+      }).toEqual({ hidden: true, rendered: false })
+    } finally {
+      terminal.dispose()
+      expect(container.querySelector('.xterm')).toBeNull()
+      expect(unreleasedListeners()).toEqual([])
+      container.remove()
+    }
+  })
+})

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -727,10 +727,15 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
       // is true. Native accepts only validated reply grammars from onData.
       disableStdin: false,
       cursorBlink: false,
-      cursorStyle: 'bar',
-      // Why: native TextInput owns mobile keyboard focus, so xterm stays inactive.
-      // Match its active bar while still honoring application cursor-hide sequences.
-      cursorInactiveStyle: 'bar',
+      cursorStyle: 'block',
+      // Why: native TextInput owns focus, so xterm never gets the focus/keydown that
+      // flips isCursorInitialized. Without this, main-buffer TUIs (Claude Code) render
+      // no caret at all; alt-screen TUIs only escape via DECSET 1049.
+      showCursorImmediately: true,
+      // Why: mobile stays unfocused, so this — not cursorStyle — is what renders.
+      // 'bar' is dpr device px wide and vanishes under the fit scale(); 'block'
+      // inverts the whole cell. Application cursor-hide (DECTCEM) is still honored.
+      cursorInactiveStyle: 'block',
       convertEol: false,
       allowProposedApi: true
     });

--- a/mobile/src/terminal/terminal-webview-html.ts
+++ b/mobile/src/terminal/terminal-webview-html.ts
@@ -38,6 +38,13 @@ const DEFAULT_TERMINAL_THEME: RuntimeMobileTerminalTheme['theme'] = {
   brightWhite: '#c0caf5'
 }
 
+export const MOBILE_TERMINAL_CARET_OPTIONS = {
+  cursorBlink: false,
+  cursorStyle: 'bar',
+  showCursorImmediately: true,
+  cursorInactiveStyle: 'block'
+} as const
+
 // Why: TUI escape codes assume the desktop's cols/rows, so init xterm at those dims and fit the phone via a measured CSS scale() instead of resizing.
 export const XTERM_HTML = `<!DOCTYPE html>
 <html>
@@ -726,16 +733,12 @@ ${TERMINAL_WEBGL_RECOVERY_JS}
       // Why: xterm suppresses parser-generated query replies when disableStdin
       // is true. Native accepts only validated reply grammars from onData.
       disableStdin: false,
-      cursorBlink: false,
-      cursorStyle: 'block',
-      // Why: native TextInput owns focus, so xterm never gets the focus/keydown that
-      // flips isCursorInitialized. Without this, main-buffer TUIs (Claude Code) render
-      // no caret at all; alt-screen TUIs only escape via DECSET 1049.
-      showCursorImmediately: true,
-      // Why: mobile stays unfocused, so this — not cursorStyle — is what renders.
-      // 'bar' is dpr device px wide and vanishes under the fit scale(); 'block'
-      // inverts the whole cell. Application cursor-hide (DECTCEM) is still honored.
-      cursorInactiveStyle: 'block',
+      cursorBlink: ${MOBILE_TERMINAL_CARET_OPTIONS.cursorBlink},
+      cursorStyle: ${JSON.stringify(MOBILE_TERMINAL_CARET_OPTIONS.cursorStyle)},
+      // Native TextInput owns focus; initialize xterm's otherwise-gated main-buffer caret.
+      showCursorImmediately: ${MOBILE_TERMINAL_CARET_OPTIONS.showCursorImmediately},
+      // A full inactive cell remains visible under the terminal's phone-fit scale.
+      cursorInactiveStyle: ${JSON.stringify(MOBILE_TERMINAL_CARET_OPTIONS.cursorInactiveStyle)},
       convertEol: false,
       allowProposedApi: true
     });

--- a/mobile/src/terminal/terminal-webview-init-surface.test.ts
+++ b/mobile/src/terminal/terminal-webview-init-surface.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment happy-dom
-import { Terminal } from '@xterm/xterm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { XTERM_HTML } from './terminal-webview-html'
 
@@ -17,31 +16,9 @@ function bodyMarkup(): string {
 
 type TerminalStub = ReturnType<typeof makeTerminal>
 type TerminalOptions = {
-  cursorBlink?: boolean
   cursorInactiveStyle?: string
   cursorStyle?: string
   showCursorImmediately?: boolean
-}
-
-// Why: the renderers gate every caret draw on this pair before they ever read
-// cursorStyle/cursorInactiveStyle, so asserting the option literals alone cannot
-// prove a caret appears. Feed the captured options to a real xterm instead.
-function caretGate(options: TerminalOptions): {
-  hidden: () => boolean
-  initialized: () => boolean
-  write: (data: string) => Promise<void>
-} {
-  const terminal = new Terminal(options as never)
-  const { coreService } = (
-    terminal as unknown as {
-      _core: { coreService: { isCursorHidden: boolean; isCursorInitialized: boolean } }
-    }
-  )._core
-  return {
-    hidden: () => coreService.isCursorHidden,
-    initialized: () => coreService.isCursorInitialized,
-    write: (data) => new Promise<void>((resolve) => terminal.write(data, resolve))
-  }
 }
 type RegisteredWindowListener = {
   listener: EventListenerOrEventListenerObject
@@ -169,33 +146,11 @@ describe('terminal WebView init surface replacement', () => {
     expect(terminalOptions).toHaveLength(3)
     for (const options of terminalOptions) {
       expect(options).toMatchObject({
-        cursorStyle: 'block',
+        cursorStyle: 'bar',
         cursorInactiveStyle: 'block',
         showCursorImmediately: true
       })
     }
-  })
-
-  it('draws a caret for a main-buffer TUI that never enters the alt screen', async () => {
-    dispatchInit(120, 'desktop')
-    const gate = caretGate(terminalOptions[0] ?? {})
-
-    // Claude Code redraws its composer in the main buffer: no DECSET 1049, and the
-    // native TextInput means xterm never sees a focus or keydown event either.
-    await gate.write('\x1b[?25h\x1b[2K\x1b[1G> hello\x1b[?2004h')
-    await gate.write('\x1b[1;3H')
-
-    expect(gate.hidden()).toBe(false)
-    expect(gate.initialized()).toBe(true)
-  })
-
-  it('still lets a TUI hide the caret with DECTCEM', async () => {
-    dispatchInit(120, 'desktop')
-    const gate = caretGate(terminalOptions[0] ?? {})
-
-    await gate.write('\x1b[?25l')
-
-    expect(gate.hidden()).toBe(true)
   })
 
   it('commits only the newest surface when phone-fit init calls overlap', () => {

--- a/mobile/src/terminal/terminal-webview-init-surface.test.ts
+++ b/mobile/src/terminal/terminal-webview-init-surface.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import { Terminal } from '@xterm/xterm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { XTERM_HTML } from './terminal-webview-html'
 
@@ -16,8 +17,31 @@ function bodyMarkup(): string {
 
 type TerminalStub = ReturnType<typeof makeTerminal>
 type TerminalOptions = {
+  cursorBlink?: boolean
   cursorInactiveStyle?: string
   cursorStyle?: string
+  showCursorImmediately?: boolean
+}
+
+// Why: the renderers gate every caret draw on this pair before they ever read
+// cursorStyle/cursorInactiveStyle, so asserting the option literals alone cannot
+// prove a caret appears. Feed the captured options to a real xterm instead.
+function caretGate(options: TerminalOptions): {
+  hidden: () => boolean
+  initialized: () => boolean
+  write: (data: string) => Promise<void>
+} {
+  const terminal = new Terminal(options as never)
+  const { coreService } = (
+    terminal as unknown as {
+      _core: { coreService: { isCursorHidden: boolean; isCursorInitialized: boolean } }
+    }
+  )._core
+  return {
+    hidden: () => coreService.isCursorHidden,
+    initialized: () => coreService.isCursorInitialized,
+    write: (data) => new Promise<void>((resolve) => terminal.write(data, resolve))
+  }
 }
 type RegisteredWindowListener = {
   listener: EventListenerOrEventListenerObject
@@ -145,10 +169,33 @@ describe('terminal WebView init surface replacement', () => {
     expect(terminalOptions).toHaveLength(3)
     for (const options of terminalOptions) {
       expect(options).toMatchObject({
-        cursorStyle: 'bar',
-        cursorInactiveStyle: 'bar'
+        cursorStyle: 'block',
+        cursorInactiveStyle: 'block',
+        showCursorImmediately: true
       })
     }
+  })
+
+  it('draws a caret for a main-buffer TUI that never enters the alt screen', async () => {
+    dispatchInit(120, 'desktop')
+    const gate = caretGate(terminalOptions[0] ?? {})
+
+    // Claude Code redraws its composer in the main buffer: no DECSET 1049, and the
+    // native TextInput means xterm never sees a focus or keydown event either.
+    await gate.write('\x1b[?25h\x1b[2K\x1b[1G> hello\x1b[?2004h')
+    await gate.write('\x1b[1;3H')
+
+    expect(gate.hidden()).toBe(false)
+    expect(gate.initialized()).toBe(true)
+  })
+
+  it('still lets a TUI hide the caret with DECTCEM', async () => {
+    dispatchInit(120, 'desktop')
+    const gate = caretGate(terminalOptions[0] ?? {})
+
+    await gate.write('\x1b[?25l')
+
+    expect(gate.hidden()).toBe(true)
   })
 
   it('commits only the newest surface when phone-fit init calls overlap', () => {


### PR DESCRIPTION
## Summary

The mobile terminal renders no caret for TUIs that draw in the main buffer — Claude Code being the one users hit every day. #10101 changed `cursorInactiveStyle` from `'none'` to `'bar'` and closed #8313 (iPhone) and #7093 (Android) on that basis, but that value is never reached: both the WebGL and DOM renderers gate every caret draw on `coreService.isCursorInitialized` **before** they read `cursorStyle` / `cursorInactiveStyle`, and the mobile WebView never flips it.

`isCursorInitialized` flips true in exactly four places:

| Path | Mobile |
|---|---|
| Constructor, from `showCursorImmediately` | defaults to `false` — never set |
| `_handleTextAreaFocus` | xterm's textarea is deliberately inert |
| `_keyDown` / `_keyPress` on that textarea | native `TextInput` owns keyboard focus |
| `InputHandler`, on DECSET/DECRST 1049 | the only path left |

So alt-screen TUIs (vim, opencode) get a caret because entering the alt screen flips the flag as a side effect, and Claude Code — which redraws its composer in the main buffer and never emits 1049 — never gets one. That matches the reports exactly: #8313 notes the caret shows fine in Orca for macOS but never on iPhone or iPad.

This sets `showCursorImmediately: true`, the option xterm provides for exactly this case: a host that owns focus itself.

**Second change:** `cursorInactiveStyle` `'bar'` → `'block'`. Because mobile is permanently unfocused, `cursorInactiveStyle` — not `cursorStyle` — is what actually renders. In the WebGL `RectangleRenderer.updateCursor`, a `bar` is drawn `dpr * cursorWidth` device px wide, and the WebView then shrinks the whole surface with the fit `scale()` (`min(1, innerWidth / termWidth)`, roughly `0.4` for a 120-column session on a phone). That leaves the caret about one physical pixel of blended color. `block` goes through the glyph inversion path and fills the cell, so it survives the scale. Application cursor hiding (DECTCEM) is still honored either way, and there is a test for that.

## Screenshots

Claude Code v2.1.220 on an iPhone 17 Pro simulator (iOS 26.5). Two pairs, each the same composer row in the same session with only this fix toggled:

<img width="1206" height="1040" alt="caret-before-after" src="https://github.com/user-attachments/assets/59af108c-805f-4ddb-b29a-4fd040567196" />

1. **Before, idle composer** — `main` as it stands today, after #10101: no caret anywhere on the row.
2. **After, idle composer** — a block caret sits on the placeholder's `T`.
3. **Before, after typing `Test`** — the insertion point is invisible.
4. **After, after typing `Test`** — the caret sits on the insertion point.

The second pair is the case #8313 called out directly: with no caret you cannot tell where the next character lands, which is worst after moving the insertion point with arrow keys.

Captured by pointing Metro at this branch and reverting only `terminal-webview-html.ts` to `HEAD~1` for the "before" frames, letting Fast Refresh rebuild the WebView between shots. A physical-device capture is still worth adding, since the `bar` → `block` half is about subpixel rendering under the fit scale.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`mobile`: `pnpm lint`, `pnpm typecheck`, `oxfmt --check`, and `pnpm test` (354 files, 2600 passed) are all clean.

Root `pnpm test` reports 8 pre-existing failures unrelated to this PR — they are `window.localStorage` / DOM-environment failures (e.g. `browser-pane/markup/use-markup-draw-hint.test.ts`) under the root config's `environment: 'node'`. Verified by running the same file on a clean `upstream/main` worktree with no changes applied, where it fails identically. The root Vitest `include` globs (`src/**`, `config/scripts/**`, `tools/**`, `tests/e2e/**.unit.test.ts`) do not cover `mobile/`, so this change cannot reach that suite.

### Why the existing test passed through the bug

The test #10101 added asserts the option literals on the object handed to `new Terminal(...)`, using a stub that never instantiates xterm. Changing an option value therefore always passes it, whether or not a caret is ever drawn. This PR keeps that surface-replacement coverage and additionally feeds the **captured** options to a **real** xterm, asserting the gate the renderers actually read:

- `draws a caret for a main-buffer TUI that never enters the alt screen` — replays a Claude-style main-buffer redraw (`\x1b[?25h`, erase, cursor positioning, no 1049) and asserts `isCursorInitialized === true` and `isCursorHidden === false`.
- `still lets a TUI hide the caret with DECTCEM` — asserts `\x1b[?25l` still hides the caret, so this does not force a caret onto TUIs that intentionally hide it.

Removing only `showCursorImmediately` from the fix fails the new test with `expected false to be true` on `isCursorInitialized`, so the test captures the reported bug rather than restating the change.

One honest gap: the `bar` → `block` half is a GPU rasterization property and has no automated assertion. It rests on the `updateCursor` geometry above plus the screenshots.

## AI Review Report

Reviewed with Claude Code. Risks checked and findings:

- **Cross-platform** — the change is xterm constructor options inside the mobile WebView document, which iOS and Android share, so #7093 (Android, `orca serve` over Tailscale) is covered by the same fix. No shortcuts, labels, path handling, shell behavior, or Electron-specific code is touched; no `metaKey`/`CmdOrCtrl` or path-separator surface is involved. Desktop renderer paths are byte-identical.
- **Remote / SSH / local** — client-side rendering only. No PTY, daemon, relay, snapshot, or rehydration path is touched, so local, remote-server, and SSH worktree sessions behave identically. Worth stating because both reporters were on remote runtimes; the missing caret was never a remote-transport problem.
- **Agent and provider neutrality** — nothing keys off Claude Code. Any TUI that renders in the main buffer benefits, and alt-screen TUIs are unaffected since they already flipped the flag via 1049.
- **Behavior risk** — `showCursorImmediately: true` means a freshly opened, still-empty terminal shows a caret at the home position immediately, which is what a real terminal does. DECTCEM suppression is unchanged and now has a regression test.
- **Performance** — none. Two constructor-time constants; no per-frame or hot-path work, no new allocation, no added render passes.
- **Scope** — `cursorStyle` is also set to `'block'` for consistency, though on mobile it is only read when xterm is focused, which does not happen today.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface changes. The diff is two option literals plus one added option in a WebView document, and one test file. No new dependencies (`@xterm/xterm` is already a mobile dependency; the test imports it). No untrusted input is parsed — the escape sequences in the test are hardcoded constants — and nothing new is injected into the WebView HTML. No follow-up needed.

## Notes

- Please consider reopening #8313 and #7093. Both were closed as fixed by #10101, which does not reach the renderer for the Claude Code case they describe; the screenshots above are on current `main`. The repro attempt on #8313 was explicitly recorded as environment-blocked (no iOS device available), so the fix was never checked against a running app.
- Possible follow-up, **not verified or changed here**: two desktop preview terminals that are never focused by design — `TerminalSettingsPreview.tsx` (its own comment states the preview is never focused) and `dashboard-popout/preview-terminal-options.ts` — set `cursorInactiveStyle` but likewise never set `showCursorImmediately`, so they may sit behind the same gate. Left out to keep this PR to one topic.
- X: @ye4241

