### PR TITLE
fix(ui): right-align Project detail in new workspace combobox

### DIFF
--- a/src/renderer/src/components/new-workspace/ProjectCombobox.tsx
+++ b/src/renderer/src/components/new-workspace/ProjectCombobox.tsx
@@ -204,7 +204,7 @@ export default function ProjectCombobox({
                   </span>
                   <ProjectOptionDetail
                     detail={selected.detail}
-                    className="min-w-0 flex-1 shrink-[999] justify-end text-xs text-muted-foreground"
+                    className="min-w-0 flex-1 shrink-[999] justify-end text-right text-xs text-muted-foreground"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Right-aligns the Project combobox detail text so it matches the Run on field layout.

Previously, short provider details like `stablyai/orca` sat next to the project name with only `gap-2` spacing (`justify-end` alone does nothing on the non-flex single-span detail path). Run on already used `text-right` so the path sat on the far right. Project now does the same.

## Screenshots

**Before** — detail sits next to the name:

![before-project-spaced.png](https://github.com/user-attachments/assets/1ed1bfc8-4033-49d0-954f-e2ddb16fe0c6)

**After** — Project detail right-aligned like Run on:

![project-runon-dialog.png](https://github.com/user-attachments/assets/4c1285cc-62c7-45da-8b54-3f7d476650ad)

Full Electron window (dev instance, CDP screenshot):

![project-detail-right-align.png](https://github.com/user-attachments/assets/7086b20a-cc65-4dec-aed7-3c0f27b6048b)

## Test plan

- [x] Open Create worktree dialog with a GitHub project selected
- [x] Confirm `stablyai/orca` (or other short detail) sits on the far right of the Project field, matching Run on
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/new-workspace/ProjectCombobox.test.tsx` (18 passed)
- [ ] Sanity-check a long path detail still truncates correctly from the left/head