### PR TITLE
[P0] fix(terminal): pause hidden paired output

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3088,7 +3088,7 @@
       "providers": ["paired-runtime", "ssh"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["paired-runtime"],
-      "coverageNotes": "Deterministic headed macOS runs launch an isolated Orca desktop server and a separate paired web client. A byte-identical headless run uses an isolated `orca serve` host. Both create six real paired host PTYs with bounded high-output scrollback, ordinary-park five client xterms without enabling the lossy retention budget, assert bounded cells/heap/timer lag, then restore 5,000 rows on the original PTY including output produced while parked and continued input/output. The headed oracle additionally keeps every remote target workspace and terminal unmounted in the host renderer before and after client recovery. Separate headed/headless ACK-starvation tests recover one stalled stream without replacing its PTY. A headed output-drop oracle proves a successful snapshot probe cannot certify a stale live stream when the authoritative PTY sequence advanced beyond the client high-water. Unit coverage requires an unsequenced client to establish a first-probe baseline, remain attached at the same sequence, and recover only after a later probe advances. A capability-disabled run proves legacy hosts retain the prior lossy limit/TTL fallback. Unit tests cover exact-owner capability routing, raw-stream release, singleton side-effect facts with timed handoff cleanup, provider-authoritative snapshots, 128 active streams plus retry after a 129th-stream capacity rejection, capacity-pressure backoff, full split-leaf remint reconciliation, truncation, and manual-disconnect queue fencing. Linux, Windows, mixed-version paired hosts, live SSH, and production-scale paired hosts remain gaps.",
+      "coverageNotes": "Deterministic headed macOS runs launch an isolated Orca desktop server and a separate paired web client. A byte-identical headless run uses an isolated `orca serve` host. Both create six real paired host PTYs with bounded high-output scrollback, prove sustained output while all six client xterms are warm-mounted but hidden causes zero renderer scheduler work, ordinary-park five xterms without enabling the lossy retention budget, assert bounded cells/heap/timer lag, then restore the bounded authoritative tail exactly once on the original PTY including output produced while parked and continued input/output. The headed oracle additionally keeps every remote target workspace and terminal unmounted in the host renderer before and after client recovery. Separate headed/headless ACK-starvation tests recover one stalled stream without replacing its PTY. A headed output-drop oracle proves a successful snapshot probe cannot certify a stale live stream when the authoritative PTY sequence advanced beyond the client high-water. Unit coverage requires an unsequenced client to establish a first-probe baseline, remain attached at the same sequence, and recover only after a later probe advances. A capability-disabled run proves legacy hosts retain the prior lossy limit/TTL fallback. Unit tests cover exact-owner capability routing, raw-stream release, singleton side-effect facts with timed handoff cleanup, provider-authoritative snapshots, 128 active streams plus retry after a 129th-stream capacity rejection, capacity-pressure backoff, full split-leaf remint reconciliation, truncation, and manual-disconnect queue fencing. Linux, Windows, mixed-version paired hosts, live SSH, and production-scale paired hosts remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/8652",
         "https://github.com/stablyai/orca/pull/10625"
@@ -3162,12 +3162,16 @@
           "file": "tests/e2e/paired-remote-terminal-retention-memory.spec.ts",
           "assertions": [
             "ordinary-parks paired terminals and restores authoritative host scrollback",
+            "warm-mounted hidden paired streams schedule zero renderer output work under sustained host output",
             "client recovery completes while every target terminal remains unmounted in the host renderer"
           ]
         },
         {
           "file": "tests/e2e/headless-paired-remote-terminal-retention-memory.spec.ts",
-          "assertions": ["ordinary-parks paired terminals against an isolated headless Orca host"]
+          "assertions": [
+            "ordinary-parks paired terminals against an isolated headless Orca host",
+            "the headless host shares the zero-hidden-renderer-work and exact-restoration contract"
+          ]
         },
         {
           "file": "tests/e2e/terminal-parked-memory.spec.ts",
@@ -3335,6 +3339,24 @@
           "result": "passed",
           "durationSeconds": 3.16,
           "summary": "All 27 encrypted shared-control tests passed. The new oracle was red on rc.1-equivalent behavior with the exact Refreshing remote runtime control transport error, then passed with one replacement connection, one delivered host RPC, and zero retained pending bytes."
+        },
+        {
+          "date": "2026-07-30",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_E2E_WEB_CLIENT=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-remote-terminal-retention-memory.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 17.5,
+          "summary": "The headed six-PTY oracle kept all warm-mounted hidden streams at zero renderer scheduler enqueues/drains under sustained output and under 500 ms timer lag, then restored the authoritative flood tail and parked/live markers exactly once."
+        },
+        {
+          "date": "2026-07-30",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_E2E_WEB_CLIENT=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-paired-remote-terminal-retention-memory.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 14.0,
+          "summary": "The isolated headless host passed the same six-stream zero-hidden-renderer-work, bounded-lag, exact authoritative restoration, same-PTY, and continued-I/O oracle."
         }
       ],
       "runtimeBudget": {
@@ -3351,14 +3373,14 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Capable paired hosts use ordinary parking: the host PTY and bounded 5,000-row provider model remain, while five hidden client xterms and their raw per-PTY multiplex streams are destroyed. Parked side effects share the singleton runtime client-event stream. Headed and headless oracles require exact reduction from six managers to one, at least 55% staged xterm-cell release, no more than 16 MiB heap growth, and under 500 ms timer drift. Legacy hosts retain the prior 12-worktree/45-minute lossy force-parking policy. Stream recovery adds no polling and is scoped to one stream."
+        "evidence": "Before ordinary parking, six warm-mounted hidden paired xterms receive zero raw frames and schedule zero renderer output drains while host models continue ingesting sustained output. Ordinary parking then retains the host PTY and bounded 5,000-row provider model while destroying five client xterms. Parked side effects share the singleton runtime client-event stream. Headed and headless oracles require exact reduction from six managers to one, at least 55% staged xterm-cell release, no more than 16 MiB heap growth, and under 500 ms timer drift. Legacy hosts retain the prior 12-worktree/45-minute lossy force-parking policy. Stream recovery adds no polling and is scoped to one stream."
       },
       "promotionCriteria": [
         "Collect 100 consecutive CI passes or 14 days of soak history for the headed and headless parking commands.",
         "Run the paired topology on Windows and Linux and add one live SSH retention run.",
         "Run the stream-stall oracle with a v1.4.160-rc.3 host and v1.4.160-rc.4 client.",
         "Add a production-scale paired run with dozens of worktrees and explicit event-loop and renderer-memory budgets.",
-        "Keep the budget-off control, exact manager count, row-4,000 reveal marker, parked-time output, and post-reveal PTY input in both topology runs."
+        "Keep the budget-off control, exact manager count, final bounded-tail flood marker, parked-time output, and post-reveal PTY input in both topology runs."
       ],
       "knownGaps": [
         "Paired reveal restores at most the requested 5,000 rows; older history is intentionally unavailable.",
@@ -6449,18 +6471,19 @@
       "platforms": ["macos", "linux", "windows", "mobile"],
       "providers": ["remote-runtime", "ssh", "local", "daemon"],
       "coveredPlatforms": ["macos"],
-      "coveredProviders": [],
-      "coverageNotes": "Local macOS evidence covers runtime-RPC stream budgets plus paired-renderer parse/discard credit. Deferred credit is shared by local and remote transports, batches ACKs at 192 KiB or 4 ms, grows per-stream windows from 512 KiB to 2 MiB and aggregate windows from 2 MiB to 8 MiB, bounds queued output to 256 KiB per stream, and caps each multiplex connection at 32 active or pending streams for an 8 MiB aggregate pending-output ceiling. Deterministic tests cover replay ordering, stale generations, malformed frames, hidden panes, queue eviction, disposal, send/recovery failure, repeated pending-slot replacement, reconnect, and round-robin fairness. The opt-in benchmark covers 1/20/100 ms RTT and 1/4/8 viewers, exact protocol-frame allocations, scheduler CPU, and measured @xterm/headless parser CPU/retained heap. Live Android restore evidence, browser/WebGL parser measurements, and legacy JSON subscribe parity remain required.",
+      "coveredProviders": ["remote-runtime"],
+      "coverageNotes": "Local macOS evidence covers runtime-RPC stream budgets, paired-renderer parse/discard credit, and negotiated host-side suppression for hidden paired desktop panes. Deferred credit is shared by local and remote transports, batches ACKs at 192 KiB or 4 ms, grows per-stream windows from 512 KiB to 2 MiB and aggregate windows from 2 MiB to 8 MiB, bounds queued output to 256 KiB per stream, and caps each multiplex connection at 32 active or pending streams for an 8 MiB aggregate pending-output ceiling. Deterministic tests cover replay ordering, stale generations, malformed frames, hidden panes, queue eviction, disposal, send/recovery failure, repeated pending-slot replacement, reconnect, mixed-version pause negotiation, and round-robin fairness. The opt-in benchmark covers 1/20/100 ms RTT and 1/4/8 viewers, exact protocol-frame allocations, scheduler CPU, and measured @xterm/headless parser CPU/retained heap. Live Android restore evidence, browser/WebGL parser measurements, and legacy JSON subscribe parity remain required.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6951",
         "https://github.com/stablyai/orca/pull/6955",
         "https://github.com/stablyai/orca/pull/7009"
       ],
