### PR TITLE
Add audit-only daemon incarnation evidence

### DIFF
--- a/src/main/agent-hooks/managed-hook-owner-identity.ts
+++ b/src/main/agent-hooks/managed-hook-owner-identity.ts
@@ -15,14 +15,14 @@ function hasCode(error: unknown, code: string): boolean {
   return error instanceof Error && 'code' in error && error.code === code
 }
 
-function parseLinuxStartTicks(statLine: string): string | null {
-  const commandEnd = statLine.lastIndexOf(') ')
+export function parseLinuxStartTicks(statLine: string): string | null {
+  const commandEnd = statLine.lastIndexOf(')')
   if (commandEnd < 0) {
     return null
   }
   // Field 22 is index 19 after removing pid and the parenthesized command.
   const startTicks = statLine
-    .slice(commandEnd + 2)
+    .slice(commandEnd + 1)
     .trim()
     .split(/\s+/)[19]
   return startTicks ?? null
@@ -115,7 +115,7 @@ async function readHostIdentity(): Promise<string> {
   return runtimeHostIdentity
 }
 
-async function readBootIdentity(): Promise<string | undefined> {
+export async function readBootIdentity(): Promise<string | undefined> {
   if (process.platform === 'linux') {
     try {
       const bootId = (await readFile('/proc/sys/kernel/random/boot_id', 'utf8')).trim()

--- a/src/main/daemon/daemon-audit-classifier.ts
+++ b/src/main/daemon/daemon-audit-classifier.ts
@@ -6,13 +6,12 @@ import {
   type DaemonProcessEvidence,
   type ExactDaemonIncarnation
 } from './daemon-incarnation-evidence'
+import type {
+  DaemonAuditFailureTrigger,
+  DaemonAuditGoneReason
+} from '../../shared/daemon-audit-eligibility'
 
-export type DaemonAuditTrigger =
-  | 'endpoint_identity_changed'
-  | 'inventory_answered'
-  | 'inventory_failed'
-  | 'token_missing_after_authenticated_disconnect'
-  | 'transport_closed'
+export type { DaemonAuditTrigger } from '../../shared/daemon-audit-eligibility'
 
 export type DaemonAuditContext = {
   protocolGeneration: number
@@ -22,10 +21,6 @@ export type DaemonAuditContext = {
   endpointKind: 'unix-socket' | 'windows-named-pipe'
   profileScope: string
 }
-
-type DaemonAuditGoneReason =
-  | Extract<DaemonProcessEvidence, { state: 'gone' }>['reason']
-  | 'windows_named_pipe_missing'
 
 export type DaemonAuditObservation =
   | {
@@ -45,7 +40,7 @@ export type DaemonAuditObservation =
   | {
       state: 'gone'
       reason: DaemonAuditGoneReason
-      trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>
+      trigger: DaemonAuditFailureTrigger
       evidenceSources: DaemonEvidenceSources
       context: DaemonAuditContext
       exactIncarnation: ExactDaemonIncarnation
@@ -58,8 +53,8 @@ export type DaemonAuditObservation =
     }
   | {
       state: 'unknown'
-      reason: Exclude<DaemonAuditTrigger, 'inventory_answered'>
-      trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>
+      reason: DaemonAuditFailureTrigger
+      trigger: DaemonAuditFailureTrigger
       evidenceSources: DaemonEvidenceSources
       context: DaemonAuditContext
       exactIncarnation: ExactDaemonIncarnation | null
@@ -74,6 +69,17 @@ export type DaemonAuditObservation =
     }
 
 export type DaemonEndpointState = 'missing' | 'named-pipe' | 'non-socket' | 'socket' | 'unknown'
+
+export type DaemonAuditClassifierDependencies = {
+  probeProcessIdentity?: typeof probeDaemonProcessIdentity
+  inspectEndpointState?: (context: DaemonAuditContext) => Promise<DaemonEndpointState>
+}
+
+export type DaemonAuditClassificationOptions = {
+  additionalEvidenceSources?: readonly DaemonEvidenceSource[]
+  endpointGoneProof?: 'windows_named_pipe_missing'
+  dependencies?: DaemonAuditClassifierDependencies
+}
 
 export function recordAuthenticatedInventory(
   context: DaemonAuditContext,
@@ -97,28 +103,34 @@ export function recordAuthenticatedInventory(
 
 export async function classifyDaemonAuditFailure(
   context: DaemonAuditContext,
-  trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>,
+  trigger: DaemonAuditFailureTrigger,
   exactIncarnation: ExactDaemonIncarnation | null,
-  additionalEvidenceSources: readonly DaemonEvidenceSource[] = [],
-  endpointGoneProof?: 'windows_named_pipe_missing'
+  options: DaemonAuditClassificationOptions = {}
 ): Promise<DaemonAuditObservation> {
+  const probeProcessIdentity =
+    options.dependencies?.probeProcessIdentity ?? probeDaemonProcessIdentity
+  const inspectEndpoint = options.dependencies?.inspectEndpointState ?? inspectDaemonEndpointState
   const [processEvidence, endpointState] = await Promise.all([
-    probeDaemonProcessIdentity(exactIncarnation, {
+    probeProcessIdentity(exactIncarnation, {
       socketPath: context.endpoint,
       tokenPath: context.tokenPath
     }),
-    inspectEndpointState(context)
+    inspectEndpoint(context)
   ])
   const reachability = reachabilityForTrigger(trigger)
   const evidenceSources = combineEvidenceSources(
     processEvidence.evidenceSources,
     context.endpointKind === 'unix-socket' ? ['endpoint_stat'] : [],
-    additionalEvidenceSources
+    options.additionalEvidenceSources ?? []
   )
-  if (endpointGoneProof && exactIncarnation) {
+  if (
+    options.endpointGoneProof &&
+    context.endpointKind === 'windows-named-pipe' &&
+    exactIncarnation
+  ) {
     return {
       state: 'gone',
-      reason: endpointGoneProof,
+      reason: options.endpointGoneProof,
       trigger,
       evidenceSources,
       context,
@@ -126,7 +138,7 @@ export async function classifyDaemonAuditFailure(
       reachability,
       inventoryAuthority: 'unavailable',
       processLiveness: 'gone',
-      processReason: endpointGoneProof,
+      processReason: options.endpointGoneProof,
       endpointState: 'missing',
       observedAtMs: Date.now()
     }
@@ -163,7 +175,9 @@ export async function classifyDaemonAuditFailure(
   }
 }
 
-async function inspectEndpointState(context: DaemonAuditContext): Promise<DaemonEndpointState> {
+async function inspectDaemonEndpointState(
+  context: DaemonAuditContext
+): Promise<DaemonEndpointState> {
   if (context.endpointKind === 'windows-named-pipe') {
     return 'named-pipe'
   }
@@ -176,7 +190,7 @@ async function inspectEndpointState(context: DaemonAuditContext): Promise<Daemon
 }
 
 function reachabilityForTrigger(
-  trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>
+  trigger: DaemonAuditFailureTrigger
 ): 'authenticated' | 'disconnected' | 'unknown' {
   if (trigger === 'endpoint_identity_changed') {
     return 'authenticated'

--- a/src/main/daemon/daemon-audit-classifier.ts
+++ b/src/main/daemon/daemon-audit-classifier.ts
@@ -1,0 +1,205 @@
+import { lstat } from 'node:fs/promises'
+import {
+  probeDaemonProcessIdentity,
+  type DaemonEvidenceSource,
+  type DaemonEvidenceSources,
+  type DaemonProcessEvidence,
+  type ExactDaemonIncarnation
+} from './daemon-incarnation-evidence'
+
+export type DaemonAuditTrigger =
+  | 'endpoint_identity_changed'
+  | 'inventory_answered'
+  | 'inventory_failed'
+  | 'token_missing_after_authenticated_disconnect'
+  | 'transport_closed'
+
+export type DaemonAuditContext = {
+  protocolGeneration: number
+  provider: 'local-daemon'
+  endpoint: string
+  tokenPath: string
+  endpointKind: 'unix-socket' | 'windows-named-pipe'
+  profileScope: string
+}
+
+type DaemonAuditGoneReason =
+  | Extract<DaemonProcessEvidence, { state: 'gone' }>['reason']
+  | 'windows_named_pipe_missing'
+
+export type DaemonAuditObservation =
+  | {
+      state: 'present'
+      reason: 'authenticated_inventory'
+      trigger: 'inventory_answered'
+      evidenceSources: DaemonEvidenceSources
+      context: DaemonAuditContext
+      exactIncarnation: ExactDaemonIncarnation | null
+      reachability: 'authenticated'
+      inventoryAuthority: 'authoritative'
+      processLiveness: 'unknown'
+      processReason: null
+      endpointState: DaemonEndpointState
+      observedAtMs: number
+    }
+  | {
+      state: 'gone'
+      reason: DaemonAuditGoneReason
+      trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>
+      evidenceSources: DaemonEvidenceSources
+      context: DaemonAuditContext
+      exactIncarnation: ExactDaemonIncarnation
+      reachability: 'authenticated' | 'disconnected' | 'unknown'
+      inventoryAuthority: 'unavailable'
+      processLiveness: 'gone'
+      processReason: DaemonAuditGoneReason
+      endpointState: DaemonEndpointState
+      observedAtMs: number
+    }
+  | {
+      state: 'unknown'
+      reason: Exclude<DaemonAuditTrigger, 'inventory_answered'>
+      trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>
+      evidenceSources: DaemonEvidenceSources
+      context: DaemonAuditContext
+      exactIncarnation: ExactDaemonIncarnation | null
+      reachability: 'authenticated' | 'disconnected' | 'unknown'
+      inventoryAuthority: 'unavailable'
+      processLiveness: 'present' | 'unknown'
+      processReason:
+        | Extract<DaemonProcessEvidence, { state: 'present' | 'unknown' }>['reason']
+        | null
+      endpointState: DaemonEndpointState
+      observedAtMs: number
+    }
+
+export type DaemonEndpointState = 'missing' | 'named-pipe' | 'non-socket' | 'socket' | 'unknown'
+
+export function recordAuthenticatedInventory(
+  context: DaemonAuditContext,
+  exactIncarnation: ExactDaemonIncarnation | null
+): DaemonAuditObservation {
+  return {
+    state: 'present',
+    reason: 'authenticated_inventory',
+    trigger: 'inventory_answered',
+    evidenceSources: ['authenticated_inventory'],
+    context,
+    exactIncarnation,
+    reachability: 'authenticated',
+    inventoryAuthority: 'authoritative',
+    processLiveness: 'unknown',
+    processReason: null,
+    endpointState: context.endpointKind === 'windows-named-pipe' ? 'named-pipe' : 'socket',
+    observedAtMs: Date.now()
+  }
+}
+
+export async function classifyDaemonAuditFailure(
+  context: DaemonAuditContext,
+  trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>,
+  exactIncarnation: ExactDaemonIncarnation | null,
+  additionalEvidenceSources: readonly DaemonEvidenceSource[] = [],
+  endpointGoneProof?: 'windows_named_pipe_missing'
+): Promise<DaemonAuditObservation> {
+  const [processEvidence, endpointState] = await Promise.all([
+    probeDaemonProcessIdentity(exactIncarnation, {
+      socketPath: context.endpoint,
+      tokenPath: context.tokenPath
+    }),
+    inspectEndpointState(context)
+  ])
+  const reachability = reachabilityForTrigger(trigger)
+  const evidenceSources = combineEvidenceSources(
+    processEvidence.evidenceSources,
+    context.endpointKind === 'unix-socket' ? ['endpoint_stat'] : [],
+    additionalEvidenceSources
+  )
+  if (endpointGoneProof && exactIncarnation) {
+    return {
+      state: 'gone',
+      reason: endpointGoneProof,
+      trigger,
+      evidenceSources,
+      context,
+      exactIncarnation,
+      reachability,
+      inventoryAuthority: 'unavailable',
+      processLiveness: 'gone',
+      processReason: endpointGoneProof,
+      endpointState: 'missing',
+      observedAtMs: Date.now()
+    }
+  }
+  if (processEvidence.state === 'gone') {
+    return {
+      state: 'gone',
+      reason: processEvidence.reason,
+      trigger,
+      evidenceSources,
+      context,
+      exactIncarnation: processEvidence.exactIncarnation,
+      reachability,
+      inventoryAuthority: 'unavailable',
+      processLiveness: 'gone',
+      processReason: processEvidence.reason,
+      endpointState,
+      observedAtMs: Date.now()
+    }
+  }
+  return {
+    state: 'unknown',
+    reason: trigger,
+    trigger,
+    evidenceSources,
+    context,
+    exactIncarnation,
+    reachability,
+    inventoryAuthority: 'unavailable',
+    processLiveness: processEvidence.state,
+    processReason: processEvidence.reason,
+    endpointState,
+    observedAtMs: Date.now()
+  }
+}
+
+async function inspectEndpointState(context: DaemonAuditContext): Promise<DaemonEndpointState> {
+  if (context.endpointKind === 'windows-named-pipe') {
+    return 'named-pipe'
+  }
+  try {
+    const stats = await lstat(context.endpoint)
+    return stats.isSocket() ? 'socket' : 'non-socket'
+  } catch (error) {
+    return hasErrorCode(error, 'ENOENT') ? 'missing' : 'unknown'
+  }
+}
+
+function reachabilityForTrigger(
+  trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>
+): 'authenticated' | 'disconnected' | 'unknown' {
+  if (trigger === 'endpoint_identity_changed') {
+    return 'authenticated'
+  }
+  if (
+    trigger === 'transport_closed' ||
+    trigger === 'token_missing_after_authenticated_disconnect'
+  ) {
+    return 'disconnected'
+  }
+  return 'unknown'
+}
+
+function combineEvidenceSources(
+  first: DaemonEvidenceSources,
+  ...rest: readonly (readonly DaemonEvidenceSource[])[]
+): DaemonEvidenceSources {
+  return [...new Set([first[0], ...first.slice(1), ...rest.flat()])] as [
+    DaemonEvidenceSource,
+    ...DaemonEvidenceSource[]
+  ]
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code
+}

--- a/src/main/daemon/daemon-audit-eligibility-event.test.ts
+++ b/src/main/daemon/daemon-audit-eligibility-event.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { validate } from '../telemetry/validator'
+import { recordAuthenticatedInventory, type DaemonAuditContext } from './daemon-audit-classifier'
+
+const { trackMock } = vi.hoisted(() => ({ trackMock: vi.fn() }))
+vi.mock('../telemetry/client', () => ({ track: trackMock }))
+
+import { trackDaemonAuditEligibility } from './daemon-audit-eligibility-event'
+
+const context: DaemonAuditContext = {
+  protocolGeneration: 23,
+  provider: 'local-daemon',
+  endpoint: '/profile/daemon.sock',
+  tokenPath: '/profile/daemon.token',
+  endpointKind: 'unix-socket',
+  profileScope: '/profile'
+}
+
+beforeEach(() => {
+  trackMock.mockReset()
+})
+
+describe('daemon audit eligibility telemetry', () => {
+  it('uses a dedicated validator-accepted event family', () => {
+    trackDaemonAuditEligibility(recordAuthenticatedInventory(context, null))
+
+    expect(trackMock).toHaveBeenCalledOnce()
+    const [name, props] = trackMock.mock.calls[0]
+    expect(name).toBe('daemon_audit_eligibility')
+    expect(name).not.toBe('daemon_lifecycle')
+    expect(props).toMatchObject({
+      state: 'present',
+      reason: 'authenticated_inventory',
+      evidence_sources: ['authenticated_inventory'],
+      protocol_generation: 23,
+      exact_incarnation: 'unavailable',
+      process_reason: null
+    })
+    expect(validate('daemon_audit_eligibility', props).ok).toBe(true)
+  })
+
+  it('cannot affect callers when telemetry throws', () => {
+    trackMock.mockImplementation(() => {
+      throw new Error('transport failed')
+    })
+
+    expect(() =>
+      trackDaemonAuditEligibility(recordAuthenticatedInventory(context, null))
+    ).not.toThrow()
+  })
+})

--- a/src/main/daemon/daemon-audit-eligibility-event.ts
+++ b/src/main/daemon/daemon-audit-eligibility-event.ts
@@ -1,0 +1,36 @@
+import { track } from '../telemetry/client'
+import type { DaemonAuditObservation } from './daemon-audit-classifier'
+
+export function trackDaemonAuditEligibility(observation: DaemonAuditObservation): void {
+  try {
+    track('daemon_audit_eligibility', {
+      state: observation.state,
+      reason: observation.reason,
+      trigger: observation.trigger,
+      evidence_sources: [...observation.evidenceSources],
+      protocol_generation: observation.context.protocolGeneration,
+      provider: observation.context.provider,
+      endpoint_kind: observation.context.endpointKind,
+      profile_scope: observation.context.profileScope ? 'configured' : 'unspecified',
+      exact_incarnation: exactIncarnationKind(observation),
+      reachability: observation.reachability,
+      inventory_authority: observation.inventoryAuthority,
+      process_liveness: observation.processLiveness,
+      process_reason: observation.processReason,
+      endpoint_state: observation.endpointState
+    })
+  } catch {
+    // Audit telemetry cannot affect daemon availability.
+  }
+}
+
+function exactIncarnationKind(
+  observation: DaemonAuditObservation
+): 'endpoint-identity' | 'endpoint-identity-linux-ticks' | 'unavailable' {
+  if (!observation.exactIncarnation) {
+    return 'unavailable'
+  }
+  return observation.exactIncarnation.linuxStartTicks && observation.exactIncarnation.bootId
+    ? 'endpoint-identity-linux-ticks'
+    : 'endpoint-identity'
+}

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -19,6 +19,7 @@ import {
 } from '../providers/macos-tcc-login-shell'
 import { MacosLoginSessionDeathWatch } from './macos-login-session-death-watch'
 import { readCurrentProcessMacSystemResolverHealth } from '../network/macos-system-resolver-health'
+import { readCurrentDaemonReadyIdentity } from './daemon-ready-identity'
 
 export type ParsedDaemonArgs = {
   socketPath: string
@@ -255,9 +256,8 @@ async function main(): Promise<void> {
 
   // Signal readiness to parent via IPC (if available)
   if (process.send) {
-    // Why: Windows has no cheap OS query for a child's start time, so the
-    // daemon self-reports it here for the pid file's pid-recycling guard.
-    process.send({ type: 'ready', startedAtMs })
+    const readyIdentity = await readCurrentDaemonReadyIdentity(startedAtMs)
+    process.send({ type: 'ready', ...readyIdentity })
   }
   daemonLog.log('ready')
 

--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -198,7 +198,10 @@ describe('parseDaemonPidFile', () => {
       pid: 12345,
       startedAtMs: 1_700_000_000_000,
       entryPath: null,
-      appVersion: null
+      appVersion: null,
+      launchNonce: null,
+      linuxStartTicks: null,
+      bootId: null
     })
   })
 
@@ -213,7 +216,25 @@ describe('parseDaemonPidFile', () => {
       pid: 12345,
       startedAtMs: 1_700_000_000_000,
       entryPath: '/repo/out/main/daemon-entry.js',
-      appVersion: '1.2.3'
+      appVersion: '1.2.3',
+      launchNonce: null,
+      linuxStartTicks: null,
+      bootId: null
+    })
+  })
+
+  it('preserves exact-incarnation launch and Linux process identity', () => {
+    const serialized = serializeDaemonPidFile({
+      pid: 12345,
+      startedAtMs: 1_700_000_000_000,
+      launchNonce: 'launch-a',
+      linuxStartTicks: '4242',
+      bootId: 'boot-a'
+    })
+    expect(parseDaemonPidFile(serialized)).toMatchObject({
+      launchNonce: 'launch-a',
+      linuxStartTicks: '4242',
+      bootId: 'boot-a'
     })
   })
 
@@ -224,7 +245,10 @@ describe('parseDaemonPidFile', () => {
       pid: 9999,
       startedAtMs: null,
       entryPath: null,
-      appVersion: null
+      appVersion: null,
+      launchNonce: null,
+      linuxStartTicks: null,
+      bootId: null
     })
   })
 
@@ -236,13 +260,19 @@ describe('parseDaemonPidFile', () => {
       pid: 12345,
       startedAtMs: null,
       entryPath: null,
-      appVersion: null
+      appVersion: null,
+      launchNonce: null,
+      linuxStartTicks: null,
+      bootId: null
     })
     expect(parseDaemonPidFile('  12345\n')).toEqual({
       pid: 12345,
       startedAtMs: null,
       entryPath: null,
-      appVersion: null
+      appVersion: null,
+      launchNonce: null,
+      linuxStartTicks: null,
+      bootId: null
     })
   })
 

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -40,11 +40,14 @@ const WIN32_START_TIME_TOLERANCE_MS = 10_000
 // also covers a live-but-wedged daemon that simply missed the RPC budget.
 export type DaemonHealth = 'healthy' | 'unreachable' | 'rejected' | 'pty-spawn-unhealthy'
 
-type ParsedDaemonPid = {
+export type ParsedDaemonPid = {
   pid: number
   startedAtMs: number | null
   entryPath: string | null
   appVersion: string | null
+  launchNonce: string | null
+  linuxStartTicks: string | null
+  bootId: string | null
 }
 
 function canConnectSocket(socketPath: string): Promise<boolean> {
@@ -301,7 +304,7 @@ export function getMacDaemonSystemResolverHealth(
   })
 }
 
-function commandLineMatchesDaemon(
+export function commandLineMatchesDaemon(
   commandLine: string,
   socketPath: string,
   tokenPath: string
@@ -321,6 +324,9 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
       startedAtMs?: unknown
       entryPath?: unknown
       appVersion?: unknown
+      launchNonce?: unknown
+      linuxStartTicks?: unknown
+      bootId?: unknown
     }
     if (typeof parsed.pid === 'number' && Number.isFinite(parsed.pid)) {
       return {
@@ -330,7 +336,10 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
             ? parsed.startedAtMs
             : null,
         entryPath: typeof parsed.entryPath === 'string' ? parsed.entryPath : null,
-        appVersion: typeof parsed.appVersion === 'string' ? parsed.appVersion : null
+        appVersion: typeof parsed.appVersion === 'string' ? parsed.appVersion : null,
+        launchNonce: typeof parsed.launchNonce === 'string' ? parsed.launchNonce : null,
+        linuxStartTicks: typeof parsed.linuxStartTicks === 'string' ? parsed.linuxStartTicks : null,
+        bootId: typeof parsed.bootId === 'string' ? parsed.bootId : null
       }
     }
   } catch {
@@ -338,7 +347,17 @@ export function parseDaemonPidFile(contents: string): ParsedDaemonPid | null {
   }
 
   const pid = Number(trimmed)
-  return Number.isFinite(pid) ? { pid, startedAtMs: null, entryPath: null, appVersion: null } : null
+  return Number.isFinite(pid)
+    ? {
+        pid,
+        startedAtMs: null,
+        entryPath: null,
+        appVersion: null,
+        launchNonce: null,
+        linuxStartTicks: null,
+        bootId: null
+      }
+    : null
 }
 
 function getLinuxProcessStartedAtMs(pid: number): number | null {

--- a/src/main/daemon/daemon-incarnation-evidence-types.ts
+++ b/src/main/daemon/daemon-incarnation-evidence-types.ts
@@ -1,0 +1,93 @@
+import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
+
+export const WINDOWS_CREATION_TIME_TOLERANCE_MS = 10_000
+
+// Oracle contract validated 2026-07-29; omitted proofs remain unknown.
+export const DAEMON_GONE_PROOFS = {
+  linux: [
+    'pid_missing',
+    'boot_identity_changed',
+    'raw_start_ticks_mismatch',
+    'matching_identity_zombie'
+  ],
+  darwin: ['pid_missing'],
+  win32: ['cim_process_missing', 'cim_creation_time_mismatch', 'named_pipe_missing']
+} as const
+
+export type DaemonEvidenceSource =
+  | 'authenticated_inventory'
+  | 'boot_identity'
+  | 'endpoint_identity'
+  | 'endpoint_stat'
+  | 'linux_proc_stat'
+  | 'pid_record'
+  | 'process_command_line'
+  | 'process_signal'
+  | 'process_start_time'
+  | 'token_file'
+  | 'windows_cim'
+  | 'windows_named_pipe'
+
+export type DaemonEvidenceSources = readonly [DaemonEvidenceSource, ...DaemonEvidenceSource[]]
+
+export type ExactDaemonIncarnation = {
+  identity: DaemonEndpointIdentity
+  linuxStartTicks?: string
+  bootId?: string
+}
+
+export type DaemonProcessEvidence =
+  | {
+      state: 'present'
+      reason: 'linux_identity_match' | 'macos_identity_match' | 'windows_identity_match'
+      evidenceSources: DaemonEvidenceSources
+    }
+  | {
+      state: 'gone'
+      reason:
+        | 'linux_boot_changed'
+        | 'linux_start_ticks_mismatch'
+        | 'linux_zombie'
+        | 'pid_missing'
+        | 'windows_creation_time_mismatch'
+        | 'windows_process_missing'
+      evidenceSources: DaemonEvidenceSources
+      exactIncarnation: ExactDaemonIncarnation
+    }
+  | {
+      state: 'unknown'
+      reason:
+        | 'command_line_mismatch'
+        | 'command_line_unavailable'
+        | 'exact_identity_unavailable'
+        | 'inspection_failed'
+        | 'linux_identity_incomplete'
+        | 'macos_start_time_mismatch'
+        | 'permission_denied'
+        | 'process_start_time_unavailable'
+        | 'windows_command_line_unavailable'
+        | 'windows_process_start_time_unavailable'
+      evidenceSources: DaemonEvidenceSources
+    }
+
+export type ProcessSignalEvidence = 'occupied' | 'permission_denied' | 'missing' | 'unavailable'
+
+export type LinuxStatEvidence =
+  | { status: 'present'; value: string }
+  | { status: 'missing' }
+  | { status: 'unavailable' }
+
+export type WindowsProcessEvidence =
+  | { status: 'present'; commandLine: string | null; startedAtMs: number | null }
+  | { status: 'missing' }
+  | { status: 'unavailable' }
+
+export type DaemonProcessProbeDependencies = {
+  platform?: NodeJS.Platform
+  signalProcess?: (pid: number) => ProcessSignalEvidence
+  readLinuxStat?: (pid: number) => Promise<LinuxStatEvidence>
+  readBootIdentity?: () => Promise<string | undefined>
+  readCommandLine?: (pid: number, platform: NodeJS.Platform) => Promise<string | undefined>
+  readProcessStartedAtMs?: (pid: number) => number | null
+  queryWindowsProcess?: (pid: number) => Promise<WindowsProcessEvidence>
+}

--- a/src/main/daemon/daemon-incarnation-evidence-types.ts
+++ b/src/main/daemon/daemon-incarnation-evidence-types.ts
@@ -1,32 +1,30 @@
 import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
+import type {
+  DaemonAuditGoneReason,
+  DaemonEvidenceSource,
+  DaemonProcessGoneReason,
+  DaemonProcessPresentReason,
+  DaemonProcessUnknownReason
+} from '../../shared/daemon-audit-eligibility'
 
 export const WINDOWS_CREATION_TIME_TOLERANCE_MS = 10_000
 
 // Oracle contract validated 2026-07-29; omitted proofs remain unknown.
 export const DAEMON_GONE_PROOFS = {
-  linux: [
-    'pid_missing',
-    'boot_identity_changed',
-    'raw_start_ticks_mismatch',
-    'matching_identity_zombie'
-  ],
+  linux: ['pid_missing', 'linux_boot_changed', 'linux_start_ticks_mismatch', 'linux_zombie'],
   darwin: ['pid_missing'],
-  win32: ['cim_process_missing', 'cim_creation_time_mismatch', 'named_pipe_missing']
-} as const
+  win32: ['windows_process_missing', 'windows_creation_time_mismatch', 'windows_named_pipe_missing']
+} as const satisfies Readonly<
+  Record<'linux' | 'darwin' | 'win32', readonly DaemonAuditGoneReason[]>
+>
 
-export type DaemonEvidenceSource =
-  | 'authenticated_inventory'
-  | 'boot_identity'
-  | 'endpoint_identity'
-  | 'endpoint_stat'
-  | 'linux_proc_stat'
-  | 'pid_record'
-  | 'process_command_line'
-  | 'process_signal'
-  | 'process_start_time'
-  | 'token_file'
-  | 'windows_cim'
-  | 'windows_named_pipe'
+export type {
+  DaemonAuditGoneReason,
+  DaemonEvidenceSource,
+  DaemonProcessGoneReason,
+  DaemonProcessPresentReason,
+  DaemonProcessUnknownReason
+} from '../../shared/daemon-audit-eligibility'
 
 export type DaemonEvidenceSources = readonly [DaemonEvidenceSource, ...DaemonEvidenceSource[]]
 
@@ -39,34 +37,18 @@ export type ExactDaemonIncarnation = {
 export type DaemonProcessEvidence =
   | {
       state: 'present'
-      reason: 'linux_identity_match' | 'macos_identity_match' | 'windows_identity_match'
+      reason: DaemonProcessPresentReason
       evidenceSources: DaemonEvidenceSources
     }
   | {
       state: 'gone'
-      reason:
-        | 'linux_boot_changed'
-        | 'linux_start_ticks_mismatch'
-        | 'linux_zombie'
-        | 'pid_missing'
-        | 'windows_creation_time_mismatch'
-        | 'windows_process_missing'
+      reason: DaemonProcessGoneReason
       evidenceSources: DaemonEvidenceSources
       exactIncarnation: ExactDaemonIncarnation
     }
   | {
       state: 'unknown'
-      reason:
-        | 'command_line_mismatch'
-        | 'command_line_unavailable'
-        | 'exact_identity_unavailable'
-        | 'inspection_failed'
-        | 'linux_identity_incomplete'
-        | 'macos_start_time_mismatch'
-        | 'permission_denied'
-        | 'process_start_time_unavailable'
-        | 'windows_command_line_unavailable'
-        | 'windows_process_start_time_unavailable'
+      reason: DaemonProcessUnknownReason
       evidenceSources: DaemonEvidenceSources
     }
 

--- a/src/main/daemon/daemon-incarnation-evidence.test.ts
+++ b/src/main/daemon/daemon-incarnation-evidence.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DAEMON_GONE_PROOFS,
+  probeDaemonProcessIdentity,
+  WINDOWS_CREATION_TIME_TOLERANCE_MS,
+  type DaemonProcessProbeDependencies,
+  type ExactDaemonIncarnation
+} from './daemon-incarnation-evidence'
+import {
+  classifyDaemonAuditFailure,
+  recordAuthenticatedInventory,
+  type DaemonAuditContext
+} from './daemon-audit-classifier'
+
+const endpoint = { socketPath: '/runtime/daemon.sock', tokenPath: '/runtime/daemon.token' }
+const exactIncarnation: ExactDaemonIncarnation = {
+  identity: { pid: 42, startedAtMs: 1_700_000_000_000, launchNonce: 'launch-a' },
+  linuxStartTicks: '4242',
+  bootId: 'boot-a'
+}
+
+function linuxStat(state: string, startTicks: string): string {
+  return `42 (orca daemon with spaces) ${[state, ...Array(18).fill('0'), startTicks].join(' ')}`
+}
+
+function linuxDependencies(
+  overrides: DaemonProcessProbeDependencies = {}
+): DaemonProcessProbeDependencies {
+  return {
+    platform: 'linux',
+    signalProcess: () => 'occupied',
+    readLinuxStat: async () => ({ status: 'present', value: linuxStat('S', '4242') }),
+    readBootIdentity: async () => 'boot-a',
+    readCommandLine: async () =>
+      `node daemon-entry --socket ${endpoint.socketPath} --token ${endpoint.tokenPath}`,
+    ...overrides
+  }
+}
+
+describe('daemon process identity evidence', () => {
+  it('pins the dated conclusive-gone oracle contract', () => {
+    expect(DAEMON_GONE_PROOFS).toEqual({
+      linux: [
+        'pid_missing',
+        'boot_identity_changed',
+        'raw_start_ticks_mismatch',
+        'matching_identity_zombie'
+      ],
+      darwin: ['pid_missing'],
+      win32: ['cim_process_missing', 'cim_creation_time_mismatch', 'named_pipe_missing']
+    })
+  })
+
+  it('proves Linux pid reuse from native start ticks without derived milliseconds', async () => {
+    const readProcessStartedAtMs = vi.fn(() => exactIncarnation.identity.startedAtMs)
+
+    await expect(
+      probeDaemonProcessIdentity(
+        exactIncarnation,
+        endpoint,
+        linuxDependencies({
+          readLinuxStat: async () => ({ status: 'present', value: linuxStat('S', '4243') }),
+          readProcessStartedAtMs
+        })
+      )
+    ).resolves.toMatchObject({
+      state: 'gone',
+      reason: 'linux_start_ticks_mismatch'
+    })
+    expect(readProcessStartedAtMs).not.toHaveBeenCalled()
+  })
+
+  it('proves Linux reboot invalidated the recorded incarnation', async () => {
+    await expect(
+      probeDaemonProcessIdentity(
+        exactIncarnation,
+        endpoint,
+        linuxDependencies({ readBootIdentity: async () => 'boot-b' })
+      )
+    ).resolves.toMatchObject({ state: 'gone', reason: 'linux_boot_changed' })
+  })
+
+  it('treats a matching unreaped Linux zombie as gone', async () => {
+    await expect(
+      probeDaemonProcessIdentity(
+        exactIncarnation,
+        endpoint,
+        linuxDependencies({
+          readLinuxStat: async () => ({ status: 'present', value: linuxStat('Z', '4242') })
+        })
+      )
+    ).resolves.toMatchObject({ state: 'gone', reason: 'linux_zombie' })
+  })
+
+  it('keeps EPERM unknown without an independent identity match', async () => {
+    await expect(
+      probeDaemonProcessIdentity(
+        exactIncarnation,
+        endpoint,
+        linuxDependencies({
+          signalProcess: () => 'permission_denied',
+          readLinuxStat: async () => ({ status: 'unavailable' })
+        })
+      )
+    ).resolves.toMatchObject({ state: 'unknown', reason: 'permission_denied' })
+  })
+
+  it('keeps an unreadable command line unknown even when Linux start identity matches', async () => {
+    await expect(
+      probeDaemonProcessIdentity(
+        exactIncarnation,
+        endpoint,
+        linuxDependencies({ readCommandLine: async () => undefined })
+      )
+    ).resolves.toMatchObject({ state: 'unknown', reason: 'command_line_unavailable' })
+  })
+
+  it('never treats signal-zero success alone as present', async () => {
+    await expect(
+      probeDaemonProcessIdentity(
+        { identity: exactIncarnation.identity },
+        endpoint,
+        linuxDependencies({
+          readCommandLine: async () => undefined
+        })
+      )
+    ).resolves.toMatchObject({ state: 'unknown' })
+  })
+
+  it('never turns a legacy identity gap into gone', async () => {
+    await expect(
+      probeDaemonProcessIdentity(null, endpoint, linuxDependencies())
+    ).resolves.toMatchObject({ state: 'unknown', reason: 'exact_identity_unavailable' })
+  })
+
+  it('uses Windows CreationDate mismatch as gone while null fields stay unknown', async () => {
+    const base = {
+      platform: 'win32' as const,
+      signalProcess: () => 'occupied' as const
+    }
+    await expect(
+      probeDaemonProcessIdentity(exactIncarnation, endpoint, {
+        ...base,
+        queryWindowsProcess: async () => ({
+          status: 'present',
+          commandLine: 'unreadable',
+          startedAtMs:
+            exactIncarnation.identity.startedAtMs + WINDOWS_CREATION_TIME_TOLERANCE_MS + 1
+        })
+      })
+    ).resolves.toMatchObject({
+      state: 'gone',
+      reason: 'windows_creation_time_mismatch'
+    })
+    await expect(
+      probeDaemonProcessIdentity(exactIncarnation, endpoint, {
+        ...base,
+        queryWindowsProcess: async () => ({
+          status: 'present',
+          commandLine: null,
+          startedAtMs: exactIncarnation.identity.startedAtMs
+        })
+      })
+    ).resolves.toMatchObject({
+      state: 'unknown',
+      reason: 'windows_command_line_unavailable'
+    })
+    await expect(
+      probeDaemonProcessIdentity(exactIncarnation, endpoint, {
+        ...base,
+        queryWindowsProcess: async () => ({
+          status: 'present',
+          commandLine: 'unrelated process',
+          startedAtMs: exactIncarnation.identity.startedAtMs
+        })
+      })
+    ).resolves.toMatchObject({
+      state: 'unknown',
+      reason: 'command_line_mismatch'
+    })
+    await expect(
+      probeDaemonProcessIdentity(exactIncarnation, endpoint, {
+        ...base,
+        queryWindowsProcess: async () => ({
+          status: 'present',
+          commandLine: 'node daemon-entry',
+          startedAtMs: null
+        })
+      })
+    ).resolves.toMatchObject({
+      state: 'unknown',
+      reason: 'windows_process_start_time_unavailable'
+    })
+    await expect(
+      probeDaemonProcessIdentity(exactIncarnation, endpoint, {
+        ...base,
+        queryWindowsProcess: async () => ({ status: 'missing' })
+      })
+    ).resolves.toMatchObject({
+      state: 'gone',
+      reason: 'windows_process_missing'
+    })
+  })
+
+  it('requires Windows CIM evidence even when signal-zero reports a missing pid', async () => {
+    await expect(
+      probeDaemonProcessIdentity(exactIncarnation, endpoint, {
+        platform: 'win32',
+        signalProcess: () => 'missing',
+        queryWindowsProcess: async () => ({
+          status: 'present',
+          commandLine: null,
+          startedAtMs: exactIncarnation.identity.startedAtMs
+        })
+      })
+    ).resolves.toMatchObject({
+      state: 'unknown',
+      reason: 'windows_command_line_unavailable'
+    })
+  })
+
+  it('keeps a macOS lstart mismatch unknown', async () => {
+    await expect(
+      probeDaemonProcessIdentity(exactIncarnation, endpoint, {
+        platform: 'darwin',
+        signalProcess: () => 'occupied',
+        readCommandLine: async () =>
+          `node daemon-entry --socket ${endpoint.socketPath} --token ${endpoint.tokenPath}`,
+        readProcessStartedAtMs: () => exactIncarnation.identity.startedAtMs + 2_500
+      })
+    ).resolves.toMatchObject({ state: 'unknown', reason: 'macos_start_time_mismatch' })
+  })
+
+  it('accepts ESRCH as conclusive POSIX process disappearance', async () => {
+    await expect(
+      probeDaemonProcessIdentity(exactIncarnation, endpoint, {
+        platform: 'darwin',
+        signalProcess: () => 'missing'
+      })
+    ).resolves.toMatchObject({ state: 'gone', reason: 'pid_missing' })
+  })
+})
+
+describe('daemon audit availability evidence', () => {
+  const context: DaemonAuditContext = {
+    protocolGeneration: 23,
+    provider: 'local-daemon',
+    endpoint: endpoint.socketPath,
+    tokenPath: endpoint.tokenPath,
+    endpointKind: 'unix-socket',
+    profileScope: '/profile'
+  }
+
+  it('records authoritative inventory as present without endpoint identity', () => {
+    expect(recordAuthenticatedInventory(context, null)).toMatchObject({
+      state: 'present',
+      reason: 'authenticated_inventory',
+      exactIncarnation: null,
+      inventoryAuthority: 'authoritative'
+    })
+  })
+
+  it('represents failed legacy inventory as unknown, never an empty process list', async () => {
+    const observation = await classifyDaemonAuditFailure(context, 'inventory_failed', null)
+
+    expect(observation).toMatchObject({
+      state: 'unknown',
+      reason: 'inventory_failed',
+      inventoryAuthority: 'unavailable',
+      processLiveness: 'unknown'
+    })
+    expect(observation.evidenceSources.length).toBeGreaterThan(0)
+    expect(observation).not.toHaveProperty('processes')
+  })
+
+  it('keeps token removal after disconnect as contributing evidence only', async () => {
+    const observation = await classifyDaemonAuditFailure(
+      context,
+      'token_missing_after_authenticated_disconnect',
+      null,
+      ['token_file']
+    )
+
+    expect(observation.state).toBe('unknown')
+    expect(observation.evidenceSources).toContain('token_file')
+  })
+
+  it('accepts Windows named-pipe absence only with exact incarnation evidence', async () => {
+    const windowsContext: DaemonAuditContext = {
+      ...context,
+      endpoint: '\\\\?\\pipe\\orca-daemon',
+      endpointKind: 'windows-named-pipe'
+    }
+    const observation = await classifyDaemonAuditFailure(
+      windowsContext,
+      'inventory_failed',
+      exactIncarnation,
+      ['windows_named_pipe'],
+      'windows_named_pipe_missing'
+    )
+
+    expect(observation).toMatchObject({
+      state: 'gone',
+      reason: 'windows_named_pipe_missing',
+      endpointState: 'missing',
+      exactIncarnation
+    })
+  })
+})

--- a/src/main/daemon/daemon-incarnation-evidence.test.ts
+++ b/src/main/daemon/daemon-incarnation-evidence.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   classifyDaemonAuditFailure,
   recordAuthenticatedInventory,
+  type DaemonAuditClassifierDependencies,
   type DaemonAuditContext
 } from './daemon-audit-classifier'
 
@@ -18,6 +19,15 @@ const exactIncarnation: ExactDaemonIncarnation = {
   linuxStartTicks: '4242',
   bootId: 'boot-a'
 }
+const auditClassifierDependencies = {
+  probeProcessIdentity: async () => ({
+    state: 'unknown',
+    reason: 'inspection_failed',
+    evidenceSources: ['process_signal']
+  }),
+  inspectEndpointState: async (context) =>
+    context.endpointKind === 'windows-named-pipe' ? 'named-pipe' : 'missing'
+} satisfies DaemonAuditClassifierDependencies
 
 function linuxStat(state: string, startTicks: string): string {
   return `42 (orca daemon with spaces) ${[state, ...Array(18).fill('0'), startTicks].join(' ')}`
@@ -40,14 +50,13 @@ function linuxDependencies(
 describe('daemon process identity evidence', () => {
   it('pins the dated conclusive-gone oracle contract', () => {
     expect(DAEMON_GONE_PROOFS).toEqual({
-      linux: [
-        'pid_missing',
-        'boot_identity_changed',
-        'raw_start_ticks_mismatch',
-        'matching_identity_zombie'
-      ],
+      linux: ['pid_missing', 'linux_boot_changed', 'linux_start_ticks_mismatch', 'linux_zombie'],
       darwin: ['pid_missing'],
-      win32: ['cim_process_missing', 'cim_creation_time_mismatch', 'named_pipe_missing']
+      win32: [
+        'windows_process_missing',
+        'windows_creation_time_mismatch',
+        'windows_named_pipe_missing'
+      ]
     })
   })
 
@@ -133,7 +142,7 @@ describe('daemon process identity evidence', () => {
     ).resolves.toMatchObject({ state: 'unknown', reason: 'exact_identity_unavailable' })
   })
 
-  it('uses Windows CreationDate mismatch as gone while null fields stay unknown', async () => {
+  it('uses Windows CreationDate as the primary identity regardless of command line', async () => {
     const base = {
       platform: 'win32' as const,
       signalProcess: () => 'occupied' as const
@@ -162,8 +171,8 @@ describe('daemon process identity evidence', () => {
         })
       })
     ).resolves.toMatchObject({
-      state: 'unknown',
-      reason: 'windows_command_line_unavailable'
+      state: 'present',
+      reason: 'windows_identity_match'
     })
     await expect(
       probeDaemonProcessIdentity(exactIncarnation, endpoint, {
@@ -175,8 +184,8 @@ describe('daemon process identity evidence', () => {
         })
       })
     ).resolves.toMatchObject({
-      state: 'unknown',
-      reason: 'command_line_mismatch'
+      state: 'present',
+      reason: 'windows_identity_match'
     })
     await expect(
       probeDaemonProcessIdentity(exactIncarnation, endpoint, {
@@ -214,8 +223,8 @@ describe('daemon process identity evidence', () => {
         })
       })
     ).resolves.toMatchObject({
-      state: 'unknown',
-      reason: 'windows_command_line_unavailable'
+      state: 'present',
+      reason: 'windows_identity_match'
     })
   })
 
@@ -261,7 +270,9 @@ describe('daemon audit availability evidence', () => {
   })
 
   it('represents failed legacy inventory as unknown, never an empty process list', async () => {
-    const observation = await classifyDaemonAuditFailure(context, 'inventory_failed', null)
+    const observation = await classifyDaemonAuditFailure(context, 'inventory_failed', null, {
+      dependencies: auditClassifierDependencies
+    })
 
     expect(observation).toMatchObject({
       state: 'unknown',
@@ -278,7 +289,10 @@ describe('daemon audit availability evidence', () => {
       context,
       'token_missing_after_authenticated_disconnect',
       null,
-      ['token_file']
+      {
+        additionalEvidenceSources: ['token_file'],
+        dependencies: auditClassifierDependencies
+      }
     )
 
     expect(observation.state).toBe('unknown')
@@ -295,8 +309,11 @@ describe('daemon audit availability evidence', () => {
       windowsContext,
       'inventory_failed',
       exactIncarnation,
-      ['windows_named_pipe'],
-      'windows_named_pipe_missing'
+      {
+        additionalEvidenceSources: ['windows_named_pipe'],
+        endpointGoneProof: 'windows_named_pipe_missing',
+        dependencies: auditClassifierDependencies
+      }
     )
 
     expect(observation).toMatchObject({
@@ -304,6 +321,25 @@ describe('daemon audit availability evidence', () => {
       reason: 'windows_named_pipe_missing',
       endpointState: 'missing',
       exactIncarnation
+    })
+  })
+
+  it('rejects named-pipe disappearance as a gone proof for Unix endpoints', async () => {
+    const observation = await classifyDaemonAuditFailure(
+      context,
+      'inventory_failed',
+      exactIncarnation,
+      {
+        additionalEvidenceSources: ['windows_named_pipe'],
+        endpointGoneProof: 'windows_named_pipe_missing',
+        dependencies: auditClassifierDependencies
+      }
+    )
+
+    expect(observation).toMatchObject({
+      state: 'unknown',
+      reason: 'inventory_failed',
+      processLiveness: 'unknown'
     })
   })
 })

--- a/src/main/daemon/daemon-incarnation-evidence.ts
+++ b/src/main/daemon/daemon-incarnation-evidence.ts
@@ -222,13 +222,13 @@ async function probeWindowsProcess(
       exactIncarnation
     )
   }
-  if (!identity.commandLine) {
-    return unknown('windows_command_line_unavailable', ['windows_cim'])
-  }
-  if (!commandLineMatchesDaemon(identity.commandLine, endpoint.socketPath, endpoint.tokenPath)) {
-    return unknown('command_line_mismatch', ['windows_cim'])
-  }
-  return present('windows_identity_match', ['windows_cim', 'endpoint_identity'])
+  return present(
+    'windows_identity_match',
+    identity.commandLine &&
+      commandLineMatchesDaemon(identity.commandLine, endpoint.socketPath, endpoint.tokenPath)
+      ? ['windows_cim', 'process_command_line', 'endpoint_identity']
+      : ['windows_cim', 'endpoint_identity']
+  )
 }
 
 export function parseLinuxProcessState(statLine: string): string | null {

--- a/src/main/daemon/daemon-incarnation-evidence.ts
+++ b/src/main/daemon/daemon-incarnation-evidence.ts
@@ -1,0 +1,267 @@
+import { parseLinuxStartTicks, readBootIdentity } from '../agent-hooks/managed-hook-owner-identity'
+import {
+  commandLineMatchesDaemon,
+  getProcessStartedAtMs,
+  startTimesWithinTolerance
+} from './daemon-health'
+import {
+  WINDOWS_CREATION_TIME_TOLERANCE_MS,
+  type DaemonEvidenceSources,
+  type DaemonProcessEvidence,
+  type DaemonProcessProbeDependencies,
+  type ExactDaemonIncarnation,
+  type ProcessSignalEvidence
+} from './daemon-incarnation-evidence-types'
+import {
+  inspectProcessSignal,
+  queryWindowsProcess,
+  readLinuxStat,
+  readProcessCommandLine
+} from './daemon-process-inspection'
+
+export {
+  DAEMON_GONE_PROOFS,
+  WINDOWS_CREATION_TIME_TOLERANCE_MS,
+  type DaemonEvidenceSource,
+  type DaemonEvidenceSources,
+  type DaemonProcessEvidence,
+  type DaemonProcessProbeDependencies,
+  type ExactDaemonIncarnation,
+  type LinuxStatEvidence,
+  type ProcessSignalEvidence,
+  type WindowsProcessEvidence
+} from './daemon-incarnation-evidence-types'
+
+const POSIX_START_TIME_TOLERANCE_MS = 1_500
+
+export async function probeDaemonProcessIdentity(
+  exactIncarnation: ExactDaemonIncarnation | null,
+  endpoint: { socketPath: string; tokenPath: string },
+  dependencies: DaemonProcessProbeDependencies = {}
+): Promise<DaemonProcessEvidence> {
+  if (!exactIncarnation) {
+    return unknown('exact_identity_unavailable', ['pid_record'])
+  }
+  const platform = dependencies.platform ?? process.platform
+  const signalProcess = dependencies.signalProcess ?? inspectProcessSignal
+  const signal = signalProcess(exactIncarnation.identity.pid)
+  if (platform !== 'win32' && signal === 'missing') {
+    return gone('pid_missing', ['process_signal', 'endpoint_identity'], exactIncarnation)
+  }
+
+  if (platform === 'linux') {
+    return await probeLinuxProcess(exactIncarnation, endpoint, signal, dependencies)
+  }
+  if (platform === 'win32') {
+    return await probeWindowsProcess(exactIncarnation, endpoint, signal, dependencies)
+  }
+  return await probeMacosProcess(exactIncarnation, endpoint, signal, dependencies)
+}
+
+async function probeLinuxProcess(
+  exactIncarnation: ExactDaemonIncarnation,
+  endpoint: { socketPath: string; tokenPath: string },
+  signal: ProcessSignalEvidence,
+  dependencies: DaemonProcessProbeDependencies
+): Promise<DaemonProcessEvidence> {
+  const stat = await (dependencies.readLinuxStat ?? readLinuxStat)(exactIncarnation.identity.pid)
+  if (stat.status === 'missing') {
+    return gone('pid_missing', ['linux_proc_stat', 'endpoint_identity'], exactIncarnation)
+  }
+  if (stat.status === 'unavailable') {
+    return unknown(signal === 'permission_denied' ? 'permission_denied' : 'inspection_failed', [
+      'linux_proc_stat',
+      'process_signal'
+    ])
+  }
+
+  const expectedTicks = exactIncarnation.linuxStartTicks
+  const expectedBootId = exactIncarnation.bootId
+  if (expectedTicks || expectedBootId) {
+    if (!expectedTicks || !expectedBootId) {
+      return unknown('linux_identity_incomplete', ['pid_record'])
+    }
+    const bootId = await (dependencies.readBootIdentity ?? readBootIdentity)()
+    if (!bootId) {
+      return unknown('inspection_failed', ['boot_identity'])
+    }
+    if (bootId !== expectedBootId) {
+      return gone(
+        'linux_boot_changed',
+        ['boot_identity', 'pid_record', 'endpoint_identity'],
+        exactIncarnation
+      )
+    }
+    const currentTicks = parseLinuxStartTicks(stat.value)
+    if (!currentTicks) {
+      return unknown('inspection_failed', ['linux_proc_stat'])
+    }
+    if (currentTicks !== expectedTicks) {
+      return gone(
+        'linux_start_ticks_mismatch',
+        ['linux_proc_stat', 'boot_identity', 'pid_record'],
+        exactIncarnation
+      )
+    }
+    if (parseLinuxProcessState(stat.value) === 'Z') {
+      return gone(
+        'linux_zombie',
+        ['linux_proc_stat', 'boot_identity', 'pid_record'],
+        exactIncarnation
+      )
+    }
+  }
+
+  const commandLine = await (dependencies.readCommandLine ?? readProcessCommandLine)(
+    exactIncarnation.identity.pid,
+    'linux'
+  )
+  if (commandLine === undefined) {
+    return unknown('command_line_unavailable', ['process_command_line'])
+  }
+  if (!commandLineMatchesDaemon(commandLine, endpoint.socketPath, endpoint.tokenPath)) {
+    return unknown('command_line_mismatch', ['process_command_line'])
+  }
+  if (expectedTicks && expectedBootId) {
+    return present('linux_identity_match', [
+      'linux_proc_stat',
+      'boot_identity',
+      'process_command_line',
+      'endpoint_identity'
+    ])
+  }
+
+  const startedAtMs = (dependencies.readProcessStartedAtMs ?? getProcessStartedAtMs)(
+    exactIncarnation.identity.pid
+  )
+  if (startedAtMs === null) {
+    return unknown('process_start_time_unavailable', ['process_start_time'])
+  }
+  return startTimesWithinTolerance(
+    startedAtMs,
+    exactIncarnation.identity.startedAtMs,
+    POSIX_START_TIME_TOLERANCE_MS
+  )
+    ? present('linux_identity_match', [
+        'process_command_line',
+        'process_start_time',
+        'endpoint_identity'
+      ])
+    : unknown('linux_identity_incomplete', ['process_start_time', 'endpoint_identity'])
+}
+
+async function probeMacosProcess(
+  exactIncarnation: ExactDaemonIncarnation,
+  endpoint: { socketPath: string; tokenPath: string },
+  signal: ProcessSignalEvidence,
+  dependencies: DaemonProcessProbeDependencies
+): Promise<DaemonProcessEvidence> {
+  const commandLine = await (dependencies.readCommandLine ?? readProcessCommandLine)(
+    exactIncarnation.identity.pid,
+    'darwin'
+  )
+  if (commandLine === undefined) {
+    return unknown(
+      signal === 'permission_denied' ? 'permission_denied' : 'command_line_unavailable',
+      ['process_command_line', 'process_signal']
+    )
+  }
+  if (!commandLineMatchesDaemon(commandLine, endpoint.socketPath, endpoint.tokenPath)) {
+    return unknown('command_line_mismatch', ['process_command_line'])
+  }
+  const startedAtMs = (dependencies.readProcessStartedAtMs ?? getProcessStartedAtMs)(
+    exactIncarnation.identity.pid
+  )
+  if (startedAtMs === null) {
+    return unknown('process_start_time_unavailable', ['process_start_time'])
+  }
+  return startTimesWithinTolerance(
+    startedAtMs,
+    exactIncarnation.identity.startedAtMs,
+    POSIX_START_TIME_TOLERANCE_MS
+  )
+    ? present('macos_identity_match', [
+        'process_command_line',
+        'process_start_time',
+        'endpoint_identity'
+      ])
+    : unknown('macos_start_time_mismatch', ['process_start_time', 'endpoint_identity'])
+}
+
+async function probeWindowsProcess(
+  exactIncarnation: ExactDaemonIncarnation,
+  endpoint: { socketPath: string; tokenPath: string },
+  signal: ProcessSignalEvidence,
+  dependencies: DaemonProcessProbeDependencies
+): Promise<DaemonProcessEvidence> {
+  const identity = await (dependencies.queryWindowsProcess ?? queryWindowsProcess)(
+    exactIncarnation.identity.pid
+  )
+  if (identity.status === 'missing') {
+    return gone('windows_process_missing', ['windows_cim', 'endpoint_identity'], exactIncarnation)
+  }
+  if (identity.status === 'unavailable') {
+    return unknown(signal === 'permission_denied' ? 'permission_denied' : 'inspection_failed', [
+      'windows_cim',
+      'process_signal'
+    ])
+  }
+  if (identity.startedAtMs === null) {
+    return unknown('windows_process_start_time_unavailable', ['windows_cim'])
+  }
+  if (
+    !startTimesWithinTolerance(
+      identity.startedAtMs,
+      exactIncarnation.identity.startedAtMs,
+      WINDOWS_CREATION_TIME_TOLERANCE_MS
+    )
+  ) {
+    return gone(
+      'windows_creation_time_mismatch',
+      ['windows_cim', 'endpoint_identity'],
+      exactIncarnation
+    )
+  }
+  if (!identity.commandLine) {
+    return unknown('windows_command_line_unavailable', ['windows_cim'])
+  }
+  if (!commandLineMatchesDaemon(identity.commandLine, endpoint.socketPath, endpoint.tokenPath)) {
+    return unknown('command_line_mismatch', ['windows_cim'])
+  }
+  return present('windows_identity_match', ['windows_cim', 'endpoint_identity'])
+}
+
+export function parseLinuxProcessState(statLine: string): string | null {
+  const commandEnd = statLine.lastIndexOf(')')
+  if (commandEnd < 0) {
+    return null
+  }
+  return (
+    statLine
+      .slice(commandEnd + 1)
+      .trim()
+      .split(/\s+/, 1)[0] ?? null
+  )
+}
+
+function present(
+  reason: Extract<DaemonProcessEvidence, { state: 'present' }>['reason'],
+  evidenceSources: DaemonEvidenceSources
+): DaemonProcessEvidence {
+  return { state: 'present', reason, evidenceSources }
+}
+
+function gone(
+  reason: Extract<DaemonProcessEvidence, { state: 'gone' }>['reason'],
+  evidenceSources: DaemonEvidenceSources,
+  exactIncarnation: ExactDaemonIncarnation
+): DaemonProcessEvidence {
+  return { state: 'gone', reason, evidenceSources, exactIncarnation }
+}
+
+function unknown(
+  reason: Extract<DaemonProcessEvidence, { state: 'unknown' }>['reason'],
+  evidenceSources: DaemonEvidenceSources
+): DaemonProcessEvidence {
+  return { state: 'unknown', reason, evidenceSources }
+}

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -241,7 +241,10 @@ vi.mock('fs', () => ({
   writeFileSync: writeFileSyncMock
 }))
 
-vi.mock('child_process', () => ({ fork: forkMock }))
+vi.mock('child_process', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  fork: forkMock
+}))
 
 vi.mock('net', () => ({ connect: netConnectMock }))
 
@@ -1754,7 +1757,14 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       on(event: string, cb: (arg?: unknown) => void) {
         handlers[event]?.push(cb)
         if (event === 'message') {
-          queueMicrotask(() => cb({ type: 'ready', startedAtMs: 1_000_000 }))
+          queueMicrotask(() =>
+            cb({
+              type: 'ready',
+              startedAtMs: 1_000_000,
+              linuxStartTicks: '4242',
+              bootId: 'boot-a'
+            })
+          )
         }
         return this
       },
@@ -1782,6 +1792,8 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(JSON.parse(pidContents as string)).toEqual({
       pid: 12345,
       startedAtMs: 1_000_000,
+      linuxStartTicks: '4242',
+      bootId: 'boot-a',
       entryPath: FAKE_DAEMON_ENTRY_PATH,
       appVersion: '1.2.3',
       launchNonce: expect.stringMatching(/^[0-9a-f-]{36}$/)

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -53,6 +53,7 @@ import {
   confirmSeededClaudeLivePtys,
   hasSeededUnconfirmedClaudePtys
 } from '../claude-accounts/live-pty-gate'
+import { parseDaemonReadyIdentity } from './daemon-ready-identity'
 
 // Why: daemon init runs concurrent with window load, so an in-process t timestamp (not harness stderr timing) measures cold-start.
 function logDaemonMilestone(event: string, details: Record<string, unknown> = {}): void {
@@ -600,14 +601,8 @@ function createOutOfProcessLauncher(
             if (settled) {
               return
             }
-            const selfReported = (msg as { startedAtMs?: unknown }).startedAtMs
-            if (
-              !Number.isSafeInteger(child.pid) ||
-              (child.pid as number) <= 0 ||
-              typeof selfReported !== 'number' ||
-              !Number.isFinite(selfReported) ||
-              selfReported <= 0
-            ) {
+            const readyIdentity = parseDaemonReadyIdentity(msg)
+            if (!Number.isSafeInteger(child.pid) || (child.pid as number) <= 0 || !readyIdentity) {
               void fail(new Error('Daemon readiness identity is incomplete'))
               return
             }
@@ -617,7 +612,7 @@ function createOutOfProcessLauncher(
                 pidPath,
                 serializeDaemonPidFile({
                   pid: child.pid as number,
-                  startedAtMs: selfReported,
+                  ...readyIdentity,
                   entryPath,
                   appVersion: app.getVersion(),
                   launchNonce
@@ -718,7 +713,9 @@ export async function initDaemonPtyProvider(
     // Why: fail-open may already have spawned fallback PTYs; don't install late, but retire an empty daemon (live sessions reject it and survive).
     const abortedStartupAdapter = new DaemonPtyAdapter({
       socketPath: info.socketPath,
-      tokenPath: info.tokenPath
+      tokenPath: info.tokenPath,
+      pidPath: getDaemonPidPath(runtimeDir),
+      profileScope: runtimeDir
     })
     releaseDaemonAdoptionLease(newSpawner.getHandle())
     await abortedStartupAdapter.disconnectOnly()
@@ -728,6 +725,8 @@ export async function initDaemonPtyProvider(
   const newAdapter = new DaemonPtyAdapter({
     socketPath: info.socketPath,
     tokenPath: info.tokenPath,
+    pidPath: getDaemonPidPath(runtimeDir),
+    profileScope: runtimeDir,
     historyPath: getHistoryDir(),
     // Why: on daemon death, ensureConnected() detects the dead socket and calls this to fork a replacement before retrying.
     respawn: async (reason: DaemonRespawnReason) => {
@@ -925,6 +924,8 @@ async function runRestartDaemon(): Promise<RestartDaemonResult> {
   const newCurrent = new DaemonPtyAdapter({
     socketPath: info.socketPath,
     tokenPath: info.tokenPath,
+    pidPath: getDaemonPidPath(runtimeDir),
+    profileScope: runtimeDir,
     historyPath: getHistoryDir(),
     respawn: async (reason: DaemonRespawnReason) => {
       // Why: attribute rather than emit — the launcher below is the one that completes the
@@ -1155,6 +1156,8 @@ export async function createLegacyDaemonAdapters(
       new DaemonPtyAdapter({
         socketPath,
         tokenPath,
+        pidPath: getDaemonPidPath(runtimeDir, protocolVersion),
+        profileScope: runtimeDir,
         protocolVersion,
         historyPath
       })

--- a/src/main/daemon/daemon-process-inspection.test.ts
+++ b/src/main/daemon/daemon-process-inspection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { queryWindowsProcess, readProcessCommandLine } from './daemon-process-inspection'
+
+describe('daemon process inspection', () => {
+  it('falls back to ps when Linux procfs returns an empty command line', async () => {
+    const readTextFile = vi.fn(async () => '')
+    const runCommand = vi.fn(async () => 'node daemon-entry --socket daemon.sock')
+
+    await expect(readProcessCommandLine(42, 'linux', { readTextFile, runCommand })).resolves.toBe(
+      'node daemon-entry --socket daemon.sock'
+    )
+    expect(readTextFile).toHaveBeenCalledWith('/proc/42/cmdline')
+    expect(runCommand).toHaveBeenCalledWith('ps', ['-p', '42', '-o', 'command='], 2_000)
+  })
+
+  it('uses a non-empty Linux procfs command line without spawning ps', async () => {
+    const readTextFile = vi.fn(async () => 'node\0daemon-entry')
+    const runCommand = vi.fn()
+
+    await expect(readProcessCommandLine(42, 'linux', { readTextFile, runCommand })).resolves.toBe(
+      'node\0daemon-entry'
+    )
+    expect(runCommand).not.toHaveBeenCalled()
+  })
+
+  it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, Number.NaN])(
+    'rejects unsafe Windows pid %s before command interpolation',
+    async (pid) => {
+      const runCommand = vi.fn()
+
+      await expect(queryWindowsProcess(pid, { runCommand })).resolves.toEqual({
+        status: 'unavailable'
+      })
+      expect(runCommand).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/main/daemon/daemon-process-inspection.ts
+++ b/src/main/daemon/daemon-process-inspection.ts
@@ -1,0 +1,97 @@
+import { execFile } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { promisify } from 'node:util'
+import type {
+  LinuxStatEvidence,
+  ProcessSignalEvidence,
+  WindowsProcessEvidence
+} from './daemon-incarnation-evidence-types'
+
+const execFileAsync = promisify(execFile)
+
+export function inspectProcessSignal(pid: number): ProcessSignalEvidence {
+  try {
+    process.kill(pid, 0)
+    return 'occupied'
+  } catch (error) {
+    if (hasErrorCode(error, 'ESRCH')) {
+      return 'missing'
+    }
+    if (hasErrorCode(error, 'EPERM')) {
+      return 'permission_denied'
+    }
+    return 'unavailable'
+  }
+}
+
+export async function readLinuxStat(pid: number): Promise<LinuxStatEvidence> {
+  try {
+    return { status: 'present', value: await readFile(`/proc/${pid}/stat`, 'utf8') }
+  } catch (error) {
+    return { status: hasErrorCode(error, 'ENOENT') ? 'missing' : 'unavailable' }
+  }
+}
+
+export async function readProcessCommandLine(
+  pid: number,
+  platform: NodeJS.Platform
+): Promise<string | undefined> {
+  if (platform === 'linux') {
+    try {
+      return await readFile(`/proc/${pid}/cmdline`, 'utf8')
+    } catch {
+      // Fall through to ps for procfs privilege or mount restrictions.
+    }
+  }
+  try {
+    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'command='], {
+      encoding: 'utf8',
+      timeout: 2_000
+    })
+    return stdout.trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+export async function queryWindowsProcess(pid: number): Promise<WindowsProcessEvidence> {
+  try {
+    const { stdout } = await execFileAsync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"; ` +
+          `if (!$p) { @{ exists = $false } | ConvertTo-Json -Compress } else { ` +
+          `$start = $null; if ($p.CreationDate) { ` +
+          `$start = [long]([DateTimeOffset]$p.CreationDate).ToUnixTimeMilliseconds() }; ` +
+          `@{ exists = $true; cmd = $p.CommandLine; start = $start } | ConvertTo-Json -Compress }`
+      ],
+      { encoding: 'utf8', timeout: 3_000 }
+    )
+    const parsed = JSON.parse(stdout.trim()) as {
+      exists?: unknown
+      cmd?: unknown
+      start?: unknown
+    }
+    if (parsed.exists === false) {
+      return { status: 'missing' }
+    }
+    if (parsed.exists !== true) {
+      return { status: 'unavailable' }
+    }
+    return {
+      status: 'present',
+      commandLine: typeof parsed.cmd === 'string' && parsed.cmd ? parsed.cmd : null,
+      startedAtMs:
+        typeof parsed.start === 'number' && Number.isFinite(parsed.start) ? parsed.start : null
+    }
+  } catch {
+    return { status: 'unavailable' }
+  }
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code
+}

--- a/src/main/daemon/daemon-process-inspection.ts
+++ b/src/main/daemon/daemon-process-inspection.ts
@@ -9,6 +9,11 @@ import type {
 
 const execFileAsync = promisify(execFile)
 
+export type DaemonProcessInspectionDependencies = {
+  readTextFile?: (path: string) => Promise<string>
+  runCommand?: (file: string, args: string[], timeoutMs: number) => Promise<string>
+}
+
 export function inspectProcessSignal(pid: number): ProcessSignalEvidence {
   try {
     process.kill(pid, 0)
@@ -34,29 +39,40 @@ export async function readLinuxStat(pid: number): Promise<LinuxStatEvidence> {
 
 export async function readProcessCommandLine(
   pid: number,
-  platform: NodeJS.Platform
+  platform: NodeJS.Platform,
+  dependencies: DaemonProcessInspectionDependencies = {}
 ): Promise<string | undefined> {
+  const readTextFile =
+    dependencies.readTextFile ?? (async (path: string) => await readFile(path, 'utf8'))
+  const runCommand = dependencies.runCommand ?? runInspectionCommand
   if (platform === 'linux') {
     try {
-      return await readFile(`/proc/${pid}/cmdline`, 'utf8')
+      const procCommandLine = await readTextFile(`/proc/${pid}/cmdline`)
+      if (procCommandLine.length > 0) {
+        return procCommandLine
+      }
     } catch {
       // Fall through to ps for procfs privilege or mount restrictions.
     }
   }
   try {
-    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'command='], {
-      encoding: 'utf8',
-      timeout: 2_000
-    })
+    const stdout = await runCommand('ps', ['-p', String(pid), '-o', 'command='], 2_000)
     return stdout.trim() || undefined
   } catch {
     return undefined
   }
 }
 
-export async function queryWindowsProcess(pid: number): Promise<WindowsProcessEvidence> {
+export async function queryWindowsProcess(
+  pid: number,
+  dependencies: DaemonProcessInspectionDependencies = {}
+): Promise<WindowsProcessEvidence> {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return { status: 'unavailable' }
+  }
+  const runCommand = dependencies.runCommand ?? runInspectionCommand
   try {
-    const { stdout } = await execFileAsync(
+    const stdout = await runCommand(
       'powershell.exe',
       [
         '-NoProfile',
@@ -68,7 +84,7 @@ export async function queryWindowsProcess(pid: number): Promise<WindowsProcessEv
           `$start = [long]([DateTimeOffset]$p.CreationDate).ToUnixTimeMilliseconds() }; ` +
           `@{ exists = $true; cmd = $p.CommandLine; start = $start } | ConvertTo-Json -Compress }`
       ],
-      { encoding: 'utf8', timeout: 3_000 }
+      3_000
     )
     const parsed = JSON.parse(stdout.trim()) as {
       exists?: unknown
@@ -90,6 +106,15 @@ export async function queryWindowsProcess(pid: number): Promise<WindowsProcessEv
   } catch {
     return { status: 'unavailable' }
   }
+}
+
+async function runInspectionCommand(
+  file: string,
+  args: string[],
+  timeoutMs: number
+): Promise<string> {
+  const { stdout } = await execFileAsync(file, args, { encoding: 'utf8', timeout: timeoutMs })
+  return stdout
 }
 
 function hasErrorCode(error: unknown, code: string): boolean {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1449,6 +1449,11 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(procs[0]).toHaveProperty('title')
       expect(procs[0].cwd).toBe('/repo/owned-before-osc7')
       expect(procs[0].worktreeId).toBe('repo::/repo/owned-before-osc7')
+      expect(adapter.getLastAuditObservation()).toMatchObject({
+        state: 'present',
+        reason: 'authenticated_inventory',
+        inventoryAuthority: 'authoritative'
+      })
     })
 
     it('reports the daemon session WSL owner', async () => {
@@ -1469,6 +1474,79 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           Object.defineProperty(process, 'platform', platform)
         }
       }
+    })
+
+    it('retains authenticated identity and reports replacement across a same-endpoint reconnect', async () => {
+      await adapter.listProcesses()
+      const firstIdentity = adapter.getLastAuthenticatedDaemonIdentity()
+      expect(firstIdentity).not.toBeNull()
+      const identityChanges: {
+        previous: NonNullable<typeof firstIdentity>
+        current: NonNullable<typeof firstIdentity>
+      }[] = []
+      adapter.onDaemonIdentityChanged((event) => identityChanges.push(event))
+
+      await server.shutdown()
+      await waitFor(
+        () => !(adapter as unknown as { client: { isConnected(): boolean } }).client.isConnected()
+      )
+      expect(adapter.getLastAuthenticatedDaemonIdentity()).toEqual(firstIdentity)
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        launchNonce: 'replacement-launch',
+        startedAtMs: (firstIdentity?.startedAtMs ?? 0) + 10_000,
+        log: daemonLog,
+        spawnSubprocess: (opts) => {
+          lastSpawnOpts = opts
+          lastSubprocess = createMockSubprocess()
+          return lastSubprocess
+        }
+      })
+      await server.start()
+
+      await adapter.listProcesses()
+
+      expect(identityChanges).toEqual([
+        {
+          previous: firstIdentity,
+          current: {
+            pid: process.pid,
+            startedAtMs: (firstIdentity?.startedAtMs ?? 0) + 10_000,
+            launchNonce: 'replacement-launch'
+          }
+        }
+      ])
+      expect(adapter.getLastAuthenticatedDaemonIdentity()).toEqual(identityChanges[0]?.current)
+    })
+
+    it('audits token ENOENT only after an authenticated disconnect', async () => {
+      const observations: {
+        trigger: string
+        state: string
+        evidenceSources: readonly string[]
+      }[] = []
+      adapter.onAuditEligibilityObservation((observation) => observations.push(observation))
+      await adapter.listProcesses()
+
+      await server.shutdown()
+      await waitFor(
+        () => !(adapter as unknown as { client: { isConnected(): boolean } }).client.isConnected()
+      )
+      await expect(adapter.listProcesses()).rejects.toThrow()
+      await waitFor(() =>
+        observations.some(
+          (observation) => observation.trigger === 'token_missing_after_authenticated_disconnect'
+        )
+      )
+
+      expect(observations).toContainEqual(
+        expect.objectContaining({
+          trigger: 'token_missing_after_authenticated_disconnect',
+          state: 'unknown',
+          evidenceSources: expect.arrayContaining(['token_file'])
+        })
+      )
     })
   })
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1484,6 +1484,9 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         previous: NonNullable<typeof firstIdentity>
         current: NonNullable<typeof firstIdentity>
       }[] = []
+      adapter.onDaemonIdentityChanged(() => {
+        throw new Error('audit listener failed')
+      })
       adapter.onDaemonIdentityChanged((event) => identityChanges.push(event))
 
       await server.shutdown()
@@ -1505,7 +1508,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       })
       await server.start()
 
-      await adapter.listProcesses()
+      await expect(adapter.listProcesses()).resolves.toEqual([])
 
       expect(identityChanges).toEqual([
         {
@@ -1518,6 +1521,28 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         }
       ])
       expect(adapter.getLastAuthenticatedDaemonIdentity()).toEqual(identityChanges[0]?.current)
+    })
+
+    it('isolates audit observation listeners from inventory and later listeners', async () => {
+      const laterListener = vi.fn()
+      adapter.onAuditEligibilityObservation(() => {
+        throw new Error('audit listener failed')
+      })
+      adapter.onAuditEligibilityObservation(laterListener)
+
+      await expect(adapter.listProcesses()).resolves.toEqual([])
+
+      expect(laterListener).toHaveBeenCalledOnce()
+      expect(laterListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: 'present',
+          reason: 'authenticated_inventory'
+        })
+      )
+      expect(adapter.getLastAuditObservation()).toMatchObject({
+        state: 'present',
+        reason: 'authenticated_inventory'
+      })
     })
 
     it('audits token ENOENT only after an authenticated disconnect', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1,8 +1,12 @@
 /* oxlint-disable max-lines -- Why: history .catch() safety wiring spread across spawn/event-routing is tightly coupled to the adapter↔history lifecycle. */
 import { basename } from 'node:path'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { DaemonClient } from './client'
-import { getMacDaemonSystemResolverHealth } from './daemon-health'
+import {
+  getMacDaemonSystemResolverHealth,
+  parseDaemonPidFile,
+  type ParsedDaemonPid
+} from './daemon-health'
 import {
   HistoryManager,
   type HistoryCheckpointResult,
@@ -63,6 +67,16 @@ import {
   TERMINAL_HISTORY_INLINE_SEED_CODE_UNITS
 } from './terminal-history-seed-chunks'
 import { NdjsonLineTooLongError } from './ndjson'
+import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
+import {
+  classifyDaemonAuditFailure,
+  recordAuthenticatedInventory,
+  type DaemonAuditContext,
+  type DaemonAuditObservation,
+  type DaemonAuditTrigger
+} from './daemon-audit-classifier'
+import type { DaemonEvidenceSource, ExactDaemonIncarnation } from './daemon-incarnation-evidence'
+import { trackDaemonAuditEligibility } from './daemon-audit-eligibility-event'
 
 type PendingDaemonSpawnOperation = {
   exitsBySessionId: Map<string, { incarnationId?: string }[]>
@@ -100,6 +114,8 @@ function providerSequenceForSpawn(
 export type DaemonPtyAdapterOptions = {
   socketPath: string
   tokenPath: string
+  pidPath?: string
+  profileScope?: string
   protocolVersion?: number
   /** Directory for disk-based terminal history; when set, raw PTY output is written to disk for cold restore on daemon crash. */
   historyPath?: string
@@ -108,6 +124,11 @@ export type DaemonPtyAdapterOptions = {
 }
 
 export type DaemonRespawnReason = 'daemon_died' | 'unhealthy_resolver'
+
+export type DaemonIdentityChangeEvent = {
+  previous: DaemonEndpointIdentity
+  current: DaemonEndpointIdentity
+}
 
 const MAX_TOMBSTONES = 1000
 const MAX_CONCURRENT_CHECKPOINTS = 4
@@ -130,7 +151,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
   readonly protocolVersion: number
   private socketPath: string
   private tokenPath: string
+  private pidPath: string | null
   private client: DaemonClient
+  private auditContext: DaemonAuditContext
+  private lastAuthenticatedIdentity: DaemonEndpointIdentity | null = null
+  private exactDaemonIncarnation: ExactDaemonIncarnation | null = null
+  private lastAuditObservation: DaemonAuditObservation | null = null
+  private auditObservationListeners: ((observation: DaemonAuditObservation) => void)[] = []
+  private identityChangeListeners: ((event: DaemonIdentityChangeEvent) => void)[] = []
   private historyManager: HistoryManager | null
   private historyReader: HistoryReader | null
   private respawnFn: DaemonPtyAdapterOptions['respawn'] | null
@@ -219,6 +247,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.protocolVersion = opts.protocolVersion ?? PROTOCOL_VERSION
     this.socketPath = opts.socketPath
     this.tokenPath = opts.tokenPath
+    this.pidPath = opts.pidPath ?? null
+    this.auditContext = {
+      protocolGeneration: this.protocolVersion,
+      provider: 'local-daemon',
+      endpoint: opts.socketPath,
+      tokenPath: opts.tokenPath,
+      endpointKind: process.platform === 'win32' ? 'windows-named-pipe' : 'unix-socket',
+      profileScope: opts.profileScope ?? ''
+    }
     this.client = new DaemonClient({
       socketPath: opts.socketPath,
       tokenPath: opts.tokenPath,
@@ -247,11 +284,32 @@ export class DaemonPtyAdapter implements IPtyProvider {
         this.producerResumesOwedOnReconnect.add(id)
       }
       this.pausedProducerSessionIds.clear()
+      this.observeAuditFailure('transport_closed')
     })
   }
 
   getHistoryManager(): HistoryManager | null {
     return this.historyManager
+  }
+
+  getLastAuthenticatedDaemonIdentity(): DaemonEndpointIdentity | null {
+    return this.lastAuthenticatedIdentity ? { ...this.lastAuthenticatedIdentity } : null
+  }
+
+  getLastAuditObservation(): DaemonAuditObservation | null {
+    return this.lastAuditObservation
+  }
+
+  onDaemonIdentityChanged(listener: (event: DaemonIdentityChangeEvent) => void): () => void {
+    this.identityChangeListeners.push(listener)
+    return () => removeListener(this.identityChangeListeners, listener)
+  }
+
+  onAuditEligibilityObservation(
+    listener: (observation: DaemonAuditObservation) => void
+  ): () => void {
+    this.auditObservationListeners.push(listener)
+    return () => removeListener(this.auditObservationListeners, listener)
   }
 
   supportsAgentSessionClaims(): boolean {
@@ -1262,36 +1320,57 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 
   async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
-    // Why: connect + listSessions share the caller's one absolute deadline so a
-    // wedged handshake cannot burn the whole teardown budget before the list issues.
-    await this.ensureConnected(opts?.deadlineMs)
-    const result = await this.client.request<ListSessionsResult>(
-      'listSessions',
-      undefined,
-      remainingRequestTimeoutMs(opts?.deadlineMs)
-    )
-    const admission = new PtyProcessListAdmission()
-    const processes: PtyProcessInfo[] = []
-    for (const session of result.sessions) {
-      if (!session.isAlive) {
-        continue
-      }
-      const { worktreeId } = parsePtySessionId(session.sessionId)
-      processes.push(
-        admission.admit({
-          id: session.sessionId,
-          ...(session.incarnationId ? { incarnationId: session.incarnationId } : {}),
-          // Why: OSC 7 may not arrive before cleanup; spawn cwd is authoritative until the daemon reports a live cwd.
-          cwd: session.cwd ?? this.initialCwds.get(session.sessionId) ?? '',
-          title: 'shell',
-          ...(worktreeId ? { worktreeId } : {}),
-          ...(session.terminalHandle ? { terminalHandle: session.terminalHandle } : {}),
-          ...(session.wslDistro !== undefined ? { wslDistro: session.wslDistro } : {}),
-          ...this.validatedAgentSessionOwners(session.agentSessionOwners)
-        })
+    try {
+      // Why: connect + listSessions share the caller's one absolute deadline so a
+      // wedged handshake cannot burn the whole teardown budget before the list issues.
+      await this.ensureConnected(opts?.deadlineMs)
+      const result = await this.client.request<ListSessionsResult>(
+        'listSessions',
+        undefined,
+        remainingRequestTimeoutMs(opts?.deadlineMs)
       )
+      const admission = new PtyProcessListAdmission()
+      const processes: PtyProcessInfo[] = []
+      for (const session of result.sessions) {
+        if (!session.isAlive) {
+          continue
+        }
+        const { worktreeId } = parsePtySessionId(session.sessionId)
+        processes.push(
+          admission.admit({
+            id: session.sessionId,
+            ...(session.incarnationId ? { incarnationId: session.incarnationId } : {}),
+            // Why: OSC 7 may not arrive before cleanup; spawn cwd is authoritative until the daemon reports a live cwd.
+            cwd: session.cwd ?? this.initialCwds.get(session.sessionId) ?? '',
+            title: 'shell',
+            ...(worktreeId ? { worktreeId } : {}),
+            ...(session.terminalHandle ? { terminalHandle: session.terminalHandle } : {}),
+            ...(session.wslDistro !== undefined ? { wslDistro: session.wslDistro } : {}),
+            ...this.validatedAgentSessionOwners(session.agentSessionOwners)
+          })
+        )
+      }
+      this.publishAuditObservation(
+        recordAuthenticatedInventory(this.auditContext, this.exactDaemonIncarnation)
+      )
+      return processes
+    } catch (error) {
+      const missingAuthenticatedToken =
+        isMissingTokenFileError(error) && this.client.hasObservedAuthenticatedDisconnect()
+      const missingNamedPipe = isMissingWindowsNamedPipeError(error)
+      this.observeAuditFailure(
+        missingAuthenticatedToken
+          ? 'token_missing_after_authenticated_disconnect'
+          : 'inventory_failed',
+        this.exactDaemonIncarnation,
+        [
+          ...(missingAuthenticatedToken ? (['token_file'] as const) : []),
+          ...(missingNamedPipe ? (['windows_named_pipe'] as const) : [])
+        ],
+        missingNamedPipe ? 'windows_named_pipe_missing' : undefined
+      )
+      throw error
     }
-    return processes
   }
 
   private validatedAgentSessionOwners(
@@ -1452,6 +1531,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.wslDistrosBySessionId.clear()
     this.pausedProducerSessionIds.clear()
     this.producerResumesOwedOnReconnect.clear()
+    this.auditObservationListeners.length = 0
+    this.identityChangeListeners.length = 0
     this.removeEventListener?.()
     this.removeEventListener = null
     // Why: final checkpoints are written daemon-side (TerminalHost.dispose); here the adapter only marks sessions
@@ -1470,6 +1551,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     // Why: an authenticated pair cancels the adoption watchdog and lets a never-used adapter retire its empty daemon on quit.
     await this.client.ensureConnected()
+    this.recordAuthenticatedIdentity()
   }
 
   // Why: unlike dispose(), leave history files unclean (no endedAt) so the next launch treats them as crash-recoverable,
@@ -1532,6 +1614,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // Why: a respawn launcher holds a temporary pair until this adapter's permanent reconnect, preventing both gaps and leaks.
       this.releasePendingRespawnAdoptionLease()
     }
+    this.recordAuthenticatedIdentity()
     // Why sampled before setupEventRouting: "no listener yet" identifies a fresh connect — the only time the
     // daemon-side backgrounded set (process state lost with the old daemon) needs a resync.
     const isFreshConnection = this.removeEventListener === null
@@ -1540,6 +1623,82 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.flushOwedProducerResumes()
     if (isFreshConnection) {
       this.resyncBackgroundedSessions()
+    }
+  }
+
+  private recordAuthenticatedIdentity(): void {
+    const current = this.client.getDaemonIdentity()
+    if (!current) {
+      return
+    }
+    const previous = this.lastAuthenticatedIdentity
+    if (previous && sameEndpointIdentity(previous, current)) {
+      return
+    }
+    const previousExactIncarnation = this.exactDaemonIncarnation
+    const pidRecord = this.readMatchingPidRecord(current)
+    this.lastAuthenticatedIdentity = { ...current }
+    this.exactDaemonIncarnation = {
+      identity: { ...current },
+      ...(pidRecord?.linuxStartTicks && pidRecord.bootId
+        ? {
+            linuxStartTicks: pidRecord.linuxStartTicks,
+            bootId: pidRecord.bootId
+          }
+        : {})
+    }
+    if (!previous) {
+      return
+    }
+    const event = { previous: { ...previous }, current: { ...current } }
+    // oxlint-disable-next-line unicorn/no-useless-spread -- listeners may unsubscribe during dispatch
+    for (const listener of [...this.identityChangeListeners]) {
+      listener(event)
+    }
+    this.observeAuditFailure('endpoint_identity_changed', previousExactIncarnation, [
+      'endpoint_identity'
+    ])
+  }
+
+  private readMatchingPidRecord(identity: DaemonEndpointIdentity): ParsedDaemonPid | null {
+    if (!this.pidPath) {
+      return null
+    }
+    try {
+      const parsed = parseDaemonPidFile(readFileSync(this.pidPath, 'utf8'))
+      return parsed?.pid === identity.pid &&
+        parsed.startedAtMs === identity.startedAtMs &&
+        parsed.launchNonce === identity.launchNonce
+        ? parsed
+        : null
+    } catch {
+      return null
+    }
+  }
+
+  private observeAuditFailure(
+    trigger: Exclude<DaemonAuditTrigger, 'inventory_answered'>,
+    exactIncarnation = this.exactDaemonIncarnation,
+    additionalEvidenceSources: readonly DaemonEvidenceSource[] = [],
+    endpointGoneProof?: 'windows_named_pipe_missing'
+  ): void {
+    void classifyDaemonAuditFailure(
+      this.auditContext,
+      trigger,
+      exactIncarnation,
+      additionalEvidenceSources,
+      endpointGoneProof
+    )
+      .then((observation) => this.publishAuditObservation(observation))
+      .catch(() => {})
+  }
+
+  private publishAuditObservation(observation: DaemonAuditObservation): void {
+    this.lastAuditObservation = observation
+    trackDaemonAuditEligibility(observation)
+    // oxlint-disable-next-line unicorn/no-useless-spread -- listeners may unsubscribe during dispatch
+    for (const listener of [...this.auditObservationListeners]) {
+      listener(observation)
     }
   }
 
@@ -1829,6 +1988,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
       // Why: the token is removed only after an authenticated drop; an initial missing token may still hide a live daemon.
       const missingRetiredEndpointToken =
         isMissingTokenFileError(err) && this.client.hasObservedAuthenticatedDisconnect()
+      if (missingRetiredEndpointToken) {
+        this.observeAuditFailure(
+          'token_missing_after_authenticated_disconnect',
+          this.exactDaemonIncarnation,
+          ['token_file']
+        )
+      }
       if (
         this.respawnAdoptionClosed ||
         !this.respawnFn ||
@@ -2135,6 +2301,24 @@ export class DaemonPtyAdapter implements IPtyProvider {
   }
 }
 
+function sameEndpointIdentity(
+  left: DaemonEndpointIdentity,
+  right: DaemonEndpointIdentity
+): boolean {
+  return (
+    left.pid === right.pid &&
+    left.startedAtMs === right.startedAtMs &&
+    left.launchNonce === right.launchNonce
+  )
+}
+
+function removeListener<T>(listeners: T[], listener: T): void {
+  const index = listeners.indexOf(listener)
+  if (index !== -1) {
+    listeners.splice(index, 1)
+  }
+}
+
 // Why: syscall='connect' distinguishes a dead-socket ENOENT/ECONNREFUSED from token-file ENOENT (no syscall);
 // message strings incl. wedged-daemon "Hello response timed out" (#8689) also warrant a respawn.
 function isDaemonGoneError(err: unknown): boolean {
@@ -2160,4 +2344,12 @@ function isMissingTokenFileError(err: unknown): boolean {
   }
   const errno = err as NodeJS.ErrnoException
   return errno.code === 'ENOENT' && errno.syscall === 'open'
+}
+
+function isMissingWindowsNamedPipeError(err: unknown): boolean {
+  if (process.platform !== 'win32' || !(err instanceof Error)) {
+    return false
+  }
+  const errno = err as NodeJS.ErrnoException
+  return errno.code === 'ENOENT' && errno.syscall === 'connect'
 }

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1651,10 +1651,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       return
     }
     const event = { previous: { ...previous }, current: { ...current } }
-    // oxlint-disable-next-line unicorn/no-useless-spread -- listeners may unsubscribe during dispatch
-    for (const listener of [...this.identityChangeListeners]) {
-      listener(event)
-    }
+    notifyAuditListeners(this.identityChangeListeners, event)
     this.observeAuditFailure('endpoint_identity_changed', previousExactIncarnation, [
       'endpoint_identity'
     ])
@@ -1682,13 +1679,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
     additionalEvidenceSources: readonly DaemonEvidenceSource[] = [],
     endpointGoneProof?: 'windows_named_pipe_missing'
   ): void {
-    void classifyDaemonAuditFailure(
-      this.auditContext,
-      trigger,
-      exactIncarnation,
+    void classifyDaemonAuditFailure(this.auditContext, trigger, exactIncarnation, {
       additionalEvidenceSources,
       endpointGoneProof
-    )
+    })
       .then((observation) => this.publishAuditObservation(observation))
       .catch(() => {})
   }
@@ -1696,10 +1690,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private publishAuditObservation(observation: DaemonAuditObservation): void {
     this.lastAuditObservation = observation
     trackDaemonAuditEligibility(observation)
-    // oxlint-disable-next-line unicorn/no-useless-spread -- listeners may unsubscribe during dispatch
-    for (const listener of [...this.auditObservationListeners]) {
-      listener(observation)
-    }
+    notifyAuditListeners(this.auditObservationListeners, observation)
   }
 
   private resyncBackgroundedSessions(): void {
@@ -2316,6 +2307,16 @@ function removeListener<T>(listeners: T[], listener: T): void {
   const index = listeners.indexOf(listener)
   if (index !== -1) {
     listeners.splice(index, 1)
+  }
+}
+
+function notifyAuditListeners<T>(listeners: readonly ((value: T) => void)[], value: T): void {
+  for (const listener of listeners.slice()) {
+    try {
+      listener(value)
+    } catch {
+      // Audit observers cannot affect daemon operations.
+    }
   }
 }
 

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -546,6 +546,35 @@ describe('DaemonPtyRouter', () => {
     await expect(router.listProcesses()).rejects.toThrow('legacy unavailable')
   })
 
+  it('keeps a legacy adapter that exits after construction in fail-closed aggregates', async () => {
+    const current = createAdapter('current', ['current-session'])
+    const legacy = createAdapter('legacy', ['legacy-session'])
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+    await router.discoverLegacySessions()
+    vi.mocked(legacy.listProcesses).mockRejectedValue(new Error('legacy exited'))
+
+    await expect(router.listProcesses()).rejects.toThrow('legacy exited')
+    await expect(router.listProcesses()).rejects.toThrow('legacy exited')
+    expect(router.getLegacyAdapters()).toEqual([legacy])
+    expect(current.listProcesses).toHaveBeenCalledTimes(2)
+  })
+
+  it('pins colliding unmapped legacy ids falling through to the current daemon', async () => {
+    const sessionId = 'cross-generation-collision'
+    const current = createAdapter('current', [sessionId])
+    const legacy = createAdapter('legacy', [sessionId])
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(legacy.listProcesses).mockRejectedValueOnce(new Error('legacy discovery failed'))
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+    await router.discoverLegacySessions()
+    router.write(sessionId, 'misrouted\n')
+
+    expect(current.write).toHaveBeenCalledWith(sessionId, 'misrouted\n')
+    expect(legacy.write).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
   it('merges startup reconciliation and updates route mappings', async () => {
     const current = createAdapter('current', [], {
       alive: ['current-alive'],

--- a/src/main/daemon/daemon-ready-identity.test.ts
+++ b/src/main/daemon/daemon-ready-identity.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { parseDaemonReadyIdentity } from './daemon-ready-identity'
+
+describe('parseDaemonReadyIdentity', () => {
+  it('accepts additive Linux incarnation identity', () => {
+    expect(
+      parseDaemonReadyIdentity({
+        type: 'ready',
+        startedAtMs: 1_700_000_000_000,
+        linuxStartTicks: '4242',
+        bootId: 'boot-a'
+      })
+    ).toEqual({
+      startedAtMs: 1_700_000_000_000,
+      linuxStartTicks: '4242',
+      bootId: 'boot-a'
+    })
+  })
+
+  it('keeps older ready payloads compatible', () => {
+    expect(parseDaemonReadyIdentity({ type: 'ready', startedAtMs: 123 })).toEqual({
+      startedAtMs: 123
+    })
+  })
+
+  it('rejects partial Linux identity instead of persisting a false proof', () => {
+    expect(
+      parseDaemonReadyIdentity({
+        type: 'ready',
+        startedAtMs: 123,
+        linuxStartTicks: '4242'
+      })
+    ).toBeNull()
+  })
+})

--- a/src/main/daemon/daemon-ready-identity.ts
+++ b/src/main/daemon/daemon-ready-identity.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+import { parseLinuxStartTicks, readBootIdentity } from '../agent-hooks/managed-hook-owner-identity'
+
+export type DaemonReadyIdentity = {
+  startedAtMs: number
+  linuxStartTicks?: string
+  bootId?: string
+}
+
+export async function readCurrentDaemonReadyIdentity(
+  startedAtMs: number
+): Promise<DaemonReadyIdentity> {
+  if (process.platform !== 'linux') {
+    return { startedAtMs }
+  }
+  try {
+    const linuxStartTicks = parseLinuxStartTicks(readFileSync('/proc/self/stat', 'utf8'))
+    const bootId = await readBootIdentity()
+    return linuxStartTicks && bootId ? { startedAtMs, linuxStartTicks, bootId } : { startedAtMs }
+  } catch {
+    return { startedAtMs }
+  }
+}
+
+export function parseDaemonReadyIdentity(message: unknown): DaemonReadyIdentity | null {
+  if (!message || typeof message !== 'object') {
+    return null
+  }
+  const value = message as {
+    startedAtMs?: unknown
+    linuxStartTicks?: unknown
+    bootId?: unknown
+  }
+  if (
+    typeof value.startedAtMs !== 'number' ||
+    !Number.isFinite(value.startedAtMs) ||
+    value.startedAtMs <= 0
+  ) {
+    return null
+  }
+  const hasLinuxStartTicks = value.linuxStartTicks !== undefined
+  const hasBootId = value.bootId !== undefined
+  if (hasLinuxStartTicks !== hasBootId) {
+    return null
+  }
+  if (!hasLinuxStartTicks) {
+    return { startedAtMs: value.startedAtMs }
+  }
+  if (
+    typeof value.linuxStartTicks !== 'string' ||
+    value.linuxStartTicks.length === 0 ||
+    typeof value.bootId !== 'string' ||
+    value.bootId.length === 0
+  ) {
+    return null
+  }
+  return {
+    startedAtMs: value.startedAtMs,
+    linuxStartTicks: value.linuxStartTicks,
+    bootId: value.bootId
+  }
+}

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -14,6 +14,8 @@ export type DaemonPidFile = {
   entryPath?: string
   appVersion?: string
   launchNonce?: string
+  linuxStartTicks?: string
+  bootId?: string
 }
 
 export type DaemonProcessHandle = {

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -405,4 +405,19 @@ describe('DegradedDaemonPtyProvider', () => {
     expect(provider.getCurrentDaemonSessionIds()).toEqual([])
     expect(provider.hasPty('legacy-session')).toBe(true)
   })
+
+  it('keeps an exited legacy daemon poisoning listProcesses after construction', async () => {
+    const current = createDaemonAdapter('daemon', ['current-session'])
+    const legacy = createDaemonAdapter('legacy', ['legacy-session'])
+    const fallback = createProvider('fallback', ['fallback-session'])
+    const provider = new DegradedDaemonPtyProvider({ current, legacy: [legacy], fallback })
+    await provider.discoverDaemonSessions()
+    vi.mocked(legacy.listProcesses).mockRejectedValue(new Error('legacy exited'))
+
+    await expect(provider.listProcesses()).rejects.toThrow('legacy exited')
+    await expect(provider.listProcesses()).rejects.toThrow('legacy exited')
+    expect(provider.getLegacyAdapters()).toEqual([legacy])
+    expect(current.listProcesses).toHaveBeenCalledTimes(3)
+    expect(fallback.listProcesses).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/main/daemon/production-launcher.test.ts
+++ b/src/main/daemon/production-launcher.test.ts
@@ -58,14 +58,16 @@ describe('createProductionLauncher', () => {
 
   it('returns a launcher function', () => {
     const launcher = createProductionLauncher({
-      getDaemonEntryPath: () => '/fake/path.js'
+      getDaemonEntryPath: () => '/fake/path.js',
+      getAppVersion: () => '1.2.3'
     })
     expect(typeof launcher).toBe('function')
   })
 
   it('rejects either ownership argument without its pair before forking', async () => {
     const launcher = createProductionLauncher({
-      getDaemonEntryPath: () => '/fake/path.js'
+      getDaemonEntryPath: () => '/fake/path.js',
+      getAppVersion: () => '1.2.3'
     })
 
     await expect(
@@ -126,12 +128,18 @@ describe('createProductionLauncher', () => {
     forkMock.mockReturnValueOnce(child)
 
     const launcher = createProductionLauncher({
-      getDaemonEntryPath: () => join(dir, 'daemon-entry.js')
+      getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
+      getAppVersion: () => '1.2.3'
     })
 
     const pidPath = join(dir, 'daemon.pid')
     const launch = launcher(socketPathFor(dir), tokenPathFor(dir), pidPath, 'launch-a')
-    handlers.message[0]?.({ type: 'ready', startedAtMs: 123_456 })
+    handlers.message[0]?.({
+      type: 'ready',
+      startedAtMs: 123_456,
+      linuxStartTicks: '4242',
+      bootId: 'boot-a'
+    })
     const handle = await launch
 
     expect(handle.shutdown).toEqual(expect.any(Function))
@@ -143,7 +151,10 @@ describe('createProductionLauncher', () => {
     expect(JSON.parse(readFileSync(pidPath, 'utf8'))).toEqual({
       pid: 12345,
       startedAtMs: 123_456,
+      linuxStartTicks: '4242',
+      bootId: 'boot-a',
       entryPath: join(dir, 'daemon-entry.js'),
+      appVersion: '1.2.3',
       launchNonce: 'launch-a'
     })
     expect(forkMock).toHaveBeenCalledWith(
@@ -194,7 +205,8 @@ describe('createProductionLauncher', () => {
     }
     forkMock.mockReturnValueOnce(child)
     const launcher = createProductionLauncher({
-      getDaemonEntryPath: () => join(dir, 'daemon-entry.js')
+      getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
+      getAppVersion: () => '1.2.3'
     })
     const launch = launcher(socketPathFor(dir), tokenPathFor(dir))
     handlers.message[0]?.({ type: 'ready', startedAtMs: 123_456 })
@@ -241,7 +253,8 @@ describe('createProductionLauncher', () => {
       forkMock.mockReturnValueOnce(child)
 
       const launcher = createProductionLauncher({
-        getDaemonEntryPath: () => join(dir, 'daemon-entry.js')
+        getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
+        getAppVersion: () => '1.2.3'
       })
 
       const launch = launcher(socketPathFor(dir), tokenPathFor(dir))
@@ -302,7 +315,8 @@ describe('createProductionLauncher', () => {
       forkMock.mockReturnValueOnce(child)
 
       const launcher = createProductionLauncher({
-        getDaemonEntryPath: () => join(dir, 'daemon-entry.js')
+        getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
+        getAppVersion: () => '1.2.3'
       })
       const launch = launcher(socketPathFor(dir), tokenPathFor(dir))
       handlers.message[0]?.({ type: 'ready' })
@@ -359,7 +373,8 @@ describe('createProductionLauncher', () => {
     const pidPath = join(dir, 'occupied.pid')
     writeFileSync(pidPath, 'occupied')
     const launcher = createProductionLauncher({
-      getDaemonEntryPath: () => join(dir, 'daemon-entry.js')
+      getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
+      getAppVersion: () => '1.2.3'
     })
 
     const launch = launcher(socketPathFor(dir), tokenPathFor(dir), pidPath, 'launch-b')

--- a/src/main/daemon/production-launcher.ts
+++ b/src/main/daemon/production-launcher.ts
@@ -5,11 +5,13 @@ import {
   type DaemonLauncher,
   type DaemonProcessHandle
 } from './daemon-spawner'
+import { parseDaemonReadyIdentity, type DaemonReadyIdentity } from './daemon-ready-identity'
 
 const READY_TIMEOUT_MS = 10_000
 
 export type ProductionLauncherOptions = {
   getDaemonEntryPath: () => string
+  getAppVersion: () => string
 }
 
 export function createProductionLauncher(opts: ProductionLauncherOptions): DaemonLauncher {
@@ -45,9 +47,9 @@ export function createProductionLauncher(opts: ProductionLauncherOptions): Daemo
       }
     )
 
-    let startedAtMs: number
+    let readyIdentity: DaemonReadyIdentity
     try {
-      startedAtMs = await waitForReady(child)
+      readyIdentity = await waitForReady(child)
     } catch (error) {
       return rejectAfterChildCleanup(child, error)
     }
@@ -60,8 +62,9 @@ export function createProductionLauncher(opts: ProductionLauncherOptions): Daemo
           pidPath,
           serializeDaemonPidFile({
             pid: child.pid as number,
-            startedAtMs,
+            ...readyIdentity,
             entryPath,
+            appVersion: opts.getAppVersion(),
             launchNonce
           }),
           { mode: 0o600, flag: 'wx' }
@@ -81,7 +84,7 @@ export function createProductionLauncher(opts: ProductionLauncherOptions): Daemo
   }
 }
 
-function waitForReady(child: ChildProcess): Promise<number> {
+function waitForReady(child: ChildProcess): Promise<DaemonReadyIdentity> {
   return new Promise((resolve, reject) => {
     let timeout: ReturnType<typeof setTimeout> | undefined
     let settled = false
@@ -106,8 +109,8 @@ function waitForReady(child: ChildProcess): Promise<number> {
         if (settled) {
           return
         }
-        const startedAtMs = (msg as { startedAtMs?: unknown }).startedAtMs
-        if (typeof startedAtMs !== 'number' || !Number.isFinite(startedAtMs) || startedAtMs <= 0) {
+        const readyIdentity = parseDaemonReadyIdentity(msg)
+        if (!readyIdentity) {
           fail(new Error('Daemon readiness identity is incomplete'))
           return
         }
@@ -115,7 +118,7 @@ function waitForReady(child: ChildProcess): Promise<number> {
         // Why: the daemon is detached after readiness, so startup listeners
         // must not keep the child process closure alive for the daemon lifetime.
         cleanupStartupListeners()
-        resolve(startedAtMs)
+        resolve(readyIdentity)
       }
     }
     function onError(err: Error): void {

--- a/src/main/runtime/worktree-teardown.test.ts
+++ b/src/main/runtime/worktree-teardown.test.ts
@@ -633,6 +633,7 @@ describe('killAllProcessesForWorktree', () => {
         // DaemonClient method so the shared connect+RPC budget path is exercised.
         ensureConnectedWithin: async () => {},
         isConnected: () => true,
+        getDaemonIdentity: () => null,
         disconnect: () => {},
         notify: () => {},
         request: (

--- a/src/shared/daemon-audit-eligibility.ts
+++ b/src/shared/daemon-audit-eligibility.ts
@@ -1,0 +1,81 @@
+export const DAEMON_AUDIT_STATE_VALUES = ['present', 'gone', 'unknown'] as const
+
+export const DAEMON_AUDIT_TRIGGER_VALUES = [
+  'endpoint_identity_changed',
+  'inventory_answered',
+  'inventory_failed',
+  'token_missing_after_authenticated_disconnect',
+  'transport_closed'
+] as const
+
+export const DAEMON_EVIDENCE_SOURCE_VALUES = [
+  'authenticated_inventory',
+  'boot_identity',
+  'endpoint_identity',
+  'endpoint_stat',
+  'linux_proc_stat',
+  'pid_record',
+  'process_command_line',
+  'process_signal',
+  'process_start_time',
+  'token_file',
+  'windows_cim',
+  'windows_named_pipe'
+] as const
+
+export const DAEMON_PROCESS_PRESENT_REASON_VALUES = [
+  'linux_identity_match',
+  'macos_identity_match',
+  'windows_identity_match'
+] as const
+
+export const DAEMON_PROCESS_GONE_REASON_VALUES = [
+  'linux_boot_changed',
+  'linux_start_ticks_mismatch',
+  'linux_zombie',
+  'pid_missing',
+  'windows_creation_time_mismatch',
+  'windows_process_missing'
+] as const
+
+export const DAEMON_PROCESS_UNKNOWN_REASON_VALUES = [
+  'command_line_mismatch',
+  'command_line_unavailable',
+  'exact_identity_unavailable',
+  'inspection_failed',
+  'linux_identity_incomplete',
+  'macos_start_time_mismatch',
+  'permission_denied',
+  'process_start_time_unavailable',
+  'windows_process_start_time_unavailable'
+] as const
+
+export const DAEMON_AUDIT_GONE_REASON_VALUES = [
+  ...DAEMON_PROCESS_GONE_REASON_VALUES,
+  'windows_named_pipe_missing'
+] as const
+
+export const DAEMON_AUDIT_REASON_VALUES = [
+  'authenticated_inventory',
+  'endpoint_identity_changed',
+  'inventory_failed',
+  'token_missing_after_authenticated_disconnect',
+  'transport_closed',
+  ...DAEMON_AUDIT_GONE_REASON_VALUES
+] as const
+
+export const DAEMON_AUDIT_PROCESS_REASON_VALUES = [
+  ...DAEMON_PROCESS_PRESENT_REASON_VALUES,
+  ...DAEMON_PROCESS_GONE_REASON_VALUES,
+  ...DAEMON_PROCESS_UNKNOWN_REASON_VALUES,
+  'windows_named_pipe_missing'
+] as const
+
+export type DaemonAuditState = (typeof DAEMON_AUDIT_STATE_VALUES)[number]
+export type DaemonAuditTrigger = (typeof DAEMON_AUDIT_TRIGGER_VALUES)[number]
+export type DaemonAuditFailureTrigger = Exclude<DaemonAuditTrigger, 'inventory_answered'>
+export type DaemonEvidenceSource = (typeof DAEMON_EVIDENCE_SOURCE_VALUES)[number]
+export type DaemonProcessPresentReason = (typeof DAEMON_PROCESS_PRESENT_REASON_VALUES)[number]
+export type DaemonProcessGoneReason = (typeof DAEMON_PROCESS_GONE_REASON_VALUES)[number]
+export type DaemonProcessUnknownReason = (typeof DAEMON_PROCESS_UNKNOWN_REASON_VALUES)[number]
+export type DaemonAuditGoneReason = (typeof DAEMON_AUDIT_GONE_REASON_VALUES)[number]

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -27,6 +27,13 @@ import {
   DAEMON_REPLACE_REASONS,
   DAEMON_RETIRE_REASONS
 } from './daemon-lifecycle-telemetry'
+import {
+  DAEMON_AUDIT_PROCESS_REASON_VALUES,
+  DAEMON_AUDIT_REASON_VALUES,
+  DAEMON_AUDIT_STATE_VALUES,
+  DAEMON_AUDIT_TRIGGER_VALUES,
+  DAEMON_EVIDENCE_SOURCE_VALUES
+} from './daemon-audit-eligibility'
 import { SETUP_SCRIPT_IMPORT_PROVIDERS } from './setup-script-import-providers'
 import { WORKSPACE_SOURCE_VALUES, type WorkspaceSource } from './workspace-source'
 import { appStarSourceSchema } from './gh-star-source'
@@ -420,47 +427,10 @@ const daemonLifecycleSchema = z.discriminatedUnion('transition', [
 
 const daemonAuditEligibilitySchema = z
   .object({
-    state: z.enum(['present', 'gone', 'unknown']),
-    reason: z.enum([
-      'authenticated_inventory',
-      'endpoint_identity_changed',
-      'inventory_failed',
-      'linux_boot_changed',
-      'linux_start_ticks_mismatch',
-      'linux_zombie',
-      'pid_missing',
-      'token_missing_after_authenticated_disconnect',
-      'transport_closed',
-      'windows_creation_time_mismatch',
-      'windows_named_pipe_missing',
-      'windows_process_missing'
-    ]),
-    trigger: z.enum([
-      'endpoint_identity_changed',
-      'inventory_answered',
-      'inventory_failed',
-      'token_missing_after_authenticated_disconnect',
-      'transport_closed'
-    ]),
-    evidence_sources: z
-      .array(
-        z.enum([
-          'authenticated_inventory',
-          'boot_identity',
-          'endpoint_identity',
-          'endpoint_stat',
-          'linux_proc_stat',
-          'pid_record',
-          'process_command_line',
-          'process_signal',
-          'process_start_time',
-          'token_file',
-          'windows_cim',
-          'windows_named_pipe'
-        ])
-      )
-      .min(1)
-      .max(12),
+    state: z.enum(DAEMON_AUDIT_STATE_VALUES),
+    reason: z.enum(DAEMON_AUDIT_REASON_VALUES),
+    trigger: z.enum(DAEMON_AUDIT_TRIGGER_VALUES),
+    evidence_sources: z.array(z.enum(DAEMON_EVIDENCE_SOURCE_VALUES)).min(1).max(12),
     protocol_generation: z.number().int().positive().max(1_000),
     provider: z.literal('local-daemon'),
     endpoint_kind: z.enum(['unix-socket', 'windows-named-pipe']),
@@ -473,30 +443,7 @@ const daemonAuditEligibilitySchema = z
     reachability: z.enum(['authenticated', 'disconnected', 'unknown']),
     inventory_authority: z.enum(['authoritative', 'unavailable']),
     process_liveness: z.enum(['present', 'gone', 'unknown']),
-    process_reason: z
-      .enum([
-        'command_line_mismatch',
-        'command_line_unavailable',
-        'exact_identity_unavailable',
-        'inspection_failed',
-        'linux_boot_changed',
-        'linux_identity_incomplete',
-        'linux_identity_match',
-        'linux_start_ticks_mismatch',
-        'linux_zombie',
-        'macos_identity_match',
-        'macos_start_time_mismatch',
-        'permission_denied',
-        'pid_missing',
-        'process_start_time_unavailable',
-        'windows_command_line_unavailable',
-        'windows_creation_time_mismatch',
-        'windows_identity_match',
-        'windows_named_pipe_missing',
-        'windows_process_missing',
-        'windows_process_start_time_unavailable'
-      ])
-      .nullable(),
+    process_reason: z.enum(DAEMON_AUDIT_PROCESS_REASON_VALUES).nullable(),
     endpoint_state: z.enum(['missing', 'named-pipe', 'non-socket', 'socket', 'unknown'])
   })
   .strict()

--- a/src/shared/telemetry-events.ts
+++ b/src/shared/telemetry-events.ts
@@ -418,6 +418,89 @@ const daemonLifecycleSchema = z.discriminatedUnion('transition', [
     .strict()
 ])
 
+const daemonAuditEligibilitySchema = z
+  .object({
+    state: z.enum(['present', 'gone', 'unknown']),
+    reason: z.enum([
+      'authenticated_inventory',
+      'endpoint_identity_changed',
+      'inventory_failed',
+      'linux_boot_changed',
+      'linux_start_ticks_mismatch',
+      'linux_zombie',
+      'pid_missing',
+      'token_missing_after_authenticated_disconnect',
+      'transport_closed',
+      'windows_creation_time_mismatch',
+      'windows_named_pipe_missing',
+      'windows_process_missing'
+    ]),
+    trigger: z.enum([
+      'endpoint_identity_changed',
+      'inventory_answered',
+      'inventory_failed',
+      'token_missing_after_authenticated_disconnect',
+      'transport_closed'
+    ]),
+    evidence_sources: z
+      .array(
+        z.enum([
+          'authenticated_inventory',
+          'boot_identity',
+          'endpoint_identity',
+          'endpoint_stat',
+          'linux_proc_stat',
+          'pid_record',
+          'process_command_line',
+          'process_signal',
+          'process_start_time',
+          'token_file',
+          'windows_cim',
+          'windows_named_pipe'
+        ])
+      )
+      .min(1)
+      .max(12),
+    protocol_generation: z.number().int().positive().max(1_000),
+    provider: z.literal('local-daemon'),
+    endpoint_kind: z.enum(['unix-socket', 'windows-named-pipe']),
+    profile_scope: z.enum(['configured', 'unspecified']),
+    exact_incarnation: z.enum([
+      'endpoint-identity',
+      'endpoint-identity-linux-ticks',
+      'unavailable'
+    ]),
+    reachability: z.enum(['authenticated', 'disconnected', 'unknown']),
+    inventory_authority: z.enum(['authoritative', 'unavailable']),
+    process_liveness: z.enum(['present', 'gone', 'unknown']),
+    process_reason: z
+      .enum([
+        'command_line_mismatch',
+        'command_line_unavailable',
+        'exact_identity_unavailable',
+        'inspection_failed',
+        'linux_boot_changed',
+        'linux_identity_incomplete',
+        'linux_identity_match',
+        'linux_start_ticks_mismatch',
+        'linux_zombie',
+        'macos_identity_match',
+        'macos_start_time_mismatch',
+        'permission_denied',
+        'pid_missing',
+        'process_start_time_unavailable',
+        'windows_command_line_unavailable',
+        'windows_creation_time_mismatch',
+        'windows_identity_match',
+        'windows_named_pipe_missing',
+        'windows_process_missing',
+        'windows_process_start_time_unavailable'
+      ])
+      .nullable(),
+    endpoint_state: z.enum(['missing', 'named-pipe', 'non-socket', 'socket', 'unknown'])
+  })
+  .strict()
+
 // Rollout signal for granting Codex hook trust via codex app-server RPCs
 // instead of Orca's self-computed trusted_hash. `fallback`/`verify_failed`
 // spikes mean the RPC lane is not taking; steady-state ledger skips are not
@@ -1412,6 +1495,7 @@ export const eventSchemas = {
   daemon_start_failed: daemonStartFailedSchema,
   main_thread_hang_detected: mainThreadHangDetectedSchema,
   daemon_lifecycle: daemonLifecycleSchema,
+  daemon_audit_eligibility: daemonAuditEligibilitySchema,
   runtime_rpc_start_failed: runtimeRpcStartFailedSchema,
 
   codex_trust_grant: codexTrustGrantSchema,


### PR DESCRIPTION
## Summary

Adds audit-only daemon incarnation evidence for #9138 without changing daemon lifecycle or routing behavior.

- Records Linux birth identity, preserves pidfile nonce and identity fields, and fixes launcher-written app version metadata.
- Adds tri-state availability and process evidence with per-platform conclusive-gone rules.
- Retains authenticated endpoint identity across disconnects and reports same-endpoint replacements.
- Emits dedicated audit eligibility telemetry.
- Pins the current router, degraded-provider, and session-id fall-through behavior with regression tests.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Executed:

- `pnpm run typecheck`
- Targeted Vitest run with `--config config/vitest.config.ts --maxWorkers=2`: 13 files, 340 tests passed
- Normal and type-aware Oxlint scans on all 23 changed TypeScript files
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

The repository changed-code wrapper could not parse the local pnpm engine warning under Node 26, so its equivalent normal and type-aware Oxlint scans were run directly and passed.

## AI Review Report

Reviewed the complete diff against the audit-only boundary, evidence polarity, exact-incarnation requirements, event triggers, and current routing/aggregate behavior. The review found one Windows edge where signal-zero PID absence could bypass CIM; the probe now requires the platform oracle and has regression coverage. Cross-platform review confirmed Linux `/proc` reads are platform-gated and use raw ticks plus boot identity, macOS weak start-time mismatch remains unknown, Windows keeps CIM CreationDate tolerance and null command-line/start-time fail-closed behavior, and touched paths use platform-aware path handling; no UI shortcuts, labels, shell behavior, or renderer behavior changed.

## Security Audit

The classifier is observational and cannot remove adapters, signal daemons beyond non-mutating signal zero, retire processes, or shut down sessions. Exact evidence is bound to authenticated endpoint identity and matching pidfile nonce/start metadata; incomplete, unreadable, permission-denied, and contradictory probes remain unknown. Process inspection uses fixed executable/argument forms, the interpolated Windows PID is numeric, telemetry excludes endpoint paths, profile paths, nonces, and command lines, and no dependencies or new external inputs were added.

## Notes

This is PR 1 of the daemon generation-leak safety sequence. PRs 2–5 follow the contract below and remain out of scope for this PR.

### Safety Invariants

- `unknown` always preserves the adapter and blocks destructive decisions.
- Unreachable does not mean dead. An empty response does not mean unowned.
- Missing socket or token files do not prove process exit.
- A boolean liveness probe whose failure paths collapse to "absent" must never serve as a `gone` oracle. Classification is tri-state end to end: inspection failure is `unknown`. A signal-0 permission error proves only that some process occupies the pid — the incarnation classification stays `unknown` unless command line, start time, or nonce independently match. An authoritative start-time mismatch at the same pid is what proves the old incarnation `gone`; a match proves presence, not death.
- Fail-open shortcuts that are safe for adoption (e.g. Windows start-time tolerance accepting a null start time) have the wrong polarity for `gone` proofs and must not be reused for them.
- Never destroy identity evidence for a process that failed identification. Today `killStaleDaemon` skips the kill when `isDaemonProcess` is inconclusive but still unlinks the pidfile unconditionally — leaving a live daemon permanently untracked with no recorded identity. An inconclusive identity check preserves the pidfile.
- Session identifiers are not globally unique across protocol generations, and the routing fall-through to the current daemon is active today. Removing a route does not transfer its PTY to another daemon.
- A stale event cannot affect a replacement daemon at the same endpoint.
- Automatic cleanup must never use broad `shutdown { killSessions: true }`.
- Pre-v24 daemons (`CLEAN_DISCONNECT_PROTOCOL_VERSION`) must not be shut down automatically without equivalent atomic retirement authority.
- Local and remote providers are separate authorities: an unavailable SSH provider must not gate local destructive decisions, and vice versa. A destructive operation targeting a local worktree still requires authority from every local generation.
- Folder workspaces and git worktrees use the same safety rules.

### PR 1: Evidence Model, Audit-Only Classifier, Regression Tests

This PR must not change daemon lifecycle behavior.

#### Changes

- Add regression coverage for the four currently untested core scenarios:
  1. a legacy daemon exits after adapter construction (the reported repro);
  2. `DegradedDaemonPtyProvider.listProcesses` rejection;
  3. cross-generation session-id collision through the routing fall-through;
  4. daemon identity change across a reconnect at the same endpoint.
- Note: the existing router fail-closed test pins today's behavior; PR 3 revises its contract.
- Add the explicit evidence state:
  - `present`: the daemon is authoritatively available — an authenticated connection answers inventory. Exact incarnation identity is not required here: responsive pre-v24 daemons have no `DaemonEndpointIdentity` yet still provide authenticated, authoritative inventory.
  - `gone`: conclusive evidence proves the exact incarnation has exited. Exact incarnation evidence is required specifically for this transition.
  - `unknown`: evidence is incomplete, unavailable, or contradictory.
- Build the classifier from existing identity:
  - preserve `launchNonce` through `parseDaemonPidFile`;
  - record the exact incarnation at birth: the daemon self-reports raw start ticks + boot id in its existing `ready` payload (read from `/proc/self` — zero pid-reuse window), and the parent persists them in the pidfile alongside the current fields. Reuse the existing agent-hooks identity abstraction; the tick proof is additive where available, and Windows keeps CIM `CreationDate` + tolerance (a wholesale replacement would regress Windows);
  - while touching the pidfile: the production launcher omits `appVersion`, so launcher-written pidfiles always read stale-for-bundle on the next boot — fix in passing;
  - retain the last authenticated `DaemonEndpointIdentity` on the adapter across disconnect;
  - construct a tri-state process-identity probe from `isDaemonProcess`'s ingredients (command-line match, start-time tolerance), with inspection failure mapping to `unknown`; permission-denied signal-0 proves the pid is occupied but leaves the incarnation `unknown` without an independent identity match; an authoritative start-time mismatch at the same pid proves `gone`;
  - make identity change across reconnect an explicit, observable event.
- Classification runs event-driven — adapter transport close, observed authenticated disconnect plus token ENOENT, and lazily on inventory failure — never on a timer alone.
- Record the reason and evidence source for every classification.
- Inventory protocol generation, provider, endpoint, profile scope, and exact incarnation where supported.
- Keep reachability, inventory authority, and process liveness as separate facts.
- Emit audit-only eligibility telemetry as its own event family. Do not reuse `daemon_lifecycle`: that event's schema means an actual replaced/retired transition, and mixing in eligibility observations would make lifecycle dashboards and counts semantically false.
- Run the classifier without removing adapters or shutting down daemons.

#### Decision Gate

Document the conclusive `gone` proofs available for each supported platform. If exact disappearance cannot be proved for a protocol/platform combination, it remains `unknown` and receives no containment behavior.

Constraints validated empirically on 2026-07-29 (macOS local; Linux via privileged container over SSH with deterministic pid reuse; Windows via a remote non-elevated box):

Linux:
- Compare the raw `/proc/<pid>/stat` start-time **ticks** for exact equality, paired with a boot id (ticks are boot-relative); both are already produced by the existing agent-hooks identity abstraction. Never derive milliseconds. Integer division by `CLK_TCK` truncates to whole seconds: under deterministic fast pid reuse the derived ms values were bit-identical for two different incarnations in 12/12 trials, while the raw ticks always differed. Even a zero tolerance fails on the derived value.
- The 1500ms tolerance is miscalibrated in both directions: it masks fast reuse, and against a wall-clock spawn stamp its worst-case error measured 1458ms on an idle host — a loaded host produces false `gone` on a live daemon.
- Parse field 22 from after the **last** `)` in the stat line; whitespace-split parsing breaks on process names containing spaces.
- Zombies: `kill(pid, 0)` succeeds and the start time is unchanged on a dead, unreaped process (a non-reaping PID 1 — the `docker run` SSH-target shape — never reaps orphans). State `Z` with matching identity is itself conclusive `gone` evidence (the process has exited); signal success alone is never `present`.
- Errno discipline: EPERM means occupied-not-gone; ESRCH appears only after reaping; the shell exit code cannot distinguish them.

macOS:
- `ps lstart` has 1-second resolution — the same reuse-masking hazard as the Linux truncation. Exact-incarnation matching needs a finer source (e.g. `proc_pidinfo`/`sysctl kern.proc.pid` start time in microseconds); with `lstart` alone the tolerance is required and the proof is weaker.
- Field census (2026-07-29, primary field machine, 7 live generations v23–v30): all 7 pidfiles parseable with matching command lines — 100% classifiable — but the LIVE current daemon's recorded stamp vs the lstart-derived value differs by ~2.5s, beyond the 1500ms tolerance. Used as a `gone` proof, the existing check would classify a live current daemon dead today; the false-`gone` risk is observed, not hypothetical. One pidfile (v23) predates `launchNonce` — older identity formats exist in the field and must classify as `unknown`-capable, not error.
- `kill -0` errno semantics and stale-socket behavior match Linux (verified: EPERM on root-owned live pid; ESRCH after kill; socket file lingers after SIGKILL with ECONNREFUSED, ENOENT only after unlink).

POSIX sockets (both):
- ECONNREFUSED means only "no listener": crash and clean-exit-without-unlink are indistinguishable by errno, and a non-socket squatter at the path also yields ECONNREFUSED. Classify the endpoint with `stat()`/`S_ISSOCK`, not the connect errno.

Windows (non-elevated, the realistic oracle view):
- pid + CIM `CreationDate` is the primary identity: 100ns underlying resolution, zero read-to-read jitter, ~20ms agreement with a parent-side spawn stamp; a dead pid is totally absent from CIM (no zombie state).
- CommandLine is corroborating-only and **never a negative signal**: 136 of 544 live processes (25%) returned a null CommandLine across the privilege boundary while CreationDate was populated for 100%.
- The 10s CreationDate tolerance is ~500x the observed need; it exists to absorb the stamp-source gap (daemon self-stamping after boot). Do not widen it; if the parent stamps at spawn it can tighten to 1–2s, shrinking the pid-reuse acceptance window.
- Named pipes vanish with their process (verified both directions): pipe presence is positive liveness evidence, pipe absence is an independent second `gone` proof, and no stale-endpoint ambiguity exists.

General:
- Token-unlink-after-authenticated-disconnect is a trigger and contributing evidence, not sole proof.
- Remote providers have no process-table oracle today (see PR 4 scoping).
