### PR TITLE
fix(preflight): route landing banner through the runtime-aware preflight slice

### DIFF
--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -235,11 +235,7 @@ export default function Landing(): React.JSX.Element {
   const hasGitHubProject = useMemo(() => hasGitHubBackedProject(repos), [repos])
   const showGitHubSupportFooter = repos.length === 0 || hasGitHubProject
 
-  // Why: the preflight slice routes to the active runtime environment via
-  // `preflight.check` RPC and only falls back to the local probe when no remote
-  // runtime is active. Calling the local preflight IPC directly here would
-  // always scan the client machine, so a remote runtime's landing banner
-  // reported the wrong host's git/gh state.
+  // Why: the runtime-aware slice probes the active remote host instead of the renderer host.
   const { preflightIssues } = useLandingPreflightRuntime()
 
   const createWorktreeShortcut = useShortcutKeyDetails('workspace.create')

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -245,6 +245,18 @@ export default function Landing(): React.JSX.Element {
   // reported the wrong host's git/gh state.
   const preflightStatus = useAppStore((s) => s.preflightStatus)
   const refreshPreflightStatus = useAppStore((s) => s.refreshPreflightStatus)
+  const invalidatePreflightStatus = useAppStore((s) => s.invalidatePreflightStatus)
+  const activeRuntimeIdentity = useAppStore((s) => {
+    const environmentId = s.settings?.activeRuntimeEnvironmentId?.trim() ?? 'local'
+    const runtimeStatus =
+      environmentId === 'local' ? undefined : s.runtimeStatusByEnvironmentId.get(environmentId)
+    const reachability = runtimeStatus
+      ? runtimeStatus.status === null
+        ? 'unreachable'
+        : 'reachable'
+      : 'unknown'
+    return `${environmentId}:${runtimeStatus?.connectionGeneration ?? 0}:${reachability}`
+  })
 
   const preflightIssues = useMemo(
     () =>
@@ -257,6 +269,11 @@ export default function Landing(): React.JSX.Element {
   )
 
   useEffect(() => {
+    if (activeRuntimeIdentity.endsWith(':unreachable')) {
+      invalidatePreflightStatus()
+      return
+    }
+
     void refreshPreflightStatus()
 
     // Why: users often install/authenticate gh outside Orca. Re-check when the
@@ -274,7 +291,7 @@ export default function Landing(): React.JSX.Element {
       document.removeEventListener('visibilitychange', handleWindowActive)
       window.removeEventListener('focus', handleWindowActive)
     }
-  }, [refreshPreflightStatus])
+  }, [activeRuntimeIdentity, invalidatePreflightStatus, refreshPreflightStatus])
 
   useEffect(() => {
     if (preflightIssues.length === 0) {

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -238,29 +238,32 @@ export default function Landing(): React.JSX.Element {
   const hasGitHubProject = useMemo(() => hasGitHubBackedProject(repos), [repos])
   const showGitHubSupportFooter = repos.length === 0 || hasGitHubProject
 
-  const [preflightIssues, setPreflightIssues] = useState<PreflightIssue[]>([])
+  // Why: the preflight slice routes to the active runtime environment via
+  // `preflight.check` RPC and only falls back to the local probe when no remote
+  // runtime is active. Calling the local preflight IPC directly here would
+  // always scan the client machine, so a remote runtime's landing banner
+  // reported the wrong host's git/gh state.
+  const preflightStatus = useAppStore((s) => s.preflightStatus)
+  const refreshPreflightStatus = useAppStore((s) => s.refreshPreflightStatus)
+
+  const preflightIssues = useMemo(
+    () =>
+      preflightStatus
+        ? getLandingPreflightIssues(preflightStatus, {
+            hasGitHubBackedProject: hasGitHubProject
+          })
+        : [],
+    [preflightStatus, hasGitHubProject]
+  )
 
   useEffect(() => {
-    let cancelled = false
-    const refreshPreflight = (force = false): void => {
-      void window.api.preflight.check(force ? { force: true } : undefined).then((status) => {
-        if (cancelled) {
-          return
-        }
-        setPreflightIssues(
-          getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
-        )
-      })
-    }
-
-    // oxlint-disable-next-line react-doctor/no-initialize-state -- Why: preflight status is read from an external IPC probe on mount and focus.
-    refreshPreflight()
+    void refreshPreflightStatus()
 
     // Why: users often install/authenticate gh outside Orca. Re-check when the
     // window becomes active again so the landing warning clears without relaunch.
     const handleWindowActive = (): void => {
       if (document.visibilityState === 'visible') {
-        refreshPreflight(true)
+        void refreshPreflightStatus({ force: true })
       }
     }
 
@@ -268,36 +271,26 @@ export default function Landing(): React.JSX.Element {
     window.addEventListener('focus', handleWindowActive)
 
     return () => {
-      cancelled = true
       document.removeEventListener('visibilitychange', handleWindowActive)
       window.removeEventListener('focus', handleWindowActive)
     }
-  }, [hasGitHubProject])
+  }, [refreshPreflightStatus])
 
   useEffect(() => {
     if (preflightIssues.length === 0) {
       return
     }
 
-    let cancelled = false
     // Why: some users complete `gh auth login` without ever leaving the Orca
     // window. Poll only while a warning is visible so the banner self-clears.
     const intervalId = window.setInterval(() => {
-      void window.api.preflight.check({ force: true }).then((status) => {
-        if (cancelled) {
-          return
-        }
-        setPreflightIssues(
-          getLandingPreflightIssues(status, { hasGitHubBackedProject: hasGitHubProject })
-        )
-      })
+      void refreshPreflightStatus({ force: true })
     }, 30000)
 
     return () => {
-      cancelled = true
       window.clearInterval(intervalId)
     }
-  }, [hasGitHubProject, preflightIssues.length])
+  }, [preflightIssues.length, refreshPreflightStatus])
 
   const createWorktreeShortcut = useShortcutKeyDetails('workspace.create')
   const previousWorktreeShortcut = useShortcutKeyDetails('worktree.navigateUp')

--- a/src/renderer/src/components/Landing.tsx
+++ b/src/renderer/src/components/Landing.tsx
@@ -14,11 +14,8 @@ import { useShortcutKeyDetails, type ShortcutKeyComboDetails } from '@/hooks/use
 import { useMountedRef } from '@/hooks/useMountedRef'
 import logo from '../../../../resources/logo.svg'
 import { translate } from '@/i18n/i18n'
-import {
-  getLandingPreflightIssues,
-  hasGitHubBackedProject,
-  type PreflightIssue
-} from './landing-preflight-issues'
+import { hasGitHubBackedProject, type PreflightIssue } from './landing-preflight-issues'
+import { useLandingPreflightRuntime } from './landing-preflight-runtime'
 
 type ShortcutItem = {
   id: string
@@ -243,71 +240,7 @@ export default function Landing(): React.JSX.Element {
   // runtime is active. Calling the local preflight IPC directly here would
   // always scan the client machine, so a remote runtime's landing banner
   // reported the wrong host's git/gh state.
-  const preflightStatus = useAppStore((s) => s.preflightStatus)
-  const refreshPreflightStatus = useAppStore((s) => s.refreshPreflightStatus)
-  const invalidatePreflightStatus = useAppStore((s) => s.invalidatePreflightStatus)
-  const activeRuntimeIdentity = useAppStore((s) => {
-    const environmentId = s.settings?.activeRuntimeEnvironmentId?.trim() ?? 'local'
-    const runtimeStatus =
-      environmentId === 'local' ? undefined : s.runtimeStatusByEnvironmentId.get(environmentId)
-    const reachability = runtimeStatus
-      ? runtimeStatus.status === null
-        ? 'unreachable'
-        : 'reachable'
-      : 'unknown'
-    return `${environmentId}:${runtimeStatus?.connectionGeneration ?? 0}:${reachability}`
-  })
-
-  const preflightIssues = useMemo(
-    () =>
-      preflightStatus
-        ? getLandingPreflightIssues(preflightStatus, {
-            hasGitHubBackedProject: hasGitHubProject
-          })
-        : [],
-    [preflightStatus, hasGitHubProject]
-  )
-
-  useEffect(() => {
-    if (activeRuntimeIdentity.endsWith(':unreachable')) {
-      invalidatePreflightStatus()
-      return
-    }
-
-    void refreshPreflightStatus()
-
-    // Why: users often install/authenticate gh outside Orca. Re-check when the
-    // window becomes active again so the landing warning clears without relaunch.
-    const handleWindowActive = (): void => {
-      if (document.visibilityState === 'visible') {
-        void refreshPreflightStatus({ force: true })
-      }
-    }
-
-    document.addEventListener('visibilitychange', handleWindowActive)
-    window.addEventListener('focus', handleWindowActive)
-
-    return () => {
-      document.removeEventListener('visibilitychange', handleWindowActive)
-      window.removeEventListener('focus', handleWindowActive)
-    }
-  }, [activeRuntimeIdentity, invalidatePreflightStatus, refreshPreflightStatus])
-
-  useEffect(() => {
-    if (preflightIssues.length === 0) {
-      return
-    }
-
-    // Why: some users complete `gh auth login` without ever leaving the Orca
-    // window. Poll only while a warning is visible so the banner self-clears.
-    const intervalId = window.setInterval(() => {
-      void refreshPreflightStatus({ force: true })
-    }, 30000)
-
-    return () => {
-      window.clearInterval(intervalId)
-    }
-  }, [preflightIssues.length, refreshPreflightStatus])
+  const { preflightIssues } = useLandingPreflightRuntime()
 
   const createWorktreeShortcut = useShortcutKeyDetails('workspace.create')
   const previousWorktreeShortcut = useShortcutKeyDetails('worktree.navigateUp')

--- a/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
+++ b/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
@@ -1,39 +1,128 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PreflightStatus } from '../../../preload/api-types'
+import type { Repo } from '../../../shared/types'
+import { useAppStore } from '../store'
+import { useLandingPreflightRuntime } from './landing-preflight-runtime'
 
-const root = process.cwd()
+const refresh = vi.fn().mockResolvedValue(undefined)
+const invalidate = vi.fn()
 
-function source(path: string): string {
-  return readFileSync(join(root, path), 'utf8')
+const status = (overrides: Partial<PreflightStatus> = {}): PreflightStatus => ({
+  git: { installed: true },
+  gh: { installed: false, authenticated: false },
+  ...overrides
+})
+
+const githubRepo: Repo = {
+  id: 'github',
+  path: '/repos/github',
+  displayName: 'github',
+  badgeColor: '#000000',
+  addedAt: 0,
+  kind: 'git',
+  upstream: { owner: 'orca', repo: 'orca' }
 }
 
-describe('landing preflight runtime ownership boundary', () => {
-  it('routes the landing preflight banner through the preflight slice', () => {
-    const text = source('src/renderer/src/components/Landing.tsx')
+beforeEach(() => {
+  vi.useFakeTimers()
+  refresh.mockClear()
+  invalidate.mockClear()
+  useAppStore.setState(useAppStore.getInitialState(), true)
+  useAppStore.setState({ refreshPreflightStatus: refresh, invalidatePreflightStatus: invalidate })
+})
 
-    expect(text).toContain('refreshPreflightStatus')
-    expect(text).toContain('s.preflightStatus')
-    expect(text).toContain('activeRuntimeIdentity')
-    expect(text).toContain('invalidatePreflightStatus')
-    expect(text).toContain('runtimeStatusByEnvironmentId')
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  useAppStore.setState(useAppStore.getInitialState(), true)
+})
+
+describe('landing preflight runtime boundary', () => {
+  it('refreshes after an active runtime A to B switch without manual action', () => {
+    const view = renderHook(() => useLandingPreflightRuntime())
+    expect(refresh).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      useAppStore.setState({
+        settings: { activeRuntimeEnvironmentId: 'runtime-a' },
+        runtimeStatusByEnvironmentId: new Map([
+          ['runtime-a', { status: { runtimeId: 'a' }, connectionGeneration: 1 }]
+        ])
+      } as never)
+    })
+    act(() => {
+      useAppStore.setState({
+        settings: { activeRuntimeEnvironmentId: 'runtime-b' },
+        runtimeStatusByEnvironmentId: new Map([
+          ['runtime-b', { status: { runtimeId: 'b' }, connectionGeneration: 1 }]
+        ])
+      } as never)
+    })
+
+    expect(refresh).toHaveBeenCalledTimes(3)
+    view.unmount()
   })
 
-  // Why: window.api.preflight.check always probes the local client. The
-  // preflight slice is the only caller that consults getActiveRuntimeTarget and
-  // forwards to `preflight.check` on the active runtime environment, so a
-  // direct IPC call here would silently report the client's git/gh state while
-  // the user is connected to a remote runtime.
-  it('never calls the local preflight IPC directly', () => {
-    const text = source('src/renderer/src/components/Landing.tsx')
+  it('invalidates on disconnect and refreshes exactly once on reconnect', () => {
+    const view = renderHook(() => useLandingPreflightRuntime())
+    act(() => {
+      useAppStore.setState({
+        settings: { activeRuntimeEnvironmentId: 'runtime-a' },
+        runtimeStatusByEnvironmentId: new Map([
+          ['runtime-a', { status: { runtimeId: 'a' }, connectionGeneration: 1 }]
+        ])
+      } as never)
+    })
+    refresh.mockClear()
 
-    expect(text).not.toContain('window.api.preflight')
+    act(() => {
+      useAppStore.setState({
+        runtimeStatusByEnvironmentId: new Map([
+          ['runtime-a', { status: null, connectionGeneration: 2 }]
+        ])
+      } as never)
+    })
+    expect(invalidate).toHaveBeenCalledTimes(1)
+    expect(refresh).not.toHaveBeenCalled()
+
+    act(() => {
+      useAppStore.setState({
+        runtimeStatusByEnvironmentId: new Map([
+          ['runtime-a', { status: { runtimeId: 'a-reconnected' }, connectionGeneration: 3 }]
+        ])
+      } as never)
+    })
+    expect(refresh).toHaveBeenCalledTimes(1)
+    view.unmount()
   })
 
-  it('keeps the preflight slice as the runtime-aware routing point', () => {
-    const text = source('src/renderer/src/store/slices/preflight.ts')
+  it('keeps one active interval and removes listeners and polling on cleanup', () => {
+    useAppStore.setState({ repos: [githubRepo], preflightStatus: status() })
+    const addEventListener = vi.spyOn(document, 'addEventListener')
+    const removeEventListener = vi.spyOn(document, 'removeEventListener')
+    const addWindowListener = vi.spyOn(window, 'addEventListener')
+    const removeWindowListener = vi.spyOn(window, 'removeEventListener')
+    const view = renderHook(() => useLandingPreflightRuntime())
 
-    expect(text).toContain('getActiveRuntimeTarget')
-    expect(text).toContain("'preflight.check'")
+    expect(vi.getTimerCount()).toBe(1)
+    act(() => {
+      useAppStore.setState({ repos: [...useAppStore.getState().repos] })
+    })
+    expect(vi.getTimerCount()).toBe(1)
+    act(() => vi.advanceTimersByTime(30_000))
+    expect(refresh).toHaveBeenCalledWith({ force: true })
+
+    view.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+    expect(removeEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    expect(removeWindowListener).toHaveBeenCalledWith('focus', expect.any(Function))
+    expect(addEventListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    expect(addWindowListener).toHaveBeenCalledWith('focus', expect.any(Function))
+    addEventListener.mockRestore()
+    removeEventListener.mockRestore()
+    addWindowListener.mockRestore()
+    removeWindowListener.mockRestore()
   })
 })

--- a/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
+++ b/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = process.cwd()
+
+function source(path: string): string {
+  return readFileSync(join(root, path), 'utf8')
+}
+
+describe('landing preflight runtime ownership boundary', () => {
+  it('routes the landing preflight banner through the preflight slice', () => {
+    const text = source('src/renderer/src/components/Landing.tsx')
+
+    expect(text).toContain('refreshPreflightStatus')
+    expect(text).toContain('s.preflightStatus')
+  })
+
+  // Why: window.api.preflight.check always probes the local client. The
+  // preflight slice is the only caller that consults getActiveRuntimeTarget and
+  // forwards to `preflight.check` on the active runtime environment, so a
+  // direct IPC call here would silently report the client's git/gh state while
+  // the user is connected to a remote runtime.
+  it('never calls the local preflight IPC directly', () => {
+    const text = source('src/renderer/src/components/Landing.tsx')
+
+    expect(text).not.toContain('window.api.preflight')
+  })
+
+  it('keeps the preflight slice as the runtime-aware routing point', () => {
+    const text = source('src/renderer/src/store/slices/preflight.ts')
+
+    expect(text).toContain('getActiveRuntimeTarget')
+    expect(text).toContain("'preflight.check'")
+  })
+})

--- a/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
+++ b/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
@@ -14,6 +14,9 @@ describe('landing preflight runtime ownership boundary', () => {
 
     expect(text).toContain('refreshPreflightStatus')
     expect(text).toContain('s.preflightStatus')
+    expect(text).toContain('activeRuntimeIdentity')
+    expect(text).toContain('invalidatePreflightStatus')
+    expect(text).toContain('runtimeStatusByEnvironmentId')
   })
 
   // Why: window.api.preflight.check always probes the local client. The

--- a/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
+++ b/src/renderer/src/components/landing-preflight-runtime-boundary.test.ts
@@ -98,6 +98,16 @@ describe('landing preflight runtime boundary', () => {
     view.unmount()
   })
 
+  it('keeps the banner empty while the active remote runtime is still unknown', () => {
+    useAppStore.setState({ settings: { activeRuntimeEnvironmentId: 'runtime-a' } } as never)
+
+    const view = renderHook(() => useLandingPreflightRuntime())
+
+    expect(invalidate).toHaveBeenCalledTimes(1)
+    expect(refresh).not.toHaveBeenCalled()
+    view.unmount()
+  })
+
   it('keeps one active interval and removes listeners and polling on cleanup', () => {
     useAppStore.setState({ repos: [githubRepo], preflightStatus: status() })
     const addEventListener = vi.spyOn(document, 'addEventListener')

--- a/src/renderer/src/components/landing-preflight-runtime.ts
+++ b/src/renderer/src/components/landing-preflight-runtime.ts
@@ -11,10 +11,12 @@ export function useLandingPreflightRuntime(): { preflightIssues: PreflightIssue[
   const preflightStatus = useAppStore((s) => s.preflightStatus)
   const refreshPreflightStatus = useAppStore((s) => s.refreshPreflightStatus)
   const invalidatePreflightStatus = useAppStore((s) => s.invalidatePreflightStatus)
-  const activeRuntimeIdentity = useAppStore((s) => {
-    const environmentId = s.settings?.activeRuntimeEnvironmentId?.trim() ?? 'local'
-    const runtimeStatus =
-      environmentId === 'local' ? undefined : s.runtimeStatusByEnvironmentId.get(environmentId)
+  const activeRuntimeState = useAppStore((s) => {
+    const environmentId = s.settings?.activeRuntimeEnvironmentId?.trim()
+    if (!environmentId) {
+      return 'local'
+    }
+    const runtimeStatus = s.runtimeStatusByEnvironmentId.get(environmentId)
     const reachability = runtimeStatus
       ? runtimeStatus.status === null
         ? 'unreachable'
@@ -35,7 +37,7 @@ export function useLandingPreflightRuntime(): { preflightIssues: PreflightIssue[
   )
 
   useEffect(() => {
-    if (activeRuntimeIdentity.endsWith(':unreachable')) {
+    if (activeRuntimeState !== 'local' && !activeRuntimeState.endsWith(':reachable')) {
       invalidatePreflightStatus()
       return
     }
@@ -52,7 +54,7 @@ export function useLandingPreflightRuntime(): { preflightIssues: PreflightIssue[
       document.removeEventListener('visibilitychange', handleWindowActive)
       window.removeEventListener('focus', handleWindowActive)
     }
-  }, [activeRuntimeIdentity, invalidatePreflightStatus, refreshPreflightStatus])
+  }, [activeRuntimeState, invalidatePreflightStatus, refreshPreflightStatus])
 
   useEffect(() => {
     if (preflightIssues.length === 0) {

--- a/src/renderer/src/components/landing-preflight-runtime.ts
+++ b/src/renderer/src/components/landing-preflight-runtime.ts
@@ -1,0 +1,68 @@
+import { useEffect, useMemo } from 'react'
+import { useAppStore } from '../store'
+import {
+  getLandingPreflightIssues,
+  hasGitHubBackedProject,
+  type PreflightIssue
+} from './landing-preflight-issues'
+
+export function useLandingPreflightRuntime(): { preflightIssues: PreflightIssue[] } {
+  const repos = useAppStore((s) => s.repos)
+  const preflightStatus = useAppStore((s) => s.preflightStatus)
+  const refreshPreflightStatus = useAppStore((s) => s.refreshPreflightStatus)
+  const invalidatePreflightStatus = useAppStore((s) => s.invalidatePreflightStatus)
+  const activeRuntimeIdentity = useAppStore((s) => {
+    const environmentId = s.settings?.activeRuntimeEnvironmentId?.trim() ?? 'local'
+    const runtimeStatus =
+      environmentId === 'local' ? undefined : s.runtimeStatusByEnvironmentId.get(environmentId)
+    const reachability = runtimeStatus
+      ? runtimeStatus.status === null
+        ? 'unreachable'
+        : 'reachable'
+      : 'unknown'
+    return `${environmentId}:${runtimeStatus?.connectionGeneration ?? 0}:${reachability}`
+  })
+
+  const hasGitHubProject = useMemo(() => hasGitHubBackedProject(repos), [repos])
+  const preflightIssues = useMemo(
+    () =>
+      preflightStatus
+        ? getLandingPreflightIssues(preflightStatus, {
+            hasGitHubBackedProject: hasGitHubProject
+          })
+        : [],
+    [preflightStatus, hasGitHubProject]
+  )
+
+  useEffect(() => {
+    if (activeRuntimeIdentity.endsWith(':unreachable')) {
+      invalidatePreflightStatus()
+      return
+    }
+
+    void refreshPreflightStatus()
+    const handleWindowActive = (): void => {
+      if (document.visibilityState === 'visible') {
+        void refreshPreflightStatus({ force: true })
+      }
+    }
+    document.addEventListener('visibilitychange', handleWindowActive)
+    window.addEventListener('focus', handleWindowActive)
+    return () => {
+      document.removeEventListener('visibilitychange', handleWindowActive)
+      window.removeEventListener('focus', handleWindowActive)
+    }
+  }, [activeRuntimeIdentity, invalidatePreflightStatus, refreshPreflightStatus])
+
+  useEffect(() => {
+    if (preflightIssues.length === 0) {
+      return
+    }
+    const intervalId = window.setInterval(() => {
+      void refreshPreflightStatus({ force: true })
+    }, 30000)
+    return () => window.clearInterval(intervalId)
+  }, [preflightIssues.length, refreshPreflightStatus])
+
+  return { preflightIssues }
+}

--- a/src/renderer/src/store/slices/preflight.test.ts
+++ b/src/renderer/src/store/slices/preflight.test.ts
@@ -124,6 +124,22 @@ describe('createPreflightSlice', () => {
     expect(store.getState().preflightStatusLoading).toBe(false)
   })
 
+  it('invalidates an in-flight result when its runtime session ends', async () => {
+    resetPreflightMocks()
+    const stale = deferred<PreflightStatus>()
+    preflightCheck.mockReturnValueOnce(stale.promise)
+    const store = createTestStore()
+
+    const request = store.getState().refreshPreflightStatus()
+    store.getState().invalidatePreflightStatus()
+    stale.resolve(makeStatus(true))
+    await request
+
+    expect(store.getState().preflightStatus).toBeNull()
+    expect(store.getState().preflightStatusChecked).toBe(false)
+    expect(store.getState().preflightStatusContextKey).toBeNull()
+  })
+
   it('lets forced checks bypass non-forced dedupe and win stale races', async () => {
     resetPreflightMocks()
     const stale = deferred<PreflightStatus>()

--- a/src/renderer/src/store/slices/preflight.test.ts
+++ b/src/renderer/src/store/slices/preflight.test.ts
@@ -4,6 +4,7 @@ import type { PreflightStatus } from '../../../../preload/api-types'
 import type { Repo, Worktree } from '../../../../shared/types'
 import type { AppState } from '../types'
 import { createPreflightSlice } from './preflight'
+import { createRuntimeStatusSlice } from './runtime-status'
 
 const preflightCheck = vi.fn()
 const callRuntimeRpc = vi.fn()
@@ -11,6 +12,9 @@ const platformGet = vi.fn(() => ({ platform: 'linux' }))
 
 vi.mock('@/runtime/runtime-rpc-client', () => ({
   callRuntimeRpc: (...args: unknown[]) => callRuntimeRpc(...args),
+  clearRecentRuntimeCompatibilityFailure: vi.fn(),
+  clearRuntimeCompatibilityCache: vi.fn(),
+  unwrapRuntimeRpcResult: <T>(response: { result?: T }) => response.result as T,
   getActiveRuntimeTarget: (
     settings?: { activeRuntimeEnvironmentId?: string | null } | null
   ): { kind: 'local' } | { kind: 'environment'; environmentId: string } => {
@@ -43,7 +47,8 @@ function createTestStore() {
   return create<AppState>()(
     (...a) =>
       ({
-        ...createPreflightSlice(...a)
+        ...createPreflightSlice(...a),
+        ...createRuntimeStatusSlice(...a)
       }) as AppState
   )
 }
@@ -347,6 +352,69 @@ describe('createPreflightSlice', () => {
     secondRuntime.resolve(makeStatus(true))
     await Promise.all([first, second])
     expect(store.getState().preflightStatusContextKey).toBe('runtime:runtime-2#0')
+    expect(store.getState().preflightStatus?.glab?.installed).toBe(true)
+  })
+
+  it('keeps a paired preflight result bound to the active runtime session', async () => {
+    resetPreflightMocks()
+    const runtimeA = deferred<PreflightStatus>()
+    const runtimeB = deferred<PreflightStatus>()
+    const reconnectedB = deferred<PreflightStatus>()
+    callRuntimeRpc
+      .mockReturnValueOnce(runtimeA.promise)
+      .mockReturnValueOnce(runtimeB.promise)
+      .mockReturnValueOnce(reconnectedB.promise)
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'runtime-a' } } as Partial<AppState>)
+    store.getState().setRuntimeEnvironmentStatus('runtime-a', {
+      status: { runtimeId: 'server-a' } as never,
+      checkedAt: 1
+    })
+
+    const requestA = store.getState().refreshPreflightStatus()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'runtime-b' } } as Partial<AppState>)
+    store.getState().setRuntimeEnvironmentStatus('runtime-b', {
+      status: { runtimeId: 'server-b' } as never,
+      checkedAt: 2
+    })
+    const requestB = store.getState().refreshPreflightStatus()
+
+    expect(callRuntimeRpc).toHaveBeenCalledTimes(2)
+    expect(callRuntimeRpc).toHaveBeenNthCalledWith(
+      1,
+      { kind: 'environment', environmentId: 'runtime-a' },
+      'preflight.check',
+      {}
+    )
+    expect(callRuntimeRpc).toHaveBeenNthCalledWith(
+      2,
+      { kind: 'environment', environmentId: 'runtime-b' },
+      'preflight.check',
+      {}
+    )
+
+    runtimeA.resolve(makeStatus(false))
+    await requestA
+    expect(store.getState().preflightStatus).toBeNull()
+    expect(store.getState().preflightStatusChecked).toBe(false)
+
+    runtimeB.resolve(makeStatus(true))
+    await requestB
+    expect(store.getState().preflightStatus?.glab?.installed).toBe(true)
+
+    store.getState().setRuntimeEnvironmentStatus('runtime-b', { status: null, checkedAt: 3 })
+    store.getState().invalidatePreflightStatus()
+    expect(store.getState().preflightStatus).toBeNull()
+    expect(store.getState().preflightStatusChecked).toBe(false)
+
+    store.getState().setRuntimeEnvironmentStatus('runtime-b', {
+      status: { runtimeId: 'server-b-reconnected' } as never,
+      checkedAt: 4
+    })
+    const reconnect = store.getState().refreshPreflightStatus()
+    expect(callRuntimeRpc).toHaveBeenCalledTimes(3)
+    reconnectedB.resolve(makeStatus(true))
+    await reconnect
     expect(store.getState().preflightStatus?.glab?.installed).toBe(true)
   })
 

--- a/src/renderer/src/store/slices/preflight.test.ts
+++ b/src/renderer/src/store/slices/preflight.test.ts
@@ -10,6 +10,10 @@ const preflightCheck = vi.fn()
 const callRuntimeRpc = vi.fn()
 const platformGet = vi.fn(() => ({ platform: 'linux' }))
 
+vi.mock('sonner', () => ({
+  toast: { warning: vi.fn(), dismiss: vi.fn() }
+}))
+
 vi.mock('@/runtime/runtime-rpc-client', () => ({
   callRuntimeRpc: (...args: unknown[]) => callRuntimeRpc(...args),
   clearRecentRuntimeCompatibilityFailure: vi.fn(),

--- a/src/renderer/src/store/slices/preflight.ts
+++ b/src/renderer/src/store/slices/preflight.ts
@@ -16,6 +16,7 @@ export type PreflightSlice = {
   preflightStatusError: string | null
 
   refreshPreflightStatus: (options?: { force?: boolean }) => Promise<void>
+  invalidatePreflightStatus: () => void
 }
 
 let nonForcedPreflightRequest: { key: string; promise: Promise<void> } | null = null
@@ -50,6 +51,19 @@ export const createPreflightSlice: StateCreator<AppState, [], [], PreflightSlice
   preflightStatusContextKey: null,
   preflightStatusLoading: false,
   preflightStatusError: null,
+
+  invalidatePreflightStatus: () => {
+    latestPreflightRequestId += 1
+    nonForcedPreflightRequest = null
+    forcedPreflightRequest = null
+    set({
+      preflightStatus: null,
+      preflightStatusChecked: false,
+      preflightStatusContextKey: null,
+      preflightStatusLoading: false,
+      preflightStatusError: null
+    })
+  },
 
   refreshPreflightStatus: async (options) => {
     const force = options?.force === true

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -13,6 +13,7 @@ import {
   type RuntimeStatusSlice,
   getRuntimeEnvironmentConnectionGeneration
 } from './runtime-status'
+import { getProviderRuntimeContextKey } from '@/lib/provider-runtime-context'
 
 vi.mock('sonner', () => ({
   toast: { warning: vi.fn(), dismiss: vi.fn() }
@@ -376,6 +377,36 @@ describe('runtime-status slice', () => {
       checkedAt: 4
     })
     expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(2)
+  })
+
+  it('invalidates provider state only when the active runtime session changes', () => {
+    const store = createSliceStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-a' } } as never)
+    const initialKey = getProviderRuntimeContextKey({ activeRuntimeEnvironmentId: 'env-a' })
+
+    store.getState().setRuntimeEnvironmentStatus('env-b', {
+      status: makeStatus({ runtimeId: 'runtime-b' }),
+      checkedAt: 1
+    })
+    expect(getProviderRuntimeContextKey({ activeRuntimeEnvironmentId: 'env-a' })).toBe(initialKey)
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: makeStatus({ runtimeId: 'runtime-a' }),
+      checkedAt: 2
+    })
+    const connectedKey = getProviderRuntimeContextKey({ activeRuntimeEnvironmentId: 'env-a' })
+    expect(connectedKey).not.toBe(initialKey)
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', {
+      status: makeStatus({ runtimeId: 'runtime-a' }),
+      checkedAt: 3
+    })
+    expect(getProviderRuntimeContextKey({ activeRuntimeEnvironmentId: 'env-a' })).toBe(connectedKey)
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 4 })
+    expect(getProviderRuntimeContextKey({ activeRuntimeEnvironmentId: 'env-a' })).not.toBe(
+      connectedKey
+    )
   })
 
   it('drops a recent compatibility failure once a status refresh succeeds', async () => {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -10,6 +10,7 @@ import {
 } from '@/runtime/runtime-rpc-client'
 import { replaceRuntimeEnvironmentRevisions } from '@/runtime/runtime-environment-revision'
 import { translate } from '@/i18n/i18n'
+import { bumpProviderRuntimeSessionGeneration } from '@/lib/provider-runtime-context'
 
 /** Live status for one saved runtime environment, as last observed by the
  * renderer. `status === null` records a probe that failed or timed out so the
@@ -257,11 +258,16 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     }
     set((s) => {
       const next = new Map(s.runtimeStatusByEnvironmentId)
+      const sessionEnded = status.status === null && previous?.status != null
       const connectionChanged =
         status.status !== null &&
         (previous?.status == null || previous.status.runtimeId !== status.status.runtimeId)
+      if (sessionEnded) {
+        bumpProviderRuntimeSessionGeneration()
+      }
       if (connectionChanged) {
         advanceRuntimeEnvironmentConnectionGeneration(environmentId)
+        bumpProviderRuntimeSessionGeneration()
       }
       next.set(environmentId, {
         ...status,

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -262,11 +262,11 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       const connectionChanged =
         status.status !== null &&
         (previous?.status == null || previous.status.runtimeId !== status.status.runtimeId)
-      if (sessionEnded) {
-        bumpProviderRuntimeSessionGeneration()
-      }
+      const activeEnvironmentId = s.settings?.activeRuntimeEnvironmentId?.trim()
       if (connectionChanged) {
         advanceRuntimeEnvironmentConnectionGeneration(environmentId)
+      }
+      if (activeEnvironmentId === environmentId && (sessionEnded || connectionChanged)) {
         bumpProviderRuntimeSessionGeneration()
       }
       next.set(environmentId, {

--- a/tests/e2e/landing-preflight-runtime-routing.spec.ts
+++ b/tests/e2e/landing-preflight-runtime-routing.spec.ts
@@ -1,0 +1,189 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { ElectronApplication, Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { createRestartSession } from './helpers/orca-restart'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient,
+  type PairedElectronClient
+} from './helpers/paired-electron-client'
+import { addPairedRuntimeEnvironment } from './helpers/nested-runtime-ssh-client-route'
+
+const missingGitPath = mkdtempSync(path.join(os.tmpdir(), 'orca-preflight-path-'))
+
+test.use({ seedTestRepo: false })
+test.describe.configure({ mode: 'serial' })
+
+test.afterAll(() => {
+  rmSync(missingGitPath, { recursive: true, force: true })
+})
+
+async function setProcessPath(app: ElectronApplication, value: string): Promise<void> {
+  await app.evaluate((_electron, nextPath) => {
+    process.env.PATH = nextPath
+  }, value)
+}
+
+async function directGitPreflight(page: Page): Promise<boolean> {
+  return page.evaluate(
+    async () => (await window.api.preflight.check({ force: true })).git.installed
+  )
+}
+
+async function expectLandingGitState(
+  client: PairedElectronClient,
+  installed: boolean
+): Promise<void> {
+  await expect
+    .poll(
+      () => client.page.evaluate(() => window.__store?.getState().preflightStatus?.git.installed),
+      { timeout: 30_000 }
+    )
+    .toBe(installed)
+  const warning = client.page.getByText('Git is not installed', { exact: true })
+  await (installed ? expect(warning).toBeHidden() : expect(warning).toBeVisible())
+}
+
+async function selectRuntime(client: PairedElectronClient, environmentId: string): Promise<void> {
+  const selected = await client.page.evaluate(async (nextEnvironmentId) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Paired desktop store is unavailable')
+    }
+    return store.getState().setActiveRuntimeEnvironmentPreference(nextEnvironmentId)
+  }, environmentId)
+  expect(selected).toBe(true)
+}
+
+async function runRuntimePreflightJourney(
+  hubAApp: ElectronApplication,
+  hubAPage: Page,
+  testInfo: TestInfo,
+  headed: boolean
+): Promise<void> {
+  test.setTimeout(240_000)
+  const hubBSession = createRestartSession(testInfo)
+  let hubB: Awaited<ReturnType<typeof hubBSession.launch>> | null = null
+  let client: PairedElectronClient | null = null
+  try {
+    await hubAPage.waitForFunction(
+      () => window.__store?.getState().workspaceSessionReady === true,
+      null,
+      { timeout: 30_000 }
+    )
+    hubB = await hubBSession.launch()
+    await hubB.page.waitForFunction(
+      () => window.__store?.getState().workspaceSessionReady === true,
+      null,
+      { timeout: 30_000 }
+    )
+    expect(await directGitPreflight(hubAPage)).toBe(true)
+    expect(await directGitPreflight(hubB.page)).toBe(true)
+
+    const offerA = await createRuntimeDesktopPairingOffer(hubAPage)
+    client = await launchPairedElectronClient(offerA, testInfo, 'Preflight runtime A')
+    await setProcessPath(client.app, missingGitPath)
+    expect(await client.app.evaluate(() => process.env.PATH)).toBe(missingGitPath)
+    if (headed) {
+      await client.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
+      expect(
+        await hubAApp.evaluate(
+          ({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.isVisible() ?? false
+        )
+      ).toBe(true)
+      expect(
+        await hubB.app.evaluate(
+          ({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.isVisible() ?? false
+        )
+      ).toBe(true)
+    }
+    expect(await directGitPreflight(client.page)).toBe(false)
+    await client.page.evaluate(() => window.dispatchEvent(new Event('focus')))
+
+    const environmentA = client.environmentId
+    await expectLandingGitState(client, true)
+    const contextA = await client.page.evaluate(
+      () => window.__store?.getState().preflightStatusContextKey
+    )
+    expect(contextA).toContain(`runtime:${environmentA}#`)
+
+    const offerB = await createRuntimeDesktopPairingOffer(hubB.page)
+    const environmentB = await addPairedRuntimeEnvironment(client, offerB, 'Preflight runtime B')
+    await expectLandingGitState(client, true)
+    expect(
+      await client.page.evaluate(async (selector) => {
+        const response = await window.api.runtimeEnvironments.call({
+          selector,
+          method: 'preflight.check',
+          params: { force: true }
+        })
+        return response.ok && (response.result as { git: { installed: boolean } }).git.installed
+      }, environmentB)
+    ).toBe(true)
+
+    await selectRuntime(client, environmentA)
+    await expectLandingGitState(client, true)
+    const beforeDisconnectContext = await client.page.evaluate(
+      () => window.__store?.getState().preflightStatusContextKey
+    )
+    await client.page.evaluate(async (environmentId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Paired desktop store is unavailable')
+      }
+      await window.api.runtimeEnvironments.disconnect({ selector: environmentId })
+      store.getState().setRuntimeEnvironmentStatus(environmentId, {
+        status: null,
+        checkedAt: Date.now()
+      })
+    }, environmentA)
+    await expect
+      .poll(() => client!.page.evaluate(() => window.__store?.getState().preflightStatus))
+      .toBeNull()
+    await expect(client.page.getByText('Git is not installed', { exact: true })).toBeHidden()
+
+    await client.page.evaluate(async (environmentId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Paired desktop store is unavailable')
+      }
+      const response = await window.api.runtimeEnvironments.connect({
+        selector: environmentId,
+        timeoutMs: 15_000
+      })
+      if (!response.ok) {
+        throw new Error(response.error.message)
+      }
+      store.getState().setRuntimeEnvironmentStatus(environmentId, {
+        status: response.result,
+        checkedAt: Date.now()
+      })
+    }, environmentA)
+    await expectLandingGitState(client, true)
+    const reconnectedContext = await client.page.evaluate(
+      () => window.__store?.getState().preflightStatusContextKey
+    )
+    expect(reconnectedContext).not.toBe(beforeDisconnectContext)
+
+    await selectRuntime(client, environmentB)
+    await expectLandingGitState(client, true)
+  } finally {
+    await client?.dispose()
+    if (hubB) {
+      await hubBSession.close(hubB.app)
+    }
+    await hubBSession.dispose()
+  }
+}
+
+test('routes landing preflight across runtime switch and reconnect', async ({
+  electronApp,
+  orcaPage
+}, testInfo) => runRuntimePreflightJourney(electronApp, orcaPage, testInfo, false))
+
+test('routes landing preflight across runtime switch and reconnect @headful', async ({
+  electronApp,
+  orcaPage
+}, testInfo) => runRuntimePreflightJourney(electronApp, orcaPage, testInfo, true))


### PR DESCRIPTION
### Summary

`Landing.tsx` calls `window.api.preflight.check(...)` directly on mount, on window focus/visibility, and on a 30s poll while a warning is visible. That IPC handler always probes the **local client machine**.

The preflight slice (`store/slices/preflight.ts`) is the only caller that consults `getActiveRuntimeTarget(settings)` and forwards to `preflight.check` on the active runtime environment. Because Landing bypasses it, a user connected to a remote Orca runtime sees a landing banner describing the **client's** git/gh state, not the server's — e.g. "Git is not installed" on a machine that isn't running anything.

This delegates Landing to `refreshPreflightStatus()` and derives the issue list from `state.preflightStatus`.

### Why this instead of the main-process proxy in #6938

This supersedes the preflight half of #6938. In https://github.com/stablyai/orca/pull/6938#issuecomment-5112486785 the ask was to reopen that half as its own PR against `preflight:check` / `detectAgents` / `refreshAgents`. That version was built and tested first — but checking the blast radius raised in that comment showed the main-side proxy is no longer the right fix:

1. **`preflight.check` is already runtime-aware.** `slices/preflight.ts` routes to `callRuntimeRpc` when `runtimeTarget.kind === 'environment'`. Proxying in main would double-handle every caller that already routes correctly, and `Landing` is the only surface still bypassing it. Fixing `Landing` closes the actual gap.
2. **`detectAgents` / `refreshAgents` are also already runtime-aware**, via the `AgentDetectionTarget` union (`local | ssh | runtime`) in `useDetectedAgents` and the `runtime-detected-agents` slice. Proxying them in main is exactly the wide blast radius flagged in that comment: it hijacks legitimately-local callers — `OrchestrationSkillAgentCoverage.tsx` hard-codes `{ kind: 'local' }` — returning the remote host's agents whenever `activeRuntimeEnvironmentId` is set, and feeding the wrong PATH to locally-spawned terminals. That half is dropped entirely rather than reopened.
3. Keeping the routing decision in one place (the slice) also avoids the `activeRuntimeEnvironmentId`-vs-`getSingleFocusedRuntimeEnvironmentId` mismatch raised in review — Landing now inherits whatever predicate the slice uses.

This matches the direction of #6887 for skills: fix it where the routing already lives.

### Behavior notes

- **No change to the error path.** Landing previously only called `setPreflightIssues` on success, so a failed check retained the last banner. The slice's `.catch` likewise leaves `preflightStatus` intact and only sets `preflightStatusError`. This is deliberately *not* the `Landing.tsx` change from #6938 (`333900d4`), which was asked to be split out — that one is not included here.
- **Removes a duplicate probe.** The slice dedupes concurrent and forced checks, so Landing's mount/focus/poll paths now share one in-flight request with the rest of the app instead of issuing their own.

### Testing

- New `landing-preflight-runtime-boundary.test.ts`, following the existing `*-boundary.test.ts` pattern (e.g. `file-explorer-runtime-owner-boundary.test.ts`): asserts Landing routes through the slice and never touches the local preflight IPC directly.
- `preflight.test.ts` already covers the remote path at the slice level (`checks integrations through the active runtime environment`), which Landing now inherits.
- 30/30 pass across the boundary, landing-preflight, and preflight-slice suites; `typecheck:web` clean; oxlint + react-doctor clean.

### Reproduction

Verified against a real remote runtime: Orca `serve` on Ubuntu 22.04 reached from a desktop client over Tailscale. Before this change the landing banner reported the client's git/gh state while an environment was active; after it, the banner reflects the server.
