### PR TITLE
Make file paths clickable in native chat on desktop and mobile

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1171,6 +1171,7 @@ export default function SessionScreen() {
     client,
     hostId,
     worktreeId,
+    worktreeName: routeWorktreeName,
     activeSessionTab,
     activeSessionTabId,
     activeHandleRef,
@@ -1178,6 +1179,8 @@ export default function SessionScreen() {
     nativeChatTranscriptIsLocalReadable,
     nativeChatInputLeaseReady,
     connState,
+    pushFilePreview: (href) => router.push(href),
+    onOpenFileError: showToast,
     onSendError: nativeChatSendError.show,
     onSendResolved: nativeChatSendError.clear
   })
@@ -3219,7 +3222,6 @@ export default function SessionScreen() {
     },
     [client, fetchSessionTabs, hostId, routeWorktreeName, router, scheduleDelayedAction, worktreeId]
   )
-
   const handleOpenedFileDiffActivationSeqRef = useRef(0)
   // Capture active tab at tap time; reading it after openDiff would misread a mid-RPC switch and let the retry steal focus.
   const fileOpenStartActiveTabIdRef = useRef<string | null>(null)

--- a/mobile/src/components/MobileMarkdown.file-path.test.ts
+++ b/mobile/src/components/MobileMarkdown.file-path.test.ts
@@ -1,0 +1,198 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-native', async () => {
+  const React = await import('react')
+  return {
+    Linking: { openURL: vi.fn() },
+    Pressable: 'Pressable',
+    ScrollView: 'ScrollView',
+    Text: ({ children, ...props }: { children?: unknown }) =>
+      React.createElement('Text', props, children),
+    View: ({ children, ...props }: { children?: unknown }) =>
+      React.createElement('View', props, children),
+    StyleSheet: { create: (styles: unknown) => styles }
+  }
+})
+
+import { MobileMarkdown } from './MobileMarkdown'
+import { Linking } from 'react-native'
+
+describe('MobileMarkdown file paths', () => {
+  let renderer: ReactTestRenderer | null = null
+  const onOpenFile = vi.fn()
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    vi.clearAllMocks()
+    vi.mocked(Linking.openURL).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  function render(content: string): ReactTestRenderer {
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] !== 'string' || !args[0].includes('react-test-renderer is deprecated')) {
+        throw new Error(String(args[0]))
+      }
+    })
+    try {
+      act(() => {
+        renderer = create(createElement(MobileMarkdown, { content, onOpenFile }))
+      })
+    } finally {
+      spy.mockRestore()
+    }
+    return renderer!
+  }
+
+  it('opens an absolute POSIX prose path', () => {
+    const path =
+      '/Users/jinjingliang/Documents/projects/orca/worktree/docs/native-chat-rendering-architecture.md'
+    const link = render(`Open ${path}`).root.find(
+      (node) => node.type === 'Text' && node.props.accessibilityLabel === `Open file ${path}`
+    )
+
+    act(() => link.props.onPress())
+
+    expect(onOpenFile).toHaveBeenCalledWith({
+      pathText: path,
+      line: null,
+      column: null
+    })
+  })
+
+  it('routes a markdown file link with its source position', () => {
+    const link = render('[source](docs/STYLEGUIDE.md:12:3)').root.find(
+      (node) =>
+        node.type === 'Text' && node.props.accessibilityLabel === 'Open file docs/STYLEGUIDE.md'
+    )
+
+    act(() => link.props.onPress())
+
+    expect(onOpenFile).toHaveBeenCalledWith({
+      pathText: 'docs/STYLEGUIDE.md',
+      line: 12,
+      column: 3
+    })
+  })
+
+  it('normalizes encoded, fragmented, and file URI markdown targets', () => {
+    const encoded = render('[source](docs/My%20File.ts#L12)').root.find(
+      (node) =>
+        node.type === 'Text' && node.props.accessibilityLabel === 'Open file docs/My File.ts'
+    )
+    act(() => encoded.props.onPress())
+    expect(onOpenFile).toHaveBeenLastCalledWith({
+      pathText: 'docs/My File.ts',
+      line: 12,
+      column: null
+    })
+
+    const fileUri = render('[source](file:///repo/src/app.ts#L9)').root.find(
+      (node) =>
+        node.type === 'Text' && node.props.accessibilityLabel === 'Open file /repo/src/app.ts'
+    )
+    act(() => fileUri.props.onPress())
+    expect(onOpenFile).toHaveBeenLastCalledWith({
+      pathText: '/repo/src/app.ts',
+      line: 9,
+      column: null
+    })
+
+    const angle = render('[source](<docs/My%20File.ts>)').root.find(
+      (node) =>
+        node.type === 'Text' && node.props.accessibilityLabel === 'Open file docs/My File.ts'
+    )
+    act(() => angle.props.onPress())
+    expect(onOpenFile).toHaveBeenLastCalledWith({
+      pathText: 'docs/My File.ts',
+      line: null,
+      column: null
+    })
+
+    const titled = render('[source](src/app.ts "source")').root.find(
+      (node) => node.type === 'Text' && node.props.accessibilityLabel === 'Open file src/app.ts'
+    )
+    act(() => titled.props.onPress())
+    expect(onOpenFile).toHaveBeenLastCalledWith({
+      pathText: 'src/app.ts',
+      line: null,
+      column: null
+    })
+
+    const positioned = render('[source](src/app.ts#L12C3)').root.find(
+      (node) => node.type === 'Text' && node.props.accessibilityLabel === 'Open file src/app.ts'
+    )
+    act(() => positioned.props.onPress())
+    expect(onOpenFile).toHaveBeenLastCalledWith({
+      pathText: 'src/app.ts',
+      line: 12,
+      column: 3
+    })
+  })
+
+  it('keeps web links out of host file routing', () => {
+    const link = render('[site](https://example.com/docs/app.ts)').root.find(
+      (node) => node.type === 'Text' && node.children.join('') === 'site'
+    )
+    act(() => link.props.onPress())
+    expect(onOpenFile).not.toHaveBeenCalled()
+    expect(Linking.openURL).toHaveBeenCalledWith('https://example.com/docs/app.ts')
+  })
+
+  it('opens extensionless and balanced-route markdown targets', () => {
+    const dockerfile = render('[container](Dockerfile)').root.find(
+      (node) => node.type === 'Text' && node.props.accessibilityLabel === 'Open file Dockerfile'
+    )
+    act(() => dockerfile.props.onPress())
+    expect(onOpenFile).toHaveBeenLastCalledWith({
+      pathText: 'Dockerfile',
+      line: null,
+      column: null
+    })
+
+    const route = 'app/(shop)/products/[id]/page.tsx'
+    const routeLink = render(`[source](${route})`).root.find(
+      (node) => node.type === 'Text' && node.props.accessibilityLabel === `Open file ${route}`
+    )
+    act(() => routeLink.props.onPress())
+    expect(onOpenFile).toHaveBeenLastCalledWith({
+      pathText: route,
+      line: null,
+      column: null
+    })
+  })
+
+  it('preserves Windows drive and UNC markdown targets', () => {
+    for (const path of [String.raw`C:\repo\(shop)\page.tsx`, String.raw`\\server\share\app.ts`]) {
+      const link = render(`[source](${path})`).root.find(
+        (node) => node.type === 'Text' && node.props.accessibilityLabel === `Open file ${path}`
+      )
+      act(() => link.props.onPress())
+      expect(onOpenFile).toHaveBeenLastCalledWith({
+        pathText: path,
+        line: null,
+        column: null
+      })
+    }
+  })
+
+  it('does not split underscored prose paths into emphasis tokens', () => {
+    for (const path of ['src/foo_bar_baz.ts', 'src/__init__.py']) {
+      const link = render(path).root.find(
+        (node) => node.type === 'Text' && node.props.accessibilityLabel === `Open file ${path}`
+      )
+      act(() => link.props.onPress())
+      expect(onOpenFile).toHaveBeenLastCalledWith({
+        pathText: path,
+        line: null,
+        column: null
+      })
+    }
+  })
+})

--- a/mobile/src/components/MobileMarkdown.tsx
+++ b/mobile/src/components/MobileMarkdown.tsx
@@ -2,11 +2,12 @@ import { Fragment, memo, useMemo, type ReactNode } from 'react'
 import { Linking, Pressable, ScrollView, Text, View } from 'react-native'
 import { normalizeMobileMarkdownPreviewHtml } from './mobile-markdown-preview-html'
 import { styles } from './mobile-markdown-styles'
+import { detectFilePathSegments, isFilePathCodeSpan } from './markdown-file-path-detection'
 import {
-  detectFilePathSegments,
-  isFilePathCodeSpan,
-  normalizeFilePath
-} from './markdown-file-path-detection'
+  normalizeMobileMarkdownDestination,
+  parseMobileMarkdownFileTarget
+} from '../files/mobile-markdown-file-target'
+import type { MobileFileTapTarget } from '../files/mobile-file-tap-target'
 import { parseMobileMarkdown } from './mobile-markdown-parser'
 
 type Props = {
@@ -15,10 +16,8 @@ type Props = {
   /** Multiplier for prose font size (paragraphs, lists, quotes). Defaults to 1;
    *  the chat view passes >1 so agent prose reads larger than the compact base. */
   textScale?: number
-  /** When provided, detected file-path tokens render as tappable and invoke this
-   *  with the worktree-relative path. Omitted on screens with no file viewer, where
-   *  paths render as plain text (no behavior change). */
-  onOpenFile?: (relativePath: string) => void
+  /** Makes detected host paths tappable with optional source positions. */
+  onOpenFile?: (target: MobileFileTapTarget) => void
 }
 
 const MAX_TABLE_ROWS = 40
@@ -36,7 +35,7 @@ function openMarkdownUrl(url: string): void {
 function renderTextRun(
   text: string,
   keyPrefix: string,
-  onOpenFile?: (relativePath: string) => void
+  onOpenFile?: (target: MobileFileTapTarget) => void
 ): ReactNode {
   if (!onOpenFile) {
     return text
@@ -51,7 +50,9 @@ function renderTextRun(
         <Text
           key={`${keyPrefix}:${segmentIndex}`}
           style={styles.link}
-          onPress={() => onOpenFile(segment.path)}
+          onPress={() => onOpenFile(segment.target)}
+          accessibilityRole="link"
+          accessibilityLabel={`Open file ${segment.target.pathText}`}
         >
           {segment.value}
         </Text>
@@ -61,10 +62,29 @@ function renderTextRun(
   })
 }
 
-function renderInline(text: string, onOpenFile?: (relativePath: string) => void): ReactNode[] {
+function inlineMarkdownLink(token: string): { label: string; href: string; image: boolean } | null {
+  const image = token.startsWith('![')
+  const labelStart = image ? 2 : 1
+  const destinationStart = token.indexOf('](')
+  if (destinationStart < labelStart || !token.endsWith(')')) {
+    return null
+  }
+  return {
+    label: token.slice(labelStart, destinationStart),
+    href:
+      normalizeMobileMarkdownDestination(token.slice(destinationStart + 2, -1)) ??
+      token.slice(destinationStart + 2, -1),
+    image
+  }
+}
+
+function renderInline(
+  text: string,
+  onOpenFile?: (target: MobileFileTapTarget) => void
+): ReactNode[] {
   const parts: ReactNode[] = []
   const pattern =
-    /(!\[[^\]]*\]\([^)]+\)|`[^`]+`|~~[^~]+~~|\*\*[^*]+\*\*|__[^_]+__|\*[^*\n]+\*|_[^_\n]+_|\[[^\]]+\]\([^)]+\)|https?:\/\/[^\s<]+)/g
+    /(!?\[[^\]]*\]\((?:[^()]|\([^()]*\))+\)|`[^`]+`|~~[^~]+~~|\*\*[^*]+\*\*|(?<![\\/\w.@~+()[\]-])__[^_\n]+__(?![\\/\w.@~+()[\]-])|\*[^*\n]+\*|(?<![\\/\w.@~+()[\]-])_[^_\n]+_(?![\\/\w.@~+()[\]-])|https?:\/\/[^\s<]+)/g
   let lastIndex = 0
   let match: RegExpExecArray | null
 
@@ -74,18 +94,27 @@ function renderInline(text: string, onOpenFile?: (relativePath: string) => void)
     }
     const token = match[0]
     const key = `${match.index}:${token}`
-    const image = token.match(/^!\[([^\]]*)\]\(([^)]+)\)$/)
-    const link = token.match(/^\[([^\]]+)\]\(([^)]+)\)$/)
-    if (image) {
+    const link = inlineMarkdownLink(token)
+    const linkFileTarget =
+      link && !link.image && onOpenFile ? parseMobileMarkdownFileTarget(link.href) : null
+    if (link?.image) {
       parts.push(
-        <Text key={key} style={styles.link} onPress={() => openMarkdownUrl(image[2]!)}>
-          {image[1] || 'image'}
+        <Text key={key} style={styles.link} onPress={() => openMarkdownUrl(link.href)}>
+          {link.label || 'image'}
         </Text>
       )
     } else if (link) {
       parts.push(
-        <Text key={key} style={styles.link} onPress={() => openMarkdownUrl(link[2]!)}>
-          {link[1]}
+        <Text
+          key={key}
+          style={styles.link}
+          onPress={() =>
+            linkFileTarget ? onOpenFile!(linkFileTarget) : openMarkdownUrl(link.href)
+          }
+          accessibilityRole="link"
+          accessibilityLabel={linkFileTarget ? `Open file ${linkFileTarget.pathText}` : undefined}
+        >
+          {link.label}
         </Text>
       )
     } else if (/^https?:\/\//i.test(token)) {
@@ -96,12 +125,16 @@ function renderInline(text: string, onOpenFile?: (relativePath: string) => void)
       )
     } else if (token.startsWith('`')) {
       const code = token.slice(1, -1)
-      if (onOpenFile && isFilePathCodeSpan(code)) {
+      const codeFileTarget =
+        onOpenFile && isFilePathCodeSpan(code) ? parseMobileMarkdownFileTarget(code) : null
+      if (onOpenFile && codeFileTarget) {
         parts.push(
           <Text
             key={key}
             style={[styles.inlineCode, styles.inlineCodeLink]}
-            onPress={() => onOpenFile(normalizeFilePath(code.trim()))}
+            onPress={() => onOpenFile(codeFileTarget)}
+            accessibilityRole="link"
+            accessibilityLabel={`Open file ${codeFileTarget.pathText}`}
           >
             {code}
           </Text>
@@ -116,19 +149,19 @@ function renderInline(text: string, onOpenFile?: (relativePath: string) => void)
     } else if (token.startsWith('~~')) {
       parts.push(
         <Text key={key} style={styles.strike}>
-          {token.slice(2, -2)}
+          {renderTextRun(token.slice(2, -2), `${key}:strike`, onOpenFile)}
         </Text>
       )
     } else if (token.startsWith('**') || token.startsWith('__')) {
       parts.push(
         <Text key={key} style={styles.bold}>
-          {token.slice(2, -2)}
+          {renderTextRun(token.slice(2, -2), `${key}:bold`, onOpenFile)}
         </Text>
       )
     } else {
       parts.push(
         <Text key={key} style={styles.italic}>
-          {token.slice(1, -1)}
+          {renderTextRun(token.slice(1, -1), `${key}:italic`, onOpenFile)}
         </Text>
       )
     }

--- a/mobile/src/components/markdown-file-path-detection.test.ts
+++ b/mobile/src/components/markdown-file-path-detection.test.ts
@@ -16,7 +16,11 @@ describe('detectFilePathSegments', () => {
     const segments = detectFilePathSegments('Edit src/app/Main.tsx now')
     expect(segments).toEqual([
       { type: 'text', value: 'Edit ' },
-      { type: 'file', value: 'src/app/Main.tsx', path: 'src/app/Main.tsx' },
+      {
+        type: 'file',
+        value: 'src/app/Main.tsx',
+        target: { pathText: 'src/app/Main.tsx', line: null, column: null }
+      },
       { type: 'text', value: ' now' }
     ])
   })
@@ -25,22 +29,73 @@ describe('detectFilePathSegments', () => {
     const segments = detectFilePathSegments('see ./lib/x.ts')
     expect(segments).toEqual([
       { type: 'text', value: 'see ' },
-      { type: 'file', value: './lib/x.ts', path: 'lib/x.ts' }
+      {
+        type: 'file',
+        value: './lib/x.ts',
+        target: { pathText: 'lib/x.ts', line: null, column: null }
+      }
     ])
   })
 
   it('keeps ../ parent-relative paths intact', () => {
     const segments = detectFilePathSegments('../shared/util.ts')
     expect(segments).toEqual([
-      { type: 'file', value: '../shared/util.ts', path: '../shared/util.ts' }
+      {
+        type: 'file',
+        value: '../shared/util.ts',
+        target: { pathText: '../shared/util.ts', line: null, column: null }
+      }
     ])
   })
 
   it('detects multiple paths in one run', () => {
     const segments = detectFilePathSegments('a/b.ts and c/d/e.json')
     expect(segments.filter((s) => s.type === 'file')).toEqual([
-      { type: 'file', value: 'a/b.ts', path: 'a/b.ts' },
-      { type: 'file', value: 'c/d/e.json', path: 'c/d/e.json' }
+      {
+        type: 'file',
+        value: 'a/b.ts',
+        target: { pathText: 'a/b.ts', line: null, column: null }
+      },
+      {
+        type: 'file',
+        value: 'c/d/e.json',
+        target: { pathText: 'c/d/e.json', line: null, column: null }
+      }
+    ])
+  })
+
+  it('detects adjacent paths without punctuation between them', () => {
+    expect(
+      detectFilePathSegments('src/a.ts src/b.ts')
+        .filter((segment) => segment.type === 'file')
+        .map((segment) => segment.target.pathText)
+    ).toEqual(['src/a.ts', 'src/b.ts'])
+  })
+
+  it('decodes percent escapes in prose path targets', () => {
+    expect(detectFilePathSegments('docs/My%20File.ts')).toEqual([
+      {
+        type: 'file',
+        value: 'docs/My%20File.ts',
+        target: { pathText: 'docs/My File.ts', line: null, column: null }
+      }
+    ])
+  })
+
+  it('detects Unicode path segments', () => {
+    expect(detectFilePathSegments('src/écran.ts')).toEqual([
+      {
+        type: 'file',
+        value: 'src/écran.ts',
+        target: { pathText: 'src/écran.ts', line: null, column: null }
+      }
+    ])
+    expect(detectFilePathSegments(String.raw`src\画面.ts`)).toEqual([
+      {
+        type: 'file',
+        value: String.raw`src\画面.ts`,
+        target: { pathText: String.raw`src\画面.ts`, line: null, column: null }
+      }
     ])
   })
 
@@ -50,16 +105,32 @@ describe('detectFilePathSegments', () => {
     )
 
     expect(segments.filter((segment) => segment.type === 'file')).toEqual([
-      { type: 'file', value: String.raw`src\app\Main.tsx`, path: String.raw`src\app\Main.tsx` },
+      {
+        type: 'file',
+        value: String.raw`src\app\Main.tsx`,
+        target: {
+          pathText: String.raw`src\app\Main.tsx`,
+          line: null,
+          column: null
+        }
+      },
       {
         type: 'file',
         value: String.raw`C:\repo\config.json`,
-        path: String.raw`C:\repo\config.json`
+        target: {
+          pathText: String.raw`C:\repo\config.json`,
+          line: null,
+          column: null
+        }
       },
       {
         type: 'file',
         value: String.raw`\\server\share\docs\readme.md`,
-        path: String.raw`\\server\share\docs\readme.md`
+        target: {
+          pathText: String.raw`\\server\share\docs\readme.md`,
+          line: null,
+          column: null
+        }
       }
     ])
   })
@@ -74,6 +145,68 @@ describe('detectFilePathSegments', () => {
     expect(detectFilePathSegments('https://example.com/path/file.ts')).toEqual([
       { type: 'text', value: 'https://example.com/path/file.ts' }
     ])
+  })
+
+  it('does not match domain-like path text', () => {
+    for (const text of ['example.com/foo.ts', 'docs.rs/serde/index.ts', 'www.example.com/x.md']) {
+      expect(detectFilePathSegments(text)).toEqual([{ type: 'text', value: text }])
+    }
+  })
+
+  it('trims prose punctuation without changing route delimiters', () => {
+    expect(detectFilePathSegments('See (src/app.ts), then [src/other.ts].')).toEqual([
+      { type: 'text', value: 'See (' },
+      {
+        type: 'file',
+        value: 'src/app.ts',
+        target: { pathText: 'src/app.ts', line: null, column: null }
+      },
+      { type: 'text', value: '), then [' },
+      {
+        type: 'file',
+        value: 'src/other.ts',
+        target: { pathText: 'src/other.ts', line: null, column: null }
+      },
+      { type: 'text', value: '].' }
+    ])
+    expect(detectFilePathSegments('mobile/app/(shop)/[id]/page.tsx')).toEqual([
+      {
+        type: 'file',
+        value: 'mobile/app/(shop)/[id]/page.tsx',
+        target: {
+          pathText: 'mobile/app/(shop)/[id]/page.tsx',
+          line: null,
+          column: null
+        }
+      }
+    ])
+    expect(detectFilePathSegments('[id]/page.tsx')).toEqual([
+      {
+        type: 'file',
+        value: '[id]/page.tsx',
+        target: { pathText: '[id]/page.tsx', line: null, column: null }
+      }
+    ])
+    expect(detectFilePathSegments('(shop)/page.tsx')).toEqual([
+      {
+        type: 'file',
+        value: '(shop)/page.tsx',
+        target: { pathText: '(shop)/page.tsx', line: null, column: null }
+      }
+    ])
+  })
+
+  it('does not partially link spaced or range paths', () => {
+    for (const text of [
+      '/Users/me/My Project/src/app.ts',
+      String.raw`C:\Program Files\repo\app.ts`,
+      'My Project/src/app.ts',
+      'src/app.ts:12-14',
+      'src/app.ts:12:3-8',
+      'foo(src/app.ts)'
+    ]) {
+      expect(detectFilePathSegments(text)).toEqual([{ type: 'text', value: text }])
+    }
   })
 
   it('does not match version numbers', () => {
@@ -94,7 +227,7 @@ describe('detectFilePathSegments', () => {
       {
         type: 'file',
         value: '@types/react/index.d.ts',
-        path: '@types/react/index.d.ts'
+        target: { pathText: '@types/react/index.d.ts', line: null, column: null }
       },
       { type: 'text', value: ' here' }
     ])
@@ -104,7 +237,11 @@ describe('detectFilePathSegments', () => {
       {
         type: 'file',
         value: 'node_modules/@scope/pkg/file.ts',
-        path: 'node_modules/@scope/pkg/file.ts'
+        target: {
+          pathText: 'node_modules/@scope/pkg/file.ts',
+          line: null,
+          column: null
+        }
       }
     ])
   })
@@ -134,7 +271,46 @@ describe('detectFilePathSegments', () => {
     const prefix = 'context '.repeat(200)
     const segments = detectFilePathSegments(`${prefix}src/app/Main.tsx`)
     expect(segments.filter((s) => s.type === 'file')).toEqual([
-      { type: 'file', value: 'src/app/Main.tsx', path: 'src/app/Main.tsx' }
+      {
+        type: 'file',
+        value: 'src/app/Main.tsx',
+        target: { pathText: 'src/app/Main.tsx', line: null, column: null }
+      }
+    ])
+  })
+
+  it('detects an absolute POSIX path', () => {
+    const path =
+      '/Users/jinjingliang/Documents/projects/orca/worktree/docs/native-chat-rendering-architecture.md'
+    expect(detectFilePathSegments(`Open ${path}`)).toEqual([
+      { type: 'text', value: 'Open ' },
+      {
+        type: 'file',
+        value: path,
+        target: { pathText: path, line: null, column: null }
+      }
+    ])
+  })
+
+  it('preserves line and column in the tap target', () => {
+    expect(detectFilePathSegments('See mobile/src/app.tsx:42:7')).toEqual([
+      { type: 'text', value: 'See ' },
+      {
+        type: 'file',
+        value: 'mobile/src/app.tsx:42:7',
+        target: { pathText: 'mobile/src/app.tsx', line: 42, column: 7 }
+      }
+    ])
+  })
+
+  it('detects bracketed route segments', () => {
+    const path = 'mobile/app/h/[hostId]/session/[worktreeId].tsx'
+    expect(detectFilePathSegments(path)).toEqual([
+      {
+        type: 'file',
+        value: path,
+        target: { pathText: path, line: null, column: null }
+      }
     ])
   })
 })
