### PR TITLE
fix(startup): prune stale mise/nvm install paths on shell PATH merge

### DIFF
--- a/src/main/startup/hydrate-shell-path.test.ts
+++ b/src/main/startup/hydrate-shell-path.test.ts
@@ -5,6 +5,7 @@ import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import {
   _resetHydrateShellPathCache,
   hydrateShellPath,
+  isVersionManagerInstallPath,
   mergePathSegments,
   type HydrationResult
 } from './hydrate-shell-path'
@@ -249,5 +250,55 @@ describe('mergePathSegments', () => {
 
     expect(added).toEqual([shellMise])
     expect(process.env.PATH).toBe(joinPath(shellMise, '/usr/bin', '/bin', customBin))
+  })
+
+  it.each([
+    {
+      name: 'nvm',
+      stale: '/Users/tester/.nvm/versions/node/v20.0.0/bin',
+      current: '/Users/tester/.nvm/versions/node/v22.0.0/bin'
+    },
+    {
+      name: 'asdf',
+      stale: '/Users/tester/.asdf/installs/nodejs/20.0.0/bin',
+      current: '/Users/tester/.asdf/installs/nodejs/22.0.0/bin'
+    },
+    {
+      name: 'fnm multishell (unix bin)',
+      stale: '/tmp/fnm_multishells/12345_174350780/bin',
+      current: '/tmp/fnm_multishells/99999_174350999/bin'
+    },
+    {
+      // Why: Windows fnm puts the session root on PATH (no trailing /bin). Avoid
+      // drive-letter paths here — `C:` collides with the Unix PATH delimiter in tests.
+      name: 'fnm multishell (session root)',
+      stale: '/Users/tester/AppData/Local/fnm_multishells/12345_174350780',
+      current: '/Users/tester/AppData/Local/fnm_multishells/99999_174350999'
+    }
+  ])('drops stale $name install paths the shell no longer exports', ({ stale, current }) => {
+    process.env.PATH = joinPath(stale, '/usr/bin', '/bin')
+
+    const added = mergePathSegments([current, '/usr/bin', '/bin'])
+
+    expect(added).toEqual([current])
+    expect(process.env.PATH).toBe(joinPath(current, '/usr/bin', '/bin'))
+    expect(process.env.PATH?.includes(stale)).toBe(false)
+  })
+
+  it('matches Windows-backslash fnm session roots as install paths', () => {
+    expect(
+      isVersionManagerInstallPath(
+        'C:\\Users\\tester\\AppData\\Local\\fnm_multishells\\12345_174350780'
+      )
+    ).toBe(true)
+  })
+
+  it('does not treat arbitrary paths containing fnm_multishells as install bins', () => {
+    const custom = '/opt/myapp/fnm_multishells/tools'
+    expect(isVersionManagerInstallPath(custom)).toBe(false)
+
+    process.env.PATH = joinPath(custom, '/usr/bin')
+    mergePathSegments(['/usr/bin', '/bin'])
+    expect(process.env.PATH).toBe(joinPath('/usr/bin', '/bin', custom))
   })
 })

--- a/src/main/startup/hydrate-shell-path.test.ts
+++ b/src/main/startup/hydrate-shell-path.test.ts
@@ -214,4 +214,40 @@ describe('mergePathSegments', () => {
     expect(mergePathSegments([])).toEqual([])
     expect(process.env.PATH).toBe(joinPath('/usr/bin', '/bin'))
   })
+
+  // Why: after mise switches Node (or auto-update inherits the pre-switch env),
+  // process PATH still holds the old installs/.../bin while the login shell
+  // only exports the current pin. Union merge must drop the stale segment.
+  it('drops stale mise install bins that the login shell no longer exports', () => {
+    const staleMise = '/Users/tester/.local/share/mise/installs/node/26.5.0/bin'
+    const currentMise = '/Users/tester/.local/share/mise/installs/node/24.18.0/bin'
+    process.env.PATH = joinPath(staleMise, '/usr/bin', '/bin')
+
+    const added = mergePathSegments([currentMise, '/usr/bin', '/bin'])
+
+    expect(added).toEqual([currentMise])
+    expect(process.env.PATH).toBe(joinPath(currentMise, '/usr/bin', '/bin'))
+    expect(process.env.PATH).not.toContain('26.5.0')
+  })
+
+  it('keeps shell-exported mise install paths at shell order', () => {
+    const shellMise = '/Users/tester/.local/share/mise/installs/node/24.18.0/bin'
+    process.env.PATH = joinPath('/usr/bin', shellMise, '/bin')
+
+    const added = mergePathSegments([shellMise, '/usr/bin', '/bin'])
+
+    expect(added).toEqual([])
+    expect(process.env.PATH).toBe(joinPath(shellMise, '/usr/bin', '/bin'))
+  })
+
+  it('preserves non-version-manager process PATH entries missing from shell', () => {
+    const customBin = '/Users/tester/.custom-tools/bin'
+    const shellMise = '/Users/tester/.local/share/mise/installs/node/24.18.0/bin'
+    process.env.PATH = joinPath(customBin, '/usr/bin', '/bin')
+
+    const added = mergePathSegments([shellMise, '/usr/bin', '/bin'])
+
+    expect(added).toEqual([shellMise])
+    expect(process.env.PATH).toBe(joinPath(shellMise, '/usr/bin', '/bin', customBin))
+  })
 })

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -188,12 +188,21 @@ export function hydrateShellPath(options: HydrateOptions = {}): Promise<Hydratio
 const VERSION_MANAGER_INSTALL_BIN_RE =
   /(?:^|[/\\])(?:\.?mise[/\\]installs|\.nvm[/\\]versions|\.asdf[/\\]installs)[/\\][^/\\]+[/\\][^/\\]+[/\\]bin$/i
 
