### PR TITLE
fix(dashboard): remove per-worktree status dot from agent cards

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.test.tsx
@@ -144,7 +144,7 @@ describe('AgentKanbanCard', () => {
     expect(onOpenTerminal).toHaveBeenCalledTimes(1)
   })
 
-  it('labels one subagent and the workspace status accessibly', () => {
+  it('labels one subagent accessibly and never renders a workspace-status dot', () => {
     renderCard({
       card: card({
         workspaceStatusId: 'in-review',
@@ -156,7 +156,7 @@ describe('AgentKanbanCard', () => {
     })
 
     expect(screen.getByRole('button', { name: '1 subagent' })).toBeInTheDocument()
-    expect(screen.getByRole('img', { name: 'In review' })).toBeInTheDocument()
+    expect(screen.queryByRole('img', { name: 'In review' })).not.toBeInTheDocument()
   })
 
   it('tints attention amber and done green, leaving every other state neutral', () => {

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -17,7 +17,6 @@ import { cn } from '@/lib/utils'
 import type { DashboardCard } from '../../../../shared/dashboard-snapshot'
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { translate } from '@/i18n/i18n'
-import { getWorkspaceStatusVisualMeta } from '../sidebar/workspace-status'
 
 /** Compact "started N ago" (the card is glanceable — coarse units are fine). */
 function formatStartedAgo(startedAt: number, now: number): string {
@@ -93,9 +92,6 @@ function sameCard(a: DashboardCard, b: DashboardCard): boolean {
     a.leafId === b.leafId &&
     a.repoName === b.repoName &&
     a.worktreeName === b.worktreeName &&
-    a.workspaceStatusId === b.workspaceStatusId &&
-    a.workspaceStatusLabel === b.workspaceStatusLabel &&
-    a.workspaceStatusColor === b.workspaceStatusColor &&
     a.hasReview === b.hasReview &&
     a.review?.number === b.review?.number &&
     a.review?.state === b.review?.state &&
@@ -200,14 +196,6 @@ export const AgentKanbanCard = memo(
   }: AgentKanbanCardProps): React.JSX.Element {
     useTranslation()
     const [subagentsOpen, setSubagentsOpen] = useState(false)
-    const workspaceStatusMeta =
-      card.workspaceStatusId && card.workspaceStatusLabel
-        ? getWorkspaceStatusVisualMeta({
-            id: card.workspaceStatusId,
-            label: card.workspaceStatusLabel,
-            color: card.workspaceStatusColor
-          })
-        : null
     // Why: the two outcomes worth scanning for get a tinted card — amber for
     // "answer me", green for "finished, look at it". Everything else stays
     // neutral so the tint keeps meaning something.
@@ -322,14 +310,6 @@ export const AgentKanbanCard = memo(
           onClick={() => onOpenTerminal(card)}
           className="flex w-full items-center gap-2 rounded-md text-left text-[11px] text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
         >
-          {workspaceStatusMeta ? (
-            <span
-              role="img"
-              aria-label={card.workspaceStatusLabel}
-              className={cn('size-2 shrink-0 rounded-full', workspaceStatusMeta.swatch)}
-              title={card.workspaceStatusLabel}
-            />
-          ) : null}
           <Tooltip>
             <TooltipTrigger asChild>
               <span


### PR DESCRIPTION
## Summary

Removes the per-worktree workspace-status dot (e.g. the amber "In progress" swatch) from agent cards on the agent dashboard. The dot rendered in each card's footer next to the repo icon and duplicated sidebar state that isn't about the agent itself. One component (`AgentKanbanCard`) serves both the in-app dashboard drawer and the pop-out window, so both surfaces lose the dot.

The workspace-status *filter* in the dashboard toolbar is intentionally untouched — this PR only removes the per-card indicator, so the `workspaceStatus*` fields stay on `DashboardCard`. The card's memo comparator no longer diffs those fields since they no longer affect rendering.

## Screenshots

Before (dot + "In progress" tooltip in the card footer):

![before](https://github.com/user-attachments/assets/9a615acf-afd6-4e70-9380-be367b5efee3)

After: the footer starts at the repo icon; no status dot renders.

![After — agent card footer begins at the repo icon with no workspace-status dot](https://github.com/user-attachments/assets/033650db-ab4c-47c1-ad47-fd75d8269aab)

## Testing

- [x] `pnpm lint` — oxlint + react-doctor oxlint + oxfmt ran clean on the changed files (pre-commit hook); full audit suite left to CI
- [x] `pnpm typecheck`
- [x] `pnpm test` — `AgentKanbanCard`, `dashboard-popout`, and `build-dashboard-snapshot` suites (146 tests) pass locally; full suite left to CI
- [ ] `pnpm build` — not run locally; renderer-only TSX removal, covered by typecheck + CI
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed — the accessibility test now asserts the status dot does **not** render even when the card carries `workspaceStatusId/Label/Color`

## AI Review Report

Change reviewed for: (1) dead references after removal — the `getWorkspaceStatusVisualMeta` import and `workspaceStatusMeta` computation are removed with the dot, and no other code in `AgentKanbanCard` reads the status fields; (2) memo-comparator correctness — dropping the three `workspaceStatus*` comparisons from `sameCard` is safe because the card no longer renders anything derived from them, and board-level filtering (which still uses `workspaceStatusId`) recomputes visible cards outside the card memo; (3) both dashboard surfaces (drawer + pop-out) render through this one component, so no surface keeps a stale dot. Cross-platform: no shortcuts, labels, paths, shell, or Electron platform behavior are touched — this is a pure JSX/markup removal identical on macOS, Linux, and Windows.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes — the diff only deletes a presentational element and its memo comparisons in the renderer. No follow-up needed.

## Notes

- The dashboard toolbar can still filter by workspace status; if that should go too, it's a separate scoped change.
- Worktree sidebar and workspace kanban status indicators are unrelated surfaces and are unchanged.

