### PR TITLE
fix(notes-send): name send targets after their tab, not the live agent title

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.tsx
@@ -10,7 +10,7 @@ import { DashboardAgentRowTrailingControls } from './DashboardAgentRowTrailingCo
 import { DashboardAgentRowToolStep } from './DashboardAgentRowToolStep'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import type { DashboardAgentRow as DashboardAgentRowData } from './useDashboardData'
-import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import { agentRowPrimaryLabel } from '@/lib/agent-row-display-name'
 import { useAgentRowConversationName } from './use-agent-row-conversation-name'
 
 // Why: narrow the dashboard's rollup states to shared dot states, defaulting unknowns to 'idle' so a row never crashes.
@@ -157,9 +157,9 @@ const DashboardAgentRow = React.memo(function DashboardAgentRow({
   const startedAt = agent.startedAt > 0 ? agent.startedAt : null
   const doneAt = lastEnteredDoneAt(agent)
   const conversationName = useAgentRowConversationName(agent)
-  const prompt = conversationName ?? getAgentRowPrimaryText(agent.entry)
-  // Why: prompt is '' when unknown, so fall back to the state label to keep the row labeled.
-  const displayLabel = prompt || agentStateLabel(asDotState(agent.state))
+  // Why: the name is '' when unknown, so fall back to the state label to keep the row labeled.
+  const displayLabel =
+    agentRowPrimaryLabel(agent, conversationName) || agentStateLabel(asDotState(agent.state))
   const model = agent.entry.model?.trim() ?? ''
   // Why: gate tool fields on 'working' — a stale tool line on a done row reads as still-running.
   const isWorking = agent.state === 'working'

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -16,6 +16,7 @@ import {
 } from './dashboard-card-terminal-input'
 import { readDashboardClientHost } from './dashboard-client-host'
 import { getAgentRowConversationName } from '../../../../shared/agent-row-conversation-name'
+import { agentRowOwnsTabName } from '@/lib/agent-row-display-name'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { applyAgentRowLineage } from './agent-row-lineage'
 import { lastEnteredDoneAt } from './agent-finished-timestamp'
@@ -98,19 +99,13 @@ function boundedLabelOrUndefined(value: string | undefined): string | undefined 
   return value === undefined ? undefined : boundedLabel(value)
 }
 
-/** Mirrors useAgentRowConversationName so the board and the sidebar label the
- *  same agent with the same name. */
+/** Shares agentRowOwnsTabName with the sidebar so the board and the sidebar
+ *  label the same agent with the same name. */
 function rowConversationName(
   row: DashboardAgentRow,
   generatedTitlesEnabled: boolean
 ): string | undefined {
-  const parentPaneKey = row.entry.orchestration?.parentPaneKey
-  // Why: a child row rendered on its parent's tab does not own that tab's name.
-  if (
-    row.lineage?.depth === 1 &&
-    parentPaneKey !== undefined &&
-    parsePaneKey(parentPaneKey)?.tabId === row.tab.id
-  ) {
+  if (!agentRowOwnsTabName(row)) {
     return undefined
   }
   return getAgentRowConversationName(row.tab, row.agentType, generatedTitlesEnabled) ?? undefined

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
@@ -1,5 +1,5 @@
 import { getAgentRowConversationName } from '../../../../shared/agent-row-conversation-name'
-import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { agentRowOwnsTabName } from '@/lib/agent-row-display-name'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import type { DashboardAgentRow } from './useDashboardData'
@@ -25,12 +25,7 @@ function getIndexedTab(
 
 /** The row's conversation name, or null when nothing usable exists. */
 export function useAgentRowConversationName(agent: DashboardAgentRow): string | null {
-  const parentPaneKey = agent.entry.orchestration?.parentPaneKey
-  const usesParentTab =
-    agent.lineage?.depth === 1 &&
-    parentPaneKey !== undefined &&
-    parsePaneKey(parentPaneKey)?.tabId === agent.tab.id
-  const cannotOwnTabName = agent.rowSource === 'subagent' || usesParentTab
+  const cannotOwnTabName = !agentRowOwnsTabName(agent)
   const generatedTitlesEnabled = useAppStore(
     (s) => !cannotOwnTabName && s.settings?.tabAutoGenerateTitle === true
   )

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -1,20 +1,27 @@
-import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
 import type { TuiAgent } from '../../../../shared/types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
 import { ReviewNotesSendMenuContent } from './ReviewNotesSendMenuContent'
+import {
+  buildSingleTargetScenario,
+  collectText,
+  createAgentRowFactory,
+  expand,
+  findAllByType,
+  findByType,
+  leafLayout,
+  sendTargetRowText,
+  tab,
+  JUNK_TITLES,
+  type SingleTargetScenario,
+  LEAF_A,
+  LEAF_B,
+  TAB_A,
+  TAB_B
+} from './notes-send-menu-test-fixtures'
 
-type ReactElementLike = {
-  type: unknown
-  props: Record<string, unknown>
-}
-
-const TAB_A = 'tab-a'
-const TAB_B = 'tab-b'
-const LEAF_A = '11111111-1111-4111-8111-111111111111'
-const LEAF_B = '22222222-2222-4222-8222-222222222222'
+const agentRow = createAgentRowFactory(600_000)
 
 const hookRuntime = vi.hoisted(() => ({
   states: [] as unknown[],
@@ -33,7 +40,7 @@ const harness = vi.hoisted(() => ({
     tabId: string
     leafId: string
     agentType: TuiAgent
-    tabTitle: string
+    tab: ReturnType<typeof tab>
     status: 'eligible' | 'disabled'
     disabledReason?: string
   }[],
@@ -171,72 +178,6 @@ vi.mock('sonner', () => ({
   }
 }))
 
-function agentEntry(
-  paneKey: string,
-  agentType: TuiAgent,
-  state: AgentStatusState = 'done',
-  stateStartedAt = harness.now
-): AgentStatusEntry {
-  return {
-    paneKey,
-    state,
-    prompt: '',
-    updatedAt: stateStartedAt,
-    stateStartedAt,
-    agentType,
-    stateHistory: []
-  }
-}
-
-function agentRow({
-  paneKey,
-  tabId,
-  title,
-  agentType,
-  state = 'done',
-  startedAt = harness.now
-}: {
-  paneKey: string
-  tabId: string
-  title: string
-  agentType: TuiAgent
-  state?: AgentStatusState | 'idle'
-  startedAt?: number
-}): DashboardAgentRowData {
-  const entryState: AgentStatusState = state === 'idle' ? 'working' : state
-  return {
-    paneKey,
-    entry: agentEntry(paneKey, agentType, entryState, startedAt),
-    tab: tab(tabId, { title }) as DashboardAgentRowData['tab'],
-    agentType,
-    state,
-    startedAt
-  }
-}
-
-function tab(id: string, overrides: Record<string, unknown> = {}) {
-  return {
-    id,
-    worktreeId: 'wt-1',
-    ptyId: null,
-    title: id,
-    customTitle: null,
-    color: null,
-    sortOrder: 0,
-    createdAt: 1,
-    ...overrides
-  }
-}
-
-function leafLayout(leafId: string, ptyId: string) {
-  return {
-    root: { type: 'leaf', leafId },
-    activeLeafId: leafId,
-    expandedLeafId: null,
-    ptyIdsByLeafId: { [leafId]: ptyId }
-  }
-}
-
 function setStore(overrides: Record<string, unknown> = {}): void {
   harness.storeState = {
     activeWorktreeId: 'wt-1',
@@ -248,81 +189,6 @@ function setStore(overrides: Record<string, unknown> = {}): void {
     runtimePaneTitlesByTabId: {},
     ...overrides
   }
-}
-
-function expand(node: unknown): unknown {
-  if (node == null || typeof node === 'string' || typeof node === 'number') {
-    return node
-  }
-  if (Array.isArray(node)) {
-    return node.map((entry) => expand(entry))
-  }
-  if (!React.isValidElement(node)) {
-    if (typeof node === 'object' && 'props' in node) {
-      const element = node as ReactElementLike
-      return { ...element, props: { ...element.props, children: expand(element.props.children) } }
-    }
-    return node
-  }
-  const element = node as React.ReactElement<Record<string, unknown>>
-  if (typeof element.type === 'function') {
-    const Component = element.type as (props: Record<string, unknown>) => unknown
-    return expand(Component(element.props))
-  }
-  return {
-    type: element.type,
-    props: { ...element.props, children: expand(element.props.children) }
-  }
-}
-
-function visit(node: unknown, cb: (node: ReactElementLike) => void): void {
-  if (node == null || typeof node === 'string' || typeof node === 'number') {
-    return
-  }
-  if (Array.isArray(node)) {
-    node.forEach((entry) => visit(entry, cb))
-    return
-  }
-  const element = node as ReactElementLike
-  cb(element)
-  if (element.props?.children) {
-    visit(element.props.children, cb)
-  }
-}
-
-function findAllByType(node: unknown, type: unknown): ReactElementLike[] {
-  const found: ReactElementLike[] = []
-  visit(node, (entry) => {
-    if (entry.type === type) {
-      found.push(entry)
-    }
-  })
-  return found
-}
-
-function findByType(node: unknown, type: unknown): ReactElementLike {
-  const found = findAllByType(node, type)[0]
-  if (!found) {
-    throw new Error(`element not found: ${String(type)}`)
-  }
-  return found
-}
-
-function collectText(node: unknown): string {
-  if (node == null || typeof node === 'boolean') {
-    return ''
-  }
-  if (typeof node === 'string') {
-    return node
-  }
-  if (typeof node === 'number') {
-    return String(node)
-  }
-  if (Array.isArray(node)) {
-    return node.map(collectText).join('')
-  }
-  const element = node as ReactElementLike
-  return collectText(element.props?.children)
 }
 
 function render(props: Record<string, unknown> = {}): unknown {
@@ -371,7 +237,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'eligible'
       },
       {
@@ -379,7 +245,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_B,
         leafId: LEAF_B,
         agentType: 'codex',
-        tabTitle: 'Codex',
+        tab: tab(TAB_B),
         status: 'eligible'
       }
     ]
@@ -393,68 +259,174 @@ describe('ReviewNotesSendMenuContent', () => {
     expect(collectText(items[1])).toContain('Codex')
   })
 
+  function renderSingleTarget(scenario: SingleTargetScenario): { name: string; detail: string } {
+    const built = buildSingleTargetScenario(scenario, makePaneKey(TAB_A, LEAF_A), agentRow)
+    harness.worktreeAgentRows = built.agentRows
+    setStore(built.store)
+    harness.noteTargets = built.noteTargets as typeof harness.noteTargets
+    return sendTargetRowText(findByType(render(), 'DropdownMenuItem'))
+  }
+
   it('leads with the tab name and demotes the agent harness to the detail line', () => {
-    const paneKey = makePaneKey(TAB_A, LEAF_A)
-    harness.worktreeAgentRows = [
-      agentRow({
-        paneKey,
-        tabId: TAB_A,
-        title: 'teste',
-        agentType: 'claude',
-        state: 'idle',
-        startedAt: harness.now
-      })
-    ]
-    setStore({
-      tabsByWorktree: { 'wt-1': [tab(TAB_A, { title: 'teste' })] },
-      terminalLayoutsByTabId: { [TAB_A]: leafLayout(LEAF_A, 'pty-a') }
-    })
-    harness.noteTargets = [
-      {
-        paneKey,
-        tabId: TAB_A,
-        leafId: LEAF_A,
-        agentType: 'claude',
-        tabTitle: 'teste',
-        status: 'eligible'
-      }
-    ]
+    const row = renderSingleTarget({ title: 'teste', agentType: 'claude' })
 
-    const spans = findAllByType(findByType(render(), 'DropdownMenuItem'), 'span')
-    const primary = spans.find((span) => span.props.className === 'truncate')
-    const secondary = spans.find((span) =>
-      String(span.props.className ?? '').includes('text-muted-foreground')
-    )
-
-    expect(collectText(primary)).toBe('teste')
-    expect(collectText(secondary)).toBe('Claude · Idle · just now')
+    expect(row.name).toBe('teste')
+    expect(row.detail).toBe('Claude · Idle · just now')
   })
 
-  it('falls back to the agent label when the target has no tab name', () => {
-    const paneKey = makePaneKey(TAB_A, LEAF_A)
-    setStore({
-      tabsByWorktree: { 'wt-1': [tab(TAB_A, { title: '' })] },
-      terminalLayoutsByTabId: { [TAB_A]: leafLayout(LEAF_A, 'pty-a') }
-    })
-    harness.noteTargets = [
-      {
-        paneKey,
-        tabId: TAB_A,
-        leafId: LEAF_A,
-        agentType: 'claude',
-        tabTitle: '',
-        status: 'eligible'
-      }
-    ]
+  it.each(JUNK_TITLES)(
+    'falls through a %s to what the agent is working on',
+    (_case, title, agentType) => {
+      const row = renderSingleTarget({ title, agentType, prompt: 'fix the login bug' })
 
-    const spans = findAllByType(findByType(render(), 'DropdownMenuItem'), 'span')
-    const primary = spans.find((span) => span.props.className === 'truncate')
-    const secondary = spans.find((span) =>
-      String(span.props.className ?? '').includes('text-muted-foreground')
+      expect(row.name).toBe('fix the login bug')
+    }
+  )
+
+  it.each(JUNK_TITLES)(
+    'falls through a %s to the tab ordinal when there is no live work',
+    (_case, title, agentType) => {
+      const row = renderSingleTarget({ title, agentType })
+
+      expect(row.name).toBe('Terminal 3')
+    }
+  )
+
+  it('falls through to the tab ordinal for a title-hint target with no agent row', () => {
+    const row = renderSingleTarget({
+      title: '✳ Claude',
+      agentType: 'claude',
+      withAgentRow: false
+    })
+
+    expect(row.name).toBe('Terminal 3')
+    expect(row.detail).toBe('Claude · Idle')
+  })
+
+  it('keeps a manual rename, a quick-command label, and a generated title', () => {
+    expect(
+      renderSingleTarget({
+        title: '✳ Add validation',
+        agentType: 'claude',
+        prompt: 'fix the login bug',
+        tabOverrides: { customTitle: 'Designer' }
+      }).name
+    ).toBe('Designer')
+    expect(
+      renderSingleTarget({
+        title: '✳ Add validation',
+        agentType: 'claude',
+        prompt: 'fix the login bug',
+        tabOverrides: { quickCommandLabel: 'Run tests' }
+      }).name
+    ).toBe('Run tests')
+    expect(
+      renderSingleTarget({
+        title: 'Codex ready',
+        agentType: 'codex',
+        prompt: 'fix the login bug',
+        tabOverrides: { generatedTitle: 'Refactor auth' },
+        generatedTitlesEnabled: true
+      }).name
+    ).toBe('Refactor auth')
+    // Why: with the setting off the generated title must not resurface — and the
+    // stale synthetic status behind it is not a name either.
+    expect(
+      renderSingleTarget({
+        title: 'Codex ready',
+        agentType: 'codex',
+        prompt: 'fix the login bug',
+        tabOverrides: { generatedTitle: 'Refactor auth' }
+      }).name
+    ).toBe('fix the login bug')
+  })
+
+  it('keeps three unnamed idle tabs distinguishable by their ordinals', () => {
+    const tabs = [
+      { tabId: TAB_A, leafId: LEAF_A, ordinal: 'Terminal 3' },
+      { tabId: TAB_B, leafId: LEAF_B, ordinal: 'Terminal 4' },
+      { tabId: 'tab-c', leafId: '33333333-3333-4333-8333-333333333333', ordinal: 'Terminal 5' }
+    ]
+    harness.worktreeAgentRows = []
+    setStore({
+      tabsByWorktree: {
+        'wt-1': tabs.map((t) => tab(t.tabId, { title: '✳ Claude', defaultTitle: t.ordinal }))
+      },
+      terminalLayoutsByTabId: Object.fromEntries(
+        tabs.map((t) => [t.tabId, leafLayout(t.leafId, `pty-${t.tabId}`)])
+      )
+    })
+    harness.noteTargets = tabs.map((t) => ({
+      paneKey: makePaneKey(t.tabId, t.leafId),
+      tabId: t.tabId,
+      leafId: t.leafId,
+      agentType: 'claude' as TuiAgent,
+      tab: tab(t.tabId, { title: '✳ Claude', defaultTitle: t.ordinal }),
+      status: 'eligible' as const
+    }))
+
+    const names = findAllByType(render(), 'DropdownMenuItem').map(
+      (item) => sendTargetRowText(item).name
     )
 
-    expect(collectText(primary)).toBe('Claude')
-    expect(collectText(secondary)).toBe('Idle')
+    expect(names).toEqual(['Terminal 3', 'Terminal 4', 'Terminal 5'])
+  })
+
+  it('does not repeat the parent tab name on a same-tab child row', () => {
+    const parentPaneKey = makePaneKey(TAB_A, LEAF_A)
+    const childPaneKey = makePaneKey(TAB_A, LEAF_B)
+    const parentTab = tab(TAB_A, { customTitle: 'Designer' })
+    const child = agentRow({
+      paneKey: childPaneKey,
+      tabId: TAB_A,
+      title: '✳ Claude',
+      agentType: 'claude',
+      state: 'idle',
+      prompt: 'write the docs',
+      tabOverrides: { customTitle: 'Designer' }
+    })
+    child.lineage = { depth: 1, isFirstSibling: true, isLastSibling: true, childCount: 0 }
+    child.entry.orchestration = { parentPaneKey, taskId: 'task-1', dispatchId: 'dispatch-1' }
+    harness.worktreeAgentRows = [
+      agentRow({
+        paneKey: parentPaneKey,
+        tabId: TAB_A,
+        title: '✳ Claude',
+        agentType: 'claude',
+        state: 'idle',
+        tabOverrides: { customTitle: 'Designer' }
+      }),
+      child
+    ]
+    setStore({
+      tabsByWorktree: { 'wt-1': [parentTab] },
+      terminalLayoutsByTabId: { [TAB_A]: leafLayout(LEAF_A, 'pty-a') }
+    })
+    harness.noteTargets = [parentPaneKey, childPaneKey].map((paneKey, index) => ({
+      paneKey,
+      tabId: TAB_A,
+      leafId: index === 0 ? LEAF_A : LEAF_B,
+      agentType: 'claude' as TuiAgent,
+      tab: parentTab,
+      status: 'eligible' as const
+    }))
+
+    const names = findAllByType(render(), 'DropdownMenuItem').map(
+      (item) => sendTargetRowText(item).name
+    )
+
+    expect(names).toEqual(['Designer', 'write the docs'])
+  })
+
+  it('promotes the harness label when the target has no name at all', () => {
+    const row = renderSingleTarget({
+      title: '',
+      agentType: 'claude',
+      tabOverrides: { defaultTitle: undefined }
+    })
+
+    expect(row.name).toBe('Claude')
+    expect(row.detail).toBe('Idle · just now')
   })
 
   it('orders send targets by the current worktree agent rows and shows status timing', () => {
@@ -491,7 +463,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'First session',
+        tab: tab(TAB_A, { title: 'First session' }),
         status: 'eligible'
       },
       {
@@ -499,7 +471,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_B,
         leafId: LEAF_B,
         agentType: 'codex',
-        tabTitle: 'Second session',
+        tab: tab(TAB_B, { title: 'Second session' }),
         status: 'eligible'
       }
     ]
@@ -563,7 +535,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_B,
         leafId: LEAF_B,
         agentType: 'codex',
-        tabTitle: 'Codex',
+        tab: tab(TAB_B),
         status: 'disabled',
         disabledReason: 'Agent needs permission'
       }
@@ -618,7 +590,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'eligible'
       }
     ]
@@ -644,7 +616,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'codex',
-        tabTitle: 'Codex',
+        tab: tab(TAB_A),
         status: 'disabled',
         disabledReason: 'Agent status is stale'
       }
@@ -671,7 +643,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'eligible'
       }
     ]
@@ -707,7 +679,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'eligible'
       }
     ]
@@ -735,7 +707,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'eligible'
       }
     ]
@@ -761,7 +733,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'eligible'
       }
     ]
@@ -773,7 +745,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'disabled',
         disabledReason: 'Agent status is stale'
       }
