### PR TITLE
Fix Gemini usage via Antigravity quota

### DIFF
--- a/src/main/rate-limits/antigravity-usage-fetcher.test.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { parseAntigravityGeminiQuota } from './antigravity-usage-fetcher'
+
+describe('parseAntigravityGeminiQuota', () => {
+  it('maps only the Gemini five-hour and weekly buckets', () => {
+    const result = parseAntigravityGeminiQuota({
+      response: {
+        groups: [
+          {
+            displayName: 'Gemini Models',
+            buckets: [
+              {
+                window: 'weekly',
+                remainingFraction: 0.72,
+                resetTime: '2026-08-03T03:13:16Z'
+              },
+              {
+                window: '5h',
+                remainingFraction: 0.91,
+                resetTime: '2026-07-30T06:05:28Z'
+              }
+            ]
+          },
+          {
+            displayName: 'Claude and GPT models',
+            buckets: [
+              {
+                window: 'weekly',
+                remainingFraction: 0.1,
+                resetTime: '2026-08-06T01:06:50Z'
+              }
+            ]
+          }
+        ]
+      }
+    })
+
+    expect(result).toEqual({
+      session: {
+        usedPercent: 9,
+        windowMinutes: 300,
+        resetsAt: Date.parse('2026-07-30T06:05:28Z'),
+        resetDescription: null
+      },
+      weekly: {
+        usedPercent: 28,
+        windowMinutes: 10_080,
+        resetsAt: Date.parse('2026-08-03T03:13:16Z'),
+        resetDescription: null
+      }
+    })
+  })
+
+  it('returns null when the Gemini quota group is missing', () => {
+    expect(
+      parseAntigravityGeminiQuota({
+        response: { groups: [{ displayName: 'Claude and GPT models', buckets: [] }] }
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/rate-limits/antigravity-usage-fetcher.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.ts
@@ -1,0 +1,233 @@
+import { unlinkSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { request } from 'node:https'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { IPty } from 'node-pty'
+import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+import { resolveCliCommand } from '../codex-cli/command'
+import { cleanupHiddenRateLimitPty, registerHiddenRateLimitPty } from './hidden-pty-cleanup'
+import { resolveHiddenRateLimitPtyCwd } from './hidden-rate-limit-pty-cwd'
+
+const STARTUP_TIMEOUT_MS = 12_000
+const REQUEST_TIMEOUT_MS = 2_000
+const POLL_INTERVAL_MS = 200
+const QUOTA_PATH = '/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary'
+const HTTPS_PORT_RE = /listening on random port at (\d+) for HTTPS/i
+
+type AntigravityBucket = {
+  window: string
+  remainingFraction: number
+  resetTime: string
+}
+
+function isBucket(value: unknown): value is AntigravityBucket {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const bucket = value as Partial<AntigravityBucket>
+  return (
+    typeof bucket.window === 'string' &&
+    typeof bucket.remainingFraction === 'number' &&
+    Number.isFinite(bucket.remainingFraction) &&
+    typeof bucket.resetTime === 'string'
+  )
+}
+
+function toWindow(bucket: AntigravityBucket, windowMinutes: number): RateLimitWindow {
+  const resetsAt = new Date(bucket.resetTime).getTime()
+  return {
+    usedPercent: Math.min(100, Math.max(0, Math.round((1 - bucket.remainingFraction) * 100))),
+    windowMinutes,
+    resetsAt: Number.isNaN(resetsAt) ? null : resetsAt,
+    resetDescription: null
+  }
+}
+
+export function parseAntigravityGeminiQuota(data: unknown): {
+  session: RateLimitWindow | null
+  weekly: RateLimitWindow | null
+} | null {
+  if (!data || typeof data !== 'object' || !('response' in data)) {
+    return null
+  }
+  const response = data.response
+  if (!response || typeof response !== 'object' || !('groups' in response)) {
+    return null
+  }
+  if (!Array.isArray(response.groups)) {
+    return null
+  }
+  const geminiGroup = response.groups.find((group) => {
+    return (
+      group &&
+      typeof group === 'object' &&
+      'displayName' in group &&
+      typeof group.displayName === 'string' &&
+      /gemini/i.test(group.displayName)
+    )
+  })
+  if (!geminiGroup || typeof geminiGroup !== 'object' || !('buckets' in geminiGroup)) {
+    return null
+  }
+  const buckets = Array.isArray(geminiGroup.buckets)
+    ? geminiGroup.buckets.filter((bucket) => isBucket(bucket))
+    : []
+  const sessionBucket = buckets.find((bucket) => bucket.window === '5h')
+  const weeklyBucket = buckets.find((bucket) => bucket.window === 'weekly')
+  if (!sessionBucket && !weeklyBucket) {
+    return null
+  }
+  return {
+    session: sessionBucket ? toWindow(sessionBucket, 300) : null,
+    weekly: weeklyBucket ? toWindow(weeklyBucket, 10_080) : null
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitForHttpsPort(logPath: string, deadline: number): Promise<number> {
+  while (Date.now() < deadline) {
+    const log = await readFile(logPath, 'utf8').catch(() => '')
+    const match = HTTPS_PORT_RE.exec(log)
+    if (match) {
+      return Number.parseInt(match[1], 10)
+    }
+    await delay(POLL_INTERVAL_MS)
+  }
+  throw new Error('Antigravity local API did not start')
+}
+
+function requestQuota(port: number): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: QUOTA_PATH,
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'connect-protocol-version': '1'
+        },
+        // Why: agy creates an ephemeral self-signed certificate for this exact
+        // loopback-only endpoint; no external host is contacted through it.
+        rejectUnauthorized: false
+      },
+      (response) => {
+        let body = ''
+        response.setEncoding('utf8')
+        response.on('data', (chunk: string) => {
+          body += chunk
+        })
+        response.on('end', () => {
+          if (response.statusCode !== 200) {
+            reject(new Error(`Antigravity quota request failed (${response.statusCode ?? 0})`))
+            return
+          }
+          try {
+            resolve(JSON.parse(body) as unknown)
+          } catch {
+            reject(new Error('Antigravity quota response was not valid JSON'))
+          }
+        })
+      }
+    )
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error('Antigravity quota request timed out'))
+    })
+    req.on('error', reject)
+    req.end('{}')
+  })
+}
+
+async function waitForQuota(
+  port: number,
+  deadline: number
+): Promise<{
+  session: RateLimitWindow | null
+  weekly: RateLimitWindow | null
+}> {
+  let lastError: Error | null = null
+  while (Date.now() < deadline) {
+    try {
+      const parsed = parseAntigravityGeminiQuota(await requestQuota(port))
+      if (parsed) {
+        return parsed
+      }
+      lastError = new Error('Antigravity Gemini quota is unavailable')
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error('Antigravity quota request failed')
+    }
+    await delay(POLL_INTERVAL_MS)
+  }
+  throw lastError ?? new Error('Antigravity Gemini quota is unavailable')
+}
+
+export async function fetchGeminiRateLimitsViaAntigravity(): Promise<ProviderRateLimits> {
+  const logPath = join(
+    tmpdir(),
+    `orca-antigravity-quota-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.log`
+  )
+  let term: IPty | null = null
+  const disposables: { dispose: () => void }[] = []
+  try {
+    const pty = await import('node-pty')
+    const command = resolveCliCommand('agy')
+    const isWin32 = process.platform === 'win32'
+    const spawnFile = isWin32 ? 'cmd.exe' : command
+    const spawnArgs = isWin32
+      ? ['/d', '/s', '/c', `"${command}" --log-file "${logPath}"`]
+      : ['--log-file', logPath]
+    term = pty.spawn(spawnFile, spawnArgs, {
+      name: 'xterm-256color',
+      cols: 120,
+      rows: 40,
+      cwd: resolveHiddenRateLimitPtyCwd(),
+      env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>
+    })
+    disposables.push(registerHiddenRateLimitPty(term))
+    const deadline = Date.now() + STARTUP_TIMEOUT_MS
+    const port = await waitForHttpsPort(logPath, deadline)
+    const quota = await waitForQuota(port, deadline)
+    return {
+      provider: 'gemini',
+      ...quota,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok',
+      usageMetadata: {
+        source: 'cli',
+        attemptedSources: ['cli'],
+        credentialSource: 'Antigravity keyring',
+        authProvenance: 'antigravity-local-rpc'
+      }
+    }
+  } catch (error) {
+    return {
+      provider: 'gemini',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: error instanceof Error ? error.message : 'Antigravity quota request failed',
+      status: 'unavailable',
+      usageMetadata: {
+        source: 'cli',
+        attemptedSources: ['cli'],
+        failureKind: 'usage-unavailable',
+        authProvenance: 'antigravity-local-rpc'
+      }
+    }
+  } finally {
+    if (term) {
+      cleanupHiddenRateLimitPty(term, disposables, { kill: true })
+    }
+    try {
+      unlinkSync(logPath)
+    } catch {
+      /* agy may exit before creating its requested log file */
+    }
+  }
+}

--- a/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
@@ -6,10 +6,15 @@ import {
   validCreds
 } from './gemini-usage-fetcher.test-fixtures'
 
-const { readFileMock, extractCredsMock, netFetchMock } = vi.hoisted(() => ({
+const { readFileMock, extractCredsMock, netFetchMock, antigravityFetchMock } = vi.hoisted(() => ({
   readFileMock: vi.fn(),
   extractCredsMock: vi.fn(),
-  netFetchMock: vi.fn()
+  netFetchMock: vi.fn(),
+  antigravityFetchMock: vi.fn()
+}))
+
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchGeminiRateLimitsViaAntigravity: antigravityFetchMock
 }))
 
 // Why: mock the CLI-credential extractor at the module boundary. The extractor
@@ -44,6 +49,15 @@ describe('fetchGeminiRateLimits fallback oauth creds', () => {
     readFileMock.mockReset()
     extractCredsMock.mockReset()
     netFetchMock.mockReset()
+    antigravityFetchMock.mockReset()
+    antigravityFetchMock.mockResolvedValue({
+      provider: 'gemini',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: 'Antigravity unavailable',
+      status: 'unavailable'
+    })
     extractCredsMock.mockResolvedValue({
       clientId: 'client-id-123',
       clientSecret: 'client-secret-456'

--- a/src/main/rate-limits/gemini-usage-fetcher.test.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.test.ts
@@ -6,10 +6,15 @@ import {
   quotaResponse
 } from './gemini-usage-fetcher.test-fixtures'
 
-const { readFileMock, extractCredsMock, netFetchMock } = vi.hoisted(() => ({
+const { readFileMock, extractCredsMock, netFetchMock, antigravityFetchMock } = vi.hoisted(() => ({
   readFileMock: vi.fn(),
   extractCredsMock: vi.fn(),
-  netFetchMock: vi.fn()
+  netFetchMock: vi.fn(),
+  antigravityFetchMock: vi.fn()
+}))
+
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchGeminiRateLimitsViaAntigravity: antigravityFetchMock
 }))
 
 // Why: mock the extractor at the module boundary rather than re-routing every
@@ -37,6 +42,15 @@ describe('fetchGeminiRateLimits', () => {
     readFileMock.mockReset()
     extractCredsMock.mockReset()
     netFetchMock.mockReset()
+    antigravityFetchMock.mockReset()
+    antigravityFetchMock.mockResolvedValue({
+      provider: 'gemini',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: 'Antigravity unavailable',
+      status: 'unavailable'
+    })
     netFetchMock.mockImplementation((url: string) => {
       if (url.includes('loadCodeAssist')) {
         return Promise.resolve(makeResponse({ cloudaicompanionProject: 'proj-123' }))
@@ -67,6 +81,33 @@ describe('fetchGeminiRateLimits', () => {
       throw { code: 'ENOENT' }
     })
   }
+
+  it('uses Antigravity Gemini quota before legacy OAuth sources', async () => {
+    antigravityFetchMock.mockResolvedValue({
+      provider: 'gemini',
+      session: {
+        usedPercent: 9,
+        windowMinutes: 300,
+        resetsAt: Date.parse('2026-07-30T06:05:28Z'),
+        resetDescription: null
+      },
+      weekly: {
+        usedPercent: 28,
+        windowMinutes: 10_080,
+        resetsAt: Date.parse('2026-08-03T03:13:16Z'),
+        resetDescription: null
+      },
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    })
+
+    const result = await fetchGeminiRateLimits(true)
+
+    expect(result.status).toBe('ok')
+    expect(result.session?.usedPercent).toBe(9)
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
 
   it('returns unavailable when no credentials exist', async () => {
     const result = await fetchGeminiRateLimits(true)

--- a/src/main/rate-limits/gemini-usage-fetcher.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.ts
@@ -14,6 +14,7 @@ import {
   deduplicateBuckets,
   deriveSessionSummary
 } from './gemini-bucket-formatting'
+import { fetchGeminiRateLimitsViaAntigravity } from './antigravity-usage-fetcher'
 
 const API_TIMEOUT_MS = 10_000
 const RETRIEVE_QUOTA_URL = 'https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota'
@@ -200,7 +201,7 @@ async function fetchViaOauthCreds(
   return result
 }
 
-export async function fetchGeminiRateLimits(
+async function fetchLegacyGeminiRateLimits(
   geminiCliOAuthEnabled = false
 ): Promise<ProviderRateLimits> {
   if (!geminiCliOAuthEnabled) {
@@ -245,4 +246,17 @@ export async function fetchGeminiRateLimits(
       status: 'error'
     }
   }
+}
+
+export async function fetchGeminiRateLimits(
+  geminiCliOAuthEnabled = false
+): Promise<ProviderRateLimits> {
+  if (!geminiCliOAuthEnabled) {
+    return fetchLegacyGeminiRateLimits(false)
+  }
+
+  const antigravity = await fetchGeminiRateLimitsViaAntigravity()
+  return antigravity.status === 'ok'
+    ? antigravity
+    : fetchLegacyGeminiRateLimits(geminiCliOAuthEnabled)
 }


### PR DESCRIPTION
> **English translation** added for maintainers. Original 한국어 / Korean text is preserved below for reference.

### English title
`Fix Gemini usage via Antigravity quota`

## Changes

- Fetch Gemini 5-hour / weekly usage from the Antigravity CLI loopback quota API.
- Prefer Antigravity usage as the primary source for the Gemini status-bar item; fall back to the existing Gemini OAuth path when unavailable.
- Select only the Gemini quota group so it is not mixed with Claude/GPT shared limits.
- Isolate the new external path in existing Gemini tests and add parser / priority regression tests.

## Root cause

Personal Gemini CLI accounts no longer provide quota (`UNSUPPORTED_CLIENT`), but Orca's Antigravity item was still cloning the failed Gemini snapshot. Antigravity CLI, using the logged-in keyring, exposes real Gemini quota via a local API.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/antigravity-usage-fetcher.test.ts src/main/rate-limits/gemini-usage-fetcher.test.ts src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts src/main/rate-limits/service.test.ts` (88 tests)
- `pnpm run typecheck:node`
- `oxlint` on changed files
- Confirmed Gemini 5-hour / weekly buckets from a live Antigravity CLI v1.1.8 loopback response

---

<details>
<summary>Original (한국어 / Korean) — title: Fix Gemini usage via Antigravity quota</summary>

## 변경 사항

- Antigravity CLI의 loopback quota API에서 Gemini 5시간/주간 사용량을 조회합니다.
- Antigravity 사용량을 Gemini 상태바 항목의 우선 소스로 사용하고, 사용할 수 없을 때 기존 Gemini OAuth 경로로 fallback합니다.
- Gemini quota 그룹만 선택해 Claude/GPT 공유 한도와 섞이지 않도록 합니다.
- 기존 Gemini 테스트에서 새 외부 경로를 격리하고 parser/우선순위 회귀 테스트를 추가합니다.

## 원인

Gemini CLI 개인 계정은 `UNSUPPORTED_CLIENT`로 더 이상 quota를 제공하지 않지만, 현재 Orca의 Antigravity 항목은 실패한 Gemini snapshot을 그대로 복제하고 있었습니다. Antigravity CLI는 로그인된 keyring을 사용해 실제 Gemini quota를 로컬 API로 제공합니다.

## 검증

- `pnpm exec vitest run --config config/vitest.config.ts src/main/rate-limits/antigravity-usage-fetcher.test.ts src/main/rate-limits/gemini-usage-fetcher.test.ts src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts src/main/rate-limits/service.test.ts` (88 tests)
- `pnpm run typecheck:node`
- 변경 파일 `oxlint`
- 실제 Antigravity CLI v1.1.8 loopback 응답에서 Gemini 5시간/주간 bucket 확인


</details>
