### PR TITLE
fix(add-project): route server "Open as Git" to the selected runtime host

### DIFF
--- a/src/renderer/src/components/sidebar/AddRepoDialog.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoDialog.tsx
@@ -76,10 +76,10 @@ const AddRepoDialog = React.memo(function AddRepoDialog({
   })
 
   const hostSelection = useAddRepoHostSelection({ isOpen, setStep })
+  const selectedParsedHost = hostSelection.selectedParsedHost
+  const selectedHostKind = selectedParsedHost?.kind
   const selectedRuntimeEnvironmentId =
-    hostSelection.selectedParsedHost?.kind === 'runtime'
-      ? hostSelection.selectedParsedHost.environmentId
-      : null
+    selectedParsedHost?.kind === 'runtime' ? selectedParsedHost.environmentId : null
   const { showRemoteNestedRepoReview, trackRemoteNestedScanResult } = useAddRepoRemoteNestedScan({
     setActiveNestedScanId,
     showNestedRepoReview
@@ -170,7 +170,6 @@ const AddRepoDialog = React.memo(function AddRepoDialog({
   })
 
   const isRuntimeEnvironmentActive = Boolean(selectedRuntimeEnvironmentId)
-  const selectedHostKind = hostSelection.selectedParsedHost?.kind
   const { handleBrowse, resetLocalFolderFlow } = useAddRepoLocalFolderFlow({
     isOpen,
     droppedLocalPath,
@@ -195,6 +194,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog({
     handleAddServerPath
   } = useAddRepoServerPathFlow({
     addRepoPath,
+    activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId,
     // Why: closes only after a folder add, which activates the folder workspace.
     closeModal: closeForFolderHandoff,
     fetchWorktrees,
@@ -332,7 +332,7 @@ const AddRepoDialog = React.memo(function AddRepoDialog({
           hostSelection.hostOptions.find((host) => host.id === hostSelection.selectedHostId)
             ?.label ?? hostSelection.selectedHostId
         }
-        lockSshTargetSelection={hostSelection.selectedParsedHost?.kind === 'ssh'}
+        lockSshTargetSelection={selectedHostKind === 'ssh'}
         remotePath={remotePath}
         remoteError={remoteError}
         isAddingRemote={isAddingRemote}

--- a/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.test.ts
@@ -76,6 +76,7 @@ describe('useAddRepoServerPathFlow', () => {
 
     const result = useAddRepoServerPathFlow({
       addRepoPath: mocks.addRepoPath,
+      activeRuntimeEnvironmentId: 'env-1',
       closeModal: mocks.closeModal,
       fetchWorktrees: mocks.fetchWorktrees,
       getNestedRepoRuntimeKind: mocks.getNestedRepoRuntimeKind,
@@ -88,11 +89,61 @@ describe('useAddRepoServerPathFlow', () => {
     })
     await result.handleAddServerPath('folder')
 
-    expect(mocks.addRepoPath).toHaveBeenCalledWith('/server/docs', 'folder')
+    expect(mocks.addRepoPath).toHaveBeenCalledWith('/server/docs', 'folder', {
+      runtimeEnvironmentId: 'env-1'
+    })
     expect(mocks.scanNestedRepos).not.toHaveBeenCalled()
     expect(mocks.fetchWorktrees).not.toHaveBeenCalled()
     expect(mocks.onGitRepoReady).not.toHaveBeenCalled()
     expect(mocks.markOnboardingProjectAdded).toHaveBeenCalledWith('addedFolder')
     expect(mocks.closeModal).toHaveBeenCalled()
+  })
+
+  it('routes the Git scan and add to the selected runtime host', async () => {
+    // Why: the Add Project host selector picks a runtime host without flipping
+    // the global active environment. Regression guard for the "Open as Git"
+    // failure where a server repo was probed locally ("checked locally").
+    mocks.getNestedRepoRuntimeKind.mockReturnValue('local')
+    mocks.scanNestedRepos.mockResolvedValue({
+      selectedPath: '/workspace/torch',
+      selectedPathKind: 'git_repo',
+      repos: [],
+      truncated: false,
+      timedOut: false,
+      stopped: false,
+      durationMs: 1,
+      maxDepth: 1,
+      maxRepos: 1,
+      timeoutMs: 1
+    })
+    mocks.addRepoPath.mockResolvedValue(
+      makeRepo({ id: 'torch', path: '/workspace/torch', kind: 'git' })
+    )
+    mocks.stateValues = ['/workspace/torch', false]
+    const { useAddRepoServerPathFlow } = await import('./useAddRepoServerPathFlow')
+
+    const result = useAddRepoServerPathFlow({
+      addRepoPath: mocks.addRepoPath,
+      activeRuntimeEnvironmentId: 'env-1',
+      closeModal: mocks.closeModal,
+      fetchWorktrees: mocks.fetchWorktrees,
+      getNestedRepoRuntimeKind: mocks.getNestedRepoRuntimeKind,
+      scanNestedRepos: mocks.scanNestedRepos,
+      setActiveNestedScanId: mocks.setActiveNestedScanId,
+      setNestedScanInProgress: mocks.setNestedScanInProgress,
+      showNestedRepoReview: mocks.showNestedRepoReview,
+      onGitRepoReady: mocks.onGitRepoReady,
+      setAddProjectBusyLabel: mocks.setAddProjectBusyLabel
+    })
+    await result.handleAddServerPath('git')
+
+    // A runtime host can't stream scans, so no scanId/onProgress is supplied.
+    expect(mocks.scanNestedRepos).toHaveBeenCalledWith('/workspace/torch', undefined, {
+      runtimeEnvironmentId: 'env-1'
+    })
+    expect(mocks.addRepoPath).toHaveBeenCalledWith('/workspace/torch', 'git', {
+      runtimeEnvironmentId: 'env-1'
+    })
+    expect(mocks.onGitRepoReady).toHaveBeenCalledWith('torch', 'runtime_server_path')
   })
 })

--- a/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.test.ts
@@ -146,4 +146,53 @@ describe('useAddRepoServerPathFlow', () => {
     })
     expect(mocks.onGitRepoReady).toHaveBeenCalledWith('torch', 'runtime_server_path')
   })
+
+  it('treats an all-whitespace runtime id as local for both the scan and the add', async () => {
+    // Why: the telemetry guard trims the id but the scan/add selectors used to
+    // forward it untrimmed, so a whitespace id disagreed — routing local for
+    // telemetry while sending whitespace to the RPC. Both must resolve to null.
+    mocks.getNestedRepoRuntimeKind.mockReturnValue('local')
+    mocks.scanNestedRepos.mockResolvedValue({
+      selectedPath: '/workspace/torch',
+      selectedPathKind: 'git_repo',
+      repos: [],
+      truncated: false,
+      timedOut: false,
+      stopped: false,
+      durationMs: 1,
+      maxDepth: 1,
+      maxRepos: 1,
+      timeoutMs: 1
+    })
+    mocks.addRepoPath.mockResolvedValue(
+      makeRepo({ id: 'torch', path: '/workspace/torch', kind: 'git' })
+    )
+    mocks.stateValues = ['/workspace/torch', false]
+    const { useAddRepoServerPathFlow } = await import('./useAddRepoServerPathFlow')
+
+    const result = useAddRepoServerPathFlow({
+      addRepoPath: mocks.addRepoPath,
+      activeRuntimeEnvironmentId: '   ',
+      closeModal: mocks.closeModal,
+      fetchWorktrees: mocks.fetchWorktrees,
+      getNestedRepoRuntimeKind: mocks.getNestedRepoRuntimeKind,
+      scanNestedRepos: mocks.scanNestedRepos,
+      setActiveNestedScanId: mocks.setActiveNestedScanId,
+      setNestedScanInProgress: mocks.setNestedScanInProgress,
+      showNestedRepoReview: mocks.showNestedRepoReview,
+      onGitRepoReady: mocks.onGitRepoReady,
+      setAddProjectBusyLabel: mocks.setAddProjectBusyLabel
+    })
+    await result.handleAddServerPath('git')
+
+    // Resolved to local, so a streaming scan (scanId) is supplied — not the
+    // no-stream runtime path — and the RPC selector gets null, not whitespace.
+    const scanArgs = mocks.scanNestedRepos.mock.calls[0]
+    expect(scanArgs[0]).toBe('/workspace/torch')
+    expect(scanArgs[2].runtimeEnvironmentId).toBeNull()
+    expect(typeof scanArgs[2].scanId).toBe('string')
+    expect(mocks.addRepoPath).toHaveBeenCalledWith('/workspace/torch', 'git', {
+      runtimeEnvironmentId: null
+    })
+  })
 })

--- a/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.test.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.test.ts
@@ -148,9 +148,8 @@ describe('useAddRepoServerPathFlow', () => {
   })
 
   it('treats an all-whitespace runtime id as local for both the scan and the add', async () => {
-    // Why: the telemetry guard trims the id but the scan/add selectors used to
-    // forward it untrimmed, so a whitespace id disagreed — routing local for
-    // telemetry while sending whitespace to the RPC. Both must resolve to null.
+    // Why: a whitespace-only id must resolve to null so the scan and add route
+    // as local, not forward whitespace to the RPC selector.
     mocks.getNestedRepoRuntimeKind.mockReturnValue('local')
     mocks.scanNestedRepos.mockResolvedValue({
       selectedPath: '/workspace/torch',
@@ -185,8 +184,7 @@ describe('useAddRepoServerPathFlow', () => {
     })
     await result.handleAddServerPath('git')
 
-    // Resolved to local, so a streaming scan (scanId) is supplied — not the
-    // no-stream runtime path — and the RPC selector gets null, not whitespace.
+    // Local routing supplies a streaming scanId and a null RPC selector.
     const scanArgs = mocks.scanNestedRepos.mock.calls[0]
     expect(scanArgs[0]).toBe('/workspace/torch')
     expect(scanArgs[2].runtimeEnvironmentId).toBeNull()

--- a/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.ts
@@ -83,13 +83,16 @@ export function useAddRepoServerPathFlow({
       const gen = ++serverAddGenRef.current
       setIsAddingServerPath(true)
       setAddProjectBusyLabel(kind === 'git' ? 'Scanning for repositories...' : 'Opening folder...')
+      // Why: this flow always targets the selected runtime host. Resolve the id
+      // once (trimmed) so the telemetry guard, the scan, and the add can't
+      // disagree on an all-whitespace value.
+      const resolvedRuntimeEnvironmentId = activeRuntimeEnvironmentId?.trim() || null
       try {
         if (kind === 'git') {
           const attemptId = createNestedRepoTelemetryAttemptId()
-          // Why: this flow always targets the selected runtime host, so derive
-          // the runtime kind from it (getNestedRepoRuntimeKind reads the global
-          // active environment, which can still be local here).
-          const runtimeKind: NestedRepoTelemetryRuntimeKind = activeRuntimeEnvironmentId?.trim()
+          // Why: getNestedRepoRuntimeKind reads the global active environment,
+          // which can still be local here, so derive the kind from the selected host.
+          const runtimeKind: NestedRepoTelemetryRuntimeKind = resolvedRuntimeEnvironmentId
             ? 'runtime'
             : getNestedRepoRuntimeKind(null)
           const supportsStreamingScan = runtimeKind !== 'runtime'
@@ -125,7 +128,7 @@ export function useAddRepoServerPathFlow({
             // Why: route the git check to the selected runtime host, not the
             // global active environment — otherwise a server repo is probed
             // locally and wrongly falls back to "Open as Folder".
-            runtimeEnvironmentId: activeRuntimeEnvironmentId ?? null
+            runtimeEnvironmentId: resolvedRuntimeEnvironmentId
           })
           if (gen !== serverAddGenRef.current) {
             return
@@ -158,7 +161,7 @@ export function useAddRepoServerPathFlow({
         // Why: pin the add to the selected runtime host so a server repo is
         // resolved where it lives, matching the scan above.
         const repo = await addRepoPath(path, kind, {
-          runtimeEnvironmentId: activeRuntimeEnvironmentId ?? null
+          runtimeEnvironmentId: resolvedRuntimeEnvironmentId
         })
         if (gen !== serverAddGenRef.current) {
           return

--- a/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.ts
+++ b/src/renderer/src/components/sidebar/useAddRepoServerPathFlow.ts
@@ -23,6 +23,7 @@ type ShowNestedRepoReview = (args: {
 
 export function useAddRepoServerPathFlow({
   addRepoPath,
+  activeRuntimeEnvironmentId,
   closeModal,
   fetchWorktrees,
   getNestedRepoRuntimeKind,
@@ -33,14 +34,23 @@ export function useAddRepoServerPathFlow({
   onGitRepoReady,
   setAddProjectBusyLabel
 }: {
-  addRepoPath: (path: string, kind?: 'git' | 'folder') => Promise<Repo | null>
+  addRepoPath: (
+    path: string,
+    kind?: 'git' | 'folder',
+    options?: { runtimeEnvironmentId?: string | null }
+  ) => Promise<Repo | null>
+  activeRuntimeEnvironmentId: string | null | undefined
   closeModal: () => void
   fetchWorktrees: (repoId: string, options?: { requireAuthoritative?: boolean }) => Promise<unknown>
   getNestedRepoRuntimeKind: (connectionId: string | null) => NestedRepoTelemetryRuntimeKind
   scanNestedRepos: (
     path: string,
     connectionId?: string,
-    controls?: { scanId?: string; onProgress?: (scan: NestedRepoScanResult) => void }
+    controls?: {
+      scanId?: string
+      onProgress?: (scan: NestedRepoScanResult) => void
+      runtimeEnvironmentId?: string | null
+    }
   ) => Promise<NestedRepoScanResult | null>
   setActiveNestedScanId: (scanId: string | null) => void
   setNestedScanInProgress: (inProgress: boolean) => void
@@ -76,17 +86,20 @@ export function useAddRepoServerPathFlow({
       try {
         if (kind === 'git') {
           const attemptId = createNestedRepoTelemetryAttemptId()
-          const runtimeKind = getNestedRepoRuntimeKind(null)
+          // Why: this flow always targets the selected runtime host, so derive
+          // the runtime kind from it (getNestedRepoRuntimeKind reads the global
+          // active environment, which can still be local here).
+          const runtimeKind: NestedRepoTelemetryRuntimeKind = activeRuntimeEnvironmentId?.trim()
+            ? 'runtime'
+            : getNestedRepoRuntimeKind(null)
           const supportsStreamingScan = runtimeKind !== 'runtime'
           const scanId = supportsStreamingScan ? createNestedRepoScanId() : null
           if (scanId) {
             setActiveNestedScanId(scanId)
             setNestedScanInProgress(true)
           }
-          const scan = await scanNestedRepos(
-            path,
-            undefined,
-            scanId
+          const scan = await scanNestedRepos(path, undefined, {
+            ...(scanId
               ? {
                   scanId,
                   onProgress: (progressScan) => {
@@ -108,8 +121,12 @@ export function useAddRepoServerPathFlow({
                     })
                   }
                 }
-              : undefined
-          )
+              : {}),
+            // Why: route the git check to the selected runtime host, not the
+            // global active environment — otherwise a server repo is probed
+            // locally and wrongly falls back to "Open as Folder".
+            runtimeEnvironmentId: activeRuntimeEnvironmentId ?? null
+          })
           if (gen !== serverAddGenRef.current) {
             return
           }
@@ -138,7 +155,11 @@ export function useAddRepoServerPathFlow({
           }
         }
         setAddProjectBusyLabel(kind === 'git' ? 'Opening project...' : 'Opening folder...')
-        const repo = await addRepoPath(path, kind)
+        // Why: pin the add to the selected runtime host so a server repo is
+        // resolved where it lives, matching the scan above.
+        const repo = await addRepoPath(path, kind, {
+          runtimeEnvironmentId: activeRuntimeEnvironmentId ?? null
+        })
         if (gen !== serverAddGenRef.current) {
           return
         }
@@ -167,6 +188,7 @@ export function useAddRepoServerPathFlow({
     },
     [
       addRepoPath,
+      activeRuntimeEnvironmentId,
       closeModal,
       fetchWorktrees,
       getNestedRepoRuntimeKind,

--- a/src/renderer/src/store/slices/repos-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups.test.ts
@@ -793,6 +793,41 @@ describe('project group store routing', () => {
     })
   })
 
+  it('routes nested scans to an explicit runtime host even when the active env is local', async () => {
+    // Why: the Add Project host selector targets a runtime host without flipping
+    // the global active environment. Without explicit routing the git check runs
+    // locally and a real server repo wrongly reads as a non-git folder.
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-scan',
+      ok: true,
+      result: {
+        selectedPath: '/workspace/torch',
+        selectedPathKind: 'git_repo',
+        repos: [],
+        truncated: false,
+        timedOut: false,
+        durationMs: 4,
+        maxDepth: 3
+      },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: null } as never })
+
+    const scan = await store
+      .getState()
+      .scanNestedRepos('/workspace/torch', undefined, { runtimeEnvironmentId: 'env-1' })
+
+    expect(scan?.selectedPathKind).toBe('git_repo')
+    expect(projectGroupsScanNested).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectGroup.scanNested',
+      params: { path: '/workspace/torch' },
+      timeoutMs: 20_000
+    })
+  })
+
   it('moves local repos to a group using the preload projectId contract', async () => {
     const movedRepo = { ...remoteRepo, projectGroupId: projectGroup.id, projectGroupOrder: 3 }
     projectGroupsMoveProject.mockResolvedValue(movedRepo)

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -175,6 +175,9 @@ function getFolderWorkspaceUpdateCoordinator(
 type NestedRepoScanControls = {
   scanId?: string
   onProgress?: (scan: NestedRepoScanResult) => void
+  // Why: the Add Project host selector picks a runtime target without changing the
+  // global active environment, so the scan must be routed to that host explicitly.
+  runtimeEnvironmentId?: string | null
 }
 
 export type FolderWorkspacePathStatusCacheEntry = {
@@ -2100,7 +2103,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   scanNestedRepos: async (path, connectionId, controls) => {
     try {
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: the Add Project host selector can target a runtime host without
+      // flipping the global active environment; route the scan to the selected
+      // host so the git check runs where the folder actually lives.
+      const target =
+        controls && 'runtimeEnvironmentId' in controls
+          ? getActiveRuntimeTarget({ activeRuntimeEnvironmentId: controls.runtimeEnvironmentId })
+          : getActiveRuntimeTarget(get().settings)
       if (target.kind === 'local') {
         const unsubscribe =
           controls?.scanId && controls.onProgress


### PR DESCRIPTION
## Summary

Opening an **existing** Git repository on a remote **Orca Server** via *Add Project → Browse host → Add Git Project* failed: Orca fell back to the non-git **"Open as Folder"** dialog reading *"This path was checked locally."* Cloning worked; only opening a pre-existing repo failed.

Root cause: in `AddRepoDialog`, every add flow threads the selected runtime host into its store calls (`activeRuntimeEnvironmentId: selectedRuntimeEnvironmentId`) — local-folder, clone, create, nested-import — **except** the server-path flow. `useAddRepoServerPathFlow` routed `scanNestedRepos()` and `addRepoPath()` through the *global* active runtime environment, so when the global host was Local the Git probe ran locally against a path that only exists on the server, misclassified it as a folder, and opened the local non-git dialog.

Fix:
- Thread the selected `runtimeEnvironmentId` through `useAddRepoServerPathFlow` into both the nested scan and the repo add.
- `scanNestedRepos` now accepts an explicit `runtimeEnvironmentId` in its controls and routes the scan to that host instead of the global active environment.
- Derive the flow's `runtimeKind` (streaming/telemetry) from the selected host so it stays consistent with where the scan runs.
- As a side effect, when a server path genuinely isn't a Git repo the confirmation dialog now names the correct host instead of saying "checked locally".

Resolves stablyai/orca#11551.

## Screenshots

No visual change. (The non-git confirmation dialog now reports the correct host name in the server-path case instead of "checked locally"; no layout change.)

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck` (web project — `tsc -p config/tsconfig.tc.web.json`)
- [x] `pnpm test` (affected suites: `useAddRepoServerPathFlow`, `repos-project-groups`, `AddRepoDialog.default-checkout`)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Notes on testing: ran `oxlint` (native + type-aware config) on the changed files clean, and `oxfmt`/`oxlint` via the pre-commit hook. Full `pnpm lint`/`pnpm build` were not run locally (dev box runs Node 26 vs the repo's Node 24; a set of unrelated sidebar suites fail in that environment on `window.localStorage.clear()` being undefined — not touched by this change). Added a store-level regression test asserting the scan routes to an explicit runtime host even when the global env is Local, and a hook test asserting both scan and add carry the selected `runtimeEnvironmentId`.

## AI Review Report

Reviewed by the coding agent for correctness and scope. Main risks checked:
- **Routing correctness:** the new `runtimeEnvironmentId` is honored via `getActiveRuntimeTarget({ activeRuntimeEnvironmentId })` and `callRuntimeRpc`, matching how clone/create/local flows already route. Presence-detection uses `'runtimeEnvironmentId' in controls` so an explicit `null` correctly forces Local while an absent field preserves the prior global-target behavior for other callers.
- **No behavior change for other `scanNestedRepos` callers:** local-folder and remote (SSH) flows don't pass the new field, so they keep routing through the global target.
- **Cross-platform:** no platform-specific code touched — no keyboard shortcuts, path separators, or shell behavior. The server-side Git probe already runs on the host that owns the path (native/WSL/SSH/runtime), so routing to the correct host is what makes cross-platform detection correct here.
- **Refactor safety:** hoisted `selectedParsedHost`/`selectedHostKind` in `AddRepoDialog` to dedupe and stay under the `max-lines` limit without disabling the rule; typecheck confirms narrowing is preserved.

## Security Audit

- **Input/path handling:** the runtime path is forwarded to the existing server RPC (`projectGroup.scanNested`, `repo.add`), which already validates absolute paths and repo-ness server-side; no new path parsing or command construction is introduced on the client.
- **Command execution / IPC:** no new IPC surface; reuses `callRuntimeRpc` with the same bounded timeout. No secrets, auth, or dependency changes.
- No follow-up security work identified.

## Notes

The fix is client-side routing only. Behavior for local and SSH add flows is unchanged; only the Orca Server (runtime) server-path flow now targets the selected host for its Git check and add.