### PR TITLE
fix(runtime): drop stale local agent rows from worktree.ps after tab close

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31311,8 +31311,9 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('keeps a retained OSC row via its connected PTY after the pane binding is cleared', async () => {
-    // Graph migration nulls pty.tabId/paneKey while the PTY stays connected;
-    // the ptyId conjunct is then the only rescue for the retained OSC row.
+    // A controller incarnation change nulls pty.tabId/paneKey while the PTY
+    // stays connected (adoptControllerTerminalHandle); the ptyId conjunct is
+    // then the only rescue for the retained OSC row.
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
       ...getDefaultWorkspaceSession(),
       tabsByWorktree: {}
@@ -31336,6 +31337,49 @@ describe('OrcaRuntimeService', () => {
     const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
 
     expect(summary?.agents).toEqual([expect.objectContaining({ prompt: 'osc reporter' })])
+  })
+
+  it('keeps the connected-PTY rescue when a hook row outraces the OSC row for the same pane', async () => {
+    // Hook payloads carry no ptyId; the OSC-observed one must survive the
+    // hook row winning the freshness race or the ptyId rescue goes dead.
+    const paneKey = 'race-tab:dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {}
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey,
+          worktreeId: TEST_WORKTREE_ID,
+          tabId: 'race-tab',
+          state: 'working',
+          prompt: 'hook-fresh agent',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: Date.now() + 60_000,
+          stateStartedAt: Date.now() - 100
+        }
+      ]
+    })
+    runtime['recordPtyWorktree']('race-pty', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'race-tab',
+      paneKey
+    })
+    runtime.onPtyData(
+      'race-pty',
+      '\x1b]9999;{"state":"working","prompt":"osc ping","agentType":"codex"}\x07',
+      1
+    )
+    const pty = runtime['ptysById'].get('race-pty')!
+    pty.tabId = null
+    pty.paneKey = null
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([expect.objectContaining({ prompt: 'hook-fresh agent' })])
   })
 
   it('keeps a retained OSC row from an SSH pane after its PTY disconnects', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -30981,20 +30981,9 @@ describe('OrcaRuntimeService', () => {
         }
       ]
     })
-    runtime.attachWindow(1)
-    runtime.syncWindowGraph(1, {
-      tabs: [
-        {
-          tabId: 'host-tab',
-          worktreeId: TEST_WORKTREE_ID,
-          title: 'Codex',
-          activeLeafId: HEADLESS_LEAF_ID,
-          layout: null
-        }
-      ],
-      leaves: []
-    })
 
+    // No renderer graph on purpose: headless rename attribution must work from
+    // the persisted session alone.
     const { worktrees } = await runtime.getWorktreePs()
     const oldSummary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
     const renamedSummary = worktrees.find((worktree) => worktree.worktreeId === renamedWorktreeId)
@@ -31104,10 +31093,10 @@ describe('OrcaRuntimeService', () => {
 
       const { worktrees } = await runtime.getWorktreePs()
 
-      expect(worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)).toMatchObject({
-        hasHostSidebarActivity,
-        status
-      })
+      const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+      expect(summary).toMatchObject({ hasHostSidebarActivity, status })
+      // Why: inactive must mean "projected but not fresh", never "row dropped".
+      expect(summary?.agents).toHaveLength(1)
     }
   )
 
