### PR TITLE
fix(computer): reap mac helper after client loss

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -2530,9 +2530,12 @@ private enum KeyMap {
 }
 
 private final class AgentRuntime: NSObject, NSApplicationDelegate {
+    private static let unclaimedSessionDeadline: TimeInterval = 30
+
     private let socketPath: String
     private let token: String?
     private var listener: SocketListener?
+    private var unclaimedSessionTimeout: DispatchWorkItem?
 
     init(socketPath: String, token: String?) {
         self.socketPath = socketPath
@@ -2541,9 +2544,31 @@ private final class AgentRuntime: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         do {
-            let listener = try SocketListener(socketPath: socketPath, token: token)
+            let timeout = DispatchWorkItem {
+                fputs("computer-use agent received no authenticated session before its deadline\n", stderr)
+                NSApp.terminate(nil)
+            }
+            unclaimedSessionTimeout = timeout
+            let listener = try SocketListener(
+                socketPath: socketPath,
+                token: token,
+                onSessionClaimed: {
+                    DispatchQueue.main.async {
+                        timeout.cancel()
+                    }
+                },
+                onSessionClosed: {
+                    DispatchQueue.main.async {
+                        NSApp.terminate(nil)
+                    }
+                }
+            )
             self.listener = listener
             listener.start()
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + Self.unclaimedSessionDeadline,
+                execute: timeout
+            )
         } catch {
             fputs("failed to start computer-use socket: \(error)\n", stderr)
             NSApp.terminate(nil)
@@ -2551,6 +2576,8 @@ private final class AgentRuntime: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        unclaimedSessionTimeout?.cancel()
+        unclaimedSessionTimeout = nil
         listener?.stop()
     }
 }
