### PR TITLE
fix(settings): keep copied skill commands bare for POSIX-family Windows shells

### DIFF
--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -243,6 +243,55 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     }
   })
 
+  it('skips the Windows preflight when the configured Windows shell is POSIX-family', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    const windowsHost = { runtime: 'host', label: 'Windows' } as const
+    const previous = useAppStore.getState()
+
+    try {
+      // MSYS rewrites cmd.exe's leading /d /s /c switches into drive paths, so
+      // the copied command must stay bare for a Git Bash / wsl.exe paste target.
+      for (const terminalWindowsShell of ['git-bash', 'C:\\Program Files\\Git\\bin\\bash.exe']) {
+        useAppStore.setState({
+          settings: { ...getDefaultSettings('/tmp'), terminalWindowsShell }
+        })
+        expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(
+          installCommand
+        )
+      }
+
+      // cmd-family shells still need the preflight wrapper.
+      useAppStore.setState({
+        settings: { ...getDefaultSettings('/tmp'), terminalWindowsShell: 'cmd.exe' }
+      })
+      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(
+        `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`
+      )
+    } finally {
+      useAppStore.setState({ settings: previous.settings })
+    }
+  })
+
+  it('keeps the bare reinstall rewrite for POSIX-family Windows skill updates', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    const previous = useAppStore.getState()
+    useAppStore.setState({
+      settings: { ...getDefaultSettings('/tmp'), terminalWindowsShell: 'git-bash' }
+    })
+
+    try {
+      expect(
+        buildSkillCommandForRuntime(
+          'npx skills update orchestration --global',
+          { runtime: 'host', label: 'Windows' },
+          'win32'
+        )
+      ).toBe(installCommand)
+    } finally {
+      useAppStore.setState({ settings: previous.settings })
+    }
+  })
+
   it('does not wrap unrelated Windows host commands', () => {
     expect(
       buildSkillCommandForRuntime(

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -8,6 +8,7 @@ import {
   quotePowerShellNativeArgument
 } from '../../../../shared/powershell-native-argument'
 import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-command'
+import { resolveWindowsShellStartupFamily } from '../../../../shared/windows-terminal-shell'
 import { getProjectAgentSkillTerminalShellOverride } from '@/lib/project-skill-runtime'
 import { useAppStore } from '@/store'
 import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
@@ -136,6 +137,10 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
     // Why: skill setup terminals spawn on the focused runtime environment, so a
     // Windows client must not hand a cmd.exe command to a remote host.
     isRemoteRuntimeEnvironmentFocused() ||
+    // Why: the copied command lands in the user's configured shell, and MSYS
+    // shells rewrite cmd.exe's leading /d /s /c switches into drive paths,
+    // starting an interactive cmd session instead of running the payload.
+    isPosixFamilyWindowsShellConfigured() ||
     !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)
   ) {
     return command
@@ -147,6 +152,13 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
   // Prompt, and it resolves the bare name through PATHEXT for both the
   // preflight and the executed command, so shims such as npx.exe still count.
   return `cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (${missingNpxGuidance}) else (${trimmedCommand})"`
+}
+
+function isPosixFamilyWindowsShellConfigured(): boolean {
+  return (
+    resolveWindowsShellStartupFamily(useAppStore.getState().settings?.terminalWindowsShell) ===
+    'posix'
+  )
 }
 
 function isRemoteRuntimeEnvironmentFocused(): boolean {


### PR DESCRIPTION
## Summary

Addresses the regression reported in #11431 (introduced by #10453).

#10453 wraps Windows-native skill install/update commands in `cmd.exe /d /s /c "…"` to preflight `npx`. The spawned-terminal path is guarded (`getProjectAgentSkillTerminalShellOverride` forces `powershell.exe` for POSIX-family shells), but the same wrapped string is also placed on the clipboard by four call sites — and a paste target can't be overridden. In Git Bash, MSYS rewrites the leading `/d /s /c` switches into `D:/ S:/ C:/` drive paths, so cmd.exe never receives `/c`, starts an interactive session, and exits 0 without ever running the payload (measured matrix in #11431).

This PR skips the cmd.exe wrapper in `wrapWindowsSkillCommandWithNpxPrerequisite` when `resolveWindowsShellStartupFamily(settings.terminalWindowsShell) === 'posix'` (Git Bash, `bash.exe`, `wsl.exe`), returning the bare `npx skills add … --global` command exactly as `main` did before #10453. The store-read mirrors the existing `isRemoteRuntimeEnvironmentFocused()` pattern in the same function.

Behavior after the fix, for a POSIX-family-configured Windows user:

- **Copied command**: bare `npx …` — works when pasted into Git Bash (and still works in PowerShell/cmd if pasted there instead).
- **Spawned terminal**: still forced to `powershell.exe` by the existing #10453 guard, now running the bare command — the same pre-#10453 behavior. The npx-missing guidance is intentionally given up for this cohort; a silent no-op is strictly worse than the pre-#10453 baseline of a shell "command not found" error.
- PowerShell/pwsh/cmd-configured users keep the preflight wrapper unchanged (all three measured PASS in #11431).

`cmd.exe //c` was deliberately **not** used: MSYS collapses `//c` to `/c`, but cmd.exe itself rejects `//c`, which would break the three shells that currently work.

## Screenshots

No visual change on macOS/Linux. On Windows with a POSIX-family shell configured, the displayed/copied setup command reverts from the cmd.exe wrapper to the bare `npx` form.

Real-app validation on this branch (macOS dev build of this worktree, CDP-driven through the real UI): the Orchestration settings pane's skill setup surface — the exact `AgentSkillSetupPanel` + `copyActiveCommand` path from #11431 — with the **Copy command** button clicked and the "Copied command." toast showing. The system clipboard afterward contained exactly `npx skills update orchestration --global` (verified via `pbpaste`), confirming the copied-command surface works and is unchanged on macOS. The Windows-only wrapper path cannot be produced on a darwin build (platform is reported by the frozen `window.api`), so that path is pinned by the red-first unit tests plus the real-Windows measurement in #11431.

![pr11599-orchestration-copy-surface.png](https://github.com/user-attachments/assets/a3190193-c7c4-4956-88e4-fecbfa91bdc0)

## Testing

- [x] `npx oxlint` on changed files (also via pre-commit hooks, including the react-doctor oxlint config)
- [x] `pnpm typecheck` (all three tsconfigs, `.tsbuildinfo` cache cleared first)
- [x] `npx vitest run --config config/vitest.config.ts` on `CliSkillRuntimeSetup.test.tsx` (20 passed) plus the 8 related suites that exercise `buildSkillCommandForRuntime` / the Linear CTA / skill-runtime hooks (60 passed)
- [x] `node config/scripts/check-react-doctor-changed.mjs` — 0 issues
- [x] Added or updated high-quality tests that would catch regressions: two new tests were written **first and confirmed red** on the parent commit — with `terminalWindowsShell: 'git-bash'` (and a `bash.exe` path) the copied command was the cmd.exe wrapper; after the fix they assert the bare install command, and a `cmd.exe`-configured case pins that the preflight wrapper is retained for cmd-family shells.

## AI Review Report

Reviewed the wrapper skip for scope (only the POSIX-family case changes; remote-runtime, WSL-runtime, non-Windows, and non-skill-command paths untouched), for regressions against the #11431 measured matrix (pwsh 7 / PowerShell 5.1 / cmd.exe keep the identical wrapper string, byte-for-byte, per unchanged existing tests), and for cross-platform behavior on macOS/Linux/Windows/WSL (non-win32 platforms return early before the new check; the WSL runtime branch never reaches the wrapper). The store read happens outside render subscription, same trade-off as the existing remote-environment check and explicitly documented there.

Two independent same-model subagent review rounds both returned clean with zero actionable findings, so no review-fix commits were needed. Round 1 verified every clipboard producer routes through `buildSkillCommandForRuntime` (including ruling out `SkillFreshnessUpdateDialog`, which copies a never-wrapped bare command) and confirmed red-on-revert for the new tests first-hand. Round 2 ran seven adversarial attack angles — pre-hydration store reads (settings `null` → `powershell` family → byte-identical pre-PR output), WSL-branch reachability, shell-neutrality of the update→reinstall rewrite under MSYS path conversion (`--`-prefixed and `://`-containing args are exempt from rewriting), i18n gate impact, test store-state leaks, import cycles/formatting drift, and a repo-wide grep for other `where.exe npx` / `/d /s /c` producers (the only other hits are a programmatic PTY agent-launch wrapper and an SSH WMI line, neither user-pasted) — all failed to find a defect.

## Security Audit

No new command execution paths: the change only *removes* a cmd.exe wrapper for one cohort, and the command strings remain fixed constants from `buildAgentFeatureSkillInstallCommand` — no user input is interpolated into the copied command. The new code performs a read-only store lookup (`settings.terminalWindowsShell`) and string classification; no IPC, path handling, or secrets are touched.

## Notes

- Windows-only behavioral change, gated on `currentPlatform === 'win32'` plus the configured-shell family; macOS/Linux/SSH-remote paths are unchanged.
- Left as-is per issue scope (worth a follow-up, mentioned in #11431): `where.exe npx` lists the extensionless `C:\Program Files\nodejs\npx` (a bash script) first on a normal Node install, so a passing preflight does not strictly prove cmd.exe can execute npx — harmless in practice because `npx.cmd` sits beside it.
- The bug cannot be reproduced in a real app run on this macOS host (the wrapper requires a `win32` platform report from the frozen `window.api`), so the repro is the red-first unit test plus the real-Windows measurement recorded in #11431.


### Real Windows Electron QA

On this exact branch in a real Windows dev build, Settings → Terminal was configured for Git Bash. The Orchestration setup surface displayed the bare command and the real Copy command action produced the Copied command toast:

![Windows Orchestration setup with bare command and copy toast](https://github.com/user-attachments/assets/b70a6d3e-2684-490b-a6e0-5769ad8eefe7)

That exact clipboard value was then pasted into a standalone Git Bash window with no cmd.exe wrapper or MSYS-rewritten switches:

![Bare skill command pasted into standalone Git Bash](https://github.com/user-attachments/assets/862b623e-f77e-446c-826f-4ca212efbaa3)

After running the clean bare command, Git Bash reached the real interactive skills CLI agent selector. QA stopped at the prompt before any installation:

![Skills CLI interactive agent selector running in Git Bash](https://github.com/user-attachments/assets/ad8dd1cc-f41c-4b9a-92c6-ec8be4612410)

## Final owner verification (2026-07-30)

- Final head: `381cb84cebd059437af6bc252852901bdbfd019d`.
- Exact-head validation: 9 focused files / 85 tests, cache-cleared `pnpm typecheck`, full `pnpm lint`, React Doctor (0 issues), and `git diff --check`.
- Conflict-free synthetic merge with pinned `main@a906f98baf1d57102731eeb481444928f8826ff9`: the changed test plus a 43-file / 427-test related sweep passed, followed by the same typecheck, lint, React Doctor, and diff gates.
- The mandated same-model/xhigh review loop completed with zero actionable findings (`run_ff79c37f9c32`, final clean task `task_cf10103418ab`). No review-fix commit was required.
- Commit authorship was verified from `%an/%ae`: Brennan Benson `<79079362+brennanb2025@users.noreply.github.com>`.