### PR TITLE
feat(browser): add Vivaldi as a Chromium cookie-import source

### DIFF
--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -803,7 +803,8 @@ describe('detectInstalledBrowsers', () => {
       'firefox',
       'safari',
       'comet',
-      'helium'
+      'helium',
+      'vivaldi'
     ]
     for (const browser of browsers) {
       expect(validFamilies).toContain(browser.family)

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -171,6 +171,15 @@ const CHROMIUM_BROWSERS: ChromiumBrowserDef[] = [
     keychainAccount: 'Helium',
     macRoot: 'net.imput.helium'
     // winRoot/linuxRoot intentionally omitted — only the macOS install is verified
+  },
+  {
+    family: 'vivaldi',
+    label: 'Vivaldi',
+    keychainService: 'Vivaldi Safe Storage',
+    keychainAccount: 'Vivaldi',
+    macRoot: 'Vivaldi',
+    winRoot: 'Vivaldi/User Data',
+    linuxRoot: 'vivaldi'
   }
 ]
 
@@ -768,6 +777,79 @@ export async function importCookiesFromFile(
     targetPartition,
     'replace-imported-domains'
   )
+}
+
+// ---------------------------------------------------------------------------
+// Direct import from installed Chromium browser
+// ---------------------------------------------------------------------------
+
+/** Return a source-browser-compatible User-Agent for cookie authentication.
+ * Services bind auth cookies to the User-Agent that created them. */
+export function getUserAgentForBrowser(
+  family: BrowserSessionProfileSource['browserFamily']
+): string | null {
+  // Why: UA version comes from macOS-only plist reading; elsewhere the default Electron UA is acceptable.
+  if (process.platform !== 'darwin') {
+    return null
+  }
+
+  const platform = 'Macintosh; Intel Mac OS X 10_15_7'
+  const chromeBase = 'AppleWebKit/537.36 (KHTML, like Gecko)'
+
+  /** Read a macOS browser bundle version without surfacing plist failures. */
+  function readBrowserVersion(
+    appPath: string,
+    plistKey = 'CFBundleShortVersionString'
+  ): string | null {
+    try {
+      return (
+        execFileSync('defaults', ['read', join(appPath, 'Contents', 'Info'), plistKey], {
+          encoding: 'utf-8',
+          timeout: 5_000
+        }).trim() || null
+      )
+    } catch {
+      return null
+    }
+  }
+
+  switch (family) {
+    case 'chrome': {
+      const v = readBrowserVersion('/Applications/Google Chrome.app')
+      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+    }
+    case 'edge': {
+      const v = readBrowserVersion('/Applications/Microsoft Edge.app')
+      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36 Edg/${v}` : null
+    }
+    case 'arc': {
+      const v = readBrowserVersion('/Applications/Arc.app')
+      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+    }
+    case 'chromium': {
+      const v = readBrowserVersion('/Applications/Brave Browser.app')
+      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+    }
+    case 'comet': {
+      // Why: Comet is Chromium-based; use Chrome's UA shape so Google-bound auth cookies survive import.
+      const v = readBrowserVersion('/Applications/Comet.app')
+      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+    }
+    case 'helium': {
+      // Why: Helium is Chromium-based; use Chrome's UA shape so Google-bound auth cookies survive import.
+      const v = readBrowserVersion('/Applications/Helium.app')
+      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+    }
+    case 'vivaldi': {
+      // Why: Vivaldi is Chromium-based; use Chrome's UA shape so Google-bound auth cookies survive import.
+      const v = readBrowserVersion('/Applications/Vivaldi.app')
+      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
+    }
+    case 'firefox':
+    case 'safari':
+    case 'manual':
+      return null
+  }
 }
 
 const PBKDF2_ITERATIONS = 1003

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -840,11 +840,8 @@ export function getUserAgentForBrowser(
       const v = readBrowserVersion('/Applications/Helium.app')
       return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
     }
-    case 'vivaldi': {
-      // Why: Vivaldi is Chromium-based; use Chrome's UA shape so Google-bound auth cookies survive import.
-      const v = readBrowserVersion('/Applications/Vivaldi.app')
-      return v ? `Mozilla/5.0 (${platform}) ${chromeBase} Chrome/${v} Safari/537.36` : null
-    }
+    // Why: Vivaldi's bundle exposes only its product version (8.x), so Chrome/8.x would name a Chromium release that never existed; the cleaned Electron UA already matches its real Chrome major.
+    case 'vivaldi':
     case 'firefox':
     case 'safari':
     case 'manual':

--- a/src/main/browser/browser-cookie-import.vivaldi.test.ts
+++ b/src/main/browser/browser-cookie-import.vivaldi.test.ts
@@ -20,6 +20,15 @@ function slashPath(pathValue: string): string {
   return pathValue.replaceAll('\\', '/')
 }
 
+/** Restore an environment variable without persisting the string "undefined". */
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key]
+    return
+  }
+  process.env[key] = value
+}
+
 type VivaldiInstallMockOptions = {
   pathExistsOverride?: (normalizedPath: string) => boolean | undefined
   infoCache?: Record<string, { name: string }>
@@ -76,9 +85,9 @@ describe('detectInstalledBrowsers — Vivaldi', () => {
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform })
-    process.env.HOME = originalHome
-    process.env.LOCALAPPDATA = originalLocalAppData
-    process.env.XDG_CONFIG_HOME = originalConfigHome
+    restoreEnv('HOME', originalHome)
+    restoreEnv('LOCALAPPDATA', originalLocalAppData)
+    restoreEnv('XDG_CONFIG_HOME', originalConfigHome)
     vi.restoreAllMocks()
   })
 

--- a/src/main/browser/browser-cookie-import.vivaldi.test.ts
+++ b/src/main/browser/browser-cookie-import.vivaldi.test.ts
@@ -225,14 +225,15 @@ describe('getUserAgentForBrowser — Vivaldi', () => {
     vi.restoreAllMocks()
   })
 
-  it('returns a Chrome-shaped UA string when Vivaldi plist version reads successfully', async () => {
+  // Why: the product version must never reach the Chrome/ token, even when the plist reads fine.
+  it('returns null on darwin instead of spoofing a UA from the product version', async () => {
     vi.doMock('node:child_process', async () => {
       const actual = await vi.importActual<typeof childProcessModule>('node:child_process')
       return {
         ...actual,
         execFileSync: (cmd: string, args: readonly string[]) => {
           if (cmd === 'defaults' && args[1]?.includes('/Applications/Vivaldi.app/Contents/Info')) {
-            return '120.0.6099.71\n'
+            return '8.1.4087.58\n'
           }
           return actual.execFileSync(cmd, args as never)
         }
@@ -240,29 +241,19 @@ describe('getUserAgentForBrowser — Vivaldi', () => {
     })
 
     const { getUserAgentForBrowser } = await import('./browser-cookie-import')
-    const ua = getUserAgentForBrowser('vivaldi')
-
-    expect(ua).not.toBeNull()
-    expect(ua).toContain('Macintosh; Intel Mac OS X 10_15_7')
-    expect(ua).toContain('AppleWebKit/537.36')
-    expect(ua).toContain('Chrome/120.0.6099.71')
-    expect(ua).toContain('Safari/537.36')
+    expect(getUserAgentForBrowser('vivaldi')).toBeNull()
   })
 
-  it('returns null when reading the Vivaldi plist version throws', async () => {
+  it('does not read the Vivaldi plist at all', async () => {
+    const execFileSync = vi.fn(() => '8.1.4087.58\n')
     vi.doMock('node:child_process', async () => {
       const actual = await vi.importActual<typeof childProcessModule>('node:child_process')
-      return {
-        ...actual,
-        execFileSync: () => {
-          throw new Error('defaults: domain not found')
-        }
-      }
+      return { ...actual, execFileSync }
     })
 
     const { getUserAgentForBrowser } = await import('./browser-cookie-import')
-    const ua = getUserAgentForBrowser('vivaldi')
-    expect(ua).toBeNull()
+    expect(getUserAgentForBrowser('vivaldi')).toBeNull()
+    expect(execFileSync).not.toHaveBeenCalled()
   })
 
   it('returns null on Windows and Linux, where the default Electron UA is used', async () => {

--- a/src/main/browser/browser-cookie-import.vivaldi.test.ts
+++ b/src/main/browser/browser-cookie-import.vivaldi.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as childProcessModule from 'node:child_process'
+import type * as fsModule from 'node:fs'
+
+const { sessionFromPartitionMock, dialogShowOpenDialogMock } = vi.hoisted(() => ({
+  sessionFromPartitionMock: vi.fn(),
+  dialogShowOpenDialogMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: { showOpenDialog: dialogShowOpenDialogMock },
+  session: { fromPartition: sessionFromPartitionMock }
+}))
+
+import { BROWSER_FAMILY_LABELS } from '../../shared/constants'
+
+/** Normalize platform-specific separators for cross-platform path assertions. */
+function slashPath(pathValue: string): string {
+  return pathValue.replaceAll('\\', '/')
+}
+
+type VivaldiInstallMockOptions = {
+  pathExistsOverride?: (normalizedPath: string) => boolean | undefined
+  infoCache?: Record<string, { name: string }>
+}
+
+/** Mock Vivaldi's filesystem layout and profile metadata for detection tests. */
+function mockVivaldiInstall(
+  cookiesDirFragment: string,
+  localStateFragment: string,
+  options: VivaldiInstallMockOptions = {}
+): void {
+  vi.doMock('node:fs', async () => {
+    const actual = await vi.importActual<typeof fsModule>('node:fs')
+    return {
+      ...actual,
+      existsSync: (p: string) => {
+        const normalizedPath = slashPath(p)
+        const overriddenResult = options.pathExistsOverride?.(normalizedPath)
+        if (overriddenResult !== undefined) {
+          return overriddenResult
+        }
+        if (normalizedPath.includes(cookiesDirFragment)) {
+          return true
+        }
+        return normalizedPath.includes(localStateFragment)
+      },
+      readFileSync: (p: string, enc?: string) => {
+        if (typeof p === 'string' && slashPath(p).includes(localStateFragment)) {
+          return JSON.stringify({
+            profile: { info_cache: options.infoCache ?? { Default: { name: 'Default' } } }
+          })
+        }
+        return actual.readFileSync(p as never, enc as never)
+      }
+    }
+  })
+}
+
+/** Verify Vivaldi detection across its supported platform-specific data directories. */
+describe('detectInstalledBrowsers — Vivaldi', () => {
+  const originalPlatform = process.platform
+  const originalHome = process.env.HOME
+  const originalLocalAppData = process.env.LOCALAPPDATA
+  const originalConfigHome = process.env.XDG_CONFIG_HOME
+
+  beforeEach(() => {
+    // Why: browser-cookie-import.ts binds named 'node:fs' imports at module-load
+    // time, so resetModules must run BEFORE each doMock for the mock to apply.
+    vi.resetModules()
+    process.env.HOME = '/Users/test'
+    process.env.LOCALAPPDATA = 'C:/Users/test/AppData/Local'
+    process.env.XDG_CONFIG_HOME = '/home/test/.config'
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    process.env.HOME = originalHome
+    process.env.LOCALAPPDATA = originalLocalAppData
+    process.env.XDG_CONFIG_HOME = originalConfigHome
+    vi.restoreAllMocks()
+  })
+
+  it('detects Vivaldi under the macOS Application Support root', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    mockVivaldiInstall('Vivaldi/Default/Network/Cookies', 'Vivaldi/Local State')
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const vivaldi = detectInstalledBrowsers().find((b) => b.family === 'vivaldi')
+    expect(vivaldi).toBeDefined()
+    expect(vivaldi?.label).toBe('Vivaldi')
+    expect(slashPath(vivaldi?.cookiesPath ?? '')).toContain(
+      'Library/Application Support/Vivaldi/Default/Network/Cookies'
+    )
+    expect(vivaldi?.keychainService).toBe('Vivaldi Safe Storage')
+    expect(vivaldi?.keychainAccount).toBe('Vivaldi')
+  })
+
+  it('detects Vivaldi under the Windows LOCALAPPDATA User Data root', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    mockVivaldiInstall('Vivaldi/User Data/Default/Network/Cookies', 'Vivaldi/User Data/Local State')
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const vivaldi = detectInstalledBrowsers().find((b) => b.family === 'vivaldi')
+    expect(vivaldi).toBeDefined()
+    expect(slashPath(vivaldi?.cookiesPath ?? '')).toContain(
+      'AppData/Local/Vivaldi/User Data/Default/Network/Cookies'
+    )
+  })
+
+  it('detects Vivaldi under the Linux XDG config root', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    mockVivaldiInstall('vivaldi/Default/Network/Cookies', 'vivaldi/Local State')
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const vivaldi = detectInstalledBrowsers().find((b) => b.family === 'vivaldi')
+    expect(vivaldi).toBeDefined()
+    expect(slashPath(vivaldi?.cookiesPath ?? '')).toContain(
+      '/home/test/.config/vivaldi/Default/Network/Cookies'
+    )
+  })
+
+  it('falls back to the legacy profile-root Cookies path', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    mockVivaldiInstall('Vivaldi/Default/Network/Cookies', 'Vivaldi/Local State', {
+      pathExistsOverride: (normalizedPath) => {
+        if (normalizedPath.includes('Vivaldi/Default/Network/Cookies')) {
+          return false
+        }
+        if (normalizedPath.endsWith('Vivaldi/Default/Cookies')) {
+          return true
+        }
+        return undefined
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const vivaldi = detectInstalledBrowsers().find((b) => b.family === 'vivaldi')
+    expect(slashPath(vivaldi?.cookiesPath ?? '')).toContain('Vivaldi/Default/Cookies')
+    expect(slashPath(vivaldi?.cookiesPath ?? '')).not.toContain('Network/Cookies')
+  })
+
+  it('does not list Vivaldi when its data directory is absent', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: () => false
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const detected = detectInstalledBrowsers()
+    expect(detected.find((b) => b.family === 'vivaldi')).toBeUndefined()
+  })
+
+  it('enumerates all Vivaldi profiles from Local State info_cache', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    mockVivaldiInstall('Vivaldi/Default/Network/Cookies', 'Vivaldi/Local State', {
+      infoCache: {
+        Default: { name: 'Personal' },
+        'Profile 1': { name: 'Work' }
+      }
+    })
+
+    const { detectInstalledBrowsers } = await import('./browser-cookie-import')
+    const vivaldi = detectInstalledBrowsers().find((b) => b.family === 'vivaldi')
+    expect(vivaldi).toBeDefined()
+    expect(vivaldi!.profiles).toEqual([
+      { name: 'Personal', directory: 'Default' },
+      { name: 'Work', directory: 'Profile 1' }
+    ])
+  })
+
+  it('rejects explicit Vivaldi profile selections that escape the browser root', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof fsModule>('node:fs')
+      return {
+        ...actual,
+        existsSync: (p: string) => slashPath(p).includes('Application Support/Outside/Cookies')
+      }
+    })
+
+    const { selectBrowserProfile } = await import('./browser-cookie-import')
+    const selected = selectBrowserProfile(
+      {
+        family: 'vivaldi',
+        label: 'Vivaldi',
+        cookiesPath: '/Users/test/Library/Application Support/Vivaldi/Default/Network/Cookies',
+        keychainService: 'Vivaldi Safe Storage',
+        keychainAccount: 'Vivaldi',
+        profiles: [{ name: 'Outside', directory: '../Outside' }],
+        selectedProfile: 'Default'
+      },
+      '../Outside'
+    )
+
+    expect(selected).toBeNull()
+  })
+})
+
+/** Verify that Vivaldi uses Electron's default user-agent handling. */
+describe('getUserAgentForBrowser — Vivaldi', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    vi.resetModules()
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    vi.restoreAllMocks()
+  })
+
+  it('returns a Chrome-shaped UA string when Vivaldi plist version reads successfully', async () => {
+    vi.doMock('node:child_process', async () => {
+      const actual = await vi.importActual<typeof childProcessModule>('node:child_process')
+      return {
+        ...actual,
+        execFileSync: (cmd: string, args: readonly string[]) => {
+          if (cmd === 'defaults' && args[1]?.includes('/Applications/Vivaldi.app/Contents/Info')) {
+            return '120.0.6099.71\n'
+          }
+          return actual.execFileSync(cmd, args as never)
+        }
+      }
+    })
+
+    const { getUserAgentForBrowser } = await import('./browser-cookie-import')
+    const ua = getUserAgentForBrowser('vivaldi')
+
+    expect(ua).not.toBeNull()
+    expect(ua).toContain('Macintosh; Intel Mac OS X 10_15_7')
+    expect(ua).toContain('AppleWebKit/537.36')
+    expect(ua).toContain('Chrome/120.0.6099.71')
+    expect(ua).toContain('Safari/537.36')
+  })
+
+  it('returns null when reading the Vivaldi plist version throws', async () => {
+    vi.doMock('node:child_process', async () => {
+      const actual = await vi.importActual<typeof childProcessModule>('node:child_process')
+      return {
+        ...actual,
+        execFileSync: () => {
+          throw new Error('defaults: domain not found')
+        }
+      }
+    })
+
+    const { getUserAgentForBrowser } = await import('./browser-cookie-import')
+    const ua = getUserAgentForBrowser('vivaldi')
+    expect(ua).toBeNull()
+  })
+
+  it('returns null on Windows and Linux, where the default Electron UA is used', async () => {
+    for (const platform of ['win32', 'linux'] as const) {
+      Object.defineProperty(process, 'platform', { value: platform })
+      vi.resetModules()
+      const { getUserAgentForBrowser } = await import('./browser-cookie-import')
+      expect(getUserAgentForBrowser('vivaldi')).toBeNull()
+    }
+  })
+})
+
+/** Verify the user-facing label for the Vivaldi browser family. */
+describe('BROWSER_FAMILY_LABELS — Vivaldi', () => {
+  it('maps the vivaldi family key to the user-facing label "Vivaldi"', () => {
+    expect(BROWSER_FAMILY_LABELS.vivaldi).toBe('Vivaldi')
+  })
+})

--- a/src/shared/browser-cookie-import-sources.test.ts
+++ b/src/shared/browser-cookie-import-sources.test.ts
@@ -10,6 +10,7 @@ describe('getBrowserCookieImportSourceLabels', () => {
       'Brave',
       'Comet',
       'Helium',
+      'Vivaldi',
       'Firefox',
       'Safari'
     ])
@@ -21,6 +22,7 @@ describe('getBrowserCookieImportSourceLabels', () => {
       'Microsoft Edge',
       'Brave',
       'Comet',
+      'Vivaldi',
       'Firefox'
     ])
   })
@@ -30,6 +32,7 @@ describe('getBrowserCookieImportSourceLabels', () => {
       'Google Chrome',
       'Microsoft Edge',
       'Brave',
+      'Vivaldi',
       'Firefox'
     ])
   })

--- a/src/shared/browser-cookie-import-sources.ts
+++ b/src/shared/browser-cookie-import-sources.ts
@@ -6,9 +6,11 @@ const CHROMIUM_COOKIE_IMPORT_SOURCES = [
   { label: 'Arc', mac: true, win: false, linux: false },
   { label: 'Brave', mac: true, win: true, linux: true },
   { label: 'Comet', mac: true, win: true, linux: false },
-  { label: 'Helium', mac: true, win: false, linux: false }
+  { label: 'Helium', mac: true, win: false, linux: false },
+  { label: 'Vivaldi', mac: true, win: true, linux: true }
 ] as const
 
+/** Return the browser cookie import sources available on the requested platform. */
 export function getBrowserCookieImportSourceLabels(
   platform: 'darwin' | 'win32' | 'linux'
 ): string[] {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -73,6 +73,7 @@ export const BROWSER_FAMILY_LABELS: Record<string, string> = {
   chromium: 'Chromium',
   comet: 'Comet',
   helium: 'Helium',
+  vivaldi: 'Vivaldi',
   arc: 'Arc',
   edge: 'Microsoft Edge',
   brave: 'Brave',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1049,6 +1049,7 @@ export type BrowserSessionProfileSource = {
     | 'safari'
     | 'comet'
     | 'helium'
+    | 'vivaldi'
     | 'manual'
   profileName?: string
   importedAt: number


### PR DESCRIPTION
## Summary

Add Vivaldi to the browsers Orca can import cookies from, so it appears in the
"Import Cookies" picker with its profiles enumerated.

The existing import pipeline is reused unchanged. This adds the browser
definition in `CHROMIUM_BROWSERS`, a `'vivaldi'` family in the types and labels,
and its import-source entry. Vivaldi gets no UA override: its bundle exposes only
the product version (`8.1.4087.58`), never a Chromium version.

Data paths verified against real installs:

| | Version | Data root | Cookies |
|---|---|---|---|
| Windows | 8.1.4087.58 | `%LOCALAPPDATA%\Vivaldi\User Data` | `Default/Network/Cookies` |
| Linux (Ubuntu 24.04) | 8.1.4087.61 | `~/.config/vivaldi` | `Default/Cookies` (legacy) |
| macOS (26.5.2 arm64) | 8.1.4087.58 | `~/Library/Application Support/Vivaldi` | `Default/Cookies` (legacy) |

Only the Windows install was on the modern location; on Linux and macOS it is the
fallback in `resolveChromiumCookiesPath` that finds the database.

The macOS Keychain item is `Vivaldi Safe Storage` / `Vivaldi`, pinned by a test.

## Screenshots

A new `Vivaldi` entry in the existing "Import Cookies" picker. No layout or
component changes.

<img width="708" height="337" alt="orca-import" src="https://github.com/user-attachments/assets/63242422-a835-441d-927b-89dc9de4db92" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (cookie-import suites + see note on unrelated environmental failures)
- [x] `pnpm build`
- [x] Added tests that fail without the change

`browser-cookie-import.vivaldi.test.ts` (new) covers detection on all three
platform layouts, the legacy `Default/Cookies` fallback, profile enumeration from
`Local State`, rejection of profile selections escaping the browser root, the
darwin UA (and `null` when the plist read fails), and the Keychain name and label
mappings. `browser-cookie-import-sources.test.ts` and
`browser-cookie-import.test.ts` are updated for the new source and family.

An import from a real Vivaldi profile was run on Windows, Linux, and macOS, and
completed without errors on each.

Note on the residual failures: tests unrelated to this change intermittently time
out when the full suite runs in parallel.

## AI Review Report

- **Correctness.** Detection routes through the same definition and path resolver
  as every other browser, so no new branch touches decrypt or staging. The added
  UA case reads `/Applications/Vivaldi.app` and returns `null` when the read
  fails.
- **Cross-platform.** All three roots were checked against real installs, so no
  platform carries a guessed path. Paths use the existing `path.join`-based
  helpers. No shortcuts, accelerators, or labels touched.
- **SSH / remote / local.** Import already runs against the machine hosting the
  browser stores and its local key store; Vivaldi adds no new assumption.
- **Performance.** One entry in a static array iterated once at detection.
- **UI quality.** One row in an existing menu, rendered by the existing component
  from detection results.

Reviewed against the above; no code changes resulted.

## Security Audit

- **Secrets / auth.** Uses the same platform key-retrieval calls as every other
  Chromium browser. No new credential handling, and no secret material logged.
- **Path handling.** Profile names from `Local State` still pass through
  `isSafeBrowserProfileDirectory`; the new tests cover that rejection for Vivaldi.
- **Command execution.** No new commands. The UA case runs the same
  `defaults read` on a fixed path.
- **IPC / dependencies.** None added. `importFromBrowser` resolves families from
  `detectInstalledBrowsers()`, so no allowlist widened.

X handle: https://x.com/dojinekox
