### PR TITLE
feat(cli): link a Jira issue to a workspace with `worktree set --jira`

### DIFF
--- a/src/cli/handlers/worktree-jira-issue-link.test.ts
+++ b/src/cli/handlers/worktree-jira-issue-link.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { getOptionalJiraIssueLinkFlag } from './worktree-jira-issue-link'
+
+function flags(entries: Record<string, string | boolean>): Map<string, string | boolean> {
+  return new Map(Object.entries(entries))
+}
+
+describe('getOptionalJiraIssueLinkFlag', () => {
+  it('is undefined when the flag is absent, so set leaves the link alone', () => {
+    expect(getOptionalJiraIssueLinkFlag(flags({}), 'jira')).toBeUndefined()
+  })
+
+  it('accepts a bare issue key and leaves the site to the active one', () => {
+    expect(getOptionalJiraIssueLinkFlag(flags({ jira: 'PROJ-123' }), 'jira')).toEqual({
+      clear: false,
+      issueKey: 'PROJ-123',
+      origin: null
+    })
+  })
+
+  it('uppercases the key so proj-123 and PROJ-123 link the same issue', () => {
+    expect(getOptionalJiraIssueLinkFlag(flags({ jira: 'proj-123' }), 'jira')).toMatchObject({
+      issueKey: 'PROJ-123'
+    })
+  })
+
+  it('pins the site when the value is a URL', () => {
+    expect(
+      getOptionalJiraIssueLinkFlag(
+        flags({ jira: 'https://acme.atlassian.net/browse/PROJ-9' }),
+        'jira'
+      )
+    ).toEqual({
+      clear: false,
+      issueKey: 'PROJ-9',
+      origin: 'https://acme.atlassian.net'
+    })
+  })
+
+  it('clears the link with null when the caller allows it', () => {
+    expect(
+      getOptionalJiraIssueLinkFlag(flags({ jira: 'null' }), 'jira', { allowNull: true })
+    ).toEqual({
+      clear: true
+    })
+  })
+
+  it('rejects null where clearing makes no sense, like on create', () => {
+    expect(() => getOptionalJiraIssueLinkFlag(flags({ jira: 'null' }), 'jira')).toThrow(
+      /Omit --jira on create/
+    )
+  })
+
+  it('rejects values that are neither a key nor an issue URL', () => {
+    // Why: a bare project name or a Jira URL that is not an issue would
+    // otherwise be stored as a key and render a dead link on the card.
+    for (const bad of ['PROJ', 'not a key', 'https://acme.atlassian.net/projects/PROJ']) {
+      expect(() => getOptionalJiraIssueLinkFlag(flags({ jira: bad }), 'jira')).toThrow(
+        /Pass a Jira issue key/
+      )
+    }
+  })
+
+  it('rejects a flag passed without a value', () => {
+    expect(() => getOptionalJiraIssueLinkFlag(flags({ jira: true }), 'jira')).toThrow(
+      /Missing value for --jira/
+    )
+  })
+})

--- a/src/cli/handlers/worktree-jira-issue-link.test.ts
+++ b/src/cli/handlers/worktree-jira-issue-link.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { getOptionalJiraIssueLinkFlag } from './worktree-jira-issue-link'
+import { getOptionalJiraIssueLinkFlag, resolveJiraWorkItem } from './worktree-jira-issue-link'
+import type { RuntimeClient } from '../runtime-client'
+import type { JiraSite } from '../../shared/jira-types'
 
 function flags(entries: Record<string, string | boolean>): Map<string, string | boolean> {
   return new Map(Object.entries(entries))
@@ -14,7 +16,7 @@ describe('getOptionalJiraIssueLinkFlag', () => {
     expect(getOptionalJiraIssueLinkFlag(flags({ jira: 'PROJ-123' }), 'jira')).toEqual({
       clear: false,
       issueKey: 'PROJ-123',
-      origin: null
+      parsed: null
     })
   })
 
@@ -30,10 +32,10 @@ describe('getOptionalJiraIssueLinkFlag', () => {
         flags({ jira: 'https://acme.atlassian.net/browse/PROJ-9' }),
         'jira'
       )
-    ).toEqual({
+    ).toMatchObject({
       clear: false,
       issueKey: 'PROJ-9',
-      origin: 'https://acme.atlassian.net'
+      parsed: { origin: 'https://acme.atlassian.net' }
     })
   })
 
