### PR TITLE
feat(kiro): completion notifications via native bell + title identity

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -68,6 +68,7 @@
     "../src/main/hermes/hook-service.ts",
     "../src/main/kimi/hook-service.ts",
     "../src/main/kimi/kimi-hook-config-toml.ts",
+    "../src/main/kiro/hook-service.ts",
     "../src/main/openclaude/hook-service.ts",
     "../src/main/rolling-file-backup.ts",
     "../src/main/startup/hydrate-shell-path.ts",

--- a/src/main/agent-hooks/managed-agent-hook-registry.ts
+++ b/src/main/agent-hooks/managed-agent-hook-registry.ts
@@ -13,6 +13,7 @@ import { geminiHookService } from '../gemini/hook-service'
 import { grokHookService } from '../grok/hook-service'
 import { hermesHookService } from '../hermes/hook-service'
 import { kimiHookService } from '../kimi/hook-service'
+import { kiroHookService } from '../kiro/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 export type ManagedAgentHookInstaller = readonly [HookInstallAgent, () => AgentHookInstallStatus]
@@ -33,7 +34,8 @@ export const MANAGED_AGENT_HOOK_INSTALLERS: readonly ManagedAgentHookInstaller[]
   ['copilot', () => copilotHookService.install()],
   ['hermes', () => hermesHookService.install()],
   ['devin', () => devinHookService.install()],
