### PR TITLE
fix(settings): reserve skill badges for attention

### DIFF
--- a/src/renderer/src/components/settings/SettingsSidebar.test.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.test.tsx
@@ -72,6 +72,12 @@ function renderSidebar(
                 installStatus: 'up-to-date'
               },
               {
+                id: 'voice-loading',
+                title: 'Voice Loading',
+                icon: Mic,
+                installStatus: 'checking'
+              },
+              {
                 id: 'linear',
                 title: 'Linear',
                 icon: GitBranch,
@@ -144,6 +150,7 @@ describe('SettingsSidebar', () => {
     expect(markup).not.toContain('Not installed')
     expect(markup).not.toContain('Installed')
     expect(markup).not.toContain('Up to date')
+    expect(markup).not.toContain('Checking...')
     expect(markup).toContain('Update available')
     expect(markup).toContain('Review skill')
     expect(markup).toContain('Optional')

--- a/src/renderer/src/components/settings/SettingsSidebar.test.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { renderToStaticMarkup } from 'react-dom/server'
-import { Bot, Mic, Network, Puzzle } from 'lucide-react'
+import { Bot, GitBranch, Mic, Network, Puzzle } from 'lucide-react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
 import { SettingsSidebar } from './SettingsSidebar'
@@ -72,6 +72,18 @@ function renderSidebar(
                 installStatus: 'up-to-date'
               },
               {
+                id: 'linear',
+                title: 'Linear',
+                icon: GitBranch,
+                installStatus: 'update-available'
+              },
+              {
+                id: 'ephemeral-vms',
+                title: 'Ephemeral VMs',
+                icon: Bot,
+                installStatus: 'needs-attention'
+              },
+              {
                 id: 'plugins',
                 title: 'Plugins',
                 icon: Puzzle
@@ -126,12 +138,14 @@ describe('SettingsSidebar', () => {
     expect(markup).toContain('--worktree-sidebar-foreground:#f0f4f8')
   })
 
-  it('renders install state labels separately from static badges', () => {
+  it('reserves install state labels for actionable skill states', () => {
     const markup = renderSidebar()
 
-    expect(markup).toContain('Not installed')
-    expect(markup).toContain('Installed')
-    expect(markup).toContain('Up to date')
+    expect(markup).not.toContain('Not installed')
+    expect(markup).not.toContain('Installed')
+    expect(markup).not.toContain('Up to date')
+    expect(markup).toContain('Update available')
+    expect(markup).toContain('Review skill')
     expect(markup).toContain('Optional')
   })
 

--- a/src/renderer/src/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.tsx
@@ -60,6 +60,17 @@ type SettingsSidebarProps = {
   ) => void
 }
 
+type VisibleInstallStatus = Extract<
+  SettingsNavInstallStatus,
+  'update-available' | 'needs-attention'
+>
+
+function isVisibleInstallStatus(
+  status: SettingsNavInstallStatus | undefined
+): status is VisibleInstallStatus {
+  return status === 'update-available' || status === 'needs-attention'
+}
+
 type SettingsSetupGuideRowProps = {
   progress: SettingsSetupGuideProgress
   setupActive: boolean
@@ -146,17 +157,8 @@ export function SettingsSidebar({
         ? 'bg-worktree-sidebar-accent font-medium text-worktree-sidebar-accent-foreground ring-1 ring-worktree-sidebar-ring/25'
         : 'text-worktree-sidebar-foreground/60 hover:bg-worktree-sidebar-accent/60 hover:text-worktree-sidebar-foreground'
     )
-  const installStatusLabel = (status: SettingsNavInstallStatus): string => {
+  const installStatusLabel = (status: VisibleInstallStatus): string => {
     switch (status) {
-      case 'install':
-        return translate(
-          'auto.components.settings.AgentSkillSetupPanel.5289300939',
-          'Not installed'
-        )
-      case 'installed':
-        return translate('auto.components.settings.AgentSkillSetupPanel.9fcebceb2a', 'Installed')
-      case 'up-to-date':
-        return translate('auto.components.skills.SkillFreshnessStatusPill.upToDate', 'Up to date')
       case 'update-available':
         return translate(
           'auto.components.skills.SkillFreshnessStatusPill.updateAvailable',
@@ -165,23 +167,12 @@ export function SettingsSidebar({
       case 'needs-attention':
         return translate(
           'auto.components.skills.SkillFreshnessStatusPill.needsAttention',
-          'Needs attention'
+          'Review skill'
         )
-      case 'checking':
-        return translate('auto.components.settings.AgentSkillSetupPanel.68a468752e', 'Checking...')
     }
   }
-  const installStatusClassName = (status: SettingsNavInstallStatus): string =>
-    cn(
-      'ml-auto shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-medium leading-none',
-      status === 'installed' || status === 'up-to-date'
-        ? 'border-status-success-border bg-status-success-background text-status-success'
-        : status === 'update-available' || status === 'needs-attention'
-          ? 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300'
-          : status === 'install'
-            ? 'border-foreground/15 bg-foreground/10 text-foreground'
-            : 'border-border/50 bg-muted/30 text-muted-foreground'
-    )
+  const installStatusClassName =
+    'ml-auto shrink-0 rounded-full border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-amber-700 dark:text-amber-300'
 
   return (
     <aside
@@ -270,8 +261,8 @@ export function SettingsSidebar({
                       >
                         <Icon className="size-4 shrink-0" />
                         <span className="truncate">{section.title}</span>
-                        {section.installStatus ? (
-                          <span className={installStatusClassName(section.installStatus)}>
+                        {isVisibleInstallStatus(section.installStatus) ? (
+                          <span className={installStatusClassName}>
                             {installStatusLabel(section.installStatus)}
                           </span>
                         ) : section.badge ? (

--- a/src/renderer/src/components/skills/SkillFreshnessStatusPill.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessStatusPill.test.tsx
@@ -117,7 +117,7 @@ describe('SkillFreshnessStatusPill', () => {
 
     const rendered = await renderPill('orca-cli')
     // Why: a green pill over a copy the update cannot reach hides real drift.
-    expect(pillText(rendered)).toBe('Needs attention')
+    expect(pillText(rendered)).toBe('Review skill')
     expect(detailsButton(rendered)?.textContent).toBe('Details')
   })
 

--- a/src/renderer/src/components/skills/SkillFreshnessStatusPill.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessStatusPill.tsx
@@ -27,7 +27,7 @@ function statusPill(status: SkillFreshnessDisplayStatus): React.JSX.Element {
       <IntegrationStatusPill tone="attention">
         {translate(
           'auto.components.skills.SkillFreshnessStatusPill.needsAttention',
-          'Needs attention'
+          'Review skill'
         )}
       </IntegrationStatusPill>
     )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3893,7 +3893,7 @@
           "upToDate": "Up to date",
           "installed": "Installed",
           "details": "Details",
-          "needsAttention": "Needs attention"
+          "needsAttention": "Review skill"
         }
       },
       "sidebar": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3863,7 +3863,7 @@
           "upToDate": "Actualizado",
           "installed": "Instalado",
           "details": "Details",
-          "needsAttention": "Needs attention"
+          "needsAttention": "Review skill"
         },
         "SkillUpdateResultRows": {
           "stillOutdated": "Still out of date after the update ran."

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3863,7 +3863,7 @@
           "upToDate": "最新です",
           "installed": "インストール済み",
           "details": "Details",
-          "needsAttention": "Needs attention"
+          "needsAttention": "Review skill"
         },
         "SkillUpdateResultRows": {
           "stillOutdated": "Still out of date after the update ran."

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3863,7 +3863,7 @@
           "upToDate": "최신 상태",
           "installed": "설치됨",
           "details": "Details",
-          "needsAttention": "Needs attention"
+          "needsAttention": "Review skill"
         },
         "SkillUpdateResultRows": {
           "stillOutdated": "Still out of date after the update ran."

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3863,7 +3863,7 @@
           "upToDate": "已是最新",
           "installed": "已安装",
           "details": "Details",
-          "needsAttention": "Needs attention"
+          "needsAttention": "Review skill"
         },
         "SkillUpdateResultRows": {
           "stillOutdated": "Still out of date after the update ran."


### PR DESCRIPTION
## Summary

- Hide healthy, loading, and optional not-installed skill badges from the Settings sidebar so navigation stays quiet.
- Keep actionable freshness badges visible: `Update available` when Orca can update the skill and `Review skill` when a copy needs manual attention.
- Preserve the detailed skill-card status while aligning its manual-review copy with the sidebar.

## Screenshots

Healthy, loading, and not-installed skill rows stay quiet; the unrelated Optional account badge remains. Verified in the live Electron build in both dark and light themes.

Dark theme:

![Settings sidebar with healthy skill labels hidden in dark theme](https://github.com/user-attachments/assets/46695025-0619-44a3-bfed-549a53fac492)

Light theme:

![Settings sidebar with healthy skill labels hidden in light theme](https://github.com/user-attachments/assets/2ba62550-02b1-44eb-b521-bd896c45e6d1)

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/SettingsSidebar.test.tsx src/renderer/src/components/skills/SkillFreshnessStatusPill.test.tsx` — 11 passed
- `pnpm run typecheck:web` — passed
- Changed-file `oxlint` and React Doctor — passed
- `pnpm run verify:localization-catalog` — passed
- `pnpm run verify:localization-coverage` — passed
- `pnpm run check:max-lines-ratchet` — passed
- Dev renderer/main/preload build and manual Settings smoke test — passed

## AI Review Report

Reviewed the status filtering and copy against the freshness-state contract introduced in #10436. The main risks checked were accidentally hiding actionable update states, presenting a manual-repair state as an automatic update, and suppressing unrelated static badges. The implementation narrows visible install statuses to `update-available` and `needs-attention`; tests cover hidden healthy/presence states, both visible attention states, and the preserved Optional badge.

Cross-platform compatibility was explicitly reviewed for macOS, Linux, and Windows. This is renderer-only status presentation: it changes no shortcuts or shortcut labels, paths, shell behavior, Electron APIs, Git commands, host routing, SSH behavior, or folder-workspace behavior.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, IPC, network access, or persisted state. The change only filters already-derived status values and updates localized display copy. No security follow-up is needed.

## Notes

`Review skill` intentionally remains distinct from `Update available`: the former can represent stale duplicates, edited copies, inaccessible paths, or other conditions Orca's updater cannot safely resolve.
