### PR TITLE
[P0] fix(relay): slice PTY flush remainder from the memoized source chunk

### DIFF
--- a/src/relay/pty-handler-source-publication.test.ts
+++ b/src/relay/pty-handler-source-publication.test.ts
@@ -301,6 +301,34 @@ describe('PtyHandler negotiated source publication', () => {
     expect(adapter.getDebugSnapshot()).toMatchObject({ deliveryTokens: 1 })
   })
 
+  it('republishes the identical memoized span after a failed projection', async () => {
+    await spawn({})
+    const appendSpy = vi.spyOn(adapter, 'appendSource')
+    const projectSpy = vi
+      .spyOn(dispatcher, 'projectPtyDataToMatchingClients')
+      .mockReturnValueOnce(false)
+    // Why: a larger capacity result on the retry must not move the memoized span boundary.
+    const maxCharsSpy = vi.spyOn(dispatcher, 'maxLegacyPtyDataChars')
+    maxCharsSpy.mockReturnValueOnce(4).mockReturnValue(8)
+
+    dataCallback!('abcdefgh')
+    await vi.advanceTimersByTimeAsync(8)
+    expect(projectSpy).toHaveBeenCalledTimes(1)
+
+    handler.handleSourcePublicationCapacity('pty-1')
+    await vi.advanceTimersByTimeAsync(8)
+
+    // Retried projection carries the byte-identical span params.
+    expect(projectSpy.mock.calls[1][1]).toEqual(projectSpy.mock.calls[0][1])
+    const spans = appendSpy.mock.calls.map(([, input]) => input)
+    expect(spans.filter((span) => span.data === 'abcd')).toHaveLength(1)
+    expect(spans.map((span) => span.data).join('')).toBe('abcdefgh')
+    expect(spans.map((span) => [span.displayStart, span.displayEnd])).toEqual([
+      [0, 4],
+      [4, 8]
+    ])
+  })
+
   it('keeps the native PTY and V1 owner live when one subscriber saturates', async () => {
     await spawn({})
     const detached: number[] = []

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -1340,6 +1340,123 @@ describe('PtyHandler', () => {
     ])
   })
 
