### PR TITLE
fix(terminal): stop dropping pasted images when the clipboard also names them

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-image-reference-text.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-image-reference-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { isImageReferenceOnlyClipboardText } from './terminal-clipboard-image-reference-text'
+
+describe('image-reference-only clipboard text', () => {
+  it('recognizes the source URL a browser "Copy Image" leaves alongside the bitmap', () => {
+    expect(isImageReferenceOnlyClipboardText('https://example.com/assets/screenshot.png')).toBe(
+      true
+    )
+    expect(isImageReferenceOnlyClipboardText('http://example.com/a/b/photo.JPG?v=2')).toBe(true)
+  })
+
+  it('recognizes percent-encoded image URLs', () => {
+    expect(isImageReferenceOnlyClipboardText('https://example.com/my%20shot.png')).toBe(true)
+  })
+
+  it('recognizes local and file:// image paths, including names with spaces', () => {
+    expect(isImageReferenceOnlyClipboardText('/Users/jane/Desktop/My Shot.png')).toBe(true)
+    expect(isImageReferenceOnlyClipboardText('~/Pictures/cat.webp')).toBe(true)
+    expect(isImageReferenceOnlyClipboardText('file:///Users/jane/Desktop/shot.png')).toBe(true)
+    expect(isImageReferenceOnlyClipboardText('C:\\Users\\jane\\shot.png')).toBe(true)
+    expect(isImageReferenceOnlyClipboardText('\\\\share\\team\\shot.png')).toBe(true)
+  })
+
+  it('tolerates surrounding whitespace', () => {
+    expect(isImageReferenceOnlyClipboardText('  /tmp/shot.png\n')).toBe(true)
+  })
+
+  it('rejects ordinary text so the text fast path keeps winning', () => {
+    expect(isImageReferenceOnlyClipboardText('hello')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('   ')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('line one\nline two')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('a69ce28e1d092e0c8825cd1a109ac36409962bc1')).toBe(
+      false
+    )
+  })
+
+  it('rejects prose that merely ends in an image filename', () => {
+    expect(isImageReferenceOnlyClipboardText('see screenshot.png')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('shot.png')).toBe(false)
+  })
+
+  it('rejects non-image references', () => {
+    expect(isImageReferenceOnlyClipboardText('https://example.com/report.pdf')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('https://example.com/')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('/Users/jane/notes.txt')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('data:image/png;base64,iVBORw0KGgo=')).toBe(false)
+  })
+
+  it('rejects paths whose only dot is in a directory component', () => {
+    expect(isImageReferenceOnlyClipboardText('/home/jane.png/photo')).toBe(false)
+  })
+
+  it('rejects oversized text, including whitespace padding, before scanning it', () => {
+    expect(isImageReferenceOnlyClipboardText(`/tmp/${'a'.repeat(4096)}.png`)).toBe(false)
+    expect(isImageReferenceOnlyClipboardText(`${' '.repeat(8192)}/tmp/shot.png`)).toBe(false)
+  })
+
+  it('leaves known-residual shapes on the text path rather than over-matching', () => {
+    // Relative paths and extensions hiding in a query string or fragment stay
+    // text: over-matching prose would replace text the user meant to paste.
+    expect(isImageReferenceOnlyClipboardText('Desktop/photo.png')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('https://example.com/view?file=shot.png')).toBe(false)
+    expect(isImageReferenceOnlyClipboardText('https://example.com/view#shot.png')).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-image-reference-text.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-image-reference-text.ts
@@ -1,0 +1,71 @@
+import { isImageDropPath } from './terminal-drop-image-path'
+
+// Why: keep the check bounded so an oversized clipboard string never turns the
+// text fast path into a scan. The raw cap is applied before trimming, so a
+// clipboard padded with megabytes of whitespace cannot force a full pass.
+const MAX_IMAGE_REFERENCE_TEXT_LENGTH = 2048
+const MAX_IMAGE_REFERENCE_RAW_TEXT_LENGTH = 4096
+const LOCAL_IMAGE_PATH_PREFIX_RE = /^(?:~\/|\/|\\\\|[A-Za-z]:[\\/])/
+
+/**
+ * True when clipboard text is nothing but a reference to an image: a local
+ * path, a `file://` URL, or an `http(s)` URL whose last path segment names an
+ * image file.
+ *
+ * Why: some sources put BOTH an image and a text description of that image on
+ * the clipboard — a browser "Copy Image" adds the source URL, a file manager
+ * adds the file path. The text fast path in `pasteTerminalClipboard` then wins
+ * and the bitmap is dropped, so Cmd/Ctrl+V injects a URL the agent reads as
+ * text instead of the screenshot the user copied. Text that merely *names* the
+ * image is never the payload the user meant to paste, so the image may win.
+ * Ordinary text keeps the untouched text fast path, including rich copies from
+ * spreadsheets and slide editors that carry a TIFF flavor alongside the cells.
+ *
+ * Deliberately narrow: relative paths (`Desktop/photo.png`) and extensions that
+ * live only in a URL query string or fragment are not treated as references, so
+ * those clipboards still paste their text. Over-matching prose would be the
+ * worse failure, since it would replace text the user meant to paste.
+ */
+export function isImageReferenceOnlyClipboardText(text: string): boolean {
+  if (!text || text.length > MAX_IMAGE_REFERENCE_RAW_TEXT_LENGTH) {
+    return false
+  }
+  const trimmed = text.trim()
+  if (!trimmed || trimmed.length > MAX_IMAGE_REFERENCE_TEXT_LENGTH) {
+    return false
+  }
+  if (/[\r\n\t]/.test(trimmed)) {
+    return false
+  }
+  // Why: check the path shape first — a Windows path (`C:\…`) also parses as a
+  // URL with a one-letter scheme, so URL parsing must not claim it. Requiring a
+  // path-shaped prefix also keeps prose that happens to end in an image
+  // filename ("see screenshot.png") from counting as a reference.
+  if (LOCAL_IMAGE_PATH_PREFIX_RE.test(trimmed)) {
+    return isImageDropPath(trimmed)
+  }
+  const url = parseAbsoluteUrl(trimmed)
+  if (!url) {
+    return false
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:' && url.protocol !== 'file:') {
+    return false
+  }
+  return isImageDropPath(decodeUrlPathname(url.pathname))
+}
+
+function parseAbsoluteUrl(text: string): URL | null {
+  try {
+    return new URL(text)
+  } catch {
+    return null
+  }
+}
+
+function decodeUrlPathname(pathname: string): string {
+  try {
+    return decodeURIComponent(pathname)
+  } catch {
+    return pathname
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -186,6 +186,105 @@ describe('terminal clipboard paste', () => {
     expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
   })
 
+  it('bracket-pastes the image when the clipboard also carries the image source URL', async () => {
+    const pasteText = vi.fn()
+    const saveClipboardImageAsTempFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png')
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('https://example.com/assets/screenshot.png'),
+      saveClipboardImageAsTempFile,
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-id.png', {
+      forceBracketedPaste: true,
+      recoverImagePasteWebglAtlas: true
+    })
+    expect(pasteText).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ status: 'pasted', kind: 'image-path' })
+  })
+
+  it('bracket-pastes the image when the clipboard also carries the copied file path', async () => {
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('/Users/jane/Desktop/My Shot.png'),
+      saveClipboardImageAsTempFile: vi
+        .fn()
+        .mockResolvedValue('/tmp/orca-paste-1760000000000-id.png'),
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('/tmp/orca-paste-1760000000000-id.png', {
+      forceBracketedPaste: true,
+      recoverImagePasteWebglAtlas: true
+    })
+    expect(result).toEqual({ status: 'pasted', kind: 'image-path' })
+  })
+
+  it('falls back to the reference text when the clipboard holds no image bitmap', async () => {
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('https://example.com/assets/screenshot.png'),
+      saveClipboardImageAsTempFile: vi.fn().mockResolvedValue(null),
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('https://example.com/assets/screenshot.png')
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
+  })
+
+  it('reports image extraction failures and still pastes the reference text', async () => {
+    const imageError = new Error('no image data')
+    const pasteText = vi.fn()
+    const onImagePasteError = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('/Users/jane/Desktop/shot.png'),
+      saveClipboardImageAsTempFile: vi.fn().mockRejectedValue(imageError),
+      pasteText,
+      onImagePasteError
+    })
+
+    expect(onImagePasteError).toHaveBeenCalledWith(imageError)
+    expect(pasteText).toHaveBeenCalledWith('/Users/jane/Desktop/shot.png')
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
+  })
+
+  it('keeps whitespace-padded reference text on the text fast path', async () => {
+    const saveClipboardImageAsTempFile = vi.fn()
+    const pasteText = vi.fn()
+    const padded = `${' '.repeat(8192)}/tmp/shot.png`
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue(padded),
+      saveClipboardImageAsTempFile,
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith(padded)
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
+  })
+
+  it('keeps rich text copies that ship a bitmap flavor on the text fast path', async () => {
+    const saveClipboardImageAsTempFile = vi.fn()
+    const pasteText = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('Q1\t1200\nQ2\t1400'),
+      saveClipboardImageAsTempFile,
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('Q1\t1200\nQ2\t1400')
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
+  })
+
   it('reports text paste execution failures without probing for image fallback', async () => {
     const pasteError = new Error('terminal disconnected')
     const saveClipboardImageAsTempFile = vi.fn()

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -2,6 +2,7 @@ import {
   isClipboardTextTooLargeError,
   type ReadClipboardTextOptions
 } from '../../../../shared/clipboard-text'
+import { isImageReferenceOnlyClipboardText } from './terminal-clipboard-image-reference-text'
 import {
   TERMINAL_PASTE_MAX_BYTES,
   type TerminalPasteTextOptions
@@ -60,7 +61,10 @@ export async function pasteTerminalClipboard({
     // Why: browser clipboard text reads can fail for image-only clipboards.
     // Still try the image path so Cmd/Ctrl+V works for screenshots.
   }
-  if (text) {
+  // Why: a clipboard that carries an image plus text *naming* that image (browser
+  // "Copy Image", file managers) must not lose the bitmap to the text fast path.
+  const imageReferenceText = text.length > 0 && isImageReferenceOnlyClipboardText(text)
+  const pasteClipboardText = async (): Promise<TerminalClipboardPasteResult> => {
     try {
       const result = await (forceBracketedMultilineTextPaste
         ? pasteText(text, { forceBracketedPasteForMultiline: true })
@@ -74,11 +78,16 @@ export async function pasteTerminalClipboard({
       return { status: 'skipped', reason: 'text-paste-failed' }
     }
   }
+  if (text && !imageReferenceText) {
+    return pasteClipboardText()
+  }
 
   try {
     const filePath = await saveClipboardImageAsTempFile({ connectionId, runtimeEnvironmentId })
     if (!filePath) {
-      return { status: 'skipped', reason: 'empty' }
+      // Why: the text still described an image, but no bitmap came with it, so
+      // fall back to the paste the user would have gotten before this check.
+      return imageReferenceText ? pasteClipboardText() : { status: 'skipped', reason: 'empty' }
     }
     const result = await pasteText(filePath, {
       // Why: a generated clipboard-image path is terminal image injection, not
@@ -92,6 +101,12 @@ export async function pasteTerminalClipboard({
     return { status: 'pasted', kind: 'image-path' }
   } catch (error) {
     onImagePasteError?.(error)
+    if (imageReferenceText) {
+      // Why: report the image failure so a broken temp-file write is still
+      // visible, but keep the paste the user would have gotten before this
+      // check instead of dropping it entirely.
+      return pasteClipboardText()
+    }
     return { status: 'skipped', reason: 'image-paste-failed' }
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -63,7 +63,7 @@ export async function pasteTerminalClipboard({
   }
   // Why: a clipboard that carries an image plus text *naming* that image (browser
   // "Copy Image", file managers) must not lose the bitmap to the text fast path.
-  const imageReferenceText = text.length > 0 && isImageReferenceOnlyClipboardText(text)
+  const isImageReferenceText = text.length > 0 && isImageReferenceOnlyClipboardText(text)
   const pasteClipboardText = async (): Promise<TerminalClipboardPasteResult> => {
     try {
       const result = await (forceBracketedMultilineTextPaste
@@ -78,7 +78,7 @@ export async function pasteTerminalClipboard({
       return { status: 'skipped', reason: 'text-paste-failed' }
     }
   }
-  if (text && !imageReferenceText) {
+  if (text && !isImageReferenceText) {
     return pasteClipboardText()
   }
 
@@ -87,7 +87,7 @@ export async function pasteTerminalClipboard({
     if (!filePath) {
       // Why: the text still described an image, but no bitmap came with it, so
       // fall back to the paste the user would have gotten before this check.
-      return imageReferenceText ? pasteClipboardText() : { status: 'skipped', reason: 'empty' }
+      return isImageReferenceText ? pasteClipboardText() : { status: 'skipped', reason: 'empty' }
     }
     const result = await pasteText(filePath, {
       // Why: a generated clipboard-image path is terminal image injection, not
@@ -101,7 +101,7 @@ export async function pasteTerminalClipboard({
     return { status: 'pasted', kind: 'image-path' }
   } catch (error) {
     onImagePasteError?.(error)
-    if (imageReferenceText) {
+    if (isImageReferenceText) {
       // Why: report the image failure so a broken temp-file write is still
       // visible, but keep the paste the user would have gotten before this
       // check instead of dropping it entirely.


### PR DESCRIPTION
## Summary

Pasting a copied image into a terminal pane silently dropped the image whenever the clipboard also carried text that merely *named* that image — a browser "Copy Image" leaves the source URL on the clipboard, and file managers leave the file path. `pasteTerminalClipboard` read clipboard text first and returned as soon as text was non-empty, so Cmd/Ctrl+V injected the URL/path and the bitmap was discarded. Screenshot-only clipboards (no text flavor) worked fine, which made the failure look random to users.

Repro before this change (macOS, 1.4.145 and current `main`):

1. Put an image *and* a text flavor on the clipboard — e.g. `Copy Image` in a browser, or write both flavors to `NSPasteboard`.
2. Focus a terminal pane running a TUI agent and press Cmd+V.
3. The URL/path is pasted as text; no `orca-paste-*.png` temp file is ever created, so the agent never sees the picture.

After: the temp PNG is written and its path is bracket-pasted, exactly as it already works for screenshot-only clipboards.

The fix stays deliberately narrow. The image is only probed ahead of the text when the clipboard text is *nothing but* a reference to an image — a local path, a `file://` URL, or an `http(s)` URL whose last path segment has an image extension. Ordinary text keeps the untouched text fast path, which matters because rich copies from spreadsheets and slide editors ship a TIFF flavor alongside the cell text and must not turn into a PNG path. If the reference text turns out to have no bitmap behind it, the paste falls back to the text, so no existing paste gets worse.

## Screenshots

No visual change — terminal paste behavior only.

## Testing

- [x] `pnpm lint` — clean on the touched files (`oxlint` exit 0); the full run fails only on a pre-existing `max-lines` violation in `src/main/daemon/daemon-pty-router.ts:381` (304 > 300) that fails identically on unmodified `main`
- [x] `pnpm typecheck` — clean (all three projects)
- [x] `pnpm test` — the touched area is green: 34/34 in the two clipboard-paste files, 2842/2842 across `src/renderer/src/components/terminal-pane`. The full suite on this machine flakes under parallel load in unrelated main-process/relay/ssh/git files (8 files / 85 tests on this branch vs 9 files / 87 tests on unmodified `main`, overlapping but not identical sets; the ones I re-ran in isolation pass). No renderer or terminal-pane failures on either side.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

New tests cover the bug directly: image-plus-source-URL and image-plus-file-path clipboards must bracket-paste the temp image path; a reference-text clipboard with no bitmap must fall back to pasting the text; and a tab/newline-separated spreadsheet copy must stay on the text fast path without probing for an image. The pure `isImageReferenceOnlyClipboardText` helper has its own table of accept/reject cases, including Windows drive paths, UNC paths, percent-encoded URLs, `data:` URLs, non-image URLs, prose ending in `screenshot.png`, and oversized input.

## AI Review Report

Reviewed with an adversarial Codex pass told to attack rather than approve; it probed ~15 inputs outside the test suite (RTLO spoofing, control bytes, one-letter Windows-drive vs URL-scheme collision, double percent-encoding, `data:`/`javascript:`/`ftp:` schemes, query-string and fragment extensions, whitespace-padded huge strings) and scored the change 8/10 with two real findings, both now fixed in this branch:

1. *Swallowed error (medium).* The first draft returned the text fallback before calling `onImagePasteError`, so a genuine failure (permission denied, disk full) looked identical to "no image on the clipboard". The callback now fires before the fallback, and the test asserts it.
2. *Length gate placement (low).* The bound was applied after `trim()`, so a whitespace-padded clipboard still forced a full linear pass and contradicted the doc comment. A raw-length gate now runs first, with tests for both padded and oversized input.

It also flagged that relative paths and extensions living only in a URL query string or fragment stay on the text path; that is intentional (over-matching prose is the worse failure) and is now documented in the module comment and locked by a test.

Checked and confirmed:

- **Cross-platform.** POSIX separators, Windows drive paths (`C:\...`), and UNC paths (`\\server\share\...`) are matched by shape before URL parsing — deliberately, because a one-letter Windows drive prefix also parses as a URL scheme, so URL parsing must not claim it. Extension matching reuses the existing `isImageDropPath` helper, so it stays case-insensitive and ignores dots in directory components. No new shortcuts, labels, or platform-specific code paths.
- **Remote/SSH/web.** `connectionId` and `runtimeEnvironmentId` are still forwarded to `saveClipboardImageAsTempFile` unchanged, so SSH panes keep saving the bitmap on the remote host. The web client path (where `readClipboardText` can reject) is untouched; a rejected text read still falls through to the image probe.
- **Agent neutrality.** No agent-specific logic; the temp path goes out through the same bracketed-paste channel every supported TUI already consumes.
- **Performance.** The text fast path still performs zero image probes for ordinary text — the pre-existing tests asserting that are unchanged and still pass. The new check is a bounded prefix/extension test on at most 2048 characters, with no backtracking-prone regex.
- **UI.** No visual change.

## Security Audit

The new code parses untrusted clipboard text, so that was the focus.

- **ReDoS / unbounded work:** the two regexes are anchored and backtracking-free (`^(?:~\/|\/|\\\\|[A-Za-z]:[\\/])` and a `[\r\n\t]` character class); input is length-capped at 2048 characters before any scan, and extension matching is a `lastIndexOf` + `Set` lookup rather than a pattern match.
- **Injection:** this PR does not change what is written to the PTY. The pasted value is a path generated by the main process (`orca-paste-<ts>-<uuid>.png`), sent through the existing `forceBracketedPaste` channel; clipboard-supplied text is never promoted to a command, and no new shell interpolation or path joining is introduced.
- **Path handling:** clipboard text is only classified, never opened, resolved, or written; there is no new filesystem access, so no traversal surface.
- **IPC / secrets / deps:** no IPC surface, no credentials, no new dependencies.

Measured, not assumed: the classifier returns in ~0.2µs even on a 1 MB string, because the raw-length gate rejects before any trim or scan, and control-byte, RTLO (`‮`), `data:`, and `javascript:` inputs were probed directly. When the classifier says "reference", the value that reaches the PTY is either the main-process-generated `orca-paste-<ts>-<uuid>.png` path or — if no bitmap materializes — byte-identical to the text the pre-patch code already pasted, so there is no new execute-vs-quote surface.

One behavior change worth calling out: when the clipboard text is an image reference and image extraction *fails*, `onImagePasteError` is still reported and the paste then falls back to that text, so a broken temp-file write stays visible instead of looking like an empty clipboard.

## Notes

- Only `src/renderer/src/components/terminal-pane/` is touched; the native-chat composer already prefers the image on mixed clipboards, so this brings terminal paste in line with it.
- Verified by hand on macOS 15 (Apple silicon) against a live Claude Code TUI pane: with a mixed image+URL clipboard the paste now produces the temp PNG path and the agent reads the picture; the same clipboard pasted a bare URL before the change.
- No X handle to shout out — happy to be credited by GitHub username.
- Related open items this does not address: #7333 (move pasted temp images into an Orca-specific temp subdirectory) and #7786 (paste OS-copied *files* as shell-escaped paths — a Finder file copy with no bitmap flavor still pastes nothing).