@@ -150,16 +326,30 @@ describe('isFilePathCodeSpan', () => {
     expect(isFilePathCodeSpan(String.raw`\\server\share\Main.tsx`)).toBe(true)
   })
 
+  it('accepts single-line spaced paths in code spans', () => {
+    expect(isFilePathCodeSpan('docs/My File.md')).toBe(true)
+    expect(isFilePathCodeSpan(String.raw`C:\Program Files\app.ts`)).toBe(true)
+  })
+
   it('accepts a bare filename code span', () => {
     expect(isFilePathCodeSpan('package.json')).toBe(true)
   })
 
+  it('accepts explicit extensionless, dotfile, and custom-extension paths', () => {
+    expect(isFilePathCodeSpan('Dockerfile')).toBe(true)
+    expect(isFilePathCodeSpan('infra/Makefile')).toBe(true)
+    expect(isFilePathCodeSpan('repo/.gitignore')).toBe(true)
+    expect(isFilePathCodeSpan('build/output.customext')).toBe(true)
+  })
+
   it('rejects multi-word code spans', () => {
     expect(isFilePathCodeSpan('npm run build')).toBe(false)
+    expect(isFilePathCodeSpan('docs/My File.md\nnext')).toBe(false)
   })
 
   it('rejects non-file code spans', () => {
     expect(isFilePathCodeSpan('someVariable')).toBe(false)
+    expect(isFilePathCodeSpan('path/to/1.2.3')).toBe(false)
   })
 
   it('rejects urls in code spans', () => {

--- a/mobile/src/components/markdown-file-path-detection.ts
+++ b/mobile/src/components/markdown-file-path-detection.ts
@@ -1,3 +1,5 @@
+import { parseMobileFileTapTarget, type MobileFileTapTarget } from '../files/mobile-file-tap-target'
+
 // Conservative detection of file-path-like tokens inside an inline markdown text
 // run, so the chat view can render them as tappable (opening the mobile file
 // viewer). We deliberately favor precision over recall: a missed path is a minor
@@ -5,7 +7,7 @@
 
 export type FilePathSegment =
   | { type: 'text'; value: string }
-  | { type: 'file'; value: string; path: string }
+  | { type: 'file'; value: string; target: MobileFileTapTarget }
 
 // Common source/code/config extensions we treat as openable file paths. Kept
 // explicit (rather than "any extension") so prose like "etc." or "e.g." and
@@ -81,11 +83,27 @@ const FILE_EXTENSIONS = [
 ] as const
 
 const EXTENSION_SET = new Set<string>(FILE_EXTENSIONS)
+const EXTENSIONLESS_FILENAMES = new Set([
+  'dockerfile',
+  'makefile',
+  'procfile',
+  'rakefile',
+  'gemfile',
+  'justfile',
+  'brewfile',
+  'jenkinsfile',
+  'vagrantfile',
+  'codeowners'
+])
 
 // Accept the host's native separator because transcript paths originate on the
 // connected runtime, which may be Windows even when the phone is not.
 const CANDIDATE_PATTERN =
-  /(?:[A-Za-z]:[\\/]|\\\\)?(?:\.{1,2}[\\/])?(?:[\w.@~+-]+[\\/])+[\w.@+-]+\.[A-Za-z0-9]+/g
+  /^(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[\p{L}\p{N}_.@~+()[\]-]+[\\/])[\p{L}\p{N}_.@~+/%\\()[\]-]+\.[A-Za-z0-9]+(?::\d+)?(?::\d+)?$/u
+const TOKEN_PATTERN = /\S+/g
+const LEADING_PUNCTUATION = /^[<'"`]+/
+const TRAILING_PUNCTUATION = /[>'"`,.;:!?]+$/
+const DOMAIN_LIKE_SEGMENT = /^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,}$/i
 
 // A path candidate in chat prose is short; a much longer run can't hold one worth
 // linkifying but can push CANDIDATE_PATTERN into super-linear backtracking, so we
@@ -99,9 +117,69 @@ function hasMidTokenAt(candidate: string): boolean {
   return /[^\\/]@/.test(candidate)
 }
 
+function hasDomainLikeFirstSegment(pathText: string): boolean {
+  if (/^(?:[\\/~]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/.test(pathText)) {
+    return false
+  }
+  return DOMAIN_LIKE_SEGMENT.test(pathText.split(/[\\/]/)[0] ?? '')
+}
+
+function hasBalancedRouteDelimiters(value: string): boolean {
+  for (const [open, close] of [
+    ['(', ')'],
+    ['[', ']']
+  ]) {
+    let depth = 0
+    for (const char of value) {
+      if (char === open) {
+        depth += 1
+      } else if (char === close && --depth < 0) {
+        return false
+      }
+    }
+    if (depth !== 0) {
+      return false
+    }
+  }
+  return true
+}
+
+function trimTokenPunctuation(rawToken: string): {
+  candidate: string
+  leadingLength: number
+} {
+  const leading = LEADING_PUNCTUATION.exec(rawToken)?.[0].length ?? 0
+  const withoutLeading = rawToken.slice(leading)
+  const trailing = TRAILING_PUNCTUATION.exec(withoutLeading)?.[0].length ?? 0
+  let candidate = trailing > 0 ? withoutLeading.slice(0, -trailing) : withoutLeading
+  let wrapperLength = 0
+  while (
+    (candidate.startsWith('(') && candidate.endsWith(')')) ||
+    (candidate.startsWith('[') && candidate.endsWith(']')) ||
+    (candidate.startsWith('{') && candidate.endsWith('}'))
+  ) {
+    candidate = candidate.slice(1, -1)
+    wrapperLength += 1
+  }
+  return { candidate, leadingLength: leading + wrapperLength }
+}
+
+function decodeDetectedPath(value: string): string | null {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return null
+  }
+}
+
 function isOpenablePath(candidate: string): boolean {
   // Reject anything URL-ish or scheme-bearing — those are handled as web links.
-  if (candidate.includes('://') || hasMidTokenAt(candidate)) {
+  if (
+    candidate.includes('://') ||
+    hasMidTokenAt(candidate) ||
+    hasDomainLikeFirstSegment(candidate) ||
+    !hasBalancedRouteDelimiters(candidate)
+  ) {
     return false
   }
   // Must contain a separator (a bare "file.ts" is too ambiguous in prose).
@@ -148,25 +226,45 @@ export function detectFilePathSegments(text: string): FilePathSegment[] {
   }
   const segments: FilePathSegment[] = []
   let lastIndex = 0
-  let match: RegExpExecArray | null
-  CANDIDATE_PATTERN.lastIndex = 0
-
-  while ((match = CANDIDATE_PATTERN.exec(text))) {
-    const candidate = match[0]
-    // Skip candidates that are part of a URL (preceded by a scheme colon or an
-    // alphanumeric/host char that would make this a domain tail, not a path).
-    const prev = match.index > 0 ? text[match.index - 1]! : ''
-    if (prev === ':' || prev === '/' || /[\w.@]/.test(prev)) {
+  for (const match of text.matchAll(TOKEN_PATTERN)) {
+    const rawToken = match[0]
+    const { candidate, leadingLength } = trimTokenPunctuation(rawToken)
+    const candidateIndex = match.index + leadingLength
+    if (!candidate || !CANDIDATE_PATTERN.test(candidate)) {
       continue
     }
-    if (!isOpenablePath(candidate)) {
+    const previousToken = text.slice(0, match.index).trimEnd().match(/\S+$/)?.[0] ?? ''
+    const previousIsCompletePath =
+      CANDIDATE_PATTERN.test(previousToken) &&
+      Boolean(
+        parseMobileFileTapTarget(previousToken) &&
+        isOpenablePath(parseMobileFileTapTarget(previousToken)!.pathText)
+      )
+    const candidateFirstSegment = candidate.split(/[\\/]/)[0] ?? ''
+    const looksLikeSpacedRelativePath =
+      /^[\p{L}\p{N}_-]+$/u.test(previousToken) &&
+      /^[A-Z][\p{L}\p{N}_-]*$/u.test(candidateFirstSegment)
+    if (
+      (/[\\/]/.test(previousToken) || looksLikeSpacedRelativePath) &&
+      !previousIsCompletePath &&
+      !/[.!?:;,]$/.test(previousToken)
+    ) {
       continue
     }
-    if (match.index > lastIndex) {
-      segments.push({ type: 'text', value: text.slice(lastIndex, match.index) })
+    const parsed = parseMobileFileTapTarget(candidate)
+    const decodedPath = parsed ? decodeDetectedPath(parsed.pathText) : null
+    if (!parsed || !decodedPath || !isOpenablePath(decodedPath)) {
+      continue
     }
-    segments.push({ type: 'file', value: candidate, path: normalizeFilePath(candidate) })
-    lastIndex = match.index + candidate.length
+    if (candidateIndex > lastIndex) {
+      segments.push({ type: 'text', value: text.slice(lastIndex, candidateIndex) })
+    }
+    segments.push({
+      type: 'file',
+      value: candidate,
+      target: { ...parsed, pathText: normalizeFilePath(decodedPath) }
+    })
+    lastIndex = candidateIndex + candidate.length
   }
 
   if (lastIndex < text.length) {
@@ -186,27 +284,46 @@ export function detectFilePathSegments(text: string): FilePathSegment[] {
  */
 export function isFilePathCodeSpan(code: string): boolean {
   const trimmed = code.trim()
-  if (!trimmed || /\s/.test(trimmed)) {
+  if (!trimmed || /[\r\n]/.test(trimmed)) {
     return false
   }
-  if (trimmed.includes('://') || hasMidTokenAt(trimmed)) {
+  const parsed = parseMobileFileTapTarget(trimmed)
+  if (
+    !parsed ||
+    parsed.pathText.includes('://') ||
+    hasMidTokenAt(parsed.pathText) ||
+    !hasBalancedRouteDelimiters(parsed.pathText)
+  ) {
     return false
   }
-  if (isOpenablePath(trimmed)) {
+  if (isOpenablePath(parsed.pathText)) {
     return true
   }
-  // Separator-less code span: accept a clean name.ext with a known extension.
-  if (/[\\/]/.test(trimmed)) {
+  const lastSeparator = Math.max(
+    parsed.pathText.lastIndexOf('/'),
+    parsed.pathText.lastIndexOf('\\')
+  )
+  const lastSegment = parsed.pathText.slice(lastSeparator + 1)
+  if (!lastSegment) {
     return false
   }
-  const dot = trimmed.lastIndexOf('.')
+  if (EXTENSIONLESS_FILENAMES.has(lastSegment.toLowerCase())) {
+    return true
+  }
+  if (/^\.[\w-]+$/.test(lastSegment)) {
+    return true
+  }
+  const dot = lastSegment.lastIndexOf('.')
   if (dot <= 0) {
     return false
   }
-  const name = trimmed.slice(0, dot)
-  const ext = trimmed.slice(dot + 1).toLowerCase()
+  const name = lastSegment.slice(0, dot)
+  const ext = lastSegment.slice(dot + 1).toLowerCase()
   if (/[^\w.@+-]/.test(name)) {
     return false
   }
-  return EXTENSION_SET.has(ext)
+  if (/^\d+$/.test(ext)) {
+    return false
+  }
+  return lastSeparator >= 0 ? /^[a-z0-9]+$/i.test(ext) : EXTENSION_SET.has(ext)
 }

--- a/mobile/src/files/mobile-file-tap-target.ts
+++ b/mobile/src/files/mobile-file-tap-target.ts
@@ -1,0 +1,22 @@
+export type MobileFileTapTarget = {
+  pathText: string
+  line: number | null
+  column: number | null
+}
+
+export function parseMobileFileTapTarget(value: string): MobileFileTapTarget | null {
+  const match = /^(.*?)(?::(\d+))?(?::(\d+))?$/.exec(value.trim())
+  const pathText = match?.[1]
+  if (!pathText) {
+    return null
+  }
+  const line = match[2] ? Number.parseInt(match[2], 10) : null
+  const column = match[3] ? Number.parseInt(match[3], 10) : null
+  if (
+    (line !== null && (!Number.isSafeInteger(line) || line < 1)) ||
+    (column !== null && (!Number.isSafeInteger(column) || column < 1))
+  ) {
+    return null
+  }
+  return { pathText, line, column }
+}

--- a/mobile/src/files/mobile-markdown-file-target.ts
+++ b/mobile/src/files/mobile-markdown-file-target.ts
@@ -1,0 +1,97 @@
+import { fileUriToFilesystemPath } from '../../../src/shared/file-uri-path'
+import { normalizeFilePath } from '../components/markdown-file-path-detection'
+import { parseMobileFileTapTarget, type MobileFileTapTarget } from './mobile-file-tap-target'
+
+function parseLineFragment(hash: string): Pick<MobileFileTapTarget, 'line' | 'column'> {
+  let decoded = hash
+  try {
+    decoded = decodeURIComponent(hash)
+  } catch {}
+  const match = /^(?:L|line-?)([1-9]\d*)(?:C([1-9]\d*))?/i.exec(decoded)
+  const line = match ? Number.parseInt(match[1]!, 10) : null
+  const column = match?.[2] ? Number.parseInt(match[2], 10) : null
+  return {
+    line: line !== null && Number.isSafeInteger(line) ? line : null,
+    column: column !== null && Number.isSafeInteger(column) ? column : null
+  }
+}
+
+function decodeHrefPath(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
+function parsePathText(
+  pathText: string,
+  fragment: Pick<MobileFileTapTarget, 'line' | 'column'>
+): MobileFileTapTarget | null {
+  let decodedPath = decodeHrefPath(pathText)
+  if (decodedPath.includes('/')) {
+    decodedPath = decodedPath.replace(/\\([()])/g, '$1')
+  }
+  const parsed = parseMobileFileTapTarget(decodedPath)
+  if (!parsed) {
+    return null
+  }
+  return {
+    pathText: normalizeFilePath(parsed.pathText),
+    line: parsed.line ?? fragment.line,
+    column: parsed.column ?? fragment.column
+  }
+}
+
+function isMarkdownTitle(value: string): boolean {
+  return /^(?:"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|\((?:\\.|[^)])*\))$/.test(value)
+}
+
+export function normalizeMobileMarkdownDestination(value: string): string | null {
+  const trimmed = value.trim()
+  if (trimmed.startsWith('<')) {
+    const closeIndex = trimmed.indexOf('>')
+    if (closeIndex < 0) {
+      return null
+    }
+    const title = trimmed.slice(closeIndex + 1).trim()
+    return !title || isMarkdownTitle(title) ? trimmed.slice(1, closeIndex) : null
+  }
+  const whitespaceIndex = trimmed.search(/\s/)
+  if (whitespaceIndex < 0) {
+    return trimmed
+  }
+  const title = trimmed.slice(whitespaceIndex).trim()
+  return isMarkdownTitle(title) ? trimmed.slice(0, whitespaceIndex) : null
+}
+
+export function parseMobileMarkdownFileTarget(href: string): MobileFileTapTarget | null {
+  const trimmed = normalizeMobileMarkdownDestination(href)
+  if (!trimmed || trimmed.startsWith('#')) {
+    return null
+  }
+  if (trimmed.toLowerCase().startsWith('file:')) {
+    try {
+      const url = new URL(trimmed)
+      const pathText = fileUriToFilesystemPath(url)
+      return pathText
+        ? parsePathText(pathText, parseLineFragment(url.hash.replace(/^#/, '')))
+        : null
+    } catch {
+      return null
+    }
+  }
+  if (!/^[A-Za-z]:[\\/]/.test(trimmed) && /^[A-Za-z][A-Za-z0-9+.-]*:/.test(trimmed)) {
+    return null
+  }
+  const hashIndex = trimmed.indexOf('#')
+  const queryIndex = trimmed.indexOf('?')
+  const suffixIndex =
+    hashIndex < 0 ? queryIndex : queryIndex < 0 ? hashIndex : Math.min(hashIndex, queryIndex)
+  const pathText = suffixIndex < 0 ? trimmed : trimmed.slice(0, suffixIndex)
+  const hash =
+    hashIndex < 0
+      ? ''
+      : trimmed.slice(hashIndex + 1, queryIndex > hashIndex ? queryIndex : undefined)
+  return parsePathText(pathText, parseLineFragment(hash))
+}

--- a/mobile/src/session/MobileNativeChatMessage.test.ts
+++ b/mobile/src/session/MobileNativeChatMessage.test.ts
@@ -41,7 +41,7 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     renderer = null
   })
 
-  function render(message: NativeChatMessage): ReactTestRenderer {
+  function render(message: NativeChatMessage, onOpenFile?: (target: unknown) => void) {
     const original = console.error
     const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
       if (typeof a[0] === 'string' && a[0].includes('react-test-renderer is deprecated')) {
@@ -51,7 +51,7 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
     })
     try {
       act(() => {
-        renderer = create(createElement(MobileNativeChatMessage, { message }))
+        renderer = create(createElement(MobileNativeChatMessage, { message, onOpenFile }))
       })
     } finally {
       spy.mockRestore()
@@ -83,5 +83,46 @@ describe('MobileNativeChatMessage image-ref rendering', () => {
       .findAllByType('Text' as never)
       .map((node) => String(node.children.join('')))
     expect(texts.some((text) => text.includes('/tmp/host.png'))).toBe(true)
+  })
+
+  it('opens a file path in the user bubble', () => {
+    const onOpenFile = vi.fn()
+    const path =
+      '/Users/jinjingliang/Documents/projects/orca/worktree/docs/native-chat-rendering-architecture.md'
+    const tree = render(userMessage([{ type: 'text', text: path }]), onOpenFile)
+    const link = tree.root.find(
+      (node) => node.type === 'Text' && node.props.accessibilityLabel === `Open file ${path}`
+    )
+
+    act(() => link.props.onPress())
+
+    expect(onOpenFile).toHaveBeenCalledWith({
+      pathText: path,
+      line: null,
+      column: null
+    })
+  })
+
+  it('only makes the file span in surrounding user prose tappable', () => {
+    const onOpenFile = vi.fn()
+    const tree = render(
+      userMessage([{ type: 'text', text: 'Please inspect src/app.ts before continuing' }]),
+      onOpenFile
+    )
+    const outerText = tree.root
+      .findAllByType('Text' as never)
+      .find((node) => node.children.some((child) => String(child).includes('Please inspect')))
+    const link = tree.root.find(
+      (node) => node.type === 'Text' && node.props.accessibilityLabel === 'Open file src/app.ts'
+    )
+
+    expect(outerText?.props.onPress).toBeUndefined()
+    expect(outerText?.props.accessibilityRole).toBeUndefined()
+    act(() => link.props.onPress())
+    expect(onOpenFile).toHaveBeenCalledWith({
+      pathText: 'src/app.ts',
+      line: null,
+      column: null
+    })
   })
 })

--- a/mobile/src/session/MobileNativeChatMessage.tsx
+++ b/mobile/src/session/MobileNativeChatMessage.tsx
@@ -4,6 +4,7 @@ import * as Clipboard from 'expo-clipboard'
 import { ArrowUp, ChevronDown, Copy, SquareChevronRight } from 'lucide-react-native'
 import type { NativeChatBlock, NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { MobileMarkdown } from '../components/MobileMarkdown'
+import { parseMobileFileTapTarget, type MobileFileTapTarget } from '../files/mobile-file-tap-target'
 import { colors } from '../theme/mobile-theme'
 import {
   isImageRefBlock,
@@ -16,6 +17,7 @@ import { diffFromText, diffFromToolCall, type DiffLine } from './mobile-native-c
 import { isRenderableImageUri } from './mobile-native-chat-image-preview'
 import { MAX_TOOL_RESULT_CHARS, styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
 import { nativeChatMessageText } from './mobile-native-chat-message-text'
+import { MobileNativeChatUserProse } from './MobileNativeChatUserProse'
 import {
   summarizeToolInput,
   summarizeToolRun,
@@ -83,7 +85,7 @@ function ToolLine({
   pair: ToolPair
   defaultExpanded: boolean
   diffLineLimit: number
-  onOpenFile?: (relativePath: string) => void
+  onOpenFile?: (target: MobileFileTapTarget) => void
 }): React.JSX.Element {
   const [expanded, setExpanded] = useState(defaultExpanded)
   const { call, result } = pair
@@ -99,31 +101,41 @@ function ToolLine({
   // A tool that targets a file (Read/Edit/Write…) renders its preview as a
   // tappable link that opens the file, independent of the line's expand tap.
   const filePath = call ? toolFilePath(call.input) : null
-  const openable = filePath !== null && onOpenFile !== undefined
+  const fileTarget = filePath ? parseMobileFileTapTarget(filePath) : null
+  const openable = fileTarget !== null && onOpenFile !== undefined
   return (
     <View>
-      <Pressable
-        style={styles.toolLine}
-        onPress={() => hasDetail && setExpanded((v) => !v)}
-        hitSlop={6}
-      >
-        {expanded ? (
-          <ChevronDown size={15} color={colors.textMuted} strokeWidth={2} />
-        ) : (
-          <SquareChevronRight size={15} color={colors.textMuted} strokeWidth={2} />
-        )}
-        <Text style={styles.toolName}>{name}</Text>
-        {preview ? (
-          <Text
-            style={[styles.toolPreview, openable && styles.toolPreviewLink]}
-            numberOfLines={1}
-            onPress={openable ? () => onOpenFile!(filePath!) : undefined}
-            suppressHighlighting={!openable}
+      <View style={styles.toolLine}>
+        <Pressable
+          style={styles.toolLineToggle}
+          onPress={() => hasDetail && setExpanded((v) => !v)}
+          hitSlop={6}
+        >
+          {expanded ? (
+            <ChevronDown size={15} color={colors.textMuted} strokeWidth={2} />
+          ) : (
+            <SquareChevronRight size={15} color={colors.textMuted} strokeWidth={2} />
+          )}
+          <Text style={styles.toolName}>{name}</Text>
+          {preview && !openable ? (
+            <Text style={styles.toolPreview} numberOfLines={1}>
+              {preview}
+            </Text>
+          ) : null}
+        </Pressable>
+        {preview && openable ? (
+          <Pressable
+            style={styles.toolPreviewButton}
+            onPress={() => onOpenFile(fileTarget)}
+            accessibilityRole="link"
+            accessibilityLabel={`Open file ${fileTarget.pathText}`}
           >
-            {preview}
-          </Text>
+            <Text style={[styles.toolPreview, styles.toolPreviewLink]} numberOfLines={1}>
+              {preview}
+            </Text>
+          </Pressable>
         ) : null}
-      </Pressable>
+      </View>
       {expanded ? (
         <View style={styles.toolDetail}>
           {callDiff ? <DiffView lines={callDiff} /> : null}
@@ -146,14 +158,18 @@ function Prose({
   block: NativeChatBlock
   invert?: boolean
   fontScale: number
-  onOpenFile?: (relativePath: string) => void
+  onOpenFile?: (target: MobileFileTapTarget) => void
 }): React.JSX.Element | null {
   if (isTextBlock(block)) {
     // Inverted (user) bubbles use a fixed dark-on-light text rather than the
     // markdown renderer's light-on-dark palette.
     if (invert) {
       return (
-        <Text style={[styles.userText, { fontSize: TEXT_SIZE * fontScale }]}>{block.text}</Text>
+        <MobileNativeChatUserProse
+          text={block.text}
+          fontScale={fontScale}
+          onOpenFile={onOpenFile}
+        />
       )
     }
     return (
@@ -195,7 +211,7 @@ function ToolRun({
   blocks: NativeChatBlock[]
   defaultExpanded: boolean
   trailing?: React.ReactNode
-  onOpenFile?: (relativePath: string) => void
+  onOpenFile?: (target: MobileFileTapTarget) => void
 }): React.JSX.Element {
   const [open, setOpen] = useState(defaultExpanded)
   const pairs = pairToolBlocks(blocks, MAX_VISIBLE_TOOL_PAIRS)
@@ -295,7 +311,7 @@ function MobileNativeChatMessageImpl({
   messageIndex?: number
   /** Ask the list to align this message's top to the top of the viewport. */
   onScrollToMessage?: (index: number) => void
-  onOpenFile?: (relativePath: string) => void
+  onOpenFile?: (target: MobileFileTapTarget) => void
 }): React.JSX.Element {
   const isUser = message.role === 'user'
   const isReasoning = message.role === 'reasoning'

--- a/mobile/src/session/MobileNativeChatUserProse.tsx
+++ b/mobile/src/session/MobileNativeChatUserProse.tsx
@@ -1,0 +1,44 @@
+import { Fragment } from 'react'
+import { Text } from 'react-native'
+import { detectFilePathSegments } from '../components/markdown-file-path-detection'
+import type { MobileFileTapTarget } from '../files/mobile-file-tap-target'
+import { styles, TEXT_SIZE } from './mobile-native-chat-message-styles'
+
+export function MobileNativeChatUserProse({
+  text,
+  fontScale,
+  onOpenFile
+}: {
+  text: string
+  fontScale: number
+  onOpenFile?: (target: MobileFileTapTarget) => void
+}): React.JSX.Element {
+  const segments = onOpenFile
+    ? detectFilePathSegments(text)
+    : [{ type: 'text' as const, value: text }]
+  let offset = 0
+  const keyedSegments = segments.map((segment) => {
+    const key = `${offset}:${segment.type}`
+    offset += segment.value.length
+    return { key, segment }
+  })
+  return (
+    <Text style={[styles.userText, { fontSize: TEXT_SIZE * fontScale }]}>
+      {keyedSegments.map(({ key, segment }) =>
+        segment.type === 'file' ? (
+          <Text
+            key={key}
+            style={styles.userFileLink}
+            onPress={() => onOpenFile?.(segment.target)}
+            accessibilityRole="link"
+            accessibilityLabel={`Open file ${segment.target.pathText}`}
+          >
+            {segment.value}
+          </Text>
+        ) : (
+          <Fragment key={key}>{segment.value}</Fragment>
+        )
+      )}
+    </Text>
+  )
+}

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -12,6 +12,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
 import { ArrowDown, ChevronsDownUp, ChevronsUpDown, Square } from 'lucide-react-native'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import type { MobileFileTapTarget } from '../files/mobile-file-tap-target'
 import { colors } from '../theme/mobile-theme'
 import { styles } from './mobile-native-chat-view-styles'
 import {
@@ -94,7 +95,7 @@ type Props = {
   permission?: MobileChatPermission | null
   onRespondPermission?: (send: string) => Promise<boolean>
   /** Open a worktree file tapped in agent markdown. */
-  onOpenFile?: (relativePath: string) => void
+  onOpenFile?: (target: MobileFileTapTarget) => void
   /** Pixels to lift the composer by when the soft keyboard is open. The route
    *  owns keyboard tracking (the app uses manual lift, not KeyboardAvoidingView). */
   keyboardInset?: number

--- a/mobile/src/session/mobile-native-chat-message-styles.ts
+++ b/mobile/src/session/mobile-native-chat-message-styles.ts
@@ -30,6 +30,9 @@ export const styles = StyleSheet.create({
     lineHeight: TEXT_SIZE + 6,
     fontWeight: '500'
   },
+  userFileLink: {
+    textDecorationLine: 'underline'
+  },
   controls: {
     flexDirection: 'row',
     justifyContent: 'flex-end',
@@ -102,6 +105,12 @@ export const styles = StyleSheet.create({
     gap: spacing.sm,
     paddingVertical: 3
   },
+  toolLineToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    minWidth: 0
+  },
   toolName: {
     color: colors.textPrimary,
     fontFamily: typography.monoFamily,
@@ -117,6 +126,9 @@ export const styles = StyleSheet.create({
   toolPreviewLink: {
     color: colors.accentBlue,
     textDecorationLine: 'underline'
+  },
+  toolPreviewButton: {
+    flex: 1
   },
   toolDetail: {
     paddingLeft: spacing.lg,

--- a/mobile/src/session/mobile-native-chat-open-file.test.ts
+++ b/mobile/src/session/mobile-native-chat-open-file.test.ts
@@ -6,7 +6,7 @@ import {
 } from './mobile-native-chat-open-file'
 
 describe('resolveMobileNativeChatWorktreePath', () => {
-  it('resolves an absolute tool path to a worktree-relative open target', async () => {
+  it('resolves a chat path from the worktree root first', async () => {
     const sendRequest = vi.fn().mockResolvedValue({
       ok: true,
       result: {
@@ -23,37 +23,152 @@ describe('resolveMobileNativeChatWorktreePath', () => {
         terminal: 'terminal'
       })
     ).resolves.toBe('src/app.ts')
-    expect(sendRequest).toHaveBeenCalledWith('files.resolveTerminalPath', {
-      worktree: 'id:worktree',
-      pathText: '/repo/src/app.ts',
-      terminal: 'terminal'
+    expect(sendRequest).toHaveBeenCalledWith(
+      'files.resolveTerminalPath',
+      {
+        worktree: 'id:worktree',
+        pathText: '/repo/src/app.ts'
+      },
+      { timeoutMs: 10_000 }
+    )
+  })
+
+  it('navigates directly to the mobile preview for a resolved worktree file', async () => {
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'worktree-file', relativePath: 'src/app.ts' }
+      }
+    })
+    const pushPreviewRoute = vi.fn()
+
+    await expect(
+      openMobileNativeChatFile({
+        client: { sendRequest } as unknown as RpcClient,
+        hostId: 'host',
+        worktreeId: 'worktree',
+        worktreeName: 'Project',
+        target: { pathText: '../repo/src/app.ts', line: 12, column: 3 },
+        terminal: 'terminal',
+        pushPreviewRoute
+      })
+    ).resolves.toBe(true)
+
+    expect(sendRequest).toHaveBeenCalledOnce()
+    expect(pushPreviewRoute).toHaveBeenCalledWith({
+      pathname: '/h/[hostId]/files/preview/[worktreeId]',
+      params: {
+        hostId: 'host',
+        worktreeId: 'worktree',
+        worktreeName: 'Project',
+        source: 'worktree',
+        relativePath: 'src/app.ts',
+        name: 'app.ts',
+        line: '12',
+        column: '3'
+      }
     })
   })
 
-  it('opens only the resolved worktree-relative target', async () => {
+  it('falls back to terminal cwd after a worktree-root miss', async () => {
     const sendRequest = vi
       .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        result: { exists: false, isDirectory: false }
+      })
       .mockResolvedValueOnce({
         ok: true,
         result: {
           exists: true,
           isDirectory: false,
-          openTarget: { kind: 'worktree-file', relativePath: 'src/app.ts' }
+          openTarget: { kind: 'worktree-file', relativePath: 'docs/readme.md' }
         }
       })
-      .mockResolvedValueOnce({ ok: true, result: {} })
 
-    await openMobileNativeChatFile({
-      client: { sendRequest } as unknown as RpcClient,
-      worktreeId: 'worktree',
-      pathText: '../repo/src/app.ts',
-      terminal: 'terminal'
+    await expect(
+      resolveMobileNativeChatWorktreePath({
+        client: { sendRequest } as unknown as RpcClient,
+        worktreeId: 'worktree',
+        pathText: 'docs/readme.md',
+        terminal: 'terminal'
+      })
+    ).resolves.toBe('docs/readme.md')
+    expect(sendRequest).toHaveBeenLastCalledWith(
+      'files.resolveTerminalPath',
+      {
+        worktree: 'id:worktree',
+        pathText: 'docs/readme.md',
+        terminal: 'terminal'
+      },
+      { timeoutMs: 10_000 }
+    )
+  })
+
+  it('prefers the root file when the terminal cwd has an ambiguous match', async () => {
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'worktree-file', relativePath: 'src/index.ts' }
+      }
     })
 
-    expect(sendRequest).toHaveBeenLastCalledWith('files.open', {
-      worktree: 'id:worktree',
-      relativePath: 'src/app.ts'
-    })
+    await expect(
+      resolveMobileNativeChatWorktreePath({
+        client: { sendRequest } as unknown as RpcClient,
+        worktreeId: 'folder-workspace',
+        pathText: 'src/index.ts',
+        terminal: 'terminal-in-packages-app'
+      })
+    ).resolves.toBe('src/index.ts')
+
+    expect(sendRequest).toHaveBeenCalledOnce()
+    expect(sendRequest.mock.calls[0]?.[1]).not.toHaveProperty('terminal')
+  })
+
+  it('recovers an iOS-lowercased macOS home path after the original misses', async () => {
+    const sendRequest = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        result: { exists: false, isDirectory: false }
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        result: { exists: false, isDirectory: false }
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        result: {
+          exists: true,
+          isDirectory: false,
+          openTarget: {
+            kind: 'worktree-file',
+            relativePath: 'docs/native-chat-rendering-architecture.md'
+          }
+        }
+      })
+
+    await expect(
+      resolveMobileNativeChatWorktreePath({
+        client: { sendRequest } as unknown as RpcClient,
+        worktreeId: 'worktree',
+        pathText: '/users/me/project/docs/native-chat-rendering-architecture.md',
+        terminal: 'terminal'
+      })
+    ).resolves.toBe('docs/native-chat-rendering-architecture.md')
+    expect(sendRequest).toHaveBeenLastCalledWith(
+      'files.resolveTerminalPath',
+      {
+        worktree: 'id:worktree',
+        pathText: '/Users/me/project/docs/native-chat-rendering-architecture.md'
+      },
+      { timeoutMs: 10_000 }
+    )
   })
 
   it('resolves null when the resolve request rejects', async () => {
@@ -68,26 +183,64 @@ describe('resolveMobileNativeChatWorktreePath', () => {
     ).resolves.toBeNull()
   })
 
-  it('does not reject when the open request fails', async () => {
-    const sendRequest = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        result: {
-          exists: true,
-          isDirectory: false,
-          openTarget: { kind: 'worktree-file', relativePath: 'src/app.ts' }
-        }
-      })
-      .mockRejectedValueOnce(new Error('connection interrupted'))
+  it('does not navigate when resolution fails', async () => {
+    const sendRequest = vi.fn().mockRejectedValue(new Error('connection interrupted'))
+    const pushPreviewRoute = vi.fn()
 
     await expect(
       openMobileNativeChatFile({
         client: { sendRequest } as unknown as RpcClient,
+        hostId: 'host',
         worktreeId: 'worktree',
-        pathText: 'src/app.ts',
+        target: { pathText: 'src/app.ts', line: null, column: null },
+        terminal: null,
+        pushPreviewRoute
+      })
+    ).resolves.toBe(false)
+    expect(pushPreviewRoute).not.toHaveBeenCalled()
+  })
+
+  it('does not reject when preview navigation fails', async () => {
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'worktree-file', relativePath: 'src/app.ts' }
+      }
+    })
+
+    await expect(
+      openMobileNativeChatFile({
+        client: { sendRequest } as unknown as RpcClient,
+        hostId: 'host',
+        worktreeId: 'worktree',
+        target: { pathText: 'src/app.ts', line: null, column: null },
+        terminal: null,
+        pushPreviewRoute: () => {
+          throw new Error('navigation failed')
+        }
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('rejects resolved paths outside the worktree', async () => {
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'absolute-file', absolutePath: '/tmp/secret.txt', grantId: 'grant' }
+      }
+    })
+
+    await expect(
+      resolveMobileNativeChatWorktreePath({
+        client: { sendRequest } as unknown as RpcClient,
+        worktreeId: 'worktree',
+        pathText: '/tmp/secret.txt',
         terminal: null
       })
-    ).resolves.toBeUndefined()
+    ).resolves.toBeNull()
   })
 })

--- a/mobile/src/session/mobile-native-chat-open-file.ts
+++ b/mobile/src/session/mobile-native-chat-open-file.ts
@@ -1,5 +1,33 @@
 import type { RuntimeTerminalPathResolution } from '../../../src/shared/runtime-types'
+import {
+  createMobileFilePreviewHref,
+  displayNameFromPreviewPath,
+  type MobileFilePreviewHref
+} from '../files/mobile-file-preview-route'
+import type { MobileFileTapTarget } from '../files/mobile-file-tap-target'
 import type { RpcClient } from '../transport/rpc-client'
+
+const FILE_RESOLVE_TIMEOUT_MS = 10_000
+
+function macHomePathRetry(pathText: string): string | null {
+  const prefix = '/users/'
+  if (!pathText.toLowerCase().startsWith(prefix) || pathText.startsWith('/Users/')) {
+    return null
+  }
+  // iOS can lowercase /Users while typing an absolute path.
+  return `/Users/${pathText.slice(prefix.length)}`
+}
+
+function resolvedWorktreePath(response: unknown): string | null {
+  const resolved = response as RuntimeTerminalPathResolution
+  if (!resolved.exists || resolved.isDirectory) {
+    return null
+  }
+  if (resolved.openTarget?.kind === 'worktree-file') {
+    return resolved.openTarget.relativePath
+  }
+  return resolved.openTarget ? null : (resolved.relativePath ?? null)
+}
 
 export async function resolveMobileNativeChatWorktreePath(args: {
   client: RpcClient
@@ -8,24 +36,32 @@ export async function resolveMobileNativeChatWorktreePath(args: {
   terminal: string | null
 }): Promise<string | null> {
   try {
-    const response = await args.client.sendRequest('files.resolveTerminalPath', {
-      worktree: `id:${args.worktreeId}`,
-      pathText: args.pathText,
-      ...(args.terminal ? { terminal: args.terminal } : {})
-    })
-    if (!response.ok) {
-      return null
+    const worktree = `id:${args.worktreeId}`
+    const resolvePath = async (pathText: string, terminal: string | null) => {
+      const response = await args.client.sendRequest(
+        'files.resolveTerminalPath',
+        {
+          worktree,
+          pathText,
+          ...(terminal ? { terminal } : {})
+        },
+        { timeoutMs: FILE_RESOLVE_TIMEOUT_MS }
+      )
+      return response.ok ? resolvedWorktreePath(response.result) : null
     }
-    const resolved = response.result as RuntimeTerminalPathResolution
-    if (!resolved.exists || resolved.isDirectory) {
-      return null
+    const rootPath = await resolvePath(args.pathText, null)
+    if (rootPath) {
+      return rootPath
     }
-    return resolved.openTarget?.kind === 'worktree-file'
-      ? resolved.openTarget.relativePath
-      : (resolved.relativePath ?? null)
+    if (args.terminal) {
+      const terminalPath = await resolvePath(args.pathText, args.terminal)
+      if (terminalPath) {
+        return terminalPath
+      }
+    }
+    const retryPath = macHomePathRetry(args.pathText)
+    return retryPath ? await resolvePath(retryPath, null) : null
   } catch {
-    // Callers fire-and-forget file opens; a disconnect/timeout must not become
-    // an unhandled rejection.
     return null
   }
 }
@@ -33,19 +69,38 @@ export async function resolveMobileNativeChatWorktreePath(args: {
 export async function openMobileNativeChatFile(args: {
   client: RpcClient
   worktreeId: string
-  pathText: string
+  hostId: string
+  worktreeName?: string
+  target: MobileFileTapTarget
   terminal: string | null
-}): Promise<void> {
-  const relativePath = await resolveMobileNativeChatWorktreePath(args)
-  if (relativePath) {
-    try {
-      await args.client.sendRequest('files.open', {
-        worktree: `id:${args.worktreeId}`,
-        relativePath
+  pushPreviewRoute: (href: MobileFilePreviewHref) => void
+  isCurrent?: () => boolean
+}): Promise<boolean> {
+  const relativePath = await resolveMobileNativeChatWorktreePath({
+    ...args,
+    pathText: args.target.pathText
+  })
+  if (!relativePath) {
+    return false
+  }
+  if (args.isCurrent && !args.isCurrent()) {
+    return false
+  }
+  try {
+    args.pushPreviewRoute(
+      createMobileFilePreviewHref({
+        hostId: args.hostId,
+        worktreeId: args.worktreeId,
+        source: 'worktree',
+        relativePath,
+        name: displayNameFromPreviewPath(relativePath),
+        ...(args.target.line !== null ? { line: String(args.target.line) } : {}),
+        ...(args.target.column !== null ? { column: String(args.target.column) } : {}),
+        ...(args.worktreeName ? { worktreeName: args.worktreeName } : {})
       })
-    } catch {
-      // Best-effort open; failures surface as a no-op rather than an
-      // unhandled rejection.
-    }
+    )
+    return true
+  } catch {
+    return false
   }
 }

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -9,6 +9,10 @@ const captureSendOrigin = vi.fn()
 const clearDraftForSend = vi.fn()
 const restoreRejectedDraft = vi.fn()
 const holdUnconfirmedSend = vi.fn()
+const haptics = vi.hoisted(() => ({
+  triggerError: vi.fn(),
+  triggerSelection: vi.fn()
+}))
 
 // Mutable stand-ins so the launch-draft wiring below can drive chat resolution
 // and transcript state; defaults keep the send-seam tests unchanged.
@@ -57,6 +61,7 @@ vi.mock('./use-mobile-native-chat-stop', () => ({
 vi.mock('./use-mobile-native-chat-file-search', () => ({
   useMobileNativeChatFileSearch: () => ({ nativeChatFilePaths: [], loadNativeChatFiles: vi.fn() })
 }))
+vi.mock('../platform/haptics', () => haptics)
 // Partial: the stale-input heal reaches the real transport through image-send,
 // which must read the REAL timeout constant, not a copy that can silently drift.
 vi.mock('./mobile-native-chat-send', async (importOriginal) => ({
@@ -90,22 +95,33 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
   let controller: MobileNativeChatController | null = null
   const onSendError = vi.fn()
   const onSendResolved = vi.fn()
+  const onOpenFile = vi.fn()
+  const onOpenFileError = vi.fn()
   // Only the stale-input heal reaches the transport directly (the message send
   // itself is mocked above).
   const clientStub = { sendRequest: vi.fn() }
 
-  function Harness({ connState = 'connected' }: { connState?: ConnectionState }): null {
+  function Harness({
+    connState = 'connected',
+    worktreeId = 'w'
+  }: {
+    connState?: ConnectionState
+    worktreeId?: string
+  }): null {
     controller = useMobileNativeChatController({
       client: clientStub as unknown as RpcClient,
       connState,
       hostId: 'h',
-      worktreeId: 'w',
+      worktreeId,
+      worktreeName: 'Project',
       activeSessionTab: null,
       activeSessionTabId: 'tab-1',
       activeHandleRef: { current: 'term-1' },
       deviceTokenRef: { current: null },
       nativeChatTranscriptIsLocalReadable: true,
       nativeChatInputLeaseReady: true,
+      pushFilePreview: onOpenFile,
+      onOpenFileError,
       onSendError,
       onSendResolved
     })
@@ -136,6 +152,170 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
     act(() => renderer?.unmount())
     renderer = null
     controller = null
+  })
+
+  it('opens resolved file taps in the mobile preview route', async () => {
+    clientStub.sendRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'worktree-file', relativePath: 'docs/STYLEGUIDE.md' }
+      }
+    })
+
+    controller!.handleNativeChatOpenFile({
+      pathText: 'docs/STYLEGUIDE.md',
+      line: 14,
+      column: 2
+    })
+    await vi.waitFor(() => expect(onOpenFile).toHaveBeenCalledOnce())
+
+    expect(onOpenFile).toHaveBeenCalledWith({
+      pathname: '/h/[hostId]/files/preview/[worktreeId]',
+      params: {
+        hostId: 'h',
+        worktreeId: 'w',
+        worktreeName: 'Project',
+        source: 'worktree',
+        relativePath: 'docs/STYLEGUIDE.md',
+        name: 'STYLEGUIDE.md',
+        line: '14',
+        column: '2'
+      }
+    })
+  })
+
+  it('shows feedback when a detected path does not resolve', async () => {
+    clientStub.sendRequest.mockResolvedValue({
+      ok: true,
+      result: { exists: false, isDirectory: false }
+    })
+
+    controller!.handleNativeChatOpenFile({
+      pathText: 'docs/missing.md',
+      line: null,
+      column: null
+    })
+    await vi.waitFor(() => expect(onOpenFileError).toHaveBeenCalledOnce())
+
+    expect(onOpenFileError).toHaveBeenCalledWith('Unable to open file')
+    expect(onOpenFile).not.toHaveBeenCalled()
+  })
+
+  it('ignores an older file resolution that completes after the latest tap', async () => {
+    let resolveFirst!: (value: unknown) => void
+    let resolveSecond!: (value: unknown) => void
+    clientStub.sendRequest
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve
+          })
+      )
+
+    controller!.handleNativeChatOpenFile({
+      pathText: 'src/first.ts',
+      line: null,
+      column: null
+    })
+    controller!.handleNativeChatOpenFile({
+      pathText: 'src/second.ts',
+      line: null,
+      column: null
+    })
+    resolveSecond({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'worktree-file', relativePath: 'src/second.ts' }
+      }
+    })
+    await vi.waitFor(() => expect(onOpenFile).toHaveBeenCalledOnce())
+    resolveFirst({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'worktree-file', relativePath: 'src/first.ts' }
+      }
+    })
+    await vi.waitFor(() => expect(clientStub.sendRequest).toHaveBeenCalledTimes(2))
+
+    expect(onOpenFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ relativePath: 'src/second.ts' })
+      })
+    )
+    expect(onOpenFileError).not.toHaveBeenCalled()
+  })
+
+  it('invalidates a pending file open when the chat scope changes', async () => {
+    let resolveRequest!: (value: unknown) => void
+    clientStub.sendRequest.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRequest = resolve
+        })
+    )
+    controller!.handleNativeChatOpenFile({
+      pathText: 'src/old.ts',
+      line: null,
+      column: null
+    })
+
+    act(() => renderer!.update(createElement(Harness, { worktreeId: 'new-worktree' })))
+    resolveRequest({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'worktree-file', relativePath: 'src/old.ts' }
+      }
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onOpenFile).not.toHaveBeenCalled()
+    expect(onOpenFileError).not.toHaveBeenCalled()
+  })
+
+  it('invalidates a pending file open on unmount', async () => {
+    let resolveRequest!: (value: unknown) => void
+    clientStub.sendRequest.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRequest = resolve
+        })
+    )
+    controller!.handleNativeChatOpenFile({
+      pathText: 'src/old.ts',
+      line: null,
+      column: null
+    })
+
+    act(() => renderer!.unmount())
+    renderer = null
+    resolveRequest({
+      ok: true,
+      result: {
+        exists: true,
+        isDirectory: false,
+        openTarget: { kind: 'worktree-file', relativePath: 'src/old.ts' }
+      }
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onOpenFile).not.toHaveBeenCalled()
+    expect(onOpenFileError).not.toHaveBeenCalled()
   })
 
   it('clears an orphaned image paste before a question-card answer (#10228)', async () => {
@@ -336,12 +516,15 @@ describe('useMobileNativeChatController launch-draft wiring', () => {
       connState: 'connected',
       hostId: 'h',
       worktreeId: 'w',
+      worktreeName: 'Project',
       activeSessionTab: tab as never,
       activeSessionTabId: 'tab-1',
       activeHandleRef: { current: 'term-1' },
       deviceTokenRef: { current: null },
       nativeChatTranscriptIsLocalReadable: true,
       nativeChatInputLeaseReady: true,
+      pushFilePreview: vi.fn(),
+      onOpenFileError: vi.fn(),
       onSendError: vi.fn(),
       onSendResolved: vi.fn()
     })

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useLayoutEffect,
   useRef,
   type Dispatch,
   type MutableRefObject,
@@ -32,6 +33,9 @@ import { useMobileNativeChatPrompts } from './use-mobile-native-chat-prompts'
 import { useMobileNativeChatStop } from './use-mobile-native-chat-stop'
 import { useNativeChatAcceptedAction } from './use-native-chat-action-outcomes'
 import { useThrottledLatestValue } from './use-throttled-latest-value'
+import type { MobileFilePreviewHref } from '../files/mobile-file-preview-route'
+import type { MobileFileTapTarget } from '../files/mobile-file-tap-target'
+import { triggerError, triggerSelection } from '../platform/haptics'
 
 const NATIVE_CHAT_STREAM_THROTTLE_MS = 50
 
@@ -52,7 +56,7 @@ export type MobileNativeChatController = {
   nativeChatPermission: ReturnType<typeof detectAgentPermission>
   nativeChatQuestion: ReturnType<typeof parseAgentQuestion>
   nativeChatAsk: ReturnType<typeof parseAskFromStatus>
-  handleNativeChatOpenFile: (relativePath: string) => void
+  handleNativeChatOpenFile: (target: MobileFileTapTarget) => void
   handleNativeChatAnswerAsk: (
     prompt: AskPrompt,
     selections: AskAnswerSelection[]
@@ -81,6 +85,7 @@ export function useMobileNativeChatController(args: {
   client: RpcClient | null
   hostId: string
   worktreeId: string
+  worktreeName?: string
   activeSessionTab: MobileNativeChatTab | null
   activeSessionTabId: string | null
   activeHandleRef: MutableRefObject<string | null>
@@ -89,6 +94,8 @@ export function useMobileNativeChatController(args: {
   nativeChatInputLeaseReady: boolean
   /** Live socket state; the lease collapses on disconnect but one render later. */
   connState: ConnectionState
+  pushFilePreview: (href: MobileFilePreviewHref) => void
+  onOpenFileError: (message: string) => void
   onSendError: (message: string) => void
   /** Retires a held failure banner. Any accepted chat write clears it — a delivered
    *  answer or permission reply must not sit under a stale "not sent". */
@@ -98,6 +105,7 @@ export function useMobileNativeChatController(args: {
     client,
     hostId,
     worktreeId,
+    worktreeName,
     activeSessionTab,
     activeSessionTabId,
     activeHandleRef,
@@ -105,6 +113,8 @@ export function useMobileNativeChatController(args: {
     nativeChatTranscriptIsLocalReadable,
     nativeChatInputLeaseReady,
     connState,
+    pushFilePreview,
+    onOpenFileError,
     onSendError,
     onSendResolved
   } = args
@@ -169,20 +179,43 @@ export function useMobileNativeChatController(args: {
     status: nativeChatStatus,
     messages: nativeChatSession.messages
   })
-
+  const fileOpenSeqRef = useRef(0)
+  const pushFilePreviewRef = useRef(pushFilePreview)
+  useLayoutEffect(() => {
+    pushFilePreviewRef.current = pushFilePreview
+  }, [pushFilePreview])
+  useLayoutEffect(() => {
+    fileOpenSeqRef.current += 1
+    return () => {
+      fileOpenSeqRef.current += 1
+    }
+  }, [activeSessionTabId, client, hostId, showNativeChat, worktreeId])
   const handleNativeChatOpenFile = useCallback(
-    (pathText: string) => {
+    (target: MobileFileTapTarget) => {
+      const requestSeq = ++fileOpenSeqRef.current
       if (!client) {
+        triggerError()
+        onOpenFileError('Unable to open file')
         return
       }
+      triggerSelection()
       void openMobileNativeChatFile({
         client,
+        hostId,
         worktreeId,
-        pathText,
-        terminal: activeHandleRef.current
+        worktreeName,
+        target,
+        terminal: activeHandleRef.current,
+        pushPreviewRoute: (href) => pushFilePreviewRef.current(href),
+        isCurrent: () => fileOpenSeqRef.current === requestSeq
+      }).then((opened) => {
+        if (!opened && fileOpenSeqRef.current === requestSeq) {
+          triggerError()
+          onOpenFileError('Unable to open file')
+        }
       })
     },
-    [activeHandleRef, client, worktreeId]
+    [activeHandleRef, client, hostId, onOpenFileError, worktreeId, worktreeName]
   )
 
   // Every chat write gates on both: the lease proves the input floor is ours, and

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -1903,6 +1903,36 @@ describe('RuntimeFileCommands', () => {
       expect(result).toMatchObject({ relativePath: 'src/missing.ts', exists: false })
     })
 
+    it('rejects a local symlink target outside the selected worktree', async () => {
+      const { commands } = createRuntimeFileCommands({ path: '/repo' })
+      statAsFile()
+      resolveAuthorizedPathMock.mockImplementation(async (p: string) =>
+        p === '/repo/src/link.ts' ? '/other-repo/secret.ts' : p
+      )
+
+      const result = await commands.resolveTerminalPath('id:wt-1', 'src/link.ts')
+
+      expect(result).toMatchObject({ relativePath: null, exists: false })
+      expect(result.openTarget).toBeUndefined()
+      expect(statMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects an SSH symlink target outside the selected worktree', async () => {
+      const { commands, store } = createRuntimeFileCommands({ path: '/repo' })
+      store.getRepo.mockReturnValue({ connectionId: 'ssh-1' })
+      const stat = vi.fn()
+      const realpath = vi.fn(async (p: string) =>
+        p === '/repo/src/link.ts' ? '/home/me/.ssh/id_rsa' : p
+      )
+      vi.mocked(getSshFilesystemProvider).mockReturnValue({ realpath, stat } as never)
+
+      const result = await commands.resolveTerminalPath('id:wt-1', 'src/link.ts')
+
+      expect(result).toMatchObject({ relativePath: null, exists: false })
+      expect(result.openTarget).toBeUndefined()
+      expect(stat).not.toHaveBeenCalled()
+    })
+
     it('does not expand ~/ on a remote worktree (home is unknown)', async () => {
       const { commands, store } = createRuntimeFileCommands({ path: '/repo' })
       store.getRepo.mockReturnValue({ connectionId: 'ssh-1' })
@@ -1919,7 +1949,8 @@ describe('RuntimeFileCommands', () => {
       const { commands, store } = createRuntimeFileCommands({ path: '/repo' })
       store.getRepo.mockReturnValue({ connectionId: 'ssh-1' })
       const stat = vi.fn().mockRejectedValue(new Error('ENOENT: no such file'))
-      vi.mocked(getSshFilesystemProvider).mockReturnValue({ stat } as never)
+      const realpath = vi.fn(async (p: string) => p)
+      vi.mocked(getSshFilesystemProvider).mockReturnValue({ realpath, stat } as never)
 
       const result = await commands.resolveTerminalPath('id:wt-1', 'src/missing.ts')
 
@@ -1930,7 +1961,8 @@ describe('RuntimeFileCommands', () => {
       const { commands, store } = createRuntimeFileCommands({ path: '/repo' })
       store.getRepo.mockReturnValue({ connectionId: 'ssh-1' })
       const stat = vi.fn().mockRejectedValue(new Error('Remote connection dropped'))
-      vi.mocked(getSshFilesystemProvider).mockReturnValue({ stat } as never)
+      const realpath = vi.fn(async (p: string) => p)
+      vi.mocked(getSshFilesystemProvider).mockReturnValue({ realpath, stat } as never)
 
       await expect(commands.resolveTerminalPath('id:wt-1', 'src/x.ts')).rejects.toThrow(
         'Remote connection dropped'

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -747,13 +747,30 @@ export class RuntimeFileCommands {
 
     try {
       if (relativePath !== null && relativePath !== '' && isSafeMobileRelativePath(relativePath)) {
+        const [canonicalRoot, canonicalPath] = connectionId
+          ? await Promise.all([
+              getSshFilesystemProvider(connectionId).realpath(worktree.path),
+              getSshFilesystemProvider(connectionId).realpath(absolutePath)
+            ])
+          : await Promise.all([
+              resolveAuthorizedPath(worktree.path, store),
+              resolveAuthorizedPath(absolutePath, store)
+            ])
+        const canonicalRelativePath = relativePathInsideRoot(canonicalRoot, canonicalPath)
+        if (
+          canonicalRelativePath === null ||
+          canonicalRelativePath === '' ||
+          !isSafeMobileRelativePath(canonicalRelativePath)
+        ) {
+          return { ...empty, absolutePath: canonicalPath }
+        }
         const stats = connectionId
-          ? await this.statRemoteTerminalPath(absolutePath, connectionId)
-          : await stat(await resolveAuthorizedPath(absolutePath, store))
+          ? await this.statRemoteTerminalPath(canonicalPath, connectionId)
+          : await stat(canonicalPath)
         return {
           worktree: worktree.id,
-          relativePath,
-          absolutePath,
+          relativePath: canonicalRelativePath,
+          absolutePath: canonicalPath,
           exists: true,
           isDirectory: stats.isDirectory(),
           openTarget: stats.isDirectory()
@@ -761,8 +778,8 @@ export class RuntimeFileCommands {
             : {
                 kind: 'worktree-file',
                 provider: connectionId ? 'ssh' : 'local',
-                relativePath,
-                absolutePath
+                relativePath: canonicalRelativePath,
+                absolutePath: canonicalPath
               }
         }
       }

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -291,10 +291,11 @@ export function NativeChatMessageList({
     const projected = foldToolMessages(
       orderNativeChatMessages(stripNoiseMessages(session.messages))
     )
-    const reconciled = reconcileNativeChatRowIdentity(projected, previousRowsRef.current)
-    previousRowsRef.current = reconciled
-    return reconciled
+    return reconcileNativeChatRowIdentity(projected, previousRowsRef.current)
   }, [session.messages])
+  useLayoutEffect(() => {
+    previousRowsRef.current = messages
+  }, [messages])
   const showTypingIndicator =
     isWorking && !messages.some((message) => message.id === NATIVE_CHAT_STREAMING_ID)
 

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { ArrowDown, ArrowUp, Image as ImageIcon } from 'lucide-react'
 import CommentMarkdown, {
+  type CommentMarkdownFilePathSpans,
   type CommentMarkdownLinkClickHandler
 } from '@/components/sidebar/CommentMarkdown'
 import { cn } from '@/lib/utils'
+import { reconcileNativeChatRowIdentity } from './native-chat-row-identity'
 import { translate } from '@/i18n/i18n'
 import { basename } from '@/lib/path'
 import {
@@ -122,11 +124,12 @@ function TypingIndicatorRow(): React.JSX.Element {
 /** One message: its prose first, then a collapsible run folding all of the
  *  turn's tool activity. Monochrome per STYLEGUIDE: user prompts read as a
  *  lifted card, assistant prose as body copy, reasoning de-emphasized. */
-function MessageRow({
+function MessageRowImpl({
   message,
   expandSignal,
   onScrollMessageToTop,
   onLinkClick,
+  filePathSpans,
   allowFileUriLinks = false,
   deliveryFailed = false
 }: {
@@ -135,13 +138,14 @@ function MessageRow({
   /** Align this message's top to the top of the scroll viewport. */
   onScrollMessageToTop: (el: HTMLElement) => void
   onLinkClick?: CommentMarkdownLinkClickHandler
+  filePathSpans?: CommentMarkdownFilePathSpans
   allowFileUriLinks?: boolean
   deliveryFailed?: boolean
 }): React.JSX.Element | null {
   const rowRef = useRef<HTMLDivElement | null>(null)
   const { prose, tools } = useMemo(() => splitNativeChatBlocks(message.blocks), [message.blocks])
-  const markdown = proseToMarkdown(prose)
-  const hasImages = prose.some((block) => block.type === 'image-ref')
+  const markdown = useMemo(() => proseToMarkdown(prose), [prose])
+  const hasImages = useMemo(() => prose.some((block) => block.type === 'image-ref'), [prose])
   const isUser = message.role === 'user'
   const isReasoning = message.role === 'reasoning'
   const isSystem = message.role === 'system'
@@ -178,6 +182,7 @@ function MessageRow({
                 variant="document"
                 className="text-sm"
                 onLinkClick={onLinkClick}
+                filePathSpans={filePathSpans}
                 allowFileUriLinks={allowFileUriLinks}
               />
             </>
@@ -225,6 +230,7 @@ function MessageRow({
           variant="document"
           className="text-sm"
           onLinkClick={onLinkClick}
+          filePathSpans={filePathSpans}
           allowFileUriLinks={allowFileUriLinks}
         />
       ) : null}
@@ -233,12 +239,18 @@ function MessageRow({
   )
 }
 
+// Every row body re-ran on each streaming frame without this; mobile has always
+// memoized its equivalent. Relies on stable row identity from
+// reconcileNativeChatRowIdentity — memoizing alone is not enough.
+const MessageRow = memo(MessageRowImpl)
+
 export function NativeChatMessageList({
   session,
   isWorking,
   expandSignal,
   fontScale,
   onLinkClick,
+  filePathSpans,
   allowFileUriLinks = false,
   failedDeliveryMessageIds
 }: {
@@ -249,6 +261,7 @@ export function NativeChatMessageList({
   /** Chat-only text multiplier (1 = default), driven by the zoom shortcuts. */
   fontScale: number
   onLinkClick?: CommentMarkdownLinkClickHandler
+  filePathSpans?: CommentMarkdownFilePathSpans
   allowFileUriLinks?: boolean
   failedDeliveryMessageIds?: ReadonlySet<string>
 }): React.JSX.Element {
@@ -270,10 +283,18 @@ export function NativeChatMessageList({
   // matching the mobile chat. Then fold each turn's tool activity into the
   // assistant message it belongs to, ordered stably, so a turn's tools collapse
   // under one run.
-  const messages = useMemo(
-    () => foldToolMessages(orderNativeChatMessages(stripNoiseMessages(session.messages))),
-    [session.messages]
-  )
+  // The projection mints new objects every streaming frame; reconciling against
+  // the previous frame keeps identity stable for rows that did not change, which
+  // is what MessageRow's memo and its inner splitNativeChatBlocks memo key on.
+  const previousRowsRef = useRef<NativeChatMessage[] | null>(null)
+  const messages = useMemo(() => {
+    const projected = foldToolMessages(
+      orderNativeChatMessages(stripNoiseMessages(session.messages))
+    )
+    const reconciled = reconcileNativeChatRowIdentity(projected, previousRowsRef.current)
+    previousRowsRef.current = reconciled
+    return reconciled
+  }, [session.messages])
   const showTypingIndicator =
     isWorking && !messages.some((message) => message.id === NATIVE_CHAT_STREAMING_ID)
 
@@ -406,6 +427,7 @@ export function NativeChatMessageList({
               expandSignal={expandSignal}
               onScrollMessageToTop={scrollMessageToTop}
               onLinkClick={onLinkClick}
+              filePathSpans={filePathSpans}
               allowFileUriLinks={allowFileUriLinks}
               deliveryFailed={failedDeliveryMessageIds?.has(message.id) === true}
             />

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
@@ -97,7 +97,6 @@ export function NativeChatToolRun({
   const [showAll, setShowAll] = useState(false)
   // Re-sync when the global toolbar toggle flips.
   useEffect(() => setOpen(expandSignal), [expandSignal])
-  useEffect(() => setShowAll(false), [blocks])
 
   const visibleBlocks =
     showAll || blocks.length <= MAX_VISIBLE_TOOL_LINES

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
@@ -1,22 +1,13 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ChevronRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
-import {
-  isToolCallBlock,
-  isToolResultBlock,
-  type NativeChatBlock
-} from '../../../../shared/native-chat-types'
-import { diffFromText, diffFromToolCall, type DiffLine } from './native-chat-diff'
-import {
-  countToolCalls,
-  formatToolInput,
-  summarizeToolInput,
-  summarizeToolRun
-} from './native-chat-tool-summary'
+import type { NativeChatBlock } from '../../../../shared/native-chat-types'
+import { countToolCalls, summarizeToolRun } from './native-chat-tool-summary'
+import { deriveToolLine } from './native-chat-tool-line'
 import { NativeChatDiffView } from './NativeChatDiffView'
 
-const MAX_TOOL_RESULT_CHARS = 4000
+const MAX_VISIBLE_TOOL_LINES = 24
 
 /** A single inline tool line — `▸ ToolName  preview` — that expands in place to
  *  show the call's diff/input or the result's body. Tool calls read as flat
@@ -25,32 +16,12 @@ const MAX_TOOL_RESULT_CHARS = 4000
  *  reveals every line at once) and is then individually collapsible. */
 function ToolLine({ block }: { block: NativeChatBlock }): React.JSX.Element | null {
   const [expanded, setExpanded] = useState(true)
+  const model = useMemo(() => deriveToolLine(block), [block])
 
-  let name: string
-  let preview: string
-  let diff: DiffLine[] | null = null
-  let body: { output: string; isError?: boolean } | null = null
-  // Full, formatted input shown when a diff-less tool call is expanded.
-  let detail: string | null = null
-
-  if (isToolCallBlock(block)) {
-    name = block.name
-    preview = summarizeToolInput(block.input)
-    diff = diffFromToolCall(block.name, block.input)
-    detail = diff ? null : formatToolInput(block.input)
-  } else if (isToolResultBlock(block)) {
-    name = translate('components.native-chat.tool.result', 'Result')
-    preview = block.output.split('\n')[0]?.slice(0, 80) ?? ''
-    diff = diffFromText(block.output)
-    body = { output: block.output, isError: block.isError }
-  } else {
+  if (!model) {
     return null
   }
-
-  // Only offer expansion when there's more than the inline preview already shows —
-  // avoids re-rendering the same truncated string in a box below it.
-  const detailAddsInfo = detail !== null && detail.replace(/\s+/g, ' ').trim() !== preview
-  const hasDetail = diff !== null || body !== null || detailAddsInfo
+  const { name, preview, diff, body, detail, hasDetail } = model
 
   return (
     <div>
@@ -94,16 +65,12 @@ function ToolLine({ block }: { block: NativeChatBlock }): React.JSX.Element | nu
                 body.isError ? 'text-destructive' : 'text-foreground/80'
               )}
             >
-              {body.output.length > MAX_TOOL_RESULT_CHARS
-                ? `${body.output.slice(0, MAX_TOOL_RESULT_CHARS)}…`
-                : body.output}
+              {body.output}
             </pre>
           ) : null}
           {!diff && !body && detail ? (
             <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-accent p-2 font-mono text-[11px] text-foreground/80 scrollbar-sleek">
-              {detail.length > MAX_TOOL_RESULT_CHARS
-                ? `${detail.slice(0, MAX_TOOL_RESULT_CHARS)}…`
-                : detail}
+              {detail}
             </pre>
           ) : null}
         </div>
@@ -124,8 +91,19 @@ export function NativeChatToolRun({
   expandSignal: boolean
 }): React.JSX.Element {
   const [open, setOpen] = useState(expandSignal)
+  // A long run mounts every line at once, and each line carries a diff or a
+  // formatted input — so cap the initial reveal and let the user ask for the
+  // rest. Mobile caps the equivalent at MAX_VISIBLE_TOOL_PAIRS.
+  const [showAll, setShowAll] = useState(false)
   // Re-sync when the global toolbar toggle flips.
   useEffect(() => setOpen(expandSignal), [expandSignal])
+  useEffect(() => setShowAll(false), [blocks])
+
+  const visibleBlocks =
+    showAll || blocks.length <= MAX_VISIBLE_TOOL_LINES
+      ? blocks
+      : blocks.slice(0, MAX_VISIBLE_TOOL_LINES)
+  const hiddenCount = blocks.length - visibleBlocks.length
 
   const callCount = countToolCalls(blocks) || blocks.length
   const summary = summarizeToolRun(blocks)
@@ -162,9 +140,18 @@ export function NativeChatToolRun({
       </button>
       {open ? (
         <div className="mt-1">
-          {blocks.map((block, i) => (
+          {visibleBlocks.map((block, i) => (
             <ToolLine key={i} block={block} />
           ))}
+          {hiddenCount > 0 ? (
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="py-0.5 font-mono text-[11px] text-muted-foreground transition-colors hover:text-foreground/80"
+            >
+              {translate('components.native-chat.tool.showAllLines', 'Show all lines')}
+            </button>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -51,7 +51,14 @@ import type { NativeChatContextMenuActions } from './use-native-chat-context-men
 import { resolveNativeChatFileLinkContext } from './native-chat-file-link'
 import { selectNativeChatRuntimeEnvironmentId } from './native-chat-runtime-owner'
 import { useNativeChatPasteBridge } from './use-native-chat-paste-bridge'
-import { useNativeChatFileLinkClick } from './use-native-chat-file-link-click'
+import {
+  useNativeChatFilePathSpans,
+  useNativeChatFileLinkClick
+} from './use-native-chat-file-link-click'
+import { useThrottledLatestValue } from './use-throttled-latest-value'
+
+// Matches mobile's NATIVE_CHAT_STREAM_THROTTLE_MS and VS Code's chat tick.
+const NATIVE_CHAT_STREAM_THROTTLE_MS = 50
 import type { NativeChatViewProps } from './native-chat-view-types'
 
 export type { NativeChatViewProps } from './native-chat-view-types'
@@ -155,7 +162,11 @@ function NativeChatResolvedView({
   const liveWorking = session.status === 'working'
   // The agent's in-progress reply preview (hook), shown as a live streaming
   // bubble while it works — before the completed turn flushes to the transcript.
-  const hookPreview = useAppStore((s) => s.agentStatusByPaneKey[paneKey]?.lastAssistantMessage)
+  const rawHookPreview = useAppStore((s) => s.agentStatusByPaneKey[paneKey]?.lastAssistantMessage)
+  // Providers publish a frame per streamed part; each one re-projects the whole
+  // transcript window. Mobile has always throttled this; desktop had no
+  // renderer-side limit at all.
+  const hookPreview = useThrottledLatestValue(rawHookPreview, NATIVE_CHAT_STREAM_THROTTLE_MS)
   // Why: Stop suppression must clear on a newer working epoch even when status
   // never leaves 'working' (interrupt + immediate next turn coalesced).
   const hookWorkingEpoch = useAppStore(
@@ -363,6 +374,7 @@ function NativeChatResolvedView({
     interactiveSend.cancel()
   }, [interactiveSend, pendingScope])
   const nativeChatFileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
+  const nativeChatFilePathSpans = useNativeChatFilePathSpans(fileLinkContext)
 
   // Chat-only font zoom via Cmd/Ctrl +/-/0, gated to the live conversation so
   // the chord is inert on the loading/empty/error states and elsewhere.
@@ -419,6 +431,7 @@ function NativeChatResolvedView({
             expandSignal={false}
             fontScale={fontScale.scale}
             onLinkClick={nativeChatFileLinkClick}
+            filePathSpans={nativeChatFilePathSpans}
             allowFileUriLinks={fileLinkContext !== null}
             failedDeliveryMessageIds={failedLaunchPromptMessageIds}
           />

--- a/src/renderer/src/components/native-chat/native-chat-live-session-subscription.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-session-subscription.ts
@@ -1,0 +1,62 @@
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { NativeChatSessionTransport } from './native-chat-session-transport'
+
+export function scheduleNativeChatRetry(
+  callback: () => void,
+  delayMs: number
+): ReturnType<typeof setTimeout> {
+  return setTimeout(callback, delayMs)
+}
+
+export function subscribeNativeChatTransport(
+  transport: NativeChatSessionTransport,
+  args: Parameters<NativeChatSessionTransport['subscribe']>[0],
+  onFrame: Parameters<NativeChatSessionTransport['subscribe']>[1]
+): ReturnType<NativeChatSessionTransport['subscribe']> {
+  return transport.subscribe(args, onFrame)
+}
+
+/** True when `whole`'s first `len` entries are referentially identical to `prefix` (a tail-extension), so the assembler can splice just the suffix. */
+export function nativeChatMessagesSharePrefix(
+  whole: readonly NativeChatMessage[],
+  prefix: readonly NativeChatMessage[],
+  len: number
+): boolean {
+  for (let i = 0; i < len; i += 1) {
+    if (whole[i] !== prefix[i]) {
+      return false
+    }
+  }
+  return true
+}
+
+let subscriptionCounter = 0
+
+export function nextNativeChatSubscriptionId(): string {
+  subscriptionCounter += 1
+  return `native-chat-${subscriptionCounter}-${Date.now()}`
+}
+
+// Why: a new session's transcript can take minutes to appear on disk (#8401); a `notFound` miss retries with backoff until the window below elapses.
+const NOTFOUND_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000]
+const NOTFOUND_RETRY_FIXED_DELAY_MS = 10_000
+export const NOTFOUND_RETRY_WINDOW_MS = 60_000
+
+export function notFoundRetryDelayMs(attempt: number): number {
+  return NOTFOUND_RETRY_DELAYS_MS[attempt] ?? NOTFOUND_RETRY_FIXED_DELAY_MS
+}
+
+/** Web RPC bridge returns a Promise (not the desktop sync unsubscribe fn); calling it as a function crashed the view, so resolve first. */
+export function closeNativeChatSubscription(unsubscribe: unknown): void {
+  if (typeof unsubscribe === 'function') {
+    ;(unsubscribe as () => void)()
+    return
+  }
+  if (unsubscribe && typeof (unsubscribe as { then?: unknown }).then === 'function') {
+    void (unsubscribe as Promise<unknown>).then((fn) => {
+      if (typeof fn === 'function') {
+        ;(fn as () => void)()
+      }
+    })
+  }
+}

--- a/src/renderer/src/components/native-chat/native-chat-pagination.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pagination.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
+  canGrowNativeChatWindow,
   hasMoreNativeChatHistory,
   NATIVE_CHAT_INITIAL_LIMIT,
+  NATIVE_CHAT_MAX_LIMIT,
   NATIVE_CHAT_PAGE,
   nextNativeChatLimit
 } from './native-chat-pagination'
@@ -14,6 +16,13 @@ describe('nextNativeChatLimit', () => {
     expect(nextNativeChatLimit(NATIVE_CHAT_INITIAL_LIMIT + NATIVE_CHAT_PAGE)).toBe(
       NATIVE_CHAT_INITIAL_LIMIT + 2 * NATIVE_CHAT_PAGE
     )
+  })
+
+  it('stops growing at the transcript window ceiling', () => {
+    expect(nextNativeChatLimit(NATIVE_CHAT_MAX_LIMIT - 100)).toBe(NATIVE_CHAT_MAX_LIMIT)
+    expect(nextNativeChatLimit(NATIVE_CHAT_MAX_LIMIT)).toBe(NATIVE_CHAT_MAX_LIMIT)
+    expect(canGrowNativeChatWindow(NATIVE_CHAT_MAX_LIMIT - 1)).toBe(true)
+    expect(canGrowNativeChatWindow(NATIVE_CHAT_MAX_LIMIT)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pagination.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pagination.ts
@@ -8,9 +8,20 @@
 export const NATIVE_CHAT_INITIAL_LIMIT = 300
 export const NATIVE_CHAT_PAGE = 200
 
+// The window is not virtualized, so every loaded turn stays live DOM. Cap the
+// growth the way mobile does (MAX_MESSAGES) rather than letting repeated
+// load-earlier clicks grow it without bound. Raise or drop this once the
+// transcript is virtualized.
+export const NATIVE_CHAT_MAX_LIMIT = 2000
+
 /** The limit to request for the next older page. */
 export function nextNativeChatLimit(currentLimit: number): number {
-  return currentLimit + NATIVE_CHAT_PAGE
+  return Math.min(currentLimit + NATIVE_CHAT_PAGE, NATIVE_CHAT_MAX_LIMIT)
+}
+
+/** Whether the window can still grow; at the ceiling, stop offering "load earlier". */
+export function canGrowNativeChatWindow(currentLimit: number): boolean {
+  return currentLimit < NATIVE_CHAT_MAX_LIMIT
 }
 
 /** Whether an older page may still exist: the last read filled the window, so

--- a/src/renderer/src/components/native-chat/native-chat-row-identity.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-row-identity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { reconcileNativeChatRowIdentity } from './native-chat-row-identity'
+import type { NativeChatBlock, NativeChatMessage } from '../../../../shared/native-chat-types'
+
+const text = (value: string): NativeChatBlock => ({ type: 'text', text: value })
+
+const message = (
+  id: string,
+  blocks: NativeChatBlock[],
+  role: NativeChatMessage['role'] = 'assistant'
+): NativeChatMessage => ({ id, role, blocks, timestamp: 0, source: 'transcript' })
+
+describe('reconcileNativeChatRowIdentity', () => {
+  it('returns next as-is on the first frame', () => {
+    const next = [message('a', [text('hi')])]
+    expect(reconcileNativeChatRowIdentity(next, null)).toBe(next)
+  })
+
+  it('returns the previous array when nothing changed', () => {
+    const blocks = [text('hi')]
+    const previous = [message('a', blocks)]
+    // A fresh projection: new message objects and a new array, same content.
+    const next = [message('a', [...blocks])]
+    expect(reconcileNativeChatRowIdentity(next, previous)).toBe(previous)
+  })
+
+  it('reuses unchanged row objects when a later row changes', () => {
+    const stableBlocks = [text('settled')]
+    const previous = [message('a', stableBlocks), message('b', [text('old')])]
+    const next = [message('a', [...stableBlocks]), message('b', [text('new')])]
+
+    const result = reconcileNativeChatRowIdentity(next, previous)
+    // This is the property MessageRow's memo depends on.
+    expect(result[0]).toBe(previous[0])
+    expect(result[1]).toBe(next[1])
+  })
+
+  it('treats an appended block as a change', () => {
+    const previous = [message('a', [text('one')])]
+    const appended = [text('one'), text('two')]
+    const next = [message('a', appended)]
+    expect(reconcileNativeChatRowIdentity(next, previous)[0]).toBe(next[0])
+  })
+
+  it('treats a replaced block object as a change even at equal length', () => {
+    // foldToolMessages clones the blocks array; a genuinely new block object
+    // must still invalidate.
+    const previous = [message('a', [text('one')])]
+    const next = [message('a', [text('changed')])]
+    expect(reconcileNativeChatRowIdentity(next, previous)[0]).toBe(next[0])
+  })
+
+  it('treats a role change as a change', () => {
+    const blocks = [text('hi')]
+    const previous = [message('a', blocks, 'assistant')]
+    const next = [message('a', blocks, 'user')]
+    expect(reconcileNativeChatRowIdentity(next, previous)[0]).toBe(next[0])
+  })
+
+  it('reuses the stable prefix when a row is appended', () => {
+    const blocks = [text('hi')]
+    const previous = [message('a', blocks)]
+    const next = [message('a', [...blocks]), message('b', [text('new')])]
+
+    const result = reconcileNativeChatRowIdentity(next, previous)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toBe(previous[0])
+  })
+
+  it('does not reuse across a differing id at the same index', () => {
+    const blocks = [text('hi')]
+    const previous = [message('a', blocks)]
+    const next = [message('z', [...blocks])]
+    expect(reconcileNativeChatRowIdentity(next, previous)[0]).toBe(next[0])
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-row-identity.ts
+++ b/src/renderer/src/components/native-chat/native-chat-row-identity.ts
@@ -1,0 +1,55 @@
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+
+// Keep object identity stable across streaming frames for rows that did not
+// change.
+//
+// Why this is needed: the projection pipeline mints a fresh array every frame
+// (sessionWithPending rebuilds session.messages), and foldToolMessages clones
+// any assistant turn that absorbed tool calls as `{...previous, blocks: [...]}`.
+// Both are correct, but they hand React a new object for a row whose content is
+// identical — so React.memo on the row and the per-row splitNativeChatBlocks memo
+// both miss, for nearly every assistant turn. Reconciling against the previous
+// frame restores the identity those memos key on.
+
+function sameBlocks(a: NativeChatMessage, b: NativeChatMessage): boolean {
+  if (a.blocks === b.blocks) {
+    return true
+  }
+  if (a.blocks.length !== b.blocks.length) {
+    return false
+  }
+  // Blocks themselves are never mutated in place — a changed block is a new
+  // object — so reference equality per element is a sound content check.
+  return a.blocks.every((block, index) => block === b.blocks[index])
+}
+
+function sameRow(a: NativeChatMessage, b: NativeChatMessage): boolean {
+  return a.id === b.id && a.role === b.role && sameBlocks(a, b)
+}
+
+/**
+ * Return `next`, with each row replaced by the corresponding row from
+ * `previous` when the two are equivalent. Returns `previous` itself when every
+ * row matched and the lengths agree, so an unchanged frame produces no new
+ * array either.
+ */
+export function reconcileNativeChatRowIdentity(
+  next: NativeChatMessage[],
+  previous: NativeChatMessage[] | null
+): NativeChatMessage[] {
+  if (!previous) {
+    return next
+  }
+  // Rows are appended and folded at the tail, so index alignment holds for the
+  // stable prefix; a shifted window simply misses and re-renders once.
+  let changed = next.length !== previous.length
+  const reconciled = next.map((row, index) => {
+    const prior = previous[index]
+    if (prior && sameRow(row, prior)) {
+      return prior
+    }
+    changed = true
+    return row
+  })
+  return changed ? reconciled : previous
+}

--- a/src/renderer/src/components/native-chat/native-chat-tool-line.ts
+++ b/src/renderer/src/components/native-chat/native-chat-tool-line.ts
@@ -1,0 +1,62 @@
+import { translate } from '@/i18n/i18n'
+import {
+  isToolCallBlock,
+  isToolResultBlock,
+  type NativeChatBlock
+} from '../../../../shared/native-chat-types'
+import { diffFromText, diffFromToolCall, type DiffLine } from './native-chat-diff'
+import { formatToolInput, summarizeToolInput } from './native-chat-tool-summary'
+
+// Pure derivation for one tool line, split out of the component so the
+// expensive parts run once per block instead of on every parent render.
+// formatToolInput is JSON.stringify over an unbounded tool input, and during
+// streaming the parent re-renders every frame.
+
+export const MAX_TOOL_RESULT_CHARS = 4000
+
+export type ToolLineModel = {
+  name: string
+  preview: string
+  diff: DiffLine[] | null
+  body: { output: string; isError?: boolean } | null
+  /** Formatted input for a diff-less call, already truncated for display. */
+  detail: string | null
+  /** Whether expanding shows anything the inline preview does not already. */
+  hasDetail: boolean
+}
+
+function truncateForDisplay(value: string): string {
+  return value.length > MAX_TOOL_RESULT_CHARS ? `${value.slice(0, MAX_TOOL_RESULT_CHARS)}…` : value
+}
+
+export function deriveToolLine(block: NativeChatBlock): ToolLineModel | null {
+  if (isToolCallBlock(block)) {
+    const preview = summarizeToolInput(block.input)
+    const diff = diffFromToolCall(block.name, block.input)
+    const detail = diff ? null : formatToolInput(block.input)
+    // Compared before truncation so a long input that merely repeats the preview
+    // still reads as "nothing more to show".
+    const detailAddsInfo = detail !== null && detail.replace(/\s+/g, ' ').trim() !== preview
+    return {
+      name: block.name,
+      preview,
+      diff,
+      body: null,
+      detail: detail === null ? null : truncateForDisplay(detail),
+      hasDetail: diff !== null || detailAddsInfo
+    }
+  }
+
+  if (isToolResultBlock(block)) {
+    return {
+      name: translate('components.native-chat.tool.result', 'Result'),
+      preview: block.output.split('\n')[0]?.slice(0, 80) ?? '',
+      diff: diffFromText(block.output),
+      body: { output: truncateForDisplay(block.output), isError: block.isError },
+      detail: null,
+      hasDetail: true
+    }
+  }
+
+  return null
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-file-link-click.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-file-link-click.ts
@@ -1,27 +1,95 @@
-import { useCallback } from 'react'
-import type { CommentMarkdownLinkClickHandler } from '@/components/sidebar/CommentMarkdown'
+import { useCallback, useMemo } from 'react'
+import { toast } from 'sonner'
+import type {
+  CommentMarkdownFilePathSpans,
+  CommentMarkdownLinkClickHandler
+} from '@/components/sidebar/CommentMarkdown'
 import { openDetectedFilePath } from '@/components/terminal-pane/terminal-file-open-routing'
+import { isFilePathCodeSpan } from '@/lib/file-path-code-span'
+import { isPathInsideWorktree } from '@/lib/terminal-links'
+import { translate } from '@/i18n/i18n'
 import { resolveNativeChatFileLink, type NativeChatFileLinkContext } from './native-chat-file-link'
+
+// Why: chat text is agent-authored and can carry injected content, so a click
+// must not reach openDetectedFilePath's ambient self-grant
+// (src/main/ipc/filesystem-auth.ts authorizes any path it is handed). Confining
+// chat opens to the worktree keeps a crafted message from opening ~/.ssh/id_rsa.
+function openWorktreeFileLink(
+  href: string | undefined,
+  context: NativeChatFileLinkContext,
+  options: { openWithSystemDefault: boolean; reportFailure: boolean }
+): boolean {
+  const target = resolveNativeChatFileLink(href, context)
+  if (!target) {
+    if (options.reportFailure) {
+      toast.error(
+        translate('components.native-chat.fileLinkUnresolved', 'Could not resolve that file path')
+      )
+    }
+    return false
+  }
+  if (!isPathInsideWorktree(target.absolutePath, context.worktreePath)) {
+    toast.error(
+      translate(
+        'components.native-chat.fileLinkOutsideWorktree',
+        'That file is outside the workspace'
+      )
+    )
+    return true
+  }
+  openDetectedFilePath(target.absolutePath, target.line, target.column, {
+    worktreeId: context.worktreeId,
+    worktreePath: context.worktreePath,
+    runtimeEnvironmentId: context.runtimeEnvironmentId,
+    openWithSystemDefault: options.openWithSystemDefault
+  })
+  return true
+}
 
 export function useNativeChatFileLinkClick(
   context: NativeChatFileLinkContext | null
 ): CommentMarkdownLinkClickHandler | undefined {
   const openFileLink = useCallback<CommentMarkdownLinkClickHandler>(
     (event, href) => {
-      const target = resolveNativeChatFileLink(href, context)
-      if (!target || !context) {
+      if (!context) {
+        return
+      }
+      // A non-file href (http, mailto) resolves to null here and must fall
+      // through to the anchor's default handling, so it reports no failure.
+      const claimed = openWorktreeFileLink(href, context, {
+        openWithSystemDefault: event.shiftKey,
+        reportFailure: false
+      })
+      if (!claimed) {
         return
       }
       event.preventDefault()
       event.stopPropagation()
-      openDetectedFilePath(target.absolutePath, target.line, target.column, {
-        worktreeId: context.worktreeId,
-        worktreePath: context.worktreePath,
-        runtimeEnvironmentId: context.runtimeEnvironmentId,
-        openWithSystemDefault: event.shiftKey
-      })
     },
     [context]
   )
   return context ? openFileLink : undefined
+}
+
+export function useNativeChatFilePathSpans(
+  context: NativeChatFileLinkContext | null
+): CommentMarkdownFilePathSpans | undefined {
+  const onOpen = useCallback<CommentMarkdownFilePathSpans['onOpen']>(
+    (event, pathText) => {
+      if (!context) {
+        return
+      }
+      // The span was already classified as a path, so a miss here is a real
+      // failure worth surfacing rather than a silent no-op.
+      openWorktreeFileLink(pathText, context, {
+        openWithSystemDefault: event.shiftKey,
+        reportFailure: true
+      })
+    },
+    [context]
+  )
+  return useMemo(
+    () => (context ? { isFilePath: isFilePathCodeSpan, onOpen } : undefined),
+    [context, onOpen]
+  )
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-file-link-click.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-file-link-click.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
 import type {
   CommentMarkdownFilePathSpans,
@@ -6,49 +6,101 @@ import type {
 } from '@/components/sidebar/CommentMarkdown'
 import { openDetectedFilePath } from '@/components/terminal-pane/terminal-file-open-routing'
 import { isFilePathCodeSpan } from '@/lib/file-path-code-span'
-import { isPathInsideWorktree } from '@/lib/terminal-links'
 import { translate } from '@/i18n/i18n'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import type { RuntimeTerminalPathResolution } from '../../../../shared/runtime-types'
 import { resolveNativeChatFileLink, type NativeChatFileLinkContext } from './native-chat-file-link'
+
+let latestNativeChatFileOpenRequestId = 0
 
 // Why: chat text is agent-authored and can carry injected content, so a click
 // must not reach openDetectedFilePath's ambient self-grant
 // (src/main/ipc/filesystem-auth.ts authorizes any path it is handed). Confining
 // chat opens to the worktree keeps a crafted message from opening ~/.ssh/id_rsa.
-function openWorktreeFileLink(
+async function openResolvedWorktreeFileLink(
+  absolutePath: string,
+  line: number | null,
+  column: number | null,
+  context: NativeChatFileLinkContext,
+  isCurrent: () => boolean
+): Promise<boolean> {
+  const resolved = await callRuntimeRpc<RuntimeTerminalPathResolution>(
+    context.runtimeEnvironmentId
+      ? { kind: 'environment', environmentId: context.runtimeEnvironmentId }
+      : { kind: 'local' },
+    'files.resolveTerminalPath',
+    {
+      worktree: `id:${context.worktreeId}`,
+      pathText: absolutePath
+    },
+    { timeoutMs: 10_000 }
+  )
+  if (
+    !isCurrent() ||
+    !resolved.exists ||
+    resolved.isDirectory ||
+    resolved.openTarget?.kind !== 'worktree-file'
+  ) {
+    return false
+  }
+  openDetectedFilePath(resolved.openTarget.absolutePath, line, column, {
+    worktreeId: context.worktreeId,
+    worktreePath: context.worktreePath,
+    runtimeEnvironmentId: context.runtimeEnvironmentId,
+    openWithSystemDefault: false,
+    allowExternalPaths: false,
+    openHtmlInBrowser: false
+  })
+  return true
+}
+
+function claimWorktreeFileLink(
   href: string | undefined,
   context: NativeChatFileLinkContext,
-  options: { openWithSystemDefault: boolean; reportFailure: boolean }
+  options: { reportUnclaimed: boolean; isCurrent: () => boolean }
 ): boolean {
   const target = resolveNativeChatFileLink(href, context)
   if (!target) {
-    if (options.reportFailure) {
+    if (options.reportUnclaimed) {
       toast.error(
         translate('components.native-chat.fileLinkUnresolved', 'Could not resolve that file path')
       )
     }
     return false
   }
-  if (!isPathInsideWorktree(target.absolutePath, context.worktreePath)) {
-    toast.error(
-      translate(
-        'components.native-chat.fileLinkOutsideWorktree',
-        'That file is outside the workspace'
-      )
-    )
-    return true
-  }
-  openDetectedFilePath(target.absolutePath, target.line, target.column, {
-    worktreeId: context.worktreeId,
-    worktreePath: context.worktreePath,
-    runtimeEnvironmentId: context.runtimeEnvironmentId,
-    openWithSystemDefault: options.openWithSystemDefault
-  })
+  void openResolvedWorktreeFileLink(
+    target.absolutePath,
+    target.line,
+    target.column,
+    context,
+    options.isCurrent
+  )
+    .then((opened) => {
+      if (!opened && options.isCurrent()) {
+        toast.error(
+          translate('components.native-chat.fileLinkUnresolved', 'Could not resolve that file path')
+        )
+      }
+    })
+    .catch(() => {
+      if (options.isCurrent()) {
+        toast.error(
+          translate('components.native-chat.fileLinkUnresolved', 'Could not resolve that file path')
+        )
+      }
+    })
   return true
 }
 
 export function useNativeChatFileLinkClick(
   context: NativeChatFileLinkContext | null
 ): CommentMarkdownLinkClickHandler | undefined {
+  useEffect(
+    () => () => {
+      latestNativeChatFileOpenRequestId += 1
+    },
+    [context]
+  )
   const openFileLink = useCallback<CommentMarkdownLinkClickHandler>(
     (event, href) => {
       if (!context) {
@@ -56,9 +108,10 @@ export function useNativeChatFileLinkClick(
       }
       // A non-file href (http, mailto) resolves to null here and must fall
       // through to the anchor's default handling, so it reports no failure.
-      const claimed = openWorktreeFileLink(href, context, {
-        openWithSystemDefault: event.shiftKey,
-        reportFailure: false
+      const requestSeq = ++latestNativeChatFileOpenRequestId
+      const claimed = claimWorktreeFileLink(href, context, {
+        reportUnclaimed: false,
+        isCurrent: () => latestNativeChatFileOpenRequestId === requestSeq
       })
       if (!claimed) {
         return
@@ -74,16 +127,23 @@ export function useNativeChatFileLinkClick(
 export function useNativeChatFilePathSpans(
   context: NativeChatFileLinkContext | null
 ): CommentMarkdownFilePathSpans | undefined {
+  useEffect(
+    () => () => {
+      latestNativeChatFileOpenRequestId += 1
+    },
+    [context]
+  )
   const onOpen = useCallback<CommentMarkdownFilePathSpans['onOpen']>(
-    (event, pathText) => {
+    (_event, pathText) => {
       if (!context) {
         return
       }
       // The span was already classified as a path, so a miss here is a real
       // failure worth surfacing rather than a silent no-op.
-      openWorktreeFileLink(pathText, context, {
-        openWithSystemDefault: event.shiftKey,
-        reportFailure: true
+      const requestSeq = ++latestNativeChatFileOpenRequestId
+      claimWorktreeFileLink(pathText, context, {
+        reportUnclaimed: true,
+        isCurrent: () => latestNativeChatFileOpenRequestId === requestSeq
       })
     },
     [context]

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -19,11 +19,21 @@ import { mergeNativeChatLiveSession } from './native-chat-live-status'
 import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
 import { surfaceSkillInvocationUserTurns } from '../../../../shared/native-chat-command-envelope'
 import {
+  canGrowNativeChatWindow,
   hasMoreNativeChatHistory,
   NATIVE_CHAT_INITIAL_LIMIT,
   nextNativeChatLimit
 } from './native-chat-pagination'
 import { getNativeChatSessionTransport } from './native-chat-session-transport'
+import {
+  closeNativeChatSubscription,
+  nativeChatMessagesSharePrefix,
+  nextNativeChatSubscriptionId,
+  NOTFOUND_RETRY_WINDOW_MS,
+  notFoundRetryDelayMs,
+  scheduleNativeChatRetry,
+  subscribeNativeChatTransport
+} from './native-chat-live-session-subscription'
 import { useNativeChatTranscriptLifecycle } from './use-native-chat-transcript-lifecycle'
 import { useNativeChatHookStatus } from './use-native-chat-hook-status'
 
@@ -55,36 +65,6 @@ export type NativeChatLiveSession = NativeChatSession & {
 
 // Stable empty-base reference so a non-ready read doesn't churn the base axis.
 const EMPTY_MESSAGES: readonly NativeChatMessage[] = []
-
-/** True when `whole`'s first `len` entries are referentially identical to `prefix` (a tail-extension), so the assembler can splice just the suffix. */
-function sharesPrefix(
-  whole: readonly NativeChatMessage[],
-  prefix: readonly NativeChatMessage[],
-  len: number
-): boolean {
-  for (let i = 0; i < len; i += 1) {
-    if (whole[i] !== prefix[i]) {
-      return false
-    }
-  }
-  return true
-}
-
-let subscriptionCounter = 0
-
-function nextSubscriptionId(): string {
-  subscriptionCounter += 1
-  return `native-chat-${subscriptionCounter}-${Date.now()}`
-}
-
-// Why: a new session's transcript can take minutes to appear on disk (#8401); a `notFound` miss retries with backoff until the window below elapses.
-const NOTFOUND_RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000]
-const NOTFOUND_RETRY_FIXED_DELAY_MS = 10_000
-const NOTFOUND_RETRY_WINDOW_MS = 60_000
-
-function notFoundRetryDelayMs(attempt: number): number {
-  return NOTFOUND_RETRY_DELAYS_MS[attempt] ?? NOTFOUND_RETRY_FIXED_DELAY_MS
-}
 
 export type ReadState =
   | { phase: 'loading' }
@@ -142,6 +122,7 @@ export function useNativeChatLiveSession(
   const baseMessagesRef = useRef<readonly NativeChatMessage[]>(EMPTY_MESSAGES)
 
   useEffect(() => {
+    let cancelled = false
     // Why: agent/path/owner rebinds can keep the same session; every source generation must invalidate pagination captured before it.
     transcriptEpochRef.current += 1
     setLoadingEarlier(false)
@@ -152,10 +133,11 @@ export function useNativeChatLiveSession(
       replaceList(appendMergerRef.current, [])
       setAppended([])
       setHasMore(false)
-      return
+      return () => {
+        cancelled = true
+      }
     }
 
-    let cancelled = false
     // Set by the first authoritative frame so the readSession seed below can't clobber a live snapshot.
     let frameArrived = false
     let retryTimer: ReturnType<typeof setTimeout> | null = null
@@ -182,7 +164,7 @@ export function useNativeChatLiveSession(
           if (result && 'error' in result) {
             // A not-yet-flushed transcript: stay in 'loading' and retry with backoff instead of a permanent error (#8401).
             if (result.notFound && Date.now() - retryStartedAt < NOTFOUND_RETRY_WINDOW_MS) {
-              retryTimer = setTimeout(() => {
+              retryTimer = scheduleNativeChatRetry(() => {
                 retryTimer = null
                 loadSession(attempt + 1)
               }, notFoundRetryDelayMs(attempt))
@@ -194,7 +176,10 @@ export function useNativeChatLiveSession(
           const messages = result?.messages ?? []
           transcriptLifecycleControl.replace(result?.lifecycle)
           setRead({ phase: 'ready', messages })
-          setHasMore(hasMoreNativeChatHistory(messages.length, limitRef.current))
+          setHasMore(
+            canGrowNativeChatWindow(limitRef.current) &&
+              hasMoreNativeChatHistory(messages.length, limitRef.current)
+          )
         })
         .catch((err: unknown) => {
           if (!cancelled && !frameArrived) {
@@ -205,8 +190,9 @@ export function useNativeChatLiveSession(
 
     loadSession(0)
 
-    const subscriptionId = nextSubscriptionId()
-    const unsubscribe = transport.subscribe(
+    const subscriptionId = nextNativeChatSubscriptionId()
+    const unsubscribe = subscribeNativeChatTransport(
+      transport,
       {
         subscriptionId,
         agent,
@@ -229,7 +215,7 @@ export function useNativeChatLiveSession(
             replaceList(appendMergerRef.current, frame.messages)
             setAppended([])
             setRead({ phase: 'ready', messages: appendMergerRef.current.list })
-            setHasMore(frame.hasMore)
+            setHasMore(canGrowNativeChatWindow(limitRef.current) && frame.hasMore)
             return
           }
           transcriptLifecycleControl.append(frame.lifecycle)
@@ -245,23 +231,19 @@ export function useNativeChatLiveSession(
         clearTimeout(retryTimer)
         retryTimer = null
       }
-      // Web RPC bridge returns a Promise (not the desktop sync unsubscribe fn); calling it as a function crashed the view, so resolve first.
-      const teardown = unsubscribe as unknown
-      if (typeof teardown === 'function') {
-        ;(teardown as () => void)()
-      } else if (teardown && typeof (teardown as { then?: unknown }).then === 'function') {
-        void (teardown as Promise<unknown>).then((fn) => {
-          if (typeof fn === 'function') {
-            ;(fn as () => void)()
-          }
-        })
-      }
+      closeNativeChatSubscription(unsubscribe)
     }
     // `transport` identity changes on an owner flip, re-running this effect to re-subscribe against the new host.
   }, [agent, sessionId, transcriptPath, transport, transcriptLifecycleControl])
 
   const loadEarlier = useCallback(() => {
-    if (!sessionId || loadingEarlier || !hasMore || read.phase !== 'ready') {
+    if (
+      !sessionId ||
+      loadingEarlier ||
+      !hasMore ||
+      !canGrowNativeChatWindow(limitRef.current) ||
+      read.phase !== 'ready'
+    ) {
       return
     }
     const nextLimit = nextNativeChatLimit(limitRef.current)
@@ -286,7 +268,10 @@ export function useNativeChatLiveSession(
         // Read results are an ordered tail: replace the base list so the older page prepends in order; live appends stay separate.
         setRead({ phase: 'ready', messages: result.messages })
         transcriptLifecycleControl.replaceFromPagination(result.lifecycle, lifecycleRevision)
-        setHasMore(hasMoreNativeChatHistory(result.messages.length, nextLimit))
+        setHasMore(
+          canGrowNativeChatWindow(nextLimit) &&
+            hasMoreNativeChatHistory(result.messages.length, nextLimit)
+        )
       })
       .catch(() => {
         // Swallow a rejected "load more" read: keep the already-loaded transcript intact rather than surface the rejection.
@@ -320,7 +305,7 @@ export function useNativeChatLiveSession(
     const isSuffixExtension =
       !baseChanged &&
       transcript.length >= applied.length &&
-      sharesPrefix(transcript, applied, applied.length)
+      nativeChatMessagesSharePrefix(transcript, applied, applied.length)
 
     let out: NativeChatMessage[]
     if (isSuffixExtension && transcript.length > applied.length) {

--- a/src/renderer/src/components/native-chat/use-throttled-latest-value.ts
+++ b/src/renderer/src/components/native-chat/use-throttled-latest-value.ts
@@ -1,57 +1,13 @@
-import { useEffect, useRef, useState } from 'react'
+import { useDeferredValue } from 'react'
 
-/** Rate-limits a rapidly-changing value to at most one emit per `intervalMs`
- *  while always surfacing the latest value. OpenCode publishes a streaming
- *  assistant frame per part; unthrottled, every frame re-projects the whole
- *  transcript window.
+/** Defers rapidly-changing stream frames so React can coalesce intermediate
+ *  values instead of re-projecting the transcript for every provider part.
  *
  *  Mirrors mobile/src/session/use-throttled-latest-value.ts. Kept duplicated
  *  rather than hoisted: src/shared has zero React imports by design (it is
  *  loaded by main, cli and relay), so a hook cannot live there. */
-export function useThrottledLatestValue<T>(value: T, intervalMs: number): T {
-  const [throttled, setThrottled] = useState(value)
-  const valueRef = useRef(value)
-  valueRef.current = value
-  const lastEmitRef = useRef(0)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => {
-    if (value == null) {
-      // Turn ended: drop any trailing emit and reset so the next stream's first
-      // frame shows at once instead of the stale bubble lingering.
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-      lastEmitRef.current = 0
-      setThrottled(value)
-      return
-    }
-    const elapsed = Date.now() - lastEmitRef.current
-    if (elapsed >= intervalMs) {
-      lastEmitRef.current = Date.now()
-      setThrottled(value)
-      return
-    }
-    if (timerRef.current) {
-      return
-    }
-    timerRef.current = setTimeout(() => {
-      timerRef.current = null
-      lastEmitRef.current = Date.now()
-      setThrottled(valueRef.current)
-    }, intervalMs - elapsed)
-  }, [value, intervalMs])
-
-  useEffect(
-    () => () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-    },
-    []
-  )
-
-  return throttled
+export function useThrottledLatestValue<T>(value: T, _intervalMs: number): T {
+  const deferred = useDeferredValue(value)
+  // A completed turn must retire its streaming bubble synchronously.
+  return value == null ? value : deferred
 }

--- a/src/renderer/src/components/native-chat/use-throttled-latest-value.ts
+++ b/src/renderer/src/components/native-chat/use-throttled-latest-value.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react'
+
+/** Rate-limits a rapidly-changing value to at most one emit per `intervalMs`
+ *  while always surfacing the latest value. OpenCode publishes a streaming
+ *  assistant frame per part; unthrottled, every frame re-projects the whole
+ *  transcript window.
+ *
+ *  Mirrors mobile/src/session/use-throttled-latest-value.ts. Kept duplicated
+ *  rather than hoisted: src/shared has zero React imports by design (it is
+ *  loaded by main, cli and relay), so a hook cannot live there. */
+export function useThrottledLatestValue<T>(value: T, intervalMs: number): T {
+  const [throttled, setThrottled] = useState(value)
+  const valueRef = useRef(value)
+  valueRef.current = value
+  const lastEmitRef = useRef(0)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (value == null) {
+      // Turn ended: drop any trailing emit and reset so the next stream's first
+      // frame shows at once instead of the stale bubble lingering.
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      lastEmitRef.current = 0
+      setThrottled(value)
+      return
+    }
+    const elapsed = Date.now() - lastEmitRef.current
+    if (elapsed >= intervalMs) {
+      lastEmitRef.current = Date.now()
+      setThrottled(value)
+      return
+    }
+    if (timerRef.current) {
+      return
+    }
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      lastEmitRef.current = Date.now()
+      setThrottled(valueRef.current)
+    }, intervalMs - elapsed)
+  }, [value, intervalMs])
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    },
+    []
+  )
+
+  return throttled
+}

--- a/src/renderer/src/components/sidebar/CommentMarkdown.file-path-span.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.file-path-span.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CommentMarkdown, { type CommentMarkdownFilePathSpans } from './CommentMarkdown'
+import { isFilePathCodeSpan } from '@/lib/file-path-code-span'
+
+describe('CommentMarkdown inline-code file paths', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+
+  const render = (content: string, spans?: CommentMarkdownFilePathSpans): void => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root?.render(<CommentMarkdown variant="document" content={content} filePathSpans={spans} />)
+    })
+  }
+
+  const spansWith = (onOpen: CommentMarkdownFilePathSpans['onOpen']) => ({
+    isFilePath: isFilePathCodeSpan,
+    onOpen
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    root = null
+    container = null
+  })
+
+  it('renders an inline-code path as an activatable button', () => {
+    const onOpen = vi.fn()
+    render('see `docs/guide.md` for details', spansWith(onOpen))
+
+    const button = container?.querySelector('button')
+    expect(button).not.toBeNull()
+    expect(button?.textContent).toBe('docs/guide.md')
+
+    act(() => {
+      button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onOpen.mock.calls[0]?.[1]).toBe('docs/guide.md')
+  })
+
+  it('leaves a fenced code block inert', () => {
+    // react-markdown routes fenced and inline code through the same slot, so a
+    // bare fence whose only line is a path must not become a button.
+    const onOpen = vi.fn()
+    render('```\ndocs/guide.md\n```', spansWith(onOpen))
+
+    expect(container?.querySelector('pre')).not.toBeNull()
+    expect(container?.querySelector('button')).toBeNull()
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('leaves a language-tagged fenced block inert', () => {
+    const onOpen = vi.fn()
+    render('```sh\ndocs/guide.md\n```', spansWith(onOpen))
+
+    expect(container?.querySelector('button')).toBeNull()
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it('leaves a non-path code span as plain code', () => {
+    const onOpen = vi.fn()
+    render('run `npm run build` first', spansWith(onOpen))
+
+    expect(container?.querySelector('button')).toBeNull()
+    expect(container?.querySelector('code')?.textContent).toBe('npm run build')
+  })
+
+  it('renders plain code when no caller opts in', () => {
+    render('see `docs/guide.md` for details')
+
+    expect(container?.querySelector('button')).toBeNull()
+    expect(container?.querySelector('code')?.textContent).toBe('docs/guide.md')
+  })
+
+  describe('bare prose paths', () => {
+    it('linkifies an unbackticked path and claims the click', () => {
+      const onOpen = vi.fn()
+      render('Design doc written: docs/mobile-chat-file-path-links.md .', spansWith(onOpen))
+
+      const anchor = container?.querySelector('a')
+      expect(anchor?.textContent).toBe('docs/mobile-chat-file-path-links.md')
+
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+      act(() => {
+        anchor?.dispatchEvent(event)
+      })
+      expect(onOpen).toHaveBeenCalledTimes(1)
+      expect(onOpen.mock.calls[0]?.[1]).toBe('docs/mobile-chat-file-path-links.md')
+      // A file path is not a URL; letting the anchor navigate would be a bug.
+      expect(event.defaultPrevented).toBe(true)
+    })
+
+    it('does not linkify prose when no caller opts in', () => {
+      render('Design doc written: docs/guide.md .')
+
+      expect(container?.querySelector('a')).toBeNull()
+    })
+
+    it('leaves a real web link alone', () => {
+      const onOpen = vi.fn()
+      render('see https://example.com/docs/guide.md now', spansWith(onOpen))
+
+      const anchor = container?.querySelector('a')
+      expect(anchor?.getAttribute('href')).toBe('https://example.com/docs/guide.md')
+      expect(anchor?.getAttribute('target')).toBe('_blank')
+      expect(onOpen).not.toHaveBeenCalled()
+    })
+
+    it('does not linkify a version number', () => {
+      const onOpen = vi.fn()
+      render('upgraded to 1.2.3 and requires Node.js 20', spansWith(onOpen))
+
+      expect(container?.querySelector('a')).toBeNull()
+    })
+
+    it('leaves prose inside a fenced block alone', () => {
+      const onOpen = vi.fn()
+      render('```\nsee docs/guide.md here\n```', spansWith(onOpen))
+
+      expect(container?.querySelector('a')).toBeNull()
+      expect(container?.querySelector('pre')).not.toBeNull()
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/CommentMarkdown.file-path-span.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.file-path-span.test.tsx
@@ -48,6 +48,17 @@ describe('CommentMarkdown inline-code file paths', () => {
     expect(onOpen.mock.calls[0]?.[1]).toBe('docs/guide.md')
   })
 
+  it('keeps code-formatted authored links owned by their anchor', () => {
+    const onOpen = vi.fn()
+    render('[`docs/a.ts`](https://example.com)', spansWith(onOpen))
+
+    expect(container?.querySelector('button')).toBeNull()
+    const anchor = container?.querySelector('a')
+    expect(anchor?.getAttribute('href')).toBe('https://example.com')
+    expect(anchor?.querySelector('code')?.textContent).toBe('docs/a.ts')
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
   it('leaves a fenced code block inert', () => {
     // react-markdown routes fenced and inline code through the same slot, so a
     // bare fence whose only line is a path must not become a button.
@@ -129,6 +140,31 @@ describe('CommentMarkdown inline-code file paths', () => {
 
       expect(container?.querySelector('a')).toBeNull()
       expect(container?.querySelector('pre')).not.toBeNull()
+    })
+
+    it('leaves reference-link labels untouched', () => {
+      const onOpen = vi.fn()
+      render('[docs/a.ts][guide]\n\n[guide]: https://example.com', spansWith(onOpen))
+
+      const anchors = container?.querySelectorAll('a')
+      expect(anchors).toHaveLength(1)
+      expect(anchors?.[0]?.getAttribute('href')).toBe('https://example.com')
+      expect(anchors?.[0]?.textContent).toBe('docs/a.ts')
+      expect(onOpen).not.toHaveBeenCalled()
+    })
+
+    it('keeps Windows drive paths alive through markdown sanitization', () => {
+      const onOpen = vi.fn()
+      render(String.raw`Open C:\repo\src\app.ts`, spansWith(onOpen))
+
+      const anchor = container?.querySelector('a')
+      expect(anchor?.textContent).toBe(String.raw`C:\repo\src\app.ts`)
+      expect(anchor?.getAttribute('href')).toContain('C%3A')
+      act(() => {
+        anchor?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
+      })
+      expect(onOpen).toHaveBeenCalledOnce()
+      expect(onOpen.mock.calls[0]?.[1]).toContain('C%3A')
     })
   })
 })

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -5,16 +5,21 @@ import remarkBreaks from 'remark-breaks'
 import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import { cn } from '@/lib/utils'
+import { remarkFilePathLinks } from './remark-file-path-links'
 import {
   compactCommentMarkdownComponents,
   createCompactCommentMarkdownComponents,
   createDocumentCommentMarkdownComponents,
   documentCommentMarkdownComponents,
   isTrustedCompactImageSrc,
+  type CommentMarkdownFilePathSpans,
   type CommentMarkdownLinkClickHandler
 } from './comment-markdown-element-renderers'
 
-export type { CommentMarkdownLinkClickHandler } from './comment-markdown-element-renderers'
+export type {
+  CommentMarkdownFilePathSpans,
+  CommentMarkdownLinkClickHandler
+} from './comment-markdown-element-renderers'
 
 type MarkdownPlugins = NonNullable<React.ComponentProps<typeof Markdown>['rehypePlugins']>
 type UrlTransform = NonNullable<React.ComponentProps<typeof Markdown>['urlTransform']>
@@ -186,6 +191,9 @@ type CommentMarkdownProps = React.ComponentPropsWithoutRef<'div'> & {
   onLinkClick?: CommentMarkdownLinkClickHandler
   allowFileUriLinks?: boolean
   expandImages?: boolean
+  // Opt-in per call site: only native chat linkifies inline-code file paths, so
+  // the ~56 other CommentMarkdown call sites keep rendering them as plain code.
+  filePathSpans?: CommentMarkdownFilePathSpans
 }
 
 // Why forwardRef + rest props: Radix's HoverCardTrigger asChild merges a ref
@@ -201,12 +209,13 @@ const CommentMarkdown = React.memo(
       onLinkClick,
       allowFileUriLinks = false,
       expandImages = false,
+      filePathSpans,
       ...rest
     },
     ref
   ) {
     const components = React.useMemo(() => {
-      if (!onLinkClick) {
+      if (!onLinkClick && !filePathSpans) {
         return variant === 'document'
           ? documentCommentMarkdownComponents
           : expandImages
@@ -214,13 +223,16 @@ const CommentMarkdown = React.memo(
             : compactCommentMarkdownComponents
       }
       return variant === 'document'
-        ? createDocumentCommentMarkdownComponents(onLinkClick)
+        ? createDocumentCommentMarkdownComponents(onLinkClick, filePathSpans)
         : createCompactCommentMarkdownComponents(onLinkClick, expandImages)
-    }, [expandImages, variant, onLinkClick])
-    const activeRemarkPlugins = React.useMemo(
-      () => (githubRepo ? [...remarkPlugins, remarkGitHubReferences(githubRepo)] : remarkPlugins),
-      [githubRepo]
-    )
+    }, [expandImages, variant, onLinkClick, filePathSpans])
+    const activeRemarkPlugins = React.useMemo(() => {
+      const plugins = githubRepo
+        ? [...remarkPlugins, remarkGitHubReferences(githubRepo)]
+        : remarkPlugins
+      // Opt-in: only surfaces that pass filePathSpans linkify bare prose paths.
+      return filePathSpans ? [...plugins, remarkFilePathLinks()] : plugins
+    }, [githubRepo, filePathSpans])
 
     return (
       <div

--- a/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
@@ -11,8 +11,10 @@ import { ExpandableMarkdownImage } from './MarkdownImageLightbox'
 import {
   FencedCodeBoundary,
   FilePathCodeSpan,
+  LinkedCodeBoundary,
   readCodeSpanText,
   useIsFencedCode,
+  useIsLinkedCode,
   type CommentMarkdownFilePathSpans
 } from './comment-markdown-file-path-code-span'
 
@@ -31,7 +33,8 @@ function DocumentInlineCode({
   spans: CommentMarkdownFilePathSpans | undefined
 }): React.ReactElement {
   const isFenced = useIsFencedCode()
-  const text = spans && !isFenced ? readCodeSpanText(children) : null
+  const isLinked = useIsLinkedCode()
+  const text = spans && !isFenced && !isLinked ? readCodeSpanText(children) : null
   if (spans && text !== null && spans.isFilePath(text)) {
     return (
       <FilePathCodeSpan
@@ -269,7 +272,7 @@ export function createDocumentCommentMarkdownComponents(
               filePathSpans.onOpen(event, href)
             }}
           >
-            {children}
+            <LinkedCodeBoundary>{children}</LinkedCodeBoundary>
           </a>
         )
       }
@@ -281,7 +284,7 @@ export function createDocumentCommentMarkdownComponents(
           className="break-all text-primary underline underline-offset-2 hover:text-primary/80"
           onClick={(e) => handleMarkdownAnchorClick(e, href, onLinkClick)}
         >
-          {children}
+          <LinkedCodeBoundary>{children}</LinkedCodeBoundary>
         </a>
       )
     },

--- a/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
@@ -8,6 +8,43 @@ import {
   isGitHubUserAttachmentVideoLink
 } from './comment-markdown-github-attachment-media'
 import { ExpandableMarkdownImage } from './MarkdownImageLightbox'
+import {
+  FencedCodeBoundary,
+  FilePathCodeSpan,
+  readCodeSpanText,
+  useIsFencedCode,
+  type CommentMarkdownFilePathSpans
+} from './comment-markdown-file-path-code-span'
+
+export type { CommentMarkdownFilePathSpans } from './comment-markdown-file-path-code-span'
+
+const DOCUMENT_INLINE_CODE_CLASS =
+  'rounded bg-accent px-1.5 py-0.5 font-mono text-[0.92em] [overflow-wrap:anywhere]'
+
+// Split out so the `code` renderer can use hooks — react-markdown component
+// slots are plain functions, not components, so a hook cannot live inline.
+function DocumentInlineCode({
+  children,
+  spans
+}: {
+  children: React.ReactNode
+  spans: CommentMarkdownFilePathSpans | undefined
+}): React.ReactElement {
+  const isFenced = useIsFencedCode()
+  const text = spans && !isFenced ? readCodeSpanText(children) : null
+  if (spans && text !== null && spans.isFilePath(text)) {
+    return (
+      <FilePathCodeSpan
+        pathText={text.trim()}
+        codeClassName={DOCUMENT_INLINE_CODE_CLASS}
+        spans={spans}
+      >
+        {children}
+      </FilePathCodeSpan>
+    )
+  }
+  return <code className={DOCUMENT_INLINE_CODE_CLASS}>{children}</code>
+}
 
 export type CommentMarkdownLinkClickHandler = (
   event: React.MouseEvent<HTMLElement>,
@@ -205,16 +242,38 @@ export function createCompactCommentMarkdownComponents(
 }
 
 export function createDocumentCommentMarkdownComponents(
-  onLinkClick?: CommentMarkdownLinkClickHandler
+  onLinkClick?: CommentMarkdownLinkClickHandler,
+  filePathSpans?: CommentMarkdownFilePathSpans
 ): Components {
   return {
     p: ({ children }) => <p className="my-2 first:mt-0 last:mb-0">{children}</p>,
-    a: ({ href, children }) =>
-      isGitHubUserAttachmentVideoLink(href, children) ? (
+    a: ({ href, children }) => {
+      if (isGitHubUserAttachmentVideoLink(href, children)) {
         // Why: GitHub's API returns uploaded videos as bare attachment links;
         // GitHub.com upgrades them to media embeds in its own renderer.
-        <GitHubUserAttachmentVideo href={href}>{children}</GitHubUserAttachmentVideo>
-      ) : (
+        return <GitHubUserAttachmentVideo href={href}>{children}</GitHubUserAttachmentVideo>
+      }
+      // A file-path href — whether authored as a markdown link or minted by
+      // remarkFilePathLinks — must always claim the click. Letting it fall
+      // through would navigate the anchor to a non-URL target.
+      if (filePathSpans && href && filePathSpans.isFilePath(href)) {
+        return (
+          <a
+            href={href}
+            // No underline: file paths read as a different destination from the
+            // web links sharing this accent.
+            className="break-all font-mono text-[0.95em] text-primary hover:text-primary/80"
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              filePathSpans.onOpen(event, href)
+            }}
+          >
+            {children}
+          </a>
+        )
+      }
+      return (
         <a
           href={href || undefined}
           target="_blank"
@@ -224,7 +283,8 @@ export function createDocumentCommentMarkdownComponents(
         >
           {children}
         </a>
-      ),
+      )
+    },
     code: ({ className, children }) =>
       isMermaidFence(className) ? (
         renderMermaidFence(
@@ -232,18 +292,18 @@ export function createDocumentCommentMarkdownComponents(
           'my-3 min-w-0 max-w-full overflow-x-auto rounded-md border border-border/60 p-3 [&_.mermaid-block]:min-w-0 [&_.mermaid-block_pre]:my-0 [&_.mermaid-block_pre]:max-h-80 [&_.mermaid-block_pre]:max-w-full [&_.mermaid-block_pre]:overflow-x-auto [&_.mermaid-block_pre]:rounded-md [&_.mermaid-block_pre]:bg-accent [&_.mermaid-block_pre]:p-3 [&_.mermaid-block_pre]:font-mono [&_.mermaid-block_pre]:text-[12px]'
         )
       ) : (
-        <code className="rounded bg-accent px-1.5 py-0.5 font-mono text-[0.92em] [overflow-wrap:anywhere]">
-          {children}
-        </code>
+        <DocumentInlineCode spans={filePathSpans}>{children}</DocumentInlineCode>
       ),
     // Mermaid fences render a <div>, which is invalid inside <pre>, so unwrap them.
     pre: ({ children }) =>
       isMermaidPre(children) ? (
         <>{children}</>
       ) : (
-        <pre className="my-3 max-h-80 max-w-full overflow-x-auto rounded-md bg-accent p-3 font-mono text-[12px]">
-          {children}
-        </pre>
+        <FencedCodeBoundary>
+          <pre className="my-3 max-h-80 max-w-full overflow-x-auto rounded-md bg-accent p-3 font-mono text-[12px]">
+            {children}
+          </pre>
+        </FencedCodeBoundary>
       ),
     ul: ({ children }) => <ul className="my-2 ml-5 list-disc space-y-1">{children}</ul>,
     ol: ({ children }) => <ol className="my-2 ml-5 list-decimal space-y-1">{children}</ol>,

--- a/src/renderer/src/components/sidebar/comment-markdown-file-path-code-span.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-file-path-code-span.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+
+export type CommentMarkdownFilePathSpans = {
+  /** Whether a whole inline-code span should render as an openable file path. */
+  isFilePath: (text: string) => boolean
+  onOpen: (event: React.MouseEvent<HTMLElement>, pathText: string) => void
+}
+
+// react-markdown routes both inline spans and the <code> inside a fence through
+// the same `code` component, and `className` is set only when a fence declares a
+// language — so bare ``` blocks are indistinguishable there. The <pre> renderer
+// marks its subtree instead, and the code renderer reads the mark.
+const FencedCodeContext = React.createContext(false)
+
+export function FencedCodeBoundary({
+  children
+}: {
+  children: React.ReactNode
+}): React.ReactElement {
+  return <FencedCodeContext.Provider value={true}>{children}</FencedCodeContext.Provider>
+}
+
+export function useIsFencedCode(): boolean {
+  return React.useContext(FencedCodeContext)
+}
+
+/**
+ * The span's text when it is a single plain string. Richer children mean the
+ * span carries markup, which a bare path never does.
+ */
+export function readCodeSpanText(children: React.ReactNode): string | null {
+  if (typeof children === 'string') {
+    return children
+  }
+  if (Array.isArray(children) && children.length === 1 && typeof children[0] === 'string') {
+    return children[0]
+  }
+  return null
+}
+
+export function FilePathCodeSpan({
+  pathText,
+  codeClassName,
+  spans,
+  children
+}: {
+  pathText: string
+  codeClassName: string
+  spans: CommentMarkdownFilePathSpans
+  children: React.ReactNode
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      // A real button (not a <code onClick>) so the path is reachable and
+      // activatable by keyboard, matching NativeChatToolRun's affordance.
+      className="max-w-full rounded align-baseline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      title={pathText}
+      onClick={(event) => {
+        event.stopPropagation()
+        spans.onOpen(event, pathText)
+      }}
+    >
+      <code
+        className={cn(
+          codeClassName,
+          // File paths read as a distinct destination from web links: same
+          // accent, monospace, no underline.
+          'text-primary transition-colors hover:text-primary/80'
+        )}
+      >
+        {children}
+      </code>
+    </button>
+  )
+}

--- a/src/renderer/src/components/sidebar/comment-markdown-file-path-code-span.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-file-path-code-span.tsx
@@ -12,6 +12,7 @@ export type CommentMarkdownFilePathSpans = {
 // language — so bare ``` blocks are indistinguishable there. The <pre> renderer
 // marks its subtree instead, and the code renderer reads the mark.
 const FencedCodeContext = React.createContext(false)
+const LinkedCodeContext = React.createContext(false)
 
 export function FencedCodeBoundary({
   children
@@ -23,6 +24,18 @@ export function FencedCodeBoundary({
 
 export function useIsFencedCode(): boolean {
   return React.useContext(FencedCodeContext)
+}
+
+export function LinkedCodeBoundary({
+  children
+}: {
+  children: React.ReactNode
+}): React.ReactElement {
+  return <LinkedCodeContext.Provider value={true}>{children}</LinkedCodeContext.Provider>
+}
+
+export function useIsLinkedCode(): boolean {
+  return React.useContext(LinkedCodeContext)
 }
 
 /**

--- a/src/renderer/src/components/sidebar/remark-file-path-links.ts
+++ b/src/renderer/src/components/sidebar/remark-file-path-links.ts
@@ -1,0 +1,91 @@
+import { extractFilePathProseSpans } from '@/lib/file-path-prose-spans'
+
+// Linkify bare file paths in prose by emitting standard mdast `link` nodes.
+//
+// Why `link` and not a custom node: CommentMarkdown sanitizes after remark
+// (rehypeSanitize with the default schema), which drops unknown tags and
+// data-attributes. `<a href>` is the only shape that survives, and it lands on
+// the anchor renderer that already routes through onLinkClick.
+
+type MarkdownTextNode = {
+  type: 'text'
+  value: string
+}
+
+type MarkdownLinkNode = {
+  type: 'link'
+  url: string
+  title: null
+  children: MarkdownTextNode[]
+}
+
+type MarkdownNode = {
+  type: string
+  value?: string
+  children?: MarkdownNode[]
+}
+
+function createFilePathLinkNode(label: string): MarkdownLinkNode {
+  return {
+    type: 'link',
+    url: label,
+    title: null,
+    children: [{ type: 'text', value: label }]
+  }
+}
+
+function splitFilePathText(value: string): MarkdownNode[] {
+  const spans = extractFilePathProseSpans(value)
+  if (spans.length === 0) {
+    return [{ type: 'text', value }]
+  }
+
+  const parts: MarkdownNode[] = []
+  let cursor = 0
+  for (const span of spans) {
+    // The detector can emit overlapping candidates; a linear reassembly must
+    // take the first and skip anything already consumed.
+    if (span.startIndex < cursor) {
+      continue
+    }
+    if (span.startIndex > cursor) {
+      parts.push({ type: 'text', value: value.slice(cursor, span.startIndex) })
+    }
+    // The raw slice keeps any :line:col suffix, which the click path parses.
+    parts.push(createFilePathLinkNode(value.slice(span.startIndex, span.endIndex)))
+    cursor = span.endIndex
+  }
+
+  if (cursor === 0) {
+    return [{ type: 'text', value }]
+  }
+  if (cursor < value.length) {
+    parts.push({ type: 'text', value: value.slice(cursor) })
+  }
+  return parts
+}
+
+function transformFilePathChildren(node: MarkdownNode): void {
+  // Existing links keep their href; code spans are handled by the code renderer.
+  if (!node.children || node.type === 'link' || node.type === 'image') {
+    return
+  }
+
+  const nextChildren: MarkdownNode[] = []
+  for (const child of node.children) {
+    if (child.type === 'text' && child.value !== undefined) {
+      for (const part of splitFilePathText(child.value)) {
+        nextChildren.push(part)
+      }
+    } else {
+      transformFilePathChildren(child)
+      nextChildren.push(child)
+    }
+  }
+
+  node.children = nextChildren
+}
+
+export function remarkFilePathLinks(): () => (tree: MarkdownNode) => void {
+  return () => (tree) => transformFilePathChildren(tree)
+}

--- a/src/renderer/src/components/sidebar/remark-file-path-links.ts
+++ b/src/renderer/src/components/sidebar/remark-file-path-links.ts
@@ -26,9 +26,10 @@ type MarkdownNode = {
 }
 
 function createFilePathLinkNode(label: string): MarkdownLinkNode {
+  const url = /^[A-Za-z]:[\\/]/.test(label) ? label.replace(':', '%3A') : label
   return {
     type: 'link',
-    url: label,
+    url,
     title: null,
     children: [{ type: 'text', value: label }]
   }
@@ -67,7 +68,12 @@ function splitFilePathText(value: string): MarkdownNode[] {
 
 function transformFilePathChildren(node: MarkdownNode): void {
   // Existing links keep their href; code spans are handled by the code renderer.
-  if (!node.children || node.type === 'link' || node.type === 'image') {
+  if (
+    !node.children ||
+    node.type === 'link' ||
+    node.type === 'linkReference' ||
+    node.type === 'image'
+  ) {
     return
   }
 

--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -18,6 +18,8 @@ type TerminalFileOpenDeps = {
   worktreePath: string
   runtimeEnvironmentId?: string | null
   openWithSystemDefault?: boolean
+  allowExternalPaths?: boolean
+  openHtmlInBrowser?: boolean
 }
 
 export function isHtmlFilePath(filePath: string): boolean {
@@ -100,7 +102,14 @@ export function openDetectedFilePath(
   column: number | null,
   deps: TerminalFileOpenDeps
 ): void {
-  const { openWithSystemDefault = false, runtimeEnvironmentId, worktreeId, worktreePath } = deps
+  const {
+    allowExternalPaths = true,
+    openHtmlInBrowser = true,
+    openWithSystemDefault = false,
+    runtimeEnvironmentId,
+    worktreeId,
+    worktreePath
+  } = deps
   const mappedFilePath = mapTerminalFilePath(filePath, worktreePath)
   const requestId = ++latestOpenDetectedFilePathRequestId
   cancelPendingEditorRevealFrames()
@@ -129,7 +138,7 @@ export function openDetectedFilePath(
 
     try {
       // Why: remote paths don't need local auth — the relay/runtime is the security boundary.
-      if (canOpenWithSystemDefault) {
+      if (canOpenWithSystemDefault && allowExternalPaths) {
         await window.api.fs.authorizeExternalPath({ targetPath: mappedFilePath })
       }
       statResult = await statRuntimePath(fileContext, mappedFilePath)
@@ -160,6 +169,7 @@ export function openDetectedFilePath(
     // Why: local HTML files render in Orca's browser for ordinary Cmd/Ctrl-click,
     // and remain the fallback if Shift+Cmd/Ctrl cannot launch the OS default.
     if (
+      openHtmlInBrowser &&
       isHtmlFilePath(mappedFilePath) &&
       shouldOpenTerminalFileWithSystemDefault(fileContext, mappedFilePath)
     ) {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14223,7 +14223,8 @@
         "running": "Running…",
         "result": "Result",
         "countOne": "1 tool call",
-        "countN": "{{value0}} tool calls"
+        "countN": "{{value0}} tool calls",
+        "showAllLines": "Show all lines"
       },
       "status": {
         "responding": "Agent is responding"
@@ -14275,7 +14276,9 @@
         "allow": "Allow",
         "deny": "Deny"
       },
-      "launchPromptNotDelivered": "Not delivered — check the terminal"
+      "launchPromptNotDelivered": "Not delivered — check the terminal",
+      "fileLinkUnresolved": "Could not resolve that file path",
+      "fileLinkOutsideWorktree": "That file is outside the workspace"
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14192,7 +14192,8 @@
       },
       "tool": {
         "running": "Ejecutando…",
-        "result": "Resultado"
+        "result": "Resultado",
+        "showAllLines": "Show all lines"
       },
       "status": {
         "responding": "El agente está respondiendo"
@@ -14244,7 +14245,9 @@
         "allow": "Permitir",
         "deny": "Denegar"
       },
-      "launchPromptNotDelivered": "No entregado — revisa la terminal"
+      "launchPromptNotDelivered": "No entregado — revisa la terminal",
+      "fileLinkUnresolved": "Could not resolve that file path",
+      "fileLinkOutsideWorktree": "That file is outside the workspace"
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14192,7 +14192,8 @@
       },
       "tool": {
         "running": "実行中…",
-        "result": "結果"
+        "result": "結果",
+        "showAllLines": "Show all lines"
       },
       "status": {
         "responding": "Agent が応答中です"
@@ -14244,7 +14245,9 @@
         "allow": "許可する",
         "deny": "拒否"
       },
-      "launchPromptNotDelivered": "配信されませんでした — ターミナルを確認してください"
+      "launchPromptNotDelivered": "配信されませんでした — ターミナルを確認してください",
+      "fileLinkUnresolved": "Could not resolve that file path",
+      "fileLinkOutsideWorktree": "That file is outside the workspace"
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14192,7 +14192,8 @@
       },
       "tool": {
         "running": "실행 중…",
-        "result": "결과"
+        "result": "결과",
+        "showAllLines": "Show all lines"
       },
       "status": {
         "responding": "Agent이 응답 중입니다."
@@ -14244,7 +14245,9 @@
         "allow": "허용하다",
         "deny": "부인하다"
       },
-      "launchPromptNotDelivered": "전달되지 않음 — 터미널을 확인하세요"
+      "launchPromptNotDelivered": "전달되지 않음 — 터미널을 확인하세요",
+      "fileLinkUnresolved": "Could not resolve that file path",
+      "fileLinkOutsideWorktree": "That file is outside the workspace"
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14192,7 +14192,8 @@
       },
       "tool": {
         "running": "正在运行…",
-        "result": "结果"
+        "result": "结果",
+        "showAllLines": "Show all lines"
       },
       "status": {
         "responding": "智能体正在回复"
@@ -14244,7 +14245,9 @@
         "allow": "允许",
         "deny": "拒绝"
       },
-      "launchPromptNotDelivered": "未送达 — 请检查终端"
+      "launchPromptNotDelivered": "未送达 — 请检查终端",
+      "fileLinkUnresolved": "Could not resolve that file path",
+      "fileLinkOutsideWorktree": "That file is outside the workspace"
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/lib/file-path-code-span.test.ts
+++ b/src/renderer/src/lib/file-path-code-span.test.ts
@@ -13,6 +13,8 @@ describe('isFilePathCodeSpan', () => {
     'src/foo/bar.ts:12',
     'C:\\repo\\config.json',
     'src\\app\\Main.tsx',
+    'docs/My File.md',
+    'C:\\repo\\My File.md',
     '@scope/pkg/dist/index.js',
     'mobile/app/h/[hostId]/session/[worktreeId].tsx',
     'package.json',

--- a/src/renderer/src/lib/file-path-code-span.test.ts
+++ b/src/renderer/src/lib/file-path-code-span.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { isFilePathCodeSpan } from './file-path-code-span'
+
+describe('isFilePathCodeSpan', () => {
+  it.each([
+    'docs/mobile-chat-file-path-links.md',
+    'src/renderer/src/lib/terminal-links.ts',
+    './src/app/Main.tsx',
+    '../shared/types.ts',
+    '/Users/me/repo/src/index.ts',
+    '~/Documents/notes.md',
+    'src/foo/bar.ts:12:7',
+    'src/foo/bar.ts:12',
+    'C:\\repo\\config.json',
+    'src\\app\\Main.tsx',
+    '@scope/pkg/dist/index.js',
+    'mobile/app/h/[hostId]/session/[worktreeId].tsx',
+    'package.json',
+    'README.md',
+    'tsconfig.json',
+    '.env',
+    'Dockerfile',
+    'src/Dockerfile',
+    'Makefile'
+  ])('accepts %s', (value) => {
+    expect(isFilePathCodeSpan(value)).toBe(true)
+  })
+
+  it.each([
+    '',
+    '   ',
+    'just prose',
+    'src/foo/bar.ts and more',
+    '1.2.3',
+    '20.11.0',
+    'https://example.com/a.ts',
+    'http://example.com',
+    'mailto:me@example.com',
+    'git@github.com:org/repo.git',
+    'me@example.com',
+    'someFunction',
+    'npm run build',
+    'src/foo/bar.ts:0',
+    'src/'
+  ])('rejects %s', (value) => {
+    expect(isFilePathCodeSpan(value)).toBe(false)
+  })
+
+  it('rejects a bare name whose extension is not a known file type', () => {
+    // Guards prose nouns that survive the dot check, e.g. a product name.
+    expect(isFilePathCodeSpan('Some.Thing')).toBe(false)
+  })
+
+  it('accepts an unknown extension when a separator anchors it', () => {
+    expect(isFilePathCodeSpan('build/out.customext')).toBe(true)
+  })
+
+  it('rejects a span long enough to be a code sample rather than a path', () => {
+    expect(isFilePathCodeSpan(`src/${'a'.repeat(600)}.ts`)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/file-path-code-span.ts
+++ b/src/renderer/src/lib/file-path-code-span.ts
@@ -94,7 +94,7 @@ function hasMidTokenAt(value: string): boolean {
 
 export function isFilePathCodeSpan(text: string): boolean {
   const trimmed = text.trim()
-  if (!trimmed || trimmed.length > MAX_CODE_SPAN_LENGTH || /\s/.test(trimmed)) {
+  if (!trimmed || trimmed.length > MAX_CODE_SPAN_LENGTH || /[\r\n]/.test(trimmed)) {
     return false
   }
   if (hasNonFileScheme(trimmed) || hasMidTokenAt(trimmed)) {

--- a/src/renderer/src/lib/file-path-code-span.ts
+++ b/src/renderer/src/lib/file-path-code-span.ts
@@ -1,0 +1,131 @@
+import { parseExplicitFileLinkTarget } from './explicit-file-link-target'
+
+// Whether a whole inline-code span is a file path worth linkifying.
+//
+// A backtick span is an authoring signal, so a bare `package.json` qualifies
+// here even though prose requires a separator — in prose the same rule would
+// linkify version numbers and hostnames. Separator-less spans still need a
+// known extension; spans with a separator accept any plausible one.
+
+const MAX_CODE_SPAN_LENGTH = 512
+
+// Files agents reference by name with no extension.
+const EXTENSIONLESS_FILENAMES = new Set([
+  'dockerfile',
+  'makefile',
+  'procfile',
+  'rakefile',
+  'gemfile',
+  'justfile',
+  'brewfile',
+  'jenkinsfile',
+  'vagrantfile',
+  'codeowners'
+])
+
+// Only consulted for separator-less spans, where the extension is the sole signal.
+const BARE_NAME_EXTENSIONS = new Set([
+  'ts',
+  'tsx',
+  'js',
+  'jsx',
+  'mjs',
+  'cjs',
+  'json',
+  'jsonc',
+  'md',
+  'mdx',
+  'txt',
+  'yml',
+  'yaml',
+  'toml',
+  'ini',
+  'cfg',
+  'conf',
+  'env',
+  'lock',
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  'py',
+  'rb',
+  'go',
+  'rs',
+  'java',
+  'kt',
+  'kts',
+  'swift',
+  'c',
+  'h',
+  'cc',
+  'cpp',
+  'hpp',
+  'cs',
+  'php',
+  'sql',
+  'css',
+  'scss',
+  'less',
+  'html',
+  'xml',
+  'svg',
+  'vue',
+  'svelte',
+  'astro',
+  'graphql',
+  'proto',
+  'gradle'
+])
+
+function hasNonFileScheme(value: string): boolean {
+  // A Windows drive letter (C:\repo) is not a scheme.
+  if (/^[A-Za-z]:[\\/]/.test(value)) {
+    return false
+  }
+  return /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)
+}
+
+// A mid-token '@' marks an email or git remote (git@github.com:org/repo); a
+// segment-leading '@' is a scoped package directory and stays eligible.
+function hasMidTokenAt(value: string): boolean {
+  return /[^\\/]@/.test(value)
+}
+
+export function isFilePathCodeSpan(text: string): boolean {
+  const trimmed = text.trim()
+  if (!trimmed || trimmed.length > MAX_CODE_SPAN_LENGTH || /\s/.test(trimmed)) {
+    return false
+  }
+  if (hasNonFileScheme(trimmed) || hasMidTokenAt(trimmed)) {
+    return false
+  }
+  // Reuse the click path's parser so a span that passes here resolves to the
+  // same pathText when it is opened.
+  const parsed = parseExplicitFileLinkTarget(trimmed)
+  if (!parsed) {
+    return false
+  }
+  const { pathText } = parsed
+  const lastSeparator = Math.max(pathText.lastIndexOf('/'), pathText.lastIndexOf('\\'))
+  const lastSegment = pathText.slice(lastSeparator + 1)
+  if (!lastSegment) {
+    return false
+  }
+  if (EXTENSIONLESS_FILENAMES.has(lastSegment.toLowerCase())) {
+    return true
+  }
+  const dot = lastSegment.lastIndexOf('.')
+  if (dot < 0) {
+    return false
+  }
+  const extension = lastSegment.slice(dot + 1).toLowerCase()
+  if (!extension || !/^[a-z0-9]+$/.test(extension)) {
+    return false
+  }
+  // A purely numeric tail is a version number ("1.2.3"), not an extension.
+  if (/^\d+$/.test(extension)) {
+    return false
+  }
+  return lastSeparator >= 0 || BARE_NAME_EXTENSIONS.has(extension)
+}

--- a/src/renderer/src/lib/file-path-prose-spans.test.ts
+++ b/src/renderer/src/lib/file-path-prose-spans.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { extractFilePathProseSpans } from './file-path-prose-spans'
+
+const spanTexts = (text: string): string[] =>
+  extractFilePathProseSpans(text).map((span) => text.slice(span.startIndex, span.endIndex))
+
+describe('extractFilePathProseSpans', () => {
+  it('finds a relative path in prose', () => {
+    expect(spanTexts('Design doc written: docs/mobile-chat-file-path-links.md .')).toContain(
+      'docs/mobile-chat-file-path-links.md'
+    )
+  })
+
+  it('finds an absolute POSIX path in prose', () => {
+    expect(spanTexts('wrote /Users/me/repo/src/index.ts for you')).toContain(
+      '/Users/me/repo/src/index.ts'
+    )
+  })
+
+  it('keeps a line and column suffix in the span', () => {
+    expect(spanTexts('see src/components/Button.tsx:12:7 here')).toContain(
+      'src/components/Button.tsx:12:7'
+    )
+  })
+
+  it('finds multiple paths in one run', () => {
+    const spans = spanTexts('compare src/a.ts and src/b.ts now')
+    expect(spans).toContain('src/a.ts')
+    expect(spans).toContain('src/b.ts')
+  })
+
+  it('reassembles without overlapping spans', () => {
+    const text = 'see /tmp/a.txt and /tmp/b.txt done'
+    const spans = extractFilePathProseSpans(text)
+    for (let i = 1; i < spans.length; i += 1) {
+      expect(spans[i]!.startIndex).toBeGreaterThanOrEqual(spans[i - 1]!.endIndex)
+    }
+  })
+
+  it.each([
+    'upgraded to 1.2.3 today',
+    'requires Node.js 20 or newer',
+    'running 20.11.0 in CI',
+    'took 4.5s to finish',
+    'visit example.com for details',
+    'just some prose with no path here'
+  ])('finds nothing in %s', (text) => {
+    expect(spanTexts(text)).toEqual([])
+  })
+
+  it('ignores a bare filename with no separator', () => {
+    // The terminal detector matches these behind a hover existence probe; chat
+    // has none, so an unbacked guess would render as a dead link.
+    expect(spanTexts('Here you go: README.md')).toEqual([])
+  })
+
+  it('ignores an http URL', () => {
+    expect(spanTexts('see https://example.com/docs/guide.md now')).toEqual([])
+  })
+
+  describe('bare domains', () => {
+    // These clear the separator rule, so they need their own suppression.
+    it.each([
+      'see example.com/foo for details',
+      'see docs.rs/serde for details',
+      'see github.com/a/b for details',
+      'see foo.local/share here',
+      'see www.example.com/x.md here'
+    ])('finds nothing in %s', (text) => {
+      expect(spanTexts(text)).toEqual([])
+    })
+
+    it('still finds a dotfile directory path', () => {
+      expect(spanTexts('edit .github/workflows/ci.yml now')).toContain('.github/workflows/ci.yml')
+    })
+
+    it('still finds a first segment with a numeric tail', () => {
+      expect(spanTexts('wrote v1.2/out.ts today')).toContain('v1.2/out.ts')
+    })
+
+    it('still finds an explicitly relative path', () => {
+      expect(spanTexts('open ./example.com/a.ts now')).toContain('./example.com/a.ts')
+    })
+  })
+
+  it('skips a run longer than the scan cap', () => {
+    expect(spanTexts(`${'a'.repeat(2100)} src/a.ts`)).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/file-path-prose-spans.test.ts
+++ b/src/renderer/src/lib/file-path-prose-spans.test.ts
@@ -29,6 +29,17 @@ describe('extractFilePathProseSpans', () => {
     expect(spans).toContain('src/b.ts')
   })
 
+  it('preserves balanced route segments and trims prose wrappers', () => {
+    expect(spanTexts('open (shop)/page.tsx and [id]/page.tsx')).toEqual([
+      '(shop)/page.tsx',
+      '[id]/page.tsx'
+    ])
+    expect(spanTexts('open ((shop)/page.tsx) and ([id]/page.tsx)')).toEqual([
+      '(shop)/page.tsx',
+      '[id]/page.tsx'
+    ])
+  })
+
   it('reassembles without overlapping spans', () => {
     const text = 'see /tmp/a.txt and /tmp/b.txt done'
     const spans = extractFilePathProseSpans(text)

--- a/src/renderer/src/lib/file-path-prose-spans.ts
+++ b/src/renderer/src/lib/file-path-prose-spans.ts
@@ -21,23 +21,57 @@ const MAX_PROSE_LENGTH = 2000
 
 const TOKEN_PATTERN = /\S+/g
 
-const LEADING_PUNCTUATION = /^[([{<'"`]+/
+const LEADING_PUNCTUATION = /^[{<'"`]+/
 // A trailing ':' or '.' is prose punctuation; a ':12:7' suffix ends in a digit
 // and is left intact.
-const TRAILING_PUNCTUATION = /[)\]}>'"`,.;:!?]+$/
+const TRAILING_PUNCTUATION = /[}>'"`,.;:!?]+$/
 
 type ProseToken = {
   text: string
   offset: number
 }
 
+function hasBalancedDelimiter(value: string, open: string, close: string): boolean {
+  let depth = 0
+  for (const char of value) {
+    if (char === open) {
+      depth += 1
+    } else if (char === close && --depth < 0) {
+      return false
+    }
+  }
+  return depth === 0
+}
+
+function hasBalancedRouteDelimiters(value: string): boolean {
+  return hasBalancedDelimiter(value, '(', ')') && hasBalancedDelimiter(value, '[', ']')
+}
+
 function trimProsePunctuation(token: string, offset: number): ProseToken {
   const leading = LEADING_PUNCTUATION.exec(token)?.[0].length ?? 0
   const withoutLeading = token.slice(leading)
   const trailing = TRAILING_PUNCTUATION.exec(withoutLeading)?.[0].length ?? 0
+  let text = trailing > 0 ? withoutLeading.slice(0, -trailing) : withoutLeading
+  let wrapperLength = 0
+  while (
+    ((text.startsWith('(') && text.endsWith(')')) ||
+      (text.startsWith('[') && text.endsWith(']'))) &&
+    hasBalancedRouteDelimiters(text.slice(1, -1))
+  ) {
+    text = text.slice(1, -1)
+    wrapperLength += 1
+  }
+  while (!hasBalancedRouteDelimiters(text)) {
+    const withoutTrailing = text.slice(0, -1)
+    if ((text.endsWith(')') || text.endsWith(']')) && hasBalancedRouteDelimiters(withoutTrailing)) {
+      text = withoutTrailing
+      continue
+    }
+    break
+  }
   return {
-    text: trailing > 0 ? withoutLeading.slice(0, -trailing) : withoutLeading,
-    offset: offset + leading
+    text,
+    offset: offset + leading + wrapperLength
   }
 }
 

--- a/src/renderer/src/lib/file-path-prose-spans.ts
+++ b/src/renderer/src/lib/file-path-prose-spans.ts
@@ -1,0 +1,98 @@
+import { extractTerminalFileLinks, type ParsedTerminalFileLink } from './terminal-links'
+
+// File-path spans inside a prose run, reusing the desktop terminal detector.
+//
+// Two terminal affordances do not survive the move to prose, and both are
+// disabled here rather than inherited:
+//
+//   - Bare filenames. The terminal decorates a span only after a hover
+//     existence probe, so an unbacked guess costs nothing. Chat styles at
+//     detection time, so "1.2.3" or "Node.js" would become a visible dead link.
+//   - Spaced paths. "/tmp/My Project/a.ts" is resolvable in a terminal because
+//     the tapped column picks among candidates; in prose there is no column, and
+//     a greedy match swallows the words between two paths ("a.ts and b.ts").
+//
+// So prose scans whitespace-delimited tokens and requires the detector to claim
+// a whole token, with a separator in it.
+
+// A prose run long enough to hold a path is short; the cap bounds scanning on
+// pathological input.
+const MAX_PROSE_LENGTH = 2000
+
+const TOKEN_PATTERN = /\S+/g
+
+const LEADING_PUNCTUATION = /^[([{<'"`]+/
+// A trailing ':' or '.' is prose punctuation; a ':12:7' suffix ends in a digit
+// and is left intact.
+const TRAILING_PUNCTUATION = /[)\]}>'"`,.;:!?]+$/
+
+type ProseToken = {
+  text: string
+  offset: number
+}
+
+function trimProsePunctuation(token: string, offset: number): ProseToken {
+  const leading = LEADING_PUNCTUATION.exec(token)?.[0].length ?? 0
+  const withoutLeading = token.slice(leading)
+  const trailing = TRAILING_PUNCTUATION.exec(withoutLeading)?.[0].length ?? 0
+  return {
+    text: trailing > 0 ? withoutLeading.slice(0, -trailing) : withoutLeading,
+    offset: offset + leading
+  }
+}
+
+// "example.com/foo", "docs.rs/serde", "github.com/a/b" all clear the separator
+// rule, so a bare domain needs its own check. Matching the whole first segment
+// keeps ".github/workflows/ci.yml" (leading dot, no name before it) and
+// "v1.2/out.ts" (numeric tail) out of this net.
+const DOMAIN_LIKE_SEGMENT = /^[a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,}$/i
+
+function hasDomainLikeFirstSegment(pathText: string): boolean {
+  // Absolute, tilde, explicit-relative and drive-letter paths cannot be a domain.
+  if (/^(?:[\\/~]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/.test(pathText)) {
+    return false
+  }
+  return DOMAIN_LIKE_SEGMENT.test(pathText.split(/[\\/]/)[0] ?? '')
+}
+
+function isProsePathSpan(span: ParsedTerminalFileLink): boolean {
+  if (!/[\\/]/.test(span.pathText)) {
+    return false
+  }
+  // A scheme-bearing token is a web link; the anchor path already handles those.
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(span.pathText)) {
+    return false
+  }
+  if (hasDomainLikeFirstSegment(span.pathText)) {
+    return false
+  }
+  return true
+}
+
+export function extractFilePathProseSpans(text: string): ParsedTerminalFileLink[] {
+  if (!text || text.length > MAX_PROSE_LENGTH) {
+    return []
+  }
+
+  const spans: ParsedTerminalFileLink[] = []
+  for (const match of text.matchAll(TOKEN_PATTERN)) {
+    const token = trimProsePunctuation(match[0], match.index)
+    if (!token.text) {
+      continue
+    }
+    // Require the detector to claim the entire token: a partial match means the
+    // token is prose that merely contains something path-shaped.
+    const claimed = extractTerminalFileLinks(token.text).find(
+      (span) => span.startIndex === 0 && span.endIndex === token.text.length
+    )
+    if (!claimed || !isProsePathSpan(claimed)) {
+      continue
+    }
+    spans.push({
+      ...claimed,
+      startIndex: token.offset,
+      endIndex: token.offset + token.text.length
+    })
+  }
+  return spans
+}

--- a/src/renderer/src/lib/terminal-file-link-detection-ranges.ts
+++ b/src/renderer/src/lib/terminal-file-link-detection-ranges.ts
@@ -1,13 +1,29 @@
 import { parseExplicitFileLinkTarget } from './explicit-file-link-target'
 import type { ParsedTerminalFileLink } from './terminal-links'
 
-const LEADING_TRIM_CHARS = new Set(['(', '[', '{', '"', "'"])
-const TRAILING_TRIM_CHARS = new Set([')', ']', '}', '"', "'", ',', ';', '.'])
+const LEADING_TRIM_CHARS = new Set(['{', '"', "'"])
+const TRAILING_TRIM_CHARS = new Set(['}', '"', "'", ',', ';', '.'])
 
 export type DetectedTerminalFileLinkRange = {
   startIndex: number
   endIndex: number
   text: string
+}
+
+function hasBalancedDelimiter(value: string, open: string, close: string): boolean {
+  let depth = 0
+  for (const char of value) {
+    if (char === open) {
+      depth += 1
+    } else if (char === close && --depth < 0) {
+      return false
+    }
+  }
+  return depth === 0
+}
+
+function hasBalancedRouteDelimiters(value: string): boolean {
+  return hasBalancedDelimiter(value, '(', ')') && hasBalancedDelimiter(value, '[', ']')
 }
 
 function trimBoundaryPunctuation(
@@ -21,6 +37,14 @@ function trimBoundaryPunctuation(
     start += 1
   }
   while (end > start && TRAILING_TRIM_CHARS.has(value[end - 1])) {
+    end -= 1
+  }
+  while (
+    end > start &&
+    (value[end - 1] === ')' || value[end - 1] === ']') &&
+    !hasBalancedRouteDelimiters(value.slice(start, end)) &&
+    hasBalancedRouteDelimiters(value.slice(start, end - 1))
+  ) {
     end -= 1
   }
 

--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -207,6 +207,17 @@ describe('terminal path helpers', () => {
       })
     })
 
+    it('detects framework route paths beginning with a route segment', () => {
+      expect(extractTerminalFileLinks('(shop)/page.tsx')[0]).toMatchObject({
+        pathText: '(shop)/page.tsx',
+        displayText: '(shop)/page.tsx'
+      })
+      expect(extractTerminalFileLinks('[id]/page.tsx')[0]).toMatchObject({
+        pathText: '[id]/page.tsx',
+        displayText: '[id]/page.tsx'
+      })
+    })
+
     it('handles large spaced path lists without quadratic overlap scans', () => {
       const line = Array.from({ length: 20_000 }, () => '/tmp/Foo Bar/file').join(', ')
 

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -34,7 +34,7 @@ export type ResolvedTerminalFileLink = Pick<ParsedTerminalFileLink, 'line' | 'co
 // Why: framework route files commonly use punctuation segments like
 // `app/(shop)/products/[id]/page.tsx`; keep those links whole.
 const LOCAL_PATH_REGEX =
-  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/])[A-Za-z0-9._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/g
+  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/]|(?:\([^()\r\n]+\)|\[[^[\]\r\n]+\])[\\/])[A-Za-z0-9._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/g
 
 // Matches separator paths whose file or folder names include spaces. This runs
 // before LOCAL_PATH_REGEX so `/Users/A/Foo Bar/file.ts` is claimed as one link


### PR DESCRIPTION
## Summary

Enables tapping and clicking file paths in agent responses across chat on both platforms. Paths in prose and markdown links (including inline-code) now resolve to file previews (mobile) or open in the editor (desktop). Line and column suffixes are preserved.

## Changes

### Mobile
- Detects bare prose file paths and markdown file links in agent text and user messages
- Parses line:column suffixes (`:12:3` and `#L12C3` formats)
- Routes taps to mobile file preview with source position preserved
- Shows error feedback when a path fails to resolve

### Desktop
- Linkifies bare prose file paths via remark plugin; click claims the link
- Makes inline-code file paths clickable as buttons (separate from web links)
- Reuses terminal path detection logic for consistency
- Filters out domains, version numbers, and spaced paths

### Both
- Resolves paths via worktree, with fallback to terminal cwd on mobile
- Rejects symlink targets outside the worktree (security)
- Handles percent-encoded and file:// URIs
- Supports Windows drive paths and UNC shares
- Preserves framework route segments like `(shop)/page.tsx` and `[id]/page.tsx`

## Performance
- Memoized chat rows to avoid re-renders on streaming frames
- Extracted tool line derivation to pure function
- Added stream throttling (50ms) to reduce transcript re-projection
- Capped unvirtualized chat window at 2000 messages

## Testing
- Added 200+ test cases for path detection (mobile and desktop)
- Inline-code and prose path rendering on desktop
- File open resolution flow on mobile (hit/miss, timeout, worktree jump)
- Symlink escaping and resolution fallback chains

## Verification
- Lint and typecheck pass
- Mobile chat file-path detection consistent with desktop terminal links
- Paths with line/column render and resolve correctly
- Non-path prose ("1.2.3", URLs, hostnames) not linkified