### PR TITLE
[P2] fix(settings): scope orchestration agent coverage to the skill-scan host

### DIFF
--- a/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeClientTarget } from '@/runtime/runtime-client-target'
 import { OrchestrationSkillAgentCoverage } from './OrchestrationSkillAgentCoverage'
 
 const useDetectedAgents = vi.fn(() => ({
@@ -8,43 +9,55 @@ const useDetectedAgents = vi.fn(() => ({
   isRefreshing: false,
   refresh: vi.fn()
 }))
+const useActiveSkillDiscoveryRuntimeTarget = vi.fn<() => RuntimeClientTarget | null>(() => ({
+  kind: 'local'
+}))
 
 vi.mock('@/hooks/useDetectedAgents', () => ({
   useDetectedAgents: (...args: unknown[]) => useDetectedAgents(...(args as []))
 }))
 
+vi.mock('@/hooks/use-active-skill-discovery-runtime-target', () => ({
+  useActiveSkillDiscoveryRuntimeTarget: () => useActiveSkillDiscoveryRuntimeTarget()
+}))
+
+const claudeHomeSource = {
+  id: 'claude-home',
+  label: 'Claude home',
+  path: '/Users/test/.claude/skills',
+  sourceKind: 'home',
+  providers: ['claude'],
+  owner: 'claude',
+  exists: true
+} as const
+
+const claudeHomeSkill = {
+  id: 'claude-skill',
+  name: 'orchestration',
+  description: null,
+  providers: ['claude'],
+  sourceKind: 'home',
+  sourceLabel: 'Claude home',
+  rootPath: '/Users/test/.claude/skills',
+  directoryPath: '/Users/test/.claude/skills/orchestration',
+  skillFilePath: '/Users/test/.claude/skills/orchestration/SKILL.md',
+  installed: true,
+  fileCount: 1,
+  updatedAt: null
+} as const
+
 describe('OrchestrationSkillAgentCoverage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useActiveSkillDiscoveryRuntimeTarget.mockReturnValue({ kind: 'local' })
+  })
+
   it('shows each detected agent with an explicit skill status', () => {
     const markup = renderToStaticMarkup(
       <OrchestrationSkillAgentCoverage
         loading={false}
-        sources={[
-          {
-            id: 'claude-home',
-            label: 'Claude home',
-            path: '/Users/test/.claude/skills',
-            sourceKind: 'home',
-            providers: ['claude'],
-            owner: 'claude',
-            exists: true
-          }
-        ]}
-        skills={[
-          {
-            id: 'claude-skill',
-            name: 'orchestration',
-            description: null,
-            providers: ['claude'],
-            sourceKind: 'home',
-            sourceLabel: 'Claude home',
-            rootPath: '/Users/test/.claude/skills',
-            directoryPath: '/Users/test/.claude/skills/orchestration',
-            skillFilePath: '/Users/test/.claude/skills/orchestration/SKILL.md',
-            installed: true,
-            fileCount: 1,
-            updatedAt: null
-          }
-        ]}
+        sources={[claudeHomeSource]}
+        skills={[claudeHomeSkill]}
       />
     )
 
@@ -56,5 +69,41 @@ describe('OrchestrationSkillAgentCoverage', () => {
     // Why: an omitted target reads as "host unknown", which pins detectedIds to
     // null and leaves the widget spinning forever.
     expect(useDetectedAgents).toHaveBeenCalledWith({ kind: 'local' })
+  })
+
+  it('detects agents on the focused runtime host that produced the skill scan', () => {
+    useActiveSkillDiscoveryRuntimeTarget.mockReturnValue({
+      kind: 'environment',
+      environmentId: 'env-1'
+    })
+
+    renderToStaticMarkup(
+      <OrchestrationSkillAgentCoverage
+        loading={false}
+        sources={[claudeHomeSource]}
+        skills={[claudeHomeSkill]}
+      />
+    )
+
+    // Why: skills/sources come from the remote scan; matching them against
+    // local agent ids reports wrong Ready/Missing chips.
+    expect(useDetectedAgents).toHaveBeenCalledWith({ kind: 'runtime', environmentId: 'env-1' })
+  })
+
+  it('stays loading while the skill-scan host is unresolved', () => {
+    useActiveSkillDiscoveryRuntimeTarget.mockReturnValue(null)
+    useDetectedAgents.mockReturnValue({
+      detectedIds: null as never,
+      isLoading: true,
+      isRefreshing: false,
+      refresh: vi.fn()
+    })
+
+    const markup = renderToStaticMarkup(
+      <OrchestrationSkillAgentCoverage loading={false} sources={[]} skills={[]} />
+    )
+
+    expect(useDetectedAgents).toHaveBeenCalledWith(undefined)
+    expect(markup).toContain('Checking installed agents')
   })
 })

--- a/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RuntimeClientTarget } from '@/runtime/runtime-client-target'
+import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
 import { OrchestrationSkillAgentCoverage } from './OrchestrationSkillAgentCoverage'
 
 const useDetectedAgents = vi.fn(() => ({
@@ -21,7 +22,7 @@ vi.mock('@/hooks/use-active-skill-discovery-runtime-target', () => ({
   useActiveSkillDiscoveryRuntimeTarget: () => useActiveSkillDiscoveryRuntimeTarget()
 }))
 
-const claudeHomeSource = {
+const claudeHomeSource: SkillDiscoverySource = {
   id: 'claude-home',
   label: 'Claude home',
   path: '/Users/test/.claude/skills',
@@ -29,9 +30,9 @@ const claudeHomeSource = {
   providers: ['claude'],
   owner: 'claude',
   exists: true
-} as const
+}
 
-const claudeHomeSkill = {
+const claudeHomeSkill: DiscoveredSkill = {
   id: 'claude-skill',
   name: 'orchestration',
   description: null,
@@ -44,7 +45,7 @@ const claudeHomeSkill = {
   installed: true,
   fileCount: 1,
   updatedAt: null
-} as const
+}
 
 describe('OrchestrationSkillAgentCoverage', () => {
   beforeEach(() => {
@@ -92,7 +93,8 @@ describe('OrchestrationSkillAgentCoverage', () => {
 
   it('stays loading while the skill-scan host is unresolved', () => {
     useActiveSkillDiscoveryRuntimeTarget.mockReturnValue(null)
-    useDetectedAgents.mockReturnValue({
+    // Why: Once keeps this loading state from leaking into later tests.
+    useDetectedAgents.mockReturnValueOnce({
       detectedIds: null as never,
       isLoading: true,
       isRefreshing: false,

--- a/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.test.tsx
@@ -1,12 +1,13 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { RuntimeClientTarget } from '@/runtime/runtime-client-target'
+import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
 import { OrchestrationSkillAgentCoverage } from './OrchestrationSkillAgentCoverage'
 
 const useDetectedAgents = vi.fn(() => ({
   detectedIds: ['claude', 'codex'],
   isLoading: false,
+  detectionFailed: false,
   isRefreshing: false,
   refresh: vi.fn()
 }))
@@ -88,7 +89,10 @@ describe('OrchestrationSkillAgentCoverage', () => {
 
     // Why: skills/sources come from the remote scan; matching them against
     // local agent ids reports wrong Ready/Missing chips.
-    expect(useDetectedAgents).toHaveBeenCalledWith({ kind: 'runtime', environmentId: 'env-1' })
+    expect(useDetectedAgents).toHaveBeenCalledWith({
+      kind: 'runtime',
+      environmentId: 'env-1'
+    })
   })
 
   it('stays loading while the skill-scan host is unresolved', () => {
@@ -97,6 +101,7 @@ describe('OrchestrationSkillAgentCoverage', () => {
     useDetectedAgents.mockReturnValueOnce({
       detectedIds: null as never,
       isLoading: true,
+      detectionFailed: false,
       isRefreshing: false,
       refresh: vi.fn()
     })
@@ -107,5 +112,33 @@ describe('OrchestrationSkillAgentCoverage', () => {
 
     expect(useDetectedAgents).toHaveBeenCalledWith(undefined)
     expect(markup).toContain('Checking installed agents')
+  })
+
+  it('drops out of loading with a retry when the runtime probe failed', () => {
+    useActiveSkillDiscoveryRuntimeTarget.mockReturnValue({
+      kind: 'environment',
+      environmentId: 'env-1'
+    })
+    // Why: ensureRuntimeDetectedAgents' catch never writes detectedIds, so a
+    // failed probe would otherwise leave the card spinning for the whole mount.
+    useDetectedAgents.mockReturnValueOnce({
+      detectedIds: null as never,
+      isLoading: false,
+      detectionFailed: true,
+      isRefreshing: false,
+      refresh: vi.fn()
+    })
+
+    const markup = renderToStaticMarkup(
+      <OrchestrationSkillAgentCoverage
+        loading={false}
+        sources={[claudeHomeSource]}
+        skills={[claudeHomeSkill]}
+      />
+    )
+
+    expect(markup).not.toContain('Checking installed agents')
+    expect(markup).toContain('reach the host')
+    expect(markup).toContain('Retry')
   })
 })

--- a/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
@@ -1,12 +1,14 @@
 import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
 import type { OrchestrationSkillAgentStatus } from '@/lib/orchestration-skill-coverage'
-import type { RuntimeClientTarget } from '@/runtime/runtime-client-target'
+import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
+import { RefreshCw } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { useActiveSkillDiscoveryRuntimeTarget } from '@/hooks/use-active-skill-discovery-runtime-target'
 import { useDetectedAgents, type AgentDetectionTarget } from '@/hooks/useDetectedAgents'
 import { getOrchestrationSkillAgentStatuses } from '@/lib/orchestration-skill-coverage'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
 
 function toAgentDetectionTarget(
   target: RuntimeClientTarget | null
@@ -16,22 +18,36 @@ function toAgentDetectionTarget(
     // host resolves, instead of flashing local agents for a remote runtime.
     return undefined
   }
-  return target.kind === 'environment'
-    ? { kind: 'runtime', environmentId: target.environmentId }
-    : { kind: 'local' }
+  switch (target.kind) {
+    case 'environment':
+      return { kind: 'runtime', environmentId: target.environmentId }
+    case 'local':
+      return { kind: 'local' }
+    default: {
+      // Why: a future RuntimeClientTarget kind must not silently fall back to
+      // local detection — that is the host mismatch this mapping exists to fix.
+      const exhaustive: never = target
+      void exhaustive
+      return undefined
+    }
+  }
 }
 
 function getAgentCoverageSummary(props: {
   loading: boolean
+  detectionFailed: boolean
   totalCount: number
   installedCount: number
   fullCoverage: boolean
   noCoverage: boolean
 }): string {
-  const { loading, totalCount, installedCount, fullCoverage, noCoverage } = props
+  const { loading, detectionFailed, totalCount, installedCount, fullCoverage, noCoverage } = props
 
   if (loading) {
     return 'Checking installed agents and skill paths…'
+  }
+  if (detectionFailed) {
+    return 'Couldn’t reach the host to check installed agents.'
   }
   if (totalCount === 0) {
     return 'No agent CLIs detected on PATH. Install agents in Settings → Agents, then re-check.'
@@ -92,18 +108,25 @@ export function OrchestrationSkillAgentCoverage(props: {
   // Why: skills/sources come from the runtime-scoped scan (#6887); detect agents
   // on that same host or remote skill roots get matched against local agent ids.
   const runtimeTarget = useActiveSkillDiscoveryRuntimeTarget()
-  const { detectedIds, isLoading: agentsLoading } = useDetectedAgents(
-    toAgentDetectionTarget(runtimeTarget)
-  )
-  const loading = skillsLoading || agentsLoading || detectedIds === null
+  const {
+    detectedIds,
+    isLoading: agentsLoading,
+    detectionFailed,
+    refresh
+  } = useDetectedAgents(toAgentDetectionTarget(runtimeTarget))
+  // Why: a failed remote probe never writes detectedIds, so gating on null alone
+  // would pin the card on "Checking…" forever with no retry.
+  const loading = skillsLoading || agentsLoading || (detectedIds === null && !detectionFailed)
   const agentStatuses = getOrchestrationSkillAgentStatuses(skills, detectedIds ?? [], sources)
   const installedCount = agentStatuses.filter((status) => status.installed).length
   const totalCount = agentStatuses.length
-  const fullCoverage = !loading && totalCount > 0 && installedCount === totalCount
-  const noCoverage = !loading && totalCount > 0 && installedCount === 0
-  const showAgentChips = !loading && totalCount > 0 && !fullCoverage
+  const resolved = !loading && !detectionFailed
+  const fullCoverage = resolved && totalCount > 0 && installedCount === totalCount
+  const noCoverage = resolved && totalCount > 0 && installedCount === 0
+  const showAgentChips = resolved && totalCount > 0 && !fullCoverage
   const summary = getAgentCoverageSummary({
     loading,
+    detectionFailed,
     totalCount,
     installedCount,
     fullCoverage,
@@ -126,6 +149,22 @@ export function OrchestrationSkillAgentCoverage(props: {
         </h3>
         <p className="text-xs leading-relaxed text-muted-foreground">{summary}</p>
       </div>
+
+      {detectionFailed ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={() => void refresh()}
+          className="h-6 gap-1.5 px-2"
+        >
+          <RefreshCw className="size-3" />
+          {translate(
+            'auto.components.settings.OrchestrationSkillAgentCoverage.retryDetection',
+            'Retry'
+          )}
+        </Button>
+      ) : null}
 
       {showAgentChips ? (
         <div className="flex flex-wrap gap-1.5">

--- a/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
+++ b/src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.tsx
@@ -1,10 +1,25 @@
 import type { DiscoveredSkill, SkillDiscoverySource } from '../../../../shared/skills'
 import type { OrchestrationSkillAgentStatus } from '@/lib/orchestration-skill-coverage'
+import type { RuntimeClientTarget } from '@/runtime/runtime-client-target'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { useActiveSkillDiscoveryRuntimeTarget } from '@/hooks/use-active-skill-discovery-runtime-target'
+import { useDetectedAgents, type AgentDetectionTarget } from '@/hooks/useDetectedAgents'
 import { getOrchestrationSkillAgentStatuses } from '@/lib/orchestration-skill-coverage'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+
+function toAgentDetectionTarget(
+  target: RuntimeClientTarget | null
+): AgentDetectionTarget | undefined {
+  if (target === null) {
+    // Why: undefined keeps detection loading (detectedIds null) until the scan
+    // host resolves, instead of flashing local agents for a remote runtime.
+    return undefined
+  }
+  return target.kind === 'environment'
+    ? { kind: 'runtime', environmentId: target.environmentId }
+    : { kind: 'local' }
+}
 
 function getAgentCoverageSummary(props: {
   loading: boolean
@@ -74,7 +89,12 @@ export function OrchestrationSkillAgentCoverage(props: {
   className?: string
 }): React.JSX.Element {
   const { skills, sources, loading: skillsLoading, embedded = false, className } = props
-  const { detectedIds, isLoading: agentsLoading } = useDetectedAgents({ kind: 'local' })
+  // Why: skills/sources come from the runtime-scoped scan (#6887); detect agents
+  // on that same host or remote skill roots get matched against local agent ids.
+  const runtimeTarget = useActiveSkillDiscoveryRuntimeTarget()
+  const { detectedIds, isLoading: agentsLoading } = useDetectedAgents(
+    toAgentDetectionTarget(runtimeTarget)
+  )
   const loading = skillsLoading || agentsLoading || detectedIds === null
   const agentStatuses = getOrchestrationSkillAgentStatuses(skills, detectedIds ?? [], sources)
   const installedCount = agentStatuses.filter((status) => status.installed).length

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6373,6 +6373,7 @@
           "2777ff0fdc": "Orchestration skill"
         },
         "OrchestrationSkillAgentCoverage": {
+          "retryDetection": "Retry",
           "6dec5ce2d2": "Agent coverage",
           "ffe13e36fb": "Missing",
           "1e8f8d8fae": "Ready"


### PR DESCRIPTION
## Summary
- `OrchestrationSkillAgentCoverage` hard-coded `useDetectedAgents({ kind: 'local' })`, but its `skills`/`sources` props come from `useInstalledAgentSkill`, which since #6887 scans the host resolved by `useActiveSkillDiscoveryRuntimeTarget()` — i.e. the connected remote runtime when one is focused.
- The coverage join in `orchestration-skill-coverage.ts` then matched remote skill roots against local agent ids, producing wrong Ready/Missing chips (e.g. remote has Codex + skill, local has Claude/Cursor → shows "0 of 2" and prompts needless reinstalls).
- Fix: the component now derives its agent-detection target from the same `useActiveSkillDiscoveryRuntimeTarget()` the skill scan uses, mapping `RuntimeClientTarget` → `AgentDetectionTarget` (`environment` → `{ kind: 'runtime', environmentId }`, `local` → `{ kind: 'local' }`).
- While the scan host is still unresolved (`null`), the detection target is `undefined`, which keeps `detectedIds` null and the widget in its loading state — no flash of local agents for a remote runtime.

## Test plan
- Extended `src/renderer/src/components/settings/OrchestrationSkillAgentCoverage.test.tsx`:
  - focused remote runtime target → detection requested as `{ kind: 'runtime', environmentId: 'env-1' }` (not local)
  - no runtime target (local) → `{ kind: 'local' }` as before
  - unresolved host → `undefined` target and the widget stays in the loading state
- Verified the remote-runtime and unresolved-host tests fail on the unfixed code (`AssertionError: expected "vi.fn()" to be called with arguments: [ { kind: 'runtime', environmentId: 'env-1' } ]` — actual call was `{ kind: 'local' }`), then pass with the fix.
- Ran `npx vitest run --config config/vitest.config.ts` for `OrchestrationSkillAgentCoverage.test.tsx`, `OrchestrationPane.test.tsx`, and `orchestration-skill-coverage.test.ts`: 3 files, 23 tests, all passing. `npx oxlint` clean on changed files.

Found by the production release scan of v1.4.162..v1.4.163-rc.0.

Made with [Orca](https://github.com/stablyai/orca) 🐋
