### PR TITLE
fix(mobile): harden attachments and compact agent statuses

### DIFF
--- a/mobile/src/components/WorktreeAgentList.test.tsx
+++ b/mobile/src/components/WorktreeAgentList.test.tsx
@@ -1,0 +1,105 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeWorktreeAgentRow } from '../../../src/shared/runtime-types'
+import { WorktreeAgentList } from './WorktreeAgentList'
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  StyleSheet: { create: <T,>(styles: T) => styles },
+  Text: 'Text',
+  View: 'View'
+}))
+vi.mock('lucide-react-native', () => ({
+  ChevronDown: 'ChevronDown',
+  ChevronRight: 'ChevronRight'
+}))
+vi.mock('./AgentStateDot', () => ({ AgentStateDot: () => null }))
+vi.mock('./MobileAgentIcon', () => ({ MobileAgentIcon: () => null }))
+vi.mock('./WorktreeAgentRow', () => ({ WorktreeAgentRow: 'WorktreeAgentRow' }))
+
+function agent(paneKey: string, parentPaneKey: string | null = null): RuntimeWorktreeAgentRow {
+  return {
+    paneKey,
+    parentPaneKey,
+    state: 'working',
+    agentType: 'codex',
+    prompt: `Prompt ${paneKey}`,
+    taskTitle: null,
+    displayName: null,
+    lastAssistantMessage: null,
+    toolName: null,
+    toolInput: null,
+    interrupted: false,
+    stateStartedAt: 1_000,
+    updatedAt: 1_000
+  }
+}
+
+describe('WorktreeAgentList', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  it('collapses multiple agents to their status icons by default', async () => {
+    const stopPropagation = vi.fn()
+    await act(async () => {
+      renderer = create(
+        createElement(WorktreeAgentList, {
+          agents: [agent('agent-1'), agent('agent-2'), agent('agent-3')],
+          now: 2_000,
+          unvisited: false
+        })
+      )
+    })
+
+    const summary = renderer!.root.findByType('Pressable')
+    expect(summary.props.accessibilityLabel).toBe('Expand 3 agents')
+    expect(summary.props.accessibilityState).toEqual({ expanded: false })
+    expect(renderer!.root.findAllByType('WorktreeAgentRow')).toHaveLength(0)
+
+    await act(async () => summary.props.onPress({ stopPropagation }))
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1)
+    expect(renderer!.root.findByType('Pressable').props.accessibilityLabel).toBe(
+      'Collapse 3 agents'
+    )
+    expect(renderer!.root.findAllByType('WorktreeAgentRow')).toHaveLength(3)
+  })
+
+  it('keeps a single agent visible without a redundant disclosure control', async () => {
+    await act(async () => {
+      renderer = create(
+        createElement(WorktreeAgentList, {
+          agents: [agent('agent-1')],
+          now: 2_000,
+          unvisited: false
+        })
+      )
+    })
+
+    expect(renderer!.root.findAllByType('Pressable')).toHaveLength(0)
+    expect(renderer!.root.findAllByType('WorktreeAgentRow')).toHaveLength(1)
+  })
+
+  it('summarizes lineage by root agents like desktop', async () => {
+    await act(async () => {
+      renderer = create(
+        createElement(WorktreeAgentList, {
+          agents: [agent('parent-1'), agent('child-1', 'parent-1'), agent('parent-2')],
+          now: 2_000,
+          unvisited: false
+        })
+      )
+    })
+
+    expect(renderer!.root.findByType('Pressable').props.accessibilityLabel).toBe('Expand 2 agents')
+  })
+})

--- a/mobile/src/components/WorktreeAgentList.tsx
+++ b/mobile/src/components/WorktreeAgentList.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { StyleSheet, View } from 'react-native'
 import type { RuntimeWorktreeAgentRow } from '../../../src/shared/runtime-types'
-import { flattenAgentRowLineage } from '../worktree/agent-row-lineage'
+import { buildAgentRowLineageTree, flattenAgentRowLineage } from '../worktree/agent-row-lineage'
 import { WorktreeAgentRow } from './WorktreeAgentRow'
