### PR TITLE
fix(mobile): keep terminal input composable while the connection is cut

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -127,6 +127,7 @@ import { isTerminalSendRpcAccepted } from '../../../../src/terminal/terminal-sen
 import { sendMobileTerminalQueryReply } from '../../../../src/terminal/mobile-terminal-query-reply'
 import { TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY } from '../../../../../src/shared/protocol-version'
 import { useTerminalLiveInputCommit } from '../../../../src/terminal/use-terminal-live-input-commit'
+import { resolveMobileTerminalInputGate } from '../../../../src/terminal/terminal-input-connection-gate'
 import {
   getTerminalCommandKeyboardType,
   getTerminalLiveInputKeyboardType
@@ -1058,18 +1059,18 @@ export default function SessionScreen() {
     activeHandleRef,
     activeSessionTabType: activeSessionTab?.type,
     activeSessionTabTypeRef,
+    connected: connState === 'connected',
     liveInputRef,
     liveInputTerminalHandles,
     liveInputTerminalHandlesRef,
     sendLiveTerminalInputRef,
     setLiveInputCapture
   })
-  const canSend =
-    connState === 'connected' &&
-    activeHandle != null &&
-    activeSessionTab?.type !== 'markdown' &&
-    activeSessionTab?.type !== 'file' &&
-    activeSessionTab?.type !== 'browser'
+  const { canCompose, canSend } = resolveMobileTerminalInputGate({
+    connState,
+    activeHandle,
+    activeSessionTabType: activeSessionTab?.type
+  })
   const liveInputEnabled = activeHandle ? liveInputTerminalHandles.has(activeHandle) : false
   const [browserScreencastSupported, setBrowserScreencastSupported] = useState<boolean | null>(null)
   // Why: hosts without aiVault.v1 reject listSessions, so hide the header entry instead of a dead-end "update this host" panel.
