### PR TITLE
perf: coalesce cancellable git status reads

### DIFF
--- a/src/main/git/git-status-read-lease-owner.test.ts
+++ b/src/main/git/git-status-read-lease-owner.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest'
+import { GitStatusReadLeaseOwner } from './git-status-read-lease-owner'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('GitStatusReadLeaseOwner', () => {
+  it('cancels first and later callers without aborting a remaining lease', async () => {
+    const owner = new GitStatusReadLeaseOwner<string>()
+    const pending = deferred<string>()
+    const load = vi.fn((_signal: AbortSignal) => pending.promise)
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const thirdController = new AbortController()
+    const firstError = new Error('first cancelled')
+    const thirdError = new Error('third cancelled')
+
+    const first = owner.lease('repo', firstController.signal, load)
+    const second = owner.lease('repo', secondController.signal, load)
+    const third = owner.lease('repo', thirdController.signal, load)
+    firstController.abort(firstError)
+    thirdController.abort(thirdError)
+
+    await expect(first).rejects.toBe(firstError)
+    await expect(third).rejects.toBe(thirdError)
+    expect(load).toHaveBeenCalledOnce()
+    expect(load.mock.calls[0][0].aborted).toBe(false)
+
+    pending.resolve('fresh')
+    await expect(second).resolves.toBe('fresh')
+  })
+
+  it('aborts underlying work when every live lease cancels and admits a fresh read', async () => {
+    const owner = new GitStatusReadLeaseOwner<string>()
+    const firstPending = deferred<string>()
+    const secondPending = deferred<string>()
+    const signals: AbortSignal[] = []
+    const load = vi.fn((signal: AbortSignal) => {
+      signals.push(signal)
+      return signals.length === 1 ? firstPending.promise : secondPending.promise
+    })
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+
+    const first = owner.lease('repo', firstController.signal, load)
+    const second = owner.lease('repo', secondController.signal, load)
+    firstController.abort(new Error('first cancelled'))
+    expect(signals[0]?.aborted).toBe(false)
+    secondController.abort(new Error('second cancelled'))
+
+    await expect(first).rejects.toThrow('first cancelled')
+    await expect(second).rejects.toThrow('second cancelled')
+    expect(signals[0]?.aborted).toBe(true)
+
+    const fresh = owner.lease('repo', undefined, load)
+    expect(load).toHaveBeenCalledTimes(2)
+    secondPending.resolve('fresh')
+    await expect(fresh).resolves.toBe('fresh')
+    firstPending.reject(new Error('underlying aborted'))
+    await Promise.resolve()
+  })
+
+  it('rejects a pre-aborted caller without starting or joining work', async () => {
+    const owner = new GitStatusReadLeaseOwner<string>()
+    const pending = deferred<string>()
+    const load = vi.fn(() => pending.promise)
+    const active = owner.lease('repo', undefined, load)
+    const controller = new AbortController()
+    const abortError = new Error('already cancelled')
+    controller.abort(abortError)
+
+    await expect(owner.lease('repo', controller.signal, load)).rejects.toBe(abortError)
+    expect(load).toHaveBeenCalledOnce()
+
+    pending.resolve('active')
+    await expect(active).resolves.toBe('active')
+  })
+
+  it('cleans listeners and entries after success, failure, and cancellation', async () => {
+    const owner = new GitStatusReadLeaseOwner<string>()
+    const successController = new AbortController()
+    const successRemove = vi.spyOn(successController.signal, 'removeEventListener')
+    await expect(
+      owner.lease('success', successController.signal, async () => 'success')
+    ).resolves.toBe('success')
+    expect(successRemove).toHaveBeenCalledOnce()
+
+    const failureController = new AbortController()
+    const failureRemove = vi.spyOn(failureController.signal, 'removeEventListener')
+    const failure = new Error('failed')
+    await expect(
+      owner.lease('failure', failureController.signal, async () => {
+        throw failure
+      })
+    ).rejects.toBe(failure)
+    expect(failureRemove).toHaveBeenCalledOnce()
+
+    const cancelController = new AbortController()
+    const cancelRemove = vi.spyOn(cancelController.signal, 'removeEventListener')
+    const cancelPending = deferred<string>()
+    const cancelled = owner.lease('cancel', cancelController.signal, () => cancelPending.promise)
+    cancelController.abort()
+    await expect(cancelled).rejects.toMatchObject({ name: 'AbortError' })
+    expect(cancelRemove).toHaveBeenCalledOnce()
+
+    const freshLoad = vi.fn(async () => 'fresh')
+    await expect(owner.lease('success', undefined, freshLoad)).resolves.toBe('fresh')
+    await expect(owner.lease('failure', undefined, freshLoad)).resolves.toBe('fresh')
+    await expect(owner.lease('cancel', undefined, freshLoad)).resolves.toBe('fresh')
+    expect(freshLoad).toHaveBeenCalledTimes(3)
+    cancelPending.reject(new Error('underlying aborted'))
+    await Promise.resolve()
+  })
+
+  it('invalidates joinability without breaking already-issued leases', async () => {
+    const owner = new GitStatusReadLeaseOwner<string>()
+    const firstPending = deferred<string>()
+    const secondPending = deferred<string>()
+    const load = vi
+      .fn<(_signal: AbortSignal) => Promise<string>>()
+      .mockReturnValueOnce(firstPending.promise)
+      .mockReturnValueOnce(secondPending.promise)
+
+    const first = owner.lease('repo', undefined, load)
+    owner.invalidate()
+    const second = owner.lease('repo', undefined, load)
+    expect(load).toHaveBeenCalledTimes(2)
+
+    firstPending.resolve('pre-mutation')
+    secondPending.resolve('post-mutation')
+    await expect(first).resolves.toBe('pre-mutation')
+    await expect(second).resolves.toBe('post-mutation')
+  })
+
+  it('never caches a settled read', async () => {
+    const owner = new GitStatusReadLeaseOwner<string>()
+    const load = vi.fn(async () => `read-${load.mock.calls.length}`)
+
+    await expect(owner.lease('repo', undefined, load)).resolves.toBe('read-1')
+    await expect(owner.lease('repo', undefined, load)).resolves.toBe('read-2')
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/git/git-status-read-lease-owner.ts
+++ b/src/main/git/git-status-read-lease-owner.ts
@@ -1,0 +1,101 @@
+type StatusReadEntry<T> = {
+  controller: AbortController
+  promise: Promise<T>
+  liveLeases: number
+  settled: boolean
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  try {
+    signal.throwIfAborted()
+  } catch (error) {
+    return error
+  }
+  return new DOMException('This operation was aborted', 'AbortError')
+}
+
+export class GitStatusReadLeaseOwner<T> {
+  private readonly entries = new Map<string, StatusReadEntry<T>>()
+
+  lease(
+    key: string,
+    signal: AbortSignal | undefined,
+    load: (sharedSignal: AbortSignal) => Promise<T>
+  ): Promise<T> {
+    if (signal?.aborted) {
+      return Promise.reject(getAbortReason(signal))
+    }
+
+    let entry = this.entries.get(key)
+    if (!entry) {
+      const controller = new AbortController()
+      const promise = load(controller.signal)
+      const createdEntry = { controller, promise, liveLeases: 0, settled: false }
+      entry = createdEntry
+      this.entries.set(key, createdEntry)
+      void promise.then(
+        () => this.settle(key, createdEntry),
+        () => this.settle(key, createdEntry)
+      )
+    }
+
+    entry.liveLeases += 1
+    return this.createLease(key, entry, signal)
+  }
+
+  invalidate(): void {
+    this.entries.clear()
+  }
+
+  private createLease(
+    key: string,
+    entry: StatusReadEntry<T>,
+    signal: AbortSignal | undefined
+  ): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      let active = true
+      const release = (abortReason?: unknown): boolean => {
+        if (!active) {
+          return false
+        }
+        active = false
+        signal?.removeEventListener('abort', onAbort)
+        entry.liveLeases -= 1
+        if (abortReason !== undefined && entry.liveLeases === 0 && !entry.settled) {
+          if (this.entries.get(key) === entry) {
+            this.entries.delete(key)
+          }
+          entry.controller.abort(abortReason)
+        }
+        return true
+      }
+      const onAbort = (): void => {
+        const reason = getAbortReason(signal!)
+        if (release(reason)) {
+          reject(reason)
+        }
+      }
+
+      signal?.addEventListener('abort', onAbort, { once: true })
+      void entry.promise.then(
+        (value) => {
+          if (release()) {
+            resolve(value)
+          }
+        },
+        (error: unknown) => {
+          if (release()) {
+            reject(error)
+          }
+        }
+      )
+    })
+  }
+
+  private settle(key: string, entry: StatusReadEntry<T>): void {
+    entry.settled = true
+    if (this.entries.get(key) === entry) {
+      this.entries.delete(key)
+    }
+  }
+}

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -11,6 +11,7 @@ import {
 const {
   gitExecFileAsyncMock,
   gitExecFileAsyncBufferMock,
+  gitStreamOptionsMock,
   lstatMock,
   realpathMock,
   readFileMock,
@@ -20,6 +21,7 @@ const {
 } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
   gitExecFileAsyncBufferMock: vi.fn(),
+  gitStreamOptionsMock: vi.fn(),
   lstatMock: vi.fn(),
   realpathMock: vi.fn(),
   readFileMock: vi.fn(),
@@ -37,10 +39,11 @@ vi.mock('./runner', () => ({
   // keep working unchanged and call ordering (status, then numstat) is preserved.
   gitStreamStdout: async (
     args: string[],
-    options: { onStdout: (chunk: string) => boolean | void }
+    options: { signal?: AbortSignal; onStdout: (chunk: string) => boolean | void }
   ) => {
     // Forward args so arg-routing mock implementations (e.g. `args.includes`)
     // still match the status read.
+    gitStreamOptionsMock(options)
     const { stdout } = await gitExecFileAsyncMock(args)
     const stoppedEarly = options.onStdout(stdout ?? '') === true
     return { stoppedEarly }
@@ -991,6 +994,7 @@ describe('getSubmoduleStatus', () => {
     clearEffectiveUpstreamStatusCacheForTests()
     gitExecFileAsyncMock.mockReset()
     gitExecFileAsyncBufferMock.mockReset()
+    gitStreamOptionsMock.mockReset()
     lstatMock.mockReset()
     readFileMock.mockReset()
     existsSyncMock.mockReset()
@@ -1105,6 +1109,7 @@ describe('getStatus', () => {
     clearEffectiveUpstreamStatusCacheForTests()
     gitExecFileAsyncMock.mockReset()
     gitExecFileAsyncBufferMock.mockReset()
+    gitStreamOptionsMock.mockReset()
     lstatMock.mockReset()
     readFileMock.mockReset()
     existsSyncMock.mockReset()
@@ -1133,12 +1138,22 @@ describe('getStatus', () => {
       return Promise.resolve({ stdout: '' })
     })
 
+    const runBurst = async (withSignals: boolean): Promise<number> => {
+      gitExecFileAsyncMock.mockClear()
+      await Promise.all(
+        Array.from({ length: 10 }, () =>
+          getStatus('/repo', withSignals ? { signal: new AbortController().signal } : {})
+        )
+      )
+      return gitExecFileAsyncMock.mock.calls.filter(([args]) =>
+        (args as string[]).includes('status')
+      ).length
+    }
+
     const startedAt = performance.now()
-    await Promise.all(Array.from({ length: 10 }, () => getStatus('/repo')))
+    const unsignalledStatusCommandCalls = await runBurst(false)
+    const signalledStatusCommandCalls = await runBurst(true)
     const durationMs = performance.now() - startedAt
-    const statusCommandCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) =>
-      (args as string[]).includes('status')
-    ).length
     const { mkdirSync, writeFileSync } = await vi.importActual<typeof NodeFs>('fs')
     mkdirSync(path.dirname(benchPath), { recursive: true })
     writeFileSync(
@@ -1146,7 +1161,16 @@ describe('getStatus', () => {
       JSON.stringify({
         scenario: 'git-status-concurrent-burst',
         concurrentCalls: 10,
-        statusCommandCalls,
+        unsignalledStatusCommandCalls,
+        signalledStatusCommandCalls,
+        statusArgs: [
+          '-c',
+          'core.quotePath=false',
+          'status',
+          '--porcelain=v2',
+          '--branch',
+          '--untracked-files=all'
+        ],
         durationMs
       })
     )
@@ -1183,6 +1207,133 @@ describe('getStatus', () => {
     expect(statusCommandCalls).toBe(2)
   })
 
+  it('shares one physical status read across distinct caller signals', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    let releaseStatus!: () => void
+    let statusCommandCalls = 0
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args.includes('status')) {
+        statusCommandCalls += 1
+        return new Promise<{ stdout: string }>((resolve) => {
+          releaseStatus = () => resolve({ stdout: '' })
+        })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const firstError = new Error('first caller cancelled')
+    const first = getStatus('/repo', { signal: firstController.signal })
+    const second = getStatus('/repo', { signal: secondController.signal })
+
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(1))
+    const underlyingSignal = gitStreamOptionsMock.mock.calls[0]?.[0].signal as AbortSignal
+    firstController.abort(firstError)
+    await expect(first).rejects.toBe(firstError)
+    expect(underlyingSignal?.aborted).toBe(false)
+
+    releaseStatus()
+    await expect(second).resolves.toMatchObject({ entries: [] })
+    expect(statusCommandCalls).toBe(1)
+  })
+
+  it('aborts physical status work after its last live caller cancels', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    let statusCommandCalls = 0
+    let rejectStatus!: (error: unknown) => void
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (!args.includes('status')) {
+        return Promise.resolve({ stdout: '' })
+      }
+      statusCommandCalls += 1
+      if (statusCommandCalls > 1) {
+        return Promise.resolve({ stdout: '' })
+      }
+      return new Promise<{ stdout: string }>((_resolve, reject) => {
+        rejectStatus = reject
+      })
+    })
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const first = getStatus('/repo', { signal: firstController.signal })
+    const second = getStatus('/repo', { signal: secondController.signal })
+
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(1))
+    const underlyingSignal = gitStreamOptionsMock.mock.calls[0]?.[0].signal as AbortSignal
+    underlyingSignal.addEventListener('abort', () => rejectStatus(underlyingSignal.reason), {
+      once: true
+    })
+    firstController.abort(new Error('first cancelled'))
+    await expect(first).rejects.toThrow('first cancelled')
+    expect(underlyingSignal.aborted).toBe(false)
+    secondController.abort(new Error('second cancelled'))
+    await expect(second).rejects.toThrow('second cancelled')
+    expect(underlyingSignal.aborted).toBe(true)
+
+    await expect(getStatus('/repo')).resolves.toMatchObject({ entries: [] })
+    expect(statusCommandCalls).toBe(2)
+  })
+
+  it('rejects a pre-aborted caller without starting or joining status work', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    let releaseStatus!: () => void
+    let statusCommandCalls = 0
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args.includes('status')) {
+        statusCommandCalls += 1
+        return new Promise<{ stdout: string }>((resolve) => {
+          releaseStatus = () => resolve({ stdout: '' })
+        })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+    const active = getStatus('/repo')
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(1))
+    const controller = new AbortController()
+    const abortError = new Error('already cancelled')
+    controller.abort(abortError)
+
+    await expect(getStatus('/repo', { signal: controller.signal })).rejects.toBe(abortError)
+    expect(statusCommandCalls).toBe(1)
+
+    releaseStatus()
+    await active
+  })
+
+  it('isolates status reads by worktree, host, and output-affecting options', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    let statusCommandCalls = 0
+    const releases: (() => void)[] = []
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args.includes('status')) {
+        statusCommandCalls += 1
+        return new Promise<{ stdout: string }>((resolve) => {
+          releases.push(() => resolve({ stdout: '' }))
+        })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+    const reads = [
+      getStatus('/repo'),
+      getStatus('/other-repo'),
+      getStatus('/repo', { wslDistro: 'Ubuntu' }),
+      getStatus('/repo', { includeIgnored: true }),
+      getStatus('/repo', { reuseLineStats: true }),
+      getStatus('/repo', { bypassEffectiveUpstreamNegativeCache: true }),
+      getStatus('/repo', { limit: 1 }),
+      getStatus('/repo', { sharedLinkPaths: ['node_modules'] })
+    ]
+
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(8))
+    releases.splice(0).forEach((release) => release())
+    await Promise.all(reads)
+    expect(statusCommandCalls).toBe(8)
+  })
+
   it('clears in-flight status reads when a mutation runs', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
     existsSyncMock.mockReturnValue(false)
@@ -1211,6 +1362,42 @@ describe('getStatus', () => {
     releaseStatusReads.splice(0).forEach((release) => release())
     await Promise.all([first, second])
     expect(statusCommandCalls).toBe(2)
+  })
+
+  it('fences reads started before, during, and after a concurrent mutation', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    existsSyncMock.mockReturnValue(false)
+    let statusCommandCalls = 0
+    let releaseMutation!: () => void
+    const releaseStatusReads: (() => void)[] = []
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args.includes('status')) {
+        statusCommandCalls += 1
+        return new Promise<{ stdout: string }>((resolve) => {
+          releaseStatusReads.push(() => resolve({ stdout: '' }))
+        })
+      }
+      if (args.includes('add')) {
+        return new Promise<{ stdout: string }>((resolve) => {
+          releaseMutation = () => resolve({ stdout: '' })
+        })
+      }
+      return Promise.resolve({ stdout: '' })
+    })
+
+    const beforeMutation = getStatus('/repo', { signal: new AbortController().signal })
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(1))
+    const mutation = stageFile('/repo', 'src/file.ts')
+    const duringMutation = getStatus('/repo', { signal: new AbortController().signal })
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(2))
+    releaseMutation()
+    await mutation
+    const afterMutation = getStatus('/repo', { signal: new AbortController().signal })
+    await vi.waitFor(() => expect(statusCommandCalls).toBe(3))
+
+    releaseStatusReads.splice(0).forEach((release) => release())
+    await Promise.all([beforeMutation, duringMutation, afterMutation])
+    expect(statusCommandCalls).toBe(3)
   })
 
   it('parses unmerged porcelain v2 entries into unresolved conflict rows', async () => {
@@ -1631,7 +1818,10 @@ describe('getStatus', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['-c', 'core.quotePath=false', 'diff', '-z', '--numstat', '-M'],
-      { cwd: '/repo', env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' }) }
+      expect.objectContaining({
+        cwd: '/repo',
+        env: expect.objectContaining({ GIT_OPTIONAL_LOCKS: '0' })
+      })
     )
     expect(result.entries).toEqual([
       { path: 'docs/a => b.txt', status: 'modified', area: 'unstaged', added: 1, removed: 0 }

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -52,6 +52,7 @@ import { getLargeDiffRenderLimit } from '../../shared/large-diff-render-limit'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
+import { GitStatusReadLeaseOwner } from './git-status-read-lease-owner'
 import { parseGitRevListFirstParentOid } from '../../shared/git-rev-list-output'
 import {
   beginGitStatusLineStatsCacheWrite,
@@ -92,12 +93,12 @@ const effectiveUpstreamStatusInFlight = new Map<string, Promise<GitUpstreamStatu
 const retiredEffectiveUpstreamStatusInFlight = new Map<string, Promise<GitUpstreamStatus>>()
 const gitDiffReadDedupe = new InFlightPromiseDedupe<GitDiffResult>()
 const effectiveUpstreamStatusWriteGeneration = new Map<string, number>()
-const statusReadsInFlight = new Map<string, Promise<GitStatusResult>>()
+const statusReadLeaseOwner = new GitStatusReadLeaseOwner<GitStatusResult>()
 
 // Why: clear both diff and status in-flight caches; clearing only diff would let getStatus() join a pre-mutation read.
 export function invalidateGitReadCaches(): void {
   gitDiffReadDedupe.clear()
-  statusReadsInFlight.clear()
+  statusReadLeaseOwner.invalidate()
   clearGitStatusLineStatsCache()
   clearSubmodulePathsCache()
   resolvedUpstreamNameCache.clear()
@@ -216,31 +217,17 @@ export async function getStatus(
   options: GetStatusOptions = {}
 ): Promise<GitStatusResult> {
   gitDiffReadDedupe.clear()
-  if (options.signal) {
-    return runGetStatus(worktreePath, options)
-  }
   // Why: dedupe only concurrent identical reads; after settle, callers must run a fresh read.
   const cacheKey = getStatusReadKey(worktreePath, options)
-  const inFlightStatus = statusReadsInFlight.get(cacheKey)
-  if (inFlightStatus) {
-    return inFlightStatus
-  }
-
-  const statusPromise = runGetStatus(worktreePath, options)
-  statusReadsInFlight.set(cacheKey, statusPromise)
-  try {
-    return await statusPromise
-  } finally {
-    if (statusReadsInFlight.get(cacheKey) === statusPromise) {
-      statusReadsInFlight.delete(cacheKey)
-    }
-  }
+  return statusReadLeaseOwner.lease(cacheKey, options.signal, (sharedSignal) =>
+    runGetStatus(worktreePath, { ...options, signal: sharedSignal })
+  )
 }
 
 function getStatusReadKey(worktreePath: string, options: GetStatusOptions): string {
   // Why: each key part can change the output shape or runtime routing.
   const limit = resolveGitStatusLimit(options.limit)
-  return [
+  return stableInFlightKey([
     worktreePath,
     options.wslDistro ?? '',
     options.includeIgnored === true,
@@ -248,8 +235,8 @@ function getStatusReadKey(worktreePath: string, options: GetStatusOptions): stri
     options.bypassEffectiveUpstreamNegativeCache === true,
     limit,
     // Why: this changes which entries survive, so it must not share a cache slot.
-    (options.sharedLinkPaths ?? []).join('\u0001')
-  ].join('\0')
+    options.sharedLinkPaths ?? []
+  ])
 }
 
 /** Remove untracked entries that are shared symlinks Orca created.


### PR DESCRIPTION
## Summary

Coalesce concurrent native and WSL Git status reads even when callers provide distinct cancellation signals.

Each caller receives an independent cancellable lease. The underlying Git operation is aborted only after its last live caller cancels, and mutations invalidate joinability without disrupting already-issued callers.

The focused concurrency test measures 10 concurrent, separately signalled `getStatus` calls collapsing to 1 physical `git status` read.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (targeted `oxlint --deny-warnings` passed)
- [x] `pnpm typecheck` (`pnpm run typecheck:node`)
- [ ] `pnpm test` (12 related status suites, 157 tests passed)
- [x] `pnpm build` (`pnpm run build:electron-vite`)
- [x] Added or updated high-quality tests that would catch regressions

Also passed targeted formatting, max-lines ratchet, and `git diff --check`.

## AI Review Report

Reviewed cancellation races, last-lease abort, pre-aborted callers, failure cleanup, settled-read eviction, mutation invalidation, cache-key isolation, and stale-entry fencing. No unresolved findings.

Cross-platform review confirmed there are no changed Git commands, shortcuts, labels, paths, shell syntax, or Electron platform branches. Worktree paths remain opaque key values, WSL distro is part of the key, and folder workspaces remain supported.

## Security Audit

No new IPC, command, path, authentication, secret, dependency, or persistence surface is introduced. The bounded stable key prevents retaining arbitrarily large raw option keys, caller-provided abort reasons are propagated only to the shared in-process operation, and entries are removed after success, failure, cancellation, or invalidation.

## Notes

This is the second focused extraction from draft PR #11539. It is independent of PR #11687 and based directly on `main`.
