### PR TITLE
fix(ai-vault): scan large remote transcripts

### DIFF
--- a/src/main/ai-vault/remote-session-scan-concurrency.ts
+++ b/src/main/ai-vault/remote-session-scan-concurrency.ts
@@ -13,10 +13,17 @@ export function limitRemoteScanFilesystemConcurrency(
   maxInFlight: number = REMOTE_SCAN_FILESYSTEM_CONCURRENCY
 ): RemoteSessionFilesystemProvider {
   const gate = createConcurrencyGate(maxInFlight)
+  const downloadFile = provider.downloadFile?.bind(provider)
   return {
     readDir: (dirPath) => gate(() => provider.readDir(dirPath)),
     readFile: (filePath) => gate(() => provider.readFile(filePath)),
-    stat: (filePath) => gate(() => provider.stat(filePath))
+    stat: (filePath) => gate(() => provider.stat(filePath)),
+    ...(downloadFile
+      ? {
+          downloadFile: (sourcePath: string, destinationPath: string) =>
+            gate(() => downloadFile(sourcePath, destinationPath))
+        }
+      : {})
   }
 }
 

--- a/src/main/ai-vault/remote-session-scanner-large-file.test.ts
+++ b/src/main/ai-vault/remote-session-scanner-large-file.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'vitest'
+import { access, truncate, writeFile } from 'node:fs/promises'
+import type { DirEntry } from '../../shared/types'
+import type { FileReadResult, FileStat, IFilesystemProvider } from '../providers/types'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { scanRemoteAiVaultSessions } from './remote-session-scanner'
+import {
+  MAX_REMOTE_SESSION_DOWNLOAD_BYTES,
+  REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES
+} from './remote-session-scanner-large-file'
+
+type RemoteFile = {
+  content: string
+  mtimeMs: number
+  reportedSizeBytes: number
+  downloadedSizeBytes?: number
+}
+
+class LargeRemoteProvider implements IFilesystemProvider {
+  private readonly files = new Map<string, RemoteFile>()
+  readonly readFilePaths: string[] = []
+  readonly downloads: { sourcePath: string; destinationPath: string }[] = []
+  maxConcurrentDownloads = 0
+  private activeDownloads = 0
+
+  addFile(
+    path: string,
+    content: string,
+    mtimeMs: number,
+    reportedSizeBytes = content.length,
+    downloadedSizeBytes?: number
+  ): void {
+    this.files.set(normalize(path), {
+      content,
+      mtimeMs,
+      reportedSizeBytes,
+      downloadedSizeBytes
+    })
+  }
+
+  async readDir(dirPath: string): Promise<DirEntry[]> {
+    const dir = normalize(dirPath)
+    const prefix = `${dir}/`
+    const entries = new Map<string, DirEntry>()
+    for (const path of this.files.keys()) {
+      if (!path.startsWith(prefix)) {
+        continue
+      }
+      const [name, ...rest] = path.slice(prefix.length).split('/')
+      if (name) {
+        entries.set(name, { name, isDirectory: rest.length > 0, isSymlink: false })
+      }
+    }
+    return [...entries.values()].sort((left, right) => left.name.localeCompare(right.name))
+  }
+
+  async readFile(filePath: string): Promise<FileReadResult> {
+    const path = normalize(filePath)
+    this.readFilePaths.push(path)
+    const file = this.files.get(path)
+    if (!file) {
+      throw new Error(`ENOENT: ${filePath}`)
+    }
+    return { content: file.content, isBinary: false }
+  }
+
+  async downloadFile(sourcePath: string, destinationPath: string): Promise<void> {
+    const file = this.files.get(normalize(sourcePath))
+    if (!file) {
+      throw new Error(`ENOENT: ${sourcePath}`)
+    }
+    this.downloads.push({ sourcePath: normalize(sourcePath), destinationPath })
+    this.activeDownloads++
+    this.maxConcurrentDownloads = Math.max(this.maxConcurrentDownloads, this.activeDownloads)
+    try {
+      await new Promise((resolve) => setImmediate(resolve))
+      await writeFile(destinationPath, file.content, { flag: 'wx' })
+      if (file.downloadedSizeBytes !== undefined) {
+        await truncate(destinationPath, file.downloadedSizeBytes)
+      }
+    } finally {
+      this.activeDownloads--
+    }
+  }
+
+  async stat(filePath: string): Promise<FileStat> {
+    const file = this.files.get(normalize(filePath))
+    if (!file) {
+      throw new Error(`ENOENT: ${filePath}`)
+    }
+    return {
+      size: file.reportedSizeBytes,
+      type: 'file',
+      mtime: file.mtimeMs,
+      mtimeMs: file.mtimeMs
+    }
+  }
+
+  writeFile = unsupported
+  writeFileBase64 = unsupported
+  writeFileBase64Chunk = unsupported
+  deletePath = unsupported
+  createFile = unsupported
+  createDir = unsupported
+  createDirNoClobber = unsupported
+  rename = unsupported
+  renameNoClobber = unsupported
+  copy = unsupported
+  realpath = async (path: string): Promise<string> => path
+  search = unsupported
+  listFiles = unsupported
+  watch = unsupported
+}
+
+describe('large remote session scanning', () => {
+  it('downloads and line-parses large transcripts one at a time', async () => {
+    const provider = new LargeRemoteProvider()
+    provider.addFile(
+      '/home/ada/.codex/session_index.jsonl',
+      jsonLines([
+        { id: 'large-a', thread_name: 'Indexed large A' },
+        { id: 'large-b', thread_name: 'Indexed large B' }
+      ]),
+      40
+    )
+    provider.addFile(
+      '/home/ada/.claude/projects/repo/large-claude.jsonl',
+      claudeTranscript(),
+      30,
+      REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES + 1
+    )
+    provider.addFile(
+      '/home/ada/.codex/sessions/large-a.jsonl',
+      codexTranscript('large-a', '2026-07-04T02:00:00.000Z'),
+      20,
+      REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES + 1
+    )
+    provider.addFile(
+      '/home/ada/.codex/sessions/large-b.jsonl',
+      codexTranscript('large-b', '2026-07-04T01:00:00.000Z'),
+      10,
+      REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES + 1
+    )
+
+    const result = await scan(provider)
+
+    expect(result.issues).toEqual([])
+    expect(result.sessions.map((session) => session.sessionId)).toEqual([
+      'large-claude',
+      'large-a',
+      'large-b'
+    ])
+    expect(result.sessions.map((session) => session.title)).toEqual([
+      'Large Claude',
+      'Indexed large A',
+      'Indexed large B'
+    ])
+    expect(provider.downloads.map(({ sourcePath }) => sourcePath)).toEqual([
+      '/home/ada/.claude/projects/repo/large-claude.jsonl',
+      '/home/ada/.codex/sessions/large-a.jsonl',
+      '/home/ada/.codex/sessions/large-b.jsonl'
+    ])
+    expect(provider.maxConcurrentDownloads).toBe(1)
+    expect(
+      provider.readFilePaths.filter(
+        (path) => path.includes('/sessions/') || path.includes('/projects/')
+      )
+    ).toEqual([])
+    for (const { destinationPath } of provider.downloads) {
+      await expect(access(destinationPath)).rejects.toThrow()
+    }
+  })
+
+  it('rejects a transcript above the bounded download limit', async () => {
+    const provider = new LargeRemoteProvider()
+    provider.addFile(
+      '/home/ada/.codex/sessions/oversized.jsonl',
+      codexTranscript('oversized', '2026-07-04T01:00:00.000Z'),
+      10,
+      MAX_REMOTE_SESSION_DOWNLOAD_BYTES + 1
+    )
+
+    const result = await scan(provider)
+
+    expect(result.sessions).toEqual([])
+    expect(result.issues[0]?.message).toContain('exceeds 256MB limit')
+    expect(provider.downloads).toEqual([])
+  })
+
+  it('removes a downloaded transcript that grew beyond the bounded limit', async () => {
+    const provider = new LargeRemoteProvider()
+    provider.addFile(
+      '/home/ada/.codex/sessions/grown.jsonl',
+      codexTranscript('grown', '2026-07-04T01:00:00.000Z'),
+      10,
+      REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES + 1,
+      MAX_REMOTE_SESSION_DOWNLOAD_BYTES + 1
+    )
+
+    const result = await scan(provider)
+
+    expect(result.sessions).toEqual([])
+    expect(result.issues[0]?.message).toContain('exceeds 256MB limit')
+    expect(provider.downloads).toHaveLength(1)
+    await expect(access(provider.downloads[0].destinationPath)).rejects.toThrow()
+  })
+})
+
+function scan(provider: IFilesystemProvider) {
+  return scanRemoteAiVaultSessions({
+    provider,
+    executionHostId: 'ssh:dev-box',
+    remoteHome: '/home/ada',
+    hostPlatform: getRemoteHostPlatform('linux-x64')
+  })
+}
+
+function codexTranscript(sessionId: string, timestamp: string): string {
+  return jsonLines([
+    {
+      timestamp,
+      type: 'session_meta',
+      payload: { id: sessionId, cwd: '/home/ada/repo' }
+    },
+    {
+      timestamp,
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'text', text: `Prompt ${sessionId}` }]
+      }
+    }
+  ])
+}
+
+function claudeTranscript(): string {
+  return jsonLines([
+    {
+      sessionId: 'large-claude',
+      timestamp: '2026-07-04T03:00:00.000Z',
+      type: 'user',
+      message: { content: [{ type: 'text', text: 'Large Claude' }] }
+    },
+    {
+      sessionId: 'large-claude',
+      timestamp: '2026-07-04T03:00:01.000Z',
+      type: 'assistant',
+      message: { model: 'claude-opus-4', content: 'Done' }
+    }
+  ])
+}
+
+function jsonLines(records: unknown[]): string {
+  return records.map((record) => JSON.stringify(record)).join('\n')
+}
+
+function normalize(path: string): string {
+  return path.replace(/\\/g, '/').replace(/\/+$/, '')
+}
+
+async function unsupported(): Promise<never> {
+  throw new Error('unsupported')
+}

