### PR TITLE
fix(sidebar): show foreground CLI agent sessions

### DIFF
--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -174,6 +174,30 @@ describe('buildDashboardSnapshot', () => {
     })
   })
 
+  it('publishes a process-only Kiro session as a neutral idle card', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        paneForegroundAgentByPaneKey: {
+          [PANE_KEY]: { agent: 'kiro', shellForeground: false }
+        }
+      }),
+      NOW
+    )
+
+    expect(snapshot.cards).toHaveLength(1)
+    expect(snapshot.cards[0]).toMatchObject({
+      paneKey: PANE_KEY,
+      agentType: 'kiro',
+      bucket: 'idle',
+      dotState: 'idle',
+      startedAt: 0,
+      stateChangedAt: 0,
+      unseen: false
+    })
+    expect(snapshot.cards[0].lastUserMessage).toBeUndefined()
+    expect(snapshot.cards[0].lastAgentMessage).toBeUndefined()
+  })
+
   it('maps a live working agent to the working bucket with a resolved ptyId', () => {
     const snapshot = buildDashboardSnapshot(
       baseState({

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -33,6 +33,7 @@ import {
 } from '../sidebar/worktree-agent-orchestration-batch'
 import {
   selectLivePtyIdsForWorktree,
+  selectPaneForegroundAgentsForWorktree,
   selectRuntimePaneTitlesForWorktree
 } from '../sidebar/worktree-card-status-inputs'
 import {
@@ -144,6 +145,7 @@ export function buildDashboardSnapshot(
         entries,
         retained: selectRetainedAgentEntriesForWorktree(state, worktreeId),
         runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, worktreeId),
+        foregroundAgentsByPaneKey: selectPaneForegroundAgentsForWorktree(state, worktreeId),
         ptyIdsByTabId: selectLivePtyIdsForWorktree(state, worktreeId),
         terminalLayoutsByTabId,
         runtimeAgentOrchestrationByPaneKey:

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts
@@ -140,6 +140,74 @@ describe('buildWorktreeAgentRows', () => {
     expect(rows[0].agentType).toBe('codex')
   })
 
+  it('shows a Kiro session from foreground process identity without hooks or titles', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'Terminal 1' })],
+      entries: [],
+      retained: [],
+      foregroundAgentsByPaneKey: {
+        [PANE_KEY_1]: { agent: 'kiro', shellForeground: false }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-kiro'] },
+      terminalLayoutsByTabId: {
+        'tab-1': makeSinglePaneLayout(LEAF_ID_1)
+      },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      paneKey: PANE_KEY_1,
+      agentType: 'kiro',
+      state: 'idle',
+      startedAt: 0,
+      entry: {
+        prompt: 'Kiro',
+        stateStartedAt: 0,
+        lastAssistantMessage: 'Session active'
+      }
+    })
+  })
+
+  it('hides a foreground agent row after the pane returns to its shell', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'Terminal 1' })],
+      entries: [],
+      retained: [],
+      foregroundAgentsByPaneKey: {
+        [PANE_KEY_1]: { agent: 'kiro', shellForeground: true }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-shell'] },
+      now: 2000
+    })
+
+    expect(rows).toEqual([])
+  })
+
+  it('keeps a hook row authoritative over foreground process identity', () => {
+    const liveEntry = makeEntry(PANE_KEY_1, 1000, {
+      state: 'working',
+      agentType: 'claude'
+    })
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { title: 'Terminal 1' })],
+      entries: [liveEntry],
+      retained: [],
+      foregroundAgentsByPaneKey: {
+        [PANE_KEY_1]: { agent: 'kiro', shellForeground: false }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-kiro'] },
+      terminalLayoutsByTabId: {
+        'tab-1': makeSinglePaneLayout(LEAF_ID_1)
+      },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].entry).toBe(liveEntry)
+    expect(rows[0].agentType).toBe('claude')
+  })
+
   it('prefers an unrelated live title over the launched tab agent for unknown rows', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent: 'omp', title: '\u280b Codex' })],

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -6,6 +6,7 @@ import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsuppor
 import { useAppStore } from '@/store'
 import {
   selectLivePtyIdsForWorktree,
+  selectPaneForegroundAgentsForWorktree,
   selectRuntimePaneTitlesForWorktree
 } from './worktree-card-status-inputs'
 import { buildWorktreeAgentRows } from './worktree-agent-rows'
