### PR TITLE
fix(sidebar): let the scroll anchor follow a re-keyed row

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -95,9 +95,11 @@ import {
   type PinnedWorktreeDisplayPolicy
 } from './worktree-list-groups'
 import {
+  buildLineageRowRekeyMap,
   estimateRenderRowSize,
   extractWorktreeVirtualRowIndexes,
   getActiveStickyIndexesForScroll,
+  getRenderRowKey,
   getStickyHeaderIndexes,
   getVirtualRowTransform,
   pruneStaleVirtualRowElementCache,
@@ -1210,30 +1212,9 @@ function buildRenderableRows(rows: HostSectionRow[]): RenderRow[] {
   return renderRows
 }
 
-export function getRenderRowKey(row: RenderRow): string {
-  if (row.type === 'host-header') {
-    return `host:${row.hostId}`
-  }
-  if (row.type === 'header') {
-    return `hdr:${row.key}`
-  }
-  if (row.type === 'lineage-group') {
-    return `lineage-group:${row.key}`
-  }
-  if (row.type === 'imported-worktrees-card') {
-    return `imported:${row.key}`
-  }
-  if (row.type === 'new-external-worktrees-inbox') {
-    return `inbox:${row.key}`
-  }
-  if (row.type === 'pending-creation') {
-    return `pending:${row.creationId}`
-  }
-  if (row.type === 'folder-workspace') {
-    return `folder-workspace:${row.folderWorkspace.id}`
-  }
-  return `wt:${row.rowKey}`
-}
+// Why: getRenderRowKey lives with the other virtual-row helpers now; keep the
+// long-standing import path working for callers that reach for it here.
+export { getRenderRowKey }
 
 export function getWorktreeDragGroups(rows: HostSectionRow[]): WorktreeDragGroup[] {
   const groups: WorktreeDragGroup[] = []
@@ -2432,6 +2413,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     [renderRows]
   )
   const activeRenderRowKeys = useMemo(() => new Set(renderRows.map(getRenderRowKey)), [renderRows])
+  const lineageRowRekeys = useMemo(() => buildLineageRowRekeyMap(renderRows), [renderRows])
   const totalSize = virtualizer.getTotalSize()
   const virtualItems = virtualizer.getVirtualItems()
   const activeStickyIndexes = getActiveStickyIndexesForScroll({
@@ -2489,6 +2471,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
     getItemElementKey: getVirtualRowKey,
     getRowKey: getRenderRowKey,
     itemElementSelector: '[data-worktree-virtual-row]',
+    rekeyedRowKeys: lineageRowRekeys,
     rows: renderRows,
     scrollElementRef: scrollRef,
     scrollOffsetRef,

--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import type { VirtualItem } from '@tanstack/react-virtual'
 import {
   HOST_STICKY_PINNED_HEIGHT,
+  buildLineageRowRekeyMap,
   extractWorktreeVirtualRowIndexes,
   getActiveStickyIndexesForScroll,
+  getRenderRowKey,
   getStickyHeaderIndexes,
   pruneStaleVirtualRowElementCache,
   type RenderRow
@@ -182,6 +184,91 @@ describe('extractWorktreeVirtualRowIndexes', () => {
       rows
     })
     expect(indexes).toContain(0)
+  })
+})
+
+describe('buildLineageRowRekeyMap', () => {
+  // Mirrors buildWorktreeRow: rowKey is `${sectionKey}:${worktree.id}`.
+  function worktreeRow(sectionKey: string, worktreeId: string): RenderRow {
+    return {
+      type: 'item',
+      rowKey: `${sectionKey}:${worktreeId}`,
+      sectionKey,
+      worktree: { id: worktreeId },
+      depth: 0,
+      groupDepth: 0,
+      lineageTrail: [],
+      isLastLineageChild: true,
+      lineageChildCount: 0
+    } as unknown as RenderRow
+  }
+
+  function lineageGroupRow(sectionKey: string, parentId: string, childIds: string[]): RenderRow {
+    return {
+      type: 'lineage-group',
+      key: `${sectionKey}:lineage:${parentId}`,
+      rows: [parentId, ...childIds].map(
+        (id) => worktreeRow(sectionKey, id) as Extract<RenderRow, { type: 'item' }>
+      )
+    }
+  }
+
+  it('folds every lineage-group member onto the group key', () => {
+    const group = lineageGroupRow('all', 'p', ['c1', 'c2'])
+    const rekeys = buildLineageRowRekeyMap([group])
+
+    // The parent's own row key is what an anchor recorded before the child
+    // existed; all members now live inside the single group row.
+    expect(rekeys.get('wt:all:p')).toBe('lineage-group:all:lineage:p')
+    expect(rekeys.get('wt:all:c1')).toBe('lineage-group:all:lineage:p')
+    expect(rekeys.get('wt:all:c2')).toBe('lineage-group:all:lineage:p')
+    expect(getRenderRowKey(group)).toBe('lineage-group:all:lineage:p')
+  })
+
+  it('dissolves a group key back onto the plain item row', () => {
+    // Last child deleted: lineageChildCount is already 0, but an anchor still
+    // holds the group key, so the reverse mapping must be unguarded.
+    const rekeys = buildLineageRowRekeyMap([worktreeRow('all', 'p')])
+
+    expect(rekeys.get('lineage-group:all:lineage:p')).toBe('wt:all:p')
+  })
+
+  it('round-trips the fold and dissolve directions for the same worktree', () => {
+    const folded = buildLineageRowRekeyMap([lineageGroupRow('all', 'p', ['c1'])])
+    const dissolved = buildLineageRowRekeyMap([worktreeRow('all', 'p')])
+
+    expect(dissolved.get(folded.get('wt:all:p') as string)).toBe('wt:all:p')
+  })
+
+  it('keeps the same worktree distinct across sections', () => {
+    // The same worktree renders in both Pinned and All; rowKey embeds the
+    // section so a pinned anchor must never follow the All copy.
+    const rekeys = buildLineageRowRekeyMap([
+      lineageGroupRow('pinned', 'p', ['c1']),
+      lineageGroupRow('all', 'p', ['c1'])
+    ])
+
+    expect(rekeys.get('wt:pinned:p')).toBe('lineage-group:pinned:lineage:p')
+    expect(rekeys.get('wt:all:p')).toBe('lineage-group:all:lineage:p')
+    expect(rekeys.get('wt:pinned:c1')).toBe('lineage-group:pinned:lineage:p')
+    expect(rekeys.get('wt:all:c1')).toBe('lineage-group:all:lineage:p')
+
+    const dissolvedRekeys = buildLineageRowRekeyMap([
+      worktreeRow('pinned', 'p'),
+      worktreeRow('all', 'p')
+    ])
+    expect(dissolvedRekeys.get('lineage-group:pinned:lineage:p')).toBe('wt:pinned:p')
+    expect(dissolvedRekeys.get('lineage-group:all:lineage:p')).toBe('wt:all:p')
+  })
+
+  it('contributes nothing for non-lineage row types', () => {
+    expect(
+      buildLineageRowRekeyMap([hostRow('a'), groupRow('a1'), hostRow('b'), groupRow('b1')]).size
+    ).toBe(0)
+  })
+
+  it('is empty for an empty row list', () => {
+    expect(buildLineageRowRekeyMap([]).size).toBe(0)
   })
 })
 

