### PR TITLE
perf(agent-status): bound Codex child rollout searches per reconcile

### DIFF
--- a/src/shared/codex-subagent-transcript.test.ts
+++ b/src/shared/codex-subagent-transcript.test.ts
@@ -6,7 +6,8 @@ import { join } from 'node:path'
 import {
   createCodexSubagentTranscriptState,
   hasTrackedCodexTranscriptSubagents,
-  reconcileCodexSubagentTranscript
+  reconcileCodexSubagentTranscript,
+  type CodexSubagentTranscriptState
 } from './codex-subagent-transcript'
 import { codexRosterToSnapshots, type CodexSubagentRoster } from './codex-subagent-roster'
 
@@ -27,6 +28,30 @@ function activity(kind: string, occurredAtMs = 1234): unknown {
       kind
     }
   }
+}
+
+function childId(index: number): string {
+  return `019fa65f-3144-7151-9c02-${String(index).padStart(12, '0')}`
+}
+
+function childActivity(index: number): unknown {
+  return {
+    type: 'event_msg',
+    payload: {
+      type: 'sub_agent_activity',
+      occurred_at_ms: 1234,
+      agent_thread_id: childId(index),
+      agent_path: '/root/sidebar_repro',
+      kind: 'started'
+    }
+  }
+}
+
+/** Children the reconciler went looking for — only a finished search sets the grace clock. */
+function searchedChildren(state: CodexSubagentTranscriptState): number {
+  return Array.from(state.subagents.values()).filter(
+    (tracked) => tracked.unresolvedSince !== undefined
+  ).length
 }
 
 /** `<root>/YYYY/MM/DD` for a timestamp, matching how Codex buckets rollouts by local start date. */