-      "invariant": "Runtime and mobile terminal subscriptions must cap initial snapshots, live output buffered while snapshots load, chunk sizes, batches, and aggregate in-flight credit. ACK means the renderer parsed the bytes or intentionally discarded them; receipt-time ACK is forbidden. Every replay, stale-generation, malformed-frame, hidden-pane, eviction, disposal, error, and reconnect path must settle credit exactly once so streams neither leak memory nor stall. A terminal covered by native chat must restore from fresh scrollback when revealed, while preserving output order, input locks, resize/driver events, fairness, and fallback parity or explicit fallback deprecation.",
-      "oracle": "Assert mobile initial snapshots downgrade until they fit <=512KB, requested binary snapshots downgrade until they fit <=2MB, live output queued while snapshots load stays <=256KB per stream, large output splits into <=48KB frames, and output bursts coalesce. Feed paired output through the xterm parse callback and prove ACK is deferred until parse or intentional discard, then inject stale generation, malformed/transformed frames, replay failure, queue eviction, hidden panes, pane disposal, ACK send failure, recovery serialization failure, and reconnect races; assert ordered replay and exactly-once credit settlement. Fill the aggregate window across bulk and interactive streams, ACK once, and prove round-robin progress. Run the opt-in 64 MiB/viewer RTT matrix and enforce bounded 8 MiB aggregate in-flight memory, >7 MiB/s/viewer at 100 ms RTT, and <200 ms completion spread. JSON fallback parity and live Android scrollback restoration remain explicit gaps.",
+      "invariant": "Runtime and mobile terminal subscriptions must cap initial snapshots, live output buffered while snapshots load, chunk sizes, batches, and aggregate in-flight credit. ACK means the renderer parsed the bytes or intentionally discarded them; receipt-time ACK is forbidden. A capability-negotiated hidden paired desktop stream must deliver zero raw output frames after host model ingestion, preserve side-effect facts, and restore from one authoritative snapshot before exact live output resumes. Every replay, stale-generation, malformed-frame, hidden-pane, eviction, disposal, error, and reconnect path must settle credit exactly once so streams neither leak memory nor stall. A terminal covered by native chat must restore from fresh scrollback when revealed, while preserving output order, input locks, resize/driver events, fairness, and safe mixed-version fallback.",
+      "oracle": "Assert mobile initial snapshots downgrade until they fit <=512KB, requested binary snapshots downgrade until they fit <=2MB, live output queued while snapshots load stays <=256KB per stream, large output splits into <=48KB frames, and output bursts coalesce. Pause three negotiated paired desktop streams, sustain output, and assert zero renderer frames; reveal one and assert one authoritative snapshot followed by exact live bytes with no loss or duplication. Prove old clients continue receiving output and new clients never send pause to old hosts. Feed paired output through the xterm parse callback and prove ACK is deferred until parse or intentional discard, then inject stale generation, malformed/transformed frames, replay failure, queue eviction, hidden panes, pane disposal, ACK send failure, recovery serialization failure, and reconnect races; assert ordered replay and exactly-once credit settlement. Fill the aggregate window across bulk and interactive streams, ACK once, and prove round-robin progress. Run the opt-in 64 MiB/viewer RTT matrix and enforce bounded 8 MiB aggregate in-flight memory, >7 MiB/s/viewer at 100 ms RTT, and <200 ms completion spread. JSON fallback parity and live Android scrollback restoration remain explicit gaps.",
       "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-multiplex.test.ts --maxWorkers=1",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/rpc/terminal-output-batching.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts",
-        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/rpc/terminal-output-batching.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/terminal-pty-ack-gate.test.ts src/renderer/src/lib/pane-manager/terminal-delivery-credit.test.ts src/renderer/src/runtime/remote-runtime-terminal-parse-backpressure.test.ts src/renderer/src/runtime/runtime-terminal-stream.test.ts --maxWorkers=1",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-subscribe-buffer.test.ts src/main/runtime/rpc/terminal-output-batching.test.ts src/main/runtime/rpc/terminal-multiplex.test.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts src/renderer/src/components/terminal-pane/terminal-pty-ack-gate.test.ts src/renderer/src/lib/pane-manager/terminal-delivery-credit.test.ts src/renderer/src/runtime/remote-runtime-terminal-parse-backpressure.test.ts src/renderer/src/runtime/runtime-terminal-stream.test.ts --maxWorkers=1",
         "ORCA_TERMINAL_PERF_BENCH=1 pnpm exec vitest run --config config/vitest.config.ts --disableConsoleIntercept src/main/runtime/rpc/terminal-multiplex-flow-control.bench.test.ts",
         "pnpm --dir mobile exec vitest run --root .. mobile/src/session/mobile-native-chat-terminal-stream.test.ts",
         "pnpm --dir mobile exec vitest run --root .. mobile/src/session/use-mobile-native-chat-terminal-stream.test.ts"
@@ -6471,6 +6494,7 @@
         "src/main/runtime/rpc/terminal-multiplex.test.ts",
         "src/main/runtime/rpc/terminal-multiplex-flow-control.bench.test.ts",
         "src/renderer/src/components/terminal-pane/pty-connection.test.ts",
+        "src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts",
         "src/renderer/src/components/terminal-pane/terminal-pty-ack-gate.test.ts",
         "src/renderer/src/lib/pane-manager/terminal-delivery-credit.test.ts",
         "src/renderer/src/runtime/remote-runtime-terminal-parse-backpressure.test.ts",
@@ -6502,7 +6526,24 @@
             "multibyte live output flushes when encoded bytes reach the batch budget",
             "adaptive credit grows only after ACK, stays globally bounded, and drains pending streams round-robin",
             "send and recovery serialization failures detach once instead of leaking credit or retrying forever",
