### PR TITLE
fix(runtime): skip unreadable Windows drives

### DIFF
--- a/src/main/runtime/windows-drive-listing.test.ts
+++ b/src/main/runtime/windows-drive-listing.test.ts
@@ -75,6 +75,22 @@ describe('listWindowsDrives', () => {
     })
   })
 
+  it('surfaces programming errors from isDirectory', async () => {
+    const error = new TypeError('programmer bug')
+    const statPath = async (p: string): Promise<Stats> => {
+      if (p === 'D:\\') {
+        return {
+          isDirectory: () => {
+            throw error
+          }
+        } as unknown as Stats
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    }
+
+    await expect(listWindowsDrives(statPath)).rejects.toBe(error)
+  })
+
   it('returns healthy drives among tolerated and unexpected stat failures', async () => {
     const error = Object.assign(new Error('EIO'), { code: 'EIO' })
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)

--- a/src/main/runtime/windows-drive-listing.test.ts
+++ b/src/main/runtime/windows-drive-listing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Stats } from 'node:fs'
 import { isServerDriveListRequest, listWindowsDrives } from './windows-drive-listing'
 
@@ -20,6 +20,10 @@ describe('isServerDriveListRequest', () => {
 })
 
 describe('listWindowsDrives', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   const statOnly = (mounted: string[]) => async (p: string) => {
     if (!mounted.includes(p)) {
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
@@ -51,14 +55,46 @@ describe('listWindowsDrives', () => {
     expect(result.entries.map((e) => e.name)).toEqual(['C:\\'])
   })
 
-  it.each(['EIO', 'EMFILE'])('surfaces systemic %s failures', async (code) => {
+  it('skips an unreadable drive with an unexpected errno and logs it', async () => {
+    const error = Object.assign(new Error('EIO'), { code: 'EIO' })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     const statPath = async (p: string): Promise<Stats> => {
       if (p === 'D:\\') {
-        throw Object.assign(new Error(code), { code })
+        throw error
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     }
 
-    await expect(listWindowsDrives(statPath)).rejects.toMatchObject({ code })
+    const result = await listWindowsDrives(statPath)
+
+    expect(result.entries).toEqual([])
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith('[windows-drive-listing] Failed to stat drive', {
+      root: 'D:\\',
+      error
+    })
+  })
+
+  it('returns healthy drives among tolerated and unexpected stat failures', async () => {
+    const error = Object.assign(new Error('EIO'), { code: 'EIO' })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const statPath = async (p: string): Promise<Stats> => {
+      if (p === 'C:\\' || p === 'F:\\') {
+        return { isDirectory: () => true } as Stats
+      }
+      if (p === 'E:\\') {
+        throw error
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    }
+
+    const result = await listWindowsDrives(statPath)
+
+    expect(result.entries.map((entry) => entry.name)).toEqual(['C:\\', 'F:\\'])
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith('[windows-drive-listing] Failed to stat drive', {
+      root: 'E:\\',
+      error
+    })
   })
 })

--- a/src/main/runtime/windows-drive-listing.ts
+++ b/src/main/runtime/windows-drive-listing.ts
@@ -30,10 +30,10 @@ export async function listWindowsDrives(
         const stats = await statPath(root)
         return stats.isDirectory() ? root : null
       } catch (error) {
-        if (isExpectedUnavailableDriveError(error)) {
-          return null
+        if (!isExpectedUnavailableDriveError(error)) {
+          console.warn('[windows-drive-listing] Failed to stat drive', { root, error })
         }
-        throw error
+        return null
       }
     })
   )

--- a/src/main/runtime/windows-drive-listing.ts
+++ b/src/main/runtime/windows-drive-listing.ts
@@ -26,15 +26,16 @@ export async function listWindowsDrives(
   const roots = await Promise.all(
     [...DRIVE_LETTERS].map(async (letter) => {
       const root = `${letter}:\\`
+      let stats: Stats
       try {
-        const stats = await statPath(root)
-        return stats.isDirectory() ? root : null
+        stats = await statPath(root)
       } catch (error) {
         if (!isExpectedUnavailableDriveError(error)) {
           console.warn('[windows-drive-listing] Failed to stat drive', { root, error })
         }
         return null
       }
+      return stats.isDirectory() ? root : null
     })
   )
   return {


### PR DESCRIPTION
## Description
Skip every Windows drive whose root cannot be stat'ed so one unreadable or not-ready device cannot reject the complete A:\ through Z:\ enumeration. Expected unavailable-drive errors remain quiet; unexpected stat errors are skipped with a warning that includes the drive root and original error. Only `statPath(root)` is tolerated: errors from interpreting a successful stat result still reject. Regression coverage includes EIO alone, a mix of expected, unexpected, and healthy probes, and the programming-error boundary.

## ELI5
Windows checks every possible drive letter to find the ones that can be opened. One unusual broken or not-ready drive no longer stops the entire check or hides healthy drives. If Orca itself hits a bug while interpreting a successful check, that bug is still reported instead of making the machine appear to have no drives.

## Proof of fix
Before narrowing the catch, the new boundary test exercised a `Stats.isDirectory()` stub that throws `TypeError('programmer bug')`.

Exact command:

```sh
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/windows-drive-listing.test.ts
```

Verbatim failing output:

```text
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3

stderr | src/main/runtime/windows-drive-listing.test.ts > listWindowsDrives > surfaces programming errors from isDirectory
[windows-drive-listing] Failed to stat drive {
  root: 'D:\\',
  error: TypeError: programmer bug
      at /Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3/src/main/runtime/windows-drive-listing.test.ts:79:19
      at file:///Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3/node_modules/.pnpm/@vitest+runner@4.1.5/node_modules/@vitest/runner/dist/chunk-artifact.js:302:11
      at file:///Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3/node_modules/.pnpm/@vitest+runner@4.1.5/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:26
      at file:///Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3/node_modules/.pnpm/@vitest+runner@4.1.5/node_modules/@vitest/runner/dist/chunk-artifact.js:2326:20
      at new Promise (<anonymous>)
      at runWithCancel (file:///Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3/node_modules/.pnpm/@vitest+runner@4.1.5/node_modules/@vitest/runner/dist/chunk-artifact.js:2323:10)
      at file:///Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3/node_modules/.pnpm/@vitest+runner@4.1.5/node_modules/@vitest/runner/dist/chunk-artifact.js:2305:20
      at new Promise (<anonymous>)
      at runWithTimeout (file:///Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3/node_modules/.pnpm/@vitest+runner@4.1.5/node_modules/@vitest/runner/dist/chunk-artifact.js:2272:10)
      at file:///Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3/node_modules/.pnpm/@vitest+runner@4.1.5/node_modules/@vitest/runner/dist/chunk-artifact.js:2955:64
}

 ❯ src/main/runtime/windows-drive-listing.test.ts (7 tests | 1 failed) 6ms
     × surfaces programming errors from isDirectory 3ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/main/runtime/windows-drive-listing.test.ts > listWindowsDrives > surfaces programming errors from isDirectory
AssertionError: promise resolved "{ resolvedPath: '/', …(2) }" instead of rejecting

- Expected
+ Received

- Error {
-   "message": "rejected promise",
+ {
+   "entries": [],
+   "pathFlavor": "win32",
+   "resolvedPath": "/",
  }

 ❯ src/main/runtime/windows-drive-listing.test.ts:91:46
     89|     }
     90|
     91|     await expect(listWindowsDrives(statPath)).rejects.toBe(error)
       |                                              ^
     92|   })
     93|

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
   Start at  19:57:00
   Duration  103ms (transform 17ms, setup 0ms, import 22ms, tests 6ms, environment 0ms)
```

After narrowing the catch, the same command passed:

```text
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  19:57:30
   Duration  85ms (transform 15ms, setup 0ms, import 21ms, tests 3ms, environment 0ms)
```

## Proof of no regression
Targeted suite for both touched files.

Exact command:

```sh
pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/windows-drive-listing.test.ts
```

Verbatim output from the pushed commit:

```text
 RUN  v4.1.5 /Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3


 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  19:57:30
   Duration  85ms (transform 15ms, setup 0ms, import 21ms, tests 3ms, environment 0ms)
```

Exact command:

```sh
pnpm run typecheck
```

Verbatim output from the pushed commit:

```text
> orca@1.4.162-rc.0 typecheck /Users/nwparker/projects/orca/.claude/worktrees/wf_228b4bf9-149-3
> tsc --noEmit -p config/tsconfig.node.json && tsc --noEmit -p config/tsconfig.tc.cli.json && tsc --noEmit -p config/tsconfig.tc.web.json
```

No user-visible UI change; no screenshot is applicable.

## Review remediation

1. **Catch is too broad:** Confirmed. The catch now wraps only `await statPath(root)`; `stats.isDirectory()` runs afterward, so programming errors reject instead of being converted to an absent drive.
2. **Missing boundary test:** Added a regression test whose successful stat returns a `Stats` stub with `isDirectory()` throwing `TypeError('programmer bug')`; the test asserts `listWindowsDrives` rejects with that exact error.

## Scan provenance
P2 — listWindowsDrives fails closed for the entire 26-drive list on one unexpected errno. Introduced by #7439, “Support Windows drives in the remote host filesystem picker.”

Made with [Orca](https://github.com/stablyai/orca)