--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
@@ -1,7 +1,7 @@
 import { defaultRangeExtractor } from '@tanstack/react-virtual'
 import type { Range, VirtualItem } from '@tanstack/react-virtual'
 import type { HostSectionRow } from './host-section-rows'
-import { PINNED_GROUP_KEY } from './worktree-list-groups'
+import { getLineageGroupKey, PINNED_GROUP_KEY } from './worktree-list-groups'
 
 export const GROUP_HEADER_ROW_HEIGHT = 28
 export const HOST_HEADER_ROW_HEIGHT = 32
@@ -14,6 +14,63 @@ type WorktreeItemRow = Extract<HostSectionRow, { type: 'item' }>
 export type RenderRow =
   | HostSectionRow
   | { type: 'lineage-group'; key: string; rows: WorktreeItemRow[] }
+
+export function getRenderRowKey(row: RenderRow): string {
+  if (row.type === 'host-header') {
+    return `host:${row.hostId}`
+  }
+  if (row.type === 'header') {
+    return `hdr:${row.key}`
+  }
+  if (row.type === 'lineage-group') {
+    return `lineage-group:${row.key}`
+  }
+  if (row.type === 'imported-worktrees-card') {
+    return `imported:${row.key}`
+  }
+  if (row.type === 'new-external-worktrees-inbox') {
+    return `inbox:${row.key}`
+  }
+  if (row.type === 'pending-creation') {
+    return `pending:${row.creationId}`
+  }
+  if (row.type === 'folder-workspace') {
+    return `folder-workspace:${row.folderWorkspace.id}`
+  }
+  return `wt:${row.rowKey}`
+}
+
+/**
+ * Old row key -> current row key for rows that were re-keyed without moving.
+ *
+ * A parent's key flips between `wt:` and `lineage-group:` the moment it gains
+ * its first child (and back when it loses its last), even though the row still
+ * starts at the same pixel. Without this, a scroll anchor recorded under the
+ * old key resolves a fallback row below it and the sidebar visibly jumps.
+ */
+export function buildLineageRowRekeyMap(rows: readonly RenderRow[]): ReadonlyMap<string, string> {
+  const rekeyed = new Map<string, string>()
+  for (const row of rows) {
+    if (row.type === 'lineage-group') {
+      const groupKey = getRenderRowKey(row)
+      for (const member of row.rows) {
+        rekeyed.set(`wt:${member.rowKey}`, groupKey)
+      }
+      continue
+    }
+    if (row.type !== 'item') {
+      continue
+    }
+    // Why: deliberately unguarded by lineageChildCount — the dissolve case (last
+    // child deleted) is exactly when the count is already 0 but an anchor still
+    // holds the group key.
+    rekeyed.set(
+      `lineage-group:${row.sectionKey}:${getLineageGroupKey(row.worktree.id)}`,
+      getRenderRowKey(row)
+    )
+  }
+  return rekeyed
+}
 
 export function shouldUseHeaderTopSpacing(args: {
   rows: readonly RenderRow[]

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.listener-deps.test.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.listener-deps.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runVirtualizedScrollAnchorRestore } from './virtualized-scroll-anchor-restore'
 
 function createReactHookHarness() {
   const refs: { current: unknown }[] = []
@@ -169,5 +170,258 @@ describe('useVirtualizedScrollAnchor listener effect dependencies', () => {
 
     expect(scrollOffsetRef.current).toBe(0)
     expect(anchorRef.current).toBe(savedAnchor)
+  })
+})
+
+// Sidebar geometry from the reported jump: 12 rows x 100px in a 300px viewport,
+// scrolled to 520 so the parent worktree ("p") sits 20px above the top edge.
+type FakeRow = { key: string; size: number }
+const VIEWPORT_HEIGHT = 300
+const ITEM_SELECTOR = '[data-worktree-virtual-row]'
+const PARENT_KEY = 'wt:sec:p'
+const GROUP_KEY = 'lineage-group:sec:lineage:p'
+
+function row(key: string, size = 100): FakeRow {
+  return { key, size }
+}
+
+const LEADING_ROWS = ['r0', 'r1', 'r2', 'r3', 'r4'].map((id) => row(`wt:sec:${id}`))
+const TRAILING_ROWS = ['s0', 's1', 's2', 'r10', 'r11'].map((id) => row(`wt:sec:${id}`))
+// Before the child exists: parent and its (future) child are separate rows.
+const UNFOLDED_ROWS = [...LEADING_ROWS, row(PARENT_KEY), row('wt:sec:c'), ...TRAILING_ROWS]
+// After the child is created: both fold into one 200px lineage-group row that
+// still starts at 500px, so nothing on screen actually moved.
+const FOLDED_ROWS = [...LEADING_ROWS, row(GROUP_KEY, 200), ...TRAILING_ROWS]
+// Parent genuinely deleted: the rows below slide up by 200px.
+const DELETED_ROWS = [...LEADING_ROWS, ...TRAILING_ROWS]
+// Last child deleted: the 200px group collapses back to a 100px card.
+const DISSOLVED_ROWS = [...LEADING_ROWS, row(PARENT_KEY), ...TRAILING_ROWS]
+
+function createFakeScroller(rows: readonly FakeRow[], scrollTop: number) {
+  const starts: number[] = []
+  let total = 0
+  for (const item of rows) {
+    starts.push(total)
+    total += item.size
+  }
+
+  const el = {
+    clientHeight: VIEWPORT_HEIGHT,
+    scrollHeight: total,
+    scrollTop,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    getBoundingClientRect: () => ({ top: 0, bottom: VIEWPORT_HEIGHT, height: VIEWPORT_HEIGHT }),
+    querySelectorAll: () => elements
+  }
+  const elements = rows.map((item, index) => ({
+    isConnected: true,
+    rowKey: item.key,
+    getBoundingClientRect: () => {
+      const top = (starts[index] as number) - el.scrollTop
+      return { top, bottom: top + item.size, height: item.size }
+    }
+  }))
+
+  return {
+    el,
+    elements,
+    rowIndexByKey: new Map(rows.map((item, index) => [item.key, index])),
+    virtualizer: {
+      getVirtualItems: () =>
+        rows.map((item, index) => ({
+          index,
+          size: item.size,
+          start: starts[index] as number,
+          end: (starts[index] as number) + item.size
+        })),
+      isScrolling: false,
+      scrollToIndex: vi.fn()
+    }
+  }
+}
+
+function restore(args: {
+  anchor: { key: string; offset: number; fallbackKeys?: string[]; scrollTop?: number }
+  rekeyedRowKeys?: ReadonlyMap<string, string>
+  rows: readonly FakeRow[]
+  scrollTop: number
+  useDom: boolean
+}): number {
+  const scroller = createFakeScroller(args.rows, args.scrollTop)
+  runVirtualizedScrollAnchorRestore({
+    anchor: args.anchor,
+    el: scroller.el,
+    ...(args.useDom
+      ? {
+          getItemElementKey: (element: { rowKey: string }) => element.rowKey,
+          itemElementSelector: ITEM_SELECTOR
+        }
+      : {}),
+    pendingRestoreRef: { current: false },
+    recordScrollAnchor: vi.fn(),
+    ...(args.rekeyedRowKeys ? { rekeyedRowKeys: args.rekeyedRowKeys } : {}),
+    rowIndexByKey: scroller.rowIndexByKey,
+    scrollOffsetRef: { current: args.scrollTop },
+    virtualizer: scroller.virtualizer
+  } as never)
+  return scroller.el.scrollTop
+}
+
+// What WorktreeList's buildLineageRowRekeyMap produces for FOLDED_ROWS.
+const FOLD_REKEYS: ReadonlyMap<string, string> = new Map([
+  [PARENT_KEY, GROUP_KEY],
+  ['wt:sec:c', GROUP_KEY]
+])
+
+const ANCHORED_ON_PARENT = {
+  key: PARENT_KEY,
+  offset: 20,
+  fallbackKeys: ['wt:sec:s0', 'wt:sec:s1', 'wt:sec:s2'],
+  scrollTop: 520
+}
+
+describe('runVirtualizedScrollAnchorRestore lineage re-keying', () => {
+  it.each([
+    ['dom', true],
+    ['measured', false]
+  ])(
+    'keeps the sidebar still (%s path) when the anchored parent folds into a lineage group',
+    (_label, useDom) => {
+      // The anchored row did not move — only its key changed from `wt:` to
+      // `lineage-group:`. Resolving a fallback here jumped the list +180px.
+      expect(
+        restore({
+          anchor: { ...ANCHORED_ON_PARENT },
+          rekeyedRowKeys: FOLD_REKEYS,
+          rows: FOLDED_ROWS,
+          scrollTop: 520,
+          useDom
+        })
+      ).toBe(520)
+    }
+  )
+
+  it.each([
+    ['dom', true],
+    ['measured', false]
+  ])(
+    'still pins a genuine fallback at offset 0 (%s path) when no rekey map is supplied',
+    (_label, useDom) => {
+      // CombinedDiffViewer never passes a map; its behaviour must not change.
+      expect(
+        restore({
+          anchor: { ...ANCHORED_ON_PARENT },
+          rows: FOLDED_ROWS,
+          scrollTop: 520,
+          useDom
+        })
+      ).toBe(700)
+    }
+  )
+
+  it('pins a fallback at offset 0 when the anchored row was genuinely deleted', () => {
+    // A rekey map is supplied but has no entry for the removed row, so the
+    // fallback path (different row, offset dropped) must still win.
+    expect(
+      restore({
+        anchor: { ...ANCHORED_ON_PARENT },
+        rekeyedRowKeys: new Map(),
+        rows: DELETED_ROWS,
+        scrollTop: 520,
+        useDom: true
+      })
+    ).toBe(500)
+  })
+
+  it.each([
+    ['dom', true],
+    ['measured', false]
+  ])(
+    'clamps the followed offset to the shorter row (%s path) when a group dissolves',
+    (_label, useDom) => {
+      // Anchor recorded 150px into the 200px group row; the dissolved card is
+      // only 100px tall, so the offset clamps the way recording does.
+      expect(
+        restore({
+          anchor: { key: GROUP_KEY, offset: 150, fallbackKeys: ['wt:sec:s0'], scrollTop: 650 },
+          rekeyedRowKeys: new Map([[GROUP_KEY, PARENT_KEY]]),
+          rows: DISSOLVED_ROWS,
+          scrollTop: 650,
+          useDom
+        })
+      ).toBe(600)
+    }
+  )
+
+  it('ignores a rekey target that is not rendered this pass', () => {
+    // Stale map entry pointing at an absent row must degrade to the fallback,
+    // not leave the anchor unresolved.
+    expect(
+      restore({
+        anchor: { ...ANCHORED_ON_PARENT },
+        rekeyedRowKeys: new Map([[PARENT_KEY, 'lineage-group:sec:lineage:gone']]),
+        rows: DELETED_ROWS,
+        scrollTop: 520,
+        useDom: true
+      })
+    ).toBe(500)
+  })
+})
+
+describe('useVirtualizedScrollAnchor with sidebar row re-keying', () => {
+  afterEach(() => {
+    vi.doUnmock('react')
+    vi.resetModules()
+  })
+
+  it('does not scroll when a child worktree folds the anchored parent into a group', async () => {
+    const harness = createReactHookHarness()
+    vi.doMock('react', () => harness.react)
+    const { useVirtualizedScrollAnchor, VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } =
+      await import('./useVirtualizedScrollAnchor')
+
+    const anchorRef: { current: unknown } = { current: null }
+    const scrollOffsetRef = { current: 520 }
+    let scroller = createFakeScroller(UNFOLDED_ROWS, 520)
+    const scrollElementRef: { current: unknown } = { current: scroller.el }
+    const listeners = new Map<string, () => void>()
+    scroller.el.addEventListener.mockImplementation((name: string, handler: () => void) => {
+      listeners.set(name, handler)
+    })
+
+    // Sidebar's real config: DOM-confirmed rows, no restoreSignal, no marks.
+    const render = (rows: readonly FakeRow[], rekeyedRowKeys?: ReadonlyMap<string, string>) => {
+      harness.beginRender()
+      // oxlint-disable-next-line react-hooks/rules-of-hooks -- test harness mocks React's hook dispatcher directly.
+      useVirtualizedScrollAnchor({
+        anchorRef,
+        getItemElementKey: (element: { rowKey: string }) => element.rowKey,
+        getRowKey: (item: FakeRow) => item.key,
+        itemElementSelector: ITEM_SELECTOR,
+        rekeyedRowKeys,
+        rows,
+        scrollElementRef,
+        scrollOffsetRef,
+        totalSize: rows.reduce((sum, item) => sum + item.size, 0),
+        virtualizer: scroller.virtualizer
+      } as never)
+    }
+
+    render(UNFOLDED_ROWS)
+    harness.effects[0]?.effect()
+    listeners.get(VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT)?.()
+    expect(anchorRef.current).toMatchObject({ key: PARENT_KEY, offset: 20, scrollTop: 520 })
+
+    // Child created: same pixels, new key for the parent's row.
+    scroller = createFakeScroller(FOLDED_ROWS, 520)
+    scrollElementRef.current = scroller.el
+    render(FOLDED_ROWS, FOLD_REKEYS)
+    harness.effects[1]?.effect()
+
+    expect(scroller.el.scrollTop).toBe(520)
+    // The anchor re-records against the row's new key so later restores hit the
+    // exact-key path.
+    expect(anchorRef.current).toMatchObject({ key: GROUP_KEY, offset: 20 })
   })
 })

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
@@ -46,6 +46,10 @@ type UseVirtualizedScrollAnchorOptions<
   // Why: some callers record user scroll anchors outside this hook; passive
   // programmatic scroll events during remount must not teach them a transient row.
   recordAnchorOnScroll?: boolean
