### PR TITLE
fix(remote): keep resumed agent tabs stable on headed hosts

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -24428,6 +24428,117 @@ describe('OrcaRuntimeService', () => {
     ])
   })
 
+  it('keeps a live headed runtime-owned tab until its explicit close', async () => {
+    const ptyId = 'local-runtime-owned-pty'
+    const splitPtyId = 'local-runtime-owned-split-pty'
+    const tabId = 'runtime-session-tab'
+    const leafId = HEADLESS_LEAF_ID
+    const kill = vi.fn(() => true)
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      activeRepoId: TEST_REPO_ID,
+      activeWorktreeId: TEST_WORKTREE_ID,
+      tabsByWorktree: {
+        [TEST_WORKTREE_ID]: [
+          {
+            id: tabId,
+            ptyId: null,
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Codex',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            launchAgent: 'codex'
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        [tabId]: makeHeadlessTerminalLayout({ [leafId]: undefined })
+      }
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValueOnce({ id: ptyId }).mockResolvedValueOnce({ id: splitPtyId }),
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: ptyId,
+          cwd: TEST_WORKTREE_PATH,
+          title: 'Codex',
+          worktreeId: TEST_WORKTREE_ID
+        },
+        {
+          id: splitPtyId,
+          cwd: TEST_WORKTREE_PATH,
+          title: 'Codex',
+          worktreeId: TEST_WORKTREE_ID
+        }
+      ]
+    })
+    const publishRendererOmission = (snapshotVersion: number): void => {
+      runtime.syncWindowGraph(1, {
+        tabs: [],
+        leaves: [],
+        mobileSessionTabs: [
+          {
+            worktree: TEST_WORKTREE_ID,
+            publicationEpoch: 'headed-runtime',
+            snapshotVersion,
+            activeGroupId: 'group-1',
+            activeTabId: null,
+            activeTabType: null,
+            tabs: []
+          }
+        ]
+      })
+    }
+    runtime.attachWindow(1)
+    publishRendererOmission(1)
+    electronMocks.BrowserWindow.fromId.mockReturnValue({
+      isDestroyed: () => false,
+      webContents: { send: vi.fn() }
+    })
+
+    const created = await runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, {
+      presentation: 'background',
+      persistHostSessionBinding: true,
+      tabId,
+      leafId,
+      launchAgent: 'codex'
+    })
+    const split = await runtime.splitTerminal(created.handle, { direction: 'vertical' })
+    publishRendererOmission(2)
+
+    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: `${tabId}::${leafId}`,
+          parentTabId: tabId,
+          ptyId,
+          status: 'ready',
+          terminal: created.handle
+        }),
+        expect.objectContaining({
+          parentTabId: tabId,
+          ptyId: splitPtyId,
+          status: 'ready',
+          terminal: split.handle
+        })
+      ])
+    )
+    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toHaveLength(2)
+
+    await runtime.closeMobileSessionTab(`id:${TEST_WORKTREE_ID}`, tabId, { reason: 'user' })
+    publishRendererOmission(3)
+
+    expect(kill).toHaveBeenCalledWith(ptyId)
+    expect(kill).toHaveBeenCalledWith(splitPtyId)
+    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([])
+  })
+
   it('publishes laptop-created remote runtime terminals to phone session tabs', async () => {
     const spawn = vi.fn().mockResolvedValue({ id: 'laptop-created-pty' })
     const runtime = new OrcaRuntimeService(store)
@@ -28691,7 +28802,7 @@ describe('OrcaRuntimeService', () => {
           {
             tabId: 'tab-renderer',
             worktreeId: TEST_WORKTREE_ID,
-            leafId: 'pane:1',
+            leafId: HEADLESS_LEAF_ID,
             paneRuntimeId: 1,
             ptyId: 'pty-renderer',
             paneTitle: null
@@ -28708,10 +28819,12 @@ describe('OrcaRuntimeService', () => {
             tabs: [
               {
                 type: 'terminal',
-                id: 'tab-renderer::pane:1',
+                id: `tab-renderer::${HEADLESS_LEAF_ID}`,
                 parentTabId: 'tab-renderer',
-                leafId: 'pane:1',
+                leafId: HEADLESS_LEAF_ID,
+                ptyId: 'pty-renderer',
                 title: 'Terminal',
+                viewMode: 'chat',
                 isActive: false
               }
             ]
@@ -28752,6 +28865,86 @@ describe('OrcaRuntimeService', () => {
     )
     expect(focusTerminal).not.toHaveBeenCalled()
     expect(result.tab).toMatchObject({ parentTabId: 'tab-renderer', isActive: false })
+
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [
+        {
+          tabId: 'tab-renderer',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId: 'pty-renderer',
+          paneTitle: null
+        }
+      ],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'epoch-1',
+          snapshotVersion: 2,
+          activeGroupId: 'group-1',
+          activeTabId: null,
+          activeTabType: null,
+          tabs: []
+        }
+      ]
+    })
+
+    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([
+      expect.objectContaining({ parentTabId: 'tab-renderer', ptyId: 'pty-renderer' })
+    ])
+
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [
+        {
+          tabId: 'tab-renderer',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_SECOND_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId: 'pty-renderer',
+          paneTitle: null
+        }
+      ],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'epoch-1',
+          snapshotVersion: 3,
+          activeGroupId: 'group-1',
+          activeTabId: null,
+          activeTabType: null,
+          tabs: []
+        }
+      ]
+    })
+    runtime.syncWindowGraph(1, {
+      tabs: [],
+      leaves: [
+        {
+          tabId: 'tab-renderer',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_SECOND_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId: 'pty-renderer',
+          paneTitle: null
+        }
+      ],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'epoch-1',
+          snapshotVersion: 4,
+          activeGroupId: 'group-1',
+          activeTabId: null,
+          activeTabType: null,
+          tabs: []
+        }
+      ]
+    })
+
+    expect((await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)).tabs).toEqual([])
   })
 
   it('dedupes concurrent mobile terminal creates that share a clientMutationId', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1198,6 +1198,7 @@ type RuntimePtyWorktreeRecord = {
   incarnationId: PtyIncarnationId | null
   worktreeId: string
   connectionId: string | null
+  runtimeSessionOwned: boolean
   // Why: a Windows host can own both native and WSL panes; preamble command
   // selection must follow the pane that executes it, not process.platform.
   isWsl: boolean | null
@@ -5712,6 +5713,35 @@ export class OrcaRuntimeService {
     return boundPtyIds.some((ptyId) => persistedPtyIds.has(ptyId))
   }
 
+  private hasLiveRuntimeSessionOwnedPtyBinding(
+    worktreeId: string,
+    tab: RuntimeMobileSessionTerminalTab
+  ): boolean {
+    const pty = this.findPtyForMobileTerminalTab(worktreeId, tab)
+    return pty?.connected === true && pty.runtimeSessionOwned
+  }
+
+  private clearRuntimeSessionOwnershipForMobileTab(
+    worktreeId: string,
+    snapshot: RuntimeMobileSessionTabsSnapshot,
+    parentTabId: string
+  ): void {
+    for (const tab of snapshot.tabs) {
+      if (tab.type !== 'terminal' || tab.parentTabId !== parentTabId) {
+        continue
+      }
+      const ptyIds = [tab.ptyId, ...Object.values(tab.parentLayout?.ptyIdsByLeafId ?? {})].filter(
+        (ptyId): ptyId is string => typeof ptyId === 'string'
+      )
+      for (const ptyId of ptyIds) {
+        const pty = this.ptysById.get(ptyId)
+        if (pty?.worktreeId === worktreeId && pty.tabId === parentTabId) {
+          pty.runtimeSessionOwned = false
+        }
+      }
+    }
+  }
+
   // Why: a tab needs authoritative runtime teardown (kill + de-persist + prune)
   // only when the renderer can't durably tear it down: either it's serve/SSH
   // (preserved + re-hydrated, would resurrect) or the renderer graph never
@@ -7170,6 +7200,7 @@ export class OrcaRuntimeService {
           this.notifyRendererOfHeadlessTerminalClose(tab.parentTabId)
           this.store?.flushOrThrow?.()
         }
+        this.clearRuntimeSessionOwnershipForMobileTab(worktreeId, snapshot!, tab.parentTabId)
         return { closed: true }
       }
       // Why: notifier implementations without the acknowledged relay may expose
@@ -7197,6 +7228,7 @@ export class OrcaRuntimeService {
         // parent tab id. Closing that parent should close the desktop tab, not
         // just whichever leaf happened to be first in the session snapshot.
         this.notifier?.closeTerminal(tab.parentTabId)
+        this.clearRuntimeSessionOwnershipForMobileTab(worktreeId, snapshot!, tab.parentTabId)
       }
     } else if (tab.type === 'browser' && this.offscreenBrowserBackend) {
       // Why: headless browser tabs are offscreen WebContents with no renderer to
@@ -7341,6 +7373,7 @@ export class OrcaRuntimeService {
     options: { killPtys?: boolean } = {}
   ): void {
     const closedParentTabId = tab.parentTabId
+    this.clearRuntimeSessionOwnershipForMobileTab(worktreeId, snapshot, closedParentTabId)
     const projectedPtyIds = this.removePersistedHeadlessTerminalTab(worktreeId, closedParentTabId)
     // Why: local provider ids can be reused after restart, so a dormant
     // persisted id is not kill authority. SSH relay ids remain durable exact
@@ -8488,6 +8521,9 @@ export class OrcaRuntimeService {
     this.recordPtyWorktree(ptyId, worktreeId, {
       connected: true,
       connectionId,
+      ...(binding && this.pendingMobileTerminalCreatesByKey.has(`${worktreeId}::${binding.tabId}`)
+        ? { runtimeSessionOwned: true }
+        : {}),
       ...(isWsl !== undefined ? { isWsl } : {}),
       ...(binding && paneKey ? { tabId: binding.tabId, paneKey } : {}),
       ...(binding?.incarnationId ? { incarnationId: binding.incarnationId } : {})
@@ -12463,6 +12499,7 @@ export class OrcaRuntimeService {
     this.agentDetector?.onExit(ptyId)
     if (pty) {
       pty.connected = false
+      pty.runtimeSessionOwned = false
       pty.disconnectedAt = Date.now()
       pty.lastExitCode = exitCode
       this.resolvePtyExitWaiters(pty, ptyId)
@@ -23710,6 +23747,9 @@ export class OrcaRuntimeService {
       })
       const pty = this.getOrCreatePtyWorktreeRecord(result.id)
       if (pty) {
+        if (launchOpts.persistHostSessionBinding) {
+          pty.runtimeSessionOwned = true
+        }
         if (launchOpts.title) {
           const observedAt = this.nextTitleObservationSequence()
           pty.title = launchOpts.title
@@ -24616,6 +24656,10 @@ export class OrcaRuntimeService {
       return null
     }
     const existing = this.findMobileTerminalSurface(worktreeId, tabId)
+    const pty = this.findLiveRegisteredPtyForRendererTab(worktreeId, tabId)
+    if (pty) {
+      pty.runtimeSessionOwned = true
+    }
     if (
       existing &&
       this.isReadyMobileTerminalSurface(existing) &&
@@ -24624,7 +24668,6 @@ export class OrcaRuntimeService {
       // Why: the renderer's ready publication already landed with the intended mode; only a pending shell needs the main-side rescue.
       return existing
     }
-    const pty = this.findLiveRegisteredPtyForRendererTab(worktreeId, tabId)
     const leafId = pty ? parsePaneKey(pty.paneKey ?? '')?.leafId : undefined
     if (!pty || !leafId) {
       return existing
@@ -25063,6 +25106,7 @@ export class OrcaRuntimeService {
     if (createdPty) {
       createdPty.tabId = parentTabId
       createdPty.paneKey = paneKey
+      createdPty.runtimeSessionOwned = pty.runtimeSessionOwned
     }
 
     try {
@@ -26931,6 +26975,7 @@ export class OrcaRuntimeService {
         | 'paneKey'
         | 'title'
         | 'connectionId'
+        | 'runtimeSessionOwned'
         | 'isWsl'
         | 'wslDistro'
         | 'incarnationId'
@@ -26955,6 +27000,7 @@ export class OrcaRuntimeService {
         incarnationId: state.incarnationId ?? null,
         worktreeId,
         connectionId,
+        runtimeSessionOwned: state.runtimeSessionOwned ?? false,
         isWsl: state.isWsl ?? null,
         wslDistro,
         tabId: state.tabId ?? null,
@@ -27011,6 +27057,9 @@ export class OrcaRuntimeService {
         pty.wslDistro = null
         this.wslDistroByPtyId.delete(ptyId)
       }
+    }
+    if (state.runtimeSessionOwned !== undefined) {
+      pty.runtimeSessionOwned = state.runtimeSessionOwned
     }
     if (state.isWsl !== undefined) {
       pty.isWsl = state.isWsl
@@ -27804,6 +27853,7 @@ export class OrcaRuntimeService {
     // are runtime-owned and preservable.
     return (
       this.isHeadlessBuiltMobileSessionPublicationBase(snapshot.publicationEpoch) ||
+      this.hasLiveRuntimeSessionOwnedPtyBinding(snapshot.worktree, tab) ||
       this.hasLiveOrPersistedServeOrSshOwnedPtyBinding(snapshot.worktree, tab)
     )
   }

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1895,7 +1895,7 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.sortEpoch).toBe(1)
   })
 
-  it('updates a mirrored same-state entry when resume identity arrives', () => {
+  it('repairs mirrored same-state attribution and retains identity from an older snapshot', () => {
     const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
     const snapshot = makeSnapshot([
       {
@@ -1929,11 +1929,15 @@ describe('applyWebSessionTabsSnapshot', () => {
     ) as Partial<WebSessionTabsSyncState>
     const mirroredPaneKey = Object.keys(initial.agentStatusByPaneKey ?? {})[0]!
     const existing = initial.agentStatusByPaneKey![mirroredPaneKey]!
-    const patch = applyWebSessionTabsSnapshot(
+    const attributionPatch = applyWebSessionTabsSnapshot(
       makeState({
         ...initial,
         agentStatusByPaneKey: {
-          [mirroredPaneKey]: { ...existing, providerSession: undefined }
+          [mirroredPaneKey]: {
+            ...existing,
+            worktreeId: 'stale-worktree',
+            tabId: 'stale-tab'
+          }
         },
         agentStatusEpoch: 7,
         sortEpoch: 11
@@ -1943,12 +1947,37 @@ describe('applyWebSessionTabsSnapshot', () => {
       NOW
     ) as Partial<WebSessionTabsSyncState>
 
-    expect(patch.agentStatusByPaneKey?.[mirroredPaneKey]?.providerSession).toEqual({
+    expect(attributionPatch.agentStatusByPaneKey?.[mirroredPaneKey]).toMatchObject({
+      worktreeId: existing.worktreeId,
+      tabId: existing.tabId
+    })
+    expect(attributionPatch.agentStatusEpoch).toBe(8)
+    expect(attributionPatch.sortEpoch).toBe(12)
+
+    const identityPatch = applyWebSessionTabsSnapshot(
+      makeState({
+        ...initial,
+        ...attributionPatch,
+        agentStatusByPaneKey: {
+          [mirroredPaneKey]: {
+            ...attributionPatch.agentStatusByPaneKey![mirroredPaneKey]!,
+            updatedAt: NOW,
+            providerSession: undefined
+          }
+        }
+      }),
+      { ...snapshot, snapshotVersion: 3 },
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(identityPatch.agentStatusByPaneKey?.[mirroredPaneKey]?.providerSession).toEqual({
       key: 'session_id',
       id: 'session-1'
     })
-    expect(patch.agentStatusEpoch).toBe(7)
-    expect(patch.sortEpoch).toBe(11)
+    expect(identityPatch.agentStatusByPaneKey?.[mirroredPaneKey]?.updatedAt).toBe(NOW)
+    expect(identityPatch.agentStatusEpoch).toBe(8)
+    expect(identityPatch.sortEpoch).toBe(12)
   })
 
   it('keeps mirrored OMP tabs from repainting to Pi-compatible titles', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2007,6 +2007,49 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(identityPatch.agentStatusByPaneKey?.[mirroredPaneKey]?.updatedAt).toBe(NOW)
     expect(identityPatch.agentStatusEpoch).toBe(8)
     expect(identityPatch.sortEpoch).toBe(12)
+
+    const nextTurnPatch = applyWebSessionTabsSnapshot(
+      makeState({
+        ...initial,
+        agentStatusByPaneKey: {
+          [mirroredPaneKey]: {
+            ...existing,
+            state: 'working',
+            updatedAt: NOW,
+            stateStartedAt: NOW,
+            worktreeId: 'stale-worktree',
+            tabId: 'stale-tab',
+            providerSession: undefined
+          }
+        }
+      }),
+      {
+        ...snapshot,
+        snapshotVersion: 5,
+        tabs: snapshot.tabs.map((tab) =>
+          tab.type === 'terminal' && tab.agentStatus
+            ? {
+                ...tab,
+                agentStatus: {
+                  ...tab.agentStatus,
+                  state: 'done',
+                  providerSession: { key: 'session_id', id: 'previous-session' }
+                }
+              }
+            : tab
+        )
+      },
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(nextTurnPatch.agentStatusByPaneKey?.[mirroredPaneKey]).toMatchObject({
+      state: 'working',
+      stateStartedAt: NOW,
+      worktreeId: WT,
+      tabId: existing.tabId
+    })
+    expect(nextTurnPatch.agentStatusByPaneKey?.[mirroredPaneKey]?.providerSession).toBeUndefined()
   })
 
   it('keeps mirrored OMP tabs from repainting to Pi-compatible titles', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1954,6 +1954,35 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(attributionPatch.agentStatusEpoch).toBe(8)
     expect(attributionPatch.sortEpoch).toBe(12)
 
+    const fresherAttributionPatch = applyWebSessionTabsSnapshot(
+      makeState({
+        ...initial,
+        agentStatusByPaneKey: {
+          [mirroredPaneKey]: {
+            ...existing,
+            updatedAt: NOW,
+            worktreeId: 'stale-worktree',
+            tabId: 'stale-tab',
+            providerSession: undefined
+          }
+        },
+        agentStatusEpoch: 7,
+        sortEpoch: 11
+      }),
+      { ...snapshot, snapshotVersion: 3 },
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(fresherAttributionPatch.agentStatusByPaneKey?.[mirroredPaneKey]).toMatchObject({
+      worktreeId: existing.worktreeId,
+      tabId: existing.tabId,
+      updatedAt: NOW,
+      providerSession: { key: 'session_id', id: 'session-1' }
+    })
+    expect(fresherAttributionPatch.agentStatusEpoch).toBe(8)
+    expect(fresherAttributionPatch.sortEpoch).toBe(12)
+
     const identityPatch = applyWebSessionTabsSnapshot(
       makeState({
         ...initial,
@@ -1966,7 +1995,7 @@ describe('applyWebSessionTabsSnapshot', () => {
           }
         }
       }),
-      { ...snapshot, snapshotVersion: 3 },
+      { ...snapshot, snapshotVersion: 4 },
       ENV,
       NOW
     ) as Partial<WebSessionTabsSyncState>

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1866,7 +1866,10 @@ describe('applyWebSessionTabsSnapshot', () => {
             stateStartedAt: NOW - 1_000,
             agentType: 'codex',
             paneKey: hostPaneKey,
+            tabId: 'host-tab-1',
+            worktreeId: WT,
             terminalTitle: 'codex [working]',
+            providerSession: { key: 'session_id', id: 'session-1' },
             stateHistory: []
           }
         }
@@ -1882,6 +1885,9 @@ describe('applyWebSessionTabsSnapshot', () => {
       prompt: 'fix web parity',
       agentType: 'codex',
       paneKey: mirroredPaneKey,
+      tabId: mirroredId,
+      worktreeId: WT,
+      providerSession: { key: 'session_id', id: 'session-1' },
       terminalTitle: 'codex [working]'
     })
     expect(patch.agentStatusByPaneKey?.[hostPaneKey]).toBeUndefined()
@@ -1889,7 +1895,7 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(patch.sortEpoch).toBe(1)
   })
 
-  it('bumps aggregate epochs when a mirrored same-state entry gains attribution', () => {
+  it('updates a mirrored same-state entry when resume identity arrives', () => {
     const hostPaneKey = makePaneKey('host-tab-1', LEAF_ID)
     const snapshot = makeSnapshot([
       {
@@ -1910,6 +1916,7 @@ describe('applyWebSessionTabsSnapshot', () => {
           paneKey: hostPaneKey,
           worktreeId: WT,
           tabId: 'host-tab-1',
+          providerSession: { key: 'session_id', id: 'session-1' },
           stateHistory: []
         }
       }
@@ -1926,7 +1933,7 @@ describe('applyWebSessionTabsSnapshot', () => {
       makeState({
         ...initial,
         agentStatusByPaneKey: {
-          [mirroredPaneKey]: { ...existing, worktreeId: 'stale-worktree', tabId: 'stale-tab' }
+          [mirroredPaneKey]: { ...existing, providerSession: undefined }
         },
         agentStatusEpoch: 7,
         sortEpoch: 11
@@ -1936,8 +1943,12 @@ describe('applyWebSessionTabsSnapshot', () => {
       NOW
     ) as Partial<WebSessionTabsSyncState>
 
-    expect(patch.agentStatusEpoch).toBe(8)
-    expect(patch.sortEpoch).toBe(12)
+    expect(patch.agentStatusByPaneKey?.[mirroredPaneKey]?.providerSession).toEqual({
+      key: 'session_id',
+      id: 'session-1'
+    })
+    expect(patch.agentStatusEpoch).toBe(7)
+    expect(patch.sortEpoch).toBe(11)
   })
 
   it('keeps mirrored OMP tabs from repainting to Pi-compatible titles', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -716,7 +716,10 @@ function buildMirroredAgentStatusPatch(
     // Why: an active web stream can report a fresher OSC 9999 status before the next host snapshot, so don't rewind it with an older host publication.
     const nextEntry =
       existing && existing.updatedAt > entry.updatedAt
-        ? normalizeCompatibleAgentStatusEntryForOwner(existing, entry.agentType)
+        ? {
+            ...normalizeCompatibleAgentStatusEntryForOwner(existing, entry.agentType),
+            providerSession: existing.providerSession ?? entry.providerSession
+          }
         : entry
     nextByPaneKey.set(entry.paneKey, nextEntry)
   }

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -713,11 +713,14 @@ function buildMirroredAgentStatusPatch(
       continue
     }
     const existing = state.agentStatusByPaneKey[entry.paneKey]
-    // Why: an active web stream can report a fresher OSC 9999 status before the next host snapshot, so don't rewind it with an older host publication.
+    // Why: keep fresher OSC state while taking remapped ownership metadata from the authoritative host snapshot.
     const nextEntry =
       existing && existing.updatedAt > entry.updatedAt
         ? {
             ...normalizeCompatibleAgentStatusEntryForOwner(existing, entry.agentType),
+            paneKey: entry.paneKey,
+            worktreeId: entry.worktreeId ?? existing.worktreeId,
+            tabId: entry.tabId,
             providerSession: existing.providerSession ?? entry.providerSession
           }
         : entry

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -8,6 +8,7 @@ import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry
 } from '../../../shared/agent-status-types'
+import { agentProviderSessionsEqual } from '../../../shared/agent-session-resume'
 import type {
   RuntimeMobileSessionTabsResult,
   RuntimeMobileSessionBrowserTab,
@@ -674,7 +675,8 @@ function remapHostAgentStatus(surface: TerminalSurface): AgentStatusEntry | null
   })
   return {
     ...normalizeCompatibleAgentStatusEntryForOwner(surface.agentStatus, ownerAgent),
-    paneKey
+    paneKey,
+    tabId: toWebTerminalSurfaceTabId(surface.parentTabId)
   }
 }
 
@@ -1346,6 +1348,7 @@ function agentStatusEntryEqual(a: AgentStatusEntry | undefined, b: AgentStatusEn
     a.lastAssistantMessage === b.lastAssistantMessage &&
     a.interrupted === b.interrupted &&
     a.promptInteractionKey === b.promptInteractionKey &&
+    agentProviderSessionsEqual(a.agentType, a.providerSession, b.providerSession) &&
     sameAgentStateHistory(a.stateHistory, b.stateHistory)
   )
 }

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -714,6 +714,11 @@ function buildMirroredAgentStatusPatch(
     }
     const existing = state.agentStatusByPaneKey[entry.paneKey]
     // Why: keep fresher OSC state while taking remapped ownership metadata from the authoritative host snapshot.
+    const hostIdentityPredatesCurrentTurn =
+      existing !== undefined &&
+      entry.state === 'done' &&
+      existing.state !== 'done' &&
+      existing.stateStartedAt > entry.stateStartedAt
     const nextEntry =
       existing && existing.updatedAt > entry.updatedAt
         ? {
@@ -721,7 +726,9 @@ function buildMirroredAgentStatusPatch(
             paneKey: entry.paneKey,
             worktreeId: entry.worktreeId ?? existing.worktreeId,
             tabId: entry.tabId,
-            providerSession: existing.providerSession ?? entry.providerSession
+            providerSession:
+              existing.providerSession ??
+              (hostIdentityPredatesCurrentTurn ? undefined : entry.providerSession)
           }
         : entry
     nextByPaneKey.set(entry.paneKey, nextEntry)


### PR DESCRIPTION
## Summary

- keep headed runtime-session terminals when a renderer snapshot temporarily omits them
- track ownership through structured runtime creates, renderer-backed creates, and splits
- clear ownership on explicit close, headless retirement, and PTY exit
- require the exact worktree/tab/leaf PTY binding before preserving a tab
- remap host agent status to the paired client's `web-terminal-*` identity and retain the correct provider identity without restoring an older turn

## Root cause

A headed desktop runtime can create a local PTY on behalf of a paired client. The PTY remains live and authoritative in main, but the host renderer can omit its synthetic session tab during reconciliation. The previous preservation predicate only recognized headless, `serve-*`, and SSH-owned PTYs, so a live local PTY created through the runtime-session path could be dropped from the publication while its process remained alive.

The runtime now records whether a PTY is runtime-session-owned and preserves it only while its exact worktree, parent tab, and leaf binding is still live. Splits inherit ownership. Explicit close, retirement, and exit clear it, so this does not turn stale or rebound PTYs into durable tabs.

The renderer-side reconciliation also keeps the paired client's remapped ownership/provider metadata and prevents an older host `done` snapshot from restoring a previous provider session onto a newer client `working` turn.

## Compatibility and performance

- Local, WSL, SSH, and folder-workspace routing is unchanged.
- Existing `serve-*`, SSH, and headless preservation remains intact.
- The hot preservation check uses the already-bound terminal lookup plus a boolean ownership flag; it adds no polling, provider inventories, or broad PTY scans.
- Cleanup work is bounded to the tab's published leaves and runs only on close/retirement/exit paths.

## Validation

### Headed Electron paired-runtime validation on final source

Validated commit `59db88d257` on macOS with an isolated headed Electron host and a separate paired Electron client. The harness rejected local scope and required:

```text
activeRuntimeEnvironmentId = 660bdb1b-b0cc-4b73-a185-5b938ccbb686
hostId = runtime:660bdb1b-b0cc-4b73-a185-5b938ccbb686
```

A structured Codex resume fixture reported through Orca's real hook and OSC status paths. The client switched to a second worktree for 15 seconds (past the 10-second close-intent TTL), returned, and confirmed:

| Assertion | Result |
|---|---|
| Mirrored tab/pane remapped to `web-terminal-*` | PASS |
| Provider identity retained | PASS (`session_id: pr11448-electron-resume`) |
| `working` state remains on the resumed tab | PASS |
| Exact authoritative PTY and handle remain connected | PASS |
| Agent process spawn count | PASS (exactly 1) |

This run covers the renderer-backed headed-host topology that previously dropped locally owned runtime PTYs. It is isolated same-machine pairing, not a physical remote-server, Windows, or Linux rerun. The earlier Windows 11 real-Codex validation still covers the original paired-runtime reproduction and renderer identity behavior, but the final ownership fix was not rerun on that rig.

### Automated checks

- [x] Same-model review loop; one exact-leaf-binding issue fixed, follow-up review clean
- [x] Focused Vitest: 986 passed, 1 skipped
- [x] Broader related matrix: 1,064 passed, 1 skipped
- [x] `pnpm run typecheck:node`
- [x] `pnpm run typecheck:web`
- [x] touched-file oxlint, native-plugin audit, and type-aware audit
- [x] touched-file `oxfmt --check`
- [x] `pnpm run check:max-lines-ratchet`
- [x] `pnpm run check:reliability-gates`
- [x] `git diff --check`
- [x] final E2E Electron and web builds

## Screenshots

Resumed agent working before the worktree round trip:

![pr11448-runtime-resume-before-roundtrip.png](https://github.com/user-attachments/assets/7a05da43-a887-4cba-a3ae-6c618d5d652d)

The same resumed tab and working agent after 15 seconds away and re-entry:

![pr11448-runtime-resume-after-15s-reentry.png](https://github.com/user-attachments/assets/ad35d0a9-4fad-49f7-aaa0-ac9135706998)

## Review history

- Same-model review found that the first ownership predicate did not verify the exact leaf binding. The fix now uses the authoritative terminal lookup, with PTY-rebinding and two-PTY split-close regressions. Follow-up review returned clean.
- Greptile's provider-identity loss finding was fixed in `d644677a8c`.
- Greptile's stale-attribution edge was fixed in `a73e37c032`.
- CodeRabbit reported no code-level findings on the earlier renderer changes.

## Security

No authentication, authorization, credential, filesystem, shell, or network-routing behavior changed. The new state is an in-memory PTY ownership marker used only by session-tab preservation and cleanup.
