### PR TITLE
[P0] fix(relay): survive PTY exit after a canceled source delivery

### DIFF
--- a/src/relay/pty-handler-source-publication.test.ts
+++ b/src/relay/pty-handler-source-publication.test.ts
@@ -250,22 +250,25 @@ describe('PtyHandler negotiated source publication', () => {
     await spawn({})
     const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
     const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
-    handler.setSourcePublication(
-      stubPublication({
-        sealAndPublishExit: () => {
-          throw new Error('ledger delivery vanished')
-        }
-      })
-    )
+    try {
+      handler.setSourcePublication(
+        stubPublication({
+          sealAndPublishExit: () => {
+            throw new Error('ledger delivery vanished')
+          }
+        })
+      )
 
-    expect(() => exitCallback!({ exitCode: 7 })).not.toThrow()
+      expect(() => exitCallback!({ exitCode: 7 })).not.toThrow()
 
-    expect(exitFrames()).toHaveLength(1)
-    expect(exitFrames()[0].params).toMatchObject({ id: spawnResult.id, code: 7 })
-    expect(String(stderr.mock.calls.at(-1)?.[0])).toContain(
-      '[pty-handler] pty source exit publication failed'
-    )
-    stderr.mockRestore()
+      expect(exitFrames()).toHaveLength(1)
+      expect(exitFrames()[0].params).toMatchObject({ id: spawnResult.id, code: 7 })
+      expect(String(stderr.mock.calls.at(-1)?.[0])).toContain(
+        '[pty-handler] pty source exit publication failed'
+      )
+    } finally {
+      stderr.mockRestore()
+    }
   })
 
   it('completes the exit from the settled state without re-sealing the delivery', async () => {

--- a/src/relay/pty-handler-source-publication.test.ts
+++ b/src/relay/pty-handler-source-publication.test.ts
@@ -56,6 +56,11 @@ describe('PtyHandler negotiated source publication', () => {
   let heldResponseSettlements: ((result: SinkWriteSettlement) => void)[]
   let adapter: SshPtyConsumerSessionAdapter
   let pausePty: ReturnType<typeof vi.fn>
+  let exitCallback: ((event: { exitCode: number }) => void) | undefined
+  let destroyPty: ReturnType<typeof vi.fn>
+  let holdDataSettlements: boolean
+  let heldDataSettlements: ((result: SinkWriteSettlement) => void)[]
+  let highWaterMark: number | undefined
 
   beforeEach(async () => {
     vi.useFakeTimers()
@@ -64,20 +69,28 @@ describe('PtyHandler negotiated source publication', () => {
     heldResponseId = null
     heldResponseSettlements = []
     dataCallback = undefined
+    exitCallback = undefined
+    holdDataSettlements = false
+    heldDataSettlements = []
+    highWaterMark = undefined
     pausePty = vi.fn()
+    destroyPty = vi.fn()
     mockPtySpawn.mockReset()
     mockPtySpawn.mockReturnValue({
       pid: process.pid,
       onData: vi.fn((callback: (data: string) => void) => {
         dataCallback = callback
       }),
-      onExit: vi.fn(),
+      onExit: vi.fn((callback: (event: { exitCode: number }) => void) => {
+        exitCallback = callback
+      }),
       write: vi.fn(),
       resize: vi.fn(),
       kill: vi.fn(),
       clear: vi.fn(),
       pause: pausePty,
-      resume: vi.fn()
+      resume: vi.fn(),
+      destroy: destroyPty
     })
     dispatcher = new RelayDispatcher(
       (data, settle) => {
@@ -86,10 +99,24 @@ describe('PtyHandler negotiated source publication', () => {
           heldResponseSettlements.push(settle)
           return true
         }
+        const frame = notification(data)
+        if (holdDataSettlements && frame?.method === 'pty.data') {
+          heldDataSettlements.push(settle)
+          return true
+        }
+        if (frame?.method === 'pty.exit') {
+          // Why: real sockets never settle inside write(); a synchronous settle would re-enter
+          // the legacy capacity path before the pending exit is retired.
+          queueMicrotask(() => settle({ ok: true }))
+          return true
+        }
         settle({ ok: true })
         return true
       },
-      { supportsWriteCallback: true },
+      {
+        supportsWriteCallback: true,
+        writableHighWaterMark: () => highWaterMark ?? 0
+      },
       endpointIdentity
     )
     handler = new PtyHandler(dispatcher)
@@ -131,6 +158,130 @@ describe('PtyHandler negotiated source publication', () => {
       .map(notification)
       .filter((frame): frame is Notification => frame?.method === 'pty.data')
   }
+
+  function exitFrames(): Notification[] {
+    return writes
+      .map(notification)
+      .filter((frame): frame is Notification => frame?.method === 'pty.exit')
+  }
+
+  async function cancelSourceDelivery(spawnResult: Record<string, unknown>): Promise<void> {
+    const activation = spawnResult.sourceActivation as Record<string, unknown>
+    dispatcher.feed(
+      requestFrame(9, 'pty.cancelDelivery', {
+        id: spawnResult.id,
+        clientGeneration: activation.clientGeneration,
+        ownerGeneration: activation.ownerGeneration,
+        deliveryToken: activation.deliveryToken
+      })
+    )
+    await vi.advanceTimersByTimeAsync(0)
+  }
+
+  function stubPublication(overrides: Partial<Record<string, unknown>>): RelayPtySourcePublication {
+    return {
+      accepts: () => true,
+      exitPublicationSettled: () => false,
+      sealAndPublishExit: () => false,
+      publish: () => false,
+      onCreditAvailable: () => {},
+      receivingActivation: () => undefined,
+      waitForPendingSend: async () => true,
+      activate: () => false,
+      getDebugSnapshot: () => ({}),
+      dispose: () => {},
+      ...overrides
+    } as unknown as RelayPtySourcePublication
+  }
+
+  it('publishes a single legacy exit after the owner cancels its delivery', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    dataCallback!('prompt')
+    await vi.advanceTimersByTimeAsync(8)
+    await cancelSourceDelivery(spawnResult)
+    expect(publication.accepts(String(spawnResult.id))).toBe(false)
+
+    expect(() => exitCallback!({ exitCode: 0 })).not.toThrow()
+
+    expect(exitFrames()).toHaveLength(1)
+    expect(exitFrames()[0].params).toMatchObject({ id: spawnResult.id, code: 0 })
+    expect(destroyPty).toHaveBeenCalledOnce()
+
+    handler.handleSourcePublicationCapacity(String(spawnResult.id))
+    await vi.advanceTimersByTimeAsync(8)
+    expect(exitFrames()).toHaveLength(1)
+  })
+
+  it('drains buffered legacy output before the exit when capacity returns', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    await cancelSourceDelivery(spawnResult)
+    holdDataSettlements = true
+
+    dataCallback!('first')
+    await vi.advanceTimersByTimeAsync(8)
+    expect(heldDataSettlements).toHaveLength(1)
+    // Why: shrinking the frame capacity makes the next chunk unpublishable, so it stays queued.
+    highWaterMark = 64
+    dataCallback!('second')
+    await vi.advanceTimersByTimeAsync(8)
+
+    expect(() => exitCallback!({ exitCode: 3 })).not.toThrow()
+    expect(exitFrames()).toHaveLength(0)
+
+    highWaterMark = undefined
+    holdDataSettlements = false
+    heldDataSettlements[0]({ ok: true })
+    await vi.advanceTimersByTimeAsync(8)
+
+    const frames = writes
+      .map(notification)
+      .filter(
+        (frame): frame is Notification =>
+          frame?.method === 'pty.data' || frame?.method === 'pty.exit'
+      )
+    expect(frames.map((frame) => frame.method)).toEqual(['pty.data', 'pty.data', 'pty.exit'])
+    expect(frames.map((frame) => frame.params.data)).toEqual(['first', 'second', undefined])
+    expect(frames.at(-1)!.params).toMatchObject({ id: spawnResult.id, code: 3 })
+  })
+
+  it('contains a source publication fault and still delivers the legacy exit', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    handler.setSourcePublication(
+      stubPublication({
+        sealAndPublishExit: () => {
+          throw new Error('ledger delivery vanished')
+        }
+      })
+    )
+
+    expect(() => exitCallback!({ exitCode: 7 })).not.toThrow()
+
+    expect(exitFrames()).toHaveLength(1)
+    expect(exitFrames()[0].params).toMatchObject({ id: spawnResult.id, code: 7 })
+    expect(String(stderr.mock.calls.at(-1)?.[0])).toContain(
+      '[pty-handler] pty source exit publication failed'
+    )
+    stderr.mockRestore()
+  })
+
+  it('completes the exit from the settled state without re-sealing the delivery', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    const sealAndPublishExit = vi.fn(() => true)
+    handler.setSourcePublication(
+      stubPublication({ exitPublicationSettled: () => true, sealAndPublishExit })
+    )
+
+    exitCallback!({ exitCode: 0 })
+    handler.handleSourcePublicationCapacity(String(spawnResult.id))
+
+    expect(sealAndPublishExit).not.toHaveBeenCalled()
+    expect(exitFrames()).toHaveLength(0)
+  })
 
   it('fences the first source frame behind immutable spawn and attach activation metadata', async () => {
     heldResponseId = 2

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1019,14 +1019,33 @@ export class PtyHandler {
       return
     }
     if (this.sourcePublication?.accepts(id)) {
-      if (
-        !this.sourcePublication.sealAndPublishExit(exit) ||
-        !this.sourcePublication.exitPublicationSettled(id)
-      ) {
+      try {
+        // Why: after the exit settlement, re-entering sealAndPublishExit would pump a closed
+        // ledger delivery; the settled state alone decides completion.
+        if (this.sourcePublication.exitPublicationSettled(id)) {
+          this.pendingExitByPty.delete(id)
+          return
+        }
+        if (!this.sourcePublication.sealAndPublishExit(exit)) {
+          return
+        }
+        if (
+          this.sourcePublication.accepts(id) &&
+          !this.sourcePublication.exitPublicationSettled(id)
+        ) {
+          return
+        }
+        this.pendingExitByPty.delete(id)
         return
+      } catch (err) {
+        // Why: a source-publication fault must never escape onExit — it reaches
+        // uncaughtException and kills the whole relay daemon. Fall back to the legacy exit.
+        process.stderr.write(
+          `[pty-handler] pty source exit publication failed for ${id}: ${
+            err instanceof Error ? (err.stack ?? err.message) : String(err)
+          }\n`
+        )
       }
-      this.pendingExitByPty.delete(id)
-      return
     }
     const published = this.dispatcher.tryNotifyPtyExit
       ? this.dispatcher.tryNotifyPtyExit(exit)

--- a/src/relay/pty-source-credit-availability-notice.ts
+++ b/src/relay/pty-source-credit-availability-notice.ts
@@ -1,0 +1,19 @@
+/**
+ * Guarded fan-out of "this delivery released credit" to the publication layer.
+ */
+export function notifyPtySourceCreditAvailable(
+  notify: ((id: string) => void) | undefined,
+  id: string
+): void {
+  try {
+    notify?.(id)
+  } catch (err) {
+    // Why: this fires from request handlers, detach paths, and a bare grace setTimeout; a
+    // downstream throw in the timer would reach uncaughtException and kill the daemon.
+    process.stderr.write(
+      `[pty-source-credit] credit-available notification failed for ${id}: ${
+        err instanceof Error ? (err.stack ?? err.message) : String(err)
+      }\n`
+    )
+  }
+}

--- a/src/relay/pty-source-credit-ledger.test.ts
+++ b/src/relay/pty-source-credit-ledger.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { PtySourceDeliveryIdentity } from '../shared/pty-source-credit-contract'
 import { RelayPtySourceCreditLedger } from './pty-source-credit-ledger'
+import { CLOSED_DELIVERY_TOMBSTONE_LIMIT } from './pty-source-credit-record'
 
 function identity(
   deliveryToken = 'token-1',
@@ -499,6 +500,40 @@ describe('RelayPtySourceCreditLedger', () => {
 
     expect(() => ledger.snapshot(owners[0])).toThrow('stale')
     expect(ledger.snapshot(owners.at(-1)!)).toMatchObject({ state: 'closed' })
+  })
+
+  it('probes live, closed, cancelled and evicted deliveries without throwing', () => {
+    const ledger = new RelayPtySourceCreditLedger()
+    const live = identity('token-live', { id: 'pty-live' })
+    ledger.open(live, 8)
+    expect(ledger.snapshotIfKnown(live)).toMatchObject({ state: 'active', exitPublished: false })
+
+    const completed = identity('token-completed', { id: 'pty-completed' })
+    ledger.open(completed, 8)
+    ledger.seal(completed)
+    ledger.settleExitPublication(completed, { ok: true })
+    expect(ledger.snapshotIfKnown(completed)).toMatchObject({
+      state: 'closed',
+      exitPublished: true
+    })
+
+    const canceled = identity('token-canceled', { id: 'pty-canceled' })
+    ledger.open(canceled, 8)
+    ledger.cancel(canceled, 'client-request')
+    expect(ledger.snapshotIfKnown(canceled)).toMatchObject({
+      state: 'closed',
+      exitPublished: false
+    })
+
+    expect(ledger.snapshotIfKnown(identity('token-unknown'))).toBeNull()
+    expect(() => ledger.snapshot(identity('token-unknown'))).toThrow('stale')
+
+    for (let index = 0; index < CLOSED_DELIVERY_TOMBSTONE_LIMIT; index++) {
+      const evicting = identity(`token-evicting-${index}`, { id: `pty-evicting-${index}` })
+      ledger.open(evicting, 8)
+      ledger.cancel(evicting, 'test')
+    }
+    expect(ledger.snapshotIfKnown(canceled)).toBeNull()
   })
 
   it('rejects reopening a recently closed one-use token', () => {

--- a/src/relay/pty-source-credit-ledger.ts
+++ b/src/relay/pty-source-credit-ledger.ts
@@ -25,6 +25,7 @@ import {
   createDeliveryCancellation,
   createDeliveryRecord,
   createReplacementDeliveryRecord,
+  matchingDeliverySnapshot,
   MAX_SOURCE_SPAN_DATA_BYTES,
   ptyOwnerKey,
   retainedDataBytesTotal,
@@ -248,16 +249,18 @@ export class RelayPtySourceCreditLedger {
     return Object.freeze({ cancellation, recovery: Object.freeze(replacement.spans.slice()) })
   }
 
+  // Why: callers that can legitimately race a close probe instead of throwing; an evicted
+  // tombstone reads as null and must be treated as closed.
+  snapshotIfKnown(identity: PtySourceDeliveryIdentity): PtySourceDeliverySnapshot | null {
+    return matchingDeliverySnapshot(this.deliveries, this.closedSnapshots, identity)
+  }
+
   snapshot(identity: PtySourceDeliveryIdentity): PtySourceDeliverySnapshot {
-    const active = this.deliveries.get(ptySourceDeliveryKey(identity))
-    if (active && samePtySourceDelivery(active.identity, identity)) {
-      return snapshotDeliveryRecord(active)
+    const snapshot = this.snapshotIfKnown(identity)
+    if (!snapshot) {
+      throw new Error('Unknown or stale PTY source delivery')
     }
-    const closed = this.closedSnapshots.get(ptySourceDeliveryKey(identity))
-    if (closed && samePtySourceDelivery(closed, identity)) {
-      return closed
-    }
-    throw new Error('Unknown or stale PTY source delivery')
+    return snapshot
   }
 
   retainedSourceSu = (): number => retainedSourceTotal(this.deliveries.values())

--- a/src/relay/pty-source-credit-record.ts
+++ b/src/relay/pty-source-credit-record.ts
@@ -5,7 +5,11 @@ import type {
   PtySourceSpan,
   PtySourceTransform
 } from '../shared/pty-source-credit-contract'
-import { ptySourceSpanIsSplittable } from '../shared/pty-source-credit-contract'
+import {
+  ptySourceDeliveryKey,
+  ptySourceSpanIsSplittable,
+  samePtySourceDelivery
+} from '../shared/pty-source-credit-contract'
 import {
   assertNonNegativeSafeInteger,
   assertPositiveSafeInteger,
@@ -167,6 +171,21 @@ export function snapshotDeliveryRecord(record: DeliveryRecord): PtySourceDeliver
     exitPublished: record.exitPublished,
     generationClosed: record.generationClosed
   })
+}
+
+// Why: identity equality is re-checked because a delivery key outlives the token that made it.
+export function matchingDeliverySnapshot(
+  deliveries: ReadonlyMap<string, DeliveryRecord>,
+  closedSnapshots: ReadonlyMap<string, PtySourceDeliverySnapshot>,
+  identity: PtySourceDeliveryIdentity
+): PtySourceDeliverySnapshot | null {
+  const key = ptySourceDeliveryKey(identity)
+  const active = deliveries.get(key)
+  if (active && samePtySourceDelivery(active.identity, identity)) {
+    return snapshotDeliveryRecord(active)
+  }
+  const closed = closedSnapshots.get(key)
+  return closed && samePtySourceDelivery(closed, identity) ? closed : null
 }
 
 export function retainedSourceTotal(records: Iterable<DeliveryRecord>): number {

--- a/src/relay/relay-pty-source-cancellation-exit.test.ts
+++ b/src/relay/relay-pty-source-cancellation-exit.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PTY_CONSUMER_OWNER_GRACE_MS } from '../shared/pty-consumer-session'
+import {
+  RelayDispatcher,
+  type RelayClientSessionIdentity,
+  type SinkWriteSettlement
+} from './dispatcher'
+import { encodeJsonRpcFrame, MessageType } from './protocol'
+import { RelayPtySourcePublication } from './relay-pty-source-publication'
+import { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+const endpointIdentity: RelayClientSessionIdentity = {
+  principal: 'endpoint-principal',
+  authenticated: true,
+  allowSessionOwner: true,
+  authenticationKind: 'endpoint-credential'
+}
+
+type Notification = { method: string; params: Record<string, unknown> }
+
+function requestFrame(id: number, method: string, params: Record<string, unknown>): Buffer {
+  return encodeJsonRpcFrame({ jsonrpc: '2.0', id, method, params }, id, 0)
+}
+
+function decode(buffer: Buffer): Record<string, unknown> | null {
+  if (buffer[0] !== MessageType.Regular) {
+    return null
+  }
+  const length = buffer.readUInt32BE(9)
+  return JSON.parse(buffer.subarray(13, 13 + length).toString('utf8'))
+}
+
+function notification(buffer: Buffer): Notification | null {
+  const message = decode(buffer)
+  return typeof message?.method === 'string' && message.id === undefined
+    ? (message as Notification)
+    : null
+}
+
+function responseResult(buffer: Buffer): Record<string, unknown> | null {
+  const message = decode(buffer)
+  return !message || message.id === undefined
+    ? null
+    : ((message.result as Record<string, unknown>) ?? null)
+}
+
+async function flushRequests(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+describe('RelayPtySourcePublication cancellation and exit', () => {
+  let dispatcher: RelayDispatcher | null = null
+
+  afterEach(() => {
+    dispatcher?.dispose()
+    dispatcher = null
+  })
+
+  async function createHarness(windowSu = 8, holdExitSettlement = false) {
+    const writes: Buffer[] = []
+    const exitSettlements: ((result: SinkWriteSettlement) => void)[] = []
+    const capacityIds: string[] = []
+    dispatcher = new RelayDispatcher(
+      (data, onSettled) => {
+        writes.push(Buffer.from(data))
+        const frame = notification(data)
+        if (frame?.method === 'pty.exit') {
+          exitSettlements.push(onSettled)
+          if (holdExitSettlement) {
+            return true
+          }
+        }
+        onSettled({ ok: true })
+        return true
+      },
+      { supportsWriteCallback: true },
+      endpointIdentity
+    )
+    let publication: RelayPtySourcePublication
+    const adapter = new SshPtyConsumerSessionAdapter(dispatcher, 'build-a', undefined, (id) =>
+      publication.onCreditAvailable(id)
+    )
+    publication = new RelayPtySourcePublication(dispatcher, adapter, (id) => capacityIds.push(id))
+    dispatcher.feed(
+      requestFrame(1, 'pty.openClient', {
+        protocolVersion: 1,
+        clientInstanceId: 'client-1',
+        requestedRole: 'session-owner',
+        capabilities: { outputFlowControl: { versions: [1], requestedWindowSu: windowSu } }
+      })
+    )
+    await flushRequests()
+    const activationSettlements: ((result: SinkWriteSettlement) => void)[] = []
+    expect(
+      publication.activate('pty-1', 'incarnation-1', {
+        clientId: 1,
+        isStale: () => false,
+        sessionIdentity: endpointIdentity,
+        onResponseSettled: (callback) => activationSettlements.push(callback)
+      })
+    ).toBe('opened')
+    activationSettlements[0]({ ok: true })
+    return { adapter, publication, exitSettlements, capacityIds, writes }
+  }
+
+  function cancelDeliveryFrame(
+    requestId: number,
+    activation: { clientGeneration: number; ownerGeneration: number; deliveryToken: string }
+  ): Buffer {
+    return requestFrame(requestId, 'pty.cancelDelivery', {
+      id: 'pty-1',
+      clientGeneration: activation.clientGeneration,
+      ownerGeneration: activation.ownerGeneration,
+      deliveryToken: activation.deliveryToken
+    })
+  }
+
+  function exitFrames(writes: Buffer[]): Notification[] {
+    return writes
+      .map(notification)
+      .filter((frame): frame is Notification => frame?.method === 'pty.exit')
+  }
+
+  function ackFrame(
+    requestId: number,
+    activation: { clientGeneration: number; ownerGeneration: number; deliveryToken: string },
+    creditedEndSu: number
+  ): Buffer {
+    return encodeJsonRpcFrame(
+      {
+        jsonrpc: '2.0',
+        method: 'pty.ackData',
+        params: {
+          acknowledgements: [
+            {
+              id: 'pty-1',
+              clientGeneration: activation.clientGeneration,
+              ownerGeneration: activation.ownerGeneration,
+              deliveryToken: activation.deliveryToken,
+              creditedEndSu
+            }
+          ]
+        }
+      },
+      requestId,
+      0
+    )
+  }
+
+  it('retires the record when a client cancels, so the exit never seals a dead ledger', async () => {
+    const harness = await createHarness()
+    harness.publication.publish('pty-1', { data: 'data' }, false)
+    const activation = harness.publication.receivingActivation('pty-1', 1)!
+
+    dispatcher!.feed(cancelDeliveryFrame(2, activation))
+    await flushRequests()
+
+    expect(harness.publication.accepts('pty-1')).toBe(false)
+    expect(harness.capacityIds).toContain('pty-1')
+    expect(() =>
+      expect(
+        harness.publication.sealAndPublishExit({
+          id: 'pty-1',
+          code: 0,
+          incarnationId: 'incarnation-1'
+        })
+      ).toBe(false)
+    ).not.toThrow()
+  })
+
+  it('retires the record when the reconnect grace expires', async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout'] })
+    try {
+      const harness = await createHarness()
+      harness.publication.publish('pty-1', { data: 'data' }, false)
+
+      dispatcher!.invalidateClient()
+      vi.advanceTimersByTime(PTY_CONSUMER_OWNER_GRACE_MS)
+
+      expect(harness.publication.accepts('pty-1')).toBe(false)
+      expect(harness.capacityIds).toContain('pty-1')
+      expect(() =>
+        expect(
+          harness.publication.sealAndPublishExit({
+            id: 'pty-1',
+            code: 0,
+            incarnationId: 'incarnation-1'
+          })
+        ).toBe(false)
+      ).not.toThrow()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('opens a fresh delivery when the same client re-attaches after a cancel', async () => {
+    const harness = await createHarness()
+    harness.publication.publish('pty-1', { data: 'data' }, false)
+    const activation = harness.publication.receivingActivation('pty-1', 1)!
+    dispatcher!.feed(cancelDeliveryFrame(2, activation))
+    await flushRequests()
+
+    const activationSettlements: ((result: SinkWriteSettlement) => void)[] = []
+    expect(
+      harness.publication.activate('pty-1', 'incarnation-1', {
+        clientId: 1,
+        isStale: () => false,
+        sessionIdentity: endpointIdentity,
+        onResponseSettled: (callback) => activationSettlements.push(callback)
+      })
+    ).toBe('opened')
+    activationSettlements[0]({ ok: true })
+
+    expect(
+      harness.publication.sealAndPublishExit({
+        id: 'pty-1',
+        code: 0,
+        incarnationId: 'incarnation-1'
+      })
+    ).toBe(true)
+    expect(exitFrames(harness.writes)).toHaveLength(1)
+  })
+
+  it('survives a cancel while the credit-mode exit frame is still in flight', async () => {
+    const harness = await createHarness(8, true)
+    harness.publication.publish('pty-1', { data: 'data' }, false)
+    const activation = harness.publication.receivingActivation('pty-1', 1)!
+    dispatcher!.feed(ackFrame(2, activation, 4))
+    expect(
+      harness.publication.sealAndPublishExit({
+        id: 'pty-1',
+        code: 0,
+        incarnationId: 'incarnation-1'
+      })
+    ).toBe(true)
+    expect(harness.exitSettlements).toHaveLength(1)
+
+    dispatcher!.feed(cancelDeliveryFrame(3, activation))
+    await flushRequests()
+    expect(
+      harness.writes.map(responseResult).filter((result) => result?.canceled === true)
+    ).toHaveLength(1)
+    // Why: A' keeps the record while the frame is in flight so no duplicate legacy exit escapes.
+    expect(harness.publication.accepts('pty-1')).toBe(true)
+
+    expect(() => harness.exitSettlements[0]({ ok: true })).not.toThrow()
+
+    expect(exitFrames(harness.writes)).toHaveLength(1)
+    expect(harness.capacityIds).toContain('pty-1')
+    expect(harness.publication.exitPublicationSettled('pty-1')).toBe(true)
+    expect(harness.publication.accepts('pty-1')).toBe(false)
+  })
+
+  it('retires the record after the in-flight exit frame fails on a canceled delivery', async () => {
+    const harness = await createHarness(8, true)
+    harness.publication.publish('pty-1', { data: 'data' }, false)
+    const activation = harness.publication.receivingActivation('pty-1', 1)!
+    dispatcher!.feed(ackFrame(2, activation, 4))
+    harness.publication.sealAndPublishExit({ id: 'pty-1', code: 0, incarnationId: 'incarnation-1' })
+    dispatcher!.feed(cancelDeliveryFrame(3, activation))
+    await flushRequests()
+    const capacityBefore = harness.capacityIds.length
+
+    expect(() =>
+      harness.exitSettlements[0]({ ok: false, error: new Error('socket write failed') })
+    ).not.toThrow()
+    // Why: the delivery is gone, so no credit event will arrive — D's widened finally must retry.
+    expect(harness.capacityIds.length).toBeGreaterThan(capacityBefore)
+
+    expect(
+      harness.publication.sealAndPublishExit({
+        id: 'pty-1',
+        code: 0,
+        incarnationId: 'incarnation-1'
+      })
+    ).toBe(true)
+    expect(harness.publication.accepts('pty-1')).toBe(false)
+    expect(harness.publication.getDebugSnapshot()).toMatchObject({
+      exitCommitted: 0,
+      exitRolledBack: 1
+    })
+  })
+
+  it('publishes exactly one exit for a healthy completion even when the retry re-runs', async () => {
+    const harness = await createHarness()
+
+    expect(
+      harness.publication.sealAndPublishExit({
+        id: 'pty-1',
+        code: 0,
+        incarnationId: 'incarnation-1'
+      })
+    ).toBe(true)
+    expect(harness.publication.exitPublicationSettled('pty-1')).toBe(true)
+    expect(harness.publication.accepts('pty-1')).toBe(false)
+
+    expect(() =>
+      expect(
+        harness.publication.sealAndPublishExit({
+          id: 'pty-1',
+          code: 0,
+          incarnationId: 'incarnation-1'
+        })
+      ).toBe(false)
+    ).not.toThrow()
+    expect(exitFrames(harness.writes)).toHaveLength(1)
+  })
+})

--- a/src/relay/relay-pty-source-exit-publication.test.ts
+++ b/src/relay/relay-pty-source-exit-publication.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  PtySourceDeliveryIdentity,
+  PtySourceDeliverySnapshot
+} from '../shared/pty-source-credit-contract'
+import type { RelayDispatcher } from './dispatcher'
+import { sealAndPublishPtySourceExit } from './relay-pty-source-exit-publication'
+import type {
+  RelayPtySourceDeliveryRecord,
+  RelayPtySourcePublicationCounters,
+  RelayPtySourceSendScheduler
+} from './relay-pty-source-send-scheduler'
+import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+const identity: PtySourceDeliveryIdentity = Object.freeze({
+  id: 'pty-1',
+  providerGeneration: 1,
+  clientGeneration: 2,
+  ownerGeneration: 3,
+  ptyIncarnation: 'incarnation-1',
+  deliveryToken: 'token-1'
+})
+
+const params = { id: 'pty-1', code: 0, incarnationId: 'incarnation-1' }
+
+function deliveryRecord(
+  overrides: Partial<RelayPtySourceDeliveryRecord> = {}
+): RelayPtySourceDeliveryRecord {
+  return {
+    clientId: 1,
+    identity,
+    sourceActivation: {
+      status: 'pending',
+      clientGeneration: identity.clientGeneration,
+      ownerGeneration: identity.ownerGeneration,
+      ptyIncarnation: identity.ptyIncarnation,
+      deliveryToken: identity.deliveryToken,
+      checkpointSourceEndSu: 0,
+      recoveryEndSu: 0
+    },
+    displayEnd: 0,
+    activating: false,
+    activationRecoveryRequest: null,
+    sealed: false,
+    legacyExitAccepted: false,
+    sourceExitState: 'idle',
+    sending: false,
+    turnFrames: 0,
+    turnSourceSu: 0,
+    turnScheduled: false,
+    sendWaiters: new Set(),
+    recoveryCheckpointSourceEndSu: null,
+    recoveryEndSu: null,
+    recoveryCompletionPending: false,
+    restoreRequired: false,
+    rotationPending: false,
+    ...overrides
+  }
+}
+
+function closedSnapshot(
+  overrides: Partial<PtySourceDeliverySnapshot> = {}
+): PtySourceDeliverySnapshot {
+  return Object.freeze({
+    ...identity,
+    state: 'closed',
+    windowSu: 8,
+    receivedEndSu: 0,
+    sentEndSu: 0,
+    creditedEndSu: 0,
+    exitPublished: false,
+    generationClosed: false,
+    ...overrides
+  })
+}
+
+function createScenario(
+  initialProbe: PtySourceDeliverySnapshot | null,
+  record: RelayPtySourceDeliveryRecord,
+  notifyAccepted = true
+) {
+  const deliveries = new Map<string, RelayPtySourceDeliveryRecord>([['pty-1', record]])
+  let probe = initialProbe
+  const setProbe = (next: PtySourceDeliverySnapshot | null): void => {
+    probe = next
+  }
+  const session = {
+    sourceDeliverySnapshotIfKnown: vi.fn(() => probe),
+    sourceDeliverySnapshot: vi.fn(() => {
+      if (!probe) {
+        throw new Error('Unknown or stale PTY source delivery')
+      }
+      return probe
+    }),
+    sealDelivery: vi.fn(),
+    settleExitPublication: vi.fn(),
+    deliveryMode: vi.fn(() => 'source-owner' as const)
+  }
+  const dispatcher = {
+    tryNotifyPtyExit: vi.fn(() => notifyAccepted),
+    tryNotifyPtyExitToMatchingClients: vi.fn(
+      (_matches: (clientId: number) => boolean, _params: unknown) => notifyAccepted
+    ),
+    projectPtyExitToMatchingClients: vi.fn(() => true),
+    tryNotifyPtyExitToClient: vi.fn(() => true)
+  }
+  const sender = { pump: vi.fn() }
+  const counters: RelayPtySourcePublicationCounters = {
+    opened: 0,
+    rotated: 0,
+    appendDenied: 0,
+    sendCommitted: 0,
+    sendRolledBack: 0,
+    exitCommitted: 0,
+    exitRolledBack: 0
+  }
+  const capacityIds: string[] = []
+  const run = (): boolean =>
+    sealAndPublishPtySourceExit({
+      params,
+      record,
+      deliveries,
+      dispatcher: dispatcher as unknown as RelayDispatcher,
+      session: session as unknown as SshPtyConsumerSessionAdapter,
+      sender: sender as unknown as RelayPtySourceSendScheduler,
+      counters,
+      onCapacity: (id) => capacityIds.push(id)
+    })
+  return { deliveries, session, dispatcher, sender, counters, capacityIds, run, setProbe }
+}
+
+describe('sealAndPublishPtySourceExit closed-delivery guard', () => {
+  it.each([
+    ['an unknown probe', null],
+    ['a closed probe', closedSnapshot()],
+    ['a closing probe', closedSnapshot({ state: 'closing' })]
+  ])('broadcasts a legacy exit and retires the record for %s', (_label, probe) => {
+    const record = deliveryRecord()
+    const scenario = createScenario(probe, record)
+
+    expect(scenario.run()).toBe(true)
+
+    expect(scenario.dispatcher.tryNotifyPtyExit).toHaveBeenCalledWith(params)
+    expect(scenario.dispatcher.tryNotifyPtyExitToMatchingClients).not.toHaveBeenCalled()
+    expect(scenario.session.sealDelivery).not.toHaveBeenCalled()
+    expect(scenario.session.settleExitPublication).not.toHaveBeenCalled()
+    expect(scenario.sender.pump).not.toHaveBeenCalled()
+    expect(scenario.deliveries.has('pty-1')).toBe(false)
+  })
+
+  it('re-targets only source-owner clients once a legacy broadcast already landed', () => {
+    const record = deliveryRecord({ legacyExitAccepted: true })
+    const scenario = createScenario(closedSnapshot(), record)
+
+    expect(scenario.run()).toBe(true)
+
+    expect(scenario.dispatcher.tryNotifyPtyExit).not.toHaveBeenCalled()
+    const matches = scenario.dispatcher.tryNotifyPtyExitToMatchingClients.mock.calls[0][0]
+    expect(matches(1)).toBe(true)
+    scenario.session.deliveryMode.mockReturnValue('legacy-owner' as never)
+    expect(matches(1)).toBe(false)
+    expect(scenario.deliveries.has('pty-1')).toBe(false)
+  })
+
+  it('keeps the record retryable when the legacy notify is refused', () => {
+    const record = deliveryRecord()
+    const scenario = createScenario(closedSnapshot(), record, false)
+
+    expect(scenario.run()).toBe(false)
+
+    expect(scenario.deliveries.get('pty-1')).toBe(record)
+  })
+
+  it.each([
+    ['the tombstone retains exitPublished', closedSnapshot({ exitPublished: true }), 'idle'],
+    ['the tombstone was evicted', null, 'published']
+  ])('retires a healthily completed delivery silently when %s', (_label, probe, exitState) => {
+    const record = deliveryRecord({
+      sourceExitState: exitState as RelayPtySourceDeliveryRecord['sourceExitState']
+    })
+    const scenario = createScenario(probe, record)
+
+    expect(scenario.run()).toBe(true)
+
+    expect(scenario.dispatcher.tryNotifyPtyExit).not.toHaveBeenCalled()
+    expect(scenario.dispatcher.tryNotifyPtyExitToMatchingClients).not.toHaveBeenCalled()
+    expect(scenario.sender.pump).not.toHaveBeenCalled()
+    expect(scenario.deliveries.has('pty-1')).toBe(false)
+  })
+
+  it('defers to the in-flight exit frame settlement', () => {
+    const record = deliveryRecord({ sourceExitState: 'pending' })
+    const scenario = createScenario(closedSnapshot(), record)
+
+    expect(scenario.run()).toBe(false)
+
+    expect(scenario.session.sourceDeliverySnapshotIfKnown).not.toHaveBeenCalled()
+    expect(scenario.dispatcher.tryNotifyPtyExit).not.toHaveBeenCalled()
+    expect(scenario.deliveries.get('pty-1')).toBe(record)
+  })
+})
+
+describe('sealAndPublishPtySourceExit settlement closure', () => {
+  function createInFlightScenario(settlementProbe: PtySourceDeliverySnapshot | null) {
+    const record = deliveryRecord({ sealed: true, legacyExitAccepted: true })
+    const scenario = createScenario(closedSnapshot({ state: 'sealed-unsettled' }), record)
+    let settle: ((result: { ok: true } | { ok: false; error: Error }) => void) | undefined
+    scenario.dispatcher.tryNotifyPtyExitToClient.mockImplementation(
+      (...args: unknown[]): boolean => {
+        settle = args[2] as typeof settle
+        return true
+      }
+    )
+    expect(scenario.run()).toBe(true)
+    scenario.setProbe(settlementProbe)
+    return { ...scenario, record, settle: settle! }
+  }
+
+  it('skips the ledger settle and still resumes capacity when the delivery vanished', () => {
+    const scenario = createInFlightScenario(null)
+
+    expect(() => scenario.settle({ ok: true })).not.toThrow()
+
+    expect(scenario.session.settleExitPublication).not.toHaveBeenCalled()
+    expect(scenario.record.sourceExitState).toBe('published')
+    expect(scenario.capacityIds).toEqual(['pty-1'])
+  })
+
+  it('resumes capacity on a failed settlement once the delivery is gone', () => {
+    const scenario = createInFlightScenario(closedSnapshot())
+
+    scenario.settle({ ok: false, error: new Error('socket write failed') })
+
+    expect(scenario.session.settleExitPublication).not.toHaveBeenCalled()
+    expect(scenario.record.sourceExitState).toBe('idle')
+    expect(scenario.capacityIds).toEqual(['pty-1'])
+  })
+
+  it('logs and contains a ledger settlement fault instead of escaping the writer callback', () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const scenario = createInFlightScenario(closedSnapshot({ state: 'sealed-unsettled' }))
+    scenario.session.settleExitPublication.mockImplementation(() => {
+      throw new Error('PTY source delivery is not sealed')
+    })
+
+    expect(() => scenario.settle({ ok: true })).not.toThrow()
+
+    expect(String(stderr.mock.calls.at(-1)?.[0])).toContain(
+      '[pty-source-exit] exit settlement failed for pty-1'
+    )
+    expect(scenario.capacityIds).toEqual(['pty-1'])
+    stderr.mockRestore()
+  })
+})

--- a/src/relay/relay-pty-source-exit-publication.test.ts
+++ b/src/relay/relay-pty-source-exit-publication.test.ts
@@ -236,19 +236,25 @@ describe('sealAndPublishPtySourceExit settlement closure', () => {
     expect(scenario.capacityIds).toEqual(['pty-1'])
   })
 
-  it('logs and contains a ledger settlement fault instead of escaping the writer callback', () => {
+  it.each([
+    ['committed', { ok: true } as const],
+    ['rolled back', { ok: false, error: new Error('socket write failed') } as const]
+  ])('logs, contains and resumes after a %s ledger settlement fault', (_label, result) => {
     const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
-    const scenario = createInFlightScenario(closedSnapshot({ state: 'sealed-unsettled' }))
-    scenario.session.settleExitPublication.mockImplementation(() => {
-      throw new Error('PTY source delivery is not sealed')
-    })
+    try {
+      const scenario = createInFlightScenario(closedSnapshot({ state: 'sealed-unsettled' }))
+      scenario.session.settleExitPublication.mockImplementation(() => {
+        throw new Error('PTY source delivery is not sealed')
+      })
 
-    expect(() => scenario.settle({ ok: true })).not.toThrow()
+      expect(() => scenario.settle(result)).not.toThrow()
 
-    expect(String(stderr.mock.calls.at(-1)?.[0])).toContain(
-      '[pty-source-exit] exit settlement failed for pty-1'
-    )
-    expect(scenario.capacityIds).toEqual(['pty-1'])
-    stderr.mockRestore()
+      expect(String(stderr.mock.calls.at(-1)?.[0])).toContain(
+        '[pty-source-exit] exit settlement failed for pty-1'
+      )
+      expect(scenario.capacityIds).toEqual(['pty-1'])
+    } finally {
+      stderr.mockRestore()
+    }
   })
 })

--- a/src/relay/relay-pty-source-exit-publication.ts
+++ b/src/relay/relay-pty-source-exit-publication.ts
@@ -84,6 +84,7 @@ export function sealAndPublishPtySourceExit(options: {
       counters.exitRolledBack++
     }
     let deliveryGone = false
+    let settlementFailed = false
     try {
       // Why: a client cancel or rotation can close the delivery while this frame is in
       // flight; settling a closed ledger entry throws out of a bare socket write/drain
@@ -94,13 +95,14 @@ export function sealAndPublishPtySourceExit(options: {
         session.settleExitPublication(record.identity, result)
       }
     } catch (err) {
+      settlementFailed = true
       process.stderr.write(
         `[pty-source-exit] exit settlement failed for ${params.id}: ${
           err instanceof Error ? (err.stack ?? err.message) : String(err)
         }\n`
       )
     } finally {
-      if (result.ok || deliveryGone) {
+      if (result.ok || deliveryGone || settlementFailed) {
         onCapacity(params.id)
       }
     }

--- a/src/relay/relay-pty-source-exit-publication.ts
+++ b/src/relay/relay-pty-source-exit-publication.ts
@@ -27,6 +27,32 @@ export function sealAndPublishPtySourceExit(options: {
     }
     return published
   }
+  if (record.sourceExitState === 'pending') {
+    // Why: an exit frame is in flight; its settlement drives the next step.
+    return false
+  }
+  const probe = session.sourceDeliverySnapshotIfKnown(record.identity)
+  if (!probe || probe.state === 'closed' || probe.state === 'closing') {
+    if (probe?.exitPublished === true || record.sourceExitState === 'published') {
+      // Why: the delivery completed healthily — the owner already has the credit-mode exit.
+      if (deliveries.get(params.id) === record) {
+        deliveries.delete(params.id)
+      }
+      return true
+    }
+    // Why: the delivery was canceled out from under the record; never touch the sealed
+    // ledger — the exit flows as a legacy broadcast instead.
+    const published = record.legacyExitAccepted
+      ? dispatcher.tryNotifyPtyExitToMatchingClients(
+          (clientId) => session.deliveryMode(clientId) === 'source-owner',
+          params
+        )
+      : dispatcher.tryNotifyPtyExit(params)
+    if (published && deliveries.get(params.id) === record) {
+      deliveries.delete(params.id)
+    }
+    return published
+  }
   if (!record.sealed) {
     session.sealDelivery(record.identity)
     record.sealed = true
@@ -50,17 +76,31 @@ export function sealAndPublishPtySourceExit(options: {
   }
   record.sourceExitState = 'pending'
   const settle = onceSinkSettlement((result) => {
+    if (result.ok) {
+      record.sourceExitState = 'published'
+      counters.exitCommitted++
+    } else {
+      record.sourceExitState = 'idle'
+      counters.exitRolledBack++
+    }
+    let deliveryGone = false
     try {
-      session.settleExitPublication(record.identity, result)
-      if (result.ok) {
-        record.sourceExitState = 'published'
-        counters.exitCommitted++
-      } else {
-        record.sourceExitState = 'idle'
-        counters.exitRolledBack++
+      // Why: a client cancel or rotation can close the delivery while this frame is in
+      // flight; settling a closed ledger entry throws out of a bare socket write/drain
+      // callback (dispatcher-client-writer releaseEntry) straight into uncaughtException.
+      deliveryGone =
+        session.sourceDeliverySnapshotIfKnown(record.identity)?.state !== 'sealed-unsettled'
+      if (!deliveryGone) {
+        session.settleExitPublication(record.identity, result)
       }
+    } catch (err) {
+      process.stderr.write(
+        `[pty-source-exit] exit settlement failed for ${params.id}: ${
+          err instanceof Error ? (err.stack ?? err.message) : String(err)
+        }\n`
+      )
     } finally {
-      if (result.ok) {
+      if (result.ok || deliveryGone) {
         onCapacity(params.id)
       }
     }

--- a/src/relay/relay-pty-source-output.ts
+++ b/src/relay/relay-pty-source-output.ts
@@ -1,3 +1,9 @@
+import { randomUUID } from 'node:crypto'
+import type { PtySourceDeliveryIdentity } from '../shared/pty-source-credit-contract'
+import type { RelayDispatcher } from './dispatcher'
+import type { RelayPtySourceDeliveryRecord } from './relay-pty-source-send-scheduler'
+import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
 export type RelayPtySourceOutput = {
   data: string
   rawLength?: number
@@ -5,4 +11,61 @@ export type RelayPtySourceOutput = {
   seq?: number
   sourceAccepted?: boolean
   sourceSpanId?: string
+}
+
+// Why: an evicted tombstone probes null, so an unknown delivery counts as closed.
+export function ptySourceDeliveryClosed(
+  session: SshPtyConsumerSessionAdapter,
+  identity: PtySourceDeliveryIdentity
+): boolean {
+  const state = session.sourceDeliverySnapshotIfKnown(identity)?.state
+  return !state || state === 'closed' || state === 'closing'
+}
+
+export function appendPtySourceOutput(
+  session: SshPtyConsumerSessionAdapter,
+  record: RelayPtySourceDeliveryRecord,
+  output: RelayPtySourceOutput
+): boolean {
+  const rawLength = output.rawLength ?? output.data.length
+  output.sourceSpanId ??= randomUUID()
+  try {
+    session.appendSource(record.identity, {
+      spanId: output.sourceSpanId,
+      data: output.data,
+      displayStart: record.displayEnd,
+      displayEnd: record.displayEnd + output.data.length,
+      splittable: output.transformed !== true,
+      transform: {
+        transformed: output.transformed === true,
+        rawLengthSu: rawLength,
+        scalarSafe: output.transformed !== true
+      }
+    })
+  } catch {
+    return false
+  }
+  output.sourceAccepted = true
+  record.displayEnd += output.data.length
+  return true
+}
+
+export function projectPtySourceOutputToLegacy(
+  dispatcher: RelayDispatcher,
+  session: SshPtyConsumerSessionAdapter,
+  id: string,
+  output: RelayPtySourceOutput,
+  interactive: boolean
+): boolean {
+  return dispatcher.projectPtyDataToMatchingClients(
+    (clientId) => session.deliveryMode(clientId) !== 'source-owner',
+    {
+      id,
+      data: output.data,
+      ...(output.seq === undefined ? {} : { seq: output.seq }),
+      ...(output.rawLength === undefined ? {} : { rawLength: output.rawLength }),
+      ...(output.transformed ? { transformed: true } : {})
+    },
+    { interactive }
+  )
 }

--- a/src/relay/relay-pty-source-publication.test.ts
+++ b/src/relay/relay-pty-source-publication.test.ts
@@ -19,7 +19,9 @@ function requestFrame(id: number, method: string, params: Record<string, unknown
   return encodeJsonRpcFrame({ jsonrpc: '2.0', id, method, params }, id, 0)
 }
 
-function notification(buffer: Buffer): { method: string; params: Record<string, unknown> } | null {
+type Notification = { method: string; params: Record<string, unknown> }
+
+function notification(buffer: Buffer): Notification | null {
   if (buffer[0] !== MessageType.Regular) {
     return null
   }
@@ -52,17 +54,23 @@ describe('RelayPtySourcePublication', () => {
   async function createHarness(
     windowSu = 4,
     settleSourceImmediately = true,
-    highWaterMark?: number
+    highWaterMark?: number,
+    holdExitSettlement = false
   ) {
     const writes: Buffer[] = []
     const sourceSettlements: ((result: SinkWriteSettlement) => void)[] = []
+    const exitSettlements: ((result: SinkWriteSettlement) => void)[] = []
+    const capacityIds: string[] = []
     dispatcher = new RelayDispatcher(
       (data, onSettled) => {
         writes.push(Buffer.from(data))
         const frame = notification(data)
         if (frame?.method === 'pty.data' || frame?.method === 'pty.exit') {
           sourceSettlements.push(onSettled)
-          if (settleSourceImmediately) {
+          if (frame.method === 'pty.exit') {
+            exitSettlements.push(onSettled)
+          }
+          if (settleSourceImmediately && !(holdExitSettlement && frame.method === 'pty.exit')) {
             onSettled({ ok: true })
           }
         } else {
@@ -85,7 +93,7 @@ describe('RelayPtySourcePublication', () => {
     const adapter = new SshPtyConsumerSessionAdapter(dispatcher, 'build-a', undefined, (id) =>
       publication.onCreditAvailable(id)
     )
-    publication = new RelayPtySourcePublication(dispatcher, adapter, () => {})
+    publication = new RelayPtySourcePublication(dispatcher, adapter, (id) => capacityIds.push(id))
     dispatcher.feed(
       requestFrame(1, 'pty.openClient', {
         protocolVersion: 1,
@@ -105,7 +113,7 @@ describe('RelayPtySourcePublication', () => {
       })
     ).toBe('opened')
     activationSettlements[0]({ ok: true })
-    return { adapter, publication, sourceSettlements, writes }
+    return { adapter, publication, sourceSettlements, exitSettlements, capacityIds, writes }
   }
 
   it('commits only from writer settlement and resumes exactly after cumulative ACK', async () => {

--- a/src/relay/relay-pty-source-publication.ts
+++ b/src/relay/relay-pty-source-publication.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import type { PtySourceDeliveryIdentity } from '../shared/pty-source-credit-contract'
 import type {
   PtySourceRecoveryRequest,
@@ -19,7 +18,12 @@ import {
 } from './relay-pty-source-send-scheduler'
 import { sealAndPublishPtySourceExit } from './relay-pty-source-exit-publication'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
-import type { RelayPtySourceOutput } from './relay-pty-source-output'
+import {
+  appendPtySourceOutput,
+  projectPtySourceOutputToLegacy,
+  ptySourceDeliveryClosed,
+  type RelayPtySourceOutput
+} from './relay-pty-source-output'
 import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
 
 export class RelayPtySourcePublication {
@@ -61,7 +65,7 @@ export class RelayPtySourcePublication {
       return false
     }
     const mode = this.session.deliveryMode(context.clientId)
-    const current = this.deliveries.get(id)
+    let current = this.deliveries.get(id)
     if (mode === 'subscriber') {
       this.sender.releaseRotationFence(current)
       return false
@@ -73,6 +77,17 @@ export class RelayPtySourcePublication {
         this.onCapacity(id)
       }
       return false
+    }
+    if (
+      current?.clientId === context.clientId &&
+      !current.restoreRequired &&
+      current.sourceExitState !== 'pending' &&
+      this.deliveryClosedUnderRecord(current)
+    ) {
+      // Why: a canceled delivery can never resume as 'existing'; retire it so re-attach opens fresh.
+      this.deliveries.delete(id)
+      this.onCapacity(id)
+      current = undefined
     }
     if (current?.clientId === context.clientId) {
       this.sender.releaseRotationFence(current)
@@ -195,42 +210,20 @@ export class RelayPtySourcePublication {
     ) {
       return false
     }
-    if (!output.sourceAccepted) {
-      const rawLength = output.rawLength ?? output.data.length
-      output.sourceSpanId ??= randomUUID()
-      try {
-        this.session.appendSource(record.identity, {
-          spanId: output.sourceSpanId,
-          data: output.data,
-          displayStart: record.displayEnd,
-          displayEnd: record.displayEnd + output.data.length,
-          splittable: output.transformed !== true,
-          transform: {
-            transformed: output.transformed === true,
-            rawLengthSu: rawLength,
-            scalarSafe: output.transformed !== true
-          }
-        })
-      } catch {
-        this.counters.appendDenied++
+    if (!output.sourceAccepted && !appendPtySourceOutput(this.session, record, output)) {
+      if (this.deliveryClosedUnderRecord(record)) {
+        this.deliveries.delete(id)
+        // Why: deferred — publish() can run inside flushPendingOutput's captured-queue drain,
+        // where pendingOutputByPty is transiently empty; a synchronous capacity callback would
+        // publish pty.exit ahead of still-buffered output. By microtask time the failed chunk
+        // has been re-queued (flushPtyOutput re-sets the queue synchronously on failure).
+        queueMicrotask(() => this.onCapacity(id))
         return false
       }
-      output.sourceAccepted = true
-      record.displayEnd += output.data.length
+      this.counters.appendDenied++
+      return false
     }
-    if (
-      !this.dispatcher.projectPtyDataToMatchingClients(
-        (clientId) => this.session.deliveryMode(clientId) !== 'source-owner',
-        {
-          id,
-          data: output.data,
-          ...(output.seq === undefined ? {} : { seq: output.seq }),
-          ...(output.rawLength === undefined ? {} : { rawLength: output.rawLength }),
-          ...(output.transformed ? { transformed: true } : {})
-        },
-        { interactive }
-      )
-    ) {
+    if (!projectPtySourceOutputToLegacy(this.dispatcher, this.session, id, output, interactive)) {
       return false
     }
     this.sender.pump(record)
@@ -268,6 +261,10 @@ export class RelayPtySourcePublication {
   getDebugSnapshot = () => this.sender.getDebugSnapshot()
 
   dispose = (): void => this.sender.dispose()
+
+  private deliveryClosedUnderRecord(record: RelayPtySourceDeliveryRecord): boolean {
+    return ptySourceDeliveryClosed(this.session, record.identity)
+  }
 
   private registerActivationSettlement(
     id: string,

--- a/src/relay/relay-pty-source-publication.ts
+++ b/src/relay/relay-pty-source-publication.ts
@@ -73,6 +73,7 @@ export class RelayPtySourcePublication {
     if (mode === 'legacy-owner') {
       if (current) {
         this.session.cancelDelivery(current.identity, 'source-credit-disabled')
+        this.sender.wakeSendWaiters(current)
         this.deliveries.delete(id)
         this.onCapacity(id)
       }
@@ -85,6 +86,7 @@ export class RelayPtySourcePublication {
       this.deliveryClosedUnderRecord(current)
     ) {
       // Why: a canceled delivery can never resume as 'existing'; retire it so re-attach opens fresh.
+      this.sender.wakeSendWaiters(current)
       this.deliveries.delete(id)
       this.onCapacity(id)
       current = undefined
@@ -212,6 +214,7 @@ export class RelayPtySourcePublication {
     }
     if (!output.sourceAccepted && !appendPtySourceOutput(this.session, record, output)) {
       if (this.deliveryClosedUnderRecord(record)) {
+        this.sender.wakeSendWaiters(record)
         this.deliveries.delete(id)
         // Why: deferred — publish() can run inside flushPendingOutput's captured-queue drain,
         // where pendingOutputByPty is transiently empty; a synchronous capacity callback would

--- a/src/relay/relay-pty-source-send-scheduler.test.ts
+++ b/src/relay/relay-pty-source-send-scheduler.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  PtySourceDeliveryIdentity,
+  PtySourceDeliverySnapshot
+} from '../shared/pty-source-credit-contract'
+import type { RelayDispatcher } from './dispatcher'
+import {
+  RelayPtySourceSendScheduler,
+  type RelayPtySourceDeliveryRecord,
+  type RelayPtySourcePublicationCounters
+} from './relay-pty-source-send-scheduler'
+import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+const identity: PtySourceDeliveryIdentity = Object.freeze({
+  id: 'pty-1',
+  providerGeneration: 1,
+  clientGeneration: 2,
+  ownerGeneration: 3,
+  ptyIncarnation: 'incarnation-1',
+  deliveryToken: 'token-1'
+})
+
+function deliveryRecord(
+  overrides: Partial<RelayPtySourceDeliveryRecord> = {}
+): RelayPtySourceDeliveryRecord {
+  return {
+    clientId: 1,
+    identity,
+    sourceActivation: {
+      status: 'pending',
+      clientGeneration: identity.clientGeneration,
+      ownerGeneration: identity.ownerGeneration,
+      ptyIncarnation: identity.ptyIncarnation,
+      deliveryToken: identity.deliveryToken,
+      checkpointSourceEndSu: 0,
+      recoveryEndSu: 0
+    },
+    displayEnd: 0,
+    activating: false,
+    activationRecoveryRequest: null,
+    sealed: false,
+    legacyExitAccepted: false,
+    sourceExitState: 'idle',
+    sending: false,
+    turnFrames: 0,
+    turnSourceSu: 0,
+    turnScheduled: false,
+    sendWaiters: new Set(),
+    recoveryCheckpointSourceEndSu: null,
+    recoveryEndSu: null,
+    recoveryCompletionPending: false,
+    restoreRequired: false,
+    rotationPending: false,
+    ...overrides
+  }
+}
+
+function createScheduler(
+  probe: PtySourceDeliverySnapshot | null,
+  record: RelayPtySourceDeliveryRecord
+) {
+  const deliveries = new Map<string, RelayPtySourceDeliveryRecord>([['pty-1', record]])
+  const session = {
+    sourceDeliverySnapshotIfKnown: vi.fn(() => probe),
+    sourceDeliverySnapshot: vi.fn(() => {
+      throw new Error('Unknown or stale PTY source delivery')
+    }),
+    reserveSourceSend: vi.fn(() => null)
+  }
+  const dispatcher = {
+    onLegacyPtyCapacity: vi.fn(() => () => {}),
+    producerDataBudget: vi.fn(() => 4096),
+    tryNotifyPtyDataToClient: vi.fn(() => true)
+  }
+  const counters: RelayPtySourcePublicationCounters = {
+    opened: 0,
+    rotated: 0,
+    appendDenied: 0,
+    sendCommitted: 0,
+    sendRolledBack: 0,
+    exitCommitted: 0,
+    exitRolledBack: 0
+  }
+  const capacityIds: string[] = []
+  const scheduler = new RelayPtySourceSendScheduler(
+    dispatcher as unknown as RelayDispatcher,
+    session as unknown as SshPtyConsumerSessionAdapter,
+    deliveries,
+    counters,
+    (id) => capacityIds.push(id)
+  )
+  return { scheduler, deliveries, session, capacityIds }
+}
+
+describe('RelayPtySourceSendScheduler close handling', () => {
+  it('leaves an in-flight exit frame untouched on a credit event', () => {
+    const record = deliveryRecord({ sourceExitState: 'pending' })
+    const harness = createScheduler(null, record)
+
+    harness.scheduler.onCreditAvailable('pty-1')
+
+    expect(harness.deliveries.get('pty-1')).toBe(record)
+    expect(harness.session.sourceDeliverySnapshotIfKnown).not.toHaveBeenCalled()
+    expect(harness.session.reserveSourceSend).not.toHaveBeenCalled()
+    expect(harness.capacityIds).toEqual([])
+  })
+
+  it('prunes a record whose tombstone was already evicted', () => {
+    const record = deliveryRecord()
+    const harness = createScheduler(null, record)
+
+    expect(() => harness.scheduler.onCreditAvailable('pty-1')).not.toThrow()
+
+    expect(harness.deliveries.has('pty-1')).toBe(false)
+    expect(harness.capacityIds).toEqual(['pty-1'])
+  })
+
+  it('skips unknown deliveries in the debug snapshot instead of throwing', () => {
+    const harness = createScheduler(null, deliveryRecord({ sealed: true }))
+
+    expect(harness.scheduler.getDebugSnapshot()).toMatchObject({
+      active: 0,
+      activating: 0,
+      sealedUnsettled: 0,
+      outstandingSourceUnits: 0
+    })
+  })
+})

--- a/src/relay/relay-pty-source-send-scheduler.test.ts
+++ b/src/relay/relay-pty-source-send-scheduler.test.ts
@@ -106,10 +106,37 @@ describe('RelayPtySourceSendScheduler close handling', () => {
   })
 
   it('prunes a record whose tombstone was already evicted', () => {
-    const record = deliveryRecord()
+    const waiter = vi.fn()
+    const record = deliveryRecord({ sendWaiters: new Set([waiter]) })
     const harness = createScheduler(null, record)
 
     expect(() => harness.scheduler.onCreditAvailable('pty-1')).not.toThrow()
+
+    expect(waiter).toHaveBeenCalledOnce()
+    expect(record.sendWaiters.size).toBe(0)
+    expect(harness.deliveries.has('pty-1')).toBe(false)
+    expect(harness.capacityIds).toEqual(['pty-1'])
+  })
+
+  it('preserves a closed record after the legacy exit projection landed', () => {
+    const record = deliveryRecord({ legacyExitAccepted: true })
+    const harness = createScheduler(null, record)
+
+    harness.scheduler.onCreditAvailable('pty-1')
+
+    expect(harness.deliveries.get('pty-1')).toBe(record)
+    expect(harness.session.reserveSourceSend).not.toHaveBeenCalled()
+    expect(harness.capacityIds).toEqual(['pty-1'])
+  })
+
+  it('prunes a healthily published exit after its final credit closes the delivery', () => {
+    const record = deliveryRecord({
+      legacyExitAccepted: true,
+      sourceExitState: 'published'
+    })
+    const harness = createScheduler(null, record)
+
+    harness.scheduler.onCreditAvailable('pty-1')
 
     expect(harness.deliveries.has('pty-1')).toBe(false)
     expect(harness.capacityIds).toEqual(['pty-1'])

--- a/src/relay/relay-pty-source-send-scheduler.ts
+++ b/src/relay/relay-pty-source-send-scheduler.ts
@@ -100,6 +100,12 @@ export class RelayPtySourceSendScheduler {
     if (!record || record.restoreRequired) {
       return
     }
+    if (record.sourceExitState === 'pending') {
+      // Why: the credit-mode exit frame is in flight; pruning now diverts publishPendingExit
+      // into a duplicate legacy pty.exit, and pumping a closed delivery throws. The exit
+      // settlement (which fires onCapacity) resumes progress.
+      return
+    }
     if (this.pruneClosed(id, record)) {
       this.onCapacity(id)
       return
@@ -114,7 +120,10 @@ export class RelayPtySourceSendScheduler {
     let sealedUnsettled = 0
     let outstandingSourceUnits = 0
     for (const record of this.deliveries.values()) {
-      const snapshot = this.session.sourceDeliverySnapshot(record.identity)
+      const snapshot = this.session.sourceDeliverySnapshotIfKnown(record.identity)
+      if (!snapshot) {
+        continue
+      }
       outstandingSourceUnits += snapshot.sentEndSu - snapshot.creditedEndSu
       if (record.activating) {
         activating++
@@ -263,7 +272,10 @@ export class RelayPtySourceSendScheduler {
   }
 
   pruneClosed(id: string, record: RelayPtySourceDeliveryRecord): boolean {
-    if (this.session.sourceDeliverySnapshot(record.identity).state !== 'closed') {
+    // Why: an evicted tombstone probes null and must count as closed — this runs from paths
+    // (credit callbacks, write settlements) where a throw escapes every caller's try/catch.
+    const snapshot = this.session.sourceDeliverySnapshotIfKnown(record.identity)
+    if (snapshot && snapshot.state !== 'closed') {
       return false
     }
     if (this.deliveries.get(id) === record) {

--- a/src/relay/relay-pty-source-send-scheduler.ts
+++ b/src/relay/relay-pty-source-send-scheduler.ts
@@ -1,4 +1,7 @@
-import type { PtySourceDeliveryIdentity } from '../shared/pty-source-credit-contract'
+import type {
+  PtySourceDeliveryIdentity,
+  PtySourceDeliverySnapshot
+} from '../shared/pty-source-credit-contract'
 import type { PtySourceRecoveryCheckpoint } from '../shared/pty-source-recovery-contract'
 import type { PtySourceReceivingActivation } from '../shared/pty-source-receiving-activation'
 import type { RelayDispatcher, SinkWriteSettlement } from './dispatcher'
@@ -106,7 +109,17 @@ export class RelayPtySourceSendScheduler {
       // settlement (which fires onCapacity) resumes progress.
       return
     }
-    if (this.pruneClosed(id, record)) {
+    const snapshot = this.session.sourceDeliverySnapshotIfKnown(record.identity)
+    if (
+      record.sourceExitState === 'idle' &&
+      record.legacyExitAccepted &&
+      (!snapshot || snapshot.state === 'closed' || snapshot.state === 'closing')
+    ) {
+      // Why: preserve partial exit progress so the retry targets only the source owner.
+      this.onCapacity(id)
+      return
+    }
+    if (this.pruneClosed(id, record, snapshot)) {
       this.onCapacity(id)
       return
     }
@@ -271,14 +284,20 @@ export class RelayPtySourceSendScheduler {
     })
   }
 
-  pruneClosed(id: string, record: RelayPtySourceDeliveryRecord): boolean {
+  pruneClosed(
+    id: string,
+    record: RelayPtySourceDeliveryRecord,
+    snapshot: PtySourceDeliverySnapshot | null = this.session.sourceDeliverySnapshotIfKnown(
+      record.identity
+    )
+  ): boolean {
     // Why: an evicted tombstone probes null and must count as closed — this runs from paths
     // (credit callbacks, write settlements) where a throw escapes every caller's try/catch.
-    const snapshot = this.session.sourceDeliverySnapshotIfKnown(record.identity)
     if (snapshot && snapshot.state !== 'closed') {
       return false
     }
     if (this.deliveries.get(id) === record) {
+      this.wakeSendWaiters(record)
       this.deliveries.delete(id)
     }
     return true

--- a/src/relay/ssh-pty-consumer-session-adapter.ts
+++ b/src/relay/ssh-pty-consumer-session-adapter.ts
@@ -217,6 +217,12 @@ export class SshPtyConsumerSessionAdapter {
     return this.sourceCredit.snapshot(identity)
   }
 
+  sourceDeliverySnapshotIfKnown(
+    identity: PtySourceDeliveryIdentity
+  ): PtySourceDeliverySnapshot | null {
+    return this.sourceCredit.snapshotIfKnown(identity)
+  }
+
   cancelDelivery(identity: PtySourceDeliveryIdentity, reason: string): void {
     this.clearPausedIdentity(identity)
     this.sourceCredit.cancelIdentity(identity, reason)

--- a/src/relay/ssh-pty-source-credit-adapter.test.ts
+++ b/src/relay/ssh-pty-source-credit-adapter.test.ts
@@ -114,6 +114,81 @@ describe('SshPtySourceCreditAdapter cleanup', () => {
     expect(() => adapter.open(grant, 'pty-late', 'incarnation-late')).toThrow('disposed')
   })
 
+  it('notifies credit availability on every adapter-side cancellation but not on rotate', () => {
+    vi.useFakeTimers()
+    const onCreditAvailable = vi.fn()
+    const adapter = new SshPtySourceCreditAdapter(undefined, onCreditAvailable)
+    const grant = ownerGrant(1, 1)
+    const canceled = adapter.open(grant, 'pty-cancel', 'incarnation-1')!
+
+    adapter.cancel(
+      {
+        id: canceled.id,
+        deliveryToken: canceled.deliveryToken,
+        clientGeneration: canceled.clientGeneration,
+        ownerGeneration: canceled.ownerGeneration
+      },
+      grant
+    )
+    expect(onCreditAvailable.mock.calls).toEqual([['pty-cancel']])
+
+    const expiring = adapter.open(grant, 'pty-grace', 'incarnation-2')!
+    adapter.retainOrCloseOnDetach(grant)
+    vi.advanceTimersByTime(PTY_CONSUMER_OWNER_GRACE_MS)
+    expect(onCreditAvailable.mock.calls).toEqual([['pty-cancel'], ['pty-grace']])
+    expect(adapter.snapshot(expiring).state).toBe('closed')
+
+    const detaching = adapter.open(ownerGrant(3, 3), 'pty-detach', 'incarnation-3')!
+    adapter.retainOrCloseOnDetach(
+      Object.freeze({
+        protocolVersion: PTY_CONSUMER_SESSION_PROTOCOL_VERSION,
+        serverBuildId: 'build-a',
+        clientGeneration: 3,
+        role: 'subscriber'
+      })
+    )
+    expect(onCreditAvailable.mock.calls).toEqual([['pty-cancel'], ['pty-grace'], ['pty-detach']])
+    expect(adapter.snapshot(detaching).state).toBe('closed')
+
+    const rotating = adapter.open(ownerGrant(4, 4), 'pty-rotate', 'incarnation-4')!
+    adapter.rotate(rotating, ownerGrant(5, 5), 0)
+    adapter.cancelIdentity(rotating, 'publication-owned')
+    expect(onCreditAvailable).toHaveBeenCalledTimes(3)
+  })
+
+  it('swallows a throwing credit-available callback in cancel and in the grace timer', () => {
+    vi.useFakeTimers()
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const adapter = new SshPtySourceCreditAdapter(undefined, () => {
+      throw new Error('publication faulted')
+    })
+    const grant = ownerGrant(1, 1)
+    const canceled = adapter.open(grant, 'pty-1', 'incarnation-1')!
+
+    expect(() =>
+      adapter.cancel(
+        {
+          id: canceled.id,
+          deliveryToken: canceled.deliveryToken,
+          clientGeneration: canceled.clientGeneration,
+          ownerGeneration: canceled.ownerGeneration
+        },
+        grant
+      )
+    ).not.toThrow()
+
+    const expiring = adapter.open(grant, 'pty-2', 'incarnation-2')!
+    adapter.retainOrCloseOnDetach(grant)
+    expect(() => vi.advanceTimersByTime(PTY_CONSUMER_OWNER_GRACE_MS)).not.toThrow()
+
+    expect(adapter.snapshot(expiring).state).toBe('closed')
+    expect(stderr.mock.calls.map(([line]) => String(line))).toEqual([
+      expect.stringContaining('[pty-source-credit] credit-available notification failed for pty-1'),
+      expect.stringContaining('[pty-source-credit] credit-available notification failed for pty-2')
+    ])
+    stderr.mockRestore()
+  })
+
   it('returns the same bounded proof for duplicate token cancellation', () => {
     const adapter = new SshPtySourceCreditAdapter()
     const grant = ownerGrant(1, 1)

--- a/src/relay/ssh-pty-source-credit-adapter.test.ts
+++ b/src/relay/ssh-pty-source-credit-adapter.test.ts
@@ -152,41 +152,50 @@ describe('SshPtySourceCreditAdapter cleanup', () => {
 
     const rotating = adapter.open(ownerGrant(4, 4), 'pty-rotate', 'incarnation-4')!
     adapter.rotate(rotating, ownerGrant(5, 5), 0)
-    adapter.cancelIdentity(rotating, 'publication-owned')
+    const publicationOwned = adapter.open(ownerGrant(6, 6), 'pty-publication', 'incarnation-5')!
+    adapter.cancelIdentity(publicationOwned, 'publication-owned')
     expect(onCreditAvailable).toHaveBeenCalledTimes(3)
+    expect(adapter.snapshot(publicationOwned).state).toBe('closed')
   })
 
   it('swallows a throwing credit-available callback in cancel and in the grace timer', () => {
     vi.useFakeTimers()
     const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
-    const adapter = new SshPtySourceCreditAdapter(undefined, () => {
-      throw new Error('publication faulted')
-    })
-    const grant = ownerGrant(1, 1)
-    const canceled = adapter.open(grant, 'pty-1', 'incarnation-1')!
+    try {
+      const adapter = new SshPtySourceCreditAdapter(undefined, () => {
+        throw new Error('publication faulted')
+      })
+      const grant = ownerGrant(1, 1)
+      const canceled = adapter.open(grant, 'pty-1', 'incarnation-1')!
 
-    expect(() =>
-      adapter.cancel(
-        {
-          id: canceled.id,
-          deliveryToken: canceled.deliveryToken,
-          clientGeneration: canceled.clientGeneration,
-          ownerGeneration: canceled.ownerGeneration
-        },
-        grant
-      )
-    ).not.toThrow()
+      expect(() =>
+        adapter.cancel(
+          {
+            id: canceled.id,
+            deliveryToken: canceled.deliveryToken,
+            clientGeneration: canceled.clientGeneration,
+            ownerGeneration: canceled.ownerGeneration
+          },
+          grant
+        )
+      ).not.toThrow()
 
-    const expiring = adapter.open(grant, 'pty-2', 'incarnation-2')!
-    adapter.retainOrCloseOnDetach(grant)
-    expect(() => vi.advanceTimersByTime(PTY_CONSUMER_OWNER_GRACE_MS)).not.toThrow()
+      const expiring = adapter.open(grant, 'pty-2', 'incarnation-2')!
+      adapter.retainOrCloseOnDetach(grant)
+      expect(() => vi.advanceTimersByTime(PTY_CONSUMER_OWNER_GRACE_MS)).not.toThrow()
 
-    expect(adapter.snapshot(expiring).state).toBe('closed')
-    expect(stderr.mock.calls.map(([line]) => String(line))).toEqual([
-      expect.stringContaining('[pty-source-credit] credit-available notification failed for pty-1'),
-      expect.stringContaining('[pty-source-credit] credit-available notification failed for pty-2')
-    ])
-    stderr.mockRestore()
+      expect(adapter.snapshot(expiring).state).toBe('closed')
+      expect(stderr.mock.calls.map(([line]) => String(line))).toEqual([
+        expect.stringContaining(
+          '[pty-source-credit] credit-available notification failed for pty-1'
+        ),
+        expect.stringContaining(
+          '[pty-source-credit] credit-available notification failed for pty-2'
+        )
+      ])
+    } finally {
+      stderr.mockRestore()
+    }
   })
 
   it('returns the same bounded proof for duplicate token cancellation', () => {

--- a/src/relay/ssh-pty-source-credit-adapter.ts
+++ b/src/relay/ssh-pty-source-credit-adapter.ts
@@ -15,6 +15,7 @@ import {
   ptySourceCancellationResult,
   RecentPtySourceCancellationIndex
 } from './pty-source-cancellation-index'
+import { notifyPtySourceCreditAvailable } from './pty-source-credit-availability-notice'
 import { ownedPtySourceDelivery } from './pty-source-delivery-ownership'
 import {
   RelayPtySourceCreditLedger,
@@ -141,6 +142,10 @@ export class SshPtySourceCreditAdapter {
     return this.sourceCredit.snapshot(identity)
   }
 
+  snapshotIfKnown(identity: PtySourceDeliveryIdentity): PtySourceDeliverySnapshot | null {
+    return this.sourceCredit.snapshotIfKnown(identity)
+  }
+
   acknowledge(
     params: Record<string, unknown>,
     grant: Readonly<PtyConsumerSessionGrant> | null
@@ -205,6 +210,9 @@ export class SshPtySourceCreditAdapter {
     this.identityByToken.delete(token)
     this.recentCancellations.remember(proof)
     this.clearGraceWhenSettled(identity.ownerGeneration)
+    // Why: the publication must retire its record the moment the delivery closes, or the next
+    // exit seals a dead ledger entry.
+    notifyPtySourceCreditAvailable(this.onCreditAvailable, identity.id)
     return ptySourceCancellationResult(proof)
   }
 
@@ -247,9 +255,7 @@ export class SshPtySourceCreditAdapter {
       return
     }
     this.disposed = true
-    for (const timer of this.graceTimers.values()) {
-      clearTimeout(timer)
-    }
+    this.graceTimers.forEach((timer) => clearTimeout(timer))
     this.graceTimers.clear()
     this.sourceCredit.closeGeneration(this.relayProviderGeneration)
     this.identityByToken.clear()
@@ -262,6 +268,7 @@ export class SshPtySourceCreditAdapter {
         continue
       }
       this.cancelExact(token, identity, 'client-detached')
+      notifyPtySourceCreditAvailable(this.onCreditAvailable, identity.id)
     }
   }
 
@@ -274,6 +281,7 @@ export class SshPtySourceCreditAdapter {
           continue
         }
         this.cancelExact(token, identity, 'reconnect-grace-expired')
+        notifyPtySourceCreditAvailable(this.onCreditAvailable, identity.id)
       }
     }, PTY_CONSUMER_OWNER_GRACE_MS)
     timer.unref?.()
@@ -314,10 +322,7 @@ export class SshPtySourceCreditAdapter {
   }
 
   private clearGraceTimer(ownerGeneration: number): void {
-    const timer = this.graceTimers.get(ownerGeneration)
-    if (timer) {
-      clearTimeout(timer)
-      this.graceTimers.delete(ownerGeneration)
-    }
+    clearTimeout(this.graceTimers.get(ownerGeneration))
+    this.graceTimers.delete(ownerGeneration)
   }
 }


### PR DESCRIPTION
## ELI5

Imagine the relay is a **coat check** for terminal output. Every remote terminal gets a **claim ticket**, and the desk keeps a ledger of which tickets are live.

- When you close a terminal from your phone or a reconnect times out, the app says *"cancel my ticket."* The coat check tears up the ticket — but **forgets to cross it off the ledger.**
- A moment later the terminal process finishes normally, and the desk goes to close out that ticket. It looks in the ledger, sees the ticket listed, reaches for it… and it's gone.
- Instead of shrugging, the desk **panics and burns the building down**: the error is thrown from a callback nobody is catching, so Node's `uncaughtException` handler runs `process.exit(1)`. The entire relay daemon dies — **every** remote terminal on that machine, every SSH session, every paired phone, not just the one that was canceled. It also leaks the terminal's file descriptor on the way out, because the cleanup code after the throw never runs.

The scary part is how ordinary the trigger is: cancel a delivery, then let a terminal exit normally. No race, no weird timing.

**The fix, in the same terms:**

1. **Cross it off the ledger when the ticket is torn up.** (Layer A — tell the publication layer at cancel time, so the stale record is retired immediately.)
2. **Don't cross it off mid-handoff.** If a closing message is already in flight, wait — otherwise you'd hand someone their coat twice. (Layer A')
3. **If the desk ever finds a missing ticket anyway, don't panic — just handle it.** Ask "is this gone because it finished normally, or because it was canceled?" Finished normally → quietly file it away. Canceled → send the goodbye message the old-fashioned way. (Layers B0–B3)
4. **Put a fire extinguisher in the room.** (Layer C — a `try/catch` around the exit path.)
5. **Put a second one in the back office**, because some of this work runs from raw socket callbacks that the first extinguisher can't reach. (Layer D)

Layers 1–3 fix the root cause. Layers 4–5 exist so that *any* future bug in this area degrades one terminal instead of killing the daemon for everyone.

---

## Summary

A production release scan of `v1.4.162..v1.4.163-rc.0` found a P0 relay-daemon crash: when a source-owner client cancels its delivery (`pty.cancelDelivery`) or its reconnect grace expires, `SshPtySourceCreditAdapter` closes the ledger delivery but never tells the publication layer. The `RelayPtySourceDeliveryRecord` survives, so `accepts(id)` stays true and the next `pty.exit` takes the credit-mode path into `session.sealDelivery()` → ledger `requireActive` → `throw new Error('Unknown or stale PTY source delivery')`. That throw escapes `publishPendingExit` inside node-pty's `onExit` callback, reaches `uncaughtException`, and kills the whole relay daemon (taking every PTY, SSH session and paired mobile client with it). The same disagreement also throws from the exit-frame settlement closure, which runs from bare socket write/drain callbacks where no `pty-handler` `try/catch` can see it.

Five coordinated layers, exactly as designed:

- **A + A' — root cause.** `cancel()`, the grace-expiry timer, and `closeClientDeliveries()` now fire the adapter's `onCreditAvailable` hook, so the existing `pruneClosed` machinery retires the stale record at cancel time. The notification is defensively wrapped (`pty-source-credit-availability-notice.ts`) because it fires from request handlers and a bare `setTimeout`. `RelayPtySourceSendScheduler.onCreditAvailable` skips pruning while `sourceExitState === 'pending'` so a cancel during an in-flight exit frame neither double-delivers `pty.exit` nor pumps a closed ledger. `cancelIdentity` is deliberately excluded — that path is publication-initiated and manages its own record lifecycle.
- **B0–B3 — tolerant exit path.** `publishPendingExit` checks `exitPublicationSettled` first (a post-settlement retry never re-enters `sealAndPublishExit`, which would `pump` a closed delivery). `sealAndPublishPtySourceExit` gains a top-of-function guard that branches on `exitPublished`: a healthily-completed delivery is retired silently with no notify (no duplicate exit), a canceled one falls back to a legacy broadcast and never touches the sealed ledger. `activate` retires a closed record on same-client re-attach so it can't return a stranded `'existing'`, and a `publish()` append failure on a closed delivery retires the record synchronously while deferring the capacity callback to a microtask (so a re-queued chunk can't be overtaken by `pty.exit`).
- **C.** A `try/catch` around the source branch of `publishPendingExit`, covering every caller (`onExit`, `flushPtyOutput`, `handleSourcePublicationCapacity`, `handleLegacyCapacity`, `disposePtys`). A fault is logged and falls through to the legacy exit instead of killing the daemon.
- **D.** A probe guard plus `try/catch` inside the exit settlement closure itself. It is invoked from `dispatcher-client-writer.ts` `releaseEntry` — a bare socket write/drain callback outside every pty-handler frame — so layer C can never reach it. The `finally` is widened to fire `onCapacity` on `!result.ok` when the delivery is gone, so the legacy exit cannot stall when no further credit event will arrive.

Supporting change: a new non-throwing `snapshotIfKnown` ledger probe (with `snapshot` refactored onto it); every caller that can legitimately race a close now probes instead of throwing, and an evicted tombstone (`CLOSED_DELIVERY_TOMBSTONE_LIMIT`) reads as closed.

Wire protocol is unchanged. The only visible behavior change is that a canceled source-owner receives legacy `pty.exit`/`pty.data` after its cancel — the protocol's existing post-cancel contract, which the RC simply never reached because `accepts(id)` never became false.

Two mechanical refactors were needed to keep the touched files under the `max-lines` budget without any lint suppression: the ledger's snapshot lookup moved to `matchingDeliverySnapshot` in `pty-source-credit-record.ts`, and `publish()`'s source append + legacy projection moved into `relay-pty-source-output.ts` (`appendPtySourceOutput`, `projectPtySourceOutputToLegacy`, `ptySourceDeliveryClosed`). Both are pure moves.

## Test plan

`npx vitest run --config config/vitest.config.ts src/relay/` — **1054 passed (96 files), zero failures.**

Note for anyone re-running this: if your shell exports `GIT_CONFIG_COUNT` (Claude Code and some git wrappers do), `agent-exec-handler.test.ts` fails 2 spurious assertions — the ambient git config is appended to the spawned env, so the test sees `GIT_CONFIG_COUNT: "4"` with duplicated `credential.interactive`/`credential.guiPrompt` keys instead of the expected `"2"`. Unrelated to this PR and unrelated to `origin/main`; run with `env -u GIT_CONFIG_COUNT ...` for a clean result.

Verified failing-then-passing: with only the production files reverted to the RC and all new tests kept, **26 new tests fail**, including the primary repro `retires the record when a client cancels, so the exit never seals a dead ledger`, whose observed failure is:

```
AssertionError: expected [Function] to not throw an error but
  'Error: Unknown or stale PTY source delivery' was thrown
```

plus `expected true to be false` on `accepts('pty-1')`. The grace-expiry variant fails identically, and the end-to-end `publishes a single legacy exit after the owner cancels its delivery` fails with zero `pty.exit` frames delivered.

New/extended coverage:

- `src/relay/relay-pty-source-cancellation-exit.test.ts` (new): the cancel → exit repro; the reconnect-grace-expiry variant; same-client re-attach after cancel opens fresh and exits exactly once (B2); a cancel while the credit-mode exit frame is in flight settles without throwing and delivers exactly one `pty.exit` (A' + D); a failed in-flight settlement on a canceled delivery still fires capacity and retires the record (D's widened `finally`); a healthy completion publishes exactly one exit even when the retry re-runs (B0 + B1's `exitPublished` branch — this one also covers the RC's latent healthy-exit crash).
- `src/relay/relay-pty-source-exit-publication.test.ts` (new): unit coverage of every B1 branch (unknown/closed/closing probe, `legacyExitAccepted` re-targeting to source-owner clients only, silent retirement on `exitPublished` and on `sourceExitState === 'published'`, `'pending'` early return, retryable refused notify) and of layer D's settlement closure (skips the ledger settle when the delivery vanished, resumes capacity on `ok:false`, logs and contains a ledger fault).
- `src/relay/relay-pty-source-send-scheduler.test.ts` (new): A' no-op on `'pending'`, pruning a record whose tombstone was evicted, `getDebugSnapshot` skipping a null probe.
- `src/relay/pty-handler-source-publication.test.ts`: end-to-end cancel → `onExit` (one legacy exit, drained pending exit, ptmx `destroy()` ran); the exit-queued-behind-output × cancel × capacity interleaving (buffered `pty.data` arrives before exactly one `pty.exit`); layer C isolation via a throwing publication stub; and B0 — `exitPublicationSettled` true means `sealAndPublishExit` is never called.
- `src/relay/ssh-pty-source-credit-adapter.test.ts`: `cancel()`, the grace timer and `closeClientDeliveries` each notify; `cancelIdentity` and `rotate` do not; a throwing callback is swallowed and logged from both `cancel()` and the bare timer.
- `src/relay/pty-source-credit-ledger.test.ts`: `snapshotIfKnown` for live / healthily-closed (`exitPublished: true`) / canceled (`exitPublished: false`) / unknown / evicted-tombstone deliveries, with `snapshot` still throwing.

The untouched exit-path suites (`publishes exit only after preceding source data settles`, recovery interleavings, restore-retry) pass unmodified.

Also green: `npx tsc --noEmit -p config/tsconfig.node.json`, `npx oxlint src/relay`, `npx oxfmt --check src/relay`, `pnpm check:max-lines-ratchet` (no new suppressions).

Found by the production release scan of v1.4.162..v1.4.163-rc.0.

Made with [Orca](https://github.com/stablyai/orca) 🐋

