### PR TITLE
fix(tasks): make GitHub pagination honest — cap unreachable pages, survive background refreshes, explain empty pages

### DIFF
--- a/src/main/github/client-work-items-query-paging.test.ts
+++ b/src/main/github/client-work-items-query-paging.test.ts
@@ -63,7 +63,8 @@ vi.mock('./gh-utils', () => ({
   release: releaseMock,
   _resetOwnerRepoCache: vi.fn(),
   classifyGhError: (stderr: string) => ({ type: 'unknown', message: stderr }),
-  classifyListIssuesError: (stderr: string) => ({ type: 'unknown', message: stderr })
+  classifyListIssuesError: (stderr: string) => ({ type: 'unknown', message: stderr }),
+  classifyListPrsError: (stderr: string) => ({ type: 'unknown', message: stderr })
 }))
 
 vi.mock('../git/runner', () => ({
@@ -264,6 +265,22 @@ describe('listWorkItems query paging', () => {
       { cwd: '/repo-root' }
     )
     expect(items.map((item) => item.number)).toEqual([4, 3])
+  })
+
+  it('lifts a swallowed PR-side failure onto errors.prs instead of reading as end-of-data', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    // Non-availability failure (plain 403): swallowed into [], must still surface.
+    ghExecFileAsyncMock.mockRejectedValueOnce(new Error('HTTP 403: Forbidden'))
+
+    const envelope = await listWorkItems('/repo-root', 10, 'is:pr is:open', 2)
+
+    expect(envelope.items).toEqual([])
+    expect(envelope.errors?.issues).toBeUndefined()
+    expect(envelope.errors?.prs).toEqual({
+      type: 'unknown',
+      message: expect.stringContaining('HTTP 403')
+    })
   })
 
   it('filters pull request rows out of issue Search API results', async () => {

--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -55,7 +55,8 @@ vi.mock('./gh-utils', () => ({
   release: releaseMock,
   _resetOwnerRepoCache: vi.fn(),
   classifyGhError: (stderr: string) => ({ type: 'unknown', message: stderr }),
-  classifyListIssuesError: (stderr: string) => ({ type: 'unknown', message: stderr })
+  classifyListIssuesError: (stderr: string) => ({ type: 'unknown', message: stderr }),
+  classifyListPrsError: (stderr: string) => ({ type: 'unknown', message: stderr })
 }))
 
 vi.mock('../git/runner', () => ({

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -54,6 +54,7 @@ import {
   release,
   classifyGhError,
   classifyListIssuesError,
+  classifyListPrsError,
   ghRepoExecOptions,
   githubRepoContext,
   getRemoteUrlForRepo,
@@ -1098,10 +1099,11 @@ function buildWorkItemListRequest(args: {
   return { args: out, offset: (page - 1) * limit }
 }
 
-// Why: shared shape so listWorkItems can lift the issue-side error (#1076 silent wrongness) into the IPC envelope; PR errors out of scope (§6).
+// Why: shared shape so listWorkItems can lift per-side errors (#1076 silent wrongness) into the IPC envelope — a swallowed side reads as end-of-data to pagination (#11485).
 type PartialWorkItemsResult = {
   items: MainWorkItem[]
   issuesError?: ClassifiedError
+  prsError?: ClassifiedError
 }
 
 function assertSshRepoHasResolvedGitHubSource(args: {
@@ -1255,6 +1257,7 @@ async function listQueriedWorkItems(
   let successfulRequestCount = 0
   let nonAvailabilityFailureCount = 0
   let availabilityError: unknown
+  let prsError: ClassifiedError | undefined
 
   // Why: surface the issue-side error separately for the IPC envelope; PR-side keeps prior swallow-and-log (parent doc §6).
   const issueFetch = (async (): Promise<PartialWorkItemsResult> => {
@@ -1326,6 +1329,7 @@ async function listQueriedWorkItems(
     } catch (err) {
       console.warn('listQueriedWorkItems PRs partial failure:', err)
       const stderr = err instanceof Error ? err.message : String(err)
+      prsError = classifyListPrsError(stderr)
       if (classifyGitHubUnavailable(stderr)) {
         availabilityError ??= err
       } else {
@@ -1342,7 +1346,8 @@ async function listQueriedWorkItems(
   }
   return {
     items: sortWorkItemsByNumber([...issueResult.items, ...prItems]).slice(0, limit),
-    issuesError: issueResult.issuesError
+    issuesError: issueResult.issuesError,
+    prsError
   }
 }
 
@@ -1400,7 +1405,13 @@ export async function listWorkItems(
           localGitOptions
         )
 
-    const errors = partial.issuesError ? { issues: partial.issuesError } : undefined
+    const errors =
+      partial.issuesError || partial.prsError
+        ? {
+            ...(partial.issuesError ? { issues: partial.issuesError } : {}),
+            ...(partial.prsError ? { prs: partial.prsError } : {})
+          }
+        : undefined
     return {
       items: partial.items,
       sources: {

--- a/src/main/github/gh-error-classification.ts
+++ b/src/main/github/gh-error-classification.ts
@@ -55,3 +55,11 @@ export function classifyListIssuesError(stderr: string): ClassifiedError {
   }
   return { type: c.type, message: readMessages[c.type] }
 }
+
+// Why: PR-side list failures need the same read-op classification — pagination
+// decisions key on the type, and swallowing them made failures look like
+// end-of-data (#11485).
+export function classifyListPrsError(stderr: string): ClassifiedError {
+  const c = classifyGhError(stderr)
+  return { type: c.type, message: `Failed to load pull requests: ${stderr.trim()}` }
+}

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -795,4 +795,16 @@ describe('gh error classification', () => {
       message: 'Issues are disabled on this repository.'
     })
   })
+
+  // Why: the renderer detects the Search API 1000-result window by matching
+  // /first 1000 search results/i against this message (#11485) — trimming the
+  // raw stderr out of the validation_error copy would silently downgrade every
+  // window 422 to a generic failure. This pins the contract.
+  it('keeps the search-window phrase in validation_error list messages', () => {
+    const stderr =
+      'Command failed: gh api --hostname github.com search/issues\nValidation Failed: Only the first 1000 search results are available (HTTP 422)'
+    const classified = classifyListIssuesError(stderr)
+    expect(classified.type).toBe('validation_error')
+    expect(classified.message).toMatch(/first 1000 search results/i)
+  })
 })

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -38,6 +38,7 @@ import {
   __resetLocalGitConfigSignatureCacheForTests,
   readLocalGitConfigSignature
 } from './local-git-config-signature'
+import { GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN } from '../../shared/github-work-items-query-bounds'
 
 describe('github owner/repo resolution', () => {
   beforeEach(() => {
@@ -797,14 +798,15 @@ describe('gh error classification', () => {
   })
 
   // Why: the renderer detects the Search API 1000-result window by matching
-  // /first 1000 search results/i against this message (#11485) — trimming the
-  // raw stderr out of the validation_error copy would silently downgrade every
-  // window 422 to a generic failure. This pins the contract.
+  // GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN against this message (#11485) —
+  // trimming the raw stderr out of the validation_error copy, or drifting the
+  // pattern off GitHub's real wording, would silently downgrade every window
+  // 422 to a generic failure. The stderr stays verbatim so this pins both ends.
   it('keeps the search-window phrase in validation_error list messages', () => {
     const stderr =
       'Command failed: gh api --hostname github.com search/issues\nValidation Failed: Only the first 1000 search results are available (HTTP 422)'
     const classified = classifyListIssuesError(stderr)
     expect(classified.type).toBe('validation_error')
-    expect(classified.message).toMatch(/first 1000 search results/i)
+    expect(classified.message).toMatch(GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN)
   })
 })

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -9,7 +9,11 @@ import { extractExecError, parseRetryAfterMs } from '../git/exec-error'
 // WSL-aware routing. Repo-scoped callers should use the runner exports below.
 export const execFileAsync = promisify(execFile)
 export { ghExecFileAsync, gitExecFileAsync, extractExecError, parseRetryAfterMs }
-export { classifyGhError, classifyListIssuesError } from './gh-error-classification'
+export {
+  classifyGhError,
+  classifyListIssuesError,
+  classifyListPrsError
+} from './gh-error-classification'
 export {
   _getOwnerRepoCacheSize,
   _resetOwnerRepoCache,

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -206,6 +206,7 @@ import {
 import { shouldHideTaskPageListChrome } from '@/components/task-page-list-chrome-visibility'
 import {
   getTaskPagePerRepoLimit,
+  resolveEmptyPageOutcome,
   taskPageToGitHubApiPage
 } from '@/components/task-page-work-item-pagination'
 import { sortWorkItemsByNumber } from '../../../shared/work-items'
@@ -3207,11 +3208,17 @@ export default function TaskPage(): React.JSX.Element {
 
   // Why: stable string key for selectedRepos — the repos store installs a fresh
   // array on every repos:changed event, so array-identity deps re-fire even when
-  // the selection is unchanged.
+  // the selection is unchanged. Includes the resolved GitHub source context so a
+  // provider-identity change still re-keys everything the requests depend on.
   const selectedReposKey = useMemo(
     () =>
       selectedRepos
-        .map((r) => `${r.id}|${r.path}|${r.connectionId ?? ''}|${r.executionHostId ?? ''}`)
+        .map(
+          (r) =>
+            `${r.id}|${r.path}|${r.connectionId ?? ''}|${r.executionHostId ?? ''}|${JSON.stringify(
+              getTaskPageRepoSourceContext(r, 'github')
+            )}`
+        )
         .join(','),
     [selectedRepos]
   )
@@ -6170,7 +6177,7 @@ export default function TaskPage(): React.JSX.Element {
       setPaginationLoading(true)
       setLoadingTargetPage(target)
       try {
-        const { items, failedCount } = await fetchWorkItemsNextPage(
+        const { items, failedCount, issueErrorTypes } = await fetchWorkItemsNextPage(
           repoArgs,
           githubPerRepoPageLimit,
           githubPageSize,
@@ -6181,20 +6188,32 @@ export default function TaskPage(): React.JSX.Element {
           return
         }
         if (items.length === 0) {
-          // Why: staying on the current page without saying so reads as a dead
-          // click (#11485). Empty with no thrown fetch means the target is past
-          // GitHub's reachable search window, so stop advertising it; thrown
-          // fetches may be transient, so keep the page count.
-          toast.error(
-            translate(
-              'auto.components.TaskPage.loadPageUnreachable',
-              'Page {{value0}} could not be loaded from GitHub.',
-              { value0: String(target + 1) }
+          // Why: see resolveEmptyPageOutcome — a dead click needs feedback only
+          // when something actually failed; a clean empty probe is end-of-data.
+          const outcome = resolveEmptyPageOutcome({ target, failedCount, issueErrorTypes })
+          if (outcome.reason === 'window-unreachable') {
+            toast.error(
+              translate(
+                'auto.components.TaskPage.loadPageUnreachable',
+                'Page {{value0}} is beyond what GitHub search can return.',
+                { value0: String(target + 1) }
+              ),
+              { id: 'work-items-page-unreachable' }
             )
-          )
-          if (failedCount === 0) {
+          } else if (outcome.reason === 'load-failed') {
+            toast.error(
+              translate(
+                'auto.components.TaskPage.loadPageFailed',
+                'Page {{value0}} could not be loaded from GitHub.',
+                { value0: String(target + 1) }
+              ),
+              { id: 'work-items-page-load-failed' }
+            )
+          }
+          const clamp = outcome.clampTotalPagesTo
+          if (clamp !== null) {
             setCountedTotalPages((previous) =>
-              previous !== null && previous > target ? target : previous
+              previous !== null && previous < clamp ? previous : clamp
             )
           }
           return
@@ -6416,9 +6435,13 @@ export default function TaskPage(): React.JSX.Element {
       cancelled = true
     }
     // Why: store selectors are stable (omit from deps); workItemsInvalidationNonce included so a preference flip re-dispatches.
+    // selectedReposKey stands in for selectedRepos — the array gets a fresh
+    // identity on every repos:changed event, and re-running this effect then
+    // resets pagination mid-click (#11485). The key covers every repo field the
+    // requests read.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    selectedRepos,
+    selectedReposKey,
     appliedTaskSearch,
     taskRefreshNonce,
     taskSource,

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -3835,7 +3835,8 @@ export default function TaskPage(): React.JSX.Element {
     workItemsInvalidationNonce,
     taskRefreshNonce,
     taskSource,
-    githubMode
+    githubMode,
+    taskResumeApplied
   ])
 
   // Why: the dialog's "Use" button routes through the same direct-launch flow as the row-level "Use" CTA so behavior is consistent regardless of entry point.
@@ -6432,7 +6433,11 @@ export default function TaskPage(): React.JSX.Element {
       githubPerRepoPageLimit
     ).then(({ totalPages: countedPages }) => {
       if (!cancelled) {
-        setCountedTotalPages(countedPages)
+        // Why: min against an already-applied clamp — the count must not
+        // re-advertise pages a probe has proven unreachable this generation.
+        setCountedTotalPages((previous) =>
+          previous !== null && previous > 0 ? Math.min(previous, countedPages) : countedPages
+        )
       }
     })
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -206,7 +206,9 @@ import {
 import { shouldHideTaskPageListChrome } from '@/components/task-page-list-chrome-visibility'
 import {
   applyEmptyPageClamp,
+  applyWindowPageLimit,
   buildSelectedReposKey,
+  deriveAdvertisedTotalPages,
   getTaskPagePerRepoLimit,
   resolveEmptyPageOutcome,
   taskPageToGitHubApiPage
@@ -3817,6 +3819,10 @@ export default function TaskPage(): React.JSX.Element {
   const [paginationLoading, setPaginationLoading] = useState(false)
   const [loadingTargetPage, setLoadingTargetPage] = useState<number | null>(null)
   const [countedTotalPages, setCountedTotalPages] = useState<number | null>(null)
+  // Proven window-422 page limit — separate from the count so a late count
+  // can't resurrect proven-unreachable pages, nor be pinned by a speculative
+  // withdrawal (see deriveAdvertisedTotalPages).
+  const [provenPageLimit, setProvenPageLimit] = useState<number | null>(null)
   const fetchWorkItemsNextPage = useAppStore((s) => s.fetchWorkItemsNextPage)
   const countWorkItemsAcrossRepos = useAppStore((s) => s.countWorkItemsAcrossRepos)
 
@@ -6155,10 +6161,12 @@ export default function TaskPage(): React.JSX.Element {
   const fallbackTotalPages = lastLoadedPageFull
     ? Math.max(pages.length, lastLoadedPageIndex + 2)
     : Math.max(1, pages.length)
-  const totalPages =
-    countedTotalPages && countedTotalPages > 0
-      ? Math.max(pages.length, countedTotalPages)
-      : fallbackTotalPages
+  const totalPages = deriveAdvertisedTotalPages({
+    loadedPages: pages.length,
+    countedTotalPages,
+    fallbackTotalPages,
+    provenPageLimit
+  })
 
   // Why: load only the clicked page so a high-page jump doesn't exhaust GitHub's Search API rate bucket.
   const handleLoadNextPage = useCallback(
@@ -6209,6 +6217,7 @@ export default function TaskPage(): React.JSX.Element {
               ),
               { id: 'work-items-page-unreachable' }
             )
+            setProvenPageLimit((previous) => applyWindowPageLimit(previous, target))
           } else if (reason === 'load-failed') {
             toast.error(
               translate(
@@ -6218,10 +6227,11 @@ export default function TaskPage(): React.JSX.Element {
               ),
               { id: 'work-items-page-load-failed' }
             )
+          } else {
+            setCountedTotalPages((previous) =>
+              applyEmptyPageClamp(previous, { target, failedCount, issueErrorTypes })
+            )
           }
-          setCountedTotalPages((previous) =>
-            applyEmptyPageClamp(previous, { target, failedCount, issueErrorTypes })
-          )
           return
         }
         setPages((previous) => {
@@ -6329,6 +6339,7 @@ export default function TaskPage(): React.JSX.Element {
     setPages([page0])
     setCurrentPage(0)
     setCountedTotalPages(null)
+    setProvenPageLimit(null)
     setTasksError(null)
     setFailedCount(0) // reset so a prior failure banner doesn't linger
     setGithubUnavailable(false)
@@ -6433,11 +6444,10 @@ export default function TaskPage(): React.JSX.Element {
       githubPerRepoPageLimit
     ).then(({ totalPages: countedPages }) => {
       if (!cancelled) {
-        // Why: min against an already-applied clamp — the count must not
-        // re-advertise pages a probe has proven unreachable this generation.
-        setCountedTotalPages((previous) =>
-          previous !== null && previous > 0 ? Math.min(previous, countedPages) : countedPages
-        )
+        // Why: the count overwrites unconditionally — proven window limits live
+        // in provenPageLimit, so a late count can't be pinned by a speculative
+        // end-of-data withdrawal, and can't resurrect proven-dead pages either.
+        setCountedTotalPages(countedPages)
       }
     })
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -3211,7 +3211,12 @@ export default function TaskPage(): React.JSX.Element {
   )
 
   // Why: see buildSelectedReposKey — array-identity deps re-fire on every
-  // repos:changed even when the selection is unchanged.
+  // repos:changed even when the selection is unchanged. The context part is
+  // resolved as GitHub, but every provider-independent field (projectId,
+  // hostId, projectHostSetupId, repoId) is identical across providers, so the
+  // GitLab effect can key off this too — it passes no gitlabProjectRef, so its
+  // context carries no providerIdentity of its own. Thread a projectRef into
+  // that call and this key needs a GitLab-scoped part.
   const selectedReposKey = useMemo(
     () => buildSelectedReposKey(selectedRepos, (r) => getTaskPageRepoSourceContext(r, 'github')),
     [selectedRepos]
@@ -4967,7 +4972,7 @@ export default function TaskPage(): React.JSX.Element {
     return () => {
       stale = true
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedReposKey encodes the only selectedRepos fields read above; keying off the array ref would re-run on every parent render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedReposKey covers every selectedRepos field read above (see its GitHub-scoped-context note); keying off the array ref would re-run on every parent render.
   }, [taskSource, gitlabView, activeGitlabFilter, gitlabRefreshNonce, selectedReposKey])
 
   // Why: Todos fetch has its own effect — different trigger (no chip filter) and data path (gl.todos is user-scoped, not repo-scoped).

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -205,6 +205,7 @@ import {
 } from '@/components/task-page-cache-selectors'
 import { shouldHideTaskPageListChrome } from '@/components/task-page-list-chrome-visibility'
 import {
+  buildSelectedReposKey,
   getTaskPagePerRepoLimit,
   resolveEmptyPageOutcome,
   taskPageToGitHubApiPage
@@ -3206,20 +3207,10 @@ export default function TaskPage(): React.JSX.Element {
     [eligibleRepos, repoSelection]
   )
 
-  // Why: stable string key for selectedRepos — the repos store installs a fresh
-  // array on every repos:changed event, so array-identity deps re-fire even when
-  // the selection is unchanged. Includes the resolved GitHub source context so a
-  // provider-identity change still re-keys everything the requests depend on.
+  // Why: see buildSelectedReposKey — array-identity deps re-fire on every
+  // repos:changed even when the selection is unchanged.
   const selectedReposKey = useMemo(
-    () =>
-      selectedRepos
-        .map(
-          (r) =>
-            `${r.id}|${r.path}|${r.connectionId ?? ''}|${r.executionHostId ?? ''}|${JSON.stringify(
-              getTaskPageRepoSourceContext(r, 'github')
-            )}`
-        )
-        .join(','),
+    () => buildSelectedReposKey(selectedRepos, (r) => getTaskPageRepoSourceContext(r, 'github')),
     [selectedRepos]
   )
 
@@ -3830,12 +3821,21 @@ export default function TaskPage(): React.JSX.Element {
 
   // Why: keyed on selectedReposKey, not the selectedRepos array — a background
   // repos:changed refresh mid-flight would otherwise bump the generation and
-  // silently discard the user's page navigation (#11485).
+  // silently discard the user's page navigation (#11485). Mirrors every dep of
+  // the fetch effect that resets page state, so a reset always invalidates
+  // in-flight page requests.
   useEffect(() => {
     paginationGenerationRef.current += 1
     setPaginationLoading(false)
     setLoadingTargetPage(null)
-  }, [selectedReposKey, appliedTaskSearch, workItemsInvalidationNonce])
+  }, [
+    selectedReposKey,
+    appliedTaskSearch,
+    workItemsInvalidationNonce,
+    taskRefreshNonce,
+    taskSource,
+    githubMode
+  ])
 
   // Why: the dialog's "Use" button routes through the same direct-launch flow as the row-level "Use" CTA so behavior is consistent regardless of entry point.
   const githubTaskDrawerWorkItem = useAppStore((s) => s.githubTaskDrawerWorkItem)
@@ -6190,7 +6190,12 @@ export default function TaskPage(): React.JSX.Element {
         if (items.length === 0) {
           // Why: see resolveEmptyPageOutcome — a dead click needs feedback only
           // when something actually failed; a clean empty probe is end-of-data.
-          const outcome = resolveEmptyPageOutcome({ target, failedCount, issueErrorTypes })
+          const outcome = resolveEmptyPageOutcome({
+            target,
+            failedCount,
+            issueErrorTypes,
+            countedTotalPages
+          })
           if (outcome.reason === 'window-unreachable') {
             toast.error(
               translate(
@@ -6242,6 +6247,7 @@ export default function TaskPage(): React.JSX.Element {
       paginationLoading,
       selectedRepos,
       currentPage,
+      countedTotalPages,
       appliedTaskSearch,
       fetchWorkItemsNextPage,
       githubPageSize,

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -3823,6 +3823,9 @@ export default function TaskPage(): React.JSX.Element {
   // can't resurrect proven-unreachable pages, nor be pinned by a speculative
   // withdrawal (see deriveAdvertisedTotalPages).
   const [provenPageLimit, setProvenPageLimit] = useState<number | null>(null)
+  // Why: synchronous mirror of countedTotalPages — the empty-page branch needs
+  // the committed value, not a click-time closure, and refs update immediately.
+  const countedTotalPagesRef = useRef<number | null>(null)
   const fetchWorkItemsNextPage = useAppStore((s) => s.fetchWorkItemsNextPage)
   const countWorkItemsAcrossRepos = useAppStore((s) => s.countWorkItemsAcrossRepos)
 
@@ -6228,23 +6231,24 @@ export default function TaskPage(): React.JSX.Element {
               { id: 'work-items-page-load-failed' }
             )
           } else {
-            // Why: with a real count the clamp is refused, so without a toast
-            // the click would look dead — the count mis-advertised the page.
-            // countedTotalPages is a click-time closure read; worst case the
-            // toast decision is off in a race, which is benign.
-            if (countedTotalPages !== null && countedTotalPages > 0) {
-              toast.error(
+            // Why: with a real count the clamp is refused, so without feedback
+            // the click would look dead — the count over-advertised; nothing
+            // failed, so the copy stays neutral. The ref carries the committed
+            // count, immune to the click-time closure race.
+            const committedCount = countedTotalPagesRef.current
+            if (committedCount !== null && committedCount > 0) {
+              toast(
                 translate(
-                  'auto.components.TaskPage.loadPageFailed',
-                  'Page {{value0}} could not be loaded from GitHub.',
+                  'auto.components.TaskPage.loadPageNoMoreResults',
+                  'No more results on page {{value0}}.',
                   { value0: String(target + 1) }
                 ),
-                { id: 'work-items-page-load-failed' }
+                { id: 'work-items-page-no-more-results' }
               )
             }
-            setCountedTotalPages((previous) =>
-              applyEmptyPageClamp(previous, { target, failedCount, errorTypes })
-            )
+            const next = applyEmptyPageClamp(committedCount, { target, failedCount, errorTypes })
+            countedTotalPagesRef.current = next
+            setCountedTotalPages(next)
           }
           return
         }
@@ -6270,7 +6274,6 @@ export default function TaskPage(): React.JSX.Element {
       paginationLoading,
       selectedRepos,
       currentPage,
-      countedTotalPages,
       appliedTaskSearch,
       fetchWorkItemsNextPage,
       githubPageSize,
@@ -6354,6 +6357,7 @@ export default function TaskPage(): React.JSX.Element {
     setPages([page0])
     setCurrentPage(0)
     setCountedTotalPages(null)
+    countedTotalPagesRef.current = null
     setProvenPageLimit(null)
     setTasksError(null)
     setFailedCount(0) // reset so a prior failure banner doesn't linger
@@ -6462,6 +6466,7 @@ export default function TaskPage(): React.JSX.Element {
         // Why: the count overwrites unconditionally — proven window limits live
         // in provenPageLimit, so a late count can't be pinned by a speculative
         // end-of-data withdrawal, and can't resurrect proven-dead pages either.
+        countedTotalPagesRef.current = countedPages
         setCountedTotalPages(countedPages)
       }
     })

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -3205,6 +3205,17 @@ export default function TaskPage(): React.JSX.Element {
     [eligibleRepos, repoSelection]
   )
 
+  // Why: stable string key for selectedRepos — the repos store installs a fresh
+  // array on every repos:changed event, so array-identity deps re-fire even when
+  // the selection is unchanged.
+  const selectedReposKey = useMemo(
+    () =>
+      selectedRepos
+        .map((r) => `${r.id}|${r.path}|${r.connectionId ?? ''}|${r.executionHostId ?? ''}`)
+        .join(','),
+    [selectedRepos]
+  )
+
   // Why: many affordances need *a* repo; use the first selected as default, while cross-repo dialogs still let the user override per-action.
   const primaryRepo = selectedRepos[0] ?? null
   const linearWorkspaces = linearStatus.workspaces ?? []
@@ -3810,11 +3821,14 @@ export default function TaskPage(): React.JSX.Element {
   const fetchWorkItemsNextPage = useAppStore((s) => s.fetchWorkItemsNextPage)
   const countWorkItemsAcrossRepos = useAppStore((s) => s.countWorkItemsAcrossRepos)
 
+  // Why: keyed on selectedReposKey, not the selectedRepos array — a background
+  // repos:changed refresh mid-flight would otherwise bump the generation and
+  // silently discard the user's page navigation (#11485).
   useEffect(() => {
     paginationGenerationRef.current += 1
     setPaginationLoading(false)
     setLoadingTargetPage(null)
-  }, [selectedRepos, appliedTaskSearch, workItemsInvalidationNonce])
+  }, [selectedReposKey, appliedTaskSearch, workItemsInvalidationNonce])
 
   // Why: the dialog's "Use" button routes through the same direct-launch flow as the row-level "Use" CTA so behavior is consistent regardless of entry point.
   const githubTaskDrawerWorkItem = useAppStore((s) => s.githubTaskDrawerWorkItem)
@@ -4828,15 +4842,6 @@ export default function TaskPage(): React.JSX.Element {
     taskResumeApplied,
     jiraTaskSourceContext
   ])
-
-  // Why: stable string key for selectedRepos so the GitLab effect doesn't re-run on every parent render from a new array ref.
-  const selectedReposKey = useMemo(
-    () =>
-      selectedRepos
-        .map((r) => `${r.id}|${r.path}|${r.connectionId ?? ''}|${r.executionHostId ?? ''}`)
-        .join(','),
-    [selectedRepos]
-  )
 
   // Why: fetch GitLab Issues and MRs separately so errors stay isolated per tab (mirrors GitHub's split endpoints).
   useEffect(() => {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -6165,7 +6165,7 @@ export default function TaskPage(): React.JSX.Element {
       setPaginationLoading(true)
       setLoadingTargetPage(target)
       try {
-        const { items } = await fetchWorkItemsNextPage(
+        const { items, failedCount } = await fetchWorkItemsNextPage(
           repoArgs,
           githubPerRepoPageLimit,
           githubPageSize,
@@ -6176,6 +6176,22 @@ export default function TaskPage(): React.JSX.Element {
           return
         }
         if (items.length === 0) {
+          // Why: staying on the current page without saying so reads as a dead
+          // click (#11485). Empty with no thrown fetch means the target is past
+          // GitHub's reachable search window, so stop advertising it; thrown
+          // fetches may be transient, so keep the page count.
+          toast.error(
+            translate(
+              'auto.components.TaskPage.loadPageUnreachable',
+              'Page {{value0}} could not be loaded from GitHub.',
+              { value0: String(target + 1) }
+            )
+          )
+          if (failedCount === 0) {
+            setCountedTotalPages((previous) =>
+              previous !== null && previous > target ? target : previous
+            )
+          }
           return
         }
         setPages((previous) => {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -6187,7 +6187,7 @@ export default function TaskPage(): React.JSX.Element {
       setPaginationLoading(true)
       setLoadingTargetPage(target)
       try {
-        const { items, failedCount, issueErrorTypes } = await fetchWorkItemsNextPage(
+        const { items, failedCount, errorTypes } = await fetchWorkItemsNextPage(
           repoArgs,
           githubPerRepoPageLimit,
           githubPageSize,
@@ -6205,7 +6205,7 @@ export default function TaskPage(): React.JSX.Element {
           const { reason } = resolveEmptyPageOutcome({
             target,
             failedCount,
-            issueErrorTypes,
+            errorTypes,
             countedTotalPages: null
           })
           if (reason === 'window-unreachable') {
@@ -6228,8 +6228,22 @@ export default function TaskPage(): React.JSX.Element {
               { id: 'work-items-page-load-failed' }
             )
           } else {
+            // Why: with a real count the clamp is refused, so without a toast
+            // the click would look dead — the count mis-advertised the page.
+            // countedTotalPages is a click-time closure read; worst case the
+            // toast decision is off in a race, which is benign.
+            if (countedTotalPages !== null && countedTotalPages > 0) {
+              toast.error(
+                translate(
+                  'auto.components.TaskPage.loadPageFailed',
+                  'Page {{value0}} could not be loaded from GitHub.',
+                  { value0: String(target + 1) }
+                ),
+                { id: 'work-items-page-load-failed' }
+              )
+            }
             setCountedTotalPages((previous) =>
-              applyEmptyPageClamp(previous, { target, failedCount, issueErrorTypes })
+              applyEmptyPageClamp(previous, { target, failedCount, errorTypes })
             )
           }
           return
@@ -6256,6 +6270,7 @@ export default function TaskPage(): React.JSX.Element {
       paginationLoading,
       selectedRepos,
       currentPage,
+      countedTotalPages,
       appliedTaskSearch,
       fetchWorkItemsNextPage,
       githubPageSize,

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -205,6 +205,7 @@ import {
 } from '@/components/task-page-cache-selectors'
 import { shouldHideTaskPageListChrome } from '@/components/task-page-list-chrome-visibility'
 import {
+  applyEmptyPageClamp,
   buildSelectedReposKey,
   getTaskPagePerRepoLimit,
   resolveEmptyPageOutcome,
@@ -6190,13 +6191,15 @@ export default function TaskPage(): React.JSX.Element {
         if (items.length === 0) {
           // Why: see resolveEmptyPageOutcome — a dead click needs feedback only
           // when something actually failed; a clean empty probe is end-of-data.
-          const outcome = resolveEmptyPageOutcome({
+          // The reason never depends on the count, so it's safe to derive here;
+          // the clamp is not (see applyEmptyPageClamp) and runs in the updater.
+          const { reason } = resolveEmptyPageOutcome({
             target,
             failedCount,
             issueErrorTypes,
-            countedTotalPages
+            countedTotalPages: null
           })
-          if (outcome.reason === 'window-unreachable') {
+          if (reason === 'window-unreachable') {
             toast.error(
               translate(
                 'auto.components.TaskPage.loadPageUnreachable',
@@ -6205,7 +6208,7 @@ export default function TaskPage(): React.JSX.Element {
               ),
               { id: 'work-items-page-unreachable' }
             )
-          } else if (outcome.reason === 'load-failed') {
+          } else if (reason === 'load-failed') {
             toast.error(
               translate(
                 'auto.components.TaskPage.loadPageFailed',
@@ -6215,14 +6218,9 @@ export default function TaskPage(): React.JSX.Element {
               { id: 'work-items-page-load-failed' }
             )
           }
-          const clamp = outcome.clampTotalPagesTo
-          if (clamp !== null) {
-            // Why: 0 means the count itself failed (fallback path) — replace it
-            // like null, or the speculative fallback page is never withdrawn.
-            setCountedTotalPages((previous) =>
-              previous !== null && previous > 0 && previous < clamp ? previous : clamp
-            )
-          }
+          setCountedTotalPages((previous) =>
+            applyEmptyPageClamp(previous, { target, failedCount, issueErrorTypes })
+          )
           return
         }
         setPages((previous) => {
@@ -6247,7 +6245,6 @@ export default function TaskPage(): React.JSX.Element {
       paginationLoading,
       selectedRepos,
       currentPage,
-      countedTotalPages,
       appliedTaskSearch,
       fetchWorkItemsNextPage,
       githubPageSize,

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -6212,8 +6212,10 @@ export default function TaskPage(): React.JSX.Element {
           }
           const clamp = outcome.clampTotalPagesTo
           if (clamp !== null) {
+            // Why: 0 means the count itself failed (fallback path) — replace it
+            // like null, or the speculative fallback page is never withdrawn.
             setCountedTotalPages((previous) =>
-              previous !== null && previous < clamp ? previous : clamp
+              previous !== null && previous > 0 && previous < clamp ? previous : clamp
             )
           }
           return

--- a/src/renderer/src/components/task-page-work-item-pagination.test.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.test.ts
@@ -80,16 +80,23 @@ describe('resolveEmptyPageOutcome', () => {
     ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 33 })
   })
 
-  it('resolves as load-failed when a window 422 coincides with a thrown repo fetch', () => {
-    // Repos advance independently; another repo's transient failure says
-    // nothing about the healthy repos' remaining pages — and the transient
-    // failure is the actionable signal, so it wins the toast too.
+  it('resolves as load-failed when a window 422 coincides with a sibling failure', () => {
+    // Repos advance independently; another repo's failure — thrown or on the
+    // envelope channel — says nothing about the healthy repos' remaining
+    // pages, and the transient failure is the actionable signal.
     expect(
       resolveEmptyPageOutcome({
         ...base,
         target: 5,
         failedCount: 1,
         issueErrorTypes: ['validation_error']
+      })
+    ).toEqual({ reason: 'load-failed', clampTotalPagesTo: null })
+    expect(
+      resolveEmptyPageOutcome({
+        ...base,
+        target: 5,
+        issueErrorTypes: ['validation_error', 'permission_denied']
       })
     ).toEqual({ reason: 'load-failed', clampTotalPagesTo: null })
   })

--- a/src/renderer/src/components/task-page-work-item-pagination.test.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { GitHubWorkItem } from '../../../shared/types'
 import {
   accumulateWorkItemPages,
+  applyEmptyPageClamp,
   buildSelectedReposKey,
   getTaskPagePerRepoLimit,
   resolveEmptyPageOutcome,
@@ -79,9 +80,10 @@ describe('resolveEmptyPageOutcome', () => {
     ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 33 })
   })
 
-  it('does not clamp on a window 422 when a sibling repo fetch threw', () => {
+  it('resolves as load-failed when a window 422 coincides with a thrown repo fetch', () => {
     // Repos advance independently; another repo's transient failure says
-    // nothing about the healthy repos' remaining pages.
+    // nothing about the healthy repos' remaining pages — and the transient
+    // failure is the actionable signal, so it wins the toast too.
     expect(
       resolveEmptyPageOutcome({
         ...base,
@@ -89,7 +91,7 @@ describe('resolveEmptyPageOutcome', () => {
         failedCount: 1,
         issueErrorTypes: ['validation_error']
       })
-    ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: null })
+    ).toEqual({ reason: 'load-failed', clampTotalPagesTo: null })
   })
 
   it('reports a failure without clamping for transient or unclassified errors', () => {
@@ -126,6 +128,40 @@ describe('resolveEmptyPageOutcome', () => {
       reason: 'end-of-data',
       clampTotalPagesTo: 1
     })
+  })
+})
+
+describe('applyEmptyPageClamp', () => {
+  const clean = { failedCount: 0, issueErrorTypes: [] as const }
+
+  it('keeps a real count that resolved between click and response', () => {
+    // The count promise routinely lands mid-flight; the committed value, not
+    // the click-time closure, must decide whether end-of-data may clamp.
+    expect(applyEmptyPageClamp(33, { ...clean, target: 2 })).toBe(33)
+  })
+
+  it('clamps while the count is unknown or failed', () => {
+    expect(applyEmptyPageClamp(null, { ...clean, target: 2 })).toBe(2)
+    expect(applyEmptyPageClamp(0, { ...clean, target: 2 })).toBe(2)
+  })
+
+  it('never raises an earlier clamp', () => {
+    // A prior probe clamped to 20; a later window 422 at page 33 must not
+    // re-advertise pages 21-33.
+    expect(
+      applyEmptyPageClamp(20, { target: 33, failedCount: 0, issueErrorTypes: ['validation_error'] })
+    ).toBe(20)
+  })
+
+  it('clamps a real count on a window 422 — the count over-advertising is the bug', () => {
+    expect(
+      applyEmptyPageClamp(39, { target: 33, failedCount: 0, issueErrorTypes: ['validation_error'] })
+    ).toBe(33)
+  })
+
+  it('leaves the count alone on failures', () => {
+    expect(applyEmptyPageClamp(33, { target: 5, failedCount: 2, issueErrorTypes: [] })).toBe(33)
+    expect(applyEmptyPageClamp(null, { target: 5, failedCount: 2, issueErrorTypes: [] })).toBe(null)
   })
 })
 

--- a/src/renderer/src/components/task-page-work-item-pagination.test.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { GitHubWorkItem } from '../../../shared/types'
 import {
   accumulateWorkItemPages,
+  buildSelectedReposKey,
   getTaskPagePerRepoLimit,
   resolveEmptyPageOutcome,
   taskPageToGitHubApiPage,
@@ -61,38 +62,92 @@ describe('numbered GitHub pagination', () => {
 })
 
 describe('resolveEmptyPageOutcome', () => {
+  const base = { failedCount: 0, issueErrorTypes: [] as const, countedTotalPages: null }
+
   it('clamps and reports unreachable when the search window 422 is present', () => {
     expect(
-      resolveEmptyPageOutcome({ target: 33, failedCount: 0, issueErrorTypes: ['validation_error'] })
+      resolveEmptyPageOutcome({ ...base, target: 33, issueErrorTypes: ['validation_error'] })
     ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 33 })
-    // A thrown repo alongside the 422 doesn't mask the window signal.
+    // A real count is still clamped — the count over-advertising is the bug.
     expect(
-      resolveEmptyPageOutcome({ target: 5, failedCount: 1, issueErrorTypes: ['validation_error'] })
-    ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 5 })
+      resolveEmptyPageOutcome({
+        ...base,
+        target: 33,
+        issueErrorTypes: ['validation_error'],
+        countedTotalPages: 39
+      })
+    ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 33 })
+  })
+
+  it('does not clamp on a window 422 when a sibling repo fetch threw', () => {
+    // Repos advance independently; another repo's transient failure says
+    // nothing about the healthy repos' remaining pages.
+    expect(
+      resolveEmptyPageOutcome({
+        ...base,
+        target: 5,
+        failedCount: 1,
+        issueErrorTypes: ['validation_error']
+      })
+    ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: null })
   })
 
   it('reports a failure without clamping for transient or unclassified errors', () => {
-    expect(resolveEmptyPageOutcome({ target: 5, failedCount: 2, issueErrorTypes: [] })).toEqual({
+    expect(resolveEmptyPageOutcome({ ...base, target: 5, failedCount: 2 })).toEqual({
       reason: 'load-failed',
       clampTotalPagesTo: null
     })
     for (const type of ['permission_denied', 'not_found', 'rate_limited', 'unknown'] as const) {
-      expect(
-        resolveEmptyPageOutcome({ target: 5, failedCount: 0, issueErrorTypes: [type] })
-      ).toEqual({ reason: 'load-failed', clampTotalPagesTo: null })
+      expect(resolveEmptyPageOutcome({ ...base, target: 5, issueErrorTypes: [type] })).toEqual({
+        reason: 'load-failed',
+        clampTotalPagesTo: null
+      })
     }
   })
 
-  it('treats a clean empty probe as end-of-data and withdraws the speculative page', () => {
-    expect(resolveEmptyPageOutcome({ target: 2, failedCount: 0, issueErrorTypes: [] })).toEqual({
+  it('withdraws the speculative page on clean empty only while the count is unknown', () => {
+    expect(resolveEmptyPageOutcome({ ...base, target: 2 })).toEqual({
       reason: 'end-of-data',
       clampTotalPagesTo: 2
     })
+    // 0 means the count itself failed — treat like unknown.
+    expect(resolveEmptyPageOutcome({ ...base, target: 2, countedTotalPages: 0 })).toEqual({
+      reason: 'end-of-data',
+      clampTotalPagesTo: 2
+    })
+    // A real count must not shrink: the PR list path swallows its own failures
+    // into clean-empty results, and clamping would hide healthy pages silently.
+    expect(resolveEmptyPageOutcome({ ...base, target: 2, countedTotalPages: 34 })).toEqual({
+      reason: 'end-of-data',
+      clampTotalPagesTo: null
+    })
     // Never clamps below one advertised page.
-    expect(resolveEmptyPageOutcome({ target: 0, failedCount: 0, issueErrorTypes: [] })).toEqual({
+    expect(resolveEmptyPageOutcome({ ...base, target: 0 })).toEqual({
       reason: 'end-of-data',
       clampTotalPagesTo: 1
     })
+  })
+})
+
+describe('buildSelectedReposKey', () => {
+  const contextFor = (r: { id: string }) => ({ provider: 'github', repoId: r.id })
+
+  it('is stable across fresh arrays with identical contents', () => {
+    const a = [{ id: 'r1', path: '/a', connectionId: null, executionHostId: null }]
+    const b = [{ ...a[0] }]
+    expect(buildSelectedReposKey(a, contextFor)).toBe(buildSelectedReposKey(b, contextFor))
+  })
+
+  it('changes when any request-relevant field changes', () => {
+    const repo = { id: 'r1', path: '/a', connectionId: null, executionHostId: null }
+    const key = buildSelectedReposKey([repo], contextFor)
+    expect(buildSelectedReposKey([{ ...repo, executionHostId: 'ssh:host' }], contextFor)).not.toBe(
+      key
+    )
+    expect(buildSelectedReposKey([{ ...repo, path: '/b' }], contextFor)).not.toBe(key)
+    expect(
+      buildSelectedReposKey([repo], (r) => ({ provider: 'github', repoId: r.id, owner: 'new' }))
+    ).not.toBe(key)
   })
 })
 

--- a/src/renderer/src/components/task-page-work-item-pagination.test.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.test.ts
@@ -65,18 +65,18 @@ describe('numbered GitHub pagination', () => {
 })
 
 describe('resolveEmptyPageOutcome', () => {
-  const base = { failedCount: 0, issueErrorTypes: [] as const, countedTotalPages: null }
+  const base = { failedCount: 0, errorTypes: [] as const, countedTotalPages: null }
 
   it('clamps and reports unreachable when the search window 422 is present', () => {
     expect(
-      resolveEmptyPageOutcome({ ...base, target: 33, issueErrorTypes: ['validation_error'] })
+      resolveEmptyPageOutcome({ ...base, target: 33, errorTypes: ['validation_error'] })
     ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 33 })
     // A real count is still clamped — the count over-advertising is the bug.
     expect(
       resolveEmptyPageOutcome({
         ...base,
         target: 33,
-        issueErrorTypes: ['validation_error'],
+        errorTypes: ['validation_error'],
         countedTotalPages: 39
       })
     ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 33 })
@@ -91,14 +91,14 @@ describe('resolveEmptyPageOutcome', () => {
         ...base,
         target: 5,
         failedCount: 1,
-        issueErrorTypes: ['validation_error']
+        errorTypes: ['validation_error']
       })
     ).toEqual({ reason: 'load-failed', clampTotalPagesTo: null })
     expect(
       resolveEmptyPageOutcome({
         ...base,
         target: 5,
-        issueErrorTypes: ['validation_error', 'permission_denied']
+        errorTypes: ['validation_error', 'permission_denied']
       })
     ).toEqual({ reason: 'load-failed', clampTotalPagesTo: null })
   })
@@ -109,7 +109,7 @@ describe('resolveEmptyPageOutcome', () => {
       clampTotalPagesTo: null
     })
     for (const type of ['permission_denied', 'not_found', 'rate_limited', 'unknown'] as const) {
-      expect(resolveEmptyPageOutcome({ ...base, target: 5, issueErrorTypes: [type] })).toEqual({
+      expect(resolveEmptyPageOutcome({ ...base, target: 5, errorTypes: [type] })).toEqual({
         reason: 'load-failed',
         clampTotalPagesTo: null
       })
@@ -141,7 +141,7 @@ describe('resolveEmptyPageOutcome', () => {
 })
 
 describe('applyEmptyPageClamp', () => {
-  const clean = { failedCount: 0, issueErrorTypes: [] as const }
+  const clean = { failedCount: 0, errorTypes: [] as const }
 
   it('keeps a real count that resolved between click and response', () => {
     // The count promise routinely lands mid-flight; the committed value, not
@@ -158,10 +158,10 @@ describe('applyEmptyPageClamp', () => {
     // Window 422 limits live in provenPageLimit (applyWindowPageLimit), not
     // the count slot.
     expect(
-      applyEmptyPageClamp(39, { target: 33, failedCount: 0, issueErrorTypes: ['validation_error'] })
+      applyEmptyPageClamp(39, { target: 33, failedCount: 0, errorTypes: ['validation_error'] })
     ).toBe(39)
-    expect(applyEmptyPageClamp(33, { target: 5, failedCount: 2, issueErrorTypes: [] })).toBe(33)
-    expect(applyEmptyPageClamp(null, { target: 5, failedCount: 2, issueErrorTypes: [] })).toBe(null)
+    expect(applyEmptyPageClamp(33, { target: 5, failedCount: 2, errorTypes: [] })).toBe(33)
+    expect(applyEmptyPageClamp(null, { target: 5, failedCount: 2, errorTypes: [] })).toBe(null)
   })
 })
 

--- a/src/renderer/src/components/task-page-work-item-pagination.test.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.test.ts
@@ -3,7 +3,9 @@ import type { GitHubWorkItem } from '../../../shared/types'
 import {
   accumulateWorkItemPages,
   applyEmptyPageClamp,
+  applyWindowPageLimit,
   buildSelectedReposKey,
+  deriveAdvertisedTotalPages,
   getTaskPagePerRepoLimit,
   resolveEmptyPageOutcome,
   taskPageToGitHubApiPage,
@@ -147,28 +149,84 @@ describe('applyEmptyPageClamp', () => {
     expect(applyEmptyPageClamp(33, { ...clean, target: 2 })).toBe(33)
   })
 
-  it('clamps while the count is unknown or failed', () => {
+  it('withdraws the speculative page while the count is unknown or failed', () => {
     expect(applyEmptyPageClamp(null, { ...clean, target: 2 })).toBe(2)
     expect(applyEmptyPageClamp(0, { ...clean, target: 2 })).toBe(2)
   })
 
-  it('never raises an earlier clamp', () => {
-    // A prior probe clamped to 20; a later window 422 at page 33 must not
-    // re-advertise pages 21-33.
-    expect(
-      applyEmptyPageClamp(20, { target: 33, failedCount: 0, issueErrorTypes: ['validation_error'] })
-    ).toBe(20)
-  })
-
-  it('clamps a real count on a window 422 — the count over-advertising is the bug', () => {
+  it('never touches the count for window or failure outcomes', () => {
+    // Window 422 limits live in provenPageLimit (applyWindowPageLimit), not
+    // the count slot.
     expect(
       applyEmptyPageClamp(39, { target: 33, failedCount: 0, issueErrorTypes: ['validation_error'] })
+    ).toBe(39)
+    expect(applyEmptyPageClamp(33, { target: 5, failedCount: 2, issueErrorTypes: [] })).toBe(33)
+    expect(applyEmptyPageClamp(null, { target: 5, failedCount: 2, issueErrorTypes: [] })).toBe(null)
+  })
+})
+
+describe('applyWindowPageLimit', () => {
+  it('sets, only lowers, and never goes below one page', () => {
+    expect(applyWindowPageLimit(null, 33)).toBe(33)
+    expect(applyWindowPageLimit(33, 20)).toBe(20)
+    expect(applyWindowPageLimit(20, 33)).toBe(20)
+    expect(applyWindowPageLimit(null, 0)).toBe(1)
+  })
+})
+
+describe('deriveAdvertisedTotalPages', () => {
+  it('is order-independent: a count landing after a speculative withdrawal wins', () => {
+    // Probe first: end-of-data wrote countedTotalPages=1 (speculative). Count
+    // then overwrites with 39 — the bar must show 39, not stay collapsed.
+    expect(
+      deriveAdvertisedTotalPages({
+        loadedPages: 1,
+        countedTotalPages: 39,
+        fallbackTotalPages: 2,
+        provenPageLimit: null
+      })
+    ).toBe(39)
+  })
+
+  it('caps a real count with the proven window limit', () => {
+    expect(
+      deriveAdvertisedTotalPages({
+        loadedPages: 3,
+        countedTotalPages: 39,
+        fallbackTotalPages: 4,
+        provenPageLimit: 33
+      })
     ).toBe(33)
   })
 
-  it('leaves the count alone on failures', () => {
-    expect(applyEmptyPageClamp(33, { target: 5, failedCount: 2, issueErrorTypes: [] })).toBe(33)
-    expect(applyEmptyPageClamp(null, { target: 5, failedCount: 2, issueErrorTypes: [] })).toBe(null)
+  it('uses the fallback while the count is unknown/failed, still window-capped', () => {
+    expect(
+      deriveAdvertisedTotalPages({
+        loadedPages: 1,
+        countedTotalPages: null,
+        fallbackTotalPages: 2,
+        provenPageLimit: null
+      })
+    ).toBe(2)
+    expect(
+      deriveAdvertisedTotalPages({
+        loadedPages: 1,
+        countedTotalPages: 0,
+        fallbackTotalPages: 5,
+        provenPageLimit: 3
+      })
+    ).toBe(3)
+  })
+
+  it('never advertises fewer pages than are loaded', () => {
+    expect(
+      deriveAdvertisedTotalPages({
+        loadedPages: 5,
+        countedTotalPages: 2,
+        fallbackTotalPages: 2,
+        provenPageLimit: 2
+      })
+    ).toBe(5)
   })
 })
 

--- a/src/renderer/src/components/task-page-work-item-pagination.test.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.test.ts
@@ -3,6 +3,7 @@ import type { GitHubWorkItem } from '../../../shared/types'
 import {
   accumulateWorkItemPages,
   getTaskPagePerRepoLimit,
+  resolveEmptyPageOutcome,
   taskPageToGitHubApiPage,
   workItemIdentity
 } from './task-page-work-item-pagination'
@@ -56,6 +57,42 @@ describe('numbered GitHub pagination', () => {
     expect(getTaskPagePerRepoLimit(2, 36, 100)).toBe(36)
     expect(getTaskPagePerRepoLimit(3, 36, 100)).toBe(33)
     expect(getTaskPagePerRepoLimit(90, 36, 100)).toBe(1)
+  })
+})
+
+describe('resolveEmptyPageOutcome', () => {
+  it('clamps and reports unreachable when the search window 422 is present', () => {
+    expect(
+      resolveEmptyPageOutcome({ target: 33, failedCount: 0, issueErrorTypes: ['validation_error'] })
+    ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 33 })
+    // A thrown repo alongside the 422 doesn't mask the window signal.
+    expect(
+      resolveEmptyPageOutcome({ target: 5, failedCount: 1, issueErrorTypes: ['validation_error'] })
+    ).toEqual({ reason: 'window-unreachable', clampTotalPagesTo: 5 })
+  })
+
+  it('reports a failure without clamping for transient or unclassified errors', () => {
+    expect(resolveEmptyPageOutcome({ target: 5, failedCount: 2, issueErrorTypes: [] })).toEqual({
+      reason: 'load-failed',
+      clampTotalPagesTo: null
+    })
+    for (const type of ['permission_denied', 'not_found', 'rate_limited', 'unknown'] as const) {
+      expect(
+        resolveEmptyPageOutcome({ target: 5, failedCount: 0, issueErrorTypes: [type] })
+      ).toEqual({ reason: 'load-failed', clampTotalPagesTo: null })
+    }
+  })
+
+  it('treats a clean empty probe as end-of-data and withdraws the speculative page', () => {
+    expect(resolveEmptyPageOutcome({ target: 2, failedCount: 0, issueErrorTypes: [] })).toEqual({
+      reason: 'end-of-data',
+      clampTotalPagesTo: 2
+    })
+    // Never clamps below one advertised page.
+    expect(resolveEmptyPageOutcome({ target: 0, failedCount: 0, issueErrorTypes: [] })).toEqual({
+      reason: 'end-of-data',
+      clampTotalPagesTo: 1
+    })
   })
 })
 

--- a/src/renderer/src/components/task-page-work-item-pagination.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.ts
@@ -65,7 +65,13 @@ export function resolveEmptyPageOutcome(args: {
   countedTotalPages: number | null
 }): EmptyPageOutcome {
   const clamp = Math.max(1, Math.floor(args.target))
-  if (args.issueErrorTypes.includes('validation_error') && args.failedCount === 0) {
+  // Why: every error must be the window 422 — a sibling repo's envelope
+  // 403/404 alongside it means a repo that may still have pages, so the
+  // transient-failure branch must win the toast and block the clamp.
+  const onlyWindowErrors =
+    args.issueErrorTypes.length > 0 &&
+    args.issueErrorTypes.every((type) => type === 'validation_error')
+  if (onlyWindowErrors && args.failedCount === 0) {
     return { reason: 'window-unreachable', clampTotalPagesTo: clamp }
   }
   if (args.failedCount > 0 || args.issueErrorTypes.length > 0) {

--- a/src/renderer/src/components/task-page-work-item-pagination.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.ts
@@ -82,11 +82,13 @@ export function resolveEmptyPageOutcome(args: {
 }
 
 /**
- * Functional-updater body for the advertised-count clamp. Must be evaluated
- * against the COMMITTED count (React updater `previous`), not a click-time
- * closure — the count promise routinely resolves between click and response,
- * and a stale-null closure would let an end-of-data clamp overwrite a real
- * count. Math.min preserves the never-raise property of earlier clamps.
+ * Functional-updater body for the SPECULATIVE end-of-data withdrawal only.
+ * Must be evaluated against the COMMITTED count (React updater `previous`),
+ * not a click-time closure — the count promise routinely resolves between
+ * click and response. Window 422 clamps are PROVEN and live in their own
+ * state (applyWindowPageLimit); keeping them out of the count slot lets a
+ * later real count overwrite the speculative value instead of being pinned
+ * under it.
  */
 export function applyEmptyPageClamp(
   previous: number | null,
@@ -96,11 +98,37 @@ export function applyEmptyPageClamp(
     issueErrorTypes: readonly ClassifiedError['type'][]
   }
 ): number | null {
-  const next = resolveEmptyPageOutcome({ ...args, countedTotalPages: previous }).clampTotalPagesTo
-  if (next === null) {
+  const outcome = resolveEmptyPageOutcome({ ...args, countedTotalPages: previous })
+  if (outcome.reason !== 'end-of-data' || outcome.clampTotalPagesTo === null) {
     return previous
   }
-  return previous !== null && previous > 0 ? Math.min(previous, next) : next
+  return outcome.clampTotalPagesTo
+}
+
+/** Proven window 422 limit: set once, only ever lowered, reset per generation. */
+export function applyWindowPageLimit(previous: number | null, target: number): number {
+  const clamp = Math.max(1, Math.floor(target))
+  return previous === null ? clamp : Math.min(previous, clamp)
+}
+
+/**
+ * Advertised page count = the count-or-fallback estimate, capped by the proven
+ * window limit, floored at the loaded pages. Splitting the proven cap from the
+ * count slot makes the result order-independent: a count arriving after a
+ * speculative withdrawal overwrites it, while a proven limit survives.
+ */
+export function deriveAdvertisedTotalPages(args: {
+  loadedPages: number
+  countedTotalPages: number | null
+  fallbackTotalPages: number
+  provenPageLimit: number | null
+}): number {
+  const uncapped =
+    args.countedTotalPages && args.countedTotalPages > 0
+      ? Math.max(args.loadedPages, args.countedTotalPages)
+      : args.fallbackTotalPages
+  const capped = args.provenPageLimit === null ? uncapped : Math.min(uncapped, args.provenPageLimit)
+  return Math.max(args.loadedPages, capped)
 }
 
 /**

--- a/src/renderer/src/components/task-page-work-item-pagination.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.ts
@@ -45,26 +45,59 @@ export type EmptyPageOutcome = {
  * An empty page load has three distinct meanings, and only the caller-side
  * error channels can tell them apart (#11485):
  * - a `validation_error` is GitHub's 422 for pages past its 1000-result search
- *   window — the page can never load, so stop advertising it;
+ *   window — the page can never load, so stop advertising it (unless a sibling
+ *   repo's fetch threw, which says nothing about the other repos' windows);
  * - any other per-repo error (thrown or issue-side envelope) may be transient
  *   (rate limit, permissions), so surface it but keep the advertised count;
- * - no error at all is the designed end-of-data signal from probing the
- *   speculative page `fallbackTotalPages` advertises while the count is
- *   unknown — withdraw the phantom page silently.
+ * - no error at all is end-of-data. That only warrants a clamp while the count
+ *   is unknown (null) or failed (0), to withdraw the speculative page
+ *   `fallbackTotalPages` advertises — a real count must not shrink, because a
+ *   provider that swallows its own failures (the PR list path) also produces
+ *   clean-empty results.
  */
 export function resolveEmptyPageOutcome(args: {
   target: number
   failedCount: number
   issueErrorTypes: readonly ClassifiedError['type'][]
+  countedTotalPages: number | null
 }): EmptyPageOutcome {
   const clamp = Math.max(1, Math.floor(args.target))
   if (args.issueErrorTypes.includes('validation_error')) {
-    return { reason: 'window-unreachable', clampTotalPagesTo: clamp }
+    return {
+      reason: 'window-unreachable',
+      clampTotalPagesTo: args.failedCount === 0 ? clamp : null
+    }
   }
   if (args.failedCount > 0 || args.issueErrorTypes.length > 0) {
     return { reason: 'load-failed', clampTotalPagesTo: null }
   }
-  return { reason: 'end-of-data', clampTotalPagesTo: clamp }
+  const countUnknown = args.countedTotalPages === null || args.countedTotalPages === 0
+  return { reason: 'end-of-data', clampTotalPagesTo: countUnknown ? clamp : null }
+}
+
+/**
+ * Stable identity string for a repo selection. The repos store installs a fresh
+ * array on every repos:changed event, so effects keyed on array identity re-fire
+ * with the selection unchanged — resetting pagination mid-click (#11485). The
+ * key must cover every repo field the work-item requests read; the caller
+ * supplies the resolved source context (which must stay free of timestamps).
+ */
+export function buildSelectedReposKey<
+  T extends {
+    id: string
+    path: string
+    connectionId?: string | null
+    executionHostId?: string | null
+  }
+>(repos: readonly T[], sourceContextFor: (repo: T) => unknown): string {
+  return repos
+    .map(
+      (r) =>
+        `${r.id}|${r.path}|${r.connectionId ?? ''}|${r.executionHostId ?? ''}|${JSON.stringify(
+          sourceContextFor(r)
+        )}`
+    )
+    .join(',')
 }
 
 // Why: provider pages cannot spill truncated rows into the next page. Divide

--- a/src/renderer/src/components/task-page-work-item-pagination.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.ts
@@ -37,7 +37,9 @@ export function taskPageToGitHubApiPage(taskPage: number): number {
 
 export type EmptyPageOutcome = {
   reason: 'window-unreachable' | 'load-failed' | 'end-of-data'
-  /** New advertised page count, or null to leave the current count alone. */
+  /** New advertised page count, or null to leave the current count alone.
+   *  Window clamps are applied via applyWindowPageLimit — this field carries
+   *  the same value there for symmetry, but the count slot must not use it. */
   clampTotalPagesTo: number | null
 }
 
@@ -47,21 +49,18 @@ export type EmptyPageOutcome = {
  * - a `validation_error` is GitHub's 422 for pages past its 1000-result search
  *   window — the page can never load, so stop advertising it. When a sibling
  *   repo's fetch also threw, the transient failure wins (load-failed, no
- *   clamp) so the toast and the clamp never disagree. Note this branch is
- *   issue-scope-only: the PR list path self-caps at the window and never 422s,
- *   so PR-tab dead clicks resolve as end-of-data.
- * - any other per-repo error (thrown or issue-side envelope) may be transient
- *   (rate limit, permissions), so surface it but keep the advertised count;
+ *   clamp) so the toast and the clamp never disagree. The window signal is
+ *   issue-side only: PR-side errors arrive demoted (never validation_error).
+ * - any other per-repo error (thrown, or on either envelope channel) may be
+ *   transient (rate limit, permissions), so surface it but keep the count;
  * - no error at all is end-of-data. That only warrants a clamp while the count
  *   is unknown (null) or failed (0), to withdraw the speculative page
- *   `fallbackTotalPages` advertises — a real count must not shrink, because a
- *   provider that swallows its own failures (the PR list path) also produces
- *   clean-empty results.
+ *   `fallbackTotalPages` advertises — a real count must not shrink.
  */
 export function resolveEmptyPageOutcome(args: {
   target: number
   failedCount: number
-  issueErrorTypes: readonly ClassifiedError['type'][]
+  errorTypes: readonly ClassifiedError['type'][]
   countedTotalPages: number | null
 }): EmptyPageOutcome {
   const clamp = Math.max(1, Math.floor(args.target))
@@ -69,12 +68,11 @@ export function resolveEmptyPageOutcome(args: {
   // 403/404 alongside it means a repo that may still have pages, so the
   // transient-failure branch must win the toast and block the clamp.
   const onlyWindowErrors =
-    args.issueErrorTypes.length > 0 &&
-    args.issueErrorTypes.every((type) => type === 'validation_error')
+    args.errorTypes.length > 0 && args.errorTypes.every((type) => type === 'validation_error')
   if (onlyWindowErrors && args.failedCount === 0) {
     return { reason: 'window-unreachable', clampTotalPagesTo: clamp }
   }
-  if (args.failedCount > 0 || args.issueErrorTypes.length > 0) {
+  if (args.failedCount > 0 || args.errorTypes.length > 0) {
     return { reason: 'load-failed', clampTotalPagesTo: null }
   }
   const countUnknown = args.countedTotalPages === null || args.countedTotalPages === 0
@@ -95,7 +93,7 @@ export function applyEmptyPageClamp(
   args: {
     target: number
     failedCount: number
-    issueErrorTypes: readonly ClassifiedError['type'][]
+    errorTypes: readonly ClassifiedError['type'][]
   }
 ): number | null {
   const outcome = resolveEmptyPageOutcome({ ...args, countedTotalPages: previous })

--- a/src/renderer/src/components/task-page-work-item-pagination.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.ts
@@ -1,4 +1,4 @@
-import type { GitHubWorkItem } from '../../../shared/types'
+import type { ClassifiedError, GitHubWorkItem } from '../../../shared/types'
 
 /**
  * Cross-repo Tasks pagination is cursor-based on `updatedAt`: each page's oldest
@@ -33,6 +33,38 @@ export function workItemIdentity(item: Pick<GitHubWorkItem, 'id' | 'repoId'>): s
 
 export function taskPageToGitHubApiPage(taskPage: number): number {
   return Math.max(0, Math.floor(taskPage)) + 1
+}
+
+export type EmptyPageOutcome = {
+  reason: 'window-unreachable' | 'load-failed' | 'end-of-data'
+  /** New advertised page count, or null to leave the current count alone. */
+  clampTotalPagesTo: number | null
+}
+
+/**
+ * An empty page load has three distinct meanings, and only the caller-side
+ * error channels can tell them apart (#11485):
+ * - a `validation_error` is GitHub's 422 for pages past its 1000-result search
+ *   window — the page can never load, so stop advertising it;
+ * - any other per-repo error (thrown or issue-side envelope) may be transient
+ *   (rate limit, permissions), so surface it but keep the advertised count;
+ * - no error at all is the designed end-of-data signal from probing the
+ *   speculative page `fallbackTotalPages` advertises while the count is
+ *   unknown — withdraw the phantom page silently.
+ */
+export function resolveEmptyPageOutcome(args: {
+  target: number
+  failedCount: number
+  issueErrorTypes: readonly ClassifiedError['type'][]
+}): EmptyPageOutcome {
+  const clamp = Math.max(1, Math.floor(args.target))
+  if (args.issueErrorTypes.includes('validation_error')) {
+    return { reason: 'window-unreachable', clampTotalPagesTo: clamp }
+  }
+  if (args.failedCount > 0 || args.issueErrorTypes.length > 0) {
+    return { reason: 'load-failed', clampTotalPagesTo: null }
+  }
+  return { reason: 'end-of-data', clampTotalPagesTo: clamp }
 }
 
 // Why: provider pages cannot spill truncated rows into the next page. Divide

--- a/src/renderer/src/components/task-page-work-item-pagination.ts
+++ b/src/renderer/src/components/task-page-work-item-pagination.ts
@@ -45,8 +45,11 @@ export type EmptyPageOutcome = {
  * An empty page load has three distinct meanings, and only the caller-side
  * error channels can tell them apart (#11485):
  * - a `validation_error` is GitHub's 422 for pages past its 1000-result search
- *   window — the page can never load, so stop advertising it (unless a sibling
- *   repo's fetch threw, which says nothing about the other repos' windows);
+ *   window — the page can never load, so stop advertising it. When a sibling
+ *   repo's fetch also threw, the transient failure wins (load-failed, no
+ *   clamp) so the toast and the clamp never disagree. Note this branch is
+ *   issue-scope-only: the PR list path self-caps at the window and never 422s,
+ *   so PR-tab dead clicks resolve as end-of-data.
  * - any other per-repo error (thrown or issue-side envelope) may be transient
  *   (rate limit, permissions), so surface it but keep the advertised count;
  * - no error at all is end-of-data. That only warrants a clamp while the count
@@ -62,17 +65,36 @@ export function resolveEmptyPageOutcome(args: {
   countedTotalPages: number | null
 }): EmptyPageOutcome {
   const clamp = Math.max(1, Math.floor(args.target))
-  if (args.issueErrorTypes.includes('validation_error')) {
-    return {
-      reason: 'window-unreachable',
-      clampTotalPagesTo: args.failedCount === 0 ? clamp : null
-    }
+  if (args.issueErrorTypes.includes('validation_error') && args.failedCount === 0) {
+    return { reason: 'window-unreachable', clampTotalPagesTo: clamp }
   }
   if (args.failedCount > 0 || args.issueErrorTypes.length > 0) {
     return { reason: 'load-failed', clampTotalPagesTo: null }
   }
   const countUnknown = args.countedTotalPages === null || args.countedTotalPages === 0
   return { reason: 'end-of-data', clampTotalPagesTo: countUnknown ? clamp : null }
+}
+
+/**
+ * Functional-updater body for the advertised-count clamp. Must be evaluated
+ * against the COMMITTED count (React updater `previous`), not a click-time
+ * closure — the count promise routinely resolves between click and response,
+ * and a stale-null closure would let an end-of-data clamp overwrite a real
+ * count. Math.min preserves the never-raise property of earlier clamps.
+ */
+export function applyEmptyPageClamp(
+  previous: number | null,
+  args: {
+    target: number
+    failedCount: number
+    issueErrorTypes: readonly ClassifiedError['type'][]
+  }
+): number | null {
+  const next = resolveEmptyPageOutcome({ ...args, countedTotalPages: previous }).clampTotalPagesTo
+  if (next === null) {
+    return previous
+  }
+  return previous !== null && previous > 0 ? Math.min(previous, next) : next
 }
 
 /**

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1889,7 +1889,8 @@
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
         "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
-        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again."
+        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
+        "loadPageUnreachable": "Page {{value0}} could not be loaded from GitHub."
       },
       "Terminal": {
         "73768427cf": "Close",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1891,7 +1891,8 @@
         "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
         "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
         "loadPageUnreachable": "Page {{value0}} is beyond what GitHub search can return.",
-        "loadPageFailed": "Page {{value0}} could not be loaded from GitHub."
+        "loadPageFailed": "Page {{value0}} could not be loaded from GitHub.",
+        "loadPageNoMoreResults": "No more results on page {{value0}}."
       },
       "Terminal": {
         "73768427cf": "Close",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1890,7 +1890,7 @@
         "noGithubSourceDetected": "No GitHub source detected for",
         "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
         "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
-        "loadPageUnreachable": "Page {{value0}} could not be loaded from GitHub.",
+        "loadPageUnreachable": "Page {{value0}} is beyond what GitHub search can return.",
         "loadPageFailed": "Page {{value0}} could not be loaded from GitHub."
       },
       "Terminal": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1890,7 +1890,8 @@
         "noGithubSourceDetected": "No GitHub source detected for",
         "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
         "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
-        "loadPageUnreachable": "Page {{value0}} could not be loaded from GitHub."
+        "loadPageUnreachable": "Page {{value0}} could not be loaded from GitHub.",
+        "loadPageFailed": "Page {{value0}} could not be loaded from GitHub."
       },
       "Terminal": {
         "73768427cf": "Close",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1865,7 +1865,10 @@
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
         "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
-        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again."
+        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
+        "loadPageUnreachable": "La página {{value0}} está más allá de lo que la búsqueda de GitHub puede devolver.",
+        "loadPageFailed": "No se pudo cargar la página {{value0}} desde GitHub.",
+        "loadPageNoMoreResults": "No hay más resultados en la página {{value0}}."
       },
       "Terminal": {
         "73768427cf": "Cerrar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1865,7 +1865,10 @@
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
         "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
-        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again."
+        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
+        "loadPageUnreachable": "ページ {{value0}} は GitHub 検索が返せる範囲を超えています。",
+        "loadPageFailed": "GitHub からページ {{value0}} を読み込めませんでした。",
+        "loadPageNoMoreResults": "ページ {{value0}} にはこれ以上結果がありません。"
       },
       "Terminal": {
         "73768427cf": "閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1865,7 +1865,10 @@
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
         "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
-        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again."
+        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
+        "loadPageUnreachable": "{{value0}} 페이지는 GitHub 검색이 반환할 수 있는 범위를 벗어났습니다.",
+        "loadPageFailed": "GitHub에서 {{value0}} 페이지를 불러오지 못했습니다.",
+        "loadPageNoMoreResults": "{{value0}} 페이지에 더 이상 결과가 없습니다."
       },
       "Terminal": {
         "73768427cf": "닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1865,7 +1865,10 @@
         "75a38d7df8": "GitHub data is temporarily unavailable. Its API may be down, rate-limited, or unreachable. Please try again shortly.",
         "noGithubSourceDetected": "No GitHub source detected for",
         "noGithubSourceDetectedHint": "it may have no GitHub remote, or the source could not be resolved.",
-        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again."
+        "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
+        "loadPageUnreachable": "第 {{value0}} 页超出了 GitHub 搜索可返回的范围。",
+        "loadPageFailed": "无法从 GitHub 加载第 {{value0}} 页。",
+        "loadPageNoMoreResults": "第 {{value0}} 页没有更多结果。"
       },
       "Terminal": {
         "73768427cf": "关闭",

--- a/src/renderer/src/store/slices/github-work-items-query-bounds.ts
+++ b/src/renderer/src/store/slices/github-work-items-query-bounds.ts
@@ -1,4 +1,5 @@
 export {
+  GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN,
   GITHUB_WORK_ITEMS_QUERY_MAX_BYTES,
   isGitHubWorkItemsQueryTooLarge
 } from '../../../../shared/github-work-items-query-bounds'

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -6694,6 +6694,37 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     expect(result).toEqual({ items: [], failedCount: 0, issueErrorTypes: ['validation_error'] })
   })
 
+  it('demotes non-window validation errors so they cannot drive the unreachable clamp', async () => {
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-work-items-page-422-other',
+      ok: true,
+      result: {
+        items: [],
+        sources: {
+          issues: { owner: 'up', repo: 'r' },
+          prs: null,
+          originCandidate: { owner: 'up', repo: 'r' },
+          upstreamCandidate: null
+        },
+        errors: {
+          issues: { type: 'validation_error', message: 'Validation Failed: query is malformed' }
+        }
+      },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' },
+      repos: [{ id: 'runtime-repo-id', path: '/server/repo', name: 'repo', kind: 'git' }]
+    } as unknown as Partial<AppState>)
+
+    const result = await store
+      .getState()
+      .fetchWorkItemsNextPage([{ repoId: 'caller-repo-id', path: '/server/repo' }], 24, 100, '', 2)
+
+    expect(result).toEqual({ items: [], failedCount: 0, issueErrorTypes: ['unknown'] })
+  })
+
   it('routes work-item counts through the active runtime environment', async () => {
     runtimeEnvironmentCall.mockResolvedValueOnce({
       id: 'rpc-work-items-count',

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -6661,6 +6661,39 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     })
   })
 
+  it('surfaces issue-side envelope errors as issueErrorTypes on next-page fetches', async () => {
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-work-items-page-422',
+      ok: true,
+      result: {
+        items: [],
+        sources: {
+          issues: { owner: 'up', repo: 'r' },
+          prs: null,
+          originCandidate: { owner: 'up', repo: 'r' },
+          upstreamCandidate: null
+        },
+        errors: {
+          issues: { type: 'validation_error', message: 'only the first 1000 search results' }
+        }
+      },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' },
+      repos: [{ id: 'runtime-repo-id', path: '/server/repo', name: 'repo', kind: 'git' }]
+    } as unknown as Partial<AppState>)
+
+    const result = await store
+      .getState()
+      .fetchWorkItemsNextPage([{ repoId: 'caller-repo-id', path: '/server/repo' }], 24, 100, '', 34)
+
+    // The window 422 travels on the envelope error channel, not failedCount —
+    // resolveEmptyPageOutcome keys on this exact string (#11485).
+    expect(result).toEqual({ items: [], failedCount: 0, issueErrorTypes: ['validation_error'] })
+  })
+
   it('routes work-item counts through the active runtime environment', async () => {
     runtimeEnvironmentCall.mockResolvedValueOnce({
       id: 'rpc-work-items-count',

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -6727,6 +6727,24 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     expect(result).toEqual({ totalCount: 101, totalPages: 3 })
   })
 
+  it('caps advertised pages at the GitHub search result window', async () => {
+    const store = createTestStore()
+    mockApi.gh.countWorkItems.mockResolvedValueOnce(1170).mockResolvedValueOnce(1)
+
+    const result = await store.getState().countWorkItemsAcrossRepos(
+      [
+        { repoId: 'large-repo', path: '/local/large' },
+        { repoId: 'small-repo', path: '/local/small' }
+      ],
+      'is:issue',
+      30
+    )
+
+    // 1170 results → 39 naive pages, but the Search API 422s past its
+    // 1000-result window; only floor(1000 / 30) = 33 pages are reachable (#11485).
+    expect(result).toEqual({ totalCount: 1171, totalPages: 33 })
+  })
+
   it('rejects oversized work-item queries before cache keys or provider calls', async () => {
     const store = createTestStore()
     const secret = 'github-work-items-secret'

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -6656,7 +6656,8 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     })
     expect(result).toEqual({
       items: [{ ...item, repoId: 'caller-repo-id' }],
-      failedCount: 0
+      failedCount: 0,
+      issueErrorTypes: []
     })
   })
 
@@ -6745,6 +6746,25 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     expect(result).toEqual({ totalCount: 1171, totalPages: 33 })
   })
 
+  it('pins the search-window cap at dividing and non-dividing per-repo limits', async () => {
+    const store = createTestStore()
+    // 36 is the shipped single-repo limit: floor(1000 / 36) = 27, so page 28
+    // (window 973-1008, crossing 1000) is never advertised.
+    mockApi.gh.countWorkItems.mockResolvedValueOnce(2000)
+    await expect(
+      store
+        .getState()
+        .countWorkItemsAcrossRepos([{ repoId: 'repo-id', path: '/local/repo' }], 'is:issue', 36)
+    ).resolves.toEqual({ totalCount: 2000, totalPages: 27 })
+    // 25 divides 1000 evenly: the full window stays reachable (40 pages).
+    mockApi.gh.countWorkItems.mockResolvedValueOnce(2000)
+    await expect(
+      store
+        .getState()
+        .countWorkItemsAcrossRepos([{ repoId: 'repo-id', path: '/local/repo' }], 'is:issue', 25)
+    ).resolves.toEqual({ totalCount: 2000, totalPages: 40 })
+  })
+
   it('rejects oversized work-item queries before cache keys or provider calls', async () => {
     const store = createTestStore()
     const secret = 'github-work-items-secret'
@@ -6773,7 +6793,7 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
           oversizedQuery,
           1
         )
-    ).resolves.toEqual({ items: [], failedCount: 0 })
+    ).resolves.toEqual({ items: [], failedCount: 0, issueErrorTypes: [] })
     await expect(
       store
         .getState()

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -6838,21 +6838,21 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
       30
     )
 
-    // 1170 results → 39 naive pages, but the Search API 422s past its
-    // 1000-result window; only floor(1000 / 30) = 33 pages are reachable (#11485).
-    expect(result).toEqual({ totalCount: 1171, totalPages: 33 })
+    // 1170 results → 39 naive pages, but the Search API 422s once a page
+    // starts past its 1000-result window; ceil(1000 / 30) = 34 stay reachable.
+    expect(result).toEqual({ totalCount: 1171, totalPages: 34 })
   })
 
   it('pins the search-window cap at dividing and non-dividing per-repo limits', async () => {
     const store = createTestStore()
-    // 36 is the shipped single-repo limit: floor(1000 / 36) = 27, so page 28
-    // (window 973-1008, crossing 1000) is never advertised.
+    // 36 is the shipped single-repo limit: page 28 starts at result 973 and is
+    // served; page 29 starts past 1000 and 422s.
     mockApi.gh.countWorkItems.mockResolvedValueOnce(2000)
     await expect(
       store
         .getState()
         .countWorkItemsAcrossRepos([{ repoId: 'repo-id', path: '/local/repo' }], 'is:issue', 36)
-    ).resolves.toEqual({ totalCount: 2000, totalPages: 27 })
+    ).resolves.toEqual({ totalCount: 2000, totalPages: 28 })
     // 25 divides 1000 evenly: the full window stays reachable (40 pages).
     mockApi.gh.countWorkItems.mockResolvedValueOnce(2000)
     await expect(

--- a/src/renderer/src/store/slices/github.test.ts
+++ b/src/renderer/src/store/slices/github.test.ts
@@ -6657,11 +6657,11 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
     expect(result).toEqual({
       items: [{ ...item, repoId: 'caller-repo-id' }],
       failedCount: 0,
-      issueErrorTypes: []
+      errorTypes: []
     })
   })
 
-  it('surfaces issue-side envelope errors as issueErrorTypes on next-page fetches', async () => {
+  it('surfaces issue-side envelope errors as errorTypes on next-page fetches', async () => {
     runtimeEnvironmentCall.mockResolvedValueOnce({
       id: 'rpc-work-items-page-422',
       ok: true,
@@ -6691,7 +6691,7 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
 
     // The window 422 travels on the envelope error channel, not failedCount —
     // resolveEmptyPageOutcome keys on this exact string (#11485).
-    expect(result).toEqual({ items: [], failedCount: 0, issueErrorTypes: ['validation_error'] })
+    expect(result).toEqual({ items: [], failedCount: 0, errorTypes: ['validation_error'] })
   })
 
   it('demotes non-window validation errors so they cannot drive the unreachable clamp', async () => {
@@ -6722,7 +6722,40 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
       .getState()
       .fetchWorkItemsNextPage([{ repoId: 'caller-repo-id', path: '/server/repo' }], 24, 100, '', 2)
 
-    expect(result).toEqual({ items: [], failedCount: 0, issueErrorTypes: ['unknown'] })
+    expect(result).toEqual({ items: [], failedCount: 0, errorTypes: ['unknown'] })
+  })
+
+  it('surfaces PR-side envelope errors demoted so they read as failures, never window 422s', async () => {
+    runtimeEnvironmentCall.mockResolvedValueOnce({
+      id: 'rpc-work-items-page-prs-error',
+      ok: true,
+      result: {
+        items: [],
+        sources: {
+          issues: null,
+          prs: { owner: 'up', repo: 'r' },
+          originCandidate: { owner: 'up', repo: 'r' },
+          upstreamCandidate: null
+        },
+        errors: {
+          prs: { type: 'validation_error', message: 'Failed to load pull requests: bad flag' }
+        }
+      },
+      _meta: { runtimeId: 'remote-runtime' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' },
+      repos: [{ id: 'runtime-repo-id', path: '/server/repo', name: 'repo', kind: 'git' }]
+    } as unknown as Partial<AppState>)
+
+    const result = await store
+      .getState()
+      .fetchWorkItemsNextPage([{ repoId: 'caller-repo-id', path: '/server/repo' }], 24, 100, '', 2)
+
+    // A swallowed PR-side failure must not read as end-of-data (#11485), and a
+    // PR-side validation error must never join the issue-only window signal.
+    expect(result).toEqual({ items: [], failedCount: 0, errorTypes: ['unknown'] })
   })
 
   it('routes work-item counts through the active runtime environment', async () => {
@@ -6857,7 +6890,7 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
           oversizedQuery,
           1
         )
-    ).resolves.toEqual({ items: [], failedCount: 0, issueErrorTypes: [] })
+    ).resolves.toEqual({ items: [], failedCount: 0, errorTypes: [] })
     await expect(
       store
         .getState()

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -655,6 +655,8 @@ const CHECKS_CACHE_TTL = 60_000 // 1 minute — checks change more frequently
 const EMPTY_CHECKS_CACHE_TTL = 10_000
 // Why: the work-item list is a browse surface, not a source of truth, so 60s staleness is fine (SWR keeps it current).
 const WORK_ITEMS_CACHE_TTL = 60_000
+// GitHub's Search API serves at most the first 1000 results; deeper requests 422.
+const GITHUB_SEARCH_RESULT_WINDOW = 1000
 // Why: long-lived (matches repos.ts) so the user has time to read + act on persist failures before the toast vanishes.
 const ERROR_TOAST_DURATION = 60_000
 
@@ -2839,6 +2841,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       return { totalCount: 0, totalPages: 0 }
     }
     const normalizedLimit = Math.max(1, Math.floor(perRepoLimit))
+    // Why: GitHub's Search API rejects requests past its 1000-result window with
+    // HTTP 422, so pages whose range crosses it are unreachable — advertising
+    // them yields page clicks that can never navigate.
+    const maxReachablePages = Math.max(1, Math.floor(GITHUB_SEARCH_RESULT_WINDOW / normalizedLimit))
     const counts = await Promise.all(
       repos.map(async (r) => {
         // Why: same stampede cap as item-fetch — without a slot a 90-repo selection fires 90 concurrent count IPCs before the main-side rate-limit guard sees the first 403.
@@ -2870,7 +2876,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       totalCount: counts.reduce((sum, count) => sum + count, 0),
       // Why: repos advance independently by page, so take the max across repos — a sum/page-width undercounts when one repo owns most results.
       totalPages: counts.reduce(
-        (maxPages, count) => Math.max(maxPages, Math.ceil(count / normalizedLimit)),
+        (maxPages, count) =>
+          Math.max(maxPages, Math.min(Math.ceil(count / normalizedLimit), maxReachablePages)),
         0
       )
     }

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -1971,7 +1971,7 @@ export type GitHubSlice = {
   ) => Promise<{
     items: GitHubWorkItem[]
     failedCount: number
-    issueErrorTypes: ClassifiedError['type'][]
+    errorTypes: ClassifiedError['type'][]
   }>
   /** Count items and derive pages from the largest per-repo result set. */
   countWorkItemsAcrossRepos: (
@@ -2792,10 +2792,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
   fetchWorkItemsNextPage: async (repos, perRepoLimit, displayLimit, query, page) => {
     if (isGitHubWorkItemsQueryTooLarge(query)) {
-      return { items: [], failedCount: 0, issueErrorTypes: [] }
+      return { items: [], failedCount: 0, errorTypes: [] }
     }
     let failedCount = 0
-    const issueErrorTypes: ClassifiedError['type'][] = []
+    const errorTypes: ClassifiedError['type'][] = []
     const perProjectResults = await Promise.all(
       repos.map(async (r) => {
         const requestState = get()
@@ -2824,7 +2824,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             const { type, message } = envelope.errors.issues
             // Why: only the 1000-result-window 422 may drive the unreachable
             // clamp; demote other validation errors so they read as failures.
-            issueErrorTypes.push(
+            errorTypes.push(
               type === 'validation_error' && !/first 1000 search results/i.test(message)
                 ? 'unknown'
                 : type
@@ -2832,6 +2832,16 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             console.warn(
               `[workItems] next page ${r.repoId} issues-side partial failure:`,
               envelope.errors.issues
+            )
+          }
+          if (envelope.errors?.prs) {
+            // Why: the window 422 is issue-side only — a PR-side validation
+            // error must never join the unreachable signal.
+            const { type } = envelope.errors.prs
+            errorTypes.push(type === 'validation_error' ? 'unknown' : type)
+            console.warn(
+              `[workItems] next page ${r.repoId} prs-side partial failure:`,
+              envelope.errors.prs
             )
           }
           return envelope.items.map((item): GitHubWorkItem => ({ ...item, repoId: r.repoId }))
@@ -2848,7 +2858,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       })
     )
     const merged = sortWorkItemsByNumber(perProjectResults.flat()).slice(0, displayLimit)
-    return { items: merged, failedCount, issueErrorTypes }
+    return { items: merged, failedCount, errorTypes }
   },
 
   countWorkItemsAcrossRepos: async (repos, query, perRepoLimit) => {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -2821,7 +2821,14 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           })
           // Why: page-N failures aren't in the per-repo banner (keyed on the initial fetch); log them so pagination failures are observable instead of silently truncating (richer surface deferred, design doc §6).
           if (envelope.errors?.issues) {
-            issueErrorTypes.push(envelope.errors.issues.type)
+            const { type, message } = envelope.errors.issues
+            // Why: only the 1000-result-window 422 may drive the unreachable
+            // clamp; demote other validation errors so they read as failures.
+            issueErrorTypes.push(
+              type === 'validation_error' && !/first 1000 search results/i.test(message)
+                ? 'unknown'
+                : type
+            )
             console.warn(
               `[workItems] next page ${r.repoId} issues-side partial failure:`,
               envelope.errors.issues

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -656,6 +656,8 @@ const EMPTY_CHECKS_CACHE_TTL = 10_000
 // Why: the work-item list is a browse surface, not a source of truth, so 60s staleness is fine (SWR keeps it current).
 const WORK_ITEMS_CACHE_TTL = 60_000
 // GitHub's Search API serves at most the first 1000 results; deeper requests 422.
+// floor() is deliberately conservative: for PR-only queries (no search call) the
+// tail `1000 % limit` results become unreachable rather than special-casing scope.
 const GITHUB_SEARCH_RESULT_WINDOW = 1000
 // Why: long-lived (matches repos.ts) so the user has time to read + act on persist failures before the toast vanishes.
 const ERROR_TOAST_DURATION = 60_000
@@ -1966,7 +1968,11 @@ export type GitHubSlice = {
     displayLimit: number,
     query: string,
     page: number
-  ) => Promise<{ items: GitHubWorkItem[]; failedCount: number }>
+  ) => Promise<{
+    items: GitHubWorkItem[]
+    failedCount: number
+    issueErrorTypes: ClassifiedError['type'][]
+  }>
   /** Count items and derive pages from the largest per-repo result set. */
   countWorkItemsAcrossRepos: (
     repos: {
@@ -2786,9 +2792,10 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
 
   fetchWorkItemsNextPage: async (repos, perRepoLimit, displayLimit, query, page) => {
     if (isGitHubWorkItemsQueryTooLarge(query)) {
-      return { items: [], failedCount: 0 }
+      return { items: [], failedCount: 0, issueErrorTypes: [] }
     }
     let failedCount = 0
+    const issueErrorTypes: ClassifiedError['type'][] = []
     const perProjectResults = await Promise.all(
       repos.map(async (r) => {
         const requestState = get()
@@ -2814,6 +2821,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
           })
           // Why: page-N failures aren't in the per-repo banner (keyed on the initial fetch); log them so pagination failures are observable instead of silently truncating (richer surface deferred, design doc §6).
           if (envelope.errors?.issues) {
+            issueErrorTypes.push(envelope.errors.issues.type)
             console.warn(
               `[workItems] next page ${r.repoId} issues-side partial failure:`,
               envelope.errors.issues
@@ -2833,7 +2841,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       })
     )
     const merged = sortWorkItemsByNumber(perProjectResults.flat()).slice(0, displayLimit)
-    return { items: merged, failedCount }
+    return { items: merged, failedCount, issueErrorTypes }
   },
 
   countWorkItemsAcrossRepos: async (repos, query, perRepoLimit) => {

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -53,7 +53,10 @@ import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility
 import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
 import { getHostedReviewCacheKey, linkedReviewHintKey } from './hosted-review-cache-identity'
 import { getGitHubPRCacheKey, getGitHubRepoCacheKey } from './github-cache-key'
-import { isGitHubWorkItemsQueryTooLarge } from './github-work-items-query-bounds'
+import {
+  GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN,
+  isGitHubWorkItemsQueryTooLarge
+} from './github-work-items-query-bounds'
 import { classifyGitHubUnavailable } from '../../../../shared/github-api-availability'
 import { isMacAppDataPath } from '@/lib/passive-macos-app-data-access'
 import { translate } from '@/i18n/i18n'
@@ -2824,7 +2827,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
             // Why: only the 1000-result-window 422 may drive the unreachable
             // clamp; demote other validation errors so they read as failures.
             errorTypes.push(
-              type === 'validation_error' && !/first 1000 search results/i.test(message)
+              type === 'validation_error' &&
+                !GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN.test(message)
                 ? 'unknown'
                 : type
             )

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -655,9 +655,8 @@ const CHECKS_CACHE_TTL = 60_000 // 1 minute — checks change more frequently
 const EMPTY_CHECKS_CACHE_TTL = 10_000
 // Why: the work-item list is a browse surface, not a source of truth, so 60s staleness is fine (SWR keeps it current).
 const WORK_ITEMS_CACHE_TTL = 60_000
-// GitHub's Search API serves at most the first 1000 results; deeper requests 422.
-// floor() is deliberately conservative: for PR-only queries (no search call) the
-// tail `1000 % limit` results become unreachable rather than special-casing scope.
+// GitHub's Search API serves the page that starts within its first 1000 results;
+// the next page 422s even when the final reachable page crosses the boundary.
 const GITHUB_SEARCH_RESULT_WINDOW = 1000
 // Why: long-lived (matches repos.ts) so the user has time to read + act on persist failures before the toast vanishes.
 const ERROR_TOAST_DURATION = 60_000
@@ -2866,10 +2865,8 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
       return { totalCount: 0, totalPages: 0 }
     }
     const normalizedLimit = Math.max(1, Math.floor(perRepoLimit))
-    // Why: GitHub's Search API rejects requests past its 1000-result window with
-    // HTTP 422, so pages whose range crosses it are unreachable — advertising
-    // them yields page clicks that can never navigate.
-    const maxReachablePages = Math.max(1, Math.floor(GITHUB_SEARCH_RESULT_WINDOW / normalizedLimit))
+    // Why: GitHub 422s pages that start past its 1000-result search window.
+    const maxReachablePages = Math.max(1, Math.ceil(GITHUB_SEARCH_RESULT_WINDOW / normalizedLimit))
     const counts = await Promise.all(
       repos.map(async (r) => {
         // Why: same stampede cap as item-fetch — without a slot a 90-repo selection fires 90 concurrent count IPCs before the main-side rate-limit guard sees the first 403.

--- a/src/shared/github-work-items-query-bounds.ts
+++ b/src/shared/github-work-items-query-bounds.ts
@@ -2,6 +2,17 @@ import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
 
 export const GITHUB_WORK_ITEMS_QUERY_MAX_BYTES = 8 * 1024
 
+/**
+ * GitHub's Search API only pages through the first 1000 matches; beyond that it
+ * 422s with "Only the first 1000 search results are available". Matching that
+ * free-text wording is the ONLY signal separating a permanently unreachable page
+ * from a transient failure (#11485), so the phrase is pinned here rather than
+ * inlined: if GitHub rewords it, window 422s silently demote to generic
+ * failures and the advertised page count stops being capped.
+ * `gh-utils.test.ts` asserts the classified message still carries this phrase.
+ */
+export const GITHUB_SEARCH_RESULT_WINDOW_ERROR_PATTERN = /first 1000 search results/i
+
 export function isGitHubWorkItemsQueryTooLarge(
   query: string,
   maxBytes = GITHUB_WORK_ITEMS_QUERY_MAX_BYTES

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2055,6 +2055,7 @@ export type ListWorkItemsResult<T> = {
   }
   errors?: {
     issues?: ClassifiedError
+    prs?: ClassifiedError
   }
   /** True when the user's per-repo preference was `'upstream'` but no upstream
    *  remote is configured, so the resolver fell back to origin. Renderer uses


### PR DESCRIPTION
## Summary

Refs #11485 (Linear STA-2972) — **partial fix, does not close the issue.** Addresses root causes 1 and 2 from the report; root cause 3 (cross-source page-count mismatch) is still open. See the status comment on #11485. Tasks-panel GitHub pagination advertised pages that could never load, and page clicks silently did nothing. Two independent live-reproduced defects:

1. **Unreachable advertised pages** — `totalPages` came from the Search API `total_count`, but GitHub's Search API rejects requests past its first-1000-results window with HTTP 422. On stablyai/orca the bar advertised 39 pages; clicking page 39 fired a 422 per repo and the UI silently stayed on page 1.
2. **In-flight navigations discarded** — the pagination-reset effect and the work-items fetch effect were keyed on the `selectedRepos` **array identity**, which the repos store refreshes on every `repos:changed` event. Any background repo refresh mid-click bumped the request generation (discarding the fetched page) and reset the pager to page 1. Live A/B: clicking page 3 while forcing `fetchRepos()` mid-flight → stuck on page 1 before, lands and stays on page 3 after.

The fix: cap advertised pages at `ceil(1000 / perRepoLimit)`; key both effects on a stable selection string covering every repo field the requests read; and classify empty page loads three ways — proven window 422 (toast + a separate never-raised `provenPageLimit`), load failure on either envelope channel including newly-plumbed PR-side errors (toast, no clamp), or genuine end-of-data (withdraw the speculative fallback page; neutral "no more results" toast when a real count over-advertised). `deriveAdvertisedTotalPages` makes the result independent of count-vs-probe arrival order.

**ELI5:** the page buttons were promises the app couldn't keep — GitHub only ever hands back the first 1000 search results, but the app did the math on the full total and drew buttons for pages GitHub refuses to serve; clicking one failed invisibly. Worse, any background refresh threw away a page you'd just asked for. Now the app only draws buttons it can honor, tells you when something actually failed, and background refreshes can't cancel your click.

## Screenshots

After — bar capped to the reachable window (30 pages at this per-repo limit, was 39) and the **last** page loads:

![sta-2972-after-page30.png](https://github.com/user-attachments/assets/54c58e97-4950-4321-9a33-90c16602e225)

After — page-3 click survives a forced mid-flight `fetchRepos()` (previously silently discarded; "before" evidence is the live console 422 + snapshot showing the pager stuck on page 1, captured during the repro):

![sta-2972-after-gen-race-page3.png](https://github.com/user-attachments/assets/e5d1ba0e-5d63-4879-9040-3e2368fd8753)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — targeted instead: the two owning suites plus all of `src/main/github/` (41 files / 795 tests green), covering the outcome matrix, clamp interleavings for both arrival orders, selection-key stability, both envelope wire tests (issue + PR side, incl. non-window-422 demotion), the classifier window-phrase contract, and cap boundaries at shipped limits (36 → 28, 25 → 40). Reviewer also ran the CI-style react-doctor changed-lines gate (clean).
- [ ] `pnpm build` — left to CI.
- [x] Added or updated high-quality tests that would catch regressions (see above; the empty-page decision logic was extracted into pure, unit-tested functions specifically so these races are pinned).

## AI Review Report

Adversarial review loop: **8 rounds, a fresh reviewer each round; round 8 came back clean (zero blocker/major).** The loop caught and fixed, per round: (1) false error toast on the designed end-of-data probe + the 422 traveling on an envelope channel `failedCount` never counted + the fetch effect still resetting on array identity; (2) stale catalog wording making the two toasts identical + a PR-tab silent clamp regression; (3) the clamp reading a click-time closure instead of the committed count; (4) sibling envelope 403/404s masked by the window branch + count-merge hardening; (5) that same count-merge hardening inverting the "a real count must not shrink" invariant when the probe won the race — fixed by splitting the proven window limit into its own state slot; (6) PR-side failures indistinguishable from end-of-data → plumbed `errors.prs` through the envelope; (7) two literal test mocks missing the new classifier + no producer-side test + closure toast race + wrong toast copy → ref mirror, neutral copy, translations; (8) clean.

Cross-platform: explicitly checked macOS/Linux/Windows — no shortcuts, labels, paths, or shell behavior touched; the change is renderer state logic plus main-process gh-CLI error classification (platform-neutral string handling); SSH/remote-runtime verified (the envelope error channels survive both transports verbatim, confirmed by reviewer trace + wire tests against the runtime RPC shape). Performance review (perf skill): pass-with-notes — keying the fetch effect off array identity is a genuine win (removes a per-`repos:changed` network fan-out; the selection-key memo costs ≤175µs even at 90 repos), and the cap removes a guaranteed-dead request fan-out against the 30/min search quota.

## Security Audit

No auth, secrets, or dependency changes. Error messages from `gh` stderr are classified in main; the renderer keys decisions on the classified **type** only. One reviewer note (accepted, no behavior change today): `classifyListPrsError` echoes trimmed stderr in its message — currently consumed only by a console.warn; a curated message map is a follow-up if a UI banner ever surfaces it. IPC surface: one additive optional field (`errors.prs`) on an existing envelope; no new handlers. Input handling: the page number is clamped/floored before use; interpolated toast values are numeric strings.

## Notes

- Trade-offs: (1) the cap is `ceil`, not `floor`: GitHub serves any search page whose **start** offset is inside the 1000-result window, so the final page is served even when it crosses the boundary (verified live — `per_page=33&page=31` returns 33 rows, `page=32` 422s; same at 30/34 and 36/28). `floor` would silently drop one reachable page; (2) the GitLab issues/MRs effect shares the repurposed selection key, so a GitHub identity resolution now re-fires it once per repo per session (bounded, correct-leaning); (3) `2`-vs-`02`-style numeric ties in Source Control ordering are unaffected here (that's the sibling PR).
- Known pre-existing issue left deliberately untouched (reviewer-flagged, same symptom class, different mechanism): the one-shot landing-refresh probe can still yank an early page click back to page 1 on the cached-landing path (`TaskPage.tsx` landing `.then` has no generation guard). Follow-up candidate.
- Follow-up candidates from the perf review: a pre-existing store-selector hot path (`selectedWorkItemsCacheEntries` runs a per-repo projection on every store write while Tasks is open), and hoisting one shared per-repo context map for the five memos that each recompute it.
- The window-422 toast is reachable only when the count itself failed (a successful count already caps the bar below the window) — it's the backstop, not the primary defense.

