### PR TITLE
feat: support multi-file open via file picker and external launch events

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -320,6 +320,10 @@ let desktopRelayStatus: RelayBrokerStatus = 'offline'
 let pendingUnpairedDeviceAuthFailure = false
 // Why: gates whether headless serve installs the offscreen browser backend (and advertises browser pane support).
 let headlessBrowserDisplayAvailable = false
+// Why: macOS open-file fires before whenReady; queue paths so the renderer can open them after the window loads.
+const pendingExternalOpenFiles: string[] = []
+// Why: macOS open-file fires before the app is ready; track whether the event was registered so we don't double-register.
+let openFileListenerRegistered = false
 
 let starNag: StarNagService | null = null
 let agentAwakeService: AgentAwakeService | null = null
@@ -581,6 +585,19 @@ function requestDesktopActivation(): void {
   desktopActivationGate.requestActivation()
 }
 
+/**
+ * second-instance callback: activates the window AND processes any file
+ * paths passed via argv (e.g. `orca file.txt` from CLI when already running).
+ */
+function handleSecondInstance(_event: Electron.Event, argv: string[]): void {
+  requestDesktopActivation()
+  const filePaths = extractFilePathsFromArgv(argv)
+  if (filePaths.length > 0) {
+    pendingExternalOpenFiles.push(...filePaths)
+    flushPendingExternalOpenFiles()
+  }
+}
+
 const handleMacAppActivation = createMacAppActivationHandler({
   getWindow: () => mainWindow,
   requestActivation: requestDesktopActivation
@@ -686,7 +703,7 @@ const hasSingleInstanceLock = skipSingleInstanceLock
   ? true
   : bypassSingleInstanceLock
     ? true
-    : acquireSingleInstanceLock(app, requestDesktopActivation)
+    : acquireSingleInstanceLock(app, handleSecondInstance)
 if (startupDiagnosticsEnabled) {
   logStartupDiagnostic('single-instance-lock-result', {
     acquired: hasSingleInstanceLock,
@@ -1243,6 +1260,8 @@ function openMainWindow(): BrowserWindow {
     clearExpectedRendererReload(rendererWebContentsId)
     recordCrashBreadcrumb('main_window_loaded')
     logStartupMilestone('did-finish-load')
+    // Why: flush any files queued by the macOS open-file event before the renderer was ready.
+    flushPendingExternalOpenFiles()
     if (!store) {
       return
     }
@@ -1931,6 +1950,62 @@ function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {
       agentEnv: args.launchConfig.agentEnv
     }) === 'yolo'
   )
+}
+
+// Why: macOS open-file fires before whenReady; queue the paths for the renderer to open after the window loads.
+// Must be registered before app.whenReady() so the first open-file event is captured.
+if (process.platform === 'darwin' && !openFileListenerRegistered) {
+  openFileListenerRegistered = true
+  app.on('open-file', (_event, filePath) => {
+    _event.preventDefault()
+    if (filePath && existsSync(filePath)) {
+      pendingExternalOpenFiles.push(filePath)
+      // Why: if the window is already loaded, flush immediately;
+      // otherwise the queue is drained on did-finish-load.
+      flushPendingExternalOpenFiles()
+    }
+  })
+}
+
+/**
+ * Extract file paths from second-instance argv.
+ * Skips the app binary, flags, and non-existent paths.
+ */
+function extractFilePathsFromArgv(argv: string[]): string[] {
+  const paths: string[] = []
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i]
+    // Why: skip flags (--foo, -f) and non-absolute paths.
+    if (arg.startsWith('-') || !isAbsolute(arg)) {
+      continue
+    }
+    try {
+      if (existsSync(arg)) {
+        paths.push(arg)
+      }
+    } catch {
+      // ignore stat errors
+    }
+  }
+  return paths
+}
+
+/**
+ * Send queued external file paths to the renderer for opening in editor tabs.
+ * Uses the same 'terminal:file-drop' IPC channel as native file drops.
+ */
+function flushPendingExternalOpenFiles(): void {
+  if (pendingExternalOpenFiles.length === 0) {
+    return
+  }
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return
+  }
+  const paths = pendingExternalOpenFiles.splice(0)
+  mainWindow.webContents.send('terminal:file-drop', {
+    paths,
+    target: 'editor'
+  })
 }
 
 void app.whenReady().then(async () => {

--- a/src/main/ipc/shell-pickers.ts
+++ b/src/main/ipc/shell-pickers.ts
@@ -1,0 +1,139 @@
+import { dialog, ipcMain } from 'electron'
+import { basename, extname } from 'node:path'
+import { readFile, stat } from 'node:fs/promises'
+import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
+
+const REPO_ICON_IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png'
+}
+
+/**
+ * Register all file/folder picker dialog IPC handlers.
+ * Extracted from shell.ts to keep the file under the max-lines limit.
+ */
+export function registerShellPickerHandlers(): void {
+  // Why: window.prompt() and <input type="file"> are unreliable in Electron,
+  // so we use the native OS dialog to let the user pick any attachment file.
+  ipcMain.handle('shell:pickAttachment', async (): Promise<string | null> => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile']
+    })
+    if (result.canceled || result.filePaths.length === 0) {
+      return null
+    }
+    return result.filePaths[0]
+  })
+
+  // Why: multi-select variant of pickAttachment so users can select several
+  // files at once instead of repeating the picker for each file.
+  ipcMain.handle('shell:pickAttachments', async (): Promise<string[]> => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile', 'multiSelections']
+    })
+    if (result.canceled || result.filePaths.length === 0) {
+      return []
+    }
+    return result.filePaths
+  })
+
+  // Why: window.prompt() and <input type="file"> are unreliable in Electron,
+  // so we use the native OS dialog to let the user pick an image file.
+  ipcMain.handle('shell:pickImage', async (): Promise<string | null> => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile'],
+      filters: [
+        { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'] }
+      ]
+    })
+    if (result.canceled || result.filePaths.length === 0) {
+      return null
+    }
+    return result.filePaths[0]
+  })
+
+  // Why: multi-select variant of pickImage so users can insert several images
+  // into a Markdown document at once instead of picking them one by one.
+  ipcMain.handle('shell:pickImages', async (): Promise<string[]> => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile', 'multiSelections'],
+      filters: [
+        { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'] }
+      ]
+    })
+    if (result.canceled || result.filePaths.length === 0) {
+      return []
+    }
+    return result.filePaths
+  })
+
+  ipcMain.handle('shell:pickAudio', async (): Promise<string | null> => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile'],
+      filters: [{ name: 'Audio', extensions: ['ogg', 'mp3', 'wav', 'm4a', 'aac', 'flac'] }]
+    })
+    if (result.canceled || result.filePaths.length === 0) {
+      return null
+    }
+    return result.filePaths[0]
+  })
+
+  // Why: multi-select variant of pickAudio so users can pick several audio
+  // files in one dialog instead of repeating the picker for each file.
+  ipcMain.handle('shell:pickAudios', async (): Promise<string[]> => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile', 'multiSelections'],
+      filters: [{ name: 'Audio', extensions: ['ogg', 'mp3', 'wav', 'm4a', 'aac', 'flac'] }]
+    })
+    if (result.canceled || result.filePaths.length === 0) {
+      return []
+    }
+    return result.filePaths
+  })
+
+  ipcMain.handle(
+    'shell:pickDirectory',
+    async (_event, args: { defaultPath?: string }): Promise<string | null> => {
+      const result = await dialog.showOpenDialog({
+        defaultPath: args.defaultPath,
+        // Why: callers only need an existing folder grant; enabling native
+        // creation can leave typed prefix directories behind on macOS.
+        properties: ['openDirectory']
+      })
+      if (result.canceled || result.filePaths.length === 0) {
+        return null
+      }
+      return result.filePaths[0]
+    }
+  )
+
+  ipcMain.handle(
+    'shell:pickRepoIconImage',
+    async (): Promise<{ dataUrl: string; fileName: string } | null> => {
+      const result = await dialog.showOpenDialog({
+        properties: ['openFile'],
+        filters: [{ name: 'Repo icon images', extensions: ['png'] }]
+      })
+      if (result.canceled || result.filePaths.length === 0) {
+        return null
+      }
+
+      const filePath = result.filePaths[0]
+      const extension = extname(filePath).toLowerCase()
+      const mimeType = REPO_ICON_IMAGE_MIME_TYPES[extension]
+      if (!mimeType) {
+        throw new Error('Repo icons must be PNG files.')
+      }
+
+      const stats = await stat(filePath)
+      if (stats.size > MAX_REPO_ICON_UPLOAD_BYTES) {
+        throw new Error('Repo icon image must be 256KB or smaller.')
+      }
+
+      const buffer = await readFile(filePath)
+      return {
+        dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
+        fileName: basename(filePath)
+      }
+    }
+  )
+}

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -693,4 +693,64 @@ describe('registerShellHandlers', () => {
       expect(openPathMock).toHaveBeenCalledWith(normalize(filePath))
     })
   })