+import { WorktreeAgentSummary } from './WorktreeAgentSummary'
 
 type Props = {
   agents: RuntimeWorktreeAgentRow[]
@@ -14,20 +15,35 @@ type Props = {
 // a depth-indented WorktreeAgentRow per agent, mirroring the desktop sidebar's
 // WorktreeCardAgents.
 export function WorktreeAgentList({ agents, now, unvisited }: Props) {
-  // Why: rebuild the lineage tree only when the agent list changes, not on every
-  // re-render (the shared useNow tick re-renders this list every 30s).
   const nodes = useMemo(() => flattenAgentRowLineage(agents), [agents])
+  const summaryAgents = useMemo(() => {
+    const lineage = buildAgentRowLineageTree(agents)
+    return lineage.childrenByParentPaneKey.size > 0 ? lineage.rootRows : agents
+  }, [agents])
+  const [expanded, setExpanded] = useState(false)
+  const usesSummary = summaryAgents.length > 1
+
   return (
     <View style={styles.list}>
-      {nodes.map((node) => (
-        <WorktreeAgentRow
-          key={node.row.paneKey}
-          agent={node.row}
-          depth={node.depth}
+      {usesSummary ? (
+        <WorktreeAgentSummary
+          agents={summaryAgents}
+          expanded={expanded}
           now={now}
-          unvisited={unvisited}
+          onToggle={() => setExpanded((value) => !value)}
         />
-      ))}
+      ) : null}
+      {!usesSummary || expanded
+        ? nodes.map((node) => (
+            <WorktreeAgentRow
+              key={node.row.paneKey}
+              agent={node.row}
+              depth={node.depth}
+              now={now}
+              unvisited={unvisited}
+            />
+          ))
+        : null}
     </View>
   )
 }

--- a/mobile/src/components/WorktreeAgentSummary.tsx
+++ b/mobile/src/components/WorktreeAgentSummary.tsx
@@ -1,0 +1,104 @@
+import { ChevronDown, ChevronRight } from 'lucide-react-native'
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import type { RuntimeWorktreeAgentRow } from '../../../src/shared/runtime-types'
+import { colors, radii, spacing } from '../theme/mobile-theme'
+import { agentDotState } from '../worktree/agent-row-display'
+import { AgentStateDot } from './AgentStateDot'
+import { MobileAgentIcon } from './MobileAgentIcon'
+
+const MAX_VISIBLE_AGENTS = 3
+
+type Props = {
+  agents: RuntimeWorktreeAgentRow[]
+  expanded: boolean
+  now: number
+  onToggle: () => void
+}
+
+export function WorktreeAgentSummary({ agents, expanded, now, onToggle }: Props) {
+  const visibleAgents = agents.slice(0, MAX_VISIBLE_AGENTS)
+  const hiddenCount = agents.length - visibleAgents.length
+  const subject = `${agents.length} agents`
+
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.summary,
+        !expanded && styles.summaryCollapsed,
+        pressed && styles.summaryPressed
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={`${expanded ? 'Collapse' : 'Expand'} ${subject}`}
+      accessibilityState={{ expanded }}
+      onPress={(event) => {
+        event.stopPropagation()
+        onToggle()
+      }}
+    >
+      {expanded ? (
+        <Text style={styles.expandedLabel}>{subject}</Text>
+      ) : (
+        <View style={styles.agentIcons}>
+          {visibleAgents.map((agent) => (
+            <View key={agent.paneKey} style={styles.agentStatus}>
+              <AgentStateDot state={agentDotState(agent, now)} />
+              {agent.agentType ? <MobileAgentIcon agentId={agent.agentType} size={13} /> : null}
+            </View>
+          ))}
+          {hiddenCount > 0 ? <Text style={styles.hiddenCount}>+{hiddenCount}</Text> : null}
+        </View>
+      )}
+      {expanded ? (
+        <ChevronDown size={12} color={colors.textMuted} />
+      ) : (
+        <ChevronRight size={12} color={colors.textMuted} />
+      )}
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  summary: {
+    minHeight: 24,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.xs,
+    borderRadius: radii.button
+  },
+  summaryCollapsed: {
+    borderWidth: 1,
+    borderColor: colors.borderSubtle,
+    backgroundColor: colors.bgRaised
+  },
+  summaryPressed: {
+    opacity: 0.72
+  },
+  expandedLabel: {
+    flex: 1,
+    paddingLeft: spacing.xs,
+    fontSize: 11,
+    fontWeight: '500',
+    color: colors.textMuted
+  },
+  agentIcons: {
+    flex: 1,
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs
+  },
+  agentStatus: {
+    height: 19,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 2,
+    paddingHorizontal: 3,
+    borderRadius: radii.button,
+    backgroundColor: colors.bgPanel
+  },
+  hiddenCount: {
+    fontSize: 10,
+    color: colors.textMuted
+  }
+})

--- a/mobile/src/session/mobile-clipboard-image.test.ts
+++ b/mobile/src/session/mobile-clipboard-image.test.ts
@@ -8,6 +8,7 @@ import {
   saveMobileClipboardImageAsTempFile
 } from './mobile-clipboard-image'
 import type { RpcClient } from '../transport/rpc-client'
+import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import type { RpcFailure, RpcResponse, RpcSuccess } from '../transport/types'
 
 function ok(id: string, result: unknown): RpcSuccess {
@@ -122,6 +123,30 @@ describe('mobile clipboard image paste helpers', () => {
       method: 'clipboard.abortImageUpload',
       params: { uploadId: 'upload-1' }
     })
+  })
+
+  it('restarts the upload after a logical connection cutover', async () => {
+    const sendRequest = vi
+      .fn()
+      .mockResolvedValueOnce(ok('start-1', { uploadId: 'upload-1' }))
+      .mockRejectedValueOnce(new LogicalClientCutoverError())
+      .mockResolvedValueOnce(ok('abort-1', { aborted: true }))
+      .mockResolvedValueOnce(ok('start-2', { uploadId: 'upload-2' }))
+      .mockResolvedValueOnce(ok('append-2', { receivedBase64Length: 8 }))
+      .mockResolvedValueOnce(ok('commit-2', '/tmp/orca-paste-image.png'))
+
+    await expect(saveMobileClipboardImageAsTempFile({ sendRequest }, 'aGVsbG8=')).resolves.toBe(
+      '/tmp/orca-paste-image.png'
+    )
+
+    expect(sendRequest.mock.calls.map(([method]) => method)).toEqual([
+      'clipboard.startImageUpload',
+      'clipboard.appendImageUploadChunk',
+      'clipboard.abortImageUpload',
+      'clipboard.startImageUpload',
+      'clipboard.appendImageUploadChunk',
+      'clipboard.commitImageUpload'
+    ])
   })
 
   it('brackets generated image paths before sending to the terminal', () => {

--- a/mobile/src/session/mobile-clipboard-image.ts
+++ b/mobile/src/session/mobile-clipboard-image.ts
@@ -1,9 +1,11 @@
 import type { RpcClient } from '../transport/rpc-client'
+import { isLogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import type { RpcFailure, RpcSuccess } from '../transport/types'
 
 export const MOBILE_CLIPBOARD_IMAGE_MAX_BASE64_CHARS = 24 * 1024 * 1024
 export const MOBILE_CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
 export const MOBILE_CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
+const MOBILE_CLIPBOARD_IMAGE_UPLOAD_CUTOVER_MAX_RETRIES = 1
 // Why: PNG bytes don't scale exactly with pixel area, so undershoot the target on
 // each pass and let the bounded retry below converge instead of distorting in one shot.
 const MOBILE_CLIPBOARD_IMAGE_DOWNSCALE_SAFETY = 0.85
@@ -106,6 +108,26 @@ export async function saveMobileClipboardImageAsTempFile(
 ): Promise<string> {
   const contentBase64 = normalizeMobileClipboardImageBase64(imageData)
   const connectionId = args?.connectionId ?? null
+  for (let retry = 0; ; retry += 1) {
+    try {
+      return await uploadMobileClipboardImageTransaction(client, contentBase64, connectionId)
+    } catch (error) {
+      if (
+        !isLogicalClientCutoverError(error) ||
+        retry >= MOBILE_CLIPBOARD_IMAGE_UPLOAD_CUTOVER_MAX_RETRIES
+      ) {
+        throw error
+      }
+      // Why: upload replay can create only temp state; terminal input is sent after this returns.
+    }
+  }
+}
+
+async function uploadMobileClipboardImageTransaction(
+  client: Pick<RpcClient, 'sendRequest'>,
+  contentBase64: string,
+  connectionId: string | null
+): Promise<string> {
   const startResponse = await client.sendRequest('clipboard.startImageUpload', {
     expectedBase64Length: contentBase64.length,
     connectionId

--- a/mobile/src/session/mobile-image-base64-accumulator.test.ts
+++ b/mobile/src/session/mobile-image-base64-accumulator.test.ts
@@ -1,7 +1,9 @@
-// eslint-disable-next-line unicorn/prefer-node-protocol -- Match the Metro-safe production import.
-import { Buffer } from 'buffer'
 import { describe, expect, it } from 'vitest'
 import { MobileImageBase64Accumulator } from './mobile-image-base64-accumulator'
+
+function decodeBase64(data: string): Uint8Array {
+  return Uint8Array.from(atob(data), (character) => character.charCodeAt(0))
+}
 
 describe('MobileImageBase64Accumulator', () => {
   it('preserves bytes split across non-aligned source chunks', () => {
@@ -10,7 +12,7 @@ describe('MobileImageBase64Accumulator', () => {
     accumulator.append(new Uint8Array([2, 3]))
     accumulator.append(new Uint8Array([4, 5]))
 
-    expect(accumulator.finish()).toBe(Buffer.from([1, 2, 3, 4, 5]).toString('base64'))
+    expect(accumulator.finish()).toBe('AQIDBAU=')
   })
 
   it('preserves bytes across internal staging flushes', () => {
@@ -22,6 +24,6 @@ describe('MobileImageBase64Accumulator', () => {
     accumulator.append(bytes.subarray(0, 123_457))
     accumulator.append(bytes.subarray(123_457))
 
-    expect(accumulator.finish()).toBe(Buffer.from(bytes).toString('base64'))
+    expect(decodeBase64(accumulator.finish())).toEqual(bytes)
   })
 })

--- a/mobile/src/session/mobile-image-base64-accumulator.test.ts
+++ b/mobile/src/session/mobile-image-base64-accumulator.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line unicorn/prefer-node-protocol -- Match the Metro-safe production import.
 import { Buffer } from 'buffer'
 import { describe, expect, it } from 'vitest'
 import { MobileImageBase64Accumulator } from './mobile-image-base64-accumulator'

--- a/mobile/src/session/mobile-image-base64-accumulator.test.ts
+++ b/mobile/src/session/mobile-image-base64-accumulator.test.ts
@@ -1,0 +1,26 @@
+import { Buffer } from 'buffer'
+import { describe, expect, it } from 'vitest'
+import { MobileImageBase64Accumulator } from './mobile-image-base64-accumulator'
+
+describe('MobileImageBase64Accumulator', () => {
+  it('preserves bytes split across non-aligned source chunks', () => {
+    const accumulator = new MobileImageBase64Accumulator()
+    accumulator.append(new Uint8Array([1]))
+    accumulator.append(new Uint8Array([2, 3]))
+    accumulator.append(new Uint8Array([4, 5]))
+
+    expect(accumulator.finish()).toBe(Buffer.from([1, 2, 3, 4, 5]).toString('base64'))
+  })
+
+  it('preserves bytes across internal staging flushes', () => {
+    const bytes = new Uint8Array(256 * 1024 + 7)
+    bytes.forEach((_, index) => {
+      bytes[index] = index % 251
+    })
+    const accumulator = new MobileImageBase64Accumulator()
+    accumulator.append(bytes.subarray(0, 123_457))
+    accumulator.append(bytes.subarray(123_457))
+
+    expect(accumulator.finish()).toBe(Buffer.from(bytes).toString('base64'))
+  })
+})

--- a/mobile/src/session/mobile-image-base64-accumulator.ts
+++ b/mobile/src/session/mobile-image-base64-accumulator.ts
@@ -1,0 +1,40 @@
+import { Buffer } from 'buffer'
+
+const MOBILE_IMAGE_BASE64_CHUNK_BYTES = 256 * 1024 - 1
+
+export class MobileImageBase64Accumulator {
+  private readonly staging = new Uint8Array(MOBILE_IMAGE_BASE64_CHUNK_BYTES)
+  private readonly encodedChunks: string[] = []
+  private stagingLength = 0
+
+  append(bytes: Uint8Array): void {
+    let offset = 0
+    while (offset < bytes.byteLength) {
+      const copied = Math.min(
+        this.staging.byteLength - this.stagingLength,
+        bytes.byteLength - offset
+      )
+      this.staging.set(bytes.subarray(offset, offset + copied), this.stagingLength)
+      this.stagingLength += copied
+      offset += copied
+      if (this.stagingLength === this.staging.byteLength) {
+        this.flushStaging()
+      }
+    }
+  }
+
+  finish(): string {
+    this.flushStaging()
+    return this.encodedChunks.join('')
+  }
+
+  private flushStaging(): void {
+    if (this.stagingLength === 0) {
+      return
+    }
+    this.encodedChunks.push(
+      Buffer.from(this.staging.subarray(0, this.stagingLength)).toString('base64')
+    )
+    this.stagingLength = 0
+  }
+}

--- a/mobile/src/session/mobile-image-base64-accumulator.ts
+++ b/mobile/src/session/mobile-image-base64-accumulator.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line unicorn/prefer-node-protocol -- Metro cannot resolve node:buffer.
 import { Buffer } from 'buffer'
 
 const MOBILE_IMAGE_BASE64_CHUNK_BYTES = 256 * 1024 - 1

--- a/mobile/src/session/mobile-image-base64-accumulator.ts
+++ b/mobile/src/session/mobile-image-base64-accumulator.ts
@@ -1,7 +1,22 @@
-// eslint-disable-next-line unicorn/prefer-node-protocol -- Metro cannot resolve node:buffer.
-import { Buffer } from 'buffer'
-
+const MOBILE_IMAGE_BASE64_BINARY_CHUNK_BYTES = 8190
 const MOBILE_IMAGE_BASE64_CHUNK_BYTES = 256 * 1024 - 1
+
+function encodeMobileImageBytes(bytes: Uint8Array): string {
+  const encoded: string[] = []
+  for (
+    let offset = 0;
+    offset < bytes.byteLength;
+    offset += MOBILE_IMAGE_BASE64_BINARY_CHUNK_BYTES
+  ) {
+    const end = Math.min(offset + MOBILE_IMAGE_BASE64_BINARY_CHUNK_BYTES, bytes.byteLength)
+    let binary = ''
+    for (let index = offset; index < end; index += 1) {
+      binary += String.fromCharCode(bytes[index]!)
+    }
+    encoded.push(btoa(binary))
+  }
+  return encoded.join('')
+}
 
 export class MobileImageBase64Accumulator {
   private readonly staging = new Uint8Array(MOBILE_IMAGE_BASE64_CHUNK_BYTES)
@@ -33,9 +48,7 @@ export class MobileImageBase64Accumulator {
     if (this.stagingLength === 0) {
       return
     }
-    this.encodedChunks.push(
-      Buffer.from(this.staging.subarray(0, this.stagingLength)).toString('base64')
-    )
+    this.encodedChunks.push(encodeMobileImageBytes(this.staging.subarray(0, this.stagingLength)))
     this.stagingLength = 0
   }
 }

--- a/mobile/src/session/mobile-image-source-picker.test.ts
+++ b/mobile/src/session/mobile-image-source-picker.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CLIPBOARD_IMAGE_MAX_SOURCE_BYTES } from '../../../src/shared/clipboard-image'
 
 vi.mock('expo-image-picker', () => ({
   requestMediaLibraryPermissionsAsync: vi.fn(),
@@ -6,6 +7,9 @@ vi.mock('expo-image-picker', () => ({
 }))
 vi.mock('expo-document-picker', () => ({
   getDocumentAsync: vi.fn()
+}))
+vi.mock('expo-file-system', () => ({
+  File: vi.fn()
 }))
 
 import { ImageLibraryPermissionError, pickMobileImage } from './mobile-image-source-picker'
@@ -15,17 +19,53 @@ const granted = { granted: true } as Awaited<
 >
 const denied = { granted: false } as typeof granted
 
+function fileFactory(
+  bytes: Uint8Array,
+  options?: { fileSize?: number; handleSize?: number | null; readError?: Error }
+) {
+  const close = vi.fn()
+  const chunks = [bytes]
+  const readBytes = vi.fn(() => {
+    if (options?.readError) {
+      throw options.readError
+    }
+    return chunks.shift() ?? new Uint8Array()
+  })
+  const open = vi.fn(() => ({
+    size: options?.handleSize ?? options?.fileSize ?? bytes.length,
+    readBytes,
+    close
+  }))
+  const createFile = vi.fn(() => ({ size: options?.fileSize ?? bytes.length, open }))
+  return { close, createFile, open }
+}
+
 describe('pickMobileImage', () => {
-  it('returns base64 from the photo library', async () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('reads a photo URI without relying on React Native fetch', async () => {
+    const bytes = new Uint8Array([0, 1, 2, 3])
+    const file = fileFactory(bytes)
+    const launchLibrary = vi.fn().mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file:///x.jpg', fileSize: bytes.length }]
+    })
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockRejectedValue(new Error('Network request failed'))
     const result = await pickMobileImage('library', {
       requestLibraryPermission: vi.fn().mockResolvedValue(granted),
-      launchLibrary: vi.fn().mockResolvedValue({
-        canceled: false,
-        assets: [{ uri: 'file:///x.jpg', base64: 'AAAA' }]
-      })
+      launchLibrary,
+      createFile: file.createFile
     })
 
-    expect(result).toEqual({ base64: 'AAAA', uri: 'file:///x.jpg' })
+    expect(result).toEqual({
+      base64: Buffer.from(bytes).toString('base64'),
+      uri: 'file:///x.jpg'
+    })
+    expect(launchLibrary).toHaveBeenCalledWith(expect.objectContaining({ base64: false }))
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(file.close).toHaveBeenCalledTimes(1)
   })
 
   it('throws when photo library permission is denied', async () => {
@@ -48,22 +88,21 @@ describe('pickMobileImage', () => {
 
   it('reads a picked file URI into base64 for the files source', async () => {
     const bytes = new Uint8Array([1, 2, 3, 4])
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(bytes.buffer, { headers: { 'content-type': 'image/png' } }))
+    const file = fileFactory(bytes)
 
     const result = await pickMobileImage('files', {
       launchFiles: vi.fn().mockResolvedValue({
         canceled: false,
-        assets: [{ uri: 'file:///doc.png' }]
-      })
+        assets: [{ uri: 'file:///doc.png', size: bytes.length }]
+      }),
+      createFile: file.createFile
     })
 
     expect(result).toEqual({
       base64: Buffer.from(bytes).toString('base64'),
       uri: 'file:///doc.png'
     })
-    fetchSpy.mockRestore()
+    expect(file.close).toHaveBeenCalledTimes(1)
   })
 
   it('returns null when the files picker is cancelled', async () => {
@@ -72,5 +111,34 @@ describe('pickMobileImage', () => {
     })
 
     expect(result).toBeNull()
+  })
+
+  it('rejects an oversized asset before opening it', async () => {
+    const file = fileFactory(new Uint8Array([1]))
+    await expect(
+      pickMobileImage('files', {
+        launchFiles: vi.fn().mockResolvedValue({
+          canceled: false,
+          assets: [{ uri: 'file:///huge.png', size: CLIPBOARD_IMAGE_MAX_SOURCE_BYTES + 1 }]
+        }),
+        createFile: file.createFile
+      })
+    ).rejects.toThrow('Clipboard image is too large')
+    expect(file.createFile).not.toHaveBeenCalled()
+    expect(file.open).not.toHaveBeenCalled()
+  })
+
+  it('closes the file handle when reading fails', async () => {
+    const file = fileFactory(new Uint8Array(), { fileSize: 4, readError: new Error('read failed') })
+    await expect(
+      pickMobileImage('files', {
+        launchFiles: vi.fn().mockResolvedValue({
+          canceled: false,
+          assets: [{ uri: 'file:///broken.png', size: 4 }]
+        }),
+        createFile: file.createFile
+      })
+    ).rejects.toThrow('read failed')
+    expect(file.close).toHaveBeenCalledTimes(1)
   })
 })

--- a/mobile/src/session/mobile-image-source-picker.ts
+++ b/mobile/src/session/mobile-image-source-picker.ts
@@ -1,8 +1,12 @@
-// Why: import from 'buffer' (the npm polyfill), not 'node:buffer' — Metro
-// can't resolve Node's builtin in a React Native bundle.
-import { Buffer } from 'buffer'
 import * as DocumentPicker from 'expo-document-picker'
+import { File as FsFile } from 'expo-file-system'
 import * as ImagePicker from 'expo-image-picker'
+import {
+  CLIPBOARD_IMAGE_MAX_SOURCE_BYTES,
+  assertClipboardImageBase64LengthWithinLimit,
+  assertClipboardImageByteLengthWithinLimit
+} from '../../../src/shared/clipboard-image'
+import { MobileImageBase64Accumulator } from './mobile-image-base64-accumulator'
 
 export type MobileImageSource = 'library' | 'files'
 
@@ -21,18 +25,68 @@ export class ImageLibraryPermissionError extends Error {
   }
 }
 
-// Why: expo-document-picker returns a file URI, not base64. Read it through
-// fetch + Buffer so we match the base64 contract the upload pipeline expects
-// without pulling in expo-file-system.
-async function readUriAsBase64(uri: string): Promise<string> {
-  const response = await fetch(uri)
-  const bytes = new Uint8Array(await response.arrayBuffer())
-  return Buffer.from(bytes).toString('base64')
+const MOBILE_IMAGE_READ_CHUNK_BYTES = 256 * 1024
+
+type MobileImageFileHandle = {
+  readonly size: number | null
+  readBytes(length: number): Uint8Array
+  close(): void
+}
+
+type MobileImageFile = {
+  readonly size: number
+  open(): MobileImageFileHandle
+}
+
+export type MobileImageFileFactory = (uri: string) => MobileImageFile
+
+function defaultMobileImageFileFactory(uri: string): MobileImageFile {
+  return new FsFile(uri)
+}
+
+async function readUriAsBase64(
+  uri: string,
+  declaredSize: number | undefined,
+  createFile: MobileImageFileFactory
+): Promise<string> {
+  if (typeof declaredSize === 'number' && Number.isFinite(declaredSize)) {
+    assertClipboardImageByteLengthWithinLimit(declaredSize)
+  }
+
+  const file = createFile(uri)
+  assertClipboardImageByteLengthWithinLimit(file.size)
+  const handle = file.open()
+  try {
+    if (handle.size !== null) {
+      assertClipboardImageByteLengthWithinLimit(handle.size)
+    }
+    const accumulator = new MobileImageBase64Accumulator()
+    let bytesRead = 0
+    while (bytesRead <= CLIPBOARD_IMAGE_MAX_SOURCE_BYTES) {
+      const requested = Math.min(
+        MOBILE_IMAGE_READ_CHUNK_BYTES,
+        CLIPBOARD_IMAGE_MAX_SOURCE_BYTES - bytesRead + 1
+      )
+      const bytes = handle.readBytes(requested)
+      if (bytes.byteLength === 0) {
+        break
+      }
+      bytesRead += bytes.byteLength
+      assertClipboardImageByteLengthWithinLimit(bytesRead)
+      accumulator.append(bytes)
+    }
+    const base64 = accumulator.finish()
+    assertClipboardImageBase64LengthWithinLimit(base64.length)
+    return base64
+  } finally {
+    handle.close()
+  }
 }
 
 async function pickFromLibrary(
   requestPermission: typeof ImagePicker.requestMediaLibraryPermissionsAsync = ImagePicker.requestMediaLibraryPermissionsAsync,
-  launch: typeof ImagePicker.launchImageLibraryAsync = ImagePicker.launchImageLibraryAsync
+  launch: typeof ImagePicker.launchImageLibraryAsync = ImagePicker.launchImageLibraryAsync,
+  createFile: MobileImageFileFactory = defaultMobileImageFileFactory
 ): Promise<PickedMobileImage | null> {
   const permission = await requestPermission()
   // Why: `granted` covers full + limited iOS access; only a hard denial blocks us.
@@ -41,7 +95,7 @@ async function pickFromLibrary(
   }
   const result = await launch({
     mediaTypes: ['images'],
-    base64: true,
+    base64: false,
     allowsMultipleSelection: false,
     quality: 1
   })
@@ -49,7 +103,7 @@ async function pickFromLibrary(
     return null
   }
   const asset = result.assets[0]
-  const base64 = asset?.base64 ?? (asset?.uri ? await readUriAsBase64(asset.uri) : null)
+  const base64 = asset?.uri ? await readUriAsBase64(asset.uri, asset.fileSize, createFile) : null
   if (!base64) {
     return null
   }
@@ -57,7 +111,8 @@ async function pickFromLibrary(
 }
 
 async function pickFromFiles(
-  launch: typeof DocumentPicker.getDocumentAsync = DocumentPicker.getDocumentAsync
+  launch: typeof DocumentPicker.getDocumentAsync = DocumentPicker.getDocumentAsync,
+  createFile: MobileImageFileFactory = defaultMobileImageFileFactory
 ): Promise<PickedMobileImage | null> {
   const result = await launch({
     type: 'image/*',
@@ -71,7 +126,8 @@ async function pickFromFiles(
   if (!asset?.uri) {
     return null
   }
-  return { base64: await readUriAsBase64(asset.uri), uri: asset.uri }
+  const base64 = await readUriAsBase64(asset.uri, asset.size, createFile)
+  return base64 ? { base64, uri: asset.uri } : null
 }
 
 export async function pickMobileImage(
@@ -80,10 +136,11 @@ export async function pickMobileImage(
     readonly requestLibraryPermission?: typeof ImagePicker.requestMediaLibraryPermissionsAsync
     readonly launchLibrary?: typeof ImagePicker.launchImageLibraryAsync
     readonly launchFiles?: typeof DocumentPicker.getDocumentAsync
+    readonly createFile?: MobileImageFileFactory
   }
 ): Promise<PickedMobileImage | null> {
   if (source === 'library') {
-    return pickFromLibrary(deps?.requestLibraryPermission, deps?.launchLibrary)
+    return pickFromLibrary(deps?.requestLibraryPermission, deps?.launchLibrary, deps?.createFile)
   }
-  return pickFromFiles(deps?.launchFiles)
+  return pickFromFiles(deps?.launchFiles, deps?.createFile)
 }


### PR DESCRIPTION
## Summary

- Harden image attachments from the mobile photo library and file picker by reading picker URIs through Expo's native file API instead of React Native `fetch`.
- Read and encode images in bounded chunks while enforcing the existing clipboard image limits before, during, and after the read.
- Match the desktop sidebar on mobile by collapsing multiple agent statuses to compact root-agent icons by default, with a tap to expand; single agents remain directly visible.

The reported physical-phone `Attach failed` error is not reproduced by the available iOS simulator: the exact pre-fix code and this PR both complete real Photo Library and Files attachments there. The native-read change removes a plausible device-specific `file://` failure mode, but this PR does not yet prove that it is the reporter's exact cause.

## Screenshots

### Agent status before

![mobile-agent-status-before.png](https://github.com/user-attachments/assets/422312ab-c195-4c8c-945f-ae3210888c8d)

### Agent status after

![mobile-agent-status-after.png](https://github.com/user-attachments/assets/68c5097e-7cc8-44a2-927a-61c6c468f5aa)

### Photo Library attachment E2E

The selected simulator image was uploaded and its generated host path was pasted into a fresh terminal.

![orca-fixed-photo-attach-success.png](https://github.com/user-attachments/assets/18bb90d8-4b7e-459f-8f48-ac8da7ee8103)

### Files attachment E2E

A long-press opened the real iOS document picker. The selected 1.3 MB PNG produced a second distinct host path; the capture also shows the host-upload state.

![orca-fixed-files-attach-success.png](https://github.com/user-attachments/assets/116eafc6-faa1-4e94-8b22-6a45944ed04f)

## Testing

- [x] `cd mobile && pnpm lint`
- [x] `cd mobile && pnpm typecheck`
- [x] `cd mobile && pnpm test` — 2,759 passed, 3 skipped
- [x] `cd mobile && pnpm format:check`
- [x] `pnpm typecheck:node`
- [x] iPhone 17 Pro / iOS 26.5 dev-client E2E against an isolated paired desktop runtime:
  - Candidate Photo Library selection → upload → distinct host path → terminal paste
  - Candidate Files selection → upload → distinct host path → terminal paste
  - Exact pre-fix picker code completed the same two flows; the reported failure did not reproduce
- [ ] Bundled Release simulator run — JS bundling completed, but Xcode's build service stalled during native build planning and was stopped after 30+ minutes
- [x] Added regression tests for native URI reads, file-size limits, handle cleanup, base64 chunk boundaries, collapsed/expanded agent summaries, single-agent rendering, and lineage root counts

## AI Review Report

Reviewed the attachment path for cancellation, missing URIs, declared and observed size bounds, partial reads, non-base64-aligned chunks, and file-handle cleanup. Reviewed the agent summary against desktop lineage behavior, accessibility labels/state, event propagation, single-agent behavior, and established mobile theme tokens.

Cross-platform compatibility was checked explicitly for macOS, Linux, and Windows concerns. This PR is confined to the Expo mobile client: it adds no shortcuts, shortcut labels, shell commands, Electron behavior, or host path construction. Picker-provided URIs are passed to Expo's cross-platform file API without assuming path separators. Existing runtime agent rows remain the source for local, folder-workspace, and SSH-backed sessions.

The simulator baseline result was checked against the original implementation rather than inferred from mocks. It did not support the earlier claim that the reported failure had been reproduced, so that claim was removed.

## Security Audit

Image inputs retain the shared source-byte and base64-length limits. Declared picker sizes, file metadata, handle metadata, cumulative bytes, and final encoded length are checked, and handles close on success and failure. No command execution, auth, secrets, dependency, IPC, or permission model changes are introduced. Screenshot evidence is hosted as GitHub user attachments and is not included in the repository diff.

## Notes

- No physical iOS device is connected to this test host, so the original phone-specific failure still needs the reporter's device/iOS/app version, attachment source, and ideally the failing image or device logs.
- The automated regression test proves behavior when React Native rejects a local URI with `Network request failed`; the available iOS 26.5 simulator did not exhibit that rejection.
- The Release-build attempt is recorded as inconclusive and is not counted as validation.


## Android emulator E2E

Tested at UI/native-read head `925d267a0d` with a native dev client on a Pixel 9 Pro emulator (Android 16 / API 36) paired to an isolated desktop runtime.

- Candidate Photo Library: selected a 1,111,773-byte PNG, uploaded it in multiple RPC chunks, pasted the generated host path into a real terminal, and verified the host file had the same byte count and SHA-256.
- Candidate Files: long-pressed Attach, selected the same PNG through Android DocumentsUI, received a second distinct host path, and again verified byte count and SHA-256.
- Exact pre-fix picker implementation: both Photo Library and Files completed with the same byte-identical host verification. The reported Samsung failure did **not** reproduce on this emulator.

### Android Photo Library proof

![android-final-head-photo-attach.png](https://github.com/user-attachments/assets/1b3bbaeb-bdd5-4cd0-a31d-e07ac6770501)

### Android Files proof

![android-final-head-files-attach.png](https://github.com/user-attachments/assets/3c9aa086-a9ba-4726-b271-d6ddcca946b7)

## Relay/Tailscale investigation

- The successful Android E2E runs used `Direct · LAN`; Tailscale was not involved.
- A real v2 Cloud Relay pairing link was accepted on Android and provisioned both a C4 Relay endpoint and a SecureStore resume credential.
- With only the advertised direct Tailscale endpoint blocked, the phone reached `c4.relay.onorca.dev` and attempted authenticated resume. C4 returned `4404 HOST_OFFLINE`, so no Relay attachment run can be counted while the cell cannot see the desktop host leg.
- The supplied pairing URL is valid: it passes the mobile parser and replaying the persisted Android intent into a warm Orca bundle opens “Pair with this desktop?”. A cold development-build launch first stops in Expo Dev Launcher until Metro is selected; the earlier “Not a valid pairing code” screen was a development-launcher/bundle-state artifact, not a Relay/Tailscale/Samsung rejection.
- Code-path inspection shows a plausible but unproven relay failure mode: image upload is start → repeated 512 KiB base64 chunks → commit, and an RPC interruption or logical-path cutover currently aborts the attachment rather than resuming the upload.
- Remaining device-specific gap: no Samsung S24 / One UI device is attached, so Samsung URI-provider behavior and the reporter’s exact Cloud Relay session remain untested.

- Director re-resolution with the installed resume credential returned C4 again at assignment epoch 3, ruling out a stale/wrong-cell mobile overlay.
- The desktop durable binding, current E2EE-derived Relay host identity, and pairing payload agree; the desktop C4 control socket also remained live and exchanged traffic while phone resumes received `4404`. The unresolved boundary is therefore C4 host-control/phone lookup correlation, which requires cell-side logs; it is not evidence that the pairing code is malformed.

## Deterministic Relay cutover reproduction

- [x] Baseline/current upload transaction: injecting `LogicalClientCutoverError` during `clipboard.appendImageUploadChunk` aborts and surfaces the attachment failure.
- [x] Candidate: aborts the superseded upload and retries the full temp-file upload once on the already-authenticated replacement path; terminal input is still sent only after a committed path returns.
- [x] Focused red-before/green-after oracle: `cd mobile && pnpm vitest run src/session/mobile-clipboard-image.test.ts` — 14 passed after the fix.
- [x] Full candidate mobile suite: 2,759 passed, 3 skipped; lint, typecheck, and format check pass.