+  // Why: old key -> new key for rows this render re-keyed without moving, so an
+  // anchor recorded under the old key follows its own row instead of pinning a
+  // neighbour. Omitted by callers whose row keys are stable.
+  rekeyedRowKeys?: ReadonlyMap<string, string>
   // Why: when provided, anchor restore runs only when this value changes
   // (structural row changes) or while a prior restore is still converging —
   // not on every totalSize/isScrolling tick. Measurement-driven shifts are the
@@ -80,6 +84,7 @@ export function useVirtualizedScrollAnchor<
   programmaticScrollMarks,
   recordAnchorOnCleanup = true,
   recordAnchorOnScroll = true,
+  rekeyedRowKeys,
   restoreSignal,
   rows,
   scrollElementRef,
@@ -291,6 +296,7 @@ export function useVirtualizedScrollAnchor<
       pendingRestoreRef,
       programmaticScrollMarks: programmaticScrollMarksRef.current,
       recordScrollAnchor,
+      rekeyedRowKeys,
       rowIndexByKey,
       scrollOffsetRef,
       virtualizer
@@ -300,6 +306,7 @@ export function useVirtualizedScrollAnchor<
     getItemElementKey,
     itemElementSelector,
     recordScrollAnchor,
+    rekeyedRowKeys,
     restoreSignal,
     rowIndexByKey,
     scrollElementRef,

