### PR TITLE
fix(board): stop truncating workflows longer than 12 columns

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -41,6 +41,7 @@ import { SshConnectionStore } from './ssh/ssh-connection-store'
 import { setSourceControlActionDefault } from '../shared/source-control-ai-actions'
 import { LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { closeTerminalTabInWorkspaceSession } from '../shared/workspace-session-terminal-tab-close'
+import { MAX_WORKSPACE_STATUSES } from '../shared/workspace-statuses'
 
 // Shared mutable state so the electron mock can reference a per-test directory
 const testState = { dir: '' }
@@ -6838,6 +6839,37 @@ describe('Store', () => {
 
     store.updateUI({ syncTaskStatusFromWorkspaceBoard: true })
     expect(store.getUI().syncTaskStatusFromWorkspaceBoard).toBe(true)
+  })
+
+  it('preserves the supported workflow and clamps statuses to the eager lane budget', async () => {
+    const authored = Array.from({ length: MAX_WORKSPACE_STATUSES }, (_, index) => ({
+      id: `state-${index + 1}`,
+      label: `State ${index + 1}`
+    }))
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: { workspaceStatuses: authored },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().workspaceStatuses?.map((status) => status.id)).toEqual(
+      authored.map((status) => status.id)
+    )
+
+    store.updateUI({
+      workspaceStatuses: [...authored, { id: 'state-over-budget', label: 'State over budget' }]
+    })
+    store.flush()
+
+    expect(store.getUI().workspaceStatuses).toHaveLength(MAX_WORKSPACE_STATUSES)
+    expect((readDataFile() as PersistedState).ui.workspaceStatuses).toHaveLength(
+      MAX_WORKSPACE_STATUSES
+    )
   })
 
   it('repairs the known-bad reordered default workspace statuses once on load', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -41,7 +41,6 @@ import { SshConnectionStore } from './ssh/ssh-connection-store'
 import { setSourceControlActionDefault } from '../shared/source-control-ai-actions'
 import { LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { closeTerminalTabInWorkspaceSession } from '../shared/workspace-session-terminal-tab-close'
-import { MAX_WORKSPACE_STATUSES } from '../shared/workspace-statuses'
 
 // Shared mutable state so the electron mock can reference a per-test directory
 const testState = { dir: '' }
@@ -6841,34 +6840,43 @@ describe('Store', () => {
     expect(store.getUI().syncTaskStatusFromWorkspaceBoard).toBe(true)
   })
 
-  it('preserves the supported workflow and clamps statuses to the eager lane budget', async () => {
-    const authored = Array.from({ length: MAX_WORKSPACE_STATUSES }, (_, index) => ({
+  it('preserves workflows above 20 statuses across load, write, and restart', async () => {
+    const imported = Array.from({ length: 21 }, (_, index) => ({
       id: `state-${index + 1}`,
       label: `State ${index + 1}`
-    }))
+    })).toReversed()
     writeDataFile({
       schemaVersion: 1,
       repos: [],
       worktreeMeta: {},
       settings: {},
-      ui: { workspaceStatuses: authored },
+      ui: { workspaceStatuses: imported },
       githubCache: { pr: {}, issue: {} },
       workspaceSession: {}
     })
 
     const store = await createStore()
     expect(store.getUI().workspaceStatuses?.map((status) => status.id)).toEqual(
-      authored.map((status) => status.id)
+      imported.map((status) => status.id)
     )
 
-    store.updateUI({
-      workspaceStatuses: [...authored, { id: 'state-over-budget', label: 'State over budget' }]
-    })
+    const authored = Array.from({ length: 64 }, (_, index) => ({
+      id: `final-${String(index + 1).padStart(3, '0')}`,
+      label: `Final ${index + 1}`
+    })).toReversed()
+    store.updateUI({ workspaceStatuses: authored })
     store.flush()
 
-    expect(store.getUI().workspaceStatuses).toHaveLength(MAX_WORKSPACE_STATUSES)
-    expect((readDataFile() as PersistedState).ui.workspaceStatuses).toHaveLength(
-      MAX_WORKSPACE_STATUSES
+    expect(store.getUI().workspaceStatuses?.map((status) => status.id)).toEqual(
+      authored.map((status) => status.id)
+    )
+    expect(
+      (readDataFile() as PersistedState).ui.workspaceStatuses?.map((status) => status.id)
+    ).toEqual(authored.map((status) => status.id))
+
+    const restarted = await createStore()
+    expect(restarted.getUI().workspaceStatuses?.map((status) => status.id)).toEqual(
+      authored.map((status) => status.id)
     )
   })
 

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -899,6 +899,7 @@ export default function WorkspaceKanbanDrawer({
             className="min-h-0 flex-1 overflow-x-auto overflow-y-hidden scrollbar-sleek"
           >
             <WorkspaceKanbanLaneGrid
+              laneScrollerRef={laneScrollerRef}
               statuses={workspaceStatuses}
               laneViews={laneViews}
               laneFullWorktreeIds={laneFullWorktreeIds}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.test.tsx
@@ -1,0 +1,229 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import React, { createRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo, WorkspaceStatusDefinition, Worktree } from '../../../../shared/types'
+
+const virtualWindow = vi.hoisted(() => ({ startIndex: 0, visibleCount: 4 }))
+const animationFrames = new Map<number, FrameRequestCallback>()
+let nextAnimationFrameId = 1
+
+vi.mock('@tanstack/react-virtual', () => {
+  const defaultRangeExtractor = (range: {
+    startIndex: number
+    endIndex: number
+    overscan: number
+    count: number
+  }): number[] => {
+    const start = Math.max(0, range.startIndex - range.overscan)
+    const end = Math.min(range.count - 1, range.endIndex + range.overscan)
+    return Array.from({ length: Math.max(0, end - start + 1) }, (_, index) => start + index)
+  }
+  return {
+    defaultRangeExtractor,
+    useVirtualizer: (options: {
+      count: number
+      estimateSize: (index: number) => number
+      getItemKey: (index: number) => string | number
+      gap: number
+      rangeExtractor: (range: {
+        startIndex: number
+        endIndex: number
+        overscan: number
+        count: number
+      }) => number[]
+    }) => {
+      const endIndex = Math.min(
+        options.count - 1,
+        virtualWindow.startIndex + virtualWindow.visibleCount - 1
+      )
+      const indexes =
+        options.count === 0
+          ? []
+          : options.rangeExtractor({
+              startIndex: virtualWindow.startIndex,
+              endIndex,
+              overscan: 1,
+              count: options.count
+            })
+      const size = options.estimateSize(0)
+      return {
+        getTotalSize: () => Math.max(0, options.count * size + (options.count - 1) * options.gap),
+        getVirtualItems: () =>
+          indexes.map((index) => ({
+            index,
+            key: options.getItemKey(index),
+            start: index * (size + options.gap)
+          })),
+        measureElement: () => {},
+        measure: () => {}
+      }
+    }
+  }
+})
+
+vi.mock('./WorkspaceKanbanStatusLane', () => ({
+  default: ({
+    status,
+    items,
+    renderCards
+  }: {
+    status: WorkspaceStatusDefinition
+    items: readonly Worktree[]
+    renderCards: boolean
+  }) => (
+    <section
+      data-workspace-status={status.id}
+      data-item-count={items.length}
+      data-render-cards={renderCards ? 'true' : 'false'}
+    >
+      <button type="button">{status.label}</button>
+    </section>
+  )
+}))
+
+const { default: WorkspaceKanbanLaneGrid } = await import('./WorkspaceKanbanLaneGrid')
+const { extractWorkspaceKanbanLaneRange } = await import('./workspace-kanban-lane-range')
+
+const STATUSES = Array.from({ length: 21 }, (_, index) => ({
+  id: `state-${String(index + 1).padStart(2, '0')}`,
+  label: `State ${index + 1}`
+}))
+const REPO_MAP = new Map<string, Repo>()
+
+function makeGrid(): React.JSX.Element {
+  return (
+    <WorkspaceKanbanLaneGrid
+      laneScrollerRef={createRef()}
+      statuses={STATUSES}
+      laneViews={new Map()}
+      laneFullWorktreeIds={new Map()}
+      hasQuery={false}
+      repoMap={REPO_MAP}
+      activeWorktreeId={null}
+      columnWidth={308}
+      isResizingColumn={false}
+      dragOverStatus={null}
+      canCreateWorktree={true}
+      renderCards={true}
+      selectedWorktreeIds={new Set()}
+      selectedWorktrees={[]}
+      onDragOver={() => {}}
+      onDragLeave={() => {}}
+      onDrop={() => {}}
+      onActivate={() => {}}
+      onSelectionGesture={() => false}
+      onContextMenuSelect={() => []}
+      onCreateWorktree={() => {}}
+      onColumnResizeStart={() => {}}
+      onColumnResizeKeyDown={() => {}}
+    />
+  )
+}
+
+function renderGrid(): ReturnType<typeof render> {
+  return render(makeGrid())
+}
+
+function mountedStatusIds(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-workspace-status]')).map(
+    (lane) => lane.dataset.workspaceStatus ?? ''
+  )
+}
+
+function flushNextAnimationFrame(): void {
+  const next = animationFrames.entries().next().value as [number, FrameRequestCallback] | undefined
+  expect(next).toBeDefined()
+  if (!next) {
+    return
+  }
+  animationFrames.delete(next[0])
+  act(() => next[1](performance.now()))
+}
+
+beforeEach(() => {
+  animationFrames.clear()
+  nextAnimationFrameId = 1
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    const id = nextAnimationFrameId
+    nextAnimationFrameId += 1
+    animationFrames.set(id, callback)
+    return id
+  })
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+    animationFrames.delete(id)
+  })
+})
+
+afterEach(() => {
+  virtualWindow.startIndex = 0
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('WorkspaceKanbanLaneGrid', () => {
+  it('reserves the full workflow width while mounting only the horizontal window', () => {
+    const { container } = renderGrid()
+
+    expect(mountedStatusIds(container)).toEqual([
+      'state-01',
+      'state-02',
+      'state-03',
+      'state-04',
+      'state-05'
+    ])
+    expect(
+      container.querySelector<HTMLElement>('[data-workspace-board-lane-grid]')?.style.width
+    ).toBe(`${21 * 308 + 20 * 12}px`)
+  })
+
+  it('mounts later ordered lanes and releases distant lanes after horizontal scroll', () => {
+    const rendered = renderGrid()
+    virtualWindow.startIndex = 17
+    rendered.rerender(makeGrid())
+
+    expect(mountedStatusIds(rendered.container)).toEqual([
+      'state-17',
+      'state-18',
+      'state-19',
+      'state-20',
+      'state-21'
+    ])
+    expect(rendered.container.querySelector('[data-workspace-status="state-01"]')).toBeNull()
+  })
+
+  it('keeps one focused lane mounted without unbounding the virtual window', () => {
+    const rendered = renderGrid()
+    fireEvent.focus(rendered.getByRole('button', { name: 'State 1' }))
+
+    virtualWindow.startIndex = 17
+    rendered.rerender(makeGrid())
+
+    expect(mountedStatusIds(rendered.container)).toEqual([
+      'state-01',
+      'state-17',
+      'state-18',
+      'state-19',
+      'state-20',
+      'state-21'
+    ])
+  })
+
+  it('adds only the focused lane to the normal overscanned range', () => {
+    expect(
+      extractWorkspaceKanbanLaneRange({ startIndex: 4, endIndex: 7, overscan: 1, count: 21 }, 18)
+    ).toEqual([3, 4, 5, 6, 7, 8, 18])
+  })
+
+  it('hydrates at most one mounted lane per animation frame', () => {
+    const { container } = renderGrid()
+    const renderedLaneCount = (): number =>
+      container.querySelectorAll('[data-render-cards="true"]').length
+
+    expect(renderedLaneCount()).toBe(0)
+    flushNextAnimationFrame()
+    expect(renderedLaneCount()).toBe(1)
+    flushNextAnimationFrame()
+    expect(renderedLaneCount()).toBe(2)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
@@ -1,4 +1,13 @@
-import React from 'react'
+import React, {
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import { useVirtualizer, type Range } from '@tanstack/react-virtual'
 import type {
   Repo,
   WorkspaceStatus,
@@ -6,12 +15,17 @@ import type {
   Worktree
 } from '../../../../shared/types'
 import type { WorkspaceKanbanLaneView } from './workspace-kanban-search'
+import { extractWorkspaceKanbanLaneRange } from './workspace-kanban-lane-range'
 import WorkspaceKanbanStatusLane from './WorkspaceKanbanStatusLane'
 
 // Why: a fresh [] per render would defeat the memoized lane on empty lanes.
 const EMPTY_LANE_ITEMS: readonly Worktree[] = []
+const EMPTY_RENDERED_LANE_IDS: ReadonlySet<WorkspaceStatus> = new Set()
+const WORKSPACE_BOARD_LANE_GAP = 12
+const WORKSPACE_BOARD_LANE_OVERSCAN = 1
 
 type WorkspaceKanbanLaneGridProps = {
+  laneScrollerRef: React.RefObject<HTMLDivElement | null>
   statuses: readonly WorkspaceStatusDefinition[]
   laneViews: ReadonlyMap<WorkspaceStatus, WorkspaceKanbanLaneView>
   laneFullWorktreeIds: ReadonlyMap<WorkspaceStatus, readonly string[]>
@@ -41,6 +55,7 @@ type WorkspaceKanbanLaneGridProps = {
 }
 
 export default function WorkspaceKanbanLaneGrid({
+  laneScrollerRef,
   statuses,
   laneViews,
   laneFullWorktreeIds,
@@ -65,44 +80,155 @@ export default function WorkspaceKanbanLaneGrid({
   onColumnResizeStart,
   onColumnResizeKeyDown
 }: WorkspaceKanbanLaneGridProps): React.JSX.Element {
+  const [focusedStatusId, setFocusedStatusId] = useState<WorkspaceStatus | null>(null)
+  const [renderedLaneIds, setRenderedLaneIds] =
+    useState<ReadonlySet<WorkspaceStatus>>(EMPTY_RENDERED_LANE_IDS)
+  const renderedLaneIdsRef = useRef(renderedLaneIds)
+  const renderCardsRef = useRef(renderCards)
+  useLayoutEffect(() => {
+    renderedLaneIdsRef.current = renderedLaneIds
+    renderCardsRef.current = renderCards
+  }, [renderCards, renderedLaneIds])
+  const focusedIndex = useMemo(
+    () =>
+      focusedStatusId === null
+        ? null
+        : statuses.findIndex((status) => status.id === focusedStatusId),
+    [focusedStatusId, statuses]
+  )
+  const estimateLaneSize = useCallback(() => columnWidth, [columnWidth])
+  const getLaneKey = useCallback((index: number) => statuses[index]?.id ?? index, [statuses])
+  const rangeExtractor = useCallback(
+    (range: Range) => extractWorkspaceKanbanLaneRange(range, focusedIndex),
+    [focusedIndex]
+  )
+  const laneVirtualizer = useVirtualizer({
+    count: statuses.length,
+    getScrollElement: () => laneScrollerRef.current,
+    estimateSize: estimateLaneSize,
+    getItemKey: getLaneKey,
+    horizontal: true,
+    overscan: WORKSPACE_BOARD_LANE_OVERSCAN,
+    gap: WORKSPACE_BOARD_LANE_GAP,
+    rangeExtractor,
+    useFlushSync: false
+  })
+  useLayoutEffect(() => {
+    laneVirtualizer.measure()
+  }, [columnWidth, laneVirtualizer])
+  const virtualLanes = laneVirtualizer.getVirtualItems()
+  const virtualStatusIds = useMemo(
+    () =>
+      virtualLanes.flatMap((virtualLane) => {
+        const status = statuses[virtualLane.index]
+        return status ? [status.id] : []
+      }),
+    [statuses, virtualLanes]
+  )
+  const mountedLaneIds = useMemo(() => new Set(virtualStatusIds), [virtualStatusIds])
+  const mountedLaneIdsRef = useRef<ReadonlySet<WorkspaceStatus>>(mountedLaneIds)
+  useLayoutEffect(() => {
+    mountedLaneIdsRef.current = mountedLaneIds
+  }, [mountedLaneIds])
+  useEffect(() => {
+    if (!renderCards) {
+      setRenderedLaneIds(EMPTY_RENDERED_LANE_IDS)
+      return
+    }
+    const missingIds = virtualStatusIds.filter((id) => !renderedLaneIdsRef.current.has(id))
+    setRenderedLaneIds((current) => {
+      const retained = new Set(Array.from(current).filter((id) => mountedLaneIds.has(id)))
+      return retained.size === current.size ? current : retained
+    })
+    let nextIndex = 0
+    let frameId = 0
+    const renderNextLane = (): void => {
+      const statusId = missingIds[nextIndex]
+      nextIndex += 1
+      if (!statusId) {
+        return
+      }
+      startTransition(() => {
+        setRenderedLaneIds((current) => {
+          if (!renderCardsRef.current || !mountedLaneIdsRef.current.has(statusId)) {
+            return current
+          }
+          return new Set(current).add(statusId)
+        })
+      })
+      if (nextIndex < missingIds.length) {
+        frameId = window.requestAnimationFrame(renderNextLane)
+      }
+    }
+    if (missingIds.length > 0) {
+      frameId = window.requestAnimationFrame(renderNextLane)
+    }
+    return () => window.cancelAnimationFrame(frameId)
+  }, [mountedLaneIds, renderCards, virtualStatusIds])
+
   return (
     <div
-      className="grid h-full min-h-0 min-w-full grid-rows-[minmax(0,1fr)] gap-3"
+      className="relative h-full min-h-0 min-w-full"
       data-contextual-tour-target="workspace-board-lanes"
-      style={{
-        gridTemplateColumns: `repeat(${statuses.length}, minmax(${columnWidth}px, ${columnWidth}px))`
+      data-workspace-board-lane-grid=""
+      style={{ width: `${laneVirtualizer.getTotalSize()}px` }}
+      onFocusCapture={(event) => {
+        const lane = (event.target as Element).closest<HTMLElement>('[data-workspace-status]')
+        setFocusedStatusId(lane?.dataset.workspaceStatus ?? null)
+      }}
+      onBlurCapture={(event) => {
+        const nextTarget = event.relatedTarget
+        if (!(nextTarget instanceof Node) || !event.currentTarget.contains(nextTarget)) {
+          setFocusedStatusId(null)
+        }
       }}
     >
-      {statuses.map((status) => (
-        <WorkspaceKanbanStatusLane
-          key={status.id}
-          status={status}
-          items={laneViews.get(status.id)?.items ?? EMPTY_LANE_ITEMS}
-          totalCount={laneViews.get(status.id)?.totalCount ?? 0}
-          hasQuery={hasQuery}
-          fullWorktreeIds={laneFullWorktreeIds.get(status.id) ?? []}
-          repoMap={repoMap}
-          activeWorktreeId={activeWorktreeId}
-          columnWidth={columnWidth}
-          isResizingColumn={isResizingColumn}
-          isDragTarget={dragOverStatus === status.id}
-          canCreateWorktree={canCreateWorktree}
-          renderCards={renderCards}
-          selectedWorktreeIds={selectedWorktreeIds}
-          selectedWorktrees={selectedWorktrees}
-          nativeDragEnabled={false}
-          onDragOver={onDragOver}
-          onDragLeave={onDragLeave}
-          onDrop={onDrop}
-          onActivate={onActivate}
-          onSelectionGesture={onSelectionGesture}
-          onContextMenuSelect={onContextMenuSelect}
-          onAssignWorkspaceStatus={onAssignWorkspaceStatus}
-          onCreateWorktree={onCreateWorktree}
-          onColumnResizeStart={onColumnResizeStart}
-          onColumnResizeKeyDown={onColumnResizeKeyDown}
-        />
-      ))}
+      {virtualLanes.map((virtualLane) => {
+        const status = statuses[virtualLane.index]
+        if (!status) {
+          return null
+        }
+        return (
+          <div
+            key={virtualLane.key}
+            ref={laneVirtualizer.measureElement}
+            data-index={virtualLane.index}
+            className="absolute left-0 top-0 h-full"
+            style={{
+              width: `${columnWidth}px`,
+              transform: `translateX(${virtualLane.start}px)`
+            }}
+          >
+            <WorkspaceKanbanStatusLane
+              status={status}
+              items={laneViews.get(status.id)?.items ?? EMPTY_LANE_ITEMS}
+              totalCount={laneViews.get(status.id)?.totalCount ?? 0}
+              hasQuery={hasQuery}
+              fullWorktreeIds={laneFullWorktreeIds.get(status.id) ?? []}
+              repoMap={repoMap}
+              activeWorktreeId={activeWorktreeId}
+              columnWidth={columnWidth}
+              isResizingColumn={isResizingColumn}
+              isDragTarget={dragOverStatus === status.id}
+              canCreateWorktree={canCreateWorktree}
+              renderCards={renderCards && renderedLaneIds.has(status.id)}
+              selectedWorktreeIds={selectedWorktreeIds}
+              selectedWorktrees={selectedWorktrees}
+              nativeDragEnabled={false}
+              onDragOver={onDragOver}
+              onDragLeave={onDragLeave}
+              onDrop={onDrop}
+              onActivate={onActivate}
+              onSelectionGesture={onSelectionGesture}
+              onContextMenuSelect={onContextMenuSelect}
+              onAssignWorkspaceStatus={onAssignWorkspaceStatus}
+              onCreateWorktree={onCreateWorktree}
+              onColumnResizeStart={onColumnResizeStart}
+              onColumnResizeKeyDown={onColumnResizeKeyDown}
+            />
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.test.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { act, type ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { WorkspaceStatusDefinition } from '../../../../shared/types'
+import { MAX_WORKSPACE_STATUSES } from '../../../../shared/workspace-statuses'
 
 const statuses: WorkspaceStatusDefinition[] = [{ id: 'todo', label: 'Todo' }]
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -25,14 +26,22 @@ import WorkspaceKanbanSettingsMenu from './WorkspaceKanbanSettingsMenu'
 let root: Root | null = null
 let container: HTMLDivElement | null = null
 
-function renderMenu(onSyncTaskStatusFromWorkspaceBoardChange = vi.fn()): void {
+function renderMenu({
+  workspaceStatuses = statuses,
+  onSyncTaskStatusFromWorkspaceBoardChange = vi.fn<(enabled: boolean) => void>(),
+  onAddStatus = vi.fn<() => void>()
+}: {
+  workspaceStatuses?: WorkspaceStatusDefinition[]
+  onSyncTaskStatusFromWorkspaceBoardChange?: (enabled: boolean) => void
+  onAddStatus?: () => void
+} = {}): void {
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
   act(() => {
     root?.render(
       <WorkspaceKanbanSettingsMenu
-        workspaceStatuses={statuses}
+        workspaceStatuses={workspaceStatuses}
         syncTaskStatusFromWorkspaceBoard={false}
         onSyncTaskStatusFromWorkspaceBoardChange={onSyncTaskStatusFromWorkspaceBoardChange}
         onRenameStatus={vi.fn()}
@@ -40,7 +49,7 @@ function renderMenu(onSyncTaskStatusFromWorkspaceBoardChange = vi.fn()): void {
         onChangeStatusIcon={vi.fn()}
         onMoveStatus={vi.fn()}
         onRemoveStatus={vi.fn()}
-        onAddStatus={vi.fn()}
+        onAddStatus={onAddStatus}
       />
     )
   })
@@ -59,7 +68,7 @@ afterEach(() => {
 describe('WorkspaceKanbanSettingsMenu', () => {
   it('renders the task status sync switch and forwards changes', async () => {
     const onChange = vi.fn()
-    renderMenu(onChange)
+    renderMenu({ onSyncTaskStatusFromWorkspaceBoardChange: onChange })
 
     const toggle = document.querySelector<HTMLButtonElement>(
       'button[role="switch"][aria-label="Sync board and issue status"]'
@@ -73,5 +82,43 @@ describe('WorkspaceKanbanSettingsMenu', () => {
     })
 
     expect(onChange).toHaveBeenCalledWith(true)
+  })
+
+  it('adds another status below the board limit', () => {
+    const onAddStatus = vi.fn()
+    renderMenu({ onAddStatus })
+
+    const addStatus = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Add status'
+    )
+
+    expect(addStatus?.disabled).toBe(false)
+    addStatus?.click()
+    expect(onAddStatus).toHaveBeenCalledOnce()
+  })
+
+  it('disables adding another status at the explicit board limit', () => {
+    const onAddStatus = vi.fn()
+    renderMenu({
+      workspaceStatuses: Array.from({ length: MAX_WORKSPACE_STATUSES }, (_, index) => ({
+        id: `state-${index + 1}`,
+        label: `State ${index + 1}`
+      })),
+      onAddStatus
+    })
+
+    const addStatus = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim().startsWith('Add status') === true
+    )
+
+    expect(document.body.textContent).toContain(
+      `${MAX_WORKSPACE_STATUSES} / ${MAX_WORKSPACE_STATUSES}`
+    )
+    expect(addStatus?.textContent).toContain(
+      `${MAX_WORKSPACE_STATUSES} / ${MAX_WORKSPACE_STATUSES}`
+    )
+    expect(addStatus?.disabled).toBe(true)
+    addStatus?.click()
+    expect(onAddStatus).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.test.tsx
@@ -3,7 +3,6 @@ import { createRoot, type Root } from 'react-dom/client'
 import { act, type ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { WorkspaceStatusDefinition } from '../../../../shared/types'
-import { MAX_WORKSPACE_STATUSES } from '../../../../shared/workspace-statuses'
 
 const statuses: WorkspaceStatusDefinition[] = [{ id: 'todo', label: 'Todo' }]
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -84,9 +83,15 @@ describe('WorkspaceKanbanSettingsMenu', () => {
     expect(onChange).toHaveBeenCalledWith(true)
   })
 
-  it('adds another status below the board limit', () => {
+  it('keeps adding available for workflows above the former board limit', () => {
     const onAddStatus = vi.fn()
-    renderMenu({ onAddStatus })
+    renderMenu({
+      workspaceStatuses: Array.from({ length: 21 }, (_, index) => ({
+        id: `state-${index + 1}`,
+        label: `State ${index + 1}`
+      })),
+      onAddStatus
+    })
 
     const addStatus = Array.from(document.querySelectorAll('button')).find(
       (button) => button.textContent?.trim() === 'Add status'
@@ -95,26 +100,5 @@ describe('WorkspaceKanbanSettingsMenu', () => {
     expect(addStatus?.disabled).toBe(false)
     addStatus?.click()
     expect(onAddStatus).toHaveBeenCalledOnce()
-  })
-
-  it('disables adding another status at the explicit board limit', () => {
-    const onAddStatus = vi.fn()
-    renderMenu({
-      workspaceStatuses: Array.from({ length: MAX_WORKSPACE_STATUSES }, (_, index) => ({
-        id: `state-${index + 1}`,
-        label: `State ${index + 1}`
-      })),
-      onAddStatus
-    })
-
-    const addStatus = Array.from(document.querySelectorAll('button')).find(
-      (button) => button.textContent?.trim().startsWith('Add status') === true
-    )
-
-    expect(document.body.textContent).toContain('20 / 20')
-    expect(addStatus?.textContent).toContain('20 / 20')
-    expect(addStatus?.disabled).toBe(true)
-    addStatus?.click()
-    expect(onAddStatus).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.test.tsx
@@ -111,12 +111,8 @@ describe('WorkspaceKanbanSettingsMenu', () => {
       (button) => button.textContent?.trim().startsWith('Add status') === true
     )
 
-    expect(document.body.textContent).toContain(
-      `${MAX_WORKSPACE_STATUSES} / ${MAX_WORKSPACE_STATUSES}`
-    )
-    expect(addStatus?.textContent).toContain(
-      `${MAX_WORKSPACE_STATUSES} / ${MAX_WORKSPACE_STATUSES}`
-    )
+    expect(document.body.textContent).toContain('20 / 20')
+    expect(addStatus?.textContent).toContain('20 / 20')
     expect(addStatus?.disabled).toBe(true)
     addStatus?.click()
     expect(onAddStatus).not.toHaveBeenCalled()

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
@@ -11,6 +11,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils'
 import { SettingsSwitch } from '../settings/SettingsFormControls'
 import type { WorkspaceStatusDefinition } from '../../../../shared/types'
+import { MAX_WORKSPACE_STATUSES } from '../../../../shared/workspace-statuses'
 import { getWorkspaceStatusVisualMeta } from './workspace-status'
 import WorkspaceStatusAppearancePopover from './WorkspaceStatusAppearancePopover'
 import { translate } from '@/i18n/i18n'
@@ -38,6 +39,8 @@ export default function WorkspaceKanbanSettingsMenu({
   onRemoveStatus,
   onAddStatus
 }: WorkspaceKanbanSettingsMenuProps): React.JSX.Element {
+  const statusLimitReached = workspaceStatuses.length >= MAX_WORKSPACE_STATUSES
+
   return (
     <DropdownMenu modal={false}>
       <Tooltip>
@@ -195,6 +198,7 @@ export default function WorkspaceKanbanSettingsMenu({
             variant="ghost"
             size="xs"
             className="mt-1 h-7 w-full justify-start text-[12px]"
+            disabled={statusLimitReached}
             onClick={onAddStatus}
           >
             <Plus className="size-3.5" />
@@ -202,6 +206,11 @@ export default function WorkspaceKanbanSettingsMenu({
               'auto.components.sidebar.WorkspaceKanbanSettingsMenu.79eb990aa4',
               'Add status'
             )}
+            {statusLimitReached ? (
+              <span className="ml-auto font-normal text-muted-foreground">
+                {workspaceStatuses.length} / {MAX_WORKSPACE_STATUSES}
+              </span>
+            ) : null}
           </Button>
         </div>
       </DropdownMenuContent>

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanSettingsMenu.tsx
@@ -11,7 +11,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils'
 import { SettingsSwitch } from '../settings/SettingsFormControls'
 import type { WorkspaceStatusDefinition } from '../../../../shared/types'
-import { MAX_WORKSPACE_STATUSES } from '../../../../shared/workspace-statuses'
 import { getWorkspaceStatusVisualMeta } from './workspace-status'
 import WorkspaceStatusAppearancePopover from './WorkspaceStatusAppearancePopover'
 import { translate } from '@/i18n/i18n'
@@ -39,8 +38,6 @@ export default function WorkspaceKanbanSettingsMenu({
   onRemoveStatus,
   onAddStatus
 }: WorkspaceKanbanSettingsMenuProps): React.JSX.Element {
-  const statusLimitReached = workspaceStatuses.length >= MAX_WORKSPACE_STATUSES
-
   return (
     <DropdownMenu modal={false}>
       <Tooltip>
@@ -198,7 +195,6 @@ export default function WorkspaceKanbanSettingsMenu({
             variant="ghost"
             size="xs"
             className="mt-1 h-7 w-full justify-start text-[12px]"
-            disabled={statusLimitReached}
             onClick={onAddStatus}
           >
             <Plus className="size-3.5" />
@@ -206,11 +202,6 @@ export default function WorkspaceKanbanSettingsMenu({
               'auto.components.sidebar.WorkspaceKanbanSettingsMenu.79eb990aa4',
               'Add status'
             )}
-            {statusLimitReached ? (
-              <span className="ml-auto font-normal text-muted-foreground">
-                {workspaceStatuses.length} / {MAX_WORKSPACE_STATUSES}
-              </span>
-            ) : null}
           </Button>
         </div>
       </DropdownMenuContent>

--- a/src/renderer/src/components/sidebar/workspace-kanban-lane-range.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-lane-range.ts
@@ -1,0 +1,17 @@
+import { defaultRangeExtractor, type Range } from '@tanstack/react-virtual'
+
+export function extractWorkspaceKanbanLaneRange(
+  range: Range,
+  focusedIndex: number | null
+): number[] {
+  const indexes = defaultRangeExtractor(range)
+  if (
+    focusedIndex === null ||
+    focusedIndex < 0 ||
+    focusedIndex >= range.count ||
+    indexes.includes(focusedIndex)
+  ) {
+    return indexes
+  }
+  return [...indexes, focusedIndex].sort((left, right) => left - right)
+}

--- a/src/shared/workspace-statuses.test.ts
+++ b/src/shared/workspace-statuses.test.ts
@@ -3,7 +3,6 @@ import {
   WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT,
   WORKSPACE_BOARD_COLUMN_WIDTH_MAX,
   WORKSPACE_BOARD_COLUMN_WIDTH_MIN,
-  MAX_WORKSPACE_STATUSES,
   clampWorkspaceBoardColumnWidth,
   cloneDefaultWorkspaceStatuses,
   normalizePersistedWorkspaceStatuses,
@@ -11,7 +10,7 @@ import {
 } from './workspace-statuses'
 
 describe('workspace status visuals', () => {
-  it.each([13, 20])('keeps all %i authored columns in order', (count) => {
+  it.each([13, 20, 21, 64])('keeps all %i authored columns in order', (count) => {
     const authored = Array.from({ length: count }, (_, index) => ({
       id: `state-${index + 1}`,
       label: `State ${index + 1}`
@@ -23,17 +22,15 @@ describe('workspace status visuals', () => {
     expect(statuses.map((status) => status.id)).toEqual(authored.map((status) => status.id))
   })
 
-  it('clamps corrupted payloads to the exact board limit', () => {
-    const corrupted = Array.from({ length: 500 }, (_, index) => ({
+  it('normalizes every valid status without truncating the workflow', () => {
+    const authored = Array.from({ length: 500 }, (_, index) => ({
       id: `state-${index}`,
       label: `State ${index}`
     }))
 
-    expect(normalizeWorkspaceStatuses(corrupted)).toHaveLength(MAX_WORKSPACE_STATUSES)
-  })
-
-  it('keeps eager board rendering within its measured lane budget', () => {
-    expect(MAX_WORKSPACE_STATUSES).toBe(20)
+    expect(normalizeWorkspaceStatuses(authored).map((status) => status.id)).toEqual(
+      authored.map((status) => status.id)
+    )
   })
 
   it('keeps the default workflow order', () => {

--- a/src/shared/workspace-statuses.test.ts
+++ b/src/shared/workspace-statuses.test.ts
@@ -32,6 +32,10 @@ describe('workspace status visuals', () => {
     expect(normalizeWorkspaceStatuses(corrupted)).toHaveLength(MAX_WORKSPACE_STATUSES)
   })
 
+  it('keeps eager board rendering within its measured lane budget', () => {
+    expect(MAX_WORKSPACE_STATUSES).toBe(20)
+  })
+
   it('keeps the default workflow order', () => {
     expect(cloneDefaultWorkspaceStatuses().map((status) => status.id)).toEqual([
       'todo',

--- a/src/shared/workspace-statuses.test.ts
+++ b/src/shared/workspace-statuses.test.ts
@@ -10,6 +10,30 @@ import {
 } from './workspace-statuses'
 
 describe('workspace status visuals', () => {
+  it('keeps workflows longer than a dozen columns', () => {
+    // Why: mirroring an external workflow (Jira, Linear) routinely needs more
+    // than a dozen states. The old cap of 12 dropped the extra ones on the
+    // next normalize, with no error and nothing in the UI preventing them.
+    const authored = Array.from({ length: 20 }, (_, index) => ({
+      id: `state-${index}`,
+      label: `State ${index}`
+    }))
+
+    const statuses = normalizeWorkspaceStatuses(authored)
+
+    expect(statuses).toHaveLength(20)
+    expect(statuses.at(-1)).toMatchObject({ id: 'state-19', label: 'State 19' })
+  })
+
+  it('still truncates absurd payloads so corrupted data cannot explode the board', () => {
+    const corrupted = Array.from({ length: 500 }, (_, index) => ({
+      id: `state-${index}`,
+      label: `State ${index}`
+    }))
+
+    expect(normalizeWorkspaceStatuses(corrupted).length).toBeLessThanOrEqual(64)
+  })
+
   it('keeps the default workflow order', () => {
     expect(cloneDefaultWorkspaceStatuses().map((status) => status.id)).toEqual([
       'todo',

--- a/src/shared/workspace-statuses.test.ts
+++ b/src/shared/workspace-statuses.test.ts
@@ -3,6 +3,7 @@ import {
   WORKSPACE_BOARD_COLUMN_WIDTH_DEFAULT,
   WORKSPACE_BOARD_COLUMN_WIDTH_MAX,
   WORKSPACE_BOARD_COLUMN_WIDTH_MIN,
+  MAX_WORKSPACE_STATUSES,
   clampWorkspaceBoardColumnWidth,
   cloneDefaultWorkspaceStatuses,
   normalizePersistedWorkspaceStatuses,
@@ -10,28 +11,25 @@ import {
 } from './workspace-statuses'
 
 describe('workspace status visuals', () => {
-  it('keeps workflows longer than a dozen columns', () => {
-    // Why: mirroring an external workflow (Jira, Linear) routinely needs more
-    // than a dozen states. The old cap of 12 dropped the extra ones on the
-    // next normalize, with no error and nothing in the UI preventing them.
-    const authored = Array.from({ length: 20 }, (_, index) => ({
-      id: `state-${index}`,
-      label: `State ${index}`
+  it.each([13, 20])('keeps all %i authored columns in order', (count) => {
+    const authored = Array.from({ length: count }, (_, index) => ({
+      id: `state-${index + 1}`,
+      label: `State ${index + 1}`
     }))
 
     const statuses = normalizeWorkspaceStatuses(authored)
 
-    expect(statuses).toHaveLength(20)
-    expect(statuses.at(-1)).toMatchObject({ id: 'state-19', label: 'State 19' })
+    expect(statuses).toHaveLength(count)
+    expect(statuses.map((status) => status.id)).toEqual(authored.map((status) => status.id))
   })
 
-  it('still truncates absurd payloads so corrupted data cannot explode the board', () => {
+  it('clamps corrupted payloads to the exact board limit', () => {
     const corrupted = Array.from({ length: 500 }, (_, index) => ({
       id: `state-${index}`,
       label: `State ${index}`
     }))
 
-    expect(normalizeWorkspaceStatuses(corrupted).length).toBeLessThanOrEqual(64)
+    expect(normalizeWorkspaceStatuses(corrupted)).toHaveLength(MAX_WORKSPACE_STATUSES)
   })
 
   it('keeps the default workflow order', () => {

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -9,13 +9,8 @@ export { DEFAULT_WORKSPACE_STATUSES } from './workspace-status-defaults'
 
 const WORKSPACE_STATUS_GROUP_PREFIX = 'workspace-status:'
 const MAX_STATUS_LABEL_LENGTH = 32
-// Why: corruption guard only — nothing in the board or the sidebar depends on
-// this number, and the renderer never enforces it, so a low cap just truncated
-// legitimate columns on the next normalize. Teams mirroring an external
-// workflow (Jira, Linear) routinely need more than a dozen states; the board
-// already scrolls horizontally and groups by status, so the extra columns cost
-// nothing structurally.
-const MAX_WORKSPACE_STATUSES = 64
+// Bounds corrupted payloads and the board's eager lane rendering.
+export const MAX_WORKSPACE_STATUSES = 64
 type WorkspaceStatusNormalizationOptions = {
   migrateDefaultWorkflowStatuses?: boolean
   migrateLegacyDefaultStatusVisuals?: boolean

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -9,7 +9,13 @@ export { DEFAULT_WORKSPACE_STATUSES } from './workspace-status-defaults'
 
 const WORKSPACE_STATUS_GROUP_PREFIX = 'workspace-status:'
 const MAX_STATUS_LABEL_LENGTH = 32
-const MAX_WORKSPACE_STATUSES = 12
+// Why: corruption guard only — nothing in the board or the sidebar depends on
+// this number, and the renderer never enforces it, so a low cap just truncated
+// legitimate columns on the next normalize. Teams mirroring an external
+// workflow (Jira, Linear) routinely need more than a dozen states; the board
+// already scrolls horizontally and groups by status, so the extra columns cost
+// nothing structurally.
+const MAX_WORKSPACE_STATUSES = 64
 type WorkspaceStatusNormalizationOptions = {
   migrateDefaultWorkflowStatuses?: boolean
   migrateLegacyDefaultStatusVisuals?: boolean

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -10,7 +10,7 @@ export { DEFAULT_WORKSPACE_STATUSES } from './workspace-status-defaults'
 const WORKSPACE_STATUS_GROUP_PREFIX = 'workspace-status:'
 const MAX_STATUS_LABEL_LENGTH = 32
 // Bounds corrupted payloads and the board's eager lane rendering.
-export const MAX_WORKSPACE_STATUSES = 64
+export const MAX_WORKSPACE_STATUSES = 20
 type WorkspaceStatusNormalizationOptions = {
   migrateDefaultWorkflowStatuses?: boolean
   migrateLegacyDefaultStatusVisuals?: boolean

--- a/src/shared/workspace-statuses.ts
+++ b/src/shared/workspace-statuses.ts
@@ -9,8 +9,6 @@ export { DEFAULT_WORKSPACE_STATUSES } from './workspace-status-defaults'
 
 const WORKSPACE_STATUS_GROUP_PREFIX = 'workspace-status:'
 const MAX_STATUS_LABEL_LENGTH = 32
-// Bounds corrupted payloads and the board's eager lane rendering.
-export const MAX_WORKSPACE_STATUSES = 20
 type WorkspaceStatusNormalizationOptions = {
   migrateDefaultWorkflowStatuses?: boolean
   migrateLegacyDefaultStatusVisuals?: boolean
@@ -170,7 +168,7 @@ function normalizeWorkspaceStatusesInternal(
 
   const statuses: WorkspaceStatusDefinition[] = []
   const usedIds = new Set<string>()
-  for (const rawStatus of value.slice(0, MAX_WORKSPACE_STATUSES)) {
+  for (const rawStatus of value) {
     if (!rawStatus || typeof rawStatus !== 'object' || Array.isArray(rawStatus)) {
       continue
     }

--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -3,6 +3,8 @@ import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
 const SEEDED_WORKSPACE_COUNT = 300
 const MARQUEE_WORKSPACE_COUNT = 102
+const MANY_LANE_COUNT = 21
+const CARDS_PER_LANE = 100
 
 /**
  * Why: the board used to mount every workspace card in every lane in one
@@ -149,6 +151,159 @@ test.describe('Workspace board lane virtualization', () => {
       })
 
     await expect.poll(readMaxIndex, { timeout: 15_000 }).toBeGreaterThan(before)
+  })
+
+  test('bounds mounted lanes and cards while preserving a 21-status workflow', async ({
+    orcaPage
+  }) => {
+    const statusIds = Array.from(
+      { length: MANY_LANE_COUNT },
+      (_, index) => `state-${String(index + 1).padStart(2, '0')}`
+    )
+    await orcaPage.evaluate(
+      ({ cardsPerLane, ids }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('window.__store is not available')
+        }
+        const state = store.getState()
+        const repo = state.repos[0]
+        if (!repo) {
+          throw new Error('Expected a seeded e2e repo')
+        }
+        const now = Date.now()
+        const synthetic = ids.flatMap((status, statusIndex) =>
+          Array.from({ length: cardsPerLane }, (_, cardIndex) => {
+            const suffix = `${String(statusIndex + 1).padStart(2, '0')}-${String(
+              cardIndex + 1
+            ).padStart(3, '0')}`
+            return {
+              id: `${repo.id}::/virtual-lane-${suffix}`,
+              instanceId: `virtual-lane-${suffix}`,
+              repoId: repo.id,
+              path: `${repo.path}/../virtual-lane-${suffix}`,
+              displayName: `Virtual lane ${suffix}`,
+              comment: '',
+              linkedIssue: null,
+              linkedPR: null,
+              linkedLinearIssue: null,
+              isArchived: false,
+              isUnread: false,
+              isPinned: false,
+              sortOrder: 20_000 - statusIndex * cardsPerLane - cardIndex,
+              manualOrder: 20_000 - statusIndex * cardsPerLane - cardIndex,
+              lastActivityAt: now - statusIndex * cardsPerLane - cardIndex,
+              head: '0000000000000000000000000000000000000000',
+              branch: `virtual-lane-${suffix}`,
+              isBare: false,
+              isMainWorktree: false,
+              workspaceStatus: status
+            }
+          })
+        )
+
+        state.setSidebarOpen(true)
+        state.setShowSleepingWorkspaces(true)
+        state.setHideDefaultBranchWorkspace(false)
+        state.setFilterRepoIds([])
+        state.setWorkspaceBoardColumnWidth(308)
+        state.setWorkspaceStatuses(
+          ids.map((id, index) => ({
+            id,
+            label: `State ${index + 1}`
+          }))
+        )
+        store.setState({
+          sortBy: 'manual',
+          worktreesByRepo: { ...state.worktreesByRepo, [repo.id]: synthetic }
+        })
+      },
+      { cardsPerLane: CARDS_PER_LANE, ids: statusIds }
+    )
+
+    await orcaPage.getByRole('button', { name: 'Workspace board' }).click()
+
+    const board = orcaPage.locator('[data-workspace-board-selection-surface]')
+    const scroller = board.locator('[data-workspace-board-lane-grid]').locator('..')
+    const lanes = board.locator('[data-workspace-status]')
+    const cards = board.locator('[data-workspace-board-card-id]')
+    await expect.poll(() => cards.count(), { timeout: 15_000 }).toBeGreaterThan(3)
+
+    const laneBudget = await scroller.evaluate(
+      (element) => Math.ceil(element.clientWidth / 320) + 3
+    )
+    const initialLaneCount = await lanes.count()
+    expect(initialLaneCount).toBeLessThanOrEqual(laneBudget)
+    expect(await cards.count()).toBeLessThan(initialLaneCount * 40)
+    expect(await board.locator('*').count()).toBeLessThan(initialLaneCount * 550 + 200)
+    await expect(board.locator('[data-workspace-status="state-01"]')).toBeVisible()
+    expect(await board.locator('[data-workspace-status="state-21"]').count()).toBe(0)
+
+    await scroller.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth
+      element.dispatchEvent(new Event('scroll', { bubbles: true }))
+    })
+
+    await expect(board.locator('[data-workspace-status="state-21"]')).toBeVisible()
+    await expect.poll(() => board.locator('[data-workspace-status="state-01"]').count()).toBe(0)
+    const finalIds = await lanes.evaluateAll((elements) =>
+      elements.map((element) => (element as HTMLElement).dataset.workspaceStatus ?? '')
+    )
+    expect(finalIds).toEqual([...finalIds].sort())
+    expect(finalIds).toContain('state-21')
+    expect(await lanes.count()).toBeLessThanOrEqual(laneBudget)
+    expect(await cards.count()).toBeLessThan((await lanes.count()) * 40)
+    expect(
+      await orcaPage.evaluate(() =>
+        window.__store?.getState().workspaceStatuses.map((status) => status.id)
+      )
+    ).toEqual(statusIds)
+
+    const finalLane = board.locator('[data-workspace-status="state-21"]')
+    const resizeHandle = finalLane.getByRole('separator', {
+      name: 'Resize workspace board columns'
+    })
+    await resizeHandle.focus()
+    await resizeHandle.press('ArrowRight')
+    await expect
+      .poll(() => orcaPage.evaluate(() => window.__store?.getState().workspaceBoardColumnWidth))
+      .toBe(328)
+    await expect(resizeHandle).toHaveAttribute('aria-valuenow', '328')
+    await scroller.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth
+      element.dispatchEvent(new Event('scroll', { bubbles: true }))
+    })
+    await expect(finalLane).toBeVisible()
+
+    const sourceCard = board
+      .locator('[data-workspace-status="state-20"] [data-workspace-board-card-id]')
+      .first()
+    const sourceId = await sourceCard.getAttribute('data-workspace-board-card-id')
+    const sourceBox = await sourceCard.boundingBox()
+    const targetBox = await finalLane
+      .locator('[data-workspace-board-lane-scroll]')
+      .first()
+      .boundingBox()
+    if (!sourceId || !sourceBox || !targetBox) {
+      throw new Error('Expected visible source card and final lane drop target')
+    }
+    await orcaPage.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+    await orcaPage.mouse.down()
+    await orcaPage.mouse.move(
+      targetBox.x + targetBox.width / 2,
+      targetBox.y + Math.min(80, targetBox.height / 2),
+      { steps: 8 }
+    )
+    await orcaPage.mouse.up()
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(
+          (worktreeId) =>
+            window.__store?.getState().getKnownWorktreeById(worktreeId)?.workspaceStatus,
+          sourceId
+        )
+      )
+      .toBe('state-21')
   })
 
   test('selects the full lane across a single large marquee scroll jump', async ({ orcaPage }) => {


### PR DESCRIPTION
## The problem

`normalizeWorkspaceStatuses` capped the list at 12 with a bare `slice(0, MAX_WORKSPACE_STATUSES)`.

**Nothing in the UI enforces that cap.** You can author a 13th column, it saves, and then it silently vanishes on the next normalize — no error, no warning, and nothing to explain why the column you just created is gone.

The constant carried no comment either, so it wasn't clear whether 12 was a product decision, a layout constraint, or a defensive guard. Looking at the code, it's the last one: nothing structural depends on the number.

## Why it matters

Teams mirroring an external workflow hit this fast. A Jira project with

```
Open · In development · Code review · Deploy DEV · Ready for QA · In QA ·
Deploy STG · Ready for STG · In STG · Deploy PROD · Done · Blocked · Reopened
```

is already **13 states** before anything project-specific, so a 1:1 board simply wasn't expressible. That's the case I ran into — the board had to collapse every post-review state into one column.

## The change

Raised to **64** and documented as what it actually is: a corruption guard.

Same shape as `MAX_PERSISTED_PROJECT_GROUP_DEPTH`, which already carries this kind of comment:

```ts
// Why: corruption guard only — must stay above the folder-scan depth limit …
export const MAX_PERSISTED_PROJECT_GROUP_DEPTH = 10
```

The board already scrolls horizontally and the sidebar groups by status, so extra columns cost nothing structurally. A damaged payload still can't explode the board.

I kept a guard rather than removing the cap entirely, on purpose: without one, a corrupted persisted array would be rendered as-is.

## Tests

Both directions, in `src/shared/workspace-statuses.test.ts`:

- a 20-column workflow survives normalize intact (this is the regression)
- a 500-entry payload is still clamped

```
✓ src/shared/workspace-statuses.test.ts  17 tests
✓ tsc -p config/tsconfig.node.json
✓ tsc -p config/tsconfig.tc.web.json
✓ oxlint
```

## Code review summary

- **Cross-platform:** none. One constant in shared code, no platform branches, no paths, no shell.
- **SSH / remote / local:** unaffected. Status normalization runs the same wherever the workspace lives; nothing here assumes a local process or file.
- **Agents / integrations / git providers:** provider-neutral. Statuses are plain string ids; no integration reads the cap.
- **Performance:** columns render lazily per group and the board already scrolls, so a longer list is the same work per visible column. The clamp still bounds a corrupted payload, which is where the real risk was.
- **UI:** **no visual change** at the default 4 columns. Users who never exceeded 12 see nothing different.
- **Security:** none — no new input path; the clamp is retained.

## Notes

No platform-, remote-, agent- or provider-specific behavior. There is a related gap I did **not** touch to keep this focused: the truncation is still silent rather than surfaced, so a >64 payload would drop entries without telling anyone. Happy to follow up if you'd like that reported instead.

X: [@EugenioValeiras](https://x.com/EugenioValeiras)