### PR TITLE
[P2] perf(relay): stop re-encoding frames to size PTY chunks

### DIFF
--- a/src/relay/dispatcher-frame-guard-regressions.test.ts
+++ b/src/relay/dispatcher-frame-guard-regressions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+import type { JsonRpcNotification } from './protocol'
+
+type DispatcherInternals = {
+  primaryClient: object
+  estimateFrameBytes: (msg: JsonRpcNotification) => number
+  enqueueFrame: (client: object, msg: JsonRpcNotification, lane: string) => boolean
+}
+
+describe('RelayDispatcher frame guards', () => {
+  it('returns zero for invalid active-client limits without encoding', () => {
+    const dispatcher = new RelayDispatcher(() => true, {
+      writableHighWaterMark: () => 1024 * 1024,
+      writableLength: () => 0
+    })
+    try {
+      const spy = vi.spyOn(dispatcher as unknown as DispatcherInternals, 'estimateFrameBytes')
+      for (const limit of [0, -1, Number.NaN]) {
+        expect(dispatcher.maxLegacyPtyDataChars({ id: 'pty-1' }, 'hello', limit)).toBe(0)
+      }
+      expect(spy).not.toHaveBeenCalled()
+    } finally {
+      dispatcher.dispose()
+    }
+  })
+
+  it('does not estimate frames after disposal', () => {
+    const dispatcher = new RelayDispatcher(() => true)
+    const internals = dispatcher as unknown as DispatcherInternals
+    const spy = vi.spyOn(internals, 'estimateFrameBytes')
+    const msg: JsonRpcNotification = {
+      jsonrpc: '2.0',
+      method: 'pty.data',
+      params: {
+        data: {
+          toJSON: () => {
+            throw new Error('must not serialize')
+          }
+        }
+      }
+    }
+    dispatcher.dispose()
+    expect(internals.enqueueFrame(internals.primaryClient, msg, 'ordinary')).toBe(false)
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/src/relay/dispatcher.test.ts
+++ b/src/relay/dispatcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { RelayDispatcher, type SinkWriteSettlement } from './dispatcher'
+import { relayWriterControlReserve } from './dispatcher-writer-admission'
 import {
   encodeJsonRpcFrame,
   encodeKeepAliveFrame,
@@ -713,6 +714,198 @@ describe('RelayDispatcher', () => {
         expect(secondaryFrames).toHaveLength(1)
       } finally {
         bulkDispatcher.dispose()
+      }
+    })
+  })
+
+  describe('legacy PTY chunk sizing', () => {
+    type DispatcherInternals = {
+      primaryClient: object
+      estimateFrameBytes: (msg: JsonRpcNotification) => number
+      enqueueFrame: (
+        client: object,
+        msg: JsonRpcNotification,
+        lane: string,
+        onSettled?: (result: SinkWriteSettlement) => void,
+        estimatedBytes?: number
+      ) => boolean
+    }
+
+    // Pre-optimization sizing loop, kept verbatim for differential verification.
+    function referenceMaxChars(
+      capacities: number[],
+      params: Record<string, unknown>,
+      data: string,
+      limit: number
+    ): number {
+      if (capacities.length === 0) {
+        return Math.min(data.length, limit)
+      }
+      let low = 0
+      let high = Math.min(data.length, limit)
+      while (low < high) {
+        const mid = Math.ceil((low + high) / 2)
+        const msg: JsonRpcNotification = {
+          jsonrpc: '2.0',
+          method: 'pty.data',
+          params: { ...params, data: data.slice(0, mid) }
+        }
+        const bytes = encodeJsonRpcFrame(msg, 0, 0).length
+        if (capacities.every((capacity) => bytes <= capacity)) {
+          low = mid
+        } else {
+          high = mid - 1
+        }
+      }
+      return low
+    }
+
+    function makeDispatcher(highWaterMarks: number[]): {
+      sized: RelayDispatcher
+      capacities: number[]
+    } {
+      const [primaryHwm, ...rest] = highWaterMarks
+      const sized = new RelayDispatcher(() => true, {
+        writableHighWaterMark: () => primaryHwm,
+        writableLength: () => 0
+      })
+      for (const hwm of rest) {
+        sized.attachClient(() => true, {
+          writableHighWaterMark: () => hwm,
+          writableLength: () => 0
+        })
+      }
+      return {
+        sized,
+        capacities: highWaterMarks.map((hwm) => Math.max(0, hwm - relayWriterControlReserve(hwm)))
+      }
+    }
+
+    function mulberry32(seed: number): () => number {
+      let a = seed
+      return () => {
+        a = (a + 0x6d2b79f5) | 0
+        let t = Math.imul(a ^ (a >>> 15), 1 | a)
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+      }
+    }
+
+    // Multi-byte UTF-8, astral pairs, lone surrogates, controls, quotes, and backslashes.
+    const alphabet = 'aZ9 "\\\n\r\t éß€中𝄞😀𐀀�'
+
+    it('matches the pre-optimization sizing loop across randomized inputs', () => {
+      const random = mulberry32(0xc0ffee)
+      const hwmChoices = [1030, 1100, 1250, 1400, 2048, 1024 * 1024]
+      for (let trial = 0; trial < 300; trial++) {
+        const length = Math.floor(random() * 240)
+        let data = ''
+        for (let i = 0; i < length; i++) {
+          data += alphabet[Math.floor(random() * alphabet.length)]
+        }
+        const clientCount = 1 + Math.floor(random() * 2)
+        const hwms = Array.from(
+          { length: clientCount },
+          () => hwmChoices[Math.floor(random() * hwmChoices.length)]
+        )
+        const params = { id: `pty-${trial}`, seq: trial }
+        const { sized, capacities } = makeDispatcher(hwms)
+        try {
+          for (const limit of [0, 1, Math.floor(length / 2), length, length + 17]) {
+            expect(sized.maxLegacyPtyDataChars(params, data, limit)).toBe(
+              referenceMaxChars(capacities, params, data, limit)
+            )
+          }
+          expect(sized.maxLegacyPtyDataChars(params, data)).toBe(
+            referenceMaxChars(capacities, params, data, data.length)
+          )
+        } finally {
+          sized.dispose()
+        }
+      }
+    })
+
+    it('sizes a chunk that fits every client with a single frame encode', () => {
+      const { sized } = makeDispatcher([1024 * 1024])
+      try {
+        const spy = vi.spyOn(sized as unknown as DispatcherInternals, 'estimateFrameBytes')
+        const data = 'x'.repeat(16 * 1024)
+        expect(sized.maxLegacyPtyDataChars({ id: 'pty-1' }, data)).toBe(data.length)
+        expect(spy).toHaveBeenCalledTimes(1)
+      } finally {
+        sized.dispose()
+      }
+    })
+
+    it('publishes PTY data with a single frame estimate', () => {
+      const frames: Buffer[] = []
+      const publisher = new RelayDispatcher((data) => {
+        frames.push(Buffer.from(data))
+        return true
+      })
+      try {
+        const spy = vi.spyOn(publisher as unknown as DispatcherInternals, 'estimateFrameBytes')
+        expect(publisher.tryNotifyPtyData({ id: 'pty-1', data: 'hello' })).toBe(true)
+        expect(frames).toHaveLength(1)
+        expect(spy).toHaveBeenCalledTimes(1)
+      } finally {
+        publisher.dispose()
+      }
+    })
+
+    it('enqueueFrame with a caller-supplied estimate matches the computed default', () => {
+      const frames: Buffer[] = []
+      const publisher = new RelayDispatcher((data) => {
+        frames.push(Buffer.from(data))
+        return true
+      })
+      try {
+        const internals = publisher as unknown as DispatcherInternals
+        const msg: JsonRpcNotification = {
+          jsonrpc: '2.0',
+          method: 'pty.data',
+          params: { id: 'pty-1', data: 'héllo "𝄞"\\\n\uD800' }
+        }
+        expect(internals.enqueueFrame(internals.primaryClient, msg, 'ordinary')).toBe(true)
+        expect(
+          internals.enqueueFrame(
+            internals.primaryClient,
+            msg,
+            'ordinary',
+            undefined,
+            internals.estimateFrameBytes(msg)
+          )
+        ).toBe(true)
+        expect(frames).toHaveLength(2)
+        expect(
+          decodeFirstFrame(frames[1]).payload.equals(decodeFirstFrame(frames[0]).payload)
+        ).toBe(true)
+      } finally {
+        publisher.dispose()
+      }
+    })
+
+    it('enqueueFrame rejects identically with and without a caller-supplied estimate', () => {
+      const { sized } = makeDispatcher([1030])
+      try {
+        const internals = sized as unknown as DispatcherInternals
+        const msg: JsonRpcNotification = {
+          jsonrpc: '2.0',
+          method: 'pty.data',
+          params: { id: 'pty-1', data: 'x'.repeat(512) }
+        }
+        expect(internals.enqueueFrame(internals.primaryClient, msg, 'ordinary')).toBe(false)
+        expect(
+          internals.enqueueFrame(
+            internals.primaryClient,
+            msg,
+            'ordinary',
+            undefined,
+            internals.estimateFrameBytes(msg)
+          )
+        ).toBe(false)
+      } finally {
+        sized.dispose()
       }
     })
   })

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -197,6 +197,9 @@ export class RelayDispatcher {
     if (clients.length === 0) {
       return max
     }
+    if (!(max > 0)) {
+      return 0
+    }
     const fitsAll = (bytes: number): boolean =>
       clients.every((client) => bytes <= client.writer.producerFrameCapacity)
     const sizeFrame = (chunk: string): number =>
@@ -835,18 +838,19 @@ export class RelayDispatcher {
     lane: DispatcherWriterLane,
     onSettled: (result: SinkWriteSettlement) => void = () => {},
     // Why: publish paths already sized the frame; avoid a redundant encode.
-    estimatedBytes: number = this.estimateFrameBytes(msg)
+    estimatedBytes?: number
   ): boolean {
     if (this.disposed || client.closed) {
       return false
     }
+    const frameBytes = estimatedBytes ?? this.estimateFrameBytes(msg)
     return client.writer.enqueue(
       lane,
       () => {
         const seq = client.nextOutgoingSeq++
         return encodeJsonRpcFrame(msg, seq, client.highestReceivedSeq)
       },
-      estimatedBytes,
+      frameBytes,
       onSettled
     )
   }

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -193,20 +193,31 @@ export class RelayDispatcher {
     limit = data.length
   ): number {
     const clients = this.activeClients()
+    const max = Math.min(data.length, limit)
     if (clients.length === 0) {
-      return Math.min(data.length, limit)
+      return max
     }
-    let low = 0
-    let high = Math.min(data.length, limit)
-    while (low < high) {
-      const mid = Math.ceil((low + high) / 2)
-      const msg: JsonRpcNotification = {
+    const fitsAll = (bytes: number): boolean =>
+      clients.every((client) => bytes <= client.writer.producerFrameCapacity)
+    const sizeFrame = (chunk: string): number =>
+      this.estimateFrameBytes({
         jsonrpc: '2.0',
         method: 'pty.data',
-        params: { ...params, data: data.slice(0, mid) }
-      }
-      const bytes = this.estimateFrameBytes(msg)
-      if (clients.every((client) => bytes <= client.writer.producerFrameCapacity)) {
+        params: { ...params, data: chunk }
+      })
+    // Fast path: the whole chunk usually fits — one encode instead of log2(n).
+    if (fitsAll(sizeFrame(data.slice(0, max)))) {
+      return max
+    }
+    // Exact per-step size: only the escaped data string varies; its quotes are in baseBytes.
+    const baseBytes = sizeFrame('')
+    const bytesFor = (chars: number): number =>
+      baseBytes + Buffer.byteLength(JSON.stringify(data.slice(0, chars))) - 2
+    let low = 0
+    let high = max
+    while (low < high) {
+      const mid = Math.ceil((low + high) / 2)
+      if (fitsAll(bytesFor(mid))) {
         low = mid
       } else {
         high = mid - 1
@@ -822,12 +833,13 @@ export class RelayDispatcher {
     client: RelayClient,
     msg: JsonRpcRequest | JsonRpcResponse | JsonRpcNotification,
     lane: DispatcherWriterLane,
-    onSettled: (result: SinkWriteSettlement) => void = () => {}
+    onSettled: (result: SinkWriteSettlement) => void = () => {},
+    // Why: publish paths already sized the frame; avoid a redundant encode.
+    estimatedBytes: number = this.estimateFrameBytes(msg)
   ): boolean {
     if (this.disposed || client.closed) {
       return false
     }
-    const estimatedBytes = this.estimateFrameBytes(msg)
     return client.writer.enqueue(
       lane,
       () => {
@@ -898,7 +910,7 @@ export class RelayDispatcher {
         return false
       }
       for (let index = 0; index < clients.length; index++) {
-        if (!this.enqueueLeasedFrame(clients[index], msg, lane, leases[index])) {
+        if (!this.enqueueLeasedFrame(clients[index], msg, lane, leases[index], bytes)) {
           if (this.disposed || clients[index].closed) {
             continue
           }
@@ -949,7 +961,7 @@ export class RelayDispatcher {
     if (!leases) {
       return false
     }
-    return this.enqueueLeasedFrame(client, msg, lane, leases[0], onSettled)
+    return this.enqueueLeasedFrame(client, msg, lane, leases[0], bytes, onSettled)
   }
 
   private publishBulkWhenAvailable(client: RelayClient, msg: JsonRpcNotification): Promise<void> {
@@ -998,13 +1010,20 @@ export class RelayDispatcher {
     msg: JsonRpcNotification,
     lane: 'interactive' | 'ordinary' | 'fixed-bulk' | 'bulk',
     lease: LegacyPublicationLease,
+    estimatedBytes: number,
     onSettled: (result: SinkWriteSettlement) => void = () => {}
   ): boolean {
-    const accepted = this.enqueueFrame(client, msg, lane, (result) => {
-      lease.release()
-      onSettled(result)
-      this.notifyLegacyCapacityIfLow()
-    })
+    const accepted = this.enqueueFrame(
+      client,
+      msg,
+      lane,
+      (result) => {
+        lease.release()
+        onSettled(result)
+        this.notifyLegacyCapacityIfLow()
+      },
+      estimatedBytes
+    )
     if (!accepted) {
       lease.release()
       this.notifyLegacyCapacityIfLow()


### PR DESCRIPTION
## Summary
- `maxLegacyPtyDataChars` binary-searched the chunk length by fully encoding the JSON-RPC frame (`JSON.stringify` + `Buffer.from` + `Buffer.concat`) at every probe — ~15 full encodes of a ~16KB frame per 16KB of terminal output, even when the whole chunk trivially fit.
- Each PTY publish also estimated the frame in `tryPublishToClients`/`publishToClient` and then re-estimated the identical message inside `enqueueFrame` before the writer encoded it a third time.
- Fix (a): fast path sizes the full candidate chunk once and returns it when it fits every client (the common case). Otherwise the binary search uses an exact cheap size: `baseBytes` (frame with `data: ''`, one encode) plus `Buffer.byteLength(JSON.stringify(slice)) - 2` — exact because the escaped data string is the only variable part and its quotes are already counted in `baseBytes`.
- Fix (b): `enqueueFrame` takes an optional pre-computed estimate (defaulting to computing it, so other callers are unchanged); the publish paths thread their estimate through `enqueueLeasedFrame`, removing the redundant admission encode.
- Chunking decisions are bit-identical to the old algorithm; verified with a differential test against a verbatim copy of the pre-optimization sizing loop.

## Test plan
- `npx vitest run --config config/vitest.config.ts src/relay/dispatcher.test.ts src/relay/dispatcher-timeout.test.ts src/relay/dispatcher-client-writer.test.ts src/relay/pty-handler.test.ts src/relay/pty-handler-output-drain-differential.test.ts src/relay/pty-handler-source-publication.test.ts src/relay/legacy-relay-publication-ledger.test.ts` — 7 files, 181 tests, all passing.
- New differential test: 300 randomized trials (multi-byte UTF-8, astral pairs, lone surrogates, control chars, quotes/backslashes, empty data, limits at/above/below data length, 1-2 clients across small and large capacities) asserting the new sizing returns exactly what the old encode-per-probe loop returned.
- New equivalence tests: `enqueueFrame` with a caller-supplied estimate accepts/rejects and emits byte-identical payloads vs. the computed default.
- Verified regression tests fail on the unfixed code (fix stashed): "sizes a chunk that fits every client with a single frame encode" failed with `expected "estimateFrameBytes" to be called 1 times, but got 15 times`, and "publishes PTY data with a single frame estimate" failed with `expected "estimateFrameBytes" to be called 1 times, but got 2 times`; both pass with the fix.
- `npx oxlint src/relay/dispatcher.ts src/relay/dispatcher.test.ts` clean; `tsc --noEmit -p config/tsconfig.node.json` clean.

Found by the production release scan of v1.4.162..v1.4.163-rc.0.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## ELI5

Orca used to wrap the same terminal message over and over just to see whether it fit in the delivery box. It now measures once and reuses the answer, reducing CPU work without changing which chunks are sent.