+  describe('legacy flush retry with a memoized source chunk', () => {
+    let capacityListener: (() => void) | undefined
+    let hasCapacity: boolean
+    let maxChars: number
+    let admitted: Record<string, unknown>[]
+    let dataCallback: ((data: string) => void) | undefined
+
+    async function setupRetryHarness(spawnParams: Record<string, unknown> = {}): Promise<void> {
+      await handler.dispose({ waitForPhysicalExit: false })
+      capacityListener = undefined
+      hasCapacity = false
+      admitted = []
+      Object.assign(dispatcher, {
+        onLegacyPtyCapacity: vi.fn((listener: () => void) => {
+          capacityListener = listener
+          return vi.fn()
+        }),
+        tryNotifyPtyData: vi.fn((params: Record<string, unknown>) => {
+          if (hasCapacity) {
+            admitted.push(params)
+          }
+          return hasCapacity
+        }),
+        tryNotifyPtyExit: vi.fn(() => true),
+        legacyRetentionBelowLowWater: true,
+        // Clamped like the real dispatcher: never more than min(data.length, limit).
+        maxLegacyPtyDataChars: vi.fn((_params: unknown, data: string, limit?: number) =>
+          Math.min(maxChars, data.length, limit ?? data.length)
+        )
+      })
+      handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+      dataCallback = undefined
+      mockPtySpawn.mockReturnValue({
+        ...mockPtyInstance,
+        onData: vi.fn((callback: (data: string) => void) => {
+          dataCallback = callback
+        }),
+        onExit: vi.fn()
+      })
+      await dispatcher.callRequest('pty.spawn', spawnParams)
+      expect(dataCallback).toBeDefined()
+    }
+
+    it('resends the memo verbatim and keeps the coalesced tail when capacity grows', async () => {
+      maxChars = 5_000
+      await setupRetryHarness()
+      dataCallback!('a'.repeat(20_000))
+      await vi.advanceTimersByTimeAsync(8)
+      // Why before restoring capacity: the failed batch made zero writes so no flush is
+      // rescheduled; this enqueue re-arms the timer.
+      dataCallback!('b'.repeat(10))
+      hasCapacity = true
+      maxChars = 16_384
+      await vi.runAllTimersAsync()
+
+      expect(admitted.map((frame) => frame.data).join('')).toBe('a'.repeat(20_000) + 'b'.repeat(10))
+      expect((admitted[0].data as string).length).toBe(5_000)
+      // Why: remainder frames must not leak transformed/rawLength/seq keys.
+      expect(admitted[1]).toStrictEqual({ id: 'pty-1', data: expect.any(String) })
+    })
+
+    it('keeps a tail appended after a failed flush under constant capacity', async () => {
+      maxChars = 16_384
+      await setupRetryHarness()
+      dataCallback!('a'.repeat(5_000))
+      await vi.advanceTimersByTimeAsync(8)
+      dataCallback!('b'.repeat(10))
+      hasCapacity = true
+      await vi.runAllTimersAsync()
+
+      expect(admitted.map((frame) => frame.data).join('')).toBe('a'.repeat(5_000) + 'b'.repeat(10))
+      expect(admitted[1].data).toBe('b'.repeat(10))
+    })
+
+    it('does not duplicate memoized chars when capacity shrinks before the retry', async () => {
+      maxChars = 16_384
+      await setupRetryHarness()
+      dataCallback!('a'.repeat(20_000))
+      await vi.advanceTimersByTimeAsync(8)
+      maxChars = 5_000
+      hasCapacity = true
+      // Why: nothing else re-arms the flush timer after a zero-write batch.
+      capacityListener!()
+      await vi.runAllTimersAsync()
+
+      expect(admitted.map((frame) => frame.data).join('')).toBe('a'.repeat(20_000))
+      expect((admitted[0].data as string).length).toBe(16_384)
+      expect((admitted[1].data as string).length).toBe(3_616)
+    })
+
+    it('retains a coalesced transformed raw advance behind a memoized source-only chunk', async () => {
+      maxChars = 16_384
+      await setupRetryHarness({
+        startupIngressVersion: PTY_STARTUP_INGRESS_VERSION,
+        startupIngress: {
+          colors: { foreground: '#2e3434', background: '#ffffff' },
+          deadlineMs: 5_000
+        }
+      })
+      // First answered query: direct publish fails, entry queued without a memo.
+      dataCallback!('\x1b]10;?\x07')
+      // Capacity event while still blocked: the flush fails and memoizes the source-only chunk.
+      capacityListener!()
+      await vi.advanceTimersByTimeAsync(0)
+      // Second answered query coalesces into the memoized transformed head.
+      dataCallback!('\x1b]11;?\x07')
+      hasCapacity = true
+      capacityListener!()
+      await vi.runAllTimersAsync()
+
+      expect(admitted).toEqual([
+        { id: 'pty-1', data: '', rawLength: 7, seq: 7, transformed: true },
+        { id: 'pty-1', data: '', rawLength: 7, seq: 14, transformed: true }
+      ])
+    })
+  })
+
   it('leaves startup queries untouched for an unsupported relay capability version', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -894,10 +894,15 @@ export class PtyHandler {
       ...(pending.rawLength === undefined ? {} : { rawLength: pending.rawLength }),
       ...(pending.transformed ? { transformed: true } : {})
     }
-    let chunkChars = pending.transformed
-      ? desiredChars
-      : (this.dispatcher.maxLegacyPtyDataChars?.(paramsWithoutData, pending.data, desiredChars) ??
-        desiredChars)
+    // Why: a failed publish may already have reserved this exact span (source-ledger append,
+    // partial legacy fan-out), so a retry must resend it verbatim and slice the remainder at
+    // the memo boundary — capacity and coalesced data can both have changed since. The capacity
+    // search is skipped on retry: its result is discarded, and publish re-checks capacity.
+    let chunkChars =
+      pending.transformed || pending.sourceChunk
+        ? desiredChars
+        : (this.dispatcher.maxLegacyPtyDataChars?.(paramsWithoutData, pending.data, desiredChars) ??
+          desiredChars)
     if (
       chunkChars > 0 &&
       chunkChars < pending.data.length &&
@@ -914,8 +919,8 @@ export class PtyHandler {
       this.pausePtyOutput(id)
       return false
     }
-    const chunk = pending.data.slice(0, chunkChars)
-    const remaining = pending.data.slice(chunkChars)
+    const chunk = pending.sourceChunk?.data ?? pending.data.slice(0, chunkChars)
+    const remaining = pending.data.slice(chunk.length)
     const chunkRawLength = pending.transformed
       ? pending.rawLength
       : pending.rawLength === undefined
@@ -938,10 +943,16 @@ export class PtyHandler {
       this.pausePtyOutput(id)
       return false
     }
-    if (remaining) {
+    // rawLength fallback is defensive only: transformed memos always carry rawLength (ingress meta).
+    const publishedRawLength = sourceChunk.rawLength ?? sourceChunk.data.length
+    const remainingRawLength = pending.transformed
+      ? (pending.rawLength ?? 0) - publishedRawLength
+      : remaining.length
+    if (remaining || (pending.transformed && remainingRawLength > 0)) {
       queue[0] = {
         data: remaining,
-        ...(pending.rawLength === undefined ? {} : { rawLength: remaining.length }),
+        ...(pending.transformed ? { transformed: true } : {}),
+        ...(pending.rawLength === undefined ? {} : { rawLength: remainingRawLength }),
         seq: pending.seq
       }
     } else {


### PR DESCRIPTION
## Summary
- `flushPtyOutput` memoizes the published span (`pending.sourceChunk`) after a failed publish because the source ledger and partial legacy fan-out may already hold it — a retry must resend the byte-identical span.
- Root cause: the retry recomputed `chunkChars` from current capacity/coalesced data and sliced the remainder at that new boundary instead of the memo boundary, so `remaining = pending.data.slice(chunkChars)` disagreed with the chunk actually published.
- Impact: silently dropped output when capacity grew or a tail was coalesced after the failed flush, duplicated already-published chars when capacity shrank, and discarded coalesced transformed raw-seq advances behind a source-only memo.
- Fix: derive the chunk from the memo (`chunk = pending.sourceChunk?.data ?? pending.data.slice(0, chunkChars)`) and always slice the remainder at `chunk.length`; skip the `maxLegacyPtyDataChars` binary search on memo retries since its result is discarded and publish re-checks capacity atomically.
- Remainder bookkeeping now preserves `transformed`/`rawLength`/`seq`: a transformed tail keeps `rawLength = pending.rawLength - memo.rawLength` and is retained even when `data === ''` so coalesced source-only raw advances are still emitted.
- No behavior change when no memo exists: chunk, remainder, and queue-entry shape are bit-identical to before (pinned by the output-drain differential oracle).

## Test plan
- New regression tests in `src/relay/pty-handler.test.ts` (listener-capturing legacy harness with a clamped `maxLegacyPtyDataChars` mock): memo resent verbatim with the coalesced tail kept when capacity grows (incl. no transformed/rawLength/seq key leakage on remainder frames), appended tail kept under constant capacity, no duplication when capacity shrinks, and coalesced transformed raw advance retained behind a memoized source-only chunk.
- New test in `src/relay/pty-handler-source-publication.test.ts`: failed projection then retry with a larger capacity result republishes the byte-identical span params, calls `appendSource` exactly once per span, and appends contiguous `displayStart`/`displayEnd` spans reproducing the full output.
- Verified all 5 new tests fail on the unfixed code (e.g. grown-capacity case delivers only 8,626 of 20,010 chars; shrink case duplicates 11,384 chars; source-only coalesce emits 1 of 2 frames) and pass with the fix.
- Ran `src/relay/pty-handler.test.ts`, `src/relay/pty-handler-source-publication.test.ts`, `src/relay/pty-handler-output-drain-differential.test.ts`, `src/relay/pty-replay-buffer-equivalence.test.ts`: 144 tests passing. `oxlint` and `tsc -p config/tsconfig.node.json` clean.

Found by the production release scan of v1.4.162..v1.4.163-rc.0.

Made with [Orca](https://github.com/stablyai/orca) 🐋


## ELI5

Imagine mailing a long message in chunks. If one chunk had to be retried, Orca sometimes moved the cut line and could lose or repeat part of the message. This keeps the original cut line, so every terminal character arrives exactly once.