@@ -31146,13 +31135,15 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
-  it('drops a hydrated row when only its stale persisted tab remains', async () => {
+  it('keeps a hydrated row while its persisted session tab exists and no renderer graph is attached', async () => {
+    // Why: headless serve has no renderer graph; session.tabs.list serves this
+    // tab to mobile as current, so its agent row must stay (desktop parity).
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
       ...getDefaultWorkspaceSession(),
       tabsByWorktree: {
         [TEST_WORKTREE_ID]: [
           {
-            id: 'stale-tab',
+            id: 'headless-tab',
             ptyId: null,
             worktreeId: TEST_WORKTREE_ID,
             title: 'Codex',
@@ -31168,11 +31159,11 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
       getAgentStatusSnapshot: () => [
         {
-          paneKey: 'stale-tab:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          paneKey: 'headless-tab:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
           worktreeId: TEST_WORKTREE_ID,
-          tabId: 'stale-tab',
+          tabId: 'headless-tab',
           state: 'done',
-          prompt: 'persisted history',
+          prompt: 'finished while headless',
           agentType: 'codex',
           connectionId: null,
           receivedAt: now,
@@ -31184,7 +31175,9 @@ describe('OrcaRuntimeService', () => {
     const { worktrees } = await runtime.getWorktreePs()
     const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
 
-    expect(summary?.agents).toEqual([])
+    expect(summary?.agents).toEqual([
+      expect.objectContaining({ state: 'done', prompt: 'finished while headless' })
+    ])
   })
 
   it('resolves legacy numeric pane keys through the stale filter too', async () => {
@@ -31232,19 +31225,6 @@ describe('OrcaRuntimeService', () => {
         }
       ]
     })
-    runtime.attachWindow(1)
-    runtime.syncWindowGraph(1, {
-      tabs: [
-        {
-          tabId: 'open-tab',
-          worktreeId: TEST_WORKTREE_ID,
-          title: 'Codex',
-          activeLeafId: '33333333-3333-4333-8333-333333333333',
-          layout: null
-        }
-      ],
-      leaves: []
-    })
 
     const { worktrees } = await runtime.getWorktreePs()
     const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
@@ -31278,9 +31258,9 @@ describe('OrcaRuntimeService', () => {
         }
       ]
     })
+    // paneKey-only record: the tabId rescue must not be what keeps this row.
     runtime['recordPtyWorktree']('daemon-pty', TEST_WORKTREE_ID, {
       connected: true,
-      tabId: 'daemon-tab',
       paneKey
     })
 
@@ -31291,6 +31271,169 @@ describe('OrcaRuntimeService', () => {
       expect.objectContaining({ paneKey, state: 'working', prompt: 'long-running daemon agent' })
     ])
     expect(summary).toMatchObject({ hasHostSidebarActivity: true, status: 'working' })
+  })
+
+  it('keeps a local hook row when a connected PTY matches only its tab id', async () => {
+    // Split-pane sibling: the PTY's paneKey names another leaf of the same tab,
+    // so only the tabId conjunct can rescue this row.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {}
+    })
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey: 'daemon-tab:88888888-8888-4888-8888-888888888887',
+          worktreeId: TEST_WORKTREE_ID,
+          tabId: 'daemon-tab',
+          state: 'working',
+          prompt: 'sibling pane agent',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: now,
+          stateStartedAt: now - 100
+        }
+      ]
+    })
+    runtime['recordPtyWorktree']('daemon-pty-2', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'daemon-tab',
+      paneKey: 'daemon-tab:99999999-9999-4999-8999-999999999998'
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([
+      expect.objectContaining({ prompt: 'sibling pane agent', state: 'working' })
+    ])
+  })
+
+  it('keeps a retained OSC row via its connected PTY after the pane binding is cleared', async () => {
+    // Graph migration nulls pty.tabId/paneKey while the PTY stays connected;
+    // the ptyId conjunct is then the only rescue for the retained OSC row.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {}
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime['recordPtyWorktree']('osc-pty', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'osc-tab',
+      paneKey: 'osc-tab:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    })
+    runtime.onPtyData(
+      'osc-pty',
+      '\x1b]9999;{"state":"working","prompt":"osc reporter","agentType":"codex"}\x07',
+      1
+    )
+    const pty = runtime['ptysById'].get('osc-pty')!
+    pty.tabId = null
+    pty.paneKey = null
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([expect.objectContaining({ prompt: 'osc reporter' })])
+  })
+
+  it('keeps a retained OSC row from an SSH pane after its PTY disconnects', async () => {
+    // Why: OSC snapshots must carry the pane transport; hardcoding local would
+    // strip the SSH exemption off rows whose freshest update arrived via OSC.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {}
+    })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime['recordPtyWorktree']('ssh-osc-pty', TEST_WORKTREE_ID, {
+      connected: true,
+      connectionId: 'ssh-osc-1',
+      tabId: 'ssh-tab',
+      paneKey: 'ssh-tab:cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    })
+    runtime.onPtyData(
+      'ssh-osc-pty',
+      '\x1b]9999;{"state":"working","prompt":"remote osc agent","agentType":"codex"}\x07',
+      1
+    )
+    runtime['recordPtyWorktree']('ssh-osc-pty', TEST_WORKTREE_ID, { connected: false })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([expect.objectContaining({ prompt: 'remote osc agent' })])
+  })
+
+  it('keeps a hook row with an unresolvable pane key', async () => {
+    // Why: no tabId means staleness is unprovable; the filter must pass it.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {}
+    })
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey: 'opaque-key-without-structure',
+          worktreeId: TEST_WORKTREE_ID,
+          state: 'working',
+          prompt: 'unattributable pane',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: now,
+          stateStartedAt: now - 100
+        }
+      ]
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([expect.objectContaining({ prompt: 'unattributable pane' })])
+  })
+
+  it('keeps a WSL hook row while its tab is still in the session', async () => {
+    // Guards the WSL clause against over-filtering: local-tab evidence must
+    // rescue WSL rows exactly like null-connection rows.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        [TEST_WORKTREE_ID]: [
+          {
+            id: 'open-wsl-tab',
+            ptyId: null,
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Codex',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    })
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey: 'open-wsl-tab:99999999-9999-4999-8999-999999999997',
+          worktreeId: TEST_WORKTREE_ID,
+          tabId: 'open-wsl-tab',
+          state: 'working',
+          prompt: 'live in WSL',
+          agentType: 'codex',
+          connectionId: 'wsl:Ubuntu',
+          receivedAt: now,
+          stateStartedAt: now - 100
+        }
+      ]
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([expect.objectContaining({ prompt: 'live in WSL' })])
   })
 
   it('drops a hydrated WSL hook row after its local tab is closed', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -30981,6 +30981,19 @@ describe('OrcaRuntimeService', () => {
         }
       ]
     })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'host-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Codex',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: []