-  ['kimi', () => kimiHookService.install()]
+  ['kimi', () => kimiHookService.install()],
+  ['kiro', () => kiroHookService.install()]
 ]
 
 export const MANAGED_AGENT_HOOK_REMOVERS: readonly ManagedAgentHookRemover[] = [
@@ -50,7 +52,8 @@ export const MANAGED_AGENT_HOOK_REMOVERS: readonly ManagedAgentHookRemover[] = [
   ['copilot', () => copilotHookService.remove()],
   ['hermes', () => hermesHookService.remove()],
   ['devin', () => devinHookService.remove()],
-  ['kimi', () => kimiHookService.remove()]
+  ['kimi', () => kimiHookService.remove()],
+  ['kiro', () => kiroHookService.remove()]
 ]
 
 export const MANAGED_AGENT_HOOK_STATUS_READERS: readonly ManagedAgentHookStatusReader[] = [
@@ -67,5 +70,6 @@ export const MANAGED_AGENT_HOOK_STATUS_READERS: readonly ManagedAgentHookStatusR
   ['copilot', () => copilotHookService.getStatus()],
   ['hermes', () => hermesHookService.getStatus()],
   ['devin', () => devinHookService.getStatus()],
-  ['kimi', () => kimiHookService.getStatus()]
+  ['kimi', () => kimiHookService.getStatus()],
+  ['kiro', () => kiroHookService.getStatus()]
 ]

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -20,6 +20,7 @@ import { CopilotHookService, copilotHookService } from '../copilot/hook-service'
 import { HermesHookService, hermesHookService } from '../hermes/hook-service'
 import { DevinHookService, devinHookService } from '../devin/hook-service'
 import { KimiHookService, kimiHookService } from '../kimi/hook-service'
+import { kiroHookService } from '../kiro/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 import { MANAGED_AGENT_HOOK_INSTALLERS } from './managed-agent-hook-controls'
 import {
@@ -687,7 +688,12 @@ describe('remote hook service installers', () => {
       ['copilot', copilotHookService],
       ['hermes', hermesHookService],
       ['devin', devinHookService],
-      ['kimi', kimiHookService]
+      ['kimi', kimiHookService],
+      // Why: Kiro has no installRemote - it manages kiro-cli's local
+      // notification settings only (see src/main/kiro/hook-service.ts). The
+      // cast is needed because weak-type checking rejects a service that
+      // shares no optional member with the map's value type.
+      ['kiro', kiroHookService as { installRemote?: unknown }]
     ])
 
     // Guard against a service silently missing from the map above as new agents land.

--- a/src/main/kiro/hook-service.test.ts
+++ b/src/main/kiro/hook-service.test.ts
@@ -180,6 +180,15 @@ describe('KiroHookService', () => {
     expect(() => service.remove()).not.toThrow()
   })
 
+  it('ignores a malformed backup with an array previous instead of crashing remove', () => {
+    const service = new KiroHookService()
+    service.install()
+    // Arrays are also `typeof === 'object'`; readBackup() must reject them.
+    writeFileSync(backupPath(), JSON.stringify({ previous: [] }))
+
+    expect(() => service.remove()).not.toThrow()
+  })
+
   it('reports error on an unparseable cli.json without writing to it', () => {
     mkdirSync(join(home, '.kiro', 'settings'), { recursive: true })
     writeFileSync(settingsPath(), '{not json')

--- a/src/main/kiro/hook-service.test.ts
+++ b/src/main/kiro/hook-service.test.ts
@@ -7,14 +7,18 @@ import { KiroHookService } from './hook-service'
 // Why: the service reads/writes homedir()/.kiro/settings/cli.json and its
 // backup under homedir()/.orca. Point HOME at a temp dir so the local
 // install/remove cycle never touches the real ~/.kiro or ~/.orca.
-// os.homedir() resolves $HOME on POSIX (verified at write time).
+// os.homedir() resolves $HOME on POSIX but USERPROFILE on Windows, so redirect
+// both to keep the suite hermetic across platforms.
 let home: string
 let originalHome: string | undefined
+let originalUserProfile: string | undefined
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'orca-kiro-hook-'))
   originalHome = process.env.HOME
+  originalUserProfile = process.env.USERPROFILE
   process.env.HOME = home
+  process.env.USERPROFILE = home
 })
 
 afterEach(() => {
@@ -22,6 +26,11 @@ afterEach(() => {
     delete process.env.HOME
   } else {
     process.env.HOME = originalHome
+  }
+  if (originalUserProfile === undefined) {
+    delete process.env.USERPROFILE
+  } else {
+    process.env.USERPROFILE = originalUserProfile
   }
   rmSync(home, { recursive: true, force: true })
 })
@@ -114,6 +123,61 @@ describe('KiroHookService', () => {
     const after = readSettings()
     expect(after['chat.notificationMethod']).toBe('osc9')
     expect('chat.enableNotifications' in after).toBe(false)
+  })
+
+  it('backs up user values when settings already match, so remove restores them', () => {
+    mkdirSync(join(home, '.kiro', 'settings'), { recursive: true })
+    // User independently set every managed value before Orca was ever involved.
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        'chat.enableNotifications': true,
+        'chat.notificationMethod': 'bell',
+        'chat.terminalTitle': true
+      })
+    )
+
+    const service = new KiroHookService()
+    // install() has nothing to change but must still record the backup.
+    expect(service.install().state).toBe('installed')
+    expect(existsSync(backupPath())).toBe(true)
+
+    service.remove()
+    const settings = readSettings()
+    // These were the user's own settings - remove() must restore, not delete.
+    expect(settings['chat.enableNotifications']).toBe(true)
+    expect(settings['chat.notificationMethod']).toBe('bell')
+    expect(settings['chat.terminalTitle']).toBe(true)
+  })
+
+  it('does not delete settings on remove when no backup exists', () => {
+    mkdirSync(join(home, '.kiro', 'settings'), { recursive: true })
+    // Settings coincidentally equal the managed values, but Orca never
+    // installed, so there is no backup to restore from.
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        'chat.enableNotifications': true,
+        'chat.notificationMethod': 'bell',
+        'chat.terminalTitle': true
+      })
+    )
+
+    new KiroHookService().remove()
+    const settings = readSettings()
+    expect(settings['chat.enableNotifications']).toBe(true)
+    expect(settings['chat.notificationMethod']).toBe('bell')
+    expect(settings['chat.terminalTitle']).toBe(true)
+  })
+
+  it('ignores a malformed backup with previous:null instead of crashing remove', () => {
+    const service = new KiroHookService()
+    service.install()
+    // Corrupt the backup so `previous` is null (typeof null === 'object').
+    writeFileSync(backupPath(), JSON.stringify({ previous: null }))
+
+    // Must not throw a TypeError from `key in null`.
+    expect(() => service.remove()).not.toThrow()
   })
 
   it('reports error on an unparseable cli.json without writing to it', () => {

--- a/src/main/kiro/hook-service.test.ts
+++ b/src/main/kiro/hook-service.test.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { KiroHookService } from './hook-service'
+
+// Why: the service reads/writes homedir()/.kiro/settings/cli.json and its
+// backup under homedir()/.orca. Point HOME at a temp dir so the local
+// install/remove cycle never touches the real ~/.kiro or ~/.orca.
+// os.homedir() resolves $HOME on POSIX (verified at write time).
+let home: string
+let originalHome: string | undefined
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'orca-kiro-hook-'))
+  originalHome = process.env.HOME
+  process.env.HOME = home
+})
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    delete process.env.HOME
+  } else {
+    process.env.HOME = originalHome
+  }
+  rmSync(home, { recursive: true, force: true })
+})
+
+const settingsPath = (): string => join(home, '.kiro', 'settings', 'cli.json')
+const backupPath = (): string => join(home, '.orca', 'agent-hooks', 'kiro-settings-backup.json')
+
+const readSettings = (): Record<string, unknown> =>
+  JSON.parse(readFileSync(settingsPath(), 'utf-8'))
+
+describe('KiroHookService', () => {
+  it('reports not_installed before install', () => {
+    expect(new KiroHookService().getStatus().state).toBe('not_installed')
+  })
+
+  it('enables Kiro native notification settings on install', () => {
+    const status = new KiroHookService().install()
+    expect(status.state).toBe('installed')
+    expect(status.managedHooksPresent).toBe(true)
+
+    const settings = readSettings()
+    expect(settings['chat.enableNotifications']).toBe(true)
+    expect(settings['chat.notificationMethod']).toBe('bell')
+    expect(settings['chat.terminalTitle']).toBe(true)
+  })
+
+  it('keeps unrelated user settings when installing', () => {
+    mkdirSync(join(home, '.kiro', 'settings'), { recursive: true })
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({ 'chat.defaultModel': 'my-model', 'mcp.loadedBefore': true })
+    )
+
+    const service = new KiroHookService()
+    expect(service.install().state).toBe('installed')
+
+    const settings = readSettings()
+    expect(settings['chat.defaultModel']).toBe('my-model')
+    expect(settings['mcp.loadedBefore']).toBe(true)
+  })
+
+  it('restores prior values on remove, deleting keys that did not exist', () => {
+    mkdirSync(join(home, '.kiro', 'settings'), { recursive: true })
+    // User had notifications explicitly off but terminal titles on.
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({ 'chat.enableNotifications': false, 'chat.terminalTitle': true })
+    )
+
+    const service = new KiroHookService()
+    expect(service.install().state).toBe('installed')
+
+    const removed = service.remove()
+    expect(removed.state).toBe('not_installed')
+
+    const settings = readSettings()
+    expect(settings['chat.enableNotifications']).toBe(false)
+    // chat.terminalTitle already had the managed value before install; the
+    // backup records the user's value, so remove() restores it instead of
+    // deleting a setting the user chose themselves.
+    expect(settings['chat.terminalTitle']).toBe(true)
+    expect(settings['chat.notificationMethod']).toBeUndefined()
+    expect(existsSync(backupPath())).toBe(false)
+  })
+
+  it('does not overwrite the first backup on re-install', () => {
+    const service = new KiroHookService()
+    service.install()
+    // Simulate a later re-install after the managed values are already live.
+    service.install()
+
+    const removed = service.remove()
+    expect(removed.state).toBe('not_installed')
+    const settings = readSettings()
+    // All three keys were absent originally, so remove() deletes them.
+    expect('chat.enableNotifications' in settings).toBe(false)
+    expect('chat.notificationMethod' in settings).toBe(false)
+    expect('chat.terminalTitle' in settings).toBe(false)
+  })
+
+  it('leaves keys the user changed away from managed values alone on remove', () => {
+    const service = new KiroHookService()
+    service.install()
+    // User later switches the notification method to their own preference.
+    const settings = readSettings()
+    settings['chat.notificationMethod'] = 'osc9'
+    writeFileSync(settingsPath(), JSON.stringify(settings))
+
+    service.remove()
+    const after = readSettings()
+    expect(after['chat.notificationMethod']).toBe('osc9')
+    expect('chat.enableNotifications' in after).toBe(false)
+  })
+
+  it('reports error on an unparseable cli.json without writing to it', () => {
+    mkdirSync(join(home, '.kiro', 'settings'), { recursive: true })
+    writeFileSync(settingsPath(), '{not json')
+
+    const service = new KiroHookService()
+    expect(service.getStatus().state).toBe('error')
+    expect(service.install().state).toBe('error')
+    expect(readFileSync(settingsPath(), 'utf-8')).toBe('{not json')
+  })
+})

