### PR TITLE
fix(mobile): correct OMP icon gradient stop

### DIFF
--- a/mobile/src/components/MobileAgentIcon.tsx
+++ b/mobile/src/components/MobileAgentIcon.tsx
@@ -32,7 +32,7 @@ function OmpIcon({ size = 16 }: { size?: number }) {
       <Defs>
         <LinearGradient id="ompMarkGradient" x1="0" y1="0" x2="1" y2="1">
           <Stop offset="0" stopColor="#ed4abf" />
-          <Stop offset=".5" stopColor="#9b4dff" />
+          <Stop offset="0.5" stopColor="#9b4dff" />
           <Stop offset="1" stopColor="#5ad8e6" />
         </LinearGradient>
       </Defs>

--- a/mobile/src/components/mobile-agent-icon-gradient.test.ts
+++ b/mobile/src/components/mobile-agent-icon-gradient.test.ts
@@ -1,0 +1,65 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MobileAgentIcon } from './MobileAgentIcon'
+
+vi.mock('react-native', () => ({
+  Image: 'Image',
+  StyleSheet: { create: (styles: unknown) => styles },
+  Text: 'Text',
+  View: 'View'
+}))
+
+vi.mock('lucide-react-native', () => ({
+  Terminal: 'Terminal'
+}))
+
+vi.mock('react-native-svg', () => ({
+  default: 'Svg',
+  Defs: 'Defs',
+  G: 'G',
+  LinearGradient: 'LinearGradient',
+  Path: 'Path',
+  Stop: 'Stop'
+}))
+
+vi.mock('./mobile-agent-icon-assets', () => ({
+  MOBILE_AGENT_ICON_ASSETS: {}
+}))
+
+vi.mock('./AgentIcons', () => ({
+  ClaudeIcon: 'ClaudeIcon',
+  OpenAIIcon: 'OpenAIIcon'
+}))
+
+describe('MobileAgentIcon OMP gradient', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    vi.restoreAllMocks()
+  })
+
+  it('uses valid SVG gradient stop offsets', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] !== 'string' || !args[0].includes('react-test-renderer is deprecated')) {
+        throw new Error(String(args[0]))
+      }
+    })
+    await act(async () => {
+      renderer = create(createElement(MobileAgentIcon, { agentId: 'omp' }))
+    })
+    consoleError.mockRestore()
+
+    expect(renderer.root.findAllByType('Stop').map((stop) => stop.props.offset)).toEqual([
+      '0',
+      '0.5',
+      '1'
+    ])
+  })
+})


### PR DESCRIPTION
## What this fixes

Rendering the OMP agent icon produced a React Native SVG warning because its middle gradient stop used the malformed value `.5`. Depending on the renderer, that stop could also be ignored.

## Before / after

- **Before:** Every OMP icon render could log an invalid gradient-offset warning.
- **After:** The gradient uses the valid `0.5` offset and renders without that warning.

## What changed

- Correct the middle OMP gradient stop from `.5` to `0.5`.
- Add a regression test that validates every gradient stop used by the icon.

There is no intended design change beyond making the existing gradient render consistently.

## Verification

- Focused gradient regression test, mobile typecheck, lint, formatting, max-lines, reliability, and native static gates passed.
- Native QA on iPad `C589AF84-2F0C-4978-952B-748933DE6804` confirmed the intended gradient at 18px in the picker and 16px in the selected field, intact adjacent icon/list behavior, and no invalid-offset warning.
- Head `802b3619e715b156fc1262c6285cd7ca15880832` was validated against current `main` `f936e7fc9c7defebc40398a1ddf2ce50e93c7dfc`; the clean merge-tree is `e268f52161c8d3af091fe337ea57b28c1fb1d4d0` and its proportional targeted checks passed.
- GitHub reports `MERGEABLE` / `CLEAN`: 43 successful checks, one intentionally skipped path-gated e2e check, and zero pending or failed checks.
- [Native QA screenshots and exact evidence](https://github.com/stablyai/orca/pull/11650#issuecomment-5141341771)
