### PR TITLE
fix(mobile): open host editor reliably

### DIFF
--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -26,6 +26,7 @@ import {
 } from '../src/components/AccountUsage'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { loadHosts } from '../src/transport/host-store'
+import { navigateToMobileHostEdit } from '../src/transport/host-edit-navigation'
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
 import { pickResumeWorktree } from '../src/worktree/resume-worktree'
 import type { RpcClient } from '../src/transport/rpc-client'
@@ -1010,7 +1011,7 @@ export default function HomeScreen() {
             closeBeforePress: true,
             onPress: () => {
               setActionTarget(null)
-              router.push(`/h/${host.id}/edit`)
+              navigateToMobileHostEdit(router, host.id)
             }
           })
           items.push({

--- a/mobile/src/transport/host-edit-navigation.test.ts
+++ b/mobile/src/transport/host-edit-navigation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mobileHostEditRoute, navigateToMobileHostEdit } from './host-edit-navigation'
+
+describe('mobileHostEditRoute', () => {
+  it('keeps the dynamic host segment explicit for a cold host navigator', () => {
+    expect(mobileHostEditRoute('host-1')).toEqual({
+      pathname: '/h/[hostId]/edit',
+      params: { hostId: 'host-1' }
+    })
+  })
+
+  it('mounts a cold host navigator before replacing its index with edit', () => {
+    let nextFrame: FrameRequestCallback | null = null
+    const push = vi.fn()
+    const replace = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      nextFrame = callback
+      return 1
+    })
+
+    navigateToMobileHostEdit({ push, replace }, 'host-1')
+    expect(push).toHaveBeenCalledWith('/h/host-1')
+    expect(replace).not.toHaveBeenCalled()
+
+    nextFrame?.(0)
+    expect(replace).toHaveBeenCalledWith(mobileHostEditRoute('host-1'))
+    vi.unstubAllGlobals()
+  })
+})

--- a/mobile/src/transport/host-edit-navigation.ts
+++ b/mobile/src/transport/host-edit-navigation.ts
@@ -1,0 +1,19 @@
+type HostEditRouter = {
+  push: (href: `/h/${string}`) => void
+  replace: (href: ReturnType<typeof mobileHostEditRoute>) => void
+}
+
+export function mobileHostEditRoute(hostId: string) {
+  return {
+    pathname: '/h/[hostId]/edit' as const,
+    params: { hostId }
+  }
+}
+
+export function navigateToMobileHostEdit(router: HostEditRouter, hostId: string): void {
+  // Why: a cold nested host navigator resolves a deep push to its index route.
+  router.push(`/h/${hostId}`)
+  requestAnimationFrame(() => {
+    router.replace(mobileHostEditRoute(hostId))
+  })
+}


### PR DESCRIPTION
## What this fixes

On mobile, choosing **Edit host** from a saved desktop could open a completely blank Settings page. This happened most often the first time the host editor was opened after launching the app.

## Before / after

- **Before:** Tap the host action menu → **Edit host** → see an empty Settings page with no form.
- **After:** The populated **Edit host** form opens immediately with the saved name, address, and connection settings.

## What changed

- Enter the selected host's navigation stack before opening its nested edit screen.
- Pass the host ID explicitly to both route levels.
- Add a regression test for opening the editor before that host navigator has ever been mounted.

This does not change how host credentials are stored or how the app connects to a host.

## Verification

- Cold-start host-edit regression coverage passed.
- Mobile typecheck, lint, formatting, and focused tests passed.
- Verified on iPad that **Edit host** opens a populated form rather than a blank page.
- [iPad action-sheet and populated-editor screenshots](https://github.com/stablyai/orca/pull/11635#issuecomment-5140332111)
