### PR TITLE
perf: coalesce SSH git status reads

### DIFF
--- a/src/main/providers/ssh-git-provider-status-lease.test.ts
+++ b/src/main/providers/ssh-git-provider-status-lease.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { SshGitProvider } from './ssh-git-provider'
+import {
+  createMockMux,
+  waitForRequestCount,
+  type MockMultiplexer
+} from './ssh-git-provider-test-harness'
+
+function deferredPromise<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('SshGitProvider status read leases', () => {
+  let mux: MockMultiplexer
+  let provider: SshGitProvider
+
+  beforeEach(() => {
+    mux = createMockMux()
+    provider = new SshGitProvider('conn-1', mux as never)
+  })
+
+  it('shares one status RPC across distinct caller signals', async () => {
+    const pending = deferredPromise<{
+      entries: never[]
+      conflictOperation: 'unknown'
+    }>()
+    mux.request.mockReturnValue(pending.promise)
+    const controllers = Array.from({ length: 10 }, () => new AbortController())
+
+    const reads = controllers.map((controller) =>
+      provider.getStatus('/home/user/repo', { signal: controller.signal })
+    )
+    await waitForRequestCount(mux.request, 1)
+
+    expect(mux.request).toHaveBeenCalledTimes(1)
+    pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    await expect(Promise.all(reads)).resolves.toHaveLength(10)
+  })
+
+  it('isolates first and later caller cancellation while a status lease remains', async () => {
+    const pending = deferredPromise<{
+      entries: never[]
+      conflictOperation: 'unknown'
+    }>()
+    mux.request.mockReturnValue(pending.promise)
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const thirdController = new AbortController()
+    const firstError = new Error('first caller cancelled')
+    const thirdError = new Error('third caller cancelled')
+
+    const first = provider.getStatus('/home/user/repo', { signal: firstController.signal })
+    const second = provider.getStatus('/home/user/repo', { signal: secondController.signal })
+    const third = provider.getStatus('/home/user/repo', { signal: thirdController.signal })
+    await waitForRequestCount(mux.request, 1)
+    const sharedSignal = mux.request.mock.calls[0][2].signal as AbortSignal
+
+    firstController.abort(firstError)
+    thirdController.abort(thirdError)
+    await expect(first).rejects.toBe(firstError)
+    await expect(third).rejects.toBe(thirdError)
+    expect(sharedSignal.aborted).toBe(false)
+
+    pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    await expect(second).resolves.toEqual({ entries: [], conflictOperation: 'unknown' })
+  })
+
+  it('cancels the underlying status RPC after its last live lease aborts', async () => {
+    const firstPending = deferredPromise<{
+      entries: never[]
+      conflictOperation: 'unknown'
+    }>()
+    mux.request.mockReturnValueOnce(firstPending.promise)
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const firstError = new Error('first caller cancelled')
+    const secondError = new Error('second caller cancelled')
+    const first = provider.getStatus('/home/user/repo', { signal: firstController.signal })
+    const second = provider.getStatus('/home/user/repo', { signal: secondController.signal })
+    await waitForRequestCount(mux.request, 1)
+    const sharedSignal = mux.request.mock.calls[0][2].signal as AbortSignal
+    sharedSignal.addEventListener('abort', () => firstPending.reject(sharedSignal.reason), {
+      once: true
+    })
+
+    firstController.abort(firstError)
+    await expect(first).rejects.toBe(firstError)
+    expect(sharedSignal.aborted).toBe(false)
+    secondController.abort(secondError)
+    await expect(second).rejects.toBe(secondError)
+    expect(sharedSignal.aborted).toBe(true)
+
+    mux.request.mockResolvedValueOnce({ entries: [], conflictOperation: 'unknown' })
+    await expect(provider.getStatus('/home/user/repo')).resolves.toMatchObject({ entries: [] })
+    expect(mux.request).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects pre-aborted status callers without starting or joining an RPC', async () => {
+    const controller = new AbortController()
+    const abortError = new Error('already cancelled')
+    controller.abort(abortError)
+
+    await expect(provider.getStatus('/home/user/repo', { signal: controller.signal })).rejects.toBe(
+      abortError
+    )
+    expect(mux.request).not.toHaveBeenCalled()
+
+    const pending = deferredPromise<{
+      entries: never[]
+      conflictOperation: 'unknown'
+    }>()
+    mux.request.mockReturnValueOnce(pending.promise)
+    const active = provider.getStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 1)
+    await expect(provider.getStatus('/home/user/repo', { signal: controller.signal })).rejects.toBe(
+      abortError
+    )
+    expect(mux.request).toHaveBeenCalledTimes(1)
+
+    pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    await active
+  })
+
+  it('starts fresh status RPCs after result and error settlement', async () => {
+    const status = { entries: [], conflictOperation: 'unknown' as const }
+    mux.request.mockResolvedValueOnce(status)
+
+    await expect(provider.getStatus('/home/user/repo')).resolves.toBe(status)
+    const failure = new Error('relay status failed')
+    mux.request.mockRejectedValueOnce(failure)
+    await expect(provider.getStatus('/home/user/repo')).rejects.toBe(failure)
+    mux.request.mockResolvedValueOnce(status)
+    await expect(provider.getStatus('/home/user/repo')).resolves.toBe(status)
+
+    expect(mux.request).toHaveBeenCalledTimes(3)
+  })
+
+  it('isolates status reads by worktree and output-affecting options', async () => {
+    const pendingRequests = Array.from({ length: 5 }, () =>
+      deferredPromise<{ entries: never[]; conflictOperation: 'unknown' }>()
+    )
+    mux.request.mockImplementation(
+      () => pendingRequests[mux.request.mock.calls.length - 1]?.promise
+    )
+
+    const reads = [
+      provider.getStatus('/home/user/repo'),
+      provider.getStatus('/home/user/other'),
+      provider.getStatus('/home/user/repo', { includeIgnored: true }),
+      provider.getStatus('/home/user/repo', {
+        bypassEffectiveUpstreamNegativeCache: true
+      }),
+      provider.getStatus('/home/user/repo', { reuseLineStats: true })
+    ]
+    await waitForRequestCount(mux.request, 5)
+
+    expect(mux.request.mock.calls.map(([, payload]) => payload)).toEqual([
+      { worktreePath: '/home/user/repo' },
+      { worktreePath: '/home/user/other' },
+      { worktreePath: '/home/user/repo', includeIgnored: true },
+      {
+        worktreePath: '/home/user/repo',
+        bypassEffectiveUpstreamNegativeCache: true
+      },
+      { worktreePath: '/home/user/repo', reuseLineStats: true }
+    ])
+    pendingRequests.forEach((pending) =>
+      pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    )
+    await Promise.all(reads)
+  })
+
+  it('isolates status reads by branch-line-total fork point', async () => {
+    const pendingRequests = Array.from({ length: 3 }, () =>
+      deferredPromise<{ entries: never[]; conflictOperation: 'unknown' }>()
+    )
+    mux.request.mockImplementation(
+      () => pendingRequests[mux.request.mock.calls.length - 1]?.promise
+    )
+
+    // Why: the response shape differs per fork point, so a poll that omitted the base
+    // must never serve a refresh that asked for it (the chip would blank or go stale).
+    const reads = [
+      provider.getStatus('/home/user/repo'),
+      provider.getStatus('/home/user/repo', { branchLineTotalMergeBase: 'abc123' }),
+      provider.getStatus('/home/user/repo', { branchLineTotalMergeBase: 'def456' })
+    ]
+    await waitForRequestCount(mux.request, 3)
+
+    expect(mux.request.mock.calls.map(([, payload]) => payload)).toEqual([
+      { worktreePath: '/home/user/repo' },
+      { worktreePath: '/home/user/repo', branchLineTotalMergeBase: 'abc123' },
+      { worktreePath: '/home/user/repo', branchLineTotalMergeBase: 'def456' }
+    ])
+    pendingRequests.forEach((pending) =>
+      pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    )
+    await Promise.all(reads)
+  })
+
+  it('keeps status leases isolated per provider and relay incarnation', async () => {
+    const pendingRequests = Array.from({ length: 3 }, () =>
+      deferredPromise<{ entries: never[]; conflictOperation: 'unknown' }>()
+    )
+    mux.request.mockImplementation(
+      () => pendingRequests[mux.request.mock.calls.length - 1]?.promise
+    )
+    const replacement = new SshGitProvider('conn-1', mux as never)
+    const otherConnection = new SshGitProvider('conn-2', mux as never)
+
+    const reads = [
+      provider.getStatus('/home/user/repo'),
+      replacement.getStatus('/home/user/repo'),
+      otherConnection.getStatus('/home/user/repo')
+    ]
+    await waitForRequestCount(mux.request, 3)
+
+    expect(mux.request).toHaveBeenCalledTimes(3)
+    pendingRequests.forEach((pending) =>
+      pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    )
+    await Promise.all(reads)
+  })
+
+  it('fences status reads before, during, and after an SSH mutation', async () => {
+    const statusRequests = Array.from({ length: 3 }, () =>
+      deferredPromise<{ entries: never[]; conflictOperation: 'unknown' }>()
+    )
+    const mutation = deferredPromise<void>()
+    let statusRequestIndex = 0
+    mux.request.mockImplementation((method) => {
+      if (method === 'git.status') {
+        return statusRequests[statusRequestIndex++]?.promise
+      }
+      if (method === 'git.stage') {
+        return mutation.promise
+      }
+      return Promise.resolve(undefined)
+    })
+
+    const beforeMutation = provider.getStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 1)
+    const mutating = provider.stageFile('/home/user/repo', 'src/file.ts')
+    await waitForRequestCount(mux.request, 2)
+    const duringMutation = provider.getStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 3)
+    mutation.resolve(undefined)
+    await mutating
+    const afterMutation = provider.getStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 4)
+
+    statusRequests.forEach((pending) =>
+      pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    )
+    await Promise.all([beforeMutation, duringMutation, afterMutation])
+    expect(mux.request.mock.calls.filter(([method]) => method === 'git.status')).toHaveLength(3)
+  })
+})

