### PR TITLE
perf: coalesce git upstream status reads

### DIFF
--- a/src/main/git/git-upstream-status-read-owner.test.ts
+++ b/src/main/git/git-upstream-status-read-owner.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { GitPushTarget, GitUpstreamStatus } from '../../shared/types'
+import {
+  GitUpstreamStatusReadOwner,
+  type GitUpstreamStatusExecutionIdentity
+} from './git-upstream-status-read-owner'
+
+const upstreamStatus: GitUpstreamStatus = {
+  hasUpstream: true,
+  upstreamName: 'origin/main',
+  ahead: 1,
+  behind: 0
+}
+
+function deferredPromise<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('GitUpstreamStatusReadOwner', () => {
+  it('shares one live read across ten identical callers', async () => {
+    const owner = new GitUpstreamStatusReadOwner()
+    const pending = deferredPromise<GitUpstreamStatus>()
+    const load = vi.fn(() => pending.promise)
+
+    const reads = Array.from({ length: 10 }, () =>
+      owner.read({ kind: 'native' }, '/repo', undefined, load)
+    )
+    await Promise.resolve()
+
+    expect(load).toHaveBeenCalledTimes(1)
+    pending.resolve(upstreamStatus)
+    await expect(Promise.all(reads)).resolves.toEqual(
+      Array.from({ length: 10 }, () => upstreamStatus)
+    )
+  })
+
+  it('isolates paths, execution hosts, and every explicit target field', async () => {
+    const owner = new GitUpstreamStatusReadOwner()
+    const load = vi.fn().mockResolvedValue(upstreamStatus)
+    const baseTarget: GitPushTarget = {
+      remoteName: 'fork',
+      branchName: 'feature'
+    }
+    const cases: [GitUpstreamStatusExecutionIdentity, string, GitPushTarget | undefined][] = [
+      [{ kind: 'native' }, '/repo-a', undefined],
+      [{ kind: 'native' }, '/repo-b', undefined],
+      [{ kind: 'wsl', distro: 'Ubuntu' }, '/repo-a', undefined],
+      [{ kind: 'wsl', distro: 'Debian' }, '/repo-a', undefined],
+      [{ kind: 'native' }, '/repo-a', baseTarget],
+      [{ kind: 'native' }, '/repo-a', { ...baseTarget, remoteName: 'origin' }],
+      [{ kind: 'native' }, '/repo-a', { ...baseTarget, branchName: 'other' }],
+      [
+        { kind: 'native' },
+        '/repo-a',
+        { ...baseTarget, remoteUrl: 'https://github.com/example/fork.git' }
+      ],
+      [{ kind: 'native' }, '/repo-a', { ...baseTarget, remoteCreated: false }],
+      [{ kind: 'native' }, '/repo-a', { ...baseTarget, remoteCreated: true }],
+      [{ kind: 'ssh-provider' }, '/repo-a', baseTarget]
+    ]
+
+    await Promise.all(
+      cases.map(([identity, worktreePath, target]) =>
+        owner.read(identity, worktreePath, target, load)
+      )
+    )
+
+    expect(load).toHaveBeenCalledTimes(cases.length)
+  })
+
+  it('runs fresh work after success and rejection', async () => {
+    const owner = new GitUpstreamStatusReadOwner()
+    const failure = new Error('upstream failed')
+    const load = vi
+      .fn<() => Promise<GitUpstreamStatus>>()
+      .mockResolvedValueOnce(upstreamStatus)
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce(upstreamStatus)
+
+    await expect(owner.read({ kind: 'native' }, '/repo', undefined, load)).resolves.toBe(
+      upstreamStatus
+    )
+    await expect(owner.read({ kind: 'native' }, '/repo', undefined, load)).rejects.toBe(failure)
+    await expect(owner.read({ kind: 'native' }, '/repo', undefined, load)).resolves.toBe(
+      upstreamStatus
+    )
+    expect(load).toHaveBeenCalledTimes(3)
+  })
+
+  it('fences before, during, and after mutation generations', async () => {
+    const owner = new GitUpstreamStatusReadOwner()
+    const pendingReads = Array.from({ length: 3 }, () => deferredPromise<GitUpstreamStatus>())
+    const load = vi.fn(() => pendingReads[load.mock.calls.length - 1].promise)
+
+    const before = owner.read({ kind: 'native' }, '/repo', undefined, load)
+    await Promise.resolve()
+    owner.invalidate()
+    const during = owner.read({ kind: 'native' }, '/repo', undefined, load)
+    await Promise.resolve()
+    owner.invalidate()
+    const after = owner.read({ kind: 'native' }, '/repo', undefined, load)
+    await Promise.resolve()
+
+    pendingReads.forEach((pending) => pending.resolve(upstreamStatus))
+    await expect(Promise.all([before, during, after])).resolves.toEqual(
+      Array.from({ length: 3 }, () => upstreamStatus)
+    )
+    expect(load).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/main/git/git-upstream-status-read-owner.test.ts
+++ b/src/main/git/git-upstream-status-read-owner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { GitPushTarget, GitUpstreamStatus } from '../../shared/types'
+import type { GitUpstreamStatus } from '../../shared/git-status-types'
+import type { GitPushTarget } from '../../shared/worktree/types'
 import {
   GitUpstreamStatusReadOwner,
   type GitUpstreamStatusExecutionIdentity

--- a/src/main/git/git-upstream-status-read-owner.ts
+++ b/src/main/git/git-upstream-status-read-owner.ts
@@ -1,0 +1,39 @@
+import type { GitPushTarget, GitUpstreamStatus } from '../../shared/types'
+import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
+
+export type GitUpstreamStatusExecutionIdentity =
+  | { kind: 'native' }
+  | { kind: 'wsl'; distro: string }
+  | { kind: 'ssh-provider' }
+
+export class GitUpstreamStatusReadOwner {
+  private readonly inFlightReads = new InFlightPromiseDedupe<GitUpstreamStatus>()
+
+  read(
+    executionIdentity: GitUpstreamStatusExecutionIdentity,
+    worktreePath: string,
+    pushTarget: GitPushTarget | undefined,
+    load: () => Promise<GitUpstreamStatus>
+  ): Promise<GitUpstreamStatus> {
+    const key = stableInFlightKey([
+      executionIdentity,
+      worktreePath,
+      pushTarget
+        ? [
+            'explicit-target',
+            pushTarget.remoteName,
+            pushTarget.branchName,
+            pushTarget.remoteUrl ?? null,
+            pushTarget.remoteCreated ?? null
+          ]
+        : ['configured-upstream']
+    ])
+    return this.inFlightReads.run(key, load)
+  }
+
+  invalidate(): void {
+    this.inFlightReads.clear()
+  }
+}
+
+export const nativeAndWslGitUpstreamStatusReadOwner = new GitUpstreamStatusReadOwner()

--- a/src/main/git/git-upstream-status-read-owner.ts
+++ b/src/main/git/git-upstream-status-read-owner.ts
@@ -1,5 +1,19 @@
-import type { GitPushTarget, GitUpstreamStatus } from '../../shared/types'
+import type { GitUpstreamStatus } from '../../shared/git-status-types'
+import type { GitPushTarget } from '../../shared/worktree/types'
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
+
+/**
+ * Why the exhaustive destructure: stableInFlightKey is JSON.stringify, which is not
+ * key-order stable, so push-target fields must be listed in a fixed order. Spreading
+ * the remainder into Record<string, never> makes a newly added GitPushTarget field a
+ * compile error instead of a silently shared lease between two different targets.
+ */
+function pushTargetKeyParts(pushTarget: GitPushTarget): readonly unknown[] {
+  const { remoteName, branchName, remoteUrl, remoteCreated, ...rest } = pushTarget
+  const exhaustive: Record<string, never> = rest
+  void exhaustive
+  return ['explicit-target', remoteName, branchName, remoteUrl ?? null, remoteCreated ?? null]
+}
 
 export type GitUpstreamStatusExecutionIdentity =
   | { kind: 'native' }
@@ -18,15 +32,7 @@ export class GitUpstreamStatusReadOwner {
     const key = stableInFlightKey([
       executionIdentity,
       worktreePath,
-      pushTarget
-        ? [
-            'explicit-target',
-            pushTarget.remoteName,
-            pushTarget.branchName,
-            pushTarget.remoteUrl ?? null,
-            pushTarget.remoteCreated ?? null
-          ]
-        : ['configured-upstream']
+      pushTarget ? pushTargetKeyParts(pushTarget) : ['configured-upstream']
     ])
     return this.inFlightReads.run(key, load)
   }

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -54,6 +54,7 @@ import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 import { GitStatusReadLeaseOwner } from './git-status-read-lease-owner'
 import { parseGitRevListFirstParentOid } from '../../shared/git-rev-list-output'
+import { nativeAndWslGitUpstreamStatusReadOwner } from './git-upstream-status-read-owner'
 import {
   beginGitStatusLineStatsCacheWrite,
   clearGitStatusLineStatsCache,
@@ -99,6 +100,7 @@ const statusReadLeaseOwner = new GitStatusReadLeaseOwner<GitStatusResult>()
 export function invalidateGitReadCaches(): void {
   gitDiffReadDedupe.clear()
   statusReadLeaseOwner.invalidate()
+  nativeAndWslGitUpstreamStatusReadOwner.invalidate()
   clearGitStatusLineStatsCache()
   clearSubmodulePathsCache()
   resolvedUpstreamNameCache.clear()

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -56,7 +56,7 @@ import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree, gitStatusReadOptionsForWorktree } from './git-runtime-options'
 import { GitStatusReadLeaseOwner } from './git-status-read-lease-owner'
 import { parseGitRevListFirstParentOid } from '../../shared/git-rev-list-output'
-import { nativeAndWslGitUpstreamStatusReadOwner } from './git-upstream-status-read-owner'
+import { invalidateGitUpstreamStatusReads } from './upstream'
 import {
   computeGitBranchLineTotal,
   invalidateGitBranchLineTotalInFlight,
@@ -111,7 +111,7 @@ export function invalidateGitReadCaches(): void {
   gitDiffReadDedupe.clear()
   statusReadLeaseOwner.invalidate()
   invalidateGitBranchLineTotalInFlight()
-  nativeAndWslGitUpstreamStatusReadOwner.invalidate()
+  invalidateGitUpstreamStatusReads()
   clearGitStatusLineStatsCache()
   clearSubmodulePathsCache()
   resolvedUpstreamNameCache.clear()

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -56,6 +56,7 @@ import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree, gitStatusReadOptionsForWorktree } from './git-runtime-options'
 import { GitStatusReadLeaseOwner } from './git-status-read-lease-owner'
 import { parseGitRevListFirstParentOid } from '../../shared/git-rev-list-output'
+import { nativeAndWslGitUpstreamStatusReadOwner } from './git-upstream-status-read-owner'
 import {
   computeGitBranchLineTotal,
   invalidateGitBranchLineTotalInFlight,
@@ -110,6 +111,7 @@ export function invalidateGitReadCaches(): void {
   gitDiffReadDedupe.clear()
   statusReadLeaseOwner.invalidate()
   invalidateGitBranchLineTotalInFlight()
+  nativeAndWslGitUpstreamStatusReadOwner.invalidate()
   clearGitStatusLineStatsCache()
   clearSubmodulePathsCache()
   resolvedUpstreamNameCache.clear()

--- a/src/main/git/upstream.test.ts
+++ b/src/main/git/upstream.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import path from 'node:path'
 
 const { gitExecFileAsyncMock } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn()
@@ -8,7 +10,8 @@ vi.mock('./runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock
 }))
 
-import { getUpstreamStatus } from './upstream'
+import { getUpstreamStatus, invalidateGitUpstreamStatusReads } from './upstream'
+import { runWithGitReadCacheInvalidation } from './status'
 
 const missingTrackingRefError = new Error(
   "fatal: ambiguous argument 'HEAD@{u}': unknown revision or path not in the working tree.\n" +
@@ -19,6 +22,157 @@ const missingTrackingRefError = new Error(
 describe('getUpstreamStatus', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
+    invalidateGitUpstreamStatusReads()
+  })
+
+  it('benchmarks concurrent upstream Git command pressure', async () => {
+    const benchPath = process.env.ORCA_GIT_UPSTREAM_COALESCING_BENCH_JSON
+    if (!benchPath) {
+      return
+    }
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'symbolic-ref') {
+        return Promise.resolve({ stdout: 'main\n' })
+      }
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: 'origin/main\n' })
+      }
+      if (args[0] === 'rev-list') {
+        return Promise.resolve({ stdout: '2\t3\n' })
+      }
+      if (args[0] === 'log') {
+        return Promise.resolve({ stdout: '+ abc123 remote work\n' })
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+
+    await Promise.all(Array.from({ length: 10 }, () => getUpstreamStatus('/repo')))
+
+    const commands = gitExecFileAsyncMock.mock.calls.map(([args, options]) => ({ args, options }))
+    const commandCounts = Object.fromEntries(
+      ['symbolic-ref', 'rev-parse', 'rev-list', 'log'].map((command) => [
+        command,
+        commands.filter(({ args }) => args[0] === command).length
+      ])
+    )
+    const { mkdirSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
+    mkdirSync(path.dirname(benchPath), { recursive: true })
+    writeFileSync(
+      benchPath,
+      JSON.stringify({
+        scenario: 'local-git-upstream-concurrent-burst',
+        concurrentCalls: 10,
+        physicalGitCalls: commands.length,
+        commandCounts,
+        commandChain: ['symbolic-ref', 'rev-parse', 'rev-list', 'log'].map((command) =>
+          commands.find(({ args }) => args[0] === command)
+        )
+      })
+    )
+  })
+
+  it('isolates physical reads by worktree, native or WSL host, and every target field', async () => {
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'symbolic-ref') {
+        return Promise.resolve({ stdout: 'main\n' })
+      }
+      if (args[0] === 'check-ref-format') {
+        return Promise.resolve({ stdout: '' })
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+        return Promise.resolve({ stdout: 'origin/main\n' })
+      }
+      if (args[0] === 'rev-parse' && args.includes('--verify')) {
+        return Promise.resolve({ stdout: 'abc123\n' })
+      }
+      if (args[0] === 'rev-list') {
+        return Promise.resolve({ stdout: '0\t0\n' })
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+    const baseTarget = { remoteName: 'fork', branchName: 'feature' }
+
+    await Promise.all([
+      getUpstreamStatus('/repo-a'),
+      getUpstreamStatus('/repo-b'),
+      getUpstreamStatus('/repo-a', undefined, { wslDistro: 'Ubuntu' }),
+      getUpstreamStatus('/repo-a', undefined, { wslDistro: 'Debian' }),
+      getUpstreamStatus('/repo-a', baseTarget),
+      getUpstreamStatus('/repo-a', { ...baseTarget, remoteName: 'origin' }),
+      getUpstreamStatus('/repo-a', { ...baseTarget, branchName: 'other' }),
+      getUpstreamStatus('/repo-a', {
+        ...baseTarget,
+        remoteUrl: 'https://github.com/example/fork.git'
+      }),
+      getUpstreamStatus('/repo-a', { ...baseTarget, remoteCreated: false }),
+      getUpstreamStatus('/repo-a', { ...baseTarget, remoteCreated: true })
+    ])
+
+    expect(
+      gitExecFileAsyncMock.mock.calls.filter(([args]) => args[0] === 'symbolic-ref')
+    ).toHaveLength(4)
+    expect(
+      gitExecFileAsyncMock.mock.calls.filter(([args]) => args[0] === 'check-ref-format')
+    ).toHaveLength(6)
+  })
+
+  it('runs fresh physical work after a normalized rejection', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'main\n' })
+      .mockResolvedValueOnce({ stdout: 'origin/main\n' })
+      .mockRejectedValueOnce(new Error('fatal: authentication failed'))
+      .mockResolvedValueOnce({ stdout: 'main\n' })
+      .mockResolvedValueOnce({ stdout: 'origin/main\n' })
+      .mockResolvedValueOnce({ stdout: '0\t0\n' })
+
+    await expect(getUpstreamStatus('/repo')).rejects.toThrow('fatal: authentication failed')
+    await expect(getUpstreamStatus('/repo')).resolves.toMatchObject({
+      hasUpstream: true,
+      upstreamName: 'origin/main'
+    })
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(6)
+  })
+
+  it('uses the common pre/post mutation fence for physical upstream reads', async () => {
+    const pendingReads: {
+      promise: Promise<{ stdout: string }>
+      resolve: (value: { stdout: string }) => void
+    }[] = []
+    gitExecFileAsyncMock.mockImplementation((args: string[]) => {
+      if (args[0] === 'symbolic-ref') {
+        let resolve!: (value: { stdout: string }) => void
+        const promise = new Promise<{ stdout: string }>((innerResolve) => {
+          resolve = innerResolve
+        })
+        pendingReads.push({ promise, resolve })
+        return promise
+      }
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: 'origin/main\n' })
+      }
+      if (args[0] === 'rev-list') {
+        return Promise.resolve({ stdout: '0\t0\n' })
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+    let finishMutation!: () => void
+    const mutationGate = new Promise<void>((resolve) => {
+      finishMutation = resolve
+    })
+
+    const before = getUpstreamStatus('/repo')
+    await vi.waitFor(() => expect(pendingReads).toHaveLength(1))
+    const mutation = runWithGitReadCacheInvalidation(() => mutationGate)
+    const during = getUpstreamStatus('/repo')
+    await vi.waitFor(() => expect(pendingReads).toHaveLength(2))
+    finishMutation()
+    await mutation
+    const after = getUpstreamStatus('/repo')
+    await vi.waitFor(() => expect(pendingReads).toHaveLength(3))
+
+    pendingReads.forEach(({ resolve }) => resolve({ stdout: 'main\n' }))
+    await Promise.all([before, during, after])
+    expect(pendingReads).toHaveLength(3)
   })
 
   it('returns upstream and ahead/behind counts when tracking is configured', async () => {

--- a/src/main/git/upstream.test.ts
+++ b/src/main/git/upstream.test.ts
@@ -71,6 +71,42 @@ describe('getUpstreamStatus', () => {
     )
   })
 
+  // Why: the benchmark above only runs under an env var, so this is the CI-enforced
+  // guard that the native/WSL path actually coalesces rather than fanning out.
+  it('shares one physical read across ten identical native callers', async () => {
+    let resolveSymbolicRef = (): void => {}
+    const symbolicRefGate = new Promise<void>((resolve) => {
+      resolveSymbolicRef = resolve
+    })
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'symbolic-ref') {
+        await symbolicRefGate
+        return { stdout: 'main\n' }
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: 'origin/main\n' }
+      }
+      if (args[0] === 'rev-list') {
+        return { stdout: '0\t0\n' }
+      }
+      throw new Error(`unexpected git args: ${args.join(' ')}`)
+    })
+
+    const reads = Array.from({ length: 10 }, () => getUpstreamStatus('/repo'))
+    resolveSymbolicRef()
+    const results = await Promise.all(reads)
+
+    expect(
+      gitExecFileAsyncMock.mock.calls.filter(([args]) => args[0] === 'symbolic-ref')
+    ).toHaveLength(1)
+    expect(new Set(results).size).toBe(1)
+    // A settled lease is dropped, so the next read must issue fresh Git work.
+    await getUpstreamStatus('/repo')
+    expect(
+      gitExecFileAsyncMock.mock.calls.filter(([args]) => args[0] === 'symbolic-ref')
+    ).toHaveLength(2)
+  })
+
   it('isolates physical reads by worktree, native or WSL host, and every target field', async () => {
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args[0] === 'symbolic-ref') {

--- a/src/main/git/upstream.ts
+++ b/src/main/git/upstream.ts
@@ -5,9 +5,14 @@ import { getEffectiveGitUpstreamStatus } from '../../shared/git-effective-upstre
 import { getPublishTargetStatus } from '../../shared/git-publish-target-status'
 import { gitExecFileAsync } from './runner'
 import { validateGitPushTarget } from './push-target-validation'
+import { nativeAndWslGitUpstreamStatusReadOwner } from './git-upstream-status-read-owner'
 
 type GitExecOptions = {
   wslDistro?: string
+}
+
+export function invalidateGitUpstreamStatusReads(): void {
+  nativeAndWslGitUpstreamStatusReadOwner.invalidate()
 }
 
 function gitExecOptions(
@@ -35,7 +40,7 @@ async function getBehindCommitsArePatchEquivalent(
   }
 }
 
-export async function getUpstreamStatus(
+async function readUpstreamStatus(
   worktreePath: string,
   pushTarget?: GitPushTarget,
   options: GitExecOptions = {}
@@ -70,4 +75,20 @@ export async function getUpstreamStatus(
     // the IPC boundary so renderers don't see execFile stderr preambles or local paths.
     throw new Error(normalizeGitErrorMessage(error, 'upstream'))
   }
+}
+
+export function getUpstreamStatus(
+  worktreePath: string,
+  pushTarget?: GitPushTarget,
+  options: GitExecOptions = {}
+): Promise<GitUpstreamStatus> {
+  const executionIdentity = options.wslDistro
+    ? ({ kind: 'wsl', distro: options.wslDistro } as const)
+    : ({ kind: 'native' } as const)
+  return nativeAndWslGitUpstreamStatusReadOwner.read(
+    executionIdentity,
+    worktreePath,
+    pushTarget,
+    () => readUpstreamStatus(worktreePath, pushTarget, options)
+  )
 }

--- a/src/main/git/upstream.ts
+++ b/src/main/git/upstream.ts
@@ -6,9 +6,14 @@ import { getEffectiveGitUpstreamStatus } from '../../shared/git-effective-upstre
 import { getPublishTargetStatus } from '../../shared/git-publish-target-status'
 import { gitExecFileAsync } from './runner'
 import { validateGitPushTarget } from './push-target-validation'
+import { nativeAndWslGitUpstreamStatusReadOwner } from './git-upstream-status-read-owner'
 
 type GitExecOptions = {
   wslDistro?: string
+}
+
+export function invalidateGitUpstreamStatusReads(): void {
+  nativeAndWslGitUpstreamStatusReadOwner.invalidate()
 }
 
 function gitExecOptions(
@@ -36,7 +41,7 @@ async function getBehindCommitsArePatchEquivalent(
   }
 }
 
-export async function getUpstreamStatus(
+async function readUpstreamStatus(
   worktreePath: string,
   pushTarget?: GitPushTarget,
   options: GitExecOptions = {}
@@ -71,4 +76,20 @@ export async function getUpstreamStatus(
     // the IPC boundary so renderers don't see execFile stderr preambles or local paths.
     throw new Error(normalizeGitErrorMessage(error, 'upstream'))
   }
+}
+
+export function getUpstreamStatus(
+  worktreePath: string,
+  pushTarget?: GitPushTarget,
+  options: GitExecOptions = {}
+): Promise<GitUpstreamStatus> {
+  const executionIdentity = options.wslDistro
+    ? ({ kind: 'wsl', distro: options.wslDistro } as const)
+    : ({ kind: 'native' } as const)
+  return nativeAndWslGitUpstreamStatusReadOwner.read(
+    executionIdentity,
+    worktreePath,
+    pushTarget,
+    () => readUpstreamStatus(worktreePath, pushTarget, options)
+  )
 }

--- a/src/main/providers/ssh-git-provider-upstream-lease.test.ts
+++ b/src/main/providers/ssh-git-provider-upstream-lease.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { SshGitProvider } from './ssh-git-provider'
+import {
+  createMockMux,
+  waitForRequestCount,
+  type MockMultiplexer
+} from './ssh-git-provider-test-harness'
+
+function deferredPromise<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('SshGitProvider upstream status read leases', () => {
+  let mux: MockMultiplexer
+  let provider: SshGitProvider
+
+  beforeEach(() => {
+    mux = createMockMux()
+    provider = new SshGitProvider('conn-1', mux as never)
+  })
+
+  it('shares one upstream-status RPC across ten identical callers', async () => {
+    const pending = deferredPromise<{
+      hasUpstream: true
+      upstreamName: string
+      ahead: number
+      behind: number
+    }>()
+    mux.request.mockReturnValue(pending.promise)
+
+    const reads = Array.from({ length: 10 }, () => provider.getUpstreamStatus('/home/user/repo'))
+    await waitForRequestCount(mux.request, 1)
+
+    expect(mux.request).toHaveBeenCalledTimes(1)
+    pending.resolve({ hasUpstream: true, upstreamName: 'origin/main', ahead: 1, behind: 0 })
+    await expect(Promise.all(reads)).resolves.toHaveLength(10)
+  })
+
+  it('isolates upstream-status RPCs by worktree and every target field', async () => {
+    mux.request.mockResolvedValue({
+      hasUpstream: true,
+      upstreamName: 'fork/feature',
+      ahead: 0,
+      behind: 0
+    })
+    const baseTarget = { remoteName: 'fork', branchName: 'feature' }
+
+    await Promise.all([
+      provider.getUpstreamStatus('/repo-a'),
+      provider.getUpstreamStatus('/repo-b'),
+      provider.getUpstreamStatus('/repo-a', baseTarget),
+      provider.getUpstreamStatus('/repo-a', { ...baseTarget, remoteName: 'origin' }),
+      provider.getUpstreamStatus('/repo-a', { ...baseTarget, branchName: 'other' }),
+      provider.getUpstreamStatus('/repo-a', {
+        ...baseTarget,
+        remoteUrl: 'https://github.com/example/fork.git'
+      }),
+      provider.getUpstreamStatus('/repo-a', { ...baseTarget, remoteCreated: false }),
+      provider.getUpstreamStatus('/repo-a', { ...baseTarget, remoteCreated: true })
+    ])
+
+    expect(mux.request).toHaveBeenCalledTimes(8)
+  })
+
+  it('keeps upstream-status reads isolated per provider instance', async () => {
+    const otherProvider = new SshGitProvider('conn-1', mux as never)
+    mux.request.mockResolvedValue({
+      hasUpstream: true,
+      upstreamName: 'origin/main',
+      ahead: 0,
+      behind: 0
+    })
+
+    await Promise.all([
+      provider.getUpstreamStatus('/home/user/repo'),
+      otherProvider.getUpstreamStatus('/home/user/repo')
+    ])
+
+    expect(mux.request).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs a fresh upstream-status RPC after result and error settlement', async () => {
+    const failure = new Error('upstream RPC failed')
+    mux.request
+      .mockResolvedValueOnce({
+        hasUpstream: true,
+        upstreamName: 'origin/main',
+        ahead: 0,
+        behind: 0
+      })
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({
+        hasUpstream: false,
+        ahead: 0,
+        behind: 0
+      })
+
+    await expect(provider.getUpstreamStatus('/home/user/repo')).resolves.toMatchObject({
+      hasUpstream: true
+    })
+    await expect(provider.getUpstreamStatus('/home/user/repo')).rejects.toBe(failure)
+    await expect(provider.getUpstreamStatus('/home/user/repo')).resolves.toMatchObject({
+      hasUpstream: false
+    })
+    expect(mux.request).toHaveBeenCalledTimes(3)
+  })
+
+  it('fences upstream-status reads before, during, and after an SSH mutation', async () => {
+    const upstreamRequests = Array.from({ length: 3 }, () =>
+      deferredPromise<{ hasUpstream: false; ahead: 0; behind: 0 }>()
+    )
+    const mutation = deferredPromise<void>()
+    let upstreamRequestIndex = 0
+    mux.request.mockImplementation((method) => {
+      if (method === 'git.upstreamStatus') {
+        return upstreamRequests[upstreamRequestIndex++]?.promise
+      }
+      if (method === 'git.stage') {
+        return mutation.promise
+      }
+      return Promise.resolve(undefined)
+    })
+
+    const beforeMutation = provider.getUpstreamStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 1)
+    const mutating = provider.stageFile('/home/user/repo', 'src/file.ts')
+    await waitForRequestCount(mux.request, 2)
+    const duringMutation = provider.getUpstreamStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 3)
+    mutation.resolve(undefined)
+    await mutating
+    const afterMutation = provider.getUpstreamStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 4)
+
+    upstreamRequests.forEach((pending) =>
+      pending.resolve({ hasUpstream: false, ahead: 0, behind: 0 })
+    )
+    await Promise.all([beforeMutation, duringMutation, afterMutation])
+    expect(
+      mux.request.mock.calls.filter(([method]) => method === 'git.upstreamStatus')
+    ).toHaveLength(3)
+  })
+})

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1002,6 +1002,125 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(upstreamResult)
   })
 