--- a/src/main/kiro/hook-service.ts
+++ b/src/main/kiro/hook-service.ts
@@ -190,13 +190,9 @@ export class KiroHookService {
         detail: 'Could not read Kiro CLI settings (cli.json)'
       }
     }
-    // Why: snapshot the user's pre-Orca values once, BEFORE any early return.
-    // Even when the user already has every managed value set, we must record a
-    // backup - otherwise a later remove() finds none and blind-deletes keys the
-    // user configured themselves. Snapshot every managed key (not just the ones
-    // changing) so remove() can tell "user already had this value" apart from
-    // "Orca introduced this key". Re-installs never overwrite an existing
-    // backup, keeping the true pre-Orca state.
+    // Snapshot the user's pre-Orca values once, BEFORE any early return, so
+    // remove() can always restore them instead of blind-deleting keys. A
+    // re-install never overwrites an existing backup.
     if (!readBackup()) {
       const previous: Record<string, unknown> = {}
       for (const key of MANAGED_KEYS) {

--- a/src/main/kiro/hook-service.ts
+++ b/src/main/kiro/hook-service.ts
@@ -125,7 +125,9 @@ function readBackup(): SettingsBackup | null {
       parsed &&
       typeof parsed === 'object' &&
       !Array.isArray(parsed) &&
-      typeof (parsed as SettingsBackup).previous === 'object'
+      typeof (parsed as SettingsBackup).previous === 'object' &&
+      (parsed as SettingsBackup).previous !== null &&
+      !Array.isArray((parsed as SettingsBackup).previous)
     ) {
       return parsed as SettingsBackup
     }
@@ -188,14 +190,13 @@ export class KiroHookService {
         detail: 'Could not read Kiro CLI settings (cli.json)'
       }
     }
-    const changedKeys = MANAGED_KEYS.filter((key) => settings[key] !== MANAGED_SETTINGS[key])
-    if (changedKeys.length === 0) {
-      return buildStatus(settings, configPath)
-    }
-    // Why: only snapshot once - re-installs must not overwrite the true
-    // pre-Orca state with Orca's own managed values. Snapshot every managed
-    // key (not just the ones changing) so remove() can tell "user already had
-    // this value" apart from "Orca introduced this key".
+    // Why: snapshot the user's pre-Orca values once, BEFORE any early return.
+    // Even when the user already has every managed value set, we must record a
+    // backup - otherwise a later remove() finds none and blind-deletes keys the
+    // user configured themselves. Snapshot every managed key (not just the ones
+    // changing) so remove() can tell "user already had this value" apart from
+    // "Orca introduced this key". Re-installs never overwrite an existing
+    // backup, keeping the true pre-Orca state.
     if (!readBackup()) {
       const previous: Record<string, unknown> = {}
       for (const key of MANAGED_KEYS) {
@@ -204,6 +205,10 @@ export class KiroHookService {
         }
       }
       writeJsonAtomic(getBackupPath(), { previous } satisfies SettingsBackup)
+    }
+    const changedKeys = MANAGED_KEYS.filter((key) => settings[key] !== MANAGED_SETTINGS[key])
+    if (changedKeys.length === 0) {
+      return buildStatus(settings, configPath)
     }
     const next = { ...settings, ...MANAGED_SETTINGS }
     writeJsonAtomic(configPath, next)
@@ -223,6 +228,13 @@ export class KiroHookService {
       }
     }
     const backup = readBackup()
