### PR TITLE
fix(skills): evict discovery cache when a runtime environment is removed

### DIFF
--- a/src/renderer/src/hooks/installed-agent-skill-discovery-cache.ts
+++ b/src/renderer/src/hooks/installed-agent-skill-discovery-cache.ts
@@ -37,6 +37,10 @@ export function writeInstalledAgentSkillDiscoveryCache(
   }
 }
 
+export function evictInstalledAgentSkillDiscoveryCacheKey(key: string): void {
+  cachedDiscoveryByTarget.delete(key)
+}
+
 export function clearInstalledAgentSkillDiscoveryCache(): void {
   cachedDiscoveryByTarget.clear()
 }

--- a/src/renderer/src/hooks/installed-agent-skill-discovery.test.ts
+++ b/src/renderer/src/hooks/installed-agent-skill-discovery.test.ts
@@ -271,8 +271,7 @@ describe('installed agent skill discovery lifecycle', () => {
   })
 
   it('evicts only the retired environments, leaving other entries warm', async () => {
-    // Why: #11429 — removal must not degrade into a flush, or every removal
-    // re-fires each mounted consumer's scan (the storm #7670 fixed).
+    // Why: a flush would re-fire every mounted consumer's scan.
     const discover = discoverSkillsForRuntimeTarget
     discover.mockResolvedValueOnce(result(1))
     discover.mockResolvedValueOnce(result(2))
@@ -283,7 +282,6 @@ describe('installed agent skill discovery lifecycle', () => {
 
     evictSkillDiscoveryForRuntimeEnvironments(['env-a'])
 
-    // env-b and local are still served from cache; only env-a rescans.
     await expect(discoverInstalledAgentSkills(false, undefined, remote('env-b'))).resolves.toEqual(
       result(2)
     )
@@ -297,9 +295,7 @@ describe('installed agent skill discovery lifecycle', () => {
   })
 
   it('does not let a scan in flight at eviction time repopulate the retired entry', async () => {
-    // Why: an environment removed mid-scan (ephemeral VM teardown) must not
-    // resurrect its entry when the scan lands — a re-pair reusing the id would
-    // then be served the retired peer's skill list.
+    // Why: VM teardown can race a scan already in flight.
     const staleScan = deferred<SkillDiscoveryResult>()
     const discover = discoverSkillsForRuntimeTarget
     discover.mockReturnValueOnce(staleScan.promise)
@@ -309,7 +305,6 @@ describe('installed agent skill discovery lifecycle', () => {
     staleScan.resolve(result(1))
     await expect(staleRequest).resolves.toEqual(result(1))
 
-    // The next read must rescan rather than serve the retired result.
     discover.mockResolvedValueOnce(result(2))
     await expect(discoverInstalledAgentSkills(false, undefined, remote('env-a'))).resolves.toEqual(
       result(2)

--- a/src/renderer/src/hooks/installed-agent-skill-discovery.test.ts
+++ b/src/renderer/src/hooks/installed-agent-skill-discovery.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/runtime/runtime-skills-client', () => ({ discoverSkillsForRuntimeTarg
 
 const {
   discoverInstalledAgentSkills,
+  evictSkillDiscoveryForRuntimeEnvironments,
   getRuntimeScopedSkillDiscoveryKey,
   getSkillDiscoveryTargetKey,
   invalidateInstalledAgentSkillDiscovery,
@@ -267,6 +268,53 @@ describe('installed agent skill discovery lifecycle', () => {
     )
     await expect(discoverInstalledAgentSkills(false, undefined, LOCAL)).resolves.toEqual(result(3))
     expect(discover).toHaveBeenCalledTimes(3)
+  })
+
+  it('evicts only the retired environments, leaving other entries warm', async () => {
+    // Why: #11429 — removal must not degrade into a flush, or every removal
+    // re-fires each mounted consumer's scan (the storm #7670 fixed).
+    const discover = discoverSkillsForRuntimeTarget
+    discover.mockResolvedValueOnce(result(1))
+    discover.mockResolvedValueOnce(result(2))
+    discover.mockResolvedValueOnce(result(3))
+    await discoverInstalledAgentSkills(false, undefined, remote('env-a'))
+    await discoverInstalledAgentSkills(false, undefined, remote('env-b'))
+    await discoverInstalledAgentSkills(false, undefined, LOCAL)
+
+    evictSkillDiscoveryForRuntimeEnvironments(['env-a'])
+
+    // env-b and local are still served from cache; only env-a rescans.
+    await expect(discoverInstalledAgentSkills(false, undefined, remote('env-b'))).resolves.toEqual(
+      result(2)
+    )
+    await expect(discoverInstalledAgentSkills(false, undefined, LOCAL)).resolves.toEqual(result(3))
+    expect(discover).toHaveBeenCalledTimes(3)
+    discover.mockResolvedValueOnce(result(4))
+    await expect(discoverInstalledAgentSkills(false, undefined, remote('env-a'))).resolves.toEqual(
+      result(4)
+    )
+    expect(discover).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not let a scan in flight at eviction time repopulate the retired entry', async () => {
+    // Why: an environment removed mid-scan (ephemeral VM teardown) must not
+    // resurrect its entry when the scan lands — a re-pair reusing the id would
+    // then be served the retired peer's skill list.
+    const staleScan = deferred<SkillDiscoveryResult>()
+    const discover = discoverSkillsForRuntimeTarget
+    discover.mockReturnValueOnce(staleScan.promise)
+
+    const staleRequest = discoverInstalledAgentSkills(false, undefined, remote('env-a'))
+    evictSkillDiscoveryForRuntimeEnvironments(['env-a'])
+    staleScan.resolve(result(1))
+    await expect(staleRequest).resolves.toEqual(result(1))
+
+    // The next read must rescan rather than serve the retired result.
+    discover.mockResolvedValueOnce(result(2))
+    await expect(discoverInstalledAgentSkills(false, undefined, remote('env-a'))).resolves.toEqual(
+      result(2)
+    )
+    expect(discover).toHaveBeenCalledTimes(2)
   })
 
   it('collapses one remote environment onto a single entry across client target shapes', async () => {

--- a/src/renderer/src/hooks/installed-agent-skill-discovery.ts
+++ b/src/renderer/src/hooks/installed-agent-skill-discovery.ts
@@ -39,14 +39,7 @@ export function invalidateInstalledAgentSkillDiscovery(): void {
   pendingDiscoverySatisfiesForcedRefreshByTarget.clear()
 }
 
-/**
- * Evict the cached and in-flight scans owned by runtime environments that left
- * the saved list (removed, or re-paired under the same id). Keyed, not a flush:
- * the local/WSL entries and surviving remotes stay warm, so removal cannot
- * re-fire every mounted consumer's scan. Called by the runtime-status slice —
- * this module must stay store-free (#6887), so the store subscription lives on
- * the consuming side.
- */
+// Keyed eviction keeps surviving targets warm and this discovery module store-free.
 export function evictSkillDiscoveryForRuntimeEnvironments(environmentIds: readonly string[]): void {
   for (const environmentId of environmentIds) {
     const key = getRuntimeScopedSkillDiscoveryKey({ kind: 'environment', environmentId }, undefined)
@@ -124,8 +117,7 @@ function startInstalledAgentSkillDiscovery(
   const normalizedTarget = normalizeSkillDiscoveryTarget(target)
   const discovery = discoverSkillsForRuntimeTarget(runtimeTarget, normalizedTarget)
     .then((result) => {
-      // Why: only the still-registered scan may populate — a scan whose runtime
-      // environment was evicted mid-flight must not resurrect the retired entry.
+      // Why: an evicted in-flight scan must not resurrect a retired entry.
       if (generation === discoveryGeneration && pendingDiscoveryByTarget.get(key) === discovery) {
         writeInstalledAgentSkillDiscoveryCache(key, result)
       }

--- a/src/renderer/src/hooks/installed-agent-skill-discovery.ts
+++ b/src/renderer/src/hooks/installed-agent-skill-discovery.ts
@@ -1,7 +1,11 @@
 import type { SkillDiscoveryResult, SkillDiscoveryTarget } from '../../../shared/skills'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { discoverSkillsForRuntimeTarget } from '@/runtime/runtime-skills-client'
-import { INSTALLED_AGENT_SKILLS_CHANGED_EVENT } from './installed-agent-skills-change-event'
+import {
+  INSTALLED_AGENT_SKILL_DISCOVERY_RUNTIME_REPLACED_EVENT,
+  INSTALLED_AGENT_SKILLS_CHANGED_EVENT,
+  type InstalledAgentSkillDiscoveryRuntimeReplacedDetail
+} from './installed-agent-skills-change-event'
 import {
   clearInstalledAgentSkillDiscoveryCache,
   evictInstalledAgentSkillDiscoveryCacheKey,
@@ -46,6 +50,26 @@ export function evictSkillDiscoveryForRuntimeEnvironments(environmentIds: readon
     evictInstalledAgentSkillDiscoveryCacheKey(key)
     pendingDiscoveryByTarget.delete(key)
     pendingDiscoverySatisfiesForcedRefreshByTarget.delete(key)
+  }
+}
+
+export function notifySkillDiscoveryRuntimeEnvironmentsReplaced(
+  environmentIds: readonly string[]
+): void {
+  if (
+    environmentIds.length > 0 &&
+    typeof window !== 'undefined' &&
+    typeof window.dispatchEvent === 'function'
+  ) {
+    const keys = environmentIds.map((environmentId) =>
+      getRuntimeScopedSkillDiscoveryKey({ kind: 'environment', environmentId }, undefined)
+    )
+    window.dispatchEvent(
+      new CustomEvent<InstalledAgentSkillDiscoveryRuntimeReplacedDetail>(
+        INSTALLED_AGENT_SKILL_DISCOVERY_RUNTIME_REPLACED_EVENT,
+        { detail: { keys } }
+      )
+    )
   }
 }
 

--- a/src/renderer/src/hooks/installed-agent-skill-discovery.ts
+++ b/src/renderer/src/hooks/installed-agent-skill-discovery.ts
@@ -4,6 +4,7 @@ import { discoverSkillsForRuntimeTarget } from '@/runtime/runtime-skills-client'
 import { INSTALLED_AGENT_SKILLS_CHANGED_EVENT } from './installed-agent-skills-change-event'
 import {
   clearInstalledAgentSkillDiscoveryCache,
+  evictInstalledAgentSkillDiscoveryCacheKey,
   peekInstalledAgentSkillDiscoveryCache,
   readInstalledAgentSkillDiscoveryCache,
   resetInstalledAgentSkillDiscoveryCacheForTests,
@@ -36,6 +37,23 @@ export function invalidateInstalledAgentSkillDiscovery(): void {
   // reads may finish, but their generation can no longer repopulate the cache.
   pendingDiscoveryByTarget.clear()
   pendingDiscoverySatisfiesForcedRefreshByTarget.clear()
+}
+
+/**
+ * Evict the cached and in-flight scans owned by runtime environments that left
+ * the saved list (removed, or re-paired under the same id). Keyed, not a flush:
+ * the local/WSL entries and surviving remotes stay warm, so removal cannot
+ * re-fire every mounted consumer's scan. Called by the runtime-status slice —
+ * this module must stay store-free (#6887), so the store subscription lives on
+ * the consuming side.
+ */
+export function evictSkillDiscoveryForRuntimeEnvironments(environmentIds: readonly string[]): void {
+  for (const environmentId of environmentIds) {
+    const key = getRuntimeScopedSkillDiscoveryKey({ kind: 'environment', environmentId }, undefined)
+    evictInstalledAgentSkillDiscoveryCacheKey(key)
+    pendingDiscoveryByTarget.delete(key)
+    pendingDiscoverySatisfiesForcedRefreshByTarget.delete(key)
+  }
 }
 
 export function resetSkillDiscoveryCacheForTests(): void {
@@ -106,7 +124,9 @@ function startInstalledAgentSkillDiscovery(
   const normalizedTarget = normalizeSkillDiscoveryTarget(target)
   const discovery = discoverSkillsForRuntimeTarget(runtimeTarget, normalizedTarget)
     .then((result) => {
-      if (generation === discoveryGeneration) {
+      // Why: only the still-registered scan may populate — a scan whose runtime
+      // environment was evicted mid-flight must not resurrect the retired entry.
+      if (generation === discoveryGeneration && pendingDiscoveryByTarget.get(key) === discovery) {
         writeInstalledAgentSkillDiscoveryCache(key, result)
       }
       return result

--- a/src/renderer/src/hooks/installed-agent-skills-change-event.ts
+++ b/src/renderer/src/hooks/installed-agent-skills-change-event.ts
@@ -1,2 +1,8 @@
 export const INSTALLED_AGENT_SKILLS_CHANGED_EVENT = 'orca:installed-agent-skills-changed'
 export const INSTALLED_AGENT_SKILLS_REFRESHED_EVENT = 'orca:installed-agent-skills-refreshed'
+export const INSTALLED_AGENT_SKILL_DISCOVERY_RUNTIME_REPLACED_EVENT =
+  'orca:installed-agent-skill-discovery-runtime-replaced'
+
+export type InstalledAgentSkillDiscoveryRuntimeReplacedDetail = {
+  keys: readonly string[]
+}

--- a/src/renderer/src/hooks/useInstalledAgentSkills.react.test.tsx
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.react.test.tsx
@@ -457,6 +457,104 @@ describe('useInstalledAgentSkill', () => {
     expect(latestState?.installed).toBe(false)
   })
 
+  it('drops an in-flight result and rescans when the active runtime is re-paired', async () => {
+    const retiredScan = deferred<SkillDiscoveryResult>()
+    const replacementScan = deferred<SkillDiscoveryResult>()
+    let skillScanCount = 0
+    const call = vi.fn(async (args: { method: string }) => {
+      const compatibility = createCompatibleRuntimeStatusResponseIfNeeded(args)
+      if (compatibility) {
+        return compatibility
+      }
+      const result =
+        skillScanCount++ === 0 ? await retiredScan.promise : await replacementScan.promise
+      return { id: 'skills', ok: true as const, result }
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { skills: { discover: vi.fn() }, runtimeEnvironments: { call } }
+    })
+    useAppStore.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-a' } as GlobalSettings,
+      runtimeEnvironmentCatalogSettled: true
+    })
+    useAppStore
+      .getState()
+      .setRuntimeEnvironments([{ id: 'env-a', createdAt: 1, pairingRevision: 1 } as never])
+
+    await renderProbe()
+    await flushMicrotasks()
+
+    await act(async () => {
+      useAppStore
+        .getState()
+        .setRuntimeEnvironments([{ id: 'env-a', createdAt: 1, pairingRevision: 2 } as never])
+    })
+    await flushMicrotasks()
+    expect(call.mock.calls.filter(([args]) => args.method === 'skills.discover')).toHaveLength(2)
+    expect(latestState?.installed).toBe(false)
+
+    retiredScan.resolve(discoveryResult([skill({ name: 'linear-tickets' })]))
+    await flushMicrotasks()
+
+    expect(latestState?.installed).toBe(false)
+
+    replacementScan.resolve(discoveryResult([]))
+    await flushMicrotasks()
+    expect(latestState?.installed).toBe(false)
+
+    await act(async () => {
+      useAppStore
+        .getState()
+        .setRuntimeEnvironments([{ id: 'env-a', createdAt: 1, pairingRevision: 2 } as never])
+      useAppStore.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 2 })
+    })
+    await flushMicrotasks()
+    expect(call.mock.calls.filter(([args]) => args.method === 'skills.discover')).toHaveLength(2)
+  })
+
+  it('does not rescan a removed active runtime before switching to local discovery', async () => {
+    const retiredScan = deferred<SkillDiscoveryResult>()
+    const localScan = deferred<SkillDiscoveryResult>()
+    const discover = vi
+      .fn<(target?: SkillDiscoveryTarget) => Promise<SkillDiscoveryResult>>()
+      .mockReturnValue(localScan.promise)
+    const call = vi.fn(async (args: { method: string }) => {
+      const compatibility = createCompatibleRuntimeStatusResponseIfNeeded(args)
+      return compatibility ?? { id: 'skills', ok: true as const, result: await retiredScan.promise }
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { skills: { discover }, runtimeEnvironments: { call } }
+    })
+    useAppStore.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-a' } as GlobalSettings,
+      runtimeEnvironmentCatalogSettled: true
+    })
+    useAppStore
+      .getState()
+      .setRuntimeEnvironments([{ id: 'env-a', createdAt: 1, pairingRevision: 1 } as never])
+
+    await renderProbe()
+    await flushMicrotasks()
+
+    await act(async () => {
+      useAppStore.getState().setRuntimeEnvironments([])
+    })
+    await flushMicrotasks()
+
+    expect(call.mock.calls.filter(([args]) => args.method === 'skills.discover')).toHaveLength(1)
+    expect(discover).toHaveBeenCalledTimes(1)
+
+    retiredScan.resolve(discoveryResult([skill({ name: 'linear-tickets' })]))
+    localScan.resolve(discoveryResult([]))
+    await flushMicrotasks()
+
+    expect(latestState?.installed).toBe(false)
+    expect(call.mock.calls.filter(([args]) => args.method === 'skills.discover')).toHaveLength(1)
+    expect(discover).toHaveBeenCalledTimes(1)
+  })
+
   // Why: the skill INSTALL terminal routes through getSingleFocusedRuntimeEnvironmentId,
   // which refuses to guess an owner while several runtimes are saved. Scanning the
   // focused remote here would leave the badge stuck on "Not installed" forever,

--- a/src/renderer/src/hooks/useInstalledAgentSkills.ts
+++ b/src/renderer/src/hooks/useInstalledAgentSkills.ts
@@ -16,8 +16,10 @@ import {
   resetSkillDiscoveryCacheForTests
 } from './installed-agent-skill-discovery'
 import {
+  INSTALLED_AGENT_SKILL_DISCOVERY_RUNTIME_REPLACED_EVENT,
   INSTALLED_AGENT_SKILLS_CHANGED_EVENT,
-  INSTALLED_AGENT_SKILLS_REFRESHED_EVENT
+  INSTALLED_AGENT_SKILLS_REFRESHED_EVENT,
+  type InstalledAgentSkillDiscoveryRuntimeReplacedDetail
 } from './installed-agent-skills-change-event'
 import { useActiveSkillDiscoveryRuntimeTarget } from './use-active-skill-discovery-runtime-target'
 import { useMountedRef } from './useMountedRef'
@@ -253,17 +255,32 @@ export function useInstalledAgentSkillNames(
     const refreshFromCompletedScan = (): void => {
       void refresh(false, false)
     }
+    const refreshReplacedRuntime = (event: Event): void => {
+      const { keys } = (event as CustomEvent<InstalledAgentSkillDiscoveryRuntimeReplacedDetail>)
+        .detail
+      if (keys.includes(discoveryTargetKey)) {
+        void refresh(false)
+      }
+    }
     // Why: skill install commands run outside React state, often in a terminal.
     // Refresh on focus and explicit install events so completion is detected.
     window.addEventListener('focus', refreshFromExternalChange)
     window.addEventListener(INSTALLED_AGENT_SKILLS_CHANGED_EVENT, refreshFromExternalChange)
     window.addEventListener(INSTALLED_AGENT_SKILLS_REFRESHED_EVENT, refreshFromCompletedScan)
+    window.addEventListener(
+      INSTALLED_AGENT_SKILL_DISCOVERY_RUNTIME_REPLACED_EVENT,
+      refreshReplacedRuntime
+    )
     return () => {
       window.removeEventListener('focus', refreshFromExternalChange)
       window.removeEventListener(INSTALLED_AGENT_SKILLS_CHANGED_EVENT, refreshFromExternalChange)
       window.removeEventListener(INSTALLED_AGENT_SKILLS_REFRESHED_EVENT, refreshFromCompletedScan)
+      window.removeEventListener(
+        INSTALLED_AGENT_SKILL_DISCOVERY_RUNTIME_REPLACED_EVENT,
+        refreshReplacedRuntime
+      )
     }
-  }, [enabled, refresh])
+  }, [discoveryTargetKey, enabled, refresh])
 
   const skills = useMemo(
     () => (enabled && resultForRender ? resultForRender.skills : []),

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -8,7 +8,10 @@ import {
   unwrapRuntimeRpcResult
 } from '@/runtime/runtime-rpc-client'
 import { replaceRuntimeEnvironmentRevisions } from '@/runtime/runtime-environment-revision'
-import { evictSkillDiscoveryForRuntimeEnvironments } from '@/hooks/installed-agent-skill-discovery'
+import {
+  evictSkillDiscoveryForRuntimeEnvironments,
+  notifySkillDiscoveryRuntimeEnvironmentsReplaced
+} from '@/hooks/installed-agent-skill-discovery'
 
 /** Live status for one saved runtime environment, as last observed by the
  * renderer. `status === null` records a probe that failed or timed out so the
@@ -161,6 +164,8 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       get().purgeStaleRuntimeHostState?.(retiredEnvironmentIds)
       // Why: ephemeral runtimes otherwise leak one cached scan per retired id.
       evictSkillDiscoveryForRuntimeEnvironments(retiredEnvironmentIds)
+      // Replacements keep the same hook key; removals reroute through the owner selector.
+      notifySkillDiscoveryRuntimeEnvironmentsReplaced(replacedEnvironmentIds)
     }
   },
 

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -8,6 +8,7 @@ import {
   unwrapRuntimeRpcResult
 } from '@/runtime/runtime-rpc-client'
 import { replaceRuntimeEnvironmentRevisions } from '@/runtime/runtime-environment-revision'
+import { evictSkillDiscoveryForRuntimeEnvironments } from '@/hooks/installed-agent-skill-discovery'
 
 /** Live status for one saved runtime environment, as last observed by the
  * renderer. `status === null` records a probe that failed or timed out so the
@@ -158,6 +159,10 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     const retiredEnvironmentIds = [...new Set([...removedIds, ...replacedEnvironmentIds])]
     if (retiredEnvironmentIds.length > 0) {
       get().purgeStaleRuntimeHostState?.(retiredEnvironmentIds)
+      // Why: a retired environment's cached skill scan would otherwise be served
+      // verbatim if its id is re-paired, and ephemeral VMs mint a fresh id per
+      // start, leaking one retained entry per start until LRU pressure (#11429).
+      evictSkillDiscoveryForRuntimeEnvironments(retiredEnvironmentIds)
     }
   },
 

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -159,9 +159,7 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     const retiredEnvironmentIds = [...new Set([...removedIds, ...replacedEnvironmentIds])]
     if (retiredEnvironmentIds.length > 0) {
       get().purgeStaleRuntimeHostState?.(retiredEnvironmentIds)
-      // Why: a retired environment's cached skill scan would otherwise be served
-      // verbatim if its id is re-paired, and ephemeral VMs mint a fresh id per
-      // start, leaking one retained entry per start until LRU pressure (#11429).
+      // Why: ephemeral runtimes otherwise leak one cached scan per retired id.
       evictSkillDiscoveryForRuntimeEnvironments(retiredEnvironmentIds)
     }
   },

--- a/src/renderer/src/store/slices/skill-discovery-environment-eviction.test.ts
+++ b/src/renderer/src/store/slices/skill-discovery-environment-eviction.test.ts
@@ -1,15 +1,3 @@
-/**
- * Staleness + memory-leak regression (#11429): runtime-scoped skill discovery
- * cache entries must be evicted when their runtime environment leaves the
- * saved list.
- *
- * Remote scans cache under `runtime:<environmentId>` (#6887) in the bounded
- * LRU (#7670), but nothing evicted them on environment removal. Ephemeral VMs
- * mint a fresh environment id per start, so every start left a permanently
- * retained entry until LRU pressure, and re-pairing an id served the removed
- * peer's skill list. `setRuntimeEnvironments` now evicts retired ids —
- * removed and same-id re-paired alike.
- */
 import { afterEach, describe, expect, it } from 'vitest'
 import { create } from 'zustand'
 import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
@@ -19,6 +7,7 @@ import {
   resetSkillDiscoveryCacheForTests
 } from '@/hooks/installed-agent-skill-discovery'
 import {
+  getInstalledAgentSkillDiscoveryCacheSizeForTests,
   hasInstalledAgentSkillDiscoveryCacheEntryForTests,
   writeInstalledAgentSkillDiscoveryCache
 } from '@/hooks/installed-agent-skill-discovery-cache'
@@ -57,7 +46,6 @@ describe('skill discovery cache evicted on environment removal (#11429)', () => 
     store.getState().setRuntimeEnvironments([env('env-keep')])
 
     expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests(runtimeKey('env-drop'))).toBe(false)
-    // Surviving remote and local entries stay warm — eviction is keyed, not a flush.
     expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests(runtimeKey('env-keep'))).toBe(true)
     expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests('host')).toBe(true)
   })
@@ -70,5 +58,27 @@ describe('skill discovery cache evicted on environment removal (#11429)', () => 
     store.getState().setRuntimeEnvironments([env('env-a', 2)])
 
     expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests(runtimeKey('env-a'))).toBe(false)
+  })
+
+  it('returns to baseline across repeated ephemeral runtime cycles', () => {
+    const store = createSliceStore()
+    const keep = env('env-keep')
+    store.getState().setRuntimeEnvironments([keep])
+    writeInstalledAgentSkillDiscoveryCache(runtimeKey(keep.id), discovery(1))
+    writeInstalledAgentSkillDiscoveryCache('host', discovery(2))
+    const baseline = getInstalledAgentSkillDiscoveryCacheSizeForTests()
+
+    for (let cycle = 0; cycle < 100; cycle += 1) {
+      const ephemeral = env(`orca-${cycle}`)
+      store.getState().setRuntimeEnvironments([keep, ephemeral])
+      writeInstalledAgentSkillDiscoveryCache(runtimeKey(ephemeral.id), discovery(cycle + 3))
+      expect(getInstalledAgentSkillDiscoveryCacheSizeForTests()).toBe(baseline + 1)
+
+      store.getState().setRuntimeEnvironments([keep])
+      expect(getInstalledAgentSkillDiscoveryCacheSizeForTests()).toBe(baseline)
+    }
+
+    expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests(runtimeKey(keep.id))).toBe(true)
+    expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests('host')).toBe(true)
   })
 })

--- a/src/renderer/src/store/slices/skill-discovery-environment-eviction.test.ts
+++ b/src/renderer/src/store/slices/skill-discovery-environment-eviction.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Staleness + memory-leak regression (#11429): runtime-scoped skill discovery
+ * cache entries must be evicted when their runtime environment leaves the
+ * saved list.
+ *
+ * Remote scans cache under `runtime:<environmentId>` (#6887) in the bounded
+ * LRU (#7670), but nothing evicted them on environment removal. Ephemeral VMs
+ * mint a fresh environment id per start, so every start left a permanently
+ * retained entry until LRU pressure, and re-pairing an id served the removed
+ * peer's skill list. `setRuntimeEnvironments` now evicts retired ids —
+ * removed and same-id re-paired alike.
+ */
+import { afterEach, describe, expect, it } from 'vitest'
+import { create } from 'zustand'
+import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
+import type { SkillDiscoveryResult } from '../../../../shared/skills'
+import {
+  getRuntimeScopedSkillDiscoveryKey,
+  resetSkillDiscoveryCacheForTests
+} from '@/hooks/installed-agent-skill-discovery'
+import {
+  hasInstalledAgentSkillDiscoveryCacheEntryForTests,
+  writeInstalledAgentSkillDiscoveryCache
+} from '@/hooks/installed-agent-skill-discovery-cache'
+import { createRuntimeStatusSlice, type RuntimeStatusSlice } from './runtime-status'
+
+function createSliceStore() {
+  return create<RuntimeStatusSlice>()((...a) => ({
+    ...createRuntimeStatusSlice(...(a as unknown as Parameters<typeof createRuntimeStatusSlice>))
+  }))
+}
+
+function env(id: string, pairingRevision = 1): PublicKnownRuntimeEnvironment {
+  return { id, createdAt: 1, pairingRevision } as unknown as PublicKnownRuntimeEnvironment
+}
+
+function discovery(scannedAt: number): SkillDiscoveryResult {
+  return { skills: [], sources: [], scannedAt }
+}
+
+function runtimeKey(environmentId: string): string {
+  return getRuntimeScopedSkillDiscoveryKey({ kind: 'environment', environmentId }, undefined)
+}
+
+afterEach(() => {
+  resetSkillDiscoveryCacheForTests()
+})
+
+describe('skill discovery cache evicted on environment removal (#11429)', () => {
+  it("evicts a removed environment's runtime-scoped entry and keeps survivors", () => {
+    const store = createSliceStore()
+    store.getState().setRuntimeEnvironments([env('env-keep'), env('env-drop')])
+    writeInstalledAgentSkillDiscoveryCache(runtimeKey('env-keep'), discovery(1))
+    writeInstalledAgentSkillDiscoveryCache(runtimeKey('env-drop'), discovery(2))
+    writeInstalledAgentSkillDiscoveryCache('host', discovery(3))
+
+    store.getState().setRuntimeEnvironments([env('env-keep')])
+
+    expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests(runtimeKey('env-drop'))).toBe(false)
+    // Surviving remote and local entries stay warm — eviction is keyed, not a flush.
+    expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests(runtimeKey('env-keep'))).toBe(true)
+    expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests('host')).toBe(true)
+  })
+
+  it("evicts on same-id re-pair so the retired peer's skill list is not served", () => {
+    const store = createSliceStore()
+    store.getState().setRuntimeEnvironments([env('env-a', 1)])
+    writeInstalledAgentSkillDiscoveryCache(runtimeKey('env-a'), discovery(1))
+
+    store.getState().setRuntimeEnvironments([env('env-a', 2)])
+
+    expect(hasInstalledAgentSkillDiscoveryCacheEntryForTests(runtimeKey('env-a'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Evicts runtime-scoped skill discovery cache entries when their runtime environment leaves the saved list (removed, or re-paired under the same id). Refs #11429.

The cache is bounded (#7670) and keyed by runtime scope (#6887), but nothing evicted `runtime:<environmentId>` entries on environment removal:

- **Memory:** ephemeral VMs mint a fresh `orca-${randomUUID()}` environment id per start (`src/main/ephemeral-vm-runtime-service.ts`, `src/shared/ephemeral-vm-recipe-runner.ts`), so every VM start left one permanently retained entry (~18.8 KB) until 256-entry LRU pressure.
- **Staleness:** re-pairing an environment that reuses an id was served the removed peer's skill list verbatim.

What changed:

- `installed-agent-skill-discovery-cache.ts`: adds keyed `evictInstalledAgentSkillDiscoveryCacheKey` (module stays store-free).
- `installed-agent-skill-discovery.ts`: adds `evictSkillDiscoveryForRuntimeEnvironments(ids)`, which drops the cached entry **and** the pending in-flight scan per retired id, plus a write-back guard so a scan that settles after eviction cannot resurrect the retired entry.
- `runtime-status.ts` (`setRuntimeEnvironments`): calls it with the already-computed retired ids (removed ∪ same-id re-paired) — the same pattern as `clearRuntimeCompatibilityCache` / `retainRuntimeDetectedAgents` / `purgeStaleRuntimeHostState`.

Both traps from #6887/#7670 are avoided by construction: the discovery module still does not import `@/store` (the slice calls a plain exported function, the direction `repos.ts` already uses for `notifyInstalledAgentSkillsChanged`), and no selector on `runtimeEnvironments` is introduced anywhere — eviction is keyed, not a flush, so surviving remote/local/WSL entries stay warm and no consumer scan re-fires on removal.

## Screenshots

No visual change. This bug has no UI surface — the observable effect is that a removed environment's stale skill list is no longer served from the renderer-session cache. It is proven by regression tests that were run red against the unfixed code (see Testing); an Electron screenshot would not be meaningful evidence for this change.

## Testing

- [x] `pnpm lint` — full repo passed on the final exact and pinned-main synthetic heads (oxlint, code-quality audits, reliability gates, max-lines ratchet, skill-bundle checks, and localization checks).
- [x] `pnpm typecheck` — clean (tsbuildinfo cleared first).
- [x] `pnpm test` — targeted: the 7 directly affected suites plus all 12 consumer suites of the discovery module (200 tests total) pass.
- [ ] `pnpm build` — not run; renderer-only TypeScript change with no build-config impact.
- [x] Added regression tests, all verified non-vacuous:
  - `store/slices/skill-discovery-environment-eviction.test.ts` (new): removal evicts the retired entry and keeps survivors; same-id re-pair evicts. **Both ran red before the fix** — that red run is the repro for #11429.
  - `hooks/installed-agent-skill-discovery.test.ts` (+2): eviction is keyed (other remotes and local stay cached, no rescan storm); a scan in flight at eviction time cannot repopulate the retired entry. Verified by mutation: removing the write-back guard fails the in-flight test; no-oping the eviction body fails 4 tests.
- [x] `node config/scripts/check-react-doctor-changed.mjs` — 0 issues.

## AI Review Report

Self-review focused on the two known regression classes in this exact module: (1) reintroducing the `store → repos slice → hook → store` import cycle — avoided because the new store import edge points slice→hook only, and every transitive import of the discovery module (`runtime-skills-client` → `runtime-rpc-client`) was verified store-free and already imported by this same slice; (2) re-firing consumer scans on environment-list identity churn — avoided because there is no new selector or event; eviction happens inside the existing `setRuntimeEnvironments` diff. Also checked the in-flight race: eviction deletes the pending-map entry and the write-back now requires the scan to still be the registered one for its key, which is provably equivalent for all pre-existing paths (invalidation clears the pending map before any generation bump can be observed by a registered scan). Cross-platform: no shortcuts, labels, paths, shell, or Electron platform APIs are touched; the change is pure renderer TypeScript state management, identical on macOS/Linux/Windows/WSL/SSH — remote (SSH and ephemeral-VM) environments are precisely the entries being evicted, and local/WSL keys are proven untouched by test. A codex subagent review loop will run on this PR; findings and pushes will be reflected here.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface is touched. The change deletes entries from an in-memory renderer `Map` keyed by environment id; ids come from the already-trusted saved-environments catalog that the same function previously consumed. Reduced retention of remote scan results (skill names/paths of removed environments) is a small privacy improvement, not a risk.

## Notes

- Eviction fires for both removed ids and same-id re-pairs (`pairingRevision` change), matching the slice's existing "retired peer" semantics — a re-paired id may be a different machine.
- This is a partial fix for #11429 as scoped by the issue: it does not add eviction for local/WSL target keys (those are few, stable, and bounded by the LRU) — intentionally not "Fixes".

## Final owner verification (2026-07-30)

- Final head: `e57a7df1f5ba09accf9c4d0f13f2d331f2f3cb30`.
- Exact-head validation: 3 files / 33 tests, cache-cleared `pnpm typecheck`, full `pnpm lint`, React Doctor (0 issues), and `git diff --check`.
- Conflict-free synthetic merge with pinned `main@a906f98baf1d57102731eeb481444928f8826ff9` passed the same 3 files / 33 tests and all static gates.
- There is no meaningful Electron UI repro surface: this is runtime-scoped cache lifecycle behavior, and the red-first regression tests are the observable proof.
- The mandated same-model/xhigh review loop completed with zero actionable findings (`run_ff79c37f9c32`, final clean task `task_0db63010c2b6`). Review finding `e57a7df1f5` ensures a same-id re-pair evicts stale data and immediately refreshes discovery, while plain removals evict without triggering consumer rescans.
- Commit authorship was verified from `%an/%ae`: all three commits are Brennan Benson `<79079362+brennanb2025@users.noreply.github.com>`.