### PR TITLE
fix(tabs): keep widths stable during title updates

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -12,6 +12,7 @@ import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 import BrowserTab from './BrowserTab'
 import EditorFileTab from './EditorFileTab'
 import SortableTab from './SortableTab'
+import { TAB_CONTAINER_WIDTH_CLASSES } from './tab-width-rules'
 
 let mockTabAgent: TuiAgent | null = null
 
@@ -188,8 +189,10 @@ function textSpanHtml(markup: string, text: string): string {
 
 function expectTabContainerWidth(markup: string, root: string): void {
   const container = firstOpeningTag(markup)
-  const widthClasses = 'min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]'
-  expect(container).toContain(widthClasses)
+  expect(container).toContain(TAB_CONTAINER_WIDTH_CLASSES)
+  expect(container).toContain('w-[180px]')
+  expect(container).toContain('min-[1280px]:w-[220px]')
+  expect(root).not.toContain('w-[180px]')
   expect(root).not.toContain('min-w-[88px]')
   expect(root).not.toContain('max-w-[280px]')
   expect(root).not.toContain('flex-[1_1_180px]')

--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -12,7 +12,6 @@ import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 import BrowserTab from './BrowserTab'
 import EditorFileTab from './EditorFileTab'
 import SortableTab from './SortableTab'
-import { TAB_CONTAINER_WIDTH_CLASSES } from './tab-width-rules'
 
 let mockTabAgent: TuiAgent | null = null
 
@@ -189,13 +188,13 @@ function textSpanHtml(markup: string, text: string): string {
 
 function expectTabContainerWidth(markup: string, root: string): void {
   const container = firstOpeningTag(markup)
-  expect(container).toContain(TAB_CONTAINER_WIDTH_CLASSES)
-  expect(container).toContain('w-[180px]')
-  expect(container).toContain('min-[1280px]:w-[220px]')
+  // Why: pinned literally — a definite `w-*` is what stops live title updates from resizing
+  // every tab, so asserting against the constant would let that guarantee be edited away.
+  const widthClasses = 'w-[180px] min-w-[88px] min-[1280px]:w-[220px]'
+  expect(container).toContain(widthClasses)
   expect(root).not.toContain('w-[180px]')
   expect(root).not.toContain('min-w-[88px]')
-  expect(root).not.toContain('max-w-[280px]')
-  expect(root).not.toContain('flex-[1_1_180px]')
+  expect(root).not.toContain('min-[1280px]:w-[220px]')
 }
 
 function expectTooltipContent(markup: string, text: string): void {

--- a/src/renderer/src/components/tab-bar/tab-width-rules.ts
+++ b/src/renderer/src/components/tab-bar/tab-width-rules.ts
@@ -1,6 +1,5 @@
-// Why: tab strips should reveal as much title as space allows, then shrink to
-// a readable floor before horizontal overflow takes over.
+// Why: explicit preferred widths keep live title changes from resizing the shrink-wrapped strip.
 export const TAB_CONTAINER_WIDTH_CLASSES =
-  'min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:flex-[1_1_220px]'
+  'w-[180px] min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:w-[220px] min-[1280px]:flex-[1_1_220px]'
 
 export const TAB_LABEL_WIDTH_CLASSES = 'min-w-0 flex-1 truncate'

--- a/src/renderer/src/components/tab-bar/tab-width-rules.ts
+++ b/src/renderer/src/components/tab-bar/tab-width-rules.ts
@@ -1,5 +1,5 @@
-// Why: explicit preferred widths keep live title changes from resizing the shrink-wrapped strip.
-export const TAB_CONTAINER_WIDTH_CLASSES =
-  'w-[180px] min-w-[88px] max-w-[280px] flex-[1_1_180px] min-[1280px]:w-[220px] min-[1280px]:flex-[1_1_220px]'
+// Why: the strip shrink-wraps its tabs, so a content-derived width lets one live title update
+// resize every tab; a definite width pins them and flex-shrink still narrows to the floor.
+export const TAB_CONTAINER_WIDTH_CLASSES = 'w-[180px] min-w-[88px] min-[1280px]:w-[220px]'
 
 export const TAB_LABEL_WIDTH_CLASSES = 'min-w-0 flex-1 truncate'

--- a/tests/e2e/tab-rename.spec.ts
+++ b/tests/e2e/tab-rename.spec.ts
@@ -308,6 +308,49 @@ test.describe('Tab Rename (Inline)', () => {
     await expect(renameInput).toBeHidden()
   })
 
+  test('terminal title updates do not resize neighboring tabs', async ({ orcaPage }) => {
+    const worktreeId = (await getActiveWorktreeId(orcaPage))!
+    const tabIds = await orcaPage.evaluate((targetWorktreeId) => {
+      const state = window.__store!.getState()
+      const existing = state.tabsByWorktree[targetWorktreeId] ?? []
+      for (let index = existing.length; index < 3; index += 1) {
+        state.createTab(targetWorktreeId, undefined, undefined, { activate: false })
+      }
+      const ids = (window.__store!.getState().tabsByWorktree[targetWorktreeId] ?? [])
+        .slice(0, 3)
+        .map((tab) => tab.id)
+      ids.forEach((id, index) => state.setTabCustomTitle(id, `Tab ${index + 1}`))
+      return ids
+    }, worktreeId)
+
+    const tabs = tabIds.map((id) =>
+      orcaPage.locator(`[data-testid="sortable-tab"][data-tab-id="${id}"]`)
+    )
+    await expect(tabs[2]!).toBeVisible()
+    const before = await Promise.all(
+      tabs.map((tab) => tab.evaluate((element) => element.getBoundingClientRect().width))
+    )
+
+    await orcaPage.evaluate(
+      ({ tabId }) => {
+        window
+          .__store!.getState()
+          .setTabCustomTitle(
+            tabId,
+            'Continuously changing generated terminal title that must remain constrained'
+          )
+      },
+      { tabId: tabIds[0] }
+    )
+    await expect(tabs[0]!).toContainText('Continuously changing generated terminal title')
+    const after = await Promise.all(
+      tabs.map((tab) => tab.evaluate((element) => element.getBoundingClientRect().width))
+    )
+
+    after.forEach((width, index) => expect(Math.abs(width - before[index]!)).toBeLessThanOrEqual(1))
+    await tabs[2]!.click()
+    await expect(tabs[2]!).toHaveAttribute('data-active', 'true')
+  })
   test('rename input stays at a usable width when many tabs are open', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
     const targetTabId = await getActiveTabId(orcaPage)

--- a/tests/e2e/tab-rename.spec.ts
+++ b/tests/e2e/tab-rename.spec.ts
@@ -330,6 +330,12 @@ test.describe('Tab Rename (Inline)', () => {
     const before = await Promise.all(
       tabs.map((tab) => tab.evaluate((element) => element.getBoundingClientRect().width))
     )
+    // Why: at the 88px shrink floor widths are stable for the wrong reason, and being above it is
+    // also what proves the definite tab width applied — so this fails first on a regression.
+    expect(
+      Math.min(...before),
+      'tabs must be above the 88px shrink floor for the stability check to mean anything'
+    ).toBeGreaterThan(88)
 
     await orcaPage.evaluate(
       ({ tabId }) => {
@@ -351,6 +357,7 @@ test.describe('Tab Rename (Inline)', () => {
     await tabs[2]!.click()
     await expect(tabs[2]!).toHaveAttribute('data-active', 'true')
   })
+
   test('rename input stays at a usable width when many tabs are open', async ({ orcaPage }) => {
     const worktreeId = (await getActiveWorktreeId(orcaPage))!
     const targetTabId = await getActiveTabId(orcaPage)


### PR DESCRIPTION
## Problem

Rapid terminal title updates repeatedly expand and shrink the tab strip. This moves neighboring tabs under the pointer, making them difficult or sometimes impossible to select.

## Summary

- Keep terminal tab widths stable while generated terminal titles change.
- Preserve the existing responsive shrink and horizontal overflow behavior.
- Add regression coverage proving neighboring tabs stay stable and selectable.

## Testing

- `pnpm exec playwright test tests/e2e/tab-rename.spec.ts --config tests/playwright.config.ts --project=electron-headless --workers=1 -g "terminal title updates"` — passed
- Related tab unit tests — 5 passed
- Changed-file `oxfmt --check` and `oxlint --deny-warnings` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed

## Screenshots

No static visual design change. The bug is a motion/layout-shift issue during live title updates, and the E2E test verifies stable tab geometry and continued tab selection.

## Security Audit

No security-sensitive behavior, data handling, IPC, filesystem access, or network access changed.

## AI review summary

- Cross-platform compatibility: CSS-only sizing behavior is identical on macOS, Linux, and Windows.
- SSH/remote/local compatibility: applies uniformly to terminal titles from all runtime hosts.
- Agent/integration compatibility: provider-neutral; title generation is unchanged.
- Performance risk: no new runtime work, subscriptions, allocations, or observers.
- UI quality: prevents layout shifts while retaining truncation and overflow behavior.
- Security risk: none identified.

## Notes

- `pnpm lint` is currently blocked by stale bundled-skill manifest outputs already present in the checkout.
- `pnpm test` timed out after 20 minutes with unrelated Windows/Git Bash-dependent failures; all directly affected tab tests pass.

X/Twitter: N/A