### PR TITLE
fix(commit-message): use Kimi --prompt instead of Claude --print

### DIFF
--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -64,9 +64,7 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
     expect(args[promptIndex + 1]).toBe('Name a branch for adding login')
     expect(args).toContain('--quiet')
     expect(args).toContain('--thinking')
-    expect(args).toEqual(
-      expect.arrayContaining(['--model', 'kimi-code/kimi-for-coding'])
-    )
+    expect(args).toEqual(expect.arrayContaining(['--model', 'kimi-code/kimi-for-coding']))
   })
 
   it('uses the provider-qualified Kimi model id accepted by the CLI', () => {
@@ -74,6 +72,25 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
       'default',
       'kimi-code/kimi-for-coding'
     ])
+  })
+
+  it('maps Kimi thinking off and omission to distinct argv', () => {
+    const spec = COMMIT_MESSAGE_AGENT_SPECS.kimi!
+    const offArgs = spec.buildArgs({ prompt: 'PROMPT', model: 'default', thinkingLevel: 'off' })
+    const defaultArgs = spec.buildArgs({ prompt: 'PROMPT', model: 'default' })
+
+    expect(offArgs).toContain('--no-thinking')
+    expect(offArgs).not.toContain('--thinking')
+    expect(defaultArgs).not.toContain('--thinking')
+    expect(defaultArgs).not.toContain('--no-thinking')
+  })
+
+  it('omits Kimi --model for the config default and an empty model', () => {
+    const spec = COMMIT_MESSAGE_AGENT_SPECS.kimi!
+
+    for (const model of ['default', '']) {
+      expect(spec.buildArgs({ prompt: 'PROMPT', model })).not.toContain('--model')
+    }
   })
 
   it('lists Copilot hosted CLI models even when account policy filters the picker', () => {

--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -46,6 +46,29 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
     expect(COMMIT_MESSAGE_AGENT_SPECS.pi?.defaultModelId).toBe('github-copilot/gpt-5.4-mini')
   })
 
+  it('uses --prompt (not Claude --print) for Kimi non-interactive generation', () => {
+    // Why: kimi-code 0.31+ rejects --print; non-interactive mode is --prompt/-p (#11669).
+    const spec = COMMIT_MESSAGE_AGENT_SPECS.kimi
+    expect(spec).toBeDefined()
+    expect(spec!.promptDelivery).toBe('argv')
+    const args = spec!.buildArgs({
+      prompt: 'Name a branch for adding login',
+      model: 'kimi-code/kimi-for-coding',
+      thinkingLevel: 'on'
+    })
+    expect(args).toContain('--prompt')
+    expect(args).not.toContain('--print')
+    // Why: with argv delivery the prompt is the value of --prompt.
+    const promptIndex = args.indexOf('--prompt')
+    expect(promptIndex).toBeGreaterThanOrEqual(0)
+    expect(args[promptIndex + 1]).toBe('Name a branch for adding login')
+    expect(args).toContain('--quiet')
+    expect(args).toContain('--thinking')
+    expect(args).toEqual(
+      expect.arrayContaining(['--model', 'kimi-code/kimi-for-coding'])
+    )
+  })
+
   it('uses the provider-qualified Kimi model id accepted by the CLI', () => {
     expect(COMMIT_MESSAGE_AGENT_SPECS.kimi?.models.map((m) => m.id)).toEqual([
       'default',

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -577,9 +577,12 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     id: 'kimi',
     label: 'Kimi',
     binary: 'kimi',
-    promptDelivery: 'stdin',
-    buildArgs: ({ model, thinkingLevel }) => [
-      '--print',
+    // Why: kimi-code accepts the generation prompt only via --prompt/-p (Claude's
+    // --print is rejected). Deliver on argv so --prompt receives the text (#11669).
+    promptDelivery: 'argv',
+    buildArgs: ({ prompt, model, thinkingLevel }) => [
+      '--prompt',
+      prompt,
       '--quiet',
       ...(model && model !== 'default' ? ['--model', model] : []),
       ...(thinkingLevel === 'on'


### PR DESCRIPTION
Fixes #11669 (P0).

Branch auto-rename and Source Control commit-message generation are broken for every Kimi Code user: Orca invokes `kimi` with Claude's `--print` flag, kimi-code exits with `unknown option '--print'` and suggests `--prompt`, and generation fails.

## Summary

The Kimi entry in `COMMIT_MESSAGE_AGENT_SPECS` now builds `kimi --prompt <text> --quiet [--model …] [--thinking|--no-thinking]`.

Why `promptDelivery` flips from `stdin` to `argv`: kimi-code accepts the generation prompt only as the value of `--prompt`, so it has to be on argv. That is not a new code path — `planCommitMessageGeneration` already passes the prompt into `spec.buildArgs` for argv specs and leaves `stdinPayload` null (`src/shared/commit-message-plan.ts:220` and `:255`), which is exactly how Copilot has been wired all along (`commit-message-agent-spec.ts`, `promptDelivery: 'argv'` with `'--prompt', prompt`). Only the Kimi spec changes; every other agent keeps stdin delivery.

Both broken surfaces run through that plan: branch auto-rename via `first-work-branch-rename.ts` → `commit-message-text-generation.ts`, and Source Control via `source-control-generation-plan.ts`.

## Screenshots

No visual change.

## Testing
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/commit-message-agent-spec.test.ts src/shared/commit-message-plan.test.ts` (52 tests)
- [x] Independent Grok review: APPROVED

New spec tests assert that `--prompt` is present and `--print` is absent, that the prompt is the argv value immediately after `--prompt`, that `--thinking` / `--no-thinking` / omission map to distinct argv, and that `--model` is omitted for both the config default and an empty model.

## Notes

Shared spec change only — no platform-specific behaviour; the flags are the same on macOS, Linux and Windows.