### PR TITLE
fix(mobile): stop a client terminal subscribe from reviving a slept workspace

### DIFF
--- a/src/renderer/src/lib/mobile-terminal-tab-mount.test.ts
+++ b/src/renderer/src/lib/mobile-terminal-tab-mount.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AppState } from '@/store/types'
 import { planMobileTerminalTabMount } from './mobile-terminal-tab-mount'
 
-type PlannerState = Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId'>
+type PlannerState = Pick<
+  AppState,
+  'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId' | 'pendingStartupByTabId'
+>
 
+/** An awake workspace: every tab holds a live PTY, so a mount attaches rather than spawns. */
 function state(tabCount = 1): PlannerState {
   return {
     tabsByWorktree: {
@@ -12,8 +16,17 @@ function state(tabCount = 1): PlannerState {
         ptyId: `wt@@${index}`
       }))
     } as unknown as AppState['tabsByWorktree'],
-    terminalLayoutsByTabId: {}
+    terminalLayoutsByTabId: {},
+    ptyIdsByTabId: Object.fromEntries(
+      Array.from({ length: tabCount }, (_, index) => [`tab-${index}`, [`wt@@${index}`]])
+    ),
+    pendingStartupByTabId: {}
   }
+}
+
+/** A slept workspace: sleep kills the PTYs but keeps `tab.ptyId` as a wake hint. */
+function sleptState(tabCount = 1): PlannerState {
+  return { ...state(tabCount), ptyIdsByTabId: {} }
 }
 
 describe('planMobileTerminalTabMount', () => {
@@ -60,6 +73,69 @@ describe('planMobileTerminalTabMount', () => {
       )
     ).toBeNull()
     expect(isTabMounted).not.toHaveBeenCalled()
+  })
+
+  it('does not revive a slept workspace for a real-tab subscribe (#10205)', () => {
+    // Why: sleep keeps tab.ptyId as a wake hint, so the handle still resolves;
+    // mounting it would spawn a PTY and un-sleep the workspace on the desktop.
+    expect(
+      planMobileTerminalTabMount(sleptState(), { worktreeId: 'wt', tabId: 'tab-0' })
+    ).toBeNull()
+  })
+
+  it('does not revive a slept workspace for a synthetic pty handle (#10205)', () => {
+    expect(
+      planMobileTerminalTabMount(sleptState(200), { worktreeId: 'wt', ptyId: 'wt@@173' })
+    ).toBeNull()
+  })
+
+  it('fails closed before consulting mount state for a slept workspace', () => {
+    const isTabMounted = vi.fn()
+
+    expect(
+      planMobileTerminalTabMount(
+        sleptState(),
+        { worktreeId: 'wt', tabId: 'tab-0' },
+        { isTabMounted }
+      )
+    ).toBeNull()
+    expect(isTabMounted).not.toHaveBeenCalled()
+  })
+
+  it('still mounts when another tab in the workspace is live', () => {
+    // Why: a never-mounted tab in an awake workspace is the case this path exists
+    // for — only a fully cold workspace must fail closed.
+    const s = sleptState(2)
+    s.ptyIdsByTabId = { 'tab-1': ['wt@@1'] }
+
+    expect(planMobileTerminalTabMount(s, { worktreeId: 'wt', tabId: 'tab-0' })).toEqual({
+      worktreeId: 'wt',
+      tabIds: ['tab-0']
+    })
+  })
+
+  it('still mounts a freshly created mobile tab whose PTY has not spawned yet', () => {
+    // Why: terminal.create -> subscribe races the spawn; the queued startup proves
+    // a PTY is coming, so this is an attach-in-waiting, not a resurrection.
+    const s = sleptState()
+    s.pendingStartupByTabId = { 'tab-0': {} } as unknown as AppState['pendingStartupByTabId']
+
+    expect(planMobileTerminalTabMount(s, { worktreeId: 'wt', tabId: 'tab-0' })).toEqual({
+      worktreeId: 'wt',
+      tabIds: ['tab-0']
+    })
+  })
+
+  it('still mounts a tab whose activation spawn is pending', () => {
+    const s = sleptState()
+    s.tabsByWorktree = {
+      wt: [{ id: 'tab-0', ptyId: 'wt@@0', pendingActivationSpawn: true }]
+    } as unknown as AppState['tabsByWorktree']
+
+    expect(planMobileTerminalTabMount(s, { worktreeId: 'wt', tabId: 'tab-0' })).toEqual({
+      worktreeId: 'wt',
+      tabIds: ['tab-0']
+    })
   })
 
   it('does not schedule hidden layout work for an already-mounted tab', () => {

--- a/src/renderer/src/lib/mobile-terminal-tab-mount.ts
+++ b/src/renderer/src/lib/mobile-terminal-tab-mount.ts
@@ -12,16 +12,9 @@ type MobileTerminalTabMountOptions = {
   isTabMounted?: (tabId: string) => boolean
 }
 
-/**
- * True when mounting this tab could only *create* a PTY rather than attach one:
- * the workspace holds no live PTY and nothing is queued to spawn.
- *
- * Why: sleeping a workspace kills its PTYs but keeps `tab.ptyId` as a wake hint,
- * so a mobile subscribe could mount the pane and bring the workspace back to life
- * on the desktop with no user activation (#10205). `terminal.subscribe` already
- * degrades to a scrollback-only stream when no PTY appears, so failing closed here
- * still serves the saved output — it just stops resurrecting a slept workspace.
- */
+/** Why: sleep keeps `tab.ptyId` as a wake hint, so a mobile subscribe could mount the pane and
+ *  revive a slept workspace (#10205); failing closed is safe — `terminal.subscribe` already
+ *  degrades to a scrollback-only stream when no PTY appears. */
 function worktreeHasNoResumableTerminal(
   state: Pick<AppState, 'tabsByWorktree' | 'ptyIdsByTabId' | 'pendingStartupByTabId'>,
   worktreeId: string

--- a/src/renderer/src/lib/mobile-terminal-tab-mount.ts
+++ b/src/renderer/src/lib/mobile-terminal-tab-mount.ts
@@ -12,13 +12,42 @@ type MobileTerminalTabMountOptions = {
   isTabMounted?: (tabId: string) => boolean
 }
 
+/**
+ * True when mounting this tab could only *create* a PTY rather than attach one:
+ * the workspace holds no live PTY and nothing is queued to spawn.
+ *
+ * Why: sleeping a workspace kills its PTYs but keeps `tab.ptyId` as a wake hint,
+ * so a mobile subscribe could mount the pane and bring the workspace back to life
+ * on the desktop with no user activation (#10205). `terminal.subscribe` already
+ * degrades to a scrollback-only stream when no PTY appears, so failing closed here
+ * still serves the saved output — it just stops resurrecting a slept workspace.
+ */
+function worktreeHasNoResumableTerminal(
+  state: Pick<AppState, 'tabsByWorktree' | 'ptyIdsByTabId' | 'pendingStartupByTabId'>,
+  worktreeId: string
+): boolean {
+  const tabs = state.tabsByWorktree[worktreeId] ?? []
+  return tabs.every(
+    (tab) =>
+      (state.ptyIdsByTabId[tab.id]?.length ?? 0) === 0 &&
+      state.pendingStartupByTabId[tab.id] === undefined &&
+      !tab.pendingActivationSpawn
+  )
+}
+
 /** Why: exact-tab planning prevents a stale ptyId from mounting every saved xterm (#8597). */
 export function planMobileTerminalTabMount(
-  state: Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId'>,
+  state: Pick<
+    AppState,
+    'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId' | 'pendingStartupByTabId'
+  >,
   request: MobileTerminalTabMountRequest,
   options: MobileTerminalTabMountOptions = {}
 ): BackgroundMountTerminalWorktreeDetail | null {
   if (!request.worktreeId) {
+    return null
+  }
+  if (worktreeHasNoResumableTerminal(state, request.worktreeId)) {
     return null
   }
   const requestedTabExists = request.tabId


### PR DESCRIPTION
## Summary

Sleeping a workspace could be undone by a phone or web client, with no action on the desktop.

Sleep kills a workspace's PTYs but deliberately keeps `tab.ptyId` as a wake hint. `planMobileTerminalTabMount` only checked that the incoming handle resolved to a real tab, so when a client called `terminal.subscribe` on one of that workspace's terminals, the desktop background-mounted the pane and brought a PTY back up — reviving the workspace without any user activation and without navigating anywhere. The user sees a workspace they slept turn green again, and opening it shows a bare shell (a fresh spawn carries no agent resume).

This makes the planner fail closed when a mount could only *create* a PTY rather than attach one: the workspace holds no live PTY, no queued startup, and no pending activation spawn. `terminal.subscribe` already degrades to a scrollback-only stream when no PTY appears, so the client still gets the terminal's saved output — it just no longer resurrects the workspace.

Still allowed, and covered by tests:
- a never-mounted tab in a workspace that has another live PTY (the case this path exists for)
- a freshly created mobile tab whose PTY has not spawned yet (`terminal.create` → `subscribe` races the spawn)
- a tab whose activation spawn is pending

Fixes #10205

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Six new cases in `mobile-terminal-tab-mount.test.ts` (12/12 pass): three that a slept workspace is not revived via real-tab id, synthetic pty handle, or before consulting mount state; three that legitimate mounts still proceed.

Note on `pnpm test`: the full suite has 43 pre-existing failures in 9 files unrelated to this change (`use-markup-draw-hint`, `pr-comment-presentation`, `pr-comments-list-selection`, `use-persisted-ai-vault-view-options`, `LinearAgentSkillSetupPrompt.reminder-toast`, `mobile-sidebar-onboarding-badge`, `SidebarToolbar`, `transcript-watch-liveness`, `agent-exec-handler`). Verified identical failures on unmodified `upstream/main` at 4543bb682 — mostly `window.localStorage` being undefined in those environments.

### Field verification

Reproduced and then verified fixed against a running dev build over CDP:

- Before: a slept workspace (0 live PTYs) received a mobile-style tab mount and came back to life — live PTYs went 0 → 1 → 2 → 3 across three tabs while the desktop stayed on a different workspace the whole time. `planMobileTerminalTabMount` returned a mount plan for every slept workspace.
- After: slept workspaces return `null`; a workspace with live PTYs still plans its mount.

## AI Review Report

Reviewed with Claude Code across the risk areas below.

- **Cross-platform (macOS/Linux/Windows):** pure state predicate over store records — no paths, shells, keyboard shortcuts, accelerators, or Electron platform APIs touched. No platform-conditional behavior added or changed.
- **SSH / remote:** the guard reads `ptyIdsByTabId`, which is populated for local, SSH, and remote-runtime PTYs alike, so a live remote workspace still mounts. Remote-runtime and SSH pty ids are not special-cased, matching the surrounding code.
- **Agent/integration compatibility:** the pending-startup and pending-activation-spawn escapes keep the `terminal.create` → `subscribe` path working, which is how mobile launches agents. Verified no other caller exists — `planMobileTerminalTabMount` is called only from `useIpcEvents`, which passes the full store state.
- **Performance:** one `Array.every` over a single workspace's tabs on an event that already does more work; no new renders, subscriptions, or IPC.
- **UI quality:** no visual change.
- **Security:** see below.
- **Flagged and addressed:** the first draft gated only on "no live PTY", which would have broken mobile terminal creation; the pending-startup and pending-activation-spawn conditions were added and given dedicated tests.
- **Considered and rejected:** a durable `sleptWorktreeIds` marker. It is the more complete fix (it would also cover the non-mobile wake paths listed in #10205), but the issue notes that approach was added and reverted historically, so it needs a maintainer decision rather than a drive-by change.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or dependency surface. The change is a read-only predicate over existing renderer store state and strictly narrows what a remote client can cause the desktop to do — a client can no longer cause PTY spawns in a workspace the user has slept. IPC shape is unchanged; the message is already validated by the existing planner, and the new check runs before any mount is scheduled. No follow-up needed.

## Notes

- Behavior change for clients: subscribing to a terminal in a slept workspace now yields scrollback-only instead of silently starting the workspace. That is the intended product behavior per the issue's "Expected" section; waking should go through explicit activation (`worktree.activate`).
- This closes the one path I could reproduce deterministically. #10205 lists other candidate wake paths (`activateAndRevealWorktree` → `resumeSleepingAgentSessionsForWorktree`, cold-restore agent resume, startup hydration); I could not reproduce those on current `main`, including the issue's own Trigger A cascade, so they are deliberately out of scope here.
- Two adjacent defects found while investigating, not fixed here to keep this single-topic — happy to file or fix separately:
  1. `hasWorktreeSleepIntent` is only set when sleeping the **active** workspace (`sleep-worktree-flow.ts`), so sleeping a background workspace lets its PTY exits reach `bumpWorktreeActivity` — a workspace registers activity at the moment it is slept.
  2. The startup reconnect fallback in `store/slices/terminals.ts` uses `session.activeWorktreeIdsOnShutdown ?? …tabs.some(t => t.ptyId)`. The primary writer in `lib/workspace-session.ts` explicitly avoids `tab.ptyId` with the comment *"which sleep preserves as a wake hint and would revive slept worktrees as active"*, but the fallback uses exactly that — so a session missing that field (older build, or a crash before the write) revives every slept workspace on next launch.
