### PR TITLE
feat(cli): let worktree create take an exact branch name

### DIFF
--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -229,10 +229,16 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       }
     }
     const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue')
+    const branchNameOverride = getOptionalStringFlag(flags, 'branch')
     const result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', {
       repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
       name: getRequiredStringFlag(flags, 'name'),
       baseBranch: getOptionalStringFlag(flags, 'base-branch'),
+      // Why: --name is slugified into the branch, which collapses slashes, so
+      // the CLI could not produce the `type/scope` branch names many teams
+      // require. --branch reaches the same override the composer already
+      // exposes, and the runtime validates it with `git check-ref-format`.
+      ...(branchNameOverride ? { branchNameOverride } : {}),
       linkedIssue: getOptionalNumberFlag(flags, 'issue'),
       ...linearIssueLink,
       comment: getOptionalStringFlag(flags, 'comment'),

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -510,6 +510,7 @@ export function formatFlagHelp(flag: string): string {
   const helpByFlag: Record<string, string> = {
     agent: '--agent <id>          Launch a known TUI agent in the first terminal',
     'base-branch': '--base-branch <ref>    Base branch/ref to create the worktree from',
+    branch: '--branch <name>        Exact git branch name; skips slugifying and the branch prefix',
     command: '--command <text>       Command to run in the terminal on startup',
     comment: '--comment <text>       Comment stored in Orca metadata',
     cursor: '--cursor <n>           Line cursor from a previous read (returns only new output)',

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1198,6 +1198,68 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
+  it('forwards --branch as branchNameOverride so slashes survive', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_create_branch_flag', {
+        worktree: buildWorktree('/tmp/repo/PROJ-123', 'feat/PROJ-123-add-login', 'abc', 'repo-1'),
+        lineage: null,
+        warnings: []
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      [
+        'worktree',
+        'create',
+        '--repo',
+        'id:repo-1',
+        '--name',
+        'PROJ-123',
+        '--branch',
+        'feat/PROJ-123-add-login',
+        '--no-parent',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.create',
+      expect.objectContaining({
+        name: 'PROJ-123',
+        // Why: the whole point of the flag. --name alone is slugified into
+        // `feat-PROJ-123-add-login`, which is a different branch.
+        branchNameOverride: 'feat/PROJ-123-add-login'
+      })
+    )
+  })
+
+  it('omits branchNameOverride when --branch is absent', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_create_no_branch_flag', {
+        worktree: buildWorktree('/tmp/repo/feature', 'feature', 'abc', 'repo-1'),
+        lineage: null,
+        warnings: []
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      ['worktree', 'create', '--repo', 'id:repo-1', '--name', 'feature', '--no-parent', '--json'],
+      '/tmp/repo'
+    )
+
+    // Why: sending the key at all would make the runtime skip the git-username
+    // probe and keep the generated name, changing existing behavior.
+    const payload = callMock.mock.calls.at(-1)?.[1] as Record<string, unknown>
+    expect(payload).not.toHaveProperty('branchNameOverride')
+  })
+
   it('normalizes bare Linear identifiers through worktree.create', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -86,7 +86,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'create'],
     summary: 'Create a new Orca-managed worktree',
     usage:
-      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
+      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--branch <name>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'repo',
@@ -94,6 +94,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'host',
       'project-host-setup',
       'name',
+      'branch',
       'agent',
       'prompt',
       'base-branch',
@@ -110,6 +111,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'This creates a new checkout. For a fresh agent in an existing worktree, use `orca terminal create --worktree active --command "codex"` instead.',
       'By default, Orca records the new worktree as a child of the caller context when it can infer one from the Orca terminal or current directory.',
       'If --repo is omitted, Orca infers the repo from the current Orca-managed worktree.',
+      'Use --branch to set the git branch name verbatim, bypassing both the slugified --name and the global branch prefix. This is the only way to create a branch containing slashes, such as feat/PROJ-123-thing. The name is validated with `git check-ref-format`.',
       'Use --project with --host to create on a ready project host setup without spelling the backing repo id.',
       'For related work, use the inferred parent or pass --parent-worktree active, folder:<id>, or worktree:<worktreeId> to make the relationship explicit. Worktree ids are the full <repo-id>::<path> values returned by `orca worktree list --json`.',
       'Use --no-parent when the new worktree should be independent of the current context.',