+    // Why: no backup means Orca never recorded a pre-install state (never
+    // installed, or a prior remove() already consumed it). Do NOT touch
+    // settings that merely happen to equal our managed values - they are the
+    // user's, not ours.
+    if (!backup) {
+      return this.getStatus()
+    }
     const next: KiroCliSettings = { ...settings }
     let changed = false
     for (const key of MANAGED_KEYS) {
@@ -231,7 +243,7 @@ export class KiroHookService {
       if (next[key] !== MANAGED_SETTINGS[key]) {
         continue
       }
-      if (backup && key in backup.previous) {
+      if (key in backup.previous) {
         next[key] = backup.previous[key]
       } else {
         delete next[key]

--- a/src/main/kiro/hook-service.ts
+++ b/src/main/kiro/hook-service.ts
@@ -1,0 +1,256 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+
+// Why: Kiro CLI (kiro-cli) only supports lifecycle hooks inside per-agent
+// config files (`~/.kiro/agents/*.json`), and its built-in default agent  -
+// what `kiro-cli chat` launches - cannot be extended or overridden with hooks
+// (verified against kiro-cli 2.15.x: neither a local nor a global agent named
+// `kiro_default` is honored, and v3 standalone `.kiro/hooks/*.json` files are
+// not read by the v2 engine). So a managed hook script would never fire for
+// the default launch path.
+//
+// Instead, Orca manages Kiro's NATIVE completion notifications: kiro-cli emits
+// a terminal BEL at end of turn whenever the hosting terminal has reported
+// focus-out (mode 1004, which xterm.js supports) and these settings are on:
+//   chat.enableNotifications = true
+//   chat.notificationMethod  = "bell"
+// Orca's existing terminal-bell notification path then delivers the OS
+// notification. `chat.terminalTitle` is also enabled so Kiro's "kiro: <title>"
+// OSC titles let Orca attribute the pane (and the notification) to Kiro - see
+// AGENT_NAMES in src/shared/agent-name-token-match.ts.
+const MANAGED_SETTINGS: Record<string, boolean | string> = {
+  'chat.enableNotifications': true,
+  'chat.notificationMethod': 'bell',
+  'chat.terminalTitle': true
+}
+
+const MANAGED_KEYS = Object.keys(MANAGED_SETTINGS)
+
+// Why: install status is judged on the notification pair only. A user can
+// legitimately have `chat.terminalTitle` on for their own reasons - that must
+// not make Orca report Kiro notifications as partially installed.
+const STATUS_KEYS = ['chat.enableNotifications', 'chat.notificationMethod'] as const
+
+type KiroCliSettings = Record<string, unknown>
+
+function getSettingsPath(): string {
+  return join(homedir(), '.kiro', 'settings', 'cli.json')
+}
+
+// Why: remove() must restore whatever the user had before install(), not blind
+// -delete keys - deleting `chat.terminalTitle` a user had enabled themselves
+// would silently change their setup. The backup is written once, on the first
+// install that actually changes something, and consumed by remove().
+function getBackupPath(): string {
+  return join(homedir(), '.orca', 'agent-hooks', 'kiro-settings-backup.json')
+}
+
+// Returns the parsed settings object, {} when the file does not exist yet
+// (kiro-cli creates it lazily), or null on an unreadable/invalid file so
+// callers can report a structured error instead of clobbering user settings.
+function readSettings(settingsPath: string): KiroCliSettings | null {
+  if (!existsSync(settingsPath)) {
+    return {}
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as KiroCliSettings
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+// Why: temp+rename keeps a hand-editable cli.json intact if a write is
+// interrupted, and a single rolling .bak makes a bad write recoverable.
+// Mirrors the Kimi service's config.toml write path.
+function writeJsonAtomic(filePath: string, value: unknown): void {
+  const dir = dirname(filePath)
+  mkdirSync(dir, { recursive: true })
+  const text = JSON.stringify(value, null, 2)
+  if (existsSync(filePath)) {
+    try {
+      if (readFileSync(filePath, 'utf-8') === text) {
+        return
+      }
+    } catch {
+      // Fall through to the atomic write path.
+    }
+  }
+  const tmpPath = join(dir, `.${Date.now()}-${randomUUID()}.tmp`)
+  try {
+    writeFileSync(tmpPath, text, 'utf-8')
+    if (existsSync(filePath)) {
+      copyFileSync(filePath, `${filePath}.bak`)
+    }
+    renameSync(tmpPath, filePath)
+  } finally {
+    if (existsSync(tmpPath)) {
+      try {
+        unlinkSync(tmpPath)
+      } catch {
+        // best effort
+      }
+    }
+  }
+}
+
+type SettingsBackup = {
+  // Value of each managed key before install; a key absent from this record
+  // means it did not exist and should be deleted on restore.
+  previous: Record<string, unknown>
+}
+
+function readBackup(): SettingsBackup | null {
+  const backupPath = getBackupPath()
+  if (!existsSync(backupPath)) {
+    return null
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(backupPath, 'utf-8'))
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as SettingsBackup).previous === 'object'
+    ) {
+      return parsed as SettingsBackup
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function buildStatus(settings: KiroCliSettings, configPath: string): AgentHookInstallStatus {
+  const missing = STATUS_KEYS.filter((key) => settings[key] !== MANAGED_SETTINGS[key])
+  let state: AgentHookInstallState
+  let detail: string | null
+  if (missing.length === 0) {
+    state = 'installed'
+    // Why: unlike hook-based agents, Kiro reports status through its native
+    // bell - make the mechanism discoverable from the settings UI.
+    detail = 'Uses Kiro CLI native notifications (terminal bell on turn completion).'
+  } else if (missing.length === STATUS_KEYS.length) {
+    state = 'not_installed'
+    detail = null
+  } else {
+    state = 'partial'
+    detail = `Managed Kiro CLI settings missing: ${missing.join(', ')}`
+  }
+  return {
+    agent: 'kiro',
+    state,
+    configPath,
+    managedHooksPresent: missing.length < STATUS_KEYS.length,
+    detail
+  }
+}
+
+export class KiroHookService {
+  getStatus(): AgentHookInstallStatus {
+    const configPath = getSettingsPath()
+    const settings = readSettings(configPath)
+    if (settings === null) {
+      return {
+        agent: 'kiro',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not read Kiro CLI settings (cli.json)'
+      }
+    }
+    return buildStatus(settings, configPath)
+  }
+
+  install(): AgentHookInstallStatus {
+    const configPath = getSettingsPath()
+    const settings = readSettings(configPath)
+    if (settings === null) {
+      return {
+        agent: 'kiro',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not read Kiro CLI settings (cli.json)'
+      }
+    }
+    const changedKeys = MANAGED_KEYS.filter((key) => settings[key] !== MANAGED_SETTINGS[key])
+    if (changedKeys.length === 0) {
+      return buildStatus(settings, configPath)
+    }
+    // Why: only snapshot once - re-installs must not overwrite the true
+    // pre-Orca state with Orca's own managed values. Snapshot every managed
+    // key (not just the ones changing) so remove() can tell "user already had
+    // this value" apart from "Orca introduced this key".
+    if (!readBackup()) {
+      const previous: Record<string, unknown> = {}
+      for (const key of MANAGED_KEYS) {
+        if (key in settings) {
+          previous[key] = settings[key]
+        }
+      }
+      writeJsonAtomic(getBackupPath(), { previous } satisfies SettingsBackup)
+    }
+    const next = { ...settings, ...MANAGED_SETTINGS }
+    writeJsonAtomic(configPath, next)
+    return this.getStatus()
+  }
+
+  remove(): AgentHookInstallStatus {
+    const configPath = getSettingsPath()
+    const settings = readSettings(configPath)
+    if (settings === null) {
+      return {
+        agent: 'kiro',
+        state: 'error',
+        configPath,
+        managedHooksPresent: false,
+        detail: 'Could not read Kiro CLI settings (cli.json)'
+      }
+    }
+    const backup = readBackup()
+    const next: KiroCliSettings = { ...settings }
+    let changed = false
+    for (const key of MANAGED_KEYS) {
+      // Why: leave keys alone when the user has since changed them away from
+      // Orca's managed values - those are their settings now, not ours.
+      if (next[key] !== MANAGED_SETTINGS[key]) {
+        continue
+      }
+      if (backup && key in backup.previous) {
+        next[key] = backup.previous[key]
+      } else {
+        delete next[key]
+      }
+      changed = true
+    }
+    if (changed) {
+      writeJsonAtomic(configPath, next)
+    }
+    const backupPath = getBackupPath()
+    if (existsSync(backupPath)) {
+      try {
+        unlinkSync(backupPath)
+      } catch {
+        // best effort
+      }
+    }
+    return this.getStatus()
+  }
+}
+
+export const kiroHookService = new KiroHookService()

--- a/src/shared/agent-hook-types.ts
+++ b/src/shared/agent-hook-types.ts
@@ -17,7 +17,11 @@ export const AGENT_HOOK_TARGETS = [
   'copilot',
   'hermes',
   'devin',
-  'kimi'
+  'kimi',
+  // Why: Kiro CLI hooks live in per-agent config files and cannot be attached
+  // to its built-in default agent, so Orca manages Kiro's native notification
+  // settings instead (see src/main/kiro/hook-service.ts).
+  'kiro'
 ] as const
 export type AgentHookTarget = (typeof AGENT_HOOK_TARGETS)[number]
 

--- a/src/shared/agent-name-token-match.ts
+++ b/src/shared/agent-name-token-match.ts
@@ -26,7 +26,11 @@ export const AGENT_NAMES = [
   'openclaw',
   'aider',
   'grok',
-  'devin'
+  'devin',
+  // Why: Kiro CLI prefixes its OSC titles with "kiro: <session title>" when its
+  // `chat.terminalTitle` setting is on; token-matching attributes those panes
+  // (and their notifications) to Kiro without claiming cwd titles like ~/kiro.
+  'kiro'
 ]
 
 // Why: Windows agent titles can surface launcher process names such as

--- a/src/shared/agent-title-identity.ts
+++ b/src/shared/agent-title-identity.ts
@@ -90,6 +90,12 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'devin')) {
     return 'Devin'
   }
+  // Why: Kiro CLI's native OSC title is "kiro: <session title>" (emitted when
+  // its `chat.terminalTitle` setting is on). Token-match before the generic
+  // braille heuristic so Kiro panes are attributed to Kiro, not Claude.
+  if (titleHasAgentName(title, 'kiro')) {
+    return 'Kiro'
+  }
   if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
   }

--- a/src/shared/terminal-title-agent-type.test.ts
+++ b/src/shared/terminal-title-agent-type.test.ts
@@ -135,3 +135,17 @@ describe('isClaudeAgent', () => {
     expect(isClaudeAgent('⠋ OpenClaude')).toBe(false)
   })
 })
+
+describe('Kiro title detection', () => {
+  it('resolves Kiro CLI native titles ("kiro: <session title>") to kiro', () => {
+    expect(resolveTerminalTitleAgentType('kiro: projects/brain')).toBe('kiro')
+    expect(resolveTerminalTitleAgentType('kiro: Fix the flaky test suite')).toBe('kiro')
+    expect(resolveExplicitTerminalTitleAgentType('kiro: projects/brain')).toBe('kiro')
+  })
+
+  it('does not claim cwd/path titles that merely contain kiro', () => {
+    expect(resolveTerminalTitleAgentType('~/kiro')).toBe(null)
+    expect(resolveTerminalTitleAgentType('user@host: ~/projects/kiro-scratch')).toBe(null)
+    expect(resolveTerminalTitleAgentType('.kiro/settings')).toBe(null)
+  })
+})

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -174,6 +174,12 @@ export function getAgentLabel(title: string): string | null {
   if (titleHasAgentName(title, 'devin')) {
     return 'Devin'
   }
+  // Why: Kiro CLI's native OSC title is "kiro: <session title>" (emitted when
+  // its `chat.terminalTitle` setting is on). Token-match before the generic
+  // braille heuristic so Kiro panes are attributed to Kiro, not Claude.
+  if (titleHasAgentName(title, 'kiro')) {
+    return 'Kiro'
+  }
   if (titleHasAgentName(title, 'antigravity') || AGY_AGENT_NAME_RE.test(title)) {
     return 'Antigravity'
   }
@@ -220,6 +226,7 @@ const TITLE_LABEL_TO_AGENT: Partial<Record<string, TuiAgent>> = {
   'GitHub Copilot': 'copilot',
   Grok: 'grok',
   Devin: 'devin',
+  Kiro: 'kiro',
   Antigravity: 'antigravity',
   OpenCode: 'opencode',
   'MiMo Code': 'mimo-code',


### PR DESCRIPTION
## Summary

Kiro CLI (`kiro-cli`) panes never produce completion notifications in Orca, while Claude Code and Codex do. This PR adds them, plus title-based agent identity for Kiro panes.

Two root causes:

1. Kiro has no managed hook service. This turns out to be by CLI design, not an omission: kiro-cli lifecycle hooks (`agentSpawn`/`stop`) only live inside per-agent config files, and the built-in default agent that `kiro-cli chat` launches cannot be extended or overridden with hooks. Verified empirically against kiro-cli 2.15.x: a local `.kiro/agents/kiro_default.json`, a global `~/.kiro/agents/kiro_default.json`, and v3 standalone `.kiro/hooks/*.json` files are all ignored by the v2 engine (hooks in explicit `--agent <custom>` configs do fire).
2. `kiro` is not in `AGENT_NAMES`, so Kiro's OSC titles (`kiro: <session title>`) never attribute the pane or a notification to Kiro.

Instead of a hook script that can never fire, the new `src/main/kiro/hook-service.ts` manages kiro-cli's NATIVE completion notifications in `~/.kiro/settings/cli.json`:

- `chat.enableNotifications: true` + `chat.notificationMethod: "bell"` make kiro-cli emit a terminal BEL at end of turn whenever the hosting terminal has reported focus-out (DECSET 1004, which xterm.js supports). Orca's existing terminal-bell notification path then delivers the OS notification. Verified empirically: with these settings and a focus-out event, kiro-cli emits exactly one standalone BEL when the turn completes.
- `chat.terminalTitle: true` turns on Kiro's `kiro: <session title>` OSC titles, which (with the new `AGENT_NAMES` entry) attribute the pane and the notification to Kiro.

The service snapshots the user's prior values once, on first install, into `~/.orca/agent-hooks/kiro-settings-backup.json`, and `remove()` restores them (deleting keys that did not exist, and leaving keys alone that the user has since changed away from Orca's managed values).

## Screenshots

No visual change (notifications use the existing terminal-bell pipeline; the Kiro row appears in the existing managed-hooks status list).

## Testing

- [x] `pnpm lint` gates on changed files: oxlint, code-quality native + type-aware, React Doctor, reliability-gates, max-lines ratchet - all pass with 0 new findings
- [x] `pnpm typecheck` - exit 0
- [x] `pnpm test` - 41,440 passed / 107 skipped; the 2 failures are `src/main/pty/posix-pty-process-groups.integration.test.ts`, which fails identically on a pristine `main` checkout on this machine (Amazon Linux dev desktop), so they are environmental and unrelated
- [x] Added tests: `src/main/kiro/hook-service.test.ts` (install/status/backup-restore/re-install idempotency/user-override preservation/unparseable-config safety) and Kiro title-detection cases in `src/shared/terminal-title-agent-type.test.ts`
- [x] Manual verification against kiro-cli 2.15.2 in a PTY harness: static `kiro: <cwd>` title captured; no working/idle title transitions (confirming title-based completion cannot work); standalone BEL emitted on turn completion with the managed settings and terminal focus-out

## AI Review Report

Reviewed with an AI coding agent. Main risks checked:

- Config clobbering: `cli.json` writes are temp+rename atomic with a rolling `.bak`, mirroring the Kimi service's config write path; unparseable `cli.json` returns an `error` status and never writes.
- Uninstall fidelity: backup is written once (first install) so re-installs cannot overwrite the true pre-Orca state; `remove()` distinguishes "user already had this value" from "Orca introduced this key" and skips keys the user changed away from managed values.
- Status semantics: install state is judged on the notification pair only, so a user who independently enabled `chat.terminalTitle` is not misreported as partially installed.
- False agent attribution: `kiro` is token-matched with the shared boundary guard; path/cwd titles such as `~/kiro`, `kiro-scratch`, and `.kiro/settings` do not classify as Kiro (covered by tests).
- Cross-platform: paths are built from `homedir()` (`~/.kiro/settings/cli.json`, `~/.orca/agent-hooks/`), valid on macOS, Linux, and Windows; no shell, no scripts, no platform-specific escaping; the BEL/focus-tracking mechanism lives in kiro-cli + xterm.js, both platform-independent. No Electron API changes.
- Guard test `remote-hook-service-installers.test.ts` updated: Kiro intentionally has no `installRemote` (it manages local CLI settings only), documented inline.

## Security Audit

- No command execution, no network calls, no scripts written; the service only reads/writes two JSON files under the user's home directory.
- Input handling: `cli.json` is parsed defensively (non-object/array/malformed input short-circuits to an `error` status without writing).
- No secrets touched; the managed keys are three boolean/string notification settings. Backup file contains only those prior values.
- No IPC surface changes: the service is invoked through the existing managed-hook registry plumbing.

## Notes

- Kiro completion notifications are bell-based only: unlike hook-based agents there is no rich working/waiting status, prompt text, or subagent telemetry. The `installed` status detail says so ("Uses Kiro CLI native notifications (terminal bell on turn completion)").
- No remote (SSH) installer: managing a remote host's kiro-cli settings is possible but deferred; the guard test documents the intentional absence.
- If kiro-cli's v3 engine (standalone `.kiro/hooks/` files that apply to all agents) becomes the default, a real hook service with rich status becomes possible and can replace this mechanism.
