### PR TITLE
feat(sidebar): add toggle to always show host sections

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -212,6 +212,7 @@ const UiUpdateFields = z
     workspaceHostScope: z.string().optional(),
     visibleWorkspaceHostIds: z.array(z.string()).nullable().optional(),
     workspaceHostOrder: z.array(z.string()).optional(),
+    showHostSections: z.boolean().optional(),
     manualRepoOrder: z
       .array(z.object({ hostId: z.string(), repoId: z.string() }).strict())
       .optional(),

--- a/src/renderer/src/components/sidebar/SidebarHostScopeMenuSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHostScopeMenuSection.tsx
@@ -20,6 +20,8 @@ type SidebarHostScopeMenuSectionProps = {
   setWorkspaceHostScope: (scope: WorkspaceHostScope) => void
   visibleWorkspaceHostIds: VisibleWorkspaceHostIds
   setVisibleWorkspaceHostIds: (ids: VisibleWorkspaceHostIds) => void
+  showHostSections: boolean
+  setShowHostSections: (v: boolean) => void
 }
 
 function getHostMetadata(host: SidebarHostOption): string {
@@ -60,7 +62,9 @@ export function SidebarHostScopeMenuSection({
   preserveWorkspaceBoardOpen,
   setWorkspaceHostScope,
   visibleWorkspaceHostIds,
-  setVisibleWorkspaceHostIds
+  setVisibleWorkspaceHostIds,
+  showHostSections,
+  setShowHostSections
 }: SidebarHostScopeMenuSectionProps): React.JSX.Element {
   const allVisible = !visibleWorkspaceHostIds
   const visibleHostIdSet = new Set(visibleWorkspaceHostIds ?? [])
@@ -148,6 +152,17 @@ export function SidebarHostScopeMenuSection({
           ))}
         </DropdownMenuSubContent>
       </DropdownMenuSub>
+
+      <DropdownMenuCheckboxItem
+        checked={showHostSections}
+        onCheckedChange={setShowHostSections}
+        onSelect={(e) => e.preventDefault()}
+      >
+        {translate(
+          'auto.components.sidebar.SidebarWorkspaceOptionsMenu.showHostSections',
+          'Show host sections'
+        )}
+      </DropdownMenuCheckboxItem>
 
       <DropdownMenuSeparator />
     </>

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -45,6 +45,8 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
   const setWorkspaceHostScope = useAppStore((s) => s.setWorkspaceHostScope)
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
   const setVisibleWorkspaceHostIds = useAppStore((s) => s.setVisibleWorkspaceHostIds)
+  const showHostSections = useAppStore((s) => s.showHostSections)
+  const setShowHostSections = useAppStore((s) => s.setShowHostSections)
   const sortBy = useAppStore((s) => s.sortBy)
   const setSortBy = useAppStore((s) => s.setSortBy)
   const groupBy = useAppStore((s) => s.groupBy)
@@ -167,6 +169,8 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
             setWorkspaceHostScope={setWorkspaceHostScope}
             visibleWorkspaceHostIds={visibleWorkspaceHostIds}
             setVisibleWorkspaceHostIds={setVisibleWorkspaceHostIds}
+            showHostSections={showHostSections}
+            setShowHostSections={setShowHostSections}
           />
         )}
 

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -5225,6 +5225,7 @@ const WorktreeList = React.memo(function WorktreeList({
   const workspaceHostScope = useAppStore((s) => s.workspaceHostScope)
   const visibleWorkspaceHostIds = useAppStore((s) => s.visibleWorkspaceHostIds)
   const workspaceHostOrder = useAppStore((s) => s.workspaceHostOrder)
+  const showHostSections = useAppStore((s) => s.showHostSections)
   const setWorkspaceHostOrder = useAppStore((s) => s.setWorkspaceHostOrder)
   const workspaceStatuses = useAppStore((s) => s.workspaceStatuses)
   const sortBy = useAppStore((s) => s.sortBy)
@@ -5822,8 +5823,8 @@ const WorktreeList = React.memo(function WorktreeList({
         defaultHostId,
         collapsedHostKeys: effectiveCollapsedGroups,
         forceCollapseHosts: hostDragActive,
-        // Why: projects/workspaces are the primary sidebar object; host sections are only an explicit host-filter view.
-        preferProjectGrouping: true
+        // Why: projects/workspaces are the primary sidebar object; host sections appear only under explicit host filters or the user's opt-in toggle.
+        preferProjectGrouping: !showHostSections
       }),
     [
       defaultHostId,
@@ -5831,6 +5832,7 @@ const WorktreeList = React.memo(function WorktreeList({
       hostDragActive,
       orderedHostOptions,
       rows,
+      showHostSections,
       visibleWorkspaceHostIds,
       workspaceHostScope
     ]

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
@@ -248,6 +248,32 @@ describe('closed-sidebar Cmd+1-9 ordering (#9497)', () => {
     ])
   })
 
+  it('groups hosts contiguously when the host-sections toggle is on without a filter', () => {
+    // Repo order interleaves the hosts (local, ssh, local); only host sections
+    // can pull the second local repo ahead of the SSH one.
+    const storeOverrides = {
+      repos: [
+        makeRepo('repo1'),
+        makeRepo('repo-ssh', { connectionId: 'my-target' }),
+        makeRepo('repo2')
+      ],
+      worktreesByRepo: {
+        repo1: [makeMainWorktree('wt-local-1')],
+        'repo-ssh': [makeMainWorktree('wt-remote', { repoId: 'repo-ssh' })],
+        repo2: [makeMainWorktree('wt-local-2', { repoId: 'repo2' })]
+      },
+      sshTargetLabels: new Map([['my-target', 'My Target']])
+    } as Partial<AppState>
+
+    seedStore([], storeOverrides)
+    // Toggle off: all-hosts default keeps plain repo ordering.
+    expect(getVisibleWorktreeIds()).toEqual(['wt-local-1', 'wt-remote', 'wt-local-2'])
+
+    seedStore([], { ...storeOverrides, showHostSections: true })
+    // Toggle on: host sections apply even without an explicit host filter, local first.
+    expect(getVisibleWorktreeIds()).toEqual(['wt-local-1', 'wt-local-2', 'wt-remote'])
+  })
+
   it('keeps the sort layer intact for smart and comparator sort modes', () => {
     const main = makeMainWorktree('wt-main')
     const older = makeWorktree('wt-older', { displayName: 'b-older', lastActivityAt: 1 })

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
@@ -87,7 +87,9 @@ export function computeRenderedSidebarWorktreeOrder(
   // Why lazy: with no host filter, addHostSectionRows is a pass-through, so skip building the whole host registry on a keystroke.
   // Deliberately a superset of its internal guards — on <=1 host it still no-ops, wasting only the registry build.
   const needsHostSections =
-    state.workspaceHostScope !== ALL_EXECUTION_HOSTS_SCOPE || state.visibleWorkspaceHostIds != null
+    state.workspaceHostScope !== ALL_EXECUTION_HOSTS_SCOPE ||
+    state.visibleWorkspaceHostIds != null ||
+    state.showHostSections
   const sectionRows = needsHostSections
     ? addHostSectionRows({
         rows,
@@ -108,7 +110,7 @@ export function computeRenderedSidebarWorktreeOrder(
         defaultHostId,
         collapsedHostKeys: state.collapsedGroups,
         forceCollapseHosts: false,
-        preferProjectGrouping: true
+        preferProjectGrouping: !state.showHostSections
       })
     : rows
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4391,7 +4391,8 @@
           "65a9820bd1": "Agent statuses",
           "219ebf1961": "Branch name",
           "folderPathIdentity": "Branch / folder path",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "showHostSections": "Show host sections"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "Connecting...",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4341,7 +4341,8 @@
           "65a9820bd1": "Estados de Agents",
           "219ebf1961": "Nombre de rama",
           "folderPathIdentity": "Rama / ruta de carpeta",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "showHostSections": "Mostrar secciones por host"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "Conectando...",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4322,7 +4322,8 @@
           "219ebf1961": "ブランチ名",
           "automation": "自動化",
           "folderPathIdentity": "ブランチ / フォルダパス",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "showHostSections": "ホストごとにセクションを表示"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "接続中...",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4322,7 +4322,8 @@
           "219ebf1961": "브랜치 이름",
           "automation": "자동화",
           "folderPathIdentity": "브랜치 / 폴더 경로",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "showHostSections": "호스트별 섹션 표시"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "연결 중...",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4322,7 +4322,8 @@
           "219ebf1961": "分支名称",
           "automation": "自动化",
           "folderPathIdentity": "分支 / 文件夹路径",
-          "cli": "Orca CLI"
+          "cli": "Orca CLI",
+          "showHostSections": "按主机显示分区"
         },
         "SshDisconnectedDialog": {
           "ca4a7892af": "正在连接...",

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -732,6 +732,16 @@ describe('createUISlice hydratePersistedUI', () => {
     expect(createUIStore().getState().manualRepoOrder).toEqual([])
   })
 
+  it('defaults host sections off and hydrates the persisted toggle', () => {
+    expect(getDefaultUIState().showHostSections).toBe(false)
+    const store = createUIStore()
+    expect(store.getState().showHostSections).toBe(false)
+
+    store.getState().hydratePersistedUI(makePersistedUI({ showHostSections: true }), 'startup')
+
+    expect(store.getState().showHostSections).toBe(true)
+  })
+
   it('defaults the persisted active view to terminal', () => {
     expect(getDefaultUIState().activeView).toBe('terminal')
     expect(createUIStore().getState().activeView).toBe('terminal')

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -865,6 +865,8 @@ export type UISlice = {
   setVisibleWorkspaceHostIds: (ids: VisibleWorkspaceHostIds) => void
   workspaceHostOrder: WorkspaceHostOrder
   setWorkspaceHostOrder: (ids: WorkspaceHostOrder) => void
+  showHostSections: boolean
+  setShowHostSections: (v: boolean) => void
   manualRepoOrder: ManualRepoOrderEntry[]
   hideDefaultBranchWorkspace: boolean
   setHideDefaultBranchWorkspace: (v: boolean) => void
@@ -2039,6 +2041,11 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set({ workspaceHostOrder })
     window.api.ui.set({ workspaceHostOrder }).catch(console.error)
   },
+  showHostSections: false,
+  setShowHostSections: (v) => {
+    set({ showHostSections: v })
+    window.api.ui.set({ showHostSections: v }).catch(console.error)
+  },
   manualRepoOrder: [],
 
   hideDefaultBranchWorkspace: false,
@@ -2448,6 +2455,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         workspaceHostScope: normalizeExecutionHostScope(ui.workspaceHostScope),
         visibleWorkspaceHostIds: normalizeHydratedVisibleWorkspaceHostIds(ui),
         workspaceHostOrder: normalizeExecutionHostOrder(ui.workspaceHostOrder),
+        showHostSections: ui.showHostSections === true,
         manualRepoOrder,
         // Why: apply the desktop-owned overlay immediately since UI state can arrive after a catalog or from another client.
         repos: orderedRepos,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -466,6 +466,7 @@ export function getDefaultUIState(): PersistedUIState {
     workspaceHostScope: 'all',
     visibleWorkspaceHostIds: null,
     workspaceHostOrder: [],
+    showHostSections: false,
     manualRepoOrder: [],
     showSleepingWorkspaces: DEFAULT_SHOW_SLEEPING_WORKSPACES,
     hideDefaultBranchWorkspace: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3316,6 +3316,8 @@ export type PersistedUIState = {
   visibleWorkspaceHostIds?: VisibleWorkspaceHostIds
   /** User-defined sidebar order for host sections; missing/new hosts append in discovered order. */
   workspaceHostOrder?: WorkspaceHostOrder
+  /** Always group the sidebar under host section headers, not only under explicit host filters. */
+  showHostSections?: boolean
   /** Desktop-owned all-host repo order; host-qualified identities keep a manual cross-host interleaving while each host owns its local permutation. */
   manualRepoOrder?: ManualRepoOrderEntry[]
   /** Deprecated legacy positive-form setting. Ignored on hydration. */


### PR DESCRIPTION
## Summary

Adds a **"Show host sections"** toggle to the sidebar host menu so workspaces can be visually separated by execution host (local first, then SSH/runtime hosts) in the default all-hosts view.

Today, host section headers only appear when an explicit host filter is active (`visibleWorkspaceHostIds`). Users working across local + remote hosts have no way to keep the two groups visually separated without narrowing visibility. This PR exposes the existing host-section rendering behind an opt-in, persisted toggle:

- New `showHostSections` flag in `PersistedUIState` (default `false`), hydrated and persisted through the existing UI state channel, mirrored in the client UI zod schema (the compile-time parity guard enforces this).
- New checkbox in `SidebarHostScopeMenuSection`, gated by the same `showHostScopeControls` guard, so local-only users never see it.
- Both `addHostSectionRows` call sites read the toggle: the rendered sidebar (`WorktreeList`) and the closed-sidebar Cmd+1-9 ordering (`rendered-sidebar-worktree-order`), keeping keyboard numbering consistent with the visible order. The lazy host-registry skip now also accounts for the toggle.
- No data-model change: locality stays derived from `ExecutionHostId`; projects remain host-neutral.

Localized strings added for en/es/ja/ko/zh.

## Screenshots

The toggle reuses the existing host-section rendering (headers, collapse persistence, drag reorder, health badges) that already appears under explicit host filters - it only makes that view reachable in the default all-hosts mode.

## Testing

- [x] `pnpm typecheck`
- [ ] `pnpm lint` (ran `oxlint` on changed files, `verify:localization-catalog`, and `audit-localization-coverage --check`; all green)
- [ ] `pnpm test` (ran targeted suites: `rendered-sidebar-worktree-order`, `ui` slice, `host-section-rows`, `sidebar-host-options`, `client-ui`, locale regression - 232 tests passing)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions
  - `rendered-sidebar-worktree-order.test.ts`: with repos interleaved local/ssh/local, toggle off keeps plain repo ordering; toggle on groups hosts contiguously (local first) without an explicit filter.
  - `ui.test.ts`: default-off + hydration restore of the persisted toggle.

## AI Review Report

Implemented and reviewed with an AI coding agent. Main risks checked:

- **Dual call-site divergence**: `addHostSectionRows` is invoked from both the rendered list and the Cmd+1-9 ordering path; both were wired to the same flag and covered by an ordering test to prevent visible-order/keyboard-order drift.
- **Lazy-evaluation skip**: the closed-sidebar path skips building the host registry when no filter is active; the skip condition now includes the toggle, verified by test.
- **Schema parity**: the `PersistedUIState` -> `UiUpdateFieldsSchema` compile-time parity guard caught the missing schema field during typecheck; added `showHostSections` to `client-ui-schemas.ts`.
- **Single-host noise**: `addHostSectionRows` already passes through when fewer than two hosts have rows, so enabling the toggle on a local-only profile renders no headers.
- Cross-platform: no shortcuts, paths, or shell behavior touched; the change is renderer state + one shared type + one zod schema field, identical on macOS/Linux/Windows. Local host labeling continues to use the existing platform-aware `getLocalExecutionHostLabel`.

## Security Audit

No input handling, command execution, path handling, auth, or secrets touched. The new field is a boolean flowing through the existing validated UI-state RPC (`z.boolean().optional()`), so malformed client payloads are rejected by the same zod schema as neighboring fields. No new IPC surface.

## Notes

- Host sections stay suppressed unless at least two hosts have visible rows, preserving current behavior for local-only users.
- Follow-up candidate (separate PR): "Local only / Remote only" quick presets in the host visibility submenu.
