### PR TITLE
Fix daemon audit evidence polarity and trigger scope

### DIFF
--- a/src/main/daemon/daemon-audit-classifier.ts
+++ b/src/main/daemon/daemon-audit-classifier.ts
@@ -123,14 +123,14 @@ export async function classifyDaemonAuditFailure(
     context.endpointKind === 'unix-socket' ? ['endpoint_stat'] : [],
     options.additionalEvidenceSources ?? []
   )
-  if (
-    options.endpointGoneProof &&
-    context.endpointKind === 'windows-named-pipe' &&
-    exactIncarnation
-  ) {
+  const windowsNamedPipeMissing =
+    options.endpointGoneProof === 'windows_named_pipe_missing' &&
+    context.endpointKind === 'windows-named-pipe'
+  const observedEndpointState = windowsNamedPipeMissing ? 'missing' : endpointState
+  if (windowsNamedPipeMissing && exactIncarnation && processEvidence.state !== 'present') {
     return {
       state: 'gone',
-      reason: options.endpointGoneProof,
+      reason: 'windows_named_pipe_missing',
       trigger,
       evidenceSources,
       context,
@@ -138,8 +138,8 @@ export async function classifyDaemonAuditFailure(
       reachability,
       inventoryAuthority: 'unavailable',
       processLiveness: 'gone',
-      processReason: options.endpointGoneProof,
-      endpointState: 'missing',
+      processReason: 'windows_named_pipe_missing',
+      endpointState: observedEndpointState,
       observedAtMs: Date.now()
     }
   }
@@ -155,7 +155,7 @@ export async function classifyDaemonAuditFailure(
       inventoryAuthority: 'unavailable',
       processLiveness: 'gone',
       processReason: processEvidence.reason,
-      endpointState,
+      endpointState: observedEndpointState,
       observedAtMs: Date.now()
     }
   }
@@ -170,7 +170,7 @@ export async function classifyDaemonAuditFailure(
     inventoryAuthority: 'unavailable',
     processLiveness: processEvidence.state,
     processReason: processEvidence.reason,
-    endpointState,
+    endpointState: observedEndpointState,
     observedAtMs: Date.now()
   }
 }