+    })
 
     const { worktrees } = await runtime.getWorktreePs()
     const oldSummary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
@@ -31133,6 +31146,47 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('drops a hydrated row when only its stale persisted tab remains', async () => {
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        [TEST_WORKTREE_ID]: [
+          {
+            id: 'stale-tab',
+            ptyId: null,
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Codex',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    })
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey: 'stale-tab:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          worktreeId: TEST_WORKTREE_ID,
+          tabId: 'stale-tab',
+          state: 'done',
+          prompt: 'persisted history',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: now,
+          stateStartedAt: now - 60_000
+        }
+      ]
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([])
+  })
+
   it('resolves legacy numeric pane keys through the stale filter too', async () => {
     // Why: non-UUID leaves produce `tabId:paneRuntimeId` keys with no tabId
     // field; they still name a real tab and must not bypass the filter.
@@ -31177,6 +31231,19 @@ describe('OrcaRuntimeService', () => {
           stateStartedAt: now - 100
         }
       ]
+    })
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'open-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Codex',
+          activeLeafId: '33333333-3333-4333-8333-333333333333',
+          layout: null
+        }
+      ],
+      leaves: []
     })
 
     const { worktrees } = await runtime.getWorktreePs()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31133,6 +31133,60 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('resolves legacy numeric pane keys through the stale filter too', async () => {
+    // Why: non-UUID leaves produce `tabId:paneRuntimeId` keys with no tabId
+    // field; they still name a real tab and must not bypass the filter.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {
+        [TEST_WORKTREE_ID]: [
+          {
+            id: 'open-tab',
+            ptyId: null,
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Codex',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      }
+    })
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey: 'closed-tab:7',
+          worktreeId: TEST_WORKTREE_ID,
+          state: 'done',
+          prompt: 'stale legacy pane',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: now,
+          stateStartedAt: now - 60_000
+        },
+        {
+          paneKey: 'open-tab:9',
+          worktreeId: TEST_WORKTREE_ID,
+          state: 'working',
+          prompt: 'live legacy pane',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: now,
+          stateStartedAt: now - 100
+        }
+      ]
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([
+      expect.objectContaining({ paneKey: 'open-tab:9', prompt: 'live legacy pane' })
+    ])
+  })
+
   it('keeps a local hook row while a connected PTY still backs its pane', async () => {
     // Why: daemon-held terminals stay live across renderer graph gaps even when
     // no session tab records them; a connected PTY is proof the pane exists.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31073,6 +31073,21 @@ describe('OrcaRuntimeService', () => {
           }
         ]
       })
+      // Why: local rows only project while their tab exists (#6072); freshness
+      // is what varies here, so keep the tab present in the runtime graph.
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, {
+        tabs: [
+          {
+            tabId: 'tab-1',
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Codex',
+            activeLeafId: '33333333-3333-4333-8333-333333333333',
+            layout: null
+          }
+        ],
+        leaves: []
+      })
 
       const { worktrees } = await runtime.getWorktreePs()
 
@@ -31082,6 +31097,138 @@ describe('OrcaRuntimeService', () => {
       })
     }
   )
