### PR TITLE
fix(skills): keep copied Git Bash commands runnable

### DIFF
--- a/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
+++ b/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
@@ -3,7 +3,10 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { OnboardingInlineCommandTerminal } from '@/components/onboarding/OnboardingInlineCommandTerminal'
-import { buildSkillCommandForRuntime } from '@/components/settings/CliSkillRuntimeSetup'
+import {
+  buildSkillCommandForRuntime,
+  getSkillCommandForClipboard
+} from '@/components/settings/CliSkillRuntimeSetup'
 import { ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
 import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
 import { translate } from '@/i18n/i18n'
@@ -18,10 +21,14 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
     ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
     activeSkillRuntime.installDisabledReason ? undefined : activeSkillRuntime.agentRuntime
   )
+  const clipboardCommand = getSkillCommandForClipboard(
+    skillCommand,
+    activeSkillRuntime.terminalShellOverride
+  )
 
   const handleCopySkillCommand = async (): Promise<void> => {
     try {
-      await window.api.ui.writeClipboardText(skillCommand)
+      await window.api.ui.writeClipboardText(clipboardCommand)
       toast.success(
         translate(
           'auto.components.feature.tips.CliSkillSetupTerminal.b8ad063571',
@@ -44,7 +51,7 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
     <div className="min-w-0">
       <div className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted/35 px-3 py-2">
         <code className="scrollbar-sleek min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-muted-foreground">
-          {skillCommand}
+          {clipboardCommand}
         </code>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -9,6 +9,7 @@ import { TooltipProvider } from '../ui/tooltip'
 
 const INSTALL_COMMAND = 'npx skills add https://github.com/stablyai/orca --skill orca-cli --global'
 const UPDATE_COMMAND = 'npx skills update orca-cli --global'
+const WINDOWS_INSTALL_COMMAND = `cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1) else (${INSTALL_COMMAND})"`
 
 const mocks = vi.hoisted(() => ({
   clipboardWrite: vi.fn(),
@@ -236,6 +237,26 @@ describe('AgentSkillSetupPanel', () => {
 
     expect(mocks.clipboardWrite).toHaveBeenCalledWith(INSTALL_COMMAND)
     expect(mocks.toastSuccess).toHaveBeenCalledWith('Copied command.')
+  })
+
+  it('copies the bare command for Git Bash while keeping the Windows terminal preflight', async () => {
+    await renderInteractivePanel({
+      command: WINDOWS_INSTALL_COMMAND,
+      terminalShellOverride: 'powershell.exe'
+    })
+
+    await clickButton('Install')
+
+    expect(container?.querySelector('code')?.textContent).toBe(INSTALL_COMMAND)
+    expect(mocks.terminalProps.at(-1)).toMatchObject({ command: WINDOWS_INSTALL_COMMAND })
+
+    await act(async () => {
+      container
+        ?.querySelector<HTMLButtonElement>('button[aria-label="Copy command"]')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(mocks.clipboardWrite).toHaveBeenCalledWith(INSTALL_COMMAND)
   })
 
   it('shows a visible pending state while CLI setup preflight is running', async () => {

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -11,6 +11,7 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import { getSkillCommandForClipboard } from './CliSkillRuntimeSetup'
 
 type AgentSkillSetupPanelVariant = 'card' | 'inline'
 type SkillPrerequisiteStatus = Awaited<ReturnType<typeof window.api.cli.getInstallStatus>>
@@ -106,6 +107,7 @@ export function AgentSkillSetupPanel({
   // Why: the inline terminal auto-inserts when its command changes, so keep an
   // already-open terminal pinned to the command selected by the user's click.
   const openTerminalCommand = terminalCommand ?? activeCommand
+  const clipboardCommand = getSkillCommandForClipboard(openTerminalCommand, terminalShellOverride)
 
   useEffect(() => {
     if (!preInstallNotice) {
@@ -153,7 +155,7 @@ export function AgentSkillSetupPanel({
 
   const copyActiveCommand = async (): Promise<void> => {
     try {
-      await window.api.ui.writeClipboardText(openTerminalCommand)
+      await window.api.ui.writeClipboardText(clipboardCommand)
       toast.success(
         translate('auto.components.settings.AgentSkillSetupPanel.copiedCommand', 'Copied command.')
       )
@@ -329,7 +331,7 @@ export function AgentSkillSetupPanel({
         >
           <div className="flex min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-md border border-border bg-muted/35 px-3 py-2">
             <code className="scrollbar-sleek min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-muted-foreground">
-              {openTerminalCommand}
+              {clipboardCommand}
             </code>
             <Tooltip>
               <TooltipTrigger asChild>

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -12,6 +12,7 @@ import {
   buildSkillInstallCommandForRuntime,
   getAgentSkillTerminalShellOverride,
   getSelectedAgentRuntime,
+  getSkillCommandForClipboard,
   getSkillDiscoveryTargetForRuntime
 } from './CliSkillRuntimeSetup'
 
@@ -156,6 +157,19 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         'win32'
       )
     ).toBe(`${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`)
+  })
+
+  it('unwraps a forced-PowerShell Windows command only at the clipboard boundary', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])
+    const terminalCommand = buildSkillCommandForRuntime(
+      installCommand,
+      { runtime: 'host', label: 'Windows' },
+      'win32'
+    )
+
+    expect(getSkillCommandForClipboard(terminalCommand, 'powershell.exe')).toBe(installCommand)
+    expect(getSkillCommandForClipboard(terminalCommand)).toBe(terminalCommand)
+    expect(getSkillCommandForClipboard(terminalCommand, 'cmd.exe')).toBe(terminalCommand)
   })
 
   it('treats missing runtime as a preflighted Windows host fallback for skill installs', () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -30,6 +30,13 @@ const LOCAL_HOST_AGENT_RUNTIME: LocalAgentRuntime = {
   label: ''
 }
 
+const WINDOWS_NPX_PREREQUISITE_PREFIX =
+  'cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 ('
+const WINDOWS_NPX_PREREQUISITE_GUIDANCE =
+  'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1'
+const WINDOWS_NPX_COMMAND_PREFIX = `${WINDOWS_NPX_PREREQUISITE_PREFIX}${WINDOWS_NPX_PREREQUISITE_GUIDANCE}) else (`
+const WINDOWS_NPX_COMMAND_SUFFIX = ')"'
+
 export function getHostRuntimeLabel(): string {
   return navigator.userAgent.includes('Windows') ? 'Windows' : 'This device'
 }
@@ -141,12 +148,27 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
     return command
   }
 
-  const missingNpxGuidance =
-    'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1'
   // Why: cmd.exe is one shell-neutral boundary for PowerShell and Command
   // Prompt, and it resolves the bare name through PATHEXT for both the
   // preflight and the executed command, so shims such as npx.exe still count.
-  return `cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (${missingNpxGuidance}) else (${trimmedCommand})"`
+  return `${WINDOWS_NPX_COMMAND_PREFIX}${trimmedCommand}${WINDOWS_NPX_COMMAND_SUFFIX}`
+}
+
+export function getSkillCommandForClipboard(
+  command: string,
+  terminalShellOverride?: string
+): string {
+  // Why: a forced PowerShell terminal signals a POSIX-configured user shell;
+  // unwrap only the exact native-host command that Git Bash cannot paste safely.
+  if (
+    terminalShellOverride !== 'powershell.exe' ||
+    !command.startsWith(WINDOWS_NPX_COMMAND_PREFIX) ||
+    !command.endsWith(WINDOWS_NPX_COMMAND_SUFFIX)
+  ) {
+    return command
+  }
+
+  return command.slice(WINDOWS_NPX_COMMAND_PREFIX.length, -WINDOWS_NPX_COMMAND_SUFFIX.length)
 }
 
 function isRemoteRuntimeEnvironmentFocused(): boolean {

--- a/src/renderer/src/components/settings/OrchestrationPane.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.tsx
@@ -165,6 +165,7 @@ export function OrchestrationPane(): React.JSX.Element {
 
       <OrchestrationSkillPromptDialog
         command={orchestrationInstallCommand}
+        terminalShellOverride={activeSkillRuntime.terminalShellOverride}
         open={skillPromptOpen}
         onOpenChange={setSkillPromptOpen}
       />

--- a/src/renderer/src/components/settings/OrchestrationSkillPromptDialog.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillPromptDialog.tsx
@@ -10,17 +10,20 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { translate } from '@/i18n/i18n'
+import { getSkillCommandForClipboard } from './CliSkillRuntimeSetup'
 
 export function OrchestrationSkillPromptDialog(props: {
   command: string
+  terminalShellOverride?: string
   open: boolean
   onOpenChange: (open: boolean) => void
 }): React.JSX.Element {
-  const { command, open, onOpenChange } = props
+  const { command, terminalShellOverride, open, onOpenChange } = props
+  const clipboardCommand = getSkillCommandForClipboard(command, terminalShellOverride)
 
   const copyCommand = async (): Promise<void> => {
     try {
-      await window.api.ui.writeClipboardText(command)
+      await window.api.ui.writeClipboardText(clipboardCommand)
       toast.success(
         translate(
           'auto.components.settings.OrchestrationSkillPromptDialog.239bf9132b',
@@ -62,7 +65,7 @@ export function OrchestrationSkillPromptDialog(props: {
         <div className="px-6 py-5">
           <div className="group relative rounded-md border border-border/70 bg-editor-surface shadow-xs">
             <p className="px-3 py-3 pr-11 font-mono text-[12px] leading-relaxed break-all text-foreground">
-              {command}
+              {clipboardCommand}
             </p>
             <Button
               type="button"

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -91,6 +91,13 @@ const installOnlyCallers = new Map<string, readonly string[]>([
   ]
 ])
 
+const clipboardCallers = [
+  'src/renderer/src/components/settings/AgentSkillSetupPanel.tsx',
+  'src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx',
+  'src/renderer/src/components/settings/OrchestrationSkillPromptDialog.tsx',
+  'src/renderer/src/components/settings/linear-agent-skill-install-cta.tsx'
+] as const
+
 const directPanelCallers = new Set([
   // BrowserUsePane and LinearAgentSkillSetupPrompt delegate through child setup
   // components that forward installedCommand and are validated separately above.
@@ -161,6 +168,15 @@ describe('AgentSkillSetupPanel installed-command call sites', () => {
     // must fall back to the host rather than skip the Windows npx preflight.
     expect(source).toContain(
       'activeSkillRuntime.installDisabledReason ? undefined : activeSkillRuntime.agentRuntime'
+    )
+  })
+
+  it('keeps every skill-command clipboard boundary Git Bash safe', () => {
+    for (const relativePath of clipboardCallers) {
+      expect(readRepoFile(relativePath), relativePath).toContain('getSkillCommandForClipboard(')
+    }
+    expect(readRepoFile('src/renderer/src/components/settings/OrchestrationPane.tsx')).toContain(
+      'terminalShellOverride={activeSkillRuntime.terminalShellOverride}'
     )
   })
 

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
@@ -27,7 +27,8 @@ vi.mock('@/hooks/useInstalledAgentSkills', async (importOriginal) => ({
 }))
 
 vi.mock('./CliSkillRuntimeSetup', () => ({
-  buildSkillCommandForRuntime: (command: string) => command
+  buildSkillCommandForRuntime: (command: string) => command,
+  getSkillCommandForClipboard: (command: string) => command
 }))
 
 vi.mock('sonner', () => ({

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.tsx
@@ -20,9 +20,10 @@ import {
   getCurrentPlatform,
   getLinearPromptAgentRuntime,
   getLinearPromptSkillDiscoveryTarget,
+  getLinearPromptTerminalShellOverride,
   type LinearAgentSkillPromptSettings
 } from '../sidebar/linear-agent-skill-runtime'
-import { buildSkillCommandForRuntime } from './CliSkillRuntimeSetup'
+import { buildSkillCommandForRuntime, getSkillCommandForClipboard } from './CliSkillRuntimeSetup'
 import {
   useIntegrationCommandRowClass,
   useIntegrationSubordinateRowClass
@@ -42,9 +43,10 @@ export function LinearAgentSkillInstallCta({
   // Why: mirror the sidebar setup prompt's runtime resolution so both surfaces
   // agree on which machine (host vs. WSL distro) is scanned and installed to.
   const remote = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
+  const currentPlatform = getCurrentPlatform()
   const agentRuntime = useMemo(
-    () => getLinearPromptAgentRuntime(settings, getCurrentPlatform(), remote),
-    [remote, settings]
+    () => getLinearPromptAgentRuntime(settings, currentPlatform, remote),
+    [currentPlatform, remote, settings]
   )
   const skillDiscoveryTarget = useMemo(
     () => getLinearPromptSkillDiscoveryTarget(agentRuntime),
@@ -64,12 +66,16 @@ export function LinearAgentSkillInstallCta({
       ),
     [agentRuntime, skill.installed, skill.skills]
   )
+  const clipboardCommand = getSkillCommandForClipboard(
+    command,
+    getLinearPromptTerminalShellOverride(currentPlatform, settings, agentRuntime)
+  )
   const subordinateRowClass = useIntegrationSubordinateRowClass('space-y-1.5')
   const commandRowClass = useIntegrationCommandRowClass()
 
   const copyCommand = async (): Promise<void> => {
     try {
-      await window.api.ui.writeClipboardText(command)
+      await window.api.ui.writeClipboardText(clipboardCommand)
       toast.success(
         translate(
           'auto.components.settings.linear.agent.skill.install.cta.copiedCommand',
@@ -148,7 +154,7 @@ export function LinearAgentSkillInstallCta({
           </p>
           <div className={commandRowClass}>
             <code className="scrollbar-sleek min-w-0 flex-1 overflow-x-auto whitespace-nowrap">
-              {command}
+              {clipboardCommand}
             </code>
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

- Separate copied skill commands from the command Orca inserts into its controlled setup terminal.
- Remove the exact native-Windows `cmd.exe` npx preflight only at clipboard boundaries when Orca has forced the setup terminal to PowerShell for a POSIX-family configured shell.
- Keep the preflight and missing-npx guidance in the controlled terminal, and preserve PowerShell, Command Prompt, WSL, remote-runtime, and non-Windows behavior.
- Cover all four skill-command clipboard surfaces identified in the issue.

Fixes #11431

## Screenshots

No layout change. With Git Bash configured, command previews now show the runnable bare `npx skills ...` command instead of the `cmd.exe /d /s /c` wrapper; Orca setup terminals still receive the wrapped command.

## Testing

- [ ] pnpm lint
- [x] pnpm typecheck
- [ ] pnpm test
- [ ] pnpm build
- [x] Added or updated high-quality tests that would catch regressions

Focused checks:

- Node 24.18.0: 52 tests passed across command construction, clipboard behavior, all clipboard call-site contracts, active runtime resolution, Windows shell overrides, and Linear runtime routing.
- Red/green regression: the new panel test failed before the fix because preview and clipboard still received the `cmd.exe` wrapper, then passed while asserting the in-app terminal retained it.
- pnpm run check:code-quality:changed -- origin/main
- pnpm run check:max-lines-ratchet
- oxfmt --check on all changed files
- git diff --check

## AI Review Report

Reviewed the four clipboard call sites, native Windows host command normalization, remote focus, WSL command wrapping, and shell override resolution. Clipboard unwrapping is restricted to the exact wrapper generated by this module and only when the controlled terminal requires a PowerShell override; unrelated commands and native PowerShell/cmd users remain unchanged. A call-site contract test prevents any of the four copy surfaces from bypassing the clipboard-safe boundary.

## Security Audit

The change adds no new command execution, IPC, filesystem, network, dependency, authentication, or secret-handling surface. It removes a generated wrapper only for displayed/copied text and leaves the controlled execution path unchanged. Exact prefix/suffix matching prevents arbitrary command rewriting.

## Notes

No live Windows build was run for this patch. The issue already contains a measured real-Windows shell matrix; this PR adds deterministic boundary tests for the regression and preserves the previously validated native-shell execution path.