### PR TITLE
fix(codex): fall back on invalid rate-limit RPC responses

### DIFF
--- a/src/main/rate-limits/codex-fetcher-rpc-test-harness.test.ts
+++ b/src/main/rate-limits/codex-fetcher-rpc-test-harness.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { makePtyTerm } from './codex-fetcher-rpc-test-harness'
+
+describe('Codex fetcher RPC test harness', () => {
+  it('stops delivering PTY events after subscriptions are disposed', () => {
+    const term = makePtyTerm()
+    const dataHandler = vi.fn()
+    const exitHandler = vi.fn()
+    const dataSubscription = term.onData(dataHandler)
+    const exitSubscription = term.onExit(exitHandler)
+
+    dataSubscription.dispose()
+    exitSubscription.dispose()
+    term.emitData('late data')
+    term.emitExit()
+
+    expect(dataHandler).not.toHaveBeenCalled()
+    expect(exitHandler).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/rate-limits/codex-fetcher-rpc-test-harness.ts
+++ b/src/main/rate-limits/codex-fetcher-rpc-test-harness.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from 'node:events'
+import { vi } from 'vitest'
+
+export function makeDisposable(): { dispose: ReturnType<typeof vi.fn> } {
+  return { dispose: vi.fn() }
+}
+
+export function makeRpcChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    stdin: { write: ReturnType<typeof vi.fn> }
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdin = { write: vi.fn() }
+  child.kill = vi.fn()
+  return child
+}
+
+export function respondToRpcResult(
+  rpcChild: ReturnType<typeof makeRpcChild>,
+  result: unknown
+): void {
+  rpcChild.stdin.write.mockImplementation((line: string) => {
+    const message = JSON.parse(line) as { id?: number; method?: string }
+    if (message.method === 'initialize') {
+      setTimeout(() => {
+        rpcChild.stdout.emit(
+          'data',
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} })}\n`)
+        )
+      }, 0)
+    }
+    if (message.method === 'account/rateLimits/read') {
+      setTimeout(() => {
+        rpcChild.stdout.emit(
+          'data',
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: message.id, result })}\n`)
+        )
+      }, 0)
+    }
+  })
+}
+
+export function respondToRpcRateLimitRead(
+  rpcChild: ReturnType<typeof makeRpcChild>,
+  rateLimits: unknown
+): void {
+  respondToRpcResult(rpcChild, { rateLimits })
+}
+
+export function makePtyTerm(): {
+  onData: ReturnType<typeof vi.fn>
+  onExit: ReturnType<typeof vi.fn>
+  write: ReturnType<typeof vi.fn>
+  kill: ReturnType<typeof vi.fn>
+  emitData: (data: string) => void
+  emitExit: () => void
+} {
+  let dataHandler: ((data: string) => void) | null = null
+  let exitHandler: (() => void) | null = null
+  return {
+    onData: vi.fn((callback: (data: string) => void) => {
+      dataHandler = callback
+      return makeDisposable()
+    }),
+    onExit: vi.fn((callback: () => void) => {
+      exitHandler = callback
+      return makeDisposable()
+    }),
+    write: vi.fn(),
+    kill: vi.fn(),
+    emitData: (data: string) => dataHandler?.(data),
+    emitExit: () => exitHandler?.()
+  }
+}

--- a/src/main/rate-limits/codex-fetcher-rpc-test-harness.ts
+++ b/src/main/rate-limits/codex-fetcher-rpc-test-harness.ts
@@ -1,8 +1,11 @@
 import { EventEmitter } from 'node:events'
+import type { Mock } from 'vitest'
 import { vi } from 'vitest'
 
