### PR TITLE
fix(daemon): split router subscription fanout

### DIFF
--- a/src/main/daemon/daemon-pty-adapter-subscription-fanout.ts
+++ b/src/main/daemon/daemon-pty-adapter-subscription-fanout.ts
@@ -1,0 +1,87 @@
+import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { PtyBackgroundStreamEvent } from '../providers/types'
+import { combineUnsubscribes } from './combine-unsubscribes'
+import type { DaemonPtyAdapter } from './daemon-pty-adapter'
+
+type DataPayload = {
+  id: string
+  data: string
+  sequenceChars?: number
+  transformed?: boolean
+  seq?: number
+}
+
+type ExitPayload = {
+  id: string
+  code: number
+  incarnationId?: PtyIncarnationId
+}
+
+export class DaemonPtyAdapterSubscriptionFanout {
+  private unsubscribers: (() => void)[] = []
+  private dataListeners: ((payload: DataPayload) => void)[] = []
+  private exitListeners: ((payload: ExitPayload) => void)[] = []
+
+  constructor(
+    private readonly adapters: readonly DaemonPtyAdapter[],
+    onAdapterExit: (id: string) => void
+  ) {
+    for (const adapter of adapters) {
+      this.unsubscribers.push(
+        adapter.onData((payload) => {
+          for (const listener of this.dataListeners) {
+            listener(payload)
+          }
+        }),
+        adapter.onExit((payload) => {
+          onAdapterExit(payload.id)
+          for (const listener of this.exitListeners) {
+            listener(payload)
+          }
+        })
+      )
+    }
+  }
+
+  onData(callback: (payload: DataPayload) => void): () => void {
+    this.dataListeners.push(callback)
+    return () => {
+      const index = this.dataListeners.indexOf(callback)
+      if (index !== -1) {
+        this.dataListeners.splice(index, 1)
+      }
+    }
+  }
+
+  onBackgroundStreamEvent(callback: (payload: PtyBackgroundStreamEvent) => void): () => void {
+    return combineUnsubscribes(
+      this.adapters.map((adapter) => adapter.onBackgroundStreamEvent(callback))
+    )
+  }
+
+  // Why: main subscribes on the routed provider, so without this the dead-endpoint
+  // fan-out never reaches the renderer and only the written pane recovers (STA-2373).
+  onWriteUnavailable(callback: (payload: { id: string }) => void): () => void {
+    return combineUnsubscribes(this.adapters.map((adapter) => adapter.onWriteUnavailable(callback)))
+  }
+
+  onReplay(_callback: (payload: { id: string; data: string }) => void): () => void {
+    return () => {}
+  }
+
+  onExit(callback: (payload: ExitPayload) => void): () => void {
+    this.exitListeners.push(callback)
+    return () => {
+      const index = this.exitListeners.indexOf(callback)
+      if (index !== -1) {
+        this.exitListeners.splice(index, 1)
+      }
+    }
+  }
+
+  dispose(): void {
+    for (const unsubscribe of this.unsubscribers.splice(0)) {
+      unsubscribe()
+    }
+  }
+}

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -1,5 +1,5 @@
 import type { DaemonPtyAdapter } from './daemon-pty-adapter'
