### PR TITLE
fix(terminal): reduce inactive pane dimming

### DIFF
--- a/src/renderer/src/components/settings/TerminalPaneAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/TerminalPaneAppearanceSection.tsx
@@ -1,4 +1,5 @@
 import type { GlobalSettings } from '../../../../shared/types'
+import { DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY } from '../../../../shared/constants'
 import { NumberField, SettingsSubsectionHeader } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
 import { clampNumber, resolvePaneStyleOptions } from '@/lib/terminal-theme'
@@ -47,7 +48,7 @@ export function TerminalPaneAppearanceSection({
               'Dim unfocused panes.'
             )}
             value={paneStyleOptions.inactivePaneOpacity}
-            defaultValue={0.8}
+            defaultValue={DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY}
             min={0}
             max={1}
             step={0.05}

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY,
   getDefaultNotificationSettings,
   getDefaultPrimarySelectionMiddleClickPaste,
   getDefaultTerminalRightClickToPaste,
@@ -43,6 +44,12 @@ describe('getDefaultSettings', () => {
 
   it('enables separate light terminal theme by default', () => {
     expect(getDefaultSettings('/tmp').terminalUseSeparateLightTheme).toBe(true)
+  })
+
+  it('keeps inactive terminal panes readable by default', () => {
+    expect(getDefaultSettings('/tmp').terminalInactivePaneOpacity).toBe(
+      DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY
+    )
   })
 
   it('asks before closing terminals with running processes by default', () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -51,6 +51,7 @@ export const DEFAULT_APP_FONT_FAMILY = 'Geist'
 export const DEFAULT_SHOW_SLEEPING_WORKSPACES = true
 export const DEFAULT_HIDE_SLEEPING_WORKSPACES = false
 export const DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE: AgentActivityDisplayMode = 'compact'
+export const DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY = 0.9
 
 export function normalizeAgentActivityDisplayMode(value: unknown): AgentActivityDisplayMode {
   return value === 'full' || value === 'compact' ? value : DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE
@@ -223,7 +224,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalThemeLight: 'Builtin Tango Light',
     terminalCustomThemes: [],
     terminalDividerColorLight: '#d4d4d8',
-    terminalInactivePaneOpacity: 0.8,
+    terminalInactivePaneOpacity: DEFAULT_TERMINAL_INACTIVE_PANE_OPACITY,
     terminalActivePaneOpacity: 1,
     terminalPaneOpacityTransitionMs: 140,
     terminalDividerThicknessPx: 3,


### PR DESCRIPTION
## Summary

- raise the default inactive terminal pane opacity from 0.8 to 0.9
- keep the settings UI default label tied to the persisted default
- cover the new default with a focused regression test

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test` (3,925 files; 41,470 tests passed)
- focused terminal/default suite (61 tests passed)
- changed-code quality and React Doctor (0 findings)