-export function makeDisposable(): { dispose: ReturnType<typeof vi.fn> } {
-  return { dispose: vi.fn() }
+type TestDisposable = { dispose: Mock<() => void> }
+
+export function makeDisposable(onDispose: () => void = () => undefined): TestDisposable {
+  return { dispose: vi.fn(onDispose) }
 }
 
 export function makeRpcChild() {
@@ -52,27 +55,31 @@ export function respondToRpcRateLimitRead(
 }
 
 export function makePtyTerm(): {
-  onData: ReturnType<typeof vi.fn>
-  onExit: ReturnType<typeof vi.fn>
+  onData: (callback: (data: string) => void) => ReturnType<typeof makeDisposable>
+  onExit: (callback: () => void) => ReturnType<typeof makeDisposable>
   write: ReturnType<typeof vi.fn>
   kill: ReturnType<typeof vi.fn>
   emitData: (data: string) => void
   emitExit: () => void
 } {
-  let dataHandler: ((data: string) => void) | null = null
-  let exitHandler: (() => void) | null = null
+  const dataHandlers = new Set<(data: string) => void>()
+  const exitHandlers = new Set<() => void>()
   return {
     onData: vi.fn((callback: (data: string) => void) => {
-      dataHandler = callback
-      return makeDisposable()
+      dataHandlers.add(callback)
+      return makeDisposable(() => {
+        dataHandlers.delete(callback)
+      })
     }),
     onExit: vi.fn((callback: () => void) => {
-      exitHandler = callback
-      return makeDisposable()
+      exitHandlers.add(callback)
+      return makeDisposable(() => {
+        exitHandlers.delete(callback)
+      })
     }),
     write: vi.fn(),
     kill: vi.fn(),
-    emitData: (data: string) => dataHandler?.(data),
-    emitExit: () => exitHandler?.()
+    emitData: (data: string) => dataHandlers.forEach((handler) => handler(data)),
+    emitExit: () => exitHandlers.forEach((handler) => handler())
   }
 }

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -32,74 +31,15 @@ vi.mock('./codex-auth-presence', () => ({
 }))
 
 import { fetchCodexRateLimits } from './codex-fetcher'
+import {
+  makeDisposable,
+  makePtyTerm,
+  makeRpcChild,
+  respondToRpcRateLimitRead,
+  respondToRpcResult
+} from './codex-fetcher-rpc-test-harness'
 import { probeCodexAuthPresence } from './codex-auth-presence'
 import { getActiveHiddenRateLimitPtyCount } from './hidden-pty-cleanup'
-
-function makeDisposable() {
-  return { dispose: vi.fn() }
-}
-
-function makeRpcChild() {
-  const child = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter
-    stderr: EventEmitter
-    stdin: { write: ReturnType<typeof vi.fn> }
-    kill: ReturnType<typeof vi.fn>
-  }
-  child.stdout = new EventEmitter()
-  child.stderr = new EventEmitter()
-  child.stdin = { write: vi.fn() }
-  child.kill = vi.fn()
-  return child
-}
-
-function respondToRpcResult(rpcChild: ReturnType<typeof makeRpcChild>, result: unknown): void {
-  rpcChild.stdin.write.mockImplementation((line: string) => {
-    const msg = JSON.parse(line) as { id?: number; method?: string }
-    if (msg.method === 'initialize') {
-      setTimeout(() => {
-        rpcChild.stdout.emit(
-          'data',
-          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
-        )
-      }, 0)
-    }
-    if (msg.method === 'account/rateLimits/read') {
-      setTimeout(() => {
-        rpcChild.stdout.emit(
-          'data',
-          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result })}\n`)
-        )
-      }, 0)
-    }
-  })
-}
-
-function respondToRpcRateLimitRead(
-  rpcChild: ReturnType<typeof makeRpcChild>,
-  rateLimits: unknown
-): void {
-  respondToRpcResult(rpcChild, { rateLimits })
-}
-
-function makePtyTerm() {
-  let dataHandler: ((data: string) => void) | null = null
-  let exitHandler: (() => void) | null = null
-  return {
-    onData: vi.fn((callback: (data: string) => void) => {
-      dataHandler = callback
-      return makeDisposable()
-    }),
-    onExit: vi.fn((callback: () => void) => {
-      exitHandler = callback
-      return makeDisposable()
-    }),
-    write: vi.fn(),
-    kill: vi.fn(),
-    emitData: (data: string) => dataHandler?.(data),
-    emitExit: () => exitHandler?.()
-  }
-}
 
 describe('fetchCodexRateLimits', () => {
   beforeEach(() => {
@@ -113,6 +53,7 @@ describe('fetchCodexRateLimits', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.useRealTimers()
   })
 
   it('does not spawn Codex when the user is not signed in', async () => {
@@ -338,6 +279,29 @@ describe('fetchCodexRateLimits', () => {
     })
   })
 
+  it('falls back to PTY when RPC returns a malformed nested rate-limit window', async () => {
+    const rpcChild = makeRpcChild()
+    const term = makePtyTerm()
+    childSpawnMock.mockReturnValue(rpcChild)
+    ptySpawnMock.mockReturnValue(term)
+    respondToRpcResult(rpcChild, { rateLimits: { primary: [] } })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(2)
+
+    expect(ptySpawnMock).toHaveBeenCalled()
+    term.emitData('>')
+    term.emitData('5h limit: 10%\nWeekly limit: 15%\n')
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: { usedPercent: 10 },
+      weekly: { usedPercent: 15 },
+      status: 'ok',
+      error: null
+    })
+  })
+
   it('accepts an explicit null RPC rate-limits snapshot without starting PTY fallback', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)
@@ -363,6 +327,21 @@ describe('fetchCodexRateLimits', () => {
     const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
     await vi.advanceTimersByTimeAsync(1)
     await vi.advanceTimersByTimeAsync(1)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: 'Invalid RPC rate-limit response'
+    })
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a malformed nested RPC window when PTY fallback is disabled', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcResult(rpcChild, { rateLimits: { secondary: [] } })
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(2)
 
     await expect(resultPromise).resolves.toMatchObject({
       status: 'error',

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -53,10 +53,7 @@ function makeRpcChild() {
   return child
 }
 
-function respondToRpcRateLimitRead(
-  rpcChild: ReturnType<typeof makeRpcChild>,
-  rateLimits: unknown
-): void {
+function respondToRpcResult(rpcChild: ReturnType<typeof makeRpcChild>, result: unknown): void {
   rpcChild.stdin.write.mockImplementation((line: string) => {
     const msg = JSON.parse(line) as { id?: number; method?: string }
     if (msg.method === 'initialize') {
@@ -71,11 +68,18 @@ function respondToRpcRateLimitRead(
       setTimeout(() => {
         rpcChild.stdout.emit(
           'data',
-          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { rateLimits } })}\n`)
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result })}\n`)
         )
       }, 0)
     }
   })
+}
+
+function respondToRpcRateLimitRead(
+  rpcChild: ReturnType<typeof makeRpcChild>,
+  rateLimits: unknown
+): void {
+  respondToRpcResult(rpcChild, { rateLimits })
 }
 
 function makePtyTerm() {
@@ -308,6 +312,63 @@ describe('fetchCodexRateLimits', () => {
       status: 'ok',
       error: null
     })
+  })
+
+  it('falls back to PTY when RPC omits the required rate-limits snapshot', async () => {
+    const rpcChild = makeRpcChild()
+    const term = makePtyTerm()
+    childSpawnMock.mockReturnValue(rpcChild)
+    ptySpawnMock.mockReturnValue(term)
+    respondToRpcResult(rpcChild, { rateLimitsByLimitId: null })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(ptySpawnMock).toHaveBeenCalled()
+    term.emitData('>')
+    term.emitData('5h limit: 9%\nWeekly limit: 14%\n')
+    await vi.advanceTimersByTimeAsync(500)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: { usedPercent: 9 },
+      weekly: { usedPercent: 14 },
+      status: 'ok',
+      error: null
+    })
+  })
+
+  it('accepts an explicit null RPC rate-limits snapshot without starting PTY fallback', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcRateLimitRead(rpcChild, null)
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: null,
+      weekly: null,
+      status: 'ok'
+    })
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a malformed RPC snapshot when PTY fallback is disabled', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcResult(rpcChild, { rateLimits: [] })
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: 'Invalid RPC rate-limit response'
+    })
+    expect(ptySpawnMock).not.toHaveBeenCalled()
   })
 
   it('does not start the PTY fallback when disabled for background account previews', async () => {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -83,7 +83,7 @@ type RateLimitResetCredits = {
 
 // Why: the Codex app-server wraps rate limit data as { rateLimits: { primary, secondary, ... } }.
 type RpcRateLimitsResponse = {
-  rateLimits?: CodexRateLimitWindowsSnapshot | null
+  rateLimits: CodexRateLimitWindowsSnapshot | null
   rateLimitResetCredits?: {
     availableCount?: number
     totalEarnedCount?: number
@@ -94,6 +94,18 @@ type RpcRateLimitsResponse = {
       grantedAt?: number | string | null
     }[]
   } | null
+}
+
+function isRpcRateLimitsResponse(value: unknown): value is RpcRateLimitsResponse {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !Object.prototype.hasOwnProperty.call(value, 'rateLimits')
+  ) {
+    return false
+  }
+  const rateLimits = (value as { rateLimits: unknown }).rateLimits
+  return rateLimits === null || (typeof rateLimits === 'object' && !Array.isArray(rateLimits))
 }
 
 type CodexAuthFile = {
@@ -754,14 +766,27 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
               return
             }
 
-            const wrapper = msg.result as RpcRateLimitsResponse | undefined
-            const result = wrapper?.rateLimits
+            if (!isRpcRateLimitsResponse(msg.result)) {
+              settle(
+                {
+                  provider: 'codex',
+                  session: null,
+                  weekly: null,
+                  updatedAt: Date.now(),
+                  error: 'Invalid RPC rate-limit response',
+                  status: 'error'
+                },
+                { kill: true }
+              )
+              return
+            }
+
+            const wrapper = msg.result
+            const result = wrapper.rateLimits
             const classifiedWindows = classifyCodexRateLimitWindows(result)
             const session = mapRpcWindow(classifiedWindows.session, CODEX_SESSION_WINDOW_MINUTES)
             const weekly = mapRpcWindow(classifiedWindows.weekly, CODEX_WEEKLY_WINDOW_MINUTES)
-            const rateLimitResetCredits = mapRpcRateLimitResetCredits(
-              wrapper?.rateLimitResetCredits
-            )
+            const rateLimitResetCredits = mapRpcRateLimitResetCredits(wrapper.rateLimitResetCredits)
 
             settle(
               {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -105,7 +105,20 @@ function isRpcRateLimitsResponse(value: unknown): value is RpcRateLimitsResponse
     return false
   }
   const rateLimits = (value as { rateLimits: unknown }).rateLimits
-  return rateLimits === null || (typeof rateLimits === 'object' && !Array.isArray(rateLimits))
+  if (rateLimits === null) {
+    return true
+  }
+  if (typeof rateLimits !== 'object' || Array.isArray(rateLimits)) {
+    return false
+  }
+  const windows = rateLimits as Partial<Record<'primary' | 'secondary', unknown>>
+  return (['primary', 'secondary'] as const).every((key) => {
+    if (!Object.prototype.hasOwnProperty.call(windows, key)) {
+      return true
+    }
+    const window = windows[key]
+    return window === null || (typeof window === 'object' && !Array.isArray(window))
+  })
 }
 
 type CodexAuthFile = {


### PR DESCRIPTION
## Summary

- Validate the successful `account/rateLimits/read` envelope before treating an app-server response as usable.
- Return an RPC error for missing or malformed required `rateLimits` data, including malformed nested `primary` / `secondary` windows, so the existing `/status` PTY fallback can recover usage instead of showing an incorrect empty state.
- Preserve Orca's existing tolerance for an explicit `rateLimits: null`, and preserve `allowPtyFallback: false` for background managed-account previews.

## Protocol evidence

The current [Codex app-server documentation](https://learn.chatgpt.com/docs/app-server.md) shows `account/rateLimits/read` returning a result wrapper with `rateLimits`, optional `rateLimitsByLimitId`, and optional `rateLimitResetCredits`.

The locally installed `codex-cli 0.146.0` generated schema (`codex app-server generate-json-schema`) declares `rateLimits` as the required backward-compatible single-bucket view and `rateLimitsByLimitId` as optional. A `rateLimitsByLimitId`-only success is therefore treated as invalid rather than silently mapped to empty usage.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — ran 8 focused files / 72 tests covering RPC, backend supplementation, PTY settlement, test-harness disposal, auth errors, window classification, and target selection
- [ ] `pnpm build` — no packaging, renderer, dependency, or asset changes
- [x] Added regression tests

Focused verification on the exact rebased head:

```text
Test Files  8 passed (8)
Tests       72 passed (72)
```

The primary regression test failed on the old implementation because `{ rateLimitsByLimitId: null }` was accepted as `status: "ok"` with null windows and PTY never started. It now reaches PTY and returns the parsed 5-hour and weekly usage. Separate tests lock explicit-null compatibility, malformed top-level rejection, and both fallback-enabled and fallback-disabled behavior for malformed nested windows.

## AI Review Report

Five independent final review axes covered correctness, reliability, security/data integrity, cross-version/platform compatibility, and maintainability/test quality.

The review checked:

- required-own-property validation versus missing, primitive, array, optional-field-only envelopes, and malformed nested windows;
- explicit-null behavior and forward-compatible fallback rather than speculative parsing of undocumented unwrapped shapes;
- listener, timer, abort, and child-process cleanup through the shared `settle(..., { kill: true })` path, including effective test-double subscription disposal;
- `allowPtyFallback: false` behavior for managed-account background previews;
- macOS, Linux, Windows host, WSL, and SSH implications;
- fixed diagnostic text without response payload, stderr, tokens, or account material;
- max-lines policy, fake-timer cleanup, and shared RPC/PTY test harness design.

All five final axes reported no remaining P0-P3 findings.

## Security Audit

- No response payload or credential material is added to logs or returned errors.
- The guard uses an own-property check and rejects null top-level values, primitives, arrays, and missing required data.
- The existing account-scoped `CODEX_HOME` / WSL execution target is unchanged.
- Normal interactive polling may start only the existing PTY fallback after an invalid RPC result; background managed-account previews still disable PTY fallback.
- No new IPC, shell command, dependency, path input, or persistence format is added.

## Notes

- This is intentionally separate from #11655: account-removal durability and rate-limit protocol parsing have independent failure modes, tests, and rollback paths.
- Unknown or future response shapes fail over to the existing PTY reader instead of being accepted as empty usage.
- Rollback is a one-commit revert with no migration.

- Contributor X: [@DevKazu42](https://x.com/DevKazu42)