@@ -65,5 +67,70 @@ describe('getOptionalJiraIssueLinkFlag', () => {
     expect(() => getOptionalJiraIssueLinkFlag(flags({ jira: true }), 'jira')).toThrow(
       /Missing value for --jira/
     )
+  })
+})
+
+const site = (id: string, siteUrl: string): JiraSite => ({ id, siteUrl }) as JiraSite
+
+function clientWith(sites: JiraSite[], activeSiteId: string | null): RuntimeClient {
+  return {
+    call: async (method: string) => {
+      if (method === 'jira.status') {
+        return { result: { connected: true, sites, activeSiteId } }
+      }
+      return {
+        result: {
+          key: 'PROJ-9',
+          title: 'A ticket',
+          url: 'https://acme.atlassian.net/browse/PROJ-9',
+          siteId: sites[0]?.id
+        }
+      }
+    }
+  } as unknown as RuntimeClient
+}
+
+describe('resolveJiraWorkItem site matching', () => {
+  it('does not match a host that merely starts with the origin', async () => {
+    // Why: the reported bug. A prefix test let acme.atlassian.net.evil.example
+    // stand in for acme.atlassian.net.
+    const input = getOptionalJiraIssueLinkFlag(
+      flags({ jira: 'https://acme.atlassian.net/browse/PROJ-9' }),
+      'jira'
+    )
+    const client = clientWith([site('1', 'https://acme.atlassian.net.evil.example')], '1')
+
+    await expect(resolveJiraWorkItem(input, client)).rejects.toThrow(/No connected Jira site/)
+  })
+
+  it('matches the exact origin', async () => {
+    const input = getOptionalJiraIssueLinkFlag(
+      flags({ jira: 'https://acme.atlassian.net/browse/PROJ-9' }),
+      'jira'
+    )
+    const client = clientWith([site('1', 'https://acme.atlassian.net')], '1')
+
+    await expect(resolveJiraWorkItem(input, client)).resolves.toMatchObject({
+      linkedWorkItem: { jiraIdentifier: 'PROJ-9' }
+    })
+  })
+
+  it('refuses to guess when several sites are connected and none is active', async () => {
+    const input = getOptionalJiraIssueLinkFlag(flags({ jira: 'PROJ-9' }), 'jira')
+    const client = clientWith(
+      [site('1', 'https://acme.atlassian.net'), site('2', 'https://other.atlassian.net')],
+      null
+    )
+
+    await expect(resolveJiraWorkItem(input, client)).rejects.toThrow(/Several Jira sites/)
+  })
+
+  it('uses the only connected site when there is no active one', async () => {
+    const input = getOptionalJiraIssueLinkFlag(flags({ jira: 'PROJ-9' }), 'jira')
+    const client = clientWith([site('1', 'https://acme.atlassian.net')], null)
+
+    await expect(resolveJiraWorkItem(input, client)).resolves.toMatchObject({
+      linkedWorkItem: { jiraIdentifier: 'PROJ-9' }
+    })
   })
 })