+
+  describe('multi-select pickers', () => {
+    it('picks multiple attachments at once', async () => {
+      showOpenDialogMock.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/a.txt', '/b.txt', '/c.pdf']
+      })
+      const handler = getHandler('shell:pickAttachments')
+      await expect(handler({})).resolves.toEqual(['/a.txt', '/b.txt', '/c.pdf'])
+      expect(showOpenDialogMock).toHaveBeenCalledWith({
+        properties: ['openFile', 'multiSelections']
+      })
+    })
+
+    it('returns empty array when multi-attachment picking is canceled', async () => {
+      showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] })
+      const handler = getHandler('shell:pickAttachments')
+      await expect(handler({})).resolves.toEqual([])
+    })
+
+    it('picks multiple images at once', async () => {
+      showOpenDialogMock.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/photos/a.jpg', '/photos/b.png']
+      })
+      const handler = getHandler('shell:pickImages')
+      await expect(handler({})).resolves.toEqual(['/photos/a.jpg', '/photos/b.png'])
+      expect(showOpenDialogMock).toHaveBeenCalledWith({
+        properties: ['openFile', 'multiSelections'],
+        filters: [
+          { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'] }
+        ]
+      })
+    })
+
+    it('returns empty array when multi-image picking is canceled', async () => {
+      showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] })
+      const handler = getHandler('shell:pickImages')
+      await expect(handler({})).resolves.toEqual([])
+    })
+
+    it('picks multiple audio files at once', async () => {
+      showOpenDialogMock.mockResolvedValue({
+        canceled: false,
+        filePaths: ['/music/a.mp3', '/music/b.ogg']
+      })
+      const handler = getHandler('shell:pickAudios')
+      await expect(handler({})).resolves.toEqual(['/music/a.mp3', '/music/b.ogg'])
+      expect(showOpenDialogMock).toHaveBeenCalledWith({
+        properties: ['openFile', 'multiSelections'],
+        filters: [{ name: 'Audio', extensions: ['ogg', 'mp3', 'wav', 'm4a', 'aac', 'flac'] }]
+      })
+    })
+
+    it('returns empty array when multi-audio picking is canceled', async () => {
+      showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] })
+      const handler = getHandler('shell:pickAudios')
+      await expect(handler({})).resolves.toEqual([])
+    })
+  })
 })

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -1,14 +1,13 @@
-import { ipcMain, shell, dialog } from 'electron'
+import { ipcMain, shell } from 'electron'
 import { spawn } from 'node:child_process'
