### PR TITLE
fix(win): harden startup during partial updates

### DIFF
--- a/config/scripts/electron-vite-output-contract.test.ts
+++ b/config/scripts/electron-vite-output-contract.test.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs'
+import { EventEmitter } from 'node:events'
+import { runInNewContext } from 'node:vm'
 import { describe, expect, it } from 'vitest'
-import { electronViteConfig } from '../../electron.vite.config'
+import { createBootstrapFatalExitBanner, electronViteConfig } from '../../electron.vite.config'
+import { BOOTSTRAP_FATAL_EXIT_GUARD_KEY } from '../../src/main/startup/bootstrap-fatal-exit-guard'
 
 const targetConfig = readFileSync('config/electron-vite-target.config.ts', 'utf8')
 const devRunner = readFileSync('config/scripts/run-electron-vite-dev.mjs', 'utf8')
@@ -29,6 +32,35 @@ describe('Electron Vite output contract', () => {
     expect(external('node:fs', undefined, false)).toBe(true)
     expect(external('@xterm/headless', undefined, false)).toBe(false)
     expect(external('@xterm/addon-serialize', undefined, false)).toBe(false)
+    expect(external('zod', undefined, false)).toBe(false)
+    expect(electronViteConfig.main?.build?.externalizeDeps?.exclude).toContain('zod')
+  })
+
+  it('exits when a static import fails before source error guards load', () => {
+    const processMock = new EventEmitter() as EventEmitter & {
+      exit: (code: number) => void
+      exitCode?: number
+    }
+    let scheduledExit: (() => void) | null = null
+    let exitedWith: number | null = null
+    processMock.exit = (code) => {
+      exitedWith = code
+    }
+    const context = {
+      process: processMock,
+      setImmediate: (callback: () => void) => {
+        scheduledExit = callback
+      }
+    }
+
+    runInNewContext(createBootstrapFatalExitBanner(), context)
+    processMock.emit('uncaughtException', new Error("Cannot find module 'zod'"))
+
+    expect(processMock.exitCode).toBe(1)
+    expect(scheduledExit).not.toBeNull()
+    scheduledExit?.()
+    expect(exitedWith).toBe(1)
+    expect(context).toHaveProperty(BOOTSTRAP_FATAL_EXIT_GUARD_KEY)
   })
 
   it('isolates renderer entry side effects behind strict facades', () => {

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -6,10 +6,17 @@ import tailwindcss from '@tailwindcss/vite'
 import { createPlainNodeEntryGuardPlugin } from './build-plugins/plain-node-entry-guard'
 import packageJson from './package.json' with { type: 'json' }
 
-const BUNDLED_MAIN_DEPENDENCIES = new Set(['@xterm/headless', '@xterm/addon-serialize'])
+const BUNDLED_MAIN_DEPENDENCIES = new Set([
+  '@xterm/headless',
+  '@xterm/addon-serialize',
+  // Why: Windows NSIS deploys app.asar before external resources; bootstrap must
+  // not race the later resources/node_modules copy.
+  'zod'
+])
 const EXTERNAL_MAIN_DEPENDENCIES = Object.keys(packageJson.dependencies).filter(
   (dependency) => !BUNDLED_MAIN_DEPENDENCIES.has(dependency)
 )
+const BOOTSTRAP_FATAL_EXIT_GUARD_KEY = '__ORCA_BOOTSTRAP_FATAL_EXIT_GUARD__'
 
 function isExternalMainModule(source: string): boolean {
   if (isBuiltin(source) || source === 'electron' || source.startsWith('electron/')) {
@@ -164,19 +171,47 @@ function createStartupDiagnosticsBanner(chunkName: string): string {
 `
 }
 
-function createStartupDiagnosticsBootstrapPlugin() {
+export function createBootstrapFatalExitBanner(): string {
+  // Why: Electron's pre-import error dialog can leave main resident and block NSIS replacement.
+  return `
+;(() => {
+  const guardKey = ${JSON.stringify(BOOTSTRAP_FATAL_EXIT_GUARD_KEY)}
+  if (typeof globalThis[guardKey] === 'function') {
+    return
+  }
+  let exitScheduled = false
+  const exitAfterBootstrapFailure = () => {
+    if (exitScheduled) {
+      return
+    }
+    exitScheduled = true
+    process.exitCode = 1
+    setImmediate(() => process.exit(1))
+  }
+  globalThis[guardKey] = () => {
+    process.off('uncaughtException', exitAfterBootstrapFailure)
+    delete globalThis[guardKey]
+  }
+  process.once('uncaughtException', exitAfterBootstrapFailure)
+})();
+`
+}
+
+function createMainBootstrapPlugin() {
   return {
-    name: 'orca-startup-diagnostics-bootstrap',
+    name: 'orca-main-bootstrap',
     generateBundle(_options, bundle) {
       const mainChunk = bundle['index.js']
       if (!mainChunk || mainChunk.type !== 'chunk') {
         return
       }
 
-      // Why: source-level startup diagnostics run after Rollup's generated
-      // prelude and require() list. Mutate the final emitted chunk so macOS
-      // launch failures can identify the earliest JS boundary reached.
-      mainChunk.code = createStartupDiagnosticsBanner(mainChunk.fileName) + mainChunk.code
+      // Why: source guards and diagnostics run after Rollup's generated require
+      // prelude, too late to handle a missing bootstrap dependency.
+      mainChunk.code =
+        createBootstrapFatalExitBanner() +
+        createStartupDiagnosticsBanner(mainChunk.fileName) +
+        mainChunk.code
     }
   }
 }
@@ -186,10 +221,10 @@ export const electronViteConfig: UserConfig = {
     build: {
       // Why: daemon-entry.js is asar-unpacked so child_process.fork() can
       // execute it from disk. Node's module resolution from the unpacked
-      // directory cannot reach into app.asar, so pure-JS dependencies used
-      // by the daemon must be bundled rather than externalized.
+      // directory cannot reach into app.asar; startup-critical pure JS must
+      // also survive a partially copied Windows resources tree.
       externalizeDeps: {
-        exclude: ['@xterm/headless', '@xterm/addon-serialize']
+        exclude: [...BUNDLED_MAIN_DEPENDENCIES]
       },
       rollupOptions: {
         // Why: native dependencies must resolve from packaged node_modules,
@@ -243,7 +278,7 @@ export const electronViteConfig: UserConfig = {
           entryFileNames: '[name].js',
           chunkFileNames: 'chunks/[name]-[hash].js'
         },
-        plugins: [createStartupDiagnosticsBootstrapPlugin(), createPlainNodeEntryGuardPlugin()]
+        plugins: [createMainBootstrapPlugin(), createPlainNodeEntryGuardPlugin()]
       }
     },
     // Why: compile-time substitution for the telemetry gate. See the block

--- a/src/main/startup/bootstrap-fatal-exit-guard.test.ts
+++ b/src/main/startup/bootstrap-fatal-exit-guard.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  BOOTSTRAP_FATAL_EXIT_GUARD_KEY,
+  removeBootstrapFatalExitGuard
+} from './bootstrap-fatal-exit-guard'
+
+type BootstrapFatalExitGlobal = typeof globalThis & {
+  [BOOTSTRAP_FATAL_EXIT_GUARD_KEY]?: () => void
+}
+
+const bootstrapGlobal = globalThis as BootstrapFatalExitGlobal
+
+afterEach(() => {
+  delete bootstrapGlobal[BOOTSTRAP_FATAL_EXIT_GUARD_KEY]
+})
+
+describe('bootstrap fatal exit guard', () => {
+  it('removes the generated pre-import guard', () => {
+    const removeGuard = vi.fn()
+    bootstrapGlobal[BOOTSTRAP_FATAL_EXIT_GUARD_KEY] = removeGuard
+
+    removeBootstrapFatalExitGuard()
+
+    expect(removeGuard).toHaveBeenCalledOnce()
+    expect(bootstrapGlobal[BOOTSTRAP_FATAL_EXIT_GUARD_KEY]).toBeUndefined()
+  })
+})

--- a/src/main/startup/bootstrap-fatal-exit-guard.ts
+++ b/src/main/startup/bootstrap-fatal-exit-guard.ts
@@ -1,0 +1,12 @@
+export const BOOTSTRAP_FATAL_EXIT_GUARD_KEY = '__ORCA_BOOTSTRAP_FATAL_EXIT_GUARD__'
+
+type BootstrapFatalExitGlobal = typeof globalThis & {
+  [BOOTSTRAP_FATAL_EXIT_GUARD_KEY]?: () => void
+}
+
+export function removeBootstrapFatalExitGuard(): void {
+  const bootstrapGlobal = globalThis as BootstrapFatalExitGlobal
+  const removeGuard = bootstrapGlobal[BOOTSTRAP_FATAL_EXIT_GUARD_KEY]
+  delete bootstrapGlobal[BOOTSTRAP_FATAL_EXIT_GUARD_KEY]
+  removeGuard?.()
+}

--- a/src/main/startup/main-process-error-guards.ts
+++ b/src/main/startup/main-process-error-guards.ts
@@ -1,4 +1,5 @@
 import { recordDurableCrashBreadcrumb } from '../crash-reporting/durable-crash-breadcrumb'
+import { removeBootstrapFatalExitGuard } from './bootstrap-fatal-exit-guard'
 
 type FatalMainProcessErrorKind = 'main_uncaught_exception' | 'main_unhandled_rejection'
 
@@ -115,6 +116,7 @@ export function installUncaughtPipeErrorGuard(): void {
   }
 
   process.on('uncaughtException', onUncaughtException)
+  removeBootstrapFatalExitGuard()
 }
 
 /** Keep one failed background promise from silently killing the whole app.


### PR DESCRIPTION
## Summary

- bundle `zod` into the Electron main-process output so startup does not depend on the later `resources/node_modules` deployment
- prepend a fatal bootstrap guard before Rollup's generated `require()` prelude, then replace it with the normal durable error guard after the source graph loads
- cover both the bundling contract and an exact pre-import `Cannot find module 'zod'` failure

## Root cause

The Windows NSIS install updates the live application directory non-transactionally. In the captured failure, the new `app.asar` and plugin-host chunk were visible 8.343 seconds before `resources/node_modules/zod` existed. The new main bundle immediately executed `require("zod")`, lost that race, and Electron displayed its native fatal-error dialog. That failed main process remained resident, held the updater lock, and prevented the runtime/pairing listener from starting.

This change uses the packaging-safe alternative to an installer rewrite: the bootstrap-critical schema dependency is part of the main bundle itself. It also ensures any future exception that occurs before source-level guards load exits instead of stranding a dialog-only Electron process.

## User-visible behavior

| | Before | After |
|---|---|---|
| Launch during the vulnerable update window | Native `Cannot find module 'zod'` dialog; no Orca window | `zod` is already in the startup bundle, so launch proceeds normally |
| Remote runtime/pairing | Never starts | Starts with the normal application runtime |
| Updater after a bootstrap failure | Failed Electron process can remain resident and block replacement | Pre-import fatal failures exit with code 1 on the next event-loop turn |
| Ordinary launches | Normal | Unchanged; the temporary bootstrap guard is removed when the durable main-process guard installs |

## Validation

- `pnpm exec vitest run config/scripts/electron-vite-output-contract.test.ts src/main/startup/bootstrap-fatal-exit-guard.test.ts src/main/startup/main-process-error-guards.test.ts` (17 tests)
- `pnpm run build:desktop`
- `pnpm run typecheck:node`
- changed-file Oxlint, type-aware Oxlint, React Doctor, and Oxfmt checks
- `pnpm run check:max-lines-ratchet`
- inspected emitted `out/main`: bootstrap guard is the first code in `index.js`; no bare `require("zod")` remains

A final `electron-builder --dir` package was not produced locally because this host lacks the Visual Studio toolchain required to rebuild `windows-native-registry`; the complete desktop build and packaging-relevant emitted-output checks passed.