--- a/src/main/providers/ssh-git-provider-status.test.ts
+++ b/src/main/providers/ssh-git-provider-status.test.ts
@@ -25,7 +25,11 @@ describe('SshGitProvider', () => {
     mux.request.mockResolvedValue(statusResult)
 
     const result = await provider.getStatus('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith('git.status', { worktreePath: '/home/user/repo' })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.status',
+      { worktreePath: '/home/user/repo' },
+      { signal: expect.any(AbortSignal) }
+    )
     expect(result).toEqual(statusResult)
   })
 
@@ -36,13 +40,21 @@ describe('SshGitProvider', () => {
     await provider.getStatus('/home/user/repo', { includeIgnored: true })
     await provider.getStatus('/home/user/repo', { includeIgnored: false })
 
-    expect(mux.request).toHaveBeenNthCalledWith(1, 'git.status', {
-      worktreePath: '/home/user/repo',
-      includeIgnored: true
-    })
-    expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
-      worktreePath: '/home/user/repo'
-    })
+    expect(mux.request).toHaveBeenNthCalledWith(
+      1,
+      'git.status',
+      {
+        worktreePath: '/home/user/repo',
+        includeIgnored: true
+      },
+      { signal: expect.any(AbortSignal) }
+    )
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'git.status',
+      { worktreePath: '/home/user/repo' },
+      { signal: expect.any(AbortSignal) }
+    )
   })
 
   it('getStatus forwards upstream-negative-cache bypass only when requested', async () => {
@@ -52,13 +64,21 @@ describe('SshGitProvider', () => {
     await provider.getStatus('/home/user/repo', { bypassEffectiveUpstreamNegativeCache: true })
     await provider.getStatus('/home/user/repo', { bypassEffectiveUpstreamNegativeCache: false })
 
-    expect(mux.request).toHaveBeenNthCalledWith(1, 'git.status', {
-      worktreePath: '/home/user/repo',
-      bypassEffectiveUpstreamNegativeCache: true
-    })
-    expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
-      worktreePath: '/home/user/repo'
-    })
+    expect(mux.request).toHaveBeenNthCalledWith(
+      1,
+      'git.status',
+      {
+        worktreePath: '/home/user/repo',
+        bypassEffectiveUpstreamNegativeCache: true
+      },
+      { signal: expect.any(AbortSignal) }
+    )
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'git.status',
+      { worktreePath: '/home/user/repo' },
+      { signal: expect.any(AbortSignal) }
+    )
   })
 
   it('getStatus forwards line-stat reuse and cancellation to the relay', async () => {
@@ -73,8 +93,9 @@ describe('SshGitProvider', () => {
     expect(mux.request).toHaveBeenCalledWith(
       'git.status',
       { worktreePath: '/home/user/repo', reuseLineStats: true },
-      { signal: controller.signal }
+      { signal: expect.any(AbortSignal) }
     )
+    expect(mux.request.mock.calls[0][2].signal).not.toBe(controller.signal)
   })
 
   it('getSubmoduleStatus sends git.submoduleStatus request', async () => {

--- a/src/main/providers/ssh-git-provider-worktree.test.ts
+++ b/src/main/providers/ssh-git-provider-worktree.test.ts
@@ -128,9 +128,12 @@ describe('SshGitProvider', () => {
       expect(mux.request).toHaveBeenNthCalledWith(1, 'git.worktreeIsClean', {
         worktreePath: '/home/user/feat'
       })
-      expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
-        worktreePath: '/home/user/feat'
-      })
+      expect(mux.request).toHaveBeenNthCalledWith(
+        2,
+        'git.status',
+        { worktreePath: '/home/user/feat' },
+        { signal: expect.any(AbortSignal) }
+      )
       expect(result).toEqual({ clean: false, stdout: 'untracked untracked: scratch.txt' })
     } finally {
       warnSpy.mockRestore()
@@ -151,9 +154,12 @@ describe('SshGitProvider', () => {
       await expect(
         provider.worktreeIsClean('/home/user/feat', { includeUntracked: false })
       ).resolves.toEqual({ clean: true })
-      expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
-        worktreePath: '/home/user/feat'
-      })
+      expect(mux.request).toHaveBeenNthCalledWith(
+        2,
+        'git.status',
+        { worktreePath: '/home/user/feat' },
+        { signal: expect.any(AbortSignal) }
+      )
     } finally {
       warnSpy.mockRestore()
     }

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable max-lines -- Why: this suite covers the SSH git provider's one-RPC-per-method contract; splitting it would duplicate the shared mux fixture. */
 import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import path from 'node:path'
 import { SshGitProvider } from './ssh-git-provider'
 
 type MockMultiplexer = {
@@ -43,6 +45,20 @@ function deferredValue<T>(value: T): { promise: Promise<T>; resolve: () => void 
   return { promise, resolve: () => resolve(value) }
 }
 
+function deferredPromise<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, resolve, reject }
+}
+
 describe('SshGitProvider', () => {
   let mux: MockMultiplexer
   let provider: SshGitProvider
@@ -56,6 +72,43 @@ describe('SshGitProvider', () => {
     expect(provider.getConnectionId()).toBe('conn-1')
   })
 
+  it('benchmarks concurrent status RPC pressure', async () => {
+    const benchPath = process.env.ORCA_SSH_GIT_STATUS_COALESCING_BENCH_JSON
+    if (!benchPath) {
+      return
+    }
+    mux.request.mockResolvedValue({ entries: [], conflictOperation: 'unknown' })
+
+    const runBurst = async (withSignals: boolean): Promise<number> => {
+      mux.request.mockClear()
+      await Promise.all(
+        Array.from({ length: 10 }, () =>
+          provider.getStatus(
+            '/home/user/repo',
+            withSignals ? { signal: new AbortController().signal } : {}
+          )
+        )
+      )
+      return mux.request.mock.calls.filter(([method]) => method === 'git.status').length
+    }
+
+    const unsignalledStatusRequests = await runBurst(false)
+    const signalledStatusRequests = await runBurst(true)
+    const { mkdirSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
+    mkdirSync(path.dirname(benchPath), { recursive: true })
+    writeFileSync(
+      benchPath,
+      JSON.stringify({
+        scenario: 'ssh-git-status-concurrent-burst',
+        concurrentCalls: 10,
+        unsignalledStatusRequests,
+        signalledStatusRequests,
+        method: 'git.status',
+        payload: { worktreePath: '/home/user/repo' }
+      })
+    )
+  })
+
   it('getStatus sends git.status request', async () => {
     const statusResult = {
       entries: [{ path: 'generated/a.ts', status: 'untracked', area: 'untracked' }],
@@ -66,7 +119,11 @@ describe('SshGitProvider', () => {
     mux.request.mockResolvedValue(statusResult)
 
     const result = await provider.getStatus('/home/user/repo')
-    expect(mux.request).toHaveBeenCalledWith('git.status', { worktreePath: '/home/user/repo' })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.status',
+      { worktreePath: '/home/user/repo' },
+      { signal: expect.any(AbortSignal) }
+    )
     expect(result).toEqual(statusResult)
   })
 
@@ -77,13 +134,21 @@ describe('SshGitProvider', () => {
     await provider.getStatus('/home/user/repo', { includeIgnored: true })
     await provider.getStatus('/home/user/repo', { includeIgnored: false })
 
-    expect(mux.request).toHaveBeenNthCalledWith(1, 'git.status', {
-      worktreePath: '/home/user/repo',
-      includeIgnored: true
-    })
-    expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
-      worktreePath: '/home/user/repo'
-    })
+    expect(mux.request).toHaveBeenNthCalledWith(
+      1,
+      'git.status',
+      {
+        worktreePath: '/home/user/repo',
+        includeIgnored: true
+      },
+      { signal: expect.any(AbortSignal) }
+    )
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'git.status',
+      { worktreePath: '/home/user/repo' },
+      { signal: expect.any(AbortSignal) }
+    )
   })
 
   it('getStatus forwards upstream-negative-cache bypass only when requested', async () => {
@@ -93,13 +158,21 @@ describe('SshGitProvider', () => {
     await provider.getStatus('/home/user/repo', { bypassEffectiveUpstreamNegativeCache: true })
     await provider.getStatus('/home/user/repo', { bypassEffectiveUpstreamNegativeCache: false })
 
-    expect(mux.request).toHaveBeenNthCalledWith(1, 'git.status', {
-      worktreePath: '/home/user/repo',
-      bypassEffectiveUpstreamNegativeCache: true
-    })
-    expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
-      worktreePath: '/home/user/repo'
-    })
+    expect(mux.request).toHaveBeenNthCalledWith(
+      1,
+      'git.status',
+      {
+        worktreePath: '/home/user/repo',
+        bypassEffectiveUpstreamNegativeCache: true
+      },
+      { signal: expect.any(AbortSignal) }
+    )
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'git.status',
+      { worktreePath: '/home/user/repo' },
+      { signal: expect.any(AbortSignal) }
+    )
   })
 
   it('getStatus forwards line-stat reuse and cancellation to the relay', async () => {
@@ -114,8 +187,184 @@ describe('SshGitProvider', () => {
     expect(mux.request).toHaveBeenCalledWith(
       'git.status',
       { worktreePath: '/home/user/repo', reuseLineStats: true },
-      { signal: controller.signal }
+      { signal: expect.any(AbortSignal) }
     )
+    expect(mux.request.mock.calls[0][2].signal).not.toBe(controller.signal)
+  })
+
+  it('shares one status RPC across distinct caller signals', async () => {
+    const pending = deferredPromise<{
+      entries: never[]
+      conflictOperation: 'unknown'
+    }>()
+    mux.request.mockReturnValue(pending.promise)
+    const controllers = Array.from({ length: 10 }, () => new AbortController())
+
+    const reads = controllers.map((controller) =>
+      provider.getStatus('/home/user/repo', { signal: controller.signal })
+    )
+    await waitForRequestCount(mux.request, 1)
+
+    expect(mux.request).toHaveBeenCalledTimes(1)
+    pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    await expect(Promise.all(reads)).resolves.toHaveLength(10)
+  })
+
+  it('isolates first and later caller cancellation while a status lease remains', async () => {
+    const pending = deferredPromise<{
+      entries: never[]
+      conflictOperation: 'unknown'
+    }>()
+    mux.request.mockReturnValue(pending.promise)
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const thirdController = new AbortController()
+    const firstError = new Error('first caller cancelled')
+    const thirdError = new Error('third caller cancelled')
+
+    const first = provider.getStatus('/home/user/repo', { signal: firstController.signal })
+    const second = provider.getStatus('/home/user/repo', { signal: secondController.signal })
+    const third = provider.getStatus('/home/user/repo', { signal: thirdController.signal })
+    await waitForRequestCount(mux.request, 1)
+    const sharedSignal = mux.request.mock.calls[0][2].signal as AbortSignal
+
+    firstController.abort(firstError)
+    thirdController.abort(thirdError)
+    await expect(first).rejects.toBe(firstError)
+    await expect(third).rejects.toBe(thirdError)
+    expect(sharedSignal.aborted).toBe(false)
+
+    pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    await expect(second).resolves.toEqual({ entries: [], conflictOperation: 'unknown' })
+  })
+
+  it('cancels the underlying status RPC after its last live lease aborts', async () => {
+    const firstPending = deferredPromise<{
+      entries: never[]
+      conflictOperation: 'unknown'
+    }>()
+    mux.request.mockReturnValueOnce(firstPending.promise)
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const firstError = new Error('first caller cancelled')
+    const secondError = new Error('second caller cancelled')
+    const first = provider.getStatus('/home/user/repo', { signal: firstController.signal })
+    const second = provider.getStatus('/home/user/repo', { signal: secondController.signal })
+    await waitForRequestCount(mux.request, 1)
+    const sharedSignal = mux.request.mock.calls[0][2].signal as AbortSignal
+    sharedSignal.addEventListener('abort', () => firstPending.reject(sharedSignal.reason), {
+      once: true
+    })
+
+    firstController.abort(firstError)
+    await expect(first).rejects.toBe(firstError)
+    expect(sharedSignal.aborted).toBe(false)
+    secondController.abort(secondError)
+    await expect(second).rejects.toBe(secondError)
+    expect(sharedSignal.aborted).toBe(true)
+
+    mux.request.mockResolvedValueOnce({ entries: [], conflictOperation: 'unknown' })
+    await expect(provider.getStatus('/home/user/repo')).resolves.toMatchObject({ entries: [] })
+    expect(mux.request).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects pre-aborted status callers without starting or joining an RPC', async () => {
+    const controller = new AbortController()
+    const abortError = new Error('already cancelled')
+    controller.abort(abortError)
+
+    await expect(provider.getStatus('/home/user/repo', { signal: controller.signal })).rejects.toBe(
+      abortError
+    )
+    expect(mux.request).not.toHaveBeenCalled()
+
+    const pending = deferredPromise<{
+      entries: never[]
+      conflictOperation: 'unknown'
+    }>()
+    mux.request.mockReturnValueOnce(pending.promise)
+    const active = provider.getStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 1)
+    await expect(provider.getStatus('/home/user/repo', { signal: controller.signal })).rejects.toBe(
+      abortError
+    )
+    expect(mux.request).toHaveBeenCalledTimes(1)
+
+    pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    await active
+  })
+
+  it('starts fresh status RPCs after result and error settlement', async () => {
+    const status = { entries: [], conflictOperation: 'unknown' as const }
+    mux.request.mockResolvedValueOnce(status)
+
+    await expect(provider.getStatus('/home/user/repo')).resolves.toBe(status)
+    const failure = new Error('relay status failed')
+    mux.request.mockRejectedValueOnce(failure)
+    await expect(provider.getStatus('/home/user/repo')).rejects.toBe(failure)
+    mux.request.mockResolvedValueOnce(status)
+    await expect(provider.getStatus('/home/user/repo')).resolves.toBe(status)
+
+    expect(mux.request).toHaveBeenCalledTimes(3)
+  })
+
+  it('isolates status reads by worktree and output-affecting options', async () => {
+    const pendingRequests = Array.from({ length: 5 }, () =>
+      deferredPromise<{ entries: never[]; conflictOperation: 'unknown' }>()
+    )
+    mux.request.mockImplementation(
+      () => pendingRequests[mux.request.mock.calls.length - 1]?.promise
+    )
+
+    const reads = [
+      provider.getStatus('/home/user/repo'),
+      provider.getStatus('/home/user/other'),
+      provider.getStatus('/home/user/repo', { includeIgnored: true }),
+      provider.getStatus('/home/user/repo', {
+        bypassEffectiveUpstreamNegativeCache: true
+      }),
+      provider.getStatus('/home/user/repo', { reuseLineStats: true })
+    ]
+    await waitForRequestCount(mux.request, 5)
+
+    expect(mux.request.mock.calls.map(([, payload]) => payload)).toEqual([
+      { worktreePath: '/home/user/repo' },
+      { worktreePath: '/home/user/other' },
+      { worktreePath: '/home/user/repo', includeIgnored: true },
+      {
+        worktreePath: '/home/user/repo',
+        bypassEffectiveUpstreamNegativeCache: true
+      },
+      { worktreePath: '/home/user/repo', reuseLineStats: true }
+    ])
+    pendingRequests.forEach((pending) =>
+      pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    )
+    await Promise.all(reads)
+  })
+
+  it('keeps status leases isolated per provider and relay incarnation', async () => {
+    const pendingRequests = Array.from({ length: 3 }, () =>
+      deferredPromise<{ entries: never[]; conflictOperation: 'unknown' }>()
+    )
+    mux.request.mockImplementation(
+      () => pendingRequests[mux.request.mock.calls.length - 1]?.promise
+    )
+    const replacement = new SshGitProvider('conn-1', mux as never)
+    const otherConnection = new SshGitProvider('conn-2', mux as never)
+
+    const reads = [
+      provider.getStatus('/home/user/repo'),
+      replacement.getStatus('/home/user/repo'),
+      otherConnection.getStatus('/home/user/repo')
+    ]
+    await waitForRequestCount(mux.request, 3)
+
+    expect(mux.request).toHaveBeenCalledTimes(3)
+    pendingRequests.forEach((pending) =>
+      pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    )
+    await Promise.all(reads)
   })
 
   it('getSubmoduleStatus sends git.submoduleStatus request', async () => {
@@ -1149,6 +1398,40 @@ describe('SshGitProvider', () => {
     expect(mux.request).toHaveBeenCalledTimes(3)
   })
 
+  it('fences status reads before, during, and after an SSH mutation', async () => {
+    const statusRequests = Array.from({ length: 3 }, () =>
+      deferredPromise<{ entries: never[]; conflictOperation: 'unknown' }>()
+    )
+    const mutation = deferredPromise<void>()
+    let statusRequestIndex = 0
+    mux.request.mockImplementation((method) => {
+      if (method === 'git.status') {
+        return statusRequests[statusRequestIndex++]?.promise
+      }
+      if (method === 'git.stage') {
+        return mutation.promise
+      }
+      return Promise.resolve(undefined)
+    })
+
+    const beforeMutation = provider.getStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 1)
+    const mutating = provider.stageFile('/home/user/repo', 'src/file.ts')
+    await waitForRequestCount(mux.request, 2)
+    const duringMutation = provider.getStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 3)
+    mutation.resolve(undefined)
+    await mutating
+    const afterMutation = provider.getStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 4)
+
+    statusRequests.forEach((pending) =>
+      pending.resolve({ entries: [], conflictOperation: 'unknown' })
+    )
+    await Promise.all([beforeMutation, duringMutation, afterMutation])
+    expect(mux.request.mock.calls.filter(([method]) => method === 'git.status')).toHaveLength(3)
+  })
+
   it.each([
     [
       'clone',
@@ -1436,9 +1719,12 @@ describe('SshGitProvider', () => {
       expect(mux.request).toHaveBeenNthCalledWith(1, 'git.worktreeIsClean', {
         worktreePath: '/home/user/feat'
       })
-      expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
-        worktreePath: '/home/user/feat'
-      })
+      expect(mux.request).toHaveBeenNthCalledWith(
+        2,
+        'git.status',
+        { worktreePath: '/home/user/feat' },
+        { signal: expect.any(AbortSignal) }
+      )
       expect(result).toEqual({ clean: false, stdout: 'untracked untracked: scratch.txt' })
     } finally {
       warnSpy.mockRestore()
@@ -1459,9 +1745,12 @@ describe('SshGitProvider', () => {
       await expect(
         provider.worktreeIsClean('/home/user/feat', { includeUntracked: false })
       ).resolves.toEqual({ clean: true })
-      expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
-        worktreePath: '/home/user/feat'
-      })
+      expect(mux.request).toHaveBeenNthCalledWith(
+        2,
+        'git.status',
+        { worktreePath: '/home/user/feat' },
+        { signal: expect.any(AbortSignal) }
+      )
     } finally {
       warnSpy.mockRestore()
     }

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -32,6 +32,7 @@ import {
 } from '../git/max-buffer-overflow'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
+import { GitStatusReadLeaseOwner } from '../git/git-status-read-lease-owner'
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -83,21 +84,26 @@ function filterUntrackedPorcelainStatus(stdout: string | undefined): string | un
 
 export class SshGitProvider implements IGitProvider {
   private readonly gitDiffReadDedupe = new InFlightPromiseDedupe<GitDiffResult | GitDiffResult[]>()
+  private readonly statusReadLeaseOwner = new GitStatusReadLeaseOwner<GitStatusResult>()
 
   private connectionId: string
   private mux: SshChannelMultiplexer
   private nonInteractiveExecQueues = new Map<string, NonInteractiveExecQueueEntry[]>()
 
-  private async runWithDiffDedupeClear<T>(run: () => Promise<T>): Promise<T> {
-    // Why: git mutations can stale both existing and concurrently-started diff reads.
-    // Clear before and after so later reads never join pre-mutation work.
-    this.gitDiffReadDedupe.clear()
+  private async runWithGitReadInvalidation<T>(run: () => Promise<T>): Promise<T> {
+    this.invalidateGitReads()
     try {
       return await run()
     } finally {
-      this.gitDiffReadDedupe.clear()
+      this.invalidateGitReads()
     }
   }
+
+  private invalidateGitReads(): void {
+    this.gitDiffReadDedupe.clear()
+    this.statusReadLeaseOwner.invalidate()
+  }
+
   private loggedWorktreeIsCleanFallback = false
 
   constructor(
@@ -133,9 +139,17 @@ export class SshGitProvider implements IGitProvider {
       ...upstreamCacheBypassArgs,
       ...lineStatsReuseArgs
     }
-    return (await (options?.signal
-      ? this.mux.request('git.status', request, { signal: options.signal })
-      : this.mux.request('git.status', request))) as GitStatusResult
+    const key = stableInFlightKey([
+      worktreePath,
+      options?.includeIgnored === true,
+      options?.bypassEffectiveUpstreamNegativeCache === true,
+      options?.reuseLineStats === true
+    ])
+    return this.statusReadLeaseOwner.lease(key, options?.signal, async (sharedSignal) => {
+      return (await this.mux.request('git.status', request, {
+        signal: sharedSignal
+      })) as GitStatusResult
+    })
   }
 
   async getSubmoduleStatus(
@@ -186,7 +200,7 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     message: string
   ): Promise<{ success: boolean; error?: string }> {
-    return this.runWithDiffDedupeClear(
+    return this.runWithGitReadInvalidation(
       async () =>
         (await this.mux.request('git.commit', {
           worktreePath,
@@ -407,57 +421,39 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async stageFile(worktreePath: string, filePath: string): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.stage', { worktreePath, filePath })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async unstageFile(worktreePath: string, filePath: string): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.unstage', { worktreePath, filePath })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.bulkStage', { worktreePath, filePaths })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.bulkUnstage', { worktreePath, filePaths })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async discardChanges(worktreePath: string, filePath: string): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.discard', { worktreePath, filePath })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async bulkDiscardChanges(worktreePath: string, filePaths: string[]): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.bulkDiscard', { worktreePath, filePaths })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async detectConflictOperation(worktreePath: string): Promise<GitConflictOperation> {
@@ -467,19 +463,19 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async abortMerge(worktreePath: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.abortMerge', { worktreePath })
     })
   }
 
   async abortRebase(worktreePath: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.abortRebase', { worktreePath })
     })
   }
 
   async checkoutBranch(worktreePath: string, branch: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.checkout', { worktreePath, branch })
     })
   }
@@ -523,7 +519,7 @@ export class SshGitProvider implements IGitProvider {
     pushTarget?: GitPushTarget,
     options: { forceWithLease?: boolean } = {}
   ): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.push', {
         worktreePath,
         publish,
@@ -534,13 +530,13 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async pullBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.pull', { worktreePath, ...(pushTarget ? { pushTarget } : {}) })
     })
   }
 
   async fastForwardBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.fastForward', {
         worktreePath,
         ...(pushTarget ? { pushTarget } : {})
@@ -549,13 +545,13 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async rebaseFromBase(worktreePath: string, baseRef: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.rebaseFromBase', { worktreePath, baseRef })
     })
   }
 
   async fetchRemote(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.fetch', { worktreePath, ...(pushTarget ? { pushTarget } : {}) })
     })
   }