--- a/src/main/ai-vault/remote-session-scanner-large-file.test.ts
+++ b/src/main/ai-vault/remote-session-scanner-large-file.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from 'vitest'
-import { access, truncate, writeFile } from 'node:fs/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as FsPromises from 'node:fs/promises'
+
+// Why: the oversized cases only need `stat` to *report* a size past the limit. Materializing a
+// real 256MB file leans on sparse-extension behavior that differs between POSIX and NTFS, so CI
+// cost would vary by platform. Mirrors node-bounded-file-reader.test.ts, which fakes the reported
+// size for the same reason.
+const { statSizeOverrides } = vi.hoisted(() => ({ statSizeOverrides: new Map<string, number>() }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromises>()
+  return {
+    ...actual,
+    stat: async (path: Parameters<typeof actual.stat>[0]) => {
+      const stats = await actual.stat(path)
+      const override = statSizeOverrides.get(String(path))
+      return override === undefined ? stats : Object.assign(stats, { size: override })
+    }
+  }
+})
+
+import { access, writeFile } from 'node:fs/promises'
 import type { DirEntry } from '../../shared/types'
 import type { FileReadResult, FileStat, IFilesystemProvider } from '../providers/types'
 import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
@@ -76,7 +96,7 @@ class LargeRemoteProvider implements IFilesystemProvider {
       await new Promise((resolve) => setImmediate(resolve))
       await writeFile(destinationPath, file.content, { flag: 'wx' })
       if (file.downloadedSizeBytes !== undefined) {
-        await truncate(destinationPath, file.downloadedSizeBytes)
+        statSizeOverrides.set(destinationPath, file.downloadedSizeBytes)
       }
     } finally {
       this.activeDownloads--
@@ -112,7 +132,11 @@ class LargeRemoteProvider implements IFilesystemProvider {
   watch = unsupported
 }
 
+const OVERSIZE_MESSAGE = `exceeds ${(MAX_REMOTE_SESSION_DOWNLOAD_BYTES / 1024 / 1024).toFixed(1)}MB limit`
+
 describe('large remote session scanning', () => {
+  beforeEach(() => statSizeOverrides.clear())
+
   it('downloads and line-parses large transcripts one at a time', async () => {
     const provider = new LargeRemoteProvider()
     provider.addFile(
@@ -183,7 +207,7 @@ describe('large remote session scanning', () => {
     const result = await scan(provider)
 
     expect(result.sessions).toEqual([])
-    expect(result.issues[0]?.message).toContain('exceeds 256MB limit')
+    expect(result.issues[0]?.message).toContain(OVERSIZE_MESSAGE)
     expect(provider.downloads).toEqual([])
   })
 
@@ -200,7 +224,7 @@ describe('large remote session scanning', () => {
     const result = await scan(provider)
 
     expect(result.sessions).toEqual([])
-    expect(result.issues[0]?.message).toContain('exceeds 256MB limit')
+    expect(result.issues[0]?.message).toContain(OVERSIZE_MESSAGE)
     expect(provider.downloads).toHaveLength(1)
     await expect(access(provider.downloads[0].destinationPath)).rejects.toThrow()
   })

--- a/src/main/ai-vault/remote-session-scanner-large-file.ts
+++ b/src/main/ai-vault/remote-session-scanner-large-file.ts
@@ -65,10 +65,14 @@ export async function tryParseLargeRemoteSession(
   }
 }
 
+function toMegabytes(bytes: number): string {
+  return (bytes / 1024 / 1024).toFixed(1)
+}
+
 function assertRemoteSessionDownloadSize(sizeBytes: number): void {
   if (sizeBytes > MAX_REMOTE_SESSION_DOWNLOAD_BYTES) {
     throw new Error(
-      `Remote session transcript is too large to scan safely: ${(sizeBytes / 1024 / 1024).toFixed(1)}MB exceeds 256MB limit`
+      `Remote session transcript is too large to scan safely: ${toMegabytes(sizeBytes)}MB exceeds ${toMegabytes(MAX_REMOTE_SESSION_DOWNLOAD_BYTES)}MB limit`
     )
   }
 }

--- a/src/main/ai-vault/remote-session-scanner-large-file.ts
+++ b/src/main/ai-vault/remote-session-scanner-large-file.ts
@@ -1,0 +1,74 @@
+import { createReadStream } from 'node:fs'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createInterface } from 'node:readline'
+import type { AiVaultSession } from '../../shared/ai-vault-types'
+import { throwIfAiVaultScanCancelled } from './ai-vault-scan-cancellation'
+import type { RemoteScannerContext, RemoteSessionCandidate } from './remote-session-scanner-types'
+
+export const REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES = 10 * 1024 * 1024
+export const MAX_REMOTE_SESSION_DOWNLOAD_BYTES = 256 * 1024 * 1024
+
+type RemoteLargeSessionParseResult =
+  | { handled: false }
+  | { handled: true; session: AiVaultSession | null }
+
+export async function tryParseLargeRemoteSession(
+  candidate: RemoteSessionCandidate,
+  context: RemoteScannerContext
+): Promise<RemoteLargeSessionParseResult> {
+  const sizeBytes = candidate.file.sizeBytes
+  if (
+    sizeBytes === undefined ||
+    sizeBytes <= REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES ||
+    !context.provider.downloadFile ||
+    !candidate.source.createParseState
+  ) {
+    return { handled: false }
+  }
+
+  throwIfAiVaultScanCancelled(context.signal)
+  const state = candidate.source.createParseState(candidate.file, context)
+  if (!state) {
+    return { handled: false }
+  }
+  assertRemoteSessionDownloadSize(sizeBytes)
+
+  const tempDir = await mkdtemp(join(tmpdir(), 'orca-remote-session-'))
+  const tempPath = join(tempDir, 'transcript.jsonl')
+  try {
+    throwIfAiVaultScanCancelled(context.signal)
+    await context.provider.downloadFile(candidate.file.path, tempPath)
+    throwIfAiVaultScanCancelled(context.signal)
+    assertRemoteSessionDownloadSize((await stat(tempPath)).size)
+    const input = createReadStream(tempPath, { encoding: 'utf-8' })
+    const lines = createInterface({ input, crlfDelay: Infinity })
+    try {
+      for await (const line of lines) {
+        throwIfAiVaultScanCancelled(context.signal)
+        state.consumeLine(line)
+      }
+    } finally {
+      lines.close()
+      input.destroy()
+    }
+    throwIfAiVaultScanCancelled(context.signal)
+    const session = await state.finalize(context.hostPlatform.os, {
+      executionHostId: context.executionHostId,
+      executionHostPlatform: context.hostPlatform.os
+    })
+    throwIfAiVaultScanCancelled(context.signal)
+    return { handled: true, session }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+}
+
+function assertRemoteSessionDownloadSize(sizeBytes: number): void {
+  if (sizeBytes > MAX_REMOTE_SESSION_DOWNLOAD_BYTES) {
+    throw new Error(
+      `Remote session transcript is too large to scan safely: ${(sizeBytes / 1024 / 1024).toFixed(1)}MB exceeds 256MB limit`
+    )
+  }
+}

--- a/src/main/ai-vault/remote-session-scanner-sources.ts
+++ b/src/main/ai-vault/remote-session-scanner-sources.ts
@@ -3,7 +3,10 @@ import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import { joinRemotePath } from '../ssh/ssh-remote-platform'
 import { parseAntigravitySessionContent } from './session-scanner-antigravity-parser'
 import { isAntigravityTranscriptPath } from './session-scanner-antigravity-paths'
-import { parseCodexSessionContent } from './session-scanner-codex-parser'
+import {
+  createCodexSessionResumeState,
+  parseCodexSessionContent
+} from './session-scanner-codex-parser'
 import { parseDevinSessionContent } from './session-scanner-devin-parser'
 import { parseDroidSessionContent } from './session-scanner-droid-parser'
 import { parseMessageGraphSessionContent } from './session-scanner-graph-parsers'
@@ -13,6 +16,7 @@ import { parseCopilotSessionContent } from './session-scanner-copilot-parser'
 import { parseCursorSessionContent } from './session-scanner-cursor-parser'
 import { parseHermesSessionContent } from './session-scanner-hermes-parser'
 import type { FileWithMtime } from './session-scanner-types'
+import { resumableStateFactoryFor } from './session-scanner-parse-cache'
 import { normalizeAgentSessionsDir } from './session-scanner-values'
 import { remoteCodexIndexTitles } from './remote-session-scanner-codex-index'
 import type {
@@ -152,6 +156,8 @@ function source(
     extensions,
     filePredicate,
     directoryPredicate,
+    createParseState: (file) =>
+      resumableStateFactoryFor({ agent, file, codexHome: null })?.() ?? null,
     parse: (file, content, context) =>
       Promise.resolve(
         parseContent(file, content, context.hostPlatform.os, parserOptions(context), context.signal)
@@ -190,6 +196,10 @@ function remoteCodexSources(
     rootDir: joinRemotePath(hostPlatform, codexHome, 'sessions'),
     codexHome,
     extensions: ['.jsonl'],
+    createParseState: (file, context) =>
+      createCodexSessionResumeState(file, codexHome, (sessionId) =>
+        readRemoteCodexTitle(context, codexHome, hostPlatform, sessionId)
+      ),
     parse: (file, content, context) =>
       parseCodexSessionContent({
         file,
@@ -199,18 +209,26 @@ function remoteCodexSources(
         executionHostId: context.executionHostId,
         executionHostPlatform: context.hostPlatform.os,
         signal: context.signal,
-        readIndexedTitle: async (sessionId) =>
-          (
-            await remoteCodexIndexTitles({
-              provider: context.provider,
-              codexHome,
-              hostPlatform,
-              titleCaches: context.titleCaches,
-              signal: context.signal
-            })
-          ).get(sessionId) ?? null
+        readIndexedTitle: (sessionId) =>
+          readRemoteCodexTitle(context, codexHome, hostPlatform, sessionId)
       })
   }))
+}
+
+async function readRemoteCodexTitle(
+  context: RemoteScannerContext,
+  codexHome: string,
+  hostPlatform: RemoteHostPlatform,
+  sessionId: string
+): Promise<string | null> {
+  const titles = await remoteCodexIndexTitles({
+    provider: context.provider,
+    codexHome,
+    hostPlatform,
+    titleCaches: context.titleCaches,
+    signal: context.signal
+  })
+  return titles.get(sessionId) ?? null
 }
 
 function remoteOpenClawSources(

--- a/src/main/ai-vault/remote-session-scanner-types.ts
+++ b/src/main/ai-vault/remote-session-scanner-types.ts
@@ -2,7 +2,7 @@ import type { AiVaultAgent, AiVaultSession } from '../../shared/ai-vault-types'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { IFilesystemProvider } from '../providers/types'
 import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
-import type { FileWithMtime } from './session-scanner-types'
+import type { FileWithMtime, ResumableSessionParseState } from './session-scanner-types'
 import type { AntigravityWorkspaceResolver } from './session-scanner-antigravity-history'
 
 export type RemoteScannerContext = {
@@ -16,7 +16,7 @@ export type RemoteScannerContext = {
 
 export type RemoteSessionFilesystemProvider = Pick<
   IFilesystemProvider,
-  'readDir' | 'readFile' | 'stat'
+  'downloadFile' | 'readDir' | 'readFile' | 'stat'
 >
 
 export type RemoteParserOptions = {
@@ -39,6 +39,12 @@ export type RemoteSessionSource = {
   // Claude layout: count `<session>/subagents/*.jsonl` siblings from the walked
   // listing and drop them from candidates instead of indexing them as sessions.
   collectSubagentSiblingCounts?: boolean
+  // Line-oriented JSONL sources can parse a downloaded large transcript
+  // without materializing the whole file as one string.
+  createParseState?: (
+    file: FileWithMtime,
+    context: RemoteScannerContext
+  ) => ResumableSessionParseState | null
   parse: (
     file: FileWithMtime,
     content: string,

--- a/src/main/ai-vault/remote-session-scanner.ts
+++ b/src/main/ai-vault/remote-session-scanner.ts
@@ -13,6 +13,10 @@ import {
   dedupeCodexSessionsBySessionId
 } from './codex-session-root-dedup'
 import { discoverRemoteSourceCandidates } from './remote-session-scanner-discovery'
+import {
+  REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES,
+  tryParseLargeRemoteSession
+} from './remote-session-scanner-large-file'
 import { remoteSessionSources } from './remote-session-scanner-sources'
 import type {
   RemoteScannerContext,
@@ -150,9 +154,7 @@ async function parseRemoteSessionCandidates(args: {
       parsedFilePaths.add(candidate.file.path)
     }
     throwIfAiVaultScanCancelled(args.context.signal)
-    const results = await Promise.all(
-      batch.map((candidate) => parseRemoteSessionCandidate(candidate, args.context, args.issues))
-    )
+    const results = await parseRemoteSessionCandidateBatch(batch, args.context, args.issues)
     sessions.push(...results.filter(isAiVaultSession))
     const uniqueSessions = dedupeCodexSessionsBySessionId(sessions)
     sessions.splice(0, sessions.length, ...uniqueSessions)
@@ -189,11 +191,10 @@ async function scanRemoteInScopeSessions(args: {
   // sessions; out-of-scope candidates no longer end the search.
   while (index < bound && sessions.length < args.limit) {
     const batchEnd = Math.min(index + REMOTE_SCAN_CONCURRENCY, bound)
-    const results = await mapRemoteScanBatches(
+    const results = await parseRemoteSessionCandidateBatch(
       candidates.slice(index, batchEnd),
-      REMOTE_SCAN_CONCURRENCY,
-      (candidate) => parseRemoteSessionCandidate(candidate, args.context, args.issues),
-      args.context.signal
+      args.context,
+      args.issues
     )
     sessions.push(
       ...results.filter(
@@ -224,12 +225,18 @@ async function parseRemoteSessionCandidate(
 ): Promise<AiVaultSession | null> {
   try {
     throwIfAiVaultScanCancelled(context.signal)
-    const read = await context.provider.readFile(candidate.file.path)
-    throwIfAiVaultScanCancelled(context.signal)
-    if (read.isBinary) {
-      return null
+    const largeResult = await tryParseLargeRemoteSession(candidate, context)
+    let session: AiVaultSession | null
+    if (largeResult.handled) {
+      session = largeResult.session
+    } else {
+      const read = await context.provider.readFile(candidate.file.path)
+      throwIfAiVaultScanCancelled(context.signal)
+      if (read.isBinary) {
+        return null
+      }
+      session = await candidate.source.parse(candidate.file, read.content, context)
     }
-    const session = await candidate.source.parse(candidate.file, read.content, context)
     throwIfAiVaultScanCancelled(context.signal)
     // Mirror the local rule: every session carries its sibling subagent
     // transcript count (row badge; recoverable signal at zero turns). The
@@ -249,6 +256,32 @@ async function parseRemoteSessionCandidate(
     })
     return null
   }
+}
+
+async function parseRemoteSessionCandidateBatch(
+  candidates: readonly RemoteSessionCandidate[],
+  context: RemoteScannerContext,
+  issues: AiVaultScanIssue[]
+): Promise<(AiVaultSession | null)[]> {
+  const regular = candidates.filter(
+    (candidate) =>
+      candidate.file.sizeBytes === undefined ||
+      candidate.file.sizeBytes <= REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES
+  )
+  const large = candidates.filter(
+    (candidate) =>
+      candidate.file.sizeBytes !== undefined &&
+      candidate.file.sizeBytes > REMOTE_SESSION_IN_MEMORY_LIMIT_BYTES
+  )
+  throwIfAiVaultScanCancelled(context.signal)
+  const results = await Promise.all(
+    regular.map((candidate) => parseRemoteSessionCandidate(candidate, context, issues))
+  )
+  for (const candidate of large) {
+    throwIfAiVaultScanCancelled(context.signal)
+    results.push(await parseRemoteSessionCandidate(candidate, context, issues))
+  }
+  return results
 }
 
 function mergeRemoteSessions(

--- a/src/main/ai-vault/session-scanner-codex-parser.ts
+++ b/src/main/ai-vault/session-scanner-codex-parser.ts
@@ -262,11 +262,11 @@ async function finalizeCodexParseState(
 
 export function createCodexSessionResumeState(
   file: FileWithMtime,
-  codexHome: string | null
-): ResumableSessionParseState {
-  return codexResumeStateFromParseState(createCodexParseState(file), codexHome, (sessionId) =>
+  codexHome: string | null,
+  titleReader: (sessionId: string) => Promise<string | null> = (sessionId) =>
     readCodexSessionIndexTitle(file.path, codexHome, sessionId)
-  )
+): ResumableSessionParseState {
+  return codexResumeStateFromParseState(createCodexParseState(file), codexHome, titleReader)
 }
 
 function codexResumeStateFromParseState(

--- a/src/main/ai-vault/session-scanner-parse-cache.ts
+++ b/src/main/ai-vault/session-scanner-parse-cache.ts
@@ -42,7 +42,7 @@ type SessionParseCacheEntry = {
 // unchanged-file reuse only and re-parse whole when they change.
 // Returns a factory (not a state) so steady-state resumes, which clone the
 // cached state instead, never pay for a throwaway accumulator.
-function resumableStateFactoryFor(
+export function resumableStateFactoryFor(
   candidate: SessionFileCandidate
 ): (() => ResumableSessionParseState) | null {
   switch (candidate.agent) {


### PR DESCRIPTION
## Summary

- Keep the generic SSH text-file read limit at 10 MiB.
- For larger line-oriented AI Vault transcripts, reuse the existing SSH file-transfer path to download into a private temporary directory and parse line by line with the existing resumable parser state.
- Serialize large transcript downloads, cap them at 256 MiB, verify size both before and after transfer, and remove temporary data in a `finally` block.

Fixes #11396.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 3,797 files / 40,143 tests passed. The same 8 Codex runtime-home/trust rollback failures reproduce on clean upstream. One unrelated native-chat watcher test timed out in the full parallel run and passed 7/7 when rerun alone.
- [x] `pnpm build`; final TypeScript state also rechecked with `pnpm run build:desktop`
- [x] Focused remote scanner/parse-cache/Codex parser coverage: 4 files, 29 tests passed.
- [x] Changed-code quality gate: 0 new findings.
- [x] Added regression coverage for Codex and Claude transcripts reported above 10 MiB, serialized downloads, remote Codex index titles, temporary-file cleanup, the 256 MiB pre-transfer bound, and post-transfer growth.

## AI Review Report

Reviewed the change for parser equivalence, remote/local path ownership, transfer lifecycle, concurrency, cleanup, and cross-platform behavior.

The large-file path reuses the same resumable line-fold states as local scanning instead of creating a second parser. Codex keeps its remote `session_index.jsonl` title lookup. Files at or below 10 MiB retain the existing concurrent `readFile` path; larger eligible files are transferred and parsed one at a time. The generic relay/client 10 MiB limit, local scanning, WSL-local scanning, and renderer/IPC contracts are unchanged.

Cross-platform behavior was checked for macOS, Linux, and Windows. Temporary paths use Node's local `tmpdir`/`path.join`, while remote path and transport differences remain owned by the existing SSH filesystem provider (SFTP or system SSH/PowerShell). No shortcuts, labels, shell construction, or Electron platform branches were added.

No additional issue was found by the changed-code review.

## Security Audit

The scan creates a unique private temporary directory, downloads only a discovered session candidate, validates the advertised size before transfer, validates the actual local size after transfer, and removes the directory on success or failure. Large transfers are serialized and bounded at 256 MiB. Remote paths still go through the existing provider's escaped SFTP/system-SSH implementation.

No new command execution, auth handling, secrets, dependencies, IPC methods, or renderer input were added. The ordinary remote file-preview safety limit remains unchanged.

## Notes

A sanitized local Codex corpus used to validate the report currently contains 371 JSONL transcripts: 79 exceed 10 MiB, 27 of the latest 50 exceed 10 MiB, and the largest is about 129.7 MiB.

This patch targets line-oriented formats that already have resumable parser states (including Codex, Claude, Cursor, Copilot, Droid, Gemini JSONL, Pi, OMP, and OpenClaw). Whole-document formats continue to use the existing bounded read path.

This is independent from #11394/#11395 (OpenClaw directory pruning) and #11362/#11364 (stream lifecycle stalls).