### PR TITLE
fix(sidebar): stop background workspace creation from scrolling the sidebar

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -36064,10 +36064,13 @@ describe('OrcaRuntimeService', () => {
       (spawn.mock.calls[1]?.[0] as { env?: Record<string, string> } | undefined)?.env ?? {}
     expectStablePaneKeyEnv(setupSpawnEnv)
     const setupLeafId = setupSpawnEnv.ORCA_PANE_KEY.slice(`${setupSpawnEnv.ORCA_TAB_ID}:`.length)
+    // Why: a background CLI create adopts its tabs silently — surfaceOwner:false
+    // keeps the sidebar from scrolling to a workspace the user never asked for.
     expect(revealTerminalSession).toHaveBeenLastCalledWith(result.worktree.id, {
       ptyId: 'pty-setup',
       title: 'Setup',
       activate: false,
+      surfaceOwner: false,
       tabId: setupSpawnEnv.ORCA_TAB_ID,
       leafId: setupLeafId
     })
@@ -36303,13 +36306,192 @@ describe('OrcaRuntimeService', () => {
     const initialLeafId = initialSpawnEnv.ORCA_PANE_KEY.slice(
       `${initialSpawnEnv.ORCA_TAB_ID}:`.length
     )
+    // Why: the renderer treats a missing surfaceOwner as "reveal the owner", which
+    // scrolled the sidebar to background CLI creates.
     expect(revealTerminalSession).toHaveBeenCalledWith(result.worktree.id, {
       ptyId: 'pty-created-worktree',
       title: null,
       activate: false,
+      surfaceOwner: false,
       tabId: initialSpawnEnv.ORCA_TAB_ID,
       leafId: initialLeafId
     })
+  })
+
+  it('does not surface the new workspace when a background CLI create launches its agent', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const activateWorktree = vi.fn()
+    const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-background-agent' })
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-background-agent' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree,
+      createTerminal: vi.fn(),
+      revealTerminalSession,
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-background-agent')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-background-agent')
+    vi.mocked(getEffectiveHooks).mockReturnValue(null)
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-background-agent',
+        head: 'def',
+        branch: 'runtime-background-agent',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'runtime-background-agent',
+      createdWithAgent: 'claude',
+      startup: { command: 'claude' }
+    })
+
+    // `orca worktree create --agent claude` without --activate: the agent tab is
+    // adopted, but the sidebar must stay on whatever the user was reading.
+    expect(activateWorktree).not.toHaveBeenCalled()
+    expect(revealTerminalSession).toHaveBeenCalledWith(
+      result.worktree.id,
+      expect.objectContaining({
+        ptyId: 'pty-background-agent',
+        activate: false,
+        surfaceOwner: false
+      })
+    )
+  })
+
+  it('still surfaces the new workspace when the caller explicitly activates it', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-activated-agent' })
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-activated-agent' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession,
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-activated-agent')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-activated-agent')
+    vi.mocked(getEffectiveHooks).mockReturnValue(null)
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-activated-agent',
+        head: 'def',
+        branch: 'runtime-activated-agent',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'runtime-activated-agent',
+      activate: true,
+      createdWithAgent: 'claude',
+      startup: { command: 'claude' }
+    })
+
+    // No-regression guard: an explicit --activate still reveals the workspace, so
+    // surfaceOwner must stay absent.
+    const revealPayload = revealTerminalSession.mock.calls[0]?.[1] as
+      | { surfaceOwner?: boolean }
+      | undefined
+    expect(revealTerminalSession).toHaveBeenCalledWith(
+      result.worktree.id,
+      expect.objectContaining({ ptyId: 'pty-activated-agent' })
+    )
+    expect(revealPayload).not.toHaveProperty('surfaceOwner')
+  })
+
+  it('still surfaces the new workspace when hooks run in the foreground', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-hooks-agent' })
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-hooks-agent' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession,
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-hooks-agent')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-hooks-agent')
+    vi.mocked(getEffectiveHooks).mockReturnValue(null)
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-hooks-agent',
+        head: 'def',
+        branch: 'runtime-hooks-agent',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'runtime-hooks-agent',
+      runHooks: true,
+      createdWithAgent: 'claude',
+      startup: { command: 'claude' }
+    })
+
+    const revealPayload = revealTerminalSession.mock.calls[0]?.[1] as
+      | { surfaceOwner?: boolean }
+      | undefined
+    expect(revealTerminalSession).toHaveBeenCalledWith(
+      result.worktree.id,
+      expect.objectContaining({ ptyId: 'pty-hooks-agent' })
+    )
+    expect(revealPayload).not.toHaveProperty('surfaceOwner')
   })
 
   it('honors split setup placement for CLI-created worktrees without startup agents', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -36582,6 +36582,172 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('does not surface the new workspace when a background create splits its setup pane', async () => {
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        setupScriptLaunchMode: 'split-horizontal' as const
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const activateWorktree = vi.fn()
+    const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-bg-setup-split' })
+    const spawn = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'pty-bg-split-main' })
+      .mockResolvedValueOnce({ id: 'pty-bg-split-setup' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree,
+      createTerminal: vi.fn(),
+      revealTerminalSession,
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-bg-split-setup')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-bg-split-setup')
+    vi.mocked(getEffectiveHooks).mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    vi.mocked(shouldRunSetupForCreate).mockReturnValue(true)
+    vi.mocked(createSetupRunnerScript).mockReturnValue({
+      runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
+      envVars: {
+        ORCA_ROOT_PATH: '/tmp/repo',
+        ORCA_WORKTREE_PATH: '/tmp/workspaces/runtime-bg-split-setup'
+      }
+    })
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-bg-split-setup',
+        head: 'def',
+        branch: 'runtime-bg-split-setup',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'runtime-bg-split-setup',
+      setupDecision: 'run'
+    })
+
+    // Split launch modes reach the renderer through splitTerminal, not
+    // createTerminal — that path must suppress owner surfacing too.
+    expect(activateWorktree).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2))
+    const mainEnv = (spawn.mock.calls[0]![0] as { env?: Record<string, string> }).env ?? {}
+    await vi.waitFor(() =>
+      expect(revealTerminalSession).toHaveBeenLastCalledWith(
+        result.worktree.id,
+        expect.objectContaining({
+          ptyId: 'pty-bg-split-setup',
+          tabId: mainEnv.ORCA_TAB_ID,
+          activate: false,
+          surfaceOwner: false,
+          splitDirection: 'horizontal'
+        })
+      )
+    )
+  })
+
+  it('still surfaces the new workspace when an activating create splits its setup pane', async () => {
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        setupScriptLaunchMode: 'split-horizontal' as const
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    const revealTerminalSession = vi.fn().mockResolvedValue({ tabId: 'tab-active-setup-split' })
+    const spawn = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'pty-active-split-main' })
+      .mockResolvedValueOnce({ id: 'pty-active-split-setup' })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession,
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    })
+    runtime.attachWindow(1)
+
+    computeWorktreePathMock.mockReturnValue('/tmp/workspaces/runtime-active-split-setup')
+    ensurePathWithinWorkspaceMock.mockReturnValue('/tmp/workspaces/runtime-active-split-setup')
+    vi.mocked(getEffectiveHooks).mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    vi.mocked(shouldRunSetupForCreate).mockReturnValue(true)
+    vi.mocked(createSetupRunnerScript).mockReturnValue({
+      runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
+      envVars: {
+        ORCA_ROOT_PATH: '/tmp/repo',
+        ORCA_WORKTREE_PATH: '/tmp/workspaces/runtime-active-split-setup'
+      }
+    })
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: '/tmp/workspaces/runtime-active-split-setup',
+        head: 'def',
+        branch: 'runtime-active-split-setup',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = await runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'runtime-active-split-setup',
+      activate: true,
+      setupDecision: 'run',
+      createdWithAgent: 'claude',
+      startup: { command: 'claude' }
+    })
+
+    // No-regression guard: an explicit --activate still reveals the workspace.
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() =>
+      expect(revealTerminalSession).toHaveBeenLastCalledWith(
+        result.worktree.id,
+        expect.objectContaining({
+          ptyId: 'pty-active-split-setup',
+          splitDirection: 'horizontal'
+        })
+      )
+    )
+    const splitRevealPayload = revealTerminalSession.mock.lastCall?.[1] as
+      | { surfaceOwner?: boolean }
+      | undefined
+    expect(splitRevealPayload).not.toHaveProperty('surfaceOwner')
+  })
+
   it('does not warn when setup is explicitly skipped for CLI-created worktrees', async () => {
     const metaById: Record<string, WorktreeMeta> = {}
     const runtimeStore = {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1274,7 +1274,7 @@ type TerminalCreateOptions = {
   // Why: `false` adopts the terminal without pointing the user at it — no
   // sidebar reveal, no tab focus. Distinct from 'background' presentation,
   // which skips renderer adoption entirely.
-  surfaceOwner?: boolean
+  surfaceOwner?: false
   tabId?: string
   leafId?: string
   sessionId?: string
@@ -1658,6 +1658,12 @@ function createTerminalRevealWarning(handle: string, error?: unknown): string {
   ].join(' ')
 }
 
+// Why: an absent `surfaceOwner` means "default", so surfacing callers must omit
+// the key rather than send `true`.
+function ownerSurfacing(shouldSurface: boolean): { surfaceOwner?: false } {
+  return shouldSurface ? {} : { surfaceOwner: false }
+}
+
 function resolveTerminalPresentation(opts: {
   presentation?: RuntimeTerminalPresentation
   focus?: boolean
@@ -1706,7 +1712,7 @@ type RuntimeNotifier = {
       viewMode?: 'terminal' | 'chat'
       activate?: boolean
       presentation?: RuntimeTerminalPresentation
-      surfaceOwner?: boolean
+      surfaceOwner?: false
       tabId?: string
       leafId?: string
       splitFromLeafId?: string
@@ -19948,7 +19954,7 @@ export class OrcaRuntimeService {
     worktreeSelector: string,
     worktreeId: string,
     defaultTabs: CreateWorktreeResult['defaultTabs'] | undefined,
-    surfaceOwner?: boolean
+    surfacing: { surfaceOwner?: false } = {}
   ): Promise<string[]> {
     if (!defaultTabs || defaultTabs.tabs.length === 0 || !this.ptyController?.spawn) {
       return []
@@ -19960,7 +19966,7 @@ export class OrcaRuntimeService {
         const terminal = await this.createTerminal(worktreeSelector, {
           ...(template.title ? { title: template.title } : {}),
           ...(command && defaultTabs.runCommands ? { command } : {}),
-          ...(surfaceOwner === false ? { surfaceOwner: false } : {})
+          ...surfacing
         })
         handles.push(terminal.handle)
         if (template.color && terminal.tabId) {
@@ -19993,12 +19999,12 @@ export class OrcaRuntimeService {
     wrappedSetupCommand?: string
     // Why: a workspace provisioned in the background must not pull the sidebar
     // to itself; the user never asked to look at these tabs.
-    surfaceOwner?: boolean
+    surfaceOwner?: false
   }): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null }> {
     if (!this.ptyController?.spawn) {
       return { setupSpawned: false, setupTerminalHandle: null }
     }
-    const silent = args.surfaceOwner === false ? ({ surfaceOwner: false } as const) : {}
+    const surfacing = ownerSurfacing(args.surfaceOwner !== false)
     let setupSpawned = false
     let setupTerminalHandle: string | null = null
     try {
@@ -20006,7 +20012,7 @@ export class OrcaRuntimeService {
         args.worktreeSelector,
         args.worktreeId,
         args.defaultTabs,
-        args.surfaceOwner
+        surfacing
       )
       let primaryTerminalHandle = args.primaryTerminalHandle ?? defaultTabHandles[0] ?? null
       const setupLaunchMode =
@@ -20016,7 +20022,7 @@ export class OrcaRuntimeService {
           >
         ).setupScriptLaunchMode ?? 'new-tab'
       if (!args.hasStartupTerminal && !primaryTerminalHandle) {
-        const terminal = await this.createTerminal(args.worktreeSelector, { ...silent })
+        const terminal = await this.createTerminal(args.worktreeSelector, surfacing)
         primaryTerminalHandle = terminal.handle
       }
       if (args.setup) {
@@ -20042,13 +20048,14 @@ export class OrcaRuntimeService {
               direction: setupLaunchMode === 'split-horizontal' ? 'horizontal' : 'vertical',
               command: setupCommand,
               env: setupEnv,
-              activate: false
+              activate: false,
+              ...surfacing
             })
           : this.createTerminal(args.worktreeSelector, {
               title: 'Setup',
               command: setupCommand,
               env: setupEnv,
-              ...silent
+              ...surfacing
             }))
         setupTerminalHandle = setupTerminal.handle
         setupSpawned = true
@@ -20328,7 +20335,7 @@ export class OrcaRuntimeService {
             ...(effectiveStartup.viewMode ? { viewMode: effectiveStartup.viewMode } : {}),
             startupCommandDelivery: effectiveStartup.startupCommandDelivery,
             telemetry: effectiveStartup.telemetry,
-            ...(shouldActivate ? {} : { surfaceOwner: false })
+            ...ownerSurfacing(shouldActivate)
           })
           if (effectiveDraftPaste) {
             this.pasteStartupDraftWhenReady(terminal.handle, effectiveDraftPaste)
@@ -21069,7 +21076,7 @@ export class OrcaRuntimeService {
           ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
           startupCommandDelivery: sequencedStartup.startupCommandDelivery,
           telemetry: sequencedStartup.telemetry,
-          ...(shouldActivate ? {} : { surfaceOwner: false })
+          ...ownerSurfacing(shouldActivate)
         })
         if (effectiveDraftPaste) {
           this.pasteStartupDraftWhenReady(terminal.handle, effectiveDraftPaste)
@@ -21421,7 +21428,7 @@ export class OrcaRuntimeService {
           ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
           startupCommandDelivery: sequencedStartup.startupCommandDelivery,
           telemetry: sequencedStartup.telemetry,
-          ...(shouldActivate ? {} : { surfaceOwner: false })
+          ...ownerSurfacing(shouldActivate)
         })
         if (args.startupDraftPaste) {
           this.pasteStartupDraftWhenReady(terminal.handle, args.startupDraftPaste)
@@ -23966,7 +23973,7 @@ export class OrcaRuntimeService {
             ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
             activate: presentation === 'focused',
             ...(presentation ? { presentation } : {}),
-            ...(opts.surfaceOwner === false ? { surfaceOwner: false } : {}),
+            ...ownerSurfacing(opts.surfaceOwner !== false),
             tabId,
             leafId
           })
@@ -24052,7 +24059,7 @@ export class OrcaRuntimeService {
         title: launchOpts.title,
         activate: presentation === 'focused',
         ...(presentation ? { presentation } : {}),
-        ...(opts.surfaceOwner === false ? { surfaceOwner: false } : {})
+        ...ownerSurfacing(opts.surfaceOwner !== false)
       })
     })
 
@@ -25192,6 +25199,9 @@ export class OrcaRuntimeService {
       env?: Record<string, string>
       envToDelete?: string[]
       activate?: boolean
+      // Why: same split as createTerminal — adopt the pane without revealing its
+      // workspace, for splits the user never asked to see.
+      surfaceOwner?: false
       telemetrySource?: TerminalPaneSplitSource
     } = {}
   ): Promise<RuntimeTerminalSplit> {
@@ -25229,6 +25239,9 @@ export class OrcaRuntimeService {
       env?: Record<string, string>
       envToDelete?: string[]
       activate?: boolean
+      // Why: same split as createTerminal — adopt the pane without revealing its
+      // workspace, for splits the user never asked to see.
+      surfaceOwner?: false
       telemetrySource?: TerminalPaneSplitSource
     } = {}
   ): Promise<RuntimeTerminalSplit> {
@@ -25279,6 +25292,7 @@ export class OrcaRuntimeService {
         ptyId: result.id,
         title: null,
         activate: opts.activate !== false,
+        ...ownerSurfacing(opts.surfaceOwner !== false),
         tabId: parentTabId,
         leafId,
         splitFromLeafId: parsedPaneKey.leafId,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1271,6 +1271,10 @@ type TerminalCreateOptions = {
   rendererBacked?: boolean
   activate?: boolean
   presentation?: RuntimeTerminalPresentation
+  // Why: `false` adopts the terminal without pointing the user at it — no
+  // sidebar reveal, no tab focus. Distinct from 'background' presentation,
+  // which skips renderer adoption entirely.
+  surfaceOwner?: boolean
   tabId?: string
   leafId?: string
   sessionId?: string
@@ -1702,6 +1706,7 @@ type RuntimeNotifier = {
       viewMode?: 'terminal' | 'chat'
       activate?: boolean
       presentation?: RuntimeTerminalPresentation
+      surfaceOwner?: boolean
       tabId?: string
       leafId?: string
       splitFromLeafId?: string
@@ -19942,7 +19947,8 @@ export class OrcaRuntimeService {
   private async createDefaultTabTerminals(
     worktreeSelector: string,
     worktreeId: string,
-    defaultTabs: CreateWorktreeResult['defaultTabs'] | undefined
+    defaultTabs: CreateWorktreeResult['defaultTabs'] | undefined,
+    surfaceOwner?: boolean
   ): Promise<string[]> {
     if (!defaultTabs || defaultTabs.tabs.length === 0 || !this.ptyController?.spawn) {
       return []
@@ -19953,7 +19959,8 @@ export class OrcaRuntimeService {
         const command = template.command?.trim()
         const terminal = await this.createTerminal(worktreeSelector, {
           ...(template.title ? { title: template.title } : {}),
-          ...(command && defaultTabs.runCommands ? { command } : {})
+          ...(command && defaultTabs.runCommands ? { command } : {}),
+          ...(surfaceOwner === false ? { surfaceOwner: false } : {})
         })
         handles.push(terminal.handle)
         if (template.color && terminal.tabId) {
@@ -19984,17 +19991,22 @@ export class OrcaRuntimeService {
     // the setup command. Pass that wrapped command through so the Setup tab runs
     // the same script the agent is waiting on instead of a bare runner.
     wrappedSetupCommand?: string
+    // Why: a workspace provisioned in the background must not pull the sidebar
+    // to itself; the user never asked to look at these tabs.
+    surfaceOwner?: boolean
   }): Promise<{ setupSpawned: boolean; setupTerminalHandle: string | null }> {
     if (!this.ptyController?.spawn) {
       return { setupSpawned: false, setupTerminalHandle: null }
     }
+    const silent = args.surfaceOwner === false ? ({ surfaceOwner: false } as const) : {}
     let setupSpawned = false
     let setupTerminalHandle: string | null = null
     try {
       const defaultTabHandles = await this.createDefaultTabTerminals(
         args.worktreeSelector,
         args.worktreeId,
-        args.defaultTabs
+        args.defaultTabs,
+        args.surfaceOwner
       )
       let primaryTerminalHandle = args.primaryTerminalHandle ?? defaultTabHandles[0] ?? null
       const setupLaunchMode =
@@ -20004,7 +20016,7 @@ export class OrcaRuntimeService {
           >
         ).setupScriptLaunchMode ?? 'new-tab'
       if (!args.hasStartupTerminal && !primaryTerminalHandle) {
-        const terminal = await this.createTerminal(args.worktreeSelector)
+        const terminal = await this.createTerminal(args.worktreeSelector, { ...silent })
         primaryTerminalHandle = terminal.handle
       }
       if (args.setup) {
@@ -20035,7 +20047,8 @@ export class OrcaRuntimeService {
           : this.createTerminal(args.worktreeSelector, {
               title: 'Setup',
               command: setupCommand,
-              env: setupEnv
+              env: setupEnv,
+              ...silent
             }))
         setupTerminalHandle = setupTerminal.handle
         setupSpawned = true
@@ -20314,7 +20327,8 @@ export class OrcaRuntimeService {
             ...(effectiveCreatedWithAgent ? { launchAgent: effectiveCreatedWithAgent } : {}),
             ...(effectiveStartup.viewMode ? { viewMode: effectiveStartup.viewMode } : {}),
             startupCommandDelivery: effectiveStartup.startupCommandDelivery,
-            telemetry: effectiveStartup.telemetry
+            telemetry: effectiveStartup.telemetry,
+            ...(shouldActivate ? {} : { surfaceOwner: false })
           })
           if (effectiveDraftPaste) {
             this.pasteStartupDraftWhenReady(terminal.handle, effectiveDraftPaste)
@@ -20345,7 +20359,7 @@ export class OrcaRuntimeService {
         }
       } else if (this.ptyController?.spawn && !didSpawnStartup) {
         try {
-          await this.createTerminal(`id:${worktree.id}`)
+          await this.createTerminal(`id:${worktree.id}`, { surfaceOwner: false })
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err)
           warning = warning
@@ -21054,7 +21068,8 @@ export class OrcaRuntimeService {
           ...(effectiveCreatedWithAgent ? { launchAgent: effectiveCreatedWithAgent } : {}),
           ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
           startupCommandDelivery: sequencedStartup.startupCommandDelivery,
-          telemetry: sequencedStartup.telemetry
+          telemetry: sequencedStartup.telemetry,
+          ...(shouldActivate ? {} : { surfaceOwner: false })
         })
         if (effectiveDraftPaste) {
           this.pasteStartupDraftWhenReady(terminal.handle, effectiveDraftPaste)
@@ -21155,7 +21170,8 @@ export class OrcaRuntimeService {
             : 'posix'
           : 'posix',
         observeSetupCompletion: args.observeSetupCompletion,
-        ...(wrappedSetupCommandStr ? { wrappedSetupCommand: wrappedSetupCommandStr } : {})
+        ...(wrappedSetupCommandStr ? { wrappedSetupCommand: wrappedSetupCommandStr } : {}),
+        surfaceOwner: false
       })
       // Why: runtime owns setup spawning here, so the RPC result must omit setup
       // to keep the headless/mobile caller from launching it a second time.
@@ -21171,7 +21187,7 @@ export class OrcaRuntimeService {
       }
     } else if (this.ptyController?.spawn) {
       try {
-        await this.createTerminal(`id:${worktree.id}`)
+        await this.createTerminal(`id:${worktree.id}`, { surfaceOwner: false })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         warning = warning
@@ -21355,6 +21371,7 @@ export class OrcaRuntimeService {
     this.invalidateWorktreeScanCacheForRepo(repo.id)
     this.notifyWorktreesChanged(repo.id)
 
+    const shouldActivate = args.activate === true || args.runHooks === true
     let warning = result.warning
     let didSpawnStartup = false
     // Why: same no-double-spawn contract as the local path — once runtime
@@ -21403,7 +21420,8 @@ export class OrcaRuntimeService {
           ...(args.createdWithAgent ? { launchAgent: args.createdWithAgent } : {}),
           ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
           startupCommandDelivery: sequencedStartup.startupCommandDelivery,
-          telemetry: sequencedStartup.telemetry
+          telemetry: sequencedStartup.telemetry,
+          ...(shouldActivate ? {} : { surfaceOwner: false })
         })
         if (args.startupDraftPaste) {
           this.pasteStartupDraftWhenReady(terminal.handle, args.startupDraftPaste)
@@ -21424,7 +21442,6 @@ export class OrcaRuntimeService {
       }
     }
 
-    const shouldActivate = args.activate === true || args.runHooks === true
     if (shouldActivate) {
       const runtimeWillProvisionTerminals =
         didSpawnStartup && Boolean(result.setup || result.defaultTabs)
@@ -21506,7 +21523,8 @@ export class OrcaRuntimeService {
             : 'posix'
           : 'posix',
         observeSetupCompletion: args.observeSetupCompletion,
-        ...(wrappedSetupCommandStr ? { wrappedSetupCommand: wrappedSetupCommandStr } : {})
+        ...(wrappedSetupCommandStr ? { wrappedSetupCommand: wrappedSetupCommandStr } : {}),
+        surfaceOwner: false
       })
       // Why: runtime owns setup spawning here, so omit setup from the RPC result
       // to keep the headless/mobile caller from launching it a second time.
@@ -21522,7 +21540,7 @@ export class OrcaRuntimeService {
       }
     } else if (!shouldActivate && this.ptyController?.spawn) {
       try {
-        await this.createTerminal(`path:${result.worktree.path}`)
+        await this.createTerminal(`path:${result.worktree.path}`, { surfaceOwner: false })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         warning = warning
@@ -23948,6 +23966,7 @@ export class OrcaRuntimeService {
             ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
             activate: presentation === 'focused',
             ...(presentation ? { presentation } : {}),
+            ...(opts.surfaceOwner === false ? { surfaceOwner: false } : {}),
             tabId,
             leafId
           })
@@ -24032,7 +24051,8 @@ export class OrcaRuntimeService {
         startupCommandDelivery: launchOpts.startupCommandDelivery,
         title: launchOpts.title,
         activate: presentation === 'focused',
-        ...(presentation ? { presentation } : {})
+        ...(presentation ? { presentation } : {}),
+        ...(opts.surfaceOwner === false ? { surfaceOwner: false } : {})
       })
     })
 

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -60,7 +60,10 @@ export async function createExistingWorktreeWorkerTerminal(args: {
 }): Promise<{ handle: string; warning?: string }> {
   const terminal = await args.runtime.createTerminal(`id:${args.worktreeId}`, {
     command: args.agent,
-    title: `worker-${args.taskId}`
+    title: `worker-${args.taskId}`,
+    // Why: dispatching a worker is background work; it must not pull the sidebar
+    // to the worker's workspace while the user is reading somewhere else.
+    surfaceOwner: false
   })
   args.effects.push({
     kind: 'terminal',

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -2176,9 +2176,12 @@ describe('orchestration RPC methods', () => {
       )
       expect(db.getTask(task.id)?.status).toBe('dispatched')
       expect(db.getWorkerDispatch(result.dispatchId)?.state).toBe('ready')
+      // Why: dispatching a worker is background work — surfaceOwner:false adopts
+      // the tab without scrolling the sidebar to the worker's workspace.
       expect(runtime.createTerminal).toHaveBeenCalledWith('id:repo::worktree', {
         command: 'codex',
-        title: `worker-${task.id}`
+        title: `worker-${task.id}`,
+        surfaceOwner: false
       })
       expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledWith(
         'term_worker',
@@ -2277,7 +2280,9 @@ describe('orchestration RPC methods', () => {
       )
       expect(runtime.createTerminal).toHaveBeenCalledWith(
         'id:repo::other',
-        expect.objectContaining({ command: 'codex' })
+        // Why: starting a worker in an existing worktree must not pull the sidebar
+        // away from whatever the user is looking at.
+        expect.objectContaining({ command: 'codex', surfaceOwner: false })
       )
       expect(createWorktree).not.toHaveBeenCalled()
     })

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -402,6 +402,7 @@ function registerRuntimeWindowLifecycle(
           ...(opts.viewMode ? { viewMode: opts.viewMode } : {}),
           activate: opts.activate !== false,
           ...(opts.presentation ? { presentation: opts.presentation } : {}),
+          ...(opts.surfaceOwner === false ? { surfaceOwner: false } : {}),
           // Why: pre-minted tabId aligns the renderer tab id with the paneKey baked into the PTY env, so hook events route right.
           ...(opts.tabId !== undefined ? { tabId: opts.tabId } : {}),
           ...(opts.leafId !== undefined ? { leafId: opts.leafId } : {}),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3157,6 +3157,7 @@ export type PreloadApi = {
         activate?: boolean
         focus?: boolean
         presentation?: RuntimeTerminalPresentation
+        surfaceOwner?: boolean
         tabId?: string
         leafId?: string
         splitFromLeafId?: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3157,7 +3157,7 @@ export type PreloadApi = {
         activate?: boolean
         focus?: boolean
         presentation?: RuntimeTerminalPresentation
-        surfaceOwner?: boolean
+        surfaceOwner?: false
         tabId?: string
         leafId?: string
         splitFromLeafId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3722,7 +3722,7 @@ const api = {
         activate?: boolean
         focus?: boolean
         presentation?: RuntimeTerminalPresentation
-        surfaceOwner?: boolean
+        surfaceOwner?: false
         tabId?: string
         leafId?: string
         splitFromLeafId?: string
@@ -3748,7 +3748,7 @@ const api = {
           activate?: boolean
           focus?: boolean
           presentation?: RuntimeTerminalPresentation
-          surfaceOwner?: boolean
+          surfaceOwner?: false
           tabId?: string
           leafId?: string
           splitFromLeafId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3722,6 +3722,7 @@ const api = {
         activate?: boolean
         focus?: boolean
         presentation?: RuntimeTerminalPresentation
+        surfaceOwner?: boolean
         tabId?: string
         leafId?: string
         splitFromLeafId?: string
@@ -3747,6 +3748,7 @@ const api = {
           activate?: boolean
           focus?: boolean
           presentation?: RuntimeTerminalPresentation
+          surfaceOwner?: boolean
           tabId?: string
           leafId?: string
           splitFromLeafId?: string

--- a/src/renderer/src/hooks/ipc-events-test-harness.ts
+++ b/src/renderer/src/hooks/ipc-events-test-harness.ts
@@ -8,10 +8,22 @@ export type CreateTerminalRequest = {
   command?: string
   title?: string
   ptyId?: string
+  activate?: boolean
   presentation?: 'background' | 'focused'
+  surfaceOwner?: boolean
   tabId?: string
   leafId?: string
   splitFromLeafId?: string
+}
+
+export type RequestTerminalCreateRequest = {
+  requestId: string
+  worktreeId?: string
+  command?: string
+  title?: string
+  activate?: boolean
+  presentation?: 'background' | 'focused'
+  surfaceOwner?: boolean
 }
 
 export type HarnessTab = { id: string; ptyId?: string | null; title?: string }
@@ -108,6 +120,7 @@ export type IpcEventsHarness = {
   /** Call inside the test body: useIpcEvents runs its effects eagerly here. */
   useIpcEvents: () => void
   createTerminal: (request: CreateTerminalRequest) => void
+  requestTerminalCreate: (request: RequestTerminalCreateRequest) => void
   replyTerminalCreate: ReturnType<typeof vi.fn>
 }
 
@@ -120,6 +133,7 @@ export async function loadIpcEventsHarness(
 ): Promise<IpcEventsHarness> {
   const replyTerminalCreate = vi.fn()
   let createTerminalListener: ((request: CreateTerminalRequest) => void) | null = null
+  let requestTerminalCreateListener: ((request: RequestTerminalCreateRequest) => void) | null = null
 
   vi.resetModules()
   vi.unstubAllGlobals()
@@ -170,6 +184,10 @@ export async function loadIpcEventsHarness(
           onCreateTerminal: (listener: (request: CreateTerminalRequest) => void) => {
             createTerminalListener = listener
             return () => {}
+          },
+          onRequestTerminalCreate: (listener: (request: RequestTerminalCreateRequest) => void) => {
+            requestTerminalCreateListener = listener
+            return () => {}
           }
         }),
         rateLimits: {
@@ -218,6 +236,12 @@ export async function loadIpcEventsHarness(
         throw new Error('Expected the create-terminal listener to be registered')
       }
       createTerminalListener(request)
+    },
+    requestTerminalCreate: (request) => {
+      if (typeof requestTerminalCreateListener !== 'function') {
+        throw new Error('Expected the request-terminal-create listener to be registered')
+      }
+      requestTerminalCreateListener(request)
     },
     replyTerminalCreate
   }

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -11,6 +11,11 @@ import {
   resolveBrowserSessionTabTarget,
   resolveZoomTarget
 } from './useIpcEvents'
+import {
+  createHarnessStoreState,
+  loadIpcEventsHarness,
+  type HarnessStoreState
+} from './ipc-events-test-harness'
 import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-resume'
 import type { AgentStatusClearIpcPayload } from '../../../shared/agent-status-types'
 import type { TuiAgent } from '../../../shared/types'
@@ -8553,5 +8558,127 @@ describe('parked terminal recovery on repos:changed', () => {
 
     expect(remountTerminalTabForRecovery).toHaveBeenCalledWith('tab-1')
     clearTerminalTabsParkedOnUnresolvedHost()
+  })
+})
+
+describe('useIpcEvents silent terminal adoption (surfaceOwner: false)', () => {
+  const asMock = (value: unknown): ReturnType<typeof vi.fn> => value as ReturnType<typeof vi.fn>
+
+  function createBackgroundWorkspaceState(): HarnessStoreState {
+    return createHarnessStoreState({
+      tabsByWorktree: {},
+      // Honour the pre-minted tab id so adoption resolves the same tab main asked for.
+      createTab: vi.fn(
+        (_worktreeId: string, _groupId?: string, _tabType?: string, options?: { id?: string }) => ({
+          id: options?.id ?? 'tab-minted'
+        })
+      ),
+      worktreesByRepo: {
+        'repo-1': [
+          { id: 'wt-1', repoId: 'repo-1' },
+          { id: 'wt-2', repoId: 'repo-1' }
+        ]
+      }
+    })
+  }
+
+  it('adopts a background workspace terminal without scrolling the sidebar to it', async () => {
+    const storeState = createBackgroundWorkspaceState()
+    const harness = await loadIpcEventsHarness(storeState)
+    harness.useIpcEvents()
+
+    // Control: `orca terminal create` (no surfaceOwner) keeps its reveal so the
+    // user can find the terminal they just asked for.
+    harness.createTerminal({
+      worktreeId: 'wt-2',
+      ptyId: 'pty-cli',
+      activate: false,
+      tabId: 'tab-cli'
+    })
+
+    expect(storeState.createTab).toHaveBeenCalledWith('wt-2', undefined, undefined, {
+      initialPtyId: 'pty-cli',
+      activate: false,
+      id: 'tab-cli'
+    })
+    expect(storeState.revealWorktreeInSidebar).toHaveBeenCalledWith('wt-2')
+
+    asMock(storeState.createTab).mockClear()
+    asMock(storeState.revealWorktreeInSidebar).mockClear()
+    asMock(storeState.setActiveView).mockClear()
+    asMock(storeState.setActiveWorktree).mockClear()
+    asMock(storeState.setActiveTabType).mockClear()
+    asMock(storeState.setActiveTab).mockClear()
+
+    // Regression: a workspace created in the background spawns its agent terminal
+    // here; the tab must still be adopted, but the sidebar must not scroll to it.
+    harness.createTerminal({
+      worktreeId: 'wt-2',
+      ptyId: 'pty-background-create',
+      activate: false,
+      surfaceOwner: false,
+      tabId: 'tab-background-create'
+    })
+
+    expect(storeState.createTab).toHaveBeenCalledWith('wt-2', undefined, undefined, {
+      initialPtyId: 'pty-background-create',
+      activate: false,
+      id: 'tab-background-create'
+    })
+    expect(storeState.revealWorktreeInSidebar).not.toHaveBeenCalled()
+    expect(storeState.setActiveView).not.toHaveBeenCalled()
+    expect(storeState.setActiveWorktree).not.toHaveBeenCalled()
+    expect(storeState.setActiveTabType).not.toHaveBeenCalled()
+    expect(storeState.setActiveTab).not.toHaveBeenCalled()
+  })
+
+  it('replies to a requested terminal create without scrolling the sidebar when surfaceOwner is false', async () => {
+    const storeState = createBackgroundWorkspaceState()
+    const harness = await loadIpcEventsHarness(storeState)
+    harness.useIpcEvents()
+
+    // Control: the same request without surfaceOwner still reveals its workspace.
+    harness.requestTerminalCreate({
+      requestId: 'req-cli',
+      worktreeId: 'wt-2',
+      title: 'Claude'
+    })
+
+    expect(harness.replyTerminalCreate).toHaveBeenCalledWith({
+      requestId: 'req-cli',
+      tabId: 'tab-minted',
+      title: 'Claude'
+    })
+    expect(storeState.revealWorktreeInSidebar).toHaveBeenCalledWith('wt-2')
+
+    asMock(storeState.createTab).mockClear()
+    asMock(storeState.revealWorktreeInSidebar).mockClear()
+    asMock(storeState.setActiveView).mockClear()
+    asMock(storeState.setActiveWorktree).mockClear()
+    asMock(storeState.setActiveTabType).mockClear()
+    asMock(storeState.setActiveTab).mockClear()
+    harness.replyTerminalCreate.mockClear()
+
+    harness.requestTerminalCreate({
+      requestId: 'req-background-create',
+      worktreeId: 'wt-2',
+      title: 'Claude',
+      surfaceOwner: false
+    })
+
+    expect(storeState.createTab).toHaveBeenCalledWith('wt-2', undefined, undefined, {
+      activate: false,
+      recordInteraction: false
+    })
+    expect(harness.replyTerminalCreate).toHaveBeenCalledWith({
+      requestId: 'req-background-create',
+      tabId: 'tab-minted',
+      title: 'Claude'
+    })
+    expect(storeState.revealWorktreeInSidebar).not.toHaveBeenCalled()
+    expect(storeState.setActiveView).not.toHaveBeenCalled()
+    expect(storeState.setActiveWorktree).not.toHaveBeenCalled()
+    expect(storeState.setActiveTabType).not.toHaveBeenCalled()
+    expect(storeState.setActiveTab).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1416,6 +1416,7 @@ export function useIpcEvents(): void {
           activate,
           focus,
           presentation,
+          surfaceOwner,
           tabId,
           leafId,
           splitFromLeafId,
@@ -1430,7 +1431,8 @@ export function useIpcEvents(): void {
               focus
             })
             const shouldActivate = terminalPresentation === 'focused'
-            const shouldSurfaceOwner = terminalPresentation !== 'background'
+            const shouldSurfaceOwner =
+              terminalPresentation !== 'background' && surfaceOwner !== false
             if (shouldActivate) {
               activateTerminalInitiatedWorktree(store, worktreeId)
             }
@@ -1682,7 +1684,8 @@ export function useIpcEvents(): void {
           }
           const terminalPresentation = resolveTerminalPresentation(data)
           const shouldActivate = terminalPresentation === 'focused'
-          const shouldSurfaceOwner = terminalPresentation !== 'background'
+          const shouldSurfaceOwner =
+            terminalPresentation !== 'background' && data.surfaceOwner !== false
           if (shouldActivate) {
             activateTerminalInitiatedWorktree(store, worktreeId)
           }

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -622,6 +622,12 @@ type RuntimeTerminalCreateBaseRequestPayload = {
   title?: string
   activate?: boolean
   presentation?: RuntimeTerminalPresentation
+  /**
+   * Why: adopting a terminal is separate from pointing the user at it. `false`
+   * keeps the tab silent — no sidebar reveal, no tab focus — for terminals the
+   * user never asked to see (e.g. a workspace created in the background).
+   */
+  surfaceOwner?: boolean
 }
 
 export type RuntimeTerminalCreateRequestPayload =

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -626,8 +626,9 @@ type RuntimeTerminalCreateBaseRequestPayload = {
    * Why: adopting a terminal is separate from pointing the user at it. `false`
    * keeps the tab silent — no sidebar reveal, no tab focus — for terminals the
    * user never asked to see (e.g. a workspace created in the background).
+   * Absent means "surface it", so this is a suppression switch, never `true`.
    */
-  surfaceOwner?: boolean
+  surfaceOwner?: false
 }
 
 export type RuntimeTerminalCreateRequestPayload =


### PR DESCRIPTION
## Description

Follow-up to #11445. That PR stopped background workspace creation from stealing the user's **selection**. The sidebar still **scrolled by itself**, because the scroll comes from a different signal.

Adopting a terminal and pointing the user at it were the same decision. This separates them with a `surfaceOwner` flag, and every background path now adopts silently.

## ELI5

Creating a workspace in the background should be like a coworker quietly filing a new folder in the cabinet behind you. Orca was tapping you on the shoulder and turning your chair toward the cabinet — not far enough to change what you were working on, but far enough to lose your place in the list.

Under the hood: a background create still has to start that workspace's terminal. When Orca handed that terminal to the UI it said nothing about how to present it, and "said nothing" was read as "show it to the user" — so the sidebar scrolled. #11445 stopped the chair from turning all the way; this removes the shoulder-tap.

Now a background create explicitly says "adopt this terminal silently": the tab is still created and the agent still runs, but the sidebar stays where you left it. Terminals you actually ask for still reveal themselves as before.

## Root cause

A background create still spawns the new workspace's terminals via `OrcaRuntimeService.createTerminal`, which asks the renderer to adopt the PTY through `notifier.revealTerminalSession(...)`.

No worktree-create call site passed a `presentation`, so `resolveTerminalPresentation` returned `undefined`. Every downstream check is `presentation !== 'background'` — **true for `undefined`** — and the renderer mirrored it:

```ts
const shouldSurfaceOwner = terminalPresentation !== 'background' // undefined -> true
if (shouldSurfaceOwner) {
  store.revealWorktreeInSidebar(worktreeId) // scrolls the sidebar, expands collapsed groups
  focusTerminalInitiatedTab(tab.id)
}
```

So "no presentation stated" meant "point the user at this terminal". That default is right for `orca terminal create`, where discoverability is the entire point — the runtime even returns a warning when the reveal fails. It is wrong for terminals the user never asked for.

`presentation: 'background'` could not express this: it means "do not adopt the terminal in the renderer at all", which would leave the new workspace with no tab for its agent.

### Version boundary

`shouldSurfaceOwner` arrived in #6686 (Jun 28), which decoupled "surface the owner" from "activate". Before it the reveal was gated on activation, so a non-activating create could not scroll the sidebar. #11445 fixed the activation half; this fixes the surfacing half.

## Design

`surfaceOwner` is typed `?: false`, not `?: boolean` — absent means "surface it", so the flag is a suppression switch and `true` is unrepresentable. One way to express each intent.

`surfaceOwner: false` is passed from every background path: the agent/startup terminal, the plain initial shell, the Setup tab (both new-tab **and** split-pane placement), default tabs, and orchestration worker dispatch. It is threaded through `createTerminal` **and** `splitTerminal`. Explicitly activated creates omit it.

No new CLI/RPC surface: `surfaceOwner` is main-internal and absent from the `terminal.create` RPC schema, so callers cannot set it.

## Proof of regression

Tests were written against the fix, then run with the production change reverted.

Main process — reverting only the `surfaceOwner: false` arguments at the worktree-create call sites, leaving the forwarding machinery intact:

```
Failed Tests 5
FAIL orca-runtime.test.ts > follows normal setup policy for CLI-created worktrees without activating them
FAIL orca-runtime.test.ts > creates the first terminal for CLI-created worktrees without activating them
FAIL orca-runtime.test.ts > does not surface the new workspace when a background CLI create launches its agent
FAIL orchestration.test.ts > starts a fresh agent in the coordinator current worktree
FAIL orchestration.test.ts > starts a fresh agent in an exact existing worktree without replaying setup
      Tests  5 failed | 1081 passed | 1 skipped (1087)
```

The no-regression pair bites in the opposite direction — replacing `...ownerSurfacing(shouldActivate)` with an unconditional `surfaceOwner: false`:

```
FAIL orca-runtime.test.ts > still surfaces the new workspace when the caller explicitly activates it
FAIL orca-runtime.test.ts > still surfaces the new workspace when hooks run in the foreground
      Tests  2 failed | 935 passed | 1 skipped (938)
```

Split-mode Setup (the review catch below) is wired to **both** halves of its fix independently — removing either the `...surfacing` spread in the `shouldSplitSetup` branch or the `...ownerSurfacing(...)` in `splitPtyBackedTerminal` produces:

```
FAIL orca-runtime.test.ts > does not surface the new workspace when a background create splits its setup pane
- "surfaceOwner": false,
```

Renderer — reverting each handler's guard fails only its own test, so both code paths are independently covered:

```
FAIL useIpcEvents.test.ts > adopts a background workspace terminal without scrolling the sidebar to it
FAIL useIpcEvents.test.ts > replies to a requested terminal create without scrolling the sidebar when surfaceOwner is false
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received: 1st vi.fn() call: Array [ "wt-2" ]
```

## Proof of fix

- Full unit suite: **41,413 passed**, 72 skipped (3,920 files passed, 10 skipped).
  - The only failure, `src/relay/agent-exec-handler.test.ts` (2 tests), reproduces identically on a clean tree at `37af4577` and is unrelated.
- `pnpm run typecheck:node`, `pnpm run typecheck:web`: passed.
- `pnpm run check:code-quality:changed`: 0 new findings across 11 files.
- `pnpm run check:max-lines-ratchet`, `pnpm run verify:bundled-skill-guides`: passed.
- `oxlint` + `oxfmt --check` clean on all changed files.

## Proof of no regression

- `orca terminal create` still reveals its workspace — no `surfaceOwner` in its payload, and the pre-existing assertion is untouched. Each new renderer test also runs a control phase asserting the default still reveals.
- Explicit `--activate` and legacy `--run-hooks` still reveal, in both new-tab and split Setup placement; four tests assert `surfaceOwner` is absent from the reveal payload.
- Terminals are still **adopted** in every background case — the new tests assert `createTab` is called with the pre-minted tab id, so the agent tab exists when the user opens the workspace.
- `presentation: 'background'` semantics are untouched; `surfaceOwner` is a separate axis.
- The renderer no longer calls `focusTerminalInitiatedTab` for background creates, removing a second latent focus-steal on a workspace the user is not viewing.

## Review notes

- **Split-mode Setup** (caught in review): with `setupScriptLaunchMode: split-vertical|split-horizontal` the Setup terminal goes through `splitTerminal`, whose reveal payload had no `surfaceOwner` — a real gap, now fixed and tested. The non-PTY split path is unaffected: `notifier.splitTerminal` only dispatches a renderer `CustomEvent` and never reveals.
- **`notifier.createTerminal`** was also flagged, but it is unreachable — `grep -rn "notifier\.createTerminal" src/main` (excluding tests) returns nothing. The worker path calls the `OrcaRuntimeService.createTerminal` *method*, which routes through `revealTerminalSession`. Threading the flag there would mean widening the notifier type for a path nothing calls.

## Known second cause (not in this PR)

While investigating I reproduced a **second, independent** cause of sidebar self-scrolling: creating a *child* worktree makes `buildRenderableRows` collapse the parent and its children into one `lineage-group` row, which rewrites the parent's scroll-anchor key. If that parent was the top-visible row, `runVirtualizedScrollAnchorRestore` cannot find the old key and pins a *different* row to the top — a measured **+180 px** jump with no reveal involved. It is long-standing rather than RC-new, needs the anchored row to be exactly that parent, and is being handled separately.
