### PR TITLE
fix(opencode): honor scanner config directory

### DIFF
--- a/src/main/ai-vault/session-scanner-opencode-sources.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sources.test.ts
@@ -21,9 +21,55 @@ describe('opencodeDiscoveries', () => {
     vi.clearAllMocks()
   })
 
-  it('discovers local storage from the OpenCode XDG data directory', async () => {
+  it('prefers the OpenCode config directory for local storage', async () => {
     vi.stubEnv('XDG_DATA_HOME', '/xdg/data')
-    vi.stubEnv('OPENCODE_CONFIG_DIR', '/opencode/config')
+    vi.stubEnv('OPENCODE_CONFIG_DIR', ' /opencode/config ')
+    listOpenCodeDatabasesMock.mockResolvedValue([])
+    discoverOpenCodeSessionsMock.mockResolvedValue({
+      agent: 'opencode',
+      rootDir: '/opencode/config/storage',
+      files: []
+    })
+    const issues = []
+
+    await Promise.all(opencodeDiscoveries({}, [], 25, issues))
+
+    expect(discoverOpenCodeSessionsMock).toHaveBeenCalledWith({
+      storageDir: join('/opencode/config', 'storage'),
+      dbPaths: [],
+      limitPerAgent: 25,
+      issues
+    })
+  })
+
+  it('keeps WSL discovery on the guest data path', async () => {
+    vi.stubEnv('OPENCODE_CONFIG_DIR', '/windows/opencode/config')
+    discoverOpenCodeSessionsMock.mockResolvedValue({
+      agent: 'opencode',
+      rootDir: '/home/wsl/.local/share/opencode/storage',
+      files: []
+    })
+    const issues = []
+
+    await Promise.all(opencodeDiscoveries({ opencodeDbPaths: [] }, ['/home/wsl'], 25, issues))
+
+    expect(discoverOpenCodeSessionsMock).toHaveBeenNthCalledWith(1, {
+      storageDir: join('/windows/opencode/config', 'storage'),
+      dbPaths: [],
+      limitPerAgent: 25,
+      issues
+    })
+    expect(discoverOpenCodeSessionsMock).toHaveBeenNthCalledWith(2, {
+      storageDir: join('/home/wsl', '.local', 'share', 'opencode', 'storage'),
+      dbPaths: [],
+      limitPerAgent: 25,
+      issues
+    })
+  })
+
+  it('falls back to the OpenCode XDG data directory', async () => {
+    vi.stubEnv('XDG_DATA_HOME', '/xdg/data')
+    vi.stubEnv('OPENCODE_CONFIG_DIR', '   ')
     listOpenCodeDatabasesMock.mockResolvedValue([])
     discoverOpenCodeSessionsMock.mockResolvedValue({
       agent: 'opencode',

--- a/src/main/opencode/opencode-data-directory.test.ts
+++ b/src/main/opencode/opencode-data-directory.test.ts
@@ -38,9 +38,24 @@ describe('resolveOpenCodeDataDirectory', () => {
     }
   )
 
-  it('derives legacy storage from the same data directory', () => {
-    expect(resolveOpenCodeStorageDirectory({}, '/users/test')).toBe(
-      join('/users/test', '.local', 'share', 'opencode', 'storage')
-    )
+  it('prefers OPENCODE_CONFIG_DIR for legacy storage', () => {
+    expect(
+      resolveOpenCodeStorageDirectory(
+        {
+          OPENCODE_CONFIG_DIR: ' /custom/config ',
+          XDG_DATA_HOME: '/custom/data'
+        },
+        '/users/test'
+      )
+    ).toBe(join('/custom/config', 'storage'))
+  })
+
+  it('derives legacy storage from the data directory without a config override', () => {
+    expect(
+      resolveOpenCodeStorageDirectory(
+        { OPENCODE_CONFIG_DIR: ' ', XDG_DATA_HOME: '/custom/data' },
+        '/users/test'
+      )
+    ).toBe(join('/custom/data', 'opencode', 'storage'))
   })
 })

--- a/src/main/opencode/opencode-data-directory.ts
+++ b/src/main/opencode/opencode-data-directory.ts
@@ -13,5 +13,9 @@ export function resolveOpenCodeStorageDirectory(
   environment: NodeJS.ProcessEnv = process.env,
   homeDirectory = homedir()
 ): string {
-  return join(resolveOpenCodeDataDirectory(environment, homeDirectory), 'storage')
+  const configDirectory = environment.OPENCODE_CONFIG_DIR?.trim()
+  return join(
+    configDirectory || resolveOpenCodeDataDirectory(environment, homeDirectory),
+    'storage'
+  )
 }


### PR DESCRIPTION
## Description

Restore the OpenCode session scanner storage precedence to `OPENCODE_CONFIG_DIR`, then `XDG_DATA_HOME`, then `~/.local/share`. WSL sources remain explicitly rooted in each guest home, so a Windows OpenCode overlay path cannot cross into WSL.

## ELI5

OpenCode can be told to keep its files in a custom folder. Orca stopped checking that folder for older-format sessions, so those sessions disappeared from Orca even though they were still on disk. This change checks the custom folder first while retaining the newer platform-neutral fallback locations.

## Proof of fix

Before the production fix, the new regression tests failed:

```text
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_4e030e35-723-5

 ❯ src/main/opencode/opencode-data-directory.test.ts (6 tests | 1 failed) 4ms
     × prefers OPENCODE_CONFIG_DIR for legacy storage 2ms
 ❯ src/main/ai-vault/session-scanner-opencode-sources.test.ts (2 tests | 1 failed) 5ms
     × prefers the OpenCode config directory for local storage 4ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/ai-vault/session-scanner-opencode-sources.test.ts > opencodeDiscoveries > prefers the OpenCode config directory for local storage
AssertionError: expected "vi.fn()" to be called with arguments: [ { …(4) } ]

Received:

  1st vi.fn() call:

  [
    {
      "dbPaths": [],
      "issues": [],
      "limitPerAgent": 25,
-     "storageDir": "/opencode/config/storage",
+     "storageDir": "/xdg/data/opencode/storage",
    },
  ]


Number of calls: 1

 ❯ src/main/ai-vault/session-scanner-opencode-sources.test.ts:37:42
     35|     await Promise.all(opencodeDiscoveries({}, [], 25, issues))
     36|
     37|     expect(discoverOpenCodeSessionsMock).toHaveBeenCalledWith({
       |                                          ^
     38|       storageDir: join('/opencode/config', 'storage'),
     39|       dbPaths: [],

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  src/main/opencode/opencode-data-directory.test.ts > resolveOpenCodeDataDirectory > prefers OPENCODE_CONFIG_DIR for legacy storage
AssertionError: expected '/custom/data/opencode/storage' to be '/custom/config/storage' // Object.is equality

Expected: "/custom/config/storage"
Received: "/custom/data/opencode/storage"

 ❯ src/main/opencode/opencode-data-directory.test.ts:50:7
     48|         '/users/test'
     49|       )
     50|     ).toBe(join('/custom/config', 'storage'))
       |       ^
     51|   })
     52|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  2 failed (2)
      Tests  2 failed | 6 passed (8)
   Start at  15:59:50
   Duration  109ms (transform 35ms, setup 0ms, import 51ms, tests 9ms, environment 0ms)
```

After the fix:

```text
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_4e030e35-723-5


 Test Files  2 passed (2)
      Tests  9 passed (9)
   Start at  16:03:04
   Duration  120ms (transform 42ms, setup 0ms, import 60ms, tests 5ms, environment 0ms)
```

## Proof of no regression

Targeted suites for all touched production and test files:

```text
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_4e030e35-723-5


 Test Files  2 passed (2)
      Tests  9 passed (9)
   Start at  16:03:04
   Duration  120ms (transform 42ms, setup 0ms, import 60ms, tests 5ms, environment 0ms)
```

Typecheck:

```text
> orca@1.4.162-rc.0 typecheck /Users/nwparker/projects/orca/.claude/worktrees/wf_4e030e35-723-5
> tsc --noEmit -p config/tsconfig.node.json && tsc --noEmit -p config/tsconfig.tc.cli.json && tsc --noEmit -p config/tsconfig.tc.web.json
```

Changed-code quality gate:

```text
> orca@1.4.162-rc.0 check:code-quality:changed /Users/nwparker/projects/orca/.claude/worktrees/wf_4e030e35-723-5
> node config/scripts/check-changed-code-quality.mjs

code quality: 0 new finding(s) across 3 changed file(s).
type-aware code quality: 0 new finding(s) across 3 changed file(s).
React Doctor: 0 new finding(s) across 3 changed file(s).
Changed-code quality gate passed since 5c8013abaa87.
```

No user-visible UI change; this only restores background session discovery, so screenshots do not apply.

## Scan provenance

P2 — OpenCode session scanner stopped honoring OPENCODE_CONFIG_DIR. Introduced by #10362 — "fix(opencode): use cross-platform data directory".

Made with [Orca](https://github.com/stablyai/orca) 🐋