@@ -3456,14 +3483,25 @@ private final class ButtonTarget: NSObject {
 private final class SocketListener: @unchecked Sendable {
     private let socketPath: String
     private let token: String?
+    private let onSessionClaimed: () -> Void
+    private let onSessionClosed: () -> Void
     private let provider = Provider()
     private let providerLock = NSLock()
+    private let sessionLock = NSLock()
+    private var sessionOwnership = AgentSessionOwnership()
     private var socketFd: Int32 = -1
     private var isStopped = false
 
-    init(socketPath: String, token: String?) throws {
+    init(
+        socketPath: String,
+        token: String?,
+        onSessionClaimed: @escaping () -> Void,
+        onSessionClosed: @escaping () -> Void
+    ) throws {
         self.socketPath = socketPath
         self.token = token
+        self.onSessionClaimed = onSessionClaimed
+        self.onSessionClosed = onSessionClosed
         try bindSocket()
     }
 
@@ -3545,7 +3583,15 @@ private final class SocketListener: @unchecked Sendable {
     }
 
     private func handleConnection(_ fd: Int32) {
-        defer { close(fd) }
+        defer {
+            sessionLock.lock()
+            let shouldTerminate = sessionOwnership.disconnect(fd)
+            sessionLock.unlock()
+            close(fd)
+            if shouldTerminate {
+                onSessionClosed()
+            }
+        }
         let authorizedPeer = peerProcessId(fd).map(isAuthorizedAgentPeer) == true
         let decoder = JSONDecoder()
         while let line = readLine(from: fd) {
@@ -3553,6 +3599,15 @@ private final class SocketListener: @unchecked Sendable {
                   let request = try? decoder.decode(Request.self, from: data)
             else {
                 continue
+            }
+            sessionLock.lock()
+            let claimed = sessionOwnership.registerConnection(
+                fd,
+                authenticated: isAuthenticated(request: request, authorizedPeer: authorizedPeer)
+            )
+            sessionLock.unlock()
+            if claimed {
+                onSessionClaimed()
             }
             let response = handleRequest(
                 provider: provider,
@@ -3563,6 +3618,11 @@ private final class SocketListener: @unchecked Sendable {
             )
             writeJSON(response, to: fd)
         }
+    }
+
+    private func isAuthenticated(request: Request, authorizedPeer: Bool) -> Bool {
+        guard let token else { return true }
+        return request.token == token && authorizedPeer
     }
 }
 

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AgentSessionOwnership.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AgentSessionOwnership.swift
@@ -1,0 +1,19 @@
+public struct AgentSessionOwnership: Sendable {
+    private var authenticatedConnections: Set<Int32> = []
+    private var wasClaimed = false
+
+    public init() {}
+
+    public mutating func registerConnection(_ connection: Int32, authenticated: Bool) -> Bool {
+        guard authenticated else { return false }
+        let inserted = authenticatedConnections.insert(connection).inserted
+        guard inserted, !wasClaimed else { return false }
+        wasClaimed = true
+        return true
+    }
+
+    public mutating func disconnect(_ connection: Int32) -> Bool {
+        guard authenticatedConnections.remove(connection) != nil else { return false }
+        return wasClaimed && authenticatedConnections.isEmpty
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentSessionOwnershipTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentSessionOwnershipTests.swift
@@ -1,0 +1,41 @@
+import OrcaComputerUseMacOSCore
+import XCTest
+
+final class AgentSessionOwnershipTests: XCTestCase {
+    func testUnclaimedDisconnectDoesNotTerminateAgent() {
+        var ownership = AgentSessionOwnership()
+
+        XCTAssertFalse(ownership.disconnect(12))
+    }
+
+    func testUnauthenticatedConnectionCannotClaimOrRetainAgent() {
+        var ownership = AgentSessionOwnership()
+
+        XCTAssertFalse(ownership.registerConnection(12, authenticated: false))
+        XCTAssertFalse(ownership.disconnect(12))
+    }
+
+    func testLastAuthenticatedDisconnectTerminatesAgent() {
+        var ownership = AgentSessionOwnership()
+
+        XCTAssertTrue(ownership.registerConnection(12, authenticated: true))
+        XCTAssertTrue(ownership.disconnect(12))
+    }
+
+    func testAgentWaitsForEveryAuthenticatedConnectionToClose() {
+        var ownership = AgentSessionOwnership()
+
+        XCTAssertTrue(ownership.registerConnection(12, authenticated: true))
+        XCTAssertFalse(ownership.registerConnection(13, authenticated: true))
+        XCTAssertFalse(ownership.disconnect(12))
+        XCTAssertTrue(ownership.disconnect(13))
+    }
+
+    func testDuplicateRegistrationDoesNotRetainAgent() {
+        var ownership = AgentSessionOwnership()
+
+        XCTAssertTrue(ownership.registerConnection(12, authenticated: true))
+        XCTAssertFalse(ownership.registerConnection(12, authenticated: true))
+        XCTAssertTrue(ownership.disconnect(12))
+    }
+}


### PR DESCRIPTION
## Summary

This is the first lifecycle prerequisite for moving the computer-use coordinator from an always-on Electron-as-Node child to a worker thread.

The detached macOS computer-use helper previously kept accepting connections indefinitely when its JavaScript socket owner disappeared. Graceful sidecar shutdown sent an explicit `terminate` request, but an unexpected sidecar exit only closed the socket; the helper stayed alive and the parent-owned `orca-computer-use-*` directory could be stranded.

The helper now treats a successfully authenticated socket as a live owner session:

- the first authenticated request claims the helper session;
- the helper terminates when the final authenticated connection closes;
- unauthenticated or malformed connections cannot claim or retain it;
- a helper that never receives an authenticated request exits after a 30-second startup deadline.

This reduces current orphan risk and establishes the self-reaping half of the lifecycle contract needed by a future worker migration. It does not convert the sidecar yet; Python/PowerShell operation supervision and parent-owned temporary-directory cleanup remain separate prerequisite work.

## Lifecycle and failure contract

`AgentSessionOwnership` is a small testable state machine in the native core target. The socket listener serializes access with its own lock and removes a connection from ownership before closing the file descriptor, preventing descriptor reuse from removing a newer session.

The existing security and cleanup boundaries are preserved:

- a connection only registers after the existing token and peer-process checks both pass;
- the helper still rejects invalid tokens and unauthorized peers through the existing response path;
- multiple authenticated connections keep the helper alive until the last one closes;
- clean shutdown still accepts the existing explicit `terminate` request;
- the helper still does not unlink caller-supplied socket or token paths; the JavaScript owner retains directory cleanup authority;
- permission/setup modes are unchanged because the deadline is scoped to `--agent` mode.

The 30-second unclaimed-session deadline is intentionally longer than the JavaScript client's 10-second connection deadline. It is a failure backstop, not a normal startup race winner.

## Why this precedes the worker conversion

Terminating a worker does not run its provider `finally` blocks and does not automatically terminate external processes. The computer-use coordinator cannot safely move until every external descendant has an owner outside the disposable worker or a self-reaping contract.

This PR handles macOS socket-owner disappearance. Follow-up PRs will:

1. move macOS helper and Linux/Windows bridge spawn, deadlines, reap, and private temporary-directory ownership into a domain-specific main-process supervisor;
2. fault-inject coordinator death at each provider lifecycle phase;
3. convert the coordinator only after those descendant checks pass;
4. measure packaged idle, peak, retained, and restart memory.

## Testing

- [x] `swift test --package-path native/computer-use-macos` — 42 tests passed
- [x] `pnpm build:computer-macos` — release helper and app bundle built
- [x] `pnpm verify:computer-native` — Swift suite, native guardrails, helper bundle, and signature passed
- [x] `pnpm lint` — static analysis, reliability gates, max-lines ratchet, and repository verifiers passed
- [x] `git diff --check`
- [x] Real release-helper backstop: an unclaimed `--agent` process exited cleanly after 31.8 seconds with the expected deadline diagnostic

New tests cover unauthenticated disconnects, unclaimed disconnects, the final authenticated disconnect, multiple authenticated connections, and duplicate registration.

The full authenticated socket flow retains its LaunchServices/bundle-identity check and remains covered by the permission-bearing macOS computer-use e2e lane; the security check was not relaxed for a headless test harness.

## AI Review Report

The review traced the change from native agent startup through peer/token authentication, request dispatch, socket EOF, application termination, and caller-owned path cleanup.

Checked risks:

- unauthorized connections canceling the startup deadline or keeping the helper alive;
- one connection terminating the helper while another authenticated connection remains;
- file-descriptor reuse racing ownership cleanup;
- malformed input claiming a session;
- clean `terminate` behavior changing;
- the deadline affecting permission windows or other helper modes;
- helper-side deletion of caller-controlled paths;
- macOS-only behavior leaking into Linux, Windows, WSL, SSH, git-worktree, or folder-workspace paths.

No unresolved correctness or maintainability findings remain within this prerequisite's scope. A native provider call that itself never returns still requires the planned main-process supervisor; this PR does not claim that broader gate is complete.

## Security Audit

- No authentication, token generation, socket permissions, TCC identity, executable path, network surface, dependency, or command execution changed.
- Session ownership is recorded only after the existing token and trusted-peer checks pass.
- Invalid tokens and unauthorized peers cannot cancel the startup backstop.
- The helper continues to avoid unlinking caller-supplied paths.
- The change narrows lifetime after authority loss; it does not grant new authority.

## Screenshots

No UI change.