@@ -138,6 +163,67 @@ describe('Codex subagent transcript reconciliation', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('bounds rollout searches per tick and rotates the backlog', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'codex-subagent-transcript-'))
+    dirs.push(dir)
+    const parentPath = join(dir, 'rollout-parent.jsonl')
+    // Why: no child here has a rollout on disk, so every one costs a directory search.
+    writeFileSync(
+      parentPath,
+      jsonl(Array.from({ length: 500 }, (_, index) => childActivity(index)))
+    )
+    const state = createCodexSubagentTranscriptState()
+    const roster: CodexSubagentRoster = new Map()
+
+    reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+    expect(searchedChildren(state)).toBe(64)
+    expect(state.subagents.size).toBe(500)
+
+    reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+    // Rotation, not repetition: the second tick searches for 64 children it has not tried yet.
+    expect(searchedChildren(state)).toBe(128)
+  })
+
+  it('finishes every located child in a single tick, however many there are', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'codex-subagent-transcript-'))
+    dirs.push(dir)
+    const parentPath = join(dir, 'rollout-parent.jsonl')
+    const total = 200
+    const writeChildren = (records: unknown[]): void => {
+      for (let index = 0; index < total; index += 1) {
+        writeFileSync(join(dir, `rollout-child-${childId(index)}.jsonl`), jsonl(records))
+      }
+    }
+    writeFileSync(
+      parentPath,
+      jsonl(Array.from({ length: total }, (_, index) => childActivity(index)))
+    )
+    writeChildren([{ type: 'event_msg', payload: { type: 'task_started' } }])
+    const state = createCodexSubagentTranscriptState()
+    const roster: CodexSubagentRoster = new Map()
+    // Searching is what the budget caps, so a parent this wide needs several ticks to locate
+    // everyone. Reading them afterwards is not capped, which is what this test pins.
+    for (let tick = 0; tick < Math.ceil(total / 64); tick += 1) {
+      reconcileCodexSubagentTranscript(state, roster, parentPath)
+    }
+
+    expect(state.subagents.size).toBe(total)
+    expect(searchedChildren(state)).toBe(0)
+
+    writeChildren([
+      { type: 'event_msg', payload: { type: 'task_started' } },
+      { type: 'event_msg', payload: { type: 'task_complete' } }
+    ])
+    // Why: the Stop hook is the last reconcile a pane ever gets — anything still tracked here
+    // blocks the roster delete and strands a "working" row for the life of the pane.
+    reconcileCodexSubagentTranscript(state, roster, parentPath)
+
+    expect(hasTrackedCodexTranscriptSubagents(state)).toBe(false)
+    expect(codexRosterToSnapshots(roster)).toBeUndefined()
   })
 
   it('removes a child when Codex reports it interrupted', () => {

--- a/src/shared/codex-subagent-transcript.ts
+++ b/src/shared/codex-subagent-transcript.ts
@@ -10,6 +10,10 @@ import {
 const TRANSCRIPT_READ_MAX_BYTES = 1024 * 1024
 const TRANSCRIPT_LINE_MAX_BYTES = 256 * 1024
 const TRANSCRIPT_DIRECTORY_MAX_ENTRIES = 4096
+// Why: locating one child scans a whole rollout directory, so a parent with thousands of
+// unlocated children would scan millions of names on a single hook event. Cap the searches;
+// reading an already-located child is one stat and stays uncapped.
+const CHILD_LOCATE_MAX_PER_TICK = 64
 // Why: retire a child whose rollout stays unreadable this long, else a deleted/never-written file pins a phantom row forever.
 const CHILD_UNREADABLE_GRACE_MS = 60_000
 const SAFE_THREAD_ID = /^[A-Za-z0-9-]{1,64}$/
@@ -270,8 +274,17 @@ export function reconcileCodexSubagentTranscript(
   }
   const entriesByDirectory = new Map<string, string[]>()
   const now = Date.now()
+  let locateBudget = CHILD_LOCATE_MAX_PER_TICK
+  const located: string[] = []
   for (const [id, tracked] of state.subagents) {
     if (!tracked.filePath) {
+      if (locateBudget === 0) {
+        // Why: leave unresolvedSince alone — a child we declined to look for must not burn
+        // its grace, or a big backlog would retire rows it never actually searched for.
+        continue
+      }
+      locateBudget -= 1
+      located.push(id)
       tracked.filePath = resolveChildTranscript(
         normalizedPath,
         id,
@@ -295,5 +308,14 @@ export function reconcileCodexSubagentTranscript(
     }
     finishCodexSubagent(roster, id)
     state.subagents.delete(id)
+  }
+  // Why: send the children we searched for and still could not find to the back, so a backlog
+  // larger than the budget takes turns instead of the same head being retried every tick.
+  for (const id of located) {
+    const tracked = state.subagents.get(id)
+    if (tracked && !tracked.filePath) {
+      state.subagents.delete(id)
+      state.subagents.set(id, tracked)
+    }
   }
 }


### PR DESCRIPTION
## Description

Locating a Codex child rollout scans a whole rollout directory — `resolveChildTranscript` runs `entries.find(entry => entry.endsWith('-<threadId>.jsonl'))` over up to `TRANSCRIPT_DIRECTORY_MAX_ENTRIES` (4096) names, for each child that has no `filePath` yet, on every reconcile. A parent with thousands of children not yet located therefore scans millions of names per Codex hook event, on the main process.

This caps the **searches** at 64 per reconcile and rotates the still-unfound children to the back of `state.subagents`, so a backlog takes turns instead of the same head being retried every tick. Reading an already-located child is a single `statSync` and stays **uncapped**, so completions are never deferred.

That distinction is the whole design. An earlier revision of this PR capped *children per tick* instead, which broke the completion path — see below.

## ELI5

Orca has to find each Codex sub-agent's log file by looking through a folder listing. With thousands of sub-agents that search got very slow. Now Orca only searches for 64 of them per check and remembers where it left off, so everyone still gets found. Reading a log file Orca has already found is cheap, so that part still happens for every sub-agent every time — which is what makes sure finished sub-agents always disappear from the list.

## Correction to the original premise

The first version of this PR said it was bounding *"one 1 Hz main-process poll."* There is no such poll. `reconcileCodexSubagentTranscript` has exactly one non-test call site:

```
src/shared/agent-hook-listener.ts:3360   ← inside normalizeCodexEvent
```

and `agent-hook-listener.ts` contains no `setInterval`. Reconciliation is hook-driven: it runs once per inbound Codex hook event and never otherwise. That mattered, because capping children per tick meant the leftovers only drained when another hook arrived — and after the final `Stop` hook, none ever does:

```ts
if (eventName === 'Stop' && !hasCodexTranscriptSubagents(state, paneKey)) {
  state.codexSubagentRosterByPaneKey.delete(paneKey)
}
```

`hasCodexTranscriptSubagents` is `state.subagents.size > 0`. With 200 completed children, the old approach finished 64, left 136 tracked, so the gate stayed false, the roster was never cleared, and 136 rows stayed `working` for the life of the pane. Capping searches instead of children removes that failure mode entirely: every located child is still read on every tick.

The rewrite also drops the `pendingReconcileIds: Set<string>` field the earlier revision added to the exported `CodexSubagentTranscriptState`, so the state shape is unchanged.

## Proof of fix

Two new tests, each RED against a different implementation.

**`bounds rollout searches per tick and rotates the backlog`** — fails on `main` (unbounded):

```
$ git archive origin/main | tar -x -C /tmp/red-main
$ cp src/shared/codex-subagent-transcript.test.ts /tmp/red-main/src/shared/
$ cd /tmp/red-main && pnpm exec vitest run --config config/vitest.config.ts \
    src/shared/codex-subagent-transcript.test.ts

  × bounds rollout searches per tick and rotates the backlog 25ms
  Tests  1 failed | 5 passed (6)
```

**`finishes every located child in a single tick, however many there are`** — fails on the earlier per-child-cap revision (`7e60037f6f`), which is the stranding regression:

```
$ git archive 7e60037f6f | tar -x -C /tmp/red-pr
$ cp src/shared/codex-subagent-transcript.test.ts /tmp/red-pr/src/shared/
$ cd /tmp/red-pr && pnpm exec vitest run --config config/vitest.config.ts \
    src/shared/codex-subagent-transcript.test.ts

  × finishes every located child in a single tick, however many there are 85ms
  AssertionError: expected true to be false
  Tests  1 failed | 5 passed (6)
```

Both green on this branch:

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

## Measurements

Median of 25 warmed reconciles, Node 24 / macOS, against a session directory holding 4096 rollout files where no child rollout exists (so every child costs a search) — three independent runs:

| children | `main` | this PR |
|---|---|---|
| 100 | 4.4 / 4.4 / 4.6 ms | 3.6 / 3.9 / 4.0 ms |
| 1,000 | 7.2 / 6.7 / 6.5 ms | 4.1 / 4.1 / 4.1 ms |
| 5,000 | 23.9 / 23.4 / 23.4 ms | 3.6 / 3.8 / 3.7 ms |

At 5,000 children this is ~6x faster per hook event, and flat in child count rather than linear. The ~3.6ms floor is the single `readdirSync` of the 4096-entry directory, which is cached per reconcile and unaffected by this change. At 100 children the two are within noise — as expected, since 100 searches were never the problem.

## Proof of no regression

```
pnpm exec vitest run --config config/vitest.config.ts \
  src/shared/codex-subagent-transcript.test.ts \
  src/shared/agent-hook-listener.test.ts \
  src/shared/codex-subagent-roster.test.ts

Test Files  3 passed (3)
     Tests  126 passed (126)
```

Every suite referencing Codex subagents:

```
Test Files  4 passed (4)
     Tests  13 passed (13)
```

```
pnpm run typecheck        # passed: node, tc.cli, tc.web
pnpm run check:code-quality:changed
  code quality: 0 new finding(s) across 2 changed file(s).
  type-aware code quality: 0 new finding(s) across 2 changed file(s).
  React Doctor: 0 new finding(s) across 2 changed file(s).
```

The pre-existing grace behaviour is preserved deliberately: a child the budget declined to search for does **not** have its `unresolvedSince` clock started, so a backlog can never retire rows it never actually looked for.

## Dropped from the earlier revision

The previous test seeded 4095 decoy files. They were dead setup — the temp dir is not a `YYYY/MM/DD` path, so `childDayDirectory` returns `undefined`, and no `child-N` id had a rollout file, so `entries.find(...)` could not match at any decoy count. The assertions were identical with zero decoys, and the decoys cost roughly 32x the runtime of the reconcile calls under test. The new bounding test uses 500 children and no decoys.

## Scan provenance

P2 — Codex subagent reconcile scan degrades badly at scale. Introduced by #11059, "fix(agent-status): show Codex v2 subagents."

No user-visible change; this only bounds background main-process work, so screenshots are not applicable.

Made with [Orca](https://github.com/stablyai/orca) 🐋