@@ -192,9 +192,6 @@ async function inspectDaemonEndpointState(
 function reachabilityForTrigger(
   trigger: DaemonAuditFailureTrigger
 ): 'authenticated' | 'disconnected' | 'unknown' {
-  if (trigger === 'endpoint_identity_changed') {
-    return 'authenticated'
-  }
   if (
     trigger === 'transport_closed' ||
     trigger === 'token_missing_after_authenticated_disconnect'

--- a/src/main/daemon/daemon-incarnation-evidence.test.ts
+++ b/src/main/daemon/daemon-incarnation-evidence.test.ts
@@ -114,6 +114,18 @@ describe('daemon process identity evidence', () => {
     ).resolves.toMatchObject({ state: 'unknown', reason: 'permission_denied' })
   })
 
+  it('keeps a missing proc stat unknown when signal zero still sees the pid', async () => {
+    await expect(
+      probeDaemonProcessIdentity(
+        exactIncarnation,
+        endpoint,
+        linuxDependencies({
+          readLinuxStat: async () => ({ status: 'missing' })
+        })
+      )
+    ).resolves.toMatchObject({ state: 'unknown', reason: 'inspection_failed' })
+  })
+
   it('keeps an unreadable command line unknown even when Linux start identity matches', async () => {
     await expect(
       probeDaemonProcessIdentity(
@@ -321,6 +333,36 @@ describe('daemon audit availability evidence', () => {
       reason: 'windows_named_pipe_missing',
       endpointState: 'missing',
       exactIncarnation
+    })
+  })
+
+  it('keeps contradictory Windows pipe and process evidence unknown', async () => {
+    const windowsContext: DaemonAuditContext = {
+      ...context,
+      endpoint: '\\\\?\\pipe\\orca-daemon',
+      endpointKind: 'windows-named-pipe'
+    }
+    const dependencies = {
+      ...auditClassifierDependencies,
+      probeProcessIdentity: async () => ({
+        state: 'present',
+        reason: 'windows_identity_match',
+        evidenceSources: ['windows_cim', 'endpoint_identity']
+      })
+    } satisfies DaemonAuditClassifierDependencies
+
+    await expect(
+      classifyDaemonAuditFailure(windowsContext, 'inventory_failed', exactIncarnation, {
+        additionalEvidenceSources: ['windows_named_pipe'],
+        endpointGoneProof: 'windows_named_pipe_missing',
+        dependencies
+      })
+    ).resolves.toMatchObject({
+      state: 'unknown',
+      reason: 'inventory_failed',
+      processLiveness: 'present',
+      processReason: 'windows_identity_match',
+      endpointState: 'missing'
     })
   })
 

--- a/src/main/daemon/daemon-incarnation-evidence.ts
+++ b/src/main/daemon/daemon-incarnation-evidence.ts
@@ -66,7 +66,10 @@ async function probeLinuxProcess(
 ): Promise<DaemonProcessEvidence> {
   const stat = await (dependencies.readLinuxStat ?? readLinuxStat)(exactIncarnation.identity.pid)
   if (stat.status === 'missing') {
-    return gone('pid_missing', ['linux_proc_stat', 'endpoint_identity'], exactIncarnation)
+    return unknown(signal === 'permission_denied' ? 'permission_denied' : 'inspection_failed', [
+      'linux_proc_stat',
+      'process_signal'
+    ])
   }
   if (stat.status === 'unavailable') {
     return unknown(signal === 'permission_denied' ? 'permission_denied' : 'inspection_failed', [

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -19,7 +19,7 @@ import type { SubprocessHandle } from './session'
 import type { PendingOutputRecord } from './types'
 import type { DaemonFileLog } from './daemon-file-log'
 import type * as DaemonHealthModule from './daemon-health'
-import { getDaemonSocketPath } from './daemon-spawner'
+import { getDaemonSocketPath, serializeDaemonPidFile } from './daemon-spawner'
 import { PtyWriteUnavailableError } from '../providers/pty-write-unavailable-error'
 import { TERMINAL_HISTORY_INLINE_SEED_CODE_UNITS } from './terminal-history-seed-chunks'
 
@@ -1454,6 +1454,53 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         reason: 'authenticated_inventory',
         inventoryAuthority: 'authoritative'
       })
+    })
+
+    it('loads persisted Linux birth identity for audit observations', async () => {
+      adapter.dispose()
+      await server.shutdown()
+      const startedAtMs = 1_700_000_000_000
+      const launchNonce = 'launch-with-linux-identity'
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        startedAtMs,
+        launchNonce,
+        log: daemonLog,
+        spawnSubprocess: (opts) => {
+          lastSpawnOpts = opts
+          lastSubprocess = createMockSubprocess()
+          return lastSubprocess
+        }
+      })
+      await server.start()
+      const pidPath = join(dir, 'daemon.pid')
+      writeFileSync(
+        pidPath,
+        serializeDaemonPidFile({
+          pid: process.pid,
+          startedAtMs,
+          launchNonce,
+          linuxStartTicks: '4242',
+          bootId: 'boot-a'
+        })
+      )
+      const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      try {
+        adapter = new DaemonPtyAdapter({ socketPath, tokenPath, pidPath })
+
+        await expect(adapter.listProcesses()).resolves.toEqual([])
+
+        expect(adapter.getLastAuditObservation()?.exactIncarnation).toMatchObject({
+          linuxStartTicks: '4242',
+          bootId: 'boot-a'
+        })
+      } finally {
+        if (platform) {
+          Object.defineProperty(process, 'platform', platform)
+        }
+      }
     })
 
     it('reports the daemon session WSL owner', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable max-lines -- Why: history .catch() safety wiring spread across spawn/event-routing is tightly coupled to the adapter↔history lifecycle. */
 import { basename } from 'node:path'
 import { existsSync, readFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { DaemonClient } from './client'
 import {
   getMacDaemonSystemResolverHealth,
@@ -152,6 +153,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
   private socketPath: string
   private tokenPath: string
   private pidPath: string | null
+  private pidRecord: ParsedDaemonPid | null
   private client: DaemonClient
   private auditContext: DaemonAuditContext
   private lastAuthenticatedIdentity: DaemonEndpointIdentity | null = null
@@ -248,6 +250,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     this.socketPath = opts.socketPath
     this.tokenPath = opts.tokenPath
     this.pidPath = opts.pidPath ?? null
+    this.pidRecord = readDaemonPidRecord(this.pidPath)
     this.auditContext = {
       protocolGeneration: this.protocolVersion,
       provider: 'local-daemon',
@@ -1635,34 +1638,61 @@ export class DaemonPtyAdapter implements IPtyProvider {
     if (previous && sameEndpointIdentity(previous, current)) {
       return
     }
-    const previousExactIncarnation = this.exactDaemonIncarnation
-    const pidRecord = this.readMatchingPidRecord(current)
     this.lastAuthenticatedIdentity = { ...current }
-    this.exactDaemonIncarnation = {
-      identity: { ...current },
-      ...(pidRecord?.linuxStartTicks && pidRecord.bootId
-        ? {
-            linuxStartTicks: pidRecord.linuxStartTicks,
-            bootId: pidRecord.bootId
-          }
-        : {})
-    }
+    this.exactDaemonIncarnation = exactDaemonIncarnationForPidRecord(current, this.pidRecord)
     if (!previous) {
       return
     }
     const event = { previous: { ...previous }, current: { ...current } }
     notifyAuditListeners(this.identityChangeListeners, event)
-    this.observeAuditFailure('endpoint_identity_changed', previousExactIncarnation, [
-      'endpoint_identity'
-    ])
   }
 
-  private readMatchingPidRecord(identity: DaemonEndpointIdentity): ParsedDaemonPid | null {
+  private async resolveExactDaemonIncarnation(
+    exactIncarnation: ExactDaemonIncarnation | null
+  ): Promise<ExactDaemonIncarnation | null> {
+    if (
+      !exactIncarnation ||
+      process.platform !== 'linux' ||
+      (exactIncarnation.linuxStartTicks && exactIncarnation.bootId)
+    ) {
+      return exactIncarnation
+    }
+    const cachedIncarnation = exactDaemonIncarnationForPidRecord(
+      exactIncarnation.identity,
+      this.pidRecord
+    )
+    if (cachedIncarnation.linuxStartTicks && cachedIncarnation.bootId) {
+      return cachedIncarnation
+    }
+    const pidRecord = await this.readMatchingPidRecord(exactIncarnation.identity)
+    this.pidRecord = pidRecord ?? this.pidRecord
+    return pidRecord?.linuxStartTicks && pidRecord.bootId
+      ? {
+          identity: { ...exactIncarnation.identity },
+          linuxStartTicks: pidRecord.linuxStartTicks,
+          bootId: pidRecord.bootId
+        }
+      : exactIncarnation
+  }
+
+  private cacheExactDaemonIncarnation(exactIncarnation: ExactDaemonIncarnation | null): void {
+    if (
+      exactIncarnation &&
+      this.lastAuthenticatedIdentity &&
+      sameEndpointIdentity(exactIncarnation.identity, this.lastAuthenticatedIdentity)
+    ) {
+      this.exactDaemonIncarnation = exactIncarnation
+    }
+  }
+
+  private async readMatchingPidRecord(
+    identity: DaemonEndpointIdentity
+  ): Promise<ParsedDaemonPid | null> {
     if (!this.pidPath) {
       return null
     }
     try {
-      const parsed = parseDaemonPidFile(readFileSync(this.pidPath, 'utf8'))
+      const parsed = parseDaemonPidFile(await readFile(this.pidPath, 'utf8'))
       return parsed?.pid === identity.pid &&
         parsed.startedAtMs === identity.startedAtMs &&
         parsed.launchNonce === identity.launchNonce
@@ -1679,10 +1709,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
     additionalEvidenceSources: readonly DaemonEvidenceSource[] = [],
     endpointGoneProof?: 'windows_named_pipe_missing'
   ): void {
-    void classifyDaemonAuditFailure(this.auditContext, trigger, exactIncarnation, {
-      additionalEvidenceSources,
-      endpointGoneProof
-    })
+    void this.resolveExactDaemonIncarnation(exactIncarnation)
+      .then((resolvedIncarnation) => {
+        this.cacheExactDaemonIncarnation(resolvedIncarnation)
+        return classifyDaemonAuditFailure(this.auditContext, trigger, resolvedIncarnation, {
+          additionalEvidenceSources,
+          endpointGoneProof
+        })
+      })
       .then((observation) => this.publishAuditObservation(observation))
       .catch(() => {})
   }
@@ -2301,6 +2335,37 @@ function sameEndpointIdentity(
     left.startedAtMs === right.startedAtMs &&
     left.launchNonce === right.launchNonce
   )
+}
+
+function exactDaemonIncarnationForPidRecord(
+  identity: DaemonEndpointIdentity,
+  pidRecord: ParsedDaemonPid | null
+): ExactDaemonIncarnation {
+  return {
+    identity: { ...identity },
+    ...(process.platform === 'linux' &&
+    pidRecord?.pid === identity.pid &&
+    pidRecord.startedAtMs === identity.startedAtMs &&
+    pidRecord.launchNonce === identity.launchNonce &&
+    pidRecord.linuxStartTicks &&
+    pidRecord.bootId
+      ? {
+          linuxStartTicks: pidRecord.linuxStartTicks,
+          bootId: pidRecord.bootId
+        }
+      : {})
+  }
+}
+
+function readDaemonPidRecord(pidPath: string | null): ParsedDaemonPid | null {
+  if (!pidPath) {
+    return null
+  }
+  try {
+    return parseDaemonPidFile(readFileSync(pidPath, 'utf8'))
+  } catch {
+    return null
+  }
 }
 
 function removeListener<T>(listeners: T[], listener: T): void {

--- a/src/shared/daemon-audit-eligibility.ts
+++ b/src/shared/daemon-audit-eligibility.ts
@@ -1,7 +1,6 @@
 export const DAEMON_AUDIT_STATE_VALUES = ['present', 'gone', 'unknown'] as const
 
 export const DAEMON_AUDIT_TRIGGER_VALUES = [
-  'endpoint_identity_changed',
   'inventory_answered',
   'inventory_failed',
   'token_missing_after_authenticated_disconnect',
@@ -57,7 +56,6 @@ export const DAEMON_AUDIT_GONE_REASON_VALUES = [
 
 export const DAEMON_AUDIT_REASON_VALUES = [
   'authenticated_inventory',
-  'endpoint_identity_changed',
   'inventory_failed',
   'token_missing_after_authenticated_disconnect',
   'transport_closed',


### PR DESCRIPTION
## Summary

Follow-up fixes from the retroactive review of merged PR #11606. The classifier remains audit-only and does not change daemon lifecycle, routing, retirement, or aggregate membership.

Review findings fixed:

1. Linux `/proc/<pid>/stat` `ENOENT` could override a simultaneously occupied or permission-denied PID and produce a false `gone`; contradictory evidence now stays `unknown`.
2. Windows named-pipe `ENOENT` could override a matching CIM `CreationDate` and produce a false `gone`; a matching process now keeps the classification `unknown`.
3. The Windows contradiction path reported the endpoint as present even though the triggering connect error proved the pipe missing; the observation now preserves both facts.
4. Endpoint identity replacement invoked the classifier as an undocumented fourth trigger; identity change remains an isolated observable event without process probing.
5. Exact-identity pidfile reads ran synchronously from the reconnect path reachable by spawn; the initial record is cached at adapter construction and refresh reads run asynchronously only on audit failure triggers.
6. The adapter-to-pidfile Linux tick/boot-id seam lacked integration coverage; a regression test now verifies the persisted identity reaches audit observations.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Executed with the repository-pinned Node 24:

- Full typecheck across node, CLI, and web TypeScript configs
- Normal and type-aware Oxlint on all changed files
- `pnpm run check:max-lines-ratchet` equivalent under Node 24
- Touched Vitest suites with `--config config/vitest.config.ts --maxWorkers=2`: 11 files, 347 tests passed
- Adjacent daemon lifecycle, client, server, spawner, provider, and health suites: 12 files, 148 tests passed
- Adjacent managed-hook identity suites: 2 files, 20 tests passed
- Non-vacuity mutation run: reverting seven load-bearing production behaviors produced seven expected failures across five suites; all five suites passed after restoration
- `git diff --check`

## AI Review Report

Three complete review rounds covered the full merged 26-file diff plus these fixes. Round 1 found the two false-`gone` contradictions, the extra classifier trigger, the reconnect-path synchronous pidfile read, and the missing adapter/pidfile integration assertion; round 2 found the contradictory Windows endpoint-state reporting; round 3 was clean.

The review traced every new production call site and confirmed the result remains observation-only: no adapter removal, daemon shutdown, retirement change, routing decision, aggregate membership change, timer, or polling was added. Cross-platform review covered Linux raw ticks, boot identity, zombie and procfs failure polarity; macOS weak start-time mismatch handling; Windows CIM tolerance, null command-line handling, and named-pipe absence; platform-gated `/proc` access; and path handling. There is no renderer diff, so shortcut, label, and visual review is not applicable.

## Security Audit

The evidence probes accept only authenticated daemon identity and local pidfile data. Windows command interpolation remains limited to a validated positive safe-integer PID, process inspection uses fixed executables and arguments, telemetry excludes endpoint paths, profile paths, nonces, and command lines, and audit listener/telemetry failures remain isolated from daemon operations. No dependencies, secrets, new external inputs, destructive operations, or IPC authority changes were added.

## Notes

Relevant contract lines:

> This PR must not change daemon lifecycle behavior.

> `unknown` always preserves the adapter and blocks destructive decisions.

> A signal-0 permission error proves only that some process occupies the pid — the incarnation classification stays `unknown` unless command line, start time, or nonce independently match.

> Classification runs event-driven — adapter transport close, observed authenticated disconnect plus token ENOENT, and lazily on inventory failure — never on a timer alone.

> Run the classifier without removing adapters or shutting down daemons.

> CommandLine is corroborating-only and **never a negative signal**.

> Named pipes vanish with their process: pipe presence is positive liveness evidence, pipe absence is an independent second `gone` proof.
