### PR TITLE
test(skills): pin both sides of the nested-skill prune boundary

### DIFF
--- a/src/main/skills/skill-plugin-cache-scan.test.ts
+++ b/src/main/skills/skill-plugin-cache-scan.test.ts
@@ -211,6 +211,48 @@ describe('plugin skill candidate scan', () => {
     expect(result).toEqual({ candidates: [], issues: [] })
   })
 
+  // Why this exists: the bound below is a deliberate tradeoff, and only the miss side of
+  // it was covered. Descending further would spend the entry budget on vendor payload —
+  // the cost that caused the false-attention root collapse in #10865 — while missing a
+  // copy only ever costs a Details row, because a plugin-cache placement is not
+  // convergeable by any update command. So the failure direction is silence, which is the
+  // safe one. Pinning BOTH sides means raising or lowering the bound has to be deliberate
+  // rather than an accident of refactoring. See #11454.
+  it.each([
+    [0, true],
+    [1, true],
+    [2, true],
+    [3, false],
+    [4, false]
+  ])(
+    'finds a nested skill %i level(s) below a package: %s',
+    async (intermediateDepth, expectFound) => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-plugin-nested-depth-'))
+      temporaryDirectories.push(root)
+      const packageRoot = join(root, 'vendor', 'plugin', '1.0.0')
+      const hostSkill = join(packageRoot, 'skills', 'host-skill')
+      await mkdir(join(packageRoot, '.codex-plugin'), { recursive: true })
+      await mkdir(hostSkill, { recursive: true })
+      await writeFile(join(packageRoot, '.codex-plugin', 'plugin.json'), '{"skills":"./skills"}\n')
+      await writeFile(join(hostSkill, 'SKILL.md'), '# Host skill\n')
+
+      let parent = hostSkill
+      for (let level = 1; level <= intermediateDepth; level += 1) {
+        parent = join(parent, `nested-${level}`)
+      }
+      const candidate = join(parent, 'orca-cli')
+      await mkdir(candidate, { recursive: true })
+      await writeFile(join(candidate, 'SKILL.md'), '# Orca CLI\n')
+
+      const result = await scanKnownPluginSkillCandidates(root, new Set(['orca-cli']))
+
+      expect(result.candidates).toEqual(expectFound ? [{ name: 'orca-cli', path: candidate }] : [])
+      // Why: pruned payload must never surface as a coverage issue either way — that is
+      // what keeps an ordinary large plugin cache from reporting a permanent problem.
+      expect(result.issues).toEqual([])
+    }
+  )
+
   it('reports a depth-truncated subtree as scan coverage instead of a skill candidate', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-plugin-skill-depth-'))
     temporaryDirectories.push(root)

--- a/src/main/skills/skill-plugin-cache-scan.ts
+++ b/src/main/skills/skill-plugin-cache-scan.ts
@@ -13,6 +13,14 @@ const MAXIMUM_DECLARED_SKILL_SCAN_DEPTH = 6
 // Why: a skill package's own payload (templates, fixtures, sample apps) is not a skill
 // tree, and it is what drives ordinary caches past the depth and entry bounds. Descend
 // far enough to still find a skill grouped under a package, then stop.
+//
+// Changing this is a real tradeoff, not a tuning knob. Raising it spends the entry budget
+// on vendor payload — the cost that made ordinary caches collapse to a poison sentinel and
+// pin every skill amber (#10865). Lowering it, or leaving it, means a skill buried deeper
+// is never seen; that costs only a Details row, because a plugin-cache placement is not
+// convergeable by any update command. So the failure direction here is silence, which is
+// the safe one. Both sides of the boundary are pinned by test (#11454) — if you move this,
+// that test will fail, and it is meant to.
 const MAXIMUM_NESTED_SKILL_DEPTH = 2
 // Why: sized against a real multi-vendor cache, which reads ~7k entries once payload is
 // pruned. The bound still exists to stop a hostile or runaway tree; it is not a budget


### PR DESCRIPTION
## Summary

No user-visible change. `MAXIMUM_NESTED_SKILL_DEPTH = 2` in the plugin-cache scan had only its *miss* side covered by tests, so the bound could be raised or lowered by a refactor with nothing failing. This pins both directions and records the tradeoff on the constant.

Measured boundary, now asserted: a skill is found through **2** intermediate directories below a verified skill package, and missed at **3**.

Why the direction matters, in the comment so the next person doesn't have to rediscover it:

- **Raising** it spends the entry budget on vendor payload — the exact cost that made ordinary Codex caches collapse to a poison sentinel and pin every skill amber (#10865).
- **Missing** a deeper copy costs only a Details row, because a `plugin-cache` placement is not convergeable by any update command. So a copy Orca doesn't see is one it couldn't have helped with.

The failure direction is silence, which is the safe one. That asymmetry is the whole reason the bound is low, and it was undocumented.

## Screenshots

`No visual change`

## Testing

- [x] `pnpm typecheck` — 0 errors (note: required `rm -f config/*.tsbuildinfo` first; a stale buildinfo reported 4 phantom errors from a discarded branch)
- [x] `pnpm test` — `src/main/skills`: 16 files / 166 tests pass
- [x] `npx oxlint src/main/skills` clean, `npx oxfmt --check src/main/skills` clean
- [ ] `pnpm lint` / `pnpm build` not run — this is a test-and-comment change with no runtime or dependency surface
- [x] Added tests that would catch a regression, **mutation-verified in both directions**:

| mutation | result |
| --- | --- |
| baseline (bound = 2) | 41 pass |
| raise to 3 | **2 fail** (miss side) |
| lower to 1 | **1 fail** (found side) |
| restored | 41 pass |

The pin is non-vacuous in both directions — moving the constant either way fails the suite, which is the point.

## AI Review Report

I established the boundary empirically before writing the test rather than reading it off the constant: probed 0–4 intermediate directories against the real scanner and observed found/found/found/missed/missed. That is what the `it.each` table encodes.

Risks checked: that the new test is not tautological (mutation table above); that pruned payload still records no scan issue in either the found or missed case, since surfacing Orca's own traversal rules as a user-facing coverage problem is the #10865 regression class; and that no production behavior changed — the only non-test edit is a comment.

Cross-platform: no platform-specific behavior. The test builds paths with `path.join` and creates only plain directories and files — no symlinks, so no Windows elevation/Developer-Mode dependency (unlike the symlink tests in this file, which are `it.skipIf(process.platform === 'win32')`). No shell invocation, no shortcuts, no labels, no Electron surface.

## Security Audit

No new input handling, command execution, auth, secrets, IPC, or dependency surface. The change is one comment plus a test that writes only into `mkdtemp` directories, all registered in the existing `temporaryDirectories` cleanup. No path is derived from untrusted input. Nothing to follow up.

## Notes

Closes #11454.

The under-detection this pins is real and deliberate: a genuine Orca skill nested 3+ levels inside another skill package is silently invisible. That is accepted, for the reason in the comment. If someone later needs those copies visible, the right change is a separate traversal for declared skill roots — not raising this bound, which would reintroduce the budget exhaustion.
