### PR TITLE
feat(terminal): enable copy-on-select by default

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -246,7 +246,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     minimizeToTrayOnClose: false,
     // Why: default-on everywhere so it round-trips across platforms; only darwin acts on it.
     showMenuBarIcon: true,
-    terminalClipboardOnSelect: false,
+    terminalClipboardOnSelect: true,
     // Why: default on so Zellij/tmux/nvim copy works out of the box. Query
     // replies stay disabled and payload size is capped in the OSC 52 handler.
     // This default only covers new profiles; existing ones persisted `false`


### PR DESCRIPTION
## Summary

Flip `terminalClipboardOnSelect` default from `false` to `true` so new installations get automatic clipboard copy when selecting text in the terminal — matching tmux, iTerm2, and other modern terminal defaults.

## Context

The copy-on-select feature already exists and is fully implemented:
- `terminal.onSelectionChange()` in `use-terminal-pane-lifecycle.ts`
- Uses the verified `writeTerminalClipboardText` clipboard channel
- Setting UI toggle in Settings → Terminal → "Copy on Select"

The only gap was the default value (`false`), which meant users had to discover and manually enable the feature.

## Changes

One line in `src/shared/constants.ts`:
```diff
-    terminalClipboardOnSelect: false,
+    terminalClipboardOnSelect: true,
```

## Impact

- **New installations**: copy-on-select works out of the box
- **Existing installations**: unaffected (persisted settings take precedence; they can toggle in Settings)

## Test plan

- [x] TypeScript typecheck passes (`tc:web` exit 0)
- [ ] Fresh install: drag-select in terminal → text appears in clipboard
- [ ] Existing install with `false` persisted: behavior unchanged until user toggles