### PR TITLE
fix(web): preserve host identity across same-server re-pairing

### DIFF
--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -347,6 +347,21 @@ describe('web runtime environment identity', () => {
     ).resolves.toMatchObject({ id: paired.environment.id, name: 'Server A again' })
   })
 
+  it('keeps the execution-host identity when re-pairing the same server key', async () => {
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const paired = await globals.window.api.runtimeEnvironments.addFromPairingCode({
+      name: 'Server A again',
+      pairingCode: encodePairingCode({ publicKeyB64: 'public-key' })
+    })
+
+    expect(paired.environment.id).toBe('web-server-a')
+    expect(paired.environment).not.toHaveProperty('compatibleEnvironmentIds')
+  })
+
   it('ignores malformed persisted compatibility ids when resolving selectors', async () => {
     const globals = installBrowserGlobals('Linux')
     writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')

--- a/src/renderer/src/web/web-runtime-environment.ts
+++ b/src/renderer/src/web/web-runtime-environment.ts
@@ -61,13 +61,14 @@ export function createStoredWebRuntimeEnvironment(args: {
   previousEnvironment?: StoredWebRuntimeEnvironment | null
   connectionDependency?: 'ssh-tunnel'
 }): StoredWebRuntimeEnvironment {
-  const id = `web-${createBrowserUuid()}`
+  const sameServerEnvironment = getSameServerEnvironment(args.previousEnvironment, args.offer)
+  const id = sameServerEnvironment?.id ?? `web-${createBrowserUuid()}`
   const now = Date.now()
-  const compatibleEnvironmentIds = getCompatibleEnvironmentIds(args.previousEnvironment, args.offer)
+  const compatibleEnvironmentIds = sameServerEnvironment?.compatibleEnvironmentIds ?? []
   return {
     id,
     name: args.name.trim() || 'Orca Server',
-    createdAt: now,
+    createdAt: sameServerEnvironment?.createdAt ?? now,
     updatedAt: now,
     lastUsedAt: null,
     runtimeId: null,
@@ -87,14 +88,14 @@ export function createStoredWebRuntimeEnvironment(args: {
   }
 }
 
-function getCompatibleEnvironmentIds(
+function getSameServerEnvironment(
   previous: StoredWebRuntimeEnvironment | null | undefined,
   offer: WebPairingOffer
-): string[] {
+): StoredWebRuntimeEnvironment | null {
   if (!previous?.endpoints.some((endpoint) => endpoint.publicKeyB64 === offer.publicKeyB64)) {
-    return []
+    return null
   }
-  return [...new Set([...(previous.compatibleEnvironmentIds ?? []), previous.id])]
+  return previous
 }
 
 export function redactStoredWebRuntimeEnvironment(


### PR DESCRIPTION
## Summary

Preserve a paired web runtime's execution-host ID when a new pairing offer proves it is the same server by pinned public key. The endpoint and device token still refresh, but existing worktree ownership and mirrored terminal handles keep one host identity.

This prevents existing AI CLI terminal sessions from failing closed with:

> Workspace identity is ambiguous across hosts. Refresh projects and try again.

A different pinned key still creates a new `web-*` environment ID.

## Root Cause

Runtime-scope browser access links auto-import on every visit. `createStoredWebRuntimeEnvironment()` minted a new `web-*` ID for each import, even for the same pinned server key.

Worktree catalogs then used the new ID while existing mirrored PTY handles could still carry the old ID. PTY routing interpreted those browser-generated IDs as distinct execution hosts and rejected the existing session as ambiguous.

## Screenshots

No visual change.

## Testing

- [x] Focused identity test failed before the fix and passes after it
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/web/web-preload-api.test.ts src/renderer/src/web/web-workspace-session.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts` (695 passed)
- [x] `pnpm run typecheck:web`
- [x] touched-file `oxlint`
- [x] touched-file `oxfmt --check`
- [x] `git diff --check`

`pnpm run check:code-quality:changed` could not run under the installed Node 22 because the repository requires Node 24 and the engine warning corrupts that script's JSON parser. The same touched-file lint and format checks run by the commit hook passed.

## AI Review Report

Reviewed same-key and different-key pairing boundaries, existing compatible-selector behavior, web startup auto-pairing, session partition ownership, mirrored PTY routing, and current ambiguity fixes. The change is limited to the browser environment constructor and preserves the existing ID only when the pinned public key matches.

Cross-platform review found no platform-specific paths, shells, keyboard behavior, native modules, Git behavior, or Electron APIs. The browser identity rule is the same on macOS, Linux, and Windows and applies to SSH-hosted server worktrees without assuming local execution.

## Security Audit

The pinned public key was already the trust boundary for `compatibleEnvironmentIds`; this change uses the same proof for stable identity. Device tokens and endpoints continue to rotate from the new offer. Different keys cannot reuse an existing ID. No credentials are logged or exposed, and no auth, IPC, command execution, filesystem, or dependency surface changes.

## Notes

This fixes browser-generated execution-host churn for one paired server. It does not merge distinct physical servers or unrelated SSH/project host records.

Closes #11574
