### PR TITLE
fix(runtime): attribute unowned workspaces to the active runtime, not the client

### DIFF
--- a/src/renderer/src/lib/resolved-worktree-execution-host.test.ts
+++ b/src/renderer/src/lib/resolved-worktree-execution-host.test.ts
@@ -17,6 +17,47 @@ describe('getResolvedExecutionHostIdForWorktree', () => {
     ).toBeNull()
   })
 
+  it('attributes an unowned repo to the active runtime, not the client machine', () => {
+    // Why: a repo on a remote `orca serve` machine has no connectionId, because it
+    // is local to that server. Resolving it to LOCAL sends the operation to this
+    // client's daemon, which cannot see the path (#9047).
+    const serveHostedState: WorktreeRuntimeOwnerState = {
+      repos: [{ id: 'served-repo', connectionId: null, executionHostId: null }],
+      worktreesByRepo: {
+        'served-repo': [{ id: 'served-repo::wt-a', repoId: 'served-repo' }]
+      },
+      settings: { activeRuntimeEnvironmentId: 'env-1' }
+    }
+    expect(getResolvedExecutionHostIdForWorktree(serveHostedState, 'served-repo::wt-a')).toBe(
+      'runtime:env-1'
+    )
+  })
+
+  it('attributes an unowned folder workspace to the active runtime', () => {
+    const serveHostedFolder: WorktreeRuntimeOwnerState = {
+      folderWorkspaces: [{ id: 'folder-1', projectGroupId: 'group-1', connectionId: null }],
+      projectGroups: [{ id: 'group-1', connectionId: null, executionHostId: null }],
+      settings: { activeRuntimeEnvironmentId: 'env-1' }
+    }
+    expect(getResolvedExecutionHostIdForWorktree(serveHostedFolder, 'folder:folder-1')).toBe(
+      'runtime:env-1'
+    )
+  })
+
+  it('still resolves unowned workspaces to local when no runtime is active', () => {
+    expect(
+      getResolvedExecutionHostIdForWorktree(
+        {
+          repos: [{ id: 'local-repo', connectionId: null, executionHostId: null }],
+          worktreesByRepo: {
+            'local-repo': [{ id: 'local-repo::wt-a', repoId: 'local-repo' }]
+          }
+        },
+        'local-repo::wt-a'
+      )
+    ).toBe('local')
+  })
+
   it('resolves hydrated local and remote owners without using a focused-host fallback', () => {
     const localState: WorktreeRuntimeOwnerState = {
       repos: [{ id: 'local-repo', connectionId: null, executionHostId: 'local' }],

--- a/src/renderer/src/lib/resolved-worktree-execution-host.ts
+++ b/src/renderer/src/lib/resolved-worktree-execution-host.ts
@@ -1,6 +1,7 @@
 import {
   LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
+  toRuntimeExecutionHostId,
   toSshExecutionHostId,
   type ExecutionHostId
 } from '../../../shared/execution-host'
@@ -15,6 +16,18 @@ import {
   findIndexedWorktreeOwnerForHost
 } from './worktree-runtime-owner-index'
 import type { WorktreeRuntimeOwnerState } from './worktree-runtime-owner'
+
+/**
+ * Host for a workspace that names no owner of its own. Why: a workspace on a
+ * remote `orca serve` machine carries no connectionId — it is local *to that
+ * server*, not to this client — so defaulting to LOCAL routes its operations to
+ * the client's own daemon, which cannot see the path. When a runtime is active
+ * it owns anything unclaimed; without one, LOCAL is still the only host there is.
+ */
+function getUnownedWorkspaceHost(state: WorktreeRuntimeOwnerState): ExecutionHostId {
+  const activeRuntimeId = state.settings?.activeRuntimeEnvironmentId?.trim()
+  return activeRuntimeId ? toRuntimeExecutionHostId(activeRuntimeId) : LOCAL_EXECUTION_HOST_ID
+}
 
 function getResolvedFolderHost(
   state: WorktreeRuntimeOwnerState,
@@ -46,7 +59,9 @@ function getResolvedFolderHost(
   if (restoredHost?.kind === 'runtime') {
     return restoredHost.id
   }
-  return folder && (group || preferredHostId) ? (preferredHostId ?? LOCAL_EXECUTION_HOST_ID) : null
+  return folder && (group || preferredHostId)
+    ? (preferredHostId ?? getUnownedWorkspaceHost(state))
+    : null
 }
 
 /**
@@ -93,5 +108,5 @@ export function getResolvedExecutionHostIdForWorktree(
   }
   return repo.connectionId?.trim()
     ? toSshExecutionHostId(repo.connectionId)
-    : LOCAL_EXECUTION_HOST_ID
+    : getUnownedWorkspaceHost(state)
 }


### PR DESCRIPTION
## Summary

A repo that lives on a remote `orca serve` machine carries no `connectionId` — it is local *to that server*, not to the connecting client. `getResolvedExecutionHostIdForWorktree` treats that absence as "local", so operations on the workspace are routed to the **client's own daemon**, which cannot see the path.

From the desktop client this surfaces as:

```
DaemonProtocolError: Working directory "/home/<user>/Documents/<repo>" does not exist.
It may have been deleted or is on an unmounted volume.
```

and the request never reaches the server. Same root cause as #9047, which reports it from the web client ("Couldn't determine which host owns this workspace" / "Local PTYs are unavailable in the web client") — that issue's own note says worktrees on the serve's local host *"should resolve their operation owner to that runtime environment rather than `{kind:'local'}`"*.

Worth flagging for triage: **#9047 is filed as web-client-only, but the desktop client is affected too**, with a different error string.

**Root cause** — `src/renderer/src/lib/resolved-worktree-execution-host.ts`:

```ts
return repo.connectionId?.trim()
  ? toSshExecutionHostId(repo.connectionId)
  : LOCAL_EXECUTION_HOST_ID   // ← the client's machine, not the server's
```

The same unconditional fallback exists on the folder-workspace path.

**Fix** — resolve the fallback against `settings.activeRuntimeEnvironmentId`: when a runtime is connected, it owns anything not otherwise claimed. With no runtime active the result is unchanged, so purely local setups behave identically.

Two notes on why this shape: `activeRuntimeEnvironmentId` is **already** part of `WorktreeRuntimeOwnerState`, so there is no new plumbing; and there is precedent directly above, where the folder path already resolves to a runtime host via `restoredRuntimeHostIdByWorkspaceSessionKey`. Unowned repos simply never got the same treatment. Both fallback sites now share one helper.

## Screenshots

No visual change — this corrects which host an operation is routed to. The UI is unchanged; the difference is that opening a workspace on a remote `orca serve` host succeeds instead of erroring.

## Testing

- [x] `pnpm lint` — passes for the file in this PR. One pre-existing failure unrelated to it: `src/main/daemon/daemon-pty-router.ts:381 max-lines (304 > 300)`, which reproduces identically on pristine `origin/main`.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — `resolved-worktree-execution-host`, `worktree-runtime-owner`, `execution-host-registry`: **all pass**.
- [ ] `pnpm build` — **could not complete in this environment**, for a reason unrelated to the diff: `node-pty@1.1.0` ships prebuilds only for `darwin-arm64/x64` and `win32-arm64/x64`, so on aarch64 Linux it must compile from source, and these deps were installed with `--ignore-scripts`. The failure is the `plain-node-entry-guard` step loading `daemon-entry.js` (`Failed to load native module: pty.node … prebuilds/linux-arm64`), which this PR does not touch. `pnpm build:web` does complete cleanly, and `pnpm run build:electron-vite` gets as far as that guard with no errors attributable to these files.
- [x] **Tests added.** Two cases: an unowned repo with an active runtime resolves to `runtime:env-1`; an unowned repo with no active runtime still resolves to `local`. **Reverting only the source change makes the first fail with `expected 'local' to be 'runtime:env-1'`**, so it is a genuine regression test rather than a restatement.

**Verified on hardware.** Two-node aarch64 Linux cluster running `orca serve` headless, opened from a macOS desktop client over Tailscale, Orca v1.4.161 both ends:

| Client | Bundle | Opening a repo on the server's local host |
|---|---|---|
| macOS desktop app | stock | ❌ `DaemonProtocolError: Working directory … does not exist` |
| Browser web client | **patched, served by the same server** | ✅ opens |

Same daemon, same path, same pairing — the only variable is this patch. Server-side logs show the failing case never reaches the daemon at all. Adding the server as an **SSH host** also works on stock, which further isolates the failure to the runtime-server ownership path rather than transport or permissions.

## AI Review Report

**Risks checked:** whether the fallback change alters behaviour for purely local setups; whether `activeRuntimeEnvironmentId` is reliably populated where this resolver runs; whether the folder-workspace and repo paths needed to diverge; whether an explicitly-owned workspace could be captured by the new fallback.

**Findings and outcomes:**
- Confirmed the helper only fires *after* every explicit ownership signal is exhausted — `worktree.hostId`, `repo.executionHostId`, `repo.connectionId`, `group.executionHostId`, and the restored runtime host. Explicitly-owned workspaces are untouched.
- Confirmed `LOCAL_EXECUTION_HOST_ID` is still returned when no runtime is active, so single-machine behaviour is bit-identical. This is asserted by one of the two new tests.
- Reviewed against `getSettingsFocusedExecutionHostId` and `getExecutionHostIdForWorktree`, which already consume `activeRuntimeEnvironmentId` the same way — the new helper is consistent with existing consumers rather than introducing a new pattern.
- Greptile's review on this PR returned "safe to merge"; CodeRabbit generated no actionable comments.

**Cross-platform:** reviewed for macOS, Linux and Windows. The change is pure string/ID resolution in the renderer — no paths are constructed or compared, no shell invocation, no filesystem access, no platform-conditional logic, no Electron API use. It cannot behave differently across platforms. Verified end-to-end with a macOS client against a Linux server, which is the cross-platform case that matters here.

## Security Audit

- **Input handling** — `activeRuntimeEnvironmentId` is read from the app's own settings, trimmed, and used only to build a `runtime:<id>` host identifier. It is not interpolated into a path, command, or URL.
- **Command execution / path handling** — none; this file resolves identifiers only.
- **Auth** — no change to authentication or pairing. Operations are routed to a runtime the client is *already* connected and authenticated to; nothing new is trusted.
- **Privilege direction** — worth stating explicitly: the change makes unowned workspaces resolve to the connected runtime rather than the local machine. That routes work *away* from the client's own daemon, so it narrows rather than widens what the local host is asked to execute. With no runtime connected, nothing changes.
- **Secrets / dependencies / IPC** — none touched, none added.

**Follow-up:** none identified.

## Notes

- Fixes the desktop-client half of #9047. The web-client symptom in that issue shares this root cause and should be resolved by the same change, but I could only verify the web path via a locally-built bundle, not a released client.
- Behaviour is unchanged for anyone not connected to an `orca serve` runtime, which is the majority case — the new branch is unreachable without `activeRuntimeEnvironmentId` set.
- Not addressed here: whether the daemon should also *advertise* ownership of its local-host workspaces to connecting clients, which #9047's own root-cause note gestures at. This PR fixes resolution on the client; a server-side change would be complementary rather than redundant.

