### PR TITLE
fix(computer): close helper session review gaps

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -3594,14 +3594,14 @@ private final class SocketListener: @unchecked Sendable {
         }
         let authorizedPeer = peerProcessId(fd).map(isAuthorizedAgentPeer) == true
         let decoder = JSONDecoder()
-        var registered = false
+        var registrationComplete = false
         while let line = readLine(from: fd) {
             guard let data = line.data(using: .utf8),
                   let request = try? decoder.decode(Request.self, from: data)
             else {
                 continue
             }
-            if !registered {
+            if !registrationComplete {
                 sessionLock.lock()
                 let registration = sessionOwnership.registerConnection(
                     fd,
@@ -3611,7 +3611,7 @@ private final class SocketListener: @unchecked Sendable {
                     )
                 )
                 sessionLock.unlock()
-                registered = registration != .rejected
+                registrationComplete = registration != .rejected
                 if registration == .claimed {
                     onSessionClaimed()
                 }

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -3594,20 +3594,27 @@ private final class SocketListener: @unchecked Sendable {
         }
         let authorizedPeer = peerProcessId(fd).map(isAuthorizedAgentPeer) == true
         let decoder = JSONDecoder()
+        var registered = false
         while let line = readLine(from: fd) {
             guard let data = line.data(using: .utf8),
                   let request = try? decoder.decode(Request.self, from: data)
             else {
                 continue
             }
-            sessionLock.lock()
-            let claimed = sessionOwnership.registerConnection(
-                fd,
-                authenticated: isAuthenticated(request: request, authorizedPeer: authorizedPeer)
-            )
-            sessionLock.unlock()
-            if claimed {
-                onSessionClaimed()
+            if !registered {
+                sessionLock.lock()
+                let registration = sessionOwnership.registerConnection(
+                    fd,
+                    authenticated: isAuthenticated(
+                        request: request,
+                        authorizedPeer: authorizedPeer
+                    )
+                )
+                sessionLock.unlock()
+                registered = registration != .rejected
+                if registration == .claimed {
+                    onSessionClaimed()
+                }
             }
             let response = handleRequest(
                 provider: provider,
@@ -3621,8 +3628,9 @@ private final class SocketListener: @unchecked Sendable {
     }
 
     private func isAuthenticated(request: Request, authorizedPeer: Bool) -> Bool {
+        guard authorizedPeer else { return false }
         guard let token else { return true }
-        return request.token == token && authorizedPeer
+        return request.token == token
     }
 }
 
@@ -3756,7 +3764,7 @@ private func handleRequest(
     if let expectedToken, request.token != expectedToken {
         return ["id": request.id, "ok": false, "error": ["code": "permission_denied", "message": "invalid computer-use agent token"]]
     }
-    if expectedToken != nil && !authorizedPeer {
+    if !authorizedPeer {
         return ["id": request.id, "ok": false, "error": ["code": "permission_denied", "message": "computer-use agent peer is not authorized"]]
     }
     if request.method == "terminate" {

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AgentSessionOwnership.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AgentSessionOwnership.swift
@@ -1,5 +1,6 @@
 public enum AgentSessionRegistration: Sendable, Equatable {
     case rejected
+    case sessionReleased
     case joined
     case claimed
 }
@@ -15,7 +16,8 @@ public struct AgentSessionOwnership: Sendable {
         _ connection: Int32,
         authenticated: Bool
     ) -> AgentSessionRegistration {
-        guard authenticated, !wasReleased else { return .rejected }
+        guard authenticated else { return .rejected }
+        guard !wasReleased else { return .sessionReleased }
         let inserted = authenticatedConnections.insert(connection).inserted
         guard inserted, !wasClaimed else { return .joined }
         wasClaimed = true

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AgentSessionOwnership.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AgentSessionOwnership.swift
@@ -1,19 +1,33 @@
+public enum AgentSessionRegistration: Sendable, Equatable {
+    case rejected
+    case joined
+    case claimed
+}
+
 public struct AgentSessionOwnership: Sendable {
     private var authenticatedConnections: Set<Int32> = []
     private var wasClaimed = false
+    private var wasReleased = false
 
     public init() {}
 
-    public mutating func registerConnection(_ connection: Int32, authenticated: Bool) -> Bool {
-        guard authenticated else { return false }
+    public mutating func registerConnection(
+        _ connection: Int32,
+        authenticated: Bool
+    ) -> AgentSessionRegistration {
+        guard authenticated, !wasReleased else { return .rejected }
         let inserted = authenticatedConnections.insert(connection).inserted
-        guard inserted, !wasClaimed else { return false }
+        guard inserted, !wasClaimed else { return .joined }
         wasClaimed = true
-        return true
+        return .claimed
     }
 
     public mutating func disconnect(_ connection: Int32) -> Bool {
         guard authenticatedConnections.remove(connection) != nil else { return false }
-        return wasClaimed && authenticatedConnections.isEmpty
+        let released = wasClaimed && authenticatedConnections.isEmpty
+        if released {
+            wasReleased = true
+        }
+        return released
     }
 }

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentSessionOwnershipTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentSessionOwnershipTests.swift
@@ -11,22 +11,22 @@ final class AgentSessionOwnershipTests: XCTestCase {
     func testUnauthenticatedConnectionCannotClaimOrRetainAgent() {
         var ownership = AgentSessionOwnership()
 
-        XCTAssertFalse(ownership.registerConnection(12, authenticated: false))
+        XCTAssertEqual(ownership.registerConnection(12, authenticated: false), .rejected)
         XCTAssertFalse(ownership.disconnect(12))
     }
 
     func testLastAuthenticatedDisconnectTerminatesAgent() {
         var ownership = AgentSessionOwnership()
 
-        XCTAssertTrue(ownership.registerConnection(12, authenticated: true))
+        XCTAssertEqual(ownership.registerConnection(12, authenticated: true), .claimed)
         XCTAssertTrue(ownership.disconnect(12))
     }
 
     func testAgentWaitsForEveryAuthenticatedConnectionToClose() {
         var ownership = AgentSessionOwnership()
 
-        XCTAssertTrue(ownership.registerConnection(12, authenticated: true))
-        XCTAssertFalse(ownership.registerConnection(13, authenticated: true))
+        XCTAssertEqual(ownership.registerConnection(12, authenticated: true), .claimed)
+        XCTAssertEqual(ownership.registerConnection(13, authenticated: true), .joined)
         XCTAssertFalse(ownership.disconnect(12))
         XCTAssertTrue(ownership.disconnect(13))
     }
@@ -34,8 +34,17 @@ final class AgentSessionOwnershipTests: XCTestCase {
     func testDuplicateRegistrationDoesNotRetainAgent() {
         var ownership = AgentSessionOwnership()
 
-        XCTAssertTrue(ownership.registerConnection(12, authenticated: true))
-        XCTAssertFalse(ownership.registerConnection(12, authenticated: true))
+        XCTAssertEqual(ownership.registerConnection(12, authenticated: true), .claimed)
+        XCTAssertEqual(ownership.registerConnection(12, authenticated: true), .joined)
         XCTAssertTrue(ownership.disconnect(12))
+    }
+
+    func testReleasedSessionCannotBeReclaimed() {
+        var ownership = AgentSessionOwnership()
+
+        XCTAssertEqual(ownership.registerConnection(12, authenticated: true), .claimed)
+        XCTAssertTrue(ownership.disconnect(12))
+        XCTAssertEqual(ownership.registerConnection(13, authenticated: true), .rejected)
+        XCTAssertFalse(ownership.disconnect(13))
     }
 }

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentSessionOwnershipTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AgentSessionOwnershipTests.swift
@@ -44,7 +44,7 @@ final class AgentSessionOwnershipTests: XCTestCase {
 
         XCTAssertEqual(ownership.registerConnection(12, authenticated: true), .claimed)
         XCTAssertTrue(ownership.disconnect(12))
-        XCTAssertEqual(ownership.registerConnection(13, authenticated: true), .rejected)
+        XCTAssertEqual(ownership.registerConnection(13, authenticated: true), .sessionReleased)
         XCTAssertFalse(ownership.disconnect(13))
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #11425 that closes all post-merge review findings before the computer-use supervisor work continues.

- Require the existing trusted-peer identity check even if the agent is ever constructed without a token. The CLI currently rejects tokenless `--agent` launches, but the lower-level request and lifecycle checks now fail closed independently.
- Register each authenticated socket once, so steady-state helper requests no longer take `sessionLock` or mutate the connection set.
- Make session release terminal. A connection arriving after the final owner disconnect is rejected from lifecycle ownership and cannot queue another termination callback.
- Return explicit `rejected` / `sessionReleased` / `joined` / `claimed` registration results so the listener distinguishes retryable authentication failures, terminal release, first ownership, and valid joins without repeating work.

## Behavior and failure contract

The first trusted, token-valid request claims the session and cancels the unclaimed-startup deadline. Additional authenticated connections may join only while that session remains live. The final registered disconnect marks the session released and triggers exactly one close callback. Malformed, untrusted, token-invalid, duplicate, and post-release connections cannot add lifetime.

Normal provider request handling, explicit `terminate`, socket permissions, token generation, peer lookup, TCC identity, and caller-owned path cleanup remain unchanged.

## Testing

- [x] `swift test --package-path native/computer-use-macos` — 43 tests passed
- [x] `pnpm verify:computer-native`
- [x] `pnpm lint`
- [x] `git diff --check`

Added coverage proves a released session cannot be reclaimed. Existing cases continue to cover unclaimed and unauthenticated disconnects, duplicate registration, multiple connections, and last-owner release.

## AI Review Report

Reviewed the authentication gate, per-request hot path, session state transitions, concurrent connection ordering, descriptor cleanup, and late-arrival termination window. The new terminal release state closes the redundant callback race, while the connection-local registration flag removes the lock/set operation from authenticated steady-state requests.

No unresolved findings remain in this follow-up.

## Security Audit

- Tokenless construction now still requires a trusted peer for both request dispatch and lifecycle ownership.
- Invalid tokens retain their existing failure classification.
- No authority, command execution, filesystem path, dependency, or network surface was added.

## Screenshots

No UI change.