+
+  it('drops a hydrated done hook row after its local tab is closed', async () => {
+    // Why (#6072): last-status.json hydrates hook rows for days; a closed tab's
+    // agent must not resurface on mobile as current worktree activity.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {}
+    })
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey: 'closed-tab:66666666-6666-4666-8666-666666666666',
+          worktreeId: TEST_WORKTREE_ID,
+          tabId: 'closed-tab',
+          state: 'done',
+          prompt: 'refactor the parser',
+          agentType: 'claude',
+          connectionId: null,
+          receivedAt: now,
+          stateStartedAt: now - 60_000
+        }
+      ]
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary).toMatchObject({
+      liveTerminalCount: 0,
+      hasHostSidebarActivity: false,
+      status: 'inactive',
+      agents: []
+    })
+  })
+
+  it('keeps a local hook row while a connected PTY still backs its pane', async () => {
+    // Why: daemon-held terminals stay live across renderer graph gaps even when
+    // no session tab records them; a connected PTY is proof the pane exists.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {}
+    })
+    const paneKey = 'daemon-tab:77777777-7777-4777-8777-777777777777'
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey,
+          worktreeId: TEST_WORKTREE_ID,
+          tabId: 'daemon-tab',
+          state: 'working',
+          prompt: 'long-running daemon agent',
+          agentType: 'codex',
+          connectionId: null,
+          receivedAt: now,
+          stateStartedAt: now - 100
+        }
+      ]
+    })
+    runtime['recordPtyWorktree']('daemon-pty', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'daemon-tab',
+      paneKey
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([
+      expect.objectContaining({ paneKey, state: 'working', prompt: 'long-running daemon agent' })
+    ])
+    expect(summary).toMatchObject({ hasHostSidebarActivity: true, status: 'working' })
+  })
+
+  it('keeps remote hook rows whose tabs are only tracked on the remote host', async () => {
+    // Why: the local session partition for an SSH host can be empty while the
+    // remote host owns the terminals; absence there is not proof of a close.
+    const remoteRepo = {
+      id: 'repo-ssh-6072',
+      path: '/home/me/project',
+      displayName: 'remote-vm',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-6072'
+    }
+    const remoteWorktree = {
+      path: '/home/me/project/.worktrees/feature-agents',
+      head: 'def',
+      branch: 'refs/heads/feature/agents',
+      isBare: false,
+      isMainWorktree: false
+    }
+    const remoteWorktreeId = `${remoteRepo.id}::${remoteWorktree.path}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [remoteWorktreeId]: makeWorktreeMeta({ displayName: 'Remote agents' })
+    }
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [remoteRepo],
+      getRepo: (id: string) => (id === remoteRepo.id ? remoteRepo : undefined),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      getWorkspaceSession: () => getDefaultWorkspaceSession()
+    }
+    registerSshGitProvider('ssh-6072', {
+      listWorktrees: vi.fn().mockResolvedValue([remoteWorktree])
+    } as never)
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey: 'remote-tab:88888888-8888-4888-8888-888888888888',
+          worktreeId: remoteWorktreeId,
+          tabId: 'remote-tab',
+          state: 'working',
+          prompt: 'remote agent without local tab records',
+          agentType: 'codex',
+          connectionId: 'ssh-6072',
+          receivedAt: now,
+          stateStartedAt: now - 100
+        }
+      ]
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === remoteWorktreeId)
+
+    expect(summary?.agents).toEqual([
+      expect.objectContaining({ prompt: 'remote agent without local tab records' })
+    ])
+  })
 
   it('marks the desktop-active worktree as isActive', async () => {
     const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31226,6 +31226,35 @@ describe('OrcaRuntimeService', () => {
     expect(summary).toMatchObject({ hasHostSidebarActivity: true, status: 'working' })
   })
 
+  it('drops a hydrated WSL hook row after its local tab is closed', async () => {
+    // Why: WSL relay ids are transport provenance; the pane remains local.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      tabsByWorktree: {}
+    })
+    const now = Date.now()
+    const runtime = new OrcaRuntimeService(runtimeStore as never, undefined, {
+      getAgentStatusSnapshot: () => [
+        {
+          paneKey: 'closed-wsl-tab:99999999-9999-4999-8999-999999999999',
+          worktreeId: TEST_WORKTREE_ID,
+          tabId: 'closed-wsl-tab',
+          state: 'done',
+          prompt: 'finished in WSL',
+          agentType: 'codex',
+          connectionId: 'wsl:Ubuntu',
+          receivedAt: now,
+          stateStartedAt: now - 60_000
+        }
+      ]
+    })
+
+    const { worktrees } = await runtime.getWorktreePs()
+    const summary = worktrees.find((worktree) => worktree.worktreeId === TEST_WORKTREE_ID)
+
+    expect(summary?.agents).toEqual([])
+  })
+
   it('keeps remote hook rows whose tabs are only tracked on the remote host', async () => {
     // Why: the local session partition for an SSH host can be empty while the
     // remote host owns the terminals; absence there is not proof of a close.

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -371,6 +371,7 @@ import {
 } from '../../shared/stable-pane-id'
 import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
 import { isValidHostTerminalTabId, isValidTerminalTabId } from '../../shared/terminal-tab-id'
+import { isWslHookRelayConnectionId } from '../../shared/wsl-hook-relay-contract'
 import {
   applyTerminalQuickCommandMutation,
   MAX_QUICK_COMMANDS,
@@ -16600,7 +16601,7 @@ export class OrcaRuntimeService {
       if (
         tabId !== undefined &&
         mirroredWorktreeId === undefined &&
-        src.connectionId === null &&
+        (src.connectionId === null || isWslHookRelayConnectionId(src.connectionId)) &&
         !connectedPtyEvidence.tabIds.has(tabId) &&
         !connectedPtyEvidence.paneKeys.has(src.paneKey) &&
         (src.ptyId === undefined || !connectedPtyEvidence.ptyIds.has(src.ptyId))
@@ -16608,7 +16609,7 @@ export class OrcaRuntimeService {
         // Why: hook snapshots hydrate from last-status.json for days, so a local
         // row whose tab left every session/graph and has no connected PTY is
         // retained history — surfacing it resurrects closed agents on mobile
-        // (#6072). Remote rows are exempt: their tabs may only exist remotely.
+        // (#6072). SSH rows are exempt: their tabs may only exist remotely.
         continue
       }
       const worktreeId = mirroredWorktreeId ?? src.worktreeId

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16576,6 +16576,9 @@ export class OrcaRuntimeService {
       }
       rowSources.set(entry.paneKey, {
         paneKey: entry.paneKey,
+        // Hook payloads carry no ptyId; keep the OSC-observed one so the
+        // connected-PTY rescue survives a hook row winning the freshness race.
+        ptyId: existing?.ptyId,
         tabId: entry.tabId,
         worktreeId: entry.worktreeId,
         connectionId: entry.connectionId,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16600,16 +16600,16 @@ export class OrcaRuntimeService {
       const mirroredWorktreeId = tabId ? mirroredWorktreeIdByTabId.get(tabId) : undefined
       if (
         tabId !== undefined &&
-        mirroredWorktreeId === undefined &&
+        !this.tabs.has(tabId) &&
         (src.connectionId === null || isWslHookRelayConnectionId(src.connectionId)) &&
         !connectedPtyEvidence.tabIds.has(tabId) &&
         !connectedPtyEvidence.paneKeys.has(src.paneKey) &&
         (src.ptyId === undefined || !connectedPtyEvidence.ptyIds.has(src.ptyId))
       ) {
         // Why: hook snapshots hydrate from last-status.json for days, so a local
-        // row whose tab left every session/graph and has no connected PTY is
-        // retained history — surfacing it resurrects closed agents on mobile
-        // (#6072). SSH rows are exempt: their tabs may only exist remotely.
+        // row missing from the live graph with no connected PTY is retained
+        // history; persisted tabs can outlive a close (#6072). SSH rows are
+        // exempt because their tabs may only exist remotely.
         continue
       }
       const worktreeId = mirroredWorktreeId ?? src.worktreeId

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16461,11 +16461,32 @@ export class OrcaRuntimeService {
       }
     }
 
+    // Why: a connected PTY proves a pane is still live even when its tab has
+    // already left every session record (daemon-held terminals, graph gaps).
+    const connectedPtyEvidence = {
+      tabIds: new Set<string>(),
+      paneKeys: new Set<string>(),
+      ptyIds: new Set<string>()
+    }
+    for (const pty of this.ptysById.values()) {
+      if (!pty.connected) {
+        continue
+      }
+      connectedPtyEvidence.ptyIds.add(pty.ptyId)
+      if (pty.tabId) {
+        connectedPtyEvidence.tabIds.add(pty.tabId)
+      }
+      if (pty.paneKey) {
+        connectedPtyEvidence.paneKeys.add(pty.paneKey)
+      }
+    }
+
     this.attachAgentRowsToSummaries(
       summaries,
       runtimeWorktreeSummaryPathIndex,
       missingRuntimeWorktreeIds,
-      mirroredWorktreeIdByTabId
+      mirroredWorktreeIdByTabId,
+      connectedPtyEvidence
     )
 
     const sorted = [...summaries.values()].sort(compareWorktreePs)
@@ -16484,7 +16505,12 @@ export class OrcaRuntimeService {
     summaries: Map<string, RuntimeWorktreePsSummary>,
     runtimeWorktreeSummaryPathIndex: RuntimeWorktreeSummaryPathIndex,
     missingRuntimeWorktreeIds: Set<string>,
-    mirroredWorktreeIdByTabId: ReadonlyMap<string, string>
+    mirroredWorktreeIdByTabId: ReadonlyMap<string, string>,
+    connectedPtyEvidence: {
+      tabIds: ReadonlySet<string>
+      paneKeys: ReadonlySet<string>
+      ptyIds: ReadonlySet<string>
+    }
   ): void {
     // Why: most agents report via hooks (agent-hooks/server), not OSC, so the
     // hook snapshot is the primary source — same one the desktop sidebar reads.
@@ -16493,8 +16519,10 @@ export class OrcaRuntimeService {
       string,
       {
         paneKey: string
+        ptyId?: string
         tabId?: string
         worktreeId?: string
+        connectionId: string | null
         state: ParsedAgentStatusPayload['state']
         agentType: string | null
         prompt: string
@@ -16510,8 +16538,10 @@ export class OrcaRuntimeService {
       const { payload } = snapshot
       rowSources.set(snapshot.paneKey, {
         paneKey: snapshot.paneKey,
+        ptyId: snapshot.ptyId,
         tabId: snapshot.tabId,
         worktreeId: snapshot.worktreeId,
+        connectionId: null,
         state: payload.state,
         agentType: payload.agentType ?? null,
         prompt: payload.prompt,
@@ -16534,6 +16564,7 @@ export class OrcaRuntimeService {
         paneKey: entry.paneKey,
         tabId: entry.tabId,
         worktreeId: entry.worktreeId,
+        connectionId: entry.connectionId,
         state: entry.state,
         agentType: entry.agentType ?? null,
         prompt: entry.prompt,
@@ -16555,8 +16586,22 @@ export class OrcaRuntimeService {
       // Why: hooks retain launch-time attribution across automatic workspace
       // renames; the tab's current mirrored owner is authoritative when present.
       const tabId = src.tabId ?? parsePaneKey(src.paneKey)?.tabId
-      const worktreeId =
-        (tabId ? mirroredWorktreeIdByTabId.get(tabId) : undefined) ?? src.worktreeId
+      const mirroredWorktreeId = tabId ? mirroredWorktreeIdByTabId.get(tabId) : undefined
+      if (
+        tabId !== undefined &&
+        mirroredWorktreeId === undefined &&
+        src.connectionId === null &&
+        !connectedPtyEvidence.tabIds.has(tabId) &&
+        !connectedPtyEvidence.paneKeys.has(src.paneKey) &&
+        (src.ptyId === undefined || !connectedPtyEvidence.ptyIds.has(src.ptyId))
+      ) {
+        // Why: hook snapshots hydrate from last-status.json for days, so a local
+        // row whose tab left every session/graph and has no connected PTY is
+        // retained history — surfacing it resurrects closed agents on mobile
+        // (#6072). Remote rows are exempt: their tabs may only exist remotely.
+        continue
+      }
+      const worktreeId = mirroredWorktreeId ?? src.worktreeId
       if (!worktreeId) {
         continue
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -363,7 +363,12 @@ import {
 } from '../../shared/setup-agent-sequencing'
 import { TASK_PROVIDERS } from '../../shared/task-providers'
 import { FIRST_PANE_ID } from '../../shared/pane-key'
-import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../shared/stable-pane-id'
+import {
+  isTerminalLeafId,
+  makePaneKey,
+  parseLegacyNumericPaneKey,
+  parsePaneKey
+} from '../../shared/stable-pane-id'
 import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
 import { isValidHostTerminalTabId, isValidTerminalTabId } from '../../shared/terminal-tab-id'
 import {
@@ -16585,7 +16590,12 @@ export class OrcaRuntimeService {
     for (const src of rowSources.values()) {
       // Why: hooks retain launch-time attribution across automatic workspace
       // renames; the tab's current mirrored owner is authoritative when present.
-      const tabId = src.tabId ?? parsePaneKey(src.paneKey)?.tabId
+      // Legacy numeric pane keys (non-UUID leaves) still name a real tab, so
+      // parse them too — otherwise their rows would bypass the stale filter.
+      const tabId =
+        src.tabId ??
+        parsePaneKey(src.paneKey)?.tabId ??
+        parseLegacyNumericPaneKey(src.paneKey)?.tabId
       const mirroredWorktreeId = tabId ? mirroredWorktreeIdByTabId.get(tabId) : undefined
       if (
         tabId !== undefined &&

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1430,6 +1430,9 @@ type RuntimeAgentRowSnapshot = {
   ptyId: string
   worktreeId?: string
   tabId?: string
+  // Transport of the pane's PTY at retain time; null for local. Without it,
+  // OSC rows for SSH panes would lose the remote exemption in worktree.ps.
+  connectionId: string | null
   payload: ParsedAgentStatusPayload
   // When the current payload.state was first observed for this pane (ms).
   stateStartedAt: number
@@ -9607,6 +9610,7 @@ export class OrcaRuntimeService {
             target.paneKey,
             target.worktreeId,
             target.tabId,
+            target.connectionId ?? null,
             payload
           ) || retainedChanged
         if (!this.onTerminalAgentStatus) {
@@ -9637,6 +9641,7 @@ export class OrcaRuntimeService {
     paneKey: string,
     worktreeId: string | undefined,
     tabId: string | undefined,
+    connectionId: string | null,
     payload: ParsedAgentStatusPayload
   ): boolean {
     const now = Date.now()
@@ -9651,6 +9656,7 @@ export class OrcaRuntimeService {
       ptyId,
       worktreeId,
       tabId,
+      connectionId,
       payload,
       stateStartedAt,
       updatedAt: now
@@ -16469,6 +16475,8 @@ export class OrcaRuntimeService {
 
     // Why: a connected PTY proves a pane is still live even when its tab has
     // already left every session record (daemon-held terminals, graph gaps).
+    // Deliberately trusts the optimistic connected flag (no freshPtyLiveness
+    // gate, unlike the count loops above): evidence only KEEPS rows.
     const connectedPtyEvidence = {
       tabIds: new Set<string>(),
       paneKeys: new Set<string>(),
@@ -16547,7 +16555,7 @@ export class OrcaRuntimeService {
         ptyId: snapshot.ptyId,
         tabId: snapshot.tabId,
         worktreeId: snapshot.worktreeId,
-        connectionId: null,
+        connectionId: snapshot.connectionId,
         state: payload.state,
         agentType: payload.agentType ?? null,
         prompt: payload.prompt,
@@ -16600,16 +16608,19 @@ export class OrcaRuntimeService {
       const mirroredWorktreeId = tabId ? mirroredWorktreeIdByTabId.get(tabId) : undefined
       if (
         tabId !== undefined &&
-        !this.tabs.has(tabId) &&
+        mirroredWorktreeId === undefined &&
         (src.connectionId === null || isWslHookRelayConnectionId(src.connectionId)) &&
         !connectedPtyEvidence.tabIds.has(tabId) &&
         !connectedPtyEvidence.paneKeys.has(src.paneKey) &&
         (src.ptyId === undefined || !connectedPtyEvidence.ptyIds.has(src.ptyId))
       ) {
-        // Why: hook snapshots hydrate from last-status.json for days, so a local
-        // row missing from the live graph with no connected PTY is retained
-        // history; persisted tabs can outlive a close (#6072). SSH rows are
-        // exempt because their tabs may only exist remotely.
+        // Why: hook snapshots hydrate from last-status.json for days, so a row
+        // from a local or WSL-relayed pane whose tab left every session and the
+        // live graph, with no connected PTY, is retained history — surfacing it
+        // resurrects closed agents on mobile (#6072). SSH rows are exempt (their
+        // tabs may exist only remotely), as are rows with no resolvable tabId
+        // (staleness unprovable). Session tabs count as existence: headless
+        // serve has no renderer graph, and session.tabs.list serves them.
         continue
       }
       const worktreeId = mirroredWorktreeId ?? src.worktreeId


### PR DESCRIPTION
## Summary

Fixes #6072 — Orca Mobile (and `orca worktree ps --json`) kept showing old agent rows for a worktree after the terminals behind them were closed.

The issue had two halves:

1. **Stale `liveTerminalCount` from persisted tabs** — already fixed on main by #9874, which removed the `Math.max(liveTerminalCount, tabs.length)` folding of saved session tabs. Verified empirically: the committed repro from the issue thread (branch `nwparker/bug-repro-pass2`, test 1) now fails to reproduce this half on current main.
2. **Stale `done` agent rows from the hydrated hook snapshot** — still reproduced on current main (same repro branch, test 2). `attachAgentRowsToSummaries()` attached every hook/OSC row by `worktreeId` with no check that the row's pane/tab still exists. Since `agent-hooks` `last-status.json` hydrates entries for days, a finished agent whose tab was closed kept resurfacing as current mobile activity.

This PR fixes half 2 at read time in `getWorktreePs()`: a row from a **local or WSL-relayed pane** (hook `connectionId === null` or `wsl:<distro>`; OSC rows carry their pane's real transport) is dropped when its tab is gone from every relevant workspace session and the live renderer graph **and** no connected PTY still backs it (tab id, pane key, or pty id match). SSH rows are exempt because their tabs may be tracked only on the remote host — the local session partition being empty is not proof of a close (this preserves the existing SSH no-PTY agent contract pinned by the runtime tests). Rows with no resolvable tab id also pass through: staleness is unprovable for them.

Relationship to adjacent work:
- **Supersedes #6222** (same author account). That PR had the right diagnosis and the same read-time-filter strategy; credit to it for the approach. It is stale/conflicting (~8 months of runtime drift: `freshPtyLiveness` gating, `mirroredWorktreeIdByTabId`, folder workspaces), half its diff was independently landed by #9874, and its hard live-PTY requirement would today break the pinned SSH contract ("keeps no-PTY agent worktrees in the truncated mobile summary"). This PR implements the surviving half against current main with a remote exemption and a connected-PTY rescue instead.
- **Not fixed by #11240** (merged while this PR was open): that PR routes the mobile long-press Close through `handleCloseSessionTab` on the mobile client, pruning the client's own mirror. The repro here drives the host runtime directly with no mobile client involved (and reproduced on a headless Linux server per the issue thread), so the host-side projection fix is independent of it. #11251 (also merged) is likewise mobile-client-only. The mobile-side stale-view symptom reported by @taifunk in the issue comments is #11240's territory.
- `session.tabs.close` hook-status clearing (suggested in the issue) is intentionally not added: read-time filtering also covers closes that happen while Orca is not running, crashes, and desktop-side closes, without new mutation paths.

<!-- user-visible-before-after:start -->
## What the user sees before and after

### Before

Mobile can continue showing old `Done` agent rows after their terminal tabs have been closed, making finished activity look current.

### After

Stale local agent rows disappear when their tabs and terminals are gone. Remote and SSH rows remain visible when local state cannot prove they were closed.
<!-- user-visible-before-after:end -->

## Simulator screenshots

Exact-current-head parent/head A/B at reviewed head `23a22ac51e254fca829a24f8596886e47e88be53` held the iOS client, Metro bundle, paired host profile, fixture workspace, port, and byte-identical injected status seed constant; only the host/runtime build changed.

### Before — parent `f4e46383df`

The closed-tab `Done` row remains visible alongside the live control row.

![Simulator before — stale closed-tab row remains](https://github.com/user-attachments/assets/05bf3b46-cda1-4a41-9c27-715341dacd8f)

### After — PR head `23a22ac51e`

The stale closed-tab row disappears while the live control row remains.

![Simulator after — stale row gone and live row retained](https://github.com/user-attachments/assets/c4a103bd-62ac-4736-a1c2-961d9c7d850b)

## Simulator validation

**PASS** on exact reviewed head `23a22ac51e254fca829a24f8596886e47e88be53`. At the parent, `worktree.ps` and the simulator both showed the hydrated row after its local tab and terminal were gone. At the head, the same seed and view dropped only that stale row while retaining the live OSC/hook row. Focused head tests also passed for the connected-PTY rescue and SSH exemption.

## Testing

- [x] `pnpm lint` — oxlint (default + react-doctor configs) clean on changed files; oxfmt clean
- [x] `pnpm typecheck` — clean (all three tsconfigs)
- [x] `pnpm test` — `src/main/runtime/orca-runtime.test.ts`: 934 passed, 1 skipped, 0 failed at head (own parent baseline measured first: 923 passed, 1 skipped, 0 failed on f4e46383df)
- [ ] `pnpm build` — not run locally (no build-affecting changes; CI covers it)
- [x] Non-vacuity proven by a 7-mutation battery: reverting the tab-existence predicate, the OSC transport threading, each of the three connected-PTY rescue conjuncts, an over-broad WSL rule, and the unresolvable-tab-id guard each turn exactly one named test RED. Every added drop test has a paired keep test (open persisted tab, connected PTY by pane key / tab id / pty id after binding clear, WSL tab open, SSH pane after disconnect, unresolvable pane key), and the freshness table asserts row presence so "inactive" can never be satisfied by a dropped row.

## AI Review Report

Three independent same-model review passes (filter semantics per environment, test integrity via mutation testing, scope/contract adherence) ran against this branch; their converged findings are applied in `142d3a914d`. Main risks checked: (1) over-filtering live agents — persisted session tabs count as tab existence (headless `orca serve` publishes an empty renderer graph by construction, `markGraphUnavailable` clears it, and unvisited/cold-parked desktop workspaces never mount panes), with the connected-PTY rescue and SSH exemption on top; an intermediate commit (`a829e8f9cf`) that narrowed existence to the live graph was reverted after all three reviewers independently traced live-row drops in those states, and every close path was verified to prune the persisted tab (mobile/headless close, PTY-exit retirement, desktop session rewrite). (2) Workspace-rename mirroring — the rename test is restored to its headless session-only fixture and passes without a synthetic graph. (3) OSC rows — retained snapshots now carry the pane's `connectionId`, so an SSH pane's exemption survives a fresher OSC ping; a WSL or local OSC row still filters as local. Cross-platform: no shortcuts, labels, paths, or shell behavior touched; WSL relay ids (`wsl:<distro>`, transport provenance for local Windows panes) are filtered as local per `wsl-hook-relay-contract.ts`; SSH and folder-workspace paths considered explicitly.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface changes. The change only removes rows from an existing read-only projection; no new data is exposed (strictly less is). No follow-up needed.

## Notes

- The SSH exemption means a stale row for an SSH worktree whose tab was closed remotely can still linger until the hook snapshot expires; fixing that requires trusting per-host session partitions, which are not reliably populated today (see @taifunk's comment on #6072). Deliberately out of scope. WSL relay rows are NOT exempt: the WSL relay never clears status entries on link death, and the pane is a local Windows tab, so local evidence is authoritative for them.
- Exact-current-head simulator A/B passed at `23a22ac51e254fca829a24f8596886e47e88be53`; the embedded screenshots above are the final-head evidence.
- #6222 can be closed in favor of this PR.
