### PR TITLE
[P2] fix(persistence): tolerate null worktreeMeta entries in linked-item normalization

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4930,12 +4930,17 @@ describe('Store', () => {
     expect(store.getWorktreeMeta('wt-malformed')?.linkedTaskSourceContext).toBeNull()
   })
 
-  it('drops a null worktreeMeta entry while still normalizing valid siblings', async () => {
+  it('drops corrupt worktreeMeta entries while still normalizing valid siblings', async () => {
     writeDataFile({
       schemaVersion: 1,
       repos: [],
+      worktreeLineageById: { 'r1::/tmp/wt': { parentWorktreeId: 'wt-sibling' } },
+      workspaceLineageByChildKey: {
+        'worktree:r1::/tmp/wt': { parentWorkspaceKey: 'worktree:wt-sibling' }
+      },
       worktreeMeta: {
         'r1::/tmp/wt': null,
+        'r1::/tmp/scalar': 5,
         'wt-sibling': {
           linkedWorkItem: {
             provider: 'jira',
@@ -4966,11 +4971,16 @@ describe('Store', () => {
 
     expect(store.getWorktreeMeta('wt-sibling')?.linkedWorkItem?.jiraIdentifier).toBe('ORCA-123')
     expect(store.getWorktreeMeta('wt-sibling')?.linkedTaskSourceContext).toBeNull()
-    // The null entry must not survive: gcStaleWorktreeMeta keeps timestamp-less keys, and downstream
+    // Corrupt entries must not survive: gcStaleWorktreeMeta keeps timestamp-less keys, and downstream
     // consumers deref worktreeMeta values unguarded (also keeps a rollback to an older build loadable).
     expect(store.getAllWorktreeMeta()).not.toHaveProperty('r1::/tmp/wt')
+    expect(store.getAllWorktreeMeta()).not.toHaveProperty('r1::/tmp/scalar')
+    expect(store.getWorktreeLineage('r1::/tmp/wt')).toBeUndefined()
     store.flush()
-    expect((readDataFile() as PersistedState).worktreeMeta).not.toHaveProperty('r1::/tmp/wt')
+    const persisted = readDataFile() as PersistedState
+    expect(persisted.worktreeMeta).not.toHaveProperty('r1::/tmp/wt')
+    expect(persisted.worktreeMeta).not.toHaveProperty('r1::/tmp/scalar')
+    expect(persisted.workspaceLineageByChildKey).not.toHaveProperty('worktree:r1::/tmp/wt')
   })
 
   it('creates and updates folder workspaces from folder-backed project groups', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -6099,10 +6099,12 @@ describe('Store', () => {
     })
   })
 
-  it('tolerates a null worktreeMeta map in the durable file', async () => {
-    writeDataFile({ worktreeMeta: null })
+  it.each([null, [], 5])('repairs a corrupt worktreeMeta map (%#)', async (worktreeMeta) => {
+    writeDataFile({ worktreeMeta })
     const store = await createStore()
     expect(store.getAllWorktreeMeta()).toEqual({})
+    store.flush()
+    expect((readDataFile() as PersistedState).worktreeMeta).toEqual({})
   })
 
   // ── GitHub cache sidecar ───────────────────────────────────────────

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4930,6 +4930,44 @@ describe('Store', () => {
     expect(store.getWorktreeMeta('wt-malformed')?.linkedTaskSourceContext).toBeNull()
   })
 
+  it('tolerates a null worktreeMeta entry while still normalizing valid siblings', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {
+        'r1::/tmp/wt': null,
+        'wt-sibling': {
+          linkedWorkItem: {
+            provider: 'jira',
+            type: 'issue',
+            number: 0,
+            title: 'ORCA-123 Link Jira',
+            url: 'https://company.atlassian.net/browse/ORCA-123',
+            jiraIdentifier: 'ORCA-123'
+          },
+          linkedTaskSourceContext: {
+            kind: 'task-source',
+            provider: 'jira',
+            projectId: 'project-1',
+            hostId: 'local',
+            accountLabel: 44,
+            providerIdentity: {
+              provider: 'jira',
+              siteId: 'site-1',
+              siteUrl: 'https://company.atlassian.net',
+              projectKey: 'ORCA'
+            }
+          }
+        }
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getWorktreeMeta('wt-sibling')?.linkedWorkItem?.jiraIdentifier).toBe('ORCA-123')
+    expect(store.getWorktreeMeta('wt-sibling')?.linkedTaskSourceContext).toBeNull()
+  })
+
   it('creates and updates folder workspaces from folder-backed project groups', async () => {
     const store = await createStore()
     const group = store.createProjectGroup({

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4930,7 +4930,7 @@ describe('Store', () => {
     expect(store.getWorktreeMeta('wt-malformed')?.linkedTaskSourceContext).toBeNull()
   })
 
-  it('tolerates a null worktreeMeta entry while still normalizing valid siblings', async () => {
+  it('drops a null worktreeMeta entry while still normalizing valid siblings', async () => {
     writeDataFile({
       schemaVersion: 1,
       repos: [],
@@ -4966,6 +4966,11 @@ describe('Store', () => {
 
     expect(store.getWorktreeMeta('wt-sibling')?.linkedWorkItem?.jiraIdentifier).toBe('ORCA-123')
     expect(store.getWorktreeMeta('wt-sibling')?.linkedTaskSourceContext).toBeNull()
+    // The null entry must not survive: gcStaleWorktreeMeta keeps timestamp-less keys, and downstream
+    // consumers deref worktreeMeta values unguarded (also keeps a rollback to an older build loadable).
+    expect(store.getAllWorktreeMeta()).not.toHaveProperty('r1::/tmp/wt')
+    store.flush()
+    expect((readDataFile() as PersistedState).worktreeMeta).not.toHaveProperty('r1::/tmp/wt')
   })
 
   it('creates and updates folder workspaces from folder-backed project groups', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -426,6 +426,10 @@ function gcStaleWorktreeMeta(state: PersistedState): number {
 function normalizeWorktreeLinkedItemMetadata(state: PersistedState): boolean {
   let changed = false
   for (const meta of Object.values(state.worktreeMeta ?? {})) {
+    // Why: hand-corrupted null entries are a real input class (see gcStaleWorktreeMeta); leave them for GC.
+    if (!meta) {
+      continue
+    }
     const linkedWorkItem = normalizeWorkspaceLinkedItem(meta.linkedWorkItem)
     const sourceContext = normalizeStoredTaskSourceContext(meta.linkedTaskSourceContext)
     const linkedTaskSourceContext = isWorkspaceLinkedItemSourceContextMatch(

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -425,9 +425,13 @@ function gcStaleWorktreeMeta(state: PersistedState): number {
 
 function normalizeWorktreeLinkedItemMetadata(state: PersistedState): boolean {
   let changed = false
-  for (const meta of Object.values(state.worktreeMeta ?? {})) {
-    // Why: hand-corrupted null entries are a real input class (see gcStaleWorktreeMeta); leave them for GC.
+  const worktreeMeta = state.worktreeMeta ?? {}
+  for (const [key, meta] of Object.entries(worktreeMeta)) {
+    // Why: hand-corrupted null entries are a real input class; drop them here because gcStaleWorktreeMeta
+    // keeps timestamp-less keys forever and every downstream consumer trusts the Record<string, WorktreeMeta> type.
     if (!meta) {
+      delete worktreeMeta[key]
+      changed = true
       continue
     }
     const linkedWorkItem = normalizeWorkspaceLinkedItem(meta.linkedWorkItem)

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -425,8 +425,15 @@ function gcStaleWorktreeMeta(state: PersistedState): number {
 
 function normalizeWorktreeLinkedItemMetadata(state: PersistedState): boolean {
   let changed = false
-  // Why: a hand-corrupted "worktreeMeta": null overrides the defaults merge, and this runs before gcStaleWorktreeMeta.
-  state.worktreeMeta ??= {}
+  const rawWorktreeMeta = state.worktreeMeta as unknown
+  if (
+    typeof rawWorktreeMeta !== 'object' ||
+    rawWorktreeMeta === null ||
+    Array.isArray(rawWorktreeMeta)
+  ) {
+    state.worktreeMeta = {}
+    changed = rawWorktreeMeta !== undefined
+  }
   for (const [key, meta] of Object.entries(state.worktreeMeta)) {
     // Why: hand-corrupted non-object entries are a real input class; drop them here because gcStaleWorktreeMeta
     // keeps timestamp-less keys forever and every downstream consumer trusts the Record<string, WorktreeMeta> type.

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -425,12 +425,17 @@ function gcStaleWorktreeMeta(state: PersistedState): number {
 
 function normalizeWorktreeLinkedItemMetadata(state: PersistedState): boolean {
   let changed = false
-  const worktreeMeta = state.worktreeMeta ?? {}
-  for (const [key, meta] of Object.entries(worktreeMeta)) {
-    // Why: hand-corrupted null entries are a real input class; drop them here because gcStaleWorktreeMeta
+  // Why: a hand-corrupted "worktreeMeta": null overrides the defaults merge, and this runs before gcStaleWorktreeMeta.
+  state.worktreeMeta ??= {}
+  for (const [key, meta] of Object.entries(state.worktreeMeta)) {
+    // Why: hand-corrupted non-object entries are a real input class; drop them here because gcStaleWorktreeMeta
     // keeps timestamp-less keys forever and every downstream consumer trusts the Record<string, WorktreeMeta> type.
-    if (!meta) {
-      delete worktreeMeta[key]
+    if (typeof meta !== 'object' || meta === null || Array.isArray(meta)) {
+      delete state.worktreeMeta[key]
+      // Companions go with it, matching gcStaleWorktreeMeta/removeWorktreeMeta; a stranded lineage row would
+      // otherwise re-attach to a worktree recreated at the same repoId::path.
+      delete state.worktreeLineageById[key]
+      delete state.workspaceLineageByChildKey[worktreeWorkspaceKey(key)]
       changed = true
       continue
     }


### PR DESCRIPTION
## Summary
- `normalizeWorktreeLinkedItemMetadata` iterated `Object.values(state.worktreeMeta ?? {})` and dereferenced `meta.linkedWorkItem` with no per-entry guard.
- A hand-corrupted file like `{"worktreeMeta":{"k":null}}` threw a `TypeError` from `Store.load()`; the call site sits outside the parse try/catch, so backup recovery never fired and the app could not start until the JSON was hand-repaired.
- Fix: **drop** corrupt entries (`typeof meta !== 'object' || meta === null || Array.isArray(meta)`) instead of skipping them. Skipping is not enough — `gcStaleWorktreeMeta` can never reap them, because a timestamp-less key short-circuits at `persistence.ts:412` (`newestTouch === 0` → `continue`), so a retained null would live in the `Record<string, WorktreeMeta>` forever and reach consumers that deref it unguarded (`reassignSshTargetId`, push-target cleanup, disconnected-SSH listing, usage metadata).
- Blast radius: dropping sets `changed = true`, which sets `loadNeedsSave`, which schedules a save — so a file with a corrupt entry gets **rewritten at startup** with those keys removed. Only corrupt entries are removed; valid entries are untouched, and files with no corrupt entries are not made dirty by this path.
- The two lineage companions go with the meta, matching the existing removal paths `gcStaleWorktreeMeta` (`persistence.ts:418-420`) and `removeWorktreeMeta` (`persistence.ts:5116-5118`): `worktreeLineageById[key]` and `workspaceLineageByChildKey[worktreeWorkspaceKey(key)]`. Otherwise a stranded lineage row would re-attach to a worktree later recreated at the same `${repoId}::${path}`.
- `state.worktreeMeta ??= {}` moved into this function so a whole-map `"worktreeMeta": null` is self-healed here rather than depending on `gcStaleWorktreeMeta` (`persistence.ts:372`) running immediately afterwards.

## Test plan
- New regression test `drops corrupt worktreeMeta entries while still normalizing valid siblings`: loads `{"repos":[],"worktreeMeta":{"r1::/tmp/wt":null,"r1::/tmp/scalar":5, ...}}` plus a `worktreeLineageById` / `workspaceLineageByChildKey` row for the corrupt key. Asserts the store loads without throwing, a valid sibling still gets its linked-item normalization applied (malformed `linkedTaskSourceContext` dropped, `linkedWorkItem` preserved), both corrupt keys are gone from memory and from the flushed file, and the lineage companions are gone too.
- Verified failing-then-passing: with the guard removed, the test fails with `TypeError: Cannot read properties of null (reading 'linkedWorkItem')` at `normalizeWorktreeLinkedItemMetadata` out of `Store` construction. With the companion deletes removed, `getWorktreeLineage('r1::/tmp/wt')` is still defined.
- Full `src/main/persistence.test.ts` run: 424 passed (424).
- `npx oxlint` on changed files: clean. `npx tsc --noEmit -p config/tsconfig.node.json`: clean.

Found by the production release scan of v1.4.162..v1.4.163-rc.0.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## ELI5

A damaged settings file could contain an empty or invalid worktree record and crash Orca during startup or later use. Orca now removes those broken records and their stale links, saves the repair, and keeps valid worktrees.