### PR TITLE
fix(skills): preflight npx before onboarding setup

### DIFF
--- a/src/main/ipc/skills.test.ts
+++ b/src/main/ipc/skills.test.ts
@@ -5,6 +5,7 @@ const {
   discoverSkillsMock,
   discoverSkillsInWslMock,
   inventorySkillFreshnessMock,
+  isNpxOnPathForSkillInstallMock,
   getDefaultWslDistroMock,
   getWslHomeMock,
   parseWslPathMock
@@ -13,6 +14,7 @@ const {
   discoverSkillsMock: vi.fn(),
   discoverSkillsInWslMock: vi.fn(),
   inventorySkillFreshnessMock: vi.fn(),
+  isNpxOnPathForSkillInstallMock: vi.fn(),
   getDefaultWslDistroMock: vi.fn(),
   getWslHomeMock: vi.fn(),
   parseWslPathMock: vi.fn()
@@ -37,6 +39,10 @@ vi.mock('../skills/skill-discovery-wsl', () => ({
 
 vi.mock('../skills/skill-freshness-inventory', () => ({
   inventorySkillFreshness: inventorySkillFreshnessMock
+}))
+
+vi.mock('../skills/skill-install-npx-preflight', () => ({
+  isNpxOnPathForSkillInstall: isNpxOnPathForSkillInstallMock
 }))
 
 vi.mock('../wsl', () => ({
@@ -80,6 +86,7 @@ describe('registerSkillsHandlers', () => {
       scanIssues: [],
       scannedAt: 1
     })
+    isNpxOnPathForSkillInstallMock.mockResolvedValue(true)
     getWslHomeMock.mockReturnValue('\\\\wsl.localhost\\Ubuntu\\home\\alice')
     Object.defineProperty(process, 'platform', {
       configurable: true,
@@ -111,6 +118,15 @@ describe('registerSkillsHandlers', () => {
       throw new Error('skills:freshnessInventory handler was not registered')
     }
     return call[1] as (_event: unknown) => Promise<unknown>
+  }
+
+  function getNpxPreflightHandler() {
+    registerSkillsHandlers(store as never)
+    const call = handleMock.mock.calls.find((entry: unknown[]) => entry[0] === 'skills:isNpxOnPath')
+    if (!call) {
+      throw new Error('skills:isNpxOnPath handler was not registered')
+    }
+    return call[1] as (_event: unknown, context?: unknown) => Promise<boolean>
   }
 
   it('uses host skill discovery when resolved project runtime overrides stale WSL target state', async () => {
@@ -224,5 +240,14 @@ describe('registerSkillsHandlers', () => {
       repos
     })
     expect(getWslHomeMock).not.toHaveBeenCalled()
+  })
+
+  it('registers the npx preflight and forwards its runtime context', async () => {
+    const handler = getNpxPreflightHandler()
+    const context = { wslDistro: 'Ubuntu' }
+
+    await expect(handler(null, context)).resolves.toBe(true)
+
+    expect(isNpxOnPathForSkillInstallMock).toHaveBeenCalledWith(context)
   })
 })

--- a/src/main/ipc/skills.test.ts
+++ b/src/main/ipc/skills.test.ts
@@ -126,7 +126,7 @@ describe('registerSkillsHandlers', () => {
     if (!call) {
       throw new Error('skills:isNpxOnPath handler was not registered')
     }
-    return call[1] as (_event: unknown, context?: unknown) => Promise<boolean>
+    return call[1] as (_event: unknown, context?: unknown, options?: unknown) => Promise<boolean>
   }
 
   it('uses host skill discovery when resolved project runtime overrides stale WSL target state', async () => {
@@ -245,9 +245,10 @@ describe('registerSkillsHandlers', () => {
   it('registers the npx preflight and forwards its runtime context', async () => {
     const handler = getNpxPreflightHandler()
     const context = { wslDistro: 'Ubuntu' }
+    const options = { forceRefresh: true }
 
-    await expect(handler(null, context)).resolves.toBe(true)
+    await expect(handler(null, context, options)).resolves.toBe(true)
 
-    expect(isNpxOnPathForSkillInstallMock).toHaveBeenCalledWith(context)
+    expect(isNpxOnPathForSkillInstallMock).toHaveBeenCalledWith(context, options)
   })
 })

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -11,9 +11,11 @@ import type {
   SkillUpdateStartResult
 } from '../../shared/skill-freshness'
 import { inventorySkillFreshness } from '../skills/skill-freshness-inventory'
+import { isNpxOnPathForSkillInstall } from '../skills/skill-install-npx-preflight'
 import { SkillUpdateRunner } from '../skills/skill-update-run'
 import { skillUpdateFailedNames } from '../skills/skill-update-outcome'
 import { readGloballyUpdatableSkillLocks } from '../skills/skill-update-registration'
+import type { PreflightRuntimeContext } from './preflight-runtime-target'
 import {
   discoverSkillsOnTarget,
   resolveSkillDiscoveryTarget
@@ -79,4 +81,11 @@ export function registerSkillsHandlers(store: Store): void {
   ipcMain.handle('skills:getUpdateRun', async (): Promise<SkillUpdateRun> => {
     return runner.getState()
   })
+
+  ipcMain.handle(
+    'skills:isNpxOnPath',
+    async (_event, context?: PreflightRuntimeContext): Promise<boolean> => {
+      return isNpxOnPathForSkillInstall(context)
+    }
+  )
 }

--- a/src/main/ipc/skills.ts
+++ b/src/main/ipc/skills.ts
@@ -84,8 +84,12 @@ export function registerSkillsHandlers(store: Store): void {
 
   ipcMain.handle(
     'skills:isNpxOnPath',
-    async (_event, context?: PreflightRuntimeContext): Promise<boolean> => {
-      return isNpxOnPathForSkillInstall(context)
+    async (
+      _event,
+      context?: PreflightRuntimeContext,
+      options?: { forceRefresh?: boolean }
+    ): Promise<boolean> => {
+      return isNpxOnPathForSkillInstall(context, options)
     }
   )
 }

--- a/src/main/skills/skill-install-npx-preflight.test.ts
+++ b/src/main/skills/skill-install-npx-preflight.test.ts
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   hydrateShellPath: vi.fn(),
-  isCommandOnPath: vi.fn()
+  isCommandOnPath: vi.fn(),
+  mergePathSegments: vi.fn(),
+  mergePersistedWindowsPath: vi.fn(),
+  refreshShellPath: vi.fn()
 }))
 
 vi.mock('../ipc/agent-detection-shell-path', () => ({
@@ -13,6 +16,15 @@ vi.mock('../ipc/preflight-command-exec', () => ({
   isCommandOnPath: mocks.isCommandOnPath
 }))
 
+vi.mock('../pty/windows-environment-path', () => ({
+  mergePersistedWindowsPathAsync: mocks.mergePersistedWindowsPath
+}))
+
+vi.mock('../startup/hydrate-shell-path', () => ({
+  hydrateShellPath: mocks.refreshShellPath,
+  mergePathSegments: mocks.mergePathSegments
+}))
+
 import { isNpxOnPathForSkillInstall } from './skill-install-npx-preflight'
 
 describe('isNpxOnPathForSkillInstall', () => {
@@ -21,6 +33,19 @@ describe('isNpxOnPathForSkillInstall', () => {
     mocks.hydrateShellPath.mockResolvedValue(undefined)
     mocks.isCommandOnPath.mockReset()
     mocks.isCommandOnPath.mockResolvedValue(true)
+    mocks.mergePathSegments.mockReset()
+    mocks.mergePersistedWindowsPath.mockReset()
+    mocks.mergePersistedWindowsPath.mockResolvedValue(undefined)
+    mocks.refreshShellPath.mockReset()
+    mocks.refreshShellPath.mockResolvedValue({
+      ok: true,
+      segments: ['/fresh/bin'],
+      failureReason: 'none'
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('hydrates and checks the local host PATH', async () => {
@@ -38,5 +63,37 @@ describe('isNpxOnPathForSkillInstall', () => {
 
     expect(mocks.hydrateShellPath).toHaveBeenCalledWith(context)
     expect(mocks.isCommandOnPath).toHaveBeenCalledWith('npx', { distro: 'Ubuntu' })
+  })
+
+  it('checks the default WSL distro without refreshing the Windows host PATH', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    await expect(
+      isNpxOnPathForSkillInstall({ wslDefault: true }, { forceRefresh: true })
+    ).resolves.toBe(true)
+
+    expect(mocks.mergePersistedWindowsPath).not.toHaveBeenCalled()
+    expect(mocks.isCommandOnPath).toHaveBeenCalledWith('npx', {})
+  })
+
+  it('force-refreshes the POSIX login-shell PATH before a re-check', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    await expect(isNpxOnPathForSkillInstall(undefined, { forceRefresh: true })).resolves.toBe(true)
+
+    expect(mocks.refreshShellPath).toHaveBeenCalledWith({ force: true })
+    expect(mocks.mergePathSegments).toHaveBeenCalledWith(['/fresh/bin'])
+    expect(mocks.hydrateShellPath).not.toHaveBeenCalled()
+  })
+
+  it('force-refreshes the persisted Windows PATH before a re-check', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+
+    await expect(isNpxOnPathForSkillInstall(undefined, { forceRefresh: true })).resolves.toBe(true)
+
+    expect(mocks.mergePersistedWindowsPath).toHaveBeenCalledWith(process.env, {
+      forceRefresh: true
+    })
+    expect(mocks.hydrateShellPath).not.toHaveBeenCalled()
   })
 })

--- a/src/main/skills/skill-install-npx-preflight.test.ts
+++ b/src/main/skills/skill-install-npx-preflight.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  hydrateShellPath: vi.fn(),
+  isCommandOnPath: vi.fn()
+}))
+
+vi.mock('../ipc/agent-detection-shell-path', () => ({
+  hydrateShellPathForAgentDetection: mocks.hydrateShellPath
+}))
+
+vi.mock('../ipc/preflight-command-exec', () => ({
+  isCommandOnPath: mocks.isCommandOnPath
+}))
+
+import { isNpxOnPathForSkillInstall } from './skill-install-npx-preflight'
+
+describe('isNpxOnPathForSkillInstall', () => {
+  beforeEach(() => {
+    mocks.hydrateShellPath.mockReset()
+    mocks.hydrateShellPath.mockResolvedValue(undefined)
+    mocks.isCommandOnPath.mockReset()
+    mocks.isCommandOnPath.mockResolvedValue(true)
+  })
+
+  it('hydrates and checks the local host PATH', async () => {
+    await expect(isNpxOnPathForSkillInstall()).resolves.toBe(true)
+
+    expect(mocks.hydrateShellPath).toHaveBeenCalledWith(undefined)
+    expect(mocks.isCommandOnPath).toHaveBeenCalledWith('npx', undefined)
+  })
+
+  it('checks the selected WSL distro on Windows', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const context = { wslDistro: 'Ubuntu' }
+
+    await expect(isNpxOnPathForSkillInstall(context)).resolves.toBe(true)
+
+    expect(mocks.hydrateShellPath).toHaveBeenCalledWith(context)
+    expect(mocks.isCommandOnPath).toHaveBeenCalledWith('npx', { distro: 'Ubuntu' })
+  })
+})

--- a/src/main/skills/skill-install-npx-preflight.test.ts
+++ b/src/main/skills/skill-install-npx-preflight.test.ts
@@ -61,8 +61,31 @@ describe('isNpxOnPathForSkillInstall', () => {
 
     await expect(isNpxOnPathForSkillInstall(context)).resolves.toBe(true)
 
-    expect(mocks.hydrateShellPath).toHaveBeenCalledWith(context)
+    expect(mocks.hydrateShellPath).not.toHaveBeenCalled()
+    expect(mocks.mergePersistedWindowsPath).not.toHaveBeenCalled()
     expect(mocks.isCommandOnPath).toHaveBeenCalledWith('npx', { distro: 'Ubuntu' })
+  })
+
+  it('awaits the asynchronous Windows PATH merge before the initial host check', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    let finishPathMerge: (() => void) | undefined
+    mocks.mergePersistedWindowsPath.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPathMerge = resolve
+        })
+    )
+
+    const check = isNpxOnPathForSkillInstall()
+    await Promise.resolve()
+
+    expect(mocks.isCommandOnPath).not.toHaveBeenCalled()
+    expect(mocks.mergePersistedWindowsPath).toHaveBeenCalledWith(process.env, {
+      forceRefresh: false
+    })
+    finishPathMerge?.()
+    await expect(check).resolves.toBe(true)
+    expect(mocks.isCommandOnPath).toHaveBeenCalledWith('npx', undefined)
   })
 
   it('checks the default WSL distro without refreshing the Windows host PATH', async () => {

--- a/src/main/skills/skill-install-npx-preflight.ts
+++ b/src/main/skills/skill-install-npx-preflight.ts
@@ -12,15 +12,22 @@ export async function isNpxOnPathForSkillInstall(
   options?: { forceRefresh?: boolean }
 ): Promise<boolean> {
   const wslTarget = getPreflightWslTarget(context) ?? undefined
-  await (options?.forceRefresh && !wslTarget
-    ? refreshHostPath()
-    : hydrateShellPathForAgentDetection(context))
+  if (wslTarget) {
+    return isCommandOnPath('npx', wslTarget)
+  }
+  const forceRefresh = options?.forceRefresh ?? false
+  await (process.platform === 'win32'
+    ? mergePersistedWindowsPathAsync(process.env, { forceRefresh })
+    : preparePosixHostPath(context, forceRefresh))
   return isCommandOnPath('npx', wslTarget)
 }
 
-async function refreshHostPath(): Promise<void> {
-  if (process.platform === 'win32') {
-    await mergePersistedWindowsPathAsync(process.env, { forceRefresh: true })
+async function preparePosixHostPath(
+  context: PreflightRuntimeContext | undefined,
+  forceRefresh: boolean
+): Promise<void> {
+  if (!forceRefresh) {
+    await hydrateShellPathForAgentDetection(context)
     return
   }
   const hydration = await hydrateShellPath({ force: true })

--- a/src/main/skills/skill-install-npx-preflight.ts
+++ b/src/main/skills/skill-install-npx-preflight.ts
@@ -1,0 +1,14 @@
+import { hydrateShellPathForAgentDetection } from '../ipc/agent-detection-shell-path'
+import { isCommandOnPath } from '../ipc/preflight-command-exec'
+import {
+  getPreflightWslTarget,
+  type PreflightRuntimeContext
+} from '../ipc/preflight-runtime-target'
+
+export async function isNpxOnPathForSkillInstall(
+  context?: PreflightRuntimeContext
+): Promise<boolean> {
+  // Why: cold GUI launches need login-shell hydration to find nvm/brew-managed Node.
+  await hydrateShellPathForAgentDetection(context)
+  return isCommandOnPath('npx', getPreflightWslTarget(context) ?? undefined)
+}

--- a/src/main/skills/skill-install-npx-preflight.ts
+++ b/src/main/skills/skill-install-npx-preflight.ts
@@ -4,11 +4,27 @@ import {
   getPreflightWslTarget,
   type PreflightRuntimeContext
 } from '../ipc/preflight-runtime-target'
+import { mergePersistedWindowsPathAsync } from '../pty/windows-environment-path'
+import { hydrateShellPath, mergePathSegments } from '../startup/hydrate-shell-path'
 
 export async function isNpxOnPathForSkillInstall(
-  context?: PreflightRuntimeContext
+  context?: PreflightRuntimeContext,
+  options?: { forceRefresh?: boolean }
 ): Promise<boolean> {
-  // Why: cold GUI launches need login-shell hydration to find nvm/brew-managed Node.
-  await hydrateShellPathForAgentDetection(context)
-  return isCommandOnPath('npx', getPreflightWslTarget(context) ?? undefined)
+  const wslTarget = getPreflightWslTarget(context) ?? undefined
+  await (options?.forceRefresh && !wslTarget
+    ? refreshHostPath()
+    : hydrateShellPathForAgentDetection(context))
+  return isCommandOnPath('npx', wslTarget)
+}
+
+async function refreshHostPath(): Promise<void> {
+  if (process.platform === 'win32') {
+    await mergePersistedWindowsPathAsync(process.env, { forceRefresh: true })
+    return
+  }
+  const hydration = await hydrateShellPath({ force: true })
+  if (hydration.ok) {
+    mergePathSegments(hydration.segments)
+  }
 }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2526,7 +2526,10 @@ export type PreloadApi = {
     cancelUpdateRun: () => Promise<void>
     acknowledgeUpdateRun: () => Promise<void>
     getUpdateRun: () => Promise<SkillUpdateRun>
-    isNpxOnPath: (context?: PreflightRuntimeContext) => Promise<boolean>
+    isNpxOnPath: (
+      context?: PreflightRuntimeContext,
+      options?: { forceRefresh?: boolean }
+    ) => Promise<boolean>
     onUpdateRun: (callback: (run: SkillUpdateRun) => void) => () => void
   }
   pet: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2526,6 +2526,7 @@ export type PreloadApi = {
     cancelUpdateRun: () => Promise<void>
     acknowledgeUpdateRun: () => Promise<void>
     getUpdateRun: () => Promise<SkillUpdateRun>
+    isNpxOnPath: (context?: PreflightRuntimeContext) => Promise<boolean>
     onUpdateRun: (callback: (run: SkillUpdateRun) => void) => () => void
   }
   pet: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2406,6 +2406,8 @@ const api = {
     cancelUpdateRun: (): Promise<void> => ipcRenderer.invoke('skills:cancelUpdateRun'),
     acknowledgeUpdateRun: (): Promise<void> => ipcRenderer.invoke('skills:acknowledgeUpdateRun'),
     getUpdateRun: (): Promise<SkillUpdateRun> => ipcRenderer.invoke('skills:getUpdateRun'),
+    isNpxOnPath: (context?: PreflightRuntimeContext): Promise<boolean> =>
+      ipcRenderer.invoke('skills:isNpxOnPath', context),
     onUpdateRun: (callback: (run: SkillUpdateRun) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, run: SkillUpdateRun): void =>
         callback(run)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2406,8 +2406,10 @@ const api = {
     cancelUpdateRun: (): Promise<void> => ipcRenderer.invoke('skills:cancelUpdateRun'),
     acknowledgeUpdateRun: (): Promise<void> => ipcRenderer.invoke('skills:acknowledgeUpdateRun'),
     getUpdateRun: (): Promise<SkillUpdateRun> => ipcRenderer.invoke('skills:getUpdateRun'),
-    isNpxOnPath: (context?: PreflightRuntimeContext): Promise<boolean> =>
-      ipcRenderer.invoke('skills:isNpxOnPath', context),
+    isNpxOnPath: (
+      context?: PreflightRuntimeContext,
+      options?: { forceRefresh?: boolean }
+    ): Promise<boolean> => ipcRenderer.invoke('skills:isNpxOnPath', context, options),
     onUpdateRun: (callback: (run: SkillUpdateRun) => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent, run: SkillUpdateRun): void =>
         callback(run)

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
@@ -147,6 +147,27 @@ describe('FeatureSetupInlineTerminal', () => {
     expect(mocks.terminalProps.at(-1)?.description).toBe(RUN_DESCRIPTION)
   })
 
+  it('ignores a stale local result after remote focus cancels the probe', async () => {
+    let finishProbe: ((onPath: boolean) => void) | undefined
+    mocks.isNpxOnPath.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishProbe = resolve
+        })
+    )
+    await renderTerminal()
+
+    mocks.settings = { activeRuntimeEnvironmentId: 'ssh-host-1' }
+    await rerenderTerminal()
+    await act(async () => {
+      finishProbe?.(false)
+    })
+
+    expect(mocks.isNpxOnPath).toHaveBeenCalledTimes(1)
+    expect(container?.textContent).not.toContain('Node.js is required')
+    expect(mocks.terminalProps.at(-1)?.description).toBe(RUN_DESCRIPTION)
+  })
+
   it('fails open when the probe rejects', async () => {
     mocks.isNpxOnPath.mockRejectedValue(new Error('ipc unavailable'))
 

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { act } from 'react'
+import { act, StrictMode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FeatureSetupInlineTerminal } from './FeatureSetupInlineTerminal'
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
     terminalWindowsShell?: string
     terminalWindowsWslDistro?: string | null
   },
+  platform: 'darwin' as NodeJS.Platform,
   isNpxOnPath: vi.fn(),
   openUrl: vi.fn()
 }))
@@ -40,17 +41,22 @@ vi.mock('@/lib/telemetry', () => ({
 let container: HTMLElement | null = null
 let root: Root | null = null
 
-async function renderTerminal(): Promise<void> {
+async function renderTerminal({ strict = false }: { strict?: boolean } = {}): Promise<void> {
   container = document.createElement('div')
   document.body.appendChild(container)
   root = createRoot(container)
+  await rerenderTerminal({ strict })
+}
+
+async function rerenderTerminal({ strict = false }: { strict?: boolean } = {}): Promise<void> {
+  const terminal = (
+    <FeatureSetupInlineTerminal
+      command={INSTALL_COMMAND}
+      selection={DEFAULT_ONBOARDING_FEATURE_SETUP_SELECTION}
+    />
+  )
   await act(async () => {
-    root?.render(
-      <FeatureSetupInlineTerminal
-        command={INSTALL_COMMAND}
-        selection={DEFAULT_ONBOARDING_FEATURE_SETUP_SELECTION}
-      />
-    )
+    root?.render(strict ? <StrictMode>{terminal}</StrictMode> : terminal)
   })
   await act(async () => {})
 }
@@ -59,13 +65,14 @@ describe('FeatureSetupInlineTerminal', () => {
   beforeEach(() => {
     mocks.terminalProps.length = 0
     mocks.settings = {}
+    mocks.platform = 'darwin'
     mocks.isNpxOnPath.mockReset()
     mocks.isNpxOnPath.mockResolvedValue(true)
     mocks.openUrl.mockReset()
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: {
-        platform: { get: () => ({ platform: 'darwin' }) },
+        platform: { get: () => ({ platform: mocks.platform }) },
         shell: { openUrl: mocks.openUrl },
         skills: { isNpxOnPath: mocks.isNpxOnPath }
       }
@@ -88,7 +95,21 @@ describe('FeatureSetupInlineTerminal', () => {
     await renderTerminal()
 
     expect(mocks.isNpxOnPath).toHaveBeenCalledTimes(1)
+    expect(mocks.isNpxOnPath).toHaveBeenCalledWith(undefined, { forceRefresh: false })
     expect(mocks.terminalProps.at(-1)?.description).toBe(RUN_DESCRIPTION)
+  })
+
+  it('issues one WSL preflight during a StrictMode mount', async () => {
+    mocks.platform = 'win32'
+    mocks.settings = {
+      terminalWindowsShell: 'wsl.exe',
+      terminalWindowsWslDistro: 'Ubuntu'
+    }
+
+    await renderTerminal({ strict: true })
+
+    expect(mocks.isNpxOnPath).toHaveBeenCalledTimes(1)
+    expect(mocks.isNpxOnPath).toHaveBeenCalledWith({ wslDistro: 'Ubuntu' }, { forceRefresh: false })
   })
 
   it('blocks the raw command and shows actionable guidance when npx is missing', async () => {
@@ -110,6 +131,19 @@ describe('FeatureSetupInlineTerminal', () => {
     await renderTerminal()
 
     expect(mocks.isNpxOnPath).not.toHaveBeenCalled()
+    expect(mocks.terminalProps.at(-1)?.description).toBe(RUN_DESCRIPTION)
+  })
+
+  it('re-probes the host after switching back from a remote runtime', async () => {
+    mocks.isNpxOnPath.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    await renderTerminal()
+
+    mocks.settings = { activeRuntimeEnvironmentId: 'ssh-host-1' }
+    await rerenderTerminal()
+    mocks.settings = {}
+    await rerenderTerminal()
+
+    expect(mocks.isNpxOnPath).toHaveBeenCalledTimes(2)
     expect(mocks.terminalProps.at(-1)?.description).toBe(RUN_DESCRIPTION)
   })
 
@@ -135,6 +169,7 @@ describe('FeatureSetupInlineTerminal', () => {
     await act(async () => {})
 
     expect(mocks.isNpxOnPath).toHaveBeenCalledTimes(2)
+    expect(mocks.isNpxOnPath).toHaveBeenNthCalledWith(2, undefined, { forceRefresh: true })
     expect(mocks.terminalProps.at(-1)?.command).toBe(INSTALL_COMMAND)
   })
 

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FeatureSetupInlineTerminal } from './FeatureSetupInlineTerminal'
+import { getFeatureSetupNpxPreflightContext } from './feature-setup-npx-preflight'
+import { DEFAULT_ONBOARDING_FEATURE_SETUP_SELECTION } from './onboarding-feature-setup'
+
+const INSTALL_COMMAND = 'npx skills add https://github.com/stablyai/orca --skill orca-cli --global'
+const RUN_DESCRIPTION =
+  'Press Enter to run the command and confirm npx if asked. You can also set this up later in Settings.'
+
+const mocks = vi.hoisted(() => ({
+  terminalProps: [] as { command: string; description: string }[],
+  settings: {} as {
+    activeRuntimeEnvironmentId?: string | null
+    terminalWindowsShell?: string
+    terminalWindowsWslDistro?: string | null
+  },
+  isNpxOnPath: vi.fn(),
+  openUrl: vi.fn()
+}))
+
+vi.mock('./OnboardingInlineCommandTerminal', () => ({
+  OnboardingInlineCommandTerminal: (props: { command: string; description: string }) => {
+    mocks.terminalProps.push(props)
+    return <div data-testid="inline-command-terminal">{props.description}</div>
+  }
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) => selector({ settings: mocks.settings })
+}))
+
+vi.mock('@/lib/telemetry', () => ({
+  track: vi.fn()
+}))
+
+let container: HTMLElement | null = null
+let root: Root | null = null
+
+async function renderTerminal(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(
+      <FeatureSetupInlineTerminal
+        command={INSTALL_COMMAND}
+        selection={DEFAULT_ONBOARDING_FEATURE_SETUP_SELECTION}
+      />
+    )
+  })
+  await act(async () => {})
+}
+
+describe('FeatureSetupInlineTerminal', () => {
+  beforeEach(() => {
+    mocks.terminalProps.length = 0
+    mocks.settings = {}
+    mocks.isNpxOnPath.mockReset()
+    mocks.isNpxOnPath.mockResolvedValue(true)
+    mocks.openUrl.mockReset()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        platform: { get: () => ({ platform: 'darwin' }) },
+        shell: { openUrl: mocks.openUrl },
+        skills: { isNpxOnPath: mocks.isNpxOnPath }
+      }
+    })
+  })
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+    }
+    root = null
+    container?.remove()
+    container = null
+    Reflect.deleteProperty(window, 'api')
+  })
+
+  it('keeps the run instruction when npx is on PATH', async () => {
+    await renderTerminal()
+
+    expect(mocks.isNpxOnPath).toHaveBeenCalledTimes(1)
+    expect(mocks.terminalProps.at(-1)?.description).toBe(RUN_DESCRIPTION)
+  })
+
+  it('blocks the raw command and shows actionable guidance when npx is missing', async () => {
+    mocks.isNpxOnPath.mockResolvedValue(false)
+
+    await renderTerminal()
+
+    expect(container?.textContent).toContain('Node.js is required')
+    expect(container?.textContent).toContain('npx was not found in this terminal environment')
+    expect(container?.textContent).toContain('Download Node.js')
+    expect(container?.textContent).toContain('Re-check')
+    expect(mocks.terminalProps).toHaveLength(0)
+  })
+
+  it('skips the local probe when a remote runtime environment is focused', async () => {
+    mocks.settings = { activeRuntimeEnvironmentId: 'ssh-host-1' }
+    mocks.isNpxOnPath.mockResolvedValue(false)
+
+    await renderTerminal()
+
+    expect(mocks.isNpxOnPath).not.toHaveBeenCalled()
+    expect(mocks.terminalProps.at(-1)?.description).toBe(RUN_DESCRIPTION)
+  })
+
+  it('fails open when the probe rejects', async () => {
+    mocks.isNpxOnPath.mockRejectedValue(new Error('ipc unavailable'))
+
+    await renderTerminal()
+
+    expect(mocks.terminalProps.at(-1)?.description).toBe(RUN_DESCRIPTION)
+  })
+
+  it('re-checks after Node.js is installed', async () => {
+    mocks.isNpxOnPath.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    await renderTerminal()
+
+    const recheck = Array.from(container?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent?.trim() === 'Re-check'
+    )
+    expect(recheck).toBeDefined()
+    await act(async () => {
+      recheck?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    await act(async () => {})
+
+    expect(mocks.isNpxOnPath).toHaveBeenCalledTimes(2)
+    expect(mocks.terminalProps.at(-1)?.command).toBe(INSTALL_COMMAND)
+  })
+
+  it('opens the Node.js download in the external browser', async () => {
+    mocks.isNpxOnPath.mockResolvedValue(false)
+    await renderTerminal()
+
+    const download = Array.from(container?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent?.trim() === 'Download Node.js'
+    )
+    download?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(mocks.openUrl).toHaveBeenCalledWith('https://nodejs.org/')
+  })
+})
+
+describe('getFeatureSetupNpxPreflightContext', () => {
+  it('targets the configured WSL distro', () => {
+    expect(getFeatureSetupNpxPreflightContext('win32', 'wsl.exe', ' Ubuntu ')).toEqual({
+      wslDistro: 'Ubuntu'
+    })
+  })
+
+  it('targets the default distro when none is configured', () => {
+    expect(
+      getFeatureSetupNpxPreflightContext('win32', 'C:\\Windows\\System32\\wsl.exe', null)
+    ).toEqual({ wslDefault: true })
+  })
+
+  it.each([
+    ['darwin', 'zsh'],
+    ['linux', 'bash'],
+    ['win32', 'powershell.exe'],
+    ['win32', 'cmd.exe'],
+    ['win32', 'C:\\Program Files\\Git\\bin\\bash.exe']
+  ] as const)('uses the host PATH for %s with %s', (platform, shell) => {
+    expect(getFeatureSetupNpxPreflightContext(platform, shell, null)).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.tsx
@@ -44,6 +44,7 @@ export function FeatureSetupInlineTerminal({
     key: probeKey,
     status: initialProbeStatus
   })
+  const npxProbeRequestRef = useRef<{ key: string; promise: Promise<boolean> } | null>(null)
 
   if (npxProbe.key !== probeKey) {
     setNpxProbe({ key: probeKey, status: initialProbeStatus })
@@ -51,6 +52,7 @@ export function FeatureSetupInlineTerminal({
 
   useEffect(() => {
     if (isRemoteRuntimeFocused) {
+      npxProbeRequestRef.current = null
       return
     }
     let cancelled = false
@@ -59,7 +61,15 @@ export function FeatureSetupInlineTerminal({
       terminalWindowsShell,
       terminalWindowsWslDistro
     )
-    window.api.skills.isNpxOnPath(context).then(
+    const existingRequest = npxProbeRequestRef.current
+    const request =
+      existingRequest?.key === probeKey
+        ? existingRequest.promise
+        : window.api.skills.isNpxOnPath(context, { forceRefresh: probeRevision > 0 })
+    if (request !== existingRequest?.promise) {
+      npxProbeRequestRef.current = { key: probeKey, promise: request }
+    }
+    void request.then(
       (onPath) => {
         if (!cancelled) {
           setNpxProbe({ key: probeKey, status: onPath ? 'available' : 'missing' })
@@ -74,7 +84,14 @@ export function FeatureSetupInlineTerminal({
     return () => {
       cancelled = true
     }
-  }, [isRemoteRuntimeFocused, platform, probeKey, terminalWindowsShell, terminalWindowsWslDistro])
+  }, [
+    isRemoteRuntimeFocused,
+    platform,
+    probeKey,
+    probeRevision,
+    terminalWindowsShell,
+    terminalWindowsWslDistro
+  ])
 
   const selectionTelemetry = useMemo(
     () => onboardingFeatureSetupTelemetrySelection(selection),

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.tsx
@@ -1,11 +1,16 @@
-import { useCallback, useMemo, useRef, type KeyboardEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+import { ExternalLink, Loader2, RefreshCw, TriangleAlert } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
 import { track } from '@/lib/telemetry'
 import { notifyInstalledAgentSkillsChanged } from '@/hooks/useInstalledAgentSkills'
+import { useAppStore } from '@/store'
 import { OnboardingInlineCommandTerminal } from './OnboardingInlineCommandTerminal'
 import {
   onboardingFeatureSetupTelemetrySelection,
   type OnboardingFeatureSetupSelection
 } from './onboarding-feature-setup'
+import { getFeatureSetupNpxPreflightContext } from './feature-setup-npx-preflight'
 import { translate } from '@/i18n/i18n'
 
 type FeatureSetupInlineTerminalProps = {
@@ -13,12 +18,63 @@ type FeatureSetupInlineTerminalProps = {
   selection: OnboardingFeatureSetupSelection
 }
 
+type NpxProbeStatus = 'checking' | 'available' | 'missing'
+
 export function FeatureSetupInlineTerminal({
   command,
   selection
 }: FeatureSetupInlineTerminalProps): React.JSX.Element {
   const terminalOpenedTrackedRef = useRef(false)
   const terminalInteractedTrackedRef = useRef(false)
+  const activeRuntimeEnvironmentId = useAppStore((s) => s.settings?.activeRuntimeEnvironmentId)
+  const terminalWindowsShell = useAppStore((s) => s.settings?.terminalWindowsShell)
+  const terminalWindowsWslDistro = useAppStore((s) => s.settings?.terminalWindowsWslDistro)
+  const isRemoteRuntimeFocused = Boolean(activeRuntimeEnvironmentId?.trim())
+  const platform = getRendererAppPlatform()
+  const [probeRevision, setProbeRevision] = useState(0)
+  const probeKey = [
+    isRemoteRuntimeFocused,
+    platform,
+    terminalWindowsShell,
+    terminalWindowsWslDistro,
+    probeRevision
+  ].join(':')
+  const initialProbeStatus = isRemoteRuntimeFocused ? 'available' : 'checking'
+  const [npxProbe, setNpxProbe] = useState<{ key: string; status: NpxProbeStatus }>({
+    key: probeKey,
+    status: initialProbeStatus
+  })
+
+  if (npxProbe.key !== probeKey) {
+    setNpxProbe({ key: probeKey, status: initialProbeStatus })
+  }
+
+  useEffect(() => {
+    if (isRemoteRuntimeFocused) {
+      return
+    }
+    let cancelled = false
+    const context = getFeatureSetupNpxPreflightContext(
+      platform,
+      terminalWindowsShell,
+      terminalWindowsWslDistro
+    )
+    window.api.skills.isNpxOnPath(context).then(
+      (onPath) => {
+        if (!cancelled) {
+          setNpxProbe({ key: probeKey, status: onPath ? 'available' : 'missing' })
+        }
+      },
+      () => {
+        if (!cancelled) {
+          setNpxProbe({ key: probeKey, status: 'available' })
+        }
+      }
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [isRemoteRuntimeFocused, platform, probeKey, terminalWindowsShell, terminalWindowsWslDistro])
 
   const selectionTelemetry = useMemo(
     () => onboardingFeatureSetupTelemetrySelection(selection),
@@ -53,6 +109,70 @@ export function FeatureSetupInlineTerminal({
     },
     [selectionTelemetry]
   )
+
+  if (npxProbe.status === 'checking') {
+    return (
+      <div
+        role="status"
+        className="mt-4 flex min-h-24 items-center justify-center gap-2 rounded-xl border border-border bg-card text-sm text-muted-foreground"
+      >
+        <Loader2 className="size-4 animate-spin" />
+        {translate(
+          'auto.components.onboarding.FeatureSetupInlineTerminal.checkingNpx',
+          'Checking for npx…'
+        )}
+      </div>
+    )
+  }
+
+  if (npxProbe.status === 'missing') {
+    return (
+      <section className="mt-4 rounded-xl border border-border bg-card p-4" aria-live="polite">
+        <div className="flex items-start gap-3">
+          <TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <div className="min-w-0">
+            <h3 className="text-sm font-medium text-foreground">
+              {translate(
+                'auto.components.onboarding.FeatureSetupInlineTerminal.npxMissingTitle',
+                'Node.js is required'
+              )}
+            </h3>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+              {translate(
+                'auto.components.onboarding.FeatureSetupInlineTerminal.npxMissingNotice',
+                'npx was not found in this terminal environment. Install Node.js LTS, then re-check to continue skill setup.'
+              )}
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void window.api.shell.openUrl('https://nodejs.org/')}
+              >
+                <ExternalLink className="size-3.5" />
+                {translate(
+                  'auto.components.onboarding.FeatureSetupInlineTerminal.downloadNode',
+                  'Download Node.js'
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setProbeRevision((revision) => revision + 1)}
+              >
+                <RefreshCw className="size-3.5" />
+                {translate(
+                  'auto.components.onboarding.FeatureSetupInlineTerminal.recheckNpx',
+                  'Re-check'
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+    )
+  }
 
   return (
     <OnboardingInlineCommandTerminal

--- a/src/renderer/src/components/onboarding/feature-setup-npx-preflight.ts
+++ b/src/renderer/src/components/onboarding/feature-setup-npx-preflight.ts
@@ -1,0 +1,13 @@
+import { isWslShellName } from '../../../../shared/local-windows-terminal-runtime'
+
+export function getFeatureSetupNpxPreflightContext(
+  platform: NodeJS.Platform,
+  terminalWindowsShell: string | undefined,
+  terminalWindowsWslDistro: string | null | undefined
+): { wslDistro?: string; wslDefault?: boolean } | undefined {
+  if (platform !== 'win32' || !isWslShellName(terminalWindowsShell)) {
+    return undefined
+  }
+  const distro = terminalWindowsWslDistro?.trim()
+  return distro ? { wslDistro: distro } : { wslDefault: true }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11440,7 +11440,12 @@
         "FeatureSetupInlineTerminal": {
           "789b59936e": "Press Enter to run the command and confirm npx if asked. You can also set this up later in Settings.",
           "47fc6cc6dc": "Skill setup command",
-          "c767ab7061": "Skill setup"
+          "c767ab7061": "Skill setup",
+          "checkingNpx": "Checking for npx…",
+          "downloadNode": "Download Node.js",
+          "npxMissingNotice": "npx was not found in this terminal environment. Install Node.js LTS, then re-check to continue skill setup.",
+          "npxMissingTitle": "Node.js is required",
+          "recheckNpx": "Re-check"
         },
         "IntegrationsStep": {
           "277f30eb34": "Linear, GitLab, Bitbucket, Azure DevOps, Gitea, and Jira live in Settings > Integrations.",

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2966,6 +2966,8 @@ function createSkillsApi(): NonNullable<Partial<PreloadApi>['skills']> {
     cancelUpdateRun: () => Promise.resolve(),
     acknowledgeUpdateRun: () => Promise.resolve(),
     getUpdateRun: () => Promise.resolve({ state: 'idle' as const }),
+    // Why: the browser client cannot inspect the host PATH; avoid a false block.
+    isNpxOnPath: () => Promise.resolve(true),
     onUpdateRun: () => () => {}
   }
 }


### PR DESCRIPTION
## Summary

- preflight npx before mounting the shared onboarding and feature-wall setup terminal
- route the prerequisite check through host-aware IPC so native Windows and WSL retain their existing command lookup behavior
- keep macOS, Linux, SSH, WSL, and headless update command behavior unchanged

Relates to #10438.

## Validation

- real Electron QA: the shared setup surface showed Checking for npx before terminal creation
- focused Vitest coverage: 22 tests passed
- pnpm typecheck
- pnpm lint
- node config/scripts/check-react-doctor-changed.mjs
- git diff --check

## Electron QA

A real Electron run exercised the shared onboarding/feature-wall surface. The npx prerequisite completed before the inline terminal mounted, after which the original interactive install command remained ready for the user to run:

![Onboarding skill setup terminal after npx preflight](https://github.com/user-attachments/assets/99ab317f-dda9-4242-877c-1eb6f0cecdc0)


## Fresh exact-head Electron QA (2026-07-30)

At `a3d137ebf7c8bdfd18724a51f1500bdfdc4ee7f3`, the real shared onboarding/feature-wall surface was launched with a controlled npx-less host PATH. It rendered `checking → missing` without creating a PTY. After making npx available and selecting **Re-check**, it rendered `checking → terminal`, created exactly one ephemeral PTY, and preserved the unchanged interactive `npx skills add ...` command at a live shell prompt.

![Uncropped full-app onboarding terminal after npx re-check](https://github.com/user-attachments/assets/47e1160e-8019-4fab-9f17-0f297e448eb9)

Live Windows/WSL execution remains unverified; focused routing, refresh, fanout, and renderer-gating tests cover those contracts.

## Updated final owner verification (2026-07-30)

- Final head: `a3d137ebf7c8bdfd18724a51f1500bdfdc4ee7f3`.
- Review fixes `6b78b40973` and `a3d137ebf7` make explicit Re-check invalidate cached PATH state, deduplicate StrictMode mount probing, and replace synchronous Windows registry PATH reads with parallel asynchronous queries.
- Three same-model/xhigh rounds completed; the final round returned zero actionable findings after 111 focused tests across 9 files plus node/web typechecks, lint/oxfmt, React Doctor, localization, diff, and performance checks.
- Performance audit: native Windows uses one IPC plus two parallel cached/shared `reg.exe` queries and no npx subprocess; WSL uses one IPC plus one `wsl.exe`; uncached POSIX uses one IPC plus one login shell; remote/SSH focus performs no local IPC or subprocess.
- Full local gates pass, all CI is successful, and the branch is synchronized, open, MERGEABLE/CLEAN.
- `SkillUpdateRunner`, mobile, and `wrapWindowsSkillCommandWithNpxPrerequisite` remain untouched.
- Commit authorship was verified from `%an/%ae`: all three commits are Brennan Benson `<79079362+brennanb2025@users.noreply.github.com>`.
- Orca rejected lifecycle completion messages because the retained legacy coordinator could not prove its original process identity; transcript-backed clean verdicts and validations remain intact.

## Final exact-prompt review

A fresh same-model/same-thinking Codex review at `a3d137ebf7c8bdfd18724a51f1500bdfdc4ee7f3` returned zero actionable findings and made no changes. Validation passed 168 focused tests across 8 files, full node/CLI/web typecheck, full lint/localization gates, React Doctor (0 issues), oxfmt, and `git diff --check`. Native Windows, WSL, POSIX, remote/SSH, StrictMode, refresh, stale-result cleanup, and performance paths were explicitly reviewed clean.