-const FNM_MULTISHELL_BIN_RE = /(?:^|[/\\])fnm_multishells[/\\]/i
+// Why: fnm session dirs are `fnm_multishells/<pid>_<ts>[/bin]`. Require that shape
+// so arbitrary paths containing the substring (e.g. /opt/myapp/fnm_multishells/tools)
+// are not treated as version-manager installs.
+const FNM_MULTISHELL_SESSION_RE = /(?:^|[/\\])fnm_multishells[/\\]\d+_\d+(?:[/\\]bin)?$/i
 
-/** @internal - exported for unit tests. */
-export function isObsoleteVersionManagerInstallSegment(segment: string): boolean {
+/**
+ * Structural match for version-manager install / session bin paths.
+ * Staleness is decided by the caller (segment absent from shell PATH).
+ * @internal - exported for unit tests.
+ */
+export function isVersionManagerInstallPath(segment: string): boolean {
   const normalized = segment.replace(/\\/g, '/')
-  return VERSION_MANAGER_INSTALL_BIN_RE.test(normalized) || FNM_MULTISHELL_BIN_RE.test(normalized)
+  return (
+    VERSION_MANAGER_INSTALL_BIN_RE.test(normalized) || FNM_MULTISHELL_SESSION_RE.test(normalized)
+  )
 }
 
 /**
@@ -214,7 +223,7 @@ export function mergePathSegments(segments: string[]): string[] {
   const merged = [
     ...shellSegments,
     ...currentSegments.filter(
-      (segment) => !shellSegmentSet.has(segment) && !isObsoleteVersionManagerInstallSegment(segment)
+      (segment) => !shellSegmentSet.has(segment) && !isVersionManagerInstallPath(segment)
     )
   ]
   const next = merged.join(delimiter)

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -180,6 +180,22 @@ export function hydrateShellPath(options: HydrateOptions = {}): Promise<Hydratio
   return cached
 }
 
+// Why: process PATH can retain version-manager install bins after mise/nvm/asdf
+// switches versions (or after auto-update inherits the pre-switch env). Union
+// merge would keep obsolete `.../installs/<tool>/<ver>/bin` ahead of the shell's
+// current pin. Drop those exact-install runtime segments when only present in
+// the inherited process PATH; shell-exported ones stay via shellSegments.
+const VERSION_MANAGER_INSTALL_BIN_RE =
+  /(?:^|[/\\])(?:\.?mise[/\\]installs|\.nvm[/\\]versions|\.asdf[/\\]installs)[/\\][^/\\]+[/\\][^/\\]+[/\\]bin$/i
+
+const FNM_MULTISHELL_BIN_RE = /(?:^|[/\\])fnm_multishells[/\\]/i
+
+/** @internal - exported for unit tests. */
+export function isObsoleteVersionManagerInstallSegment(segment: string): boolean {
+  const normalized = segment.replace(/\\/g, '/')
+  return VERSION_MANAGER_INSTALL_BIN_RE.test(normalized) || FNM_MULTISHELL_BIN_RE.test(normalized)
+}
+
 /**
  * Promote shell-discovered PATH segments to the front of process.env.PATH,
  * preserving shell ordering and avoiding duplicates. Returns the segments that
@@ -197,7 +213,9 @@ export function mergePathSegments(segments: string[]): string[] {
   const added = shellSegments.filter((segment) => !existing.has(segment))
   const merged = [
     ...shellSegments,
-    ...currentSegments.filter((segment) => !shellSegmentSet.has(segment))
+    ...currentSegments.filter(
+      (segment) => !shellSegmentSet.has(segment) && !isObsoleteVersionManagerInstallSegment(segment)
+    )
   ]
   const next = merged.join(delimiter)
   if (next === current) {


### PR DESCRIPTION
## Description
Stop obsolete version-manager install bins (e.g. stale `mise/installs/node/26.5.0/bin`) from surviving `mergePathSegments` after the login shell has moved to a new pin.

When hydrating packaged PATH from the user's shell, exact-version mise/nvm/asdf install segments and fnm multishell paths that the shell no longer exports are dropped from the process PATH tail instead of being union-merged forever.

## Focused fix
- In scope: prune obsolete version-manager install segments in `mergePathSegments`
- Out of scope: daemon fork env rewrite, broader PATH redesign, agent CLI resolution (#10932)

## Preserves
- Shell-exported version-manager paths still win via shell segment ordering
- Non-version-manager custom process PATH entries still append when missing from shell
- Existing prepend/promote PATH tests unchanged in intent

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/hydrate-shell-path.test.ts` (15 passed)
- Stale mise 26.5.0 dropped when shell only has current pin; custom non-VM path retained

## User-regression-tradeoffs
- If a user relied on a *stale* exact-version install that their shell no longer puts on PATH, Orca will match the shell (desired) rather than keep the orphaned entry

Fixes #11529