-import { constants, copyFile, readFile, stat } from 'node:fs/promises'
-import { basename, extname, isAbsolute, normalize, posix, win32 } from 'node:path'
+import { constants, copyFile, stat } from 'node:fs/promises'
+import { isAbsolute, normalize, posix, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type {
   ShellOpenExternalEditorRequest,
   ShellOpenExternalEditorResult,
   ShellOpenLocalPathResult
 } from '../../shared/shell-open-types'
-import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
 import type { Store } from '../persistence'
 import { getSpawnArgsForWindows } from '../win32-utils'
 import {
@@ -18,12 +17,9 @@ import {
   type ExternalEditorLaunchSpec
 } from '../external-editor-launch'
 import { resolveVsCodeSshAuthority } from '../ssh/vscode-ssh-authority'
+import { registerShellPickerHandlers } from './shell-pickers'
 
 export { EXTERNAL_EDITOR_CLI_COMMAND }
-
-const REPO_ICON_IMAGE_MIME_TYPES: Record<string, string> = {
-  '.png': 'image/png'
-}
 
 async function pathExists(pathValue: string): Promise<boolean> {
   try {
@@ -253,90 +249,7 @@ export function registerShellHandlers(store: Store): void {
     return pathExists(filePath)
   })
 
-  ipcMain.handle(
-    'shell:pickDirectory',
-    async (_event, args: { defaultPath?: string }): Promise<string | null> => {
-      const result = await dialog.showOpenDialog({
-        defaultPath: args.defaultPath,
-        // Why: callers only need an existing folder grant; enabling native
-        // creation can leave typed prefix directories behind on macOS.
-        properties: ['openDirectory']
-      })
-      if (result.canceled || result.filePaths.length === 0) {
-        return null
-      }
-      return result.filePaths[0]
-    }
-  )
-
-  // Why: window.prompt() and <input type="file"> are unreliable in Electron,
-  // so we use the native OS dialog to let the user pick any attachment file.
-  ipcMain.handle('shell:pickAttachment', async (): Promise<string | null> => {
-    const result = await dialog.showOpenDialog({
-      properties: ['openFile']
-    })
-    if (result.canceled || result.filePaths.length === 0) {
-      return null
-    }
-    return result.filePaths[0]
-  })
-
-  // Why: window.prompt() and <input type="file"> are unreliable in Electron,
-  // so we use the native OS dialog to let the user pick an image file.
-  ipcMain.handle('shell:pickImage', async (): Promise<string | null> => {
-    const result = await dialog.showOpenDialog({
-      properties: ['openFile'],
-      filters: [
-        { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'] }
-      ]
-    })
-    if (result.canceled || result.filePaths.length === 0) {
-      return null
-    }
-    return result.filePaths[0]
-  })
-
-  ipcMain.handle(
-    'shell:pickRepoIconImage',
-    async (): Promise<{ dataUrl: string; fileName: string } | null> => {
-      const result = await dialog.showOpenDialog({
-        properties: ['openFile'],
-        filters: [{ name: 'Repo icon images', extensions: ['png'] }]
-      })
-      if (result.canceled || result.filePaths.length === 0) {
-        return null
-      }
-
-      const filePath = result.filePaths[0]
-      const extension = extname(filePath).toLowerCase()
-      const mimeType = REPO_ICON_IMAGE_MIME_TYPES[extension]
-      if (!mimeType) {
-        throw new Error('Repo icons must be PNG files.')
-      }
-
-      const stats = await stat(filePath)
-      if (stats.size > MAX_REPO_ICON_UPLOAD_BYTES) {
-        throw new Error('Repo icon image must be 256KB or smaller.')
-      }
-
-      const buffer = await readFile(filePath)
-      return {
-        dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
-        fileName: basename(filePath)
-      }
-    }
-  )
-
-  ipcMain.handle('shell:pickAudio', async (): Promise<string | null> => {
-    const result = await dialog.showOpenDialog({
-      properties: ['openFile'],
-      filters: [{ name: 'Audio', extensions: ['ogg', 'mp3', 'wav', 'm4a', 'aac', 'flac'] }]
-    })
-    if (result.canceled || result.filePaths.length === 0) {
-      return null
-    }
-    return result.filePaths[0]
-  })
+  registerShellPickerHandlers()
 
   // Why: copying a picked image next to the markdown file lets us insert a
   // relative path (e.g. `![](image.png)`) instead of embedding base64,

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -26,7 +26,10 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
  * way dev (`orca-dev` userData) and packaged (`orca` userData) runs lock in
  * separate namespaces instead of serialising against each other.
  */
-export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void): boolean {
+export function acquireSingleInstanceLock(
+  app: App,
+  onSecondInstance: (event: Electron.Event, argv: string[], workingDirectory: string) => void
+): boolean {
   if (!app.requestSingleInstanceLock()) {
     return false
   }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2512,9 +2512,12 @@ export type PreloadApi = {
     openFileUri: (uri: string) => Promise<void>
     pathExists: (path: string) => Promise<boolean>
     pickAttachment: () => Promise<string | null>
+    pickAttachments: () => Promise<string[]>
     pickImage: () => Promise<string | null>
+    pickImages: () => Promise<string[]>
     pickRepoIconImage: () => Promise<{ dataUrl: string; fileName: string } | null>
     pickAudio: () => Promise<string | null>
+    pickAudios: () => Promise<string[]>
     pickDirectory: (args: { defaultPath?: string }) => Promise<string | null>
     copyFile: (args: { srcPath: string; destPath: string }) => Promise<void>
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2376,12 +2376,18 @@ const api = {
 
     pickAttachment: (): Promise<string | null> => ipcRenderer.invoke('shell:pickAttachment'),
 
+    pickAttachments: (): Promise<string[]> => ipcRenderer.invoke('shell:pickAttachments'),
+
     pickImage: (): Promise<string | null> => ipcRenderer.invoke('shell:pickImage'),
+
+    pickImages: (): Promise<string[]> => ipcRenderer.invoke('shell:pickImages'),
 
     pickRepoIconImage: (): Promise<{ dataUrl: string; fileName: string } | null> =>
       ipcRenderer.invoke('shell:pickRepoIconImage'),
 
     pickAudio: (): Promise<string | null> => ipcRenderer.invoke('shell:pickAudio'),
+
+    pickAudios: (): Promise<string[]> => ipcRenderer.invoke('shell:pickAudios'),
 
     pickDirectory: (args: { defaultPath?: string }): Promise<string | null> =>
       ipcRenderer.invoke('shell:pickDirectory', args),

--- a/src/renderer/src/components/editor/useLocalImagePick.ts
+++ b/src/renderer/src/components/editor/useLocalImagePick.ts
@@ -21,20 +21,24 @@ export function useLocalImagePick(
     const insertPos = editor.state.selection.from
     const targetDom = editor.view.dom
     try {
-      const srcPath = await window.api.shell.pickImage()
-      if (!srcPath) {
+      const srcPaths = await window.api.shell.pickImages()
+      if (srcPaths.length === 0) {
         return
       }
-      await insertRichMarkdownImageFromPath({
-        editor,
-        filePath,
-        sourcePath: srcPath,
-        worktreeId,
-        runtimeEnvironmentId,
-        insertPos,
-        canInsert: (candidate) =>
-          !candidate.isDestroyed && candidate.view.dom === targetDom && targetDom.isConnected
-      })
+      // Why: insertContentAt with a fixed position inserts in reverse order
+      // when called repeatedly. Reversing preserves the user's selection order.
+      for (const srcPath of srcPaths.toReversed()) {
+        await insertRichMarkdownImageFromPath({
+          editor,
+          filePath,
+          sourcePath: srcPath,
+          worktreeId,
+          runtimeEnvironmentId,
+          insertPos,
+          canInsert: (candidate) =>
+            !candidate.isDestroyed && candidate.view.dom === targetDom && targetDom.isConnected
+        })
+      }
     } catch (err) {
       toast.error(extractIpcErrorMessage(err, 'Failed to insert image.'))
     }

--- a/src/renderer/src/components/native-chat/use-native-chat-file-attachment-actions.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-file-attachment-actions.ts
@@ -16,9 +16,9 @@ export function useNativeChatFileAttachmentActions(
 
   const pickAttachment = useCallback(() => {
     void (async () => {
-      const filePath = await window.api.shell.pickAttachment()
-      if (filePath) {
-        attachExternalPaths([filePath])
+      const filePaths = await window.api.shell.pickAttachments()
+      if (filePaths.length > 0) {
+        attachExternalPaths(filePaths)
       }
     })()
   }, [attachExternalPaths])

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -2455,17 +2455,17 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
 
   const handleAddAttachment = useCallback(async (): Promise<void> => {
     try {
-      const selectedPath = await window.api.shell.pickAttachment()
-      if (!selectedPath) {
+      const selectedPaths = await window.api.shell.pickAttachments()
+      if (selectedPaths.length === 0) {
         return
       }
-      const uploaded = await uploadComposerPaths([selectedPath])
+      const uploaded = await uploadComposerPaths(selectedPaths)
       if (uploaded) {
         addComposerAttachments(uploaded.filePaths)
         insertComposerFolderPaths(uploaded.folderPaths)
         return
       }
-      addComposerAttachments([selectedPath])
+      addComposerAttachments(selectedPaths)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to add attachment.'
       toast.error(message)

--- a/src/renderer/src/hooks/useGlobalFileDrop.ts
+++ b/src/renderer/src/hooks/useGlobalFileDrop.ts
@@ -153,11 +153,10 @@ export function useGlobalFileDrop(): void {
         return
       }
 
-      // Why: the relay payload now sends all paths in one gesture-scoped event.
-      // Loop over every dropped file so multi-file editor drops still open
-      // each file, matching the prior per-path behavior.
-      for (const filePath of data.paths) {
-        void (async () => {
+      // Why: process each dropped file sequentially in a single async context
+      // so that concurrent store.openFile() calls never race on Zustand set().
+      void (async () => {
+        for (const filePath of data.paths) {
           try {
             const isRemoteRuntimePath = isRemoteRuntimeFileOperation(fileContext, filePath)
             // Why: remote paths don't need local auth — the relay/runtime is the security boundary.
@@ -166,7 +165,7 @@ export function useGlobalFileDrop(): void {
             }
             const stat = await statRuntimePath(fileContext, filePath)
             if (stat.isDirectory) {
-              return
+              continue
             }
 
             let relativePath = filePath
@@ -192,8 +191,8 @@ export function useGlobalFileDrop(): void {
           } catch {
             // Ignore files that cannot be authorized or stat'd.
           }
-        })()
-      }
+        }
+      })()
     })
   }, [])
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3094,9 +3094,12 @@ function createShellApi(): NonNullable<Partial<PreloadApi>['shell']> {
       }
     },
     pickAttachment: () => Promise.resolve(null),
+    pickAttachments: () => Promise.resolve([]),
     pickImage: () => Promise.resolve(null),
+    pickImages: () => Promise.resolve([]),
     pickRepoIconImage: () => Promise.resolve(null),
     pickAudio: () => Promise.resolve(null),
+    pickAudios: () => Promise.resolve([]),
     pickDirectory: () => Promise.resolve(null),
     copyFile: () => Promise.resolve()
   }


### PR DESCRIPTION
## Summary

This PR adds multi-file selection support to native file pickers and enables opening multiple files from external events (macOS Finder, CLI second-instance).

## Scene A: Multi-select file picker

- Added `pickAttachments`, `pickImages`, `pickAudios` IPC handlers with `multiSelections` property for batch file selection
- Updated renderer hooks (`useComposerState`, `useNativeChatFileAttachmentActions`, `useLocalImagePick`) to use the new multi-select variants
- Exposed new APIs in `preload` and `web-preload-api`
- Added 6 test cases for multi-select picker handlers

## Scene B: External file open (macOS `open-file` + `second-instance`)

- Registered `app.on('open-file')` handler on macOS before `whenReady`, queuing file paths until the renderer is ready
- Handled `second-instance` event to process CLI file arguments (e.g. `orca file1.txt file2.txt`)
- Extracted file paths from argv, skipping flags and non-existent paths
- Flushed pending files to the renderer via the existing `terminal:file-drop` IPC channel
- Updated `single-instance-lock` callback signature to accept `(event, argv, workingDirectory)` for second-instance handling
- Fixed a race condition in `useGlobalFileDrop` by awaiting all files sequentially instead of firing parallel async IIFEs

## Code Quality

- Fixed oxlint `no-array-reverse` warning: replaced `.reverse()` with `.toReversed()` in `useLocalImagePick.ts`
- Extracted picker dialog handlers from `shell.ts` into `shell-pickers.ts` to stay under the 300-line max-lines limit