### PR TITLE
Fix Node 26 test gate and happy-dom storage

### DIFF
--- a/.github/actions/install-node-dependencies/action.yml
+++ b/.github/actions/install-node-dependencies/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Native runtime to prepare after the script-free install (none, node, or electron).
     required: false
     default: none
+  node-version:
+    description: Node.js version override; defaults to the version declared in package.json.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -17,9 +21,17 @@ runs:
         run_install: false
 
     - name: Setup Node.js
+      if: inputs.node-version == ''
       uses: actions/setup-node@v6
       with:
         node-version-file: package.json
+        cache: pnpm
+
+    - name: Setup requested Node.js
+      if: inputs.node-version != ''
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
         cache: pnpm
 
     - name: Validate native runtime

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -179,12 +179,14 @@ jobs:
             src/shared/posix-command-path-lookup.test.ts
 
   test:
-    name: tests ${{ matrix.shard }}/${{ strategy.job-total }}
+    name: tests node ${{ matrix.node }} ${{ matrix.shard }}/${{ matrix.shard_total }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        node: ['24', '26']
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        shard_total: [16]
 
     steps:
       - name: Checkout
@@ -195,6 +197,7 @@ jobs:
       - uses: ./.github/actions/install-node-dependencies
         with:
           native-runtime: node
+          node-version: ${{ matrix.node }}
 
       - name: Install Electron package binary for tests
         run: node config/scripts/install-electron-package-binary.mjs
@@ -208,7 +211,7 @@ jobs:
             --exclude=src/main/providers/__tests__/shell-ready-framework-example.test.ts \
             --exclude=src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
-            --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+            --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
 
   package:
     name: package

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -37,13 +37,19 @@ describe('PR workflow parallelism', () => {
     expect(workflow.permissions).toEqual({ contents: 'read' })
   })
 
-  it('shards the general test suite across sixteen runners', () => {
+  it('shards the general test suite across Node 24 and Node 26', () => {
+    expect(workflow.jobs.test.strategy.matrix.node).toEqual(['24', '26'])
     expect(workflow.jobs.test.strategy.matrix.shard).toEqual(
       Array.from({ length: 16 }, (_, index) => index + 1)
     )
+    expect(workflow.jobs.test.strategy.matrix.shard_total).toEqual([16])
     const testStep = workflow.jobs.test.steps.find((step) => step.name === 'Test shard')
+    const installStep = workflow.jobs.test.steps.find(
+      (step) => step.uses === './.github/actions/install-node-dependencies'
+    )
 
-    expect(testStep.run).toContain('--shard=${{ matrix.shard }}/${{ strategy.job-total }}')
+    expect(installStep.with['node-version']).toBe('${{ matrix.node }}')
+    expect(testStep.run).toContain('--shard=${{ matrix.shard }}/${{ matrix.shard_total }}')
     for (const testFile of nativeShellContractFiles) {
       expect(testStep.run).toContain(`--exclude=${testFile}`)
     }
@@ -95,9 +101,15 @@ describe('PR workflow parallelism', () => {
     const steps = dependencyAction.runs.steps
     const pnpmIndex = steps.findIndex((step) => step.name === 'Setup pnpm')
     const nodeIndex = steps.findIndex((step) => step.name === 'Setup Node.js')
+    const requestedNodeIndex = steps.findIndex((step) => step.name === 'Setup requested Node.js')
 
     expect(pnpmIndex).toBeLessThan(nodeIndex)
+    expect(pnpmIndex).toBeLessThan(requestedNodeIndex)
     expect(steps[nodeIndex].with.cache).toBe('pnpm')
+    expect(steps[nodeIndex].if).toBe("inputs.node-version == ''")
+    expect(steps[requestedNodeIndex].if).toBe("inputs.node-version != ''")
+    expect(steps[requestedNodeIndex].with['node-version']).toBe('${{ inputs.node-version }}')
+    expect(steps[requestedNodeIndex].with.cache).toBe('pnpm')
   })
 
   it('restores Electron downloads before preparing the package runtime', () => {

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
+    // Why: Node 26's undefined Web Storage globals prevent Vitest from installing happy-dom's.
+    execArgv: ['--no-experimental-webstorage'],
     include: [
       'src/**/*.test.ts',
       'src/**/*.test.tsx',


### PR DESCRIPTION
## Summary

- Run every PR test shard on both Node 24 and Node 26 so runtime-specific red suites block the aggregate required check.
- Allow the shared dependency action to select a requested Node version while preserving its package.json default.
- Disable Node's experimental Web Storage in Vitest workers so happy-dom consistently supplies `window.localStorage`.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — focused `npx oxlint` passed for every changed lintable file.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the affected seven-file suite passed on Node 24 and Node 26; the complete two-runtime suite is the PR matrix.
- [ ] `pnpm build` — no production or packaging code changed.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional evidence:

- `npx vitest run --config config/vitest.config.ts <7 affected files> --maxWorkers=1`: 50/50 passed on Node 26.
- The same seven files under Node 24: 50/50 passed.
- `config/scripts/pr-workflow-parallelism.test.mjs`: 11/11 passed.
- `npx oxfmt --check <changed files>` passed.
- Gate mutation: removing the Node 24/26 matrix made the new workflow assertions fail.
- Environment mutation: removing `--no-experimental-webstorage` restored the Node 26 `window.localStorage` failure.

## AI Review Report

Reviewed the complete diff and the underlying Vitest environment setup. The review checked that all seven files are collected, that Node 24 versus Node 26 is the actual behavioral discriminator, that each runtime still receives all 16 shards, and that native dependencies are prepared after selecting the matrix runtime. It flagged `strategy.job-total` as unsafe after adding the second matrix axis because it would become 32; the workflow now carries an explicit shard total of 16.

Cross-platform review covered macOS, Linux, and Windows. The Node worker flag is supported by the repository's Node baseline on all three platforms. No shortcuts, labels, paths, shell behavior, or Electron-specific behavior changed.

## Security Audit

No application input, command execution, path handling, authentication, secrets, dependencies, or IPC behavior changed. The workflow retains read-only repository permissions, uses fixed Node version inputs, and does not expose new credentials or interpolate untrusted values into shell commands.

## Notes

- The required test matrix grows from 16 to 32 jobs so the full suite runs once per Node runtime.
- The Web Storage flag is scoped to Vitest workers; production runtime behavior is unchanged.