--- a/src/cli/handlers/worktree-jira-issue-link.ts
+++ b/src/cli/handlers/worktree-jira-issue-link.ts
@@ -1,0 +1,128 @@
+import { JIRA_ISSUE_KEY_PATTERN, parseJiraIssueUrl } from '../../shared/jira-issue-url'
+import { RuntimeClientError, type RuntimeClient } from '../runtime-client'
+import type { WorkspaceLinkedItem } from '../../shared/types'
+import type { JiraIssue, JiraSite } from '../../shared/jira-types'
+
+export type JiraIssueLinkInput =
+  | { clear: true }
+  | { clear: false; issueKey: string; origin: string | null }
+
+/**
+ * Parses `--jira`, accepting a bare issue key (`PROJ-123`) or a full Jira issue
+ * URL. `null` clears the link.
+ *
+ * The URL form also carries the site origin, which matters when more than one
+ * Jira site is connected: the same key can exist on two instances, so a bare
+ * key resolves against the active site while a URL pins the one it came from.
+ */
+export function getOptionalJiraIssueLinkFlag(
+  flags: Map<string, string | boolean>,
+  name: string,
+  options: { allowNull?: boolean } = {}
+): JiraIssueLinkInput | undefined {
+  const value = getPresentStringFlag(flags, name)
+  if (value === undefined) {
+    return undefined
+  }
+
+  const trimmed = value.trim()
+  if (trimmed.toLowerCase() === 'null') {
+    if (!options.allowNull) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'Omit --jira on create, or pass a Jira issue key or URL.'
+      )
+    }
+    return { clear: true }
+  }
+
+  const parsed = parseJiraIssueUrl(trimmed)
+  if (parsed) {
+    return { clear: false, issueKey: parsed.issueKey, origin: parsed.origin }
+  }
+
+  if (JIRA_ISSUE_KEY_PATTERN.test(trimmed)) {
+    return { clear: false, issueKey: trimmed.toUpperCase(), origin: null }
+  }
+
+  throw new RuntimeClientError(
+    'invalid_argument',
+    'Pass a Jira issue key like PROJ-123, a Jira issue URL, or null to clear.'
+  )
+}
+
+function getPresentStringFlag(
+  flags: Map<string, string | boolean>,
+  name: string
+): string | undefined {
+  if (!flags.has(name)) {
+    return undefined
+  }
+  const value = flags.get(name)
+  if (typeof value === 'string' && value.length > 0) {
+    return value
+  }
+  throw new RuntimeClientError('invalid_argument', `Missing value for --${name}`)
+}
+
+/**
+ * Turns `--jira` into the `linkedWorkItem` the workspace stores.
+ *
+ * The title and URL are not something the caller should have to type, so the
+ * key is resolved against the connected Jira site. Failing to resolve is a hard
+ * error rather than a partial link: a card showing a key with no title or URL
+ * is worse than no link at all, and the card renderer already expects both.
+ */
+export async function resolveJiraWorkItem(
+  input: ReturnType<typeof getOptionalJiraIssueLinkFlag>,
+  client: RuntimeClient
+): Promise<{ linkedWorkItem?: WorkspaceLinkedItem | null }> {
+  if (input === undefined) {
+    return {}
+  }
+  if (input.clear) {
+    return { linkedWorkItem: null }
+  }
+
+  const status = await client.call<{
+    connected: boolean
+    sites: JiraSite[]
+    activeSiteId: string | null
+  }>('jira.status', null)
+  const all = status.result?.sites ?? []
+  // A URL pins its own site; a bare key uses the active one.
+  const site = input.origin
+    ? all.find((candidate) => candidate.siteUrl.toLowerCase().startsWith(input.origin!))
+    : (all.find((candidate) => candidate.id === status.result?.activeSiteId) ?? all[0])
+  if (!site) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      input.origin
+        ? `No connected Jira site matches ${input.origin}. Connect it first, or pass a bare issue key to use the active site.`
+        : 'No Jira site is connected. Connect one in Settings before linking an issue.'
+    )
+  }
+
+  // The handler returns the issue itself, not a wrapper object.
+  const looked = await client.call<JiraIssue | null>('jira.lookupIssueSummary', {
+    key: input.issueKey,
+    siteId: site.id
+  })
+  const issue = looked.result
+  if (!issue) {
+    throw new RuntimeClientError('invalid_argument', `Jira issue ${input.issueKey} was not found.`)
+  }
+
+  return {
+    linkedWorkItem: {
+      provider: 'jira',
+      type: 'issue',
+      // Why: Jira keys are not numeric, so the shared numeric field carries no
+      // meaning here; the identifier is what the card renders.
+      number: 0,
+      title: issue.title,
+      url: issue.url,
+      jiraIdentifier: issue.key
+    }
+  }
+}

--- a/src/cli/handlers/worktree-jira-issue-link.ts
+++ b/src/cli/handlers/worktree-jira-issue-link.ts
@@ -1,11 +1,16 @@
-import { JIRA_ISSUE_KEY_PATTERN, parseJiraIssueUrl } from '../../shared/jira-issue-url'
+import {
+  getMatchingJiraSites,
+  JIRA_ISSUE_KEY_PATTERN,
+  parseJiraIssueUrl,
+  type ParsedJiraIssueUrl
+} from '../../shared/jira-issue-url'
 import { RuntimeClientError, type RuntimeClient } from '../runtime-client'
 import type { WorkspaceLinkedItem } from '../../shared/types'
 import type { JiraIssue, JiraSite } from '../../shared/jira-types'
 
 export type JiraIssueLinkInput =
   | { clear: true }
