### PR TITLE
Add editable Mermaid diagram views

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -714,8 +714,81 @@
    in diagram mode. Centers the rendered SVG and adds padding so diagrams
    don't press against viewport edges. */
 .mermaid-viewer {
-  background: var(--color-background, transparent);
+  display: flex;
+  flex-direction: column;
+  background: var(--background);
 }
+.mermaid-text-diagram-toolbar {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 40px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground));
+}
+
+.mermaid-text-diagram-title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mermaid-text-diagram-body {
+  display: grid;
+  flex: 1;
+  min-height: 0;
+  background: var(--editor-surface);
+}
+
+.mermaid-text-diagram-body.is-split {
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+}
+
+.mermaid-text-diagram-source {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  overflow: auto;
+  padding: 16px 18px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.mermaid-text-diagram-source-editor {
+  resize: none;
+  outline: none;
+  tab-size: 2;
+}
+
+.mermaid-text-diagram-source-editor:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--ring);
+}
+
+.mermaid-text-diagram-body.is-split .mermaid-text-diagram-source {
+  border-right: 1px solid var(--border);
+}
+
+.mermaid-text-diagram-chart {
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
+}
+
 .mermaid-viewer-canvas {
   display: flex;
   align-items: flex-start;
@@ -729,6 +802,119 @@
 .mermaid-viewer-canvas .mermaid-block svg {
   width: 100%;
   height: auto;
+}
+
+.zoomable-diagram-surface {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--editor-surface);
+}
+
+.zoomable-diagram-surface-viewport {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  background: color-mix(in srgb, var(--editor-surface) 96%, var(--foreground));
+  cursor: grab;
+  outline: none;
+  overscroll-behavior: contain;
+  touch-action: none;
+}
+
+.zoomable-diagram-surface-viewport:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--ring);
+}
+
+.zoomable-diagram-surface-viewport.is-pan-ready,
+.zoomable-diagram-surface-viewport.is-panning {
+  cursor: grabbing;
+}
+
+.zoomable-diagram-surface-viewport.is-panning {
+  user-select: none;
+}
+
+.zoomable-diagram-surface-stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 100%;
+  min-height: 100%;
+  padding: 24px;
+}
+
+.zoomable-diagram-surface-content {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.zoomable-diagram-surface-content.is-sized .mermaid-block {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.zoomable-diagram-surface-content.is-sized .mermaid-block svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+}
+
+.zoomable-diagram-surface-toolbar {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 34px;
+  padding: 5px 8px;
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 94%, var(--foreground));
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.zoomable-diagram-surface-controls {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 2px;
+}
+
+.zoomable-diagram-surface-zoom {
+  min-width: 38px;
+  margin-left: 2px;
+}
+
+.zoomable-diagram-surface-label {
+  min-width: 0;
+  overflow: hidden;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+  .mermaid-text-diagram-body.is-split {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(160px, 0.9fr) minmax(220px, 1.1fr);
+  }
+
+  .mermaid-text-diagram-body.is-split .mermaid-text-diagram-source {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
 }
 
 .markdown-body ul,

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -805,6 +805,8 @@
 }
 
 .zoomable-diagram-surface {
+  --diagram-surface-padding: 24px; /* Why: fit math uses DIAGRAM_SURFACE_PADDING. */
+
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -845,7 +847,7 @@
   justify-content: center;
   min-width: 100%;
   min-height: 100%;
-  padding: 24px;
+  padding: var(--diagram-surface-padding);
 }
 
 .zoomable-diagram-surface-content {

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -993,6 +993,68 @@
   color: var(--foreground);
 }
 
+.rich-markdown-mermaid-code-block {
+  container-type: inline-size;
+  overflow: hidden;
+}
+
+.rich-markdown-mermaid-view-toggle {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 2;
+  background: color-mix(in srgb, var(--background) 86%, transparent);
+}
+
+.rich-markdown-mermaid-view-toggle [data-slot='toggle-group-item'] {
+  height: 22px;
+  padding-inline: 8px;
+  font-size: 11px;
+}
+
+.rich-markdown-mermaid-layout > pre {
+  min-width: 0;
+  padding-top: 42px;
+}
+
+.rich-markdown-code-block-source-hidden {
+  display: none;
+}
+
+.rich-markdown-mermaid-layout.is-chart .mermaid-preview {
+  min-height: 260px;
+  padding: 42px 12px 12px;
+  border-top: none;
+}
+
+.rich-markdown-mermaid-layout.is-split .mermaid-preview {
+  min-height: 240px;
+  padding: 42px 12px 12px;
+}
+
+.rich-markdown-mermaid-layout.is-chart .zoomable-diagram-surface,
+.rich-markdown-mermaid-layout.is-split .zoomable-diagram-surface {
+  min-height: 220px;
+}
+
+@container (min-width: 760px) {
+  .rich-markdown-mermaid-layout.is-split {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .rich-markdown-mermaid-layout.is-split > pre {
+    margin: 0;
+    border-right: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
+    border-radius: 0;
+  }
+
+  .rich-markdown-mermaid-layout.is-split .mermaid-preview {
+    min-width: 0;
+    border-top: none;
+  }
+}
+
 /* Live mermaid diagram preview rendered below the editable source */
 .mermaid-preview {
   padding: 12px 18px;

--- a/src/renderer/src/components/editor/EditorEditFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorEditFileSurface.tsx
@@ -225,7 +225,14 @@ export function EditorEditFileSurface({
       monacoEditor={monacoEditor}
     />
   ) : isMermaid && mdViewMode === 'rich' ? (
-    <MermaidViewer key={activeFile.id} content={currentContent} filePath={activeFile.filePath} />
+    <MermaidViewer
+      key={activeFile.id}
+      content={currentContent}
+      filePath={activeFile.filePath}
+      readOnly={activeFile.readOnly === true}
+      onContentChange={activeFile.readOnly === true ? undefined : handleContentChange}
+      onSave={activeFile.readOnly === true ? undefined : handleSave}
+    />
   ) : isCsv && mdViewMode === 'rich' ? (
     <CsvViewer key={activeFile.id} content={currentContent} filePath={activeFile.filePath} />
   ) : isNotebook && mdViewMode === 'rich' ? (

--- a/src/renderer/src/components/editor/MermaidViewer.test.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.test.tsx
@@ -113,7 +113,7 @@ describe('MermaidViewer', () => {
 
     rerender(
       <MermaidViewer
-        content={'flowchart TD\n  A --> Echo'}
+        content={'flowchart TD\n  A --> Draft'}
         filePath="/repo/demo.mmd"
         onContentChange={vi.fn()}
       />
@@ -121,6 +121,30 @@ describe('MermaidViewer', () => {
 
     expect((screen.getByLabelText('Mermaid source') as HTMLTextAreaElement).value).toBe(
       'flowchart TD\n  A --> Draft'
+    )
+  })
+
+  it('accepts external content updates for the same file (reload, external edit)', () => {
+    const { rerender } = render(
+      <MermaidViewer
+        content={'flowchart TD\n  A --> B'}
+        filePath="/repo/demo.mmd"
+        onContentChange={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Split' }))
+
+    rerender(
+      <MermaidViewer
+        content={'flowchart TD\n  A --> Reloaded'}
+        filePath="/repo/demo.mmd"
+        onContentChange={vi.fn()}
+      />
+    )
+
+    expect((screen.getByLabelText('Mermaid source') as HTMLTextAreaElement).value).toBe(
+      'flowchart TD\n  A --> Reloaded'
     )
   })
 

--- a/src/renderer/src/components/editor/MermaidViewer.test.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/store', () => {
+  const mockState = { keybindings: {}, settings: { theme: 'light' } }
+  const useAppStore = Object.assign(
+    (selector: (state: typeof mockState) => unknown) => selector(mockState),
+    { getState: () => mockState }
+  )
+  return { useAppStore }
+})
+
+vi.mock('./MermaidBlock', () => ({
+  default: ({ content }: { content: string }) => <div data-testid="mermaid-block">{content}</div>
+}))
+
+vi.mock('./ZoomableDiagramSurface', () => ({
+  default: ({ children, diagramKey }: { children: ReactNode; diagramKey: string }) => (
+    <div data-diagram-key={diagramKey} data-testid="diagram-surface">
+      {children}
+    </div>
+  )
+}))
+
+import MermaidViewer from './MermaidViewer'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MermaidViewer', () => {
+  it('edits source in split mode and rerenders the diagram from the draft', () => {
+    const onContentChange = vi.fn()
+
+    render(
+      <MermaidViewer
+        content={'flowchart TD\n  A --> B'}
+        filePath="/repo/demo.mmd"
+        onContentChange={onContentChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Split' }))
+    fireEvent.change(screen.getByLabelText('Mermaid source'), {
+      target: { value: 'flowchart TD\n  A --> C' }
+    })
+
+    expect(onContentChange).toHaveBeenLastCalledWith('flowchart TD\n  A --> C')
+    expect(screen.getByTestId('diagram-surface').getAttribute('data-diagram-key')).toBe(
+      'flowchart TD\n  A --> C'
+    )
+    expect(screen.getByTestId('mermaid-block').textContent).toContain('A --> C')
+  })
+
+  it('keeps code mode editable without rendering the diagram panel', () => {
+    render(
+      <MermaidViewer
+        content={'flowchart TD\n  A --> B'}
+        filePath="/repo/demo.mmd"
+        onContentChange={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Code' }))
+
+    expect((screen.getByLabelText('Mermaid source') as HTMLTextAreaElement).readOnly).toBe(false)
+    expect(screen.queryByTestId('diagram-surface')).toBeNull()
+  })
+
+  it('keeps a new empty diagram editable after the first input', () => {
+    render(<MermaidViewer content="" filePath="/repo/new.mmd" onContentChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Mermaid source'), {
+      target: { value: 'flowchart LR\n  Start --> Done' }
+    })
+
+    expect(screen.getByRole('radio', { name: 'Split' }).getAttribute('aria-checked')).toBe('true')
+    expect((screen.getByLabelText('Mermaid source') as HTMLTextAreaElement).value).toBe(
+      'flowchart LR\n  Start --> Done'
+    )
+    expect(screen.getByTestId('diagram-surface').getAttribute('data-diagram-key')).toBe(
+      'flowchart LR\n  Start --> Done'
+    )
+  })
+})

--- a/src/renderer/src/components/editor/MermaidViewer.test.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.test.tsx
@@ -145,4 +145,33 @@ describe('MermaidViewer', () => {
     expect(source.readOnly).toBe(true)
     expect(onSave).not.toHaveBeenCalled()
   })
+
+  it('flushes the diagram immediately when switching to a different file', () => {
+    vi.useFakeTimers()
+
+    const { rerender } = render(
+      <MermaidViewer
+        content={'flowchart TD\n  A --> B'}
+        filePath="/repo/first.mmd"
+        onContentChange={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Chart' }))
+    expect(screen.getByTestId('diagram-surface').getAttribute('data-diagram-key')).toBe(
+      'flowchart TD\n  A --> B'
+    )
+
+    rerender(
+      <MermaidViewer
+        content={'flowchart TD\n  X --> Y'}
+        filePath="/repo/second.mmd"
+        onContentChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('diagram-surface').getAttribute('data-diagram-key')).toBe(
+      'flowchart TD\n  X --> Y'
+    )
+  })
 })

--- a/src/renderer/src/components/editor/MermaidViewer.test.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -26,13 +26,16 @@ vi.mock('./ZoomableDiagramSurface', () => ({
 }))
 
 import MermaidViewer from './MermaidViewer'
+import { MERMAID_RENDER_DEBOUNCE_MS } from './use-debounced-mermaid-diagram-content'
 
 afterEach(() => {
   cleanup()
+  vi.useRealTimers()
 })
 
 describe('MermaidViewer', () => {
   it('edits source in split mode and rerenders the diagram from the draft', () => {
+    vi.useFakeTimers()
     const onContentChange = vi.fn()
 
     render(
@@ -49,6 +52,9 @@ describe('MermaidViewer', () => {
     })
 
     expect(onContentChange).toHaveBeenLastCalledWith('flowchart TD\n  A --> C')
+    act(() => {
+      vi.advanceTimersByTime(MERMAID_RENDER_DEBOUNCE_MS)
+    })
     expect(screen.getByTestId('diagram-surface').getAttribute('data-diagram-key')).toBe(
       'flowchart TD\n  A --> C'
     )
@@ -71,6 +77,8 @@ describe('MermaidViewer', () => {
   })
 
   it('keeps a new empty diagram editable after the first input', () => {
+    vi.useFakeTimers()
+
     render(<MermaidViewer content="" filePath="/repo/new.mmd" onContentChange={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Mermaid source'), {
@@ -81,8 +89,60 @@ describe('MermaidViewer', () => {
     expect((screen.getByLabelText('Mermaid source') as HTMLTextAreaElement).value).toBe(
       'flowchart LR\n  Start --> Done'
     )
+    act(() => {
+      vi.advanceTimersByTime(MERMAID_RENDER_DEBOUNCE_MS)
+    })
     expect(screen.getByTestId('diagram-surface').getAttribute('data-diagram-key')).toBe(
       'flowchart LR\n  Start --> Done'
     )
+  })
+
+  it('keeps the draft when parent content echoes back for the same file', () => {
+    const { rerender } = render(
+      <MermaidViewer
+        content={'flowchart TD\n  A --> B'}
+        filePath="/repo/demo.mmd"
+        onContentChange={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Code' }))
+    fireEvent.change(screen.getByLabelText('Mermaid source'), {
+      target: { value: 'flowchart TD\n  A --> Draft' }
+    })
+
+    rerender(
+      <MermaidViewer
+        content={'flowchart TD\n  A --> Echo'}
+        filePath="/repo/demo.mmd"
+        onContentChange={vi.fn()}
+      />
+    )
+
+    expect((screen.getByLabelText('Mermaid source') as HTMLTextAreaElement).value).toBe(
+      'flowchart TD\n  A --> Draft'
+    )
+  })
+
+  it('keeps read-only files immutable and suppresses the save shortcut', () => {
+    const onSave = vi.fn()
+
+    render(
+      <MermaidViewer
+        content={'flowchart TD\n  A --> B'}
+        filePath="/repo/demo.mmd"
+        onContentChange={vi.fn()}
+        onSave={onSave}
+        readOnly
+      />
+    )
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Code' }))
+    const source = screen.getByLabelText('Mermaid source') as HTMLTextAreaElement
+    const modifier = navigator.userAgent.includes('Mac') ? { metaKey: true } : { ctrlKey: true }
+    fireEvent.keyDown(source, { key: 's', code: 'KeyS', ...modifier })
+
+    expect(source.readOnly).toBe(true)
+    expect(onSave).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -30,17 +30,24 @@ export default function MermaidViewer({
 }: MermaidViewerProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
   const latestContentRef = useRef(content)
-  const syncedFilePathRef = useRef(filePath)
   const [mode, setMode] = useState<MermaidTextDiagramMode>('chart')
   const [draftContent, setDraftContent] = useState(content)
+  const [syncedFilePath, setSyncedFilePath] = useState(filePath)
   const settings = useAppStore((s) => s.settings)
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
+  // Sync draft on file switch during render so debounce hook sees fresh content
+  if (syncedFilePath !== filePath) {
+    setSyncedFilePath(filePath)
+    setDraftContent(content)
+    latestContentRef.current = content
+  }
+
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
   const trimmedContent = useMemo(() => draftContent.trim(), [draftContent])
-  const renderContent = useDebouncedMermaidDiagramContent(trimmedContent)
+  const renderContent = useDebouncedMermaidDiagramContent(trimmedContent, filePath)
   const viewOptions = getMermaidTextDiagramModeOptions('auto.components.editor.MermaidViewer')
   const showSource = mode !== 'chart' || trimmedContent.length === 0
   const showDiagram = mode !== 'code' && trimmedContent.length > 0
@@ -49,15 +56,6 @@ export default function MermaidViewer({
     'auto.components.editor.MermaidViewer.sourcePlaceholder',
     'Type Mermaid source...'
   )
-
-  useEffect(() => {
-    if (syncedFilePathRef.current === filePath) {
-      return
-    }
-    syncedFilePathRef.current = filePath
-    setDraftContent(content)
-    latestContentRef.current = content
-  }, [content, filePath])
 
   useEffect(() => {
     latestContentRef.current = draftContent

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -30,19 +30,31 @@ export default function MermaidViewer({
 }: MermaidViewerProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
   const latestContentRef = useRef(content)
+  const lastEmittedContentRef = useRef(content)
   const [mode, setMode] = useState<MermaidTextDiagramMode>('chart')
   const [draftContent, setDraftContent] = useState(content)
   const [syncedFilePath, setSyncedFilePath] = useState(filePath)
+  const [syncedContent, setSyncedContent] = useState(content)
   const settings = useAppStore((s) => s.settings)
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
-  // Sync draft on file switch during render so debounce hook sees fresh content
+  // File switch: immediate sync so debounce hook flushes. Same-file: only accept
+  // content that differs from what we last emitted (external reload, not echo).
   if (syncedFilePath !== filePath) {
     setSyncedFilePath(filePath)
+    setSyncedContent(content)
     setDraftContent(content)
+    lastEmittedContentRef.current = content
     latestContentRef.current = content
+  } else if (content !== syncedContent) {
+    setSyncedContent(content)
+    if (content !== lastEmittedContentRef.current) {
+      setDraftContent(content)
+      lastEmittedContentRef.current = content
+      latestContentRef.current = content
+    }
   }
 
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
@@ -78,6 +90,7 @@ export default function MermaidViewer({
       setMode('split')
     }
     setDraftContent(nextContent)
+    lastEmittedContentRef.current = nextContent
     onContentChange?.(nextContent)
   }
 

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -1,103 +1,145 @@
-import React, { useLayoutEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { useAppStore } from '@/store'
-import { scrollTopCache, setWithLRU } from '@/lib/scroll-cache'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { installEditorSaveShortcut } from './editor-shortcuts'
 import MermaidBlock from './MermaidBlock'
+import ZoomableDiagramSurface from './ZoomableDiagramSurface'
 
 type MermaidViewerProps = {
   content: string
   filePath: string
+  onContentChange?: (content: string) => void
+  onSave?: (content: string) => void | Promise<boolean>
+  readOnly?: boolean
 }
 
-// Why: MermaidViewer is the full-file counterpart to MermaidBlock (which
-// renders fenced mermaid blocks inside markdown). When a user opens a .mmd
-// or .mermaid file in diagram mode, the entire file content is the diagram
-// source — no markdown wrapper, no frontmatter, just mermaid syntax.
+type MermaidTextDiagramMode = 'code' | 'split' | 'chart'
+
+const VIEW_OPTIONS = [
+  {
+    value: 'code',
+    get label() {
+      return translate('auto.components.editor.MermaidViewer.code', 'Code')
+    }
+  },
+  {
+    value: 'split',
+    get label() {
+      return translate('auto.components.editor.MermaidViewer.split', 'Split')
+    }
+  },
+  {
+    value: 'chart',
+    get label() {
+      return translate('auto.components.editor.MermaidViewer.chart', 'Chart')
+    }
+  }
+] as const satisfies readonly { value: MermaidTextDiagramMode; label: string }[]
+
 export default function MermaidViewer({
   content,
-  filePath
+  filePath,
+  onContentChange,
+  onSave,
+  readOnly = false
 }: MermaidViewerProps): React.JSX.Element {
-  const rootRef = useRef<HTMLDivElement>(null)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const latestContentRef = useRef(content)
+  const [mode, setMode] = useState<MermaidTextDiagramMode>('chart')
+  const [draftContent, setDraftContent] = useState(content)
   const settings = useAppStore((s) => s.settings)
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
-  // Why: Each viewing mode (source vs diagram) produces different DOM heights.
-  // Mode-scoped keys prevent restoring a source-mode scroll position in diagram
-  // mode (same reasoning as MarkdownPreview's scrollCacheKey).
-  const scrollCacheKey = `${filePath}:mermaid-diagram`
+  const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
+  const trimmedContent = useMemo(() => draftContent.trim(), [draftContent])
+  const showSource = mode !== 'chart' || trimmedContent.length === 0
+  const showDiagram = mode !== 'code' && trimmedContent.length > 0
+  const sourceLabel = translate('auto.components.editor.MermaidViewer.source', 'Mermaid source')
+  const sourcePlaceholder = translate(
+    'auto.components.editor.MermaidViewer.sourcePlaceholder',
+    'Type Mermaid source...'
+  )
 
-  useLayoutEffect(() => {
-    const container = rootRef.current
-    if (!container) {
+  useEffect(() => {
+    setDraftContent(content)
+  }, [content, filePath])
+
+  useEffect(() => {
+    latestContentRef.current = draftContent
+  }, [draftContent])
+
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root || !onSave || readOnly) {
       return
     }
 
-    let throttleTimer: ReturnType<typeof setTimeout> | null = null
+    return installEditorSaveShortcut(root, () => {
+      void onSave(latestContentRef.current)
+    })
+  }, [onSave, readOnly])
 
-    const onScroll = (): void => {
-      if (throttleTimer !== null) {
-        clearTimeout(throttleTimer)
-      }
-      throttleTimer = setTimeout(() => {
-        setWithLRU(scrollTopCache, scrollCacheKey, container.scrollTop)
-        throttleTimer = null
-      }, 150)
+  const handleSourceChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
+    const nextContent = event.currentTarget.value
+    if (mode === 'chart' && trimmedContent.length === 0 && nextContent.trim().length > 0) {
+      setMode('split')
     }
-
-    container.addEventListener('scroll', onScroll, { passive: true })
-    return () => {
-      // Why: guard against writing 0 when the SVG has not rendered yet (e.g.,
-      // StrictMode double-mount or quick tab switch before mermaid.render()
-      // completes). Without this, a valid cached position gets clobbered.
-      if (container.scrollHeight > container.clientHeight || container.scrollTop > 0) {
-        setWithLRU(scrollTopCache, scrollCacheKey, container.scrollTop)
-      }
-      if (throttleTimer !== null) {
-        clearTimeout(throttleTimer)
-      }
-      container.removeEventListener('scroll', onScroll)
-    }
-  }, [scrollCacheKey])
-
-  useLayoutEffect(() => {
-    const container = rootRef.current
-    const targetScrollTop = scrollTopCache.get(scrollCacheKey)
-    if (!container || targetScrollTop === undefined) {
-      return
-    }
-
-    let frameId = 0
-    let attempts = 0
-
-    // Why: mermaid.render() is async, so the SVG may not exist on the first
-    // frame. Retry up to 30 frames (~500ms) to match MarkdownPreview's pattern.
-    const tryRestore = (): void => {
-      const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight)
-      const nextScrollTop = Math.min(targetScrollTop, maxScrollTop)
-      container.scrollTop = nextScrollTop
-
-      if (Math.abs(container.scrollTop - targetScrollTop) <= 1 || maxScrollTop >= targetScrollTop) {
-        return
-      }
-
-      attempts += 1
-      if (attempts < 30) {
-        frameId = window.requestAnimationFrame(tryRestore)
-      }
-    }
-
-    tryRestore()
-    return () => window.cancelAnimationFrame(frameId)
-  }, [scrollCacheKey, content])
+    setDraftContent(nextContent)
+    onContentChange?.(nextContent)
+  }
 
   return (
-    <div ref={rootRef} className="mermaid-viewer h-full min-h-0 overflow-auto scrollbar-editor">
-      <div className="mermaid-viewer-canvas">
-        {/* Why: DOMPurify's SVG profile strips <foreignObject> elements that
-           mermaid uses for HTML labels. Force SVG-native <text> labels so
-           they survive sanitization — same fix as the markdown preview path. */}
-        <MermaidBlock content={content.trim()} isDark={isDark} htmlLabels={false} />
+    <div ref={rootRef} className="mermaid-viewer h-full min-h-0">
+      <div className="mermaid-text-diagram-toolbar">
+        <div className="mermaid-text-diagram-title" title={filename}>
+          {filename}
+        </div>
+        <ToggleGroup
+          type="single"
+          size="sm"
+          variant="outline"
+          spacing={0}
+          value={mode}
+          onValueChange={(nextMode) => {
+            if (nextMode) {
+              setMode(nextMode as MermaidTextDiagramMode)
+            }
+          }}
+        >
+          {VIEW_OPTIONS.map((option) => (
+            <ToggleGroupItem key={option.value} value={option.value}>
+              {option.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+      <div className={cn('mermaid-text-diagram-body', `is-${mode}`)}>
+        {showSource ? (
+          <textarea
+            className="mermaid-text-diagram-source mermaid-text-diagram-source-editor scrollbar-editor"
+            value={draftContent}
+            readOnly={readOnly || !onContentChange}
+            spellCheck={false}
+            wrap="off"
+            aria-label={sourceLabel}
+            placeholder={sourcePlaceholder}
+            onChange={handleSourceChange}
+          />
+        ) : null}
+        {showDiagram ? (
+          <ZoomableDiagramSurface
+            className="mermaid-text-diagram-chart"
+            diagramKey={trimmedContent}
+            resetKey={filePath}
+            label={translate('auto.components.editor.MermaidViewer.mermaid', 'Mermaid')}
+          >
+            <MermaidBlock content={trimmedContent} isDark={isDark} htmlLabels={false} />
+          </ZoomableDiagramSurface>
+        ) : null}
       </div>
     </div>
   )

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -4,7 +4,13 @@ import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { installEditorSaveShortcut } from './editor-shortcuts'
+import {
+  getMermaidTextDiagramModeOptions,
+  isMermaidTextDiagramMode,
+  type MermaidTextDiagramMode
+} from './mermaid-text-diagram-view-modes'
 import MermaidBlock from './MermaidBlock'
+import { useDebouncedMermaidDiagramContent } from './use-debounced-mermaid-diagram-content'
 import ZoomableDiagramSurface from './ZoomableDiagramSurface'
 
 type MermaidViewerProps = {
@@ -15,29 +21,6 @@ type MermaidViewerProps = {
   readOnly?: boolean
 }
 
-type MermaidTextDiagramMode = 'code' | 'split' | 'chart'
-
-const VIEW_OPTIONS = [
-  {
-    value: 'code',
-    get label() {
-      return translate('auto.components.editor.MermaidViewer.code', 'Code')
-    }
-  },
-  {
-    value: 'split',
-    get label() {
-      return translate('auto.components.editor.MermaidViewer.split', 'Split')
-    }
-  },
-  {
-    value: 'chart',
-    get label() {
-      return translate('auto.components.editor.MermaidViewer.chart', 'Chart')
-    }
-  }
-] as const satisfies readonly { value: MermaidTextDiagramMode; label: string }[]
-
 export default function MermaidViewer({
   content,
   filePath,
@@ -47,6 +30,7 @@ export default function MermaidViewer({
 }: MermaidViewerProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
   const latestContentRef = useRef(content)
+  const syncedFilePathRef = useRef(filePath)
   const [mode, setMode] = useState<MermaidTextDiagramMode>('chart')
   const [draftContent, setDraftContent] = useState(content)
   const settings = useAppStore((s) => s.settings)
@@ -56,6 +40,8 @@ export default function MermaidViewer({
 
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
   const trimmedContent = useMemo(() => draftContent.trim(), [draftContent])
+  const renderContent = useDebouncedMermaidDiagramContent(trimmedContent)
+  const viewOptions = getMermaidTextDiagramModeOptions('auto.components.editor.MermaidViewer')
   const showSource = mode !== 'chart' || trimmedContent.length === 0
   const showDiagram = mode !== 'code' && trimmedContent.length > 0
   const sourceLabel = translate('auto.components.editor.MermaidViewer.source', 'Mermaid source')
@@ -65,7 +51,12 @@ export default function MermaidViewer({
   )
 
   useEffect(() => {
+    if (syncedFilePathRef.current === filePath) {
+      return
+    }
+    syncedFilePathRef.current = filePath
     setDraftContent(content)
+    latestContentRef.current = content
   }, [content, filePath])
 
   useEffect(() => {
@@ -105,12 +96,12 @@ export default function MermaidViewer({
           spacing={0}
           value={mode}
           onValueChange={(nextMode) => {
-            if (nextMode) {
-              setMode(nextMode as MermaidTextDiagramMode)
+            if (isMermaidTextDiagramMode(nextMode)) {
+              setMode(nextMode)
             }
           }}
         >
-          {VIEW_OPTIONS.map((option) => (
+          {viewOptions.map((option) => (
             <ToggleGroupItem key={option.value} value={option.value}>
               {option.label}
             </ToggleGroupItem>
@@ -133,11 +124,11 @@ export default function MermaidViewer({
         {showDiagram ? (
           <ZoomableDiagramSurface
             className="mermaid-text-diagram-chart"
-            diagramKey={trimmedContent}
+            diagramKey={renderContent}
             resetKey={filePath}
             label={translate('auto.components.editor.MermaidViewer.mermaid', 'Mermaid')}
           >
-            <MermaidBlock content={trimmedContent} isDark={isDark} htmlLabels={false} />
+            <MermaidBlock content={renderContent} isDark={isDark} htmlLabels={false} />
           </ZoomableDiagramSurface>
         ) : null}
       </div>

--- a/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownCodeBlock.tsx
@@ -5,8 +5,9 @@ import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
 import type { NodeViewProps } from '@tiptap/react'
 import { Copy, Check } from 'lucide-react'
 import { useAppStore } from '@/store'
-import MermaidBlock from './MermaidBlock'
 import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import RichMarkdownMermaidViews from './RichMarkdownMermaidViews'
 import {
   getCodeBlockLanguageLabel,
   getCodeBlockLanguages,
@@ -93,7 +94,12 @@ export function RichMarkdownCodeBlock({
   )
 
   return (
-    <NodeViewWrapper className="rich-markdown-code-block-wrapper">
+    <NodeViewWrapper
+      className={cn(
+        'rich-markdown-code-block-wrapper',
+        isMermaid && 'rich-markdown-mermaid-code-block'
+      )}
+    >
       <select
         className="rich-markdown-code-block-lang"
         contentEditable={false}
@@ -143,16 +149,10 @@ export function RichMarkdownCodeBlock({
           <Copy size={14} />
         )}
       </button>
-      <NodeViewContent<'pre'> as="pre" />
-      {/* Why: mermaid diagrams render as a live SVG preview below the editable
-          source so users can see the result while editing. The code block stays
-          editable — the diagram is read-only output. This preview also goes
-          through MermaidBlock's sanitized SVG path, so it must opt out of
-          Mermaid HTML labels just like markdown preview to keep labels visible. */}
-      {isMermaid && node.textContent.trim() && (
-        <div contentEditable={false} className="mermaid-preview">
-          <MermaidBlock content={node.textContent.trim()} isDark={isDark} htmlLabels={false} />
-        </div>
+      {isMermaid ? (
+        <RichMarkdownMermaidViews content={node.textContent} isDark={isDark} />
+      ) : (
+        <NodeViewContent<'pre'> as="pre" />
       )}
     </NodeViewWrapper>
   )

--- a/src/renderer/src/components/editor/RichMarkdownMermaidViews.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownMermaidViews.tsx
@@ -1,0 +1,89 @@
+import { NodeViewContent } from '@tiptap/react'
+import { type JSX, useState } from 'react'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import MermaidBlock from './MermaidBlock'
+import ZoomableDiagramSurface from './ZoomableDiagramSurface'
+
+type MermaidTextDiagramMode = 'code' | 'split' | 'chart'
+
+const MODE_OPTIONS = [
+  {
+    value: 'code',
+    get label() {
+      return translate('auto.components.editor.RichMarkdownMermaidViews.code', 'Code')
+    }
+  },
+  {
+    value: 'split',
+    get label() {
+      return translate('auto.components.editor.RichMarkdownMermaidViews.split', 'Split')
+    }
+  },
+  {
+    value: 'chart',
+    get label() {
+      return translate('auto.components.editor.RichMarkdownMermaidViews.chart', 'Chart')
+    }
+  }
+] as const satisfies readonly { value: MermaidTextDiagramMode; label: string }[]
+
+type RichMarkdownMermaidViewsProps = {
+  content: string
+  isDark: boolean
+}
+
+export default function RichMarkdownMermaidViews({
+  content,
+  isDark
+}: RichMarkdownMermaidViewsProps): JSX.Element {
+  const [mode, setMode] = useState<MermaidTextDiagramMode>('split')
+  const trimmedContent = content.trim()
+  const showSource = mode !== 'chart' || trimmedContent.length === 0
+  const showDiagram = mode !== 'code' && trimmedContent.length > 0
+
+  return (
+    <>
+      <ToggleGroup
+        type="single"
+        size="sm"
+        variant="outline"
+        spacing={0}
+        value={mode}
+        className="rich-markdown-mermaid-view-toggle"
+        contentEditable={false}
+        onValueChange={(nextMode) => {
+          if (nextMode) {
+            setMode(nextMode as MermaidTextDiagramMode)
+          }
+        }}
+      >
+        {MODE_OPTIONS.map((option) => (
+          <ToggleGroupItem key={option.value} value={option.value}>
+            {option.label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+      <div className={cn('rich-markdown-mermaid-layout', `is-${mode}`)}>
+        <NodeViewContent<'pre'>
+          as="pre"
+          className={cn(!showSource && 'rich-markdown-code-block-source-hidden')}
+        />
+        {showDiagram ? (
+          <div contentEditable={false} className="mermaid-preview">
+            <ZoomableDiagramSurface
+              diagramKey={trimmedContent}
+              label={translate(
+                'auto.components.editor.RichMarkdownMermaidViews.mermaid',
+                'Mermaid'
+              )}
+            >
+              <MermaidBlock content={trimmedContent} isDark={isDark} htmlLabels={false} />
+            </ZoomableDiagramSurface>
+          </div>
+        ) : null}
+      </div>
+    </>
+  )
+}

--- a/src/renderer/src/components/editor/RichMarkdownMermaidViews.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownMermaidViews.tsx
@@ -3,31 +3,14 @@ import { type JSX, useState } from 'react'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import {
+  getMermaidTextDiagramModeOptions,
+  isMermaidTextDiagramMode,
+  type MermaidTextDiagramMode
+} from './mermaid-text-diagram-view-modes'
 import MermaidBlock from './MermaidBlock'
+import { useDebouncedMermaidDiagramContent } from './use-debounced-mermaid-diagram-content'
 import ZoomableDiagramSurface from './ZoomableDiagramSurface'
-
-type MermaidTextDiagramMode = 'code' | 'split' | 'chart'
-
-const MODE_OPTIONS = [
-  {
-    value: 'code',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownMermaidViews.code', 'Code')
-    }
-  },
-  {
-    value: 'split',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownMermaidViews.split', 'Split')
-    }
-  },
-  {
-    value: 'chart',
-    get label() {
-      return translate('auto.components.editor.RichMarkdownMermaidViews.chart', 'Chart')
-    }
-  }
-] as const satisfies readonly { value: MermaidTextDiagramMode; label: string }[]
 
 type RichMarkdownMermaidViewsProps = {
   content: string
@@ -40,6 +23,10 @@ export default function RichMarkdownMermaidViews({
 }: RichMarkdownMermaidViewsProps): JSX.Element {
   const [mode, setMode] = useState<MermaidTextDiagramMode>('split')
   const trimmedContent = content.trim()
+  const renderContent = useDebouncedMermaidDiagramContent(trimmedContent)
+  const modeOptions = getMermaidTextDiagramModeOptions(
+    'auto.components.editor.RichMarkdownMermaidViews'
+  )
   const showSource = mode !== 'chart' || trimmedContent.length === 0
   const showDiagram = mode !== 'code' && trimmedContent.length > 0
 
@@ -54,12 +41,12 @@ export default function RichMarkdownMermaidViews({
         className="rich-markdown-mermaid-view-toggle"
         contentEditable={false}
         onValueChange={(nextMode) => {
-          if (nextMode) {
-            setMode(nextMode as MermaidTextDiagramMode)
+          if (isMermaidTextDiagramMode(nextMode)) {
+            setMode(nextMode)
           }
         }}
       >
-        {MODE_OPTIONS.map((option) => (
+        {modeOptions.map((option) => (
           <ToggleGroupItem key={option.value} value={option.value}>
             {option.label}
           </ToggleGroupItem>
@@ -73,13 +60,13 @@ export default function RichMarkdownMermaidViews({
         {showDiagram ? (
           <div contentEditable={false} className="mermaid-preview">
             <ZoomableDiagramSurface
-              diagramKey={trimmedContent}
+              diagramKey={renderContent}
               label={translate(
                 'auto.components.editor.RichMarkdownMermaidViews.mermaid',
                 'Mermaid'
               )}
             >
-              <MermaidBlock content={trimmedContent} isDark={isDark} htmlLabels={false} />
+              <MermaidBlock content={renderContent} isDark={isDark} htmlLabels={false} />
             </ZoomableDiagramSurface>
           </div>
         ) : null}

--- a/src/renderer/src/components/editor/ZoomableDiagramSurface.tsx
+++ b/src/renderer/src/components/editor/ZoomableDiagramSurface.tsx
@@ -92,6 +92,7 @@ export default function ZoomableDiagramSurface({
   const [zoom, setZoom] = useState(1)
   const [isPanReady, setIsPanReady] = useState(false)
   const [isPanning, setIsPanning] = useState(false)
+  const [surfaceElement, setSurfaceElement] = useState<HTMLDivElement | null>(null)
   const [surfaceSize, setSurfaceSize] = useState<DiagramSurfaceDimensions | null>(null)
   const [diagramSize, setDiagramSize] = useState<DiagramSurfaceDimensions | null>(null)
   const shortcutPlatform = useMemo(() => getShortcutPlatform(), [])
@@ -136,24 +137,18 @@ export default function ZoomableDiagramSurface({
     [applyZoomChange]
   )
 
-  const setSurfaceRef = useCallback(
-    (surface: HTMLDivElement | null) => {
-      if (surfaceRef.current) {
-        surfaceRef.current.removeEventListener('wheel', handleWheel)
-      }
-      surfaceRef.current = surface
-      if (surface) {
-        const nextSize = getElementSurfaceSize(surface)
-        setSurfaceSize((currentSize) =>
-          dimensionsEqual(currentSize, nextSize) ? currentSize : nextSize
-        )
-        surface.addEventListener('wheel', handleWheel, { passive: false })
-      } else {
-        setSurfaceSize(null)
-      }
-    },
-    [handleWheel]
-  )
+  const setSurfaceRef = useCallback((surface: HTMLDivElement | null) => {
+    surfaceRef.current = surface
+    setSurfaceElement(surface)
+    if (surface) {
+      const nextSize = getElementSurfaceSize(surface)
+      setSurfaceSize((currentSize) =>
+        dimensionsEqual(currentSize, nextSize) ? currentSize : nextSize
+      )
+    } else {
+      setSurfaceSize(null)
+    }
+  }, [])
 
   const updateDiagramSize = useCallback(() => {
     const svg = contentRef.current?.querySelector('svg') ?? null
@@ -168,14 +163,13 @@ export default function ZoomableDiagramSurface({
   }, [resetKey])
 
   useEffect(() => {
-    const surface = surfaceRef.current
-    if (!surface) {
+    if (!surfaceElement) {
       setSurfaceSize(null)
       return
     }
 
     const updateSize = () => {
-      const nextSize = getElementSurfaceSize(surface)
+      const nextSize = getElementSurfaceSize(surfaceElement)
       setSurfaceSize((currentSize) =>
         dimensionsEqual(currentSize, nextSize) ? currentSize : nextSize
       )
@@ -186,9 +180,18 @@ export default function ZoomableDiagramSurface({
     }
 
     const observer = new ResizeObserver(updateSize)
-    observer.observe(surface)
+    observer.observe(surfaceElement)
     return () => observer.disconnect()
-  }, [])
+  }, [surfaceElement])
+
+  useEffect(() => {
+    if (!surfaceElement) {
+      return
+    }
+
+    surfaceElement.addEventListener('wheel', handleWheel, { passive: false })
+    return () => surfaceElement.removeEventListener('wheel', handleWheel)
+  }, [handleWheel, surfaceElement])
 
   useEffect(() => {
     const content = contentRef.current
@@ -207,7 +210,7 @@ export default function ZoomableDiagramSurface({
     return () => {
       mutationObserver?.disconnect()
     }
-  }, [children, diagramKey, updateDiagramSize])
+  }, [diagramKey, updateDiagramSize])
 
   const finishPanDrag = useCallback((pointerId: number) => {
     const surface = surfaceRef.current

--- a/src/renderer/src/components/editor/ZoomableDiagramSurface.tsx
+++ b/src/renderer/src/components/editor/ZoomableDiagramSurface.tsx
@@ -1,0 +1,412 @@
+import { RotateCcw, ZoomIn, ZoomOut } from 'lucide-react'
+import React, {
+  type CSSProperties,
+  type JSX,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import { Button } from '@/components/ui/button'
+import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import {
+  type ApplySurfaceZoomChange,
+  applyAnchoredSurfaceZoomChange,
+  applySurfaceWheel,
+  getElementSurfaceSize,
+  getSurfaceLayoutStyle
+} from './anchored-surface-dom-zoom'
+import {
+  DIAGRAM_SURFACE_ZOOM_BOUNDS,
+  DIAGRAM_SURFACE_ZOOM_STEP,
+  MAX_DIAGRAM_SURFACE_ZOOM,
+  MIN_DIAGRAM_SURFACE_ZOOM,
+  type DiagramSurfacePanStart,
+  type DiagramSurfaceDimensions,
+  getDiagramSurfaceKeyboardZoomIntent,
+  getDraggedDiagramSurfaceScrollPosition,
+  getZoomedDiagramLayoutSize
+} from './diagram-surface-zoom'
+
+type ZoomableDiagramSurfaceProps = {
+  children: React.ReactNode
+  className?: string
+  contentClassName?: string
+  diagramKey: string
+  label?: string
+  resetKey?: string
+}
+
+function parseSvgLength(value: string | null): number | null {
+  if (!value) {
+    return null
+  }
+
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function getSvgIntrinsicSize(svg: SVGSVGElement | null): DiagramSurfaceDimensions | null {
+  if (!svg) {
+    return null
+  }
+
+  const viewBox = svg.viewBox?.baseVal
+  if (viewBox && viewBox.width > 0 && viewBox.height > 0) {
+    return { width: viewBox.width, height: viewBox.height }
+  }
+
+  const width = parseSvgLength(svg.getAttribute('width'))
+  const height = parseSvgLength(svg.getAttribute('height'))
+  if (width !== null && height !== null) {
+    return { width, height }
+  }
+
+  const rect = svg.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0 ? { width: rect.width, height: rect.height } : null
+}
+
+function dimensionsEqual(
+  current: DiagramSurfaceDimensions | null,
+  next: DiagramSurfaceDimensions | null
+): boolean {
+  return current?.width === next?.width && current?.height === next?.height
+}
+
+export default function ZoomableDiagramSurface({
+  children,
+  className,
+  contentClassName,
+  diagramKey,
+  label,
+  resetKey
+}: ZoomableDiagramSurfaceProps): JSX.Element {
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const panDragRef = useRef<
+    (DiagramSurfacePanStart & { didMove: boolean; pointerId: number }) | null
+  >(null)
+  const [zoom, setZoom] = useState(1)
+  const [isPanReady, setIsPanReady] = useState(false)
+  const [isPanning, setIsPanning] = useState(false)
+  const [surfaceSize, setSurfaceSize] = useState<DiagramSurfaceDimensions | null>(null)
+  const [diagramSize, setDiagramSize] = useState<DiagramSurfaceDimensions | null>(null)
+  const shortcutPlatform = useMemo(() => getShortcutPlatform(), [])
+
+  const zoomPercent = Math.round(zoom * 100)
+  const layoutSize = useMemo(
+    () => getZoomedDiagramLayoutSize({ diagramDimensions: diagramSize, surfaceSize, zoom }),
+    [diagramSize, surfaceSize, zoom]
+  )
+  const layoutStyle = useMemo<CSSProperties | undefined>(
+    () => getSurfaceLayoutStyle(layoutSize),
+    [layoutSize]
+  )
+  const zoomOutLabel = translate(
+    'auto.components.editor.ZoomableDiagramSurface.zoomOut',
+    'Zoom out'
+  )
+  const resetZoomLabel = translate(
+    'auto.components.editor.ZoomableDiagramSurface.resetZoom',
+    'Reset zoom'
+  )
+  const zoomInLabel = translate('auto.components.editor.ZoomableDiagramSurface.zoomIn', 'Zoom in')
+  const viewportLabel = translate(
+    'auto.components.editor.ZoomableDiagramSurface.viewport',
+    'Diagram canvas'
+  )
+
+  const applyZoomChange = useCallback<ApplySurfaceZoomChange>((getNextZoom, anchor) => {
+    applyAnchoredSurfaceZoomChange(
+      surfaceRef.current,
+      setZoom,
+      getNextZoom,
+      DIAGRAM_SURFACE_ZOOM_BOUNDS,
+      anchor
+    )
+  }, [])
+
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      applySurfaceWheel(event, applyZoomChange, DIAGRAM_SURFACE_ZOOM_BOUNDS)
+    },
+    [applyZoomChange]
+  )
+
+  const setSurfaceRef = useCallback(
+    (surface: HTMLDivElement | null) => {
+      if (surfaceRef.current) {
+        surfaceRef.current.removeEventListener('wheel', handleWheel)
+      }
+      surfaceRef.current = surface
+      if (surface) {
+        const nextSize = getElementSurfaceSize(surface)
+        setSurfaceSize((currentSize) =>
+          dimensionsEqual(currentSize, nextSize) ? currentSize : nextSize
+        )
+        surface.addEventListener('wheel', handleWheel, { passive: false })
+      } else {
+        setSurfaceSize(null)
+      }
+    },
+    [handleWheel]
+  )
+
+  const updateDiagramSize = useCallback(() => {
+    const svg = contentRef.current?.querySelector('svg') ?? null
+    const nextSize = getSvgIntrinsicSize(svg)
+    setDiagramSize((currentSize) =>
+      dimensionsEqual(currentSize, nextSize) ? currentSize : nextSize
+    )
+  }, [])
+
+  useEffect(() => {
+    setZoom(1)
+  }, [resetKey])
+
+  useEffect(() => {
+    const surface = surfaceRef.current
+    if (!surface) {
+      setSurfaceSize(null)
+      return
+    }
+
+    const updateSize = () => {
+      const nextSize = getElementSurfaceSize(surface)
+      setSurfaceSize((currentSize) =>
+        dimensionsEqual(currentSize, nextSize) ? currentSize : nextSize
+      )
+    }
+    updateSize()
+    if (typeof ResizeObserver === 'undefined') {
+      return
+    }
+
+    const observer = new ResizeObserver(updateSize)
+    observer.observe(surface)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const content = contentRef.current
+    if (!content) {
+      setDiagramSize(null)
+      return
+    }
+
+    updateDiagramSize()
+    let mutationObserver: MutationObserver | null = null
+    if (typeof MutationObserver !== 'undefined') {
+      mutationObserver = new MutationObserver(updateDiagramSize)
+      mutationObserver.observe(content, { childList: true, subtree: true, attributes: true })
+    }
+
+    return () => {
+      mutationObserver?.disconnect()
+    }
+  }, [children, diagramKey, updateDiagramSize])
+
+  const finishPanDrag = useCallback((pointerId: number) => {
+    const surface = surfaceRef.current
+    if (surface?.hasPointerCapture?.(pointerId)) {
+      surface.releasePointerCapture(pointerId)
+    }
+    panDragRef.current = null
+    setIsPanning(false)
+  }, [])
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0 && event.button !== 1) {
+      return
+    }
+
+    const surface = surfaceRef.current
+    if (!surface) {
+      return
+    }
+
+    surface.focus({ preventScroll: true })
+    panDragRef.current = {
+      clientX: event.clientX,
+      clientY: event.clientY,
+      didMove: false,
+      pointerId: event.pointerId,
+      scrollLeft: surface.scrollLeft,
+      scrollTop: surface.scrollTop
+    }
+    surface.setPointerCapture?.(event.pointerId)
+    event.preventDefault()
+  }, [])
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = panDragRef.current
+    const surface = surfaceRef.current
+    if (!drag || drag.pointerId !== event.pointerId || !surface) {
+      return
+    }
+
+    const deltaX = event.clientX - drag.clientX
+    const deltaY = event.clientY - drag.clientY
+    if (!drag.didMove && Math.hypot(deltaX, deltaY) > 2) {
+      drag.didMove = true
+      setIsPanning(true)
+    }
+
+    const nextScroll = getDraggedDiagramSurfaceScrollPosition({
+      start: drag,
+      clientX: event.clientX,
+      clientY: event.clientY
+    })
+    surface.scrollLeft = nextScroll.scrollLeft
+    surface.scrollTop = nextScroll.scrollTop
+    event.preventDefault()
+  }, [])
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (panDragRef.current?.pointerId === event.pointerId) {
+        finishPanDrag(event.pointerId)
+      }
+    },
+    [finishPanDrag]
+  )
+
+  const handleViewportKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const zoomIntent = getDiagramSurfaceKeyboardZoomIntent(event, shortcutPlatform)
+      if (zoomIntent) {
+        event.preventDefault()
+        event.stopPropagation()
+        if (zoomIntent === 'zoom-in') {
+          applyZoomChange((currentZoom) => currentZoom * DIAGRAM_SURFACE_ZOOM_STEP)
+        } else if (zoomIntent === 'zoom-out') {
+          applyZoomChange((currentZoom) => currentZoom / DIAGRAM_SURFACE_ZOOM_STEP)
+        } else {
+          applyZoomChange(() => 1)
+        }
+        return
+      }
+
+      if (
+        (event.key === ' ' || event.code === 'Space') &&
+        !event.altKey &&
+        !event.ctrlKey &&
+        !event.metaKey
+      ) {
+        event.preventDefault()
+        setIsPanReady(true)
+      }
+    },
+    [applyZoomChange, shortcutPlatform]
+  )
+
+  const handleViewportKeyUp = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === ' ' || event.code === 'Space') {
+      event.preventDefault()
+      setIsPanReady(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const handleWindowKeyUp = (event: KeyboardEvent): void => {
+      if (event.key === ' ' || event.code === 'Space') {
+        setIsPanReady(false)
+      }
+    }
+    const handleWindowBlur = (): void => {
+      panDragRef.current = null
+      setIsPanReady(false)
+      setIsPanning(false)
+    }
+
+    window.addEventListener('keyup', handleWindowKeyUp)
+    window.addEventListener('blur', handleWindowBlur)
+    return () => {
+      window.removeEventListener('keyup', handleWindowKeyUp)
+      window.removeEventListener('blur', handleWindowBlur)
+    }
+  }, [])
+
+  return (
+    <div className={cn('zoomable-diagram-surface', className)}>
+      <div
+        ref={setSurfaceRef}
+        className={cn(
+          'zoomable-diagram-surface-viewport scrollbar-editor',
+          isPanReady && 'is-pan-ready',
+          isPanning && 'is-panning'
+        )}
+        tabIndex={0}
+        aria-label={viewportLabel}
+        onBlur={() => setIsPanReady(false)}
+        onKeyDown={handleViewportKeyDown}
+        onKeyUp={handleViewportKeyUp}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerCancel={handlePointerUp}
+        onPointerUp={handlePointerUp}
+        onLostPointerCapture={handlePointerUp}
+      >
+        <div className="zoomable-diagram-surface-stage">
+          <div
+            ref={contentRef}
+            className={cn(
+              'zoomable-diagram-surface-content',
+              layoutSize && 'is-sized',
+              contentClassName
+            )}
+            style={layoutStyle}
+          >
+            {children}
+          </div>
+        </div>
+      </div>
+      <div className="zoomable-diagram-surface-toolbar">
+        <div className="zoomable-diagram-surface-controls">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={() =>
+              applyZoomChange((currentZoom) => currentZoom / DIAGRAM_SURFACE_ZOOM_STEP)
+            }
+            disabled={zoom <= MIN_DIAGRAM_SURFACE_ZOOM}
+            aria-label={zoomOutLabel}
+            title={zoomOutLabel}
+          >
+            <ZoomOut />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => applyZoomChange(() => 1)}
+            disabled={zoom === 1}
+            aria-label={resetZoomLabel}
+            title={resetZoomLabel}
+          >
+            <RotateCcw />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={() =>
+              applyZoomChange((currentZoom) => currentZoom * DIAGRAM_SURFACE_ZOOM_STEP)
+            }
+            disabled={zoom >= MAX_DIAGRAM_SURFACE_ZOOM}
+            aria-label={zoomInLabel}
+            title={zoomInLabel}
+          >
+            <ZoomIn />
+          </Button>
+          <span className="zoomable-diagram-surface-zoom tabular-nums">{zoomPercent}%</span>
+        </div>
+        {label ? <div className="zoomable-diagram-surface-label">{label}</div> : null}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/anchored-surface-dom-zoom.ts
+++ b/src/renderer/src/components/editor/anchored-surface-dom-zoom.ts
@@ -1,0 +1,97 @@
+import type { CSSProperties, Dispatch, SetStateAction } from 'react'
+import { flushSync } from 'react-dom'
+import {
+  type SurfaceContentDimensions,
+  type SurfaceSize,
+  type SurfaceZoomAnchor,
+  type SurfaceZoomBounds,
+  clampSurfaceZoom,
+  getAnchoredSurfaceScrollOffset,
+  getNextWheelSurfaceZoom,
+  shouldHandleSurfaceZoomWheel
+} from './anchored-surface-zoom'
+
+export type ApplySurfaceZoomChange = (
+  getNextZoom: (currentZoom: number) => number,
+  anchor?: SurfaceZoomAnchor | null
+) => void
+
+export function getElementSurfaceSize(element: HTMLElement): SurfaceSize {
+  return {
+    width: element.clientWidth,
+    height: element.clientHeight
+  }
+}
+
+export function getSurfaceLayoutStyle(
+  size: SurfaceContentDimensions | null
+): CSSProperties | undefined {
+  if (!size) {
+    return undefined
+  }
+
+  return {
+    width: `${size.width}px`,
+    height: `${size.height}px`
+  }
+}
+
+export function applyAnchoredSurfaceZoomChange(
+  surface: HTMLDivElement | null,
+  setZoom: Dispatch<SetStateAction<number>>,
+  getNextZoom: (currentZoom: number) => number,
+  bounds: SurfaceZoomBounds,
+  anchor?: SurfaceZoomAnchor | null
+): void {
+  const resolvedAnchor = surface
+    ? (anchor ?? { x: surface.clientWidth / 2, y: surface.clientHeight / 2 })
+    : null
+  const scrollLeft = surface?.scrollLeft ?? 0
+  const scrollTop = surface?.scrollTop ?? 0
+  let currentZoom = 1
+  let nextZoom = 1
+
+  flushSync(() => {
+    setZoom((current) => {
+      currentZoom = current
+      nextZoom = clampSurfaceZoom(getNextZoom(current), bounds)
+      return nextZoom
+    })
+  })
+
+  if (!surface || !resolvedAnchor || currentZoom === nextZoom) {
+    return
+  }
+
+  surface.scrollLeft = getAnchoredSurfaceScrollOffset({
+    scrollOffset: scrollLeft,
+    anchorOffset: resolvedAnchor.x,
+    currentZoom,
+    nextZoom
+  })
+  surface.scrollTop = getAnchoredSurfaceScrollOffset({
+    scrollOffset: scrollTop,
+    anchorOffset: resolvedAnchor.y,
+    currentZoom,
+    nextZoom
+  })
+}
+
+export function applySurfaceWheel(
+  event: WheelEvent,
+  applyZoomChange: ApplySurfaceZoomChange,
+  bounds: SurfaceZoomBounds
+): void {
+  if (!shouldHandleSurfaceZoomWheel(event)) {
+    return
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+  const surface = event.currentTarget instanceof HTMLDivElement ? event.currentTarget : null
+  const rect = surface?.getBoundingClientRect()
+  applyZoomChange(
+    (currentZoom) => getNextWheelSurfaceZoom(currentZoom, event.deltaY, event.deltaMode, bounds),
+    rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : null
+  )
+}

--- a/src/renderer/src/components/editor/anchored-surface-zoom.ts
+++ b/src/renderer/src/components/editor/anchored-surface-zoom.ts
@@ -1,0 +1,128 @@
+const DOM_DELTA_LINE = 1
+const DOM_DELTA_PAGE = 2
+const PIXELS_PER_LINE = 16
+const PIXELS_PER_PAGE = 800
+const MAX_NORMALIZED_WHEEL_DELTA = 200
+const WHEEL_ZOOM_SENSITIVITY = 300
+
+type SurfaceZoomWheelEventLike = {
+  ctrlKey: boolean
+  metaKey?: boolean
+}
+
+export type SurfaceZoomBounds = {
+  min: number
+  max: number
+}
+
+export type SurfaceContentDimensions = {
+  width: number
+  height: number
+}
+
+export type SurfaceSize = {
+  width: number
+  height: number
+}
+
+export type SurfaceZoomAnchor = {
+  x: number
+  y: number
+}
+
+export function clampSurfaceZoom(next: number, bounds: SurfaceZoomBounds): number {
+  return Math.min(bounds.max, Math.max(bounds.min, next))
+}
+
+export function shouldHandleSurfaceZoomWheel(event: SurfaceZoomWheelEventLike): boolean {
+  return event.ctrlKey || event.metaKey === true
+}
+
+export function getSurfacePinchZoomFactor(deltaY: number, deltaMode: number): number {
+  if (deltaY === 0) {
+    return 1
+  }
+
+  const normalizedDeltaY =
+    deltaMode === DOM_DELTA_LINE
+      ? deltaY * PIXELS_PER_LINE
+      : deltaMode === DOM_DELTA_PAGE
+        ? deltaY * PIXELS_PER_PAGE
+        : deltaY
+  const boundedDeltaY = Math.max(
+    -MAX_NORMALIZED_WHEEL_DELTA,
+    Math.min(MAX_NORMALIZED_WHEEL_DELTA, normalizedDeltaY)
+  )
+
+  return Math.exp(-boundedDeltaY / WHEEL_ZOOM_SENSITIVITY)
+}
+
+export function getNextWheelSurfaceZoom(
+  currentZoom: number,
+  deltaY: number,
+  deltaMode: number,
+  bounds: SurfaceZoomBounds
+): number {
+  return clampSurfaceZoom(currentZoom * getSurfacePinchZoomFactor(deltaY, deltaMode), bounds)
+}
+
+export function getZoomedSurfaceLayoutSize({
+  contentDimensions,
+  surfaceSize,
+  zoom,
+  bounds,
+  padding
+}: {
+  contentDimensions: SurfaceContentDimensions | null
+  surfaceSize: SurfaceSize | null
+  zoom: number
+  bounds: SurfaceZoomBounds
+  padding: number
+}): SurfaceContentDimensions | null {
+  if (
+    !contentDimensions ||
+    !surfaceSize ||
+    contentDimensions.width <= 0 ||
+    contentDimensions.height <= 0 ||
+    surfaceSize.width <= 0 ||
+    surfaceSize.height <= 0
+  ) {
+    return null
+  }
+
+  const availableWidth = Math.max(0, surfaceSize.width - padding * 2)
+  const availableHeight = Math.max(0, surfaceSize.height - padding * 2)
+  if (availableWidth <= 0 || availableHeight <= 0) {
+    return null
+  }
+
+  const fitScale = Math.min(
+    1,
+    availableWidth / contentDimensions.width,
+    availableHeight / contentDimensions.height
+  )
+  const boundedZoom = clampSurfaceZoom(zoom, bounds)
+
+  return {
+    width: contentDimensions.width * fitScale * boundedZoom,
+    height: contentDimensions.height * fitScale * boundedZoom
+  }
+}
+
+export function getAnchoredSurfaceScrollOffset({
+  scrollOffset,
+  anchorOffset,
+  currentZoom,
+  nextZoom
+}: {
+  scrollOffset: number
+  anchorOffset: number
+  currentZoom: number
+  nextZoom: number
+}): number {
+  if (currentZoom <= 0) {
+    return scrollOffset
+  }
+
+  return (scrollOffset + anchorOffset) * (nextZoom / currentZoom) - anchorOffset
+}

--- a/src/renderer/src/components/editor/diagram-surface-zoom.test.ts
+++ b/src/renderer/src/components/editor/diagram-surface-zoom.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_DIAGRAM_SURFACE_ZOOM,
+  MIN_DIAGRAM_SURFACE_ZOOM,
+  getDiagramSurfaceKeyboardZoomIntent,
+  getDraggedDiagramSurfaceScrollPosition,
+  getZoomedDiagramLayoutSize
+} from './diagram-surface-zoom'
+
+describe('diagram surface zoom helpers', () => {
+  it('fits large diagrams before applying user zoom', () => {
+    expect(
+      getZoomedDiagramLayoutSize({
+        diagramDimensions: { width: 1200, height: 600 },
+        surfaceSize: { width: 624, height: 424 },
+        zoom: 1
+      })
+    ).toEqual({ width: 576, height: 288 })
+
+    expect(
+      getZoomedDiagramLayoutSize({
+        diagramDimensions: { width: 1200, height: 600 },
+        surfaceSize: { width: 624, height: 424 },
+        zoom: 2
+      })
+    ).toEqual({ width: 1152, height: 576 })
+  })
+
+  it('does not upscale small diagrams at 100 percent', () => {
+    expect(
+      getZoomedDiagramLayoutSize({
+        diagramDimensions: { width: 200, height: 100 },
+        surfaceSize: { width: 800, height: 600 },
+        zoom: 1
+      })
+    ).toEqual({ width: 200, height: 100 })
+  })
+
+  it('clamps the layout zoom to diagram bounds', () => {
+    expect(
+      getZoomedDiagramLayoutSize({
+        diagramDimensions: { width: 100, height: 50 },
+        surfaceSize: { width: 800, height: 600 },
+        zoom: 0.01
+      })
+    ).toEqual({ width: 100 * MIN_DIAGRAM_SURFACE_ZOOM, height: 50 * MIN_DIAGRAM_SURFACE_ZOOM })
+
+    expect(
+      getZoomedDiagramLayoutSize({
+        diagramDimensions: { width: 100, height: 50 },
+        surfaceSize: { width: 800, height: 600 },
+        zoom: 20
+      })
+    ).toEqual({ width: 100 * MAX_DIAGRAM_SURFACE_ZOOM, height: 50 * MAX_DIAGRAM_SURFACE_ZOOM })
+  })
+
+  it('maps platform zoom shortcuts to diagram zoom intents', () => {
+    expect(
+      getDiagramSurfaceKeyboardZoomIntent(
+        { key: '+', code: 'Equal', ctrlKey: false, metaKey: true, altKey: false },
+        'darwin'
+      )
+    ).toBe('zoom-in')
+    expect(
+      getDiagramSurfaceKeyboardZoomIntent(
+        { key: '-', code: 'Minus', ctrlKey: true, metaKey: false, altKey: false },
+        'win32'
+      )
+    ).toBe('zoom-out')
+    expect(
+      getDiagramSurfaceKeyboardZoomIntent(
+        { key: '0', code: 'Digit0', ctrlKey: true, metaKey: false, altKey: false },
+        'linux'
+      )
+    ).toBe('reset')
+  })
+
+  it('ignores non-platform zoom modifiers', () => {
+    expect(
+      getDiagramSurfaceKeyboardZoomIntent(
+        { key: '+', code: 'Equal', ctrlKey: true, metaKey: false, altKey: false },
+        'darwin'
+      )
+    ).toBeNull()
+    expect(
+      getDiagramSurfaceKeyboardZoomIntent(
+        { key: '+', code: 'Equal', ctrlKey: false, metaKey: true, altKey: false },
+        'win32'
+      )
+    ).toBeNull()
+    expect(
+      getDiagramSurfaceKeyboardZoomIntent(
+        { key: '+', code: 'Equal', ctrlKey: true, metaKey: false, altKey: true },
+        'linux'
+      )
+    ).toBeNull()
+  })
+
+  it('converts drag distance into scroll position', () => {
+    expect(
+      getDraggedDiagramSurfaceScrollPosition({
+        start: { clientX: 300, clientY: 200, scrollLeft: 80, scrollTop: 50 },
+        clientX: 240,
+        clientY: 260
+      })
+    ).toEqual({ scrollLeft: 140, scrollTop: -10 })
+  })
+})

--- a/src/renderer/src/components/editor/diagram-surface-zoom.ts
+++ b/src/renderer/src/components/editor/diagram-surface-zoom.ts
@@ -1,0 +1,100 @@
+import type { SurfaceContentDimensions, SurfaceSize } from './anchored-surface-zoom'
+import { getZoomedSurfaceLayoutSize } from './anchored-surface-zoom'
+
+export const MIN_DIAGRAM_SURFACE_ZOOM = 0.25
+export const MAX_DIAGRAM_SURFACE_ZOOM = 8
+export const DIAGRAM_SURFACE_ZOOM_STEP = 1.25
+export const DIAGRAM_SURFACE_PADDING = 24
+export const DIAGRAM_SURFACE_ZOOM_BOUNDS = {
+  min: MIN_DIAGRAM_SURFACE_ZOOM,
+  max: MAX_DIAGRAM_SURFACE_ZOOM
+}
+
+export type DiagramSurfaceDimensions = SurfaceContentDimensions
+export type DiagramSurfaceSize = SurfaceSize
+export type DiagramSurfaceKeyboardZoomIntent = 'zoom-in' | 'zoom-out' | 'reset'
+
+type DiagramSurfaceKeyboardZoomEvent = {
+  altKey: boolean
+  code: string
+  ctrlKey: boolean
+  key: string
+  metaKey: boolean
+}
+
+export type DiagramSurfacePanStart = {
+  clientX: number
+  clientY: number
+  scrollLeft: number
+  scrollTop: number
+}
+
+export function getDiagramSurfaceKeyboardZoomIntent(
+  event: DiagramSurfaceKeyboardZoomEvent,
+  platform: NodeJS.Platform
+): DiagramSurfaceKeyboardZoomIntent | null {
+  const isMac = platform === 'darwin'
+  const hasPlatformModifier = isMac
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey
+  if (!hasPlatformModifier || event.altKey) {
+    return null
+  }
+
+  if (
+    event.key === '+' ||
+    event.key === '=' ||
+    event.code === 'Equal' ||
+    event.code === 'NumpadAdd'
+  ) {
+    return 'zoom-in'
+  }
+  if (
+    event.key === '-' ||
+    event.key === '_' ||
+    event.code === 'Minus' ||
+    event.code === 'NumpadSubtract'
+  ) {
+    return 'zoom-out'
+  }
+  if (event.key === '0' || event.code === 'Digit0' || event.code === 'Numpad0') {
+    return 'reset'
+  }
+
+  return null
+}
+
+export function getDraggedDiagramSurfaceScrollPosition({
+  start,
+  clientX,
+  clientY
+}: {
+  start: DiagramSurfacePanStart
+  clientX: number
+  clientY: number
+}): { scrollLeft: number; scrollTop: number } {
+  return {
+    scrollLeft: start.scrollLeft - (clientX - start.clientX),
+    scrollTop: start.scrollTop - (clientY - start.clientY)
+  }
+}
+
+export function getZoomedDiagramLayoutSize({
+  diagramDimensions,
+  surfaceSize,
+  zoom,
+  padding = DIAGRAM_SURFACE_PADDING
+}: {
+  diagramDimensions: DiagramSurfaceDimensions | null
+  surfaceSize: DiagramSurfaceSize | null
+  zoom: number
+  padding?: number
+}): DiagramSurfaceDimensions | null {
+  return getZoomedSurfaceLayoutSize({
+    contentDimensions: diagramDimensions,
+    surfaceSize,
+    zoom,
+    bounds: DIAGRAM_SURFACE_ZOOM_BOUNDS,
+    padding
+  })
+}

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
@@ -1,14 +1,16 @@
 import type { CSSProperties, Dispatch, SetStateAction } from 'react'
-import { flushSync } from 'react-dom'
 import {
   type ImageViewerImageDimensions,
   type ImageViewerSurfaceSize,
   type ImageViewerZoomAnchor,
-  clampImageViewerZoom,
-  getAnchoredImageViewerScrollOffset,
-  getNextWheelImageViewerZoom,
-  shouldHandleImageZoomWheel
+  IMAGE_VIEWER_ZOOM_BOUNDS
 } from './image-viewer-zoom'
+import {
+  applyAnchoredSurfaceZoomChange,
+  applySurfaceWheel,
+  getElementSurfaceSize as getSurfaceElementSize,
+  getSurfaceLayoutStyle
+} from './anchored-surface-dom-zoom'
 
 export type ApplyImageViewerZoomChange = (
   getNextZoom: (currentZoom: number) => number,
@@ -16,23 +18,13 @@ export type ApplyImageViewerZoomChange = (
 ) => void
 
 export function getElementSurfaceSize(element: HTMLElement): ImageViewerSurfaceSize {
-  return {
-    width: element.clientWidth,
-    height: element.clientHeight
-  }
+  return getSurfaceElementSize(element)
 }
 
 export function getImageLayoutStyle(
   size: ImageViewerImageDimensions | null
 ): CSSProperties | undefined {
-  if (!size) {
-    return undefined
-  }
-
-  return {
-    width: `${size.width}px`,
-    height: `${size.height}px`
-  }
+  return getSurfaceLayoutStyle(size)
 }
 
 export function applyAnchoredImageViewerZoomChange(
@@ -41,54 +33,12 @@ export function applyAnchoredImageViewerZoomChange(
   getNextZoom: (currentZoom: number) => number,
   anchor?: ImageViewerZoomAnchor | null
 ): void {
-  const resolvedAnchor = surface
-    ? (anchor ?? { x: surface.clientWidth / 2, y: surface.clientHeight / 2 })
-    : null
-  const scrollLeft = surface?.scrollLeft ?? 0
-  const scrollTop = surface?.scrollTop ?? 0
-  let currentZoom = 1
-  let nextZoom = 1
-
-  flushSync(() => {
-    setZoom((current) => {
-      currentZoom = current
-      nextZoom = clampImageViewerZoom(getNextZoom(current))
-      return nextZoom
-    })
-  })
-
-  if (!surface || !resolvedAnchor || currentZoom === nextZoom) {
-    return
-  }
-
-  surface.scrollLeft = getAnchoredImageViewerScrollOffset({
-    scrollOffset: scrollLeft,
-    anchorOffset: resolvedAnchor.x,
-    currentZoom,
-    nextZoom
-  })
-  surface.scrollTop = getAnchoredImageViewerScrollOffset({
-    scrollOffset: scrollTop,
-    anchorOffset: resolvedAnchor.y,
-    currentZoom,
-    nextZoom
-  })
+  applyAnchoredSurfaceZoomChange(surface, setZoom, getNextZoom, IMAGE_VIEWER_ZOOM_BOUNDS, anchor)
 }
 
 export function applyImageSurfaceWheel(
   event: WheelEvent,
   applyZoomChange: ApplyImageViewerZoomChange
 ): void {
-  if (!shouldHandleImageZoomWheel(event)) {
-    return
-  }
-
-  event.preventDefault()
-  event.stopPropagation()
-  const surface = event.currentTarget instanceof HTMLDivElement ? event.currentTarget : null
-  const rect = surface?.getBoundingClientRect()
-  applyZoomChange(
-    (currentZoom) => getNextWheelImageViewerZoom(currentZoom, event.deltaY, event.deltaMode),
-    rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : null
-  )
+  applySurfaceWheel(event, applyZoomChange, IMAGE_VIEWER_ZOOM_BOUNDS)
 }

--- a/src/renderer/src/components/editor/image-viewer-zoom.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-zoom.test.ts
@@ -17,8 +17,9 @@ describe('image viewer zoom helpers', () => {
     expect(clampImageViewerZoom(20)).toBe(MAX_IMAGE_VIEWER_ZOOM)
   })
 
-  it('handles only ctrl-wheel input as image zoom', () => {
+  it('handles modifier-wheel input as image zoom', () => {
     expect(shouldHandleImageZoomWheel({ ctrlKey: true })).toBe(true)
+    expect(shouldHandleImageZoomWheel({ ctrlKey: false, metaKey: true })).toBe(true)
     expect(shouldHandleImageZoomWheel({ ctrlKey: false })).toBe(false)
   })
 

--- a/src/renderer/src/components/editor/image-viewer-zoom.ts
+++ b/src/renderer/src/components/editor/image-viewer-zoom.ts
@@ -1,59 +1,43 @@
+import {
+  type SurfaceContentDimensions,
+  type SurfaceSize,
+  type SurfaceZoomAnchor,
+  clampSurfaceZoom,
+  getAnchoredSurfaceScrollOffset,
+  getNextWheelSurfaceZoom,
+  getSurfacePinchZoomFactor,
+  getZoomedSurfaceLayoutSize,
+  shouldHandleSurfaceZoomWheel
+} from './anchored-surface-zoom'
+
 export const MIN_IMAGE_VIEWER_ZOOM = 0.25
 export const MAX_IMAGE_VIEWER_ZOOM = 8
 export const IMAGE_VIEWER_ZOOM_STEP = 1.25
 export const IMAGE_VIEWER_SURFACE_PADDING = 16
-
-const DOM_DELTA_LINE = 1
-const DOM_DELTA_PAGE = 2
-const PIXELS_PER_LINE = 16
-const PIXELS_PER_PAGE = 800
-const MAX_NORMALIZED_WHEEL_DELTA = 200
-const WHEEL_ZOOM_SENSITIVITY = 300
+export const IMAGE_VIEWER_ZOOM_BOUNDS = {
+  min: MIN_IMAGE_VIEWER_ZOOM,
+  max: MAX_IMAGE_VIEWER_ZOOM
+}
 
 type ImageZoomWheelEventLike = {
   ctrlKey: boolean
+  metaKey?: boolean
 }
 
-export type ImageViewerImageDimensions = {
-  width: number
-  height: number
-}
-
-export type ImageViewerSurfaceSize = {
-  width: number
-  height: number
-}
-
-export type ImageViewerZoomAnchor = {
-  x: number
-  y: number
-}
+export type ImageViewerImageDimensions = SurfaceContentDimensions
+export type ImageViewerSurfaceSize = SurfaceSize
+export type ImageViewerZoomAnchor = SurfaceZoomAnchor
 
 export function clampImageViewerZoom(next: number): number {
-  return Math.min(MAX_IMAGE_VIEWER_ZOOM, Math.max(MIN_IMAGE_VIEWER_ZOOM, next))
+  return clampSurfaceZoom(next, IMAGE_VIEWER_ZOOM_BOUNDS)
 }
 
 export function shouldHandleImageZoomWheel(event: ImageZoomWheelEventLike): boolean {
-  return event.ctrlKey
+  return shouldHandleSurfaceZoomWheel(event)
 }
 
 export function getPinchZoomFactor(deltaY: number, deltaMode: number): number {
-  if (deltaY === 0) {
-    return 1
-  }
-
-  const normalizedDeltaY =
-    deltaMode === DOM_DELTA_LINE
-      ? deltaY * PIXELS_PER_LINE
-      : deltaMode === DOM_DELTA_PAGE
-        ? deltaY * PIXELS_PER_PAGE
-        : deltaY
-  const boundedDeltaY = Math.max(
-    -MAX_NORMALIZED_WHEEL_DELTA,
-    Math.min(MAX_NORMALIZED_WHEEL_DELTA, normalizedDeltaY)
-  )
-
-  return Math.exp(-boundedDeltaY / WHEEL_ZOOM_SENSITIVITY)
+  return getSurfacePinchZoomFactor(deltaY, deltaMode)
 }
 
 export function getNextWheelImageViewerZoom(
@@ -61,7 +45,7 @@ export function getNextWheelImageViewerZoom(
   deltaY: number,
   deltaMode: number
 ): number {
-  return clampImageViewerZoom(currentZoom * getPinchZoomFactor(deltaY, deltaMode))
+  return getNextWheelSurfaceZoom(currentZoom, deltaY, deltaMode, IMAGE_VIEWER_ZOOM_BOUNDS)
 }
 
 export function getZoomedImageLayoutSize({
@@ -75,36 +59,15 @@ export function getZoomedImageLayoutSize({
   zoom: number
   padding?: number
 }): ImageViewerImageDimensions | null {
-  if (
-    !imageDimensions ||
-    !surfaceSize ||
-    imageDimensions.width <= 0 ||
-    imageDimensions.height <= 0 ||
-    surfaceSize.width <= 0 ||
-    surfaceSize.height <= 0
-  ) {
-    return null
-  }
-
-  const availableWidth = Math.max(0, surfaceSize.width - padding * 2)
-  const availableHeight = Math.max(0, surfaceSize.height - padding * 2)
-  if (availableWidth <= 0 || availableHeight <= 0) {
-    return null
-  }
-
-  const fitScale = Math.min(
-    1,
-    availableWidth / imageDimensions.width,
-    availableHeight / imageDimensions.height
-  )
-  const boundedZoom = clampImageViewerZoom(zoom)
-
   // Why: transformed images do not change scroll extents, so zoom must resize
   // the layout box for popup panning to reach the full image.
-  return {
-    width: imageDimensions.width * fitScale * boundedZoom,
-    height: imageDimensions.height * fitScale * boundedZoom
-  }
+  return getZoomedSurfaceLayoutSize({
+    contentDimensions: imageDimensions,
+    surfaceSize,
+    zoom,
+    bounds: IMAGE_VIEWER_ZOOM_BOUNDS,
+    padding
+  })
 }
 
 export function getAnchoredImageViewerScrollOffset({
@@ -118,9 +81,10 @@ export function getAnchoredImageViewerScrollOffset({
   currentZoom: number
   nextZoom: number
 }): number {
-  if (currentZoom <= 0) {
-    return scrollOffset
-  }
-
-  return (scrollOffset + anchorOffset) * (nextZoom / currentZoom) - anchorOffset
+  return getAnchoredSurfaceScrollOffset({
+    scrollOffset,
+    anchorOffset,
+    currentZoom,
+    nextZoom
+  })
 }

--- a/src/renderer/src/components/editor/mermaid-text-diagram-view-modes.ts
+++ b/src/renderer/src/components/editor/mermaid-text-diagram-view-modes.ts
@@ -1,0 +1,29 @@
+import { translate } from '@/i18n/i18n'
+
+export type MermaidTextDiagramMode = 'code' | 'split' | 'chart'
+
+type MermaidTextDiagramModeOption = {
+  value: MermaidTextDiagramMode
+  label: string
+}
+
+const MERMAID_TEXT_DIAGRAM_MODES = ['code', 'split', 'chart'] as const
+
+const MERMAID_TEXT_DIAGRAM_MODE_LABELS = {
+  code: 'Code',
+  split: 'Split',
+  chart: 'Chart'
+} as const satisfies Record<MermaidTextDiagramMode, string>
+
+export function getMermaidTextDiagramModeOptions(
+  i18nPrefix: string
+): readonly MermaidTextDiagramModeOption[] {
+  return MERMAID_TEXT_DIAGRAM_MODES.map((mode) => ({
+    value: mode,
+    label: translate(`${i18nPrefix}.${mode}`, MERMAID_TEXT_DIAGRAM_MODE_LABELS[mode])
+  }))
+}
+
+export function isMermaidTextDiagramMode(value: string): value is MermaidTextDiagramMode {
+  return (MERMAID_TEXT_DIAGRAM_MODES as readonly string[]).includes(value)
+}

--- a/src/renderer/src/components/editor/use-debounced-mermaid-diagram-content.ts
+++ b/src/renderer/src/components/editor/use-debounced-mermaid-diagram-content.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export const MERMAID_RENDER_DEBOUNCE_MS = 250
+
+export function useDebouncedMermaidDiagramContent(content: string): string {
+  const [debouncedContent, setDebouncedContent] = useState(content)
+
+  useEffect(() => {
+    if (content.length === 0) {
+      setDebouncedContent('')
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      setDebouncedContent(content)
+    }, MERMAID_RENDER_DEBOUNCE_MS)
+    return () => window.clearTimeout(timer)
+  }, [content])
+
+  return debouncedContent
+}

--- a/src/renderer/src/components/editor/use-debounced-mermaid-diagram-content.ts
+++ b/src/renderer/src/components/editor/use-debounced-mermaid-diagram-content.ts
@@ -1,11 +1,18 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export const MERMAID_RENDER_DEBOUNCE_MS = 250
 
-export function useDebouncedMermaidDiagramContent(content: string): string {
+export function useDebouncedMermaidDiagramContent(content: string, resetKey?: unknown): string {
   const [debouncedContent, setDebouncedContent] = useState(content)
+  const previousResetKeyRef = useRef(resetKey)
 
   useEffect(() => {
+    if (resetKey !== previousResetKeyRef.current) {
+      previousResetKeyRef.current = resetKey
+      setDebouncedContent(content)
+      return
+    }
+
     if (content.length === 0) {
       setDebouncedContent('')
       return
@@ -15,7 +22,7 @@ export function useDebouncedMermaidDiagramContent(content: string): string {
       setDebouncedContent(content)
     }, MERMAID_RENDER_DEBOUNCE_MS)
     return () => window.clearTimeout(timer)
-  }, [content])
+  }, [content, resetKey])
 
   return debouncedContent
 }


### PR DESCRIPTION
## Summary

Adds editable Mermaid diagram views for both markdown-embedded Mermaid fences and standalone `.mmd` / `.mermaid` files. Mermaid blocks now support Code / Split / Chart modes, standalone Mermaid files can edit source in Code and Split with live rerendering, and rendered diagrams share a zoomable canvas with anchored modifier-wheel zoom, keyboard zoom shortcuts, and drag panning.

Review fixes applied across three commits:
1. First follow-up: kept draft edits from being clobbered by same-file content echoes, debounced Mermaid rendering while source text is changing, moved wheel listener cleanup into an effect lifecycle, removed unnecessary MutationObserver churn, shared the Mermaid mode contract across both views, and added read-only/draft regression coverage.
2. Second follow-up: fixed stale diagram render on file switch (debounce hook now accepts a resetKey and flushes immediately when the file changes; file-sync moved to render-time state update so the debounce sees fresh content).

## Screenshots

| After |
|-------|
| ![Markdown Mermaid split view](https://raw.githubusercontent.com/Pr1p/orca/a67989e77fbbabb59684f348a895ed4dd82cb3bd/.github/pr-screenshots/11404-markdown-mermaid-split-view.png) |

## Testing

- [x] `pnpm typecheck` — passed (tsc across node, cli, and web configs)
- [x] `pnpm lint` (changed files) — oxlint passed on all 15 changed editor files with `--report-unused-disable-directives-severity warn`
- [ ] `pnpm test` (full) — times out on this Windows worktree (10 min, no log progress); targeted and editor-level runs below
- [ ] `pnpm build` — not run locally

Validation run:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MermaidViewer.test.tsx src/renderer/src/components/editor/diagram-surface-zoom.test.ts src/renderer/src/components/editor/image-viewer-zoom.test.ts` — passed, 3 files / 24 tests
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/` — 151 files / 990 tests: 989 passed, 1 failed (`monaco-content-sync.undo-history.test.ts`, a pre-existing Windows `\r\n` vs `\n` issue unrelated to this PR)
- `pnpm exec oxlint --report-unused-disable-directives-severity warn` over all 15 changed editor files — passed
- `pnpm run typecheck` — passed
- `pnpm dlx react-doctor@0.9.1 . --yes --scope lines --base origin/main --include-untracked --no-dead-code --no-supply-chain --no-telemetry --blocking error` — passed with non-blocking warnings only
- `git diff --cached --check` — passed before commit

Notes on failed/local-only checks:

- `pnpm run check:code-quality:changed` failed before scanning because Node hit `spawnSync pnpm.cmd EINVAL` on Windows; the equivalent printed oxlint command was run manually and passed.
- `pnpm run check:react-doctor:changed` failed for the same `spawnSync pnpm.cmd EINVAL`; the equivalent direct React Doctor command was run manually and passed.
- Full `pnpm test` was attempted from this Windows worktree. It timed out after 10 minutes with no further log output. The `src/renderer/src/components/editor/` suite (the scope of this PR) completed with 989/990 tests passing; the single failure is a pre-existing Windows line-ending issue in an unrelated Monaco test.

## AI Review Report

AI review checked the Mermaid editing flow, zoom math, event listener cleanup, and integration points in rich markdown, standalone Mermaid files, and the existing image viewer zoom path. It specifically checked cross-platform compatibility for macOS, Linux, and Windows: keyboard zoom uses the platform shortcut helper instead of hardcoding `metaKey`, UI labels are text-based, file path handling remains in existing editor plumbing, and the change does not add shell behavior. It also checked SSH/folder-workspace assumptions and kept the feature in renderer-local UI code without assuming a local git worktree.

Greptile feedback has been addressed: same-file `content` prop echoes no longer overwrite in-flight Mermaid drafts, wheel listener registration now has an effect cleanup path, and the diagram MutationObserver no longer depends on freshly-created React children. CodeRabbit feedback has also been addressed: Code/Split/Chart mode definitions are shared, Mermaid rendering is debounced, diagram padding is cross-referenced with the fit math via `--diagram-surface-padding`, read-only save behavior is covered by tests, and file-switch stale rendering is fixed (debounce flushes immediately on resetKey change, file-sync moved to render-time state update).

Main risks reviewed were editor focus conflicts, diagram zoom jitter while source is edited, stale SVG measurements, and accidentally hijacking markdown/source editing shortcuts. The implementation keeps source edits immediate while debouncing expensive diagram rerenders, keeps zoom stable across edits, scopes pointer/wheel/keyboard handlers to the diagram surface, and tests live rerendering, read-only behavior, draft preservation, file-switch flush, keyboard zoom intent, drag panning math, and modifier-wheel zoom behavior.

## Security Audit

The change does not add command execution, IPC, authentication, secret handling, dependency changes, or provider/network access. User-provided Mermaid text continues to render through the existing MermaidBlock path, which sanitizes SVG output with DOMPurify and forces SVG-native labels for compatibility with the SVG sanitization profile. New pointer, wheel, and keyboard handlers are scoped to the diagram surface and clean up listeners on unmount/blur; no filesystem paths are newly parsed beyond passing through existing editor file props.

No follow-up security work is currently known.

## Notes

- X/Twitter handle: not provided.