### PR TITLE
[P1] fix(mobile): restore pairing self-heal and recover a wedged handshake

### DIFF
--- a/mobile/src/transport/cellular-connecting-label-stall.test.ts
+++ b/mobile/src/transport/cellular-connecting-label-stall.test.ts
@@ -31,6 +31,9 @@ type CarrierBehavior =
   // Endpoint is healthy but its e2ee_ready lands after readyAfterMs, which a
   // high-latency / lossy cellular link readily pushes past the 5s budget.
   | { kind: 'slow-handshake'; readyAfterMs: number }
+  // Upgrade completes, nothing is ever answered, and the native socket is already
+  // half-open, so RN never delivers a close event for the client's own close().
+  | { kind: 'wedged-open-then-silent' }
 
 let carrier: CarrierBehavior = { kind: 'blackhole' }
 const sockets: CarrierWebSocket[] = []
@@ -54,7 +57,11 @@ class CarrierWebSocket {
       setTimeout(() => this.fail(), 1)
       return
     }
-    if (carrier.kind === 'open-then-silent' || carrier.kind === 'slow-handshake') {
+    if (
+      carrier.kind === 'open-then-silent' ||
+      carrier.kind === 'slow-handshake' ||
+      carrier.kind === 'wedged-open-then-silent'
+    ) {
       setTimeout(() => {
         this.readyState = 1
         this.onopen?.()
@@ -86,6 +93,10 @@ class CarrierWebSocket {
 
   close(): void {
     if (this.readyState === 3) {
+      return
+    }
+    if (carrier.kind === 'wedged-open-then-silent') {
+      this.readyState = 3
       return
     }
     this.fail()
@@ -233,6 +244,35 @@ describe('issue #10119 — what a phone shows while it cannot reach the desktop'
     expect(client.getReconnectAttempt()).toBe(0)
 
     client.close()
+  })
+
+  it('redials after a handshake timeout the wedged transport never reports as closed', () => {
+    carrier = { kind: 'wedged-open-then-silent' }
+    const client = connect('ws://192.168.0.56:6769', 'device-token', 'server-public-key')
+
+    // 200ms upgrade plus the 5s handshake budget, still inside the reconnect delay.
+    vi.advanceTimersByTime(5_400)
+
+    // Without the onclose fallback nothing else leaves 'handshaking': no reconnect
+    // timer is armed, the activity probe bails, and foregrounding is a no-op.
+    expect(sockets).toHaveLength(1)
+    expect(client.getState()).toBe('reconnecting')
+
+    vi.advanceTimersByTime(1_000)
+    expect(sockets).toHaveLength(2)
+
+    client.close()
+  })
+
+  it('escalates past "Connecting…" while every wedged dial swallows its close event', () => {
+    carrier = { kind: 'wedged-open-then-silent' }
+    const samples = observe('ws://192.168.0.56:6769', 900_000)
+
+    expect(Math.max(...samples.map((s) => s.attempts))).toBeGreaterThanOrEqual(12)
+    expect(samples.some((s) => s.label === "Can't reach desktop")).toBe(true)
+
+    const after = labelsAfterFirstEscalation(samples)
+    expect(after.every((s) => s.label !== 'Connecting…')).toBe(true)
   })
 
   it('contrast: an endpoint that RSTs escalates the same way', () => {

--- a/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
@@ -339,6 +339,43 @@ describe('mobile relay pairing journal store', () => {
     await expect(loadMobileRelayPairingJournal()).resolves.toEqual(journal)
   })
 
+  it('self-heals an undecryptable Android secret so the next QR scan can pair', async () => {
+    platform.OS = 'android'
+    const created = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-1',
+      hostName: 'Blue Whale',
+      randomBytes: (length) => new Uint8Array(length).fill(13)
+    })
+    // Why: the candidate race stamps winner/authorizationMode long before pairing completes.
+    const journal = {
+      ...created,
+      metadata: {
+        ...created.metadata,
+        winner: 'relay' as const,
+        authorizationMode: 'relay-basis' as const
+      }
+    }
+    await saveMobileRelayPairingJournal(journal)
+    expect(presenceRaw).toBe('0')
+
+    // Why: Android SecureStore reports an undecryptable keystore entry as null (#6600).
+    secretRaw = null
+
+    await expect(loadMobileRelayPairingJournal()).resolves.toBeNull()
+    expect(metadataRaw).toBeNull()
+    expect(presenceRaw).toBeNull()
+
+    const rescan = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-2',
+      hostName: 'Red Panda',
+      randomBytes: (length) => new Uint8Array(length).fill(14)
+    })
+    await expect(saveMobileRelayPairingJournal(rescan)).resolves.toBeUndefined()
+    await expect(loadMobileRelayPairingJournal()).resolves.toEqual(rescan)
+  })
+
   it('clears metadata before deleting its secret and keeps relay unavailable on web', async () => {
     const journal = createMobileRelayPairingJournal({
       offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },

--- a/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
@@ -364,6 +364,11 @@ describe('mobile relay pairing journal store', () => {
 
     await expect(loadMobileRelayPairingJournal()).resolves.toBeNull()
     expect(metadataRaw).toBeNull()
+    // Why: the presence record must outlive the self-heal so reads stay absent instead of
+    // walking back to an older generation; the metadata-less load sweeps it next.
+    expect(presenceRaw).toBe('0')
+
+    await expect(loadMobileRelayPairingJournal()).resolves.toBeNull()
     expect(presenceRaw).toBeNull()
 
     const rescan = createMobileRelayPairingJournal({

--- a/mobile/src/transport/pairing-keychain.test.ts
+++ b/mobile/src/transport/pairing-keychain.test.ts
@@ -284,7 +284,11 @@ describe('pairing keychain', () => {
     // caller's orphan cleanup unreachable; absent is the only self-healing answer.
     await expect(readPairingKeychainItem(TOKEN_KEY)).resolves.toBeNull()
     expect(secureStoreMock.getItemAsync).toHaveBeenCalledTimes(1)
-    expect(presenceRecord).toBeNull()
+
+    // Why: clearing the presence record would let the next read walk back to 'legacy-token'.
+    expect(presenceRecord).toBe('1')
+    await expect(readPairingKeychainItem(TOKEN_KEY)).resolves.toBeNull()
+    expect(secureStoreMock.getItemAsync).toHaveBeenCalledTimes(2)
   })
 
   it('reads an older value while a newly recorded alias has no item yet', async () => {

--- a/mobile/src/transport/pairing-keychain.test.ts
+++ b/mobile/src/transport/pairing-keychain.test.ts
@@ -246,7 +246,7 @@ describe('pairing keychain', () => {
     expect(secureStoreMock.getItemAsync).toHaveBeenCalledTimes(1)
   })
 
-  it('does not return a stale older value when a recorded current item decrypts as null', async () => {
+  it('self-heals to absent, never a stale older value, when a recorded item decrypts as null', async () => {
     generationRecord = '1'
     let presenceRecord: string | null = null
     asyncStorageMock.getItem.mockImplementation(async (key: string) => {
@@ -263,6 +263,11 @@ describe('pairing keychain', () => {
         presenceRecord = raw
       }
     })
+    asyncStorageMock.removeItem.mockImplementation(async (key: string) => {
+      if (key === TOKEN_PRESENCE_KEY) {
+        presenceRecord = null
+      }
+    })
 
     await writePairingKeychainItem(TOKEN_KEY, 'rotated-token')
     expect(presenceRecord).toBe('1')
@@ -275,8 +280,11 @@ describe('pairing keychain', () => {
       serviceOf(options) === undefined ? 'legacy-token' : null
     )
 
-    await expect(readPairingKeychainItem(TOKEN_KEY)).rejects.toThrow(/recorded generation/)
+    // Why: Android cannot distinguish absent from undecryptable, and a throw here left every
+    // caller's orphan cleanup unreachable; absent is the only self-healing answer.
+    await expect(readPairingKeychainItem(TOKEN_KEY)).resolves.toBeNull()
     expect(secureStoreMock.getItemAsync).toHaveBeenCalledTimes(1)
+    expect(presenceRecord).toBeNull()
   })
 
   it('reads an older value while a newly recorded alias has no item yet', async () => {

--- a/mobile/src/transport/pairing-keychain.ts
+++ b/mobile/src/transport/pairing-keychain.ts
@@ -134,6 +134,17 @@ async function preparePresenceWrite(
   return { storageKey, previousRaw }
 }
 
+async function clearPresence(key: string): Promise<void> {
+  if (Platform.OS !== 'android') {
+    return
+  }
+  try {
+    await AsyncStorage.removeItem(presenceStorageKey(key))
+  } catch {
+    // Why: the read already self-healed; a stuck presence record must not fail the caller.
+  }
+}
+
 async function restorePresence(change: PresenceChange | null): Promise<void> {
   if (!change) {
     return
@@ -162,7 +173,11 @@ export async function readPairingKeychainItem(key: string): Promise<string | nul
   if (presenceGeneration !== null) {
     const value = await SecureStore.getItemAsync(key, optionsForGeneration(presenceGeneration))
     if (value === null) {
-      throw new Error('pairing keychain item is unavailable at its recorded generation')
+      // Why: Android reports an undecryptable entry as null, so failing closed here latched
+      // callers out of their own orphan cleanup forever; report absent and drop the stale
+      // claim instead, without ever falling back to the superseded older generation.
+      await clearPresence(key)
+      return null
     }
     return value
   }

--- a/mobile/src/transport/pairing-keychain.ts
+++ b/mobile/src/transport/pairing-keychain.ts
@@ -134,17 +134,6 @@ async function preparePresenceWrite(
   return { storageKey, previousRaw }
 }
 
-async function clearPresence(key: string): Promise<void> {
-  if (Platform.OS !== 'android') {
-    return
-  }
-  try {
-    await AsyncStorage.removeItem(presenceStorageKey(key))
-  } catch {
-    // Why: the read already self-healed; a stuck presence record must not fail the caller.
-  }
-}
-
 async function restorePresence(change: PresenceChange | null): Promise<void> {
   if (!change) {
     return
@@ -174,9 +163,10 @@ export async function readPairingKeychainItem(key: string): Promise<string | nul
     const value = await SecureStore.getItemAsync(key, optionsForGeneration(presenceGeneration))
     if (value === null) {
       // Why: Android reports an undecryptable entry as null, so failing closed here latched
-      // callers out of their own orphan cleanup forever; report absent and drop the stale
-      // claim instead, without ever falling back to the superseded older generation.
-      await clearPresence(key)
+      // callers out of their own orphan cleanup forever; report absent instead. The presence
+      // record must survive — it is the only thing that keeps a later read from resurrecting
+      // the superseded value under an older generation. Callers clear it via delete or a
+      // re-pair write, so a legitimately-current older value is traded for re-pairing.
       return null
     }
     return value

--- a/mobile/src/transport/rpc-client-synthesized-close-diagnostics.test.ts
+++ b/mobile/src/transport/rpc-client-synthesized-close-diagnostics.test.ts
@@ -1,0 +1,169 @@
+// Why: RN can swallow onclose for a wedged iOS transport, so the client synthesizes the close.
+// These cover the diagnostic clocks that synthesis has to keep honest, and prove synthesis
+// never costs us the auth-failed latch when the real close lands late.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { connect } from './rpc-client'
+
+vi.mock('./e2ee', () => ({
+  generateKeyPair: () => ({
+    publicKey: new Uint8Array(32),
+    secretKey: new Uint8Array(32)
+  }),
+  deriveSharedKey: () => new Uint8Array(32),
+  publicKeyFromBase64: () => new Uint8Array(32),
+  publicKeyToBase64: () => 'client-public-key',
+  encrypt: (plaintext: string) => `encrypted:${plaintext}`,
+  decrypt: (raw: string) => raw.replace(/^encrypted:/, ''),
+  decryptBytes: (bytes: Uint8Array) => bytes
+}))
+
+// Why: close() deliberately never fires onclose — that is the wedged-transport bug being modelled.
+class WedgedWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readonly CONNECTING = WedgedWebSocket.CONNECTING
+  readonly OPEN = WedgedWebSocket.OPEN
+  readonly CLOSING = WedgedWebSocket.CLOSING
+  readonly CLOSED = WedgedWebSocket.CLOSED
+
+  readyState = WedgedWebSocket.CONNECTING
+  onopen: (() => void) | null = null
+  onclose: ((event?: { code?: number; reason?: string; wasClean?: boolean }) => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onerror: (() => void) | null = null
+  sent: string[] = []
+  close = vi.fn(() => {
+    this.readyState = WedgedWebSocket.CLOSED
+  })
+
+  constructor(readonly endpoint: string) {
+    sockets.push(this)
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload)
+  }
+
+  open(): void {
+    this.readyState = WedgedWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  receive(payload: unknown): void {
+    this.onmessage?.({ data: payload })
+  }
+
+  // Why: the close event the native layer eventually coughs up, possibly long after we gave up.
+  deliverClose(code: number, reason = ''): void {
+    this.readyState = WedgedWebSocket.CLOSED
+    this.onclose?.({ code, reason, wasClean: true })
+  }
+}
+
+const sockets: WedgedWebSocket[] = []
+const originalWebSocket = globalThis.WebSocket
+
+function lastSocket(): WedgedWebSocket {
+  return sockets[sockets.length - 1]!
+}
+
+function openConnectionLogs(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown>[] {
+  return spy.mock.calls
+    .filter((call) => call[0] === '[net] openConnection')
+    .map((call) => call[1] as Record<string, unknown>)
+}
+
+describe('synthesized close diagnostics', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    sockets.length = 0
+    globalThis.WebSocket = WedgedWebSocket as unknown as typeof WebSocket
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+    vi.useRealTimers()
+    globalThis.WebSocket = originalWebSocket
+  })
+
+  it('records the close clock when a handshake timeout synthesizes the close', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    lastSocket().open()
+
+    // 5s handshake budget elapses with no e2ee_ready — the client closes and synthesizes onclose.
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(client.getState()).toBe('reconnecting')
+
+    // 500ms is the first reconnect delay; the redial log must date the close it just made.
+    await vi.advanceTimersByTimeAsync(500)
+    expect(sockets).toHaveLength(2)
+
+    const redial = openConnectionLogs(logSpy)[1]
+    expect(redial?.msSinceLastClose).toBe(500)
+
+    client.close()
+  })
+
+  it('keeps the replacement socket clock when the swallowed close arrives late', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const wedged = lastSocket()
+    wedged.open()
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(500)
+    expect(sockets).toHaveLength(2)
+
+    // The native layer finally reports the dead socket's close, 200ms into the replacement's life.
+    await vi.advanceTimersByTimeAsync(200)
+    wedged.deliverClose(1006)
+
+    // The replacement's own close must still be able to date itself against its open.
+    await vi.advanceTimersByTimeAsync(300)
+    lastSocket().deliverClose(1006)
+    const closeLog = logSpy.mock.calls.findLast((call) => call[0] === '[net] ws.onclose')?.[1] as
+      | Record<string, unknown>
+      | undefined
+    expect(closeLog?.constructToCloseMs).toBe(500)
+
+    client.close()
+  })
+
+  it('still latches auth-failed when a real 4001 lands after a synthesized close', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const wedged = lastSocket()
+    wedged.open()
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(client.getState()).toBe('reconnecting')
+
+    // The revoked-device close finally surfaces, after synthesis already gave up on this socket.
+    wedged.deliverClose(4001, 'Unauthorized')
+
+    for (let i = 0; i < 3; i++) {
+      const previous = lastSocket()
+      await vi.advanceTimersByTimeAsync(2_500)
+      expect(lastSocket()).not.toBe(previous)
+      const socket = lastSocket()
+      expect(socket.readyState).toBe(WedgedWebSocket.CONNECTING)
+      socket.open()
+      socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
+      socket.deliverClose(4001, 'Unauthorized')
+    }
+
+    expect(client.getState()).toBe('auth-failed')
+
+    // A latched client must stay latched and stop redialling.
+    const dialCount = sockets.length
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(sockets).toHaveLength(dialCount)
+    expect(client.getState()).toBe('auth-failed')
+
+    client.close()
+  })
+})

--- a/mobile/src/transport/rpc-client-synthesized-close-diagnostics.test.ts
+++ b/mobile/src/transport/rpc-client-synthesized-close-diagnostics.test.ts
@@ -115,13 +115,25 @@ describe('synthesized close diagnostics', () => {
     const wedged = lastSocket()
     wedged.open()
 
-    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(100)
+    wedged.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    await vi.advanceTimersByTimeAsync(4_900)
     await vi.advanceTimersByTimeAsync(500)
     expect(sockets).toHaveLength(2)
+    const replacement = lastSocket()
+    replacement.open()
+    replacement.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    replacement.receive('encrypted:{"type":"e2ee_authenticated"}')
 
     // The native layer finally reports the dead socket's close, 200ms into the replacement's life.
     await vi.advanceTimersByTimeAsync(200)
     wedged.deliverClose(1006)
+    const staleCloseLog = logSpy.mock.calls.findLast(
+      (call) => call[0] === '[net] ws.onclose'
+    )?.[1] as Record<string, unknown> | undefined
+    expect(staleCloseLog?.constructToCloseMs).toBe(5_700)
+    expect(staleCloseLog?.aliveMs).toBeNull()
+    expect(staleCloseLog?.inboundIdleMs).toBe(5_600)
 
     // The replacement's own close must still be able to date itself against its open.
     await vi.advanceTimersByTimeAsync(300)
@@ -130,6 +142,8 @@ describe('synthesized close diagnostics', () => {
       | Record<string, unknown>
       | undefined
     expect(closeLog?.constructToCloseMs).toBe(500)
+    expect(closeLog?.aliveMs).toBe(500)
+    expect(closeLog?.inboundIdleMs).toBe(500)
 
     client.close()
   })
@@ -138,30 +152,68 @@ describe('synthesized close diagnostics', () => {
     const client = connect('ws://desktop.invalid', 'token', 'server-key')
     const wedged = lastSocket()
     wedged.open()
-
     await vi.advanceTimersByTimeAsync(5_000)
     expect(client.getState()).toBe('reconnecting')
+    await vi.advanceTimersByTimeAsync(500)
+    const replacement = lastSocket()
 
-    // The revoked-device close finally surfaces, after synthesis already gave up on this socket.
+    // The rejection counts, but stale cleanup must not disturb the replacement or its timer path.
     wedged.deliverClose(4001, 'Unauthorized')
+    expect(lastSocket()).toBe(replacement)
+    expect(replacement.close).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(sockets).toHaveLength(2)
+    expect(lastSocket()).toBe(replacement)
+    expect(client.getState()).toBe('connecting')
 
-    for (let i = 0; i < 3; i++) {
-      const previous = lastSocket()
-      await vi.advanceTimersByTimeAsync(2_500)
-      expect(lastSocket()).not.toBe(previous)
+    for (let rejection = 0; rejection < 2; rejection += 1) {
       const socket = lastSocket()
-      expect(socket.readyState).toBe(WedgedWebSocket.CONNECTING)
       socket.open()
       socket.receive(JSON.stringify({ type: 'e2ee_ready' }))
       socket.deliverClose(4001, 'Unauthorized')
+      if (rejection === 0) {
+        await vi.advanceTimersByTimeAsync(2_500)
+      }
     }
 
     expect(client.getState()).toBe('auth-failed')
+    expect(sockets).toHaveLength(3)
 
     // A latched client must stay latched and stop redialling.
     const dialCount = sockets.length
     await vi.advanceTimersByTimeAsync(10 * 60_000)
     expect(sockets).toHaveLength(dialCount)
+    expect(client.getState()).toBe('auth-failed')
+
+    client.close()
+  })
+
+  it('ignores a stale 4001 after the replacement authenticates', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const wedged = lastSocket()
+    wedged.open()
+    await vi.advanceTimersByTimeAsync(5_500)
+
+    const replacement = lastSocket()
+    replacement.open()
+    replacement.receive(JSON.stringify({ type: 'e2ee_ready' }))
+    replacement.receive('encrypted:{"type":"e2ee_authenticated"}')
+    expect(client.getState()).toBe('connected')
+
+    wedged.deliverClose(4001, 'Unauthorized')
+    expect(client.getState()).toBe('connected')
+    expect(replacement.close).not.toHaveBeenCalled()
+
+    for (let rejection = 0; rejection < 2; rejection += 1) {
+      const socket = lastSocket()
+      socket.deliverClose(4001, 'Unauthorized')
+      expect(client.getState()).toBe('reconnecting')
+      await vi.advanceTimersByTimeAsync(rejection === 0 ? 500 : 1_000)
+      lastSocket().open()
+      lastSocket().receive(JSON.stringify({ type: 'e2ee_ready' }))
+    }
+
+    lastSocket().deliverClose(4001, 'Unauthorized')
     expect(client.getState()).toBe('auth-failed')
 
     client.close()

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -27,7 +27,12 @@ import {
   buildTerminalUnsubscribeParams,
   updateTerminalSubscriptionViewport as updateCachedTerminalSubscriptionViewport
 } from './rpc-client-terminal-subscription'
-import { describeSocketEvent } from './socket-event-debug'
+import { describeSocketEvent, redactSocketEndpoint } from './socket-event-debug'
+import {
+  isStaleRpcSocketEvent,
+  logRpcSocketClose,
+  RpcSynthesizedCloseIndex
+} from './rpc-socket-close-evidence'
 import { markRpcDeliveryUnknown } from './rpc-delivery-ambiguity'
 import { openRpcRequestBudget, resolvePostConnectRequestTimeout } from './rpc-request-budget'
 import { isRpcResponse } from './rpc-response-shape'
@@ -157,6 +162,7 @@ export function connect(
     })
   }
   let ws: WebSocket | null = null
+  const synthesizedCloses = new RpcSynthesizedCloseIndex()
   let state: ConnectionState = 'disconnected'
   let requestCounter = 0
   let reconnectAttempt = 0
@@ -168,13 +174,13 @@ export function connect(
   let intentionallyClosed = false
   // Consecutive auth rejections; tolerate up to AUTH_RETRY_BUDGET (issue #5200) before latching to avoid a needless re-pair.
   let authRejectionCount = 0
+  let authenticationGeneration = 0
   let lastConnectedAt: number | null = null
   // Why: cheap diagnostics for RN/OkHttp process-state poisoning (retry cadence, inbound traffic, close timing).
   let lastInboundAt: number | null = null
   let inboundSequence = 0
   let lastWsClosedAt: number | null = null
   let wsConstructionCounter = 0
-  let currentWsOpenedAt: number | null = null
 
   // Why: fresh ephemeral keypair per connection provides forward secrecy.
   let sharedKey: Uint8Array | null = null
@@ -220,10 +226,11 @@ export function connect(
       to: next,
       dweltMs: dwelt,
       attempt: reconnectAttempt,
-      endpoint: redactedEndpoint(endpoint)
+      endpoint: redactSocketEndpoint(endpoint)
     })
     if (next === 'connected') {
       lastConnectedAt = Date.now()
+      authenticationGeneration++
       // Why: only a completed E2EE handshake proves the path is healthy (issue #10119).
       reconnectAttempt = 0
       // Why: a clean handshake proves the token is valid — reset the auth retry budget.
@@ -241,15 +248,6 @@ export function connect(
     }
     for (const listener of stateListeners) {
       listener(next)
-    }
-  }
-
-  // Why: keep device tokens / full URLs out of log scrolls — truncate to host:port.
-  function redactedEndpoint(ep: string): string {
-    try {
-      return new URL(ep).host || 'unknown'
-    } catch {
-      return 'unknown'
     }
   }
 
@@ -296,7 +294,7 @@ export function connect(
     wsConstructionCounter++
     console.log('[net] openConnection', {
       attempt: reconnectAttempt,
-      endpoint: redactedEndpoint(endpoint),
+      endpoint: redactSocketEndpoint(endpoint),
       // Why: diagnostic for RN/OkHttp pool corruption — high wsCount + repeated 1006 closes means process-state stuck.
       wsCount: wsConstructionCounter,
       msSinceLastConnected: lastConnectedAt != null ? now - lastConnectedAt : null,
@@ -306,27 +304,16 @@ export function connect(
     setState('connecting')
     sharedKey = null
 
-    currentWsOpenedAt = now
     emitLog(
       'info',
       reconnectAttempt > 0 ? `Reconnecting (attempt ${reconnectAttempt + 1})` : 'Opening WebSocket',
-      redactedEndpoint(endpoint)
+      redactSocketEndpoint(endpoint)
     )
 
     ws = new WebSocket(endpoint)
     const openingWs = ws
-    const ignoreStaleSocketEvent = (eventName: string): boolean => {
-      if (ws === openingWs) {
-        return false
-      }
-      // Why: RN can deliver callbacks from a timed-out socket after reconnect swapped in a replacement — ignore them.
-      console.log('[net] stale ws event ignored', {
-        eventName,
-        state,
-        attempt: reconnectAttempt
-      })
-      return true
-    }
+    let openingWsAuthenticated = false
+    let openingWsLastInboundAt: number | null = null
 
     // Why: RN can leave opens pending forever on flaky handoffs — force reconnect if onopen never arrives.
     connectTimer = setTimeout(() => {
@@ -343,13 +330,14 @@ export function connect(
         )
         openingWs.close()
         if (ws === openingWs) {
+          synthesizedCloses.remember(openingWs, authenticationGeneration)
           handleSocketClosed(openingWs, { timedOut: true })
         }
       }
     }, CONNECT_TIMEOUT_MS)
 
     ws.onopen = () => {
-      if (ignoreStaleSocketEvent('open')) {
+      if (isStaleRpcSocketEvent(ws, openingWs, 'open', state, reconnectAttempt)) {
         return
       }
       console.log('[net] ws.onopen', { attempt: reconnectAttempt })
@@ -387,20 +375,23 @@ export function connect(
         openingWs.close()
         // Why: React Native can omit onclose for a wedged iOS transport.
         if (ws === openingWs) {
+          synthesizedCloses.remember(openingWs, authenticationGeneration)
           handleSocketClosed(openingWs, { timedOut: true })
         }
       }, HANDSHAKE_TIMEOUT_MS)
     }
 
     ws.onmessage = (event) => {
-      if (ignoreStaleSocketEvent('message')) {
+      if (isStaleRpcSocketEvent(ws, openingWs, 'message', state, reconnectAttempt)) {
         return
       }
       void handleSocketMessage(event.data)
     }
 
     async function handleSocketMessage(rawData: unknown) {
-      lastInboundAt = Date.now()
+      const receivedAt = Date.now()
+      lastInboundAt = receivedAt
+      openingWsLastInboundAt = receivedAt
       const raw = typeof rawData === 'string' ? rawData : null
 
       // Why: e2ee_ready is plaintext (precedes encrypted auth); e2ee_authenticated/e2ee_error are encrypted.
@@ -438,6 +429,7 @@ export function connect(
             console.log('[net] e2ee_authenticated — connected', {
               streamCount: streamListeners.size
             })
+            openingWsAuthenticated = true
             setState('connected')
             emitLog('success', 'Authenticated', 'Channel ready for RPC')
             startActivityProbe()
@@ -603,34 +595,21 @@ export function connect(
     }
 
     ws.onclose = (event) => {
-      const e = event as { code?: number; reason?: string; wasClean?: boolean } | undefined
-      const closeAt = Date.now()
-      // Why: time-since-construct classifies the failure — instant close = RST/unreachable, slow = SYN timeout/packet loss.
-      const constructToCloseMs = currentWsOpenedAt != null ? closeAt - currentWsOpenedAt : null
-      const aliveMs =
-        currentWsOpenedAt != null && state === 'connected' ? closeAt - currentWsOpenedAt : null
-      const inboundIdleMs = lastInboundAt != null ? closeAt - lastInboundAt : null
-      // Why: statically imported — a hot-reload bug came from a stale closure capturing a half-loaded module.
-      const closeEvent = describeSocketEvent(event)
-      console.log('[net] ws.onclose', {
-        code: e?.code,
-        reason: e?.reason,
-        wasClean: e?.wasClean,
+      const closeCode = logRpcSocketClose({
+        event,
         state,
         attempt: reconnectAttempt,
         intentionallyClosed,
-        endpoint: redactedEndpoint(endpoint),
-        constructToCloseMs,
-        aliveMs,
-        inboundIdleMs,
-        eventKeys: closeEvent.keys,
-        eventStr: closeEvent.json
+        endpoint: redactSocketEndpoint(endpoint),
+        constructedAt: now,
+        authenticated: openingWsAuthenticated,
+        lastInboundAt: openingWsLastInboundAt
       })
-      handleSocketClosed(openingWs, { closeCode: e?.code })
+      handleSocketClosed(openingWs, { closeCode })
     }
 
     ws.onerror = (event) => {
-      if (ignoreStaleSocketEvent('error')) {
+      if (isStaleRpcSocketEvent(ws, openingWs, 'error', state, reconnectAttempt)) {
         return
       }
       // Why: RN surfaces the original network error here — onclose follows but its close code alone hides the cause.
@@ -651,16 +630,24 @@ export function connect(
     opts: { timedOut?: boolean; closeCode?: number } = {}
   ) {
     if (ws !== closedWs) {
+      if (
+        synthesizedCloses.takeUnauthorized(
+          closedWs,
+          opts.closeCode,
+          authenticationGeneration,
+          UNAUTHORIZED_CLOSE_CODE
+        )
+      ) {
+        handleAuthRejection('Unauthorized — pairing may be revoked', true)
+        return
+      }
       console.log('[net] handleSocketClosed STALE — ignoring (ws already swapped)', {
         state,
         attempt: reconnectAttempt
       })
       return
     }
-    // Why: log-only close clocks live behind the stale guard so synthesized closes record them too,
-    // and a late onclose from a dead socket can't clobber the replacement's timings.
     lastWsClosedAt = Date.now()
-    currentWsOpenedAt = null
     clearConnectTimer()
     ws = null
     sharedKey = null
@@ -701,21 +688,24 @@ export function connect(
   }
 
   // Why: an auth rejection may be transient (issue #5200) — retry up to AUTH_RETRY_BUDGET times before latching auth-failed.
-  function handleAuthRejection(reason: string): void {
-    activeBrowserScreencastRequestId = null
-    pendingBrowserScreencastRequestId = null
+  function handleAuthRejection(reason: string, preserveRecovery = false): void {
     authRejectionCount++
     if (authRejectionCount < AUTH_RETRY_BUDGET) {
       console.log('[net] auth rejected — retrying handshake', {
         attempt: authRejectionCount,
         budget: AUTH_RETRY_BUDGET,
-        endpoint: redactedEndpoint(endpoint)
+        endpoint: redactSocketEndpoint(endpoint)
       })
       emitLog(
         'warn',
         'Authentication rejected',
         `Retrying (${authRejectionCount}/${AUTH_RETRY_BUDGET})`
       )
+      if (preserveRecovery) {
+        return
+      }
+      activeBrowserScreencastRequestId = null
+      pendingBrowserScreencastRequestId = null
       // Why: close without setting intentionallyClosed so handleSocketClosed routes to reconnect and retries the handshake.
       const closing = ws
       ws = null
@@ -730,9 +720,11 @@ export function connect(
       scheduleReconnect()
       return
     }
+    activeBrowserScreencastRequestId = null
+    pendingBrowserScreencastRequestId = null
     console.log('[net] auth rejected — budget exhausted, latching auth-failed', {
       attempt: authRejectionCount,
-      endpoint: redactedEndpoint(endpoint)
+      endpoint: redactSocketEndpoint(endpoint)
     })
     intentionallyClosed = true
     ws?.close()
@@ -799,6 +791,7 @@ export function connect(
         probeWs.close()
         // Why: React Native can omit onclose for a wedged iOS transport.
         if (probeWs === ws) {
+          synthesizedCloses.remember(probeWs, authenticationGeneration)
           handleSocketClosed(probeWs, { timedOut: true })
         }
       }
@@ -979,6 +972,7 @@ export function connect(
       console.log('[net] sendEncrypted detected ws desync — forcing reconnect', {
         readyState: ws.readyState
       })
+      synthesizedCloses.remember(ws, authenticationGeneration)
       handleSocketClosed(ws, { timedOut: false })
     }
     return false

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -626,8 +626,6 @@ export function connect(
         eventKeys: closeEvent.keys,
         eventStr: closeEvent.json
       })
-      lastWsClosedAt = closeAt
-      currentWsOpenedAt = null
       handleSocketClosed(openingWs, { closeCode: e?.code })
     }
 
@@ -659,6 +657,10 @@ export function connect(
       })
       return
     }
+    // Why: log-only close clocks live behind the stale guard so synthesized closes record them too,
+    // and a late onclose from a dead socket can't clobber the replacement's timings.
+    lastWsClosedAt = Date.now()
+    currentWsOpenedAt = null
     clearConnectTimer()
     ws = null
     sharedKey = null

--- a/mobile/src/transport/rpc-client.ts
+++ b/mobile/src/transport/rpc-client.ts
@@ -385,6 +385,10 @@ export function connect(
           `No e2ee_ready/e2ee_authenticated within ${HANDSHAKE_TIMEOUT_MS / 1000}s`
         )
         openingWs.close()
+        // Why: React Native can omit onclose for a wedged iOS transport.
+        if (ws === openingWs) {
+          handleSocketClosed(openingWs, { timedOut: true })
+        }
       }, HANDSHAKE_TIMEOUT_MS)
     }
 

--- a/mobile/src/transport/rpc-socket-close-evidence.ts
+++ b/mobile/src/transport/rpc-socket-close-evidence.ts
@@ -1,0 +1,70 @@
+import { describeSocketEvent } from './socket-event-debug'
+import type { ConnectionState } from './types'
+
+type SocketCloseLogOptions = {
+  event: unknown
+  state: ConnectionState
+  attempt: number
+  intentionallyClosed: boolean
+  endpoint: string
+  constructedAt: number
+  authenticated: boolean
+  lastInboundAt: number | null
+}
+
+export class RpcSynthesizedCloseIndex {
+  private readonly authenticationBySocket = new WeakMap<WebSocket, number>()
+
+  remember(socket: WebSocket, authenticationGeneration: number): void {
+    this.authenticationBySocket.set(socket, authenticationGeneration)
+  }
+
+  takeUnauthorized(
+    socket: WebSocket,
+    closeCode: number | undefined,
+    authenticationGeneration: number,
+    unauthorizedCloseCode: number
+  ): boolean {
+    const synthesizedAtGeneration = this.authenticationBySocket.get(socket)
+    this.authenticationBySocket.delete(socket)
+    return (
+      closeCode === unauthorizedCloseCode && synthesizedAtGeneration === authenticationGeneration
+    )
+  }
+}
+
+export function isStaleRpcSocketEvent(
+  current: WebSocket | null,
+  opening: WebSocket,
+  eventName: string,
+  state: ConnectionState,
+  attempt: number
+): boolean {
+  if (current === opening) {
+    return false
+  }
+  console.log('[net] stale ws event ignored', { eventName, state, attempt })
+  return true
+}
+
+export function logRpcSocketClose(options: SocketCloseLogOptions): number | undefined {
+  const event = options.event as { code?: number; reason?: string; wasClean?: boolean } | undefined
+  const closeAt = Date.now()
+  const constructToCloseMs = closeAt - options.constructedAt
+  const closeEvent = describeSocketEvent(options.event)
+  console.log('[net] ws.onclose', {
+    code: event?.code,
+    reason: event?.reason,
+    wasClean: event?.wasClean,
+    state: options.state,
+    attempt: options.attempt,
+    intentionallyClosed: options.intentionallyClosed,
+    endpoint: options.endpoint,
+    constructToCloseMs,
+    aliveMs: options.authenticated ? constructToCloseMs : null,
+    inboundIdleMs: options.lastInboundAt != null ? closeAt - options.lastInboundAt : null,
+    eventKeys: closeEvent.keys,
+    eventStr: closeEvent.json
+  })
+  return event?.code
+}

--- a/mobile/src/transport/socket-event-debug.ts
+++ b/mobile/src/transport/socket-event-debug.ts
@@ -32,3 +32,11 @@ export function describeSocketEvent(event: unknown): { keys: string[]; json: str
   }
   return { keys, json }
 }
+
+export function redactSocketEndpoint(endpoint: string): string {
+  try {
+    return new URL(endpoint).host || 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}


### PR DESCRIPTION
## ELI5

Your phone keeps the desktop-pairing secret in the Android keystore, plus a sticky note in ordinary storage saying "the secret is in drawer 1". If the keystore key gets corrupted or an OS backup restores the sticky note but not the keystore, Android hands back "nothing" — and it hands back the exact same "nothing" whether the drawer is empty or the contents are unreadable. We recently taught the app to treat that "nothing" as a hard error. But the app's own cleanup routine was waiting to hear "nothing" so it could throw away the leftover paperwork and let you re-pair. Now it hears an error instead, gives up, and the leftover paperwork blocks every future QR scan. There is no button that fixes it — only wiping app data. This PR makes that case say "nothing's there" again — while deliberately keeping the sticky note, so a later read can never wander into an older drawer and hand back a secret that was already replaced. The cleanup routine then tears up the paperwork and the next scan pairs.

Separately: when a connection stalls mid-handshake we close the socket and wait for the OS to tell us it closed. On a wedged iOS transport that message never arrives, so the app sits on "Connecting…" forever. We now assume the close and reconnect ourselves, like the other two timeout paths already do.

## Summary

- `readPairingKeychainItem` failed closed on a null read at the recorded presence generation (`mobile/src/transport/pairing-keychain.ts:173-181`), but the module's own comment at `:129` notes Expo Android returns null for both absent and undecryptable entries — so the #6600 keystore fault, and OS restores that carry AsyncStorage without the keystore alias, took the throw.
- That made the journal store's self-heal unreachable: `mobile/src/transport/mobile-relay-pairing-journal-store.ts:63-67` clears orphan metadata only on a `null` secret. `mobile-relay-pairing-recovery.ts` swallows the rejection and returns `deferred`, leaving winner-stamped metadata behind, after which `saveMobileRelayPairingJournal` (`:32-38`) rejects every later QR scan with `mobile relay pairing recovery pending` — permanently, with no in-app recovery.
- Fix: report absent, and keep the presence record (`mobile/src/transport/pairing-keychain.ts:164-172`). #11430's invariant is preserved permanently — the presence record is the only thing that stops the generation walk, so clearing it would let the *next* read fall back to the superseded value under an older generation; the read now returns `null` instead of throwing and nothing else changes. Callers do the cleanup they already did: the journal store's metadata-less load calls `deletePairingKeychainItem`, which sweeps every generation and the presence record, and a re-pair write re-stamps it. This also matches the host-token precedent, where `doLoadHosts` treats a missing token as "skip the host" (`mobile/src/transport/host-store.ts:141-149`).
- Tradeoff: a presence record left pointing at a generation whose write failed *and* whose presence rollback also failed (`setItemAtGeneration:152`) makes a still-valid older value read as absent until a delete or re-pair. That is strictly better than #11430, which threw forever in the same state, and absent-over-superseded is the invariant #11430 chose.
- The handshake-timeout path called `openingWs.close()` with no `handleSocketClosed` fallback (`mobile/src/transport/rpc-client.ts:387`), unlike the connect-timeout path (`:344-347`) and the activity-probe path (`:795-801`). With `onclose` omitted, `ws` stayed non-null and `state` stayed `handshaking`: `scheduleReconnect` is only reached from `handleSocketClosed`, `runActivityProbe` bails on `state !== 'connected'`, `notifyForeground` handles only `connected`/`reconnecting`, and the relay supervisor's `needsRecovery` explicitly excludes `handshaking`.
- Fix: mirror the existing fallback, guarded by the same current-socket identity check (`mobile/src/transport/rpc-client.ts:388-391`).

## Regression source

Introduced by #11430 (7db0101bcb) — "fix(mobile): recover pairing saves from Android SecureStore failures" added the presence record and made a null read at the recorded generation throw where it previously returned null.
Introduced by #11368 (89a9d4fbda) — "fix(mobile): recover when half-open sockets omit close events" added the omitted-onclose fallback to the activity-probe path but not to the handshake-timeout path.

## Test plan

`mobile` suite via `./node_modules/.bin/vitest run --config vitest.config.ts src/transport` — 61 files, 409 passed, 3 skipped. Full mobile suite: 2647 passed; the only failures are 10 pre-existing `src/terminal/*` files that need the un-built `terminal-webview-engine.generated.ts` artifact, unrelated to this change and failing identically on `origin/main`. `npx oxlint` clean on all five changed files; `tsc --noEmit` reports only the same pre-existing generated-artifact error.

Regression tests, each verified failing with the production files reverted to `origin/main` and passing with the fix:

- `mobile/src/transport/mobile-relay-pairing-journal-store.test.ts` — "self-heals an undecryptable Android secret so the next QR scan can pair": saves a winner-stamped Android journal, makes SecureStore report the entry as null, and asserts the load returns `null` and clears the metadata while the presence record survives, that the following metadata-less load sweeps the presence record, and that a fresh scan then saves and loads. Observed on unfixed code: `AssertionError: promise rejected "Error: pairing keychain item is unavailab…" instead of resolving`.
- `mobile/src/transport/pairing-keychain.test.ts` — "self-heals to absent, never a stale older value, when a recorded item decrypts as null" (the existing #11430 case, re-pointed): still asserts exactly one `getItemAsync` probe so no older generation is resurrected, now asserting `null`, a retained presence record, and that a *second* read is still `null` with one further single probe. Observed on unfixed code: `AssertionError: promise rejected "Error: pairing keychain item is unavailab…" instead of resolving`.
- `mobile/src/transport/cellular-connecting-label-stall.test.ts` — "redials after a handshake timeout the wedged transport never reports as closed": new `wedged-open-then-silent` carrier whose `close()` swallows the close event. Observed on unfixed code: `AssertionError: expected 'handshaking' to be 'reconnecting'`.
- `mobile/src/transport/cellular-connecting-label-stall.test.ts` — "escalates past 'Connecting…' while every wedged dial swallows its close event": 15 simulated minutes on the same carrier must reach the unreachable gate. Observed on unfixed code: `AssertionError: expected 0 to be greater than or equal to 12` (the attempt counter never moves because the client never leaves `handshaking`).

Found by the production release scan of v1.4.163-rc.0..origin/main.

Made with [Orca](https://github.com/stablyai/orca) 🐋