-  | { clear: false; issueKey: string; origin: string | null }
+  | { clear: false; issueKey: string; parsed: ParsedJiraIssueUrl | null }
 
 /**
  * Parses `--jira`, accepting a bare issue key (`PROJ-123`) or a full Jira issue
@@ -38,11 +43,11 @@ export function getOptionalJiraIssueLinkFlag(
 
   const parsed = parseJiraIssueUrl(trimmed)
   if (parsed) {
-    return { clear: false, issueKey: parsed.issueKey, origin: parsed.origin }
+    return { clear: false, issueKey: parsed.issueKey, parsed }
   }
 
   if (JIRA_ISSUE_KEY_PATTERN.test(trimmed)) {
-    return { clear: false, issueKey: trimmed.toUpperCase(), origin: null }
+    return { clear: false, issueKey: trimmed.toUpperCase(), parsed: null }
   }
 
   throw new RuntimeClientError(
@@ -90,15 +95,18 @@ export async function resolveJiraWorkItem(
     activeSiteId: string | null
   }>('jira.status', null)
   const all = status.result?.sites ?? []
-  // A URL pins its own site; a bare key uses the active one.
-  const site = input.origin
-    ? all.find((candidate) => candidate.siteUrl.toLowerCase().startsWith(input.origin!))
-    : (all.find((candidate) => candidate.id === status.result?.activeSiteId) ?? all[0])
+  // A URL pins its own site; a bare key uses the active one. Matching goes
+  // through the shared helper rather than a prefix test: origin has to be equal,
+  // not a prefix (a look-alike host would pass), and Jira Server instances can
+  // share a host while differing only in their path.
+  const site = input.parsed
+    ? getMatchingJiraSites(input.parsed, all)[0]
+    : resolveActiveJiraSite(all, status.result?.activeSiteId ?? null)
   if (!site) {
     throw new RuntimeClientError(
       'invalid_argument',
-      input.origin
-        ? `No connected Jira site matches ${input.origin}. Connect it first, or pass a bare issue key to use the active site.`
+      input.parsed
+        ? `No connected Jira site matches ${input.parsed.origin}. Connect it first, or pass a bare issue key to use the active site.`
         : 'No Jira site is connected. Connect one in Settings before linking an issue.'
     )
   }
@@ -125,4 +133,28 @@ export async function resolveJiraWorkItem(
       jiraIdentifier: issue.key
     }
   }
+}
+
+/**
+ * Picks the site a bare issue key resolves against.
+ *
+ * Falling back to the first site is only safe when it is the only one: with
+ * several connected, the same key can exist on more than one, and silently
+ * guessing would link the wrong ticket.
+ */
+function resolveActiveJiraSite(
+  sites: readonly JiraSite[],
+  activeSiteId: string | null
+): JiraSite | undefined {
+  const active = sites.find((candidate) => candidate.id === activeSiteId)
+  if (active) {
+    return active
+  }
+  if (sites.length > 1) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Several Jira sites are connected and none is active. Pass a full Jira issue URL so the site is unambiguous.'
+    )
+  }
+  return sites[0]
 }

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -33,6 +33,7 @@ import {
   resolveCreateParentSelector
 } from './worktree-create-parent-selector'
 import { getOptionalLinearIssueLinkFlag } from './worktree-linear-issue-link'
+import { getOptionalJiraIssueLinkFlag, resolveJiraWorkItem } from './worktree-jira-issue-link'
 
 type HookWarningResult = {
   warning?: string
@@ -264,11 +265,16 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue', {
       allowNull: true
     })