@@ -564,7 +560,7 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     expectedUpstream: GitForkSyncExpectedUpstream
   ): Promise<GitForkSyncResult> {
-    return this.runWithDiffDedupeClear(
+    return this.runWithGitReadInvalidation(
       async () =>
         (await this.mux.request('git.forkSync', {
           worktreePath,
@@ -580,7 +576,7 @@ export class SshGitProvider implements IGitProvider {
     ref: string,
     options?: { skipAutoMaintenance?: boolean }
   ): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.fetchRemoteTrackingRef', {
         worktreePath,
         remote,
@@ -597,7 +593,7 @@ export class SshGitProvider implements IGitProvider {
     mrIid: number
   ): Promise<string> {
     try {
-      return await this.runWithDiffDedupeClear(async () => {
+      return await this.runWithGitReadInvalidation(async () => {
         // Why: the durable-ref RPC is a NEW method name. Old relays only implement
         // FETCH_HEAD-semantics git.fetchGitLabMergeRequestHead, so calling the ref
         // variant makes them return -32601 rather than silently no-op the durable
@@ -628,7 +624,7 @@ export class SshGitProvider implements IGitProvider {
     prNumber: number
   ): Promise<string> {
     try {
-      return await this.runWithDiffDedupeClear(async () => {
+      return await this.runWithGitReadInvalidation(async () => {
         const result = await this.mux.request('git.fetchGitHubPullRequestHead', {
           worktreePath,
           remote,
@@ -713,7 +709,7 @@ export class SshGitProvider implements IGitProvider {
     targetDir: string,
     options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
   ): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.addWorktree', {
         repoPath,
         branchName,
@@ -728,7 +724,7 @@ export class SshGitProvider implements IGitProvider {
     force?: boolean,
     options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
   ): Promise<RemoveWorktreeResult> {
-    return this.runWithDiffDedupeClear(
+    return this.runWithGitReadInvalidation(
       async () =>
         ((await this.mux.request('git.removeWorktree', {
           worktreePath,
@@ -787,13 +783,13 @@ export class SshGitProvider implements IGitProvider {
     ownerWorktreePath?: string
     checkOnly?: boolean
   }): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.refreshLocalBaseRefForWorktreeCreate', args)
     })
   }
 
   async renameCurrentBranch(worktreePath: string, newBranch: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.renameCurrentBranch', { worktreePath, newBranch })
     })
   }
@@ -804,7 +800,7 @@ export class SshGitProvider implements IGitProvider {
     expectedHead: string
   ): Promise<void> {
     try {
-      await this.runWithDiffDedupeClear(async () => {
+      await this.runWithGitReadInvalidation(async () => {
         await this.mux.request('git.forceDeletePreservedBranch', {
           repoPath,
           branchName,
@@ -833,7 +829,7 @@ export class SshGitProvider implements IGitProvider {
         ? requestGitStreamable(this.mux, 'git.exec', { args, cwd }, options)
         : requestGitStreamable(this.mux, 'git.exec', { args, cwd })
     const result = gitExecMutatesRepository(args)
-      ? await this.runWithDiffDedupeClear(run)
+      ? await this.runWithGitReadInvalidation(run)
       : await run()
     return result as {
       stdout: string
@@ -850,41 +846,41 @@ export class SshGitProvider implements IGitProvider {
       onProgress?: (progress: { phase: string; percent: number }) => void
     }
   ): Promise<{ stdout: string; stderr: string }> {
-    this.gitDiffReadDedupe.clear()
-    const progressId = `clone-${Date.now()}-${Math.random().toString(36).slice(2)}`
-    const unsubscribe = options?.onProgress
-      ? this.mux.onNotificationByMethod('git.cloneProgress', (params) => {
-          if (params.progressId !== progressId) {
-            return
-          }
-          const phase = params.phase
-          const percent = params.percent
-          if (typeof phase === 'string' && typeof percent === 'number') {
-            options.onProgress?.({ phase, percent })
-          }
-        })
-      : undefined
-    try {
-      const result = await this.mux.request(
-        'git.clone',
-        { args, cwd, progressId },
-        { signal: options?.signal, timeoutMs: options?.timeoutMs }
-      )
-      return result as {
-        stdout: string
-        stderr: string
-      }
-    } catch (error) {
-      if (isJsonRpcMethodNotFoundError(error)) {
-        throw new Error(
-          'SSH clone support is unavailable on this relay. Reconnect the SSH target to update Orca on the host, then try again.'
+    return this.runWithGitReadInvalidation(async () => {
+      const progressId = `clone-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const unsubscribe = options?.onProgress
+        ? this.mux.onNotificationByMethod('git.cloneProgress', (params) => {
+            if (params.progressId !== progressId) {
+              return
+            }
+            const phase = params.phase
+            const percent = params.percent
+            if (typeof phase === 'string' && typeof percent === 'number') {
+              options.onProgress?.({ phase, percent })
+            }
+          })
+        : undefined
+      try {
+        const result = await this.mux.request(
+          'git.clone',
+          { args, cwd, progressId },
+          { signal: options?.signal, timeoutMs: options?.timeoutMs }
         )
+        return result as {
+          stdout: string
+          stderr: string
+        }
+      } catch (error) {
+        if (isJsonRpcMethodNotFoundError(error)) {
+          throw new Error(
+            'SSH clone support is unavailable on this relay. Reconnect the SSH target to update Orca on the host, then try again.'
+          )
+        }
+        throw error
+      } finally {
+        unsubscribe?.()
       }
-      throw error
-    } finally {
-      unsubscribe?.()
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async isGitRepoAsync(dirPath: string): Promise<{ isRepo: boolean; rootPath: string | null }> {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -151,7 +151,10 @@ export class SshGitProvider implements IGitProvider {
       worktreePath,
       options?.includeIgnored === true,
       options?.bypassEffectiveUpstreamNegativeCache === true,
-      options?.reuseLineStats === true
+      options?.reuseLineStats === true,
+      // Why: the result carries a total only for callers who asked, and only for
+      // this fork point, so a shared lease must never serve one to the other.
+      options?.branchLineTotalMergeBase ?? ''
     ])
     return this.statusReadLeaseOwner.lease(key, options?.signal, async (sharedSignal) => {
       return (await this.mux.request('git.status', request, {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -32,6 +32,7 @@ import {
 } from '../git/max-buffer-overflow'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
+import { GitStatusReadLeaseOwner } from '../git/git-status-read-lease-owner'
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -86,21 +87,26 @@ function filterUntrackedPorcelainStatus(stdout: string | undefined): string | un
 
 export class SshGitProvider implements IGitProvider {
   private readonly gitDiffReadDedupe = new InFlightPromiseDedupe<GitDiffResult | GitDiffResult[]>()
+  private readonly statusReadLeaseOwner = new GitStatusReadLeaseOwner<GitStatusResult>()
 
   private connectionId: string
   private mux: SshChannelMultiplexer
   private nonInteractiveExecQueues = new Map<string, NonInteractiveExecQueueEntry[]>()
 
-  private async runWithDiffDedupeClear<T>(run: () => Promise<T>): Promise<T> {
-    // Why: git mutations can stale both existing and concurrently-started diff reads.
-    // Clear before and after so later reads never join pre-mutation work.
-    this.gitDiffReadDedupe.clear()
+  private async runWithGitReadInvalidation<T>(run: () => Promise<T>): Promise<T> {
+    this.invalidateGitReads()
     try {
       return await run()
     } finally {
-      this.gitDiffReadDedupe.clear()
+      this.invalidateGitReads()
     }
   }
+
+  private invalidateGitReads(): void {
+    this.gitDiffReadDedupe.clear()
+    this.statusReadLeaseOwner.invalidate()
+  }
+
   private loggedWorktreeIsCleanFallback = false
 
   constructor(
@@ -141,9 +147,17 @@ export class SshGitProvider implements IGitProvider {
       ...lineStatsReuseArgs,
       ...branchLineTotalArgs
     }
-    return (await (options?.signal
-      ? this.mux.request('git.status', request, { signal: options.signal })
-      : this.mux.request('git.status', request))) as GitStatusResult
+    const key = stableInFlightKey([
+      worktreePath,
+      options?.includeIgnored === true,
+      options?.bypassEffectiveUpstreamNegativeCache === true,
+      options?.reuseLineStats === true
+    ])
+    return this.statusReadLeaseOwner.lease(key, options?.signal, async (sharedSignal) => {
+      return (await this.mux.request('git.status', request, {
+        signal: sharedSignal
+      })) as GitStatusResult
+    })
   }
 
   async getSubmoduleStatus(
@@ -194,7 +208,7 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     message: string
   ): Promise<{ success: boolean; error?: string }> {
-    return this.runWithDiffDedupeClear(
+    return this.runWithGitReadInvalidation(
       async () =>
         (await this.mux.request('git.commit', {
           worktreePath,
@@ -414,57 +428,39 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async stageFile(worktreePath: string, filePath: string): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.stage', { worktreePath, filePath })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async unstageFile(worktreePath: string, filePath: string): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.unstage', { worktreePath, filePath })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async bulkStageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.bulkStage', { worktreePath, filePaths })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async bulkUnstageFiles(worktreePath: string, filePaths: string[]): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.bulkUnstage', { worktreePath, filePaths })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async discardChanges(worktreePath: string, filePath: string): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.discard', { worktreePath, filePath })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async bulkDiscardChanges(worktreePath: string, filePaths: string[]): Promise<void> {
-    this.gitDiffReadDedupe.clear()
-    try {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.bulkDiscard', { worktreePath, filePaths })
-    } finally {
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async detectConflictOperation(worktreePath: string): Promise<GitConflictOperation> {
@@ -474,19 +470,19 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async abortMerge(worktreePath: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.abortMerge', { worktreePath })
     })
   }
 
   async abortRebase(worktreePath: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.abortRebase', { worktreePath })
     })
   }
 
   async checkoutBranch(worktreePath: string, branch: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.checkout', { worktreePath, branch })
     })
   }
@@ -530,7 +526,7 @@ export class SshGitProvider implements IGitProvider {
     pushTarget?: GitPushTarget,
     options: { forceWithLease?: boolean } = {}
   ): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.push', {
         worktreePath,
         publish,
@@ -541,13 +537,13 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async pullBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.pull', { worktreePath, ...(pushTarget ? { pushTarget } : {}) })
     })
   }
 
   async fastForwardBranch(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.fastForward', {
         worktreePath,
         ...(pushTarget ? { pushTarget } : {})
@@ -556,13 +552,13 @@ export class SshGitProvider implements IGitProvider {
   }
 
   async rebaseFromBase(worktreePath: string, baseRef: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.rebaseFromBase', { worktreePath, baseRef })
     })
   }
 
   async fetchRemote(worktreePath: string, pushTarget?: GitPushTarget): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.fetch', { worktreePath, ...(pushTarget ? { pushTarget } : {}) })
     })
   }
@@ -571,7 +567,7 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     expectedUpstream: GitForkSyncExpectedUpstream
   ): Promise<GitForkSyncResult> {
-    return this.runWithDiffDedupeClear(
+    return this.runWithGitReadInvalidation(
       async () =>
         (await this.mux.request('git.forkSync', {
           worktreePath,
@@ -587,7 +583,7 @@ export class SshGitProvider implements IGitProvider {
     ref: string,
     options?: { skipAutoMaintenance?: boolean }
   ): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.fetchRemoteTrackingRef', {
         worktreePath,
         remote,
@@ -604,7 +600,7 @@ export class SshGitProvider implements IGitProvider {
     mrIid: number
   ): Promise<string> {
     try {
-      return await this.runWithDiffDedupeClear(async () => {
+      return await this.runWithGitReadInvalidation(async () => {
         // Why: the durable-ref RPC is a NEW method name. Old relays only implement
         // FETCH_HEAD-semantics git.fetchGitLabMergeRequestHead, so calling the ref
         // variant makes them return -32601 rather than silently no-op the durable
@@ -635,7 +631,7 @@ export class SshGitProvider implements IGitProvider {
     prNumber: number
   ): Promise<string> {
     try {
-      return await this.runWithDiffDedupeClear(async () => {
+      return await this.runWithGitReadInvalidation(async () => {
         const result = await this.mux.request('git.fetchGitHubPullRequestHead', {
           worktreePath,
           remote,
@@ -727,7 +723,7 @@ export class SshGitProvider implements IGitProvider {
     targetDir: string,
     options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
   ): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.addWorktree', {
         repoPath,
         branchName,
@@ -742,7 +738,7 @@ export class SshGitProvider implements IGitProvider {
     force?: boolean,
     options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
   ): Promise<RemoveWorktreeResult> {
-    return this.runWithDiffDedupeClear(
+    return this.runWithGitReadInvalidation(
       async () =>
         ((await this.mux.request('git.removeWorktree', {
           worktreePath,
@@ -801,13 +797,13 @@ export class SshGitProvider implements IGitProvider {
     ownerWorktreePath?: string
     checkOnly?: boolean
   }): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.refreshLocalBaseRefForWorktreeCreate', args)
     })
   }
 
   async renameCurrentBranch(worktreePath: string, newBranch: string): Promise<void> {
-    await this.runWithDiffDedupeClear(async () => {
+    await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.renameCurrentBranch', { worktreePath, newBranch })
     })
   }
@@ -818,7 +814,7 @@ export class SshGitProvider implements IGitProvider {
     expectedHead: string
   ): Promise<void> {
     try {
-      await this.runWithDiffDedupeClear(async () => {
+      await this.runWithGitReadInvalidation(async () => {
         await this.mux.request('git.forceDeletePreservedBranch', {
           repoPath,
           branchName,
@@ -847,7 +843,7 @@ export class SshGitProvider implements IGitProvider {
         ? requestGitStreamable(this.mux, 'git.exec', { args, cwd }, options)
         : requestGitStreamable(this.mux, 'git.exec', { args, cwd })
     const result = gitExecMutatesRepository(args)
-      ? await this.runWithDiffDedupeClear(run)
+      ? await this.runWithGitReadInvalidation(run)
       : await run()
     return result as {
       stdout: string
@@ -864,41 +860,41 @@ export class SshGitProvider implements IGitProvider {
       onProgress?: (progress: { phase: string; percent: number }) => void
     }
   ): Promise<{ stdout: string; stderr: string }> {
-    this.gitDiffReadDedupe.clear()
-    const progressId = `clone-${Date.now()}-${Math.random().toString(36).slice(2)}`
-    const unsubscribe = options?.onProgress
-      ? this.mux.onNotificationByMethod('git.cloneProgress', (params) => {
-          if (params.progressId !== progressId) {
-            return
-          }
-          const phase = params.phase
-          const percent = params.percent
-          if (typeof phase === 'string' && typeof percent === 'number') {
-            options.onProgress?.({ phase, percent })
-          }
-        })
-      : undefined
-    try {
-      const result = await this.mux.request(
-        'git.clone',
-        { args, cwd, progressId },
-        { signal: options?.signal, timeoutMs: options?.timeoutMs }
-      )
-      return result as {
-        stdout: string
-        stderr: string
-      }
-    } catch (error) {
-      if (isJsonRpcMethodNotFoundError(error)) {
-        throw new Error(
-          'SSH clone support is unavailable on this relay. Reconnect the SSH target to update Orca on the host, then try again.'
+    return this.runWithGitReadInvalidation(async () => {
+      const progressId = `clone-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const unsubscribe = options?.onProgress
+        ? this.mux.onNotificationByMethod('git.cloneProgress', (params) => {
+            if (params.progressId !== progressId) {
+              return
+            }
+            const phase = params.phase
+            const percent = params.percent
+            if (typeof phase === 'string' && typeof percent === 'number') {
+              options.onProgress?.({ phase, percent })
+            }
+          })
+        : undefined
+      try {
+        const result = await this.mux.request(
+          'git.clone',
+          { args, cwd, progressId },
+          { signal: options?.signal, timeoutMs: options?.timeoutMs }
         )
+        return result as {
+          stdout: string
+          stderr: string
+        }
+      } catch (error) {
+        if (isJsonRpcMethodNotFoundError(error)) {
+          throw new Error(
+            'SSH clone support is unavailable on this relay. Reconnect the SSH target to update Orca on the host, then try again.'
+          )
+        }
+        throw error
+      } finally {
+        unsubscribe?.()
       }
-      throw error
-    } finally {
-      unsubscribe?.()
-      this.gitDiffReadDedupe.clear()
-    }
+    })
   }
 
   async isGitRepoAsync(dirPath: string): Promise<{ isRepo: boolean; rootPath: string | null }> {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | +317 | −22 | +295 |
| Prod | 1 | +89 | −90 | −1 |

<!-- /orca-pr-loc -->

## Summary

Coalesce concurrent SSH Git status reads across callers with distinct cancellation signals.

Each caller gets an independent lease over one client-side `git.status` RPC. The RPC aborts only after its final live lease cancels, and SSH mutations fence status joins before and after execution. Leases are in-flight only — the entry is deleted on settle, so there is no result cache and no stale-badge failure mode.

The focused concurrency test measures 10 concurrent, separately signalled status calls collapsing to 1 SSH `git.status` RPC.

## Fork-point key fix

The original revision of this PR had a defect that merged textually clean: the `git.status` request payload carries `branchLineTotalMergeBase`, but the lease key did not hash it. Two real callers disagree on that field — `git-status-refresh.ts:121-138` (automatic poll) and `:250-267` (strict user-triggered refresh) each read the gate independently — so a refresh asking for the branch-line total could join an in-flight poll that omitted it and render a response with no `branchLineTotal`, blanking the branch-header chip. After a commit moved the merge base, a refresh with the new base could also join an in-flight read using the old one and show a pre-commit number.

The key now includes the fork point, mirroring the guard already on the local path (`src/main/git/status.ts:249-251`, whose inline comment warns about exactly this).

## Rebase notes

- Base retargeted from `nwparker/perf-coalesce-git-status` to `main`; the parent (#11691) has since merged and `GitStatusReadLeaseOwner` now lives in `src/shared/`.
- #14728 split `ssh-git-provider.test.ts` into per-area files after this PR was opened. The lease tests were carried into a new `ssh-git-provider-status-lease.test.ts`, and the `{ signal: expect.any(AbortSignal) }` assertion updates were applied to `ssh-git-provider-status.test.ts` and `ssh-git-provider-worktree.test.ts` (6 tests failed without them).
- The env-gated benchmark test (`ORCA_SSH_GIT_STATUS_COALESCING_BENCH_JSON`) was dropped rather than carried into the split file.
- #11697 is stacked on this branch and will need retargeting to `main` and a rebase once this merges.

## Mutation fencing

`runWithGitReadInvalidation` fences a strict superset of what `main` fenced as `runWithDiffDedupeClear`: all 16 of main's methods, plus `stageFile`, `unstageFile`, `discardChanges`, `bulkStageFiles`, `bulkUnstageFiles`, and `bulkDiscardChanges` — the mutations that change status output and therefore must not be joinable across a write.

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck` (all three tsconfigs: node, cli, web)
- [x] Targeted Vitest: `src/main/providers` + `src/main/git` — 2,459 passed, 6 skipped
- [x] `pnpm check:max-lines-ratchet`, `pnpm check:reliability-gates`
- [x] Targeted `oxlint` + `oxfmt`
- [x] Added or updated high-quality tests that would catch regressions

The new fork-point test was verified non-vacuous: it fails against the source without the key fix (`× isolates status reads by branch-line-total fork point`) and passes with it.

## Remote / cross-platform review

No new RPC method, payload field, command, path, authentication, secret, dependency, or persistence surface. The lease always passes a provider-owned shared `AbortSignal` to `mux.request`, but that only registers a local abort listener (`ssh-channel-multiplexer.ts:277`) — nothing goes on the wire and no relay upgrade is required, so mixed client/host versions are unaffected. No Git commands or options change, so the Git 2.25 floor is untouched. Lease state is scoped to one `SshGitProvider` instance and removed after settlement or invalidation.

Known residual: the key does not normalize Windows path casing, so two callers using different casing for the same worktree perform separate reads. That costs a duplicate read, never a wrong result, and matches the local path's existing behavior.

## Notes

This is the third focused extraction from draft PR #11539.
