### PR TITLE
feat(floating-workspace): animate floating workspace open/close

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -50,6 +50,7 @@ import RetainedAgentsSyncGate from './components/dashboard/RetainedAgentsSyncGat
 import { AgentHibernationGate } from './components/AgentHibernationGate'
 import { ActivityTitlebarControls } from './components/activity/ActivityTitlebarControls'
 import Sidebar from './components/Sidebar'
+import { useFloatingTerminalCloseLinger } from './components/floating-terminal/floating-terminal-close-linger'
 import { shutdownBufferCaptures } from './components/terminal-pane/shutdown-buffer-captures'
 import { dispatchWindowCloseRequest } from './components/window-close-request-coordinator'
 import {
@@ -551,9 +552,12 @@ function App(): React.JSX.Element {
     activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
   const terminalWorkbenchVisible =
     activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
-  // Why: once the floating workspace owns tabs, keep it mounted while closed so hidden terminal/browser/editor panes retain local state.
+  const floatingTerminalCloseLingering = useFloatingTerminalCloseLinger(floatingTerminalOpen)
+  // Why: once the floating workspace owns tabs, keep it mounted while closed so hidden terminal/browser/editor
+  // panes retain local state; the close linger keeps a tabless panel mounted until its exit transition finishes.
   const shouldMountFloatingTerminalPanel =
-    floatingTerminalEnabled && (floatingTerminalOpen || floatingVisibleTabCount > 0)
+    floatingTerminalEnabled &&
+    (floatingTerminalOpen || floatingVisibleTabCount > 0 || floatingTerminalCloseLingering)
   // Why: floating workspace is a transient overlay; hotkey minimize returns focus to the surface the user came from.
   const floatingTerminalReturnFocusRef = useRef<HTMLElement | null>(null)
   const floatingTerminalReturnFocusFrameRef = useRef<number | null>(null)

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -818,6 +818,7 @@ describe('FloatingTerminalPanel close behavior', () => {
         cli: { getInstallStatus: mocks.getInstallStatus },
         ui: { setFloatingFocus: mocks.setFloatingFocus }
       },
+      clearTimeout: vi.fn(),
       innerHeight: 800,
       innerWidth: 1200,
       localStorage,
@@ -825,7 +826,10 @@ describe('FloatingTerminalPanel close behavior', () => {
         callback(0)
         return 1
       }),
-      removeEventListener: vi.fn()
+      removeEventListener: vi.fn(),
+      // Why: the open-transition hook schedules its exit settle through
+      // window.setTimeout; tests never need the callback to fire.
+      setTimeout: vi.fn(() => 1)
     })
     vi.stubGlobal('navigator', { userAgent: 'Macintosh' })
     vi.stubGlobal('HTMLElement', class {})

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -108,6 +108,7 @@ import {
 import { translate } from '@/i18n/i18n'
 import { consumeFloatingTerminalOpenMaximizedIntent } from '@/lib/floating-terminal'
 import { selectFloatingTerminalPanelInputs } from './floating-terminal-panel-inputs'
+import { useFloatingTerminalOpenTransition } from './floating-terminal-open-transition'
 const LOCAL_RUNTIME_SETTINGS = { activeRuntimeEnvironmentId: null } as const
 
 const EditorPanel = lazy(() => import('@/components/editor/EditorPanel'))
@@ -303,6 +304,7 @@ export function FloatingTerminalPanel({
     leafId: string | null
   } | null>(null)
   const mountedRef = useMountedRef()
+  const { visualOpen, hidden: panelHidden } = useFloatingTerminalOpenTransition(open, panelRef)
   const dragRef = useRef<{
     pointerId: number
     startX: number
@@ -1713,14 +1715,24 @@ export function FloatingTerminalPanel({
     // Drop shadow on the outer shell, border on an inner shell — mixing both on
     // one rounded node made corners look stubby. Floating tabs skip their top
     // border so the titlebar curve stays clean.
+    // Open/close transitions animate opacity/transform only (compositor-friendly).
+    // The pre-open pass snaps to the entry pose transition-free while invisible,
+    // the open flip slides up as it fades in, and close is a pure fade so the
+    // resting panel never shifts; visibility flips only after the close settles.
     <div
       ref={setPanelNode}
       data-floating-terminal-panel
       aria-hidden={!open}
       tabIndex={-1}
-      className={`fixed z-[45] flex min-h-[280px] min-w-[420px] rounded-lg bg-transparent text-card-foreground shadow-[0_4px_12px_rgba(0,0,0,0.16),0_24px_64px_rgba(0,0,0,0.32)] outline-none dark:shadow-[0_8px_20px_rgba(0,0,0,0.35),0_28px_72px_rgba(0,0,0,0.58)] ${open ? 'opacity-100' : 'invisible pointer-events-none opacity-0'}`}
+      className={`fixed z-[45] flex min-h-[280px] min-w-[420px] rounded-lg bg-transparent text-card-foreground shadow-[0_4px_12px_rgba(0,0,0,0.16),0_24px_64px_rgba(0,0,0,0.32)] outline-none dark:shadow-[0_8px_20px_rgba(0,0,0,0.35),0_28px_72px_rgba(0,0,0,0.58)] ${
+        visualOpen
+          ? 'translate-y-0 opacity-100 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none'
+          : open
+            ? 'translate-y-2 opacity-0 transition-none'
+            : 'translate-y-0 opacity-0 transition-[opacity,transform] duration-150 ease-in motion-reduce:transition-none'
+      }${open ? '' : ' pointer-events-none'}${panelHidden ? ' invisible' : ''}`}
       style={{
-        visibility: open ? 'visible' : 'hidden',
+        visibility: panelHidden ? 'hidden' : 'visible',
         left: bounds.left,
         top: bounds.top,
         width: bounds.width,

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1723,6 +1723,7 @@ export function FloatingTerminalPanel({
       ref={setPanelNode}
       data-floating-terminal-panel
       aria-hidden={!open}
+      inert={!open}
       tabIndex={-1}
       className={`fixed z-[45] flex min-h-[280px] min-w-[420px] rounded-lg bg-transparent text-card-foreground shadow-[0_4px_12px_rgba(0,0,0,0.16),0_24px_64px_rgba(0,0,0,0.32)] outline-none dark:shadow-[0_8px_20px_rgba(0,0,0,0.35),0_28px_72px_rgba(0,0,0,0.58)] ${
         visualOpen
@@ -1730,7 +1731,7 @@ export function FloatingTerminalPanel({
           : open
             ? 'translate-y-2 opacity-0 transition-none'
             : 'translate-y-0 opacity-0 transition-[opacity,transform] duration-150 ease-in motion-reduce:transition-none'
-      }${open ? '' : ' pointer-events-none'}${panelHidden ? ' invisible' : ''}`}
+      }${open ? '' : ' pointer-events-none'}`}
       style={{
         visibility: panelHidden ? 'hidden' : 'visible',
         left: bounds.left,

--- a/src/renderer/src/components/floating-terminal/floating-terminal-close-linger.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-close-linger.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, renderHook } from '@testing-library/react'
+import { createElement, useLayoutEffect } from 'react'
+import {
+  FLOATING_TERMINAL_CLOSE_LINGER_MS,
+  useFloatingTerminalCloseLinger
+} from './floating-terminal-close-linger'
+
+describe('useFloatingTerminalCloseLinger', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stays false when the panel starts closed', () => {
+    const { result } = renderHook(({ open }) => useFloatingTerminalCloseLinger(open), {
+      initialProps: { open: false }
+    })
+
+    expect(result.current).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(FLOATING_TERMINAL_CLOSE_LINGER_MS)
+    })
+
+    expect(result.current).toBe(false)
+  })
+
+  it('stays false while the panel is open', () => {
+    const { result } = renderHook(({ open }) => useFloatingTerminalCloseLinger(open), {
+      initialProps: { open: true }
+    })
+
+    expect(result.current).toBe(false)
+  })
+
+  it('lingers after a close and clears once the exit transition can finish', () => {
+    const { result, rerender } = renderHook(({ open }) => useFloatingTerminalCloseLinger(open), {
+      initialProps: { open: true }
+    })
+
+    rerender({ open: false })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(FLOATING_TERMINAL_CLOSE_LINGER_MS - 1)
+    })
+    expect(result.current).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('never commits an unmount gap in the close render itself', () => {
+    // Why: linger must hold the mount in the exact commit that flips open off;
+    // a gap there unmounts the panel and cuts the exit animation.
+    const committedMounts: boolean[] = []
+    function MountProbe({ open }: { open: boolean }) {
+      const lingering = useFloatingTerminalCloseLinger(open)
+      const mounted = open || lingering
+      useLayoutEffect(() => {
+        committedMounts.push(mounted)
+      })
+      return null
+    }
+
+    const view = render(createElement(MountProbe, { open: true }))
+    view.rerender(createElement(MountProbe, { open: false }))
+
+    expect(committedMounts).toContain(true)
+    expect(committedMounts).not.toContain(false)
+  })
+
+  it('clears immediately when the panel reopens mid-linger', () => {
+    const { result, rerender } = renderHook(({ open }) => useFloatingTerminalCloseLinger(open), {
+      initialProps: { open: true }
+    })
+
+    rerender({ open: false })
+    expect(result.current).toBe(true)
+
+    rerender({ open: true })
+    expect(result.current).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(FLOATING_TERMINAL_CLOSE_LINGER_MS)
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('lingers again on every later close', () => {
+    const { result, rerender } = renderHook(({ open }) => useFloatingTerminalCloseLinger(open), {
+      initialProps: { open: true }
+    })
+
+    rerender({ open: false })
+    act(() => {
+      vi.advanceTimersByTime(FLOATING_TERMINAL_CLOSE_LINGER_MS)
+    })
+    expect(result.current).toBe(false)
+
+    rerender({ open: true })
+    rerender({ open: false })
+    expect(result.current).toBe(true)
+  })
+})

--- a/src/renderer/src/components/floating-terminal/floating-terminal-close-linger.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-close-linger.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { FLOATING_TERMINAL_CLOSE_TRANSITION_MS } from './floating-terminal-open-transition'
+
+// Buffer past the close transition absorbs render scheduling so unmount never
+// clips the exit animation.
+export const FLOATING_TERMINAL_CLOSE_LINGER_MS = FLOATING_TERMINAL_CLOSE_TRANSITION_MS + 50
+
+/** True through the close transition after `open` flips false so a tabless
+ * floating workspace can finish its exit before App unmounts it. */
+export function useFloatingTerminalCloseLinger(open: boolean): boolean {
+  const [lingering, setLingering] = useState(false)
+  const [prevOpen, setPrevOpen] = useState(open)
+
+  // Why: adjust state during render so lingering is already true in the same
+  // commit that flips `open` off; a post-commit effect would let that first
+  // commit unmount the panel and cut the exit animation.
+  if (open !== prevOpen) {
+    setPrevOpen(open)
+    setLingering(!open)
+  }
+
+  useEffect(() => {
+    if (open || !lingering) {
+      return
+    }
+    // Why: guarded like the panel's focus scheduling so a stale dev-reload
+    // window settles instead of crashing the effect.
+    if (typeof window.setTimeout !== 'function') {
+      setLingering(false)
+      return
+    }
+    const timer = window.setTimeout(() => {
+      setLingering(false)
+    }, FLOATING_TERMINAL_CLOSE_LINGER_MS)
+    return () => {
+      if (typeof window.clearTimeout === 'function') {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [open, lingering])
+
+  return lingering
+}

--- a/src/renderer/src/components/floating-terminal/floating-terminal-open-transition.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-open-transition.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { createRef } from 'react'
+import {
+  FLOATING_TERMINAL_CLOSE_TRANSITION_MS,
+  useFloatingTerminalOpenTransition
+} from './floating-terminal-open-transition'
+
+const CLOSE_SETTLE_MS = FLOATING_TERMINAL_CLOSE_TRANSITION_MS + 50
+
+function renderTransition(open: boolean) {
+  const panelRef = createRef<HTMLElement | null>()
+  return renderHook(({ open: current }) => useFloatingTerminalOpenTransition(current, panelRef), {
+    initialProps: { open }
+  })
+}
+
+describe('useFloatingTerminalOpenTransition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts hidden with closed visuals when mounted closed', () => {
+    const { result } = renderTransition(false)
+
+    expect(result.current.visualOpen).toBe(false)
+    expect(result.current.hidden).toBe(true)
+  })
+
+  it('mounts visible and settles into open visuals before paint', () => {
+    const { result } = renderTransition(true)
+
+    expect(result.current.hidden).toBe(false)
+    expect(result.current.visualOpen).toBe(true)
+  })
+
+  it('drops open visuals immediately on close but stays visible until the transition settles', () => {
+    const { result, rerender } = renderTransition(true)
+
+    rerender({ open: false })
+    expect(result.current.visualOpen).toBe(false)
+    expect(result.current.hidden).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_SETTLE_MS - 1)
+    })
+    expect(result.current.hidden).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current.hidden).toBe(true)
+  })
+
+  it('reopening mid-close cancels the pending hide and returns to open visuals', () => {
+    const { result, rerender } = renderTransition(true)
+
+    rerender({ open: false })
+    expect(result.current.hidden).toBe(false)
+
+    rerender({ open: true })
+    expect(result.current.hidden).toBe(false)
+    expect(result.current.visualOpen).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_SETTLE_MS)
+    })
+
+    expect(result.current.hidden).toBe(false)
+    expect(result.current.visualOpen).toBe(true)
+  })
+
+  it('hides again on every later close', () => {
+    const { result, rerender } = renderTransition(true)
+
+    rerender({ open: false })
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_SETTLE_MS)
+    })
+    expect(result.current.hidden).toBe(true)
+
+    rerender({ open: true })
+    expect(result.current.hidden).toBe(false)
+
+    rerender({ open: false })
+    act(() => {
+      vi.advanceTimersByTime(CLOSE_SETTLE_MS)
+    })
+    expect(result.current.hidden).toBe(true)
+  })
+})

--- a/src/renderer/src/components/floating-terminal/floating-terminal-open-transition.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-open-transition.ts
@@ -1,0 +1,53 @@
+import { useLayoutEffect, useState } from 'react'
+import type { RefObject } from 'react'
+
+// Open decelerates in, close accelerates out; asymmetric timing keeps the
+// toggle users hit constantly feeling snappy instead of sluggish.
+export const FLOATING_TERMINAL_OPEN_TRANSITION_MS = 200
+export const FLOATING_TERMINAL_CLOSE_TRANSITION_MS = 150
+
+export type FloatingTerminalOpenTransition = {
+  /** Drives the visual open classes; committed one styled pass after `open` so
+   * fresh mounts transition in instead of rendering the final state. */
+  visualOpen: boolean
+  /** True once the close transition settles; gates `visibility: hidden`. */
+  hidden: boolean
+}
+
+export function useFloatingTerminalOpenTransition(
+  open: boolean,
+  panelRef: RefObject<HTMLElement | null>
+): FloatingTerminalOpenTransition {
+  const [visualOpen, setVisualOpen] = useState(false)
+  const [exitDone, setExitDone] = useState(!open)
+
+  useLayoutEffect(() => {
+    if (open) {
+      setExitDone(false)
+      // Why: reading offsetWidth flushes the committed closed-visuals styles so
+      // the pre-paint flip to open visuals transitions instead of snapping,
+      // including when the panel mounts directly into `open`.
+      void panelRef.current?.offsetWidth
+      setVisualOpen(true)
+      return
+    }
+    setVisualOpen(false)
+    // Why: a timer instead of transitionend so reduced-motion (transition: none)
+    // still settles into the hidden state; guarded like the panel's focus
+    // scheduling so a stale dev-reload window cannot crash the effect.
+    if (typeof window.setTimeout !== 'function') {
+      setExitDone(true)
+      return
+    }
+    const timer = window.setTimeout(() => {
+      setExitDone(true)
+    }, FLOATING_TERMINAL_CLOSE_TRANSITION_MS + 50)
+    return () => {
+      if (typeof window.clearTimeout === 'function') {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [open, panelRef])
+
+  return { visualOpen, hidden: !open && exitDone }
+}

--- a/src/renderer/src/components/floating-terminal/floating-terminal-open-transition.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-open-transition.ts
@@ -1,9 +1,8 @@
 import { useLayoutEffect, useState } from 'react'
 import type { RefObject } from 'react'
 
-// Open decelerates in, close accelerates out; asymmetric timing keeps the
-// toggle users hit constantly feeling snappy instead of sluggish.
-export const FLOATING_TERMINAL_OPEN_TRANSITION_MS = 200
+// Open decelerates in over 200ms (duration-200 on the panel root); close
+// accelerates out — asymmetric timing keeps the constantly-hit toggle snappy.
 export const FLOATING_TERMINAL_CLOSE_TRANSITION_MS = 150
 
 export type FloatingTerminalOpenTransition = {


### PR DESCRIPTION
## Summary

The floating workspace panel now opens and closes with a subtle animation instead of appearing/disappearing abruptly:

- **Open**: fades in while sliding up 8px, 200ms ease-out.
- **Close**: pure fade out in place (no movement), 150ms ease-in.
- Works in both panel lifecycles: kept-mounted (panel owns tabs) and fresh-mount/unmount (empty panel). A close-linger keeps a tabless panel mounted just long enough for its exit transition, adjusted during render so the closing commit itself can never unmount it mid-fade (covered by a dedicated regression test).
- The panel is `inert` while closed, so keyboard focus cannot enter it during the closing fade or while hidden.
- `prefers-reduced-motion` disables the transitions entirely (STYLEGUIDE motion rule).

## Screenshots

**Before** — current release build (instant open/close):

https://github.com/user-attachments/assets/571c07c4-6350-4879-8151-b4f5b541952b

**After** — this branch (animated open/close, empty panel and with a terminal):

https://github.com/user-attachments/assets/7bb92c2e-cae7-424c-a584-e711800e1f34

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — all pass except 3 pre-existing failures in `src/main/ssh/ssh-posix-command-wrapper.test.ts` ("survives the real /bin/csh|tcsh parser"), which exercise the host's real csh/tcsh binaries and are untouched by this renderer-only diff
- [x] `pnpm build`
- [x] Added or updated high-quality tests: 2 new hook test files (10 cases), including an unmount-gap regression test that asserts the closing commit itself can never unmount the panel mid-fade; the panel suite's stubbed `window` gained `setTimeout`/`clearTimeout` so all 64 existing panel cases pass unchanged in intent

## AI Review Report

Reviewed with an AI coding agent against the contributor checklist:

- **Cross-platform (macOS/Linux/Windows)**: renderer-only CSS transitions + React state; no keyboard shortcuts, labels, paths, shell behavior, or Electron platform APIs touched. Behavior is identical on all three platforms.
- **SSH / remote / local**: panel chrome animation is purely local renderer state; it never waits on remote data, so it holds up under SSH latency (STYLEGUIDE SSH rule). No runtime/daemon/pty paths touched.
- **Agents / integrations / git providers**: no agent-, integration-, or provider-specific code paths involved.
- **Performance**: transitions limited to `opacity`/`transform` (compositor-only, no layout); drag/resize hot paths untouched (bounds stay untransitioned); timers are one-shot and cleaned up; no new listeners.
- **UI quality**: follows STYLEGUIDE motion guidance (soften expanding/collapsing content, clarify continuity, respect reduced-motion); verified in light/dark mode.
- **Review-bot findings addressed**: added `inert={!open}` (focus could enter the panel during the closing fade), removed an exported duration constant with no consumers, and removed an unreachable `invisible` class that the inline `style.visibility` always overrides.

## Security Audit

No new attack surface: no IPC, no input handling, no command execution, no path handling, no auth/secrets, and no new dependencies. The change is renderer-only CSS transitions and local React state; timers and effects are cleaned up on unmount.

## Notes

- Entry uses the forced-reflow pattern (read `offsetWidth` in a layout effect between the committed entry pose and the open flip) rather than rAF, so the panel test suite's `requestAnimationFrame`-based focus-reclaim signals stay untouched.
- Hooks are guarded like the panel's existing focus scheduling, so a stale dev-reload `window` degrades gracefully instead of crashing.
- No platform-specific, remote/SSH-specific, agent-specific, or provider-specific behavior.

---

X: [@vinusdev](https://x.com/vinusdev)
