### PR TITLE
fix(settings): reject malformed navigation targets

### DIFF
--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -181,7 +181,7 @@ function getSettingsSectionId(
   pane: SettingsNavTarget,
   repoId: string | null,
   repoIdToRepresentative: Map<string, string>
-): string {
+) {
   if (pane === 'repo' && repoId) {
     // Why: Settings renders one collapsed pane per project, so resolve a repoId target to its project's representative section.
     return `repo-${repoIdToRepresentative.get(repoId) ?? repoId}`
@@ -632,7 +632,7 @@ function Settings(): React.JSX.Element {
     }
 
     const paneSectionId = getSettingsSectionId(
-      settingsNavigationTarget.pane as SettingsNavTarget,
+      settingsNavigationTarget.pane,
       settingsNavigationTarget.repoId,
       repoIdToRepresentative
     )

--- a/src/renderer/src/lib/settings-navigation-types.ts
+++ b/src/renderer/src/lib/settings-navigation-types.ts
@@ -38,6 +38,7 @@ const SETTINGS_NAV_TARGETS = [
   'agents',
   'orchestration',
   'linear',
+  'setup-guide',
   'servers',
   'mobile',
   'mobile-emulator',

--- a/src/renderer/src/lib/settings-navigation-types.ts
+++ b/src/renderer/src/lib/settings-navigation-types.ts
@@ -11,37 +11,70 @@ export type SettingsNavInstallStatus =
   | 'needs-attention'
   | 'checking'
 
-export type SettingsNavTarget =
-  | 'general'
-  | 'integrations'
-  | 'accounts'
-  | 'browser'
-  | 'git'
-  | 'tasks'
-  | 'appearance'
-  | 'input'
-  | 'floating-workspace'
-  | 'terminal'
-  | 'quick-commands'
-  | 'notifications'
-  | 'computer-use'
-  | 'developer-permissions'
-  | 'privacy'
-  | 'advanced'
-  | 'dev'
-  | 'voice'
-  | 'shortcuts'
-  | 'stats'
-  | 'ssh'
-  | 'experimental'
-  | 'plugins'
-  | 'agents'
-  | 'orchestration'
-  | 'linear'
-  | 'servers'
-  | 'mobile'
-  | 'mobile-emulator'
-  | 'repo'
+const SETTINGS_NAV_TARGETS = [
+  'general',
+  'integrations',
+  'accounts',
+  'browser',
+  'git',
+  'tasks',
+  'appearance',
+  'input',
+  'floating-workspace',
+  'terminal',
+  'quick-commands',
+  'notifications',
+  'computer-use',
+  'developer-permissions',
+  'privacy',
+  'advanced',
+  'dev',
+  'voice',
+  'shortcuts',
+  'stats',
+  'ssh',
+  'experimental',
+  'plugins',
+  'agents',
+  'orchestration',
+  'linear',
+  'servers',
+  'mobile',
+  'mobile-emulator',
+  'repo'
+] as const
+
+const SETTINGS_NAV_INTENTS = [
+  'add-quick-command',
+  'add-remote-orca-server',
+  'add-ssh-host'
+] as const
+
+const SETTINGS_NAV_TARGET_SET: ReadonlySet<string> = new Set(SETTINGS_NAV_TARGETS)
+const SETTINGS_NAV_INTENT_SET: ReadonlySet<string> = new Set(SETTINGS_NAV_INTENTS)
+
+export type SettingsNavTarget = (typeof SETTINGS_NAV_TARGETS)[number]
+export type SettingsNavigationTarget = {
+  pane: SettingsNavTarget
+  repoId: string | null
+  sectionId?: string
+  intent?: (typeof SETTINGS_NAV_INTENTS)[number]
+}
+
+export function isSettingsNavigationTarget(value: unknown): value is SettingsNavigationTarget {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const target = value as Record<string, unknown>
+  return (
+    typeof target.pane === 'string' &&
+    SETTINGS_NAV_TARGET_SET.has(target.pane) &&
+    (typeof target.repoId === 'string' || target.repoId === null) &&
+    (target.sectionId === undefined || typeof target.sectionId === 'string') &&
+    (target.intent === undefined ||
+      (typeof target.intent === 'string' && SETTINGS_NAV_INTENT_SET.has(target.intent)))
+  )
+}
 
 export type SettingsNavSection = {
   id: string

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1920,6 +1920,18 @@ describe('createUISlice hydratePersistedUI', () => {
 })
 
 describe('createUISlice settings navigation', () => {
+  it('rejects malformed settings targets before storing them', () => {
+    const store = createUIStore()
+    const openSettingsTarget = store.getState().openSettingsTarget as unknown as (
+      target: unknown
+    ) => void
+
+    expect(() => openSettingsTarget({ page: 'orchestration' })).toThrowError(
+      'openSettingsTarget received an invalid navigation target'
+    )
+    expect(store.getState().settingsNavigationTarget).toBeNull()
+  })
+
   it('prefetches the restored default task source when provider settings drifted', () => {
     const store = createUIStore()
     const prefetchWorkItems = vi.fn()

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -1920,6 +1920,17 @@ describe('createUISlice hydratePersistedUI', () => {
 })
 
 describe('createUISlice settings navigation', () => {
+  it('accepts the setup guide target emitted by Settings navigation metadata', () => {
+    const store = createUIStore()
+
+    store.getState().openSettingsTarget({ pane: 'setup-guide', repoId: null })
+
+    expect(store.getState().settingsNavigationTarget).toEqual({
+      pane: 'setup-guide',
+      repoId: null
+    })
+  })
+
   it('rejects malformed settings targets before storing them', () => {
     const store = createUIStore()
     const openSettingsTarget = store.getState().openSettingsTarget as unknown as (

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -104,7 +104,10 @@ import { clampMarkdownTocPanelWidth } from '../../../../shared/markdown-toc-pane
 import { clampCombinedDiffFileTreeWidth } from '../../../../shared/combined-diff-file-tree-width'
 import { normalizeKagiSessionLink } from '../../../../shared/browser-url'
 import type { OrcaHookScriptKind } from '../../lib/orca-hook-trust'
-import type { SettingsNavTarget } from '@/lib/settings-navigation-types'
+import {
+  isSettingsNavigationTarget,
+  type SettingsNavigationTarget
+} from '@/lib/settings-navigation-types'
 import {
   filterSetupScriptPromptDismissalsToValidRepos,
   getSetupScriptPromptDismissalKey,
@@ -740,12 +743,7 @@ export type UISlice = {
   clearNewWorkspaceDraft: () => void
   openSettingsPage: () => void
   closeSettingsPage: () => void
-  settingsNavigationTarget: {
-    pane: SettingsNavTarget
-    repoId: string | null
-    sectionId?: string
-    intent?: 'add-quick-command' | 'add-remote-orca-server' | 'add-ssh-host'
-  } | null
+  settingsNavigationTarget: SettingsNavigationTarget | null
   openSettingsTarget: (target: NonNullable<UISlice['settingsNavigationTarget']>) => void
   clearSettingsTarget: () => void
   /** Which host the Projects Settings pane shows per project (keyed by projectId). Ephemeral on purpose — never persisted, so reload reopens on the effective host. */
@@ -1503,7 +1501,15 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       return { activeView: previousView }
     }),
   settingsNavigationTarget: null,
-  openSettingsTarget: (target) => set({ settingsNavigationTarget: target }),
+  openSettingsTarget: (target) => {
+    if (!isSettingsNavigationTarget(target)) {
+      if (import.meta.env.DEV) {
+        throw new TypeError('openSettingsTarget received an invalid navigation target')
+      }
+      return
+    }
+    set({ settingsNavigationTarget: target })
+  },
   clearSettingsTarget: () => set({ settingsNavigationTarget: null }),
   settingsProjectHostSelection: {},
   settingsProjectSetupSelection: {},


### PR DESCRIPTION
## Summary

- Reject malformed Settings navigation targets at the store action boundary before they can corrupt mounted section state.
- Derive the compile-time target types from the runtime allowlists and remove the Settings cast and broad string return annotation.
- Throw at the caller in development while making invalid production calls a no-op, preserving the Settings page.

## Screenshots

![Settings Onboarding checklist after guarded navigation](https://github.com/user-attachments/assets/0ae73b78-d202-4c86-8452-992633647518)

_Electron validation: opened Onboarding checklist through Cmd+J, then rejected a malformed navigation target without corrupting Settings or rendering an error._

## Testing

- [ ] `pnpm lint` (full repo lint not run; changed files passed oxlint)
- [x] `npm run typecheck`
- [ ] `pnpm test` (full suite not run; focused suites passed)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification:

- `npx vitest run --config config/vitest.config.ts src/renderer/src/store/slices/ui.test.ts src/renderer/src/components/settings/Settings.load-performance.test.ts` (164 passed)
- `npx oxlint` on all four changed files
- `npx oxfmt --check` on all four changed files
- `npm run check:max-lines-ratchet`
- Mutation check: temporarily restoring the unsafe direct store assignment made the new regression fail; restoring the guard made it pass.

## AI Review Report

Traced the malformed value from `openSettingsTarget` into `settingsNavigationTarget`, through `getSettingsSectionId`, and into `mountedSectionIds`; confirmed `deriveNeededSectionIds` clones that set before its truthy active and pending checks, leading to the `startsWith` crash. Reviewed the fix for target-list completeness, valid target compatibility, dev and production behavior, and ensured the source action is fixed instead of adding a downstream defensive filter.

Cross-platform review explicitly covered macOS, Linux, and Windows, plus SSH and folder workspaces. This PR changes no shortcuts, labels, paths, shell behavior, runtime-host behavior, or Electron platform integration; input validation is platform-independent.

## Security Audit

Reviewed the programmatic navigation target as untrusted runtime input. The action now validates the pane allowlist, required nullable repo ID, and optional section and intent values before storing anything. No command execution, path handling, auth, secrets, dependencies, network calls, or IPC surfaces are added or changed.

## Notes

Invalid targets throw a clear `TypeError` at the action caller in development so programmer errors are visible immediately. Production ignores invalid targets to keep Settings recoverable. No platform-specific behavior or follow-up work is required.
