### PR TITLE
fix(test): stabilize system SSH transport integration

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -244,6 +244,7 @@ import {
   getActiveTabIdForHandle,
   isFileExistsErrorMessage,
   isGestureMouseTrackingMode,
+  isTerminalPhoneDisplayMode,
   MOBILE_SESSION_STATUS_LABELS,
   TERMINAL_GESTURE_INPUT_BUCKET_CAPACITY,
   TERMINAL_GESTURE_INPUT_FLUSH_DELAY_MS,
@@ -4167,14 +4168,6 @@ export default function SessionScreen() {
   })
   const closeWithBulkActions = createCloseWithBulkActions(handleCloseSessionTab, bulkCloseActions)
 
-  const isPhoneMode = (handle: string | null): boolean => {
-    if (!handle) {
-      return false
-    }
-    const mode = terminalModes.get(handle)
-    return mode === 'auto' || mode === 'phone' || mode === undefined
-  }
-
   const visibleTabs: MobileSessionTab[] = sessionTabs
   const activeMarkdownTab = activeSessionTab?.type === 'markdown' ? activeSessionTab : null
   const activeFileTab = activeSessionTab?.type === 'file' ? activeSessionTab : null
@@ -4832,12 +4825,12 @@ export default function SessionScreen() {
                         }
                       }}
                       accessibilityLabel={
-                        isPhoneMode(activeHandle)
+                        isTerminalPhoneDisplayMode(activeHandle, terminalModes)
                           ? 'Switch to desktop mode'
                           : 'Switch to phone mode'
                       }
                     >