+  it('benchmarks concurrent upstream-status RPC pressure', async () => {
+    const benchPath = process.env.ORCA_SSH_GIT_UPSTREAM_COALESCING_BENCH_JSON
+    if (!benchPath) {
+      return
+    }
+    mux.request.mockResolvedValue({
+      hasUpstream: true,
+      upstreamName: 'origin/main',
+      ahead: 1,
+      behind: 0
+    })
+
+    await Promise.all(
+      Array.from({ length: 10 }, () => provider.getUpstreamStatus('/home/user/repo'))
+    )
+
+    const upstreamRequests = mux.request.mock.calls.filter(
+      ([method]) => method === 'git.upstreamStatus'
+    )
+    const { mkdirSync, writeFileSync } = await vi.importActual<typeof NodeFs>('node:fs')
+    mkdirSync(path.dirname(benchPath), { recursive: true })
+    writeFileSync(
+      benchPath,
+      JSON.stringify({
+        scenario: 'ssh-git-upstream-concurrent-burst',
+        concurrentCalls: 10,
+        upstreamStatusRequests: upstreamRequests.length,
+        method: 'git.upstreamStatus',
+        payload: { worktreePath: '/home/user/repo' }
+      })
+    )
+  })
+
+  it('shares one upstream-status RPC across ten identical callers', async () => {
+    const pending = deferredPromise<{
+      hasUpstream: true
+      upstreamName: string
+      ahead: number
+      behind: number
+    }>()
+    mux.request.mockReturnValue(pending.promise)
+
+    const reads = Array.from({ length: 10 }, () => provider.getUpstreamStatus('/home/user/repo'))
+    await waitForRequestCount(mux.request, 1)
+
+    expect(mux.request).toHaveBeenCalledTimes(1)
+    pending.resolve({ hasUpstream: true, upstreamName: 'origin/main', ahead: 1, behind: 0 })
+    await expect(Promise.all(reads)).resolves.toHaveLength(10)
+  })
+
+  it('isolates upstream-status RPCs by worktree and every target field', async () => {
+    mux.request.mockResolvedValue({
+      hasUpstream: true,
+      upstreamName: 'fork/feature',
+      ahead: 0,
+      behind: 0
+    })
+    const baseTarget = { remoteName: 'fork', branchName: 'feature' }
+
+    await Promise.all([
+      provider.getUpstreamStatus('/repo-a'),
+      provider.getUpstreamStatus('/repo-b'),
+      provider.getUpstreamStatus('/repo-a', baseTarget),
+      provider.getUpstreamStatus('/repo-a', { ...baseTarget, remoteName: 'origin' }),
+      provider.getUpstreamStatus('/repo-a', { ...baseTarget, branchName: 'other' }),
+      provider.getUpstreamStatus('/repo-a', {
+        ...baseTarget,
+        remoteUrl: 'https://github.com/example/fork.git'
+      }),
+      provider.getUpstreamStatus('/repo-a', { ...baseTarget, remoteCreated: false }),
+      provider.getUpstreamStatus('/repo-a', { ...baseTarget, remoteCreated: true })
+    ])
+
+    expect(mux.request).toHaveBeenCalledTimes(8)
+  })
+
+  it('keeps upstream-status reads isolated per provider instance', async () => {
+    const otherProvider = new SshGitProvider('conn-1', mux as never)
+    mux.request.mockResolvedValue({
+      hasUpstream: true,
+      upstreamName: 'origin/main',
+      ahead: 0,
+      behind: 0
+    })
+
+    await Promise.all([
+      provider.getUpstreamStatus('/home/user/repo'),
+      otherProvider.getUpstreamStatus('/home/user/repo')
+    ])
+
+    expect(mux.request).toHaveBeenCalledTimes(2)
+  })
+
+  it('runs a fresh upstream-status RPC after result and error settlement', async () => {
+    const failure = new Error('upstream RPC failed')
+    mux.request
+      .mockResolvedValueOnce({
+        hasUpstream: true,
+        upstreamName: 'origin/main',
+        ahead: 0,
+        behind: 0
+      })
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({
+        hasUpstream: false,
+        ahead: 0,
+        behind: 0
+      })
+
+    await expect(provider.getUpstreamStatus('/home/user/repo')).resolves.toMatchObject({
+      hasUpstream: true
+    })
+    await expect(provider.getUpstreamStatus('/home/user/repo')).rejects.toBe(failure)
+    await expect(provider.getUpstreamStatus('/home/user/repo')).resolves.toMatchObject({
+      hasUpstream: false
+    })
+    expect(mux.request).toHaveBeenCalledTimes(3)
+  })
+
   it('getUpstreamStatus forwards an explicit push target', async () => {
     const upstreamResult = { hasUpstream: true, upstreamName: 'fork/feature', ahead: 0, behind: 1 }
     mux.request.mockResolvedValue(upstreamResult)
@@ -1430,6 +1549,42 @@ describe('SshGitProvider', () => {
     )
     await Promise.all([beforeMutation, duringMutation, afterMutation])
     expect(mux.request.mock.calls.filter(([method]) => method === 'git.status')).toHaveLength(3)
+  })
+
+  it('fences upstream-status reads before, during, and after an SSH mutation', async () => {
+    const upstreamRequests = Array.from({ length: 3 }, () =>
+      deferredPromise<{ hasUpstream: false; ahead: 0; behind: 0 }>()
+    )
+    const mutation = deferredPromise<void>()
+    let upstreamRequestIndex = 0
+    mux.request.mockImplementation((method) => {
+      if (method === 'git.upstreamStatus') {
+        return upstreamRequests[upstreamRequestIndex++]?.promise
+      }
+      if (method === 'git.stage') {
+        return mutation.promise
+      }
+      return Promise.resolve(undefined)
+    })
+
+    const beforeMutation = provider.getUpstreamStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 1)
+    const mutating = provider.stageFile('/home/user/repo', 'src/file.ts')
+    await waitForRequestCount(mux.request, 2)
+    const duringMutation = provider.getUpstreamStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 3)
+    mutation.resolve(undefined)
+    await mutating
+    const afterMutation = provider.getUpstreamStatus('/home/user/repo')
+    await waitForRequestCount(mux.request, 4)
+
+    upstreamRequests.forEach((pending) =>
+      pending.resolve({ hasUpstream: false, ahead: 0, behind: 0 })
+    )
+    await Promise.all([beforeMutation, duringMutation, afterMutation])
+    expect(
+      mux.request.mock.calls.filter(([method]) => method === 'git.upstreamStatus')
+    ).toHaveLength(3)
   })
 
   it.each([

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -33,6 +33,7 @@ import {
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
 import { GitStatusReadLeaseOwner } from '../git/git-status-read-lease-owner'
+import { GitUpstreamStatusReadOwner } from '../git/git-upstream-status-read-owner'
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -85,6 +86,7 @@ function filterUntrackedPorcelainStatus(stdout: string | undefined): string | un
 export class SshGitProvider implements IGitProvider {
   private readonly gitDiffReadDedupe = new InFlightPromiseDedupe<GitDiffResult | GitDiffResult[]>()
   private readonly statusReadLeaseOwner = new GitStatusReadLeaseOwner<GitStatusResult>()
+  private readonly upstreamStatusReadOwner = new GitUpstreamStatusReadOwner()
 
   private connectionId: string
   private mux: SshChannelMultiplexer
@@ -102,6 +104,7 @@ export class SshGitProvider implements IGitProvider {
   private invalidateGitReads(): void {
     this.gitDiffReadDedupe.clear()
     this.statusReadLeaseOwner.invalidate()
+    this.upstreamStatusReadOwner.invalidate()
   }
 
   private loggedWorktreeIsCleanFallback = false
@@ -507,10 +510,16 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     pushTarget?: GitPushTarget
   ): Promise<GitUpstreamStatus> {
-    return (await this.mux.request('git.upstreamStatus', {
+    return this.upstreamStatusReadOwner.read(
+      { kind: 'ssh-provider' },
       worktreePath,
-      ...(pushTarget ? { pushTarget } : {})
-    })) as GitUpstreamStatus
+      pushTarget,
+      async () =>
+        (await this.mux.request('git.upstreamStatus', {
+          worktreePath,
+          ...(pushTarget ? { pushTarget } : {})
+        })) as GitUpstreamStatus
+    )
   }
 
   async pushBranch(

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -33,6 +33,7 @@ import {
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
 import { GitStatusReadLeaseOwner } from '../git/git-status-read-lease-owner'
+import { GitUpstreamStatusReadOwner } from '../git/git-upstream-status-read-owner'
 
 type NonInteractiveExecQueueEntry = {
   started: boolean
@@ -88,6 +89,7 @@ function filterUntrackedPorcelainStatus(stdout: string | undefined): string | un
 export class SshGitProvider implements IGitProvider {
   private readonly gitDiffReadDedupe = new InFlightPromiseDedupe<GitDiffResult | GitDiffResult[]>()
   private readonly statusReadLeaseOwner = new GitStatusReadLeaseOwner<GitStatusResult>()
+  private readonly upstreamStatusReadOwner = new GitUpstreamStatusReadOwner()
 
   private connectionId: string
   private mux: SshChannelMultiplexer
@@ -105,6 +107,7 @@ export class SshGitProvider implements IGitProvider {
   private invalidateGitReads(): void {
     this.gitDiffReadDedupe.clear()
     this.statusReadLeaseOwner.invalidate()
+    this.upstreamStatusReadOwner.invalidate()
   }
 
   private loggedWorktreeIsCleanFallback = false
@@ -517,10 +520,16 @@ export class SshGitProvider implements IGitProvider {
     worktreePath: string,
     pushTarget?: GitPushTarget
   ): Promise<GitUpstreamStatus> {
-    return (await this.mux.request('git.upstreamStatus', {
+    return this.upstreamStatusReadOwner.read(
+      { kind: 'ssh-provider' },
       worktreePath,
-      ...(pushTarget ? { pushTarget } : {})
-    })) as GitUpstreamStatus
+      pushTarget,
+      async () =>
+        (await this.mux.request('git.upstreamStatus', {
+          worktreePath,
+          ...(pushTarget ? { pushTarget } : {})
+        })) as GitUpstreamStatus
+    )
   }
 
   async pushBranch(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | +465 | −1 | +464 |
| Prod | 4 | +81 | −4 | +77 |

<!-- /orca-pr-loc -->

## Summary

Coalesce concurrent upstream-status reads across native, WSL, and SSH execution.

Identical in-flight reads share work by execution host, worktree, and complete push-target identity. Git mutations fence joins before and after execution, while completed or failed reads are never retained as a result cache.

Focused concurrency measurements:

- Native/WSL: 10 callers, each requiring a four-command status chain, collapse from 40 physical Git calls to 4.
- SSH: 10 callers collapse from 10 `git.upstreamStatus` RPCs to 1.

Depends on draft PR #11696 and, transitively, draft PR #11691. This PR is stacked so its GitHub diff contains only the upstream-status change.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (targeted `oxlint --deny-warnings` passed)
- [x] `pnpm typecheck` (`pnpm run typecheck:node`)
- [ ] `pnpm test` (5 focused suites, 221 tests passed)
- [x] `pnpm build` (`pnpm run build:electron-vite`)
- [x] Added or updated high-quality tests that would catch regressions

Also passed targeted formatting, max-lines ratchet, and `git diff --check`.

## AI Review Report

Reviewed execution-host isolation, every `GitPushTarget` field, success/error eviction, bounded in-flight retention, native/WSL/SSH mutation fencing, provider-instance isolation, and existing error normalization. No unresolved findings.

Cross-platform and remote-workspace review confirmed that native paths remain opaque, WSL distros are distinct identities, SSH providers are per connection, and no Git commands or options changed. Git 2.25 compatibility is therefore unchanged.

## Security Audit

No new IPC method, RPC method, command, path, authentication, secret, dependency, or persistence surface is introduced. Existing validated push-target fields form a bounded stable key, and entries are removed after settlement, timeout, or mutation invalidation.

## Notes

This is the fourth and final focused extraction from draft PR #11539.


---

## Readiness checklist review (2026-08-15)

**Verdict: ship.** No P0 or P1. One P1 was found and fixed in this branch; details below.

### Fixed during review

**P1 — the native/WSL path had no CI-enforced coalescing test.** The only test exercising 10 concurrent native callers was gated behind `ORCA_GIT_UPSTREAM_COALESCING_BENCH_JSON` and returned early in CI. Verified by bypassing `nativeAndWslGitUpstreamStatusReadOwner.read` in `getUpstreamStatus`: all 22 tests in `upstream.test.ts` still passed. The remaining native tests are negative or count-neutral cases that hold with or without coalescing. Since the native path is the default for every local worktree, a later change to the key or the owner call would have gone undetected.

Added `shares one physical read across ten identical native callers`, which gates `symbolic-ref` behind a promise, fires ten concurrent reads, and asserts exactly one physical chain plus shared result identity — then asserts a second read after settle issues fresh Git work, so the lease cannot silently become a result cache. Re-running the same bypass now fails with `expected [ …(10) ] to have a length of 1 but got 10`.

**P2 — `invalidateGitUpstreamStatusReads` was a test-only production export.** `status.ts` reached into the singleton directly, leaving two ways to invalidate with only one used in production. `invalidateGitReadCaches` now calls the named function, matching the sibling `invalidateGitBranchLineTotalInFlight` pattern and keeping `status.ts` off the owner instance.

### Verified clean

- **SSH / remote (01).** A fresh `SshGitProvider` is constructed per connection establishment with a new mux and re-registered, so a reconnect cannot inherit a lease from a previous generation. Mutations fence reads before and after via `runWithGitReadInvalidation`.
- **Crash / retry / unbounded growth (02).** `InFlightPromiseDedupe` caps at 128 entries, drops entries on settle, and clears its timer; overflow callers still run but cannot extend retention. A 30s max-in-flight timer prevents a hung read from pinning an entry. No unsafe casts introduced beyond the pre-existing `as GitUpstreamStatus` on the mux response.
- **Security (03).** No new dependency, shell, eval, network sink, or persisted surface. Pure in-process memoization.
- **Functional correctness (05).** `GitPushTarget` is exactly `{remoteName, branchName, remoteUrl?, remoteCreated?}`, matching the exhaustive destructure; the `Record<string, never>` spread makes a new field a compile error rather than a silently shared lease. All four `getUpstreamStatus` call sites (`orca-runtime-git`, `hosted-review-creation`, `ipc/filesystem`, provider contract) route through the coalesced entry point.
- **Backward compatibility (06).** No persisted state, schema, migration, or wire change — `git.upstreamStatus` params are untouched. No mobile-facing surface touched.
- **Cross-platform (07).** WSL distro is part of the execution identity, so a native and a WSL read of the same path never share a lease. Divergent path spellings on Windows produce distinct keys, which costs a missed coalescing opportunity and never a wrong result.

### Residual risk

- A `signal` passed in `GitRuntimeOptions` is dropped at the `getUpstreamStatus` boundary because the local `GitExecOptions` type does not declare it. This predates the PR — `readUpstreamStatus` never honoured a signal — so coalescing does not make cancellation any less effective than it is today.
- Path-spelling differences (trailing slash, Windows drive-letter case) reduce coalescing effectiveness without affecting correctness.

### Gates

`tsc --noEmit` clean · `src/main/git` + `src/main/providers`: 2,473 passed / 6 skipped · oxlint clean · oxfmt clean · `audit:code-quality:type-aware` exit 0 · `check:max-lines-ratchet` OK · `check:reliability-gates` OK (84 gates)