@@ -65,6 +66,9 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const runtimePaneTitlesByTabId = useAppStore(
     useShallow((s) => (active ? selectRuntimePaneTitlesForWorktree(s, worktreeId) : {}))
   )
+  const foregroundAgentsByPaneKey = useAppStore(
+    useShallow((s) => (active ? selectPaneForegroundAgentsForWorktree(s, worktreeId) : {}))
+  )
   const ptyIdsByTabId = useAppStore(
     useShallow((s) => (active ? selectLivePtyIdsForWorktree(s, worktreeId) : {}))
   )
@@ -101,6 +105,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
         entries,
         retained,
         runtimePaneTitlesByTabId,
+        foregroundAgentsByPaneKey,
         ptyIdsByTabId,
         terminalLayoutsByTabId,
         runtimeAgentOrchestrationByPaneKey,
@@ -115,6 +120,7 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     migrationUnsupported,
     retained,
     runtimePaneTitlesByTabId,
+    foregroundAgentsByPaneKey,
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,

--- a/src/renderer/src/components/sidebar/worktree-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-rows.ts
@@ -1,6 +1,7 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentType,
@@ -25,6 +26,7 @@ import {
 import { buildSubagentChildRows } from './worktree-subagent-child-rows'
 import { resolveCompatibleAgentTypeForOwner } from '../../../../shared/agent-title-owner'
 import { compareWorktreeAgentRows } from './worktree-agent-row-order'
+import { buildForegroundAgentRows } from './worktree-foreground-agent-rows'
 import {
   effectiveWorktreeAgentRowStartedAt,
   tabFromWorktreeAttributedStatusEntry
@@ -206,6 +208,7 @@ export function buildWorktreeAgentRows(args: {
   entries: AgentStatusEntry[]
   retained: RetainedAgentEntry[]
   runtimePaneTitlesByTabId?: Record<string, Record<number, string>>
+  foregroundAgentsByPaneKey?: Record<string, PaneForegroundAgentEntry>
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot | undefined>
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
@@ -264,6 +267,7 @@ export function buildWorktreeAgentRows(args: {
   })
 
   rows.push(...buildTitleDerivedAgentRows({ ...args, seenPaneKeys }))
+  rows.push(...buildForegroundAgentRows(args, seenPaneKeys))
 
   // Why: orchestration workers can be attributed to a worktree by main before
   // their tab is present in this renderer. Keep those live rows visible in the

--- a/src/renderer/src/components/sidebar/worktree-card-status-inputs.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-status-inputs.test.ts
@@ -5,8 +5,10 @@ import type {
   TerminalPaneLayoutNode,
   TerminalTab
 } from '../../../../shared/types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
 import {
   selectLivePtyIdsForWorktree,
+  selectPaneForegroundAgentsForWorktree,
   selectTerminalLayoutRootsForWorktree,
   selectTerminalLayoutRootsForWorktrees,
   selectRuntimePaneTitlesForWorktree
@@ -79,6 +81,40 @@ describe('worktree card status input selectors', () => {
         selectLivePtyIdsForWorktree(state, worktreeId),
         selectLivePtyIdsForWorktree(unrelatedUpdate, worktreeId)
       )
+    ).toBe(true)
+  })
+
+  it('selects foreground agents only for this worktree and stays shallow-stable', () => {
+    const worktreeId = 'repo1::/path/wt1'
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const paneKey = makePaneKey('tab-1', leafId)
+    const foreground = { agent: 'kiro' as const, shellForeground: false }
+    const state = {
+      tabsByWorktree: {
+        [worktreeId]: [makeTab('tab-1', worktreeId)]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': makeLayout({ type: 'leaf', leafId }, 'pty-1')
+      },
+      paneForegroundAgentByPaneKey: {
+        [paneKey]: foreground
+      }
+    }
+    const unrelatedUpdate = {
+      ...state,
+      paneForegroundAgentByPaneKey: {
+        ...state.paneForegroundAgentByPaneKey,
+        [makePaneKey('tab-other', '22222222-2222-4222-8222-222222222222')]: {
+          agent: 'codex' as const,
+          shellForeground: false
+        }
+      }
+    }
+
+    const selected = selectPaneForegroundAgentsForWorktree(state, worktreeId)
+    expect(selected).toEqual({ [paneKey]: foreground })
+    expect(
+      shallow(selected, selectPaneForegroundAgentsForWorktree(unrelatedUpdate, worktreeId))
     ).toBe(true)
   })
 

--- a/src/renderer/src/components/sidebar/worktree-card-status-inputs.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-status-inputs.ts
@@ -1,5 +1,8 @@
 import type { AppState } from '@/store/types'
 import type { TerminalPaneLayoutNode } from '../../../../shared/types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import { collectLeafIdsInOrder } from '@/components/terminal-pane/terminal-layout-leaf-ids'
 
 // Why: these selectors return fresh maps whose top-level values preserve
 // underlying per-tab references, so callers must compare them shallowly.
@@ -61,5 +64,32 @@ export function selectTerminalLayoutRootsForWorktrees(
       out[tab.id] = state.terminalLayoutsByTabId[tab.id]?.root
     }
   }
+  return out
+}
+
+type WorktreePaneForegroundAgentState = {
+  tabsByWorktree?: Record<string, readonly { id: string }[]>
+  terminalLayoutsByTabId?: AppState['terminalLayoutsByTabId']
+  paneForegroundAgentByPaneKey?: AppState['paneForegroundAgentByPaneKey']
+}
+
+export function selectPaneForegroundAgentsForWorktree(
+  state: WorktreePaneForegroundAgentState,
+  worktreeId: string
+): Record<string, PaneForegroundAgentEntry> {
+  const out: Record<string, PaneForegroundAgentEntry> = {}
+  const layouts = state.terminalLayoutsByTabId ?? {}
+  const foregroundAgents = state.paneForegroundAgentByPaneKey ?? {}
+
+  for (const tab of state.tabsByWorktree?.[worktreeId] ?? []) {
+    for (const leafId of collectLeafIdsInOrder(layouts[tab.id]?.root)) {
+      const paneKey = makePaneKey(tab.id, leafId)
+      const foreground = foregroundAgents[paneKey]
+      if (foreground) {
+        out[paneKey] = foreground
+      }
+    }
+  }
+
   return out
 }

--- a/src/renderer/src/components/sidebar/worktree-foreground-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-foreground-agent-rows.ts
@@ -1,0 +1,67 @@
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import { formatAgentTypeLabel } from '@/lib/agent-status'
+import { tabHasLivePty } from '@/lib/tab-has-live-pty'
+import type { PaneForegroundAgentEntry } from '@/store/slices/pane-foreground-agent'
+import type {
+  AgentStatusEntry,
+  AgentStatusOrchestrationContext
+} from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
+
+const EMPTY_FOREGROUND_AGENTS: Record<string, PaneForegroundAgentEntry> = {}
+
+export function buildForegroundAgentRows(
+  args: {
+    tabs: TerminalTab[]
+    foregroundAgentsByPaneKey?: Record<string, PaneForegroundAgentEntry>
+    ptyIdsByTabId?: Record<string, string[]>
+    runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
+    now: number
+  },
+  seenPaneKeys: Set<string>
+): DashboardAgentRow[] {
+  const rows: DashboardAgentRow[] = []
+  const tabsById = new Map(args.tabs.map((tab) => [tab.id, tab]))
+
+  for (const [paneKey, foreground] of Object.entries(
+    args.foregroundAgentsByPaneKey ?? EMPTY_FOREGROUND_AGENTS
+  )) {
+    if (!foreground.agent || foreground.shellForeground || seenPaneKeys.has(paneKey)) {
+      continue
+    }
+    const parsed = parsePaneKey(paneKey)
+    const tab = parsed ? tabsById.get(parsed.tabId) : undefined
+    if (!tab || !tabHasLivePty(args.ptyIdsByTabId ?? {}, tab.id)) {
+      continue
+    }
+
+    const label = formatAgentTypeLabel(foreground.agent)
+    const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
+    const entry: AgentStatusEntry = {
+      paneKey,
+      // AgentStatusEntry has no idle state; the row state below is authoritative.
+      state: 'working',
+      prompt: label,
+      updatedAt: args.now,
+      stateStartedAt: 0,
+      stateHistory: [],
+      agentType: foreground.agent,
+      lastAssistantMessage: 'Session active',
+      ...(orchestration ? { orchestration } : {})
+    }
+    // Process identity proves a live session, not turn activity.
+    rows.push({
+      paneKey,
+      entry,
+      tab,
+      agentType: foreground.agent,
+      rowSource: 'live',
+      state: 'idle',
+      startedAt: 0
+    })
+    seenPaneKeys.add(paneKey)
+  }
+
+  return rows
+}

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -25,6 +25,21 @@ describe('agent process recognition', () => {
     expect(isExpectedAgentProcess('/usr/local/bin/openclaude', 'claude')).toBe(false)
   })
 
+  it('recognizes the Kiro CLI foreground process', () => {
+    expect(recognizeAgentProcess('/Users/dev/.local/bin/kiro-cli')).toEqual({
+      agent: 'kiro',
+      processName: 'kiro-cli'
+    })
+    expect(recognizeAgentProcess('/home/dev/.local/bin/kiro-cli')).toEqual({
+      agent: 'kiro',
+      processName: 'kiro-cli'
+    })
+    expect(recognizeAgentProcess(String.raw`C:\Users\dev\AppData\Local\Kiro\kiro-cli.exe`)).toEqual(
+      { agent: 'kiro', processName: 'kiro-cli' }
+    )
+    expect(isRecognizedAgentType('kiro-cli')).toBe(true)
+  })
+
   it('recognizes the Droid foreground process on Windows', () => {
     expect(recognizeAgentProcess(String.raw`C:\Users\dev\AppData\Roaming\npm\droid.cmd`)).toEqual({
       agent: 'droid',

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -24,6 +24,7 @@ export type WellKnownAgentType =
   | 'gemini'
   | 'antigravity'
   | 'amp'
+  | 'kiro'
   | 'opencode'
   | 'mimo-code'
   | 'cursor'

--- a/src/shared/agent-type-label.ts
+++ b/src/shared/agent-type-label.ts
@@ -9,6 +9,7 @@ const WELL_KNOWN_LABELS: Record<string, string> = {
   gemini: 'Gemini',
   antigravity: 'Antigravity',
   amp: 'Amp',
+  kiro: 'Kiro',
   copilot: 'GitHub Copilot',
   opencode: 'OpenCode',
   'mimo-code': 'MiMo Code',


### PR DESCRIPTION
## Summary

- Surface recognized local foreground CLI sessions in Worktree cards when hook and terminal-title metadata are absent.
- Keep explicit hook/title rows authoritative, require a live PTY, and present process-only sessions as neutral idle rows.
- Keep dashboard and sidebar row projection aligned, including a proper Kiro type label.

## Screenshots

<img width="1512" height="982" alt="pr11683" src="https://github.com/user-attachments/assets/0079c352-92b8-4b09-96ba-020d9a5b856c" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] Targeted foreground-session suite: 78/78 passed
- [x] `pnpm build`
- [x] Added regression coverage for foreground-session projection, live-PTY gating, hook/title precedence, pane deduplication, shell cleanup, selector isolation, and dashboard snapshots

## AI Review Report

Read-only review found no blocking issues. It checked row-source precedence, live-PTY gating, pane deduplication, selector stability, dashboard/sidebar parity, and local/SSH/folder-workspace behavior.

## Security Audit

- Reuses the existing allowlisted foreground-agent identity map.
- Does not expose process paths, command lines, prompts, credentials, or secrets.
- Adds no shell execution, IPC channel, dependency, network call, telemetry, or schema migration.
- Process-only rows require a live PTY and disappear when the process returns to the shell.

## Notes

- Rebased onto current `main` (7e60b338e); the three original commits (change + revert pair) are squashed into one.

- Foreground process projection is local-PTY scoped; SSH/remote panes keep their existing identity path.
- Hook and terminal-title status remain authoritative over process-only fallback rows.
- No platform-specific shortcut or path behavior was added.
- X (Twitter) handle: @bamtori_kr