### PR TITLE
fix(codex): make account removal crash-safe

### DIFF
--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -2112,6 +2112,57 @@ describe('CodexAccountService config sync', () => {
     expect(existsSync(managedHomePath)).toBe(false)
   })
 
+  it('prunes a stale next selection in the same removal commit', async () => {
+    const managedHomePath = createManagedHome(testState.userDataDir, 'account-1')
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeCodexManagedAccountId: 'missing-account',
+      activeCodexManagedAccountIdsByRuntime: {
+        host: 'missing-account',
+        wsl: { Ubuntu: 'missing-wsl-account' }
+      }
+    })
+    const store = createStore(settings)
+    const runtimeHome = createRuntimeHome()
+    runtimeHome.syncForCurrentSelection.mockImplementation(() => {
+      const current = store.getSettings().activeCodexManagedAccountIdsByRuntime ?? {
+        host: null,
+        wsl: {}
+      }
+      if (current.host === 'missing-account') {
+        store.updateSettings({
+          activeCodexManagedAccountId: null,
+          activeCodexManagedAccountIdsByRuntime: { host: null, wsl: current.wsl }
+        })
+      }
+    })
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      createRateLimits() as never,
+      runtimeHome as never
+    )
+
+    await expect(service.removeAccount('account-1')).resolves.toMatchObject({
+      accounts: [],
+      activeAccountId: null,
+      activeAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+    })
+    expect(existsSync(managedHomePath)).toBe(false)
+    expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledOnce()
+  })
+
   it('refuses to remove a managed home owned by a different account', async () => {
     const otherAccountHome = createManagedHome(
       testState.userDataDir,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -20,6 +20,7 @@ import { buildCodexResetCreditExpectedScope } from '../../shared/codex-reset-cre
 import type { CodexResetCreditAttemptLedger } from '../../shared/codex-reset-credit-attempt-ledger'
 import { buildWslCodexAvailabilityArgs, buildWslCodexLoginArgs } from './wsl-codex-command'
 import type { readHookTrustEntries as ReadHookTrustEntries } from '../codex/config-toml-trust'
+import type { Store } from '../persistence'
 
 const testState = {
   userDataDir: '',
@@ -190,7 +191,10 @@ function createStore(settings: GlobalSettings) {
     }
     return applySettings(updates)
   }
-  const withSettingsPreview = <T>(updates: Partial<GlobalSettings>, action: () => T): T => {
+  const withSettingsPreview: Store['withCodexAccountSettingsPreview'] = <T>(
+    updates: Partial<GlobalSettings>,
+    action: () => T
+  ): T => {
     if (settingsPreviewActive) {
       throw new Error('Cannot nest Codex account settings previews')
     }
@@ -218,7 +222,7 @@ function createStore(settings: GlobalSettings) {
     getSettings: vi.fn(() => settings),
     updateSettings: vi.fn(updateSettings),
     updateCodexAccountSettingsAndFlush: vi.fn(updateSettings),
-    withCodexAccountSettingsPreview: vi.fn(withSettingsPreview),
+    withCodexAccountSettingsPreview: withSettingsPreview,
     getCodexResetCreditAttemptLedger: vi.fn(() => structuredClone(resetLedger)),
     replaceCodexResetCreditAttemptLedgerAndFlush: vi.fn((next: CodexResetCreditAttemptLedger) => {
       resetLedger = structuredClone(next)
@@ -229,7 +233,7 @@ function createStore(settings: GlobalSettings) {
         resetLedger = structuredClone(next)
       }
     )
-  }
+  } satisfies Partial<Store>
 }
 
 function failNextAccountRemovalPersistence(store: ReturnType<typeof createStore>): void {
@@ -2824,6 +2828,7 @@ describe('CodexAccountService config sync', () => {
     await expect(service.removeAccount('account-1')).resolves.toMatchObject({ accounts: [] })
     expect(existsSync(managedHomePath)).toBe(false)
     expect(store.updateCodexAccountSettingsAndFlush).toHaveBeenCalledOnce()
+    expect(store.updateCodexAccountSettingsAndResetLedgerAndFlush).not.toHaveBeenCalled()
     expect(() => store.getCodexResetCreditAttemptLedger()).toThrow(
       'Codex reset-credit attempt ledger is corrupt'
     )
@@ -3333,7 +3338,7 @@ describe('CodexAccountService config sync', () => {
     expect(consume).toHaveBeenCalledTimes(1)
   })
 
-  it('restores the selected runtime when account removal persistence fails', async () => {
+  it('restores the selected account when account removal persistence fails', async () => {
     const managedHomePath = createManagedHome(testState.userDataDir, 'account-1')
     const settings = createSettings({
       codexManagedAccounts: [

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -172,6 +172,7 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
 
 function createStore(settings: GlobalSettings) {
   let resetLedger: CodexResetCreditAttemptLedger = { version: 1, attempts: [] }
+  let settingsPreviewActive = false
   const applySettings = (updates: Partial<GlobalSettings>) => {
     settings = {
       ...settings,
@@ -183,19 +184,40 @@ function createStore(settings: GlobalSettings) {
     }
     return settings
   }
+  const updateSettings = (updates: Partial<GlobalSettings>) => {
+    if (settingsPreviewActive) {
+      throw new Error('Cannot update settings during a Codex account settings preview')
+    }
+    return applySettings(updates)
+  }
   const withSettingsPreview = <T>(updates: Partial<GlobalSettings>, action: () => T): T => {
+    if (settingsPreviewActive) {
+      throw new Error('Cannot nest Codex account settings previews')
+    }
     const previousSettings = settings
     applySettings(updates)
+    settingsPreviewActive = true
     try {
-      return action()
+      const result = action()
+      const resultType = typeof result
+      if (
+        result !== null &&
+        (resultType === 'object' || resultType === 'function') &&
+        typeof (result as { then?: unknown }).then === 'function'
+      ) {
+        void Promise.resolve(result).catch(() => {})
+        throw new Error('Codex account settings preview callback must be synchronous')
+      }
+      return result
     } finally {
       settings = previousSettings
+      settingsPreviewActive = false
     }
   }
   return {
     getSettings: vi.fn(() => settings),
-    updateSettings: vi.fn(applySettings),
-    updateCodexAccountSettingsAndFlush: vi.fn(applySettings),
+    updateSettings: vi.fn(updateSettings),
+    updateCodexAccountSettingsAndFlush: vi.fn(updateSettings),
     withCodexAccountSettingsPreview: vi.fn(withSettingsPreview),
     getCodexResetCreditAttemptLedger: vi.fn(() => structuredClone(resetLedger)),
     replaceCodexResetCreditAttemptLedgerAndFlush: vi.fn((next: CodexResetCreditAttemptLedger) => {
@@ -203,7 +225,7 @@ function createStore(settings: GlobalSettings) {
     }),
     updateCodexAccountSettingsAndResetLedgerAndFlush: vi.fn(
       (updates: Partial<GlobalSettings>, next: CodexResetCreditAttemptLedger) => {
-        applySettings(updates)
+        updateSettings(updates)
         resetLedger = structuredClone(next)
       }
     )
@@ -2044,6 +2066,47 @@ describe('CodexAccountService config sync', () => {
     expect(observedSelections).toEqual([null, 'account-1'])
     expect(store.getSettings().codexManagedAccounts.map(({ id }) => id)).toEqual(['account-1'])
     expect(existsSync(managedHomePath)).toBe(true)
+
+    await expect(service.removeAccount('account-1')).resolves.toMatchObject({ accounts: [] })
+    expect(existsSync(managedHomePath)).toBe(false)
+  })
+
+  it('rolls removal back when runtime reconciliation tries to mutate preview settings', async () => {
+    const managedHomePath = createManagedHome(testState.userDataDir, 'account-1')
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeCodexManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const runtimeHome = createRuntimeHome()
+    runtimeHome.syncForCurrentSelection.mockImplementationOnce(() => {
+      store.updateSettings({ activeCodexManagedAccountId: 'unexpected-account' })
+    })
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      createRateLimits() as never,
+      runtimeHome as never
+    )
+
+    await expect(service.removeAccount('account-1')).rejects.toThrow(
+      'Cannot update settings during a Codex account settings preview'
+    )
+    expect(store.getSettings().codexManagedAccounts.map(({ id }) => id)).toEqual(['account-1'])
+    expect(existsSync(managedHomePath)).toBe(true)
+    expect(store.updateCodexAccountSettingsAndResetLedgerAndFlush).not.toHaveBeenCalled()
+    expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledTimes(2)
 
     await expect(service.removeAccount('account-1')).resolves.toMatchObject({ accounts: [] })
     expect(existsSync(managedHomePath)).toBe(false)

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -172,24 +172,48 @@ function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings
 
 function createStore(settings: GlobalSettings) {
   let resetLedger: CodexResetCreditAttemptLedger = { version: 1, attempts: [] }
+  const applySettings = (updates: Partial<GlobalSettings>) => {
+    settings = {
+      ...settings,
+      ...updates,
+      notifications: {
+        ...settings.notifications,
+        ...updates.notifications
+      }
+    }
+    return settings
+  }
+  const withSettingsPreview = <T>(updates: Partial<GlobalSettings>, action: () => T): T => {
+    const previousSettings = settings
+    applySettings(updates)
+    try {
+      return action()
+    } finally {
+      settings = previousSettings
+    }
+  }
   return {
     getSettings: vi.fn(() => settings),
-    updateSettings: vi.fn((updates: Partial<GlobalSettings>) => {
-      settings = {
-        ...settings,
-        ...updates,
-        notifications: {
-          ...settings.notifications,
-          ...updates.notifications
-        }
-      }
-      return settings
-    }),
+    updateSettings: vi.fn(applySettings),
+    updateCodexAccountSettingsAndFlush: vi.fn(applySettings),
+    withCodexAccountSettingsPreview: vi.fn(withSettingsPreview),
     getCodexResetCreditAttemptLedger: vi.fn(() => structuredClone(resetLedger)),
     replaceCodexResetCreditAttemptLedgerAndFlush: vi.fn((next: CodexResetCreditAttemptLedger) => {
       resetLedger = structuredClone(next)
-    })
+    }),
+    updateCodexAccountSettingsAndResetLedgerAndFlush: vi.fn(
+      (updates: Partial<GlobalSettings>, next: CodexResetCreditAttemptLedger) => {
+        applySettings(updates)
+        resetLedger = structuredClone(next)
+      }
+    )
   }
+}
+
+function failNextAccountRemovalPersistence(store: ReturnType<typeof createStore>): void {
+  store.updateCodexAccountSettingsAndResetLedgerAndFlush.mockImplementationOnce(() => {
+    throw new Error('disk full')
+  })
 }
 
 function createRateLimits() {
@@ -1740,6 +1764,10 @@ describe('CodexAccountService config sync', () => {
       expect(existsSync(wslManagedHomePath)).toBe(false)
       expect(existsSync(join(testState.userDataDir, 'wsl-account'))).toBe(false)
       expect(rateLimits.evictInactiveCodexCache).toHaveBeenCalledWith('account-1')
+      expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledWith({
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu'
+      })
     } finally {
       Object.defineProperty(process, 'platform', {
         configurable: true,
@@ -1974,6 +2002,51 @@ describe('CodexAccountService config sync', () => {
     expect(result.activeAccountId).toBe(null)
     expect(existsSync(managedHomePath)).toBe(false)
     expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalled()
+    expect(store.updateCodexAccountSettingsAndResetLedgerAndFlush).toHaveBeenCalledOnce()
+  })
+
+  it('keeps account removal retryable when runtime reconciliation fails', async () => {
+    const managedHomePath = createManagedHome(testState.userDataDir, 'account-1')
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeCodexManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const observedSelections: (string | null)[] = []
+    let failReconciliation = true
+    const runtimeHome = createRuntimeHome()
+    runtimeHome.syncForCurrentSelection.mockImplementation(() => {
+      observedSelections.push(store.getSettings().activeCodexManagedAccountId)
+      if (failReconciliation) {
+        failReconciliation = false
+        throw new Error('activation failed')
+      }
+    })
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      createRateLimits() as never,
+      runtimeHome as never
+    )
+
+    await expect(service.removeAccount('account-1')).rejects.toThrow('activation failed')
+    expect(observedSelections).toEqual([null, 'account-1'])
+    expect(store.getSettings().codexManagedAccounts.map(({ id }) => id)).toEqual(['account-1'])
+    expect(existsSync(managedHomePath)).toBe(true)
+
+    await expect(service.removeAccount('account-1')).resolves.toMatchObject({ accounts: [] })
+    expect(existsSync(managedHomePath)).toBe(false)
   })
 
   it('refuses to remove a managed home owned by a different account', async () => {
@@ -2588,7 +2661,21 @@ describe('CodexAccountService config sync', () => {
   })
 
   it('fails only reset operations closed when the durable ledger is corrupt', async () => {
-    const settings = createSettings()
+    const managedHomePath = createManagedHome(testState.userDataDir, 'account-1')
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ]
+    })
     const store = createStore(settings)
     store.getCodexResetCreditAttemptLedger.mockImplementation(() => {
       throw new Error('Codex reset-credit attempt ledger is corrupt')
@@ -2604,7 +2691,9 @@ describe('CodexAccountService config sync', () => {
       createRuntimeHome() as never
     )
 
-    expect(service.listAccounts()).toMatchObject({ accounts: [] })
+    expect(service.listAccounts()).toMatchObject({
+      accounts: [expect.objectContaining({ id: 'account-1' })]
+    })
     await expect(
       service.consumeRateLimitResetCredit('dddddddd-dddd-4ddd-8ddd-dddddddddddd', {
         target: { runtime: 'host', wslDistro: null },
@@ -2617,6 +2706,13 @@ describe('CodexAccountService config sync', () => {
       'Codex reset-credit attempt ledger is corrupt'
     )
     expect(consume).not.toHaveBeenCalled()
+
+    await expect(service.removeAccount('account-1')).resolves.toMatchObject({ accounts: [] })
+    expect(existsSync(managedHomePath)).toBe(false)
+    expect(store.updateCodexAccountSettingsAndFlush).toHaveBeenCalledOnce()
+    expect(() => store.getCodexResetCreditAttemptLedger()).toThrow(
+      'Codex reset-credit attempt ledger is corrupt'
+    )
   })
 
   it('rejects a stale offer scope before calling the provider and permits a corrected retry key', async () => {
@@ -3060,7 +3156,7 @@ describe('CodexAccountService config sync', () => {
     expect(store.getCodexResetCreditAttemptLedger().attempts).toEqual([])
   })
 
-  it('keeps reset attempts fail-closed when removal cannot persist their purge', async () => {
+  it('keeps account removal retryable when reset-attempt purge cannot persist', async () => {
     const managedHomePath = createManagedHome(testState.userDataDir, 'account-1')
     const account = {
       id: 'account-1',
@@ -3105,13 +3201,60 @@ describe('CodexAccountService config sync', () => {
       } as never,
       createRuntimeHome() as never
     )
-    vi.spyOn(store, 'replaceCodexResetCreditAttemptLedgerAndFlush').mockImplementationOnce(() => {
-      throw new Error('disk full')
-    })
+    failNextAccountRemovalPersistence(store)
 
     await expect(service.removeAccount('account-1')).rejects.toThrow('disk full')
+    expect(store.getSettings().codexManagedAccounts.map(({ id }) => id)).toEqual(['account-1'])
+    expect(existsSync(managedHomePath)).toBe(true)
     await expect(service.consumeCurrentRateLimitResetCredit()).rejects.toThrow('unknown outcome')
     expect(consume).not.toHaveBeenCalled()
+
+    await expect(service.removeAccount('account-1')).resolves.toMatchObject({ accounts: [] })
+    expect(existsSync(managedHomePath)).toBe(false)
+    expect(store.getCodexResetCreditAttemptLedger().attempts).toEqual([])
+    await expect(service.consumeCurrentRateLimitResetCredit()).resolves.toEqual({
+      outcome: 'reset',
+      state
+    })
+    expect(consume).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores the selected runtime when account removal persistence fails', async () => {
+    const managedHomePath = createManagedHome(testState.userDataDir, 'account-1')
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'user@example.com',
+          managedHomePath,
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeCodexManagedAccountId: 'account-1'
+    })
+    const store = createStore(settings)
+    const observedSelections: (string | null)[] = []
+    const runtimeHome = createRuntimeHome()
+    runtimeHome.syncForCurrentSelection.mockImplementation(() => {
+      observedSelections.push(store.getSettings().activeCodexManagedAccountId)
+    })
+    failNextAccountRemovalPersistence(store)
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      createRateLimits() as never,
+      runtimeHome as never
+    )
+
+    await expect(service.removeAccount('account-1')).rejects.toThrow('disk full')
+
+    expect(observedSelections).toEqual([null, 'account-1'])
+    expect(store.getSettings().activeCodexManagedAccountId).toBe('account-1')
+    expect(existsSync(managedHomePath)).toBe(true)
   })
 
   it('does not reset a different system-default target after waiting in the mutation queue', async () => {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -715,14 +715,13 @@ export class CodexAccountService {
     outgoingAccountId: string | null | undefined,
     target: CodexAccountSelectionTarget | undefined
   ): void {
-    try {
-      void this.rateLimits
-        .refreshForCodexAccountChange(outgoingAccountId, target)
-        .catch((error) => {
-          console.error('[codex-accounts] Quota refresh after account change failed:', error)
-        })
-    } catch (error) {
+    const logFailure = (error: unknown): void => {
       console.error('[codex-accounts] Quota refresh after account change failed:', error)
+    }
+    try {
+      void this.rateLimits.refreshForCodexAccountChange(outgoingAccountId, target).catch(logFailure)
+    } catch (error) {
+      logFailure(error)
     }
   }
 

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -10,7 +10,8 @@ import type {
   CodexManagedAccount,
   CodexManagedAccountSummary,
   CodexRateLimitAccountsState,
-  CodexSystemDefaultIdentity
+  CodexSystemDefaultIdentity,
+  GlobalSettings
 } from '../../shared/types'
 import type {
   CodexRateLimitResetOutcome,
@@ -665,32 +666,35 @@ export class CodexAccountService {
     }
   }
 
-  // Why: a removed account's managed home is gone, so its unresolved providerPending
-  // attempt can never validate or be replayed; drop it so a target-scoped default reset
-  // is not wedged forever by hasPendingResetForTarget matching the orphan.
-  private discardResetAttemptsForRemovedAccount(accountId: string): void {
+  private persistAccountRemoval(
+    accountId: string,
+    updates: Pick<
+      GlobalSettings,
+      | 'codexManagedAccounts'
+      | 'activeCodexManagedAccountId'
+      | 'activeCodexManagedAccountIdsByRuntime'
+    >
+  ): void {
+    if (!this.durableResetLedger) {
+      // Why: reset stays fail-closed, but a corrupt ledger must not trap managed credentials on disk.
+      this.store.updateCodexAccountSettingsAndFlush(updates)
+      return
+    }
     const staleAttempts: [string, CodexResetCreditAttempt][] = []
     for (const [idempotencyKey, attempt] of this.resetAttemptsByKey) {
       if (attempt.expectedScope.accountId === accountId) {
         staleAttempts.push([idempotencyKey, attempt])
       }
     }
-    if (staleAttempts.length === 0) {
-      return
-    }
-    const staleKeySet = new Set(staleAttempts.map(([idempotencyKey]) => idempotencyKey))
-    if (this.durableResetLedger) {
-      const attempts = this.durableResetLedger.attempts.filter(
-        (attempt) => !staleKeySet.has(attempt.idempotencyKey)
+    const nextLedger: CodexResetCreditAttemptLedger = {
+      version: 1,
+      attempts: this.durableResetLedger.attempts.filter(
+        (attempt) => attempt.expectedScope.accountId !== accountId
       )
-      if (attempts.length !== this.durableResetLedger.attempts.length) {
-        const nextLedger: CodexResetCreditAttemptLedger = { version: 1, attempts }
-        // Persist first so a failed durability barrier leaves the in-memory
-        // fail-closed guards aligned with the ledger that will reload.
-        this.store.replaceCodexResetCreditAttemptLedgerAndFlush(nextLedger)
-        this.durableResetLedger = structuredClone(nextLedger)
-      }
     }
+    // Why: the account and its orphan guards must share one durability barrier before deleting its home.
+    this.store.updateCodexAccountSettingsAndResetLedgerAndFlush(updates, nextLedger)
+    this.durableResetLedger = structuredClone(nextLedger)
     for (const [idempotencyKey, attempt] of staleAttempts) {
       this.resetAttemptsByKey.delete(idempotencyKey)
       if (this.resetAttemptKeyByOffer.get(attempt.scopeKey) === idempotencyKey) {
@@ -711,9 +715,15 @@ export class CodexAccountService {
     outgoingAccountId: string | null | undefined,
     target: CodexAccountSelectionTarget | undefined
   ): void {
-    void this.rateLimits.refreshForCodexAccountChange(outgoingAccountId, target).catch((error) => {
+    try {
+      void this.rateLimits
+        .refreshForCodexAccountChange(outgoingAccountId, target)
+        .catch((error) => {
+          console.error('[codex-accounts] Quota refresh after account change failed:', error)
+        })
+    } catch (error) {
       console.error('[codex-accounts] Quota refresh after account change failed:', error)
-    })
+    }
   }
 
   private async doAddAccount(target?: CodexAccountAddTarget): Promise<CodexRateLimitAccountsState> {
@@ -901,6 +911,7 @@ export class CodexAccountService {
 
   private async doRemoveAccount(accountId: string): Promise<CodexRateLimitAccountsState> {
     const account = this.requireAccount(accountId)
+    const accountTarget = getCodexSelectionTargetForAccount(account)
     const settings = this.store.getSettings()
     const nextAccounts = settings.codexManagedAccounts.filter((entry) => entry.id !== accountId)
     const nextSelection = removeCodexAccountIdFromSelection(
@@ -910,27 +921,51 @@ export class CodexAccountService {
     const nextActiveId =
       settings.activeCodexManagedAccountId === accountId ? null : nextSelection.host
 
-    this.store.updateSettings({
+    const settingsUpdate = {
       codexManagedAccounts: nextAccounts,
       activeCodexManagedAccountId: nextActiveId,
       activeCodexManagedAccountIdsByRuntime: nextSelection
-    })
-    this.runtimeHome.syncForCurrentSelection()
+    }
+    try {
+      this.store.withCodexAccountSettingsPreview(settingsUpdate, () => {
+        this.runtimeHome.syncForCurrentSelection(accountTarget)
+      })
+      this.persistAccountRemoval(accountId, settingsUpdate)
+    } catch (error) {
+      try {
+        this.runtimeHome.syncForCurrentSelection(accountTarget)
+      } catch (rollbackError) {
+        console.error(
+          '[codex-accounts] Failed to restore runtime after account removal rollback:',
+          rollbackError
+        )
+      }
+      throw error
+    }
     if (account.managedHomeRuntime === 'host' && nextSelection.host === null) {
-      this.lifecycle.onHostSystemDefaultSelected?.()
+      try {
+        this.lifecycle.onHostSystemDefaultSelected?.()
+      } catch (error) {
+        console.error(
+          '[codex-accounts] Failed to reconcile host lifecycle after account removal:',
+          error
+        )
+      }
     }
 
     this.safeRemoveManagedHome(account.managedHomePath, account.id)
     // Why: a removed account can no longer appear in the switcher dropdown,
     // so purge its cached usage to avoid stale entries.
-    this.rateLimits.evictInactiveCodexCache(accountId)
-    this.discardResetAttemptsForRemovedAccount(accountId)
+    try {
+      this.rateLimits.evictInactiveCodexCache(accountId)
+    } catch (error) {
+      console.error('[codex-accounts] Failed to evict removed account quota cache:', error)
+    }
     this.startQuotaRefreshInBackground(
-      getSelectedCodexAccountIdForTarget(settings, getCodexSelectionTargetForAccount(account)) ===
-        accountId
+      getSelectedCodexAccountIdForTarget(settings, accountTarget) === accountId
         ? accountId
         : undefined,
-      getCodexSelectionTargetForAccount(account)
+      accountTarget
     )
     return this.getSnapshot()
   }

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -913,16 +913,14 @@ export class CodexAccountService {
     const accountTarget = getCodexSelectionTargetForAccount(account)
     const settings = this.store.getSettings()
     const nextAccounts = settings.codexManagedAccounts.filter((entry) => entry.id !== accountId)
-    const nextSelection = removeCodexAccountIdFromSelection(
-      normalizeCodexRuntimeSelection(settings),
-      accountId
+    const nextSelection = pruneInvalidCodexRuntimeSelection(
+      removeCodexAccountIdFromSelection(normalizeCodexRuntimeSelection(settings), accountId),
+      nextAccounts
     )
-    const nextActiveId =
-      settings.activeCodexManagedAccountId === accountId ? null : nextSelection.host
 
     const settingsUpdate = {
       codexManagedAccounts: nextAccounts,
-      activeCodexManagedAccountId: nextActiveId,
+      activeCodexManagedAccountId: nextSelection.host,
       activeCodexManagedAccountIdsByRuntime: nextSelection
     }
     try {

--- a/src/main/durable-file-write.test.ts
+++ b/src/main/durable-file-write.test.ts
@@ -1,7 +1,8 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import * as fsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { writeFileDurable, writeFileDurableSync } from './durable-file-write'
 
 describe('durable file write', () => {
@@ -83,5 +84,40 @@ describe('durable file write', () => {
     await writeFileDurable(`${final}.a.tmp`, final, 'from-async')
     writeFileDurableSync(`${final}.b.tmp`, final, 'from-sync')
     expect(readFileSync(final, 'utf-8')).toBe('from-sync')
+  })
+
+  it('keeps the publish point synchronous so a newer sync writer remains last', async () => {
+    const final = join(dir, 'state.json')
+    const asyncTemp = `${final}.async.tmp`
+    writeFileSync(asyncTemp, 'older-async', 'utf-8')
+    let releaseRename = () => {}
+    const renameGate = new Promise<void>((resolve) => {
+      releaseRename = resolve
+    })
+    const asyncRename = vi.fn(async (...args: Parameters<typeof fsPromises.rename>) => {
+      await renameGate
+      return fsPromises.rename(...args)
+    })
+    vi.resetModules()
+    vi.doMock('node:fs/promises', () => ({
+      ...fsPromises,
+      // Recreate the old yield between the caller's generation check and publish.
+      rename: asyncRename
+    }))
+
+    try {
+      const { renameDurable } = await import('./durable-file-write')
+      const asyncCommit = renameDurable(asyncTemp, final)
+      const usedYieldingRename = asyncRename.mock.calls.length > 0
+      writeFileDurableSync(`${final}.sync.tmp`, final, 'newer-sync')
+      releaseRename()
+      await asyncCommit
+
+      expect(usedYieldingRename).toBe(false)
+      expect(readFileSync(final, 'utf-8')).toBe('newer-sync')
+    } finally {
+      vi.doUnmock('node:fs/promises')
+      vi.resetModules()
+    }
   })
 })

--- a/src/main/durable-file-write.ts
+++ b/src/main/durable-file-write.ts
@@ -4,7 +4,7 @@
 // hour's loss; fsync stops it from happening.
 
 import { closeSync, fsyncSync, openSync, renameSync, writeFileSync } from 'node:fs'
-import { open, readdir, rename, rm, stat } from 'node:fs/promises'
+import { open, readdir, rm, stat } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 
 /**
@@ -47,7 +47,8 @@ function syncDirectorySync(directory: string): void {
  * themselves and need the rename made durable.
  */
 export async function renameDurable(tmpPath: string, finalPath: string): Promise<void> {
-  await rename(tmpPath, finalPath)
+  // Why: the commit must not yield after a caller's generation check, or an older writer can overwrite a newer sync flush.
+  renameSync(tmpPath, finalPath)
   await syncDirectory(dirname(finalPath))
 }
 
@@ -85,7 +86,8 @@ export async function writeFileDurableIfCurrent(
     if (!isCurrent()) {
       return false
     }
-    await rename(tmpPath, finalPath)
+    // Why: keep the current-generation check and its publish point in one event-loop turn.
+    renameSync(tmpPath, finalPath)
     renamed = true
     await syncDirectory(dirname(finalPath))
     return true

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -495,6 +495,24 @@ describe('Store', () => {
     expect(store.getSettings()).toEqual(beforeSettings)
   })
 
+  it('rejects nested Codex account settings previews', async () => {
+    const store = await createStore()
+    const beforeSettings = structuredClone(store.getSettings())
+    const preview = {
+      codexManagedAccounts: [],
+      activeCodexManagedAccountId: null,
+      activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+    }
+
+    expect(() =>
+      store.withCodexAccountSettingsPreview(preview, () => {
+        store.withCodexAccountSettingsPreview(preview, () => {})
+      })
+    ).toThrow('Cannot nest Codex account settings previews')
+
+    expect(store.getSettings()).toEqual(beforeSettings)
+  })
+
   it('rejects Codex settings mutations during an account settings preview', async () => {
     const store = await createStore()
     const beforeSettings = structuredClone(store.getSettings())

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -41,6 +41,7 @@ import { SshConnectionStore } from './ssh/ssh-connection-store'
 import { setSourceControlActionDefault } from '../shared/source-control-ai-actions'
 import { LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { closeTerminalTabInWorkspaceSession } from '../shared/workspace-session-terminal-tab-close'
+import type { CodexResetCreditAttemptLedger } from '../shared/codex-reset-credit-attempt-ledger'
 
 // Shared mutable state so the electron mock can reference a per-test directory
 const testState = { dir: '' }
@@ -158,6 +159,37 @@ function writeDataFile(data: unknown): void {
 
 function readDataFile(): unknown {
   return JSON.parse(readFileSync(dataFile(), 'utf-8'))
+}
+
+function createPersistedCodexAccount(): GlobalSettings['codexManagedAccounts'][number] {
+  return {
+    id: 'account-host',
+    email: 'user@example.com',
+    managedHomePath: join(testState.dir, 'account-host', 'home'),
+    managedHomeRuntime: 'host',
+    wslDistro: null,
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1
+  }
+}
+
+function createPendingCodexResetLedger(): CodexResetCreditAttemptLedger {
+  return {
+    version: 1,
+    attempts: [
+      {
+        idempotencyKey: '11111111-1111-4111-8111-111111111111',
+        expectedScope: {
+          target: { runtime: 'host', wslDistro: null },
+          accountId: 'account-host',
+          accountRevision: 42,
+          offerRevision: 'v1:offer'
+        },
+        state: 'providerPending'
+      }
+    ]
+  }
 }
 
 function symlinkDirectorySync(target: string, linkPath: string): void {
@@ -389,19 +421,148 @@ describe('Store', () => {
     expect(store.getCodexResetCreditAttemptLedger()).toEqual(before)
   })
 
+  it('persists Codex account removal and reset-ledger cleanup in one flush', async () => {
+    const store = await createStore()
+    const account = createPersistedCodexAccount()
+    store.updateSettings({
+      codexManagedAccounts: [account],
+      activeCodexManagedAccountId: 'account-host',
+      activeCodexManagedAccountIdsByRuntime: { host: 'account-host', wsl: {} }
+    })
+    store.replaceCodexResetCreditAttemptLedgerAndFlush(createPendingCodexResetLedger())
+
+    store.updateCodexAccountSettingsAndResetLedgerAndFlush(
+      {
+        codexManagedAccounts: [],
+        activeCodexManagedAccountId: null,
+        activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+      },
+      { version: 1, attempts: [] }
+    )
+
+    expect(store.getSettings().codexManagedAccounts).toEqual([])
+    expect(store.getCodexResetCreditAttemptLedger().attempts).toEqual([])
+    const persisted = readDataFile() as PersistedState
+    expect(persisted.settings.codexManagedAccounts).toEqual([])
+    expect(persisted.codexResetCreditAttemptLedger?.attempts).toEqual([])
+  })
+
+  it('restores Codex account settings when pre-removal reconciliation fails', async () => {
+    const store = await createStore()
+    const account = createPersistedCodexAccount()
+    store.updateSettings({
+      codexManagedAccounts: [account],
+      activeCodexManagedAccountId: 'account-host',
+      activeCodexManagedAccountIdsByRuntime: { host: 'account-host', wsl: {} }
+    })
+    store.flushOrThrow()
+    const beforeSettings = structuredClone(store.getSettings())
+
+    expect(() =>
+      store.withCodexAccountSettingsPreview(
+        {
+          codexManagedAccounts: [],
+          activeCodexManagedAccountId: null,
+          activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+        },
+        () => {
+          expect(store.getSettings().codexManagedAccounts).toEqual([])
+          throw new Error('activation failed')
+        }
+      )
+    ).toThrow('activation failed')
+
+    expect(store.getSettings()).toEqual(beforeSettings)
+    expect((readDataFile() as PersistedState).settings).toEqual(beforeSettings)
+  })
+
+  it('rejects asynchronous Codex account settings preview callbacks', async () => {
+    const store = await createStore()
+    const beforeSettings = structuredClone(store.getSettings())
+
+    expect(() =>
+      store.withCodexAccountSettingsPreview(
+        {
+          codexManagedAccounts: [],
+          activeCodexManagedAccountId: null,
+          activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+        },
+        () => Promise.reject(new Error('async failed'))
+      )
+    ).toThrow('Codex account settings preview callback must be synchronous')
+
+    await Promise.resolve()
+    expect(store.getSettings()).toEqual(beforeSettings)
+  })
+
+  it('rolls Codex account settings and reset ledger back together when removal flush fails', async () => {
+    const store = await createStore()
+    const account = createPersistedCodexAccount()
+    const ledger = createPendingCodexResetLedger()
+    store.updateSettings({
+      codexManagedAccounts: [account],
+      activeCodexManagedAccountId: 'account-host',
+      activeCodexManagedAccountIdsByRuntime: { host: 'account-host', wsl: {} }
+    })
+    store.replaceCodexResetCreditAttemptLedgerAndFlush(ledger)
+    const beforeSettings = structuredClone(store.getSettings())
+    vi.spyOn(store, 'flushOrThrow').mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+
+    expect(() =>
+      store.updateCodexAccountSettingsAndResetLedgerAndFlush(
+        {
+          codexManagedAccounts: [],
+          activeCodexManagedAccountId: null,
+          activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+        },
+        { version: 1, attempts: [] }
+      )
+    ).toThrow('disk full')
+
+    expect(store.getSettings()).toEqual(beforeSettings)
+    expect(store.getCodexResetCreditAttemptLedger()).toEqual(ledger)
+    const persisted = readDataFile() as PersistedState
+    expect(persisted.settings).toEqual(beforeSettings)
+    expect(persisted.codexResetCreditAttemptLedger).toEqual(ledger)
+  })
+
   it('preserves a corrupt Codex reset ledger as a fail-closed read error', async () => {
+    const account = createPersistedCodexAccount()
+    const corruptLedger = {
+      version: 1,
+      attempts: [{ state: 'providerPending' }]
+    }
+    const initialState = getDefaultPersistedState(testState.dir)
     writeDataFile({
-      ...getDefaultPersistedState(testState.dir),
-      codexResetCreditAttemptLedger: {
-        version: 1,
-        attempts: [{ state: 'providerPending' }]
-      }
+      ...initialState,
+      settings: {
+        ...initialState.settings,
+        codexManagedAccounts: [account],
+        activeCodexManagedAccountId: 'account-host',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-host', wsl: {} }
+      },
+      codexResetCreditAttemptLedger: corruptLedger
     })
 
     const store = await createStore()
     expect(() => store.getCodexResetCreditAttemptLedger()).toThrow(
       'Codex reset-credit attempt ledger is corrupt'
     )
+    store.updateCodexAccountSettingsAndFlush({
+      codexManagedAccounts: [],
+      activeCodexManagedAccountId: null,
+      activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+    })
+
+    expect(store.getSettings().codexManagedAccounts).toEqual([])
+    expect(() => store.getCodexResetCreditAttemptLedger()).toThrow(
+      'Codex reset-credit attempt ledger is corrupt'
+    )
+    const persisted = readDataFile() as PersistedState
+    expect(persisted.settings.codexManagedAccounts).toEqual([])
+    expect(persisted.codexResetCreditAttemptLedger).toEqual(corruptLedger)
   })
 
   it('does not restore a terminal tab after its durable close flush returns', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -495,6 +495,48 @@ describe('Store', () => {
     expect(store.getSettings()).toEqual(beforeSettings)
   })
 
+  it('rejects Codex settings mutations during an account settings preview', async () => {
+    const store = await createStore()
+    const beforeSettings = structuredClone(store.getSettings())
+
+    expect(() =>
+      store.withCodexAccountSettingsPreview(
+        {
+          codexManagedAccounts: [],
+          activeCodexManagedAccountId: null,
+          activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+        },
+        () => {
+          store.updateSettings({ activeCodexManagedAccountId: 'unexpected-account' })
+        }
+      )
+    ).toThrow('Cannot update settings during a Codex account settings preview')
+
+    expect(store.getSettings()).toEqual(beforeSettings)
+  })
+
+  it('rejects persistence during a Codex account settings preview', async () => {
+    const store = await createStore()
+    store.flushOrThrow()
+    const beforeSettings = structuredClone(store.getSettings())
+
+    expect(() =>
+      store.withCodexAccountSettingsPreview(
+        {
+          codexManagedAccounts: [],
+          activeCodexManagedAccountId: null,
+          activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+        },
+        () => {
+          store.flushOrThrow()
+        }
+      )
+    ).toThrow('Cannot persist during a Codex account settings preview')
+
+    expect(store.getSettings()).toEqual(beforeSettings)
+    expect((readDataFile() as PersistedState).settings).toEqual(beforeSettings)
+  })
+
   it('rolls Codex account settings and reset ledger back together when removal flush fails', async () => {
     const store = await createStore()
     const account = createPersistedCodexAccount()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2783,6 +2783,11 @@ export type StoreOptions = {
   dataFile?: string
 }
 
+type CodexAccountSettingsUpdate = Pick<
+  GlobalSettings,
+  'codexManagedAccounts' | 'activeCodexManagedAccountId' | 'activeCodexManagedAccountIdsByRuntime'
+>
+
 export class Store {
   private state: PersistedState
   private readonly dataFile: string
@@ -4208,6 +4213,66 @@ export class Store {
       // Why: callers use a successful return as the durability barrier before
       // handing a scarce-credit mutation to the provider.
       this.state.codexResetCreditAttemptLedger = previous
+      throw error
+    }
+  }
+
+  updateCodexAccountSettingsAndFlush(updates: CodexAccountSettingsUpdate): void {
+    this.updateCodexAccountStateAndFlush(updates)
+  }
+
+  withCodexAccountSettingsPreview<T>(updates: CodexAccountSettingsUpdate, action: () => T): T {
+    if (this.writesFrozen) {
+      throw new Error('Cannot preview Codex account removal while writes are frozen')
+    }
+    const previousSettings = this.state.settings
+    this.state.settings = { ...previousSettings, ...updates }
+    try {
+      const result = action()
+      const resultType = typeof result
+      if (
+        result !== null &&
+        (resultType === 'object' || resultType === 'function') &&
+        typeof (result as { then?: unknown }).then === 'function'
+      ) {
+        // Why: consume a rejected forbidden callback so the contract error does not leak an unhandled rejection.
+        void Promise.resolve(result).catch(() => {})
+        throw new Error('Codex account settings preview callback must be synchronous')
+      }
+      return result
+    } finally {
+      this.state.settings = previousSettings
+    }
+  }
+
+  updateCodexAccountSettingsAndResetLedgerAndFlush(
+    updates: CodexAccountSettingsUpdate,
+    ledger: CodexResetCreditAttemptLedger
+  ): void {
+    this.updateCodexAccountStateAndFlush(updates, ledger)
+  }
+
+  private updateCodexAccountStateAndFlush(
+    updates: CodexAccountSettingsUpdate,
+    ledger?: CodexResetCreditAttemptLedger
+  ): void {
+    if (this.writesFrozen) {
+      throw new Error('Cannot persist Codex account removal while writes are frozen')
+    }
+    const nextLedger = ledger ? parseCodexResetCreditAttemptLedger(ledger) : undefined
+    const previousSettings = this.state.settings
+    const previousLedger = this.state.codexResetCreditAttemptLedger
+      ? structuredClone(this.state.codexResetCreditAttemptLedger)
+      : undefined
+    try {
+      this.updateSettings(updates)
+      if (nextLedger !== undefined) {
+        this.state.codexResetCreditAttemptLedger = nextLedger
+      }
+      this.flushOrThrow()
+    } catch (error) {
+      this.state.settings = previousSettings
+      this.state.codexResetCreditAttemptLedger = previousLedger
       throw error
     }
   }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2806,6 +2806,7 @@ export class Store {
   /** Set by flushAsync so the quit flush is the final write; see scheduleSave. */
   private quitFlushStarted = false
   private quitFlushPromise: Promise<void> | null = null
+  private codexAccountSettingsPreviewActive = false
   // Content hash at last write, to skip no-op writes; derived from the payload with encrypted blobs normalized back to plaintext (see buildStateToSave), since encrypt() uses a random IV per call.
   private lastWrittenStateHash: string | null = null
   private lastDurableWriteGeneration = -1
@@ -4161,6 +4162,9 @@ export class Store {
   }
 
   flushOrThrow(): void {
+    if (this.codexAccountSettingsPreviewActive) {
+      throw new Error('Cannot persist during a Codex account settings preview')
+    }
     if (this.quitFlushStarted) {
       throw new Error('Cannot synchronously flush after final persistence has started')
     }
@@ -4225,7 +4229,11 @@ export class Store {
     if (this.writesFrozen) {
       throw new Error('Cannot preview Codex account removal while writes are frozen')
     }
+    if (this.codexAccountSettingsPreviewActive) {
+      throw new Error('Cannot nest Codex account settings previews')
+    }
     const previousSettings = this.state.settings
+    this.codexAccountSettingsPreviewActive = true
     this.state.settings = { ...previousSettings, ...updates }
     try {
       const result = action()
@@ -4242,6 +4250,7 @@ export class Store {
       return result
     } finally {
       this.state.settings = previousSettings
+      this.codexAccountSettingsPreviewActive = false
     }
   }
 
@@ -5865,6 +5874,9 @@ export class Store {
     updates: Partial<GlobalSettings>,
     options: { notifyListeners?: boolean; originWebContentsId?: number } = {}
   ): GlobalSettings {
+    if (this.codexAccountSettingsPreviewActive) {
+      throw new Error('Cannot update settings during a Codex account settings preview')
+    }
     const sanitizedUpdates = stripLegacyTerminalScrollbackBytes(updates)
     if ('opencodeSessionCookie' in updates && !updates.opencodeSessionCookie) {
       this.protectedSecrets.removeRetainedBlob(PROTECTED_SECRET_SLOT.opencodeSessionCookie)


### PR DESCRIPTION
## Summary

- Persist managed Codex account removal and reset-credit attempt cleanup in one synchronous durability boundary, rolling both values back if the write fails.
- Reconcile the exact host or WSL runtime before committing; if reconciliation or persistence fails, restore the original runtime selection and leave the account, managed home, and reset guards retryable.
- Keep the temporary settings preview synchronous and read-only so runtime reconciliation cannot mutate or persist preview state.
- Preserve a corrupt reset ledger unchanged so reset operations remain fail-closed without trapping managed credentials on disk.
- Make the durable writer's final rename non-yielding so an older async snapshot cannot overwrite a newer synchronous flush after its generation check.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — ran 11 focused files / 712 tests before the final test-only follow-up; after rebasing the final head onto current `main`, reran the 3 directly changed suites / 524 tests
- [ ] `pnpm build` — no packaging or renderer asset changes
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification before the final test-only follow-up:

```text
Test Files  11 passed (11)
Tests       712 passed (712)
```

Post-rebase verification on exact HEAD:

```text
Test Files  3 passed (3)
Tests       524 passed (524)
```

Full `pnpm typecheck` and `pnpm lint` also passed again after the final rebase.

The review follow-up adds red-to-green coverage proving that nested previews, `updateSettings()`, and `flushOrThrow()` cannot run during a Codex account settings preview; that a runtime mutation attempt rolls the removal back before the account or managed home is deleted; and that stale host/WSL account IDs are pruned in the same successful removal commit.

## AI Review Report

Ran five independent review axes against the final diff: correctness, reliability, security/data integrity, cross-platform compatibility, and maintainability/test quality.

The review initially found and the implementation now covers:

- settings removal and reset-ledger purge committing separately;
- a stale async writer publishing after a newer synchronous durability barrier;
- corrupt reset-ledger state blocking unrelated credential/account removal;
- runtime reconciliation failure leaving a non-retryable partial removal;
- persistence failure leaving runtime identity different from the restored Store selection;
- WSL removal reconciling the host lane instead of the exact distro;
- an asynchronous preview callback escaping its synchronous settings scope or leaking an unhandled rejection;
- a synchronous Store mutation or flush persisting temporary preview state;
- stale legacy host/WSL selection IDs forcing an otherwise safe removal to be retried.

CodeRabbit's follow-up also identified that the service test double did not enforce the real Store's synchronous preview callback contract. The double now rejects nested, asynchronous, and settings-mutating callbacks like the production Store. Its optional duplicated quota-refresh log suggestion was also applied without changing failure behavior.

All five final review passes reported no remaining P0-P3 findings. Cross-platform review explicitly covered macOS, Linux, Windows, host/WSL target shapes, same-directory rename behavior, legacy persisted selection state, and the small main-thread cost of synchronizing only the final rename metadata operation. No shortcuts, labels, shell commands, or renderer/Electron UI behavior are changed.

## Security Audit

- No new IPC methods, external commands, dependencies, credential parsing, or user-controlled path inputs are introduced.
- Reset-credit provider calls remain fail-closed: valid ledgers commit account removal and attempt cleanup atomically; corrupt ledgers remain corrupt and reset consumption stays disabled.
- Runtime reconciliation uses the account's exact host/WSL target and rolls back to the original selection on both preview and persistence failures.
- The preview boundary rejects settings writes, flushes, and nested previews before temporary removal state can be persisted.
- Managed-home deletion still uses the existing ownership/canonical-path checks.

The review identified a pre-existing credential-remanence risk when managed-home deletion itself fails after account metadata is removed. That is not introduced by this change and is tracked separately in #11653 with a durable cleanup-tombstone design.

## Notes

- The multi-megabyte write and file fsync remain asynchronous. Only the same-directory rename publish point is synchronous so the generation check and commit cannot be interleaved.
- No persisted schema migration is added.
- Rollback is a single-commit revert; account settings and reset-ledger formats remain unchanged.
- Real Windows + WSL smoke testing was not available locally; exact-target behavior and failure rollback are covered by focused tests.

- Contributor X: [@DevKazu42](https://x.com/DevKazu42)