--- a/src/renderer/src/hooks/virtualized-scroll-anchor-restore.ts
+++ b/src/renderer/src/hooks/virtualized-scroll-anchor-restore.ts
@@ -17,6 +17,9 @@ type RunVirtualizedScrollAnchorRestoreArgs<
   pendingRestoreRef: MutableRefObject<boolean>
   programmaticScrollMarks?: ProgrammaticScrollMarks
   recordScrollAnchor: (scrollTop: number) => void
+  // Why: old key -> new key for rows that were re-keyed without moving. Lets an
+  // anchor follow its own row instead of resolving a fallback row below it.
+  rekeyedRowKeys?: ReadonlyMap<string, string>
   rowIndexByKey: ReadonlyMap<string, number>
   scrollOffsetRef: MutableRefObject<number>
   virtualizer: Virtualizer<TScrollElement, TItemElement>
@@ -40,13 +43,18 @@ export function runVirtualizedScrollAnchorRestore<
   pendingRestoreRef,
   programmaticScrollMarks,
   recordScrollAnchor,
+  rekeyedRowKeys,
   rowIndexByKey,
   scrollOffsetRef,
   virtualizer
 }: RunVirtualizedScrollAnchorRestoreArgs<TScrollElement, TItemElement>): (() => void) | undefined {
-  const resolvedKey = rowIndexByKey.has(anchor.key)
+  const hasExactKey = rowIndexByKey.has(anchor.key)
+  const rekeyed = hasExactKey ? undefined : rekeyedRowKeys?.get(anchor.key)
+  // Why: only follow a rekey that names a row present in this render.
+  const followedKey = rekeyed !== undefined && rowIndexByKey.has(rekeyed) ? rekeyed : undefined
+  const resolvedKey = hasExactKey
     ? anchor.key
-    : anchor.fallbackKeys?.find((key) => rowIndexByKey.has(key))
+    : (followedKey ?? anchor.fallbackKeys?.find((key) => rowIndexByKey.has(key)))
   if (!resolvedKey) {
     // Why: an unresolvable anchor has nothing to converge; rows that make it
     // resolvable again always arrive via a signal change, so leaving the arm
@@ -59,7 +67,16 @@ export function runVirtualizedScrollAnchorRestore<
     pendingRestoreRef.current = false
     return
   }
-  const offset = resolvedKey === anchor.key ? anchor.offset : 0
+  // Why: a fallback key means the anchored row was REMOVED and the row below
+  // slid up — a different row, so the within-row offset does not transfer. A
+  // followed key is the SAME row under a new key, so it does.
+  const followedRow = resolvedKey === followedKey
+  const offset = hasExactKey || followedRow ? anchor.offset : 0
+  // Why: the followed row can be a different height than the one the offset was
+  // recorded against (a lineage group dissolving back to a single card), so
+  // clamp it the same way recording does.
+  const offsetWithinRow = (rowHeight: number): number =>
+    followedRow ? Math.min(rowHeight, offset) : offset
   const canConfirmFromDom = Boolean(itemElementSelector && getItemElementKey)
 
   const restoreFromDomElement = (): boolean => {
@@ -75,7 +92,7 @@ export function runVirtualizedScrollAnchorRestore<
     }
     const scrollRect = el.getBoundingClientRect()
     const rect = element.getBoundingClientRect()
-    const desiredTop = scrollRect.top - offset
+    const desiredTop = scrollRect.top - offsetWithinRow(rect.height)
     const delta = rect.top - desiredTop
     if (Math.abs(delta) > 1) {
       // Why: this scroll write is still part of restore; keep the target
@@ -99,7 +116,10 @@ export function runVirtualizedScrollAnchorRestore<
       return false
     }
     const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
-    const nextScrollTop = Math.min(maxScrollTop, Math.max(0, item.start + offset))
+    const nextScrollTop = Math.min(
+      maxScrollTop,
+      Math.max(0, item.start + offsetWithinRow(item.size))
+    )
     if (Math.abs(el.scrollTop - nextScrollTop) > 1) {
       programmaticScrollMarks?.mark(nextScrollTop)
       el.scrollTop = nextScrollTop


### PR DESCRIPTION
## Description

Second, independent cause of "the left sidebar scrolls by itself". #11530 fixed the *reveal* path; this one has nothing to do with reveal.

Creating a **child** worktree makes `buildRenderableRows` fold the parent and its descendants into a single `lineage-group` render row, which **rewrites the parent's virtual row key**. A scroll anchor recorded under the old key could no longer find its row, fell through to a fallback key — a *different* row — and pinned that to the viewport top.

Measured: **scrollTop 520 → 700, a +180px jump**, with no `revealWorktreeInSidebar` involved.

## ELI5

The sidebar remembers your place with a bookmark: "the row at the top is *this* one, and you're 20px into it."

When a workspace gets its first child, Orca merges the parent and its children into one combined row — and in doing so gives it a new name. The bookmark still said the old name, and nothing answered to it anymore. So the sidebar reached for its backup plan: "if the bookmarked row is gone, it must have been deleted, so pin whatever slid up into its place." But the row wasn't deleted — it was standing right there under a new name. The sidebar pinned the *next* row instead, and everything lurched 180px.

Now the list hands restore a small "this row was renamed to that" note, so the bookmark can follow its own row. The backup plan still applies to genuinely deleted rows.

## Root cause

`getRenderRowKey` gives the same workspace two different keys depending on whether it currently has children:

```
wt:<sectionKey>:<worktreeId>   ->   lineage-group:<sectionKey>:lineage:<worktreeId>
```

`runVirtualizedScrollAnchorRestore` resolved `anchor.key`, then `anchor.fallbackKeys`. Those fallbacks encode a specific assumption — *"the anchored row was removed and the row below slid up"* — which is only sound for deletions. A re-key is not a deletion, so the fallback silently pinned a neighbour and forced the within-row offset to 0.

The reproduction's own decomposition proves the fix and rules out the obvious alternative:

| resolution | resulting scrollTop |
|---|---|
| fallback row, offset forced to 0 | 700 ← the bug |
| fallback row, offset preserved | 720 (worse) |
| **parent's new `lineage-group` key, original offset** | **520 — no movement** |

So the defect was never the `offset = 0` line; it was that the anchor had no way to follow a row whose identity was rewritten.

## Design

A caller-supplied `rekeyedRowKeys?: ReadonlyMap<string, string>`. Resolution becomes: exact `anchor.key` → **followed (re-keyed) key, if it names a row in this render** → `anchor.fallbackKeys`.

The offset transfers for a followed key (same row, new name) but is still dropped for a genuine fallback (different row) — the deletion semantics are preserved exactly. On the followed branch only, the offset is clamped to the resolved row's height, mirroring the record-time clamp, so a group dissolving back into a single card cannot overshoot.

`WorktreeList` owns the key scheme, so it builds the map; the hook stays generic. `getRenderRowKey` moved to `worktree-list-virtual-rows.ts` alongside the other row helpers (still re-exported from `WorktreeList` for existing importers) — `WorktreeList.tsx` net **shrinks by 19 lines**.

### What this deliberately does not do

An earlier design added a general "stable row identity" subsystem — a new public anchor field, a new hook option, a record-time transform, a resolver type, and 3 new test files. An adversarial review rejected it: the generality was inert for 6 of 7 row shapes, and it introduced a bug where an unclamped offset was written back into the anchor. This ships ~40 lines instead. If `pending → real` or pin/unpin are ever shown to jump in practice, they extend the same map with one entry each — on evidence.

The sidebar's missing `restoreSignal` is **not** bundled. It is verifiably non-curative here: at the moment the child lands no user scroll has happened, so the divergence guard passes while the structural gate opens, and restore still lands at 700. It is a real gap, but a separate PR.

## Proof of regression

Reverting only the resolution change (back to exact-key → fallbacks):

```
 ❯ useVirtualizedScrollAnchor.listener-deps.test.ts (12 tests | 3 failed)
   × keeps the sidebar still (dom path) when the anchored parent folds into a lineage group
   × keeps the sidebar still (measured path) when the anchored parent folds into a lineage group
   × does not scroll when a child worktree folds the anchored parent into a group

AssertionError: expected 700 to be 520 // Object.is equality
- Expected  520
+ Received  700

 Tests  3 failed | 9 passed (12)
```

Exactly the reported +180px. I reproduced this red independently of the agent that wrote the tests. The three control tests stayed **green** under the revert, confirming they are not coupled to the follow branch.

## Proof of fix

- Targeted: 27 passed across the two test files.
- Sidebar + hooks suites: **270 files, 2,395 tests passed**.
- Full unit suite: see below.
- `pnpm run typecheck:web`: passed.
- `pnpm run check:code-quality:changed`: 0 new findings across 6 files.
- `oxlint` + `oxfmt --check` clean.

## Proof of no regression

- **`CombinedDiffViewer` is provably unaffected** — it is the only other consumer of this hook, never passes `rekeyedRowKeys`, so `followedKey` is always `undefined` and resolution degenerates byte-for-byte to today's two-step logic. Covered by explicit "no rekey map supplied" tests asserting the old **700** behavior still happens.
- **Genuine deletions unchanged** — a map with no matching entry still resolves a fallback with offset 0.
- **Stale map entries are ignored** — a rekey target not rendered this pass degrades to the fallback rather than leaving the anchor unresolved.
- The scroll-listener effect and its deps are untouched; `rekeyedRowKeys` is read only in the restore effect. No new `useLayoutEffect`.
- `getRenderRowKey` output is unchanged, so the reveal path (`findPreferredRenderRowIndexForWorktree`, `revealMountedWorktreeElement`), drag, context-menu, and `elementsCache` pruning all keep their existing key namespace.

## Known limitation

The jump requires the anchored **top-visible** row to be exactly the parent gaining its first child (or losing its last). If that parent sits above or below the anchor row, the anchor key survives and restore already held position correctly. Scrolling *within* an already-formed lineage group as it grows is a separate composite-row concern and is not addressed here.

Made with [Orca](https://github.com/stablyai/orca) 🐋
