### PR TITLE
[P0] fix(relay): stop the retired exit record from double-broadcasting pty.exit

### DIFF
--- a/src/relay/pty-handler-source-publication.test.ts
+++ b/src/relay/pty-handler-source-publication.test.ts
@@ -347,6 +347,64 @@ describe('PtyHandler negotiated source publication', () => {
     }
   })
 
+  it('retires the delivery after the owner exit publication throws', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    const id = String(spawnResult.id)
+    const subscriberWrites = attachSubscriber()
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const publishOwnerExit = vi
+      .spyOn(dispatcher, 'tryNotifyPtyExitToClient')
+      .mockImplementationOnce(() => {
+        throw new Error('owner write failed')
+      })
+    try {
+      expect(() => exitCallback!({ exitCode: 8 })).not.toThrow()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(exitFrames()).toHaveLength(1)
+      expect(subscriberExitFrames(subscriberWrites)).toHaveLength(1)
+      expect(publication.accepts(id)).toBe(false)
+      expect(adapter.getDebugSnapshot().deliveryTokens).toBe(0)
+
+      handler.handleSourcePublicationCapacity(id)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(exitFrames()).toHaveLength(1)
+      expect(subscriberExitFrames(subscriberWrites)).toHaveLength(1)
+    } finally {
+      publishOwnerExit.mockRestore()
+      stderr.mockRestore()
+    }
+  })
+
+  it('retires the delivery when committed owner exit settlement fails', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    const id = String(spawnResult.id)
+    const subscriberWrites = attachSubscriber()
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    const settleOwnerExit = vi.spyOn(adapter, 'settleExitPublication').mockImplementation(() => {
+      throw new Error('exit settlement failed')
+    })
+    try {
+      exitCallback!({ exitCode: 9 })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(exitFrames()).toHaveLength(1)
+      expect(subscriberExitFrames(subscriberWrites)).toHaveLength(1)
+      expect(publication.accepts(id)).toBe(false)
+      expect(adapter.getDebugSnapshot().deliveryTokens).toBe(0)
+
+      handler.handleSourcePublicationCapacity(id)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(exitFrames()).toHaveLength(1)
+      expect(subscriberExitFrames(subscriberWrites)).toHaveLength(1)
+    } finally {
+      settleOwnerExit.mockRestore()
+      stderr.mockRestore()
+    }
+  })
+
   it('lets a retired record re-target its own exit instead of broadcasting a duplicate', async () => {
     await spawn({})
     const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!

--- a/src/relay/pty-handler-source-publication.test.ts
+++ b/src/relay/pty-handler-source-publication.test.ts
@@ -60,6 +60,8 @@ describe('PtyHandler negotiated source publication', () => {
   let destroyPty: ReturnType<typeof vi.fn>
   let holdDataSettlements: boolean
   let heldDataSettlements: ((result: SinkWriteSettlement) => void)[]
+  let holdExitSettlements: boolean
+  let heldExitSettlements: ((result: SinkWriteSettlement) => void)[]
   let highWaterMark: number | undefined
 
   beforeEach(async () => {
@@ -72,6 +74,8 @@ describe('PtyHandler negotiated source publication', () => {
     exitCallback = undefined
     holdDataSettlements = false
     heldDataSettlements = []
+    holdExitSettlements = false
+    heldExitSettlements = []
     highWaterMark = undefined
     pausePty = vi.fn()
     destroyPty = vi.fn()
@@ -105,6 +109,10 @@ describe('PtyHandler negotiated source publication', () => {
           return true
         }
         if (frame?.method === 'pty.exit') {
+          if (holdExitSettlements) {
+            heldExitSettlements.push(settle)
+            return true
+          }
           // Why: real sockets never settle inside write(); a synchronous settle would re-enter
           // the legacy capacity path before the pending exit is retired.
           queueMicrotask(() => settle({ ok: true }))
@@ -211,6 +219,74 @@ describe('PtyHandler negotiated source publication', () => {
     handler.handleSourcePublicationCapacity(String(spawnResult.id))
     await vi.advanceTimersByTimeAsync(8)
     expect(exitFrames()).toHaveLength(1)
+  })
+
+  function attachSubscriber(): Buffer[] {
+    const subscriberWrites: Buffer[] = []
+    dispatcher.attachClient(
+      (data, settle) => {
+        subscriberWrites.push(Buffer.from(data))
+        if (notification(data)?.method === 'pty.exit') {
+          // Why: real sockets never settle inside write(); see the primary sink above.
+          queueMicrotask(() => settle({ ok: true }))
+          return true
+        }
+        settle({ ok: true })
+        return true
+      },
+      { supportsWriteCallback: true }
+    )
+    return subscriberWrites
+  }
+
+  function subscriberExitFrames(subscriberWrites: Buffer[]): Notification[] {
+    return subscriberWrites
+      .map(notification)
+      .filter((frame): frame is Notification => frame?.method === 'pty.exit')
+  }
+
+  it('never re-delivers the exit to subscribers when a cancel retires the record', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    const subscriberWrites = attachSubscriber()
+    dataCallback!('prompt')
+    await vi.advanceTimersByTimeAsync(8)
+
+    // Why: the owner's producer lane is saturated when the PTY exits, so only the legacy
+    // projection lands; the record then still holds the undelivered owner exit.
+    highWaterMark = 64
+    expect(() => exitCallback!({ exitCode: 0 })).not.toThrow()
+    await vi.advanceTimersByTimeAsync(8)
+    expect(subscriberExitFrames(subscriberWrites)).toHaveLength(1)
+
+    highWaterMark = undefined
+    await cancelSourceDelivery(spawnResult)
+    await vi.advanceTimersByTimeAsync(8)
+
+    expect(subscriberExitFrames(subscriberWrites)).toHaveLength(1)
+  })
+
+  it('drains the pending exit once the retired record published it', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    dataCallback!('prompt')
+    await vi.advanceTimersByTimeAsync(8)
+    holdExitSettlements = true
+
+    exitCallback!({ exitCode: 0 })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(heldExitSettlements).toHaveLength(1)
+    await cancelSourceDelivery(spawnResult)
+    // Why: the in-flight frame failing on a canceled delivery is the only path that reaches
+    // the retiring branch with an unsettled exit publication.
+    heldExitSettlements[0]({ ok: false, error: new Error('socket write failed') })
+    await vi.advanceTimersByTimeAsync(8)
+    expect(exitFrames()).toHaveLength(2)
+
+    handler.handleSourcePublicationCapacity(String(spawnResult.id))
+    await vi.advanceTimersByTimeAsync(8)
+
+    expect(exitFrames()).toHaveLength(2)
   })
 
   it('drains buffered legacy output before the exit when capacity returns', async () => {

--- a/src/relay/pty-handler-source-publication.test.ts
+++ b/src/relay/pty-handler-source-publication.test.ts
@@ -380,6 +380,32 @@ describe('PtyHandler negotiated source publication', () => {
     expect(exitFrames()[0].params).toMatchObject({ id: spawnResult.id, code: 5 })
   })
 
+  it('contains a retired-record publication fault and falls back to the legacy exit', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    try {
+      handler.setSourcePublication(
+        stubPublication({
+          accepts: () => false,
+          publishExitAfterRetire: () => {
+            throw new Error('retired owner lookup failed')
+          }
+        })
+      )
+
+      expect(() => exitCallback!({ exitCode: 6 })).not.toThrow()
+
+      expect(exitFrames()).toHaveLength(1)
+      expect(exitFrames()[0].params).toMatchObject({ id: spawnResult.id, code: 6 })
+      expect(String(stderr.mock.calls.at(-1)?.[0])).toContain(
+        '[pty-handler] retired pty exit publication failed'
+      )
+    } finally {
+      stderr.mockRestore()
+    }
+  })
+
   it('completes the exit from the settled state without re-sealing the delivery', async () => {
     await spawn({})
     const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!

--- a/src/relay/pty-handler-source-publication.test.ts
+++ b/src/relay/pty-handler-source-publication.test.ts
@@ -347,6 +347,39 @@ describe('PtyHandler negotiated source publication', () => {
     }
   })
 
+  it('lets a retired record re-target its own exit instead of broadcasting a duplicate', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    const subscriberWrites = attachSubscriber()
+    const publishExitAfterRetire = vi.fn(() => true)
+    handler.setSourcePublication(stubPublication({ accepts: () => false, publishExitAfterRetire }))
+
+    expect(() => exitCallback!({ exitCode: 4 })).not.toThrow()
+
+    expect(publishExitAfterRetire).toHaveBeenCalledWith(
+      expect.objectContaining({ id: spawnResult.id, code: 4 })
+    )
+    expect(exitFrames()).toHaveLength(0)
+    expect(subscriberExitFrames(subscriberWrites)).toHaveLength(0)
+
+    handler.handleSourcePublicationCapacity(String(spawnResult.id))
+    await vi.advanceTimersByTimeAsync(8)
+    expect(publishExitAfterRetire).toHaveBeenCalledOnce()
+  })
+
+  it('broadcasts the legacy exit when the retired record never projected one', async () => {
+    await spawn({})
+    const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!
+    handler.setSourcePublication(
+      stubPublication({ accepts: () => false, publishExitAfterRetire: () => null })
+    )
+
+    exitCallback!({ exitCode: 5 })
+
+    expect(exitFrames()).toHaveLength(1)
+    expect(exitFrames()[0].params).toMatchObject({ id: spawnResult.id, code: 5 })
+  })
+
   it('completes the exit from the settled state without re-sealing the delivery', async () => {
     await spawn({})
     const spawnResult = writes.map((buffer) => responseResult(buffer, 2)).find(Boolean)!

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1060,8 +1060,18 @@ export class PtyHandler {
     }
     // Why: a retired record can already have projected this exit to the legacy subscribers, and
     // the broadcast below would hand them a second copy.
+    let retiredExitPublished: boolean | null | undefined
+    try {
+      retiredExitPublished = this.sourcePublication?.publishExitAfterRetire?.(exit)
+    } catch (err) {
+      process.stderr.write(
+        `[pty-handler] retired pty exit publication failed for ${id}: ${
+          err instanceof Error ? (err.stack ?? err.message) : String(err)
+        }\n`
+      )
+    }
     const published =
-      this.sourcePublication?.publishExitAfterRetire?.(exit) ??
+      retiredExitPublished ??
       (this.dispatcher.tryNotifyPtyExit
         ? this.dispatcher.tryNotifyPtyExit(exit)
         : (this.dispatcher.notify('pty.exit', exit), true))

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1058,9 +1058,13 @@ export class PtyHandler {
         )
       }
     }
-    const published = this.dispatcher.tryNotifyPtyExit
-      ? this.dispatcher.tryNotifyPtyExit(exit)
-      : (this.dispatcher.notify('pty.exit', exit), true)
+    // Why: a retired record can already have projected this exit to the legacy subscribers, and
+    // the broadcast below would hand them a second copy.
+    const published =
+      this.sourcePublication?.publishExitAfterRetire?.(exit) ??
+      (this.dispatcher.tryNotifyPtyExit
+        ? this.dispatcher.tryNotifyPtyExit(exit)
+        : (this.dispatcher.notify('pty.exit', exit), true))
     if (!published) {
       return
     }

--- a/src/relay/relay-pty-source-cancellation-exit.test.ts
+++ b/src/relay/relay-pty-source-cancellation-exit.test.ts
@@ -364,4 +364,31 @@ describe('RelayPtySourcePublication cancellation and exit', () => {
     ).not.toThrow()
     expect(exitFrames(harness.writes)).toHaveLength(1)
   })
+
+  it('forgets the legacy exit projection once the healthy exit settles', async () => {
+    const harness = await createHarness()
+    const exit = { id: 'pty-1', code: 0, incarnationId: 'incarnation-1' }
+    expect(harness.publication.sealAndPublishExit(exit)).toBe(true)
+
+    expect(harness.publication.exitPublicationSettled('pty-1')).toBe(true)
+
+    // Why: every client already holds this exit, so a retained index entry would both leak a row
+    // per exited pty and re-publish to the owner if any later fallback ran for the same id.
+    expect(harness.publication.publishExitAfterRetire(exit)).toBeNull()
+    expect(exitFrames(harness.writes)).toHaveLength(1)
+  })
+
+  it('re-targets the owner when a re-attach retires a record that already projected the exit', async () => {
+    const harness = await createHarness()
+    const exit = { id: 'pty-1', code: 0, incarnationId: 'incarnation-1' }
+    expect(harness.publication.sealAndPublishExit(exit)).toBe(true)
+
+    // Why: the handler holds its settled-check back while legacy output is still buffered, so B2
+    // can retire the record first — the index is then all that remembers the projection.
+    activateOwner(harness.publication)
+
+    expect(harness.publication.publishExitAfterRetire(exit)).toBe(true)
+    expect(exitFrames(harness.writes)).toHaveLength(2)
+    expect(harness.publication.publishExitAfterRetire(exit)).toBeNull()
+  })
 })

--- a/src/relay/relay-pty-source-cancellation-exit.test.ts
+++ b/src/relay/relay-pty-source-cancellation-exit.test.ts
@@ -77,9 +77,12 @@ describe('RelayPtySourcePublication cancellation and exit', () => {
       endpointIdentity
     )
     let publication: RelayPtySourcePublication
-    const adapter = new SshPtyConsumerSessionAdapter(dispatcher, 'build-a', undefined, (id) =>
-      publication.onCreditAvailable(id)
-    )
+    let creditNoticeEnabled = true
+    const adapter = new SshPtyConsumerSessionAdapter(dispatcher, 'build-a', undefined, (id) => {
+      if (creditNoticeEnabled) {
+        publication.onCreditAvailable(id)
+      }
+    })
     publication = new RelayPtySourcePublication(dispatcher, adapter, (id) => capacityIds.push(id))
     dispatcher.feed(
       requestFrame(1, 'pty.openClient', {
@@ -100,7 +103,29 @@ describe('RelayPtySourcePublication cancellation and exit', () => {
       })
     ).toBe('opened')
     activationSettlements[0]({ ok: true })
-    return { adapter, publication, exitSettlements, capacityIds, writes }
+    return {
+      adapter,
+      publication,
+      exitSettlements,
+      capacityIds,
+      writes,
+      setCreditNoticeEnabled: (enabled: boolean): void => {
+        creditNoticeEnabled = enabled
+      }
+    }
+  }
+
+  function activateOwner(publication: RelayPtySourcePublication): void {
+    const settlements: ((result: SinkWriteSettlement) => void)[] = []
+    expect(
+      publication.activate('pty-1', 'incarnation-1', {
+        clientId: 1,
+        isStale: () => false,
+        sessionIdentity: endpointIdentity,
+        onResponseSettled: (callback) => settlements.push(callback)
+      })
+    ).toBe('opened')
+    settlements[0]({ ok: true })
   }
 
   function cancelDeliveryFrame(
@@ -200,16 +225,7 @@ describe('RelayPtySourcePublication cancellation and exit', () => {
     dispatcher!.feed(cancelDeliveryFrame(2, activation))
     await flushRequests()
 
-    const activationSettlements: ((result: SinkWriteSettlement) => void)[] = []
-    expect(
-      harness.publication.activate('pty-1', 'incarnation-1', {
-        clientId: 1,
-        isStale: () => false,
-        sessionIdentity: endpointIdentity,
-        onResponseSettled: (callback) => activationSettlements.push(callback)
-      })
-    ).toBe('opened')
-    activationSettlements[0]({ ok: true })
+    activateOwner(harness.publication)
 
     expect(
       harness.publication.sealAndPublishExit({
@@ -219,6 +235,46 @@ describe('RelayPtySourcePublication cancellation and exit', () => {
       })
     ).toBe(true)
     expect(exitFrames(harness.writes)).toHaveLength(1)
+  })
+
+  it('reopens the delivery when the same client re-attaches over a closed ledger record', async () => {
+    const harness = await createHarness(8, true)
+    harness.publication.publish('pty-1', { data: 'data' }, false)
+    const activation = harness.publication.receivingActivation('pty-1', 1)!
+    dispatcher!.feed(ackFrame(2, activation, 4))
+    harness.publication.sealAndPublishExit({ id: 'pty-1', code: 0, incarnationId: 'incarnation-1' })
+    dispatcher!.feed(cancelDeliveryFrame(3, activation))
+    await flushRequests()
+    harness.exitSettlements[0]({ ok: true })
+    // Why: A' held the record across the in-flight frame, so it outlives the closed ledger until
+    // a capacity consumer prunes it — a re-attach must not resume that dead delivery.
+    expect(harness.publication.accepts('pty-1')).toBe(true)
+
+    activateOwner(harness.publication)
+
+    expect(harness.publication.publish('pty-1', { data: 'more' }, false)).toBe(true)
+  })
+
+  it('retires the record and defers capacity when an append lands on a closed delivery', async () => {
+    const harness = await createHarness()
+    harness.publication.publish('pty-1', { data: 'data' }, false)
+    const activation = harness.publication.receivingActivation('pty-1', 1)!
+    // Why: emulate a close the publication never saw — B3 backstops exactly the record/ledger
+    // disagreement that layer A's credit notification normally prevents.
+    harness.setCreditNoticeEnabled(false)
+    dispatcher!.feed(cancelDeliveryFrame(2, activation))
+    await flushRequests()
+    expect(harness.publication.accepts('pty-1')).toBe(true)
+    const capacityBefore = harness.capacityIds.length
+
+    expect(harness.publication.publish('pty-1', { data: 'more' }, false)).toBe(false)
+
+    expect(harness.publication.accepts('pty-1')).toBe(false)
+    // Why: publish() can run inside the captured-queue drain, so a synchronous capacity callback
+    // would publish pty.exit ahead of the chunk that is re-queued later in this same tick.
+    expect(harness.capacityIds).toHaveLength(capacityBefore)
+    await Promise.resolve()
+    expect(harness.capacityIds.slice(capacityBefore)).toEqual(['pty-1'])
   })
 
   it('survives a cancel while the credit-mode exit frame is still in flight', async () => {
@@ -275,6 +331,9 @@ describe('RelayPtySourcePublication cancellation and exit', () => {
       })
     ).toBe(true)
     expect(harness.publication.accepts('pty-1')).toBe(false)
+    // Why: the failed write closed the owner socket, so B1's owner-targeted retry matches no
+    // client — it must still retire the record rather than fan the exit out to everyone else.
+    expect(exitFrames(harness.writes)).toHaveLength(1)
     expect(harness.publication.getDebugSnapshot()).toMatchObject({
       exitCommitted: 0,
       exitRolledBack: 1

--- a/src/relay/relay-pty-source-exit-publication.test.ts
+++ b/src/relay/relay-pty-source-exit-publication.test.ts
@@ -4,7 +4,10 @@ import type {
   PtySourceDeliverySnapshot
 } from '../shared/pty-source-credit-contract'
 import type { RelayDispatcher } from './dispatcher'
-import { sealAndPublishPtySourceExit } from './relay-pty-source-exit-publication'
+import {
+  RelayPtySourceLegacyExitIndex,
+  sealAndPublishPtySourceExit
+} from './relay-pty-source-exit-publication'
 import type {
   RelayPtySourceDeliveryRecord,
   RelayPtySourcePublicationCounters,
@@ -197,6 +200,80 @@ describe('sealAndPublishPtySourceExit closed-delivery guard', () => {
     expect(scenario.session.sourceDeliverySnapshotIfKnown).not.toHaveBeenCalled()
     expect(scenario.dispatcher.tryNotifyPtyExit).not.toHaveBeenCalled()
     expect(scenario.deliveries.get('pty-1')).toBe(record)
+  })
+})
+
+describe('RelayPtySourceLegacyExitIndex', () => {
+  function createIndex(notifyAccepted = true) {
+    const index = new RelayPtySourceLegacyExitIndex()
+    const dispatcher = {
+      tryNotifyPtyExitToMatchingClients: vi.fn(
+        (_matches: (clientId: number) => boolean, _params: unknown) => notifyAccepted
+      )
+    }
+    const session = { deliveryMode: vi.fn(() => 'source-owner' as const) }
+    const publish = (): boolean | null =>
+      index.publishAfterRetire(
+        params,
+        dispatcher as unknown as RelayDispatcher,
+        session as unknown as SshPtyConsumerSessionAdapter
+      )
+    return { index, dispatcher, session, publish }
+  }
+
+  it('defers to the caller when nothing was projected for the pty', () => {
+    const scenario = createIndex()
+
+    expect(scenario.publish()).toBeNull()
+
+    expect(scenario.dispatcher.tryNotifyPtyExitToMatchingClients).not.toHaveBeenCalled()
+  })
+
+  it('re-targets the owner exactly once for a remembered projection', () => {
+    const scenario = createIndex()
+    scenario.index.remember(params, true)
+
+    expect(scenario.publish()).toBe(true)
+
+    const matches = scenario.dispatcher.tryNotifyPtyExitToMatchingClients.mock.calls[0][0]
+    expect(matches(1)).toBe(true)
+    scenario.session.deliveryMode.mockReturnValue('legacy-owner' as never)
+    expect(matches(1)).toBe(false)
+    // Why: the second pass is the handler's retry after a later capacity event; re-publishing
+    // would hand the owner a duplicate exit.
+    expect(scenario.publish()).toBeNull()
+  })
+
+  it('keeps the projection retryable when the owner notify is refused', () => {
+    const scenario = createIndex(false)
+    scenario.index.remember(params, true)
+
+    expect(scenario.publish()).toBe(false)
+    expect(scenario.publish()).toBe(false)
+  })
+
+  it.each([
+    [
+      'a later incarnation reused the pty id',
+      (index: RelayPtySourceLegacyExitIndex) =>
+        index.remember({ ...params, incarnationId: 'incarnation-2' }, true)
+    ],
+    [
+      'the projection was withdrawn',
+      (index: RelayPtySourceLegacyExitIndex) => index.remember(params, false)
+    ],
+    [
+      'the exit completed for every client',
+      (index: RelayPtySourceLegacyExitIndex) => index.forget(params.id)
+    ],
+    ['the publication was disposed', (index: RelayPtySourceLegacyExitIndex) => index.clear()]
+  ])('defers to the caller once %s', (_label, mutate) => {
+    const scenario = createIndex()
+    scenario.index.remember(params, true)
+
+    mutate(scenario.index)
+
+    expect(scenario.publish()).toBeNull()
   })
 })
 

--- a/src/relay/relay-pty-source-exit-publication.test.ts
+++ b/src/relay/relay-pty-source-exit-publication.test.ts
@@ -6,7 +6,8 @@ import type {
 import type { RelayDispatcher } from './dispatcher'
 import {
   RelayPtySourceLegacyExitIndex,
-  sealAndPublishPtySourceExit
+  sealAndPublishPtySourceExit,
+  sealAndPublishTrackedPtySourceExit
 } from './relay-pty-source-exit-publication'
 import type {
   RelayPtySourceDeliveryRecord,
@@ -129,7 +130,28 @@ function createScenario(
       counters,
       onCapacity: (id) => capacityIds.push(id)
     })
-  return { deliveries, session, dispatcher, sender, counters, capacityIds, run, setProbe }
+  const runTracked = (legacyExits: RelayPtySourceLegacyExitIndex): boolean =>
+    sealAndPublishTrackedPtySourceExit({
+      params,
+      legacyExits,
+      deliveries,
+      dispatcher: dispatcher as unknown as RelayDispatcher,
+      session: session as unknown as SshPtyConsumerSessionAdapter,
+      sender: sender as unknown as RelayPtySourceSendScheduler,
+      counters,
+      onCapacity: (id) => capacityIds.push(id)
+    })
+  return {
+    deliveries,
+    session,
+    dispatcher,
+    sender,
+    counters,
+    capacityIds,
+    run,
+    runTracked,
+    setProbe
+  }
 }
 
 describe('sealAndPublishPtySourceExit closed-delivery guard', () => {
@@ -250,6 +272,33 @@ describe('RelayPtySourceLegacyExitIndex', () => {
 
     expect(scenario.publish()).toBe(false)
     expect(scenario.publish()).toBe(false)
+  })
+
+  it('remembers a subscriber projection when the owner publication throws', () => {
+    const record = deliveryRecord({ sealed: true })
+    const scenario = createScenario(closedSnapshot({ state: 'sealed-unsettled' }), record)
+    const index = new RelayPtySourceLegacyExitIndex()
+    scenario.dispatcher.tryNotifyPtyExitToClient.mockImplementation(() => {
+      throw new Error('owner write failed')
+    })
+
+    expect(() => scenario.runTracked(index)).toThrow('owner write failed')
+    expect(scenario.dispatcher.projectPtyExitToMatchingClients).toHaveBeenCalledOnce()
+    expect(
+      index.publishAfterRetire(
+        params,
+        scenario.dispatcher as unknown as RelayDispatcher,
+        scenario.session as unknown as SshPtyConsumerSessionAdapter
+      )
+    ).toBe(true)
+    expect(scenario.dispatcher.tryNotifyPtyExit).not.toHaveBeenCalled()
+    expect(
+      index.publishAfterRetire(
+        params,
+        scenario.dispatcher as unknown as RelayDispatcher,
+        scenario.session as unknown as SshPtyConsumerSessionAdapter
+      )
+    ).toBeNull()
   })
 
   it.each([

--- a/src/relay/relay-pty-source-exit-publication.test.ts
+++ b/src/relay/relay-pty-source-exit-publication.test.ts
@@ -96,6 +96,7 @@ function createScenario(
       }
       return probe
     }),
+    cancelDelivery: vi.fn(),
     sealDelivery: vi.fn(),
     settleExitPublication: vi.fn(),
     deliveryMode: vi.fn(() => 'source-owner' as const)
@@ -108,7 +109,7 @@ function createScenario(
     projectPtyExitToMatchingClients: vi.fn(() => true),
     tryNotifyPtyExitToClient: vi.fn(() => true)
   }
-  const sender = { pump: vi.fn() }
+  const sender = { pump: vi.fn(), wakeSendWaiters: vi.fn() }
   const counters: RelayPtySourcePublicationCounters = {
     opened: 0,
     rotated: 0,
@@ -119,6 +120,13 @@ function createScenario(
     exitRolledBack: 0
   }
   const capacityIds: string[] = []
+  let capacityError: Error | null = null
+  const onCapacity = (id: string): void => {
+    capacityIds.push(id)
+    if (capacityError) {
+      throw capacityError
+    }
+  }
   const run = (): boolean =>
     sealAndPublishPtySourceExit({
       params,
@@ -128,7 +136,7 @@ function createScenario(
       session: session as unknown as SshPtyConsumerSessionAdapter,
       sender: sender as unknown as RelayPtySourceSendScheduler,
       counters,
-      onCapacity: (id) => capacityIds.push(id)
+      onCapacity
     })
   const runTracked = (legacyExits: RelayPtySourceLegacyExitIndex): boolean =>
     sealAndPublishTrackedPtySourceExit({
@@ -139,7 +147,7 @@ function createScenario(
       session: session as unknown as SshPtyConsumerSessionAdapter,
       sender: sender as unknown as RelayPtySourceSendScheduler,
       counters,
-      onCapacity: (id) => capacityIds.push(id)
+      onCapacity
     })
   return {
     deliveries,
@@ -150,7 +158,10 @@ function createScenario(
     capacityIds,
     run,
     runTracked,
-    setProbe
+    setProbe,
+    setCapacityError: (error: Error): void => {
+      capacityError = error
+    }
   }
 }
 
@@ -274,6 +285,33 @@ describe('RelayPtySourceLegacyExitIndex', () => {
     expect(scenario.publish()).toBe(false)
   })
 
+  it('consumes a completed retired exit without publishing it again', () => {
+    const scenario = createIndex()
+    scenario.index.remember(params, true)
+    scenario.index.complete(params)
+
+    expect(scenario.publish()).toBe(true)
+    expect(scenario.dispatcher.tryNotifyPtyExitToMatchingClients).not.toHaveBeenCalled()
+    expect(scenario.publish()).toBeNull()
+  })
+
+  it('does not let stale completion overwrite a later incarnation', () => {
+    const scenario = createIndex()
+    const next = { ...params, incarnationId: 'incarnation-2' }
+    scenario.index.remember(next, true)
+
+    scenario.index.complete(params)
+
+    expect(scenario.publish()).toBeNull()
+    expect(
+      scenario.index.publishAfterRetire(
+        next,
+        scenario.dispatcher as unknown as RelayDispatcher,
+        scenario.session as unknown as SshPtyConsumerSessionAdapter
+      )
+    ).toBe(true)
+  })
+
   it('remembers a subscriber projection when the owner publication throws', () => {
     const record = deliveryRecord({ sealed: true })
     const scenario = createScenario(closedSnapshot({ state: 'sealed-unsettled' }), record)
@@ -284,6 +322,11 @@ describe('RelayPtySourceLegacyExitIndex', () => {
 
     expect(() => scenario.runTracked(index)).toThrow('owner write failed')
     expect(scenario.dispatcher.projectPtyExitToMatchingClients).toHaveBeenCalledOnce()
+    expect(scenario.session.cancelDelivery).toHaveBeenCalledWith(
+      record.identity,
+      'exit-publication-failed'
+    )
+    expect(scenario.deliveries.has(params.id)).toBe(false)
     expect(
       index.publishAfterRetire(
         params,
@@ -362,6 +405,44 @@ describe('sealAndPublishPtySourceExit settlement closure', () => {
     expect(scenario.capacityIds).toEqual(['pty-1'])
   })
 
+  it('retains committed completion until a failed capacity signal is retried', () => {
+    const record = deliveryRecord({ sealed: true })
+    const scenario = createScenario(closedSnapshot({ state: 'sealed-unsettled' }), record)
+    const index = new RelayPtySourceLegacyExitIndex()
+    let settle: ((result: { ok: true }) => void) | undefined
+    scenario.dispatcher.tryNotifyPtyExitToClient.mockImplementation((...args: unknown[]) => {
+      settle = args[2] as typeof settle
+      return true
+    })
+    scenario.session.settleExitPublication.mockImplementation(() => {
+      throw new Error('PTY source delivery is not sealed')
+    })
+    scenario.setCapacityError(new Error('capacity callback failed'))
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
+    try {
+      expect(scenario.runTracked(index)).toBe(true)
+      expect(() => settle!({ ok: true })).not.toThrow()
+
+      expect(
+        index.publishAfterRetire(
+          params,
+          scenario.dispatcher as unknown as RelayDispatcher,
+          scenario.session as unknown as SshPtyConsumerSessionAdapter
+        )
+      ).toBe(true)
+      expect(scenario.dispatcher.tryNotifyPtyExitToMatchingClients).not.toHaveBeenCalled()
+      expect(
+        index.publishAfterRetire(
+          params,
+          scenario.dispatcher as unknown as RelayDispatcher,
+          scenario.session as unknown as SshPtyConsumerSessionAdapter
+        )
+      ).toBeNull()
+    } finally {
+      stderr.mockRestore()
+    }
+  })
+
   it.each([
     ['committed', { ok: true } as const],
     ['rolled back', { ok: false, error: new Error('socket write failed') } as const]
@@ -369,9 +450,14 @@ describe('sealAndPublishPtySourceExit settlement closure', () => {
     const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true)
     try {
       const scenario = createInFlightScenario(closedSnapshot({ state: 'sealed-unsettled' }))
+      scenario.record.sendWaiters.add(vi.fn())
       scenario.session.settleExitPublication.mockImplementation(() => {
         throw new Error('PTY source delivery is not sealed')
       })
+      scenario.sender.wakeSendWaiters.mockImplementation(() => {
+        throw new Error('send waiter failed')
+      })
+      scenario.setCapacityError(new Error('capacity callback failed'))
 
       expect(() => scenario.settle(result)).not.toThrow()
 
@@ -379,6 +465,12 @@ describe('sealAndPublishPtySourceExit settlement closure', () => {
         '[pty-source-exit] exit settlement failed for pty-1'
       )
       expect(scenario.capacityIds).toEqual(['pty-1'])
+      expect(scenario.session.cancelDelivery).toHaveBeenCalledWith(
+        scenario.record.identity,
+        'exit-publication-failed'
+      )
+      expect(scenario.deliveries.has(params.id)).toBe(false)
+      expect(scenario.record.sendWaiters.size).toBe(0)
     } finally {
       stderr.mockRestore()
     }

--- a/src/relay/relay-pty-source-exit-publication.ts
+++ b/src/relay/relay-pty-source-exit-publication.ts
@@ -13,6 +13,7 @@ type PtySourceExitOptions = {
   params: PtyExitParams
   record: RelayPtySourceDeliveryRecord
   deliveries: Map<string, RelayPtySourceDeliveryRecord>
+  legacyExits?: RelayPtySourceLegacyExitIndex
   dispatcher: RelayDispatcher
   session: SshPtyConsumerSessionAdapter
   sender: RelayPtySourceSendScheduler
@@ -26,22 +27,35 @@ type PtySourceExitOptions = {
  * projection and the owner's exit frame, and the fallback must not broadcast a second copy.
  */
 export class RelayPtySourceLegacyExitIndex {
-  private readonly incarnationByPty = new Map<string, string>()
+  private readonly stateByPty = new Map<
+    string,
+    Readonly<{ incarnationId: string; state: 'owner-pending' | 'complete' }>
+  >()
 
   remember(params: PtyExitParams, delivered: boolean): void {
     if (delivered) {
-      this.incarnationByPty.set(params.id, params.incarnationId)
+      this.stateByPty.set(params.id, {
+        incarnationId: params.incarnationId,
+        state: 'owner-pending'
+      })
     } else {
       this.forget(params.id)
     }
   }
 
-  /** Drops the entry once the exit is complete for every client, so the map cannot grow unbounded. */
-  forget(id: string): void {
-    this.incarnationByPty.delete(id)
+  complete(params: PtyExitParams): void {
+    if (this.stateByPty.get(params.id)?.incarnationId !== params.incarnationId) {
+      return
+    }
+    this.stateByPty.set(params.id, { incarnationId: params.incarnationId, state: 'complete' })
   }
 
-  clear = (): void => this.incarnationByPty.clear()
+  /** Drops the entry once the exit is complete for every client, so the map cannot grow unbounded. */
+  forget(id: string): void {
+    this.stateByPty.delete(id)
+  }
+
+  clear = (): void => this.stateByPty.clear()
 
   /** Publishes a retired record's exit to the owner alone, or null when nothing was projected. */
   publishAfterRetire(
@@ -49,8 +63,13 @@ export class RelayPtySourceLegacyExitIndex {
     dispatcher: RelayDispatcher,
     session: SshPtyConsumerSessionAdapter
   ): boolean | null {
-    if (this.incarnationByPty.get(params.id) !== params.incarnationId) {
+    const remembered = this.stateByPty.get(params.id)
+    if (remembered?.incarnationId !== params.incarnationId) {
       return null
+    }
+    if (remembered.state === 'complete') {
+      this.forget(params.id)
+      return true
     }
     const published = dispatcher.tryNotifyPtyExitToMatchingClients(
       (clientId) => session.deliveryMode(clientId) === 'source-owner',
@@ -71,6 +90,27 @@ function logExitSettlementFault(id: string, err: unknown): void {
   )
 }
 
+function retireFaultedPtySourceExit(
+  options: PtySourceExitOptions,
+  record: RelayPtySourceDeliveryRecord
+): void {
+  try {
+    options.session.cancelDelivery(record.identity, 'exit-publication-failed')
+  } catch (err) {
+    logExitSettlementFault(options.params.id, err)
+  }
+  try {
+    options.sender.wakeSendWaiters(record)
+  } catch (err) {
+    logExitSettlementFault(options.params.id, err)
+  } finally {
+    record.sendWaiters.clear()
+  }
+  if (options.deliveries.get(options.params.id) === record) {
+    options.deliveries.delete(options.params.id)
+  }
+}
+
 /** Seals and publishes the pty's exit, recording whether the legacy projection outlives the record. */
 export function sealAndPublishTrackedPtySourceExit(
   options: Omit<PtySourceExitOptions, 'record'> & { legacyExits: RelayPtySourceLegacyExitIndex }
@@ -81,13 +121,9 @@ export function sealAndPublishTrackedPtySourceExit(
   }
   try {
     return sealAndPublishPtySourceExit({ ...options, record })
-  } finally {
-    // Why: the subscriber projection may succeed before the owner write throws; the handler's
-    // fallback must still know to target only the owner instead of broadcasting a duplicate.
-    options.legacyExits.remember(
-      options.params,
-      record.legacyExitAccepted && options.deliveries.get(options.params.id) === record
-    )
+  } catch (err) {
+    retireFaultedPtySourceExit({ ...options, record }, record)
+    throw err
   }
 }
 
@@ -97,6 +133,7 @@ export function sealAndPublishPtySourceExit(options: PtySourceExitOptions): bool
     const published = dispatcher.tryNotifyPtyExit(params)
     if (published && deliveries.get(params.id) === record) {
       deliveries.delete(params.id)
+      options.legacyExits?.forget(params.id)
     }
     return published
   }
@@ -113,6 +150,7 @@ export function sealAndPublishPtySourceExit(options: PtySourceExitOptions): bool
       if (deliveries.get(params.id) === record) {
         deliveries.delete(params.id)
       }
+      options.legacyExits?.forget(params.id)
       return true
     }
     // Why: the delivery was canceled out from under the record; never touch the sealed
@@ -125,6 +163,7 @@ export function sealAndPublishPtySourceExit(options: PtySourceExitOptions): bool
       : dispatcher.tryNotifyPtyExit(params)
     if (published && deliveries.get(params.id) === record) {
       deliveries.delete(params.id)
+      options.legacyExits?.forget(params.id)
     }
     return published
   }
@@ -142,6 +181,7 @@ export function sealAndPublishPtySourceExit(options: PtySourceExitOptions): bool
       (clientId) => session.deliveryMode(clientId) !== 'source-owner',
       params
     )
+    options.legacyExits?.remember(params, record.legacyExitAccepted)
     if (!record.legacyExitAccepted) {
       return false
     }
@@ -172,6 +212,10 @@ export function sealAndPublishPtySourceExit(options: PtySourceExitOptions): bool
     } catch (err) {
       settlementFailed = true
       logExitSettlementFault(params.id, err)
+      if (result.ok) {
+        options.legacyExits?.complete(params)
+      }
+      retireFaultedPtySourceExit(options, record)
     } finally {
       if (result.ok || deliveryGone || settlementFailed) {
         try {

--- a/src/relay/relay-pty-source-exit-publication.ts
+++ b/src/relay/relay-pty-source-exit-publication.ts
@@ -79,12 +79,16 @@ export function sealAndPublishTrackedPtySourceExit(
   if (!record) {
     return false
   }
-  const published = sealAndPublishPtySourceExit({ ...options, record })
-  options.legacyExits.remember(
-    options.params,
-    record.legacyExitAccepted && options.deliveries.get(options.params.id) === record
-  )
-  return published
+  try {
+    return sealAndPublishPtySourceExit({ ...options, record })
+  } finally {
+    // Why: the subscriber projection may succeed before the owner write throws; the handler's
+    // fallback must still know to target only the owner instead of broadcasting a duplicate.
+    options.legacyExits.remember(
+      options.params,
+      record.legacyExitAccepted && options.deliveries.get(options.params.id) === record
+    )
+  }
 }
 
 export function sealAndPublishPtySourceExit(options: PtySourceExitOptions): boolean {

--- a/src/relay/relay-pty-source-exit-publication.ts
+++ b/src/relay/relay-pty-source-exit-publication.ts
@@ -32,8 +32,13 @@ export class RelayPtySourceLegacyExitIndex {
     if (delivered) {
       this.incarnationByPty.set(params.id, params.incarnationId)
     } else {
-      this.incarnationByPty.delete(params.id)
+      this.forget(params.id)
     }
+  }
+
+  /** Drops the entry once the exit is complete for every client, so the map cannot grow unbounded. */
+  forget(id: string): void {
+    this.incarnationByPty.delete(id)
   }
 
   clear = (): void => this.incarnationByPty.clear()
@@ -52,7 +57,7 @@ export class RelayPtySourceLegacyExitIndex {
       params
     )
     if (published) {
-      this.incarnationByPty.delete(params.id)
+      this.forget(params.id)
     }
     return published
   }

--- a/src/relay/relay-pty-source-exit-publication.ts
+++ b/src/relay/relay-pty-source-exit-publication.ts
@@ -7,10 +7,10 @@ import {
 } from './relay-pty-source-send-scheduler'
 import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
 
-type ExitParams = { id: string; code: number; incarnationId: string }
+export type PtyExitParams = { id: string; code: number; incarnationId: string }
 
-export function sealAndPublishPtySourceExit(options: {
-  params: ExitParams
+type PtySourceExitOptions = {
+  params: PtyExitParams
   record: RelayPtySourceDeliveryRecord
   deliveries: Map<string, RelayPtySourceDeliveryRecord>
   dispatcher: RelayDispatcher
@@ -18,7 +18,71 @@ export function sealAndPublishPtySourceExit(options: {
   sender: RelayPtySourceSendScheduler
   counters: RelayPtySourcePublicationCounters
   onCapacity: (id: string) => void
-}): boolean {
+}
+
+/**
+ * Remembers which exits already reached the legacy subscribers. `legacyExitAccepted` dies with
+ * the delivery record, but a cancel or grace expiry can retire the record between the legacy
+ * projection and the owner's exit frame, and the fallback must not broadcast a second copy.
+ */
+export class RelayPtySourceLegacyExitIndex {
+  private readonly incarnationByPty = new Map<string, string>()
+
+  remember(params: PtyExitParams, delivered: boolean): void {
+    if (delivered) {
+      this.incarnationByPty.set(params.id, params.incarnationId)
+    } else {
+      this.incarnationByPty.delete(params.id)
+    }
+  }
+
+  clear = (): void => this.incarnationByPty.clear()
+
+  /** Publishes a retired record's exit to the owner alone, or null when nothing was projected. */
+  publishAfterRetire(
+    params: PtyExitParams,
+    dispatcher: RelayDispatcher,
+    session: SshPtyConsumerSessionAdapter
+  ): boolean | null {
+    if (this.incarnationByPty.get(params.id) !== params.incarnationId) {
+      return null
+    }
+    const published = dispatcher.tryNotifyPtyExitToMatchingClients(
+      (clientId) => session.deliveryMode(clientId) === 'source-owner',
+      params
+    )
+    if (published) {
+      this.incarnationByPty.delete(params.id)
+    }
+    return published
+  }
+}
+
+function logExitSettlementFault(id: string, err: unknown): void {
+  process.stderr.write(
+    `[pty-source-exit] exit settlement failed for ${id}: ${
+      err instanceof Error ? (err.stack ?? err.message) : String(err)
+    }\n`
+  )
+}
+
+/** Seals and publishes the pty's exit, recording whether the legacy projection outlives the record. */
+export function sealAndPublishTrackedPtySourceExit(
+  options: Omit<PtySourceExitOptions, 'record'> & { legacyExits: RelayPtySourceLegacyExitIndex }
+): boolean {
+  const record = options.deliveries.get(options.params.id)
+  if (!record) {
+    return false
+  }
+  const published = sealAndPublishPtySourceExit({ ...options, record })
+  options.legacyExits.remember(
+    options.params,
+    record.legacyExitAccepted && options.deliveries.get(options.params.id) === record
+  )
+  return published
+}
+
+export function sealAndPublishPtySourceExit(options: PtySourceExitOptions): boolean {
   const { params, record, deliveries, dispatcher, session, sender, counters, onCapacity } = options
   if (record.restoreRequired) {
     const published = dispatcher.tryNotifyPtyExit(params)
@@ -32,6 +96,8 @@ export function sealAndPublishPtySourceExit(options: {
     return false
   }
   const probe = session.sourceDeliverySnapshotIfKnown(record.identity)
+  // Why: 'closing' is defensive — the ledger closes a canceled record in the same call, so it
+  // only ever hands back 'closed' (or null once the tombstone is evicted).
   if (!probe || probe.state === 'closed' || probe.state === 'closing') {
     if (probe?.exitPublished === true || record.sourceExitState === 'published') {
       // Why: the delivery completed healthily — the owner already has the credit-mode exit.
@@ -96,14 +162,15 @@ export function sealAndPublishPtySourceExit(options: {
       }
     } catch (err) {
       settlementFailed = true
-      process.stderr.write(
-        `[pty-source-exit] exit settlement failed for ${params.id}: ${
-          err instanceof Error ? (err.stack ?? err.message) : String(err)
-        }\n`
-      )
+      logExitSettlementFault(params.id, err)
     } finally {
       if (result.ok || deliveryGone || settlementFailed) {
-        onCapacity(params.id)
+        try {
+          // Why: capacity fans out into arbitrary handler code, still from the bare socket callback.
+          onCapacity(params.id)
+        } catch (err) {
+          logExitSettlementFault(params.id, err)
+        }
       }
     }
   })

--- a/src/relay/relay-pty-source-publication.ts
+++ b/src/relay/relay-pty-source-publication.ts
@@ -261,6 +261,9 @@ export class RelayPtySourcePublication {
     if (!record || record.sourceExitState !== 'published') {
       return false
     }
+    // Why: owner and legacy subscribers both hold this exit now, so the index row would otherwise
+    // outlive the pty for the daemon's lifetime and re-publish on any later fallback.
+    this.legacyExits.forget(id)
     this.sender.pruneClosed(id, record)
     return true
   }

--- a/src/relay/relay-pty-source-publication.ts
+++ b/src/relay/relay-pty-source-publication.ts
@@ -16,7 +16,11 @@ import {
   type RelayPtySourceDeliveryRecord,
   type RelayPtySourcePublicationCounters
 } from './relay-pty-source-send-scheduler'
-import { sealAndPublishPtySourceExit } from './relay-pty-source-exit-publication'
+import {
+  RelayPtySourceLegacyExitIndex,
+  sealAndPublishTrackedPtySourceExit,
+  type PtyExitParams
+} from './relay-pty-source-exit-publication'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import {
   appendPtySourceOutput,
@@ -28,6 +32,7 @@ import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-ad
 
 export class RelayPtySourcePublication {
   private readonly deliveries = new Map<string, RelayPtySourceDeliveryRecord>()
+  private readonly legacyExits = new RelayPtySourceLegacyExitIndex()
   private readonly counters: RelayPtySourcePublicationCounters = {
     opened: 0,
     rotated: 0,
@@ -213,6 +218,7 @@ export class RelayPtySourcePublication {
       return false
     }
     if (!output.sourceAccepted && !appendPtySourceOutput(this.session, record, output)) {
+      this.counters.appendDenied++
       if (this.deliveryClosedUnderRecord(record)) {
         this.sender.wakeSendWaiters(record)
         this.deliveries.delete(id)
@@ -223,7 +229,6 @@ export class RelayPtySourcePublication {
         queueMicrotask(() => this.onCapacity(id))
         return false
       }
-      this.counters.appendDenied++
       return false
     }
     if (!projectPtySourceOutputToLegacy(this.dispatcher, this.session, id, output, interactive)) {
@@ -233,14 +238,10 @@ export class RelayPtySourcePublication {
     return true
   }
 
-  sealAndPublishExit(params: { id: string; code: number; incarnationId: string }): boolean {
-    const record = this.deliveries.get(params.id)
-    if (!record) {
-      return false
-    }
-    return sealAndPublishPtySourceExit({
+  sealAndPublishExit = (params: PtyExitParams): boolean =>
+    sealAndPublishTrackedPtySourceExit({
       params,
-      record,
+      legacyExits: this.legacyExits,
       deliveries: this.deliveries,
       dispatcher: this.dispatcher,
       session: this.session,
@@ -248,7 +249,10 @@ export class RelayPtySourcePublication {
       counters: this.counters,
       onCapacity: this.onCapacity
     })
-  }
+
+  /** Returns null when the caller should fall back to its own legacy exit broadcast. */
+  publishExitAfterRetire = (params: PtyExitParams): boolean | null =>
+    this.legacyExits.publishAfterRetire(params, this.dispatcher, this.session)
 
   onCreditAvailable = (id: string): void => this.sender.onCreditAvailable(id)
 
@@ -263,7 +267,10 @@ export class RelayPtySourcePublication {
 
   getDebugSnapshot = () => this.sender.getDebugSnapshot()
 
-  dispose = (): void => this.sender.dispose()
+  dispose = (): void => {
+    this.legacyExits.clear()
+    this.sender.dispose()
+  }
 
   private deliveryClosedUnderRecord(record: RelayPtySourceDeliveryRecord): boolean {
     return ptySourceDeliveryClosed(this.session, record.identity)

--- a/src/relay/ssh-pty-source-credit-adapter.ts
+++ b/src/relay/ssh-pty-source-credit-adapter.ts
@@ -289,7 +289,10 @@ export class SshPtySourceCreditAdapter {
   }
 
   private cancelExact(token: string, identity: PtySourceDeliveryIdentity, reason: string): void {
-    if (this.sourceCredit.snapshot(identity).state !== 'closed') {
+    // Why: this runs from the bare grace setTimeout, where an evicted tombstone probing unknown
+    // would throw straight into uncaughtException.
+    const snapshot = this.sourceCredit.snapshotIfKnown(identity)
+    if (snapshot && snapshot.state !== 'closed') {
       const proof = this.sourceCredit.cancel(identity, reason)
       this.recentCancellations.remember(proof)
       this.publishCancellation?.(proof)


### PR DESCRIPTION
## ELI5

Same coat check as [#11634](https://github.com/stablyai/orca/pull/11634). That PR stopped the desk from **burning the building down** when it found a torn-up ticket. This one fixes what it does *next*.

- **You get told twice that your coat is gone.** When a ticket is retired at cancel time, the pending goodbye message (`pty.exit`) took a fallback path that shouted it to *everyone* — including subscribers who already got it from the record's own projection. On the consumer side a duplicate exit doesn't just look odd: it fans out into a **whole-provider teardown**.
- **The desk never forgets a ticket.** Every source-mode PTY exit leaked one `Map` row for the daemon's lifetime, and a stale row could re-publish an exit for a recycled id later.
- **The second fire extinguisher wasn't plugged in.** #11634's layer D wrapped the ledger settle in a `try/catch`, but left `onCapacity(...)` — which fans out into arbitrary handler code, still on the bare socket callback — sitting *outside* it in the `finally`. A throw there escapes to `uncaughtException` and kills the daemon: exactly the failure class layer D exists to stop.
- **Three defenses were never actually tested.** B2, B3 and the `accepts(id) &&` sub-guard could each be deleted with the entire relay suite still green.

## Summary

Follow-up to #11634 (merged as `8eee7f039a`). That PR's five defense layers landed, but three of them shipped unverified and its retire path introduced a duplicate-exit regression. Found by re-reviewing the merged commit with a three-lens adversarial pass plus mutation testing.

- **Duplicate `pty.exit` (regression from #11634).** Retiring the publication record at cancel/grace-expiry routed the pending exit through pty-handler's *unconditional* broadcast, so subscribers that already received the exit from the record's legacy projection got a second copy. Now tracked in a `RelayPtySourceLegacyExitIndex` keyed by pty incarnation so it outlives the delivery record; the fallback re-targets **only source-owner clients** when subscribers already have the exit, and still broadcasts when nothing was projected.
- **Index row leak.** `remember()` only re-ran from the exit path, which B0 short-circuits after a settled exit — so every source-mode PTY exit leaked a `Map` row for the daemon's lifetime and would re-publish on any later fallback for that id. `exitPublicationSettled` now forgets the entry when it prunes a healthy exit.
- **Layer D hardening.** `onCapacity` moved inside a `try/catch` with `logExitSettlementFault`, closing the escape hatch described above.
- **`cancelExact` throwing probe.** Routed through the non-throwing `snapshotIfKnown`, so the bare-timer path can't throw from a `setTimeout` callback.
- **Coverage for the previously untested layers:** B2 (same-client re-attach healing), B3 (retire-on-append-failure plus the microtask deferral), and `publishPendingExit`'s `accepts(id) &&` sub-guard.

## Test plan

`env -u GIT_CONFIG_COUNT npx vitest run --config config/vitest.config.ts src/relay/` — **1084 passed (97 files), zero failures**, rebased onto current `main` (`cc078a5021`). Also green: `npx tsc --noEmit -p config/tsconfig.node.json`, `npx oxlint src/relay`.

> Note: unset `GIT_CONFIG_COUNT` when running locally. If your shell exports it (Claude Code and some git wrappers do), the ambient git config is appended to the spawned env and `agent-exec-handler.test.ts` fails 2 spurious assertions — unrelated to this PR.

**Mutation-tested, because "the suite is green" is what let these ship untested in the first place.** Against the merged state of #11634, disabling each layer left the suite fully green. With this PR:

| Mutation | On `8eee7f039a` (merged) | With this PR |
|---|---|---|
| B2 guard → `false &&` (`relay-pty-source-publication.ts:88`) | 0 tests fail | **2 tests fail** |
| B3 retire branch → `if (false)` (`:222`) | 0 tests fail | **1 test fails** |
| B3 deferral → synchronous `onCapacity` (`:229`) | 0 tests fail | covered |

The deferral matters beyond tidiness: its own comment notes a synchronous callback "would publish `pty.exit` ahead of still-buffered output" — a user-visible ordering defect that previously had nothing pinning it.

Found by the production release scan of v1.4.162..v1.4.163-rc.0.

Made with [Orca](https://github.com/stablyai/orca) 🐋
