### PR TITLE
Fix stale agent icons in terminal tabs

### DIFF
--- a/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
@@ -10,6 +10,7 @@ const storeState = vi.hoisted(
     agentStatusByPaneKey: Record<string, unknown>
     clearTabLaunchAgent: ReturnType<typeof vi.fn>
     ptyIdsByTabId: Record<string, string[]>
+    retainedAgentsByPaneKey: Record<string, unknown>
     renamingTabId: string | null
     keybindings: Record<string, unknown>
     repos: unknown[]
@@ -21,6 +22,7 @@ const storeState = vi.hoisted(
     agentStatusByPaneKey: {},
     clearTabLaunchAgent: vi.fn(),
     ptyIdsByTabId: {} as Record<string, string[]>,
+    retainedAgentsByPaneKey: {},
     renamingTabId: null as string | null,
     keybindings: {},
     repos: [],

--- a/src/renderer/src/lib/tab-agent.test.ts
+++ b/src/renderer/src/lib/tab-agent.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from 'vitest'
 import {
   resolveFocusedCompletedTabAgent,
+  resolveFocusedRetainedTabAgent,
   resolveFocusedTabAgent,
   resolveSiblingCompletedTabAgent,
+  resolveSiblingRetainedTabAgent,
   resolveSiblingTabAgent
 } from './tab-agent'
 import type { AgentStatusEntry, AgentType } from '../../../shared/agent-status-types'
-import type { TerminalLayoutSnapshot, TuiAgent } from '../../../shared/types'
+import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../shared/types'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 
 // Composed exactly the way useTabAgent layers the resolvers: focused pane
 // first, then any sibling agent pane in the tab.
@@ -35,6 +38,27 @@ function entry(paneKey: string, agentType: AgentType | undefined): AgentStatusEn
 
 function layout(activeLeafId: string | null): TerminalLayoutSnapshot {
   return { root: null, activeLeafId, expandedLeafId: null }
+}
+
+function retainedEntry(paneKey: string, agentType: AgentType): RetainedAgentEntry {
+  const tabId = paneKey.slice(0, paneKey.indexOf(':'))
+  const tab: TerminalTab = {
+    id: tabId,
+    ptyId: null,
+    worktreeId: 'wt-1',
+    title: 'Terminal 1',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+  return {
+    entry: { ...entry(paneKey, agentType), state: 'done' },
+    worktreeId: tab.worktreeId,
+    tab,
+    agentType,
+    startedAt: 0
+  }
 }
 
 describe('resolveTabAgent', () => {
@@ -122,6 +146,34 @@ describe('resolveTabAgent', () => {
 
     expect(resolveFocusedCompletedTabAgent(map, layout(LEAF_A), 'tab-1')).toBe('claude')
     expect(resolveSiblingCompletedTabAgent(map, layout(LEAF_A), 'tab-1')).toBe('codex')
+  })
+
+  it('resolves retained completion identity for the focused pane and siblings separately', () => {
+    const retained = {
+      [`tab-1:${LEAF_A}`]: retainedEntry(`tab-1:${LEAF_A}`, 'codex'),
+      [`tab-1:${LEAF_B}`]: retainedEntry(`tab-1:${LEAF_B}`, 'claude')
+    }
+
+    expect(resolveFocusedRetainedTabAgent(retained, layout(LEAF_A), 'tab-1')).toBe('codex')
+    expect(resolveSiblingRetainedTabAgent(retained, layout(LEAF_A), 'tab-1')).toBe('claude')
+  })
+
+  it('treats a same-tab retained completion as focused while layout is unavailable', () => {
+    const retained = {
+      [`tab-1:${LEAF_A}`]: retainedEntry(`tab-1:${LEAF_A}`, 'codex')
+    }
+
+    expect(resolveFocusedRetainedTabAgent(retained, undefined, 'tab-1')).toBe('codex')
+    expect(resolveSiblingRetainedTabAgent(retained, undefined, 'tab-1')).toBeNull()
+  })
+
+  it('does not leak retained identity from another tab', () => {
+    const retained = {
+      [`tab-2:${LEAF_A}`]: retainedEntry(`tab-2:${LEAF_A}`, 'codex')
+    }
+
+    expect(resolveFocusedRetainedTabAgent(retained, layout(LEAF_A), 'tab-1')).toBeNull()
+    expect(resolveSiblingRetainedTabAgent(retained, layout(LEAF_A), 'tab-1')).toBeNull()
   })
 
   it('keeps the terminal glyph for an agent Orca has no icon for', () => {

--- a/src/renderer/src/lib/tab-agent.ts
+++ b/src/renderer/src/lib/tab-agent.ts
@@ -1,6 +1,7 @@
 import type { AgentStatusEntry } from '../../../shared/agent-status-types'
 import type { TerminalLayoutSnapshot, TuiAgent } from '../../../shared/types'
 import { isTerminalLeafId, makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { agentTypeToIconAgent } from './agent-status'
 
 /**
@@ -109,4 +110,50 @@ function completedAgentFromStatusEntry(entry: AgentStatusEntry | undefined): Tui
     return null
   }
   return agentTypeToIconAgent(entry.agentType)
+}
+
+export function resolveFocusedRetainedTabAgent(
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>,
+  layout: TerminalLayoutSnapshot | undefined,
+  tabId: string
+): TuiAgent | null {
+  const activeLeafId = layout?.activeLeafId
+  if (activeLeafId && isTerminalLeafId(activeLeafId)) {
+    return agentFromRetainedEntry(retainedAgentsByPaneKey[makePaneKey(tabId, activeLeafId)])
+  }
+  return resolveAnyRetainedTabAgent(retainedAgentsByPaneKey, tabId)
+}
+
+export function resolveSiblingRetainedTabAgent(
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>,
+  layout: TerminalLayoutSnapshot | undefined,
+  tabId: string
+): TuiAgent | null {
+  const activeLeafId =
+    layout?.activeLeafId && isTerminalLeafId(layout.activeLeafId) ? layout.activeLeafId : null
+  if (!activeLeafId) {
+    return null
+  }
+  return resolveAnyRetainedTabAgent(retainedAgentsByPaneKey, tabId, activeLeafId)
+}
+
+function resolveAnyRetainedTabAgent(
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>,
+  tabId: string,
+  excludedLeafId?: string
+): TuiAgent | null {
+  for (const [paneKey, retained] of Object.entries(retainedAgentsByPaneKey)) {
+    const parsedPaneKey = parsePaneKey(paneKey)
+    if (parsedPaneKey?.tabId === tabId && parsedPaneKey.leafId !== excludedLeafId) {
+      const agent = agentFromRetainedEntry(retained)
+      if (agent) {
+        return agent
+      }
+    }
+  }
+  return null
+}
+
+function agentFromRetainedEntry(entry: RetainedAgentEntry | undefined): TuiAgent | null {
+  return agentTypeToIconAgent(entry?.agentType)
 }

--- a/src/renderer/src/lib/use-tab-agent-retained-identity.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-retained-identity.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { AgentStatusEntry, AgentType } from '../../../shared/agent-status-types'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab, TuiAgent } from '../../../shared/types'
+import { useTabAgent } from './use-tab-agent'
+
+const initialAppState = useAppStore.getInitialState()
+const FOCUSED_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const SIBLING_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const TAB_ID = 'tab-1'
+const WORKTREE_ID = 'wt-1'
+let latestAgent: TuiAgent | null | undefined
+let root: Root | null = null
+
+const baseTab: TerminalTab = {
+  id: TAB_ID,
+  ptyId: 'pty-focused',
+  worktreeId: WORKTREE_ID,
+  title: 'Terminal 1',
+  customTitle: null,
+  color: null,
+  sortOrder: 0,
+  createdAt: 1,
+  launchAgent: 'claude'
+}
+
+function HookProbe({ tab }: { tab: TerminalTab }): null {
+  latestAgent = useTabAgent(tab)
+  return null
+}
+
+function statusEntry(paneKey: string, agentType: AgentType, state: AgentStatusEntry['state']) {
+  return {
+    paneKey,
+    agentType,
+    state,
+    prompt: '',
+    updatedAt: 1,
+    stateStartedAt: 1,
+    stateHistory: []
+  } satisfies AgentStatusEntry
+}
+
+function retainedEntry(paneKey: string, agentType: AgentType): RetainedAgentEntry {
+  return {
+    entry: statusEntry(paneKey, agentType, 'done'),
+    worktreeId: WORKTREE_ID,
+    tab: baseTab,
+    agentType,
+    startedAt: 1
+  }
+}
+
+function layout(): TerminalLayoutSnapshot {
+  return {
+    root: null,
+    activeLeafId: FOCUSED_LEAF_ID,
+    expandedLeafId: null,
+    ptyIdsByLeafId: {
+      [FOCUSED_LEAF_ID]: 'pty-focused',
+      [SIBLING_LEAF_ID]: 'pty-sibling'
+    }
+  }
+}
+
+async function renderProbe(tab: TerminalTab = baseTab): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(createElement(HookProbe, { tab }))
+    await Promise.resolve()
+  })
+}
+
+describe('useTabAgent retained completion identity', () => {
+  beforeEach(() => {
+    latestAgent = undefined
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({
+      ptyIdsByTabId: { [TAB_ID]: ['pty-focused', 'pty-sibling'] },
+      terminalLayoutsByTabId: { [TAB_ID]: layout() },
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {},
+      clearTabLaunchAgent: vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+      root = null
+    }
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+  })
+
+  it('uses focused retained Codex identity over stale Claude launch metadata', async () => {
+    const paneKey = makePaneKey(TAB_ID, FOCUSED_LEAF_ID)
+    useAppStore.setState({
+      retainedAgentsByPaneKey: { [paneKey]: retainedEntry(paneKey, 'codex') }
+    })
+
+    await renderProbe()
+
+    expect(latestAgent).toBe('codex')
+  })
+
+  it('keeps a live focused hook ahead of retained identity', async () => {
+    const paneKey = makePaneKey(TAB_ID, FOCUSED_LEAF_ID)
+    useAppStore.setState({
+      agentStatusByPaneKey: {
+        [paneKey]: statusEntry(paneKey, 'gemini', 'working')
+      },
+      retainedAgentsByPaneKey: { [paneKey]: retainedEntry(paneKey, 'codex') }
+    })
+
+    await renderProbe()
+
+    expect(latestAgent).toBe('gemini')
+  })
+
+  it('lets an explicit cross-agent title reclaim a retained idle pane', async () => {
+    const paneKey = makePaneKey(TAB_ID, FOCUSED_LEAF_ID)
+    useAppStore.setState({
+      retainedAgentsByPaneKey: { [paneKey]: retainedEntry(paneKey, 'codex') }
+    })
+
+    await renderProbe({ ...baseTab, launchAgent: 'codex', title: '✳ Claude Code' })
+
+    expect(latestAgent).toBe('claude')
+  })
+
+  it('keeps focused launch metadata ahead of sibling retained identity', async () => {
+    const paneKey = makePaneKey(TAB_ID, SIBLING_LEAF_ID)
+    useAppStore.setState({
+      retainedAgentsByPaneKey: { [paneKey]: retainedEntry(paneKey, 'codex') }
+    })
+
+    await renderProbe()
+
+    expect(latestAgent).toBe('claude')
+  })
+})

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -6,8 +6,10 @@ import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
 import {
   resolveFocusedCompletedTabAgent,
+  resolveFocusedRetainedTabAgent,
   resolveFocusedTabAgent,
   resolveSiblingCompletedTabAgent,
+  resolveSiblingRetainedTabAgent,
   resolveSiblingTabAgent
 } from './tab-agent'
 import { resolveExplicitTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
@@ -167,10 +169,10 @@ export function resolveTabAgentFromSignals(args: {
  * 1. Live focused hook — ground truth while the agent works; never title-overridden.
  * 2. Process identity — recognized foreground process (local only); re-owned within its title-identity group so OMP's nested `pi` (shell → omp → pi) can't flip the icon.
  * 3. Title — only a reuse override or legacy standalone identity; native OpenCode titles cannot displace durable ownership.
- * 4. Idle focused identity — the pane's own completed hook; suppressed locally once OSC 133;D proves exit.
+ * 4. Idle focused identity — the pane's completed hook or sidebar-retained completion; suppressed locally once OSC 133;D proves exit.
  * 5. Sleeping session identity — current provider-session ownership.
  * 6. launchAgent — bootstrap before any hook/process signal; cleared once exit evidence shows it left.
- * 7. Sibling-pane identity (live, then idle) — split-tab fallback.
+ * 7. Sibling-pane identity (live, then completed/retained) — split-tab fallback.
  */
 export function useTabAgent(tab: TerminalTab): TuiAgent | null {
   const focusedHookAgent = useAppStore((s) =>
@@ -179,19 +181,31 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
   const siblingHookAgent = useAppStore((s) =>
     resolveSiblingTabAgent(s.agentStatusByPaneKey, s.terminalLayoutsByTabId[tab.id], tab.id)
   )
-  const focusedCompletedHookAgent = useAppStore((s) =>
-    resolveFocusedCompletedTabAgent(
-      s.agentStatusByPaneKey,
-      s.terminalLayoutsByTabId[tab.id],
-      tab.id
-    )
+  const focusedCompletedHookAgent = useAppStore(
+    (s) =>
+      resolveFocusedCompletedTabAgent(
+        s.agentStatusByPaneKey,
+        s.terminalLayoutsByTabId[tab.id],
+        tab.id
+      ) ??
+      resolveFocusedRetainedTabAgent(
+        s.retainedAgentsByPaneKey,
+        s.terminalLayoutsByTabId[tab.id],
+        tab.id
+      )
   )
-  const siblingCompletedHookAgent = useAppStore((s) =>
-    resolveSiblingCompletedTabAgent(
-      s.agentStatusByPaneKey,
-      s.terminalLayoutsByTabId[tab.id],
-      tab.id
-    )
+  const siblingCompletedHookAgent = useAppStore(
+    (s) =>
+      resolveSiblingCompletedTabAgent(
+        s.agentStatusByPaneKey,
+        s.terminalLayoutsByTabId[tab.id],
+        tab.id
+      ) ??
+      resolveSiblingRetainedTabAgent(
+        s.retainedAgentsByPaneKey,
+        s.terminalLayoutsByTabId[tab.id],
+        tab.id
+      )
   )
   const hasCompletedHook = focusedCompletedHookAgent !== null
   const clearTabLaunchAgent = useAppStore((s) => s.clearTabLaunchAgent)


### PR DESCRIPTION
## Summary

- Keep terminal tab icons aligned with sidebar agent rows after a completed agent leaves live hook status.
- Resolve retained completion identity by the focused stable pane ID before falling back to stale launch metadata.
- Preserve live hook, process, title-reuse, sleeping-session, split-pane, remote, and Pi/OMP ownership precedence.

The bug was reproduced in Electron by creating a Claude-default worktree, interrupting Claude, starting Codex, and completing a turn. The deterministic failing state had no live/process/sleeping identity, stale `launchAgent: "claude"`, and the sidebar-retained pane completion identified as Codex. This is the retained-row gap left between the unified pipeline in #7059 and completed identity in #7860; the fix extends that pipeline instead of adding another detector.

## Screenshots

Before — the tab falls back to Claude while the retained sidebar row identifies Codex:

![Before: Claude tab icon and Codex sidebar row](https://github.com/user-attachments/assets/7275794d-53b6-4424-b793-11c6f2630c22)

After — the same backing state renders Codex in both places:

![After: Codex tab icon and Codex sidebar row](https://github.com/user-attachments/assets/cd7aa16c-a8f0-4848-a87e-ba90a7982918)

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- 8 tab-agent test files / 106 tests passed, covering retained identity, live hook priority, process signals, title reuse, sleeping sessions, Pi/OMP, native OpenCode titles, split panes, missing layout, and tab isolation.
- Type-aware Oxlint, formatting, reliability gates, max-lines ratchet, and diff checks passed.
- Electron DOM verified `data-agent-icon="codex"` with stale Claude launch metadata, null live/process/sleeping identity, and retained Codex completion.
- `check:code-quality:changed` could not parse pnpm's Node-24 engine warning under local Node 26; its direct strict and type-aware Oxlint scans passed.

## AI Review Report

Reviewed the change against the prior tab-identity contracts from #5860, #6543, #7059, #7755, #7860, #9077, and #11382. The main risks were stale retained state overriding a fresh live run, sibling completion hijacking a focused pane, title-based pane reuse regressing, and Pi/OMP or native OpenCode ownership changing. Regression tests and the existing focused suites cover each boundary.

Cross-platform review found no platform-specific behavior: this is renderer store resolution keyed by stable pane IDs. It adds no shortcuts, labels, paths, shell commands, native modules, Git behavior, or Electron platform branches, and applies equally to macOS, Linux, Windows, SSH, and folder workspaces.

## Security Audit

No new external input, command execution, path handling, authentication, secrets, dependencies, persistence, network access, or IPC surface. The change reads an existing renderer-owned retained-status map and converts its existing agent type to an icon identity.

## Notes

Retained identity is treated as completed pane evidence. It beats stale launch fallback for the focused pane, but remains below live hooks, process identity, and valid title-based pane reuse; sibling retained identity remains below focused launch metadata.