@@ -2991,7 +2992,8 @@ export default function SessionScreen() {
   }, [activeSessionTab, fileDocs, readFileTab])
 
   async function handleSend() {
-    if (!client || !activeHandle || sendingRef.current) {
+    // Why: the return key still submits while offline; hold the composed text instead of firing a doomed RPC (#6713).
+    if (!client || !activeHandle || sendingRef.current || !canSend) {
       return
     }
     sendingRef.current = true
@@ -4849,9 +4851,10 @@ export default function SessionScreen() {
                         styles.accessoryKey,
                         liveInputEnabled && styles.accessoryKeyActive,
                         pressed && styles.accessoryKeyPressed,
-                        !canSend && styles.accessoryKeyDisabled
+                        !canCompose && styles.accessoryKeyDisabled
                       ]}
-                      disabled={!canSend}
+                      // Why: offline, live mode is dead but the buffered box still composes — keep the escape hatch tappable (#6713).
+                      disabled={!canCompose}
                       onPress={toggleLiveInput}
                       accessibilityLabel={
                         liveInputEnabled
@@ -4864,7 +4867,7 @@ export default function SessionScreen() {
                         color={
                           liveInputEnabled
                             ? colors.bgBase
-                            : canSend
+                            : canCompose
                               ? colors.textSecondary
                               : colors.textMuted
                         }
@@ -5059,7 +5062,8 @@ export default function SessionScreen() {
                         autocompleteEnabled
                       )}
                       returnKeyType="send"
-                      editable={canSend}
+                      // Why: composing is local — an outage must not lock the field or discard typed text (#6713).
+                      editable={canCompose}
                       onSubmitEditing={() => void handleSend()}
                     />
                     <MobileTerminalInputActions

--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -114,7 +114,7 @@ import {
   loadTerminalAccessoryLayout
 } from '../../../../src/terminal/terminal-accessory-layout'
 import { createTerminalLiveAccessoryInput } from '../../../../src/terminal/terminal-live-accessory-input'
-import { getTerminalLiveAccessoryRawSendTarget } from '../../../../src/terminal/terminal-live-accessory-raw-send-target'
+import { sendTerminalLiveAccessoryRawBytes } from '../../../../src/terminal/terminal-live-accessory-raw-send'
 import {
   clearTerminalLiveInputFocusTimer,
   focusTerminalLiveInputTarget,
@@ -128,6 +128,10 @@ import { sendMobileTerminalQueryReply } from '../../../../src/terminal/mobile-te
 import { TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY } from '../../../../../src/shared/protocol-version'
 import { useTerminalLiveInputCommit } from '../../../../src/terminal/use-terminal-live-input-commit'
 import { resolveMobileTerminalInputGate } from '../../../../src/terminal/terminal-input-connection-gate'
+import {
+  buildTerminalSendParams,
+  TERMINAL_INPUT_SEND_OPTIONS
+} from '../../../../src/terminal/terminal-send-request'
 import {
   getTerminalCommandKeyboardType,
   getTerminalLiveInputKeyboardType
@@ -3002,15 +3006,17 @@ export default function SessionScreen() {
     setInput('')
 
     try {
-      await client.sendRequest('terminal.send', {
-        terminal: activeHandle,
-        text,
-        enter: true,
-        // Why: presence-lock take-floor; marks this phone active so multi-mobile contention resolves to the last actor.
-        ...(deviceTokenRef.current
-          ? { client: { id: deviceTokenRef.current, type: 'mobile' as const } }
-          : {})
-      })
+      // Why: fail now and restore the text — a send parked across a reconnect would execute long after the tap.
+      await client.sendRequest(
+        'terminal.send',
+        buildTerminalSendParams({
+          terminal: activeHandle,
+          text,
+          enter: true,
+          deviceToken: deviceTokenRef.current
+        }),
+        TERMINAL_INPUT_SEND_OPTIONS
+      )
     } catch {
       setInput(text)
     } finally {
@@ -3027,29 +3033,15 @@ export default function SessionScreen() {
     if (accessoryCommit.kind !== 'allow-raw') {
       return
     }
-    const currentClient = clientRef.current
-    // Why: async IME flushing can outlive the original terminal selection.
-    const rawSendTarget = getTerminalLiveAccessoryRawSendTarget({
+    await sendTerminalLiveAccessoryRawBytes({
+      client: clientRef.current,
       targetHandle,
       activeHandle: activeHandleRef.current,
-      activeSessionTabType: activeSessionTabTypeRef.current
+      activeSessionTabType: activeSessionTabTypeRef.current,
+      connState: connStateRef.current,
+      bytes: input.bytes,
+      deviceToken: deviceTokenRef.current
     })
-    if (!currentClient || !rawSendTarget || connStateRef.current !== 'connected') {
-      return
-    }
-    await currentClient
-      .sendRequest('terminal.send', {
-        terminal: rawSendTarget,
-        text: input.bytes,
-        enter: false,
-        ...(deviceTokenRef.current
-          ? { client: { id: deviceTokenRef.current, type: 'mobile' as const } }
-          : {})
-      })
-      .then(
-        () => undefined,
-        () => undefined
-      )
   }
 
   const sendLiveTerminalInput = useCallback(
@@ -3073,15 +3065,19 @@ export default function SessionScreen() {
       ) {
         return false
       }
+      // Why: live-mirror deltas queued behind a dying send drain into the connect
+      // wait and replay stale bytes after reconnect (#6713's `YZZYecho …` corruption).
       return rpc
-        .sendRequest('terminal.send', {
-          terminal: handle,
-          text,
-          enter: false,
-          ...(deviceTokenRef.current
-            ? { client: { id: deviceTokenRef.current, type: 'mobile' as const } }
-            : {})
-        })
+        .sendRequest(
+          'terminal.send',
+          buildTerminalSendParams({
+            terminal: handle,
+            text,
+            enter: false,
+            deviceToken: deviceTokenRef.current
+          }),
+          TERMINAL_INPUT_SEND_OPTIONS
+        )
         .then(isTerminalSendRpcAccepted, () => false)
     },
     [showToast]
@@ -3343,14 +3339,17 @@ export default function SessionScreen() {
 
     terminalGestureInputInFlightRef.current.add(handle)
     try {
-      await rpc.sendRequest('terminal.send', {
-        terminal: handle,
-        text: queued.bytes,
-        enter: false,
-        ...(deviceTokenRef.current
-          ? { client: { id: deviceTokenRef.current, type: 'mobile' as const } }
-          : {})
-      })
+      // Why: gesture arrows parked across a reconnect would move a TUI long after the swipe.
+      await rpc.sendRequest(
+        'terminal.send',
+        buildTerminalSendParams({
+          terminal: handle,
+          text: queued.bytes,
+          enter: false,
+          deviceToken: deviceTokenRef.current
+        }),
+        TERMINAL_INPUT_SEND_OPTIONS
+      )
     } catch {
       // Transient failure
     } finally {
@@ -3831,14 +3830,15 @@ export default function SessionScreen() {
           subscribeToTerminal(createdHandle)
           if (options?.initialPrompt?.trim()) {
             void client
-              .sendRequest('terminal.send', {
-                terminal: createdHandle,
-                text: options.initialPrompt,
-                enter: options.enter !== false,
-                ...(deviceTokenRef.current
-                  ? { client: { id: deviceTokenRef.current, type: 'mobile' as const } }
-                  : {})
-              })
+              .sendRequest(
+                'terminal.send',
+                buildTerminalSendParams({
+                  terminal: createdHandle,
+                  text: options.initialPrompt,
+                  enter: options.enter !== false,
+                  deviceToken: deviceTokenRef.current
+                })
+              )
               .then((sendResponse) => {
                 if (!sendResponse.ok) {
                   throw new Error(

--- a/mobile/src/terminal/terminal-input-connection-gate.test.ts
+++ b/mobile/src/terminal/terminal-input-connection-gate.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { resolveMobileTerminalInputGate } from './terminal-input-connection-gate'
+import { buildTerminalSendParams, TERMINAL_INPUT_SEND_OPTIONS } from './terminal-send-request'
 
 const sessionRouteSource = readFileSync(
   new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
@@ -111,5 +112,23 @@ describe('session route offline-compose wiring', () => {
   it('tells the live-input commit hook about connection loss so stale mirror state resets', () => {
     const hookCall = routeSlice('useTerminalLiveInputCommit({', 'setLiveInputCapture')
     expect(hookCall).toContain("connected: connState === 'connected'")
+  })
+
+  it('keeps every keystroke-grade terminal send now-or-never so nothing replays after reconnect', () => {
+    // Live mirror, buffered send, and gesture arrows must all opt out of the
+    // connect wait — a parked send replays stale bytes into the PTY. Accessory
+    // keys get the same option inside terminal-live-accessory-raw-send.ts.
+    const optOuts = sessionRouteSource.match(/TERMINAL_INPUT_SEND_OPTIONS/g)?.length ?? 0
+    expect(optOuts).toBe(4)
+    expect(TERMINAL_INPUT_SEND_OPTIONS).toEqual({ failWhenDisconnected: true })
+  })
+
+  it('tags terminal sends with the device presence lock only when a token exists', () => {
+    expect(
+      buildTerminalSendParams({ terminal: 't1', text: 'ls', enter: true, deviceToken: 'tok' })
+    ).toEqual({ terminal: 't1', text: 'ls', enter: true, client: { id: 'tok', type: 'mobile' } })
+    expect(
+      buildTerminalSendParams({ terminal: 't1', text: 'ls', enter: false, deviceToken: null })
+    ).toEqual({ terminal: 't1', text: 'ls', enter: false })
   })
 })

--- a/mobile/src/terminal/terminal-input-connection-gate.test.ts
+++ b/mobile/src/terminal/terminal-input-connection-gate.test.ts
@@ -11,6 +11,8 @@ const sessionRouteSource = readFileSync(
 function routeSlice(anchorStart: string, anchorEnd: string): string {
   const start = sessionRouteSource.indexOf(anchorStart)
   expect(start).toBeGreaterThanOrEqual(0)
+  // Why: a duplicated start anchor would silently slice the wrong region.
+  expect(sessionRouteSource.indexOf(anchorStart, start + 1)).toBe(-1)
   const end = sessionRouteSource.indexOf(anchorEnd, start)
   expect(end).toBeGreaterThan(start)
   return sessionRouteSource.slice(start, end + anchorEnd.length)

--- a/mobile/src/terminal/terminal-input-connection-gate.test.ts
+++ b/mobile/src/terminal/terminal-input-connection-gate.test.ts
@@ -1,0 +1,115 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { resolveMobileTerminalInputGate } from './terminal-input-connection-gate'
+
+const sessionRouteSource = readFileSync(
+  new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
+  'utf8'
+)
+
+function routeSlice(anchorStart: string, anchorEnd: string): string {
+  const start = sessionRouteSource.indexOf(anchorStart)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = sessionRouteSource.indexOf(anchorEnd, start)
+  expect(end).toBeGreaterThan(start)
+  return sessionRouteSource.slice(start, end + anchorEnd.length)
+}
+
+describe('terminal input connection gate', () => {
+  it('Given a live connection on a terminal tab Then composing and sending are both allowed', () => {
+    expect(
+      resolveMobileTerminalInputGate({
+        connState: 'connected',
+        activeHandle: 'terminal-a',
+        activeSessionTabType: 'terminal'
+      })
+    ).toEqual({ canCompose: true, canSend: true })
+  })
+
+  it('Given a cut connection Then composing stays available while sending is blocked', () => {
+    for (const connState of [
+      'connecting',
+      'handshaking',
+      'disconnected',
+      'reconnecting',
+      'auth-failed'
+    ] as const) {
+      expect(
+        resolveMobileTerminalInputGate({
+          connState,
+          activeHandle: 'terminal-a',
+          activeSessionTabType: 'terminal'
+        })
+      ).toEqual({ canCompose: true, canSend: false })
+    }
+  })
+
+  it('Given a non-terminal tab or no handle Then neither composing nor sending is allowed', () => {
+    for (const activeSessionTabType of ['markdown', 'file', 'browser']) {
+      expect(
+        resolveMobileTerminalInputGate({
+          connState: 'connected',
+          activeHandle: 'terminal-a',
+          activeSessionTabType
+        })
+      ).toEqual({ canCompose: false, canSend: false })
+    }
+    expect(
+      resolveMobileTerminalInputGate({
+        connState: 'connected',
+        activeHandle: null,
+        activeSessionTabType: 'terminal'
+      })
+    ).toEqual({ canCompose: false, canSend: false })
+  })
+
+  it('Given a lagging tab list yielding no tab Then the gate treats the type as unknown, not non-terminal', () => {
+    expect(
+      resolveMobileTerminalInputGate({
+        connState: 'disconnected',
+        activeHandle: 'terminal-a',
+        activeSessionTabType: undefined
+      })
+    ).toEqual({ canCompose: true, canSend: false })
+  })
+})
+
+describe('session route offline-compose wiring', () => {
+  it('derives both gates from the shared resolver', () => {
+    expect(sessionRouteSource).toContain('resolveMobileTerminalInputGate({')
+  })
+
+  it('keeps the buffered command box editable offline while the live capture stays send-gated', () => {
+    const bufferedInput = routeSlice(
+      'ref={commandInputRef}',
+      'onSubmitEditing={() => void handleSend()}'
+    )
+    expect(bufferedInput).toContain('editable={canCompose}')
+
+    const liveCapture = routeSlice('ref={liveInputRef}', 'importantForAutofill="no"')
+    expect(liveCapture).toContain('editable={canSend}')
+  })
+
+  it('keeps the send button connection-gated so held text cannot fire into a dead link', () => {
+    const sendButton = routeSlice('styles.sendButton,', 'accessibilityLabel="Send command"')
+    expect(sendButton).toContain('disabled={!canSend}')
+  })
+
+  it('holds composed text when the return key submits offline', () => {
+    const handleSend = routeSlice('async function handleSend()', 'sendingRef.current = true')
+    expect(handleSend).toContain('!canSend')
+  })
+
+  it('keeps the live/buffered mode toggle reachable offline', () => {
+    const modeToggle = routeSlice(
+      'liveInputEnabled && styles.accessoryKeyActive',
+      'onPress={toggleLiveInput}'
+    )
+    expect(modeToggle).toContain('disabled={!canCompose}')
+  })
+
+  it('tells the live-input commit hook about connection loss so stale mirror state resets', () => {
+    const hookCall = routeSlice('useTerminalLiveInputCommit({', 'setLiveInputCapture')
+    expect(hookCall).toContain("connected: connState === 'connected'")
+  })
+})

--- a/mobile/src/terminal/terminal-input-connection-gate.ts
+++ b/mobile/src/terminal/terminal-input-connection-gate.ts
@@ -1,0 +1,26 @@
+import type { ConnectionState } from '../transport/types'
+
+type MobileTerminalInputGateOptions = {
+  readonly connState: ConnectionState
+  readonly activeHandle: string | null
+  readonly activeSessionTabType: string | null | undefined
+}
+
+type MobileTerminalInputGate = {
+  // Why: composing is local — it must survive an outage so typed text is held, not discarded (#6713).
+  readonly canCompose: boolean
+  readonly canSend: boolean
+}
+
+export function resolveMobileTerminalInputGate({
+  connState,
+  activeHandle,
+  activeSessionTabType
+}: MobileTerminalInputGateOptions): MobileTerminalInputGate {
+  const canCompose =
+    activeHandle != null &&
+    activeSessionTabType !== 'markdown' &&
+    activeSessionTabType !== 'file' &&
+    activeSessionTabType !== 'browser'
+  return { canCompose, canSend: canCompose && connState === 'connected' }
+}

--- a/mobile/src/terminal/terminal-live-accessory-raw-send.test.ts
+++ b/mobile/src/terminal/terminal-live-accessory-raw-send.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sendTerminalLiveAccessoryRawBytes } from './terminal-live-accessory-raw-send'
+import type { RpcClient } from '../transport/rpc-client'
+
+function captureClient(result: Promise<unknown> = Promise.resolve({ ok: true })) {
+  const sendRequest = vi.fn(() => result)
+  return { client: { sendRequest } as unknown as Pick<RpcClient, 'sendRequest'>, sendRequest }
+}
+
+const BASE_ARGS = {
+  targetHandle: 'terminal-a',
+  activeHandle: 'terminal-a',
+  activeSessionTabType: 'terminal',
+  connState: 'connected',
+  bytes: '',
+  deviceToken: 'tok'
+} as const
+
+describe('terminal live accessory raw send', () => {
+  it('sends raw bytes now-or-never with the device presence tag', async () => {
+    const { client, sendRequest } = captureClient()
+
+    await sendTerminalLiveAccessoryRawBytes({ ...BASE_ARGS, client })
+
+    expect(sendRequest).toHaveBeenCalledWith(
+      'terminal.send',
+      { terminal: 'terminal-a', text: '', enter: false, client: { id: 'tok', type: 'mobile' } },
+      // Why: an accessory key parked in the connect wait would fire into the PTY long after the tap.
+      { failWhenDisconnected: true }
+    )
+  })
+
+  it('drops the bytes instead of sending while disconnected', async () => {
+    const { client, sendRequest } = captureClient()
+
+    await sendTerminalLiveAccessoryRawBytes({ ...BASE_ARGS, client, connState: 'reconnecting' })
+
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('drops the bytes when the terminal selection went stale mid-flush', async () => {
+    const { client, sendRequest } = captureClient()
+
+    await sendTerminalLiveAccessoryRawBytes({ ...BASE_ARGS, client, activeHandle: 'terminal-b' })
+
+    expect(sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('swallows a rejected send so accessory taps never surface transport errors', async () => {
+    const { client } = captureClient(Promise.reject(new Error('Not connected: terminal.send')))
+
+    await expect(
+      sendTerminalLiveAccessoryRawBytes({ ...BASE_ARGS, client })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/mobile/src/terminal/terminal-live-accessory-raw-send.ts
+++ b/mobile/src/terminal/terminal-live-accessory-raw-send.ts
@@ -1,0 +1,43 @@
+import { getTerminalLiveAccessoryRawSendTarget } from './terminal-live-accessory-raw-send-target'
+import { buildTerminalSendParams, TERMINAL_INPUT_SEND_OPTIONS } from './terminal-send-request'
+import type { RpcClient } from '../transport/rpc-client'
+import type { ConnectionState } from '../transport/types'
+
+type TerminalLiveAccessoryRawSendArgs = {
+  readonly client: Pick<RpcClient, 'sendRequest'> | null
+  readonly targetHandle: string
+  readonly activeHandle: string | null
+  readonly activeSessionTabType: string | null
+  readonly connState: ConnectionState
+  readonly bytes: string
+  readonly deviceToken: string | null
+}
+
+export async function sendTerminalLiveAccessoryRawBytes(
+  args: TerminalLiveAccessoryRawSendArgs
+): Promise<void> {
+  // Why: async IME flushing can outlive the original terminal selection.
+  const rawSendTarget = getTerminalLiveAccessoryRawSendTarget({
+    targetHandle: args.targetHandle,
+    activeHandle: args.activeHandle,
+    activeSessionTabType: args.activeSessionTabType
+  })
+  if (!args.client || !rawSendTarget || args.connState !== 'connected') {
+    return
+  }
+  await args.client
+    .sendRequest(
+      'terminal.send',
+      buildTerminalSendParams({
+        terminal: rawSendTarget,
+        text: args.bytes,
+        enter: false,
+        deviceToken: args.deviceToken
+      }),
+      TERMINAL_INPUT_SEND_OPTIONS
+    )
+    .then(
+      () => undefined,
+      () => undefined
+    )
+}

--- a/mobile/src/terminal/terminal-send-request.ts
+++ b/mobile/src/terminal/terminal-send-request.ts
@@ -7,9 +7,7 @@ type TerminalSendParams = {
   readonly client?: { readonly id: string; readonly type: 'mobile' }
 }
 
-// Why: keystroke-grade sends must never park in the connect wait — a send parked
-// across a reconnect replays stale bytes into the PTY long after they were typed
-// (#6713's `YZZYecho …` corruption of the first post-recovery command).
+// Why: keystroke sends must never park in the connect wait — parked sends replay into the PTY after reconnect (#6713).
 export const TERMINAL_INPUT_SEND_OPTIONS: SendRequestOptions = { failWhenDisconnected: true }
 
 export function buildTerminalSendParams(args: {

--- a/mobile/src/terminal/terminal-send-request.ts
+++ b/mobile/src/terminal/terminal-send-request.ts
@@ -1,0 +1,28 @@
+import type { SendRequestOptions } from '../transport/rpc-client'
+
+type TerminalSendParams = {
+  readonly terminal: string
+  readonly text: string
+  readonly enter: boolean
+  readonly client?: { readonly id: string; readonly type: 'mobile' }
+}
+
+// Why: keystroke-grade sends must never park in the connect wait — a send parked
+// across a reconnect replays stale bytes into the PTY long after they were typed
+// (#6713's `YZZYecho …` corruption of the first post-recovery command).
+export const TERMINAL_INPUT_SEND_OPTIONS: SendRequestOptions = { failWhenDisconnected: true }
+
+export function buildTerminalSendParams(args: {
+  terminal: string
+  text: string
+  enter: boolean
+  // Why: presence-lock take-floor; marks this phone active so multi-mobile contention resolves to the last actor.
+  deviceToken: string | null
+}): TerminalSendParams {
+  return {
+    terminal: args.terminal,
+    text: args.text,
+    enter: args.enter,
+    ...(args.deviceToken ? { client: { id: args.deviceToken, type: 'mobile' as const } } : {})
+  }
+}

--- a/mobile/src/terminal/use-terminal-live-input-commit.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.test.ts
@@ -11,6 +11,8 @@ type TerminalLiveInputCommitHarness = {
   readonly handlers: ReturnType<typeof useTerminalLiveInputCommit<string>>
   readonly sent: readonly string[]
   readonly setActiveSessionTabType: (next: string | undefined) => void
+  readonly setConnected: (next: boolean) => void
+  readonly setSendResult: (next: boolean) => void
   readonly unmount: () => void
 }
 
@@ -46,15 +48,17 @@ function createTerminalLiveInputCommitHarness({
     current: new Set([activeHandle])
   }
   const sent: string[] = []
+  let currentSendResult = sendResult
   const sendLiveTerminalInputRef: RefObject<TerminalLiveInputSender> = {
     current: async (_handle, bytes) => {
       sent.push(bytes)
-      return sendResult
+      return currentSendResult
     }
   }
   // The hook keeps live-input state in refs, so a change handler alone never
-  // re-renders; only a prop change (this variable) re-runs the pending-clear effect.
+  // re-renders; only a prop change (these variables) re-runs the clear effects.
   let currentActiveSessionTabType: string | undefined = 'terminal'
+  let currentConnected = true
   let handlers: ReturnType<typeof useTerminalLiveInputCommit<string>> | null = null
   let renderer: ReactTestRenderer | null = null
 
@@ -64,6 +68,7 @@ function createTerminalLiveInputCommitHarness({
       activeHandleRef,
       activeSessionTabType: currentActiveSessionTabType,
       activeSessionTabTypeRef,
+      connected: currentConnected,
       liveInputRef,
       liveInputTerminalHandles,
       liveInputTerminalHandlesRef,
@@ -97,6 +102,15 @@ function createTerminalLiveInputCommitHarness({
       act(() => {
         renderer?.update(createElement(Harness))
       })
+    },
+    setConnected: (next: boolean): void => {
+      currentConnected = next
+      act(() => {
+        renderer?.update(createElement(Harness))
+      })
+    },
+    setSendResult: (next: boolean): void => {
+      currentSendResult = next
     },
     unmount: () => {
       act(() => renderer?.unmount())
@@ -339,5 +353,41 @@ describe('terminal live input commit hook', () => {
 
     // Then: pending was dropped, so submit sends only the carriage return
     await vi.waitFor(() => expect(sent).toEqual(['\r']))
+  })
+
+  it('Given bytes lost in a silent stall When the disconnect is detected Then the first post-recovery send carries no stale fragment or phantom erases', async () => {
+    // Given: a stalled link — the mirror sends but the PTY never accepts (#6713 second defect)
+    const { captures, handlers, sent, setConnected, setSendResult } =
+      createTerminalLiveInputCommitHarness({ sendResult: false })
+    handlers.handleLiveInputChange('XYZZY')
+    await vi.waitFor(() => expect(sent).toEqual(['XYZZY']))
+
+    // When: the outage is finally detected, then the link recovers
+    setConnected(false)
+    setSendResult(true)
+    setConnected(true)
+
+    // Then: the capture was wiped, and fresh typing sends verbatim bytes — not
+    // 'XYZZY…' replayed and not DELs erasing PTY chars that never arrived
+    expect(captures.at(-1)).toBe('')
+    const sentBeforeRecovery = sent.length
+    handlers.handleLiveInputChange('echo CLEANLINE')
+    await vi.waitFor(() => expect(sent.slice(sentBeforeRecovery)).toEqual(['echo CLEANLINE']))
+  })
+
+  it('Given a held syllable during an outage When the disconnect is detected Then the settle timer cannot commit it later', async () => {
+    // Given
+    vi.useFakeTimers()
+    const { handlers, sent, setConnected } = createTerminalLiveInputCommitHarness({
+      sendResult: false
+    })
+    handlers.handleLiveInputChange('한')
+
+    // When
+    setConnected(false)
+    await vi.advanceTimersByTimeAsync(TERMINAL_LIVE_HELD_SYLLABLE_COMMIT_DELAY_MS)
+
+    // Then: the outage cleared the held text before the timer could send it
+    expect(sent).toEqual([])
   })
 })

--- a/mobile/src/terminal/use-terminal-live-input-commit.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.test.ts
@@ -55,8 +55,7 @@ function createTerminalLiveInputCommitHarness({
       return currentSendResult
     }
   }
-  // The hook keeps live-input state in refs, so a change handler alone never
-  // re-renders; only a prop change (these variables) re-runs the clear effects.
+  // Refs never re-render; only these variables re-run the hook's clear effects.
   let currentActiveSessionTabType: string | undefined = 'terminal'
   let currentConnected = true
   let handlers: ReturnType<typeof useTerminalLiveInputCommit<string>> | null = null

--- a/mobile/src/terminal/use-terminal-live-input-commit.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.ts
@@ -22,6 +22,7 @@ type TerminalLiveInputCommitOptions<TTabType extends string> = {
   readonly activeHandleRef: RefObject<string | null>
   readonly activeSessionTabType: TTabType | null | undefined
   readonly activeSessionTabTypeRef: RefObject<TTabType | null>
+  readonly connected: boolean
   readonly liveInputRef: RefObject<TextInput | null>
   readonly liveInputTerminalHandles: ReadonlySet<string>
   readonly liveInputTerminalHandlesRef: RefObject<Set<string>>
@@ -45,6 +46,7 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
   activeHandleRef,
   activeSessionTabType,
   activeSessionTabTypeRef,
+  connected,
   liveInputRef,
   liveInputTerminalHandles,
   liveInputTerminalHandlesRef,
@@ -67,6 +69,15 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
     sendLiveTerminalInputRef,
     setLiveInputCapture
   })
+
+  useEffect(() => {
+    // Why: sends during an outage are silently lost, so the mirror's "already on the PTY"
+    // record is unknowable after a cut — stale state would replay fragments or emit phantom
+    // erases into the first post-reconnect send. Reset while down; the PTY echo is truth.
+    if (!connected) {
+      clearPendingLiveInputCommit()
+    }
+  }, [connected, clearPendingLiveInputCommit])
 
   useEffect(() => {
     const pendingHandle = pendingLiveInputHandleRef.current

--- a/mobile/src/terminal/use-terminal-live-input-commit.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.ts
@@ -71,9 +71,7 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
   })
 
   useEffect(() => {
-    // Why: sends during an outage are silently lost, so the mirror's "already on the PTY"
-    // record is unknowable after a cut — stale state would replay fragments or emit phantom
-    // erases into the first post-reconnect send. Reset while down; the PTY echo is truth.
+    // Why: what reached the PTY is unknowable across an outage — stale mirror state corrupts the first post-reconnect send.
     if (!connected) {
       clearPendingLiveInputCommit()
     }

--- a/mobile/src/transport/rpc-client-connect-wait-replay.test.ts
+++ b/mobile/src/transport/rpc-client-connect-wait-replay.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { connect } from './rpc-client'
+
+vi.mock('./e2ee', () => ({
+  generateKeyPair: () => ({
+    publicKey: new Uint8Array(32),
+    secretKey: new Uint8Array(32)
+  }),
+  deriveSharedKey: () => new Uint8Array(32),
+  publicKeyFromBase64: () => new Uint8Array(32),
+  publicKeyToBase64: () => 'client-public-key',
+  encrypt: (plaintext: string) => `encrypted:${plaintext}`,
+  decrypt: (raw: string) => raw.replace(/^encrypted:/, ''),
+  decryptBytes: (bytes: Uint8Array) => bytes
+}))
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 3
+
+  readonly CONNECTING = MockWebSocket.CONNECTING
+  readonly OPEN = MockWebSocket.OPEN
+  readonly CLOSED = MockWebSocket.CLOSED
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  sent: string[] = []
+  close = vi.fn(() => {
+    if (this.readyState === MockWebSocket.CLOSED) {
+      return
+    }
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  })
+
+  constructor(readonly endpoint: string) {
+    mockSockets.push(this)
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload)
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+    this.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    this.receive('encrypted:{"type":"e2ee_authenticated"}')
+  }
+
+  receive(payload: unknown): void {
+    this.onmessage?.({ data: payload })
+  }
+}
+
+const mockSockets: MockWebSocket[] = []
+const originalWebSocket = globalThis.WebSocket
+
+function track(request: Promise<unknown>): { read: () => string } {
+  let outcome = 'pending'
+  request.then(
+    () => {
+      outcome = 'resolved'
+    },
+    (error: Error) => {
+      outcome = error.message
+    }
+  )
+  return { read: () => outcome }
+}
+
+function terminalSendFrames(socket: MockWebSocket): string[] {
+  return socket.sent.filter((frame) => frame.includes('terminal.send'))
+}
+
+describe('mobile rpc-client connect-wait replay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockSockets.length = 0
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    globalThis.WebSocket = originalWebSocket
+  })
+
+  it('Given a cut connection When a send opts into failWhenDisconnected Then it rejects now and nothing replays after reconnect', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = mockSockets[0]!
+    socket.open()
+    socket.close()
+
+    const request = client.sendRequest(
+      'terminal.send',
+      { terminal: 't1', text: 'YZZY' },
+      { failWhenDisconnected: true }
+    )
+    const outcome = track(request)
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      expect(outcome.read()).toBe('Not connected: terminal.send')
+
+      // Reconnect; the rejected keystroke must not ride the new socket.
+      await vi.advanceTimersByTimeAsync(500)
+      mockSockets[1]!.open()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(terminalSendFrames(mockSockets[1]!)).toEqual([])
+    } finally {
+      client.close()
+      await request.catch(() => undefined)
+    }
+  })
+
+  it('Given a cut connection When a caller does not opt in Then the send parks and is delivered on the next socket', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = mockSockets[0]!
+    socket.open()
+    socket.close()
+
+    // Pins the default behavior that motivates the opt-out: parked requests
+    // replay after reconnect, which is what corrupted post-recovery input.
+    const request = client.sendRequest('terminal.send', { terminal: 't1', text: 'YZZY' })
+    const outcome = track(request)
+
+    try {
+      await vi.advanceTimersByTimeAsync(0)
+      expect(outcome.read()).toBe('pending')
+
+      await vi.advanceTimersByTimeAsync(500)
+      mockSockets[1]!.open()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(terminalSendFrames(mockSockets[1]!)).toHaveLength(1)
+    } finally {
+      client.close()
+      await request.catch(() => undefined)
+    }
+  })
+})

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -54,6 +54,11 @@ export type SendRequestOptions = {
    *  against the post-connect clock, and squeezing them to the floor after a slow
    *  reconnect would fail sends that used to land. */
   budgetSpansConnect?: boolean
+  /** Reject immediately when not connected instead of parking in the connect
+   *  wait. Keystroke-grade terminal input needs it: a send parked across a
+   *  reconnect replays stale bytes into the PTY long after they were typed
+   *  (observed as `YZZYecho …` corrupting the first post-recovery command). */
+  failWhenDisconnected?: boolean
 }
 
 type SubscribeOptions = {
@@ -999,6 +1004,9 @@ export function connect(
       const budget = openRpcRequestBudget(options)
       const waitStart = budget.startedAt
       const wasConnected = state === 'connected'
+      if (options?.failWhenDisconnected && !wasConnected) {
+        throw new Error(`Not connected: ${method}`)
+      }
       await waitForConnected(options?.timeoutMs)
       if (!wasConnected) {
         console.log('[net] sendRequest waited for connect', {

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -54,10 +54,8 @@ export type SendRequestOptions = {
    *  against the post-connect clock, and squeezing them to the floor after a slow
    *  reconnect would fail sends that used to land. */
   budgetSpansConnect?: boolean
-  /** Reject immediately when not connected instead of parking in the connect
-   *  wait. Keystroke-grade terminal input needs it: a send parked across a
-   *  reconnect replays stale bytes into the PTY long after they were typed
-   *  (observed as `YZZYecho …` corrupting the first post-recovery command). */
+  /** Reject immediately when not connected — a send parked in the connect wait
+   *  replays stale terminal bytes into the PTY after reconnect. */
   failWhenDisconnected?: boolean
 }
 


### PR DESCRIPTION
## Summary

Fixes #6713 — on iOS (and Android), cutting the connection made it impossible to type in the terminal input box. A single `canSend` gate hard-disabled **all 18 input controls** on the session screen while `connState !== 'connected'`: both typing modes went `editable={false}` (which on iOS also blocks focus, so the keyboard never opened), and everything typed during an outage was silently discarded. Reproduced deterministically on device via a TCP cut-proxy before writing the fix.

Three changes:

1. **Compose is decoupled from send** (`resolveMobileTerminalInputGate` → `canCompose` / `canSend`). The buffered "Type a command…" box stays editable while disconnected and holds the text locally; the send button, accessory keys (Esc/Tab/arrows/…), paste, and the live-input capture stay connection-gated because they push bytes at the PTY. The live/buffered mode toggle stays tappable offline so a live-mode user can reach the compose box. The keyboard return key (which submits even with the send button disabled) now holds the composed text instead of firing a doomed RPC.
2. **Stalled keystrokes no longer replay into the PTY after reconnect.** A second defect found during the device repro: text typed during a silent stall (link up, packets going nowhere) corrupted the first post-recovery command — observed as `echo CLEANLINE` arriving as `YZZYecho CLEANLINE` → `zsh: command not found: YZZYecho` (tail-execution hazard: `foo; rm -rf x` losing `foo` still runs `rm -rf x`). Device verification pinned the true vector: `sendRequest` begins with `await waitForConnected(...)`, so live-mirror deltas queued behind a dying send drain into the connect wait and fire on the **next** socket, executing tens of seconds after they were typed. New `SendRequestOptions.failWhenDisconnected` rejects immediately instead of parking, and every keystroke-grade terminal send opts in: live mirror, accessory keys, buffered command send, gesture arrows. Deliberate command sends (`initialPrompt` on terminal create) keep the connect wait.
3. **The live-input mirror resets when the connection drops** (`connected` fed into `useTerminalLiveInputCommit`). Bytes recorded as delivered but lost in the stall would otherwise desync every later erase/append delta — the client cannot know what actually reached the PTY across an outage, so the mirror restarts empty and the PTY echo is truth.

This is deliberately **not** #10385 (client falsely believes it is connected) — opposite failure direction, confirmed during the device repro; that issue is being handled separately.

<!-- user-visible-before-after:start -->
## What the user sees before and after

### Before

When the connection becomes patchy, the command box becomes unusable. Some keystrokes typed around the outage can also be delayed and replayed after reconnection, corrupting a later command.

### After

The command box stays editable while disconnected, allowing the user to compose text offline. Controls that would transmit data are disabled until reconnection, composed text survives, and stale keystrokes are not replayed into the new connection.
<!-- user-visible-before-after:end -->

## Screenshots

Fixed build on the simulator, connection cut via TCP proxy (`drop` = clean FIN, `blackhole` = silent stall). Input-control state read from the iOS accessibility tree, which exposes per-element `enabled` — 0/18 controls enabled during a cut before the fix.

**During the cut — command box stays editable and focusable, everything that transmits is disabled, "Reconnect to desktop" affordance shown; text composed offline is held:**

![during-cut](https://github.com/user-attachments/assets/83973b63-e202-4378-a6db-358be08a1d6e)
![typed-while-cut](https://github.com/user-attachments/assets/bbeb6da4-0935-4608-8e35-8f7ee25da0b4)

**After reconnect — the held text survived and executes cleanly (`HELD_OFFLINE_6713`); the scrollback above it shows the pre-fix corruption for contrast (`YZZYecho CLEANLINE`, `Qecho`, `cho` — all `command not found`):**

![held-sent](https://github.com/user-attachments/assets/366f09ea-42c3-4089-95e4-70d2b30c4d97)

**Replay fix A/B on the same PTY: `nOPQ` on the prompt is bytes typed during a stall on the parent build replaying after reconnect (flushed deliberately); with the fix, `RSTUV` typed during an identical stall never appears and `echo CLEAN5` executes verbatim:**

![clean-final](https://github.com/user-attachments/assets/7bb3b72d-84f9-43be-b8ff-1ac7eba3f57a)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` (n/a — mobile-only change; Mobile Checks is the gating job)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New tests, all verified RED against the parent commit `24a2accc3c` by reverting source while keeping the tests (9 behavioral failures, including the exact `XYZZY` stale-fragment mechanism and the parked-request replay):

- `terminal-input-connection-gate.test.ts` — pure gate behavior (compose survives every non-connected state, send does not) plus anchored source pins for the route wiring and the now-or-never opt-ins.
- `use-terminal-live-input-commit.test.ts` — a silent stall followed by detected disconnect wipes the capture so the first post-recovery send is verbatim; a held Hangul syllable cannot be committed by the settle timer after the connection drops.
- `rpc-client-connect-wait-replay.test.ts` — `failWhenDisconnected` rejects immediately and writes nothing to the next socket; a second case pins the default parking behavior that motivated the option.
- `terminal-live-accessory-raw-send.test.ts` — accessory raw sends carry the now-or-never option and presence tag, drop when disconnected or stale, and swallow transport rejections.

Parent baseline measured on this machine: 355 files / 2606 passed, 2 skipped. With this change: 358 files / 2626 passed, 2 skipped.

Device verification (simulator, dev client + cut-proxy): offline compose → hold → reconnect → clean execution, and stall-typed bytes no longer replay (screenshots above). The end-to-end pass exercised the same code paths a physical device runs; the original repro was on a physical iPhone.

## AI Review Report

Reviewed the split gate for state-coverage: every prior `canSend` consumer was audited — paste, image/file attach, dictation, accessory keys, gesture input, and the live-input focus target intentionally remain on `canSend`; only the buffered field, the mode toggle, and their styles moved to `canCompose`. Reviewed the `failWhenDisconnected` blast radius: only the four keystroke-grade `terminal.send` call sites opt in — no other RPC changes behavior, and the option rejects with a definite (non-delivery-unknown) error so no caller misreports an ambiguous send. Checked the return-key path (`onSubmitEditing` fires with the send button disabled) — without the guard it could wedge `sendingRef` on a stalled socket. Checked the disconnect-reset effect for dependency completeness and mount behavior. Cross-platform: no shortcuts, paths, or shell behavior touched; changed `editable`/`disabled` props behave identically on iOS and Android; the Android IME-remount key on the buffered input is unaffected; this screen is mobile-only so macOS/Linux/Windows desktop surfaces are untouched.

## Security Audit

The replay fix *removes* an injection-shaped hazard: bytes typed during an outage can no longer execute on the PTY tens of seconds later, and stale fragments can no longer be prepended to the next command (the `foo; rm -rf x` tail-execution case above). No new input sinks: offline-composed text goes through the existing `normalizeTerminalTextInput` → `terminal.send` path only after the user explicitly sends while connected; nothing auto-replays on reconnect. No auth, secrets, path, or IPC surface touched.

## Notes

- Text composed offline is **held, not queued**: the user taps send after reconnect. Auto-send on reconnect was deliberately rejected.
- Live-input mode remains fully disabled offline by design — it is send-as-you-type; the mode toggle is the escape hatch to the compose box.
- Paste and image/file attach still use the default connect-wait; they are explicit multi-step flows with their own error UX. Worth a follow-up if the same replay shape is ever observed there.
- The desktop STA-2373-style input quarantine has no mobile equivalent (verified — there is no timer to get stuck); the mechanism here was the connect-wait park, not a quarantine latch.
