### PR TITLE
fix(browser): clear grab mode operation queue on teardown

### DIFF
--- a/src/main/ipc/browser.ts
+++ b/src/main/ipc/browser.ts
@@ -194,6 +194,8 @@ function isTrustedBrowserRenderer(sender: Electron.WebContents): boolean {
 
 export function registerBrowserHandlers(): void {
   grabModeIntentByPageId.clear()
+  // Why: a stale in-flight chain from a prior registration would block new operations forever.
+  grabModeOperationByPageId.clear()
   ipcMain.removeHandler('browser:registerGuest')
   ipcMain.removeHandler('browser:unregisterGuest')
   ipcMain.removeHandler('browser:openDevTools')
@@ -264,6 +266,8 @@ export function registerBrowserHandlers(): void {
     }
     browserManager.unregisterGuest(args.browserPageId)
     grabModeIntentByPageId.delete(args.browserPageId)
+    // Why: don't let a reused browserPageId queue behind the destroyed guest's pending chain.
+    grabModeOperationByPageId.delete(args.browserPageId)
     return true
   })
 


### PR DESCRIPTION
Follow-up to review feedback on #11661 (already merged).

## Problem

`grabModeOperationByPageId` holds the pending promise chain that serializes grab mode operations per browser page. Two teardown paths cleared `grabModeIntentByPageId` but left the operation queue intact:

- **`registerBrowserHandlers()`** — on handler re-registration (e.g. workspace restart), a pending chain from the previous session survives in the map. The next `queueGrabModeOperation` for that page chains behind it, so if the stale promise never settles (an in-flight `executeJavaScript` whose guest was destroyed), new operations are silently stuck forever.
- **`browser:unregisterGuest`** — if an operation is still in flight against a guest that is mid-destroy, the chain stays alive. A `browserPageId` reused by a new tab then queues behind that stale promise.

## Fix

Clear/delete the operation queue alongside the existing intent cleanup in both paths.

This is safe with the existing teardown in `queueGrabModeOperation`: its `.finally` only removes the map entry when it still identity-matches its own `completion` promise, so a late-settling stale operation cannot clobber an entry created by a subsequent operation.

## Validation

- `npx vitest run src/main/ipc/browser.test.ts` — 20 passed
- `npm run typecheck:node` — clean
- `npx oxlint src/main/ipc/browser.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)