### PR TITLE
fix(fs): open workspace symlinks that point outside the root

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -1,5 +1,5 @@
 import type * as NodePath from 'node:path'
-import { mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -265,7 +265,7 @@ describe('filesystem-auth path containment', () => {
   })
 
   it.skipIf(process.platform === 'win32')(
-    'rejects missing descendants under a symlinked ancestor outside the repo',
+    'allows access to missing descendants under a symlinked ancestor outside the repo',
     async () => {
       const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-symlink-'))
       try {
@@ -278,6 +278,49 @@ describe('filesystem-auth path containment', () => {
 
         await expect(
           resolveAuthorizedPath(join(repoPath, 'linked-outside', 'new', 'file.ts'), store)
+        ).resolves.toBe(join(await realpath(outsidePath), 'new', 'file.ts'))
+      } finally {
+        await rm(tempRoot, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'allows opening an existing file through a workspace file symlink (issue #11654)',
+    async () => {
+      const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-symlink-file-'))
+      try {
+        const repoPath = join(tempRoot, 'repo')
+        const outsidePath = join(tempRoot, 'outside')
+        const externalFile = join(outsidePath, 'notes.md')
+        await mkdir(repoPath)
+        await mkdir(outsidePath)
+        await writeFile(externalFile, 'hello')
+        await symlink(externalFile, join(repoPath, 'notes.md'), 'file')
+        const store = makeStore([{ ...repo, id: 'repo-temp', path: repoPath }])
+
+        await expect(resolveAuthorizedPath(join(repoPath, 'notes.md'), store)).resolves.toBe(
+          await realpath(externalFile)
+        )
+      } finally {
+        await rm(tempRoot, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'still rejects plain path traversal that never passed through a workspace symlink',
+    async () => {
+      const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-escape-'))
+      try {
+        const repoPath = join(tempRoot, 'repo')
+        const outsideFile = join(tempRoot, 'secret.txt')
+        await mkdir(repoPath)
+        await writeFile(outsideFile, 'secret')
+        const store = makeStore([{ ...repo, id: 'repo-temp', path: repoPath }])
+
+        await expect(
+          resolveAuthorizedPath(join(repoPath, '..', 'secret.txt'), store)
         ).rejects.toThrow('Access denied')
       } finally {
         await rm(tempRoot, { recursive: true, force: true })

--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -390,6 +390,29 @@ describe('filesystem-auth authorized external path bound', () => {
   const flood = (n: number): string =>
     resolve(`/leak-audit-ext/flood-${String(n).padStart(6, '0')}`)
 
+  it.skipIf(process.platform === 'win32')(
+    'does not transfer an external path grant through a nested symlink',
+    async () => {
+      const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-external-symlink-'))
+      try {
+        const grantedPath = join(tempRoot, 'granted')
+        const outsidePath = join(tempRoot, 'outside')
+        const outsideFile = join(outsidePath, 'secret.txt')
+        await mkdir(grantedPath)
+        await mkdir(outsidePath)
+        await writeFile(outsideFile, 'secret')
+        await symlink(outsidePath, join(grantedPath, 'linked-outside'), 'dir')
+        authorizeExternalPath(grantedPath)
+
+        await expect(
+          resolveAuthorizedPath(join(grantedPath, 'linked-outside', 'secret.txt'), emptyStore)
+        ).rejects.toThrow('Access denied')
+      } finally {
+        await rm(tempRoot, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('bounds the authorized external path set with LRU eviction', () => {
     const keep = resolve('/leak-audit-ext/keep')
     authorizeExternalPath(keep)

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -368,6 +368,23 @@ async function resolveAuthorizedMissingPath(resolvedTarget: string, store: Store
   }
 }
 
+function isWorkspaceSymlinkSourceAuthorized(
+  sourcePath: string | undefined,
+  targetPath: string,
+  store: Store
+): boolean {
+  // Why: an in-workspace symlink already required write access to the root; following
+  // it to an external target matches VS Code and the SSH relay (#1672). Only grant
+  // when the pre-realpath source lives inside a trusted root and realpath changed
+  // the path — plain `../` escapes still fail because source and target normalize
+  // to the same outside path (issue #11654 / #4556).
+  return Boolean(
+    sourcePath &&
+    sourcePath !== targetPath &&
+    (isPathAllowed(sourcePath, store) || isRegisteredWorktreePath(sourcePath))
+  )
+}
+
 async function isPathAllowedIncludingRegisteredWorktrees(
   targetPath: string,
   store: Store,
@@ -389,12 +406,17 @@ async function isPathAllowedIncludingRegisteredWorktrees(
     return true
   }
 
+  if (isWorkspaceSymlinkSourceAuthorized(options.canonicalSourcePath, targetPath, store)) {
+    return true
+  }
+
   await ensureAuthorizedRootsCache(store)
 
   // Why: linked worktrees are already git-trusted; reuse the cached root index so reads don't spawn `git worktree list` each time.
   return (
     isRegisteredWorktreePath(targetPath) ||
-    (await isPathAllowedByCanonicalRegisteredRoot(targetPath, options.canonicalSourcePath))
+    (await isPathAllowedByCanonicalRegisteredRoot(targetPath, options.canonicalSourcePath)) ||
+    isWorkspaceSymlinkSourceAuthorized(options.canonicalSourcePath, targetPath, store)
   )
 }
 

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -375,13 +375,16 @@ function isWorkspaceSymlinkSourceAuthorized(
 ): boolean {
   // Why: an in-workspace symlink already required write access to the root; following
   // it to an external target matches VS Code and the SSH relay (#1672). Only grant
-  // when the pre-realpath source lives inside a trusted root and realpath changed
-  // the path — plain `../` escapes still fail because source and target normalize
-  // to the same outside path (issue #11654 / #4556).
+  // when the pre-realpath source lives inside a trusted root/worktree and realpath
+  // changed the path — plain `../` escapes still fail because source and target
+  // normalize to the same outside path (issue #11654 / #4556).
+  // Why not isPathAllowed: that set also holds one-off authorizedExternalPaths; a
+  // single external grant must not transfer to arbitrary symlink targets.
   return Boolean(
     sourcePath &&
     sourcePath !== targetPath &&
-    (isPathAllowed(sourcePath, store) || isRegisteredWorktreePath(sourcePath))
+    (getAllowedRoots(store).some((root) => isDescendantOrEqual(sourcePath, resolve(root))) ||
+      isRegisteredWorktreePath(sourcePath))
   )
 }
 
@@ -406,13 +409,16 @@ async function isPathAllowedIncludingRegisteredWorktrees(
     return true
   }
 
+  // Why: early grant when registered worktree roots are already warm.
   if (isWorkspaceSymlinkSourceAuthorized(options.canonicalSourcePath, targetPath, store)) {
     return true
   }
 
   await ensureAuthorizedRootsCache(store)
 
-  // Why: linked worktrees are already git-trusted; reuse the cached root index so reads don't spawn `git worktree list` each time.
+  // Why: linked worktrees are already git-trusted; reuse the cached root index so
+  // reads don't spawn `git worktree list` each time. Re-check the symlink source
+  // after cache rebuild — isRegisteredWorktreePath can flip from false→true here.
   return (
     isRegisteredWorktreePath(targetPath) ||
     (await isPathAllowedByCanonicalRegisteredRoot(targetPath, options.canonicalSourcePath)) ||

--- a/src/main/ipc/filesystem-mutations.test.ts
+++ b/src/main/ipc/filesystem-mutations.test.ts
@@ -118,16 +118,22 @@ describe('registerFilesystemMutationHandlers', () => {
     ).rejects.toThrow("A file or folder named 'existing.ts' already exists in this location")
   })
 
-  it('rejects file creation outside allowed roots', async () => {
+  it('allows file creation through a workspace symlink to a path outside allowed roots', async () => {
+    // Why: the symlink entry is inside the authorized repo root, so following it
+    // to an external target is permitted (issue #11654 / #4556).
+    const externalTarget = path.resolve('/private/secret.ts')
     mockRealpath({
-      [path.resolve('/workspace/repo/link.ts')]: path.resolve('/private/secret.ts')
+      [path.resolve('/workspace/repo/link.ts')]: externalTarget
     })
 
-    await expect(
-      handlers.get('fs:createFile')!(null, { filePath: path.resolve('/workspace/repo/link.ts') })
-    ).rejects.toThrow('Access denied')
+    await handlers.get('fs:createFile')!(null, {
+      filePath: path.resolve('/workspace/repo/link.ts')
+    })
 
-    expect(writeFileMock).not.toHaveBeenCalled()
+    expect(writeFileMock).toHaveBeenCalledWith(externalTarget, '', {
+      encoding: 'utf-8',
+      flag: 'wx'
+    })
   })
 
   // ── fs:createDir ───────────────────────────────────────────────
@@ -149,16 +155,15 @@ describe('registerFilesystemMutationHandlers', () => {
     expect(mkdirMock).not.toHaveBeenCalled()
   })
 
-  it('rejects directory creation outside allowed roots', async () => {
+  it('allows directory creation through a workspace symlink to a path outside allowed roots', async () => {
+    const externalTarget = path.resolve('/etc/evil')
     mockRealpath({
-      [path.resolve('/workspace/repo/escape')]: path.resolve('/etc/evil')
+      [path.resolve('/workspace/repo/escape')]: externalTarget
     })
 
-    await expect(
-      handlers.get('fs:createDir')!(null, { dirPath: path.resolve('/workspace/repo/escape') })
-    ).rejects.toThrow('Access denied')
+    await handlers.get('fs:createDir')!(null, { dirPath: path.resolve('/workspace/repo/escape') })
 
-    expect(mkdirMock).not.toHaveBeenCalled()
+    expect(mkdirMock).toHaveBeenCalledWith(externalTarget, { recursive: true })
   })
 
   // ── fs:rename ──────────────────────────────────────────────────
@@ -310,22 +315,21 @@ describe('registerFilesystemMutationHandlers', () => {
     expect(renameMock).not.toHaveBeenCalled()
   })
 
-  it('rejects rename when parent directory escapes allowed roots', async () => {
-    // Why: the parent is still canonicalized (preserveSymlink only preserves
-    // the leaf). A symlinked ancestor that points outside allowed roots must
-    // still be rejected so callers cannot redirect rename through it.
+  it('allows rename through a symlinked parent directory that points outside allowed roots', async () => {
+    // Why: preserveSymlink keeps the leaf, but the parent is still canonicalized.
+    // When that parent is an in-workspace symlink to an external dir, follow it.
+    const oldPath = path.resolve('/workspace/repo/old.ts')
+    const externalParent = path.resolve('/private/escape-dir')
     mockRealpath({
-      [path.resolve('/workspace/repo/escape-dir')]: path.resolve('/private/escape-dir')
+      [path.resolve('/workspace/repo/escape-dir')]: externalParent
     })
 
-    await expect(
-      handlers.get('fs:rename')!(null, {
-        oldPath: path.resolve('/workspace/repo/old.ts'),
-        newPath: path.resolve('/workspace/repo/escape-dir/new.ts')
-      })
-    ).rejects.toThrow('Access denied')
+    await handlers.get('fs:rename')!(null, {
+      oldPath,
+      newPath: path.resolve('/workspace/repo/escape-dir/new.ts')
+    })
 
-    expect(renameMock).not.toHaveBeenCalled()
+    expect(renameMock).toHaveBeenCalledWith(oldPath, path.join(externalParent, 'new.ts'))
   })
 
   it('renames a symlink without following its target', async () => {

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -1019,22 +1019,27 @@ describe('registerFilesystemHandlers', () => {
     expect(folderDownloadSender.listenerCount('destroyed')).toBe(0)
   })
 
-  it('rejects readFile when the real path escapes allowed roots', async () => {
+  it('allows readFile when a workspace symlink resolves outside allowed roots (issue #11654)', async () => {
+    // Why: the symlink entry lives inside the authorized repo root; following it
+    // is permitted because creating the link already required write access.
     const linkPath = path.resolve('/workspace/repo/link.txt')
+    const externalTarget = path.resolve('/private/secret.txt')
     realpathMock.mockImplementation(async (targetPath: string) => {
       if (targetPath === linkPath) {
-        return path.resolve('/private/secret.txt')
+        return externalTarget
       }
       return targetPath
     })
+    statMock.mockResolvedValue({ size: 7, isDirectory: () => false, mtimeMs: 123 })
+    readFileMock.mockResolvedValue(Buffer.from('content'))
 
     registerFilesystemHandlers(store as never)
 
-    await expect(handlers.get('fs:readFile')!(null, { filePath: linkPath })).rejects.toThrow(
-      'Access denied: path resolves outside allowed directories'
+    await expect(handlers.get('fs:readFile')!(null, { filePath: linkPath })).resolves.toMatchObject(
+      { content: 'content' }
     )
 
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(readFileMock).toHaveBeenCalledWith(externalTarget)
   })
 
   it('allows readDir when a registered worktree resolves to a macOS canonical alias', async () => {
@@ -1132,28 +1137,31 @@ describe('registerFilesystemHandlers', () => {
     expect(listWorktreesMock).not.toHaveBeenCalled()
   })
 
-  it('rejects readFile when a symlink in a canonical alias worktree escapes the registered root', async () => {
+  it('allows readFile when a symlink in a canonical alias worktree resolves outside the registered root', async () => {
     const aliasWorktreePath = path.resolve('/var/folders/orca/worktrees/feature')
     const canonicalWorktreePath = path.resolve('/private/var/folders/orca/worktrees/feature')
     const aliasLinkPath = path.join(aliasWorktreePath, 'link.txt')
+    const externalTarget = path.resolve('/private/secret.txt')
     registerWorktreeRootsForRepo(store as never, 'repo-1', [REPO_PATH, aliasWorktreePath])
     realpathMock.mockImplementation(async (targetPath: string) => {
       if (targetPath === aliasWorktreePath) {
         return canonicalWorktreePath
       }
       if (targetPath === aliasLinkPath) {
-        return path.resolve('/private/secret.txt')
+        return externalTarget
       }
       return targetPath
     })
+    statMock.mockResolvedValue({ size: 7, isDirectory: () => false, mtimeMs: 123 })
+    readFileMock.mockResolvedValue(Buffer.from('content'))
 
     registerFilesystemHandlers(store as never)
 
-    await expect(handlers.get('fs:readFile')!(null, { filePath: aliasLinkPath })).rejects.toThrow(
-      'Access denied: path resolves outside allowed directories'
-    )
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: aliasLinkPath })
+    ).resolves.toMatchObject({ content: 'content' })
 
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(readFileMock).toHaveBeenCalledWith(externalTarget)
   })
 
   it('does not enumerate worktrees when filesystem handlers register', () => {


### PR DESCRIPTION
## Summary

- This is the complete fix, applied at the auth boundary: `resolveAuthorizedPath` follows a symlink whose **entry** sits inside a trusted workspace/worktree root even when the realpath target lands outside it, so `fs:stat` and `fs:readFile` both succeed. #11670 is explorer-only — it changes one renderer handler (`useFileExplorerHandlers.ts`, +1/-7) and leaves `filesystem-auth.ts` untouched, so the file opens and the content read then fails at the unchanged boundary.
- Plain `../` traversal is still rejected: source and target normalise to the same outside path, so there is no realpath divergence to grant on.
- Covers File Explorer open (`fs:stat` / `fs:readFile`) and the shared auth used by create/rename — the same workspace-trust model as VS Code and the SSH relay after #1672.

This is the local half of #4556 applied on current `main`.

Closes #11654

## Security note

The decision this PR asks reviewers to accept: follow is granted only when the symlink **entry** lies inside a trusted workspace or registered worktree root — matching VS Code's post-trust behaviour — and never on the strength of the realpath target alone. Placing such a symlink already required write access to that root.

`isWorkspaceSymlinkSourceAuthorized` deliberately checks `getAllowedRoots` / `isRegisteredWorktreePath` rather than `isPathAllowed`, because the latter set also holds one-off `authorizedExternalPaths`; a single external grant must not become a transferable capability. Plain `../` traversal keeps failing for the same reason it always did.

A malicious repository can still aim symlinks at sensitive files, exactly as under VS Code once the user trusts the folder. Treat this as a deliberate boundary relaxation for local/remote parity, not a read-only open patch.

## Test plan

- [x] `vitest run` `filesystem-auth.test.ts` `filesystem.test.ts` `filesystem-mutations.test.ts` (159 passed, 1 skipped), covering:
  - the negative-boundary contract test `does not transfer an external path grant through a nested symlink` — a one-off `authorizeExternalPath` grant on one directory cannot reach a file through a symlink nested inside it; still `Access denied`
  - `still rejects plain path traversal that never passed through a workspace symlink`
  - readFile through a workspace file symlink, and through a symlink inside a canonical alias worktree
  - create, mkdir, and rename through a symlinked parent that points outside allowed roots
- [x] Independent Grok review (AI): APPROVED
- [ ] Actions suites (fork-gated, currently `action_required`)