-import { combineUnsubscribes } from './combine-unsubscribes'
+import { DaemonPtyAdapterSubscriptionFanout } from './daemon-pty-adapter-subscription-fanout'
 import type {
   IPtyProvider,
   PtyBackgroundStreamEvent,
@@ -17,39 +17,14 @@ export class DaemonPtyRouter implements IPtyProvider {
   private current: DaemonPtyAdapter
   private legacy: DaemonPtyAdapter[]
   private sessionAdapters = new Map<string, DaemonPtyAdapter>()
-  private unsubscribers: (() => void)[] = []
-  private dataListeners: ((payload: {
-    id: string
-    data: string
-    sequenceChars?: number
-    transformed?: boolean
-    seq?: number
-  }) => void)[] = []
-  private exitListeners: ((payload: {
-    id: string
-    code: number
-    incarnationId?: PtyIncarnationId
-  }) => void)[] = []
+  private readonly subscriptions: DaemonPtyAdapterSubscriptionFanout
 
   constructor(opts: { current: DaemonPtyAdapter; legacy: DaemonPtyAdapter[] }) {
     this.current = opts.current
     this.legacy = opts.legacy
-
-    for (const adapter of this.allAdapters()) {
-      this.unsubscribers.push(
-        adapter.onData((payload) => {
-          for (const listener of this.dataListeners) {
-            listener(payload)
-          }
-        }),
-        adapter.onExit((payload) => {
-          this.sessionAdapters.delete(payload.id)
-          for (const listener of this.exitListeners) {
-            listener(payload)
-          }
-        })
-      )
-    }
+    this.subscriptions = new DaemonPtyAdapterSubscriptionFanout(this.allAdapters(), (id) => {
+      this.sessionAdapters.delete(id)
+    })
   }
 
   async discoverLegacySessions(): Promise<void> {
@@ -240,43 +215,25 @@ export class DaemonPtyRouter implements IPtyProvider {
       seq?: number
     }) => void
   ): () => void {
-    this.dataListeners.push(callback)
-    return () => {
-      const idx = this.dataListeners.indexOf(callback)
-      if (idx !== -1) {
-        this.dataListeners.splice(idx, 1)
-      }
-    }
+    return this.subscriptions.onData(callback)
   }
 
   onBackgroundStreamEvent(callback: (payload: PtyBackgroundStreamEvent) => void): () => void {
-    return combineUnsubscribes(
-      this.allAdapters().map((adapter) => adapter.onBackgroundStreamEvent(callback))
-    )
+    return this.subscriptions.onBackgroundStreamEvent(callback)
   }
 
-  // Why: main subscribes on the routed provider, so without this the dead-endpoint
-  // fan-out never reaches the renderer and only the written pane recovers (STA-2373).
   onWriteUnavailable(callback: (payload: { id: string }) => void): () => void {
-    return combineUnsubscribes(
-      this.allAdapters().map((adapter) => adapter.onWriteUnavailable(callback))
-    )
+    return this.subscriptions.onWriteUnavailable(callback)
   }
 
-  onReplay(_callback: (payload: { id: string; data: string }) => void): () => void {
-    return () => {}
+  onReplay(callback: (payload: { id: string; data: string }) => void): () => void {
+    return this.subscriptions.onReplay(callback)
   }
 
   onExit(
     callback: (payload: { id: string; code: number; incarnationId?: PtyIncarnationId }) => void
   ): () => void {
-    this.exitListeners.push(callback)
-    return () => {
-      const idx = this.exitListeners.indexOf(callback)
-      if (idx !== -1) {
-        this.exitListeners.splice(idx, 1)
-      }
-    }
+    return this.subscriptions.onExit(callback)
   }
 
   ackColdRestore(sessionId: string): void {
@@ -314,9 +271,7 @@ export class DaemonPtyRouter implements IPtyProvider {
   }
 
   dispose(): void {
-    for (const unsubscribe of this.unsubscribers.splice(0)) {
-      unsubscribe()
-    }
+    this.subscriptions.dispose()
     for (const adapter of this.allAdapters()) {
       adapter.dispose()
     }
@@ -330,15 +285,11 @@ export class DaemonPtyRouter implements IPtyProvider {
   // Without this, each restart leaked a router instance pinned by the legacy
   // adapters' listener arrays (one pair per adapter per restart).
   disposeRouterOnly(): void {
-    for (const unsubscribe of this.unsubscribers.splice(0)) {
-      unsubscribe()
-    }
+    this.subscriptions.dispose()
   }
 
   async disconnectOnly(): Promise<void> {
-    for (const unsubscribe of this.unsubscribers.splice(0)) {
-      unsubscribe()
-    }
+    this.subscriptions.dispose()
     await Promise.all([...this.allAdapters()].map((adapter) => adapter.disconnectOnly()))
   }
 


### PR DESCRIPTION
## Description

Extract the daemon PTY adapter subscription fan-out into `DaemonPtyAdapterSubscriptionFanout`. The router still subscribes current-first followed by legacy adapters, delegates the same subscription APIs, drains every child disposer idempotently, and preserves all routing fallback behavior.

This reduces `daemon-pty-router.ts` from 304 oxlint-counted lines to 258 without adding a suppression or changing the max-lines cap. It unblocks static analysis for the other open release PRs whose verify gate currently fails only because main's static-analysis job is red.

## ELI5

The router had grown just past the repository's file-size rule, so every PR inherited a lint failure from main. This moves one self-contained job—forwarding terminal event subscriptions across daemon adapters—into its own named class without changing what the router does.

## Proof of fix

RED on fetched `origin/main`:

```text
$ pnpm exec oxlint src/main/daemon/daemon-pty-router.ts
src/main/daemon/daemon-pty-router.ts:381:2: error eslint(max-lines): File has too many lines (304). help: Maximum allowed is 300.
```

GREEN at `c57d3d16b6`:

```text
$ pnpm exec oxlint src/main/daemon/daemon-pty-router.ts
# 0 findings
```

The router is now 332 raw lines and 258 lines under oxlint's `skipBlankLines` / `skipComments` count, providing 42 lines of headroom.

```text
$ pnpm exec oxlint
# 0 findings
```

## Proof of no regression

```text
$ pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/
Test Files  77 passed | 2 skipped (79)
Tests       1164 passed | 5 skipped (1169)
```

```text
$ pnpm run typecheck
# config/tsconfig.node.json, config/tsconfig.tc.cli.json, and config/tsconfig.tc.web.json passed
```

```text
$ pnpm run check:max-lines-ratchet
max-lines ratchet OK — 354 grandfathered suppression(s), no new bypasses.
```

No UI change; screenshots are not applicable.

Made with [Orca](https://github.com/stablyai/orca) 🐋
