### PR TITLE
fix(github): lengthen no-PR background refresh TTL to 60m

### DIFF
--- a/src/main/github/pr-refresh-coordinator.test.ts
+++ b/src/main/github/pr-refresh-coordinator.test.ts
@@ -220,6 +220,53 @@ describe('pr-refresh-coordinator', () => {
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps a 15-minute-old no-PR cache fresh for background refresh until 60 minutes', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    const candidate = makeCandidate({
+      cachedHasPR: false,
+      cachedFetchedAt: Date.now() - 15 * 60_000
+    })
+    reportVisiblePRRefreshCandidates([candidate], 1, 1)
+
+    // Still within the 60m no-PR TTL (was eligible under the old 15m interval).
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getPRForBranchOutcomeMock).not.toHaveBeenCalled()
+
+    // Remaining wait is 45m (60m TTL − 15m age); stay just under it.
+    await vi.advanceTimersByTimeAsync(45 * 60_000 - 1)
+    expect(getPRForBranchOutcomeMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshes no-PR candidates once the 60-minute background TTL has elapsed', async () => {
+    const { reportVisiblePRRefreshCandidates } = await import('./pr-refresh-coordinator')
+    getPRForBranchOutcomeMock.mockResolvedValue({
+      kind: 'no-pr',
+      fetchedAt: Date.now()
+    })
+
+    reportVisiblePRRefreshCandidates(
+      [
+        makeCandidate({
+          cachedHasPR: false,
+          cachedFetchedAt: Date.now() - 61 * 60_000
+        })
+      ],
+      1,
+      1
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledTimes(1)
+  })
+
   it('lets an active worktree refresh bypass a delayed visible follow-up', async () => {
     const { enqueuePRRefresh, reportVisiblePRRefreshCandidates } =
       await import('./pr-refresh-coordinator')

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -73,6 +73,8 @@ const MANUAL_MERGEABILITY_PENDING_REFRESH_MS = 2_500
 const BACKGROUND_BUDGET_WINDOW_MS = 5 * 60_000
 const MIN_BACKGROUND_SPACING_MS = 10_000
 const BACKGROUND_BUDGET_MAX = 20
+// Why: no-PR branches are common across many worktrees; 15m re-polls burn gh rate limit at scale.
+const NO_PR_BACKGROUND_REFRESH_MS = 60 * 60_000
 const POST_PUSH_DELAY_MS = 2_500
 const BACKOFF_BASE_MS = 60_000
 const BACKOFF_MAX_MS = 15 * 60_000
@@ -509,7 +511,7 @@ function refreshIntervalForCandidate(candidate: GitHubPRRefreshCandidate): numbe
     return 30 * 60_000
   }
   if (candidate.cachedHasPR === false) {
-    return 15 * 60_000
+    return NO_PR_BACKGROUND_REFRESH_MS
   }
   if (
     candidate.cachedHasPR === true &&


### PR DESCRIPTION
## Description
Cut background `gh` re-queries for branches already cached as having no PR, so Orca is less likely to burn the shared GitHub REST primary rate limit (5k/hr per user).

`refreshIntervalForCandidate` now uses a 60-minute TTL for `cachedHasPR === false` (was 15 minutes).

## Focused fix
- In scope: no-PR background freshness interval only
- Out of scope: settings UI, budget constants, open-PR check intervals, disable toggle

## Preserves
- Manual / post-push / visible-active refresh still bypasses freshness as today
- Open PRs with pending/failing checks keep their existing shorter intervals
- A newly opened PR on a previously no-PR branch still appears within ≤60m (sooner on activation)

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/github/pr-refresh-coordinator.test.ts` (37 passed)
- 15m-old no-PR stays fresh; becomes eligible again after 60m

## User-regression-tradeoffs
- Background discovery of a brand-new PR on a long-idle no-PR branch can lag up to 60m until the next background cycle (user navigation still refreshes sooner)

Fixes #11532