### PR TITLE
Clarify Cloud VM setup in settings

### DIFF
--- a/src/renderer/src/components/settings/CloudVmSetupGuide.test.tsx
+++ b/src/renderer/src/components/settings/CloudVmSetupGuide.test.tsx
@@ -22,9 +22,11 @@ describe('CloudVmSetupGuide', () => {
     expect(container.textContent).toContain('Create a Cloud VM')
     expect(container.textContent).toContain('Create a workspace')
 
-    act(() => {
-      container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
+    const button = container.querySelector('button')
+    if (!button) {
+      throw new Error('Cloud VM setup button was not rendered')
+    }
+    act(() => button.dispatchEvent(new MouseEvent('click', { bubbles: true })))
 
     expect(useAppStore.getState().settingsNavigationTarget).toEqual({
       pane: 'experimental',

--- a/src/renderer/src/components/settings/CloudVmSetupGuide.test.tsx
+++ b/src/renderer/src/components/settings/CloudVmSetupGuide.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import { CloudVmSetupGuide } from './CloudVmSetupGuide'
+
+describe('CloudVmSetupGuide', () => {
+  afterEach(() => {
+    useAppStore.setState({ settingsNavigationTarget: null })
+    document.body.replaceChildren()
+  })
+
+  it('explains creation and opens environment recipe setup', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+
+    act(() => root.render(<CloudVmSetupGuide />))
+
+    expect(container.textContent).toContain('Create a Cloud VM')
+    expect(container.textContent).toContain('Create a workspace')
+
+    act(() => {
+      container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(useAppStore.getState().settingsNavigationTarget).toEqual({
+      pane: 'experimental',
+      repoId: null,
+      sectionId: 'ephemeral-vms'
+    })
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/components/settings/CloudVmSetupGuide.tsx
+++ b/src/renderer/src/components/settings/CloudVmSetupGuide.tsx
@@ -1,0 +1,54 @@
+import type React from 'react'
+import { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+
+export function CloudVmSetupGuide(): React.JSX.Element {
+  const openSettingsTarget = useAppStore((state) => state.openSettingsTarget)
+
+  return (
+    <section className="space-y-3" data-settings-section="cloud-vm-setup">
+      <div className="space-y-1">
+        <div className="text-sm font-medium">
+          {translate('auto.components.settings.CloudVmSetupGuide.title', 'Create a Cloud VM')}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.CloudVmSetupGuide.description',
+            'Cloud VMs are created from environment recipes when you create a workspace.'
+          )}
+        </p>
+      </div>
+      <ol className="ml-4 list-decimal space-y-1 text-xs text-muted-foreground">
+        <li>
+          {translate(
+            'auto.components.settings.CloudVmSetupGuide.setupRecipe',
+            'Set up an environment recipe for your cloud provider.'
+          )}
+        </li>
+        <li>
+          {translate(
+            'auto.components.settings.CloudVmSetupGuide.createWorkspace',
+            'Create a workspace and select that recipe under Run on.'
+          )}
+        </li>
+      </ol>
+      <Button
+        type="button"
+        size="sm"
+        onClick={() =>
+          openSettingsTarget({
+            pane: 'experimental',
+            repoId: null,
+            sectionId: 'ephemeral-vms'
+          })
+        }
+      >
+        {translate(
+          'auto.components.settings.CloudVmSetupGuide.openSetup',
+          'Set up environment recipes'
+        )}
+      </Button>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/EphemeralVmRuntimesSection.test.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmRuntimesSection.test.tsx
@@ -139,7 +139,9 @@ describe('EphemeralVmRuntimesSection', () => {
     const container = await renderSection()
 
     await vi.waitFor(() =>
-      expect(container.textContent).toContain('No Cloud VM runtimes need cleanup.')
+      expect(container.textContent).toContain(
+        'No Cloud VM runtimes yet. Create one from a workspace using an environment recipe.'
+      )
     )
   })
 

--- a/src/renderer/src/components/settings/EphemeralVmRuntimesSection.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmRuntimesSection.tsx
@@ -210,8 +210,8 @@ export function EphemeralVmRuntimesSection(): React.JSX.Element {
                   'Checking Cloud VM runtimes…'
                 )
               : translate(
-                  'auto.components.settings.EphemeralVmRuntimesSection.cloudVmEmpty',
-                  'No Cloud VM runtimes need cleanup.'
+                  'auto.components.settings.EphemeralVmRuntimesSection.cloudVmEmptyWithSetup',
+                  'No Cloud VM runtimes yet. Create one from a workspace using an environment recipe.'
                 )}
           </div>
         ) : (

--- a/src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmsExperimentalSetting.tsx
@@ -29,10 +29,7 @@ export function EphemeralVmsExperimentalSetting({
       <div className="flex max-w-3xl items-start justify-between gap-4">
         <div className="min-w-0 shrink space-y-0.5">
           <Label>
-            {translate(
-              'auto.components.settings.ephemeralVms.search.title',
-              'Per-Workspace Environments'
-            )}
+            {translate('auto.components.settings.ephemeralVms.search.cloudVmTitle', 'Cloud VM')}
           </Label>
           <p className="text-xs text-muted-foreground">
             {translate(
@@ -44,8 +41,8 @@ export function EphemeralVmsExperimentalSetting({
         <SettingsSwitch
           checked={enabled}
           ariaLabel={translate(
-            'auto.components.settings.ephemeralVmsExperimentalSetting.toggleLabel',
-            'Toggle per-workspace environments'
+            'auto.components.settings.ephemeralVmsExperimentalSetting.cloudVmToggleLabel',
+            'Toggle Cloud VM'
           )}
           onChange={() => updateSettings({ experimentalEphemeralVms: !enabled })}
         />

--- a/src/renderer/src/components/settings/EphemeralVmsPane.test.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmsPane.test.tsx
@@ -120,9 +120,7 @@ describe('EphemeralVmsPane', () => {
     const container = await renderPane()
 
     await vi.waitFor(() => expect(container.textContent).toContain('Cloud Sandbox'))
-    await vi.waitFor(() =>
-      expect(container.textContent).toContain('Per-Workspace Environments skill')
-    )
+    await vi.waitFor(() => expect(container.textContent).toContain('Cloud VM setup skill'))
     expect(container.textContent).toContain('What the skill does, with you')
     const useButton = [...container.querySelectorAll('button')].find(
       (button) => button.textContent === 'Use in workspace'

--- a/src/renderer/src/components/settings/EphemeralVmsPane.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmsPane.tsx
@@ -153,8 +153,14 @@ export function EphemeralVmsPane(): React.JSX.Element {
         )}
         command={installCommand}
         installedCommand={updateCommand}
-        terminalTitle="Cloud VM setup"
-        terminalAriaLabel="Cloud VM skill install terminal"
+        terminalTitle={translate(
+          'auto.components.settings.EphemeralVmsPane.cloudVmTerminalTitle',
+          'Cloud VM setup'
+        )}
+        terminalAriaLabel={translate(
+          'auto.components.settings.EphemeralVmsPane.cloudVmTerminalAriaLabel',
+          'Cloud VM skill install terminal'
+        )}
         terminalWorktreeId="settings-ephemeral-vms-skill-terminal"
         terminalShellOverride={activeSkillRuntime.terminalShellOverride}
         installed={skillDetected}

--- a/src/renderer/src/components/settings/EphemeralVmsPane.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmsPane.tsx
@@ -144,8 +144,8 @@ export function EphemeralVmsPane(): React.JSX.Element {
     <div className="space-y-6" data-settings-section="ephemeral-vms">
       <AgentSkillSetupPanel
         title={translate(
-          'auto.components.settings.EphemeralVmsPane.skillTitle',
-          'Per-Workspace Environments skill'
+          'auto.components.settings.EphemeralVmsPane.cloudVmSkillTitle',
+          'Cloud VM setup skill'
         )}
         description={translate(
           'auto.components.settings.EphemeralVmsPane.skillDescription',
@@ -153,8 +153,8 @@ export function EphemeralVmsPane(): React.JSX.Element {
         )}
         command={installCommand}
         installedCommand={updateCommand}
-        terminalTitle="Ephemeral VMs setup"
-        terminalAriaLabel="Ephemeral VMs skill install terminal"
+        terminalTitle="Cloud VM setup"
+        terminalAriaLabel="Cloud VM skill install terminal"
         terminalWorktreeId="settings-ephemeral-vms-skill-terminal"
         terminalShellOverride={activeSkillRuntime.terminalShellOverride}
         installed={skillDetected}
@@ -258,8 +258,8 @@ export function EphemeralVmsPane(): React.JSX.Element {
             variant="outline"
             size="icon-sm"
             aria-label={translate(
-              'auto.components.settings.EphemeralVmsPane.refresh',
-              'Refresh ephemeral VM recipes'
+              'auto.components.settings.EphemeralVmsPane.cloudVmRefresh',
+              'Refresh Cloud VM recipes'
             )}
             onClick={() => void refresh()}
             disabled={isLoading}

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -15,9 +15,7 @@ vi.mock('../../store', () => ({
 }))
 
 vi.mock('./EphemeralVmsPane', () => ({
-  EphemeralVmsPane: () => (
-    <div data-testid="ephemeral-vms-pane">Per-Workspace Environments pane</div>
-  )
+  EphemeralVmsPane: () => <div data-testid="ephemeral-vms-pane">Cloud VM pane</div>
 }))
 
 vi.mock('../ui/select', async () => {
@@ -191,23 +189,23 @@ describe('ExperimentalPane', () => {
     root.unmount()
   })
 
-  it('renders per-workspace environments as an off-by-default experimental subsection', () => {
+  it('renders Cloud VM as an off-by-default experimental subsection', () => {
     const settings = getDefaultSettings('/tmp')
     const markup = renderToStaticMarkup(
       <ExperimentalPane settings={settings} updateSettings={vi.fn()} />
     )
     const entry = getExperimentalPaneSearchEntries().find(
-      (searchEntry) => searchEntry.title === 'Per-Workspace Environments'
+      (searchEntry) => searchEntry.title === 'Cloud VM'
     )
 
     expect(settings.experimentalEphemeralVms).toBe(false)
-    expect(markup).toContain('Per-Workspace Environments')
+    expect(markup).toContain('Cloud VM')
     expect(markup).toContain('aria-checked="false"')
-    expect(markup).not.toContain('Per-Workspace Environments pane')
+    expect(markup).not.toContain('Cloud VM pane')
     expect(entry?.targetSectionId).toBe('ephemeral-vms')
   })
 
-  it('enables per-workspace environments through the experimental switch', async () => {
+  it('enables Cloud VM through the experimental switch', async () => {
     const updateSettings = vi.fn()
     const { root, container } = await renderExperimentalPane({ updateSettings })
 
@@ -215,7 +213,7 @@ describe('ExperimentalPane', () => {
       '#ephemeral-vms button[role="switch"]'
     )
     if (!switchButton) {
-      throw new Error('Per-workspace environments switch was not rendered')
+      throw new Error('Cloud VM switch was not rendered')
     }
 
     await act(async () => {
@@ -226,7 +224,7 @@ describe('ExperimentalPane', () => {
     root.unmount()
   })
 
-  it('shows per-workspace environment setup controls when enabled', () => {
+  it('shows Cloud VM setup controls when enabled', () => {
     const markup = renderToStaticMarkup(
       <ExperimentalPane
         settings={{ ...getDefaultSettings('/tmp'), experimentalEphemeralVms: true }}
@@ -234,7 +232,7 @@ describe('ExperimentalPane', () => {
       />
     )
 
-    expect(markup).toContain('Per-Workspace Environments pane')
+    expect(markup).toContain('Cloud VM pane')
     expect(markup).toContain('aria-checked="true"')
   })
 

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -47,6 +47,7 @@ import {
 } from '../ui/dialog'
 import { RuntimePairingUrlGenerator } from './RuntimePairingUrlGenerator'
 import { EphemeralVmRuntimesSection } from './EphemeralVmRuntimesSection'
+import { CloudVmSetupGuide } from './CloudVmSetupGuide'
 import {
   getRuntimeEnvironmentsSearchEntry,
   getWebRuntimeEnvironmentsSearchEntry
@@ -1116,7 +1117,8 @@ export function RuntimeEnvironmentsPane({
         </div>
       </div>
 
-      <div className={visibleWorkflow !== 'cloud-vm' ? 'hidden' : undefined}>
+      <div className={cn('space-y-5 pt-2', visibleWorkflow !== 'cloud-vm' && 'hidden')}>
+        <CloudVmSetupGuide />
         <EphemeralVmRuntimesSection />
       </div>
 

--- a/src/renderer/src/components/settings/ephemeral-vms-search.ts
+++ b/src/renderer/src/components/settings/ephemeral-vms-search.ts
@@ -5,10 +5,7 @@ import { createLocalizedCatalog } from '@/i18n/localized-catalog'
 
 export const getEphemeralVmsSearchEntry = createLocalizedCatalog(
   (): SettingsSearchEntry => ({
-    title: translate(
-      'auto.components.settings.ephemeralVms.search.title',
-      'Per-Workspace Environments'
-    ),
+    title: translate('auto.components.settings.ephemeralVms.search.cloudVmTitle', 'Cloud VM'),
     description: translate(
       'auto.components.settings.ephemeralVms.search.description',
       'Learn how repo-owned recipes give each workspace its own on-demand, disposable environment.'

--- a/src/renderer/src/components/settings/experimental-search.ts
+++ b/src/renderer/src/components/settings/experimental-search.ts
@@ -275,7 +275,7 @@ export function getExperimentalSearchEntry() {
       )
     ),
     ephemeralVms: findEntry(
-      translate('auto.components.settings.ephemeralVms.search.title', 'Per-Workspace Environments')
+      translate('auto.components.settings.ephemeralVms.search.cloudVmTitle', 'Cloud VM')
     )
   } as const
 }

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -116,7 +116,7 @@ describe('settings navigation metadata', () => {
     expect(sections.find((section) => section.id === 'voice')?.badge).toBeUndefined()
   })
 
-  it('places per-workspace environments under Experimental instead of as a beta sidebar item', () => {
+  it('places Cloud VM under Experimental instead of as a beta sidebar item', () => {
     const sections = buildSettingsNavigationMetadata({
       isMac: false,
       isWindows: false,
@@ -125,7 +125,7 @@ describe('settings navigation metadata', () => {
     })
     const experimental = sections.find((section) => section.id === 'experimental')
     const entry = experimental?.searchEntries.find(
-      (searchEntry) => searchEntry.title === 'Per-Workspace Environments'
+      (searchEntry) => searchEntry.title === 'Cloud VM'
     )
 
     expect(sections.map((section) => section.id)).not.toContain('ephemeral-vms')

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9459,12 +9459,14 @@
           "cloudVmTitle": "Cloud VM runtimes",
           "cloudVmRefresh": "Refresh Cloud VM runtimes",
           "cloudVmLoading": "Checking Cloud VM runtimes…",
-          "cloudVmEmpty": "No Cloud VM runtimes need cleanup."
+          "cloudVmEmpty": "No Cloud VM runtimes need cleanup.",
+          "cloudVmEmptyWithSetup": "No Cloud VM runtimes yet. Create one from a workspace using an environment recipe."
         },
         "ephemeralVms": {
           "search": {
             "title": "Per-Workspace Environments",
-            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment."
+            "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment.",
+            "cloudVmTitle": "Cloud VM"
           }
         },
         "EphemeralVmsPane": {
@@ -9483,11 +9485,14 @@
           "recipesHelp": "Recipes from orca.yaml and enabled plugins show up here, ready to launch a workspace on.",
           "refresh": "Refresh ephemeral VM recipes",
           "checking": "Checking recipes...",
-          "none": "No recipes found yet."
+          "none": "No recipes found yet.",
+          "cloudVmSkillTitle": "Cloud VM setup skill",
+          "cloudVmRefresh": "Refresh Cloud VM recipes"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
-          "toggleLabel": "Toggle per-workspace environments"
+          "toggleLabel": "Toggle per-workspace environments",
+          "cloudVmToggleLabel": "Toggle Cloud VM"
         },
         "SourceControlActionRepoOverrideNote": {
           "agent": "Agent",
@@ -9972,6 +9977,13 @@
           "notAttempted": "Not attempted",
           "saveFailed": "Could not save the host",
           "saveFailedHelp": "The host was verified, but Orca could not save it. Check the name and local settings storage, then try again."
+        },
+        "CloudVmSetupGuide": {
+          "title": "Create a Cloud VM",
+          "description": "Cloud VMs are created from environment recipes when you create a workspace.",
+          "setupRecipe": "Set up an environment recipe for your cloud provider.",
+          "createWorkspace": "Create a workspace and select that recipe under Run on.",
+          "openSetup": "Set up environment recipes"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9459,12 +9459,10 @@
           "cloudVmTitle": "Cloud VM runtimes",
           "cloudVmRefresh": "Refresh Cloud VM runtimes",
           "cloudVmLoading": "Checking Cloud VM runtimes…",
-          "cloudVmEmpty": "No Cloud VM runtimes need cleanup.",
           "cloudVmEmptyWithSetup": "No Cloud VM runtimes yet. Create one from a workspace using an environment recipe."
         },
         "ephemeralVms": {
           "search": {
-            "title": "Per-Workspace Environments",
             "description": "Learn how repo-owned recipes give each workspace its own on-demand, disposable environment.",
             "cloudVmTitle": "Cloud VM"
           }
@@ -9472,7 +9470,6 @@
         "EphemeralVmsPane": {
           "loadError": "Could not load recipes.",
           "copyError": "Could not copy the prompt.",
-          "skillTitle": "Per-Workspace Environments skill",
           "skillDescription": "Sets up, builds, authenticates, and validates repo-owned environment recipes.",
           "whatTitle": "What the skill does, with you",
           "whatScaffold": "Writes the recipe & scripts for your provider — connected over an Orca server or SSH.",
@@ -9483,7 +9480,6 @@
           "copied": "Copied",
           "recipes": "Recipes",
           "recipesHelp": "Recipes from orca.yaml and enabled plugins show up here, ready to launch a workspace on.",
-          "refresh": "Refresh ephemeral VM recipes",
           "checking": "Checking recipes...",
           "none": "No recipes found yet.",
           "cloudVmSkillTitle": "Cloud VM setup skill",
@@ -9491,7 +9487,6 @@
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",
-          "toggleLabel": "Toggle per-workspace environments",
           "cloudVmToggleLabel": "Toggle Cloud VM"
         },
         "SourceControlActionRepoOverrideNote": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9483,7 +9483,9 @@
           "checking": "Checking recipes...",
           "none": "No recipes found yet.",
           "cloudVmSkillTitle": "Cloud VM setup skill",
-          "cloudVmRefresh": "Refresh Cloud VM recipes"
+          "cloudVmRefresh": "Refresh Cloud VM recipes",
+          "cloudVmTerminalTitle": "Cloud VM setup",
+          "cloudVmTerminalAriaLabel": "Cloud VM skill install terminal"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "Shows setup controls and workspace run targets for repo-owned, on-demand environments.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9430,12 +9430,10 @@
           "cloudVmTitle": "Runtimes de VM en la nube",
           "cloudVmRefresh": "Actualizar runtimes de VM en la nube",
           "cloudVmLoading": "Comprobando runtimes de VM en la nube…",
-          "cloudVmEmpty": "Ningún runtime de VM en la nube necesita limpieza.",
           "cloudVmEmptyWithSetup": "Aún no hay runtimes de VM en la nube. Crea uno desde un espacio de trabajo mediante una receta de entorno."
         },
         "ephemeralVms": {
           "search": {
-            "title": "Entornos por espacio de trabajo",
             "description": "Aprende cómo las recetas del repositorio dan a cada espacio de trabajo su propio entorno desechable bajo demanda.",
             "cloudVmTitle": "VM en la nube"
           }
@@ -9443,7 +9441,6 @@
         "EphemeralVmsPane": {
           "loadError": "No se pudieron cargar las recetas.",
           "copyError": "No se pudo copiar el prompt.",
-          "skillTitle": "Skill de entornos por espacio de trabajo",
           "skillDescription": "Configura, construye, autentica y valida recetas de entornos del repositorio.",
           "whatTitle": "Lo que la skill hace contigo",
           "whatScaffold": "Escribe la receta y los scripts para tu proveedor, conectados mediante un servidor Orca o SSH.",
@@ -9454,7 +9451,6 @@
           "copied": "Copiado",
           "recipes": "Recetas",
           "recipesHelp": "Las recetas de orca.yaml y de los plugins activados aparecen aquí, listas para iniciar un espacio de trabajo.",
-          "refresh": "Actualizar recetas de VMs efímeras",
           "checking": "Comprobando recetas…",
           "none": "Aún no se han encontrado recetas.",
           "cloudVmSkillTitle": "Skill de configuración de VM en la nube",
@@ -9462,7 +9458,6 @@
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "Muestra controles de configuración y destinos de ejecución de espacios de trabajo para entornos bajo demanda del repositorio.",
-          "toggleLabel": "Activar o desactivar entornos por espacio de trabajo",
           "cloudVmToggleLabel": "Activar o desactivar VM en la nube"
         },
         "SourceControlActionRepoOverrideNote": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9454,7 +9454,9 @@
           "checking": "Comprobando recetas…",
           "none": "Aún no se han encontrado recetas.",
           "cloudVmSkillTitle": "Skill de configuración de VM en la nube",
-          "cloudVmRefresh": "Actualizar recetas de VM en la nube"
+          "cloudVmRefresh": "Actualizar recetas de VM en la nube",
+          "cloudVmTerminalTitle": "Configuración de VM en la nube",
+          "cloudVmTerminalAriaLabel": "Terminal de instalación de la skill de VM en la nube"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "Muestra controles de configuración y destinos de ejecución de espacios de trabajo para entornos bajo demanda del repositorio.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9430,12 +9430,14 @@
           "cloudVmTitle": "Runtimes de VM en la nube",
           "cloudVmRefresh": "Actualizar runtimes de VM en la nube",
           "cloudVmLoading": "Comprobando runtimes de VM en la nube…",
-          "cloudVmEmpty": "Ningún runtime de VM en la nube necesita limpieza."
+          "cloudVmEmpty": "Ningún runtime de VM en la nube necesita limpieza.",
+          "cloudVmEmptyWithSetup": "Aún no hay runtimes de VM en la nube. Crea uno desde un espacio de trabajo mediante una receta de entorno."
         },
         "ephemeralVms": {
           "search": {
             "title": "Entornos por espacio de trabajo",
-            "description": "Aprende cómo las recetas del repositorio dan a cada espacio de trabajo su propio entorno desechable bajo demanda."
+            "description": "Aprende cómo las recetas del repositorio dan a cada espacio de trabajo su propio entorno desechable bajo demanda.",
+            "cloudVmTitle": "VM en la nube"
           }
         },
         "EphemeralVmsPane": {
@@ -9454,11 +9456,14 @@
           "recipesHelp": "Las recetas de orca.yaml y de los plugins activados aparecen aquí, listas para iniciar un espacio de trabajo.",
           "refresh": "Actualizar recetas de VMs efímeras",
           "checking": "Comprobando recetas…",
-          "none": "Aún no se han encontrado recetas."
+          "none": "Aún no se han encontrado recetas.",
+          "cloudVmSkillTitle": "Skill de configuración de VM en la nube",
+          "cloudVmRefresh": "Actualizar recetas de VM en la nube"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "Muestra controles de configuración y destinos de ejecución de espacios de trabajo para entornos bajo demanda del repositorio.",
-          "toggleLabel": "Activar o desactivar entornos por espacio de trabajo"
+          "toggleLabel": "Activar o desactivar entornos por espacio de trabajo",
+          "cloudVmToggleLabel": "Activar o desactivar VM en la nube"
         },
         "SourceControlActionRepoOverrideNote": {
           "agent": "Agente",
@@ -9941,6 +9946,13 @@
           "endpointKind": "Tipo de destino",
           "networkConnection": "Conexión de red",
           "notAttempted": "No se intentó"
+        },
+        "CloudVmSetupGuide": {
+          "title": "Crear una VM en la nube",
+          "description": "Las VMs en la nube se crean a partir de recetas de entorno al crear un espacio de trabajo.",
+          "setupRecipe": "Configura una receta de entorno para tu proveedor de nube.",
+          "createWorkspace": "Crea un espacio de trabajo y selecciona esa receta en Ejecutar en.",
+          "openSetup": "Configurar recetas de entorno"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9430,12 +9430,14 @@
           "cloudVmTitle": "クラウド VM ランタイム",
           "cloudVmRefresh": "クラウド VM ランタイムを更新",
           "cloudVmLoading": "クラウド VM ランタイムを確認中…",
-          "cloudVmEmpty": "クリーンアップが必要なクラウド VM ランタイムはありません。"
+          "cloudVmEmpty": "クリーンアップが必要なクラウド VM ランタイムはありません。",
+          "cloudVmEmptyWithSetup": "クラウド VM ランタイムはまだありません。環境レシピを使用してワークスペースから作成してください。"
         },
         "ephemeralVms": {
           "search": {
             "title": "ワークスペースごとの環境",
-            "description": "repo 所有のレシピが各ワークスペースに独自のオンデマンドの使い捨て環境を与える方法を学びましょう。"
+            "description": "repo 所有のレシピが各ワークスペースに独自のオンデマンドの使い捨て環境を与える方法を学びましょう。",
+            "cloudVmTitle": "クラウド VM"
           }
         },
         "EphemeralVmsPane": {
@@ -9454,11 +9456,14 @@
           "recipesHelp": "orca.yaml と有効なプラグインのレシピがここに表示され、ワークスペースを起動できます。",
           "refresh": "一時的な VM レシピを更新する",
           "checking": "レシピを確認中...",
-          "none": "レシピはまだ見つかりません。"
+          "none": "レシピはまだ見つかりません。",
+          "cloudVmSkillTitle": "クラウド VM セットアップスキル",
+          "cloudVmRefresh": "クラウド VM レシピを更新"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "repo が所有するオンデマンド環境のセットアップ コントロールとワークスペース実行ターゲットを示します。",
-          "toggleLabel": "ワークスペースごとの環境を切り替える"
+          "toggleLabel": "ワークスペースごとの環境を切り替える",
+          "cloudVmToggleLabel": "クラウド VM を切り替える"
         },
         "SourceControlActionRepoOverrideNote": {
           "agent": "エージェント",
@@ -9941,6 +9946,13 @@
           "endpointKind": "接続先の種類",
           "networkConnection": "ネットワーク接続",
           "notAttempted": "未試行"
+        },
+        "CloudVmSetupGuide": {
+          "title": "クラウド VM を作成",
+          "description": "クラウド VM は、ワークスペースの作成時に環境レシピから作成されます。",
+          "setupRecipe": "クラウドプロバイダー用の環境レシピをセットアップします。",
+          "createWorkspace": "ワークスペースを作成し、「実行先」でそのレシピを選択します。",
+          "openSetup": "環境レシピをセットアップ"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9430,12 +9430,10 @@
           "cloudVmTitle": "クラウド VM ランタイム",
           "cloudVmRefresh": "クラウド VM ランタイムを更新",
           "cloudVmLoading": "クラウド VM ランタイムを確認中…",
-          "cloudVmEmpty": "クリーンアップが必要なクラウド VM ランタイムはありません。",
           "cloudVmEmptyWithSetup": "クラウド VM ランタイムはまだありません。環境レシピを使用してワークスペースから作成してください。"
         },
         "ephemeralVms": {
           "search": {
-            "title": "ワークスペースごとの環境",
             "description": "repo 所有のレシピが各ワークスペースに独自のオンデマンドの使い捨て環境を与える方法を学びましょう。",
             "cloudVmTitle": "クラウド VM"
           }
@@ -9443,7 +9441,6 @@
         "EphemeralVmsPane": {
           "loadError": "レシピを読み込めませんでした。",
           "copyError": "プロンプトをコピーできませんでした。",
-          "skillTitle": "ワークスペースごとの環境スキル",
           "skillDescription": "repo が所有する環境レシピをセットアップ、構築、認証、および検証します。",
           "whatTitle": "スキルが何をするのか、あなたと一緒に",
           "whatScaffold": "Orca サーバーまたは SSH 経由で接続されているプロバイダーのレシピとスクリプトを作成します。",
@@ -9454,7 +9451,6 @@
           "copied": "コピーされました",
           "recipes": "レシピ",
           "recipesHelp": "orca.yaml と有効なプラグインのレシピがここに表示され、ワークスペースを起動できます。",
-          "refresh": "一時的な VM レシピを更新する",
           "checking": "レシピを確認中...",
           "none": "レシピはまだ見つかりません。",
           "cloudVmSkillTitle": "クラウド VM セットアップスキル",
@@ -9462,7 +9458,6 @@
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "repo が所有するオンデマンド環境のセットアップ コントロールとワークスペース実行ターゲットを示します。",
-          "toggleLabel": "ワークスペースごとの環境を切り替える",
           "cloudVmToggleLabel": "クラウド VM を切り替える"
         },
         "SourceControlActionRepoOverrideNote": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9454,7 +9454,9 @@
           "checking": "レシピを確認中...",
           "none": "レシピはまだ見つかりません。",
           "cloudVmSkillTitle": "クラウド VM セットアップスキル",
-          "cloudVmRefresh": "クラウド VM レシピを更新"
+          "cloudVmRefresh": "クラウド VM レシピを更新",
+          "cloudVmTerminalTitle": "クラウド VM のセットアップ",
+          "cloudVmTerminalAriaLabel": "クラウド VM スキルインストールターミナル"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "repo が所有するオンデマンド環境のセットアップ コントロールとワークスペース実行ターゲットを示します。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9454,7 +9454,9 @@
           "checking": "레시피 확인 중...",
           "none": "아직 레시피를 찾을 수 없습니다.",
           "cloudVmSkillTitle": "클라우드 VM 설정 스킬",
-          "cloudVmRefresh": "클라우드 VM 레시피 새로 고침"
+          "cloudVmRefresh": "클라우드 VM 레시피 새로 고침",
+          "cloudVmTerminalTitle": "클라우드 VM 설정",
+          "cloudVmTerminalAriaLabel": "클라우드 VM 스킬 설치 터미널"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "repo 소유 온디맨드 환경에 대한 설정 제어 및 워크스페이스 실행 대상을 표시합니다.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9430,12 +9430,14 @@
           "cloudVmTitle": "클라우드 VM 런타임",
           "cloudVmRefresh": "클라우드 VM 런타임 새로 고침",
           "cloudVmLoading": "클라우드 VM 런타임 확인 중…",
-          "cloudVmEmpty": "정리가 필요한 클라우드 VM 런타임이 없습니다."
+          "cloudVmEmpty": "정리가 필요한 클라우드 VM 런타임이 없습니다.",
+          "cloudVmEmptyWithSetup": "아직 클라우드 VM 런타임이 없습니다. 환경 레시피를 사용해 워크스페이스에서 생성하세요."
         },
         "ephemeralVms": {
           "search": {
             "title": "워크스페이스별 환경",
-            "description": "repo 소유 레시피가 각 워크스페이스에 고유한 주문형 일회용 환경을 제공하는 방법을 알아보세요."
+            "description": "repo 소유 레시피가 각 워크스페이스에 고유한 주문형 일회용 환경을 제공하는 방법을 알아보세요.",
+            "cloudVmTitle": "클라우드 VM"
           }
         },
         "EphemeralVmsPane": {
@@ -9454,11 +9456,14 @@
           "recipesHelp": "orca.yaml과 활성화된 플러그인의 레시피가 여기에 표시되어 워크스페이스를 시작할 수 있습니다.",
           "refresh": "임시 VM 레시피 새로 고침",
           "checking": "레시피 확인 중...",
-          "none": "아직 레시피를 찾을 수 없습니다."
+          "none": "아직 레시피를 찾을 수 없습니다.",
+          "cloudVmSkillTitle": "클라우드 VM 설정 스킬",
+          "cloudVmRefresh": "클라우드 VM 레시피 새로 고침"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "repo 소유 온디맨드 환경에 대한 설정 제어 및 워크스페이스 실행 대상을 표시합니다.",
-          "toggleLabel": "워크스페이스별 환경 전환"
+          "toggleLabel": "워크스페이스별 환경 전환",
+          "cloudVmToggleLabel": "클라우드 VM 전환"
         },
         "SourceControlActionRepoOverrideNote": {
           "agent": "에이전트",
@@ -9941,6 +9946,13 @@
           "endpointKind": "대상 유형",
           "networkConnection": "네트워크 연결",
           "notAttempted": "시도하지 않음"
+        },
+        "CloudVmSetupGuide": {
+          "title": "클라우드 VM 만들기",
+          "description": "클라우드 VM은 워크스페이스를 만들 때 환경 레시피에서 생성됩니다.",
+          "setupRecipe": "클라우드 공급자를 위한 환경 레시피를 설정하세요.",
+          "createWorkspace": "워크스페이스를 만들고 실행 위치에서 해당 레시피를 선택하세요.",
+          "openSetup": "환경 레시피 설정"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9430,12 +9430,10 @@
           "cloudVmTitle": "클라우드 VM 런타임",
           "cloudVmRefresh": "클라우드 VM 런타임 새로 고침",
           "cloudVmLoading": "클라우드 VM 런타임 확인 중…",
-          "cloudVmEmpty": "정리가 필요한 클라우드 VM 런타임이 없습니다.",
           "cloudVmEmptyWithSetup": "아직 클라우드 VM 런타임이 없습니다. 환경 레시피를 사용해 워크스페이스에서 생성하세요."
         },
         "ephemeralVms": {
           "search": {
-            "title": "워크스페이스별 환경",
             "description": "repo 소유 레시피가 각 워크스페이스에 고유한 주문형 일회용 환경을 제공하는 방법을 알아보세요.",
             "cloudVmTitle": "클라우드 VM"
           }
@@ -9443,7 +9441,6 @@
         "EphemeralVmsPane": {
           "loadError": "레시피를 로드할 수 없습니다.",
           "copyError": "프롬프트를 복사할 수 없습니다.",
-          "skillTitle": "워크스페이스별 환경 기술",
           "skillDescription": "repo 소유 환경 레시피를 설정, 빌드, 인증 및 검증합니다.",
           "whatTitle": "당신과 함께 기술이 하는 일",
           "whatScaffold": "Orca 서버 또는 SSH를 통해 연결된 공급자를 위한 레시피 및 스크립트를 작성합니다.",
@@ -9454,7 +9451,6 @@
           "copied": "복사됨",
           "recipes": "조리법",
           "recipesHelp": "orca.yaml과 활성화된 플러그인의 레시피가 여기에 표시되어 워크스페이스를 시작할 수 있습니다.",
-          "refresh": "임시 VM 레시피 새로 고침",
           "checking": "레시피 확인 중...",
           "none": "아직 레시피를 찾을 수 없습니다.",
           "cloudVmSkillTitle": "클라우드 VM 설정 스킬",
@@ -9462,7 +9458,6 @@
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "repo 소유 온디맨드 환경에 대한 설정 제어 및 워크스페이스 실행 대상을 표시합니다.",
-          "toggleLabel": "워크스페이스별 환경 전환",
           "cloudVmToggleLabel": "클라우드 VM 전환"
         },
         "SourceControlActionRepoOverrideNote": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9430,12 +9430,10 @@
           "cloudVmTitle": "云虚拟机运行时",
           "cloudVmRefresh": "刷新云虚拟机运行时",
           "cloudVmLoading": "正在检查云虚拟机运行时…",
-          "cloudVmEmpty": "没有需要清理的云虚拟机运行时。",
           "cloudVmEmptyWithSetup": "还没有云虚拟机运行时。请在创建工作区时使用环境模板来创建。"
         },
         "ephemeralVms": {
           "search": {
-            "title": "工作区专属环境",
             "description": "了解仓库自带的环境模板如何为每个工作区提供按需创建、可丢弃的独立环境。",
             "cloudVmTitle": "云虚拟机"
           }
@@ -9443,7 +9441,6 @@
         "EphemeralVmsPane": {
           "loadError": "无法加载环境模板。",
           "copyError": "无法复制提示词。",
-          "skillTitle": "工作区专属环境技能",
           "skillDescription": "设置、构建、认证并验证仓库自带的环境模板。",
           "whatTitle": "此技能会与你一起完成",
           "whatScaffold": "为你的提供商编写环境模板和脚本，可通过 Orca 服务器或 SSH 连接。",
@@ -9454,7 +9451,6 @@
           "copied": "已复制",
           "recipes": "环境模板",
           "recipesHelp": "orca.yaml 和已启用插件中的配方会显示在这里，可用于启动工作区。",
-          "refresh": "刷新临时 VM 环境模板",
           "checking": "正在检查环境模板...",
           "none": "还没有找到环境模板。",
           "cloudVmSkillTitle": "云虚拟机设置技能",
@@ -9462,7 +9458,6 @@
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "显示仓库自带按需环境的设置控件和工作区运行目标。",
-          "toggleLabel": "切换工作区专属环境",
           "cloudVmToggleLabel": "切换云虚拟机"
         },
         "SourceControlActionRepoOverrideNote": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9430,12 +9430,14 @@
           "cloudVmTitle": "云虚拟机运行时",
           "cloudVmRefresh": "刷新云虚拟机运行时",
           "cloudVmLoading": "正在检查云虚拟机运行时…",
-          "cloudVmEmpty": "没有需要清理的云虚拟机运行时。"
+          "cloudVmEmpty": "没有需要清理的云虚拟机运行时。",
+          "cloudVmEmptyWithSetup": "还没有云虚拟机运行时。请在创建工作区时使用环境模板来创建。"
         },
         "ephemeralVms": {
           "search": {
             "title": "工作区专属环境",
-            "description": "了解仓库自带的环境模板如何为每个工作区提供按需创建、可丢弃的独立环境。"
+            "description": "了解仓库自带的环境模板如何为每个工作区提供按需创建、可丢弃的独立环境。",
+            "cloudVmTitle": "云虚拟机"
           }
         },
         "EphemeralVmsPane": {
@@ -9454,11 +9456,14 @@
           "recipesHelp": "orca.yaml 和已启用插件中的配方会显示在这里，可用于启动工作区。",
           "refresh": "刷新临时 VM 环境模板",
           "checking": "正在检查环境模板...",
-          "none": "还没有找到环境模板。"
+          "none": "还没有找到环境模板。",
+          "cloudVmSkillTitle": "云虚拟机设置技能",
+          "cloudVmRefresh": "刷新云虚拟机环境模板"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "显示仓库自带按需环境的设置控件和工作区运行目标。",
-          "toggleLabel": "切换工作区专属环境"
+          "toggleLabel": "切换工作区专属环境",
+          "cloudVmToggleLabel": "切换云虚拟机"
         },
         "SourceControlActionRepoOverrideNote": {
           "agent": "智能体",
@@ -9941,6 +9946,13 @@
           "endpointKind": "端点类型",
           "networkConnection": "网络连接",
           "notAttempted": "未尝试"
+        },
+        "CloudVmSetupGuide": {
+          "title": "创建云虚拟机",
+          "description": "云虚拟机会在创建工作区时通过环境模板创建。",
+          "setupRecipe": "为你的云提供商设置环境模板。",
+          "createWorkspace": "创建工作区，并在“运行于”中选择该模板。",
+          "openSetup": "设置环境模板"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9454,7 +9454,9 @@
           "checking": "正在检查环境模板...",
           "none": "还没有找到环境模板。",
           "cloudVmSkillTitle": "云虚拟机设置技能",
-          "cloudVmRefresh": "刷新云虚拟机环境模板"
+          "cloudVmRefresh": "刷新云虚拟机环境模板",
+          "cloudVmTerminalTitle": "云虚拟机设置",
+          "cloudVmTerminalAriaLabel": "云虚拟机技能安装终端"
         },
         "ephemeralVmsExperimentalSetting": {
           "description": "显示仓库自带按需环境的设置控件和工作区运行目标。",


### PR DESCRIPTION
## Summary

- rename the experimental per-workspace environment surfaces to Cloud VM
- add an actionable Cloud VM setup guide and clearer empty runtime state
- localize the new guidance consistently across English, Spanish, Japanese, Korean, and Chinese

## Screenshots

Live Electron review completed for Remote Orca Servers → Cloud VM and the setup navigation flow in dark mode with the Chinese locale. No screenshot attached from the CLI.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 41,411 passed; one unrelated GitHub Project test timed out under full-suite load and passed 2/2 immediately in isolation
- [x] `pnpm build:electron-vite`
- [x] `pnpm build:web`
- [x] Added or updated focused tests for setup navigation, empty-state copy, search metadata, and the experimental setting

## AI Review Report

Ran two review/fix rounds plus a post-rebase review. The review checked functionality, performance, empty-state acquisition, action hierarchy, settings navigation, copy clarity, localization coverage, SSH and folder-workspace behavior, and macOS/Linux/Windows compatibility. It flagged mixed Chinese terminology and missing Spanish/Japanese/Korean strings; both were fixed. Live Electron QA verified the Cloud VM workflow, off-by-default toggle, setup navigation, empty state, and localized labels. No hot-path work, additional IPC, platform-specific shortcut, path, shell, or Electron behavior was introduced.

## Security Audit

The change adds static settings copy and uses the existing typed settings navigation action. It introduces no new user input, command execution, filesystem/path handling, IPC surface, authentication, secrets, dependencies, or external requests.

## Notes

The branch is rebased onto current `main`. Cloud VM setup continues to use the existing host-aware skill runtime, so native, WSL, SSH, and folder-workspace behavior remains unchanged.