+    const jiraLink = await resolveJiraWorkItem(
+      getOptionalJiraIssueLinkFlag(flags, 'jira', { allowNull: true }),
+      client
+    )
     const result = await client.call<{ worktree: RuntimeWorktreeRecord }>('worktree.set', {
       worktree: await getRequiredWorktreeSelector(flags, 'worktree', cwd, client),
       displayName: getOptionalStringFlag(flags, 'display-name'),
       linkedIssue: getOptionalNullableNumberFlag(flags, 'issue'),
       ...linearIssueLink,
+      ...jiraLink,
       comment: getOptionalStringFlag(flags, 'comment'),
       workspaceStatus: getOptionalStringFlag(flags, 'workspace-status'),
       parentWorktree: await getOptionalWorktreeSelector(flags, 'parent-worktree', cwd, client),

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -510,6 +510,7 @@ export function formatFlagHelp(flag: string): string {
   const helpByFlag: Record<string, string> = {
     agent: '--agent <id>          Launch a known TUI agent in the first terminal',
     'base-branch': '--base-branch <ref>    Base branch/ref to create the worktree from',
+    jira: '--jira <key|url|null>   Link a Jira issue to the workspace; null clears it',
     command: '--command <text>       Command to run in the terminal on startup',
     comment: '--comment <text>       Comment stored in Orca metadata',
     cursor: '--cursor <n>           Line cursor from a previous read (returns only new output)',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -136,7 +136,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'set'],
     summary: 'Update Orca metadata for a worktree',
     usage:
-      'orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--linear-issue <identifier-or-url|null>] [--jira <key-url-or-null>] [--comment <text>] [--workspace-status <id>] [--parent-worktree <selector>|--no-parent] [--json]',
+      'orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--linear-issue <identifier-or-url|null>] [--jira <key|url|null>] [--comment <text>] [--workspace-status <id>] [--parent-worktree <selector>|--no-parent] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'worktree',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -136,19 +136,21 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'set'],
     summary: 'Update Orca metadata for a worktree',
     usage:
-      'orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--linear-issue <identifier-or-url|null>] [--comment <text>] [--workspace-status <id>] [--parent-worktree <selector>|--no-parent] [--json]',
+      'orca worktree set --worktree <selector> [--display-name <name>] [--issue <number|null>] [--linear-issue <identifier-or-url|null>] [--jira <key-url-or-null>] [--comment <text>] [--workspace-status <id>] [--parent-worktree <selector>|--no-parent] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'worktree',
       'display-name',
       'issue',
       'linear-issue',
+      'jira',
       'comment',
       'workspace-status',
       'parent-worktree',
       'no-parent'
     ],
     notes: [
+      'Use --jira with an issue key (PROJ-123) or a Jira issue URL to link the workspace to a ticket; the title and URL are resolved from the connected Jira site. Pass null to clear. The card shows it when the jira-issue card property is enabled.',
       'Workspace status ids match the board columns (defaults: todo, in-progress, in-review, completed); custom statuses use their configured id.',
       'Pass --linear-issue null to clear the Linear issue link.'
     ],


### PR DESCRIPTION
## The gap

Almost all of this already exists:

| Piece | Status |
|---|---|
| `WorkspaceLinkedItem` with `provider: 'jira'` and `jiraIdentifier` | ✅ |
| `getWorktreeCardJiraIssueDisplay` → clickable pill on the card | ✅ |
| `jira-issue` card property | ✅ |
| `worktree.set` RPC accepting `linkedWorkItem` | ✅ |
| **A way to set it on a workspace that already exists** | ❌ |

Today the link is only created when the workspace is born from **Tasks → Jira**. If your workspaces come from `worktree create` — scripted flows especially — there is no way to attach the ticket afterwards, even though the model and the renderer are both ready for it.

## The change

```bash
orca worktree set --worktree <sel> --jira PROJ-123
orca worktree set --worktree <sel> --jira https://acme.atlassian.net/browse/PROJ-123
orca worktree set --worktree <sel> --jira null      # clears it
```

Title and URL are **resolved from the connected Jira site**, not typed by the caller. A card showing a key with no title and a dead URL is worse than no link at all, and `getWorktreeCardJiraIssueDisplay` expects both — so a failed lookup is a hard error rather than a partial link.

A bare key resolves against the **active** site; a URL **pins** the site it came from, which matters when several Jira sites are connected and the same key exists on more than one.

Shaped after `--linear-issue`, which solves the same problem for Linear.

## Relationship to #10905

[#10905](https://github.com/stablyai/orca/issues/10905) asks for this link from the **Create Worktree composer**. This is the CLI half; the composer is untouched. I'm happy to follow up with it, or for someone to build it on top — the resolution logic lives in `worktree-jira-issue-link.ts` and is reusable as-is.

## Verification

Tested end-to-end against a real Jira Cloud site: linking by key and by URL, clearing with `null`, and a non-existent key (which surfaces Jira's own message rather than a generic one). The card renders the ticket once `jira-issue` is enabled as a card property.

```
✓ src/cli/  55 files  719 tests
✓ tsc -p config/tsconfig.node.json
✓ tsc -p config/tsconfig.tc.cli.json
✓ oxlint
```

Parser tests cover: bare key, lowercase key, full URL, `null` to clear, `null` rejected where clearing makes no sense, non-issue Jira URLs, and a flag passed with no value.

## Code review summary

- **Cross-platform:** none. Flag parsing plus two RPC calls; no paths, no shell, no platform branches.
- **SSH / remote / local:** unaffected. Both calls go through the runtime client like every other CLI command, and Jira credentials are already runtime-side — nothing here assumes a local process or file.
- **Agents / integrations / providers:** additive and provider-scoped. `--jira` writes the same `linkedWorkItem` the Tasks → Jira flow writes; GitHub/GitLab/Linear links are untouched, and the flag is rejected on `worktree create` where clearing has no meaning.
- **Performance:** two extra requests, only when `--jira` is passed. Nothing added to any hot path.
- **UI:** **no visual change of its own** — it populates data the card already knows how to render. Users who never pass `--jira` see nothing different.
- **Security:** no new credential path; site resolution and lookup both go through the existing Jira client. A URL cannot point the lookup at an unconnected site — it only selects among already-connected ones, and errors otherwise.

## Notes

No platform-, remote- or agent-specific behavior. One deliberate choice worth flagging: `number` is set to `0`, since Jira keys are not numeric and the card renders `jiraIdentifier`. That mirrors what the existing Jira-linked workspaces already store.

X: [@EugenioValeiras](https://x.com/EugenioValeiras)