### PR TITLE
fix(browser): keep host awake only while screencast streams are live

### DIFF
--- a/src/main/browser-screencast-awake-service-platform-assertions.test.ts
+++ b/src/main/browser-screencast-awake-service-platform-assertions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BrowserScreencastAwakeService } from './browser-screencast-awake-service'
+
+vi.mock('electron', () => ({
+  powerMonitor: {
+    on: vi.fn(),
+    off: vi.fn()
+  },
+  powerSaveBlocker: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    isStarted: vi.fn()
+  }
+}))
+
+function createBlocker() {
+  const startedIds = new Set<number>()
+  let nextId = 1
+  return {
+    start: vi.fn(() => {
+      const id = nextId++
+      startedIds.add(id)
+      return id
+    }),
+    stop: vi.fn((id: number) => {
+      startedIds.delete(id)
+    }),
+    isStarted: vi.fn((id: number) => startedIds.has(id))
+  }
+}
+
+function createPlatformAssertion() {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+function createService(
+  blocker = createBlocker(),
+  macosAssertion = createPlatformAssertion(),
+  linuxAssertion = createPlatformAssertion()
+): BrowserScreencastAwakeService {
+  return new BrowserScreencastAwakeService({
+    blocker,
+    linuxAssertion,
+    macosAssertion,
+    powerMonitor: null,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn()
+    }
+  })
+}
+
+describe('BrowserScreencastAwakeService platform assertions', () => {
+  it('keeps Electron blocker active when macOS assertion start fails', () => {
+    const blocker = createBlocker()
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    macosAssertion.start.mockImplementation(() => {
+      throw new Error('caffeinate failed')
+    })
+    const service = createService(blocker, macosAssertion, linuxAssertion)
+
+    service.acquire('stream-1')
+    service.release('stream-1')
+
+    expect(blocker.start).toHaveBeenCalledWith('prevent-display-sleep')
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(macosAssertion.stop).toHaveBeenCalled()
+    expect(linuxAssertion.start).toHaveBeenCalledTimes(1)
+    expect(linuxAssertion.stop).toHaveBeenCalled()
+  })
+
+  it('keeps Electron blocker active when Linux assertion start fails', () => {
+    const blocker = createBlocker()
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    linuxAssertion.start.mockImplementation(() => {
+      throw new Error('systemd-inhibit failed')
+    })
+    const service = createService(blocker, macosAssertion, linuxAssertion)
+
+    service.acquire('stream-1')
+    service.release('stream-1')
+
+    expect(blocker.start).toHaveBeenCalledWith('prevent-display-sleep')
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(macosAssertion.start).toHaveBeenCalledTimes(1)
+    expect(macosAssertion.stop).toHaveBeenCalled()
+    expect(linuxAssertion.stop).toHaveBeenCalled()
+  })
+
+  it('starts platform assertions when Electron blocker start fails', () => {
+    const blocker = createBlocker()
+    blocker.start.mockImplementation(() => {
+      throw new Error('electron failed')
+    })
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    const service = createService(blocker, macosAssertion, linuxAssertion)
+
+    service.acquire('stream-1')
+    service.release('stream-1')
+
+    expect(macosAssertion.start).toHaveBeenCalledTimes(1)
+    expect(macosAssertion.stop).toHaveBeenCalled()
+    expect(linuxAssertion.start).toHaveBeenCalledTimes(1)
+    expect(linuxAssertion.stop).toHaveBeenCalled()
+    expect(blocker.stop).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/browser-screencast-awake-service.test.ts
+++ b/src/main/browser-screencast-awake-service.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { BrowserScreencastAwakeService } from './browser-screencast-awake-service'
+import {
+  BrowserScreencastAwakeService,
+  BROWSER_SCREENCAST_AWAKE_TOKEN_STALE_AFTER_MS
+} from './browser-screencast-awake-service'
 
 vi.mock('electron', () => ({
   powerMonitor: {
@@ -56,15 +59,19 @@ function createPowerMonitor() {
 }
 
 function createService(
+  now: () => number,
   blocker = createBlocker(),
   macosAssertion = createPlatformAssertion(),
   linuxAssertion = createPlatformAssertion(),
-  powerMonitor: ReturnType<typeof createPowerMonitor> | null = null
+  powerMonitor: ReturnType<typeof createPowerMonitor> | null = null,
+  getLiveTokens?: () => Iterable<string>
 ): BrowserScreencastAwakeService {
   return new BrowserScreencastAwakeService({
     blocker,
+    getLiveTokens,
     linuxAssertion,
     macosAssertion,
+    now,
     powerMonitor,
     logger: {
       debug: vi.fn(),
@@ -80,7 +87,7 @@ describe('BrowserScreencastAwakeService', () => {
 
   it('does not start until a screencast token is acquired', () => {
     const blocker = createBlocker()
-    createService(blocker)
+    createService(() => 1_000, blocker)
 
     expect(blocker.start).not.toHaveBeenCalled()
   })
@@ -89,7 +96,7 @@ describe('BrowserScreencastAwakeService', () => {
     const blocker = createBlocker()
     const macosAssertion = createPlatformAssertion()
     const linuxAssertion = createPlatformAssertion()
-    const service = createService(blocker, macosAssertion, linuxAssertion)
+    const service = createService(() => 1_000, blocker, macosAssertion, linuxAssertion)
 
     service.acquire('stream-1')
 
@@ -104,7 +111,7 @@ describe('BrowserScreencastAwakeService', () => {
     const blocker = createBlocker()
     const macosAssertion = createPlatformAssertion()
     const linuxAssertion = createPlatformAssertion()
-    const service = createService(blocker, macosAssertion, linuxAssertion)
+    const service = createService(() => 1_000, blocker, macosAssertion, linuxAssertion)
 
     service.acquire('stream-1')
     service.acquire('stream-2')
@@ -122,12 +129,12 @@ describe('BrowserScreencastAwakeService', () => {
     expect(service.getActiveCount()).toBe(0)
   })
 
-  it('ignores duplicate acquire and unknown release', () => {
+  it('ignores empty acquire and unknown release', () => {
     const blocker = createBlocker()
-    const service = createService(blocker)
+    const service = createService(() => 1_000, blocker)
 
     service.acquire('stream-1')
-    service.acquire('stream-1')
+    service.acquire('')
     service.release('missing')
 
     expect(blocker.start).toHaveBeenCalledTimes(1)
@@ -139,6 +146,7 @@ describe('BrowserScreencastAwakeService', () => {
     const blocker = createBlocker()
     const powerMonitor = createPowerMonitor()
     const service = createService(
+      () => 1_000,
       blocker,
       createPlatformAssertion(),
       createPlatformAssertion(),
@@ -155,11 +163,69 @@ describe('BrowserScreencastAwakeService', () => {
     expect(blocker.start).toHaveBeenLastCalledWith('prevent-display-sleep')
   })
 
+  it('stops the blocker after the agent-awake stale window without a live-token renew', () => {
+    vi.useFakeTimers()
+    const blocker = createBlocker()
+    let now = 1_000
+    const service = createService(() => now, blocker)
+
+    service.acquire('stream-1')
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+
+    now = 1_000 + BROWSER_SCREENCAST_AWAKE_TOKEN_STALE_AFTER_MS + 1
+    vi.advanceTimersByTime(BROWSER_SCREENCAST_AWAKE_TOKEN_STALE_AFTER_MS + 1)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(service.getActiveCount()).toBe(0)
+  })
+
+  it('renews live tokens from the authoritative source so long sessions stay awake', () => {
+    vi.useFakeTimers()
+    const blocker = createBlocker()
+    let now = 1_000
+    const live = new Set<string>(['stream-1'])
+    const service = createService(
+      () => now,
+      blocker,
+      createPlatformAssertion(),
+      createPlatformAssertion(),
+      null,
+      () => live
+    )
+
+    service.acquire('stream-1')
+    now = 1_000 + BROWSER_SCREENCAST_AWAKE_TOKEN_STALE_AFTER_MS + 1
+    vi.advanceTimersByTime(BROWSER_SCREENCAST_AWAKE_TOKEN_STALE_AFTER_MS + 1)
+
+    expect(blocker.stop).not.toHaveBeenCalled()
+    expect(service.getActiveCount()).toBe(1)
+  })
+
+  it('drops leaked tokens that the live source no longer reports', () => {
+    const blocker = createBlocker()
+    const live = new Set<string>(['stream-1'])
+    const service = createService(
+      () => 1_000,
+      blocker,
+      createPlatformAssertion(),
+      createPlatformAssertion(),
+      null,
+      () => live
+    )
+
+    service.acquire('stream-1')
+    live.delete('stream-1')
+    service.setLiveTokenSource(() => live)
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(service.getActiveCount()).toBe(0)
+  })
+
   it('dispose clears tokens and stops assertions', () => {
     const blocker = createBlocker()
     const macosAssertion = createPlatformAssertion()
     const linuxAssertion = createPlatformAssertion()
-    const service = createService(blocker, macosAssertion, linuxAssertion)
+    const service = createService(() => 1_000, blocker, macosAssertion, linuxAssertion)
 
     service.acquire('stream-1')
     service.dispose()

--- a/src/main/browser-screencast-awake-service.test.ts
+++ b/src/main/browser-screencast-awake-service.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BrowserScreencastAwakeService } from './browser-screencast-awake-service'
+
+vi.mock('electron', () => ({
+  powerMonitor: {
+    on: vi.fn(),
+    off: vi.fn()
+  },
+  powerSaveBlocker: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    isStarted: vi.fn()
+  }
+}))
+
+function createBlocker() {
+  const startedIds = new Set<number>()
+  let nextId = 1
+  return {
+    start: vi.fn(() => {
+      const id = nextId++
+      startedIds.add(id)
+      return id
+    }),
+    stop: vi.fn((id: number) => {
+      startedIds.delete(id)
+    }),
+    isStarted: vi.fn((id: number) => startedIds.has(id)),
+    startedIds
+  }
+}
+
+function createPlatformAssertion() {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+function createPowerMonitor() {
+  const listeners = new Set<() => void>()
+  return {
+    on: vi.fn((_event: 'resume', listener: () => void) => {
+      listeners.add(listener)
+    }),
+    off: vi.fn((_event: 'resume', listener: () => void) => {
+      listeners.delete(listener)
+    }),
+    emitResume: () => {
+      for (const listener of listeners) {
+        listener()
+      }
+    }
+  }
+}
+
+function createService(
+  blocker = createBlocker(),
+  macosAssertion = createPlatformAssertion(),
+  linuxAssertion = createPlatformAssertion(),
+  powerMonitor: ReturnType<typeof createPowerMonitor> | null = null
+): BrowserScreencastAwakeService {
+  return new BrowserScreencastAwakeService({
+    blocker,
+    linuxAssertion,
+    macosAssertion,
+    powerMonitor,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn()
+    }
+  })
+}
+
+describe('BrowserScreencastAwakeService', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not start until a screencast token is acquired', () => {
+    const blocker = createBlocker()
+    createService(blocker)
+
+    expect(blocker.start).not.toHaveBeenCalled()
+  })
+
+  it('starts Electron and platform assertions on the first acquire', () => {
+    const blocker = createBlocker()
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    const service = createService(blocker, macosAssertion, linuxAssertion)
+
+    service.acquire('stream-1')
+
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+    expect(blocker.start).toHaveBeenCalledWith('prevent-display-sleep')
+    expect(macosAssertion.start).toHaveBeenCalledTimes(1)
+    expect(linuxAssertion.start).toHaveBeenCalledTimes(1)
+    expect(service.getActiveCount()).toBe(1)
+  })
+
+  it('keeps one blocker across overlapping acquires and releases on the last token', () => {
+    const blocker = createBlocker()
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    const service = createService(blocker, macosAssertion, linuxAssertion)
+
+    service.acquire('stream-1')
+    service.acquire('stream-2')
+    service.release('stream-1')
+
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+    expect(blocker.stop).not.toHaveBeenCalled()
+    expect(service.getActiveCount()).toBe(1)
+
+    service.release('stream-2')
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(macosAssertion.stop).toHaveBeenCalled()
+    expect(linuxAssertion.stop).toHaveBeenCalled()
+    expect(service.getActiveCount()).toBe(0)
+  })
+
+  it('ignores duplicate acquire and unknown release', () => {
+    const blocker = createBlocker()
+    const service = createService(blocker)
+
+    service.acquire('stream-1')
+    service.acquire('stream-1')
+    service.release('missing')
+
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+    expect(blocker.stop).not.toHaveBeenCalled()
+    expect(service.getActiveCount()).toBe(1)
+  })
+
+  it('restarts the blocker after power resume while streams are active', () => {
+    const blocker = createBlocker()
+    const powerMonitor = createPowerMonitor()
+    const service = createService(
+      blocker,
+      createPlatformAssertion(),
+      createPlatformAssertion(),
+      powerMonitor
+    )
+
+    service.acquire('stream-1')
+    blocker.startedIds.clear()
+    expect(blocker.isStarted(1)).toBe(false)
+
+    powerMonitor.emitResume()
+
+    expect(blocker.start).toHaveBeenCalledTimes(2)
+    expect(blocker.start).toHaveBeenLastCalledWith('prevent-display-sleep')
+  })
+
+  it('dispose clears tokens and stops assertions', () => {
+    const blocker = createBlocker()
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    const service = createService(blocker, macosAssertion, linuxAssertion)
+
+    service.acquire('stream-1')
+    service.dispose()
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(macosAssertion.dispose).toHaveBeenCalledTimes(1)
+    expect(linuxAssertion.dispose).toHaveBeenCalledTimes(1)
+    expect(service.getActiveCount()).toBe(0)
+  })
+})

--- a/src/main/browser-screencast-awake-service.ts
+++ b/src/main/browser-screencast-awake-service.ts
@@ -1,0 +1,220 @@
+import { powerMonitor, powerSaveBlocker } from 'electron'
+import { LinuxLidSleepAssertion } from './linux-lid-sleep-assertion'
+import { MacosSystemSleepAssertion } from './macos-system-sleep-assertion'
+
+type PowerSaveBlocker = {
+  start: (type: 'prevent-app-suspension' | 'prevent-display-sleep') => number
+  stop: (id: number) => void
+  isStarted: (id: number) => boolean
+}
+
+type PlatformAwakeAssertion = {
+  start: (reason: string) => void
+  stop: (reason: string) => void
+  dispose: () => void
+}
+
+type PowerMonitorEventSource = {
+  on: (event: 'resume', listener: () => void) => void
+  off: (event: 'resume', listener: () => void) => void
+}
+
+type Logger = Pick<Console, 'debug' | 'warn'>
+
+type BrowserScreencastAwakeServiceOptions = {
+  blocker?: PowerSaveBlocker
+  linuxAssertion?: PlatformAwakeAssertion
+  logger?: Logger
+  macosAssertion?: PlatformAwakeAssertion
+  powerMonitor?: PowerMonitorEventSource | null
+}
+
+/**
+ * Keeps the display/compositor awake while any browser.screencast stream is live.
+ *
+ * Why: mobile/remote browser panes consume CDP screencast frames from the host
+ * Chromium. Display sleep and occlusion park the compositor, so frames stop even
+ * though the main process, PTYs, and guest `setBackgroundThrottling(false)` stay
+ * healthy. Gate the same prevent-display-sleep path agents use on active
+ * screencast subscriptions so idle hosts still save power.
+ */
+export class BrowserScreencastAwakeService {
+  private readonly activeTokens = new Set<string>()
+  private blockerId: number | null = null
+  private readonly blocker: PowerSaveBlocker
+  private readonly linuxAssertion: PlatformAwakeAssertion
+  private readonly logger: Logger
+  private readonly macosAssertion: PlatformAwakeAssertion
+  private readonly unsubscribeResume: (() => void) | null
+
+  constructor(options: BrowserScreencastAwakeServiceOptions = {}) {
+    this.blocker = options.blocker ?? powerSaveBlocker
+    this.logger = options.logger ?? console
+    // Windows lid close is intentionally not modeled as an assertion here:
+    // keeping it awake requires mutating the user's global power plan.
+    this.linuxAssertion =
+      options.linuxAssertion ??
+      new LinuxLidSleepAssertion({
+        logger: this.logger,
+        onUnexpectedFailure: (reason) => this.refresh(reason)
+      })
+    this.macosAssertion =
+      options.macosAssertion ??
+      new MacosSystemSleepAssertion({
+        logger: this.logger,
+        onUnexpectedFailure: (reason) => this.refresh(reason)
+      })
+    const resumeSource = options.powerMonitor === undefined ? powerMonitor : options.powerMonitor
+    if (resumeSource) {
+      const onResume = () => this.refresh('power-resume')
+      resumeSource.on('resume', onResume)
+      this.unsubscribeResume = () => resumeSource.off('resume', onResume)
+    } else {
+      this.unsubscribeResume = null
+    }
+  }
+
+  acquire(token: string): void {
+    if (!token || this.activeTokens.has(token)) {
+      return
+    }
+    this.activeTokens.add(token)
+    this.refresh('screencast-acquire')
+  }
+
+  release(token: string): void {
+    if (!token || !this.activeTokens.delete(token)) {
+      return
+    }
+    this.refresh('screencast-release')
+  }
+
+  getActiveCount(): number {
+    return this.activeTokens.size
+  }
+
+  dispose(): void {
+    this.unsubscribeResume?.()
+    this.activeTokens.clear()
+    this.stopBlocker('dispose')
+    this.macosAssertion.dispose()
+    this.linuxAssertion.dispose()
+  }
+
+  private refresh(reason: string): void {
+    const activeCount = this.activeTokens.size
+    if (activeCount > 0) {
+      this.startBlocker(reason, activeCount)
+      this.startMacosAssertion(reason)
+      this.startLinuxAssertion(reason)
+    } else {
+      this.stopBlocker(reason, activeCount)
+      this.stopMacosAssertion(reason)
+      this.stopLinuxAssertion(reason)
+    }
+  }
+
+  private startBlocker(reason: string, activeCount: number): void {
+    if (this.blockerId !== null) {
+      if (this.reconcileBlocker('start-reconcile')) {
+        return
+      }
+    }
+    try {
+      const id = this.blocker.start('prevent-display-sleep')
+      this.blockerId = id
+      this.reconcileBlocker('post-start')
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to start blocker', {
+        reason,
+        activeCount,
+        error: err
+      })
+    }
+  }
+
+  private startMacosAssertion(reason: string): void {
+    try {
+      this.macosAssertion.start(reason)
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to start macOS system sleep assertion', {
+        reason,
+        error: err
+      })
+    }
+  }
+
+  private startLinuxAssertion(reason: string): void {
+    try {
+      this.linuxAssertion.start(reason)
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to start Linux lid sleep assertion', {
+        reason,
+        error: err
+      })
+    }
+  }
+
+  private stopMacosAssertion(reason: string): void {
+    try {
+      this.macosAssertion.stop(reason)
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to stop macOS system sleep assertion', {
+        reason,
+        error: err
+      })
+    }
+  }
+
+  private stopLinuxAssertion(reason: string): void {
+    try {
+      this.linuxAssertion.stop(reason)
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to stop Linux lid sleep assertion', {
+        reason,
+        error: err
+      })
+    }
+  }
+
+  private stopBlocker(reason: string, activeCount = 0): void {
+    if (this.blockerId === null) {
+      return
+    }
+    const id = this.blockerId
+    try {
+      this.blocker.stop(id)
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to stop blocker', {
+        reason,
+        activeCount,
+        blockerId: id,
+        error: err
+      })
+    }
+    this.reconcileBlocker('post-stop')
+  }
+
+  private reconcileBlocker(reason: string): boolean {
+    if (this.blockerId === null) {
+      return false
+    }
+    const id = this.blockerId
+    try {
+      const isStarted = this.blocker.isStarted(id)
+      if (!isStarted) {
+        this.blockerId = null
+      }
+      return isStarted
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to reconcile blocker', {
+        reason,
+        blockerId: id,
+        error: err
+      })
+      return true
+    }
+  }
+}
+
+export const browserScreencastAwakeService = new BrowserScreencastAwakeService()

--- a/src/main/browser-screencast-awake-service.ts
+++ b/src/main/browser-screencast-awake-service.ts
@@ -1,6 +1,9 @@
 import { LinuxLidSleepAssertion } from './linux-lid-sleep-assertion'
 import { MacosSystemSleepAssertion } from './macos-system-sleep-assertion'
 
+// Why: match AGENT_AWAKE_STATUS_STALE_AFTER_MS so abandoned power assertions cannot linger forever.
+export const BROWSER_SCREENCAST_AWAKE_TOKEN_STALE_AFTER_MS = 2 * 60 * 60 * 1000
+
 type PowerSaveBlocker = {
   start: (type: 'prevent-app-suspension' | 'prevent-display-sleep') => number
   stop: (id: number) => void
@@ -22,10 +25,13 @@ type Logger = Pick<Console, 'debug' | 'warn'>
 
 type BrowserScreencastAwakeServiceOptions = {
   blocker?: PowerSaveBlocker
+  getLiveTokens?: () => Iterable<string>
   linuxAssertion?: PlatformAwakeAssertion
   logger?: Logger
   macosAssertion?: PlatformAwakeAssertion
+  now?: () => number
   powerMonitor?: PowerMonitorEventSource | null
+  staleAfterMs?: number
 }
 
 type ElectronPowerApis = {
@@ -40,16 +46,23 @@ function loadElectronPowerApis(): ElectronPowerApis {
 
 /** Keeps display/compositor awake while browser.screencast streams need CDP frames. */
 export class BrowserScreencastAwakeService {
-  private readonly activeTokens = new Set<string>()
+  private readonly tokens = new Map<string, number>()
   private blockerId: number | null = null
+  private staleTimer: ReturnType<typeof setTimeout> | null = null
+  private getLiveTokens: (() => Iterable<string>) | null
   private readonly blocker: PowerSaveBlocker
   private readonly linuxAssertion: PlatformAwakeAssertion
   private readonly logger: Logger
   private readonly macosAssertion: PlatformAwakeAssertion
+  private readonly now: () => number
+  private readonly staleAfterMs: number
   private readonly unsubscribeResume: (() => void) | null
 
   constructor(options: BrowserScreencastAwakeServiceOptions = {}) {
     this.logger = options.logger ?? console
+    this.now = options.now ?? Date.now
+    this.staleAfterMs = options.staleAfterMs ?? BROWSER_SCREENCAST_AWAKE_TOKEN_STALE_AFTER_MS
+    this.getLiveTokens = options.getLiveTokens ?? null
     const electronApis =
       options.blocker !== undefined && options.powerMonitor !== undefined
         ? null
@@ -61,12 +74,14 @@ export class BrowserScreencastAwakeService {
       options.linuxAssertion ??
       new LinuxLidSleepAssertion({
         logger: this.logger,
+        now: this.now,
         onUnexpectedFailure: (reason) => this.refresh(reason)
       })
     this.macosAssertion =
       options.macosAssertion ??
       new MacosSystemSleepAssertion({
         logger: this.logger,
+        now: this.now,
         onUnexpectedFailure: (reason) => this.refresh(reason)
       })
     const resumeSource =
@@ -80,44 +95,136 @@ export class BrowserScreencastAwakeService {
     }
   }
 
+  // Why: RuntimeBrowserCommands owns live pages; sync drops leaks and renews long sessions.
+  setLiveTokenSource(getLiveTokens: (() => Iterable<string>) | null): void {
+    this.getLiveTokens = getLiveTokens
+    this.refresh('live-token-source-change')
+  }
+
   acquire(token: string): void {
-    if (!token || this.activeTokens.has(token)) {
+    if (!token) {
       return
     }
-    this.activeTokens.add(token)
+    this.tokens.set(token, this.now())
     this.refresh('screencast-acquire')
   }
 
   release(token: string): void {
-    if (!token || !this.activeTokens.delete(token)) {
+    if (!token || !this.tokens.delete(token)) {
       return
     }
     this.refresh('screencast-release')
   }
 
   getActiveCount(): number {
-    return this.activeTokens.size
+    return this.getEligibleTokenCount(this.now())
   }
 
   dispose(): void {
+    this.clearStaleTimer()
     this.unsubscribeResume?.()
-    this.activeTokens.clear()
+    this.getLiveTokens = null
+    this.tokens.clear()
     this.stopBlocker('dispose')
     this.macosAssertion.dispose()
     this.linuxAssertion.dispose()
   }
 
   private refresh(reason: string): void {
-    const activeCount = this.activeTokens.size
+    this.reconcileWithLiveSource()
+    this.scheduleStaleTimer()
+    const activeCount = this.getEligibleTokenCount(this.now())
     if (activeCount > 0) {
       this.startBlocker(reason, activeCount)
-      this.startMacosAssertion(reason)
-      this.startLinuxAssertion(reason)
+      this.runAssertion('start', this.macosAssertion, reason, 'macOS system sleep assertion')
+      this.runAssertion('start', this.linuxAssertion, reason, 'Linux lid sleep assertion')
     } else {
       this.stopBlocker(reason, activeCount)
-      this.stopMacosAssertion(reason)
-      this.stopLinuxAssertion(reason)
+      this.runAssertion('stop', this.macosAssertion, reason, 'macOS system sleep assertion')
+      this.runAssertion('stop', this.linuxAssertion, reason, 'Linux lid sleep assertion')
     }
+  }
+
+  private reconcileWithLiveSource(): void {
+    if (!this.getLiveTokens) {
+      return
+    }
+    const live = new Set<string>()
+    for (const token of this.getLiveTokens()) {
+      if (token) {
+        live.add(token)
+      }
+    }
+    for (const token of this.tokens.keys()) {
+      if (!live.has(token)) {
+        this.tokens.delete(token)
+      }
+    }
+    const now = this.now()
+    for (const token of live) {
+      this.tokens.set(token, now)
+    }
+  }
+
+  private getEligibleTokenCount(now: number): number {
+    let count = 0
+    for (const seenAt of this.tokens.values()) {
+      if (this.isWakeEligible(seenAt, now)) {
+        count += 1
+      }
+    }
+    return count
+  }
+
+  private isWakeEligible(seenAt: number, now: number): boolean {
+    return Number.isFinite(seenAt) && now - seenAt <= this.staleAfterMs
+  }
+
+  private scheduleStaleTimer(): void {
+    this.clearStaleTimer()
+    const now = this.now()
+    let earliestExpiry: number | null = null
+    for (const seenAt of this.tokens.values()) {
+      if (!Number.isFinite(seenAt)) {
+        continue
+      }
+      const expiry = seenAt + this.staleAfterMs
+      if (expiry <= now) {
+        continue
+      }
+      earliestExpiry = earliestExpiry === null ? expiry : Math.min(earliestExpiry, expiry)
+    }
+    // Why: with a live-token source, renewals keep timestamps fresh; still poll so a
+    // leaked token without a matching live page is pruned even when no expiry is due.
+    if (earliestExpiry === null && !(this.getLiveTokens && this.tokens.size > 0)) {
+      return
+    }
+    const delay = earliestExpiry === null ? this.staleAfterMs : Math.max(0, earliestExpiry - now)
+    this.staleTimer = setTimeout(() => {
+      this.staleTimer = null
+      this.pruneExpiredTokens()
+      this.refresh('stale-expiry')
+    }, delay)
+    if (typeof this.staleTimer.unref === 'function') {
+      this.staleTimer.unref()
+    }
+  }
+
+  private pruneExpiredTokens(): void {
+    const now = this.now()
+    for (const [token, seenAt] of this.tokens) {
+      if (!this.isWakeEligible(seenAt, now)) {
+        this.tokens.delete(token)
+      }
+    }
+  }
+
+  private clearStaleTimer(): void {
+    if (!this.staleTimer) {
+      return
+    }
+    clearTimeout(this.staleTimer)
+    this.staleTimer = null
   }
 
   private startBlocker(reason: string, activeCount: number): void {
@@ -139,44 +246,16 @@ export class BrowserScreencastAwakeService {
     }
   }
 
-  private startMacosAssertion(reason: string): void {
+  private runAssertion(
+    action: 'start' | 'stop',
+    assertion: PlatformAwakeAssertion,
+    reason: string,
+    label: string
+  ): void {
     try {
-      this.macosAssertion.start(reason)
+      assertion[action](reason)
     } catch (err) {
-      this.logger.warn('[browser-screencast-awake] failed to start macOS system sleep assertion', {
-        reason,
-        error: err
-      })
-    }
-  }
-
-  private startLinuxAssertion(reason: string): void {
-    try {
-      this.linuxAssertion.start(reason)
-    } catch (err) {
-      this.logger.warn('[browser-screencast-awake] failed to start Linux lid sleep assertion', {
-        reason,
-        error: err
-      })
-    }
-  }
-
-  private stopMacosAssertion(reason: string): void {
-    try {
-      this.macosAssertion.stop(reason)
-    } catch (err) {
-      this.logger.warn('[browser-screencast-awake] failed to stop macOS system sleep assertion', {
-        reason,
-        error: err
-      })
-    }
-  }
-
-  private stopLinuxAssertion(reason: string): void {
-    try {
-      this.linuxAssertion.stop(reason)
-    } catch (err) {
-      this.logger.warn('[browser-screencast-awake] failed to stop Linux lid sleep assertion', {
+      this.logger.warn(`[browser-screencast-awake] failed to ${action} ${label}`, {
         reason,
         error: err
       })

--- a/src/main/browser-screencast-awake-service.ts
+++ b/src/main/browser-screencast-awake-service.ts
@@ -33,22 +33,12 @@ type ElectronPowerApis = {
   powerSaveBlocker: PowerSaveBlocker
 }
 
-// Why: keep this module importable under incomplete `vi.mock('electron')` fixtures
-// used by orca-runtime tests. Resolve Electron power APIs only when constructing.
+// Why: lazy-resolve Electron so incomplete `vi.mock('electron')` fixtures still import this module.
 function loadElectronPowerApis(): ElectronPowerApis {
-  // Why: lazy CJS resolve avoids static electron named-import mock breakage in orca-runtime tests.
   return require('electron') as ElectronPowerApis
 }
 
-/**
- * Keeps the display/compositor awake while any browser.screencast stream is live.
- *
- * Why: mobile/remote browser panes consume CDP screencast frames from the host
- * Chromium. Display sleep and occlusion park the compositor, so frames stop even
- * though the main process, PTYs, and guest `setBackgroundThrottling(false)` stay
- * healthy. Gate the same prevent-display-sleep path agents use on active
- * screencast subscriptions so idle hosts still save power.
- */
+/** Keeps display/compositor awake while browser.screencast streams need CDP frames. */
 export class BrowserScreencastAwakeService {
   private readonly activeTokens = new Set<string>()
   private blockerId: number | null = null
@@ -198,8 +188,7 @@ export class BrowserScreencastAwakeService {
       return
     }
     const id = this.blockerId
-    // Why: clear before reconcile so a flaky isStarted() after a successful stop
-    // cannot strand a stale id and skip the next startBlocker.
+    // Why: clear before stop so a later flaky isStarted() cannot strand a stale id.
     this.blockerId = null
     try {
       this.blocker.stop(id)

--- a/src/main/browser-screencast-awake-service.ts
+++ b/src/main/browser-screencast-awake-service.ts
@@ -198,6 +198,9 @@ export class BrowserScreencastAwakeService {
       return
     }
     const id = this.blockerId
+    // Why: clear before reconcile so a flaky isStarted() after a successful stop
+    // cannot strand a stale id and skip the next startBlocker.
+    this.blockerId = null
     try {
       this.blocker.stop(id)
     } catch (err) {
@@ -208,7 +211,6 @@ export class BrowserScreencastAwakeService {
         error: err
       })
     }
-    this.reconcileBlocker('post-stop')
   }
 
   private reconcileBlocker(reason: string): boolean {

--- a/src/main/browser-screencast-awake-service.ts
+++ b/src/main/browser-screencast-awake-service.ts
@@ -1,4 +1,3 @@
-import { powerMonitor, powerSaveBlocker } from 'electron'
 import { LinuxLidSleepAssertion } from './linux-lid-sleep-assertion'
 import { MacosSystemSleepAssertion } from './macos-system-sleep-assertion'
 
@@ -29,6 +28,18 @@ type BrowserScreencastAwakeServiceOptions = {
   powerMonitor?: PowerMonitorEventSource | null
 }
 
+type ElectronPowerApis = {
+  powerMonitor: PowerMonitorEventSource
+  powerSaveBlocker: PowerSaveBlocker
+}
+
+// Why: keep this module importable under incomplete `vi.mock('electron')` fixtures
+// used by orca-runtime tests. Resolve Electron power APIs only when constructing.
+function loadElectronPowerApis(): ElectronPowerApis {
+  // Why: lazy CJS resolve avoids static electron named-import mock breakage in orca-runtime tests.
+  return require('electron') as ElectronPowerApis
+}
+
 /**
  * Keeps the display/compositor awake while any browser.screencast stream is live.
  *
@@ -48,8 +59,12 @@ export class BrowserScreencastAwakeService {
   private readonly unsubscribeResume: (() => void) | null
 
   constructor(options: BrowserScreencastAwakeServiceOptions = {}) {
-    this.blocker = options.blocker ?? powerSaveBlocker
     this.logger = options.logger ?? console
+    const electronApis =
+      options.blocker !== undefined && options.powerMonitor !== undefined
+        ? null
+        : loadElectronPowerApis()
+    this.blocker = options.blocker ?? electronApis!.powerSaveBlocker
     // Windows lid close is intentionally not modeled as an assertion here:
     // keeping it awake requires mutating the user's global power plan.
     this.linuxAssertion =
@@ -64,7 +79,8 @@ export class BrowserScreencastAwakeService {
         logger: this.logger,
         onUnexpectedFailure: (reason) => this.refresh(reason)
       })
-    const resumeSource = options.powerMonitor === undefined ? powerMonitor : options.powerMonitor
+    const resumeSource =
+      options.powerMonitor !== undefined ? options.powerMonitor : electronApis!.powerMonitor
     if (resumeSource) {
       const onResume = () => this.refresh('power-resume')
       resumeSource.on('resume', onResume)
@@ -217,4 +233,14 @@ export class BrowserScreencastAwakeService {
   }
 }
 
-export const browserScreencastAwakeService = new BrowserScreencastAwakeService()
+let sharedBrowserScreencastAwakeService: BrowserScreencastAwakeService | null = null
+
+export function getBrowserScreencastAwakeService(): BrowserScreencastAwakeService {
+  sharedBrowserScreencastAwakeService ??= new BrowserScreencastAwakeService()
+  return sharedBrowserScreencastAwakeService
+}
+
+export function disposeBrowserScreencastAwakeService(): void {
+  sharedBrowserScreencastAwakeService?.dispose()
+  sharedBrowserScreencastAwakeService = null
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -240,7 +240,7 @@ import { AutomationService } from './automations/service'
 import { createHeadlessAutomationOutputSnapshotBuffer } from './automations/headless-dispatch'
 import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headless-workspace-create'
 import { AgentAwakeService } from './agent-awake-service'
-import { browserScreencastAwakeService } from './browser-screencast-awake-service'
+import { disposeBrowserScreencastAwakeService } from './browser-screencast-awake-service'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { settleTeardownWithinDeadline } from './quit-teardown-deadline'
 import { PluginService } from './plugins/plugin-service'
@@ -2887,7 +2887,7 @@ app.on('before-quit', () => {
   unsubscribeAgentAwakeStatusChanges = null
   agentAwakeService?.dispose()
   agentAwakeService = null
-  browserScreencastAwakeService.dispose()
+  disposeBrowserScreencastAwakeService()
   // Why: defer PTY cleanup to will-quit so the renderer captures scrollback before PTY-exit events unmount TerminalPane (dropping its capture callbacks).
   rateLimits?.stop()
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -240,6 +240,7 @@ import { AutomationService } from './automations/service'
 import { createHeadlessAutomationOutputSnapshotBuffer } from './automations/headless-dispatch'
 import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headless-workspace-create'
 import { AgentAwakeService } from './agent-awake-service'
+import { browserScreencastAwakeService } from './browser-screencast-awake-service'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { settleTeardownWithinDeadline } from './quit-teardown-deadline'
 import { PluginService } from './plugins/plugin-service'
@@ -2886,6 +2887,7 @@ app.on('before-quit', () => {
   unsubscribeAgentAwakeStatusChanges = null
   agentAwakeService?.dispose()
   agentAwakeService = null
+  browserScreencastAwakeService.dispose()
   // Why: defer PTY cleanup to will-quit so the renderer captures scrollback before PTY-exit events unmount TerminalPane (dropping its capture callbacks).
   rateLimits?.stop()
 })

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -63,6 +63,7 @@ vi.mock('../browser-screencast-awake-service', () => ({
   getBrowserScreencastAwakeService: () => ({
     acquire: browserScreencastAwakeAcquireMock,
     release: browserScreencastAwakeReleaseMock,
+    setLiveTokenSource: vi.fn(),
     dispose: vi.fn(),
     getActiveCount: vi.fn(() => 0)
   }),

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -589,7 +589,7 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     )
 
     expect(browserScreencastAwakeAcquireMock).toHaveBeenCalledTimes(1)
-    expect(browserScreencastAwakeAcquireMock).toHaveBeenCalledWith('runtime-browser-screencast')
+    expect(browserScreencastAwakeAcquireMock).toHaveBeenCalledWith('browser-screencast:page-1')
     expect(setBackgroundThrottling).toHaveBeenCalledWith(false)
     expect(browserScreencastAwakeReleaseMock).not.toHaveBeenCalled()
 
@@ -597,7 +597,7 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     await session.session.done
 
     expect(browserScreencastAwakeReleaseMock).toHaveBeenCalledTimes(1)
-    expect(browserScreencastAwakeReleaseMock).toHaveBeenCalledWith('runtime-browser-screencast')
+    expect(browserScreencastAwakeReleaseMock).toHaveBeenCalledWith('browser-screencast:page-1')
     expect(setBackgroundThrottling).toHaveBeenLastCalledWith(true)
   })
 })

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -60,12 +60,13 @@ vi.mock('../browser/browser-screencast-stream', () => ({
 }))
 
 vi.mock('../browser-screencast-awake-service', () => ({
-  browserScreencastAwakeService: {
+  getBrowserScreencastAwakeService: () => ({
     acquire: browserScreencastAwakeAcquireMock,
     release: browserScreencastAwakeReleaseMock,
     dispose: vi.fn(),
     getActiveCount: vi.fn(() => 0)
-  }
+  }),
+  disposeBrowserScreencastAwakeService: vi.fn()
 }))
 
 vi.mock('../ipc/browser', () => ({

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -9,7 +9,9 @@ const {
   startBrowserScreencastMock,
   waitForTabRegistrationMock,
   waitForWorktreeTabRegistrationMock,
-  browserSessionRegistryMock
+  browserSessionRegistryMock,
+  browserScreencastAwakeAcquireMock,
+  browserScreencastAwakeReleaseMock
 } = vi.hoisted(() => ({
   ipcMainOnMock: vi.fn(),
   ipcMainRemoveListenerMock: vi.fn(),
@@ -17,6 +19,8 @@ const {
   startBrowserScreencastMock: vi.fn(),
   waitForTabRegistrationMock: vi.fn(),
   waitForWorktreeTabRegistrationMock: vi.fn(),
+  browserScreencastAwakeAcquireMock: vi.fn(),
+  browserScreencastAwakeReleaseMock: vi.fn(),
   browserSessionRegistryMock: {
     profiles: new Map([
       [
@@ -53,6 +57,15 @@ vi.mock('electron', () => ({
 
 vi.mock('../browser/browser-screencast-stream', () => ({
   startBrowserScreencast: startBrowserScreencastMock
+}))
+
+vi.mock('../browser-screencast-awake-service', () => ({
+  browserScreencastAwakeService: {
+    acquire: browserScreencastAwakeAcquireMock,
+    release: browserScreencastAwakeReleaseMock,
+    dispose: vi.fn(),
+    getActiveCount: vi.fn(() => 0)
+  }
 }))
 
 vi.mock('../ipc/browser', () => ({
@@ -112,6 +125,8 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     waitForTabRegistrationMock.mockResolvedValue(undefined)
     waitForWorktreeTabRegistrationMock.mockReset()
     waitForWorktreeTabRegistrationMock.mockResolvedValue(undefined)
+    browserScreencastAwakeAcquireMock.mockReset()
+    browserScreencastAwakeReleaseMock.mockReset()
     browserSessionRegistryMock.getDefaultProfile.mockReset()
     browserSessionRegistryMock.getDefaultProfile.mockImplementation(() =>
       browserSessionRegistryMock.profiles.get('default')
@@ -552,6 +567,38 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     await second.session.done
     expect(secondStop).toHaveBeenCalledTimes(1)
   }, 10_000)
+
+  it('keeps the host awake and unthrottles the main window only while a screencast is live', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    webContentsFromIdMock.mockReturnValue({ isDestroyed: () => false })
+    const done = deferred<void>()
+    const stop = vi.fn(() => done.resolve())
+    startBrowserScreencastMock.mockResolvedValue({ stop, done: done.promise })
+    const setBackgroundThrottling = vi.fn()
+    const getAvailableAuthoritativeWindow = vi.fn(() => ({
+      webContents: { setBackgroundThrottling, isDestroyed: () => false }
+    }))
+
+    const commands = new RuntimeBrowserCommands(
+      createHost({ getAvailableAuthoritativeWindow: getAvailableAuthoritativeWindow as never })
+    )
+    const session = await commands.browserScreencast(
+      { worktree: 'id:wt-1', page: 'page-1', format: 'jpeg' },
+      { sendBinary: vi.fn() }
+    )
+
+    expect(browserScreencastAwakeAcquireMock).toHaveBeenCalledTimes(1)
+    expect(browserScreencastAwakeAcquireMock).toHaveBeenCalledWith('runtime-browser-screencast')
+    expect(setBackgroundThrottling).toHaveBeenCalledWith(false)
+    expect(browserScreencastAwakeReleaseMock).not.toHaveBeenCalled()
+
+    session.session.stop()
+    await session.session.done
+
+    expect(browserScreencastAwakeReleaseMock).toHaveBeenCalledTimes(1)
+    expect(browserScreencastAwakeReleaseMock).toHaveBeenCalledWith('runtime-browser-screencast')
+    expect(setBackgroundThrottling).toHaveBeenLastCalledWith(true)
+  })
 })
 
 describe('RuntimeBrowserCommands headless offscreen routing', () => {

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -165,10 +165,7 @@ function syncMainWindowBackgroundThrottlingForScreencast(
     return
   }
   try {
-    // Why: keep the main renderer painting while a remote/mobile screencast needs
-    // compositor frames. Electron has no getter for the current throttle flag, so
-    // restore to `true` — the intentional createMainWindow default on darwin and
-    // Electron's default elsewhere — when the last stream ends.
+    // Why: Electron has no throttle getter; restore `true` (createMainWindow default) when idle.
     contents.setBackgroundThrottling(!screencastActive)
   } catch {
     // Why: the window can tear down between the null-check and the call during quit.

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -64,7 +64,7 @@ import {
   importCookiesFromBrowser,
   selectBrowserProfile
 } from '../browser/browser-cookie-import'
-import { browserScreencastAwakeService } from '../browser-screencast-awake-service'
+import { getBrowserScreencastAwakeService } from '../browser-screencast-awake-service'
 import { waitForTabRegistration, waitForWorktreeTabRegistration } from '../ipc/browser'
 
 export type BrowserCommandTargetParams = {
@@ -188,9 +188,9 @@ export class RuntimeBrowserCommands {
     }
     this.screencastAwakeActive = shouldKeepAwake
     if (shouldKeepAwake) {
-      browserScreencastAwakeService.acquire('runtime-browser-screencast')
+      getBrowserScreencastAwakeService().acquire('runtime-browser-screencast')
     } else {
-      browserScreencastAwakeService.release('runtime-browser-screencast')
+      getBrowserScreencastAwakeService().release('runtime-browser-screencast')
     }
     syncMainWindowBackgroundThrottlingForScreencast(this.host, shouldKeepAwake)
   }

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -166,7 +166,9 @@ function syncMainWindowBackgroundThrottlingForScreencast(
   }
   try {
     // Why: keep the main renderer painting while a remote/mobile screencast needs
-    // compositor frames; restore the default throttle when the last stream ends.
+    // compositor frames. Electron has no getter for the current throttle flag, so
+    // restore to `true` — the intentional createMainWindow default on darwin and
+    // Electron's default elsewhere — when the last stream ends.
     contents.setBackgroundThrottling(!screencastActive)
   } catch {
     // Why: the window can tear down between the null-check and the call during quit.
@@ -177,22 +179,26 @@ export class RuntimeBrowserCommands {
   private readonly activeScreencastPageIds = new Set<string>()
   private readonly activeScreencastsByPageId = new Map<string, ActiveBrowserScreencastPage>()
   private readonly stoppingScreencastPageIds = new Map<string, Promise<void>>()
-  private screencastAwakeActive = false
 
   constructor(private readonly host: RuntimeBrowserCommandHost) {}
 
-  private syncScreencastAwake(): void {
-    const shouldKeepAwake = this.activeScreencastsByPageId.size > 0
-    if (shouldKeepAwake === this.screencastAwakeActive) {
-      return
-    }
-    this.screencastAwakeActive = shouldKeepAwake
-    if (shouldKeepAwake) {
-      getBrowserScreencastAwakeService().acquire('runtime-browser-screencast')
-    } else {
-      getBrowserScreencastAwakeService().release('runtime-browser-screencast')
-    }
-    syncMainWindowBackgroundThrottlingForScreencast(this.host, shouldKeepAwake)
+  private screencastAwakeToken(browserPageId: string): string {
+    return `browser-screencast:${browserPageId}`
+  }
+
+  private markScreencastPageActive(browserPageId: string): void {
+    // Why: one token per live page so overlapping streams keep the host awake until
+    // the last page ends, even if multiple RuntimeBrowserCommands instances exist.
+    getBrowserScreencastAwakeService().acquire(this.screencastAwakeToken(browserPageId))
+    syncMainWindowBackgroundThrottlingForScreencast(this.host, true)
+  }
+
+  private markScreencastPageInactive(browserPageId: string): void {
+    getBrowserScreencastAwakeService().release(this.screencastAwakeToken(browserPageId))
+    syncMainWindowBackgroundThrottlingForScreencast(
+      this.host,
+      this.activeScreencastsByPageId.size > 0
+    )
   }
 
   private requireAgentBrowserBridge(): AgentBrowserBridge {
@@ -526,7 +532,7 @@ export class RuntimeBrowserCommands {
       done: activeDone
     }
     this.activeScreencastsByPageId.set(browserPageId, activeRecord)
-    this.syncScreencastAwake()
+    this.markScreencastPageActive(browserPageId)
     try {
       session = await startBrowserScreencast(guest, {
         format,
@@ -553,12 +559,17 @@ export class RuntimeBrowserCommands {
       if (this.activeScreencastsByPageId.get(browserPageId) === activeRecord) {
         this.activeScreencastsByPageId.delete(browserPageId)
       }
-      this.syncScreencastAwake()
+      this.markScreencastPageInactive(browserPageId)
       resolveActiveDone()
       throw error
     }
     let stoppingPromise: Promise<void> | null = null
+    let pageGateCleared = false
     const clearPageGate = (): void => {
+      if (pageGateCleared) {
+        return
+      }
+      pageGateCleared = true
       this.activeScreencastPageIds.delete(browserPageId)
       if (this.activeScreencastsByPageId.get(browserPageId) === activeRecord) {
         this.activeScreencastsByPageId.delete(browserPageId)
@@ -569,7 +580,7 @@ export class RuntimeBrowserCommands {
       ) {
         this.stoppingScreencastPageIds.delete(browserPageId)
       }
-      this.syncScreencastAwake()
+      this.markScreencastPageInactive(browserPageId)
       resolveActiveDone()
     }
     const markStopping = (): void => {

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -64,6 +64,7 @@ import {
   importCookiesFromBrowser,
   selectBrowserProfile
 } from '../browser/browser-cookie-import'
+import { browserScreencastAwakeService } from '../browser-screencast-awake-service'
 import { waitForTabRegistration, waitForWorktreeTabRegistration } from '../ipc/browser'
 
 export type BrowserCommandTargetParams = {
@@ -154,12 +155,45 @@ export type RuntimeBrowserCommandHost = {
   ): void
 }
 
+function syncMainWindowBackgroundThrottlingForScreencast(
+  host: RuntimeBrowserCommandHost,
+  screencastActive: boolean
+): void {
+  const window = host.getAvailableAuthoritativeWindow()
+  const contents = window?.webContents
+  if (!contents || contents.isDestroyed?.() === true) {
+    return
+  }
+  try {
+    // Why: keep the main renderer painting while a remote/mobile screencast needs
+    // compositor frames; restore the default throttle when the last stream ends.
+    contents.setBackgroundThrottling(!screencastActive)
+  } catch {
+    // Why: the window can tear down between the null-check and the call during quit.
+  }
+}
+
 export class RuntimeBrowserCommands {
   private readonly activeScreencastPageIds = new Set<string>()
   private readonly activeScreencastsByPageId = new Map<string, ActiveBrowserScreencastPage>()
   private readonly stoppingScreencastPageIds = new Map<string, Promise<void>>()
+  private screencastAwakeActive = false
 
   constructor(private readonly host: RuntimeBrowserCommandHost) {}
+
+  private syncScreencastAwake(): void {
+    const shouldKeepAwake = this.activeScreencastsByPageId.size > 0
+    if (shouldKeepAwake === this.screencastAwakeActive) {
+      return
+    }
+    this.screencastAwakeActive = shouldKeepAwake
+    if (shouldKeepAwake) {
+      browserScreencastAwakeService.acquire('runtime-browser-screencast')
+    } else {
+      browserScreencastAwakeService.release('runtime-browser-screencast')
+    }
+    syncMainWindowBackgroundThrottlingForScreencast(this.host, shouldKeepAwake)
+  }
 
   private requireAgentBrowserBridge(): AgentBrowserBridge {
     const bridge = this.host.getAgentBrowserBridge()
@@ -492,6 +526,7 @@ export class RuntimeBrowserCommands {
       done: activeDone
     }
     this.activeScreencastsByPageId.set(browserPageId, activeRecord)
+    this.syncScreencastAwake()
     try {
       session = await startBrowserScreencast(guest, {
         format,
@@ -518,6 +553,7 @@ export class RuntimeBrowserCommands {
       if (this.activeScreencastsByPageId.get(browserPageId) === activeRecord) {
         this.activeScreencastsByPageId.delete(browserPageId)
       }
+      this.syncScreencastAwake()
       resolveActiveDone()
       throw error
     }
@@ -533,6 +569,7 @@ export class RuntimeBrowserCommands {
       ) {
         this.stoppingScreencastPageIds.delete(browserPageId)
       }
+      this.syncScreencastAwake()
       resolveActiveDone()
     }
     const markStopping = (): void => {

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -177,7 +177,12 @@ export class RuntimeBrowserCommands {
   private readonly activeScreencastsByPageId = new Map<string, ActiveBrowserScreencastPage>()
   private readonly stoppingScreencastPageIds = new Map<string, Promise<void>>()
 
-  constructor(private readonly host: RuntimeBrowserCommandHost) {}
+  constructor(private readonly host: RuntimeBrowserCommandHost) {
+    // Why: authoritative live pages renew/prune awake tokens on the agent-awake stale cadence.
+    getBrowserScreencastAwakeService().setLiveTokenSource(() =>
+      [...this.activeScreencastsByPageId.keys()].map((pageId) => this.screencastAwakeToken(pageId))
+    )
+  }
 
   private screencastAwakeToken(browserPageId: string): string {
     return `browser-screencast:${browserPageId}`


### PR DESCRIPTION
Fixes #11492

## Summary

- Mobile/remote browser panes stream CDP screencast frames from the host Chromium. When the host display sleeps (or the main window is background-throttled), the compositor parks and frames stop — even though the main process, PTYs, and agent RPCs keep working.
- Add `BrowserScreencastAwakeService` (same `prevent-display-sleep` + macOS/Linux sleep-assertion pattern as agent-awake) and acquire it only while at least one `browser.screencast` session is active; release when the last stream ends.
- While a screencast is live, also temporarily set the authoritative main window's `setBackgroundThrottling(false)` so occlusion/display-sleep can't stall painting; restore the default throttle when idle.
- Electron power APIs are resolved lazily so incomplete `vi.mock('electron')` fixtures used by `orca-runtime` tests keep loading.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — changed-file gates pass (`check:code-quality:changed`, `audit:code-quality:*`, `check:max-lines-ratchet`, `check:reliability-gates`, localization/skill verifies). Full-repo `oxlint` currently fails on unrelated pre-existing `src/main/daemon/daemon-pty-router.ts` max-lines (304 > 300) on `main` tip; not introduced by this PR.
- [x] `pnpm typecheck`
- [x] `pnpm test` — fixed regression where static `powerSaveBlocker` import broke electron-mocked runtime suites; verified `orca-runtime*.test.ts`, `pty.test.ts`, `cdp-bridge-integration.test.ts`, SSH remote CLI/orchestration tests, plus screencast awake unit/integration tests (1406+ passing in the affected set). Full suite also surfaced unrelated flaky/env failures (managed-hook lock timing, WSL live relay, ephemeral-vm, SSH transport timeout) outside this change.
- [x] `pnpm build` — `pnpm run build:desktop` (typecheck + relay + cli + electron-vite + web) passes. Full `pnpm build` then fails on local macOS `build:computer-macos` Swift PackageDescription linker mismatch with Command Line Tools (environment), unrelated to this PR. CI package job on Ubuntu does not use that path the same way.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the change for cross-platform compatibility, remote/mobile behavior, and power impact:

- **macOS**: Electron `prevent-display-sleep` + existing `MacosSystemSleepAssertion` (`caffeinate -i -s`), matching agent-awake.
- **Linux**: existing `LinuxLidSleepAssertion` + Electron blocker.
- **Windows**: Electron `prevent-display-sleep` only (same intentional omission of lid-plan mutation as agent-awake). No shortcut/label/path changes.
- **Headless / `orca serve`**: awake assertions still run; main-window unthrottle is skipped when no authoritative window exists.
- **Remote/SSH/local**: trigger is runtime `browser.screencast`, so mobile and remote browser panes benefit; local PTY/agent traffic is unchanged.
- **Performance**: idle hosts keep background throttling and may sleep; cost only while a screencast subscription is live.
- **Testability**: avoided static Electron named imports so runtime test mocks without `powerSaveBlocker` continue to load.
- No UI surface changes.

## Security Audit

No new IPC, command execution, path handling, auth, or secrets. The change only starts/stops OS power assertions and toggles Electron background throttling for an existing privileged main-process browser stream. Refcounted acquire/release and quit-time dispose avoid leaking blockers. Lazy `require('electron')` is confined to service construction defaults.

## Notes

- Browser guest webviews already call `setBackgroundThrottling(false)` permanently for screenshots; this PR gates *host* display-sleep prevention and main-window unthrottle on live screencast sessions so phone/remote browsing survives display-off without paying that cost when idle.
- Manual check: pair mobile → open browser pane → turn host display off → page should keep updating; close mobile browser pane → host may sleep/throttle again.
- First-time fork PR: GitHub Actions are in `action_required` awaiting maintainer workflow approval. Please approve `PR Checks` so CI can run on the latest commit.