@@ -797,7 +769,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'eligible'
       }
     ]
@@ -823,7 +795,7 @@ describe('ReviewNotesSendMenuContent', () => {
         tabId: TAB_A,
         leafId: LEAF_A,
         agentType: 'claude',
-        tabTitle: 'Terminal 1',
+        tab: tab(TAB_A),
         status: 'eligible'
       }
     ]

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.test.tsx
@@ -393,6 +393,70 @@ describe('ReviewNotesSendMenuContent', () => {
     expect(collectText(items[1])).toContain('Codex')
   })
 
+  it('leads with the tab name and demotes the agent harness to the detail line', () => {
+    const paneKey = makePaneKey(TAB_A, LEAF_A)
+    harness.worktreeAgentRows = [
+      agentRow({
+        paneKey,
+        tabId: TAB_A,
+        title: 'teste',
+        agentType: 'claude',
+        state: 'idle',
+        startedAt: harness.now
+      })
+    ]
+    setStore({
+      tabsByWorktree: { 'wt-1': [tab(TAB_A, { title: 'teste' })] },
+      terminalLayoutsByTabId: { [TAB_A]: leafLayout(LEAF_A, 'pty-a') }
+    })
+    harness.noteTargets = [
+      {
+        paneKey,
+        tabId: TAB_A,
+        leafId: LEAF_A,
+        agentType: 'claude',
+        tabTitle: 'teste',
+        status: 'eligible'
+      }
+    ]
+
+    const spans = findAllByType(findByType(render(), 'DropdownMenuItem'), 'span')
+    const primary = spans.find((span) => span.props.className === 'truncate')
+    const secondary = spans.find((span) =>
+      String(span.props.className ?? '').includes('text-muted-foreground')
+    )
+
+    expect(collectText(primary)).toBe('teste')
+    expect(collectText(secondary)).toBe('Claude · Idle · just now')
+  })
+
+  it('falls back to the agent label when the target has no tab name', () => {
+    const paneKey = makePaneKey(TAB_A, LEAF_A)
+    setStore({
+      tabsByWorktree: { 'wt-1': [tab(TAB_A, { title: '' })] },
+      terminalLayoutsByTabId: { [TAB_A]: leafLayout(LEAF_A, 'pty-a') }
+    })
+    harness.noteTargets = [
+      {
+        paneKey,
+        tabId: TAB_A,
+        leafId: LEAF_A,
+        agentType: 'claude',
+        tabTitle: '',
+        status: 'eligible'
+      }
+    ]
+
+    const spans = findAllByType(findByType(render(), 'DropdownMenuItem'), 'span')
+    const primary = spans.find((span) => span.props.className === 'truncate')
+    const secondary = spans.find((span) =>
+      String(span.props.className ?? '').includes('text-muted-foreground')
+    )
+
+    expect(collectText(primary)).toBe('Claude')
+    expect(collectText(secondary)).toBe('Idle')
+  })
+
   it('orders send targets by the current worktree agent rows and shows status timing', () => {
     const paneKeyA = makePaneKey(TAB_A, LEAF_A)
     const paneKeyB = makePaneKey(TAB_B, LEAF_B)

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -25,6 +25,9 @@ import {
   formatAgentTypeLabel,
   agentTypeToIconAgent
 } from '@/lib/agent-status'
+import { agentRowOwnsTabName, agentRowPrimaryLabel } from '@/lib/agent-row-display-name'
+import { getAgentRowConversationName } from '../../../../shared/agent-row-conversation-name'
+import type { AgentType } from '../../../../shared/agent-status-types'
 import { track } from '@/lib/telemetry'
 import { useNow } from '@/components/dashboard/useNow'
 import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
@@ -37,6 +40,7 @@ import { translate } from '@/i18n/i18n'
 type OrderedSendTarget = {
   target: NotesSendAgentTarget
   agent: DashboardAgentRowData | null
+  name: string
 }
 
 export function ReviewNotesSendMenuContent({
@@ -76,8 +80,7 @@ export function ReviewNotesSendMenuContent({
         tabsByWorktree,
         terminalLayoutsByTabId,
         ptyIdsByTabId,
-        runtimePaneTitlesByTabId,
-        generatedTabTitlesEnabled
+        runtimePaneTitlesByTabId
       },
       worktreeId
     )
@@ -90,12 +93,11 @@ export function ReviewNotesSendMenuContent({
     terminalLayoutsByTabId,
     runtimePaneTitlesByTabId,
     ptyIdsByTabId,
-    generatedTabTitlesEnabled,
     worktreeId
   ])
   const orderedSendTargets = useMemo(
-    () => orderSendTargetsByWorktreeAgentRows(sendTargets, agentRows),
-    [agentRows, sendTargets]
+    () => orderSendTargetsByWorktreeAgentRows(sendTargets, agentRows, generatedTabTitlesEnabled),
+    [agentRows, sendTargets, generatedTabTitlesEnabled]
   )
 
   const runNotesSend = useCallback(
@@ -186,11 +188,12 @@ export function ReviewNotesSendMenuContent({
       <DropdownMenuLabel>
         {translate('auto.components.editor.ReviewNotesSendMenuContent.03378aea75', 'Send notes to')}
       </DropdownMenuLabel>
-      {orderedSendTargets.map(({ target, agent }) => (
+      {orderedSendTargets.map(({ target, agent, name }) => (
         <AgentTargetMenuItem
           key={target.paneKey}
           target={target}
           agent={agent}
+          name={name}
           now={now}
           disabled={!hasPrompt || target.status !== 'eligible'}
           onSend={sendToAgentTarget}
@@ -217,13 +220,9 @@ function resolveCurrentSendTargetEligibility(
   target: NotesSendAgentTarget,
   worktreeId: string
 ): { status: 'eligible' } | { status: 'disabled'; disabledReason: string } {
-  const state = useAppStore.getState()
-  // Why: this re-check only reads eligibility, but pass the title flag anyway so
-  // it can never derive a different label than the row the user just clicked.
-  const currentTarget = deriveNotesSendAgentTargets(
-    { ...state, generatedTabTitlesEnabled: state.settings?.tabAutoGenerateTitle === true },
-    worktreeId
-  ).find((candidate) => candidate.paneKey === target.paneKey)
+  const currentTarget = deriveNotesSendAgentTargets(useAppStore.getState(), worktreeId).find(
+    (candidate) => candidate.paneKey === target.paneKey
+  )
   if (currentTarget) {
     return currentTarget.status === 'eligible'
       ? { status: 'eligible' }
@@ -239,42 +238,54 @@ function resolveCurrentSendTargetEligibility(
 function AgentTargetMenuItem({
   target,
   agent,
+  name,
   now,
   disabled,
   onSend
 }: {
   target: NotesSendAgentTarget
   agent: DashboardAgentRowData | null
+  name: string
   now: number
   disabled: boolean
   onSend: (target: NotesSendAgentTarget) => void
 }): React.JSX.Element {
-  const tabTitle = target.tabTitle.trim()
   const state = asDotState(agent?.state ?? 'idle')
   const timeAgo = agent ? formatAgentRelativeTime(agent, now) : null
   const agentLabel = formatAgentTypeLabel(target.agentType ?? agent?.agentType)
-  // Why: the tab name is what the user picks between — several targets can share
-  // the same harness — so it leads and the harness drops to the detail line.
+  // Why: the name is what the user picks between — several targets can share the
+  // same harness — so it leads and the harness drops to the detail line. With no
+  // name the harness label moves up rather than being repeated on both lines.
   const secondaryParts = [
-    ...(tabTitle ? [agentLabel] : []),
+    ...(name ? [agentLabel] : []),
     agentStateLabel(state),
     ...(timeAgo ? [timeAgo] : [])
   ]
+  const disabledReason = target.status === 'disabled' ? target.disabledReason : undefined
   return (
     <DropdownMenuItem
       disabled={disabled}
       onSelect={() => onSend(target)}
       // Why: surface the ineligibility reason (permission/stale/no-terminal) as a
       // hover tooltip rather than inline text, matching DashboardAgentRow's
-      // title-attribute treatment of the same disabledReason.
-      title={target.status === 'disabled' ? target.disabledReason : undefined}
+      // title-attribute treatment of the same disabledReason. The name can be a
+      // live prompt, so it needs the same hover treatment once it is elided.
+      title={disabledReason ?? (name || undefined)}
       className="min-w-[240px] gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
     >
       <AgentStateDot state={state} size="sm" className="shrink-0" />
       <AgentIcon agent={agentTypeToIconAgent(target.agentType ?? agent?.agentType)} size={14} />
-      <span className="grid min-w-0 flex-1 text-left">
-        <span className="truncate">{tabTitle || agentLabel}</span>
-        <span className="truncate text-[11px] font-normal text-muted-foreground">
+      {/* Why: the menu has no max width, so an unbounded name would widen the
+          whole dropdown instead of eliding — bound it the way every other menu
+          label does (TabBarQuickCommandsMenu, PRFilterDropdowns). */}
+      <span className="grid max-w-[240px] min-w-0 flex-1 text-left">
+        <span className="truncate" data-testid="send-target-name">
+          {name || agentLabel}
+        </span>
+        <span
+          className="truncate text-[11px] font-normal text-muted-foreground"
+          data-testid="send-target-detail"
+        >
           {secondaryParts.join(' · ')}
         </span>
       </span>
@@ -282,9 +293,31 @@ function AgentTargetMenuItem({
   )
 }
 
+// Why: the row already carries the provider icon and harness name, so a title
+// that only echoes identity or status is no name at all. Fall through to what
+// the agent is working on — the same text the sidebar row shows for it — and
+// then to the tab's stable ordinal so two unnamed idle tabs stay distinct.
+function sendTargetName(
+  target: NotesSendAgentTarget,
+  agent: DashboardAgentRowData | null,
+  agentType: AgentType | null | undefined,
+  generatedTitlesEnabled: boolean
+): string {
+  const conversationName =
+    agent && !agentRowOwnsTabName(agent)
+      ? null
+      : getAgentRowConversationName(target.tab, agentType, generatedTitlesEnabled)
+  const named = agent ? agentRowPrimaryLabel(agent, conversationName) : (conversationName ?? '')
+  return named.trim() || target.tab.defaultTitle?.trim() || ''
+}
+
+// Why: names resolve here, not in the derivation — this is the only place the
+// agent type is reconciled against the row that renders, so a name resolved
+// against a different harness than the row shows is impossible by construction.
 function orderSendTargetsByWorktreeAgentRows(
   sendTargets: NotesSendAgentTarget[],
-  agentRows: DashboardAgentRowData[]
+  agentRows: DashboardAgentRowData[],
+  generatedTitlesEnabled: boolean
 ): OrderedSendTarget[] {
   const targetsByPaneKey = new Map(sendTargets.map((target) => [target.paneKey, target]))
   const usedPaneKeys = new Set<string>()
@@ -295,13 +328,22 @@ function orderSendTargetsByWorktreeAgentRows(
     if (!target) {
       continue
     }
-    ordered.push({ target: { ...target, agentType: agent.agentType }, agent })
+    const reconciled = { ...target, agentType: agent.agentType }
+    ordered.push({
+      target: reconciled,
+      agent,
+      name: sendTargetName(reconciled, agent, agent.agentType, generatedTitlesEnabled)
+    })
     usedPaneKeys.add(target.paneKey)
   }
 
   for (const target of sendTargets) {
     if (!usedPaneKeys.has(target.paneKey)) {
-      ordered.push({ target, agent: null })
+      ordered.push({
+        target,
+        agent: null,
+        name: sendTargetName(target, null, target.agentType, generatedTitlesEnabled)
+      })
     }
   }
 

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -64,6 +64,7 @@ export function ReviewNotesSendMenuContent({
   const terminalLayoutsByTabId = useAppStore((s) => s.terminalLayoutsByTabId)
   const ptyIdsByTabId = useAppStore(useShallow((s) => selectLivePtyIdsForWorktree(s, worktreeId)))
   const runtimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
+  const settings = useAppStore((s) => s.settings)
   const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
   const agentRows = useWorktreeAgentRows(worktreeId)
   const now = useNow(30_000)
@@ -75,7 +76,8 @@ export function ReviewNotesSendMenuContent({
         tabsByWorktree,
         terminalLayoutsByTabId,
         ptyIdsByTabId,
-        runtimePaneTitlesByTabId
+        runtimePaneTitlesByTabId,
+        settings
       },
       worktreeId
     )
@@ -88,6 +90,7 @@ export function ReviewNotesSendMenuContent({
     terminalLayoutsByTabId,
     runtimePaneTitlesByTabId,
     ptyIdsByTabId,
+    settings,
     worktreeId
   ])
   const orderedSendTargets = useMemo(
@@ -246,10 +249,13 @@ function AgentTargetMenuItem({
   const tabTitle = target.tabTitle.trim()
   const state = asDotState(agent?.state ?? 'idle')
   const timeAgo = agent ? formatAgentRelativeTime(agent, now) : null
+  const agentLabel = formatAgentTypeLabel(target.agentType ?? agent?.agentType)
+  // Why: the tab name is what the user picks between — several targets can share
+  // the same harness — so it leads and the harness drops to the detail line.
   const secondaryParts = [
+    ...(tabTitle ? [agentLabel] : []),
     agentStateLabel(state),
-    ...(timeAgo ? [timeAgo] : []),
-    ...(tabTitle ? [tabTitle] : [])
+    ...(timeAgo ? [timeAgo] : [])
   ]
   return (
     <DropdownMenuItem
@@ -264,9 +270,7 @@ function AgentTargetMenuItem({
       <AgentStateDot state={state} size="sm" className="shrink-0" />
       <AgentIcon agent={agentTypeToIconAgent(target.agentType ?? agent?.agentType)} size={14} />
       <span className="grid min-w-0 flex-1 text-left">
-        <span className="truncate">
-          {formatAgentTypeLabel(target.agentType ?? agent?.agentType)}
-        </span>
+        <span className="truncate">{tabTitle || agentLabel}</span>
         <span className="truncate text-[11px] font-normal text-muted-foreground">
           {secondaryParts.join(' · ')}
         </span>

--- a/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
+++ b/src/renderer/src/components/editor/ReviewNotesSendMenuContent.tsx
@@ -64,7 +64,7 @@ export function ReviewNotesSendMenuContent({
   const terminalLayoutsByTabId = useAppStore((s) => s.terminalLayoutsByTabId)
   const ptyIdsByTabId = useAppStore(useShallow((s) => selectLivePtyIdsForWorktree(s, worktreeId)))
   const runtimePaneTitlesByTabId = useAppStore((s) => s.runtimePaneTitlesByTabId)
-  const settings = useAppStore((s) => s.settings)
+  const generatedTabTitlesEnabled = useAppStore((s) => s.settings?.tabAutoGenerateTitle === true)
   const agentStatusEpoch = useAppStore((s) => s.agentStatusEpoch)
   const agentRows = useWorktreeAgentRows(worktreeId)
   const now = useNow(30_000)
@@ -77,7 +77,7 @@ export function ReviewNotesSendMenuContent({
         terminalLayoutsByTabId,
         ptyIdsByTabId,
         runtimePaneTitlesByTabId,
-        settings
+        generatedTabTitlesEnabled
       },
       worktreeId
     )
@@ -90,7 +90,7 @@ export function ReviewNotesSendMenuContent({
     terminalLayoutsByTabId,
     runtimePaneTitlesByTabId,
     ptyIdsByTabId,
-    settings,
+    generatedTabTitlesEnabled,
     worktreeId
   ])
   const orderedSendTargets = useMemo(
@@ -218,9 +218,12 @@ function resolveCurrentSendTargetEligibility(
   worktreeId: string
 ): { status: 'eligible' } | { status: 'disabled'; disabledReason: string } {
   const state = useAppStore.getState()
-  const currentTarget = deriveNotesSendAgentTargets(state, worktreeId).find(
-    (candidate) => candidate.paneKey === target.paneKey
-  )
+  // Why: this re-check only reads eligibility, but pass the title flag anyway so
+  // it can never derive a different label than the row the user just clicked.
+  const currentTarget = deriveNotesSendAgentTargets(
+    { ...state, generatedTabTitlesEnabled: state.settings?.tabAutoGenerateTitle === true },
+    worktreeId
+  ).find((candidate) => candidate.paneKey === target.paneKey)
   if (currentTarget) {
     return currentTarget.status === 'eligible'
       ? { status: 'eligible' }

--- a/src/renderer/src/components/editor/notes-send-menu-test-fixtures.ts
+++ b/src/renderer/src/components/editor/notes-send-menu-test-fixtures.ts
@@ -1,0 +1,245 @@
+// Shared fixtures and React-tree walkers for the notes send-menu tests. The
+// vi.mock preamble stays per test file; everything here is pure.
+import React from 'react'
+import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
+import type { TuiAgent } from '../../../../shared/types'
+import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
+
+export type ReactElementLike = {
+  type: unknown
+  props: Record<string, unknown>
+}
+
+export const TAB_A = 'tab-a'
+export const TAB_B = 'tab-b'
+export const LEAF_A = '11111111-1111-4111-8111-111111111111'
+export const LEAF_B = '22222222-2222-4222-8222-222222222222'
+
+export function agentEntry(
+  paneKey: string,
+  agentType: TuiAgent,
+  state: AgentStatusState,
+  stateStartedAt: number,
+  prompt = ''
+): AgentStatusEntry {
+  return {
+    paneKey,
+    state,
+    prompt,
+    updatedAt: stateStartedAt,
+    stateStartedAt,
+    agentType,
+    stateHistory: []
+  }
+}
+
+export function tab(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    worktreeId: 'wt-1',
+    ptyId: null,
+    title: id,
+    defaultTitle: 'Terminal 3',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ...overrides
+  }
+}
+
+/** Bound to the harness clock so callers can omit `startedAt`. */
+export function createAgentRowFactory(defaultStartedAt: number) {
+  return function agentRow({
+    paneKey,
+    tabId,
+    title,
+    agentType,
+    state = 'done',
+    startedAt = defaultStartedAt,
+    prompt = '',
+    tabOverrides = {}
+  }: {
+    paneKey: string
+    tabId: string
+    title: string
+    agentType: TuiAgent
+    state?: AgentStatusState | 'idle'
+    startedAt?: number
+    prompt?: string
+    tabOverrides?: Record<string, unknown>
+  }): DashboardAgentRowData {
+    const entryState: AgentStatusState = state === 'idle' ? 'working' : state
+    return {
+      paneKey,
+      entry: agentEntry(paneKey, agentType, entryState, startedAt, prompt),
+      tab: tab(tabId, { title, ...tabOverrides }) as DashboardAgentRowData['tab'],
+      agentType,
+      state,
+      startedAt
+    }
+  }
+}
+
+export function leafLayout(leafId: string, ptyId: string) {
+  return {
+    root: { type: 'leaf', leafId },
+    activeLeafId: leafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId: { [leafId]: ptyId }
+  }
+}
+
+/** Render function components down to a plain host-element tree. */
+export function expand(node: unknown): unknown {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return node
+  }
+  if (Array.isArray(node)) {
+    return node.map((entry) => expand(entry))
+  }
+  if (!React.isValidElement(node)) {
+    if (typeof node === 'object' && 'props' in node) {
+      const element = node as ReactElementLike
+      return { ...element, props: { ...element.props, children: expand(element.props.children) } }
+    }
+    return node
+  }
+  const element = node as React.ReactElement<Record<string, unknown>>
+  if (typeof element.type === 'function') {
+    const Component = element.type as (props: Record<string, unknown>) => unknown
+    return expand(Component(element.props))
+  }
+  return {
+    type: element.type,
+    props: { ...element.props, children: expand(element.props.children) }
+  }
+}
+
+function visit(node: unknown, cb: (node: ReactElementLike) => void): void {
+  if (node == null || typeof node === 'string' || typeof node === 'number') {
+    return
+  }
+  if (Array.isArray(node)) {
+    node.forEach((entry) => visit(entry, cb))
+    return
+  }
+  const element = node as ReactElementLike
+  cb(element)
+  if (element.props?.children) {
+    visit(element.props.children, cb)
+  }
+}
+
+export function findAllByType(node: unknown, type: unknown): ReactElementLike[] {
+  const found: ReactElementLike[] = []
+  visit(node, (entry) => {
+    if (entry.type === type) {
+      found.push(entry)
+    }
+  })
+  return found
+}
+
+export function findByType(node: unknown, type: unknown): ReactElementLike {
+  const found = findAllByType(node, type)[0]
+  if (!found) {
+    throw new Error(`element not found: ${String(type)}`)
+  }
+  return found
+}
+
+export function collectText(node: unknown): string {
+  if (node == null || typeof node === 'boolean') {
+    return ''
+  }
+  if (typeof node === 'string') {
+    return node
+  }
+  if (typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(collectText).join('')
+  }
+  const element = node as ReactElementLike
+  return collectText(element.props?.children)
+}
+
+/** The name and detail line a rendered send-target row shows. */
+export function sendTargetRowText(item: unknown): { name: string; detail: string } {
+  const spans = findAllByType(item, 'span')
+  const byTestId = (id: string): ReactElementLike | undefined =>
+    spans.find((span) => span.props['data-testid'] === id)
+  return {
+    name: collectText(byTestId('send-target-name')),
+    detail: collectText(byTestId('send-target-detail'))
+  }
+}
+
+// Why: titles the shared conversation-name resolver rejects — identity echoes,
+// synthetic status labels, cwd-shaped titles, placeholders. The menu renders the
+// provider icon and the harness name already, so none of these is a name.
+export const JUNK_TITLES: [string, string, TuiAgent][] = [
+  ['claude identity echo', '✳ Claude', 'claude'],
+  ['gemini identity echo', '✦ Gemini CLI', 'gemini'],
+  ['synthetic idle status', 'Codex ready', 'codex'],
+  ['synthetic permission status', 'Cursor - action required', 'cursor'],
+  ['cwd title over ssh', '⠋ ~/orca/workspaces', 'claude'],
+  ['placeholder title', 'Terminal 3', 'claude'],
+  ['glyph-only title', '✳', 'claude'],
+  ['empty title', '', 'claude']
+]
+
+export type SingleTargetScenario = {
+  title: string
+  agentType: TuiAgent
+  prompt?: string
+  tabOverrides?: Record<string, unknown>
+  withAgentRow?: boolean
+  generatedTitlesEnabled?: boolean
+}
+
+/** One eligible send target on TAB_A, with the agent row that orders it. */
+export function buildSingleTargetScenario(
+  scenario: SingleTargetScenario,
+  paneKey: string,
+  agentRow: ReturnType<typeof createAgentRowFactory>
+): {
+  agentRows: DashboardAgentRowData[]
+  store: Record<string, unknown>
+  noteTargets: Record<string, unknown>[]
+} {
+  const targetTab = tab(TAB_A, { title: scenario.title, ...scenario.tabOverrides })
+  return {
+    agentRows:
+      scenario.withAgentRow === false
+        ? []
+        : [
+            agentRow({
+              paneKey,
+              tabId: TAB_A,
+              title: scenario.title,
+              agentType: scenario.agentType,
+              state: 'idle',
+              prompt: scenario.prompt ?? '',
+              tabOverrides: scenario.tabOverrides
+            })
+          ],
+    store: {
+      tabsByWorktree: { 'wt-1': [targetTab] },
+      terminalLayoutsByTabId: { [TAB_A]: leafLayout(LEAF_A, 'pty-a') },
+      settings: { tabAutoGenerateTitle: scenario.generatedTitlesEnabled === true }
+    },
+    noteTargets: [
+      {
+        paneKey,
+        tabId: TAB_A,
+        leafId: LEAF_A,
+        agentType: scenario.agentType,
+        tab: targetTab,
+        status: 'eligible'
+      }
+    ]
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -7,7 +7,7 @@ import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { cn } from '@/lib/utils'
 import { getAgentDotState } from './worktree-card-agent-summary'
 import { translate } from '@/i18n/i18n'
-import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import { agentRowPrimaryLabel } from '@/lib/agent-row-display-name'
 import { useAgentRowConversationName } from '@/components/dashboard/use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
 import CacheTimer, { usePromptCacheCountdownForPane } from './CacheTimer'
@@ -32,8 +32,7 @@ function getCompactAgentPrimary(
   agent: DashboardAgentRowData,
   conversationName: string | null
 ): string {
-  const prompt = conversationName ?? getAgentRowPrimaryText(agent.entry)
-  return prompt || agentStateLabel(getAgentDotState(agent))
+  return agentRowPrimaryLabel(agent, conversationName) || agentStateLabel(getAgentDotState(agent))
 }
 
 function getCompactAgentSecondary(agent: DashboardAgentRowData): string {

--- a/src/renderer/src/lib/agent-row-display-name.test.ts
+++ b/src/renderer/src/lib/agent-row-display-name.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { agentRowOwnsTabName, agentRowPrimaryLabel } from './agent-row-display-name'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+
+const TAB_ID = 'tab-1'
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const row = (
+  overrides: Partial<Parameters<typeof agentRowOwnsTabName>[0]> & {
+    parentPaneKey?: string
+    prompt?: string
+  } = {}
+): Parameters<typeof agentRowOwnsTabName>[0] => ({
+  entry: {
+    prompt: overrides.prompt ?? '',
+    orchestration: overrides.parentPaneKey ? { parentPaneKey: overrides.parentPaneKey } : undefined
+  } as Parameters<typeof agentRowOwnsTabName>[0]['entry'],
+  tab: { id: TAB_ID },
+  lineage: overrides.lineage,
+  rowSource: overrides.rowSource
+})
+
+describe('agentRowOwnsTabName', () => {
+  it('lets a root row own its tab name', () => {
+    expect(agentRowOwnsTabName(row())).toBe(true)
+  })
+
+  it('refuses a synthetic subagent row', () => {
+    expect(agentRowOwnsTabName(row({ rowSource: 'subagent' }))).toBe(false)
+  })
+
+  it('refuses a child rendered on its parent tab', () => {
+    const child = row({
+      lineage: { depth: 1 },
+      parentPaneKey: makePaneKey(TAB_ID, LEAF_ID)
+    })
+    expect(agentRowOwnsTabName(child)).toBe(false)
+  })
+
+  it('lets a child on its own tab keep the name', () => {
+    const child = row({
+      lineage: { depth: 1 },
+      parentPaneKey: makePaneKey('tab-other', LEAF_ID)
+    })
+    expect(agentRowOwnsTabName(child)).toBe(true)
+  })
+
+  it('lets a depth-0 row with a parent key keep the name', () => {
+    const sibling = row({
+      lineage: { depth: 0 },
+      parentPaneKey: makePaneKey(TAB_ID, LEAF_ID)
+    })
+    expect(agentRowOwnsTabName(sibling)).toBe(true)
+  })
+})
+
+describe('agentRowPrimaryLabel', () => {
+  it('prefers the conversation name', () => {
+    expect(agentRowPrimaryLabel(row({ prompt: 'fix the bug' }), 'Designer')).toBe('Designer')
+  })
+
+  it('falls through to what the agent is working on', () => {
+    expect(agentRowPrimaryLabel(row({ prompt: 'fix the bug' }), null)).toBe('fix the bug')
+  })
+
+  it('returns empty when neither exists, leaving the last resort to the caller', () => {
+    expect(agentRowPrimaryLabel(row(), null)).toBe('')
+  })
+})

--- a/src/renderer/src/lib/agent-row-display-name.ts
+++ b/src/renderer/src/lib/agent-row-display-name.ts
@@ -1,0 +1,36 @@
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../shared/types'
+import { getAgentRowPrimaryText } from './agent-row-primary-text'
+
+/** The parts of an agent row that decide how it is named. Structural so this
+ *  module stays independent of the dashboard row type. */
+export type AgentRowNameInputs = {
+  entry: Pick<AgentStatusEntry, 'orchestration' | 'prompt'>
+  tab: Pick<TerminalTab, 'id'>
+  lineage?: { depth: 0 | 1 }
+  rowSource?: 'live' | 'retained' | 'subagent'
+}
+
+/** Why: a synthetic child row, or a depth-1 child rendered on its parent's tab,
+ *  is not the thing that tab is named after. */
+export function agentRowOwnsTabName(row: AgentRowNameInputs): boolean {
+  if (row.rowSource === 'subagent') {
+    return false
+  }
+  const parentPaneKey = row.entry.orchestration?.parentPaneKey
+  return !(
+    row.lineage?.depth === 1 &&
+    parentPaneKey !== undefined &&
+    parsePaneKey(parentPaneKey)?.tabId === row.tab.id
+  )
+}
+
+/** The row's name: its tab's conversation name, else what the agent is working
+ *  on. Empty when neither exists — callers supply their own last resort. */
+export function agentRowPrimaryLabel(
+  row: Pick<AgentRowNameInputs, 'entry'>,
+  conversationName: string | null
+): string {
+  return conversationName ?? getAgentRowPrimaryText(row.entry)
+}

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -129,24 +129,19 @@ describe('notes send agent targets', () => {
         tabId: STATUS_TAB_ID,
         leafId: LEAF_A,
         agentType: 'codex',
-        tabTitle: 'Terminal 1',
+        tab: expect.objectContaining({ id: STATUS_TAB_ID }),
         status: 'eligible'
       }
     ])
   })
 
-  it('names a status-backed target after its tab, not the live agent title', () => {
+  it('carries the tab so the menu can name the target where the agent type is final', () => {
     const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
     const targets = deriveNotesSendAgentTargets(
       state({
         agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
         tabsByWorktree: {
-          [WORKTREE_ID]: [
-            tab(STATUS_TAB_ID, {
-              title: '✳ Add validation to prevent deleting live attractions',
-              customTitle: 'Designer'
-            })
-          ]
+          [WORKTREE_ID]: [tab(STATUS_TAB_ID, { title: '✳ Say hello', customTitle: 'Designer' })]
         },
         terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
       }),
@@ -154,127 +149,8 @@ describe('notes send agent targets', () => {
       NOW
     )
 
-    expect(targets[0].tabTitle).toBe('Designer')
-  })
-
-  it('names a title-hint target after its tab, not the live agent title', () => {
-    const targets = deriveNotesSendAgentTargets(
-      state({
-        tabsByWorktree: {
-          [WORKTREE_ID]: [
-            tab(LAUNCH_TAB_ID, {
-              title: 'Codex ready',
-              customTitle: 'Import Parks',
-              launchAgent: 'codex'
-            })
-          ]
-        },
-        terminalLayoutsByTabId: { [LAUNCH_TAB_ID]: leafLayout(LEAF_B, 'pty-b') },
-        runtimePaneTitlesByTabId: { [LAUNCH_TAB_ID]: { 1: 'Codex ready' } }
-      }),
-      WORKTREE_ID,
-      NOW
-    )
-
-    expect(targets[0].tabTitle).toBe('Import Parks')
-  })
-
-  // Why: the menu row renders the provider icon, so the agent's own leading
-  // status glyph would read as a second icon — the same reason SortableTab
-  // strips it. Every agent that decorates its OSC title is affected, not Claude
-  // alone, so the shared decoration table is exercised here.
-  it.each([
-    ['Claude', '✳ Say hello world', 'Say hello world'],
-    ['Gemini', '◇ Refactor the parser', 'Refactor the parser'],
-    ['Gemini clock', '⏲ Refactor the parser', 'Refactor the parser'],
-    ['braille spinner', '⠋ Refactor the parser', 'Refactor the parser'],
-    ['Claude text prefix', '* Refactor the parser', 'Refactor the parser']
-  ])('strips the %s status glyph from a live-title target name', (_agent, liveTitle, expected) => {
-    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
-    const targets = deriveNotesSendAgentTargets(
-      state({
-        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
-        tabsByWorktree: { [WORKTREE_ID]: [tab(STATUS_TAB_ID, { title: liveTitle })] },
-        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
-      }),
-      WORKTREE_ID,
-      NOW
-    )
-
-    expect(targets[0].tabTitle).toBe(expected)
-  })
-
-  it('keeps a manual rename that starts with a status glyph intact', () => {
-    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
-    const targets = deriveNotesSendAgentTargets(
-      state({
-        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
-        tabsByWorktree: {
-          [WORKTREE_ID]: [
-            tab(STATUS_TAB_ID, { title: '✳ Say hello world', customTitle: '✳ my own label' })
-          ]
-        },
-        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
-      }),
-      WORKTREE_ID,
-      NOW
-    )
-
-    expect(targets[0].tabTitle).toBe('✳ my own label')
-  })
-
-  it('keeps a glyph-only live title rather than collapsing the name to empty', () => {
-    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
-    const targets = deriveNotesSendAgentTargets(
-      state({
-        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
-        tabsByWorktree: { [WORKTREE_ID]: [tab(STATUS_TAB_ID, { title: '✳' })] },
-        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
-      }),
-      WORKTREE_ID,
-      NOW
-    )
-
-    expect(targets[0].tabTitle).toBe('✳')
-  })
-
-  // Why: an empty name is the signal the menu row uses to promote the harness
-  // label to its title line, so a whitespace-only title must not survive as one.
-  it('resolves a whitespace-only live title to an empty name', () => {
-    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
-    const targets = deriveNotesSendAgentTargets(
-      state({
-        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
-        tabsByWorktree: { [WORKTREE_ID]: [tab(STATUS_TAB_ID, { title: '   ' })] },
-        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
-      }),
-      WORKTREE_ID,
-      NOW
-    )
-
-    expect(targets[0].tabTitle).toBe('')
-  })
-
-  it('uses the generated tab title only while generated titles are enabled', () => {
-    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
-    const titleFor = (generatedTabTitlesEnabled: boolean): string =>
-      deriveNotesSendAgentTargets(
-        state({
-          generatedTabTitlesEnabled,
-          agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
-          tabsByWorktree: {
-            [WORKTREE_ID]: [
-              tab(STATUS_TAB_ID, { title: 'Codex ready', generatedTitle: 'Refactor auth' })
-            ]
-          },
-          terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
-        }),
-        WORKTREE_ID,
-        NOW
-      )[0].tabTitle
-
-    expect(titleFor(true)).toBe('Refactor auth')
-    expect(titleFor(false)).toBe('Codex ready')
+    expect(targets[0].tab.id).toBe(STATUS_TAB_ID)
+    expect(targets[0].tab.customTitle).toBe('Designer')
   })
 
   it('keeps permission status-backed targets visible but disabled', () => {
@@ -339,7 +215,7 @@ describe('notes send agent targets', () => {
         tabId: LAUNCH_TAB_ID,
         leafId: LEAF_B,
         agentType: 'codex',
-        tabTitle: 'Terminal 2',
+        tab: expect.objectContaining({ id: LAUNCH_TAB_ID }),
         status: 'eligible'
       }
     ])
@@ -364,7 +240,7 @@ describe('notes send agent targets', () => {
         tabId: MANUAL_TAB_ID,
         leafId: LEAF_B,
         agentType: 'codex',
-        tabTitle: 'Terminal 2',
+        tab: expect.objectContaining({ id: MANUAL_TAB_ID }),
         status: 'eligible'
       }
     ])
@@ -609,7 +485,7 @@ describe('notes send agent targets', () => {
         tabId: LAUNCH_TAB_ID,
         leafId: LEAF_B,
         agentType: 'codex',
-        tabTitle: 'Previous Codex session',
+        tab: expect.objectContaining({ id: LAUNCH_TAB_ID }),
         status: 'eligible'
       }
     ])

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -85,7 +85,7 @@ function state(
     terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
     ptyIdsByTabId: Record<string, string[]>
     runtimePaneTitlesByTabId: Record<string, Record<number, string>>
-    settings: NotesSendAgentTargetState['settings']
+    generatedTabTitlesEnabled: boolean
   }> = {}
 ): NotesSendAgentTargetState {
   const terminalLayoutsByTabId = overrides.terminalLayoutsByTabId ?? {}
@@ -238,12 +238,29 @@ describe('notes send agent targets', () => {
     expect(targets[0].tabTitle).toBe('✳')
   })
 
+  // Why: an empty name is the signal the menu row uses to promote the harness
+  // label to its title line, so a whitespace-only title must not survive as one.
+  it('resolves a whitespace-only live title to an empty name', () => {
+    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
+        tabsByWorktree: { [WORKTREE_ID]: [tab(STATUS_TAB_ID, { title: '   ' })] },
+        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets[0].tabTitle).toBe('')
+  })
+
   it('uses the generated tab title only while generated titles are enabled', () => {
     const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
-    const titleFor = (settings: NotesSendAgentTargetState['settings']): string =>
+    const titleFor = (generatedTabTitlesEnabled: boolean): string =>
       deriveNotesSendAgentTargets(
         state({
-          settings,
+          generatedTabTitlesEnabled,
           agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
           tabsByWorktree: {
             [WORKTREE_ID]: [
@@ -256,10 +273,8 @@ describe('notes send agent targets', () => {
         NOW
       )[0].tabTitle
 
-    expect(titleFor({ tabAutoGenerateTitle: true } as NotesSendAgentTargetState['settings'])).toBe(
-      'Refactor auth'
-    )
-    expect(titleFor(null)).toBe('Codex ready')
+    expect(titleFor(true)).toBe('Refactor auth')
+    expect(titleFor(false)).toBe('Codex ready')
   })
 
   it('keeps permission status-backed targets visible but disabled', () => {

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -179,6 +179,65 @@ describe('notes send agent targets', () => {
     expect(targets[0].tabTitle).toBe('Import Parks')
   })
 
+  // Why: the menu row renders the provider icon, so the agent's own leading
+  // status glyph would read as a second icon — the same reason SortableTab
+  // strips it. Every agent that decorates its OSC title is affected, not Claude
+  // alone, so the shared decoration table is exercised here.
+  it.each([
+    ['Claude', '✳ Say hello world', 'Say hello world'],
+    ['Gemini', '◇ Refactor the parser', 'Refactor the parser'],
+    ['Gemini clock', '⏲ Refactor the parser', 'Refactor the parser'],
+    ['braille spinner', '⠋ Refactor the parser', 'Refactor the parser'],
+    ['Claude text prefix', '* Refactor the parser', 'Refactor the parser']
+  ])('strips the %s status glyph from a live-title target name', (_agent, liveTitle, expected) => {
+    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
+        tabsByWorktree: { [WORKTREE_ID]: [tab(STATUS_TAB_ID, { title: liveTitle })] },
+        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets[0].tabTitle).toBe(expected)
+  })
+
+  it('keeps a manual rename that starts with a status glyph intact', () => {
+    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
+        tabsByWorktree: {
+          [WORKTREE_ID]: [
+            tab(STATUS_TAB_ID, { title: '✳ Say hello world', customTitle: '✳ my own label' })
+          ]
+        },
+        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets[0].tabTitle).toBe('✳ my own label')
+  })
+
+  it('keeps a glyph-only live title rather than collapsing the name to empty', () => {
+    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
+        tabsByWorktree: { [WORKTREE_ID]: [tab(STATUS_TAB_ID, { title: '✳' })] },
+        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets[0].tabTitle).toBe('✳')
+  })
+
   it('uses the generated tab title only while generated titles are enabled', () => {
     const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
     const titleFor = (settings: NotesSendAgentTargetState['settings']): string =>

--- a/src/renderer/src/lib/notes-send-agent-targets.test.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.test.ts
@@ -85,6 +85,7 @@ function state(
     terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot>
     ptyIdsByTabId: Record<string, string[]>
     runtimePaneTitlesByTabId: Record<string, Record<number, string>>
+    settings: NotesSendAgentTargetState['settings']
   }> = {}
 ): NotesSendAgentTargetState {
   const terminalLayoutsByTabId = overrides.terminalLayoutsByTabId ?? {}
@@ -132,6 +133,74 @@ describe('notes send agent targets', () => {
         status: 'eligible'
       }
     ])
+  })
+
+  it('names a status-backed target after its tab, not the live agent title', () => {
+    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
+        tabsByWorktree: {
+          [WORKTREE_ID]: [
+            tab(STATUS_TAB_ID, {
+              title: '✳ Add validation to prevent deleting live attractions',
+              customTitle: 'Designer'
+            })
+          ]
+        },
+        terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets[0].tabTitle).toBe('Designer')
+  })
+
+  it('names a title-hint target after its tab, not the live agent title', () => {
+    const targets = deriveNotesSendAgentTargets(
+      state({
+        tabsByWorktree: {
+          [WORKTREE_ID]: [
+            tab(LAUNCH_TAB_ID, {
+              title: 'Codex ready',
+              customTitle: 'Import Parks',
+              launchAgent: 'codex'
+            })
+          ]
+        },
+        terminalLayoutsByTabId: { [LAUNCH_TAB_ID]: leafLayout(LEAF_B, 'pty-b') },
+        runtimePaneTitlesByTabId: { [LAUNCH_TAB_ID]: { 1: 'Codex ready' } }
+      }),
+      WORKTREE_ID,
+      NOW
+    )
+
+    expect(targets[0].tabTitle).toBe('Import Parks')
+  })
+
+  it('uses the generated tab title only while generated titles are enabled', () => {
+    const paneKey = makePaneKey(STATUS_TAB_ID, LEAF_A)
+    const titleFor = (settings: NotesSendAgentTargetState['settings']): string =>
+      deriveNotesSendAgentTargets(
+        state({
+          settings,
+          agentStatusByPaneKey: { [paneKey]: entry(paneKey, 'done') },
+          tabsByWorktree: {
+            [WORKTREE_ID]: [
+              tab(STATUS_TAB_ID, { title: 'Codex ready', generatedTitle: 'Refactor auth' })
+            ]
+          },
+          terminalLayoutsByTabId: { [STATUS_TAB_ID]: leafLayout(LEAF_A, 'pty-a') }
+        }),
+        WORKTREE_ID,
+        NOW
+      )[0].tabTitle
+
+    expect(titleFor({ tabAutoGenerateTitle: true } as NotesSendAgentTargetState['settings'])).toBe(
+      'Refactor auth'
+    )
+    expect(titleFor(null)).toBe('Codex ready')
   })
 
   it('keeps permission status-backed targets visible but disabled', () => {

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -1,8 +1,6 @@
 import type { AgentType } from '../../../shared/agent-status-types'
 import type { AppState } from '@/store/types'
-import { stripLeadingAgentTitleDecoration } from '../../../shared/agent-title-decoration'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
-import { resolveTerminalTabTitle } from '../../../shared/tab-title-resolution'
 import { resolveTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import type { TerminalTab } from '../../../shared/types'
 import { detectAgentSendTitleStatus } from './agent-send-title-status'
@@ -16,18 +14,16 @@ import {
 } from './running-agent-targets'
 
 export type NotesSendAgentTargetState = RunningAgentTargetState &
-  Pick<AppState, 'runtimePaneTitlesByTabId'> & {
-    /** Why: the one setting this derivation reads, not the whole settings object
-     *  — selecting the object would re-derive on every unrelated settings write. */
-    generatedTabTitlesEnabled?: boolean
-  }
+  Pick<AppState, 'runtimePaneTitlesByTabId'>
 
 export type NotesSendAgentTarget = {
   paneKey: string
   tabId: string
   leafId: string
   agentType: AgentType | null | undefined
-  tabTitle: string
+  /** Why: identity, not a name. The menu resolves the label where the agent type
+   *  is final, so this record never carries presentation. */
+  tab: TerminalTab
   status: 'eligible' | 'disabled'
   disabledReason?: string
 }
@@ -35,19 +31,6 @@ export type NotesSendAgentTarget = {
 type AgentTitleEvidence = {
   status: NonNullable<ReturnType<typeof detectAgentSendTitleStatus>>
   title: string
-}
-
-// Why: name each target the way its tab is named in the tab bar. `tab.title` is
-// the agent's live OSC title, so a manual rename or generated title would be
-// dropped and the menu would disagree with the tab the user is looking at.
-// Stripping the leading status glyph mirrors SortableTab: every row here renders
-// the provider icon, so the agent's own glyph would read as a second one. A
-// manual rename is the user's text and is never stripped.
-function resolveTargetTabTitle(state: NotesSendAgentTargetState, tab: TerminalTab): string {
-  // Why: no fallback — the resolver only reaches it once the trimmed live title
-  // is empty, so passing `tab.title` back would only ever restore whitespace.
-  const title = resolveTerminalTabTitle(tab, state.generatedTabTitlesEnabled === true)
-  return tab.customTitle?.trim() ? title : stripLeadingAgentTitleDecoration(title)
 }
 
 function detectTitleHintPaneEvidence(
@@ -94,7 +77,7 @@ export function deriveNotesSendAgentTargets(
       tabId: target.tabId,
       leafId: target.leafId,
       agentType: resolveNotesTargetAgentType(target.entry.agentType, target.tab.launchAgent),
-      tabTitle: resolveTargetTabTitle(state, target.tab),
+      tab: target.tab,
       status: target.status,
       ...(target.disabledReason ? { disabledReason: target.disabledReason } : {})
     })
@@ -161,7 +144,7 @@ function deriveTitleHintAgentTarget(
     tabId: tab.id,
     leafId,
     agentType: tab.launchAgent ?? resolveTerminalTitleAgentType(titleEvidence.title),
-    tabTitle: resolveTargetTabTitle(state, tab),
+    tab,
     status: disabledReason ? 'disabled' : 'eligible',
     ...(disabledReason ? { disabledReason } : {})
   }
@@ -198,8 +181,7 @@ function mergeLaunchAgentTitleTarget(
       agentType:
         existing.agentType && existing.agentType !== 'unknown'
           ? existing.agentType
-          : target.agentType,
-      tabTitle: existing.tabTitle || target.tabTitle
+          : target.agentType
     }
     return
   }

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -16,8 +16,11 @@ import {
 } from './running-agent-targets'
 
 export type NotesSendAgentTargetState = RunningAgentTargetState &
-  Pick<AppState, 'runtimePaneTitlesByTabId'> &
-  Partial<Pick<AppState, 'settings'>>
+  Pick<AppState, 'runtimePaneTitlesByTabId'> & {
+    /** Why: the one setting this derivation reads, not the whole settings object
+     *  — selecting the object would re-derive on every unrelated settings write. */
+    generatedTabTitlesEnabled?: boolean
+  }
 
 export type NotesSendAgentTarget = {
   paneKey: string
@@ -41,11 +44,9 @@ type AgentTitleEvidence = {
 // the provider icon, so the agent's own glyph would read as a second one. A
 // manual rename is the user's text and is never stripped.
 function resolveTargetTabTitle(state: NotesSendAgentTargetState, tab: TerminalTab): string {
-  const title = resolveTerminalTabTitle(
-    tab,
-    state.settings?.tabAutoGenerateTitle === true,
-    tab.title
-  )
+  // Why: no fallback — the resolver only reaches it once the trimmed live title
+  // is empty, so passing `tab.title` back would only ever restore whitespace.
+  const title = resolveTerminalTabTitle(tab, state.generatedTabTitlesEnabled === true)
   return tab.customTitle?.trim() ? title : stripLeadingAgentTitleDecoration(title)
 }
 

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -1,5 +1,6 @@
 import type { AgentType } from '../../../shared/agent-status-types'
 import type { AppState } from '@/store/types'
+import { stripLeadingAgentTitleDecoration } from '../../../shared/agent-title-decoration'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
 import { resolveTerminalTabTitle } from '../../../shared/tab-title-resolution'
 import { resolveTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
@@ -36,8 +37,16 @@ type AgentTitleEvidence = {
 // Why: name each target the way its tab is named in the tab bar. `tab.title` is
 // the agent's live OSC title, so a manual rename or generated title would be
 // dropped and the menu would disagree with the tab the user is looking at.
+// Stripping the leading status glyph mirrors SortableTab: every row here renders
+// the provider icon, so the agent's own glyph would read as a second one. A
+// manual rename is the user's text and is never stripped.
 function resolveTargetTabTitle(state: NotesSendAgentTargetState, tab: TerminalTab): string {
-  return resolveTerminalTabTitle(tab, state.settings?.tabAutoGenerateTitle === true, tab.title)
+  const title = resolveTerminalTabTitle(
+    tab,
+    state.settings?.tabAutoGenerateTitle === true,
+    tab.title
+  )
+  return tab.customTitle?.trim() ? title : stripLeadingAgentTitleDecoration(title)
 }
 
 function detectTitleHintPaneEvidence(

--- a/src/renderer/src/lib/notes-send-agent-targets.ts
+++ b/src/renderer/src/lib/notes-send-agent-targets.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from '../../../shared/agent-status-types'
 import type { AppState } from '@/store/types'
 import { isTerminalLeafId, makePaneKey } from '../../../shared/stable-pane-id'
+import { resolveTerminalTabTitle } from '../../../shared/tab-title-resolution'
 import { resolveTerminalTitleAgentType } from '../../../shared/terminal-title-agent-type'
 import type { TerminalTab } from '../../../shared/types'
 import { detectAgentSendTitleStatus } from './agent-send-title-status'
@@ -14,7 +15,8 @@ import {
 } from './running-agent-targets'
 
 export type NotesSendAgentTargetState = RunningAgentTargetState &
-  Pick<AppState, 'runtimePaneTitlesByTabId'>
+  Pick<AppState, 'runtimePaneTitlesByTabId'> &
+  Partial<Pick<AppState, 'settings'>>
 
 export type NotesSendAgentTarget = {
   paneKey: string
@@ -29,6 +31,13 @@ export type NotesSendAgentTarget = {
 type AgentTitleEvidence = {
   status: NonNullable<ReturnType<typeof detectAgentSendTitleStatus>>
   title: string
+}
+
+// Why: name each target the way its tab is named in the tab bar. `tab.title` is
+// the agent's live OSC title, so a manual rename or generated title would be
+// dropped and the menu would disagree with the tab the user is looking at.
+function resolveTargetTabTitle(state: NotesSendAgentTargetState, tab: TerminalTab): string {
+  return resolveTerminalTabTitle(tab, state.settings?.tabAutoGenerateTitle === true, tab.title)
 }
 
 function detectTitleHintPaneEvidence(
@@ -75,7 +84,7 @@ export function deriveNotesSendAgentTargets(
       tabId: target.tabId,
       leafId: target.leafId,
       agentType: resolveNotesTargetAgentType(target.entry.agentType, target.tab.launchAgent),
-      tabTitle: target.tab.title,
+      tabTitle: resolveTargetTabTitle(state, target.tab),
       status: target.status,
       ...(target.disabledReason ? { disabledReason: target.disabledReason } : {})
     })
@@ -142,7 +151,7 @@ function deriveTitleHintAgentTarget(
     tabId: tab.id,
     leafId,
     agentType: tab.launchAgent ?? resolveTerminalTitleAgentType(titleEvidence.title),
-    tabTitle: tab.title,
+    tabTitle: resolveTargetTabTitle(state, tab),
     status: disabledReason ? 'disabled' : 'eligible',
     ...(disabledReason ? { disabledReason } : {})
   }


### PR DESCRIPTION
## Summary

Three fixes to the "Send notes to" menu (browser annotations and editor review notes — both render `ReviewNotesSendMenuContent`):

1. **Targets were named after the agent's live OSC title, not the tab.** `deriveNotesSendAgentTargets` read `tab.title` directly, so a tab renamed "Designer" listed as `✳ Add validation to prevent deleting live attractions` and a tab named "Import Parks" listed as `Faça uma revisao da importacao,` — whatever the CLI happened to be writing to the terminal title at that moment. It now resolves the label through `resolveTerminalTabTitle`, the same precedence the tab bar uses (manual rename → quick-command label → OpenCode session title → generated title → live title), so the menu agrees with the tab the user is looking at. `NotesSendAgentTargetState` gained `settings` so the generated-title tier stays gated on `tabAutoGenerateTitle`.

2. **The harness name outranked the tab name.** The row led with "Claude"/"Codex" and buried the tab name at the end of the detail line. Since several targets routinely share one harness, the tab name is what the user actually picks between — it now leads, and the harness qualifies it on the detail line next to state and timing.

3. **The agent's status glyph leaked into the name.** With the tab name promoted to the title line, a live-title fallback dragged its leading OSC decoration along (`✳ Say hello world`) and read as a second icon beside the provider icon the row already renders. Stripped with the shared decoration table, mirroring `SortableTab`, which does this for the same reason. Not Claude-specific — Gemini's `✦ ⏲ ◇ ✋` and the braille spinner frames Pi/OMP normalize to go through the same table. A manual rename is the user's own text and is never stripped.

Before / after for the same row:

```
Claude                                        teste
Idle · just now · teste                       Claude · Idle · just now

Claude                                        Say hello world
Done · just now · ✳ Say hello world           Claude · Done · just now
```

When a target has no resolvable tab name, the harness label moves up to the title line and is not repeated below (no "Claude / Claude · Idle").

## Screenshots

Reporter screenshots of the defects are in the originating conversation; I did not attach binaries here. The text before/after above shows the exact rendered strings, and every state is covered by assertions in `ReviewNotesSendMenuContent.test.tsx`. Happy to attach captures if you want them on the PR.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 41853 passed | 71 skipped
- [ ] `pnpm build` — **not run.** The build writes to `out/`, which the running `pnpm dev` instance owns; starting it risked restarting the app over live agent terminals. Nothing here touches build config, native modules, or main-process code — it is renderer-only TS/TSX that `pnpm typecheck` already covers end to end. CI's build job is the gate.
- [x] Added or updated high-quality tests that would catch regressions

New tests:

- `notes-send-agent-targets.test.ts` — a rename beats the live agent title for a status-backed target and for a title-hint target; the generated title is used only while `tabAutoGenerateTitle` is on; a table-driven case strips the Claude, Gemini, braille-spinner, and text-prefix decorations; a glyph-only title keeps its original text instead of collapsing to empty; a whitespace-only title resolves to an empty name; a rename that legitimately starts with a glyph survives untouched.
- `ReviewNotesSendMenuContent.test.tsx` — the row leads with the tab name and pushes the harness to the detail line; falls back to the harness label when the tab has no name.

## AI Review Report

Reviewed with Claude Opus 5. Risks checked and their outcome:

- **Send routing unchanged.** `tabTitle` is display-only — grepped every read: the two menu render paths and the `existing.tabTitle || target.tabTitle` merge in `mergeLaunchAgentTitleTarget`. Targeting still keys off `paneKey`/`tabId`/`leafId`, and eligibility still re-derives against live store state in `resolveCurrentSendTargetEligibility` before any send. No change to which pane receives a note.
- **Eligibility gating unchanged.** The agent-title detectors (`detectAgentSendTitleStatus`, `detectTitleHintPaneEvidence`) still read the raw `tab.title` / runtime pane title. Only the label the user sees was re-resolved and stripped, so a renamed tab cannot make a non-agent pane look sendable.
- **Agent coverage for the glyph strip.** Verified against `normalizeTerminalTitle` rather than assuming: Gemini frames normalize to `<glyph> Gemini CLI` and Pi/OMP frames collapse to `⠋ Pi` or bare `Pi` before reaching `tab.title`, so both land in the shared decoration table. Codex, Cursor, Droid, Hermes, and Devin use undecorated synthetic labels and are unaffected. No per-agent list is introduced — the one shared table stays the single source, same as the tab bar.
- **Render churn.** The first cut selected the whole `settings` object, so any settings write re-derived the memo. Greptile flagged it and it is fixed: `NotesSendAgentTargetState` now takes a `generatedTabTitlesEnabled` boolean — the one setting this derivation reads — matching the derived-flag pattern in `sync-runtime-graph.ts` and `useTabGroupWorkspaceModel.ts`. Zustand now compares a primitive instead of an object identity.
- **Cross-platform.** Explicitly checked — the diff is renderer-only string resolution and JSX. No keyboard shortcuts, no modifier keys, no shortcut labels, no filesystem paths, no shell invocation, no Electron main-process or platform-conditional code. Behavior is identical on macOS, Linux, and Windows, and unaffected by SSH vs. local vs. WSL hosts since it consumes store state that is already host-normalized. Folder workspaces and git worktrees are equally covered — nothing here reads git state.
- **Flagged and resolved during review:** the first cut left the harness name duplicated on both lines when a tab had no name; the empty-`tabTitle` branch and its test were added in response. The glyph leak in (3) was caught in the app after (2) landed, not by the tests, which is why the decoration cases are now table-driven across agents.

## Security Audit

No new attack surface. The change is renderer-side label resolution over data already in the Zustand store — no IPC surface added or changed, no new input parsing, no command execution, no path handling, no auth or secrets, no dependency changes. Terminal titles are attacker-influenceable in principle (a process can emit arbitrary OSC), but they were already rendered here; React escapes them as text and `truncate` bounds the display. If anything this narrows exposure, since a manual rename or generated title now takes precedence over the process-controlled string, and the decoration strip removes a class of leading glyphs a hostile title could use to imitate a provider icon. No follow-up needed.

## Notes

Both entry points into this menu — `BrowserAnnotationSendMenuContent` and `NotesSendMenu` — share `ReviewNotesSendMenuContent`, so both pick up the fix. Sibling surfaces that name agent rows (`useAgentRowConversationName`, `build-dashboard-snapshot`) use `getAgentRowConversationName`, a stricter resolver that returns `null` for status-shaped titles. This menu deliberately uses the tab-bar resolver instead, since the user's complaint was that the menu disagreed with the tab bar. The resolve-then-strip pair is now duplicated between `SortableTab` and this derivation; worth a follow-up if the team wants one shared helper so the two can't drift.