@@ -123,6 +125,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     ],
     examples: [
       'orca worktree create --name agent-task --agent codex --prompt "hi" --json',
+      'orca worktree create --name PROJ-123 --branch feat/PROJ-123-add-login --json',
       'orca worktree create --repo id:<repoId> --name related-task --json',
       'orca worktree create --project github:stablyai/orca --host runtime:gpu --name benchmark --json',
       'orca worktree create --repo id:<repoId> --name linear-task --linear-issue https://linear.app/stably/issue/STA-335/test-issue --json',


### PR DESCRIPTION
## The problem

`orca worktree create` derives the branch from `--name`. That value goes through `sanitizeWorktreeName`, which collapses every `/` to `-`, and then the global branch prefix is prepended. So from the CLI there is no way to create a branch like `feat/PROJ-123-add-login`:

| What you pass | What you get |
|---|---|
| `--name "feat/PROJ-123-add-login"` | `<prefix>/feat-PROJ-123-add-login` |
| `--name "PROJ-123"` + prefix `feat` | `feat/PROJ-123` — but now *everything* is `feat/`, in every repo |

Teams whose convention encodes the change type in the branch (`fix/`, `feat/`, `chore/`) can't script worktree creation at all: the branch name comes out wrong no matter what they pass. The branch prefix setting doesn't help, because it's global — one value for every repo and every kind of work.

## The change

The app's composer already solves this. It exposes a branch-name field backed by `branchNameOverride`, which the runtime validates with `git check-ref-format` and then uses verbatim.

This exposes that same field to the CLI as `--branch`:

```bash
orca worktree create --name PROJ-123 --branch feat/PROJ-123-add-login --json
# branch: refs/heads/feat/PROJ-123-add-login
```

**Nothing is added to the runtime** — `resolveCreateBranchName` already handles the override, including the `check-ref-format` validation and the leading-`-` rejection. This is a CLI-side flag mapping, bringing scripted creation to parity with the UI.

`--name` still drives the workspace name and directory; `--branch` only overrides the git branch.

## Backwards compatibility

The key is omitted from the payload entirely when the flag is absent, so the existing path is byte-identical. This matters: the runtime uses the presence of `branchNameOverride` to decide whether to skip the `git-username` probe, so sending `undefined` explicitly would be a behavior change. There's a test pinning that.

## Tests

Two tests in `src/cli/index.test.ts`, both at the payload level rather than the help text:

- `--branch` reaches the runtime as `branchNameOverride`, with the slash intact
- the key is **absent** from the payload when the flag isn't passed

```
✓ src/cli/  50 files  637 tests
✓ tsc -p config/tsconfig.tc.cli.json
✓ tsc -p config/tsconfig.node.json
✓ oxlint src/cli/
```

Also verified end-to-end against a running Orca with the rebuilt CLI: `--branch task/ZZ-9999-prueba-branch-flag` produced `refs/heads/task/ZZ-9999-prueba-branch-flag`, slash intact and no username prefix. Worktree removed afterwards.

## Code review summary

- **Cross-platform:** no platform-specific code. The flag is parsed by the shared arg parser and forwarded over RPC; branch validation happens in the runtime via `git check-ref-format`, which is already the cross-platform path. No new path handling, no shell invocation.
- **SSH / remote / local:** the CLI calls `worktree.create` over RPC and never branches on locality. `worktree-remote.ts` carries the same `branchNameOverride` validation as the local runtime, so remote and SSH worktrees get identical behavior. No new assumption about a local process, file, or credential.
- **Agents / integrations / git providers:** provider-neutral. The flag doesn't touch agent startup, and it composes with `--agent`, `--issue`, `--linear-issue` and the rest without special-casing any of them.
- **Performance:** none. One optional string read at parse time; no new I/O, no hot-path work. If anything it skips the `resolveLocalGitUsername` probe when the override is set, which is the runtime's existing behavior.
- **UI:** **no visual change.** This is CLI-only — the composer already had this capability.
- **Security:** the override goes through the same validation as the UI path (`git check-ref-format` plus the leading-`-` rejection that prevents a branch name from being read as a git flag). No new argument reaches a shell, and nothing is interpolated into a command string.

## Notes

No platform-, remote-, agent-, integration- or provider-specific behavior to flag beyond the above.

X: [@EugenioValeiras](https://x.com/EugenioValeiras)
