### PR TITLE
fix(macos): stop automatic period substitution corrupting terminal input

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join } from 'node:path'
 import os from 'node:os'
 import { app, BrowserWindow, dialog, ipcMain, nativeTheme, type Tray } from 'electron'
 import { initTccPromptNotice, stopTccPromptNotice } from './macos-tcc-prompt-notice'
+import { disableMacAutomaticPeriodSubstitution } from './macos-automatic-period-substitution'
 import { electronApp, is } from '@electron-toolkit/utils'
 import {
   Store,
@@ -1979,6 +1980,8 @@ function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {
 
 void app.whenReady().then(async () => {
   logStartupMilestone('app-ready')
+  // Why: before any window exists, so the first terminal never inherits the substitution.
+  disableMacAutomaticPeriodSubstitution()
   installMainThreadHangWatchdog({ userDataPath: getCanonicalUserDataPath() })
   const hangDetection = consumeHangDetectionMarker(
     hangDetectionMarkerPath(getCanonicalUserDataPath())

--- a/src/main/macos-automatic-period-substitution.test.ts
+++ b/src/main/macos-automatic-period-substitution.test.ts
@@ -1,0 +1,57 @@
+import { systemPreferences } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { disableMacAutomaticPeriodSubstitution } from './macos-automatic-period-substitution'
+
+vi.mock('electron', () => ({
+  systemPreferences: { setUserDefault: vi.fn() }
+}))
+
+describe('disableMacAutomaticPeriodSubstitution', () => {
+  beforeEach(() => {
+    vi.mocked(systemPreferences.setUserDefault).mockClear()
+  })
+
+  // Why: startup calls this with no options, so the Electron delegation is the path that ships.
+  it('writes through systemPreferences when no writer is injected', () => {
+    expect(disableMacAutomaticPeriodSubstitution({ platform: 'darwin' })).toBe(true)
+    expect(systemPreferences.setUserDefault).toHaveBeenCalledWith(
+      'NSAutomaticPeriodSubstitutionEnabled',
+      'boolean',
+      false
+    )
+  })
+
+  it('writes the app-domain override on macOS', () => {
+    const setUserDefault = vi.fn()
+
+    expect(disableMacAutomaticPeriodSubstitution({ platform: 'darwin', setUserDefault })).toBe(true)
+    expect(setUserDefault).toHaveBeenCalledWith(
+      'NSAutomaticPeriodSubstitutionEnabled',
+      'boolean',
+      false
+    )
+  })
+
+  it.each(['win32', 'linux'] as const)('does not touch defaults on %s', (platform) => {
+    const setUserDefault = vi.fn()
+
+    expect(disableMacAutomaticPeriodSubstitution({ platform, setUserDefault })).toBe(false)
+    expect(setUserDefault).not.toHaveBeenCalled()
+  })
+
+  it('survives a failing preferences write', () => {
+    const warn = vi.fn()
+    const setUserDefault = vi.fn(() => {
+      throw new Error('defaults unavailable')
+    })
+
+    expect(
+      disableMacAutomaticPeriodSubstitution({
+        platform: 'darwin',
+        setUserDefault,
+        logger: { warn }
+      })
+    ).toBe(false)
+    expect(warn).toHaveBeenCalled()
+  })
+})

--- a/src/main/macos-automatic-period-substitution.ts
+++ b/src/main/macos-automatic-period-substitution.ts
@@ -1,0 +1,49 @@
+import { systemPreferences } from 'electron'
+
+/**
+ * macOS "Add period with double-space" (`NSAutomaticPeriodSubstitutionEnabled`, on by
+ * default) is applied by the text input system, which Chromium text fields opt into.
+ * Native terminals never see it, but Orca's xterm helper does: with a Hangul input
+ * source even a single word-separating space is re-processed on the IME commit path and
+ * comes back as `". "` straight into the PTY, corrupting the typed command.
+ * Writing the key into Orca's own defaults domain overrides the global value for this
+ * app only — the user's system-wide setting is left untouched.
+ *
+ * The substitution is enforced outside the renderer and never reproduces in dev builds,
+ * so changes here must be verified against a packaged app (#11504).
+ */
+const AUTOMATIC_PERIOD_SUBSTITUTION_KEY = 'NSAutomaticPeriodSubstitutionEnabled'
+
+type SetUserDefault = (key: string, type: 'boolean', value: boolean) => void
+
+export type DisableMacAutomaticPeriodSubstitutionOptions = {
+  logger?: Pick<Console, 'warn'>
+  platform?: NodeJS.Platform
+  setUserDefault?: SetUserDefault
+}
+
+/** Returns true when the app-domain override was written. No-op off macOS. */
+export function disableMacAutomaticPeriodSubstitution(
+  options: DisableMacAutomaticPeriodSubstitutionOptions = {}
+): boolean {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'darwin') {
+    return false
+  }
+
+  const setUserDefault =
+    options.setUserDefault ??
+    ((key, type, value) => systemPreferences.setUserDefault(key, type, value))
+
+  try {
+    setUserDefault(AUTOMATIC_PERIOD_SUBSTITUTION_KEY, 'boolean', false)
+    return true
+  } catch (error) {
+    // Why: a preferences write is never worth failing startup over.
+    ;(options.logger ?? console).warn(
+      'Failed to disable macOS automatic period substitution',
+      error
+    )
+    return false
+  }
+}


### PR DESCRIPTION
Fixes #11504

## Summary

On macOS with a CJK input source active, typing an ordinary word-separating space in an Orca terminal can commit a space **plus a period** to the PTY. The same keystrokes are clean in Terminal.app and iTerm2.

A captured sequence ([#11504 comment](https://github.com/stablyai/orca/issues/11504#issuecomment-5127247965)) shows a **single** space press is enough: the Hangul IME folds the space into the composition and commits `"아 "`, then the text input system processes that same space again, counts it as a second consecutive space, and rewrites it to `"아. "`. No deliberate double press is involved, so for Korean typists every word boundary is a candidate.

The text is not produced by Orca code — it comes from macOS "Add period with double-space" (`NSAutomaticPeriodSubstitutionEnabled`), which is on by default and applied by the text input system. Chromium text fields participate in that system, so xterm's helper textarea inherits it; native terminals never do. This is a known platform gap: [crbug 752640](https://bugs.chromium.org/p/chromium/issues/detail?id=752640) (open since 2017), and VS Code closed the same report as out-of-scope ([microsoft/vscode#109047](https://github.com/microsoft/vscode/issues/109047)).

This PR writes the key into Orca's own defaults domain at startup, which overrides the global value **for this app only** and leaves the user's system-wide setting untouched.

**History of this PR:** an earlier revision of this change was marked invalid after a live test on 1.4.161 showed the app-domain override not taking effect. Retesting on 1.4.164 — after #11293 reworked the IME composition lifecycle — shows the override **does** work there. Both observations stand; the fix is verified against the composition path that ships today.

## Screenshots

`No visual change`

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm vitest run src/main/macos-automatic-period-substitution.test.ts` (5 tests: Electron delegation path, injected-writer path, win32/linux no-op, failing write does not break startup)
- [x] `oxlint` on the three touched files (clean; full `pnpm lint` currently dies OOM in my workspace on unrelated files)
- [x] **Live A/B on the installed packaged app (1.4.164), Hangul input source, global setting on**, by writing the exact key/value this code writes via `defaults` and relaunching:
  - no override → substitution reproduces intermittently at word boundaries
  - app-domain key `false` → no substitution across multi-day normal use
- [ ] Packaged build carrying this commit re-verified (dev builds never reproduce the substitution — see Notes)

## AI Review Report

- **Cross-platform**: guarded by `platform !== 'darwin'`, which returns before touching Electron APIs; `setUserDefault` is never reached on Windows or Linux. Covered by tests for all three platforms.
- **SSH / remote / folder workspaces**: none. This is a local app preference read by the host's text input system; it does not touch PTY transport, remote hosts, or workspace type.
- **Performance**: one preferences write during `whenReady`, before any window is created. Not in a hot path.
- **Behavior risk flagged**: the override is rewritten on every launch, so a user who deliberately wants period substitution inside Orca cannot keep it by setting the app-domain key manually. That trade-off is deliberate for a terminal-hosting app; `systemPreferences.removeUserDefault` makes an opt-back-in straightforward if maintainers want one.

## Security Audit

No input handling, command execution, path handling, auth, secrets, IPC, or dependency changes. The single side effect is one `NSUserDefaults` write of a boolean into the app's own domain, with a constant key and a constant value; the call is wrapped so a failed write logs and returns instead of propagating into startup. No new dependencies.

## Notes

- macOS-only behavior; no-op elsewhere.
- **For reviewers: dev builds (`pnpm dev`) never reproduce the substitution**, so a dev-build "verification" proves nothing either way. Verify against a packaged build with a Hangul input source and the global setting on (its macOS default).
- The substitution can only be controlled per-application, not per-field, so this necessarily covers the chat composer as well as terminals.
- Manual workaround for anyone on an older build: `defaults write com.stablyai.orca NSAutomaticPeriodSubstitutionEnabled -bool false` (or disable it system-wide in System Settings → Keyboard → Text).
- Smart quote and dash substitution (`NSAutomaticQuoteSubstitutionEnabled`, `NSAutomaticDashSubstitutionEnabled`) are the same class of problem for a terminal, but were not reported and are not reproduced here, so they are left out of this PR.