-                      {isPhoneMode(activeHandle) ? (
+                      {isTerminalPhoneDisplayMode(activeHandle, terminalModes) ? (
                         <Monitor
                           size={14}
                           color={canSend ? colors.textSecondary : colors.textMuted}
@@ -5216,7 +5209,7 @@ export default function SessionScreen() {
           nativeChatTranscriptIsLocalReadable,
           onDismiss: () => setActionTarget(null),
           onToggleChat: toggleTabChatView,
-          isPhoneMode,
+          isPhoneMode: (handle) => isTerminalPhoneDisplayMode(handle, terminalModes),
           onToggleDisplayMode: (handle) => void toggleDisplayMode(handle),
           onRename: setRenameTarget,
           onClear: (target) => void handleClearTerminal(target),

--- a/mobile/src/session/mobile-session-route-helpers.test.ts
+++ b/mobile/src/session/mobile-session-route-helpers.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isTerminalPhoneDisplayMode } from './mobile-session-route-helpers'
+
+describe('isTerminalPhoneDisplayMode', () => {
+  it('uses phone mode for automatic, phone, and unreported terminals', () => {
+    const modes = new Map([
+      ['auto', 'auto'],
+      ['phone', 'phone']
+    ] as const)
+
+    expect(isTerminalPhoneDisplayMode('auto', modes)).toBe(true)
+    expect(isTerminalPhoneDisplayMode('phone', modes)).toBe(true)
+    expect(isTerminalPhoneDisplayMode('missing', modes)).toBe(true)
+  })
+
+  it('rejects absent handles and desktop terminals', () => {
+    const modes = new Map([['desktop', 'desktop']] as const)
+
+    expect(isTerminalPhoneDisplayMode(null, modes)).toBe(false)
+    expect(isTerminalPhoneDisplayMode('desktop', modes)).toBe(false)
+  })
+})

--- a/mobile/src/session/mobile-session-route-helpers.ts
+++ b/mobile/src/session/mobile-session-route-helpers.ts
@@ -34,6 +34,17 @@ export function isGestureMouseTrackingMode(
   return mode === 'x10' || mode === 'vt200' || mode === 'drag' || mode === 'any'
 }
 
+export function isTerminalPhoneDisplayMode(
+  handle: string | null,
+  terminalModes: ReadonlyMap<string, 'auto' | 'phone' | 'desktop'>
+): boolean {
+  if (!handle) {
+    return false
+  }
+  const mode = terminalModes.get(handle)
+  return mode === undefined || mode === 'auto' || mode === 'phone'
+}
+
 export function getActiveTabIdForHandle(
   tabs: ReadonlyArray<{ id: string; type: string; terminal?: string | null }>,
   terminalHandle: string | null

--- a/src/main/ssh/ssh-system-transport.integration.test.ts
+++ b/src/main/ssh/ssh-system-transport.integration.test.ts
@@ -54,6 +54,8 @@ exec /bin/sh -c "$cmd"
 }
 
 function writeFakeRelay(dir: string): void {
+  writeFileSync(join(dir, 'relay-watcher.js'), '')
+  writeFileSync(join(dir, 'managed-hook-runtime.js'), '')
   writeFileSync(
     join(dir, 'relay.js'),
     `
@@ -94,9 +96,11 @@ function serve(socket) {
 
 if (process.argv.includes('--detached')) {
   try { fs.unlinkSync(sockPath); } catch {}
-  const server = net.createServer(serve);
+  const server = net.createServer((socket) => {
+    serve(socket);
+    server.close();
+  });
   server.listen(sockPath);
-  setTimeout(() => process.exit(0), 20000).unref();
 } else if (process.argv.includes('--connect')) {
   process.stdout.write(sentinel);
   let buffer = Buffer.alloc(0);
@@ -137,12 +141,15 @@ function createRelayTree(root: string, remoteHome: string): void {
   }
 
   const remoteDir = join(remoteHome, '.orca-remote', `relay-${RELAY_VERSION}`)
-  mkdirSync(join(remoteDir, 'node_modules', 'node-pty'), { recursive: true })
+  mkdirSync(join(remoteDir, 'node_modules', 'node-pty', 'lib'), { recursive: true })
   mkdirSync(join(remoteDir, 'node_modules', '@parcel', 'watcher'), { recursive: true })
   writeFileSync(join(remoteDir, 'node_modules', 'node-pty', 'index.js'), '')
+  writeFileSync(
+    join(remoteDir, 'node_modules', 'node-pty', 'lib', 'utils.js'),
+    'exports.loadNativeModule = () => ({})\n'
+  )
   writeFileSync(join(remoteDir, 'node_modules', '@parcel', 'watcher', 'index.js'), '')
   writeFileSync(join(remoteDir, '.install-complete'), '')
-  writeFileSync(join(remoteDir, 'managed-hook-runtime.js'), '')
   writeFakeRelay(remoteDir)
 }
 
@@ -205,10 +212,13 @@ describe('system SSH transport integration', () => {
     'deploys and speaks relay RPC over a system ssh process for ProxyUseFdpass targets',
     async () => {
       const conn = new SshConnection(makeTarget(), { onStateChange: vi.fn() })
+      const onProgress = vi.fn()
       await conn.connect()
       expect(conn.usesSystemSshTransport()).toBe(true)
 
-      const result = await deployAndLaunchRelay(conn, undefined, 60, makeTarget().id)
+      const result = await deployAndLaunchRelay(conn, onProgress, 60, makeTarget().id)
+      expect(onProgress).not.toHaveBeenCalledWith('Uploading relay...')
+      expect(onProgress).not.toHaveBeenCalledWith('Installing native dependencies...')
       const mux = new SshChannelMultiplexer(result.transport)
       try {
         await expect(mux.request('session.resolveHome', { path: '~' })).resolves.toBe(

--- a/src/main/ssh/ssh-system-transport.integration.test.ts
+++ b/src/main/ssh/ssh-system-transport.integration.test.ts
@@ -74,7 +74,8 @@ function encode(msg) {
   return Buffer.concat([header, payload]);
 }
 
-function serve(socket) {
+function serve(socket, onResolved) {
+  socket.on('error', () => {});
   socket.write(sentinel);
   let buffer = Buffer.alloc(0);
   socket.on('data', (chunk) => {
@@ -88,7 +89,10 @@ function serve(socket) {
       if (type !== 1) continue;
       const message = JSON.parse(payload.toString('utf8'));
       if (message.method === 'session.resolveHome') {
-        socket.write(encode({ jsonrpc: '2.0', id: message.id, result: process.env.HOME }));
+        socket.write(
+          encode({ jsonrpc: '2.0', id: message.id, result: process.env.HOME }),
+          onResolved
+        );
       }
     }
   });
@@ -97,28 +101,17 @@ function serve(socket) {
 if (process.argv.includes('--detached')) {
   try { fs.unlinkSync(sockPath); } catch {}
   const server = net.createServer((socket) => {
-    serve(socket);
-    server.close();
+    serve(socket, () => server.close());
   });
   server.listen(sockPath);
 } else if (process.argv.includes('--connect')) {
-  process.stdout.write(sentinel);
-  let buffer = Buffer.alloc(0);
-  process.stdin.on('data', (chunk) => {
-    buffer = Buffer.concat([buffer, chunk]);
-    while (buffer.length >= 13) {
-      const type = buffer[0];
-      const length = buffer.readUInt32BE(9);
-      if (buffer.length < 13 + length) return;
-      const payload = buffer.subarray(13, 13 + length);
-      buffer = buffer.subarray(13 + length);
-      if (type !== 1) continue;
-      const message = JSON.parse(payload.toString('utf8'));
-      if (message.method === 'session.resolveHome') {
-        process.stdout.write(encode({ jsonrpc: '2.0', id: message.id, result: process.env.HOME }));
-      }
-    }
+  const socket = net.createConnection(sockPath);
+  socket.on('error', (error) => {
+    process.stderr.write(error.message);
+    process.exit(1);
   });
+  process.stdin.pipe(socket);
+  socket.pipe(process.stdout);
 }
 `
   )
@@ -217,6 +210,7 @@ describe('system SSH transport integration', () => {
       expect(conn.usesSystemSshTransport()).toBe(true)
 
       const result = await deployAndLaunchRelay(conn, onProgress, 60, makeTarget().id)
+      expect(onProgress).toHaveBeenCalledWith('Starting relay...')
       expect(onProgress).not.toHaveBeenCalledWith('Uploading relay...')
       expect(onProgress).not.toHaveBeenCalledWith('Installing native dependencies...')
       const mux = new SshChannelMultiplexer(result.transport)


### PR DESCRIPTION
## Summary

- Keep the preinstalled system SSH relay fixture aligned with the current required-artifact and native-module health probes.
- Prevent the integration test from silently running a real `npm install` and close the fake detached relay after its readiness probe.
- Assert that the warm-install scenario never enters relay upload or native dependency installation.
- Extract the mobile terminal display-mode predicate so current `main` remains below its max-lines ratchet without a disable or limit increase.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification:

- `pnpm exec oxlint --format default` — 0 warnings, 0 errors across 11,025 files
- `pnpm run check:max-lines-ratchet`
- `pnpm run typecheck:node`
- SSH integration: 10 consecutive focused runs, 30/30 tests passed, with no leaked fake relay process
- Mobile route helper: focused tests, typecheck, lint, and format checks passed

The full `pnpm test` run passed the SSH transport integration file and completed 41,639 tests successfully. It reported four failures outside this change: two environment-sensitive assertions in `agent-exec-handler.test.ts` and two timeouts in `pty-subprocess.test.ts`.

## AI Review Report

Reviewed the fixture against the current relay install and native dependency probe contracts. The review found that the fixture lacked `relay-watcher.js` and a working `node-pty/lib/utils` probe stub, so the intended warm-install test performed a real upload and `npm install`. It also found that the fake detached relay stayed alive for 20 seconds after the test. Both issues are fixed, and progress assertions now guard the warm path.

The initial CI run also exposed an unrelated max-lines regression already present on current `main`. The terminal display-mode predicate was moved into the existing session route domain module with focused tests; behavior and styling are unchanged.

Cross-platform review covered macOS, Linux, and Windows. The SSH fixture remains explicitly POSIX-only and skipped on Windows; added paths use `node:path`, no production shortcuts or labels changed, no Electron behavior changed, and no production SSH shell behavior changed. The mobile extraction preserves the existing display-mode behavior on every platform.

## Security Audit

The SSH change has no production input, auth, IPC, or dependency changes. Reviewed temporary path handling, fake shell execution, process cleanup, and dependency behavior. All commands operate on test-generated paths, and the change removes the test's unintended external package installation. The mobile follow-up is a pure predicate extraction with no new input or side effects.

## Notes

The local full-suite run used Node 26 while the repository declares Node 24. No production SSH behavior changed.