-            "32 active or pending slots cap aggregate queued output and repeated pending-slot subscribe cancels its older waiter"
+            "32 active or pending slots cap aggregate queued output and repeated pending-slot subscribe cancels its older waiter",
+            "three negotiated hidden desktop streams emit zero output frames under sustained load while an unpaused stream remains live",
+            "an older client that omits pause negotiation continues receiving output"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal-pane/pty-connection.test.ts",
+          "assertions": [
+            "a runtime-owned hidden pane pauses output, consumes status/title/theme facts, and keeps input writable",
+            "reveal resumes before one authoritative snapshot and exact live output with no hidden raw write, loss, or duplication",
+            "dispose releases pause and unregisters the fact consumer"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts",
+          "assertions": [
+            "desired pause reapplies after either capability/snapshot ordering and across reconnect",
+            "reconnect delivers each authoritative snapshot and post-resume live marker exactly once"
           ]
         },
         {
@@ -6577,6 +6618,15 @@
           "result": "passed",
           "durationSeconds": 0.91,
           "summary": "The 1/20/100 ms RTT x 1/4/8 viewer matrix stayed at or below 8 MiB in flight with zero completion spread. At 100 ms it modeled 18.8 MiB/s per viewer for 1-4 viewers and 9.7 MiB/s for 8 viewers. Measured @xterm/headless parsing was 26.7/63.6/95.3 aggregate MiB/s for 1/4/8 viewers, with 84.4/236.5/336.0 ms CPU and 2893/13409/28991 KiB retained heap for 4 MiB per viewer."
+        },
+        {
+          "date": "2026-07-30",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-multiplex.test.ts --maxWorkers=1",
+          "result": "passed",
+          "durationSeconds": 9.05,
+          "summary": "All 58 terminal multiplex tests passed, including the three-stream hidden-output oracle. Its byte-identical title-selected command failed on current origin/main and failed again with the two causal host/protocol files reverted because hidden Output frames reached the renderer."
         }
       ],
       "runtimeBudget": {
@@ -6589,11 +6639,11 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Tests cover mobile initial snapshot byte downgrade, requested binary snapshot byte downgrade, pending live-output cap while snapshot loads, output chunk size, output coalescing, abort cleanup, and stale resize re-stream suppression. Needs intentional-break proof plus JSON fallback coverage before promotion."
+        "evidence": "The hidden paired-output oracle is red on origin/main, green on the candidate, and red with its causal host/protocol files reverted. It proves three paused streams emit no raw frames while an unpaused control remains live; compatibility tests preserve old-client/new-host output and prevent new-client/old-host pause opcodes. The broader gate remains partial pending legacy JSON fallback and live Android coverage."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Parsed/discarded credit uses 192 KiB/4 ms ACK batching, 512 KiB-to-2 MiB adaptive per-stream windows, a 2 MiB-to-8 MiB aggregate window, <=48 KiB output frames, <=256 KiB queued output per stream, and <=32 streams per connection (8 MiB aggregate pending output). The 64 MiB/viewer model gate requires >7 MiB/s/viewer at 100 ms RTT, <200 ms completion spread, and aggregate in-flight bytes <=8 MiB. The 2026-07-22 run modeled 9.7 MiB/s/viewer at 100 ms with eight viewers and measured @xterm/headless at 95.3 aggregate MiB/s, 336.0 ms parser CPU, and 28991 KiB retained heap for eight 4 MiB viewers."
+        "evidence": "Parsed/discarded credit uses 192 KiB/4 ms ACK batching, 512 KiB-to-2 MiB adaptive per-stream windows, a 2 MiB-to-8 MiB aggregate window, <=48 KiB output frames, <=256 KiB queued output per stream, and <=32 streams per connection (8 MiB aggregate pending output). Negotiated hidden paired streams add zero renderer output frames or scheduler drains after host ingestion; headed and headless six-stream runs enforce under 500 ms timer lag. The 64 MiB/viewer model gate requires >7 MiB/s/viewer at 100 ms RTT, <200 ms completion spread, and aggregate in-flight bytes <=8 MiB."
       },
       "promotionCriteria": [
         "Gate binary multiplex first.",

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -8579,17 +8579,23 @@ describe('OrcaRuntimeService', () => {
       expect(batches[0].seq).toBeLessThan(batches[1].seq)
     })
 
-    it('emits nothing for chunks without derived facts', () => {
+    it('emits only agent-status facts for status-only chunks', () => {
       const { runtime, batches } = createSideEffectRuntime()
       syncSinglePty(runtime)
 
-      // Plain output, a BEL-terminated non-title OSC split across chunks, and an Orca status payload — none is a title/bell/agent fact.
+      // Plain output and a BEL-terminated non-title OSC stay fact-free.
       runtime.onPtyData('pty-1', 'plain output\r\n', 100)
       runtime.onPtyData('pty-1', '\x1b]7;file://host', 101)
       runtime.onPtyData('pty-1', '/tmp\x07', 102)
       runtime.onPtyData('pty-1', '\x1b]9999;{"state":"working","agentType":"codex"}\x07', 103)
 
-      expect(batches).toEqual([])
+      expect(batches).toHaveLength(1)
+      expect(batches[0].facts).toEqual([
+        {
+          kind: 'agent-status',
+          payload: expect.objectContaining({ state: 'working', agentType: 'codex' })
+        }
+      ])
     })
 
     it('emits the stale-working-title rewrite as between-chunk fact batches', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1429,8 +1429,8 @@ type RuntimePtyTitleTrackerEntry = {
   lastMobileTitleGateKey: string | null
   chunkTouchedSessionTabs: boolean
   // Why: facts observed while applying a chunk are batched into one
-  // pty:sideEffect emission per chunk, preserving byte order (titles in
-  // sequence, then bell). Timer-fired facts emit immediately between chunks.
+  // pty:sideEffect emission per chunk, preserving status/title/bell order.
+  // Timer-fired facts emit immediately between chunks.
   pendingFacts: TerminalSideEffectFact[]
   // Why: Command Code lacks hooks, so its working/done state is scraped from
   // TUI output. Null when no side-effect consumer exists (headless serve) —
@@ -9198,6 +9198,9 @@ export class OrcaRuntimeService {
     titleTrackerEntry.chunkTouchedSessionTabs = false
     let retainedAgentStatusChanged = false
     try {
+      for (const payload of agentStatusChunk.payloads) {
+        titleTrackerEntry.pendingFacts.push({ kind: 'agent-status', payload })
+      }
       titleTrackerEntry.tracker.handleChunk(agentStatusChunk.cleanData, {
         titleScanData: titleInput
       })

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -130,6 +130,8 @@ type TerminalMultiplexStream = {
   sourceRangeReplacement: RemoteTerminalSourceRangeReplacementReservation | null
   ackInFlightBytes: number
   ackWindowBytes: number
+  supportsOutputPause: boolean
+  outputPaused: boolean
   supportsDesktopViewportClaims: boolean
   desktopClaimTail: Promise<boolean>
   // Whether THIS stream registered the width driver, so detach won't release a peer stream's floor.
@@ -1027,7 +1029,8 @@ const TerminalMultiplexSubscribeFrame = TerminalHandle.extend({
     .object({
       ackOutput: z.literal(1).optional(),
       ackOutputSourceRanges: z.literal(1).optional(),
-      desktopViewportClaims: z.literal(1).optional()
+      desktopViewportClaims: z.literal(1).optional(),
+      outputPause: z.literal(1).optional()
     })
     .optional()
 })
@@ -1721,7 +1724,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         stream: TerminalMultiplexStream,
         chunk: TerminalOutputFrameChunk
       ): void => {
-        if (closed || streams.get(stream.streamId) !== stream) {
+        if (closed || streams.get(stream.streamId) !== stream || stream.outputPaused) {
           return
         }
         if (
@@ -1738,6 +1741,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         if (
           closed ||
           streams.get(stream.streamId) !== stream ||
+          stream.outputPaused ||
           stream.ackRecoverySnapshotInFlight
         ) {
           return
@@ -1746,7 +1750,7 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         let replacement: RemoteTerminalSourceRangeReplacementReservation | null = null
         try {
           const serialized = await serializeBudgetedRequestedSnapshot(runtime, stream.ptyId, 0)
-          if (closed || streams.get(stream.streamId) !== stream) {
+          if (closed || streams.get(stream.streamId) !== stream || stream.outputPaused) {
             return
           }
           if (!serialized) {
@@ -1862,6 +1866,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         stream: TerminalMultiplexStream,
         maxChunks = Number.POSITIVE_INFINITY
       ): number => {
+        if (stream.outputPaused) {
+          return 0
+        }
         if (stream.ackPendingOutputOverflowed) {
           void sendAckRecoverySnapshot(stream)
           return 0
@@ -2110,6 +2117,20 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
               isMobile: stream.isMobile
             })
           })
+          return
+        }
+        if (frame.opcode === TerminalStreamOpcode.SetOutputPaused && stream.supportsOutputPause) {
+          const payload = decodeTerminalStreamJson<{ paused?: unknown }>(frame.payload)
+          if (typeof payload?.paused !== 'boolean' || stream.outputPaused === payload.paused) {
+            return
+          }
+          stream.outputPaused = payload.paused
+          if (stream.outputPaused) {
+            stream.outputBatcher.flush()
+            stream.ackPendingOutput = []
+            stream.ackPendingOutputBytes = 0
+            stream.ackPendingOutputOverflowed = false
+          }
           return
         }
         if (frame.opcode === TerminalStreamOpcode.Resize && stream.client) {
@@ -2430,6 +2451,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
           sourceRangeReplacement: null,
           ackInFlightBytes: 0,
           ackWindowBytes: TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES,
+          supportsOutputPause: request.capabilities?.outputPause === 1,
+          outputPaused: false,
           supportsDesktopViewportClaims: request.capabilities?.desktopViewportClaims === 1,
           desktopClaimTail: Promise.resolve(true),
           registeredRemoteDesktopDriver: false,
@@ -2474,6 +2497,9 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
         try {
           const unsubscribeStreamData = runtime.subscribeToTerminalData(ptyId, (data, meta) => {
             if (closed || streams.get(request.streamId) !== stream) {
+              return
+            }
+            if (stream.outputPaused) {
               return
             }
             if (stream.buffering) {
@@ -2554,12 +2580,13 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             rows: serialized?.rows ?? size?.rows,
             displayMode,
             seq: layoutSeq,
-            ...(stream.ackOutputSourceRanges
-              ? {
-                  streamGeneration: stream.streamGeneration,
-                  capabilities: { ackOutputSourceRanges: 1 as const }
-                }
-              : {}),
+            ...((stream.ackOutputSourceRanges || stream.supportsOutputPause) && {
+              capabilities: {
+                ...(stream.ackOutputSourceRanges ? { ackOutputSourceRanges: 1 as const } : {}),
+                ...(stream.supportsOutputPause ? { outputPause: 1 as const } : {})
+              }
+            }),
+            ...(stream.ackOutputSourceRanges ? { streamGeneration: stream.streamGeneration } : {}),
             // Why: retained-tail truncation loses history, not the authoritative latest-screen fallback.
             truncated: initialOutputOverflowed
           })

--- a/src/main/runtime/rpc/terminal-multiplex.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex.test.ts
@@ -21,6 +21,8 @@ import {
 } from '../../../shared/terminal-multiplex-flow-control'
 import { SshPtyOutputIntake, type SshPtyOutputDataEvent } from '../../ipc/ssh-pty-output-intake'
 
+const SET_OUTPUT_PAUSED_OPCODE = 16 as TerminalStreamOpcode
+
 function stubRuntime(overrides: Partial<OrcaRuntimeService> = {}): OrcaRuntimeService {
   const serializeAuthoritativeTerminalBuffer =
     overrides.serializeAuthoritativeTerminalBuffer ??
@@ -1316,6 +1318,170 @@ describe('terminal multiplex RPC', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('withholds sustained output from multiple paused desktop streams', async () => {
+    const listeners: ((data: string, meta?: RuntimeTerminalDataMeta) => void)[] = []
+    const harness = startDesktopMultiplexSubscribe({
+      subscribeToTerminalData: vi.fn((_ptyId, listener) => {
+        listeners.push(listener)
+        return vi.fn()
+      }),
+      serializeAuthoritativeTerminalBuffer: vi.fn().mockResolvedValue({
+        data: 'authoritative hidden snapshot',
+        cols: 120,
+        rows: 40,
+        seq: 7,
+        source: 'headless'
+      })
+    })
+    await vi.waitFor(() => expect(harness.handlers.has(0)).toBe(true))
+
+    for (const streamId of [1, 2, 3]) {
+      harness.handlers.get(0)?.(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.Subscribe,
+            streamId: 0,
+            seq: streamId,
+            payload: encodeTerminalStreamJson({
+              streamId,
+              terminal: `terminal-${streamId}`,
+              client: { id: `desktop-${streamId}`, type: 'desktop' },
+              capabilities: { ackOutput: 1, outputPause: 1 }
+            })
+          })
+        )!
+      )
+    }
+    await vi.waitFor(() =>
+      expect(
+        harness.messages.filter((message) => JSON.parse(message).result?.type === 'subscribed')
+      ).toHaveLength(3)
+    )
+    const pauseCapable = harness.messages
+      .map((message) => JSON.parse(message).result)
+      .filter((event) => event?.type === 'subscribed')
+      .every((event) => event.capabilities?.outputPause === 1)
+    if (pauseCapable) {
+      for (const streamId of [1, 2, 3]) {
+        harness.handlers.get(streamId)?.(
+          decodeTerminalStreamFrame(
+            encodeTerminalStreamFrame({
+              opcode: SET_OUTPUT_PAUSED_OPCODE,
+              streamId,
+              seq: 10,
+              payload: encodeTerminalStreamJson({ paused: true })
+            })
+          )!
+        )
+      }
+    }
+    harness.binaryFrames.splice(0)
+    const chunk = 'x'.repeat(64 * 1024)
+    for (let turn = 0; turn < 8; turn += 1) {
+      for (const listener of listeners) {
+        listener(chunk, { seq: (turn + 1) * chunk.length, rawLength: chunk.length })
+      }
+    }
+    expect(
+      harness.binaryFrames.some(
+        (bytes) => decodeTerminalStreamFrame(bytes)?.opcode === TerminalStreamOpcode.Output
+      )
+    ).toBe(false)
+    expect(pauseCapable).toBe(true)
+
+    harness.handlers.get(1)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: SET_OUTPUT_PAUSED_OPCODE,
+          streamId: 1,
+          seq: 11,
+          payload: encodeTerminalStreamJson({ paused: false })
+        })
+      )!
+    )
+    listeners[0]?.('VISIBLE_MARKER', { seq: 8 * chunk.length + 14, rawLength: 14 })
+    listeners[0]?.('y'.repeat(64 * 1024), {
+      seq: 9 * chunk.length + 14,
+      rawLength: 64 * 1024
+    })
+    expect(
+      harness.binaryFrames
+        .map(decodeTerminalStreamFrame)
+        .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+        .map((frame) => decodeTerminalStreamText(frame!.payload))
+        .join('')
+    ).toContain('VISIBLE_MARKER')
+
+    harness.cleanups.get('terminal-multiplex:conn-desktop-first-paint')?.()
+    await harness.dispatchPromise
+    expect(harness.handlers.size).toBe(0)
+  })
+
+  it('keeps output flowing when an older client does not negotiate pause', async () => {
+    const listeners: ((data: string, meta?: RuntimeTerminalDataMeta) => void)[] = []
+    const harness = startDesktopMultiplexSubscribe({
+      subscribeToTerminalData: vi.fn((_ptyId, nextListener) => {
+        listeners.push(nextListener)
+        return vi.fn()
+      })
+    })
+    await vi.waitFor(() => expect(harness.handlers.has(0)).toBe(true))
+
+    harness.handlers.get(0)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: TerminalStreamOpcode.Subscribe,
+          streamId: 0,
+          seq: 1,
+          payload: encodeTerminalStreamJson({
+            streamId: 1,
+            terminal: 'terminal-legacy-client',
+            client: { id: 'desktop-legacy', type: 'desktop' },
+            capabilities: { ackOutput: 1 }
+          })
+        })
+      )!
+    )
+    await vi.waitFor(() =>
+      expect(
+        harness.messages
+          .map((message) => JSON.parse(message).result)
+          .find((event) => event?.type === 'subscribed' && event.streamId === 1)
+      ).toMatchObject({ type: 'subscribed', streamId: 1 })
+    )
+    const subscribed = harness.messages
+      .map((message) => JSON.parse(message).result)
+      .find((event) => event?.type === 'subscribed' && event.streamId === 1)
+    expect(subscribed.capabilities?.outputPause).toBeUndefined()
+
+    harness.handlers.get(1)?.(
+      decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({
+          opcode: SET_OUTPUT_PAUSED_OPCODE,
+          streamId: 1,
+          seq: 2,
+          payload: encodeTerminalStreamJson({ paused: true })
+        })
+      )!
+    )
+    harness.binaryFrames.splice(0)
+    listeners[0]?.('LEGACY_VISIBLE'.padEnd(64 * 1024, 'x'), {
+      seq: 64 * 1024,
+      rawLength: 64 * 1024
+    })
+
+    expect(
+      harness.binaryFrames
+        .map(decodeTerminalStreamFrame)
+        .filter((frame) => frame?.opcode === TerminalStreamOpcode.Output)
+        .map((frame) => decodeTerminalStreamText(frame!.payload))
+        .join('')
+    ).toContain('LEGACY_VISIBLE')
+
+    harness.cleanups.get('terminal-multiplex:conn-desktop-first-paint')?.()
+    await harness.dispatchPromise
   })
 
   it('applies a viewer resize parked during a snapshot-request buffering window', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -305,6 +305,7 @@ type ConnectCallbacks = {
   onReplayData?: (data: string, meta?: { clearBeforeReplay?: boolean }) => void
   onError?: (msg: string) => void
   onWriteUnavailable?: () => void
+  onOutputPauseChanged?: (paused: boolean, supported: boolean) => void
 }
 
 type MockTransport = {
@@ -320,6 +321,7 @@ type MockTransport = {
   sendInputImmediate: ReturnType<typeof vi.fn>
   sendInputAccepted?: ReturnType<typeof vi.fn>
   claimViewport: ReturnType<typeof vi.fn>
+  setOutputPaused?: ReturnType<typeof vi.fn>
   resize: ReturnType<typeof vi.fn>
   getPtyId: ReturnType<typeof vi.fn>
   getConnectionId: ReturnType<typeof vi.fn>
@@ -14002,6 +14004,137 @@ describe('connectPanePty', () => {
     expect(pane.terminal.write).toHaveBeenCalledWith(hidden)
     expect(pane.terminal.write).toHaveBeenCalledWith(live, expect.any(Function))
     disposable.dispose()
+  })
+
+  it('pauses capable paired output while hidden and restores exactly on reveal', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const remotePtyId = 'remote:env-1@@terminal-1'
+    const transport = createMockTransport(remotePtyId)
+    let callbacks: ConnectCallbacks = {}
+    transport.connect.mockImplementation(async (options: { callbacks?: ConnectCallbacks }) => {
+      callbacks = options.callbacks ?? {}
+      return remotePtyId
+    })
+    transport.setOutputPaused = vi.fn((paused: boolean) => {
+      callbacks.onOutputPauseChanged?.(paused, true)
+      return true
+    })
+    const hidden = 'paired hidden flood\r\n'
+    const snapshot = 'paired snapshot with hidden flood\r\n'
+    const live = 'paired visible marker\r\n'
+    transport.serializeBuffer = vi.fn().mockResolvedValue({
+      data: snapshot,
+      cols: 100,
+      rows: 30,
+      seq: hidden.length,
+      source: 'headless'
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState.repos = [
+      { id: 'repo1', connectionId: null, displayName: 'orca', executionHostId: 'runtime:env-1' }
+    ]
+    mockStoreState.worktreesByRepo.repo1[0].runtimeOwnerEnvironmentId = 'env-1'
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const recordPaneMode2031Subscription = vi.fn()
+    const deps = createDeps({
+      isVisibleRef: { current: false },
+      recordPaneMode2031Subscription
+    })
+    const binding = connectPanePty(pane as never, manager as never, deps as never) as {
+      syncProcessTracking: () => void
+      dispose: () => void
+    }
+    await flushAsyncTicks(6)
+
+    expect(transport.setOutputPaused).toHaveBeenLastCalledWith(true)
+    expect(
+      (transport.sendInput as unknown as (data: string) => boolean)('hidden input marker')
+    ).toBe(true)
+    expect(transport.sendInput).toHaveBeenCalledWith('hidden input marker')
+    callbacks.onData?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(hidden, expect.any(Function))
+
+    const factsHandler = await import('./terminal-side-effect-facts-handler')
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    expect(createRemoteRuntimePtyTransport).toHaveBeenCalledWith('env-1', expect.any(Object))
+    mockStoreState.ptyIdsByTabId = { 'tab-1': [remotePtyId] }
+    mockStoreState.terminalLayoutsByTabId!['tab-1'].ptyIdsByLeafId = {
+      [LEAF_1]: remotePtyId
+    }
+    const visibleStatusHandler = createdTransportOptions[0]?.onAgentStatus as
+      | ((payload: { state: 'working'; prompt: string; agentType: 'claude' }) => void)
+      | undefined
+    expect(visibleStatusHandler).toBeTypeOf('function')
+    visibleStatusHandler?.({
+      state: 'working',
+      prompt: 'visible control',
+      agentType: 'claude'
+    })
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledTimes(1)
+    mockStoreState.setAgentStatus.mockClear()
+    factsHandler._dispatchTerminalSideEffectBatchForTest({
+      ptyId: remotePtyId,
+      seq: hidden.length,
+      facts: [
+        {
+          kind: 'agent-status',
+          payload: { state: 'working', prompt: 'paired task', agentType: 'claude' }
+        },
+        { kind: 'title', normalizedTitle: 'remote working', rawTitle: 'remote working' },
+        { kind: '2031-subscribe' }
+      ]
+    })
+    expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'remote working')
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledTimes(1)
+    expect(mockStoreState.setAgentStatus).toHaveBeenCalledWith(
+      makePaneKey('tab-1', LEAF_1),
+      { state: 'working', prompt: 'paired task', agentType: 'claude' },
+      undefined,
+      undefined,
+      { connectionId: null }
+    )
+    expect(transport.sendInput).toHaveBeenCalledWith(expect.stringContaining('\x1b['))
+    expect(recordPaneMode2031Subscription).toHaveBeenCalledWith(1, expect.any(String))
+    deps.paneMode2031Ref.current.set(1, true)
+    deps.paneLastThemeModeRef.current.set(1, 'dark')
+    factsHandler._dispatchTerminalSideEffectBatchForTest({
+      ptyId: remotePtyId,
+      seq: hidden.length + 1,
+      facts: [{ kind: '2031-unsubscribe' }]
+    })
+    expect(deps.paneMode2031Ref.current.has(1)).toBe(false)
+
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    binding.syncProcessTracking()
+    await flushAsyncTicks(20)
+
+    expect(transport.setOutputPaused).toHaveBeenLastCalledWith(false)
+    expect(transport.serializeBuffer).toHaveBeenCalledWith({ scrollbackRows: 5000 })
+    expect(transport.setOutputPaused.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      transport.serializeBuffer.mock.invocationCallOrder[0]
+    )
+    callbacks.onData?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+    const written = pane.terminal.write.mock.calls.map((call) => String(call[0])).join('')
+    const countWritten = (marker: string): number => written.split(marker).length - 1
+    expect(countWritten(snapshot)).toBe(1)
+    expect(countWritten(live)).toBe(1)
+    expect(countWritten(hidden)).toBe(0)
+
+    binding.dispose()
+    expect(transport.setOutputPaused).toHaveBeenLastCalledWith(false)
+    deps.setRuntimePaneTitle.mockClear()
+    factsHandler._dispatchTerminalSideEffectBatchForTest({
+      ptyId: remotePtyId,
+      seq: hidden.length + live.length + 1,
+      facts: [{ kind: 'title', normalizedTitle: 'stale', rawTitle: 'stale' }]
+    })
+    expect(deps.setRuntimePaneTitle).not.toHaveBeenCalled()
   })
 
   it('restores overflowed hidden remote runtime output from its serialized snapshot', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -36,7 +36,7 @@ import {
 import { serializeWithAbsoluteCursor } from '../../../../shared/terminal-serialize-absolute-cursor'
 import { isTerminalQueryReply } from '../../../../shared/terminal-query-reply'
 import type { PtyBufferSnapshot, PtyConnectResult } from './pty-transport'
-import type { PtyTransportRecoveryState } from './pty-transport-types'
+import type { IpcPtyTransportOptions, PtyTransportRecoveryState } from './pty-transport-types'
 import { createIpcPtyTransport } from './pty-transport'
 import { createRemoteRuntimePtyTransport } from './remote-runtime-pty-transport'
 import { toAgentLaunchPreferences } from '@/runtime/agent-session-create-operation'
@@ -1098,6 +1098,11 @@ export function connectPanePty(
   // flips, exit, dispose) run before/after it exists, so start with no-ops.
   let syncHiddenRendererPtyDelivery: () => void = () => {}
   let releaseHiddenRendererPtyDelivery: () => void = () => {}
+  let handleRemoteOutputPauseChanged: (paused: boolean, supported: boolean) => void = () => {}
+  let handleRendererOwnedAgentStatus: NonNullable<
+    IpcPtyTransportOptions['onAgentStatus']
+  > = () => {}
+  let remoteOutputPausedPtyId: string | null = null
   let suppressViewportClaimTerminalResize = false
   // Why: idle callbacks are registered before the deferred PTY output plumbing
   // exists. Start with the shared scheduler, then switch to the PTY writer
@@ -2285,8 +2290,11 @@ export function connectPanePty(
   // restoreTitleOnRegister replaces the eager-replay title restore: main's
   // title-only snapshot carries the no-attention-replay rule.
   let unregisterSideEffectFactConsumer: (() => void) | null = null
-  const registerSideEffectFactConsumerForPty = (ptyId: string): void => {
-    if (!mainSideEffectAuthority || disposed) {
+  const registerSideEffectFactConsumerForPty = (
+    ptyId: string,
+    remoteOutputPaused = false
+  ): void => {
+    if ((!mainSideEffectAuthority && !remoteOutputPaused) || disposed) {
       return
     }
     unregisterSideEffectFactConsumer?.()
@@ -2306,9 +2314,12 @@ export function connectPanePty(
         // renderer seeds also write), so main only emits scrape facts.
         onCommandCodeWorking: seedCommandCodeOutputWorkingStatus,
         onCommandCodeDone: scheduleCommandCodeOutputDoneStatus,
+        ...(shouldOwnAgentStatusInRenderer
+          ? { onAgentStatus: (payload) => handleRendererOwnedAgentStatus(payload) }
+          : {}),
         // Why: gated hidden panes never see the subscribe bytes; the fact
         // replaces the byte scan (and the old post-latch subscribe drop).
-        ...(hiddenDeliveryGateActive
+        ...(hiddenDeliveryGateActive || remoteOutputPaused
           ? {
               onMode2031Subscribe: handleHiddenMode2031SubscribeFact,
               onMode2031Unsubscribe: handleHiddenMode2031UnsubscribeFact
@@ -3553,6 +3564,53 @@ export function connectPanePty(
         })
       : undefined
   const shouldOwnAgentStatusInRenderer = runtimeEnvironmentId !== null
+  handleRendererOwnedAgentStatus = (payload): void => {
+    if (
+      shouldSuppressCodexAutoApprovalStatus(payload, {
+        paneKey: cacheKey,
+        tabId: deps.tabId,
+        ...(launchToken ? { launchToken } : {})
+      })
+    ) {
+      return
+    }
+    const currentState = useAppStore.getState()
+    const routing = resolveCurrentAgentStatusRouting()
+    if (!routing) {
+      return
+    }
+    const title = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
+    const authoritativePaneAgent = getAuthoritativePaneAgent()
+    const agentType = resolveCompatibleAgentTypeForOwner(payload.agentType, authoritativePaneAgent)
+    const statusPayload = agentType === payload.agentType ? payload : { ...payload, agentType }
+    const resolvedStatusTitle = resolveAgentStatusTerminalTitle(statusPayload, title)
+    const statusTitle = resolvedStatusTitle
+      ? normalizeCompatibleAgentTitleForOwner(
+          resolvedStatusTitle,
+          agentType ?? authoritativePaneAgent
+        )
+      : resolvedStatusTitle
+    if (launchToken) {
+      currentState.setAgentStatus(cacheKey, statusPayload, statusTitle, undefined, routing, {
+        launchToken
+      })
+    } else {
+      currentState.setAgentStatus(cacheKey, statusPayload, statusTitle, undefined, routing)
+    }
+    if (payload.state === 'working' && syncAgentTaskCompleteTrackingEnabled()) {
+      requiresFreshWorkingForAgentTaskCompleteNotification = false
+    }
+    const storedStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]
+    const notificationPayload =
+      typeof storedStatus?.stateStartedAt === 'number'
+        ? { ...statusPayload, stateStartedAt: storedStatus.stateStartedAt }
+        : statusPayload
+    // Why: hook lifecycle owns deferred side effects even when alerts are disabled.
+    agentCompletionCoordinator.observeHookStatus(notificationPayload)
+    if (payload.state === 'working' && pendingTerminalBellNotification) {
+      scheduleTerminalBellNotification()
+    }
+  }
   // Why: when main holds side-effect authority for this PTY's bytes, the
   // transport must NOT register title/bell/agent byte parsers — the
   // pty:sideEffect fact consumer below is the single policy consumer.
@@ -3699,75 +3757,7 @@ export function connectPanePty(
     // parses OSC 9999 before renderer delivery and forwards through the hook
     // server with local/SSH identity. Remote-runtime streams do not pass through
     // local main, so the renderer remains their status owner for now.
-    ...(shouldOwnAgentStatusInRenderer
-      ? {
-          onAgentStatus: (payload) => {
-            if (
-              shouldSuppressCodexAutoApprovalStatus(payload, {
-                paneKey: cacheKey,
-                tabId: deps.tabId,
-                ...(launchToken ? { launchToken } : {})
-              })
-            ) {
-              return
-            }
-            // Why: capture the store snapshot once so the title lookup and the
-            // setAgentStatus call observe the same state. Re-reading getState()
-            // between the two lines opens a brief window where the title could
-            // shift (OSC title update landing in between) and the status would
-            // be stored against a title that was never paired with it.
-            const currentState = useAppStore.getState()
-            const routing = resolveCurrentAgentStatusRouting()
-            if (!routing) {
-              return
-            }
-            const title = currentState.runtimePaneTitlesByTabId?.[deps.tabId]?.[pane.id]
-            const authoritativePaneAgent = getAuthoritativePaneAgent()
-            const agentType = resolveCompatibleAgentTypeForOwner(
-              payload.agentType,
-              authoritativePaneAgent
-            )
-            const statusPayload =
-              agentType === payload.agentType ? payload : { ...payload, agentType }
-            const resolvedStatusTitle = resolveAgentStatusTerminalTitle(statusPayload, title)
-            const statusTitle = resolvedStatusTitle
-              ? normalizeCompatibleAgentTitleForOwner(
-                  resolvedStatusTitle,
-                  agentType ?? authoritativePaneAgent
-                )
-              : resolvedStatusTitle
-            if (launchToken) {
-              currentState.setAgentStatus(
-                cacheKey,
-                statusPayload,
-                statusTitle,
-                undefined,
-                routing,
-                {
-                  launchToken
-                }
-              )
-            } else {
-              currentState.setAgentStatus(cacheKey, statusPayload, statusTitle, undefined, routing)
-            }
-            const trackingEnabled = syncAgentTaskCompleteTrackingEnabled()
-            if (payload.state === 'working' && trackingEnabled) {
-              requiresFreshWorkingForAgentTaskCompleteNotification = false
-            }
-            const storedStatus = useAppStore.getState().agentStatusByPaneKey[cacheKey]
-            const notificationPayload =
-              typeof storedStatus?.stateStartedAt === 'number'
-                ? { ...statusPayload, stateStartedAt: storedStatus.stateStartedAt }
-                : statusPayload
-            // Why: hook lifecycle owns deferred terminal side effects even when
-            // every outward completion alert consumer is disabled.
-            agentCompletionCoordinator.observeHookStatus(notificationPayload)
-            if (payload.state === 'working' && pendingTerminalBellNotification) {
-              scheduleTerminalBellNotification()
-            }
-          }
-        }
-      : {})
+    ...(shouldOwnAgentStatusInRenderer ? { onAgentStatus: handleRendererOwnedAgentStatus } : {})
   }
   if (connectionOwnerHydrating) {
     // Why: this pane holds an inert transport until its host resolves; register it so
@@ -3800,7 +3790,8 @@ export function connectPanePty(
   // skipped-byte scan are disabled for these panes (same structural
   // predicate), so exactly one reply goes out.
   const handleHiddenMode2031SubscribeFact = (): void => {
-    if (disposed || !isHiddenDeliveryGateManagedPty(transport.getPtyId())) {
+    const ptyId = transport.getPtyId()
+    if (disposed || (!isHiddenDeliveryGateManagedPty(ptyId) && remoteOutputPausedPtyId !== ptyId)) {
       return
     }
     const mode = resolveTerminalColorSchemeMode(
@@ -3824,7 +3815,8 @@ export function connectPanePty(
   // into the shell that replaced it (#9993 via maybePushMode2031Flip). No reply is
   // sent: a withdrawal is not a query.
   const handleHiddenMode2031UnsubscribeFact = (): void => {
-    if (disposed || !isHiddenDeliveryGateManagedPty(transport.getPtyId())) {
+    const ptyId = transport.getPtyId()
+    if (disposed || (!isHiddenDeliveryGateManagedPty(ptyId) && remoteOutputPausedPtyId !== ptyId)) {
       return
     }
     deps.paneMode2031Ref.current.delete(pane.id)
@@ -5720,6 +5712,11 @@ export function connectPanePty(
               pane.container.dataset.ptyRecoveryState = state.phase
               deps.onPtyRecoveryStateRef?.current?.(pane.id, state)
             }
+          },
+          onOutputPauseChanged: (paused: boolean, supported: boolean): void => {
+            if (isCurrent()) {
+              handleRemoteOutputPauseChanged(paused, supported)
+            }
           }
         }
       }
@@ -5975,9 +5972,45 @@ export function connectPanePty(
       )
     }
 
+    handleRemoteOutputPauseChanged = (paused, supported): void => {
+      const ptyId = transport.getPtyId()
+      if (!ptyId || !isRemoteRuntimePtyId(ptyId)) {
+        return
+      }
+      if (!supported || !paused) {
+        if (remoteOutputPausedPtyId === ptyId) {
+          remoteOutputPausedPtyId = null
+          if (!mainSideEffectAuthority) {
+            dropSideEffectFactConsumer()
+          }
+        }
+        if (supported && !paused && hiddenOutputRestorePtyId === ptyId) {
+          requestHiddenOutputRestoreIfNeeded()
+        }
+        return
+      }
+      if (remoteOutputPausedPtyId !== ptyId) {
+        remoteOutputPausedPtyId = ptyId
+        registerSideEffectFactConsumerForPty(ptyId, true)
+      }
+      markHiddenOutputRestoreNeeded()
+    }
+
     syncHiddenRendererPtyDelivery = (): void => {
       const ptyId = transport.getPtyId()
       syncModelRestoreNeededSubscription(ptyId)
+      if (remoteOutputPausedPtyId !== null && remoteOutputPausedPtyId !== ptyId) {
+        remoteOutputPausedPtyId = null
+        if (!mainSideEffectAuthority) {
+          dropSideEffectFactConsumer()
+        }
+      }
+      if (isRemoteRuntimePtyId(ptyId) && canUseHiddenOutputSnapshot(ptyId)) {
+        transport.setOutputPaused?.(
+          !disposed && !shouldWritePtyOutputForeground(deps.isVisibleRef.current)
+        )
+        return
+      }
       if (hiddenDeliverySyncedPtyId !== null && hiddenDeliverySyncedPtyId !== ptyId) {
         releaseHiddenDeliveryClaim?.()
         releaseHiddenDeliveryClaim = null
@@ -6002,6 +6035,13 @@ export function connectPanePty(
       }
     }
     releaseHiddenRendererPtyDelivery = (): void => {
+      transport.setOutputPaused?.(false)
+      if (remoteOutputPausedPtyId !== null) {
+        remoteOutputPausedPtyId = null
+        if (!mainSideEffectAuthority) {
+          dropSideEffectFactConsumer()
+        }
+      }
       releaseHiddenDeliveryClaim?.()
       releaseHiddenDeliveryClaim = null
       hiddenDeliverySyncedPtyId = null
@@ -6292,10 +6332,11 @@ export function connectPanePty(
     }
 
     function shouldSkipHiddenRendererOutput(foreground: boolean, data: string): boolean {
+      const ptyId = transport.getPtyId()
       if (
         foreground ||
-        !shouldSnapshotHiddenCodexOutput ||
-        !canUseHiddenOutputSnapshot(transport.getPtyId())
+        (!shouldSnapshotHiddenCodexOutput && remoteOutputPausedPtyId !== ptyId) ||
+        !canUseHiddenOutputSnapshot(ptyId)
       ) {
         return false
       }

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -84,6 +84,7 @@ type PtyCallbacks = {
   onExit?: (code: number) => void
   onWriteUnavailable?: () => void
   onRecoveryStateChange?: (state: PtyTransportRecoveryState) => void
+  onOutputPauseChanged?: (paused: boolean, supported: boolean) => void
 }
 
 export type PtyTransportRecoveryState = {
@@ -141,6 +142,8 @@ export type PtyTransport = {
   sendInputImmediate: (data: string) => boolean
   sendInputAccepted?: (data: string) => Promise<boolean>
   claimViewport?: (cols: number, rows: number) => boolean
+  /** Capability-negotiated paired-runtime delivery gate; false preserves legacy delivery. */
+  setOutputPaused?: (paused: boolean) => boolean
   resize: (
     cols: number,
     rows: number,

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts
@@ -226,7 +226,8 @@ describe('createRemoteRuntimePtyTransport', () => {
       expect(latestSubscribePayload().capabilities).toEqual({
         ackOutput: 1,
         ackOutputSourceRanges: 1,
-        desktopViewportClaims: 1
+        desktopViewportClaims: 1,
+        outputPause: 1
       })
     )
     expect(runtimeSubscribe).toHaveBeenCalledWith(
@@ -3521,6 +3522,80 @@ describe('createRemoteRuntimePtyTransport', () => {
     expect(onPtyExit).not.toHaveBeenCalled()
     expect(onError).not.toHaveBeenCalled()
     await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+  })
+
+  it('reapplies negotiated output pause across reconnect and resumes exact snapshot plus live data', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onReplayData = vi.fn()
+    const onData = vi.fn()
+    const onOutputPauseChanged = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'pane:1'
+    })
+
+    await transport.connect({
+      url: '',
+      callbacks: { onData, onReplayData, onOutputPauseChanged }
+    })
+    await vi.waitFor(() => expect(subscriptionSendBinary).toHaveBeenCalled())
+    expect(transport.setOutputPaused?.(true)).toBe(false)
+    const firstStreamId = latestSubscribePayload().streamId
+    emitSnapshot(firstStreamId, 'INITIAL_SNAPSHOT')
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'subscribed',
+        streamId: firstStreamId,
+        capabilities: { outputPause: 1 }
+      }
+    })
+    await vi.waitFor(() =>
+      expect(
+        decodeTerminalStreamJson<{ paused?: boolean }>(
+          latestFrameForOpcode(TerminalStreamOpcode.SetOutputPaused)!.payload
+        )
+      ).toEqual({ paused: true })
+    )
+
+    subscriptionCallbacks?.onClose?.()
+    await vi.waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() =>
+      expect(
+        subscriptionSendBinary.mock.calls
+          .map((call) => decodeTerminalStreamFrame(call[0]))
+          .filter((frame) => frame?.opcode === TerminalStreamOpcode.Subscribe)
+      ).toHaveLength(2)
+    )
+    const reconnectStreamId = latestSubscribePayload().streamId
+    emitSnapshot(reconnectStreamId, 'RECONNECT_SNAPSHOT')
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'subscribed',
+        streamId: reconnectStreamId,
+        capabilities: { outputPause: 1 }
+      }
+    })
+    await vi.waitFor(() =>
+      expect(
+        subscriptionSendBinary.mock.calls
+          .map((call) => decodeTerminalStreamFrame(call[0]))
+          .filter((frame) => frame?.opcode === TerminalStreamOpcode.SetOutputPaused)
+          .map((frame) => decodeTerminalStreamJson<{ paused?: boolean }>(frame!.payload))
+      ).toEqual([{ paused: true }, { paused: true }])
+    )
+
+    expect(transport.setOutputPaused?.(false)).toBe(true)
+    emitOutput(reconnectStreamId, 'LIVE_AFTER_RECONNECT')
+    expect(onReplayData.mock.calls.map((call) => call[0])).toEqual([
+      'INITIAL_SNAPSHOT',
+      'RECONNECT_SNAPSHOT'
+    ])
+    expect(onData.mock.calls.map((call) => call[0])).toEqual(['LIVE_AFTER_RECONNECT'])
+    expect(onOutputPauseChanged).toHaveBeenLastCalledWith(false, true)
+    transport.destroy?.()
   })
 
   it('backs off before retrying a capacity-rejected terminal stream', async () => {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -157,6 +157,7 @@ export function createRemoteRuntimePtyTransport(
   const runtimeEnvironmentPairingRevision = getRuntimeEnvironmentRevision(runtimeEnvironmentId)
   let multiplexedStream: RemoteRuntimeMultiplexedTerminal | null = null
   let multiplexedStreamHandle: string | null = null
+  let desiredOutputPaused = false
   let desiredViewport: { cols: number; rows: number } | null = null
   let storedCallbacks: Parameters<PtyTransport['connect']>[0]['callbacks'] = {}
   let resubscribeEpoch: number | null = null
@@ -1478,10 +1479,22 @@ export function createRemoteRuntimePtyTransport(
             })
           }
         },
+        onOutputPauseCapability: () => {
+          if (isCurrentSubscription()) {
+            storedCallbacks.onOutputPauseChanged?.(
+              desiredOutputPaused,
+              nextStream.setOutputPaused(desiredOutputPaused)
+            )
+          }
+        },
         onSubscribed: () => {
           if (!isCurrentSubscription()) {
             return
           }
+          storedCallbacks.onOutputPauseChanged?.(
+            desiredOutputPaused,
+            nextStream.setOutputPaused(desiredOutputPaused)
+          )
           subscriptionAttached = true
           setAttachmentReady(true)
           connecting = false
@@ -2038,6 +2051,16 @@ export function createRemoteRuntimePtyTransport(
       viewportBatcher.clear()
       sendViewportUpdate(cols, rows, true)
       return true
+    },
+
+    setOutputPaused(paused: boolean): boolean {
+      desiredOutputPaused = paused
+      if (!connected || !handle) {
+        return false
+      }
+      const supported = getCurrentMultiplexedStream(handle)?.setOutputPaused(paused) === true
+      storedCallbacks.onOutputPauseChanged?.(paused, supported)
+      return supported
     },
 
     resize(cols: number, rows: number, meta): boolean {

--- a/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.test.ts
@@ -152,10 +152,20 @@ describe('registerTerminalSideEffectFactConsumer', () => {
 
   it('routes live facts to the registered consumer in batch order', () => {
     const { callbacks, events } = createCallbackRecorder()
-    registerTerminalSideEffectFactConsumer({ ptyId: PTY_ID, callbacks })
+    registerTerminalSideEffectFactConsumer({
+      ptyId: PTY_ID,
+      callbacks: {
+        ...callbacks,
+        onAgentStatus: (payload) => events.push(['status', payload.state, payload.agentType])
+      }
+    })
 
     _dispatchTerminalSideEffectBatchForTest(
       batch([
+        {
+          kind: 'agent-status',
+          payload: { state: 'working', prompt: 'fix it', agentType: 'codex' }
+        },
         { kind: 'title', normalizedTitle: '⠋ Claude', rawTitle: '⠋ Claude' },
         { kind: 'agent-working' },
         { kind: 'title', normalizedTitle: '✳ Claude', rawTitle: '✳ Claude' },
@@ -165,6 +175,7 @@ describe('registerTerminalSideEffectFactConsumer', () => {
     )
 
     expect(events).toEqual([
+      ['status', 'working', 'codex'],
       ['title', '⠋ Claude', '⠋ Claude'],
       ['working'],
       ['title', '✳ Claude', '✳ Claude'],

--- a/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-side-effect-facts-handler.ts
@@ -13,6 +13,7 @@
  * is a PTY whose consumer just unregistered: see the handoff buffer below.
  */
 import type { GlobalSettings } from '../../../../shared/types'
+import type { ParsedAgentStatusPayload } from '../../../../shared/agent-status-types'
 import type { TerminalGitHubPRLink } from '../../../../shared/terminal-github-pr-link-detector'
 import type {
   TerminalSideEffectBatch,
@@ -63,6 +64,7 @@ export function isMainTerminalSideEffectAuthorityForPty(args: {
 }
 
 export type TerminalSideEffectFactConsumerCallbacks = {
+  onAgentStatus?: (payload: ParsedAgentStatusPayload) => void
   /** `meta.staleWorkingTitleClear` marks facts derived from main's 3s
    *  stale-title timer — policy must clear title/cache state without
    *  scheduling task-complete notifications or unread attention. */
@@ -104,6 +106,9 @@ let channelUnsubscribe: (() => void) | null = null
 
 function applyLiveFact(entry: ConsumerEntry, fact: TerminalSideEffectFact, seq: number): void {
   switch (fact.kind) {
+    case 'agent-status':
+      entry.callbacks.onAgentStatus?.(fact.payload)
+      return
     case 'title':
       entry.lastLiveTitleSeq = seq
       entry.callbacks.onTitleChange?.(

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -36,7 +36,7 @@ type TerminalMultiplexEvent =
       type: 'subscribed'
       streamId: number
       streamGeneration?: string
-      capabilities?: { ackOutputSourceRanges?: 1 }
+      capabilities?: { ackOutputSourceRanges?: 1; outputPause?: 1 }
     }
   | { type: 'end'; streamId: number }
   | { type: 'error'; streamId: number; message?: string }
@@ -58,6 +58,7 @@ export type RemoteRuntimeMultiplexedTerminalCallbacks = {
   onData: (data: string, meta?: { seq?: number; rawLength?: number; transformed?: boolean }) => void
   onSnapshot: (data: string, meta?: { pendingEscapeTailAnsi?: string }) => void
   onSubscribed?: () => void
+  onOutputPauseCapability?: () => void
   onEnd?: () => void
   onError?: (message: string) => void
   onFitOverrideChanged?: (event: {
@@ -76,6 +77,7 @@ export type RemoteRuntimeMultiplexedTerminal = {
   sendInput: (text: string) => boolean
   resize: (cols: number, rows: number) => boolean
   claimViewport: (cols: number, rows: number) => boolean
+  setOutputPaused: (paused: boolean) => boolean
   serializeBuffer: (opts?: { scrollbackRows?: number }) => Promise<{
     data: string
     cols: number
@@ -93,6 +95,8 @@ type RemoteRuntimeMultiplexedTerminalState = {
   subscriptionRequested: boolean
   acknowledgeOutput: boolean
   acknowledgeOutputSourceRanges: boolean
+  supportsOutputPause: boolean
+  outputPaused: boolean
   streamGeneration: string | null
   sourceAckedEndByte: number
   heldAckBytes: number
@@ -320,6 +324,8 @@ class RemoteRuntimeTerminalMultiplexer {
       subscriptionRequested: false,
       acknowledgeOutput: true,
       acknowledgeOutputSourceRanges: false,
+      supportsOutputPause: false,
+      outputPaused: false,
       streamGeneration: null,
       sourceAckedEndByte: 0,
       heldAckBytes: 0,
@@ -391,6 +397,7 @@ class RemoteRuntimeTerminalMultiplexer {
         )
         return claimed && resized
       },
+      setOutputPaused: (paused) => this.setOutputPaused(state, paused),
       serializeBuffer: (opts) => this.requestSnapshot(state, opts),
       close: () => {
         if (this.streams.get(streamId) === state) {
@@ -421,6 +428,7 @@ class RemoteRuntimeTerminalMultiplexer {
           capabilities: {
             ackOutput: 1,
             ackOutputSourceRanges: 1,
+            outputPause: 1,
             ...(args.client.type === 'desktop' ? { desktopViewportClaims: 1 } : {})
           }
         })
@@ -539,7 +547,7 @@ class RemoteRuntimeTerminalMultiplexer {
     if (event.type === 'subscribed') {
       const capabilities =
         typeof event.capabilities === 'object' && event.capabilities !== null
-          ? (event.capabilities as { ackOutputSourceRanges?: unknown })
+          ? (event.capabilities as { ackOutputSourceRanges?: unknown; outputPause?: unknown })
           : null
       if (
         capabilities?.ackOutputSourceRanges === 1 &&
@@ -548,6 +556,10 @@ class RemoteRuntimeTerminalMultiplexer {
       ) {
         stream.acknowledgeOutputSourceRanges = true
         stream.streamGeneration = event.streamGeneration
+      }
+      stream.supportsOutputPause = capabilities?.outputPause === 1
+      if (stream.supportsOutputPause) {
+        stream.callbacks.onOutputPauseCapability?.()
       }
     } else if (event.type === 'end') {
       discardOutputAcknowledgements(stream)
@@ -1043,8 +1055,26 @@ class RemoteRuntimeTerminalMultiplexer {
       TerminalStreamOpcode.Input,
       encodeTerminalStreamText(text)
     )
-    if (sent) {
+    if (sent && !stream.outputPaused) {
       stream.watchdog.recordCommandInput(text)
+    }
+    return sent
+  }
+
+  private setOutputPaused(stream: RemoteRuntimeMultiplexedTerminalState, paused: boolean): boolean {
+    if (!stream.supportsOutputPause || this.streams.get(stream.streamId) !== stream) {
+      return false
+    }
+    if (stream.outputPaused === paused) {
+      return true
+    }
+    const sent = this.sendFrame(
+      stream.streamId,
+      TerminalStreamOpcode.SetOutputPaused,
+      encodeTerminalStreamJson({ paused })
+    )
+    if (sent) {
+      stream.outputPaused = paused
     }
     return sent
   }

--- a/src/renderer/src/runtime/remote-runtime-terminal-parse-backpressure.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-parse-backpressure.test.ts
@@ -157,6 +157,71 @@ describe('remote terminal renderer backpressure', () => {
     stream.close()
   })
 
+  it('pauses output only after the host confirms the stream capability', async () => {
+    const { getRemoteRuntimeTerminalMultiplexer } =
+      await import('./remote-runtime-terminal-multiplexer')
+    const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
+      terminal: 'term-hidden',
+      client: { id: 'mac-viewer', type: 'desktop' },
+      callbacks: { onData: vi.fn(), onSnapshot: vi.fn() }
+    })
+    sendBinary.mockClear()
+
+    expect(stream.setOutputPaused(true)).toBe(false)
+    expect(sentOpcodes()).not.toContain(TerminalStreamOpcode.SetOutputPaused)
+
+    callbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'subscribed',
+        streamId: stream.streamId,
+        capabilities: { outputPause: 1 }
+      }
+    })
+
+    expect(stream.setOutputPaused(true)).toBe(true)
+    expect(sentOpcodes()).toEqual([TerminalStreamOpcode.SetOutputPaused])
+    expect(
+      decodeTerminalStreamJson<{ paused?: boolean }>(
+        decodeTerminalStreamFrame(sendBinary.mock.calls[0]![0])!.payload
+      )
+    ).toEqual({ paused: true })
+    expect(stream.setOutputPaused(true)).toBe(true)
+    expect(sentOpcodes()).toEqual([TerminalStreamOpcode.SetOutputPaused])
+    stream.close()
+  })
+
+  it('keeps paused input immediate without arming a hidden-output probe', async () => {
+    vi.useFakeTimers()
+    try {
+      const { getRemoteRuntimeTerminalMultiplexer } =
+        await import('./remote-runtime-terminal-multiplexer')
+      const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
+        terminal: 'term-hidden-input',
+        client: { id: 'mac-viewer', type: 'desktop' },
+        callbacks: { onData: vi.fn(), onSnapshot: vi.fn() }
+      })
+      callbacks?.onResponse({
+        ok: true,
+        result: {
+          type: 'subscribed',
+          streamId: stream.streamId,
+          capabilities: { outputPause: 1 }
+        }
+      })
+      expect(stream.setOutputPaused(true)).toBe(true)
+      sendBinary.mockClear()
+
+      expect(stream.sendInput('\r')).toBe(true)
+      await vi.advanceTimersByTimeAsync(10_000)
+
+      expect(sentOpcodes()).toEqual([TerminalStreamOpcode.Input])
+      stream.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('releases unknown streams and closes malformed connections instead of leaking credit', async () => {
     const { getRemoteRuntimeTerminalMultiplexer } =
       await import('./remote-runtime-terminal-multiplexer')
@@ -370,6 +435,13 @@ describe('remote terminal renderer backpressure', () => {
       }
       const payload = decodeTerminalStreamJson<{ bytes?: number }>(frame.payload)
       return typeof payload?.bytes === 'number' ? [payload.bytes] : []
+    })
+  }
+
+  function sentOpcodes(): TerminalStreamOpcode[] {
+    return sendBinary.mock.calls.flatMap(([bytes]) => {
+      const opcode = decodeTerminalStreamFrame(bytes)?.opcode
+      return opcode === undefined ? [] : [opcode]
     })
   }
 })

--- a/src/renderer/src/runtime/runtime-terminal-stream.test.ts
+++ b/src/renderer/src/runtime/runtime-terminal-stream.test.ts
@@ -112,7 +112,8 @@ describe('remote runtime terminal data subscriptions', () => {
     expect(subscribePayload?.capabilities).toEqual({
       ackOutput: 1,
       ackOutputSourceRanges: 1,
-      desktopViewportClaims: 1
+      desktopViewportClaims: 1,
+      outputPause: 1
     })
 
     callbacks?.onBinary?.(

--- a/src/shared/terminal-side-effect-facts.ts
+++ b/src/shared/terminal-side-effect-facts.ts
@@ -5,6 +5,7 @@
  * renderer store handler owns notification/unread policy.
  */
 
+import type { ParsedAgentStatusPayload } from './agent-status-types'
 import type { TerminalGitHubPRLink } from './terminal-github-pr-link-detector'
 
 /** Why tagged: stale-clear facts come from main's unthrottled 3s timer, not
@@ -12,6 +13,7 @@ import type { TerminalGitHubPRLink } from './terminal-github-pr-link-detector'
  *  must not schedule task-complete notifications or unread attention — a
  *  merely-paused agent (>3s silent mid-task) is not a completion. */
 export type TerminalSideEffectFact =
+  | { kind: 'agent-status'; payload: ParsedAgentStatusPayload }
   | { kind: 'title'; normalizedTitle: string; rawTitle: string; staleWorkingTitleClear?: boolean }
   | { kind: 'bell' }
   | { kind: 'agent-working' }
@@ -43,7 +45,7 @@ export type TerminalSideEffectBatch = {
    *  their title state was current at, so the handler can drop a replay title
    *  older than the last live title fact it applied. */
   seq: number
-  /** Facts from one chunk, in byte order: titles in sequence, then bell.
+  /** Facts from one chunk, in byte order: agent status, titles, then bell.
    *  Command Code scrape facts trail the chunk's parser facts — their policy
    *  (status-row seeding) never interacts with title/bell ordering. */
   facts: TerminalSideEffectFact[]

--- a/src/shared/terminal-stream-protocol.ts
+++ b/src/shared/terminal-stream-protocol.ts
@@ -28,7 +28,9 @@ export enum TerminalStreamOpcode {
   // Why 14: Ack already occupies 13 on current clients; older runtimes ignore
   // this opcode and still receive the compatibility Resize frame behind it.
   ClaimViewport = 14,
-  OutputSpan = 15
+  OutputSpan = 15,
+  // Negotiated per stream; older hosts reject unknown opcodes, so clients send only after capability confirmation.
+  SetOutputPaused = 16
 }
 
 export type TerminalStreamFrame = {
@@ -116,6 +118,7 @@ function isTerminalStreamOpcode(value: number): value is TerminalStreamOpcode {
     value === TerminalStreamOpcode.Metadata ||
     value === TerminalStreamOpcode.Ack ||
     value === TerminalStreamOpcode.ClaimViewport ||
-    value === TerminalStreamOpcode.OutputSpan
+    value === TerminalStreamOpcode.OutputSpan ||
+    value === TerminalStreamOpcode.SetOutputPaused
   )
 }

--- a/tests/e2e/helpers/paired-terminal-hidden-output-oracle.ts
+++ b/tests/e2e/helpers/paired-terminal-hidden-output-oracle.ts
@@ -1,0 +1,113 @@
+import type { Page } from '@stablyai/playwright-test'
+import type { RuntimeTerminalRead } from '../../../src/shared/runtime-types'
+import { startRendererLagProbe } from '../paired-runtime-retention-metrics'
+import { expect } from './orca-app'
+
+const MAX_HIDDEN_FLOOD_LAG_MS = 500
+
+type HiddenPairedTerminal = {
+  tabId: string
+  terminal: string
+}
+
+async function callRuntime<TResult>(page: Page, method: string, params: unknown): Promise<TResult> {
+  return page.evaluate(
+    async ({ method, params }) => {
+      const response = await window.api.runtime.call({ method, params })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { method, params }
+  ) as Promise<TResult>
+}
+
+export async function verifyHiddenPairedTerminalOutputSuppression(
+  page: Page,
+  terminals: HiddenPairedTerminal[]
+): Promise<string[]> {
+  await page.evaluate(() => window.__store?.getState().setActiveView('tasks'))
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          (ids) => ids.filter((id) => window.__paneManagers?.has(id)).length,
+          terminals.map((terminal) => terminal.tabId)
+        ),
+      { timeout: 10_000 }
+    )
+    .toBe(terminals.length)
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+      })
+  )
+  await page.evaluate(() => {
+    const debug = (
+      window as typeof window & {
+        __terminalOutputSchedulerDebug?: { reset: () => void }
+      }
+    ).__terminalOutputSchedulerDebug
+    if (!debug) {
+      throw new Error('Terminal output scheduler debug API is unavailable')
+    }
+    debug.reset()
+  })
+
+  const lagProbe = await startRendererLagProbe(page)
+  const tokens = terminals.map((_, index) => `HIDDEN_FLOOD_${index}_${Date.now()}`)
+  try {
+    await Promise.all(
+      terminals.map((terminal, index) =>
+        callRuntime(page, 'terminal.send', {
+          terminal: terminal.terminal,
+          text: `FLOOD:${tokens[index]}`,
+          enter: true,
+          client: { id: 'paired-hidden-flood-e2e', type: 'desktop' }
+        })
+      )
+    )
+    await expect
+      .poll(
+        async () =>
+          Promise.all(
+            terminals.map(async (terminal, index) => {
+              const result = await callRuntime<{ terminal: RuntimeTerminalRead }>(
+                page,
+                'terminal.read',
+                { terminal: terminal.terminal, limit: 1_000 }
+              )
+              return result.terminal.tail.join('\n').includes(`FLOODED:${tokens[index]}`)
+            })
+          ),
+        { timeout: 30_000 }
+      )
+      .toEqual(Array(terminals.length).fill(true))
+    const hiddenFloodLagMs = await lagProbe.evaluate((probe) => probe.stop())
+    const scheduler = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __terminalOutputSchedulerDebug?: {
+              snapshot: () => {
+                backgroundEnqueueCount: number
+                queuedChars: number
+                scheduledDrainCount: number
+              }
+            }
+          }
+        ).__terminalOutputSchedulerDebug?.snapshot() ?? null
+    )
+    expect(scheduler).not.toBeNull()
+    expect(scheduler?.backgroundEnqueueCount).toBe(0)
+    expect(scheduler?.scheduledDrainCount).toBe(0)
+    expect(scheduler?.queuedChars).toBe(0)
+    expect(hiddenFloodLagMs).toBeLessThan(MAX_HIDDEN_FLOOD_LAG_MS)
+  } finally {
+    await lagProbe.evaluate((probe) => probe.stop()).catch(() => undefined)
+    await lagProbe.dispose()
+  }
+  return tokens
+}

--- a/tests/e2e/helpers/paired-terminal-parking-fixture.ts
+++ b/tests/e2e/helpers/paired-terminal-parking-fixture.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 const FILL_ROWS = 6_000
+const FLOOD_ROWS = 4_000
 
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`
@@ -30,6 +31,12 @@ export function createPairedTerminalParkingFixture(): {
       "process.stdin.setEncoding('utf8')",
       "process.stdin.on('data', (data) => {",
       '  for (const command of data.split(/\\r\\n|\\r|\\n/).filter(Boolean)) {',
+      "    if (command.startsWith('FLOOD:')) {",
+      "      const token = command.slice('FLOOD:'.length)",
+      `      for (let row = 0; row < ${FLOOD_ROWS}; row += 1) process.stdout.write(\`flood-${'${token}'}-${'${row}'}-${'x'.repeat(80)}\\r\\n\`)`,
+      '      process.stdout.write(`FLOODED:${token}\\r\\n`)',
+      '      continue',
+      '    }',
       "    if (command === 'FILL') {",
       `      for (let row = 0; row < ${FILL_ROWS}; row += 1) process.stdout.write(\`fill-${'${marker}'}-${'${row}'}-${'x'.repeat(80)}\\r\\n\`)`,
       '      process.stdout.write(`FILLED:${marker}\\r\\n`)',

--- a/tests/e2e/helpers/paired-terminal-parking-oracle.ts
+++ b/tests/e2e/helpers/paired-terminal-parking-oracle.ts
@@ -10,6 +10,7 @@ import {
   startRendererLagProbe
 } from '../paired-runtime-retention-metrics'
 import { expect } from './orca-app'
+import { verifyHiddenPairedTerminalOutputSuppression } from './paired-terminal-hidden-output-oracle'
 import { createPairedTerminalParkingFixture } from './paired-terminal-parking-fixture'
 import { getTerminalContent, waitForActivePanePtyId } from './terminal'
 
@@ -133,17 +134,7 @@ export async function runPairedTerminalParkingOracle(
     }
     await expectHostTerminalsUnmounted(options.hostPage, seed.fallbackWorktreeId, remoteTabs)
 
-    await page.evaluate(() => window.__store?.getState().setActiveView('tasks'))
-    await expect
-      .poll(
-        () =>
-          page.evaluate(
-            (ids) => ids.filter((id) => window.__paneManagers?.has(id)).length,
-            remoteTabs.map((tab) => tab.tabId)
-          ),
-        { timeout: 10_000 }
-      )
-      .toBe(TARGET_WORKTREE_COUNT)
+    const hiddenFloodTokens = await verifyHiddenPairedTerminalOutputSuppression(page, remoteTabs)
     const baseline = await readPairedRetentionSample(
       page,
       remoteTabs.map((tab) => tab.tabId)
@@ -217,6 +208,8 @@ export async function runPairedTerminalParkingOracle(
     if (!evicted) {
       throw new Error('Ordinary parking did not unmount a paired terminal')
     }
+    const hiddenFloodToken =
+      hiddenFloodTokens[remoteTabs.findIndex((tab) => tab.tabId === evicted.tabId)]
     const parkedMarker = `WHILE_PARKED_${Date.now()}`
     await callRuntime(page, 'terminal.send', {
       terminal: evicted.terminal,
@@ -248,11 +241,18 @@ export async function runPairedTerminalParkingOracle(
     await restored.click()
     expect(await waitForActivePanePtyId(page, 30_000)).toBe(evicted.originalPtyId)
     await expect
-      .poll(() => getTerminalContent(page, 1_000_000), { timeout: 30_000 })
-      .toContain(`fill-${evicted.marker}-4000-`)
-    await expect
-      .poll(() => getTerminalContent(page, 1_000_000), { timeout: 30_000 })
-      .toContain(`LIVE:${parkedMarker}`)
+      .poll(
+        async () => {
+          const content = await getTerminalContent(page, 1_000_000)
+          return [
+            `flood-${hiddenFloodToken}-3999-`,
+            `FLOODED:${hiddenFloodToken}`,
+            `LIVE:${parkedMarker}`
+          ].map((marker) => content.split(marker).length - 1)
+        },
+        { timeout: 30_000 }
+      )
+      .toEqual([1, 1, 1])
     const liveMarker = `AFTER_RETENTION_${Date.now()}`
     await callRuntime(page, 'terminal.send', {
       terminal: evicted.terminal,


### PR DESCRIPTION
## Summary

- capability-negotiate a per-stream output pause for hidden paired desktop terminals
- suppress raw renderer frames only after host-authoritative terminal model ingestion
- keep title, agent lifecycle, command, theme, bell, and PR-link facts live while paused
- resume transport before requesting the bounded authoritative reveal snapshot
- preserve legacy delivery when either side does not negotiate the capability

## Authority and causal chain

The authoritative path is:

`paired renderer visibility -> remote PTY transport -> binary terminal multiplexer -> owning host runtime -> host PTY model -> per-view stream`

The incident boundary was the final edge. `OrcaRuntimeService.onPtyData` ingests each chunk into the owning host model and derives side-effect facts before notifying terminal-data subscribers. Previously every mounted paired stream then forwarded every raw chunk to the client, including warm-retained CSS-hidden panes. Per-stream ACK windows bounded memory but still admitted aggregate decode, sequencing, scanning, scheduler, and xterm work in the renderer.

This change adds negotiated `outputPause` support and `SetOutputPaused`. A capable hidden desktop stream is gated at the host subscriber after model/fact ingestion. Visible output is never dropped. Input, viewport ownership, process lifecycle, and side-effect facts remain live. Reveal first reopens live delivery, then uses the existing sequence-aware snapshot reconciliation to paint one bounded authoritative snapshot and discard overlap exactly once.

## Falsifiable invariant and oracle

Invariant: after three paired desktop streams negotiate hidden output pause, sustained host PTY output emits zero renderer `Output` frames while host authority remains live. Revealing one stream restores one authoritative snapshot followed by exact live bytes, with no hidden raw write, loss, duplication, or leaked stream handlers.

Byte-identical causal command:

```sh
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/rpc/terminal-multiplex.test.ts \
  -t "withholds sustained output from multiple paused desktop streams" \
  --maxWorkers=1
```

Results on the current PR base:

- `origin/main`: red, 1 failed / 57 skipped in 2.69s; an `Output` frame was observed.
- candidate: green, 1 passed / 57 skipped in 3.70s.
- candidate with only `src/main/runtime/rpc/methods/terminal.ts` and `src/shared/terminal-stream-protocol.ts` restored from `origin/main`: red, 1 failed / 57 skipped in 2.59s; the same `Output` assertion failed.

## Compatibility and safety

- New client -> old host: the client advertises support but sends no pause opcode until the host echoes `outputPause: 1`.
- Old client -> new host: omission of the capability leaves `outputPaused` false and output continues unchanged.
- Desired hidden state is reapplied across reconnect and both capability/snapshot wire orderings.
- Hidden input remains writable and does not arm an output watchdog probe.
- Local and SSH transports do not expose this paired-runtime pause method.
- No Git, filesystem, provider, folder-workspace, stream-limit, parking-policy, or visible-output behavior changed.

## Validation

Focused and reliability coverage:

- 17-file paired reliability matrix: 1,991 passed, 1 skipped.
- 9-file stream budget/ACK/restore matrix: 731 passed.
- 7-file local PTY, SSH provider/workspace, scheduler, restore, and shared-control matrix: 266 passed.
- Full terminal multiplex file: 58 passed.
- `pnpm run typecheck`: passed.
- `pnpm run lint`: passed, including reliability gates, max-lines ratchet, code-quality audits, skill manifests, and localization checks.
- `pnpm run check:code-quality:changed`: zero native, type-aware, or React Doctor findings.
- `git diff --check`: passed.

Fresh E2E-mode artifacts were built with:

```sh
pnpm exec electron-vite build --mode e2e
VITE_EXPOSE_STORE=true pnpm run build:web
```

Real paired topology:

- Headed desktop host + separate paired web client: retention/starvation oracle passed in 17.5s.
- Isolated headless `orca serve` host + paired web client: parity oracle passed in 14.0s.
- Both six-stream runs observed zero hidden renderer scheduler enqueues/drains, under-500ms timer lag, exact final flood/completion/parked markers once, original PTY identity, continued input/output, and cleanup.
- Headed ACK-starved reconnect passed in 19.1s without replacing the PTY.
- Headless ACK-starved reconnect passed in 15.7s.

## Remaining gaps

- No physical Windows or Linux paired-server run.
- No live SSH journey; deterministic SSH provider and workspace-scope contracts passed, and SSH does not use the changed paired stream.
- Mixed-version behavior is contract-tested in both directions but was not exercised with packaged old binaries.
- Battery impact is proved through zero hidden raw frames/scheduler drains and bounded timer lag, not a physical power measurement.
