### PR TITLE
fix(updater): skip IPC when main WebContents is destroyed

### DIFF
--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -416,6 +416,35 @@ describe('updater check failure handling', () => {
     expect(sendMock).not.toHaveBeenCalled()
   })
 
+  it('skips IPC when the whole BrowserWindow is destroyed (webContents getter throws)', async () => {
+    makeBenignCheckFailure('Unable to find latest version on GitHub')
+
+    // Why: a real destroyed BrowserWindow throws "Object has been destroyed"
+    // from the webContents getter itself; a plain destroyed-webContents mock
+    // cannot catch a helper that touches webContents before checking the window.
+    const mainWindow = {
+      isDestroyed: () => true,
+      get webContents(): never {
+        throw new TypeError('Object has been destroyed')
+      }
+    }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu, getUpdateStatus } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    await expect(
+      (async () => {
+        checkForUpdatesFromMenu()
+        await vi.waitFor(() => {
+          expect(getUpdateStatus()).toEqual(
+            expect.objectContaining({ state: 'error', userInitiated: true })
+          )
+        })
+      })()
+    ).resolves.toBeUndefined()
+  })
+
   it('still sends updater:status when main WebContents is live', async () => {
     makeBenignCheckFailure('Unable to find latest version on GitHub')
 

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -422,9 +422,11 @@ describe('updater check failure handling', () => {
     // Why: a real destroyed BrowserWindow throws "Object has been destroyed"
     // from the webContents getter itself; a plain destroyed-webContents mock
     // cannot catch a helper that touches webContents before checking the window.
+    let webContentsAccessed = false
     const mainWindow = {
       isDestroyed: () => true,
       get webContents(): never {
+        webContentsAccessed = true
         throw new TypeError('Object has been destroyed')
       }
     }
@@ -443,6 +445,7 @@ describe('updater check failure handling', () => {
         })
       })()
     ).resolves.toBeUndefined()
+    expect(webContentsAccessed).toBe(false)
   })
 
   it('still sends updater:status when main WebContents is live', async () => {

--- a/src/main/updater.check-failure.test.ts
+++ b/src/main/updater.check-failure.test.ts
@@ -384,4 +384,63 @@ describe('updater check failure handling', () => {
     await vi.advanceTimersByTimeAsync(ONE_HOUR_MS)
     expect(autoUpdaterMock.checkForUpdates).toHaveBeenCalledTimes(7)
   })
+
+  it('skips IPC when main WebContents is destroyed during check-failure status', async () => {
+    makeBenignCheckFailure('Unable to find latest version on GitHub')
+
+    const sendMock = vi.fn(() => {
+      throw new Error('Object has been destroyed')
+    })
+    const mainWindow = {
+      webContents: {
+        send: sendMock,
+        isDestroyed: () => true
+      }
+    }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu, getUpdateStatus } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+
+    await expect(
+      (async () => {
+        checkForUpdatesFromMenu()
+        await vi.waitFor(() => {
+          expect(getUpdateStatus()).toEqual(
+            expect.objectContaining({ state: 'error', userInitiated: true })
+          )
+        })
+      })()
+    ).resolves.toBeUndefined()
+
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('still sends updater:status when main WebContents is live', async () => {
+    makeBenignCheckFailure('Unable to find latest version on GitHub')
+
+    const sendMock = vi.fn()
+    const mainWindow = {
+      webContents: {
+        send: sendMock,
+        isDestroyed: () => false
+      }
+    }
+
+    const { setupAutoUpdater, checkForUpdatesFromMenu } = await import('./updater')
+
+    setupAutoUpdater(mainWindow as never, { getLastUpdateCheckAt: () => Date.now() })
+    checkForUpdatesFromMenu()
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith(
+        'updater:status',
+        expect.objectContaining({
+          state: 'error',
+          userInitiated: true,
+          message: FRIENDLY_MESSAGE
+        })
+      )
+    })
+  })
 })

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -158,7 +158,13 @@ function clearAvailableUpdateContext(): void {
 
 // Why: renderer restart/teardown can race with async updater callbacks (MacUpdater hourly check).
 function sendToMainWindow(channel: string, payload?: unknown): void {
-  const wc = mainWindowRef?.webContents
+  const win = mainWindowRef
+  // Why: a destroyed BrowserWindow throws "Object has been destroyed" from the
+  // webContents getter itself, so check the window before touching webContents.
+  if (!win || win.isDestroyed?.()) {
+    return
+  }
+  const wc = win.webContents
   if (!wc || wc.isDestroyed?.()) {
     return
   }

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -156,6 +156,23 @@ function clearAvailableUpdateContext(): void {
   availableReleaseUrl = null
 }
 
+// Why: renderer restart/teardown can race with async updater callbacks (MacUpdater hourly check).
+function sendToMainWindow(channel: string, payload?: unknown): void {
+  const wc = mainWindowRef?.webContents
+  if (!wc || wc.isDestroyed?.()) {
+    return
+  }
+  try {
+    if (payload === undefined) {
+      wc.send(channel)
+    } else {
+      wc.send(channel, payload)
+    }
+  } catch {
+    // Why: isDestroyed() can race with actual destroy mid-send.
+  }
+}
+
 function closeLocalBuildFeed(): void {
   const feed = activeLocalBuildFeed
   activeLocalBuildFeed = null
@@ -297,7 +314,7 @@ function sendStatus(status: UpdateStatus): void {
     return
   }
   currentStatus = decoratedStatus
-  mainWindowRef?.webContents.send('updater:status', decoratedStatus)
+  sendToMainWindow('updater:status', decoratedStatus)
 }
 
 function getOptionsForUpdateCheckVariant(variant: UpdateCheckVariant): UpdateCheckOptions {
@@ -1535,7 +1552,7 @@ async function checkForUpdateNudge(): Promise<void> {
     ) {
       awaitingNudgeCheckOutcome = true
       _setPendingUpdateNudgeId?.(nudge.id)
-      mainWindowRef?.webContents.send('updater:clearDismissal')
+      sendToMainWindow('updater:clearDismissal')
       runBackgroundUpdateCheck(nudge.id)
     }
   } finally {


### PR DESCRIPTION
## Description
Prevent hourly unhandled rejections when MacUpdater reports a check failure after the main window's WebContents was already destroyed (renderer restart/teardown race).

`sendToMainWindow` guards `updater:status` and `updater:clearDismissal` with `isDestroyed()` (+ try/catch) so async updater callbacks never throw into the main process.

## Focused fix
- In scope: safe IPC send from the auto-updater path when the target window is gone
- Out of scope: broader window lifecycle refactors, update policy changes

## Preserves
- Live windows still receive update status exactly as before
- Check/retry/menu-driven update flows unchanged when WebContents is alive

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/updater.check-failure.test.ts` (11 passed)
- Destroyed WebContents: no throw / no send; live: still sends error status

## User-regression-tradeoffs
- None expected: only drops IPC to already-dead targets

Fixes #11544